### PR TITLE
fix(gameplay): improve E29N55 bootstrap worker efficiency

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -26794,8 +26794,11 @@ function hasRoutineRepairAssignmentCapacity(creep, structure) {
   return isWorkerAssignedToRepairTarget(creep, structure) || !hasOtherWorkerAssignedToRepairTarget(creep, structure);
 }
 function hasOtherWorkerAssignedToRepairTarget(creep, structure) {
-  return getGameCreeps().some(
-    (worker) => !isSameCreep(worker, creep) && isSameRoomWorker(worker, creep.room) && isWorkerAssignedToRepairTarget(worker, structure)
+  return getRoomOwnedCreeps(creep.room).some(
+    (worker) => {
+      var _a;
+      return !isSameCreep(worker, creep) && ((_a = worker.memory) == null ? void 0 : _a.role) === "worker" && isWorkerAssignedToRepairTarget(worker, structure);
+    }
   );
 }
 function isWorkerAssignedToRepairTarget(worker, structure) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -22759,6 +22759,9 @@ var LOW_LOAD_CONTROLLER_DOWNGRADE_IMMINENT_TICKS = 1e3;
 var LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
 var LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE = 6;
 var LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE = 12;
+var ROUTINE_REPAIR_MIN_HITS_DEFICIT = 500;
+var ROUTINE_REPAIR_MIN_HITS_DEFICIT_RATIO = 0.1;
+var ROUTINE_REPAIR_MAX_RANGE = 5;
 var BUILDER_STORAGE_WITHDRAW_MIN = 100;
 var BUILDER_DROPPED_PICKUP_RANGE = 5;
 var DEFAULT_SPAWN_ENERGY_CAPACITY = 300;
@@ -23626,7 +23629,37 @@ function isTerritoryControlTask(task) {
 }
 function hasEmergencySpawnExtensionRefillDemand(creep) {
   const energyAvailable = getRoomEnergyAvailable9(creep.room);
-  return energyAvailable === null || energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD;
+  if (energyAvailable !== null && energyAvailable >= URGENT_SPAWN_REFILL_ENERGY_THRESHOLD) {
+    return false;
+  }
+  if (!getLowLoadWorkerEnergyContext(creep)) {
+    return true;
+  }
+  return hasTrueLowLoadSpawnExtensionRefillEmergency(creep);
+}
+function hasTrueLowLoadSpawnExtensionRefillEmergency(creep) {
+  if (hasVisibleHostilePresence2(creep.room)) {
+    return true;
+  }
+  if (isControllerDowngradeImminentForLowLoadReturn(creep.room.controller)) {
+    return true;
+  }
+  if (isNearTermSpawnCompletionBlockedWithoutLowLoadEnergy(creep)) {
+    return true;
+  }
+  return selectLowLoadSpawnExtensionDeliveryContinuationCandidate(creep) === null;
+}
+function isNearTermSpawnCompletionBlockedWithoutLowLoadEnergy(creep) {
+  const spawnExtensionEnergyStructures = findSpawnExtensionEnergyStructures(creep.room);
+  if (!spawnExtensionEnergyStructures.some(isNearTermSpawningSpawn)) {
+    return false;
+  }
+  const energyAvailable = getRoomEnergyAvailable9(creep.room);
+  if (energyAvailable === null) {
+    return true;
+  }
+  const otherLoadedEnergy = getSameRoomLoadedWorkersForRefillReservations(creep).filter((worker) => !isSameCreep(worker, creep)).reduce((total, worker) => total + getUsedEnergy2(worker), 0);
+  return energyAvailable + otherLoadedEnergy < MINIMUM_WORKER_SPAWN_ENERGY;
 }
 function shouldGuardControllerDowngradeForWorkerLoad(creep, controller) {
   if (!shouldGuardControllerDowngrade2(controller)) {
@@ -24877,7 +24910,7 @@ function selectNearbyProductiveEnergySinkTask(creep, constructionSites, controll
         canCompleteConstructionSiteWithCarriedEnergy(creep, site, constructionReservationContext)
       )
     ),
-    ...findVisibleRoomStructures(creep.room).filter((structure) => isSafeRepairTargetForWorkerRoom(creep, structure)).map(
+    ...findVisibleRoomStructures(creep.room).filter((structure) => isRoutineRepairTargetForWorker(creep, structure)).map(
       (structure) => createProductiveEnergySinkCandidate(
         creep,
         structure,
@@ -26588,7 +26621,9 @@ function selectRepairTarget(creep) {
   if (((_a = creep.room.controller) == null ? void 0 : _a.my) !== true) {
     return null;
   }
-  const repairTargets = findVisibleRoomStructures(creep.room).filter(isSafeRepairTarget);
+  const repairTargets = findVisibleRoomStructures(creep.room).filter(
+    (structure) => isRoutineRepairTargetForWorker(creep, structure)
+  );
   if (repairTargets.length === 0) {
     return null;
   }
@@ -26736,6 +26771,37 @@ function isRoutineRampartMaintenanceRepairTarget(structure) {
 function isSafeRepairTargetForWorkerRoom(creep, structure) {
   var _a;
   return isSafeRepairTarget(structure) && (!isSpawnRepairTarget(structure) || ((_a = creep.room.controller) == null ? void 0 : _a.my) === true);
+}
+function isRoutineRepairTargetForWorker(creep, structure) {
+  if (!isSafeRepairTargetForWorkerRoom(creep, structure)) {
+    return false;
+  }
+  if (isWorkerBarrierRepairStructure(structure)) {
+    return true;
+  }
+  return hasMeaningfulRoutineRepairDeficit(structure) && isRoutineRepairTargetWithinOpportunisticRange(creep, structure) && hasRoutineRepairAssignmentCapacity(creep, structure);
+}
+function hasMeaningfulRoutineRepairDeficit(structure) {
+  const repairCeiling = getWorkerRepairHitsCeiling(structure);
+  const deficit = Math.max(0, repairCeiling - structure.hits);
+  return deficit >= ROUTINE_REPAIR_MIN_HITS_DEFICIT && repairCeiling > 0 && deficit / repairCeiling >= ROUTINE_REPAIR_MIN_HITS_DEFICIT_RATIO;
+}
+function isRoutineRepairTargetWithinOpportunisticRange(creep, structure) {
+  const range = getRangeBetweenRoomObjects3(creep, structure);
+  return range === null || range <= ROUTINE_REPAIR_MAX_RANGE;
+}
+function hasRoutineRepairAssignmentCapacity(creep, structure) {
+  return isWorkerAssignedToRepairTarget(creep, structure) || !hasOtherWorkerAssignedToRepairTarget(creep, structure);
+}
+function hasOtherWorkerAssignedToRepairTarget(creep, structure) {
+  return getGameCreeps().some(
+    (worker) => !isSameCreep(worker, creep) && isSameRoomWorker(worker, creep.room) && isWorkerAssignedToRepairTarget(worker, structure)
+  );
+}
+function isWorkerAssignedToRepairTarget(worker, structure) {
+  var _a;
+  const task = (_a = worker.memory) == null ? void 0 : _a.task;
+  return (task == null ? void 0 : task.type) === "repair" && String(task.targetId) === String(structure.id);
 }
 function isCriticalInfrastructureRepairTarget(structure, criticalRoadContext, options) {
   if (!isSafeRepairTarget(structure) || !isRoadOrContainerRepairTarget(structure) || getHitsRatio(structure) > CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO) {
@@ -26998,6 +27064,9 @@ function shouldStandbySurplusWorkerInsteadOfAcquiring(creep, controller) {
 function hasNonControllerWorkerEnergyDemand(creep) {
   var _a;
   if (selectFillableEnergySink(creep)) {
+    return true;
+  }
+  if (hasRoomSpawnExtensionEnergyDeficit(creep.room)) {
     return true;
   }
   const constructionSites = typeof FIND_CONSTRUCTION_SITES === "number" && typeof ((_a = creep.room) == null ? void 0 : _a.find) === "function" ? creep.room.find(FIND_CONSTRUCTION_SITES) : [];

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -23658,8 +23658,24 @@ function isNearTermSpawnCompletionBlockedWithoutLowLoadEnergy(creep) {
   if (energyAvailable === null) {
     return true;
   }
-  const otherLoadedEnergy = getSameRoomLoadedWorkersForRefillReservations(creep).filter((worker) => !isSameCreep(worker, creep)).reduce((total, worker) => total + getUsedEnergy2(worker), 0);
-  return energyAvailable + otherLoadedEnergy < MINIMUM_WORKER_SPAWN_ENERGY;
+  const otherRefillCoverageEnergy = getOtherNearTermSpawnExtensionRefillCoverageEnergy(
+    creep,
+    spawnExtensionEnergyStructures
+  );
+  return energyAvailable + otherRefillCoverageEnergy < MINIMUM_WORKER_SPAWN_ENERGY;
+}
+function getOtherNearTermSpawnExtensionRefillCoverageEnergy(creep, spawnExtensionEnergyStructures) {
+  const spawnExtensionEnergyStructureIds = new Set(
+    spawnExtensionEnergyStructures.map((structure) => String(structure.id))
+  );
+  return getSameRoomLoadedWorkersForRefillReservations(creep).filter((worker) => !isSameCreep(worker, creep)).filter(
+    (worker) => isWorkerRefillBoundOrReservableForSpawnExtensionDelivery(worker, spawnExtensionEnergyStructureIds)
+  ).reduce((total, worker) => total + getUsedEnergy2(worker), 0);
+}
+function isWorkerRefillBoundOrReservableForSpawnExtensionDelivery(worker, spawnExtensionEnergyStructureIds) {
+  var _a;
+  const task = (_a = worker.memory) == null ? void 0 : _a.task;
+  return task == null || (task == null ? void 0 : task.type) === "transfer" && task.targetId !== void 0 && spawnExtensionEnergyStructureIds.has(String(task.targetId));
 }
 function shouldGuardControllerDowngradeForWorkerLoad(creep, controller) {
   if (!shouldGuardControllerDowngrade2(controller)) {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1490,10 +1490,39 @@ function isNearTermSpawnCompletionBlockedWithoutLowLoadEnergy(creep: Creep): boo
     return true;
   }
 
-  const otherLoadedEnergy = getSameRoomLoadedWorkersForRefillReservations(creep)
+  const otherRefillCoverageEnergy = getOtherNearTermSpawnExtensionRefillCoverageEnergy(
+    creep,
+    spawnExtensionEnergyStructures
+  );
+  return energyAvailable + otherRefillCoverageEnergy < MINIMUM_WORKER_SPAWN_ENERGY;
+}
+
+function getOtherNearTermSpawnExtensionRefillCoverageEnergy(
+  creep: Creep,
+  spawnExtensionEnergyStructures: SpawnExtensionEnergyStructure[]
+): number {
+  const spawnExtensionEnergyStructureIds = new Set(
+    spawnExtensionEnergyStructures.map((structure) => String(structure.id))
+  );
+
+  return getSameRoomLoadedWorkersForRefillReservations(creep)
     .filter((worker) => !isSameCreep(worker, creep))
+    .filter((worker) =>
+      isWorkerRefillBoundOrReservableForSpawnExtensionDelivery(worker, spawnExtensionEnergyStructureIds)
+    )
     .reduce((total, worker) => total + getUsedEnergy(worker), 0);
-  return energyAvailable + otherLoadedEnergy < MINIMUM_WORKER_SPAWN_ENERGY;
+}
+
+function isWorkerRefillBoundOrReservableForSpawnExtensionDelivery(
+  worker: Creep,
+  spawnExtensionEnergyStructureIds: ReadonlySet<string>
+): boolean {
+  const task = worker.memory?.task as Partial<CreepTaskMemory> | null | undefined;
+  return task == null || (
+    task?.type === 'transfer' &&
+    task.targetId !== undefined &&
+    spawnExtensionEnergyStructureIds.has(String(task.targetId))
+  );
 }
 
 function shouldGuardControllerDowngradeForWorkerLoad(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -6476,10 +6476,10 @@ function hasRoutineRepairAssignmentCapacity(creep: Creep, structure: RepairableW
 }
 
 function hasOtherWorkerAssignedToRepairTarget(creep: Creep, structure: RepairableWorkerStructure): boolean {
-  return getGameCreeps().some(
+  return getRoomOwnedCreeps(creep.room).some(
     (worker) =>
       !isSameCreep(worker, creep) &&
-      isSameRoomWorker(worker, creep.room) &&
+      worker.memory?.role === 'worker' &&
       isWorkerAssignedToRepairTarget(worker, structure)
   );
 }

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -39,6 +39,7 @@ import {
   getStorageEnergyAvailableForWithdrawal,
   getStorageEnergyReserveThreshold,
   hasMinimumWorkerSpawnEnergyForConstruction,
+  MINIMUM_WORKER_SPAWN_ENERGY,
   withdrawFromStorage
 } from '../economy/energyBuffer';
 import {
@@ -88,6 +89,9 @@ export const LOW_LOAD_CONTROLLER_DOWNGRADE_IMMINENT_TICKS = 1_000;
 export const LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
 export const LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE = 6;
 export const LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE = 12;
+export const ROUTINE_REPAIR_MIN_HITS_DEFICIT = 500;
+export const ROUTINE_REPAIR_MIN_HITS_DEFICIT_RATIO = 0.1;
+export const ROUTINE_REPAIR_MAX_RANGE = 5;
 export const BUILDER_STORAGE_WITHDRAW_MIN = 100;
 export const BUILDER_DROPPED_PICKUP_RANGE = 5;
 const DEFAULT_SPAWN_ENERGY_CAPACITY = 300;
@@ -1448,7 +1452,48 @@ function isTerritoryControlTask(task: CreepTaskMemory | null): task is Extract<C
 
 function hasEmergencySpawnExtensionRefillDemand(creep: Creep): boolean {
   const energyAvailable = getRoomEnergyAvailable(creep.room);
-  return energyAvailable === null || energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD;
+  if (energyAvailable !== null && energyAvailable >= URGENT_SPAWN_REFILL_ENERGY_THRESHOLD) {
+    return false;
+  }
+
+  if (!getLowLoadWorkerEnergyContext(creep)) {
+    return true;
+  }
+
+  return hasTrueLowLoadSpawnExtensionRefillEmergency(creep);
+}
+
+function hasTrueLowLoadSpawnExtensionRefillEmergency(creep: Creep): boolean {
+  if (hasVisibleHostilePresence(creep.room)) {
+    return true;
+  }
+
+  if (isControllerDowngradeImminentForLowLoadReturn(creep.room.controller)) {
+    return true;
+  }
+
+  if (isNearTermSpawnCompletionBlockedWithoutLowLoadEnergy(creep)) {
+    return true;
+  }
+
+  return selectLowLoadSpawnExtensionDeliveryContinuationCandidate(creep) === null;
+}
+
+function isNearTermSpawnCompletionBlockedWithoutLowLoadEnergy(creep: Creep): boolean {
+  const spawnExtensionEnergyStructures = findSpawnExtensionEnergyStructures(creep.room);
+  if (!spawnExtensionEnergyStructures.some(isNearTermSpawningSpawn)) {
+    return false;
+  }
+
+  const energyAvailable = getRoomEnergyAvailable(creep.room);
+  if (energyAvailable === null) {
+    return true;
+  }
+
+  const otherLoadedEnergy = getSameRoomLoadedWorkersForRefillReservations(creep)
+    .filter((worker) => !isSameCreep(worker, creep))
+    .reduce((total, worker) => total + getUsedEnergy(worker), 0);
+  return energyAvailable + otherLoadedEnergy < MINIMUM_WORKER_SPAWN_ENERGY;
 }
 
 function shouldGuardControllerDowngradeForWorkerLoad(
@@ -3387,7 +3432,7 @@ function selectNearbyProductiveEnergySinkTask(
         )
       ),
     ...findVisibleRoomStructures(creep.room)
-      .filter((structure) => isSafeRepairTargetForWorkerRoom(creep, structure))
+      .filter((structure) => isRoutineRepairTargetForWorker(creep, structure))
       .map((structure) =>
         createProductiveEnergySinkCandidate(
           creep,
@@ -6170,7 +6215,9 @@ function selectRepairTarget(creep: Creep): RepairableWorkerStructure | null {
     return null;
   }
 
-  const repairTargets = findVisibleRoomStructures(creep.room).filter(isSafeRepairTarget);
+  const repairTargets = findVisibleRoomStructures(creep.room).filter((structure) =>
+    isRoutineRepairTargetForWorker(creep, structure)
+  );
   if (repairTargets.length === 0) {
     return null;
   }
@@ -6382,6 +6429,64 @@ function isSafeRepairTargetForWorkerRoom(
   structure: AnyStructure
 ): structure is RepairableWorkerStructure {
   return isSafeRepairTarget(structure) && (!isSpawnRepairTarget(structure) || creep.room.controller?.my === true);
+}
+
+function isRoutineRepairTargetForWorker(
+  creep: Creep,
+  structure: AnyStructure
+): structure is RepairableWorkerStructure {
+  if (!isSafeRepairTargetForWorkerRoom(creep, structure)) {
+    return false;
+  }
+
+  if (isWorkerBarrierRepairStructure(structure)) {
+    return true;
+  }
+
+  return (
+    hasMeaningfulRoutineRepairDeficit(structure) &&
+    isRoutineRepairTargetWithinOpportunisticRange(creep, structure) &&
+    hasRoutineRepairAssignmentCapacity(creep, structure)
+  );
+}
+
+function hasMeaningfulRoutineRepairDeficit(structure: RepairableWorkerStructure): boolean {
+  const repairCeiling = getWorkerRepairHitsCeiling(structure);
+  const deficit = Math.max(0, repairCeiling - structure.hits);
+  return (
+    deficit >= ROUTINE_REPAIR_MIN_HITS_DEFICIT &&
+    repairCeiling > 0 &&
+    deficit / repairCeiling >= ROUTINE_REPAIR_MIN_HITS_DEFICIT_RATIO
+  );
+}
+
+function isRoutineRepairTargetWithinOpportunisticRange(
+  creep: Creep,
+  structure: RepairableWorkerStructure
+): boolean {
+  const range = getRangeBetweenRoomObjects(creep, structure);
+  return range === null || range <= ROUTINE_REPAIR_MAX_RANGE;
+}
+
+function hasRoutineRepairAssignmentCapacity(creep: Creep, structure: RepairableWorkerStructure): boolean {
+  return (
+    isWorkerAssignedToRepairTarget(creep, structure) ||
+    !hasOtherWorkerAssignedToRepairTarget(creep, structure)
+  );
+}
+
+function hasOtherWorkerAssignedToRepairTarget(creep: Creep, structure: RepairableWorkerStructure): boolean {
+  return getGameCreeps().some(
+    (worker) =>
+      !isSameCreep(worker, creep) &&
+      isSameRoomWorker(worker, creep.room) &&
+      isWorkerAssignedToRepairTarget(worker, structure)
+  );
+}
+
+function isWorkerAssignedToRepairTarget(worker: Creep, structure: RepairableWorkerStructure): boolean {
+  const task = worker.memory?.task as Partial<CreepTaskMemory> | undefined;
+  return task?.type === 'repair' && String(task.targetId) === String(structure.id);
 }
 
 function isCriticalInfrastructureRepairTarget(
@@ -6795,6 +6900,10 @@ function shouldStandbySurplusWorkerInsteadOfAcquiring(
 
 function hasNonControllerWorkerEnergyDemand(creep: Creep): boolean {
   if (selectFillableEnergySink(creep)) {
+    return true;
+  }
+
+  if (hasRoomSpawnExtensionEnergyDeficit(creep.room)) {
     return true;
   }
 

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -11,6 +11,8 @@ import {
   LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE,
   LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE,
   MINIMUM_USEFUL_LOAD_RATIO,
+  ROUTINE_REPAIR_MAX_RANGE,
+  ROUTINE_REPAIR_MIN_HITS_DEFICIT,
   TOWER_REFILL_ENERGY_FLOOR,
   URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
   WORKER_PRE_HARVEST_REGEN_THRESHOLD,
@@ -4781,6 +4783,56 @@ describe('selectWorkerTask', () => {
     });
   });
 
+  it('keeps a 2/50 low-load refill worker acquiring reachable energy below urgent room energy', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const source = makeSource('source1', 16, 29, 300);
+    const carriedEnergy = 2;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        source1: LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE,
+        spawn1: 1
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const room = makeWorkerTaskRoom({
+      controller: {
+        id: 'controller1',
+        my: true,
+        level: 2,
+        ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+      } as StructureController,
+      energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+      energyCapacityAvailable: 300,
+      myStructures: [spawn as AnyOwnedStructure],
+      sources: [source]
+    });
+    const creep = {
+      name: 'BootstrapCarrier',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getCapacity: jest.fn().mockReturnValue(50),
+        getUsedCapacity: jest.fn().mockReturnValue(carriedEnergy),
+        getFreeCapacity: jest.fn().mockReturnValue(48)
+      },
+      pos: { getRangeTo },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ BootstrapCarrier: creep });
+    (globalThis as unknown as { Game: Partial<Game> }).Game.time = 329;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'nearbyEnergyChoice',
+      tick: 329,
+      carriedEnergy,
+      freeCapacity: 48,
+      selectedTask: 'harvest',
+      targetId: 'source1',
+      energy: 300,
+      range: LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE
+    });
+  });
+
   it('lets a worker at the minimum useful load proceed with normal refill', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const source = { id: 'source1', energy: 300 } as Source;
@@ -6016,10 +6068,10 @@ describe('selectWorkerTask', () => {
     });
   });
 
-  it('lets emergency spawn refill preempt the minimum useful load requirement', () => {
+  it('lets emergency spawn refill preempt the minimum useful load requirement when no continuation exists', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
-    const droppedEnergy = { id: 'drop-near', resourceType: 'energy', amount: 50 } as Resource<ResourceConstant>;
-    const getRangeTo = jest.fn((target: { id: string }) => (target.id === 'drop-near' ? 1 : 99));
+    const depletedSource = makeSource('source-empty', 8, 8, 0);
+    const getRangeTo = jest.fn((target: { id: string }) => (target.id === 'source-empty' ? 1 : 99));
     const roomFind = jest.fn(
       (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
         if (type === FIND_MY_STRUCTURES) {
@@ -6028,7 +6080,7 @@ describe('selectWorkerTask', () => {
         }
 
         if (type === FIND_DROPPED_RESOURCES) {
-          return [droppedEnergy];
+          return [];
         }
 
         if (
@@ -6039,6 +6091,10 @@ describe('selectWorkerTask', () => {
           type === FIND_RUINS
         ) {
           return [];
+        }
+
+        if (type === FIND_SOURCES) {
+          return [depletedSource];
         }
 
         return [];
@@ -13006,6 +13062,78 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'road-damaged' });
+  });
+
+  it.each([
+    ['road', 'road-minor', 'road' as StructureConstant, {}],
+    ['container', 'container-minor', 'container' as StructureConstant, {}],
+    ['spawn', 'spawn-minor', 'spawn' as StructureConstant, { my: true }]
+  ])('ignores minor long-distance %s damage for generic repair', (_label, targetId, structureType, extra) => {
+    const controller = { id: 'controller1', my: true } as StructureController;
+    const target = makeStructure(
+      targetId,
+      structureType,
+      5_000 - ROUTINE_REPAIR_MIN_HITS_DEFICIT + 1,
+      5_000,
+      extra
+    );
+    const getRangeTo = jest.fn((targetObject: { id?: string }) => {
+      const ranges: Record<string, number> = {
+        controller1: 1,
+        [targetId]: ROUTINE_REPAIR_MAX_RANGE + 1
+      };
+      return ranges[String(targetObject.id)] ?? 99;
+    });
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo },
+      room: makeWorkerTaskRoom({
+        controller,
+        structures: [target]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('keeps a generic repair target from consuming a second loaded worker', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const road = makeStructure('road-damaged', 'road' as StructureConstant, 3_000, 5_000);
+    const room = makeWorkerTaskRoom({ controller, structures: [road] });
+    const repairer = makeLoadedWorker(room, { type: 'repair', targetId: 'road-damaged' as Id<Structure> });
+    const creep = {
+      name: 'SecondWorker',
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ Repairer: repairer, SecondWorker: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('keeps critical container repair ahead of routine assignment caps', () => {
+    const controller = { id: 'controller1', my: true } as StructureController;
+    const container = makeStructure('container-critical', 'container' as StructureConstant, 500, 2_000);
+    const room = makeWorkerTaskRoom({ controller, structures: [container] });
+    const repairer = makeLoadedWorker(room, {
+      type: 'repair',
+      targetId: 'container-critical' as Id<Structure>
+    });
+    const creep = {
+      name: 'CriticalRepairWorker',
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ Repairer: repairer, CriticalRepairWorker: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'container-critical' });
   });
 
   it('chooses repair targets deterministically and avoids hostile structures', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -5333,6 +5333,109 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toBeNull();
   });
 
+  it('does not let loaded build workers suppress near-term low-load emergency refill', () => {
+    const spawningSpawn = makeEnergySinkWithEnergy('spawn1', 'spawn' as StructureConstant, 175, 125, {
+      spawning: { remainingTime: 10 }
+    });
+    const source = makeSource('source1', 20, 20, 300);
+    const room = makeWorkerTaskRoom({
+      controller: {
+        id: 'controller1' as Id<StructureController>,
+        my: false
+      } as StructureController,
+      energyAvailable: MINIMUM_WORKER_SPAWN_ENERGY - 25,
+      energyCapacityAvailable: 300,
+      myStructures: [spawningSpawn as AnyOwnedStructure],
+      sources: [source]
+    });
+    const builder = {
+      name: 'Builder',
+      memory: {
+        role: 'worker',
+        task: { type: 'build', targetId: 'road-site1' as Id<ConstructionSite> }
+      },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    const creep = {
+      name: 'LowLoadRefill',
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(10),
+        getFreeCapacity: jest.fn().mockReturnValue(40)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'source1' ? 1 : 2))
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ Builder: builder, LowLoadRefill: creep });
+    (globalThis as unknown as { Game: Partial<Game> }).Game.time = 342;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'lowLoadReturn',
+      tick: 342,
+      carriedEnergy: 10,
+      freeCapacity: 40,
+      selectedTask: 'transfer',
+      targetId: 'spawn1',
+      reason: 'emergencySpawnExtensionRefill'
+    });
+  });
+
+  it('lets refill-bound workers cover near-term low-load emergency refill', () => {
+    const spawningSpawn = makeEnergySinkWithEnergy('spawn1', 'spawn' as StructureConstant, 175, 125, {
+      spawning: { remainingTime: 10 }
+    });
+    const source = makeSource('source1', 20, 20, 300);
+    const room = makeWorkerTaskRoom({
+      controller: {
+        id: 'controller1' as Id<StructureController>,
+        my: false
+      } as StructureController,
+      energyAvailable: MINIMUM_WORKER_SPAWN_ENERGY - 25,
+      energyCapacityAvailable: 300,
+      myStructures: [spawningSpawn as AnyOwnedStructure],
+      sources: [source]
+    });
+    const refillWorker = {
+      name: 'RefillWorker',
+      memory: {
+        role: 'worker',
+        task: { type: 'transfer', targetId: 'spawn1' as Id<AnyStoreStructure> }
+      },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(25) },
+      room
+    } as unknown as Creep;
+    const creep = {
+      name: 'LowLoadRefill',
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(10),
+        getFreeCapacity: jest.fn().mockReturnValue(40)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'source1' ? 1 : 2))
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ RefillWorker: refillWorker, LowLoadRefill: creep });
+    (globalThis as unknown as { Game: Partial<Game> }).Game.time = 343;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'nearbyEnergyChoice',
+      tick: 343,
+      carriedEnergy: 10,
+      freeCapacity: 40,
+      selectedTask: 'harvest',
+      targetId: 'source1',
+      energy: 300,
+      range: 1
+    });
+  });
+
   it('returns to refill instead of taking a far low-load harvest detour', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const source = { id: 'source1', energy: 300 } as Source;


### PR DESCRIPTION
## Summary
- Fixes the E29N55 bootstrap worker-efficiency P0 from #1104.
- Keeps tiny 2/50 low-load workers from prematurely returning to spawn refill when useful nearby energy acquisition can continue.
- Bounds routine non-barrier repair selection by meaningful deficit, opportunistic range, and one-worker assignment capacity to reduce trivial repair stampedes.
- Preserves emergency behavior for true spawn/refill/downgrade/hostile cases.

Closes #1104.

## Controller verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 96 suites / 1852 tests passed
- `cd prod && npm run build`
- `git diff --exit-code -- prod/dist/main.js`

## Runtime evidence motivating the fix
- Latest runtime alert output `1df5ef0c3835/2026-05-16_03-36-25.md` reports `worker_assignment_gap_sustained` in `shardX/E29N55` at tick `989227`, with `owned_spawns=1`, `owned_creeps=4`, `constructionSiteCount=2`, `pendingBuildProgress=10000`, `storedEnergy=56`, `workerCarriedEnergy=6`, and all task counts zero.

## Safety
- No secrets touched.
- Generated `prod/dist/main.js` included via `npm run build`.
- Official MMO deploy is still gated by normal PR/merge/deploy floor checks.
