### PR TITLE
fix(prod): resolve spawn-refill-priority deadlock — de-prioritize spawn refill below construction when spawn is idle (#1036)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -22901,6 +22901,17 @@ function selectHeuristicWorkerTask(creep) {
       targetId: bootstrapExtensionConstructionSite.id
     });
   }
+  if (!bootstrapNonCriticalWorkSuppressed && !remoteProductiveSpendingSuppressed) {
+    const productiveTaskBeforeIdleRefill = selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(
+      creep,
+      spawnOrExtensionEnergySink,
+      constructionSites,
+      constructionReservationContext
+    );
+    if (productiveTaskBeforeIdleRefill) {
+      return applyMinimumUsefulLoadPolicy(creep, productiveTaskBeforeIdleRefill);
+    }
+  }
   if (spawnOrExtensionEnergySink) {
     const spawnOrExtensionRefillTask = {
       type: "transfer",
@@ -24934,6 +24945,36 @@ function selectReadyFollowUpProductiveEnergySinkTask(creep, capacityConstruction
     priorityContext
   );
   return criticalRoadConstructionSite ? { type: "build", targetId: criticalRoadConstructionSite.id } : null;
+}
+function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(creep, spawnOrExtensionEnergySink, constructionSites, constructionReservationContext) {
+  if (!shouldDeferIdleSpawnExtensionRefillForProductiveWork(creep, spawnOrExtensionEnergySink)) {
+    return null;
+  }
+  const constructionPriorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  const constructionSite = selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    () => true,
+    { priorityContext: constructionPriorityContext }
+  );
+  if (constructionSite) {
+    return { type: "build", targetId: constructionSite.id };
+  }
+  const repairTarget = selectRepairTarget(creep);
+  return repairTarget ? { type: "repair", targetId: repairTarget.id } : null;
+}
+function shouldDeferIdleSpawnExtensionRefillForProductiveWork(creep, spawnOrExtensionEnergySink) {
+  return spawnOrExtensionEnergySink !== null && hasHealthyRoomEnergyBuffer(creep.room) && !hasActiveSpawningSpawn(creep.room);
+}
+function hasHealthyRoomEnergyBuffer(room) {
+  const energyAvailable = getRoomEnergyAvailable9(room);
+  return energyAvailable !== null && energyAvailable >= getEffectiveRoomEnergyBufferThreshold(room);
+}
+function hasActiveSpawningSpawn(room) {
+  return findSpawnExtensionEnergyStructures(room).some(
+    (structure) => isSpawnEnergySink(structure) && Boolean(structure.spawning)
+  );
 }
 function isSpawnConstructionSite(site) {
   return matchesStructureType18(site.structureType, "STRUCTURE_SPAWN", "spawn");
@@ -28300,6 +28341,9 @@ function selectWorkerTaskForRunner(creep) {
   return fallbackToEnergyOnNullSelectionLoop(creep, selectedTask);
 }
 function selectSpawnEnergyReservationRefillTask(creep, currentTask, selectedTask) {
+  if (shouldDeferSpawnReservationRefillForProductiveWork(creep, selectedTask)) {
+    return null;
+  }
   const target = selectSpawnEnergyReservationRefillTarget(creep);
   if (!target) {
     return null;
@@ -28309,6 +28353,22 @@ function selectSpawnEnergyReservationRefillTask(creep, currentTask, selectedTask
   }
   const targetId = getObjectId10(target.spawn);
   return targetId.length > 0 ? { type: "transfer", targetId } : null;
+}
+function shouldDeferSpawnReservationRefillForProductiveWork(creep, selectedTask) {
+  return ((selectedTask == null ? void 0 : selectedTask.type) === "build" || (selectedTask == null ? void 0 : selectedTask.type) === "repair") && hasHealthyRoomEnergyBuffer2(creep.room) && !hasActiveSpawningSpawn2(creep.room);
+}
+function hasHealthyRoomEnergyBuffer2(room) {
+  const energyAvailable = getRoomEnergyAvailable11(room);
+  return energyAvailable !== null && energyAvailable >= getEffectiveRoomEnergyBufferThreshold(room);
+}
+function hasActiveSpawningSpawn2(room) {
+  if (typeof FIND_MY_STRUCTURES !== "number" || typeof (room == null ? void 0 : room.find) !== "function") {
+    return false;
+  }
+  return room.find(FIND_MY_STRUCTURES).some((structure) => {
+    const structureType = structure.structureType;
+    return typeof structureType === "string" && matchesTransferSinkStructureType(structureType, "STRUCTURE_SPAWN", "spawn") && Boolean(structure.spawning);
+  });
 }
 function isSoftSpawnReservationPreemptibleTask(creep, task) {
   if (!task) {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -326,6 +326,10 @@ function selectSpawnEnergyReservationRefillTask(
   currentTask: CreepTaskMemory | null | undefined,
   selectedTask: CreepTaskMemory | null
 ): Extract<CreepTaskMemory, { type: 'transfer' }> | null {
+  if (shouldDeferSpawnReservationRefillForProductiveWork(creep, selectedTask)) {
+    return null;
+  }
+
   const target = selectSpawnEnergyReservationRefillTarget(creep);
   if (!target) {
     return null;
@@ -340,6 +344,37 @@ function selectSpawnEnergyReservationRefillTask(
 
   const targetId = getObjectId(target.spawn);
   return targetId.length > 0 ? { type: 'transfer', targetId: targetId as Id<AnyStoreStructure> } : null;
+}
+
+function shouldDeferSpawnReservationRefillForProductiveWork(
+  creep: Creep,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  return (
+    (selectedTask?.type === 'build' || selectedTask?.type === 'repair') &&
+    hasHealthyRoomEnergyBuffer(creep.room) &&
+    !hasActiveSpawningSpawn(creep.room)
+  );
+}
+
+function hasHealthyRoomEnergyBuffer(room: Room): boolean {
+  const energyAvailable = getRoomEnergyAvailable(room);
+  return energyAvailable !== null && energyAvailable >= getEffectiveRoomEnergyBufferThreshold(room);
+}
+
+function hasActiveSpawningSpawn(room: Room): boolean {
+  if (typeof FIND_MY_STRUCTURES !== 'number' || typeof room?.find !== 'function') {
+    return false;
+  }
+
+  return room.find(FIND_MY_STRUCTURES).some((structure) => {
+    const structureType = (structure as { structureType?: unknown }).structureType;
+    return (
+      typeof structureType === 'string' &&
+      matchesTransferSinkStructureType(structureType, 'STRUCTURE_SPAWN', 'spawn') &&
+      Boolean((structure as StructureSpawn).spawning)
+    );
+  });
 }
 
 function isSoftSpawnReservationPreemptibleTask(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -488,6 +488,18 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     });
   }
 
+  if (!bootstrapNonCriticalWorkSuppressed && !remoteProductiveSpendingSuppressed) {
+    const productiveTaskBeforeIdleRefill = selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(
+      creep,
+      spawnOrExtensionEnergySink,
+      constructionSites,
+      constructionReservationContext
+    );
+    if (productiveTaskBeforeIdleRefill) {
+      return applyMinimumUsefulLoadPolicy(creep, productiveTaskBeforeIdleRefill);
+    }
+  }
+
   if (spawnOrExtensionEnergySink) {
     const spawnOrExtensionRefillTask: Extract<CreepTaskMemory, { type: 'transfer' }> = {
       type: 'transfer',
@@ -3592,6 +3604,54 @@ function selectReadyFollowUpProductiveEnergySinkTask(
     priorityContext
   );
   return criticalRoadConstructionSite ? { type: 'build', targetId: criticalRoadConstructionSite.id } : null;
+}
+
+function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(
+  creep: Creep,
+  spawnOrExtensionEnergySink: StructureSpawn | StructureExtension | null,
+  constructionSites: ConstructionSite[],
+  constructionReservationContext: ConstructionReservationContext
+): ProductiveEnergySinkTask | null {
+  if (!shouldDeferIdleSpawnExtensionRefillForProductiveWork(creep, spawnOrExtensionEnergySink)) {
+    return null;
+  }
+
+  const constructionPriorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  const constructionSite = selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    () => true,
+    { priorityContext: constructionPriorityContext }
+  );
+  if (constructionSite) {
+    return { type: 'build', targetId: constructionSite.id };
+  }
+
+  const repairTarget = selectRepairTarget(creep);
+  return repairTarget ? { type: 'repair', targetId: repairTarget.id as Id<Structure> } : null;
+}
+
+function shouldDeferIdleSpawnExtensionRefillForProductiveWork(
+  creep: Creep,
+  spawnOrExtensionEnergySink: StructureSpawn | StructureExtension | null
+): boolean {
+  return (
+    spawnOrExtensionEnergySink !== null &&
+    hasHealthyRoomEnergyBuffer(creep.room) &&
+    !hasActiveSpawningSpawn(creep.room)
+  );
+}
+
+function hasHealthyRoomEnergyBuffer(room: Room): boolean {
+  const energyAvailable = getRoomEnergyAvailable(room);
+  return energyAvailable !== null && energyAvailable >= getEffectiveRoomEnergyBufferThreshold(room);
+}
+
+function hasActiveSpawningSpawn(room: Room): boolean {
+  return findSpawnExtensionEnergyStructures(room).some(
+    (structure) => isSpawnEnergySink(structure) && Boolean(structure.spawning)
+  );
 }
 
 function isSpawnConstructionSite(site: ConstructionSite): boolean {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1649,6 +1649,162 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
+  it('keeps construction ahead of idle spawn refill when the energy buffer is healthy', () => {
+    const site = { id: 'site1', structureType: 'road', progress: 0, progressTotal: 100 } as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(200),
+        getFreeCapacity: jest.fn().mockReturnValue(100)
+      }
+    } as unknown as StructureSpawn;
+    const extension = {
+      id: 'extension1',
+      structureType: 'extension',
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(42),
+        getFreeCapacity: jest.fn().mockReturnValue(8)
+      }
+    } as unknown as StructureExtension;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const build = jest.fn().mockReturnValue(0);
+    const transfer = jest.fn();
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 442,
+      energyCapacityAvailable: 450,
+      controller,
+      find: jest.fn(
+        (type: number, options?: { filter?: (structure: StructureSpawn | StructureExtension) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn, extension];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1', task: { type: 'build', targetId: 'site1' as Id<ConstructionSite> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      build,
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Builder: creep },
+      getObjectById: jest.fn((id: string) => (id === 'site1' ? site : spawn))
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'site1' });
+    expect(build).toHaveBeenCalledWith(site);
+    expect(transfer).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
+  it('keeps construction ahead of idle spawn reservation refill when the energy buffer is healthy', () => {
+    const site = { id: 'site1', structureType: 'road', progress: 0, progressTotal: 100 } as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(150),
+        getFreeCapacity: jest.fn().mockReturnValue(150)
+      }
+    } as unknown as StructureSpawn;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const build = jest.fn().mockReturnValue(0);
+    const transfer = jest.fn();
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 442,
+      energyCapacityAvailable: 450,
+      controller,
+      memory: { spawnEnergyReservation: { transferThreshold: 250 } },
+      find: jest.fn(
+        (type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1', task: { type: 'build', targetId: 'site1' as Id<ConstructionSite> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      build,
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      economy: {
+        spawnEnergyReservation: {
+          updatedAt: 123,
+          rooms: {
+            W1N1: {
+              bodyCost: 650,
+              creepName: 'worker-W1N1-124',
+              reservedAt: 123,
+              reservedEnergy: 650,
+              role: 'worker',
+              roomName: 'W1N1',
+              updatedAt: 123
+            }
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Builder: creep },
+      rooms: { W1N1: room },
+      time: 124,
+      getObjectById: jest.fn((id: string) => (id === 'site1' ? site : spawn))
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'site1' });
+    expect(creep.memory.workerDispatchDiagnostic?.spawnReservationTask).toBeUndefined();
+    expect(build).toHaveBeenCalledWith(site);
+    expect(transfer).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
   it('preempts construction for an assigned visible reserve target before spawn refill pressure', () => {
     const spawn = {
       id: 'spawn1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -10622,7 +10622,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
   });
 
-  it('keeps spawn refill before construction when follow-up energy target is ready', () => {
+  it('builds before idle spawn refill when follow-up energy target is ready', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const site = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
     const controller = {
@@ -10652,7 +10652,7 @@ describe('selectWorkerTask', () => {
       })
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
   });
 
   it('keeps extension refill before controller upgrade when follow-up energy target is ready', () => {
@@ -10686,7 +10686,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension1' });
   });
 
-  it('keeps spawn refill before nearby non-urgent repair when follow-up energy target is ready', () => {
+  it('repairs before idle spawn refill when follow-up energy target is ready', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const road = makeStructure('road-worn', 'road' as StructureConstant, 4_000, 5_000);
     const controller = {
@@ -10724,7 +10724,7 @@ describe('selectWorkerTask', () => {
       })
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'road-worn' });
   });
 
   it('builds follow-up-ready capacity construction before fallback territory upgrading', () => {


### PR DESCRIPTION
## Summary
Fix spawn-refill-priority deadlock where workers prioritize transferring energy to idle spawn/extensions over construction, even when the energy buffer is healthy.

## Root Cause
When `spawnExtensionNeedCount>0` (spawn + extensions need energy), worker task dispatch prioritized `transfer` to spawn/extensions above construction tasks. Even when the spawn was idle (not spawning) and the energy buffer was healthy, the refill priority consumed all available worker assignment slots, leaving `build=0` despite 10 construction sites.

## Fix
Add `shouldDeferIdleSpawnExtensionRefillForProductiveWork()` check in worker task dispatch. When the spawn is idle and the energy buffer is healthy (above threshold), construction (build/repair) out-prioritizes spawn refill. This is a narrow, targeted fix — the refill behavior is preserved when the spawn is actively spawning or when the energy buffer is below threshold.

## Verification
- `npm run typecheck` — passes
- `npm test -- --runInBand` — 1784/1784 tests pass
- `npm run build` — succeeds

## Related
- Fixes #1036
- Follows analysis from #1035 post-deploy evidence (buildBlockedReason=worker_assignment_gap, spawnExtensionNeedCount=4, spawnStatus=idle)
