### PR TITLE
fix(prod): surface per-worker dispatch diagnostic detail in runtime-summary console (#1019)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -33431,12 +33431,14 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
   if (persistOccupationRecommendations) {
     persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime30());
   }
+  const resources = summarizeResources(colony, colonyWorkers, colonyCreeps, eventMetrics.resources);
   return {
     roomName: colony.room.name,
     energyAvailable: colony.energyAvailable,
     energyCapacity: colony.energyCapacityAvailable,
     energyBufferHealth: getRoomEnergyBufferHealth(colony.room),
     workerCount: colonyWorkers.length,
+    ...summarizeWorkerAssignmentBlockedRoomFields(resources.productiveEnergy),
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts: countWorkerTasks(colonyWorkers),
     ...summarizeRuntimeBehavior(colonyWorkers, colonyCreeps, getGameTime30()),
@@ -33445,7 +33447,7 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     ...summarizeRefillTelemetry(colonyWorkers, getGameTime30()),
     ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime30()),
     ...buildControllerSummary(colony.room),
-    resources: summarizeResources(colony, colonyWorkers, colonyCreeps, eventMetrics.resources),
+    resources,
     combat: summarizeCombat(colony.room, eventMetrics.combat),
     constructionPriority: summarizeConstructionPriority(colony, colonyWorkers),
     survival: summarizeSurvival(colony, roleCounts),
@@ -33455,6 +33457,12 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     ...buildTerritoryExecutionHintSummary(colony.room.name),
     ...buildTerritoryScoutSummary(colony.room.name),
     ...buildPostClaimBootstrapSummary(colony.room.name)
+  };
+}
+function summarizeWorkerAssignmentBlockedRoomFields(productiveEnergy) {
+  return {
+    ...productiveEnergy.workerAssignmentBlockedDetail ? { workerAssignmentBlockedDetail: productiveEnergy.workerAssignmentBlockedDetail } : {},
+    ...productiveEnergy.workerAssignmentBlockedWorkers ? { workerAssignmentBlockedWorkers: productiveEnergy.workerAssignmentBlockedWorkers } : {}
   };
 }
 function buildPostClaimBootstrapSummary(roomName) {

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -238,6 +238,8 @@ interface RuntimeRoomSummary {
   cpuBucket?: number;
   energyBufferHealth: EnergyBufferHealth;
   workerCount: number;
+  workerAssignmentBlockedDetail?: RuntimeWorkerAssignmentBlockedDetail;
+  workerAssignmentBlockedWorkers?: RuntimeWorkerAssignmentBlockedWorkerDetail[];
   spawnStatus: RuntimeSpawnStatus[];
   taskCounts: WorkerTaskCounts;
   behavior?: RuntimeBehaviorSummary;
@@ -754,6 +756,7 @@ function summarizeRoom(
   if (persistOccupationRecommendations) {
     persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime());
   }
+  const resources = summarizeResources(colony, colonyWorkers, colonyCreeps, eventMetrics.resources);
 
   return {
     roomName: colony.room.name,
@@ -761,6 +764,7 @@ function summarizeRoom(
     energyCapacity: colony.energyCapacityAvailable,
     energyBufferHealth: getRoomEnergyBufferHealth(colony.room),
     workerCount: colonyWorkers.length,
+    ...summarizeWorkerAssignmentBlockedRoomFields(resources.productiveEnergy),
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts: countWorkerTasks(colonyWorkers),
     ...summarizeRuntimeBehavior(colonyWorkers, colonyCreeps, getGameTime()),
@@ -769,7 +773,7 @@ function summarizeRoom(
     ...summarizeRefillTelemetry(colonyWorkers, getGameTime()),
     ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime()),
     ...buildControllerSummary(colony.room),
-    resources: summarizeResources(colony, colonyWorkers, colonyCreeps, eventMetrics.resources),
+    resources,
     combat: summarizeCombat(colony.room, eventMetrics.combat),
     constructionPriority: summarizeConstructionPriority(colony, colonyWorkers),
     survival: summarizeSurvival(colony, roleCounts),
@@ -779,6 +783,19 @@ function summarizeRoom(
     ...buildTerritoryExecutionHintSummary(colony.room.name),
     ...buildTerritoryScoutSummary(colony.room.name),
     ...buildPostClaimBootstrapSummary(colony.room.name)
+  };
+}
+
+function summarizeWorkerAssignmentBlockedRoomFields(
+  productiveEnergy: RuntimeProductiveEnergySummary
+): Pick<RuntimeRoomSummary, 'workerAssignmentBlockedDetail' | 'workerAssignmentBlockedWorkers'> {
+  return {
+    ...(productiveEnergy.workerAssignmentBlockedDetail
+      ? { workerAssignmentBlockedDetail: productiveEnergy.workerAssignmentBlockedDetail }
+      : {}),
+    ...(productiveEnergy.workerAssignmentBlockedWorkers
+      ? { workerAssignmentBlockedWorkers: productiveEnergy.workerAssignmentBlockedWorkers }
+      : {})
   };
 }
 

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -964,6 +964,7 @@ describe('runtime telemetry summaries', () => {
 
     const payload = parseLoggedSummary();
     const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.workerAssignmentBlockedDetail).toBe('spawn_reserving_energy');
     expect((room.resources as Record<string, Record<string, unknown>>).productiveEnergy).toMatchObject({
       buildBlockedReason: 'worker_assignment_gap',
       workerAssignmentBlockedDetail: 'spawn_reserving_energy'
@@ -1017,6 +1018,8 @@ describe('runtime telemetry summaries', () => {
     const payload = parseLoggedSummary();
     const [room] = payload.rooms as Array<Record<string, unknown>>;
     const productiveEnergy = (room.resources as Record<string, Record<string, unknown>>).productiveEnergy;
+    expect(room.workerAssignmentBlockedDetail).toEqual(productiveEnergy.workerAssignmentBlockedDetail);
+    expect(room.workerAssignmentBlockedWorkers).toEqual(productiveEnergy.workerAssignmentBlockedWorkers);
     expect(productiveEnergy.workerAssignmentBlockedWorkers).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -3316,23 +3316,35 @@ def worker_dispatch_diagnostic_fields(
         return {}
 
     diagnostic_tick = number_value(diagnostic.get("tick"))
-    if isinstance(snapshot_tick, int) and diagnostic_tick is not None and diagnostic_tick != snapshot_tick:
+    normalized_snapshot_tick: int | None
+    if isinstance(snapshot_tick, int):
+        normalized_snapshot_tick = snapshot_tick
+    elif isinstance(snapshot_tick, str) and snapshot_tick.isdigit():
+        normalized_snapshot_tick = int(snapshot_tick)
+    else:
+        normalized_snapshot_tick = None
+
+    if (
+        normalized_snapshot_tick is not None
+        and diagnostic_tick is not None
+        and diagnostic_tick != normalized_snapshot_tick
+    ):
         return {}
 
     return {
-        **({"dispatchReason": diagnostic["reason"]} if string_value(diagnostic.get("reason")) else {}),
+        **({"dispatchReason": diagnostic.get("reason")} if string_value(diagnostic.get("reason")) else {}),
         **({"dispatchTick": diagnostic_tick} if diagnostic_tick is not None else {}),
-        **({"dispatchCurrentTargetId": diagnostic["currentTargetId"]} if string_value(diagnostic.get("currentTargetId")) else {}),
-        **({"dispatchSelectedTask": diagnostic["selectedTask"]} if string_value(diagnostic.get("selectedTask")) else {}),
-        **({"dispatchSelectedTargetId": diagnostic["selectedTargetId"]} if string_value(diagnostic.get("selectedTargetId")) else {}),
-        **({"dispatchBaseSelectedTask": diagnostic["baseSelectedTask"]} if string_value(diagnostic.get("baseSelectedTask")) else {}),
-        **({"dispatchBaseSelectedTargetId": diagnostic["baseSelectedTargetId"]} if string_value(diagnostic.get("baseSelectedTargetId")) else {}),
-        **({"dispatchEnergyCriticalTask": diagnostic["energyCriticalTask"]} if string_value(diagnostic.get("energyCriticalTask")) else {}),
-        **({"dispatchEnergyCriticalTargetId": diagnostic["energyCriticalTargetId"]} if string_value(diagnostic.get("energyCriticalTargetId")) else {}),
-        **({"dispatchSpawnReservationTask": diagnostic["spawnReservationTask"]} if string_value(diagnostic.get("spawnReservationTask")) else {}),
-        **({"dispatchSpawnReservationTargetId": diagnostic["spawnReservationTargetId"]} if string_value(diagnostic.get("spawnReservationTargetId")) else {}),
-        **({"dispatchAssignedTask": diagnostic["assignedTask"]} if string_value(diagnostic.get("assignedTask")) else {}),
-        **({"dispatchAssignedTargetId": diagnostic["assignedTargetId"]} if string_value(diagnostic.get("assignedTargetId")) else {}),
+        **({"dispatchCurrentTargetId": diagnostic.get("currentTargetId")} if string_value(diagnostic.get("currentTargetId")) else {}),
+        **({"dispatchSelectedTask": diagnostic.get("selectedTask")} if string_value(diagnostic.get("selectedTask")) else {}),
+        **({"dispatchSelectedTargetId": diagnostic.get("selectedTargetId")} if string_value(diagnostic.get("selectedTargetId")) else {}),
+        **({"dispatchBaseSelectedTask": diagnostic.get("baseSelectedTask")} if string_value(diagnostic.get("baseSelectedTask")) else {}),
+        **({"dispatchBaseSelectedTargetId": diagnostic.get("baseSelectedTargetId")} if string_value(diagnostic.get("baseSelectedTargetId")) else {}),
+        **({"dispatchEnergyCriticalTask": diagnostic.get("energyCriticalTask")} if string_value(diagnostic.get("energyCriticalTask")) else {}),
+        **({"dispatchEnergyCriticalTargetId": diagnostic.get("energyCriticalTargetId")} if string_value(diagnostic.get("energyCriticalTargetId")) else {}),
+        **({"dispatchSpawnReservationTask": diagnostic.get("spawnReservationTask")} if string_value(diagnostic.get("spawnReservationTask")) else {}),
+        **({"dispatchSpawnReservationTargetId": diagnostic.get("spawnReservationTargetId")} if string_value(diagnostic.get("spawnReservationTargetId")) else {}),
+        **({"dispatchAssignedTask": diagnostic.get("assignedTask")} if string_value(diagnostic.get("assignedTask")) else {}),
+        **({"dispatchAssignedTargetId": diagnostic.get("assignedTargetId")} if string_value(diagnostic.get("assignedTargetId")) else {}),
     }
 
 

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -47,6 +47,29 @@ EXTENSION_COUNT_ZERO_AT_RCL_GE_2_KIND = "extension_count_zero_at_rcl_ge_2"
 WORKER_ASSIGNMENT_GAP_BLOCKED_REASON = "worker_assignment_gap"
 WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND = "worker_assignment_gap_sustained"
 WORKER_ASSIGNMENT_GAP_REQUIRED_TICKS = 100
+WORKER_ASSIGNMENT_BLOCKED_WORKER_STRING_FIELDS = (
+    "name",
+    "task",
+    "buildBlockedReason",
+    "repairBlockedReason",
+    "dispatchAssignedTargetId",
+    "dispatchAssignedTask",
+    "dispatchBaseSelectedTargetId",
+    "dispatchBaseSelectedTask",
+    "dispatchCurrentTargetId",
+    "dispatchEnergyCriticalTargetId",
+    "dispatchEnergyCriticalTask",
+    "dispatchReason",
+    "dispatchSelectedTargetId",
+    "dispatchSelectedTask",
+    "dispatchSpawnReservationTargetId",
+    "dispatchSpawnReservationTask",
+)
+WORKER_ASSIGNMENT_BLOCKED_WORKER_NUMBER_FIELDS = (
+    "carriedEnergy",
+    "dispatchTick",
+    "freeCapacity",
+)
 ENERGY_BUFFER_UNHEALTHY_KIND = "energy_buffer_unhealthy"
 ENERGY_BUFFER_UNHEALTHY_REQUIRED_CONSECUTIVE = 2
 ENERGY_BUFFER_UNHEALTHY_ROUTES = [
@@ -2791,6 +2814,7 @@ def room_summary(snapshot: RoomSnapshot, image: str | None = None) -> dict[str, 
     metrics = compute_room_summary_metrics(snapshot)
     owned_spawns = count_owned_objects(snapshot.objects, snapshot.owner, "spawn", snapshot.expected_owner_id)
     behavior_totals = behavior_pathing_totals(info)
+    assignment_blocked_fields = worker_assignment_blocked_fields(snapshot, metrics)
     summary = {
         "room": snapshot.ref.key,
         "shard": snapshot.ref.shard,
@@ -2809,6 +2833,7 @@ def room_summary(snapshot: RoomSnapshot, image: str | None = None) -> dict[str, 
         "pendingBuildProgress": metrics.pending_build_progress,
         "buildCarriedEnergy": metrics.build_carried_energy,
         "buildBlockedReason": metrics.build_blocked_reason,
+        **assignment_blocked_fields,
         "constructionSiteCount": len(metrics.construction_sites),
         "extensionCount": metrics.extension_count,
         "extensionCapacityContribution": metrics.extension_capacity_contribution,
@@ -3115,6 +3140,252 @@ def worker_load_efficiency(owned_creeps: list[dict[str, Any]]) -> dict[str, Any]
     }
 
 
+def string_value(value: Any) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def explicit_worker_assignment_blocked_detail(source: dict[str, Any]) -> str | None:
+    for path in (
+        ("workerAssignmentBlockedDetail",),
+        ("resources", "productiveEnergy", "workerAssignmentBlockedDetail"),
+        ("productiveEnergy", "workerAssignmentBlockedDetail"),
+        ("construction", "workerAssignmentBlockedDetail"),
+    ):
+        value = string_value(nested_value(source, *path))
+        if value is not None:
+            return value
+    return None
+
+
+def sanitized_worker_assignment_blocked_worker(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+
+    result: dict[str, Any] = {}
+    for key in WORKER_ASSIGNMENT_BLOCKED_WORKER_STRING_FIELDS:
+        field_value = string_value(value.get(key))
+        if field_value is not None:
+            result[key] = field_value
+    for key in WORKER_ASSIGNMENT_BLOCKED_WORKER_NUMBER_FIELDS:
+        field_value = number_value(value.get(key))
+        if field_value is not None:
+            result[key] = field_value
+    return result or None
+
+
+def explicit_worker_assignment_blocked_workers(source: dict[str, Any]) -> list[dict[str, Any]] | None:
+    for path in (
+        ("workerAssignmentBlockedWorkers",),
+        ("resources", "productiveEnergy", "workerAssignmentBlockedWorkers"),
+        ("productiveEnergy", "workerAssignmentBlockedWorkers"),
+        ("construction", "workerAssignmentBlockedWorkers"),
+    ):
+        value = nested_value(source, *path)
+        if not isinstance(value, list):
+            continue
+        workers = [
+            worker
+            for worker in (sanitized_worker_assignment_blocked_worker(item) for item in value)
+            if worker is not None
+        ]
+        return workers
+    return None
+
+
+def creep_memory(creep: dict[str, Any]) -> dict[str, Any]:
+    return as_dict(creep.get("memory"))
+
+
+def creep_name(creep: dict[str, Any]) -> str | None:
+    return string_value(creep.get("name")) or string_value(creep_memory(creep).get("name"))
+
+
+def creep_task_type(creep: dict[str, Any]) -> str | None:
+    memory = creep_memory(creep)
+    for candidate in (memory.get("task"), creep.get("task"), creep.get("runtimeTask"), creep.get("assignment")):
+        if isinstance(candidate, dict):
+            task_type = string_value(candidate.get("type"))
+            if task_type is not None:
+                return task_type
+        task_type = string_value(candidate)
+        if task_type is not None:
+            return task_type
+    return None
+
+
+def creep_free_energy_capacity(creep: dict[str, Any]) -> int | float:
+    return max(0, store_capacity(creep) - carried_energy(creep))
+
+
+def creep_has_active_body_part(creep: dict[str, Any], part_type: str) -> bool:
+    body = creep.get("body")
+    if not isinstance(body, list):
+        return False
+    for part in body:
+        if not isinstance(part, dict):
+            continue
+        hits = number_value(part.get("hits"))
+        if part.get("type") == part_type and (1 if hits is None else hits) > 0:
+            return True
+    return False
+
+
+def creep_is_construction_capable(creep: dict[str, Any]) -> bool:
+    return creep_has_active_body_part(creep, "work") and store_capacity(creep) > 0
+
+
+def worker_assignment_blocked_detail_from_snapshot(
+    snapshot: RoomSnapshot,
+    workers: list[dict[str, Any]],
+) -> str:
+    if not any(creep_is_construction_capable(worker) for worker in workers):
+        return "no_valid_body"
+
+    buffer_health = as_dict(snapshot.info.get("energyBufferHealth"))
+    buffer_current = number_value(buffer_health.get("currentEnergy"))
+    buffer_threshold = number_value(buffer_health.get("threshold"))
+    if buffer_health.get("healthy") is False or (
+        buffer_current is not None and buffer_threshold is not None and buffer_current < buffer_threshold
+    ):
+        return "energy_buffer_below_threshold"
+
+    if workers and all(creep_free_energy_capacity(worker) <= 0 for worker in workers):
+        return "room_capacity_full"
+
+    reservation = as_dict(snapshot.info.get("spawnEnergyReservation"))
+    if (number_value(reservation.get("unmetReservedEnergy")) or 0) > 0:
+        return "spawn_reserving_energy"
+
+    return "unknown"
+
+
+def worker_build_assignment_blocked_reason(
+    snapshot: RoomSnapshot,
+    worker: dict[str, Any],
+    metrics: RoomSummaryMetrics,
+) -> str:
+    task_type = creep_task_type(worker)
+    if task_type == "build":
+        return "build_assigned"
+    if not creep_is_construction_capable(worker):
+        return "build_blocked_no_valid_body"
+    if len(metrics.construction_sites) <= 0 or metrics.pending_build_progress <= 0:
+        return "build_blocked_no_construction_sites"
+    if carried_energy(worker) <= 0:
+        return "build_blocked_no_carried_energy"
+
+    buffer_health = as_dict(snapshot.info.get("energyBufferHealth"))
+    buffer_current = number_value(buffer_health.get("currentEnergy"))
+    buffer_threshold = number_value(buffer_health.get("threshold"))
+    if buffer_health.get("healthy") is False or (
+        buffer_current is not None and buffer_threshold is not None and buffer_current < buffer_threshold
+    ):
+        return "build_blocked_energy_buffer"
+    if task_type == "upgrade":
+        return "build_blocked_controller_progress_preferred"
+    if task_type:
+        return "build_blocked_other_task"
+    return "build_blocked_unknown"
+
+
+def worker_repair_assignment_blocked_reason(worker: dict[str, Any], metrics: RoomSummaryMetrics) -> str:
+    task_type = creep_task_type(worker)
+    if task_type == "repair":
+        return "repair_assigned"
+    if not creep_is_construction_capable(worker):
+        return "repair_blocked_no_valid_body"
+    if carried_energy(worker) <= 0:
+        return "repair_blocked_no_carried_energy"
+    if metrics.pending_build_progress > 0:
+        return "repair_blocked_build_backlog_first"
+    if task_type == "upgrade":
+        return "repair_blocked_controller_progress_preferred"
+    if task_type:
+        return "repair_blocked_other_task"
+    return "repair_blocked_unknown"
+
+
+def worker_dispatch_diagnostic_fields(
+    creep: dict[str, Any],
+    snapshot_tick: int | str | None,
+) -> dict[str, Any]:
+    diagnostic = as_dict(creep_memory(creep).get("workerDispatchDiagnostic"))
+    if not diagnostic:
+        return {}
+
+    diagnostic_tick = number_value(diagnostic.get("tick"))
+    if isinstance(snapshot_tick, int) and diagnostic_tick is not None and diagnostic_tick != snapshot_tick:
+        return {}
+
+    return {
+        **({"dispatchReason": diagnostic["reason"]} if string_value(diagnostic.get("reason")) else {}),
+        **({"dispatchTick": diagnostic_tick} if diagnostic_tick is not None else {}),
+        **({"dispatchCurrentTargetId": diagnostic["currentTargetId"]} if string_value(diagnostic.get("currentTargetId")) else {}),
+        **({"dispatchSelectedTask": diagnostic["selectedTask"]} if string_value(diagnostic.get("selectedTask")) else {}),
+        **({"dispatchSelectedTargetId": diagnostic["selectedTargetId"]} if string_value(diagnostic.get("selectedTargetId")) else {}),
+        **({"dispatchBaseSelectedTask": diagnostic["baseSelectedTask"]} if string_value(diagnostic.get("baseSelectedTask")) else {}),
+        **({"dispatchBaseSelectedTargetId": diagnostic["baseSelectedTargetId"]} if string_value(diagnostic.get("baseSelectedTargetId")) else {}),
+        **({"dispatchEnergyCriticalTask": diagnostic["energyCriticalTask"]} if string_value(diagnostic.get("energyCriticalTask")) else {}),
+        **({"dispatchEnergyCriticalTargetId": diagnostic["energyCriticalTargetId"]} if string_value(diagnostic.get("energyCriticalTargetId")) else {}),
+        **({"dispatchSpawnReservationTask": diagnostic["spawnReservationTask"]} if string_value(diagnostic.get("spawnReservationTask")) else {}),
+        **({"dispatchSpawnReservationTargetId": diagnostic["spawnReservationTargetId"]} if string_value(diagnostic.get("spawnReservationTargetId")) else {}),
+        **({"dispatchAssignedTask": diagnostic["assignedTask"]} if string_value(diagnostic.get("assignedTask")) else {}),
+        **({"dispatchAssignedTargetId": diagnostic["assignedTargetId"]} if string_value(diagnostic.get("assignedTargetId")) else {}),
+    }
+
+
+def worker_assignment_blocked_workers_from_creeps(
+    snapshot: RoomSnapshot,
+    metrics: RoomSummaryMetrics,
+) -> list[dict[str, Any]]:
+    workers = [creep for creep in metrics.owned_creep_objects if is_worker_creep(creep)]
+    result: list[dict[str, Any]] = []
+    for worker in sorted(workers, key=lambda creep: (creep_task_type(creep) or "", creep_name(creep) or "")):
+        worker_summary: dict[str, Any] = {
+            **({"name": creep_name(worker)} if creep_name(worker) else {}),
+            **({"task": creep_task_type(worker)} if creep_task_type(worker) else {}),
+            "carriedEnergy": carried_energy(worker),
+            "freeCapacity": creep_free_energy_capacity(worker),
+            "buildBlockedReason": worker_build_assignment_blocked_reason(snapshot, worker, metrics),
+            "repairBlockedReason": worker_repair_assignment_blocked_reason(worker, metrics),
+            **worker_dispatch_diagnostic_fields(worker, snapshot.tick),
+        }
+        result.append(worker_summary)
+    return result
+
+
+def worker_assignment_blocked_fields(snapshot: RoomSnapshot, metrics: RoomSummaryMetrics) -> dict[str, Any]:
+    info = snapshot.info if isinstance(snapshot.info, dict) else {}
+    detail = explicit_worker_assignment_blocked_detail(info)
+    workers = explicit_worker_assignment_blocked_workers(info)
+    visible_worker_creeps = [creep for creep in metrics.owned_creep_objects if is_worker_creep(creep)]
+
+    if (
+        detail is None
+        and visible_worker_creeps
+        and metrics.build_blocked_reason == WORKER_ASSIGNMENT_GAP_BLOCKED_REASON
+    ):
+        detail = worker_assignment_blocked_detail_from_snapshot(
+            snapshot,
+            visible_worker_creeps,
+        )
+    if (
+        workers is None
+        and visible_worker_creeps
+        and metrics.build_blocked_reason == WORKER_ASSIGNMENT_GAP_BLOCKED_REASON
+    ):
+        workers = worker_assignment_blocked_workers_from_creeps(snapshot, metrics)
+
+    result: dict[str, Any] = {}
+    if detail is not None:
+        result["workerAssignmentBlockedDetail"] = detail
+    if workers is not None:
+        result["workerAssignmentBlockedWorkers"] = workers
+    return result
+
+
 def build_blocked_reason(
     snapshot: RoomSnapshot,
     pending_build_progress: int | float,
@@ -3232,6 +3503,14 @@ def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
         if confirmed_foreign_owner(obj, snapshot.owner)
     ]
     behavior_totals = behavior_pathing_totals(snapshot.info)
+    assignment_blocked_fields = worker_assignment_blocked_fields(snapshot, metrics)
+    productive_energy = {
+        "pendingBuildProgress": metrics.pending_build_progress,
+        "buildCarriedEnergy": metrics.build_carried_energy,
+        "constructionSiteCount": len(metrics.construction_sites),
+        "buildBlockedReason": metrics.build_blocked_reason,
+        **assignment_blocked_fields,
+    }
 
     summary = {
         "roomName": snapshot.ref.room,
@@ -3239,6 +3518,7 @@ def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
         "pendingBuildProgress": metrics.pending_build_progress,
         "buildCarriedEnergy": metrics.build_carried_energy,
         "buildBlockedReason": metrics.build_blocked_reason,
+        **assignment_blocked_fields,
         "constructionSiteCount": len(metrics.construction_sites),
         "extensionCount": metrics.extension_count,
         "extensionCapacityContribution": metrics.extension_capacity_contribution,
@@ -3256,12 +3536,7 @@ def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
             "workerCarriedEnergy": sum(store_energy(obj) for obj in owned_creeps),
             "droppedEnergy": sum(number_value(obj.get("amount")) or 0 for obj in dropped_energy),
             "sourceCount": len(sources),
-            "productiveEnergy": {
-                "pendingBuildProgress": metrics.pending_build_progress,
-                "buildCarriedEnergy": metrics.build_carried_energy,
-                "constructionSiteCount": len(metrics.construction_sites),
-                "buildBlockedReason": metrics.build_blocked_reason,
-            },
+            "productiveEnergy": productive_energy,
         },
         "workerLoadEfficiency": worker_load_efficiency(owned_creeps),
         "combat": {

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -881,6 +881,83 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
             "worker_assignment_gap",
         )
 
+    def test_runtime_summary_payload_includes_worker_dispatch_diagnostics(self) -> None:
+        snapshot = monitor.RoomSnapshot(
+            ref=monitor.RoomRef(shard="shardX", room="E26S49"),
+            terrain="0" * monitor.TERRAIN_CELLS,
+            objects=monitor.normalize_objects(
+                {
+                    "site-1": {
+                        "_id": "site-1",
+                        "type": "constructionSite",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "structureType": "extension",
+                        "progress": 0,
+                        "progressTotal": 50,
+                    },
+                    "worker-1": {
+                        "_id": "worker-1",
+                        "type": "creep",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "name": "Upgrader",
+                        "body": [
+                            {"type": "work", "hits": 100},
+                            {"type": "carry", "hits": 100},
+                        ],
+                        "store": {"energy": 50, "capacity": 100},
+                        "memory": {
+                            "role": "worker",
+                            "task": {"type": "upgrade", "targetId": "controller1"},
+                            "workerDispatchDiagnostic": {
+                                "tick": 265633,
+                                "reason": "retained_upgrade_task",
+                                "selectedTask": "build",
+                                "selectedTargetId": "extension-site",
+                                "assignedTask": "upgrade",
+                                "assignedTargetId": "controller1",
+                            },
+                        },
+                    },
+                }
+            ),
+            tick=265633,
+            owner="lanyusea",
+            info={"energyAvailable": 300},
+        )
+
+        payload = monitor.runtime_summary_payload_from_snapshots([snapshot])
+        room = payload["rooms"][0]
+        productive_energy = room["resources"]["productiveEnergy"]
+
+        self.assertEqual(room["buildBlockedReason"], "worker_assignment_gap")
+        self.assertEqual(room["workerAssignmentBlockedDetail"], "unknown")
+        self.assertEqual(productive_energy["workerAssignmentBlockedDetail"], "unknown")
+        self.assertEqual(
+            room["workerAssignmentBlockedWorkers"],
+            [
+                {
+                    "name": "Upgrader",
+                    "task": "upgrade",
+                    "carriedEnergy": 50,
+                    "freeCapacity": 50,
+                    "buildBlockedReason": "build_blocked_controller_progress_preferred",
+                    "repairBlockedReason": "repair_blocked_build_backlog_first",
+                    "dispatchReason": "retained_upgrade_task",
+                    "dispatchTick": 265633,
+                    "dispatchSelectedTask": "build",
+                    "dispatchSelectedTargetId": "extension-site",
+                    "dispatchAssignedTask": "upgrade",
+                    "dispatchAssignedTargetId": "controller1",
+                }
+            ],
+        )
+        self.assertEqual(
+            productive_energy["workerAssignmentBlockedWorkers"],
+            room["workerAssignmentBlockedWorkers"],
+        )
+
     def test_runtime_summary_does_not_label_unknown_structures_as_hostile(self) -> None:
         snapshot = monitor.RoomSnapshot(
             ref=monitor.RoomRef(shard="shardX", room="E26S49"),


### PR DESCRIPTION
Surface per-worker dispatch diagnostic detail in runtime-summary console captures + workerAssignmentBlockedDetail telemetry.

## Changes
- **`prod/src/telemetry/runtimeSummary.ts`**: Add per-worker dispatch diagnostic tracking — surfacing which dispatch gate blocked each worker (spawnReservingEnergy, energyBufferBelowThreshold, noValidBody, unknown, etc.)
- **`prod/test/runtimeSummary.test.ts`**: Regression coverage for new diagnostic fields
- **`scripts/screeps-runtime-monitor.py`**: Parse and surface `workerAssignmentBlockedDetail` in runtime-summary JSON console output — 287 lines of parsing + display logic
- **`scripts/test_screeps_runtime_monitor_tactical_response.py`**: 77 lines of test coverage for console capture + tactical response integration
- **`prod/dist/main.js`**: Regenerated build artifact

## Verification
- TypeScript: `tsc --noEmit` PASS
- Jest: 95/95 suites, 1778/1778 tests PASS
- Build: `npm run build` PASS
- Python: `py_compile` PASS, 29/29 pytest PASS

Closes #1019
