### PR TITLE
fix(rl): skip monitor captures in KPI artifact bridge to prevent dataset contamination

### DIFF
--- a/scripts/screeps_runtime_kpi_artifact_bridge.py
+++ b/scripts/screeps_runtime_kpi_artifact_bridge.py
@@ -106,9 +106,18 @@ def iter_directory_files(root: Path, result: ScanResult) -> list[Path]:
     return sorted(files, key=lambda path: str(path))
 
 
+# Files from the external runtime monitor contain a separate summary format with
+# zero-valued energy fields.  Skip them so RL datasets are not contaminated.
+_MONITOR_FILE_PREFIX = "runtime-summary-monitor-"
+
+
 def scan_file(path: Path, result: ScanResult, max_file_bytes: int) -> None:
     if path.is_symlink():
         result.skip(path, "symlink")
+        return
+
+    if path.name.startswith(_MONITOR_FILE_PREFIX):
+        result.skip(path, "monitor_source")
         return
 
     try:


### PR DESCRIPTION
Monitor captures (runtime-summary-monitor-*) contain a separate summary format with zero-valued energy fields. When the bridge scanned default paths, 1,548 monitor captures overwhelmed 21 console captures, causing storedEnergy and workerCarriedEnergy to appear as zero in RL datasets.

This adds a filename-prefix guard in `scan_file()` so monitor-source captures are skipped before their `#runtime-summary` lines are collected. Console captures (`runtime-summary-console-*`) are unaffected.

**Verification:**
- Default scan: 103,248 files → 21 console-only matches → storedEnergy=300, workerCarriedEnergy=38 (non-zero) ✅
- Console-only scan: 21 files → same output ✅
- 14/14 unit tests PASS (reducer + bridge) ✅
- py_compile: PASS ✅

**Why this matters for RL:** The RL flywheel needs accurate energy telemetry to train strategy models. Monitor contamination with zero-valued fields would produce invalid training data.
