### PR TITLE
feat(metrics): add 7 console capture fields and metric taxonomy v2 (#960)

### DIFF
--- a/docs/ops/metric-taxonomy.md
+++ b/docs/ops/metric-taxonomy.md
@@ -1,0 +1,78 @@
+# Metric Taxonomy
+
+Status: runtime-summary console capture schema v2 for issue #960.
+
+This document describes the room-level `#runtime-summary` payload consumed by the KPI reducer, RL metrics SQLite ingestor, dashboard, and Gameplay Evolution review loop. The v2 schema is additive: older artifacts without these fields remain valid and historical SQLite columns stay `NULL` when a field was not present.
+
+## Console Capture Payload
+
+Top-level payload:
+
+| Field | Source | Type | Interpretation | Coverage |
+| --- | --- | --- | --- | --- |
+| `type` | monitor payload constant | string | Must be `runtime-summary`; identifies reducer-compatible lines. | INSTRUMENTED |
+| `tick` | room snapshot `gameTime`/overview time | integer or null | Latest game tick represented by the payload. | INSTRUMENTED |
+| `source` | monitor payload constant | string | Producer identity for audit/debugging. | INSTRUMENTED |
+| `rooms` | collected room snapshots | array | Per-room gameplay metrics. | INSTRUMENTED |
+| `cpu.used` | snapshot `info.cpu.used`/`info.cpuUsed` when available | number or null | CPU used for the tick/window. | INSTRUMENTED |
+| `cpu.bucket` | snapshot `info.cpu.bucket`/`info.cpuBucket` when available | number or null | Screeps CPU bucket reserve. | INSTRUMENTED |
+| `reliability.loopExceptionCount` | in-bot runtime summary only | number | Tick-loop exception count. | MISSING |
+| `reliability.telemetrySilenceTicks` | in-bot runtime summary only | number | Runtime telemetry silence window. | MISSING |
+
+Per-room payload:
+
+| Field | Source | Type | Interpretation | Coverage |
+| --- | --- | --- | --- | --- |
+| `roomName` | room ref | string | Screeps room name without shard. | INSTRUMENTED |
+| `shard` | room ref | string | Screeps shard name. | INSTRUMENTED |
+| `pendingBuildProgress` | owned construction sites, sum of `progressTotal - progress` | number | Remaining construction work in the room. `0` means no owned construction backlog is visible. | INSTRUMENTED |
+| `buildCarriedEnergy` | owned creeps with build role/task, `carry.energy` or store fallback | number | Energy builders can currently spend on construction. `0` with backlog suggests builder starvation or misassignment. | INSTRUMENTED |
+| `constructionSiteCount` | owned construction site objects | number | Active owned construction sites. | INSTRUMENTED |
+| `cpuUsed` | snapshot CPU info copied to room metrics | number or null | CPU used this tick/window when the API snapshot exposes it. | INSTRUMENTED |
+| `cpuBucket` | snapshot CPU info copied to room metrics | number or null | CPU bucket when the API snapshot exposes it. | INSTRUMENTED |
+| `rclLevel` | room controller `level` | number or null | Room controller level. `null` means no controller was visible. | INSTRUMENTED |
+| `storedEnergy` | structures with store/energy, excluding confirmed foreign-owned structures | number | Energy held in spawn/extension/container/storage-like structures. | INSTRUMENTED |
+| `controller.level` | controller object `level` | number or null | Existing nested RCL field. | INSTRUMENTED |
+| `controller.progress` | controller object `progress` | number or null | Current controller upgrade progress. | INSTRUMENTED |
+| `controller.progressTotal` | controller object `progressTotal` | number or null | Progress required for next RCL. | INSTRUMENTED |
+| `controller.ticksToDowngrade` | controller object `ticksToDowngrade` | number or null | Downgrade safety window. | INSTRUMENTED |
+| `resources.storedEnergy` | same value as room `storedEnergy` | number | Durable room energy reserve for existing resource dashboards. | INSTRUMENTED |
+| `resources.workerCarriedEnergy` | owned creep stores/carry | number | Energy currently carried by owned creeps. | INSTRUMENTED |
+| `resources.droppedEnergy` | dropped energy resource objects | number | Visible dropped energy in room. | INSTRUMENTED |
+| `resources.sourceCount` | source objects | number | Visible energy source count. | INSTRUMENTED |
+| `resources.productiveEnergy.pendingBuildProgress` | same value as room `pendingBuildProgress` | number | Existing productive-energy namespace for construction analysis. | INSTRUMENTED |
+| `resources.productiveEnergy.buildCarriedEnergy` | same value as room `buildCarriedEnergy` | number | Builder energy under productive-energy namespace. | INSTRUMENTED |
+| `resources.productiveEnergy.constructionSiteCount` | same value as room `constructionSiteCount` | number | Construction site count under productive-energy namespace. | INSTRUMENTED |
+| `resources.harvestedThisTick` | in-bot runtime summary event accounting | number | Energy harvested during the tick/window. | MISSING |
+| `resources.events.harvestedEnergy` | in-bot runtime summary event accounting | number | Window harvest delta for reducer event summaries. | MISSING |
+| `resources.events.transferredEnergy` | in-bot runtime summary event accounting | number | Window transfer delta for reducer event summaries. | MISSING |
+| `combat.hostileCreepCount` | hostile creep objects | number | Visible hostile creeps. | INSTRUMENTED |
+| `combat.hostileStructureCount` | confirmed foreign-owned structures | number | Visible hostile structures. | INSTRUMENTED |
+| `combat.events.attackCount` | in-bot combat event accounting | number | Attack action count in the tick/window. | MISSING |
+| `combat.events.attackDamage` | in-bot combat event accounting | number | Attack damage dealt in the tick/window. | MISSING |
+| `combat.events.objectDestroyedCount` | in-bot combat event accounting | number | Destroyed object count in the tick/window. | MISSING |
+| `combat.events.creepDestroyedCount` | in-bot combat event accounting | number | Destroyed creep count in the tick/window. | MISSING |
+
+## SQLite Persistence
+
+The historical store is `runtime-artifacts/rl-metrics/rl_metrics.sqlite`. The seven v2 fields are persisted in `runtime_room_metrics`:
+
+| Column | Capture field | NULL behavior |
+| --- | --- | --- |
+| `pending_build_progress` | `pendingBuildProgress` | `NULL` for old rows or unreadable values. |
+| `build_carried_energy` | `buildCarriedEnergy` | `NULL` for old rows or unreadable values. |
+| `construction_site_count` | `constructionSiteCount` | `NULL` for old rows or unreadable values. |
+| `cpu_used` | `cpuUsed` | `NULL` when CPU data is not exposed by the snapshot. |
+| `cpu_bucket` | `cpuBucket` | `NULL` when CPU data is not exposed by the snapshot. |
+| `rcl_level` | `rclLevel` | `NULL` when no controller is visible. |
+| `stored_energy` | `storedEnergy` | `NULL` for historical rows before v2. |
+
+The ingestor also emits metric observations for dashboard queries where useful: `construction.pending_build_progress`, `construction.build_carried_energy`, `construction.site_count`, `territory.rcl_level`, `cpu.used`, `cpu.bucket`, and `economy.stored_energy`.
+
+## Coverage Gap Workflow
+
+1. Gap: a missing field, missing source root, or ambiguous behavior signal is recorded as `metric_coverage_gaps` or marked `MISSING` in this taxonomy.
+2. Issue: the controller opens or refreshes a GitHub issue with the smallest implementation surface needed to close the gap.
+3. Implementation: code changes add instrumentation without removing older fields or invalidating historical artifacts.
+4. Verification: run script compilation/tests, ingest a representative artifact, and confirm the reducer/SQLite summary exposes the field.
+5. Close: after the field is observed in live or fixture evidence and the automated review gate is satisfied, close the issue and update this taxonomy from `MISSING` to `INSTRUMENTED`.

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -394,6 +394,20 @@ class RoomSnapshot:
         )
 
 
+@dataclass
+class RoomSummaryMetrics:
+    structures: list[dict[str, Any]]
+    controller_summary: dict[str, Any]
+    owned_creep_objects: list[dict[str, Any]]
+    construction_sites: list[dict[str, Any]]
+    pending_build_progress: int | float
+    build_carried_energy: int | float
+    stored_energy: int | float
+    cpu_used: int | float | None
+    cpu_bucket: int | float | None
+    rcl_level: int | float | None
+
+
 def esc(value: Any) -> str:
     return html.escape(str(value), quote=True)
 
@@ -2408,22 +2422,7 @@ def render_room_snapshot(
 def room_summary(snapshot: RoomSnapshot, image: str | None = None) -> dict[str, Any]:
     info = snapshot.info if isinstance(snapshot.info, dict) else {}
     hostiles = detect_hostile_creeps(snapshot.objects, snapshot.owner)
-    structures = structure_objects(snapshot.objects)
-    controller = next((obj for obj in structures if obj.get("type") == "controller"), None)
-    owned_creep_objects = [
-        obj
-        for obj in snapshot.objects.values()
-        if (
-            isinstance(obj, dict)
-            and obj.get("type") == "creep"
-            and is_owned_object(obj, snapshot.owner, snapshot.expected_owner_id)
-        )
-    ]
-    construction_sites = owned_construction_sites(snapshot)
-    pending_build_progress = sum(construction_site_pending_progress(site) for site in construction_sites)
-    build_carried_energy = sum(carried_energy(creep) for creep in owned_creep_objects if creep_has_build_task(creep))
-    stored_energy = room_stored_energy(snapshot.objects, snapshot.owner)
-    owned_creeps = count_owned_objects(snapshot.objects, snapshot.owner, "creep", snapshot.expected_owner_id)
+    metrics = compute_room_summary_metrics(snapshot)
     owned_spawns = count_owned_objects(snapshot.objects, snapshot.owner, "spawn", snapshot.expected_owner_id)
     summary = {
         "room": snapshot.ref.key,
@@ -2432,21 +2431,21 @@ def room_summary(snapshot: RoomSnapshot, image: str | None = None) -> dict[str, 
         "tick": snapshot.tick,
         "objects": len(snapshot.objects),
         "creeps": snapshot.counts.get("creep", 0),
-        "owned_creeps": owned_creeps,
-        "structures": len(structures),
-        "spawns": sum(1 for structure in structures if structure.get("type") == "spawn"),
+        "owned_creeps": len(metrics.owned_creep_objects),
+        "structures": len(metrics.structures),
+        "spawns": sum(1 for structure in metrics.structures if structure.get("type") == "spawn"),
         "owned_spawns": owned_spawns,
         "hostiles": len(hostiles),
         "owner": snapshot.owner,
         "expected_owner": snapshot.expected_owner,
         "expected_owner_id": snapshot.expected_owner_id,
-        "pendingBuildProgress": pending_build_progress,
-        "buildCarriedEnergy": build_carried_energy,
-        "constructionSiteCount": len(construction_sites),
-        "cpuUsed": snapshot_cpu_used(snapshot),
-        "cpuBucket": snapshot_cpu_bucket(snapshot),
-        "rclLevel": number_value(controller.get("level")) if controller is not None else None,
-        "storedEnergy": stored_energy,
+        "pendingBuildProgress": metrics.pending_build_progress,
+        "buildCarriedEnergy": metrics.build_carried_energy,
+        "constructionSiteCount": len(metrics.construction_sites),
+        "cpuUsed": metrics.cpu_used,
+        "cpuBucket": metrics.cpu_bucket,
+        "rclLevel": metrics.rcl_level,
+        "storedEnergy": metrics.stored_energy,
         "energyCapacity": number_value(info.get("energyCapacity") or info.get("energyCapacityAvailable")),
         "energyCapacityAvailable": number_value(info.get("energyCapacityAvailable")),
         "energyBufferHealth": as_dict(info.get("energyBufferHealth")),
@@ -2703,6 +2702,41 @@ def snapshot_cpu_bucket(snapshot: RoomSnapshot) -> int | float | None:
     )
 
 
+def compute_room_summary_metrics(snapshot: RoomSnapshot) -> RoomSummaryMetrics:
+    structures = structure_objects(snapshot.objects)
+    controller = next((obj for obj in structures if obj.get("type") == "controller"), None)
+    owned_creep_objects = [
+        obj
+        for obj in snapshot.objects.values()
+        if (
+            isinstance(obj, dict)
+            and obj.get("type") == "creep"
+            and is_owned_object(obj, snapshot.owner, snapshot.expected_owner_id)
+        )
+    ]
+    construction_sites = owned_construction_sites(snapshot)
+    pending_build_progress = sum(construction_site_pending_progress(site) for site in construction_sites)
+    build_carried_energy = sum(carried_energy(creep) for creep in owned_creep_objects if creep_has_build_task(creep))
+    stored_energy = room_stored_energy(snapshot.objects, snapshot.owner)
+    controller_summary: dict[str, Any] = {}
+    if controller is not None:
+        for key in ("level", "progress", "progressTotal", "ticksToDowngrade"):
+            controller_summary[key] = number_value(controller.get(key))
+
+    return RoomSummaryMetrics(
+        structures=structures,
+        controller_summary=controller_summary,
+        owned_creep_objects=owned_creep_objects,
+        construction_sites=construction_sites,
+        pending_build_progress=pending_build_progress,
+        build_carried_energy=build_carried_energy,
+        stored_energy=stored_energy,
+        cpu_used=snapshot_cpu_used(snapshot),
+        cpu_bucket=snapshot_cpu_bucket(snapshot),
+        rcl_level=number_value(controller.get("level")) if controller is not None else None,
+    )
+
+
 def confirmed_foreign_owner(obj: dict[str, Any], owner_username: str | None) -> bool:
     username = room_owner(obj)
     return bool(username is not None and username != owner_username)
@@ -2710,11 +2744,8 @@ def confirmed_foreign_owner(obj: dict[str, Any], owner_username: str | None) -> 
 
 def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
     objects = snapshot.objects
-    owned_creeps = [
-        obj
-        for obj in objects.values()
-        if isinstance(obj, dict) and obj.get("type") == "creep" and is_owned_object(obj, snapshot.owner)
-    ]
+    metrics = compute_room_summary_metrics(snapshot)
+    owned_creeps = metrics.owned_creep_objects
     sources = [obj for obj in objects.values() if isinstance(obj, dict) and obj.get("type") == "source"]
     dropped_energy = [
         obj
@@ -2727,43 +2758,30 @@ def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
     hostiles = detect_hostile_creeps(objects, snapshot.owner)
     hostile_structures = [
         obj
-        for obj in structure_objects(objects)
+        for obj in metrics.structures
         if confirmed_foreign_owner(obj, snapshot.owner)
     ]
-    controller = next((obj for obj in structure_objects(objects) if obj.get("type") == "controller"), None)
-    construction_sites = owned_construction_sites(snapshot)
-    pending_build_progress = sum(construction_site_pending_progress(site) for site in construction_sites)
-    build_carried_energy = sum(carried_energy(creep) for creep in owned_creeps if creep_has_build_task(creep))
-    stored_energy = room_stored_energy(objects, snapshot.owner)
-    rcl_level = number_value(controller.get("level")) if controller is not None else None
-    cpu_used = snapshot_cpu_used(snapshot)
-    cpu_bucket = snapshot_cpu_bucket(snapshot)
-
-    controller_summary: dict[str, Any] = {}
-    if controller is not None:
-        for key in ("level", "progress", "progressTotal", "ticksToDowngrade"):
-            controller_summary[key] = number_value(controller.get(key))
 
     return {
         "roomName": snapshot.ref.room,
         "shard": snapshot.ref.shard,
-        "pendingBuildProgress": pending_build_progress,
-        "buildCarriedEnergy": build_carried_energy,
-        "constructionSiteCount": len(construction_sites),
-        "cpuUsed": cpu_used,
-        "cpuBucket": cpu_bucket,
-        "rclLevel": rcl_level,
-        "storedEnergy": stored_energy,
-        "controller": controller_summary,
+        "pendingBuildProgress": metrics.pending_build_progress,
+        "buildCarriedEnergy": metrics.build_carried_energy,
+        "constructionSiteCount": len(metrics.construction_sites),
+        "cpuUsed": metrics.cpu_used,
+        "cpuBucket": metrics.cpu_bucket,
+        "rclLevel": metrics.rcl_level,
+        "storedEnergy": metrics.stored_energy,
+        "controller": metrics.controller_summary,
         "resources": {
-            "storedEnergy": stored_energy,
+            "storedEnergy": metrics.stored_energy,
             "workerCarriedEnergy": sum(store_energy(obj) for obj in owned_creeps),
             "droppedEnergy": sum(number_value(obj.get("amount")) or 0 for obj in dropped_energy),
             "sourceCount": len(sources),
             "productiveEnergy": {
-                "pendingBuildProgress": pending_build_progress,
-                "buildCarriedEnergy": build_carried_energy,
-                "constructionSiteCount": len(construction_sites),
+                "pendingBuildProgress": metrics.pending_build_progress,
+                "buildCarriedEnergy": metrics.build_carried_energy,
+                "constructionSiteCount": len(metrics.construction_sites),
             },
         },
         "combat": {

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -102,6 +102,13 @@ CRITICAL_STRUCTURE_TYPES = {
     "tower",
 }
 
+ENERGY_STORAGE_STRUCTURE_TYPES = {
+    "container",
+    "extension",
+    "spawn",
+    "storage",
+}
+
 TACTICAL_SEVERITY_RANK = {
     "none": 0,
     "warning": 1,
@@ -2402,6 +2409,20 @@ def room_summary(snapshot: RoomSnapshot, image: str | None = None) -> dict[str, 
     info = snapshot.info if isinstance(snapshot.info, dict) else {}
     hostiles = detect_hostile_creeps(snapshot.objects, snapshot.owner)
     structures = structure_objects(snapshot.objects)
+    controller = next((obj for obj in structures if obj.get("type") == "controller"), None)
+    owned_creep_objects = [
+        obj
+        for obj in snapshot.objects.values()
+        if (
+            isinstance(obj, dict)
+            and obj.get("type") == "creep"
+            and is_owned_object(obj, snapshot.owner, snapshot.expected_owner_id)
+        )
+    ]
+    construction_sites = owned_construction_sites(snapshot)
+    pending_build_progress = sum(construction_site_pending_progress(site) for site in construction_sites)
+    build_carried_energy = sum(carried_energy(creep) for creep in owned_creep_objects if creep_has_build_task(creep))
+    stored_energy = room_stored_energy(snapshot.objects, snapshot.owner)
     owned_creeps = count_owned_objects(snapshot.objects, snapshot.owner, "creep", snapshot.expected_owner_id)
     owned_spawns = count_owned_objects(snapshot.objects, snapshot.owner, "spawn", snapshot.expected_owner_id)
     summary = {
@@ -2419,6 +2440,13 @@ def room_summary(snapshot: RoomSnapshot, image: str | None = None) -> dict[str, 
         "owner": snapshot.owner,
         "expected_owner": snapshot.expected_owner,
         "expected_owner_id": snapshot.expected_owner_id,
+        "pendingBuildProgress": pending_build_progress,
+        "buildCarriedEnergy": build_carried_energy,
+        "constructionSiteCount": len(construction_sites),
+        "cpuUsed": snapshot_cpu_used(snapshot),
+        "cpuBucket": snapshot_cpu_bucket(snapshot),
+        "rclLevel": number_value(controller.get("level")) if controller is not None else None,
+        "storedEnergy": stored_energy,
         "energyCapacity": number_value(info.get("energyCapacity") or info.get("energyCapacityAvailable")),
         "energyCapacityAvailable": number_value(info.get("energyCapacityAvailable")),
         "energyBufferHealth": as_dict(info.get("energyBufferHealth")),
@@ -2568,8 +2596,111 @@ def store_energy(obj: dict[str, Any]) -> int | float:
         energy = number_value(store.get("energy"))
         if energy is not None:
             return energy
+    carry = obj.get("carry")
+    if isinstance(carry, dict):
+        energy = number_value(carry.get("energy"))
+        if energy is not None:
+            return energy
     energy = number_value(obj.get("energy"))
     return energy if energy is not None else 0
+
+
+def carried_energy(obj: dict[str, Any]) -> int | float:
+    carry = obj.get("carry")
+    if isinstance(carry, dict):
+        energy = number_value(carry.get("energy"))
+        if energy is not None:
+            return energy
+    return store_energy(obj)
+
+
+def first_number_value(value: Any, *paths: tuple[str, ...]) -> int | float | None:
+    for path in paths:
+        found = number_value(nested_value(value, *path))
+        if found is not None:
+            return found
+    return None
+
+
+def construction_site_pending_progress(site: dict[str, Any]) -> int | float:
+    progress = number_value(site.get("progress")) or 0
+    progress_total = number_value(site.get("progressTotal"))
+    if progress_total is None:
+        return 0
+    return max(0, progress_total - progress)
+
+
+def is_owned_construction_site(site: dict[str, Any], snapshot: RoomSnapshot) -> bool:
+    return site.get("type") == "constructionSite" and is_owned_object(
+        site,
+        snapshot.owner,
+        snapshot.expected_owner_id,
+    )
+
+
+def owned_construction_sites(snapshot: RoomSnapshot) -> list[dict[str, Any]]:
+    return [
+        obj
+        for obj in snapshot.objects.values()
+        if isinstance(obj, dict) and is_owned_construction_site(obj, snapshot)
+    ]
+
+
+def object_has_build_task(value: Any) -> bool:
+    if isinstance(value, str):
+        lowered = value.lower()
+        return lowered == "build" or lowered == "builder" or lowered.endswith(":build")
+    if isinstance(value, dict):
+        for key, item in value.items():
+            lowered_key = str(key).lower()
+            if lowered_key in {"role", "task", "taskname", "action", "job", "intent"} and object_has_build_task(item):
+                return True
+            if isinstance(item, dict) and object_has_build_task(item):
+                return True
+        return False
+    return False
+
+
+def creep_has_build_task(creep: dict[str, Any]) -> bool:
+    for candidate in (
+        creep.get("role"),
+        creep.get("task"),
+        creep.get("memory"),
+        creep.get("runtimeTask"),
+        creep.get("assignment"),
+    ):
+        if object_has_build_task(candidate):
+            return True
+    return False
+
+
+def room_stored_energy(objects: dict[str, dict[str, Any]], owner_username: str | None) -> int | float:
+    total: int | float = 0
+    for obj in structure_objects(objects):
+        if confirmed_foreign_owner(obj, owner_username):
+            continue
+        if isinstance(obj.get("store"), dict) or obj.get("type") in ENERGY_STORAGE_STRUCTURE_TYPES:
+            total += store_energy(obj)
+    return total
+
+
+def snapshot_cpu_used(snapshot: RoomSnapshot) -> int | float | None:
+    return first_number_value(
+        snapshot.info,
+        ("cpu", "used"),
+        ("cpu", "cpuUsed"),
+        ("cpuUsed",),
+        ("usedCpu",),
+    )
+
+
+def snapshot_cpu_bucket(snapshot: RoomSnapshot) -> int | float | None:
+    return first_number_value(
+        snapshot.info,
+        ("cpu", "bucket"),
+        ("cpuBucket",),
+        ("bucket",),
+    )
 
 
 def confirmed_foreign_owner(obj: dict[str, Any], owner_username: str | None) -> bool:
@@ -2579,7 +2710,6 @@ def confirmed_foreign_owner(obj: dict[str, Any], owner_username: str | None) -> 
 
 def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
     objects = snapshot.objects
-    owned_structures = [obj for obj in structure_objects(objects) if is_owned_object(obj, snapshot.owner)]
     owned_creeps = [
         obj
         for obj in objects.values()
@@ -2601,6 +2731,13 @@ def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
         if confirmed_foreign_owner(obj, snapshot.owner)
     ]
     controller = next((obj for obj in structure_objects(objects) if obj.get("type") == "controller"), None)
+    construction_sites = owned_construction_sites(snapshot)
+    pending_build_progress = sum(construction_site_pending_progress(site) for site in construction_sites)
+    build_carried_energy = sum(carried_energy(creep) for creep in owned_creeps if creep_has_build_task(creep))
+    stored_energy = room_stored_energy(objects, snapshot.owner)
+    rcl_level = number_value(controller.get("level")) if controller is not None else None
+    cpu_used = snapshot_cpu_used(snapshot)
+    cpu_bucket = snapshot_cpu_bucket(snapshot)
 
     controller_summary: dict[str, Any] = {}
     if controller is not None:
@@ -2610,12 +2747,24 @@ def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
     return {
         "roomName": snapshot.ref.room,
         "shard": snapshot.ref.shard,
+        "pendingBuildProgress": pending_build_progress,
+        "buildCarriedEnergy": build_carried_energy,
+        "constructionSiteCount": len(construction_sites),
+        "cpuUsed": cpu_used,
+        "cpuBucket": cpu_bucket,
+        "rclLevel": rcl_level,
+        "storedEnergy": stored_energy,
         "controller": controller_summary,
         "resources": {
-            "storedEnergy": sum(store_energy(obj) for obj in owned_structures),
+            "storedEnergy": stored_energy,
             "workerCarriedEnergy": sum(store_energy(obj) for obj in owned_creeps),
             "droppedEnergy": sum(number_value(obj.get("amount")) or 0 for obj in dropped_energy),
             "sourceCount": len(sources),
+            "productiveEnergy": {
+                "pendingBuildProgress": pending_build_progress,
+                "buildCarriedEnergy": build_carried_energy,
+                "constructionSiteCount": len(construction_sites),
+            },
         },
         "combat": {
             "hostileCreepCount": len(hostiles),
@@ -2626,10 +2775,13 @@ def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
 
 def runtime_summary_payload_from_snapshots(snapshots: list[RoomSnapshot]) -> dict[str, Any]:
     ticks = [snapshot.tick for snapshot in snapshots if isinstance(snapshot.tick, int)]
+    cpu_used = next((value for value in (snapshot_cpu_used(snapshot) for snapshot in snapshots) if value is not None), None)
+    cpu_bucket = next((value for value in (snapshot_cpu_bucket(snapshot) for snapshot in snapshots) if value is not None), None)
     return {
         "type": "runtime-summary",
         "tick": max(ticks) if ticks else None,
         "rooms": [runtime_summary_room(snapshot) for snapshot in snapshots],
+        "cpu": {"used": cpu_used, "bucket": cpu_bucket},
         "source": "screeps-runtime-monitor",
     }
 

--- a/scripts/screeps_kpi_reducer.py
+++ b/scripts/screeps_kpi_reducer.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Compatibility entrypoint for the runtime KPI reducer."""
+
+from __future__ import annotations
+
+from screeps_runtime_kpi_reducer import *  # noqa: F403 - preserve legacy script/module surface
+from screeps_runtime_kpi_reducer import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/screeps_rl_metrics_ingestor.py
+++ b/scripts/screeps_rl_metrics_ingestor.py
@@ -556,7 +556,7 @@ RUNTIME_ROOM_METRIC_COLUMNS = {
 
 DEDUPE_TABLE_KEYS = {
     "metric_observations": ("metric_name", "tick", "room_name", "source_artifact", "evidence_json"),
-    "runtime_room_metrics": ("tick", "room_name", "source_artifact"),
+    "runtime_room_metrics": ("tick", "shard", "room_name", "source_artifact"),
     "gameplay_behavior_findings": ("finding_key", "source_artifact", "tick", "room_name"),
     "metric_coverage_gaps": ("metric_name", "source_artifact", "room_name", "tick", "gap_type"),
     "rl_dataset_gate_metrics": ("gate_id", "status", "metric_name", "source_artifact", "evidence_json"),
@@ -893,6 +893,7 @@ def record_runtime_room_metrics(
     dedupe_key = dedupe_key_for_values(
         "runtime_room_metrics",
         tick=tick,
+        shard=shard,
         room_name=room_name,
         source_artifact=source_artifact,
     )

--- a/scripts/screeps_rl_metrics_ingestor.py
+++ b/scripts/screeps_rl_metrics_ingestor.py
@@ -52,6 +52,24 @@ CREATE TABLE IF NOT EXISTS metric_observations (
   dedupe_key TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS runtime_room_metrics (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  observed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  tick INTEGER,
+  shard TEXT,
+  room_name TEXT NOT NULL,
+  pending_build_progress REAL,
+  build_carried_energy REAL,
+  construction_site_count REAL,
+  cpu_used REAL,
+  cpu_bucket REAL,
+  rcl_level REAL,
+  stored_energy REAL,
+  source_artifact TEXT NOT NULL,
+  evidence_json TEXT NOT NULL DEFAULT '{}',
+  dedupe_key TEXT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS gameplay_behavior_findings (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   finding_key TEXT NOT NULL,
@@ -134,6 +152,8 @@ CREATE TABLE IF NOT EXISTS metric_iteration_decisions (
 
 CREATE INDEX IF NOT EXISTS idx_metric_observations_metric_tick
   ON metric_observations(metric_name, tick);
+CREATE INDEX IF NOT EXISTS idx_runtime_room_metrics_room_tick
+  ON runtime_room_metrics(room_name, tick);
 CREATE INDEX IF NOT EXISTS idx_findings_category_severity
   ON gameplay_behavior_findings(category, severity);
 CREATE INDEX IF NOT EXISTS idx_coverage_metric
@@ -211,6 +231,16 @@ METRIC_DEFINITIONS = [
         "interpretation": "A value above grace means expansion survival is failing.",
         "missing_coverage_behavior": "Record a gap if claim age is not emitted.",
         "promotion_rule": "Critical after grace; warning while age telemetry is missing.",
+    },
+    {
+        "metric_name": "territory.rcl_level",
+        "category": "survival/ownership",
+        "purpose": "Track room controller level from room-level runtime summary fields.",
+        "source_artifacts": "#runtime-summary room.rclLevel or controller.level",
+        "directionality": "higher is better",
+        "interpretation": "RCL progression is durable territory/economy capability evidence.",
+        "missing_coverage_behavior": "Leave historical rows NULL and rely on controller coverage gaps.",
+        "promotion_rule": "Repeated absence promotes controller-level telemetry work.",
     },
     {
         "metric_name": "economy.energy_available",
@@ -311,6 +341,26 @@ METRIC_DEFINITIONS = [
         "interpretation": "Backlog with no build progress means construction is stalled.",
         "missing_coverage_behavior": "Record construction telemetry gap when priority exists but backlog/progress is absent.",
         "promotion_rule": "Repeated backlog with zero build promotes to construction issue.",
+    },
+    {
+        "metric_name": "construction.pending_build_progress",
+        "category": "construction/infrastructure",
+        "purpose": "Track remaining progress across owned construction sites.",
+        "source_artifacts": "#runtime-summary pendingBuildProgress",
+        "directionality": "lower is better when planned work should progress",
+        "interpretation": "Positive values mean build work remains available in the room.",
+        "missing_coverage_behavior": "Leave historical rows NULL and fall back to backlog coverage gaps.",
+        "promotion_rule": "Repeated positive value with no build work promotes construction issue.",
+    },
+    {
+        "metric_name": "construction.site_count",
+        "category": "construction/infrastructure",
+        "purpose": "Track active owned construction site count per room.",
+        "source_artifacts": "#runtime-summary constructionSiteCount",
+        "directionality": "lower is better after planned sites complete",
+        "interpretation": "Nonzero sites identify build backlog shape and help distinguish no-work from no-builder states.",
+        "missing_coverage_behavior": "Leave historical rows NULL and use construction backlog gaps.",
+        "promotion_rule": "Repeated nonzero value with no build progress promotes construction issue.",
     },
     {
         "metric_name": "construction.build_task_count",
@@ -493,8 +543,20 @@ SOURCE_ROOT_METRICS = {
 }
 
 
+RUNTIME_ROOM_METRIC_COLUMNS = {
+    "pending_build_progress": "REAL",
+    "build_carried_energy": "REAL",
+    "construction_site_count": "REAL",
+    "cpu_used": "REAL",
+    "cpu_bucket": "REAL",
+    "rcl_level": "REAL",
+    "stored_energy": "REAL",
+}
+
+
 DEDUPE_TABLE_KEYS = {
     "metric_observations": ("metric_name", "tick", "room_name", "source_artifact", "evidence_json"),
+    "runtime_room_metrics": ("tick", "room_name", "source_artifact"),
     "gameplay_behavior_findings": ("finding_key", "source_artifact", "tick", "room_name"),
     "metric_coverage_gaps": ("metric_name", "source_artifact", "room_name", "tick", "gap_type"),
     "rl_dataset_gate_metrics": ("gate_id", "status", "metric_name", "source_artifact", "evidence_json"),
@@ -670,6 +732,13 @@ def table_columns(conn: sqlite3.Connection, table_name: str) -> set[str]:
     return {row["name"] for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
 
 
+def ensure_runtime_room_metrics_schema(conn: sqlite3.Connection) -> None:
+    columns = table_columns(conn, "runtime_room_metrics")
+    for column_name, column_type in RUNTIME_ROOM_METRIC_COLUMNS.items():
+        if column_name not in columns:
+            conn.execute(f"ALTER TABLE runtime_room_metrics ADD COLUMN {column_name} {column_type}")
+
+
 def ensure_dedupe_schema(conn: sqlite3.Connection) -> None:
     for table_name, key_columns in DEDUPE_TABLE_KEYS.items():
         columns = table_columns(conn, table_name)
@@ -719,6 +788,7 @@ def remove_duplicate_dedupe_rows(conn: sqlite3.Connection, table_name: str) -> N
 def initialize_database(db_path: Path) -> dict[str, int]:
     with connect_database(db_path) as conn:
         conn.executescript(SCHEMA_SQL)
+        ensure_runtime_room_metrics_schema(conn)
         ensure_dedupe_schema(conn)
         upsert_metric_definitions(conn)
         conn.commit()
@@ -796,6 +866,56 @@ def record_observation(
             value,
             value_text,
             unit,
+            source_artifact,
+            evidence_json,
+            dedupe_key,
+        ),
+    )
+
+
+def record_runtime_room_metrics(
+    conn: sqlite3.Connection,
+    *,
+    source_artifact: str,
+    tick: int | None,
+    shard: str | None,
+    room_name: str,
+    pending_build_progress: float | None,
+    build_carried_energy: float | None,
+    construction_site_count: float | None,
+    cpu_used: float | None,
+    cpu_bucket: float | None,
+    rcl_level: float | None,
+    stored_energy: float | None,
+    evidence: object | None = None,
+) -> None:
+    evidence_json = canonical_json(evidence or {})
+    dedupe_key = dedupe_key_for_values(
+        "runtime_room_metrics",
+        tick=tick,
+        room_name=room_name,
+        source_artifact=source_artifact,
+    )
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO runtime_room_metrics (
+          tick, shard, room_name, pending_build_progress, build_carried_energy,
+          construction_site_count, cpu_used, cpu_bucket, rcl_level, stored_energy,
+          source_artifact, evidence_json, dedupe_key
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            tick,
+            shard,
+            room_name,
+            pending_build_progress,
+            build_carried_energy,
+            construction_site_count,
+            cpu_used,
+            cpu_bucket,
+            rcl_level,
+            stored_energy,
             source_artifact,
             evidence_json,
             dedupe_key,
@@ -1314,13 +1434,34 @@ def process_runtime_room(
     build_tasks = task_count(task_counts, "build")
     upgrade_tasks = task_count(task_counts, "upgrade")
     construction_backlog = construction_backlog_progress(room)
+    pending_build_progress = pending_build_progress_value(room)
+    construction_site_count = construction_site_count_value(room)
     built_progress = built_progress_value(room)
     build_carried_energy = build_carried_energy_value(room)
+    cpu_used = room_cpu_used_value(room)
+    cpu_bucket = room_cpu_bucket_value(room)
+    rcl_level = rcl_level_value(room)
+    stored_energy = stored_energy_value(room)
     hostile_count = hostile_creep_count(room)
     tower_count = structure_count(room, ("tower", "towers"))
     rampart_count = structure_count(room, ("rampart", "ramparts"))
     defense_backlog = defense_backlog_value(room, construction_backlog)
 
+    record_runtime_room_metrics(
+        conn,
+        source_artifact=source_artifact,
+        tick=tick,
+        shard=shard,
+        room_name=room_name,
+        pending_build_progress=pending_build_progress,
+        build_carried_energy=build_carried_energy,
+        construction_site_count=construction_site_count,
+        cpu_used=cpu_used,
+        cpu_bucket=cpu_bucket,
+        rcl_level=rcl_level,
+        stored_energy=stored_energy,
+        evidence={"line": line_number},
+    )
     record_number_if_present(
         conn,
         "survival.owned_spawns",
@@ -1351,6 +1492,26 @@ def process_runtime_room(
         shard,
         room_name,
         {"taskCounts": task_counts},
+    )
+    record_number_if_present(
+        conn,
+        "construction.pending_build_progress",
+        pending_build_progress,
+        source_artifact,
+        tick,
+        shard,
+        room_name,
+        {},
+    )
+    record_number_if_present(
+        conn,
+        "construction.site_count",
+        construction_site_count,
+        source_artifact,
+        tick,
+        shard,
+        room_name,
+        {},
     )
     record_number_if_present(
         conn,
@@ -1385,6 +1546,9 @@ def process_runtime_room(
     record_number_if_present(conn, "defense.hostile_creep_count", hostile_count, source_artifact, tick, shard, room_name, {})
     record_number_if_present(conn, "defense.tower_count", tower_count, source_artifact, tick, shard, room_name, {})
     record_number_if_present(conn, "defense.rampart_count", rampart_count, source_artifact, tick, shard, room_name, {})
+    record_number_if_present(conn, "territory.rcl_level", rcl_level, source_artifact, tick, shard, room_name, {})
+    record_number_if_present(conn, "cpu.used", cpu_used, source_artifact, tick, shard, room_name, {})
+    record_number_if_present(conn, "cpu.bucket", cpu_bucket, source_artifact, tick, shard, room_name, {})
 
     process_energy_metrics(conn, room, source_artifact, tick, shard, room_name)
     process_low_load_metrics(conn, room, source_artifact, tick, shard, room_name)
@@ -1559,6 +1723,36 @@ def construction_backlog_progress(room: dict[str, object]) -> float | None:
     return None
 
 
+def pending_build_progress_value(room: dict[str, object]) -> float | None:
+    return first_number(
+        room,
+        (
+            ("pendingBuildProgress",),
+            ("resources", "productiveEnergy", "pendingBuildProgress"),
+            ("resources", "pendingBuildProgress"),
+            ("construction", "pendingBuildProgress"),
+        ),
+    )
+
+
+def construction_site_count_value(room: dict[str, object]) -> float | None:
+    direct = first_number(
+        room,
+        (
+            ("constructionSiteCount",),
+            ("construction", "siteCount"),
+            ("constructionSites", "count"),
+        ),
+    )
+    if direct is not None:
+        return direct
+    for key in ("constructionSites", "sites"):
+        value = room.get(key)
+        if isinstance(value, list):
+            return float(len(value))
+    return None
+
+
 def built_progress_value(room: dict[str, object]) -> float | None:
     direct = first_number(
         room,
@@ -1588,6 +1782,18 @@ def build_carried_energy_value(room: dict[str, object]) -> float | None:
             ("buildCarriedEnergy",),
         ),
     ) or find_first_number_by_keys(room, ("buildCarriedEnergy", "builderCarriedEnergy"))
+
+
+def rcl_level_value(room: dict[str, object]) -> float | None:
+    return first_number(room, (("rclLevel",), ("controller", "rclLevel"), ("controller", "level")))
+
+
+def room_cpu_used_value(room: dict[str, object]) -> float | None:
+    return first_number(room, (("cpuUsed",), ("cpu", "used")))
+
+
+def room_cpu_bucket_value(room: dict[str, object]) -> float | None:
+    return first_number(room, (("cpuBucket",), ("cpu", "bucket")))
 
 
 def hostile_creep_count(room: dict[str, object]) -> float | None:
@@ -1645,7 +1851,7 @@ def process_energy_metrics(
     room_name: str,
 ) -> None:
     energy_available = first_number(room, (("energyAvailable",), ("energy", "available")))
-    stored_energy = first_number(room, (("resources", "storedEnergy"), ("storedEnergy",), ("storage", "energy")))
+    stored_energy = stored_energy_value(room)
     worker_carried = first_number(
         room,
         (("resources", "workerCarriedEnergy"), ("workerCarriedEnergy",), ("workers", "carriedEnergy")),
@@ -1691,6 +1897,10 @@ def process_energy_metrics(
             gap_type="missing_energy_fields",
             message="no energyAvailable, storedEnergy, or workerCarriedEnergy fields were present",
         )
+
+
+def stored_energy_value(room: dict[str, object]) -> float | None:
+    return first_number(room, (("resources", "storedEnergy"), ("storedEnergy",), ("storage", "energy")))
 
 
 def process_low_load_metrics(
@@ -2302,6 +2512,7 @@ def summarize_database(db_path: Path, output_format: str = "text") -> str:
         for table in (
             "metric_definitions",
             "metric_observations",
+            "runtime_room_metrics",
             "gameplay_behavior_findings",
             "metric_coverage_gaps",
             "rl_dataset_gate_metrics",
@@ -2327,14 +2538,49 @@ def summarize_database(db_path: Path, output_format: str = "text") -> str:
             LIMIT 10
             """
         ).fetchall()
+        latest_tick_row = conn.execute("SELECT MAX(tick) AS latest_tick FROM runtime_room_metrics").fetchone()
+        latest_tick = latest_tick_row["latest_tick"] if latest_tick_row is not None else None
+        if latest_tick is None:
+            runtime_room_row = None
+        else:
+            runtime_room_row = conn.execute(
+                """
+                SELECT
+                  COUNT(*) AS room_samples,
+                  SUM(COALESCE(pending_build_progress, 0)) AS pending_build_progress,
+                  SUM(COALESCE(build_carried_energy, 0)) AS build_carried_energy,
+                  SUM(COALESCE(construction_site_count, 0)) AS construction_site_count,
+                  AVG(cpu_used) AS avg_cpu_used,
+                  MIN(cpu_bucket) AS min_cpu_bucket,
+                  MAX(rcl_level) AS max_rcl_level,
+                  SUM(COALESCE(stored_energy, 0)) AS stored_energy
+                FROM runtime_room_metrics
+                WHERE tick = ?
+                """,
+                (latest_tick,),
+            ).fetchone()
 
     if output_format == "json":
+        latest_runtime_room_metrics = {}
+        if runtime_room_row is not None:
+            latest_runtime_room_metrics = {
+                "tick": latest_tick,
+                "roomSamples": runtime_room_row["room_samples"],
+                "pendingBuildProgress": runtime_room_row["pending_build_progress"],
+                "buildCarriedEnergy": runtime_room_row["build_carried_energy"],
+                "constructionSiteCount": runtime_room_row["construction_site_count"],
+                "avgCpuUsed": runtime_room_row["avg_cpu_used"],
+                "minCpuBucket": runtime_room_row["min_cpu_bucket"],
+                "maxRclLevel": runtime_room_row["max_rcl_level"],
+                "storedEnergy": runtime_room_row["stored_energy"],
+            }
         return json.dumps(
             {
                 "db": str(db_path),
                 "counts": counts,
                 "findingsBySeverity": {row["severity"]: row["count"] for row in severity_rows},
                 "topCoverageGaps": {row["metric_name"]: row["count"] for row in gap_rows},
+                "latestRuntimeRoomMetrics": latest_runtime_room_metrics,
             },
             indent=2,
             sort_keys=True,
@@ -2351,6 +2597,17 @@ def summarize_database(db_path: Path, output_format: str = "text") -> str:
         lines.append("top_coverage_gaps:")
         for row in gap_rows:
             lines.append(f"  {row['metric_name']}: {row['count']}")
+    if runtime_room_row is not None:
+        lines.append("latest_runtime_room_metrics:")
+        lines.append(f"  tick: {latest_tick}")
+        lines.append(f"  room_samples: {runtime_room_row['room_samples']}")
+        lines.append(f"  pendingBuildProgress: {runtime_room_row['pending_build_progress']}")
+        lines.append(f"  buildCarriedEnergy: {runtime_room_row['build_carried_energy']}")
+        lines.append(f"  constructionSiteCount: {runtime_room_row['construction_site_count']}")
+        lines.append(f"  avgCpuUsed: {runtime_room_row['avg_cpu_used']}")
+        lines.append(f"  minCpuBucket: {runtime_room_row['min_cpu_bucket']}")
+        lines.append(f"  maxRclLevel: {runtime_room_row['max_rcl_level']}")
+        lines.append(f"  storedEnergy: {runtime_room_row['stored_energy']}")
     return "\n".join(lines)
 
 

--- a/scripts/screeps_runtime_kpi_reducer.py
+++ b/scripts/screeps_runtime_kpi_reducer.py
@@ -25,6 +25,15 @@ RESOURCE_FIELDS = ("storedEnergy", "workerCarriedEnergy", "harvestedThisTick", "
 RESOURCE_EVENT_FIELDS = ("harvestedEnergy", "transferredEnergy")
 COMBAT_FIELDS = ("hostileCreepCount", "hostileStructureCount")
 COMBAT_EVENT_FIELDS = ("attackCount", "attackDamage", "objectDestroyedCount", "creepDestroyedCount")
+ROOM_LEVEL_FIELDS = (
+    "pendingBuildProgress",
+    "buildCarriedEnergy",
+    "constructionSiteCount",
+    "cpuUsed",
+    "cpuBucket",
+    "rclLevel",
+    "storedEnergy",
+)
 
 
 JsonObject = dict[str, Any]
@@ -41,6 +50,7 @@ class RoomState:
     controller: SectionState = field(default_factory=SectionState)
     resources: SectionState = field(default_factory=SectionState)
     combat: SectionState = field(default_factory=SectionState)
+    room_metrics: SectionState = field(default_factory=SectionState)
     resource_events: dict[str, int | float] = field(default_factory=lambda: zero_totals(RESOURCE_EVENT_FIELDS))
     combat_events: dict[str, int | float] = field(default_factory=lambda: zero_totals(COMBAT_EVENT_FIELDS))
     resource_event_seen: bool = False
@@ -78,6 +88,32 @@ def clean_numeric_section(section: Any, fields: tuple[str, ...]) -> dict[str, in
         return None
 
     return values
+
+
+def clean_room_level_metrics(room: dict[str, Any]) -> dict[str, int | float | None] | None:
+    resources = room.get("resources") if isinstance(room.get("resources"), dict) else {}
+    productive = resources.get("productiveEnergy") if isinstance(resources.get("productiveEnergy"), dict) else {}
+    controller = room.get("controller") if isinstance(room.get("controller"), dict) else {}
+    values = {
+        "pendingBuildProgress": first_number(room, resources, productive, key="pendingBuildProgress"),
+        "buildCarriedEnergy": first_number(room, resources, productive, key="buildCarriedEnergy"),
+        "constructionSiteCount": first_number(room, productive, key="constructionSiteCount"),
+        "cpuUsed": room.get("cpuUsed") if is_number(room.get("cpuUsed")) else None,
+        "cpuBucket": room.get("cpuBucket") if is_number(room.get("cpuBucket")) else None,
+        "rclLevel": first_number(room, controller, key="rclLevel") or (controller.get("level") if is_number(controller.get("level")) else None),
+        "storedEnergy": first_number(room, resources, key="storedEnergy"),
+    }
+    if all(value is None for value in values.values()):
+        return None
+    return values
+
+
+def first_number(*sections: dict[str, Any], key: str) -> int | float | None:
+    for section in sections:
+        value = section.get(key)
+        if is_number(value):
+            return value
+    return None
 
 
 def add_events(target: dict[str, int | float], events: Any, fields: tuple[str, ...]) -> bool:
@@ -162,6 +198,9 @@ def reduce_runtime_kpis(lines: Iterable[str]) -> JsonObject:
                 summary_rooms.add(room_name)
                 room_state = state.rooms.setdefault(room_name, RoomState())
 
+                room_metrics = clean_room_level_metrics(room)
+                update_section(room_state.room_metrics, room_metrics)
+
                 controller = clean_numeric_section(room.get("controller"), CONTROLLER_FIELDS)
                 update_section(room_state.controller, controller)
 
@@ -225,6 +264,16 @@ def build_report(state: ReductionState) -> JsonObject:
             COMBAT_EVENT_FIELDS,
             "combat_events",
             "combat_event_seen",
+        ),
+        "roomMetrics": build_numeric_section_report(
+            state.rooms,
+            first_rooms,
+            latest_rooms,
+            ROOM_LEVEL_FIELDS,
+            "room_metrics",
+            (),
+            "",
+            "",
         ),
     }
 
@@ -463,6 +512,7 @@ def render_human(report: JsonObject) -> str:
 
     lines.append(render_section_human("resources", report["resources"], RESOURCE_FIELDS, RESOURCE_EVENT_FIELDS))
     lines.append(render_section_human("combat", report["combat"], COMBAT_FIELDS, COMBAT_EVENT_FIELDS))
+    lines.append(render_section_human("roomMetrics", report["roomMetrics"], ROOM_LEVEL_FIELDS, ()))
 
     return "\n".join(lines)
 
@@ -501,6 +551,8 @@ def render_section_human(
     latest = section_report["totals"]["latest"]
     delta = section_report["totals"]["delta"]
     values = ", ".join(f"{field_name} {format_value(latest[field_name])} ({format_delta(delta[field_name])})" for field_name in fields)
+    if not event_fields:
+        return f"{label}: {values}"
     events = section_report.get("eventDeltas")
     if not isinstance(events, dict) or events["status"] != OBSERVED:
         return f"{label}: {values}; events {NOT_OBSERVED}"

--- a/scripts/test_screeps_rl_metrics_ingestor.py
+++ b/scripts/test_screeps_rl_metrics_ingestor.py
@@ -68,6 +68,9 @@ class ScreepsRlMetricsIngestorTest(unittest.TestCase):
                 metric_observation_columns = {
                     row[1] for row in conn.execute("PRAGMA table_info(metric_observations)").fetchall()
                 }
+                runtime_room_metric_columns = {
+                    row[1] for row in conn.execute("PRAGMA table_info(runtime_room_metrics)").fetchall()
+                }
                 dedupe_indexes = {
                     table: {
                         row[1]
@@ -79,6 +82,7 @@ class ScreepsRlMetricsIngestorTest(unittest.TestCase):
 
         self.assertIn("metric_definitions", tables)
         self.assertIn("metric_observations", tables)
+        self.assertIn("runtime_room_metrics", tables)
         self.assertIn("gameplay_behavior_findings", tables)
         self.assertIn("metric_coverage_gaps", tables)
         self.assertIn("rl_dataset_gate_metrics", tables)
@@ -87,6 +91,16 @@ class ScreepsRlMetricsIngestorTest(unittest.TestCase):
         self.assertIn("metric_iteration_decisions", tables)
 
         self.assertIn("dedupe_key", metric_observation_columns)
+        for column_name in (
+            "pending_build_progress",
+            "build_carried_energy",
+            "construction_site_count",
+            "cpu_used",
+            "cpu_bucket",
+            "rcl_level",
+            "stored_energy",
+        ):
+            self.assertIn(column_name, runtime_room_metric_columns)
         for table in ingestor.DEDUPE_TABLE_KEYS:
             self.assertIn(f"idx_{table}_dedupe_key", dedupe_indexes[table])
 
@@ -165,10 +179,17 @@ class ScreepsRlMetricsIngestorTest(unittest.TestCase):
                     {
                         "roomName": "E26S49",
                         "controller": {"my": True, "level": 3},
+                        "rclLevel": 3,
                         "workerCount": 4,
                         "spawnStatus": [{"name": "Spawn1", "status": "idle"}],
                         "taskCounts": {"harvest": 1, "upgrade": 3, "build": 0},
                         "energyAvailable": 300,
+                        "pendingBuildProgress": 700,
+                        "buildCarriedEnergy": 0,
+                        "constructionSiteCount": 2,
+                        "cpuUsed": 6.25,
+                        "cpuBucket": 8123,
+                        "storedEnergy": 800,
                         "resources": {
                             "storedEnergy": 800,
                             "workerCarriedEnergy": 120,
@@ -199,6 +220,31 @@ class ScreepsRlMetricsIngestorTest(unittest.TestCase):
                     "metric_observations",
                     "WHERE metric_name = ?",
                     ("construction.backlog_progress",),
+                ),
+                1,
+            )
+            with sqlite3.connect(db_path) as conn:
+                row = conn.execute(
+                    """
+                    SELECT pending_build_progress, build_carried_energy, construction_site_count,
+                           cpu_used, cpu_bucket, rcl_level, stored_energy
+                    FROM runtime_room_metrics
+                    WHERE room_name = ?
+                    """,
+                    ("E26S49",),
+                ).fetchone()
+            summary = json.loads(ingestor.summarize_database(db_path, output_format="json"))
+
+            self.assertEqual(row, (700.0, 0.0, 2.0, 6.25, 8123.0, 3.0, 800.0))
+            self.assertEqual(summary["latestRuntimeRoomMetrics"]["pendingBuildProgress"], 700.0)
+            self.assertEqual(summary["latestRuntimeRoomMetrics"]["constructionSiteCount"], 2.0)
+            self.assertEqual(summary["latestRuntimeRoomMetrics"]["minCpuBucket"], 8123.0)
+            self.assertEqual(
+                fetch_count(
+                    db_path,
+                    "metric_observations",
+                    "WHERE metric_name = ?",
+                    ("construction.site_count",),
                 ),
                 1,
             )

--- a/scripts/test_screeps_rl_metrics_ingestor.py
+++ b/scripts/test_screeps_rl_metrics_ingestor.py
@@ -39,11 +39,11 @@ def table_counts(db_path: Path, tables: tuple[str, ...]) -> dict[str, int]:
     return {table: fetch_count(db_path, table) for table in tables}
 
 
-def runtime_payload(room: JsonObject) -> JsonObject:
+def runtime_payload(room: JsonObject, *, tick: int = 12345, shard: str = "shardX") -> JsonObject:
     return {
         "type": "runtime-summary",
-        "tick": 12345,
-        "shard": "shardX",
+        "tick": tick,
+        "shard": shard,
         "cpu": {"bucket": 9000, "used": 7.5},
         "reliability": {"loopExceptionCount": 0, "telemetrySilenceTicks": 0},
         "rooms": [room],
@@ -285,6 +285,42 @@ class ScreepsRlMetricsIngestorTest(unittest.TestCase):
                     ("economy.energy_telemetry", "missing_energy_fields"),
                 ),
                 1,
+            )
+
+    def test_runtime_room_metric_dedupe_keeps_same_tick_room_across_shards(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            db_path = root / "rl_metrics.sqlite"
+            artifact_dir = root / "runtime-summary-console"
+            artifact_dir.mkdir(parents=True, exist_ok=True)
+            room = {
+                "roomName": "E26S49",
+                "controller": {"my": True, "level": 3},
+                "pendingBuildProgress": 700,
+            }
+            (artifact_dir / "runtime.log").write_text(
+                runtime_line(runtime_payload(room, tick=12345, shard="shardX"))
+                + runtime_line(runtime_payload(room, tick=12345, shard="shardY")),
+                encoding="utf-8",
+            )
+
+            ingestor.ingest_artifacts(db_path, [artifact_dir])
+
+            with sqlite3.connect(db_path) as conn:
+                rows = conn.execute(
+                    """
+                    SELECT shard, room_name, tick, pending_build_progress
+                    FROM runtime_room_metrics
+                    ORDER BY shard
+                    """
+                ).fetchall()
+
+            self.assertEqual(
+                rows,
+                [
+                    ("shardX", "E26S49", 12345, 700.0),
+                    ("shardY", "E26S49", 12345, 700.0),
+                ],
             )
 
     def test_low_load_return_metric_creates_behavior_finding(self) -> None:

--- a/scripts/test_screeps_runtime_kpi_reducer.py
+++ b/scripts/test_screeps_runtime_kpi_reducer.py
@@ -25,6 +25,13 @@ class RuntimeKpiReducerTest(unittest.TestCase):
             "rooms": [
                 {
                     "roomName": "W1N1",
+                    "pendingBuildProgress": 500,
+                    "buildCarriedEnergy": 20,
+                    "constructionSiteCount": 2,
+                    "cpuUsed": 5.0,
+                    "cpuBucket": 9000,
+                    "rclLevel": 2,
+                    "storedEnergy": 175,
                     "controller": {"level": 2, "progress": 1000, "progressTotal": 45000, "ticksToDowngrade": 15000},
                     "resources": {
                         "storedEnergy": 175,
@@ -53,6 +60,13 @@ class RuntimeKpiReducerTest(unittest.TestCase):
             "rooms": [
                 {
                     "roomName": "W1N1",
+                    "pendingBuildProgress": 450,
+                    "buildCarriedEnergy": 15,
+                    "constructionSiteCount": 2,
+                    "cpuUsed": 6.0,
+                    "cpuBucket": 8990,
+                    "rclLevel": 2,
+                    "storedEnergy": 210,
                     "controller": {"level": 2, "progress": 1300, "progressTotal": 45000, "ticksToDowngrade": 14950},
                     "resources": {
                         "storedEnergy": 210,
@@ -129,6 +143,24 @@ class RuntimeKpiReducerTest(unittest.TestCase):
             "attackDamage": 30,
             "objectDestroyedCount": 1,
             "creepDestroyedCount": 1,
+        })
+        self.assertEqual(report["roomMetrics"]["totals"]["latest"], {
+            "pendingBuildProgress": 450,
+            "buildCarriedEnergy": 15,
+            "constructionSiteCount": 2,
+            "cpuUsed": 6.0,
+            "cpuBucket": 8990,
+            "rclLevel": 2,
+            "storedEnergy": 210,
+        })
+        self.assertEqual(report["roomMetrics"]["totals"]["delta"], {
+            "pendingBuildProgress": -50,
+            "buildCarriedEnergy": -5,
+            "constructionSiteCount": 0,
+            "cpuUsed": 1.0,
+            "cpuBucket": -10,
+            "rclLevel": 0,
+            "storedEnergy": 35,
         })
 
     def test_rejects_runtime_summary_lines_with_trailing_garbage(self) -> None:
@@ -320,6 +352,7 @@ class RuntimeKpiReducerTest(unittest.TestCase):
         self.assertIn("territory: 1 owned room(s): W1N1", human)
         self.assertIn("controller W1N1: RCL 2 progress 10/45000", human)
         self.assertIn("resources:", human)
+        self.assertIn("roomMetrics:", human)
         self.assertIn("events not observed", human)
 
 

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -512,14 +512,33 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
                     "x": 26,
                     "y": 23,
                 },
+                "container-1": {
+                    "_id": "container-1",
+                    "type": "container",
+                    "store": {"energy": 40},
+                    "x": 26,
+                    "y": 24,
+                },
                 "worker-1": {
                     "_id": "worker-1",
                     "type": "creep",
                     "my": True,
                     "owner": {"username": "lanyusea"},
-                    "store": {"energy": 61},
+                    "carry": {"energy": 61},
+                    "memory": {"task": "build"},
                     "x": 27,
                     "y": 23,
+                },
+                "site-1": {
+                    "_id": "site-1",
+                    "type": "constructionSite",
+                    "my": True,
+                    "owner": {"username": "lanyusea"},
+                    "structureType": "extension",
+                    "progress": 75,
+                    "progressTotal": 200,
+                    "x": 27,
+                    "y": 24,
                 },
                 "source-1": {"_id": "source-1", "type": "source", "energy": 2846, "x": 20, "y": 20},
                 "hostile-1": {
@@ -533,7 +552,7 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
             },
             tick=265630,
             owner="lanyusea",
-            info={},
+            info={"cpu": {"used": 7.25, "bucket": 9123}},
         )
 
         payload = monitor.runtime_summary_payload_from_snapshots([snapshot])
@@ -543,9 +562,20 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         self.assertEqual(payload["rooms"][0]["roomName"], "E26S49")
         self.assertEqual(payload["rooms"][0]["controller"]["level"], 3)
         self.assertEqual(payload["rooms"][0]["controller"]["progress"], 1250)
-        self.assertEqual(payload["rooms"][0]["resources"]["storedEnergy"], 315)
+        self.assertEqual(payload["rooms"][0]["rclLevel"], 3)
+        self.assertEqual(payload["rooms"][0]["storedEnergy"], 355)
+        self.assertEqual(payload["rooms"][0]["resources"]["storedEnergy"], 355)
         self.assertEqual(payload["rooms"][0]["resources"]["workerCarriedEnergy"], 61)
         self.assertEqual(payload["rooms"][0]["resources"]["sourceCount"], 1)
+        self.assertEqual(payload["rooms"][0]["pendingBuildProgress"], 125)
+        self.assertEqual(payload["rooms"][0]["buildCarriedEnergy"], 61)
+        self.assertEqual(payload["rooms"][0]["constructionSiteCount"], 1)
+        self.assertEqual(payload["rooms"][0]["resources"]["productiveEnergy"]["pendingBuildProgress"], 125)
+        self.assertEqual(payload["rooms"][0]["resources"]["productiveEnergy"]["buildCarriedEnergy"], 61)
+        self.assertEqual(payload["rooms"][0]["resources"]["productiveEnergy"]["constructionSiteCount"], 1)
+        self.assertEqual(payload["rooms"][0]["cpuUsed"], 7.25)
+        self.assertEqual(payload["rooms"][0]["cpuBucket"], 9123)
+        self.assertEqual(payload["cpu"], {"used": 7.25, "bucket": 9123})
         self.assertEqual(payload["rooms"][0]["combat"]["hostileCreepCount"], 1)
 
     def test_runtime_summary_artifact_line_is_bridge_compatible(self) -> None:


### PR DESCRIPTION
## Summary
Implements #960 (replaces #906): adds 7 missing console capture fields required for reliable Gameplay Evolution rationality analysis.

## Changes
- **Console capture schema** (`scripts/screeps-runtime-monitor.py`): Add `pendingBuildProgress`, `buildCarriedEnergy`, `constructionSiteCount`, `cpuUsed`, `cpuBucket`, `rclLevel`, `storedEnergy` to room-level summary output
- **KPI reducer** (`scripts/screeps_kpi_reducer.py`, `scripts/screeps_runtime_kpi_reducer.py`): Add new columns to SQLite schema, handle NULL/missing gracefully, include in summary queries
- **RL metrics ingestor** (`scripts/screeps_rl_metrics_ingestor.py`): Add new fields with tests
- **Metric taxonomy** (`docs/ops/metric-taxonomy.md`): Document all console capture fields, coverage status, and gap tracking workflow

## Verification
```bash
python3 -m py_compile scripts/screeps-runtime-monitor.py
python3 -m py_compile scripts/screeps_kpi_reducer.py
python3 -m py_compile scripts/screeps_rl_metrics_ingestor.py
python3 -m py_compile scripts/screeps_runtime_kpi_reducer.py
```

All fields are additive — existing schema compatibility preserved.

Closes #960