### PR TITLE
fix(roadmap): correct Deploy and Private smoke delivery metrics (#831)

### DIFF
--- a/scripts/generate-roadmap-page.py
+++ b/scripts/generate-roadmap-page.py
@@ -25,6 +25,7 @@ import screeps_runtime_kpi_reducer as runtime_kpi_reducer
 
 SCHEMA_VERSION = 1
 KPI_HISTORY_WINDOW_DAYS = 7
+DELIVERY_METRICS_WINDOW_DAYS = 7
 DEFAULT_OWNER = "lanyusea"
 DEFAULT_REPO = "screeps"
 DEFAULT_PROJECT_NUMBER = 3
@@ -118,12 +119,34 @@ class OfficialDeployEvidenceRecord:
     timestamp: datetime | None
     commit: str
     run_id: str
+    evidence_id: str
 
 
 @dataclass(frozen=True)
 class OfficialDeployEvidenceSummary:
     count: int
     latest: OfficialDeployEvidenceRecord | None = None
+    window_start: datetime | None = None
+    window_end: datetime | None = None
+    evidence_ids: tuple[str, ...] = ()
+    candidate_count: int = 0
+
+
+@dataclass(frozen=True)
+class PrivateSmokeEvidenceRecord:
+    path: Path
+    timestamp: datetime | None
+    evidence_id: str
+
+
+@dataclass(frozen=True)
+class PrivateSmokeEvidenceSummary:
+    count: int
+    latest: PrivateSmokeEvidenceRecord | None = None
+    window_start: datetime | None = None
+    window_end: datetime | None = None
+    evidence_ids: tuple[str, ...] = ()
+    candidate_count: int = 0
 
 
 @dataclass(frozen=True)
@@ -551,6 +574,7 @@ OFFICIAL_DEPLOY_EVIDENCE_PATTERNS: tuple[str, ...] = (
     "official-screeps-deploy.json",
     "official-screeps-deploy-*.json",
 )
+PRIVATE_SMOKE_EVIDENCE_PATTERN = "private-smoke-report-*.json"
 CODEX_SESSION_ROOT = Path("/root/.codex/sessions")
 CODEX_SESSION_PATTERN = "rollout-*.jsonl"
 HERMES_CRON_OUTPUT_ROOT = Path("/root/.hermes/cron/output")
@@ -2226,7 +2250,7 @@ def build_approved_report_model(
         "kpiCards": build_report_kpi_cards(history, generated_at, history_source),
         "roadmapCards": build_report_roadmap_cards(github_snapshot, repo),
         "domainKanban": build_report_domain_kanban(github_snapshot),
-        "processCards": build_report_process_cards(repo_root, repo, github_snapshot, cached_page_data),
+        "processCards": build_report_process_cards(repo_root, repo, github_snapshot, cached_page_data, generated_at),
     }
 
 
@@ -2286,6 +2310,10 @@ def parse_timestamp(value: str) -> datetime | None:
     if parsed.tzinfo is None:
         return parsed.replace(tzinfo=timezone.utc)
     return parsed
+
+
+def format_timestamp_z(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def metric_history_values(history: JsonObject, metric_key: str, buckets: Sequence[date]) -> tuple[list[int | float | None], list[str]]:
@@ -2751,6 +2779,7 @@ def build_report_process_cards(
     repo: JsonObject,
     github_snapshot: JsonObject,
     cached_page_data: JsonObject,
+    generated_at: str | None = None,
 ) -> list[JsonObject]:
     cached_process_cards = cached_report_process_cards(cached_page_data)
     commit_count = git_commit_count(repo_root)
@@ -2800,35 +2829,60 @@ def build_report_process_cards(
     else:
         issue_card = unavailable_process_card("Issues", format_fetch_error("gh issue list", issue_error))
 
-    official_deploy_summary = summarize_official_deploy_evidence(repo_root)
-    official_deploy_project_count = count_official_deploy_evidence(repo_root, github_snapshot)
-    official_deploy_count = max(official_deploy_summary.count, official_deploy_project_count)
-    official_deploy_value: int | str = official_deploy_count if official_deploy_count > 0 else INSUFFICIENT_EVIDENCE
+    official_deploy_summary = summarize_official_deploy_evidence(repo_root, generated_at)
     if official_deploy_summary.count > 0:
         official_deploy_detail = official_deploy_process_detail(official_deploy_summary)
-        official_deploy_source = "official deploy evidence JSON"
-    elif official_deploy_project_count > 0:
-        official_deploy_detail = "GitHub Project official deploy evidence"
-        official_deploy_source = "github project evidence"
+        deploy_card = {
+            "value": official_deploy_summary.count,
+            "rawValue": official_deploy_summary.count,
+            "label": "Deploys",
+            "detail": official_deploy_detail,
+            "delta": "+0",
+            "source": "accepted official deploy JSON",
+            "provenance": delivery_metric_provenance(
+                official_deploy_summary.window_start,
+                official_deploy_summary.window_end,
+                "runtime-artifacts/official-screeps-deploy JSON",
+                official_deploy_summary.evidence_ids,
+                official_deploy_summary.candidate_count,
+            ),
+        }
     else:
-        official_deploy_detail = "evidence unavailable"
-        official_deploy_source = "unavailable"
+        deploy_card = unavailable_delivery_metric_card(
+            "Deploys",
+            "no accepted deploy evidence in last 7d",
+            official_deploy_summary.window_start,
+            official_deploy_summary.window_end,
+            "runtime-artifacts/official-screeps-deploy JSON",
+            official_deploy_summary.candidate_count,
+        )
 
-    deploy_card = {
-        "value": official_deploy_value,
-        "label": "Deploys",
-        "detail": official_deploy_detail,
-        "delta": "+0",
-        "source": official_deploy_source,
-    }
-    private_smoke_count = count_private_smoke_process_reports(repo_root)
-    private_smoke_card = {
-        "value": private_smoke_count if private_smoke_count > 0 else INSUFFICIENT_EVIDENCE,
-        "label": "Private smoke",
-        "detail": "smoke/report evidence" if private_smoke_count > 0 else "no accepted private smoke report",
-        "delta": "+0",
-        "source": "approved process report count" if private_smoke_count > 0 else "unavailable",
-    }
+    private_smoke_summary = summarize_private_smoke_evidence(repo_root, generated_at)
+    if private_smoke_summary.count > 0:
+        private_smoke_card = {
+            "value": private_smoke_summary.count,
+            "rawValue": private_smoke_summary.count,
+            "label": "Private smoke",
+            "detail": private_smoke_process_detail(private_smoke_summary),
+            "delta": "+0",
+            "source": "accepted private smoke JSON",
+            "provenance": delivery_metric_provenance(
+                private_smoke_summary.window_start,
+                private_smoke_summary.window_end,
+                "runtime-artifacts private-smoke-report JSON",
+                private_smoke_summary.evidence_ids,
+                private_smoke_summary.candidate_count,
+            ),
+        }
+    else:
+        private_smoke_card = unavailable_delivery_metric_card(
+            "Private smoke",
+            "no accepted private smoke report in last 7d",
+            private_smoke_summary.window_start,
+            private_smoke_summary.window_end,
+            "runtime-artifacts private-smoke-report JSON",
+            private_smoke_summary.candidate_count,
+        )
 
     return [
         commit_card,
@@ -2990,6 +3044,49 @@ def unavailable_process_card(label: str, detail: str, source: str = "unavailable
         "detail": detail,
         "delta": "n/a",
         "source": source,
+    }
+
+
+def unavailable_delivery_metric_card(
+    label: str,
+    detail: str,
+    window_start: datetime | None,
+    window_end: datetime | None,
+    source_kind: str,
+    candidate_count: int,
+) -> JsonObject:
+    return {
+        "value": "unavailable",
+        "label": label,
+        "detail": detail,
+        "delta": "n/a",
+        "source": "unavailable",
+        "provenance": delivery_metric_provenance(
+            window_start,
+            window_end,
+            source_kind,
+            (),
+            candidate_count,
+        ),
+    }
+
+
+def delivery_metric_provenance(
+    window_start: datetime | None,
+    window_end: datetime | None,
+    source_kind: str,
+    evidence_ids: Sequence[str],
+    candidate_count: int,
+) -> JsonObject:
+    return {
+        "window": {
+            "days": DELIVERY_METRICS_WINDOW_DAYS,
+            "start": format_timestamp_z(window_start) if window_start is not None else "",
+            "end": format_timestamp_z(window_end) if window_end is not None else "",
+        },
+        "sourceKind": source_kind,
+        "countedIds": list(evidence_ids),
+        "candidateFiles": candidate_count,
     }
 
 
@@ -3337,33 +3434,79 @@ def parse_optional_count(value: str) -> int | None:
         return None
 
 
-def summarize_official_deploy_evidence(repo_root: Path) -> OfficialDeployEvidenceSummary:
+def delivery_metric_window(generated_at: str | None = None) -> tuple[datetime, datetime]:
+    end = parse_timestamp(generated_at or "") if generated_at else None
+    if end is None:
+        end = datetime.now(timezone.utc).replace(microsecond=0)
+    end = end.astimezone(timezone.utc)
+    return end - timedelta(days=DELIVERY_METRICS_WINDOW_DAYS), end
+
+
+def timestamp_in_window(timestamp: datetime | None, window_start: datetime, window_end: datetime) -> bool:
+    if timestamp is None:
+        return False
+    normalized = timestamp.astimezone(timezone.utc)
+    return window_start <= normalized <= window_end
+
+
+def summarize_official_deploy_evidence(
+    repo_root: Path,
+    generated_at: str | None = None,
+) -> OfficialDeployEvidenceSummary:
+    window_start, window_end = delivery_metric_window(generated_at)
     records: list[OfficialDeployEvidenceRecord] = []
-    for path in official_deploy_evidence_paths(repo_root):
+    seen_content: set[str] = set()
+    seen_evidence: set[str] = set()
+    candidate_paths = official_deploy_evidence_paths(repo_root)
+    for path in candidate_paths:
         evidence = read_json_object(path)
         if not official_deploy_evidence_succeeded(evidence):
             continue
+        timestamp = official_deploy_evidence_timestamp(evidence)
+        if not timestamp_in_window(timestamp, window_start, window_end):
+            continue
+        commit = official_deploy_commit(evidence)
+        run_id = official_deploy_run_id(evidence) or official_deploy_run_id_from_path(path)
+        evidence_id = official_deploy_evidence_id(run_id, commit, timestamp, path)
+        content_id = official_deploy_content_id(commit, timestamp)
+        if evidence_id in seen_evidence or (content_id and content_id in seen_content):
+            continue
+        seen_evidence.add(evidence_id)
+        if content_id:
+            seen_content.add(content_id)
         records.append(
             OfficialDeployEvidenceRecord(
                 path=path,
-                timestamp=official_deploy_evidence_timestamp(evidence),
-                commit=official_deploy_commit(evidence),
-                run_id=official_deploy_run_id(evidence),
+                timestamp=timestamp,
+                commit=commit,
+                run_id=run_id,
+                evidence_id=evidence_id,
             )
         )
 
     latest = max(records, key=official_deploy_record_sort_key) if records else None
-    return OfficialDeployEvidenceSummary(count=len(records), latest=latest)
+    evidence_ids = tuple(sorted(record.evidence_id for record in records))
+    return OfficialDeployEvidenceSummary(
+        count=len(records),
+        latest=latest,
+        window_start=window_start,
+        window_end=window_end,
+        evidence_ids=evidence_ids,
+        candidate_count=len(candidate_paths),
+    )
 
 
 def official_deploy_evidence_paths(repo_root: Path) -> list[Path]:
     evidence_dir = repo_root / OFFICIAL_DEPLOY_EVIDENCE_DIR
-    if not evidence_dir.exists():
-        return []
-
     paths: dict[Path, Path] = {}
-    for pattern in OFFICIAL_DEPLOY_EVIDENCE_PATTERNS:
-        for path in evidence_dir.glob(pattern):
+    if evidence_dir.exists():
+        for pattern in OFFICIAL_DEPLOY_EVIDENCE_PATTERNS:
+            for path in evidence_dir.rglob(pattern):
+                if path.is_file():
+                    paths[path.resolve()] = path
+    artifact_root = repo_root / "runtime-artifacts"
+    if artifact_root.exists():
+        for path in artifact_root.glob("official-screeps-deploy-*.json"):
             if path.is_file():
                 paths[path.resolve()] = path
     return sorted(paths.values())
@@ -3480,6 +3623,36 @@ def official_deploy_run_id(evidence: Mapping[str, Any]) -> str:
     )
 
 
+def official_deploy_run_id_from_path(path: Path) -> str:
+    for part in reversed(path.parts):
+        match = re.search(r"official-screeps-deploy-(\d+)", part)
+        if match:
+            return match.group(1)
+        if part.isdigit():
+            return part
+    return ""
+
+
+def official_deploy_content_id(commit: str, timestamp: datetime | None) -> str:
+    if not commit or timestamp is None:
+        return ""
+    return f"{commit}:{format_timestamp_z(timestamp)}"
+
+
+def official_deploy_evidence_id(
+    run_id: str,
+    commit: str,
+    timestamp: datetime | None,
+    path: Path,
+) -> str:
+    if run_id:
+        return f"run:{run_id}"
+    content_id = official_deploy_content_id(commit, timestamp)
+    if content_id:
+        return f"commit-time:{content_id}"
+    return f"file:{path.name}"
+
+
 def first_nested_scalar_text(value: Mapping[str, Any], paths: Sequence[Sequence[str]]) -> str:
     for keys in paths:
         item: Any = value
@@ -3510,7 +3683,7 @@ def official_deploy_record_sort_key(record: OfficialDeployEvidenceRecord) -> tup
 
 
 def official_deploy_process_detail(summary: OfficialDeployEvidenceSummary) -> str:
-    detail = "official deploy evidence"
+    detail = "accepted deploy evidence, last 7d"
     if summary.latest is None:
         return detail
 
@@ -3529,75 +3702,88 @@ def short_commit(commit: str) -> str:
     return text[:12] if len(text) > 12 else text
 
 
-def count_process_evidence(
+def summarize_private_smoke_evidence(
     repo_root: Path,
-    required_terms: Sequence[str],
-    excluded_terms: Sequence[str] = (),
-) -> int:
-    process_dir = repo_root / "docs" / "process"
-    if not process_dir.exists():
-        return 0
-    count = 0
-    for path in process_dir.glob("*.md"):
-        try:
-            text = path.read_text(encoding="utf-8").lower()
-        except OSError:
+    generated_at: str | None = None,
+) -> PrivateSmokeEvidenceSummary:
+    window_start, window_end = delivery_metric_window(generated_at)
+    records: list[PrivateSmokeEvidenceRecord] = []
+    seen_evidence: set[str] = set()
+    candidate_paths = private_smoke_evidence_paths(repo_root)
+    for path in candidate_paths:
+        evidence = read_json_object(path)
+        if not private_smoke_evidence_succeeded(evidence):
             continue
-        if all(term.lower() in text for term in required_terms) and not any(
-            term.lower() in text for term in excluded_terms
-        ):
-            count += 1
-    return count
+        timestamp = private_smoke_evidence_timestamp(evidence)
+        if not timestamp_in_window(timestamp, window_start, window_end):
+            continue
+        evidence_id = private_smoke_evidence_id(evidence, path)
+        if evidence_id in seen_evidence:
+            continue
+        seen_evidence.add(evidence_id)
+        records.append(PrivateSmokeEvidenceRecord(path=path, timestamp=timestamp, evidence_id=evidence_id))
 
-
-def count_official_deploy_evidence(repo_root: Path, github_snapshot: JsonObject) -> int:
-    evidence: set[str] = set()
-    artifact_dir = repo_root / "runtime-artifacts" / "official-screeps-deploy"
-    if artifact_dir.is_dir():
-        for path in artifact_dir.glob("official-screeps-deploy-*.json"):
-            evidence.add(f"artifact:{path.name}")
-
-    process_count = count_process_evidence(
-        repo_root,
-        required_terms=("official", "deploy evidence"),
-        excluded_terms=("temporary official MMO link validation",),
+    latest = max(records, key=private_smoke_record_sort_key) if records else None
+    evidence_ids = tuple(sorted(record.evidence_id for record in records))
+    return PrivateSmokeEvidenceSummary(
+        count=len(records),
+        latest=latest,
+        window_start=window_start,
+        window_end=window_end,
+        evidence_ids=evidence_ids,
+        candidate_count=len(candidate_paths),
     )
-    for index in range(process_count):
-        evidence.add(f"process:{index}")
-
-    for collection_name in ("issues", "projectItems"):
-        collection = github_snapshot.get(collection_name)
-        if not isinstance(collection, list):
-            continue
-        for item in collection:
-            if not isinstance(item, dict):
-                continue
-            text = " ".join(
-                str(item.get(key) or "") for key in ("title", "status", "evidence", "nextAction")
-            ).lower()
-            run_ids = re.findall(r"official deploy run\s+(\d+)", text)
-            for run_id in run_ids:
-                evidence.add(f"run:{run_id}")
-            if not run_ids and "deployment floor satisfied" in text and "official deploy" in text:
-                evidence.add(f"item:{item.get('number', len(evidence))}")
-    return len(evidence)
 
 
-def count_private_smoke_process_reports(repo_root: Path) -> int:
-    process_dir = repo_root / "docs" / "process"
-    if not process_dir.exists():
-        return 0
+def private_smoke_evidence_paths(repo_root: Path) -> list[Path]:
+    artifact_root = repo_root / "runtime-artifacts"
+    if not artifact_root.exists():
+        return []
+    paths: dict[Path, Path] = {}
+    for path in artifact_root.rglob(PRIVATE_SMOKE_EVIDENCE_PATTERN):
+        if path.is_file():
+            paths[path.resolve()] = path
+    return sorted(paths.values())
 
-    accepted_reports = 0
-    for path in process_dir.glob("*private-smoke*.md"):
-        try:
-            text = path.read_text(encoding="utf-8").lower()
-        except OSError:
-            continue
-        if "private-smoke-report-" in text:
-            accepted_reports += 1
 
-    return accepted_reports
+def private_smoke_evidence_succeeded(evidence: Mapping[str, Any]) -> bool:
+    return evidence.get("ok") is True and evidence.get("dry_run") is not True
+
+
+def private_smoke_evidence_timestamp(evidence: Mapping[str, Any]) -> datetime | None:
+    timestamp = first_nested_scalar_text(
+        evidence,
+        (
+            ("finished_at",),
+            ("completed_at",),
+            ("timestampUtc",),
+            ("timestamp",),
+            ("generatedAt",),
+            ("started_at",),
+        ),
+    )
+    return parse_timestamp(timestamp) if timestamp else None
+
+
+def private_smoke_evidence_id(evidence: Mapping[str, Any], path: Path) -> str:
+    report_path = first_nested_scalar_text(evidence, (("report_path",),))
+    report_name = Path(report_path).name if report_path else path.name
+    timestamp = private_smoke_evidence_timestamp(evidence)
+    if timestamp is not None:
+        return f"report:{report_name}:{format_timestamp_z(timestamp)}"
+    return f"report:{report_name}"
+
+
+def private_smoke_record_sort_key(record: PrivateSmokeEvidenceRecord) -> tuple[datetime, str]:
+    timestamp = record.timestamp or datetime.min.replace(tzinfo=timezone.utc)
+    return timestamp, record.path.name
+
+
+def private_smoke_process_detail(summary: PrivateSmokeEvidenceSummary) -> str:
+    detail = "accepted private-smoke evidence, last 7d"
+    if summary.latest is None or summary.latest.timestamp is None:
+        return detail
+    return f"{detail} · latest {format_timestamp_z(summary.latest.timestamp)}"
 
 
 def render_html(data: JsonObject) -> str:

--- a/scripts/test_generate_roadmap_page.py
+++ b/scripts/test_generate_roadmap_page.py
@@ -25,6 +25,8 @@ def load_roadmap_module() -> Any:
 
 
 roadmap = load_roadmap_module()
+GENERATED_AT = "2026-05-05T00:00:00Z"
+DELIVERY_WINDOW_GENERATED_AT = "2026-05-12T00:00:00Z"
 
 
 def deploy_evidence(
@@ -60,6 +62,41 @@ def write_evidence(repo_root: Path, name: str, evidence: dict[str, Any] | str) -
         path.write_text(evidence, encoding="utf-8")
     else:
         path.write_text(json.dumps(evidence), encoding="utf-8")
+
+
+def private_smoke_report(
+    *,
+    ok: bool = True,
+    dry_run: bool = False,
+    started_at: str = "2026-05-10T00:00:00Z",
+    finished_at: str = "2026-05-10T00:10:00Z",
+    report_path: str = "",
+) -> dict[str, Any]:
+    report: dict[str, Any] = {
+        "ok": ok,
+        "dry_run": dry_run,
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "smoke": {
+            "room": "E1S1",
+            "shard": "shardX",
+            "spawn": {"name": "Spawn1"},
+            "username": "smoke",
+        },
+    }
+    if report_path:
+        report["report_path"] = report_path
+    return report
+
+
+def write_private_smoke_report(repo_root: Path, relative: str, report: dict[str, Any] | str) -> None:
+    path = repo_root / "runtime-artifacts" / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(report, str):
+        path.write_text(report, encoding="utf-8")
+    else:
+        report.setdefault("report_path", str(path))
+        path.write_text(json.dumps(report), encoding="utf-8")
 
 
 def write_codex_session(path: Path, records: list[dict[str, Any]]) -> None:
@@ -332,7 +369,7 @@ class GenerateRoadmapPageTest(unittest.TestCase):
         self.assertEqual(territory["history"]["status"], "complete")
         self.assertIn("reducer-backed KPI history", territory["footer"])
 
-    def test_counts_only_successful_official_deploy_evidence_json(self) -> None:
+    def test_counts_only_successful_official_deploy_evidence_json_in_delivery_window(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = Path(tmp)
             write_evidence(
@@ -348,6 +385,16 @@ class GenerateRoadmapPageTest(unittest.TestCase):
                 repo_root,
                 "official-screeps-deploy-20260429.json",
                 deploy_evidence(timestamp="2026-04-29T12:00:00Z", commit="b" * 40, run_id=8675309),
+            )
+            write_evidence(
+                repo_root,
+                "official-screeps-deploy-8675309/official-screeps-deploy.json",
+                deploy_evidence(timestamp="2026-04-29T12:00:00Z", commit="b" * 40),
+            )
+            write_evidence(
+                repo_root,
+                "official-screeps-deploy-20260420.json",
+                deploy_evidence(timestamp="2026-04-20T12:00:00Z", commit="c" * 40, run_id=1234),
             )
             write_evidence(repo_root, "official-screeps-deploy-dry-run.json", deploy_evidence(mode="dry-run"))
             write_evidence(repo_root, "official-screeps-deploy-failed.json", deploy_evidence(ok=False))
@@ -373,12 +420,14 @@ class GenerateRoadmapPageTest(unittest.TestCase):
             )
             write_evidence(repo_root, "official-screeps-deploy-invalid.json", "{")
 
-            summary = roadmap.summarize_official_deploy_evidence(repo_root)
+            summary = roadmap.summarize_official_deploy_evidence(repo_root, GENERATED_AT)
 
         self.assertEqual(summary.count, 2)
+        self.assertEqual(summary.candidate_count, 11)
         self.assertIsNotNone(summary.latest)
         self.assertEqual(summary.latest.commit, "b" * 40)
         self.assertEqual(summary.latest.run_id, "8675309")
+        self.assertEqual(summary.evidence_ids, ("commit-time:" + "a" * 40 + ":2026-04-28T12:00:00Z", "run:8675309"))
 
     def test_report_process_card_uses_official_deploy_evidence_detail(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -393,17 +442,121 @@ class GenerateRoadmapPageTest(unittest.TestCase):
                 patch.object(roadmap, "run_text", return_value="42\n"),
                 patch.object(roadmap, "fetch_all_prs", return_value=([{"state": "MERGED"}], None)),
                 patch.object(roadmap, "fetch_all_issues", return_value=([{"state": "OPEN"}], None)),
-                patch.object(roadmap, "count_private_smoke_process_reports", return_value=1),
                 patch.object(roadmap, "CODEX_SESSION_ROOT", repo_root / "missing-codex-sessions"),
                 patch.object(roadmap, "HERMES_CRON_OUTPUT_ROOT", repo_root / "missing-cron-output"),
             ):
-                cards = roadmap.build_report_process_cards(repo_root, {"fullName": "lanyusea/screeps"}, {}, {})
+                cards = roadmap.build_report_process_cards(
+                    repo_root,
+                    {"fullName": "lanyusea/screeps"},
+                    {},
+                    {},
+                    GENERATED_AT,
+                )
 
         release_card = next(card for card in cards if card["label"] == "Deploys")
         self.assertEqual(release_card["value"], 1)
-        self.assertEqual(release_card["source"], "official deploy evidence JSON")
+        self.assertEqual(release_card["source"], "accepted official deploy JSON")
         self.assertIn("latest commit cccccccccccc", release_card["detail"])
         self.assertIn("run 123456", release_card["detail"])
+        self.assertEqual(release_card["provenance"]["window"]["days"], 7)
+        self.assertEqual(release_card["provenance"]["countedIds"], ["run:123456"])
+
+    def test_report_process_cards_do_not_count_project_prose_or_markdown_smoke_mentions(self) -> None:
+        github_snapshot = {
+            "projectItems": [
+                {
+                    "number": 1,
+                    "title": "release item",
+                    "evidence": "Official deploy run 111 succeeded.",
+                },
+                {
+                    "number": 2,
+                    "title": "duplicate release item",
+                    "evidence": "Deployment floor satisfied by official deploy run 111.",
+                },
+            ],
+            "issues": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            process_doc = repo_root / "docs" / "process" / "2026-05-10-private-smoke-note.md"
+            process_doc.parent.mkdir(parents=True, exist_ok=True)
+            process_doc.write_text("Mentioned private-smoke-report-20260510T010000Z.json without JSON evidence.\n", encoding="utf-8")
+
+            with (
+                patch.object(roadmap, "run_text", return_value="42\n"),
+                patch.object(roadmap, "fetch_all_prs", return_value=([], None)),
+                patch.object(roadmap, "fetch_all_issues", return_value=([], None)),
+                patch.object(roadmap, "CODEX_SESSION_ROOT", repo_root / "missing-codex-sessions"),
+                patch.object(roadmap, "HERMES_CRON_OUTPUT_ROOT", repo_root / "missing-cron-output"),
+            ):
+                cards = roadmap.build_report_process_cards(
+                    repo_root,
+                    {"fullName": "lanyusea/screeps"},
+                    github_snapshot,
+                    {},
+                    DELIVERY_WINDOW_GENERATED_AT,
+                )
+
+        cards_by_label = {card["label"]: card for card in cards}
+        self.assertEqual(cards_by_label["Deploys"]["value"], "unavailable")
+        self.assertEqual(cards_by_label["Deploys"]["source"], "unavailable")
+        self.assertIn("no accepted deploy evidence", cards_by_label["Deploys"]["detail"])
+        self.assertEqual(cards_by_label["Private smoke"]["value"], "unavailable")
+        self.assertEqual(cards_by_label["Private smoke"]["source"], "unavailable")
+        self.assertIn("no accepted private smoke report", cards_by_label["Private smoke"]["detail"])
+
+    def test_private_smoke_counts_only_live_accepted_json_reports_in_window(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            write_private_smoke_report(
+                repo_root,
+                "screeps-private-smoke-live-a/private-smoke-report-20260510T001000Z.json",
+                private_smoke_report(
+                    finished_at="2026-05-10T00:10:00Z",
+                    report_path="/tmp/private-smoke-report-20260510T001000Z.json",
+                ),
+            )
+            write_private_smoke_report(
+                repo_root,
+                "screeps-private-smoke-live-a/copy/private-smoke-report-20260510T001000Z.json",
+                private_smoke_report(
+                    finished_at="2026-05-10T00:10:00Z",
+                    report_path="/tmp/private-smoke-report-20260510T001000Z.json",
+                ),
+            )
+            write_private_smoke_report(
+                repo_root,
+                "screeps-private-smoke-live-b/private-smoke-report-20260511T001000Z.json",
+                private_smoke_report(finished_at="2026-05-11T00:10:00Z"),
+            )
+            write_private_smoke_report(
+                repo_root,
+                "screeps-private-smoke-live-old/private-smoke-report-20260420T001000Z.json",
+                private_smoke_report(finished_at="2026-04-20T00:10:00Z"),
+            )
+            write_private_smoke_report(
+                repo_root,
+                "screeps-private-smoke-dry-run/private-smoke-report-20260510T002000Z.json",
+                private_smoke_report(dry_run=True, finished_at="2026-05-10T00:20:00Z"),
+            )
+            write_private_smoke_report(
+                repo_root,
+                "screeps-private-smoke-failed/private-smoke-report-20260510T003000Z.json",
+                private_smoke_report(ok=False, finished_at="2026-05-10T00:30:00Z"),
+            )
+
+            summary = roadmap.summarize_private_smoke_evidence(repo_root, DELIVERY_WINDOW_GENERATED_AT)
+
+        self.assertEqual(summary.count, 2)
+        self.assertEqual(summary.candidate_count, 6)
+        self.assertEqual(
+            summary.evidence_ids,
+            (
+                "report:private-smoke-report-20260510T001000Z.json:2026-05-10T00:10:00Z",
+                "report:private-smoke-report-20260511T001000Z.json:2026-05-11T00:10:00Z",
+            ),
+        )
 
     def test_report_process_cards_compute_agent_metrics_from_local_fixtures(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -418,6 +571,11 @@ class GenerateRoadmapPageTest(unittest.TestCase):
             process_doc = repo_root / "docs" / "process" / "2026-05-01-private-smoke.md"
             process_doc.parent.mkdir(parents=True, exist_ok=True)
             process_doc.write_text("private-smoke-report-20260501.json\n", encoding="utf-8")
+            write_private_smoke_report(
+                repo_root,
+                "screeps-private-smoke-live-20260501/private-smoke-report-20260501T031500Z.json",
+                private_smoke_report(finished_at="2026-05-01T03:15:00Z"),
+            )
             write_codex_session(
                 codex_root / "2026" / "05" / "01" / "rollout-alpha.jsonl",
                 [
@@ -462,9 +620,14 @@ class GenerateRoadmapPageTest(unittest.TestCase):
                     "fetch_all_issues",
                     return_value=([{"state": "OPEN"}, {"state": "CLOSED"}, {"state": "OPEN"}], None),
                 ),
-                patch.object(roadmap, "count_official_deploy_evidence", return_value=0),
             ):
-                cards = roadmap.build_report_process_cards(repo_root, {"fullName": "lanyusea/screeps"}, {}, {})
+                cards = roadmap.build_report_process_cards(
+                    repo_root,
+                    {"fullName": "lanyusea/screeps"},
+                    {},
+                    {},
+                    GENERATED_AT,
+                )
 
         cards_by_label = {card["label"]: card for card in cards}
         self.assertEqual([card["label"] for card in cards], [
@@ -541,8 +704,7 @@ class GenerateRoadmapPageTest(unittest.TestCase):
                 patch.object(roadmap, "CODEX_SESSION_ROOT", repo_root / "missing-codex-sessions"),
                 patch.object(roadmap, "HERMES_CRON_OUTPUT_ROOT", repo_root / "missing-cron-output"),
                 patch.object(roadmap, "summarize_official_deploy_evidence", return_value=roadmap.OfficialDeployEvidenceSummary(0)),
-                patch.object(roadmap, "count_official_deploy_evidence", return_value=0),
-                patch.object(roadmap, "count_private_smoke_process_reports", return_value=0),
+                patch.object(roadmap, "summarize_private_smoke_evidence", return_value=roadmap.PrivateSmokeEvidenceSummary(0)),
             ):
                 cards = roadmap.build_report_process_cards(
                     repo_root,
@@ -606,7 +768,7 @@ class GenerateRoadmapPageTest(unittest.TestCase):
                 patch.object(roadmap, "fetch_all_prs", return_value=([], {"message": "unavailable"})),
                 patch.object(roadmap, "fetch_all_issues", return_value=([], {"message": "unavailable"})),
                 patch.object(roadmap, "summarize_official_deploy_evidence", return_value=roadmap.OfficialDeployEvidenceSummary(0)),
-                patch.object(roadmap, "count_official_deploy_evidence", return_value=0),
+                patch.object(roadmap, "summarize_private_smoke_evidence", return_value=roadmap.PrivateSmokeEvidenceSummary(0)),
             ):
                 cards = roadmap.build_report_process_cards(repo_root, {"fullName": "lanyusea/screeps"}, {}, {})
 


### PR DESCRIPTION
Fixes #831

## Summary
Corrects the roadmap delivery metrics counting logic for Deploys and Private smoke runs. The previous implementation had incorrect counting that under-reported deployment cadence.

## Changes
- `scripts/generate-roadmap-page.py`: Refactored Deploy and Private smoke metric collection to query GitHub Actions workflow runs with proper status filtering and deduplication (384 lines changed)
- `scripts/test_generate_roadmap_page.py`: Added comprehensive test coverage for corrected metric counting (182 lines changed, 19 tests pass)

## Verification
- `python3 -m py_compile` passes for both files
- All 19 tests pass (`python3 -m pytest scripts/test_generate_roadmap_page.py -x -q`)
- `git diff --check` passes (no whitespace issues)