### PR TITLE
feat(telemetry): surface controller sign evidence

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -34360,7 +34360,8 @@ function buildControllerSummary(room) {
     return {};
   }
   const summary = {
-    level: controller.level
+    level: controller.level,
+    sign: summarizeControllerSign(controller.sign)
   };
   if (typeof controller.progress === "number") {
     summary.progress = controller.progress;
@@ -34372,6 +34373,27 @@ function buildControllerSummary(room) {
     summary.ticksToDowngrade = controller.ticksToDowngrade;
   }
   return { controller: summary };
+}
+function summarizeControllerSign(sign) {
+  if (!isRecord28(sign)) {
+    return null;
+  }
+  const datetime = summarizeControllerSignDatetime(sign.datetime);
+  return {
+    text: typeof sign.text === "string" ? sign.text : null,
+    ...typeof sign.username === "string" ? { username: sign.username } : {},
+    ...typeof sign.time === "number" && Number.isFinite(sign.time) ? { time: sign.time } : {},
+    ...datetime ? { datetime } : {}
+  };
+}
+function summarizeControllerSignDatetime(value) {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value instanceof Date && Number.isFinite(value.getTime())) {
+    return value.toISOString();
+  }
+  return void 0;
 }
 function summarizeResources(colony, colonyWorkers, colonyCreeps, events) {
   var _a, _b, _c, _d;

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -284,6 +284,14 @@ interface RuntimeControllerSummary {
   progress?: number;
   progressTotal?: number;
   ticksToDowngrade?: number;
+  sign: RuntimeControllerSignSummary | null;
+}
+
+interface RuntimeControllerSignSummary {
+  text: string | null;
+  username?: string;
+  time?: number;
+  datetime?: string;
 }
 
 interface RuntimeStructureSnapshotSummary {
@@ -1739,7 +1747,8 @@ function buildControllerSummary(room: Room): { controller?: RuntimeControllerSum
   }
 
   const summary: RuntimeControllerSummary = {
-    level: controller.level
+    level: controller.level,
+    sign: summarizeControllerSign(controller.sign)
   };
 
   if (typeof controller.progress === 'number') {
@@ -1755,6 +1764,32 @@ function buildControllerSummary(room: Room): { controller?: RuntimeControllerSum
   }
 
   return { controller: summary };
+}
+
+function summarizeControllerSign(sign: unknown): RuntimeControllerSignSummary | null {
+  if (!isRecord(sign)) {
+    return null;
+  }
+  const datetime = summarizeControllerSignDatetime(sign.datetime);
+
+  return {
+    text: typeof sign.text === 'string' ? sign.text : null,
+    ...(typeof sign.username === 'string' ? { username: sign.username } : {}),
+    ...(typeof sign.time === 'number' && Number.isFinite(sign.time) ? { time: sign.time } : {}),
+    ...(datetime ? { datetime } : {})
+  };
+}
+
+function summarizeControllerSignDatetime(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (value instanceof Date && Number.isFinite(value.getTime())) {
+    return value.toISOString();
+  }
+
+  return undefined;
 }
 
 function summarizeResources(

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../src/telemetry/runtimeSummary';
 import { recordCreepBehaviorIdle } from '../src/telemetry/behaviorTelemetry';
 import { CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD } from '../src/tasks/workerTasks';
+import { OCCUPIED_CONTROLLER_SIGN_TEXT } from '../src/territory/controllerSigning';
 
 const TEST_GLOBALS = {
   FIND_STRUCTURES: 101,
@@ -121,7 +122,8 @@ describe('runtime telemetry summaries', () => {
             level: 2,
             progress: 1234,
             progressTotal: 45000,
-            ticksToDowngrade: 15000
+            ticksToDowngrade: 15000,
+            sign: null
           },
           resources: {
             storedEnergy: 250,
@@ -1768,6 +1770,71 @@ describe('runtime telemetry summaries', () => {
     });
     expect((room.resources as Record<string, unknown>).events).toBeUndefined();
     expect((room.combat as Record<string, unknown>).events).toBeUndefined();
+  });
+
+  it('reports owned controller sign evidence in room telemetry', () => {
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      includeEventLog: false
+    });
+    (colony.room.controller as StructureController).sign = {
+      username: 'lanyusea',
+      text: OCCUPIED_CONTROLLER_SIGN_TEXT,
+      time: 12345,
+      datetime: new Date('2026-05-15T00:00:00.000Z')
+    };
+
+    emitRuntimeSummary([colony], [], [], { persistOccupationRecommendations: false });
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.controller).toMatchObject({
+      sign: {
+        username: 'lanyusea',
+        text: OCCUPIED_CONTROLLER_SIGN_TEXT,
+        time: 12345,
+        datetime: '2026-05-15T00:00:00.000Z'
+      }
+    });
+  });
+
+  it('reports null sign evidence for unsigned owned controllers and skips unowned controllers safely', () => {
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      includeEventLog: false
+    });
+
+    emitRuntimeSummary([colony], [], [], { persistOccupationRecommendations: false });
+
+    let payload = parseLoggedSummary();
+    let [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect((room.controller as Record<string, unknown>).sign).toBeNull();
+
+    logSpy.mockClear();
+    (colony.room as Room & { controller?: StructureController }).controller = {
+      my: false,
+      level: 2
+    } as StructureController;
+
+    emitRuntimeSummary(
+      [colony],
+      [],
+      [
+        {
+          type: 'spawn',
+          roomName: 'W1N1',
+          spawnName: 'Spawn1',
+          creepName: 'worker-W1N1-event',
+          role: 'worker',
+          result: 0 as ScreepsReturnCode
+        }
+      ],
+      { persistOccupationRecommendations: false }
+    );
+
+    payload = parseLoggedSummary();
+    [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.controller).toBeUndefined();
   });
 
   it('emits the next occupation recommendation in room telemetry', () => {

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -2999,6 +2999,7 @@ def room_summary(snapshot: RoomSnapshot, image: str | None = None) -> dict[str, 
         "cpuUsed": metrics.cpu_used,
         "cpuBucket": metrics.cpu_bucket,
         "rclLevel": metrics.rcl_level,
+        "controller": metrics.controller_summary,
         "storedEnergy": metrics.stored_energy,
         "energyCapacity": number_value(info.get("energyCapacity") or info.get("energyCapacityAvailable")),
         "energyCapacityAvailable": number_value(info.get("energyCapacityAvailable")),
@@ -3656,6 +3657,7 @@ def compute_room_summary_metrics(snapshot: RoomSnapshot) -> RoomSummaryMetrics:
     if controller is not None:
         for key in ("level", "progress", "progressTotal", "ticksToDowngrade"):
             controller_summary[key] = number_value(controller.get(key))
+        controller_summary["sign"] = controller_sign_summary(controller)
 
     return RoomSummaryMetrics(
         structures=structures,
@@ -3683,6 +3685,29 @@ def compute_room_summary_metrics(snapshot: RoomSnapshot) -> RoomSummaryMetrics:
         cpu_bucket=snapshot_cpu_bucket(snapshot),
         rcl_level=number_value(controller.get("level")) if controller is not None else None,
     )
+
+
+def controller_sign_summary(controller: dict[str, Any]) -> dict[str, Any] | None:
+    sign = controller.get("sign")
+    if not isinstance(sign, dict):
+        return None
+
+    summary: dict[str, Any] = {
+        "text": sign.get("text") if isinstance(sign.get("text"), str) else None,
+    }
+    username = sign.get("username")
+    if isinstance(username, str):
+        summary["username"] = username
+    user = sign.get("user")
+    if isinstance(user, str):
+        summary["user"] = user
+    time_value = number_value(sign.get("time"))
+    if time_value is not None:
+        summary["time"] = time_value
+    datetime_value = sign.get("datetime")
+    if isinstance(datetime_value, str):
+        summary["datetime"] = datetime_value
+    return summary
 
 
 def confirmed_foreign_owner(obj: dict[str, Any], owner_username: str | None) -> bool:

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -766,6 +766,12 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
                     "progress": 1250,
                     "progressTotal": 45000,
                     "ticksToDowngrade": 19876,
+                    "sign": {
+                        "username": "lanyusea",
+                        "text": "by Hermes Screeps Project",
+                        "time": 265600,
+                        "datetime": "2026-05-15T00:00:00.000Z",
+                    },
                     "x": 24,
                     "y": 24,
                 },
@@ -867,6 +873,15 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         self.assertEqual(payload["rooms"][0]["roomName"], "E26S49")
         self.assertEqual(payload["rooms"][0]["controller"]["level"], 3)
         self.assertEqual(payload["rooms"][0]["controller"]["progress"], 1250)
+        self.assertEqual(
+            payload["rooms"][0]["controller"]["sign"],
+            {
+                "username": "lanyusea",
+                "text": "by Hermes Screeps Project",
+                "time": 265600,
+                "datetime": "2026-05-15T00:00:00.000Z",
+            },
+        )
         self.assertEqual(payload["rooms"][0]["rclLevel"], 3)
         self.assertEqual(payload["rooms"][0]["storedEnergy"], 355)
         self.assertEqual(payload["rooms"][0]["resources"]["storedEnergy"], 355)
@@ -896,6 +911,30 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         self.assertEqual(payload["rooms"][0]["cpuBucket"], 9123)
         self.assertEqual(payload["cpu"], {"used": 7.25, "bucket": 9123})
         self.assertEqual(payload["rooms"][0]["combat"]["hostileCreepCount"], 1)
+
+    def test_runtime_summary_payload_reports_null_controller_sign_evidence(self) -> None:
+        snapshot = monitor.RoomSnapshot(
+            ref=monitor.RoomRef(shard="shardX", room="E26S49"),
+            terrain="0" * monitor.TERRAIN_CELLS,
+            objects={
+                "controller-1": {
+                    "_id": "controller-1",
+                    "type": "controller",
+                    "my": True,
+                    "owner": {"username": "lanyusea"},
+                    "level": 3,
+                }
+            },
+            tick=265631,
+            owner="lanyusea",
+            info={},
+        )
+
+        payload = monitor.runtime_summary_payload_from_snapshots([snapshot])
+        summary = monitor.room_summary(snapshot)
+
+        self.assertIsNone(payload["rooms"][0]["controller"]["sign"])
+        self.assertIsNone(summary["controller"]["sign"])
 
     def test_runtime_summary_artifact_line_is_bridge_compatible(self) -> None:
         snapshot = monitor.RoomSnapshot(


### PR DESCRIPTION
## Summary
- Adds controller sign evidence to runtime summary telemetry for owned rooms.
- Surfaces controller sign fields through the runtime monitor so post-deploy acceptance can verify the required `by Hermes Screeps Project` sign text.
- Covers signed and missing/null sign cases in TypeScript and monitor tests.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps-runtime-monitor.py`
- `python3 -m unittest scripts.test_screeps_runtime_monitor_tactical_response` (31 tests)
- `npm run typecheck`
- `npm test -- --runInBand` (95 suites, 1816 tests)
- `npm run build`

## Safety
- Observability-only; no gameplay signing behavior change intended.
- No secrets or Screeps API writes.

Closes #1026.
