### PR TITLE
fix(economy): apply energy buffer capacity cap after survival multiplier (#916)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2736,16 +2736,16 @@ var CAPACITY_ENABLING_CONSTRUCTION_HEALTHY_ENERGY_CAPACITY = 550;
 var CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY = 300;
 var MINIMUM_WORKER_SPAWN_ENERGY = 200;
 function getRoomEnergyBufferThreshold(room) {
-  const desiredThreshold = getConfiguredRoomEnergyBufferThreshold(room);
-  const energyCapacityAvailable = getRoomEnergyCapacityAvailable2(room);
-  if (energyCapacityAvailable === null) {
-    return desiredThreshold;
-  }
-  return Math.min(desiredThreshold, energyCapacityAvailable);
+  return getConfiguredRoomEnergyBufferThreshold(room);
 }
 function getEffectiveRoomEnergyBufferThreshold(room) {
   const threshold = getRoomEnergyBufferThreshold(room);
-  return isSurvivalBufferMode(room) ? Math.ceil(threshold * SURVIVAL_ENERGY_BUFFER_MULTIPLIER) : threshold;
+  const effectiveThreshold = isSurvivalBufferMode(room) ? Math.ceil(threshold * SURVIVAL_ENERGY_BUFFER_MULTIPLIER) : threshold;
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable2(room);
+  if (energyCapacityAvailable === null) {
+    return effectiveThreshold;
+  }
+  return Math.min(effectiveThreshold, energyCapacityAvailable);
 }
 function getStorageEnergyReserveThreshold(room) {
   return Math.min(getEffectiveConfiguredRoomEnergyBufferThreshold(room), STORAGE_EMERGENCY_RESERVE);

--- a/prod/src/economy/energyBuffer.ts
+++ b/prod/src/economy/energyBuffer.ts
@@ -38,18 +38,20 @@ interface EnergyObservation {
 }
 
 export function getRoomEnergyBufferThreshold(room: Room): number {
-  const desiredThreshold = getConfiguredRoomEnergyBufferThreshold(room);
-  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(room);
-  if (energyCapacityAvailable === null) {
-    return desiredThreshold;
-  }
-
-  return Math.min(desiredThreshold, energyCapacityAvailable);
+  return getConfiguredRoomEnergyBufferThreshold(room);
 }
 
 export function getEffectiveRoomEnergyBufferThreshold(room: Room): number {
   const threshold = getRoomEnergyBufferThreshold(room);
-  return isSurvivalBufferMode(room) ? Math.ceil(threshold * SURVIVAL_ENERGY_BUFFER_MULTIPLIER) : threshold;
+  const effectiveThreshold = isSurvivalBufferMode(room)
+    ? Math.ceil(threshold * SURVIVAL_ENERGY_BUFFER_MULTIPLIER)
+    : threshold;
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(room);
+  if (energyCapacityAvailable === null) {
+    return effectiveThreshold;
+  }
+
+  return Math.min(effectiveThreshold, energyCapacityAvailable);
 }
 
 export function getStorageEnergyReserveThreshold(room: Room): number {

--- a/prod/test/energyBuffer.test.ts
+++ b/prod/test/energyBuffer.test.ts
@@ -63,10 +63,10 @@ describe('energyBuffer', () => {
     );
   });
 
-  it('caps the RCL 4 buffer threshold at spawn-only room capacity', () => {
+  it('caps the effective RCL 4 buffer threshold at spawn-only room capacity', () => {
     const room = makeRoom({ level: 4, energyAvailable: 300, energyCapacityAvailable: 300 });
 
-    expect(getRoomEnergyBufferThreshold(room)).toBe(300);
+    expect(getRoomEnergyBufferThreshold(room)).toBe(500);
     expect(getEffectiveRoomEnergyBufferThreshold(room)).toBe(300);
     expect(getRoomEnergyBufferHealth(room)).toEqual({
       currentEnergy: 300,
@@ -76,27 +76,45 @@ describe('energyBuffer', () => {
     });
   });
 
-  it('caps the RCL 5 buffer threshold at limited extension capacity', () => {
+  it('caps the effective RCL 5 buffer threshold at limited extension capacity', () => {
     const room = makeRoom({ level: 5, energyAvailable: 650, energyCapacityAvailable: 650 });
 
-    expect(getRoomEnergyBufferThreshold(room)).toBe(650);
+    expect(getRoomEnergyBufferThreshold(room)).toBe(800);
     expect(getEffectiveRoomEnergyBufferThreshold(room)).toBe(650);
     expect(getRoomEnergyBufferHealth(room).healthy).toBe(true);
   });
 
-  it('applies the survival multiplier after capping the threshold to room capacity', () => {
-    const room = makeRoom({ level: 4, energyAvailable: 300, energyCapacityAvailable: 300 });
-    recordSurvivalMode('DEFENSE');
+  it('caps an RCL 2 bootstrap threshold after applying the survival multiplier', () => {
+    const room = makeRoom({ level: 2, energyAvailable: 300, energyCapacityAvailable: 300 });
+    recordSurvivalMode('BOOTSTRAP');
 
     expect(getRoomEnergyBufferThreshold(room)).toBe(300);
-    expect(getEffectiveRoomEnergyBufferThreshold(room)).toBe(450);
+    expect(getEffectiveRoomEnergyBufferThreshold(room)).toBe(300);
   });
 
-  it('normalizes edge-case room capacity values before capping thresholds', () => {
-    expect(getRoomEnergyBufferThreshold(makeRoom({ level: 4, energyCapacityAvailable: 0 }))).toBe(0);
-    expect(getRoomEnergyBufferThreshold(makeRoom({ level: 4, energyCapacityAvailable: -1 }))).toBe(0);
+  it('caps an RCL 3 bootstrap threshold after applying the survival multiplier', () => {
+    const room = makeRoom({ level: 3, energyAvailable: 550, energyCapacityAvailable: 550 });
+    recordSurvivalMode('BOOTSTRAP');
+
+    expect(getRoomEnergyBufferThreshold(room)).toBe(500);
+    expect(getEffectiveRoomEnergyBufferThreshold(room)).toBe(550);
+  });
+
+  it('keeps non-survival effective thresholds capped at room capacity', () => {
+    const room = makeRoom({ level: 3, energyAvailable: 300, energyCapacityAvailable: 300 });
+    recordSurvivalMode('LOCAL_STABLE');
+
+    expect(getRoomEnergyBufferThreshold(room)).toBe(500);
+    expect(getEffectiveRoomEnergyBufferThreshold(room)).toBe(300);
+  });
+
+  it('normalizes edge-case room capacity values before capping effective thresholds', () => {
+    expect(getEffectiveRoomEnergyBufferThreshold(makeRoom({ level: 4, energyCapacityAvailable: 0 }))).toBe(0);
+    expect(getEffectiveRoomEnergyBufferThreshold(makeRoom({ level: 4, energyCapacityAvailable: -1 }))).toBe(0);
     expect(
-      getRoomEnergyBufferThreshold(makeRoom({ level: 4, energyCapacityAvailable: Number.POSITIVE_INFINITY }))
+      getEffectiveRoomEnergyBufferThreshold(
+        makeRoom({ level: 4, energyCapacityAvailable: Number.POSITIVE_INFINITY })
+      )
     ).toBe(500);
   });
 
@@ -104,7 +122,8 @@ describe('energyBuffer', () => {
     const storage = makeStorage(520);
     const room = makeRoom({ level: 3, energyAvailable: 300, energyCapacityAvailable: 300, storage });
 
-    expect(getRoomEnergyBufferThreshold(room)).toBe(300);
+    expect(getRoomEnergyBufferThreshold(room)).toBe(500);
+    expect(getEffectiveRoomEnergyBufferThreshold(room)).toBe(300);
     expect(getStorageEnergyReserveThreshold(room)).toBe(500);
     expect(getStorageEnergyAvailableForWithdrawal(room, storage)).toBe(20);
     expect(withdrawFromStorage(room, 20)).toBe(true);
@@ -193,8 +212,9 @@ describe('energyBuffer', () => {
   });
 });
 
-function recordSurvivalMode(mode: 'LOCAL_STABLE' | 'DEFENSE'): void {
+function recordSurvivalMode(mode: 'BOOTSTRAP' | 'LOCAL_STABLE' | 'DEFENSE'): void {
   const inputByMode = {
+    BOOTSTRAP: { workerCapacity: 1, workerTarget: 3, hostileCreepCount: 0 },
     LOCAL_STABLE: { workerCapacity: 3, workerTarget: 4, hostileCreepCount: 0 },
     DEFENSE: { workerCapacity: 4, workerTarget: 4, hostileCreepCount: 1 }
   }[mode];


### PR DESCRIPTION
## Root cause
`getEffectiveRoomEnergyBufferThreshold()` in `prod/src/economy/energyBuffer.ts` applies `SURVIVAL_ENERGY_BUFFER_MULTIPLIER` (1.5×) AFTER the capacity cap in `getRoomEnergyBufferThreshold()`. For BOOTSTRAP/DEFENSE rooms at RCL 2 with energyCapacity=300, the cap limits to 300, but then the survival multiplier pushes it to 450 — blocking construction because `threshold > capacity`.

## Fix
Moved the capacity cap (`Math.min(threshold, energyCapacityAvailable)`) from `getRoomEnergyBufferThreshold()` into `getEffectiveRoomEnergyBufferThreshold()`, applied AFTER the survival multiplier. The cap is now the last operation before returning the effective threshold.

## Evidence
- Console capture tick 800540: `energyCapacity=300, threshold=450, healthy=false`
- `SURVIVAL_ENERGY_BUFFER_MULTIPLIER = 1.5` applied to RCL 2 threshold of 300 → 450

## Testing
- All 94 test suites pass (1731 tests)
- New tests cover BOOTSTRAP mode cap behavior:
  - RCL 2 + BOOTSTRAP + capacity=300 → effective threshold = 300 (was 450)
  - RCL 3 + BOOTSTRAP + capacity=550 → effective threshold = 550 (was 750)
- Typecheck and build pass

## Deployment
After merge, deploy to official MMO and verify `energyBufferHealth.healthy=true` when `currentEnergy >= threshold` and `threshold <= energyCapacity`.
