### PR TITLE
docs(rl): add reward decision registry

### DIFF
--- a/docs/ops/examples/rl-reward-decisions/RD-0001-defense-construction.json
+++ b/docs/ops/examples/rl-reward-decisions/RD-0001-defense-construction.json
@@ -1,0 +1,75 @@
+{
+  "rewardDecisionId": "RD-0001-defense-construction",
+  "title": "Proposal: defense construction readiness reward",
+  "state": "proposed",
+  "linkedGitHubIssue": "https://github.com/lanyusea/screeps/issues/907",
+  "linkedMetricEvidence": [
+    "https://github.com/lanyusea/screeps/issues/906",
+    "needs metric evidence: hostile or damage context, defense construction backlog, build progress, and worker availability"
+  ],
+  "linkedDashboardPanels": [
+    "planned: runtime monitor defense construction backlog",
+    "planned: runtime KPI defense readiness panel"
+  ],
+  "problemStatement": "Owner-observed behavior suggests defense-critical construction can be missing or late when the room needs protective structures or defensive readiness.",
+  "hypothesis": "Rewarding timely defense construction readiness after safety floors pass should reduce delayed tower, rampart, road, or repair posture work that can threaten room survival.",
+  "currentRewardCoverage": "baseline undefined until implemented; no accepted reward registry change exists for defense construction readiness",
+  "proposedChangeType": "add_or_adjust_component",
+  "component": "defense_construction_readiness",
+  "direction": "higher_is_better after reliability safety gates; missing critical defense after threat evidence is lower",
+  "expectedBehaviorChange": "In shadow validation, priority defense construction or repair work should begin earlier when threat, damage, or downgrade evidence exists, without starving spawn recovery or core energy throughput.",
+  "riskAndRegressions": [
+    "Over-prioritizing defense sites can starve controller, spawn, or economy progression.",
+    "False-positive threat evidence can waste energy on low-value construction.",
+    "Construction churn can increase CPU or path congestion."
+  ],
+  "validationWindows": [
+    {
+      "name": "offline_replay",
+      "minimumDurationHours": 8,
+      "requiredEvidence": [
+        "defense backlog by site type",
+        "build work ticks",
+        "hostile or damage context",
+        "resource and territory non-regression"
+      ]
+    },
+    {
+      "name": "shadow_runtime",
+      "minimumDurationHours": 8,
+      "requiredEvidence": [
+        "liveEffect:false",
+        "officialMmoWrites:false",
+        "no reliability regression"
+      ]
+    }
+  ],
+  "acceptanceCriteria": [
+    "Owner approves at least shadow exploration.",
+    "Metric taxonomy #906 defines the defense readiness evidence fields.",
+    "Shadow candidate improves timely defense construction without territory, resource, or reliability regression."
+  ],
+  "rollbackCriteria": [
+    "Reliability or telemetry floor fails.",
+    "Territory or resource metrics regress outside the approved window.",
+    "Defense prioritization blocks spawn recovery or essential worker economy.",
+    "Owner rejects or suspends the decision."
+  ],
+  "stewardDecision": {
+    "state": "needs_evidence",
+    "decidedBy": null,
+    "decidedAt": null,
+    "notes": "Seed proposal only. Needs metric evidence before owner review."
+  },
+  "ownerDecision": {
+    "state": "not_requested",
+    "decidedBy": null,
+    "decidedAt": null,
+    "notes": "No accepted reward change."
+  },
+  "linkedPRs": [],
+  "linkedTrainingRuns": [],
+  "linkedPolicyEvaluations": [],
+  "createdAt": "2026-05-11T00:00:00Z",
+  "updatedAt": "2026-05-11T00:00:00Z"
+}

--- a/docs/ops/examples/rl-reward-decisions/RD-0002-worker-load-efficiency.json
+++ b/docs/ops/examples/rl-reward-decisions/RD-0002-worker-load-efficiency.json
@@ -1,0 +1,75 @@
+{
+  "rewardDecisionId": "RD-0002-worker-load-efficiency",
+  "title": "Proposal: worker load efficiency reward",
+  "state": "proposed",
+  "linkedGitHubIssue": "https://github.com/lanyusea/screeps/issues/907",
+  "linkedMetricEvidence": [
+    "https://github.com/lanyusea/screeps/issues/906",
+    "needs metric evidence: carry utilization, delivered energy per trip, transfer target state, and CPU impact"
+  ],
+  "linkedDashboardPanels": [
+    "planned: worker carry utilization histogram",
+    "planned: delivered energy per trip panel"
+  ],
+  "problemStatement": "Owner-observed tiny-load returns, for example a worker returning 2/50 energy, may waste trips and slow resource throughput.",
+  "hypothesis": "Adding a worker load efficiency reward or penalty should reduce low-value return trips when enough energy can be gathered safely and when higher-priority survival tasks are not blocked.",
+  "currentRewardCoverage": "baseline undefined until implemented; no accepted reward registry change exists for worker load efficiency",
+  "proposedChangeType": "add_or_adjust_component",
+  "component": "worker_load_efficiency",
+  "direction": "higher_is_better for useful delivered energy per trip; tiny carried-load returns are lower unless a safety or starvation exception applies",
+  "expectedBehaviorChange": "In shadow validation, workers should deliver fuller loads on normal logistics trips while preserving emergency refill, spawn recovery, and short-haul exceptions.",
+  "riskAndRegressions": [
+    "Waiting for fuller loads can delay urgent spawn or extension refills.",
+    "A naive penalty can harm bootstrap rooms with sparse energy.",
+    "Longer trips can increase path CPU or expose creeps to hostiles."
+  ],
+  "validationWindows": [
+    {
+      "name": "offline_replay",
+      "minimumDurationHours": 8,
+      "requiredEvidence": [
+        "carry utilization distribution",
+        "delivered energy per trip",
+        "spawn/extension starvation checks",
+        "resource non-regression"
+      ]
+    },
+    {
+      "name": "shadow_runtime",
+      "minimumDurationHours": 8,
+      "requiredEvidence": [
+        "liveEffect:false",
+        "officialMmoWrites:false",
+        "CPU bucket non-regression"
+      ]
+    }
+  ],
+  "acceptanceCriteria": [
+    "Owner approves at least shadow exploration.",
+    "Metric taxonomy #906 defines carry utilization and tiny-load evidence fields.",
+    "Shadow candidate improves delivered energy per trip without spawn starvation, territory loss, or reliability regression."
+  ],
+  "rollbackCriteria": [
+    "Spawn or extension refill latency regresses.",
+    "Resource score regresses after territory ties.",
+    "CPU or stuck/actionless metrics regress.",
+    "Owner rejects or suspends the decision."
+  ],
+  "stewardDecision": {
+    "state": "needs_evidence",
+    "decidedBy": null,
+    "decidedAt": null,
+    "notes": "Seed proposal only. Needs metric evidence before owner review."
+  },
+  "ownerDecision": {
+    "state": "not_requested",
+    "decidedBy": null,
+    "decidedAt": null,
+    "notes": "No accepted reward change."
+  },
+  "linkedPRs": [],
+  "linkedTrainingRuns": [],
+  "linkedPolicyEvaluations": [],
+  "createdAt": "2026-05-11T00:00:00Z",
+  "updatedAt": "2026-05-11T00:00:00Z"
+}

--- a/docs/ops/examples/rl-reward-decisions/RD-0003-stuck-actionless-creeps.json
+++ b/docs/ops/examples/rl-reward-decisions/RD-0003-stuck-actionless-creeps.json
@@ -1,0 +1,75 @@
+{
+  "rewardDecisionId": "RD-0003-stuck-actionless-creeps",
+  "title": "Proposal: stuck and actionless creep liveness reward",
+  "state": "proposed",
+  "linkedGitHubIssue": "https://github.com/lanyusea/screeps/issues/907",
+  "linkedMetricEvidence": [
+    "https://github.com/lanyusea/screeps/issues/906",
+    "needs metric evidence: idle/actionless ticks, repeated positions, action result codes, task memory, and target validity"
+  ],
+  "linkedDashboardPanels": [
+    "planned: creep action liveness panel",
+    "planned: repeated stuck position panel"
+  ],
+  "problemStatement": "Owner-observed stuck or actionless creeps may burn ticks and CPU while failing to advance territory, resources, construction, or defense.",
+  "hypothesis": "Adding a creep action liveness reward or hard gate for repeated actionlessness should favor policies that keep creeps assigned to valid, productive actions without causing unsafe movement loops.",
+  "currentRewardCoverage": "baseline undefined until implemented; no accepted reward registry change exists for creep action liveness",
+  "proposedChangeType": "add_or_adjust_component",
+  "component": "creep_action_liveness",
+  "direction": "higher_is_better for productive action ratio; repeated stuck or actionless cycles are lower and may become a hard gate when reliability is threatened",
+  "expectedBehaviorChange": "In shadow validation, creeps should spend fewer repeated ticks with no useful action, invalid target, or unchanged stuck position while preserving safe fallback behavior.",
+  "riskAndRegressions": [
+    "Over-penalizing idle ticks can force wasteful actions when waiting is correct.",
+    "A movement-heavy fix can increase CPU or road fatigue.",
+    "The policy can hide task assignment bugs if metric evidence is too coarse."
+  ],
+  "validationWindows": [
+    {
+      "name": "offline_replay",
+      "minimumDurationHours": 8,
+      "requiredEvidence": [
+        "productive action ratio",
+        "idle/actionless tick count",
+        "action result code distribution",
+        "target validity and task state"
+      ]
+    },
+    {
+      "name": "shadow_runtime",
+      "minimumDurationHours": 8,
+      "requiredEvidence": [
+        "liveEffect:false",
+        "officialMmoWrites:false",
+        "no CPU or reliability regression"
+      ]
+    }
+  ],
+  "acceptanceCriteria": [
+    "Owner approves at least shadow exploration.",
+    "Metric taxonomy #906 defines stuck/actionless evidence fields.",
+    "Shadow candidate reduces repeated actionless ticks without increasing unsafe movement, CPU pressure, or task churn."
+  ],
+  "rollbackCriteria": [
+    "CPU bucket or reliability regresses.",
+    "Movement loops, invalid intents, or task churn increase.",
+    "Resources, construction, or territory regress after higher-priority ties.",
+    "Owner rejects or suspends the decision."
+  ],
+  "stewardDecision": {
+    "state": "needs_evidence",
+    "decidedBy": null,
+    "decidedAt": null,
+    "notes": "Seed proposal only. Needs metric evidence before owner review."
+  },
+  "ownerDecision": {
+    "state": "not_requested",
+    "decidedBy": null,
+    "decidedAt": null,
+    "notes": "No accepted reward change."
+  },
+  "linkedPRs": [],
+  "linkedTrainingRuns": [],
+  "linkedPolicyEvaluations": [],
+  "createdAt": "2026-05-11T00:00:00Z",
+  "updatedAt": "2026-05-11T00:00:00Z"
+}

--- a/docs/ops/examples/rl-reward-decisions/README.md
+++ b/docs/ops/examples/rl-reward-decisions/README.md
@@ -1,0 +1,17 @@
+# RL Reward Decision Examples
+
+These files are tracked seed examples for issue #907. They live under `docs/ops/examples/` because repository-level `runtime-artifacts/` is gitignored and has no tracked convention files.
+
+Every example is a proposal only. None of these files accepts a reward change, authorizes training promotion, or permits official MMO writes.
+
+Validate the examples with:
+
+```bash
+python3 scripts/validate_rl_reward_decisions.py docs/ops/examples/rl-reward-decisions
+```
+
+Current examples:
+
+- `RD-0001-defense-construction.json`
+- `RD-0002-worker-load-efficiency.json`
+- `RD-0003-stuck-actionless-creeps.json`

--- a/docs/ops/rl-reward-decision-log.md
+++ b/docs/ops/rl-reward-decision-log.md
@@ -1,0 +1,145 @@
+# RL Reward Decision Log
+
+Status: seed registry for issue #907.
+
+Metric taxonomy link: issue #906.
+
+## Purpose
+
+This log is the durable index for reward Act decisions. It keeps reward model changes explicit, reviewable, and linked to GitHub work rather than implicit in prompts, training intuition, or model defaults.
+
+Machine-readable decision files live under `docs/ops/examples/rl-reward-decisions/` for this first slice because repository-level `runtime-artifacts/` is gitignored and has no tracked convention files.
+
+## Lifecycle
+
+Reward decisions move through exactly these states:
+
+```text
+proposed -> owner_review -> approved_for_shadow -> training -> candidate_policy -> validating -> accepted/rejected/rolled_back
+```
+
+State meaning:
+
+- `proposed`: documented idea with linked issue and metric taxonomy, not accepted.
+- `owner_review`: steward has enough evidence to request owner direction.
+- `approved_for_shadow`: owner approved offline/shadow exploration only.
+- `training`: training run is executing or queued against the approved decision.
+- `candidate_policy`: a concrete candidate policy or reward config exists.
+- `validating`: candidate is under offline, simulator, historical, shadow, or rollout validation.
+- `accepted`: owner accepted the reward change after evidence and validation.
+- `rejected`: evidence, owner review, or validation rejected the change.
+- `rolled_back`: an accepted change was reverted or disabled by rollback criteria.
+
+Default state is `proposed`. No seed entry in this file is an accepted reward change.
+
+## Required Fields
+
+Every machine-readable reward decision must include:
+
+- `rewardDecisionId`
+- `title`
+- `state`
+- `linkedGitHubIssue`
+- `linkedMetricEvidence`
+- `linkedDashboardPanels`
+- `problemStatement`
+- `hypothesis`
+- `currentRewardCoverage`
+- `proposedChangeType`
+- `component`
+- `direction`
+- `expectedBehaviorChange`
+- `riskAndRegressions`
+- `validationWindows`
+- `acceptanceCriteria`
+- `rollbackCriteria`
+- `stewardDecision`
+- `ownerDecision`
+- `linkedPRs`
+- `linkedTrainingRuns`
+- `linkedPolicyEvaluations`
+- `createdAt`
+- `updatedAt`
+
+The JSON template is `docs/ops/templates/rl-reward-decision.template.json`.
+
+## Seed Decision Index
+
+| ID | State | Behavior class | Proposal status | Links |
+| --- | --- | --- | --- | --- |
+| `RD-0001-defense-construction` | `proposed` | missing or late defense construction | needs metric evidence; not accepted | #907, #906 |
+| `RD-0002-worker-load-efficiency` | `proposed` | tiny-load returns such as 2/50 energy | needs metric evidence; not accepted | #907, #906 |
+| `RD-0003-stuck-actionless-creeps` | `proposed` | stuck/actionless creeps | needs metric evidence; not accepted | #907, #906 |
+| `RD-0004-construction-backlog-build-zero` | `proposed` | `build=0` with construction backlog | needs metric evidence; not accepted | #907, #906 |
+| `RD-0005-expansion-without-spawn` | `proposed` | claim/expansion room with 0 spawns after grace window | needs metric evidence; not accepted | #907, #906 |
+| `RD-0006-metric-and-reliability-gates` | `proposed` | CPU, reliability, or missing metrics | needs metric evidence; not accepted | #907, #906 |
+
+## Seed Entries
+
+### RD-0001-defense-construction
+
+- State: `proposed`
+- Linked issue: https://github.com/lanyusea/screeps/issues/907
+- Linked metric taxonomy: https://github.com/lanyusea/screeps/issues/906
+- Problem: owner-observed behavior suggests defense-critical construction may be missing or late.
+- Possible Act choice: add or adjust `defense_construction_readiness` as a safety/territory-sensitive reward component.
+- Evidence needed: hostile/damage/downgrade context, defense site backlog, rampart/tower/road/site state, build progress, worker availability.
+- Acceptance status: not accepted; proposal only.
+
+### RD-0002-worker-load-efficiency
+
+- State: `proposed`
+- Linked issue: https://github.com/lanyusea/screeps/issues/907
+- Linked metric taxonomy: https://github.com/lanyusea/screeps/issues/906
+- Problem: owner-observed tiny-load returns such as 2/50 energy may waste worker trips and slow economy.
+- Possible Act choice: add or adjust `worker_load_efficiency` so useful delivery per trip improves after higher-priority floors pass.
+- Evidence needed: carry utilization distribution, transfer target saturation, source/drop distance, delivered energy per trip, CPU impact.
+- Acceptance status: not accepted; proposal only.
+
+### RD-0003-stuck-actionless-creeps
+
+- State: `proposed`
+- Linked issue: https://github.com/lanyusea/screeps/issues/907
+- Linked metric taxonomy: https://github.com/lanyusea/screeps/issues/906
+- Problem: owner-observed stuck/actionless creeps may indicate task assignment, pathing, or action-result failure.
+- Possible Act choice: add or adjust `creep_action_liveness`, and escalate to a hard gate when repeated actionlessness threatens reliability.
+- Evidence needed: idle/actionless ticks, repeated position evidence, action result codes, task memory, target validity, CPU bucket.
+- Acceptance status: not accepted; proposal only.
+
+### RD-0004-construction-backlog-build-zero
+
+- State: `proposed`
+- Linked issue: https://github.com/lanyusea/screeps/issues/907
+- Linked metric taxonomy: https://github.com/lanyusea/screeps/issues/906
+- Problem: `build=0` while construction backlog exists can block territory and resource progression.
+- Possible Act choice: add or adjust `construction_progress` reward or a backlog gate for priority site classes.
+- Evidence needed: site backlog by type, build work ticks, worker task counts, energy availability, spawn queue pressure.
+- Acceptance status: not accepted; proposal only.
+
+### RD-0005-expansion-without-spawn
+
+- State: `proposed`
+- Linked issue: https://github.com/lanyusea/screeps/issues/907
+- Linked metric taxonomy: https://github.com/lanyusea/screeps/issues/906
+- Problem: a claimed or expansion room with 0 spawns after a grace window is not durable territory.
+- Possible Act choice: add or adjust `expansion_viability` so territory reward counts only survived expansion.
+- Evidence needed: claim timestamp, grace window, spawn/site state, local workers, bootstrap energy path, hostile pressure.
+- Acceptance status: not accepted; proposal only.
+
+### RD-0006-metric-and-reliability-gates
+
+- State: `proposed`
+- Linked issue: https://github.com/lanyusea/screeps/issues/907
+- Linked metric taxonomy: https://github.com/lanyusea/screeps/issues/906
+- Problem: CPU, reliability, or missing metric data can make reward changes unsafe or impossible to validate.
+- Possible Act choice: hard gate training, candidate promotion, or rollout until telemetry and reliability floors are satisfied.
+- Evidence needed: runtime summary freshness, malformed count, CPU bucket/window data, validator output, missing-field report.
+- Acceptance status: not accepted; proposal only.
+
+## Update Rules
+
+- Add one row here for every reward decision JSON.
+- Keep `state`, linked PRs, training runs, policy evaluations, and owner/steward decisions synchronized with the decision JSON.
+- Mark rejected and rolled-back decisions as durable evidence; do not delete them.
+- Do not mark a decision `accepted` unless validation evidence and owner decision are linked.
+- Do not use this log to authorize official MMO writes. It records reward governance only.

--- a/docs/ops/rl-reward-model.md
+++ b/docs/ops/rl-reward-model.md
@@ -1,0 +1,111 @@
+# RL Reward Model Registry
+
+Status: baseline registry slice for issue #907.
+
+Metric taxonomy link: issue #906.
+
+## Purpose
+
+This document defines the reward-governance contract for RL Act decisions. Reward changes must be explicit GitHub-managed decision items with evidence, owner review, validation windows, and rollback criteria. They must not be hidden inside prompts, model intuition, ad hoc training runs, or untracked local artifacts.
+
+The current production bot does not expose a deployed reward-weight registry. Any exact production reward weights, scalar coefficients, or decision-order values not already implemented in code are **baseline undefined until implemented**.
+
+The existing offline training docs may describe specific helper behavior for prior slices. This registry is the durable change-control layer that decides when a reward definition is proposed, reviewed, trained, validated, accepted, rejected, or rolled back.
+
+## Lexicographic Priority
+
+Reward comparison must follow this order:
+
+1. Reliability and safety floor.
+2. Territory/control.
+3. Resources/economy.
+4. Enemy kills/combat value.
+5. Efficiency and CPU constraints.
+
+Reliability and safety are gates, not compensating reward. A candidate that violates safety, crashes the tick loop, loses required telemetry, or fails validation is rejected even if later gameplay metrics improve.
+
+Territory dominates resources. Resources dominate kills. Efficiency and CPU are constraints and tie-breakers; they cannot justify territory loss, economy collapse, or safety regression.
+
+## Reward Components
+
+| Component | Conceptual formula | Direction | Current registry baseline |
+| --- | --- | --- | --- |
+| `reliability_safety_floor` | pass/fail from loop exceptions, malformed/missing telemetry, unsafe write flags, validation status, rollback gate status, and hard liveness floors | must pass | baseline undefined until implemented |
+| `territory_control` | owned-room delta, survived expansion rooms, controller/RCL progress, reservation uptime, downgrade-risk reduction, room survival after claim | higher is better | baseline undefined until implemented |
+| `resource_economy` | stored energy/resource delta, harvested and collected energy, useful transfer throughput, spawn/economy utilization, sustainable RCL/GCL conversion | higher is better | baseline undefined until implemented |
+| `combat_value` | hostile creep/structure destruction, hostile objective denial, minus own creep/structure/room losses | higher is better | baseline undefined until implemented |
+| `efficiency_cpu` | useful action per CPU, CPU bucket health, fewer wasted intents, fewer tiny-load or actionless ticks after preserving higher priorities | lower cost and higher useful work are better | baseline undefined until implemented |
+| `construction_progress` | useful construction progress on priority sites when construction backlog exists, especially spawn, extension, tower, rampart, road, and container priorities | higher is better | baseline undefined until implemented |
+| `worker_load_efficiency` | delivered energy per trip, carry utilization at delivery, avoid repeated return trips with negligible carried energy | higher useful delivery per trip is better | baseline undefined until implemented |
+| `creep_action_liveness` | non-idle productive ticks, valid target/action success, no repeated stuck/actionless cycles | higher productive-action ratio is better | baseline undefined until implemented |
+| `expansion_viability` | claimed/reserved expansion survival, spawn established after grace window, local worker/bootstrap continuity | higher viable expansion survival is better | baseline undefined until implemented |
+| `defense_construction_readiness` | timely tower/rampart/road/repair construction or repair posture when hostile or downgrade risk evidence exists | higher timely defensive readiness is better | baseline undefined until implemented |
+
+The component names above are governance names. A reward decision may map one governance component to one or more implementation metrics only after the linked decision is approved and implemented.
+
+## Hard Gates
+
+Every reward decision, training run, shadow evaluation, and policy candidate must preserve:
+
+- `liveEffect:false`
+- `officialMmoWrites:false`
+- no official MMO writes, no Memory writes, no RawMemory writes, no spawn/creep/construction/market authority from learned output
+- validation before training promotion
+- validation before rollout promotion
+- deterministic production validators remain the final gate before any later high-level live recommendation path
+
+Default decision is reject. Missing evidence, missing metric definitions, unsafe flags, unknown state, or failed validation blocks advancement.
+
+## Change-Control Rules
+
+Reward changes advance through the decision registry in `docs/ops/rl-reward-decision-log.md`. A change may not enter training unless its proposal identifies:
+
+- linked GitHub issue and metric evidence;
+- current reward coverage;
+- proposed change type, component, and direction;
+- expected behavior change;
+- risk and regression analysis;
+- validation windows;
+- acceptance criteria;
+- rollback criteria;
+- steward and owner decisions.
+
+Accepted reward behavior must be traceable to a reviewed decision JSON, linked PRs, linked training runs, and linked policy evaluations.
+
+## Rollback Conditions
+
+Roll back a reward change, or reject the candidate before rollout, if any of these occur:
+
+- reliability falls below the current rollout floor or loop exceptions increase;
+- territory/control regresses outside the accepted window;
+- a claimed room fails the expansion survival rule after the defined grace window;
+- resources/economy regress beyond the accepted tolerance after higher-priority metrics tie;
+- combat gains are purchased with own-room, own-spawn, or reliability loss;
+- CPU bucket, tick latency, or useful-action-per-CPU degrades enough to threaten runtime stability;
+- required metric evidence is missing, malformed, or contradicted by newer evidence;
+- owner decision rejects or suspends the decision;
+- validation or rollback helper output rejects the candidate.
+
+Rollback restores the last accepted reward registry state and marks the decision `rolled_back` with the evidence window and linked rollback PR/run.
+
+## Anti-Oscillation Rules
+
+- Do not alternate reward direction for the same component without new metric evidence and owner review.
+- Keep one active reward decision per component unless the linked decisions explicitly describe dependency ordering.
+- Require at least one full validation window before reversing an accepted reward direction, except for safety rollback.
+- Small bounded changes are preferred over broad reward rewrites.
+- A failed candidate remains negative evidence; do not retry the same change under a new ID without explaining what evidence changed.
+- Efficiency and CPU tuning must be treated as tie-breakers or floors unless the issue is a reliability blocker.
+
+## Mapping Findings To Act Choices
+
+| Behavior metric finding | Possible reward Act choice | Priority layer | Required evidence before approval |
+| --- | --- | --- | --- |
+| Missing or late defense construction | propose `defense_construction_readiness` component or hard gate for defense-critical construction backlog | reliability/safety, then territory | hostile/damage/downgrade context, construction backlog, build progress, tower/rampart/road/site state |
+| Tiny-load returns such as 2/50 energy | propose `worker_load_efficiency` penalty or logistics throughput component | resources, then efficiency | carry load histograms, transfer target state, source/drop distance, delivered energy per trip |
+| Stuck/actionless creeps | propose `creep_action_liveness` penalty or reliability gate when repeated | reliability/safety, then resources | idle/actionless tick ratio, stuck position evidence, action result codes, task assignment state |
+| `build=0` with construction backlog | propose `construction_progress` reward or construction backlog gate | territory/resources | construction site count, priority site types, worker availability, energy availability, build work ticks |
+| Claim/expansion room with 0 spawns after grace window | propose `expansion_viability` survival rule or territory component adjustment | territory | claim timestamp, grace window, spawn/site state, local worker/bootstrap continuity |
+| CPU, reliability, or missing metrics | hard gate: block training, candidate promotion, or rollout until metrics are available and stable | reliability/safety | runtime summary integrity, CPU bucket/window data, validator output, telemetry freshness |
+
+These mappings are proposal starting points, not accepted reward changes. Each Act choice must be recorded in the decision log and validated through the template before it can affect training or rollout.

--- a/docs/ops/templates/rl-reward-decision.template.json
+++ b/docs/ops/templates/rl-reward-decision.template.json
@@ -1,0 +1,38 @@
+{
+  "rewardDecisionId": "RD-0000-short-name",
+  "title": "Proposal: short reward decision title",
+  "state": "proposed",
+  "linkedGitHubIssue": "https://github.com/lanyusea/screeps/issues/907",
+  "linkedMetricEvidence": [
+    "https://github.com/lanyusea/screeps/issues/906"
+  ],
+  "linkedDashboardPanels": [],
+  "problemStatement": "Describe the observed behavior and why it matters.",
+  "hypothesis": "Describe why this reward change should improve the prioritized metric.",
+  "currentRewardCoverage": "baseline undefined until implemented",
+  "proposedChangeType": "proposal",
+  "component": "baseline undefined until implemented",
+  "direction": "higher_is_better | lower_is_better | hard_gate | tie_breaker",
+  "expectedBehaviorChange": "Describe the concrete behavior change expected in shadow validation.",
+  "riskAndRegressions": [],
+  "validationWindows": [],
+  "acceptanceCriteria": [],
+  "rollbackCriteria": [],
+  "stewardDecision": {
+    "state": "needs_evidence",
+    "decidedBy": null,
+    "decidedAt": null,
+    "notes": "Proposal only."
+  },
+  "ownerDecision": {
+    "state": "not_requested",
+    "decidedBy": null,
+    "decidedAt": null,
+    "notes": "No owner approval yet."
+  },
+  "linkedPRs": [],
+  "linkedTrainingRuns": [],
+  "linkedPolicyEvaluations": [],
+  "createdAt": "2026-05-11T00:00:00Z",
+  "updatedAt": "2026-05-11T00:00:00Z"
+}

--- a/scripts/test_validate_rl_reward_decisions.py
+++ b/scripts/test_validate_rl_reward_decisions.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import validate_rl_reward_decisions as validator
+
+
+JsonObject = dict[str, Any]
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = ROOT / "docs/ops/templates/rl-reward-decision.template.json"
+EXAMPLES = ROOT / "docs/ops/examples/rl-reward-decisions"
+
+
+def write_json(path: Path, payload: JsonObject) -> None:
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
+
+class RlRewardDecisionValidatorTest(unittest.TestCase):
+    def test_template_and_seed_examples_pass(self) -> None:
+        errors = validator.validate_paths([TEMPLATE, EXAMPLES])
+
+        self.assertEqual([], errors)
+
+    def test_missing_required_field_fails(self) -> None:
+        payload = json.loads(TEMPLATE.read_text(encoding="utf-8"))
+        del payload["title"]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            decision_path = Path(temp_dir) / "missing-title.json"
+            write_json(decision_path, payload)
+
+            errors = validator.validate_file(decision_path)
+
+        self.assertEqual(1, len(errors))
+        self.assertIn("missing required fields: title", errors[0].message)
+
+    def test_unknown_state_fails(self) -> None:
+        payload = json.loads(TEMPLATE.read_text(encoding="utf-8"))
+        payload["state"] = "live_rollout"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            decision_path = Path(temp_dir) / "bad-state.json"
+            write_json(decision_path, payload)
+
+            errors = validator.validate_file(decision_path)
+
+        self.assertEqual(1, len(errors))
+        self.assertIn("state must be one of", errors[0].message)
+
+    def test_unsafe_true_flag_fails(self) -> None:
+        payload = json.loads(TEMPLATE.read_text(encoding="utf-8"))
+        payload["safety"] = {"officialMmoWrites": True}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            decision_path = Path(temp_dir) / "unsafe.json"
+            write_json(decision_path, payload)
+
+            errors = validator.validate_file(decision_path)
+
+        self.assertEqual(1, len(errors))
+        self.assertIn("unsafe true flag at safety.officialMmoWrites", errors[0].message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_rl_reward_decisions.py
+++ b/scripts/validate_rl_reward_decisions.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Validate RL reward decision registry JSON files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+
+REQUIRED_FIELDS = (
+    "rewardDecisionId",
+    "title",
+    "state",
+    "linkedGitHubIssue",
+    "linkedMetricEvidence",
+    "linkedDashboardPanels",
+    "problemStatement",
+    "hypothesis",
+    "currentRewardCoverage",
+    "proposedChangeType",
+    "component",
+    "direction",
+    "expectedBehaviorChange",
+    "riskAndRegressions",
+    "validationWindows",
+    "acceptanceCriteria",
+    "rollbackCriteria",
+    "stewardDecision",
+    "ownerDecision",
+    "linkedPRs",
+    "linkedTrainingRuns",
+    "linkedPolicyEvaluations",
+    "createdAt",
+    "updatedAt",
+)
+
+SAFE_STATES = {
+    "proposed",
+    "owner_review",
+    "approved_for_shadow",
+    "training",
+    "candidate_policy",
+    "validating",
+    "accepted",
+    "rejected",
+    "rolled_back",
+}
+
+UNSAFE_TRUE_KEYS = {
+    "liveEffect",
+    "officialMmoWrites",
+    "officialMmoWritesAllowed",
+    "officialMmoControl",
+    "memoryWritesAllowed",
+    "rawMemoryWritesAllowed",
+    "rawCreepIntentControl",
+    "spawnIntentControl",
+    "constructionIntentControl",
+    "marketIntentControl",
+}
+
+DEFAULT_DECISION_DIR = Path("docs/ops/examples/rl-reward-decisions")
+
+
+@dataclass(frozen=True)
+class ValidationError:
+    path: Path
+    message: str
+
+    def format(self) -> str:
+        return f"{self.path}: {self.message}"
+
+
+def load_json_object(path: Path) -> tuple[dict[str, Any] | None, list[ValidationError]]:
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        return None, [ValidationError(path, f"invalid JSON: {error}")]
+    except OSError as error:
+        return None, [ValidationError(path, f"could not read file: {error}")]
+
+    if not isinstance(loaded, dict):
+        return None, [ValidationError(path, "top-level JSON value must be an object")]
+    return loaded, []
+
+
+def walk_json(value: Any, path: tuple[str, ...] = ()) -> Iterable[tuple[tuple[str, ...], Any]]:
+    yield path, value
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if isinstance(key, str):
+                yield from walk_json(nested, (*path, key))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            yield from walk_json(nested, (*path, str(index)))
+
+
+def validate_payload(path: Path, payload: dict[str, Any]) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+
+    missing = [field for field in REQUIRED_FIELDS if field not in payload]
+    if missing:
+        errors.append(ValidationError(path, "missing required fields: " + ", ".join(missing)))
+
+    state = payload.get("state")
+    if state not in SAFE_STATES:
+        errors.append(
+            ValidationError(
+                path,
+                f"state must be one of {', '.join(sorted(SAFE_STATES))}; got {state!r}",
+            )
+        )
+
+    for nested_path, value in walk_json(payload):
+        key = nested_path[-1] if nested_path else ""
+        if key in UNSAFE_TRUE_KEYS and value is True:
+            errors.append(ValidationError(path, f"unsafe true flag at {'.'.join(nested_path)}"))
+
+    return errors
+
+
+def validate_file(path: Path) -> list[ValidationError]:
+    payload, errors = load_json_object(path)
+    if payload is None:
+        return errors
+    return errors + validate_payload(path, payload)
+
+
+def collect_json_files(paths: Sequence[Path]) -> list[Path]:
+    files: list[Path] = []
+    for path in paths:
+        if path.is_dir():
+            files.extend(sorted(candidate for candidate in path.rglob("*.json") if candidate.is_file()))
+        elif path.is_file():
+            files.append(path)
+        else:
+            files.append(path)
+    return files
+
+
+def validate_paths(paths: Sequence[Path]) -> list[ValidationError]:
+    files = collect_json_files(paths)
+    errors: list[ValidationError] = []
+
+    if not files:
+        return [ValidationError(paths[0] if paths else DEFAULT_DECISION_DIR, "no JSON files found")]
+
+    for path in files:
+        if not path.exists():
+            errors.append(ValidationError(path, "path does not exist"))
+            continue
+        errors.extend(validate_file(path))
+    return errors
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate RL reward decision JSON files.")
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[DEFAULT_DECISION_DIR],
+        help="Decision JSON file or directory to validate. Defaults to docs/ops/examples/rl-reward-decisions.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    paths: list[Path] = args.paths
+
+    errors = validate_paths(paths)
+    if errors:
+        for error in errors:
+            print(error.format(), file=sys.stderr)
+        return 1
+
+    file_count = len(collect_json_files(paths))
+    print(f"validated {file_count} RL reward decision JSON file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements the first reward decision registry landing slice for #907:

- adds durable RL reward model and decision log docs
- adds a machine-readable reward decision JSON template
- seeds proposal-state examples for defense construction, worker load efficiency, and stuck/actionless creeps
- adds a stdlib validator and unit tests for reward decision records

This makes reward changes explicit GitHub-managed decisions with evidence, hypothesis, validation windows, and rollback criteria. It does not change production bot behavior or any deployed reward weight.

## Verification

- `python3 -m json.tool docs/ops/templates/rl-reward-decision.template.json >/dev/null`
- `for f in docs/ops/examples/rl-reward-decisions/*.json; do python3 -m json.tool "$f" >/dev/null; done`
- `python3 -m py_compile scripts/validate_rl_reward_decisions.py`
- `python3 scripts/validate_rl_reward_decisions.py docs/ops/templates/rl-reward-decision.template.json docs/ops/examples/rl-reward-decisions`
- `python3 -m unittest scripts/test_validate_rl_reward_decisions.py`
- `git diff --check`

Refs #907
