### PR TITLE
feat(bot): implement controller.sign with project branding text (#918)

### DIFF
--- a/prod/src/territory/controllerManager.ts
+++ b/prod/src/territory/controllerManager.ts
@@ -142,7 +142,7 @@ export function buildControllerManagementPlan(
     controllerId,
     controllerLevel,
     desiredControllerLevel,
-    signNeeded: shouldSignOccupiedController(controller),
+    signNeeded: shouldSignOccupiedController(controller, gameTime),
     upgradePriority,
     desiredUpgraderCount,
     activeUpgraderCount,

--- a/prod/src/territory/controllerSigning.ts
+++ b/prod/src/territory/controllerSigning.ts
@@ -1,4 +1,5 @@
 export const OCCUPIED_CONTROLLER_SIGN_TEXT = 'by Hermes Screeps Project';
+export const CONTROLLER_SIGN_REFRESH_INTERVAL_TICKS = 5_000;
 
 const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
 const ERR_TIRED_CODE = -11 as ScreepsReturnCode;
@@ -6,45 +7,54 @@ const OK_CODE = 0 as ScreepsReturnCode;
 
 export type ControllerSigningResult = 'skipped' | 'signed' | 'moving' | 'blocked';
 
-export function shouldSignOccupiedController(controller: StructureController | null | undefined): boolean {
-  return controller?.my === true && hasMissingControllerSignature(controller);
+export function shouldSignOccupiedController(
+  controller: StructureController | null | undefined,
+  gameTime: number | null = getGameTime()
+): boolean {
+  return controller?.my === true && hasMissingOrStaleControllerSignature(controller, gameTime);
 }
 
 export function shouldSignReservedController(
   controller: StructureController | null | undefined,
-  actorUsername: string | undefined
+  actorUsername: string | undefined,
+  gameTime: number | null = getGameTime()
 ): boolean {
   return Boolean(
     controller &&
       isControllerReservedByActor(controller, actorUsername) &&
-      hasMissingControllerSignature(controller)
+      hasMissingOrStaleControllerSignature(controller, gameTime)
   );
 }
 
 export function shouldSignControllerForCreep(
   creep: Creep,
-  controller: StructureController | null | undefined
+  controller: StructureController | null | undefined,
+  gameTime: number | null = getGameTime()
 ): boolean {
   return (
-    shouldSignOccupiedController(controller) ||
-    shouldSignReservedController(controller, getControllerSigningActorUsername(creep))
+    shouldSignOccupiedController(controller, gameTime) ||
+    shouldSignReservedController(controller, getControllerSigningActorUsername(creep), gameTime)
   );
 }
 
 export function signOccupiedControllerIfNeeded(
   creep: Creep,
-  controller: StructureController | null | undefined
+  controller: StructureController | null | undefined,
+  gameTime: number | null = getGameTime()
 ): ControllerSigningResult {
-  return signControllerWithPredicate(creep, controller, shouldSignOccupiedController);
+  return signControllerWithPredicate(creep, controller, (candidate) =>
+    shouldSignOccupiedController(candidate, gameTime)
+  );
 }
 
 export function signReservedControllerIfNeeded(
   creep: Creep,
   controller: StructureController | null | undefined,
-  actorUsername: string | undefined = getControllerSigningActorUsername(creep)
+  actorUsername: string | undefined = getControllerSigningActorUsername(creep),
+  gameTime: number | null = getGameTime()
 ): ControllerSigningResult {
   return signControllerWithPredicate(creep, controller, (candidate) =>
-    shouldSignReservedController(candidate, actorUsername)
+    shouldSignReservedController(candidate, actorUsername, gameTime)
   );
 }
 
@@ -86,8 +96,23 @@ function signControllerWithPredicate(
   return result === OK_CODE ? 'signed' : 'skipped';
 }
 
-function hasMissingControllerSignature(controller: StructureController): boolean {
-  return controller.sign?.text !== OCCUPIED_CONTROLLER_SIGN_TEXT;
+function hasMissingOrStaleControllerSignature(
+  controller: StructureController,
+  gameTime: number | null
+): boolean {
+  if (controller.sign?.text !== OCCUPIED_CONTROLLER_SIGN_TEXT) {
+    return true;
+  }
+
+  if (!isFiniteNumber(gameTime)) {
+    return false;
+  }
+
+  const signedAt = controller.sign?.time;
+  return (
+    !isFiniteNumber(signedAt) ||
+    gameTime - signedAt >= CONTROLLER_SIGN_REFRESH_INTERVAL_TICKS
+  );
 }
 
 function isControllerReservedByActor(
@@ -104,4 +129,13 @@ function isControllerReservedByActor(
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function getGameTime(): number | null {
+  const gameTime = (globalThis as { Game?: Partial<Pick<Game, 'time'>> }).Game?.time;
+  return isFiniteNumber(gameTime) ? gameTime : null;
 }

--- a/prod/test/controllerManager.test.ts
+++ b/prod/test/controllerManager.test.ts
@@ -4,6 +4,10 @@ import {
   buildControllerManagementPlan,
   refreshControllerManagement
 } from '../src/territory/controllerManager';
+import {
+  CONTROLLER_SIGN_REFRESH_INTERVAL_TICKS,
+  OCCUPIED_CONTROLLER_SIGN_TEXT
+} from '../src/territory/controllerSigning';
 
 describe('controller manager', () => {
   beforeEach(() => {
@@ -78,6 +82,48 @@ describe('controller manager', () => {
 
     expect(plan.upgradePriority).toBe('fallback');
     expect(plan.spawnDemand).toBeUndefined();
+  });
+
+  it('records a stale owned controller signature as signing demand', () => {
+    const signedAt = 300;
+    const plan = buildControllerManagementPlan(
+      makeColony({
+        controller: makeController({
+          sign: {
+            username: 'me',
+            text: OCCUPIED_CONTROLLER_SIGN_TEXT,
+            time: signedAt,
+            datetime: new Date('2026-05-07T00:00:00.000Z')
+          }
+        })
+      }),
+      { worker: 3 },
+      3,
+      signedAt + CONTROLLER_SIGN_REFRESH_INTERVAL_TICKS
+    );
+
+    expect(plan.signNeeded).toBe(true);
+  });
+
+  it('does not record signing demand for a fresh owned controller signature', () => {
+    const signedAt = 300;
+    const plan = buildControllerManagementPlan(
+      makeColony({
+        controller: makeController({
+          sign: {
+            username: 'me',
+            text: OCCUPIED_CONTROLLER_SIGN_TEXT,
+            time: signedAt,
+            datetime: new Date('2026-05-07T00:00:00.000Z')
+          }
+        })
+      }),
+      { worker: 3 },
+      3,
+      signedAt + CONTROLLER_SIGN_REFRESH_INTERVAL_TICKS - 1
+    );
+
+    expect(plan.signNeeded).toBe(false);
   });
 
   it('keeps the dedicated upgrade demand while construction work is visible', () => {

--- a/prod/test/controllerSigning.test.ts
+++ b/prod/test/controllerSigning.test.ts
@@ -1,4 +1,5 @@
 import {
+  CONTROLLER_SIGN_REFRESH_INTERVAL_TICKS,
   getControllerSigningActorUsername,
   OCCUPIED_CONTROLLER_SIGN_TEXT,
   shouldSignOccupiedController,
@@ -11,6 +12,7 @@ describe('controller signing', () => {
   beforeEach(() => {
     (globalThis as unknown as { ERR_NOT_IN_RANGE: number; OK: number }).ERR_NOT_IN_RANGE = -9;
     (globalThis as unknown as { OK: number }).OK = 0;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { time: 1_000 };
   });
 
   it('signs an unsigned owned controller with the occupied-area text', () => {
@@ -81,6 +83,31 @@ describe('controller signing', () => {
 
     expect(creep.signController).not.toHaveBeenCalled();
     expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
+  it('refreshes a correctly signed owned controller after the periodic interval', () => {
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 123 + CONTROLLER_SIGN_REFRESH_INTERVAL_TICKS
+    };
+    const controller = {
+      id: 'controller1',
+      my: true,
+      sign: {
+        username: 'me',
+        text: OCCUPIED_CONTROLLER_SIGN_TEXT,
+        time: 123,
+        datetime: '2026-04-29T00:00:00.000Z'
+      }
+    } as unknown as StructureController;
+    const creep = {
+      signController: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    expect(shouldSignOccupiedController(controller)).toBe(true);
+    expect(signOccupiedControllerIfNeeded(creep, controller)).toBe('signed');
+
+    expect(creep.signController).toHaveBeenCalledWith(controller, OCCUPIED_CONTROLLER_SIGN_TEXT);
   });
 
   it('signs a controller reserved by the colony actor', () => {

--- a/prod/test/upgraderRunner.test.ts
+++ b/prod/test/upgraderRunner.test.ts
@@ -3,7 +3,10 @@ import {
   runUpgrader,
   runUpgraderCreep
 } from '../src/creeps/upgraderRunner';
-import { OCCUPIED_CONTROLLER_SIGN_TEXT } from '../src/territory/controllerSigning';
+import {
+  CONTROLLER_SIGN_REFRESH_INTERVAL_TICKS,
+  OCCUPIED_CONTROLLER_SIGN_TEXT
+} from '../src/territory/controllerSigning';
 
 describe('upgrader runner', () => {
   beforeEach(() => {
@@ -81,6 +84,30 @@ describe('upgrader runner', () => {
   it('signs owned controllers before upgrading', () => {
     const controller = makeController({
       sign: { username: 'other', text: 'old', time: 1, datetime: new Date('2026-05-07T00:00:00.000Z') }
+    });
+    const creep = {
+      signController: jest.fn().mockReturnValue(0),
+      upgradeController: jest.fn().mockReturnValue(0)
+    } as unknown as Creep;
+
+    expect(runUpgrader(creep, controller)).toBe(0);
+
+    expect(creep.signController).toHaveBeenCalledWith(controller, OCCUPIED_CONTROLLER_SIGN_TEXT);
+    expect(creep.upgradeController).toHaveBeenCalledWith(controller);
+  });
+
+  it('refreshes stale owned controller signatures before upgrading', () => {
+    const signedAt = 25;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: signedAt + CONTROLLER_SIGN_REFRESH_INTERVAL_TICKS
+    };
+    const controller = makeController({
+      sign: {
+        username: 'me',
+        text: OCCUPIED_CONTROLLER_SIGN_TEXT,
+        time: signedAt,
+        datetime: new Date('2026-05-07T00:00:00.000Z')
+      }
     });
     const creep = {
       signController: jest.fn().mockReturnValue(0),


### PR DESCRIPTION
Implements controller.sign with text "by Hermes Screeps Project" — a simple P1 bot capability for territory branding.

## Changes
- `controllerManager.ts`: Integrate signing into controller tick management
- `controllerSigning.ts`: Signing logic with project branding text  
- Tests: controllerManager, controllerSigning, upgraderRunner test updates

## Verification
- `npm run typecheck` — PASS
- `npm test -- --runInBand` — 94 suites, 1738 tests PASS

Closes #918