### PR TITLE
fix(defense): prioritize active rampart maintenance

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -22747,7 +22747,7 @@ function getGameTick2() {
 var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
 var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 var CRITICAL_SPAWN_REPAIR_HITS_RATIO = 0.25;
-var IDLE_RAMPART_REPAIR_HITS_CEILING2 = 1e5;
+var IDLE_RAMPART_REPAIR_HITS_CEILING2 = 12e4;
 var TOWER_REFILL_ENERGY_FLOOR = 500;
 var CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
 var URGENT_SPAWN_REFILL_ENERGY_THRESHOLD = CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD;
@@ -23114,6 +23114,13 @@ function selectHeuristicWorkerTask(creep) {
   if (shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep)) {
     return null;
   }
+  const controllerSustainBarrierMaintenanceTask = selectControllerSustainBarrierMaintenanceTask(
+    creep,
+    constructionSites
+  );
+  if (controllerSustainBarrierMaintenanceTask) {
+    return applyMinimumUsefulLoadPolicy(creep, controllerSustainBarrierMaintenanceTask);
+  }
   const controllerSustainUpgradeTask = selectControllerSustainUpgradeTask(creep, controller);
   if (controllerSustainUpgradeTask) {
     return applyMinimumUsefulLoadPolicy(creep, controllerSustainUpgradeTask);
@@ -23365,6 +23372,15 @@ function selectControllerSustainUpgradeTask(creep, controller) {
     return null;
   }
   return { type: "upgrade", targetId: controller.id };
+}
+function selectControllerSustainBarrierMaintenanceTask(creep, constructionSites) {
+  var _a, _b;
+  const sustain = (_a = creep.memory) == null ? void 0 : _a.controllerSustain;
+  if ((sustain == null ? void 0 : sustain.role) !== "upgrader" || sustain.targetRoom !== ((_b = creep.room) == null ? void 0 : _b.name) || constructionSites.length > 0 || hasSameRoomWorkerAssignedToTask(creep.room, creep, "repair")) {
+    return null;
+  }
+  const barrierMaintenanceTarget = selectRoutineBarrierMaintenanceRepairTarget(creep);
+  return barrierMaintenanceTarget ? { type: "repair", targetId: barrierMaintenanceTarget.id } : null;
 }
 function shouldYieldControllerSustainUpgradeToConstruction(creep, sustain) {
   return sustain.homeRoom !== sustain.targetRoom && hasVisibleOwnedConstructionDemand(creep.room);

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -77,7 +77,7 @@ import { selectWorkerTaskWithBcFallback } from '../rl/workerTaskPolicy';
 export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
 export const CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 export const CRITICAL_SPAWN_REPAIR_HITS_RATIO = 0.25;
-export const IDLE_RAMPART_REPAIR_HITS_CEILING = 100_000;
+export const IDLE_RAMPART_REPAIR_HITS_CEILING = 120_000;
 export const TOWER_REFILL_ENERGY_FLOOR = 500;
 export const CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
 export const URGENT_SPAWN_REFILL_ENERGY_THRESHOLD = CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD;
@@ -666,6 +666,14 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     return null;
   }
 
+  const controllerSustainBarrierMaintenanceTask = selectControllerSustainBarrierMaintenanceTask(
+    creep,
+    constructionSites
+  );
+  if (controllerSustainBarrierMaintenanceTask) {
+    return applyMinimumUsefulLoadPolicy(creep, controllerSustainBarrierMaintenanceTask);
+  }
+
   const controllerSustainUpgradeTask = selectControllerSustainUpgradeTask(creep, controller);
   if (controllerSustainUpgradeTask) {
     return applyMinimumUsefulLoadPolicy(creep, controllerSustainUpgradeTask);
@@ -1022,6 +1030,26 @@ function selectControllerSustainUpgradeTask(
   }
 
   return { type: 'upgrade', targetId: controller.id };
+}
+
+function selectControllerSustainBarrierMaintenanceTask(
+  creep: Creep,
+  constructionSites: ConstructionSite[]
+): Extract<CreepTaskMemory, { type: 'repair' }> | null {
+  const sustain = creep.memory?.controllerSustain;
+  if (
+    sustain?.role !== 'upgrader' ||
+    sustain.targetRoom !== creep.room?.name ||
+    constructionSites.length > 0 ||
+    hasSameRoomWorkerAssignedToTask(creep.room, creep, 'repair')
+  ) {
+    return null;
+  }
+
+  const barrierMaintenanceTarget = selectRoutineBarrierMaintenanceRepairTarget(creep);
+  return barrierMaintenanceTarget
+    ? { type: 'repair', targetId: barrierMaintenanceTarget.id as Id<Structure> }
+    : null;
 }
 
 function shouldYieldControllerSustainUpgradeToConstruction(

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -13023,6 +13023,87 @@ describe('selectWorkerTask', () => {
     }
   );
 
+  it('uses post-construction controller sustain energy on active rampart maintenance before upgrading', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const rampart = makeStructure(
+      'rampart-alert-band',
+      'rampart' as StructureConstant,
+      98_301,
+      300_000,
+      { my: true }
+    );
+    const room = makeWorkerTaskRoom({
+      name: 'W3N9',
+      controller,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      structures: [rampart]
+    });
+    const creep = {
+      name: 'SustainUpgrader',
+      memory: {
+        role: 'worker',
+        colony: 'W3N9',
+        controllerSustain: { homeRoom: 'W3N9', targetRoom: 'W3N9', role: 'upgrader' }
+      },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'rampart-alert-band' });
+  });
+
+  it('keeps controller sustain upgrading when another worker covers routine barrier maintenance', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const rampart = makeStructure(
+      'rampart-alert-band',
+      'rampart' as StructureConstant,
+      98_301,
+      300_000,
+      { my: true }
+    );
+    const room = makeWorkerTaskRoom({
+      name: 'W3N9',
+      controller,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      structures: [rampart]
+    });
+    const repairer = {
+      name: 'Repairer',
+      memory: {
+        role: 'worker',
+        colony: 'W3N9',
+        task: { type: 'repair', targetId: 'rampart-alert-band' as Id<Structure> }
+      },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    const creep = {
+      name: 'SustainUpgrader',
+      memory: {
+        role: 'worker',
+        colony: 'W3N9',
+        controllerSustain: { homeRoom: 'W3N9', targetRoom: 'W3N9', role: 'upgrader' }
+      },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ Repairer: repairer, SustainUpgrader: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
   it('keeps spawn refill before routine barrier maintenance', () => {
     const controller = {
       id: 'controller1',
@@ -13054,6 +13135,41 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+  });
+
+  it('keeps critical infrastructure repair before active rampart maintenance', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const container = makeStructure('container-critical', 'container' as StructureConstant, 500, 2_000);
+    const rampart = makeStructure(
+      'rampart-alert-band',
+      'rampart' as StructureConstant,
+      98_301,
+      300_000,
+      { my: true }
+    );
+    const creep = {
+      name: 'SustainUpgrader',
+      memory: {
+        role: 'worker',
+        colony: 'W3N9',
+        controllerSustain: { homeRoom: 'W3N9', targetRoom: 'W3N9', role: 'upgrader' }
+      },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        name: 'W3N9',
+        controller,
+        energyAvailable: 550,
+        energyCapacityAvailable: 550,
+        structures: [rampart, container]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'container-critical' });
   });
 
   it('reuses the routine barrier maintenance target for workers in the same room tick', () => {


### PR DESCRIPTION
## Summary
- Prioritizes active owned rampart maintenance after the post-#1066 W3N9 runtime alert showed continued rampart hit loss.
- Preserves emergency refill, hostile response, critical repair, active construction, and upgrade-throughput guard cases.
- Regenerates the Screeps bundle artifact.

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` (95 suites, 1817 tests)
- `npm run build`

## Runtime context
- Fresh scheduler recheck at tick 978162: `owned_spawns=1`, `owned_creeps=9`, `hostiles=0`, `storedEnergy=4659`, but `alert=true` with 3 rampart `structure_damage` reasons.
- Alert evidence: `/tmp/screeps-scheduler-alert.g5eQwU/alert.json` and `/tmp/screeps-scheduler-alert.g5eQwU/health-gate.json`.

## Safety
- No secrets.
- No destructive Screeps API calls.
- Post-merge requires official MMO deploy plus fresh runtime-alert silence before #1068 closure.

Closes #1068.
