### PR TITLE
fix: restore W3N9 throughput under energy deficit (#1040)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -22726,6 +22726,7 @@ var LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE = 12;
 var BUILDER_STORAGE_WITHDRAW_MIN = 100;
 var BUILDER_DROPPED_PICKUP_RANGE = 5;
 var DEFAULT_SPAWN_ENERGY_CAPACITY = 300;
+var LOW_WORKER_THROUGHPUT_WORKER_COUNT = 3;
 var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 var MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
@@ -23206,7 +23207,14 @@ function selectMinimumHarvesterAllocationTask(creep) {
   if (!shouldGuaranteeMinimumHarvesterAllocation(creep)) {
     return null;
   }
-  return selectWorkerHarvestTask(creep, { allowPreHarvest: false, assignSourceContainer: true });
+  const assignedHarvestTask = selectWorkerHarvestTask(creep, { allowPreHarvest: false, assignSourceContainer: true });
+  if (assignedHarvestTask) {
+    return assignedHarvestTask;
+  }
+  if (!shouldForceGenericHarvestForThroughputRecovery(creep)) {
+    return null;
+  }
+  return selectWorkerHarvestTask(creep, { allowPreHarvest: false, ignoreHarvestAssignments: true });
 }
 function shouldGuaranteeMinimumHarvesterAllocation(creep) {
   var _a;
@@ -23214,14 +23222,19 @@ function shouldGuaranteeMinimumHarvesterAllocation(creep) {
     return false;
   }
   const roomCreeps = getSameRoomCreepsIncludingCurrent(creep);
-  if (roomCreeps.some(isAssignedHarvestCreep)) {
-    return false;
-  }
   const workerCreeps = roomCreeps.filter(isWorkerCreep);
   const hasSpawnExtensionEnergyDeficit = hasRoomSpawnExtensionEnergyDeficit(creep.room);
+  const hasWorkerHarvestCoverage = workerCreeps.some(isAssignedHarvestCreep);
+  const hasDedicatedHarvestCoverage = roomCreeps.some(isDedicatedHarvestCreep);
+  if (hasWorkerHarvestCoverage || hasDedicatedHarvestCoverage && !hasSpawnExtensionEnergyDeficit) {
+    return false;
+  }
   const hasBuildDeadlockSignal = workerCreeps.length > 1 && roomCreeps.some(isZeroEnergyBuildWorker) || workerCreeps.length > 1 && workerCreeps.every(isBuildAssignedWorker);
   const hasGenericDeadlockSignal = workerCreeps.length > 1 && workerCreeps.every(isAssignedNonHarvestWorker) || hasSpawnExtensionEnergyDeficit && workerCreeps.some(isAssignedNonHarvestWorker);
   return hasBuildDeadlockSignal || hasGenericDeadlockSignal || isBuildAssignedWorker(creep) && hasSpawnExtensionEnergyDeficit;
+}
+function shouldForceGenericHarvestForThroughputRecovery(creep) {
+  return hasLowWorkerThroughputRecoveryPressure(creep) && !getSameRoomCreepsIncludingCurrent(creep).filter(isWorkerCreep).some(isAssignedHarvestCreep);
 }
 function getSameRoomCreepsIncludingCurrent(creep) {
   const roomCreeps = getGameCreeps().filter((candidate) => isInRoom(candidate, creep.room));
@@ -23236,9 +23249,13 @@ function hasRoomSpawnExtensionEnergyDeficit(room) {
   return energyAvailable !== null && energyCapacityAvailable !== null && Math.max(0, energyAvailable) < Math.max(0, energyCapacityAvailable);
 }
 function isAssignedHarvestCreep(creep) {
-  var _a, _b, _c;
+  var _a;
   const task = (_a = creep.memory) == null ? void 0 : _a.task;
-  return (task == null ? void 0 : task.type) === "harvest" || ((_b = creep.memory) == null ? void 0 : _b.role) === SOURCE_HARVESTER_ROLE && typeof ((_c = creep.memory.sourceHarvester) == null ? void 0 : _c.sourceId) === "string";
+  return (task == null ? void 0 : task.type) === "harvest";
+}
+function isDedicatedHarvestCreep(creep) {
+  var _a, _b;
+  return ((_a = creep.memory) == null ? void 0 : _a.role) === SOURCE_HARVESTER_ROLE && typeof ((_b = creep.memory.sourceHarvester) == null ? void 0 : _b.sourceId) === "string";
 }
 function isWorkerCreep(creep) {
   var _a;
@@ -23425,6 +23442,14 @@ function selectBootstrapSurvivalSpendingTask(creep, controller, constructionSite
   if (criticalRoadConstructionSite) {
     return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: criticalRoadConstructionSite.id });
   }
+  const throughputRecoveryConstructionSite = selectLowWorkerThroughputRecoveryConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext
+  );
+  if (throughputRecoveryConstructionSite) {
+    return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: throughputRecoveryConstructionSite.id });
+  }
   return null;
 }
 function selectBootstrapSurvivalConstructionSite(creep, constructionSites, constructionReservationContext) {
@@ -23453,6 +23478,38 @@ function hasOtherSameRoomLoadedBuildWorker(creep) {
       return !isSameCreep(worker, creep) && isSameRoomWorker(worker, creep.room) && ((_b = (_a = worker.memory) == null ? void 0 : _a.task) == null ? void 0 : _b.type) === "build" && getUsedEnergy2(worker) > 0;
     }
   );
+}
+function selectLowWorkerThroughputRecoveryConstructionSite(creep, constructionSites, constructionReservationContext) {
+  if (!hasLowWorkerThroughputRecoveryPressure(creep) || hasOtherSameRoomLoadedBuildWorker(creep)) {
+    return null;
+  }
+  const priorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  return selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    () => true,
+    { priorityContext }
+  );
+}
+function hasLowWorkerThroughputRecoveryPressure(creep) {
+  var _a;
+  const room = creep.room;
+  const controller = room.controller;
+  if (((_a = creep.memory) == null ? void 0 : _a.role) !== "worker" || (controller == null ? void 0 : controller.my) !== true || getControllerLevel(controller) > 2 || shouldGuardControllerDowngrade2(controller) || hasVisibleHostilePresence2(room)) {
+    return false;
+  }
+  const energyAvailable = getRoomEnergyAvailable9(room);
+  if (energyAvailable === null || energyAvailable < MINIMUM_WORKER_SPAWN_ENERGY || energyAvailable >= getEffectiveRoomEnergyBufferThreshold(room)) {
+    return false;
+  }
+  if (!hasVisibleOwnedConstructionDemand(room)) {
+    return false;
+  }
+  return getSameRoomCreepsIncludingCurrent(creep).filter(isWorkerCreep).length <= LOW_WORKER_THROUGHPUT_WORKER_COUNT;
+}
+function getControllerLevel(controller) {
+  return typeof controller.level === "number" && Number.isFinite(controller.level) ? Math.max(0, Math.floor(controller.level)) : 0;
 }
 function shouldSuppressBootstrapControllerSpending(creep, recoveryOnlyWorkSuppressed) {
   return recoveryOnlyWorkSuppressed && !isWorkerInColonyRoom(creep);
@@ -24637,7 +24694,10 @@ function canSpendWorkerEnergyOnConstructionSite(creep, site) {
 }
 function canSpendCreepEnergyOnConstructionSite(creep, site, priorityContext) {
   const carriedEnergy = getUsedEnergy2(creep);
-  return carriedEnergy > 0 && isMissingSpawnRecoveryConstructionSite(creep.room, site) || carriedEnergy > 0 && checkEnergyBufferForConstructionSpending(creep.room) || carriedEnergy > 0 && isExtensionConstructionSite(site) && checkEnergyBufferForExtensionConstruction(creep.room, carriedEnergy) || carriedEnergy > 0 && !isExtensionConstructionSite(site) && isCapacityEnablingConstructionSite(site, priorityContext) && checkEnergyBufferForCapacityEnablingConstruction(creep.room, carriedEnergy) || carriedEnergy > 0 && hasMinimumWorkerSpawnEnergyForConstruction(creep.room) && isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext);
+  return carriedEnergy > 0 && isMissingSpawnRecoveryConstructionSite(creep.room, site) || carriedEnergy > 0 && checkEnergyBufferForConstructionSpending(creep.room) || carriedEnergy > 0 && isExtensionConstructionSite(site) && checkEnergyBufferForExtensionConstruction(creep.room, carriedEnergy) || carriedEnergy > 0 && !isExtensionConstructionSite(site) && isCapacityEnablingConstructionSite(site, priorityContext) && checkEnergyBufferForCapacityEnablingConstruction(creep.room, carriedEnergy) || carriedEnergy > 0 && isLowWorkerThroughputRecoveryConstructionAllowed(creep, site) || carriedEnergy > 0 && hasMinimumWorkerSpawnEnergyForConstruction(creep.room) && isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext);
+}
+function isLowWorkerThroughputRecoveryConstructionAllowed(creep, site) {
+  return site.my !== false && hasLowWorkerThroughputRecoveryPressure(creep);
 }
 function isMissingSpawnRecoveryConstructionSite(room, site) {
   return isSpawnConstructionSite(site) && getOwnedSpawnCount(room) === 0;
@@ -27403,7 +27463,7 @@ function selectBestHarvestSource(creep, sources, options = {}) {
   const assignmentLoads = getWorkerHarvestLoads(viableSources);
   const assignableSources = selectReachableHarvestSources(
     creep,
-    selectAssignableHarvestSources(creep, viableSources, assignmentLoads)
+    selectAssignableHarvestSources(creep, viableSources, assignmentLoads, options)
   );
   if (assignableSources.length === 0) {
     return null;
@@ -27419,9 +27479,9 @@ function selectBestHarvestSource(creep, sources, options = {}) {
   }
   return selectedLoad.source;
 }
-function selectAssignableHarvestSources(creep, sources, assignmentLoads) {
+function selectAssignableHarvestSources(creep, sources, assignmentLoads, options = {}) {
   return sources.filter(
-    (source) => isAssignableHarvestSource(creep, source, getHarvestSourceAssignmentLoad(assignmentLoads, source))
+    (source) => isAssignableHarvestSource(creep, source, getHarvestSourceAssignmentLoad(assignmentLoads, source), options)
   );
 }
 function selectReachableHarvestSources(creep, sources) {
@@ -27430,7 +27490,10 @@ function selectReachableHarvestSources(creep, sources) {
   }
   return sources.filter((source) => getHarvestSourceTravelCost(creep, source) !== null);
 }
-function isAssignableHarvestSource(creep, source, assignmentLoad) {
+function isAssignableHarvestSource(creep, source, assignmentLoad, options = {}) {
+  if (options.ignoreHarvestAssignments === true) {
+    return true;
+  }
   if (isWorkerPreHarvestSource(source)) {
     if (isWorkerAssignedToHarvestSource(creep, source)) {
       return true;
@@ -28276,6 +28339,8 @@ function runWorker(creep) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptForWorkerEnergyCriticalTask(currentTask, energyCriticalTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
+  } else if (shouldPreemptControllerSigningForRecovery(currentTask, selectedTask)) {
+    taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptForControllerSigning(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, currentTask, selectedTask)) {
@@ -28870,6 +28935,12 @@ function shouldPreemptForVisibleTerritoryControllerTask(task, selectedTask) {
 }
 function shouldPreemptForControllerSigning(creep, task, selectedTask) {
   return (selectedTask == null ? void 0 : selectedTask.type) === "signController" && !isSameTask2(task, selectedTask) && task.type === "upgrade" && isOwnedControllerUpgradeTask(creep, task);
+}
+function shouldPreemptControllerSigningForRecovery(task, selectedTask) {
+  return task.type === "signController" && isWorkerRecoveryTask(selectedTask);
+}
+function isWorkerRecoveryTask(task) {
+  return (task == null ? void 0 : task.type) === "harvest" || (task == null ? void 0 : task.type) === "pickup" || (task == null ? void 0 : task.type) === "withdraw" || (task == null ? void 0 : task.type) === "transfer" || (task == null ? void 0 : task.type) === "build" || (task == null ? void 0 : task.type) === "repair";
 }
 function shouldPreemptSpendingTaskForEnergySink(task, selectedTask) {
   if (!isEnergySpendingTask(task)) {
@@ -31121,7 +31192,7 @@ function getVisibleMultiRoomUpgradeCandidate(homeRoom, room, config, activeUpgra
   if (!hasStorageSurplus && !postClaimProgression) {
     return null;
   }
-  const controllerLevel = getControllerLevel(controller);
+  const controllerLevel = getControllerLevel2(controller);
   const desiredControllerLevel = (_a = postClaimProgression == null ? void 0 : postClaimProgression.desiredControllerLevel) != null ? _a : MAX_CONTROLLER_LEVEL4;
   if (controllerLevel >= desiredControllerLevel) {
     return null;
@@ -31155,7 +31226,7 @@ function getVisibleMultiRoomUpgradeCandidate(homeRoom, room, config, activeUpgra
   };
 }
 function getEligibleControllerState(controller) {
-  return controller.my === true && getControllerLevel(controller) < MAX_CONTROLLER_LEVEL4 ? "owned" : null;
+  return controller.my === true && getControllerLevel2(controller) < MAX_CONTROLLER_LEVEL4 ? "owned" : null;
 }
 function getPostClaimControllerUpgradeProgression(homeRoom, targetRoom, controller) {
   var _a, _b, _c;
@@ -31164,7 +31235,7 @@ function getPostClaimControllerUpgradeProgression(homeRoom, targetRoom, controll
     return null;
   }
   const desiredControllerLevel = POST_CLAIM_CONTROLLER_UPGRADE_DESIRED_RCL;
-  return getControllerLevel(controller) < desiredControllerLevel ? { desiredControllerLevel } : null;
+  return getControllerLevel2(controller) < desiredControllerLevel ? { desiredControllerLevel } : null;
 }
 function isPostClaimControllerUpgradeRecord(record, homeRoom, targetRoom) {
   return isRecord25(record) && record.colony === homeRoom && record.roomName === targetRoom && isPostClaimControllerUpgradeStatus(record.status);
@@ -31323,7 +31394,7 @@ function getActiveMultiRoomUpgraderCountCache() {
 function isActiveMultiRoomUpgrader(creep) {
   return creep.ticksToLive === void 0 || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE;
 }
-function getControllerLevel(controller) {
+function getControllerLevel2(controller) {
   return typeof controller.level === "number" && Number.isFinite(controller.level) ? controller.level : MAX_CONTROLLER_LEVEL4;
 }
 function getControllerTicksToDowngradePlanField(controller) {
@@ -31505,7 +31576,7 @@ function buildControllerManagementPlan(colony, roleCounts, workerTarget, gameTim
     };
   }
   const controllerId = controller.id;
-  const controllerLevel = getControllerLevel2(controller);
+  const controllerLevel = getControllerLevel3(controller);
   const desiredControllerLevel = normalizeDesiredControllerLevel(options.desiredControllerLevel);
   const activeUpgraderCount = (_a = options.activeUpgraderCount) != null ? _a : Math.max(getUpgraderCapacity(roleCounts), countActiveControllerUpgraders(roomName, controllerId));
   const competingSpawnDemand = (_b = options.competingSpawnDemand) != null ? _b : getWorkerCapacity(roleCounts) < workerTarget;
@@ -31689,7 +31760,7 @@ function getControllerProgressFields(controller) {
     progressRatio: normalizedProgress / progressTotal
   };
 }
-function getControllerLevel2(controller) {
+function getControllerLevel3(controller) {
   return typeof controller.level === "number" && Number.isFinite(controller.level) ? Math.max(0, Math.min(MAX_CONTROLLER_LEVEL5, Math.floor(controller.level))) : 0;
 }
 function normalizeDesiredControllerLevel(value) {
@@ -31863,7 +31934,7 @@ function getRoomCreepBudget(colony, roleCounts) {
   return {
     roomName: colony.room.name,
     constructionSiteCount: getVisibleConstructionSiteCount(colony.room),
-    controllerLevel: getControllerLevel3(colony.room.controller),
+    controllerLevel: getControllerLevel4(colony.room.controller),
     energyAvailable: normalizeNonNegativeInteger13(colony.energyAvailable),
     energyCapacityAvailable: normalizeNonNegativeInteger13(colony.energyCapacityAvailable),
     effectiveEnergyAvailable: forecast.effectiveEnergyAvailable,
@@ -33043,7 +33114,7 @@ function getEnergyGateRank(gate) {
       return 3;
   }
 }
-function getControllerLevel3(controller) {
+function getControllerLevel4(controller) {
   return typeof (controller == null ? void 0 : controller.level) === "number" ? controller.level : MAX_CONTROLLER_LEVEL6;
 }
 function getStorageBalanceMemory() {
@@ -43335,10 +43406,23 @@ function planSpawnWithEnergyBudget(colony, sourceColony, energyBudget, usedSpawn
   };
 }
 function shouldBypassSpawnEnergyBuffer(spawnRequest, roleCounts, availableEnergy, bodyCost, survivalAssessment) {
-  return roleCounts.worker === 0 || isBootstrapWorkerRecoverySpawnRequest(spawnRequest, roleCounts, availableEnergy, survivalAssessment) || isLocalSourceMinerRecoverySpawnRequest(spawnRequest, roleCounts, availableEnergy, bodyCost, survivalAssessment) || isTerritoryControllerSpawnRequest(spawnRequest);
+  return roleCounts.worker === 0 || isBootstrapWorkerRecoverySpawnRequest(spawnRequest, roleCounts, availableEnergy, survivalAssessment) || isLocalWorkerRecoverySpawnRequest(spawnRequest, availableEnergy, bodyCost, survivalAssessment) || isLocalSourceMinerRecoverySpawnRequest(spawnRequest, roleCounts, availableEnergy, bodyCost, survivalAssessment) || isTerritoryControllerSpawnRequest(spawnRequest);
 }
 function isBootstrapWorkerRecoverySpawnRequest(spawnRequest, roleCounts, availableEnergy, survivalAssessment) {
   return spawnRequest.memory.role === "worker" && survivalAssessment.mode === "BOOTSTRAP" && (roleCounts.worker < survivalAssessment.survivalWorkerFloor || availableEnergy >= BOOTSTRAP_WORKER_BUFFER_BYPASS_MIN_ENERGY);
+}
+function isLocalWorkerRecoverySpawnRequest(spawnRequest, availableEnergy, bodyCost, survivalAssessment) {
+  return spawnRequest.memory.role === "worker" && survivalAssessment.mode !== "DEFENSE" && !survivalAssessment.hostilePresence && !survivalAssessment.controllerDowngradeGuard && isEarlyRclWorkerRecoveryRoom(spawnRequest.spawn.room) && survivalAssessment.workerCapacity < survivalAssessment.workerTarget && isRoomCurrentlyBelowSpawnEnergyBuffer(spawnRequest.spawn) && availableEnergy >= bodyCost;
+}
+function isEarlyRclWorkerRecoveryRoom(room) {
+  var _a;
+  const controllerLevel = normalizeOptionalNonNegativeInteger3((_a = room.controller) == null ? void 0 : _a.level);
+  return controllerLevel !== void 0 && controllerLevel <= 2;
+}
+function isRoomCurrentlyBelowSpawnEnergyBuffer(spawn) {
+  var _a;
+  const currentRoomEnergy = normalizeOptionalNonNegativeInteger3((_a = spawn.room) == null ? void 0 : _a.energyAvailable);
+  return currentRoomEnergy !== void 0 && currentRoomEnergy < getSpawnEnergyBufferRequirement(spawn.room, [spawn]);
 }
 function isTerritoryControllerSpawnRequest(spawnRequest) {
   return spawnRequest.memory.role === TERRITORY_CLAIMER_ROLE || spawnRequest.memory.role === TERRITORY_SCOUT_ROLE;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -23500,7 +23500,7 @@ function hasLowWorkerThroughputRecoveryPressure(creep) {
     return false;
   }
   const energyAvailable = getRoomEnergyAvailable9(room);
-  if (energyAvailable === null || energyAvailable < MINIMUM_WORKER_SPAWN_ENERGY || energyAvailable >= getEffectiveRoomEnergyBufferThreshold(room)) {
+  if (energyAvailable === null || energyAvailable >= getEffectiveRoomEnergyBufferThreshold(room)) {
     return false;
   }
   if (!hasVisibleOwnedConstructionDemand(room)) {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -106,6 +106,8 @@ export function runWorker(creep: Creep): void {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptForWorkerEnergyCriticalTask(currentTask, energyCriticalTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
+  } else if (shouldPreemptControllerSigningForRecovery(currentTask, selectedTask)) {
+    taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptForControllerSigning(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, currentTask, selectedTask)) {
@@ -964,6 +966,26 @@ function shouldPreemptForControllerSigning(
     !isSameTask(task, selectedTask) &&
     task.type === 'upgrade' &&
     isOwnedControllerUpgradeTask(creep, task)
+  );
+}
+
+function shouldPreemptControllerSigningForRecovery(
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  return task.type === 'signController' && isWorkerRecoveryTask(selectedTask);
+}
+
+function isWorkerRecoveryTask(
+  task: CreepTaskMemory | null
+): task is Extract<CreepTaskMemory, { type: 'harvest' | 'pickup' | 'withdraw' | 'transfer' | 'build' | 'repair' }> {
+  return (
+    task?.type === 'harvest' ||
+    task?.type === 'pickup' ||
+    task?.type === 'withdraw' ||
+    task?.type === 'transfer' ||
+    task?.type === 'build' ||
+    task?.type === 'repair'
   );
 }
 

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -1122,6 +1122,7 @@ function shouldBypassSpawnEnergyBuffer(
   return (
     roleCounts.worker === 0 ||
     isBootstrapWorkerRecoverySpawnRequest(spawnRequest, roleCounts, availableEnergy, survivalAssessment) ||
+    isLocalWorkerRecoverySpawnRequest(spawnRequest, availableEnergy, bodyCost, survivalAssessment) ||
     isLocalSourceMinerRecoverySpawnRequest(spawnRequest, roleCounts, availableEnergy, bodyCost, survivalAssessment) ||
     isTerritoryControllerSpawnRequest(spawnRequest)
   );
@@ -1138,6 +1139,37 @@ function isBootstrapWorkerRecoverySpawnRequest(
     survivalAssessment.mode === 'BOOTSTRAP' &&
     (roleCounts.worker < survivalAssessment.survivalWorkerFloor ||
       availableEnergy >= BOOTSTRAP_WORKER_BUFFER_BYPASS_MIN_ENERGY)
+  );
+}
+
+function isLocalWorkerRecoverySpawnRequest(
+  spawnRequest: SpawnRequest,
+  availableEnergy: number,
+  bodyCost: number,
+  survivalAssessment: ReturnType<typeof assessColonySnapshotSurvival>
+): boolean {
+  return (
+    spawnRequest.memory.role === 'worker' &&
+    survivalAssessment.mode !== 'DEFENSE' &&
+    !survivalAssessment.hostilePresence &&
+    !survivalAssessment.controllerDowngradeGuard &&
+    isEarlyRclWorkerRecoveryRoom(spawnRequest.spawn.room) &&
+    survivalAssessment.workerCapacity < survivalAssessment.workerTarget &&
+    isRoomCurrentlyBelowSpawnEnergyBuffer(spawnRequest.spawn) &&
+    availableEnergy >= bodyCost
+  );
+}
+
+function isEarlyRclWorkerRecoveryRoom(room: Room): boolean {
+  const controllerLevel = normalizeOptionalNonNegativeInteger(room.controller?.level);
+  return controllerLevel !== undefined && controllerLevel <= 2;
+}
+
+function isRoomCurrentlyBelowSpawnEnergyBuffer(spawn: StructureSpawn): boolean {
+  const currentRoomEnergy = normalizeOptionalNonNegativeInteger(spawn.room?.energyAvailable);
+  return (
+    currentRoomEnergy !== undefined &&
+    currentRoomEnergy < getSpawnEnergyBufferRequirement(spawn.room, [spawn])
   );
 }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -38,7 +38,6 @@ import {
   getStorageEnergyAvailableForWithdrawal,
   getStorageEnergyReserveThreshold,
   hasMinimumWorkerSpawnEnergyForConstruction,
-  MINIMUM_WORKER_SPAWN_ENERGY,
   withdrawFromStorage
 } from '../economy/energyBuffer';
 import {
@@ -1299,11 +1298,7 @@ function hasLowWorkerThroughputRecoveryPressure(creep: Creep): boolean {
   }
 
   const energyAvailable = getRoomEnergyAvailable(room);
-  if (
-    energyAvailable === null ||
-    energyAvailable < MINIMUM_WORKER_SPAWN_ENERGY ||
-    energyAvailable >= getEffectiveRoomEnergyBufferThreshold(room)
-  ) {
+  if (energyAvailable === null || energyAvailable >= getEffectiveRoomEnergyBufferThreshold(room)) {
     return false;
   }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -38,6 +38,7 @@ import {
   getStorageEnergyAvailableForWithdrawal,
   getStorageEnergyReserveThreshold,
   hasMinimumWorkerSpawnEnergyForConstruction,
+  MINIMUM_WORKER_SPAWN_ENERGY,
   withdrawFromStorage
 } from '../economy/energyBuffer';
 import {
@@ -90,6 +91,7 @@ export const LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE = 12;
 export const BUILDER_STORAGE_WITHDRAW_MIN = 100;
 export const BUILDER_DROPPED_PICKUP_RANGE = 5;
 const DEFAULT_SPAWN_ENERGY_CAPACITY = 300;
+const LOW_WORKER_THROUGHPUT_WORKER_COUNT = 3;
 const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 const MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
@@ -263,6 +265,7 @@ interface HarvestSourceAssignmentLoad {
 
 export interface HarvestSourceSelectionOptions {
   allowPreHarvest?: boolean;
+  ignoreHarvestAssignments?: boolean;
 }
 
 interface WorkerHarvestTaskOptions extends HarvestSourceSelectionOptions {
@@ -826,7 +829,16 @@ function selectMinimumHarvesterAllocationTask(creep: Creep): Extract<CreepTaskMe
     return null;
   }
 
-  return selectWorkerHarvestTask(creep, { allowPreHarvest: false, assignSourceContainer: true });
+  const assignedHarvestTask = selectWorkerHarvestTask(creep, { allowPreHarvest: false, assignSourceContainer: true });
+  if (assignedHarvestTask) {
+    return assignedHarvestTask;
+  }
+
+  if (!shouldForceGenericHarvestForThroughputRecovery(creep)) {
+    return null;
+  }
+
+  return selectWorkerHarvestTask(creep, { allowPreHarvest: false, ignoreHarvestAssignments: true });
 }
 
 function shouldGuaranteeMinimumHarvesterAllocation(creep: Creep): boolean {
@@ -835,12 +847,14 @@ function shouldGuaranteeMinimumHarvesterAllocation(creep: Creep): boolean {
   }
 
   const roomCreeps = getSameRoomCreepsIncludingCurrent(creep);
-  if (roomCreeps.some(isAssignedHarvestCreep)) {
+  const workerCreeps = roomCreeps.filter(isWorkerCreep);
+  const hasSpawnExtensionEnergyDeficit = hasRoomSpawnExtensionEnergyDeficit(creep.room);
+  const hasWorkerHarvestCoverage = workerCreeps.some(isAssignedHarvestCreep);
+  const hasDedicatedHarvestCoverage = roomCreeps.some(isDedicatedHarvestCreep);
+  if (hasWorkerHarvestCoverage || (hasDedicatedHarvestCoverage && !hasSpawnExtensionEnergyDeficit)) {
     return false;
   }
 
-  const workerCreeps = roomCreeps.filter(isWorkerCreep);
-  const hasSpawnExtensionEnergyDeficit = hasRoomSpawnExtensionEnergyDeficit(creep.room);
   const hasBuildDeadlockSignal =
     (workerCreeps.length > 1 && roomCreeps.some(isZeroEnergyBuildWorker)) ||
     (workerCreeps.length > 1 && workerCreeps.every(isBuildAssignedWorker));
@@ -852,6 +866,13 @@ function shouldGuaranteeMinimumHarvesterAllocation(creep: Creep): boolean {
     hasBuildDeadlockSignal ||
     hasGenericDeadlockSignal ||
     (isBuildAssignedWorker(creep) && hasSpawnExtensionEnergyDeficit)
+  );
+}
+
+function shouldForceGenericHarvestForThroughputRecovery(creep: Creep): boolean {
+  return (
+    hasLowWorkerThroughputRecoveryPressure(creep) &&
+    !getSameRoomCreepsIncludingCurrent(creep).filter(isWorkerCreep).some(isAssignedHarvestCreep)
   );
 }
 
@@ -876,9 +897,13 @@ function hasRoomSpawnExtensionEnergyDeficit(room: Room): boolean {
 
 function isAssignedHarvestCreep(creep: Creep): boolean {
   const task = creep.memory?.task as Partial<CreepTaskMemory> | undefined;
+  return task?.type === 'harvest';
+}
+
+function isDedicatedHarvestCreep(creep: Creep): boolean {
   return (
-    task?.type === 'harvest' ||
-    (creep.memory?.role === SOURCE_HARVESTER_ROLE && typeof creep.memory.sourceHarvester?.sourceId === 'string')
+    creep.memory?.role === SOURCE_HARVESTER_ROLE &&
+    typeof creep.memory.sourceHarvester?.sourceId === 'string'
   );
 }
 
@@ -1178,6 +1203,15 @@ function selectBootstrapSurvivalSpendingTask(
     return applyMinimumUsefulLoadPolicy(creep, { type: 'build', targetId: criticalRoadConstructionSite.id });
   }
 
+  const throughputRecoveryConstructionSite = selectLowWorkerThroughputRecoveryConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext
+  );
+  if (throughputRecoveryConstructionSite) {
+    return applyMinimumUsefulLoadPolicy(creep, { type: 'build', targetId: throughputRecoveryConstructionSite.id });
+  }
+
   return null;
 }
 
@@ -1230,6 +1264,60 @@ function hasOtherSameRoomLoadedBuildWorker(creep: Creep): boolean {
       worker.memory?.task?.type === 'build' &&
       getUsedEnergy(worker) > 0
   );
+}
+
+function selectLowWorkerThroughputRecoveryConstructionSite(
+  creep: Creep,
+  constructionSites: ConstructionSite[],
+  constructionReservationContext: ConstructionReservationContext
+): ConstructionSite | null {
+  if (!hasLowWorkerThroughputRecoveryPressure(creep) || hasOtherSameRoomLoadedBuildWorker(creep)) {
+    return null;
+  }
+
+  const priorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  return selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    () => true,
+    { priorityContext }
+  );
+}
+
+function hasLowWorkerThroughputRecoveryPressure(creep: Creep): boolean {
+  const room = creep.room;
+  const controller = room.controller;
+  if (
+    creep.memory?.role !== 'worker' ||
+    controller?.my !== true ||
+    getControllerLevel(controller) > 2 ||
+    shouldGuardControllerDowngrade(controller) ||
+    hasVisibleHostilePresence(room)
+  ) {
+    return false;
+  }
+
+  const energyAvailable = getRoomEnergyAvailable(room);
+  if (
+    energyAvailable === null ||
+    energyAvailable < MINIMUM_WORKER_SPAWN_ENERGY ||
+    energyAvailable >= getEffectiveRoomEnergyBufferThreshold(room)
+  ) {
+    return false;
+  }
+
+  if (!hasVisibleOwnedConstructionDemand(room)) {
+    return false;
+  }
+
+  return getSameRoomCreepsIncludingCurrent(creep).filter(isWorkerCreep).length <= LOW_WORKER_THROUGHPUT_WORKER_COUNT;
+}
+
+function getControllerLevel(controller: StructureController): number {
+  return typeof controller.level === 'number' && Number.isFinite(controller.level)
+    ? Math.max(0, Math.floor(controller.level))
+    : 0;
 }
 
 function shouldSuppressBootstrapControllerSpending(creep: Creep, recoveryOnlyWorkSuppressed: boolean): boolean {
@@ -3057,10 +3145,15 @@ function canSpendCreepEnergyOnConstructionSite(
       !isExtensionConstructionSite(site) &&
       isCapacityEnablingConstructionSite(site, priorityContext) &&
       checkEnergyBufferForCapacityEnablingConstruction(creep.room, carriedEnergy)) ||
+    (carriedEnergy > 0 && isLowWorkerThroughputRecoveryConstructionAllowed(creep, site)) ||
     (carriedEnergy > 0 &&
       hasMinimumWorkerSpawnEnergyForConstruction(creep.room) &&
       isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext))
   );
+}
+
+function isLowWorkerThroughputRecoveryConstructionAllowed(creep: Creep, site: ConstructionSite): boolean {
+  return site.my !== false && hasLowWorkerThroughputRecoveryPressure(creep);
 }
 
 function isMissingSpawnRecoveryConstructionSite(room: Room, site: ConstructionSite): boolean {
@@ -7399,7 +7492,7 @@ function selectBestHarvestSource(
   const assignmentLoads = getWorkerHarvestLoads(viableSources);
   const assignableSources = selectReachableHarvestSources(
     creep,
-    selectAssignableHarvestSources(creep, viableSources, assignmentLoads)
+    selectAssignableHarvestSources(creep, viableSources, assignmentLoads, options)
   );
   if (assignableSources.length === 0) {
     return null;
@@ -7422,10 +7515,11 @@ function selectBestHarvestSource(
 function selectAssignableHarvestSources(
   creep: Creep,
   sources: Source[],
-  assignmentLoads: Map<Id<Source>, HarvestSourceAssignmentLoad>
+  assignmentLoads: Map<Id<Source>, HarvestSourceAssignmentLoad>,
+  options: HarvestSourceSelectionOptions = {}
 ): Source[] {
   return sources.filter((source) =>
-    isAssignableHarvestSource(creep, source, getHarvestSourceAssignmentLoad(assignmentLoads, source))
+    isAssignableHarvestSource(creep, source, getHarvestSourceAssignmentLoad(assignmentLoads, source), options)
   );
 }
 
@@ -7440,8 +7534,13 @@ function selectReachableHarvestSources(creep: Creep, sources: Source[]): Source[
 function isAssignableHarvestSource(
   creep: Creep,
   source: Source,
-  assignmentLoad: HarvestSourceAssignmentLoad
+  assignmentLoad: HarvestSourceAssignmentLoad,
+  options: HarvestSourceSelectionOptions = {}
 ): boolean {
+  if (options.ignoreHarvestAssignments === true) {
+    return true;
+  }
+
   if (isWorkerPreHarvestSource(source)) {
     if (isWorkerAssignedToHarvestSource(creep, source)) {
       return true;

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -157,6 +157,99 @@ describe('runEconomy', () => {
     );
   });
 
+  it('spawns a local recovery worker below the spawn buffer when W3N9 has three workers and build backlog', () => {
+    (globalThis as unknown as {
+      FIND_SOURCES: number;
+      FIND_MY_CONSTRUCTION_SITES: number;
+      FIND_CONSTRUCTION_SITES: number;
+      FIND_MY_STRUCTURES: number;
+      FIND_STRUCTURES: number;
+      RESOURCE_ENERGY: ResourceConstant;
+      STRUCTURE_SPAWN: StructureConstant;
+      STRUCTURE_EXTENSION: StructureConstant;
+    }).FIND_SOURCES = 1;
+    (globalThis as unknown as { FIND_MY_CONSTRUCTION_SITES: number }).FIND_MY_CONSTRUCTION_SITES = 2;
+    (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 3;
+    (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 4;
+    (globalThis as unknown as { FIND_STRUCTURES: number }).FIND_STRUCTURES = 5;
+    (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+    (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
+    (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    const sourceA = { id: 'sourceA', energy: 300, pos: { x: 10, y: 10, roomName: 'W3N9' } } as Source;
+    const sourceB = { id: 'sourceB', energy: 300, pos: { x: 40, y: 40, roomName: 'W3N9' } } as Source;
+    const sites = Array.from({ length: 7 }, (_, index) => ({ id: `site${index}`, my: true }) as ConstructionSite);
+    const room = {
+      name: 'W3N9',
+      energyAvailable: 290,
+      energyCapacityAvailable: 550,
+      controller: { id: 'controller1', my: true, level: 2, ticksToDowngrade: 10_000 } as StructureController,
+      find: jest.fn((type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+        if (type === FIND_SOURCES) {
+          return [sourceA, sourceB];
+        }
+        if (type === FIND_MY_CONSTRUCTION_SITES || type === FIND_CONSTRUCTION_SITES) {
+          return sites;
+        }
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn as unknown as AnyOwnedStructure];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+        return [];
+      })
+    } as unknown as Room;
+    const spawn = {
+      id: 'spawn1',
+      name: 'Spawn1',
+      room,
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(190),
+        getFreeCapacity: jest.fn().mockReturnValue(110)
+      },
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const makeWorker = (name: string, energy: number, task?: CreepTaskMemory): Creep => ({
+      name,
+      memory: { role: 'worker', colony: 'W3N9', ...(task ? { task } : {}) },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(energy),
+        getFreeCapacity: jest.fn().mockReturnValue(energy > 0 ? 0 : 50)
+      },
+      room,
+      pos: { getRangeTo: jest.fn().mockReturnValue(5) },
+      harvest: jest.fn().mockReturnValue(OK_CODE),
+      transfer: jest.fn().mockReturnValue(OK_CODE),
+      upgradeController: jest.fn().mockReturnValue(OK_CODE),
+      moveTo: jest.fn()
+    }) as unknown as Creep;
+    const workerA = makeWorker('WorkerA', 50, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> });
+    const workerB = makeWorker('WorkerB', 50, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> });
+    const workerC = makeWorker('WorkerC', 0);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 140,
+      rooms: { W3N9: room },
+      spawns: { Spawn1: spawn },
+      creeps: { WorkerA: workerA, WorkerB: workerB, WorkerC: workerC },
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'spawn1') {
+          return spawn;
+        }
+        if (id === 'sourceA') {
+          return sourceA;
+        }
+        return room.controller ?? null;
+      })
+    };
+
+    runEconomy();
+
+    expect(spawn.spawnCreep).toHaveBeenCalledWith(['work', 'carry', 'move'], 'worker-W3N9-140', {
+      memory: { role: 'worker', colony: 'W3N9' }
+    });
+  });
+
   it('spawns an emergency bootstrap worker when the energy buffer is satisfied', () => {
     const room = {
       name: 'W1N1',

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -173,6 +173,64 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
+  it('preempts an assigned controller sign for emergency harvest during low-energy buildout', () => {
+    const source = { id: 'source1', energy: 300 } as Source;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getUsedCapacity: jest.fn().mockReturnValue(190), getFreeCapacity: jest.fn().mockReturnValue(110) }
+    } as unknown as StructureSpawn;
+    const site = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1,
+      sign: { username: 'enemy', text: 'not ours', time: 10, datetime: '2026-05-08T00:00:00.000Z' }
+    } as unknown as StructureController;
+    const room = {
+      name: 'W3N9',
+      energyAvailable: 290,
+      energyCapacityAvailable: 550,
+      controller,
+      find: jest.fn((type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+        if (type === FIND_SOURCES) {
+          return [source];
+        }
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn as unknown as AnyOwnedStructure];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+        return [];
+      })
+    } as unknown as Room;
+    const creep = {
+      name: 'Worker1',
+      memory: { role: 'worker', colony: 'W3N9', task: { type: 'signController', targetId: 'controller1' as Id<StructureController> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room,
+      harvest: jest.fn().mockReturnValue(0),
+      signController: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Worker1: creep },
+      getObjectById: jest.fn((id: string) => (id === 'source1' ? source : controller))
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(creep.harvest).toHaveBeenCalledWith(source);
+    expect(creep.signController).not.toHaveBeenCalled();
+  });
+
   it('does not assign owned controller signing while hostiles are visible', () => {
     const controller = {
       id: 'controller1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -10177,6 +10177,110 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
   });
 
+  it('forces a generic worker harvest during low-worker energy deficit even when source containers are assigned', () => {
+    const source = makeSource('source1', 20, 10);
+    const sourceContainer = makeStoredEnergyStructure('source-container1', 'container' as StructureConstant, 0, {
+      pos: makeRoomPosition(20, 11)
+    });
+    const spawn = makeEnergySinkWithEnergy('spawn1', 'spawn' as StructureConstant, 190, 110);
+    const site = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'W3N9',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 290,
+      energyCapacityAvailable: 550,
+      myStructures: [spawn as unknown as AnyOwnedStructure],
+      sources: [source],
+      structures: [sourceContainer as AnyStructure]
+    });
+    const creep = {
+      name: 'RecoveryWorker',
+      memory: { role: 'worker', colony: 'W3N9' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+    const upgraderA = makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> });
+    const upgraderB = makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> });
+    const sourceHarvester = {
+      name: 'SourceHarvester',
+      memory: {
+        role: 'sourceHarvester',
+        colony: 'W3N9',
+        sourceHarvester: {
+          roomName: 'W3N9',
+          sourceId: 'source1' as Id<Source>,
+          containerId: 'source-container1' as Id<StructureContainer>
+        }
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ RecoveryWorker: creep, UpgraderA: upgraderA, UpgraderB: upgraderB, SourceHarvester: sourceHarvester });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+  });
+
+  it('uses carried energy on build recovery before upgrade during low-worker buffer deficit', () => {
+    const site = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'W3N9',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 290,
+      energyCapacityAvailable: 550
+    });
+    const creep = {
+      name: 'LoadedWorker',
+      memory: { role: 'worker', colony: 'W3N9', task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> } },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    const emptyWorker = {
+      name: 'EmptyWorker',
+      memory: { role: 'worker', colony: 'W3N9' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({
+      LoadedWorker: creep,
+      OtherUpgrader: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }),
+      EmptyWorker: emptyWorker
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      ...((globalThis as unknown as { Game?: Partial<Game> }).Game ?? {}),
+      time: 100
+    };
+    recordColonySurvivalAssessment(
+      'W3N9',
+      assessColonySurvival({
+        roomName: 'W3N9',
+        workerCapacity: 3,
+        workerTarget: 4,
+        energyAvailable: 290,
+        energyCapacityAvailable: 550,
+        controller: { my: true, level: 2, ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1 }
+      }),
+      100
+    );
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
+  });
+
   it('builds RCL4 spawn-only extension construction when capacity is below the energy buffer threshold', () => {
     const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
     const controller = {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -41,6 +41,7 @@ import {
   TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS,
   TERRITORY_RESERVATION_RENEWAL_TICKS
 } from '../src/territory/territoryPlanner';
+import { MINIMUM_WORKER_SPAWN_ENERGY } from '../src/economy/energyBuffer';
 
 const TEST_CRITICAL_SPAWN_REPAIR_HITS_RATIO = 0.25 as const;
 const TEST_ERR_NO_PATH = -2 as const;
@@ -10177,12 +10178,13 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
   });
 
-  it('forces a generic worker harvest during low-worker energy deficit even when source containers are assigned', () => {
+  it('forces a generic worker harvest during low-worker energy deficit below the spawn floor', () => {
+    const scarceEnergyAvailable = MINIMUM_WORKER_SPAWN_ENERGY - 10;
     const source = makeSource('source1', 20, 10);
     const sourceContainer = makeStoredEnergyStructure('source-container1', 'container' as StructureConstant, 0, {
       pos: makeRoomPosition(20, 11)
     });
-    const spawn = makeEnergySinkWithEnergy('spawn1', 'spawn' as StructureConstant, 190, 110);
+    const spawn = makeEnergySinkWithEnergy('spawn1', 'spawn' as StructureConstant, scarceEnergyAvailable, 110);
     const site = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
     const controller = {
       id: 'controller1',
@@ -10194,7 +10196,7 @@ describe('selectWorkerTask', () => {
       name: 'W3N9',
       constructionSites: [site],
       controller,
-      energyAvailable: 290,
+      energyAvailable: scarceEnergyAvailable,
       energyCapacityAvailable: 550,
       myStructures: [spawn as unknown as AnyOwnedStructure],
       sources: [source],
@@ -10229,7 +10231,8 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
   });
 
-  it('uses carried energy on build recovery before upgrade during low-worker buffer deficit', () => {
+  it('uses carried energy on build recovery below the spawn floor before upgrade', () => {
+    const scarceEnergyAvailable = MINIMUM_WORKER_SPAWN_ENERGY - 10;
     const site = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
     const controller = {
       id: 'controller1',
@@ -10241,7 +10244,7 @@ describe('selectWorkerTask', () => {
       name: 'W3N9',
       constructionSites: [site],
       controller,
-      energyAvailable: 290,
+      energyAvailable: scarceEnergyAvailable,
       energyCapacityAvailable: 550
     });
     const creep = {
@@ -10271,7 +10274,7 @@ describe('selectWorkerTask', () => {
         roomName: 'W3N9',
         workerCapacity: 3,
         workerTarget: 4,
-        energyAvailable: 290,
+        energyAvailable: scarceEnergyAvailable,
         energyCapacityAvailable: 550,
         controller: { my: true, level: 2, ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1 }
       }),
@@ -10374,6 +10377,12 @@ describe('selectWorkerTask', () => {
         myStructures: builtExtensions as AnyOwnedStructure[]
       })
     } as unknown as Creep;
+    setGameCreeps({
+      WorkerA: { memory: { role: 'worker' }, room: creep.room } as unknown as Creep,
+      WorkerB: { memory: { role: 'worker' }, room: creep.room } as unknown as Creep,
+      WorkerC: { memory: { role: 'worker' }, room: creep.room } as unknown as Creep,
+      WorkerD: { memory: { role: 'worker' }, room: creep.room } as unknown as Creep
+    });
     recordSurvivalMode('BOOTSTRAP');
 
     expect(selectWorkerTask(creep)?.type).not.toBe('build');


### PR DESCRIPTION
## Summary
- Restores low-worker W3N9 throughput by making emergency harvest/refill/build recovery outrank upgrade/sign behavior when the energy buffer is unhealthy and construction backlog exists.
- Adjusts economy/worker task selection so scarce workers and idle spawn conditions recover energy/build flow instead of entering upgrade/no-work starvation cycles.
- Adds regression coverage for the fresh W3N9 failure mode: low worker count, below-threshold energy, construction backlog, no harvest/build, and upgrade/sign starvation risk.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (95 suites / 1796 tests)
- `cd prod && npm run build`

## Runtime follow-up
- Deploy after merge and verify fresh W3N9 console/monitor windows show harvest/build resumed, Spawn1 not idling during low-worker energy deficit, pendingBuildProgress decreasing, and no sustained worker_assignment_gap.

Refs #1040
