### PR TITLE
feat(scouting): refresh W3N9 adjacent expansion intel

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3401,6 +3401,49 @@ function isRecord3(value) {
   return typeof value === "object" && value !== null;
 }
 
+// src/territory/expansionConfig.ts
+var TERRITORY_EXPANSION_SCOUT_TARGETS = [
+  {
+    colony: "W3N9",
+    roomName: "W3N8",
+    nearestOwnedRoom: "W3N9",
+    nearestOwnedRoomDistance: 1,
+    routeDistance: 1,
+    adjacentToOwnedRoom: true,
+    scoutOnly: true
+  },
+  {
+    colony: "W3N9",
+    roomName: "W2N9",
+    nearestOwnedRoom: "W3N9",
+    nearestOwnedRoomDistance: 1,
+    routeDistance: 1,
+    adjacentToOwnedRoom: true,
+    scoutOnly: true
+  },
+  {
+    colony: "E17S59",
+    roomName: "E18S59",
+    nearestOwnedRoom: "E17S59",
+    nearestOwnedRoomDistance: 1,
+    routeDistance: 1,
+    adjacentToOwnedRoom: true
+  },
+  {
+    colony: "E17S59",
+    roomName: "E17S60",
+    nearestOwnedRoom: "E17S58",
+    nearestOwnedRoomDistance: 1,
+    routeDistance: 2,
+    adjacentToOwnedRoom: true
+  }
+];
+function isConfiguredExpansionScoutOnlyTarget(colony, roomName) {
+  return TERRITORY_EXPANSION_SCOUT_TARGETS.some(
+    (target) => target.colony === colony && target.roomName === roomName && target.scoutOnly === true
+  );
+}
+
 // src/territory/autoClaim.ts
 var GLOBAL_AUTO_CLAIM_MIN_RCL = globalThis.TERRITORY_AUTO_CLAIM_MIN_RCL;
 var GLOBAL_AUTO_CLAIM_RESERVATION_MIN_TICKS = globalThis.TERRITORY_AUTO_CLAIM_RESERVATION_MIN_TICKS;
@@ -4252,26 +4295,6 @@ function isNonEmptyString4(value) {
 function isRecord5(value) {
   return typeof value === "object" && value !== null;
 }
-
-// src/territory/expansionConfig.ts
-var TERRITORY_EXPANSION_SCOUT_TARGETS = [
-  {
-    colony: "E17S59",
-    roomName: "E18S59",
-    nearestOwnedRoom: "E17S59",
-    nearestOwnedRoomDistance: 1,
-    routeDistance: 1,
-    adjacentToOwnedRoom: true
-  },
-  {
-    colony: "E17S59",
-    roomName: "E17S60",
-    nearestOwnedRoom: "E17S58",
-    nearestOwnedRoomDistance: 1,
-    routeDistance: 2,
-    adjacentToOwnedRoom: true
-  }
-];
 
 // src/territory/roomScouting.ts
 var EXIT_DIRECTION_ORDER = ["1", "3", "5", "7"];
@@ -5301,6 +5324,7 @@ function buildRuntimeExpansionCandidates(colony) {
         ...routeDistance !== void 0 ? { routeDistance } : {},
         ...nearestOwnedDistance.roomName ? { nearestOwnedRoom: nearestOwnedDistance.roomName } : {},
         ...nearestOwnedDistance.distance !== void 0 ? { nearestOwnedRoomDistance: nearestOwnedDistance.distance } : {},
+        ...(configuredScoutTarget == null ? void 0 : configuredScoutTarget.scoutOnly) === true ? { scoutOnly: true } : {},
         ...room ? buildVisibleExpansionCandidateEvidence(room) : scoutIntel ? buildScoutedExpansionCandidateEvidence(scoutIntel) : buildUnseenExpansionCandidateEvidence(roomName, gameTime)
       }
     ];
@@ -5543,7 +5567,8 @@ function scoreExpansionCandidate(input, candidate) {
     ...candidate.hostileCreepCount !== void 0 ? { hostileCreepCount: candidate.hostileCreepCount } : {},
     ...candidate.hostileStructureCount !== void 0 ? { hostileStructureCount: candidate.hostileStructureCount } : {},
     ...reservation ? { reservation } : {},
-    ...requiresControllerPressure ? { requiresControllerPressure: true } : {}
+    ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
+    ...candidate.scoutOnly === true ? { scoutOnly: true } : {}
   };
 }
 function calculateExpansionScore(input, candidate, evidenceStatus, synergyScore = 0) {
@@ -5767,6 +5792,7 @@ function toPersistedExpansionCandidateMemory(colony, candidate, gameTime, rank) 
     visible: candidate.visible,
     updatedAt: gameTime,
     adjacentToOwnedRoom: candidate.adjacentToOwnedRoom,
+    ...candidate.scoutOnly === true ? { scoutOnly: true } : {},
     ...recommendedAction ? { recommendedAction } : {},
     ...candidate.routeDistance !== void 0 ? { routeDistance: candidate.routeDistance } : {},
     ...candidate.nearestOwnedRoom ? { nearestOwnedRoom: candidate.nearestOwnedRoom } : {},
@@ -5786,6 +5812,9 @@ function toPersistedExpansionCandidateMemory(colony, candidate, gameTime, rank) 
   };
 }
 function getPersistedExpansionCandidateRecommendedAction(candidate) {
+  if (candidate.scoutOnly === true) {
+    return candidate.evidenceStatus === "unavailable" ? void 0 : "scout";
+  }
   if (isViableExpansionCandidate(candidate)) {
     return "claim";
   }
@@ -6303,7 +6332,7 @@ function buildRuntimeExpansionPlannerCandidates(colony) {
   let order = 0;
   for (const ownedRoomName of ownedRoomNames) {
     for (const adjacentRoomName of getAdjacentRoomNames3(ownedRoomName)) {
-      if (ownedRoomNames.has(adjacentRoomName)) {
+      if (ownedRoomNames.has(adjacentRoomName) || isConfiguredExpansionScoutOnlyTarget(colonyName, adjacentRoomName)) {
         continue;
       }
       const room = rooms[adjacentRoomName];
@@ -11795,6 +11824,9 @@ function buildRuntimeOccupationCandidates(colonyName) {
     }
   }
   for (const roomName of getAdjacentRoomNames4(colonyName)) {
+    if (isConfiguredExpansionScoutOnlyTarget(colonyName, roomName)) {
+      continue;
+    }
     const cachedRouteDistance = getCachedRouteDistance(colonyName, roomName);
     const routeDistance = cachedRouteDistance === void 0 ? 1 : cachedRouteDistance;
     upsertOccupationCandidate(candidatesByRoom, {
@@ -14162,7 +14194,7 @@ function selectExpansionTriggerCandidate(colony, report, territoryMemory, gameTi
 function findExpansionTriggerCandidate(colony, report, territoryMemory, config) {
   var _a;
   return (_a = report.candidates.find(
-    (scoredCandidate) => scoredCandidate.evidenceStatus !== "unavailable" && scoredCandidate.score >= config.scoreThreshold && scoredCandidate.preconditions.length === 0 && !isClaimPlanBlockedByHigherPriorityColony({
+    (scoredCandidate) => scoredCandidate.evidenceStatus !== "unavailable" && !isConfiguredExpansionScoutOnlyTarget(colony.room.name, scoredCandidate.roomName) && scoredCandidate.score >= config.scoreThreshold && scoredCandidate.preconditions.length === 0 && !isClaimPlanBlockedByHigherPriorityColony({
       colony,
       targetRoom: scoredCandidate.roomName,
       ...scoredCandidate.routeDistance !== void 0 ? { routeDistance: scoredCandidate.routeDistance } : {},
@@ -14228,7 +14260,7 @@ function shouldDirectClaimScoutedPipeline(pipeline) {
 }
 function isConfiguredAdjacentClaimTarget(colony, targetRoom) {
   return TERRITORY_EXPANSION_SCOUT_TARGETS.some(
-    (target) => target.colony === colony && target.roomName === targetRoom && target.adjacentToOwnedRoom === true && target.nearestOwnedRoomDistance <= 1
+    (target) => target.colony === colony && target.roomName === targetRoom && target.scoutOnly !== true && target.adjacentToOwnedRoom === true && target.nearestOwnedRoomDistance <= 1
   );
 }
 function markPipelineClaimed(pipeline, controllerId, gameTime) {
@@ -16284,7 +16316,7 @@ function getAdjacentReserveCandidates(colonyName, originRoomName, colonyOwnerUse
   const existingTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
   return adjacentRooms.flatMap((roomName, order) => {
     const target = { colony: colonyName, roomName, action: "reserve" };
-    if (roomName === colonyName || existingTargetRooms.has(roomName) || isKnownDeadZoneRoom(roomName) || isTerritoryTargetSuppressed(target, intents, gameTime) || isTerritoryRoomSuspendedForColony(intents, colonyName, roomName, gameTime) || isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(intents, colonyName, roomName, "reserve", gameTime)) {
+    if (roomName === colonyName || isConfiguredExpansionScoutOnlyTarget(colonyName, roomName) || existingTargetRooms.has(roomName) || isKnownDeadZoneRoom(roomName) || isTerritoryTargetSuppressed(target, intents, gameTime) || isTerritoryRoomSuspendedForColony(intents, colonyName, roomName, gameTime) || isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(intents, colonyName, roomName, "reserve", gameTime)) {
       return [];
     }
     const candidateState = getAdjacentReserveCandidateState(roomName, colonyOwnerUsername);
@@ -38216,7 +38248,9 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, tel
   var _a, _b, _c;
   const colonyName = colony.room.name;
   const expansionReport = scoreExpansionCandidates(buildAutonomousExpansionScoringInput(colony, report, context));
-  const adjacentCandidates = getRankedAdjacentExpansionCandidates(expansionReport);
+  const adjacentCandidates = getRankedAdjacentExpansionCandidates(expansionReport).filter(
+    (scoredCandidate) => !isConfiguredExpansionScoutOnlyTarget(colonyName, scoredCandidate.roomName)
+  );
   const candidate = (_a = adjacentCandidates.find(
     (scoredCandidate) => !hasBlockingClaimIntentForRoom(scoredCandidate.roomName, context.territoryIntents)
   )) != null ? _a : null;
@@ -40637,7 +40671,7 @@ function selectAdjacentRoomReservationPlan(colony, options = {}) {
   const ownerUsername = getControllerOwnerUsername12(colony.room.controller);
   const expansionPriorities = getPersistedExpansionCandidatePriorities(colonyName);
   const candidates = getAdjacentRoomNames9(colonyName).flatMap(
-    (roomName, order) => buildReservationCandidate(
+    (roomName, order) => isConfiguredExpansionScoutOnlyTarget(colonyName, roomName) ? [] : buildReservationCandidate(
       colony.room,
       roomName,
       order,
@@ -41185,6 +41219,9 @@ function selectColonyExpansionCandidate(colony) {
   const claimedRooms = buildRuntimeClaimedRoomSynergyEvidence(colony.room, ownerUsername);
   const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString34(room.mineralType));
   const candidates = getAdjacentRoomNames10(colony.room.name).flatMap((roomName, order) => {
+    if (isConfiguredExpansionScoutOnlyTarget(colony.room.name, roomName)) {
+      return [];
+    }
     const room = getVisibleRoom18(roomName);
     if (!room && !getScoutIntel3(colony.room.name, roomName)) {
       return [];

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -6332,7 +6332,7 @@ function buildRuntimeExpansionPlannerCandidates(colony) {
   let order = 0;
   for (const ownedRoomName of ownedRoomNames) {
     for (const adjacentRoomName of getAdjacentRoomNames3(ownedRoomName)) {
-      if (ownedRoomNames.has(adjacentRoomName) || isConfiguredExpansionScoutOnlyTarget(colonyName, adjacentRoomName)) {
+      if (isRuntimeExpansionPlannerControlRoomSkipped(colonyName, adjacentRoomName, ownedRoomNames)) {
         continue;
       }
       const room = rooms[adjacentRoomName];
@@ -6353,7 +6353,7 @@ function buildRuntimeExpansionPlannerCandidates(colony) {
     }
   }
   for (const room of Object.values(rooms)) {
-    if (!room || !isNonEmptyString9(room.name) || room.name === colonyName || ownedRoomNames.has(room.name)) {
+    if (!room || !isNonEmptyString9(room.name) || isRuntimeExpansionPlannerControlRoomSkipped(colonyName, room.name, ownedRoomNames)) {
       continue;
     }
     const distance = getNearestOwnedRoomDistance2(ownedRoomNames, room.name);
@@ -7277,6 +7277,9 @@ function toRuntimeExpansionPlannerCandidate(colony, room, distance, order, colon
     ),
     ...suitability
   };
+}
+function isRuntimeExpansionPlannerControlRoomSkipped(colonyName, roomName, ownedRoomNames) {
+  return roomName === colonyName || ownedRoomNames.has(roomName) || isConfiguredExpansionScoutOnlyTarget(colonyName, roomName);
 }
 function compareExpansionPlannerCandidates(left, right) {
   return right.score - left.score || right.sourceCount - left.sourceCount || left.distance - right.distance || getExpansionPlannerCandidateAdjacencyBonus(right) - getExpansionPlannerCandidateAdjacencyBonus(left) || left.order - right.order || left.roomName.localeCompare(right.roomName);

--- a/prod/src/territory/claimExecutor.ts
+++ b/prod/src/territory/claimExecutor.ts
@@ -1,5 +1,6 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
 import { recordClaimedRoomBootstrapStage } from '../colony/colonyStage';
+import { isConfiguredExpansionScoutOnlyTarget } from './expansionConfig';
 import {
   TERRITORY_CONTROLLER_BODY_COST,
   TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS
@@ -439,7 +440,9 @@ function evaluateAutonomousExpansionClaim(
 ): AutonomousExpansionClaimEvaluation {
   const colonyName = colony.room.name;
   const expansionReport = scoreExpansionCandidates(buildAutonomousExpansionScoringInput(colony, report, context));
-  const adjacentCandidates = getRankedAdjacentExpansionCandidates(expansionReport);
+  const adjacentCandidates = getRankedAdjacentExpansionCandidates(expansionReport).filter(
+    (scoredCandidate) => !isConfiguredExpansionScoutOnlyTarget(colonyName, scoredCandidate.roomName)
+  );
   const candidate =
     adjacentCandidates.find(
       (scoredCandidate) => !hasBlockingClaimIntentForRoom(scoredCandidate.roomName, context.territoryIntents)

--- a/prod/src/territory/colonyExpansionPlanner.ts
+++ b/prod/src/territory/colonyExpansionPlanner.ts
@@ -1,5 +1,6 @@
 import type { ColonyStageAssessment } from '../colony/colonyStage';
 import type { ColonySnapshot } from '../colony/colonyRegistry';
+import { isConfiguredExpansionScoutOnlyTarget } from './expansionConfig';
 import {
   CLAIM_SCORE_RESERVED_PENALTY,
   scoreClaimTarget,
@@ -165,6 +166,10 @@ function selectColonyExpansionCandidate(colony: ColonySnapshot): ColonyExpansion
   const claimedRooms = buildRuntimeClaimedRoomSynergyEvidence(colony.room, ownerUsername);
   const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString(room.mineralType));
   const candidates = getAdjacentRoomNames(colony.room.name).flatMap((roomName, order) => {
+    if (isConfiguredExpansionScoutOnlyTarget(colony.room.name, roomName)) {
+      return [];
+    }
+
     const room = getVisibleRoom(roomName);
     if (!room && !getScoutIntel(colony.room.name, roomName)) {
       return [];

--- a/prod/src/territory/expansionConfig.ts
+++ b/prod/src/territory/expansionConfig.ts
@@ -5,10 +5,29 @@ export interface TerritoryExpansionScoutTargetConfig {
   nearestOwnedRoomDistance: number;
   routeDistance: number;
   adjacentToOwnedRoom: boolean;
+  scoutOnly?: boolean;
 }
 
-// Legacy E17S59 corridor targets remain room-scoped; current E19S57 expansion targets need fresh intel before adding static config.
+// Static scout targets are room-scoped so official W3N9 intel refreshes do not retarget old recovery rooms.
 export const TERRITORY_EXPANSION_SCOUT_TARGETS: readonly TerritoryExpansionScoutTargetConfig[] = [
+  {
+    colony: 'W3N9',
+    roomName: 'W3N8',
+    nearestOwnedRoom: 'W3N9',
+    nearestOwnedRoomDistance: 1,
+    routeDistance: 1,
+    adjacentToOwnedRoom: true,
+    scoutOnly: true
+  },
+  {
+    colony: 'W3N9',
+    roomName: 'W2N9',
+    nearestOwnedRoom: 'W3N9',
+    nearestOwnedRoomDistance: 1,
+    routeDistance: 1,
+    adjacentToOwnedRoom: true,
+    scoutOnly: true
+  },
   {
     colony: 'E17S59',
     roomName: 'E18S59',
@@ -26,3 +45,9 @@ export const TERRITORY_EXPANSION_SCOUT_TARGETS: readonly TerritoryExpansionScout
     adjacentToOwnedRoom: true
   }
 ];
+
+export function isConfiguredExpansionScoutOnlyTarget(colony: string, roomName: string): boolean {
+  return TERRITORY_EXPANSION_SCOUT_TARGETS.some(
+    (target) => target.colony === colony && target.roomName === roomName && target.scoutOnly === true
+  );
+}

--- a/prod/src/territory/expansionPlanner.ts
+++ b/prod/src/territory/expansionPlanner.ts
@@ -1,4 +1,5 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
+import { isConfiguredExpansionScoutOnlyTarget } from './expansionConfig';
 import { TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY } from './autoClaim';
 import { maxRoomsForRcl } from './expansionScoring';
 import { normalizeTerritoryIntents } from './territoryMemoryUtils';
@@ -277,7 +278,10 @@ export function buildRuntimeExpansionPlannerCandidates(
 
   for (const ownedRoomName of ownedRoomNames) {
     for (const adjacentRoomName of getAdjacentRoomNames(ownedRoomName)) {
-      if (ownedRoomNames.has(adjacentRoomName)) {
+      if (
+        ownedRoomNames.has(adjacentRoomName) ||
+        isConfiguredExpansionScoutOnlyTarget(colonyName, adjacentRoomName)
+      ) {
         continue;
       }
 

--- a/prod/src/territory/expansionPlanner.ts
+++ b/prod/src/territory/expansionPlanner.ts
@@ -278,10 +278,7 @@ export function buildRuntimeExpansionPlannerCandidates(
 
   for (const ownedRoomName of ownedRoomNames) {
     for (const adjacentRoomName of getAdjacentRoomNames(ownedRoomName)) {
-      if (
-        ownedRoomNames.has(adjacentRoomName) ||
-        isConfiguredExpansionScoutOnlyTarget(colonyName, adjacentRoomName)
-      ) {
+      if (isRuntimeExpansionPlannerControlRoomSkipped(colonyName, adjacentRoomName, ownedRoomNames)) {
         continue;
       }
 
@@ -308,8 +305,7 @@ export function buildRuntimeExpansionPlannerCandidates(
     if (
       !room ||
       !isNonEmptyString(room.name) ||
-      room.name === colonyName ||
-      ownedRoomNames.has(room.name)
+      isRuntimeExpansionPlannerControlRoomSkipped(colonyName, room.name, ownedRoomNames)
     ) {
       continue;
     }
@@ -1655,6 +1651,18 @@ function toRuntimeExpansionPlannerCandidate(
     ),
     ...suitability
   };
+}
+
+function isRuntimeExpansionPlannerControlRoomSkipped(
+  colonyName: string,
+  roomName: string,
+  ownedRoomNames: Set<string>
+): boolean {
+  return (
+    roomName === colonyName ||
+    ownedRoomNames.has(roomName) ||
+    isConfiguredExpansionScoutOnlyTarget(colonyName, roomName)
+  );
 }
 
 function compareExpansionPlannerCandidates(

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -96,6 +96,7 @@ export interface ExpansionCandidateScore {
   hostileStructureCount?: number;
   reservation?: ExpansionReservationEvidence;
   requiresControllerPressure?: boolean;
+  scoutOnly?: boolean;
 }
 
 export interface ExpansionScoringInput {
@@ -135,6 +136,7 @@ export interface ExpansionCandidateInput {
   mineral?: ExpansionMineralEvidence;
   hostileCreepCount?: number;
   hostileStructureCount?: number;
+  scoutOnly?: boolean;
 }
 
 export interface ExpansionMineralEvidence {
@@ -483,6 +485,7 @@ function buildRuntimeExpansionCandidates(colony: ColonySnapshot): ExpansionCandi
         ...(nearestOwnedDistance.distance !== undefined
           ? { nearestOwnedRoomDistance: nearestOwnedDistance.distance }
           : {}),
+        ...(configuredScoutTarget?.scoutOnly === true ? { scoutOnly: true } : {}),
         ...(room
           ? buildVisibleExpansionCandidateEvidence(room)
           : scoutIntel
@@ -803,7 +806,8 @@ function scoreExpansionCandidate(
       ? { hostileStructureCount: candidate.hostileStructureCount }
       : {}),
     ...(reservation ? { reservation } : {}),
-    ...(requiresControllerPressure ? { requiresControllerPressure: true } : {})
+    ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
+    ...(candidate.scoutOnly === true ? { scoutOnly: true } : {})
   };
 }
 
@@ -1189,6 +1193,7 @@ function toPersistedExpansionCandidateMemory(
     visible: candidate.visible,
     updatedAt: gameTime,
     adjacentToOwnedRoom: candidate.adjacentToOwnedRoom,
+    ...(candidate.scoutOnly === true ? { scoutOnly: true } : {}),
     ...(recommendedAction ? { recommendedAction } : {}),
     ...(candidate.routeDistance !== undefined ? { routeDistance: candidate.routeDistance } : {}),
     ...(candidate.nearestOwnedRoom ? { nearestOwnedRoom: candidate.nearestOwnedRoom } : {}),
@@ -1217,6 +1222,10 @@ function toPersistedExpansionCandidateMemory(
 function getPersistedExpansionCandidateRecommendedAction(
   candidate: ExpansionCandidateScore
 ): PersistedExpansionCandidateRecommendedAction | undefined {
+  if (candidate.scoutOnly === true) {
+    return candidate.evidenceStatus === 'unavailable' ? undefined : 'scout';
+  }
+
   if (isViableExpansionCandidate(candidate)) {
     return 'claim';
   }

--- a/prod/src/territory/expansionTrigger.ts
+++ b/prod/src/territory/expansionTrigger.ts
@@ -21,7 +21,10 @@ import {
 } from './scoutIntel';
 import { normalizeTerritoryIntents } from './territoryMemoryUtils';
 import { recordPostClaimBootstrapClaimSuccess } from './postClaimBootstrap';
-import { TERRITORY_EXPANSION_SCOUT_TARGETS } from './expansionConfig';
+import {
+  TERRITORY_EXPANSION_SCOUT_TARGETS,
+  isConfiguredExpansionScoutOnlyTarget
+} from './expansionConfig';
 import { TERRITORY_CONTROLLER_BODY_COST } from '../spawn/bodyTemplates';
 
 const DEFAULT_EXPANSION_TRIGGER_SCORE_THRESHOLD = 700;
@@ -403,6 +406,7 @@ function findExpansionTriggerCandidate(
   return report.candidates.find(
     (scoredCandidate) =>
       scoredCandidate.evidenceStatus !== 'unavailable' &&
+      !isConfiguredExpansionScoutOnlyTarget(colony.room.name, scoredCandidate.roomName) &&
       scoredCandidate.score >= config.scoreThreshold &&
       scoredCandidate.preconditions.length === 0 &&
       !isClaimPlanBlockedByHigherPriorityColony({
@@ -509,6 +513,7 @@ function isConfiguredAdjacentClaimTarget(colony: string, targetRoom: string): bo
     (target) =>
       target.colony === colony &&
       target.roomName === targetRoom &&
+      target.scoutOnly !== true &&
       target.adjacentToOwnedRoom === true &&
       target.nearestOwnedRoomDistance <= 1
   );

--- a/prod/src/territory/occupationRecommendation.ts
+++ b/prod/src/territory/occupationRecommendation.ts
@@ -1,4 +1,5 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
+import { isConfiguredExpansionScoutOnlyTarget } from './expansionConfig';
 import { normalizeTerritoryFollowUp, normalizeTerritoryIntents } from './territoryMemoryUtils';
 
 export type OccupationRecommendationAction = 'occupy' | 'reserve' | 'scout';
@@ -463,6 +464,10 @@ function buildRuntimeOccupationCandidates(colonyName: string): OccupationRecomme
   }
 
   for (const roomName of getAdjacentRoomNames(colonyName)) {
+    if (isConfiguredExpansionScoutOnlyTarget(colonyName, roomName)) {
+      continue;
+    }
+
     const cachedRouteDistance = getCachedRouteDistance(colonyName, roomName);
     const routeDistance = cachedRouteDistance === undefined ? 1 : cachedRouteDistance;
     upsertOccupationCandidate(candidatesByRoom, {

--- a/prod/src/territory/reservationPlanner.ts
+++ b/prod/src/territory/reservationPlanner.ts
@@ -5,6 +5,7 @@ import {
   scoreClaimTarget,
   type ClaimScore
 } from './claimScoring';
+import { isConfiguredExpansionScoutOnlyTarget } from './expansionConfig';
 import { maxRoomsForRcl } from './expansionScoring';
 import { normalizeTerritoryIntents } from './territoryMemoryUtils';
 
@@ -119,14 +120,16 @@ export function selectAdjacentRoomReservationPlan(
   const ownerUsername = getControllerOwnerUsername(colony.room.controller);
   const expansionPriorities = getPersistedExpansionCandidatePriorities(colonyName);
   const candidates = getAdjacentRoomNames(colonyName).flatMap((roomName, order) =>
-    buildReservationCandidate(
-      colony.room,
-      roomName,
-      order,
-      ownerUsername,
-      renewalThresholdTicks,
-      expansionPriorities.get(roomName)
-    )
+    isConfiguredExpansionScoutOnlyTarget(colonyName, roomName)
+      ? []
+      : buildReservationCandidate(
+          colony.room,
+          roomName,
+          order,
+          ownerUsername,
+          renewalThresholdTicks,
+          expansionPriorities.get(roomName)
+        )
   );
   const actionableCandidate = selectBestReservationCandidate(
     candidates.filter((candidate) => candidate.actionable)

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -41,6 +41,7 @@ import {
   isClaimPlanBlockedByHigherPriorityColony,
   pruneLowerPriorityDuplicateClaimPlans
 } from './multiRoomTerritory';
+import { isConfiguredExpansionScoutOnlyTarget } from './expansionConfig';
 
 export const TERRITORY_CLAIMER_ROLE = 'claimer';
 export const TERRITORY_SCOUT_ROLE = 'scout';
@@ -2565,6 +2566,7 @@ function getAdjacentReserveCandidates(
     const target: TerritoryTargetMemory = { colony: colonyName, roomName, action: 'reserve' };
     if (
       roomName === colonyName ||
+      isConfiguredExpansionScoutOnlyTarget(colonyName, roomName) ||
       existingTargetRooms.has(roomName) ||
       isKnownDeadZoneRoom(roomName) ||
       isTerritoryTargetSuppressed(target, intents, gameTime) ||

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -898,6 +898,7 @@ declare global {
     visible: boolean;
     updatedAt: number;
     adjacentToOwnedRoom: boolean;
+    scoutOnly?: boolean;
     recommendedAction?: TerritoryExpansionCandidateRecommendedAction;
     routeDistance?: number;
     nearestOwnedRoom?: string;

--- a/prod/test/expansionExecutor.test.ts
+++ b/prod/test/expansionExecutor.test.ts
@@ -319,6 +319,57 @@ describe('expansion executor', () => {
     ]);
   });
 
+  it('does not convert fresh W3N9 scout-only expansion intel into claim or reserve automation', () => {
+    const colony = makeColony({ roomName: 'W3N9' });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        scoutIntel: {
+          'W3N9>W3N8': makeScoutIntel('W3N9', 'W3N8', 968_700),
+          'W3N9>W2N9': makeScoutIntel('W3N9', 'W2N9', 968_700)
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 968_900,
+      rooms: {
+        W3N9: colony.room
+      },
+      map: {
+        describeExits: jest.fn(() => ({})),
+        findRoute: jest.fn(() => [{ exit: 1, room: 'next' }]),
+        getRoomTerrain: jest.fn(() => makeTerrain(0))
+      } as unknown as GameMap
+    };
+    setSafeHomeThreat('W3N9', 968_900);
+
+    expect(refreshExpansionExecutorIntent(colony, 968_900)).toEqual({
+      status: 'skipped',
+      colony: 'W3N9',
+      reason: 'unavailable'
+    });
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.intents).toBeUndefined();
+    expect(Memory.territory?.expansionPipelines).toEqual({});
+    expect(Memory.territory?.expansionCandidates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          colony: 'W3N9',
+          roomName: 'W3N8',
+          evidenceStatus: 'sufficient',
+          recommendedAction: 'scout',
+          scoutOnly: true
+        }),
+        expect.objectContaining({
+          colony: 'W3N9',
+          roomName: 'W2N9',
+          evidenceStatus: 'sufficient',
+          recommendedAction: 'scout',
+          scoutOnly: true
+        })
+      ])
+    );
+  });
+
   it('skips and clears claim targets when the colony is not ready to bootstrap an expansion', () => {
     const colony = makeColony({ energyAvailable: 650, energyCapacityAvailable: 650 });
     Memory.territory = {
@@ -434,6 +485,38 @@ function makeExpansionRoom(
       return [];
     })
   } as unknown as Room;
+}
+
+function makeScoutIntel(
+  colony: string,
+  roomName: string,
+  updatedAt: number
+): TerritoryScoutIntelMemory {
+  return {
+    colony,
+    roomName,
+    updatedAt,
+    controller: {
+      id: `controller-${roomName}` as Id<StructureController>,
+      my: false
+    },
+    sourceIds: [`source-${roomName}-0`, `source-${roomName}-1`],
+    sourceCount: 2,
+    sourcePositions: [
+      { id: `source-${roomName}-0`, x: 10, y: 20, accessPoints: 8 },
+      { id: `source-${roomName}-1`, x: 20, y: 30, accessPoints: 8 }
+    ],
+    sourceAccessPoints: 8,
+    controllerSourceRange: 12,
+    terrain: {
+      walkableRatio: 1,
+      swampRatio: 0,
+      wallRatio: 0
+    },
+    hostileCreepCount: 0,
+    hostileStructureCount: 0,
+    hostileSpawnCount: 0
+  };
 }
 
 function makeSources(roomName: string, count: number): Source[] {

--- a/prod/test/expansionPlanner.test.ts
+++ b/prod/test/expansionPlanner.test.ts
@@ -10,6 +10,7 @@ import {
   prioritizeExpansionCandidates,
   refreshExpansionPlannerIntent
 } from '../src/territory/expansionPlanner';
+import { refreshConfiguredExpansionRoomScouting } from '../src/territory/roomScouting';
 import { planTerritoryIntent, type TerritoryIntentPlan } from '../src/territory/territoryPlanner';
 
 describe('expansion planner', () => {
@@ -460,6 +461,80 @@ describe('expansion planner', () => {
         controllerId: 'controller-W2N1'
       }
     ]);
+  });
+
+  it('keeps visible W3N9 scout-only rooms out of expansion planner control candidates and intents', () => {
+    const { colony } = makeColony({
+      roomName: 'W3N9',
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300
+    });
+    installGame(colony, {
+      gclLevel: 2,
+      exits: { W3N9: { '1': 'W3N8', '7': 'W2N9' } },
+      rooms: {
+        W3N8: makeExpansionRoom('W3N8'),
+        W2N9: makeExpansionRoom('W2N9')
+      }
+    });
+
+    expect(buildRuntimeExpansionPlannerCandidates(colony)).toEqual([]);
+
+    const plan = refreshExpansionPlannerIntent(colony, 968_900);
+
+    expect(plan).toEqual({
+      status: 'skipped',
+      colony: 'W3N9',
+      reason: 'noCandidate',
+      candidates: []
+    });
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(
+      (Memory.territory?.intents ?? []).filter((intent) => intent.action === 'claim' || intent.action === 'reserve')
+    ).toEqual([]);
+
+    const scouting = refreshConfiguredExpansionRoomScouting(colony, 968_900);
+
+    expect(scouting.records).toEqual([
+      {
+        colony: 'W3N9',
+        roomName: 'W3N8',
+        status: 'observed',
+        updatedAt: 968_900,
+        distance: 1,
+        sourceCount: 2,
+        controllerPresent: true,
+        controllerId: 'controller-W3N8',
+        terrainType: 'unknown'
+      },
+      {
+        colony: 'W3N9',
+        roomName: 'W2N9',
+        status: 'observed',
+        updatedAt: 968_900,
+        distance: 1,
+        sourceCount: 2,
+        controllerPresent: true,
+        controllerId: 'controller-W2N9',
+        terrainType: 'unknown'
+      }
+    ]);
+    expect(Memory.territory?.scoutIntel?.['W3N9>W3N8']).toMatchObject({
+      colony: 'W3N9',
+      roomName: 'W3N8',
+      updatedAt: 968_900,
+      sourceCount: 2
+    });
+    expect(Memory.territory?.scoutIntel?.['W3N9>W2N9']).toMatchObject({
+      colony: 'W3N9',
+      roomName: 'W2N9',
+      updatedAt: 968_900,
+      sourceCount: 2
+    });
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(
+      (Memory.territory?.intents ?? []).filter((intent) => intent.action === 'claim' || intent.action === 'reserve')
+    ).toEqual([]);
   });
 
   it.each([
@@ -1514,13 +1589,15 @@ describe('expansion planner', () => {
 });
 
 function makeColony({
+  roomName = 'W1N1',
   energyAvailable = 650,
   energyCapacityAvailable = 650,
   controllerLevel = 3,
   hostileCreepCount = 0,
   hostileStructureCount = 0,
-  spawns = [makeActiveSpawn('spawn-W1N1')]
+  spawns = [makeActiveSpawn(`spawn-${roomName}`)]
 }: {
+  roomName?: string;
   energyAvailable?: number;
   energyCapacityAvailable?: number;
   controllerLevel?: number;
@@ -1529,11 +1606,11 @@ function makeColony({
   spawns?: StructureSpawn[];
 } = {}): { colony: ColonySnapshot } {
   const room = {
-    name: 'W1N1',
+    name: roomName,
     energyAvailable,
     energyCapacityAvailable,
     controller: {
-      id: 'controller-W1N1' as Id<StructureController>,
+      id: `controller-${roomName}` as Id<StructureController>,
       my: true,
       owner: { username: 'me' },
       level: controllerLevel,
@@ -1541,7 +1618,7 @@ function makeColony({
     } as StructureController,
     find: jest.fn((findType: number): unknown[] => {
       if (findType === FIND_SOURCES) {
-        return [{ id: 'source-W1N1-0' }];
+        return [{ id: `source-${roomName}-0` }];
       }
       if (findType === FIND_HOSTILE_CREEPS) {
         return Array.from({ length: hostileCreepCount }, (_value, index) => ({ id: `home-hostile-${index}` }));

--- a/prod/test/roomScouting.test.ts
+++ b/prod/test/roomScouting.test.ts
@@ -219,6 +219,52 @@ describe('room scouting', () => {
       }
     ]);
   });
+
+  it('requests only scout intents for W3N9 adjacent expansion intel refresh targets', () => {
+    const colony = makeColony('W3N9');
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 968_800,
+      rooms: {
+        W3N9: colony.room
+      }
+    };
+
+    const result = refreshConfiguredExpansionRoomScouting(colony, 968_800);
+
+    expect(result.records).toEqual([
+      {
+        colony: 'W3N9',
+        roomName: 'W3N8',
+        status: 'requested',
+        updatedAt: 968_800,
+        distance: 1
+      },
+      {
+        colony: 'W3N9',
+        roomName: 'W2N9',
+        status: 'requested',
+        updatedAt: 968_800,
+        distance: 1
+      }
+    ]);
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W3N9',
+        targetRoom: 'W3N8',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: 968_800
+      },
+      {
+        colony: 'W3N9',
+        targetRoom: 'W2N9',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: 968_800
+      }
+    ]);
+  });
 });
 
 function makeColony(roomName = 'W1N1'): ColonySnapshot {

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -4658,6 +4658,43 @@ describe('planSpawn', () => {
     ]);
   });
 
+  it('spawns a MOVE-only scout for the W3N9 scout-only W3N8 intel refresh without reserve or claim memory', () => {
+    const { colony, spawn } = makeColony({
+      roomName: 'W3N9',
+      energyAvailable: 450,
+      energyCapacityAvailable: 550,
+      controller: { my: true, level: 2, ticksToDowngrade: 10_000 } as StructureController
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: { W3N9: colony.room }
+    };
+
+    expect(planSpawn(colony, { worker: 6, claimer: 0, claimersByTargetRoom: {} }, 968_801)).toEqual({
+      spawn,
+      body: ['move'],
+      name: 'scout-W3N9-W3N8-968801',
+      memory: {
+        role: 'scout',
+        colony: 'W3N9',
+        territory: {
+          targetRoom: 'W3N8',
+          action: 'scout'
+        }
+      }
+    });
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W3N9',
+        targetRoom: 'W3N8',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: 968_801
+      }
+    ]);
+  });
+
   it('spawns a minimal claimer for E17S58 after scout intel and claim capacity are ready', () => {
     const { colony, spawn } = makeColony({
       roomName: 'E17S59',

--- a/prod/test/territory/expansionConfig.test.ts
+++ b/prod/test/territory/expansionConfig.test.ts
@@ -1,8 +1,26 @@
 import { TERRITORY_EXPANSION_SCOUT_TARGETS } from '../../src/territory/expansionConfig';
 
 describe('territory expansion config', () => {
-  it('keeps the E17S59 expansion scout target configuration complete', () => {
+  it('keeps the W3N9 expansion scout targets scout-only and the legacy E17S59 config complete', () => {
     expect(TERRITORY_EXPANSION_SCOUT_TARGETS).toEqual([
+      {
+        colony: 'W3N9',
+        roomName: 'W3N8',
+        nearestOwnedRoom: 'W3N9',
+        nearestOwnedRoomDistance: 1,
+        routeDistance: 1,
+        adjacentToOwnedRoom: true,
+        scoutOnly: true
+      },
+      {
+        colony: 'W3N9',
+        roomName: 'W2N9',
+        nearestOwnedRoom: 'W3N9',
+        nearestOwnedRoomDistance: 1,
+        routeDistance: 1,
+        adjacentToOwnedRoom: true,
+        scoutOnly: true
+      },
       {
         colony: 'E17S59',
         roomName: 'E18S59',


### PR DESCRIPTION
## Summary
- Adds bounded W3N9 scout-only adjacent expansion targets for W3N8 and W2N9.
- Ensures scout-only intel refresh creates scout intents / MOVE-only scout work but does not claim, reserve, attack, or convert fresh intel into control automation.
- Preserves legacy E17S59 expansion configuration while marking W3N9 scout-only recommendations in scoring/planning surfaces.

## Verification
- `npm run typecheck`
- `npm test -- --runInBand` (95 suites / 1805 tests)
- `npm run build`
- `git diff --check`

Closes #958.
