### PR TITLE
feat: isolate seasonal monitor artifacts

### DIFF
--- a/docs/ops/screeps-world-profiles.md
+++ b/docs/ops/screeps-world-profiles.md
@@ -25,6 +25,7 @@ Do not pass API roots such as `https://screeps.com/api` or `https://screeps.com/
 | Deploy artifact | `prod/dist/main.js` | `prod/dist/main.js` built from the same verified source |
 | Deploy evidence | `runtime-artifacts/official-screeps-deploy/` | `runtime-artifacts/seasonal/official-screeps-deploy/` |
 | Routine monitor artifacts | `runtime-artifacts/screeps-monitor/` | `runtime-artifacts/seasonal/screeps-monitor/` |
+| Runtime-summary console artifacts | `runtime-artifacts/runtime-summary-console/` | `runtime-artifacts/seasonal/runtime-summary-console/` |
 | Runtime monitor state | `/root/.hermes/screeps-runtime-monitor/state.json` | `/root/.hermes/screeps-seasonal-runtime-monitor/state.json` |
 | Runtime monitor terrain cache | `/root/.hermes/screeps-runtime-monitor/terrain-cache/` | `/root/.hermes/screeps-seasonal-runtime-monitor/terrain-cache/` |
 | Deploy health-gate state | `runtime-artifacts/official-screeps-deploy/postdeploy-monitor-state.json` | `runtime-artifacts/seasonal/official-screeps-deploy/postdeploy-monitor-state.json` |
@@ -43,6 +44,8 @@ The following defaults are part of the persistent production contract:
 - Runtime monitor state/cache remain under `/root/.hermes/screeps-runtime-monitor/`.
 
 Seasonal commands must set their Seasonal world root, selectors, and state/cache/artifact paths explicitly. They must not rely on persistent defaults.
+
+`scripts/screeps-runtime-monitor.py` live subcommands and `scripts/screeps_runtime_summary_console_capture.py` also accept `SCREEPS_WORLD_PROFILE` or `--world-profile` with values `persistent` or `seasonal`. Omitted or `persistent` preserves the defaults above. Explicit `seasonal` switches only default monitor/capture paths, runtime-summary paths, `SCREEPS_API_URL` fallback, and `SCREEPS_SHARD` fallback to Seasonal values; existing CLI arguments and env overrides such as `SCREEPS_API_URL`, `SCREEPS_SHARD`, `SCREEPS_MONITOR_STATE_FILE`, `SCREEPS_MONITOR_CACHE_DIR`, `SCREEPS_RUNTIME_SUMMARY_DIR`, and `SCREEPS_RUNTIME_SUMMARY_CONSOLE_OUT_DIR` still win.
 
 ## Seasonal Smoke Contract
 

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -28,6 +28,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
+import screeps_world_profiles as world_profiles
+
 
 DEFAULT_API_URL = "https://screeps.com"
 DEFAULT_OUT_DIR = Path("/root/screeps/runtime-artifacts/screeps-monitor")
@@ -39,6 +41,7 @@ DEFAULT_COLLECTION_ATTEMPTS = 3
 DEFAULT_COLLECTION_RETRY_DELAY_SECONDS = 5
 DEFAULT_SHARD = "shardX"
 DEFAULT_ROOM = "W3N9"
+WORLD_PROFILE_ENV = world_profiles.WORLD_PROFILE_ENV
 RUNTIME_SUMMARY_PREFIX = "#runtime-summary "
 WORKER_IDLE_COLLAPSE_KIND = "worker_idle_collapse"
 WORKER_IDLE_COLLAPSE_TICK_THRESHOLD = 20
@@ -607,7 +610,12 @@ def parse_room_arg(value: str | None, default_shard: str) -> RoomRef | None:
     return RoomRef(shard=default_shard, room=value)
 
 
-def context_from_env() -> RuntimeContext:
+def env_default(name: str, default: str) -> str:
+    return os.environ[name] if name in os.environ else default
+
+
+def context_from_env(world_profile: str | None = None) -> RuntimeContext:
+    profile = world_profiles.resolve_world_profile(world_profile, os.environ)
     token = os.environ.get("SCREEPS_AUTH_TOKEN")
     if not token:
         raise RuntimeError("SCREEPS_AUTH_TOKEN is required for live summary and alert commands")
@@ -618,14 +626,14 @@ def context_from_env() -> RuntimeContext:
         float(os.environ.get("SCREEPS_MONITOR_COLLECTION_RETRY_DELAY_SECONDS", DEFAULT_COLLECTION_RETRY_DELAY_SECONDS)),
     )
     return RuntimeContext(
-        base_http=os.environ.get("SCREEPS_API_URL", DEFAULT_API_URL).rstrip("/"),
+        base_http=env_default("SCREEPS_API_URL", profile.api_url).rstrip("/"),
         token=token,
-        default_shard=os.environ.get("SCREEPS_SHARD", DEFAULT_SHARD),
+        default_shard=env_default("SCREEPS_SHARD", profile.shard),
         default_room=os.environ.get("SCREEPS_ROOM", DEFAULT_ROOM),
         owner=os.environ.get("SCREEPS_OWNER"),
         owner_id=os.environ.get("SCREEPS_OWNER_ID"),
-        state_file=Path(os.environ.get("SCREEPS_MONITOR_STATE_FILE", str(DEFAULT_STATE_FILE))),
-        cache_dir=Path(os.environ.get("SCREEPS_MONITOR_CACHE_DIR", str(DEFAULT_CACHE_DIR))),
+        state_file=Path(env_default("SCREEPS_MONITOR_STATE_FILE", str(profile.monitor_state_file))),
+        cache_dir=Path(env_default("SCREEPS_MONITOR_CACHE_DIR", str(profile.monitor_cache_dir))),
         debounce_seconds=debounce,
         collection_attempts=collection_attempts,
         collection_retry_delay_seconds=collection_retry_delay_seconds,
@@ -4064,7 +4072,7 @@ def command_health_gate(args: argparse.Namespace) -> int:
 
 
 def command_summary(args: argparse.Namespace) -> int:
-    ctx = context_from_env()
+    ctx = context_from_env(args.world_profile)
     snapshots, warnings = collect_snapshots(ctx, args.room)
     images: list[str] = []
     room_summaries: list[dict[str, Any]] = []
@@ -4100,7 +4108,7 @@ def command_summary(args: argparse.Namespace) -> int:
 
 
 def command_alert(args: argparse.Namespace) -> int:
-    ctx = context_from_env()
+    ctx = context_from_env(args.world_profile)
     snapshots, warnings = collect_snapshots(ctx, args.room)
     runtime_room_summaries = load_latest_runtime_room_summaries(
         Path(args.runtime_summary_dir).expanduser(),
@@ -4186,12 +4194,41 @@ def command_tactical_response(args: argparse.Namespace) -> int:
     return 0
 
 
+def apply_world_profile_defaults(args: argparse.Namespace) -> argparse.Namespace:
+    if not hasattr(args, "world_profile"):
+        return args
+
+    profile = world_profiles.resolve_world_profile(getattr(args, "world_profile", None), os.environ)
+    args.world_profile = profile.name
+    if hasattr(args, "out_dir") and getattr(args, "out_dir") is None:
+        args.out_dir = str(profile.monitor_out_dir)
+    if hasattr(args, "runtime_summary_out_dir") and getattr(args, "runtime_summary_out_dir") is None:
+        args.runtime_summary_out_dir = str(profile.runtime_summary_out_dir)
+    if hasattr(args, "runtime_summary_dir") and getattr(args, "runtime_summary_dir") is None:
+        args.runtime_summary_dir = env_default("SCREEPS_RUNTIME_SUMMARY_DIR", str(profile.runtime_summary_out_dir))
+    return args
+
+
+class WorldProfileArgumentParser(argparse.ArgumentParser):
+    def parse_args(
+        self,
+        args: list[str] | None = None,
+        namespace: argparse.Namespace | None = None,
+    ) -> argparse.Namespace:
+        parsed = super().parse_args(args, namespace)
+        try:
+            return apply_world_profile_defaults(parsed)
+        except ValueError as exc:
+            self.error(str(exc))
+
+
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Render Screeps runtime summary and alert monitor images.")
+    parser = WorldProfileArgumentParser(description="Render Screeps runtime summary and alert monitor images.")
     subcommands = parser.add_subparsers(dest="command", required=True)
 
     def add_live_options(subparser: argparse.ArgumentParser) -> None:
-        subparser.add_argument("--out-dir", default=str(DEFAULT_OUT_DIR), help=f"artifact directory (default: {DEFAULT_OUT_DIR})")
+        world_profiles.add_world_profile_argument(subparser)
+        subparser.add_argument("--out-dir", default=None, help=f"artifact directory (default: {DEFAULT_OUT_DIR})")
         subparser.add_argument("--room", help="optional single room selector, preferably shard/room")
         subparser.add_argument("--format", choices=["json"], default="json", help="output format")
 
@@ -4199,7 +4236,7 @@ def build_parser() -> argparse.ArgumentParser:
     add_live_options(summary)
     summary.add_argument(
         "--runtime-summary-out-dir",
-        default=str(DEFAULT_RUNTIME_SUMMARY_OUT_DIR),
+        default=None,
         help="Directory for reducer-compatible #runtime-summary artifacts written from the same live room snapshot.",
     )
     summary.add_argument(
@@ -4214,7 +4251,7 @@ def build_parser() -> argparse.ArgumentParser:
     alert.add_argument("--force-alert-image", action="store_true", help="render alert-style image even when no alert is emitted")
     alert.add_argument(
         "--runtime-summary-dir",
-        default=os.environ.get("SCREEPS_RUNTIME_SUMMARY_DIR", str(DEFAULT_RUNTIME_SUMMARY_OUT_DIR)),
+        default=None,
         help="Directory containing persisted #runtime-summary console .log artifacts for semantic alert rules.",
     )
     alert.set_defaults(func=command_alert)

--- a/scripts/screeps_runtime_summary_console_capture.py
+++ b/scripts/screeps_runtime_summary_console_capture.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Iterable, TextIO
 
 import screeps_runtime_kpi_reducer as reducer
+import screeps_world_profiles as world_profiles
 
 
 DEFAULT_OUT_DIR = Path("/root/screeps/runtime-artifacts/runtime-summary-console")
@@ -32,6 +33,7 @@ API_URL_ENV = "SCREEPS_API_URL"
 CONSOLE_CHANNELS_ENV = "SCREEPS_CONSOLE_CHANNELS"
 LIVE_TIMEOUT_ENV = "SCREEPS_CONSOLE_CAPTURE_TIMEOUT_SECONDS"
 LIVE_MAX_MESSAGES_ENV = "SCREEPS_CONSOLE_CAPTURE_MAX_MESSAGES"
+WORLD_PROFILE_ENV = world_profiles.WORLD_PROFILE_ENV
 SAFE_ARTIFACT_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 
@@ -454,13 +456,43 @@ def render_human(result: PersistResult) -> str:
     return rendered
 
 
+def env_default(name: str, default: str) -> str:
+    return os.environ[name] if name in os.environ else default
+
+
+def apply_world_profile_defaults(args: argparse.Namespace) -> argparse.Namespace:
+    profile = world_profiles.resolve_world_profile(getattr(args, "world_profile", None), os.environ)
+    args.world_profile = profile.name
+    if getattr(args, "out_dir", None) is None:
+        args.out_dir = env_default(OUT_DIR_ENV, str(profile.console_capture_out_dir))
+    if getattr(args, "out_file", None) is None and OUT_FILE_ENV in os.environ:
+        args.out_file = os.environ[OUT_FILE_ENV]
+    if getattr(args, "api_url", None) is None:
+        args.api_url = env_default(API_URL_ENV, profile.api_url)
+    return args
+
+
+class WorldProfileArgumentParser(argparse.ArgumentParser):
+    def parse_args(
+        self,
+        args: list[str] | None = None,
+        namespace: argparse.Namespace | None = None,
+    ) -> argparse.Namespace:
+        parsed = super().parse_args(args, namespace)
+        try:
+            return apply_world_profile_defaults(parsed)
+        except ValueError as exc:
+            self.error(str(exc))
+
+
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
+    parser = WorldProfileArgumentParser(
         description=(
             "Persist only exact-prefix Screeps #runtime-summary console lines into a local artifact "
             "that the KPI artifact bridge can scan."
         ),
     )
+    world_profiles.add_world_profile_argument(parser)
     parser.add_argument(
         "inputs",
         nargs="*",
@@ -468,12 +500,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--out-dir",
-        default=os.environ.get(OUT_DIR_ENV, str(DEFAULT_OUT_DIR)),
+        default=None,
         help=f"Artifact directory. Default: ${OUT_DIR_ENV} or {DEFAULT_OUT_DIR}.",
     )
     parser.add_argument(
         "--out-file",
-        default=os.environ.get(OUT_FILE_ENV),
+        default=None,
         help=f"Exact artifact file path. Overrides --out-dir and --artifact-name. May also be set with ${OUT_FILE_ENV}.",
     )
     parser.add_argument(
@@ -496,7 +528,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--api-url",
-        default=os.environ.get(API_URL_ENV, DEFAULT_API_URL),
+        default=None,
         help=f"Screeps API base URL for live capture. Default: ${API_URL_ENV} or {DEFAULT_API_URL}.",
     )
     parser.add_argument(

--- a/scripts/screeps_world_profiles.py
+++ b/scripts/screeps_world_profiles.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Shared official Screeps world profile defaults."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+
+WORLD_PROFILE_ENV = "SCREEPS_WORLD_PROFILE"
+PERSISTENT_PROFILE = "persistent"
+SEASONAL_PROFILE = "seasonal"
+VALID_WORLD_PROFILES = (PERSISTENT_PROFILE, SEASONAL_PROFILE)
+
+
+@dataclass(frozen=True)
+class WorldProfileDefaults:
+    name: str
+    api_url: str
+    shard: str
+    monitor_out_dir: Path
+    monitor_state_file: Path
+    monitor_cache_dir: Path
+    runtime_summary_out_dir: Path
+    console_capture_out_dir: Path
+
+
+PERSISTENT_DEFAULTS = WorldProfileDefaults(
+    name=PERSISTENT_PROFILE,
+    api_url="https://screeps.com",
+    shard="shardX",
+    monitor_out_dir=Path("/root/screeps/runtime-artifacts/screeps-monitor"),
+    monitor_state_file=Path("/root/.hermes/screeps-runtime-monitor/state.json"),
+    monitor_cache_dir=Path("/root/.hermes/screeps-runtime-monitor/terrain-cache"),
+    runtime_summary_out_dir=Path("/root/screeps/runtime-artifacts/runtime-summary-console"),
+    console_capture_out_dir=Path("/root/screeps/runtime-artifacts/runtime-summary-console"),
+)
+
+SEASONAL_DEFAULTS = WorldProfileDefaults(
+    name=SEASONAL_PROFILE,
+    api_url="https://screeps.com/season",
+    shard="shardSeason",
+    monitor_out_dir=Path("/root/screeps/runtime-artifacts/seasonal/screeps-monitor"),
+    monitor_state_file=Path("/root/.hermes/screeps-seasonal-runtime-monitor/state.json"),
+    monitor_cache_dir=Path("/root/.hermes/screeps-seasonal-runtime-monitor/terrain-cache"),
+    runtime_summary_out_dir=Path("/root/screeps/runtime-artifacts/seasonal/runtime-summary-console"),
+    console_capture_out_dir=Path("/root/screeps/runtime-artifacts/seasonal/runtime-summary-console"),
+)
+
+WORLD_PROFILE_DEFAULTS = {
+    PERSISTENT_PROFILE: PERSISTENT_DEFAULTS,
+    SEASONAL_PROFILE: SEASONAL_DEFAULTS,
+}
+
+
+def parse_world_profile(value: str) -> str:
+    profile = value.strip().lower()
+    if profile not in WORLD_PROFILE_DEFAULTS:
+        choices = ", ".join(VALID_WORLD_PROFILES)
+        raise argparse.ArgumentTypeError(f"world profile must be one of: {choices}")
+    return profile
+
+
+def resolve_world_profile(
+    value: str | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> WorldProfileDefaults:
+    env = environ if environ is not None else os.environ
+    raw_value = value
+    source = "--world-profile"
+    if raw_value is None or not raw_value.strip():
+        raw_value = env.get(WORLD_PROFILE_ENV, PERSISTENT_PROFILE)
+        source = f"${WORLD_PROFILE_ENV}"
+    if raw_value is None or not raw_value.strip():
+        raw_value = PERSISTENT_PROFILE
+
+    try:
+        profile = parse_world_profile(raw_value)
+    except argparse.ArgumentTypeError as exc:
+        raise ValueError(f"invalid {source}: {exc}") from exc
+    return WORLD_PROFILE_DEFAULTS[profile]
+
+
+def add_world_profile_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--world-profile",
+        default=None,
+        type=parse_world_profile,
+        help=(
+            "World profile for default paths and selectors. "
+            f"Default: ${WORLD_PROFILE_ENV} or {PERSISTENT_PROFILE}. "
+            f"Choices: {', '.join(VALID_WORLD_PROFILES)}."
+        ),
+    )

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -8,9 +8,11 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 MODULE_PATH = Path(__file__).with_name("screeps-runtime-monitor.py")
+sys.path.insert(0, str(MODULE_PATH.parent))
 SPEC = importlib.util.spec_from_file_location("screeps_runtime_monitor_script", MODULE_PATH)
 if SPEC is None or SPEC.loader is None:
     raise RuntimeError(f"could not load {MODULE_PATH}")
@@ -196,6 +198,102 @@ def make_snapshot(objects: dict[str, dict[str, object]]) -> monitor.RoomSnapshot
         owner="owner",
         info={},
     )
+
+
+class WorldProfileDefaultsTest(unittest.TestCase):
+    def test_persistent_profile_preserves_monitor_defaults(self) -> None:
+        self.assertEqual(monitor.DEFAULT_OUT_DIR, Path("/root/screeps/runtime-artifacts/screeps-monitor"))
+        self.assertEqual(monitor.DEFAULT_STATE_FILE, Path("/root/.hermes/screeps-runtime-monitor/state.json"))
+        self.assertEqual(monitor.DEFAULT_CACHE_DIR, Path("/root/.hermes/screeps-runtime-monitor/terrain-cache"))
+        self.assertEqual(
+            monitor.DEFAULT_RUNTIME_SUMMARY_OUT_DIR,
+            Path("/root/screeps/runtime-artifacts/runtime-summary-console"),
+        )
+
+        with mock.patch.dict(monitor.os.environ, {"SCREEPS_AUTH_TOKEN": "token"}, clear=True):
+            summary_args = monitor.build_parser().parse_args(["summary"])
+            alert_args = monitor.build_parser().parse_args(["alert"])
+            ctx = monitor.context_from_env(summary_args.world_profile)
+
+        self.assertEqual(summary_args.world_profile, "persistent")
+        self.assertEqual(Path(summary_args.out_dir), monitor.DEFAULT_OUT_DIR)
+        self.assertEqual(Path(summary_args.runtime_summary_out_dir), monitor.DEFAULT_RUNTIME_SUMMARY_OUT_DIR)
+        self.assertEqual(alert_args.world_profile, "persistent")
+        self.assertEqual(Path(alert_args.out_dir), monitor.DEFAULT_OUT_DIR)
+        self.assertEqual(Path(alert_args.runtime_summary_dir), monitor.DEFAULT_RUNTIME_SUMMARY_OUT_DIR)
+        self.assertEqual(ctx.base_http, monitor.DEFAULT_API_URL)
+        self.assertEqual(ctx.default_shard, monitor.DEFAULT_SHARD)
+        self.assertEqual(ctx.default_room, monitor.DEFAULT_ROOM)
+        self.assertEqual(ctx.state_file, monitor.DEFAULT_STATE_FILE)
+        self.assertEqual(ctx.cache_dir, monitor.DEFAULT_CACHE_DIR)
+
+    def test_seasonal_profile_isolates_monitor_defaults(self) -> None:
+        with mock.patch.dict(monitor.os.environ, {"SCREEPS_AUTH_TOKEN": "token"}, clear=True):
+            summary_args = monitor.build_parser().parse_args(["summary", "--world-profile", "seasonal"])
+            alert_args = monitor.build_parser().parse_args(["alert", "--world-profile", "seasonal"])
+            ctx = monitor.context_from_env(summary_args.world_profile)
+
+        self.assertEqual(summary_args.world_profile, "seasonal")
+        self.assertEqual(Path(summary_args.out_dir), Path("/root/screeps/runtime-artifacts/seasonal/screeps-monitor"))
+        self.assertEqual(
+            Path(summary_args.runtime_summary_out_dir),
+            Path("/root/screeps/runtime-artifacts/seasonal/runtime-summary-console"),
+        )
+        self.assertEqual(alert_args.world_profile, "seasonal")
+        self.assertEqual(Path(alert_args.out_dir), Path("/root/screeps/runtime-artifacts/seasonal/screeps-monitor"))
+        self.assertEqual(
+            Path(alert_args.runtime_summary_dir),
+            Path("/root/screeps/runtime-artifacts/seasonal/runtime-summary-console"),
+        )
+        self.assertEqual(ctx.base_http, "https://screeps.com/season")
+        self.assertEqual(ctx.default_shard, "shardSeason")
+        self.assertEqual(ctx.default_room, monitor.DEFAULT_ROOM)
+        self.assertEqual(ctx.state_file, Path("/root/.hermes/screeps-seasonal-runtime-monitor/state.json"))
+        self.assertEqual(ctx.cache_dir, Path("/root/.hermes/screeps-seasonal-runtime-monitor/terrain-cache"))
+
+    def test_profile_env_and_explicit_overrides_win_for_monitor(self) -> None:
+        with mock.patch.dict(
+            monitor.os.environ,
+            {
+                "SCREEPS_AUTH_TOKEN": "token",
+                "SCREEPS_WORLD_PROFILE": "seasonal",
+                "SCREEPS_API_URL": "https://example.invalid/custom",
+                "SCREEPS_SHARD": "shardCustom",
+                "SCREEPS_MONITOR_STATE_FILE": "/tmp/custom-state.json",
+                "SCREEPS_MONITOR_CACHE_DIR": "/tmp/custom-cache",
+                "SCREEPS_RUNTIME_SUMMARY_DIR": "/tmp/custom-runtime-summary",
+            },
+            clear=True,
+        ):
+            summary_args = monitor.build_parser().parse_args(
+                [
+                    "summary",
+                    "--out-dir",
+                    "/tmp/custom-monitor",
+                    "--runtime-summary-out-dir",
+                    "/tmp/custom-summary-out",
+                ]
+            )
+            alert_args = monitor.build_parser().parse_args(["alert"])
+            ctx = monitor.context_from_env(summary_args.world_profile)
+
+        self.assertEqual(summary_args.world_profile, "seasonal")
+        self.assertEqual(Path(summary_args.out_dir), Path("/tmp/custom-monitor"))
+        self.assertEqual(Path(summary_args.runtime_summary_out_dir), Path("/tmp/custom-summary-out"))
+        self.assertEqual(Path(alert_args.runtime_summary_dir), Path("/tmp/custom-runtime-summary"))
+        self.assertEqual(ctx.base_http, "https://example.invalid/custom")
+        self.assertEqual(ctx.default_shard, "shardCustom")
+        self.assertEqual(ctx.state_file, Path("/tmp/custom-state.json"))
+        self.assertEqual(ctx.cache_dir, Path("/tmp/custom-cache"))
+
+    def test_invalid_monitor_world_profile_is_rejected(self) -> None:
+        with mock.patch.dict(monitor.os.environ, {}, clear=True):
+            with self.assertRaises(SystemExit):
+                monitor.build_parser().parse_args(["summary", "--world-profile", "invalid"])
+
+        with mock.patch.dict(monitor.os.environ, {"SCREEPS_WORLD_PROFILE": "invalid"}, clear=True):
+            with self.assertRaises(SystemExit):
+                monitor.build_parser().parse_args(["summary"])
 
 
 class TacticalResponseBridgeTest(unittest.TestCase):

--- a/scripts/test_screeps_runtime_summary_console_capture.py
+++ b/scripts/test_screeps_runtime_summary_console_capture.py
@@ -119,7 +119,11 @@ class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
 
         self.assertEqual(capture.DEFAULT_OUT_DIR, expected)
         self.assertIn(str(expected.parent), bridge.DEFAULT_INPUT_PATHS)
-        self.assertEqual(Path(capture.build_parser().parse_args([]).out_dir), expected)
+        with mock.patch.dict(capture.os.environ, {}, clear=True):
+            args = capture.build_parser().parse_args([])
+        self.assertEqual(args.world_profile, "persistent")
+        self.assertEqual(Path(args.out_dir), expected)
+        self.assertEqual(args.api_url, capture.DEFAULT_API_URL)
 
         env_override = Path("/tmp/runtime-summary-console-env")
         with mock.patch.dict(capture.os.environ, {capture.OUT_DIR_ENV: str(env_override)}):
@@ -131,6 +135,52 @@ class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
                 Path(capture.build_parser().parse_args(["--out-dir", str(cli_override)]).out_dir),
                 cli_override,
             )
+
+    def test_seasonal_profile_isolates_console_capture_defaults(self) -> None:
+        with mock.patch.dict(capture.os.environ, {}, clear=True):
+            args = capture.build_parser().parse_args(["--world-profile", "seasonal"])
+
+        self.assertEqual(args.world_profile, "seasonal")
+        self.assertEqual(
+            Path(args.out_dir),
+            Path("/root/screeps/runtime-artifacts/seasonal/runtime-summary-console"),
+        )
+        self.assertEqual(args.api_url, "https://screeps.com/season")
+
+    def test_profile_env_and_explicit_overrides_win_for_console_capture(self) -> None:
+        with mock.patch.dict(
+            capture.os.environ,
+            {
+                "SCREEPS_WORLD_PROFILE": "seasonal",
+                capture.OUT_DIR_ENV: "/tmp/runtime-summary-console-env",
+                capture.API_URL_ENV: "https://example.invalid/custom",
+            },
+            clear=True,
+        ):
+            env_args = capture.build_parser().parse_args([])
+            cli_args = capture.build_parser().parse_args(
+                [
+                    "--out-dir",
+                    "/tmp/runtime-summary-console-cli",
+                    "--api-url",
+                    "https://example.invalid/cli",
+                ]
+            )
+
+        self.assertEqual(env_args.world_profile, "seasonal")
+        self.assertEqual(Path(env_args.out_dir), Path("/tmp/runtime-summary-console-env"))
+        self.assertEqual(env_args.api_url, "https://example.invalid/custom")
+        self.assertEqual(Path(cli_args.out_dir), Path("/tmp/runtime-summary-console-cli"))
+        self.assertEqual(cli_args.api_url, "https://example.invalid/cli")
+
+    def test_invalid_console_capture_world_profile_is_rejected(self) -> None:
+        with mock.patch.dict(capture.os.environ, {}, clear=True):
+            with self.assertRaises(SystemExit):
+                capture.build_parser().parse_args(["--world-profile", "invalid"])
+
+        with mock.patch.dict(capture.os.environ, {"SCREEPS_WORLD_PROFILE": "invalid"}, clear=True):
+            with self.assertRaises(SystemExit):
+                capture.build_parser().parse_args([])
 
     def test_does_not_write_artifact_when_no_summary_lines_match(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- Adds a shared `scripts/screeps_world_profiles.py` helper for explicit `persistent` vs `seasonal` defaults.
- Adds `SCREEPS_WORLD_PROFILE` / `--world-profile` opt-in handling for the runtime monitor and runtime-summary console capture tooling.
- Keeps all persistent defaults unchanged while seasonal profile defaults route to isolated runtime artifact/state/cache paths.
- Documents the exact profile override contract in `docs/ops/screeps-world-profiles.md`.

## Persistent MMO no-impact verification
Persistent defaults remain unchanged when no profile is selected:
```json
{
  "persistentMonitor": {
    "profile": "persistent",
    "apiUrl": "https://screeps.com",
    "shard": "shardX",
    "outDir": "/root/screeps/runtime-artifacts/screeps-monitor",
    "runtimeSummaryOutDir": "/root/screeps/runtime-artifacts/runtime-summary-console",
    "alertRuntimeSummaryDir": "/root/screeps/runtime-artifacts/runtime-summary-console",
    "stateFile": "/root/.hermes/screeps-runtime-monitor/state.json",
    "cacheDir": "/root/.hermes/screeps-runtime-monitor/terrain-cache"
  },
  "persistentConsole": {
    "profile": "persistent",
    "apiUrl": "https://screeps.com",
    "outDir": "/root/screeps/runtime-artifacts/runtime-summary-console"
  }
}
```

Seasonal profile is explicit opt-in and isolated:
```json
{
  "seasonalMonitor": {
    "profile": "seasonal",
    "apiUrl": "https://screeps.com/season",
    "shard": "shardSeason",
    "outDir": "/root/screeps/runtime-artifacts/seasonal/screeps-monitor",
    "runtimeSummaryOutDir": "/root/screeps/runtime-artifacts/seasonal/runtime-summary-console",
    "alertRuntimeSummaryDir": "/root/screeps/runtime-artifacts/seasonal/runtime-summary-console",
    "stateFile": "/root/.hermes/screeps-seasonal-runtime-monitor/state.json",
    "cacheDir": "/root/.hermes/screeps-seasonal-runtime-monitor/terrain-cache"
  },
  "seasonalConsole": {
    "profile": "seasonal",
    "apiUrl": "https://screeps.com/season",
    "outDir": "/root/screeps/runtime-artifacts/seasonal/runtime-summary-console"
  }
}
```

## Verification
- TDD: added monitor/console profile tests first and observed RED before implementation.
- `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/screeps_runtime_summary_console_capture.py scripts/screeps_world_profiles.py`
- `python3 -m unittest scripts.test_screeps_runtime_monitor_tactical_response scripts.test_screeps_runtime_summary_console_capture` — 48 tests passed
- `python3 -m unittest discover scripts` — 248 tests passed
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 95 suites / 1819 tests passed
- `cd prod && npm run build`
- `git diff --check`
- Explicit parser/context proof for persistent and seasonal monitor/console defaults.

Resolves #1072
