### PR TITLE
feat(economy): multi-room spawn queue balancing and worker creep distribution across colonies

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -25100,6 +25100,7 @@ function getRoomCreepBudget(colony, roleCounts) {
   const workerDeficit = Math.max(0, workerTarget - workerCapacity);
   return {
     roomName: colony.room.name,
+    constructionSiteCount: getVisibleConstructionSiteCount(colony.room),
     controllerLevel: getControllerLevel2(colony.room.controller),
     energyAvailable: normalizeNonNegativeInteger9(colony.energyAvailable),
     energyCapacityAvailable: normalizeNonNegativeInteger9(colony.energyCapacityAvailable),
@@ -25111,7 +25112,8 @@ function getRoomCreepBudget(colony, roleCounts) {
     workerTarget,
     workerDeficit,
     priority: selectRoomSpawnPriority(survival, workerDeficit),
-    reservedSpawnEnergy: forecast.reservedEnergy
+    reservedSpawnEnergy: forecast.reservedEnergy,
+    sourceCount: getSourceCount(colony.room)
   };
 }
 function buildSpawnQueue(context) {
@@ -26113,7 +26115,10 @@ function getVisibleRoom7(roomName) {
 function compareColoniesForSpawnPlanning(left, right, roleCountsByRoom) {
   const leftBudget = getRoomCreepBudget(left, getRoleCountsForSpawnPlanning(left, roleCountsByRoom));
   const rightBudget = getRoomCreepBudget(right, getRoleCountsForSpawnPlanning(right, roleCountsByRoom));
-  return getRoomSpawnPriorityRank(leftBudget.priority) - getRoomSpawnPriorityRank(rightBudget.priority) || rightBudget.workerDeficit - leftBudget.workerDeficit || getOperationalSpawnRank(rightBudget) - getOperationalSpawnRank(leftBudget) || getNoSpawnRoomOrdering(leftBudget, rightBudget) || leftBudget.controllerLevel - rightBudget.controllerLevel || getEnergyGateRank(rightBudget.energyGate) - getEnergyGateRank(leftBudget.energyGate) || rightBudget.effectiveEnergyAvailable - leftBudget.effectiveEnergyAvailable || right.energyAvailable - left.energyAvailable || left.room.name.localeCompare(right.room.name);
+  return getRoomSpawnPriorityRank(leftBudget.priority) - getRoomSpawnPriorityRank(rightBudget.priority) || rightBudget.workerDeficit - leftBudget.workerDeficit || getSpawnlessWorkerRecoveryRank(rightBudget) - getSpawnlessWorkerRecoveryRank(leftBudget) || rightBudget.constructionSiteCount - leftBudget.constructionSiteCount || rightBudget.sourceCount - leftBudget.sourceCount || getOperationalSpawnRank(rightBudget) - getOperationalSpawnRank(leftBudget) || getNoSpawnRoomOrdering(leftBudget, rightBudget) || leftBudget.controllerLevel - rightBudget.controllerLevel || getEnergyGateRank(rightBudget.energyGate) - getEnergyGateRank(leftBudget.energyGate) || rightBudget.effectiveEnergyAvailable - leftBudget.effectiveEnergyAvailable || right.energyAvailable - left.energyAvailable || left.room.name.localeCompare(right.room.name);
+}
+function getSpawnlessWorkerRecoveryRank(budget) {
+  return budget.ownedSpawnCount === 0 && budget.workerDeficit > 0 ? 1 : 0;
 }
 function getOperationalSpawnRank(budget) {
   return budget.ownedSpawnCount > 0 ? 1 : 0;
@@ -26147,11 +26152,11 @@ function isRoleCountsMap(value) {
   return typeof value.get === "function";
 }
 function selectRoomSpawnPriority(survival, workerDeficit) {
-  if (survival.mode === "BOOTSTRAP" && hasEmergencyBootstrapCreepShortfall(survival)) {
-    return "emergencyBootstrap";
-  }
   if (survival.hostilePresence) {
     return "defense";
+  }
+  if (survival.mode === "BOOTSTRAP" && hasEmergencyBootstrapCreepShortfall(survival)) {
+    return "emergencyBootstrap";
   }
   if (survival.controllerDowngradeGuard) {
     return "controllerDowngradeGuard";
@@ -26163,9 +26168,9 @@ function selectRoomSpawnPriority(survival, workerDeficit) {
 }
 function getRoomSpawnPriorityRank(priority) {
   switch (priority) {
-    case "emergencyBootstrap":
-      return 0;
     case "defense":
+      return 0;
+    case "emergencyBootstrap":
       return 1;
     case "controllerDowngradeGuard":
       return 2;
@@ -26227,6 +26232,22 @@ function findRoomObjects17(room, globalName) {
   } catch {
     return [];
   }
+}
+function getVisibleConstructionSiteCount(room) {
+  const constructionSites = [
+    ...findRoomObjects17(room, "FIND_MY_CONSTRUCTION_SITES"),
+    ...findRoomObjects17(room, "FIND_CONSTRUCTION_SITES").filter((site) => site.my !== false)
+  ];
+  const seenIds = /* @__PURE__ */ new Set();
+  let anonymousSiteCount = 0;
+  for (const site of constructionSites) {
+    if (typeof site.id !== "string" || site.id.length === 0) {
+      anonymousSiteCount += 1;
+      continue;
+    }
+    seenIds.add(site.id);
+  }
+  return seenIds.size + anonymousSiteCount;
 }
 function getGlobalNumber10(name) {
   const value = globalThis[name];
@@ -36155,6 +36176,7 @@ function isRecord32(value) {
 
 // src/economy/economyLoop.ts
 var ERR_BUSY_CODE = -4;
+var ERR_NO_PATH_CODE8 = -2;
 var OK_CODE17 = 0;
 var BOOTSTRAP_WORKER_BUFFER_BYPASS_MIN_ENERGY = 300;
 function runEconomy(preludeTelemetryEvents = []) {
@@ -36557,7 +36579,7 @@ function getCoordinatedSpawnSourceColonies(targetColony, colonies, creeps, usedS
       plannedRoleCountsByRoom
     )
   ).sort(
-    (left, right) => compareCoordinatedSpawnSources(left, right, reservedSpawnEnergyByRoom)
+    (left, right) => compareCoordinatedSpawnSources(left, right, targetColony, reservedSpawnEnergyByRoom)
   );
   return localSource ? [localSource, ...remoteSources] : remoteSources;
 }
@@ -36587,8 +36609,31 @@ function canUseCrossRoomSpawnSource(sourceColony, creeps, usedSpawnsByRoom, rese
   const survival = assessColonySnapshotSurvival(sourceColony, roleCounts);
   return survival.mode === "TERRITORY_READY" && !survival.controllerDowngradeGuard && !survival.hostilePresence;
 }
-function compareCoordinatedSpawnSources(left, right, reservedSpawnEnergyByRoom) {
-  return getAvailableSpawnEnergy(right, reservedSpawnEnergyByRoom) - getAvailableSpawnEnergy(left, reservedSpawnEnergyByRoom) || normalizeNonNegativeInteger15(right.energyCapacityAvailable) - normalizeNonNegativeInteger15(left.energyCapacityAvailable) || left.room.name.localeCompare(right.room.name);
+function compareCoordinatedSpawnSources(left, right, targetColony, reservedSpawnEnergyByRoom) {
+  return getCrossRoomSpawnRouteDistance(left.room.name, targetColony.room.name) - getCrossRoomSpawnRouteDistance(right.room.name, targetColony.room.name) || getAvailableSpawnEnergy(right, reservedSpawnEnergyByRoom) - getAvailableSpawnEnergy(left, reservedSpawnEnergyByRoom) || normalizeNonNegativeInteger15(right.energyCapacityAvailable) - normalizeNonNegativeInteger15(left.energyCapacityAvailable) || left.room.name.localeCompare(right.room.name);
+}
+function getCrossRoomSpawnRouteDistance(sourceRoomName, targetRoomName) {
+  var _a;
+  if (sourceRoomName === targetRoomName) {
+    return 0;
+  }
+  const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
+  if (typeof (gameMap == null ? void 0 : gameMap.findRoute) === "function") {
+    const route = gameMap.findRoute.call(gameMap, sourceRoomName, targetRoomName);
+    if (Array.isArray(route)) {
+      return route.length;
+    }
+    if (route === ERR_NO_PATH_CODE8) {
+      return Number.POSITIVE_INFINITY;
+    }
+  }
+  if (typeof (gameMap == null ? void 0 : gameMap.getRoomLinearDistance) === "function") {
+    const distance = gameMap.getRoomLinearDistance.call(gameMap, sourceRoomName, targetRoomName);
+    if (typeof distance === "number" && Number.isFinite(distance)) {
+      return Math.max(0, Math.floor(distance));
+    }
+  }
+  return Number.POSITIVE_INFINITY;
 }
 function getUnusedSpawnCount(colony, usedSpawnsByRoom) {
   var _a;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -36610,7 +36610,24 @@ function canUseCrossRoomSpawnSource(sourceColony, creeps, usedSpawnsByRoom, rese
   return survival.mode === "TERRITORY_READY" && !survival.controllerDowngradeGuard && !survival.hostilePresence;
 }
 function compareCoordinatedSpawnSources(left, right, targetColony, reservedSpawnEnergyByRoom) {
-  return getCrossRoomSpawnRouteDistance(left.room.name, targetColony.room.name) - getCrossRoomSpawnRouteDistance(right.room.name, targetColony.room.name) || getAvailableSpawnEnergy(right, reservedSpawnEnergyByRoom) - getAvailableSpawnEnergy(left, reservedSpawnEnergyByRoom) || normalizeNonNegativeInteger15(right.energyCapacityAvailable) - normalizeNonNegativeInteger15(left.energyCapacityAvailable) || left.room.name.localeCompare(right.room.name);
+  return compareSpawnSourceRouteDistances(
+    getCrossRoomSpawnRouteDistance(left.room.name, targetColony.room.name),
+    getCrossRoomSpawnRouteDistance(right.room.name, targetColony.room.name)
+  ) || getAvailableSpawnEnergy(right, reservedSpawnEnergyByRoom) - getAvailableSpawnEnergy(left, reservedSpawnEnergyByRoom) || normalizeNonNegativeInteger15(right.energyCapacityAvailable) - normalizeNonNegativeInteger15(left.energyCapacityAvailable) || left.room.name.localeCompare(right.room.name);
+}
+function compareSpawnSourceRouteDistances(leftDistance, rightDistance) {
+  if (leftDistance === rightDistance) {
+    return 0;
+  }
+  const leftFinite = Number.isFinite(leftDistance);
+  const rightFinite = Number.isFinite(rightDistance);
+  if (!leftFinite || !rightFinite) {
+    if (!leftFinite && !rightFinite) {
+      return 0;
+    }
+    return leftFinite ? -1 : 1;
+  }
+  return leftDistance < rightDistance ? -1 : 1;
 }
 function getCrossRoomSpawnRouteDistance(sourceRoomName, targetRoomName) {
   var _a;

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -108,6 +108,7 @@ import {
 } from '../strategy/strategyRecommender';
 
 const ERR_BUSY_CODE = -4 as ScreepsReturnCode;
+const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
 const OK_CODE = 0 as ScreepsReturnCode;
 const BOOTSTRAP_WORKER_BUFFER_BYPASS_MIN_ENERGY = 300;
 
@@ -646,7 +647,7 @@ function getCoordinatedSpawnSourceColonies(
       )
     )
     .sort((left, right) =>
-      compareCoordinatedSpawnSources(left, right, reservedSpawnEnergyByRoom)
+      compareCoordinatedSpawnSources(left, right, targetColony, reservedSpawnEnergyByRoom)
     );
 
   return localSource ? [localSource, ...remoteSources] : remoteSources;
@@ -699,15 +700,51 @@ function canUseCrossRoomSpawnSource(
 function compareCoordinatedSpawnSources(
   left: ColonySnapshot,
   right: ColonySnapshot,
+  targetColony: ColonySnapshot,
   reservedSpawnEnergyByRoom: Map<string, number>
 ): number {
   return (
+    getCrossRoomSpawnRouteDistance(left.room.name, targetColony.room.name) -
+      getCrossRoomSpawnRouteDistance(right.room.name, targetColony.room.name) ||
     getAvailableSpawnEnergy(right, reservedSpawnEnergyByRoom) -
       getAvailableSpawnEnergy(left, reservedSpawnEnergyByRoom) ||
     normalizeNonNegativeInteger(right.energyCapacityAvailable) -
       normalizeNonNegativeInteger(left.energyCapacityAvailable) ||
     left.room.name.localeCompare(right.room.name)
   );
+}
+
+function getCrossRoomSpawnRouteDistance(sourceRoomName: string, targetRoomName: string): number {
+  if (sourceRoomName === targetRoomName) {
+    return 0;
+  }
+
+  const gameMap = (globalThis as { Game?: Partial<Pick<Game, 'map'>> }).Game?.map as
+    | (Partial<GameMap> & {
+        findRoute?: (fromRoom: string, toRoom: string) => unknown;
+        getRoomLinearDistance?: (roomName1: string, roomName2: string) => number;
+      })
+    | undefined;
+
+  if (typeof gameMap?.findRoute === 'function') {
+    const route = gameMap.findRoute.call(gameMap, sourceRoomName, targetRoomName);
+    if (Array.isArray(route)) {
+      return route.length;
+    }
+
+    if (route === ERR_NO_PATH_CODE) {
+      return Number.POSITIVE_INFINITY;
+    }
+  }
+
+  if (typeof gameMap?.getRoomLinearDistance === 'function') {
+    const distance = gameMap.getRoomLinearDistance.call(gameMap, sourceRoomName, targetRoomName);
+    if (typeof distance === 'number' && Number.isFinite(distance)) {
+      return Math.max(0, Math.floor(distance));
+    }
+  }
+
+  return Number.POSITIVE_INFINITY;
 }
 
 function getUnusedSpawnCount(

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -704,14 +704,34 @@ function compareCoordinatedSpawnSources(
   reservedSpawnEnergyByRoom: Map<string, number>
 ): number {
   return (
-    getCrossRoomSpawnRouteDistance(left.room.name, targetColony.room.name) -
-      getCrossRoomSpawnRouteDistance(right.room.name, targetColony.room.name) ||
+    compareSpawnSourceRouteDistances(
+      getCrossRoomSpawnRouteDistance(left.room.name, targetColony.room.name),
+      getCrossRoomSpawnRouteDistance(right.room.name, targetColony.room.name)
+    ) ||
     getAvailableSpawnEnergy(right, reservedSpawnEnergyByRoom) -
       getAvailableSpawnEnergy(left, reservedSpawnEnergyByRoom) ||
     normalizeNonNegativeInteger(right.energyCapacityAvailable) -
       normalizeNonNegativeInteger(left.energyCapacityAvailable) ||
     left.room.name.localeCompare(right.room.name)
   );
+}
+
+export function compareSpawnSourceRouteDistances(leftDistance: number, rightDistance: number): number {
+  if (leftDistance === rightDistance) {
+    return 0;
+  }
+
+  const leftFinite = Number.isFinite(leftDistance);
+  const rightFinite = Number.isFinite(rightDistance);
+  if (!leftFinite || !rightFinite) {
+    if (!leftFinite && !rightFinite) {
+      return 0;
+    }
+
+    return leftFinite ? -1 : 1;
+  }
+
+  return leftDistance < rightDistance ? -1 : 1;
 }
 
 function getCrossRoomSpawnRouteDistance(sourceRoomName: string, targetRoomName: string): number {

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -160,6 +160,7 @@ export type SpawnPlanningRoomPriority =
 
 export interface RoomCreepBudget {
   roomName: string;
+  constructionSiteCount: number;
   controllerLevel: number;
   energyAvailable: number;
   energyCapacityAvailable: number;
@@ -172,6 +173,7 @@ export interface RoomCreepBudget {
   workerDeficit: number;
   priority: SpawnPlanningRoomPriority;
   reservedSpawnEnergy: number;
+  sourceCount: number;
 }
 
 export interface SpawnEnergyReservationCandidate {
@@ -380,6 +382,7 @@ export function getRoomCreepBudget(
 
   return {
     roomName: colony.room.name,
+    constructionSiteCount: getVisibleConstructionSiteCount(colony.room),
     controllerLevel: getControllerLevel(colony.room.controller),
     energyAvailable: normalizeNonNegativeInteger(colony.energyAvailable),
     energyCapacityAvailable: normalizeNonNegativeInteger(colony.energyCapacityAvailable),
@@ -391,7 +394,8 @@ export function getRoomCreepBudget(
     workerTarget,
     workerDeficit,
     priority: selectRoomSpawnPriority(survival, workerDeficit),
-    reservedSpawnEnergy: forecast.reservedEnergy
+    reservedSpawnEnergy: forecast.reservedEnergy,
+    sourceCount: getSourceCount(colony.room)
   };
 }
 
@@ -1934,6 +1938,9 @@ function compareColoniesForSpawnPlanning(
   return (
     getRoomSpawnPriorityRank(leftBudget.priority) - getRoomSpawnPriorityRank(rightBudget.priority) ||
     rightBudget.workerDeficit - leftBudget.workerDeficit ||
+    getSpawnlessWorkerRecoveryRank(rightBudget) - getSpawnlessWorkerRecoveryRank(leftBudget) ||
+    rightBudget.constructionSiteCount - leftBudget.constructionSiteCount ||
+    rightBudget.sourceCount - leftBudget.sourceCount ||
     getOperationalSpawnRank(rightBudget) - getOperationalSpawnRank(leftBudget) ||
     getNoSpawnRoomOrdering(leftBudget, rightBudget) ||
     leftBudget.controllerLevel - rightBudget.controllerLevel ||
@@ -1942,6 +1949,10 @@ function compareColoniesForSpawnPlanning(
     right.energyAvailable - left.energyAvailable ||
     left.room.name.localeCompare(right.room.name)
   );
+}
+
+function getSpawnlessWorkerRecoveryRank(budget: RoomCreepBudget): number {
+  return budget.ownedSpawnCount === 0 && budget.workerDeficit > 0 ? 1 : 0;
 }
 
 function getOperationalSpawnRank(budget: RoomCreepBudget): number {
@@ -1996,12 +2007,12 @@ function selectRoomSpawnPriority(
   survival: ColonySurvivalAssessment,
   workerDeficit: number
 ): SpawnPlanningRoomPriority {
-  if (survival.mode === 'BOOTSTRAP' && hasEmergencyBootstrapCreepShortfall(survival)) {
-    return 'emergencyBootstrap';
-  }
-
   if (survival.hostilePresence) {
     return 'defense';
+  }
+
+  if (survival.mode === 'BOOTSTRAP' && hasEmergencyBootstrapCreepShortfall(survival)) {
+    return 'emergencyBootstrap';
   }
 
   if (survival.controllerDowngradeGuard) {
@@ -2017,9 +2028,9 @@ function selectRoomSpawnPriority(
 
 function getRoomSpawnPriorityRank(priority: SpawnPlanningRoomPriority): number {
   switch (priority) {
-    case 'emergencyBootstrap':
-      return 0;
     case 'defense':
+      return 0;
+    case 'emergencyBootstrap':
       return 1;
     case 'controllerDowngradeGuard':
       return 2;
@@ -2094,6 +2105,26 @@ function findRoomObjects<T>(room: Room, globalName: string): T[] {
   } catch {
     return [];
   }
+}
+
+function getVisibleConstructionSiteCount(room: Room): number {
+  const constructionSites = [
+    ...findRoomObjects<ConstructionSite>(room, 'FIND_MY_CONSTRUCTION_SITES'),
+    ...findRoomObjects<ConstructionSite>(room, 'FIND_CONSTRUCTION_SITES').filter((site) => site.my !== false)
+  ];
+  const seenIds = new Set<string>();
+  let anonymousSiteCount = 0;
+
+  for (const site of constructionSites) {
+    if (typeof site.id !== 'string' || site.id.length === 0) {
+      anonymousSiteCount += 1;
+      continue;
+    }
+
+    seenIds.add(site.id);
+  }
+
+  return seenIds.size + anonymousSiteCount;
 }
 
 function getGlobalNumber(name: string): number | undefined {

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -3026,6 +3026,156 @@ describe('runEconomy', () => {
     );
   });
 
+  it('spawns a cross-room worker for spawnless E26S48 when claimed sources and containers are visible', () => {
+    installMultiRoomSpawnQueueGlobals();
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    const homeRoom = makeSpawnCoordinationRoom({
+      roomName: 'E26S49',
+      energyAvailable: 950,
+      energyCapacityAvailable: 950
+    });
+    const claimedRoom = makeClaimedSpawnlessEconomyRoom({ roomName: 'E26S48', sourceCount: 2 });
+    const spawn = {
+      name: 'Spawn1',
+      room: homeRoom,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 818,
+      rooms: { E26S49: homeRoom, E26S48: claimedRoom },
+      spawns: { Spawn1: spawn },
+      creeps: {
+        Worker1: makeEconomyWorker(homeRoom),
+        Worker2: makeEconomyWorker(homeRoom),
+        Worker3: makeEconomyWorker(homeRoom)
+      },
+      map: {
+        findRoute: jest.fn((_fromRoom: string, toRoom: string) => [{ exit: 1, room: toRoom }])
+      } as unknown as GameMap
+    };
+
+    runEconomy();
+
+    expect(spawn.spawnCreep).toHaveBeenCalledWith(['work', 'carry', 'move'], 'worker-E26S48-818', {
+      memory: {
+        role: 'worker',
+        colony: 'E26S48',
+        spawnSupport: { originRoom: 'E26S49', targetRoom: 'E26S48' }
+      }
+    });
+  });
+
+  it('keeps E26S49 defender spawning ahead of E26S48 economic recovery', () => {
+    installMultiRoomSpawnQueueGlobals();
+    const hostile = { id: 'hostile1' } as Creep;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    const baseHomeRoom = makeSpawnCoordinationRoom({
+      roomName: 'E26S49',
+      energyAvailable: 950,
+      energyCapacityAvailable: 950
+    });
+    const homeFind = baseHomeRoom.find as (type: number) => unknown[];
+    const homeRoom = {
+      ...baseHomeRoom,
+      find: jest.fn((type: number) => (type === FIND_HOSTILE_CREEPS ? [hostile] : homeFind(type)))
+    } as unknown as Room;
+    const claimedRoom = makeClaimedSpawnlessEconomyRoom({ roomName: 'E26S48', sourceCount: 2 });
+    const spawn = {
+      name: 'Spawn1',
+      room: homeRoom,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 819,
+      rooms: { E26S49: homeRoom, E26S48: claimedRoom },
+      spawns: { Spawn1: spawn },
+      creeps: {
+        Worker1: makeEconomyWorker(homeRoom),
+        Worker2: makeEconomyWorker(homeRoom),
+        Worker3: makeEconomyWorker(homeRoom)
+      },
+      map: {
+        findRoute: jest.fn((_fromRoom: string, toRoom: string) => [{ exit: 1, room: toRoom }])
+      } as unknown as GameMap
+    };
+
+    runEconomy();
+
+    expect(spawn.spawnCreep).toHaveBeenCalledTimes(1);
+    expect(spawn.spawnCreep).toHaveBeenCalledWith(['tough', 'attack', 'move'], 'defender-E26S49-819', {
+      memory: {
+        role: 'defender',
+        colony: 'E26S49',
+        defense: { homeRoom: 'E26S49' }
+      }
+    });
+  });
+
+  it('uses the nearest viable spawn room for a spawnless colony worker deficit', () => {
+    installMultiRoomSpawnQueueGlobals();
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    const targetRoom = makeClaimedSpawnlessEconomyRoom({ roomName: 'E26S48', sourceCount: 1 });
+    const nearRoom = makeSpawnCoordinationRoom({
+      roomName: 'E26S49',
+      energyAvailable: 950,
+      energyCapacityAvailable: 950
+    });
+    const farRoom = makeSpawnCoordinationRoom({
+      roomName: 'W9N9',
+      energyAvailable: 1300,
+      energyCapacityAvailable: 1300,
+      controllerLevel: 8
+    });
+    const nearSpawn = {
+      name: 'NearSpawn',
+      room: nearRoom,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const farSpawn = {
+      name: 'FarSpawn',
+      room: farRoom,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 820,
+      rooms: { E26S48: targetRoom, W9N9: farRoom, E26S49: nearRoom },
+      spawns: { FarSpawn: farSpawn, NearSpawn: nearSpawn },
+      creeps: {
+        TargetWorker1: makeEconomyWorker(targetRoom),
+        TargetWorker2: makeEconomyWorker(targetRoom),
+        NearWorker1: makeEconomyWorker(nearRoom),
+        NearWorker2: makeEconomyWorker(nearRoom),
+        NearWorker3: makeEconomyWorker(nearRoom),
+        FarWorker1: makeEconomyWorker(farRoom),
+        FarWorker2: makeEconomyWorker(farRoom),
+        FarWorker3: makeEconomyWorker(farRoom)
+      },
+      map: {
+        findRoute: jest.fn((fromRoom: string, toRoom: string) =>
+          Array.from(
+            { length: fromRoom === 'E26S49' ? 1 : 5 },
+            (_value, index) => ({ exit: 1, room: index === 0 ? toRoom : `transit${index}` })
+          )
+        )
+      } as unknown as GameMap
+    };
+
+    runEconomy();
+
+    expect(nearSpawn.spawnCreep).toHaveBeenCalledWith(['work', 'carry', 'move'], 'worker-E26S48-820', {
+      memory: {
+        role: 'worker',
+        colony: 'E26S48',
+        spawnSupport: { originRoom: 'E26S49', targetRoom: 'E26S48' }
+      }
+    });
+    expect(farSpawn.spawnCreep).not.toHaveBeenCalled();
+  });
+
   it('refreshes remote mining setup for claimed expansion rooms during the economy tick', () => {
     (globalThis as unknown as {
       FIND_SOURCES: number;
@@ -3451,6 +3601,21 @@ function installSpawnCoordinationGlobals(): void {
   (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
 }
 
+function installMultiRoomSpawnQueueGlobals(): void {
+  installSpawnCoordinationGlobals();
+  (globalThis as unknown as {
+    FIND_STRUCTURES: number;
+    FIND_HOSTILE_CREEPS: number;
+    RESOURCE_ENERGY: ResourceConstant;
+    STRUCTURE_CONTAINER: StructureConstant;
+    STRUCTURE_SPAWN: StructureConstant;
+  }).FIND_STRUCTURES = 5;
+  (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 6;
+  (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+  (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+  (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
+}
+
 function makeSpawnCoordinationRoom({
   roomName,
   energyAvailable,
@@ -3475,6 +3640,70 @@ function makeSpawnCoordinationRoom({
     } as StructureController,
     memory: {},
     find: jest.fn((type: number) => (type === FIND_SOURCES ? [{ id: `${roomName}-source` } as Source] : []))
+  } as unknown as Room;
+}
+
+function makeClaimedSpawnlessEconomyRoom({
+  roomName,
+  sourceCount,
+  energyAvailable = 0,
+  energyCapacityAvailable = 0
+}: {
+  roomName: string;
+  sourceCount: number;
+  energyAvailable?: number;
+  energyCapacityAvailable?: number;
+}): Room {
+  const sources = Array.from(
+    { length: sourceCount },
+    (_value, index) =>
+      ({
+        id: `${roomName}-source-${index}`,
+        pos: { x: 10 + index * 5, y: 10 + index * 5, roomName } as RoomPosition
+      }) as Source
+  );
+  const containers = sources.map(
+    (source, index) =>
+      ({
+        id: `${roomName}-container-${index}`,
+        structureType: 'container',
+        pos: { x: source.pos.x, y: source.pos.y + 1, roomName } as RoomPosition,
+        store: makeEnergyStore(200, 2_000)
+      }) as StructureContainer
+  );
+  const constructionSites: ConstructionSite[] = [];
+
+  return {
+    name: roomName,
+    energyAvailable,
+    energyCapacityAvailable,
+    controller: {
+      id: `${roomName}-controller`,
+      my: true,
+      owner: { username: 'me' },
+      level: 2,
+      ticksToDowngrade: 10_000
+    } as StructureController,
+    memory: {},
+    find: jest.fn((type: number) => {
+      if (type === FIND_SOURCES) {
+        return sources;
+      }
+
+      if (type === FIND_STRUCTURES) {
+        return containers;
+      }
+
+      if (type === FIND_MY_CONSTRUCTION_SITES || type === FIND_CONSTRUCTION_SITES) {
+        return constructionSites;
+      }
+
+      if (type === FIND_HOSTILE_CREEPS) {
+        return [];
+      }
+
+      return [];
+    })
   } as unknown as Room;
 }
 

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -1,4 +1,4 @@
-import { runEconomy } from '../src/economy/economyLoop';
+import { compareSpawnSourceRouteDistances, runEconomy } from '../src/economy/economyLoop';
 import { SPAWN_ENERGY_RESERVATION_IDLE_RELEASE_TICKS } from '../src/economy/spawnEnergyReservation';
 import { MIN_SPAWN_ENERGY_BUFFER } from '../src/spawn/spawnConfig';
 import { CONTROLLER_DOWNGRADE_GUARD_TICKS } from '../src/tasks/workerTasks';
@@ -27,6 +27,26 @@ describe('runEconomy', () => {
 
   afterEach(() => {
     logSpy.mockRestore();
+  });
+
+  it('keeps spawn source route sorting numeric when unreachable routes compare', () => {
+    const comparisons: number[] = [];
+    const sortedSources = [
+      { roomName: 'W2N1', distance: Number.POSITIVE_INFINITY, availableEnergy: 650 },
+      { roomName: 'W3N1', distance: Number.POSITIVE_INFINITY, availableEnergy: 950 }
+    ].sort((left, right) => {
+      const routeComparison = compareSpawnSourceRouteDistances(left.distance, right.distance);
+      comparisons.push(routeComparison);
+      return (
+        routeComparison ||
+        right.availableEnergy - left.availableEnergy ||
+        left.roomName.localeCompare(right.roomName)
+      );
+    });
+
+    expect(comparisons).toContain(0);
+    expect(comparisons.every(Number.isFinite)).toBe(true);
+    expect(sortedSources.map((source) => source.roomName)).toEqual(['W3N1', 'W2N1']);
   });
 
   it('spawns a worker request for an owned colony below target workers', () => {

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -1125,6 +1125,63 @@ describe('planSpawn', () => {
     ).toEqual(['W1N17', 'W2N17']);
   });
 
+  it('orders threatened rooms ahead of spawnless economic recovery', () => {
+    installHostileFindGlobals();
+    const hostile = { id: 'hostile1' } as Creep;
+    const { colony: threatenedColony } = makeColony({
+      roomName: 'E26S49',
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      hostileCreeps: [hostile],
+      controller: makeSafeOwnedController()
+    });
+    const { colony: spawnlessRecoveryColony } = makeColony({
+      roomName: 'E26S48',
+      energyAvailable: 300,
+      energyCapacityAvailable: 300,
+      controller: { my: true, level: 2, ticksToDowngrade: 10_000 } as StructureController
+    });
+    spawnlessRecoveryColony.spawns = [];
+
+    expect(
+      orderColoniesForSpawnPlanning(
+        [spawnlessRecoveryColony, threatenedColony],
+        new Map([
+          ['E26S49', { worker: 3 }],
+          ['E26S48', { worker: 0 }]
+        ])
+      ).map((colony) => colony.room.name)
+    ).toEqual(['E26S49', 'E26S48']);
+  });
+
+  it('uses construction and source pressure as multi-room ordering tie breakers', () => {
+    const { colony: constructionColony } = makeColony({
+      roomName: 'W1N18',
+      sourceCount: 2,
+      constructionSiteCount: 3,
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+    const { colony: idleColony } = makeColony({
+      roomName: 'W2N18',
+      sourceCount: 1,
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+
+    expect(
+      orderColoniesForSpawnPlanning(
+        [idleColony, constructionColony],
+        new Map([
+          ['W1N18', { worker: 5 }],
+          ['W2N18', { worker: 5 }]
+        ])
+      ).map((colony) => colony.room.name)
+    ).toEqual(['W1N18', 'W2N18']);
+  });
+
   it('plans a steady dedicated upgrader when stable room buffers can fund it', () => {
     const { colony, spawn } = makeColony({
       roomName: 'W1N17',


### PR DESCRIPTION
Closes #818

## Summary
Multi-room spawn queue balancing and worker creep distribution across colonies (E26S49 primary + E26S48 claimed).

## Changes
- `economyLoop.ts`: Multi-room spawn priority scoring integration
- `spawnPlanner.ts`: Holistic spawn queue that considers both E26S49 and E26S48 room states
- Tests: economyLoop multi-room spawn decisions, spawnPlanner cross-room spawning

## Verification
- typecheck: PASS
- Jest: 1571/1571 pass
- build: PASS
- Commit author: lanyusea's bot <lanyusea@gmail.com>
