### PR TITLE
feat: add surplus controller upgrader surge

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -31652,6 +31652,11 @@ function isNonEmptyString22(value) {
 
 // src/territory/controllerManager.ts
 var CONTROLLER_UPGRADE_MIN_ENERGY_CAPACITY = MIN_UPGRADER_BODY_COST;
+var CONTROLLER_UPGRADE_SURGE_TARGET = 2;
+var CONTROLLER_UPGRADE_SURGE_MIN_CONTROLLER_LEVEL = 2;
+var CONTROLLER_UPGRADE_SURGE_MAX_CONTROLLER_LEVEL = 3;
+var CONTROLLER_UPGRADE_SURGE_STORED_ENERGY_CAPACITY_MULTIPLIER = 2;
+var CONTROLLER_UPGRADE_SURGE_MIN_STORED_ENERGY = 1e3;
 var MAX_CONTROLLER_LEVEL5 = 8;
 function refreshControllerManagement(colony, roleCounts, workerTarget, gameTime, options = {}) {
   const plan = buildControllerManagementPlan(colony, roleCounts, workerTarget, gameTime, options);
@@ -31692,22 +31697,34 @@ function buildControllerManagementPlan(colony, roleCounts, workerTarget, gameTim
   const controllerLevel = getControllerLevel3(controller);
   const desiredControllerLevel = normalizeDesiredControllerLevel(options.desiredControllerLevel);
   const activeUpgraderCount = (_a = options.activeUpgraderCount) != null ? _a : Math.max(getUpgraderCapacity(roleCounts), countActiveControllerUpgraders(roomName, controllerId));
-  const competingSpawnDemand = (_b = options.competingSpawnDemand) != null ? _b : getWorkerCapacity(roleCounts) < workerTarget;
+  const workerCapacity = getWorkerCapacity(roleCounts);
+  const competingSpawnDemand = (_b = options.competingSpawnDemand) != null ? _b : workerCapacity < workerTarget;
   const constructionDemand = (_c = options.constructionDemand) != null ? _c : hasVisibleConstructionDemand(colony.room);
+  const defenseDemand = options.defenseDemand === true;
   const energyBufferHealthy = (_d = options.energyBufferHealthy) != null ? _d : hasControllerUpgradeSpawnEnergy(colony);
+  const hasEnergySurplus = (_e = options.hasEnergySurplus) != null ? _e : hasControllerUpgradeSurplusEnergy(colony);
   const upgradePriority = getControllerUpgradePriority(controller, {
     energyAvailable: options.allowReservedSpawnEnergy === true ? colony.energyCapacityAvailable : colony.energyAvailable,
     energyCapacityAvailable: colony.energyCapacityAvailable,
     competingSpawnDemand,
     constructionDemand,
-    defenseDemand: options.defenseDemand,
+    defenseDemand,
     energyBufferHealthy,
-    hasEnergySurplus: (_e = options.hasEnergySurplus) != null ? _e : hasRecordedEnergySurplus(roomName)
+    hasEnergySurplus
   });
   const desiredUpgraderCount = getDesiredControllerUpgraderCount(
     upgradePriority,
     colony,
-    desiredControllerLevel
+    desiredControllerLevel,
+    {
+      competingSpawnDemand,
+      constructionDemand,
+      defenseDemand,
+      energySurplus: hasEnergySurplus,
+      spawnEnergyBufferAvailable: hasControllerUpgradeSpawnEnergyAfterBuffer(colony),
+      spawnEnergyFull: hasFullRoomSpawnEnergy2(colony),
+      workerFloorMet: workerCapacity >= workerTarget
+    }
   );
   const plan = {
     roomName,
@@ -31750,10 +31767,21 @@ function hasControllerUpgradeSpawnEnergy(colony) {
   }
   return normalizeNonNegativeInteger12(colony.energyAvailable) >= MIN_UPGRADER_BODY_COST || getBufferedSpawnEnergyBudget(colony.room, colony.spawns, colony.energyAvailable) >= MIN_UPGRADER_BODY_COST;
 }
+function hasControllerUpgradeSpawnEnergyAfterBuffer(colony) {
+  if (colony.energyCapacityAvailable < CONTROLLER_UPGRADE_MIN_ENERGY_CAPACITY) {
+    return false;
+  }
+  return getBufferedSpawnEnergyBudget(colony.room, colony.spawns, colony.energyAvailable) >= MIN_UPGRADER_BODY_COST;
+}
+function hasFullRoomSpawnEnergy2(colony) {
+  const energyAvailable = normalizeNonNegativeInteger12(colony.energyAvailable);
+  const energyCapacityAvailable = normalizeNonNegativeInteger12(colony.energyCapacityAvailable);
+  return energyCapacityAvailable > 0 && energyAvailable >= energyCapacityAvailable;
+}
 function isControllerUpgradeSpawnPriority(priority) {
   return priority === "rcl1Rush" || priority === "rclProgress" || priority === "energySurplus" || priority === "steady";
 }
-function getDesiredControllerUpgraderCount(priority, colony, desiredControllerLevel) {
+function getDesiredControllerUpgraderCount(priority, colony, desiredControllerLevel, context) {
   if (!canMaintainDedicatedControllerUpgrader(colony.room.controller, desiredControllerLevel)) {
     return 0;
   }
@@ -31762,12 +31790,18 @@ function getDesiredControllerUpgraderCount(priority, colony, desiredControllerLe
     case "rclProgress":
     case "energySurplus":
     case "steady":
-      return 1;
+      return shouldSurgeControllerUpgraders(priority, colony.room.controller, context) ? CONTROLLER_UPGRADE_SURGE_TARGET : 1;
     case "downgradeGuard":
     case "fallback":
     case "none":
       return 0;
   }
+}
+function shouldSurgeControllerUpgraders(priority, controller, context) {
+  return (priority === "energySurplus" || priority === "rclProgress") && context.energySurplus && context.spawnEnergyFull && context.spawnEnergyBufferAvailable && context.workerFloorMet && !context.competingSpawnDemand && !context.constructionDemand && !context.defenseDemand && isEarlyControllerUpgradeSurgeTarget(controller);
+}
+function isEarlyControllerUpgradeSurgeTarget(controller) {
+  return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && Number.isFinite(controller.level) && controller.level >= CONTROLLER_UPGRADE_SURGE_MIN_CONTROLLER_LEVEL && controller.level <= CONTROLLER_UPGRADE_SURGE_MAX_CONTROLLER_LEVEL;
 }
 function canMaintainDedicatedControllerUpgrader(controller, desiredControllerLevel) {
   return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && Number.isFinite(controller.level) && controller.level < Math.min(MAX_CONTROLLER_LEVEL5, desiredControllerLevel);
@@ -31816,9 +31850,87 @@ function findRoomObjects24(room, globalName) {
     return [];
   }
 }
+function hasControllerUpgradeSurplusEnergy(colony) {
+  return hasRecordedEnergySurplus(colony.room.name) || hasRecordedMultiRoomEnergySurplus(colony.room.name, colony.energyCapacityAvailable) || hasVisibleStoredEnergySurplus(colony);
+}
 function hasRecordedEnergySurplus(roomName) {
   var _a, _b, _c, _d, _e;
   return ((_e = (_d = (_c = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.economy) == null ? void 0 : _b.energySurplus) == null ? void 0 : _c.rooms) == null ? void 0 : _d[roomName]) == null ? void 0 : _e.surplus) === true;
+}
+function hasRecordedMultiRoomEnergySurplus(roomName, energyCapacityAvailable) {
+  var _a, _b, _c, _d;
+  const state = (_d = (_c = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.economy) == null ? void 0 : _b.multiRoomEnergy) == null ? void 0 : _c.rooms) == null ? void 0 : _d[roomName];
+  return normalizeNonNegativeInteger12(state == null ? void 0 : state.surplusEnergy) >= MIN_UPGRADER_BODY_COST || normalizeNonNegativeInteger12(state == null ? void 0 : state.storedEnergy) >= getStoredEnergySurplusThreshold(energyCapacityAvailable);
+}
+function hasVisibleStoredEnergySurplus(colony) {
+  if (!hasFullRoomSpawnEnergy2(colony)) {
+    return false;
+  }
+  return getVisibleStoredEnergy(colony.room) >= getStoredEnergySurplusThreshold(colony.energyCapacityAvailable);
+}
+function getStoredEnergySurplusThreshold(energyCapacityAvailable) {
+  return Math.max(
+    CONTROLLER_UPGRADE_SURGE_MIN_STORED_ENERGY,
+    normalizeNonNegativeInteger12(energyCapacityAvailable) * CONTROLLER_UPGRADE_SURGE_STORED_ENERGY_CAPACITY_MULTIPLIER
+  );
+}
+function getVisibleStoredEnergy(room) {
+  return uniqueRoomObjects([
+    ...findRoomObjects24(room, "FIND_STRUCTURES"),
+    ...getDirectRoomEnergyStructures(room)
+  ]).filter(isControllerUpgradeStoredEnergyStructure).reduce((total, structure) => total + getStoredEnergy23(structure), 0);
+}
+function getDirectRoomEnergyStructures(room) {
+  const roomWithStores = room;
+  return [roomWithStores.storage, roomWithStores.terminal].filter(Boolean);
+}
+function uniqueRoomObjects(objects) {
+  const seen = /* @__PURE__ */ new Set();
+  const unique = [];
+  for (const object of objects) {
+    const key = getStableObjectKey(object);
+    if (key.length > 0) {
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+    }
+    unique.push(object);
+  }
+  return unique;
+}
+function getStableObjectKey(object) {
+  const candidate = object;
+  if (typeof candidate.id === "string" && candidate.id.length > 0) {
+    return `id:${candidate.id}`;
+  }
+  if (typeof candidate.name === "string" && candidate.name.length > 0) {
+    return `name:${candidate.name}`;
+  }
+  return "";
+}
+function isControllerUpgradeStoredEnergyStructure(structure) {
+  const structureType = structure.structureType;
+  return matchesStructureType25(structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType25(structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType25(structureType, "STRUCTURE_LINK", "link") || matchesStructureType25(structureType, "STRUCTURE_TERMINAL", "terminal");
+}
+function getStoredEnergy23(target) {
+  var _a;
+  const store = target == null ? void 0 : target.store;
+  const energyResource = getEnergyResource22();
+  const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, energyResource);
+  if (typeof usedCapacity === "number" && Number.isFinite(usedCapacity)) {
+    return Math.max(0, Math.floor(usedCapacity));
+  }
+  const storedEnergy = store == null ? void 0 : store[energyResource];
+  return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, Math.floor(storedEnergy)) : 0;
+}
+function matchesStructureType25(actual, globalName, fallback) {
+  var _a;
+  return actual === ((_a = globalThis[globalName]) != null ? _a : fallback);
+}
+function getEnergyResource22() {
+  var _a;
+  return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
 }
 function persistControllerManagementPlan(plan) {
   var _a, _b;
@@ -32823,7 +32935,7 @@ function planMultiRoomControllerUpgradeSpawn(context) {
   return null;
 }
 function shouldSpawnControllerUpgradeSurplusWorker(context) {
-  if (context.options.workersOnly || context.territoryIntentPending || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || context.workerCapacity > 0 && shouldSuppressWorkerSpawnForCrossRoomImport(context.colony) || !hasControllerUpgradeSurplusEnergy(context.colony) || !isControllerUpgradeableForSurplus(context.colony.room.controller)) {
+  if (context.options.workersOnly || context.territoryIntentPending || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || context.workerCapacity > 0 && shouldSuppressWorkerSpawnForCrossRoomImport(context.colony) || !hasControllerUpgradeSurplusEnergy2(context.colony) || !isControllerUpgradeableForSurplus(context.colony.room.controller)) {
     return false;
   }
   const surplusWorkerTarget = Math.min(
@@ -32858,7 +32970,7 @@ function getControllerUpgradeTargetRooms(options) {
   }
   return void 0;
 }
-function hasControllerUpgradeSurplusEnergy(colony) {
+function hasControllerUpgradeSurplusEnergy2(colony) {
   return colony.energyCapacityAvailable >= CONTROLLER_UPGRADE_SURPLUS_MIN_ENERGY_CAPACITY && colony.energyAvailable >= colony.energyCapacityAvailable;
 }
 function isControllerUpgradeableForSurplus(controller) {
@@ -33636,21 +33748,21 @@ function hasDroppedEnergyDecayingAtSource(room, source) {
 function isDroppedEnergy2(resource) {
   const amount = resource.amount;
   const ticksToDecay = resource.ticksToDecay;
-  return resource.resourceType === getEnergyResource22() && typeof amount === "number" && Number.isFinite(amount) && amount > 0 && (typeof ticksToDecay !== "number" || ticksToDecay > 0);
+  return resource.resourceType === getEnergyResource23() && typeof amount === "number" && Number.isFinite(amount) && amount > 0 && (typeof ticksToDecay !== "number" || ticksToDecay > 0);
 }
 function getUsedEnergy3(creep) {
   var _a;
   const store = creep.store;
-  const used = (_a = store.getUsedCapacity) == null ? void 0 : _a.call(store, getEnergyResource22());
+  const used = (_a = store.getUsedCapacity) == null ? void 0 : _a.call(store, getEnergyResource23());
   return typeof used === "number" && Number.isFinite(used) ? Math.max(0, used) : 0;
 }
 function getFreeEnergyCapacity13(creep) {
   var _a;
   const store = creep.store;
-  const free = (_a = store.getFreeCapacity) == null ? void 0 : _a.call(store, getEnergyResource22());
+  const free = (_a = store.getFreeCapacity) == null ? void 0 : _a.call(store, getEnergyResource23());
   return typeof free === "number" && Number.isFinite(free) ? Math.max(0, free) : null;
 }
-function getEnergyResource22() {
+function getEnergyResource23() {
   var _a;
   return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
 }
@@ -34117,7 +34229,7 @@ function toRuntimeRepairTargetSnapshot(targetId, repairCount, structure) {
   };
 }
 function isStructureOfType(structure, globalName, fallback) {
-  return isRecord28(structure) && matchesStructureType25(structure.structureType, globalName, fallback);
+  return isRecord28(structure) && matchesStructureType26(structure.structureType, globalName, fallback);
 }
 function calculateRoadCoverageRatio(roadCount, pendingRoadSiteCount) {
   const totalKnownRoadWork = roadCount + pendingRoadSiteCount;
@@ -34477,13 +34589,13 @@ function findRoomEnergyStoreStructures(room, spawns) {
   const allStructures = findRoomObjects27(room, "FIND_STRUCTURES");
   const myStructures = findRoomObjects27(room, "FIND_MY_STRUCTURES");
   const discoveredStructures = [...allStructures != null ? allStructures : [], ...myStructures != null ? myStructures : []];
-  return uniqueRoomObjects([
+  return uniqueRoomObjects2([
     ...discoveredStructures,
     ...discoveredStructures.length === 0 ? spawns : [],
-    ...getDirectRoomEnergyStructures(room)
+    ...getDirectRoomEnergyStructures2(room)
   ]).filter(isRoomEnergyStoreStructure);
 }
-function getDirectRoomEnergyStructures(room) {
+function getDirectRoomEnergyStructures2(room) {
   const roomWithDurableStores = room;
   return [roomWithDurableStores.storage, roomWithDurableStores.terminal].filter(
     (structure) => structure !== void 0 && structure !== null
@@ -34493,7 +34605,7 @@ function isRoomEnergyStoreStructure(structure) {
   if (!isRecord28(structure)) {
     return false;
   }
-  return matchesStructureType25(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType25(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType25(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType25(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType25(structure.structureType, "STRUCTURE_LINK", "link") || matchesStructureType25(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
+  return matchesStructureType26(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType26(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType26(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType26(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType26(structure.structureType, "STRUCTURE_LINK", "link") || matchesStructureType26(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
 }
 function summarizeStoredEnergy(colony, roomEnergyStructures) {
   return Math.max(sumEnergyInStores(roomEnergyStructures), getRoomEnergyAvailable12(colony));
@@ -34506,7 +34618,7 @@ function getRoomEnergyAvailable12(colony) {
 }
 function findOwnedRoomCreeps(room, colonyCreeps) {
   var _a;
-  return uniqueRoomObjects([
+  return uniqueRoomObjects2([
     ...(_a = findRoomObjects27(room, "FIND_MY_CREEPS")) != null ? _a : [],
     ...colonyCreeps
   ]);
@@ -34704,10 +34816,10 @@ function canSpendWorkerEnergyOnConstructionSiteForTelemetry(room, carriedEnergy,
   if (!isRecord28(constructionSite)) {
     return checkEnergyBufferForConstructionSpending(room);
   }
-  if (matchesStructureType25(constructionSite.structureType, "STRUCTURE_EXTENSION", "extension")) {
+  if (matchesStructureType26(constructionSite.structureType, "STRUCTURE_EXTENSION", "extension")) {
     return checkEnergyBufferForExtensionConstruction(room, carriedEnergy);
   }
-  if (matchesStructureType25(constructionSite.structureType, "STRUCTURE_CONTAINER", "container")) {
+  if (matchesStructureType26(constructionSite.structureType, "STRUCTURE_CONTAINER", "container")) {
     return checkEnergyBufferForCapacityEnablingConstruction(room, carriedEnergy);
   }
   return checkEnergyBufferForConstructionSpending(room);
@@ -34825,7 +34937,7 @@ function hasSpawnReservedConstructionEnergy(colony, roomEnergyStructures, energy
   return spawnEnergy > 0 && getRoomEnergyAvailable12(colony) > energyBuffer.threshold;
 }
 function isSpawnEnergyStructure(structure) {
-  return isRecord28(structure) && matchesStructureType25(structure.structureType, "STRUCTURE_SPAWN", "spawn");
+  return isRecord28(structure) && matchesStructureType26(structure.structureType, "STRUCTURE_SPAWN", "spawn");
 }
 function isBuildBlockedByEnergyBuffer(colony, assignedCarriedEnergy) {
   const energyAvailable = getRoomEnergyAvailable12(colony);
@@ -34895,10 +35007,10 @@ function getRepairBacklogHits(structure) {
   return Math.max(0, Math.ceil(repairCeiling - hits));
 }
 function isObservableRepairBacklogStructure(structure) {
-  return matchesStructureType25(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType25(structure.structureType, "STRUCTURE_CONTAINER", "container") || isObservedOwnedRampart(structure);
+  return matchesStructureType26(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType26(structure.structureType, "STRUCTURE_CONTAINER", "container") || isObservedOwnedRampart(structure);
 }
 function isObservedOwnedRampart(structure) {
-  return matchesStructureType25(structure.structureType, "STRUCTURE_RAMPART", "rampart") && structure.my === true;
+  return matchesStructureType26(structure.structureType, "STRUCTURE_RAMPART", "rampart") && structure.my === true;
 }
 function buildControllerProgressRemaining(room) {
   const controller = room.controller;
@@ -35174,7 +35286,7 @@ function getSpawnExtensionEnergyStructureIds(room) {
   return ids;
 }
 function isSpawnExtensionEnergyStructure2(structure) {
-  return isRecord28(structure) && (matchesStructureType25(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType25(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
+  return isRecord28(structure) && (matchesStructureType26(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType26(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
 }
 function getEventTargetId(data) {
   return typeof data.targetId === "string" && data.targetId.length > 0 ? data.targetId : null;
@@ -35210,7 +35322,7 @@ function getRoomEventLog(room) {
     return void 0;
   }
 }
-function uniqueRoomObjects(objects) {
+function uniqueRoomObjects2(objects) {
   const uniqueObjects = [];
   const seenReferences = /* @__PURE__ */ new Set();
   const seenKeys = /* @__PURE__ */ new Set();
@@ -35251,13 +35363,13 @@ function getEnergyInStore(object) {
   if (!isRecord28(object) || !isRecord28(object.store)) {
     return 0;
   }
-  const storedEnergy = object.store[getEnergyResource23()];
+  const storedEnergy = object.store[getEnergyResource24()];
   if (typeof storedEnergy === "number") {
     return storedEnergy;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
   if (typeof getUsedCapacity === "function") {
-    const usedCapacity = getUsedCapacity.call(object.store, getEnergyResource23());
+    const usedCapacity = getUsedCapacity.call(object.store, getEnergyResource24());
     return typeof usedCapacity === "number" ? usedCapacity : 0;
   }
   return 0;
@@ -35271,12 +35383,12 @@ function getEnergyCapacityInStore(object) {
   }
   const getCapacity = object.store.getCapacity;
   if (typeof getCapacity === "function") {
-    const capacity2 = getCapacity.call(object.store, getEnergyResource23());
+    const capacity2 = getCapacity.call(object.store, getEnergyResource24());
     return typeof capacity2 === "number" && Number.isFinite(capacity2) ? Math.max(0, capacity2) : 0;
   }
   const getFreeCapacity = object.store.getFreeCapacity;
   if (typeof getFreeCapacity === "function") {
-    const freeCapacity = getFreeCapacity.call(object.store, getEnergyResource23());
+    const freeCapacity = getFreeCapacity.call(object.store, getEnergyResource24());
     if (typeof freeCapacity === "number" && Number.isFinite(freeCapacity)) {
       return Math.max(0, getEnergyInStore(object) + freeCapacity);
     }
@@ -35292,11 +35404,11 @@ function getFreeEnergyCapacityInStore(object) {
   if (typeof getFreeCapacity !== "function") {
     return 0;
   }
-  const freeCapacity = getFreeCapacity.call(object.store, getEnergyResource23());
+  const freeCapacity = getFreeCapacity.call(object.store, getEnergyResource24());
   return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
 }
 function sumDroppedEnergy2(droppedResources) {
-  const energyResource = getEnergyResource23();
+  const energyResource = getEnergyResource24();
   return droppedResources.reduce((total, droppedResource) => {
     if (!isRecord28(droppedResource) || droppedResource.resourceType !== energyResource) {
       return total;
@@ -35305,7 +35417,7 @@ function sumDroppedEnergy2(droppedResources) {
   }, 0);
 }
 function isEnergyEventData(data) {
-  return data.resourceType === void 0 || data.resourceType === getEnergyResource23();
+  return data.resourceType === void 0 || data.resourceType === getEnergyResource24();
 }
 function getNumericEventData(data, key) {
   const value = data[key];
@@ -35315,7 +35427,7 @@ function getGlobalNumber19(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function matchesStructureType25(value, globalName, fallback) {
+function matchesStructureType26(value, globalName, fallback) {
   var _a;
   const expectedValue = (_a = globalThis[globalName]) != null ? _a : fallback;
   return value === expectedValue;
@@ -35323,7 +35435,7 @@ function matchesStructureType25(value, globalName, fallback) {
 function getFiniteNumber(value) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
-function getEnergyResource23() {
+function getEnergyResource24() {
   const value = globalThis.RESOURCE_ENERGY;
   return typeof value === "string" ? value : "energy";
 }
@@ -35541,7 +35653,7 @@ function manageStorage(room) {
     return { assignedTasks: 0, linkTransfers: [] };
   }
   const linkTransfers = transferStorageLinkEnergy(room);
-  const storageEnergy = getStoredEnergy23(storage);
+  const storageEnergy = getStoredEnergy24(storage);
   if (storageEnergy <= 0) {
     return { assignedTasks: 0, linkTransfers };
   }
@@ -35562,7 +35674,7 @@ function transferStorageLinkEnergy(room) {
   if (getLinkCooldown2(storageLink) > 0) {
     return [];
   }
-  const storedEnergy = getStoredEnergy23(storageLink);
+  const storedEnergy = getStoredEnergy24(storageLink);
   const destinationFreeCapacity = getFreeEnergyCapacity14(controllerLink);
   const amount = Math.min(storedEnergy, destinationFreeCapacity);
   if (amount <= 0) {
@@ -35593,7 +35705,7 @@ function buildEnergyDemandState(room) {
 }
 function findSpawnExtensionRefillTargets(room) {
   const structures = findOwnedStructures7(room).filter(
-    (structure) => (matchesStructureType26(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType26(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && getFreeEnergyCapacity14(structure) > 0
+    (structure) => (matchesStructureType27(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType27(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && getFreeEnergyCapacity14(structure) > 0
   );
   if (!isRoomSpawnExtensionEnergyLow(room, structures)) {
     return [];
@@ -35607,7 +35719,7 @@ function findSpawnExtensionRefillTargets(room) {
 }
 function findTowerRefillTargets(room) {
   return findOwnedStructures7(room).filter(
-    (structure) => matchesStructureType26(structure.structureType, "STRUCTURE_TOWER", "tower") && getStoredEnergy23(structure) < TOWER_REFILL_THRESHOLD && getFreeEnergyCapacity14(structure) > 0
+    (structure) => matchesStructureType27(structure.structureType, "STRUCTURE_TOWER", "tower") && getStoredEnergy24(structure) < TOWER_REFILL_THRESHOLD && getFreeEnergyCapacity14(structure) > 0
   ).map((target) => ({
     freeCapacity: getFreeEnergyCapacity14(target),
     id: getObjectId14(target),
@@ -35808,7 +35920,7 @@ function getRoomStorage4(room) {
     return room.storage;
   }
   return (_a = findOwnedStructures7(room).filter(
-    (structure) => matchesStructureType26(structure.structureType, "STRUCTURE_STORAGE", "storage")
+    (structure) => matchesStructureType27(structure.structureType, "STRUCTURE_STORAGE", "storage")
   )[0]) != null ? _a : null;
 }
 function findOwnedStructures7(room) {
@@ -35825,25 +35937,25 @@ function findMyCreeps3(room) {
   const result = room.find(FIND_MY_CREEPS);
   return Array.isArray(result) ? result : [];
 }
-function getStoredEnergy23(target) {
+function getStoredEnergy24(target) {
   var _a;
   const store = target == null ? void 0 : target.store;
-  const storedEnergy = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, getEnergyResource24());
+  const storedEnergy = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, getEnergyResource25());
   return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
 }
 function getFreeEnergyCapacity14(target) {
   var _a;
   const store = target == null ? void 0 : target.store;
-  const freeCapacity = (_a = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _a.call(store, getEnergyResource24());
+  const freeCapacity = (_a = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _a.call(store, getEnergyResource25());
   return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
 }
 function getCarriedEnergy7(creep) {
-  return getStoredEnergy23(creep);
+  return getStoredEnergy24(creep);
 }
 function getLinkCooldown2(link) {
   return typeof link.cooldown === "number" && Number.isFinite(link.cooldown) ? link.cooldown : 0;
 }
-function getEnergyResource24() {
+function getEnergyResource25() {
   var _a;
   return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
 }
@@ -35857,7 +35969,7 @@ function getObjectId14(object) {
   }
   return typeof candidate.name === "string" ? candidate.name : "";
 }
-function matchesStructureType26(actual, globalName, fallback) {
+function matchesStructureType27(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
@@ -35874,7 +35986,7 @@ function manageTerminalEnergy() {
   const gameTime = getGameTime31();
   for (const plan of plans) {
     const result = plan.sourceTerminal.send(
-      getEnergyResource25(),
+      getEnergyResource26(),
       plan.amount,
       plan.targetRoom,
       plan.description
@@ -35984,7 +36096,7 @@ function buildProjectedTerminalRoomState(room) {
     return null;
   }
   const state = getRoomStoredEnergyState(room);
-  const terminalEnergy = getStoredEnergy24(terminal);
+  const terminalEnergy = getStoredEnergy25(terminal);
   const terminalFreeCapacity = getFreeEnergyCapacity15(terminal);
   const terminalTargetEnergy = getTerminalEnergyTarget(terminal);
   const sourceBudget = Math.min(
@@ -36066,7 +36178,7 @@ function recordTerminalLogisticsState(results, gameTime) {
         {
           roomName: room.name,
           terminalId: getObjectId15(terminal),
-          energy: getStoredEnergy24(terminal),
+          energy: getStoredEnergy25(terminal),
           freeCapacity: getFreeEnergyCapacity15(terminal),
           cooldown,
           ...(result == null ? void 0 : result.result) === OK_CODE13 ? {
@@ -36106,10 +36218,10 @@ function getOwnedRooms2() {
     return ((_a2 = room == null ? void 0 : room.controller) == null ? void 0 : _a2.my) === true;
   });
 }
-function getStoredEnergy24(target) {
+function getStoredEnergy25(target) {
   var _a;
   const store = getStore2(target);
-  const resource = getEnergyResource25();
+  const resource = getEnergyResource26();
   const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, resource);
   if (typeof usedCapacity === "number" && Number.isFinite(usedCapacity)) {
     return Math.max(0, usedCapacity);
@@ -36120,18 +36232,18 @@ function getStoredEnergy24(target) {
 function getFreeEnergyCapacity15(target) {
   var _a;
   const store = getStore2(target);
-  const resource = getEnergyResource25();
+  const resource = getEnergyResource26();
   const freeCapacity = (_a = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _a.call(store, resource);
   if (typeof freeCapacity === "number" && Number.isFinite(freeCapacity)) {
     return Math.max(0, freeCapacity);
   }
   const capacity = getEnergyCapacity5(target);
-  return capacity > 0 ? Math.max(0, capacity - getStoredEnergy24(target)) : 0;
+  return capacity > 0 ? Math.max(0, capacity - getStoredEnergy25(target)) : 0;
 }
 function getEnergyCapacity5(target) {
   var _a, _b, _c;
   const store = getStore2(target);
-  const resource = getEnergyResource25();
+  const resource = getEnergyResource26();
   const capacity = (_a = store == null ? void 0 : store.getCapacity) == null ? void 0 : _a.call(store, resource);
   if (typeof capacity === "number" && Number.isFinite(capacity)) {
     return Math.max(0, capacity);
@@ -36141,7 +36253,7 @@ function getEnergyCapacity5(target) {
     return Math.max(0, genericCapacity);
   }
   const freeCapacity = (_c = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _c.call(store, resource);
-  return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? getStoredEnergy24(target) + Math.max(0, freeCapacity) : 0;
+  return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? getStoredEnergy25(target) + Math.max(0, freeCapacity) : 0;
 }
 function getStore2(target) {
   return target == null ? void 0 : target.store;
@@ -36178,7 +36290,7 @@ function getGameTime31() {
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
 }
-function getEnergyResource25() {
+function getEnergyResource26() {
   var _a;
   return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
 }
@@ -36272,7 +36384,7 @@ function detectOwnedLabs(room) {
 function buildLabInventory(room, labs) {
   const inventory = {};
   for (const lab of labs) {
-    addResourceAmount(inventory, getEnergyResource26(), getLabEnergy(lab));
+    addResourceAmount(inventory, getEnergyResource27(), getLabEnergy(lab));
     const mineralType = getLabMineralType(lab);
     if (mineralType) {
       addResourceAmount(inventory, mineralType, getLabResourceAmount(lab, mineralType));
@@ -36799,9 +36911,9 @@ function findRoomObjects28(room, globalConstantName) {
   return room.find(findConstant);
 }
 function isLabStructure(structure) {
-  return matchesStructureType27(structure.structureType, "STRUCTURE_LAB", "lab");
+  return matchesStructureType28(structure.structureType, "STRUCTURE_LAB", "lab");
 }
-function matchesStructureType27(structureType, globalConstantName, fallback) {
+function matchesStructureType28(structureType, globalConstantName, fallback) {
   const globalConstant = globalThis[globalConstantName];
   return structureType === globalConstant || structureType === fallback;
 }
@@ -36810,7 +36922,7 @@ function getLabResourceAmount(lab, resource) {
   if (storeAmount > 0) {
     return storeAmount;
   }
-  if (resource === getEnergyResource26()) {
+  if (resource === getEnergyResource27()) {
     return normalizeNonNegativeInteger16(lab.energy);
   }
   if (getLabMineralType(lab) === resource) {
@@ -36846,7 +36958,7 @@ function getLabFreeMineralCapacity(lab, resource) {
   return Math.max(0, DEFAULT_LAB_MINERAL_CAPACITY - getLabResourceAmount(lab, resource));
 }
 function getLabEnergy(lab) {
-  return getLabResourceAmount(lab, getEnergyResource26());
+  return getLabResourceAmount(lab, getEnergyResource27());
 }
 function getLabMineralType(lab) {
   const mineralType = lab.mineralType;
@@ -36880,7 +36992,7 @@ function getInventoryAmount(inventory, resource) {
 function getStore3(target) {
   return target == null ? void 0 : target.store;
 }
-function getEnergyResource26() {
+function getEnergyResource27() {
   var _a;
   return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
 }
@@ -37246,7 +37358,7 @@ function clampAmountForOrderAndEnergyBudget({
   if (maxAmount < minOrderAmount || !order.roomName) {
     return 0;
   }
-  const energyResource = getEnergyResource27();
+  const energyResource = getEnergyResource28();
   const terminalEnergy = getRecordAmount(room.terminalResources, energyResource);
   const energyBudget = Math.max(0, terminalEnergy - TERMINAL_ENERGY_MIN_RESERVE);
   if (energyBudget <= 0) {
@@ -37277,7 +37389,7 @@ function buildMarketTradingRoomState(room, gameTime) {
   const terminalResources = collectStoredResources([terminal]);
   const storageResources = collectStoredResources([room.storage]);
   const resources = mergeResourceRecords(storageResources, terminalResources);
-  const energyResource = getEnergyResource27();
+  const energyResource = getEnergyResource28();
   const terminalEnergy = getRecordAmount(terminalResources, energyResource);
   const terminalFreeCapacity = getStoreFreeCapacity(terminal);
   const memoryAvailableAt = getProjectedMarketAvailableAt(room.name, gameTime);
@@ -37353,7 +37465,7 @@ function buildResourcePostureByResource(room, resources) {
   return postures;
 }
 function getResourcePolicy(resourceType) {
-  if (resourceType === getEnergyResource27()) {
+  if (resourceType === getEnergyResource28()) {
     return {
       reserve: TERMINAL_ENERGY_MIN_RESERVE,
       target: ENERGY_RESOURCE_TARGET,
@@ -37518,7 +37630,7 @@ function collectStoredResources(targets) {
         resources[resourceType] = amount;
       }
     }
-    const energyResource = getEnergyResource27();
+    const energyResource = getEnergyResource28();
     const energyAmount = getStoreUsedCapacity(store, energyResource);
     if (energyAmount > 0) {
       resources[energyResource] = Math.max((_b = resources[energyResource]) != null ? _b : 0, energyAmount);
@@ -37546,7 +37658,7 @@ function getStoreFreeCapacity(target) {
   if (typeof genericFreeCapacity === "number" && Number.isFinite(genericFreeCapacity)) {
     return Math.max(0, Math.floor(genericFreeCapacity));
   }
-  const energyFreeCapacity = (_b = store.getFreeCapacity) == null ? void 0 : _b.call(store, getEnergyResource27());
+  const energyFreeCapacity = (_b = store.getFreeCapacity) == null ? void 0 : _b.call(store, getEnergyResource28());
   if (typeof energyFreeCapacity === "number" && Number.isFinite(energyFreeCapacity)) {
     return Math.max(0, Math.floor(energyFreeCapacity));
   }
@@ -37619,7 +37731,7 @@ function getTerminalCooldown2(terminal) {
   const cooldown = terminal.cooldown;
   return normalizeNonNegativeInteger17(cooldown);
 }
-function getEnergyResource27() {
+function getEnergyResource28() {
   var _a;
   return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
 }
@@ -37816,7 +37928,7 @@ function selectAvailableMineral(room, extractor) {
   return (_a = findRoomObjects29(room, "FIND_MINERALS").find((mineral) => isMineralAvailable(mineral) && isExtractorOnMineral(extractor, mineral))) != null ? _a : null;
 }
 function isExtractorStructure(structure) {
-  return matchesStructureType28(structure.structureType, "STRUCTURE_EXTRACTOR", "extractor");
+  return matchesStructureType29(structure.structureType, "STRUCTURE_EXTRACTOR", "extractor");
 }
 function isMineralAvailable(mineral) {
   return getMineralAmount(mineral) > 0;
@@ -37896,7 +38008,7 @@ function selectDeliveryTargetForAssignment(room, assignment, resourceType) {
   return selectMineralDeliveryTarget(room, resourceType);
 }
 function isStorageStructure2(structure) {
-  return matchesStructureType28(structure.structureType, "STRUCTURE_STORAGE", "storage");
+  return matchesStructureType29(structure.structureType, "STRUCTURE_STORAGE", "storage");
 }
 function selectCarriedResourceType(creep, preferredResourceType) {
   if (preferredResourceType && getStoreUsedCapacity2(creep.store, preferredResourceType) > 0) {
@@ -37966,7 +38078,7 @@ function findRoomObjects29(room, constantName) {
     return [];
   }
 }
-function matchesStructureType28(actual, globalName, fallback) {
+function matchesStructureType29(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
@@ -39665,7 +39777,7 @@ function refreshClaimedRoomBootstrapperOwnership(telemetryEvents = []) {
 }
 function countExistingStructures2(room, globalName, fallback) {
   return findRoomObjects31(room, "FIND_MY_STRUCTURES").filter(
-    (object) => matchesStructureType29(object.structureType, globalName, fallback)
+    (object) => matchesStructureType30(object.structureType, globalName, fallback)
   ).length;
 }
 function findRoomObjects31(room, globalName) {
@@ -39836,7 +39948,7 @@ function getRoomRouteDistance(fromRoom, toRoom) {
   }
   return Number.POSITIVE_INFINITY;
 }
-function matchesStructureType29(actual, globalName, fallback) {
+function matchesStructureType30(actual, globalName, fallback) {
   return actual === getStructureConstant8(globalName, fallback);
 }
 function getStructureConstant8(globalName, fallback) {
@@ -42658,7 +42770,7 @@ function buildStrategyRecommendationRoomState(colony, creeps) {
     workerCount: colonyCreeps.filter((creep) => creep.memory.role === "worker").length,
     energyAvailable: colony.energyAvailable,
     energyCapacity: colony.energyCapacityAvailable,
-    storedEnergy: getStoredEnergy25(room),
+    storedEnergy: getStoredEnergy26(room),
     sourceCount: sources.length,
     hostileCreepCount: hostileCreeps.length,
     hostileStructureCount: hostileStructures.length,
@@ -42803,7 +42915,7 @@ function countVisibleOwnedRooms7() {
 }
 function countStructuresByType3(structures, globalName, fallback) {
   return structures.filter(
-    (structure) => isRecord39(structure) && matchesStructureType30(structure.structureType, globalName, fallback)
+    (structure) => isRecord39(structure) && matchesStructureType31(structure.structureType, globalName, fallback)
   ).length;
 }
 function estimateRepairBacklogHits(structures) {
@@ -42819,7 +42931,7 @@ function estimateRepairBacklogHits(structures) {
     return total + (hitsMax - hits);
   }, 0);
 }
-function getStoredEnergy25(room) {
+function getStoredEnergy26(room) {
   const storage = room.storage;
   return getEnergyInStore2(storage);
 }
@@ -42848,7 +42960,7 @@ function findRoomObjects33(room, constantName) {
     return [];
   }
 }
-function matchesStructureType30(value, globalName, fallback) {
+function matchesStructureType31(value, globalName, fallback) {
   const globalValue = globalThis[globalName];
   return value === globalValue || value === fallback;
 }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -31876,9 +31876,21 @@ function getStoredEnergySurplusThreshold(energyCapacityAvailable) {
 }
 function getVisibleStoredEnergy(room) {
   return uniqueRoomObjects([
-    ...findRoomObjects24(room, "FIND_STRUCTURES"),
+    ...findOwnedStoredEnergyStructures(room),
     ...getDirectRoomEnergyStructures(room)
   ]).filter(isControllerUpgradeStoredEnergyStructure).reduce((total, structure) => total + getStoredEnergy23(structure), 0);
+}
+function findOwnedStoredEnergyStructures(room) {
+  const findConstant = globalThis.FIND_MY_STRUCTURES;
+  if (typeof findConstant !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  try {
+    const result = room.find(findConstant, { filter: isControllerUpgradeStoredEnergyStructure });
+    return Array.isArray(result) ? result.filter(isControllerUpgradeStoredEnergyStructure) : [];
+  } catch {
+    return [];
+  }
 }
 function getDirectRoomEnergyStructures(room) {
   const roomWithStores = room;

--- a/prod/src/territory/controllerManager.ts
+++ b/prod/src/territory/controllerManager.ts
@@ -437,11 +437,30 @@ function getStoredEnergySurplusThreshold(energyCapacityAvailable: number): numbe
 
 function getVisibleStoredEnergy(room: Room): number {
   return uniqueRoomObjects([
-    ...findRoomObjects<Structure>(room, 'FIND_STRUCTURES'),
+    ...findOwnedStoredEnergyStructures(room),
     ...(getDirectRoomEnergyStructures(room) as Structure[])
   ])
     .filter(isControllerUpgradeStoredEnergyStructure)
     .reduce((total, structure) => total + getStoredEnergy(structure), 0);
+}
+
+function findOwnedStoredEnergyStructures(room: Room): Structure[] {
+  const findConstant = (globalThis as Record<string, unknown>).FIND_MY_STRUCTURES;
+  if (typeof findConstant !== 'number' || typeof room.find !== 'function') {
+    return [];
+  }
+
+  try {
+    const result = (
+      room.find as unknown as (
+        type: number,
+        options: { filter: (structure: Structure) => boolean }
+      ) => unknown[]
+    )(findConstant, { filter: isControllerUpgradeStoredEnergyStructure });
+    return Array.isArray(result) ? (result as Structure[]).filter(isControllerUpgradeStoredEnergyStructure) : [];
+  } catch {
+    return [];
+  }
 }
 
 function getDirectRoomEnergyStructures(room: Room): unknown[] {

--- a/prod/src/territory/controllerManager.ts
+++ b/prod/src/territory/controllerManager.ts
@@ -52,7 +52,22 @@ export interface ControllerManagementPlan {
 }
 
 const CONTROLLER_UPGRADE_MIN_ENERGY_CAPACITY = MIN_UPGRADER_BODY_COST;
+const CONTROLLER_UPGRADE_SURGE_TARGET = 2;
+const CONTROLLER_UPGRADE_SURGE_MIN_CONTROLLER_LEVEL = 2;
+const CONTROLLER_UPGRADE_SURGE_MAX_CONTROLLER_LEVEL = 3;
+const CONTROLLER_UPGRADE_SURGE_STORED_ENERGY_CAPACITY_MULTIPLIER = 2;
+const CONTROLLER_UPGRADE_SURGE_MIN_STORED_ENERGY = 1_000;
 const MAX_CONTROLLER_LEVEL = 8;
+
+interface ControllerUpgraderDemandContext {
+  competingSpawnDemand: boolean;
+  constructionDemand: boolean;
+  defenseDemand: boolean;
+  energySurplus: boolean;
+  spawnEnergyBufferAvailable: boolean;
+  spawnEnergyFull: boolean;
+  workerFloorMet: boolean;
+}
 
 export function refreshControllerManagement(
   colony: ColonySnapshot,
@@ -118,23 +133,35 @@ export function buildControllerManagementPlan(
   const activeUpgraderCount =
     options.activeUpgraderCount ??
     Math.max(getUpgraderCapacity(roleCounts), countActiveControllerUpgraders(roomName, controllerId));
-  const competingSpawnDemand = options.competingSpawnDemand ?? getWorkerCapacity(roleCounts) < workerTarget;
+  const workerCapacity = getWorkerCapacity(roleCounts);
+  const competingSpawnDemand = options.competingSpawnDemand ?? workerCapacity < workerTarget;
   const constructionDemand = options.constructionDemand ?? hasVisibleConstructionDemand(colony.room);
+  const defenseDemand = options.defenseDemand === true;
   const energyBufferHealthy = options.energyBufferHealthy ?? hasControllerUpgradeSpawnEnergy(colony);
+  const hasEnergySurplus = options.hasEnergySurplus ?? hasControllerUpgradeSurplusEnergy(colony);
   const upgradePriority = getControllerUpgradePriority(controller, {
     energyAvailable:
       options.allowReservedSpawnEnergy === true ? colony.energyCapacityAvailable : colony.energyAvailable,
     energyCapacityAvailable: colony.energyCapacityAvailable,
     competingSpawnDemand,
     constructionDemand,
-    defenseDemand: options.defenseDemand,
+    defenseDemand,
     energyBufferHealthy,
-    hasEnergySurplus: options.hasEnergySurplus ?? hasRecordedEnergySurplus(roomName)
+    hasEnergySurplus
   });
   const desiredUpgraderCount = getDesiredControllerUpgraderCount(
     upgradePriority,
     colony,
-    desiredControllerLevel
+    desiredControllerLevel,
+    {
+      competingSpawnDemand,
+      constructionDemand,
+      defenseDemand,
+      energySurplus: hasEnergySurplus,
+      spawnEnergyBufferAvailable: hasControllerUpgradeSpawnEnergyAfterBuffer(colony),
+      spawnEnergyFull: hasFullRoomSpawnEnergy(colony),
+      workerFloorMet: workerCapacity >= workerTarget
+    }
   );
   const plan: ControllerManagementPlan = {
     roomName,
@@ -200,6 +227,20 @@ function hasControllerUpgradeSpawnEnergy(colony: ColonySnapshot): boolean {
     getBufferedSpawnEnergyBudget(colony.room, colony.spawns, colony.energyAvailable) >= MIN_UPGRADER_BODY_COST;
 }
 
+function hasControllerUpgradeSpawnEnergyAfterBuffer(colony: ColonySnapshot): boolean {
+  if (colony.energyCapacityAvailable < CONTROLLER_UPGRADE_MIN_ENERGY_CAPACITY) {
+    return false;
+  }
+
+  return getBufferedSpawnEnergyBudget(colony.room, colony.spawns, colony.energyAvailable) >= MIN_UPGRADER_BODY_COST;
+}
+
+function hasFullRoomSpawnEnergy(colony: ColonySnapshot): boolean {
+  const energyAvailable = normalizeNonNegativeInteger(colony.energyAvailable);
+  const energyCapacityAvailable = normalizeNonNegativeInteger(colony.energyCapacityAvailable);
+  return energyCapacityAvailable > 0 && energyAvailable >= energyCapacityAvailable;
+}
+
 function isControllerUpgradeSpawnPriority(priority: ControllerUpgradePriority): boolean {
   return (
     priority === 'rcl1Rush' ||
@@ -212,7 +253,8 @@ function isControllerUpgradeSpawnPriority(priority: ControllerUpgradePriority): 
 function getDesiredControllerUpgraderCount(
   priority: ControllerUpgradePriority,
   colony: ColonySnapshot,
-  desiredControllerLevel: number
+  desiredControllerLevel: number,
+  context: ControllerUpgraderDemandContext
 ): number {
   if (!canMaintainDedicatedControllerUpgrader(colony.room.controller, desiredControllerLevel)) {
     return 0;
@@ -223,12 +265,42 @@ function getDesiredControllerUpgraderCount(
     case 'rclProgress':
     case 'energySurplus':
     case 'steady':
-      return 1;
+      return shouldSurgeControllerUpgraders(priority, colony.room.controller, context)
+        ? CONTROLLER_UPGRADE_SURGE_TARGET
+        : 1;
     case 'downgradeGuard':
     case 'fallback':
     case 'none':
       return 0;
   }
+}
+
+function shouldSurgeControllerUpgraders(
+  priority: ControllerUpgradePriority,
+  controller: StructureController | undefined,
+  context: ControllerUpgraderDemandContext
+): boolean {
+  return (
+    (priority === 'energySurplus' || priority === 'rclProgress') &&
+    context.energySurplus &&
+    context.spawnEnergyFull &&
+    context.spawnEnergyBufferAvailable &&
+    context.workerFloorMet &&
+    !context.competingSpawnDemand &&
+    !context.constructionDemand &&
+    !context.defenseDemand &&
+    isEarlyControllerUpgradeSurgeTarget(controller)
+  );
+}
+
+function isEarlyControllerUpgradeSurgeTarget(controller: StructureController | undefined): boolean {
+  return (
+    controller?.my === true &&
+    typeof controller.level === 'number' &&
+    Number.isFinite(controller.level) &&
+    controller.level >= CONTROLLER_UPGRADE_SURGE_MIN_CONTROLLER_LEVEL &&
+    controller.level <= CONTROLLER_UPGRADE_SURGE_MAX_CONTROLLER_LEVEL
+  );
 }
 
 function canMaintainDedicatedControllerUpgrader(
@@ -323,11 +395,134 @@ function findRoomObjects<T>(room: Room, globalName: string): T[] {
   }
 }
 
+function hasControllerUpgradeSurplusEnergy(colony: ColonySnapshot): boolean {
+  return (
+    hasRecordedEnergySurplus(colony.room.name) ||
+    hasRecordedMultiRoomEnergySurplus(colony.room.name, colony.energyCapacityAvailable) ||
+    hasVisibleStoredEnergySurplus(colony)
+  );
+}
+
 function hasRecordedEnergySurplus(roomName: string): boolean {
   return (
     (globalThis as unknown as { Memory?: Partial<Memory> }).Memory?.economy?.energySurplus?.rooms?.[roomName]
       ?.surplus === true
   );
+}
+
+function hasRecordedMultiRoomEnergySurplus(roomName: string, energyCapacityAvailable: number): boolean {
+  const state = (globalThis as unknown as { Memory?: Partial<Memory> }).Memory?.economy?.multiRoomEnergy?.rooms?.[
+    roomName
+  ];
+  return (
+    normalizeNonNegativeInteger(state?.surplusEnergy) >= MIN_UPGRADER_BODY_COST ||
+    normalizeNonNegativeInteger(state?.storedEnergy) >= getStoredEnergySurplusThreshold(energyCapacityAvailable)
+  );
+}
+
+function hasVisibleStoredEnergySurplus(colony: ColonySnapshot): boolean {
+  if (!hasFullRoomSpawnEnergy(colony)) {
+    return false;
+  }
+
+  return getVisibleStoredEnergy(colony.room) >= getStoredEnergySurplusThreshold(colony.energyCapacityAvailable);
+}
+
+function getStoredEnergySurplusThreshold(energyCapacityAvailable: number): number {
+  return Math.max(
+    CONTROLLER_UPGRADE_SURGE_MIN_STORED_ENERGY,
+    normalizeNonNegativeInteger(energyCapacityAvailable) * CONTROLLER_UPGRADE_SURGE_STORED_ENERGY_CAPACITY_MULTIPLIER
+  );
+}
+
+function getVisibleStoredEnergy(room: Room): number {
+  return uniqueRoomObjects([
+    ...findRoomObjects<Structure>(room, 'FIND_STRUCTURES'),
+    ...(getDirectRoomEnergyStructures(room) as Structure[])
+  ])
+    .filter(isControllerUpgradeStoredEnergyStructure)
+    .reduce((total, structure) => total + getStoredEnergy(structure), 0);
+}
+
+function getDirectRoomEnergyStructures(room: Room): unknown[] {
+  const roomWithStores = room as Room & {
+    storage?: unknown;
+    terminal?: unknown;
+  };
+  return [roomWithStores.storage, roomWithStores.terminal].filter(Boolean);
+}
+
+function uniqueRoomObjects<T extends object>(objects: T[]): T[] {
+  const seen = new Set<string>();
+  const unique: T[] = [];
+  for (const object of objects) {
+    const key = getStableObjectKey(object);
+    if (key.length > 0) {
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+    }
+    unique.push(object);
+  }
+
+  return unique;
+}
+
+function getStableObjectKey(object: object): string {
+  const candidate = object as { id?: unknown; name?: unknown };
+  if (typeof candidate.id === 'string' && candidate.id.length > 0) {
+    return `id:${candidate.id}`;
+  }
+
+  if (typeof candidate.name === 'string' && candidate.name.length > 0) {
+    return `name:${candidate.name}`;
+  }
+
+  return '';
+}
+
+function isControllerUpgradeStoredEnergyStructure(structure: Structure): boolean {
+  const structureType = structure.structureType;
+  return (
+    matchesStructureType(structureType, 'STRUCTURE_STORAGE', 'storage') ||
+    matchesStructureType(structureType, 'STRUCTURE_CONTAINER', 'container') ||
+    matchesStructureType(structureType, 'STRUCTURE_LINK', 'link') ||
+    matchesStructureType(structureType, 'STRUCTURE_TERMINAL', 'terminal')
+  );
+}
+
+function getStoredEnergy(target: unknown): number {
+  const store = (
+    target as {
+      store?: {
+        getUsedCapacity?: (resource?: ResourceConstant) => number | null;
+        [resource: string]: unknown;
+      };
+    } | null
+  )?.store;
+  const energyResource = getEnergyResource();
+  const usedCapacity = store?.getUsedCapacity?.(energyResource);
+  if (typeof usedCapacity === 'number' && Number.isFinite(usedCapacity)) {
+    return Math.max(0, Math.floor(usedCapacity));
+  }
+
+  const storedEnergy = store?.[energyResource];
+  return typeof storedEnergy === 'number' && Number.isFinite(storedEnergy)
+    ? Math.max(0, Math.floor(storedEnergy))
+    : 0;
+}
+
+function matchesStructureType(
+  actual: string | undefined,
+  globalName: string,
+  fallback: string
+): boolean {
+  return actual === ((globalThis as Record<string, unknown>)[globalName] ?? fallback);
+}
+
+function getEnergyResource(): ResourceConstant {
+  return ((globalThis as { RESOURCE_ENERGY?: ResourceConstant }).RESOURCE_ENERGY ?? 'energy') as ResourceConstant;
 }
 
 function persistControllerManagementPlan(plan: ControllerManagementPlan): void {

--- a/prod/test/controllerManager.test.ts
+++ b/prod/test/controllerManager.test.ts
@@ -16,6 +16,7 @@ describe('controller manager', () => {
     (globalThis as unknown as { FIND_MY_CONSTRUCTION_SITES: number }).FIND_MY_CONSTRUCTION_SITES = 1;
     (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 2;
     (globalThis as unknown as { FIND_STRUCTURES: number }).FIND_STRUCTURES = 3;
+    (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 4;
     (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
     (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
     (globalThis as unknown as { STRUCTURE_LINK: StructureConstant }).STRUCTURE_LINK = 'link';
@@ -176,7 +177,7 @@ describe('controller manager', () => {
         energyAvailable: 550,
         energyCapacityAvailable: 550,
         controller: makeController({ level: 2, progress: 3_000, progressTotal: 45_000 }),
-        structures: [makeEnergyStore('container1', 'container', 2_000)]
+        myStructures: [makeEnergyStore('storage1', 'storage', 2_000)]
       }),
       { worker: 4, upgrader: 1 },
       4,
@@ -201,7 +202,7 @@ describe('controller manager', () => {
         energyAvailable: 550,
         energyCapacityAvailable: 550,
         controller: makeController({ level: 2, progress: 3_000, progressTotal: 45_000 }),
-        structures: [makeEnergyStore('container1', 'container', 2_000)]
+        myStructures: [makeEnergyStore('storage1', 'storage', 2_000)]
       }),
       { worker: 3, upgrader: 1 },
       4,
@@ -219,7 +220,7 @@ describe('controller manager', () => {
         energyAvailable: 550,
         energyCapacityAvailable: 550,
         controller: makeController({ level: 2, progress: 3_000, progressTotal: 45_000 }),
-        structures: [makeEnergyStore('container1', 'container', 2_000)]
+        myStructures: [makeEnergyStore('storage1', 'storage', 2_000)]
       }),
       { worker: 4, upgrader: 1 },
       4,
@@ -237,7 +238,7 @@ describe('controller manager', () => {
         energyAvailable: 550,
         energyCapacityAvailable: 550,
         controller: makeController({ level: 2, progress: 3_000, progressTotal: 45_000 }),
-        structures: [makeEnergyStore('container1', 'container', 2_000)]
+        myStructures: [makeEnergyStore('storage1', 'storage', 2_000)]
       }),
       { worker: 4, upgrader: 1 },
       4,
@@ -255,7 +256,7 @@ describe('controller manager', () => {
         energyAvailable: 599,
         energyCapacityAvailable: 650,
         controller: makeController({ level: 3, progress: 3_000, progressTotal: 135_000 }),
-        structures: [makeEnergyStore('container1', 'container', 2_000)]
+        myStructures: [makeEnergyStore('storage1', 'storage', 2_000)]
       }),
       { worker: 4, upgrader: 1 },
       4,
@@ -282,6 +283,49 @@ describe('controller manager', () => {
 
     expect(plan.desiredUpgraderCount).toBe(0);
     expect(plan.spawnDemand).toBeUndefined();
+  });
+
+  it('uses owned stored-energy structures without scanning every room structure', () => {
+    const colony = makeColony({
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      controller: makeController({ level: 2, progress: 3_000, progressTotal: 45_000 }),
+      myStructures: [makeEnergyStore('link1', 'link', 2_000)],
+      structures: [makeEnergyStore('container1', 'container', 5_000)]
+    });
+
+    const plan = buildControllerManagementPlan(colony, { worker: 4, upgrader: 1 }, 4, 215);
+
+    expect(plan).toMatchObject({
+      upgradePriority: 'energySurplus',
+      desiredUpgraderCount: 2,
+      spawnDemand: {
+        priority: 'energySurplus',
+        desiredUpgraderCount: 2
+      }
+    });
+    const find = colony.room.find as jest.Mock;
+    expect(find.mock.calls.some(([type]) => type === FIND_STRUCTURES)).toBe(false);
+    expect(find).toHaveBeenCalledWith(
+      FIND_MY_STRUCTURES,
+      expect.objectContaining({ filter: expect.any(Function) })
+    );
+  });
+
+  it('counts direct room storage and terminal energy without a global structure scan', () => {
+    const colony = makeColony({
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      controller: makeController({ level: 2, progress: 3_000, progressTotal: 45_000 }),
+      storage: makeEnergyStore('storage1', 'storage', 700) as StructureStorage,
+      terminal: makeEnergyStore('terminal1', 'terminal', 500) as StructureTerminal
+    });
+
+    const plan = buildControllerManagementPlan(colony, { worker: 4, upgrader: 1 }, 4, 216);
+
+    const find = colony.room.find as jest.Mock;
+    expect(plan.desiredUpgraderCount).toBe(2);
+    expect(find.mock.calls.some(([type]) => type === FIND_STRUCTURES)).toBe(false);
   });
 
   it('treats missing Game state as no active controller upgraders', () => {
@@ -412,13 +456,19 @@ describe('controller manager', () => {
     energyAvailable = 650,
     energyCapacityAvailable = 650,
     constructionSiteCount = 0,
-    structures = []
+    structures = [],
+    myStructures = [],
+    storage,
+    terminal
   }: {
     controller?: StructureController;
     energyAvailable?: number;
     energyCapacityAvailable?: number;
     constructionSiteCount?: number;
     structures?: Structure[];
+    myStructures?: Structure[];
+    storage?: StructureStorage;
+    terminal?: StructureTerminal;
   } = {}): ColonySnapshot {
     const constructionSites = Array.from(
       { length: constructionSiteCount },
@@ -427,9 +477,15 @@ describe('controller manager', () => {
     const room = {
       name: 'W1N1',
       controller,
-      find: jest.fn((type: number) => {
+      ...(storage ? { storage } : {}),
+      ...(terminal ? { terminal } : {}),
+      find: jest.fn((type: number, options?: { filter?: (structure: Structure) => boolean }) => {
         if (type === FIND_MY_CONSTRUCTION_SITES || type === FIND_CONSTRUCTION_SITES) {
           return constructionSites;
+        }
+
+        if (type === FIND_MY_STRUCTURES) {
+          return typeof options?.filter === 'function' ? myStructures.filter(options.filter) : myStructures;
         }
 
         if (type === FIND_STRUCTURES) {

--- a/prod/test/controllerManager.test.ts
+++ b/prod/test/controllerManager.test.ts
@@ -15,6 +15,12 @@ describe('controller manager', () => {
     (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {} };
     (globalThis as unknown as { FIND_MY_CONSTRUCTION_SITES: number }).FIND_MY_CONSTRUCTION_SITES = 1;
     (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 2;
+    (globalThis as unknown as { FIND_STRUCTURES: number }).FIND_STRUCTURES = 3;
+    (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+    (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+    (globalThis as unknown as { STRUCTURE_LINK: StructureConstant }).STRUCTURE_LINK = 'link';
+    (globalThis as unknown as { STRUCTURE_STORAGE: StructureConstant }).STRUCTURE_STORAGE = 'storage';
+    (globalThis as unknown as { STRUCTURE_TERMINAL: StructureConstant }).STRUCTURE_TERMINAL = 'terminal';
   });
 
   it('records owned controller sign state and near-level upgrade demand', () => {
@@ -164,6 +170,104 @@ describe('controller manager', () => {
     });
   });
 
+  it('requests a second low-RCL upgrader when stored surplus remains after construction clears', () => {
+    const plan = buildControllerManagementPlan(
+      makeColony({
+        energyAvailable: 550,
+        energyCapacityAvailable: 550,
+        controller: makeController({ level: 2, progress: 3_000, progressTotal: 45_000 }),
+        structures: [makeEnergyStore('container1', 'container', 2_000)]
+      }),
+      { worker: 4, upgrader: 1 },
+      4,
+      210
+    );
+
+    expect(plan).toMatchObject({
+      upgradePriority: 'energySurplus',
+      desiredUpgraderCount: 2,
+      activeUpgraderCount: 1,
+      spawnDemand: {
+        priority: 'energySurplus',
+        desiredUpgraderCount: 2,
+        activeUpgraderCount: 1
+      }
+    });
+  });
+
+  it('keeps surplus upgrade demand at the baseline while the worker floor is missing', () => {
+    const plan = buildControllerManagementPlan(
+      makeColony({
+        energyAvailable: 550,
+        energyCapacityAvailable: 550,
+        controller: makeController({ level: 2, progress: 3_000, progressTotal: 45_000 }),
+        structures: [makeEnergyStore('container1', 'container', 2_000)]
+      }),
+      { worker: 3, upgrader: 1 },
+      4,
+      211
+    );
+
+    expect(plan.desiredUpgraderCount).toBe(0);
+    expect(plan.spawnDemand).toBeUndefined();
+  });
+
+  it('does not surge extra upgraders while visible construction still needs workers', () => {
+    const plan = buildControllerManagementPlan(
+      makeColony({
+        constructionSiteCount: 1,
+        energyAvailable: 550,
+        energyCapacityAvailable: 550,
+        controller: makeController({ level: 2, progress: 3_000, progressTotal: 45_000 }),
+        structures: [makeEnergyStore('container1', 'container', 2_000)]
+      }),
+      { worker: 4, upgrader: 1 },
+      4,
+      212
+    );
+
+    expect(plan.upgradePriority).toBe('energySurplus');
+    expect(plan.desiredUpgraderCount).toBe(1);
+    expect(plan.spawnDemand).toBeUndefined();
+  });
+
+  it('does not surge extra upgraders during defense pressure', () => {
+    const plan = buildControllerManagementPlan(
+      makeColony({
+        energyAvailable: 550,
+        energyCapacityAvailable: 550,
+        controller: makeController({ level: 2, progress: 3_000, progressTotal: 45_000 }),
+        structures: [makeEnergyStore('container1', 'container', 2_000)]
+      }),
+      { worker: 4, upgrader: 1 },
+      4,
+      213,
+      { defenseDemand: true }
+    );
+
+    expect(plan.desiredUpgraderCount).toBe(0);
+    expect(plan.spawnDemand).toBeUndefined();
+  });
+
+  it('does not surge extra upgraders until spawn energy and buffer margin are ready', () => {
+    const plan = buildControllerManagementPlan(
+      makeColony({
+        energyAvailable: 599,
+        energyCapacityAvailable: 650,
+        controller: makeController({ level: 3, progress: 3_000, progressTotal: 135_000 }),
+        structures: [makeEnergyStore('container1', 'container', 2_000)]
+      }),
+      { worker: 4, upgrader: 1 },
+      4,
+      214,
+      { hasEnergySurplus: true }
+    );
+
+    expect(plan.upgradePriority).toBe('energySurplus');
+    expect(plan.desiredUpgraderCount).toBe(1);
+    expect(plan.spawnDemand).toBeUndefined();
+  });
+
   it('does not request a dedicated upgrader for an RCL 8 controller', () => {
     const plan = buildControllerManagementPlan(
       makeColony({
@@ -307,12 +411,14 @@ describe('controller manager', () => {
     controller = makeController(),
     energyAvailable = 650,
     energyCapacityAvailable = 650,
-    constructionSiteCount = 0
+    constructionSiteCount = 0,
+    structures = []
   }: {
     controller?: StructureController;
     energyAvailable?: number;
     energyCapacityAvailable?: number;
     constructionSiteCount?: number;
+    structures?: Structure[];
   } = {}): ColonySnapshot {
     const constructionSites = Array.from(
       { length: constructionSiteCount },
@@ -324,6 +430,10 @@ describe('controller manager', () => {
       find: jest.fn((type: number) => {
         if (type === FIND_MY_CONSTRUCTION_SITES || type === FIND_CONSTRUCTION_SITES) {
           return constructionSites;
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return structures;
         }
 
         return [];
@@ -348,5 +458,19 @@ describe('controller manager', () => {
       ticksToDowngrade: 10_000,
       ...overrides
     } as StructureController;
+  }
+
+  function makeEnergyStore(
+    id: string,
+    structureType: StructureConstant,
+    energy: number
+  ): Structure {
+    return {
+      id,
+      structureType,
+      store: {
+        getUsedCapacity: jest.fn((resource: ResourceConstant) => (resource === RESOURCE_ENERGY ? energy : 0))
+      }
+    } as unknown as Structure;
   }
 });

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -109,7 +109,7 @@ describe('planSpawn', () => {
     spawnPosition?: RoomPosition;
     structures?: AnyStructure[];
     ownedStructures?: AnyOwnedStructure[];
-  } = {}): { colony: ColonySnapshot; spawn: StructureSpawn; find: jest.Mock<unknown[], [number]> } {
+  } = {}): { colony: ColonySnapshot; spawn: StructureSpawn; find: jest.Mock } {
     const sources = Array.from(
       { length: sourceCount },
       (_, index) =>
@@ -122,7 +122,7 @@ describe('planSpawn', () => {
       { length: constructionSiteCount },
       (_, index) => ({ id: `site${index}` }) as ConstructionSite
     );
-    const find = jest.fn((type: number) => {
+    const find = jest.fn((type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
       if (type === FIND_SOURCES) {
         return sources;
       }
@@ -136,7 +136,7 @@ describe('planSpawn', () => {
       }
 
       if (type === FIND_MY_STRUCTURES) {
-        return ownedStructures;
+        return typeof options?.filter === 'function' ? ownedStructures.filter(options.filter) : ownedStructures;
       }
 
       if (type === FIND_STRUCTURES) {
@@ -1328,7 +1328,7 @@ describe('planSpawn', () => {
         progress: 3_000,
         progressTotal: 45_000
       } as StructureController,
-      structures: [makeEnergyHaulingStructure('stored-surplus', 'container', 2_000, 0)]
+      ownedStructures: [makeEnergyHaulingStructure('stored-surplus', 'storage', 2_000, 0)]
     });
 
     expect(planSpawn(colony, { worker: 4, upgrader: 1 }, 980_333)).toEqual({
@@ -1361,7 +1361,7 @@ describe('planSpawn', () => {
         progress: 3_000,
         progressTotal: 45_000
       } as StructureController,
-      structures: [makeEnergyHaulingStructure('stored-surplus', 'container', 2_000, 0)]
+      ownedStructures: [makeEnergyHaulingStructure('stored-surplus', 'storage', 2_000, 0)]
     });
 
     expect(planSpawn(colony, { worker: 3, upgrader: 1 }, 980_334)).toEqual({
@@ -1385,7 +1385,7 @@ describe('planSpawn', () => {
         progress: 3_000,
         progressTotal: 45_000
       } as StructureController,
-      structures: [makeEnergyHaulingStructure('stored-surplus', 'container', 2_000, 0)]
+      ownedStructures: [makeEnergyHaulingStructure('stored-surplus', 'storage', 2_000, 0)]
     });
 
     expect(planSpawn(colony, { worker: 4, upgrader: 1 }, 980_335)?.memory.role).not.toBe('upgrader');
@@ -1403,7 +1403,7 @@ describe('planSpawn', () => {
         progress: 3_000,
         progressTotal: 135_000
       } as StructureController,
-      structures: [makeEnergyHaulingStructure('stored-surplus', 'container', 2_000, 0)]
+      ownedStructures: [makeEnergyHaulingStructure('stored-surplus', 'storage', 2_000, 0)]
     });
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       economy: { energySurplus: { updatedAt: 980_336, rooms: { W3N9: { surplus: true } as EconomyEnergySurplusRoomMemory } } }

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -1316,6 +1316,102 @@ describe('planSpawn', () => {
     });
   });
 
+  it('spawns a second dedicated low-RCL upgrader when construction is clear and stored energy is surplus', () => {
+    const { colony, spawn } = makeColony({
+      roomName: 'W3N9',
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      controller: {
+        ...makeSafeOwnedController(),
+        id: 'controller-w3n9' as Id<StructureController>,
+        level: 2,
+        progress: 3_000,
+        progressTotal: 45_000
+      } as StructureController,
+      structures: [makeEnergyHaulingStructure('stored-surplus', 'container', 2_000, 0)]
+    });
+
+    expect(planSpawn(colony, { worker: 4, upgrader: 1 }, 980_333)).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move'],
+      name: 'upgrader-W3N9-controller-980333',
+      memory: {
+        role: 'upgrader',
+        colony: 'W3N9',
+        controllerUpgrade: {
+          roomName: 'W3N9',
+          controllerId: 'controller-w3n9',
+          priority: 'energySurplus',
+          assignedAt: 980_333
+        }
+      }
+    });
+  });
+
+  it('keeps worker recovery ahead of surplus low-RCL upgrader surge', () => {
+    const { colony, spawn } = makeColony({
+      roomName: 'W3N9',
+      sourceCount: 2,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      controller: {
+        ...makeSafeOwnedController(),
+        id: 'controller-w3n9' as Id<StructureController>,
+        level: 2,
+        progress: 3_000,
+        progressTotal: 45_000
+      } as StructureController,
+      structures: [makeEnergyHaulingStructure('stored-surplus', 'container', 2_000, 0)]
+    });
+
+    expect(planSpawn(colony, { worker: 3, upgrader: 1 }, 980_334)).toEqual({
+      spawn,
+      body: SCALED_WORKER_550,
+      name: 'worker-W3N9-980334',
+      memory: { role: 'worker', colony: 'W3N9' }
+    });
+  });
+
+  it('does not spawn surplus low-RCL upgraders while construction demand remains', () => {
+    const { colony } = makeColony({
+      roomName: 'W3N9',
+      constructionSiteCount: 1,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      controller: {
+        ...makeSafeOwnedController(),
+        id: 'controller-w3n9' as Id<StructureController>,
+        level: 2,
+        progress: 3_000,
+        progressTotal: 45_000
+      } as StructureController,
+      structures: [makeEnergyHaulingStructure('stored-surplus', 'container', 2_000, 0)]
+    });
+
+    expect(planSpawn(colony, { worker: 4, upgrader: 1 }, 980_335)?.memory.role).not.toBe('upgrader');
+  });
+
+  it('does not spawn surplus low-RCL upgraders until spawn energy is full with buffer margin', () => {
+    const { colony } = makeColony({
+      roomName: 'W3N9',
+      energyAvailable: 599,
+      energyCapacityAvailable: 650,
+      controller: {
+        ...makeSafeOwnedController(),
+        id: 'controller-w3n9' as Id<StructureController>,
+        level: 3,
+        progress: 3_000,
+        progressTotal: 135_000
+      } as StructureController,
+      structures: [makeEnergyHaulingStructure('stored-surplus', 'container', 2_000, 0)]
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      economy: { energySurplus: { updatedAt: 980_336, rooms: { W3N9: { surplus: true } as EconomyEnergySurplusRoomMemory } } }
+    };
+
+    expect(planSpawn(colony, { worker: 4, upgrader: 1 }, 980_336)?.memory.role).not.toBe('upgrader');
+  });
+
   it('keeps controller-upgrade demand eligible during worker-only follow-up passes', () => {
     const { colony, spawn } = makeColony({
       roomName: 'W1N20',


### PR DESCRIPTION
## Summary
- Add a guarded surplus controller-upgrade surge for early owned rooms after construction backlog clears.
- Preserve emergency/recovery/construction/defense guardrails before requesting additional upgrader capacity.
- Add focused controller/spawn planner coverage for surplus and guard cases.

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` — 95 suites / 1830 tests passed
- `npm run build`
- `git diff --check`

Closes #1081
