### PR TITLE
fix(prod): prioritize build/repair task assignment over upgrade when uncovered backlog exists (#1015)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -23047,6 +23047,15 @@ function selectHeuristicWorkerTask(creep) {
   if (highImpactConstructionSite) {
     return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: highImpactConstructionSite.id });
   }
+  const uncoveredProductiveBacklogTask = selectUncoveredProductiveBacklogTaskBeforeControllerProgress(
+    creep,
+    controller,
+    constructionSites,
+    constructionReservationContext
+  );
+  if (uncoveredProductiveBacklogTask) {
+    return applyMinimumUsefulLoadPolicy(creep, uncoveredProductiveBacklogTask);
+  }
   if (controller && shouldUseSurplusForControllerProgress(creep, controller)) {
     const productiveEnergySinkTask = selectNearbyProductiveEnergySinkTask(
       creep,
@@ -24622,6 +24631,81 @@ function selectNearbyProductiveEnergySinkTask(creep, constructionSites, controll
     return null;
   }
   return candidates.sort(compareProductiveEnergySinkCandidates)[0].task;
+}
+function selectUncoveredProductiveBacklogTaskBeforeControllerProgress(creep, controller, constructionSites, constructionReservationContext) {
+  if (!controller || !shouldReserveWorkerForUncoveredProductiveBacklog(creep, controller)) {
+    return null;
+  }
+  const constructionPriorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  if (!hasSameRoomWorkerAssignedToTask(creep.room, "build")) {
+    const constructionSite = selectUnreservedConstructionSite(
+      creep,
+      constructionSites,
+      constructionReservationContext,
+      () => true,
+      { priorityContext: constructionPriorityContext }
+    );
+    if (constructionSite) {
+      return { type: "build", targetId: constructionSite.id };
+    }
+  }
+  if (!hasSameRoomWorkerAssignedToTask(creep.room, "repair")) {
+    const repairTarget = selectRepairTarget(creep);
+    if (repairTarget) {
+      return { type: "repair", targetId: repairTarget.id };
+    }
+  }
+  return null;
+}
+function shouldReserveWorkerForUncoveredProductiveBacklog(creep, controller) {
+  if (!hasControllerProgressDemand(creep, controller)) {
+    return false;
+  }
+  if (hasLoadedWorkerAvailableForUncoveredProductiveBacklog(creep, controller)) {
+    return false;
+  }
+  const loadedWorkers = getSameRoomLoadedWorkers(creep);
+  const controllerProgressWorkerLimit = Math.max(
+    1,
+    getControllerProgressWorkerLimit(
+      creep,
+      loadedWorkers.length,
+      hasActiveTerritoryExpansionPressure(creep)
+    )
+  );
+  const controllerProgressReserveLimit = Math.max(1, controllerProgressWorkerLimit - 1);
+  const controllerUpgraders = loadedWorkers.filter((worker) => isUpgradingController(worker, controller)).length;
+  return controllerUpgraders >= controllerProgressReserveLimit;
+}
+function hasControllerProgressDemand(creep, controller) {
+  var _a, _b;
+  if (shouldApplyControllerPressureLane(creep, controller)) {
+    return true;
+  }
+  const upgradePriority = getControllerUpgradePriority(controller, {
+    energyAvailable: (_a = getRoomEnergyAvailable9(creep.room)) != null ? _a : void 0,
+    energyCapacityAvailable: (_b = getRoomEnergyCapacityAvailable7(creep.room)) != null ? _b : void 0,
+    hasEnergySurplus: hasRecoverableSurplusEnergy(creep)
+  });
+  return upgradePriority === "rclProgress" || upgradePriority === "energySurplus";
+}
+function hasLoadedWorkerAvailableForUncoveredProductiveBacklog(creep, controller) {
+  return getSameRoomLoadedWorkers(creep).some((worker) => {
+    var _a, _b;
+    if (isSameCreep(worker, creep) || isUpgradingController(worker, controller) || getActiveWorkParts2(worker) <= 0) {
+      return false;
+    }
+    const taskType = (_b = (_a = worker.memory) == null ? void 0 : _a.task) == null ? void 0 : _b.type;
+    return taskType === void 0 || taskType === null;
+  });
+}
+function hasSameRoomWorkerAssignedToTask(room, taskType) {
+  return getGameCreeps().some(
+    (worker) => {
+      var _a, _b;
+      return isSameRoomWorker(worker, room) && ((_b = (_a = worker.memory) == null ? void 0 : _a.task) == null ? void 0 : _b.type) === taskType;
+    }
+  );
 }
 function createProductiveEnergySinkCandidate(creep, target, task, taskPriority, canCompleteConstruction = false) {
   const range = getRangeBetweenRoomObjects3(creep, target);
@@ -33105,6 +33189,7 @@ var MAX_WORKER_BEHAVIOR_SAMPLES = 10;
 var MAX_WORKER_EFFICIENCY_REASON_SAMPLES = 5;
 var MAX_REFILL_DELIVERY_SAMPLES = 5;
 var MAX_SPAWN_CRITICAL_REFILL_SAMPLES = 5;
+var MAX_WORKER_ASSIGNMENT_BLOCKED_WORKERS = 5;
 var MAX_TERRITORY_INTENT_SUMMARIES = 5;
 var WORKER_EFFICIENCY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 var WORKER_BEHAVIOR_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
@@ -33910,6 +33995,7 @@ function getEnergySurplusSinkIds(state) {
 function summarizeProductiveEnergy(colony, colonyWorkers, constructionSites, roomStructures, roomEnergyStructures, events) {
   const productiveAssignments = summarizeProductiveWorkerAssignments(colonyWorkers);
   const pendingBuildProgress = sumPendingBuildProgress(constructionSites);
+  const repairBacklogHits = sumRepairBacklogHits(roomStructures);
   const buildBlockedReason = selectBuildBlockedReason(
     colony,
     colonyWorkers,
@@ -33921,13 +34007,20 @@ function summarizeProductiveEnergy(colony, colonyWorkers, constructionSites, roo
   return {
     ...productiveAssignments,
     pendingBuildProgress,
-    repairBacklogHits: sumRepairBacklogHits(roomStructures),
+    repairBacklogHits,
     ...buildBlockedReason ? { buildBlockedReason } : {},
     ...buildBlockedReason === "worker_assignment_gap" ? {
       workerAssignmentBlockedDetail: selectWorkerAssignmentBlockedDetail(
         colony,
         colonyWorkers,
         roomEnergyStructures
+      ),
+      workerAssignmentBlockedWorkers: selectWorkerAssignmentBlockedWorkers(
+        colony,
+        colonyWorkers,
+        constructionSites,
+        pendingBuildProgress,
+        repairBacklogHits
       )
     } : {},
     ...buildControllerProgressRemaining(colony.room)
@@ -33964,6 +34057,107 @@ function selectWorkerAssignmentBlockedDetail(colony, colonyWorkers, roomEnergySt
     return "spawn_reserving_energy";
   }
   return "unknown";
+}
+function selectWorkerAssignmentBlockedWorkers(colony, colonyWorkers, constructionSites, pendingBuildProgress, repairBacklogHits) {
+  return [...colonyWorkers].sort(compareWorkerAssignmentBlockedDiagnosticPriority).slice(0, MAX_WORKER_ASSIGNMENT_BLOCKED_WORKERS).map((worker) => {
+    const taskType = getWorkerTaskType(worker);
+    return {
+      ...getWorkerName(worker) ? { name: getWorkerName(worker) } : {},
+      ...taskType ? { task: taskType } : {},
+      carriedEnergy: getEnergyInStore(worker),
+      freeCapacity: getFreeEnergyCapacityInStore(worker),
+      buildBlockedReason: selectWorkerBuildAssignmentBlockedReason(
+        colony,
+        worker,
+        constructionSites,
+        pendingBuildProgress
+      ),
+      repairBlockedReason: selectWorkerRepairAssignmentBlockedReason(
+        worker,
+        pendingBuildProgress,
+        repairBacklogHits
+      )
+    };
+  });
+}
+function compareWorkerAssignmentBlockedDiagnosticPriority(left, right) {
+  return getWorkerAssignmentBlockedDiagnosticTaskPriority(left) - getWorkerAssignmentBlockedDiagnosticTaskPriority(right) || getEnergyInStore(right) - getEnergyInStore(left) || getWorkerStableLabel(left).localeCompare(getWorkerStableLabel(right));
+}
+function getWorkerAssignmentBlockedDiagnosticTaskPriority(worker) {
+  const taskType = getWorkerTaskType(worker);
+  if (!taskType) {
+    return 0;
+  }
+  if (taskType === "upgrade") {
+    return 1;
+  }
+  if (taskType === "build" || taskType === "repair") {
+    return 3;
+  }
+  return 2;
+}
+function selectWorkerBuildAssignmentBlockedReason(colony, worker, constructionSites, pendingBuildProgress) {
+  const taskType = getWorkerTaskType(worker);
+  if (taskType === "build") {
+    return "build_assigned";
+  }
+  if (!isConstructionCapableWorker(worker)) {
+    return "build_blocked_no_valid_body";
+  }
+  if (constructionSites.length <= 0 || pendingBuildProgress <= 0) {
+    return "build_blocked_no_construction_sites";
+  }
+  if (getEnergyInStore(worker) <= 0) {
+    return "build_blocked_no_carried_energy";
+  }
+  if (isBuildBlockedByEnergyBuffer(colony, getEnergyInStore(worker))) {
+    return "build_blocked_energy_buffer";
+  }
+  if (taskType === "upgrade") {
+    return "build_blocked_controller_progress_preferred";
+  }
+  if (taskType) {
+    return "build_blocked_other_task";
+  }
+  return "build_blocked_unknown";
+}
+function selectWorkerRepairAssignmentBlockedReason(worker, pendingBuildProgress, repairBacklogHits) {
+  const taskType = getWorkerTaskType(worker);
+  if (taskType === "repair") {
+    return "repair_assigned";
+  }
+  if (!isConstructionCapableWorker(worker)) {
+    return "repair_blocked_no_valid_body";
+  }
+  if (repairBacklogHits <= 0) {
+    return "repair_blocked_no_repair_targets";
+  }
+  if (getEnergyInStore(worker) <= 0) {
+    return "repair_blocked_no_carried_energy";
+  }
+  if (pendingBuildProgress > 0) {
+    return "repair_blocked_build_backlog_first";
+  }
+  if (taskType === "upgrade") {
+    return "repair_blocked_controller_progress_preferred";
+  }
+  if (taskType) {
+    return "repair_blocked_other_task";
+  }
+  return "repair_blocked_unknown";
+}
+function getWorkerTaskType(worker) {
+  var _a, _b;
+  const taskType = (_b = (_a = worker.memory) == null ? void 0 : _a.task) == null ? void 0 : _b.type;
+  return typeof taskType === "string" && taskType.length > 0 ? taskType : void 0;
+}
+function getWorkerName(worker) {
+  const name = worker.name;
+  return typeof name === "string" && name.length > 0 ? name : void 0;
+}
+function getWorkerStableLabel(worker) {
+  var _a, _b;
+  return (_b = getWorkerName(worker)) != null ? _b : String((_a = worker.id) != null ? _a : "");
 }
 function hasConstructionEnergyAcquisitionTask(creep) {
   var _a;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -24637,7 +24637,7 @@ function selectUncoveredProductiveBacklogTaskBeforeControllerProgress(creep, con
     return null;
   }
   const constructionPriorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
-  if (!hasSameRoomWorkerAssignedToTask(creep.room, "build")) {
+  if (!hasSameRoomWorkerAssignedToTask(creep.room, creep, "build")) {
     const constructionSite = selectUnreservedConstructionSite(
       creep,
       constructionSites,
@@ -24649,7 +24649,7 @@ function selectUncoveredProductiveBacklogTaskBeforeControllerProgress(creep, con
       return { type: "build", targetId: constructionSite.id };
     }
   }
-  if (!hasSameRoomWorkerAssignedToTask(creep.room, "repair")) {
+  if (!hasSameRoomWorkerAssignedToTask(creep.room, creep, "repair")) {
     const repairTarget = selectRepairTarget(creep);
     if (repairTarget) {
       return { type: "repair", targetId: repairTarget.id };
@@ -24699,11 +24699,11 @@ function hasLoadedWorkerAvailableForUncoveredProductiveBacklog(creep, controller
     return taskType === void 0 || taskType === null;
   });
 }
-function hasSameRoomWorkerAssignedToTask(room, taskType) {
+function hasSameRoomWorkerAssignedToTask(room, currentCreep, taskType) {
   return getGameCreeps().some(
     (worker) => {
       var _a, _b;
-      return isSameRoomWorker(worker, room) && ((_b = (_a = worker.memory) == null ? void 0 : _a.task) == null ? void 0 : _b.type) === taskType;
+      return !isSameCreep(worker, currentCreep) && isSameRoomWorker(worker, room) && ((_b = (_a = worker.memory) == null ? void 0 : _a.task) == null ? void 0 : _b.type) === taskType;
     }
   );
 }

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -683,6 +683,16 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     return applyMinimumUsefulLoadPolicy(creep, { type: 'build', targetId: highImpactConstructionSite.id });
   }
 
+  const uncoveredProductiveBacklogTask = selectUncoveredProductiveBacklogTaskBeforeControllerProgress(
+    creep,
+    controller,
+    constructionSites,
+    constructionReservationContext
+  );
+  if (uncoveredProductiveBacklogTask) {
+    return applyMinimumUsefulLoadPolicy(creep, uncoveredProductiveBacklogTask);
+  }
+
   if (controller && shouldUseSurplusForControllerProgress(creep, controller)) {
     const productiveEnergySinkTask = selectNearbyProductiveEnergySinkTask(
       creep,
@@ -3115,6 +3125,99 @@ function selectNearbyProductiveEnergySinkTask(
   }
 
   return candidates.sort(compareProductiveEnergySinkCandidates)[0].task;
+}
+
+function selectUncoveredProductiveBacklogTaskBeforeControllerProgress(
+  creep: Creep,
+  controller: StructureController | undefined,
+  constructionSites: ConstructionSite[],
+  constructionReservationContext: ConstructionReservationContext
+): ProductiveEnergySinkTask | null {
+  if (!controller || !shouldReserveWorkerForUncoveredProductiveBacklog(creep, controller)) {
+    return null;
+  }
+
+  const constructionPriorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  if (!hasSameRoomWorkerAssignedToTask(creep.room, 'build')) {
+    const constructionSite = selectUnreservedConstructionSite(
+      creep,
+      constructionSites,
+      constructionReservationContext,
+      () => true,
+      { priorityContext: constructionPriorityContext }
+    );
+    if (constructionSite) {
+      return { type: 'build', targetId: constructionSite.id };
+    }
+  }
+
+  if (!hasSameRoomWorkerAssignedToTask(creep.room, 'repair')) {
+    const repairTarget = selectRepairTarget(creep);
+    if (repairTarget) {
+      return { type: 'repair', targetId: repairTarget.id as Id<Structure> };
+    }
+  }
+
+  return null;
+}
+
+function shouldReserveWorkerForUncoveredProductiveBacklog(
+  creep: Creep,
+  controller: StructureController
+): boolean {
+  if (!hasControllerProgressDemand(creep, controller)) {
+    return false;
+  }
+
+  if (hasLoadedWorkerAvailableForUncoveredProductiveBacklog(creep, controller)) {
+    return false;
+  }
+
+  const loadedWorkers = getSameRoomLoadedWorkers(creep);
+  const controllerProgressWorkerLimit = Math.max(
+    1,
+    getControllerProgressWorkerLimit(
+      creep,
+      loadedWorkers.length,
+      hasActiveTerritoryExpansionPressure(creep)
+    )
+  );
+  const controllerProgressReserveLimit = Math.max(1, controllerProgressWorkerLimit - 1);
+  const controllerUpgraders = loadedWorkers.filter((worker) => isUpgradingController(worker, controller)).length;
+  return controllerUpgraders >= controllerProgressReserveLimit;
+}
+
+function hasControllerProgressDemand(creep: Creep, controller: StructureController): boolean {
+  if (shouldApplyControllerPressureLane(creep, controller)) {
+    return true;
+  }
+
+  const upgradePriority = getControllerUpgradePriority(controller, {
+    energyAvailable: getRoomEnergyAvailable(creep.room) ?? undefined,
+    energyCapacityAvailable: getRoomEnergyCapacityAvailable(creep.room) ?? undefined,
+    hasEnergySurplus: hasRecoverableSurplusEnergy(creep)
+  });
+  return upgradePriority === 'rclProgress' || upgradePriority === 'energySurplus';
+}
+
+function hasLoadedWorkerAvailableForUncoveredProductiveBacklog(
+  creep: Creep,
+  controller: StructureController
+): boolean {
+  return getSameRoomLoadedWorkers(creep).some((worker) => {
+    if (isSameCreep(worker, creep) || isUpgradingController(worker, controller) || getActiveWorkParts(worker) <= 0) {
+      return false;
+    }
+
+    const taskType = worker.memory?.task?.type;
+    return taskType === undefined || taskType === null;
+  });
+}
+
+function hasSameRoomWorkerAssignedToTask(room: Room, taskType: 'build' | 'repair'): boolean {
+  return getGameCreeps().some(
+    (worker) => isSameRoomWorker(worker, room) && worker.memory?.task?.type === taskType
+  );
 }
 
 function createProductiveEnergySinkCandidate(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -3138,7 +3138,7 @@ function selectUncoveredProductiveBacklogTaskBeforeControllerProgress(
   }
 
   const constructionPriorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
-  if (!hasSameRoomWorkerAssignedToTask(creep.room, 'build')) {
+  if (!hasSameRoomWorkerAssignedToTask(creep.room, creep, 'build')) {
     const constructionSite = selectUnreservedConstructionSite(
       creep,
       constructionSites,
@@ -3151,7 +3151,7 @@ function selectUncoveredProductiveBacklogTaskBeforeControllerProgress(
     }
   }
 
-  if (!hasSameRoomWorkerAssignedToTask(creep.room, 'repair')) {
+  if (!hasSameRoomWorkerAssignedToTask(creep.room, creep, 'repair')) {
     const repairTarget = selectRepairTarget(creep);
     if (repairTarget) {
       return { type: 'repair', targetId: repairTarget.id as Id<Structure> };
@@ -3214,9 +3214,16 @@ function hasLoadedWorkerAvailableForUncoveredProductiveBacklog(
   });
 }
 
-function hasSameRoomWorkerAssignedToTask(room: Room, taskType: 'build' | 'repair'): boolean {
+function hasSameRoomWorkerAssignedToTask(
+  room: Room,
+  currentCreep: Creep,
+  taskType: 'build' | 'repair'
+): boolean {
   return getGameCreeps().some(
-    (worker) => isSameRoomWorker(worker, room) && worker.memory?.task?.type === taskType
+    (worker) =>
+      !isSameCreep(worker, currentCreep) &&
+      isSameRoomWorker(worker, room) &&
+      worker.memory?.task?.type === taskType
   );
 }
 

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -52,6 +52,7 @@ const MAX_WORKER_BEHAVIOR_SAMPLES = 10;
 const MAX_WORKER_EFFICIENCY_REASON_SAMPLES = 5;
 const MAX_REFILL_DELIVERY_SAMPLES = 5;
 const MAX_SPAWN_CRITICAL_REFILL_SAMPLES = 5;
+const MAX_WORKER_ASSIGNMENT_BLOCKED_WORKERS = 5;
 const MAX_TERRITORY_INTENT_SUMMARIES = 5;
 const WORKER_EFFICIENCY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 const WORKER_BEHAVIOR_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
@@ -75,6 +76,24 @@ type RuntimeWorkerAssignmentBlockedDetail =
   | 'no_valid_body'
   | 'room_capacity_full'
   | 'unknown';
+type RuntimeWorkerBuildAssignmentBlockedReason =
+  | 'build_assigned'
+  | 'build_blocked_controller_progress_preferred'
+  | 'build_blocked_energy_buffer'
+  | 'build_blocked_no_carried_energy'
+  | 'build_blocked_no_construction_sites'
+  | 'build_blocked_no_valid_body'
+  | 'build_blocked_other_task'
+  | 'build_blocked_unknown';
+type RuntimeWorkerRepairAssignmentBlockedReason =
+  | 'repair_assigned'
+  | 'repair_blocked_build_backlog_first'
+  | 'repair_blocked_controller_progress_preferred'
+  | 'repair_blocked_no_carried_energy'
+  | 'repair_blocked_no_repair_targets'
+  | 'repair_blocked_no_valid_body'
+  | 'repair_blocked_other_task'
+  | 'repair_blocked_unknown';
 
 interface WorkerTaskCounts extends Record<WorkerTaskType, number> {
   none: number;
@@ -351,7 +370,17 @@ interface RuntimeProductiveEnergySummary {
   repairBacklogHits: number;
   buildBlockedReason?: RuntimeBuildBlockedReason;
   workerAssignmentBlockedDetail?: RuntimeWorkerAssignmentBlockedDetail;
+  workerAssignmentBlockedWorkers?: RuntimeWorkerAssignmentBlockedWorkerDetail[];
   controllerProgressRemaining?: number;
+}
+
+interface RuntimeWorkerAssignmentBlockedWorkerDetail {
+  buildBlockedReason: RuntimeWorkerBuildAssignmentBlockedReason;
+  carriedEnergy: number;
+  freeCapacity: number;
+  repairBlockedReason: RuntimeWorkerRepairAssignmentBlockedReason;
+  name?: string;
+  task?: string;
 }
 
 interface RuntimeWorkerEfficiencySummary {
@@ -1783,6 +1812,7 @@ function summarizeProductiveEnergy(
 ): RuntimeProductiveEnergySummary {
   const productiveAssignments = summarizeProductiveWorkerAssignments(colonyWorkers);
   const pendingBuildProgress = sumPendingBuildProgress(constructionSites);
+  const repairBacklogHits = sumRepairBacklogHits(roomStructures);
   const buildBlockedReason = selectBuildBlockedReason(
     colony,
     colonyWorkers,
@@ -1795,7 +1825,7 @@ function summarizeProductiveEnergy(
   return {
     ...productiveAssignments,
     pendingBuildProgress,
-    repairBacklogHits: sumRepairBacklogHits(roomStructures),
+    repairBacklogHits,
     ...(buildBlockedReason ? { buildBlockedReason } : {}),
     ...(buildBlockedReason === 'worker_assignment_gap'
       ? {
@@ -1803,6 +1833,13 @@ function summarizeProductiveEnergy(
             colony,
             colonyWorkers,
             roomEnergyStructures
+          ),
+          workerAssignmentBlockedWorkers: selectWorkerAssignmentBlockedWorkers(
+            colony,
+            colonyWorkers,
+            constructionSites,
+            pendingBuildProgress,
+            repairBacklogHits
           )
         }
       : {}),
@@ -1865,6 +1902,153 @@ function selectWorkerAssignmentBlockedDetail(
   }
 
   return 'unknown';
+}
+
+function selectWorkerAssignmentBlockedWorkers(
+  colony: ColonySnapshot,
+  colonyWorkers: Creep[],
+  constructionSites: unknown[],
+  pendingBuildProgress: number,
+  repairBacklogHits: number
+): RuntimeWorkerAssignmentBlockedWorkerDetail[] {
+  return [...colonyWorkers]
+    .sort(compareWorkerAssignmentBlockedDiagnosticPriority)
+    .slice(0, MAX_WORKER_ASSIGNMENT_BLOCKED_WORKERS)
+    .map((worker) => {
+      const taskType = getWorkerTaskType(worker);
+      return {
+        ...(getWorkerName(worker) ? { name: getWorkerName(worker) } : {}),
+        ...(taskType ? { task: taskType } : {}),
+        carriedEnergy: getEnergyInStore(worker),
+        freeCapacity: getFreeEnergyCapacityInStore(worker),
+        buildBlockedReason: selectWorkerBuildAssignmentBlockedReason(
+          colony,
+          worker,
+          constructionSites,
+          pendingBuildProgress
+        ),
+        repairBlockedReason: selectWorkerRepairAssignmentBlockedReason(
+          worker,
+          pendingBuildProgress,
+          repairBacklogHits
+        )
+      };
+    });
+}
+
+function compareWorkerAssignmentBlockedDiagnosticPriority(left: Creep, right: Creep): number {
+  return (
+    getWorkerAssignmentBlockedDiagnosticTaskPriority(left) -
+      getWorkerAssignmentBlockedDiagnosticTaskPriority(right) ||
+    getEnergyInStore(right) - getEnergyInStore(left) ||
+    getWorkerStableLabel(left).localeCompare(getWorkerStableLabel(right))
+  );
+}
+
+function getWorkerAssignmentBlockedDiagnosticTaskPriority(worker: Creep): number {
+  const taskType = getWorkerTaskType(worker);
+  if (!taskType) {
+    return 0;
+  }
+
+  if (taskType === 'upgrade') {
+    return 1;
+  }
+
+  if (taskType === 'build' || taskType === 'repair') {
+    return 3;
+  }
+
+  return 2;
+}
+
+function selectWorkerBuildAssignmentBlockedReason(
+  colony: ColonySnapshot,
+  worker: Creep,
+  constructionSites: unknown[],
+  pendingBuildProgress: number
+): RuntimeWorkerBuildAssignmentBlockedReason {
+  const taskType = getWorkerTaskType(worker);
+  if (taskType === 'build') {
+    return 'build_assigned';
+  }
+
+  if (!isConstructionCapableWorker(worker)) {
+    return 'build_blocked_no_valid_body';
+  }
+
+  if (constructionSites.length <= 0 || pendingBuildProgress <= 0) {
+    return 'build_blocked_no_construction_sites';
+  }
+
+  if (getEnergyInStore(worker) <= 0) {
+    return 'build_blocked_no_carried_energy';
+  }
+
+  if (isBuildBlockedByEnergyBuffer(colony, getEnergyInStore(worker))) {
+    return 'build_blocked_energy_buffer';
+  }
+
+  if (taskType === 'upgrade') {
+    return 'build_blocked_controller_progress_preferred';
+  }
+
+  if (taskType) {
+    return 'build_blocked_other_task';
+  }
+
+  return 'build_blocked_unknown';
+}
+
+function selectWorkerRepairAssignmentBlockedReason(
+  worker: Creep,
+  pendingBuildProgress: number,
+  repairBacklogHits: number
+): RuntimeWorkerRepairAssignmentBlockedReason {
+  const taskType = getWorkerTaskType(worker);
+  if (taskType === 'repair') {
+    return 'repair_assigned';
+  }
+
+  if (!isConstructionCapableWorker(worker)) {
+    return 'repair_blocked_no_valid_body';
+  }
+
+  if (repairBacklogHits <= 0) {
+    return 'repair_blocked_no_repair_targets';
+  }
+
+  if (getEnergyInStore(worker) <= 0) {
+    return 'repair_blocked_no_carried_energy';
+  }
+
+  if (pendingBuildProgress > 0) {
+    return 'repair_blocked_build_backlog_first';
+  }
+
+  if (taskType === 'upgrade') {
+    return 'repair_blocked_controller_progress_preferred';
+  }
+
+  if (taskType) {
+    return 'repair_blocked_other_task';
+  }
+
+  return 'repair_blocked_unknown';
+}
+
+function getWorkerTaskType(worker: Creep): string | undefined {
+  const taskType = worker.memory?.task?.type;
+  return typeof taskType === 'string' && taskType.length > 0 ? taskType : undefined;
+}
+
+function getWorkerName(worker: Creep): string | undefined {
+  const name = (worker as Creep & { name?: unknown }).name;
+  return typeof name === 'string' && name.length > 0 ? name : undefined;
+}
+
+function getWorkerStableLabel(worker: Creep): string {
+  return getWorkerName(worker) ?? String((worker as Creep & { id?: unknown }).id ?? '');
 }
 
 function hasConstructionEnergyAcquisitionTask(creep: Creep): boolean {

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -970,6 +970,57 @@ describe('runtime telemetry summaries', () => {
     });
   });
 
+  it('reports per-worker build and repair rejection reasons for construction assignment gaps', () => {
+    const idleWorker = {
+      name: 'IdleBuilder',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: makeEnergyStore(0, 50),
+      getActiveBodyparts: jest.fn().mockReturnValue(1)
+    } as unknown as Creep;
+    const upgrader = {
+      name: 'Upgrader',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }
+      },
+      store: makeEnergyStore(50, 50),
+      getActiveBodyparts: jest.fn().mockReturnValue(1)
+    } as unknown as Creep;
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      includeEventLog: false,
+      creeps: [idleWorker, upgrader],
+      constructionSites: [
+        { id: 'extension-site', structureType: TEST_GLOBALS.STRUCTURE_EXTENSION, progress: 0, progressTotal: 50 }
+      ]
+    });
+    (colony.room as Room & { energyAvailable: number; energyCapacityAvailable: number }).energyAvailable = 317;
+    (colony.room as Room & { energyAvailable: number; energyCapacityAvailable: number }).energyCapacityAvailable = 400;
+    colony.energyAvailable = 317;
+    colony.energyCapacityAvailable = 400;
+
+    emitRuntimeSummary([colony], [idleWorker, upgrader]);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    const productiveEnergy = (room.resources as Record<string, Record<string, unknown>>).productiveEnergy;
+    expect(productiveEnergy.workerAssignmentBlockedWorkers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'IdleBuilder',
+          buildBlockedReason: 'build_blocked_no_carried_energy',
+          repairBlockedReason: 'repair_blocked_no_repair_targets'
+        }),
+        expect.objectContaining({
+          name: 'Upgrader',
+          buildBlockedReason: 'build_blocked_controller_progress_preferred',
+          repairBlockedReason: 'repair_blocked_no_repair_targets'
+        })
+      ])
+    );
+  });
+
   it('does not report a construction gap while a worker is acquiring energy for a construction site', () => {
     const colony = makeColony({
       time: RUNTIME_SUMMARY_INTERVAL,

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -11082,6 +11082,43 @@ describe('selectWorkerTask', () => {
     expect(selectedTask).toEqual({ type: 'build', targetId: 'wall-site1' });
   });
 
+  it('does not count the current build-assigned worker as uncovered construction coverage', () => {
+    const site = { id: 'wall-site1', structureType: 'constructedWall' } as ConstructionSite;
+    const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 317, {
+      my: true
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [site],
+      controller,
+      energyAvailable: 317,
+      energyCapacityAvailable: 400,
+      structures: [storage]
+    });
+    const builder = {
+      name: 'BuilderCandidate',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'build', targetId: 'wall-site1' as Id<ConstructionSite> }
+      },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({
+      BuilderCandidate: builder,
+      UpgraderA: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }),
+      UpgraderB: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> })
+    });
+
+    expect(selectWorkerTask(builder)).toEqual({ type: 'build', targetId: 'wall-site1' });
+  });
+
   it('routes carried energy to controller upgrade before non-critical construction when salvage surplus exists', () => {
     const site = { id: 'wall-site1', structureType: 'constructedWall' } as ConstructionSite;
     const tombstone = makeSalvageEnergySource('tombstone-surplus', 100);

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -11039,6 +11039,49 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
+  it('reserves a loaded worker for construction when healthy energy and idle workers leave build coverage empty', () => {
+    const site = { id: 'wall-site1', structureType: 'constructedWall' } as ConstructionSite;
+    const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 317, {
+      my: true
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [site],
+      controller,
+      energyAvailable: 317,
+      energyCapacityAvailable: 400,
+      structures: [storage]
+    });
+    const builder = {
+      name: 'BuilderCandidate',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    const idleWorker = {
+      name: 'EmptyIdle',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({
+      UpgraderA: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }),
+      UpgraderB: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }),
+      EmptyIdle: idleWorker
+    });
+
+    const selectedTask = selectWorkerTask(builder);
+    const taskCounts = { build: selectedTask?.type === 'build' ? 1 : 0 };
+
+    expect(taskCounts.build).toBeGreaterThan(0);
+    expect(selectedTask).toEqual({ type: 'build', targetId: 'wall-site1' });
+  });
+
   it('routes carried energy to controller upgrade before non-critical construction when salvage surplus exists', () => {
     const site = { id: 'wall-site1', structureType: 'constructedWall' } as ConstructionSite;
     const tombstone = makeSalvageEnergySource('tombstone-surplus', 100);


### PR DESCRIPTION
## Summary
Fixes the persistent `build=0` / `worker_assignment_gap` deadlock where upgrade tasks resumed after e13274e but build and repair tasks remained deadlocked.

## Root cause
In `selectHeuristicWorkerTask`, the `shouldUseSurplusForControllerProgress` gate checked for upgrade demand *before* build/repair backlog. When upgrade was eligible, idle workers with energy were all directed to upgrading — none were assigned to construction or repair.

## Fix
Inserted `selectUncoveredProductiveBacklogTaskBeforeControllerProgress` as a new priority layer:
- Before assigning workers to controller upgrade, check whether any build or repair task is *uncovered* (no other worker already assigned to it).
- If build is uncovered: assign a worker to the highest-impact construction site.
- If repair is uncovered: assign a worker to the repair target.
- Only release remaining workers to upgrade after build/repair coverage is satisfied.

New helpers:
- `hasSameRoomWorkerAssignedToTask` — detects whether another worker already covers build/repair
- `shouldReserveWorkerForUncoveredProductiveBacklog` — gates the priority override on upgrade demand existing
- `hasLoadedWorkerAvailableForUncoveredProductiveBacklog` — checks for idle loaded workers
- `hasControllerProgressDemand` — checks upgrade priority tier

## Verification
- Typecheck: PASS
- 95/95 test suites, 1776/1776 tests: PASS
- Build: PASS

## Closes
#1015
