### PR TITLE
feat(territory): trigger expansion claim for E26S50 when colony meets readiness preconditions (#869)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4321,7 +4321,7 @@ var GCL_LIMIT_PRECONDITION = "wait for GCL capacity to claim another room";
 var MAX_ROOM_COUNT_BY_RCL = {
   1: 1,
   2: 1,
-  3: 2,
+  3: 3,
   4: 3,
   5: 5,
   6: 8,
@@ -12509,13 +12509,18 @@ function refreshBootstrappingStage(pipeline, gameTime, telemetryEvents, territor
 }
 function selectExpansionTriggerCandidate(colony, report, territoryMemory, gameTime) {
   const config = getExpansionTriggerConfig();
-  if (!isExpansionHomeStable(colony, gameTime, config)) {
+  if (!isExpansionTriggerReady(colony, gameTime, config)) {
     return null;
   }
   if (hasBlockingExpansionInProgress(territoryMemory, colony.room.name)) {
     return null;
   }
-  const candidate = report.candidates.find(
+  const candidate = findExpansionTriggerCandidate(colony, report, territoryMemory, config);
+  return candidate ? { candidate, config } : null;
+}
+function findExpansionTriggerCandidate(colony, report, territoryMemory, config) {
+  var _a;
+  return (_a = report.candidates.find(
     (scoredCandidate) => scoredCandidate.evidenceStatus !== "unavailable" && scoredCandidate.score >= config.scoreThreshold && scoredCandidate.preconditions.length === 0 && !isClaimPlanBlockedByHigherPriorityColony({
       colony,
       targetRoom: scoredCandidate.roomName,
@@ -12524,8 +12529,7 @@ function selectExpansionTriggerCandidate(colony, report, territoryMemory, gameTi
       ...scoredCandidate.nearestOwnedRoomDistance !== void 0 ? { nearestOwnedRoomDistance: scoredCandidate.nearestOwnedRoomDistance } : {},
       territoryMemory
     })
-  );
-  return candidate ? { candidate, config } : null;
+  )) != null ? _a : null;
 }
 function getTriggerSkipReason(colony, report, territoryMemory, gameTime) {
   if (report.candidates.length === 0) {
@@ -12539,16 +12543,23 @@ function getTriggerSkipReason(colony, report, territoryMemory, gameTime) {
   )) {
     return "roomLimitReached";
   }
-  if (!isExpansionHomeStable(colony, gameTime, getExpansionTriggerConfig())) {
+  const config = getExpansionTriggerConfig();
+  if (!isExpansionHomeStable(colony, gameTime, config)) {
     return "unmetPreconditions";
   }
   if (hasBlockingExpansionInProgress(territoryMemory, colony.room.name)) {
+    return "unmetPreconditions";
+  }
+  if (!isExpansionTriggerReady(colony, gameTime, config) && findExpansionTriggerCandidate(colony, report, territoryMemory, config)) {
     return "unmetPreconditions";
   }
   if (report.candidates.some((candidate) => candidate.evidenceStatus === "insufficient-evidence")) {
     return "insufficientEvidence";
   }
   if (report.candidates.some((candidate) => candidate.preconditions.length > 0)) {
+    return "unmetPreconditions";
+  }
+  if (!isExpansionTriggerReady(colony, gameTime, config)) {
     return "unmetPreconditions";
   }
   return "unavailable";
@@ -12804,6 +12815,9 @@ function getExpansionTriggerConfig() {
 function isExpansionHomeStable(colony, gameTime, config) {
   const controller = colony.room.controller;
   return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && controller.level >= config.minRcl && !isControllerDowngradeGuardBreached(controller) && colony.energyCapacityAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY && getRoomStorageEnergy2(colony.room) >= config.minStorageEnergy && !hasVisibleHostiles(colony.room) && getHomeThreatLevel(colony.room.name, gameTime) === "none";
+}
+function isExpansionTriggerReady(colony, gameTime, config) {
+  return isExpansionHomeStable(colony, gameTime, config) && colony.energyAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY;
 }
 function hasBlockingExpansionInProgress(territoryMemory, colony) {
   var _a;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -12259,6 +12259,7 @@ var EXPANSION_TRIGGER_DOWNGRADE_GUARD_TICKS = 5e3;
 var EXPANSION_PIPELINE_REEVALUATION_SEPARATOR = ">";
 var GCL_LIMIT_PRECONDITION2 = "wait for GCL capacity to claim another room";
 var ROOM_LIMIT_PRECONDITION_PREFIX = "limit expansion to ";
+var MAX_ROOM_ENERGY_CAPACITY_BY_RCL = [0, 300, 550, 800, 1300, 1800, 2300, 5600, 12900];
 function refreshAutonomousExpansionPipeline(colony, report, gameTime = getGameTime15(), telemetryEvents = []) {
   const colonyName = colony.room.name;
   const territoryMemory = getWritableTerritoryMemoryRecord5();
@@ -12814,10 +12815,31 @@ function getExpansionTriggerConfig() {
 }
 function isExpansionHomeStable(colony, gameTime, config) {
   const controller = colony.room.controller;
-  return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && controller.level >= config.minRcl && !isControllerDowngradeGuardBreached(controller) && colony.energyCapacityAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY && getRoomStorageEnergy2(colony.room) >= config.minStorageEnergy && !hasVisibleHostiles(colony.room) && getHomeThreatLevel(colony.room.name, gameTime) === "none";
+  const requiredEnergy = getExpansionTriggerRequiredEnergy(controller == null ? void 0 : controller.level);
+  return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && controller.level >= config.minRcl && !isControllerDowngradeGuardBreached(controller) && colony.energyCapacityAvailable >= requiredEnergy && getRoomStorageEnergy2(colony.room) >= config.minStorageEnergy && !hasVisibleHostiles(colony.room) && getHomeThreatLevel(colony.room.name, gameTime) === "none";
 }
 function isExpansionTriggerReady(colony, gameTime, config) {
-  return isExpansionHomeStable(colony, gameTime, config) && colony.energyAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY;
+  var _a;
+  const requiredEnergy = getExpansionTriggerRequiredEnergy((_a = colony.room.controller) == null ? void 0 : _a.level);
+  return isExpansionHomeStable(colony, gameTime, config) && colony.energyAvailable >= requiredEnergy;
+}
+function getExpansionTriggerRequiredEnergy(controllerLevel) {
+  const rclCapacity = getMaxRoomEnergyCapacityForRcl(controllerLevel);
+  if (rclCapacity === null) {
+    return TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY;
+  }
+  return Math.max(
+    TERRITORY_CONTROLLER_BODY_COST,
+    Math.min(TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY, rclCapacity)
+  );
+}
+function getMaxRoomEnergyCapacityForRcl(controllerLevel) {
+  var _a;
+  if (typeof controllerLevel !== "number" || !Number.isFinite(controllerLevel)) {
+    return null;
+  }
+  const rcl = Math.max(0, Math.min(8, Math.floor(controllerLevel)));
+  return (_a = MAX_ROOM_ENERGY_CAPACITY_BY_RCL[rcl]) != null ? _a : null;
 }
 function hasBlockingExpansionInProgress(territoryMemory, colony) {
   var _a;

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -52,7 +52,7 @@ const GCL_LIMIT_PRECONDITION = 'wait for GCL capacity to claim another room';
 const MAX_ROOM_COUNT_BY_RCL: Record<number, number> = {
   1: 1,
   2: 1,
-  3: 2,
+  3: 3,
   4: 3,
   5: 5,
   6: 8,

--- a/prod/src/territory/expansionTrigger.ts
+++ b/prod/src/territory/expansionTrigger.ts
@@ -22,6 +22,7 @@ import {
 import { normalizeTerritoryIntents } from './territoryMemoryUtils';
 import { recordPostClaimBootstrapClaimSuccess } from './postClaimBootstrap';
 import { TERRITORY_EXPANSION_SCOUT_TARGETS } from './expansionConfig';
+import { TERRITORY_CONTROLLER_BODY_COST } from '../spawn/bodyTemplates';
 
 const DEFAULT_EXPANSION_TRIGGER_SCORE_THRESHOLD = 700;
 const DEFAULT_EXPANSION_TRIGGER_MIN_STORAGE_ENERGY = 0;
@@ -31,6 +32,7 @@ const EXPANSION_TRIGGER_DOWNGRADE_GUARD_TICKS = 5_000;
 const EXPANSION_PIPELINE_REEVALUATION_SEPARATOR = '>';
 const GCL_LIMIT_PRECONDITION = 'wait for GCL capacity to claim another room';
 const ROOM_LIMIT_PRECONDITION_PREFIX = 'limit expansion to ';
+const MAX_ROOM_ENERGY_CAPACITY_BY_RCL = [0, 300, 550, 800, 1_300, 1_800, 2_300, 5_600, 12_900];
 
 interface ExpansionTriggerConfig {
   scoreThreshold: number;
@@ -847,12 +849,13 @@ function isExpansionHomeStable(
   config: ExpansionTriggerConfig
 ): boolean {
   const controller = colony.room.controller;
+  const requiredEnergy = getExpansionTriggerRequiredEnergy(controller?.level);
   return (
     controller?.my === true &&
     typeof controller.level === 'number' &&
     controller.level >= config.minRcl &&
     !isControllerDowngradeGuardBreached(controller) &&
-    colony.energyCapacityAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY &&
+    colony.energyCapacityAvailable >= requiredEnergy &&
     getRoomStorageEnergy(colony.room) >= config.minStorageEnergy &&
     !hasVisibleHostiles(colony.room) &&
     getHomeThreatLevel(colony.room.name, gameTime) === 'none'
@@ -864,10 +867,32 @@ function isExpansionTriggerReady(
   gameTime: number,
   config: ExpansionTriggerConfig
 ): boolean {
+  const requiredEnergy = getExpansionTriggerRequiredEnergy(colony.room.controller?.level);
   return (
     isExpansionHomeStable(colony, gameTime, config) &&
-    colony.energyAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY
+    colony.energyAvailable >= requiredEnergy
   );
+}
+
+export function getExpansionTriggerRequiredEnergy(controllerLevel: number | undefined): number {
+  const rclCapacity = getMaxRoomEnergyCapacityForRcl(controllerLevel);
+  if (rclCapacity === null) {
+    return TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY;
+  }
+
+  return Math.max(
+    TERRITORY_CONTROLLER_BODY_COST,
+    Math.min(TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY, rclCapacity)
+  );
+}
+
+function getMaxRoomEnergyCapacityForRcl(controllerLevel: number | undefined): number | null {
+  if (typeof controllerLevel !== 'number' || !Number.isFinite(controllerLevel)) {
+    return null;
+  }
+
+  const rcl = Math.max(0, Math.min(8, Math.floor(controllerLevel)));
+  return MAX_ROOM_ENERGY_CAPACITY_BY_RCL[rcl] ?? null;
 }
 
 function hasBlockingExpansionInProgress(territoryMemory: TerritoryMemory, colony: string): boolean {

--- a/prod/src/territory/expansionTrigger.ts
+++ b/prod/src/territory/expansionTrigger.ts
@@ -380,7 +380,7 @@ function selectExpansionTriggerCandidate(
   gameTime: number
 ): ExpansionTriggerCandidate | null {
   const config = getExpansionTriggerConfig();
-  if (!isExpansionHomeStable(colony, gameTime, config)) {
+  if (!isExpansionTriggerReady(colony, gameTime, config)) {
     return null;
   }
 
@@ -388,7 +388,17 @@ function selectExpansionTriggerCandidate(
     return null;
   }
 
-  const candidate = report.candidates.find(
+  const candidate = findExpansionTriggerCandidate(colony, report, territoryMemory, config);
+  return candidate ? { candidate, config } : null;
+}
+
+function findExpansionTriggerCandidate(
+  colony: ColonySnapshot,
+  report: ExpansionCandidateReport,
+  territoryMemory: TerritoryMemory,
+  config: ExpansionTriggerConfig
+): ExpansionCandidateScore | null {
+  return report.candidates.find(
     (scoredCandidate) =>
       scoredCandidate.evidenceStatus !== 'unavailable' &&
       scoredCandidate.score >= config.scoreThreshold &&
@@ -403,8 +413,7 @@ function selectExpansionTriggerCandidate(
           : {}),
         territoryMemory
       })
-  );
-  return candidate ? { candidate, config } : null;
+  ) ?? null;
 }
 
 function getTriggerSkipReason(
@@ -429,11 +438,19 @@ function getTriggerSkipReason(
     return 'roomLimitReached';
   }
 
-  if (!isExpansionHomeStable(colony, gameTime, getExpansionTriggerConfig())) {
+  const config = getExpansionTriggerConfig();
+  if (!isExpansionHomeStable(colony, gameTime, config)) {
     return 'unmetPreconditions';
   }
 
   if (hasBlockingExpansionInProgress(territoryMemory, colony.room.name)) {
+    return 'unmetPreconditions';
+  }
+
+  if (
+    !isExpansionTriggerReady(colony, gameTime, config) &&
+    findExpansionTriggerCandidate(colony, report, territoryMemory, config)
+  ) {
     return 'unmetPreconditions';
   }
 
@@ -442,6 +459,10 @@ function getTriggerSkipReason(
   }
 
   if (report.candidates.some((candidate) => candidate.preconditions.length > 0)) {
+    return 'unmetPreconditions';
+  }
+
+  if (!isExpansionTriggerReady(colony, gameTime, config)) {
     return 'unmetPreconditions';
   }
 
@@ -835,6 +856,17 @@ function isExpansionHomeStable(
     getRoomStorageEnergy(colony.room) >= config.minStorageEnergy &&
     !hasVisibleHostiles(colony.room) &&
     getHomeThreatLevel(colony.room.name, gameTime) === 'none'
+  );
+}
+
+function isExpansionTriggerReady(
+  colony: ColonySnapshot,
+  gameTime: number,
+  config: ExpansionTriggerConfig
+): boolean {
+  return (
+    isExpansionHomeStable(colony, gameTime, config) &&
+    colony.energyAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY
   );
 }
 

--- a/prod/test/e26s50ClaimPipeline.test.ts
+++ b/prod/test/e26s50ClaimPipeline.test.ts
@@ -2,6 +2,7 @@ import type { ColonySnapshot } from '../src/colony/colonyRegistry';
 import { runClaimer } from '../src/creeps/claimerRunner';
 import { planSpawn } from '../src/spawn/spawnPlanner';
 import { refreshExpansionExecutorIntent } from '../src/territory/expansionExecutor';
+import { getExpansionTriggerRequiredEnergy } from '../src/territory/expansionTrigger';
 import { planTerritoryIntent } from '../src/territory/territoryPlanner';
 
 describe('E26S50 claim pipeline', () => {
@@ -126,8 +127,13 @@ describe('E26S50 claim pipeline', () => {
     ]);
   });
 
-  it('skips the E26S50 trigger when current energy is below claim readiness', () => {
-    const colony = makeColony({ controllerLevel: 3, energyAvailable: 999 });
+  it('skips the E26S50 trigger when current energy is below RCL 3 expansion readiness', () => {
+    const threshold = getExpansionTriggerRequiredEnergy(3);
+    const colony = makeColony({
+      controllerLevel: 3,
+      energyAvailable: threshold - 1,
+      energyCapacityAvailable: 800
+    });
     setGame(colony, 828, { includeE26S48: true, gclLevel: 3 });
     setSafeHomeThreat('E26S49', 828);
     Memory.scout = {

--- a/prod/test/e26s50ClaimPipeline.test.ts
+++ b/prod/test/e26s50ClaimPipeline.test.ts
@@ -90,6 +90,59 @@ describe('E26S50 claim pipeline', () => {
     ]);
   });
 
+  it('triggers an E26S50 claim at RCL 3 when GCL capacity and claim energy are ready', () => {
+    const colony = makeColony({ controllerLevel: 3 });
+    setGame(colony, 827, { includeE26S48: true, gclLevel: 3 });
+    setSafeHomeThreat('E26S49', 827);
+    Memory.scout = {
+      E26S50: makeLegacyScoutIntel()
+    };
+
+    expect(refreshExpansionExecutorIntent(colony, 827)).toMatchObject({
+      status: 'planned',
+      colony: 'E26S49',
+      targetRoom: 'E26S50',
+      controllerId: 'controller-e26s50'
+    });
+    expect(Memory.territory?.expansionCandidates?.[0]).toMatchObject({
+      colony: 'E26S49',
+      roomName: 'E26S50',
+      evidenceStatus: 'sufficient',
+      recommendedAction: 'claim',
+      nearestOwnedRoom: 'E26S49',
+      nearestOwnedRoomDistance: 1,
+      routeDistance: 1
+    });
+    expect(Memory.territory?.expansionCandidates?.[0]).not.toHaveProperty('preconditions');
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'E26S49',
+        roomName: 'E26S50',
+        action: 'claim',
+        createdBy: 'nextExpansionScoring',
+        controllerId: 'controller-e26s50',
+        postClaimBootstrapReserveEnergy: 400
+      }
+    ]);
+  });
+
+  it('skips the E26S50 trigger when current energy is below claim readiness', () => {
+    const colony = makeColony({ controllerLevel: 3, energyAvailable: 999 });
+    setGame(colony, 828, { includeE26S48: true, gclLevel: 3 });
+    setSafeHomeThreat('E26S49', 828);
+    Memory.scout = {
+      E26S50: makeLegacyScoutIntel()
+    };
+
+    expect(refreshExpansionExecutorIntent(colony, 828)).toEqual({
+      status: 'skipped',
+      colony: 'E26S49',
+      reason: 'unmetPreconditions'
+    });
+    expect(Memory.territory?.expansionPipelines?.E26S49).toBeUndefined();
+    expect(Memory.territory?.targets).toBeUndefined();
+  });
+
   it.each([
     ['hostile scout evidence', { hostileCreepCount: 1 }],
     [
@@ -228,16 +281,24 @@ describe('E26S50 claim pipeline', () => {
   });
 });
 
-function makeColony(): ColonySnapshot {
+function makeColony({
+  controllerLevel = 4,
+  energyAvailable = 1_300,
+  energyCapacityAvailable = 1_300
+}: {
+  controllerLevel?: number;
+  energyAvailable?: number;
+  energyCapacityAvailable?: number;
+} = {}): ColonySnapshot {
   const room = {
     name: 'E26S49',
-    energyAvailable: 1_300,
-    energyCapacityAvailable: 1_300,
+    energyAvailable,
+    energyCapacityAvailable,
     controller: {
       id: 'controller-e26s49' as Id<StructureController>,
       my: true,
       owner: { username: 'me' },
-      level: 4,
+      level: controllerLevel,
       ticksToDowngrade: 10_000
     } as StructureController,
     storage: {
@@ -253,23 +314,55 @@ function makeColony(): ColonySnapshot {
   return {
     room,
     spawns: [spawn],
-    energyAvailable: 1_300,
-    energyCapacityAvailable: 1_300,
-    spawnEnergyBudget: 1_300,
+    energyAvailable,
+    energyCapacityAvailable,
+    spawnEnergyBudget: energyCapacityAvailable,
     memory: room.memory
   };
 }
 
-function setGame(colony: ColonySnapshot, gameTime: number): void {
+function setGame(
+  colony: ColonySnapshot,
+  gameTime: number,
+  {
+    includeE26S48 = false,
+    gclLevel
+  }: {
+    includeE26S48?: boolean;
+    gclLevel?: number;
+  } = {}
+): void {
+  const rooms: Record<string, Room> = {
+    E26S49: colony.room
+  };
+  if (includeE26S48) {
+    rooms.E26S48 = makeOwnedRoom('E26S48');
+  }
+
   (globalThis as unknown as { Game: Partial<Game> }).Game = {
     time: gameTime,
-    rooms: {
-      E26S49: colony.room
-    },
+    rooms,
+    ...(gclLevel !== undefined ? { gcl: { level: gclLevel, progress: 0, progressTotal: 1 } } : {}),
     map: {
       describeExits: jest.fn((roomName: string) => (roomName === 'E26S49' ? { '5': 'E26S50' } : {}))
     } as unknown as GameMap
   };
+}
+
+function makeOwnedRoom(roomName: string): Room {
+  return {
+    name: roomName,
+    controller: {
+      id: `controller-${roomName.toLowerCase()}` as Id<StructureController>,
+      my: true,
+      owner: { username: 'me' },
+      level: 3,
+      ticksToDowngrade: 10_000
+    } as StructureController,
+    energyAvailable: 1_300,
+    energyCapacityAvailable: 1_300,
+    find: jest.fn((findType: number) => (findType === FIND_SOURCES ? makeSources(roomName) : []))
+  } as unknown as Room;
 }
 
 function makeLegacyScoutIntel(overrides: Partial<TerritoryScoutIntelMemory> = {}): Record<string, unknown> {

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -1789,13 +1789,14 @@ describe('runEconomy', () => {
     (globalThis as unknown as { Game: Partial<Game> }).Game.rooms = {
       W1N1: room,
       W2N1: targetRoom,
-      W3N1: makeOwnedEconomyRoom('W3N1')
+      W3N1: makeOwnedEconomyRoom('W3N1'),
+      W4N1: makeOwnedEconomyRoom('W4N1')
     };
     (globalThis as unknown as { Game: Partial<Game> }).Game.time = 502;
 
     runEconomy();
 
-    expect(getRoomTerrain).toHaveBeenCalledTimes(4);
+    expect(getRoomTerrain).toHaveBeenCalledTimes(5);
     expect(room.memory.lastExpansionScoreTime).toBe(502);
     expect(room.memory.cachedExpansionSelection).toMatchObject({
       status: 'skipped',
@@ -1919,7 +1920,12 @@ describe('runEconomy', () => {
     };
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       time: 503,
-      rooms: { W1N1: room, W2N1: targetRoom, W3N1: makeOwnedEconomyRoom('W3N1') },
+      rooms: {
+        W1N1: room,
+        W2N1: targetRoom,
+        W3N1: makeOwnedEconomyRoom('W3N1'),
+        W4N1: makeOwnedEconomyRoom('W4N1')
+      },
       spawns: {},
       creeps: workers,
       getObjectById: jest.fn().mockReturnValue(null),
@@ -2010,7 +2016,12 @@ describe('runEconomy', () => {
     };
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       time: 504,
-      rooms: { W1N1: room, W2N1: targetRoom, W3N1: makeOwnedEconomyRoom('W3N1') },
+      rooms: {
+        W1N1: room,
+        W2N1: targetRoom,
+        W3N1: makeOwnedEconomyRoom('W3N1'),
+        W4N1: makeOwnedEconomyRoom('W4N1')
+      },
       spawns: {},
       creeps: workers,
       getObjectById: jest.fn().mockReturnValue(null),

--- a/prod/test/expansionScoring.test.ts
+++ b/prod/test/expansionScoring.test.ts
@@ -1267,7 +1267,7 @@ describe('next expansion scoring', () => {
   it.each([
     [1, 1],
     [2, 1],
-    [3, 2],
+    [3, 3],
     [4, 3],
     [5, 5],
     [6, 8],
@@ -1299,7 +1299,7 @@ describe('next expansion scoring', () => {
     const report = scoreExpansionCandidates(
       makeInput([makeCandidate({ roomName: 'W3N1', sourceCount: 2 })], {
         controllerLevel: 3,
-        ownedRoomCount: 2
+        ownedRoomCount: 3
       })
     );
 
@@ -1338,14 +1338,14 @@ describe('next expansion scoring', () => {
     const report = scoreExpansionCandidates(
       makeInput([makeCandidate({ roomName: 'W3N1', sourceCount: 2 })], {
         controllerLevel: 3,
-        ownedRoomCount: 2,
+        ownedRoomCount: 3,
         ticksToDowngrade: 100
       })
     );
 
     expect(report.next?.preconditions).toEqual(
       expect.arrayContaining([
-        'limit expansion to 2 owned rooms for current controller level',
+        'limit expansion to 3 owned rooms for current controller level',
         'stabilize home controller downgrade timer'
       ])
     );
@@ -1423,7 +1423,7 @@ describe('next expansion scoring', () => {
     const report = scoreExpansionCandidates(
       makeInput([makeCandidate({ roomName: 'W3N1', sourceCount: 2 })], {
         controllerLevel: 3,
-        ownedRoomCount: 2
+        ownedRoomCount: 3
       })
     );
 

--- a/prod/test/expansionTrigger.test.ts
+++ b/prod/test/expansionTrigger.test.ts
@@ -1,5 +1,6 @@
 import type { ColonySnapshot } from '../src/colony/colonyRegistry';
 import {
+  getExpansionTriggerRequiredEnergy,
   refreshAutonomousExpansionPipeline
 } from '../src/territory/expansionTrigger';
 import type {
@@ -34,6 +35,71 @@ describe('autonomous expansion trigger pipeline', () => {
       .TERRITORY_EXPANSION_TRIGGER_MIN_STORAGE_ENERGY;
     delete (globalThis as { TERRITORY_EXPANSION_TRIGGER_SCORE_THRESHOLD?: number })
       .TERRITORY_EXPANSION_TRIGGER_SCORE_THRESHOLD;
+  });
+
+  it('keeps the RCL 3 expansion energy threshold within room capacity', () => {
+    expect(getExpansionTriggerRequiredEnergy(3)).toBeLessThanOrEqual(800);
+  });
+
+  it('starts an RCL 3 pipeline when room energy reaches the capped threshold', () => {
+    const threshold = getExpansionTriggerRequiredEnergy(3);
+    const colony = makeColony({
+      storageEnergy: 2_000,
+      rcl: 3,
+      energyAvailable: threshold,
+      energyCapacityAvailable: 800
+    });
+    const report = makeReport([
+      makeCandidate({ roomName: 'W2N1', controllerId: 'controller2' as Id<StructureController> })
+    ]);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 9,
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeTargetRoom('W2N1', 'controller2' as Id<StructureController>)
+      }
+    };
+    setSafeHomeThreat('W1N1', 9);
+
+    expect(refreshAutonomousExpansionPipeline(colony, report, 9)).toMatchObject({
+      status: 'planned',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      controllerId: 'controller2'
+    });
+    expect(Memory.territory?.expansionPipelines?.W1N1).toMatchObject({
+      status: 'active',
+      stage: 'reserving',
+      targetRoom: 'W2N1'
+    });
+  });
+
+  it('waits at RCL 3 when room energy is below the capped threshold', () => {
+    const threshold = getExpansionTriggerRequiredEnergy(3);
+    const colony = makeColony({
+      storageEnergy: 2_000,
+      rcl: 3,
+      energyAvailable: threshold - 1,
+      energyCapacityAvailable: 800
+    });
+    const report = makeReport([
+      makeCandidate({ roomName: 'W2N1', controllerId: 'controller2' as Id<StructureController> })
+    ]);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 9,
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeTargetRoom('W2N1', 'controller2' as Id<StructureController>)
+      }
+    };
+    setSafeHomeThreat('W1N1', 9);
+
+    expect(refreshAutonomousExpansionPipeline(colony, report, 9)).toEqual({
+      status: 'skipped',
+      colony: 'W1N1',
+      reason: 'unmetPreconditions'
+    });
+    expect(Memory.territory?.expansionPipelines).toEqual({});
   });
 
   it('gates the trigger on configured storage energy before starting the reserve stage', () => {
@@ -498,16 +564,20 @@ function makeCandidate({
 function makeColony({
   storageEnergy = 0,
   rcl = 3,
-  ticksToDowngrade = 10_000
+  ticksToDowngrade = 10_000,
+  energyAvailable = 1_300,
+  energyCapacityAvailable = 1_300
 }: {
   storageEnergy?: number;
   rcl?: number;
   ticksToDowngrade?: number;
+  energyAvailable?: number;
+  energyCapacityAvailable?: number;
 } = {}): ColonySnapshot {
   const room = {
     name: 'W1N1',
-    energyAvailable: 1_300,
-    energyCapacityAvailable: 1_300,
+    energyAvailable,
+    energyCapacityAvailable,
     storage: makeStorage(storageEnergy),
     controller: {
       id: 'controller1' as Id<StructureController>,
@@ -523,8 +593,8 @@ function makeColony({
   return {
     room,
     spawns: [],
-    energyAvailable: 1_300,
-    energyCapacityAvailable: 1_300,
+    energyAvailable,
+    energyCapacityAvailable,
     memory: room.memory
   };
 }

--- a/prod/test/reservationPlanner.test.ts
+++ b/prod/test/reservationPlanner.test.ts
@@ -199,6 +199,7 @@ describe('adjacent room reservation planner', () => {
       gclLevel: 5,
       rooms: {
         W3N1: makeOwnedRoom('W3N1'),
+        W4N1: makeOwnedRoom('W4N1'),
         W1N2: makeReservationRoom('W1N2', { sourceCount: 2 })
       },
       exits: { W1N1: { '1': 'W1N2' } }

--- a/prod/test/territory/expansionScoring.test.ts
+++ b/prod/test/territory/expansionScoring.test.ts
@@ -28,6 +28,39 @@ describe('configured territory expansion scoring', () => {
     delete (globalThis as { TERRAIN_MASK_SWAMP?: number }).TERRAIN_MASK_SWAMP;
   });
 
+  it('scores E26S50 as the nearest configured expansion candidate for E26S49', () => {
+    const colony = makeColony('E26S49');
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 840,
+      rooms: {
+        E26S49: colony.room,
+        E26S48: makeOwnedRoom('E26S48')
+      },
+      map: {
+        describeExits: jest.fn(() => ({})),
+        getRoomTerrain: jest.fn(() => makeTerrain(0))
+      } as unknown as GameMap
+    };
+
+    const report = buildRuntimeExpansionCandidateReport(colony);
+    const candidate = getCandidate(report, 'E26S50');
+
+    expect(report.candidates[0]).toMatchObject({
+      roomName: 'E26S50',
+      evidenceStatus: 'insufficient-evidence',
+      visible: false,
+      adjacentToOwnedRoom: true,
+      nearestOwnedRoom: 'E26S49',
+      nearestOwnedRoomDistance: 1,
+      routeDistance: 1
+    });
+    expect(candidate).toBe(report.candidates[0]);
+    expect(selectExpansionScoutTargets(report, 2, 840).map((target) => target.roomName)).toEqual([
+      'E26S50',
+      'E26S47'
+    ]);
+  });
+
   it('scores E26S47 for scouting once E26S48 is owned', () => {
     const colony = makeColony('E26S49');
     (globalThis as unknown as { Game: Partial<Game> }).Game = {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1175,7 +1175,10 @@ describe('planTerritoryIntent', () => {
         rooms: {
           W1N1: scenario.colony.room,
           ...(scenario.ownedRoom
-            ? { W9N9: { name: 'W9N9', controller: { my: true, owner: { username: 'me' } } } as Room }
+            ? {
+                W8N8: { name: 'W8N8', controller: { my: true, owner: { username: 'me' } } } as Room,
+                W9N9: { name: 'W9N9', controller: { my: true, owner: { username: 'me' } } } as Room
+              }
             : {}),
           W1N2: makeRecommendationRoom('W1N2', {
             sourceCount: 2,


### PR DESCRIPTION
## Summary
Trigger expansion claim for E26S50 when the colony meets readiness preconditions. Fixes overly conservative expansion thresholds and logic bugs in the expansion trigger/scoring pipeline.

## Changes
- `prod/src/territory/expansionTrigger.ts`: Fixed expansion trigger readiness checks and thresholds for E26S50
- `prod/src/territory/expansionScoring.ts`: Adjusted scoring parameters for expansion evaluation
- `prod/test/`: Added and updated tests for expansion trigger, scoring, claim pipeline, and reservation planner

## Verification
- typecheck: PASS
- 93 test suites, 1675 tests: ALL PASS
- build: PASS

Closes #869
