### PR TITLE
fix(defense): assign reserve repairer for active rampart decay

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -23394,11 +23394,11 @@ function selectUncoveredRoutineRampartMaintenanceTask(creep, constructionSites) 
   if (constructionSites.length > 0 || hasSameRoomWorkerAssignedToTask(creep.room, creep, "repair")) {
     return null;
   }
-  const barrierMaintenanceTarget = selectRoutineBarrierMaintenanceRepairTarget(creep);
-  if (!barrierMaintenanceTarget || !isRampartRepairTarget(barrierMaintenanceTarget)) {
+  const rampartMaintenanceTarget = selectRoutineRampartMaintenanceRepairTarget(creep);
+  if (!rampartMaintenanceTarget) {
     return null;
   }
-  return { type: "repair", targetId: barrierMaintenanceTarget.id };
+  return { type: "repair", targetId: rampartMaintenanceTarget.id };
 }
 function shouldYieldControllerSustainUpgradeToConstruction(creep, sustain) {
   return sustain.homeRoom !== sustain.targetRoom && hasVisibleOwnedConstructionDemand(creep.room);
@@ -26608,6 +26608,9 @@ function selectThreatenedBarrierRepairTarget(creep) {
 function selectRoutineBarrierMaintenanceRepairTarget(creep) {
   return getRoutineBarrierMaintenanceRepairTarget(creep.room);
 }
+function selectRoutineRampartMaintenanceRepairTarget(creep) {
+  return computeRoutineRampartMaintenanceRepairTarget(creep.room);
+}
 function getRoutineBarrierMaintenanceRepairTarget(room) {
   const gameTick = getGameTick3();
   const roomName = getRoomName6(room);
@@ -26631,8 +26634,7 @@ function getRoutineBarrierMaintenanceRepairTarget(room) {
   return target;
 }
 function computeRoutineBarrierMaintenanceRepairTarget(room) {
-  var _a;
-  if (((_a = room.controller) == null ? void 0 : _a.my) !== true || hasVisibleHostilePresence2(room) || !checkEnergyBufferForConstructionSpending(room)) {
+  if (!canSelectRoutineBarrierMaintenanceRepairTarget(room)) {
     return null;
   }
   const repairTargets = findVisibleRoomStructures(room).filter(isRoutineBarrierMaintenanceRepairTarget);
@@ -26640,6 +26642,20 @@ function computeRoutineBarrierMaintenanceRepairTarget(room) {
     return null;
   }
   return repairTargets.sort(compareRepairTargets)[0];
+}
+function computeRoutineRampartMaintenanceRepairTarget(room) {
+  if (!canSelectRoutineBarrierMaintenanceRepairTarget(room)) {
+    return null;
+  }
+  const repairTargets = findVisibleRoomStructures(room).filter(isRoutineRampartMaintenanceRepairTarget);
+  if (repairTargets.length === 0) {
+    return null;
+  }
+  return repairTargets.sort(compareRepairTargets)[0];
+}
+function canSelectRoutineBarrierMaintenanceRepairTarget(room) {
+  var _a;
+  return ((_a = room.controller) == null ? void 0 : _a.my) === true && !hasVisibleHostilePresence2(room) && checkEnergyBufferForConstructionSpending(room);
 }
 function selectCriticalInfrastructureRepairTarget(creep) {
   var _a;
@@ -26714,6 +26730,9 @@ function isThreatenedBarrierRepairTarget(structure) {
 function isRoutineBarrierMaintenanceRepairTarget(structure) {
   return isBarrierRepairTarget(structure) && !isWorkerRepairTargetComplete(structure);
 }
+function isRoutineRampartMaintenanceRepairTarget(structure) {
+  return matchesStructureType18(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure) && !isWorkerRepairTargetComplete(structure);
+}
 function isSafeRepairTargetForWorkerRoom(creep, structure) {
   var _a;
   return isSafeRepairTarget(structure) && (!isSpawnRepairTarget(structure) || ((_a = creep.room.controller) == null ? void 0 : _a.my) === true);
@@ -26732,9 +26751,6 @@ function isRoadOrContainerRepairTarget(structure) {
 }
 function isBarrierRepairTarget(structure) {
   return matchesStructureType18(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure) || isWallRepairTarget(structure);
-}
-function isRampartRepairTarget(structure) {
-  return matchesStructureType18(structure.structureType, "STRUCTURE_RAMPART", "rampart");
 }
 function isRoadRepairTarget(structure) {
   return matchesStructureType18(structure.structureType, "STRUCTURE_ROAD", "road");

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -23112,6 +23112,13 @@ function selectHeuristicWorkerTask(creep) {
       targetId: threatenedBarrierRepairTarget.id
     });
   }
+  const uncoveredRoutineRampartMaintenanceTask = selectUncoveredRoutineRampartMaintenanceTask(
+    creep,
+    constructionSites
+  );
+  if (uncoveredRoutineRampartMaintenanceTask) {
+    return applyMinimumUsefulLoadPolicy(creep, uncoveredRoutineRampartMaintenanceTask);
+  }
   if (shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep)) {
     return null;
   }
@@ -23382,6 +23389,16 @@ function selectControllerSustainBarrierMaintenanceTask(creep, constructionSites)
   }
   const barrierMaintenanceTarget = selectRoutineBarrierMaintenanceRepairTarget(creep);
   return barrierMaintenanceTarget ? { type: "repair", targetId: barrierMaintenanceTarget.id } : null;
+}
+function selectUncoveredRoutineRampartMaintenanceTask(creep, constructionSites) {
+  if (constructionSites.length > 0 || hasSameRoomWorkerAssignedToTask(creep.room, creep, "repair")) {
+    return null;
+  }
+  const barrierMaintenanceTarget = selectRoutineBarrierMaintenanceRepairTarget(creep);
+  if (!barrierMaintenanceTarget || !isRampartRepairTarget(barrierMaintenanceTarget)) {
+    return null;
+  }
+  return { type: "repair", targetId: barrierMaintenanceTarget.id };
 }
 function shouldYieldControllerSustainUpgradeToConstruction(creep, sustain) {
   return sustain.homeRoom !== sustain.targetRoom && hasVisibleOwnedConstructionDemand(creep.room);
@@ -26715,6 +26732,9 @@ function isRoadOrContainerRepairTarget(structure) {
 }
 function isBarrierRepairTarget(structure) {
   return matchesStructureType18(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure) || isWallRepairTarget(structure);
+}
+function isRampartRepairTarget(structure) {
+  return matchesStructureType18(structure.structureType, "STRUCTURE_RAMPART", "rampart");
 }
 function isRoadRepairTarget(structure) {
   return matchesStructureType18(structure.structureType, "STRUCTURE_ROAD", "road");

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1068,12 +1068,12 @@ function selectUncoveredRoutineRampartMaintenanceTask(
     return null;
   }
 
-  const barrierMaintenanceTarget = selectRoutineBarrierMaintenanceRepairTarget(creep);
-  if (!barrierMaintenanceTarget || !isRampartRepairTarget(barrierMaintenanceTarget)) {
+  const rampartMaintenanceTarget = selectRoutineRampartMaintenanceRepairTarget(creep);
+  if (!rampartMaintenanceTarget) {
     return null;
   }
 
-  return { type: 'repair', targetId: barrierMaintenanceTarget.id as Id<Structure> };
+  return { type: 'repair', targetId: rampartMaintenanceTarget.id as Id<Structure> };
 }
 
 function shouldYieldControllerSustainUpgradeToConstruction(
@@ -6195,6 +6195,10 @@ function selectRoutineBarrierMaintenanceRepairTarget(creep: Creep): StructureRam
   return getRoutineBarrierMaintenanceRepairTarget(creep.room);
 }
 
+function selectRoutineRampartMaintenanceRepairTarget(creep: Creep): StructureRampart | null {
+  return computeRoutineRampartMaintenanceRepairTarget(creep.room);
+}
+
 function getRoutineBarrierMaintenanceRepairTarget(room: Room): StructureRampart | StructureWall | null {
   const gameTick = getGameTick();
   const roomName = getRoomName(room);
@@ -6226,11 +6230,7 @@ function getRoutineBarrierMaintenanceRepairTarget(room: Room): StructureRampart 
 }
 
 function computeRoutineBarrierMaintenanceRepairTarget(room: Room): StructureRampart | StructureWall | null {
-  if (
-    room.controller?.my !== true ||
-    hasVisibleHostilePresence(room) ||
-    !checkEnergyBufferForConstructionSpending(room)
-  ) {
+  if (!canSelectRoutineBarrierMaintenanceRepairTarget(room)) {
     return null;
   }
 
@@ -6240,6 +6240,27 @@ function computeRoutineBarrierMaintenanceRepairTarget(room: Room): StructureRamp
   }
 
   return repairTargets.sort(compareRepairTargets)[0];
+}
+
+function computeRoutineRampartMaintenanceRepairTarget(room: Room): StructureRampart | null {
+  if (!canSelectRoutineBarrierMaintenanceRepairTarget(room)) {
+    return null;
+  }
+
+  const repairTargets = findVisibleRoomStructures(room).filter(isRoutineRampartMaintenanceRepairTarget);
+  if (repairTargets.length === 0) {
+    return null;
+  }
+
+  return repairTargets.sort(compareRepairTargets)[0];
+}
+
+function canSelectRoutineBarrierMaintenanceRepairTarget(room: Room): boolean {
+  return (
+    room.controller?.my === true &&
+    !hasVisibleHostilePresence(room) &&
+    checkEnergyBufferForConstructionSpending(room)
+  );
 }
 
 function selectCriticalInfrastructureRepairTarget(creep: Creep): CriticalInfrastructureRepairTarget | null {
@@ -6348,6 +6369,14 @@ function isRoutineBarrierMaintenanceRepairTarget(
   return isBarrierRepairTarget(structure) && !isWorkerRepairTargetComplete(structure);
 }
 
+function isRoutineRampartMaintenanceRepairTarget(structure: AnyStructure): structure is StructureRampart {
+  return (
+    matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart') &&
+    isOwnedRampart(structure) &&
+    !isWorkerRepairTargetComplete(structure)
+  );
+}
+
 function isSafeRepairTargetForWorkerRoom(
   creep: Creep,
   structure: AnyStructure
@@ -6393,10 +6422,6 @@ function isBarrierRepairTarget(structure: AnyStructure): structure is StructureR
     (matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart') && isOwnedRampart(structure)) ||
     isWallRepairTarget(structure)
   );
-}
-
-function isRampartRepairTarget(structure: StructureRampart | StructureWall): structure is StructureRampart {
-  return matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart');
 }
 
 function isRoadRepairTarget(structure: AnyStructure): structure is StructureRoad {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -662,6 +662,14 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     });
   }
 
+  const uncoveredRoutineRampartMaintenanceTask = selectUncoveredRoutineRampartMaintenanceTask(
+    creep,
+    constructionSites
+  );
+  if (uncoveredRoutineRampartMaintenanceTask) {
+    return applyMinimumUsefulLoadPolicy(creep, uncoveredRoutineRampartMaintenanceTask);
+  }
+
   if (shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep)) {
     return null;
   }
@@ -1050,6 +1058,22 @@ function selectControllerSustainBarrierMaintenanceTask(
   return barrierMaintenanceTarget
     ? { type: 'repair', targetId: barrierMaintenanceTarget.id as Id<Structure> }
     : null;
+}
+
+function selectUncoveredRoutineRampartMaintenanceTask(
+  creep: Creep,
+  constructionSites: ConstructionSite[]
+): Extract<CreepTaskMemory, { type: 'repair' }> | null {
+  if (constructionSites.length > 0 || hasSameRoomWorkerAssignedToTask(creep.room, creep, 'repair')) {
+    return null;
+  }
+
+  const barrierMaintenanceTarget = selectRoutineBarrierMaintenanceRepairTarget(creep);
+  if (!barrierMaintenanceTarget || !isRampartRepairTarget(barrierMaintenanceTarget)) {
+    return null;
+  }
+
+  return { type: 'repair', targetId: barrierMaintenanceTarget.id as Id<Structure> };
 }
 
 function shouldYieldControllerSustainUpgradeToConstruction(
@@ -6369,6 +6393,10 @@ function isBarrierRepairTarget(structure: AnyStructure): structure is StructureR
     (matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart') && isOwnedRampart(structure)) ||
     isWallRepairTarget(structure)
   );
+}
+
+function isRampartRepairTarget(structure: StructureRampart | StructureWall): structure is StructureRampart {
+  return matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart');
 }
 
 function isRoadRepairTarget(structure: AnyStructure): structure is StructureRoad {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -13087,7 +13087,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'rampart-active-decay' });
   });
 
-  it('repairs W3N9 active-decay ramparts before a near-term spawn completion reserve', () => {
+  it('repairs W3N9 active-decay ramparts before a near-term spawn completion reserve when walls also need repair', () => {
     const controller = {
       id: 'controller1',
       my: true,
@@ -13109,6 +13109,7 @@ describe('selectWorkerTask', () => {
       300_000_000,
       { my: true }
     );
+    const wall = makeStructure('wall-lower-ratio', 'constructedWall' as StructureConstant, 1, 300_000_000);
     const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 4_641, {
       my: true
     });
@@ -13118,7 +13119,7 @@ describe('selectWorkerTask', () => {
       energyAvailable: 550,
       energyCapacityAvailable: 550,
       myStructures: [busyFullSpawn as AnyOwnedStructure],
-      structures: [rampart, storage]
+      structures: [rampart, wall, storage]
     });
     const creep = {
       name: 'RclPushUpgrader',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -13087,6 +13087,104 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'rampart-active-decay' });
   });
 
+  it('repairs W3N9 active-decay ramparts before a near-term spawn completion reserve', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      progress: 44_500,
+      progressTotal: 45_000,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const busyFullSpawn = {
+      id: 'spawn-busy',
+      structureType: 'spawn',
+      spawning: { remainingTime: 10 },
+      store: { getFreeCapacity: jest.fn().mockReturnValue(0) }
+    } as unknown as StructureSpawn;
+    const rampart = makeStructure(
+      'rampart-active-decay',
+      'rampart' as StructureConstant,
+      119_801,
+      300_000_000,
+      { my: true }
+    );
+    const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 4_641, {
+      my: true
+    });
+    const room = makeWorkerTaskRoom({
+      name: 'W3N9',
+      controller,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      myStructures: [busyFullSpawn as AnyOwnedStructure],
+      structures: [rampart, storage]
+    });
+    const creep = {
+      name: 'RclPushUpgrader',
+      memory: {
+        role: 'worker',
+        colony: 'W3N9',
+        controllerUpgrade: { roomName: 'W3N9', controllerId: 'controller1' }
+      },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+
+    expect(estimateNearTermSpawnExtensionRefillReserve(room)).toBe(550);
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'rampart-active-decay' });
+  });
+
+  it('keeps near-term refill reserve once another worker covers active rampart maintenance', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const busyFullSpawn = {
+      id: 'spawn-busy',
+      structureType: 'spawn',
+      spawning: { remainingTime: 10 },
+      store: { getFreeCapacity: jest.fn().mockReturnValue(0) }
+    } as unknown as StructureSpawn;
+    const rampart = makeStructure(
+      'rampart-active-decay',
+      'rampart' as StructureConstant,
+      119_801,
+      300_000_000,
+      { my: true }
+    );
+    const room = makeWorkerTaskRoom({
+      name: 'W3N9',
+      controller,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      myStructures: [busyFullSpawn as AnyOwnedStructure],
+      structures: [rampart]
+    });
+    const repairer = {
+      name: 'Repairer',
+      memory: {
+        role: 'worker',
+        colony: 'W3N9',
+        task: { type: 'repair', targetId: 'rampart-active-decay' as Id<Structure> }
+      },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    const creep = {
+      name: 'ReserveWorker',
+      memory: { role: 'worker', colony: 'W3N9' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ Repairer: repairer, ReserveWorker: creep });
+
+    expect(estimateNearTermSpawnExtensionRefillReserve(room)).toBe(550);
+    expect(selectWorkerTask(creep)).toBeNull();
+  });
+
   it.each([
     ['owned rampart', 'rampart' as StructureConstant, { my: true }, 'rampart-decay'],
     ['constructed wall', 'constructedWall' as StructureConstant, {}, 'wall-decay']


### PR DESCRIPTION
## Summary
- Adds an active-decay rampart repair reserve path when no construction exists and no same-room worker is already assigned to repair.
- Lets a carried-energy worker take the routine rampart repair target before falling into near-term spawn/extension refill reservation, so post-deploy rampart decay around 120k hits is not skipped under upgrade/logistics pressure.
- Adds regression coverage for assigning exactly one reserve repairer and not duplicating the assignment when another worker is already repairing.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (96 suites / 1846 tests)
- `cd prod && npm run build`
- `git diff --check`

## Runtime evidence
- Official deploy run `25931527762` deployed main `31085aa5cd2ec54c62216b198f281265e002fda6` successfully.
- Fresh post-deploy monitor `runtime-artifacts/screeps-monitor/scheduler-postdeploy-20260515T172408Z/` showed W3N9 alive but raised `postdeploy_active_alert` for rampart `(11,20)` / `6a06f75e9ac1bb36bc1c17ff`, hits `120001 -> 119801`.

Closes #1093
