### PR TITLE
feat: gate seasonal runtime logistics

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35360,6 +35360,41 @@ function getGameTime30() {
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.time) != null ? _b : 0;
 }
 
+// src/runtime/featureGates.ts
+function getRuntimeFeatureGates(game = getRuntimeGame()) {
+  var _a, _b;
+  const shardName = normalizeString((_a = game == null ? void 0 : game.shard) == null ? void 0 : _a.name);
+  const shardType = normalizeString((_b = game == null ? void 0 : game.shard) == null ? void 0 : _b.type);
+  const isSeasonal = shardName === "shardSeason" || /season/i.test(shardType != null ? shardType : "");
+  const enabledInPersistent = !isSeasonal;
+  return {
+    cpu: buildCpuMetadata(game == null ? void 0 : game.cpu),
+    isSeasonal,
+    ...shardName ? { shardName } : {},
+    ...shardType ? { shardType } : {},
+    world: isSeasonal ? "seasonal" : "persistent",
+    marketTrading: enabledInPersistent,
+    terminalEnergyTransfers: enabledInPersistent,
+    labManagement: enabledInPersistent
+  };
+}
+function getRuntimeGame() {
+  return globalThis.Game;
+}
+function buildCpuMetadata(cpu) {
+  return {
+    ...optionalFiniteNumber("limit", cpu == null ? void 0 : cpu.limit),
+    ...optionalFiniteNumber("bucket", cpu == null ? void 0 : cpu.bucket),
+    ...optionalFiniteNumber("tickLimit", cpu == null ? void 0 : cpu.tickLimit)
+  };
+}
+function optionalFiniteNumber(key, value) {
+  return typeof value === "number" && Number.isFinite(value) ? { [key]: value } : {};
+}
+function normalizeString(value) {
+  return typeof value === "string" && value.length > 0 ? value : void 0;
+}
+
 // src/economy/sourceWorkload.ts
 var HARVEST_ENERGY_PER_WORK_PART3 = 2;
 var DEFAULT_SOURCE_ENERGY_CAPACITY3 = 3e3;
@@ -42888,10 +42923,13 @@ var BOOTSTRAP_WORKER_BUFFER_BYPASS_MIN_ENERGY = 300;
 var LOW_ROOM_ENERGY_TASK_PRIORITY_RATIO = 0.5;
 function runEconomy(preludeTelemetryEvents = []) {
   var _a, _b, _c, _d;
+  const featureGates = getRuntimeFeatureGates();
   const creeps = Object.values(Game.creeps);
   balanceStorage();
-  manageTerminalEnergy();
-  if (Memory.enableMarketTrading === true && shouldRunMarketTrading(Game.time)) {
+  if (featureGates.terminalEnergyTransfers) {
+    manageTerminalEnergy();
+  }
+  if (featureGates.marketTrading && Memory.enableMarketTrading === true && shouldRunMarketTrading(Game.time)) {
     runMarketTrading();
   }
   const ownedColonies = getOwnedColonies();
@@ -43015,7 +43053,7 @@ function runEconomy(preludeTelemetryEvents = []) {
     transferEnergy(colony.room);
     manageStorage(colony.room);
     refreshRoomEnergySurplusState(colony.room);
-    const labStructures = shouldRunLabManagement(colony.room);
+    const labStructures = shouldRunLabManagement(colony.room, featureGates);
     if (labStructures.length > 0) {
       manageLabs(colony.room, { creeps, labs: labStructures });
     }
@@ -43027,7 +43065,7 @@ function runEconomy(preludeTelemetryEvents = []) {
   refreshSpawnEnergyReservationStates(colonies);
   refreshSpawnEnergyBufferStates(colonies, reservedSpawnEnergyByRoom);
   for (const creep of orderCreepsForEconomyTaskPriority(creeps)) {
-    if (shouldYieldCreepToLabManager(creep, Game.time)) {
+    if (featureGates.labManagement && shouldYieldCreepToLabManager(creep, Game.time)) {
       continue;
     }
     if (creep.memory.role === "worker") {
@@ -43133,8 +43171,11 @@ function getResourceEnergyConstant() {
   var _a;
   return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
 }
-function shouldRunLabManagement(room) {
+function shouldRunLabManagement(room, featureGates) {
   var _a, _b;
+  if (!featureGates.labManagement) {
+    return [];
+  }
   if (((_a = room.controller) == null ? void 0 : _a.my) !== true || ((_b = room.controller.level) != null ? _b : 0) < 6) {
     return [];
   }

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -28,6 +28,7 @@ import {
   type RuntimeSummary,
   type RuntimeTelemetryEvent
 } from '../telemetry/runtimeSummary';
+import { getRuntimeFeatureGates, type RuntimeFeatureGates } from '../runtime/featureGates';
 import { recordSourceWorkloads } from './sourceWorkload';
 import {
   ensureRemoteSourceContainersForAssignedHarvesters
@@ -140,10 +141,13 @@ interface CoordinatedSpawnPlan {
 }
 
 export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = []): RuntimeSummary | undefined {
+  const featureGates = getRuntimeFeatureGates();
   const creeps = Object.values(Game.creeps);
   balanceStorage();
-  manageTerminalEnergy();
-  if (Memory.enableMarketTrading === true && shouldRunMarketTrading(Game.time)) {
+  if (featureGates.terminalEnergyTransfers) {
+    manageTerminalEnergy();
+  }
+  if (featureGates.marketTrading && Memory.enableMarketTrading === true && shouldRunMarketTrading(Game.time)) {
     runMarketTrading();
   }
   const ownedColonies = getOwnedColonies();
@@ -281,7 +285,7 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
     transferLinkEnergy(colony.room);
     manageStorage(colony.room);
     refreshRoomEnergySurplusState(colony.room);
-    const labStructures = shouldRunLabManagement(colony.room);
+    const labStructures = shouldRunLabManagement(colony.room, featureGates);
     if (labStructures.length > 0) {
       manageLabs(colony.room, { creeps, labs: labStructures });
     }
@@ -295,7 +299,7 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
   refreshSpawnEnergyBufferStates(colonies, reservedSpawnEnergyByRoom);
 
   for (const creep of orderCreepsForEconomyTaskPriority(creeps)) {
-    if (shouldYieldCreepToLabManager(creep, Game.time)) {
+    if (featureGates.labManagement && shouldYieldCreepToLabManager(creep, Game.time)) {
       continue;
     }
 
@@ -433,7 +437,11 @@ function getResourceEnergyConstant(): ResourceConstant {
   return ((globalThis as unknown as { RESOURCE_ENERGY?: ResourceConstant }).RESOURCE_ENERGY ?? 'energy') as ResourceConstant;
 }
 
-function shouldRunLabManagement(room: Room): StructureLab[] {
+function shouldRunLabManagement(room: Room, featureGates: RuntimeFeatureGates): StructureLab[] {
+  if (!featureGates.labManagement) {
+    return [];
+  }
+
   if (room.controller?.my !== true || (room.controller.level ?? 0) < 6) {
     return [];
   }

--- a/prod/src/runtime/featureGates.ts
+++ b/prod/src/runtime/featureGates.ts
@@ -1,0 +1,73 @@
+export type RuntimeWorldKind = 'persistent' | 'seasonal';
+
+export interface RuntimeCpuMetadata {
+  bucket?: number;
+  limit?: number;
+  tickLimit?: number;
+}
+
+export interface RuntimeFeatureGates {
+  cpu: RuntimeCpuMetadata;
+  isSeasonal: boolean;
+  labManagement: boolean;
+  marketTrading: boolean;
+  shardName?: string;
+  shardType?: string;
+  terminalEnergyTransfers: boolean;
+  world: RuntimeWorldKind;
+}
+
+interface RuntimeGameLike {
+  cpu?: {
+    bucket?: unknown;
+    limit?: unknown;
+    tickLimit?: unknown;
+  };
+  shard?: {
+    name?: unknown;
+    type?: unknown;
+  };
+}
+
+export function getRuntimeFeatureGates(game: RuntimeGameLike | undefined = getRuntimeGame()): RuntimeFeatureGates {
+  const shardName = normalizeString(game?.shard?.name);
+  const shardType = normalizeString(game?.shard?.type);
+  const isSeasonal = shardName === 'shardSeason' || /season/i.test(shardType ?? '');
+  const enabledInPersistent = !isSeasonal;
+
+  return {
+    cpu: buildCpuMetadata(game?.cpu),
+    isSeasonal,
+    ...(shardName ? { shardName } : {}),
+    ...(shardType ? { shardType } : {}),
+    world: isSeasonal ? 'seasonal' : 'persistent',
+    marketTrading: enabledInPersistent,
+    terminalEnergyTransfers: enabledInPersistent,
+    labManagement: enabledInPersistent
+  };
+}
+
+function getRuntimeGame(): RuntimeGameLike | undefined {
+  return (globalThis as { Game?: RuntimeGameLike }).Game;
+}
+
+function buildCpuMetadata(cpu: RuntimeGameLike['cpu']): RuntimeCpuMetadata {
+  return {
+    ...optionalFiniteNumber('limit', cpu?.limit),
+    ...optionalFiniteNumber('bucket', cpu?.bucket),
+    ...optionalFiniteNumber('tickLimit', cpu?.tickLimit)
+  };
+}
+
+function optionalFiniteNumber<K extends keyof RuntimeCpuMetadata>(
+  key: K,
+  value: unknown
+): Pick<RuntimeCpuMetadata, K> | Record<string, never> {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? { [key]: value } as Pick<RuntimeCpuMetadata, K>
+    : {};
+}
+
+function normalizeString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}

--- a/prod/test/seasonalRuntimeFeatureGates.test.ts
+++ b/prod/test/seasonalRuntimeFeatureGates.test.ts
@@ -1,0 +1,385 @@
+import { runEconomy } from '../src/economy/economyLoop';
+import { MARKET_TRADING_INTERVAL } from '../src/economy/marketTrading';
+import { getRuntimeFeatureGates } from '../src/runtime/featureGates';
+
+const OK_CODE = 0 as ScreepsReturnCode;
+const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
+
+type TestTerminal = StructureTerminal & { send: jest.Mock };
+
+describe('runtime world feature gates', () => {
+  afterEach(() => {
+    cleanupRuntimeGlobals();
+  });
+
+  it('defaults missing and partial Game globals to persistent feature availability', () => {
+    delete (globalThis as { Game?: Partial<Game> }).Game;
+
+    expect(getRuntimeFeatureGates()).toMatchObject({
+      isSeasonal: false,
+      world: 'persistent',
+      marketTrading: true,
+      terminalEnergyTransfers: true,
+      labManagement: true
+    });
+
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {};
+
+    expect(getRuntimeFeatureGates()).toMatchObject({
+      isSeasonal: false,
+      world: 'persistent',
+      marketTrading: true,
+      terminalEnergyTransfers: true,
+      labManagement: true
+    });
+  });
+
+  it('detects Seasonal World by shard name and disables smoke-risky logistics', () => {
+    installFeatureGateGame({ shard: { name: 'shardSeason', type: 'normal' } });
+
+    expect(getRuntimeFeatureGates()).toMatchObject({
+      isSeasonal: true,
+      world: 'seasonal',
+      marketTrading: false,
+      terminalEnergyTransfers: false,
+      labManagement: false
+    });
+  });
+
+  it('detects Seasonal World by shard type case-insensitively and preserves CPU metadata', () => {
+    installFeatureGateGame({
+      shard: { name: 'shard3', type: 'Seasonal-event' },
+      cpu: { limit: 20, bucket: 9_000, tickLimit: 500 }
+    });
+
+    expect(getRuntimeFeatureGates()).toMatchObject({
+      isSeasonal: true,
+      world: 'seasonal',
+      shardName: 'shard3',
+      shardType: 'Seasonal-event',
+      cpu: {
+        limit: 20,
+        bucket: 9_000,
+        tickLimit: 500
+      }
+    });
+  });
+});
+
+describe('runEconomy Seasonal feature gates', () => {
+  let logSpy: jest.SpyInstance<void, [message?: unknown, ...optionalParams: unknown[]]>;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation();
+    installEconomyGlobals();
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    cleanupRuntimeGlobals();
+  });
+
+  it('skips market API calls on Seasonal World even when trading is enabled on cadence', () => {
+    const deal = jest.fn().mockReturnValue(OK_CODE);
+    const getAllOrders = makeMarketOrderGetter([
+      makeOrder({ id: 'buy-H', type: 'buy', resourceType: 'H', price: 2, roomName: 'W2N1' }),
+      makeOrder({ id: 'sell-H', type: 'sell', resourceType: 'H', price: 1, roomName: 'W3N1' })
+    ]);
+    installMarketEconomyGame({
+      time: MARKET_TRADING_INTERVAL * 8,
+      shard: { name: 'shardSeason', type: 'normal' },
+      deal,
+      getAllOrders
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = { enableMarketTrading: true };
+
+    runEconomy();
+
+    expect(getAllOrders).not.toHaveBeenCalled();
+    expect(deal).not.toHaveBeenCalled();
+  });
+
+  it('skips terminal sends on Seasonal World in an imbalance that persistent worlds send', () => {
+    const persistentSource = makeTerminalBalanceRoom({
+      roomName: 'W1N1',
+      storageEnergy: 100_000,
+      terminalEnergy: 80_000
+    });
+    const persistentTarget = makeTerminalBalanceRoom({
+      roomName: 'W2N1',
+      storageEnergy: 10_000,
+      terminalEnergy: 20_000
+    });
+    installTerminalEconomyGame({
+      rooms: [persistentSource, persistentTarget],
+      shard: { name: 'shard3', type: 'normal' }
+    });
+
+    runEconomy();
+
+    expect(persistentSource.terminal?.send).toHaveBeenCalledWith(
+      RESOURCE_ENERGY,
+      10_000,
+      'W2N1',
+      'energy-balance W1N1->W2N1'
+    );
+
+    const seasonalSource = makeTerminalBalanceRoom({
+      roomName: 'W1N1',
+      storageEnergy: 100_000,
+      terminalEnergy: 80_000
+    });
+    const seasonalTarget = makeTerminalBalanceRoom({
+      roomName: 'W2N1',
+      storageEnergy: 10_000,
+      terminalEnergy: 20_000
+    });
+    installTerminalEconomyGame({
+      rooms: [seasonalSource, seasonalTarget],
+      shard: { name: 'shardSeason', type: 'normal' }
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+
+    runEconomy();
+
+    expect(seasonalSource.terminal?.send).not.toHaveBeenCalled();
+  });
+
+  it('keeps an empty-world Seasonal smoke path away from disabled APIs', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = { enableMarketTrading: true };
+    const game = {
+      time: MARKET_TRADING_INTERVAL * 12,
+      rooms: {},
+      spawns: {},
+      creeps: {},
+      shard: { name: 'shardSeason', type: 'normal' }
+    } as Partial<Game>;
+    Object.defineProperty(game, 'market', {
+      get: () => {
+        throw new Error('Seasonal smoke must not access Game.market');
+      }
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = game;
+
+    expect(() => runEconomy()).not.toThrow();
+  });
+});
+
+function installFeatureGateGame(game: {
+  shard?: { name?: string; type?: string };
+  cpu?: { limit?: number; bucket?: number; tickLimit?: number };
+}): void {
+  (globalThis as unknown as { Game: Partial<Game> }).Game = game as Partial<Game>;
+}
+
+function installEconomyGlobals(): void {
+  Object.assign(globalThis, {
+    ERR_NO_PATH: ERR_NO_PATH_CODE,
+    FIND_HOSTILE_CREEPS: 1,
+    FIND_HOSTILE_STRUCTURES: 2,
+    FIND_MY_STRUCTURES: 3,
+    FIND_SOURCES: 4,
+    RESOURCE_ENERGY: 'energy',
+    ORDER_BUY: 'buy',
+    ORDER_SELL: 'sell',
+    STRUCTURE_EXTENSION: 'extension',
+    STRUCTURE_LAB: 'lab',
+    STRUCTURE_SPAWN: 'spawn',
+    STRUCTURE_STORAGE: 'storage',
+    STRUCTURE_TERMINAL: 'terminal'
+  });
+}
+
+function installMarketEconomyGame({
+  time,
+  shard,
+  deal,
+  getAllOrders
+}: {
+  time: number;
+  shard: { name: string; type: string };
+  deal: jest.Mock;
+  getAllOrders: jest.Mock;
+}): void {
+  const room = makeMarketRoom();
+  const spawn = {
+    name: 'Spawn1',
+    room,
+    spawning: null,
+    spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+  } as unknown as StructureSpawn;
+
+  (globalThis as unknown as { Game: Partial<Game> }).Game = {
+    time,
+    rooms: { W1N1: room },
+    spawns: { Spawn1: spawn },
+    creeps: {},
+    shard: shard as Shard,
+    market: {
+      credits: 20_000,
+      deal,
+      getAllOrders,
+      calcTransactionCost: jest.fn().mockReturnValue(0)
+    } as unknown as Market
+  };
+}
+
+function installTerminalEconomyGame({
+  rooms,
+  shard
+}: {
+  rooms: Room[];
+  shard: { name: string; type: string };
+}): void {
+  (globalThis as unknown as { Game: Partial<Game> }).Game = {
+    time: 100,
+    creeps: {},
+    rooms: Object.fromEntries(rooms.map((room) => [room.name, room])),
+    spawns: {},
+    shard: shard as Shard,
+    map: {
+      getRoomLinearDistance: jest.fn().mockReturnValue(2),
+      findRoute: jest.fn((_fromRoom: string, targetRoom: string) => [{ exit: 1, room: targetRoom }])
+    } as unknown as GameMap
+  };
+}
+
+function makeMarketRoom(): Room {
+  return {
+    name: 'W1N1',
+    controller: { my: true, level: 6 } as StructureController,
+    energyAvailable: 800,
+    energyCapacityAvailable: 800,
+    storage: {
+      id: 'storage1',
+      structureType: 'storage',
+      store: makeResourceStore({ energy: 50_000 }, 500_000)
+    } as unknown as StructureStorage,
+    terminal: {
+      id: 'terminal1',
+      cooldown: 0,
+      structureType: 'terminal',
+      store: makeResourceStore({ energy: 80_000, H: 30_000 }, 200_000)
+    } as unknown as StructureTerminal,
+    find: jest.fn(() => [])
+  } as unknown as Room;
+}
+
+function makeTerminalBalanceRoom({
+  roomName,
+  storageEnergy,
+  terminalEnergy
+}: {
+  roomName: string;
+  storageEnergy: number;
+  terminalEnergy: number;
+}): Room {
+  return {
+    name: roomName,
+    controller: { my: true, level: 4 } as StructureController,
+    energyAvailable: 800,
+    energyCapacityAvailable: 800,
+    storage: {
+      id: `${roomName}-storage`,
+      structureType: 'storage',
+      store: makeResourceStore({ energy: storageEnergy }, 100_000)
+    } as unknown as StructureStorage,
+    terminal: {
+      id: `${roomName}-terminal`,
+      cooldown: 0,
+      structureType: 'terminal',
+      store: makeResourceStore({ energy: terminalEnergy }, 100_000),
+      send: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as TestTerminal,
+    find: jest.fn((type: number) => {
+      if (type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES || type === FIND_MY_STRUCTURES) {
+        return [];
+      }
+
+      if (type === FIND_SOURCES) {
+        return [{ id: `${roomName}-source` } as Source];
+      }
+
+      return [];
+    })
+  } as unknown as Room;
+}
+
+function makeResourceStore(resources: Record<string, number>, capacity: number): StoreDefinition {
+  return {
+    ...resources,
+    getUsedCapacity: jest.fn((resource?: ResourceConstant) =>
+      resource ? resources[resource] ?? 0 : sumResources(resources)
+    ),
+    getCapacity: jest.fn(() => capacity),
+    getFreeCapacity: jest.fn(() => Math.max(0, capacity - sumResources(resources)))
+  } as unknown as StoreDefinition;
+}
+
+function makeOrder({
+  id,
+  type,
+  resourceType,
+  price,
+  roomName,
+  remainingAmount = 5_000
+}: {
+  id: string;
+  type: 'buy' | 'sell';
+  resourceType: string;
+  price: number;
+  roomName: string;
+  remainingAmount?: number;
+}): Order {
+  return {
+    id,
+    created: 1,
+    active: true,
+    type,
+    resourceType: resourceType as MarketResourceConstant,
+    roomName,
+    amount: remainingAmount,
+    remainingAmount,
+    price
+  } as Order;
+}
+
+function makeMarketOrderGetter(orders: Order[]): jest.Mock {
+  return jest.fn((filter?: OrderFilter | ((order: Order) => boolean)) => {
+    if (typeof filter === 'function') {
+      return orders.filter(filter);
+    }
+
+    if (!filter) {
+      return orders;
+    }
+
+    return orders.filter((order) => (
+      (filter.type === undefined || order.type === filter.type) &&
+      (filter.resourceType === undefined || order.resourceType === filter.resourceType)
+    ));
+  });
+}
+
+function sumResources(resources: Record<string, number>): number {
+  return Object.values(resources).reduce((total, amount) => total + amount, 0);
+}
+
+function cleanupRuntimeGlobals(): void {
+  delete (globalThis as { Game?: Partial<Game> }).Game;
+  delete (globalThis as { Memory?: Partial<Memory> }).Memory;
+  delete (globalThis as { ERR_NO_PATH?: ScreepsReturnCode }).ERR_NO_PATH;
+  delete (globalThis as { FIND_HOSTILE_CREEPS?: number }).FIND_HOSTILE_CREEPS;
+  delete (globalThis as { FIND_HOSTILE_STRUCTURES?: number }).FIND_HOSTILE_STRUCTURES;
+  delete (globalThis as { FIND_MY_STRUCTURES?: number }).FIND_MY_STRUCTURES;
+  delete (globalThis as { FIND_SOURCES?: number }).FIND_SOURCES;
+  delete (globalThis as { RESOURCE_ENERGY?: ResourceConstant }).RESOURCE_ENERGY;
+  delete (globalThis as { ORDER_BUY?: string }).ORDER_BUY;
+  delete (globalThis as { ORDER_SELL?: string }).ORDER_SELL;
+  delete (globalThis as { STRUCTURE_EXTENSION?: StructureConstant }).STRUCTURE_EXTENSION;
+  delete (globalThis as { STRUCTURE_LAB?: StructureConstant }).STRUCTURE_LAB;
+  delete (globalThis as { STRUCTURE_SPAWN?: StructureConstant }).STRUCTURE_SPAWN;
+  delete (globalThis as { STRUCTURE_STORAGE?: StructureConstant }).STRUCTURE_STORAGE;
+  delete (globalThis as { STRUCTURE_TERMINAL?: StructureConstant }).STRUCTURE_TERMINAL;
+}


### PR DESCRIPTION
## Summary
- Adds `getRuntimeFeatureGates()` to detect Seasonal World from `Game.shard.name === 'shardSeason'` or seasonal shard type, while defaulting partial/missing test globals to persistent-safe behavior.
- Gates smoke-risky runtime logistics on Seasonal: market trading, terminal energy transfers, and lab management are disabled; bootstrap/spawn/construction/claim/reserve/expansion/defense paths are not disabled.
- Adds deterministic Seasonal runtime tests covering feature detection, market skip, terminal-send skip, and empty-world no-disabled-API smoke behavior.

## Verification
- `npm run typecheck`
- `npm test -- --runInBand seasonalRuntimeFeatureGates.test.ts`
- `npm test -- --runInBand` (96 suites / 1827 tests)
- `npm run build`
- `git diff --check`
- Persistent MMO deploy dry-run: `python3 scripts/screeps_official_deploy.py --dry-run --api-url https://screeps.com --branch main --shard shardX --room W3N9` returned `ok: true`

## Operational notes
- No live Screeps writes or Seasonal uploads performed.
- #1075 remains gated on owner confirmation before any branch upload/activation.

Closes #1074
