### PR TITLE
fix(bot): bypass energy buffer for spawn construction when owned_spawns=0 (#970)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -23585,7 +23585,23 @@ function canSpendWorkerEnergyOnConstructionSite(creep, site) {
 }
 function canSpendCreepEnergyOnConstructionSite(creep, site, priorityContext) {
   const carriedEnergy = getUsedEnergy2(creep);
-  return checkEnergyBufferForSpending(creep.room, carriedEnergy) || carriedEnergy > 0 && isExtensionConstructionSite(site) && checkEnergyBufferForExtensionConstruction(creep.room, carriedEnergy) || carriedEnergy > 0 && !isExtensionConstructionSite(site) && isCapacityEnablingConstructionSite(site, priorityContext) && checkEnergyBufferForCapacityEnablingConstruction(creep.room, carriedEnergy) || carriedEnergy > 0 && hasMinimumWorkerSpawnEnergyForConstruction(creep.room) && isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext);
+  return carriedEnergy > 0 && isMissingSpawnRecoveryConstructionSite(creep.room, site) || checkEnergyBufferForSpending(creep.room, carriedEnergy) || carriedEnergy > 0 && isExtensionConstructionSite(site) && checkEnergyBufferForExtensionConstruction(creep.room, carriedEnergy) || carriedEnergy > 0 && !isExtensionConstructionSite(site) && isCapacityEnablingConstructionSite(site, priorityContext) && checkEnergyBufferForCapacityEnablingConstruction(creep.room, carriedEnergy) || carriedEnergy > 0 && hasMinimumWorkerSpawnEnergyForConstruction(creep.room) && isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext);
+}
+function isMissingSpawnRecoveryConstructionSite(room, site) {
+  return isSpawnConstructionSite(site) && getOwnedSpawnCount(room) === 0;
+}
+function getOwnedSpawnCount(room) {
+  if (typeof FIND_MY_STRUCTURES !== "number" || typeof room.find !== "function") {
+    return null;
+  }
+  try {
+    return room.find(FIND_MY_STRUCTURES).filter(isOwnedSpawnStructure).length;
+  } catch {
+    return null;
+  }
+}
+function isOwnedSpawnStructure(structure) {
+  return matchesStructureType18(structure.structureType, "STRUCTURE_SPAWN", "spawn");
 }
 function isCapacityEnablingConstructionSite(site, priorityContext) {
   if (isExtensionConstructionSite(site)) {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -2891,6 +2891,7 @@ function canSpendCreepEnergyOnConstructionSite(
 ): boolean {
   const carriedEnergy = getUsedEnergy(creep);
   return (
+    (carriedEnergy > 0 && isMissingSpawnRecoveryConstructionSite(creep.room, site)) ||
     checkEnergyBufferForSpending(creep.room, carriedEnergy) ||
     (carriedEnergy > 0 &&
       isExtensionConstructionSite(site) &&
@@ -2903,6 +2904,26 @@ function canSpendCreepEnergyOnConstructionSite(
       hasMinimumWorkerSpawnEnergyForConstruction(creep.room) &&
       isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext))
   );
+}
+
+function isMissingSpawnRecoveryConstructionSite(room: Room, site: ConstructionSite): boolean {
+  return isSpawnConstructionSite(site) && getOwnedSpawnCount(room) === 0;
+}
+
+function getOwnedSpawnCount(room: Room): number | null {
+  if (typeof FIND_MY_STRUCTURES !== 'number' || typeof room.find !== 'function') {
+    return null;
+  }
+
+  try {
+    return room.find(FIND_MY_STRUCTURES).filter(isOwnedSpawnStructure).length;
+  } catch {
+    return null;
+  }
+}
+
+function isOwnedSpawnStructure(structure: AnyOwnedStructure): structure is StructureSpawn {
+  return matchesStructureType(structure.structureType, 'STRUCTURE_SPAWN', 'spawn');
 }
 
 function isCapacityEnablingConstructionSite(

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -17,6 +17,7 @@ import {
   estimateNearTermSpawnExtensionRefillReserve,
   isWorkerPreHarvestSource,
   canLevelUpController,
+  canSpendWorkerEnergyOnConstructionSite,
   canUpgradeController,
   isUpgraderBoostActive,
   selectWorkerEnergyCriticalAcquisitionTask,
@@ -10322,6 +10323,52 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('bypasses construction energy buffer for spawn sites when no owned spawn exists', () => {
+    const spawnSite = { id: 'spawn-site1', structureType: 'spawn' } as ConstructionSite;
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0);
+    const makeCreep = (myStructures: AnyOwnedStructure[] = []): Creep =>
+      ({
+        store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+        room: makeWorkerTaskRoom({
+          constructionSites: [spawnSite],
+          energyAvailable: 0,
+          myStructures
+        })
+      }) as unknown as Creep;
+
+    expect(canSpendWorkerEnergyOnConstructionSite(makeCreep(), spawnSite)).toBe(true);
+    expect(canSpendWorkerEnergyOnConstructionSite(makeCreep([fullSpawn as AnyOwnedStructure]), spawnSite)).toBe(false);
+  });
+
+  it('builds missing spawn construction during bootstrap suppression even when room energy is zero', () => {
+    const spawnSite = {
+      id: 'spawn-site1',
+      structureType: 'spawn',
+      progress: 0,
+      progressTotal: 15_000
+    } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [spawnSite],
+        controller,
+        energyAvailable: 0,
+        energyCapacityAvailable: 650,
+        myStructures: []
+      })
+    } as unknown as Creep;
+    recordSurvivalMode('BOOTSTRAP');
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'spawn-site1' });
   });
 
   it('uses the survival buffer multiplier before selecting construction spending', () => {


### PR DESCRIPTION
## Summary
Fixes P0 issue #970: E24S49 spawn was destroyed by hostiles but surviving creeps couldn't rebuild it.

## Root cause
`canSpendCreepEnergyOnConstructionSite` in `prod/src/tasks/workerTasks.ts` required `checkEnergyBufferForSpending` to pass for spawn construction sites. When `owned_spawns=0`, the spawn provides no energy, so the energy buffer gate blocked ALL construction spending — including the critical spawn rebuild, even with `storedEnergy=3767` and `owned_creeps=5`.

## Fix
Added a bypass in `canSpendCreepEnergyOnConstructionSite`: when `spawnCount === 0` in the room, workers are allowed to spend energy on spawn construction sites regardless of energy buffer state.

## Verification
- `npm run typecheck` ✅
- `npm test -- --runInBand` ✅ (94 suites, 1749 tests)
- `npm run build` ✅

## Related
Addresses #970 (do not auto-close until live recovery acceptance is verified)
