### PR TITLE
fix(ops): pass runtime-summary-console dir flags in deploy workflow post-deploy step (#920)

### DIFF
--- a/.github/workflows/official-screeps-deploy.yml
+++ b/.github/workflows/official-screeps-deploy.yml
@@ -135,13 +135,16 @@ jobs:
           SCREEPS_MONITOR_STATE_FILE: runtime-artifacts/official-screeps-deploy/postdeploy-monitor-state.json
           SCREEPS_MONITOR_CACHE_DIR: runtime-artifacts/screeps-monitor/terrain-cache
         run: |
+          mkdir -p runtime-artifacts/runtime-summary-console
           python3 scripts/screeps-runtime-monitor.py summary \
             --room "$SCREEPS_SHARD/$SCREEPS_ROOM" \
             --out-dir runtime-artifacts/screeps-monitor \
+            --runtime-summary-out-dir runtime-artifacts/runtime-summary-console \
             > "$EVIDENCE_DIR/postdeploy-summary.json"
           python3 scripts/screeps-runtime-monitor.py alert \
             --room "$SCREEPS_SHARD/$SCREEPS_ROOM" \
             --out-dir runtime-artifacts/screeps-monitor \
+            --runtime-summary-dir runtime-artifacts/runtime-summary-console \
             --force-alert-image \
             > "$EVIDENCE_DIR/postdeploy-alert.json"
           python3 scripts/screeps-runtime-monitor.py health-gate \


### PR DESCRIPTION
## Problem
Closes #920: Deploy workflow postdeploy summary reports `Permission denied: /root/screeps/runtime-artifacts/runtime-summary-console` because the hardcoded default path doesn't exist in the GitHub Actions sandbox.

## Fix
- Add `mkdir -p runtime-artifacts/runtime-summary-console` before the post-deploy monitor commands
- Pass `--runtime-summary-out-dir runtime-artifacts/runtime-summary-console` to the `summary` command
- Pass `--runtime-summary-dir runtime-artifacts/runtime-summary-console` to the `alert` command

All paths are workspace-relative, resolving correctly in the GitHub Actions sandbox.

## Verification
- YAML syntax validated with Python yaml.safe_load
- No production code changes — workflow config only

## Impact
Unblocks RL E1 data quality by enabling console capture evidence in post-deploy summaries.