### PR TITLE
feat(economy): export cross-room energy transfer selector and add link energy management tests (#861)

### DIFF
--- a/prod/src/economy/crossRoomHauler.ts
+++ b/prod/src/economy/crossRoomHauler.ts
@@ -156,7 +156,7 @@ export function runCrossRoomHauler(creep: Creep): void {
   collectEnergy(creep, assignment);
 }
 
-function selectCrossRoomEnergyTransfer(): EconomyStorageTransferMemory | null {
+export function selectCrossRoomEnergyTransfer(): EconomyStorageTransferMemory | null {
   const balance = getStorageBalanceState();
   return (
     balance.transfers

--- a/prod/test/economy/interRoomEnergyTransfers.test.ts
+++ b/prod/test/economy/interRoomEnergyTransfers.test.ts
@@ -1,0 +1,215 @@
+import {
+  CROSS_ROOM_HAULER_ROLE,
+  planCrossRoomHauler,
+  selectCrossRoomEnergyTransfer
+} from '../../src/economy/crossRoomHauler';
+import { balanceStorage } from '../../src/economy/storageBalancer';
+
+const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
+
+describe('economy inter-room energy transfers', () => {
+  beforeEach(() => {
+    Object.assign(globalThis, {
+      ERR_NO_PATH: ERR_NO_PATH_CODE,
+      FIND_HOSTILE_CREEPS: 1,
+      FIND_HOSTILE_STRUCTURES: 2,
+      FIND_MY_STRUCTURES: 3,
+      RESOURCE_ENERGY: 'energy',
+      STRUCTURE_EXTENSION: 'extension',
+      STRUCTURE_SPAWN: 'spawn',
+      STRUCTURE_STORAGE: 'storage',
+      STRUCTURE_TERMINAL: 'terminal',
+      STRUCTURE_TOWER: 'tower'
+    });
+  });
+
+  afterEach(() => {
+    delete (globalThis as { Game?: Partial<Game> }).Game;
+    delete (globalThis as { Memory?: Partial<Memory> }).Memory;
+    delete (globalThis as { ERR_NO_PATH?: ScreepsReturnCode }).ERR_NO_PATH;
+    delete (globalThis as { FIND_HOSTILE_CREEPS?: number }).FIND_HOSTILE_CREEPS;
+    delete (globalThis as { FIND_HOSTILE_STRUCTURES?: number }).FIND_HOSTILE_STRUCTURES;
+    delete (globalThis as { FIND_MY_STRUCTURES?: number }).FIND_MY_STRUCTURES;
+    delete (globalThis as { RESOURCE_ENERGY?: ResourceConstant }).RESOURCE_ENERGY;
+    delete (globalThis as { STRUCTURE_EXTENSION?: StructureConstant }).STRUCTURE_EXTENSION;
+    delete (globalThis as { STRUCTURE_SPAWN?: StructureConstant }).STRUCTURE_SPAWN;
+    delete (globalThis as { STRUCTURE_STORAGE?: StructureConstant }).STRUCTURE_STORAGE;
+    delete (globalThis as { STRUCTURE_TERMINAL?: StructureConstant }).STRUCTURE_TERMINAL;
+    delete (globalThis as { STRUCTURE_TOWER?: StructureConstant }).STRUCTURE_TOWER;
+  });
+
+  it('identifies surplus and deficit rooms and assigns a cross-room hauler transfer', () => {
+    const sourceRoom = makeOwnedRoom({ roomName: 'W1N1', storageEnergy: 900 });
+    const targetRoom = makeOwnedRoom({ roomName: 'W2N1', storageEnergy: 200 });
+    const sourceSpawn = makeSpawn('Spawn1', sourceRoom);
+    installGame([sourceRoom, targetRoom], [sourceSpawn]);
+
+    balanceStorage();
+
+    expect(Memory.economy?.storageBalance?.rooms.W1N1).toMatchObject({
+      mode: 'export',
+      exportableEnergy: 100
+    });
+    expect(Memory.economy?.storageBalance?.rooms.W2N1).toMatchObject({
+      mode: 'import',
+      importDemand: 100
+    });
+    expect(selectCrossRoomEnergyTransfer()).toEqual({
+      sourceRoom: 'W1N1',
+      targetRoom: 'W2N1',
+      amount: 100,
+      updatedAt: 100
+    });
+    expect(planCrossRoomHauler()).toMatchObject({
+      memory: {
+        role: CROSS_ROOM_HAULER_ROLE,
+        colony: 'W1N1',
+        crossRoomHauler: {
+          homeRoom: 'W1N1',
+          targetRoom: 'W2N1',
+          sourceId: 'W1N1-storage',
+          state: 'collecting',
+          route: ['W2N1']
+        }
+      }
+    });
+  });
+
+  it('orders inter-room imports by critical spawn pressure before controller upgrade and routine deficits', () => {
+    const sourceRoom = makeOwnedRoom({
+      roomName: 'W1N1',
+      storageEnergy: 2_000,
+      storageCapacity: 2_000
+    });
+    const criticalSpawnRoom = makeOwnedRoom({
+      roomName: 'W2N1',
+      energyAvailable: 100,
+      energyCapacityAvailable: 800,
+      storageEnergy: 100
+    });
+    const controllerUpgradeRoom = makeOwnedRoom({ roomName: 'W3N1', storageEnergy: 100 });
+    const routineRoom = makeOwnedRoom({ roomName: 'W4N1', storageEnergy: 100 });
+    installGame(
+      [sourceRoom, criticalSpawnRoom, controllerUpgradeRoom, routineRoom],
+      [makeSpawn('Spawn1', sourceRoom), makeSpawn('Spawn2', criticalSpawnRoom)]
+    );
+    Memory.territory = {
+      controllers: {
+        W3N1: {
+          activeUpgraderCount: 0,
+          controllerId: 'W3N1-controller' as Id<StructureController>,
+          desiredUpgraderCount: 1,
+          roomName: 'W3N1',
+          signNeeded: false,
+          updatedAt: 100,
+          upgradePriority: 'rclProgress'
+        }
+      }
+    };
+
+    balanceStorage();
+
+    expect(Memory.economy?.storageBalance?.transfers).toEqual([
+      { sourceRoom: 'W1N1', targetRoom: 'W2N1', amount: 200, updatedAt: 100 },
+      { sourceRoom: 'W1N1', targetRoom: 'W3N1', amount: 200, updatedAt: 100 }
+    ]);
+    expect(selectCrossRoomEnergyTransfer()?.targetRoom).toBe('W2N1');
+  });
+});
+
+function makeOwnedRoom({
+  roomName,
+  storageEnergy,
+  storageCapacity = 1_000,
+  energyAvailable = 800,
+  energyCapacityAvailable = 800
+}: {
+  roomName: string;
+  storageEnergy: number;
+  storageCapacity?: number;
+  energyAvailable?: number;
+  energyCapacityAvailable?: number;
+}): Room {
+  const controller = {
+    id: `${roomName}-controller`,
+    my: true,
+    level: 4
+  } as StructureController;
+  return {
+    name: roomName,
+    controller,
+    energyAvailable,
+    energyCapacityAvailable,
+    memory: {},
+    storage: makeStorage(`${roomName}-storage`, storageEnergy, storageCapacity, roomName),
+    find: jest.fn((type: number) => {
+      if (type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES || type === FIND_MY_STRUCTURES) {
+        return [];
+      }
+
+      return [];
+    })
+  } as unknown as Room;
+}
+
+function makeSpawn(name: string, room: Room): StructureSpawn {
+  return {
+    id: name,
+    name,
+    room,
+    pos: makeRoomPosition(10, 10, room.name),
+    structureType: 'spawn',
+    spawning: null,
+    store: makeStore(300, 300)
+  } as unknown as StructureSpawn;
+}
+
+function makeStorage(id: string, energy: number, capacity: number, roomName: string): StructureStorage {
+  return {
+    id,
+    pos: makeRoomPosition(12, 10, roomName),
+    structureType: 'storage',
+    store: makeStore(energy, capacity)
+  } as unknown as StructureStorage;
+}
+
+function makeStore(energy: number, capacity: number): StoreDefinition {
+  return {
+    getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? capacity : 0)),
+    getFreeCapacity: jest.fn((resource?: ResourceConstant) =>
+      resource === RESOURCE_ENERGY ? Math.max(0, capacity - energy) : 0
+    ),
+    getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? energy : 0))
+  } as unknown as StoreDefinition;
+}
+
+function makeRoomPosition(x: number, y: number, roomName: string): RoomPosition {
+  return {
+    x,
+    y,
+    roomName,
+    getRangeTo: jest.fn((target: RoomObject | RoomPosition) => {
+      const position = 'pos' in target ? target.pos : target;
+      return Math.max(Math.abs(x - position.x), Math.abs(y - position.y));
+    })
+  } as unknown as RoomPosition;
+}
+
+function installGame(rooms: Room[], spawns: StructureSpawn[]): void {
+  (globalThis as { Game: Partial<Game> }).Game = {
+    time: 100,
+    creeps: {},
+    rooms: Object.fromEntries(rooms.map((room) => [room.name, room])),
+    spawns: Object.fromEntries(spawns.map((spawn) => [spawn.name, spawn])),
+    map: {
+      findRoute: jest.fn((_fromRoom: string, targetRoom: string, options?: { routeCallback?: (roomName: string) => number }) => {
+        if (options?.routeCallback?.(targetRoom) === Infinity) {
+          return ERR_NO_PATH_CODE;
+        }
+
+        return [{ exit: 1, room: targetRoom }];
+      })
+    } as unknown as GameMap
+  };
+  (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+}

--- a/prod/test/economy/linkEnergyManagement.test.ts
+++ b/prod/test/economy/linkEnergyManagement.test.ts
@@ -1,0 +1,149 @@
+import {
+  classifyLinks,
+  getSourceLinkWorkerEnergyAvailable,
+  transferEnergy
+} from '../../src/economy/linkManager';
+
+const OK_CODE = 0 as ScreepsReturnCode;
+
+type TestStructureLink = StructureLink & { transferEnergy: jest.Mock };
+
+describe('economy link energy management', () => {
+  beforeEach(() => {
+    Object.assign(globalThis, {
+      FIND_MY_STRUCTURES: 1,
+      FIND_SOURCES: 2,
+      RESOURCE_ENERGY: 'energy',
+      STRUCTURE_LINK: 'link',
+      STRUCTURE_STORAGE: 'storage'
+    });
+  });
+
+  afterEach(() => {
+    delete (globalThis as { FIND_MY_STRUCTURES?: number }).FIND_MY_STRUCTURES;
+    delete (globalThis as { FIND_SOURCES?: number }).FIND_SOURCES;
+    delete (globalThis as { RESOURCE_ENERGY?: ResourceConstant }).RESOURCE_ENERGY;
+    delete (globalThis as { STRUCTURE_LINK?: StructureConstant }).STRUCTURE_LINK;
+    delete (globalThis as { STRUCTURE_STORAGE?: StructureConstant }).STRUCTURE_STORAGE;
+  });
+
+  it('detects owned source and controller links from room structures', () => {
+    const sourceLink = makeLink('source-link', 11, 10, 400, 400);
+    const controllerLink = makeLink('controller-link', 25, 23, 0, 800);
+    const room = makeRoom({
+      controller: makeController(25, 25),
+      links: [controllerLink, sourceLink],
+      sources: [makeSource('source1', 10, 10)]
+    });
+
+    expect(classifyLinks(room)).toMatchObject({
+      links: [{ id: 'controller-link' }, { id: 'source-link' }],
+      sourceLinks: [{ id: 'source-link' }],
+      controllerLink: { id: 'controller-link' }
+    });
+  });
+
+  it('routes source-adjacent link energy to controller capacity while respecting cooldown', () => {
+    const coolingSourceLink = makeLink('cooling-source', 11, 10, 800, 0, 3);
+    const readySourceLink = makeLink('ready-source', 15, 10, 500, 300);
+    const controllerLink = makeLink('controller-link', 25, 23, 0, 300);
+    const room = makeRoom({
+      controller: makeController(25, 25),
+      links: [coolingSourceLink, readySourceLink, controllerLink],
+      sources: [makeSource('source1', 10, 10), makeSource('source2', 14, 10)]
+    });
+
+    expect(transferEnergy(room)).toEqual([
+      {
+        amount: 300,
+        destinationId: 'controller-link',
+        destinationRole: 'controller',
+        result: OK_CODE,
+        sourceId: 'ready-source'
+      }
+    ]);
+    expect(coolingSourceLink.transferEnergy).not.toHaveBeenCalled();
+    expect(readySourceLink.transferEnergy).toHaveBeenCalledWith(controllerLink, 300);
+  });
+
+  it('reserves controller-link routing energy from worker withdrawals', () => {
+    const sourceLink = makeLink('source-link', 11, 10, 500, 300);
+    const controllerLink = makeLink('controller-link', 25, 23, 0, 300);
+    const room = makeRoom({
+      controller: makeController(25, 25),
+      links: [sourceLink, controllerLink],
+      sources: [makeSource('source1', 10, 10)]
+    });
+
+    expect(getSourceLinkWorkerEnergyAvailable(room, sourceLink)).toBe(200);
+  });
+});
+
+function makeRoom({
+  roomName = 'W1N1',
+  controller = makeController(25, 25, roomName),
+  links,
+  sources
+}: {
+  roomName?: string;
+  controller?: StructureController;
+  links: TestStructureLink[];
+  sources: Source[];
+}): Room {
+  return {
+    name: roomName,
+    controller,
+    find: jest.fn((type: number) => {
+      if (type === FIND_MY_STRUCTURES) {
+        return links;
+      }
+
+      if (type === FIND_SOURCES) {
+        return sources;
+      }
+
+      return [];
+    })
+  } as unknown as Room;
+}
+
+function makeLink(
+  id: string,
+  x: number,
+  y: number,
+  energy: number,
+  freeCapacity: number,
+  cooldown = 0,
+  roomName = 'W1N1'
+): TestStructureLink {
+  return {
+    id,
+    cooldown,
+    pos: makeRoomPosition(x, y, roomName),
+    structureType: 'link',
+    store: {
+      getFreeCapacity: jest.fn(() => freeCapacity),
+      getUsedCapacity: jest.fn(() => energy)
+    },
+    transferEnergy: jest.fn(() => OK_CODE)
+  } as unknown as TestStructureLink;
+}
+
+function makeSource(id: string, x: number, y: number, roomName = 'W1N1'): Source {
+  return {
+    id,
+    pos: makeRoomPosition(x, y, roomName)
+  } as unknown as Source;
+}
+
+function makeController(x: number, y: number, roomName = 'W1N1'): StructureController {
+  return {
+    id: `${roomName}-controller`,
+    my: true,
+    pos: makeRoomPosition(x, y, roomName)
+  } as unknown as StructureController;
+}
+
+function makeRoomPosition(x: number, y: number, roomName: string): RoomPosition {
+  return { x, y, roomName } as RoomPosition;
+}


### PR DESCRIPTION
## Summary
- Exports `selectCrossRoomEnergyTransfer` function from `crossRoomHauler.ts` for reuse by link energy management
- Adds unit tests for inter-room energy transfers and link energy management
- Generated build artifact updated

## Verification
- `npm run typecheck`: passes
- `npm test -- --runInBand`: 90 suites, 1656 tests pass
- `npm run build`: succeeds

Refs #861
