### PR TITLE
feat(economy): implement terminal resource management for cross-room energy logistics (#780)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -28427,10 +28427,7 @@ function clampSendAmountForEnergyBudget(requestedAmount, distance, energyBudget)
   if (normalizedBudget <= 0) {
     return 0;
   }
-  let amount = Math.min(
-    normalizeNonNegativeInteger9(requestedAmount),
-    Math.floor(normalizedBudget / (1 + 0.1 * Math.max(0, distance)))
-  );
+  let amount = normalizeNonNegativeInteger9(requestedAmount);
   while (amount > 0 && amount + calculateTerminalEnergyCostForDistance(distance, amount) > normalizedBudget) {
     amount -= 1;
   }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -28350,7 +28350,7 @@ function selectTerminalEnergyTransfers(filter = {}) {
 function calculateTerminalEnergyCostForDistance(distance, amount) {
   const normalizedDistance = normalizeNonNegativeInteger9(distance);
   const normalizedAmount = normalizeNonNegativeInteger9(amount);
-  return Math.floor(0.1 * normalizedDistance * normalizedAmount);
+  return Math.ceil(normalizedAmount * (1 - Math.exp(-normalizedDistance / 30)));
 }
 function getTerminalSendCooldown(amount) {
   const normalizedAmount = normalizeNonNegativeInteger9(amount);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -28277,6 +28277,342 @@ function matchesStructureType22(actual, globalName, fallback) {
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
 }
 
+// src/economy/terminalManager.ts
+var TERMINAL_ENERGY_MIN_RESERVE = 2e4;
+var TERMINAL_MAX_ENERGY_SEND_AMOUNT = 1e4;
+var TERMINAL_MIN_ENERGY_SEND_AMOUNT = 100;
+var OK_CODE10 = 0;
+function manageTerminalEnergy() {
+  const plans = selectTerminalEnergyTransfers();
+  const results = [];
+  const gameTime = getGameTime23();
+  for (const plan of plans) {
+    const result = plan.sourceTerminal.send(
+      getEnergyResource17(),
+      plan.amount,
+      plan.targetRoom,
+      plan.description
+    );
+    const transferResult = {
+      amount: plan.amount,
+      availableAt: gameTime + plan.cooldown,
+      cooldown: plan.cooldown,
+      description: plan.description,
+      distance: plan.distance,
+      energyCost: plan.energyCost,
+      result,
+      sourceRoom: plan.sourceRoom,
+      targetRoom: plan.targetRoom
+    };
+    results.push(transferResult);
+    if (result === OK_CODE10) {
+      reduceStorageBalanceTransfer(plan.sourceRoom, plan.targetRoom, plan.amount, gameTime);
+    }
+  }
+  recordTerminalLogisticsState(results, gameTime);
+  return results;
+}
+function selectTerminalEnergyTransfers(filter = {}) {
+  const balance = getStorageBalanceState();
+  const roomStates = buildProjectedTerminalRoomStates();
+  const selectedPlans = [];
+  const spentSourceRooms = /* @__PURE__ */ new Set();
+  for (const transfer of [...balance.transfers].filter((candidate) => candidate.amount > 0).sort(compareStorageTransfers)) {
+    if (filter.sourceRoom && transfer.sourceRoom !== filter.sourceRoom) {
+      continue;
+    }
+    if (filter.targetRoom && transfer.targetRoom !== filter.targetRoom) {
+      continue;
+    }
+    if (spentSourceRooms.has(transfer.sourceRoom)) {
+      continue;
+    }
+    const sourceState = roomStates.get(transfer.sourceRoom);
+    const targetState = roomStates.get(transfer.targetRoom);
+    if (!sourceState || !targetState || sourceState.room.name === targetState.room.name) {
+      continue;
+    }
+    const plan = buildTerminalEnergyTransferPlan(transfer, sourceState, targetState);
+    if (!plan) {
+      continue;
+    }
+    selectedPlans.push(plan);
+    spentSourceRooms.add(plan.sourceRoom);
+    sourceState.sourceBudget = Math.max(0, sourceState.sourceBudget - plan.amount - plan.energyCost);
+    sourceState.terminalEnergy = Math.max(0, sourceState.terminalEnergy - plan.amount - plan.energyCost);
+    sourceState.cooldown = plan.cooldown;
+    targetState.targetDemand = Math.max(0, targetState.targetDemand - plan.amount);
+    targetState.terminalEnergy += plan.amount;
+    targetState.terminalFreeCapacity = Math.max(0, targetState.terminalFreeCapacity - plan.amount);
+  }
+  return selectedPlans;
+}
+function calculateTerminalEnergyCostForDistance(distance, amount) {
+  const normalizedDistance = normalizeNonNegativeInteger9(distance);
+  const normalizedAmount = normalizeNonNegativeInteger9(amount);
+  return Math.floor(0.1 * normalizedDistance * normalizedAmount);
+}
+function getTerminalSendCooldown(amount) {
+  const normalizedAmount = normalizeNonNegativeInteger9(amount);
+  return normalizedAmount > 0 ? Math.max(1, Math.ceil(normalizedAmount / 100)) : 0;
+}
+function buildTerminalEnergyTransferPlan(transfer, sourceState, targetState) {
+  if (sourceState.state.mode !== "export" || targetState.state.mode !== "import" || sourceState.cooldown > 0 || sourceState.sourceBudget <= 0 || targetState.targetDemand <= 0) {
+    return null;
+  }
+  const distance = getRoomLinearDistance(sourceState.room.name, targetState.room.name);
+  if (distance === null || distance <= 0) {
+    return null;
+  }
+  const requestedAmount = Math.min(
+    transfer.amount,
+    sourceState.sourceBudget,
+    targetState.targetDemand,
+    TERMINAL_MAX_ENERGY_SEND_AMOUNT
+  );
+  const amount = clampSendAmountForEnergyBudget(requestedAmount, distance, sourceState.sourceBudget);
+  if (amount < TERMINAL_MIN_ENERGY_SEND_AMOUNT) {
+    return null;
+  }
+  const energyCost = calculateTerminalEnergyCostForDistance(distance, amount);
+  return {
+    amount,
+    cooldown: getTerminalSendCooldown(amount),
+    description: `energy-balance ${sourceState.room.name}->${targetState.room.name}`,
+    distance,
+    energyCost,
+    sourceRoom: sourceState.room.name,
+    sourceTerminal: sourceState.terminal,
+    targetRoom: targetState.room.name,
+    targetTerminal: targetState.terminal
+  };
+}
+function buildProjectedTerminalRoomStates() {
+  return new Map(
+    getOwnedRooms2().map((room) => buildProjectedTerminalRoomState(room)).filter((state) => state !== null).map((state) => [state.room.name, state])
+  );
+}
+function buildProjectedTerminalRoomState(room) {
+  const terminal = room.terminal;
+  if (!terminal) {
+    return null;
+  }
+  const state = getRoomStoredEnergyState(room);
+  const terminalEnergy = getStoredEnergy18(terminal);
+  const terminalFreeCapacity = getFreeEnergyCapacity13(terminal);
+  const terminalTargetEnergy = getTerminalEnergyTarget(terminal);
+  const sourceBudget = Math.min(
+    state.exportableEnergy,
+    Math.max(0, terminalEnergy - TERMINAL_ENERGY_MIN_RESERVE)
+  );
+  const targetDemand = Math.min(
+    state.importDemand,
+    terminalFreeCapacity,
+    Math.max(0, terminalTargetEnergy - terminalEnergy)
+  );
+  return {
+    room,
+    state,
+    terminal,
+    terminalEnergy,
+    terminalFreeCapacity,
+    terminalTargetEnergy,
+    cooldown: getTerminalCooldown(terminal),
+    sourceBudget,
+    targetDemand
+  };
+}
+function clampSendAmountForEnergyBudget(requestedAmount, distance, energyBudget) {
+  const normalizedBudget = normalizeNonNegativeInteger9(energyBudget);
+  if (normalizedBudget <= 0) {
+    return 0;
+  }
+  let amount = Math.min(
+    normalizeNonNegativeInteger9(requestedAmount),
+    Math.floor(normalizedBudget / (1 + 0.1 * Math.max(0, distance)))
+  );
+  while (amount > 0 && amount + calculateTerminalEnergyCostForDistance(distance, amount) > normalizedBudget) {
+    amount -= 1;
+  }
+  return amount;
+}
+function compareStorageTransfers(left, right) {
+  var _a, _b;
+  const leftDistance = (_a = getRoomLinearDistance(left.sourceRoom, left.targetRoom)) != null ? _a : Number.POSITIVE_INFINITY;
+  const rightDistance = (_b = getRoomLinearDistance(right.sourceRoom, right.targetRoom)) != null ? _b : Number.POSITIVE_INFINITY;
+  return getTransferEfficiency(right, rightDistance) - getTransferEfficiency(left, leftDistance) || right.amount - left.amount || leftDistance - rightDistance || left.sourceRoom.localeCompare(right.sourceRoom) || left.targetRoom.localeCompare(right.targetRoom);
+}
+function getTransferEfficiency(transfer, distance) {
+  if (!Number.isFinite(distance)) {
+    return 0;
+  }
+  return transfer.amount / Math.max(1, transfer.amount + calculateTerminalEnergyCostForDistance(distance, transfer.amount));
+}
+function reduceStorageBalanceTransfer(sourceRoom, targetRoom, sentAmount, gameTime) {
+  const memory = getEconomyMemory3();
+  const balance = memory.storageBalance;
+  if (!balance || !Array.isArray(balance.transfers)) {
+    return;
+  }
+  const updatedTransfers = [];
+  let remainingSentAmount = sentAmount;
+  for (const transfer of balance.transfers) {
+    if (remainingSentAmount > 0 && transfer.sourceRoom === sourceRoom && transfer.targetRoom === targetRoom) {
+      const reduction = Math.min(transfer.amount, remainingSentAmount);
+      remainingSentAmount -= reduction;
+      const amount = transfer.amount - reduction;
+      if (amount > 0) {
+        updatedTransfers.push({ ...transfer, amount, updatedAt: gameTime });
+      }
+      continue;
+    }
+    updatedTransfers.push(transfer);
+  }
+  balance.transfers = updatedTransfers;
+}
+function recordTerminalLogisticsState(results, gameTime) {
+  const memory = getEconomyMemory3();
+  const resultBySourceRoom = new Map(results.map((result) => [result.sourceRoom, result]));
+  const rooms = Object.fromEntries(
+    getOwnedRooms2().filter((room) => room.terminal !== void 0).map((room) => {
+      const terminal = room.terminal;
+      const result = resultBySourceRoom.get(room.name);
+      const cooldown = (result == null ? void 0 : result.result) === OK_CODE10 ? result.cooldown : getTerminalCooldown(terminal);
+      return [
+        room.name,
+        {
+          roomName: room.name,
+          terminalId: getObjectId12(terminal),
+          energy: getStoredEnergy18(terminal),
+          freeCapacity: getFreeEnergyCapacity13(terminal),
+          cooldown,
+          ...(result == null ? void 0 : result.result) === OK_CODE10 ? {
+            projectedCooldown: result.cooldown,
+            availableAt: result.availableAt
+          } : {},
+          updatedAt: gameTime
+        }
+      ];
+    })
+  );
+  memory.terminalLogistics = {
+    updatedAt: gameTime,
+    rooms,
+    transfers: results.map((result) => ({
+      sourceRoom: result.sourceRoom,
+      targetRoom: result.targetRoom,
+      amount: result.amount,
+      energyCost: result.energyCost,
+      distance: result.distance,
+      cooldown: result.cooldown,
+      availableAt: result.availableAt,
+      result: result.result,
+      description: result.description,
+      updatedAt: gameTime
+    }))
+  };
+}
+function getOwnedRooms2() {
+  var _a;
+  const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
+  if (!rooms) {
+    return [];
+  }
+  return Object.values(rooms).filter((room) => {
+    var _a2;
+    return ((_a2 = room == null ? void 0 : room.controller) == null ? void 0 : _a2.my) === true;
+  });
+}
+function getStoredEnergy18(target) {
+  var _a;
+  const store = getStore2(target);
+  const resource = getEnergyResource17();
+  const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, resource);
+  if (typeof usedCapacity === "number" && Number.isFinite(usedCapacity)) {
+    return Math.max(0, usedCapacity);
+  }
+  const directEnergy = store == null ? void 0 : store[resource];
+  return typeof directEnergy === "number" && Number.isFinite(directEnergy) ? Math.max(0, directEnergy) : 0;
+}
+function getFreeEnergyCapacity13(target) {
+  var _a;
+  const store = getStore2(target);
+  const resource = getEnergyResource17();
+  const freeCapacity = (_a = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _a.call(store, resource);
+  if (typeof freeCapacity === "number" && Number.isFinite(freeCapacity)) {
+    return Math.max(0, freeCapacity);
+  }
+  const capacity = getEnergyCapacity4(target);
+  return capacity > 0 ? Math.max(0, capacity - getStoredEnergy18(target)) : 0;
+}
+function getEnergyCapacity4(target) {
+  var _a, _b, _c;
+  const store = getStore2(target);
+  const resource = getEnergyResource17();
+  const capacity = (_a = store == null ? void 0 : store.getCapacity) == null ? void 0 : _a.call(store, resource);
+  if (typeof capacity === "number" && Number.isFinite(capacity)) {
+    return Math.max(0, capacity);
+  }
+  const genericCapacity = (_b = store == null ? void 0 : store.getCapacity) == null ? void 0 : _b.call(store);
+  if (typeof genericCapacity === "number" && Number.isFinite(genericCapacity)) {
+    return Math.max(0, genericCapacity);
+  }
+  const freeCapacity = (_c = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _c.call(store, resource);
+  return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? getStoredEnergy18(target) + Math.max(0, freeCapacity) : 0;
+}
+function getStore2(target) {
+  return target == null ? void 0 : target.store;
+}
+function getTerminalCooldown(terminal) {
+  const cooldown = terminal.cooldown;
+  return typeof cooldown === "number" && Number.isFinite(cooldown) ? Math.max(0, Math.floor(cooldown)) : 0;
+}
+function getRoomLinearDistance(fromRoom, targetRoom) {
+  var _a, _b, _c;
+  const distance = (_c = (_b = (_a = globalThis.Game) == null ? void 0 : _a.map) == null ? void 0 : _b.getRoomLinearDistance) == null ? void 0 : _c.call(
+    _b,
+    fromRoom,
+    targetRoom
+  );
+  return typeof distance === "number" && Number.isFinite(distance) ? Math.max(0, Math.floor(distance)) : null;
+}
+function getEconomyMemory3() {
+  const memory = getMemory3();
+  if (!memory.economy) {
+    memory.economy = {};
+  }
+  return memory.economy;
+}
+function getMemory3() {
+  const global = globalThis;
+  if (!global.Memory) {
+    global.Memory = {};
+  }
+  return global.Memory;
+}
+function getGameTime23() {
+  var _a;
+  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
+}
+function getEnergyResource17() {
+  var _a;
+  return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
+}
+function getObjectId12(object) {
+  if (typeof object !== "object" || object === null) {
+    return "";
+  }
+  const candidate = object;
+  if (typeof candidate.id === "string") {
+    return candidate.id;
+  }
+  return typeof candidate.name === "string" ? candidate.name : "";
+}
+function normalizeNonNegativeInteger9(value) {
+  return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
 // src/economy/mineral-harvesting.ts
 var MINERAL_HARVESTER_ROLE = "mineralHarvester";
 var MINERAL_HARVESTER_REPLACEMENT_TICKS = 100;
@@ -28285,10 +28621,10 @@ var MINERAL_MOVE_OPTS = { reusePath: 20, ignoreRoads: false };
 var ERR_NOT_IN_RANGE_CODE9 = -9;
 function planMineralHarvesterSpawn(colony, creeps, gameTime, options = {}) {
   var _a, _b, _c, _d, _e;
-  const energyAvailable = normalizeNonNegativeInteger9(
+  const energyAvailable = normalizeNonNegativeInteger10(
     (_b = (_a = options.energyAvailable) != null ? _a : colony.energyAvailable) != null ? _b : colony.room.energyAvailable
   );
-  const energyCapacity = normalizeNonNegativeInteger9(
+  const energyCapacity = normalizeNonNegativeInteger10(
     (_c = colony.energyCapacityAvailable) != null ? _c : colony.room.energyCapacityAvailable
   );
   if (!shouldAllowMineralHarvesting(energyAvailable, energyCapacity)) {
@@ -28303,7 +28639,7 @@ function planMineralHarvesterSpawn(colony, creeps, gameTime, options = {}) {
     return null;
   }
   const body = buildMineralHarvesterBody(
-    normalizeNonNegativeInteger9((_d = options.bodyEnergyBudget) != null ? _d : energyAvailable),
+    normalizeNonNegativeInteger10((_d = options.bodyEnergyBudget) != null ? _d : energyAvailable),
     (_e = colony.room.controller) == null ? void 0 : _e.level
   );
   if (body.length === 0) {
@@ -28346,14 +28682,14 @@ function selectMineralHarvestAssignment(room, creeps = Object.values(((_b) => (_
   };
 }
 function shouldAllowMineralHarvesting(energyAvailable, energyCapacity) {
-  const capacity = normalizeNonNegativeInteger9(energyCapacity);
+  const capacity = normalizeNonNegativeInteger10(energyCapacity);
   if (capacity <= 0) {
     return false;
   }
-  return normalizeNonNegativeInteger9(energyAvailable) >= capacity * MINERAL_HARVESTING_MIN_ENERGY_RATIO;
+  return normalizeNonNegativeInteger10(energyAvailable) >= capacity * MINERAL_HARVESTING_MIN_ENERGY_RATIO;
 }
 function buildMineralHarvesterBody(energyAvailable, controllerLevel) {
-  const energyBudget = normalizeNonNegativeInteger9(energyAvailable);
+  const energyBudget = normalizeNonNegativeInteger10(energyAvailable);
   const maxWorkParts = typeof controllerLevel === "number" && controllerLevel >= 6 ? 3 : 2;
   for (let workParts = maxWorkParts; workParts >= 1; workParts -= 1) {
     const body = buildMineralHarvesterBodyWithWorkParts(workParts);
@@ -28427,7 +28763,7 @@ function isExtractorStructure(structure) {
   return matchesStructureType23(structure.structureType, "STRUCTURE_EXTRACTOR", "extractor");
 }
 function isMineralAvailable(mineral) {
-  return normalizeNonNegativeInteger9(mineral.mineralAmount) > 0;
+  return normalizeNonNegativeInteger10(mineral.mineralAmount) > 0;
 }
 function getMineralResourceType(mineral) {
   const mineralType = mineral.mineralType;
@@ -28447,7 +28783,7 @@ function selectMineralDeliveryTarget(room, resourceType) {
   ).sort(compareMineralDeliveryTargets)[0]) != null ? _a : null;
 }
 function compareMineralDeliveryTargets(left, right) {
-  return getDeliveryPriority2(right) - getDeliveryPriority2(left) || getObjectId12(left).localeCompare(getObjectId12(right));
+  return getDeliveryPriority2(right) - getDeliveryPriority2(left) || getObjectId13(left).localeCompare(getObjectId13(right));
 }
 function getDeliveryPriority2(target) {
   return matchesStructureType23(target.structureType, "STRUCTURE_TERMINAL", "terminal") ? 2 : 1;
@@ -28587,10 +28923,10 @@ function getBodyCost3(body) {
   };
   return body.reduce((total, part) => total + costs[part], 0);
 }
-function getObjectId12(object) {
+function getObjectId13(object) {
   return typeof object.id === "string" ? object.id : "";
 }
-function normalizeNonNegativeInteger9(value) {
+function normalizeNonNegativeInteger10(value) {
   return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
 }
 function isRecord22(value) {
@@ -28615,7 +28951,7 @@ function refreshTerritoryExecutionTargets(action, options = {}) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return { action, targetCount: 0, intentCount: 0 };
   }
-  const gameTime = (_a = options.gameTime) != null ? _a : getGameTime23();
+  const gameTime = (_a = options.gameTime) != null ? _a : getGameTime24();
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
   let targetCount = 0;
@@ -28719,7 +29055,7 @@ function isNonEmptyString21(value) {
 function isRecord23(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
-function getGameTime23() {
+function getGameTime24() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -28731,7 +29067,7 @@ var EXPANSION_CLAIM_EXECUTION_TIMEOUT_TICKS = 1500;
 var MIN_AUTONOMOUS_EXPANSION_CLAIM_SCORE = 500;
 var MIN_AUTONOMOUS_EXPANSION_CLAIM_RCL = 2;
 var EXIT_DIRECTION_ORDER5 = ["1", "3", "5", "7"];
-var OK_CODE10 = 0;
+var OK_CODE11 = 0;
 var ERR_NOT_IN_RANGE_CODE10 = -9;
 var ERR_INVALID_TARGET_CODE4 = -7;
 var ERR_NO_BODYPART_CODE = -12;
@@ -28775,7 +29111,7 @@ function runRecommendedExpansionClaimExecutor(creep, telemetryEvents = []) {
   if (!isClaimExecutionAssignment(assignment)) {
     return false;
   }
-  const gameTime = getGameTime24();
+  const gameTime = getGameTime25();
   const recommendedClaim = getRecommendedExpansionClaimExecutionGate(creep.memory.colony, assignment);
   if (!recommendedClaim) {
     return false;
@@ -28862,7 +29198,7 @@ function runRecommendedExpansionClaimExecutor(creep, telemetryEvents = []) {
   const result = executeExpansionClaim(creep, controller, telemetryEvents);
   execution.lastClaimAttemptAt = gameTime;
   execution.claimAttemptCount = ((_b = execution.claimAttemptCount) != null ? _b : 0) + 1;
-  if (result === OK_CODE10 && isClaimVerified(assignment.targetRoom, controller)) {
+  if (result === OK_CODE11 && isClaimVerified(assignment.targetRoom, controller)) {
     completeRecommendedClaimIfSigned(creep, assignment, controller, telemetryEvents);
     return true;
   }
@@ -28965,7 +29301,7 @@ function getAutonomousExpansionClaimTickContext(gameTime) {
 }
 function executeExpansionClaim(creep, controller, telemetryEvents = []) {
   var _a, _b, _c, _d, _e, _f, _g, _h;
-  const result = typeof creep.claimController === "function" ? creep.claimController(controller) : OK_CODE10;
+  const result = typeof creep.claimController === "function" ? creep.claimController(controller) : OK_CODE11;
   const reason = getClaimResultReason(result);
   recordTerritoryClaimTelemetry(telemetryEvents, {
     colony: (_e = (_d = (_b = creep.memory.colony) != null ? _b : (_a = creep.room) == null ? void 0 : _a.name) != null ? _d : (_c = controller.room) == null ? void 0 : _c.name) != null ? _e : "unknown",
@@ -29458,7 +29794,7 @@ function recordTerritoryClaimTelemetry(telemetryEvents, event) {
 }
 function getClaimResultReason(result) {
   switch (result) {
-    case OK_CODE10:
+    case OK_CODE11:
       return null;
     case ERR_NOT_IN_RANGE_CODE10:
       return "notInRange";
@@ -29635,7 +29971,7 @@ function recordRecommendedClaimSuccess(creep, assignment, controller, telemetryE
     },
     telemetryEvents
   );
-  recordClaimedRoomBootstrapStage(targetRoom, getGameTime24());
+  recordClaimedRoomBootstrapStage(targetRoom, getGameTime25());
   completeRecommendedClaimIntent(colony, targetRoom, controller.id);
   recordColonyExpansionClaimVerification({
     colony,
@@ -29643,7 +29979,7 @@ function recordRecommendedClaimSuccess(creep, assignment, controller, telemetryE
     status: "claimed",
     controllerId: controller.id,
     creepName: creep.name,
-    updatedAt: getGameTime24()
+    updatedAt: getGameTime25()
   });
 }
 function completeRecommendedClaimIfSigned(creep, assignment, controller, telemetryEvents) {
@@ -29667,7 +30003,7 @@ function recordRecommendedClaimTerminalFailure(creep, assignment, result, reason
     reason
   });
   if (options.suppressIntent) {
-    suppressRecommendedClaimIntent(colony, assignment, getGameTime24(), options.controllerId, reason);
+    suppressRecommendedClaimIntent(colony, assignment, getGameTime25(), options.controllerId, reason);
   }
   recordColonyExpansionClaimVerification({
     colony,
@@ -29677,7 +30013,7 @@ function recordRecommendedClaimTerminalFailure(creep, assignment, result, reason
     creepName: creep.name,
     result,
     reason,
-    updatedAt: getGameTime24()
+    updatedAt: getGameTime25()
   });
 }
 function recordRecommendedClaimRetry(creep, assignment, result, reason, options = {}) {
@@ -29692,7 +30028,7 @@ function recordRecommendedClaimRetry(creep, assignment, result, reason, options 
     result,
     reason
   });
-  updateRecommendedClaimIntentForRetry(colony, assignment, getGameTime24(), options);
+  updateRecommendedClaimIntentForRetry(colony, assignment, getGameTime25(), options);
 }
 function updateRecommendedClaimIntentForRetry(colony, assignment, gameTime, options) {
   var _a, _b, _c, _d;
@@ -29902,7 +30238,7 @@ function getVisibleRoom11(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
-function getGameTime24() {
+function getGameTime25() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -30228,11 +30564,11 @@ function refreshClaimedRoomBootstrapperOwnership() {
     if (newlyClaimed) {
       detectedRoomNames.push(room.name);
     }
-    const claimedAt = newlyClaimed ? getGameTime25() : (_a = previous == null ? void 0 : previous.claimedAt) != null ? _a : activePostClaimRecord == null ? void 0 : activePostClaimRecord.claimedAt;
+    const claimedAt = newlyClaimed ? getGameTime26() : (_a = previous == null ? void 0 : previous.claimedAt) != null ? _a : activePostClaimRecord == null ? void 0 : activePostClaimRecord.claimedAt;
     memory.rooms[room.name] = {
       roomName: room.name,
       owned,
-      updatedAt: getGameTime25(),
+      updatedAt: getGameTime26(),
       ...claimedAt !== void 0 ? { claimedAt } : {},
       ...newlyClaimed ? {} : (previous == null ? void 0 : previous.completedAt) !== void 0 ? { completedAt: previous.completedAt } : {}
     };
@@ -30257,7 +30593,7 @@ function getActivePostClaimBootstrapRecord(roomName) {
   const record = (_c = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps) == null ? void 0 : _c[roomName];
   return isRecord26(record) && record.roomName === roomName && record.status !== "ready" ? record : null;
 }
-function getGameTime25() {
+function getGameTime26() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
@@ -30271,7 +30607,7 @@ var ERR_NOT_IN_RANGE_CODE11 = -9;
 var ERR_INVALID_TARGET_CODE5 = -7;
 var ERR_NO_BODYPART_CODE2 = -12;
 var ERR_GCL_NOT_ENOUGH_CODE2 = -15;
-var OK_CODE11 = 0;
+var OK_CODE12 = 0;
 var CLAIM_FATAL_RESULT_CODES = /* @__PURE__ */ new Set([
   ERR_INVALID_TARGET_CODE5,
   ERR_NO_BODYPART_CODE2,
@@ -30304,7 +30640,7 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
     return;
   }
   if (assignment.action === "scout") {
-    recordVisibleRoomScoutIntel(creep.memory.colony, creep.room, getGameTime26(), creep.name, telemetryEvents);
+    recordVisibleRoomScoutIntel(creep.memory.colony, creep.room, getGameTime27(), creep.name, telemetryEvents);
     completeTerritoryAssignment(creep);
     return;
   }
@@ -30354,7 +30690,7 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
     return;
   }
   const result = assignment.action === "claim" ? executeExpansionClaim(creep, controller, telemetryEvents) : executeControllerAction(creep, controller, "reserveController");
-  if (assignment.action === "claim" && result === OK_CODE11) {
+  if (assignment.action === "claim" && result === OK_CODE12) {
     recordPostClaimBootstrapIfOwned(creep, assignment, controller, telemetryEvents);
   }
   if (result === ERR_NOT_IN_RANGE_CODE11 && typeof creep.moveTo === "function") {
@@ -30386,7 +30722,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   if (typeof creep.reserveController !== "function" || !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)) {
     return false;
   }
-  const gameTime = getGameTime26();
+  const gameTime = getGameTime27();
   const reserveAssignment = {
     targetRoom: assignment.targetRoom,
     action: "reserve",
@@ -30406,7 +30742,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   return true;
 }
 function suppressTerritoryAssignment(creep, assignment) {
-  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime26());
+  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime27());
   completeTerritoryAssignment(creep);
 }
 function completeTerritoryAssignment(creep) {
@@ -30453,7 +30789,7 @@ function selectTargetController(creep, assignment) {
 function executeControllerAction(creep, controller, action) {
   const controllerAction = creep[action];
   if (typeof controllerAction !== "function") {
-    return OK_CODE11;
+    return OK_CODE12;
   }
   return controllerAction.call(creep, controller);
 }
@@ -30486,7 +30822,7 @@ function selectVisibleTargetRoomController(assignment) {
   }
   return (_c = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[assignment.targetRoom]) == null ? void 0 : _b.controller) != null ? _c : null;
 }
-function getGameTime26() {
+function getGameTime27() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -30526,7 +30862,7 @@ function isTerritoryAssignment(assignment) {
 var EXPANSION_EXECUTOR_REFRESH_INTERVAL = 50;
 var EXPANSION_EXECUTOR_DOWNGRADE_GUARD_TICKS = 5e3;
 var EXPANSION_EXECUTOR_THREAT_MEMORY_STALE_TICKS = 5;
-function refreshExpansionExecutorIntent(colony, gameTime = getGameTime27(), telemetryEvents = []) {
+function refreshExpansionExecutorIntent(colony, gameTime = getGameTime28(), telemetryEvents = []) {
   const colonyName = colony.room.name;
   const colonyMemory = getWritableColonyMemory2(colony);
   let stateKey = getExpansionExecutorCacheStateKey(colony, gameTime);
@@ -30639,7 +30975,7 @@ function hasExpansionExecutorTarget(colony, targetRoom) {
     (target) => isRecord27(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
   ) : false;
 }
-function getExpansionExecutorCacheStateKey(colony, gameTime = getGameTime27()) {
+function getExpansionExecutorCacheStateKey(colony, gameTime = getGameTime28()) {
   var _a;
   const controller = colony.room.controller;
   const controllerLevel = isFiniteNumber9(controller == null ? void 0 : controller.level) ? controller.level : "unknown";
@@ -30778,7 +31114,7 @@ function getLatestTerritoryScoutIntelUpdatedAt(colony) {
   }
   return latestUpdatedAt;
 }
-function getGameTime27() {
+function getGameTime28() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -30809,7 +31145,7 @@ function isFiniteNumber9(value) {
 }
 
 // src/territory/roomReservation.ts
-var OK_CODE12 = 0;
+var OK_CODE13 = 0;
 var ERR_NOT_IN_RANGE_CODE12 = -9;
 function runPlannedClaimReservation(creep) {
   const result = reserveRoomForPlannedClaim(creep);
@@ -30883,7 +31219,7 @@ function reserveRoomForPlannedClaim(creep) {
     controllerId: controller.id,
     ...assignment.followUp ? { followUp: assignment.followUp } : {}
   };
-  creep.memory.territory = (_b = recordTerritoryReserveFallbackIntent(creep.memory.colony, reserveAssignment, getGameTime28())) != null ? _b : reserveAssignment;
+  creep.memory.territory = (_b = recordTerritoryReserveFallbackIntent(creep.memory.colony, reserveAssignment, getGameTime29())) != null ? _b : reserveAssignment;
   const result = creep.reserveController(controller);
   if (result === ERR_NOT_IN_RANGE_CODE12) {
     if (typeof creep.moveTo === "function") {
@@ -30896,7 +31232,7 @@ function reserveRoomForPlannedClaim(creep) {
       controllerId: controller.id
     };
   }
-  if (result === OK_CODE12) {
+  if (result === OK_CODE13) {
     return {
       status: "reserved",
       result,
@@ -30999,7 +31335,7 @@ function getClaimBodyPartConstant() {
   var _a;
   return (_a = globalThis.CLAIM) != null ? _a : "claim";
 }
-function getGameTime28() {
+function getGameTime29() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -31014,7 +31350,7 @@ var MIN_ADJACENT_ROOM_RESERVATION_SCORE = 500;
 var ADJACENT_ROOM_RESERVATION_RENEWAL_TICKS_PER_CLAIM_PART = 600;
 var MAX_ADJACENT_ROOM_RESERVATION_RENEWAL_TICKS = 1e3;
 var EXIT_DIRECTION_ORDER7 = ["1", "3", "5", "7"];
-function refreshAdjacentRoomReservationIntent(colony, gameTime = getGameTime29(), options = {}) {
+function refreshAdjacentRoomReservationIntent(colony, gameTime = getGameTime30(), options = {}) {
   const evaluation = selectAdjacentRoomReservationPlan(colony, options);
   if (evaluation.status === "planned" && evaluation.targetRoom) {
     persistAdjacentRoomReservationIntent(colony.room.name, evaluation, gameTime);
@@ -31498,7 +31834,7 @@ function getWritableTerritoryMemoryRecord7() {
   }
   return root.Memory.territory;
 }
-function getGameTime29() {
+function getGameTime30() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -31514,7 +31850,7 @@ function isRecord28(value) {
 var COLONY_EXPANSION_CLAIM_TARGET_CREATOR = "colonyExpansion";
 var MIN_COLONY_EXPANSION_CLAIM_SCORE = MIN_ADJACENT_ROOM_RESERVATION_SCORE;
 var EXIT_DIRECTION_ORDER8 = ["1", "3", "5", "7"];
-function refreshColonyExpansionIntent(colony, assessment, gameTime = getGameTime30()) {
+function refreshColonyExpansionIntent(colony, assessment, gameTime = getGameTime31()) {
   const colonyName = colony.room.name;
   if (assessment.territoryReady !== true) {
     const reservation2 = refreshAdjacentRoomReservationIntent(colony, gameTime, {
@@ -31972,7 +32308,7 @@ function getWritableTerritoryMemoryRecord8() {
   }
   return memory.territory;
 }
-function getGameTime30() {
+function getGameTime31() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
@@ -31985,7 +32321,7 @@ function isNonEmptyString27(value) {
 }
 
 // src/territory/reservationExecutor.ts
-var OK_CODE13 = 0;
+var OK_CODE14 = 0;
 var ERR_NOT_IN_RANGE_CODE13 = -9;
 var ERR_INVALID_TARGET_CODE6 = -7;
 var ERR_NO_BODYPART_CODE3 = -12;
@@ -32015,7 +32351,7 @@ function runReservationExecutor(creep) {
 function runAssignedReservation(creep, assignment, gate) {
   var _a;
   const colony = creep.memory.colony;
-  const gameTime = getGameTime31();
+  const gameTime = getGameTime32();
   if (!isNonEmptyString28(colony) || !isReservationExecutionGateRunnable(gate, gameTime)) {
     completeReservationAssignment(creep);
     return true;
@@ -32078,7 +32414,7 @@ function runAssignedReservation(creep, assignment, gate) {
     moveTowardController2(creep, controller);
     return true;
   }
-  if (result === OK_CODE13) {
+  if (result === OK_CODE14) {
     return true;
   }
   if (result === ERR_NO_BODYPART_CODE3) {
@@ -32121,7 +32457,7 @@ function selectReservationAssignment(creep) {
 }
 function buildReservationSelection(creep, territoryMemory, recommendation, order, activeReservationCounts) {
   var _a, _b, _c;
-  const gameTime = getGameTime31();
+  const gameTime = getGameTime32();
   const intent = getMatchingReservationIntent(
     recommendation.colony,
     recommendation.targetRoom,
@@ -32426,8 +32762,8 @@ function hasReservationEnergyBudget(colony) {
   if (!room) {
     return true;
   }
-  const energyAvailable = normalizeNonNegativeInteger10(room.energyAvailable);
-  const energyCapacityAvailable = normalizeNonNegativeInteger10(room.energyCapacityAvailable);
+  const energyAvailable = normalizeNonNegativeInteger11(room.energyAvailable);
+  const energyCapacityAvailable = normalizeNonNegativeInteger11(room.energyCapacityAvailable);
   return energyAvailable >= TERRITORY_CONTROLLER_BODY_COST && energyCapacityAvailable >= TERRITORY_CONTROLLER_BODY_COST;
 }
 function selectCurrentOrVisibleReservationController(creep, assignment) {
@@ -32571,7 +32907,7 @@ function getWritableTerritoryMemoryRecord9() {
   }
   return memory.territory;
 }
-function getGameTime31() {
+function getGameTime32() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -32591,7 +32927,7 @@ function compareOptionalNumbersDescending3(left, right) {
   }
   return right - left;
 }
-function normalizeNonNegativeInteger10(value) {
+function normalizeNonNegativeInteger11(value) {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
 }
 function isPositiveFiniteNumber4(value) {
@@ -32626,7 +32962,7 @@ function refreshReserveExecutionTargets(options = {}) {
 // src/territory/towerConstructionExecutor.ts
 var EXPANSION_TOWER_CONSTRUCTION_MIN_RCL = 3;
 var EXPANSION_TOWER_CONSTRUCTION_MIN_ENERGY = 1;
-var OK_CODE14 = 0;
+var OK_CODE15 = 0;
 var ERR_FULL_CODE5 = -8;
 var ERR_RCL_NOT_ENOUGH_CODE2 = -14;
 var FALLBACK_TOWER_LIMITS_BY_RCL = [0, 0, 0, 1, 1, 2, 2, 3, 6];
@@ -32664,7 +33000,7 @@ function runTowerConstructionExecutorForColony(colony, options = {}) {
   });
   for (const placement of placements) {
     const result = room.createConstructionSite(placement.x, placement.y, structureType);
-    if (result === OK_CODE14) {
+    if (result === OK_CODE15) {
       return {
         roomName: room.name,
         status: "created",
@@ -32770,7 +33106,7 @@ function isRecord31(value) {
 // src/territory/rampartWallConstructionExecutor.ts
 var EXPANSION_DEFENSE_BARRIER_CONSTRUCTION_MIN_RCL = 3;
 var EXPANSION_DEFENSE_BARRIER_CONSTRUCTION_MIN_ENERGY = 1;
-var OK_CODE15 = 0;
+var OK_CODE16 = 0;
 var ERR_FULL_CODE6 = -8;
 var ERR_RCL_NOT_ENOUGH_CODE3 = -14;
 var FALLBACK_EXTENSION_LIMITS_BY_RCL = [0, 0, 5, 10, 20, 30, 40, 50, 60];
@@ -32813,7 +33149,7 @@ function runRampartWallConstructionExecutorForColony(colony, options = {}) {
       continue;
     }
     const result = room.createConstructionSite(placement.x, placement.y, placement.structureType);
-    if (result === OK_CODE15) {
+    if (result === OK_CODE16) {
       return {
         roomName: room.name,
         status: "created",
@@ -33128,7 +33464,7 @@ function buildStrategyRecommendationRoomState(colony, creeps) {
     workerCount: colonyCreeps.filter((creep) => creep.memory.role === "worker").length,
     energyAvailable: colony.energyAvailable,
     energyCapacity: colony.energyCapacityAvailable,
-    storedEnergy: getStoredEnergy18(room),
+    storedEnergy: getStoredEnergy19(room),
     sourceCount: sources.length,
     hostileCreepCount: hostileCreeps.length,
     hostileStructureCount: hostileStructures.length,
@@ -33289,7 +33625,7 @@ function estimateRepairBacklogHits(structures) {
     return total + (hitsMax - hits);
   }, 0);
 }
-function getStoredEnergy18(room) {
+function getStoredEnergy19(room) {
   const storage = room.storage;
   return getEnergyInStore2(storage);
 }
@@ -33352,12 +33688,13 @@ function isRecord33(value) {
 
 // src/economy/economyLoop.ts
 var ERR_BUSY_CODE = -4;
-var OK_CODE16 = 0;
+var OK_CODE17 = 0;
 var BOOTSTRAP_WORKER_BUFFER_BYPASS_MIN_ENERGY = 300;
 function runEconomy(preludeTelemetryEvents = []) {
   var _a, _b, _c, _d;
   const creeps = Object.values(Game.creeps);
   balanceStorage();
+  manageTerminalEnergy();
   const ownedColonies = getOwnedColonies();
   refreshSpawnEnergyReservationStates(ownedColonies);
   const initialRoleCountsByRoom = new Map(
@@ -33440,7 +33777,7 @@ function runEconomy(preludeTelemetryEvents = []) {
         telemetryEvents,
         coordinatedPlan.spawns
       );
-      if (!outcome || outcome.result !== OK_CODE16) {
+      if (!outcome || outcome.result !== OK_CODE17) {
         break;
       }
       const spawnRoomName = (_b = (_a = outcome.spawn.room) == null ? void 0 : _a.name) != null ? _b : "unknown";
@@ -33568,7 +33905,7 @@ function attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom
     telemetryEvents,
     candidateSpawns
   );
-  if (!outcome || outcome.result !== OK_CODE16) {
+  if (!outcome || outcome.result !== OK_CODE17) {
     return;
   }
   recordUsedSpawn(usedSpawnsByRoom, sourceRoomName, outcome.spawn);
@@ -33600,7 +33937,7 @@ function attemptMineralHarvesterSpawns(colonies, creeps, telemetryEvents, usedSp
     }
     const bodyCost = getBodyCost(spawnRequest.body);
     const outcome = attemptSpawnRequest(spawnRequest, roomName, telemetryEvents, candidateSpawns);
-    if (!outcome || outcome.result !== OK_CODE16) {
+    if (!outcome || outcome.result !== OK_CODE17) {
       continue;
     }
     recordUsedSpawn(usedSpawnsByRoom, roomName, outcome.spawn);
@@ -33654,7 +33991,7 @@ function refreshExecutableTerritoryRecommendation(colony, creeps, territoryReady
     refreshAdjacentRoomReservationIntent(colony, Game.time);
   }
 }
-function normalizeNonNegativeInteger11(value) {
+function normalizeNonNegativeInteger12(value) {
   return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
 }
 function planCoordinatedSpawn(colony, roleCounts, gameTime, options, colonies, creeps, usedSpawnsByRoom, reservedSpawnEnergyByRoom, plannedRoleCountsByRoom, survivalAssessment) {
@@ -33704,14 +34041,14 @@ function createSpawnPlanningColony(colony, sourceColony, energyAvailable, usedSp
   return {
     ...colony,
     energyAvailable,
-    energyCapacityAvailable: normalizeNonNegativeInteger11(sourceColony.energyCapacityAvailable),
-    spawnEnergyBudget: normalizeNonNegativeInteger11(energyAvailable),
+    energyCapacityAvailable: normalizeNonNegativeInteger12(sourceColony.energyCapacityAvailable),
+    spawnEnergyBudget: normalizeNonNegativeInteger12(energyAvailable),
     spawns: sourceColony.spawns.filter((spawn) => !spawn.spawning && !usedSpawns.has(spawn))
   };
 }
 function createSpawnEnergyReservationPlanningColony(colony, sourceColony, energyBudget) {
-  const energyCapacityAvailable = normalizeNonNegativeInteger11(sourceColony.energyCapacityAvailable);
-  const normalizedEnergyBudget = normalizeNonNegativeInteger11(energyBudget);
+  const energyCapacityAvailable = normalizeNonNegativeInteger12(sourceColony.energyCapacityAvailable);
+  const normalizedEnergyBudget = normalizeNonNegativeInteger12(energyBudget);
   return {
     ...colony,
     energyAvailable: normalizedEnergyBudget,
@@ -33765,7 +34102,7 @@ function canUseCrossRoomSpawnSource(sourceColony, creeps, usedSpawnsByRoom, rese
   return survival.mode === "TERRITORY_READY" && !survival.controllerDowngradeGuard && !survival.hostilePresence;
 }
 function compareCoordinatedSpawnSources(left, right, reservedSpawnEnergyByRoom) {
-  return getAvailableSpawnEnergy(right, reservedSpawnEnergyByRoom) - getAvailableSpawnEnergy(left, reservedSpawnEnergyByRoom) || normalizeNonNegativeInteger11(right.energyCapacityAvailable) - normalizeNonNegativeInteger11(left.energyCapacityAvailable) || left.room.name.localeCompare(right.room.name);
+  return getAvailableSpawnEnergy(right, reservedSpawnEnergyByRoom) - getAvailableSpawnEnergy(left, reservedSpawnEnergyByRoom) || normalizeNonNegativeInteger12(right.energyCapacityAvailable) - normalizeNonNegativeInteger12(left.energyCapacityAvailable) || left.room.name.localeCompare(right.room.name);
 }
 function getUnusedSpawnCount(colony, usedSpawnsByRoom) {
   var _a;
@@ -33773,7 +34110,7 @@ function getUnusedSpawnCount(colony, usedSpawnsByRoom) {
   return colony.spawns.filter((spawn) => !spawn.spawning && !usedSpawns.has(spawn)).length;
 }
 function hasFullSpawnEnergyAfterReservations(colony, reservedSpawnEnergyByRoom) {
-  const energyCapacity = normalizeNonNegativeInteger11(colony.energyCapacityAvailable);
+  const energyCapacity = normalizeNonNegativeInteger12(colony.energyCapacityAvailable);
   return energyCapacity > 0 && getAvailableSpawnEnergy(colony, reservedSpawnEnergyByRoom) >= energyCapacity;
 }
 function getAvailableSpawnEnergy(colony, reservedSpawnEnergyByRoom) {
@@ -33783,14 +34120,14 @@ function getAvailableSpawnEnergy(colony, reservedSpawnEnergyByRoom) {
   }
   return Math.max(
     0,
-    normalizeNonNegativeInteger11(colony.energyAvailable) - ((_a = reservedSpawnEnergyByRoom.get(colony.room.name)) != null ? _a : 0)
+    normalizeNonNegativeInteger12(colony.energyAvailable) - ((_a = reservedSpawnEnergyByRoom.get(colony.room.name)) != null ? _a : 0)
   );
 }
 function updateNextSpawnEnergyReservation(colony, sourceColony, roleCounts, gameTime, options, spawnedRequest, spentSpawnEnergyThisTick) {
   const sourceRoomName = sourceColony.room.name;
   const energyBudgetAfterSpawn = Math.max(
     0,
-    normalizeNonNegativeInteger11(sourceColony.energyAvailable) - normalizeNonNegativeInteger11(spentSpawnEnergyThisTick)
+    normalizeNonNegativeInteger12(sourceColony.energyAvailable) - normalizeNonNegativeInteger12(spentSpawnEnergyThisTick)
   );
   const reservationPlanningColony = createSpawnEnergyReservationPlanningColony(
     colony,
@@ -34082,7 +34419,7 @@ var Kernel = class {
     this.dependencies.cleanupDeadCreepMemory();
     const defenseEvents = this.dependencies.runDefense();
     return this.dependencies.runEconomy(
-      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime32())
+      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime33())
     );
   }
 };
@@ -34154,7 +34491,7 @@ function getDefenseEventPriority(event) {
       return 3;
   }
 }
-function getGameTime32() {
+function getGameTime33() {
   return typeof Game !== "undefined" && typeof Game.time === "number" ? Game.time : 0;
 }
 

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -35,6 +35,7 @@ import {
 import { transferEnergy as transferLinkEnergy } from './linkManager';
 import { manageStorage } from './storageManager';
 import { balanceStorage } from './storageBalancer';
+import { manageTerminalEnergy } from './terminalManager';
 import {
   getBufferedSpawnEnergyBudget,
   getSpawnEnergyBufferRequirement,
@@ -137,6 +138,7 @@ interface CoordinatedSpawnPlan {
 export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = []): RuntimeSummary | undefined {
   const creeps = Object.values(Game.creeps);
   balanceStorage();
+  manageTerminalEnergy();
   const ownedColonies = getOwnedColonies();
   refreshSpawnEnergyReservationStates(ownedColonies);
   const initialRoleCountsByRoom = new Map(

--- a/prod/src/economy/terminalManager.ts
+++ b/prod/src/economy/terminalManager.ts
@@ -271,10 +271,7 @@ function clampSendAmountForEnergyBudget(
     return 0;
   }
 
-  let amount = Math.min(
-    normalizeNonNegativeInteger(requestedAmount),
-    Math.floor(normalizedBudget / (1 + 0.1 * Math.max(0, distance)))
-  );
+  let amount = normalizeNonNegativeInteger(requestedAmount);
   while (amount > 0 && amount + calculateTerminalEnergyCostForDistance(distance, amount) > normalizedBudget) {
     amount -= 1;
   }

--- a/prod/src/economy/terminalManager.ts
+++ b/prod/src/economy/terminalManager.ts
@@ -166,7 +166,7 @@ export function calculateTerminalEnergyCost(
 export function calculateTerminalEnergyCostForDistance(distance: number, amount: number): number {
   const normalizedDistance = normalizeNonNegativeInteger(distance);
   const normalizedAmount = normalizeNonNegativeInteger(amount);
-  return Math.floor(0.1 * normalizedDistance * normalizedAmount);
+  return Math.ceil(normalizedAmount * (1 - Math.exp(-normalizedDistance / 30)));
 }
 
 export function getTerminalSendCooldown(amount: number): number {

--- a/prod/src/economy/terminalManager.ts
+++ b/prod/src/economy/terminalManager.ts
@@ -1,0 +1,508 @@
+import { getTerminalEnergyTarget } from './energySurplus';
+import {
+  getRoomStoredEnergyState,
+  getStorageBalanceState,
+  type RoomStoredEnergyState
+} from './storageBalancer';
+
+export const TERMINAL_ENERGY_MIN_RESERVE = 20_000;
+export const TERMINAL_MAX_ENERGY_SEND_AMOUNT = 10_000;
+export const TERMINAL_MIN_ENERGY_SEND_AMOUNT = 100;
+
+const OK_CODE = 0 as ScreepsReturnCode;
+
+interface TerminalStoreLike {
+  getUsedCapacity?: (resource?: ResourceConstant) => number | null;
+  getCapacity?: (resource?: ResourceConstant) => number | null;
+  getFreeCapacity?: (resource?: ResourceConstant) => number | null;
+  [resource: string]: unknown;
+}
+
+export interface TerminalEnergyTransferPlan {
+  amount: number;
+  cooldown: number;
+  description: string;
+  distance: number;
+  energyCost: number;
+  sourceRoom: string;
+  sourceTerminal: StructureTerminal;
+  targetRoom: string;
+  targetTerminal: StructureTerminal;
+}
+
+export interface TerminalEnergyTransferResult {
+  amount: number;
+  availableAt: number;
+  cooldown: number;
+  description: string;
+  distance: number;
+  energyCost: number;
+  result: ScreepsReturnCode;
+  sourceRoom: string;
+  targetRoom: string;
+}
+
+interface TerminalTransferSelectionFilter {
+  sourceRoom?: string;
+  targetRoom?: string;
+}
+
+interface ProjectedTerminalRoomState {
+  room: Room;
+  state: RoomStoredEnergyState;
+  terminal: StructureTerminal;
+  terminalEnergy: number;
+  terminalFreeCapacity: number;
+  terminalTargetEnergy: number;
+  cooldown: number;
+  sourceBudget: number;
+  targetDemand: number;
+}
+
+export function manageTerminalEnergy(): TerminalEnergyTransferResult[] {
+  const plans = selectTerminalEnergyTransfers();
+  const results: TerminalEnergyTransferResult[] = [];
+  const gameTime = getGameTime();
+
+  for (const plan of plans) {
+    const result = plan.sourceTerminal.send(
+      getEnergyResource(),
+      plan.amount,
+      plan.targetRoom,
+      plan.description
+    );
+    const transferResult: TerminalEnergyTransferResult = {
+      amount: plan.amount,
+      availableAt: gameTime + plan.cooldown,
+      cooldown: plan.cooldown,
+      description: plan.description,
+      distance: plan.distance,
+      energyCost: plan.energyCost,
+      result,
+      sourceRoom: plan.sourceRoom,
+      targetRoom: plan.targetRoom
+    };
+    results.push(transferResult);
+
+    if (result === OK_CODE) {
+      reduceStorageBalanceTransfer(plan.sourceRoom, plan.targetRoom, plan.amount, gameTime);
+    }
+  }
+
+  recordTerminalLogisticsState(results, gameTime);
+  return results;
+}
+
+export function selectTerminalEnergyExport(room: Room): TerminalEnergyTransferPlan | null {
+  return selectTerminalEnergyTransfer({ sourceRoom: room.name });
+}
+
+export function selectTerminalEnergyImport(room: Room): TerminalEnergyTransferPlan | null {
+  return selectTerminalEnergyTransfer({ targetRoom: room.name });
+}
+
+export function selectTerminalEnergyTransfer(
+  filter: TerminalTransferSelectionFilter = {}
+): TerminalEnergyTransferPlan | null {
+  return selectTerminalEnergyTransfers(filter)[0] ?? null;
+}
+
+export function selectTerminalEnergyTransfers(
+  filter: TerminalTransferSelectionFilter = {}
+): TerminalEnergyTransferPlan[] {
+  const balance = getStorageBalanceState();
+  const roomStates = buildProjectedTerminalRoomStates();
+  const selectedPlans: TerminalEnergyTransferPlan[] = [];
+  const spentSourceRooms = new Set<string>();
+
+  for (const transfer of [...balance.transfers].filter((candidate) => candidate.amount > 0).sort(compareStorageTransfers)) {
+    if (filter.sourceRoom && transfer.sourceRoom !== filter.sourceRoom) {
+      continue;
+    }
+
+    if (filter.targetRoom && transfer.targetRoom !== filter.targetRoom) {
+      continue;
+    }
+
+    if (spentSourceRooms.has(transfer.sourceRoom)) {
+      continue;
+    }
+
+    const sourceState = roomStates.get(transfer.sourceRoom);
+    const targetState = roomStates.get(transfer.targetRoom);
+    if (!sourceState || !targetState || sourceState.room.name === targetState.room.name) {
+      continue;
+    }
+
+    const plan = buildTerminalEnergyTransferPlan(transfer, sourceState, targetState);
+    if (!plan) {
+      continue;
+    }
+
+    selectedPlans.push(plan);
+    spentSourceRooms.add(plan.sourceRoom);
+    sourceState.sourceBudget = Math.max(0, sourceState.sourceBudget - plan.amount - plan.energyCost);
+    sourceState.terminalEnergy = Math.max(0, sourceState.terminalEnergy - plan.amount - plan.energyCost);
+    sourceState.cooldown = plan.cooldown;
+    targetState.targetDemand = Math.max(0, targetState.targetDemand - plan.amount);
+    targetState.terminalEnergy += plan.amount;
+    targetState.terminalFreeCapacity = Math.max(0, targetState.terminalFreeCapacity - plan.amount);
+  }
+
+  return selectedPlans;
+}
+
+export function calculateTerminalEnergyCost(
+  fromRoom: string,
+  targetRoom: string,
+  amount: number
+): number {
+  return calculateTerminalEnergyCostForDistance(
+    getRoomLinearDistance(fromRoom, targetRoom) ?? 0,
+    amount
+  );
+}
+
+export function calculateTerminalEnergyCostForDistance(distance: number, amount: number): number {
+  const normalizedDistance = normalizeNonNegativeInteger(distance);
+  const normalizedAmount = normalizeNonNegativeInteger(amount);
+  return Math.floor(0.1 * normalizedDistance * normalizedAmount);
+}
+
+export function getTerminalSendCooldown(amount: number): number {
+  const normalizedAmount = normalizeNonNegativeInteger(amount);
+  return normalizedAmount > 0 ? Math.max(1, Math.ceil(normalizedAmount / 100)) : 0;
+}
+
+function buildTerminalEnergyTransferPlan(
+  transfer: EconomyStorageTransferMemory,
+  sourceState: ProjectedTerminalRoomState,
+  targetState: ProjectedTerminalRoomState
+): TerminalEnergyTransferPlan | null {
+  if (
+    sourceState.state.mode !== 'export' ||
+    targetState.state.mode !== 'import' ||
+    sourceState.cooldown > 0 ||
+    sourceState.sourceBudget <= 0 ||
+    targetState.targetDemand <= 0
+  ) {
+    return null;
+  }
+
+  const distance = getRoomLinearDistance(sourceState.room.name, targetState.room.name);
+  if (distance === null || distance <= 0) {
+    return null;
+  }
+
+  const requestedAmount = Math.min(
+    transfer.amount,
+    sourceState.sourceBudget,
+    targetState.targetDemand,
+    TERMINAL_MAX_ENERGY_SEND_AMOUNT
+  );
+  const amount = clampSendAmountForEnergyBudget(requestedAmount, distance, sourceState.sourceBudget);
+  if (amount < TERMINAL_MIN_ENERGY_SEND_AMOUNT) {
+    return null;
+  }
+
+  const energyCost = calculateTerminalEnergyCostForDistance(distance, amount);
+  return {
+    amount,
+    cooldown: getTerminalSendCooldown(amount),
+    description: `energy-balance ${sourceState.room.name}->${targetState.room.name}`,
+    distance,
+    energyCost,
+    sourceRoom: sourceState.room.name,
+    sourceTerminal: sourceState.terminal,
+    targetRoom: targetState.room.name,
+    targetTerminal: targetState.terminal
+  };
+}
+
+function buildProjectedTerminalRoomStates(): Map<string, ProjectedTerminalRoomState> {
+  return new Map(
+    getOwnedRooms()
+      .map((room) => buildProjectedTerminalRoomState(room))
+      .filter((state): state is ProjectedTerminalRoomState => state !== null)
+      .map((state) => [state.room.name, state])
+  );
+}
+
+function buildProjectedTerminalRoomState(room: Room): ProjectedTerminalRoomState | null {
+  const terminal = room.terminal;
+  if (!terminal) {
+    return null;
+  }
+
+  const state = getRoomStoredEnergyState(room);
+  const terminalEnergy = getStoredEnergy(terminal);
+  const terminalFreeCapacity = getFreeEnergyCapacity(terminal);
+  const terminalTargetEnergy = getTerminalEnergyTarget(terminal);
+  const sourceBudget = Math.min(
+    state.exportableEnergy,
+    Math.max(0, terminalEnergy - TERMINAL_ENERGY_MIN_RESERVE)
+  );
+  const targetDemand = Math.min(
+    state.importDemand,
+    terminalFreeCapacity,
+    Math.max(0, terminalTargetEnergy - terminalEnergy)
+  );
+
+  return {
+    room,
+    state,
+    terminal,
+    terminalEnergy,
+    terminalFreeCapacity,
+    terminalTargetEnergy,
+    cooldown: getTerminalCooldown(terminal),
+    sourceBudget,
+    targetDemand
+  };
+}
+
+function clampSendAmountForEnergyBudget(
+  requestedAmount: number,
+  distance: number,
+  energyBudget: number
+): number {
+  const normalizedBudget = normalizeNonNegativeInteger(energyBudget);
+  if (normalizedBudget <= 0) {
+    return 0;
+  }
+
+  let amount = Math.min(
+    normalizeNonNegativeInteger(requestedAmount),
+    Math.floor(normalizedBudget / (1 + 0.1 * Math.max(0, distance)))
+  );
+  while (amount > 0 && amount + calculateTerminalEnergyCostForDistance(distance, amount) > normalizedBudget) {
+    amount -= 1;
+  }
+
+  return amount;
+}
+
+function compareStorageTransfers(
+  left: EconomyStorageTransferMemory,
+  right: EconomyStorageTransferMemory
+): number {
+  const leftDistance = getRoomLinearDistance(left.sourceRoom, left.targetRoom) ?? Number.POSITIVE_INFINITY;
+  const rightDistance = getRoomLinearDistance(right.sourceRoom, right.targetRoom) ?? Number.POSITIVE_INFINITY;
+  return (
+    getTransferEfficiency(right, rightDistance) -
+      getTransferEfficiency(left, leftDistance) ||
+    right.amount - left.amount ||
+    leftDistance - rightDistance ||
+    left.sourceRoom.localeCompare(right.sourceRoom) ||
+    left.targetRoom.localeCompare(right.targetRoom)
+  );
+}
+
+function getTransferEfficiency(transfer: EconomyStorageTransferMemory, distance: number): number {
+  if (!Number.isFinite(distance)) {
+    return 0;
+  }
+
+  return transfer.amount / Math.max(1, transfer.amount + calculateTerminalEnergyCostForDistance(distance, transfer.amount));
+}
+
+function reduceStorageBalanceTransfer(
+  sourceRoom: string,
+  targetRoom: string,
+  sentAmount: number,
+  gameTime: number
+): void {
+  const memory = getEconomyMemory();
+  const balance = memory.storageBalance;
+  if (!balance || !Array.isArray(balance.transfers)) {
+    return;
+  }
+
+  const updatedTransfers: EconomyStorageTransferMemory[] = [];
+  let remainingSentAmount = sentAmount;
+  for (const transfer of balance.transfers) {
+    if (
+      remainingSentAmount > 0 &&
+      transfer.sourceRoom === sourceRoom &&
+      transfer.targetRoom === targetRoom
+    ) {
+      const reduction = Math.min(transfer.amount, remainingSentAmount);
+      remainingSentAmount -= reduction;
+      const amount = transfer.amount - reduction;
+      if (amount > 0) {
+        updatedTransfers.push({ ...transfer, amount, updatedAt: gameTime });
+      }
+      continue;
+    }
+
+    updatedTransfers.push(transfer);
+  }
+
+  balance.transfers = updatedTransfers;
+}
+
+function recordTerminalLogisticsState(
+  results: TerminalEnergyTransferResult[],
+  gameTime: number
+): void {
+  const memory = getEconomyMemory();
+  const resultBySourceRoom = new Map(results.map((result) => [result.sourceRoom, result]));
+  const rooms = Object.fromEntries(
+    getOwnedRooms()
+      .filter((room) => room.terminal !== undefined)
+      .map((room) => {
+        const terminal = room.terminal as StructureTerminal;
+        const result = resultBySourceRoom.get(room.name);
+        const cooldown = result?.result === OK_CODE ? result.cooldown : getTerminalCooldown(terminal);
+        return [
+          room.name,
+          {
+            roomName: room.name,
+            terminalId: getObjectId(terminal),
+            energy: getStoredEnergy(terminal),
+            freeCapacity: getFreeEnergyCapacity(terminal),
+            cooldown,
+            ...(result?.result === OK_CODE
+              ? {
+                  projectedCooldown: result.cooldown,
+                  availableAt: result.availableAt
+                }
+              : {}),
+            updatedAt: gameTime
+          }
+        ];
+      })
+  );
+
+  memory.terminalLogistics = {
+    updatedAt: gameTime,
+    rooms,
+    transfers: results.map((result) => ({
+      sourceRoom: result.sourceRoom,
+      targetRoom: result.targetRoom,
+      amount: result.amount,
+      energyCost: result.energyCost,
+      distance: result.distance,
+      cooldown: result.cooldown,
+      availableAt: result.availableAt,
+      result: result.result,
+      description: result.description,
+      updatedAt: gameTime
+    }))
+  };
+}
+
+function getOwnedRooms(): Room[] {
+  const rooms = (globalThis as { Game?: Partial<Pick<Game, 'rooms'>> }).Game?.rooms;
+  if (!rooms) {
+    return [];
+  }
+
+  return Object.values(rooms).filter((room): room is Room => room?.controller?.my === true);
+}
+
+function getStoredEnergy(target: unknown): number {
+  const store = getStore(target);
+  const resource = getEnergyResource();
+  const usedCapacity = store?.getUsedCapacity?.(resource);
+  if (typeof usedCapacity === 'number' && Number.isFinite(usedCapacity)) {
+    return Math.max(0, usedCapacity);
+  }
+
+  const directEnergy = store?.[resource];
+  return typeof directEnergy === 'number' && Number.isFinite(directEnergy)
+    ? Math.max(0, directEnergy)
+    : 0;
+}
+
+function getFreeEnergyCapacity(target: unknown): number {
+  const store = getStore(target);
+  const resource = getEnergyResource();
+  const freeCapacity = store?.getFreeCapacity?.(resource);
+  if (typeof freeCapacity === 'number' && Number.isFinite(freeCapacity)) {
+    return Math.max(0, freeCapacity);
+  }
+
+  const capacity = getEnergyCapacity(target);
+  return capacity > 0 ? Math.max(0, capacity - getStoredEnergy(target)) : 0;
+}
+
+function getEnergyCapacity(target: unknown): number {
+  const store = getStore(target);
+  const resource = getEnergyResource();
+  const capacity = store?.getCapacity?.(resource);
+  if (typeof capacity === 'number' && Number.isFinite(capacity)) {
+    return Math.max(0, capacity);
+  }
+
+  const genericCapacity = store?.getCapacity?.();
+  if (typeof genericCapacity === 'number' && Number.isFinite(genericCapacity)) {
+    return Math.max(0, genericCapacity);
+  }
+
+  const freeCapacity = store?.getFreeCapacity?.(resource);
+  return typeof freeCapacity === 'number' && Number.isFinite(freeCapacity)
+    ? getStoredEnergy(target) + Math.max(0, freeCapacity)
+    : 0;
+}
+
+function getStore(target: unknown): TerminalStoreLike | undefined {
+  return (target as { store?: TerminalStoreLike } | null)?.store;
+}
+
+function getTerminalCooldown(terminal: StructureTerminal): number {
+  const cooldown = terminal.cooldown;
+  return typeof cooldown === 'number' && Number.isFinite(cooldown) ? Math.max(0, Math.floor(cooldown)) : 0;
+}
+
+function getRoomLinearDistance(fromRoom: string, targetRoom: string): number | null {
+  const distance = (globalThis as { Game?: Partial<Pick<Game, 'map'>> }).Game?.map?.getRoomLinearDistance?.(
+    fromRoom,
+    targetRoom
+  );
+  return typeof distance === 'number' && Number.isFinite(distance) ? Math.max(0, Math.floor(distance)) : null;
+}
+
+function getEconomyMemory(): EconomyMemory {
+  const memory = getMemory();
+  if (!memory.economy) {
+    memory.economy = {};
+  }
+
+  return memory.economy;
+}
+
+function getMemory(): Partial<Memory> {
+  const global = globalThis as unknown as { Memory?: Partial<Memory> };
+  if (!global.Memory) {
+    global.Memory = {};
+  }
+
+  return global.Memory;
+}
+
+function getGameTime(): number {
+  const gameTime = (globalThis as { Game?: Partial<Pick<Game, 'time'>> }).Game?.time;
+  return typeof gameTime === 'number' && Number.isFinite(gameTime) ? gameTime : 0;
+}
+
+function getEnergyResource(): ResourceConstant {
+  return ((globalThis as { RESOURCE_ENERGY?: ResourceConstant }).RESOURCE_ENERGY ?? 'energy') as ResourceConstant;
+}
+
+function getObjectId(object: unknown): string {
+  if (typeof object !== 'object' || object === null) {
+    return '';
+  }
+
+  const candidate = object as { id?: unknown; name?: unknown };
+  if (typeof candidate.id === 'string') {
+    return candidate.id;
+  }
+
+  return typeof candidate.name === 'string' ? candidate.name : '';
+}
+
+function normalizeNonNegativeInteger(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -184,6 +184,7 @@ declare global {
   interface EconomyMemory {
     sourceWorkloads?: Record<string, EconomyRoomSourceWorkloadMemory>;
     storageBalance?: EconomyStorageBalanceMemory;
+    terminalLogistics?: EconomyTerminalLogisticsMemory;
     energySurplus?: EconomyEnergySurplusMemory;
     spawnEnergyBuffer?: EconomySpawnEnergyBufferMemory;
     spawnEnergyReservation?: EconomySpawnEnergyReservationMemory;
@@ -273,6 +274,36 @@ declare global {
     sourceRoom: string;
     targetRoom: string;
     amount: number;
+    updatedAt: number;
+  }
+
+  interface EconomyTerminalLogisticsMemory {
+    updatedAt: number;
+    rooms: Record<string, EconomyTerminalLogisticsRoomMemory>;
+    transfers: EconomyTerminalTransferMemory[];
+  }
+
+  interface EconomyTerminalLogisticsRoomMemory {
+    roomName: string;
+    terminalId?: string;
+    energy: number;
+    freeCapacity: number;
+    cooldown: number;
+    projectedCooldown?: number;
+    availableAt?: number;
+    updatedAt: number;
+  }
+
+  interface EconomyTerminalTransferMemory {
+    sourceRoom: string;
+    targetRoom: string;
+    amount: number;
+    energyCost: number;
+    distance: number;
+    cooldown: number;
+    availableAt: number;
+    result: ScreepsReturnCode;
+    description: string;
     updatedAt: number;
   }
 

--- a/prod/test/terminalManager.test.ts
+++ b/prod/test/terminalManager.test.ts
@@ -1,0 +1,238 @@
+import {
+  calculateTerminalEnergyCost,
+  getTerminalSendCooldown,
+  manageTerminalEnergy,
+  selectTerminalEnergyExport,
+  selectTerminalEnergyImport,
+  TERMINAL_ENERGY_MIN_RESERVE
+} from '../src/economy/terminalManager';
+
+const OK_CODE = 0 as ScreepsReturnCode;
+
+type TestStructureTerminal = StructureTerminal & { send: jest.Mock };
+
+describe('terminalManager', () => {
+  beforeEach(() => {
+    Object.assign(globalThis, {
+      RESOURCE_ENERGY: 'energy',
+      Memory: {}
+    });
+    delete (globalThis as { Game?: Partial<Game> }).Game;
+  });
+
+  it('calculates terminal send energy cost and projected cooldown', () => {
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: {
+        getRoomLinearDistance: jest.fn().mockReturnValue(3)
+      } as unknown as GameMap
+    };
+
+    expect(calculateTerminalEnergyCost('W1N1', 'W4N1', 333)).toBe(99);
+    expect(getTerminalSendCooldown(0)).toBe(0);
+    expect(getTerminalSendCooldown(1)).toBe(1);
+    expect(getTerminalSendCooldown(100)).toBe(1);
+    expect(getTerminalSendCooldown(101)).toBe(2);
+  });
+
+  it('sends energy from an exporting room terminal to an importing room terminal', () => {
+    const sourceRoom = makeOwnedRoom({
+      roomName: 'W1N1',
+      storageEnergy: 100_000,
+      terminalEnergy: 80_000
+    });
+    const targetRoom = makeOwnedRoom({
+      roomName: 'W2N1',
+      storageEnergy: 10_000,
+      terminalEnergy: 20_000
+    });
+    installGame([sourceRoom, targetRoom], 2);
+
+    const results = manageTerminalEnergy();
+
+    expect(results).toEqual([
+      {
+        amount: 10_000,
+        availableAt: 200,
+        cooldown: 100,
+        description: 'energy-balance W1N1->W2N1',
+        distance: 2,
+        energyCost: 2_000,
+        result: OK_CODE,
+        sourceRoom: 'W1N1',
+        targetRoom: 'W2N1'
+      }
+    ]);
+    expect(sourceRoom.terminal?.send).toHaveBeenCalledWith(
+      RESOURCE_ENERGY,
+      10_000,
+      'W2N1',
+      'energy-balance W1N1->W2N1'
+    );
+    expect(Memory.economy?.terminalLogistics?.rooms.W1N1).toMatchObject({
+      cooldown: 100,
+      projectedCooldown: 100,
+      availableAt: 200
+    });
+    expect(Memory.economy?.terminalLogistics?.transfers).toMatchObject([
+      {
+        sourceRoom: 'W1N1',
+        targetRoom: 'W2N1',
+        amount: 10_000,
+        energyCost: 2_000,
+        cooldown: 100
+      }
+    ]);
+    expect(Memory.economy?.storageBalance?.transfers).toEqual([
+      { sourceRoom: 'W1N1', targetRoom: 'W2N1', amount: 10_000, updatedAt: 100 }
+    ]);
+  });
+
+  it('selects terminal transfers from both export and import viewpoints', () => {
+    const sourceRoom = makeOwnedRoom({
+      roomName: 'W1N1',
+      storageEnergy: 100_000,
+      terminalEnergy: 80_000
+    });
+    const targetRoom = makeOwnedRoom({
+      roomName: 'W2N1',
+      storageEnergy: 10_000,
+      terminalEnergy: 20_000
+    });
+    installGame([sourceRoom, targetRoom], 2);
+
+    expect(selectTerminalEnergyExport(sourceRoom)).toMatchObject({
+      sourceRoom: 'W1N1',
+      targetRoom: 'W2N1',
+      amount: 10_000
+    });
+    expect(selectTerminalEnergyImport(targetRoom)).toMatchObject({
+      sourceRoom: 'W1N1',
+      targetRoom: 'W2N1',
+      amount: 10_000
+    });
+  });
+
+  it('does not send while the exporting terminal is cooling down', () => {
+    const sourceRoom = makeOwnedRoom({
+      roomName: 'W1N1',
+      storageEnergy: 100_000,
+      terminalEnergy: 80_000,
+      cooldown: 5
+    });
+    const targetRoom = makeOwnedRoom({
+      roomName: 'W2N1',
+      storageEnergy: 10_000,
+      terminalEnergy: 20_000
+    });
+    installGame([sourceRoom, targetRoom], 2);
+
+    expect(manageTerminalEnergy()).toEqual([]);
+    expect(sourceRoom.terminal?.send).not.toHaveBeenCalled();
+    expect(Memory.economy?.terminalLogistics?.rooms.W1N1).toMatchObject({ cooldown: 5 });
+  });
+
+  it('keeps source terminals above the reserve threshold', () => {
+    const sourceRoom = makeOwnedRoom({
+      roomName: 'W1N1',
+      storageCapacity: 25_000,
+      storageEnergy: 25_000,
+      terminalCapacity: 30_000,
+      terminalEnergy: TERMINAL_ENERGY_MIN_RESERVE + 99
+    });
+    const targetRoom = makeOwnedRoom({
+      roomName: 'W2N1',
+      storageEnergy: 10_000,
+      terminalEnergy: 20_000
+    });
+    installGame([sourceRoom, targetRoom], 1);
+
+    expect(manageTerminalEnergy()).toEqual([]);
+    expect(sourceRoom.terminal?.send).not.toHaveBeenCalled();
+  });
+
+  it('does not import energy into a terminal that is already at its target threshold', () => {
+    const sourceRoom = makeOwnedRoom({
+      roomName: 'W1N1',
+      storageEnergy: 100_000,
+      terminalEnergy: 80_000
+    });
+    const targetRoom = makeOwnedRoom({
+      roomName: 'W2N1',
+      storageCapacity: 500_000,
+      storageEnergy: 10_000,
+      terminalEnergy: 50_000
+    });
+    installGame([sourceRoom, targetRoom], 2);
+
+    expect(manageTerminalEnergy()).toEqual([]);
+    expect(sourceRoom.terminal?.send).not.toHaveBeenCalled();
+  });
+});
+
+function makeOwnedRoom({
+  roomName,
+  storageEnergy,
+  storageCapacity = 100_000,
+  terminalEnergy,
+  terminalCapacity = 100_000,
+  cooldown = 0
+}: {
+  roomName: string;
+  storageEnergy: number;
+  storageCapacity?: number;
+  terminalEnergy: number;
+  terminalCapacity?: number;
+  cooldown?: number;
+}): Room {
+  return {
+    name: roomName,
+    controller: { my: true } as StructureController,
+    energyAvailable: 800,
+    energyCapacityAvailable: 800,
+    storage: makeStorage(`${roomName}-storage`, storageEnergy, storageCapacity),
+    terminal: makeTerminal(`${roomName}-terminal`, terminalEnergy, terminalCapacity, cooldown)
+  } as unknown as Room;
+}
+
+function makeStorage(id: string, energy: number, capacity: number): StructureStorage {
+  return {
+    id,
+    structureType: 'storage',
+    store: makeStore(energy, capacity)
+  } as unknown as StructureStorage;
+}
+
+function makeTerminal(
+  id: string,
+  energy: number,
+  capacity: number,
+  cooldown: number
+): TestStructureTerminal {
+  return {
+    id,
+    cooldown,
+    structureType: 'terminal',
+    store: makeStore(energy, capacity),
+    send: jest.fn().mockReturnValue(OK_CODE)
+  } as unknown as TestStructureTerminal;
+}
+
+function makeStore(energy: number, capacity: number): StoreDefinition {
+  return {
+    getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? energy : 0)),
+    getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? capacity : 0)),
+    getFreeCapacity: jest.fn((resource?: ResourceConstant) =>
+      resource === RESOURCE_ENERGY ? Math.max(0, capacity - energy) : 0
+    )
+  } as unknown as StoreDefinition;
+}
+
+function installGame(rooms: Room[], linearDistance: number): void {
+  (globalThis as unknown as { Game: Partial<Game> }).Game = {
+    time: 100,
+    rooms: Object.fromEntries(rooms.map((room) => [room.name, room])),
+    map: {
+      getRoomLinearDistance: jest.fn().mockReturnValue(linearDistance)
+    } as unknown as GameMap
+  };
+}

--- a/prod/test/terminalManager.test.ts
+++ b/prod/test/terminalManager.test.ts
@@ -27,7 +27,7 @@ describe('terminalManager', () => {
       } as unknown as GameMap
     };
 
-    expect(calculateTerminalEnergyCost('W1N1', 'W4N1', 333)).toBe(99);
+    expect(calculateTerminalEnergyCost('W1N1', 'W4N1', 333)).toBe(32);
     expect(getTerminalSendCooldown(0)).toBe(0);
     expect(getTerminalSendCooldown(1)).toBe(1);
     expect(getTerminalSendCooldown(100)).toBe(1);
@@ -56,7 +56,7 @@ describe('terminalManager', () => {
         cooldown: 100,
         description: 'energy-balance W1N1->W2N1',
         distance: 2,
-        energyCost: 2_000,
+        energyCost: 645,
         result: OK_CODE,
         sourceRoom: 'W1N1',
         targetRoom: 'W2N1'
@@ -78,7 +78,7 @@ describe('terminalManager', () => {
         sourceRoom: 'W1N1',
         targetRoom: 'W2N1',
         amount: 10_000,
-        energyCost: 2_000,
+        energyCost: 645,
         cooldown: 100
       }
     ]);


### PR DESCRIPTION
Closes #780

## Summary
Implement terminal resource management for cross-room energy logistics. Adds a `TerminalManager` module that handles terminal send/receive operations for moving energy between rooms.

## Changes
- `prod/src/economy/terminalManager.ts` — new terminal resource management module
- `prod/src/economy/economyLoop.ts` — integrate terminal management into economy loop
- `prod/src/types.d.ts` — type definitions for terminal operations
- `prod/test/terminalManager.test.ts` — comprehensive test coverage

## Verification
- `npm run typecheck` — PASS
- `npm test -- --runInBand` — 73 suites, 1490 tests PASS
- `npm run build` — OK, generated `prod/dist/main.js`
- `git diff --check` — clean

## Commit
- `dc3a91a` — `lanyusea's bot <lanyusea@gmail.com>`