### PR TITLE
fix(economy): allow W3N9 construction below buffer margin

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -25401,7 +25401,7 @@ function getSpawnConstructionEnergyAvailableForWithdrawal(creep, source, energy,
   );
   const constructionBudget = Math.max(
     0,
-    roomEnergyAvailable - getEffectiveRoomEnergyBufferThreshold(creep.room) - reservationContext.constructionEnergyWithdrawn
+    roomEnergyAvailable - getConstructionSpendingEnergyThreshold(creep.room) - reservationContext.constructionEnergyWithdrawn
   );
   return Math.min(projectedSourceEnergy, constructionBudget, spawnReservationBudget);
 }
@@ -29388,7 +29388,7 @@ function getConstructionSpawnWithdrawEnergyAvailable(creep, target) {
   );
   const constructionBudget = Math.max(
     0,
-    roomEnergyAvailable - getEffectiveRoomEnergyBufferThreshold(creep.room) - reservationContext.constructionEnergyWithdrawn
+    roomEnergyAvailable - getConstructionSpendingEnergyThreshold(creep.room) - reservationContext.constructionEnergyWithdrawn
   );
   return Math.min(sourceEnergy, constructionBudget, spawnReservationBudget);
 }

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -16,7 +16,10 @@ import {
 } from './workerTaskPolicy';
 import { runUpgrader } from './upgraderRunner';
 import { canCreepPressureTerritoryController } from '../territory/territoryPlanner';
-import { getEffectiveRoomEnergyBufferThreshold } from '../economy/energyBuffer';
+import {
+  getConstructionSpendingEnergyThreshold,
+  getEffectiveRoomEnergyBufferThreshold
+} from '../economy/energyBuffer';
 import { getSpawnEnergyWithdrawalAmount, isSpawnEnergySource } from '../economy/spawnEnergyBuffer';
 import {
   getRoomSpawnEnergyReservationState,
@@ -1669,7 +1672,7 @@ function getConstructionSpawnWithdrawEnergyAvailable(creep: Creep, target: Struc
   const constructionBudget = Math.max(
     0,
     roomEnergyAvailable -
-      getEffectiveRoomEnergyBufferThreshold(creep.room) -
+      getConstructionSpendingEnergyThreshold(creep.room) -
       reservationContext.constructionEnergyWithdrawn
   );
   return Math.min(sourceEnergy, constructionBudget, spawnReservationBudget);

--- a/prod/src/economy/energyBuffer.ts
+++ b/prod/src/economy/energyBuffer.ts
@@ -227,7 +227,7 @@ function getNonCrisisEnergyBufferCapacityCap(energyCapacityAvailable: number): n
   );
 }
 
-function getConstructionSpendingEnergyThreshold(room: Room): number {
+export function getConstructionSpendingEnergyThreshold(room: Room): number {
   return Math.min(
     getEffectiveRoomEnergyBufferThreshold(room),
     CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -35,6 +35,7 @@ import {
   checkEnergyBufferForConstructionSpending,
   checkEnergyBufferForExtensionConstruction,
   getEffectiveRoomEnergyBufferThreshold,
+  getConstructionSpendingEnergyThreshold,
   getStorageEnergyAvailableForWithdrawal,
   getStorageEnergyReserveThreshold,
   hasMinimumWorkerSpawnEnergyForConstruction,
@@ -4315,7 +4316,7 @@ function getSpawnConstructionEnergyAvailableForWithdrawal(
   const constructionBudget = Math.max(
     0,
     roomEnergyAvailable -
-      getEffectiveRoomEnergyBufferThreshold(creep.room) -
+      getConstructionSpendingEnergyThreshold(creep.room) -
       reservationContext.constructionEnergyWithdrawn
   );
   return Math.min(projectedSourceEnergy, constructionBudget, spawnReservationBudget);

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -124,6 +124,75 @@ describe('runWorker', () => {
     expect(withdraw).toHaveBeenCalledWith(spawn, RESOURCE_ENERGY, 50);
   });
 
+  it('withdraws only construction-safe spawn energy below the W3N9 bootstrap buffer margin', () => {
+    const site = withRangeTo(
+      { id: 'extension-site1', structureType: 'extension' } as ConstructionSite,
+      { spawn1: 1 }
+    );
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(323),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      }
+    } as unknown as StructureSpawn;
+    const withdraw = jest.fn().mockReturnValue(0);
+    const room = {
+      name: 'W3N9',
+      energyAvailable: 323,
+      energyCapacityAvailable: 550,
+      controller,
+      find: jest.fn((type: number) => {
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        return type === FIND_STRUCTURES ? [spawn] : [];
+      })
+    } as unknown as Room;
+    const creep = {
+      name: 'Builder',
+      memory: { role: 'worker', colony: 'W3N9' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room,
+      withdraw,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const assessment = assessColonySurvival({
+      roomName: 'W3N9',
+      workerCapacity: 1,
+      workerTarget: 3,
+      hostileCreepCount: 0,
+      energyCapacityAvailable: 550,
+      controller: { my: true, level: 2, ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1 }
+    });
+    expect(assessment.mode).toBe('BOOTSTRAP');
+    recordColonySurvivalAssessment('W3N9', assessment, 966752);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Builder: creep },
+      getObjectById: jest.fn().mockReturnValue(spawn)
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({
+      type: 'withdraw',
+      targetId: 'spawn1',
+      constructionSiteId: 'extension-site1'
+    });
+    expect(withdraw).toHaveBeenCalledWith(spawn, RESOURCE_ENERGY, 23);
+  });
+
   it('signs an owned controller when controller management reports a missing signature', () => {
     const controller = {
       id: 'controller1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -10546,6 +10546,54 @@ describe('selectWorkerTask', () => {
     });
   });
 
+  it('uses safe W3N9 construction energy below the bootstrap buffer margin', () => {
+    const site = withRangeTo(
+      { id: 'extension-site1', structureType: 'extension' } as ConstructionSite,
+      { spawn1: 1 }
+    );
+    const spawn = makeEnergySinkWithEnergy('spawn1', 'spawn' as StructureConstant, 323, 0);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'W3N9',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 323,
+      energyCapacityAvailable: 550,
+      structures: [spawn as AnyStructure]
+    });
+    const creep = {
+      name: 'Builder',
+      memory: { role: 'worker', colony: 'W3N9' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+    const assessment = assessColonySurvival({
+      roomName: 'W3N9',
+      workerCapacity: 1,
+      workerTarget: 3,
+      hostileCreepCount: 0,
+      energyCapacityAvailable: 550,
+      controller: { my: true, level: 2, ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1 }
+    });
+    expect(assessment.mode).toBe('BOOTSTRAP');
+    recordColonySurvivalAssessment('W3N9', assessment, 966752);
+    setGameCreeps({ Builder: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({
+      type: 'withdraw',
+      targetId: 'spawn1',
+      constructionSiteId: 'extension-site1'
+    });
+  });
+
   it('allows carried construction energy when room energy stays above the construction floor', () => {
     const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0);
     const site = { id: 'road-site1', structureType: 'road' } as ConstructionSite;


### PR DESCRIPTION
## Summary
- lets W3N9/RCL2 construction draw only the construction-safe portion of spawn energy below the bootstrap buffer margin
- uses the existing construction-spending floor for both task selection and worker execution instead of treating the full effective energy buffer as an absolute construction-withdraw block
- adds regression coverage for the observed post-deploy state: 323/550 energy, construction backlog, and no hostile emergency

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (95 suites, 1798 tests)
- `cd prod && npm run build`

Fixes #1040

Post-deploy acceptance remains tracked by #1026/#1005/#1041: after merge/deploy, verify fresh runtime windows show `taskCounts.build>0`, `buildCarriedEnergy>0`, and pending build progress decreasing without sustained `worker_assignment_gap`.
