### PR TITLE
fix(rl): recover simulator workers after broken pipe

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -82,6 +82,8 @@ RUN_PORT_SCAN_ATTEMPTS = 2048
 RUN_TICK_TIMEOUT_SECONDS = 300
 RUN_TICK_POLL_SECONDS = 0.20
 RUN_WORKER_PREFIX = "rl-sim-worker"
+RUN_BROKEN_PIPE_MAX_RETRIES = 1
+RUN_BROKEN_PIPE_RETRY_BACKOFF_SECONDS = 2.0
 RUN_ID_PREFIX = "rl-sim-run"
 RUN_ID_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 RUN_RESOURCE_GUARD_ALLOW_UNSAFE_ENV = "SCREEPS_RL_SIM_ALLOW_UNSAFE_SCALE"
@@ -375,6 +377,20 @@ def _safe_text(value: Any, max_len: int = 320) -> str:
     return text[:max_len]
 
 
+def _text_mentions_broken_pipe(value: Any) -> bool:
+    text = str(value).lower()
+    return "broken pipe" in text or "errno 32" in text
+
+
+def _variant_result_mentions_broken_pipe(result: JsonObject) -> bool:
+    if _text_mentions_broken_pipe(result.get("error")):
+        return True
+    errors = result.get("errors")
+    if isinstance(errors, list):
+        return any(_text_mentions_broken_pipe(error) for error in errors)
+    return False
+
+
 def _safe_filename(value: str) -> str:
     safe = re.sub(r"[^A-Za-z0-9._-]", "-", value)
     safe = re.sub(r"-+", "-", safe).strip("-.")
@@ -424,10 +440,20 @@ def _run_worker_project_prefix(run_id: str) -> str:
     return sentinel_project
 
 
-def _matching_run_worker_container_names(run_id: str, container_names: Sequence[str]) -> list[str]:
+def _matching_run_worker_container_names(
+    run_id: str,
+    container_names: Sequence[str],
+    *,
+    worker_index: int | None = None,
+) -> list[str]:
     """Return only Docker container names owned by this simulator run id."""
     prefix = f"{_run_worker_project_prefix(run_id)}-"
-    worker_container_pattern = re.compile(rf"^{re.escape(prefix)}\d{{2,}}-")
+    if worker_index is None:
+        worker_container_pattern = re.compile(rf"^{re.escape(prefix)}\d{{2,}}-")
+    else:
+        if worker_index < 0:
+            return []
+        worker_container_pattern = re.compile(rf"^{re.escape(prefix)}{worker_index:02d}-")
     matches = []
     for raw_name in container_names:
         name = raw_name.lstrip("/")
@@ -2625,6 +2651,40 @@ def _run_worker_assignments(
     return buckets
 
 
+def _broken_pipe_retry_run_id(run_id: str, attempt: int) -> str:
+    return run_id if attempt == 0 else f"{run_id}-bp-retry-{attempt}"
+
+
+def _broken_pipe_retry_host_port_start(host_port_start: int, worker_count: int, attempt: int) -> int:
+    if worker_count <= 0:
+        raise RuntimeError("worker count must be a positive integer")
+    retry_host_port_start = host_port_start + (attempt * worker_count * RUN_HTTP_PORT_STEP)
+    last_cli_port = retry_host_port_start + ((worker_count - 1) * RUN_HTTP_PORT_STEP) + 1
+    if last_cli_port > 65535:
+        raise RuntimeError(f"simulator retry host port range exceeds TCP port limit: {last_cli_port}")
+    return retry_host_port_start
+
+
+def _annotate_broken_pipe_recovery(
+    result: JsonObject,
+    *,
+    retry_errors: Sequence[str],
+    attempts: int,
+) -> JsonObject:
+    if not retry_errors:
+        return result
+    result["brokenPipeRecovery"] = {
+        "triggered": True,
+        "attempts": attempts,
+        "maxRetries": RUN_BROKEN_PIPE_MAX_RETRIES,
+        "recovered": result.get("ok") is True,
+        "errors": list(retry_errors),
+    }
+    if result.get("ok") is True:
+        result["recoveredErrors"] = list(retry_errors)
+    return result
+
+
 def run_variants(
     *,
     variants: Sequence[str],
@@ -2661,14 +2721,24 @@ def run_variants(
         results: list[JsonObject] = []
         for variant_id in assigned_variants:
             variant_start = time.time()
+            retry_errors: list[str] = []
             try:
-                results.append(
-                    _run_variant(
+                result: JsonObject | None = None
+                attempts_made = 0
+                for attempt in range(RUN_BROKEN_PIPE_MAX_RETRIES + 1):
+                    attempts_made = attempt + 1
+                    attempt_run_id = _broken_pipe_retry_run_id(run_id, attempt)
+                    attempt_host_port_start = _broken_pipe_retry_host_port_start(
+                        host_port_start,
+                        normalized_workers,
+                        attempt,
+                    )
+                    result = _run_variant(
                         worker_index=worker_id,
                         variant_id=variant_id,
-                        run_id=run_id,
+                        run_id=attempt_run_id,
                         worker_count=normalized_workers,
-                        host_port_start=host_port_start,
+                        host_port_start=attempt_host_port_start,
                         ticks=ticks,
                         room=room,
                         shard=shard,
@@ -2676,6 +2746,20 @@ def run_variants(
                         code_path=code_path,
                         map_source_file=map_source_file,
                         out_dir=out_dir,
+                    )
+                    if result.get("ok") is True or not _variant_result_mentions_broken_pipe(result):
+                        break
+                    retry_errors.append(_safe_text(result.get("error") or result.get("errors"), 480))
+                    cleanup_exact_run_worker_containers(attempt_run_id, worker_index=worker_id)
+                    if attempt < RUN_BROKEN_PIPE_MAX_RETRIES:
+                        time.sleep(RUN_BROKEN_PIPE_RETRY_BACKOFF_SECONDS)
+                if result is None:
+                    raise RuntimeError("worker did not produce a variant result")
+                results.append(
+                    _annotate_broken_pipe_recovery(
+                        result,
+                        retry_errors=retry_errors,
+                        attempts=attempts_made,
                     )
                 )
             except Exception as exc:  # noqa: BLE001 - keep one result row per requested variant
@@ -3626,6 +3710,7 @@ def run_self_test(stdout: TextIO = sys.stdout) -> int:
 def cleanup_exact_run_worker_containers(
     run_id: str,
     *,
+    worker_index: int | None = None,
     container_names: Sequence[str] | None = None,
     docker_binary: str | None = None,
     runner: Any | None = None,
@@ -3634,7 +3719,7 @@ def cleanup_exact_run_worker_containers(
     names_error: str | None = None
     if container_names is None:
         container_names, names_error = _docker_container_names(all_containers=True, docker_binary=docker_binary)
-    matched = _matching_run_worker_container_names(run_id, container_names)
+    matched = _matching_run_worker_container_names(run_id, container_names, worker_index=worker_index)
     docker = docker_binary or _docker_binary_for_guard()
     errors: list[str] = []
     command_summary: list[str] | None = None
@@ -3672,7 +3757,12 @@ def cleanup_exact_run_worker_containers(
     return {
         "ok": not errors,
         "runId": run_id,
-        "targetNamePrefix": f"{_run_worker_project_prefix(run_id)}-",
+        "workerIndex": worker_index,
+        "targetNamePrefix": (
+            f"{_run_worker_project_prefix(run_id)}-{worker_index:02d}-"
+            if worker_index is not None and worker_index >= 0
+            else f"{_run_worker_project_prefix(run_id)}-"
+        ),
         "matchedContainers": matched,
         "removedContainers": matched if matched and not errors else [],
         "command": command_summary,

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -586,10 +586,13 @@ def simulator_repetition_host_port_start(base_host_port_start: int, repetition_i
         raise ValueError("repetition_index must be non-negative")
     if effective_workers <= 0:
         raise ValueError("effective_workers must be a positive integer")
+    attempts_per_run = 1 + simulator_harness.RUN_BROKEN_PIPE_MAX_RETRIES
     host_port_start = base_host_port_start + (
-        repetition_index * effective_workers * simulator_harness.RUN_HTTP_PORT_STEP
+        repetition_index * effective_workers * simulator_harness.RUN_HTTP_PORT_STEP * attempts_per_run
     )
-    last_cli_port = host_port_start + ((effective_workers - 1) * simulator_harness.RUN_HTTP_PORT_STEP) + 1
+    last_cli_port = (
+        host_port_start + (effective_workers * simulator_harness.RUN_HTTP_PORT_STEP * attempts_per_run) - 1
+    )
     if last_cli_port > 65535:
         raise RuntimeError(f"simulator repetition host port range exceeds TCP port limit: {last_cli_port}")
     return host_port_start

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -71,6 +71,7 @@ class SimulationConfig:
     ticks: int
     workers: int
     repetitions: int
+    host_port_start: int
     room: str
     shard: str
     branch: str
@@ -83,6 +84,7 @@ class SimulationConfig:
             "ticks": self.ticks,
             "workers": self.workers,
             "repetitions": self.repetitions,
+            "hostPortStart": self.host_port_start,
             "room": self.room,
             "shard": self.shard,
             "branch": self.branch,
@@ -181,6 +183,11 @@ def validate_experiment_card(card: JsonObject) -> None:
         raise TrainingCardError("simulation.workers must be a positive integer")
     if "repetitions" in simulation and positive_int_value(simulation["repetitions"]) is None:
         raise TrainingCardError("simulation.repetitions must be a positive integer")
+    if (
+        ("host_port_start" in simulation or "hostPortStart" in simulation)
+        and positive_int_value(simulation.get("host_port_start", simulation.get("hostPortStart"))) is None
+    ):
+        raise TrainingCardError("simulation.host_port_start must be a positive integer")
 
 
 def raw_variant_definitions(card: JsonObject) -> Any:
@@ -419,6 +426,10 @@ def simulation_config_from_card(card: JsonObject) -> SimulationConfig:
         ticks=positive_int_value(simulation.get("ticks")) or simulator_harness.DEFAULT_RUN_TICKS,
         workers=positive_int_value(simulation.get("workers")) or simulator_harness.DEFAULT_RUN_WORKERS,
         repetitions=positive_int_value(simulation.get("repetitions")) or DEFAULT_RUN_REPETITIONS,
+        host_port_start=positive_int_value(
+            simulation.get("host_port_start", simulation.get("hostPortStart"))
+        )
+        or simulator_harness.resolve_run_host_port_start(None),
         room=text_or_none(simulation.get("room")) or simulator_harness.DEFAULT_SIM_ROOM,
         shard=text_or_none(simulation.get("shard")) or simulator_harness.DEFAULT_SIM_SHARD,
         branch=text_or_none(simulation.get("branch")) or simulator_harness.DEFAULT_ACTIVE_WORLD_BRANCH,
@@ -544,8 +555,14 @@ def execute_simulator_runs(
     raw_run_id = text_or_none(card.get("run_id")) or text_or_none(card.get("runId")) or report_id
     base_run_id = normalize_simulator_run_id(raw_run_id)
     runs: list[JsonObject] = []
+    effective_workers = max(1, min(config.workers, len(variant_ids)))
     for repetition in range(config.repetitions):
         run_id = base_run_id if config.repetitions == 1 else f"{base_run_id}-r{repetition + 1:02d}"
+        host_port_start = simulator_repetition_host_port_start(
+            config.host_port_start,
+            repetition,
+            effective_workers,
+        )
         runs.append(
             simulator_runner(
                 ticks=config.ticks,
@@ -553,6 +570,7 @@ def execute_simulator_runs(
                 variants=variant_ids,
                 out_dir=config.simulator_out_dir,
                 run_id=run_id,
+                host_port_start=host_port_start,
                 room=config.room,
                 shard=config.shard,
                 branch=config.branch,
@@ -561,6 +579,20 @@ def execute_simulator_runs(
             )
         )
     return runs
+
+
+def simulator_repetition_host_port_start(base_host_port_start: int, repetition_index: int, effective_workers: int) -> int:
+    if repetition_index < 0:
+        raise ValueError("repetition_index must be non-negative")
+    if effective_workers <= 0:
+        raise ValueError("effective_workers must be a positive integer")
+    host_port_start = base_host_port_start + (
+        repetition_index * effective_workers * simulator_harness.RUN_HTTP_PORT_STEP
+    )
+    last_cli_port = host_port_start + ((effective_workers - 1) * simulator_harness.RUN_HTTP_PORT_STEP) + 1
+    if last_cli_port > 65535:
+        raise RuntimeError(f"simulator repetition host port range exceeds TCP port limit: {last_cli_port}")
+    return host_port_start
 
 
 def normalize_simulator_run_id(raw: str) -> str:

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1589,6 +1589,61 @@ cli:
         self.assertEqual([item["variant_id"] for item in results], ["a", "b"])
         self.assertEqual(artifact["wallClockSeconds"], 1.25)
 
+    def test_run_variants_retries_broken_pipe_with_fresh_worker_lifecycle(self) -> None:
+        calls: list[dict[str, object]] = []
+
+        def fake_run_variant(worker_index: int, variant_id: str, **kwargs: object) -> dict[str, object]:
+            calls.append({"worker_index": worker_index, "variant_id": variant_id, **kwargs})
+            if len(calls) == 1:
+                return {
+                    "variant_id": variant_id,
+                    "worker_id": worker_index,
+                    "variant_run_id": f"{kwargs['run_id']}-{variant_id}",
+                    "ticks_run": 0,
+                    "wall_clock_seconds": 0.1,
+                    "tick_log": [],
+                    "ok": False,
+                    "error": "[Errno 32] Broken pipe",
+                    "errors": ["[Errno 32] Broken pipe"],
+                }
+            return {
+                "variant_id": variant_id,
+                "worker_id": worker_index,
+                "variant_run_id": f"{kwargs['run_id']}-{variant_id}",
+                "ticks_run": 1,
+                "wall_clock_seconds": 0.2,
+                "tick_log": [{"tick": 1}],
+                "ok": True,
+            }
+
+        with mock.patch("screeps_rl_simulator_harness._run_variant", side_effect=fake_run_variant):
+            with mock.patch("screeps_rl_simulator_harness.cleanup_exact_run_worker_containers") as cleanup:
+                with mock.patch("screeps_rl_simulator_harness.time.sleep") as sleep:
+                    artifact, results = harness.run_variants(
+                        variants=["baseline"],
+                        ticks=1,
+                        workers=1,
+                        host_port_start=24125,
+                        room="E1S1",
+                        shard="shardX",
+                        branch="activeWorld",
+                        code_path=Path("main.js"),
+                        map_source_file=Path("map.json"),
+                        out_dir=Path("out"),
+                        run_id="bp-run",
+                        bot_commit="0" * 40,
+                    )
+
+        self.assertEqual([call["run_id"] for call in calls], ["bp-run", "bp-run-bp-retry-1"])
+        self.assertEqual([call["host_port_start"] for call in calls], [24125, 24127])
+        cleanup.assert_called_once_with("bp-run", worker_index=0)
+        sleep.assert_called_once_with(harness.RUN_BROKEN_PIPE_RETRY_BACKOFF_SECONDS)
+        self.assertTrue(results[0]["ok"])
+        self.assertTrue(results[0]["brokenPipeRecovery"]["recovered"])
+        self.assertEqual(results[0]["brokenPipeRecovery"]["attempts"], 2)
+        self.assertEqual(artifact["successful"], 1)
+        self.assertEqual(artifact["failed"], 0)
+
     def test_run_simulator_writes_schema_validated_and_redacted_artifact(self) -> None:
         mock_variant = {
             "variant_id": "baseline",
@@ -1897,6 +1952,55 @@ cli:
                     "-f",
                     "rl-sim-worker-run-1-00-screeps-1",
                     "rl-sim-worker-run-1-01-mongo-1",
+                ]
+            ],
+        )
+
+    def test_exact_run_cleanup_can_target_one_worker_index(self) -> None:
+        commands: list[list[str]] = []
+
+        class Result:
+            returncode = 0
+            stdout = "removed\n"
+            stderr = ""
+
+        def fake_runner(command: list[str], **kwargs: object) -> Result:
+            _ = kwargs
+            commands.append(command)
+            return Result()
+
+        cleanup = harness.cleanup_exact_run_worker_containers(
+            "run-1",
+            worker_index=1,
+            container_names=[
+                "rl-sim-worker-run-1-00-screeps-1",
+                "/rl-sim-worker-run-1-01-mongo-1",
+                "rl-sim-worker-run-1-01-redis-1",
+                "rl-sim-worker-run-10-01-screeps-1",
+            ],
+            docker_binary="/usr/bin/docker",
+            runner=fake_runner,
+        )
+
+        self.assertTrue(cleanup["ok"])
+        self.assertEqual(cleanup["workerIndex"], 1)
+        self.assertEqual(cleanup["targetNamePrefix"], "rl-sim-worker-run-1-01-")
+        self.assertEqual(
+            cleanup["matchedContainers"],
+            [
+                "rl-sim-worker-run-1-01-mongo-1",
+                "rl-sim-worker-run-1-01-redis-1",
+            ],
+        )
+        self.assertEqual(
+            commands,
+            [
+                [
+                    "/usr/bin/docker",
+                    "rm",
+                    "-f",
+                    "rl-sim-worker-run-1-01-mongo-1",
+                    "rl-sim-worker-run-1-01-redis-1",
                 ]
             ],
         )

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -460,6 +460,30 @@ export const STRATEGY_REGISTRY = [
 
         self.assertEqual(simulator.calls[0]["run_id"], "rl_exp_with_dots")
 
+    def test_repetitions_use_disjoint_run_ids_and_host_port_ranges(self) -> None:
+        start = tick(1, [room("W1N1", energy=100)])
+        baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200)])])
+        candidate = variant_result("candidate", [start, tick(2, [room("W1N1", energy=250)])])
+        simulator = MockSimulator({"baseline": baseline, "candidate": candidate})
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            card = base_card()
+            card["simulation"]["workers"] = 2
+            card["simulation"]["repetitions"] = 3
+            card["simulation"]["host_port_start"] = 24125
+            write_json(card_path, card)
+            runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="multi-rep-ports",
+                simulator_runner=simulator,
+            )
+
+        self.assertEqual([call["run_id"] for call in simulator.calls], ["multi-rep-ports-r01", "multi-rep-ports-r02", "multi-rep-ports-r03"])
+        self.assertEqual([call["host_port_start"] for call in simulator.calls], [24125, 24129, 24133])
+
     def test_unsafe_simulator_flags_fail_before_report_is_persisted(self) -> None:
         start = tick(1, [room("W1N1", energy=100)])
         baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200)])])

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -482,7 +482,17 @@ export const STRATEGY_REGISTRY = [
             )
 
         self.assertEqual([call["run_id"] for call in simulator.calls], ["multi-rep-ports-r01", "multi-rep-ports-r02", "multi-rep-ports-r03"])
-        self.assertEqual([call["host_port_start"] for call in simulator.calls], [24125, 24129, 24133])
+        self.assertEqual([call["host_port_start"] for call in simulator.calls], [24125, 24133, 24141])
+        attempts_per_run = 1 + runner.simulator_harness.RUN_BROKEN_PIPE_MAX_RETRIES
+        repetition_port_width = 2 * runner.simulator_harness.RUN_HTTP_PORT_STEP * attempts_per_run
+        reserved_ports_by_repetition = [
+            set(range(call["host_port_start"], call["host_port_start"] + repetition_port_width))
+            for call in simulator.calls
+        ]
+        self.assertEqual([max(ports) for ports in reserved_ports_by_repetition], [24132, 24140, 24148])
+        for left_index, left_ports in enumerate(reserved_ports_by_repetition):
+            for right_ports in reserved_ports_by_repetition[left_index + 1 :]:
+                self.assertTrue(left_ports.isdisjoint(right_ports))
 
     def test_unsafe_simulator_flags_fail_before_report_is_persisted(self) -> None:
         start = tick(1, [room("W1N1", energy=100)])


### PR DESCRIPTION
## Summary
- Recover RL simulator variant runs after `[Errno 32] Broken pipe` by cleaning the exact failed worker and retrying on a fresh run/port lane.
- Give multi-repetition training runs disjoint run IDs and HTTP port ranges so repeated simulator executions do not collide.
- Add regression coverage for BrokenPipe recovery, per-worker cleanup targeting, and multi-repetition port allocation.

## Verification
- `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py`
- `python3 scripts/test_screeps_rl_simulator_harness.py`
- `python3 scripts/test_screeps_rl_training_runner.py`

Closes #1059.
