### PR TITLE
fix(rl): repair E2 simulator harness replay data formatting and test coverage (#879)

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -80,6 +80,61 @@ RUN_TICK_POLL_SECONDS = 0.20
 RUN_WORKER_PREFIX = "rl-sim-worker"
 RUN_ID_PREFIX = "rl-sim-run"
 RUN_ID_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+SIMULATOR_REPAIR_MOD_FILENAME = "rl-simulator-harness-repair.js"
+HARNESS_EXCLUDED_DIRECTORY_NAMES = ("node_modules", ".git", "__pycache__")
+HARNESS_BINARY_FILE_EXTENSIONS = (
+    ".bmp",
+    ".gif",
+    ".gz",
+    ".ico",
+    ".jpeg",
+    ".jpg",
+    ".png",
+    ".sqlite",
+    ".sqlite3",
+    ".zip",
+)
+SIMULATOR_REPAIR_MOD_SOURCE = """\
+const bodyParser = require('body-parser');
+const zlib = require('zlib');
+
+const plainTerrain = '0'.repeat(2500);
+
+function buildFallbackTerrainData(accessibleRoomsJson) {
+  let rooms = [];
+  try {
+    const parsed = JSON.parse(accessibleRoomsJson || '[]');
+    if (Array.isArray(parsed)) {
+      rooms = parsed.filter(room => typeof room === 'string');
+    }
+  } catch (err) {
+    rooms = [];
+  }
+  const payload = rooms.map(room => ({ room, terrain: plainTerrain }));
+  return zlib.deflateSync(Buffer.from(JSON.stringify(payload))).toString('base64');
+}
+
+module.exports = config => {
+  const env = config.common && config.common.storage && config.common.storage.env;
+  if (env && env.keys && typeof env.get === 'function') {
+    const originalGet = env.get.bind(env);
+    env.get = key => Promise.resolve(originalGet(key)).then(value => {
+      if ((value === null || value === undefined) && key === env.keys.TERRAIN_DATA) {
+        return Promise.resolve(originalGet(env.keys.ACCESSIBLE_ROOMS))
+          .then(buildFallbackTerrainData)
+          .catch(() => buildFallbackTerrainData('[]'));
+      }
+      return value;
+    });
+  }
+
+  if (config.backend) {
+    config.backend.on('expressPreConfig', app => {
+      app.use('/api/user/code', bodyParser.json({ limit: '8mb' }));
+    });
+  }
+};
+"""
 
 JsonObject = dict[str, Any]
 _smoke_module = None
@@ -652,6 +707,13 @@ def _require_launcher_cli_success(smoke: Any, compose: list[str], cfg: Any, expr
     raise RuntimeError(f"{phase} failed: launcher CLI result did not include success status")
 
 
+def _install_simulator_repair_mod(smoke: Any, cfg: Any) -> Path:
+    """Install local launcher compatibility fixes into this worker's generated mod dir."""
+    mod_path = cfg.work_dir / "mods" / SIMULATOR_REPAIR_MOD_FILENAME
+    smoke.write_generated_text(cfg.work_dir, mod_path, SIMULATOR_REPAIR_MOD_SOURCE)
+    return mod_path
+
+
 def _terrain_payload_has_data(payload: Any) -> bool:
     summary = _terrain_summary(payload)
     return bool(summary.get("bytes"))
@@ -1069,6 +1131,7 @@ def _run_variant(
     token: str | None = None
     variant_ticks: list[JsonObject] = []
     terrain_ready: JsonObject | None = None
+    repair_mod_path: Path | None = None
     compose = None
     try:
         for error in smoke.required_env_errors(cfg):
@@ -1083,6 +1146,7 @@ def _run_variant(
             raise RuntimeError("port preflight returned empty checks")
         compose = smoke.find_compose_command()
         smoke.prepare_work_dir(cfg)
+        repair_mod_path = _install_simulator_repair_mod(smoke, cfg)
         smoke.prepare_map(cfg)
 
         # Reset server-owned state by removing any leftover stack and volumes first.
@@ -1138,7 +1202,10 @@ def _run_variant(
         )
         token = smoke.update_token_from_headers(token, upload.headers)
         if not smoke.upload_code_succeeded(upload):
-            raise RuntimeError("code upload failed")
+            raise RuntimeError(
+                "code upload failed: "
+                f"{_safe_redact_smoke_payload({'status': upload.status, 'payload': upload.payload})}"
+            )
 
         place = smoke.http_json(
             "POST",
@@ -1218,6 +1285,7 @@ def _run_variant(
         "branch": api_branch,
         "requestedBranch": branch,
         "terrainReady": terrain_ready,
+        "launcherRepairMod": str(repair_mod_path) if repair_mod_path is not None else None,
     }
 
 
@@ -1395,6 +1463,8 @@ def build_harness_manifest(
         paths,
         max_file_bytes=max_file_bytes,
         excluded_roots=[resolved_out_dir],
+        excluded_directory_names=HARNESS_EXCLUDED_DIRECTORY_NAMES,
+        binary_file_extensions=HARNESS_BINARY_FILE_EXTENSIONS,
     )
     metadata = collect_local_metadata(scan)
     throughput = build_throughput_evidence(

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -249,6 +249,28 @@ class RlSimulatorHarnessTest(unittest.TestCase):
         self.assertTrue(manifest["throughput"]["aggregate"]["targetMet"])
         self.assertEqual(manifest["workers"]["plannedParallelRoomCount"], 10)
 
+    def test_harness_manifest_scan_excludes_generated_dependency_trees(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            out_dir = root / "out"
+            empty_scan = harness.dataset_export.ScanResult(input_paths=[])
+
+            with mock.patch(
+                "screeps_rl_simulator_harness.dataset_export.collect_artifact_records",
+                return_value=empty_scan,
+            ) as collect:
+                harness.build_harness_manifest(
+                    [],
+                    out_dir,
+                    manifest_id="scan-excludes-test",
+                    bot_commit="a" * 40,
+                )
+
+        kwargs = collect.call_args.kwargs
+        self.assertIn("node_modules", kwargs["excluded_directory_names"])
+        self.assertIn(".git", kwargs["excluded_directory_names"])
+        self.assertIn(".png", kwargs["binary_file_extensions"])
+
     def test_cli_dry_run_and_self_test_are_offline_and_secret_free(self) -> None:
         secret = "dryrunsecret123456"
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -502,6 +524,22 @@ class RlSimulatorHarnessTest(unittest.TestCase):
                 "resume simulator",
             )
 
+    def test_install_simulator_repair_mod_writes_launcher_compatibility_mod(self) -> None:
+        writes: list[tuple[Path, str]] = []
+
+        class FakeSmoke:
+            def write_generated_text(self, work_dir: Path, path: Path, text: str) -> None:
+                writes.append((path.relative_to(work_dir), text))
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cfg = argparse.Namespace(work_dir=Path(temp_dir))
+            mod_path = harness._install_simulator_repair_mod(FakeSmoke(), cfg)
+
+        self.assertEqual(mod_path.name, harness.SIMULATOR_REPAIR_MOD_FILENAME)
+        self.assertEqual(writes[0][0], Path("mods") / harness.SIMULATOR_REPAIR_MOD_FILENAME)
+        self.assertIn("env.keys.TERRAIN_DATA", writes[0][1])
+        self.assertIn("bodyParser.json({ limit: '8mb' })", writes[0][1])
+
     def test_run_id_rejects_dots_even_without_path_separators(self) -> None:
         with self.assertRaisesRegex(argparse.ArgumentTypeError, "letters, numbers"):
             harness.parse_run_id_token("run.1")
@@ -634,6 +672,82 @@ class RlSimulatorHarnessTest(unittest.TestCase):
         self.assertEqual(captured_branches, ["$activeWorld"])
         self.assertFalse(result["ok"])
         self.assertEqual(result["error"], "stop before side effects")
+        self.assertIsNone(result["launcherRepairMod"])
+
+    def test_run_variant_installs_repair_mod_before_compose_start(self) -> None:
+        events: list[str] = []
+        run_command_calls = 0
+
+        class FakeSmokeConfig:
+            def __init__(self, **kwargs: object) -> None:
+                for key, value in kwargs.items():
+                    setattr(self, key, value)
+
+        class FakeSmoke:
+            SmokeConfig = FakeSmokeConfig
+
+            def required_env_errors(self, cfg: FakeSmokeConfig) -> list[str]:
+                return []
+
+            def assert_safe_work_dir(self, work_dir: Path) -> None:
+                return None
+
+            def preflight_host_ports(self, cfg: FakeSmokeConfig) -> dict[str, object]:
+                return {"checks": [{"available": True}]}
+
+            def find_compose_command(self) -> list[str]:
+                return ["compose"]
+
+            def prepare_work_dir(self, cfg: FakeSmokeConfig) -> None:
+                events.append("prepare_work_dir")
+
+            def write_generated_text(self, work_dir: Path, path: Path, text: str) -> None:
+                events.append(f"write_mod:{path.name}")
+
+            def prepare_map(self, cfg: FakeSmokeConfig) -> None:
+                events.append("prepare_map")
+
+            def run_command(self, command: list[str], cfg: FakeSmokeConfig, timeout: int) -> dict[str, object]:
+                nonlocal run_command_calls
+                run_command_calls += 1
+                events.append(f"run_command:{command[-2:]}")
+                if run_command_calls == 1:
+                    raise RuntimeError("stop after mod install")
+                return {"returncode": 0}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            code_path = root / "main.js"
+            map_path = root / "map.json"
+            code_path.write_text("module.exports.loop = function() {};", encoding="utf-8")
+            map_path.write_text("{\"ok\": true}", encoding="utf-8")
+
+            with mock.patch("screeps_rl_simulator_harness._load_private_smoke_module", return_value=FakeSmoke()):
+                result = harness._run_variant(
+                    0,
+                    "baseline",
+                    run_id="mod-install",
+                    ticks=1,
+                    room="E26S49",
+                    shard="shardX",
+                    branch="activeWorld",
+                    code_path=code_path,
+                    map_source_file=map_path,
+                    out_dir=root / "out",
+                )
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["error"], "stop after mod install")
+        self.assertEqual(
+            events[:4],
+            [
+                "prepare_work_dir",
+                f"write_mod:{harness.SIMULATOR_REPAIR_MOD_FILENAME}",
+                "prepare_map",
+                "run_command:['down', '-v']",
+            ],
+        )
+        self.assertTrue(str(result["launcherRepairMod"]).endswith(harness.SIMULATOR_REPAIR_MOD_FILENAME))
 
     def test_run_variants_passes_worker_index_and_records_elapsed_wall_clock(self) -> None:
         calls: list[tuple[int, str]] = []


### PR DESCRIPTION
Repairs E2 RL simulator harness for replay data formatting and test coverage.

### Changes
- **Launcher compatibility mod**: Installs a repair module that handles missing TERRAIN_DATA in private-server environments and adjusts body parser limits for large code uploads
- **Harness manifest scanning**: Excludes generated dependency trees (`node_modules`, `.git`, `__pycache__`) and binary files (`.png`, `.sqlite`, etc.) during artifact collection
- **Better error messages**: Code upload failures now include sanitized status/payload for debugging
- **Test coverage**: New tests for repair mod installation ordering, manifest scan exclusions, and variant-level mod-path recording

### Verification
- Python syntax check: PASS
- New tests cover mod installation order, scan exclusions, and variant-level fix

Refs #879, #893
