### PR TITLE
feat(territory): implement multi-room expansion planning with adjacency scoring and readiness gate (#770)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -8642,6 +8642,8 @@ var EXIT_DIRECTION_ORDER3 = ["1", "3", "5", "7"];
 var ERR_NO_PATH_CODE4 = -2;
 var SOURCE_SCORE_WEIGHT = 1e3;
 var DISTANCE_SCORE_WEIGHT = 100;
+var DIRECT_ADJACENCY_SCORE_BONUS = 1500;
+var NEARBY_ADJACENCY_SCORE_BONUS = 500;
 var EXPANSION_PLANNER_TARGET_CREATOR = "expansionPlanner";
 var EXPANSION_TOWER_DEFAULT_MAX_PLACEMENTS = 6;
 var EXPANSION_DEFENSE_BARRIER_DEFAULT_MAX_PLACEMENTS = 24;
@@ -8683,35 +8685,52 @@ function buildRuntimeExpansionPlannerCandidates(colony) {
   const ownerUsername = getControllerOwnerUsername4(colony.room.controller);
   const ownedRoomNames = getVisibleOwnedRoomNames3(colonyName, ownerUsername);
   const candidates = [];
-  const seenRooms = /* @__PURE__ */ new Set();
   let order = 0;
   for (const ownedRoomName of ownedRoomNames) {
     for (const adjacentRoomName of getAdjacentRoomNames3(ownedRoomName)) {
-      if (seenRooms.has(adjacentRoomName) || ownedRoomNames.has(adjacentRoomName)) {
+      if (ownedRoomNames.has(adjacentRoomName)) {
         continue;
       }
-      seenRooms.add(adjacentRoomName);
       const room = rooms[adjacentRoomName];
       if (!room) {
         continue;
       }
-      candidates.push(toRuntimeExpansionPlannerCandidate(colonyName, room, 1, order, ownerUsername));
+      candidates.push(
+        toRuntimeExpansionPlannerCandidate(
+          colonyName,
+          room,
+          1,
+          order,
+          ownerUsername,
+          getExpansionPlannerAdjacencyBonus(1)
+        )
+      );
       order += 1;
     }
   }
   for (const room of Object.values(rooms)) {
-    if (!room || !isNonEmptyString9(room.name) || room.name === colonyName || ownedRoomNames.has(room.name) || seenRooms.has(room.name)) {
+    if (!room || !isNonEmptyString9(room.name) || room.name === colonyName || ownedRoomNames.has(room.name)) {
       continue;
     }
     const distance = getNearestOwnedRoomDistance2(ownedRoomNames, room.name);
     if (distance === null || distance > EXPANSION_PLANNER_MAX_ROUTE_DISTANCE) {
       continue;
     }
-    seenRooms.add(room.name);
-    candidates.push(toRuntimeExpansionPlannerCandidate(colonyName, room, distance, order, ownerUsername));
+    candidates.push(
+      toRuntimeExpansionPlannerCandidate(
+        colonyName,
+        room,
+        distance,
+        order,
+        ownerUsername,
+        getExpansionPlannerAdjacencyBonus(distance)
+      )
+    );
     order += 1;
   }
-  return candidates.filter((candidate) => candidate.suitable).sort(compareExpansionPlannerCandidates);
+  return dedupeExpansionPlannerCandidates(
+    candidates.filter((candidate) => candidate.suitable)
+  ).sort(compareExpansionPlannerCandidates);
 }
 function refreshExpansionPlannerIntent(colony, gameTime = getGameTime12()) {
   const colonyName = colony.room.name;
@@ -8906,6 +8925,7 @@ function createExpansionIntent(candidate, action, gameTime = getGameTime12()) {
   }
   if (action === "claim") {
     removeSupersededExpansionReservationPlan(territoryMemory, intents, candidate.colony, candidate.roomName);
+    disableLowerPriorityExpansionClaimPlans(territoryMemory, intents, candidate, gameTime);
   }
   const target = {
     colony: candidate.colony,
@@ -9582,23 +9602,54 @@ function evaluateExpansionSuitability({
     ...reservationUsername ? { reservationUsername } : {}
   };
 }
-function toRuntimeExpansionPlannerCandidate(colony, room, distance, order, colonyOwnerUsername) {
+function toRuntimeExpansionPlannerCandidate(colony, room, distance, order, colonyOwnerUsername, adjacencyBonus) {
   const suitability = evaluateExpansionRoomSuitability(room, colonyOwnerUsername);
   const normalizedDistance = Math.max(1, normalizeNonNegativeInteger4(distance));
+  const normalizedAdjacencyBonus = normalizeExpansionPlannerAdjacencyBonus(
+    adjacencyBonus,
+    normalizedDistance
+  );
   return {
     colony,
     roomName: room.name,
     distance: normalizedDistance,
     order,
-    score: scoreExpansionPlannerCandidate(suitability.sourceCount, normalizedDistance),
+    adjacencyBonus: normalizedAdjacencyBonus,
+    score: scoreExpansionPlannerCandidate(
+      suitability.sourceCount,
+      normalizedDistance,
+      normalizedAdjacencyBonus
+    ),
     ...suitability
   };
 }
 function compareExpansionPlannerCandidates(left, right) {
-  return right.sourceCount - left.sourceCount || left.distance - right.distance || right.score - left.score || left.order - right.order || left.roomName.localeCompare(right.roomName);
+  return right.score - left.score || right.sourceCount - left.sourceCount || left.distance - right.distance || getExpansionPlannerCandidateAdjacencyBonus(right) - getExpansionPlannerCandidateAdjacencyBonus(left) || left.order - right.order || left.roomName.localeCompare(right.roomName);
 }
-function scoreExpansionPlannerCandidate(sourceCount, distance) {
-  return sourceCount * SOURCE_SCORE_WEIGHT - distance * DISTANCE_SCORE_WEIGHT;
+function scoreExpansionPlannerCandidate(sourceCount, distance, adjacencyBonus) {
+  return sourceCount * SOURCE_SCORE_WEIGHT + adjacencyBonus - distance * DISTANCE_SCORE_WEIGHT;
+}
+function dedupeExpansionPlannerCandidates(candidates) {
+  const candidatesByRoom = /* @__PURE__ */ new Map();
+  for (const candidate of candidates) {
+    const existingCandidate = candidatesByRoom.get(candidate.roomName);
+    if (!existingCandidate || compareExpansionPlannerCandidates(candidate, existingCandidate) < 0) {
+      candidatesByRoom.set(candidate.roomName, candidate);
+    }
+  }
+  return Array.from(candidatesByRoom.values());
+}
+function normalizeExpansionPlannerAdjacencyBonus(adjacencyBonus, distance) {
+  if (typeof adjacencyBonus === "number" && Number.isFinite(adjacencyBonus)) {
+    return Math.max(0, Math.floor(adjacencyBonus));
+  }
+  return getExpansionPlannerAdjacencyBonus(distance);
+}
+function getExpansionPlannerAdjacencyBonus(distance) {
+  return distance <= 1 ? DIRECT_ADJACENCY_SCORE_BONUS : distance <= EXPANSION_PLANNER_MAX_ROUTE_DISTANCE ? NEARBY_ADJACENCY_SCORE_BONUS : 0;
+}
+function getExpansionPlannerCandidateAdjacencyBonus(candidate) {
+  return normalizeExpansionPlannerAdjacencyBonus(candidate.adjacencyBonus, candidate.distance);
 }
 function selectExpansionIntentAction(colony) {
   var _a;
@@ -9614,7 +9665,32 @@ function selectExpansionIntentAction(colony) {
   if (ownedRoomCount >= maxRoomsForRcl((_a = colony.room.controller) == null ? void 0 : _a.level)) {
     return "reserve";
   }
-  return "claim";
+  return isExpansionPlannerClaimReady(colony) ? "claim" : "reserve";
+}
+function isExpansionPlannerClaimReady(colony) {
+  const controller = colony.room.controller;
+  return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && controller.level >= 2 && hasActiveExpansionPlannerSpawn(colony) && !hasExpansionPlannerActiveHostiles(colony.room) && !hasExpansionPlannerPendingThreat(colony.room.name, getGameTime12()) && colony.energyAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY && colony.energyCapacityAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY;
+}
+function hasActiveExpansionPlannerSpawn(colony) {
+  return colony.spawns.some((spawn) => {
+    if (typeof spawn.isActive !== "function") {
+      return true;
+    }
+    try {
+      return spawn.isActive() !== false;
+    } catch {
+      return false;
+    }
+  });
+}
+function hasExpansionPlannerActiveHostiles(room) {
+  return findRoomObjects12(room, getFindConstant4("FIND_HOSTILE_CREEPS")).length > 0 || findRoomObjects12(room, getFindConstant4("FIND_HOSTILE_STRUCTURES")).length > 0;
+}
+function hasExpansionPlannerPendingThreat(roomName, gameTime) {
+  var _a, _b, _c;
+  const threatMemory = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.defense) == null ? void 0 : _b.colonyThreats;
+  const roomThreat = (_c = threatMemory == null ? void 0 : threatMemory.rooms) == null ? void 0 : _c[roomName];
+  return (threatMemory == null ? void 0 : threatMemory.updatedAt) === gameTime && (roomThreat == null ? void 0 : roomThreat.updatedAt) === gameTime && roomThreat.level !== "none";
 }
 function refreshTerminalExpansionPlans(territoryMemory, colony, gameTime) {
   var _a, _b;
@@ -9804,6 +9880,28 @@ function removeSupersededExpansionReservationPlan(territoryMemory, intents, colo
     if (intent.createdBy === EXPANSION_PLANNER_TARGET_CREATOR && intent.colony === colony && intent.targetRoom === roomName && intent.action === "reserve") {
       intents.splice(index, 1);
     }
+  }
+}
+function disableLowerPriorityExpansionClaimPlans(territoryMemory, intents, selectedCandidate, gameTime) {
+  if (Array.isArray(territoryMemory.targets)) {
+    for (const rawTarget of territoryMemory.targets) {
+      const target = normalizeTerritoryTarget2(rawTarget);
+      if (!target || target.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR || target.action !== "claim" || target.roomName !== selectedCandidate.roomName || target.enabled === false || target.colony === selectedCandidate.colony) {
+        continue;
+      }
+      rawTarget.enabled = false;
+    }
+  }
+  for (let index = 0; index < intents.length; index += 1) {
+    const intent = intents[index];
+    if (intent.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR || intent.action !== "claim" || intent.targetRoom !== selectedCandidate.roomName || intent.status !== "planned" && intent.status !== "active" || intent.colony === selectedCandidate.colony) {
+      continue;
+    }
+    intents[index] = {
+      ...intent,
+      status: "inactive",
+      updatedAt: gameTime
+    };
   }
 }
 function getExpansionPlanKey(colony, targetRoom, action) {
@@ -30204,7 +30302,15 @@ function refreshExpansionExecutorIntent(colony, gameTime = getGameTime27(), tele
     return cachedSelection.selection;
   }
   const report = buildRuntimeExpansionCandidateReport(colony);
-  const selection = refreshNextExpansionTargetSelection(colony, report, gameTime);
+  let selection = refreshNextExpansionTargetSelection(colony, report, gameTime);
+  if (selection.status === "planned" && !isExpansionExecutorClaimReady(colony, gameTime)) {
+    clearNextExpansionTargetIntent(colonyName);
+    selection = {
+      status: "skipped",
+      colony: colonyName,
+      reason: "unmetPreconditions"
+    };
+  }
   const scoutTargetRooms = [];
   if (selection.targetRoom) {
     scoutTargetRooms.push(selection.targetRoom);
@@ -30304,14 +30410,60 @@ function getExpansionExecutorCacheStateKey(colony) {
   const downgradeState = isFiniteNumber9(controller == null ? void 0 : controller.ticksToDowngrade) && controller.ticksToDowngrade < EXPANSION_EXECUTOR_DOWNGRADE_GUARD_TICKS ? "guarded" : "stable";
   return [
     colony.room.name,
+    colony.energyAvailable,
     colony.energyCapacityAvailable,
     controllerLevel,
     (_a = getGclLevel4()) != null ? _a : "unknown",
     countVisibleOwnedRooms2(),
     downgradeState,
+    countActiveExpansionExecutorSpawns(colony),
+    getExpansionExecutorThreatState(colony.room.name, getGameTime27()),
     countActivePostClaimBootstraps3(),
     getLatestTerritoryScoutIntelUpdatedAt(colony.room.name)
   ].join("|");
+}
+function isExpansionExecutorClaimReady(colony, gameTime) {
+  const controller = colony.room.controller;
+  return (controller == null ? void 0 : controller.my) === true && isFiniteNumber9(controller.level) && controller.level >= 2 && countActiveExpansionExecutorSpawns(colony) > 0 && !hasExpansionExecutorActiveHostiles(colony.room) && getExpansionExecutorThreatState(colony.room.name, gameTime) === "none" && colony.energyAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY && colony.energyCapacityAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY;
+}
+function countActiveExpansionExecutorSpawns(colony) {
+  var _a;
+  const snapshotSpawnCount = colony.spawns.filter(isActiveExpansionExecutorSpawn).length;
+  if (snapshotSpawnCount > 0) {
+    return snapshotSpawnCount;
+  }
+  const gameSpawns = (_a = globalThis.Game) == null ? void 0 : _a.spawns;
+  if (!gameSpawns) {
+    return 0;
+  }
+  return Object.values(gameSpawns).filter(
+    (spawn) => {
+      var _a2;
+      return ((_a2 = spawn == null ? void 0 : spawn.room) == null ? void 0 : _a2.name) === colony.room.name && isActiveExpansionExecutorSpawn(spawn);
+    }
+  ).length;
+}
+function isActiveExpansionExecutorSpawn(spawn) {
+  if (typeof spawn.isActive !== "function") {
+    return true;
+  }
+  try {
+    return spawn.isActive() !== false;
+  } catch {
+    return false;
+  }
+}
+function hasExpansionExecutorActiveHostiles(room) {
+  return findRoomObjects22(room, getFindConstant8("FIND_HOSTILE_CREEPS")).length > 0 || findRoomObjects22(room, getFindConstant8("FIND_HOSTILE_STRUCTURES")).length > 0;
+}
+function getExpansionExecutorThreatState(roomName, gameTime) {
+  var _a, _b, _c, _d;
+  const threatMemory = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.defense) == null ? void 0 : _b.colonyThreats;
+  const roomThreat = (_c = threatMemory == null ? void 0 : threatMemory.rooms) == null ? void 0 : _c[roomName];
+  if ((threatMemory == null ? void 0 : threatMemory.updatedAt) !== gameTime || (roomThreat == null ? void 0 : roomThreat.updatedAt) !== gameTime) {
+    return "none";
+  }
+  return (_d = roomThreat.level) != null ? _d : "none";
 }
 function refreshExpansionExecutorCacheStateKeyAfterCurrentTickScoutIntel(stateKey, colony, roomNames, gameTime) {
   const recordedCurrentTickScoutIntel = roomNames.some(
@@ -30375,6 +30527,21 @@ function getGameTime27() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
+}
+function findRoomObjects22(room, findConstant) {
+  if (typeof findConstant !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  try {
+    const result = room.find(findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return [];
+  }
+}
+function getFindConstant8(name) {
+  const value = globalThis[name];
+  return typeof value === "number" ? value : void 0;
 }
 function isRecord27(value) {
   return typeof value === "object" && value !== null;
@@ -30858,7 +31025,7 @@ function hasHostilePresence2(colonyName, roomName) {
   return ((_a = scoutIntel == null ? void 0 : scoutIntel.hostileCreepCount) != null ? _a : 0) + ((_b = scoutIntel == null ? void 0 : scoutIntel.hostileStructureCount) != null ? _b : 0) + ((_c = scoutIntel == null ? void 0 : scoutIntel.hostileSpawnCount) != null ? _c : 0) > 0;
 }
 function countVisibleHostiles(room) {
-  return countVisibleRoomObjects2(room, getFindConstant8("FIND_HOSTILE_CREEPS")) + countVisibleRoomObjects2(room, getFindConstant8("FIND_HOSTILE_STRUCTURES"));
+  return countVisibleRoomObjects2(room, getFindConstant9("FIND_HOSTILE_CREEPS")) + countVisibleRoomObjects2(room, getFindConstant9("FIND_HOSTILE_STRUCTURES"));
 }
 function persistAdjacentRoomReservationIntent(colony, evaluation, gameTime) {
   if (!evaluation.targetRoom) {
@@ -31038,7 +31205,7 @@ function countVisibleRoomObjects2(room, findConstant) {
   const result = room.find(findConstant);
   return Array.isArray(result) ? result.length : 0;
 }
-function getFindConstant8(name) {
+function getFindConstant9(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
@@ -32305,9 +32472,9 @@ function getTowerLimitForRcl2(rcl) {
   return (_b = FALLBACK_TOWER_LIMITS_BY_RCL[normalizedRcl]) != null ? _b : 0;
 }
 function countExistingAndPendingTowers(room) {
-  return findRoomObjects22(room, "FIND_MY_STRUCTURES").filter(isTowerLike).length + findRoomObjects22(room, "FIND_MY_CONSTRUCTION_SITES").filter(isTowerLike).length;
+  return findRoomObjects23(room, "FIND_MY_STRUCTURES").filter(isTowerLike).length + findRoomObjects23(room, "FIND_MY_CONSTRUCTION_SITES").filter(isTowerLike).length;
 }
-function findRoomObjects22(room, globalName) {
+function findRoomObjects23(room, globalName) {
   const findConstant = getGlobalNumber13(globalName);
   if (findConstant === null || typeof room.find !== "function") {
     return [];
@@ -32436,15 +32603,15 @@ function hasTowerCoverage(room, rcl) {
   return towerLimit <= 0 || countExistingAndPendingStructures2(room, "STRUCTURE_TOWER", "tower") >= Math.min(1, towerLimit);
 }
 function hasSourceContainerCoverage3(room) {
-  const sources = findRoomObjects23(room, "FIND_SOURCES").filter(
+  const sources = findRoomObjects24(room, "FIND_SOURCES").filter(
     (source) => isSameRoomPosition7(getRoomObjectPosition5(source), room.name)
   );
   if (sources.length === 0) {
     return true;
   }
   const containers = [
-    ...findRoomObjects23(room, "FIND_STRUCTURES"),
-    ...findRoomObjects23(room, "FIND_CONSTRUCTION_SITES")
+    ...findRoomObjects24(room, "FIND_STRUCTURES"),
+    ...findRoomObjects24(room, "FIND_CONSTRUCTION_SITES")
   ].filter(
     (object) => matchesStructureType24(object.structureType, "STRUCTURE_CONTAINER", "container")
   );
@@ -32453,9 +32620,9 @@ function hasSourceContainerCoverage3(room) {
   );
 }
 function countExistingAndPendingStructures2(room, globalName, fallback) {
-  return findRoomObjects23(room, "FIND_MY_STRUCTURES").filter(
+  return findRoomObjects24(room, "FIND_MY_STRUCTURES").filter(
     (structure) => matchesStructureType24(structure.structureType, globalName, fallback)
-  ).length + findRoomObjects23(room, "FIND_MY_CONSTRUCTION_SITES").filter(
+  ).length + findRoomObjects24(room, "FIND_MY_CONSTRUCTION_SITES").filter(
     (site) => matchesStructureType24(String(site.structureType), globalName, fallback)
   ).length;
 }
@@ -32506,7 +32673,7 @@ function getStructureLimitForRcl(globalName, fallback, rcl, fallbackLimits) {
   }
   return (_b = fallbackLimits[normalizedRcl]) != null ? _b : 0;
 }
-function findRoomObjects23(room, globalName) {
+function findRoomObjects24(room, globalName) {
   const findConstant = getGlobalNumber14(globalName);
   if (findConstant === null || typeof room.find !== "function") {
     return [];
@@ -32694,11 +32861,11 @@ function buildStrategyRecommendationRoomState(colony, creeps) {
       return creep.memory.colony === room.name || ((_a2 = creep.room) == null ? void 0 : _a2.name) === room.name;
     }
   );
-  const hostileCreeps = findRoomObjects24(room, "FIND_HOSTILE_CREEPS");
-  const hostileStructures = findRoomObjects24(room, "FIND_HOSTILE_STRUCTURES");
-  const ownedStructures = findRoomObjects24(room, "FIND_MY_STRUCTURES");
-  const constructionSites = findRoomObjects24(room, "FIND_MY_CONSTRUCTION_SITES");
-  const sources = findRoomObjects24(room, "FIND_SOURCES");
+  const hostileCreeps = findRoomObjects25(room, "FIND_HOSTILE_CREEPS");
+  const hostileStructures = findRoomObjects25(room, "FIND_HOSTILE_STRUCTURES");
+  const ownedStructures = findRoomObjects25(room, "FIND_MY_STRUCTURES");
+  const constructionSites = findRoomObjects25(room, "FIND_MY_CONSTRUCTION_SITES");
+  const sources = findRoomObjects25(room, "FIND_SOURCES");
   return {
     roomName: room.name,
     controllerLevel: (_a = room.controller) == null ? void 0 : _a.level,
@@ -32883,7 +33050,7 @@ function getEnergyInStore2(object) {
   }
   return finiteNumberOrZero(object.store[resourceEnergy]);
 }
-function findRoomObjects24(room, constantName) {
+function findRoomObjects25(room, constantName) {
   const findConstant = getGlobalNumber15(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -8658,6 +8658,7 @@ var EXPANSION_TOWER_ENTRANCE_WEIGHT = 1;
 var EXPANSION_TOWER_MAX_ROAD_ANCHORS = 12;
 var EXPANSION_DEFENSE_BARRIER_MAX_CORE_RAMPARTS = 16;
 var DEFAULT_TERRAIN_WALL_MASK9 = 1;
+var EXPANSION_PLANNER_THREAT_MEMORY_STALE_TICKS = 5;
 function evaluateExpansionRoomSuitability(room, colonyOwnerUsername) {
   var _a;
   const ownerUsername = getControllerOwnerUsername4(room.controller);
@@ -9672,16 +9673,30 @@ function isExpansionPlannerClaimReady(colony) {
   return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && controller.level >= 2 && hasActiveExpansionPlannerSpawn(colony) && !hasExpansionPlannerActiveHostiles(colony.room) && !hasExpansionPlannerPendingThreat(colony.room.name, getGameTime12()) && colony.energyAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY && colony.energyCapacityAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY;
 }
 function hasActiveExpansionPlannerSpawn(colony) {
-  return colony.spawns.some((spawn) => {
-    if (typeof spawn.isActive !== "function") {
-      return true;
+  var _a;
+  if (colony.spawns.some(isActiveExpansionPlannerSpawn)) {
+    return true;
+  }
+  const gameSpawns = (_a = globalThis.Game) == null ? void 0 : _a.spawns;
+  if (!gameSpawns) {
+    return false;
+  }
+  return Object.values(gameSpawns).some(
+    (spawn) => {
+      var _a2;
+      return ((_a2 = spawn == null ? void 0 : spawn.room) == null ? void 0 : _a2.name) === colony.room.name && isActiveExpansionPlannerSpawn(spawn);
     }
-    try {
-      return spawn.isActive() !== false;
-    } catch {
-      return false;
-    }
-  });
+  );
+}
+function isActiveExpansionPlannerSpawn(spawn) {
+  if (typeof spawn.isActive !== "function") {
+    return true;
+  }
+  try {
+    return spawn.isActive() !== false;
+  } catch {
+    return false;
+  }
 }
 function hasExpansionPlannerActiveHostiles(room) {
   return findRoomObjects12(room, getFindConstant4("FIND_HOSTILE_CREEPS")).length > 0 || findRoomObjects12(room, getFindConstant4("FIND_HOSTILE_STRUCTURES")).length > 0;
@@ -9689,8 +9704,14 @@ function hasExpansionPlannerActiveHostiles(room) {
 function hasExpansionPlannerPendingThreat(roomName, gameTime) {
   var _a, _b, _c;
   const threatMemory = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.defense) == null ? void 0 : _b.colonyThreats;
+  if (!threatMemory) {
+    return false;
+  }
   const roomThreat = (_c = threatMemory == null ? void 0 : threatMemory.rooms) == null ? void 0 : _c[roomName];
-  return (threatMemory == null ? void 0 : threatMemory.updatedAt) === gameTime && (roomThreat == null ? void 0 : roomThreat.updatedAt) === gameTime && roomThreat.level !== "none";
+  return !isRecentExpansionPlannerThreatMemory(threatMemory.updatedAt, gameTime) || !roomThreat || !isRecentExpansionPlannerThreatMemory(roomThreat.updatedAt, gameTime) || roomThreat.level !== "none";
+}
+function isRecentExpansionPlannerThreatMemory(updatedAt, gameTime) {
+  return typeof updatedAt === "number" && Number.isFinite(updatedAt) && updatedAt <= gameTime && gameTime - updatedAt <= EXPANSION_PLANNER_THREAT_MEMORY_STALE_TICKS;
 }
 function refreshTerminalExpansionPlans(territoryMemory, colony, gameTime) {
   var _a, _b;
@@ -9886,7 +9907,7 @@ function disableLowerPriorityExpansionClaimPlans(territoryMemory, intents, selec
   if (Array.isArray(territoryMemory.targets)) {
     for (const rawTarget of territoryMemory.targets) {
       const target = normalizeTerritoryTarget2(rawTarget);
-      if (!target || target.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR || target.action !== "claim" || target.roomName !== selectedCandidate.roomName || target.enabled === false || target.colony === selectedCandidate.colony) {
+      if (!target || target.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR || target.action !== "claim" || target.colony !== selectedCandidate.colony || target.roomName === selectedCandidate.roomName || target.enabled === false) {
         continue;
       }
       rawTarget.enabled = false;
@@ -9894,7 +9915,7 @@ function disableLowerPriorityExpansionClaimPlans(territoryMemory, intents, selec
   }
   for (let index = 0; index < intents.length; index += 1) {
     const intent = intents[index];
-    if (intent.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR || intent.action !== "claim" || intent.targetRoom !== selectedCandidate.roomName || intent.status !== "planned" && intent.status !== "active" || intent.colony === selectedCandidate.colony) {
+    if (intent.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR || intent.action !== "claim" || intent.colony !== selectedCandidate.colony || intent.targetRoom === selectedCandidate.roomName || intent.status !== "planned" && intent.status !== "active") {
       continue;
     }
     intents[index] = {
@@ -30293,12 +30314,13 @@ function isTerritoryAssignment(assignment) {
 // src/territory/expansionExecutor.ts
 var EXPANSION_EXECUTOR_REFRESH_INTERVAL = 50;
 var EXPANSION_EXECUTOR_DOWNGRADE_GUARD_TICKS = 5e3;
+var EXPANSION_EXECUTOR_THREAT_MEMORY_STALE_TICKS = 5;
 function refreshExpansionExecutorIntent(colony, gameTime = getGameTime27(), telemetryEvents = []) {
   const colonyName = colony.room.name;
   const colonyMemory = getWritableColonyMemory2(colony);
-  let stateKey = getExpansionExecutorCacheStateKey(colony);
+  let stateKey = getExpansionExecutorCacheStateKey(colony, gameTime);
   const cachedSelection = getCachedExpansionExecutorSelection(colonyMemory, colonyName);
-  if (cachedSelection && isExpansionExecutorCacheReusable(cachedSelection, colonyName, gameTime, stateKey)) {
+  if (cachedSelection && isExpansionExecutorCacheReusable(cachedSelection, colony, gameTime, stateKey)) {
     return cachedSelection.selection;
   }
   const report = buildRuntimeExpansionCandidateReport(colony);
@@ -30391,7 +30413,10 @@ function isExpansionExecutorCacheReusable(cachedSelection, colony, gameTime, sta
   if (cachedSelection.stateKey !== stateKey || gameTime < cachedSelection.refreshedAt || gameTime - cachedSelection.refreshedAt >= EXPANSION_EXECUTOR_REFRESH_INTERVAL) {
     return false;
   }
-  return cachedSelection.selection.status !== "planned" || hasExpansionExecutorTarget(colony, cachedSelection.selection.targetRoom);
+  if (cachedSelection.selection.status !== "planned") {
+    return true;
+  }
+  return hasExpansionExecutorTarget(colony.room.name, cachedSelection.selection.targetRoom) && isExpansionExecutorClaimReady(colony, gameTime);
 }
 function hasExpansionExecutorTarget(colony, targetRoom) {
   var _a, _b;
@@ -30403,24 +30428,27 @@ function hasExpansionExecutorTarget(colony, targetRoom) {
     (target) => isRecord27(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
   ) : false;
 }
-function getExpansionExecutorCacheStateKey(colony) {
+function getExpansionExecutorCacheStateKey(colony, gameTime = getGameTime27()) {
   var _a;
   const controller = colony.room.controller;
   const controllerLevel = isFiniteNumber9(controller == null ? void 0 : controller.level) ? controller.level : "unknown";
   const downgradeState = isFiniteNumber9(controller == null ? void 0 : controller.ticksToDowngrade) && controller.ticksToDowngrade < EXPANSION_EXECUTOR_DOWNGRADE_GUARD_TICKS ? "guarded" : "stable";
   return [
     colony.room.name,
-    colony.energyAvailable,
+    getExpansionExecutorAvailableEnergyState(colony.energyAvailable),
     colony.energyCapacityAvailable,
     controllerLevel,
     (_a = getGclLevel4()) != null ? _a : "unknown",
     countVisibleOwnedRooms2(),
     downgradeState,
     countActiveExpansionExecutorSpawns(colony),
-    getExpansionExecutorThreatState(colony.room.name, getGameTime27()),
+    getExpansionExecutorThreatState(colony.room.name, gameTime),
     countActivePostClaimBootstraps3(),
     getLatestTerritoryScoutIntelUpdatedAt(colony.room.name)
   ].join("|");
+}
+function getExpansionExecutorAvailableEnergyState(energyAvailable) {
+  return energyAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY ? "availableReady" : "availableWaiting";
 }
 function isExpansionExecutorClaimReady(colony, gameTime) {
   const controller = colony.room.controller;
@@ -30459,11 +30487,17 @@ function hasExpansionExecutorActiveHostiles(room) {
 function getExpansionExecutorThreatState(roomName, gameTime) {
   var _a, _b, _c, _d;
   const threatMemory = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.defense) == null ? void 0 : _b.colonyThreats;
-  const roomThreat = (_c = threatMemory == null ? void 0 : threatMemory.rooms) == null ? void 0 : _c[roomName];
-  if ((threatMemory == null ? void 0 : threatMemory.updatedAt) !== gameTime || (roomThreat == null ? void 0 : roomThreat.updatedAt) !== gameTime) {
+  if (!threatMemory) {
     return "none";
   }
-  return (_d = roomThreat.level) != null ? _d : "none";
+  const roomThreat = (_c = threatMemory == null ? void 0 : threatMemory.rooms) == null ? void 0 : _c[roomName];
+  if (!isRecentExpansionExecutorThreatMemory(threatMemory.updatedAt, gameTime) || !roomThreat || !isRecentExpansionExecutorThreatMemory(roomThreat.updatedAt, gameTime)) {
+    return "unknown";
+  }
+  return (_d = roomThreat.level) != null ? _d : "unknown";
+}
+function isRecentExpansionExecutorThreatMemory(updatedAt, gameTime) {
+  return isFiniteNumber9(updatedAt) && updatedAt <= gameTime && gameTime - updatedAt <= EXPANSION_EXECUTOR_THREAT_MEMORY_STALE_TICKS;
 }
 function refreshExpansionExecutorCacheStateKeyAfterCurrentTickScoutIntel(stateKey, colony, roomNames, gameTime) {
   const recordedCurrentTickScoutIntel = roomNames.some(

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -9627,6 +9627,9 @@ function toRuntimeExpansionPlannerCandidate(colony, room, distance, order, colon
 function compareExpansionPlannerCandidates(left, right) {
   return right.score - left.score || right.sourceCount - left.sourceCount || left.distance - right.distance || getExpansionPlannerCandidateAdjacencyBonus(right) - getExpansionPlannerCandidateAdjacencyBonus(left) || left.order - right.order || left.roomName.localeCompare(right.roomName);
 }
+function compareExpansionPlannerCandidatePriority(left, right) {
+  return right.score - left.score || right.sourceCount - left.sourceCount || left.distance - right.distance || getExpansionPlannerCandidateAdjacencyBonus(right) - getExpansionPlannerCandidateAdjacencyBonus(left) || left.roomName.localeCompare(right.roomName);
+}
 function scoreExpansionPlannerCandidate(sourceCount, distance, adjacencyBonus) {
   return sourceCount * SOURCE_SCORE_WEIGHT + adjacencyBonus - distance * DISTANCE_SCORE_WEIGHT;
 }
@@ -9907,7 +9910,11 @@ function disableLowerPriorityExpansionClaimPlans(territoryMemory, intents, selec
   if (Array.isArray(territoryMemory.targets)) {
     for (const rawTarget of territoryMemory.targets) {
       const target = normalizeTerritoryTarget2(rawTarget);
-      if (!target || target.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR || target.action !== "claim" || target.colony !== selectedCandidate.colony || target.roomName === selectedCandidate.roomName || target.enabled === false) {
+      if (!target || target.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR || target.action !== "claim" || target.enabled === false || !shouldDisableLowerPriorityExpansionClaimPlan(
+        selectedCandidate,
+        target.colony,
+        target.roomName
+      )) {
         continue;
       }
       rawTarget.enabled = false;
@@ -9915,7 +9922,11 @@ function disableLowerPriorityExpansionClaimPlans(territoryMemory, intents, selec
   }
   for (let index = 0; index < intents.length; index += 1) {
     const intent = intents[index];
-    if (intent.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR || intent.action !== "claim" || intent.colony !== selectedCandidate.colony || intent.targetRoom === selectedCandidate.roomName || intent.status !== "planned" && intent.status !== "active") {
+    if (intent.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR || intent.action !== "claim" || intent.status !== "planned" && intent.status !== "active" || !shouldDisableLowerPriorityExpansionClaimPlan(
+      selectedCandidate,
+      intent.colony,
+      intent.targetRoom
+    )) {
       continue;
     }
     intents[index] = {
@@ -9924,6 +9935,38 @@ function disableLowerPriorityExpansionClaimPlans(territoryMemory, intents, selec
       updatedAt: gameTime
     };
   }
+}
+function shouldDisableLowerPriorityExpansionClaimPlan(selectedCandidate, colony, roomName) {
+  if (colony === selectedCandidate.colony && roomName === selectedCandidate.roomName) {
+    return false;
+  }
+  if (colony !== selectedCandidate.colony && roomName !== selectedCandidate.roomName) {
+    return false;
+  }
+  const existingCandidate = buildVisibleExpansionPlannerClaimPlanCandidate(colony, roomName);
+  return existingCandidate !== null && compareExpansionPlannerCandidatePriority(existingCandidate, selectedCandidate) > 0;
+}
+function buildVisibleExpansionPlannerClaimPlanCandidate(colony, roomName) {
+  var _a;
+  const rooms = getGameRooms3();
+  const room = rooms == null ? void 0 : rooms[roomName];
+  if (!room) {
+    return null;
+  }
+  const ownerUsername = getControllerOwnerUsername4((_a = rooms == null ? void 0 : rooms[colony]) == null ? void 0 : _a.controller);
+  const ownedRoomNames = getVisibleOwnedRoomNames3(colony, ownerUsername);
+  const distance = getNearestOwnedRoomDistance2(ownedRoomNames, roomName);
+  if (distance === null || distance > EXPANSION_PLANNER_MAX_ROUTE_DISTANCE) {
+    return null;
+  }
+  return toRuntimeExpansionPlannerCandidate(
+    colony,
+    room,
+    distance,
+    0,
+    ownerUsername,
+    getExpansionPlannerAdjacencyBonus(distance)
+  );
 }
 function getExpansionPlanKey(colony, targetRoom, action) {
   return `${colony}:${targetRoom}:${action}`;
@@ -30442,6 +30485,7 @@ function getExpansionExecutorCacheStateKey(colony, gameTime = getGameTime27()) {
     countVisibleOwnedRooms2(),
     downgradeState,
     countActiveExpansionExecutorSpawns(colony),
+    getExpansionExecutorVisibleHostileState(colony.room),
     getExpansionExecutorThreatState(colony.room.name, gameTime),
     countActivePostClaimBootstraps3(),
     getLatestTerritoryScoutIntelUpdatedAt(colony.room.name)
@@ -30453,6 +30497,9 @@ function getExpansionExecutorAvailableEnergyState(energyAvailable) {
 function isExpansionExecutorClaimReady(colony, gameTime) {
   const controller = colony.room.controller;
   return (controller == null ? void 0 : controller.my) === true && isFiniteNumber9(controller.level) && controller.level >= 2 && countActiveExpansionExecutorSpawns(colony) > 0 && !hasExpansionExecutorActiveHostiles(colony.room) && getExpansionExecutorThreatState(colony.room.name, gameTime) === "none" && colony.energyAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY && colony.energyCapacityAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY;
+}
+function getExpansionExecutorVisibleHostileState(room) {
+  return hasExpansionExecutorActiveHostiles(room) ? "visibleHostile" : "visibleSafe";
 }
 function countActiveExpansionExecutorSpawns(colony) {
   var _a;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -30537,8 +30537,14 @@ function getExpansionExecutorThreatState(roomName, gameTime) {
   if (!threatMemory) {
     return "none";
   }
-  const roomThreat = (_c = threatMemory == null ? void 0 : threatMemory.rooms) == null ? void 0 : _c[roomName];
-  if (!isRecentExpansionExecutorThreatMemory(threatMemory.updatedAt, gameTime) || !roomThreat || !isRecentExpansionExecutorThreatMemory(roomThreat.updatedAt, gameTime)) {
+  if (!isRecentExpansionExecutorThreatMemory(threatMemory.updatedAt, gameTime)) {
+    return "unknown";
+  }
+  const roomThreat = (_c = threatMemory.rooms) == null ? void 0 : _c[roomName];
+  if (roomThreat === void 0 || roomThreat === null) {
+    return "none";
+  }
+  if (!isRecentExpansionExecutorThreatMemory(roomThreat.updatedAt, gameTime)) {
     return "unknown";
   }
   return (_d = roomThreat.level) != null ? _d : "unknown";

--- a/prod/src/territory/expansionExecutor.ts
+++ b/prod/src/territory/expansionExecutor.ts
@@ -298,12 +298,16 @@ function getExpansionExecutorThreatState(roomName: string, gameTime: number): Ex
     return 'none';
   }
 
-  const roomThreat = threatMemory?.rooms?.[roomName];
-  if (
-    !isRecentExpansionExecutorThreatMemory(threatMemory.updatedAt, gameTime) ||
-    !roomThreat ||
-    !isRecentExpansionExecutorThreatMemory(roomThreat.updatedAt, gameTime)
-  ) {
+  if (!isRecentExpansionExecutorThreatMemory(threatMemory.updatedAt, gameTime)) {
+    return 'unknown';
+  }
+
+  const roomThreat = threatMemory.rooms?.[roomName];
+  if (roomThreat === undefined || roomThreat === null) {
+    return 'none';
+  }
+
+  if (!isRecentExpansionExecutorThreatMemory(roomThreat.updatedAt, gameTime)) {
     return 'unknown';
   }
 

--- a/prod/src/territory/expansionExecutor.ts
+++ b/prod/src/territory/expansionExecutor.ts
@@ -16,6 +16,9 @@ import { logBestClaimTarget } from './territoryRunner';
 
 const EXPANSION_EXECUTOR_REFRESH_INTERVAL = 50;
 const EXPANSION_EXECUTOR_DOWNGRADE_GUARD_TICKS = 5_000;
+const EXPANSION_EXECUTOR_THREAT_MEMORY_STALE_TICKS = 5;
+
+type ExpansionExecutorThreatState = DefenseThreatLevel | 'unknown';
 
 interface CachedExpansionExecutorSelection {
   refreshedAt: number;
@@ -30,11 +33,11 @@ export function refreshExpansionExecutorIntent(
 ): NextExpansionTargetSelection {
   const colonyName = colony.room.name;
   const colonyMemory = getWritableColonyMemory(colony);
-  let stateKey = getExpansionExecutorCacheStateKey(colony);
+  let stateKey = getExpansionExecutorCacheStateKey(colony, gameTime);
   const cachedSelection = getCachedExpansionExecutorSelection(colonyMemory, colonyName);
   if (
     cachedSelection &&
-    isExpansionExecutorCacheReusable(cachedSelection, colonyName, gameTime, stateKey)
+    isExpansionExecutorCacheReusable(cachedSelection, colony, gameTime, stateKey)
   ) {
     return cachedSelection.selection;
   }
@@ -167,7 +170,7 @@ function normalizeExpansionExecutorSkipReason(
 
 function isExpansionExecutorCacheReusable(
   cachedSelection: CachedExpansionExecutorSelection,
-  colony: string,
+  colony: ColonySnapshot,
   gameTime: number,
   stateKey: string
 ): boolean {
@@ -179,9 +182,13 @@ function isExpansionExecutorCacheReusable(
     return false;
   }
 
+  if (cachedSelection.selection.status !== 'planned') {
+    return true;
+  }
+
   return (
-    cachedSelection.selection.status !== 'planned' ||
-    hasExpansionExecutorTarget(colony, cachedSelection.selection.targetRoom)
+    hasExpansionExecutorTarget(colony.room.name, cachedSelection.selection.targetRoom) &&
+    isExpansionExecutorClaimReady(colony, gameTime)
   );
 }
 
@@ -203,7 +210,7 @@ function hasExpansionExecutorTarget(colony: string, targetRoom: string | undefin
     : false;
 }
 
-function getExpansionExecutorCacheStateKey(colony: ColonySnapshot): string {
+function getExpansionExecutorCacheStateKey(colony: ColonySnapshot, gameTime = getGameTime()): string {
   const controller = colony.room.controller;
   const controllerLevel = isFiniteNumber(controller?.level) ? controller.level : 'unknown';
   const downgradeState =
@@ -214,17 +221,21 @@ function getExpansionExecutorCacheStateKey(colony: ColonySnapshot): string {
 
   return [
     colony.room.name,
-    colony.energyAvailable,
+    getExpansionExecutorAvailableEnergyState(colony.energyAvailable),
     colony.energyCapacityAvailable,
     controllerLevel,
     getGclLevel() ?? 'unknown',
     countVisibleOwnedRooms(),
     downgradeState,
     countActiveExpansionExecutorSpawns(colony),
-    getExpansionExecutorThreatState(colony.room.name, getGameTime()),
+    getExpansionExecutorThreatState(colony.room.name, gameTime),
     countActivePostClaimBootstraps(),
     getLatestTerritoryScoutIntelUpdatedAt(colony.room.name)
   ].join('|');
+}
+
+function getExpansionExecutorAvailableEnergyState(energyAvailable: number): string {
+  return energyAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY ? 'availableReady' : 'availableWaiting';
 }
 
 function isExpansionExecutorClaimReady(colony: ColonySnapshot, gameTime: number): boolean {
@@ -276,14 +287,30 @@ function hasExpansionExecutorActiveHostiles(room: Room): boolean {
   );
 }
 
-function getExpansionExecutorThreatState(roomName: string, gameTime: number): DefenseThreatLevel {
+function getExpansionExecutorThreatState(roomName: string, gameTime: number): ExpansionExecutorThreatState {
   const threatMemory = (globalThis as { Memory?: Partial<Memory> }).Memory?.defense?.colonyThreats;
-  const roomThreat = threatMemory?.rooms?.[roomName];
-  if (threatMemory?.updatedAt !== gameTime || roomThreat?.updatedAt !== gameTime) {
+  if (!threatMemory) {
     return 'none';
   }
 
-  return roomThreat.level ?? 'none';
+  const roomThreat = threatMemory?.rooms?.[roomName];
+  if (
+    !isRecentExpansionExecutorThreatMemory(threatMemory.updatedAt, gameTime) ||
+    !roomThreat ||
+    !isRecentExpansionExecutorThreatMemory(roomThreat.updatedAt, gameTime)
+  ) {
+    return 'unknown';
+  }
+
+  return roomThreat.level ?? 'unknown';
+}
+
+function isRecentExpansionExecutorThreatMemory(updatedAt: unknown, gameTime: number): boolean {
+  return (
+    isFiniteNumber(updatedAt) &&
+    updatedAt <= gameTime &&
+    gameTime - updatedAt <= EXPANSION_EXECUTOR_THREAT_MEMORY_STALE_TICKS
+  );
 }
 
 function refreshExpansionExecutorCacheStateKeyAfterCurrentTickScoutIntel(

--- a/prod/src/territory/expansionExecutor.ts
+++ b/prod/src/territory/expansionExecutor.ts
@@ -1,8 +1,10 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
 import type { RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
+import { TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY } from './autoClaim';
 import { runRecommendedExpansionClaimExecutor } from './claimExecutor';
 import {
   buildRuntimeExpansionCandidateReport,
+  clearNextExpansionTargetIntent,
   NEXT_EXPANSION_TARGET_CREATOR,
   refreshNextExpansionTargetSelection,
   selectExpansionScoutTargets,
@@ -38,7 +40,15 @@ export function refreshExpansionExecutorIntent(
   }
 
   const report = buildRuntimeExpansionCandidateReport(colony);
-  const selection = refreshNextExpansionTargetSelection(colony, report, gameTime);
+  let selection = refreshNextExpansionTargetSelection(colony, report, gameTime);
+  if (selection.status === 'planned' && !isExpansionExecutorClaimReady(colony, gameTime)) {
+    clearNextExpansionTargetIntent(colonyName);
+    selection = {
+      status: 'skipped',
+      colony: colonyName,
+      reason: 'unmetPreconditions'
+    };
+  }
   const scoutTargetRooms: string[] = [];
   if (selection.targetRoom) {
     scoutTargetRooms.push(selection.targetRoom);
@@ -204,14 +214,76 @@ function getExpansionExecutorCacheStateKey(colony: ColonySnapshot): string {
 
   return [
     colony.room.name,
+    colony.energyAvailable,
     colony.energyCapacityAvailable,
     controllerLevel,
     getGclLevel() ?? 'unknown',
     countVisibleOwnedRooms(),
     downgradeState,
+    countActiveExpansionExecutorSpawns(colony),
+    getExpansionExecutorThreatState(colony.room.name, getGameTime()),
     countActivePostClaimBootstraps(),
     getLatestTerritoryScoutIntelUpdatedAt(colony.room.name)
   ].join('|');
+}
+
+function isExpansionExecutorClaimReady(colony: ColonySnapshot, gameTime: number): boolean {
+  const controller = colony.room.controller;
+  return (
+    controller?.my === true &&
+    isFiniteNumber(controller.level) &&
+    controller.level >= 2 &&
+    countActiveExpansionExecutorSpawns(colony) > 0 &&
+    !hasExpansionExecutorActiveHostiles(colony.room) &&
+    getExpansionExecutorThreatState(colony.room.name, gameTime) === 'none' &&
+    colony.energyAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY &&
+    colony.energyCapacityAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY
+  );
+}
+
+function countActiveExpansionExecutorSpawns(colony: ColonySnapshot): number {
+  const snapshotSpawnCount = colony.spawns.filter(isActiveExpansionExecutorSpawn).length;
+  if (snapshotSpawnCount > 0) {
+    return snapshotSpawnCount;
+  }
+
+  const gameSpawns = (globalThis as { Game?: Partial<Game> }).Game?.spawns;
+  if (!gameSpawns) {
+    return 0;
+  }
+
+  return Object.values(gameSpawns).filter(
+    (spawn) => spawn?.room?.name === colony.room.name && isActiveExpansionExecutorSpawn(spawn)
+  ).length;
+}
+
+function isActiveExpansionExecutorSpawn(spawn: StructureSpawn): boolean {
+  if (typeof spawn.isActive !== 'function') {
+    return true;
+  }
+
+  try {
+    return spawn.isActive() !== false;
+  } catch {
+    return false;
+  }
+}
+
+function hasExpansionExecutorActiveHostiles(room: Room): boolean {
+  return (
+    findRoomObjects<Creep>(room, getFindConstant('FIND_HOSTILE_CREEPS')).length > 0 ||
+    findRoomObjects<AnyStructure>(room, getFindConstant('FIND_HOSTILE_STRUCTURES')).length > 0
+  );
+}
+
+function getExpansionExecutorThreatState(roomName: string, gameTime: number): DefenseThreatLevel {
+  const threatMemory = (globalThis as { Memory?: Partial<Memory> }).Memory?.defense?.colonyThreats;
+  const roomThreat = threatMemory?.rooms?.[roomName];
+  if (threatMemory?.updatedAt !== gameTime || roomThreat?.updatedAt !== gameTime) {
+    return 'none';
+  }
+
+  return roomThreat.level ?? 'none';
 }
 
 function refreshExpansionExecutorCacheStateKeyAfterCurrentTickScoutIntel(
@@ -286,6 +358,24 @@ function getLatestTerritoryScoutIntelUpdatedAt(colony: string): number {
 function getGameTime(): number {
   const gameTime = (globalThis as { Game?: Partial<Game> }).Game?.time;
   return typeof gameTime === 'number' ? gameTime : 0;
+}
+
+function findRoomObjects<T>(room: Room, findConstant: number | undefined): T[] {
+  if (typeof findConstant !== 'number' || typeof room.find !== 'function') {
+    return [];
+  }
+
+  try {
+    const result = room.find(findConstant as FindConstant);
+    return Array.isArray(result) ? (result as T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function getFindConstant(name: string): number | undefined {
+  const value = (globalThis as Record<string, unknown>)[name];
+  return typeof value === 'number' ? value : undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/prod/src/territory/expansionExecutor.ts
+++ b/prod/src/territory/expansionExecutor.ts
@@ -228,6 +228,7 @@ function getExpansionExecutorCacheStateKey(colony: ColonySnapshot, gameTime = ge
     countVisibleOwnedRooms(),
     downgradeState,
     countActiveExpansionExecutorSpawns(colony),
+    getExpansionExecutorVisibleHostileState(colony.room),
     getExpansionExecutorThreatState(colony.room.name, gameTime),
     countActivePostClaimBootstraps(),
     getLatestTerritoryScoutIntelUpdatedAt(colony.room.name)
@@ -250,6 +251,10 @@ function isExpansionExecutorClaimReady(colony: ColonySnapshot, gameTime: number)
     colony.energyAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY &&
     colony.energyCapacityAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY
   );
+}
+
+function getExpansionExecutorVisibleHostileState(room: Room): string {
+  return hasExpansionExecutorActiveHostiles(room) ? 'visibleHostile' : 'visibleSafe';
 }
 
 function countActiveExpansionExecutorSpawns(colony: ColonySnapshot): number {

--- a/prod/src/territory/expansionPlanner.ts
+++ b/prod/src/territory/expansionPlanner.ts
@@ -27,6 +27,7 @@ const EXPANSION_TOWER_ENTRANCE_WEIGHT = 1;
 const EXPANSION_TOWER_MAX_ROAD_ANCHORS = 12;
 const EXPANSION_DEFENSE_BARRIER_MAX_CORE_RAMPARTS = 16;
 const DEFAULT_TERRAIN_WALL_MASK = 1;
+const EXPANSION_PLANNER_THREAT_MEMORY_STALE_TICKS = 5;
 
 type TerminalExpansionIntentStatus = Extract<TerritoryIntentMemory['status'], 'inactive' | 'completed'>;
 
@@ -1715,17 +1716,30 @@ function isExpansionPlannerClaimReady(colony: ColonySnapshot): boolean {
 }
 
 function hasActiveExpansionPlannerSpawn(colony: ColonySnapshot): boolean {
-  return colony.spawns.some((spawn) => {
-    if (typeof spawn.isActive !== 'function') {
-      return true;
-    }
+  if (colony.spawns.some(isActiveExpansionPlannerSpawn)) {
+    return true;
+  }
 
-    try {
-      return spawn.isActive() !== false;
-    } catch {
-      return false;
-    }
-  });
+  const gameSpawns = (globalThis as { Game?: Partial<Game> }).Game?.spawns;
+  if (!gameSpawns) {
+    return false;
+  }
+
+  return Object.values(gameSpawns).some(
+    (spawn) => spawn?.room?.name === colony.room.name && isActiveExpansionPlannerSpawn(spawn)
+  );
+}
+
+function isActiveExpansionPlannerSpawn(spawn: StructureSpawn): boolean {
+  if (typeof spawn.isActive !== 'function') {
+    return true;
+  }
+
+  try {
+    return spawn.isActive() !== false;
+  } catch {
+    return false;
+  }
 }
 
 function hasExpansionPlannerActiveHostiles(room: Room): boolean {
@@ -1737,11 +1751,25 @@ function hasExpansionPlannerActiveHostiles(room: Room): boolean {
 
 function hasExpansionPlannerPendingThreat(roomName: string, gameTime: number): boolean {
   const threatMemory = (globalThis as { Memory?: Partial<Memory> }).Memory?.defense?.colonyThreats;
+  if (!threatMemory) {
+    return false;
+  }
+
   const roomThreat = threatMemory?.rooms?.[roomName];
   return (
-    threatMemory?.updatedAt === gameTime &&
-    roomThreat?.updatedAt === gameTime &&
+    !isRecentExpansionPlannerThreatMemory(threatMemory.updatedAt, gameTime) ||
+    !roomThreat ||
+    !isRecentExpansionPlannerThreatMemory(roomThreat.updatedAt, gameTime) ||
     roomThreat.level !== 'none'
+  );
+}
+
+function isRecentExpansionPlannerThreatMemory(updatedAt: unknown, gameTime: number): boolean {
+  return (
+    typeof updatedAt === 'number' &&
+    Number.isFinite(updatedAt) &&
+    updatedAt <= gameTime &&
+    gameTime - updatedAt <= EXPANSION_PLANNER_THREAT_MEMORY_STALE_TICKS
   );
 }
 
@@ -2128,9 +2156,9 @@ function disableLowerPriorityExpansionClaimPlans(
         !target ||
         target.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR ||
         target.action !== 'claim' ||
-        target.roomName !== selectedCandidate.roomName ||
-        target.enabled === false ||
-        target.colony === selectedCandidate.colony
+        target.colony !== selectedCandidate.colony ||
+        target.roomName === selectedCandidate.roomName ||
+        target.enabled === false
       ) {
         continue;
       }
@@ -2144,9 +2172,9 @@ function disableLowerPriorityExpansionClaimPlans(
     if (
       intent.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR ||
       intent.action !== 'claim' ||
-      intent.targetRoom !== selectedCandidate.roomName ||
-      (intent.status !== 'planned' && intent.status !== 'active') ||
-      intent.colony === selectedCandidate.colony
+      intent.colony !== selectedCandidate.colony ||
+      intent.targetRoom === selectedCandidate.roomName ||
+      (intent.status !== 'planned' && intent.status !== 'active')
     ) {
       continue;
     }

--- a/prod/src/territory/expansionPlanner.ts
+++ b/prod/src/territory/expansionPlanner.ts
@@ -1,4 +1,5 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
+import { TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY } from './autoClaim';
 import { maxRoomsForRcl } from './expansionScoring';
 import { normalizeTerritoryIntents } from './territoryMemoryUtils';
 
@@ -9,6 +10,8 @@ const EXIT_DIRECTION_ORDER = ['1', '3', '5', '7'];
 const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
 const SOURCE_SCORE_WEIGHT = 1_000;
 const DISTANCE_SCORE_WEIGHT = 100;
+const DIRECT_ADJACENCY_SCORE_BONUS = 1_500;
+const NEARBY_ADJACENCY_SCORE_BONUS = 500;
 export const EXPANSION_PLANNER_TARGET_CREATOR = 'expansionPlanner';
 export const EXPANSION_TOWER_DEFAULT_MAX_PLACEMENTS = 6;
 export const EXPANSION_DEFENSE_BARRIER_DEFAULT_MAX_PLACEMENTS = 24;
@@ -53,6 +56,7 @@ export interface ExpansionPlannerCandidateInput {
   distance: number;
   sourceCount: number;
   order?: number;
+  adjacencyBonus?: number;
   hostileCreepCount?: number;
   hostileStructureCount?: number;
   controllerId?: Id<StructureController>;
@@ -65,6 +69,7 @@ export interface ExpansionPlannerCandidate extends ExpansionRoomSuitability {
   roomName: string;
   distance: number;
   order: number;
+  adjacencyBonus?: number;
   score: number;
 }
 
@@ -225,13 +230,15 @@ export function evaluateExpansionCandidate(
   });
   const order = normalizeNonNegativeInteger(candidate.order ?? 0);
   const distance = Math.max(1, normalizeNonNegativeInteger(candidate.distance));
+  const adjacencyBonus = normalizeExpansionPlannerAdjacencyBonus(candidate.adjacencyBonus, distance);
 
   return {
     colony: candidate.colony,
     roomName: candidate.roomName,
     distance,
     order,
-    score: scoreExpansionPlannerCandidate(suitability.sourceCount, distance),
+    adjacencyBonus,
+    score: scoreExpansionPlannerCandidate(suitability.sourceCount, distance, adjacencyBonus),
     ...suitability
   };
 }
@@ -239,10 +246,11 @@ export function evaluateExpansionCandidate(
 export function prioritizeExpansionCandidates(
   candidates: ExpansionPlannerCandidateInput[]
 ): ExpansionPlannerCandidate[] {
-  return candidates
-    .map(evaluateExpansionCandidate)
-    .filter((candidate) => candidate.suitable)
-    .sort(compareExpansionPlannerCandidates);
+  return dedupeExpansionPlannerCandidates(
+    candidates
+      .map(evaluateExpansionCandidate)
+      .filter((candidate) => candidate.suitable)
+  ).sort(compareExpansionPlannerCandidates);
 }
 
 export function buildRuntimeExpansionPlannerCandidates(
@@ -257,22 +265,29 @@ export function buildRuntimeExpansionPlannerCandidates(
   const ownerUsername = getControllerOwnerUsername(colony.room.controller);
   const ownedRoomNames = getVisibleOwnedRoomNames(colonyName, ownerUsername);
   const candidates: ExpansionPlannerCandidate[] = [];
-  const seenRooms = new Set<string>();
   let order = 0;
 
   for (const ownedRoomName of ownedRoomNames) {
     for (const adjacentRoomName of getAdjacentRoomNames(ownedRoomName)) {
-      if (seenRooms.has(adjacentRoomName) || ownedRoomNames.has(adjacentRoomName)) {
+      if (ownedRoomNames.has(adjacentRoomName)) {
         continue;
       }
 
-      seenRooms.add(adjacentRoomName);
       const room = rooms[adjacentRoomName];
       if (!room) {
         continue;
       }
 
-      candidates.push(toRuntimeExpansionPlannerCandidate(colonyName, room, 1, order, ownerUsername));
+      candidates.push(
+        toRuntimeExpansionPlannerCandidate(
+          colonyName,
+          room,
+          1,
+          order,
+          ownerUsername,
+          getExpansionPlannerAdjacencyBonus(1)
+        )
+      );
       order += 1;
     }
   }
@@ -282,8 +297,7 @@ export function buildRuntimeExpansionPlannerCandidates(
       !room ||
       !isNonEmptyString(room.name) ||
       room.name === colonyName ||
-      ownedRoomNames.has(room.name) ||
-      seenRooms.has(room.name)
+      ownedRoomNames.has(room.name)
     ) {
       continue;
     }
@@ -293,14 +307,22 @@ export function buildRuntimeExpansionPlannerCandidates(
       continue;
     }
 
-    seenRooms.add(room.name);
-    candidates.push(toRuntimeExpansionPlannerCandidate(colonyName, room, distance, order, ownerUsername));
+    candidates.push(
+      toRuntimeExpansionPlannerCandidate(
+        colonyName,
+        room,
+        distance,
+        order,
+        ownerUsername,
+        getExpansionPlannerAdjacencyBonus(distance)
+      )
+    );
     order += 1;
   }
 
-  return candidates
-    .filter((candidate) => candidate.suitable)
-    .sort(compareExpansionPlannerCandidates);
+  return dedupeExpansionPlannerCandidates(
+    candidates.filter((candidate) => candidate.suitable)
+  ).sort(compareExpansionPlannerCandidates);
 }
 
 export function refreshExpansionPlannerIntent(
@@ -540,6 +562,7 @@ export function createExpansionIntent(
 
   if (action === 'claim') {
     removeSupersededExpansionReservationPlan(territoryMemory, intents, candidate.colony, candidate.roomName);
+    disableLowerPriorityExpansionClaimPlans(territoryMemory, intents, candidate, gameTime);
   }
 
   const target: TerritoryTargetMemory = {
@@ -1575,16 +1598,26 @@ function toRuntimeExpansionPlannerCandidate(
   room: Room,
   distance: number,
   order: number,
-  colonyOwnerUsername: string | undefined
+  colonyOwnerUsername: string | undefined,
+  adjacencyBonus?: number
 ): ExpansionPlannerCandidate {
   const suitability = evaluateExpansionRoomSuitability(room, colonyOwnerUsername);
   const normalizedDistance = Math.max(1, normalizeNonNegativeInteger(distance));
+  const normalizedAdjacencyBonus = normalizeExpansionPlannerAdjacencyBonus(
+    adjacencyBonus,
+    normalizedDistance
+  );
   return {
     colony,
     roomName: room.name,
     distance: normalizedDistance,
     order,
-    score: scoreExpansionPlannerCandidate(suitability.sourceCount, normalizedDistance),
+    adjacencyBonus: normalizedAdjacencyBonus,
+    score: scoreExpansionPlannerCandidate(
+      suitability.sourceCount,
+      normalizedDistance,
+      normalizedAdjacencyBonus
+    ),
     ...suitability
   };
 }
@@ -1594,16 +1627,58 @@ function compareExpansionPlannerCandidates(
   right: ExpansionPlannerCandidate
 ): number {
   return (
+    right.score - left.score ||
     right.sourceCount - left.sourceCount ||
     left.distance - right.distance ||
-    right.score - left.score ||
+    getExpansionPlannerCandidateAdjacencyBonus(right) - getExpansionPlannerCandidateAdjacencyBonus(left) ||
     left.order - right.order ||
     left.roomName.localeCompare(right.roomName)
   );
 }
 
-function scoreExpansionPlannerCandidate(sourceCount: number, distance: number): number {
-  return sourceCount * SOURCE_SCORE_WEIGHT - distance * DISTANCE_SCORE_WEIGHT;
+function scoreExpansionPlannerCandidate(
+  sourceCount: number,
+  distance: number,
+  adjacencyBonus: number
+): number {
+  return sourceCount * SOURCE_SCORE_WEIGHT + adjacencyBonus - distance * DISTANCE_SCORE_WEIGHT;
+}
+
+function dedupeExpansionPlannerCandidates(
+  candidates: ExpansionPlannerCandidate[]
+): ExpansionPlannerCandidate[] {
+  const candidatesByRoom = new Map<string, ExpansionPlannerCandidate>();
+  for (const candidate of candidates) {
+    const existingCandidate = candidatesByRoom.get(candidate.roomName);
+    if (!existingCandidate || compareExpansionPlannerCandidates(candidate, existingCandidate) < 0) {
+      candidatesByRoom.set(candidate.roomName, candidate);
+    }
+  }
+
+  return Array.from(candidatesByRoom.values());
+}
+
+function normalizeExpansionPlannerAdjacencyBonus(
+  adjacencyBonus: number | undefined,
+  distance: number
+): number {
+  if (typeof adjacencyBonus === 'number' && Number.isFinite(adjacencyBonus)) {
+    return Math.max(0, Math.floor(adjacencyBonus));
+  }
+
+  return getExpansionPlannerAdjacencyBonus(distance);
+}
+
+function getExpansionPlannerAdjacencyBonus(distance: number): number {
+  return distance <= 1
+    ? DIRECT_ADJACENCY_SCORE_BONUS
+    : distance <= EXPANSION_PLANNER_MAX_ROUTE_DISTANCE
+      ? NEARBY_ADJACENCY_SCORE_BONUS
+      : 0;
+}
+
+function getExpansionPlannerCandidateAdjacencyBonus(candidate: ExpansionPlannerCandidate): number {
+  return normalizeExpansionPlannerAdjacencyBonus(candidate.adjacencyBonus, candidate.distance);
 }
 
 function selectExpansionIntentAction(colony: ColonySnapshot): TerritoryControlAction {
@@ -1622,7 +1697,52 @@ function selectExpansionIntentAction(colony: ColonySnapshot): TerritoryControlAc
     return 'reserve';
   }
 
-  return 'claim';
+  return isExpansionPlannerClaimReady(colony) ? 'claim' : 'reserve';
+}
+
+function isExpansionPlannerClaimReady(colony: ColonySnapshot): boolean {
+  const controller = colony.room.controller;
+  return (
+    controller?.my === true &&
+    typeof controller.level === 'number' &&
+    controller.level >= 2 &&
+    hasActiveExpansionPlannerSpawn(colony) &&
+    !hasExpansionPlannerActiveHostiles(colony.room) &&
+    !hasExpansionPlannerPendingThreat(colony.room.name, getGameTime()) &&
+    colony.energyAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY &&
+    colony.energyCapacityAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY
+  );
+}
+
+function hasActiveExpansionPlannerSpawn(colony: ColonySnapshot): boolean {
+  return colony.spawns.some((spawn) => {
+    if (typeof spawn.isActive !== 'function') {
+      return true;
+    }
+
+    try {
+      return spawn.isActive() !== false;
+    } catch {
+      return false;
+    }
+  });
+}
+
+function hasExpansionPlannerActiveHostiles(room: Room): boolean {
+  return (
+    findRoomObjects<Creep>(room, getFindConstant('FIND_HOSTILE_CREEPS')).length > 0 ||
+    findRoomObjects<AnyStructure>(room, getFindConstant('FIND_HOSTILE_STRUCTURES')).length > 0
+  );
+}
+
+function hasExpansionPlannerPendingThreat(roomName: string, gameTime: number): boolean {
+  const threatMemory = (globalThis as { Memory?: Partial<Memory> }).Memory?.defense?.colonyThreats;
+  const roomThreat = threatMemory?.rooms?.[roomName];
+  return (
+    threatMemory?.updatedAt === gameTime &&
+    roomThreat?.updatedAt === gameTime &&
+    roomThreat.level !== 'none'
+  );
 }
 
 function refreshTerminalExpansionPlans(
@@ -1992,6 +2112,50 @@ function removeSupersededExpansionReservationPlan(
     ) {
       intents.splice(index, 1);
     }
+  }
+}
+
+function disableLowerPriorityExpansionClaimPlans(
+  territoryMemory: TerritoryMemory,
+  intents: TerritoryIntentMemory[],
+  selectedCandidate: ExpansionPlannerCandidate,
+  gameTime: number
+): void {
+  if (Array.isArray(territoryMemory.targets)) {
+    for (const rawTarget of territoryMemory.targets) {
+      const target = normalizeTerritoryTarget(rawTarget);
+      if (
+        !target ||
+        target.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR ||
+        target.action !== 'claim' ||
+        target.roomName !== selectedCandidate.roomName ||
+        target.enabled === false ||
+        target.colony === selectedCandidate.colony
+      ) {
+        continue;
+      }
+
+      rawTarget.enabled = false;
+    }
+  }
+
+  for (let index = 0; index < intents.length; index += 1) {
+    const intent = intents[index];
+    if (
+      intent.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR ||
+      intent.action !== 'claim' ||
+      intent.targetRoom !== selectedCandidate.roomName ||
+      (intent.status !== 'planned' && intent.status !== 'active') ||
+      intent.colony === selectedCandidate.colony
+    ) {
+      continue;
+    }
+
+    intents[index] = {
+      ...intent,
+      status: 'inactive',
+      updatedAt: gameTime
+    };
   }
 }
 

--- a/prod/src/territory/expansionPlanner.ts
+++ b/prod/src/territory/expansionPlanner.ts
@@ -1637,6 +1637,19 @@ function compareExpansionPlannerCandidates(
   );
 }
 
+function compareExpansionPlannerCandidatePriority(
+  left: ExpansionPlannerCandidate,
+  right: ExpansionPlannerCandidate
+): number {
+  return (
+    right.score - left.score ||
+    right.sourceCount - left.sourceCount ||
+    left.distance - right.distance ||
+    getExpansionPlannerCandidateAdjacencyBonus(right) - getExpansionPlannerCandidateAdjacencyBonus(left) ||
+    left.roomName.localeCompare(right.roomName)
+  );
+}
+
 function scoreExpansionPlannerCandidate(
   sourceCount: number,
   distance: number,
@@ -2156,9 +2169,12 @@ function disableLowerPriorityExpansionClaimPlans(
         !target ||
         target.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR ||
         target.action !== 'claim' ||
-        target.colony !== selectedCandidate.colony ||
-        target.roomName === selectedCandidate.roomName ||
-        target.enabled === false
+        target.enabled === false ||
+        !shouldDisableLowerPriorityExpansionClaimPlan(
+          selectedCandidate,
+          target.colony,
+          target.roomName
+        )
       ) {
         continue;
       }
@@ -2172,9 +2188,12 @@ function disableLowerPriorityExpansionClaimPlans(
     if (
       intent.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR ||
       intent.action !== 'claim' ||
-      intent.colony !== selectedCandidate.colony ||
-      intent.targetRoom === selectedCandidate.roomName ||
-      (intent.status !== 'planned' && intent.status !== 'active')
+      (intent.status !== 'planned' && intent.status !== 'active') ||
+      !shouldDisableLowerPriorityExpansionClaimPlan(
+        selectedCandidate,
+        intent.colony,
+        intent.targetRoom
+      )
     ) {
       continue;
     }
@@ -2185,6 +2204,53 @@ function disableLowerPriorityExpansionClaimPlans(
       updatedAt: gameTime
     };
   }
+}
+
+function shouldDisableLowerPriorityExpansionClaimPlan(
+  selectedCandidate: ExpansionPlannerCandidate,
+  colony: string,
+  roomName: string
+): boolean {
+  if (colony === selectedCandidate.colony && roomName === selectedCandidate.roomName) {
+    return false;
+  }
+
+  if (colony !== selectedCandidate.colony && roomName !== selectedCandidate.roomName) {
+    return false;
+  }
+
+  const existingCandidate = buildVisibleExpansionPlannerClaimPlanCandidate(colony, roomName);
+  return (
+    existingCandidate !== null &&
+    compareExpansionPlannerCandidatePriority(existingCandidate, selectedCandidate) > 0
+  );
+}
+
+function buildVisibleExpansionPlannerClaimPlanCandidate(
+  colony: string,
+  roomName: string
+): ExpansionPlannerCandidate | null {
+  const rooms = getGameRooms();
+  const room = rooms?.[roomName];
+  if (!room) {
+    return null;
+  }
+
+  const ownerUsername = getControllerOwnerUsername(rooms?.[colony]?.controller);
+  const ownedRoomNames = getVisibleOwnedRoomNames(colony, ownerUsername);
+  const distance = getNearestOwnedRoomDistance(ownedRoomNames, roomName);
+  if (distance === null || distance > EXPANSION_PLANNER_MAX_ROUTE_DISTANCE) {
+    return null;
+  }
+
+  return toRuntimeExpansionPlannerCandidate(
+    colony,
+    room,
+    distance,
+    0,
+    ownerUsername,
+    getExpansionPlannerAdjacencyBonus(distance)
+  );
 }
 
 function getExpansionPlanKey(colony: string, targetRoom: string, action: TerritoryControlAction): string {

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -1288,7 +1288,10 @@ describe('runEconomy', () => {
   it('turns a safe occupation recommendation into same-tick expansion claim pressure', () => {
     (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
-    const room = makeTerritoryReadyEconomyRoom();
+    const room = makeTerritoryReadyEconomyRoom({
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300
+    });
     const targetRoom = makeVisibleReserveRoom('W2N1', 'controller2' as Id<StructureController>);
     const spawn = {
       name: 'Spawn1',
@@ -1314,17 +1317,21 @@ describe('runEconomy', () => {
 
     runEconomy();
 
-    expect(spawn.spawnCreep).toHaveBeenCalledWith(['claim', 'move'], 'claimer-W1N1-W2N1-320', {
-      memory: {
-        role: 'claimer',
-        colony: 'W1N1',
-        territory: {
-          targetRoom: 'W2N1',
-          action: 'claim',
-          controllerId: 'controller2'
+    expect(spawn.spawnCreep).toHaveBeenCalledWith(
+      ['claim', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move'],
+      'claimer-W1N1-W2N1-320',
+      {
+        memory: {
+          role: 'claimer',
+          colony: 'W1N1',
+          territory: {
+            targetRoom: 'W2N1',
+            action: 'claim',
+            controllerId: 'controller2'
+          }
         }
       }
-    });
+    );
     expect(Memory.territory?.targets).toEqual([
       {
         colony: 'W1N1',
@@ -1369,7 +1376,10 @@ describe('runEconomy', () => {
         }
       }
     };
-    const room = makeTerritoryReadyEconomyRoom();
+    const room = makeTerritoryReadyEconomyRoom({
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300
+    });
     const spawn = {
       name: 'Spawn1',
       room,
@@ -1396,17 +1406,21 @@ describe('runEconomy', () => {
 
     runEconomy();
 
-    expect(spawn.spawnCreep).toHaveBeenCalledWith(['claim', 'move'], 'claimer-W1N1-W2N1-505', {
-      memory: {
-        role: 'claimer',
-        colony: 'W1N1',
-        territory: {
-          targetRoom: 'W2N1',
-          action: 'claim',
-          controllerId: 'controller2'
+    expect(spawn.spawnCreep).toHaveBeenCalledWith(
+      ['claim', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move'],
+      'claimer-W1N1-W2N1-505',
+      {
+        memory: {
+          role: 'claimer',
+          colony: 'W1N1',
+          territory: {
+            targetRoom: 'W2N1',
+            action: 'claim',
+            controllerId: 'controller2'
+          }
         }
       }
-    });
+    );
     expect(room.memory.cachedExpansionSelection).toMatchObject({
       status: 'planned',
       colony: 'W1N1',
@@ -1438,8 +1452,17 @@ describe('runEconomy', () => {
     (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
     (globalThis as unknown as { TERRAIN_MASK_SWAMP: number }).TERRAIN_MASK_SWAMP = 2;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
-    const room = makeTerritoryReadyEconomyRoom();
+    const room = makeTerritoryReadyEconomyRoom({
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300
+    });
     const targetRoom = makeVisibleExpansionScoringRoom('W2N1', 'controller2' as Id<StructureController>);
+    const spawn = {
+      name: 'Spawn1',
+      room,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
     const workers = {
       Worker1: makeEconomyWorker(room),
       Worker2: makeEconomyWorker(room),
@@ -1449,7 +1472,7 @@ describe('runEconomy', () => {
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       time: 501,
       rooms: { W1N1: room, W2N1: targetRoom },
-      spawns: {},
+      spawns: { Spawn1: spawn },
       creeps: workers,
       getObjectById: jest.fn().mockReturnValue(null),
       map: {
@@ -1461,7 +1484,7 @@ describe('runEconomy', () => {
 
     runEconomy();
 
-    expect(getRoomTerrain).toHaveBeenCalledTimes(2);
+    expect(getRoomTerrain).toHaveBeenCalledTimes(3);
     expect(room.memory.lastExpansionScoreTime).toBe(501);
     expect(room.memory.cachedExpansionSelection).toMatchObject({
       status: 'planned',
@@ -1482,11 +1505,15 @@ describe('runEconomy', () => {
     getRoomTerrain.mockImplementation(() => {
       throw new Error('next expansion scoring should reuse the cached selection between refresh ticks');
     });
+    (spawn as StructureSpawn & { spawning: Spawning | null }).spawning = {
+      name: 'claimer-W1N1-W2N1-501',
+      remainingTime: 1
+    } as Spawning;
     (globalThis as unknown as { Game: Partial<Game> }).Game.time = 502;
 
     runEconomy();
 
-    expect(getRoomTerrain).toHaveBeenCalledTimes(2);
+    expect(getRoomTerrain).toHaveBeenCalledTimes(3);
     expect(room.memory.lastExpansionScoreTime).toBe(501);
   });
 
@@ -1504,8 +1531,17 @@ describe('runEconomy', () => {
     (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
     (globalThis as unknown as { TERRAIN_MASK_SWAMP: number }).TERRAIN_MASK_SWAMP = 2;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
-    const room = makeTerritoryReadyEconomyRoom();
+    const room = makeTerritoryReadyEconomyRoom({
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300
+    });
     const targetRoom = makeVisibleExpansionScoringRoom('W2N1', 'controller2' as Id<StructureController>);
+    const spawn = {
+      name: 'Spawn1',
+      room,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
     const workers = {
       Worker1: makeEconomyWorker(room),
       Worker2: makeEconomyWorker(room),
@@ -1515,7 +1551,7 @@ describe('runEconomy', () => {
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       time: 501,
       rooms: { W1N1: room, W2N1: targetRoom },
-      spawns: {},
+      spawns: { Spawn1: spawn },
       creeps: workers,
       getObjectById: jest.fn().mockReturnValue(null),
       map: {
@@ -1527,12 +1563,12 @@ describe('runEconomy', () => {
 
     runEconomy();
 
-    room.energyCapacityAvailable = 750;
+    room.energyCapacityAvailable = 1_400;
     (globalThis as unknown as { Game: Partial<Game> }).Game.time = 502;
 
     runEconomy();
 
-    expect(getRoomTerrain).toHaveBeenCalledTimes(4);
+    expect(getRoomTerrain).toHaveBeenCalledTimes(6);
     expect(room.memory.lastExpansionScoreTime).toBe(502);
     expect(room.memory.cachedExpansionSelection).toMatchObject({
       status: 'planned',
@@ -1555,8 +1591,17 @@ describe('runEconomy', () => {
     (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
     (globalThis as unknown as { TERRAIN_MASK_SWAMP: number }).TERRAIN_MASK_SWAMP = 2;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
-    const room = makeTerritoryReadyEconomyRoom();
+    const room = makeTerritoryReadyEconomyRoom({
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300
+    });
     const targetRoom = makeVisibleExpansionScoringRoom('W2N1', 'controller2' as Id<StructureController>);
+    const spawn = {
+      name: 'Spawn1',
+      room,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
     const workers = {
       Worker1: makeEconomyWorker(room),
       Worker2: makeEconomyWorker(room),
@@ -1566,7 +1611,7 @@ describe('runEconomy', () => {
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       time: 501,
       rooms: { W1N1: room, W2N1: targetRoom },
-      spawns: {},
+      spawns: { Spawn1: spawn },
       creeps: workers,
       getObjectById: jest.fn().mockReturnValue(null),
       map: {
@@ -1587,7 +1632,7 @@ describe('runEconomy', () => {
 
     runEconomy();
 
-    expect(getRoomTerrain).toHaveBeenCalledTimes(3);
+    expect(getRoomTerrain).toHaveBeenCalledTimes(6);
     expect(room.memory.lastExpansionScoreTime).toBe(502);
     expect(room.memory.cachedExpansionSelection).toMatchObject({
       status: 'skipped',

--- a/prod/test/expansionExecutor.test.ts
+++ b/prod/test/expansionExecutor.test.ts
@@ -115,6 +115,14 @@ describe('expansion executor', () => {
       reason: 'unmetPreconditions'
     });
     expect(Memory.territory?.targets).toEqual([]);
+
+    hostileCreepCount = 0;
+    ((globalThis as unknown as { Game: Partial<Game> }).Game as { time: number }).time = 152;
+
+    expect(refreshExpansionExecutorIntent(colony, 152)).toMatchObject({
+      status: 'planned',
+      targetRoom: 'W2N1'
+    });
   });
 
   it('blocks claiming when recent threat memory was not refreshed on the current tick', () => {

--- a/prod/test/expansionExecutor.test.ts
+++ b/prod/test/expansionExecutor.test.ts
@@ -163,6 +163,42 @@ describe('expansion executor', () => {
     expect(Memory.territory?.targets).toEqual([]);
   });
 
+  it('allows claiming when recent threat memory omits the colony room', () => {
+    const colony = makeColony();
+    Memory.defense = {
+      colonyThreats: {
+        updatedAt: 200,
+        rooms: {
+          W9N9: {
+            roomName: 'W9N9',
+            level: 'hostile_present',
+            updatedAt: 200,
+            hostileCreepCount: 1,
+            hostileStructureCount: 0,
+            damagedCriticalStructureCount: 0
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 200,
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeExpansionRoom('W2N1', 'controller2' as Id<StructureController>, 2)
+      },
+      map: {
+        describeExits: jest.fn((roomName: string) => (roomName === 'W1N1' ? { '3': 'W2N1' } : {})),
+        findRoute: jest.fn(() => [{ exit: 3, room: 'W2N1' }]),
+        getRoomTerrain: jest.fn(() => makeTerrain(0))
+      } as unknown as GameMap
+    };
+
+    expect(refreshExpansionExecutorIntent(colony, 200)).toMatchObject({
+      status: 'planned',
+      targetRoom: 'W2N1'
+    });
+  });
+
   it('requests scouting for the highest-ranked unseen expansion candidate', () => {
     const colony = makeColony();
     (globalThis as unknown as { Game: Partial<Game> }).Game = {

--- a/prod/test/expansionExecutor.test.ts
+++ b/prod/test/expansionExecutor.test.ts
@@ -109,13 +109,67 @@ describe('expansion executor', () => {
       }
     ]);
   });
+
+  it('skips and clears claim targets when the colony is not ready to bootstrap an expansion', () => {
+    const colony = makeColony({ energyAvailable: 650, energyCapacityAvailable: 650 });
+    Memory.territory = {
+      targets: [
+        {
+          colony: 'W1N1',
+          roomName: 'W2N1',
+          action: 'claim',
+          createdBy: 'nextExpansionScoring',
+          controllerId: 'controller2' as Id<StructureController>
+        }
+      ],
+      intents: [
+        {
+          colony: 'W1N1',
+          targetRoom: 'W2N1',
+          action: 'claim',
+          status: 'planned',
+          updatedAt: 190,
+          createdBy: 'nextExpansionScoring',
+          controllerId: 'controller2' as Id<StructureController>
+        }
+      ]
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 300,
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeExpansionRoom('W2N1', 'controller2' as Id<StructureController>, 2)
+      },
+      map: {
+        describeExits: jest.fn((roomName: string) => (roomName === 'W1N1' ? { '3': 'W2N1' } : {})),
+        findRoute: jest.fn(() => [{ exit: 3, room: 'W2N1' }]),
+        getRoomTerrain: jest.fn(() => makeTerrain(0))
+      } as unknown as GameMap
+    };
+
+    expect(refreshExpansionExecutorIntent(colony, 300)).toEqual({
+      status: 'skipped',
+      colony: 'W1N1',
+      reason: 'unmetPreconditions'
+    });
+    expect(Memory.territory?.targets).toEqual([]);
+    expect(Memory.territory?.intents).toEqual([]);
+  });
 });
 
-function makeColony(): ColonySnapshot {
+function makeColony({
+  energyAvailable = 1_300,
+  energyCapacityAvailable = 1_300,
+  spawns = [makeActiveSpawn('spawn-W1N1')]
+}: {
+  energyAvailable?: number;
+  energyCapacityAvailable?: number;
+  spawns?: StructureSpawn[];
+} = {}): ColonySnapshot {
   const room = {
     name: 'W1N1',
-    energyAvailable: 650,
-    energyCapacityAvailable: 650,
+    energyAvailable,
+    energyCapacityAvailable,
     controller: {
       id: 'controller1' as Id<StructureController>,
       my: true,
@@ -129,11 +183,20 @@ function makeColony(): ColonySnapshot {
 
   return {
     room,
-    spawns: [],
-    energyAvailable: 650,
-    energyCapacityAvailable: 650,
+    spawns,
+    energyAvailable,
+    energyCapacityAvailable,
     memory: room.memory
   };
+}
+
+function makeActiveSpawn(name: string): StructureSpawn {
+  return {
+    id: `${name}-id` as Id<StructureSpawn>,
+    name,
+    spawning: null,
+    isActive: jest.fn(() => true)
+  } as unknown as StructureSpawn;
 }
 
 function makeExpansionRoom(

--- a/prod/test/expansionExecutor.test.ts
+++ b/prod/test/expansionExecutor.test.ts
@@ -64,11 +64,95 @@ describe('expansion executor', () => {
     getRoomTerrain.mockImplementation(() => {
       throw new Error('cached expansion executor selection should avoid rescoring');
     });
+    colony.energyAvailable = 1_299;
+    (colony.room as Room & { energyAvailable: number }).energyAvailable = 1_299;
+    ((globalThis as unknown as { Game: Partial<Game> }).Game as { time: number }).time = 101;
 
     expect(refreshExpansionExecutorIntent(colony, 101)).toMatchObject({
       status: 'planned',
       targetRoom: 'W3N1'
     });
+  });
+
+  it('revalidates claim readiness before reusing a cached planned selection', () => {
+    const colony = makeColony();
+    const homeSources = makeSources('W1N1', 2);
+    let hostileCreepCount = 0;
+    (colony.room.find as jest.Mock).mockImplementation((findType: number) => {
+      if (findType === FIND_SOURCES) {
+        return homeSources;
+      }
+      if (findType === FIND_HOSTILE_CREEPS) {
+        return Array.from({ length: hostileCreepCount }, (_value, index) => ({ id: `hostile-${index}` }));
+      }
+
+      return [];
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 150,
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeExpansionRoom('W2N1', 'controller2' as Id<StructureController>, 2)
+      },
+      map: {
+        describeExits: jest.fn((roomName: string) => (roomName === 'W1N1' ? { '3': 'W2N1' } : {})),
+        findRoute: jest.fn(() => [{ exit: 3, room: 'W2N1' }]),
+        getRoomTerrain: jest.fn(() => makeTerrain(0))
+      } as unknown as GameMap
+    };
+
+    expect(refreshExpansionExecutorIntent(colony, 150)).toMatchObject({
+      status: 'planned',
+      targetRoom: 'W2N1'
+    });
+
+    hostileCreepCount = 1;
+    ((globalThis as unknown as { Game: Partial<Game> }).Game as { time: number }).time = 151;
+
+    expect(refreshExpansionExecutorIntent(colony, 151)).toEqual({
+      status: 'skipped',
+      colony: 'W1N1',
+      reason: 'unmetPreconditions'
+    });
+    expect(Memory.territory?.targets).toEqual([]);
+  });
+
+  it('blocks claiming when recent threat memory was not refreshed on the current tick', () => {
+    const colony = makeColony();
+    Memory.defense = {
+      colonyThreats: {
+        updatedAt: 199,
+        rooms: {
+          W1N1: {
+            roomName: 'W1N1',
+            level: 'hostile_present',
+            updatedAt: 199,
+            hostileCreepCount: 1,
+            hostileStructureCount: 0,
+            damagedCriticalStructureCount: 0
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 200,
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeExpansionRoom('W2N1', 'controller2' as Id<StructureController>, 2)
+      },
+      map: {
+        describeExits: jest.fn((roomName: string) => (roomName === 'W1N1' ? { '3': 'W2N1' } : {})),
+        findRoute: jest.fn(() => [{ exit: 3, room: 'W2N1' }]),
+        getRoomTerrain: jest.fn(() => makeTerrain(0))
+      } as unknown as GameMap
+    };
+
+    expect(refreshExpansionExecutorIntent(colony, 200)).toEqual({
+      status: 'skipped',
+      colony: 'W1N1',
+      reason: 'unmetPreconditions'
+    });
+    expect(Memory.territory?.targets).toEqual([]);
   });
 
   it('requests scouting for the highest-ranked unseen expansion candidate', () => {

--- a/prod/test/expansionPlanner.test.ts
+++ b/prod/test/expansionPlanner.test.ts
@@ -494,6 +494,23 @@ describe('expansion planner', () => {
           }
         }
       }
+    ],
+    [
+      'recent colony threat not refreshed this tick',
+      { energyAvailable: 1_300, energyCapacityAvailable: 1_300 },
+      {
+        updatedAt: 99,
+        rooms: {
+          W1N1: {
+            roomName: 'W1N1',
+            level: 'hostile_present' as DefenseThreatLevel,
+            updatedAt: 99,
+            hostileCreepCount: 1,
+            hostileStructureCount: 0,
+            damagedCriticalStructureCount: 0
+          }
+        }
+      }
     ]
   ])('falls back to reservation when claim readiness is blocked by %s', (_label, colonyOptions, threatMemory) => {
     const { colony } = makeColony(colonyOptions);
@@ -521,6 +538,41 @@ describe('expansion planner', () => {
         colony: 'W1N1',
         roomName: 'W2N1',
         action: 'reserve',
+        createdBy: 'expansionPlanner',
+        controllerId: 'controller-W2N1'
+      }
+    ]);
+  });
+
+  it('uses Game.spawns as a claim-readiness fallback when the colony snapshot has no spawns', () => {
+    const { colony } = makeColony({ energyAvailable: 1_300, energyCapacityAvailable: 1_300, spawns: [] });
+    installGame(colony, {
+      gclLevel: 2,
+      exits: { W1N1: { '3': 'W2N1' } },
+      rooms: {
+        W2N1: makeExpansionRoom('W2N1')
+      }
+    });
+    ((globalThis as unknown as { Game: Partial<Game> }).Game as { spawns: Record<string, StructureSpawn> }).spawns = {
+      'spawn-W1N1': {
+        ...makeActiveSpawn('spawn-W1N1'),
+        room: colony.room
+      } as StructureSpawn
+    };
+
+    const plan = refreshExpansionPlannerIntent(colony, 100);
+
+    expect(plan).toMatchObject({
+      status: 'planned',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
         createdBy: 'expansionPlanner',
         controllerId: 'controller-W2N1'
       }
@@ -928,7 +980,7 @@ describe('expansion planner', () => {
     ]);
   });
 
-  it('cancels lower-priority duplicate expansion planner claim plans for the selected room', () => {
+  it('does not disable another colony claim plan for the selected room without priority comparison', () => {
     const controllerId = 'controller-W2N1' as Id<StructureController>;
     Memory.territory = {
       targets: [
@@ -977,8 +1029,7 @@ describe('expansion planner', () => {
         roomName: 'W2N1',
         action: 'claim',
         createdBy: 'expansionPlanner',
-        controllerId,
-        enabled: false
+        controllerId
       },
       {
         colony: 'W1N1',
@@ -993,8 +1044,8 @@ describe('expansion planner', () => {
         colony: 'W0N1',
         targetRoom: 'W2N1',
         action: 'claim',
-        status: 'inactive',
-        updatedAt: 122,
+        status: 'planned',
+        updatedAt: 100,
         createdBy: 'expansionPlanner',
         controllerId
       },
@@ -1006,6 +1057,89 @@ describe('expansion planner', () => {
         updatedAt: 122,
         createdBy: 'expansionPlanner',
         controllerId
+      }
+    ]);
+  });
+
+  it('disables older same-colony expansion planner claim plans when a new claim is selected', () => {
+    const oldControllerId = 'controller-W3N1' as Id<StructureController>;
+    const nextControllerId = 'controller-W2N1' as Id<StructureController>;
+    Memory.territory = {
+      targets: [
+        {
+          colony: 'W1N1',
+          roomName: 'W3N1',
+          action: 'claim',
+          createdBy: 'expansionPlanner',
+          controllerId: oldControllerId
+        }
+      ],
+      intents: [
+        {
+          colony: 'W1N1',
+          targetRoom: 'W3N1',
+          action: 'claim',
+          status: 'planned',
+          updatedAt: 100,
+          createdBy: 'expansionPlanner',
+          controllerId: oldControllerId
+        }
+      ]
+    };
+
+    const intent = createExpansionIntent(
+      evaluateExpansionCandidate({
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        distance: 1,
+        sourceCount: 2,
+        controllerId: nextControllerId
+      }),
+      'claim',
+      123
+    );
+
+    const territory = Memory.territory as TerritoryMemory;
+    expect(intent).toMatchObject({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim'
+    });
+    expect(territory.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W3N1',
+        action: 'claim',
+        createdBy: 'expansionPlanner',
+        controllerId: oldControllerId,
+        enabled: false
+      },
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        createdBy: 'expansionPlanner',
+        controllerId: nextControllerId
+      }
+    ]);
+    expect(territory.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'claim',
+        status: 'inactive',
+        updatedAt: 123,
+        createdBy: 'expansionPlanner',
+        controllerId: oldControllerId
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 123,
+        createdBy: 'expansionPlanner',
+        controllerId: nextControllerId
       }
     ]);
   });

--- a/prod/test/expansionPlanner.test.ts
+++ b/prod/test/expansionPlanner.test.ts
@@ -980,7 +980,7 @@ describe('expansion planner', () => {
     ]);
   });
 
-  it('does not disable another colony claim plan for the selected room without priority comparison', () => {
+  it('keeps a higher-priority existing colony claim plan for the selected room', () => {
     const controllerId = 'controller-W2N1' as Id<StructureController>;
     Memory.territory = {
       targets: [
@@ -1004,12 +1004,23 @@ describe('expansion planner', () => {
         }
       ]
     };
+    const { colony } = makeColony({ energyAvailable: 1_300, energyCapacityAvailable: 1_300 });
+    installGame(colony, {
+      gclLevel: 3,
+      exits: {
+        W0N1: { '3': 'W2N1' },
+        W1N1: {}
+      },
+      rooms: {
+        W2N1: makeExpansionRoom('W2N1')
+      }
+    });
 
     const intent = createExpansionIntent(
       evaluateExpansionCandidate({
         colony: 'W1N1',
         roomName: 'W2N1',
-        distance: 1,
+        distance: 2,
         sourceCount: 2,
         controllerId
       }),
@@ -1086,13 +1097,22 @@ describe('expansion planner', () => {
         }
       ]
     };
+    const { colony } = makeColony({ energyAvailable: 1_300, energyCapacityAvailable: 1_300 });
+    installGame(colony, {
+      gclLevel: 3,
+      exits: { W1N1: { '3': 'W2N1', '5': 'W3N1' } },
+      rooms: {
+        W2N1: makeExpansionRoom('W2N1', { sourceCount: 3 }),
+        W3N1: makeExpansionRoom('W3N1', { sourceCount: 2 })
+      }
+    });
 
     const intent = createExpansionIntent(
       evaluateExpansionCandidate({
         colony: 'W1N1',
         roomName: 'W2N1',
         distance: 1,
-        sourceCount: 2,
+        sourceCount: 3,
         controllerId: nextControllerId
       }),
       'claim',
@@ -1138,6 +1158,97 @@ describe('expansion planner', () => {
         action: 'claim',
         status: 'planned',
         updatedAt: 123,
+        createdBy: 'expansionPlanner',
+        controllerId: nextControllerId
+      }
+    ]);
+  });
+
+  it('keeps a higher-priority same-colony claim plan active when a weaker claim is selected', () => {
+    const oldControllerId = 'controller-W3N1' as Id<StructureController>;
+    const nextControllerId = 'controller-W2N1' as Id<StructureController>;
+    Memory.territory = {
+      targets: [
+        {
+          colony: 'W1N1',
+          roomName: 'W3N1',
+          action: 'claim',
+          createdBy: 'expansionPlanner',
+          controllerId: oldControllerId
+        }
+      ],
+      intents: [
+        {
+          colony: 'W1N1',
+          targetRoom: 'W3N1',
+          action: 'claim',
+          status: 'planned',
+          updatedAt: 100,
+          createdBy: 'expansionPlanner',
+          controllerId: oldControllerId
+        }
+      ]
+    };
+    const { colony } = makeColony({ energyAvailable: 1_300, energyCapacityAvailable: 1_300 });
+    installGame(colony, {
+      gclLevel: 3,
+      exits: { W1N1: { '3': 'W2N1', '5': 'W3N1' } },
+      rooms: {
+        W2N1: makeExpansionRoom('W2N1', { sourceCount: 2 }),
+        W3N1: makeExpansionRoom('W3N1', { sourceCount: 3 })
+      }
+    });
+
+    const intent = createExpansionIntent(
+      evaluateExpansionCandidate({
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        distance: 1,
+        sourceCount: 2,
+        controllerId: nextControllerId
+      }),
+      'claim',
+      124
+    );
+
+    const territory = Memory.territory as TerritoryMemory;
+    expect(intent).toMatchObject({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim'
+    });
+    expect(territory.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W3N1',
+        action: 'claim',
+        createdBy: 'expansionPlanner',
+        controllerId: oldControllerId
+      },
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        createdBy: 'expansionPlanner',
+        controllerId: nextControllerId
+      }
+    ]);
+    expect(territory.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 100,
+        createdBy: 'expansionPlanner',
+        controllerId: oldControllerId
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 124,
         createdBy: 'expansionPlanner',
         controllerId: nextControllerId
       }

--- a/prod/test/expansionPlanner.test.ts
+++ b/prod/test/expansionPlanner.test.ts
@@ -76,7 +76,7 @@ describe('expansion planner', () => {
     ).toContain('controllerReserved');
   });
 
-  it('prioritizes suitable candidates by source count, distance, and stable order', () => {
+  it('prioritizes suitable candidates by adjacency score, source count, and stable order', () => {
     const orderedCandidates = prioritizeExpansionCandidates([
       {
         colony: 'W1N1',
@@ -112,7 +112,42 @@ describe('expansion planner', () => {
       }
     ]);
 
-    expect(orderedCandidates.map((candidate) => candidate.roomName)).toEqual(['W4N1', 'W1N2', 'W2N1']);
+    expect(orderedCandidates.map((candidate) => candidate.roomName)).toEqual(['W1N2', 'W4N1', 'W2N1']);
+  });
+
+  it('deduplicates expansion candidates for the same room by keeping the highest score', () => {
+    const orderedCandidates = prioritizeExpansionCandidates([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        distance: 2,
+        sourceCount: 2,
+        controllerId: 'controller-W2N1' as Id<StructureController>,
+        order: 0
+      },
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        distance: 1,
+        sourceCount: 2,
+        controllerId: 'controller-W2N1' as Id<StructureController>,
+        order: 1
+      },
+      {
+        colony: 'W1N1',
+        roomName: 'W3N1',
+        distance: 1,
+        sourceCount: 2,
+        controllerId: 'controller-W3N1' as Id<StructureController>,
+        order: 2
+      }
+    ]);
+
+    expect(orderedCandidates).toHaveLength(2);
+    expect(orderedCandidates[0]).toMatchObject({
+      roomName: 'W2N1',
+      distance: 1
+    });
   });
 
   it('plans valid strategic tower placements from controller, source, and entrance anchors', () => {
@@ -421,6 +456,71 @@ describe('expansion planner', () => {
         action: 'claim',
         status: 'planned',
         updatedAt: 100,
+        createdBy: 'expansionPlanner',
+        controllerId: 'controller-W2N1'
+      }
+    ]);
+  });
+
+  it.each([
+    [
+      'low bootstrap energy',
+      { energyAvailable: 650, energyCapacityAvailable: 650 },
+      undefined
+    ],
+    [
+      'no active spawn',
+      { energyAvailable: 1_300, energyCapacityAvailable: 1_300, spawns: [] },
+      undefined
+    ],
+    [
+      'visible home hostiles',
+      { energyAvailable: 1_300, energyCapacityAvailable: 1_300, hostileCreepCount: 1 },
+      undefined
+    ],
+    [
+      'pending colony threat',
+      { energyAvailable: 1_300, energyCapacityAvailable: 1_300 },
+      {
+        updatedAt: 100,
+        rooms: {
+          W1N1: {
+            roomName: 'W1N1',
+            level: 'hostile_present' as DefenseThreatLevel,
+            updatedAt: 100,
+            hostileCreepCount: 1,
+            hostileStructureCount: 0,
+            damagedCriticalStructureCount: 0
+          }
+        }
+      }
+    ]
+  ])('falls back to reservation when claim readiness is blocked by %s', (_label, colonyOptions, threatMemory) => {
+    const { colony } = makeColony(colonyOptions);
+    if (threatMemory) {
+      Memory.defense = { colonyThreats: threatMemory };
+    }
+    installGame(colony, {
+      gclLevel: 2,
+      exits: { W1N1: { '3': 'W2N1' } },
+      rooms: {
+        W2N1: makeExpansionRoom('W2N1')
+      }
+    });
+
+    const plan = refreshExpansionPlannerIntent(colony, 100);
+
+    expect(plan).toMatchObject({
+      status: 'planned',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'reserve',
         createdBy: 'expansionPlanner',
         controllerId: 'controller-W2N1'
       }
@@ -804,7 +904,7 @@ describe('expansion planner', () => {
       colony: 'W1N1',
       targetRoom: 'W2N1',
       action: 'claim',
-      score: 1_900,
+      score: 3_400,
       controllerId
     });
     expect(territory.targets?.[0]).toMatchObject({
@@ -822,6 +922,88 @@ describe('expansion planner', () => {
         action: 'claim',
         status: 'planned',
         updatedAt: 121,
+        createdBy: 'expansionPlanner',
+        controllerId
+      }
+    ]);
+  });
+
+  it('cancels lower-priority duplicate expansion planner claim plans for the selected room', () => {
+    const controllerId = 'controller-W2N1' as Id<StructureController>;
+    Memory.territory = {
+      targets: [
+        {
+          colony: 'W0N1',
+          roomName: 'W2N1',
+          action: 'claim',
+          createdBy: 'expansionPlanner',
+          controllerId
+        }
+      ],
+      intents: [
+        {
+          colony: 'W0N1',
+          targetRoom: 'W2N1',
+          action: 'claim',
+          status: 'planned',
+          updatedAt: 100,
+          createdBy: 'expansionPlanner',
+          controllerId
+        }
+      ]
+    };
+
+    const intent = createExpansionIntent(
+      evaluateExpansionCandidate({
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        distance: 1,
+        sourceCount: 2,
+        controllerId
+      }),
+      'claim',
+      122
+    );
+
+    const territory = Memory.territory as TerritoryMemory;
+    expect(intent).toMatchObject({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim'
+    });
+    expect(territory.targets).toEqual([
+      {
+        colony: 'W0N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        createdBy: 'expansionPlanner',
+        controllerId,
+        enabled: false
+      },
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        createdBy: 'expansionPlanner',
+        controllerId
+      }
+    ]);
+    expect(territory.intents).toEqual([
+      {
+        colony: 'W0N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'inactive',
+        updatedAt: 122,
+        createdBy: 'expansionPlanner',
+        controllerId
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 122,
         createdBy: 'expansionPlanner',
         controllerId
       }
@@ -1098,11 +1280,17 @@ describe('expansion planner', () => {
 function makeColony({
   energyAvailable = 650,
   energyCapacityAvailable = 650,
-  controllerLevel = 3
+  controllerLevel = 3,
+  hostileCreepCount = 0,
+  hostileStructureCount = 0,
+  spawns = [makeActiveSpawn('spawn-W1N1')]
 }: {
   energyAvailable?: number;
   energyCapacityAvailable?: number;
   controllerLevel?: number;
+  hostileCreepCount?: number;
+  hostileStructureCount?: number;
+  spawns?: StructureSpawn[];
 } = {}): { colony: ColonySnapshot } {
   const room = {
     name: 'W1N1',
@@ -1119,6 +1307,14 @@ function makeColony({
       if (findType === FIND_SOURCES) {
         return [{ id: 'source-W1N1-0' }];
       }
+      if (findType === FIND_HOSTILE_CREEPS) {
+        return Array.from({ length: hostileCreepCount }, (_value, index) => ({ id: `home-hostile-${index}` }));
+      }
+      if (findType === FIND_HOSTILE_STRUCTURES) {
+        return Array.from({ length: hostileStructureCount }, (_value, index) => ({
+          id: `home-hostile-structure-${index}`
+        }));
+      }
 
       return [];
     })
@@ -1127,11 +1323,20 @@ function makeColony({
   return {
     colony: {
       room,
-      spawns: [],
+      spawns,
       energyAvailable,
       energyCapacityAvailable
     }
   };
+}
+
+function makeActiveSpawn(name: string): StructureSpawn {
+  return {
+    id: `${name}-id` as Id<StructureSpawn>,
+    name,
+    spawning: null,
+    isActive: jest.fn(() => true)
+  } as unknown as StructureSpawn;
 }
 
 function makeExpansionRoom(


### PR DESCRIPTION
Closes #770

## Summary
Implement multi-room expansion planning with:
1. **Adjacency-based colony scoring**: Prefer rooms adjacent to existing colonies (within distance 2). Score adjacency bonus higher for directly connected rooms.
2. **Expansion readiness gate**: Before claiming a second colony, verify controller level >= 2, active spawn, no hostiles, and energy buffer for bootstrapping.
3. **Claim queue deduplication**: Resolve competing expansion candidates targeting the same room to the highest-scoring candidate.

## Verification
```
Controller: typecheck PASS, 1465 tests PASS, build PASS, git diff --check clean
Commit: fb7f008 by lanyusea's bot
Reconciled on top of e24ed84 (container energy merge)
```
