### PR TITLE
fix(economy): recover W3N9 build assignment gap

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -23457,13 +23457,36 @@ function shouldGuardControllerDowngradeForWorkerLoad(creep, controller) {
   if (!shouldGuardControllerDowngrade2(controller)) {
     return false;
   }
-  if (!getLowLoadWorkerEnergyContext(creep)) {
-    return true;
+  if (shouldYieldControllerDowngradeGuardToConstructionBacklog(creep, controller)) {
+    return false;
   }
-  return isControllerDowngradeImminentForLowLoadReturn(controller);
+  return !getLowLoadWorkerEnergyContext(creep) || isControllerDowngradeImminentForLowLoadReturn(controller);
 }
 function isControllerDowngradeImminentForLowLoadReturn(controller) {
   return (controller == null ? void 0 : controller.my) === true && typeof controller.ticksToDowngrade === "number" && controller.ticksToDowngrade < LOW_LOAD_CONTROLLER_DOWNGRADE_IMMINENT_TICKS;
+}
+function shouldYieldControllerDowngradeGuardToConstructionBacklog(creep, controller) {
+  return (controller == null ? void 0 : controller.my) === true && controller.level === 2 && !isControllerDowngradeImminentForLowLoadReturn(controller) && getUsedEnergy2(creep) > 0 && getActiveWorkParts2(creep) > 0 && hasOtherLoadedWorkerUpgradingController(creep, controller) && !hasSameRoomWorkerAssignedToTask(creep.room, creep, "build") && hasSpendableConstructionBacklog(creep);
+}
+function hasOtherLoadedWorkerUpgradingController(creep, controller) {
+  return getSameRoomLoadedWorkers(creep).some(
+    (worker) => !isSameCreep(worker, creep) && getActiveWorkParts2(worker) > 0 && isUpgradingController(worker, controller)
+  );
+}
+function hasSpendableConstructionBacklog(creep) {
+  var _a;
+  if (typeof FIND_CONSTRUCTION_SITES !== "number" || typeof ((_a = creep.room) == null ? void 0 : _a.find) !== "function") {
+    return false;
+  }
+  const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
+  if (constructionSites.length === 0) {
+    return false;
+  }
+  const constructionReservationContext = createConstructionReservationContext(creep.room);
+  const priorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  return constructionSites.some(
+    (site) => site.my !== false && hasUnreservedConstructionProgress(creep, site, constructionReservationContext) && canSpendCreepEnergyOnConstructionSite(creep, site, priorityContext)
+  );
 }
 function getLowLoadWorkerEnergyContext(creep) {
   const carriedEnergy = getUsedEnergy2(creep);

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1296,11 +1296,11 @@ function shouldGuardControllerDowngradeForWorkerLoad(
     return false;
   }
 
-  if (!getLowLoadWorkerEnergyContext(creep)) {
-    return true;
+  if (shouldYieldControllerDowngradeGuardToConstructionBacklog(creep, controller)) {
+    return false;
   }
 
-  return isControllerDowngradeImminentForLowLoadReturn(controller);
+  return !getLowLoadWorkerEnergyContext(creep) || isControllerDowngradeImminentForLowLoadReturn(controller);
 }
 
 function isControllerDowngradeImminentForLowLoadReturn(
@@ -1310,6 +1310,51 @@ function isControllerDowngradeImminentForLowLoadReturn(
     controller?.my === true &&
     typeof controller.ticksToDowngrade === 'number' &&
     controller.ticksToDowngrade < LOW_LOAD_CONTROLLER_DOWNGRADE_IMMINENT_TICKS
+  );
+}
+
+function shouldYieldControllerDowngradeGuardToConstructionBacklog(
+  creep: Creep,
+  controller: StructureController | undefined
+): boolean {
+  return (
+    controller?.my === true &&
+    controller.level === 2 &&
+    !isControllerDowngradeImminentForLowLoadReturn(controller) &&
+    getUsedEnergy(creep) > 0 &&
+    getActiveWorkParts(creep) > 0 &&
+    hasOtherLoadedWorkerUpgradingController(creep, controller) &&
+    !hasSameRoomWorkerAssignedToTask(creep.room, creep, 'build') &&
+    hasSpendableConstructionBacklog(creep)
+  );
+}
+
+function hasOtherLoadedWorkerUpgradingController(creep: Creep, controller: StructureController): boolean {
+  return getSameRoomLoadedWorkers(creep).some(
+    (worker) =>
+      !isSameCreep(worker, creep) &&
+      getActiveWorkParts(worker) > 0 &&
+      isUpgradingController(worker, controller)
+  );
+}
+
+function hasSpendableConstructionBacklog(creep: Creep): boolean {
+  if (typeof FIND_CONSTRUCTION_SITES !== 'number' || typeof creep.room?.find !== 'function') {
+    return false;
+  }
+
+  const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES) as ConstructionSite[];
+  if (constructionSites.length === 0) {
+    return false;
+  }
+
+  const constructionReservationContext = createConstructionReservationContext(creep.room);
+  const priorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  return constructionSites.some(
+    (site) =>
+      site.my !== false &&
+      hasUnreservedConstructionProgress(creep, site, constructionReservationContext) &&
+      canSpendCreepEnergyOnConstructionSite(creep, site, priorityContext)
   );
 }
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1464,6 +1464,113 @@ describe('runWorker', () => {
     expect(workers[0].build).toHaveBeenCalledWith(sourceContainerSite);
   });
 
+  it('keeps one W3N9 worker building while other loaded workers sustain a non-imminent downgrade guard', () => {
+    const source = {
+      id: 'source1',
+      pos: { x: 20, y: 10, roomName: 'W3N9' } as RoomPosition
+    } as Source;
+    const sourceContainerSite = {
+      id: 'source-container-site1',
+      my: true,
+      structureType: 'container',
+      progress: 2_500,
+      progressTotal: 5_000,
+      pos: { x: 21, y: 10, roomName: 'W3N9' } as RoomPosition
+    } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS - 27
+    } as StructureController;
+    const extension = {
+      id: 'extension1',
+      my: true,
+      structureType: 'extension',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      }
+    } as unknown as StructureExtension;
+    const workers: Creep[] = [];
+    const room = {
+      name: 'W3N9',
+      energyAvailable: 350,
+      energyCapacityAvailable: 450,
+      controller,
+      find: jest.fn((type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [sourceContainerSite];
+        }
+
+        if (type === FIND_SOURCES) {
+          return [source];
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return workers;
+        }
+
+        if (type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES) {
+          const structures = [extension as unknown as AnyOwnedStructure];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const makeWorker = (name: string): Creep =>
+      ({
+        name,
+        memory: {
+          role: 'worker',
+          colony: 'W3N9',
+          task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }
+        },
+        store: {
+          getUsedCapacity: jest.fn().mockReturnValue(16),
+          getFreeCapacity: jest.fn().mockReturnValue(34),
+          getCapacity: jest.fn().mockReturnValue(50)
+        },
+        pos: { getRangeTo: jest.fn().mockReturnValue(12) },
+        room,
+        build: jest.fn().mockReturnValue(0),
+        upgradeController: jest.fn().mockReturnValue(0),
+        moveTo: jest.fn()
+      }) as unknown as Creep;
+    workers.push(makeWorker('worker-W3N9-1'), makeWorker('worker-W3N9-2'), makeWorker('worker-W3N9-3'));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 960_880,
+      creeps: Object.fromEntries(workers.map((worker) => [worker.name, worker])),
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'source-container-site1') {
+          return sourceContainerSite;
+        }
+
+        if (id === 'controller1') {
+          return controller;
+        }
+
+        if (id === 'extension1') {
+          return extension;
+        }
+
+        return id === 'source1' ? source : null;
+      })
+    };
+
+    workers.forEach(runWorker);
+
+    const assignedTasks = workers.map((worker) => worker.memory.task?.type);
+    expect(assignedTasks.filter((task) => task === 'build')).toHaveLength(1);
+    expect(assignedTasks.filter((task) => task === 'upgrade')).toHaveLength(2);
+    expect(workers[0].memory.task).toEqual({ type: 'build', targetId: 'source-container-site1' });
+    expect(workers[0].build).toHaveBeenCalledWith(sourceContainerSite);
+    expect(workers[1].upgradeController).toHaveBeenCalledWith(controller);
+    expect(workers[2].upgradeController).toHaveBeenCalledWith(controller);
+  });
+
   it('keeps the RCL2 downgrade guard above upgrade preemption', () => {
     const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
     const controller = {


### PR DESCRIPTION
## Summary
- Recover W3N9 RCL2 construction assignment when the downgrade guard is already being covered by other loaded workers.
- Add a W3N9-style regression test for low-worker recovery with construction backlog and upgrade competition.
- Rebuild `prod/dist/main.js`.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (95 suites, 1786 tests passed)
- `cd prod && npm run build`

Closes #1050

Post-deploy acceptance must still be tracked by #1026/#1041: fresh runtime windows should show construction workers/energy and no repeated `worker_assignment_gap_sustained` alert.
