### PR TITLE
fix: expose shadow ranking context coverage (#1034)

### DIFF
--- a/docs/research/2026-05-15-issue-1034-e1-shadow-delta-diagnosis.md
+++ b/docs/research/2026-05-15-issue-1034-e1-shadow-delta-diagnosis.md
@@ -1,0 +1,44 @@
+# Issue 1034 E1 Shadow Delta Diagnosis
+
+Date: 2026-05-15
+
+## Question
+
+Issue #1034 asked whether the E1 shadow eval `changedTopCount` decline from 134 -> 42 -> 14 was benign policy convergence or dangerous data/evaluator coverage collapse.
+
+## Evidence
+
+The local worktree does not contain `runtime-artifacts/`, so the inspected artifacts were read from `/root/screeps/runtime-artifacts/`.
+
+| Artifact | Generated | Dataset | Samples and coverage | Room sample distribution | Ranking diffs | Changed top | Family split |
+| --- | --- | --- | --- | --- | ---: | ---: | --- |
+| `rl-gate-ff93c4694f08-shadow` | 2026-05-13T10:53:55Z | `rl-60b314addef5` | 200 samples, 191 accepted, 2,331 source artifacts, 2,434 runtime summaries | E26S49=122, E27S49=28, E26S48=25, E27S48=24, E24S49=1 | 451 | 134 | construction 280/121, expansion 171/13 |
+| `rl-gate-5a1fa785798d-shadow` | 2026-05-13T22:08:26Z | `rl-d1b56cbc4603` | 200 samples, 198 accepted, 2,463 source artifacts, 5,146 runtime summaries | E26S49=193, E27S49=5, E24S49=2 | 410 | 42 | construction 212/42, expansion 198/0 |
+| `rl-gate-93bf1aa18b62-shadow` | 2026-05-14T04:22:20Z | `rl-ebf33fae619f` | 200 samples, 198 accepted, 2,538 source artifacts, 5,328 runtime summaries | E26S49=193, E27S49=5, E24S49=2 | 406 | 14 | construction 208/14, expansion 198/0 |
+| `strategy-shadow-20260514T161345Z` | 2026-05-14T16:13:45Z | `rl-b6a57148129f` | 300 evaluated artifacts, paired gate had 200 samples and 191 accepted | E26S49=122, E27S49=28, E26S48=25, E27S48=24, E24S49=1 | 555 | 192 | construction 384/179, expansion 171/13 |
+| `gate-20260514T222356Z-shadow` | 2026-05-14T22:25:57Z | `rl-5db4d84c8ede` | 151 evaluated artifacts, paired gate had 200 samples and 198 accepted, home room W3N9 | E26S49=193, E27S49=5, E24S49=2 in dataset; shadow source came from official deploy summaries | 0 | 0 | construction 0/0, expansion 0/0 |
+
+Family split values are `rankingDiffCount/changedTopCount`.
+
+## Diagnosis
+
+The 134 -> 42 -> 14 drop is not benign policy convergence. `rankingDiffCount` stayed high at 451 -> 410 -> 406, both model families were still emitted, and the decline was concentrated in construction-priority `changedTopCount`. A converged policy would normally reduce both top-choice changes and broader ranking movement. Here, broader ranking movement persisted.
+
+The stronger explanation is data coverage/sample composition drift. The 134-count baseline used a 5-room sample mix. The 42-count and 14-count gates collapsed to an E26S49-heavy 3-room mix and dropped E26S48/E27S48 coverage. That removed much of the context where the construction shadow model flips the top recommendation.
+
+The 2026-05-14T16:13:45Z rebound to `changedTopCount=192` and `rankingDiffCount=555` confirms the evaluator had not prematurely converged to no signal. When fed broader coverage again, the shadow evaluator produced record movement.
+
+The later W3N9 report `gate-20260514T222356Z-shadow` is a separate low-signal anomaly. It parsed 151 artifacts from official deploy summary paths and produced 2 model reports but 0 ranking diffs and 0 changed-top events. Those artifacts did not expose construction-priority or territory-recommendation ranking contexts, so the old report shape could be misread as policy convergence. This branch adds `rankingContextCount` plus a warning for parsed artifacts that contain no evaluable contexts for a model family.
+
+## Conclusion Classification
+
+Classification: coverage/sampling collapse plus missing ranking-context instrumentation, not policy convergence.
+
+`rlc-20260513-changedTopCount-drop-signal` should not be closed yet. The controller should mirror the intended registry transition as:
+
+- Status: `ACTIONED` after this instrumentation patch lands.
+- Category: `data-traversal` / `shadow-eval-instrumentation`.
+- Required evidence to close: two consecutive E1 gates with nonzero `rankingContextCount` for both strategy families, no no-context warnings, explicit room/source coverage in the gate evidence, and no repeated 0/low `changedTopCount` unless `rankingDiffCount` also falls and the room mix remains stable.
+- Next verification: the next E1 shadow-eval gate after this commit should include `rankingContextCount` in the strategy-shadow report and generation summary.
+
+No repository-tracked `conclusion-registry.json` exists in this worktree. The live registry is under `/root/screeps/runtime-artifacts/rl-control-loop/conclusion-registry.json`, so it was not edited here.

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -43907,7 +43907,11 @@ function evaluateStrategyShadowReplay(input = {}, varianceConfig = {}) {
       continue;
     }
     const evaluatedCandidate = candidate.rolloutStatus === "incumbent" ? candidate : injectStrategyVariance(candidate, { ...resolvedVarianceConfig, strategyOverrides: void 0 }, evaluationTimestamp);
-    modelReports.push(evaluateModelPair(artifacts, incumbent, evaluatedCandidate));
+    const modelReport = evaluateModelPair(artifacts, incumbent, evaluatedCandidate);
+    if (artifacts.length > 0 && modelReport.rankingContextCount === 0) {
+      warnings.push(`no ranking contexts evaluated for ${modelReport.family}; input artifacts may lack strategy candidates`);
+    }
+    modelReports.push(modelReport);
   }
   return {
     enabled: true,
@@ -43998,8 +44002,10 @@ function hashString(value) {
 }
 function evaluateModelPair(artifacts, incumbent, candidate) {
   const rankingDiffs = [];
+  let rankingContextCount = 0;
   artifacts.forEach((artifact, artifactIndex) => {
     const rankingGroups = buildRankingGroups(artifact, artifactIndex, candidate.family);
+    rankingContextCount += rankingGroups.length;
     for (const group of rankingGroups) {
       const incumbentRanking = scoreRankingItems(group.items, incumbent);
       const candidateRanking = scoreRankingItems(group.items, candidate);
@@ -44013,6 +44019,7 @@ function evaluateModelPair(artifacts, incumbent, candidate) {
     incumbentStrategyId: incumbent.id,
     candidateStrategyId: candidate.id,
     family: candidate.family,
+    rankingContextCount,
     rankingDiffs
   };
 }

--- a/prod/src/strategy/shadowEvaluator.ts
+++ b/prod/src/strategy/shadowEvaluator.ts
@@ -54,6 +54,7 @@ export interface StrategyShadowModelReport {
   incumbentStrategyId: string;
   candidateStrategyId: string;
   family: StrategyModelFamily;
+  rankingContextCount: number;
   rankingDiffs: StrategyRankingDiff[];
 }
 
@@ -173,7 +174,11 @@ export function evaluateStrategyShadowReplay(
       candidate.rolloutStatus === 'incumbent'
         ? candidate
         : injectStrategyVariance(candidate, { ...resolvedVarianceConfig, strategyOverrides: undefined }, evaluationTimestamp);
-    modelReports.push(evaluateModelPair(artifacts, incumbent, evaluatedCandidate));
+    const modelReport = evaluateModelPair(artifacts, incumbent, evaluatedCandidate);
+    if (artifacts.length > 0 && modelReport.rankingContextCount === 0) {
+      warnings.push(`no ranking contexts evaluated for ${modelReport.family}; input artifacts may lack strategy candidates`);
+    }
+    modelReports.push(modelReport);
   }
 
   return {
@@ -288,9 +293,11 @@ function evaluateModelPair(
   candidate: StrategyRegistryEntry
 ): StrategyShadowModelReport {
   const rankingDiffs: StrategyRankingDiff[] = [];
+  let rankingContextCount = 0;
 
   artifacts.forEach((artifact, artifactIndex) => {
     const rankingGroups = buildRankingGroups(artifact, artifactIndex, candidate.family);
+    rankingContextCount += rankingGroups.length;
     for (const group of rankingGroups) {
       const incumbentRanking = scoreRankingItems(group.items, incumbent);
       const candidateRanking = scoreRankingItems(group.items, candidate);
@@ -305,6 +312,7 @@ function evaluateModelPair(
     incumbentStrategyId: incumbent.id,
     candidateStrategyId: candidate.id,
     family: candidate.family,
+    rankingContextCount,
     rankingDiffs
   };
 }

--- a/prod/test/strategyShadowEvaluator.test.ts
+++ b/prod/test/strategyShadowEvaluator.test.ts
@@ -35,6 +35,7 @@ describe('strategy shadow evaluator', () => {
     expect(report.kpi.reliability.passed).toBe(true);
 
     const constructionReport = report.modelReports.find((modelReport) => modelReport.family === 'construction-priority');
+    expect(constructionReport?.rankingContextCount).toBe(1);
     expect(constructionReport?.rankingDiffs).toHaveLength(1);
     expect(constructionReport?.rankingDiffs[0]).toMatchObject({
       artifactIndex: 0,
@@ -69,6 +70,7 @@ describe('strategy shadow evaluator', () => {
     const expansionReport = report.modelReports.find(
       (modelReport) => modelReport.family === 'expansion-remote-candidate'
     );
+    expect(expansionReport?.rankingContextCount).toBe(1);
     expect(expansionReport?.rankingDiffs).toHaveLength(1);
     expect(expansionReport?.rankingDiffs[0]).toMatchObject({
       context: 'expansion-remote-candidate',
@@ -100,6 +102,41 @@ describe('strategy shadow evaluator', () => {
     });
 
     expect(first.defaultValues).not.toEqual(second.defaultValues);
+  });
+
+  it('warns when artifacts have no evaluable ranking contexts for a model family', () => {
+    const report = evaluateStrategyShadowReplay({
+      artifacts: [
+        {
+          type: 'runtime-summary',
+          tick: 100,
+          rooms: [
+            {
+              roomName: 'W3N9',
+              energyAvailable: 300,
+              energyCapacity: 450,
+              workerCount: 4
+            }
+          ]
+        }
+      ],
+      config: {
+        enabled: true,
+        candidateStrategyIds: [
+          'construction-priority.territory-shadow.v1',
+          'expansion-remote.territory-shadow.v1'
+        ]
+      }
+    }, { enabled: false });
+
+    expect(report.artifactCount).toBe(1);
+    expect(report.modelReports).toHaveLength(2);
+    expect(report.modelReports.map((modelReport) => modelReport.rankingContextCount)).toEqual([0, 0]);
+    expect(report.modelReports.flatMap((modelReport) => modelReport.rankingDiffs)).toHaveLength(0);
+    expect(report.warnings).toEqual([
+      'no ranking contexts evaluated for construction-priority; input artifacts may lack strategy candidates',
+      'no ranking contexts evaluated for expansion-remote-candidate; input artifacts may lack strategy candidates'
+    ]);
   });
 
   it('keeps incumbent default values even when variance is enabled', () => {

--- a/scripts/screeps_rl_dataset_export.py
+++ b/scripts/screeps_rl_dataset_export.py
@@ -469,6 +469,7 @@ def strategy_shadow_report_metadata(raw: JsonObject, source: SourceFile, line_nu
     incumbent_ids: set[str] = set()
     ranking_diff_count = 0
     changed_top_count = 0
+    ranking_context_count = 0
     for report in model_reports:
         if not isinstance(report, dict):
             continue
@@ -478,6 +479,7 @@ def strategy_shadow_report_metadata(raw: JsonObject, source: SourceFile, line_nu
             candidate_ids.add(report["candidateStrategyId"])
         if isinstance(report.get("incumbentStrategyId"), str):
             incumbent_ids.add(report["incumbentStrategyId"])
+        ranking_context_count += int(report["rankingContextCount"]) if is_number(report.get("rankingContextCount")) else 0
         ranking_diffs = report.get("rankingDiffs") if isinstance(report.get("rankingDiffs"), list) else []
         ranking_diff_count += int(report["rankingDiffCount"]) if is_number(report.get("rankingDiffCount")) else len(ranking_diffs)
         changed_top_count += (
@@ -493,6 +495,7 @@ def strategy_shadow_report_metadata(raw: JsonObject, source: SourceFile, line_nu
         "enabled": raw.get("enabled") if isinstance(raw.get("enabled"), bool) else None,
         "artifactCount": number_or_none(raw.get("artifactCount")),
         "modelReportCount": len(model_reports),
+        "rankingContextCount": ranking_context_count,
         "rankingDiffCount": ranking_diff_count,
         "changedTopCount": changed_top_count,
         "families": sorted(families),

--- a/scripts/screeps_strategy_shadow_report.py
+++ b/scripts/screeps_strategy_shadow_report.py
@@ -292,6 +292,7 @@ def sanitize_report(
     dist_path: Path,
 ) -> JsonObject:
     model_reports = sanitize_model_reports(evaluator_report.get("modelReports"), max_ranking_diff_samples)
+    ranking_context_count = sum(number_or_zero(report.get("rankingContextCount")) for report in model_reports)
     ranking_diff_count = sum(number_or_zero(report.get("rankingDiffCount")) for report in model_reports)
     changed_top_count = sum(number_or_zero(report.get("changedTopCount")) for report in model_reports)
     warnings = bounded_warnings(evaluator_report.get("warnings"), max_warning_count)
@@ -344,6 +345,7 @@ def sanitize_report(
         ),
         "rankingDiffCount": ranking_diff_count,
         "changedTopCount": changed_top_count,
+        "rankingContextCount": ranking_context_count,
         "kpiSummary": sanitize_kpi_summary(evaluator_report.get("kpi")),
         "modelReports": model_reports,
         "warnings": warnings[:max_warning_count],
@@ -454,6 +456,7 @@ def sanitize_model_reports(raw_model_reports: Any, max_ranking_diff_samples: int
                 "family": sanitize_text(raw_report.get("family"), max_bytes=80),
                 "incumbentStrategyId": sanitize_text(raw_report.get("incumbentStrategyId"), max_bytes=120),
                 "candidateStrategyId": sanitize_text(raw_report.get("candidateStrategyId"), max_bytes=120),
+                "rankingContextCount": number_or_zero(raw_report.get("rankingContextCount")),
                 "rankingDiffCount": len(raw_diffs),
                 "changedTopCount": changed_top_count,
                 "rankingDiffsTruncated": len(raw_diffs) > len(diff_samples),
@@ -542,6 +545,7 @@ def build_generation_summary(report: JsonObject, report_path: Path, scan: datase
         "artifactCount": report["artifactCount"],
         "parsedRuntimeArtifactCount": len(scan.records),
         "modelReportCount": report["modelReportCount"],
+        "rankingContextCount": report["rankingContextCount"],
         "rankingDiffCount": report["rankingDiffCount"],
         "changedTopCount": report["changedTopCount"],
         "candidateStrategyIds": report["candidateStrategyIds"],
@@ -765,6 +769,7 @@ def build_json_summary(report_summary: JsonObject, wall_seconds: float) -> JsonO
         "artifactCount": report_summary.get("artifactCount"),
         "parsedRuntimeArtifactCount": report_summary.get("parsedRuntimeArtifactCount"),
         "modelReportCount": report_summary.get("modelReportCount"),
+        "rankingContextCount": report_summary.get("rankingContextCount"),
         "rankingDiffCount": report_summary.get("rankingDiffCount"),
         "changedTopCount": report_summary.get("changedTopCount"),
         "warnings": report_summary.get("warnings", []),

--- a/scripts/test_screeps_rl_dataset_export.py
+++ b/scripts/test_screeps_rl_dataset_export.py
@@ -307,6 +307,7 @@ class RlDatasetExportTest(unittest.TestCase):
                     "incumbentStrategyId": "construction-priority.incumbent.v1",
                     "candidateStrategyId": "construction-priority.territory-shadow.v1",
                     "family": "construction-priority",
+                    "rankingContextCount": 3,
                     "rankingDiffs": [{"changedTop": True}, {"changedTop": False}],
                 }
             ],
@@ -334,6 +335,7 @@ class RlDatasetExportTest(unittest.TestCase):
         self.assertEqual(source_index["strategyShadowReportCount"], 1)
         shadow_metadata = run_manifest["strategy"]["shadowReports"][0]
         self.assertEqual(shadow_metadata["families"], ["construction-priority"])
+        self.assertEqual(shadow_metadata["rankingContextCount"], 3)
         self.assertEqual(shadow_metadata["rankingDiffCount"], 2)
         self.assertEqual(shadow_metadata["changedTopCount"], 1)
         self.assertNotIn("warnings", shadow_metadata)

--- a/scripts/test_screeps_strategy_shadow_report.py
+++ b/scripts/test_screeps_strategy_shadow_report.py
@@ -188,6 +188,7 @@ class StrategyShadowReportTest(unittest.TestCase):
         self.assertFalse(report["safety"]["memoryWritesAllowed"])
         self.assertFalse(report["safety"]["creepSpawnMarketIntentsAllowed"])
         self.assertEqual(report["artifactCount"], 1)
+        self.assertEqual(report["rankingContextCount"], 2)
         self.assertGreaterEqual(report["rankingDiffCount"], 2)
         self.assertGreaterEqual(report["changedTopCount"], 2)
         self.assertEqual(
@@ -232,6 +233,7 @@ class StrategyShadowReportTest(unittest.TestCase):
         self.assertTrue(report["source"]["artifactLimitApplied"])
         self.assertTrue(any("artifact limit applied" in warning for warning in report["warnings"]))
         for model_report in report["modelReports"]:
+            self.assertEqual(model_report["rankingContextCount"], 2)
             self.assertLessEqual(len(model_report["rankingDiffs"]), 1)
             if model_report["rankingDiffCount"] > 1:
                 self.assertTrue(model_report["rankingDiffsTruncated"])
@@ -273,6 +275,7 @@ class StrategyShadowReportTest(unittest.TestCase):
         self.assertIn("reportPath", cli_output)
         self.assertEqual(summary["strategyShadowReportCount"], 1)
         shadow_metadata = run_manifest["strategy"]["shadowReports"][0]
+        self.assertEqual(shadow_metadata["rankingContextCount"], 2)
         self.assertEqual(shadow_metadata["rankingDiffCount"], 2)
         self.assertEqual(shadow_metadata["changedTopCount"], 2)
         self.assertEqual(


### PR DESCRIPTION
## Summary
- diagnoses #1034 as coverage/sample-composition collapse plus missing ranking-context instrumentation, not benign policy convergence
- adds `rankingContextCount` to the TypeScript shadow evaluator, Python sanitized report output, dataset export metadata, CLI JSON summary, and generated bundle
- documents the inspected E1/shadow artifacts and closure criteria for `rlc-20260513-changedTopCount-drop-signal`

## Verification
- `git diff --check`
- `PYTHONPATH=scripts python3 -m unittest scripts.test_screeps_strategy_shadow_report scripts.test_screeps_rl_dataset_export`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`

Fixes #1034.
