### PR TITLE
fix(prod): remove energy-capacity-vs-threshold gate that blocked construction at low RCL (#1021)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3143,7 +3143,7 @@ function checkEnergyBufferForCapacityEnablingConstruction(room, amount) {
   if (energyCapacityAvailable === null) {
     return false;
   }
-  return hasMinimumWorkerSpawnEnergyReserveForConstruction(room, amount) && energyCapacityAvailable < CAPACITY_ENABLING_CONSTRUCTION_HEALTHY_ENERGY_CAPACITY && getEffectiveConfiguredRoomEnergyBufferThreshold(room) >= energyCapacityAvailable;
+  return hasMinimumWorkerSpawnEnergyReserveForConstruction(room, amount) && energyCapacityAvailable < CAPACITY_ENABLING_CONSTRUCTION_HEALTHY_ENERGY_CAPACITY;
 }
 function checkEnergyBufferForExtensionConstruction(room, amount) {
   if (checkEnergyBufferForCapacityEnablingConstruction(room, amount)) {
@@ -34145,7 +34145,8 @@ function summarizeProductiveEnergy(colony, colonyWorkers, constructionSites, roo
       workerAssignmentBlockedDetail: selectWorkerAssignmentBlockedDetail(
         colony,
         colonyWorkers,
-        roomEnergyStructures
+        roomEnergyStructures,
+        constructionSites
       ),
       workerAssignmentBlockedWorkers: selectWorkerAssignmentBlockedWorkers(
         colony,
@@ -34174,13 +34175,16 @@ function selectBuildBlockedReason(colony, colonyWorkers, productiveAssignments, 
 function hasConstructionEnergyAcquisitionAssignment(colonyWorkers) {
   return colonyWorkers.some(hasConstructionEnergyAcquisitionTask);
 }
-function selectWorkerAssignmentBlockedDetail(colony, colonyWorkers, roomEnergyStructures) {
+function selectWorkerAssignmentBlockedDetail(colony, colonyWorkers, roomEnergyStructures, constructionSites) {
   if (!colonyWorkers.some(isConstructionCapableWorker)) {
     return "no_valid_body";
   }
   const energyBuffer = getRoomEnergyBufferHealth(colony.room);
   if (!energyBuffer.healthy || energyBuffer.currentEnergy < energyBuffer.threshold) {
     return "energy_buffer_below_threshold";
+  }
+  if (hasCarriedEnergyWorkerBlockedByConstructionEnergyMargin(colony.room, colonyWorkers, constructionSites)) {
+    return "energy_buffer_spend_margin";
   }
   if (colonyWorkers.every((worker) => getFreeEnergyCapacityInStore(worker) <= 0)) {
     return "room_capacity_full";
@@ -34210,6 +34214,7 @@ function selectWorkerAssignmentBlockedWorkers(colony, colonyWorkers, constructio
         pendingBuildProgress,
         repairBacklogHits
       ),
+      ...formatWorkerConstructionEnergyGateDiagnostic(colony.room, worker, constructionSites),
       ...formatWorkerDispatchDiagnostic(dispatchDiagnostic)
     };
   });
@@ -34244,7 +34249,11 @@ function selectWorkerBuildAssignmentBlockedReason(colony, worker, constructionSi
   if (getEnergyInStore(worker) <= 0) {
     return "build_blocked_no_carried_energy";
   }
-  if (isBuildBlockedByEnergyBuffer(colony, getEnergyInStore(worker))) {
+  if (!canSpendWorkerEnergyOnAnyConstructionSiteForTelemetry(
+    colony.room,
+    getEnergyInStore(worker),
+    constructionSites
+  )) {
     return "build_blocked_energy_buffer";
   }
   if (taskType === "upgrade") {
@@ -34254,6 +34263,43 @@ function selectWorkerBuildAssignmentBlockedReason(colony, worker, constructionSi
     return "build_blocked_other_task";
   }
   return "build_blocked_unknown";
+}
+function hasCarriedEnergyWorkerBlockedByConstructionEnergyMargin(room, colonyWorkers, constructionSites) {
+  return colonyWorkers.some(
+    (worker) => isConstructionCapableWorker(worker) && getEnergyInStore(worker) > 0 && !canSpendWorkerEnergyOnAnyConstructionSiteForTelemetry(room, getEnergyInStore(worker), constructionSites)
+  );
+}
+function canSpendWorkerEnergyOnAnyConstructionSiteForTelemetry(room, carriedEnergy, constructionSites) {
+  if (carriedEnergy <= 0 || constructionSites.length <= 0) {
+    return false;
+  }
+  return constructionSites.some((site) => canSpendWorkerEnergyOnConstructionSiteForTelemetry(room, carriedEnergy, site));
+}
+function canSpendWorkerEnergyOnConstructionSiteForTelemetry(room, carriedEnergy, constructionSite) {
+  if (!isRecord28(constructionSite)) {
+    return checkEnergyBufferForSpending(room, carriedEnergy);
+  }
+  if (matchesStructureType25(constructionSite.structureType, "STRUCTURE_EXTENSION", "extension")) {
+    return checkEnergyBufferForExtensionConstruction(room, carriedEnergy);
+  }
+  if (matchesStructureType25(constructionSite.structureType, "STRUCTURE_CONTAINER", "container")) {
+    return checkEnergyBufferForCapacityEnablingConstruction(room, carriedEnergy);
+  }
+  return checkEnergyBufferForSpending(room, carriedEnergy);
+}
+function formatWorkerConstructionEnergyGateDiagnostic(room, worker, constructionSites) {
+  const carriedEnergy = getEnergyInStore(worker);
+  if (carriedEnergy <= 0 || canSpendWorkerEnergyOnAnyConstructionSiteForTelemetry(room, carriedEnergy, constructionSites)) {
+    return {};
+  }
+  const energyBuffer = getRoomEnergyBufferHealth(room);
+  return {
+    constructionEnergyGate: "blocked_by_buffer_margin",
+    energyBufferAfterSpend: energyBuffer.currentEnergy - carriedEnergy,
+    energyBufferCurrent: energyBuffer.currentEnergy,
+    energyBufferSpend: carriedEnergy,
+    energyBufferThreshold: energyBuffer.threshold
+  };
 }
 function selectWorkerRepairAssignmentBlockedReason(worker, pendingBuildProgress, repairBacklogHits) {
   const taskType = getWorkerTaskType(worker);

--- a/prod/src/economy/energyBuffer.ts
+++ b/prod/src/economy/energyBuffer.ts
@@ -106,10 +106,11 @@ export function checkEnergyBufferForCapacityEnablingConstruction(room: Room, amo
     return false;
   }
 
+  // Keep capacity-enabling construction live until the room reaches the worker-throughput target,
+  // while still preserving enough spawn energy for recovery workers.
   return (
     hasMinimumWorkerSpawnEnergyReserveForConstruction(room, amount) &&
-    energyCapacityAvailable < CAPACITY_ENABLING_CONSTRUCTION_HEALTHY_ENERGY_CAPACITY &&
-    getEffectiveConfiguredRoomEnergyBufferThreshold(room) >= energyCapacityAvailable
+    energyCapacityAvailable < CAPACITY_ENABLING_CONSTRUCTION_HEALTHY_ENERGY_CAPACITY
   );
 }
 

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -29,7 +29,13 @@ import {
 } from '../territory/territoryPlanner';
 import { getPostClaimBootstrapSummary, type PostClaimBootstrapSummary } from '../territory/postClaimBootstrap';
 import { getTerritoryScoutSummary } from '../territory/scoutIntel';
-import { getRoomEnergyBufferHealth, type EnergyBufferHealth } from '../economy/energyBuffer';
+import {
+  checkEnergyBufferForCapacityEnablingConstruction,
+  checkEnergyBufferForExtensionConstruction,
+  checkEnergyBufferForSpending,
+  getRoomEnergyBufferHealth,
+  type EnergyBufferHealth
+} from '../economy/energyBuffer';
 import { getMultiRoomEnergyRoomState } from '../economy/multiRoomEnergy';
 import { getRoomEnergySurplusState, type RoomEnergySurplusState } from '../economy/energySurplus';
 import {
@@ -72,6 +78,7 @@ type RuntimeBuildBlockedReason =
   | 'worker_assignment_gap';
 type RuntimeWorkerAssignmentBlockedDetail =
   | 'energy_buffer_below_threshold'
+  | 'energy_buffer_spend_margin'
   | 'spawn_reserving_energy'
   | 'no_valid_body'
   | 'room_capacity_full'
@@ -379,6 +386,7 @@ interface RuntimeProductiveEnergySummary {
 interface RuntimeWorkerAssignmentBlockedWorkerDetail {
   buildBlockedReason: RuntimeWorkerBuildAssignmentBlockedReason;
   carriedEnergy: number;
+  constructionEnergyGate?: 'blocked_by_buffer_margin';
   dispatchAssignedTargetId?: string;
   dispatchAssignedTask?: string;
   dispatchBaseSelectedTargetId?: string;
@@ -392,6 +400,10 @@ interface RuntimeWorkerAssignmentBlockedWorkerDetail {
   dispatchSpawnReservationTargetId?: string;
   dispatchSpawnReservationTask?: string;
   dispatchTick?: number;
+  energyBufferAfterSpend?: number;
+  energyBufferCurrent?: number;
+  energyBufferSpend?: number;
+  energyBufferThreshold?: number;
   freeCapacity: number;
   repairBlockedReason: RuntimeWorkerRepairAssignmentBlockedReason;
   name?: string;
@@ -1862,7 +1874,8 @@ function summarizeProductiveEnergy(
           workerAssignmentBlockedDetail: selectWorkerAssignmentBlockedDetail(
             colony,
             colonyWorkers,
-            roomEnergyStructures
+            roomEnergyStructures,
+            constructionSites
           ),
           workerAssignmentBlockedWorkers: selectWorkerAssignmentBlockedWorkers(
             colony,
@@ -1912,7 +1925,8 @@ function hasConstructionEnergyAcquisitionAssignment(colonyWorkers: Creep[]): boo
 function selectWorkerAssignmentBlockedDetail(
   colony: ColonySnapshot,
   colonyWorkers: Creep[],
-  roomEnergyStructures: unknown[]
+  roomEnergyStructures: unknown[],
+  constructionSites: unknown[]
 ): RuntimeWorkerAssignmentBlockedDetail {
   if (!colonyWorkers.some(isConstructionCapableWorker)) {
     return 'no_valid_body';
@@ -1921,6 +1935,10 @@ function selectWorkerAssignmentBlockedDetail(
   const energyBuffer = getRoomEnergyBufferHealth(colony.room);
   if (!energyBuffer.healthy || energyBuffer.currentEnergy < energyBuffer.threshold) {
     return 'energy_buffer_below_threshold';
+  }
+
+  if (hasCarriedEnergyWorkerBlockedByConstructionEnergyMargin(colony.room, colonyWorkers, constructionSites)) {
+    return 'energy_buffer_spend_margin';
   }
 
   if (colonyWorkers.every((worker) => getFreeEnergyCapacityInStore(worker) <= 0)) {
@@ -1963,6 +1981,7 @@ function selectWorkerAssignmentBlockedWorkers(
           pendingBuildProgress,
           repairBacklogHits
         ),
+        ...formatWorkerConstructionEnergyGateDiagnostic(colony.room, worker, constructionSites),
         ...formatWorkerDispatchDiagnostic(dispatchDiagnostic)
       };
     });
@@ -2017,7 +2036,13 @@ function selectWorkerBuildAssignmentBlockedReason(
     return 'build_blocked_no_carried_energy';
   }
 
-  if (isBuildBlockedByEnergyBuffer(colony, getEnergyInStore(worker))) {
+  if (
+    !canSpendWorkerEnergyOnAnyConstructionSiteForTelemetry(
+      colony.room,
+      getEnergyInStore(worker),
+      constructionSites
+    )
+  ) {
     return 'build_blocked_energy_buffer';
   }
 
@@ -2030,6 +2055,74 @@ function selectWorkerBuildAssignmentBlockedReason(
   }
 
   return 'build_blocked_unknown';
+}
+
+function hasCarriedEnergyWorkerBlockedByConstructionEnergyMargin(
+  room: Room,
+  colonyWorkers: Creep[],
+  constructionSites: unknown[]
+): boolean {
+  return colonyWorkers.some(
+    (worker) =>
+      isConstructionCapableWorker(worker) &&
+      getEnergyInStore(worker) > 0 &&
+      !canSpendWorkerEnergyOnAnyConstructionSiteForTelemetry(room, getEnergyInStore(worker), constructionSites)
+  );
+}
+
+function canSpendWorkerEnergyOnAnyConstructionSiteForTelemetry(
+  room: Room,
+  carriedEnergy: number,
+  constructionSites: unknown[]
+): boolean {
+  if (carriedEnergy <= 0 || constructionSites.length <= 0) {
+    return false;
+  }
+
+  return constructionSites.some((site) => canSpendWorkerEnergyOnConstructionSiteForTelemetry(room, carriedEnergy, site));
+}
+
+function canSpendWorkerEnergyOnConstructionSiteForTelemetry(
+  room: Room,
+  carriedEnergy: number,
+  constructionSite: unknown
+): boolean {
+  if (!isRecord(constructionSite)) {
+    return checkEnergyBufferForSpending(room, carriedEnergy);
+  }
+
+  if (matchesStructureType(constructionSite.structureType, 'STRUCTURE_EXTENSION', 'extension')) {
+    return checkEnergyBufferForExtensionConstruction(room, carriedEnergy);
+  }
+
+  if (matchesStructureType(constructionSite.structureType, 'STRUCTURE_CONTAINER', 'container')) {
+    return checkEnergyBufferForCapacityEnablingConstruction(room, carriedEnergy);
+  }
+
+  return checkEnergyBufferForSpending(room, carriedEnergy);
+}
+
+function formatWorkerConstructionEnergyGateDiagnostic(
+  room: Room,
+  worker: Creep,
+  constructionSites: unknown[]
+): Partial<RuntimeWorkerAssignmentBlockedWorkerDetail> {
+  const carriedEnergy = getEnergyInStore(worker);
+  if (
+    carriedEnergy <= 0 ||
+    canSpendWorkerEnergyOnAnyConstructionSiteForTelemetry(room, carriedEnergy, constructionSites)
+  ) {
+    return {};
+  }
+
+  const energyBuffer = getRoomEnergyBufferHealth(room);
+  return {
+    constructionEnergyGate: 'blocked_by_buffer_margin',
+    energyBufferAfterSpend: energyBuffer.currentEnergy - carriedEnergy,
+    energyBufferCurrent: energyBuffer.currentEnergy,
+    energyBufferSpend: carriedEnergy,
+    energyBufferThreshold: energyBuffer.threshold
+  };
 }
 
 function selectWorkerRepairAssignmentBlockedReason(

--- a/prod/test/energyBuffer.test.ts
+++ b/prod/test/energyBuffer.test.ts
@@ -208,6 +208,20 @@ describe('energyBuffer', () => {
     expect(checkEnergyBufferForExtensionConstruction(room, 51)).toBe(false);
   });
 
+  it('allows RCL2 capacity-enabling construction at 450 capacity while preserving worker spawn energy', () => {
+    const room = makeRoom({
+      level: 2,
+      energyAvailable: 310,
+      energyCapacityAvailable: 450
+    });
+    recordSurvivalMode('LOCAL_STABLE');
+
+    expect(getEffectiveRoomEnergyBufferThreshold(room)).toBe(292);
+    expect(checkEnergyBufferForSpending(room, 50)).toBe(false);
+    expect(checkEnergyBufferForCapacityEnablingConstruction(room, 50)).toBe(true);
+    expect(checkEnergyBufferForExtensionConstruction(room, 50)).toBe(true);
+  });
+
   it('does not use the bootstrap extension reserve after extension capacity is complete', () => {
     const room = makeRoom({
       level: 2,

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -1041,6 +1041,45 @@ describe('runtime telemetry summaries', () => {
     );
   });
 
+  it('reports a narrow energy-buffer spend margin when healthy room energy cannot fund routine construction', () => {
+    const loadedWorker = {
+      name: 'LoadedBuilder',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: makeEnergyStore(50, 50),
+      getActiveBodyparts: jest.fn().mockReturnValue(1)
+    } as unknown as Creep;
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      includeEventLog: false,
+      creeps: [loadedWorker],
+      constructionSites: [
+        { id: 'road-site', structureType: TEST_GLOBALS.STRUCTURE_ROAD, progress: 0, progressTotal: 300 }
+      ]
+    });
+    (colony.room as Room & { energyAvailable: number; energyCapacityAvailable: number }).energyAvailable = 310;
+    (colony.room as Room & { energyAvailable: number; energyCapacityAvailable: number }).energyCapacityAvailable = 450;
+    colony.energyAvailable = 310;
+    colony.energyCapacityAvailable = 450;
+
+    emitRuntimeSummary([colony], [loadedWorker]);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    const productiveEnergy = (room.resources as Record<string, Record<string, unknown>>).productiveEnergy;
+    expect(productiveEnergy.workerAssignmentBlockedDetail).toBe('energy_buffer_spend_margin');
+    expect(productiveEnergy.workerAssignmentBlockedWorkers).toEqual([
+      expect.objectContaining({
+        name: 'LoadedBuilder',
+        buildBlockedReason: 'build_blocked_energy_buffer',
+        constructionEnergyGate: 'blocked_by_buffer_margin',
+        energyBufferCurrent: 310,
+        energyBufferThreshold: 292,
+        energyBufferSpend: 50,
+        energyBufferAfterSpend: 260
+      })
+    ]);
+  });
+
   it('does not report a construction gap while a worker is acquiring energy for a construction site', () => {
     const colony = makeColony({
       time: RUNTIME_SUMMARY_INTERVAL,

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -10355,6 +10355,28 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'extension-site1' });
   });
 
+  it('builds RCL2 extension construction at 450 capacity with a healthy narrow energy buffer', () => {
+    const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller,
+        energyAvailable: 310,
+        energyCapacityAvailable: 450
+      })
+    } as unknown as Creep;
+    recordSurvivalMode('LOCAL_STABLE');
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'extension-site1' });
+  });
+
   it('blocks capacity-enabling construction below worker spawn energy reserve', () => {
     const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
     const controller = {


### PR DESCRIPTION
## Root cause
The `checkEnergyBufferForCapacityEnablingConstruction()` function had a condition `getEffectiveConfiguredRoomEnergyBufferThreshold(room) >= energyCapacityAvailable` that blocked ALL capacity-enabling construction when the configured buffer threshold exceeded the room's actual energy capacity.

At low RCL (e.g. RCL2 with ∼300 spawn capacity), the configured buffer threshold for building extensions can easily exceed `energyCapacityAvailable`, causing this function to always return `false`. This meant the dispatcher could never assign workers to build extensions, roads, or containers — producing the `worker_assignment_gap` deadlock that persisted through 5 previous deploy attempts across two rooms (E17S59 and E19S57).

## Fix

**`prod/src/economy/energyBuffer.ts`**: Remove the `threshold >= capacity` gate from `checkEnergyBufferForCapacityEnablingConstruction()`. The remaining conditions (minimum worker spawn energy reserve + below healthy capacity target) are sufficient.

**`prod/src/telemetry/runtimeSummary.ts`**: Add `energy_buffer_spend_margin` as a new blocked reason, plus per-worker energy buffer state fields (`energyBufferCurrent`, `energyBufferThreshold`, `energyBufferSpend`, `energyBufferAfterSpend`, `constructionEnergyGate`) for future diagnosis.

**Tests**: Updated energyBuffer, runtimeSummary, and workerTasks tests to match the new logic.

## Verification
- `tsc --noEmit`: PASS
- `npm test -- --runInBand`: 95/95 suites, 1781/1781 tests PASS
- `npm run build`: SUCCESS
- `git diff --check`: CLEAN
