### PR TITLE
fix(prod): cap energy buffer threshold below 100% capacity in survival mode to unblock construction (#1031)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3121,7 +3121,8 @@ function getEffectiveRoomEnergyBufferThreshold(room) {
   }
   const capacityLimitedThreshold = Math.min(effectiveThreshold, energyCapacityAvailable);
   if (survivalBufferMode) {
-    return capacityLimitedThreshold;
+    const survivalCapacityCap = Math.ceil(energyCapacityAvailable * NON_CRISIS_ENERGY_BUFFER_CAPACITY_RATIO);
+    return Math.min(capacityLimitedThreshold, survivalCapacityCap);
   }
   return Math.min(capacityLimitedThreshold, getNonCrisisEnergyBufferCapacityCap(energyCapacityAvailable));
 }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3121,7 +3121,10 @@ function getEffectiveRoomEnergyBufferThreshold(room) {
   }
   const capacityLimitedThreshold = Math.min(effectiveThreshold, energyCapacityAvailable);
   if (survivalBufferMode) {
-    const survivalCapacityCap = Math.ceil(energyCapacityAvailable * NON_CRISIS_ENERGY_BUFFER_CAPACITY_RATIO);
+    const survivalCapacityCap = Math.max(
+      MINIMUM_WORKER_SPAWN_ENERGY,
+      Math.ceil(energyCapacityAvailable * NON_CRISIS_ENERGY_BUFFER_CAPACITY_RATIO)
+    );
     return Math.min(capacityLimitedThreshold, survivalCapacityCap);
   }
   return Math.min(capacityLimitedThreshold, getNonCrisisEnergyBufferCapacityCap(energyCapacityAvailable));

--- a/prod/src/economy/energyBuffer.ts
+++ b/prod/src/economy/energyBuffer.ts
@@ -77,7 +77,8 @@ export function getEffectiveRoomEnergyBufferThreshold(room: Room): number {
 
   const capacityLimitedThreshold = Math.min(effectiveThreshold, energyCapacityAvailable);
   if (survivalBufferMode) {
-    return capacityLimitedThreshold;
+    const survivalCapacityCap = Math.ceil(energyCapacityAvailable * NON_CRISIS_ENERGY_BUFFER_CAPACITY_RATIO);
+    return Math.min(capacityLimitedThreshold, survivalCapacityCap);
   }
 
   return Math.min(capacityLimitedThreshold, getNonCrisisEnergyBufferCapacityCap(energyCapacityAvailable));

--- a/prod/src/economy/energyBuffer.ts
+++ b/prod/src/economy/energyBuffer.ts
@@ -77,7 +77,10 @@ export function getEffectiveRoomEnergyBufferThreshold(room: Room): number {
 
   const capacityLimitedThreshold = Math.min(effectiveThreshold, energyCapacityAvailable);
   if (survivalBufferMode) {
-    const survivalCapacityCap = Math.ceil(energyCapacityAvailable * NON_CRISIS_ENERGY_BUFFER_CAPACITY_RATIO);
+    const survivalCapacityCap = Math.max(
+      MINIMUM_WORKER_SPAWN_ENERGY,
+      Math.ceil(energyCapacityAvailable * NON_CRISIS_ENERGY_BUFFER_CAPACITY_RATIO)
+    );
     return Math.min(capacityLimitedThreshold, survivalCapacityCap);
   }
 

--- a/prod/test/constructionPlanner.test.ts
+++ b/prod/test/constructionPlanner.test.ts
@@ -184,7 +184,7 @@ describe('owned room construction planner', () => {
     recordBootstrapSurvivalMode();
     const { room, colony } = makeColony({
       controllerLevel: 2,
-      energyAvailable: 249,
+      energyAvailable: 244,
       energyCapacityAvailable: 300,
       sources: [makeSource('source-a', 20, 10)],
       pathsByTarget: {
@@ -203,7 +203,7 @@ describe('owned room construction planner', () => {
     recordBootstrapSurvivalMode();
     const { room, colony } = makeColony({
       controllerLevel: 2,
-      energyAvailable: 300,
+      energyAvailable: 244,
       energyCapacityAvailable: 300,
       constructionSites: [makeConstructionSite('extension-pending', TEST_GLOBALS.STRUCTURE_EXTENSION, 9, 9, 'W1N1')],
       sources: [makeSource('source-a', 20, 10)],
@@ -276,7 +276,7 @@ describe('owned room construction planner', () => {
     recordBootstrapSurvivalMode();
     const { room, colony } = makeColony({
       controllerLevel: 4,
-      energyAvailable: 300,
+      energyAvailable: 277,
       energyCapacityAvailable: 350,
       structures: [makeStructure('extension-existing', TEST_GLOBALS.STRUCTURE_EXTENSION, 30, 30)],
       sources: [],
@@ -295,7 +295,7 @@ describe('owned room construction planner', () => {
     recordBootstrapSurvivalMode();
     const { room, colony } = makeColony({
       controllerLevel: 4,
-      energyAvailable: 300,
+      energyAvailable: 277,
       energyCapacityAvailable: 350,
       structures: [
         ...Array.from({ length: 20 }, (_, index) =>

--- a/prod/test/energyBuffer.test.ts
+++ b/prod/test/energyBuffer.test.ts
@@ -100,12 +100,15 @@ describe('energyBuffer', () => {
     expect(checkEnergyBufferForSpending(room, 343)).toBe(false);
   });
 
-  it('caps an RCL 2 bootstrap threshold after applying the survival multiplier', () => {
-    const room = makeRoom({ level: 2, energyAvailable: 300, energyCapacityAvailable: 300 });
+  it('caps an RCL 2 bootstrap threshold below full capacity after applying the survival multiplier', () => {
+    const room = makeRoom({ level: 2, energyAvailable: 450, energyCapacityAvailable: 450 });
     recordSurvivalMode('BOOTSTRAP');
 
     expect(getRoomEnergyBufferThreshold(room)).toBe(300);
-    expect(getEffectiveRoomEnergyBufferThreshold(room)).toBe(300);
+    expect(getEffectiveRoomEnergyBufferThreshold(room)).toBe(
+      Math.ceil(450 * NON_CRISIS_ENERGY_BUFFER_CAPACITY_RATIO)
+    );
+    expect(getEffectiveRoomEnergyBufferThreshold(room)).toBeLessThan(room.energyCapacityAvailable);
   });
 
   it('caps an RCL 3 bootstrap threshold after applying the survival multiplier', () => {
@@ -113,7 +116,9 @@ describe('energyBuffer', () => {
     recordSurvivalMode('BOOTSTRAP');
 
     expect(getRoomEnergyBufferThreshold(room)).toBe(500);
-    expect(getEffectiveRoomEnergyBufferThreshold(room)).toBe(550);
+    expect(getEffectiveRoomEnergyBufferThreshold(room)).toBe(
+      Math.ceil(550 * NON_CRISIS_ENERGY_BUFFER_CAPACITY_RATIO)
+    );
   });
 
   it('keeps non-survival effective thresholds above basic worker spawn energy', () => {
@@ -156,8 +161,8 @@ describe('energyBuffer', () => {
   it('allows capacity-enabling construction when it preserves basic worker spawn energy', () => {
     const room = makeRoom({
       level: 3,
-      energyAvailable: MINIMUM_WORKER_SPAWN_ENERGY + 50,
-      energyCapacityAvailable: 300
+      energyAvailable: MINIMUM_WORKER_SPAWN_ENERGY + 110,
+      energyCapacityAvailable: 450
     });
     recordSurvivalMode('BOOTSTRAP');
 
@@ -169,7 +174,7 @@ describe('energyBuffer', () => {
     const room = makeRoom({
       level: 3,
       energyAvailable: MINIMUM_WORKER_SPAWN_ENERGY + 49,
-      energyCapacityAvailable: 300
+      energyCapacityAvailable: 450
     });
     recordSurvivalMode('BOOTSTRAP');
 
@@ -179,7 +184,7 @@ describe('energyBuffer', () => {
   it('keeps bootstrap extension construction above the worker spawn recovery floor', () => {
     const room = makeRoom({
       level: 2,
-      energyAvailable: 400,
+      energyAvailable: 250,
       energyCapacityAvailable: 400,
       myStructures: [makeExtension('extension1'), makeExtension('extension2')]
     });

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -10390,7 +10390,7 @@ describe('selectWorkerTask', () => {
       room: makeWorkerTaskRoom({
         constructionSites: [site],
         controller,
-        energyAvailable: 249,
+        energyAvailable: 194,
         energyCapacityAvailable: 300
       })
     } as unknown as Creep;


### PR DESCRIPTION
## Summary
Fixes the root cause of the 6-fix construction deadlock in E19S57: `energyBufferHealth.threshold` equals 100% of `energyCapacity` in survival mode, making the energy buffer gate impossible to clear at any energy level below full capacity.

## Root cause
In `getEffectiveRoomEnergyBufferThreshold` (energyBuffer.ts), the survival mode return path returned `capacityLimitedThreshold` directly without applying a capacity ratio cap. When the survival multiplier (1.5×) pushed the RCL2 threshold (300 → 450) to match the room's total energy capacity (spawn 300 + 3 × 50 extensions = 450), construction was permanently blocked because `currentEnergy ≥ threshold` could never be satisfied.

Non-survival mode correctly applied `NON_CRISIS_ENERGY_BUFFER_CAPACITY_RATIO` (0.65) via `getNonCrisisEnergyBufferCapacityCap`, but survival mode skipped this cap.

## Fix
Apply `NON_CRISIS_ENERGY_BUFFER_CAPACITY_RATIO` cap in the survival return path (2-line change):

```typescript
// Before (bug):
if (survivalBufferMode) {
    return capacityLimitedThreshold;  // could be 450 = 100% capacity!
}

// After (fix):
if (survivalBufferMode) {
    const survivalCapacityCap = Math.ceil(energyCapacityAvailable * NON_CRISIS_ENERGY_BUFFER_CAPACITY_RATIO);
    return Math.min(capacityLimitedThreshold, survivalCapacityCap);  // max 293 at capacity 450
}
```

## Verification
- `npm run typecheck` ✓
- `npm test -- --runInBand` — 95 suites, 1782 tests passing ✓
- `npm run build` — dist/main.js rebuilt ✓
- `git diff --check` — clean ✓

## Acceptance criteria (post-deploy)
1. `energyBufferHealth.threshold < energyCapacity` at all RCL levels in survival mode
2. `taskCounts.build > 0` for ≥100 consecutive ticks
3. `buildCarriedEnergy > 0` at least once within 50 ticks
4. `pendingBuildProgress` decreases by ≥500 within 200 ticks

## Related
- Closes #1031
- Follows diagnosis from 2026-05-14T05:20Z scheduler run (root cause isolated: threshold=capacity gate)
- Unblocks #1030 (extensions 3→5), #1033 (E2 simulator), #958 (expansion scouting), #1001 (rampart repair)
