### PR TITLE
fix: HTML-decode console capture payloads before JSON parse (#822)

### DIFF
--- a/scripts/screeps_runtime_kpi_reducer.py
+++ b/scripts/screeps_runtime_kpi_reducer.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import html
 import json
 import sys
 from dataclasses import dataclass, field
@@ -116,7 +117,7 @@ def parse_runtime_summary_line(line: str) -> tuple[JsonObject | None, bool]:
         return None, saw_prefix
 
     try:
-        payload = json.loads(payload_text)
+        payload = json.loads(html.unescape(payload_text))
     except json.JSONDecodeError:
         return None, saw_prefix
 


### PR DESCRIPTION
## Summary
- Adds `import html` and wraps `json.loads(payload_text)` with `html.unescape()` in the KPI reducer
- Fixes issue where HTML-encoded console capture payloads (e.g., `&amp;` for `&`) fail JSON parsing
- Two-line change in `scripts/screeps_runtime_kpi_reducer.py`

## Linked issue
Fixes #822

## Verification
- [x] `python3 -m py_compile scripts/screeps_runtime_kpi_reducer.py`
- [x] `python3 -m unittest scripts/test_screeps_runtime_kpi_reducer.py` (7 tests)
- [x] Manual HTML unescape + JSON parse verification
- [x] `git diff --check --staged`

## Notes
- Scripts-only change; no `prod/` code changed.
- No secrets included.