### PR TITLE
fix(economy): cap energy buffer threshold at room energyCapacity to prevent deadlock

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2697,11 +2697,19 @@ var CAPACITY_ENABLING_CONSTRUCTION_HEALTHY_ENERGY_CAPACITY = 550;
 var CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY = 300;
 var MINIMUM_WORKER_SPAWN_ENERGY = 200;
 function getRoomEnergyBufferThreshold(room) {
-  return ENERGY_BUFFER_THRESHOLDS_BY_RCL[getRoomRcl(room)];
+  const desiredThreshold = getConfiguredRoomEnergyBufferThreshold(room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable2(room);
+  if (energyCapacityAvailable === null) {
+    return desiredThreshold;
+  }
+  return Math.min(desiredThreshold, energyCapacityAvailable);
 }
 function getEffectiveRoomEnergyBufferThreshold(room) {
   const threshold = getRoomEnergyBufferThreshold(room);
   return isSurvivalBufferMode(room) ? Math.ceil(threshold * SURVIVAL_ENERGY_BUFFER_MULTIPLIER) : threshold;
+}
+function getStorageEnergyReserveThreshold(room) {
+  return Math.min(getEffectiveConfiguredRoomEnergyBufferThreshold(room), STORAGE_EMERGENCY_RESERVE);
 }
 function checkEnergyBufferForSpending(room, amount) {
   const observation = getRoomSpawnExtensionEnergyObservation(room);
@@ -2767,13 +2775,20 @@ function getRoomRcl(room) {
   }
   return Math.min(8, Math.max(1, Math.floor(level)));
 }
+function getConfiguredRoomEnergyBufferThreshold(room) {
+  return ENERGY_BUFFER_THRESHOLDS_BY_RCL[getRoomRcl(room)];
+}
+function getEffectiveConfiguredRoomEnergyBufferThreshold(room) {
+  const threshold = getConfiguredRoomEnergyBufferThreshold(room);
+  return isSurvivalBufferMode(room) ? Math.ceil(threshold * SURVIVAL_ENERGY_BUFFER_MULTIPLIER) : threshold;
+}
 function isSurvivalBufferMode(room) {
   var _a;
   const mode = (_a = getRecordedColonySurvivalAssessment(getRoomName3(room))) == null ? void 0 : _a.mode;
   return mode === "BOOTSTRAP" || mode === "DEFENSE";
 }
 function getStorageEnergyReserve(room) {
-  return Math.min(getEffectiveRoomEnergyBufferThreshold(room), STORAGE_EMERGENCY_RESERVE);
+  return getStorageEnergyReserveThreshold(room);
 }
 function canWithdrawBelowStorageReserve(room, options) {
   return options.allowBelowReserve === true || isRoomEnergyCriticalForStorageWithdrawal(room);
@@ -26044,7 +26059,7 @@ function isRoomStorageEnergyCriticalNow(room) {
   if (!storage || !matchesStructureType18(storage.structureType, "STRUCTURE_STORAGE", "storage")) {
     return false;
   }
-  const enterThreshold = Math.min(getEffectiveRoomEnergyBufferThreshold(room), STORAGE_EMERGENCY_RESERVE);
+  const enterThreshold = getStorageEnergyReserveThreshold(room);
   return enterThreshold > 0 && getStoredEnergy14(storage) < enterThreshold;
 }
 function getHarvestSourceAvailableEnergy(source) {
@@ -26286,7 +26301,7 @@ function getStorageEnterThreshold(room, storage) {
   if (!storage) {
     return 0;
   }
-  return Math.min(getEffectiveRoomEnergyBufferThreshold(room), STORAGE_EMERGENCY_RESERVE);
+  return getStorageEnergyReserveThreshold(room);
 }
 function getRoomStorage3(room) {
   const storage = room.storage;

--- a/prod/src/creeps/workerTaskPolicy.ts
+++ b/prod/src/creeps/workerTaskPolicy.ts
@@ -1,7 +1,4 @@
-import {
-  getEffectiveRoomEnergyBufferThreshold,
-  STORAGE_EMERGENCY_RESERVE
-} from '../economy/energyBuffer';
+import { getStorageEnergyReserveThreshold } from '../economy/energyBuffer';
 import {
   CONTROLLER_DOWNGRADE_GUARD_TICKS,
   CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD,
@@ -292,7 +289,7 @@ function getStorageEnterThreshold(room: Room, storage: StructureStorage | null):
     return 0;
   }
 
-  return Math.min(getEffectiveRoomEnergyBufferThreshold(room), STORAGE_EMERGENCY_RESERVE);
+  return getStorageEnergyReserveThreshold(room);
 }
 
 function getRoomStorage(room: Room): StructureStorage | null {

--- a/prod/src/economy/energyBuffer.ts
+++ b/prod/src/economy/energyBuffer.ts
@@ -38,12 +38,22 @@ interface EnergyObservation {
 }
 
 export function getRoomEnergyBufferThreshold(room: Room): number {
-  return ENERGY_BUFFER_THRESHOLDS_BY_RCL[getRoomRcl(room)];
+  const desiredThreshold = getConfiguredRoomEnergyBufferThreshold(room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(room);
+  if (energyCapacityAvailable === null) {
+    return desiredThreshold;
+  }
+
+  return Math.min(desiredThreshold, energyCapacityAvailable);
 }
 
 export function getEffectiveRoomEnergyBufferThreshold(room: Room): number {
   const threshold = getRoomEnergyBufferThreshold(room);
   return isSurvivalBufferMode(room) ? Math.ceil(threshold * SURVIVAL_ENERGY_BUFFER_MULTIPLIER) : threshold;
+}
+
+export function getStorageEnergyReserveThreshold(room: Room): number {
+  return Math.min(getEffectiveConfiguredRoomEnergyBufferThreshold(room), STORAGE_EMERGENCY_RESERVE);
 }
 
 export function checkEnergyBufferForSpending(room: Room, amount: number): boolean {
@@ -140,13 +150,22 @@ function getRoomRcl(room: Room): 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 {
   return Math.min(8, Math.max(1, Math.floor(level))) as 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 }
 
+function getConfiguredRoomEnergyBufferThreshold(room: Room): number {
+  return ENERGY_BUFFER_THRESHOLDS_BY_RCL[getRoomRcl(room)];
+}
+
+function getEffectiveConfiguredRoomEnergyBufferThreshold(room: Room): number {
+  const threshold = getConfiguredRoomEnergyBufferThreshold(room);
+  return isSurvivalBufferMode(room) ? Math.ceil(threshold * SURVIVAL_ENERGY_BUFFER_MULTIPLIER) : threshold;
+}
+
 function isSurvivalBufferMode(room: Room): boolean {
   const mode = getRecordedColonySurvivalAssessment(getRoomName(room))?.mode;
   return mode === 'BOOTSTRAP' || mode === 'DEFENSE';
 }
 
 function getStorageEnergyReserve(room: Room): number {
-  return Math.min(getEffectiveRoomEnergyBufferThreshold(room), STORAGE_EMERGENCY_RESERVE);
+  return getStorageEnergyReserveThreshold(room);
 }
 
 function canWithdrawBelowStorageReserve(room: Room, options: StorageWithdrawalOptions): boolean {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -34,8 +34,8 @@ import {
   checkEnergyBufferForSpending,
   getEffectiveRoomEnergyBufferThreshold,
   getStorageEnergyAvailableForWithdrawal,
+  getStorageEnergyReserveThreshold,
   hasMinimumWorkerSpawnEnergyForConstruction,
-  STORAGE_EMERGENCY_RESERVE,
   withdrawFromStorage
 } from '../economy/energyBuffer';
 import {
@@ -7260,7 +7260,7 @@ function isRoomStorageEnergyCriticalNow(room: Room): boolean {
     return false;
   }
 
-  const enterThreshold = Math.min(getEffectiveRoomEnergyBufferThreshold(room), STORAGE_EMERGENCY_RESERVE);
+  const enterThreshold = getStorageEnergyReserveThreshold(room);
   return enterThreshold > 0 && getStoredEnergy(storage) < enterThreshold;
 }
 

--- a/prod/test/energyBuffer.test.ts
+++ b/prod/test/energyBuffer.test.ts
@@ -6,6 +6,7 @@ import {
   getRoomEnergyBufferHealth,
   getRoomEnergyBufferThreshold,
   getStorageEnergyAvailableForWithdrawal,
+  getStorageEnergyReserveThreshold,
   STORAGE_EMERGENCY_RESERVE,
   withdrawFromStorage
 } from '../src/economy/energyBuffer';
@@ -42,8 +43,72 @@ describe('energyBuffer', () => {
     [6, 800],
     [7, 1_000],
     [8, 1_000]
-  ])('returns the configured RCL %i buffer threshold', (level, threshold) => {
+  ])('returns the configured RCL %i buffer threshold when room capacity is unknown', (level, threshold) => {
     expect(getRoomEnergyBufferThreshold(makeRoom({ level }))).toBe(threshold);
+  });
+
+  it.each([
+    [1, 300],
+    [2, 300],
+    [3, 500],
+    [4, 500],
+    [5, 800],
+    [6, 800],
+    [7, 1_000],
+    [8, 1_000]
+  ])('keeps the configured RCL %i threshold when room capacity is sufficient', (level, threshold) => {
+    expect(getRoomEnergyBufferThreshold(makeRoom({ level, energyCapacityAvailable: threshold }))).toBe(threshold);
+    expect(getRoomEnergyBufferThreshold(makeRoom({ level, energyCapacityAvailable: threshold + 50 }))).toBe(
+      threshold
+    );
+  });
+
+  it('caps the RCL 4 buffer threshold at spawn-only room capacity', () => {
+    const room = makeRoom({ level: 4, energyAvailable: 300, energyCapacityAvailable: 300 });
+
+    expect(getRoomEnergyBufferThreshold(room)).toBe(300);
+    expect(getEffectiveRoomEnergyBufferThreshold(room)).toBe(300);
+    expect(getRoomEnergyBufferHealth(room)).toEqual({
+      currentEnergy: 300,
+      threshold: 300,
+      room: 'W1N1',
+      healthy: true
+    });
+  });
+
+  it('caps the RCL 5 buffer threshold at limited extension capacity', () => {
+    const room = makeRoom({ level: 5, energyAvailable: 650, energyCapacityAvailable: 650 });
+
+    expect(getRoomEnergyBufferThreshold(room)).toBe(650);
+    expect(getEffectiveRoomEnergyBufferThreshold(room)).toBe(650);
+    expect(getRoomEnergyBufferHealth(room).healthy).toBe(true);
+  });
+
+  it('applies the survival multiplier after capping the threshold to room capacity', () => {
+    const room = makeRoom({ level: 4, energyAvailable: 300, energyCapacityAvailable: 300 });
+    recordSurvivalMode('DEFENSE');
+
+    expect(getRoomEnergyBufferThreshold(room)).toBe(300);
+    expect(getEffectiveRoomEnergyBufferThreshold(room)).toBe(450);
+  });
+
+  it('normalizes edge-case room capacity values before capping thresholds', () => {
+    expect(getRoomEnergyBufferThreshold(makeRoom({ level: 4, energyCapacityAvailable: 0 }))).toBe(0);
+    expect(getRoomEnergyBufferThreshold(makeRoom({ level: 4, energyCapacityAvailable: -1 }))).toBe(0);
+    expect(
+      getRoomEnergyBufferThreshold(makeRoom({ level: 4, energyCapacityAvailable: Number.POSITIVE_INFINITY }))
+    ).toBe(500);
+  });
+
+  it('keeps storage reserves based on the configured threshold when room capacity is capped', () => {
+    const storage = makeStorage(520);
+    const room = makeRoom({ level: 3, energyAvailable: 300, energyCapacityAvailable: 300, storage });
+
+    expect(getRoomEnergyBufferThreshold(room)).toBe(300);
+    expect(getStorageEnergyReserveThreshold(room)).toBe(500);
+    expect(getStorageEnergyAvailableForWithdrawal(room, storage)).toBe(20);
+    expect(withdrawFromStorage(room, 20)).toBe(true);
+    expect(withdrawFromStorage(room, 21)).toBe(false);
   });
 
   it('gates construction spending against spawn and extension energy', () => {
@@ -53,7 +118,7 @@ describe('energyBuffer', () => {
     expect(checkEnergyBufferForSpending(room, 61)).toBe(false);
   });
 
-  it('allows capacity-enabling construction when the buffer threshold exceeds room capacity', () => {
+  it('allows capacity-enabling construction when spending would consume a full-capacity buffer', () => {
     const room = makeRoom({
       level: 3,
       energyAvailable: CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY,


### PR DESCRIPTION
## Problem

At RCL 4 with energyCapacity=300, the configured energy buffer threshold (500) permanently exceeds room capacity. `energyBufferHealth` reports `healthy=false`, blocking all construction spending. Extensions cannot be built, keeping capacity stuck at 300. This deadlocks the entire progression chain and also degrades RL training data quality (all samples are from capacity-starved states).

## Fix

- `getRoomEnergyBufferThreshold()` now caps the configured RCL threshold at `room.energyCapacityAvailable`
- If `energyCapacityAvailable` is unavailable (null), falls back to the configured threshold
- `SURVIVAL_ENERGY_BUFFER_MULTIPLIER` is applied after capping, not before
- Extracted `getStorageEnergyReserveThreshold()` to centralize storage reserve threshold logic
- Updated callers in `workerTasks.ts`, `workerTaskPolicy.ts` to use the centralized function

## Verification

- `npm run typecheck`: PASS
- `npm test -- --runInBand`: 1717/1717 PASS
- `npm run build`: PASS
- `git diff --check`: PASS

## Test coverage

Added tests for:
- RCL 4 with energyCapacity=300 (caps threshold at 300, health becomes healthy)
- RCL 5 with limited extension capacity (650)
- Survival multiplier applied after capping
- Edge cases: zero, negative, infinite capacity
- Storage reserve behavior with capped room capacity

Closes #899
Relates to #885 (extensions construction unblocking)
Relates to #879 (ALL IN RL — unblocks training data quality)
