### PR TITLE
fix(defense): maintain decaying ramparts

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -23150,6 +23150,13 @@ function selectHeuristicWorkerTask(creep) {
   if (constructionSite) {
     return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: constructionSite.id });
   }
+  const routineBarrierMaintenanceTarget = selectRoutineBarrierMaintenanceRepairTarget(creep);
+  if (routineBarrierMaintenanceTarget) {
+    return applyMinimumUsefulLoadPolicy(creep, {
+      type: "repair",
+      targetId: routineBarrierMaintenanceTarget.id
+    });
+  }
   const source2ControllerLaneLoadedTask = controller ? selectSource2ControllerLaneLoadedTask(creep, controller, constructionSites, constructionReservationContext) : null;
   if (source2ControllerLaneLoadedTask) {
     return applyMinimumUsefulLoadPolicy(creep, source2ControllerLaneLoadedTask);
@@ -26563,6 +26570,17 @@ function selectThreatenedBarrierRepairTarget(creep) {
   }
   return repairTargets.sort(compareRepairTargets)[0];
 }
+function selectRoutineBarrierMaintenanceRepairTarget(creep) {
+  var _a;
+  if (((_a = creep.room.controller) == null ? void 0 : _a.my) !== true || hasVisibleHostilePresence2(creep.room) || !checkEnergyBufferForConstructionSpending(creep.room)) {
+    return null;
+  }
+  const repairTargets = findVisibleRoomStructures(creep.room).filter(isRoutineBarrierMaintenanceRepairTarget);
+  if (repairTargets.length === 0) {
+    return null;
+  }
+  return repairTargets.sort(compareRepairTargets)[0];
+}
 function selectCriticalInfrastructureRepairTarget(creep) {
   var _a;
   const visibleStructures = findVisibleRoomStructures(creep.room);
@@ -26631,6 +26649,9 @@ function isSafeRepairTarget(structure) {
   return matchesStructureType18(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure);
 }
 function isThreatenedBarrierRepairTarget(structure) {
+  return isBarrierRepairTarget(structure) && !isWorkerRepairTargetComplete(structure);
+}
+function isRoutineBarrierMaintenanceRepairTarget(structure) {
   return isBarrierRepairTarget(structure) && !isWorkerRepairTargetComplete(structure);
 }
 function isSafeRepairTargetForWorkerRoom(creep, structure) {
@@ -26898,7 +26919,7 @@ function hasNonControllerWorkerEnergyDemand(creep) {
   if (constructionSites.length > 0) {
     return true;
   }
-  return selectCriticalInfrastructureRepairTarget(creep) !== null || selectRepairTarget(creep) !== null;
+  return selectCriticalInfrastructureRepairTarget(creep) !== null || selectRepairTarget(creep) !== null || selectRoutineBarrierMaintenanceRepairTarget(creep) !== null;
 }
 function isControllerUpgradeSaturated(creep, controller) {
   if (controller.my !== true || shouldGuardControllerDowngrade2(controller)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -22810,6 +22810,7 @@ var nearTermSpawnExtensionRefillReserveCache = null;
 var interRoomLiveTransferCandidateCache = null;
 var interRoomHaulReservationCache = null;
 var gameCreepsCache = null;
+var routineBarrierMaintenanceRepairTargetCache = null;
 function selectWorkerTask(creep) {
   clearWorkerEfficiencyTelemetry(creep);
   const heuristicTask = selectHeuristicWorkerTask(creep);
@@ -26571,11 +26572,36 @@ function selectThreatenedBarrierRepairTarget(creep) {
   return repairTargets.sort(compareRepairTargets)[0];
 }
 function selectRoutineBarrierMaintenanceRepairTarget(creep) {
+  return getRoutineBarrierMaintenanceRepairTarget(creep.room);
+}
+function getRoutineBarrierMaintenanceRepairTarget(room) {
+  const gameTick = getGameTick3();
+  const roomName = getRoomName6(room);
+  if (gameTick === null || roomName === null) {
+    return computeRoutineBarrierMaintenanceRepairTarget(room);
+  }
+  const game = getGameReference();
+  if (!routineBarrierMaintenanceRepairTargetCache || routineBarrierMaintenanceRepairTargetCache.tick !== gameTick || routineBarrierMaintenanceRepairTargetCache.game !== game) {
+    routineBarrierMaintenanceRepairTargetCache = {
+      game,
+      roomsByName: /* @__PURE__ */ new Map(),
+      tick: gameTick
+    };
+  }
+  const cachedEntry = routineBarrierMaintenanceRepairTargetCache.roomsByName.get(roomName);
+  if ((cachedEntry == null ? void 0 : cachedEntry.room) === room) {
+    return cachedEntry.target;
+  }
+  const target = computeRoutineBarrierMaintenanceRepairTarget(room);
+  routineBarrierMaintenanceRepairTargetCache.roomsByName.set(roomName, { room, target });
+  return target;
+}
+function computeRoutineBarrierMaintenanceRepairTarget(room) {
   var _a;
-  if (((_a = creep.room.controller) == null ? void 0 : _a.my) !== true || hasVisibleHostilePresence2(creep.room) || !checkEnergyBufferForConstructionSpending(creep.room)) {
+  if (((_a = room.controller) == null ? void 0 : _a.my) !== true || hasVisibleHostilePresence2(room) || !checkEnergyBufferForConstructionSpending(room)) {
     return null;
   }
-  const repairTargets = findVisibleRoomStructures(creep.room).filter(isRoutineBarrierMaintenanceRepairTarget);
+  const repairTargets = findVisibleRoomStructures(room).filter(isRoutineBarrierMaintenanceRepairTarget);
   if (repairTargets.length === 0) {
     return null;
   }

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -695,6 +695,14 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     return applyMinimumUsefulLoadPolicy(creep, { type: 'build', targetId: constructionSite.id });
   }
 
+  const routineBarrierMaintenanceTarget = selectRoutineBarrierMaintenanceRepairTarget(creep);
+  if (routineBarrierMaintenanceTarget) {
+    return applyMinimumUsefulLoadPolicy(creep, {
+      type: 'repair',
+      targetId: routineBarrierMaintenanceTarget.id as Id<Structure>
+    });
+  }
+
   const source2ControllerLaneLoadedTask = controller
     ? selectSource2ControllerLaneLoadedTask(creep, controller, constructionSites, constructionReservationContext)
     : null;
@@ -6119,6 +6127,23 @@ function selectThreatenedBarrierRepairTarget(creep: Creep): StructureRampart | S
   return repairTargets.sort(compareRepairTargets)[0];
 }
 
+function selectRoutineBarrierMaintenanceRepairTarget(creep: Creep): StructureRampart | StructureWall | null {
+  if (
+    creep.room.controller?.my !== true ||
+    hasVisibleHostilePresence(creep.room) ||
+    !checkEnergyBufferForConstructionSpending(creep.room)
+  ) {
+    return null;
+  }
+
+  const repairTargets = findVisibleRoomStructures(creep.room).filter(isRoutineBarrierMaintenanceRepairTarget);
+  if (repairTargets.length === 0) {
+    return null;
+  }
+
+  return repairTargets.sort(compareRepairTargets)[0];
+}
+
 function selectCriticalInfrastructureRepairTarget(creep: Creep): CriticalInfrastructureRepairTarget | null {
   const visibleStructures = findVisibleRoomStructures(creep.room);
   const criticalSpawnRepairTarget = selectCriticalOwnedSpawnRepairTarget(creep, visibleStructures);
@@ -6214,6 +6239,12 @@ function isSafeRepairTarget(structure: AnyStructure): structure is RepairableWor
 }
 
 function isThreatenedBarrierRepairTarget(
+  structure: AnyStructure
+): structure is StructureRampart | StructureWall {
+  return isBarrierRepairTarget(structure) && !isWorkerRepairTargetComplete(structure);
+}
+
+function isRoutineBarrierMaintenanceRepairTarget(
   structure: AnyStructure
 ): structure is StructureRampart | StructureWall {
   return isBarrierRepairTarget(structure) && !isWorkerRepairTargetComplete(structure);
@@ -6644,7 +6675,11 @@ function hasNonControllerWorkerEnergyDemand(creep: Creep): boolean {
     return true;
   }
 
-  return selectCriticalInfrastructureRepairTarget(creep) !== null || selectRepairTarget(creep) !== null;
+  return (
+    selectCriticalInfrastructureRepairTarget(creep) !== null ||
+    selectRepairTarget(creep) !== null ||
+    selectRoutineBarrierMaintenanceRepairTarget(creep) !== null
+  );
 }
 
 function isControllerUpgradeSaturated(creep: Creep, controller: StructureController): boolean {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -234,6 +234,17 @@ interface GameCreepsCache {
   tick: number | null;
 }
 
+interface RoutineBarrierMaintenanceRepairTargetCacheEntry {
+  room: Room;
+  target: StructureRampart | StructureWall | null;
+}
+
+interface RoutineBarrierMaintenanceRepairTargetCache {
+  game: Partial<Game> | undefined;
+  roomsByName: Map<string, RoutineBarrierMaintenanceRepairTargetCacheEntry>;
+  tick: number;
+}
+
 interface ConstructionSiteSelectionOptions {
   priorityContext?: ConstructionSiteImpactPriorityContext | undefined;
   requireReasonableRange?: boolean;
@@ -281,6 +292,7 @@ let nearTermSpawnExtensionRefillReserveCache: NearTermSpawnExtensionRefillReserv
 let interRoomLiveTransferCandidateCache: LiveTransferCandidateCache | null = null;
 let interRoomHaulReservationCache: InterRoomHaulReservationCache | null = null;
 let gameCreepsCache: GameCreepsCache | null = null;
+let routineBarrierMaintenanceRepairTargetCache: RoutineBarrierMaintenanceRepairTargetCache | null = null;
 
 export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   clearWorkerEfficiencyTelemetry(creep);
@@ -6128,15 +6140,49 @@ function selectThreatenedBarrierRepairTarget(creep: Creep): StructureRampart | S
 }
 
 function selectRoutineBarrierMaintenanceRepairTarget(creep: Creep): StructureRampart | StructureWall | null {
+  return getRoutineBarrierMaintenanceRepairTarget(creep.room);
+}
+
+function getRoutineBarrierMaintenanceRepairTarget(room: Room): StructureRampart | StructureWall | null {
+  const gameTick = getGameTick();
+  const roomName = getRoomName(room);
+  if (gameTick === null || roomName === null) {
+    return computeRoutineBarrierMaintenanceRepairTarget(room);
+  }
+
+  const game = getGameReference();
   if (
-    creep.room.controller?.my !== true ||
-    hasVisibleHostilePresence(creep.room) ||
-    !checkEnergyBufferForConstructionSpending(creep.room)
+    !routineBarrierMaintenanceRepairTargetCache ||
+    routineBarrierMaintenanceRepairTargetCache.tick !== gameTick ||
+    routineBarrierMaintenanceRepairTargetCache.game !== game
+  ) {
+    routineBarrierMaintenanceRepairTargetCache = {
+      game,
+      roomsByName: new Map<string, RoutineBarrierMaintenanceRepairTargetCacheEntry>(),
+      tick: gameTick
+    };
+  }
+
+  const cachedEntry = routineBarrierMaintenanceRepairTargetCache.roomsByName.get(roomName);
+  if (cachedEntry?.room === room) {
+    return cachedEntry.target;
+  }
+
+  const target = computeRoutineBarrierMaintenanceRepairTarget(room);
+  routineBarrierMaintenanceRepairTargetCache.roomsByName.set(roomName, { room, target });
+  return target;
+}
+
+function computeRoutineBarrierMaintenanceRepairTarget(room: Room): StructureRampart | StructureWall | null {
+  if (
+    room.controller?.my !== true ||
+    hasVisibleHostilePresence(room) ||
+    !checkEnergyBufferForConstructionSpending(room)
   ) {
     return null;
   }
 
-  const repairTargets = findVisibleRoomStructures(creep.room).filter(isRoutineBarrierMaintenanceRepairTarget);
+  const repairTargets = findVisibleRoomStructures(room).filter(isRoutineBarrierMaintenanceRepairTarget);
   if (repairTargets.length === 0) {
     return null;
   }

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -11827,6 +11827,44 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toBeNull();
   });
 
+  it('lets an empty surplus worker acquire energy for safe barrier maintenance', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const source = makeSource('source1', 20, 20);
+    const wall = makeStructure(
+      'wall-decay',
+      'constructedWall' as StructureConstant,
+      IDLE_RAMPART_REPAIR_HITS_CEILING - 299,
+      300_000_000
+    );
+    const room = makeWorkerTaskRoom({
+      controller,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      sources: [source],
+      structures: [wall]
+    });
+    const creep = {
+      name: 'SurplusWorker',
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({
+      Upgrader: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }),
+      SurplusWorker: creep
+    });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+  });
+
   it('keeps saturated surplus workers hauling container energy to spawn refill', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300, {
       pos: makeRoomPosition(10, 10)
@@ -12945,6 +12983,108 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'rampart-low' });
+  });
+
+  it.each([
+    ['owned rampart', 'rampart' as StructureConstant, { my: true }, 'rampart-decay'],
+    ['constructed wall', 'constructedWall' as StructureConstant, {}, 'wall-decay']
+  ])(
+    'repairs a decaying %s before managed controller upgrade when the room buffer is healthy',
+    (_label, structureType, extra, targetId) => {
+      const controller = {
+        id: 'controller1',
+        my: true,
+        level: 2,
+        ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+      } as StructureController;
+      const barrier = makeStructure(
+        targetId,
+        structureType,
+        IDLE_RAMPART_REPAIR_HITS_CEILING - 299,
+        300_000_000,
+        extra
+      );
+      const room = makeWorkerTaskRoom({
+        controller,
+        energyAvailable: 550,
+        energyCapacityAvailable: 550,
+        structures: [barrier]
+      });
+      const creep = {
+        memory: {
+          role: 'worker',
+          controllerUpgrade: { roomName: 'W1N1', controllerId: 'controller1' }
+        },
+        store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+        room
+      } as unknown as Creep;
+
+      expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId });
+    }
+  );
+
+  it('keeps spawn refill before routine barrier maintenance', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const rampart = makeStructure(
+      'rampart-decay',
+      'rampart' as StructureConstant,
+      IDLE_RAMPART_REPAIR_HITS_CEILING - 299,
+      300_000_000,
+      { my: true }
+    );
+    const creep = {
+      memory: {
+        role: 'worker',
+        controllerUpgrade: { roomName: 'W1N1', controllerId: 'controller1' }
+      },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        controller,
+        energyAvailable: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+        energyCapacityAvailable: 550,
+        myStructures: [spawn as AnyOwnedStructure],
+        structures: [rampart]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+  });
+
+  it('keeps managed controller upgrade when barrier maintenance would spend below the construction floor', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const rampart = makeStructure(
+      'rampart-decay',
+      'rampart' as StructureConstant,
+      IDLE_RAMPART_REPAIR_HITS_CEILING - 299,
+      300_000_000,
+      { my: true }
+    );
+    const creep = {
+      memory: {
+        role: 'worker',
+        controllerUpgrade: { roomName: 'W1N1', controllerId: 'controller1' }
+      },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        controller,
+        energyAvailable: 299,
+        energyCapacityAvailable: 550,
+        structures: [rampart]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
   it('prioritizes barrier repair in threatened rooms before ordinary repair work', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -13056,6 +13056,49 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
   });
 
+  it('reuses the routine barrier maintenance target for workers in the same room tick', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const wall = makeStructure(
+      'wall-decay',
+      'constructedWall' as StructureConstant,
+      IDLE_RAMPART_REPAIR_HITS_CEILING - 299,
+      300_000_000
+    );
+    const room = makeWorkerTaskRoom({
+      controller,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      structures: [wall]
+    });
+    const makeCreep = (name: string): Creep =>
+      ({
+        name,
+        memory: { role: 'worker' },
+        store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+        room
+      }) as unknown as Creep;
+    const firstWorker = makeCreep('FirstWorker');
+    const secondWorker = makeCreep('SecondWorker');
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { FirstWorker: firstWorker, SecondWorker: secondWorker },
+      time: 700
+    };
+    const findMock = room.find as unknown as jest.Mock;
+
+    expect(selectWorkerTask(firstWorker)).toEqual({ type: 'repair', targetId: 'wall-decay' });
+    const firstWorkerStructureFinds = findMock.mock.calls.filter(([type]) => type === FIND_STRUCTURES).length;
+
+    expect(selectWorkerTask(secondWorker)).toEqual({ type: 'repair', targetId: 'wall-decay' });
+    const totalStructureFinds = findMock.mock.calls.filter(([type]) => type === FIND_STRUCTURES).length;
+
+    expect(totalStructureFinds - firstWorkerStructureFinds).toBeLessThan(firstWorkerStructureFinds);
+  });
+
   it('keeps managed controller upgrade when barrier maintenance would spend below the construction floor', () => {
     const controller = {
       id: 'controller1',


### PR DESCRIPTION
## Summary
- Adds routine safe rampart/wall maintenance selection for decaying defense barriers when the room has a healthy energy buffer and no hostile presence.
- Keeps critical spawn/refill/recovery work ahead of routine barrier maintenance.
- Lets surplus workers acquire energy when safe barrier maintenance is the only non-controller demand.
- Regenerates `prod/dist/main.js` from the updated TypeScript source.

## Runtime evidence
- Fresh tactical alert bundle: `/root/screeps/runtime-artifacts/screeps-monitor/scheduler-check-20260515T113548Z/`
- Alert: W3N9 `owned_spawns=1`, `owned_creeps=9`, `hostiles=0`; ramparts at `(31,22)` and `(34,24)` continued decaying.
- GitHub issue: Refs #1001.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 95 suites / 1813 tests passed
- `cd prod && npm run build`

## Safety
- No owner action required; this is self-actionable P1 defense maintenance.
- No direct official MMO writes in this PR; deploy and post-deploy runtime-alert verification remain controller actions after merge.

Refs #1001
