### PR TITLE
fix(rl): repair E2 simulator bot no-op — discover spawns before controller.my is true

### DIFF
--- a/prod/src/colony/colonyRegistry.ts
+++ b/prod/src/colony/colonyRegistry.ts
@@ -17,17 +17,70 @@ export function getOwnedColonies(): ColonySnapshot[] {
 
   for (const spawn of Object.values(Game.spawns)) {
     const room = spawn.room;
-    if (room && room.controller?.my && !ownedRoomsByName.has(room.name)) {
+    if (room && isOwnedSpawn(spawn) && !ownedRoomsByName.has(room.name)) {
       ownedRoomsByName.set(room.name, room);
     }
   }
 
   return [...ownedRoomsByName.values()]
-    .map((room) => ({
-      room,
-      memory: room.memory,
-      spawns: Object.values(Game.spawns).filter((spawn) => spawn.room.name === room.name),
-      energyAvailable: room.energyAvailable,
-      energyCapacityAvailable: room.energyCapacityAvailable
-    }));
+    .map((room) => buildColonySnapshot(room));
+}
+
+function buildColonySnapshot(room: Room): ColonySnapshot {
+  const spawns = Object.values(Game.spawns).filter((spawn) => spawn.room.name === room.name);
+  return {
+    room,
+    memory: room.memory,
+    spawns,
+    energyAvailable: Math.max(normalizeEnergyAmount(room.energyAvailable), getSpawnEnergyAvailable(spawns)),
+    energyCapacityAvailable: Math.max(
+      normalizeEnergyAmount(room.energyCapacityAvailable),
+      getSpawnEnergyCapacityAvailable(spawns)
+    )
+  };
+}
+
+function isOwnedSpawn(spawn: StructureSpawn): boolean {
+  return spawn.my === true || spawn.room?.controller?.my === true;
+}
+
+function getSpawnEnergyAvailable(spawns: StructureSpawn[]): number {
+  return spawns.reduce((total, spawn) => total + getSpawnStoreAmount(spawn, 'getUsedCapacity', 'energy'), 0);
+}
+
+function getSpawnEnergyCapacityAvailable(spawns: StructureSpawn[]): number {
+  return spawns.reduce((total, spawn) => total + getSpawnCapacity(spawn), 0);
+}
+
+function getSpawnCapacity(spawn: StructureSpawn): number {
+  const storeCapacity = getSpawnStoreAmount(spawn, 'getCapacity', 'energyCapacity');
+  if (storeCapacity > 0) {
+    return storeCapacity;
+  }
+
+  return (
+    getSpawnStoreAmount(spawn, 'getUsedCapacity', 'energy') +
+    getSpawnStoreAmount(spawn, 'getFreeCapacity', undefined)
+  );
+}
+
+function getSpawnStoreAmount(
+  spawn: StructureSpawn,
+  method: 'getUsedCapacity' | 'getFreeCapacity' | 'getCapacity',
+  legacyField: 'energy' | 'energyCapacity' | undefined
+): number {
+  const storeMethod = spawn.store?.[method];
+  if (typeof storeMethod === 'function') {
+    return normalizeEnergyAmount(storeMethod.call(spawn.store, getEnergyResourceConstant()));
+  }
+
+  return legacyField ? normalizeEnergyAmount((spawn as unknown as Record<string, unknown>)[legacyField]) : 0;
+}
+
+function getEnergyResourceConstant(): ResourceConstant {
+  return ((globalThis as unknown as { RESOURCE_ENERGY?: ResourceConstant }).RESOURCE_ENERGY ?? 'energy') as ResourceConstant;
+}
+
+function normalizeEnergyAmount(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
 }

--- a/prod/test/colonyRegistry.test.ts
+++ b/prod/test/colonyRegistry.test.ts
@@ -115,4 +115,42 @@ describe('getOwnedColonies', () => {
       }
     ]);
   });
+
+  it('discovers a fresh simulator room from an owned spawn before controller ownership is visible', () => {
+    const simulatorRoom = {
+      name: 'E1S1',
+      controller: { my: false },
+      energyAvailable: 0,
+      energyCapacityAvailable: 0
+    } as Room;
+    const spawn = {
+      name: 'Spawn1',
+      my: true,
+      room: simulatorRoom,
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(300),
+        getCapacity: jest.fn().mockReturnValue(300)
+      }
+    } as unknown as StructureSpawn;
+
+    (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        E1S1: simulatorRoom
+      },
+      spawns: {
+        Spawn1: spawn
+      }
+    };
+
+    expect(getOwnedColonies()).toEqual([
+      {
+        room: simulatorRoom,
+        spawns: [spawn],
+        energyAvailable: 300,
+        energyCapacityAvailable: 300
+      }
+    ]);
+  });
 });

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -184,6 +184,43 @@ describe('runEconomy', () => {
     });
   });
 
+  it('bootstraps a fresh simulator room from an owned placed spawn', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+    const room = {
+      name: 'E1S1',
+      energyAvailable: 0,
+      energyCapacityAvailable: 0,
+      controller: { my: false } as StructureController,
+      memory: {},
+      find: jest.fn().mockReturnValue([])
+    } as unknown as Room;
+    const spawn = {
+      name: 'Spawn1',
+      my: true,
+      room,
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(300),
+        getCapacity: jest.fn().mockReturnValue(300)
+      },
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 10,
+      rooms: { E1S1: room },
+      spawns: { Spawn1: spawn },
+      creeps: {},
+      map: {} as GameMap
+    };
+
+    runEconomy();
+
+    expect(spawn.spawnCreep).toHaveBeenCalledWith(['work', 'carry', 'move'], 'worker-E1S1-10', {
+      memory: { role: 'worker', colony: 'E1S1' }
+    });
+  });
+
   it('uses multiple idle spawns in one tick when worker recovery has enough room energy', () => {
     (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 3;
     (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 4;

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -832,6 +832,13 @@ def _build_tick_entry(
                     "gametime": selected.get("gametime"),
                     "gametimes": selected.get("gametimes"),
                 }
+        elif isinstance(overview.get("rooms"), list):
+            overview_payload = {
+                "rooms": overview.get("rooms") or [],
+                "roomCount": len(overview.get("rooms") or []),
+                "gametime": overview.get("gametime"),
+                "gametimes": overview.get("gametimes"),
+            }
     room_names = (
         _dedupe_room_names(visible_rooms)
         if visible_rooms is not None
@@ -1019,6 +1026,10 @@ def _visible_room_names(overview: Any, shard: str, anchor_room: str) -> list[str
     for room_name in runtime_monitor.overview_rooms(overview, shard):
         if room_name not in ordered:
             ordered.append(room_name)
+    if isinstance(overview, dict):
+        for room_name in overview.get("rooms") or []:
+            if isinstance(room_name, str) and room_name not in ordered:
+                ordered.append(room_name)
     if anchor_room not in ordered:
         ordered.insert(0, anchor_room)
     return ordered
@@ -1042,6 +1053,30 @@ def _wait_for_http_with_smoke(cfg: Any, smoke: Any, timeout_seconds: int = RUN_P
 
 def _read_gametime_from_overview(payload: Any, shard: str) -> int | None:
     gametime = runtime_monitor.gametime_from_overview(payload, shard)
+    if isinstance(gametime, str):
+        return _coerce_int(gametime)
+    if isinstance(gametime, int):
+        return gametime
+    if isinstance(payload, dict):
+        flat_gametime = payload.get("gametime")
+        if isinstance(flat_gametime, str):
+            return _coerce_int(flat_gametime)
+        if isinstance(flat_gametime, int):
+            return flat_gametime
+        flat_gametimes = payload.get("gametimes")
+        if isinstance(flat_gametimes, list) and flat_gametimes:
+            first_gametime = flat_gametimes[0]
+            if isinstance(first_gametime, str):
+                return _coerce_int(first_gametime)
+            if isinstance(first_gametime, int):
+                return first_gametime
+    return None
+
+
+def _read_gametime_from_stats(payload: Any) -> int | None:
+    if not isinstance(payload, dict):
+        return None
+    gametime = payload.get("gametime")
     if isinstance(gametime, str):
         return _coerce_int(gametime)
     if isinstance(gametime, int):
@@ -1103,6 +1138,16 @@ def _run_one_tick(
         )
         token = smoke.update_token_from_headers(token, terrain_result.headers)
         current_tick = _read_gametime_from_overview(overview_result.payload, shard)
+        if current_tick is None:
+            stats_result = smoke.http_json(
+                "GET",
+                cfg.server_url,
+                "/stats",
+                headers=smoke.token_headers(token),
+                timeout=RUN_API_TIMEOUT_SECONDS,
+            )
+            token = smoke.update_token_from_headers(token, stats_result.headers)
+            current_tick = _read_gametime_from_stats(stats_result.payload)
         if isinstance(overview_result.payload, dict) and not smoke.api_dict_succeeded(overview_result):
             raise RuntimeError(f"/api/user/overview returned unusable payload: {_safe_redact_smoke_payload(overview_result.payload)}")
         if current_tick is None:

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -594,6 +594,84 @@ class RlSimulatorHarnessTest(unittest.TestCase):
         self.assertEqual(tick_entry["rooms"]["E26S49"]["structures"]["spawn"], 1)
         self.assertEqual(tick_entry["rooms"]["E26S50"]["controller"]["level"], 2)
 
+    def test_build_tick_entry_accepts_private_server_flat_overview(self) -> None:
+        overview = {"ok": 1, "rooms": ["E1S1"], "gametimes": [], "stats": {}, "totals": {}}
+
+        tick_entry = harness._build_tick_entry(
+            "shardX",
+            "E1S1",
+            42,
+            overview,
+            {"terrain": [{"room": "E1S1", "terrain": "0" * 2500}]},
+            {
+                "E1S1": {
+                    "room": "E1S1",
+                    "roomData": {
+                        "controller": {"level": 1},
+                        "objects": [{"type": "spawn"}],
+                        "creeps": 1,
+                        "energy": 300,
+                    },
+                }
+            },
+        )
+
+        self.assertEqual(tick_entry["overview"]["rooms"], ["E1S1"])
+        self.assertEqual(tick_entry["overview"]["roomCount"], 1)
+        self.assertEqual(tick_entry["rooms"]["E1S1"]["structures"]["spawn"], 1)
+
+    def test_run_one_tick_uses_stats_gametime_when_private_overview_has_no_shard_clock(self) -> None:
+        class Result:
+            def __init__(self, payload: object) -> None:
+                self.payload = payload
+                self.headers: dict[str, str] = {}
+
+        class FakeSmoke:
+            def token_headers(self, token: str) -> dict[str, str]:
+                return {"X-Token": token}
+
+            def update_token_from_headers(self, token: str, headers: dict[str, str]) -> str:
+                return token
+
+            def api_dict_succeeded(self, result: Result) -> bool:
+                return isinstance(result.payload, dict) and result.payload.get("ok", 1) == 1
+
+            def http_json(self, method: str, base_url: str, path: str, **kwargs: object) -> Result:
+                _ = method, base_url, kwargs
+                if path == "/api/user/overview":
+                    return Result({"ok": 1, "rooms": ["E1S1"], "gametimes": []})
+                if path == "/stats":
+                    return Result({"gametime": 42})
+                if path == "/api/game/room-terrain":
+                    return Result({"terrain": [{"room": "E1S1", "terrain": "0" * 2500}]})
+                if path == "/api/game/room-overview":
+                    return Result({
+                        "ok": 1,
+                        "room": "E1S1",
+                        "roomData": {
+                            "controller": {"level": 1},
+                            "objects": [{"type": "spawn"}],
+                            "creeps": 1,
+                            "energy": 300,
+                        },
+                    })
+                raise AssertionError(path)
+
+        token, observed_tick, tick_entry = harness._run_one_tick(
+            argparse.Namespace(server_url="http://127.0.0.1"),
+            FakeSmoke(),
+            "token",
+            "E1S1",
+            "shardX",
+            previous_tick=41,
+            timeout_seconds=0.1,
+        )
+
+        self.assertEqual(token, "token")
+        self.assertEqual(observed_tick, 42)
+        self.assertEqual(tick_entry["tick"], 42)
+        self.assertEqual(tick_entry["rooms"]["E1S1"]["creeps"], 1)
+
     def test_build_variant_metrics_reduces_territory_resources_and_combat(self) -> None:
         tick_log = [
             {


### PR DESCRIPTION
## Summary
Fix E2 simulator bot no-op timeout — the bot spawned successfully in simulator environments but never executed any ticks because `colonyRegistry.getOwnedColonies()` couldn't discover the simulator room.

## Root cause
In fresh simulator rooms, the spawn is created with `spawn.my = true` but `room.controller.my` is still `false` because controller ownership hasn't propagated yet. The old code checked `room.controller?.my` which failed. Additionally, `spawn.store` API methods were not used for energy detection.

## Changes
- **colonyRegistry.ts**: Check `spawn.my` instead of `room.controller?.my` for spawn ownership; add `spawn.store.getUsedCapacity/getCapacity` methods for accurate energy reporting
- **E2 harness**: Handle list-format rooms in overview payloads; fallback to `/stats` endpoint when gametime is missing from overview; improved room name extraction
- **Tests**: New test for simulator-room colony discovery; economyLoop regression coverage

## Verification
```
npm run typecheck: PASS (0 errors)
npx jest --runInBand: 94 suites, 1726 tests — ALL PASS
python3 -m py_compile scripts/screeps_rl_simulator_harness.py: PASS
python3 -m py_compile scripts/test_screeps_rl_simulator_harness.py: PASS
```

## Linked
- #879 ALL IN RL execution
- #893 RL closed-loop ledgers
- RL conclusion: `rlc-20260510-simulator-all-environments-fail` (P0)
