### PR TITLE
feat(construction): exempt capacity-enabling extension construction from energy buffer gate

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -10022,7 +10022,11 @@ function getRemainingEnergySlots(room, budgetState, priority, options) {
     return budgetSlots;
   }
   let energyBufferSlots = 0;
-  while (energyBufferSlots < budgetSlots && checkEnergyBufferForSpending(room, budgetState.energyReserved + reservation * (energyBufferSlots + 1))) {
+  while (energyBufferSlots < budgetSlots && checkEnergyBufferForConstructionPriority(
+    room,
+    priority,
+    budgetState.energyReserved + reservation * (energyBufferSlots + 1)
+  )) {
     energyBufferSlots += 1;
   }
   return energyBufferSlots;
@@ -10039,6 +10043,12 @@ function shouldBypassEnergyBufferForSourceLogisticsConstruction(room, priority) 
     getRoomEnergyAvailableFromRoom(room),
     getRoomEnergyCapacityAvailableFromRoom(room)
   );
+}
+function checkEnergyBufferForConstructionPriority(room, priority, amount) {
+  if (priority === "extension" && hasRemainingStructureCapacity(room, "extension")) {
+    return checkEnergyBufferForCapacityEnablingConstruction(room, amount);
+  }
+  return checkEnergyBufferForSpending(room, amount);
 }
 function resolveEnergyBudgetRatio(value) {
   if (typeof value !== "number" || !Number.isFinite(value)) {

--- a/prod/src/construction/planner.ts
+++ b/prod/src/construction/planner.ts
@@ -1,5 +1,8 @@
 import { getOwnedColonies, type ColonySnapshot } from '../colony/colonyRegistry';
-import { checkEnergyBufferForSpending } from '../economy/energyBuffer';
+import {
+  checkEnergyBufferForCapacityEnablingConstruction,
+  checkEnergyBufferForSpending
+} from '../economy/energyBuffer';
 import { planExpansionDefenseBarrierPlacements } from '../territory/expansionPlanner';
 import { planSourceContainerConstruction, planStorageConstruction, planTowerConstruction } from './constructionPriority';
 import { planExtensionConstruction } from './extensionPlanner';
@@ -695,7 +698,11 @@ function getRemainingEnergySlots(
   let energyBufferSlots = 0;
   while (
     energyBufferSlots < budgetSlots &&
-    checkEnergyBufferForSpending(room, budgetState.energyReserved + reservation * (energyBufferSlots + 1))
+    checkEnergyBufferForConstructionPriority(
+      room,
+      priority,
+      budgetState.energyReserved + reservation * (energyBufferSlots + 1)
+    )
   ) {
     energyBufferSlots += 1;
   }
@@ -726,6 +733,18 @@ function shouldBypassEnergyBufferForSourceLogisticsConstruction(
       getRoomEnergyCapacityAvailableFromRoom(room)
     )
   );
+}
+
+function checkEnergyBufferForConstructionPriority(
+  room: Room,
+  priority: ConstructionPlannerPriority,
+  amount: number
+): boolean {
+  if (priority === 'extension' && hasRemainingStructureCapacity(room, 'extension')) {
+    return checkEnergyBufferForCapacityEnablingConstruction(room, amount);
+  }
+
+  return checkEnergyBufferForSpending(room, amount);
 }
 
 function resolveEnergyBudgetRatio(value: number | undefined): number {

--- a/prod/test/constructionPlanner.test.ts
+++ b/prod/test/constructionPlanner.test.ts
@@ -1,4 +1,9 @@
 import type { ColonySnapshot } from '../src/colony/colonyRegistry';
+import {
+  assessColonySurvival,
+  clearColonySurvivalAssessmentCache,
+  recordColonySurvivalAssessment
+} from '../src/colony/survivalMode';
 import { planConstructionForColony } from '../src/construction/planner';
 import { planExpansionDefenseBarrierPlacements } from '../src/territory/expansionPlanner';
 
@@ -38,10 +43,12 @@ describe('owned room construction planner', () => {
       globals[key] = value;
     }
     mockPlanExpansionDefenseBarrierPlacements.mockReset();
+    clearColonySurvivalAssessmentCache();
     globals.CONTROLLER_STRUCTURES = makeControllerStructures();
   });
 
   afterEach(() => {
+    clearColonySurvivalAssessmentCache();
     const globals = globalThis as Record<string, unknown>;
     for (const key of Object.keys(TEST_GLOBALS)) {
       delete globals[key];
@@ -193,6 +200,47 @@ describe('owned room construction planner', () => {
 
     expect(result.placements.map((placement) => placement.priority)).toEqual(['road']);
     expect(room.createConstructionSite).toHaveBeenCalledWith(11, 10, STRUCTURE_ROAD);
+  });
+
+  it('places capacity-enabling extensions while room capacity is below the survival buffer threshold', () => {
+    installOpenTerrain();
+    recordBootstrapSurvivalMode();
+    const { room, colony } = makeColony({
+      controllerLevel: 4,
+      energyAvailable: 300,
+      energyCapacityAvailable: 350,
+      structures: [makeStructure('extension-existing', TEST_GLOBALS.STRUCTURE_EXTENSION, 30, 30)],
+      sources: [],
+      pathsByTarget: {}
+    });
+
+    const result = planConstructionForColony(colony, { respectRoomEnergyBuffer: true });
+
+    expect(result.placements.map((placement) => placement.priority)).toEqual(['extension']);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite.mock.calls[0][2]).toBe(STRUCTURE_EXTENSION);
+  });
+
+  it('keeps non-capacity construction gated while room capacity is below the survival buffer threshold', () => {
+    installOpenTerrain();
+    recordBootstrapSurvivalMode();
+    const { room, colony } = makeColony({
+      controllerLevel: 4,
+      energyAvailable: 300,
+      energyCapacityAvailable: 350,
+      structures: [
+        ...Array.from({ length: 20 }, (_, index) =>
+          makeStructure(`extension-${index}`, TEST_GLOBALS.STRUCTURE_EXTENSION, 20 + index, 30)
+        )
+      ],
+      sources: [],
+      pathsByTarget: {}
+    });
+
+    const result = planConstructionForColony(colony, { respectRoomEnergyBuffer: true });
+
+    expect(result.placements).toEqual([]);
+    expect(room.createConstructionSite).not.toHaveBeenCalled();
   });
 
   it('respects CONTROLLER_STRUCTURES counts before calling lower-level planners', () => {
@@ -434,12 +482,26 @@ function makeColony(options: MakeColonyOptions): { room: MockRoom; colony: Colon
 
 function installOpenTerrain(): void {
   (globalThis as unknown as { Game: Partial<Game> }).Game = {
+    time: 100,
     map: {
       getRoomTerrain: jest.fn().mockReturnValue({
         get: jest.fn().mockReturnValue(0)
       })
     } as unknown as GameMap
   };
+}
+
+function recordBootstrapSurvivalMode(): void {
+  const assessment = assessColonySurvival({
+    roomName: 'W1N1',
+    workerCapacity: 2,
+    workerTarget: 4,
+    energyAvailable: 300,
+    energyCapacityAvailable: 350,
+    controller: { my: true, level: 4, ticksToDowngrade: 10_000 }
+  });
+  expect(assessment.mode).toBe('BOOTSTRAP');
+  recordColonySurvivalAssessment('W1N1', assessment, 100);
 }
 
 function makeControllerStructures(): Record<string, number[]> {


### PR DESCRIPTION
## Summary
Exempt capacity-enabling extension construction from the energy buffer gate so the bot can build extensions even when energy buffer threshold exceeds current capacity.

## Problem
At RCL 4 with energyCapacity=300, the energy buffer threshold (500) permanently blocks all construction spending. Extensions cannot be built, keeping capacity stuck at 300. This deadlocks the entire progression chain: extensions → spawn capacity → claimer bodies → territory expansion.

## Fix
Added `checkEnergyBufferForConstructionPriority()` that routes extension-grade construction through `checkEnergyBufferForCapacityEnablingConstruction()` instead of the general `checkEnergyBufferForSpending()`. This mirrors the existing container/road exemption pattern but targets extension construction specifically.

## Verification
- `npm run typecheck`: ✅ passes
- `npm test -- --runInBand`: ✅ 94 suites, 1706 tests pass
- `npm run build`: ✅ succeeds
- Controller-side full suite verification confirmed

Refs #885
