### PR TITLE
feat: scope runtime KPI artifacts by world

### DIFF
--- a/scripts/generate-roadmap-page.py
+++ b/scripts/generate-roadmap-page.py
@@ -1531,8 +1531,10 @@ def load_runtime_artifact_metric_history(
     generated_at: str,
     existing_history: JsonObject,
     paths: Sequence[str] | None = None,
+    world_id: str = runtime_kpi_bridge.PERSISTENT_WORLD_ID,
 ) -> tuple[JsonObject, JsonObject]:
     input_paths = runtime_history_input_paths(repo_root) if paths is None else list(paths)
+    selected_world_id = runtime_kpi_bridge.normalize_world_id(world_id) or runtime_kpi_bridge.PERSISTENT_WORLD_ID
     try:
         scan_result = runtime_kpi_bridge.collect_runtime_summary_lines(input_paths)
     except Exception as error:
@@ -1541,13 +1543,19 @@ def load_runtime_artifact_metric_history(
             "message": "runtime-summary artifact history scan failed",
             "error": error.__class__.__name__,
             "inputPaths": runtime_history_input_path_labels(input_paths),
+            "worldId": selected_world_id,
         }
 
     buckets = report_kpi_date_buckets(existing_history, generated_at)
     bucket_days = set(buckets)
     records_by_day: dict[date, list[runtime_kpi_bridge.RuntimeSummaryRecord]] = {}
     untimestamped_records = 0
-    for record in scan_result.records:
+    selected_records = [
+        record
+        for record in scan_result.records
+        if runtime_kpi_bridge.normalize_world_id(getattr(record, "world_id", None)) == selected_world_id
+    ]
+    for record in selected_records:
         if record.timestamp is None:
             untimestamped_records += 1
             continue
@@ -1573,7 +1581,7 @@ def load_runtime_artifact_metric_history(
         if latest_record is None:
             continue
         sampled_at = format_utc_timestamp(latest_record)
-        provenance = daily_runtime_history_provenance(report)
+        provenance = daily_runtime_history_provenance(report, world_id=selected_world_id)
         for metric in build_current_metrics(report):
             history.setdefault(metric["key"], []).append(
                 metric_history_point(
@@ -1587,6 +1595,7 @@ def load_runtime_artifact_metric_history(
 
     day_count = len(records_by_day)
     status = "observed" if day_count else "unavailable"
+    scan_metadata = scan_result.metadata()
     return history, {
         "status": status,
         "message": (
@@ -1597,10 +1606,14 @@ def load_runtime_artifact_metric_history(
         "inputPaths": runtime_history_input_path_labels(scan_result.input_paths),
         "matchedFiles": scan_result.matched_files,
         "runtimeSummaryLines": len(scan_result.lines),
+        "selectedRuntimeSummaryLines": len(selected_records),
         "scannedFiles": scan_result.scanned_files,
         "skippedFileCount": len(scan_result.skipped_files),
         "untimestampedRuntimeSummaryLines": untimestamped_records,
         "dailyBucketDays": day_count,
+        "worldId": selected_world_id,
+        "worldIdCounts": scan_metadata.get("worldIdCounts", {}),
+        "worldIdStatusCounts": scan_metadata.get("worldIdStatusCounts", {}),
     }
 
 
@@ -1630,15 +1643,21 @@ def format_utc_timestamp(value: datetime) -> str:
     return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
-def daily_runtime_history_provenance(report: JsonObject) -> JsonObject:
+def daily_runtime_history_provenance(
+    report: JsonObject,
+    world_id: str = runtime_kpi_bridge.PERSISTENT_WORLD_ID,
+) -> JsonObject:
     target = build_screeps_room_target()
     latest_rooms = get_path(report, ("territory", "ownedRooms", "latest"), [])
     if not isinstance(latest_rooms, list):
         latest_rooms = []
+    selected_world_id = runtime_kpi_bridge.normalize_world_id(world_id) or runtime_kpi_bridge.PERSISTENT_WORLD_ID
     return {
         "sourceKind": RUNTIME_ARTIFACT_SOURCE_KIND,
         "reducerSchemaVersion": report.get("schemaVersion"),
         "scope": {
+            "targetWorld": selected_world_id,
+            "worldId": selected_world_id,
             "targetShard": target.get("shard"),
             "targetRoom": target.get("room"),
             "targetStatus": target.get("status"),

--- a/scripts/screeps_runtime_kpi_artifact_bridge.py
+++ b/scripts/screeps_runtime_kpi_artifact_bridge.py
@@ -20,6 +20,9 @@ DEFAULT_INPUT_PATHS = (
     "/root/.hermes/cron/output",
 )
 DEFAULT_MAX_FILE_BYTES = 5 * 1024 * 1024
+PERSISTENT_WORLD_ID = "persistent"
+SEASONAL_WORLD_ID = "seasonal"
+RUNTIME_SUMMARY_WORLD_FIELDS = ("worldId", "world", "worldProfile")
 
 JsonObject = dict[str, Any]
 
@@ -29,6 +32,9 @@ class RuntimeSummaryRecord:
     line: str
     path: Path
     timestamp: datetime | None
+    world_id: str = PERSISTENT_WORLD_ID
+    world_id_status: str = "fallback"
+    world_id_source: str = "default"
 
 
 @dataclass
@@ -53,6 +59,8 @@ class ScanResult:
             "scannedFiles": self.scanned_files,
             "skippedFileCount": len(self.skipped_files),
             "skippedFiles": self.skipped_files,
+            "worldIdCounts": count_record_values(self.records, "world_id"),
+            "worldIdStatusCounts": count_record_values(self.records, "world_id_status"),
         }
 
 
@@ -162,7 +170,18 @@ def scan_file(path: Path, result: ScanResult, max_file_bytes: int) -> None:
     result.matched_files += 1
     result.lines.extend(matching_lines)
     timestamp = infer_runtime_summary_timestamp(path)
-    result.records.extend(RuntimeSummaryRecord(line=line, path=path, timestamp=timestamp) for line in matching_lines)
+    for line in matching_lines:
+        world_id, world_id_status, world_id_source = infer_runtime_summary_world_id(line, path)
+        result.records.append(
+            RuntimeSummaryRecord(
+                line=line,
+                path=path,
+                timestamp=timestamp,
+                world_id=world_id,
+                world_id_status=world_id_status,
+                world_id_source=world_id_source,
+            )
+        )
 
 
 def infer_runtime_summary_timestamp(path: Path) -> datetime | None:
@@ -176,6 +195,45 @@ def infer_runtime_summary_timestamp(path: Path) -> datetime | None:
         return dashed_match
 
     return None
+
+
+def normalize_world_id(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if normalized in {"season", "seasonal", "screeps-seasonal"}:
+        return SEASONAL_WORLD_ID
+    if normalized in {"main", "mmo", "official", "persistent", "screeps"}:
+        return PERSISTENT_WORLD_ID
+    return re.sub(r"[^a-z0-9_.-]+", "-", normalized).strip("-") or None
+
+
+def infer_runtime_summary_world_id(line: str, path: Path) -> tuple[str, str, str]:
+    payload, _malformed = reducer.parse_runtime_summary_line(line)
+    if isinstance(payload, dict):
+        for field_name in RUNTIME_SUMMARY_WORLD_FIELDS:
+            world_id = normalize_world_id(payload.get(field_name))
+            if world_id is not None:
+                return world_id, "explicit", f"payload.{field_name}"
+
+    for part in path.parts:
+        normalized = part.strip().lower()
+        if normalized == SEASONAL_WORLD_ID or normalized == "screeps-seasonal-runtime-monitor":
+            return SEASONAL_WORLD_ID, "path", "path"
+
+    return PERSISTENT_WORLD_ID, "fallback", "default"
+
+
+def count_record_values(records: Sequence[RuntimeSummaryRecord], attribute: str) -> JsonObject:
+    counts: dict[str, int] = {}
+    for record in records:
+        value = str(getattr(record, attribute, "") or "")
+        if not value:
+            continue
+        counts[value] = counts.get(value, 0) + 1
+    return {key: counts[key] for key in sorted(counts)}
 
 
 def re_search_timestamp(pattern: str, value: str) -> datetime | None:

--- a/scripts/test_generate_roadmap_page.py
+++ b/scripts/test_generate_roadmap_page.py
@@ -165,7 +165,15 @@ def lfs_pointer_text() -> str:
     )
 
 
-def runtime_summary_line(*, tick: int, level: int = 3, stored_energy: int = 0, hostile_creeps: int = 0) -> str:
+def runtime_summary_line(
+    *,
+    tick: int,
+    level: int = 3,
+    stored_energy: int = 0,
+    hostile_creeps: int = 0,
+    world_id: str | None = None,
+    world_profile: str | None = None,
+) -> str:
     payload = {
         "type": "runtime-summary",
         "tick": tick,
@@ -193,6 +201,10 @@ def runtime_summary_line(*, tick: int, level: int = 3, stored_energy: int = 0, h
             }
         ],
     }
+    if world_id is not None:
+        payload["worldId"] = world_id
+    if world_profile is not None:
+        payload["worldProfile"] = world_profile
     return f"#runtime-summary {json.dumps(payload, sort_keys=True)}\n"
 
 
@@ -529,6 +541,60 @@ class GenerateRoadmapPageTest(unittest.TestCase):
         self.assertEqual(stored_energy["scope"]["targetShard"], "shardX")
         self.assertEqual(stored_energy["scope"]["targetRoom"], "W3N9")
         self.assertEqual(stored_energy["scope"]["observedRooms"], ["E19S57", "W9N9"])
+
+    def test_runtime_artifact_history_filters_by_world_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            persistent_dir = repo_root / "runtime-artifacts" / "runtime-summary-console"
+            seasonal_dir = repo_root / "runtime-artifacts" / "seasonal" / "runtime-summary-console"
+            persistent_dir.mkdir(parents=True)
+            seasonal_dir.mkdir(parents=True)
+            (persistent_dir / "runtime-summary-console-20260501T120000Z.log").write_text(
+                runtime_summary_line(tick=100, stored_energy=100),
+                encoding="utf-8",
+            )
+            (seasonal_dir / "runtime-summary-console-20260501T130000Z.log").write_text(
+                runtime_summary_line(tick=200, stored_energy=900),
+                encoding="utf-8",
+            )
+            (persistent_dir / "runtime-summary-console-20260502T120000Z.log").write_text(
+                runtime_summary_line(tick=300, stored_energy=700, world_profile="seasonal"),
+                encoding="utf-8",
+            )
+
+            persistent_history, persistent_status = roadmap.load_runtime_artifact_metric_history(
+                repo_root,
+                "2026-05-02T15:00:00Z",
+                {},
+                paths=[str(repo_root / "runtime-artifacts")],
+            )
+            seasonal_history, seasonal_status = roadmap.load_runtime_artifact_metric_history(
+                repo_root,
+                "2026-05-02T15:00:00Z",
+                {},
+                paths=[str(repo_root / "runtime-artifacts")],
+                world_id="seasonal",
+            )
+
+        persistent_values = [point["value"] for point in persistent_history["stored_energy"]]
+        seasonal_values = [point["value"] for point in seasonal_history["stored_energy"]]
+
+        self.assertEqual(persistent_status["worldId"], "persistent")
+        self.assertEqual(persistent_status["dailyBucketDays"], 1)
+        self.assertEqual(persistent_status["selectedRuntimeSummaryLines"], 1)
+        self.assertEqual(persistent_status["worldIdCounts"], {"persistent": 1, "seasonal": 2})
+        self.assertEqual(persistent_values, [100])
+        self.assertEqual(persistent_history["stored_energy"][0]["scope"]["targetWorld"], "persistent")
+        self.assertEqual(persistent_history["stored_energy"][0]["scope"]["worldId"], "persistent")
+        self.assertEqual(persistent_history["stored_energy"][0]["scope"]["targetShard"], "shardX")
+        self.assertEqual(persistent_history["stored_energy"][0]["scope"]["targetRoom"], "W3N9")
+
+        self.assertEqual(seasonal_status["worldId"], "seasonal")
+        self.assertEqual(seasonal_status["dailyBucketDays"], 2)
+        self.assertEqual(seasonal_status["selectedRuntimeSummaryLines"], 2)
+        self.assertEqual(seasonal_values, [900, 700])
+        self.assertEqual(seasonal_history["stored_energy"][0]["scope"]["targetWorld"], "seasonal")
+        self.assertEqual(seasonal_history["stored_energy"][0]["scope"]["worldId"], "seasonal")
 
     def test_counts_only_successful_official_deploy_evidence_json_in_delivery_window(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/test_screeps_runtime_kpi_artifact_bridge.py
+++ b/scripts/test_screeps_runtime_kpi_artifact_bridge.py
@@ -167,6 +167,43 @@ class RuntimeKpiArtifactBridgeTest(unittest.TestCase):
             "transferredEnergy": 4,
         })
 
+    def test_runtime_summary_records_carry_inferred_world_id_metadata(self) -> None:
+        persistent_payload = {"type": "runtime-summary", "tick": 10, "rooms": [{"roomName": "W3N9"}]}
+        seasonal_path_payload = {"type": "runtime-summary", "tick": 20, "rooms": [{"roomName": "E1S1"}]}
+        seasonal_payload = {
+            "type": "runtime-summary",
+            "worldProfile": "seasonal",
+            "tick": 30,
+            "rooms": [{"roomName": "E2S2"}],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "runtime-artifacts"
+            persistent_path = root / "runtime-summary-console" / "runtime-summary-console-20260501T120000Z.log"
+            seasonal_path = root / "seasonal" / "runtime-summary-console" / "runtime-summary-console-20260501T130000Z.log"
+            explicit_path = root / "runtime-summary-console" / "runtime-summary-console-20260501T140000Z.log"
+            persistent_path.parent.mkdir(parents=True)
+            seasonal_path.parent.mkdir(parents=True)
+            persistent_path.write_text(runtime_line(persistent_payload), encoding="utf-8")
+            seasonal_path.write_text(runtime_line(seasonal_path_payload), encoding="utf-8")
+            explicit_path.write_text(runtime_line(seasonal_payload), encoding="utf-8")
+
+            scan_result = bridge.collect_runtime_summary_lines([str(root)])
+
+        records_by_tick = {}
+        for record in scan_result.records:
+            payload = json.loads(record.line.removeprefix("#runtime-summary "))
+            records_by_tick[payload["tick"]] = record
+
+        self.assertEqual(records_by_tick[10].world_id, "persistent")
+        self.assertEqual(records_by_tick[10].world_id_status, "fallback")
+        self.assertEqual(records_by_tick[20].world_id, "seasonal")
+        self.assertEqual(records_by_tick[20].world_id_status, "path")
+        self.assertEqual(records_by_tick[30].world_id, "seasonal")
+        self.assertEqual(records_by_tick[30].world_id_status, "explicit")
+        self.assertEqual(scan_result.metadata()["worldIdCounts"], {"persistent": 1, "seasonal": 2})
+        self.assertEqual(scan_result.metadata()["worldIdStatusCounts"], {"explicit": 1, "fallback": 1, "path": 1})
+
     def test_human_format_includes_source_and_reducer_summary(self) -> None:
         payload = {"type": "runtime-summary", "tick": 100, "rooms": [{"roomName": "W1N1"}]}
 


### PR DESCRIPTION
## Summary
- Adds world-id inference to persisted runtime-summary artifact records (`persistent` fallback, explicit payload world fields, Seasonal path inference).
- Filters roadmap runtime-artifact KPI history by world, defaulting to persistent so Seasonal artifacts under `runtime-artifacts/seasonal/...` do not contaminate official MMO KPIs.
- Adds scope metadata (`targetWorld` / `worldId`) to runtime-derived metric history while preserving existing `targetShard`, `targetRoom`, and `observedRooms` fields.
- Adds mixed persistent+Seasonal tests proving default persistent isolation and explicit Seasonal queryability.

## Persistent MMO no-impact verification
- Default `load_runtime_artifact_metric_history(...)` selects `persistent` only.
- Old unscoped runtime-summary artifacts remain `persistent` fallback and still carry `shardX/W3N9` scope.
- Persistent deploy dry-run for `https://screeps.com main shardX W3N9` passed with no writes.

## Verification
- `python3 -m py_compile scripts/screeps_runtime_kpi_artifact_bridge.py scripts/generate-roadmap-page.py`
- `python3 -m unittest scripts.test_screeps_runtime_kpi_artifact_bridge scripts.test_generate_roadmap_page` — 34 tests passed
- `python3 -m unittest discover scripts` — 251 tests passed
- `python3 scripts/screeps_official_deploy.py --dry-run --api-url https://screeps.com --branch main --shard shardX --room W3N9` — passed
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 95 suites / 1821 tests passed
- `cd prod && npm run build`
- `git diff --check`

Closes #1073
