### PR TITLE
feat: add seasonal world profile dry-run support

### DIFF
--- a/docs/ops/cron-and-route-registry.md
+++ b/docs/ops/cron-and-route-registry.md
@@ -1,6 +1,6 @@
 # Screeps Cron and Route Registry
 
-Last updated: 2026-05-13
+Last updated: 2026-05-15
 Tracking issue: https://github.com/lanyusea/screeps/issues/620
 
 This registry keeps the minimum cron/channel contract in one place. Cron prompts may embed short self-contained summaries, but their target/cadence/route expectations must match this file.
@@ -10,6 +10,10 @@ This registry keeps the minimum cron/channel contract in one place. Cron prompts
 - Official bot deployment and gameplay target: `main / shardX / W3N9`; `Spawn1` at `(35,23)`.
 - Runtime monitoring and alerting jobs (`befcbb7b2d60`, `1df5ef0c3835`) auto-discover all owned rooms via `/api/user/overview` and are not constrained to the single-room target.
 - Old room references (`E24S49`, `E19S55`, `E22S49`, `E48S28`, `E48S29`, `E26S49`, `E17S59`, `E19S57`) are historical incident/fallback or superseded rooms unless explicitly retargeted by the owner.
+
+## Seasonal smoke note
+
+No Seasonal World cron job is active yet. Future Seasonal jobs must use separate names, env selectors, state files, cache directories, and artifact roots, including `SCREEPS_API_URL=https://screeps.com/season`, `SCREEPS_SHARD=shardSeason`, `runtime-artifacts/seasonal/...`, and `/root/.hermes/screeps-seasonal-runtime-monitor/...`. They must preserve the existing persistent MMO jobs and must not reuse persistent monitor state or cache paths.
 
 ## Discord routes
 

--- a/docs/ops/official-mmo-deploy.md
+++ b/docs/ops/official-mmo-deploy.md
@@ -75,6 +75,8 @@ PR #588 (`e87059d`) added 847 lines to `linkManager.ts` and modified `economyLoo
 ## Live Deploy
 
 Load `SCREEPS_AUTH_TOKEN` into the environment through local secret storage or CI secrets. Do not print it.
+Live deploy mode is intentionally limited to the persistent MMO root, `https://screeps.com`.
+Seasonal roots such as `https://screeps.com/season` are supported only for dry-run planning by this helper until Seasonal live-deploy evidence, monitor state, and cache paths are isolated.
 
 ```bash
 mkdir -p runtime-artifacts/official-screeps-deploy

--- a/docs/ops/rules-registry.md
+++ b/docs/ops/rules-registry.md
@@ -1,6 +1,6 @@
 # Screeps Minimal Rules Registry
 
-Last updated: 2026-05-14
+Last updated: 2026-05-15
 Tracking issue: https://github.com/lanyusea/screeps/issues/620
 
 This registry is the canonical compact rules standard for the two-person Screeps project. It intentionally avoids multi-level governance. The goal is to keep autonomous agents from doing the wrong thing while keeping the system small enough to maintain.
@@ -48,7 +48,8 @@ Canonical Domain values:
 7. `Territory/Economy`
 8. `Gameplay Evolution`
 9. `RL flywheel`
-10. `Docs/process`
+10. `Seasonal World`
+11. `Docs/process`
 
 `roadmap:*` labels are compatibility/search labels. Project `Domain` is the primary machine-readable grouping for Kanban, reports, and Pages domain progress.
 
@@ -121,6 +122,12 @@ This authorization is automatic — no owner approval required. The agent MUST a
 The dead-end condition is checked by the runtime alert cron job (`1df5ef0c3835`, `Screeps runtime room alert text check`). When detected with `room_dead` category and `owned_spawns=0 AND owned_creeps=0`, the alert handler must trigger the recovery sequence above, not just report.
 
 Owner @ notification is still required for: rollback decisions when multiple healthy commits exist, manual respawn when automated recovery fails, and non-recovery strategic decisions.
+
+## Seasonal World current-season smoke rule
+
+Seasonal World work is isolated, explicit opt-in smoke work only unless a future owner decision expands the scope. Seasonal commands must use the Seasonal world root (`https://screeps.com/season`), Seasonal selectors, and isolated artifact/state/cache paths from `docs/ops/screeps-world-profiles.md`.
+
+Seasonal work does not inherit W3N9 autonomous recovery, respawn, or spawn-placement authorization. No destructive Seasonal recovery action is authorized unless the owner explicitly approves it for Seasonal.
 
 ## Rules-change process
 

--- a/docs/ops/screeps-world-profiles.md
+++ b/docs/ops/screeps-world-profiles.md
@@ -49,10 +49,12 @@ Seasonal commands must set their Seasonal world root, selectors, and state/cache
 The current Seasonal goal is a smoke test only:
 
 1. Discover the authenticated Seasonal room target without writing to the persistent MMO.
-2. Use `https://screeps.com/season` as the world root and `shardSeason` as the shard selector.
+2. Use `https://screeps.com/season` as the dry-run world root and `shardSeason` as the shard selector.
 3. Use an isolated Seasonal branch, pending final choice between `seasonal-smoke` and `seasonal-main`.
 4. Write evidence and monitor outputs only under `runtime-artifacts/seasonal/...` and `/root/.hermes/screeps-seasonal-runtime-monitor/...`.
 5. Keep persistent deploy, monitor, cron, and recovery automation unchanged.
+
+`scripts/screeps_official_deploy.py` accepts the Seasonal world root for dry-run planning only. Seasonal live deploy is not enabled; its `--deploy` mode remains restricted to the persistent MMO root, `https://screeps.com`, until monitor/evidence/state/cache isolation is complete in a later slice.
 
 ## No-Impact Verification
 

--- a/docs/ops/screeps-world-profiles.md
+++ b/docs/ops/screeps-world-profiles.md
@@ -1,0 +1,76 @@
+# Screeps World Profiles
+
+Date: 2026-05-15
+
+This document defines the durable profile contract for official Screeps: World automation. The persistent MMO profile remains the default. Seasonal World support is explicit opt-in and must never change persistent `main / shardX / W3N9` behavior unless a later owner decision says so.
+
+## URL Contract
+
+Scripts that talk to the official Screeps service must receive a world root:
+
+- Persistent MMO: `https://screeps.com`
+- Seasonal World: `https://screeps.com/season`
+
+Do not pass API roots such as `https://screeps.com/api` or `https://screeps.com/season/api`. Scripts append endpoint paths such as `/api/user/code` themselves.
+
+## Profiles
+
+| Field | Persistent MMO default | Seasonal current-season smoke |
+| --- | --- | --- |
+| Purpose | Durable production bot operation | Owner-approved current-season smoke only, not a ranking push |
+| World root | `https://screeps.com` | `https://screeps.com/season` |
+| Code branch | `main` | `seasonal-smoke` or `seasonal-main`; final branch name pending authenticated discovery |
+| Shard | `shardX` | `shardSeason` |
+| Room | `W3N9` | `TBD` until authenticated discovery |
+| Deploy artifact | `prod/dist/main.js` | `prod/dist/main.js` built from the same verified source |
+| Deploy evidence | `runtime-artifacts/official-screeps-deploy/` | `runtime-artifacts/seasonal/official-screeps-deploy/` |
+| Routine monitor artifacts | `runtime-artifacts/screeps-monitor/` | `runtime-artifacts/seasonal/screeps-monitor/` |
+| Runtime monitor state | `/root/.hermes/screeps-runtime-monitor/state.json` | `/root/.hermes/screeps-seasonal-runtime-monitor/state.json` |
+| Runtime monitor terrain cache | `/root/.hermes/screeps-runtime-monitor/terrain-cache/` | `/root/.hermes/screeps-seasonal-runtime-monitor/terrain-cache/` |
+| Deploy health-gate state | `runtime-artifacts/official-screeps-deploy/postdeploy-monitor-state.json` | `runtime-artifacts/seasonal/official-screeps-deploy/postdeploy-monitor-state.json` |
+| Recovery authorization | W3N9 autonomous recovery rules in `docs/ops/rules-registry.md` | No destructive recovery, respawn, or autonomous placement authorization unless explicitly approved for Seasonal |
+
+## Persistent MMO Invariant
+
+The following defaults are part of the persistent production contract:
+
+- `SCREEPS_API_URL=https://screeps.com`
+- `SCREEPS_BRANCH=main`
+- `SCREEPS_SHARD=shardX`
+- `SCREEPS_ROOM=W3N9`
+- Deployment evidence remains under `runtime-artifacts/official-screeps-deploy/`.
+- Runtime monitor artifacts remain under `runtime-artifacts/screeps-monitor/`.
+- Runtime monitor state/cache remain under `/root/.hermes/screeps-runtime-monitor/`.
+
+Seasonal commands must set their Seasonal world root, selectors, and state/cache/artifact paths explicitly. They must not rely on persistent defaults.
+
+## Seasonal Smoke Contract
+
+The current Seasonal goal is a smoke test only:
+
+1. Discover the authenticated Seasonal room target without writing to the persistent MMO.
+2. Use `https://screeps.com/season` as the world root and `shardSeason` as the shard selector.
+3. Use an isolated Seasonal branch, pending final choice between `seasonal-smoke` and `seasonal-main`.
+4. Write evidence and monitor outputs only under `runtime-artifacts/seasonal/...` and `/root/.hermes/screeps-seasonal-runtime-monitor/...`.
+5. Keep persistent deploy, monitor, cron, and recovery automation unchanged.
+
+## No-Impact Verification
+
+Every Seasonal-related change or smoke step must include persistent MMO no-impact verification:
+
+1. Confirm the command line or environment uses a world root, not an API root.
+2. Confirm persistent selectors are unchanged when running persistent checks: `https://screeps.com`, `main`, `shardX`, `W3N9`.
+3. Confirm Seasonal checks use isolated selectors and paths: `https://screeps.com/season`, `shardSeason`, `runtime-artifacts/seasonal/...`, and `/root/.hermes/screeps-seasonal-runtime-monitor/...`.
+4. Run the deploy helper dry run for the persistent profile after script changes:
+
+   ```bash
+   python3 scripts/screeps_official_deploy.py \
+     --dry-run \
+     --api-url https://screeps.com \
+     --branch main \
+     --shard shardX \
+     --room W3N9
+   ```
+
+5. Run the narrow script tests and production build/test gate required by the task or PR.
+6. Before any live Seasonal write, verify no command will touch persistent artifact/state/cache paths and no W3N9 recovery or respawn authorization is being applied to Seasonal.

--- a/scripts/screeps_official_deploy.py
+++ b/scripts/screeps_official_deploy.py
@@ -206,8 +206,15 @@ def normalize_api_url(raw_url: str) -> str:
 
 
 def require_https_api_url(api_url: str) -> None:
-    """Reject non-official world roots before authenticated deploy requests."""
-    normalize_api_url(api_url)
+    """Reject non-persistent world roots before authenticated deploy requests."""
+    world_root = normalize_api_url(api_url)
+    if world_root != PERSISTENT_WORLD_ROOT:
+        raise DeployError(
+            "Seasonal live deploy is not enabled. --deploy currently supports only "
+            f"the persistent Screeps MMO root {PERSISTENT_WORLD_ROOT}; Seasonal root "
+            f"{SEASONAL_WORLD_ROOT} is dry-run only until monitor/evidence/state/cache "
+            "isolation is complete"
+        )
 
 
 def world_profile_metadata(api_url: str) -> dict[str, str]:

--- a/scripts/screeps_official_deploy.py
+++ b/scripts/screeps_official_deploy.py
@@ -28,6 +28,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_ARTIFACT_PATH = REPO_ROOT / "prod" / "dist" / "main.js"
 DEFAULT_EVIDENCE_DIR = REPO_ROOT / "runtime-artifacts" / "official-screeps-deploy"
 DEFAULT_API_URL = "https://screeps.com"
+PERSISTENT_WORLD_ROOT = "https://screeps.com"
+SEASONAL_WORLD_ROOT = "https://screeps.com/season"
+OFFICIAL_WORLD_ROOTS = (PERSISTENT_WORLD_ROOT, SEASONAL_WORLD_ROOT)
 DEFAULT_BRANCH = "main"
 DEFAULT_SHARD = "shardX"
 DEFAULT_ROOM = "W3N9"
@@ -179,24 +182,42 @@ class ScreepsApi:
 
 
 def normalize_api_url(raw_url: str) -> str:
-    """Normalize and validate the official HTTPS API base URL."""
+    """Normalize and validate an official Screeps world root URL."""
     parsed = urllib.parse.urlparse(raw_url.strip())
-    if parsed.scheme != "https" or parsed.netloc != "screeps.com":
-        raise DeployError("SCREEPS_API_URL must be https://screeps.com for official deploys")
     if parsed.username or parsed.password:
         raise DeployError("SCREEPS_API_URL must not include credentials")
     if parsed.query or parsed.fragment:
         raise DeployError("SCREEPS_API_URL must not include query strings or fragments")
-    if parsed.path.rstrip("/"):
-        raise DeployError("SCREEPS_API_URL must not include path prefixes")
-    return urllib.parse.urlunparse((parsed.scheme, parsed.netloc, "", "", "", ""))
+    official_roots = " or ".join(OFFICIAL_WORLD_ROOTS)
+    if parsed.scheme != "https" or parsed.netloc != "screeps.com":
+        raise DeployError(f"SCREEPS_API_URL must be an official Screeps world root: {official_roots}")
+    path = parsed.path.rstrip("/")
+    if path == "/api" or path.startswith("/api/") or path == "/season/api" or path.startswith("/season/api/"):
+        raise DeployError(
+            "SCREEPS_API_URL must be a Screeps world root, not an API root; "
+            f"use {official_roots}"
+        )
+    if path not in ("", "/season"):
+        raise DeployError(
+            "SCREEPS_API_URL must not include invalid path prefixes; "
+            f"use {official_roots}"
+        )
+    return urllib.parse.urlunparse((parsed.scheme, parsed.netloc, path, "", "", ""))
 
 
 def require_https_api_url(api_url: str) -> None:
-    """Reject non-official API URLs before authenticated deploy requests."""
-    parsed = urllib.parse.urlparse(api_url)
-    if parsed.scheme != "https" or parsed.netloc != "screeps.com":
-        raise DeployError("SCREEPS_API_URL must be https://screeps.com for --deploy")
+    """Reject non-official world roots before authenticated deploy requests."""
+    normalize_api_url(api_url)
+
+
+def world_profile_metadata(api_url: str) -> dict[str, str]:
+    """Return non-secret world identity metadata for deploy evidence."""
+    try:
+        world_root = normalize_api_url(api_url)
+    except DeployError:
+        return {"world": "custom", "worldRoot": api_url}
+    world = "seasonal" if world_root == SEASONAL_WORLD_ROOT else "persistent"
+    return {"world": world, "worldRoot": world_root}
 
 
 def validate_selector(name: str, value: str, pattern: re.Pattern[str]) -> str:
@@ -484,6 +505,7 @@ def base_evidence(cfg: DeployConfig, artifact: dict[str, Any]) -> dict[str, Any]
         "git": git_metadata(cfg.repo_root),
         "target": {
             "apiUrl": cfg.api_url,
+            **world_profile_metadata(cfg.api_url),
             "branch": cfg.branch,
             "shard": cfg.shard,
             "room": cfg.room,

--- a/scripts/test_screeps_official_deploy.py
+++ b/scripts/test_screeps_official_deploy.py
@@ -226,6 +226,29 @@ class OfficialDeployTest(unittest.TestCase):
                     transport=lambda **_kwargs: self.fail("no HTTP expected"),
                 )
 
+    def test_deploy_rejects_seasonal_api_url_before_authenticated_requests(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            artifact = self.write_artifact(Path(tmp))
+            cfg = self.config(
+                artifact,
+                api_url="https://screeps.com/season",
+                branch="seasonal-smoke",
+                shard="shardSeason",
+                room="W1N1",
+                deploy_mode=True,
+                confirm="deploy seasonal-smoke to shardSeason/W1N1",
+            )
+
+            with self.assertRaisesRegex(
+                deploy.DeployError,
+                "Seasonal live deploy is not enabled.*dry-run only.*isolation",
+            ):
+                deploy.run_deploy(
+                    cfg,
+                    env={deploy.AUTH_TOKEN_ENV: "fixture-value"},
+                    transport=lambda **_kwargs: self.fail("no HTTP expected"),
+                )
+
     def test_deploy_requests_expected_endpoints_and_verifies_hashes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             artifact_body = "module.exports.loop = function () { return 1; };\n"

--- a/scripts/test_screeps_official_deploy.py
+++ b/scripts/test_screeps_official_deploy.py
@@ -38,6 +38,9 @@ class OfficialDeployTest(unittest.TestCase):
         artifact: Path,
         *,
         api_url: str = "https://screeps.com",
+        branch: str = "main",
+        shard: str = "shardX",
+        room: str = "E19S57",
         deploy_mode: bool = False,
         activate_world: bool = False,
         confirm: str | None = None,
@@ -47,9 +50,9 @@ class OfficialDeployTest(unittest.TestCase):
     ) -> deploy.DeployConfig:
         return deploy.DeployConfig(
             api_url=api_url,
-            branch="main",
-            shard="shardX",
-            room="E19S57",
+            branch=branch,
+            shard=shard,
+            room=room,
             artifact_path=artifact,
             deploy=deploy_mode,
             activate_world=activate_world,
@@ -129,12 +132,21 @@ class OfficialDeployTest(unittest.TestCase):
 
     def test_normalize_api_url_requires_official_https_origin(self) -> None:
         self.assertEqual(deploy.normalize_api_url("https://screeps.com/"), "https://screeps.com")
+        self.assertEqual(deploy.normalize_api_url("https://screeps.com/season/"), "https://screeps.com/season")
         with self.assertRaisesRegex(deploy.DeployError, "https://screeps.com"):
             deploy.normalize_api_url("http://localhost:21025/")
         with self.assertRaisesRegex(deploy.DeployError, "https://screeps.com"):
             deploy.normalize_api_url("https://example.com")
-        with self.assertRaisesRegex(deploy.DeployError, "path prefixes"):
+        with self.assertRaisesRegex(deploy.DeployError, "world root, not an API root"):
             deploy.normalize_api_url("https://screeps.com/api")
+        with self.assertRaisesRegex(deploy.DeployError, "world root, not an API root"):
+            deploy.normalize_api_url("https://screeps.com/season/api")
+        with self.assertRaisesRegex(deploy.DeployError, "credentials"):
+            deploy.normalize_api_url("https://token@screeps.com/season")
+        with self.assertRaisesRegex(deploy.DeployError, "query strings or fragments"):
+            deploy.normalize_api_url("https://screeps.com/season?x=1")
+        with self.assertRaisesRegex(deploy.DeployError, "invalid path prefixes"):
+            deploy.normalize_api_url("https://screeps.com/season/extra")
 
     def test_artifact_metadata_reports_hash_and_size(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -162,6 +174,29 @@ class OfficialDeployTest(unittest.TestCase):
         self.assertIn("/api/user/code", encoded)
         self.assertNotIn("SCREEPS_AUTH_TOKEN", encoded)
         self.assertNotIn("module.exports.loop", encoded)
+
+    def test_dry_run_can_target_seasonal_world_without_http(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            artifact = self.write_artifact(Path(tmp))
+            cfg = self.config(
+                artifact,
+                api_url="https://screeps.com/season",
+                branch="seasonal-smoke",
+                shard="shardSeason",
+                room="W1N1",
+                activate_world=True,
+            )
+
+            evidence = deploy.run_deploy(cfg, env={}, transport=lambda **_kwargs: self.fail("no HTTP expected"))
+
+        self.assertTrue(evidence["ok"])
+        self.assertEqual(evidence["mode"], "dry-run")
+        self.assertEqual(evidence["target"]["apiUrl"], "https://screeps.com/season")
+        self.assertEqual(evidence["target"]["world"], "seasonal")
+        self.assertEqual(evidence["target"]["worldRoot"], "https://screeps.com/season")
+        self.assertEqual(evidence["target"]["branch"], "seasonal-smoke")
+        self.assertEqual(evidence["target"]["shard"], "shardSeason")
+        self.assertEqual(evidence["requests"][2]["payload"]["branch"], "seasonal-smoke")
 
     def test_dry_run_allows_plaintext_local_api_url_without_http(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- Adds the `docs/ops/screeps-world-profiles.md` contract for persistent MMO vs Seasonal smoke profiles.
- Registers `Seasonal World` as a canonical Project Domain and records that Seasonal smoke does not inherit W3N9 recovery/respawn authorization.
- Allows the official deploy helper to accept `https://screeps.com/season` as an explicit Seasonal world root while rejecting `/api` roots.
- Adds deploy-helper tests for persistent URL compatibility, Seasonal world-root dry-run support, and API-root rejection.

## Persistent MMO no-impact verification
Persistent defaults remain explicit and unchanged:
- `SCREEPS_API_URL=https://screeps.com`
- `SCREEPS_BRANCH=main`
- `SCREEPS_SHARD=shardX`
- `SCREEPS_ROOM=W3N9`
- Existing persistent deploy/monitor artifact paths remain unchanged.

Dry-run proof with no token/no HTTP writes:
```json
{
  "ok": true,
  "mode": "dry-run",
  "target": {
    "apiUrl": "https://screeps.com",
    "world": "persistent",
    "worldRoot": "https://screeps.com",
    "branch": "main",
    "shard": "shardX",
    "room": "W3N9"
  },
  "dryRunStatus": "passed"
}
```

Seasonal dry-run proof stays explicit opt-in:
```json
{
  "ok": true,
  "mode": "dry-run",
  "target": {
    "apiUrl": "https://screeps.com/season",
    "world": "seasonal",
    "worldRoot": "https://screeps.com/season",
    "branch": "seasonal-smoke",
    "shard": "shardSeason",
    "room": "W1N1"
  },
  "dryRunStatus": "passed"
}
```

## Verification
- `python3 -m py_compile scripts/screeps_official_deploy.py`
- `python3 -m unittest scripts.test_screeps_official_deploy` — 23 tests passed
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 95 suites / 1814 tests passed
- `cd prod && npm run build`
- `git diff --check`
- Persistent deploy-helper dry-run for `https://screeps.com main shardX W3N9` passed with no HTTP writes
- Seasonal deploy-helper dry-run for `https://screeps.com/season seasonal-smoke shardSeason W1N1` passed with no HTTP writes

Resolves #1070
Resolves #1071
