### PR TITLE
fix(roadmap): hide cached issue pr counts on fetch failure

### DIFF
--- a/scripts/generate-roadmap-page.py
+++ b/scripts/generate-roadmap-page.py
@@ -2773,7 +2773,6 @@ def build_report_process_cards(
         }
 
     prs, pr_error = fetch_all_prs(repo_root, str(repo["fullName"]))
-    cached_pr_card = cached_process_card(cached_process_cards, "PRs", "Total PRs")
     if pr_error is None:
         merged_prs = sum(1 for item in prs if str(item.get("state") or "").upper() == "MERGED")
         pr_card = {
@@ -2785,16 +2784,9 @@ def build_report_process_cards(
             "source": "github",
         }
     else:
-        pr_card = cached_or_unavailable_process_card(
-            cached_process_cards,
-            "PRs",
-            process_detail(pr_error, "gh pr list", "unavailable", cached_pr_card),
-            "unavailable",
-            "Total PRs",
-        )
+        pr_card = unavailable_process_card("PRs", format_fetch_error("gh pr list", pr_error))
 
     issues, issue_error = fetch_all_issues(repo_root, str(repo["fullName"]))
-    cached_issue_card = cached_process_card(cached_process_cards, "Issues", "Total issues")
     if issue_error is None:
         open_issues = sum(1 for item in issues if str(item.get("state") or "").upper() == "OPEN")
         issue_card = {
@@ -2806,13 +2798,7 @@ def build_report_process_cards(
             "source": "github",
         }
     else:
-        issue_card = cached_or_unavailable_process_card(
-            cached_process_cards,
-            "Issues",
-            process_detail(issue_error, "gh issue list", "unavailable", cached_issue_card),
-            "unavailable",
-            "Total issues",
-        )
+        issue_card = unavailable_process_card("Issues", format_fetch_error("gh issue list", issue_error))
 
     official_deploy_summary = summarize_official_deploy_evidence(repo_root)
     official_deploy_project_count = count_official_deploy_evidence(repo_root, github_snapshot)
@@ -2994,6 +2980,10 @@ def cached_or_unavailable_process_card(
             "source": "cached",
             "delta": cached_card.get("delta", "cached"),
         }
+    return unavailable_process_card(label, detail, source)
+
+
+def unavailable_process_card(label: str, detail: str, source: str = "unavailable") -> JsonObject:
     return {
         "value": "unavailable",
         "label": label,
@@ -3294,21 +3284,6 @@ def cached_process_card(cards: Sequence[JsonObject], *labels: str) -> JsonObject
         if str(card.get("label") or "") in label_set:
             return card
     return {}
-
-
-def process_detail(
-    error: JsonObject | None,
-    command_label: str,
-    live_detail: str,
-    cached_card: JsonObject,
-) -> str:
-    if error is None:
-        return live_detail
-    cached_detail = str(cached_card.get("detail") or "").strip()
-    if cached_detail:
-        cached_detail = CACHED_SUFFIX_RE.sub("", cached_detail).strip()
-        return f"{cached_detail} · cached"
-    return format_fetch_error(command_label, error)
 
 
 def fetch_all_prs(repo_root: Path, repo_full_name: str) -> tuple[list[JsonObject], JsonObject | None]:

--- a/scripts/test_generate_roadmap_page.py
+++ b/scripts/test_generate_roadmap_page.py
@@ -501,6 +501,80 @@ class GenerateRoadmapPageTest(unittest.TestCase):
         self.assertEqual(cards_by_label["Longest Codex run"]["rawValueSeconds"], 1800)
         self.assertIn("maximum first-to-last JSONL timestamp span", cards_by_label["Longest Codex run"]["detail"])
 
+    def test_report_process_cards_hide_cached_issue_pr_counts_when_github_unavailable(self) -> None:
+        cached_page_data = {
+            "report": {
+                "processCards": [
+                    {
+                        "label": "Issues",
+                        "value": 210,
+                        "rawValue": 210,
+                        "detail": "210 total issues",
+                        "delta": "+0",
+                        "source": "cached",
+                    },
+                    {
+                        "label": "PRs",
+                        "value": 248,
+                        "rawValue": 248,
+                        "detail": "248 total PRs",
+                        "delta": "+0",
+                        "source": "cached",
+                    },
+                ]
+            }
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            with (
+                patch.object(roadmap, "run_text", return_value="42\n"),
+                patch.object(
+                    roadmap,
+                    "fetch_all_prs",
+                    return_value=([], {"message": "unavailable", "exitCode": 1}),
+                ),
+                patch.object(
+                    roadmap,
+                    "fetch_all_issues",
+                    return_value=([], {"message": "unavailable", "exitCode": 1}),
+                ),
+                patch.object(roadmap, "CODEX_SESSION_ROOT", repo_root / "missing-codex-sessions"),
+                patch.object(roadmap, "HERMES_CRON_OUTPUT_ROOT", repo_root / "missing-cron-output"),
+                patch.object(roadmap, "summarize_official_deploy_evidence", return_value=roadmap.OfficialDeployEvidenceSummary(0)),
+                patch.object(roadmap, "count_official_deploy_evidence", return_value=0),
+                patch.object(roadmap, "count_private_smoke_process_reports", return_value=0),
+            ):
+                cards = roadmap.build_report_process_cards(
+                    repo_root,
+                    {"fullName": "lanyusea/screeps"},
+                    {},
+                    cached_page_data,
+                )
+
+        self.assertEqual([card["label"] for card in cards], [
+            "Commits",
+            "Issues",
+            "PRs",
+            "Deploys",
+            "Private smoke",
+            "Agent tokens",
+            "Codex runtime",
+            "Codex runs",
+            "Cron runs",
+            "Longest Codex run",
+        ])
+        cards_by_label = {card["label"]: card for card in cards}
+        expected_commands = {"Issues": "gh issue list", "PRs": "gh pr list"}
+        for label, command in expected_commands.items():
+            with self.subTest(label=label):
+                card = cards_by_label[label]
+                self.assertEqual(card["value"], "unavailable")
+                self.assertEqual(card["delta"], "n/a")
+                self.assertEqual(card["source"], "unavailable")
+                self.assertNotIn("rawValue", card)
+                self.assertIn(command, card["detail"])
+                self.assertIn("unavailable", card["detail"])
+
     def test_report_process_cards_ignore_unattributed_host_global_metrics(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = Path(tmp)


### PR DESCRIPTION
## Summary
- Fixes the Delivery Metrics fallback path for `Issues` and `PRs` so failed `gh issue/pr` fetches no longer reuse precise cached counts.
- Adds a regression test covering stale cached process-card values being hidden when GitHub fetches are unavailable.
- Leaves successful live-fetch behavior unchanged: live `Issues` and `PRs` still count all GitHub issues/PRs and show open/merged detail.

## Evidence / context
- Discord re-audit: live Pages is still `generatedAt=2026-05-07T03:12:22Z`, `github.sourceMode=cached`, showing `Issues=210` and `PRs=248`.
- Fresh GitHub counts at audit time: `Issues=442` (`15 open + 427 closed`) and `PRs=489` (`475 merged + 14 closed + 0 open`).
- Temp generator run with live GitHub access produced `Issues=442` and `PRs=489`, confirming the precise cached fallback is the bad path this PR fixes.

## Test plan
- [x] `python3 scripts/test_generate_roadmap_page.py GenerateRoadmapPageTest.test_report_process_cards_hide_cached_issue_pr_counts_when_github_unavailable GenerateRoadmapPageTest.test_report_process_cards_compute_agent_metrics_from_local_fixtures`
- [x] `python3 -m py_compile scripts/generate-roadmap-page.py scripts/check-roadmap-kpi-placeholders.py`
- [x] `python3 -B scripts/check-roadmap-kpi-placeholders.py /root/screeps-worktrees/fix-roadmap-delivery-counts-834`
- [x] `git diff --check`

## Known existing failure
- `python3 scripts/test_generate_roadmap_page.py` still fails on `test_runtime_artifact_history_derives_daily_buckets_outside_sqlite` with `artifact_status["dailyBucketDays"]` being `0` instead of `7`.
- This failure reproduces on current `main` before this branch, so it is tracked as pre-existing and outside this PR's narrow Delivery Metrics fallback scope.

Refs #834
