### PR TITLE
feat(economy): multi-room spawn energy buffer coordination for E26S49+E26S47 colony (#865)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -17362,7 +17362,7 @@ function getSpawnEnergyBufferSnapshot(room, spawns, currentEnergy = getRoomEnerg
 }
 function getRoomSpawnEnergyBufferNeed(room, spawns = getRoomSpawns2(room), currentEnergy = getRoomEnergyAvailable8(room)) {
   const snapshot = getSpawnEnergyBufferSnapshot(room, spawns, currentEnergy);
-  const threshold = snapshot.spawnCount > 0 ? snapshot.threshold : 0;
+  const threshold = snapshot.threshold;
   const criticalThreshold = getCriticalSpawnEnergyBufferThreshold(threshold, snapshot.spawnCount);
   return {
     criticalDeficit: Math.max(0, criticalThreshold - snapshot.currentEnergy),
@@ -18483,7 +18483,7 @@ function buildMultiRoomEnergyRoom(input) {
     spawnEnergyBufferDeficit: roomState.spawnEnergyBufferDeficit,
     criticalSpawnEnergyDeficit: roomState.criticalSpawnEnergyDeficit,
     storageDeficit,
-    deficitEnergy: storageDeficit + roomState.spawnEnergyBufferDeficit,
+    deficitEnergy: storageDeficit,
     surplusEnergy,
     suppressedImportEnergy,
     blockedImportEnergy,

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -18749,7 +18749,7 @@ function getRoomStoredEnergyState(room) {
   const rawExportableEnergy = capacity > 0 && ratio > STORAGE_BALANCE_EXPORT_RATIO ? Math.floor(energy - capacity * STORAGE_BALANCE_EXPORT_RATIO) : 0;
   const exportableEnergy = Math.max(
     0,
-    rawExportableEnergy - spawnEnergyReservation.unmetReservedEnergy - spawnEnergyBufferNeed.deficit
+    rawExportableEnergy - spawnEnergyBufferNeed.deficit
   );
   const storageImportDemand = capacity > 0 && ratio < STORAGE_BALANCE_IMPORT_RATIO ? Math.ceil(capacity * STORAGE_BALANCE_IMPORT_RATIO - energy) : 0;
   const importDemand = storageImportDemand + spawnEnergyBufferNeed.deficit;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -17360,6 +17360,21 @@ function getSpawnEnergyBufferSnapshot(room, spawns, currentEnergy = getRoomEnerg
     unmetReservedEnergy: reservation.unmetReservedEnergy
   };
 }
+function getRoomSpawnEnergyBufferNeed(room, spawns = getRoomSpawns2(room), currentEnergy = getRoomEnergyAvailable8(room)) {
+  const snapshot = getSpawnEnergyBufferSnapshot(room, spawns, currentEnergy);
+  const threshold = snapshot.spawnCount > 0 ? snapshot.threshold : 0;
+  const criticalThreshold = getCriticalSpawnEnergyBufferThreshold(threshold, snapshot.spawnCount);
+  return {
+    criticalDeficit: Math.max(0, criticalThreshold - snapshot.currentEnergy),
+    criticalThreshold,
+    currentEnergy: snapshot.currentEnergy,
+    deficit: Math.max(0, threshold - snapshot.currentEnergy),
+    healthy: snapshot.currentEnergy >= threshold,
+    roomName: snapshot.roomName,
+    spawnCount: snapshot.spawnCount,
+    threshold
+  };
+}
 function getSpawnEnergyBufferThresholdForSpawnCount(room, spawnCount) {
   const configured = getConfiguredSpawnEnergyBufferThreshold(room);
   if (configured !== null) {
@@ -17438,6 +17453,12 @@ function getMinerOutputBufferCredit(minerOutputEnergyPerTick) {
 function getSpawnEnergyBufferRequirementForReservation(baseRequirement, reservedSpawnEnergy) {
   return Math.max(normalizeEnergyAmount2(baseRequirement), normalizeEnergyAmount2(reservedSpawnEnergy));
 }
+function getCriticalSpawnEnergyBufferThreshold(threshold, spawnCount) {
+  if (spawnCount <= 0 || threshold <= 0) {
+    return 0;
+  }
+  return Math.min(threshold, MINIMUM_SPAWN_ENERGY_BUFFER_PER_SPAWN * spawnCount);
+}
 function normalizeConfiguredThreshold(value) {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return null;
@@ -17449,17 +17470,28 @@ function getSpawnBufferCount(spawns) {
 }
 function getRoomSpawns2(room) {
   var _a, _b;
-  const findMyStructures = globalThis.FIND_MY_STRUCTURES;
-  const find = room.find;
-  if (typeof findMyStructures === "number" && typeof find === "function") {
-    return find.call(room, findMyStructures, { filter: (structure) => isSpawnStructure2(structure) }).filter(isSpawnStructure2);
-  }
-  return Object.values((_b = (_a = globalThis.Game) == null ? void 0 : _a.spawns) != null ? _b : {}).filter(
+  const gameSpawns = Object.values((_b = (_a = globalThis.Game) == null ? void 0 : _a.spawns) != null ? _b : {}).filter(
     (spawn) => {
       var _a2;
       return ((_a2 = spawn.room) == null ? void 0 : _a2.name) === getRoomName5(room);
     }
   );
+  const findMyStructures = globalThis.FIND_MY_STRUCTURES;
+  const find = room.find;
+  if (typeof findMyStructures === "number" && typeof find === "function") {
+    const foundSpawns = find.call(room, findMyStructures, { filter: (structure) => isSpawnStructure2(structure) }).filter(isSpawnStructure2);
+    return mergeSpawnLists(foundSpawns, gameSpawns);
+  }
+  return gameSpawns;
+}
+function mergeSpawnLists(left, right) {
+  const merged = [];
+  for (const spawn of [...left, ...right]) {
+    if (!merged.some((existing) => isSameSpawn(existing, spawn))) {
+      merged.push(spawn);
+    }
+  }
+  return merged;
 }
 function ensureSpawnListIncludesTarget(spawns, target) {
   return spawns.some((spawn) => isSameSpawn(spawn, target)) ? spawns : [...spawns, target];
@@ -18447,8 +18479,11 @@ function buildMultiRoomEnergyRoom(input) {
     spawnEnergyAvailable: spawnEnergy.available,
     spawnEnergyCapacity: spawnEnergy.capacity,
     spawnEnergyDeficit: spawnEnergy.deficit,
+    spawnEnergyBufferThreshold: roomState.spawnEnergyBufferThreshold,
+    spawnEnergyBufferDeficit: roomState.spawnEnergyBufferDeficit,
+    criticalSpawnEnergyDeficit: roomState.criticalSpawnEnergyDeficit,
     storageDeficit,
-    deficitEnergy: storageDeficit + spawnEnergy.deficit,
+    deficitEnergy: storageDeficit + roomState.spawnEnergyBufferDeficit,
     surplusEnergy,
     suppressedImportEnergy,
     blockedImportEnergy,
@@ -18710,9 +18745,14 @@ function getRoomStoredEnergyState(room) {
   const capacity = stores.reduce((total, structure) => total + getEnergyCapacity2(structure), 0);
   const ratio = capacity > 0 ? energy / capacity : 0;
   const spawnEnergyReservation = getRoomSpawnEnergyReservationState(room);
+  const spawnEnergyBufferNeed = getRoomSpawnEnergyBufferNeed(room);
   const rawExportableEnergy = capacity > 0 && ratio > STORAGE_BALANCE_EXPORT_RATIO ? Math.floor(energy - capacity * STORAGE_BALANCE_EXPORT_RATIO) : 0;
-  const exportableEnergy = Math.max(0, rawExportableEnergy - spawnEnergyReservation.unmetReservedEnergy);
-  const importDemand = capacity > 0 && ratio < STORAGE_BALANCE_IMPORT_RATIO ? Math.ceil(capacity * STORAGE_BALANCE_IMPORT_RATIO - energy) : 0;
+  const exportableEnergy = Math.max(
+    0,
+    rawExportableEnergy - spawnEnergyReservation.unmetReservedEnergy - spawnEnergyBufferNeed.deficit
+  );
+  const storageImportDemand = capacity > 0 && ratio < STORAGE_BALANCE_IMPORT_RATIO ? Math.ceil(capacity * STORAGE_BALANCE_IMPORT_RATIO - energy) : 0;
+  const importDemand = storageImportDemand + spawnEnergyBufferNeed.deficit;
   return {
     roomName: room.name,
     energy,
@@ -18729,13 +18769,18 @@ function getRoomStoredEnergyState(room) {
     terminalTargetEnergy,
     terminalEnergyDeficit,
     terminalEnergySurplus,
+    spawnEnergyAvailable: spawnEnergyBufferNeed.currentEnergy,
+    spawnEnergyCapacity: normalizeNonNegativeInteger9(room.energyCapacityAvailable),
+    spawnEnergyBufferThreshold: spawnEnergyBufferNeed.threshold,
+    spawnEnergyBufferDeficit: spawnEnergyBufferNeed.deficit,
+    criticalSpawnEnergyDeficit: spawnEnergyBufferNeed.criticalDeficit,
     reservedSpawnEnergy: spawnEnergyReservation.reservedEnergy,
     unmetSpawnEnergyReservation: spawnEnergyReservation.unmetReservedEnergy,
-    mode: selectStorageBalanceMode(capacity, ratio)
+    mode: selectStorageBalanceMode(capacity, ratio, exportableEnergy, importDemand)
   };
 }
 function buildStorageBalanceState(gameTime) {
-  const roomStates = getOwnedRooms().map(getRoomStoredEnergyState).filter((state2) => state2.capacity > 0);
+  const roomStates = getOwnedRooms().map(getRoomStoredEnergyState).filter((state2) => state2.capacity > 0 || state2.spawnEnergyBufferThreshold > 0);
   const transferPlan = buildStorageTransfers(roomStates, gameTime);
   const state = {
     updatedAt: gameTime,
@@ -18759,6 +18804,11 @@ function buildStorageBalanceState(gameTime) {
           terminalTargetEnergy: state2.terminalTargetEnergy,
           terminalEnergyDeficit: state2.terminalEnergyDeficit,
           terminalEnergySurplus: state2.terminalEnergySurplus,
+          spawnEnergyAvailable: state2.spawnEnergyAvailable,
+          spawnEnergyCapacity: state2.spawnEnergyCapacity,
+          spawnEnergyBufferThreshold: state2.spawnEnergyBufferThreshold,
+          spawnEnergyBufferDeficit: state2.spawnEnergyBufferDeficit,
+          criticalSpawnEnergyDeficit: state2.criticalSpawnEnergyDeficit,
           reservedSpawnEnergy: state2.reservedSpawnEnergy,
           unmetSpawnEnergyReservation: state2.unmetSpawnEnergyReservation,
           updatedAt: gameTime
@@ -18835,7 +18885,7 @@ function buildStorageTransfers(roomStates, gameTime) {
         targetRoom: importer.roomName,
         amount,
         status: "planned",
-        reason: "storage-balance",
+        reason: selectPlannedTransferReason(importer),
         updatedAt: gameTime
       });
       remainingExport.set(exporter.roomName, exportableEnergy - amount);
@@ -18866,6 +18916,9 @@ function getStorageTransferLocalEnergyAudit(importer) {
   };
 }
 function getStorageTransferSuppressionReason(importer, sourceRoom, localEnergyAudit) {
+  if (importer.criticalSpawnEnergyDeficit > 0 || importer.unmetSpawnEnergyReservation > 0) {
+    return null;
+  }
   if (!localEnergyAudit) {
     return null;
   }
@@ -18913,7 +18966,7 @@ function getRoomStorageImportPriorityRank(roomName) {
   return 10;
 }
 function getImportRoomPriorityRank(state) {
-  return state.unmetSpawnEnergyReservation > 0 ? 0 : getRoomStorageImportPriorityRank(state.roomName);
+  return state.unmetSpawnEnergyReservation > 0 || state.criticalSpawnEnergyDeficit > 0 ? 0 : getRoomStorageImportPriorityRank(state.roomName);
 }
 function getControllerUpgradeImportPriorityRank(roomName) {
   var _a, _b, _c;
@@ -18944,11 +18997,10 @@ function hasCriticalSpawnEnergyPressure(roomName) {
   if (!room) {
     return false;
   }
-  const capacity = normalizeNonNegativeInteger9(room.energyCapacityAvailable);
-  if (capacity <= 0 || !hasOwnedSpawn2(room)) {
-    return false;
-  }
-  return normalizeNonNegativeInteger9(room.energyAvailable) < Math.min(200, capacity);
+  return hasOwnedSpawn2(room) && getRoomSpawnEnergyBufferNeed(room).criticalDeficit > 0;
+}
+function selectPlannedTransferReason(importer) {
+  return importer.spawnEnergyBufferDeficit > 0 ? "spawn-energy-buffer" : "storage-balance";
 }
 function hasOwnedSpawn2(room) {
   var _a, _b;
@@ -18994,12 +19046,15 @@ function getCachedOwnedLogisticsRoute(sourceRoom, targetRoom, routeContext) {
   }
   return (_a = routeContext.routesByRoomPair.get(key)) != null ? _a : null;
 }
-function selectStorageBalanceMode(capacity, ratio) {
+function selectStorageBalanceMode(capacity, ratio, exportableEnergy, importDemand) {
   if (capacity <= 0) {
-    return "balanced";
+    return importDemand > 0 ? "import" : "balanced";
   }
-  if (ratio > STORAGE_BALANCE_EXPORT_RATIO) {
+  if (ratio > STORAGE_BALANCE_EXPORT_RATIO && exportableEnergy > 0) {
     return "export";
+  }
+  if (importDemand > 0) {
+    return "import";
   }
   if (ratio < STORAGE_BALANCE_IMPORT_RATIO) {
     return "import";

--- a/prod/src/economy/multiRoomEnergy.ts
+++ b/prod/src/economy/multiRoomEnergy.ts
@@ -6,6 +6,7 @@ export const MULTI_ROOM_ENERGY_SOURCE_WORKLOAD_MAX_AGE = 50;
 export type MultiRoomEnergyTransferAuditStatus = 'planned' | 'suppressed' | 'blocked';
 export type MultiRoomEnergyTransferAuditReason =
   | 'storage-balance'
+  | 'spawn-energy-buffer'
   | 'local-first-sufficient'
   | 'local-first-policy'
   | 'insufficient-exportable-energy'
@@ -123,8 +124,11 @@ function buildMultiRoomEnergyRoom(input: MultiRoomEnergyRoomInput): EconomyMulti
     spawnEnergyAvailable: spawnEnergy.available,
     spawnEnergyCapacity: spawnEnergy.capacity,
     spawnEnergyDeficit: spawnEnergy.deficit,
+    spawnEnergyBufferThreshold: roomState.spawnEnergyBufferThreshold,
+    spawnEnergyBufferDeficit: roomState.spawnEnergyBufferDeficit,
+    criticalSpawnEnergyDeficit: roomState.criticalSpawnEnergyDeficit,
     storageDeficit,
-    deficitEnergy: storageDeficit + spawnEnergy.deficit,
+    deficitEnergy: storageDeficit + roomState.spawnEnergyBufferDeficit,
     surplusEnergy,
     suppressedImportEnergy,
     blockedImportEnergy,

--- a/prod/src/economy/multiRoomEnergy.ts
+++ b/prod/src/economy/multiRoomEnergy.ts
@@ -128,7 +128,7 @@ function buildMultiRoomEnergyRoom(input: MultiRoomEnergyRoomInput): EconomyMulti
     spawnEnergyBufferDeficit: roomState.spawnEnergyBufferDeficit,
     criticalSpawnEnergyDeficit: roomState.criticalSpawnEnergyDeficit,
     storageDeficit,
-    deficitEnergy: storageDeficit + roomState.spawnEnergyBufferDeficit,
+    deficitEnergy: storageDeficit,
     surplusEnergy,
     suppressedImportEnergy,
     blockedImportEnergy,

--- a/prod/src/economy/spawnEnergyBuffer.ts
+++ b/prod/src/economy/spawnEnergyBuffer.ts
@@ -32,6 +32,17 @@ export interface SpawnEnergyBufferSnapshot {
   unmetReservedEnergy: number;
 }
 
+export interface RoomSpawnEnergyBufferNeed {
+  criticalDeficit: number;
+  criticalThreshold: number;
+  currentEnergy: number;
+  deficit: number;
+  healthy: boolean;
+  roomName: string;
+  spawnCount: number;
+  threshold: number;
+}
+
 export interface RefreshSpawnEnergyBufferOptions {
   currentEnergy?: number;
 }
@@ -105,6 +116,26 @@ export function getSpawnEnergyBufferSnapshot(
     threshold,
     thresholdPerSpawn,
     unmetReservedEnergy: reservation.unmetReservedEnergy
+  };
+}
+
+export function getRoomSpawnEnergyBufferNeed(
+  room: Room,
+  spawns = getRoomSpawns(room),
+  currentEnergy = getRoomEnergyAvailable(room)
+): RoomSpawnEnergyBufferNeed {
+  const snapshot = getSpawnEnergyBufferSnapshot(room, spawns, currentEnergy);
+  const threshold = snapshot.spawnCount > 0 ? snapshot.threshold : 0;
+  const criticalThreshold = getCriticalSpawnEnergyBufferThreshold(threshold, snapshot.spawnCount);
+  return {
+    criticalDeficit: Math.max(0, criticalThreshold - snapshot.currentEnergy),
+    criticalThreshold,
+    currentEnergy: snapshot.currentEnergy,
+    deficit: Math.max(0, threshold - snapshot.currentEnergy),
+    healthy: snapshot.currentEnergy >= threshold,
+    roomName: snapshot.roomName,
+    spawnCount: snapshot.spawnCount,
+    threshold
   };
 }
 
@@ -247,6 +278,14 @@ function getSpawnEnergyBufferRequirementForReservation(
   return Math.max(normalizeEnergyAmount(baseRequirement), normalizeEnergyAmount(reservedSpawnEnergy));
 }
 
+function getCriticalSpawnEnergyBufferThreshold(threshold: number, spawnCount: number): number {
+  if (spawnCount <= 0 || threshold <= 0) {
+    return 0;
+  }
+
+  return Math.min(threshold, MINIMUM_SPAWN_ENERGY_BUFFER_PER_SPAWN * spawnCount);
+}
+
 function normalizeConfiguredThreshold(value: unknown): number | null {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
     return null;
@@ -260,6 +299,9 @@ function getSpawnBufferCount(spawns: StructureSpawn[]): number {
 }
 
 function getRoomSpawns(room: Room): StructureSpawn[] {
+  const gameSpawns = Object.values((globalThis as { Game?: Partial<Game> }).Game?.spawns ?? {}).filter(
+    (spawn) => spawn.room?.name === getRoomName(room)
+  );
   const findMyStructures = (globalThis as { FIND_MY_STRUCTURES?: number }).FIND_MY_STRUCTURES;
   const find = (room as {
     find?: (
@@ -268,14 +310,24 @@ function getRoomSpawns(room: Room): StructureSpawn[] {
     ) => AnyOwnedStructure[];
   }).find;
   if (typeof findMyStructures === 'number' && typeof find === 'function') {
-    return find
+    const foundSpawns = find
       .call(room, findMyStructures, { filter: (structure) => isSpawnStructure(structure) })
       .filter(isSpawnStructure);
+    return mergeSpawnLists(foundSpawns, gameSpawns);
   }
 
-  return Object.values((globalThis as { Game?: Partial<Game> }).Game?.spawns ?? {}).filter(
-    (spawn) => spawn.room?.name === getRoomName(room)
-  );
+  return gameSpawns;
+}
+
+function mergeSpawnLists(left: StructureSpawn[], right: StructureSpawn[]): StructureSpawn[] {
+  const merged: StructureSpawn[] = [];
+  for (const spawn of [...left, ...right]) {
+    if (!merged.some((existing) => isSameSpawn(existing, spawn))) {
+      merged.push(spawn);
+    }
+  }
+
+  return merged;
 }
 
 function ensureSpawnListIncludesTarget(spawns: StructureSpawn[], target: StructureSpawn): StructureSpawn[] {

--- a/prod/src/economy/spawnEnergyBuffer.ts
+++ b/prod/src/economy/spawnEnergyBuffer.ts
@@ -125,7 +125,7 @@ export function getRoomSpawnEnergyBufferNeed(
   currentEnergy = getRoomEnergyAvailable(room)
 ): RoomSpawnEnergyBufferNeed {
   const snapshot = getSpawnEnergyBufferSnapshot(room, spawns, currentEnergy);
-  const threshold = snapshot.spawnCount > 0 ? snapshot.threshold : 0;
+  const threshold = snapshot.threshold;
   const criticalThreshold = getCriticalSpawnEnergyBufferThreshold(threshold, snapshot.spawnCount);
   return {
     criticalDeficit: Math.max(0, criticalThreshold - snapshot.currentEnergy),

--- a/prod/src/economy/storageBalancer.ts
+++ b/prod/src/economy/storageBalancer.ts
@@ -9,6 +9,7 @@ import {
   type MultiRoomEnergyTransferAudit,
   type MultiRoomEnergyTransferAuditReason
 } from './multiRoomEnergy';
+import { getRoomSpawnEnergyBufferNeed } from './spawnEnergyBuffer';
 import { getRoomSpawnEnergyReservationState } from './spawnEnergyReservation';
 import {
   canFindOwnedLogisticsRoute,
@@ -36,6 +37,11 @@ export interface RoomStoredEnergyState {
   terminalTargetEnergy: number;
   terminalEnergyDeficit: number;
   terminalEnergySurplus: number;
+  spawnEnergyAvailable: number;
+  spawnEnergyCapacity: number;
+  spawnEnergyBufferThreshold: number;
+  spawnEnergyBufferDeficit: number;
+  criticalSpawnEnergyDeficit: number;
   reservedSpawnEnergy: number;
   unmetSpawnEnergyReservation: number;
   mode: EconomyStorageBalanceMode;
@@ -105,15 +111,22 @@ export function getRoomStoredEnergyState(room: Room): RoomStoredEnergyState {
   const capacity = stores.reduce((total, structure) => total + getEnergyCapacity(structure), 0);
   const ratio = capacity > 0 ? energy / capacity : 0;
   const spawnEnergyReservation = getRoomSpawnEnergyReservationState(room);
+  const spawnEnergyBufferNeed = getRoomSpawnEnergyBufferNeed(room);
   const rawExportableEnergy =
     capacity > 0 && ratio > STORAGE_BALANCE_EXPORT_RATIO
       ? Math.floor(energy - capacity * STORAGE_BALANCE_EXPORT_RATIO)
       : 0;
-  const exportableEnergy = Math.max(0, rawExportableEnergy - spawnEnergyReservation.unmetReservedEnergy);
-  const importDemand =
+  const exportableEnergy = Math.max(
+    0,
+    rawExportableEnergy -
+      spawnEnergyReservation.unmetReservedEnergy -
+      spawnEnergyBufferNeed.deficit
+  );
+  const storageImportDemand =
     capacity > 0 && ratio < STORAGE_BALANCE_IMPORT_RATIO
       ? Math.ceil(capacity * STORAGE_BALANCE_IMPORT_RATIO - energy)
       : 0;
+  const importDemand = storageImportDemand + spawnEnergyBufferNeed.deficit;
 
   return {
     roomName: room.name,
@@ -131,16 +144,21 @@ export function getRoomStoredEnergyState(room: Room): RoomStoredEnergyState {
     terminalTargetEnergy,
     terminalEnergyDeficit,
     terminalEnergySurplus,
+    spawnEnergyAvailable: spawnEnergyBufferNeed.currentEnergy,
+    spawnEnergyCapacity: normalizeNonNegativeInteger(room.energyCapacityAvailable),
+    spawnEnergyBufferThreshold: spawnEnergyBufferNeed.threshold,
+    spawnEnergyBufferDeficit: spawnEnergyBufferNeed.deficit,
+    criticalSpawnEnergyDeficit: spawnEnergyBufferNeed.criticalDeficit,
     reservedSpawnEnergy: spawnEnergyReservation.reservedEnergy,
     unmetSpawnEnergyReservation: spawnEnergyReservation.unmetReservedEnergy,
-    mode: selectStorageBalanceMode(capacity, ratio)
+    mode: selectStorageBalanceMode(capacity, ratio, exportableEnergy, importDemand)
   };
 }
 
 function buildStorageBalanceState(gameTime: number): EconomyStorageBalanceMemory {
   const roomStates = getOwnedRooms()
     .map(getRoomStoredEnergyState)
-    .filter((state) => state.capacity > 0);
+    .filter((state) => state.capacity > 0 || state.spawnEnergyBufferThreshold > 0);
   const transferPlan = buildStorageTransfers(roomStates, gameTime);
   const state = {
     updatedAt: gameTime,
@@ -164,6 +182,11 @@ function buildStorageBalanceState(gameTime: number): EconomyStorageBalanceMemory
           terminalTargetEnergy: state.terminalTargetEnergy,
           terminalEnergyDeficit: state.terminalEnergyDeficit,
           terminalEnergySurplus: state.terminalEnergySurplus,
+          spawnEnergyAvailable: state.spawnEnergyAvailable,
+          spawnEnergyCapacity: state.spawnEnergyCapacity,
+          spawnEnergyBufferThreshold: state.spawnEnergyBufferThreshold,
+          spawnEnergyBufferDeficit: state.spawnEnergyBufferDeficit,
+          criticalSpawnEnergyDeficit: state.criticalSpawnEnergyDeficit,
           reservedSpawnEnergy: state.reservedSpawnEnergy,
           unmetSpawnEnergyReservation: state.unmetSpawnEnergyReservation,
           updatedAt: gameTime
@@ -259,7 +282,7 @@ function buildStorageTransfers(
         targetRoom: importer.roomName,
         amount,
         status: 'planned',
-        reason: 'storage-balance',
+        reason: selectPlannedTransferReason(importer),
         updatedAt: gameTime
       });
       remainingExport.set(exporter.roomName, exportableEnergy - amount);
@@ -302,6 +325,10 @@ function getStorageTransferSuppressionReason(
   sourceRoom: string,
   localEnergyAudit: StorageTransferLocalEnergyAudit | undefined
 ): MultiRoomEnergyTransferAuditReason | null {
+  if (importer.criticalSpawnEnergyDeficit > 0 || importer.unmetSpawnEnergyReservation > 0) {
+    return null;
+  }
+
   if (!localEnergyAudit) {
     return null;
   }
@@ -388,7 +415,9 @@ export function getRoomStorageImportPriorityRank(roomName: string): number {
 }
 
 function getImportRoomPriorityRank(state: RoomStoredEnergyState): number {
-  return state.unmetSpawnEnergyReservation > 0 ? 0 : getRoomStorageImportPriorityRank(state.roomName);
+  return state.unmetSpawnEnergyReservation > 0 || state.criticalSpawnEnergyDeficit > 0
+    ? 0
+    : getRoomStorageImportPriorityRank(state.roomName);
 }
 
 function getControllerUpgradeImportPriorityRank(roomName: string): number | null {
@@ -421,12 +450,11 @@ function hasCriticalSpawnEnergyPressure(roomName: string): boolean {
     return false;
   }
 
-  const capacity = normalizeNonNegativeInteger(room.energyCapacityAvailable);
-  if (capacity <= 0 || !hasOwnedSpawn(room)) {
-    return false;
-  }
+  return hasOwnedSpawn(room) && getRoomSpawnEnergyBufferNeed(room).criticalDeficit > 0;
+}
 
-  return normalizeNonNegativeInteger(room.energyAvailable) < Math.min(200, capacity);
+function selectPlannedTransferReason(importer: RoomStoredEnergyState): MultiRoomEnergyTransferAuditReason {
+  return importer.spawnEnergyBufferDeficit > 0 ? 'spawn-energy-buffer' : 'storage-balance';
 }
 
 function hasOwnedSpawn(room: Room): boolean {
@@ -489,14 +517,20 @@ function getCachedOwnedLogisticsRoute(
 
 function selectStorageBalanceMode(
   capacity: number,
-  ratio: number
+  ratio: number,
+  exportableEnergy: number,
+  importDemand: number
 ): EconomyStorageBalanceMode {
   if (capacity <= 0) {
-    return 'balanced';
+    return importDemand > 0 ? 'import' : 'balanced';
   }
 
-  if (ratio > STORAGE_BALANCE_EXPORT_RATIO) {
+  if (ratio > STORAGE_BALANCE_EXPORT_RATIO && exportableEnergy > 0) {
     return 'export';
+  }
+
+  if (importDemand > 0) {
+    return 'import';
   }
 
   if (ratio < STORAGE_BALANCE_IMPORT_RATIO) {

--- a/prod/src/economy/storageBalancer.ts
+++ b/prod/src/economy/storageBalancer.ts
@@ -118,9 +118,7 @@ export function getRoomStoredEnergyState(room: Room): RoomStoredEnergyState {
       : 0;
   const exportableEnergy = Math.max(
     0,
-    rawExportableEnergy -
-      spawnEnergyReservation.unmetReservedEnergy -
-      spawnEnergyBufferNeed.deficit
+    rawExportableEnergy - spawnEnergyBufferNeed.deficit
   );
   const storageImportDemand =
     capacity > 0 && ratio < STORAGE_BALANCE_IMPORT_RATIO

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -362,6 +362,11 @@ declare global {
     ratio: number;
     exportableEnergy: number;
     importDemand: number;
+    spawnEnergyAvailable?: number;
+    spawnEnergyCapacity?: number;
+    spawnEnergyBufferThreshold?: number;
+    spawnEnergyBufferDeficit?: number;
+    criticalSpawnEnergyDeficit?: number;
     reservedSpawnEnergy?: number;
     unmetSpawnEnergyReservation?: number;
     storageEnergy?: number;
@@ -393,6 +398,7 @@ declare global {
 
   type EconomyMultiRoomEnergyTransferReason =
     | 'storage-balance'
+    | 'spawn-energy-buffer'
     | 'local-first-sufficient'
     | 'local-first-policy'
     | 'insufficient-exportable-energy'
@@ -424,6 +430,9 @@ declare global {
     spawnEnergyAvailable: number;
     spawnEnergyCapacity: number;
     spawnEnergyDeficit: number;
+    spawnEnergyBufferThreshold: number;
+    spawnEnergyBufferDeficit: number;
+    criticalSpawnEnergyDeficit: number;
     storageDeficit: number;
     deficitEnergy: number;
     surplusEnergy: number;

--- a/prod/test/economy/interRoomEnergyTransfers.test.ts
+++ b/prod/test/economy/interRoomEnergyTransfers.test.ts
@@ -110,8 +110,7 @@ describe('economy inter-room energy transfers', () => {
     balanceStorage();
 
     expect(Memory.economy?.storageBalance?.transfers).toEqual([
-      { sourceRoom: 'W1N1', targetRoom: 'W2N1', amount: 200, updatedAt: 100 },
-      { sourceRoom: 'W1N1', targetRoom: 'W3N1', amount: 200, updatedAt: 100 }
+      { sourceRoom: 'W1N1', targetRoom: 'W2N1', amount: 400, updatedAt: 100 }
     ]);
     expect(selectCrossRoomEnergyTransfer()?.targetRoom).toBe('W2N1');
   });

--- a/prod/test/economy/multiRoomSpawnEnergyBuffer.test.ts
+++ b/prod/test/economy/multiRoomSpawnEnergyBuffer.test.ts
@@ -62,11 +62,77 @@ describe('multi-room spawn energy buffer coordination', () => {
       criticalSpawnEnergyDeficit: 200
     });
     expect(Memory.economy?.multiRoomEnergy?.rooms.E26S47).toMatchObject({
+      plannedImportEnergy: 400,
       spawnEnergyAvailable: 100,
       spawnEnergyBufferThreshold: 500,
       spawnEnergyBufferDeficit: 400,
       criticalSpawnEnergyDeficit: 200,
-      deficitEnergy: 400
+      storageDeficit: 0,
+      deficitEnergy: 0
+    });
+  });
+
+  it('imports for active spawn reservations in rooms without local spawns', () => {
+    const sourceStructures: AnyOwnedStructure[] = [];
+    const sourceRoom = makeOwnedRoom({
+      roomName: 'E26S49',
+      storageEnergy: 2_000,
+      storageCapacity: 2_000,
+      energyAvailable: 800,
+      myStructures: sourceStructures
+    });
+    const targetRoom = makeOwnedRoom({
+      roomName: 'E26S47',
+      storageEnergy: 500,
+      storageCapacity: 1_000,
+      energyAvailable: 200
+    });
+    const sourceSpawn = makeSpawn('SpawnE26S49', sourceRoom, 0);
+    sourceStructures.push(sourceSpawn as unknown as AnyOwnedStructure);
+    installGame([sourceRoom, targetRoom], [sourceSpawn]);
+    Memory.economy = {
+      spawnEnergyReservation: {
+        updatedAt: 99,
+        rooms: {
+          E26S47: {
+            bodyCost: 650,
+            creepName: 'worker-E26S47-100',
+            reservedAt: 99,
+            reservedEnergy: 650,
+            role: 'worker',
+            roomName: 'E26S47',
+            updatedAt: 99
+          }
+        }
+      }
+    };
+
+    balanceStorage();
+
+    expect(Memory.economy?.storageBalance?.rooms.E26S47).toMatchObject({
+      importDemand: 450,
+      reservedSpawnEnergy: 650,
+      spawnEnergyBufferThreshold: 650,
+      spawnEnergyBufferDeficit: 450,
+      unmetSpawnEnergyReservation: 450
+    });
+    expect(Memory.economy?.storageBalance?.transfers).toEqual([
+      { sourceRoom: 'E26S49', targetRoom: 'E26S47', amount: 400, updatedAt: 100 }
+    ]);
+    expect(Memory.economy?.multiRoomEnergy?.rooms.E26S47).toMatchObject({
+      plannedImportEnergy: 400,
+      spawnEnergyBufferThreshold: 650,
+      spawnEnergyBufferDeficit: 450,
+      storageDeficit: 50,
+      deficitEnergy: 50
+    });
+    expect(Memory.economy?.multiRoomEnergy?.transfers).toContainEqual({
+      sourceRoom: 'E26S49',
+      targetRoom: 'E26S47',
+      amount: 400,
+      status: 'planned',
+      reason: 'spawn-energy-buffer',
+      updatedAt: 100
     });
   });
 
@@ -168,6 +234,11 @@ describe('multi-room spawn energy buffer coordination', () => {
 
     expect(Memory.economy?.storageBalance?.rooms.E26S47).toMatchObject({
       spawnEnergyBufferDeficit: 500
+    });
+    expect(Memory.economy?.multiRoomEnergy?.rooms.E26S47).toMatchObject({
+      spawnEnergyBufferDeficit: 500,
+      storageDeficit: 500,
+      deficitEnergy: 500
     });
     expect(Memory.economy?.storageBalance?.transfers).toEqual([]);
     expect(planCrossRoomHauler()).toBeNull();

--- a/prod/test/economy/multiRoomSpawnEnergyBuffer.test.ts
+++ b/prod/test/economy/multiRoomSpawnEnergyBuffer.test.ts
@@ -136,6 +136,50 @@ describe('multi-room spawn energy buffer coordination', () => {
     });
   });
 
+  it('keeps reservation-driven spawn buffer deficits from being subtracted twice from exports', () => {
+    const sourceRoom = makeOwnedRoom({
+      roomName: 'E26S49',
+      storageEnergy: 1_000,
+      storageCapacity: 1_000,
+      energyAvailable: 700
+    });
+    const targetRoom = makeOwnedRoom({
+      roomName: 'E26S47',
+      storageEnergy: 200,
+      storageCapacity: 1_000
+    });
+    installGame([sourceRoom, targetRoom], []);
+    Memory.economy = {
+      spawnEnergyReservation: {
+        updatedAt: 99,
+        rooms: {
+          E26S49: {
+            bodyCost: 800,
+            creepName: 'claimer-E26S49-E26S47-100',
+            reservedAt: 99,
+            reservedEnergy: 800,
+            role: 'claimer',
+            roomName: 'E26S49',
+            updatedAt: 99
+          }
+        }
+      }
+    };
+
+    balanceStorage();
+
+    expect(Memory.economy?.storageBalance?.rooms.E26S49).toMatchObject({
+      mode: 'export',
+      exportableEnergy: 100,
+      reservedSpawnEnergy: 800,
+      spawnEnergyBufferDeficit: 100,
+      unmetSpawnEnergyReservation: 100
+    });
+    expect(Memory.economy?.storageBalance?.transfers).toEqual([
+      { sourceRoom: 'E26S49', targetRoom: 'E26S47', amount: 100, updatedAt: 100 }
+    ]);
+  });
+
   it('routes cross-room energy to replenish a critically low spawn buffer', () => {
     const sourceStructures: AnyOwnedStructure[] = [];
     const targetStructures: AnyOwnedStructure[] = [];

--- a/prod/test/economy/multiRoomSpawnEnergyBuffer.test.ts
+++ b/prod/test/economy/multiRoomSpawnEnergyBuffer.test.ts
@@ -1,0 +1,305 @@
+import {
+  CROSS_ROOM_HAULER_ROLE,
+  planCrossRoomHauler,
+  runCrossRoomHauler
+} from '../../src/economy/crossRoomHauler';
+import { balanceStorage } from '../../src/economy/storageBalancer';
+
+const OK_CODE = 0 as ScreepsReturnCode;
+const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
+
+describe('multi-room spawn energy buffer coordination', () => {
+  beforeEach(() => {
+    Object.assign(globalThis, {
+      ERR_NO_PATH: ERR_NO_PATH_CODE,
+      FIND_HOSTILE_CREEPS: 1,
+      FIND_HOSTILE_STRUCTURES: 2,
+      FIND_MY_STRUCTURES: 3,
+      FIND_STRUCTURES: 4,
+      RESOURCE_ENERGY: 'energy',
+      STRUCTURE_EXTENSION: 'extension',
+      STRUCTURE_SPAWN: 'spawn',
+      STRUCTURE_STORAGE: 'storage',
+      STRUCTURE_TERMINAL: 'terminal',
+      STRUCTURE_TOWER: 'tower'
+    });
+  });
+
+  afterEach(() => {
+    delete (globalThis as { Game?: Partial<Game> }).Game;
+    delete (globalThis as { Memory?: Partial<Memory> }).Memory;
+  });
+
+  it('tracks spawn buffer deficits across owned rooms', () => {
+    const sourceStructures: AnyOwnedStructure[] = [];
+    const targetStructures: AnyOwnedStructure[] = [];
+    const sourceRoom = makeOwnedRoom({
+      roomName: 'E26S49',
+      storageEnergy: 2_000,
+      storageCapacity: 2_000,
+      energyAvailable: 800,
+      myStructures: sourceStructures
+    });
+    const targetRoom = makeOwnedRoom({
+      roomName: 'E26S47',
+      storageEnergy: 500,
+      storageCapacity: 1_000,
+      energyAvailable: 100,
+      myStructures: targetStructures
+    });
+    sourceStructures.push(makeSpawn('SpawnE26S49', sourceRoom, 0) as unknown as AnyOwnedStructure);
+    targetStructures.push(makeSpawn('SpawnE26S47', targetRoom, 200) as unknown as AnyOwnedStructure);
+    installGame([sourceRoom, targetRoom], sourceStructures.concat(targetStructures) as unknown as StructureSpawn[]);
+
+    balanceStorage();
+
+    expect(Memory.economy?.storageBalance?.rooms.E26S47).toMatchObject({
+      mode: 'import',
+      importDemand: 400,
+      spawnEnergyAvailable: 100,
+      spawnEnergyBufferThreshold: 500,
+      spawnEnergyBufferDeficit: 400,
+      criticalSpawnEnergyDeficit: 200
+    });
+    expect(Memory.economy?.multiRoomEnergy?.rooms.E26S47).toMatchObject({
+      spawnEnergyAvailable: 100,
+      spawnEnergyBufferThreshold: 500,
+      spawnEnergyBufferDeficit: 400,
+      criticalSpawnEnergyDeficit: 200,
+      deficitEnergy: 400
+    });
+  });
+
+  it('routes cross-room energy to replenish a critically low spawn buffer', () => {
+    const sourceStructures: AnyOwnedStructure[] = [];
+    const targetStructures: AnyOwnedStructure[] = [];
+    const sourceRoom = makeOwnedRoom({
+      roomName: 'E26S49',
+      storageEnergy: 2_000,
+      storageCapacity: 2_000,
+      energyAvailable: 800,
+      myStructures: sourceStructures
+    });
+    const targetRoom = makeOwnedRoom({
+      roomName: 'E26S47',
+      storageEnergy: 500,
+      storageCapacity: 1_000,
+      energyAvailable: 100,
+      myStructures: targetStructures
+    });
+    const sourceSpawn = makeSpawn('SpawnE26S49', sourceRoom, 0);
+    const targetSpawn = makeSpawn('SpawnE26S47', targetRoom, 200);
+    sourceStructures.push(sourceSpawn as unknown as AnyOwnedStructure);
+    targetStructures.push(targetSpawn as unknown as AnyOwnedStructure);
+    installGame([sourceRoom, targetRoom], [sourceSpawn, targetSpawn]);
+
+    balanceStorage();
+
+    expect(Memory.economy?.storageBalance?.transfers).toEqual([
+      { sourceRoom: 'E26S49', targetRoom: 'E26S47', amount: 400, updatedAt: 100 }
+    ]);
+    expect(Memory.economy?.multiRoomEnergy?.transfers).toContainEqual({
+      sourceRoom: 'E26S49',
+      targetRoom: 'E26S47',
+      amount: 400,
+      status: 'planned',
+      reason: 'spawn-energy-buffer',
+      updatedAt: 100
+    });
+    expect(planCrossRoomHauler()).toMatchObject({
+      spawn: sourceSpawn,
+      memory: {
+        role: CROSS_ROOM_HAULER_ROLE,
+        colony: 'E26S49',
+        crossRoomHauler: {
+          homeRoom: 'E26S49',
+          targetRoom: 'E26S47',
+          sourceId: 'E26S49-storage',
+          route: ['E26S47']
+        }
+      }
+    });
+  });
+
+  it('delivers imported energy to the empty room spawn before durable storage', () => {
+    const sourceRoom = makeOwnedRoom({
+      roomName: 'E26S49',
+      storageEnergy: 2_000,
+      storageCapacity: 2_000,
+      energyAvailable: 800
+    });
+    const targetStructures: AnyOwnedStructure[] = [];
+    const targetRoom = makeOwnedRoom({
+      roomName: 'E26S47',
+      storageEnergy: 500,
+      storageCapacity: 1_000,
+      energyAvailable: 0,
+      myStructures: targetStructures
+    });
+    const targetSpawn = makeSpawn('SpawnE26S47', targetRoom, 300);
+    targetStructures.push(targetSpawn as unknown as AnyOwnedStructure);
+    installGame([sourceRoom, targetRoom], [targetSpawn]);
+    const creep = makeCrossRoomHauler({
+      room: targetRoom,
+      carriedEnergy: () => 100,
+      transfer: jest.fn(() => OK_CODE)
+    });
+
+    runCrossRoomHauler(creep);
+
+    expect(creep.transfer).toHaveBeenCalledWith(targetSpawn, RESOURCE_ENERGY);
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'SpawnE26S47' });
+  });
+
+  it('does not create cross-room spawn-buffer transfers for a single owned room', () => {
+    const structures: AnyOwnedStructure[] = [];
+    const room = makeOwnedRoom({
+      roomName: 'E26S47',
+      storageEnergy: 500,
+      storageCapacity: 1_000,
+      energyAvailable: 0,
+      myStructures: structures
+    });
+    const spawn = makeSpawn('SpawnE26S47', room, 300);
+    structures.push(spawn as unknown as AnyOwnedStructure);
+    installGame([room], [spawn]);
+
+    balanceStorage();
+
+    expect(Memory.economy?.storageBalance?.rooms.E26S47).toMatchObject({
+      spawnEnergyBufferDeficit: 500
+    });
+    expect(Memory.economy?.storageBalance?.transfers).toEqual([]);
+    expect(planCrossRoomHauler()).toBeNull();
+  });
+});
+
+function makeOwnedRoom({
+  roomName,
+  storageEnergy,
+  storageCapacity = 1_000,
+  energyAvailable = 800,
+  energyCapacityAvailable = 800,
+  myStructures = []
+}: {
+  roomName: string;
+  storageEnergy: number;
+  storageCapacity?: number;
+  energyAvailable?: number;
+  energyCapacityAvailable?: number;
+  myStructures?: AnyOwnedStructure[];
+}): Room {
+  return {
+    name: roomName,
+    energyAvailable,
+    energyCapacityAvailable,
+    controller: { id: `${roomName}-controller`, my: true, level: 4 } as StructureController,
+    memory: {},
+    storage: makeStorage(`${roomName}-storage`, storageEnergy, storageCapacity, roomName),
+    find: jest.fn((type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+      if (type === FIND_MY_STRUCTURES) {
+        return options?.filter ? myStructures.filter(options.filter) : myStructures;
+      }
+
+      if (type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES || type === FIND_STRUCTURES) {
+        return [];
+      }
+
+      return [];
+    })
+  } as unknown as Room;
+}
+
+function makeSpawn(name: string, room: Room, freeCapacity: number): StructureSpawn {
+  return {
+    id: name,
+    name,
+    room,
+    pos: makeRoomPosition(10, 10, room.name),
+    structureType: 'spawn',
+    spawning: null,
+    store: makeStore(300 - freeCapacity, 300)
+  } as unknown as StructureSpawn;
+}
+
+function makeStorage(id: string, energy: number, capacity: number, roomName: string): StructureStorage {
+  return {
+    id,
+    pos: makeRoomPosition(12, 10, roomName),
+    structureType: 'storage',
+    store: makeStore(energy, capacity)
+  } as unknown as StructureStorage;
+}
+
+function makeStore(energy: number, capacity: number): StoreDefinition {
+  return {
+    getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? capacity : 0)),
+    getFreeCapacity: jest.fn((resource?: ResourceConstant) =>
+      resource === RESOURCE_ENERGY ? Math.max(0, capacity - energy) : 0
+    ),
+    getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? energy : 0))
+  } as unknown as StoreDefinition;
+}
+
+function makeCrossRoomHauler({
+  room,
+  carriedEnergy,
+  transfer = jest.fn(() => OK_CODE)
+}: {
+  room: Room;
+  carriedEnergy: () => number;
+  transfer?: jest.Mock;
+}): Creep {
+  return {
+    pos: makeRoomPosition(1, 1, room.name),
+    room,
+    memory: {
+      role: CROSS_ROOM_HAULER_ROLE,
+      colony: 'E26S49',
+      crossRoomHauler: {
+        homeRoom: 'E26S49',
+        targetRoom: 'E26S47',
+        sourceId: 'E26S49-storage' as Id<AnyStoreStructure>,
+        state: 'delivering',
+        route: ['E26S47']
+      }
+    },
+    store: {
+      getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? carriedEnergy() : 0)),
+      getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 200 - carriedEnergy() : 0))
+    },
+    transfer,
+    moveTo: jest.fn()
+  } as unknown as Creep;
+}
+
+function makeRoomPosition(x: number, y: number, roomName: string): RoomPosition {
+  return {
+    x,
+    y,
+    roomName,
+    getRangeTo: jest.fn((target: RoomObject | RoomPosition) => {
+      const position = 'pos' in target ? target.pos : target;
+      return Math.max(Math.abs(x - position.x), Math.abs(y - position.y));
+    })
+  } as unknown as RoomPosition;
+}
+
+function installGame(rooms: Room[], spawns: StructureSpawn[]): void {
+  (globalThis as { Game: Partial<Game> }).Game = {
+    time: 100,
+    creeps: {},
+    rooms: Object.fromEntries(rooms.map((room) => [room.name, room])),
+    spawns: Object.fromEntries(spawns.map((spawn) => [spawn.name, spawn])),
+    map: {
+      findRoute: jest.fn((_fromRoom: string, targetRoom: string, options?: { routeCallback?: (roomName: string) => number }) => {
+        if (options?.routeCallback?.(targetRoom) === Infinity) {
+          return ERR_NO_PATH_CODE;
+        }
+
+        return [{ exit: 1, room: targetRoom }];
+      })
+    } as unknown as GameMap
+  };
+  (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+}

--- a/prod/test/spawnEnergyBuffer.test.ts
+++ b/prod/test/spawnEnergyBuffer.test.ts
@@ -4,6 +4,7 @@ import {
   SPAWN_ENERGY_BUFFER_THRESHOLDS_BY_RCL,
   canWithdrawFromSpawnEnergyBuffer,
   getBufferedSpawnEnergyBudget,
+  getRoomSpawnEnergyBufferNeed,
   getSpawnEnergyAvailableForWithdrawal,
   getSpawnEnergyBufferRequirement,
   getSpawnEnergyBufferSnapshot,
@@ -148,6 +149,34 @@ describe('spawnEnergyBuffer', () => {
       unmetReservedEnergy: 150
     });
     expect(getSpawnEnergyAvailableForWithdrawal(room, spawn)).toBe(0);
+  });
+
+  it('keeps active spawn energy reservations visible in rooms without spawns', () => {
+    Memory.economy = {
+      spawnEnergyReservation: {
+        updatedAt: 99,
+        rooms: {
+          W1N1: {
+            bodyCost: 650,
+            creepName: 'worker-W1N1-100',
+            reservedAt: 99,
+            reservedEnergy: 650,
+            role: 'worker',
+            roomName: 'W1N1',
+            updatedAt: 99
+          }
+        }
+      }
+    };
+    const room = makeRoom({ energyAvailable: 200, level: 1 });
+
+    expect(getRoomSpawnEnergyBufferNeed(room, [])).toMatchObject({
+      currentEnergy: 200,
+      deficit: 450,
+      healthy: false,
+      spawnCount: 0,
+      threshold: 650
+    });
   });
 
   it('applies miner throughput credit once before splitting a multi-spawn buffer', () => {


### PR DESCRIPTION
## Summary
Implement multi-room spawn energy buffer coordination for E26S49+E26S47 colony.

After E26S47 claim (#860) and cross-room energy transfer (#862), spawn energy buffers must account for multi-room spawn needs. This PR:
1. Tracks spawn energy needs across all owned rooms
2. Prioritizes energy delivery to rooms with critically low spawn energy
3. Integrates with existing spawnEnergyBuffer.ts, multiRoomEnergy.ts, and crossRoomHauler.ts
4. Adds unit tests for multi-room spawn energy deficit detection, cross-room energy routing, and edge cases

## Verification
```
npm run typecheck  # PASS
npm test -- --runInBand  # 92 suites, 1664 tests PASS
npm run build  # PASS
```

## Files changed
- `prod/src/economy/multiRoomEnergy.ts` — multi-room energy deficit tracking
- `prod/src/economy/spawnEnergyBuffer.ts` — spawn energy buffer coordination
- `prod/src/economy/storageBalancer.ts` — storage balancing across rooms
- `prod/src/types.d.ts` — type additions
- `prod/test/economy/interRoomEnergyTransfers.test.ts` — updated tests
- `prod/test/economy/multiRoomSpawnEnergyBuffer.test.ts` — new test suite

Closes #865
