### PR TITLE
P0 EMERGENCY: Rollback construction spending and scoring fixes — restore harvesting (#877/#882/#884)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2693,8 +2693,6 @@ var ENERGY_BUFFER_THRESHOLDS_BY_RCL = {
 };
 var SURVIVAL_ENERGY_BUFFER_MULTIPLIER = 1.5;
 var STORAGE_EMERGENCY_RESERVE = 1e3;
-var CAPACITY_ENABLING_CONSTRUCTION_HEALTHY_ENERGY_CAPACITY = 550;
-var CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY = 300;
 var MINIMUM_WORKER_SPAWN_ENERGY = 200;
 function getRoomEnergyBufferThreshold(room) {
   return ENERGY_BUFFER_THRESHOLDS_BY_RCL[getRoomRcl(room)];
@@ -2709,20 +2707,6 @@ function checkEnergyBufferForSpending(room, amount) {
     return true;
   }
   return observation.currentEnergy - normalizeEnergyAmount(amount) >= getEffectiveRoomEnergyBufferThreshold(room);
-}
-function checkEnergyBufferForCapacityEnablingConstruction(room, amount) {
-  if (checkEnergyBufferForSpending(room, amount)) {
-    return true;
-  }
-  const energyCapacityAvailable = getRoomEnergyCapacityAvailable2(room);
-  if (energyCapacityAvailable === null) {
-    return false;
-  }
-  return hasMinimumWorkerSpawnEnergyForConstruction(room) && energyCapacityAvailable < CAPACITY_ENABLING_CONSTRUCTION_HEALTHY_ENERGY_CAPACITY && getEffectiveRoomEnergyBufferThreshold(room) > energyCapacityAvailable;
-}
-function hasMinimumWorkerSpawnEnergyForConstruction(room) {
-  const observation = getRoomSpawnExtensionEnergyObservation(room);
-  return !observation.known || observation.currentEnergy >= CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY;
 }
 function withdrawFromStorage(room, amount, storage = getRoomStorage(room), currentStorageEnergy = storage ? getStoredEnergy(storage) : 0, options = {}) {
   if (!storage) {
@@ -2788,10 +2772,6 @@ function getRoomSpawnExtensionEnergyObservation(room) {
     return { currentEnergy: Math.max(0, energyAvailable), known: true };
   }
   return { currentEnergy: 0, known: false };
-}
-function getRoomEnergyCapacityAvailable2(room) {
-  const energyCapacityAvailable = room.energyCapacityAvailable;
-  return typeof energyCapacityAvailable === "number" && Number.isFinite(energyCapacityAvailable) ? Math.max(0, energyCapacityAvailable) : null;
 }
 function getRoomStorage(room) {
   var _a;
@@ -4096,7 +4076,7 @@ function buildClaimOwnerCandidate(colonyName, input, activePlan) {
   }
   const spawnCount = getActiveSpawnCount(colonyName, input.colony);
   const controllerLevel = normalizeNonNegativeInteger4(room.controller.level);
-  const energyCapacityAvailable = getRoomEnergyCapacityAvailable3(colonyName, room, input.colony);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable2(colonyName, room, input.colony);
   const energyAvailable = getRoomEnergyAvailable2(colonyName, room, input.colony);
   const routeDistance = getClaimRouteDistance(colonyName, input);
   const claimCapable = spawnCount > 0 && controllerLevel >= TERRITORY_AUTO_CLAIM_MIN_RCL && energyCapacityAvailable >= TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY;
@@ -4269,7 +4249,7 @@ function normalizeFiniteDistance(distance) {
 function getRoomEnergyAvailable2(roomName, room, currentColony) {
   return roomName === currentColony.room.name ? normalizeNonNegativeInteger4(currentColony.energyAvailable) : normalizeNonNegativeInteger4(room.energyAvailable);
 }
-function getRoomEnergyCapacityAvailable3(roomName, room, currentColony) {
+function getRoomEnergyCapacityAvailable2(roomName, room, currentColony) {
   return roomName === currentColony.room.name ? normalizeNonNegativeInteger4(currentColony.energyCapacityAvailable) : normalizeNonNegativeInteger4(room.energyCapacityAvailable);
 }
 function getRoomStorageEnergy(room) {
@@ -7886,7 +7866,7 @@ function shouldPrioritizeSourceLogisticsConstruction(room) {
   return isSourceLogisticsEnergyStarved(
     getOwnedRoomRcl(room),
     getRoomEnergyAvailable3(room),
-    getRoomEnergyCapacityAvailable4(room)
+    getRoomEnergyCapacityAvailable3(room)
   );
 }
 function getConstructionSiteImpactPriority(site, context = {}) {
@@ -8044,7 +8024,7 @@ function getRoomEnergyAvailable3(room) {
   const energyAvailable = room.energyAvailable;
   return typeof energyAvailable === "number" && Number.isFinite(energyAvailable) ? Math.max(0, energyAvailable) : void 0;
 }
-function getRoomEnergyCapacityAvailable4(room) {
+function getRoomEnergyCapacityAvailable3(room) {
   const energyCapacityAvailable = room.energyCapacityAvailable;
   return typeof energyCapacityAvailable === "number" && Number.isFinite(energyCapacityAvailable) ? Math.max(0, energyCapacityAvailable) : void 0;
 }
@@ -9242,8 +9222,6 @@ function isContainerConstructionSite(site) {
 // src/economy/stagingContainers.ts
 var SPAWN_STAGING_CONTAINER_RANGE = 1;
 var CONTROLLER_STAGING_CONTAINER_RANGE = 1;
-var cachedStructureTick = null;
-var uniqueRoomStructuresCache = /* @__PURE__ */ new Map();
 function getEnergyStagingContainerRole(room, structure) {
   if (!isContainerStructure(structure)) {
     return null;
@@ -9277,24 +9255,6 @@ function hasNearbySpawnOrExtension(room, position) {
   });
 }
 function getUniqueRoomStructures(room) {
-  const gameTime = getGameTime13();
-  if (gameTime !== null) {
-    if (cachedStructureTick !== gameTime) {
-      cachedStructureTick = gameTime;
-      uniqueRoomStructuresCache.clear();
-    }
-    const cacheKey = `${room.name}:${gameTime}`;
-    const cachedStructures = uniqueRoomStructuresCache.get(cacheKey);
-    if (cachedStructures) {
-      return cachedStructures;
-    }
-    const uniqueStructures = buildUniqueRoomStructures(room);
-    uniqueRoomStructuresCache.set(cacheKey, uniqueStructures);
-    return uniqueStructures;
-  }
-  return buildUniqueRoomStructures(room);
-}
-function buildUniqueRoomStructures(room) {
   const structures = [
     ...findRoomStructures2(room, "FIND_MY_STRUCTURES"),
     ...findRoomStructures2(room, "FIND_STRUCTURES")
@@ -9310,11 +9270,6 @@ function buildUniqueRoomStructures(room) {
     uniqueStructures.push(structure);
   }
   return uniqueStructures;
-}
-function getGameTime13() {
-  var _a;
-  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
-  return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : null;
 }
 function findRoomStructures2(room, globalName) {
   const findConstant = globalThis[globalName];
@@ -9676,7 +9631,7 @@ function planConstructionForColony(colony, options = {}) {
   const sourceLogisticsStarved = shouldPrioritizeSourceLogisticsBeforeCapacity(
     rcl,
     energyAvailable,
-    getRoomEnergyCapacityAvailable5(colony)
+    getRoomEnergyCapacityAvailable4(colony)
   );
   const spawnPlacement = planSpawnIfMissing(colony);
   if (spawnPlacement) {
@@ -9832,21 +9787,7 @@ function planContainers(colony, result, budgetState, options, containerOptions =
   if (remainingContainerSitesThisTick <= 0) {
     return;
   }
-  const containerResults = planSourceContainerConstruction(colony, {
-    maxContainerSitesPerTick: remainingContainerSitesThisTick,
-    maxPendingContainerSites: options.maxPendingContainerSites
-  });
-  for (const containerResult of containerResults) {
-    recordPlacement(result, budgetState, "container", containerResult, options);
-    if (containerResult !== getOkCode4()) {
-      return;
-    }
-    remainingContainerSitesThisTick -= 1;
-    if (remainingContainerSitesThisTick <= 0) {
-      return;
-    }
-  }
-  if (containerOptions.includeStagingContainers !== false && !hasRemainingStructureCapacity(colony.room, "extension") && (remainingContainerSitesThisTick > 1 || hasCompleteSourceContainerCoverage(colony.room))) {
+  if (containerOptions.includeStagingContainers !== false && !hasRemainingStructureCapacity(colony.room, "extension")) {
     const stagingContainerResults = planStagingContainerConstruction(colony, {
       maxContainerSitesPerTick: remainingContainerSitesThisTick,
       maxPendingContainerSites: options.maxPendingContainerSites
@@ -9860,6 +9801,16 @@ function planContainers(colony, result, budgetState, options, containerOptions =
       if (remainingContainerSitesThisTick <= 0) {
         return;
       }
+    }
+  }
+  const containerResults = planSourceContainerConstruction(colony, {
+    maxContainerSitesPerTick: remainingContainerSitesThisTick,
+    maxPendingContainerSites: options.maxPendingContainerSites
+  });
+  for (const containerResult of containerResults) {
+    recordPlacement(result, budgetState, "container", containerResult, options);
+    if (containerResult !== getOkCode4()) {
+      return;
     }
   }
 }
@@ -9937,23 +9888,6 @@ function hasSpawnCoverage(colony) {
     var _a;
     return ((_a = spawn.room) == null ? void 0 : _a.name) === colony.room.name;
   }) || countExistingStructures(colony.room, "spawn") > 0 || countPendingConstructionSites(colony.room, "spawn") > 0;
-}
-function hasCompleteSourceContainerCoverage(room) {
-  const sources = getSortedSources3(room);
-  if (sources.length === 0) {
-    return true;
-  }
-  const containerPositions = [
-    ...findRoomObjects12(room, "FIND_STRUCTURES"),
-    ...findRoomObjects12(room, "FIND_CONSTRUCTION_SITES")
-  ].filter((object) => object.structureType === getStructureConstant("STRUCTURE_CONTAINER")).map((object) => getAnyObjectPosition(object)).filter((position) => isSameRoomPosition5(position, room.name));
-  return sources.every((source) => {
-    const sourcePosition = getAnyObjectPosition(source);
-    if (sourcePosition === null || !isSameRoomPosition5(sourcePosition, room.name)) {
-      return false;
-    }
-    return containerPositions.some((position) => getRangeBetweenPositions5(sourcePosition, position) <= 1);
-  });
 }
 function hasRemainingStructureCapacity(room, priority) {
   return getRemainingStructureCapacity(room, priority) > 0;
@@ -10059,7 +9993,7 @@ function getRoomEnergyAvailable4(colony) {
   }
   return typeof colony.energyAvailable === "number" && Number.isFinite(colony.energyAvailable) ? Math.max(0, colony.energyAvailable) : 0;
 }
-function getRoomEnergyCapacityAvailable5(colony) {
+function getRoomEnergyCapacityAvailable4(colony) {
   const roomEnergyCapacity = getOptionalRoomEnergyCapacityAvailable(colony.room);
   if (roomEnergyCapacity !== null) {
     return roomEnergyCapacity;
@@ -10496,7 +10430,7 @@ function scoreOccupationRecommendations(input) {
     input.colonyName
   );
 }
-function persistOccupationRecommendationFollowUpIntent(report, gameTime = getGameTime14()) {
+function persistOccupationRecommendationFollowUpIntent(report, gameTime = getGameTime13()) {
   var _a, _b;
   const followUpIntent = report.followUpIntent;
   if (!followUpIntent) {
@@ -11075,7 +11009,7 @@ function getGameRooms4() {
   var _a;
   return (_a = globalThis.Game) == null ? void 0 : _a.rooms;
 }
-function getGameTime14() {
+function getGameTime13() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -11769,7 +11703,7 @@ function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
   if (!bootstraps) {
     return;
   }
-  const gameTime = getGameTime15();
+  const gameTime = getGameTime14();
   const existing = getPostClaimBootstrapRecord(input.roomName);
   const claimedAt = (existing == null ? void 0 : existing.status) === "ready" ? gameTime : (_a = existing == null ? void 0 : existing.claimedAt) != null ? _a : gameTime;
   const status = getRefreshedPostClaimBootstrapStatus(existing);
@@ -11971,7 +11905,7 @@ function recordPostClaimBootstrapWorkerSpawn(roomName, spawnName, creepName, res
   }
   updatePostClaimBootstrapRecord(roomName, {
     status: "spawningWorkers",
-    updatedAt: getGameTime15()
+    updatedAt: getGameTime14()
   });
   telemetryEvents.push({
     type: "postClaimBootstrap",
@@ -12280,7 +12214,7 @@ function placePostClaimSpawnConstructionSite(roomName, telemetryEvents) {
     const spawnSite = toSpawnSiteMemory(existingSpawnSite);
     updatePostClaimBootstrapRecord(roomName, {
       status: "spawnSitePending",
-      updatedAt: getGameTime15(),
+      updatedAt: getGameTime14(),
       workerTarget,
       spawnSite,
       lastResult: OK_CODE7
@@ -12304,7 +12238,7 @@ function placePostClaimSpawnConstructionSite(roomName, telemetryEvents) {
   const nextStatus = sitePlan.result === OK_CODE7 ? "spawnSitePending" : "spawnSiteBlocked";
   updatePostClaimBootstrapRecord(roomName, {
     status: nextStatus,
-    updatedAt: getGameTime15(),
+    updatedAt: getGameTime14(),
     workerTarget,
     ...sitePlan.position ? { spawnSite: sitePlan.position } : {},
     lastResult: sitePlan.result
@@ -12397,7 +12331,7 @@ function planInitialSpawnConstructionSiteWithPlanner(room) {
     room,
     spawns: getRoomSpawns(room.name),
     energyAvailable: getRoomEnergyAvailable6(room),
-    energyCapacityAvailable: getRoomEnergyCapacityAvailable6(room)
+    energyCapacityAvailable: getRoomEnergyCapacityAvailable5(room)
   });
   const spawnPlacement = result.placements.find((placement) => placement.priority === "spawn");
   if (!spawnPlacement) {
@@ -12422,7 +12356,7 @@ function getRoomSpawns(roomName) {
 function getRoomEnergyAvailable6(room) {
   return typeof room.energyAvailable === "number" && Number.isFinite(room.energyAvailable) ? Math.max(0, room.energyAvailable) : 0;
 }
-function getRoomEnergyCapacityAvailable6(room) {
+function getRoomEnergyCapacityAvailable5(room) {
   return typeof room.energyCapacityAvailable === "number" && Number.isFinite(room.energyCapacityAvailable) ? Math.max(0, room.energyCapacityAvailable) : getRoomEnergyAvailable6(room);
 }
 function findInitialSpawnConstructionPositions(room) {
@@ -12664,7 +12598,7 @@ function getGlobalString2(name) {
   const value = globalThis[name];
   return typeof value === "string" ? value : null;
 }
-function getGameTime15() {
+function getGameTime14() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
@@ -12689,7 +12623,7 @@ var EXPANSION_PIPELINE_REEVALUATION_SEPARATOR = ">";
 var GCL_LIMIT_PRECONDITION2 = "wait for GCL capacity to claim another room";
 var ROOM_LIMIT_PRECONDITION_PREFIX = "limit expansion to ";
 var MAX_ROOM_ENERGY_CAPACITY_BY_RCL = [0, 300, 550, 800, 1300, 1800, 2300, 5600, 12900];
-function refreshAutonomousExpansionPipeline(colony, report, gameTime = getGameTime16(), telemetryEvents = []) {
+function refreshAutonomousExpansionPipeline(colony, report, gameTime = getGameTime15(), telemetryEvents = []) {
   const colonyName = colony.room.name;
   const territoryMemory = getWritableTerritoryMemoryRecord5();
   if (!territoryMemory) {
@@ -12743,7 +12677,7 @@ function recordExpansionPipelineClaimState({
   colony,
   targetRoom,
   claimState,
-  gameTime = getGameTime16(),
+  gameTime = getGameTime15(),
   controllerId
 }) {
   const territoryMemory = getTerritoryMemoryRecord7();
@@ -13467,7 +13401,7 @@ function getWritableTerritoryMemoryRecord5() {
   }
   return memory.territory;
 }
-function getGameTime16() {
+function getGameTime15() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -13554,7 +13488,7 @@ function getTerritoryIntentRouteDistance(plan) {
   var _a;
   return (_a = plan.routeDistance) != null ? _a : territoryIntentRouteDistances.get(plan);
 }
-function recordRecoveredTerritoryFollowUpRetryCooldown(plan, gameTime = getGameTime17()) {
+function recordRecoveredTerritoryFollowUpRetryCooldown(plan, gameTime = getGameTime16()) {
   if (!plan || !plan.followUp || !isTerritoryControlAction3(plan.action)) {
     return;
   }
@@ -13586,7 +13520,7 @@ function recordRecoveredTerritoryFollowUpRetryCooldown(plan, gameTime = getGameT
   removeTerritoryFollowUpDemand(territoryMemory, plan.colony, plan.targetRoom, plan.action);
   removeTerritoryFollowUpExecutionHint(territoryMemory, plan.colony, plan.targetRoom, plan.action);
 }
-function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGameTime17()) {
+function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGameTime16()) {
   if (isKnownDeadZoneRoom(plan.targetRoom)) {
     return false;
   }
@@ -13636,7 +13570,7 @@ function isTerritoryIntentPlanSpawnCapable(plan) {
   const energyCapacityAvailable = (_b = getVisibleRoom3(plan.colony)) == null ? void 0 : _b.energyCapacityAvailable;
   return typeof energyCapacityAvailable !== "number" || energyCapacityAvailable >= TERRITORY_CONTROLLER_PRESSURE_BODY_COST;
 }
-function getTerritoryFollowUpPreparationWorkerDemand(plan, gameTime = getGameTime17()) {
+function getTerritoryFollowUpPreparationWorkerDemand(plan, gameTime = getGameTime16()) {
   var _a;
   if (!plan || !isTerritoryControlAction3(plan.action)) {
     return 0;
@@ -13658,7 +13592,7 @@ function getTerritoryFollowUpPreparationWorkerDemand(plan, gameTime = getGameTim
   const demand = getCurrentTerritoryFollowUpDemand(plan, gameTime);
   return (_a = demand == null ? void 0 : demand.workerCount) != null ? _a : 0;
 }
-function hasActiveTerritoryFollowUpPreparationDemand(colony, gameTime = getGameTime17()) {
+function hasActiveTerritoryFollowUpPreparationDemand(colony, gameTime = getGameTime16()) {
   if (!isNonEmptyString13(colony)) {
     return false;
   }
@@ -13670,7 +13604,7 @@ function hasActiveTerritoryFollowUpPreparationDemand(colony, gameTime = getGameT
     (demand) => demand.updatedAt === gameTime && demand.colony === colony && demand.workerCount > 0
   );
 }
-function hasPendingTerritoryFollowUpIntent(colony, roleCounts, gameTime = getGameTime17()) {
+function hasPendingTerritoryFollowUpIntent(colony, roleCounts, gameTime = getGameTime16()) {
   if (!isNonEmptyString13(colony)) {
     return false;
   }
@@ -13706,7 +13640,7 @@ function getTerritoryIntentProgressSummaries(colony, roleCounts) {
   if (!territoryMemory) {
     return [];
   }
-  const gameTime = getGameTime17();
+  const gameTime = getGameTime16();
   return normalizeTerritoryIntents(territoryMemory.intents).filter(
     (intent) => isTerritoryIntentProgressVisibleForColony(intent, colony, gameTime)
   ).map((intent) => {
@@ -13726,7 +13660,7 @@ function getTerritoryIntentProgressSummaries(colony, roleCounts) {
     };
   }).sort(compareTerritoryIntentProgressSummaries);
 }
-function getSuspendedTerritoryIntentCountsByRoom(colony, gameTime = getGameTime17()) {
+function getSuspendedTerritoryIntentCountsByRoom(colony, gameTime = getGameTime16()) {
   var _a;
   if (!isNonEmptyString13(colony)) {
     return {};
@@ -14024,7 +13958,7 @@ function recordAutonomousExpansionClaimReserveFallbackIntent(colony, evaluation,
     gameTime
   );
 }
-function refreshRemoteMiningSetup(colony, gameTime = getGameTime17(), options = {}) {
+function refreshRemoteMiningSetup(colony, gameTime = getGameTime16(), options = {}) {
   var _a, _b, _c, _d;
   const territoryMemory = getWritableTerritoryMemoryRecord6();
   if (!territoryMemory) {
@@ -16361,7 +16295,7 @@ function hasActiveTerritoryFollowUpIntentForColony(intents, colony) {
   return intents.some((intent) => intent.colony === colony && isActiveTerritoryFollowUpIntent(intent));
 }
 function isActiveTerritoryFollowUpIntent(intent) {
-  return (intent.status === "planned" || intent.status === "active") && intent.followUp !== void 0 && !isTerritoryIntentSuspensionActive(intent, getGameTime17());
+  return (intent.status === "planned" || intent.status === "active") && intent.followUp !== void 0 && !isTerritoryIntentSuspensionActive(intent, getGameTime16());
 }
 function buildTerritoryFollowUpExecutionHint(plan, gameTime) {
   if (!plan.followUp) {
@@ -16515,7 +16449,7 @@ function withoutTerritoryIntentSuspension(intent) {
 function isHostileTerritoryIntentSuspensionCoolingDown(suspension, gameTime) {
   return gameTime - suspension.updatedAt <= TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS;
 }
-function isTerritoryIntentSuspended(colony, targetRoom, action, gameTime = getGameTime17()) {
+function isTerritoryIntentSuspended(colony, targetRoom, action, gameTime = getGameTime16()) {
   const territoryMemory = getTerritoryMemoryRecord8();
   if (!territoryMemory) {
     return false;
@@ -16558,7 +16492,7 @@ function isSuppressedTerritoryIntentForAction(intents, colony, targetRoom, actio
     (intent) => isTerritorySuppressionFresh2(intent, gameTime) && intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action
   );
 }
-function isTerritoryIntentSuppressed(colony, targetRoom, action, gameTime = getGameTime17()) {
+function isTerritoryIntentSuppressed(colony, targetRoom, action, gameTime = getGameTime16()) {
   const territoryMemory = getTerritoryMemoryRecord8();
   if (!territoryMemory) {
     return false;
@@ -16611,7 +16545,7 @@ function normalizeCreepTerritoryIntent(creep, roomName) {
     targetRoom: assignment.targetRoom,
     action: assignment.action,
     status: "active",
-    updatedAt: getGameTime17(),
+    updatedAt: getGameTime16(),
     ...assignment.controllerId ? { controllerId: assignment.controllerId } : {},
     ...followUp ? { followUp } : {}
   };
@@ -16918,7 +16852,7 @@ function getVisibleController2(targetRoom, controllerId) {
   }
   return null;
 }
-function getGameTime17() {
+function getGameTime16() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -17418,7 +17352,7 @@ var SPAWN_ENERGY_RESERVATION_IDLE_RELEASE_TICKS = 10;
 var SPAWN_ENERGY_RESERVATION_CRITICAL_ENERGY_THRESHOLD = 200;
 var DEFAULT_SPAWN_ENERGY_RESERVATION_TRANSFER_THRESHOLD = 300;
 var SPAWN_ENERGY_RESERVATION_TRANSFER_MAX_RANGE = 3;
-function reserveSpawnEnergyForNextRequest(request, gameTime = getGameTime18()) {
+function reserveSpawnEnergyForNextRequest(request, gameTime = getGameTime17()) {
   if (!request || request.bodyCost <= 0 || request.roomName.length === 0) {
     if (request == null ? void 0 : request.roomName) {
       clearSpawnEnergyReservation(request.roomName, gameTime);
@@ -17443,13 +17377,13 @@ function reserveSpawnEnergyForNextRequest(request, gameTime = getGameTime18()) {
   reservationMemory.rooms[request.roomName] = reservation;
   return reservation;
 }
-function clearSpawnEnergyReservation(roomName, gameTime = getGameTime18()) {
+function clearSpawnEnergyReservation(roomName, gameTime = getGameTime17()) {
   const memory = getWritableEconomyMemory();
   const reservationMemory = ensureSpawnEnergyReservationMemory(memory, gameTime);
   delete reservationMemory.rooms[roomName];
   reservationMemory.updatedAt = gameTime;
 }
-function refreshSpawnEnergyReservationState(room, spawns, gameTime = getGameTime18()) {
+function refreshSpawnEnergyReservationState(room, spawns, gameTime = getGameTime17()) {
   const roomName = getRoomName4(room);
   const reservation = getSpawnEnergyReservation(roomName);
   if (!reservation) {
@@ -17525,7 +17459,7 @@ function getSpawnEnergyReservation(roomName) {
   if (!reservation) {
     return null;
   }
-  const gameTime = getGameTime18();
+  const gameTime = getGameTime17();
   return reservation.updatedAt <= gameTime && reservation.reservedAt <= gameTime ? reservation : null;
 }
 function writeSpawnEnergyReservation(reservation, gameTime) {
@@ -17727,7 +17661,7 @@ function getConfiguredSpawnEnergyReservationNumber(room, field) {
   );
   return economyConfig != null ? economyConfig : null;
 }
-function getGameTime18() {
+function getGameTime17() {
   var _a;
   const time = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof time === "number" && Number.isFinite(time) ? Math.max(0, Math.floor(time)) : 0;
@@ -18139,7 +18073,7 @@ var BEHAVIOR_COUNTER_KEYS = [
   { key: "pathLength" }
 ];
 var TOP_IDLE_WORKER_COUNT = 3;
-function observeCreepBehaviorTick(creep, tick = getGameTime19()) {
+function observeCreepBehaviorTick(creep, tick = getGameTime18()) {
   var _a, _b;
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastObservedTick === tick) {
@@ -18159,7 +18093,7 @@ function observeCreepBehaviorTick(creep, tick = getGameTime19()) {
   }
   telemetry.lastObservedTick = tick;
 }
-function recordCreepBehaviorIdle(creep, tick = getGameTime19()) {
+function recordCreepBehaviorIdle(creep, tick = getGameTime18()) {
   var _a;
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastIdleTick === tick) {
@@ -18168,7 +18102,7 @@ function recordCreepBehaviorIdle(creep, tick = getGameTime19()) {
   telemetry.idleTicks = ((_a = telemetry.idleTicks) != null ? _a : 0) + 1;
   telemetry.lastIdleTick = tick;
 }
-function recordCreepBehaviorMove(creep, tick = getGameTime19()) {
+function recordCreepBehaviorMove(creep, tick = getGameTime18()) {
   var _a;
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastMoveTick === tick) {
@@ -18177,7 +18111,7 @@ function recordCreepBehaviorMove(creep, tick = getGameTime19()) {
   telemetry.moveTicks = ((_a = telemetry.moveTicks) != null ? _a : 0) + 1;
   telemetry.lastMoveTick = tick;
 }
-function recordCreepBehaviorWork(creep, tick = getGameTime19()) {
+function recordCreepBehaviorWork(creep, tick = getGameTime18()) {
   var _a;
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastWorkTick === tick) {
@@ -18194,7 +18128,7 @@ function recordCreepBehaviorContainerTransfer(creep) {
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   telemetry.containerTransfers = ((_a = telemetry.containerTransfers) != null ? _a : 0) + 1;
 }
-function recordCreepBehaviorSourceContainerWithdrawal(creep, tick = getGameTime19()) {
+function recordCreepBehaviorSourceContainerWithdrawal(creep, tick = getGameTime18()) {
   var _a;
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastSourceContainerWithdrawalTick === tick) {
@@ -18359,7 +18293,7 @@ function getStepDistance(previous, current) {
   }
   return Math.max(Math.abs(current.x - previous.x), Math.abs(current.y - previous.y));
 }
-function getGameTime19() {
+function getGameTime18() {
   const game = globalThis.Game;
   return typeof (game == null ? void 0 : game.time) === "number" ? game.time : 0;
 }
@@ -18412,7 +18346,7 @@ function getRoomEnergySurplusState(room) {
 function refreshRoomEnergySurplusState(room) {
   const state = getRoomEnergySurplusState(room);
   const memory = getEconomyMemory();
-  const updatedAt = getGameTime20();
+  const updatedAt = getGameTime19();
   if (!isPlainObject2(memory.energySurplus) || !isPlainObject2(memory.energySurplus.rooms)) {
     memory.energySurplus = { updatedAt, rooms: {} };
   }
@@ -18593,7 +18527,7 @@ function getMemory() {
   }
   return global.Memory;
 }
-function getGameTime20() {
+function getGameTime19() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
@@ -18775,7 +18709,7 @@ function isSourceWorkloadFresh(workload, freshTicks) {
   if (!workload || typeof workload.updatedAt !== "number" || !Number.isFinite(workload.updatedAt)) {
     return false;
   }
-  const gameTime = getGameTime21();
+  const gameTime = getGameTime20();
   return gameTime >= workload.updatedAt && gameTime - workload.updatedAt <= freshTicks;
 }
 function isSourceHarvestSufficient(source, harvestCoverageRatio) {
@@ -18857,7 +18791,7 @@ function matchesStructureType14(actual, globalName, fallback) {
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
 }
-function getGameTime21() {
+function getGameTime20() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
@@ -19031,7 +18965,7 @@ function getRecentSourceWorkload(roomName) {
   if (!workload || typeof workload.updatedAt !== "number" || !Number.isFinite(workload.updatedAt)) {
     return null;
   }
-  const gameTime = getGameTime22();
+  const gameTime = getGameTime21();
   if (gameTime < workload.updatedAt || gameTime - workload.updatedAt > MULTI_ROOM_ENERGY_SOURCE_WORKLOAD_MAX_AGE) {
     return null;
   }
@@ -19076,7 +19010,7 @@ function getGlobalNumber12(name, fallback) {
   const value = globalThis[name];
   return typeof value === "number" && Number.isFinite(value) ? value : fallback;
 }
-function getGameTime22() {
+function getGameTime21() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
@@ -19178,7 +19112,7 @@ var STORAGE_BALANCE_IMPORT_RATIO = 0.3;
 var STORAGE_BALANCE_REFRESH_INTERVAL = 25;
 function balanceStorage() {
   const memory = getEconomyMemory2();
-  const gameTime = getGameTime23();
+  const gameTime = getGameTime22();
   const existing = memory.storageBalance;
   if (existing && isStorageBalanceFresh(existing, gameTime)) {
     return;
@@ -19187,7 +19121,7 @@ function balanceStorage() {
 }
 function getStorageBalanceState() {
   const memory = getEconomyMemory2();
-  const gameTime = getGameTime23();
+  const gameTime = getGameTime22();
   const existing = memory.storageBalance;
   if (existing && isStorageBalanceFresh(existing, gameTime)) {
     return existing;
@@ -19649,7 +19583,7 @@ function getMemory2() {
   }
   return global.Memory;
 }
-function getGameTime23() {
+function getGameTime22() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
@@ -19714,7 +19648,7 @@ function planCrossRoomHauler(getEnergyBudget = getDefaultCrossRoomHaulerEnergyBu
   return {
     spawn,
     body,
-    name: `crossRoomHauler-${sourceRoom.name}-${targetRoom.name}-${getGameTime24()}`,
+    name: `crossRoomHauler-${sourceRoom.name}-${targetRoom.name}-${getGameTime23()}`,
     memory: {
       role: CROSS_ROOM_HAULER_ROLE,
       colony: sourceRoom.name,
@@ -20223,7 +20157,7 @@ function getVisibleRoom7(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
-function getGameTime24() {
+function getGameTime23() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
@@ -22006,7 +21940,7 @@ function estimateNearTermSpawnCompletionRefillReserve(room, spawnExtensionEnergy
   if (!spawnExtensionEnergyStructures.some(isNearTermSpawningSpawn)) {
     return 0;
   }
-  return Math.max(0, (_a = getRoomEnergyCapacityAvailable7(room)) != null ? _a : 0);
+  return Math.max(0, (_a = getRoomEnergyCapacityAvailable6(room)) != null ? _a : 0);
 }
 function isTerritoryControlTask(task) {
   return (task == null ? void 0 : task.type) === "claim" || (task == null ? void 0 : task.type) === "reserve";
@@ -22068,7 +22002,7 @@ function applyMinimumUsefulSpawnExtensionDeliveryPolicy(creep, task) {
   return task;
 }
 function hasKnownSpawnExtensionEnergyCapacity(room) {
-  return getRoomEnergyCapacityAvailable7(room) !== null;
+  return getRoomEnergyCapacityAvailable6(room) !== null;
 }
 function clearWorkerEfficiencyTelemetry(creep) {
   const memory = creep.memory;
@@ -22181,7 +22115,7 @@ function selectStorageToSpawnExtensionRefillAcquisitionTask(creep) {
 }
 function isSpawnExtensionThroughputBottlenecked(room) {
   const energyAvailable = getRoomEnergyAvailable9(room);
-  const energyCapacityAvailable = getRoomEnergyCapacityAvailable7(room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable6(room);
   if (energyAvailable === null || energyCapacityAvailable === null || energyCapacityAvailable <= 0) {
     return false;
   }
@@ -23133,18 +23067,7 @@ function canSpendCreepEnergyOnConstruction(creep) {
   return checkEnergyBufferForSpending(creep.room, getUsedEnergy2(creep));
 }
 function canSpendCreepEnergyOnConstructionSite(creep, site, priorityContext) {
-  const carriedEnergy = getUsedEnergy2(creep);
-  return checkEnergyBufferForSpending(creep.room, carriedEnergy) || carriedEnergy > 0 && isCapacityEnablingConstructionSite(site, priorityContext) && checkEnergyBufferForCapacityEnablingConstruction(creep.room, carriedEnergy) || carriedEnergy > 0 && hasMinimumWorkerSpawnEnergyForConstruction(creep.room) && isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext);
-}
-function isCapacityEnablingConstructionSite(site, priorityContext) {
-  if (isExtensionConstructionSite(site)) {
-    return true;
-  }
-  const priority = getConstructionSiteImpactPriority(site, priorityContext);
-  if (isContainerConstructionSite3(site)) {
-    return priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.sourceContainer || priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedSourceContainer;
-  }
-  return isRoadConstructionSite2(site) && (priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.criticalRoad || priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedCriticalRoad);
+  return canSpendCreepEnergyOnConstruction(creep) || getUsedEnergy2(creep) > 0 && isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext);
 }
 function isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext) {
   if (priorityContext.prioritizeSourceLogisticsForEnergyStarvation !== true) {
@@ -23391,7 +23314,7 @@ function isOwnedRoomStructure(structure) {
   return ownership === true;
 }
 function shouldPrioritizeExtensionCapacity(room) {
-  const energyCapacityAvailable = getRoomEnergyCapacityAvailable7(room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable6(room);
   return !shouldPrioritizeSourceLogisticsConstruction(room) && (energyCapacityAvailable === null || energyCapacityAvailable < BASELINE_WORKER_THROUGHPUT_ENERGY_CAPACITY);
 }
 function selectReadyFollowUpProductiveEnergySinkTask(creep, capacityConstructionSite, controller, constructionSites, constructionReservationContext, priorityContext) {
@@ -23940,7 +23863,7 @@ function hasAbundantEnergyForLowLoadYieldSwitch(room) {
   if (energyAvailable === null) {
     return false;
   }
-  const energyCapacityAvailable = getRoomEnergyCapacityAvailable7(room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable6(room);
   if (energyCapacityAvailable !== null && energyCapacityAvailable <= 0) {
     return false;
   }
@@ -25034,7 +24957,7 @@ function shouldUseSurplusForControllerProgress(creep, controller) {
   const hasRecoverableEnergySurplus = hasRecoverableSurplusEnergy(creep);
   const upgradePriority = getControllerUpgradePriority(controller, {
     energyAvailable: (_a = getRoomEnergyAvailable9(creep.room)) != null ? _a : void 0,
-    energyCapacityAvailable: (_b = getRoomEnergyCapacityAvailable7(creep.room)) != null ? _b : void 0,
+    energyCapacityAvailable: (_b = getRoomEnergyCapacityAvailable6(creep.room)) != null ? _b : void 0,
     hasEnergySurplus: hasRecoverableEnergySurplus
   });
   if (controller.my === true && controller.level >= 2 && (upgradePriority === "rclProgress" || upgradePriority === "energySurplus")) {
@@ -25223,7 +25146,7 @@ function hasControllerUpgradeEnergySurplus(creep) {
 }
 function hasFullRoomEnergyForControllerProgress(room) {
   const energyAvailable = getRoomEnergyAvailable9(room);
-  const energyCapacityAvailable = getRoomEnergyCapacityAvailable7(room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable6(room);
   return energyAvailable !== null && energyCapacityAvailable !== null && energyCapacityAvailable >= TERRITORY_CONTROLLER_BODY_COST && energyAvailable >= energyCapacityAvailable;
 }
 function hasReservedTerritoryFollowUpRefillCapacity(creep) {
@@ -25234,7 +25157,7 @@ function hasReadyTerritoryFollowUpEnergy(creep) {
     return false;
   }
   const energyAvailable = getRoomEnergyAvailable9(creep.room);
-  const energyCapacityAvailable = getRoomEnergyCapacityAvailable7(creep.room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable6(creep.room);
   if (energyAvailable === null || energyCapacityAvailable === null) {
     return false;
   }
@@ -25245,13 +25168,13 @@ function getRoomEnergyAvailable9(room) {
   const energyAvailable = room.energyAvailable;
   return typeof energyAvailable === "number" && Number.isFinite(energyAvailable) ? energyAvailable : null;
 }
-function getRoomEnergyCapacityAvailable7(room) {
+function getRoomEnergyCapacityAvailable6(room) {
   const energyCapacityAvailable = room.energyCapacityAvailable;
   return typeof energyCapacityAvailable === "number" && Number.isFinite(energyCapacityAvailable) ? energyCapacityAvailable : null;
 }
 function estimateRoomEnergyRefillShortfall(room) {
   const energyAvailable = getRoomEnergyAvailable9(room);
-  const energyCapacityAvailable = getRoomEnergyCapacityAvailable7(room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable6(room);
   if (energyAvailable === null || energyCapacityAvailable === null) {
     return null;
   }
@@ -26141,7 +26064,7 @@ function updateEnergyCriticalPolicyMemory(creep, assessment, previousMemory) {
     delete creep.memory.workerEnergyCriticalPolicy;
     return;
   }
-  const gameTime = getGameTime25();
+  const gameTime = getGameTime24();
   creep.memory.workerEnergyCriticalPolicy = {
     type: "workerEnergyCriticalPolicy",
     schemaVersion: 1,
@@ -26261,7 +26184,7 @@ function getGameObjectById3(id) {
   const object = (_a = game == null ? void 0 : game.getObjectById) == null ? void 0 : _a.call(game, id);
   return object ? object : null;
 }
-function getGameTime25() {
+function getGameTime24() {
   var _a;
   const time = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof time === "number" && Number.isFinite(time) ? time : 0;
@@ -26588,7 +26511,7 @@ function isSoftSpawnReservationPreemptibleTask(creep, task) {
     if (!target) {
       return false;
     }
-    return !isCapacityEnablingConstructionSite2(target);
+    return !isCapacityEnablingConstructionSite(target);
   }
   if (task.type === "transfer") {
     return isStorageTransferTarget(getTaskTarget(task));
@@ -27208,14 +27131,14 @@ function isUrgentEnergySpendingTask(task) {
   if (task.type === "transfer") {
     return getTransferSinkPriority(target) >= 2;
   }
-  return task.type === "build" && isCapacityEnablingConstructionSite2(target);
+  return task.type === "build" && isCapacityEnablingConstructionSite(target);
 }
 function getTaskTarget(task) {
   const game = globalThis.Game;
   const getObjectById6 = game == null ? void 0 : game.getObjectById;
   return typeof getObjectById6 === "function" ? getObjectById6(String(task.targetId)) : null;
 }
-function isCapacityEnablingConstructionSite2(target) {
+function isCapacityEnablingConstructionSite(target) {
   const structureType = target == null ? void 0 : target.structureType;
   if (typeof structureType !== "string") {
     return false;
@@ -29310,7 +29233,7 @@ function combineNestedCountMaps(countsByHomeRoom) {
 function getActiveMultiRoomUpgraderCountCache() {
   var _a;
   const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
-  const gameTime = getGameTime26();
+  const gameTime = getGameTime25();
   if ((activeMultiRoomUpgraderCountCache == null ? void 0 : activeMultiRoomUpgraderCountCache.gameTime) !== gameTime || activeMultiRoomUpgraderCountCache.creeps !== creeps) {
     activeMultiRoomUpgraderCountCache = {
       gameTime,
@@ -29361,7 +29284,7 @@ function getRouteDistance2(fromRoom, targetRoom) {
   if (fromRoom === targetRoom) {
     return 0;
   }
-  const gameTime = getGameTime26();
+  const gameTime = getGameTime25();
   const cache = getTerritoryRouteDistanceCache3(gameTime);
   const cacheKey = getTerritoryRouteDistanceCacheKey3(fromRoom, targetRoom);
   const cachedRouteDistance = (_a = cache == null ? void 0 : cache.distances) == null ? void 0 : _a[cacheKey];
@@ -29455,7 +29378,7 @@ function getNoPathResultCode7() {
   const noPathCode = globalThis.ERR_NO_PATH;
   return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE6;
 }
-function getGameTime26() {
+function getGameTime25() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -31491,7 +31414,7 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   if (colonies.length === 0 && events.length === 0) {
     return void 0;
   }
-  const tick = getGameTime27();
+  const tick = getGameTime26();
   resetCachedRefillTelemetryIfTickRewound(tick);
   const emitsSummary = shouldEmitRuntimeSummary(tick, events);
   const creepsByColony = groupCreepsByColony(creeps);
@@ -31588,7 +31511,7 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
   const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   const territoryExpansion = buildRuntimeExpansionCandidateReport(colony);
   if (persistOccupationRecommendations) {
-    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime27());
+    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime26());
   }
   return {
     roomName: colony.room.name,
@@ -31598,11 +31521,11 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     workerCount: colonyWorkers.length,
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts: countWorkerTasks(colonyWorkers),
-    ...summarizeRuntimeBehavior(colonyWorkers, colonyCreeps, getGameTime27()),
+    ...summarizeRuntimeBehavior(colonyWorkers, colonyCreeps, getGameTime26()),
     ...includeStructureSnapshot ? { structures: summarizeStructures(colony, colonyWorkers) } : {},
-    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime27()),
-    ...summarizeRefillTelemetry(colonyWorkers, getGameTime27()),
-    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime27()),
+    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime26()),
+    ...summarizeRefillTelemetry(colonyWorkers, getGameTime26()),
+    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime26()),
     ...buildControllerSummary(colony.room),
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
@@ -31622,7 +31545,7 @@ function buildPostClaimBootstrapSummary(roomName) {
 }
 function buildTerritoryIntentSummary(colonyName, roleCounts) {
   const territoryIntents = getTerritoryIntentProgressSummaries(colonyName, roleCounts);
-  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime27());
+  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime26());
   const hasSuspendedTerritoryIntents = Object.keys(suspendedTerritoryIntentCounts).length > 0;
   if (territoryIntents.length === 0 && !hasSuspendedTerritoryIntents) {
     return {};
@@ -32685,7 +32608,7 @@ function buildCpuSummary() {
   }
   return Object.keys(summary).length > 0 ? { cpu: summary } : {};
 }
-function getGameTime27() {
+function getGameTime26() {
   return typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -33200,7 +33123,7 @@ var OK_CODE12 = 0;
 function manageTerminalEnergy() {
   const plans = selectTerminalEnergyTransfers();
   const results = [];
-  const gameTime = getGameTime28();
+  const gameTime = getGameTime27();
   for (const plan of plans) {
     const result = plan.sourceTerminal.send(
       getEnergyResource24(),
@@ -33502,7 +33425,7 @@ function getMemory3() {
   }
   return global.Memory;
 }
-function getGameTime28() {
+function getGameTime27() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
@@ -33626,7 +33549,7 @@ function planReactionChain(targetResource, inventory, desiredAmount = DEFAULT_LA
 function selectBoostPlans(room, labs, creeps, inventory) {
   return buildBoostRequests(room, creeps, inventory).map((request) => buildBoostPlan(request, labs)).sort(compareBoostPlans);
 }
-function shouldYieldCreepToLabManager(creep, gameTime = getGameTime29()) {
+function shouldYieldCreepToLabManager(creep, gameTime = getGameTime28()) {
   const labMemory = creep.memory.lab;
   return (labMemory == null ? void 0 : labMemory.boostState) === "moving" && labMemory.updatedAt === gameTime;
 }
@@ -33955,7 +33878,7 @@ function dedupeMissingResources(resources) {
 function recordLabManagementState(room, result, previousRoomMemory, options) {
   var _a, _b, _c, _d, _e, _f, _g;
   const memory = getEconomyMemory4();
-  const gameTime = getGameTime29();
+  const gameTime = getGameTime28();
   const rooms = (_b = (_a = memory.labManagement) == null ? void 0 : _a.rooms) != null ? _b : {};
   const reactionMemory = buildReactionMemory(result.reaction, previousRoomMemory == null ? void 0 : previousRoomMemory.reaction, result.inventory, gameTime);
   const roomMemory = {
@@ -34044,7 +33967,7 @@ function markCreepBoostState(creep, boostState, plan) {
   creep.memory.lab = {
     ...creep.memory.lab,
     boostState,
-    updatedAt: getGameTime29(),
+    updatedAt: getGameTime28(),
     ...plan ? {
       activeBoost: {
         labId: plan.lab ? getObjectId16(plan.lab) : void 0,
@@ -34262,7 +34185,7 @@ function getMemory4() {
   }
   return global.Memory;
 }
-function getGameTime29() {
+function getGameTime28() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return normalizeNonNegativeInteger15(gameTime);
@@ -34298,12 +34221,12 @@ var DEFAULT_RESOURCE_EXCESS = 2e4;
 var ENERGY_RESOURCE_TARGET = 75e3;
 var ENERGY_RESOURCE_EXCESS = 15e4;
 var MAX_ORDERS_PER_RESOURCE_SIDE = 5;
-function shouldRunMarketTrading(gameTime = getGameTime30(), interval = MARKET_TRADING_INTERVAL) {
+function shouldRunMarketTrading(gameTime = getGameTime29(), interval = MARKET_TRADING_INTERVAL) {
   const normalizedInterval = normalizePositiveInteger(interval);
   return gameTime > 0 && gameTime % normalizedInterval === 0;
 }
 function runMarketTrading() {
-  const gameTime = getGameTime30();
+  const gameTime = getGameTime29();
   const market = getMarket();
   if (!market) {
     recordMarketTradingState([], gameTime, { skippedReason: "missingMarket" });
@@ -34939,7 +34862,7 @@ function getMemory5() {
   }
   return global.Memory;
 }
-function getGameTime30() {
+function getGameTime29() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return normalizeNonNegativeInteger16(gameTime);
@@ -35345,7 +35268,7 @@ function refreshTerritoryExecutionTargets(action, options = {}) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return { action, targetCount: 0, intentCount: 0 };
   }
-  const gameTime = (_a = options.gameTime) != null ? _a : getGameTime31();
+  const gameTime = (_a = options.gameTime) != null ? _a : getGameTime30();
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
   let targetCount = 0;
@@ -35449,7 +35372,7 @@ function isNonEmptyString24(value) {
 function isRecord28(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
-function getGameTime31() {
+function getGameTime30() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -35505,7 +35428,7 @@ function runRecommendedExpansionClaimExecutor(creep, telemetryEvents = []) {
   if (!isClaimExecutionAssignment(assignment)) {
     return false;
   }
-  const gameTime = getGameTime32();
+  const gameTime = getGameTime31();
   const recommendedClaim = getRecommendedExpansionClaimExecutionGate(creep.memory.colony, assignment);
   if (!recommendedClaim) {
     return false;
@@ -36366,13 +36289,13 @@ function recordRecommendedClaimSuccess(creep, assignment, controller, telemetryE
     },
     telemetryEvents
   );
-  recordClaimedRoomBootstrapStage(targetRoom, getGameTime32());
+  recordClaimedRoomBootstrapStage(targetRoom, getGameTime31());
   recordExpansionPipelineClaimState({
     colony,
     targetRoom,
     claimState: "claimed",
     controllerId: controller.id,
-    gameTime: getGameTime32()
+    gameTime: getGameTime31()
   });
   completeRecommendedClaimIntent(colony, targetRoom, controller.id);
   recordColonyExpansionClaimVerification({
@@ -36381,7 +36304,7 @@ function recordRecommendedClaimSuccess(creep, assignment, controller, telemetryE
     status: "claimed",
     controllerId: controller.id,
     creepName: creep.name,
-    updatedAt: getGameTime32()
+    updatedAt: getGameTime31()
   });
 }
 function completeRecommendedClaimIfSigned(creep, assignment, controller, telemetryEvents) {
@@ -36405,7 +36328,7 @@ function recordRecommendedClaimTerminalFailure(creep, assignment, result, reason
     reason
   });
   if (options.suppressIntent) {
-    suppressRecommendedClaimIntent(colony, assignment, getGameTime32(), options.controllerId, reason);
+    suppressRecommendedClaimIntent(colony, assignment, getGameTime31(), options.controllerId, reason);
   }
   recordColonyExpansionClaimVerification({
     colony,
@@ -36415,7 +36338,7 @@ function recordRecommendedClaimTerminalFailure(creep, assignment, result, reason
     creepName: creep.name,
     result,
     reason,
-    updatedAt: getGameTime32()
+    updatedAt: getGameTime31()
   });
 }
 function recordRecommendedClaimRetry(creep, assignment, result, reason, options = {}) {
@@ -36430,7 +36353,7 @@ function recordRecommendedClaimRetry(creep, assignment, result, reason, options 
     result,
     reason
   });
-  updateRecommendedClaimIntentForRetry(colony, assignment, getGameTime32(), options);
+  updateRecommendedClaimIntentForRetry(colony, assignment, getGameTime31(), options);
 }
 function updateRecommendedClaimIntentForRetry(colony, assignment, gameTime, options) {
   var _a, _b, _c, _d;
@@ -36640,7 +36563,7 @@ function getVisibleRoom14(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
-function getGameTime32() {
+function getGameTime31() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -36968,11 +36891,11 @@ function refreshClaimedRoomBootstrapperOwnership(telemetryEvents = []) {
     if (newlyClaimed) {
       detectedRoomNames.push(room.name);
     }
-    const claimedAt = newlyClaimed ? getGameTime33() : (_a = previous == null ? void 0 : previous.claimedAt) != null ? _a : activePostClaimRecord == null ? void 0 : activePostClaimRecord.claimedAt;
+    const claimedAt = newlyClaimed ? getGameTime32() : (_a = previous == null ? void 0 : previous.claimedAt) != null ? _a : activePostClaimRecord == null ? void 0 : activePostClaimRecord.claimedAt;
     memory.rooms[room.name] = {
       roomName: room.name,
       owned,
-      updatedAt: getGameTime33(),
+      updatedAt: getGameTime32(),
       ...claimedAt !== void 0 ? { claimedAt } : {},
       ...newlyClaimed ? {} : (previous == null ? void 0 : previous.completedAt) !== void 0 ? { completedAt: previous.completedAt } : {}
     };
@@ -37018,7 +36941,7 @@ function resolveClaimOriginColony(room, previous, activePostClaimRecord) {
   if (plannedClaimOrigin) {
     return plannedClaimOrigin;
   }
-  return selectNearestOwnedSpawnRoom(room.name);
+  return (previous == null ? void 0 : previous.owned) === false ? selectNearestOwnedSpawnRoom(room.name) : null;
 }
 function getPlannedClaimOriginColony(roomName) {
   var _a, _b, _c, _d, _e;
@@ -37033,30 +36956,21 @@ function getPlannedClaimOriginColony(roomName) {
     return pipelineOrigin;
   }
   const targetOrigin = Array.isArray(territory.targets) ? (_d = territory.targets.find(
-    (target) => isRecord31(target) && target.roomName === roomName && target.action === "claim" && isNonEmptyString27(target.colony)
+    (target) => target.roomName === roomName && target.action === "claim" && isNonEmptyString27(target.colony)
   )) == null ? void 0 : _d.colony : null;
   if (isNonEmptyString27(targetOrigin)) {
     return targetOrigin;
   }
   const intentOrigin = Array.isArray(territory.intents) ? (_e = territory.intents.find(
-    (intent) => isRecord31(intent) && intent.targetRoom === roomName && intent.action === "claim" && intent.status !== "completed" && intent.status !== "inactive" && isNonEmptyString27(intent.colony)
+    (intent) => intent.targetRoom === roomName && intent.action === "claim" && intent.status !== "completed" && intent.status !== "inactive" && isNonEmptyString27(intent.colony)
   )) == null ? void 0 : _e.colony : null;
   return isNonEmptyString27(intentOrigin) ? intentOrigin : null;
 }
 function selectNearestOwnedSpawnRoom(targetRoomName) {
-  var _a, _b;
+  var _a;
   const game = globalThis.Game;
   const spawns = game == null ? void 0 : game.spawns;
   if (!spawns) {
-    return null;
-  }
-  if (!isFreshClaimFallbackEligibleRoom((_a = game.rooms) == null ? void 0 : _a[targetRoomName])) {
-    return null;
-  }
-  if (Object.values(spawns).some((spawn) => {
-    var _a2;
-    return ((_a2 = spawn == null ? void 0 : spawn.room) == null ? void 0 : _a2.name) === targetRoomName;
-  })) {
     return null;
   }
   const candidateRoomNames = [
@@ -37069,23 +36983,12 @@ function selectNearestOwnedSpawnRoom(targetRoomName) {
       ).map((room) => room.name)
     )
   ];
-  const routeDistances = new Map(
-    candidateRoomNames.map((roomName) => [roomName, getRoomRouteDistance(roomName, targetRoomName)])
-  );
-  return (_b = candidateRoomNames.sort(
-    (left, right) => {
-      var _a2, _b2;
-      return compareRouteDistance(
-        (_a2 = routeDistances.get(left)) != null ? _a2 : Number.POSITIVE_INFINITY,
-        (_b2 = routeDistances.get(right)) != null ? _b2 : Number.POSITIVE_INFINITY
-      ) || left.localeCompare(right);
-    }
-  )[0]) != null ? _b : null;
+  return (_a = candidateRoomNames.sort(
+    (left, right) => compareClaimOriginRooms(left, right, targetRoomName)
+  )[0]) != null ? _a : null;
 }
-function isFreshClaimFallbackEligibleRoom(room) {
-  var _a;
-  const controllerLevel = (_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.level;
-  return typeof controllerLevel !== "number" || controllerLevel <= 2;
+function compareClaimOriginRooms(left, right, targetRoomName) {
+  return compareRouteDistance(getRoomRouteDistance(left, targetRoomName), getRoomRouteDistance(right, targetRoomName)) || left.localeCompare(right);
 }
 function compareRouteDistance(left, right) {
   const leftFinite = Number.isFinite(left);
@@ -37121,7 +37024,7 @@ function getRoomRouteDistance(fromRoom, toRoom) {
   }
   return Number.POSITIVE_INFINITY;
 }
-function getGameTime33() {
+function getGameTime32() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
@@ -37179,7 +37082,7 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
     return;
   }
   if (assignment.action === "scout") {
-    recordVisibleRoomScoutIntel(creep.memory.colony, creep.room, getGameTime34(), creep.name, telemetryEvents);
+    recordVisibleRoomScoutIntel(creep.memory.colony, creep.room, getGameTime33(), creep.name, telemetryEvents);
     if (assignNextScoutTarget(creep, assignment.targetRoom)) {
       moveTowardTargetRoom(creep, creep.memory.territory);
       return;
@@ -37276,7 +37179,7 @@ function selectNextScoutAssignment(colony, excludedTargetRoom) {
   if (!isNonEmptyString28(colony)) {
     return null;
   }
-  const gameTime = getGameTime34();
+  const gameTime = getGameTime33();
   return (_b = (_a = selectNextScoutIntentAssignment(colony, excludedTargetRoom, gameTime)) != null ? _a : selectNextScoutAttemptAssignment(colony, excludedTargetRoom, gameTime)) != null ? _b : selectNextConfiguredScoutAssignment(colony, excludedTargetRoom, gameTime);
 }
 function selectNextScoutIntentAssignment(colony, excludedTargetRoom, gameTime) {
@@ -37397,7 +37300,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   if (typeof creep.reserveController !== "function" || !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)) {
     return false;
   }
-  const gameTime = getGameTime34();
+  const gameTime = getGameTime33();
   const reserveAssignment = {
     targetRoom: assignment.targetRoom,
     action: "reserve",
@@ -37417,7 +37320,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   return true;
 }
 function suppressTerritoryAssignment(creep, assignment) {
-  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime34());
+  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime33());
   completeTerritoryAssignment(creep);
 }
 function completeTerritoryAssignment(creep) {
@@ -37497,7 +37400,7 @@ function selectVisibleTargetRoomController(assignment) {
   }
   return (_c = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[assignment.targetRoom]) == null ? void 0 : _b.controller) != null ? _c : null;
 }
-function getGameTime34() {
+function getGameTime33() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -37537,7 +37440,7 @@ function isTerritoryAssignment(assignment) {
 var EXPANSION_EXECUTOR_REFRESH_INTERVAL = 50;
 var EXPANSION_EXECUTOR_DOWNGRADE_GUARD_TICKS = 5e3;
 var EXPANSION_EXECUTOR_THREAT_MEMORY_STALE_TICKS = 5;
-function refreshExpansionExecutorIntent(colony, gameTime = getGameTime35(), telemetryEvents = []) {
+function refreshExpansionExecutorIntent(colony, gameTime = getGameTime34(), telemetryEvents = []) {
   const colonyName = colony.room.name;
   const colonyMemory = getWritableColonyMemory2(colony);
   let stateKey = getExpansionExecutorCacheStateKey(colony, gameTime);
@@ -37672,7 +37575,7 @@ function hasExpansionExecutorTarget(colony, targetRoom) {
     (target) => isRecord33(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
   ) : false;
 }
-function getExpansionExecutorCacheStateKey(colony, gameTime = getGameTime35()) {
+function getExpansionExecutorCacheStateKey(colony, gameTime = getGameTime34()) {
   var _a;
   const controller = colony.room.controller;
   const controllerLevel = isFiniteNumber10(controller == null ? void 0 : controller.level) ? controller.level : "unknown";
@@ -37812,7 +37715,7 @@ function getLatestTerritoryScoutIntelUpdatedAt(colony) {
   }
   return latestUpdatedAt;
 }
-function getGameTime35() {
+function getGameTime34() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -37917,7 +37820,7 @@ function reserveRoomForPlannedClaim(creep) {
     controllerId: controller.id,
     ...assignment.followUp ? { followUp: assignment.followUp } : {}
   };
-  creep.memory.territory = (_b = recordTerritoryReserveFallbackIntent(creep.memory.colony, reserveAssignment, getGameTime36())) != null ? _b : reserveAssignment;
+  creep.memory.territory = (_b = recordTerritoryReserveFallbackIntent(creep.memory.colony, reserveAssignment, getGameTime35())) != null ? _b : reserveAssignment;
   const result = creep.reserveController(controller);
   if (result === ERR_NOT_IN_RANGE_CODE12) {
     if (typeof creep.moveTo === "function") {
@@ -38033,7 +37936,7 @@ function getClaimBodyPartConstant() {
   var _a;
   return (_a = globalThis.CLAIM) != null ? _a : "claim";
 }
-function getGameTime36() {
+function getGameTime35() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -38048,7 +37951,7 @@ var MIN_ADJACENT_ROOM_RESERVATION_SCORE = 500;
 var ADJACENT_ROOM_RESERVATION_RENEWAL_TICKS_PER_CLAIM_PART = 600;
 var MAX_ADJACENT_ROOM_RESERVATION_RENEWAL_TICKS = 1e3;
 var EXIT_DIRECTION_ORDER7 = ["1", "3", "5", "7"];
-function refreshAdjacentRoomReservationIntent(colony, gameTime = getGameTime37(), options = {}) {
+function refreshAdjacentRoomReservationIntent(colony, gameTime = getGameTime36(), options = {}) {
   const evaluation = selectAdjacentRoomReservationPlan(colony, options);
   if (evaluation.status === "planned" && evaluation.targetRoom) {
     persistAdjacentRoomReservationIntent(colony.room.name, evaluation, gameTime);
@@ -38532,7 +38435,7 @@ function getWritableTerritoryMemoryRecord8() {
   }
   return root.Memory.territory;
 }
-function getGameTime37() {
+function getGameTime36() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -38548,7 +38451,7 @@ function isRecord34(value) {
 var COLONY_EXPANSION_CLAIM_TARGET_CREATOR = "colonyExpansion";
 var MIN_COLONY_EXPANSION_CLAIM_SCORE = MIN_ADJACENT_ROOM_RESERVATION_SCORE;
 var EXIT_DIRECTION_ORDER8 = ["1", "3", "5", "7"];
-function refreshColonyExpansionIntent(colony, assessment, gameTime = getGameTime38()) {
+function refreshColonyExpansionIntent(colony, assessment, gameTime = getGameTime37()) {
   const colonyName = colony.room.name;
   if (assessment.territoryReady !== true) {
     const reservation2 = refreshAdjacentRoomReservationIntent(colony, gameTime, {
@@ -39006,7 +38909,7 @@ function getWritableTerritoryMemoryRecord9() {
   }
   return memory.territory;
 }
-function getGameTime38() {
+function getGameTime37() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
@@ -39049,7 +38952,7 @@ function runReservationExecutor(creep) {
 function runAssignedReservation(creep, assignment, gate) {
   var _a;
   const colony = creep.memory.colony;
-  const gameTime = getGameTime39();
+  const gameTime = getGameTime38();
   if (!isNonEmptyString33(colony) || !isReservationExecutionGateRunnable(gate, gameTime)) {
     completeReservationAssignment(creep);
     return true;
@@ -39155,7 +39058,7 @@ function selectReservationAssignment(creep) {
 }
 function buildReservationSelection(creep, territoryMemory, recommendation, order, activeReservationCounts) {
   var _a, _b, _c;
-  const gameTime = getGameTime39();
+  const gameTime = getGameTime38();
   const intent = getMatchingReservationIntent(
     recommendation.colony,
     recommendation.targetRoom,
@@ -39605,7 +39508,7 @@ function getWritableTerritoryMemoryRecord10() {
   }
   return memory.territory;
 }
-function getGameTime39() {
+function getGameTime38() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -41033,7 +40936,7 @@ var Kernel = class {
     this.dependencies.cleanupDeadCreepMemory();
     const defenseEvents = this.dependencies.runDefense();
     return this.dependencies.runEconomy(
-      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime40())
+      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime39())
     );
   }
 };
@@ -41105,7 +41008,7 @@ function getDefenseEventPriority(event) {
       return 3;
   }
 }
-function getGameTime40() {
+function getGameTime39() {
   return typeof Game !== "undefined" && typeof Game.time === "number" ? Game.time : 0;
 }
 

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2718,7 +2718,7 @@ function checkEnergyBufferForCapacityEnablingConstruction(room, amount) {
   if (energyCapacityAvailable === null) {
     return false;
   }
-  return hasMinimumWorkerSpawnEnergyForConstruction(room) && energyCapacityAvailable < CAPACITY_ENABLING_CONSTRUCTION_HEALTHY_ENERGY_CAPACITY && getEffectiveRoomEnergyBufferThreshold(room) >= energyCapacityAvailable;
+  return hasMinimumWorkerSpawnEnergyForConstruction(room) && energyCapacityAvailable < CAPACITY_ENABLING_CONSTRUCTION_HEALTHY_ENERGY_CAPACITY && getEffectiveRoomEnergyBufferThreshold(room) > energyCapacityAvailable;
 }
 function hasMinimumWorkerSpawnEnergyForConstruction(room) {
   const observation = getRoomSpawnExtensionEnergyObservation(room);
@@ -23144,7 +23144,7 @@ function isCapacityEnablingConstructionSite(site, priorityContext) {
   if (isContainerConstructionSite3(site)) {
     return priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.sourceContainer || priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedSourceContainer;
   }
-  return false;
+  return isRoadConstructionSite2(site) && (priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.criticalRoad || priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedCriticalRoad);
 }
 function isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext) {
   if (priorityContext.prioritizeSourceLogisticsForEnergyStarvation !== true) {

--- a/prod/src/economy/energyBuffer.ts
+++ b/prod/src/economy/energyBuffer.ts
@@ -68,7 +68,7 @@ export function checkEnergyBufferForCapacityEnablingConstruction(room: Room, amo
   return (
     hasMinimumWorkerSpawnEnergyForConstruction(room) &&
     energyCapacityAvailable < CAPACITY_ENABLING_CONSTRUCTION_HEALTHY_ENERGY_CAPACITY &&
-    getEffectiveRoomEnergyBufferThreshold(room) >= energyCapacityAvailable
+    getEffectiveRoomEnergyBufferThreshold(room) > energyCapacityAvailable
   );
 }
 

--- a/prod/src/economy/energyBuffer.ts
+++ b/prod/src/economy/energyBuffer.ts
@@ -13,8 +13,6 @@ export const ENERGY_BUFFER_THRESHOLDS_BY_RCL: Record<1 | 2 | 3 | 4 | 5 | 6 | 7 |
 
 export const SURVIVAL_ENERGY_BUFFER_MULTIPLIER = 1.5;
 export const STORAGE_EMERGENCY_RESERVE = 1_000;
-export const CAPACITY_ENABLING_CONSTRUCTION_HEALTHY_ENERGY_CAPACITY = 550;
-export const CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY = 300;
 
 const MINIMUM_WORKER_SPAWN_ENERGY = 200;
 
@@ -53,28 +51,6 @@ export function checkEnergyBufferForSpending(room: Room, amount: number): boolea
   }
 
   return observation.currentEnergy - normalizeEnergyAmount(amount) >= getEffectiveRoomEnergyBufferThreshold(room);
-}
-
-export function checkEnergyBufferForCapacityEnablingConstruction(room: Room, amount: number): boolean {
-  if (checkEnergyBufferForSpending(room, amount)) {
-    return true;
-  }
-
-  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(room);
-  if (energyCapacityAvailable === null) {
-    return false;
-  }
-
-  return (
-    hasMinimumWorkerSpawnEnergyForConstruction(room) &&
-    energyCapacityAvailable < CAPACITY_ENABLING_CONSTRUCTION_HEALTHY_ENERGY_CAPACITY &&
-    getEffectiveRoomEnergyBufferThreshold(room) > energyCapacityAvailable
-  );
-}
-
-export function hasMinimumWorkerSpawnEnergyForConstruction(room: Room): boolean {
-  const observation = getRoomSpawnExtensionEnergyObservation(room);
-  return !observation.known || observation.currentEnergy >= CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY;
 }
 
 export function withdrawFromStorage(
@@ -165,13 +141,6 @@ function getRoomSpawnExtensionEnergyObservation(room: Room): EnergyObservation {
   }
 
   return { currentEnergy: 0, known: false };
-}
-
-function getRoomEnergyCapacityAvailable(room: Room): number | null {
-  const energyCapacityAvailable = (room as Partial<Room>).energyCapacityAvailable;
-  return typeof energyCapacityAvailable === 'number' && Number.isFinite(energyCapacityAvailable)
-    ? Math.max(0, energyCapacityAvailable)
-    : null;
 }
 
 function getRoomStorage(room: Room): StructureStorage | null {

--- a/prod/src/strategy/strategyRegistry.ts
+++ b/prod/src/strategy/strategyRegistry.ts
@@ -157,10 +157,10 @@ export const DEFAULT_STRATEGY_REGISTRY: StrategyRegistryEntry[] = [
     ],
     defaultValues: {
       baseScoreWeight: 1,
-      territorySignalWeight: 10,
-      resourceSignalWeight: 8,
+      territorySignalWeight: 22,
+      resourceSignalWeight: 3,
       killSignalWeight: 5,
-      riskPenalty: 5
+      riskPenalty: 4
     },
     rolloutStatus: 'shadow',
     evidenceLinks: [

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -30,11 +30,9 @@ import {
   type ConstructionSiteImpactPriorityContext
 } from '../construction/constructionPriority';
 import {
-  checkEnergyBufferForCapacityEnablingConstruction,
   checkEnergyBufferForSpending,
   getEffectiveRoomEnergyBufferThreshold,
   getStorageEnergyAvailableForWithdrawal,
-  hasMinimumWorkerSpawnEnergyForConstruction,
   STORAGE_EMERGENCY_RESERVE,
   withdrawFromStorage
 } from '../economy/energyBuffer';
@@ -2732,38 +2730,9 @@ function canSpendCreepEnergyOnConstructionSite(
   site: ConstructionSite,
   priorityContext: ConstructionSiteImpactPriorityContext
 ): boolean {
-  const carriedEnergy = getUsedEnergy(creep);
   return (
-    checkEnergyBufferForSpending(creep.room, carriedEnergy) ||
-    (carriedEnergy > 0 &&
-      isCapacityEnablingConstructionSite(site, priorityContext) &&
-      checkEnergyBufferForCapacityEnablingConstruction(creep.room, carriedEnergy)) ||
-    (carriedEnergy > 0 &&
-      hasMinimumWorkerSpawnEnergyForConstruction(creep.room) &&
-      isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext))
-  );
-}
-
-function isCapacityEnablingConstructionSite(
-  site: ConstructionSite,
-  priorityContext: ConstructionSiteImpactPriorityContext
-): boolean {
-  if (isExtensionConstructionSite(site)) {
-    return true;
-  }
-
-  const priority = getConstructionSiteImpactPriority(site, priorityContext);
-  if (isContainerConstructionSite(site)) {
-    return (
-      priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.sourceContainer ||
-      priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedSourceContainer
-    );
-  }
-
-  return (
-    isRoadConstructionSite(site) &&
-    (priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.criticalRoad ||
-      priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedCriticalRoad)
+    canSpendCreepEnergyOnConstruction(creep) ||
+    (getUsedEnergy(creep) > 0 && isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext))
   );
 }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -2760,7 +2760,11 @@ function isCapacityEnablingConstructionSite(
     );
   }
 
-  return false;
+  return (
+    isRoadConstructionSite(site) &&
+    (priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.criticalRoad ||
+      priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedCriticalRoad)
+  );
 }
 
 function isEnergyStarvationSourceLogisticsConstructionSite(

--- a/prod/test/energyBuffer.test.ts
+++ b/prod/test/energyBuffer.test.ts
@@ -58,10 +58,10 @@ describe('energyBuffer', () => {
     expect(checkEnergyBufferForCapacityEnablingConstruction(room, 50)).toBe(true);
   });
 
-  it('allows capacity-enabling construction when RCL4 room capacity equals the buffer threshold', () => {
+  it('keeps the normal buffer threshold once RCL4 room capacity reaches the buffer threshold', () => {
     const room = makeRoom({ level: 4, energyAvailable: 500, energyCapacityAvailable: 500 });
 
-    expect(checkEnergyBufferForCapacityEnablingConstruction(room, 50)).toBe(true);
+    expect(checkEnergyBufferForCapacityEnablingConstruction(room, 50)).toBe(false);
   });
 
   it('blocks the capacity-enabling construction carveout below worker spawn energy', () => {

--- a/prod/test/energyBuffer.test.ts
+++ b/prod/test/energyBuffer.test.ts
@@ -1,5 +1,4 @@
 import {
-  checkEnergyBufferForCapacityEnablingConstruction,
   checkEnergyBufferForSpending,
   getEffectiveRoomEnergyBufferThreshold,
   getRoomEnergyBufferHealth,
@@ -50,24 +49,6 @@ describe('energyBuffer', () => {
 
     expect(checkEnergyBufferForSpending(room, 60)).toBe(true);
     expect(checkEnergyBufferForSpending(room, 61)).toBe(false);
-  });
-
-  it('allows capacity-enabling construction while spawn-only RCL4 capacity is below the energy buffer threshold', () => {
-    const room = makeRoom({ level: 4, energyAvailable: 300, energyCapacityAvailable: 300 });
-
-    expect(checkEnergyBufferForCapacityEnablingConstruction(room, 50)).toBe(true);
-  });
-
-  it('keeps the normal buffer threshold once RCL4 room capacity reaches the buffer threshold', () => {
-    const room = makeRoom({ level: 4, energyAvailable: 500, energyCapacityAvailable: 500 });
-
-    expect(checkEnergyBufferForCapacityEnablingConstruction(room, 50)).toBe(false);
-  });
-
-  it('blocks the capacity-enabling construction carveout below worker spawn energy', () => {
-    const room = makeRoom({ level: 4, energyAvailable: 299, energyCapacityAvailable: 300 });
-
-    expect(checkEnergyBufferForCapacityEnablingConstruction(room, 50)).toBe(false);
   });
 
   it('gates routine storage withdrawals against the storage reserve', () => {
@@ -141,19 +122,16 @@ function recordSurvivalMode(mode: 'LOCAL_STABLE' | 'DEFENSE'): void {
 
 function makeRoom({
   energyAvailable = 0,
-  energyCapacityAvailable,
   level,
   storage
 }: {
   energyAvailable?: number;
-  energyCapacityAvailable?: number;
   level?: number;
   storage?: StructureStorage;
 }): Room {
   return {
     name: 'W1N1',
     energyAvailable,
-    ...(energyCapacityAvailable === undefined ? {} : { energyCapacityAvailable }),
     controller: { level, my: true } as StructureController,
     ...(storage ? { storage } : {}),
     find: jest.fn((type: number) => {

--- a/prod/test/strategyShadowEvaluator.test.ts
+++ b/prod/test/strategyShadowEvaluator.test.ts
@@ -35,7 +35,36 @@ describe('strategy shadow evaluator', () => {
     expect(report.kpi.reliability.passed).toBe(true);
 
     const constructionReport = report.modelReports.find((modelReport) => modelReport.family === 'construction-priority');
-    expect(constructionReport?.rankingDiffs).toEqual([]);
+    expect(constructionReport?.rankingDiffs).toHaveLength(1);
+    expect(constructionReport?.rankingDiffs[0]).toMatchObject({
+      artifactIndex: 0,
+      tick: 200,
+      roomName: 'E26S49',
+      context: 'construction-priority',
+      changedTop: true,
+      incumbentTop: {
+        label: 'build extension capacity',
+        rank: 1
+      },
+      candidateTop: {
+        label: 'build remote road/container logistics',
+        rank: 1
+      },
+      rankChanges: [
+        {
+          label: 'build extension capacity',
+          incumbentRank: 1,
+          candidateRank: 2,
+          delta: -1
+        },
+        {
+          label: 'build remote road/container logistics',
+          incumbentRank: 2,
+          candidateRank: 1,
+          delta: 1
+        }
+      ]
+    });
 
     const expansionReport = report.modelReports.find(
       (modelReport) => modelReport.family === 'expansion-remote-candidate'
@@ -53,39 +82,6 @@ describe('strategy shadow evaluator', () => {
         rank: 1
       }
     });
-  });
-
-  it('keeps extension scoring elevated without demoting source-container or road logistics', () => {
-    const report = evaluateStrategyShadowReplay({
-      artifacts: makeConstructionPriorityScoringFixture(),
-      config: {
-        enabled: true,
-        candidateStrategyIds: ['construction-priority.territory-shadow.v1']
-      }
-    }, { enabled: false });
-
-    const constructionReport = report.modelReports.find((modelReport) => modelReport.family === 'construction-priority');
-    expect(constructionReport?.rankingDiffs).toHaveLength(1);
-
-    const rankingDiff = constructionReport?.rankingDiffs[0];
-    expect(rankingDiff).toMatchObject({
-      artifactIndex: 0,
-      tick: 739_620,
-      roomName: 'E26S49',
-      context: 'construction-priority',
-      changedTop: false,
-      incumbentTop: {
-        label: 'finish extension site',
-        rank: 1
-      },
-      candidateTop: {
-        label: 'finish extension site',
-        rank: 1
-      }
-    });
-    expect(rankingDiff?.candidateTop?.score).toBeGreaterThan(rankingDiff?.incumbentTop?.score ?? 0);
-    expectRankNotRegressed(rankingDiff, 'build source containers');
-    expectRankNotRegressed(rankingDiff, 'build source/controller roads');
   });
 
   it('injects candidate variance that varies by seed', () => {
@@ -211,91 +207,4 @@ function calculatePerturbationMagnitude(seedCandidate: (typeof DEFAULT_STRATEGY_
     }
     return total + Math.abs(perturbedValue - defaultValue);
   }, 0);
-}
-
-function expectRankNotRegressed(
-  rankingDiff: NonNullable<ReturnType<typeof evaluateStrategyShadowReplay>['modelReports'][number]['rankingDiffs'][number]> | undefined,
-  label: string
-): void {
-  const rankChange = rankingDiff?.rankChanges.find((change) => change.label === label);
-  expect(rankChange?.delta ?? 0).toBeGreaterThanOrEqual(0);
-}
-
-function makeConstructionPriorityScoringFixture(): string {
-  return `#runtime-summary ${JSON.stringify({
-    type: 'runtime-summary',
-    tick: 739_620,
-    rooms: [
-      {
-        roomName: 'E26S49',
-        energyAvailable: 300,
-        energyCapacity: 300,
-        workerCount: 5,
-        controller: {
-          level: 4,
-          progress: 95_914,
-          progressTotal: 405_000
-        },
-        resources: {
-          storedEnergy: 300,
-          workerCarriedEnergy: 0,
-          sourceCount: 2
-        },
-        constructionPriority: {
-          candidates: [
-            constructionCandidate(
-              'finish extension site',
-              55,
-              'high',
-              ['raises spawn energy capacity', 'unlocks larger workers and faster RCL progress']
-            ),
-            constructionCandidate(
-              'build source containers',
-              25,
-              'low',
-              ['improves source harvest throughput', 'stabilizes energy resource capacity for workers']
-            ),
-            constructionCandidate(
-              'build source/controller roads',
-              20,
-              'low',
-              ['improves source harvest throughput', 'keeps worker energy route moving to controller']
-            ),
-            constructionCandidate('finish generic container site', 47, 'low', ['finishes queued local storage work']),
-            constructionCandidate(
-              'build remote road/container logistics',
-              1,
-              'medium',
-              ['opens remote territory route', 'supports reserve room economy', 'improves harvest throughput']
-            ),
-            constructionCandidate(
-              'build rampart defense',
-              8,
-              'medium',
-              ['protects controller territory', 'adds rampart defense survivability'],
-              ['decays without sustained repair budget']
-            )
-          ]
-        }
-      }
-    ]
-  })}`;
-}
-
-function constructionCandidate(
-  buildItem: string,
-  score: number,
-  urgency: string,
-  expectedKpiMovement: string[],
-  risk: string[] = []
-): Record<string, unknown> {
-  return {
-    buildItem,
-    room: 'E26S49',
-    score,
-    urgency,
-    preconditions: [],
-    expectedKpiMovement,
-    risk
-  };
 }

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -9962,7 +9962,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'extension-site1' });
   });
 
-  it('builds RCL4 extension construction when capacity equals the energy buffer threshold', () => {
+  it('keeps the normal RCL4 buffer threshold once extension capacity reaches 500', () => {
     const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
     const controller = {
       id: 'controller1',
@@ -9977,37 +9977,6 @@ describe('selectWorkerTask', () => {
         controller,
         energyAvailable: 500,
         energyCapacityAvailable: 500
-      })
-    } as unknown as Creep;
-
-    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'extension-site1' });
-  });
-
-  it('keeps critical road construction behind the buffer during capacity recovery', () => {
-    const roadSite = {
-      id: 'road-critical-site1',
-      structureType: 'road',
-      pos: makeRoomPosition(12, 10)
-    } as ConstructionSite;
-    const fullSpawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 0, {
-      pos: makeRoomPosition(10, 10)
-    });
-    const source = makeSource('source1', 20, 10);
-    const controller = {
-      id: 'controller1',
-      my: true,
-      level: 4,
-      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
-    } as StructureController;
-    const creep = {
-      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
-      room: makeWorkerTaskRoom({
-        constructionSites: [roadSite],
-        controller,
-        energyAvailable: 300,
-        energyCapacityAvailable: 300,
-        myStructures: [fullSpawn as AnyOwnedStructure],
-        sources: [source]
       })
     } as unknown as Creep;
 

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -9932,103 +9932,13 @@ describe('selectWorkerTask', () => {
       room: makeWorkerTaskRoom({
         constructionSites: [extensionSite, sourceContainerSite],
         controller,
-        energyAvailable: 350,
-        energyCapacityAvailable: 800,
-        sources: [source]
-      })
-    } as unknown as Creep;
-
-    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'source-container-site1' });
-  });
-
-  it('builds RCL4 spawn-only extension construction when capacity is below the energy buffer threshold', () => {
-    const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
-    const controller = {
-      id: 'controller1',
-      my: true,
-      level: 4,
-      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
-    } as StructureController;
-    const creep = {
-      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
-      room: makeWorkerTaskRoom({
-        constructionSites: [site],
-        controller,
-        energyAvailable: 300,
-        energyCapacityAvailable: 300
-      })
-    } as unknown as Creep;
-
-    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'extension-site1' });
-  });
-
-  it('keeps the normal RCL4 buffer threshold once extension capacity reaches 500', () => {
-    const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
-    const controller = {
-      id: 'controller1',
-      my: true,
-      level: 4,
-      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
-    } as StructureController;
-    const creep = {
-      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
-      room: makeWorkerTaskRoom({
-        constructionSites: [site],
-        controller,
-        energyAvailable: 500,
-        energyCapacityAvailable: 500
-      })
-    } as unknown as Creep;
-
-    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
-  });
-
-  it('builds RCL3 spawn-only source container construction when capacity is below the energy buffer threshold', () => {
-    const source = makeSource('source1', 20, 10);
-    const site = {
-      id: 'source-container-site1',
-      structureType: 'container',
-      pos: makeRoomPosition(19, 10)
-    } as ConstructionSite;
-    const controller = {
-      id: 'controller1',
-      my: true,
-      level: 3,
-      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
-    } as StructureController;
-    const creep = {
-      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
-      room: makeWorkerTaskRoom({
-        constructionSites: [site],
-        controller,
-        energyAvailable: 300,
+        energyAvailable: 120,
         energyCapacityAvailable: 300,
         sources: [source]
       })
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'source-container-site1' });
-  });
-
-  it('blocks capacity-enabling construction below worker spawn energy', () => {
-    const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
-    const controller = {
-      id: 'controller1',
-      my: true,
-      level: 4,
-      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
-    } as StructureController;
-    const creep = {
-      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
-      room: makeWorkerTaskRoom({
-        constructionSites: [site],
-        controller,
-        energyAvailable: 299,
-        energyCapacityAvailable: 300
-      })
-    } as unknown as Creep;
-
-    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
   it('gates construction spending when the room energy buffer would be breached', () => {


### PR DESCRIPTION
## Emergency Rollback

The bot at commit 78767e5 entered a worker-idle state with harvest=0, upgrade=0, build=5. All 5 workers idleTicks=20 at tick 754040. Room storedEnergy dropped from 300→0 by tick 755061. Room is on trajectory toward room_dead.

### Reverted commits
- 78767e5: fix(rl): adjust construction-priority shadow scoring weights (#884)
- a603d2d: fix(economy): address review — remove roads from capacity-enabling set (#882)
- 84507b0: fix(economy): allow construction spending on capacity-enabling structures (#877)

### Rationale
These three commits together appear to have caused a deadlock where all workers are assigned build tasks with no harvester allocation when the energy buffer threshold (500) exceeds room capacity (300) and pending construction exists. The revert restores the pre-#877 task assignment behavior, which had harvest=2, upgrade=3 at tick 739620.

### Post-deploy
- Monitor worker taskCounts for ≥ 30 minutes
- Verify harvest ≥ 1, upgrade ≥ 1, energy > 0
- If room_dead occurs before deploy takes effect, trigger autonomous recovery

### Related
- Closes: New P0 emergency issue (to be created)
- Game Evaluation Review: 2026-05-10 08:15 CST classified CLOSED_LOOP_FAILED
