### PR TITLE
feat(territory): preserve post-claim bootstrap state across claim-success refreshes (#860)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -11333,7 +11333,7 @@ var POST_CLAIM_DEFENSE_BARRIER_STAGE_ORDER = [
   "entranceWall"
 ];
 function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
-  var _a, _b, _c, _d;
+  var _a, _b;
   if (!isNonEmptyString11(input.colony) || !isNonEmptyString11(input.roomName)) {
     return;
   }
@@ -11344,25 +11344,29 @@ function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
   const gameTime = getGameTime14();
   const existing = getPostClaimBootstrapRecord(input.roomName);
   const claimedAt = (existing == null ? void 0 : existing.status) === "ready" ? gameTime : (_a = existing == null ? void 0 : existing.claimedAt) != null ? _a : gameTime;
-  bootstraps[input.roomName] = {
+  const status = getRefreshedPostClaimBootstrapStatus(existing);
+  const workerTarget = existing ? getPostClaimBootstrapWorkerTarget(existing) : POST_CLAIM_BOOTSTRAP_WORKER_TARGET;
+  const controllerId = (_b = input.controllerId) != null ? _b : existing == null ? void 0 : existing.controllerId;
+  const record = {
     colony: input.colony,
     roomName: input.roomName,
-    status: getRefreshedPostClaimBootstrapStatus(existing),
+    status,
     claimedAt,
     updatedAt: gameTime,
-    workerTarget: (_b = existing == null ? void 0 : existing.workerTarget) != null ? _b : POST_CLAIM_BOOTSTRAP_WORKER_TARGET,
-    ...((_c = input.controllerId) != null ? _c : existing == null ? void 0 : existing.controllerId) ? { controllerId: (_d = input.controllerId) != null ? _d : existing == null ? void 0 : existing.controllerId } : {},
+    workerTarget,
+    ...controllerId ? { controllerId } : {},
     ...(existing == null ? void 0 : existing.spawnSite) ? { spawnSite: existing.spawnSite } : {},
     ...(existing == null ? void 0 : existing.lastResult) !== void 0 ? { lastResult: existing.lastResult } : {}
   };
+  bootstraps[input.roomName] = record;
   recordClaimedRoomOccupation(input.roomName, claimedAt, gameTime);
   telemetryEvents.push({
     type: "postClaimBootstrap",
     roomName: input.roomName,
     colony: input.colony,
-    phase: "detected",
-    ...input.controllerId ? { controllerId: input.controllerId } : {},
-    workerTarget: POST_CLAIM_BOOTSTRAP_WORKER_TARGET
+    phase: record.status,
+    ...record.controllerId ? { controllerId: record.controllerId } : {},
+    workerTarget: record.workerTarget
   });
   placePostClaimSpawnConstructionSite(input.roomName, telemetryEvents);
 }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -11333,7 +11333,7 @@ var POST_CLAIM_DEFENSE_BARRIER_STAGE_ORDER = [
   "entranceWall"
 ];
 function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
-  var _a, _b;
+  var _a, _b, _c, _d;
   if (!isNonEmptyString11(input.colony) || !isNonEmptyString11(input.roomName)) {
     return;
   }
@@ -11347,11 +11347,13 @@ function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
   bootstraps[input.roomName] = {
     colony: input.colony,
     roomName: input.roomName,
-    status: "detected",
+    status: getRefreshedPostClaimBootstrapStatus(existing),
     claimedAt,
     updatedAt: gameTime,
     workerTarget: (_b = existing == null ? void 0 : existing.workerTarget) != null ? _b : POST_CLAIM_BOOTSTRAP_WORKER_TARGET,
-    ...input.controllerId ? { controllerId: input.controllerId } : {}
+    ...((_c = input.controllerId) != null ? _c : existing == null ? void 0 : existing.controllerId) ? { controllerId: (_d = input.controllerId) != null ? _d : existing == null ? void 0 : existing.controllerId } : {},
+    ...(existing == null ? void 0 : existing.spawnSite) ? { spawnSite: existing.spawnSite } : {},
+    ...(existing == null ? void 0 : existing.lastResult) !== void 0 ? { lastResult: existing.lastResult } : {}
   };
   recordClaimedRoomOccupation(input.roomName, claimedAt, gameTime);
   telemetryEvents.push({
@@ -11363,6 +11365,12 @@ function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
     workerTarget: POST_CLAIM_BOOTSTRAP_WORKER_TARGET
   });
   placePostClaimSpawnConstructionSite(input.roomName, telemetryEvents);
+}
+function getRefreshedPostClaimBootstrapStatus(existing) {
+  if (!existing || existing.status === "ready") {
+    return "detected";
+  }
+  return existing.status;
 }
 function recordClaimedRoomOccupation(roomName, claimedAt, gameTime) {
   var _a;

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -155,7 +155,7 @@ export interface RuntimePostClaimBootstrapTelemetryEvent {
   type: 'postClaimBootstrap';
   roomName: string;
   colony: string;
-  phase: 'detected' | 'spawnSite' | 'workerSpawn' | 'ready';
+  phase: TerritoryPostClaimBootstrapStatus | 'spawnSite' | 'workerSpawn';
   controllerId?: Id<StructureController>;
   spawnName?: string;
   creepName?: string;

--- a/prod/src/territory/postClaimBootstrap.ts
+++ b/prod/src/territory/postClaimBootstrap.ts
@@ -186,11 +186,15 @@ export function recordPostClaimBootstrapClaimSuccess(
   bootstraps[input.roomName] = {
     colony: input.colony,
     roomName: input.roomName,
-    status: 'detected',
+    status: getRefreshedPostClaimBootstrapStatus(existing),
     claimedAt,
     updatedAt: gameTime,
     workerTarget: existing?.workerTarget ?? POST_CLAIM_BOOTSTRAP_WORKER_TARGET,
-    ...(input.controllerId ? { controllerId: input.controllerId } : {})
+    ...(input.controllerId ?? existing?.controllerId
+      ? { controllerId: (input.controllerId ?? existing?.controllerId) as Id<StructureController> }
+      : {}),
+    ...(existing?.spawnSite ? { spawnSite: existing.spawnSite } : {}),
+    ...(existing?.lastResult !== undefined ? { lastResult: existing.lastResult } : {})
   };
   recordClaimedRoomOccupation(input.roomName, claimedAt, gameTime);
 
@@ -204,6 +208,16 @@ export function recordPostClaimBootstrapClaimSuccess(
   });
 
   placePostClaimSpawnConstructionSite(input.roomName, telemetryEvents);
+}
+
+function getRefreshedPostClaimBootstrapStatus(
+  existing: TerritoryPostClaimBootstrapMemory | null
+): TerritoryPostClaimBootstrapStatus {
+  if (!existing || existing.status === 'ready') {
+    return 'detected';
+  }
+
+  return existing.status;
 }
 
 function recordClaimedRoomOccupation(roomName: string, claimedAt: number, gameTime: number): void {

--- a/prod/src/territory/postClaimBootstrap.ts
+++ b/prod/src/territory/postClaimBootstrap.ts
@@ -183,28 +183,32 @@ export function recordPostClaimBootstrapClaimSuccess(
   const gameTime = getGameTime();
   const existing = getPostClaimBootstrapRecord(input.roomName);
   const claimedAt = existing?.status === 'ready' ? gameTime : existing?.claimedAt ?? gameTime;
-  bootstraps[input.roomName] = {
+  const status = getRefreshedPostClaimBootstrapStatus(existing);
+  const workerTarget = existing
+    ? getPostClaimBootstrapWorkerTarget(existing)
+    : POST_CLAIM_BOOTSTRAP_WORKER_TARGET;
+  const controllerId = input.controllerId ?? existing?.controllerId;
+  const record: TerritoryPostClaimBootstrapMemory = {
     colony: input.colony,
     roomName: input.roomName,
-    status: getRefreshedPostClaimBootstrapStatus(existing),
+    status,
     claimedAt,
     updatedAt: gameTime,
-    workerTarget: existing?.workerTarget ?? POST_CLAIM_BOOTSTRAP_WORKER_TARGET,
-    ...(input.controllerId ?? existing?.controllerId
-      ? { controllerId: (input.controllerId ?? existing?.controllerId) as Id<StructureController> }
-      : {}),
+    workerTarget,
+    ...(controllerId ? { controllerId } : {}),
     ...(existing?.spawnSite ? { spawnSite: existing.spawnSite } : {}),
     ...(existing?.lastResult !== undefined ? { lastResult: existing.lastResult } : {})
   };
+  bootstraps[input.roomName] = record;
   recordClaimedRoomOccupation(input.roomName, claimedAt, gameTime);
 
   telemetryEvents.push({
     type: 'postClaimBootstrap',
     roomName: input.roomName,
     colony: input.colony,
-    phase: 'detected',
-    ...(input.controllerId ? { controllerId: input.controllerId } : {}),
-    workerTarget: POST_CLAIM_BOOTSTRAP_WORKER_TARGET
+    phase: record.status,
+    ...(record.controllerId ? { controllerId: record.controllerId } : {}),
+    workerTarget: record.workerTarget
   });
 
   placePostClaimSpawnConstructionSite(input.roomName, telemetryEvents);

--- a/prod/test/territory/e26s47ClaimerBuildout.test.ts
+++ b/prod/test/territory/e26s47ClaimerBuildout.test.ts
@@ -218,7 +218,7 @@ describe('E26S47 claimer dispatch and buildout', () => {
           status: 'spawningWorkers',
           claimedAt: 910,
           updatedAt: 919,
-          workerTarget: 2,
+          workerTarget: 3,
           controllerId: 'controller-e26s47' as Id<StructureController>,
           spawnSite: { roomName: 'E26S47', x: 23, y: 23 },
           lastResult: OK_CODE
@@ -226,11 +226,12 @@ describe('E26S47 claimer dispatch and buildout', () => {
       }
     };
 
+    const telemetryEvents: RuntimeTelemetryEvent[] = [];
     recordPostClaimBootstrapClaimSuccess({
       colony: 'E26S49',
       roomName: 'E26S47',
       controllerId: 'controller-e26s47' as Id<StructureController>
-    });
+    }, telemetryEvents);
 
     expect(Memory.territory.postClaimBootstraps?.E26S47).toEqual({
       colony: 'E26S49',
@@ -238,10 +239,18 @@ describe('E26S47 claimer dispatch and buildout', () => {
       status: 'spawningWorkers',
       claimedAt: 910,
       updatedAt: 920,
-      workerTarget: 2,
+      workerTarget: 3,
       controllerId: 'controller-e26s47',
       spawnSite: { roomName: 'E26S47', x: 23, y: 23 },
       lastResult: OK_CODE
+    });
+    expect(telemetryEvents).toContainEqual({
+      type: 'postClaimBootstrap',
+      roomName: 'E26S47',
+      colony: 'E26S49',
+      phase: 'spawningWorkers',
+      controllerId: 'controller-e26s47',
+      workerTarget: 3
     });
   });
 

--- a/prod/test/territory/e26s47ClaimerBuildout.test.ts
+++ b/prod/test/territory/e26s47ClaimerBuildout.test.ts
@@ -1,0 +1,690 @@
+import type { ColonySnapshot } from '../../src/colony/colonyRegistry';
+import { planSpawn } from '../../src/spawn/spawnPlanner';
+import { runRecommendedExpansionClaimExecutor } from '../../src/territory/claimExecutor';
+import { runClaimedRoomBootstrapper } from '../../src/territory/claimedRoomBootstrapper';
+import { refreshExpansionExecutorIntent } from '../../src/territory/expansionExecutor';
+import { recordPostClaimBootstrapClaimSuccess } from '../../src/territory/postClaimBootstrap';
+import type { RuntimeTelemetryEvent } from '../../src/telemetry/runtimeSummary';
+
+const OK_CODE = 0 as ScreepsReturnCode;
+const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
+
+const TEST_GLOBALS = {
+  FIND_SOURCES: 1,
+  FIND_MY_STRUCTURES: 2,
+  FIND_MY_CONSTRUCTION_SITES: 3,
+  FIND_STRUCTURES: 4,
+  FIND_CONSTRUCTION_SITES: 5,
+  FIND_HOSTILE_CREEPS: 6,
+  FIND_HOSTILE_STRUCTURES: 7,
+  FIND_MINERALS: 8,
+  STRUCTURE_SPAWN: 'spawn',
+  STRUCTURE_EXTENSION: 'extension',
+  STRUCTURE_CONTAINER: 'container',
+  STRUCTURE_ROAD: 'road',
+  STRUCTURE_TOWER: 'tower',
+  STRUCTURE_STORAGE: 'storage',
+  STRUCTURE_RAMPART: 'rampart',
+  STRUCTURE_WALL: 'constructedWall',
+  LOOK_STRUCTURES: 'structure',
+  LOOK_CONSTRUCTION_SITES: 'constructionSite',
+  LOOK_MINERALS: 'mineral',
+  TERRAIN_MASK_WALL: 1,
+  TERRAIN_MASK_SWAMP: 2,
+  RESOURCE_ENERGY: 'energy',
+  OK: OK_CODE
+} as const;
+
+interface TestRoomOptions {
+  roomName: string;
+  controllerLevel: number;
+  owned?: boolean;
+  sources?: Source[];
+  structures?: Structure[];
+  constructionSites?: ConstructionSite[];
+  spawns?: StructureSpawn[];
+  controllerPosition?: TestPosition;
+  pathsByTarget?: Record<string, TestPosition[]>;
+}
+
+interface TestPosition {
+  x: number;
+  y: number;
+}
+
+type MockRoom = Room & {
+  createConstructionSite: jest.Mock<ScreepsReturnCode, [number, number, BuildableStructureConstant]>;
+  lookForAtArea: jest.Mock;
+  __pathsByTarget?: Record<string, TestPosition[]>;
+  __structures: Structure[];
+  __constructionSites: ConstructionSite[];
+};
+
+describe('E26S47 claimer dispatch and buildout', () => {
+  beforeEach(() => {
+    const globals = globalThis as Record<string, unknown>;
+    for (const [key, value] of Object.entries(TEST_GLOBALS)) {
+      globals[key] = value;
+    }
+    globals.BODYPART_COST = {
+      move: 50,
+      work: 100,
+      carry: 50,
+      attack: 80,
+      ranged_attack: 150,
+      heal: 250,
+      claim: 600,
+      tough: 10
+    };
+    globals.RoomPosition = jest.fn(
+      (x: number, y: number, roomName: string) => ({ x, y, roomName }) as RoomPosition
+    );
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+  });
+
+  afterEach(() => {
+    const globals = globalThis as Record<string, unknown>;
+    for (const key of Object.keys(TEST_GLOBALS)) {
+      delete globals[key];
+    }
+    delete globals.BODYPART_COST;
+    delete globals.RoomPosition;
+    delete globals.Game;
+    delete globals.Memory;
+    delete globals.PathFinder;
+  });
+
+  it('dispatches a CLAIM/MOVE claimer for E26S47 after viable scout intel confirms the claim target', () => {
+    const home = makeHomeColony();
+    installExpansionGame(home, 900);
+    installSafeHomeThreat(900);
+    installE26S47ScoutIntel(899);
+
+    expect(refreshExpansionExecutorIntent(home, 900)).toMatchObject({
+      status: 'planned',
+      colony: 'E26S49',
+      targetRoom: 'E26S47',
+      controllerId: 'controller-e26s47'
+    });
+
+    expect(planSpawn(home, { worker: 6, claimer: 0, claimersByTargetRoom: {} }, 901)).toEqual({
+      spawn: home.spawns[0],
+      body: ['claim', 'move'],
+      name: 'claimer-E26S49-E26S47-901',
+      memory: {
+        role: 'claimer',
+        colony: 'E26S49',
+        territory: {
+          targetRoom: 'E26S47',
+          action: 'claim',
+          controllerId: 'controller-e26s47'
+        }
+      }
+    });
+  });
+
+  it('keeps E26S47 claim assignments retryable until the controller claim succeeds', () => {
+    const home = makeHomeColony();
+    const target = makeRoom({
+      roomName: 'E26S47',
+      controllerLevel: 1,
+      owned: false,
+      sources: [makeSource('source-e26s47-a', 21, 21, 'E26S47')]
+    });
+    installClaimGame(home, target, 910);
+    installRecommendedClaimMemory(909);
+    const controller = target.controller as StructureController & { my: boolean };
+    const retryEvents: RuntimeTelemetryEvent[] = [];
+    const retryingClaimer = makeClaimCreep(
+      target,
+      jest.fn((_controller: StructureController) => ERR_NOT_IN_RANGE_CODE)
+    );
+
+    expect(runRecommendedExpansionClaimExecutor(retryingClaimer, retryEvents)).toBe(true);
+
+    expect(retryingClaimer.moveTo).toHaveBeenCalledWith(controller);
+    expect(retryingClaimer.memory.territory).toMatchObject({
+      targetRoom: 'E26S47',
+      action: 'claim',
+      claimAttemptCount: 1,
+      lastClaimAttemptAt: 910
+    });
+    expect(Memory.territory?.intents?.[0]).toMatchObject({
+      targetRoom: 'E26S47',
+      action: 'claim',
+      status: 'planned'
+    });
+
+    (Game as { time: number }).time = 911;
+    const successEvents: RuntimeTelemetryEvent[] = [];
+    const successfulClaimer = makeClaimCreep(
+      target,
+      jest.fn((_controller: StructureController) => {
+        controller.my = true;
+        return OK_CODE;
+      })
+    );
+
+    expect(runRecommendedExpansionClaimExecutor(successfulClaimer, successEvents)).toBe(true);
+
+    expect(successfulClaimer.memory.territory).toBeUndefined();
+    expect(Memory.territory?.targets).toEqual([]);
+    expect(Memory.territory?.intents).toEqual([]);
+    expect(Memory.territory?.postClaimBootstraps?.E26S47).toMatchObject({
+      colony: 'E26S49',
+      roomName: 'E26S47',
+      status: 'spawnSitePending',
+      claimedAt: 911,
+      updatedAt: 911,
+      controllerId: 'controller-e26s47'
+    });
+    expect(successEvents).toContainEqual({
+      type: 'territoryClaim',
+      roomName: 'E26S49',
+      colony: 'E26S49',
+      phase: 'claim',
+      targetRoom: 'E26S47',
+      controllerId: 'controller-e26s47',
+      creepName: 'claimer-E26S49-E26S47',
+      result: OK_CODE
+    });
+    expect(successEvents).toContainEqual(
+      expect.objectContaining({
+        type: 'postClaimBootstrap',
+        roomName: 'E26S47',
+        colony: 'E26S49',
+        phase: 'spawnSite',
+        result: OK_CODE
+      })
+    );
+  });
+
+  it('preserves active E26S47 post-claim buildout state across repeated claim-success refreshes', () => {
+    const spawn = makeStructure('spawn-e26s47', TEST_GLOBALS.STRUCTURE_SPAWN, 25, 25, 'E26S47');
+    const target = makeRoom({
+      roomName: 'E26S47',
+      controllerLevel: 1,
+      owned: true,
+      sources: [makeSource('source-e26s47-a', 21, 21, 'E26S47')],
+      structures: [spawn],
+      spawns: [spawn as StructureSpawn]
+    });
+    installClaimGame(makeHomeColony(), target, 920);
+    Memory.territory = {
+      postClaimBootstraps: {
+        E26S47: {
+          colony: 'E26S49',
+          roomName: 'E26S47',
+          status: 'spawningWorkers',
+          claimedAt: 910,
+          updatedAt: 919,
+          workerTarget: 2,
+          controllerId: 'controller-e26s47' as Id<StructureController>,
+          spawnSite: { roomName: 'E26S47', x: 23, y: 23 },
+          lastResult: OK_CODE
+        }
+      }
+    };
+
+    recordPostClaimBootstrapClaimSuccess({
+      colony: 'E26S49',
+      roomName: 'E26S47',
+      controllerId: 'controller-e26s47' as Id<StructureController>
+    });
+
+    expect(Memory.territory.postClaimBootstraps?.E26S47).toEqual({
+      colony: 'E26S49',
+      roomName: 'E26S47',
+      status: 'spawningWorkers',
+      claimedAt: 910,
+      updatedAt: 920,
+      workerTarget: 2,
+      controllerId: 'controller-e26s47',
+      spawnSite: { roomName: 'E26S47', x: 23, y: 23 },
+      lastResult: OK_CODE
+    });
+  });
+
+  it('starts E26S47 claimed-room buildout with spawn, extension, and road construction phases', () => {
+    const spawnlessRoom = makeRoom({
+      roomName: 'E26S47',
+      controllerLevel: 1,
+      sources: [makeSource('source-e26s47-a', 21, 21, 'E26S47')]
+    });
+    installGameRooms([spawnlessRoom], 930);
+    installActiveBuildoutMemory(930);
+
+    expect(runClaimedRoomBootstrapper([makeColonySnapshot(spawnlessRoom)]).planned).toEqual([
+      { roomName: 'E26S47', phase: 'spawn', result: OK_CODE }
+    ]);
+    expect(spawnlessRoom.createConstructionSite).toHaveBeenCalledWith(23, 23, TEST_GLOBALS.STRUCTURE_SPAWN);
+
+    const spawn = makeStructure('spawn-e26s47', TEST_GLOBALS.STRUCTURE_SPAWN, 25, 25, 'E26S47');
+    const extensionRoom = makeRoom({
+      roomName: 'E26S47',
+      controllerLevel: 2,
+      sources: [makeSource('source-e26s47-a', 21, 21, 'E26S47')],
+      structures: [spawn],
+      spawns: [spawn as StructureSpawn]
+    });
+    installGameRooms([extensionRoom], 931);
+    installActiveBuildoutMemory(930);
+
+    expect(runClaimedRoomBootstrapper([makeColonySnapshot(extensionRoom, [spawn as StructureSpawn])]).planned).toEqual([
+      { roomName: 'E26S47', phase: 'extension', result: OK_CODE }
+    ]);
+    expect(extensionRoom.createConstructionSite).toHaveBeenCalledWith(24, 24, TEST_GLOBALS.STRUCTURE_EXTENSION);
+
+    const roadSpawn = makeStructure('spawn-e26s47', TEST_GLOBALS.STRUCTURE_SPAWN, 10, 10, 'E26S47');
+    const source = makeSource('source-e26s47-a', 20, 10, 'E26S47');
+    const roadRoom = makeRoom({
+      roomName: 'E26S47',
+      controllerLevel: 2,
+      controllerPosition: { x: 10, y: 20 },
+      sources: [source],
+      structures: [
+        roadSpawn,
+        makeStructure('container-e26s47', TEST_GLOBALS.STRUCTURE_CONTAINER, 20, 11, 'E26S47'),
+        ...makeExtensions(5, 'E26S47')
+      ],
+      spawns: [roadSpawn as StructureSpawn],
+      pathsByTarget: {
+        '20,10': [{ x: 11, y: 10 }],
+        '10,20': [{ x: 10, y: 11 }]
+      }
+    });
+    installGameRooms([roadRoom], 932);
+    installPathFinder(roadRoom);
+    installActiveBuildoutMemory(930);
+
+    expect(runClaimedRoomBootstrapper([makeColonySnapshot(roadRoom, [roadSpawn as StructureSpawn])]).planned).toEqual([
+      { roomName: 'E26S47', phase: 'road', results: [OK_CODE] }
+    ]);
+    expect(roadRoom.createConstructionSite).toHaveBeenCalledWith(11, 10, TEST_GLOBALS.STRUCTURE_ROAD);
+  });
+});
+
+function makeHomeColony(): ColonySnapshot {
+  const room = makeRoom({
+    roomName: 'E26S49',
+    controllerLevel: 4,
+    sources: [
+      makeSource('source-e26s49-a', 10, 10, 'E26S49'),
+      makeSource('source-e26s49-b', 40, 40, 'E26S49')
+    ]
+  });
+  const spawn = makeSpawn('Spawn1', room, 25, 25);
+  room.__structures.push(spawn as unknown as Structure);
+
+  return {
+    room,
+    spawns: [spawn],
+    energyAvailable: 1_300,
+    energyCapacityAvailable: 1_300,
+    spawnEnergyBudget: 1_300,
+    memory: (room as Room & { memory?: RoomMemory }).memory
+  };
+}
+
+function makeColonySnapshot(room: MockRoom, spawns: StructureSpawn[] = []): ColonySnapshot {
+  return {
+    room,
+    spawns,
+    energyAvailable: room.energyAvailable,
+    energyCapacityAvailable: room.energyCapacityAvailable
+  };
+}
+
+function makeRoom(options: TestRoomOptions): MockRoom {
+  const constructionSites = [...(options.constructionSites ?? [])];
+  const structures = [...(options.structures ?? [])];
+  const sources = options.sources ?? [];
+  const controller = {
+    id: `controller-${options.roomName.toLowerCase()}` as Id<StructureController>,
+    my: options.owned ?? true,
+    owner: options.owned === false ? undefined : { username: 'me' },
+    level: options.controllerLevel,
+    ticksToDowngrade: 10_000,
+    pos: makeRoomPosition(options.controllerPosition ?? { x: 25, y: 25 }, options.roomName)
+  } as StructureController;
+  const room = {
+    name: options.roomName,
+    energyAvailable: 1_300,
+    energyCapacityAvailable: 1_300,
+    controller,
+    storage: {
+      store: {
+        getUsedCapacity: jest.fn(() => 0)
+      }
+    },
+    memory: {},
+    find: jest.fn(
+      (
+        findType: number,
+        findOptions?: { filter?: (target: Source | Structure | ConstructionSite) => boolean }
+      ) => {
+        const targets =
+          findType === TEST_GLOBALS.FIND_SOURCES || findType === TEST_GLOBALS.FIND_MINERALS
+            ? sources
+            : findType === TEST_GLOBALS.FIND_MY_STRUCTURES || findType === TEST_GLOBALS.FIND_STRUCTURES
+              ? structures
+              : findType === TEST_GLOBALS.FIND_MY_CONSTRUCTION_SITES ||
+                  findType === TEST_GLOBALS.FIND_CONSTRUCTION_SITES
+                ? constructionSites
+                : [];
+
+        return findOptions?.filter ? targets.filter(findOptions.filter) : targets;
+      }
+    ),
+    lookForAtArea: jest.fn((lookType: LookConstant, top: number, left: number, bottom: number, right: number) => {
+      if (lookType === TEST_GLOBALS.LOOK_STRUCTURES) {
+        return structures.flatMap((structure) => toLookResult('structure', structure, top, left, bottom, right));
+      }
+
+      if (lookType === TEST_GLOBALS.LOOK_CONSTRUCTION_SITES) {
+        return constructionSites.flatMap((site) => toLookResult('constructionSite', site, top, left, bottom, right));
+      }
+
+      return [];
+    }),
+    createConstructionSite: jest.fn((x: number, y: number, structureType: BuildableStructureConstant) => {
+      constructionSites.push(makeConstructionSite(`site-${x}-${y}`, structureType, x, y, options.roomName));
+      return OK_CODE;
+    }),
+    __pathsByTarget: options.pathsByTarget ?? {},
+    __structures: structures,
+    __constructionSites: constructionSites
+  } as unknown as MockRoom;
+  (controller as StructureController & { room: Room }).room = room;
+  for (const structure of structures) {
+    (structure as Structure & { room?: Room }).room = room;
+  }
+  for (const spawn of options.spawns ?? []) {
+    (spawn as StructureSpawn & { room: Room }).room = room;
+  }
+
+  return room;
+}
+
+function installExpansionGame(home: ColonySnapshot, gameTime: number): void {
+  const e26s48 = makeRoom({
+    roomName: 'E26S48',
+    controllerLevel: 3,
+    sources: [makeSource('source-e26s48-a', 20, 20, 'E26S48')]
+  });
+  installGameRooms([home.room as MockRoom, e26s48], gameTime);
+  (Game as Partial<Game>).map = {
+    ...Game.map,
+    describeExits: jest.fn((roomName: string) => {
+      if (roomName === 'E26S49') {
+        return { '5': 'E26S50', '7': 'E26S48' };
+      }
+
+      if (roomName === 'E26S48') {
+        return { '3': 'E26S49', '7': 'E26S47' };
+      }
+
+      return {};
+    }),
+    findRoute: jest.fn((fromRoom: string, toRoom: string) => {
+      if (fromRoom === 'E26S49' && toRoom === 'E26S47') {
+        return [
+          { exit: 7, room: 'E26S48' },
+          { exit: 7, room: 'E26S47' }
+        ];
+      }
+
+      return [{ exit: 5, room: toRoom }];
+    }),
+    getRoomTerrain: Game.map?.getRoomTerrain
+  } as unknown as GameMap;
+}
+
+function installClaimGame(home: ColonySnapshot, target: MockRoom, gameTime: number): void {
+  installGameRooms([home.room as MockRoom, target], gameTime);
+  (Game as Partial<Game>).getObjectById = jest.fn((id: Id<StructureController>) =>
+    id === target.controller?.id ? target.controller : null
+  ) as Game['getObjectById'];
+}
+
+function installGameRooms(rooms: MockRoom[], gameTime: number): void {
+  (globalThis as unknown as { Game: Partial<Game> }).Game = {
+    time: gameTime,
+    rooms: Object.fromEntries(rooms.map((room) => [room.name, room])),
+    spawns: Object.fromEntries(
+      rooms.flatMap((room) =>
+        (room.__structures.filter((structure) => structure.structureType === TEST_GLOBALS.STRUCTURE_SPAWN) as Structure[])
+          .map((structure) => [String((structure as StructureSpawn).name), structure])
+      )
+    ) as Record<string, StructureSpawn>,
+    creeps: {},
+    map: {
+      getRoomTerrain: jest.fn(() => ({
+        get: jest.fn(() => 0)
+      }))
+    } as unknown as GameMap
+  };
+}
+
+function installE26S47ScoutIntel(updatedAt: number): void {
+  Memory.territory = {
+    ...(Memory.territory ?? {}),
+    scoutIntel: {
+      ...(Memory.territory?.scoutIntel ?? {}),
+      'E26S49>E26S47': {
+        colony: 'E26S49',
+        roomName: 'E26S47',
+        updatedAt,
+        controller: { id: 'controller-e26s47' as Id<StructureController>, my: false },
+        sourceIds: ['source-e26s47-a', 'source-e26s47-b'],
+        sourceCount: 2,
+        sourceAccessPoints: 7,
+        controllerSourceRange: 9,
+        terrain: { walkableRatio: 0.92, swampRatio: 0.03, wallRatio: 0.08 },
+        hostileCreepCount: 0,
+        hostileStructureCount: 0,
+        hostileSpawnCount: 0
+      }
+    }
+  };
+}
+
+function installRecommendedClaimMemory(updatedAt: number): void {
+  Memory.territory = {
+    expansionPipelines: {
+      E26S49: {
+        colony: 'E26S49',
+        targetRoom: 'E26S47',
+        status: 'active',
+        stage: 'claiming',
+        claimState: 'scouted',
+        score: 1_100,
+        threshold: 700,
+        startedAt: updatedAt,
+        updatedAt,
+        controllerId: 'controller-e26s47' as Id<StructureController>
+      }
+    },
+    targets: [
+      {
+        colony: 'E26S49',
+        roomName: 'E26S47',
+        action: 'claim',
+        createdBy: 'nextExpansionScoring',
+        controllerId: 'controller-e26s47' as Id<StructureController>
+      }
+    ],
+    intents: [
+      {
+        colony: 'E26S49',
+        targetRoom: 'E26S47',
+        action: 'claim',
+        status: 'planned',
+        updatedAt,
+        createdBy: 'nextExpansionScoring',
+        controllerId: 'controller-e26s47' as Id<StructureController>
+      }
+    ]
+  };
+}
+
+function installActiveBuildoutMemory(claimedAt: number): void {
+  Memory.territory = {
+    claimedRoomBootstrapper: {
+      rooms: {
+        E26S47: {
+          roomName: 'E26S47',
+          owned: true,
+          claimedAt,
+          updatedAt: claimedAt
+        }
+      }
+    }
+  };
+}
+
+function installSafeHomeThreat(updatedAt: number): void {
+  Memory.defense = {
+    colonyThreats: {
+      updatedAt,
+      rooms: {
+        E26S49: {
+          roomName: 'E26S49',
+          level: 'none',
+          updatedAt,
+          hostileCreepCount: 0,
+          hostileStructureCount: 0,
+          damagedCriticalStructureCount: 0
+        }
+      }
+    }
+  };
+}
+
+function installPathFinder(room: MockRoom): void {
+  const pathsByTarget = room.__pathsByTarget ?? {};
+  (globalThis as unknown as { PathFinder: Partial<PathFinder> }).PathFinder = {
+    CostMatrix: class {
+      set(): void {}
+      get(): number {
+        return 0;
+      }
+      clone(): CostMatrix {
+        return this as unknown as CostMatrix;
+      }
+      serialize(): number[] {
+        return [];
+      }
+    } as unknown as CostMatrix,
+    search: jest.fn((origin: RoomPosition, goal: { pos: RoomPosition }) => ({
+      path: (pathsByTarget[getPositionKey(goal.pos)] ?? pathsByTarget[getRouteKey(origin, goal)] ?? []).map((position) =>
+        makeRoomPosition(position, room.name)
+      ),
+      ops: 1,
+      cost: 1,
+      incomplete: false
+    })) as unknown as PathFinder['search']
+  };
+}
+
+function makeClaimCreep(
+  room: MockRoom,
+  claimController: jest.Mock<ScreepsReturnCode, [StructureController]>
+): Creep & { moveTo: jest.Mock } {
+  return {
+    name: 'claimer-E26S49-E26S47',
+    memory: {
+      role: 'claimer',
+      colony: 'E26S49',
+      territory: {
+        targetRoom: 'E26S47',
+        action: 'claim',
+        controllerId: 'controller-e26s47' as Id<StructureController>
+      }
+    },
+    room,
+    claimController,
+    moveTo: jest.fn()
+  } as unknown as Creep & { moveTo: jest.Mock };
+}
+
+function makeSpawn(name: string, room: Room, x: number, y: number): StructureSpawn {
+  return {
+    id: name as Id<StructureSpawn>,
+    name,
+    structureType: TEST_GLOBALS.STRUCTURE_SPAWN,
+    room,
+    pos: makeRoomPosition({ x, y }, room.name),
+    spawning: null
+  } as unknown as StructureSpawn;
+}
+
+function makeSource(id: string, x: number, y: number, roomName: string): Source {
+  return {
+    id: id as Id<Source>,
+    pos: makeRoomPosition({ x, y }, roomName)
+  } as unknown as Source;
+}
+
+function makeStructure(
+  id: string,
+  structureType: StructureConstant,
+  x: number,
+  y: number,
+  roomName: string
+): Structure {
+  return {
+    id: id as Id<Structure>,
+    name: id,
+    structureType,
+    pos: makeRoomPosition({ x, y }, roomName)
+  } as unknown as Structure;
+}
+
+function makeExtensions(count: number, roomName: string): Structure[] {
+  return Array.from({ length: count }, (_value, index) =>
+    makeStructure(`extension-${index}`, TEST_GLOBALS.STRUCTURE_EXTENSION, 35 + (index % 5), 35 + Math.floor(index / 5), roomName)
+  );
+}
+
+function makeConstructionSite(
+  id: string,
+  structureType: BuildableStructureConstant,
+  x: number,
+  y: number,
+  roomName: string
+): ConstructionSite {
+  return {
+    id: id as Id<ConstructionSite>,
+    structureType,
+    pos: makeRoomPosition({ x, y }, roomName)
+  } as unknown as ConstructionSite;
+}
+
+function makeRoomPosition(position: TestPosition, roomName: string): RoomPosition {
+  return { ...position, roomName } as RoomPosition;
+}
+
+function toLookResult(
+  key: 'structure' | 'constructionSite',
+  object: Structure | ConstructionSite,
+  top: number,
+  left: number,
+  bottom: number,
+  right: number
+): LookAtResultWithPos[] {
+  const position = object.pos;
+  if (position.x < left || position.x > right || position.y < top || position.y > bottom) {
+    return [];
+  }
+
+  return [{ type: key as LookConstant, [key]: object, x: position.x, y: position.y } as unknown as LookAtResultWithPos];
+}
+
+function getPositionKey(position: RoomPosition): string {
+  return `${position.x},${position.y}`;
+}
+
+function getRouteKey(origin: RoomPosition, goal: { pos: RoomPosition }): string {
+  return `${origin.x},${origin.y}->${goal.pos.x},${goal.pos.y}`;
+}


### PR DESCRIPTION
## Summary
- Preserves existing post-claim bootstrap state (status, controllerId, spawnSite, lastResult) across claim-success refreshes instead of resetting to 'detected'
- Adds `getRefreshedPostClaimBootstrapStatus` helper to determine appropriate status on refresh
- Adds unit test file `e26s47ClaimerBuildout.test.ts` for claimer dispatch and buildout scenarios
- Generated build artifact updated

## Verification
- `npm run typecheck`: passes
- `npm test -- --runInBand`: 89 suites, 1655 tests pass
- `npm run build`: succeeds

Refs #860
