### PR TITLE
feat(rl): add gameplay metrics store and dashboard seed

### DIFF
--- a/docs/ops/grafana/screeps-rl-gameplay-metrics.json
+++ b/docs/ops/grafana/screeps-rl-gameplay-metrics.json
@@ -1,0 +1,332 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "targetBlank": true,
+      "title": "Metric taxonomy",
+      "type": "link",
+      "url": "docs/ops/rl-gameplay-metrics-taxonomy.md"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "screeps-rl-metrics-sqlite"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "format": "table",
+          "queryText": "SELECT observed_at, tick, room_name, metric_name, value, source_artifact FROM metric_observations WHERE metric_name IN ('survival.owned_rooms','survival.owned_spawns','survival.claimed_room_without_spawn_age_ticks') ORDER BY observed_at DESC LIMIT 200;",
+          "rawQuery": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Survival And Ownership",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "screeps-rl-metrics-sqlite"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "format": "time_series",
+          "queryText": "SELECT observed_at AS time, room_name || ':' || metric_name AS metric, value FROM metric_observations WHERE metric_name IN ('economy.energy_available','economy.stored_energy','economy.worker_carried_energy') ORDER BY observed_at;",
+          "rawQuery": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Resource Economy",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "screeps-rl-metrics-sqlite"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "format": "table",
+          "queryText": "SELECT observed_at, tick, room_name, metric_name, value, source_artifact FROM metric_observations WHERE metric_name IN ('construction.backlog_progress','construction.build_task_count','construction.built_progress','construction.build_carried_energy') ORDER BY observed_at DESC LIMIT 200;",
+          "rawQuery": true,
+          "refId": "A"
+        },
+        {
+          "format": "table",
+          "queryText": "SELECT first_seen_at, severity, room_name, finding_key, evidence_json, recommendation FROM gameplay_behavior_findings WHERE category = 'stalled-construction' ORDER BY first_seen_at DESC LIMIT 50;",
+          "rawQuery": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Construction And Infrastructure",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "screeps-rl-metrics-sqlite"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "format": "table",
+          "queryText": "SELECT observed_at, tick, room_name, metric_name, value, evidence_json FROM metric_observations WHERE metric_name IN ('creep.worker_count','creep.low_load_return_count','creep.return_load_factor','creep.idle_count','creep.stuck_ticks','behavior.upgrade_dominance_ratio') ORDER BY observed_at DESC LIMIT 250;",
+          "rawQuery": true,
+          "refId": "A"
+        },
+        {
+          "format": "table",
+          "queryText": "SELECT first_seen_at, severity, category, room_name, evidence_json, recommendation FROM gameplay_behavior_findings WHERE category IN ('low-load-return','stuck-actionless','upgrade-dominant-backlog') ORDER BY first_seen_at DESC LIMIT 100;",
+          "rawQuery": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Creep Efficiency, Stuck, And Load Factor",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "screeps-rl-metrics-sqlite"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "format": "table",
+          "queryText": "SELECT observed_at, tick, room_name, metric_name, value, source_artifact FROM metric_observations WHERE metric_name IN ('defense.hostile_creep_count','defense.tower_count','defense.rampart_count','construction.defense_backlog') ORDER BY observed_at DESC LIMIT 200;",
+          "rawQuery": true,
+          "refId": "A"
+        },
+        {
+          "format": "table",
+          "queryText": "SELECT first_seen_at, severity, room_name, evidence_json, recommendation FROM gameplay_behavior_findings WHERE category = 'missing-late-defense-construction' ORDER BY first_seen_at DESC LIMIT 50;",
+          "rawQuery": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Defense Readiness",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "screeps-rl-metrics-sqlite"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "format": "table",
+          "queryText": "SELECT observed_at, tick, metric_name, value, source_artifact FROM metric_observations WHERE metric_name IN ('cpu.bucket','cpu.used','reliability.loop_exception_count','reliability.telemetry_silence_ticks') ORDER BY observed_at DESC LIMIT 200;",
+          "rawQuery": true,
+          "refId": "A"
+        },
+        {
+          "format": "table",
+          "queryText": "SELECT first_seen_at, severity, finding_key, evidence_json, recommendation FROM gameplay_behavior_findings WHERE category = 'runtime-reliability' ORDER BY first_seen_at DESC LIMIT 50;",
+          "rawQuery": true,
+          "refId": "B"
+        }
+      ],
+      "title": "CPU And Reliability",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "screeps-rl-metrics-sqlite"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 7,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "format": "table",
+          "queryText": "SELECT observed_at, gate_id, status, metric_name, value, source_artifact FROM rl_dataset_gate_metrics ORDER BY observed_at DESC LIMIT 100;",
+          "rawQuery": true,
+          "refId": "A"
+        },
+        {
+          "format": "table",
+          "queryText": "SELECT observed_at, report_id, variant_id, metric_name, value, source_artifact FROM rl_training_execution_metrics ORDER BY observed_at DESC LIMIT 150;",
+          "rawQuery": true,
+          "refId": "B"
+        },
+        {
+          "format": "table",
+          "queryText": "SELECT observed_at, report_id, candidate_id, incumbent_id, metric_name, value, directionality FROM rl_policy_advantage_metrics ORDER BY observed_at DESC LIMIT 150;",
+          "rawQuery": true,
+          "refId": "C"
+        }
+      ],
+      "title": "RL Dataset, Training, And Policy Metrics",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "screeps-rl-metrics-sqlite"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 8,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "format": "table",
+          "queryText": "SELECT observed_at, severity, metric_name, category, room_name, tick, gap_type, message, source_artifact FROM metric_coverage_gaps ORDER BY observed_at DESC LIMIT 250;",
+          "rawQuery": true,
+          "refId": "A"
+        },
+        {
+          "format": "table",
+          "queryText": "SELECT metric_name, severity, COUNT(*) AS gap_count FROM metric_coverage_gaps GROUP BY metric_name, severity ORDER BY gap_count DESC, metric_name LIMIT 100;",
+          "rawQuery": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Metric Coverage Gaps",
+      "type": "table"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 39,
+  "tags": [
+    "screeps",
+    "rl",
+    "gameplay-metrics",
+    "pdca-check"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Screeps RL Gameplay Metrics",
+  "uid": "screeps-rl-gameplay-metrics",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/ops/rl-gameplay-metrics-taxonomy.md
+++ b/docs/ops/rl-gameplay-metrics-taxonomy.md
@@ -1,0 +1,125 @@
+# RL Gameplay Metrics Taxonomy
+
+Status: first PDCA Check landing slice for issue #906.
+
+This taxonomy turns local runtime/RL artifacts into a durable SQLite metric store for Gameplay Evolution. The store is intentionally offline-only: it reads saved artifacts, stores derived metrics and concise evidence paths, and never copies raw console logs, raw secrets, or full artifact bodies.
+
+Default store:
+
+```text
+runtime-artifacts/rl-metrics/rl_metrics.sqlite
+```
+
+Primary ingestor:
+
+```text
+python3 scripts/screeps_rl_metrics_ingestor.py init
+python3 scripts/screeps_rl_metrics_ingestor.py ingest-artifacts
+python3 scripts/screeps_rl_metrics_ingestor.py summarize
+```
+
+Default source roots:
+
+```text
+runtime-artifacts/runtime-summary-console
+runtime-artifacts/rl-dataset-gates
+runtime-artifacts/rl-control-loop
+runtime-artifacts/rl-training
+```
+
+## Schema Contract
+
+The ingestor owns these tables:
+
+| Table | Purpose |
+| --- | --- |
+| `metric_definitions` | Durable taxonomy: category, metric name, purpose, sources, direction, interpretation, missing-coverage behavior, promotion rule. |
+| `metric_observations` | Derived numeric/text observations by tick, room, shard, metric, source artifact path, and bounded evidence JSON. |
+| `gameplay_behavior_findings` | Behavior defects detected from available metrics, with severity, recommendation, and promotion state. |
+| `metric_coverage_gaps` | Explicit missing instrumentation/source coverage instead of silent false negatives. |
+| `rl_dataset_gate_metrics` | Dataset/evaluation gate pass/fail and quality counters. |
+| `rl_training_execution_metrics` | Training report sample/reward metrics by variant. |
+| `rl_policy_advantage_metrics` | Candidate-vs-incumbent territory/resources/kills advantage metrics. |
+| `metric_iteration_decisions` | Ingested RL control-loop or rollout/iteration decisions and blocking reasons. |
+
+## Metric Categories
+
+| Category | Goal | Irrational behavior covered |
+| --- | --- | --- |
+| Survival/ownership | Keep claimed rooms alive and spawn-capable. | Claimed expansion rooms with 0 spawns after grace. |
+| Resource economy | Keep energy telemetry visible and energy flow useful. | Missing energy telemetry, low-load worker returns. |
+| Construction/infrastructure | Ensure build backlog turns into build work/progress. | `build=0` or `buildCarriedEnergy=0` while backlog exists. |
+| Creep efficiency | Detect idle/stuck/actionless creeps and poor load factor. | Long stuck windows; 2/50-style returns. |
+| Defense readiness | Ensure threat/backlog drives towers/ramparts/defense construction. | Missing/late tower/rampart/defense infra while threatened. |
+| Gameplay behavior | Detect bad priority allocation. | Upgrade dominance while capacity/defense/construction backlog exists. |
+| CPU/reliability | Keep runtime evidence trustworthy. | Loop exceptions, telemetry silence, CPU gaps. |
+| RL dataset/training/policy | Keep offline learning gates measurable. | Dataset gate rejections, missing training/policy advantage evidence. |
+| Metric coverage | Make blind spots actionable. | Missing source roots, missing fields, unreadable files. |
+
+## Metric Definitions
+
+| Metric | Category | Purpose | Source artifact(s) | Directionality | Interpretation | Missing coverage behavior | Promotion rule |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `source.runtime_summary_console.present` | Metric coverage | Confirm saved runtime-summary artifacts exist. | `runtime-artifacts/runtime-summary-console` | Higher is better | `1` means the Check loop has runtime samples. | Insert `missing_source_root` gap. | Missing for two steward windows promotes runtime capture work. |
+| `source.rl_dataset_gates.present` | Metric coverage | Confirm RL dataset/evaluation gate artifacts exist. | `runtime-artifacts/rl-dataset-gates` | Higher is better | Required to explain policy gate decisions. | Insert `missing_source_root` gap. | Repeated absence promotes RL pipeline evidence work. |
+| `source.rl_control_loop.present` | Metric coverage | Confirm RL iteration/control decisions exist. | `runtime-artifacts/rl-control-loop` | Higher is better | Required to close PDCA Act decisions. | Insert `missing_source_root` gap. | Repeated absence promotes control-loop observability work. |
+| `source.rl_training.present` | Metric coverage | Confirm RL training reports exist. | `runtime-artifacts/rl-training` | Higher is better | Required for policy advantage panels. | Insert `missing_source_root` gap. | Repeated absence during active RL work promotes experiment evidence issue. |
+| `survival.owned_rooms` | Survival/ownership | Count visible claimed rooms. | Runtime-summary JSON/log lines. | Higher is better | Drops imply territory loss or visibility loss. | Gap if room ownership fields are absent. | Severe drop promotes P0 recovery; missing data promotes telemetry work. |
+| `survival.owned_spawns` | Survival/ownership | Count spawn infrastructure per room. | `spawnStatus`, `structures.spawn`, spawn count fields. | Higher until target met | Claimed room with 0 spawns is survival risk. | Gap if spawn telemetry absent. | Critical when claimed room has 0 spawns after grace. |
+| `survival.claimed_room_without_spawn_age_ticks` | Survival/ownership | Measure no-spawn claimed room age. | Claim age and controller fields. | Lower is better | Above grace means expansion is not self-sustaining. | Gap if claim age is missing. | Critical after `1500` ticks without spawn. |
+| `economy.energy_available` | Resource economy | Track spawn/extension energy. | `energyAvailable`, `energy.available`. | Contextual | Low can be normal after spending; dangerous in recovery. | Energy telemetry gap. | Repeated absence promotes energy telemetry work. |
+| `economy.stored_energy` | Resource economy | Track durable reserves. | `resources.storedEnergy`, storage fields. | Higher is better | Persistent low/0 values indicate starvation or missing visibility. | Energy telemetry gap. | Repeated starvation promotes economy recovery work. |
+| `economy.worker_carried_energy` | Resource economy | Track carried worker energy. | `resources.workerCarriedEnergy`. | Contextual | Carried energy with no sink work indicates assignment imbalance. | Energy telemetry gap. | Repeated absence promotes worker energy telemetry work. |
+| `economy.energy_telemetry` | Metric coverage | Boolean coverage marker for energy fields. | Any available energy field. | Higher is better | Gap means economy behavior cannot be judged safely. | Insert `missing_energy_fields`. | Repeated gap promotes telemetry construction issue. |
+| `creep.worker_count` | Creep efficiency | Count visible owned workers/creeps. | `workerCount`, `ownedCreeps`, `creeps`. | Higher until target met | Explains energy/construction deadlocks. | Worker telemetry gap. | Critical during recovery if no workers and spawn can act. |
+| `creep.low_load_return_count` | Creep efficiency | Count low-load returns. | Low-load/worker-efficiency fields. | Lower is better | Nonzero values mean travel/CPU waste. | `missing_low_load_return_fields`. | Repeated nonzero values promote logistics issue. |
+| `creep.return_load_factor` | Creep efficiency | Track return energy divided by carry capacity. | Return energy/capacity or load-factor fields. | Higher is better | `<=0.10` outside emergency is irrational. | Low-load telemetry gap. | Repeated low factor promotes logistics issue. |
+| `creep.idle_count` | Creep efficiency | Count idle/actionless workers or idle ticks. | Behavior fields. | Lower is better | High values indicate missing targets or blocked pathing. | Stuck/actionless gap. | Critical if long windows repeat. |
+| `creep.stuck_ticks` | Creep efficiency | Track stuck/actionless windows. | `stuckTicks`, `actionlessTicks`, stuck count fields. | Lower is better | Long windows waste CPU and block work. | `missing_stuck_actionless_fields`. | Critical when `>=50` ticks repeats or blocks survival work. |
+| `construction.backlog_progress` | Construction/infrastructure | Track remaining construction backlog. | Productive-energy/construction priority fields. | Lower when work should progress | Backlog with no progress means construction stalled. | Construction telemetry gap. | Repeated backlog with zero build promotes construction issue. |
+| `construction.build_task_count` | Construction/infrastructure | Track workers assigned to build. | `taskCounts.build`. | Contextual | `0` while backlog exists is stalled construction. | Task assignment gap. | Repeated `0` with backlog promotes construction issue. |
+| `construction.built_progress` | Construction/infrastructure | Track actual build progress. | Build progress fields. | Higher when backlog exists | `0` with backlog means no effective build work. | `missing_build_progress`. | Repeated `0` or gap with backlog promotes behavior/telemetry issue. |
+| `construction.build_carried_energy` | Construction/infrastructure | Track energy carried/used by builders. | `buildCarriedEnergy` fields. | Higher when backlog exists | `0` with backlog confirms builder starvation/misassignment. | `missing_build_carried_energy`. | Repeated `0` or gap with backlog promotes construction issue. |
+| `construction.defense_backlog` | Defense readiness | Track tower/rampart/defense backlog. | Defense fields and construction priority text. | Lower is better when threatened | Defense backlog with no builders is survival risk. | Defense construction gap. | Critical with hostile/threat evidence. |
+| `defense.hostile_creep_count` | Defense readiness | Count visible hostiles. | `combat.hostileCreepCount`. | Lower is better | Nonzero requires defense readiness. | Combat telemetry gap. | Missing during incidents promotes combat telemetry work. |
+| `defense.tower_count` | Defense readiness | Count tower infrastructure. | `structures.tower`, tower count fields. | Higher until target met | `0` during threat/backlog means missing defense infra. | Defense infra gap. | Critical with hostiles or high-urgency defense backlog. |
+| `defense.rampart_count` | Defense readiness | Count rampart infrastructure. | `structures.rampart`, rampart count fields. | Higher until target met | `0` during rampart backlog means late fortification. | Defense infra gap. | Critical with hostiles or high-urgency defense backlog. |
+| `behavior.upgrade_dominance_ratio` | Gameplay behavior | Fraction of workers assigned to upgrade. | `taskCounts.upgrade` and worker count. | Lower when backlog exists | High upgrade ratio with urgent backlog is misprioritized progress. | Task/backlog gap. | Repeated `>=0.60` with backlog promotes prioritization issue. |
+| `cpu.bucket` | CPU/reliability | Track CPU bucket resilience. | `cpu.bucket`. | Higher is better | Low bucket can mask policy quality. | CPU telemetry gap. | Repeated low/missing values promote reliability work. |
+| `cpu.used` | CPU/reliability | Track CPU used. | `cpu.used`. | Lower for equal outcome | Spikes may correlate with pathing/stuck behavior. | CPU telemetry gap. | Repeated missing values promote CPU instrumentation work. |
+| `reliability.loop_exception_count` | CPU/reliability | Count tick-loop exceptions. | `reliability.loopExceptionCount`. | Lower is better | Any nonzero value invalidates behavior evidence. | Reliability telemetry gap. | Nonzero promotes P0 runtime correctness issue. |
+| `reliability.telemetry_silence_ticks` | CPU/reliability | Track telemetry silence. | `reliability.telemetrySilenceTicks`. | Lower is better | Silence means the Check loop may be blind. | Reliability telemetry gap. | Repeated silence promotes monitor/capture issue. |
+| `rl.dataset_gate.status` | RL dataset/training/policy | Persist gate pass/fail. | RL dataset gate report/summary JSON. | Pass is better | Failing gates block policy advancement. | Source-root gap. | Repeated failures promote RL dataset quality issue. |
+| `rl.training.execution_sample_count` | RL dataset/training/policy | Track simulator samples by variant. | RL training reports. | Higher until target met | `0` samples make comparisons unusable. | Training coverage gap. | Repeated `0`/missing promotes simulator/training issue. |
+| `rl.policy.advantage_territory` | RL dataset/training/policy | Candidate territory reward advantage. | RL training ranking/reward tuples. | Higher is better | First lexicographic objective. | Policy comparison gap. | Negative/repeated missing value blocks rollout and feeds iteration. |
+| `rl.policy.advantage_resources` | RL dataset/training/policy | Candidate resource reward advantage after territory tie. | RL training ranking/reward tuples. | Higher is better | Matters only after territory is not worse. | Policy comparison gap. | Negative value feeds reward/strategy iteration. |
+| `rl.policy.advantage_kills` | RL dataset/training/policy | Candidate kill reward advantage after territory/resources. | RL training ranking/reward tuples. | Higher is better | Third lexicographic objective. | Policy comparison gap. | Negative value feeds combat-policy iteration. |
+
+## Finding Rules
+
+The first ingestor slice detects these behavior findings when the required fields exist:
+
+| Finding category | Trigger | Severity |
+| --- | --- | --- |
+| `missing-late-defense-construction` | Threat or defense backlog exists and tower/rampart infrastructure is missing. | Critical with hostiles, warning with backlog only. |
+| `low-load-return` | Low-load return count is nonzero or return load factor is `<=0.10`, e.g. `2/50`. | Warning unless later policy raises it during emergency windows. |
+| `stuck-actionless` | Stuck/actionless window is `>=50` ticks. | Critical. |
+| `stalled-construction` | Construction backlog exists and build task/progress/build-carried energy are all `0` or missing. | Critical when high-urgency/defense, otherwise warning. |
+| `upgrade-dominant-backlog` | Upgrade tasks are `>=60%` of workers while construction/defense/threat backlog exists. | Warning. |
+| `claimed-expansion-zero-spawn` | Claimed room has 0 spawns after `1500` claim-age ticks. | Critical. |
+| `runtime-reliability` | Loop exception count is nonzero. | Critical. |
+| `rl-gate-rejection` | Dataset gate fails or rejects samples. | Warning, blocks policy advancement. |
+
+When fields are missing, the ingestor writes `metric_coverage_gaps` instead of pretending the behavior is healthy. This is deliberate: missing coverage is itself a Check finding.
+
+## Promotion To GitHub Construction Issues
+
+Codex does not update GitHub for this task, but the taxonomy defines when the controller or Gameplay Evolution should promote findings:
+
+1. **Immediate promotion:** any critical survival/runtime correctness finding, including claimed room with 0 spawns after grace, nonzero loop exceptions, hostiles with missing defense infra, or severe defense construction stall.
+2. **Repeated promotion:** same `category + room_name` appears in two or more consecutive steward windows, or appears in three windows within 24 hours.
+3. **Coverage promotion:** a coverage gap for a required category appears in two consecutive steward windows and blocks interpretation of a P0/P1 behavior.
+4. **RL gate promotion:** dataset/training/policy metrics fail or are missing during an active RL experiment window, blocking rollout or iteration.
+5. **Issue body minimum evidence:** metric name, room, tick/window if known, concise source artifact path, bounded evidence JSON, expected behavior, and the smallest implementation surface likely to fix it.
+
+Promotion should create construction issues, not raw alert spam. One issue should aggregate repeated evidence for the same root behavior unless the blast radius or owning module differs.

--- a/scripts/screeps_rl_metrics_ingestor.py
+++ b/scripts/screeps_rl_metrics_ingestor.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import sqlite3
 from pathlib import Path
@@ -48,7 +49,7 @@ CREATE TABLE IF NOT EXISTS metric_observations (
   unit TEXT,
   source_artifact TEXT NOT NULL,
   evidence_json TEXT NOT NULL DEFAULT '{}',
-  UNIQUE(metric_name, tick, room_name, source_artifact, evidence_json)
+  dedupe_key TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS gameplay_behavior_findings (
@@ -64,7 +65,7 @@ CREATE TABLE IF NOT EXISTS gameplay_behavior_findings (
   evidence_json TEXT NOT NULL DEFAULT '{}',
   recommendation TEXT NOT NULL,
   promotion_state TEXT NOT NULL DEFAULT 'candidate',
-  UNIQUE(finding_key, source_artifact, tick, room_name)
+  dedupe_key TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS metric_coverage_gaps (
@@ -79,7 +80,7 @@ CREATE TABLE IF NOT EXISTS metric_coverage_gaps (
   message TEXT NOT NULL,
   evidence_json TEXT NOT NULL DEFAULT '{}',
   observed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-  UNIQUE(metric_name, source_artifact, room_name, tick, gap_type)
+  dedupe_key TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS rl_dataset_gate_metrics (
@@ -91,7 +92,7 @@ CREATE TABLE IF NOT EXISTS rl_dataset_gate_metrics (
   source_artifact TEXT NOT NULL,
   evidence_json TEXT NOT NULL DEFAULT '{}',
   observed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-  UNIQUE(gate_id, status, metric_name, source_artifact, evidence_json)
+  dedupe_key TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS rl_training_execution_metrics (
@@ -103,7 +104,7 @@ CREATE TABLE IF NOT EXISTS rl_training_execution_metrics (
   source_artifact TEXT NOT NULL,
   evidence_json TEXT NOT NULL DEFAULT '{}',
   observed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-  UNIQUE(report_id, variant_id, metric_name, source_artifact, evidence_json)
+  dedupe_key TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS rl_policy_advantage_metrics (
@@ -117,7 +118,7 @@ CREATE TABLE IF NOT EXISTS rl_policy_advantage_metrics (
   source_artifact TEXT NOT NULL,
   evidence_json TEXT NOT NULL DEFAULT '{}',
   observed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-  UNIQUE(report_id, candidate_id, incumbent_id, metric_name, source_artifact, evidence_json)
+  dedupe_key TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS metric_iteration_decisions (
@@ -492,8 +493,47 @@ SOURCE_ROOT_METRICS = {
 }
 
 
+DEDUPE_TABLE_KEYS = {
+    "metric_observations": ("metric_name", "tick", "room_name", "source_artifact", "evidence_json"),
+    "gameplay_behavior_findings": ("finding_key", "source_artifact", "tick", "room_name"),
+    "metric_coverage_gaps": ("metric_name", "source_artifact", "room_name", "tick", "gap_type"),
+    "rl_dataset_gate_metrics": ("gate_id", "status", "metric_name", "source_artifact", "evidence_json"),
+    "rl_training_execution_metrics": ("report_id", "variant_id", "metric_name", "source_artifact", "evidence_json"),
+    "rl_policy_advantage_metrics": (
+        "report_id",
+        "candidate_id",
+        "incumbent_id",
+        "metric_name",
+        "source_artifact",
+        "evidence_json",
+    ),
+}
+
+
 def canonical_json(value: object) -> str:
     return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def canonical_json_field(value: object) -> object:
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return value
+
+
+def dedupe_key_for_fields(table_name: str, fields: dict[str, object]) -> str:
+    normalized_fields = {
+        key: canonical_json_field(value) if key == "evidence_json" else value for key, value in fields.items()
+    }
+    payload = {"table": table_name, "fields": normalized_fields}
+    digest = hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def dedupe_key_for_values(table_name: str, **fields: object) -> str:
+    return dedupe_key_for_fields(table_name, fields)
 
 
 def display_path(path: Path | str) -> str:
@@ -626,9 +666,60 @@ def connect_database(db_path: Path) -> sqlite3.Connection:
     return conn
 
 
+def table_columns(conn: sqlite3.Connection, table_name: str) -> set[str]:
+    return {row["name"] for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
+
+
+def ensure_dedupe_schema(conn: sqlite3.Connection) -> None:
+    for table_name, key_columns in DEDUPE_TABLE_KEYS.items():
+        columns = table_columns(conn, table_name)
+        if not columns:
+            continue
+        if "dedupe_key" not in columns:
+            conn.execute(f"ALTER TABLE {table_name} ADD COLUMN dedupe_key TEXT")
+        backfill_dedupe_keys(conn, table_name, key_columns)
+        remove_duplicate_dedupe_rows(conn, table_name)
+        conn.execute(
+            f"CREATE UNIQUE INDEX IF NOT EXISTS idx_{table_name}_dedupe_key "
+            f"ON {table_name}(dedupe_key)"
+        )
+
+
+def backfill_dedupe_keys(conn: sqlite3.Connection, table_name: str, key_columns: tuple[str, ...]) -> None:
+    selected_columns = ", ".join(("id", *key_columns))
+    rows = conn.execute(
+        f"""
+        SELECT {selected_columns}
+        FROM {table_name}
+        WHERE dedupe_key IS NULL OR dedupe_key = ''
+        """
+    ).fetchall()
+    for row in rows:
+        fields = {column: row[column] for column in key_columns}
+        conn.execute(
+            f"UPDATE {table_name} SET dedupe_key = ? WHERE id = ?",
+            (dedupe_key_for_fields(table_name, fields), row["id"]),
+        )
+
+
+def remove_duplicate_dedupe_rows(conn: sqlite3.Connection, table_name: str) -> None:
+    conn.execute(
+        f"""
+        DELETE FROM {table_name}
+        WHERE dedupe_key IS NOT NULL
+          AND id NOT IN (
+            SELECT MIN(id)
+            FROM {table_name}
+            GROUP BY dedupe_key
+          )
+        """
+    )
+
+
 def initialize_database(db_path: Path) -> dict[str, int]:
     with connect_database(db_path) as conn:
         conn.executescript(SCHEMA_SQL)
+        ensure_dedupe_schema(conn)
         upsert_metric_definitions(conn)
         conn.commit()
         definition_count = conn.execute("SELECT COUNT(*) FROM metric_definitions").fetchone()[0]
@@ -680,12 +771,22 @@ def record_observation(
     evidence: object | None = None,
     value_text: str | None = None,
 ) -> None:
+    evidence_json = canonical_json(evidence or {})
+    dedupe_key = dedupe_key_for_values(
+        "metric_observations",
+        metric_name=metric_name,
+        tick=tick,
+        room_name=room_name,
+        source_artifact=source_artifact,
+        evidence_json=evidence_json,
+    )
     conn.execute(
         """
         INSERT OR IGNORE INTO metric_observations (
-          metric_name, tick, shard, room_name, value, value_text, unit, source_artifact, evidence_json
+          metric_name, tick, shard, room_name, value, value_text, unit, source_artifact,
+          evidence_json, dedupe_key
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             metric_name,
@@ -696,7 +797,8 @@ def record_observation(
             value_text,
             unit,
             source_artifact,
-            canonical_json(evidence or {}),
+            evidence_json,
+            dedupe_key,
         ),
     )
 
@@ -715,13 +817,21 @@ def record_finding(
     evidence: object | None = None,
     promotion_state: str = "candidate",
 ) -> None:
+    evidence_json = canonical_json(evidence or {})
+    dedupe_key = dedupe_key_for_values(
+        "gameplay_behavior_findings",
+        finding_key=finding_key,
+        source_artifact=source_artifact,
+        tick=tick,
+        room_name=room_name,
+    )
     conn.execute(
         """
         INSERT OR IGNORE INTO gameplay_behavior_findings (
           finding_key, category, severity, room_name, tick, source_artifact,
-          metric_name, evidence_json, recommendation, promotion_state
+          metric_name, evidence_json, recommendation, promotion_state, dedupe_key
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             finding_key,
@@ -731,9 +841,10 @@ def record_finding(
             tick,
             source_artifact,
             metric_name,
-            canonical_json(evidence or {}),
+            evidence_json,
             recommendation,
             promotion_state,
+            dedupe_key,
         ),
     )
 
@@ -751,13 +862,22 @@ def record_coverage_gap(
     room_name: str | None = None,
     evidence: object | None = None,
 ) -> None:
+    evidence_json = canonical_json(evidence or {})
+    dedupe_key = dedupe_key_for_values(
+        "metric_coverage_gaps",
+        metric_name=metric_name,
+        source_artifact=source_artifact,
+        room_name=room_name,
+        tick=tick,
+        gap_type=gap_type,
+    )
     conn.execute(
         """
         INSERT OR IGNORE INTO metric_coverage_gaps (
           metric_name, category, severity, source_artifact, room_name, tick,
-          gap_type, message, evidence_json
+          gap_type, message, evidence_json, dedupe_key
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             metric_name,
@@ -768,7 +888,8 @@ def record_coverage_gap(
             tick,
             gap_type,
             message,
-            canonical_json(evidence or {}),
+            evidence_json,
+            dedupe_key,
         ),
     )
 
@@ -783,14 +904,23 @@ def record_dataset_gate_metric(
     source_artifact: str,
     evidence: object | None = None,
 ) -> None:
+    evidence_json = canonical_json(evidence or {})
+    dedupe_key = dedupe_key_for_values(
+        "rl_dataset_gate_metrics",
+        gate_id=gate_id,
+        status=status,
+        metric_name=metric_name,
+        source_artifact=source_artifact,
+        evidence_json=evidence_json,
+    )
     conn.execute(
         """
         INSERT OR IGNORE INTO rl_dataset_gate_metrics (
-          gate_id, status, metric_name, value, source_artifact, evidence_json
+          gate_id, status, metric_name, value, source_artifact, evidence_json, dedupe_key
         )
-        VALUES (?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
         """,
-        (gate_id, status, metric_name, value, source_artifact, canonical_json(evidence or {})),
+        (gate_id, status, metric_name, value, source_artifact, evidence_json, dedupe_key),
     )
 
 
@@ -804,14 +934,23 @@ def record_training_metric(
     source_artifact: str,
     evidence: object | None = None,
 ) -> None:
+    evidence_json = canonical_json(evidence or {})
+    dedupe_key = dedupe_key_for_values(
+        "rl_training_execution_metrics",
+        report_id=report_id,
+        variant_id=variant_id,
+        metric_name=metric_name,
+        source_artifact=source_artifact,
+        evidence_json=evidence_json,
+    )
     conn.execute(
         """
         INSERT OR IGNORE INTO rl_training_execution_metrics (
-          report_id, variant_id, metric_name, value, source_artifact, evidence_json
+          report_id, variant_id, metric_name, value, source_artifact, evidence_json, dedupe_key
         )
-        VALUES (?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
         """,
-        (report_id, variant_id, metric_name, value, source_artifact, canonical_json(evidence or {})),
+        (report_id, variant_id, metric_name, value, source_artifact, evidence_json, dedupe_key),
     )
 
 
@@ -827,13 +966,23 @@ def record_policy_advantage(
     source_artifact: str,
     evidence: object | None = None,
 ) -> None:
+    evidence_json = canonical_json(evidence or {})
+    dedupe_key = dedupe_key_for_values(
+        "rl_policy_advantage_metrics",
+        report_id=report_id,
+        candidate_id=candidate_id,
+        incumbent_id=incumbent_id,
+        metric_name=metric_name,
+        source_artifact=source_artifact,
+        evidence_json=evidence_json,
+    )
     conn.execute(
         """
         INSERT OR IGNORE INTO rl_policy_advantage_metrics (
           report_id, candidate_id, incumbent_id, metric_name, value,
-          directionality, source_artifact, evidence_json
+          directionality, source_artifact, evidence_json, dedupe_key
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             report_id,
@@ -843,7 +992,8 @@ def record_policy_advantage(
             value,
             directionality,
             source_artifact,
-            canonical_json(evidence or {}),
+            evidence_json,
+            dedupe_key,
         ),
     )
 

--- a/scripts/screeps_rl_metrics_ingestor.py
+++ b/scripts/screeps_rl_metrics_ingestor.py
@@ -1,0 +1,2242 @@
+#!/usr/bin/env python3
+"""Ingest local Screeps gameplay/RL artifacts into a SQLite metrics store."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from pathlib import Path
+
+
+DEFAULT_DB_PATH = Path("runtime-artifacts/rl-metrics/rl_metrics.sqlite")
+DEFAULT_ARTIFACT_ROOTS = (
+    Path("runtime-artifacts/runtime-summary-console"),
+    Path("runtime-artifacts/rl-dataset-gates"),
+    Path("runtime-artifacts/rl-control-loop"),
+    Path("runtime-artifacts/rl-training"),
+)
+RUNTIME_SUMMARY_PREFIX = "#runtime-summary "
+DEFAULT_MAX_FILE_BYTES = 5 * 1024 * 1024
+EXPANSION_SPAWN_GRACE_TICKS = 1500
+
+
+SCHEMA_SQL = """
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS metric_definitions (
+  metric_name TEXT PRIMARY KEY,
+  category TEXT NOT NULL,
+  purpose TEXT NOT NULL,
+  source_artifacts TEXT NOT NULL,
+  directionality TEXT NOT NULL,
+  interpretation TEXT NOT NULL,
+  missing_coverage_behavior TEXT NOT NULL,
+  promotion_rule TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS metric_observations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  metric_name TEXT NOT NULL,
+  observed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  tick INTEGER,
+  shard TEXT,
+  room_name TEXT,
+  value REAL,
+  value_text TEXT,
+  unit TEXT,
+  source_artifact TEXT NOT NULL,
+  evidence_json TEXT NOT NULL DEFAULT '{}',
+  UNIQUE(metric_name, tick, room_name, source_artifact, evidence_json)
+);
+
+CREATE TABLE IF NOT EXISTS gameplay_behavior_findings (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  finding_key TEXT NOT NULL,
+  category TEXT NOT NULL,
+  severity TEXT NOT NULL,
+  room_name TEXT,
+  tick INTEGER,
+  first_seen_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  source_artifact TEXT NOT NULL,
+  metric_name TEXT NOT NULL,
+  evidence_json TEXT NOT NULL DEFAULT '{}',
+  recommendation TEXT NOT NULL,
+  promotion_state TEXT NOT NULL DEFAULT 'candidate',
+  UNIQUE(finding_key, source_artifact, tick, room_name)
+);
+
+CREATE TABLE IF NOT EXISTS metric_coverage_gaps (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  metric_name TEXT NOT NULL,
+  category TEXT NOT NULL,
+  severity TEXT NOT NULL,
+  source_artifact TEXT NOT NULL,
+  room_name TEXT,
+  tick INTEGER,
+  gap_type TEXT NOT NULL,
+  message TEXT NOT NULL,
+  evidence_json TEXT NOT NULL DEFAULT '{}',
+  observed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  UNIQUE(metric_name, source_artifact, room_name, tick, gap_type)
+);
+
+CREATE TABLE IF NOT EXISTS rl_dataset_gate_metrics (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  gate_id TEXT,
+  status TEXT NOT NULL,
+  metric_name TEXT NOT NULL,
+  value REAL,
+  source_artifact TEXT NOT NULL,
+  evidence_json TEXT NOT NULL DEFAULT '{}',
+  observed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  UNIQUE(gate_id, status, metric_name, source_artifact, evidence_json)
+);
+
+CREATE TABLE IF NOT EXISTS rl_training_execution_metrics (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  report_id TEXT,
+  variant_id TEXT,
+  metric_name TEXT NOT NULL,
+  value REAL,
+  source_artifact TEXT NOT NULL,
+  evidence_json TEXT NOT NULL DEFAULT '{}',
+  observed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  UNIQUE(report_id, variant_id, metric_name, source_artifact, evidence_json)
+);
+
+CREATE TABLE IF NOT EXISTS rl_policy_advantage_metrics (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  report_id TEXT,
+  candidate_id TEXT,
+  incumbent_id TEXT,
+  metric_name TEXT NOT NULL,
+  value REAL,
+  directionality TEXT NOT NULL,
+  source_artifact TEXT NOT NULL,
+  evidence_json TEXT NOT NULL DEFAULT '{}',
+  observed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  UNIQUE(report_id, candidate_id, incumbent_id, metric_name, source_artifact, evidence_json)
+);
+
+CREATE TABLE IF NOT EXISTS metric_iteration_decisions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  decision_key TEXT NOT NULL,
+  status TEXT NOT NULL,
+  source_artifact TEXT NOT NULL,
+  rationale TEXT NOT NULL,
+  evidence_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  UNIQUE(decision_key, source_artifact)
+);
+
+CREATE INDEX IF NOT EXISTS idx_metric_observations_metric_tick
+  ON metric_observations(metric_name, tick);
+CREATE INDEX IF NOT EXISTS idx_findings_category_severity
+  ON gameplay_behavior_findings(category, severity);
+CREATE INDEX IF NOT EXISTS idx_coverage_metric
+  ON metric_coverage_gaps(metric_name, severity);
+"""
+
+
+METRIC_DEFINITIONS = [
+    {
+        "metric_name": "source.runtime_summary_console.present",
+        "category": "metric coverage",
+        "purpose": "Detect whether saved #runtime-summary artifacts are available to the PDCA Check loop.",
+        "source_artifacts": "runtime-artifacts/runtime-summary-console",
+        "directionality": "higher is better",
+        "interpretation": "1 means the root exists and was scanned; a gap means runtime summary evidence is absent.",
+        "missing_coverage_behavior": "Insert a coverage gap for the source root and do not fail ingestion.",
+        "promotion_rule": "If absent for two steward windows, create/refresh a construction issue for runtime capture.",
+    },
+    {
+        "metric_name": "source.rl_dataset_gates.present",
+        "category": "metric coverage",
+        "purpose": "Detect whether RL dataset/evaluation gate artifacts are available.",
+        "source_artifacts": "runtime-artifacts/rl-dataset-gates",
+        "directionality": "higher is better",
+        "interpretation": "1 means gate artifacts were scanned.",
+        "missing_coverage_behavior": "Insert a coverage gap and continue.",
+        "promotion_rule": "Repeated absence blocks RL rollout evidence and should promote to an RL pipeline issue.",
+    },
+    {
+        "metric_name": "source.rl_control_loop.present",
+        "category": "metric coverage",
+        "purpose": "Detect whether RL control-loop decision artifacts are available.",
+        "source_artifacts": "runtime-artifacts/rl-control-loop",
+        "directionality": "higher is better",
+        "interpretation": "1 means control-loop artifacts were scanned.",
+        "missing_coverage_behavior": "Insert a coverage gap and continue.",
+        "promotion_rule": "Repeated absence promotes to a control-loop observability issue.",
+    },
+    {
+        "metric_name": "source.rl_training.present",
+        "category": "metric coverage",
+        "purpose": "Detect whether RL training report artifacts are available.",
+        "source_artifacts": "runtime-artifacts/rl-training",
+        "directionality": "higher is better",
+        "interpretation": "1 means training artifacts were scanned.",
+        "missing_coverage_behavior": "Insert a coverage gap and continue.",
+        "promotion_rule": "Repeated absence during active training work promotes to an RL experiment evidence issue.",
+    },
+    {
+        "metric_name": "survival.owned_rooms",
+        "category": "survival/ownership",
+        "purpose": "Count claimed rooms visible in runtime summary evidence.",
+        "source_artifacts": "#runtime-summary JSON/log lines",
+        "directionality": "higher is better",
+        "interpretation": "Drops indicate territory loss or missing visibility.",
+        "missing_coverage_behavior": "Record a coverage gap when room ownership fields are absent.",
+        "promotion_rule": "Severe drops create P0 recovery work; missing data creates telemetry work.",
+    },
+    {
+        "metric_name": "survival.owned_spawns",
+        "category": "survival/ownership",
+        "purpose": "Count owned spawns per room.",
+        "source_artifacts": "#runtime-summary room spawnStatus/structures fields",
+        "directionality": "higher is better",
+        "interpretation": "0 in a claimed room after grace is expansion collapse or unrecovered spawn loss.",
+        "missing_coverage_behavior": "Record missing spawn telemetry coverage.",
+        "promotion_rule": "Critical when claimed room has 0 spawns after grace or during survival recovery.",
+    },
+    {
+        "metric_name": "survival.claimed_room_without_spawn_age_ticks",
+        "category": "survival/ownership",
+        "purpose": "Track claimed rooms without spawn infrastructure against the expansion grace window.",
+        "source_artifacts": "#runtime-summary controller/claim-age/spawn fields",
+        "directionality": "lower is better",
+        "interpretation": "A value above grace means expansion survival is failing.",
+        "missing_coverage_behavior": "Record a gap if claim age is not emitted.",
+        "promotion_rule": "Critical after grace; warning while age telemetry is missing.",
+    },
+    {
+        "metric_name": "economy.energy_available",
+        "category": "resource economy",
+        "purpose": "Track room spawn/extension energy availability.",
+        "source_artifacts": "#runtime-summary energyAvailable or energy.available",
+        "directionality": "contextual",
+        "interpretation": "Low values are normal after spawn/build spend but dangerous during worker recovery.",
+        "missing_coverage_behavior": "Record an energy telemetry coverage gap.",
+        "promotion_rule": "Repeated absence promotes to runtime-summary energy telemetry work.",
+    },
+    {
+        "metric_name": "economy.stored_energy",
+        "category": "resource economy",
+        "purpose": "Track durable room energy reserves.",
+        "source_artifacts": "#runtime-summary resources.storedEnergy",
+        "directionality": "higher is better",
+        "interpretation": "Persistent 0/low values indicate starvation or missing storage visibility.",
+        "missing_coverage_behavior": "Record an energy telemetry coverage gap.",
+        "promotion_rule": "Repeated starvation promotes economy recovery work; missing data promotes telemetry work.",
+    },
+    {
+        "metric_name": "economy.worker_carried_energy",
+        "category": "resource economy",
+        "purpose": "Track energy currently carried by workers.",
+        "source_artifacts": "#runtime-summary resources.workerCarriedEnergy",
+        "directionality": "contextual",
+        "interpretation": "Carried energy with no sink work indicates role/task imbalance.",
+        "missing_coverage_behavior": "Record an energy telemetry coverage gap.",
+        "promotion_rule": "Repeated absence promotes worker energy telemetry work.",
+    },
+    {
+        "metric_name": "economy.energy_telemetry",
+        "category": "metric coverage",
+        "purpose": "Boolean coverage marker for at least one usable room energy field.",
+        "source_artifacts": "#runtime-summary energy/resource fields",
+        "directionality": "higher is better",
+        "interpretation": "0/gap means economy behavior cannot be judged safely.",
+        "missing_coverage_behavior": "Insert metric_coverage_gaps instead of inferring economy state.",
+        "promotion_rule": "Repeated gap promotes to telemetry construction issue.",
+    },
+    {
+        "metric_name": "creep.worker_count",
+        "category": "creep efficiency",
+        "purpose": "Track visible owned worker/creep count per room.",
+        "source_artifacts": "#runtime-summary workerCount/ownedCreeps fields",
+        "directionality": "higher is better until target met",
+        "interpretation": "0 or drops can explain energy/construction deadlocks.",
+        "missing_coverage_behavior": "Record a worker telemetry coverage gap.",
+        "promotion_rule": "Critical during recovery if no workers and spawn can act.",
+    },
+    {
+        "metric_name": "creep.low_load_return_count",
+        "category": "creep efficiency",
+        "purpose": "Count low-load worker return events such as 2/50 energy returns outside emergencies.",
+        "source_artifacts": "#runtime-summary behavior/worker-efficiency fields",
+        "directionality": "lower is better",
+        "interpretation": "Persistent values mean workers waste travel/CPU and starve sinks.",
+        "missing_coverage_behavior": "Record a coverage gap when no low-load return fields are emitted.",
+        "promotion_rule": "Repeated nonzero values promote to worker logistics issue.",
+    },
+    {
+        "metric_name": "creep.return_load_factor",
+        "category": "creep efficiency",
+        "purpose": "Track carried/capacity ratio on worker returns.",
+        "source_artifacts": "#runtime-summary low-load/load-factor fields",
+        "directionality": "higher is better",
+        "interpretation": "Very low values without emergency exception are irrational logistics behavior.",
+        "missing_coverage_behavior": "Record low-load telemetry gap.",
+        "promotion_rule": "Repeated sub-0.10 values promote to logistics issue.",
+    },
+    {
+        "metric_name": "creep.idle_count",
+        "category": "creep efficiency",
+        "purpose": "Track idle/actionless worker count or idle tick windows.",
+        "source_artifacts": "#runtime-summary behavior fields",
+        "directionality": "lower is better",
+        "interpretation": "High idle/actionless windows indicate missing targets, pathing blocks, or saturated sinks.",
+        "missing_coverage_behavior": "Record stuck/actionless telemetry gap.",
+        "promotion_rule": "Critical if long windows repeat in same room.",
+    },
+    {
+        "metric_name": "creep.stuck_ticks",
+        "category": "creep efficiency",
+        "purpose": "Track stuck or actionless creep windows.",
+        "source_artifacts": "#runtime-summary stuck/actionless fields",
+        "directionality": "lower is better",
+        "interpretation": "Long windows waste CPU and block planned work.",
+        "missing_coverage_behavior": "Record stuck/actionless telemetry gap.",
+        "promotion_rule": "Critical if >=50 ticks repeats or blocks survival work.",
+    },
+    {
+        "metric_name": "construction.backlog_progress",
+        "category": "construction/infrastructure",
+        "purpose": "Track remaining construction/progress backlog.",
+        "source_artifacts": "#runtime-summary resources.productiveEnergy and constructionPriority",
+        "directionality": "lower is better when planned work should progress",
+        "interpretation": "Backlog with no build progress means construction is stalled.",
+        "missing_coverage_behavior": "Record construction telemetry gap when priority exists but backlog/progress is absent.",
+        "promotion_rule": "Repeated backlog with zero build promotes to construction issue.",
+    },
+    {
+        "metric_name": "construction.build_task_count",
+        "category": "construction/infrastructure",
+        "purpose": "Track workers assigned to build tasks.",
+        "source_artifacts": "#runtime-summary taskCounts.build",
+        "directionality": "contextual",
+        "interpretation": "0 while backlog exists is a stalled construction signal.",
+        "missing_coverage_behavior": "Record task assignment coverage gap.",
+        "promotion_rule": "Repeated 0 with backlog promotes to construction issue.",
+    },
+    {
+        "metric_name": "construction.built_progress",
+        "category": "construction/infrastructure",
+        "purpose": "Track actual build progress emitted by the bot/runtime summary.",
+        "source_artifacts": "#runtime-summary build/progress fields",
+        "directionality": "higher is better when backlog exists",
+        "interpretation": "0 while backlog remains indicates builders are not completing work.",
+        "missing_coverage_behavior": "Record progress telemetry gap when backlog exists.",
+        "promotion_rule": "Repeated 0/gap with backlog promotes to construction telemetry or behavior issue.",
+    },
+    {
+        "metric_name": "construction.build_carried_energy",
+        "category": "construction/infrastructure",
+        "purpose": "Track energy carried/used by builders.",
+        "source_artifacts": "#runtime-summary buildCarriedEnergy fields",
+        "directionality": "higher is better when backlog exists",
+        "interpretation": "0 with backlog confirms builders are not servicing construction.",
+        "missing_coverage_behavior": "Record progress telemetry gap when backlog exists.",
+        "promotion_rule": "Repeated 0/gap with backlog promotes to construction issue.",
+    },
+    {
+        "metric_name": "construction.defense_backlog",
+        "category": "defense readiness",
+        "purpose": "Track tower/rampart/defense construction backlog.",
+        "source_artifacts": "#runtime-summary constructionPriority and defense fields",
+        "directionality": "lower is better when threatened",
+        "interpretation": "Defense backlog during threat with no builders is a P0 survival risk.",
+        "missing_coverage_behavior": "Record defense construction coverage gap.",
+        "promotion_rule": "Critical when hostile/threat evidence is present.",
+    },
+    {
+        "metric_name": "defense.hostile_creep_count",
+        "category": "defense readiness",
+        "purpose": "Track visible hostile creeps.",
+        "source_artifacts": "#runtime-summary combat.hostileCreepCount",
+        "directionality": "lower is better",
+        "interpretation": "Nonzero hostiles require defense readiness and construction response.",
+        "missing_coverage_behavior": "Record combat telemetry gap.",
+        "promotion_rule": "Missing combat data during defense incidents promotes telemetry issue.",
+    },
+    {
+        "metric_name": "defense.tower_count",
+        "category": "defense readiness",
+        "purpose": "Track tower infrastructure count.",
+        "source_artifacts": "#runtime-summary structures.tower/towers",
+        "directionality": "higher is better until target met",
+        "interpretation": "0 during threat/backlog is missing defense infrastructure.",
+        "missing_coverage_behavior": "Record defense infra telemetry gap.",
+        "promotion_rule": "Critical with hostiles or high-urgency defense backlog.",
+    },
+    {
+        "metric_name": "defense.rampart_count",
+        "category": "defense readiness",
+        "purpose": "Track rampart infrastructure count.",
+        "source_artifacts": "#runtime-summary structures.rampart/ramparts",
+        "directionality": "higher is better until defensive plan met",
+        "interpretation": "0 during tower/rampart backlog means defense construction is late.",
+        "missing_coverage_behavior": "Record defense infra telemetry gap.",
+        "promotion_rule": "Critical with hostiles or high-urgency defense backlog.",
+    },
+    {
+        "metric_name": "behavior.upgrade_dominance_ratio",
+        "category": "gameplay behavior",
+        "purpose": "Track fraction of workers assigned to upgrade while capacity/defense/construction backlog exists.",
+        "source_artifacts": "#runtime-summary taskCounts",
+        "directionality": "lower is better when backlog exists",
+        "interpretation": "High upgrade dominance with urgent backlog is misprioritized progress.",
+        "missing_coverage_behavior": "Record task/backlog coverage gap.",
+        "promotion_rule": "Repeated high ratio with urgent backlog promotes to prioritization issue.",
+    },
+    {
+        "metric_name": "cpu.bucket",
+        "category": "CPU/reliability",
+        "purpose": "Track Screeps CPU bucket resilience.",
+        "source_artifacts": "#runtime-summary cpu.bucket",
+        "directionality": "higher is better",
+        "interpretation": "Low bucket constrains runtime behavior and can mask policy quality.",
+        "missing_coverage_behavior": "Record CPU telemetry gap.",
+        "promotion_rule": "Repeated low/missing CPU data promotes reliability instrumentation work.",
+    },
+    {
+        "metric_name": "cpu.used",
+        "category": "CPU/reliability",
+        "purpose": "Track CPU used per tick/window when available.",
+        "source_artifacts": "#runtime-summary cpu.used",
+        "directionality": "lower is better for equal outcome",
+        "interpretation": "Spikes may correlate with stuck/pathing behavior.",
+        "missing_coverage_behavior": "Record CPU telemetry gap.",
+        "promotion_rule": "Repeated missing data promotes runtime CPU instrumentation work.",
+    },
+    {
+        "metric_name": "reliability.loop_exception_count",
+        "category": "CPU/reliability",
+        "purpose": "Track tick-loop exception count.",
+        "source_artifacts": "#runtime-summary reliability.loopExceptionCount",
+        "directionality": "lower is better",
+        "interpretation": "Any nonzero value can invalidate behavior evidence.",
+        "missing_coverage_behavior": "Record reliability telemetry gap.",
+        "promotion_rule": "Nonzero values promote to P0 runtime correctness issue.",
+    },
+    {
+        "metric_name": "reliability.telemetry_silence_ticks",
+        "category": "CPU/reliability",
+        "purpose": "Track telemetry silence windows.",
+        "source_artifacts": "#runtime-summary reliability.telemetrySilenceTicks",
+        "directionality": "lower is better",
+        "interpretation": "Silence means the Check loop may be blind.",
+        "missing_coverage_behavior": "Record reliability telemetry gap.",
+        "promotion_rule": "Repeated silence promotes runtime monitor/capture issue.",
+    },
+    {
+        "metric_name": "rl.dataset_gate.status",
+        "category": "RL dataset/training/policy",
+        "purpose": "Persist pass/fail/not-configured dataset gate status.",
+        "source_artifacts": "runtime-artifacts/rl-dataset-gates",
+        "directionality": "pass is better",
+        "interpretation": "Failing gates block policy advancement and become behavior findings.",
+        "missing_coverage_behavior": "Record source-root coverage gap.",
+        "promotion_rule": "Repeated failures promote to RL dataset quality issue.",
+    },
+    {
+        "metric_name": "rl.training.execution_sample_count",
+        "category": "RL dataset/training/policy",
+        "purpose": "Track training simulator sample count by variant.",
+        "source_artifacts": "runtime-artifacts/rl-training",
+        "directionality": "higher is better until experiment target met",
+        "interpretation": "0 samples make training comparisons unusable.",
+        "missing_coverage_behavior": "Record RL training coverage gap.",
+        "promotion_rule": "Repeated 0/missing values promote to simulator/training issue.",
+    },
+    {
+        "metric_name": "rl.policy.advantage_territory",
+        "category": "RL dataset/training/policy",
+        "purpose": "Track candidate policy territory reward advantage.",
+        "source_artifacts": "runtime-artifacts/rl-training reports",
+        "directionality": "higher is better",
+        "interpretation": "Positive territory advantage is the first lexicographic objective.",
+        "missing_coverage_behavior": "Record RL policy comparison gap.",
+        "promotion_rule": "Repeated negative territory advantage blocks rollout and feeds experiment iteration.",
+    },
+    {
+        "metric_name": "rl.policy.advantage_resources",
+        "category": "RL dataset/training/policy",
+        "purpose": "Track candidate policy resource reward advantage after territory tie.",
+        "source_artifacts": "runtime-artifacts/rl-training reports",
+        "directionality": "higher is better",
+        "interpretation": "Positive value matters only after territory is not worse.",
+        "missing_coverage_behavior": "Record RL policy comparison gap.",
+        "promotion_rule": "Repeated negative value feeds reward/strategy iteration.",
+    },
+    {
+        "metric_name": "rl.policy.advantage_kills",
+        "category": "RL dataset/training/policy",
+        "purpose": "Track candidate policy kill reward advantage after territory/resources.",
+        "source_artifacts": "runtime-artifacts/rl-training reports",
+        "directionality": "higher is better",
+        "interpretation": "Positive value matters after territory and resources.",
+        "missing_coverage_behavior": "Record RL policy comparison gap.",
+        "promotion_rule": "Repeated negative value feeds combat-policy iteration.",
+    },
+]
+
+
+SOURCE_ROOT_METRICS = {
+    "runtime-summary-console": "source.runtime_summary_console.present",
+    "rl-dataset-gates": "source.rl_dataset_gates.present",
+    "rl-control-loop": "source.rl_control_loop.present",
+    "rl-training": "source.rl_training.present",
+}
+
+
+def canonical_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def display_path(path: Path | str) -> str:
+    text = str(path)
+    lowered = text.lower()
+    if any(marker in lowered for marker in ("token", "secret", "password", "steam_key")):
+        return "[redacted-path]"
+    try:
+        path_obj = Path(path).expanduser()
+        resolved = path_obj.resolve()
+        return str(resolved.relative_to(Path.cwd().resolve()))
+    except (OSError, ValueError):
+        return text
+
+
+def as_dict(value: object) -> dict[str, object]:
+    return value if isinstance(value, dict) else {}
+
+
+def as_list(value: object) -> list[object]:
+    return value if isinstance(value, list) else []
+
+
+def number_value(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        parsed = float(value)
+    elif isinstance(value, str):
+        try:
+            parsed = float(value)
+        except ValueError:
+            return None
+    else:
+        return None
+    if parsed != parsed or parsed in (float("inf"), float("-inf")):
+        return None
+    return parsed
+
+
+def integer_value(value: object) -> int | None:
+    numeric = number_value(value)
+    if numeric is None:
+        return None
+    return int(numeric)
+
+
+def text_value(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def nested_value(value: object, path: tuple[str, ...]) -> object:
+    current = value
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def first_number(value: object, paths: tuple[tuple[str, ...], ...]) -> float | None:
+    for path in paths:
+        found = number_value(nested_value(value, path))
+        if found is not None:
+            return found
+    return None
+
+
+def normalized_key(value: str) -> str:
+    return "".join(character for character in value.lower() if character.isalnum())
+
+
+def find_first_number_by_keys(value: object, key_names: tuple[str, ...]) -> float | None:
+    wanted = {normalized_key(name) for name in key_names}
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if normalized_key(str(key)) in wanted:
+                found = number_value(item)
+                if found is not None:
+                    return found
+            found = find_first_number_by_keys(item, key_names)
+            if found is not None:
+                return found
+    elif isinstance(value, list):
+        for item in value:
+            found = find_first_number_by_keys(item, key_names)
+            if found is not None:
+                return found
+    return None
+
+
+def find_first_text_by_keys(value: object, key_names: tuple[str, ...]) -> str | None:
+    wanted = {normalized_key(name) for name in key_names}
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if normalized_key(str(key)) in wanted:
+                found = text_value(item)
+                if found is not None:
+                    return found
+            found = find_first_text_by_keys(item, key_names)
+            if found is not None:
+                return found
+    elif isinstance(value, list):
+        for item in value:
+            found = find_first_text_by_keys(item, key_names)
+            if found is not None:
+                return found
+    return None
+
+
+def collect_text(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        return " ".join(collect_text(item) for item in value.values())
+    if isinstance(value, list):
+        return " ".join(collect_text(item) for item in value)
+    return ""
+
+
+def contains_any(value: str, needles: tuple[str, ...]) -> bool:
+    lowered = value.lower()
+    return any(needle in lowered for needle in needles)
+
+
+def connect_database(db_path: Path) -> sqlite3.Connection:
+    db_path.expanduser().parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path.expanduser()))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def initialize_database(db_path: Path) -> dict[str, int]:
+    with connect_database(db_path) as conn:
+        conn.executescript(SCHEMA_SQL)
+        upsert_metric_definitions(conn)
+        conn.commit()
+        definition_count = conn.execute("SELECT COUNT(*) FROM metric_definitions").fetchone()[0]
+    return {"metric_definitions": int(definition_count)}
+
+
+def upsert_metric_definitions(conn: sqlite3.Connection) -> None:
+    for definition in METRIC_DEFINITIONS:
+        conn.execute(
+            """
+            INSERT INTO metric_definitions (
+              metric_name, category, purpose, source_artifacts, directionality,
+              interpretation, missing_coverage_behavior, promotion_rule
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(metric_name) DO UPDATE SET
+              category=excluded.category,
+              purpose=excluded.purpose,
+              source_artifacts=excluded.source_artifacts,
+              directionality=excluded.directionality,
+              interpretation=excluded.interpretation,
+              missing_coverage_behavior=excluded.missing_coverage_behavior,
+              promotion_rule=excluded.promotion_rule,
+              updated_at=strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+            """,
+            (
+                definition["metric_name"],
+                definition["category"],
+                definition["purpose"],
+                definition["source_artifacts"],
+                definition["directionality"],
+                definition["interpretation"],
+                definition["missing_coverage_behavior"],
+                definition["promotion_rule"],
+            ),
+        )
+
+
+def record_observation(
+    conn: sqlite3.Connection,
+    metric_name: str,
+    value: float | None,
+    *,
+    source_artifact: str,
+    tick: int | None = None,
+    shard: str | None = None,
+    room_name: str | None = None,
+    unit: str | None = None,
+    evidence: object | None = None,
+    value_text: str | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO metric_observations (
+          metric_name, tick, shard, room_name, value, value_text, unit, source_artifact, evidence_json
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            metric_name,
+            tick,
+            shard,
+            room_name,
+            value,
+            value_text,
+            unit,
+            source_artifact,
+            canonical_json(evidence or {}),
+        ),
+    )
+
+
+def record_finding(
+    conn: sqlite3.Connection,
+    *,
+    finding_key: str,
+    category: str,
+    severity: str,
+    metric_name: str,
+    source_artifact: str,
+    recommendation: str,
+    tick: int | None = None,
+    room_name: str | None = None,
+    evidence: object | None = None,
+    promotion_state: str = "candidate",
+) -> None:
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO gameplay_behavior_findings (
+          finding_key, category, severity, room_name, tick, source_artifact,
+          metric_name, evidence_json, recommendation, promotion_state
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            finding_key,
+            category,
+            severity,
+            room_name,
+            tick,
+            source_artifact,
+            metric_name,
+            canonical_json(evidence or {}),
+            recommendation,
+            promotion_state,
+        ),
+    )
+
+
+def record_coverage_gap(
+    conn: sqlite3.Connection,
+    *,
+    metric_name: str,
+    category: str,
+    severity: str,
+    source_artifact: str,
+    gap_type: str,
+    message: str,
+    tick: int | None = None,
+    room_name: str | None = None,
+    evidence: object | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO metric_coverage_gaps (
+          metric_name, category, severity, source_artifact, room_name, tick,
+          gap_type, message, evidence_json
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            metric_name,
+            category,
+            severity,
+            source_artifact,
+            room_name,
+            tick,
+            gap_type,
+            message,
+            canonical_json(evidence or {}),
+        ),
+    )
+
+
+def record_dataset_gate_metric(
+    conn: sqlite3.Connection,
+    *,
+    gate_id: str | None,
+    status: str,
+    metric_name: str,
+    value: float | None,
+    source_artifact: str,
+    evidence: object | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO rl_dataset_gate_metrics (
+          gate_id, status, metric_name, value, source_artifact, evidence_json
+        )
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (gate_id, status, metric_name, value, source_artifact, canonical_json(evidence or {})),
+    )
+
+
+def record_training_metric(
+    conn: sqlite3.Connection,
+    *,
+    report_id: str | None,
+    variant_id: str | None,
+    metric_name: str,
+    value: float | None,
+    source_artifact: str,
+    evidence: object | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO rl_training_execution_metrics (
+          report_id, variant_id, metric_name, value, source_artifact, evidence_json
+        )
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (report_id, variant_id, metric_name, value, source_artifact, canonical_json(evidence or {})),
+    )
+
+
+def record_policy_advantage(
+    conn: sqlite3.Connection,
+    *,
+    report_id: str | None,
+    candidate_id: str | None,
+    incumbent_id: str | None,
+    metric_name: str,
+    value: float | None,
+    directionality: str,
+    source_artifact: str,
+    evidence: object | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO rl_policy_advantage_metrics (
+          report_id, candidate_id, incumbent_id, metric_name, value,
+          directionality, source_artifact, evidence_json
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            report_id,
+            candidate_id,
+            incumbent_id,
+            metric_name,
+            value,
+            directionality,
+            source_artifact,
+            canonical_json(evidence or {}),
+        ),
+    )
+
+
+def record_iteration_decision(
+    conn: sqlite3.Connection,
+    *,
+    decision_key: str,
+    status: str,
+    source_artifact: str,
+    rationale: str,
+    evidence: object | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO metric_iteration_decisions (
+          decision_key, status, source_artifact, rationale, evidence_json
+        )
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (decision_key, status, source_artifact, rationale, canonical_json(evidence or {})),
+    )
+
+
+def ingest_artifacts(db_path: Path, paths: list[Path], max_file_bytes: int = DEFAULT_MAX_FILE_BYTES) -> dict[str, int]:
+    initialize_database(db_path)
+    stats = {
+        "source_roots": 0,
+        "files_scanned": 0,
+        "files_skipped": 0,
+        "runtime_summaries": 0,
+        "dataset_gate_artifacts": 0,
+        "training_artifacts": 0,
+        "iteration_decisions": 0,
+        "coverage_gaps": 0,
+    }
+    artifact_paths = paths or list(DEFAULT_ARTIFACT_ROOTS)
+
+    with connect_database(db_path) as conn:
+        for raw_path in artifact_paths:
+            path = raw_path.expanduser()
+            source_metric = source_root_metric(path)
+            if not path.exists():
+                record_coverage_gap(
+                    conn,
+                    metric_name=source_metric,
+                    category="metric coverage",
+                    severity="warning",
+                    source_artifact=display_path(path),
+                    gap_type="missing_source_root",
+                    message=f"artifact source root {display_path(path)} does not exist",
+                )
+                stats["coverage_gaps"] += 1
+                continue
+            stats["source_roots"] += 1
+            record_observation(
+                conn,
+                source_metric,
+                1,
+                source_artifact=display_path(path),
+                evidence={"sourceRoot": display_path(path)},
+            )
+            for file_path in iter_artifact_files(path):
+                try:
+                    file_size = file_path.stat().st_size
+                except OSError:
+                    file_size = DEFAULT_MAX_FILE_BYTES + 1
+                if file_size > max_file_bytes:
+                    record_coverage_gap(
+                        conn,
+                        metric_name="source.artifact_file_readable",
+                        category="metric coverage",
+                        severity="warning",
+                        source_artifact=display_path(file_path),
+                        gap_type="file_too_large",
+                        message="artifact file exceeds max_file_bytes and was not scanned",
+                        evidence={"maxFileBytes": max_file_bytes, "sizeBytes": file_size},
+                    )
+                    stats["files_skipped"] += 1
+                    stats["coverage_gaps"] += 1
+                    continue
+                process_artifact_file(conn, file_path, stats)
+        conn.commit()
+    return stats
+
+
+def source_root_metric(path: Path) -> str:
+    for part in reversed(path.parts):
+        metric = SOURCE_ROOT_METRICS.get(part)
+        if metric is not None:
+            return metric
+    return "source.runtime_summary_console.present"
+
+
+def iter_artifact_files(path: Path) -> list[Path]:
+    if path.is_file():
+        return [path]
+    if not path.is_dir():
+        return []
+    try:
+        return sorted(item for item in path.rglob("*") if item.is_file())
+    except OSError:
+        return []
+
+
+def process_artifact_file(conn: sqlite3.Connection, path: Path, stats: dict[str, int]) -> None:
+    source_artifact = display_path(path)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        record_coverage_gap(
+            conn,
+            metric_name="source.artifact_file_readable",
+            category="metric coverage",
+            severity="warning",
+            source_artifact=source_artifact,
+            gap_type="read_error",
+            message="artifact file could not be read as UTF-8 text",
+        )
+        stats["files_skipped"] += 1
+        stats["coverage_gaps"] += 1
+        return
+
+    stats["files_scanned"] += 1
+    runtime_line_count = process_runtime_summary_lines(conn, text, source_artifact, stats)
+    if runtime_line_count:
+        return
+
+    parsed = parse_json_text(text)
+    if parsed is not None:
+        process_json_payload(conn, parsed, source_artifact, stats)
+        return
+
+    if path.suffix.lower() == ".ndjson":
+        for line in text.splitlines():
+            parsed_line = parse_json_text(line)
+            if parsed_line is not None:
+                process_json_payload(conn, parsed_line, source_artifact, stats)
+
+
+def process_runtime_summary_lines(
+    conn: sqlite3.Connection,
+    text: str,
+    source_artifact: str,
+    stats: dict[str, int],
+) -> int:
+    count = 0
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if not line.startswith(RUNTIME_SUMMARY_PREFIX):
+            continue
+        parsed = parse_json_text(line[len(RUNTIME_SUMMARY_PREFIX) :])
+        if isinstance(parsed, dict):
+            process_runtime_summary(conn, parsed, source_artifact, stats, line_number=line_number)
+            count += 1
+    return count
+
+
+def parse_json_text(text: str) -> object | None:
+    stripped = text.strip()
+    if not stripped:
+        return None
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+
+
+def process_json_payload(
+    conn: sqlite3.Connection,
+    payload: object,
+    source_artifact: str,
+    stats: dict[str, int],
+) -> None:
+    if isinstance(payload, list):
+        for item in payload:
+            process_json_payload(conn, item, source_artifact, stats)
+        return
+    if not isinstance(payload, dict):
+        return
+
+    artifact_type = text_value(payload.get("type")) or text_value(payload.get("artifactType")) or ""
+    if artifact_type == "runtime-summary":
+        process_runtime_summary(conn, payload, source_artifact, stats, line_number=None)
+    elif "dataset-evaluation-gate" in artifact_type or "datasetGate" in payload or "quality_checks" in payload:
+        process_dataset_gate(conn, payload, source_artifact, stats)
+    elif artifact_type == "screeps-rl-training-report" or "variantResults" in payload:
+        process_training_report(conn, payload, source_artifact, stats)
+    elif "decision" in payload or "feedbackIngestion" in payload or "blockingReasons" in payload:
+        process_iteration_payload(conn, payload, source_artifact, stats)
+
+
+def process_runtime_summary(
+    conn: sqlite3.Connection,
+    payload: dict[str, object],
+    source_artifact: str,
+    stats: dict[str, int],
+    *,
+    line_number: int | None,
+) -> None:
+    tick = integer_value(payload.get("tick") or payload.get("gameTime"))
+    shard = text_value(payload.get("shard"))
+    rooms = extract_rooms(payload)
+    owned_rooms = sum(1 for room in rooms if room_is_claimed(room))
+    record_observation(
+        conn,
+        "survival.owned_rooms",
+        owned_rooms,
+        source_artifact=source_artifact,
+        tick=tick,
+        shard=shard,
+        evidence={"line": line_number, "roomCount": len(rooms)},
+    )
+    process_top_level_runtime_metrics(conn, payload, source_artifact, tick, shard)
+    if not rooms:
+        record_coverage_gap(
+            conn,
+            metric_name="survival.owned_rooms",
+            category="survival/ownership",
+            severity="warning",
+            source_artifact=source_artifact,
+            tick=tick,
+            gap_type="missing_rooms",
+            message="runtime summary did not contain a rooms list/object",
+            evidence={"line": line_number},
+        )
+    for room in rooms:
+        process_runtime_room(conn, payload, room, source_artifact, tick, shard, line_number)
+    stats["runtime_summaries"] += 1
+
+
+def extract_rooms(payload: dict[str, object]) -> list[dict[str, object]]:
+    raw_rooms = payload.get("rooms")
+    rooms: list[dict[str, object]] = []
+    if isinstance(raw_rooms, list):
+        for room in raw_rooms:
+            if isinstance(room, dict):
+                rooms.append(room)
+    elif isinstance(raw_rooms, dict):
+        for room_name, room in raw_rooms.items():
+            if isinstance(room, dict):
+                normalized = dict(room)
+                normalized.setdefault("roomName", room_name)
+                rooms.append(normalized)
+    elif text_value(payload.get("roomName")):
+        rooms.append(payload)
+    return rooms
+
+
+def process_top_level_runtime_metrics(
+    conn: sqlite3.Connection,
+    payload: dict[str, object],
+    source_artifact: str,
+    tick: int | None,
+    shard: str | None,
+) -> None:
+    observed = {
+        "cpu.bucket": first_number(payload, (("cpu", "bucket"), ("cpuBucket",))),
+        "cpu.used": first_number(payload, (("cpu", "used"), ("cpuUsed",))),
+        "reliability.loop_exception_count": first_number(
+            payload,
+            (("reliability", "loopExceptionCount"), ("loopExceptionCount",)),
+        ),
+        "reliability.telemetry_silence_ticks": first_number(
+            payload,
+            (("reliability", "telemetrySilenceTicks"), ("telemetrySilenceTicks",)),
+        ),
+    }
+    for metric_name, value in observed.items():
+        if value is None:
+            record_coverage_gap(
+                conn,
+                metric_name=metric_name,
+                category="CPU/reliability",
+                severity="info",
+                source_artifact=source_artifact,
+                tick=tick,
+                gap_type="missing_field",
+                message=f"{metric_name} was not present in runtime summary",
+            )
+        else:
+            record_observation(
+                conn,
+                metric_name,
+                value,
+                source_artifact=source_artifact,
+                tick=tick,
+                shard=shard,
+            )
+            if metric_name == "reliability.loop_exception_count" and value > 0:
+                record_finding(
+                    conn,
+                    finding_key=f"loop-exceptions:{tick}",
+                    category="runtime-reliability",
+                    severity="critical",
+                    metric_name=metric_name,
+                    source_artifact=source_artifact,
+                    tick=tick,
+                    evidence={"loopExceptionCount": value},
+                    recommendation="Fix tick-loop exceptions before trusting gameplay behavior metrics.",
+                    promotion_state="promote-immediately",
+                )
+
+
+def process_runtime_room(
+    conn: sqlite3.Connection,
+    payload: dict[str, object],
+    room: dict[str, object],
+    source_artifact: str,
+    tick: int | None,
+    shard: str | None,
+    line_number: int | None,
+) -> None:
+    del payload
+    room_name = text_value(room.get("roomName")) or text_value(room.get("name")) or "unknown"
+    spawn_count = room_spawn_count(room)
+    worker_count = room_worker_count(room)
+    task_counts = room_task_counts(room)
+    build_tasks = task_count(task_counts, "build")
+    upgrade_tasks = task_count(task_counts, "upgrade")
+    construction_backlog = construction_backlog_progress(room)
+    built_progress = built_progress_value(room)
+    build_carried_energy = build_carried_energy_value(room)
+    hostile_count = hostile_creep_count(room)
+    tower_count = structure_count(room, ("tower", "towers"))
+    rampart_count = structure_count(room, ("rampart", "ramparts"))
+    defense_backlog = defense_backlog_value(room, construction_backlog)
+
+    record_number_if_present(
+        conn,
+        "survival.owned_spawns",
+        spawn_count,
+        source_artifact,
+        tick,
+        shard,
+        room_name,
+        {"line": line_number},
+    )
+    record_number_if_present(conn, "creep.worker_count", worker_count, source_artifact, tick, shard, room_name, {})
+    record_number_if_present(
+        conn,
+        "construction.backlog_progress",
+        construction_backlog,
+        source_artifact,
+        tick,
+        shard,
+        room_name,
+        {},
+    )
+    record_number_if_present(
+        conn,
+        "construction.build_task_count",
+        build_tasks,
+        source_artifact,
+        tick,
+        shard,
+        room_name,
+        {"taskCounts": task_counts},
+    )
+    record_number_if_present(
+        conn,
+        "construction.built_progress",
+        built_progress,
+        source_artifact,
+        tick,
+        shard,
+        room_name,
+        {},
+    )
+    record_number_if_present(
+        conn,
+        "construction.build_carried_energy",
+        build_carried_energy,
+        source_artifact,
+        tick,
+        shard,
+        room_name,
+        {},
+    )
+    record_number_if_present(
+        conn,
+        "construction.defense_backlog",
+        defense_backlog,
+        source_artifact,
+        tick,
+        shard,
+        room_name,
+        {},
+    )
+    record_number_if_present(conn, "defense.hostile_creep_count", hostile_count, source_artifact, tick, shard, room_name, {})
+    record_number_if_present(conn, "defense.tower_count", tower_count, source_artifact, tick, shard, room_name, {})
+    record_number_if_present(conn, "defense.rampart_count", rampart_count, source_artifact, tick, shard, room_name, {})
+
+    process_energy_metrics(conn, room, source_artifact, tick, shard, room_name)
+    process_low_load_metrics(conn, room, source_artifact, tick, shard, room_name)
+    process_stuck_idle_metrics(conn, room, source_artifact, tick, shard, room_name)
+    process_upgrade_dominance(
+        conn,
+        room,
+        source_artifact,
+        tick,
+        shard,
+        room_name,
+        worker_count,
+        upgrade_tasks,
+        construction_backlog,
+        defense_backlog,
+        hostile_count,
+    )
+    process_construction_findings(
+        conn,
+        room,
+        source_artifact,
+        tick,
+        room_name,
+        construction_backlog,
+        build_tasks,
+        built_progress,
+        build_carried_energy,
+        defense_backlog,
+    )
+    process_defense_findings(
+        conn,
+        room,
+        source_artifact,
+        tick,
+        room_name,
+        hostile_count,
+        tower_count,
+        rampart_count,
+        defense_backlog,
+        build_tasks,
+    )
+    process_expansion_spawn_findings(conn, room, source_artifact, tick, room_name, spawn_count)
+
+
+def record_number_if_present(
+    conn: sqlite3.Connection,
+    metric_name: str,
+    value: float | None,
+    source_artifact: str,
+    tick: int | None,
+    shard: str | None,
+    room_name: str,
+    evidence: object,
+) -> None:
+    if value is not None:
+        record_observation(
+            conn,
+            metric_name,
+            value,
+            source_artifact=source_artifact,
+            tick=tick,
+            shard=shard,
+            room_name=room_name,
+            evidence=evidence,
+        )
+
+
+def room_is_claimed(room: dict[str, object]) -> bool:
+    controller = as_dict(room.get("controller"))
+    if controller.get("my") is True:
+        return True
+    if text_value(controller.get("owner")) or text_value(controller.get("username")):
+        return True
+    return room.get("owned") is True or room.get("claimed") is True
+
+
+def room_spawn_count(room: dict[str, object]) -> float | None:
+    direct = first_number(
+        room,
+        (
+            ("spawnCount",),
+            ("ownedSpawnCount",),
+            ("ownedSpawns",),
+            ("spawns", "count"),
+            ("spawn", "total"),
+            ("structures", "spawn"),
+            ("structures", "spawns"),
+        ),
+    )
+    if direct is not None:
+        return direct
+    spawn_status = room.get("spawnStatus")
+    if isinstance(spawn_status, list):
+        return float(len(spawn_status))
+    spawns = room.get("spawns")
+    if isinstance(spawns, list):
+        return float(len(spawns))
+    return None
+
+
+def room_worker_count(room: dict[str, object]) -> float | None:
+    direct = first_number(
+        room,
+        (
+            ("workerCount",),
+            ("ownedCreeps",),
+            ("ownedCreepCount",),
+            ("creeps",),
+            ("creepCount",),
+            ("workers", "count"),
+        ),
+    )
+    if direct is not None:
+        return direct
+    creeps = room.get("creeps")
+    if isinstance(creeps, list):
+        return float(len(creeps))
+    return None
+
+
+def room_task_counts(room: dict[str, object]) -> dict[str, object]:
+    for candidate in (
+        room.get("taskCounts"),
+        nested_value(room, ("workers", "taskCounts")),
+        nested_value(room, ("behavior", "taskCounts")),
+        room.get("roleCounts"),
+    ):
+        if isinstance(candidate, dict):
+            return candidate
+    return {}
+
+
+def task_count(task_counts: dict[str, object], name: str) -> float | None:
+    value = number_value(task_counts.get(name))
+    if value is not None:
+        return value
+    for key, item in task_counts.items():
+        if str(key).lower() == name.lower():
+            return number_value(item)
+    return None
+
+
+def construction_backlog_progress(room: dict[str, object]) -> float | None:
+    direct = first_number(
+        room,
+        (
+            ("resources", "productiveEnergy", "pendingBuildProgress"),
+            ("resources", "pendingBuildProgress"),
+            ("construction", "pendingBuildProgress"),
+            ("construction", "backlogProgress"),
+            ("constructionBacklogProgress",),
+            ("backlog", "constructionProgress"),
+            ("pendingBuildProgress",),
+            ("constructionSiteProgressRemaining",),
+        ),
+    )
+    if direct is not None:
+        return direct
+    site_count = first_number(
+        room,
+        (
+            ("constructionSiteCount",),
+            ("construction", "siteCount"),
+            ("constructionSites", "count"),
+        ),
+    )
+    if site_count is not None and site_count > 0:
+        return site_count
+    priority_text = collect_text(room.get("constructionPriority"))
+    if contains_any(priority_text, ("build", "construction", "extension", "spawn", "tower", "rampart")):
+        return 1
+    return None
+
+
+def built_progress_value(room: dict[str, object]) -> float | None:
+    direct = first_number(
+        room,
+        (
+            ("resources", "productiveEnergy", "builtProgress"),
+            ("resources", "productiveEnergy", "builtProgressThisTick"),
+            ("resources", "events", "builtProgress"),
+            ("resources", "events", "buildProgress"),
+            ("construction", "builtProgress"),
+            ("construction", "builtProgressThisTick"),
+            ("buildProgress",),
+            ("builtProgress",),
+        ),
+    )
+    if direct is not None:
+        return direct
+    return find_first_number_by_keys(room, ("builtProgress", "buildProgressThisTick", "builtProgressThisTick"))
+
+
+def build_carried_energy_value(room: dict[str, object]) -> float | None:
+    return first_number(
+        room,
+        (
+            ("resources", "productiveEnergy", "buildCarriedEnergy"),
+            ("resources", "buildCarriedEnergy"),
+            ("construction", "buildCarriedEnergy"),
+            ("buildCarriedEnergy",),
+        ),
+    ) or find_first_number_by_keys(room, ("buildCarriedEnergy", "builderCarriedEnergy"))
+
+
+def hostile_creep_count(room: dict[str, object]) -> float | None:
+    return first_number(
+        room,
+        (
+            ("combat", "hostileCreepCount"),
+            ("hostileCreepCount",),
+            ("hostiles", "creeps"),
+            ("defense", "hostileCreepCount"),
+        ),
+    )
+
+
+def structure_count(room: dict[str, object], keys: tuple[str, ...]) -> float | None:
+    structures = as_dict(room.get("structures"))
+    for key in keys:
+        value = number_value(structures.get(key))
+        if value is not None:
+            return value
+        listed = structures.get(key)
+        if isinstance(listed, list):
+            return float(len(listed))
+    for key in keys:
+        value = first_number(room, ((f"{key}Count",), (key, "count")))
+        if value is not None:
+            return value
+    return None
+
+
+def defense_backlog_value(room: dict[str, object], construction_backlog: float | None) -> float | None:
+    direct = first_number(
+        room,
+        (
+            ("defense", "backlog"),
+            ("defense", "constructionBacklog"),
+            ("defenseBacklog",),
+            ("construction", "defenseBacklog"),
+        ),
+    )
+    if direct is not None:
+        return direct
+    priority_text = collect_text(room.get("constructionPriority"))
+    if contains_any(priority_text, ("tower", "rampart", "defense", "wall")):
+        return construction_backlog if construction_backlog is not None else 1
+    return None
+
+
+def process_energy_metrics(
+    conn: sqlite3.Connection,
+    room: dict[str, object],
+    source_artifact: str,
+    tick: int | None,
+    shard: str | None,
+    room_name: str,
+) -> None:
+    energy_available = first_number(room, (("energyAvailable",), ("energy", "available")))
+    stored_energy = first_number(room, (("resources", "storedEnergy"), ("storedEnergy",), ("storage", "energy")))
+    worker_carried = first_number(
+        room,
+        (("resources", "workerCarriedEnergy"), ("workerCarriedEnergy",), ("workers", "carriedEnergy")),
+    )
+    values = {
+        "economy.energy_available": energy_available,
+        "economy.stored_energy": stored_energy,
+        "economy.worker_carried_energy": worker_carried,
+    }
+    present = [name for name, value in values.items() if value is not None]
+    for metric_name, value in values.items():
+        if value is not None:
+            record_observation(
+                conn,
+                metric_name,
+                value,
+                source_artifact=source_artifact,
+                tick=tick,
+                shard=shard,
+                room_name=room_name,
+                unit="energy",
+            )
+    if present:
+        record_observation(
+            conn,
+            "economy.energy_telemetry",
+            1,
+            source_artifact=source_artifact,
+            tick=tick,
+            shard=shard,
+            room_name=room_name,
+            evidence={"presentMetrics": present},
+        )
+    else:
+        record_coverage_gap(
+            conn,
+            metric_name="economy.energy_telemetry",
+            category="resource economy",
+            severity="critical",
+            source_artifact=source_artifact,
+            tick=tick,
+            room_name=room_name,
+            gap_type="missing_energy_fields",
+            message="no energyAvailable, storedEnergy, or workerCarriedEnergy fields were present",
+        )
+
+
+def process_low_load_metrics(
+    conn: sqlite3.Connection,
+    room: dict[str, object],
+    source_artifact: str,
+    tick: int | None,
+    shard: str | None,
+    room_name: str,
+) -> None:
+    low_count = first_number(
+        room,
+        (
+            ("behavior", "lowLoadReturnCount"),
+            ("workerEfficiency", "lowLoadReturnCount"),
+            ("lowLoadReturnCount",),
+            ("lowLoadReturns",),
+        ),
+    )
+    return_energy = first_number(
+        room,
+        (
+            ("behavior", "lastReturnEnergy"),
+            ("workerEfficiency", "lastReturnEnergy"),
+            ("lastReturnEnergy",),
+            ("returnEnergy",),
+            ("returnedEnergy",),
+            ("lowLoadReturnEnergy",),
+        ),
+    )
+    return_capacity = first_number(
+        room,
+        (
+            ("behavior", "returnCapacity"),
+            ("workerEfficiency", "returnCapacity"),
+            ("returnCapacity",),
+            ("carryCapacity",),
+            ("returnedCapacity",),
+        ),
+    )
+    load_factor = first_number(
+        room,
+        (
+            ("behavior", "returnLoadFactor"),
+            ("workerEfficiency", "returnLoadFactor"),
+            ("returnLoadFactor",),
+            ("workerReturnLoadFactor",),
+            ("loadFactor",),
+        ),
+    )
+    if load_factor is None and return_energy is not None and return_capacity is not None and return_capacity > 0:
+        load_factor = round(return_energy / return_capacity, 4)
+    if low_count is None and load_factor is not None and load_factor <= 0.10:
+        low_count = 1
+
+    if low_count is None and load_factor is None:
+        record_coverage_gap(
+            conn,
+            metric_name="creep.low_load_return_count",
+            category="creep efficiency",
+            severity="warning",
+            source_artifact=source_artifact,
+            tick=tick,
+            room_name=room_name,
+            gap_type="missing_low_load_return_fields",
+            message="low-load return/load-factor fields were not present",
+        )
+        return
+
+    if low_count is not None:
+        record_observation(
+            conn,
+            "creep.low_load_return_count",
+            low_count,
+            source_artifact=source_artifact,
+            tick=tick,
+            shard=shard,
+            room_name=room_name,
+            evidence={"returnEnergy": return_energy, "returnCapacity": return_capacity, "loadFactor": load_factor},
+        )
+    if load_factor is not None:
+        record_observation(
+            conn,
+            "creep.return_load_factor",
+            load_factor,
+            source_artifact=source_artifact,
+            tick=tick,
+            shard=shard,
+            room_name=room_name,
+            evidence={"returnEnergy": return_energy, "returnCapacity": return_capacity},
+        )
+
+    if (low_count is not None and low_count > 0) or (load_factor is not None and load_factor <= 0.10):
+        record_finding(
+            conn,
+            finding_key=f"low-load-return:{room_name}:{tick}",
+            category="low-load-return",
+            severity="warning",
+            metric_name="creep.low_load_return_count",
+            source_artifact=source_artifact,
+            tick=tick,
+            room_name=room_name,
+            evidence={
+                "lowLoadReturnCount": low_count,
+                "returnEnergy": return_energy,
+                "returnCapacity": return_capacity,
+                "loadFactor": load_factor,
+            },
+            recommendation="Audit worker return/transfer selection and suppress low-load trips outside emergency recovery.",
+        )
+
+
+def process_stuck_idle_metrics(
+    conn: sqlite3.Connection,
+    room: dict[str, object],
+    source_artifact: str,
+    tick: int | None,
+    shard: str | None,
+    room_name: str,
+) -> None:
+    idle_count = first_number(
+        room,
+        (("behavior", "idleCount"), ("behavior", "idleTicks"), ("idleCount",), ("idleTicks",)),
+    )
+    stuck_ticks = first_number(
+        room,
+        (
+            ("behavior", "stuckTicks"),
+            ("behavior", "actionlessTicks"),
+            ("stuckTicks",),
+            ("actionlessTicks",),
+            ("stuckCreepCount",),
+        ),
+    )
+    if idle_count is not None:
+        record_observation(
+            conn,
+            "creep.idle_count",
+            idle_count,
+            source_artifact=source_artifact,
+            tick=tick,
+            shard=shard,
+            room_name=room_name,
+        )
+    if stuck_ticks is not None:
+        record_observation(
+            conn,
+            "creep.stuck_ticks",
+            stuck_ticks,
+            source_artifact=source_artifact,
+            tick=tick,
+            shard=shard,
+            room_name=room_name,
+        )
+    if idle_count is None and stuck_ticks is None:
+        record_coverage_gap(
+            conn,
+            metric_name="creep.stuck_ticks",
+            category="creep efficiency",
+            severity="warning",
+            source_artifact=source_artifact,
+            tick=tick,
+            room_name=room_name,
+            gap_type="missing_stuck_actionless_fields",
+            message="idle/stuck/actionless fields were not present",
+        )
+    if stuck_ticks is not None and stuck_ticks >= 50:
+        record_finding(
+            conn,
+            finding_key=f"stuck-actionless:{room_name}:{tick}",
+            category="stuck-actionless",
+            severity="critical",
+            metric_name="creep.stuck_ticks",
+            source_artifact=source_artifact,
+            tick=tick,
+            room_name=room_name,
+            evidence={"stuckTicks": stuck_ticks, "idleCount": idle_count},
+            recommendation="Inspect creep task/path state and add recovery for long actionless windows.",
+            promotion_state="promote-if-repeated",
+        )
+
+
+def process_upgrade_dominance(
+    conn: sqlite3.Connection,
+    room: dict[str, object],
+    source_artifact: str,
+    tick: int | None,
+    shard: str | None,
+    room_name: str,
+    worker_count: float | None,
+    upgrade_tasks: float | None,
+    construction_backlog: float | None,
+    defense_backlog: float | None,
+    hostile_count: float | None,
+) -> None:
+    if worker_count is None or worker_count <= 0 or upgrade_tasks is None:
+        return
+    ratio = round(upgrade_tasks / worker_count, 4)
+    record_observation(
+        conn,
+        "behavior.upgrade_dominance_ratio",
+        ratio,
+        source_artifact=source_artifact,
+        tick=tick,
+        shard=shard,
+        room_name=room_name,
+        evidence={"workerCount": worker_count, "upgradeTasks": upgrade_tasks},
+    )
+    urgent_backlog = (construction_backlog is not None and construction_backlog > 0) or (
+        defense_backlog is not None and defense_backlog > 0
+    ) or (hostile_count is not None and hostile_count > 0)
+    if ratio >= 0.60 and urgent_backlog:
+        record_finding(
+            conn,
+            finding_key=f"upgrade-dominant:{room_name}:{tick}",
+            category="upgrade-dominant-backlog",
+            severity="warning",
+            metric_name="behavior.upgrade_dominance_ratio",
+            source_artifact=source_artifact,
+            tick=tick,
+            room_name=room_name,
+            evidence={
+                "upgradeDominanceRatio": ratio,
+                "constructionBacklog": construction_backlog,
+                "defenseBacklog": defense_backlog,
+                "hostileCreepCount": hostile_count,
+            },
+            recommendation="Reduce upgrade assignment while capacity, defense, or construction backlog remains.",
+        )
+
+
+def process_construction_findings(
+    conn: sqlite3.Connection,
+    room: dict[str, object],
+    source_artifact: str,
+    tick: int | None,
+    room_name: str,
+    construction_backlog: float | None,
+    build_tasks: float | None,
+    built_progress: float | None,
+    build_carried_energy: float | None,
+    defense_backlog: float | None,
+) -> None:
+    if construction_backlog is None or construction_backlog <= 0:
+        return
+    if built_progress is None:
+        record_coverage_gap(
+            conn,
+            metric_name="construction.built_progress",
+            category="construction/infrastructure",
+            severity="warning",
+            source_artifact=source_artifact,
+            tick=tick,
+            room_name=room_name,
+            gap_type="missing_build_progress",
+            message="construction backlog exists but build progress telemetry is missing",
+        )
+    if build_carried_energy is None:
+        record_coverage_gap(
+            conn,
+            metric_name="construction.build_carried_energy",
+            category="construction/infrastructure",
+            severity="warning",
+            source_artifact=source_artifact,
+            tick=tick,
+            room_name=room_name,
+            gap_type="missing_build_carried_energy",
+            message="construction backlog exists but build-carried energy telemetry is missing",
+        )
+
+    build_zero = build_tasks == 0 or build_tasks is None
+    progress_zero = built_progress == 0 or built_progress is None
+    build_energy_zero = build_carried_energy == 0 or build_carried_energy is None
+    if build_zero and progress_zero and build_energy_zero:
+        high_urgency = defense_backlog is not None and defense_backlog > 0
+        priority_text = collect_text(room.get("constructionPriority"))
+        if contains_any(priority_text, ("high", "urgent", "tower", "rampart", "defense")):
+            high_urgency = True
+        record_finding(
+            conn,
+            finding_key=f"build-zero-with-backlog:{room_name}:{tick}",
+            category="stalled-construction",
+            severity="critical" if high_urgency else "warning",
+            metric_name="construction.backlog_progress",
+            source_artifact=source_artifact,
+            tick=tick,
+            room_name=room_name,
+            evidence={
+                "constructionBacklog": construction_backlog,
+                "buildTaskCount": build_tasks,
+                "builtProgress": built_progress,
+                "buildCarriedEnergy": build_carried_energy,
+                "defenseBacklog": defense_backlog,
+            },
+            recommendation="Assign builder work or clear stale construction plans when backlog cannot progress.",
+            promotion_state="promote-if-repeated-or-severe",
+        )
+
+
+def process_defense_findings(
+    conn: sqlite3.Connection,
+    room: dict[str, object],
+    source_artifact: str,
+    tick: int | None,
+    room_name: str,
+    hostile_count: float | None,
+    tower_count: float | None,
+    rampart_count: float | None,
+    defense_backlog: float | None,
+    build_tasks: float | None,
+) -> None:
+    threatened = hostile_count is not None and hostile_count > 0
+    defense_pending = defense_backlog is not None and defense_backlog > 0
+    if not threatened and not defense_pending:
+        return
+    if tower_count is None and rampart_count is None:
+        record_coverage_gap(
+            conn,
+            metric_name="defense.tower_count",
+            category="defense readiness",
+            severity="critical" if threatened else "warning",
+            source_artifact=source_artifact,
+            tick=tick,
+            room_name=room_name,
+            gap_type="missing_defense_infra_fields",
+            message="threat/defense backlog exists but tower/rampart telemetry is missing",
+        )
+        return
+    missing_tower = tower_count is not None and tower_count <= 0
+    missing_rampart = rampart_count is not None and rampart_count <= 0
+    if missing_tower or (defense_pending and missing_rampart):
+        record_finding(
+            conn,
+            finding_key=f"missing-defense-infra:{room_name}:{tick}",
+            category="missing-late-defense-construction",
+            severity="critical" if threatened else "warning",
+            metric_name="construction.defense_backlog",
+            source_artifact=source_artifact,
+            tick=tick,
+            room_name=room_name,
+            evidence={
+                "hostileCreepCount": hostile_count,
+                "towerCount": tower_count,
+                "rampartCount": rampart_count,
+                "defenseBacklog": defense_backlog,
+                "buildTaskCount": build_tasks,
+            },
+            recommendation="Prioritize tower/rampart/defense construction before discretionary upgrade work.",
+            promotion_state="promote-if-severe-or-repeated",
+        )
+
+
+def process_expansion_spawn_findings(
+    conn: sqlite3.Connection,
+    room: dict[str, object],
+    source_artifact: str,
+    tick: int | None,
+    room_name: str,
+    spawn_count: float | None,
+) -> None:
+    if not room_is_claimed(room) or spawn_count != 0:
+        return
+    claim_age = first_number(
+        room,
+        (
+            ("ticksSinceClaim",),
+            ("claimAgeTicks",),
+            ("claimedAgeTicks",),
+            ("roomClaimAge",),
+            ("ageTicks",),
+            ("territory", "claimAgeTicks"),
+        ),
+    )
+    if claim_age is None:
+        record_coverage_gap(
+            conn,
+            metric_name="survival.claimed_room_without_spawn_age_ticks",
+            category="survival/ownership",
+            severity="warning",
+            source_artifact=source_artifact,
+            tick=tick,
+            room_name=room_name,
+            gap_type="missing_claim_age",
+            message="claimed room has 0 spawns but claim age/grace telemetry is missing",
+        )
+        return
+    record_observation(
+        conn,
+        "survival.claimed_room_without_spawn_age_ticks",
+        claim_age,
+        source_artifact=source_artifact,
+        tick=tick,
+        room_name=room_name,
+        unit="ticks",
+        evidence={"spawnCount": spawn_count, "graceTicks": EXPANSION_SPAWN_GRACE_TICKS},
+    )
+    if claim_age >= EXPANSION_SPAWN_GRACE_TICKS:
+        record_finding(
+            conn,
+            finding_key=f"claimed-room-zero-spawns:{room_name}:{tick}",
+            category="claimed-expansion-zero-spawn",
+            severity="critical",
+            metric_name="survival.claimed_room_without_spawn_age_ticks",
+            source_artifact=source_artifact,
+            tick=tick,
+            room_name=room_name,
+            evidence={"claimAgeTicks": claim_age, "spawnCount": spawn_count, "graceTicks": EXPANSION_SPAWN_GRACE_TICKS},
+            recommendation="Recover expansion spawn construction or abandon/demote the failed claim.",
+            promotion_state="promote-immediately",
+        )
+
+
+def process_dataset_gate(
+    conn: sqlite3.Connection,
+    payload: dict[str, object],
+    source_artifact: str,
+    stats: dict[str, int],
+) -> None:
+    gate_id = text_value(payload.get("gateId"))
+    dataset_gate = as_dict(payload.get("datasetGate"))
+    quality = as_dict(payload.get("quality_checks")) or as_dict(payload.get("qualityChecks"))
+    status = (
+        text_value(dataset_gate.get("status"))
+        or text_value(payload.get("datasetGateStatus"))
+        or ("pass" if payload.get("ok") is True else "fail" if payload.get("ok") is False else "unknown")
+    )
+    status_value = 1 if status == "pass" else 0 if status in ("fail", "error") else None
+    record_dataset_gate_metric(
+        conn,
+        gate_id=gate_id,
+        status=status,
+        metric_name="rl.dataset_gate.status",
+        value=status_value,
+        source_artifact=source_artifact,
+        evidence={"gateId": gate_id, "status": status},
+    )
+    for metric_name, value in (
+        ("rl.dataset_gate.sample_count", dataset_gate.get("sampleCount") or payload.get("sampleCount")),
+        ("rl.dataset_gate.quality_samples_rejected", quality.get("samples_rejected")),
+        ("rl.dataset_gate.quality_samples_accepted", quality.get("samples_accepted")),
+    ):
+        numeric = number_value(value)
+        if numeric is not None:
+            record_dataset_gate_metric(
+                conn,
+                gate_id=gate_id,
+                status=status,
+                metric_name=metric_name,
+                value=numeric,
+                source_artifact=source_artifact,
+            )
+    if status == "fail" or number_value(quality.get("samples_rejected")) not in (None, 0):
+        record_finding(
+            conn,
+            finding_key=f"rl-dataset-gate-rejected:{gate_id or source_artifact}",
+            category="rl-gate-rejection",
+            severity="warning",
+            metric_name="rl.dataset_gate.status",
+            source_artifact=source_artifact,
+            evidence={
+                "gateId": gate_id,
+                "status": status,
+                "qualitySamplesRejected": quality.get("samples_rejected"),
+                "blockingReasons": payload.get("blockingReasons"),
+            },
+            recommendation="Inspect rejected RL samples/gate checks before training or rollout advances.",
+            promotion_state="promote-if-repeated",
+        )
+    stats["dataset_gate_artifacts"] += 1
+
+
+def process_training_report(
+    conn: sqlite3.Connection,
+    payload: dict[str, object],
+    source_artifact: str,
+    stats: dict[str, int],
+) -> None:
+    report_id = text_value(payload.get("reportId"))
+    for result in as_list(payload.get("variantResults")):
+        if not isinstance(result, dict):
+            continue
+        variant_id = text_value(result.get("variantId"))
+        sample_count = number_value(result.get("sampleCount"))
+        record_training_metric(
+            conn,
+            report_id=report_id,
+            variant_id=variant_id,
+            metric_name="rl.training.execution_sample_count",
+            value=sample_count,
+            source_artifact=source_artifact,
+        )
+        reward = as_dict(result.get("reward"))
+        reward_tuple = as_list(reward.get("tuple"))
+        for index, metric_name in enumerate(
+            (
+                "rl.training.reward_territory",
+                "rl.training.reward_resources",
+                "rl.training.reward_kills",
+            )
+        ):
+            if index < len(reward_tuple):
+                record_training_metric(
+                    conn,
+                    report_id=report_id,
+                    variant_id=variant_id,
+                    metric_name=metric_name,
+                    value=number_value(reward_tuple[index]),
+                    source_artifact=source_artifact,
+                    evidence={"rewardTuple": reward_tuple},
+                )
+
+    incumbent_ids = [item for item in as_list(payload.get("incumbentStrategyIds")) if isinstance(item, str)]
+    ranking = [item for item in as_list(payload.get("ranking")) if isinstance(item, dict)]
+    if ranking and incumbent_ids:
+        best = ranking[0]
+        candidate_id = text_value(best.get("variantId"))
+        best_tuple = reward_tuple_from_ranking_item(best)
+        incumbent = first_incumbent_ranking(ranking, incumbent_ids)
+        incumbent_tuple = reward_tuple_from_ranking_item(incumbent) if incumbent else []
+        for index, metric_name in enumerate(
+            (
+                "rl.policy.advantage_territory",
+                "rl.policy.advantage_resources",
+                "rl.policy.advantage_kills",
+            )
+        ):
+            if index < len(best_tuple) and index < len(incumbent_tuple):
+                record_policy_advantage(
+                    conn,
+                    report_id=report_id,
+                    candidate_id=candidate_id,
+                    incumbent_id=text_value(incumbent.get("variantId")) if incumbent else None,
+                    metric_name=metric_name,
+                    value=number_value(best_tuple[index]) - number_value(incumbent_tuple[index]),
+                    directionality="higher is better",
+                    source_artifact=source_artifact,
+                    evidence={"bestRewardTuple": best_tuple, "incumbentRewardTuple": incumbent_tuple},
+                )
+    for metric_name, raw_value in (
+        ("rl.training.changed_top_count", payload.get("changedTopCount")),
+        ("rl.training.ranking_diff_count", payload.get("rankingDiffCount")),
+    ):
+        value = number_value(raw_value)
+        if value is not None:
+            record_training_metric(
+                conn,
+                report_id=report_id,
+                variant_id=None,
+                metric_name=metric_name,
+                value=value,
+                source_artifact=source_artifact,
+            )
+    stats["training_artifacts"] += 1
+
+
+def reward_tuple_from_ranking_item(item: dict[str, object] | None) -> list[float]:
+    if not isinstance(item, dict):
+        return []
+    raw_tuple = as_list(item.get("rewardTuple"))
+    if not raw_tuple:
+        raw_tuple = as_list(as_dict(item.get("reward")).get("tuple"))
+    values: list[float] = []
+    for raw_value in raw_tuple:
+        value = number_value(raw_value)
+        if value is not None:
+            values.append(value)
+    return values
+
+
+def first_incumbent_ranking(ranking: list[dict[str, object]], incumbent_ids: list[str]) -> dict[str, object] | None:
+    for item in ranking:
+        if text_value(item.get("variantId")) in incumbent_ids:
+            return item
+    return None
+
+
+def process_iteration_payload(
+    conn: sqlite3.Connection,
+    payload: dict[str, object],
+    source_artifact: str,
+    stats: dict[str, int],
+) -> None:
+    decision = text_value(payload.get("decision")) or text_value(payload.get("status")) or "observed"
+    decision_key = (
+        text_value(payload.get("decisionId"))
+        or text_value(payload.get("rolloutId"))
+        or text_value(payload.get("candidateId"))
+        or f"decision:{source_artifact}"
+    )
+    blocking = as_list(payload.get("blockingReasons"))
+    rationale = "decision artifact ingested"
+    if blocking:
+        rationale = "decision has blocking reasons"
+    record_iteration_decision(
+        conn,
+        decision_key=decision_key,
+        status=decision,
+        source_artifact=source_artifact,
+        rationale=rationale,
+        evidence={"blockingReasons": blocking[:10], "feedbackIngestion": payload.get("feedbackIngestion")},
+    )
+    stats["iteration_decisions"] += 1
+
+
+def summarize_database(db_path: Path, output_format: str = "text") -> str:
+    initialize_database(db_path)
+    with connect_database(db_path) as conn:
+        counts = {}
+        for table in (
+            "metric_definitions",
+            "metric_observations",
+            "gameplay_behavior_findings",
+            "metric_coverage_gaps",
+            "rl_dataset_gate_metrics",
+            "rl_training_execution_metrics",
+            "rl_policy_advantage_metrics",
+            "metric_iteration_decisions",
+        ):
+            counts[table] = int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+        severity_rows = conn.execute(
+            """
+            SELECT severity, COUNT(*) AS count
+            FROM gameplay_behavior_findings
+            GROUP BY severity
+            ORDER BY severity
+            """
+        ).fetchall()
+        gap_rows = conn.execute(
+            """
+            SELECT metric_name, COUNT(*) AS count
+            FROM metric_coverage_gaps
+            GROUP BY metric_name
+            ORDER BY count DESC, metric_name
+            LIMIT 10
+            """
+        ).fetchall()
+
+    if output_format == "json":
+        return json.dumps(
+            {
+                "db": str(db_path),
+                "counts": counts,
+                "findingsBySeverity": {row["severity"]: row["count"] for row in severity_rows},
+                "topCoverageGaps": {row["metric_name"]: row["count"] for row in gap_rows},
+            },
+            indent=2,
+            sort_keys=True,
+        )
+
+    lines = [f"RL metrics DB: {db_path}"]
+    for table, count in counts.items():
+        lines.append(f"{table}: {count}")
+    if severity_rows:
+        lines.append("findings_by_severity:")
+        for row in severity_rows:
+            lines.append(f"  {row['severity']}: {row['count']}")
+    if gap_rows:
+        lines.append("top_coverage_gaps:")
+        for row in gap_rows:
+            lines.append(f"  {row['metric_name']}: {row['count']}")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Ingest Screeps RL gameplay metrics into SQLite.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="initialize the metrics SQLite schema")
+    init_parser.add_argument("--db", type=Path, default=DEFAULT_DB_PATH)
+
+    ingest_parser = subparsers.add_parser("ingest-artifacts", help="ingest local runtime/RL artifact files")
+    ingest_parser.add_argument("paths", nargs="*", type=Path, help="artifact files/directories to scan")
+    ingest_parser.add_argument("--db", type=Path, default=DEFAULT_DB_PATH)
+    ingest_parser.add_argument("--max-file-bytes", type=int, default=DEFAULT_MAX_FILE_BYTES)
+
+    summarize_parser = subparsers.add_parser("summarize", help="summarize stored metrics")
+    summarize_parser.add_argument("--db", type=Path, default=DEFAULT_DB_PATH)
+    summarize_parser.add_argument("--format", choices=("text", "json"), default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "init":
+        result = initialize_database(args.db)
+        print(json.dumps({"ok": True, "db": str(args.db), **result}, sort_keys=True))
+        return 0
+    if args.command == "ingest-artifacts":
+        result = ingest_artifacts(args.db, args.paths, max_file_bytes=args.max_file_bytes)
+        print(json.dumps({"ok": True, "db": str(args.db), **result}, sort_keys=True))
+        return 0
+    if args.command == "summarize":
+        print(summarize_database(args.db, output_format=args.format))
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_screeps_rl_metrics_ingestor.py
+++ b/scripts/test_screeps_rl_metrics_ingestor.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import screeps_rl_metrics_ingestor as ingestor
+
+
+JsonObject = dict[str, Any]
+
+
+def runtime_line(payload: JsonObject) -> str:
+    return f"#runtime-summary {json.dumps(payload, sort_keys=True)}\n"
+
+
+def write_runtime_artifact(root: Path, payload: JsonObject, name: str = "runtime.log") -> Path:
+    artifact_dir = root / "runtime-summary-console"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    artifact = artifact_dir / name
+    artifact.write_text(runtime_line(payload), encoding="utf-8")
+    return artifact_dir
+
+
+def fetch_count(db_path: Path, table: str, where: str = "", params: tuple[object, ...] = ()) -> int:
+    with sqlite3.connect(db_path) as conn:
+        query = f"SELECT COUNT(*) FROM {table} {where}"
+        return int(conn.execute(query, params).fetchone()[0])
+
+
+def runtime_payload(room: JsonObject) -> JsonObject:
+    return {
+        "type": "runtime-summary",
+        "tick": 12345,
+        "shard": "shardX",
+        "cpu": {"bucket": 9000, "used": 7.5},
+        "reliability": {"loopExceptionCount": 0, "telemetrySilenceTicks": 0},
+        "rooms": [room],
+    }
+
+
+class ScreepsRlMetricsIngestorTest(unittest.TestCase):
+    def test_schema_initialization_creates_required_tables_and_definitions(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "rl_metrics.sqlite"
+
+            result = ingestor.initialize_database(db_path)
+
+            self.assertGreaterEqual(result["metric_definitions"], 20)
+            with sqlite3.connect(db_path) as conn:
+                tables = {
+                    row[0]
+                    for row in conn.execute(
+                        "SELECT name FROM sqlite_master WHERE type='table'"
+                    ).fetchall()
+                }
+
+        self.assertIn("metric_definitions", tables)
+        self.assertIn("metric_observations", tables)
+        self.assertIn("gameplay_behavior_findings", tables)
+        self.assertIn("metric_coverage_gaps", tables)
+        self.assertIn("rl_dataset_gate_metrics", tables)
+        self.assertIn("rl_training_execution_metrics", tables)
+        self.assertIn("rl_policy_advantage_metrics", tables)
+        self.assertIn("metric_iteration_decisions", tables)
+
+    def test_ingests_runtime_summary_and_finds_build_zero_with_backlog(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            db_path = root / "rl_metrics.sqlite"
+            artifact_root = write_runtime_artifact(
+                root,
+                runtime_payload(
+                    {
+                        "roomName": "E26S49",
+                        "controller": {"my": True, "level": 3},
+                        "workerCount": 4,
+                        "spawnStatus": [{"name": "Spawn1", "status": "idle"}],
+                        "taskCounts": {"harvest": 1, "upgrade": 3, "build": 0},
+                        "energyAvailable": 300,
+                        "resources": {
+                            "storedEnergy": 800,
+                            "workerCarriedEnergy": 120,
+                            "productiveEnergy": {
+                                "pendingBuildProgress": 700,
+                                "builtProgress": 0,
+                                "buildCarriedEnergy": 0,
+                            },
+                        },
+                        "constructionPriority": {
+                            "nextPrimary": {
+                                "buildItem": "build tower",
+                                "urgency": "high",
+                            }
+                        },
+                        "combat": {"hostileCreepCount": 0},
+                        "structures": {"spawn": 1, "tower": 0, "rampart": 0},
+                    }
+                ),
+            )
+
+            stats = ingestor.ingest_artifacts(db_path, [artifact_root])
+
+            self.assertEqual(stats["runtime_summaries"], 1)
+            self.assertEqual(
+                fetch_count(
+                    db_path,
+                    "metric_observations",
+                    "WHERE metric_name = ?",
+                    ("construction.backlog_progress",),
+                ),
+                1,
+            )
+            self.assertEqual(
+                fetch_count(
+                    db_path,
+                    "gameplay_behavior_findings",
+                    "WHERE category = ? AND severity = ?",
+                    ("stalled-construction", "critical"),
+                ),
+                1,
+            )
+
+    def test_missing_energy_fields_record_coverage_gap_instead_of_crashing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            db_path = root / "rl_metrics.sqlite"
+            artifact_root = write_runtime_artifact(
+                root,
+                runtime_payload(
+                    {
+                        "roomName": "E26S49",
+                        "controller": {"my": True, "level": 2},
+                        "workerCount": 1,
+                        "spawnStatus": [{"name": "Spawn1", "status": "idle"}],
+                        "taskCounts": {"harvest": 1},
+                    }
+                ),
+            )
+
+            ingestor.ingest_artifacts(db_path, [artifact_root])
+
+            self.assertEqual(
+                fetch_count(
+                    db_path,
+                    "metric_coverage_gaps",
+                    "WHERE metric_name = ? AND gap_type = ?",
+                    ("economy.energy_telemetry", "missing_energy_fields"),
+                ),
+                1,
+            )
+
+    def test_low_load_return_metric_creates_behavior_finding(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            db_path = root / "rl_metrics.sqlite"
+            artifact_root = write_runtime_artifact(
+                root,
+                runtime_payload(
+                    {
+                        "roomName": "E26S49",
+                        "controller": {"my": True, "level": 2},
+                        "workerCount": 2,
+                        "spawnStatus": [{"name": "Spawn1", "status": "idle"}],
+                        "taskCounts": {"harvest": 1, "transfer": 1},
+                        "energyAvailable": 250,
+                        "resources": {"storedEnergy": 400, "workerCarriedEnergy": 2},
+                        "behavior": {
+                            "lowLoadReturnCount": 1,
+                            "lastReturnEnergy": 2,
+                            "returnCapacity": 50,
+                        },
+                    }
+                ),
+            )
+
+            ingestor.ingest_artifacts(db_path, [artifact_root])
+
+            self.assertEqual(
+                fetch_count(
+                    db_path,
+                    "metric_observations",
+                    "WHERE metric_name = ?",
+                    ("creep.low_load_return_count",),
+                ),
+                1,
+            )
+            self.assertEqual(
+                fetch_count(
+                    db_path,
+                    "gameplay_behavior_findings",
+                    "WHERE category = ?",
+                    ("low-load-return",),
+                ),
+                1,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_screeps_rl_metrics_ingestor.py
+++ b/scripts/test_screeps_rl_metrics_ingestor.py
@@ -35,6 +35,10 @@ def fetch_count(db_path: Path, table: str, where: str = "", params: tuple[object
         return int(conn.execute(query, params).fetchone()[0])
 
 
+def table_counts(db_path: Path, tables: tuple[str, ...]) -> dict[str, int]:
+    return {table: fetch_count(db_path, table) for table in tables}
+
+
 def runtime_payload(room: JsonObject) -> JsonObject:
     return {
         "type": "runtime-summary",
@@ -61,6 +65,17 @@ class ScreepsRlMetricsIngestorTest(unittest.TestCase):
                         "SELECT name FROM sqlite_master WHERE type='table'"
                     ).fetchall()
                 }
+                metric_observation_columns = {
+                    row[1] for row in conn.execute("PRAGMA table_info(metric_observations)").fetchall()
+                }
+                dedupe_indexes = {
+                    table: {
+                        row[1]
+                        for row in conn.execute(f"PRAGMA index_list({table})").fetchall()
+                        if row[2]
+                    }
+                    for table in ingestor.DEDUPE_TABLE_KEYS
+                }
 
         self.assertIn("metric_definitions", tables)
         self.assertIn("metric_observations", tables)
@@ -70,6 +85,75 @@ class ScreepsRlMetricsIngestorTest(unittest.TestCase):
         self.assertIn("rl_training_execution_metrics", tables)
         self.assertIn("rl_policy_advantage_metrics", tables)
         self.assertIn("metric_iteration_decisions", tables)
+
+        self.assertIn("dedupe_key", metric_observation_columns)
+        for table in ingestor.DEDUPE_TABLE_KEYS:
+            self.assertIn(f"idx_{table}_dedupe_key", dedupe_indexes[table])
+
+    def test_reingesting_nullable_key_runtime_artifact_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            db_path = root / "rl_metrics.sqlite"
+            artifact_root = write_runtime_artifact(
+                root,
+                {
+                    "type": "runtime-summary",
+                    "shard": "shardX",
+                    "cpu": {"bucket": 9000, "used": 7.5},
+                    "rooms": [
+                        {
+                            "roomName": "E26S49",
+                            "controller": {"my": True, "level": 2},
+                            "workerCount": 2,
+                            "spawnStatus": [{"name": "Spawn1", "status": "idle"}],
+                            "taskCounts": {"harvest": 1},
+                            "behavior": {
+                                "lowLoadReturnCount": 1,
+                                "lastReturnEnergy": 2,
+                                "returnCapacity": 50,
+                            },
+                        }
+                    ],
+                },
+            )
+            tables = (
+                "metric_observations",
+                "gameplay_behavior_findings",
+                "metric_coverage_gaps",
+            )
+
+            ingestor.ingest_artifacts(db_path, [artifact_root])
+            first_counts = table_counts(db_path, tables)
+            ingestor.ingest_artifacts(db_path, [artifact_root])
+
+            self.assertEqual(table_counts(db_path, tables), first_counts)
+            self.assertEqual(
+                fetch_count(
+                    db_path,
+                    "metric_observations",
+                    "WHERE metric_name = ? AND tick IS NULL AND room_name IS NULL",
+                    ("survival.owned_rooms",),
+                ),
+                1,
+            )
+            self.assertEqual(
+                fetch_count(
+                    db_path,
+                    "gameplay_behavior_findings",
+                    "WHERE category = ? AND tick IS NULL",
+                    ("low-load-return",),
+                ),
+                1,
+            )
+            self.assertEqual(
+                fetch_count(
+                    db_path,
+                    "metric_coverage_gaps",
+                    "WHERE metric_name = ? AND gap_type = ? AND tick IS NULL",
+                    ("economy.energy_telemetry", "missing_energy_fields"),
+                ),
+                1,
+            )
 
     def test_ingests_runtime_summary_and_finds_build_zero_with_backlog(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

Implements the first gameplay metrics landing slice for #906:

- adds a durable RL gameplay metrics taxonomy covering survival, resources, construction, creep efficiency, spawn/body planning, defense, CPU/reliability, RL dataset/training/policy, strategy-quality, and monitor-quality meta-metrics
- adds a stdlib SQLite metrics ingestor with schema for metric definitions/observations, behavior findings, coverage gaps, dataset gates, training execution, policy advantage, and metric iteration decisions
- detects or records coverage gaps for owner-observed irrational behavior classes such as stalled construction with backlog, tiny-load returns, missing energy telemetry, and related behavior findings
- adds a Grafana dashboard JSON seed for the Check layer
- adds unit tests for schema, synthetic runtime ingestion, missing-field gaps, and low-load return findings

This does not modify production bot behavior or write to the official MMO.

## Verification

- `python3 -m py_compile scripts/screeps_rl_metrics_ingestor.py`
- `python3 -m unittest scripts/test_screeps_rl_metrics_ingestor.py`
- `python3 scripts/screeps_rl_metrics_ingestor.py init --db /tmp/rl_metrics_test.sqlite`
- `python3 scripts/screeps_rl_metrics_ingestor.py summarize --db /tmp/rl_metrics_test.sqlite`
- `python3 -m json.tool docs/ops/grafana/screeps-rl-gameplay-metrics.json >/dev/null`
- `git diff --check`

Refs #906
