### PR TITLE
fix(rl): add worker phase debug logging to E2 simulator harness

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -969,7 +969,10 @@ def _debug_worker_phase(worker_index: int, variant_id: str, phase: str, **detail
     for key, value in sorted(details.items()):
         if value is None:
             continue
-        detail_parts.append(f"{key}={json.dumps(_safe_text(value, 160), ensure_ascii=True)}")
+        try:
+            detail_parts.append(f"{key}={json.dumps(_safe_text(value, 160), ensure_ascii=True)}")
+        except Exception:
+            detail_parts.append(f"{key}=\"[unserializable]\"")
     detail_text = f" {' '.join(detail_parts)}" if detail_parts else ""
     print(
         f"{timestamp} rl-sim-worker[{worker_index}] variant={variant_id} "

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -962,6 +962,21 @@ def _resolve_smoke_map_source_file(map_source_file: Path) -> Path | None:
     raise RuntimeError(f"map source file is not a file: {resolved}")
 
 
+def _debug_worker_phase(worker_index: int, variant_id: str, phase: str, **details: object) -> None:
+    """Emit bounded stderr phase logs for diagnosing worker startup hangs."""
+    timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    detail_parts = []
+    for key, value in sorted(details.items()):
+        if value is None:
+            continue
+        detail_parts.append(f"{key}={json.dumps(_safe_text(value, 160), ensure_ascii=True)}")
+    detail_text = f" {' '.join(detail_parts)}" if detail_parts else ""
+    print(
+        f"{timestamp} rl-sim-worker[{worker_index}] variant={variant_id} "
+        f"phase={json.dumps(phase, ensure_ascii=True)}{detail_text}",
+        file=sys.stderr,
+        flush=True,
+    )
 def _terrain_payload_has_data(payload: Any) -> bool:
     summary = _terrain_summary(payload)
     return bool(summary.get("bytes"))
@@ -1469,12 +1484,27 @@ def _run_variant(
         compose = smoke.find_compose_command()
         smoke.prepare_work_dir(cfg)
         launcher_auto_map_import_disabled = _disable_launcher_auto_map_import(smoke, cfg)
+        _debug_worker_phase(
+            worker_index,
+            variant_id,
+            "after _disable_launcher_auto_map_import",
+            disabled=launcher_auto_map_import_disabled,
+        )
         repair_mod_path = _install_simulator_repair_mod(smoke, cfg)
+        _debug_worker_phase(
+            worker_index,
+            variant_id,
+            "after _install_simulator_repair_mod",
+            mod_path=repair_mod_path,
+        )
         smoke.prepare_map(cfg)
         scenario_map_source_file = smoke_map_source_file or cfg.map_path
+        _debug_worker_phase(worker_index, variant_id, "after prepare_map", map_path=str(scenario_map_source_file))
 
         # Reset server-owned state by removing any leftover stack and volumes first.
+        _debug_worker_phase(worker_index, variant_id, "before docker compose down", command="down -v")
         smoke.run_command([*compose, "down", "-v"], cfg, timeout=RUN_CONTAINER_DOWN_TIMEOUT_SECONDS)
+        _debug_worker_phase(worker_index, variant_id, "before docker compose up", command="up -d")
         smoke.run_command([*compose, "up", "-d"], cfg, timeout=RUN_CONTAINER_UP_TIMEOUT_SECONDS)
         _wait_for_http_with_smoke(cfg, smoke, timeout_seconds=RUN_CONTAINER_UP_TIMEOUT_SECONDS)
         _require_launcher_cli_success(smoke, compose, cfg, "system.resetAllData()", "reset simulator data")


### PR DESCRIPTION
## Summary
Recovered and committed orphaned Codex work from the fix/e2-harness-hang worktree. The Codex agent left 30 lines of uncommitted changes adding worker-phase debug logging to the E2 simulator harness. Changes were merged with current main (2c4cd5c7, which already contained #956 E2 harness fixes), conflicts resolved, tests passed (39/39), and committed with Codex authorship.

## Changes
- Added `_debug_worker_phase()` helper function for bounded stderr phase diagnostics
- Added debug logging calls around: launcher auto-map-import disable, repair mod install, map prepare, docker compose down, docker compose up
- All debug output goes to stderr with structured JSON details

## Verification
- `python3 -m pytest scripts/test_screeps_rl_simulator_harness.py`: 39 passed, 6 subtests passed
- `python3 -m py_compile`: passed
- No conflict markers remain

## Related
- #879 (ALL IN RL umbrella)
- #956 (prior E2 harness fixes already merged to main)
- RL conclusion rlc-20260510-training-not-running (E2 simulator 0 ticks, 100% failure)