### PR TITLE
fix(rl): update E2 simulator harness — bot commit to de2bdfa, fix ACCESSIBLE_ROOMS null handling, fix unknown commit fallback

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -66,7 +66,7 @@ DEFAULT_SIM_SHARD = "shardX"
 DEFAULT_SPAWN_X = 20
 DEFAULT_SPAWN_Y = 20
 DEFAULT_ACTIVE_WORLD_BRANCH = "$activeWorld"
-DEFAULT_BOT_COMMIT = "a9c12ed60e2c32370977fc1b10ea8e7e5265cd8c"
+DEFAULT_BOT_COMMIT = "de2bdfa31cabb2996e73ffe30051a3b375bf5b94"
 HARNESS_VERSION = "1.0.0"
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_CODE_PATH = REPO_ROOT / "prod" / "dist" / "main.js"
@@ -119,6 +119,9 @@ module.exports = config => {
   if (env && env.keys && typeof env.get === 'function') {
     const originalGet = env.get.bind(env);
     env.get = key => Promise.resolve(originalGet(key)).then(value => {
+      if ((value === null || value === undefined) && key === env.keys.ACCESSIBLE_ROOMS) {
+        return '[]';
+      }
       if ((value === null || value === undefined) && key === env.keys.TERRAIN_DATA) {
         return Promise.resolve(originalGet(env.keys.ACCESSIBLE_ROOMS))
           .then(buildFallbackTerrainData)
@@ -144,7 +147,8 @@ def resolve_bot_commit(bot_commit: str | None = None, repo_root: Path | None = N
     if bot_commit:
         return bot_commit
     repo = repo_root or REPO_ROOT
-    return dataset_export.git_commit(repo) or DEFAULT_BOT_COMMIT
+    detected = dataset_export.git_commit(repo)
+    return detected if detected and detected != "unknown" else DEFAULT_BOT_COMMIT
 
 
 DEFAULT_STRATEGY_VARIANT_CONFIGS: tuple[JsonObject, ...] = (

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -382,6 +382,10 @@ class RlSimulatorHarnessTest(unittest.TestCase):
         self.assertEqual(harness.normalize_private_server_code_branch("activeSim"), "$activeSim")
         self.assertEqual(harness.normalize_private_server_code_branch("default"), "default")
 
+    def test_resolve_bot_commit_falls_back_when_git_detection_is_unknown(self) -> None:
+        with mock.patch("screeps_rl_simulator_harness.dataset_export.git_commit", return_value="unknown"):
+            self.assertEqual(harness.resolve_bot_commit(), harness.DEFAULT_BOT_COMMIT)
+
     def test_build_scenario_config_is_stable_and_records_inputs(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -538,6 +542,8 @@ class RlSimulatorHarnessTest(unittest.TestCase):
         self.assertEqual(mod_path.name, harness.SIMULATOR_REPAIR_MOD_FILENAME)
         self.assertEqual(writes[0][0], Path("mods") / harness.SIMULATOR_REPAIR_MOD_FILENAME)
         self.assertIn("env.keys.TERRAIN_DATA", writes[0][1])
+        self.assertIn("env.keys.ACCESSIBLE_ROOMS", writes[0][1])
+        self.assertIn("return '[]';", writes[0][1])
         self.assertIn("bodyParser.json({ limit: '8mb' })", writes[0][1])
 
     def test_run_id_rejects_dots_even_without_path_separators(self) -> None:


### PR DESCRIPTION
## Summary
E2 simulator harness repair:
- Updated DEFAULT_BOT_COMMIT to current `main` HEAD (`de2bdfa`)
- Fixed `ACCESSIBLE_ROOMS` null/undefined handling in private-server env fallback
- Fixed `resolve_bot_commit` to not return `"unknown"` when git commit detection fails

## Changes
- `scripts/screeps_rl_simulator_harness.py`: bot commit update + env key fallback fix + commit resolution fix
- `scripts/test_screeps_rl_simulator_harness.py`: test additions

## Verification
```
python3 -m py_compile scripts/screeps_rl_simulator_harness.py  # OK
python3 -m py_compile scripts/test_screeps_rl_simulator_harness.py  # OK
git diff --check  # clean
```

Refs #879
