### PR TITLE
fix(economy): sustain upgrades after construction backlog clears

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -26934,7 +26934,13 @@ function shouldUseSurplusForControllerProgress(creep, controller) {
   return false;
 }
 function shouldStandbySurplusWorkerInsteadOfAcquiring(creep, controller) {
-  return (controller == null ? void 0 : controller.my) === true && isControllerUpgradeSaturated(creep, controller) && !hasNonControllerWorkerEnergyDemand(creep);
+  if ((controller == null ? void 0 : controller.my) !== true || !isControllerUpgradeSaturated(creep, controller)) {
+    return false;
+  }
+  if (hasNonControllerWorkerEnergyDemand(creep)) {
+    return false;
+  }
+  return !hasPostConstructionControllerUpgradeEnergy(creep, controller);
 }
 function hasNonControllerWorkerEnergyDemand(creep) {
   var _a;
@@ -26946,6 +26952,12 @@ function hasNonControllerWorkerEnergyDemand(creep) {
     return true;
   }
   return selectCriticalInfrastructureRepairTarget(creep) !== null || selectRepairTarget(creep) !== null || selectRoutineBarrierMaintenanceRepairTarget(creep) !== null;
+}
+function hasPostConstructionControllerUpgradeEnergy(creep, controller) {
+  return isLowRclControllerProgressTarget(controller) && !hasVisibleHostilePresence2(creep.room) && !hasVisibleOwnedConstructionDemand(creep.room) && (findWorkerEnergyAcquisitionCandidates(creep).length > 0 || hasFullRoomEnergyForControllerProgress(creep.room));
+}
+function isLowRclControllerProgressTarget(controller) {
+  return canLevelUpController2(controller) && controller.level >= 2 && controller.level <= 3;
 }
 function isControllerUpgradeSaturated(creep, controller) {
   if (controller.my !== true || shouldGuardControllerDowngrade2(controller)) {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -6701,11 +6701,15 @@ function shouldStandbySurplusWorkerInsteadOfAcquiring(
   creep: Creep,
   controller: StructureController | undefined
 ): boolean {
-  return (
-    controller?.my === true &&
-    isControllerUpgradeSaturated(creep, controller) &&
-    !hasNonControllerWorkerEnergyDemand(creep)
-  );
+  if (controller?.my !== true || !isControllerUpgradeSaturated(creep, controller)) {
+    return false;
+  }
+
+  if (hasNonControllerWorkerEnergyDemand(creep)) {
+    return false;
+  }
+
+  return !hasPostConstructionControllerUpgradeEnergy(creep, controller);
 }
 
 function hasNonControllerWorkerEnergyDemand(creep: Creep): boolean {
@@ -6726,6 +6730,20 @@ function hasNonControllerWorkerEnergyDemand(creep: Creep): boolean {
     selectRepairTarget(creep) !== null ||
     selectRoutineBarrierMaintenanceRepairTarget(creep) !== null
   );
+}
+
+function hasPostConstructionControllerUpgradeEnergy(creep: Creep, controller: StructureController): boolean {
+  return (
+    isLowRclControllerProgressTarget(controller) &&
+    !hasVisibleHostilePresence(creep.room) &&
+    !hasVisibleOwnedConstructionDemand(creep.room) &&
+    (findWorkerEnergyAcquisitionCandidates(creep).length > 0 ||
+      hasFullRoomEnergyForControllerProgress(creep.room))
+  );
+}
+
+function isLowRclControllerProgressTarget(controller: StructureController): boolean {
+  return canLevelUpController(controller) && controller.level >= 2 && controller.level <= 3;
 }
 
 function isControllerUpgradeSaturated(creep: Creep, controller: StructureController): boolean {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -11827,6 +11827,68 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toBeNull();
   });
 
+  it('withdraws stored energy for post-construction RCL2 controller progress when one worker is already upgrading', () => {
+    const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 4_399, {
+      my: true
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      progress: 3_900,
+      progressTotal: 45_000,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      controller,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      structures: [storage]
+    });
+    const creep = {
+      name: 'PostConstructionWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({
+      Upgrader: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }),
+      PostConstructionWorker: creep
+    });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'storage-surplus' });
+  });
+
+  it('keeps emergency spawn refill before post-construction stored-surplus controller upgrading', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 4_399, {
+      my: true
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      name: 'LoadedWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        controller,
+        energyAvailable: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+        energyCapacityAvailable: 550,
+        myStructures: [spawn as AnyOwnedStructure],
+        structures: [storage]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+  });
+
   it('lets an empty surplus worker acquire energy for safe barrier maintenance', () => {
     const controller = {
       id: 'controller1',


### PR DESCRIPTION
## Summary
- Sustains controller upgrading when the home room has no construction backlog and sufficient energy.
- Keeps emergency refill/critical repair/construction precedence intact via focused worker-task tests.
- Regenerates the Screeps bundle artifact.

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` (95 suites, 1816 tests)
- `npm run build`

## Runtime context
- Fresh W3N9 evidence before dispatch: construction complete (`constructionSiteCount=0`, `pendingBuildProgress=0`), stored energy buffered, RCL2 progress active, room alive with spawn/creeps and no hostiles.
- Linked issue: closes #1067.

## Safety
- No secrets.
- No destructive Screeps API calls.
- Emergency spawn/refill/repair and active construction should still outrank discretionary upgrade throughput.
