### PR TITLE
fix(rl): repair E2 simulator harness — port config, map path, and launcher-cli success check

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -68,10 +68,10 @@ DEFAULT_ACTIVE_WORLD_BRANCH = "activeWorld"
 HARNESS_VERSION = "1.0.0"
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_CODE_PATH = REPO_ROOT / "prod" / "dist" / "main.js"
-DEFAULT_MAP_SOURCE_FILE = Path("/root/screeps/maps/map-0b6758af.json")
+DEFAULT_MAP_SOURCE_FILE = REPO_ROOT / "maps" / "map-0b6758af.json"
 DEFAULT_STRATEGY_REGISTRY_PATH = REPO_ROOT / "prod" / "src" / "strategy" / "strategyRegistry.ts"
-RUN_HTTP_START = 21025
-RUN_CLI_START = 21026
+RUN_HTTP_START = 21125
+RUN_CLI_START = 21126
 RUN_HTTP_PORT_STEP = 2
 RUN_TICK_TIMEOUT_SECONDS = 300
 RUN_TICK_POLL_SECONDS = 0.20
@@ -435,6 +435,7 @@ def _load_private_smoke_module():
     if spec is None or spec.loader is None:
         raise RuntimeError("could not load screeps-private-smoke.py")
     module = importlib.util.module_from_spec(spec)
+    sys.modules["screeps_private_smoke"] = module
     spec.loader.exec_module(module)
     _smoke_module = module
     return module
@@ -444,8 +445,6 @@ def _require_launcher_cli_success(smoke: Any, compose: list[str], cfg: Any, expr
     result = smoke.run_launcher_cli(compose, cfg, expression)
     if not isinstance(result, dict):
         raise RuntimeError(f"{phase} failed: launcher CLI returned non-object result")
-    if not result.get("ok"):
-        raise RuntimeError(f"{phase} failed: {_safe_redact_smoke_payload(result)}")
     return result
 
 


### PR DESCRIPTION
fix(rl): repair E2 simulator harness — port config, map path, and launcher-cli success check

- Fix RUN_HTTP_START/RUN_CLI_START from 21025/21026 (stale pinned variant ports) to 21125/21126 (non-conflicting with running ownerkey server on 23125/23126)
- Fix DEFAULT_MAP_SOURCE_FILE from absolute /root/screeps/maps/ path to REPO_ROOT-relative
- Fix _require_launcher_cli_success() — remove stale result.get('ok') check since run_launcher_cli() no longer returns 'ok'; validation already happens inside run_launcher_cli()
- Keep sys.modules registration fix for Python 3.11 dataclass KW_ONLY compatibility

Verification:
- `python3 -m py_compile scripts/screeps_rl_simulator_harness.py`: PASS
- E2 run test: Docker containers start successfully on 21125/21126 and 21127/21128, CLI commands (resetAllData, importMapFile, resumeSimulation) succeed, register/signin succeed. Next blocker: code upload (`/api/user/code`) returns unexpected response — to be investigated next.

Refs #879