### PR TITLE
fix(monitor): suppress false spawn_collapse for alert=false expansion rooms (#968)

### DIFF
--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -1808,11 +1808,17 @@ def room_summary_count(room_summary_payload: dict[str, Any], owned_key: str, fal
     return room_summary_payload.get(fallback_key)
 
 
+def tactical_payload_is_clean_no_alert(alert_payload: dict[str, Any]) -> bool:
+    raw_reasons = alert_payload.get("reasons")
+    return alert_payload.get("alert") is False and isinstance(raw_reasons, list) and not raw_reasons
+
+
 def tactical_room_summary_survival_reasons(alert_payload: dict[str, Any]) -> list[dict[str, Any]]:
     raw_room_summaries = alert_payload.get("room_summaries")
     if not isinstance(raw_room_summaries, list):
         return []
 
+    clean_no_alert = tactical_payload_is_clean_no_alert(alert_payload)
     reasons: list[dict[str, Any]] = []
     for room in raw_room_summaries:
         if not isinstance(room, dict):
@@ -1820,6 +1826,7 @@ def tactical_room_summary_survival_reasons(alert_payload: dict[str, Any]) -> lis
         room_name = room.get("room")
         owned_spawns = room_summary_count(room, "owned_spawns", "spawns")
         owned_creeps = room_summary_count(room, "owned_creeps", "creeps")
+        hostiles = room.get("hostiles")
         if isinstance(owned_spawns, (int, float)) and owned_spawns <= 0:
             if isinstance(owned_creeps, (int, float)) and owned_creeps <= 0:
                 reasons.append(
@@ -1832,6 +1839,14 @@ def tactical_room_summary_survival_reasons(alert_payload: dict[str, Any]) -> lis
                     }
                 )
             else:
+                if (
+                    clean_no_alert
+                    and isinstance(owned_creeps, (int, float))
+                    and owned_creeps > 0
+                    and isinstance(hostiles, (int, float))
+                    and hostiles <= 0
+                ):
+                    continue
                 reasons.append(
                     {
                         "kind": "owned_spawns=0",

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -81,6 +81,39 @@ HEALTHY_ALERT_FIXTURE = {
     "warnings": [],
 }
 
+EXPANSION_BOOTSTRAP_NO_ALERT_FIXTURE = {
+    "ok": True,
+    "mode": "alert",
+    "alert": False,
+    "reasons": [],
+    "rooms": ["shardX/E24S49", "shardX/E23S49"],
+    "room_summaries": [
+        {
+            "room": "shardX/E24S49",
+            "name": "E24S49",
+            "owned_creeps": 13,
+            "owned_spawns": 1,
+            "creeps": 13,
+            "spawns": 1,
+            "hostiles": 0,
+            "structures": 35,
+            "owner": "lanyusea",
+        },
+        {
+            "room": "shardX/E23S49",
+            "name": "E23S49",
+            "owned_creeps": 4,
+            "owned_spawns": 0,
+            "creeps": 4,
+            "spawns": 0,
+            "hostiles": 0,
+            "structures": 1,
+            "owner": "lanyusea",
+        },
+    ],
+    "warnings": [],
+}
+
 
 PRIVATE_SMOKE_PHASES = [
     "host-port-preflight",
@@ -223,6 +256,18 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertTrue(report["silent"])
         self.assertEqual(report["severity"], "none")
         self.assertIsNone(report["priority"])
+        self.assertEqual(report["scheduler"]["recommended_output"], "[SILENT]")
+
+    def test_clean_no_alert_expansion_bootstrap_without_spawn_stays_silent(self) -> None:
+        report = monitor.build_tactical_response_report(EXPANSION_BOOTSTRAP_NO_ALERT_FIXTURE)
+
+        self.assertFalse(report["emergency"])
+        self.assertTrue(report["silent"])
+        self.assertEqual(report["severity"], "none")
+        self.assertIsNone(report["priority"])
+        self.assertNotIn("spawn_collapse", report["categories"])
+        self.assertEqual(report["triggers"], [])
+        self.assertEqual(report["source"]["reason_count"], 0)
         self.assertEqual(report["scheduler"]["recommended_output"], "[SILENT]")
 
     def test_suppressed_room_dead_still_escalates(self) -> None:


### PR DESCRIPTION
## Summary
Fixes P0 issue #968: tactical-response was emitting `spawn_collapse` for `alert=false` claimed expansion rooms.

## Root cause
The tactical-response classifier in `scripts/screeps-runtime-monitor.py` synthesized P0 `spawn_collapse` for expansion rooms (E23S49) even when `alert=false` with `reasons=[]`, `owned_creeps=4`, and `hostiles=0` — normal post-claim bootstrap before a spawn is built.

## Fix
When `alert=false` and `reasons=[]`, do NOT synthesize P0 `spawn_collapse` for rooms where `owned_creeps > 0` and `hostiles=0`. Preserves real P0 behavior for: true `room_dead`, baseline spawn-drop in primary room, post-deploy no-spawn, and hostile alerts.

## Verification
- `python3 -m py_compile` ✅
- `python3 -m unittest` ✅ (22/22 tests)

## Related
Closes #968