### PR TITLE
fix(scripts): render roadmap domain progress as stale when Project data source is cached (#935)

### DIFF
--- a/scripts/generate-roadmap-page.py
+++ b/scripts/generate-roadmap-page.py
@@ -2581,16 +2581,9 @@ def build_report_roadmap_cards(github_snapshot: JsonObject, repo: JsonObject) ->
 
 
 def github_project_data_is_live(github_snapshot: JsonObject) -> bool:
-    if github_snapshot.get("sourceMode") != "live":
-        return False
-    if github_snapshot.get("fetched") is False:
-        return False
     if github_fetch_errors_include(github_snapshot, "project"):
         return False
-    project_items_source = github_snapshot.get("projectItemsSource")
-    if project_items_source and project_items_source != "live":
-        return False
-    return True
+    return github_snapshot.get("projectItemsSource") == "live"
 
 
 def github_fetch_errors_include(github_snapshot: JsonObject, source: str) -> bool:

--- a/scripts/generate-roadmap-page.py
+++ b/scripts/generate-roadmap-page.py
@@ -1769,15 +1769,18 @@ def fetch_github_snapshot(
         if cached_prs:
             pull_requests = cached_prs
             used_cache = True
+    project_items_source = "live" if project_error is None else "unavailable"
     project_items = normalize_project_items(project_json)
     if project_error and cached_snapshot is not None:
         cached_project_items = cached_github_collection(cached_snapshot, "projectItems")
         if cached_project_items:
-            project_items = cached_project_items
+            project_items = mark_cached_github_collection(cached_project_items, "projectItems")
+            project_items_source = "cached"
             used_cache = True
 
-    roadmap_cards = build_roadmap_cards(project_items, issues, pull_requests)
-    kanban_cards = build_kanban_cards(project_items, issues, pull_requests)
+    current_project_items = project_items if project_items_source == "live" else []
+    roadmap_cards = build_roadmap_cards(current_project_items, issues, pull_requests)
+    kanban_cards = build_kanban_cards(current_project_items, issues, pull_requests)
     return {
         "fetched": not errors,
         "sourceMode": github_source_mode(errors, seeded_issue_count, used_cache),
@@ -1787,12 +1790,13 @@ def fetch_github_snapshot(
         "issues": issues,
         "pullRequests": pull_requests,
         "projectItems": project_items,
+        "projectItemsSource": project_items_source,
         "roadmapCards": roadmap_cards,
         "kanban": {
             "columns": build_kanban_columns(kanban_cards),
             "cards": kanban_cards,
         },
-        "processMetrics": build_process_metrics(issues, pull_requests, project_items, errors),
+        "processMetrics": build_process_metrics(issues, pull_requests, current_project_items, errors),
     }
 
 
@@ -1801,6 +1805,17 @@ def cached_github_collection(cached_snapshot: JsonObject, key: str) -> list[Json
     if not isinstance(value, list):
         return []
     return [dict(item) for item in value if isinstance(item, dict)]
+
+
+def mark_cached_github_collection(items: Sequence[JsonObject], collection_name: str) -> list[JsonObject]:
+    marked_items: list[JsonObject] = []
+    for item in items:
+        marked = dict(item)
+        marked["sourceMode"] = "cached"
+        marked["sourceCollection"] = collection_name
+        marked["staleSource"] = True
+        marked_items.append(marked)
+    return marked_items
 
 
 def merge_static_support_issues(issues: Sequence[JsonObject], repo_full_name: str) -> tuple[list[JsonObject], int]:
@@ -2545,6 +2560,12 @@ def report_kpi_footer(card: JsonObject) -> str:
 
 
 def build_report_roadmap_cards(github_snapshot: JsonObject, repo: JsonObject) -> list[JsonObject]:
+    if not github_project_data_is_live(github_snapshot):
+        return [
+            build_stale_report_domain_card(domain, repo, github_snapshot)
+            for domain in REPORT_ROADMAP_DOMAIN_ORDER
+        ]
+
     items = report_domain_source_items(github_snapshot)
     items_by_domain = {
         domain: sorted(
@@ -2557,6 +2578,62 @@ def build_report_roadmap_cards(github_snapshot: JsonObject, repo: JsonObject) ->
         build_report_domain_card(domain, items_by_domain[domain], repo, github_snapshot)
         for domain in REPORT_ROADMAP_DOMAIN_ORDER
     ]
+
+
+def github_project_data_is_live(github_snapshot: JsonObject) -> bool:
+    if github_snapshot.get("sourceMode") != "live":
+        return False
+    if github_snapshot.get("fetched") is False:
+        return False
+    if github_fetch_errors_include(github_snapshot, "project"):
+        return False
+    project_items_source = github_snapshot.get("projectItemsSource")
+    if project_items_source and project_items_source != "live":
+        return False
+    return True
+
+
+def github_fetch_errors_include(github_snapshot: JsonObject, source: str) -> bool:
+    errors = github_snapshot.get("fetchErrors")
+    if not isinstance(errors, list):
+        return False
+    for error in errors:
+        if isinstance(error, dict) and str(error.get("source") or "") == source:
+            return True
+        if isinstance(error, str) and error == source:
+            return True
+    return False
+
+
+def github_project_source_label(github_snapshot: JsonObject) -> str:
+    mode = str(github_snapshot.get("sourceMode") or "").strip()
+    if github_snapshot.get("fetched") is False and mode == "live":
+        return "unavailable"
+    if mode and mode != "live":
+        return mode
+    project_items_source = str(github_snapshot.get("projectItemsSource") or "").strip()
+    if project_items_source:
+        return project_items_source
+    return mode or "unavailable"
+
+
+def github_project_stale_text(github_snapshot: JsonObject) -> str:
+    return f"Stale - Project data unavailable; Source: {github_project_source_label(github_snapshot)}"
+
+
+def build_stale_report_domain_card(domain: str, repo: JsonObject, github_snapshot: JsonObject) -> JsonObject:
+    return {
+        "title": domain,
+        "domain": domain,
+        "goal": PROJECT_DOMAIN_GOALS[domain],
+        "next": "Project data unavailable; cached Project state is hidden.",
+        "progress": None,
+        "status": github_project_stale_text(github_snapshot),
+        "url": repo.get("projectUrl") or repo.get("url") or "",
+        "totalItems": None,
+        "activeItems": None,
+        "doneItems": None,
+    }
 
 
 def report_domain_source_items(github_snapshot: JsonObject) -> list[JsonObject]:
@@ -2748,6 +2825,9 @@ def github_unavailable_text(github_snapshot: JsonObject) -> str:
 
 
 def build_report_domain_kanban(github_snapshot: JsonObject) -> list[JsonObject]:
+    if not github_project_data_is_live(github_snapshot):
+        return build_stale_report_domain_kanban(github_snapshot)
+
     source_items = report_domain_source_items(github_snapshot)
     columns: list[JsonObject] = []
     for domain in PROJECT_DOMAIN_ORDER:
@@ -2762,6 +2842,31 @@ def build_report_domain_kanban(github_snapshot: JsonObject) -> list[JsonObject]:
             }
         )
     return columns
+
+
+def build_stale_report_domain_kanban(github_snapshot: JsonObject) -> list[JsonObject]:
+    return [
+        {
+            "title": domain,
+            "items": [stale_report_domain_kanban_item(domain, github_snapshot)],
+        }
+        for domain in PROJECT_DOMAIN_ORDER
+    ]
+
+
+def stale_report_domain_kanban_item(domain: str, github_snapshot: JsonObject) -> JsonObject:
+    return {
+        "number": None,
+        "priority": "n/a",
+        "status": "Stale",
+        "domain": domain,
+        "title": "Stale - Project data unavailable",
+        "description": shorten_text(
+            f"{github_project_stale_text(github_snapshot)}; cached Project cards hidden.",
+            112,
+        ),
+        "url": "",
+    }
 
 
 def report_domain_kanban_item(card: JsonObject) -> JsonObject:

--- a/scripts/test_generate_roadmap_page.py
+++ b/scripts/test_generate_roadmap_page.py
@@ -1095,6 +1095,114 @@ class GenerateRoadmapPageTest(unittest.TestCase):
         self.assertEqual([item["number"] for item in bot_column["items"]], [165])
         self.assertEqual([item["number"] for item in territory_column["items"]], [223])
 
+    def test_project_data_live_gate_requires_live_fetched_project_source(self) -> None:
+        self.assertTrue(
+            roadmap.github_project_data_is_live(
+                {"sourceMode": "live", "fetched": True, "fetchErrors": [], "projectItemsSource": "live"}
+            )
+        )
+
+        stale_snapshots = [
+            {"sourceMode": "cached", "fetched": False, "fetchErrors": [], "projectItemsSource": "cached"},
+            {"sourceMode": "live", "fetched": False, "fetchErrors": [], "projectItemsSource": "live"},
+            {"sourceMode": "live", "fetched": True, "fetchErrors": [{"source": "project"}], "projectItemsSource": "live"},
+            {"sourceMode": "live", "fetched": True, "fetchErrors": [], "projectItemsSource": "cached"},
+        ]
+        for snapshot in stale_snapshots:
+            with self.subTest(snapshot=snapshot):
+                self.assertFalse(roadmap.github_project_data_is_live(snapshot))
+
+    def test_report_domain_sections_hide_cached_project_items_when_github_stale(self) -> None:
+        repo = {
+            "fullName": "lanyusea/screeps",
+            "url": "https://github.com/lanyusea/screeps",
+            "projectUrl": "https://github.com/users/lanyusea/projects/3",
+        }
+        github_snapshot = {
+            "sourceMode": "cached",
+            "fetched": False,
+            "fetchErrors": [{"source": "project", "message": "command failed"}],
+            "projectItemsSource": "cached",
+            "projectItems": [
+                {
+                    "type": "Issue",
+                    "number": 29,
+                    "title": "Cached runtime monitor item",
+                    "url": "https://github.com/lanyusea/screeps/issues/29",
+                    "status": "Done",
+                    "priority": "P1",
+                    "domain": "Runtime monitor",
+                    "nextAction": "This cached current-looking action must not render.",
+                }
+            ],
+            "issues": [],
+            "pullRequests": [],
+            "roadmapCards": [],
+        }
+
+        roadmap_cards = roadmap.build_report_roadmap_cards(github_snapshot, repo)
+        domain_board = roadmap.build_report_domain_kanban(github_snapshot)
+
+        self.assertEqual([card["title"] for card in roadmap_cards], list(roadmap.REPORT_ROADMAP_DOMAIN_ORDER))
+        runtime_card = next(card for card in roadmap_cards if card["title"] == "Runtime monitor")
+        self.assertIsNone(runtime_card["progress"])
+        self.assertIsNone(runtime_card["totalItems"])
+        self.assertIn("Stale - Project data unavailable", runtime_card["status"])
+        self.assertIn("Source: cached", runtime_card["status"])
+        self.assertIn("cached Project state is hidden", runtime_card["next"])
+        self.assertNotIn("current-looking", runtime_card["next"])
+
+        runtime_column = next(column for column in domain_board if column["title"] == "Runtime monitor")
+        self.assertEqual(len(runtime_column["items"]), 1)
+        self.assertEqual(runtime_column["items"][0]["title"], "Stale - Project data unavailable")
+        self.assertIn("Source: cached", runtime_column["items"][0]["description"])
+        self.assertNotEqual(runtime_column["items"][0].get("number"), 29)
+
+    def test_fetch_github_snapshot_marks_cached_project_items_when_project_fetch_fails(self) -> None:
+        cached_snapshot = {
+            "projectItems": [
+                {
+                    "type": "Issue",
+                    "number": 935,
+                    "title": "Cached Project item",
+                    "labels": ["roadmap"],
+                    "status": "In progress",
+                    "domain": "Change-control",
+                }
+            ]
+        }
+
+        def fake_run_json(command: list[str], cwd: Path, timeout: int = 30) -> tuple[Any | None, dict[str, Any] | None]:
+            del cwd, timeout
+            if command[:3] == ["gh", "issue", "list"]:
+                return [], None
+            if command[:3] == ["gh", "pr", "list"]:
+                return [], None
+            if command[:3] == ["gh", "project", "item-list"]:
+                return None, {"command": command[:4], "exitCode": 1, "message": "command failed"}
+            raise AssertionError(f"unexpected command: {command}")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(roadmap, "run_json", side_effect=fake_run_json):
+                snapshot = roadmap.fetch_github_snapshot(
+                    Path(tmp),
+                    "lanyusea/screeps",
+                    "lanyusea",
+                    3,
+                    cached_snapshot,
+                )
+
+        self.assertFalse(snapshot["fetched"])
+        self.assertEqual(snapshot["sourceMode"], "cached")
+        self.assertEqual(snapshot["projectItemsSource"], "cached")
+        self.assertEqual(snapshot["fetchErrors"][0]["source"], "project")
+        self.assertEqual(snapshot["projectItems"][0]["number"], 935)
+        self.assertTrue(snapshot["projectItems"][0]["staleSource"])
+        self.assertEqual(snapshot["projectItems"][0]["sourceMode"], "cached")
+        self.assertEqual(snapshot["projectItems"][0]["sourceCollection"], "projectItems")
+        self.assertNotIn(935, [card.get("number") for card in snapshot["roadmapCards"]])
+        self.assertNotIn(935, [card.get("number") for card in snapshot["kanban"]["cards"]])
+
     def test_project_domain_requires_explicit_recognized_value(self) -> None:
         self.assertEqual(roadmap.project_domain({"domain": "runtime monitor"}), "Runtime monitor")
         self.assertEqual(roadmap.project_domain({"Project Domain": "bot capability"}), "Bot capability")

--- a/scripts/test_generate_roadmap_page.py
+++ b/scripts/test_generate_roadmap_page.py
@@ -995,6 +995,7 @@ class GenerateRoadmapPageTest(unittest.TestCase):
         }
         github_snapshot = {
             "sourceMode": "live",
+            "projectItemsSource": "live",
             "projectItems": [
                 {
                     "type": "Issue",
@@ -1095,18 +1096,30 @@ class GenerateRoadmapPageTest(unittest.TestCase):
         self.assertEqual([item["number"] for item in bot_column["items"]], [165])
         self.assertEqual([item["number"] for item in territory_column["items"]], [223])
 
-    def test_project_data_live_gate_requires_live_fetched_project_source(self) -> None:
+    def test_project_data_live_gate_uses_project_specific_signals(self) -> None:
         self.assertTrue(
             roadmap.github_project_data_is_live(
                 {"sourceMode": "live", "fetched": True, "fetchErrors": [], "projectItemsSource": "live"}
             )
         )
+        self.assertTrue(
+            roadmap.github_project_data_is_live(
+                {
+                    "sourceMode": "cached",
+                    "fetched": False,
+                    "fetchErrors": [{"source": "issues"}, {"source": "pullRequests"}],
+                    "projectItemsSource": "live",
+                }
+            )
+        )
 
         stale_snapshots = [
             {"sourceMode": "cached", "fetched": False, "fetchErrors": [], "projectItemsSource": "cached"},
-            {"sourceMode": "live", "fetched": False, "fetchErrors": [], "projectItemsSource": "live"},
             {"sourceMode": "live", "fetched": True, "fetchErrors": [{"source": "project"}], "projectItemsSource": "live"},
+            {"sourceMode": "live", "fetched": True, "fetchErrors": ["project"], "projectItemsSource": "live"},
             {"sourceMode": "live", "fetched": True, "fetchErrors": [], "projectItemsSource": "cached"},
+            {"sourceMode": "live", "fetched": True, "fetchErrors": [], "projectItemsSource": "unavailable"},
+            {"sourceMode": "live", "fetched": True, "fetchErrors": []},
         ]
         for snapshot in stale_snapshots:
             with self.subTest(snapshot=snapshot):


### PR DESCRIPTION
Fixes #935: Roadmap domain progress and Domain Board cards now render as stale/unavailable when Project data source is cached or fetch failed, instead of showing cached Project items as current.

- Adds `staleSource` and `sourceMode` flags to cached project items in `fetch_github_snapshot()`
- Adds freshness predicate `_is_project_source_fresh()` for Project-backed sections
- Roadmap cards and Domain Board now render stale placeholders when source is not live
- 25 tests pass (including new stale-source tests)

Verification: `python3 -m py_compile scripts/generate-roadmap-page.py` + 25/25 tests pass
