### PR TITLE
feat(territory): add colony upgrade priority selection for multi-room controller optimization (#856)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -29379,11 +29379,11 @@ function selectPostClaimControllerSustainPlan(colony) {
     if (((_a = targetRoom == null ? void 0 : targetRoom.controller) == null ? void 0 : _a.my) !== true) {
       continue;
     }
-    const hasOperationalSpawn = hasOperationalSpawnInRoom(record.roomName);
+    const hasOperationalSpawn2 = hasOperationalSpawnInRoom(record.roomName);
     const counts = countPostClaimControllerSustainCreeps(record.roomName);
     const workerTarget = getPostClaimControllerSustainWorkerTarget(record);
     const controllerId = getPostClaimControllerSustainControllerId(record, targetRoom);
-    if (!hasOperationalSpawn) {
+    if (!hasOperationalSpawn2) {
       if (counts.upgraders < POST_CLAIM_SUSTAIN_UPGRADER_TARGET) {
         return { targetRoom: record.roomName, role: "upgrader", ...controllerId ? { controllerId } : {} };
       }
@@ -29717,7 +29717,7 @@ function planControllerUpgradeSurplusSpawn(context) {
   return planWorkerSpawn(context.colony, context.roleCounts, context.gameTime, context.options);
 }
 function planControllerUpgradeDemandSpawn(context) {
-  if (context.territoryIntentPending || context.survival.mode === "BOOTSTRAP" || context.survival.hostilePresence || hasControllerUpgradeBlockingTerritoryWork(context.colony) || context.workerCapacity > 0 && shouldSuppressWorkerSpawnForCrossRoomImport(context.colony)) {
+  if (context.territoryIntentPending || !isSelectedControllerUpgradeTarget(context) || context.survival.mode === "BOOTSTRAP" || context.survival.hostilePresence || hasControllerUpgradeBlockingTerritoryWork(context.colony) || context.workerCapacity > 0 && shouldSuppressWorkerSpawnForCrossRoomImport(context.colony)) {
     return null;
   }
   const demand = selectControllerUpgradeSpawnDemand(
@@ -29756,10 +29756,12 @@ function hasVisibleControllerUpgradeConstructionDemand(room) {
   return findRoomObjects21(room, "FIND_MY_CONSTRUCTION_SITES").length > 0 || findRoomObjects21(room, "FIND_CONSTRUCTION_SITES").filter((site) => site.my !== false).length > 0;
 }
 function planMultiRoomControllerUpgradeSpawn(context) {
-  if (context.options.workersOnly || context.territoryIntentPending || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || context.workerCapacity < context.workerTarget || context.colony.energyAvailable < context.colony.energyCapacityAvailable) {
+  if (context.options.workersOnly || context.territoryIntentPending || context.options.controllerUpgradeTargetRoom === null || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || context.workerCapacity < context.workerTarget || context.colony.energyAvailable < context.colony.energyCapacityAvailable) {
     return null;
   }
-  const upgradePlans = selectMultiRoomUpgradePlans(context.colony);
+  const upgradePlans = selectMultiRoomUpgradePlans(context.colony).filter(
+    (plan) => context.options.controllerUpgradeTargetRoom === void 0 || plan.targetRoom === context.options.controllerUpgradeTargetRoom
+  );
   if (upgradePlans.length === 0) {
     return null;
   }
@@ -29793,6 +29795,10 @@ function shouldSpawnControllerUpgradeSurplusWorker(context) {
     context.workerTarget + CONTROLLER_UPGRADE_SURPLUS_WORKER_BONUS
   );
   return context.workerCapacity < surplusWorkerTarget;
+}
+function isSelectedControllerUpgradeTarget(context) {
+  const targetRoom = context.options.controllerUpgradeTargetRoom;
+  return targetRoom === void 0 || targetRoom === context.colony.room.name;
 }
 function hasControllerUpgradeSurplusEnergy(colony) {
   return colony.energyCapacityAvailable >= CONTROLLER_UPGRADE_SURPLUS_MIN_ENERGY_CAPACITY && colony.energyAvailable >= colony.energyCapacityAvailable;
@@ -38655,6 +38661,85 @@ function refreshReserveExecutionTargets(options = {}) {
   return refreshTerritoryExecutionTargets("reserve", options);
 }
 
+// src/territory/colonyUpgradePriority.ts
+var MAX_CONTROLLER_LEVEL6 = 8;
+function selectColonyUpgradeTarget(colonies) {
+  var _a, _b;
+  const candidates = colonies.flatMap((colony) => {
+    const candidate = buildColonyUpgradeCandidate(colony);
+    return candidate && candidate.workerCount > 0 ? [candidate] : [];
+  });
+  return (_b = (_a = candidates.sort(compareColonyUpgradeCandidates)[0]) == null ? void 0 : _a.colony) != null ? _b : null;
+}
+function buildColonyUpgradeCandidate(colony) {
+  const controller = colony.room.controller;
+  if (!canUpgradeOwnedController(controller)) {
+    return null;
+  }
+  return {
+    colony,
+    roomName: colony.room.name,
+    remainingProgress: getControllerRemainingProgress(controller),
+    progress: getControllerProgress(controller),
+    roleRank: getColonyRoleRank(colony),
+    workerCount: countAvailableWorkers(colony.room.name)
+  };
+}
+function compareColonyUpgradeCandidates(left, right) {
+  return left.remainingProgress - right.remainingProgress || right.progress - left.progress || left.roleRank - right.roleRank || right.workerCount - left.workerCount || left.roomName.localeCompare(right.roomName);
+}
+function canUpgradeOwnedController(controller) {
+  return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && Number.isFinite(controller.level) && controller.level < MAX_CONTROLLER_LEVEL6;
+}
+function getControllerRemainingProgress(controller) {
+  const progressTotal = getControllerProgressTotal(controller);
+  if (progressTotal <= 0) {
+    return Number.POSITIVE_INFINITY;
+  }
+  return Math.max(0, progressTotal - getControllerProgress(controller));
+}
+function getControllerProgress(controller) {
+  return normalizeNonNegativeNumber5(controller.progress);
+}
+function getControllerProgressTotal(controller) {
+  return normalizeNonNegativeNumber5(controller.progressTotal);
+}
+function getColonyRoleRank(colony) {
+  return hasOperationalSpawn(colony) ? 1 : 0;
+}
+function hasOperationalSpawn(colony) {
+  return colony.spawns.some((spawn) => {
+    if (!spawn) {
+      return false;
+    }
+    if (typeof spawn.isActive === "function") {
+      return spawn.isActive();
+    }
+    return true;
+  });
+}
+function countAvailableWorkers(roomName) {
+  var _a;
+  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
+  if (!creeps) {
+    return 0;
+  }
+  return Object.values(creeps).filter((creep) => isAvailableWorkerForRoom(creep, roomName)).length;
+}
+function isAvailableWorkerForRoom(creep, roomName) {
+  var _a, _b;
+  if (creep.ticksToLive !== void 0 && creep.ticksToLive <= WORKER_REPLACEMENT_TICKS_TO_LIVE) {
+    return false;
+  }
+  if (((_a = creep.memory) == null ? void 0 : _a.role) !== "worker") {
+    return false;
+  }
+  return creep.memory.colony === roomName || ((_b = creep.memory.controllerSustain) == null ? void 0 : _b.targetRoom) === roomName;
+}
+function normalizeNonNegativeNumber5(value) {
+  return typeof value === "number" && Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
 // src/strategy/strategyRecommender.ts
 var DEFAULT_STRATEGY_RECOMMENDATION_CONFIDENCE_THRESHOLD = 0.7;
 var MAX_RECOMMENDATIONS = 5;
@@ -39024,7 +39109,7 @@ var OK_CODE19 = 0;
 var BOOTSTRAP_WORKER_BUFFER_BYPASS_MIN_ENERGY = 300;
 var LOW_ROOM_ENERGY_TASK_PRIORITY_RATIO = 0.5;
 function runEconomy(preludeTelemetryEvents = []) {
-  var _a, _b, _c, _d;
+  var _a, _b, _c, _d, _e, _f;
   const creeps = Object.values(Game.creeps);
   balanceStorage();
   manageTerminalEnergy();
@@ -39044,6 +39129,7 @@ function runEconomy(preludeTelemetryEvents = []) {
   clearColonySurvivalAssessmentCache();
   refreshClaimedRoomBootstrapperOwnership();
   const postClaimBootstrapFocusRoomName = selectPostClaimBootstrapFocusRoomName(colonies);
+  const controllerUpgradeTargetRoom = (_b = (_a = selectColonyUpgradeTarget(colonies)) == null ? void 0 : _a.room.name) != null ? _b : null;
   for (const colony of colonies) {
     recordSourceWorkloads(colony.room, creeps, Game.time);
     let roleCounts = getPlannedOrCurrentRoleCounts(creeps, colony.room.name, plannedRoleCountsByRoom);
@@ -39091,7 +39177,7 @@ function runEconomy(preludeTelemetryEvents = []) {
         colony,
         roleCounts,
         Game.time,
-        getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp),
+        getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp, controllerUpgradeTargetRoom),
         colonies,
         creeps,
         usedSpawnsByRoom,
@@ -39115,8 +39201,8 @@ function runEconomy(preludeTelemetryEvents = []) {
       if (!outcome || outcome.result !== OK_CODE19) {
         break;
       }
-      const spawnRoomName = (_b = (_a = outcome.spawn.room) == null ? void 0 : _a.name) != null ? _b : "unknown";
-      const usedSpawns = (_c = usedSpawnsByRoom.get(spawnRoomName)) != null ? _c : /* @__PURE__ */ new Set();
+      const spawnRoomName = (_d = (_c = outcome.spawn.room) == null ? void 0 : _c.name) != null ? _d : "unknown";
+      const usedSpawns = (_e = usedSpawnsByRoom.get(spawnRoomName)) != null ? _e : /* @__PURE__ */ new Set();
       usedSpawns.add(outcome.spawn);
       usedSpawnsByRoom.set(spawnRoomName, usedSpawns);
       recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, spawnRoomName, bodyCost);
@@ -39137,9 +39223,9 @@ function runEconomy(preludeTelemetryEvents = []) {
         coordinatedPlan.sourceColony,
         roleCounts,
         Game.time,
-        getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp),
+        getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp, controllerUpgradeTargetRoom),
         spawnRequest,
-        (_d = reservedSpawnEnergyByRoom.get(spawnRoomName)) != null ? _d : bodyCost
+        (_f = reservedSpawnEnergyByRoom.get(spawnRoomName)) != null ? _f : bodyCost
       );
       if (!shouldContinueAfterWorkerSpawn) {
         break;
@@ -39648,11 +39734,15 @@ function getPlannedOrCurrentRoleCounts(creeps, roomName, plannedRoleCountsByRoom
   return (_a = plannedRoleCountsByRoom.get(roomName)) != null ? _a : countCreepsByRole(creeps, roomName);
 }
 function isAllowedCrossRoomSpawnRequest(spawnRequest, targetRoomName) {
+  var _a;
   if (spawnRequest.memory.colony !== targetRoomName) {
     return false;
   }
   if (spawnRequest.memory.role === "worker") {
     return !spawnRequest.memory.controllerSustain;
+  }
+  if (isControllerUpgradeSpawnRequest(spawnRequest)) {
+    return ((_a = spawnRequest.memory.controllerUpgrade) == null ? void 0 : _a.roomName) === targetRoomName;
   }
   return spawnRequest.memory.role === TERRITORY_CLAIMER_ROLE || spawnRequest.memory.role === TERRITORY_SCOUT_ROLE;
 }
@@ -39776,16 +39866,17 @@ function buildAffordableCrossRoomHaulerBody(body, energyBudget) {
   }
   return affordableBody;
 }
-function getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp) {
+function getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp, controllerUpgradeTargetRoom) {
   const allowTerritoryFollowUp = successfulSpawnCount > 0 || hasPendingTerritoryFollowUp;
   if (successfulSpawnCount === 0) {
-    return allowTerritoryFollowUp ? { allowTerritoryFollowUp } : {};
+    return allowTerritoryFollowUp ? { allowTerritoryFollowUp, controllerUpgradeTargetRoom } : { controllerUpgradeTargetRoom };
   }
   return {
     nameSuffix: String(successfulSpawnCount + 1),
     workersOnly: true,
     allowTerritoryControllerPressure: true,
-    allowTerritoryFollowUp
+    allowTerritoryFollowUp,
+    controllerUpgradeTargetRoom
   };
 }
 function isAllowedPostSpawnRequest(spawnRequest) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -29756,11 +29756,11 @@ function hasVisibleControllerUpgradeConstructionDemand(room) {
   return findRoomObjects21(room, "FIND_MY_CONSTRUCTION_SITES").length > 0 || findRoomObjects21(room, "FIND_CONSTRUCTION_SITES").filter((site) => site.my !== false).length > 0;
 }
 function planMultiRoomControllerUpgradeSpawn(context) {
-  if (context.options.workersOnly || context.territoryIntentPending || context.options.controllerUpgradeTargetRoom === null || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || context.workerCapacity < context.workerTarget || context.colony.energyAvailable < context.colony.energyCapacityAvailable) {
+  if (context.options.workersOnly || context.territoryIntentPending || hasNoControllerUpgradeTargets(context.options) || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || context.workerCapacity < context.workerTarget || context.colony.energyAvailable < context.colony.energyCapacityAvailable) {
     return null;
   }
   const upgradePlans = selectMultiRoomUpgradePlans(context.colony).filter(
-    (plan) => context.options.controllerUpgradeTargetRoom === void 0 || plan.targetRoom === context.options.controllerUpgradeTargetRoom
+    (plan) => isAllowedControllerUpgradeTarget(context.options, plan.targetRoom)
   );
   if (upgradePlans.length === 0) {
     return null;
@@ -29797,8 +29797,30 @@ function shouldSpawnControllerUpgradeSurplusWorker(context) {
   return context.workerCapacity < surplusWorkerTarget;
 }
 function isSelectedControllerUpgradeTarget(context) {
-  const targetRoom = context.options.controllerUpgradeTargetRoom;
-  return targetRoom === void 0 || targetRoom === context.colony.room.name;
+  return isAllowedControllerUpgradeTarget(context.options, context.colony.room.name);
+}
+function hasNoControllerUpgradeTargets(options) {
+  const targetRooms = getControllerUpgradeTargetRooms(options);
+  return targetRooms === null || (targetRooms == null ? void 0 : targetRooms.length) === 0;
+}
+function isAllowedControllerUpgradeTarget(options, roomName) {
+  const targetRooms = getControllerUpgradeTargetRooms(options);
+  if (targetRooms === void 0) {
+    return true;
+  }
+  if (targetRooms === null) {
+    return false;
+  }
+  return targetRooms.includes(roomName);
+}
+function getControllerUpgradeTargetRooms(options) {
+  if (options.controllerUpgradeTargetRooms !== void 0) {
+    return options.controllerUpgradeTargetRooms;
+  }
+  if (options.controllerUpgradeTargetRoom !== void 0) {
+    return options.controllerUpgradeTargetRoom === null ? null : [options.controllerUpgradeTargetRoom];
+  }
+  return void 0;
 }
 function hasControllerUpgradeSurplusEnergy(colony) {
   return colony.energyCapacityAvailable >= CONTROLLER_UPGRADE_SURPLUS_MIN_ENERGY_CAPACITY && colony.energyAvailable >= colony.energyCapacityAvailable;
@@ -38663,13 +38685,21 @@ function refreshReserveExecutionTargets(options = {}) {
 
 // src/territory/colonyUpgradePriority.ts
 var MAX_CONTROLLER_LEVEL6 = 8;
-function selectColonyUpgradeTarget(colonies) {
-  var _a, _b;
+var COLONY_UPGRADE_DOWNGRADE_RISK_TICKS = 5e3;
+function selectColonyUpgradeTargets(colonies) {
   const candidates = colonies.flatMap((colony) => {
     const candidate = buildColonyUpgradeCandidate(colony);
     return candidate && candidate.workerCount > 0 ? [candidate] : [];
   });
-  return (_b = (_a = candidates.sort(compareColonyUpgradeCandidates)[0]) == null ? void 0 : _a.colony) != null ? _b : null;
+  if (candidates.length === 0) {
+    return [];
+  }
+  const levelUpTarget = [...candidates].sort(compareColonyLevelUpgradeCandidates)[0];
+  const downgradeRiskTargets = candidates.filter(isControllerDowngradeRiskCandidate).sort(compareColonyDowngradeRiskCandidates);
+  return uniqueColonyUpgradeCandidates([
+    ...downgradeRiskTargets,
+    ...levelUpTarget ? [levelUpTarget] : []
+  ]).map((candidate) => candidate.colony);
 }
 function buildColonyUpgradeCandidate(colony) {
   const controller = colony.room.controller;
@@ -38678,6 +38708,7 @@ function buildColonyUpgradeCandidate(colony) {
   }
   return {
     colony,
+    ...getControllerTicksToDowngradeField2(controller),
     roomName: colony.room.name,
     remainingProgress: getControllerRemainingProgress(controller),
     progress: getControllerProgress(controller),
@@ -38685,8 +38716,26 @@ function buildColonyUpgradeCandidate(colony) {
     workerCount: countAvailableWorkers(colony.room.name)
   };
 }
-function compareColonyUpgradeCandidates(left, right) {
+function compareColonyDowngradeRiskCandidates(left, right) {
+  return compareOptionalNumbers10(left.controllerTicksToDowngrade, right.controllerTicksToDowngrade) || compareColonyLevelUpgradeCandidates(left, right);
+}
+function compareColonyLevelUpgradeCandidates(left, right) {
   return left.remainingProgress - right.remainingProgress || right.progress - left.progress || left.roleRank - right.roleRank || right.workerCount - left.workerCount || left.roomName.localeCompare(right.roomName);
+}
+function uniqueColonyUpgradeCandidates(candidates) {
+  const seenRooms = /* @__PURE__ */ new Set();
+  const uniqueCandidates = [];
+  for (const candidate of candidates) {
+    if (seenRooms.has(candidate.roomName)) {
+      continue;
+    }
+    seenRooms.add(candidate.roomName);
+    uniqueCandidates.push(candidate);
+  }
+  return uniqueCandidates;
+}
+function isControllerDowngradeRiskCandidate(candidate) {
+  return typeof candidate.controllerTicksToDowngrade === "number" && candidate.controllerTicksToDowngrade <= COLONY_UPGRADE_DOWNGRADE_RISK_TICKS;
 }
 function canUpgradeOwnedController(controller) {
   return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && Number.isFinite(controller.level) && controller.level < MAX_CONTROLLER_LEVEL6;
@@ -38703,6 +38752,9 @@ function getControllerProgress(controller) {
 }
 function getControllerProgressTotal(controller) {
   return normalizeNonNegativeNumber5(controller.progressTotal);
+}
+function getControllerTicksToDowngradeField2(controller) {
+  return typeof controller.ticksToDowngrade === "number" && Number.isFinite(controller.ticksToDowngrade) ? { controllerTicksToDowngrade: Math.max(0, Math.floor(controller.ticksToDowngrade)) } : {};
 }
 function getColonyRoleRank(colony) {
   return hasOperationalSpawn(colony) ? 1 : 0;
@@ -38738,6 +38790,9 @@ function isAvailableWorkerForRoom(creep, roomName) {
 }
 function normalizeNonNegativeNumber5(value) {
   return typeof value === "number" && Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+function compareOptionalNumbers10(left, right) {
+  return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
 }
 
 // src/strategy/strategyRecommender.ts
@@ -39109,7 +39164,7 @@ var OK_CODE19 = 0;
 var BOOTSTRAP_WORKER_BUFFER_BYPASS_MIN_ENERGY = 300;
 var LOW_ROOM_ENERGY_TASK_PRIORITY_RATIO = 0.5;
 function runEconomy(preludeTelemetryEvents = []) {
-  var _a, _b, _c, _d, _e, _f;
+  var _a, _b, _c, _d;
   const creeps = Object.values(Game.creeps);
   balanceStorage();
   manageTerminalEnergy();
@@ -39129,7 +39184,7 @@ function runEconomy(preludeTelemetryEvents = []) {
   clearColonySurvivalAssessmentCache();
   refreshClaimedRoomBootstrapperOwnership();
   const postClaimBootstrapFocusRoomName = selectPostClaimBootstrapFocusRoomName(colonies);
-  const controllerUpgradeTargetRoom = (_b = (_a = selectColonyUpgradeTarget(colonies)) == null ? void 0 : _a.room.name) != null ? _b : null;
+  const controllerUpgradeTargetRooms = getControllerUpgradeTargetRooms2(colonies);
   for (const colony of colonies) {
     recordSourceWorkloads(colony.room, creeps, Game.time);
     let roleCounts = getPlannedOrCurrentRoleCounts(creeps, colony.room.name, plannedRoleCountsByRoom);
@@ -39177,7 +39232,7 @@ function runEconomy(preludeTelemetryEvents = []) {
         colony,
         roleCounts,
         Game.time,
-        getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp, controllerUpgradeTargetRoom),
+        getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp, controllerUpgradeTargetRooms),
         colonies,
         creeps,
         usedSpawnsByRoom,
@@ -39201,8 +39256,8 @@ function runEconomy(preludeTelemetryEvents = []) {
       if (!outcome || outcome.result !== OK_CODE19) {
         break;
       }
-      const spawnRoomName = (_d = (_c = outcome.spawn.room) == null ? void 0 : _c.name) != null ? _d : "unknown";
-      const usedSpawns = (_e = usedSpawnsByRoom.get(spawnRoomName)) != null ? _e : /* @__PURE__ */ new Set();
+      const spawnRoomName = (_b = (_a = outcome.spawn.room) == null ? void 0 : _a.name) != null ? _b : "unknown";
+      const usedSpawns = (_c = usedSpawnsByRoom.get(spawnRoomName)) != null ? _c : /* @__PURE__ */ new Set();
       usedSpawns.add(outcome.spawn);
       usedSpawnsByRoom.set(spawnRoomName, usedSpawns);
       recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, spawnRoomName, bodyCost);
@@ -39223,9 +39278,9 @@ function runEconomy(preludeTelemetryEvents = []) {
         coordinatedPlan.sourceColony,
         roleCounts,
         Game.time,
-        getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp, controllerUpgradeTargetRoom),
+        getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp, controllerUpgradeTargetRooms),
         spawnRequest,
-        (_f = reservedSpawnEnergyByRoom.get(spawnRoomName)) != null ? _f : bodyCost
+        (_d = reservedSpawnEnergyByRoom.get(spawnRoomName)) != null ? _d : bodyCost
       );
       if (!shouldContinueAfterWorkerSpawn) {
         break;
@@ -39866,18 +39921,22 @@ function buildAffordableCrossRoomHaulerBody(body, energyBudget) {
   }
   return affordableBody;
 }
-function getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp, controllerUpgradeTargetRoom) {
+function getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp, controllerUpgradeTargetRooms) {
   const allowTerritoryFollowUp = successfulSpawnCount > 0 || hasPendingTerritoryFollowUp;
   if (successfulSpawnCount === 0) {
-    return allowTerritoryFollowUp ? { allowTerritoryFollowUp, controllerUpgradeTargetRoom } : { controllerUpgradeTargetRoom };
+    return allowTerritoryFollowUp ? { allowTerritoryFollowUp, controllerUpgradeTargetRooms } : { controllerUpgradeTargetRooms };
   }
   return {
     nameSuffix: String(successfulSpawnCount + 1),
     workersOnly: true,
     allowTerritoryControllerPressure: true,
     allowTerritoryFollowUp,
-    controllerUpgradeTargetRoom
+    controllerUpgradeTargetRooms
   };
+}
+function getControllerUpgradeTargetRooms2(colonies) {
+  const targetRooms = selectColonyUpgradeTargets(colonies).map((colony) => colony.room.name);
+  return targetRooms.length > 0 ? targetRooms : null;
 }
 function isAllowedPostSpawnRequest(spawnRequest) {
   return spawnRequest.memory.role === "worker" || isControllerUpgradeSpawnRequest(spawnRequest) || isTerritoryControllerPressureSpawnRequest(spawnRequest) || isTerritoryControllerFollowUpSpawnRequest(spawnRequest);

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -94,6 +94,7 @@ import {
   refreshClaimedRoomBootstrapperOwnership,
   runTerritoryControllerCreep
 } from '../territory/territoryRunner';
+import { selectColonyUpgradeTarget } from '../territory/colonyUpgradePriority';
 import { recordPlannedMultiRoomUpgraderSpawn } from '../territory/multiRoomUpgrader';
 import { refreshControllerManagement } from '../territory/controllerManager';
 import {
@@ -158,6 +159,7 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
   clearColonySurvivalAssessmentCache();
   refreshClaimedRoomBootstrapperOwnership();
   const postClaimBootstrapFocusRoomName = selectPostClaimBootstrapFocusRoomName(colonies);
+  const controllerUpgradeTargetRoom = selectColonyUpgradeTarget(colonies)?.room.name ?? null;
 
   for (const colony of colonies) {
     recordSourceWorkloads(colony.room, creeps, Game.time);
@@ -210,7 +212,7 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
         colony,
         roleCounts,
         Game.time,
-        getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp),
+        getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp, controllerUpgradeTargetRoom),
         colonies,
         creeps,
         usedSpawnsByRoom,
@@ -262,7 +264,7 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
         coordinatedPlan.sourceColony,
         roleCounts,
         Game.time,
-        getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp),
+        getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp, controllerUpgradeTargetRoom),
         spawnRequest,
         reservedSpawnEnergyByRoom.get(spawnRoomName) ?? bodyCost
       );
@@ -993,6 +995,10 @@ function isAllowedCrossRoomSpawnRequest(
     return !spawnRequest.memory.controllerSustain;
   }
 
+  if (isControllerUpgradeSpawnRequest(spawnRequest)) {
+    return spawnRequest.memory.controllerUpgrade?.roomName === targetRoomName;
+  }
+
   return spawnRequest.memory.role === TERRITORY_CLAIMER_ROLE || spawnRequest.memory.role === TERRITORY_SCOUT_ROLE;
 }
 
@@ -1211,18 +1217,22 @@ function buildAffordableCrossRoomHaulerBody(
 
 function getSpawnPlanningOptions(
   successfulSpawnCount: number,
-  hasPendingTerritoryFollowUp: boolean
+  hasPendingTerritoryFollowUp: boolean,
+  controllerUpgradeTargetRoom: string | null
 ): SpawnPlanningOptions {
   const allowTerritoryFollowUp = successfulSpawnCount > 0 || hasPendingTerritoryFollowUp;
   if (successfulSpawnCount === 0) {
-    return allowTerritoryFollowUp ? { allowTerritoryFollowUp } : {};
+    return allowTerritoryFollowUp
+      ? { allowTerritoryFollowUp, controllerUpgradeTargetRoom }
+      : { controllerUpgradeTargetRoom };
   }
 
   return {
     nameSuffix: String(successfulSpawnCount + 1),
     workersOnly: true,
     allowTerritoryControllerPressure: true,
-    allowTerritoryFollowUp
+    allowTerritoryFollowUp,
+    controllerUpgradeTargetRoom
   };
 }
 

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -94,7 +94,7 @@ import {
   refreshClaimedRoomBootstrapperOwnership,
   runTerritoryControllerCreep
 } from '../territory/territoryRunner';
-import { selectColonyUpgradeTarget } from '../territory/colonyUpgradePriority';
+import { selectColonyUpgradeTargets } from '../territory/colonyUpgradePriority';
 import { recordPlannedMultiRoomUpgraderSpawn } from '../territory/multiRoomUpgrader';
 import { refreshControllerManagement } from '../territory/controllerManager';
 import {
@@ -159,7 +159,7 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
   clearColonySurvivalAssessmentCache();
   refreshClaimedRoomBootstrapperOwnership();
   const postClaimBootstrapFocusRoomName = selectPostClaimBootstrapFocusRoomName(colonies);
-  const controllerUpgradeTargetRoom = selectColonyUpgradeTarget(colonies)?.room.name ?? null;
+  const controllerUpgradeTargetRooms = getControllerUpgradeTargetRooms(colonies);
 
   for (const colony of colonies) {
     recordSourceWorkloads(colony.room, creeps, Game.time);
@@ -212,7 +212,7 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
         colony,
         roleCounts,
         Game.time,
-        getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp, controllerUpgradeTargetRoom),
+        getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp, controllerUpgradeTargetRooms),
         colonies,
         creeps,
         usedSpawnsByRoom,
@@ -264,7 +264,7 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
         coordinatedPlan.sourceColony,
         roleCounts,
         Game.time,
-        getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp, controllerUpgradeTargetRoom),
+        getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp, controllerUpgradeTargetRooms),
         spawnRequest,
         reservedSpawnEnergyByRoom.get(spawnRoomName) ?? bodyCost
       );
@@ -1218,13 +1218,13 @@ function buildAffordableCrossRoomHaulerBody(
 function getSpawnPlanningOptions(
   successfulSpawnCount: number,
   hasPendingTerritoryFollowUp: boolean,
-  controllerUpgradeTargetRoom: string | null
+  controllerUpgradeTargetRooms: readonly string[] | null
 ): SpawnPlanningOptions {
   const allowTerritoryFollowUp = successfulSpawnCount > 0 || hasPendingTerritoryFollowUp;
   if (successfulSpawnCount === 0) {
     return allowTerritoryFollowUp
-      ? { allowTerritoryFollowUp, controllerUpgradeTargetRoom }
-      : { controllerUpgradeTargetRoom };
+      ? { allowTerritoryFollowUp, controllerUpgradeTargetRooms }
+      : { controllerUpgradeTargetRooms };
   }
 
   return {
@@ -1232,8 +1232,13 @@ function getSpawnPlanningOptions(
     workersOnly: true,
     allowTerritoryControllerPressure: true,
     allowTerritoryFollowUp,
-    controllerUpgradeTargetRoom
+    controllerUpgradeTargetRooms
   };
+}
+
+function getControllerUpgradeTargetRooms(colonies: ColonySnapshot[]): readonly string[] | null {
+  const targetRooms = selectColonyUpgradeTargets(colonies).map((colony) => colony.room.name);
+  return targetRooms.length > 0 ? targetRooms : null;
 }
 
 function isAllowedPostSpawnRequest(spawnRequest: SpawnRequest): boolean {

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -139,6 +139,7 @@ export interface SpawnPlanningOptions {
   workersOnly?: boolean;
   allowTerritoryControllerPressure?: boolean;
   allowTerritoryFollowUp?: boolean;
+  controllerUpgradeTargetRoom?: string | null;
 }
 
 export interface SpawnEnergyForecast {
@@ -1423,6 +1424,7 @@ function planControllerUpgradeSurplusSpawn(context: SpawnPlanningContext): Spawn
 function planControllerUpgradeDemandSpawn(context: SpawnPlanningContext): SpawnRequest | null {
   if (
     context.territoryIntentPending ||
+    !isSelectedControllerUpgradeTarget(context) ||
     context.survival.mode === 'BOOTSTRAP' ||
     context.survival.hostilePresence ||
     hasControllerUpgradeBlockingTerritoryWork(context.colony) ||
@@ -1478,6 +1480,7 @@ function planMultiRoomControllerUpgradeSpawn(context: SpawnPlanningContext): Spa
   if (
     context.options.workersOnly ||
     context.territoryIntentPending ||
+    context.options.controllerUpgradeTargetRoom === null ||
     context.survival.mode !== 'TERRITORY_READY' ||
     hasControllerUpgradeBlockingTerritoryWork(context.colony) ||
     context.workerCapacity < context.workerTarget ||
@@ -1486,7 +1489,10 @@ function planMultiRoomControllerUpgradeSpawn(context: SpawnPlanningContext): Spa
     return null;
   }
 
-  const upgradePlans = selectMultiRoomUpgradePlans(context.colony);
+  const upgradePlans = selectMultiRoomUpgradePlans(context.colony).filter((plan) =>
+    context.options.controllerUpgradeTargetRoom === undefined ||
+    plan.targetRoom === context.options.controllerUpgradeTargetRoom
+  );
   if (upgradePlans.length === 0) {
     return null;
   }
@@ -1534,6 +1540,11 @@ function shouldSpawnControllerUpgradeSurplusWorker(context: SpawnPlanningContext
     context.workerTarget + CONTROLLER_UPGRADE_SURPLUS_WORKER_BONUS
   );
   return context.workerCapacity < surplusWorkerTarget;
+}
+
+function isSelectedControllerUpgradeTarget(context: SpawnPlanningContext): boolean {
+  const targetRoom = context.options.controllerUpgradeTargetRoom;
+  return targetRoom === undefined || targetRoom === context.colony.room.name;
 }
 
 function hasControllerUpgradeSurplusEnergy(colony: ColonySnapshot): boolean {

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -140,6 +140,7 @@ export interface SpawnPlanningOptions {
   allowTerritoryControllerPressure?: boolean;
   allowTerritoryFollowUp?: boolean;
   controllerUpgradeTargetRoom?: string | null;
+  controllerUpgradeTargetRooms?: readonly string[] | null;
 }
 
 export interface SpawnEnergyForecast {
@@ -1480,7 +1481,7 @@ function planMultiRoomControllerUpgradeSpawn(context: SpawnPlanningContext): Spa
   if (
     context.options.workersOnly ||
     context.territoryIntentPending ||
-    context.options.controllerUpgradeTargetRoom === null ||
+    hasNoControllerUpgradeTargets(context.options) ||
     context.survival.mode !== 'TERRITORY_READY' ||
     hasControllerUpgradeBlockingTerritoryWork(context.colony) ||
     context.workerCapacity < context.workerTarget ||
@@ -1490,8 +1491,7 @@ function planMultiRoomControllerUpgradeSpawn(context: SpawnPlanningContext): Spa
   }
 
   const upgradePlans = selectMultiRoomUpgradePlans(context.colony).filter((plan) =>
-    context.options.controllerUpgradeTargetRoom === undefined ||
-    plan.targetRoom === context.options.controllerUpgradeTargetRoom
+    isAllowedControllerUpgradeTarget(context.options, plan.targetRoom)
   );
   if (upgradePlans.length === 0) {
     return null;
@@ -1543,8 +1543,41 @@ function shouldSpawnControllerUpgradeSurplusWorker(context: SpawnPlanningContext
 }
 
 function isSelectedControllerUpgradeTarget(context: SpawnPlanningContext): boolean {
-  const targetRoom = context.options.controllerUpgradeTargetRoom;
-  return targetRoom === undefined || targetRoom === context.colony.room.name;
+  return isAllowedControllerUpgradeTarget(context.options, context.colony.room.name);
+}
+
+function hasNoControllerUpgradeTargets(options: SpawnPlanningOptions): boolean {
+  const targetRooms = getControllerUpgradeTargetRooms(options);
+  return targetRooms === null || targetRooms?.length === 0;
+}
+
+function isAllowedControllerUpgradeTarget(options: SpawnPlanningOptions, roomName: string): boolean {
+  const targetRooms = getControllerUpgradeTargetRooms(options);
+  if (targetRooms === undefined) {
+    return true;
+  }
+
+  if (targetRooms === null) {
+    return false;
+  }
+
+  return targetRooms.includes(roomName);
+}
+
+function getControllerUpgradeTargetRooms(
+  options: SpawnPlanningOptions
+): readonly string[] | null | undefined {
+  if (options.controllerUpgradeTargetRooms !== undefined) {
+    return options.controllerUpgradeTargetRooms;
+  }
+
+  if (options.controllerUpgradeTargetRoom !== undefined) {
+    return options.controllerUpgradeTargetRoom === null
+      ? null
+      : [options.controllerUpgradeTargetRoom];
+  }
+
+  return undefined;
 }
 
 function hasControllerUpgradeSurplusEnergy(colony: ColonySnapshot): boolean {

--- a/prod/src/territory/colonyUpgradePriority.ts
+++ b/prod/src/territory/colonyUpgradePriority.ts
@@ -2,9 +2,11 @@ import type { ColonySnapshot } from '../colony/colonyRegistry';
 import { WORKER_REPLACEMENT_TICKS_TO_LIVE } from '../creeps/roleCounts';
 
 const MAX_CONTROLLER_LEVEL = 8;
+export const COLONY_UPGRADE_DOWNGRADE_RISK_TICKS = 5_000;
 
 interface ColonyUpgradeCandidate {
   colony: ColonySnapshot;
+  controllerTicksToDowngrade?: number;
   roomName: string;
   remainingProgress: number;
   progress: number;
@@ -13,12 +15,27 @@ interface ColonyUpgradeCandidate {
 }
 
 export function selectColonyUpgradeTarget(colonies: ColonySnapshot[]): ColonySnapshot | null {
+  return selectColonyUpgradeTargets(colonies)[0] ?? null;
+}
+
+export function selectColonyUpgradeTargets(colonies: ColonySnapshot[]): ColonySnapshot[] {
   const candidates = colonies.flatMap((colony) => {
     const candidate = buildColonyUpgradeCandidate(colony);
     return candidate && candidate.workerCount > 0 ? [candidate] : [];
   });
+  if (candidates.length === 0) {
+    return [];
+  }
 
-  return candidates.sort(compareColonyUpgradeCandidates)[0]?.colony ?? null;
+  const levelUpTarget = [...candidates].sort(compareColonyLevelUpgradeCandidates)[0];
+  const downgradeRiskTargets = candidates
+    .filter(isControllerDowngradeRiskCandidate)
+    .sort(compareColonyDowngradeRiskCandidates);
+
+  return uniqueColonyUpgradeCandidates([
+    ...downgradeRiskTargets,
+    ...(levelUpTarget ? [levelUpTarget] : [])
+  ]).map((candidate) => candidate.colony);
 }
 
 function buildColonyUpgradeCandidate(colony: ColonySnapshot): ColonyUpgradeCandidate | null {
@@ -29,6 +46,7 @@ function buildColonyUpgradeCandidate(colony: ColonySnapshot): ColonyUpgradeCandi
 
   return {
     colony,
+    ...getControllerTicksToDowngradeField(controller),
     roomName: colony.room.name,
     remainingProgress: getControllerRemainingProgress(controller),
     progress: getControllerProgress(controller),
@@ -37,7 +55,17 @@ function buildColonyUpgradeCandidate(colony: ColonySnapshot): ColonyUpgradeCandi
   };
 }
 
-function compareColonyUpgradeCandidates(
+function compareColonyDowngradeRiskCandidates(
+  left: ColonyUpgradeCandidate,
+  right: ColonyUpgradeCandidate
+): number {
+  return (
+    compareOptionalNumbers(left.controllerTicksToDowngrade, right.controllerTicksToDowngrade) ||
+    compareColonyLevelUpgradeCandidates(left, right)
+  );
+}
+
+function compareColonyLevelUpgradeCandidates(
   left: ColonyUpgradeCandidate,
   right: ColonyUpgradeCandidate
 ): number {
@@ -47,6 +75,31 @@ function compareColonyUpgradeCandidates(
     left.roleRank - right.roleRank ||
     right.workerCount - left.workerCount ||
     left.roomName.localeCompare(right.roomName)
+  );
+}
+
+function uniqueColonyUpgradeCandidates(
+  candidates: ColonyUpgradeCandidate[]
+): ColonyUpgradeCandidate[] {
+  const seenRooms = new Set<string>();
+  const uniqueCandidates: ColonyUpgradeCandidate[] = [];
+
+  for (const candidate of candidates) {
+    if (seenRooms.has(candidate.roomName)) {
+      continue;
+    }
+
+    seenRooms.add(candidate.roomName);
+    uniqueCandidates.push(candidate);
+  }
+
+  return uniqueCandidates;
+}
+
+function isControllerDowngradeRiskCandidate(candidate: ColonyUpgradeCandidate): boolean {
+  return (
+    typeof candidate.controllerTicksToDowngrade === 'number' &&
+    candidate.controllerTicksToDowngrade <= COLONY_UPGRADE_DOWNGRADE_RISK_TICKS
   );
 }
 
@@ -76,6 +129,14 @@ function getControllerProgress(controller: StructureController): number {
 
 function getControllerProgressTotal(controller: StructureController): number {
   return normalizeNonNegativeNumber(controller.progressTotal);
+}
+
+function getControllerTicksToDowngradeField(
+  controller: StructureController
+): Pick<ColonyUpgradeCandidate, 'controllerTicksToDowngrade'> {
+  return typeof controller.ticksToDowngrade === 'number' && Number.isFinite(controller.ticksToDowngrade)
+    ? { controllerTicksToDowngrade: Math.max(0, Math.floor(controller.ticksToDowngrade)) }
+    : {};
 }
 
 function getColonyRoleRank(colony: ColonySnapshot): number {
@@ -122,4 +183,8 @@ function isAvailableWorkerForRoom(creep: Creep, roomName: string): boolean {
 
 function normalizeNonNegativeNumber(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
+function compareOptionalNumbers(left: number | undefined, right: number | undefined): number {
+  return (left ?? Number.POSITIVE_INFINITY) - (right ?? Number.POSITIVE_INFINITY);
 }

--- a/prod/src/territory/colonyUpgradePriority.ts
+++ b/prod/src/territory/colonyUpgradePriority.ts
@@ -1,0 +1,125 @@
+import type { ColonySnapshot } from '../colony/colonyRegistry';
+import { WORKER_REPLACEMENT_TICKS_TO_LIVE } from '../creeps/roleCounts';
+
+const MAX_CONTROLLER_LEVEL = 8;
+
+interface ColonyUpgradeCandidate {
+  colony: ColonySnapshot;
+  roomName: string;
+  remainingProgress: number;
+  progress: number;
+  roleRank: number;
+  workerCount: number;
+}
+
+export function selectColonyUpgradeTarget(colonies: ColonySnapshot[]): ColonySnapshot | null {
+  const candidates = colonies.flatMap((colony) => {
+    const candidate = buildColonyUpgradeCandidate(colony);
+    return candidate && candidate.workerCount > 0 ? [candidate] : [];
+  });
+
+  return candidates.sort(compareColonyUpgradeCandidates)[0]?.colony ?? null;
+}
+
+function buildColonyUpgradeCandidate(colony: ColonySnapshot): ColonyUpgradeCandidate | null {
+  const controller = colony.room.controller;
+  if (!canUpgradeOwnedController(controller)) {
+    return null;
+  }
+
+  return {
+    colony,
+    roomName: colony.room.name,
+    remainingProgress: getControllerRemainingProgress(controller),
+    progress: getControllerProgress(controller),
+    roleRank: getColonyRoleRank(colony),
+    workerCount: countAvailableWorkers(colony.room.name)
+  };
+}
+
+function compareColonyUpgradeCandidates(
+  left: ColonyUpgradeCandidate,
+  right: ColonyUpgradeCandidate
+): number {
+  return (
+    left.remainingProgress - right.remainingProgress ||
+    right.progress - left.progress ||
+    left.roleRank - right.roleRank ||
+    right.workerCount - left.workerCount ||
+    left.roomName.localeCompare(right.roomName)
+  );
+}
+
+function canUpgradeOwnedController(
+  controller: StructureController | undefined
+): controller is StructureController {
+  return (
+    controller?.my === true &&
+    typeof controller.level === 'number' &&
+    Number.isFinite(controller.level) &&
+    controller.level < MAX_CONTROLLER_LEVEL
+  );
+}
+
+function getControllerRemainingProgress(controller: StructureController): number {
+  const progressTotal = getControllerProgressTotal(controller);
+  if (progressTotal <= 0) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  return Math.max(0, progressTotal - getControllerProgress(controller));
+}
+
+function getControllerProgress(controller: StructureController): number {
+  return normalizeNonNegativeNumber(controller.progress);
+}
+
+function getControllerProgressTotal(controller: StructureController): number {
+  return normalizeNonNegativeNumber(controller.progressTotal);
+}
+
+function getColonyRoleRank(colony: ColonySnapshot): number {
+  return hasOperationalSpawn(colony) ? 1 : 0;
+}
+
+function hasOperationalSpawn(colony: ColonySnapshot): boolean {
+  return colony.spawns.some((spawn) => {
+    if (!spawn) {
+      return false;
+    }
+
+    if (typeof spawn.isActive === 'function') {
+      return spawn.isActive();
+    }
+
+    return true;
+  });
+}
+
+function countAvailableWorkers(roomName: string): number {
+  const creeps = (globalThis as { Game?: Partial<Pick<Game, 'creeps'>> }).Game?.creeps;
+  if (!creeps) {
+    return 0;
+  }
+
+  return Object.values(creeps).filter((creep) => isAvailableWorkerForRoom(creep, roomName)).length;
+}
+
+function isAvailableWorkerForRoom(creep: Creep, roomName: string): boolean {
+  if (
+    creep.ticksToLive !== undefined &&
+    creep.ticksToLive <= WORKER_REPLACEMENT_TICKS_TO_LIVE
+  ) {
+    return false;
+  }
+
+  if (creep.memory?.role !== 'worker') {
+    return false;
+  }
+
+  return creep.memory.colony === roomName || creep.memory.controllerSustain?.targetRoom === roomName;
+}
+
+function normalizeNonNegativeNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, value) : 0;
+}

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -1491,6 +1491,54 @@ describe('planSpawn', () => {
     });
   });
 
+  it('keeps downgrade-risk multi-room targets eligible when a level-up target is selected', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController(),
+      storageEnergy: 850,
+      storageCapacity: 1_000
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeTerritoryRoom('W2N1', {
+          id: 'levelUpController',
+          my: true,
+          level: 1,
+          ticksToDowngrade: 20_000
+        } as StructureController),
+        W3N1: makeTerritoryRoom('W3N1', {
+          id: 'urgentController',
+          my: true,
+          level: 4,
+          ticksToDowngrade: 1_500
+        } as StructureController)
+      },
+      spawns: { Spawn1: spawn },
+      creeps: {},
+      map: {
+        findRoute: jest.fn((_fromRoom: string, toRoom: string) => [{ exit: 3, room: toRoom }])
+      } as unknown as GameMap
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+
+    expect(
+      planSpawn(colony, { worker: 3 }, 132, {
+        controllerUpgradeTargetRooms: ['W2N1', 'W3N1']
+      })
+    ).toMatchObject({
+      spawn,
+      name: 'worker-W1N1-W3N1-multiroom-upgrader-132',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W3N1', action: 'claim', controllerId: 'urgentController' },
+        controllerSustain: { homeRoom: 'W1N1', targetRoom: 'W3N1', role: 'upgrader' }
+      }
+    });
+  });
+
   it('skips unowned multi-room upgrade candidates before selecting an owned room', () => {
     const { colony, spawn } = makeColony({
       energyAvailable: 650,

--- a/prod/test/territory/colonyUpgradePriority.test.ts
+++ b/prod/test/territory/colonyUpgradePriority.test.ts
@@ -1,5 +1,9 @@
 import type { ColonySnapshot } from '../../src/colony/colonyRegistry';
-import { selectColonyUpgradeTarget } from '../../src/territory/colonyUpgradePriority';
+import {
+  COLONY_UPGRADE_DOWNGRADE_RISK_TICKS,
+  selectColonyUpgradeTarget,
+  selectColonyUpgradeTargets
+} from '../../src/territory/colonyUpgradePriority';
 
 describe('colony upgrade priority', () => {
   afterEach(() => {
@@ -19,6 +23,29 @@ describe('colony upgrade priority', () => {
     installWorkers(['W1N1', 'W2N1']);
 
     expect(selectColonyUpgradeTarget([slowProgress, nearLevel])).toBe(nearLevel);
+    expect(selectColonyUpgradeTargets([slowProgress, nearLevel])).toEqual([nearLevel]);
+  });
+
+  it('keeps downgrade-risk rooms eligible alongside the level-up target', () => {
+    const nearLevel = makeColony({
+      roomName: 'W1N1',
+      progress: 950,
+      progressTotal: 1_000,
+      ticksToDowngrade: 20_000
+    });
+    const downgradeRisk = makeColony({
+      roomName: 'W2N1',
+      progress: 100,
+      progressTotal: 1_000,
+      ticksToDowngrade: COLONY_UPGRADE_DOWNGRADE_RISK_TICKS
+    });
+    installWorkers(['W1N1', 'W2N1']);
+
+    expect(selectColonyUpgradeTarget([nearLevel, downgradeRisk])).toBe(downgradeRisk);
+    expect(selectColonyUpgradeTargets([nearLevel, downgradeRisk])).toEqual([
+      downgradeRisk,
+      nearLevel
+    ]);
   });
 
   it('skips rooms without available workers', () => {
@@ -52,13 +79,15 @@ function makeColony({
   level = 3,
   progress = 100,
   progressTotal = 1_000,
-  spawnCount = 1
+  spawnCount = 1,
+  ticksToDowngrade
 }: {
   roomName: string;
   level?: number;
   progress?: number;
   progressTotal?: number;
   spawnCount?: number;
+  ticksToDowngrade?: number;
 }): ColonySnapshot {
   const room = {
     name: roomName,
@@ -67,7 +96,8 @@ function makeColony({
       my: true,
       level,
       progress,
-      progressTotal
+      progressTotal,
+      ...(typeof ticksToDowngrade === 'number' ? { ticksToDowngrade } : {})
     } as StructureController
   } as Room;
   const spawns = Array.from(

--- a/prod/test/territory/colonyUpgradePriority.test.ts
+++ b/prod/test/territory/colonyUpgradePriority.test.ts
@@ -1,0 +1,102 @@
+import type { ColonySnapshot } from '../../src/colony/colonyRegistry';
+import { selectColonyUpgradeTarget } from '../../src/territory/colonyUpgradePriority';
+
+describe('colony upgrade priority', () => {
+  afterEach(() => {
+    delete (globalThis as { Game?: Partial<Game> }).Game;
+  });
+
+  it('returns the only upgradeable room when it has workers', () => {
+    const colony = makeColony({ roomName: 'W1N1' });
+    installWorkers(['W1N1']);
+
+    expect(selectColonyUpgradeTarget([colony])).toBe(colony);
+  });
+
+  it('prefers the room closest to the next controller level', () => {
+    const slowProgress = makeColony({ roomName: 'W1N1', progress: 100, progressTotal: 1_000 });
+    const nearLevel = makeColony({ roomName: 'W2N1', progress: 950, progressTotal: 1_000 });
+    installWorkers(['W1N1', 'W2N1']);
+
+    expect(selectColonyUpgradeTarget([slowProgress, nearLevel])).toBe(nearLevel);
+  });
+
+  it('skips rooms without available workers', () => {
+    const starvedNearLevel = makeColony({ roomName: 'W1N1', progress: 990, progressTotal: 1_000 });
+    const staffedRoom = makeColony({ roomName: 'W2N1', progress: 100, progressTotal: 1_000 });
+    installWorkers(['W2N1']);
+
+    expect(selectColonyUpgradeTarget([starvedNearLevel, staffedRoom])).toBe(staffedRoom);
+    expect(selectColonyUpgradeTarget([starvedNearLevel])).toBeNull();
+  });
+
+  it('uses colony role after controller progress signals match', () => {
+    const homeRoom = makeColony({ roomName: 'W1N1', progress: 500, progressTotal: 1_000, spawnCount: 1 });
+    const expansionRoom = makeColony({ roomName: 'W2N1', progress: 500, progressTotal: 1_000, spawnCount: 0 });
+    installWorkers(['W1N1', 'W2N1']);
+
+    expect(selectColonyUpgradeTarget([homeRoom, expansionRoom])).toBe(expansionRoom);
+  });
+
+  it('breaks equal priorities by stable room name ordering', () => {
+    const west = makeColony({ roomName: 'W2N1', progress: 500, progressTotal: 1_000 });
+    const east = makeColony({ roomName: 'W1N1', progress: 500, progressTotal: 1_000 });
+    installWorkers(['W1N1', 'W2N1']);
+
+    expect(selectColonyUpgradeTarget([west, east])).toBe(east);
+  });
+});
+
+function makeColony({
+  roomName,
+  level = 3,
+  progress = 100,
+  progressTotal = 1_000,
+  spawnCount = 1
+}: {
+  roomName: string;
+  level?: number;
+  progress?: number;
+  progressTotal?: number;
+  spawnCount?: number;
+}): ColonySnapshot {
+  const room = {
+    name: roomName,
+    controller: {
+      id: `controller-${roomName}` as Id<StructureController>,
+      my: true,
+      level,
+      progress,
+      progressTotal
+    } as StructureController
+  } as Room;
+  const spawns = Array.from(
+    { length: spawnCount },
+    (_, index) =>
+      ({
+        name: `Spawn${index}-${roomName}`,
+        room,
+        isActive: jest.fn(() => true)
+      }) as unknown as StructureSpawn
+  );
+
+  return {
+    room,
+    spawns,
+    energyAvailable: 650,
+    energyCapacityAvailable: 650
+  };
+}
+
+function installWorkers(roomNames: string[]): void {
+  const creeps = Object.fromEntries(
+    roomNames.map((roomName, index) => [
+      `Worker${index}-${roomName}`,
+      {
+        ticksToLive: 1_000,
+        memory: { role: 'worker', colony: roomName }
+      } as Creep
+    ])
+  );
+  (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps };
+}


### PR DESCRIPTION
## Summary
- **Commit**: d39abe7
- **Author**: lanyusea's bot <lanyusea@gmail.com>
- **Verification**: typecheck PASS, 87 suites / 1644 tests PASS, build PASS, whitespace clean

## Changes
- `prod/src/territory/colonyUpgradePriority.ts` (new): `selectColonyUpgradeTarget()` function
- `prod/test/territory/colonyUpgradePriority.test.ts` (new): comprehensive unit tests
- `prod/src/economy/economyLoop.ts`: integrate colony upgrade priority into economy loop
- `prod/src/spawn/spawnPlanner.ts`: use upgrade priority for spawn decisions
- `prod/dist/main.js`: generated bundle

## Verification
```
npm run typecheck: PASS
npm test -- --runInBand: 87 suites, 1644 tests PASS
npm run build: PASS
git diff --check: clean
```
