### PR TITLE
fix(rl-sim): add port conflict detection with 2048-candidate scan in _select_run_ports

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -75,6 +75,7 @@ DEFAULT_STRATEGY_REGISTRY_PATH = REPO_ROOT / "prod" / "src" / "strategy" / "stra
 RUN_HTTP_START = 21125
 RUN_CLI_START = 21126
 RUN_HTTP_PORT_STEP = 2
+RUN_PORT_SCAN_ATTEMPTS = 2048
 RUN_TICK_TIMEOUT_SECONDS = 300
 RUN_TICK_POLL_SECONDS = 0.20
 RUN_WORKER_PREFIX = "rl-sim-worker"
@@ -372,6 +373,49 @@ def _build_run_ports(worker_index: int) -> tuple[int, int]:
     if http_port == cli_port:
         raise RuntimeError(f"worker HTTP and CLI ports must differ: {http_port}")
     return http_port, cli_port
+
+
+def _host_port_unavailable_reason(smoke: Any, host: str, port: int) -> str | None:
+    probe = getattr(smoke, "host_port_unavailable_reason", None)
+    if not callable(probe):
+        return None
+    reason = probe(host, port)
+    return _safe_text(reason, 200) if reason else None
+
+
+def _select_run_ports(
+    smoke: Any,
+    server_host: str,
+    *,
+    worker_index: int,
+    worker_count: int,
+) -> tuple[int, int]:
+    if worker_count <= 0:
+        raise RuntimeError("worker count must be a positive integer")
+
+    last_failure = ""
+    for attempt in range(RUN_PORT_SCAN_ATTEMPTS):
+        candidate_worker_index = worker_index + (attempt * worker_count)
+        try:
+            http_port, cli_port = _build_run_ports(candidate_worker_index)
+        except RuntimeError as exc:
+            last_failure = _safe_text(exc, 200)
+            break
+
+        unavailable = []
+        for service, port in (("http", http_port), ("cli", cli_port)):
+            reason = _host_port_unavailable_reason(smoke, server_host, port)
+            if reason:
+                unavailable.append(f"{service} {server_host}:{port} ({reason})")
+        if not unavailable:
+            return http_port, cli_port
+        last_failure = "; ".join(unavailable)
+
+    suffix = f": {last_failure}" if last_failure else ""
+    raise RuntimeError(
+        f"no available simulator host port pair for worker {worker_index} "
+        f"after scanning {RUN_PORT_SCAN_ATTEMPTS} candidates{suffix}"
+    )
 
 
 def _extract_int(value: Any) -> int | None:
@@ -1086,6 +1130,7 @@ def _run_variant(
     variant_id: str,
     *,
     run_id: str,
+    worker_count: int = 1,
     ticks: int,
     room: str,
     shard: str,
@@ -1101,7 +1146,12 @@ def _run_variant(
     worker_run_id = f"{run_id}-{variant_slug}"
     safe_run_root = _worker_output_dir(out_dir, run_id, worker_index)
     server_host = "127.0.0.1"
-    http_port, cli_port = _build_run_ports(worker_index)
+    http_port, cli_port = _select_run_ports(
+        smoke,
+        server_host,
+        worker_index=worker_index,
+        worker_count=worker_count,
+    )
     compose_project = f"{RUN_WORKER_PREFIX}-{_safe_filename(run_id)}-{worker_index:02d}"
     password = secrets.token_urlsafe(20)
     cfg = smoke.SmokeConfig(
@@ -1340,6 +1390,7 @@ def run_variants(
                     worker_index=worker_id,
                     variant_id=variant_id,
                     run_id=run_id,
+                    worker_count=normalized_workers,
                     ticks=ticks,
                     room=room,
                     shard=shard,

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -680,6 +680,54 @@ class RlSimulatorHarnessTest(unittest.TestCase):
         self.assertEqual(result["error"], "stop before side effects")
         self.assertIsNone(result["launcherRepairMod"])
 
+    def test_select_run_ports_skips_occupied_default_pair(self) -> None:
+        class FakeSmoke:
+            def host_port_unavailable_reason(self, host: str, port: int) -> str | None:
+                if port in {harness.RUN_HTTP_START, harness.RUN_CLI_START}:
+                    return "address already in use"
+                return None
+
+        self.assertEqual(
+            harness._select_run_ports(
+                FakeSmoke(),
+                "127.0.0.1",
+                worker_index=0,
+                worker_count=1,
+            ),
+            (
+                harness.RUN_HTTP_START + harness.RUN_HTTP_PORT_STEP,
+                harness.RUN_CLI_START + harness.RUN_HTTP_PORT_STEP,
+            ),
+        )
+
+    def test_select_run_ports_keeps_parallel_worker_fallbacks_disjoint(self) -> None:
+        class FakeSmoke:
+            def host_port_unavailable_reason(self, host: str, port: int) -> str | None:
+                if port == harness.RUN_HTTP_START:
+                    return "address already in use"
+                return None
+
+        smoke = FakeSmoke()
+
+        self.assertEqual(
+            harness._select_run_ports(
+                smoke,
+                "127.0.0.1",
+                worker_index=0,
+                worker_count=2,
+            ),
+            harness._build_run_ports(2),
+        )
+        self.assertEqual(
+            harness._select_run_ports(
+                smoke,
+                "127.0.0.1",
+                worker_index=1,
+                worker_count=2,
+            ),
+            harness._build_run_ports(1),
+        )
+
     def test_run_variant_installs_repair_mod_before_compose_start(self) -> None:
         events: list[str] = []
         run_command_calls = 0


### PR DESCRIPTION
## Summary
Add port conflict detection to E2 RL simulator harness: `_select_run_ports()` scans up to 2048 candidate port pairs across all workers, skipping occupied host:port pairs via the smoke module's `host_port_unavailable_reason` callback. Falls back to `_build_run_ports` when the callback is unavailable.

## Changes
- `scripts/screeps_rl_simulator_harness.py`: New `_select_run_ports()`, `_host_port_unavailable_reason()`, `RUN_PORT_SCAN_ATTEMPTS=2048` constant. Replaces `_build_run_ports()` call in `_run_variant()`.
- `scripts/test_screeps_rl_simulator_harness.py`: New `test_select_run_ports_skips_occupied_default_pair` test.

## Verification
```
python3 -m pytest scripts/test_screeps_rl_simulator_harness.py -q
28 passed, 6 subtests passed in 0.27s
python3 -m py_compile scripts/screeps_rl_simulator_harness.py: OK
python3 -m py_compile scripts/test_screeps_rl_simulator_harness.py: OK
git diff --check: clean
```

## Safety
- `liveEffect: false`, `officialMmoWrites: false`
- No Screeps runtime code changes
- No secrets

Refs #879
