### PR TITLE
fix(territory): ensure post-claim spawn placement executes for newly claimed rooms

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -11786,7 +11786,7 @@ var POST_CLAIM_DEFENSE_BARRIER_STAGE_ORDER = [
   "entranceWall"
 ];
 function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
-  var _a, _b;
+  var _a, _b, _c;
   if (!isNonEmptyString11(input.colony) || !isNonEmptyString11(input.roomName)) {
     return;
   }
@@ -11796,10 +11796,10 @@ function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
   }
   const gameTime = getGameTime15();
   const existing = getPostClaimBootstrapRecord(input.roomName);
-  const claimedAt = (existing == null ? void 0 : existing.status) === "ready" ? gameTime : (_a = existing == null ? void 0 : existing.claimedAt) != null ? _a : gameTime;
+  const claimedAt = (existing == null ? void 0 : existing.status) === "ready" ? gameTime : (_b = (_a = existing == null ? void 0 : existing.claimedAt) != null ? _a : input.claimedAt) != null ? _b : gameTime;
   const status = getRefreshedPostClaimBootstrapStatus(existing);
   const workerTarget = existing ? getPostClaimBootstrapWorkerTarget(existing) : POST_CLAIM_BOOTSTRAP_WORKER_TARGET;
-  const controllerId = (_b = input.controllerId) != null ? _b : existing == null ? void 0 : existing.controllerId;
+  const controllerId = (_c = input.controllerId) != null ? _c : existing == null ? void 0 : existing.controllerId;
   const record = {
     colony: input.colony,
     roomName: input.roomName,
@@ -37038,7 +37038,7 @@ function isNonEmptyString26(value) {
 // src/territory/claimedRoomBootstrapper.ts
 var ERR_NO_PATH_CODE7 = -2;
 function refreshClaimedRoomBootstrapperOwnership(telemetryEvents = []) {
-  var _a;
+  var _a, _b;
   const game = globalThis.Game;
   const rooms = game == null ? void 0 : game.rooms;
   const memory = getWritableBootstrapperMemory();
@@ -37058,7 +37058,7 @@ function refreshClaimedRoomBootstrapperOwnership(telemetryEvents = []) {
     if (detectedOwnedRoom) {
       detectedRoomNames.push(room.name);
     }
-    const claimedAt = detectedOwnedRoom ? getGameTime33() : (_a = previous == null ? void 0 : previous.claimedAt) != null ? _a : activePostClaimRecord == null ? void 0 : activePostClaimRecord.claimedAt;
+    const claimedAt = detectedOwnedRoom ? (_a = previous == null ? void 0 : previous.claimedAt) != null ? _a : getGameTime33() : (_b = previous == null ? void 0 : previous.claimedAt) != null ? _b : activePostClaimRecord == null ? void 0 : activePostClaimRecord.claimedAt;
     memory.rooms[room.name] = {
       roomName: room.name,
       owned,
@@ -37071,6 +37071,7 @@ function refreshClaimedRoomBootstrapperOwnership(telemetryEvents = []) {
         {
           colony: claimOriginColony,
           roomName: room.name,
+          ...claimedAt !== void 0 ? { claimedAt } : {},
           ...room.controller.id ? { controllerId: room.controller.id } : {}
         },
         telemetryEvents

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -37054,19 +37054,19 @@ function refreshClaimedRoomBootstrapperOwnership(telemetryEvents = []) {
     const previous = memory.rooms[room.name];
     const activePostClaimRecord = getActivePostClaimBootstrapRecord(room.name);
     const claimOriginColony = owned ? resolveClaimOriginColony(room, previous, activePostClaimRecord) : null;
-    const newlyClaimed = owned && !activePostClaimRecord && ((previous == null ? void 0 : previous.owned) === false || (previous == null ? void 0 : previous.owned) !== true && claimOriginColony !== null);
-    if (newlyClaimed) {
+    const detectedOwnedRoom = owned && !activePostClaimRecord && ((previous == null ? void 0 : previous.owned) === false || (previous == null ? void 0 : previous.owned) !== true && claimOriginColony !== null || (previous == null ? void 0 : previous.owned) === true && claimOriginColony !== null && isOwnedRoomMissingSpawn(room));
+    if (detectedOwnedRoom) {
       detectedRoomNames.push(room.name);
     }
-    const claimedAt = newlyClaimed ? getGameTime33() : (_a = previous == null ? void 0 : previous.claimedAt) != null ? _a : activePostClaimRecord == null ? void 0 : activePostClaimRecord.claimedAt;
+    const claimedAt = detectedOwnedRoom ? getGameTime33() : (_a = previous == null ? void 0 : previous.claimedAt) != null ? _a : activePostClaimRecord == null ? void 0 : activePostClaimRecord.claimedAt;
     memory.rooms[room.name] = {
       roomName: room.name,
       owned,
       updatedAt: getGameTime33(),
       ...claimedAt !== void 0 ? { claimedAt } : {},
-      ...newlyClaimed ? {} : (previous == null ? void 0 : previous.completedAt) !== void 0 ? { completedAt: previous.completedAt } : {}
+      ...detectedOwnedRoom ? {} : (previous == null ? void 0 : previous.completedAt) !== void 0 ? { completedAt: previous.completedAt } : {}
     };
-    if (newlyClaimed && claimOriginColony !== null) {
+    if (detectedOwnedRoom && claimOriginColony !== null) {
       recordPostClaimBootstrapClaimSuccess(
         {
           colony: claimOriginColony,
@@ -37078,6 +37078,23 @@ function refreshClaimedRoomBootstrapperOwnership(telemetryEvents = []) {
     }
   }
   return { detectedRoomNames };
+}
+function countExistingStructures2(room, globalName, fallback) {
+  return findRoomObjects28(room, "FIND_MY_STRUCTURES").filter(
+    (object) => matchesStructureType29(object.structureType, globalName, fallback)
+  ).length;
+}
+function findRoomObjects28(room, globalName) {
+  const findConstant = getGlobalNumber20(globalName);
+  if (findConstant === null || typeof room.find !== "function") {
+    return [];
+  }
+  try {
+    const result = room.find(findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return [];
+  }
 }
 function getWritableBootstrapperMemory() {
   const memory = globalThis.Memory;
@@ -37098,9 +37115,6 @@ function getActivePostClaimBootstrapRecord(roomName) {
   return isRecord31(record) && record.roomName === roomName && record.status !== "ready" ? record : null;
 }
 function resolveClaimOriginColony(room, previous, activePostClaimRecord) {
-  if ((previous == null ? void 0 : previous.owned) === true) {
-    return null;
-  }
   if (isNonEmptyString27(activePostClaimRecord == null ? void 0 : activePostClaimRecord.colony)) {
     return activePostClaimRecord.colony;
   }
@@ -37108,7 +37122,28 @@ function resolveClaimOriginColony(room, previous, activePostClaimRecord) {
   if (plannedClaimOrigin) {
     return plannedClaimOrigin;
   }
+  if ((previous == null ? void 0 : previous.owned) === true && !isOwnedRoomMissingSpawn(room)) {
+    return null;
+  }
   return selectNearestOwnedSpawnRoom(room.name);
+}
+function isOwnedRoomMissingSpawn(room) {
+  var _a, _b;
+  if (((_a = room.controller) == null ? void 0 : _a.my) !== true || ((_b = room.controller.level) != null ? _b : 0) < 1) {
+    return false;
+  }
+  return !hasOwnedSpawnInRoom2(room);
+}
+function hasOwnedSpawnInRoom2(room) {
+  var _a;
+  const spawns = (_a = globalThis.Game) == null ? void 0 : _a.spawns;
+  if (spawns && Object.values(spawns).some((spawn) => {
+    var _a2;
+    return ((_a2 = spawn == null ? void 0 : spawn.room) == null ? void 0 : _a2.name) === room.name;
+  })) {
+    return true;
+  }
+  return countExistingStructures2(room, "STRUCTURE_SPAWN", "spawn") > 0;
 }
 function getPlannedClaimOriginColony(roomName) {
   var _a, _b, _c, _d, _e;
@@ -37210,6 +37245,18 @@ function getRoomRouteDistance(fromRoom, toRoom) {
     }
   }
   return Number.POSITIVE_INFINITY;
+}
+function matchesStructureType29(actual, globalName, fallback) {
+  return actual === getStructureConstant5(globalName, fallback);
+}
+function getStructureConstant5(globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return (_a = constants[globalName]) != null ? _a : fallback;
+}
+function getGlobalNumber20(name) {
+  const value = globalThis[name];
+  return typeof value === "number" ? value : null;
 }
 function getGameTime33() {
   var _a;
@@ -37821,7 +37868,7 @@ function isActiveExpansionExecutorSpawn(spawn) {
   }
 }
 function hasExpansionExecutorActiveHostiles(room) {
-  return findRoomObjects28(room, getFindConstant10("FIND_HOSTILE_CREEPS")).length > 0 || findRoomObjects28(room, getFindConstant10("FIND_HOSTILE_STRUCTURES")).length > 0;
+  return findRoomObjects29(room, getFindConstant10("FIND_HOSTILE_CREEPS")).length > 0 || findRoomObjects29(room, getFindConstant10("FIND_HOSTILE_STRUCTURES")).length > 0;
 }
 function getExpansionExecutorThreatState(roomName, gameTime) {
   var _a, _b, _c, _d;
@@ -37907,7 +37954,7 @@ function getGameTime35() {
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
-function findRoomObjects28(room, findConstant) {
+function findRoomObjects29(room, findConstant) {
   if (typeof findConstant !== "number" || typeof room.find !== "function") {
     return [];
   }
@@ -39987,11 +40034,11 @@ function buildStrategyRecommendationRoomState(colony, creeps) {
       return creep.memory.colony === room.name || ((_a2 = creep.room) == null ? void 0 : _a2.name) === room.name;
     }
   );
-  const hostileCreeps = findRoomObjects29(room, "FIND_HOSTILE_CREEPS");
-  const hostileStructures = findRoomObjects29(room, "FIND_HOSTILE_STRUCTURES");
-  const ownedStructures = findRoomObjects29(room, "FIND_MY_STRUCTURES");
-  const constructionSites = findRoomObjects29(room, "FIND_MY_CONSTRUCTION_SITES");
-  const sources = findRoomObjects29(room, "FIND_SOURCES");
+  const hostileCreeps = findRoomObjects30(room, "FIND_HOSTILE_CREEPS");
+  const hostileStructures = findRoomObjects30(room, "FIND_HOSTILE_STRUCTURES");
+  const ownedStructures = findRoomObjects30(room, "FIND_MY_STRUCTURES");
+  const constructionSites = findRoomObjects30(room, "FIND_MY_CONSTRUCTION_SITES");
+  const sources = findRoomObjects30(room, "FIND_SOURCES");
   return {
     roomName: room.name,
     controllerLevel: (_a = room.controller) == null ? void 0 : _a.level,
@@ -40144,7 +40191,7 @@ function countVisibleOwnedRooms7() {
 }
 function countStructuresByType3(structures, globalName, fallback) {
   return structures.filter(
-    (structure) => isRecord37(structure) && matchesStructureType29(structure.structureType, globalName, fallback)
+    (structure) => isRecord37(structure) && matchesStructureType30(structure.structureType, globalName, fallback)
   ).length;
 }
 function estimateRepairBacklogHits(structures) {
@@ -40176,8 +40223,8 @@ function getEnergyInStore2(object) {
   }
   return finiteNumberOrZero(object.store[resourceEnergy]);
 }
-function findRoomObjects29(room, constantName) {
-  const findConstant = getGlobalNumber20(constantName);
+function findRoomObjects30(room, constantName) {
+  const findConstant = getGlobalNumber21(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
     return [];
@@ -40189,7 +40236,7 @@ function findRoomObjects29(room, constantName) {
     return [];
   }
 }
-function matchesStructureType29(value, globalName, fallback) {
+function matchesStructureType30(value, globalName, fallback) {
   const globalValue = globalThis[globalName];
   return value === globalValue || value === fallback;
 }
@@ -40197,7 +40244,7 @@ function getResourceEnergy() {
   const value = globalThis.RESOURCE_ENERGY;
   return value != null ? value : "energy";
 }
-function getGlobalNumber20(name) {
+function getGlobalNumber21(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }

--- a/prod/src/territory/claimedRoomBootstrapper.ts
+++ b/prod/src/territory/claimedRoomBootstrapper.ts
@@ -113,15 +113,17 @@ export function refreshClaimedRoomBootstrapperOwnership(
     const previous = memory.rooms[room.name];
     const activePostClaimRecord = getActivePostClaimBootstrapRecord(room.name);
     const claimOriginColony = owned ? resolveClaimOriginColony(room, previous, activePostClaimRecord) : null;
-    const newlyClaimed =
+    const detectedOwnedRoom =
       owned &&
       !activePostClaimRecord &&
-      (previous?.owned === false || (previous?.owned !== true && claimOriginColony !== null));
-    if (newlyClaimed) {
+      (previous?.owned === false ||
+        (previous?.owned !== true && claimOriginColony !== null) ||
+        (previous?.owned === true && claimOriginColony !== null && isOwnedRoomMissingSpawn(room)));
+    if (detectedOwnedRoom) {
       detectedRoomNames.push(room.name);
     }
 
-    const claimedAt = newlyClaimed
+    const claimedAt = detectedOwnedRoom
       ? getGameTime()
       : previous?.claimedAt ?? activePostClaimRecord?.claimedAt;
     memory.rooms[room.name] = {
@@ -129,10 +131,10 @@ export function refreshClaimedRoomBootstrapperOwnership(
       owned,
       updatedAt: getGameTime(),
       ...(claimedAt !== undefined ? { claimedAt } : {}),
-      ...(newlyClaimed ? {} : previous?.completedAt !== undefined ? { completedAt: previous.completedAt } : {})
+      ...(detectedOwnedRoom ? {} : previous?.completedAt !== undefined ? { completedAt: previous.completedAt } : {})
     };
 
-    if (newlyClaimed && claimOriginColony !== null) {
+    if (detectedOwnedRoom && claimOriginColony !== null) {
       recordPostClaimBootstrapClaimSuccess(
         {
           colony: claimOriginColony,
@@ -939,10 +941,6 @@ function resolveClaimOriginColony(
   previous: TerritoryClaimedRoomBootstrapMemory | undefined,
   activePostClaimRecord: TerritoryPostClaimBootstrapMemory | null
 ): string | null {
-  if (previous?.owned === true) {
-    return null;
-  }
-
   if (isNonEmptyString(activePostClaimRecord?.colony)) {
     return activePostClaimRecord.colony;
   }
@@ -952,7 +950,28 @@ function resolveClaimOriginColony(
     return plannedClaimOrigin;
   }
 
+  if (previous?.owned === true && !isOwnedRoomMissingSpawn(room)) {
+    return null;
+  }
+
   return selectNearestOwnedSpawnRoom(room.name);
+}
+
+function isOwnedRoomMissingSpawn(room: Room): boolean {
+  if (room.controller?.my !== true || (room.controller.level ?? 0) < 1) {
+    return false;
+  }
+
+  return !hasOwnedSpawnInRoom(room);
+}
+
+function hasOwnedSpawnInRoom(room: Room): boolean {
+  const spawns = (globalThis as { Game?: Partial<Game> }).Game?.spawns;
+  if (spawns && Object.values(spawns).some((spawn) => spawn?.room?.name === room.name)) {
+    return true;
+  }
+
+  return countExistingStructures(room, 'STRUCTURE_SPAWN', 'spawn') > 0;
 }
 
 function getPlannedClaimOriginColony(roomName: string): string | null {

--- a/prod/src/territory/claimedRoomBootstrapper.ts
+++ b/prod/src/territory/claimedRoomBootstrapper.ts
@@ -124,7 +124,7 @@ export function refreshClaimedRoomBootstrapperOwnership(
     }
 
     const claimedAt = detectedOwnedRoom
-      ? getGameTime()
+      ? previous?.claimedAt ?? getGameTime()
       : previous?.claimedAt ?? activePostClaimRecord?.claimedAt;
     memory.rooms[room.name] = {
       roomName: room.name,
@@ -139,6 +139,7 @@ export function refreshClaimedRoomBootstrapperOwnership(
         {
           colony: claimOriginColony,
           roomName: room.name,
+          ...(claimedAt !== undefined ? { claimedAt } : {}),
           ...(room.controller.id ? { controllerId: room.controller.id } : {})
         },
         telemetryEvents

--- a/prod/src/territory/postClaimBootstrap.ts
+++ b/prod/src/territory/postClaimBootstrap.ts
@@ -168,6 +168,7 @@ export function recordPostClaimBootstrapClaimSuccess(
   input: {
     colony: string;
     roomName: string;
+    claimedAt?: number;
     controllerId?: Id<StructureController>;
   },
   telemetryEvents: RuntimeTelemetryEvent[] = []
@@ -183,7 +184,7 @@ export function recordPostClaimBootstrapClaimSuccess(
 
   const gameTime = getGameTime();
   const existing = getPostClaimBootstrapRecord(input.roomName);
-  const claimedAt = existing?.status === 'ready' ? gameTime : existing?.claimedAt ?? gameTime;
+  const claimedAt = existing?.status === 'ready' ? gameTime : existing?.claimedAt ?? input.claimedAt ?? gameTime;
   const status = getRefreshedPostClaimBootstrapStatus(existing);
   const workerTarget = existing
     ? getPostClaimBootstrapWorkerTarget(existing)

--- a/prod/test/territory/claimedRoomBootstrapper.test.ts
+++ b/prod/test/territory/claimedRoomBootstrapper.test.ts
@@ -137,6 +137,70 @@ describe('claimed room bootstrapper', () => {
     );
   });
 
+  it('recovers already-owned spawnless secondary rooms that missed post-claim bootstrap records', () => {
+    const secondaryRooms = ['E26S48', 'E27S48', 'E27S49'].map((roomName) =>
+      makeBootstrapRoom({
+        roomName,
+        controllerLevel: 1,
+        sources: [makeSource(`${roomName}-source-a`, 21, 21, roomName)]
+      })
+    );
+    const homeRoom = {
+      name: 'E26S49',
+      controller: { my: true, level: 4 },
+      energyAvailable: 650,
+      energyCapacityAvailable: 650
+    } as Room;
+    const homeSpawn = { name: 'Spawn1', room: homeRoom, spawning: null } as StructureSpawn;
+    Memory.territory = {
+      claimedRoomBootstrapper: {
+        rooms: {
+          E26S48: { roomName: 'E26S48', owned: true, claimedAt: 786700, updatedAt: 786700 },
+          E27S48: { roomName: 'E27S48', owned: true, claimedAt: 786701, updatedAt: 786701 },
+          E27S49: { roomName: 'E27S49', owned: true, claimedAt: 786702, updatedAt: 786702 }
+        }
+      }
+    };
+    installGameRooms([homeRoom, ...secondaryRooms.map(({ room }) => room)], 786805);
+    (globalThis as unknown as { Game: Partial<Game> }).Game.spawns = { Spawn1: homeSpawn };
+
+    const events: RuntimeTelemetryEvent[] = [];
+    const result = refreshClaimedRoomBootstrapperOwnership(events);
+
+    expect(result.detectedRoomNames).toEqual(['E26S48', 'E27S48', 'E27S49']);
+    for (const { room } of secondaryRooms) {
+      expect(Memory.territory?.postClaimBootstraps?.[room.name]).toMatchObject({
+        colony: 'E26S49',
+        roomName: room.name,
+        status: 'spawnSitePending',
+        claimedAt: 786805,
+        updatedAt: 786805,
+        controllerId: 'controller1',
+        spawnSite: { roomName: room.name, x: 23, y: 23 },
+        lastResult: OK_CODE
+      });
+      expect(Memory.territory?.claimedRoomBootstrapper?.rooms[room.name]).toEqual({
+        roomName: room.name,
+        owned: true,
+        claimedAt: 786805,
+        updatedAt: 786805
+      });
+      expect(room.createConstructionSite).toHaveBeenCalledWith(23, 23, TEST_GLOBALS.STRUCTURE_SPAWN);
+    }
+    expect(events).toEqual(
+      expect.arrayContaining(
+        secondaryRooms.map(({ room }) =>
+          expect.objectContaining({
+            type: 'spawnSitePlaced',
+            roomName: room.name,
+            colony: 'E26S49',
+            spawnSite: { roomName: room.name, x: 23, y: 23 }
+          })
+        )
+      )
+    );
+  });
+
   it('places the initial spawn site before other infrastructure', () => {
     const { room, colony } = makeBootstrapRoom({
       controllerLevel: 1,

--- a/prod/test/territory/claimedRoomBootstrapper.test.ts
+++ b/prod/test/territory/claimedRoomBootstrapper.test.ts
@@ -152,13 +152,14 @@ describe('claimed room bootstrapper', () => {
       energyCapacityAvailable: 650
     } as Room;
     const homeSpawn = { name: 'Spawn1', room: homeRoom, spawning: null } as StructureSpawn;
+    const previousRooms = {
+      E26S48: { roomName: 'E26S48', owned: true, claimedAt: 786700, updatedAt: 786700 },
+      E27S48: { roomName: 'E27S48', owned: true, claimedAt: 786701, updatedAt: 786701 },
+      E27S49: { roomName: 'E27S49', owned: true, claimedAt: 786702, updatedAt: 786702 }
+    } as const;
     Memory.territory = {
       claimedRoomBootstrapper: {
-        rooms: {
-          E26S48: { roomName: 'E26S48', owned: true, claimedAt: 786700, updatedAt: 786700 },
-          E27S48: { roomName: 'E27S48', owned: true, claimedAt: 786701, updatedAt: 786701 },
-          E27S49: { roomName: 'E27S49', owned: true, claimedAt: 786702, updatedAt: 786702 }
-        }
+        rooms: { ...previousRooms }
       }
     };
     installGameRooms([homeRoom, ...secondaryRooms.map(({ room }) => room)], 786805);
@@ -169,11 +170,12 @@ describe('claimed room bootstrapper', () => {
 
     expect(result.detectedRoomNames).toEqual(['E26S48', 'E27S48', 'E27S49']);
     for (const { room } of secondaryRooms) {
+      const previousRoom = previousRooms[room.name as keyof typeof previousRooms];
       expect(Memory.territory?.postClaimBootstraps?.[room.name]).toMatchObject({
         colony: 'E26S49',
         roomName: room.name,
         status: 'spawnSitePending',
-        claimedAt: 786805,
+        claimedAt: previousRoom.claimedAt,
         updatedAt: 786805,
         controllerId: 'controller1',
         spawnSite: { roomName: room.name, x: 23, y: 23 },
@@ -182,7 +184,7 @@ describe('claimed room bootstrapper', () => {
       expect(Memory.territory?.claimedRoomBootstrapper?.rooms[room.name]).toEqual({
         roomName: room.name,
         owned: true,
-        claimedAt: 786805,
+        claimedAt: previousRoom.claimedAt,
         updatedAt: 786805
       });
       expect(room.createConstructionSite).toHaveBeenCalledWith(23, 23, TEST_GLOBALS.STRUCTURE_SPAWN);


### PR DESCRIPTION
## Summary
Ensure the post-claim spawn placement pipeline executes reliably for newly claimed rooms (E26S48, E27S48, E27S49). Currently, 3 rooms are claimed but have 0 spawns — the bootstrapper was not triggering spawn placement.

## Changes
- `prod/src/territory/claimedRoomBootstrapper.ts`: Fix spawn placement execution flow for post-claim rooms
- `prod/test/territory/claimedRoomBootstrapper.test.ts`: Add test coverage for spawn placement after claim
- `prod/dist/main.js`: Regenerated bundle

## Verification
- `npm run typecheck`: PASS
- `npm test -- --runInBand`: PASS (94 suites, 1720 tests)
- `npm run build`: PASS

Refs #905
