### PR TITLE
fix(rl): load steam key for cron training runs

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any, Sequence, TextIO
 
 import screeps_rl_dataset_export as dataset_export
+import screeps_secret_env
 
 
 def _load_runtime_monitor_module():
@@ -96,6 +97,8 @@ RUN_RESOURCE_GUARD_HISTORICAL_NODE_GYP_JOBS_PER_WORKER = 4
 RUN_RESOURCE_GUARD_FAILURE_TYPE = "screeps-rl-simulator-resource-guard-failure"
 RUN_SCALE_VALIDATION_PLAN_TYPE = "screeps-rl-simulator-scale-validation-plan"
 RUN_SCALE_VALIDATION_DEFAULT_MIN_ENVIRONMENTS = 5
+DEFAULT_STEAM_KEY_ENV_FILE = screeps_secret_env.DEFAULT_LOCAL_SECRET_ENV_FILE
+STEAM_KEY_ENV_FILE_ENV = "SCREEPS_RL_STEAM_KEY_ENV_FILE"
 RUN_SCALE_VALIDATION_TARGET_SUCCESS_RATE = 0.8
 RUN_SETUP_FAILURE_TYPE = "screeps-rl-simulator-setup-failure"
 RUN_FAILURE_TYPE = "screeps-rl-simulator-run-failure"
@@ -4208,6 +4211,7 @@ def run_simulator(
     bot_commit: str | None = None,
     allow_unsafe_scale: bool = False,
     min_concurrent_environments: int = 0,
+    steam_key_env_file: Path | None = None,
 ) -> JsonObject:
     resolved_out_dir = out_dir.expanduser()
     resolved_code_path = code_path.expanduser()
@@ -4245,6 +4249,7 @@ def run_simulator(
             cleanup=cleanup,
         )
         raise RuntimeError("resource guard rejected simulator scale run: " + "; ".join(resource_guard["reasons"]))
+    ensure_steam_key_for_simulator_run(env_file=steam_key_env_file)
     if not os.environ.get("STEAM_KEY"):
         cleanup = cleanup_exact_run_worker_containers(resolved_run_id)
         write_run_failure_artifacts(
@@ -4313,6 +4318,16 @@ def run_simulator(
     write_json_atomic(run_artifact_path, artifact)
     artifact["run_artifact_path"] = str(run_artifact_path)
     return artifact
+
+
+def ensure_steam_key_for_simulator_run(env_file: Path | None = None) -> None:
+    """Load STEAM_KEY from the local secret env file before the simulator required-env gate."""
+    screeps_secret_env.ensure_env_value_from_file(
+        "STEAM_KEY",
+        env_file=env_file,
+        override_env_var=STEAM_KEY_ENV_FILE_ENV,
+        default_env_file=DEFAULT_STEAM_KEY_ENV_FILE,
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -4499,6 +4514,15 @@ def build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_MAP_SOURCE_FILE,
         help=f"Map source JSON path. Default: {DEFAULT_MAP_SOURCE_FILE}.",
     )
+    run.add_argument(
+        "--steam-key-env-file",
+        type=Path,
+        default=None,
+        help=(
+            "Optional env file to load STEAM_KEY from when it is absent. "
+            f"Defaults to {DEFAULT_STEAM_KEY_ENV_FILE}; env override: {STEAM_KEY_ENV_FILE_ENV}."
+        ),
+    )
 
     plan_scale = subparsers.add_parser(
         "plan-scale",
@@ -4603,6 +4627,7 @@ def main(argv: list[str] | None = None, stdout: TextIO = sys.stdout) -> int:
             bot_commit=args.bot_commit,
             allow_unsafe_scale=args.allow_unsafe_scale,
             min_concurrent_environments=min_concurrent_environments,
+            steam_key_env_file=args.steam_key_env_file,
         )
         stdout.write(json.dumps(summary, indent=2, sort_keys=True, ensure_ascii=True))
         stdout.write("\n")

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -4250,7 +4250,7 @@ def run_simulator(
         )
         raise RuntimeError("resource guard rejected simulator scale run: " + "; ".join(resource_guard["reasons"]))
     ensure_steam_key_for_simulator_run(env_file=steam_key_env_file)
-    if not os.environ.get("STEAM_KEY"):
+    if not os.environ.get("STEAM_KEY", "").strip():
         cleanup = cleanup_exact_run_worker_containers(resolved_run_id)
         write_run_failure_artifacts(
             run_id=resolved_run_id,

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -9,7 +9,6 @@ import json
 import math
 import os
 import re
-import shlex
 import statistics
 import sys
 import tempfile
@@ -19,6 +18,7 @@ from pathlib import Path
 from typing import Any, Callable, Sequence, TextIO
 
 import screeps_rl_dataset_export as dataset_export
+import screeps_secret_env
 import screeps_rl_simulator_harness as simulator_harness
 
 
@@ -28,7 +28,7 @@ SUMMARY_TYPE = "screeps-rl-training-generation"
 DEFAULT_OUT_DIR = Path("runtime-artifacts/rl-training")
 DEFAULT_RESOURCE_NORMALIZER = 1000.0
 DEFAULT_RUN_REPETITIONS = 1
-DEFAULT_STEAM_KEY_ENV_FILE = Path("/root/.secret/.env")
+DEFAULT_STEAM_KEY_ENV_FILE = screeps_secret_env.DEFAULT_LOCAL_SECRET_ENV_FILE
 STEAM_KEY_ENV_FILE_ENV = "SCREEPS_RL_STEAM_KEY_ENV_FILE"
 REWARD_TIERS = ("territory", "resources", "kills")
 REPORT_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
@@ -119,83 +119,43 @@ def ensure_steam_key_for_training(
     """Load STEAM_KEY for real simulator-backed training runs when the shell omitted it."""
     if os.environ.get("STEAM_KEY"):
         return
-    configured_env_file = os.environ.get(STEAM_KEY_ENV_FILE_ENV)
-    if env_file is None:
-        if configured_env_file:
-            env_file = Path(configured_env_file)
-        elif simulator_runner is simulator_harness.run_simulator:
-            env_file = DEFAULT_STEAM_KEY_ENV_FILE
-        else:
-            return
-    steam_key = read_steam_key_from_env_file(env_file.expanduser())
-    if steam_key:
-        os.environ["STEAM_KEY"] = steam_key
+    if (
+        env_file is None
+        and not os.environ.get(STEAM_KEY_ENV_FILE_ENV)
+        and simulator_runner is not simulator_harness.run_simulator
+    ):
+        return
+    screeps_secret_env.ensure_env_value_from_file(
+        "STEAM_KEY",
+        env_file=env_file,
+        override_env_var=STEAM_KEY_ENV_FILE_ENV,
+        default_env_file=DEFAULT_STEAM_KEY_ENV_FILE,
+    )
 
 
 def read_steam_key_from_env_file(path: Path) -> str | None:
     try:
-        text = path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        return None
-    except OSError as error:
-        reason = getattr(error, "strerror", None) or error.__class__.__name__
+        return screeps_secret_env.read_env_value_from_file(path, "STEAM_KEY")
+    except RuntimeError as error:
         display_path = dataset_export.display_path(path)
-        raise RuntimeError(f"could not read STEAM_KEY env file {display_path}: {reason}") from error
-    steam_key: str | None = None
-    for line in text.splitlines():
-        parsed = parse_steam_key_env_line(line)
-        if parsed is not None:
-            steam_key = parsed
-    if steam_key is None:
-        return None
-    steam_key = steam_key.strip()
-    return steam_key or None
+        message = str(error).replace(str(path), display_path)
+        raise RuntimeError(message) from error
 
 
 def parse_steam_key_env_line(line: str) -> str | None:
-    stripped = line.strip()
-    if not stripped or stripped.startswith("#"):
+    parsed = screeps_secret_env.parse_env_assignment_line(line)
+    if parsed is None:
         return None
-    export_match = re.match(r"export\s+", stripped)
-    if export_match:
-        stripped = stripped[export_match.end() :].lstrip()
-    match = re.match(r"STEAM_KEY\s*=\s*(.*)\Z", stripped)
-    if not match:
-        return None
-    return parse_env_assignment_value(match.group(1).strip())
+    key, value = parsed
+    return value if key == "STEAM_KEY" else None
 
 
 def parse_env_assignment_value(raw: str) -> str:
-    uncommented = strip_unquoted_env_comment(raw).strip()
-    if not uncommented:
-        return ""
-    if uncommented[0] not in {"'", '"'}:
-        return uncommented
-    try:
-        parsed = shlex.split(uncommented, comments=False, posix=True)
-    except ValueError:
-        return uncommented
-    return parsed[0] if parsed else ""
+    return screeps_secret_env.parse_env_assignment_value(raw)
 
 
 def strip_unquoted_env_comment(raw: str) -> str:
-    quote: str | None = None
-    escaped = False
-    for index, char in enumerate(raw):
-        if quote:
-            if escaped:
-                escaped = False
-            elif char == "\\":
-                escaped = True
-            elif char == quote:
-                quote = None
-            continue
-        if char in {"'", '"'}:
-            quote = char
-            continue
-        if char == "#" and (index == 0 or raw[index - 1].isspace()):
-            return raw[:index]
-    return raw
+    return screeps_secret_env.strip_unquoted_env_comment(raw)
 
 
 def load_experiment_card(path: Path) -> JsonObject:

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -117,7 +117,7 @@ def ensure_steam_key_for_training(
     env_file: Path | None = None,
 ) -> None:
     """Load STEAM_KEY for real simulator-backed training runs when the shell omitted it."""
-    if os.environ.get("STEAM_KEY"):
+    if os.environ.get("STEAM_KEY", "").strip():
         return
     if (
         env_file is None

--- a/scripts/screeps_secret_env.py
+++ b/scripts/screeps_secret_env.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Load selected local secret env values without logging their contents."""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+from pathlib import Path
+from typing import Mapping, MutableMapping
+
+
+DEFAULT_LOCAL_SECRET_ENV_FILE = Path("/root/.secret/.env")
+
+
+def ensure_env_value_from_file(
+    name: str,
+    *,
+    env_file: Path | None = None,
+    override_env_var: str | None = None,
+    default_env_file: Path = DEFAULT_LOCAL_SECRET_ENV_FILE,
+    environ: MutableMapping[str, str] | None = None,
+) -> bool:
+    """Set one env value from an env file only when the current value is absent or empty."""
+    env = environ if environ is not None else os.environ
+    if env.get(name):
+        return False
+    path = resolve_env_file(
+        env_file=env_file,
+        override_env_var=override_env_var,
+        default_env_file=default_env_file,
+        environ=env,
+    )
+    value = read_env_value_from_file(path, name)
+    if not value:
+        return False
+    env[name] = value
+    return True
+
+
+def resolve_env_file(
+    *,
+    env_file: Path | None = None,
+    override_env_var: str | None = None,
+    default_env_file: Path = DEFAULT_LOCAL_SECRET_ENV_FILE,
+    environ: Mapping[str, str] | None = None,
+) -> Path:
+    env = environ if environ is not None else os.environ
+    if env_file is not None:
+        return env_file.expanduser()
+    if override_env_var:
+        configured = env.get(override_env_var)
+        if configured:
+            return Path(configured).expanduser()
+    return default_env_file.expanduser()
+
+
+def read_env_value_from_file(path: Path, name: str) -> str | None:
+    values = read_env_values_from_file(path, {name})
+    value = values.get(name)
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
+def read_env_values_from_file(path: Path, names: set[str] | None = None) -> dict[str, str]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
+    except OSError as error:
+        reason = getattr(error, "strerror", None) or error.__class__.__name__
+        raise RuntimeError(f"could not read secret env file {path}: {reason}") from error
+
+    values: dict[str, str] = {}
+    for line in text.splitlines():
+        parsed = parse_env_assignment_line(line)
+        if parsed is None:
+            continue
+        key, value = parsed
+        if names is None or key in names:
+            values[key] = value
+    return values
+
+
+def parse_env_assignment_line(line: str) -> tuple[str, str] | None:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    export_match = re.match(r"export\s+", stripped)
+    if export_match:
+        stripped = stripped[export_match.end() :].lstrip()
+    match = re.match(r"([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\Z", stripped)
+    if not match:
+        return None
+    return match.group(1), parse_env_assignment_value(match.group(2).strip())
+
+
+def parse_env_assignment_value(raw: str) -> str:
+    uncommented = strip_unquoted_env_comment(raw).strip()
+    if not uncommented:
+        return ""
+    if uncommented[0] not in {"'", '"'}:
+        return uncommented
+    try:
+        parsed = shlex.split(uncommented, comments=False, posix=True)
+    except ValueError:
+        return uncommented
+    return parsed[0] if parsed else ""
+
+
+def strip_unquoted_env_comment(raw: str) -> str:
+    quote: str | None = None
+    escaped = False
+    for index, char in enumerate(raw):
+        if quote:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            continue
+        if char == "#" and (index == 0 or raw[index - 1].isspace()):
+            return raw[:index]
+    return raw

--- a/scripts/screeps_secret_env.py
+++ b/scripts/screeps_secret_env.py
@@ -21,9 +21,10 @@ def ensure_env_value_from_file(
     default_env_file: Path = DEFAULT_LOCAL_SECRET_ENV_FILE,
     environ: MutableMapping[str, str] | None = None,
 ) -> bool:
-    """Set one env value from an env file only when the current value is absent or empty."""
+    """Set one env value from an env file only when the current value is absent or blank."""
     env = environ if environ is not None else os.environ
-    if env.get(name):
+    existing = env.get(name)
+    if existing is not None and existing.strip():
         return False
     path = resolve_env_file(
         env_file=env_file,

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1792,6 +1792,67 @@ cli:
         self.assertEqual(summary["runId"], "env-file-load")
         self.assertNotIn(file_secret, output_text)
 
+    def test_run_simulator_loads_whitespace_steam_key_from_configured_env_file(self) -> None:
+        file_secret = "harness-file-secret-token-123456"
+        mock_variant = {
+            "variant_id": "baseline",
+            "variant_run_id": "whitespace-env-file-load-baseline",
+            "ticks_requested": 1,
+            "ticks_run": 1,
+            "wall_clock_seconds": 0.1,
+            "tick_log": [],
+            "live_effect": False,
+            "official_mmo_writes": False,
+            "ok": True,
+        }
+        run_artifact = {
+            "type": harness.RUN_SUMMARY_TYPE,
+            "runId": "whitespace-env-file-load",
+            "harness_version": harness.HARNESS_VERSION,
+            "botCommit": harness.DEFAULT_BOT_COMMIT,
+            "safety": {"liveEffect": False},
+            "live_effect": False,
+            "official_mmo_writes": False,
+            "official_mmo_writes_allowed": False,
+            "variants": [mock_variant],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            code_path = root / "main.js"
+            map_path = root / "map.json"
+            env_file = root / "local.env"
+            code_path.write_text("module.exports.loop = function() {};", encoding="utf-8")
+            map_path.write_text("{\"ok\": true}", encoding="utf-8")
+            env_file.write_text(f"STEAM_KEY={file_secret}\n", encoding="utf-8")
+            out_dir = root / "runtime-artifacts"
+
+            with mock.patch.dict(
+                os.environ,
+                {"STEAM_KEY": " \t  ", harness.STEAM_KEY_ENV_FILE_ENV: str(env_file)},
+                clear=True,
+            ):
+                with mock.patch(
+                    "screeps_rl_simulator_harness.run_variants",
+                    return_value=(run_artifact, [mock_variant]),
+                ):
+                    summary = harness.run_simulator(
+                        ticks=1,
+                        workers=1,
+                        variants=["baseline"],
+                        out_dir=out_dir,
+                        run_id="whitespace-env-file-load",
+                        code_path=code_path,
+                        map_source_file=map_path,
+                    )
+                    output_text = (out_dir / "whitespace-env-file-load" / "run_summary.json").read_text(
+                        encoding="utf-8"
+                    )
+                    self.assertEqual(os.environ.get("STEAM_KEY"), file_secret)
+
+        self.assertEqual(summary["runId"], "whitespace-env-file-load")
+        self.assertNotIn(file_secret, output_text)
+
     def test_run_simulator_does_not_overwrite_existing_steam_key_from_env_file(self) -> None:
         env_secret = "harness-env-secret-token-123456"
         file_secret = "harness-file-secret-token-123456"

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1740,6 +1740,101 @@ cli:
         self.assertFalse(output_data["live_effect"])
         self.assertNotIn("super-secret-key", json.dumps(output_data))
 
+    def test_run_simulator_loads_steam_key_from_configured_env_file(self) -> None:
+        file_secret = "harness-file-secret-token-123456"
+        mock_variant = {
+            "variant_id": "baseline",
+            "variant_run_id": "env-file-load-baseline",
+            "ticks_requested": 1,
+            "ticks_run": 1,
+            "wall_clock_seconds": 0.1,
+            "tick_log": [],
+            "live_effect": False,
+            "official_mmo_writes": False,
+            "ok": True,
+        }
+        run_artifact = {
+            "type": harness.RUN_SUMMARY_TYPE,
+            "runId": "env-file-load",
+            "harness_version": harness.HARNESS_VERSION,
+            "botCommit": harness.DEFAULT_BOT_COMMIT,
+            "safety": {"liveEffect": False},
+            "live_effect": False,
+            "official_mmo_writes": False,
+            "official_mmo_writes_allowed": False,
+            "variants": [mock_variant],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            code_path = root / "main.js"
+            map_path = root / "map.json"
+            env_file = root / "local.env"
+            code_path.write_text("module.exports.loop = function() {};", encoding="utf-8")
+            map_path.write_text("{\"ok\": true}", encoding="utf-8")
+            env_file.write_text(f"export STEAM_KEY='{file_secret}' # local only\n", encoding="utf-8")
+            out_dir = root / "runtime-artifacts"
+
+            with mock.patch.dict(os.environ, {harness.STEAM_KEY_ENV_FILE_ENV: str(env_file)}, clear=True):
+                with mock.patch("screeps_rl_simulator_harness.run_variants", return_value=(run_artifact, [mock_variant])):
+                    summary = harness.run_simulator(
+                        ticks=1,
+                        workers=1,
+                        variants=["baseline"],
+                        out_dir=out_dir,
+                        run_id="env-file-load",
+                        code_path=code_path,
+                        map_source_file=map_path,
+                    )
+                    output_text = (out_dir / "env-file-load" / "run_summary.json").read_text(encoding="utf-8")
+                    self.assertEqual(os.environ.get("STEAM_KEY"), file_secret)
+
+        self.assertEqual(summary["runId"], "env-file-load")
+        self.assertNotIn(file_secret, output_text)
+
+    def test_run_simulator_does_not_overwrite_existing_steam_key_from_env_file(self) -> None:
+        env_secret = "harness-env-secret-token-123456"
+        file_secret = "harness-file-secret-token-123456"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_file = Path(temp_dir) / "local.env"
+            env_file.write_text(f"STEAM_KEY={file_secret}\n", encoding="utf-8")
+
+            with mock.patch.dict(
+                os.environ,
+                {"STEAM_KEY": env_secret, harness.STEAM_KEY_ENV_FILE_ENV: str(env_file)},
+                clear=True,
+            ):
+                harness.ensure_steam_key_for_simulator_run()
+                self.assertEqual(os.environ.get("STEAM_KEY"), env_secret)
+
+    def test_run_simulator_missing_steam_key_fails_closed_without_secret_leak(self) -> None:
+        unrelated_secret = "unrelated-secret-token-123456"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            env_file = root / "local.env"
+            out_dir = root / "runtime-artifacts"
+            env_file.write_text(f"OTHER_SECRET={unrelated_secret}\n", encoding="utf-8")
+
+            with mock.patch.dict(os.environ, {harness.STEAM_KEY_ENV_FILE_ENV: str(env_file)}, clear=True):
+                with mock.patch("screeps_rl_simulator_harness.run_variants") as run_variants:
+                    with self.assertRaisesRegex(RuntimeError, "STEAM_KEY environment variable is required"):
+                        harness.run_simulator(
+                            ticks=1,
+                            workers=1,
+                            variants=["baseline"],
+                            out_dir=out_dir,
+                            run_id="missing-steam-key",
+                            code_path=root / "main.js",
+                            map_source_file=root / "map.json",
+                        )
+                    failure_text = (out_dir / "missing-steam-key" / "setup_failure.json").read_text(encoding="utf-8")
+
+        run_variants.assert_not_called()
+        self.assertIn("STEAM_KEY environment variable is required", failure_text)
+        self.assertNotIn(unrelated_secret, failure_text)
+
     def test_run_simulator_rejects_unsafe_run_id_before_writing_artifact(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -215,6 +215,45 @@ class RlTrainingRunnerTest(unittest.TestCase):
 
         self.assertEqual(simulator.observed_steam_keys, [file_secret])
 
+    def test_default_real_training_path_loads_steam_key_env_file(self) -> None:
+        file_secret = "default-file-secret-token-123456"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_file = Path(temp_dir) / "local.env"
+            env_file.write_text(f"STEAM_KEY={file_secret}\n", encoding="utf-8")
+
+            with (
+                mock.patch.dict(os.environ, {}, clear=True),
+                mock.patch.object(runner, "DEFAULT_STEAM_KEY_ENV_FILE", env_file),
+            ):
+                runner.ensure_steam_key_for_training(simulator_runner=runner.simulator_harness.run_simulator)
+                self.assertEqual(os.environ.get("STEAM_KEY"), file_secret)
+
+    def test_configured_steam_key_env_file_loads_for_wrapped_training_path(self) -> None:
+        file_secret = "configured-file-secret-token-123456"
+        simulator = RequiredSteamKeySimulator({
+            "baseline": variant_result("baseline", []),
+            "candidate": variant_result("candidate", []),
+        })
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            env_file = root / "runner.env"
+            write_json(card_path, base_card())
+            env_file.write_text(f"STEAM_KEY={file_secret}\n", encoding="utf-8")
+
+            with mock.patch.dict(os.environ, {runner.STEAM_KEY_ENV_FILE_ENV: str(env_file)}, clear=True):
+                runner.run_training_experiment(
+                    card_path,
+                    root / "reports",
+                    report_id="steam-key-configured-env-file-load",
+                    simulator_runner=simulator,
+                )
+                self.assertEqual(os.environ.get("STEAM_KEY"), file_secret)
+
+        self.assertEqual(simulator.observed_steam_keys, [file_secret])
+
     def test_missing_or_empty_steam_key_env_reports_required_env_error(self) -> None:
         for case, contents in (("missing", None), ("empty", "STEAM_KEY=\n")):
             with self.subTest(case=case), tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -156,7 +156,7 @@ class RequiredSteamKeySimulator(MockSimulator):
 
     def __call__(self, **kwargs: Any) -> JsonObject:
         self.observed_steam_keys.append(os.environ.get("STEAM_KEY"))
-        if not os.environ.get("STEAM_KEY"):
+        if not os.environ.get("STEAM_KEY", "").strip():
             raise RuntimeError("STEAM_KEY environment variable is required for run mode")
         return super().__call__(**kwargs)
 
@@ -214,6 +214,35 @@ class RlTrainingRunnerTest(unittest.TestCase):
                 self.assertEqual(os.environ.get("STEAM_KEY"), file_secret)
 
         self.assertEqual(simulator.observed_steam_keys, [file_secret])
+
+    def test_whitespace_steam_key_env_loads_from_env_file_without_secret_leak(self) -> None:
+        file_secret = "file-secret-token-123456"
+        simulator = RequiredSteamKeySimulator({
+            "baseline": variant_result("baseline", []),
+            "candidate": variant_result("candidate", []),
+        })
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            env_file = root / "runner.env"
+            write_json(card_path, base_card())
+            env_file.write_text(f"STEAM_KEY={file_secret}\n", encoding="utf-8")
+
+            with mock.patch.dict(os.environ, {"STEAM_KEY": "   \t  "}, clear=True):
+                runner.run_training_experiment(
+                    card_path,
+                    out_dir,
+                    report_id="steam-key-whitespace-env-file-load",
+                    simulator_runner=simulator,
+                    steam_key_env_file=env_file,
+                )
+                self.assertEqual(os.environ.get("STEAM_KEY"), file_secret)
+                report_text = (out_dir / "steam-key-whitespace-env-file-load.json").read_text(encoding="utf-8")
+
+        self.assertEqual(simulator.observed_steam_keys, [file_secret])
+        self.assertNotIn(file_secret, report_text)
 
     def test_default_real_training_path_loads_steam_key_env_file(self) -> None:
         file_secret = "default-file-secret-token-123456"


### PR DESCRIPTION
## Summary
- Adds a shared secret-env loader that reads only requested keys without logging secret values.
- Loads `STEAM_KEY` from the configured local env file for both the RL training runner and simulator harness before required-env gates.
- Adds regression tests covering env-file loading, existing-env precedence, and no secret leakage in failure artifacts.

## Verification
- `python3 -m py_compile scripts/screeps_secret_env.py scripts/screeps_rl_training_runner.py scripts/screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py scripts/test_screeps_rl_simulator_harness.py`
- `PYTHONPATH=scripts python3 -m unittest scripts/test_screeps_rl_training_runner.py scripts/test_screeps_rl_simulator_harness.py` (83 tests OK)
- `git diff --check`

## Safety
- Does not print, commit, or expose the actual `STEAM_KEY`; tests use synthetic placeholder values only.
- Keeps official MMO writes disabled; this only fixes offline/private RL training invocation context.

Fixes #1096
