### PR TITLE
fix(prod): assign builders for W3N9 construction gap

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -23371,6 +23371,14 @@ function selectBootstrapSurvivalSpendingTask(creep, controller, constructionSite
   if (shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep)) {
     return null;
   }
+  const bootstrapConstructionSite = selectBootstrapSurvivalConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext
+  );
+  if (bootstrapConstructionSite) {
+    return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: bootstrapConstructionSite.id });
+  }
   const criticalRoadConstructionSite = selectCriticalRoadConstructionSite(
     creep,
     constructionSites,
@@ -23380,6 +23388,33 @@ function selectBootstrapSurvivalSpendingTask(creep, controller, constructionSite
     return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: criticalRoadConstructionSite.id });
   }
   return null;
+}
+function selectBootstrapSurvivalConstructionSite(creep, constructionSites, constructionReservationContext) {
+  if (getUsedEnergy2(creep) <= 0 || hasOtherSameRoomLoadedBuildWorker(creep)) {
+    return null;
+  }
+  const priorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  return selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    (site) => isBootstrapSurvivalConstructionSite(site, priorityContext),
+    { priorityContext }
+  );
+}
+function isBootstrapSurvivalConstructionSite(site, priorityContext) {
+  return isSpawnConstructionSite(site) || isCapacityEnablingConstructionSite(site, priorityContext) || isCriticalRoadLogisticsConstructionSite(site, priorityContext);
+}
+function isCriticalRoadLogisticsConstructionSite(site, priorityContext) {
+  return isRoadConstructionSite2(site) && priorityContext.criticalRoadContext !== void 0 && isCriticalRoadLogisticsWork(site, priorityContext.criticalRoadContext);
+}
+function hasOtherSameRoomLoadedBuildWorker(creep) {
+  return getGameCreeps().some(
+    (worker) => {
+      var _a, _b;
+      return !isSameCreep(worker, creep) && isSameRoomWorker(worker, creep.room) && ((_b = (_a = worker.memory) == null ? void 0 : _a.task) == null ? void 0 : _b.type) === "build" && getUsedEnergy2(worker) > 0;
+    }
+  );
 }
 function shouldSuppressBootstrapControllerSpending(creep, recoveryOnlyWorkSuppressed) {
   return recoveryOnlyWorkSuppressed && !isWorkerInColonyRoom(creep);

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1157,6 +1157,15 @@ function selectBootstrapSurvivalSpendingTask(
     return null;
   }
 
+  const bootstrapConstructionSite = selectBootstrapSurvivalConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext
+  );
+  if (bootstrapConstructionSite) {
+    return applyMinimumUsefulLoadPolicy(creep, { type: 'build', targetId: bootstrapConstructionSite.id });
+  }
+
   const criticalRoadConstructionSite = selectCriticalRoadConstructionSite(
     creep,
     constructionSites,
@@ -1167,6 +1176,57 @@ function selectBootstrapSurvivalSpendingTask(
   }
 
   return null;
+}
+
+function selectBootstrapSurvivalConstructionSite(
+  creep: Creep,
+  constructionSites: ConstructionSite[],
+  constructionReservationContext: ConstructionReservationContext
+): ConstructionSite | null {
+  if (getUsedEnergy(creep) <= 0 || hasOtherSameRoomLoadedBuildWorker(creep)) {
+    return null;
+  }
+
+  const priorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  return selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    (site) => isBootstrapSurvivalConstructionSite(site, priorityContext),
+    { priorityContext }
+  );
+}
+
+function isBootstrapSurvivalConstructionSite(
+  site: ConstructionSite,
+  priorityContext: ConstructionSiteImpactPriorityContext
+): boolean {
+  return (
+    isSpawnConstructionSite(site) ||
+    isCapacityEnablingConstructionSite(site, priorityContext) ||
+    isCriticalRoadLogisticsConstructionSite(site, priorityContext)
+  );
+}
+
+function isCriticalRoadLogisticsConstructionSite(
+  site: ConstructionSite,
+  priorityContext: ConstructionSiteImpactPriorityContext
+): boolean {
+  return (
+    isRoadConstructionSite(site) &&
+    priorityContext.criticalRoadContext !== undefined &&
+    isCriticalRoadLogisticsWork(site, priorityContext.criticalRoadContext)
+  );
+}
+
+function hasOtherSameRoomLoadedBuildWorker(creep: Creep): boolean {
+  return getGameCreeps().some(
+    (worker) =>
+      !isSameCreep(worker, creep) &&
+      isSameRoomWorker(worker, creep.room) &&
+      worker.memory?.task?.type === 'build' &&
+      getUsedEnergy(worker) > 0
+  );
 }
 
 function shouldSuppressBootstrapControllerSpending(creep: Creep, recoveryOnlyWorkSuppressed: boolean): boolean {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -5,6 +5,11 @@ import {
   IDLE_RAMPART_REPAIR_HITS_CEILING,
   URGENT_SPAWN_REFILL_ENERGY_THRESHOLD
 } from '../src/tasks/workerTasks';
+import {
+  assessColonySurvival,
+  clearColonySurvivalAssessmentCache,
+  recordColonySurvivalAssessment
+} from '../src/colony/survivalMode';
 import { OCCUPIED_CONTROLLER_SIGN_TEXT } from '../src/territory/controllerSigning';
 import { TERRITORY_RESERVATION_RENEWAL_TICKS } from '../src/territory/territoryPlanner';
 
@@ -44,6 +49,7 @@ describe('runWorker', () => {
     delete (globalThis as unknown as { PathFinder?: Partial<PathFinder> }).PathFinder;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
     (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {} };
+    clearColonySurvivalAssessmentCache();
   });
 
   it('assigns a task when the creep has none', () => {
@@ -1324,6 +1330,138 @@ describe('runWorker', () => {
     for (const worker of workers) {
       expect(worker.upgradeController).not.toHaveBeenCalled();
     }
+  });
+
+  it('assigns a W3N9 bootstrap builder when controller upgrades leave construction uncovered', () => {
+    const source = {
+      id: 'source1',
+      pos: { x: 20, y: 10, roomName: 'W3N9' } as RoomPosition
+    } as Source;
+    const sourceContainerSite = {
+      id: 'source-container-site1',
+      structureType: 'container',
+      progress: 0,
+      progressTotal: 5_000,
+      pos: { x: 21, y: 10, roomName: 'W3N9' } as RoomPosition
+    } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 300
+    } as StructureController;
+    const spawn = {
+      id: 'spawn1',
+      my: true,
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(278),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      }
+    } as unknown as StructureSpawn;
+    const workers: Creep[] = [];
+    const sourceHarvester = {
+      name: 'SourceHarvester',
+      memory: {
+        role: 'sourceHarvester',
+        sourceHarvester: { sourceId: 'source1' as Id<Source>, colony: 'W3N9' }
+      },
+      room: undefined as unknown as Room
+    } as unknown as Creep;
+    const room = {
+      name: 'W3N9',
+      energyAvailable: 278,
+      energyCapacityAvailable: 300,
+      controller,
+      find: jest.fn((type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [sourceContainerSite];
+        }
+
+        if (type === FIND_SOURCES) {
+          return [source];
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return [...workers, sourceHarvester];
+        }
+
+        if (type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES) {
+          const structures = [spawn];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    (sourceHarvester as Creep & { room: Room }).room = room;
+    const makeWorker = (name: string, carriedEnergy: number, freeCapacity: number): Creep =>
+      ({
+        name,
+        memory: {
+          role: 'worker',
+          colony: 'W3N9',
+          task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }
+        },
+        store: {
+          getUsedCapacity: jest.fn().mockReturnValue(carriedEnergy),
+          getFreeCapacity: jest.fn().mockReturnValue(freeCapacity),
+          getCapacity: jest.fn().mockReturnValue(carriedEnergy + freeCapacity)
+        },
+        pos: { getRangeTo: jest.fn().mockReturnValue(18) },
+        room,
+        build: jest.fn().mockReturnValue(0),
+        upgradeController: jest.fn().mockReturnValue(0),
+        moveTo: jest.fn()
+      }) as unknown as Creep;
+    workers.push(
+      makeWorker('worker-W3N9-1', 50, 0),
+      makeWorker('worker-W3N9-2', 17, 33),
+      makeWorker('worker-W3N9-3', 16, 34)
+    );
+    const assessment = assessColonySurvival({
+      roomName: 'W3N9',
+      totalCreeps: workers.length,
+      workerCapacity: workers.length,
+      workerTarget: 6,
+      energyAvailable: 278,
+      energyCapacityAvailable: 300,
+      spawnEnergyAvailable: 278,
+      controller: { my: true, level: 2, ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 300 },
+      hostileCreepCount: 0,
+      hostileStructureCount: 0
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 954_381,
+      creeps: Object.fromEntries([
+        ...workers.map((worker) => [worker.name, worker]),
+        [sourceHarvester.name, sourceHarvester]
+      ]),
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'source-container-site1') {
+          return sourceContainerSite;
+        }
+
+        if (id === 'controller1') {
+          return controller;
+        }
+
+        if (id === 'spawn1') {
+          return spawn;
+        }
+
+        return id === 'source1' ? source : null;
+      })
+    };
+    expect(assessment.mode).toBe('BOOTSTRAP');
+    recordColonySurvivalAssessment('W3N9', assessment, 954_381);
+
+    workers.forEach(runWorker);
+
+    expect(workers.map((worker) => worker.memory.task?.type).filter((task) => task === 'build')).toHaveLength(1);
+    expect(workers[0].memory.task).toEqual({ type: 'build', targetId: 'source-container-site1' });
+    expect(workers[0].build).toHaveBeenCalledWith(sourceContainerSite);
   });
 
   it('keeps the RCL2 downgrade guard above upgrade preemption', () => {


### PR DESCRIPTION
## Summary
- Fixes the W3N9 `worker_assignment_gap` by allowing one loaded same-room worker in bootstrap survival mode to take an unreserved capacity/logistics construction site before all workers remain on controller upgrade work.
- Keeps emergency priority ordering intact: spawn/critical energy recovery and controller downgrade protections still run before discretionary construction.
- Adds a W3N9-shaped regression at tick 954381 covering RCL2 bootstrap, carried worker energy, source-container construction backlog, and no hostile/downgrade emergency.

Fixes #1045
Refs #1041, #879

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (95 suites, 1785 tests passed)
- `cd prod && npm run build`

## Runtime / RL note
Fresh runtime-summary-console captures showed W3N9 alive at RCL2 with storedEnergy 353–400, workerCarriedEnergy 146–162, constructionSiteCount=11, `buildCarriedEnergy=0`, and `buildBlockedReason=worker_assignment_gap`. This PR targets the blocker so later RL gates can validate sustained build/progress evidence before closing #1041/#1045.
