### PR TITLE
fix(rl): repair E2 non-Docker simulator Broken pipe regression at >=3 concurrent environments (#1009)

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -84,6 +84,7 @@ RUN_ID_PREFIX = "rl-sim-run"
 RUN_ID_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 SIMULATOR_REPAIR_MOD_FILENAME = "rl-simulator-harness-repair.js"
 OWNED_ROOM_SCORECARD_TYPE = "screeps-rl-simulator-owned-room-scorecard"
+_WORKER_PHASE_DEBUG_DISABLED = False
 HARNESS_EXCLUDED_DIRECTORY_NAMES = ("node_modules", ".git", "__pycache__")
 HARNESS_BINARY_FILE_EXTENSIONS = (
     ".bmp",
@@ -1338,6 +1339,9 @@ def _resolve_smoke_map_source_file(map_source_file: Path) -> Path | None:
 
 def _debug_worker_phase(worker_index: int, variant_id: str, phase: str, **details: object) -> None:
     """Emit bounded stderr phase logs for diagnosing worker startup hangs."""
+    global _WORKER_PHASE_DEBUG_DISABLED
+    if _WORKER_PHASE_DEBUG_DISABLED:
+        return
     timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
     detail_parts = []
     for key, value in sorted(details.items()):
@@ -1348,12 +1352,17 @@ def _debug_worker_phase(worker_index: int, variant_id: str, phase: str, **detail
         except Exception:
             detail_parts.append(f"{key}=\"[unserializable]\"")
     detail_text = f" {' '.join(detail_parts)}" if detail_parts else ""
-    print(
-        f"{timestamp} rl-sim-worker[{worker_index}] variant={variant_id} "
-        f"phase={json.dumps(phase, ensure_ascii=True)}{detail_text}",
-        file=sys.stderr,
-        flush=True,
-    )
+    try:
+        print(
+            f"{timestamp} rl-sim-worker[{worker_index}] variant={variant_id} "
+            f"phase={json.dumps(phase, ensure_ascii=True)}{detail_text}",
+            file=sys.stderr,
+            flush=True,
+        )
+    except (BrokenPipeError, OSError, ValueError):
+        _WORKER_PHASE_DEBUG_DISABLED = True
+
+
 def _terrain_payload_has_data(payload: Any) -> bool:
     summary = _terrain_summary(payload)
     return bool(summary.get("bytes"))

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -573,6 +573,29 @@ cli:
         self.assertIn("shardName: shardX", updated)
         self.assertNotIn("mapFile:", updated)
 
+    def test_debug_worker_phase_broken_stderr_pipe_is_nonfatal(self) -> None:
+        class BrokenPipeStderr:
+            def __init__(self) -> None:
+                self.write_attempts = 0
+
+            def write(self, text: str) -> int:
+                self.write_attempts += 1
+                raise BrokenPipeError(32, "Broken pipe")
+
+            def flush(self) -> None:
+                return None
+
+        broken_stderr = BrokenPipeStderr()
+        harness._WORKER_PHASE_DEBUG_DISABLED = False
+        try:
+            with mock.patch("sys.stderr", broken_stderr):
+                harness._debug_worker_phase(2, "variant-a", "before startup", port=21125)
+                harness._debug_worker_phase(2, "variant-a", "after startup", port=21125)
+        finally:
+            harness._WORKER_PHASE_DEBUG_DISABLED = False
+
+        self.assertEqual(broken_stderr.write_attempts, 1)
+
     def test_default_sim_room_matches_bundled_private_map(self) -> None:
         self.assertEqual(harness.DEFAULT_SIM_ROOM, "E1S1")
 


### PR DESCRIPTION
## Problem
The E2 non-Docker simulator path works at 2 concurrent environments (100% success) but fails with `[Errno 32] Broken pipe` at 25 environments (92% failure rate). Root cause: `_debug_worker_phase()` writes to stderr which can raise `BrokenPipeError` when subprocess pipelines close during concurrent worker shutdown.

## Fix
- Added `_WORKER_PHASE_DEBUG_DISABLED` global flag to suppress subsequent debug output after any broken pipe
- Wrapped stderr print in `_debug_worker_phase()` with try/except for `BrokenPipeError`, `OSError`, `ValueError`
- Added unit test `test_debug_worker_phase_broken_stderr_pipe_is_nonfatal` verifying the fix catches broken pipe and disables further debug output

## Scope
- `scripts/screeps_rl_simulator_harness.py` only — non-Docker path
- No Docker code, no prod/ TypeScript code
- Preserves `liveEffect=false`, `officialMmoWrites=false` safety flags

## Verification
```
python3 -m py_compile scripts/screeps_rl_simulator_harness.py  # OK
python3 -m py_compile scripts/test_screeps_rl_simulator_harness.py  # OK
git diff --check  # clean
```

Closes #1009