### PR TITLE
feat(economy): implement spawn queue role-priority scheduler for room-state-aware creep production (#797)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -24708,18 +24708,19 @@ var POST_CLAIM_SUSTAIN_DEFAULT_WORKER_TARGET = 2;
 var POST_CLAIM_SUSTAIN_WORKER_REPLACEMENT_TICKS = 100;
 var POST_CLAIM_SUSTAIN_MIN_HAULER_ENERGY = 200;
 var MINIMUM_EMERGENCY_WORKER_BODY_COST = getBodyCost(EMERGENCY_BOOTSTRAP_WORKER_BODY);
-var SPAWN_PRIORITY_TIERS = [
-  "emergencyBootstrap",
-  "localSourceMining",
-  "localRefillSurvival",
-  "controllerDowngradeGuard",
-  "defense",
-  "localEnergyHauling",
-  "postClaimControllerSustain",
-  "remoteEconomy",
-  "territoryRemote",
-  "controllerUpgradeDemand",
-  "multiRoomControllerUpgrade"
+var LOW_ENERGY_NON_CRITICAL_DEFER_RATIO = 0.5;
+var SPAWN_QUEUE = [
+  { tier: "emergencyBootstrap", getPriority: () => "critical" },
+  { tier: "defense", getPriority: getDefenseSpawnQueuePriority },
+  { tier: "localSourceMining", getPriority: getLocalSourceMiningSpawnQueuePriority },
+  { tier: "controllerDowngradeGuard", getPriority: () => "critical" },
+  { tier: "localEnergyHauling", getPriority: getLocalEnergyHaulingSpawnQueuePriority },
+  { tier: "remoteEconomy", getPriority: () => "high" },
+  { tier: "localRefillSurvival", getPriority: () => "normal" },
+  { tier: "postClaimControllerSustain", getPriority: () => "normal" },
+  { tier: "controllerUpgradeDemand", getPriority: () => "normal" },
+  { tier: "multiRoomControllerUpgrade", getPriority: () => "normal" },
+  { tier: "territoryRemote", getPriority: () => "low" }
 ];
 function planSpawn(colony, roleCounts, gameTime, options = {}) {
   const workerTarget = getWorkerTarget(colony, roleCounts);
@@ -24734,10 +24735,14 @@ function planSpawn(colony, roleCounts, gameTime, options = {}) {
     workerCapacity,
     workerTarget
   };
-  for (const tier of SPAWN_PRIORITY_TIERS) {
-    const request = planSpawnForPriorityTier(tier, context);
+  for (const entry of buildSpawnQueue(context)) {
+    const deferredForLowEnergy = shouldDeferSpawnQueueEntryForLowEnergy(entry, context);
+    if (deferredForLowEnergy && entry.tier !== "territoryRemote") {
+      continue;
+    }
+    const request = planSpawnForPriorityTier(entry.tier, context);
     if (request) {
-      return request;
+      return deferredForLowEnergy ? null : request;
     }
   }
   return null;
@@ -24746,6 +24751,9 @@ function orderColoniesForSpawnPlanning(colonies, roleCountsByRoom) {
   return [...colonies].sort(
     (left, right) => compareColoniesForSpawnPlanning(left, right, roleCountsByRoom)
   );
+}
+function sortSpawnQueueByRolePriority(queue) {
+  return [...queue].sort(compareSpawnQueuePriorityCandidates);
 }
 function getSpawnEnergyForecast(colony) {
   const balance = getStorageBalanceMemory();
@@ -24839,6 +24847,68 @@ function getRoomCreepBudget(colony, roleCounts) {
     reservedSpawnEnergy: forecast.reservedEnergy
   };
 }
+function buildSpawnQueue(context) {
+  return sortSpawnQueueByRolePriority(
+    SPAWN_QUEUE.map((definition, enqueueOrder) => ({
+      tier: definition.tier,
+      priority: definition.getPriority(context),
+      enqueueOrder
+    }))
+  );
+}
+function compareSpawnQueuePriorityCandidates(left, right) {
+  return getSpawnQueueRolePriorityRank(left.priority) - getSpawnQueueRolePriorityRank(right.priority) || left.enqueueOrder - right.enqueueOrder;
+}
+function getSpawnQueueRolePriorityRank(priority) {
+  switch (priority) {
+    case "critical":
+      return 0;
+    case "high":
+      return 1;
+    case "normal":
+      return 2;
+    case "low":
+      return 3;
+  }
+}
+function getDefenseSpawnQueuePriority(context) {
+  return context.survival.hostilePresence || hasOwnedRoomHostilePresence() || hasControllerAttackPressure(context.colony.room.controller) || selectPostClaimControllerDefensePlan(context.colony) ? "critical" : "normal";
+}
+function getLocalSourceMiningSpawnQueuePriority(context) {
+  return hasLocalSourceHarvesterShortfall(context) ? "critical" : "high";
+}
+function getLocalEnergyHaulingSpawnQueuePriority(context) {
+  const demand = selectEnergyHaulerSpawnDemand(context.colony.room);
+  return demand && demand.activeHaulers <= 0 ? "high" : "normal";
+}
+function shouldDeferSpawnQueueEntryForLowEnergy(entry, context) {
+  return isLowSpawnEnergy(context.colony) && entry.priority !== "critical" && !isEmergencyLocalRefillSurvivalEntry(entry, context);
+}
+function isLowSpawnEnergy(colony) {
+  const energyAvailable = normalizeNonNegativeInteger9(colony.energyAvailable);
+  const energyCapacityAvailable = normalizeNonNegativeInteger9(colony.energyCapacityAvailable);
+  return energyCapacityAvailable > 0 && energyAvailable < energyCapacityAvailable * LOW_ENERGY_NON_CRITICAL_DEFER_RATIO;
+}
+function isEmergencyLocalRefillSurvivalEntry(entry, context) {
+  return entry.tier === "localRefillSurvival" && (context.workerCapacity < context.survival.survivalWorkerFloor || context.survival.bootstrapRecovery);
+}
+function hasLocalSourceHarvesterShortfall(context) {
+  var _a, _b, _c;
+  return context.options.workersOnly !== true && context.survival.hostilePresence !== true && context.survival.controllerDowngradeGuard !== true && ((_a = context.colony.room.controller) == null ? void 0 : _a.my) === true && ((_b = context.colony.room.controller.level) != null ? _b : 0) >= 2 && context.roleCounts.worker >= LOCAL_SUPPORT_WORKER_FLOOR && normalizeNonNegativeInteger9((_c = context.roleCounts.sourceHarvester) != null ? _c : 0) < getSourceCount(context.colony.room);
+}
+function hasOwnedRoomHostilePresence() {
+  var _a;
+  const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
+  if (!rooms) {
+    return false;
+  }
+  return Object.values(rooms).some(
+    (room) => {
+      var _a2;
+      return ((_a2 = room == null ? void 0 : room.controller) == null ? void 0 : _a2.my) === true && getRoomHostileCreepCount(room) > 0;
+    }
+  );
+}
 function planSpawnForPriorityTier(tier, context) {
   switch (tier) {
     case "emergencyBootstrap":
@@ -24885,7 +24955,7 @@ function planLocalSurvivalSpawn(context) {
   return planWorkerSpawn(context.colony, context.roleCounts, context.gameTime, context.options);
 }
 function planLocalEnergyHaulingSpawn(context) {
-  if (context.options.workersOnly || context.workerCapacity <= 0 || context.workerCapacity < context.workerTarget) {
+  if (context.options.workersOnly || context.workerCapacity <= 0) {
     return null;
   }
   const demand = selectEnergyHaulerSpawnDemand(context.colony.room);

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -88,6 +88,22 @@ type SpawnPriorityTier =
   | 'multiRoomControllerUpgrade'
   | 'controllerUpgradeSurplus';
 
+export type SpawnQueueRolePriority = 'critical' | 'high' | 'normal' | 'low';
+
+export interface SpawnQueuePriorityCandidate {
+  enqueueOrder: number;
+  priority: SpawnQueueRolePriority;
+}
+
+interface SpawnQueueDefinition {
+  tier: SpawnPriorityTier;
+  getPriority: (context: SpawnPlanningContext) => SpawnQueueRolePriority;
+}
+
+interface SpawnQueueEntry extends SpawnQueuePriorityCandidate {
+  tier: SpawnPriorityTier;
+}
+
 interface SpawnPlanningContext {
   colony: ColonySnapshot;
   gameTime: number;
@@ -188,18 +204,19 @@ const POST_CLAIM_SUSTAIN_DEFAULT_WORKER_TARGET = 2;
 const POST_CLAIM_SUSTAIN_WORKER_REPLACEMENT_TICKS = 100;
 const POST_CLAIM_SUSTAIN_MIN_HAULER_ENERGY = 200;
 const MINIMUM_EMERGENCY_WORKER_BODY_COST = getBodyCost(EMERGENCY_BOOTSTRAP_WORKER_BODY);
-const SPAWN_PRIORITY_TIERS: SpawnPriorityTier[] = [
-  'emergencyBootstrap',
-  'localSourceMining',
-  'localRefillSurvival',
-  'controllerDowngradeGuard',
-  'defense',
-  'localEnergyHauling',
-  'postClaimControllerSustain',
-  'remoteEconomy',
-  'territoryRemote',
-  'controllerUpgradeDemand',
-  'multiRoomControllerUpgrade'
+const LOW_ENERGY_NON_CRITICAL_DEFER_RATIO = 0.5;
+const SPAWN_QUEUE: SpawnQueueDefinition[] = [
+  { tier: 'emergencyBootstrap', getPriority: () => 'critical' },
+  { tier: 'defense', getPriority: getDefenseSpawnQueuePriority },
+  { tier: 'localSourceMining', getPriority: getLocalSourceMiningSpawnQueuePriority },
+  { tier: 'controllerDowngradeGuard', getPriority: () => 'critical' },
+  { tier: 'localEnergyHauling', getPriority: getLocalEnergyHaulingSpawnQueuePriority },
+  { tier: 'remoteEconomy', getPriority: () => 'high' },
+  { tier: 'localRefillSurvival', getPriority: () => 'normal' },
+  { tier: 'postClaimControllerSustain', getPriority: () => 'normal' },
+  { tier: 'controllerUpgradeDemand', getPriority: () => 'normal' },
+  { tier: 'multiRoomControllerUpgrade', getPriority: () => 'normal' },
+  { tier: 'territoryRemote', getPriority: () => 'low' }
 ];
 
 export function planSpawn(
@@ -221,10 +238,15 @@ export function planSpawn(
     workerTarget
   };
 
-  for (const tier of SPAWN_PRIORITY_TIERS) {
-    const request = planSpawnForPriorityTier(tier, context);
+  for (const entry of buildSpawnQueue(context)) {
+    const deferredForLowEnergy = shouldDeferSpawnQueueEntryForLowEnergy(entry, context);
+    if (deferredForLowEnergy && entry.tier !== 'territoryRemote') {
+      continue;
+    }
+
+    const request = planSpawnForPriorityTier(entry.tier, context);
     if (request) {
-      return request;
+      return deferredForLowEnergy ? null : request;
     }
   }
 
@@ -238,6 +260,10 @@ export function orderColoniesForSpawnPlanning(
   return [...colonies].sort((left, right) =>
     compareColoniesForSpawnPlanning(left, right, roleCountsByRoom)
   );
+}
+
+export function sortSpawnQueueByRolePriority<T extends SpawnQueuePriorityCandidate>(queue: readonly T[]): T[] {
+  return [...queue].sort(compareSpawnQueuePriorityCandidates);
 }
 
 export function getSpawnEnergyForecast(colony: ColonySnapshot): SpawnEnergyForecast {
@@ -367,6 +393,111 @@ export function getRoomCreepBudget(
   };
 }
 
+function buildSpawnQueue(context: SpawnPlanningContext): SpawnQueueEntry[] {
+  return sortSpawnQueueByRolePriority(
+    SPAWN_QUEUE.map((definition, enqueueOrder) => ({
+      tier: definition.tier,
+      priority: definition.getPriority(context),
+      enqueueOrder
+    }))
+  );
+}
+
+function compareSpawnQueuePriorityCandidates(
+  left: SpawnQueuePriorityCandidate,
+  right: SpawnQueuePriorityCandidate
+): number {
+  return (
+    getSpawnQueueRolePriorityRank(left.priority) - getSpawnQueueRolePriorityRank(right.priority) ||
+    left.enqueueOrder - right.enqueueOrder
+  );
+}
+
+function getSpawnQueueRolePriorityRank(priority: SpawnQueueRolePriority): number {
+  switch (priority) {
+    case 'critical':
+      return 0;
+    case 'high':
+      return 1;
+    case 'normal':
+      return 2;
+    case 'low':
+      return 3;
+  }
+}
+
+function getDefenseSpawnQueuePriority(context: SpawnPlanningContext): SpawnQueueRolePriority {
+  return context.survival.hostilePresence ||
+    hasOwnedRoomHostilePresence() ||
+    hasControllerAttackPressure(context.colony.room.controller) ||
+    selectPostClaimControllerDefensePlan(context.colony)
+    ? 'critical'
+    : 'normal';
+}
+
+function getLocalSourceMiningSpawnQueuePriority(context: SpawnPlanningContext): SpawnQueueRolePriority {
+  return hasLocalSourceHarvesterShortfall(context) ? 'critical' : 'high';
+}
+
+function getLocalEnergyHaulingSpawnQueuePriority(context: SpawnPlanningContext): SpawnQueueRolePriority {
+  const demand = selectEnergyHaulerSpawnDemand(context.colony.room);
+  return demand && demand.activeHaulers <= 0 ? 'high' : 'normal';
+}
+
+function shouldDeferSpawnQueueEntryForLowEnergy(
+  entry: SpawnQueueEntry,
+  context: SpawnPlanningContext
+): boolean {
+  return (
+    isLowSpawnEnergy(context.colony) &&
+    entry.priority !== 'critical' &&
+    !isEmergencyLocalRefillSurvivalEntry(entry, context)
+  );
+}
+
+function isLowSpawnEnergy(colony: ColonySnapshot): boolean {
+  const energyAvailable = normalizeNonNegativeInteger(colony.energyAvailable);
+  const energyCapacityAvailable = normalizeNonNegativeInteger(colony.energyCapacityAvailable);
+  return (
+    energyCapacityAvailable > 0 &&
+    energyAvailable < energyCapacityAvailable * LOW_ENERGY_NON_CRITICAL_DEFER_RATIO
+  );
+}
+
+function isEmergencyLocalRefillSurvivalEntry(
+  entry: SpawnQueueEntry,
+  context: SpawnPlanningContext
+): boolean {
+  return (
+    entry.tier === 'localRefillSurvival' &&
+    (context.workerCapacity < context.survival.survivalWorkerFloor ||
+      context.survival.bootstrapRecovery)
+  );
+}
+
+function hasLocalSourceHarvesterShortfall(context: SpawnPlanningContext): boolean {
+  return (
+    context.options.workersOnly !== true &&
+    context.survival.hostilePresence !== true &&
+    context.survival.controllerDowngradeGuard !== true &&
+    context.colony.room.controller?.my === true &&
+    (context.colony.room.controller.level ?? 0) >= 2 &&
+    context.roleCounts.worker >= LOCAL_SUPPORT_WORKER_FLOOR &&
+    normalizeNonNegativeInteger(context.roleCounts.sourceHarvester ?? 0) < getSourceCount(context.colony.room)
+  );
+}
+
+function hasOwnedRoomHostilePresence(): boolean {
+  const rooms = (globalThis as unknown as { Game?: Partial<Pick<Game, 'rooms'>> }).Game?.rooms;
+  if (!rooms) {
+    return false;
+  }
+
+  return Object.values(rooms).some(
+    (room) => room?.controller?.my === true && getRoomHostileCreepCount(room) > 0
+  );
+}
+
 function planSpawnForPriorityTier(
   tier: SpawnPriorityTier,
   context: SpawnPlanningContext
@@ -431,8 +562,7 @@ function planLocalSurvivalSpawn(context: SpawnPlanningContext): SpawnRequest | n
 function planLocalEnergyHaulingSpawn(context: SpawnPlanningContext): SpawnRequest | null {
   if (
     context.options.workersOnly ||
-    context.workerCapacity <= 0 ||
-    context.workerCapacity < context.workerTarget
+    context.workerCapacity <= 0
   ) {
     return null;
   }

--- a/prod/test/colonyStage.test.ts
+++ b/prod/test/colonyStage.test.ts
@@ -160,9 +160,13 @@ describe('colony bootstrap stage', () => {
     });
     expect(planSpawn(defenseColony, { worker: 3 }, 101)).toEqual({
       spawn: defenseSpawn,
-      body: SCALED_WORKER_800,
-      name: 'worker-W1N1-101',
-      memory: { role: 'worker', colony: 'W1N1' }
+      body: ['tough', 'attack', 'move'],
+      name: 'defender-W1N1-101',
+      memory: {
+        role: 'defender',
+        colony: 'W1N1',
+        defense: { homeRoom: 'W1N1' }
+      }
     });
 
     expect(planSpawn(defenseColony, { worker: 4 }, 102)).toEqual({

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -2,7 +2,8 @@ import {
   generateHarvesterBody,
   getRoomCreepBudget,
   orderColoniesForSpawnPlanning,
-  planSpawn
+  planSpawn,
+  sortSpawnQueueByRolePriority
 } from '../src/spawn/spawnPlanner';
 import { getEnergyReservationScore } from '../src/economy/energyReservation';
 import { ColonySnapshot } from '../src/colony/colonyRegistry';
@@ -400,6 +401,28 @@ describe('planSpawn', () => {
     return creeps ? Object.values(creeps).filter((creep) => creep.room?.name === roomName) : [];
   }
 
+  it('orders spawn queue candidates by role priority before lower tiers', () => {
+    expect(
+      sortSpawnQueueByRolePriority([
+        { id: 'low-scout', priority: 'low', enqueueOrder: 0 },
+        { id: 'normal-worker', priority: 'normal', enqueueOrder: 1 },
+        { id: 'critical-defender', priority: 'critical', enqueueOrder: 2 },
+        { id: 'high-hauler', priority: 'high', enqueueOrder: 3 }
+      ]).map((candidate) => candidate.id)
+    ).toEqual(['critical-defender', 'high-hauler', 'normal-worker', 'low-scout']);
+  });
+
+  it('keeps FIFO order within a spawn queue priority tier', () => {
+    expect(
+      sortSpawnQueueByRolePriority([
+        { id: 'first-hauler', priority: 'high', enqueueOrder: 4 },
+        { id: 'critical-defender', priority: 'critical', enqueueOrder: 5 },
+        { id: 'second-hauler', priority: 'high', enqueueOrder: 6 },
+        { id: 'third-hauler', priority: 'high', enqueueOrder: 7 }
+      ]).map((candidate) => candidate.id)
+    ).toEqual(['critical-defender', 'first-hauler', 'second-hauler', 'third-hauler']);
+  });
+
   it('plans a worker when the colony has no workers and an idle spawn', () => {
     const { colony, spawn } = makeColony();
 
@@ -592,6 +615,36 @@ describe('planSpawn', () => {
         colony: 'W1N28',
         sourceHarvester: {
           roomName: 'W1N28',
+          sourceId: 'source0',
+          containerId: 'container0'
+        }
+      }
+    });
+  });
+
+  it('promotes a missing source harvester ahead of normal worker recovery', () => {
+    const sourcePosition = makeRoomPosition(10, 10, 'W1N40');
+    const container = makeRemoteContainer('container0', 0, 10, 11, 'W1N40') as unknown as AnyStructure;
+    const { colony, spawn } = makeColony({
+      roomName: 'W1N40',
+      sourceCount: 1,
+      sourcePositions: [sourcePosition],
+      structures: [container],
+      energyAvailable: 600,
+      energyCapacityAvailable: 600,
+      spawnEnergyBudget: 600,
+      controller: makeSafeOwnedController()
+    });
+
+    expect(planSpawn(colony, { worker: 3, workerCapacity: 2 }, 166)).toEqual({
+      spawn,
+      body: ['work', 'work', 'work', 'work', 'work', 'carry', 'move'],
+      name: 'sourceHarvester-W1N40-source0-166',
+      memory: {
+        role: 'sourceHarvester',
+        colony: 'W1N40',
+        sourceHarvester: {
+          roomName: 'W1N40',
           sourceId: 'source0',
           containerId: 'container0'
         }
@@ -1750,6 +1803,56 @@ describe('planSpawn', () => {
     expect(planSpawn(colony, { worker: 3 }, 505)?.memory.role).not.toBe('hauler');
   });
 
+  it('preempts normal worker recovery when a high-priority hauler fits the energy budget', () => {
+    const container = makeEnergyHaulingStructure('container1', STRUCTURE_CONTAINER, 650, 1_350, 5, 5, 2_000);
+    const storage = makeEnergyHaulingStructure('storage1', STRUCTURE_STORAGE, 1_000, 9_000, 12, 12, 10_000);
+    const { colony, spawn } = makeColony({
+      sourceCount: 0,
+      energyAvailable: 800,
+      energyCapacityAvailable: 800,
+      spawnEnergyBudget: 800,
+      controller: makeSafeOwnedController(),
+      structures: [container as unknown as AnyStructure],
+      ownedStructures: [storage]
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 506,
+      rooms: { W1N1: colony.room },
+      spawns: { Spawn1: spawn },
+      creeps: {}
+    };
+
+    expect(planSpawn(colony, { worker: 3, workerCapacity: 2 }, 506)).toEqual({
+      spawn,
+      body: [
+        'carry',
+        'move',
+        'carry',
+        'move',
+        'carry',
+        'move',
+        'carry',
+        'move',
+        'carry',
+        'move',
+        'carry',
+        'move',
+        'carry',
+        'move',
+        'carry',
+        'move'
+      ],
+      name: 'hauler-W1N1-energy-506',
+      memory: {
+        role: 'hauler',
+        colony: 'W1N1',
+        energyHauler: {
+          roomName: 'W1N1'
+        }
+      }
+    });
+  });
+
   it('plans a remote harvester for a newly claimed adjacent room source before container completion', () => {
     const { colony, spawn } = makeColony({
       energyAvailable: 650,
@@ -1976,6 +2079,19 @@ describe('planSpawn', () => {
     expect(planSpawn(colony, { worker: 4 }, 146)).toBeNull();
   });
 
+  it('defers non-critical worker backlog while room energy is below half capacity', () => {
+    const { colony } = makeColony({
+      roomName: 'W1N41',
+      constructionSiteCount: 1,
+      energyAvailable: 200,
+      energyCapacityAvailable: 600,
+      spawnEnergyBudget: 200,
+      controller: makeSafeOwnedController()
+    });
+
+    expect(planSpawn(colony, { worker: 3 }, 147)).toBeNull();
+  });
+
   it('adds one worker target while spawn-extension refill pressure remains after baseline workers', () => {
     const { colony, spawn } = makeColony({
       roomName: 'W1N16',
@@ -2079,9 +2195,13 @@ describe('planSpawn', () => {
 
     expect(planSpawn(colony, { worker: 3, defender: 1 }, 152)).toEqual({
       spawn,
-      body: SCALED_WORKER_550,
-      name: 'worker-W1N9-152',
-      memory: { role: 'worker', colony: 'W1N9' }
+      body: ['tough', 'attack', 'move'],
+      name: 'defender-W1N9-152',
+      memory: {
+        role: 'defender',
+        colony: 'W1N9',
+        defense: { homeRoom: 'W1N9' }
+      }
     });
   });
 
@@ -2112,7 +2232,7 @@ describe('planSpawn', () => {
     });
   });
 
-  it('plans local worker refill before an emergency defender while hostiles are visible', () => {
+  it('promotes hostile-room defenders ahead of normal worker refill', () => {
     installHostileFindGlobals();
     const { colony: localRefillColony, spawn: localRefillSpawn } = makeColony({ sourceCount: 2 });
     expect(planSpawn(localRefillColony, { worker: 3 }, 163)).toEqual({
@@ -2127,9 +2247,13 @@ describe('planSpawn', () => {
 
     expect(planSpawn(colony, { worker: 3 }, 164)).toEqual({
       spawn,
-      body: SCALED_WORKER_300,
-      name: 'worker-W1N1-164',
-      memory: { role: 'worker', colony: 'W1N1' }
+      body: ['tough', 'attack', 'move'],
+      name: 'defender-W1N1-164',
+      memory: {
+        role: 'defender',
+        colony: 'W1N1',
+        defense: { homeRoom: 'W1N1' }
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
Implement spawn queue role-priority scheduler for room-state-aware creep production.

## Changes
- **Modified**: `prod/src/spawn/spawnPlanner.ts` — role-priority tiers (CRITICAL/HIGH/NORMAL/LOW), dynamic priority escalation, energy budget integration, FIFO within tiers
- **Tests**: 3 test files updated, 1526/1526 total tests pass
- **Build**: `prod/dist/main.js` regenerated

## Verification
```
npm run typecheck — PASS
npm test -- --runInBand — 77 suites, 1526 tests PASS
npm run build — PASS
git diff --check — clean
```

## Refs
Closes #797
