### PR TITLE
feat(economy): E26S48 source harvesting and inter-room energy logistics for claimed room (#814)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -17381,10 +17381,20 @@ function selectColonyRecallEnergySink(room) {
 function selectControllerSustainUpgradeTask(creep, controller) {
   var _a, _b;
   const sustain = (_a = creep.memory) == null ? void 0 : _a.controllerSustain;
-  if ((sustain == null ? void 0 : sustain.role) !== "upgrader" || sustain.targetRoom !== ((_b = creep.room) == null ? void 0 : _b.name) || (controller == null ? void 0 : controller.my) !== true || !canLevelUpController2(controller)) {
+  if ((sustain == null ? void 0 : sustain.role) !== "upgrader" || sustain.targetRoom !== ((_b = creep.room) == null ? void 0 : _b.name) || (controller == null ? void 0 : controller.my) !== true || !canLevelUpController2(controller) || shouldYieldControllerSustainUpgradeToConstruction(creep, sustain)) {
     return null;
   }
   return { type: "upgrade", targetId: controller.id };
+}
+function shouldYieldControllerSustainUpgradeToConstruction(creep, sustain) {
+  return sustain.homeRoom !== sustain.targetRoom && hasVisibleOwnedConstructionDemand(creep.room);
+}
+function hasVisibleOwnedConstructionDemand(room) {
+  if (typeof FIND_CONSTRUCTION_SITES !== "number" || typeof (room == null ? void 0 : room.find) !== "function") {
+    return false;
+  }
+  const sites = room.find(FIND_CONSTRUCTION_SITES);
+  return sites.some((site) => site.my !== false);
 }
 function selectManagedControllerUpgradeTask(creep, controller, carriedEnergy) {
   var _a, _b;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -722,12 +722,29 @@ function selectControllerSustainUpgradeTask(
     sustain?.role !== 'upgrader' ||
     sustain.targetRoom !== creep.room?.name ||
     controller?.my !== true ||
-    !canLevelUpController(controller)
+    !canLevelUpController(controller) ||
+    shouldYieldControllerSustainUpgradeToConstruction(creep, sustain)
   ) {
     return null;
   }
 
   return { type: 'upgrade', targetId: controller.id };
+}
+
+function shouldYieldControllerSustainUpgradeToConstruction(
+  creep: Creep,
+  sustain: CreepControllerSustainMemory
+): boolean {
+  return sustain.homeRoom !== sustain.targetRoom && hasVisibleOwnedConstructionDemand(creep.room);
+}
+
+function hasVisibleOwnedConstructionDemand(room: Room | undefined): boolean {
+  if (typeof FIND_CONSTRUCTION_SITES !== 'number' || typeof room?.find !== 'function') {
+    return false;
+  }
+
+  const sites = room.find(FIND_CONSTRUCTION_SITES) as ConstructionSite[];
+  return sites.some((site) => site.my !== false);
 }
 
 function selectManagedControllerUpgradeTask(

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -3127,6 +3127,119 @@ describe('runEconomy', () => {
     });
   });
 
+  it('registers all visible E26S48 sources for post-claim remote mining from E26S49', () => {
+    (globalThis as unknown as {
+      FIND_SOURCES: number;
+      FIND_STRUCTURES: number;
+      FIND_CONSTRUCTION_SITES: number;
+      FIND_MY_CREEPS: number;
+      STRUCTURE_CONTAINER: StructureConstant;
+      TERRAIN_MASK_WALL: number;
+      OK: ScreepsReturnCode;
+      Memory: Partial<Memory>;
+    }).FIND_SOURCES = 1;
+    (globalThis as unknown as { FIND_STRUCTURES: number }).FIND_STRUCTURES = 2;
+    (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 3;
+    (globalThis as unknown as { FIND_MY_CREEPS: number }).FIND_MY_CREEPS = 4;
+    (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+    (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+    (globalThis as unknown as { OK: ScreepsReturnCode }).OK = OK_CODE;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          E26S48: {
+            colony: 'E26S49',
+            roomName: 'E26S48',
+            status: 'ready',
+            claimedAt: 814,
+            updatedAt: 815,
+            workerTarget: 2,
+            controllerId: 'controller-e26s48' as Id<StructureController>
+          }
+        }
+      }
+    };
+    const homeRoom = makeTerritoryReadyEconomyRoom();
+    (homeRoom as Room & { name: string }).name = 'E26S49';
+    const constructionSites: ConstructionSite[] = [];
+    const claimedRoom = {
+      name: 'E26S48',
+      energyAvailable: 0,
+      energyCapacityAvailable: 0,
+      controller: {
+        id: 'controller-e26s48',
+        my: true,
+        level: 1,
+        pos: { x: 25, y: 25, roomName: 'E26S48' } as RoomPosition
+      } as StructureController,
+      find: jest.fn((type: number) => {
+        if (type === FIND_SOURCES) {
+          return [
+            { id: 'e26s48-source-a', pos: { x: 10, y: 10, roomName: 'E26S48' } as RoomPosition } as Source,
+            { id: 'e26s48-source-b', pos: { x: 35, y: 35, roomName: 'E26S48' } as RoomPosition } as Source
+          ];
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [];
+        }
+
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return constructionSites;
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return [];
+        }
+
+        return [];
+      }),
+      createConstructionSite: jest.fn((x: number, y: number, structureType: StructureConstant) => {
+        constructionSites.push({
+          id: `site-${x}-${y}`,
+          structureType,
+          pos: { x, y, roomName: 'E26S48' } as RoomPosition
+        } as ConstructionSite);
+        return OK_CODE;
+      })
+    } as unknown as Room & { createConstructionSite: jest.Mock };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 816,
+      rooms: { E26S49: homeRoom, E26S48: claimedRoom },
+      spawns: {},
+      creeps: {
+        Worker1: makeEconomyWorker(homeRoom),
+        Worker2: makeEconomyWorker(homeRoom),
+        Worker3: makeEconomyWorker(homeRoom),
+        Worker4: makeEconomyWorker(homeRoom),
+        Worker5: makeEconomyWorker(homeRoom)
+      },
+      map: {
+        getRoomTerrain: jest.fn().mockReturnValue({ get: jest.fn().mockReturnValue(0) })
+      } as unknown as GameMap
+    };
+
+    runEconomy();
+
+    expect(Object.keys(Memory.territory?.remoteMining?.['E26S49:E26S48']?.sources ?? {})).toEqual([
+      'e26s48-source-a',
+      'e26s48-source-b'
+    ]);
+    expect(Memory.territory?.remoteMining?.['E26S49:E26S48']).toMatchObject({
+      colony: 'E26S49',
+      roomName: 'E26S48',
+      status: 'containerPending',
+      sources: {
+        'e26s48-source-a': {
+          sourceId: 'e26s48-source-a'
+        },
+        'e26s48-source-b': {
+          sourceId: 'e26s48-source-b'
+        }
+      }
+    });
+  });
+
   it('keeps unsafe occupation recommendations on worker recovery before territory spawn pressure', () => {
     (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -1940,6 +1940,61 @@ describe('planSpawn', () => {
     });
   });
 
+  it('assigns a dedicated remote miner to an E26S48 source after the room is claimed', () => {
+    const { colony, spawn } = makeColony({
+      roomName: 'E26S49',
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+    const source = makeRemoteSource('e26s48-source-a', 10, 10, 'E26S48');
+    const claimedRoom = makeRemoteEconomyRoom({
+      roomName: 'E26S48',
+      source,
+      container: null,
+      controller: {
+        id: 'controller-e26s48',
+        my: true,
+        level: 1
+      } as StructureController
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 814,
+      rooms: { E26S49: colony.room, E26S48: claimedRoom },
+      spawns: { Spawn1: spawn },
+      creeps: {
+        RemoteUpgrader: makePostClaimSustainUpgrader('E26S48')
+      },
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          E26S48: {
+            ...makeSatisfiedPostClaimRemoteMemory('E26S48'),
+            colony: 'E26S49',
+            controllerId: 'controller-e26s48' as Id<StructureController>
+          }
+        }
+      }
+    };
+
+    expect(planSpawn(colony, { worker: 3 }, 815)).toEqual({
+      spawn,
+      body: ['work', 'work', 'work', 'work', 'work', 'carry', 'move'],
+      name: 'remoteHarvester-E26S49-E26S48-e26s48-source-a-815',
+      memory: {
+        role: 'remoteHarvester',
+        colony: 'E26S49',
+        remoteHarvester: {
+          homeRoom: 'E26S49',
+          targetRoom: 'E26S48',
+          sourceId: 'e26s48-source-a'
+        }
+      }
+    });
+  });
+
   it('dispatches a remote hauler only when the assigned remote container is above threshold', () => {
     const { colony, spawn } = makeColony({
       energyAvailable: 650,

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -345,12 +345,12 @@ describe('planSpawn', () => {
     };
   }
 
-  function makePostClaimSustainUpgrader(targetRoom = 'W2N1'): Creep {
+  function makePostClaimSustainUpgrader(targetRoom = 'W2N1', homeRoom = 'W1N1'): Creep {
     return {
       memory: {
         role: 'worker',
         colony: targetRoom,
-        controllerSustain: { homeRoom: 'W1N1', targetRoom, role: 'upgrader' }
+        controllerSustain: { homeRoom, targetRoom, role: 'upgrader' }
       }
     } as Creep;
   }
@@ -1963,7 +1963,7 @@ describe('planSpawn', () => {
       rooms: { E26S49: colony.room, E26S48: claimedRoom },
       spawns: { Spawn1: spawn },
       creeps: {
-        RemoteUpgrader: makePostClaimSustainUpgrader('E26S48')
+        RemoteUpgrader: makePostClaimSustainUpgrader('E26S48', 'E26S49')
       },
       getObjectById: jest.fn().mockReturnValue(null)
     };

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -7948,7 +7948,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'spawn-site1' });
   });
 
-  it('keeps a dedicated claimed-room controller sustainer on upgrading before spawn construction', () => {
+  it('uses dedicated claimed-room sustain energy on construction before controller upgrade', () => {
     const controller = { id: 'controller2', my: true, level: 1 } as StructureController;
     const site = { id: 'spawn-site1', structureType: 'spawn' } as ConstructionSite;
     const creep = {
@@ -7968,7 +7968,7 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
     (creep.room as Room & { name: string }).name = 'W2N1';
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller2' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'spawn-site1' });
   });
 
   it('does not spend dedicated controller sustain energy on a maxed controller', () => {


### PR DESCRIPTION
Implements E26S48 source harvesting and inter-room energy logistics for the claimed adjacent room.

## Changes
- Updated worker tasks with source harvesting target selection for E26S48
- Inter-room energy logistics: haulers can move energy from E26S49 to E26S48 construction sites
- Tests: economyLoop, spawnPlanner, workerTasks

Fixes #814
