### PR TITLE
docs: require Codex triage for CodeRabbit feedback

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,7 +8,7 @@ chat:
   auto_reply: true
 
 reviews:
-  profile: chill
+  profile: assertive
   request_changes_workflow: false
   high_level_summary: true
   high_level_summary_in_walkthrough: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ This repository builds and operates a Screeps: World bot. Use this file as the c
 - Do not edit or commit directly on `main`. Use a topic branch in a git worktree, normally under `~/screeps-worktrees/<topic>`.
 - Production/test/build code changes under `prod/` must be implemented through the Codex CLI coding agent when this project is being operated by Hermes. Hermes may edit docs/config directly, but Codex owns production code implementation commits.
 - A Codex coding task is not complete until the change is verified, committed, pushed, reviewed by the automated review gate, and merged to `main` when it creates a PR. If a PR is superseded, close it with a PR comment explaining the replacement. The review gate uses the owner-approved automated口径: CodeRabbit/Gemini no blocking findings, resolved/outdated discussions, green required checks, and the required elapsed window; formal GitHub approval is not required unless a later owner decision changes it.
+- CodeRabbit may run in assertive/aggressive mode. Treat automated review feedback as input to a Codex triage loop, not as commands to blindly edit code. For every active CodeRabbit/Gemini review body, PR comment, or review thread, provide Codex the exact finding plus current diff/context and have it classify the item as: actionable critical fix, non-critical/advisory, false positive, stale/outdated, or owner-decision needed. Actionable critical findings get the smallest verified patch on the PR branch; non-actionable or stale findings get a concise evidence comment and explicit thread resolution via GitHub/GraphQL after verification. Do not merge while an active automated finding is pending, untriaged, or unresolved.
 - **Merge gate — mandatory pre-merge checklist.** Before merging any PR, every autonomous finisher (scheduler, Codex, QA agent, or main agent) MUST:
   1. Compute elapsed time: `now - PR.createdAt`. Reject merge if under 15 minutes. Use `gh pr view <PR> --json createdAt` and compare to current UTC. Do not rely on memory or session clocks — compute fresh each time.
   2. Re-query live checks: `gh pr checks <PR>`. All required checks must be green/pass. Do not merge on stale or cached check state.
@@ -78,6 +79,8 @@ Prioritize issues that can break runtime correctness or safe operations:
 For PR review tasks, **only report critical issues**: bugs or risks that are likely to cause data loss, deployment failure, runtime crashes, incorrect gameplay automation, secret leakage, or security exposure.
 
 Do not leave comments for style, formatting, naming, small refactors, documentation phrasing, speculative architecture, or minor test preferences unless they mask a critical failure.
+
+When responding to CodeRabbit assertive/aggressive-mode feedback, do not assume every finding is valid. Codex must state why each item is fixed, resolved as stale/outdated, or resolved as non-actionable before the controller closes the thread/comment.
 
 When reviewing, use this compact format:
 

--- a/docs/ops/codex-skills.md
+++ b/docs/ops/codex-skills.md
@@ -95,6 +95,30 @@ If nothing is critical, output exactly:
 No critical issues found.
 ```
 
+## Skill 3a — Automated review feedback triage
+
+Use when a PR has CodeRabbit/Gemini comments, review threads, or top-level review bodies, especially while CodeRabbit is in assertive/aggressive mode.
+
+Controller workflow:
+
+1. Re-query the live PR head SHA, checks/statuses, comments, reviews, and GraphQL review threads.
+2. Give Codex the exact finding text, URLs/thread IDs, current diff, relevant file context, and project review severity policy.
+3. Require Codex to classify each finding:
+   - `FIX` — critical and actionable; implement the smallest patch and run verification.
+   - `RESOLVE_FALSE_POSITIVE` — contradicted by current code/tests/Screeps semantics.
+   - `RESOLVE_STALE_OR_OUTDATED` — already fixed on the latest head or no longer applies.
+   - `ADVISORY_ONLY` — style/preference/non-critical optimization that should not churn code.
+   - `OWNER_DECISION` — would change strategy, reward policy, live deployment, secrets, or another owner-controlled choice.
+4. For `FIX`, keep changes in the PR branch, commit with the required Codex author, push, then rerun controller verification and exact-head QA.
+5. For `RESOLVE_FALSE_POSITIVE`, `RESOLVE_STALE_OR_OUTDATED`, or `ADVISORY_ONLY`, post concise evidence when useful and resolve the GitHub review thread/comment with GraphQL/`gh` after verifying it is safe. Do not add code just to appease a non-critical bot suggestion.
+6. Do not merge while CodeRabbit/Gemini is pending, while a fresh top-level review body contains untriaged actionable language, or while unresolved active review threads remain.
+
+Prompt clause for Codex review-fix runs:
+
+```text
+Triage the automated review feedback first. Not every CodeRabbit/Gemini finding is valid or worth changing. For each finding, classify it as FIX, RESOLVE_FALSE_POSITIVE, RESOLVE_STALE_OR_OUTDATED, ADVISORY_ONLY, or OWNER_DECISION. Only implement FIX items that are critical under AGENTS.md; otherwise explain the evidence the controller should use to resolve the thread/comment without code churn.
+```
+
 ## Skill 4 — Screeps operations/documentation updates
 
 Use for docs, runbooks, and runtime monitor scripts.
@@ -127,6 +151,7 @@ Use for any repository change.
 | New bot behavior under `prod/src` | Screeps TDD implementation |
 | Failing test/build/private-server smoke | Screeps systematic debugging |
 | PR/diff review | Critical-only PR review |
+| CodeRabbit/Gemini PR feedback | Automated review feedback triage |
 | Monitoring/runbook/doc update | Screeps operations/documentation updates |
 | Any branch/PR workflow | Worktree and PR hygiene |
 
@@ -140,3 +165,4 @@ Include these clauses in most Codex prompts for this project:
 - "Run the project verification commands before finishing."
 - "Commit the verified change; do not leave unrelated files staged."
 - "For review, only report critical issues; otherwise say `No critical issues found.`"
+- "For automated review feedback, triage each CodeRabbit/Gemini item before editing; implement only critical `FIX` items and provide evidence for false-positive/stale/advisory resolution."

--- a/docs/ops/cron-and-route-registry.md
+++ b/docs/ops/cron-and-route-registry.md
@@ -45,7 +45,7 @@ When using raw IDs and named channels together, this registry is the comparison 
 
 | Job | ID | Schedule | Delivery | Purpose |
 | --- | --- | --- | --- | --- |
-| Screeps autonomous continuation worker | `f66ed36d7be0` | `13,22,50 * * * *` | `discord:#task-queue` | Dispatcher/reconciler for safe work lanes. Stable workdir: `/root/screeps`. |
+| Screeps autonomous continuation worker | `f66ed36d7be0` | `8,28,48 * * * *` | `discord:#task-queue` | Dispatcher/reconciler for safe work lanes. Stable workdir: `/root/screeps`. |
 | Screeps P0 agent operations monitor | `75cedbb77150` | `7,37 * * * *` | `discord:1497820688843800776` | P0 autonomous-system health monitor. |
 | Screeps runtime room summary images | `befcbb7b2d60` | `58 * * * *` | `discord:1497588267057680385` | Runtime summary report/images for all owned rooms (auto-discovered via `/api/user/overview`). Include economy KPIs: total resources, energy output/collection, construction progress. |
 | Screeps runtime room alert text check | `1df5ef0c3835` | `1,16,31,46 * * * *` | `discord:1497588512436785284` | Runtime alert/tactical response and autonomous recovery for all owned rooms (auto-discovered via `/api/user/overview`); no-alert runs return exactly `[SILENT]`. |
@@ -66,6 +66,7 @@ When using raw IDs and named channels together, this registry is the comparison 
 - Reporter state files and old cron outputs are caches/history, not rules authority.
 - When scanning cron output, ignore prompt/system/skill sections unless explicitly auditing historical prompt drift.
 - Cron runs must not recursively schedule new cron jobs.
+- PR-draining/continuation cron prompts must include the CodeRabbit assertive-mode triage rule: use Codex to classify each automated review finding before choosing a patch or thread/comment resolution, and never merge with pending/untriaged CodeRabbit/Gemini feedback.
 - Cron prompt updates require a pre-change snapshot and post-change `cronjob list` verification.
 - Long-lived recurring Screeps jobs should be configured as `forever` or with a very high repeat horizon. A finite `999` cap on critical recurring jobs is abnormal because it can silently stop automation after enough successful runs.
 - Repo/worktree-manipulating cron jobs must keep a stable current directory. Use `/root/screeps` as the default controller cwd, prefer `git -C <path>` or subshells over persistent `cd`, and return to `/root/screeps` before deleting any linked worktree. The 2026-05-05 continuation-worker incident was caused by a deleted `/root/screeps-worktrees/rl-dataset-gate-409` cwd blocking later terminal/file calls in the same cron run.

--- a/docs/ops/rules-registry.md
+++ b/docs/ops/rules-registry.md
@@ -95,6 +95,16 @@ A meaningful task is not complete until:
 
 Closed/Done issues are not reopened. Repeated or corrected scope gets a new linked issue.
 
+## Automated review feedback triage
+
+CodeRabbit may run with the assertive/aggressive profile to increase review coverage. This does not make every bot finding mandatory. For every active automated PR review body, top-level comment, or review thread:
+
+1. The controller must give Codex the exact finding, PR head SHA, current diff, relevant file context, and this registry/`AGENTS.md` review policy.
+2. Codex must classify the finding before any edit: `FIX`, `RESOLVE_FALSE_POSITIVE`, `RESOLVE_STALE_OR_OUTDATED`, `ADVISORY_ONLY`, or `OWNER_DECISION`.
+3. Only `FIX` items that meet the project's critical review threshold get code changes, and those changes must be committed by Codex on the PR branch with normal verification.
+4. False-positive, stale/outdated, and advisory findings should be resolved with concise evidence through GitHub review-thread/comment resolution instead of code churn.
+5. A PR is not merge-ready while CodeRabbit/Gemini is pending, while a fresh review body has untriaged actionable language, or while unresolved active review threads remain.
+
 ## Blocked-state rule
 
 An active item is blocked only when all of these are true:


### PR DESCRIPTION
## Summary
- switch CodeRabbit repository profile to `assertive` to match the owner-enabled aggressive review mode
- document the Codex-first triage loop for CodeRabbit/Gemini findings in AGENTS, rules registry, and Codex skill playbook
- update the cron registry with the live continuation-worker cadence and the new PR review-feedback prompt requirement

## Verification
- `git diff --check`
- `python3` YAML parse asserting `.coderabbit.yaml` has `reviews.profile == "assertive"`
- `python3 scripts/audit-rules-consistency.py --repo .` (PASS; existing warning: roadmap generator legacy Private smoke alias)

Refs #1100
