### PR TITLE
fix(monitor): suppress recovered worker gap false positives

### DIFF
--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -3127,7 +3127,12 @@ def ambiguous_runtime_room_names(refs: list[RoomRef]) -> set[str]:
     return {room for room, shards in shards_by_room.items() if len(shards) > 1}
 
 
-def runtime_summary_room_matches(room: dict[str, Any], ref: RoomRef, ambiguous_room_names: set[str]) -> bool:
+def runtime_summary_room_matches(
+    room: dict[str, Any],
+    ref: RoomRef,
+    ambiguous_room_names: set[str],
+    payload_explicit_shards_by_room: dict[str, set[str]] | None = None,
+) -> bool:
     room_ref = room.get("room")
     if isinstance(room_ref, str) and room_ref == ref.key:
         return True
@@ -3137,7 +3142,20 @@ def runtime_summary_room_matches(room: dict[str, Any], ref: RoomRef, ambiguous_r
         return False
     if shard is not None:
         return shard == ref.shard
-    return room_name not in ambiguous_room_names
+    if room_name in ambiguous_room_names:
+        return False
+    explicit_shards = (payload_explicit_shards_by_room or {}).get(room_name, set())
+    return not explicit_shards or explicit_shards == {ref.shard}
+
+
+def runtime_summary_explicit_shards_by_room(rooms: list[dict[str, Any]]) -> dict[str, set[str]]:
+    result: dict[str, set[str]] = {}
+    for room in rooms:
+        room_name = runtime_summary_room_name(room)
+        shard = runtime_summary_room_shard(room)
+        if room_name is not None and shard is not None:
+            result.setdefault(room_name, set()).add(shard)
+    return result
 
 
 def runtime_summary_room_has_worker_idle_fields(room: dict[str, Any]) -> bool:
@@ -3174,11 +3192,50 @@ def payload_runtime_rooms(payload: dict[str, Any]) -> list[dict[str, Any]]:
     return [room for room in rooms if isinstance(room, dict)]
 
 
+def runtime_summary_artifact_timestamp(path: Path) -> float | None:
+    match = re.search(r"(\d{8}T\d{6}Z)", path.name)
+    if match is not None:
+        try:
+            return datetime.strptime(match.group(1), "%Y%m%dT%H%M%SZ").replace(tzinfo=timezone.utc).timestamp()
+        except ValueError:
+            pass
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return None
+
+
+def runtime_summary_log_sort_key(path: Path) -> tuple[bool, float, str]:
+    timestamp = runtime_summary_artifact_timestamp(path)
+    return (timestamp is not None, timestamp if timestamp is not None else -1.0, str(path))
+
+
 def runtime_summary_log_paths(runtime_summary_dir: Path) -> list[Path]:
-    all_paths = list(runtime_summary_dir.glob("*.log"))
-    console_paths = [path for path in all_paths if path.name.startswith("runtime-summary-console-")]
-    paths = console_paths if console_paths else all_paths
-    return sorted(paths, key=lambda path: (path.stat().st_mtime, str(path)), reverse=True)
+    return sorted(runtime_summary_dir.glob("*.log"), key=runtime_summary_log_sort_key, reverse=True)
+
+
+def runtime_summary_payload_tick(payload: dict[str, Any]) -> int | None:
+    return tick_number(payload.get("tick"))
+
+
+def runtime_summary_candidate_key(
+    payload: dict[str, Any],
+    path: Path,
+    line_index: int,
+    room: dict[str, Any],
+) -> tuple[bool, int, bool, float, int, int, str]:
+    tick = runtime_summary_payload_tick(payload)
+    timestamp = runtime_summary_artifact_timestamp(path)
+    explicit_shard_rank = 1 if runtime_summary_room_shard(room) is not None else 0
+    return (
+        tick is not None,
+        tick if tick is not None else -1,
+        timestamp is not None,
+        timestamp if timestamp is not None else -1.0,
+        line_index,
+        explicit_shard_rank,
+        str(path),
+    )
 
 
 def load_latest_runtime_room_summaries(
@@ -3198,6 +3255,7 @@ def load_latest_runtime_room_summaries(
 
     ambiguous_room_names = ambiguous_runtime_room_names([*refs, *(disambiguation_refs or [])])
     result: dict[str, dict[str, Any]] = {}
+    result_keys: dict[str, tuple[bool, int, bool, float, int, int, str]] = {}
     for path in paths:
         try:
             lines = path.read_text(encoding="utf-8").splitlines()
@@ -3205,19 +3263,29 @@ def load_latest_runtime_room_summaries(
             warnings.append(f"runtime-summary artifact unreadable {path.name}: {short_text(exc, 140)}")
             continue
 
-        for line in reversed(lines):
+        for line_index, line in reversed(list(enumerate(lines))):
             payload = parse_runtime_summary_line(line)
             if payload is None:
                 continue
-            for room in payload_runtime_rooms(payload):
+            rooms = payload_runtime_rooms(payload)
+            payload_explicit_shards_by_room = runtime_summary_explicit_shards_by_room(rooms)
+            for room in rooms:
                 if not runtime_summary_room_has_worker_idle_fields(room):
                     continue
                 for ref in refs:
-                    if ref.key in result or not runtime_summary_room_matches(room, ref, ambiguous_room_names):
+                    if not runtime_summary_room_matches(
+                        room,
+                        ref,
+                        ambiguous_room_names,
+                        payload_explicit_shards_by_room,
+                    ):
+                        continue
+                    candidate_key = runtime_summary_candidate_key(payload, path, line_index, room)
+                    if candidate_key <= result_keys.get(ref.key, (False, -1, False, -1.0, -1, -1, "")):
                         continue
                     result[ref.key] = room
+                    result_keys[ref.key] = candidate_key
                     break
-            return result
 
     return result
 

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -51,6 +51,11 @@ WORKER_ASSIGNMENT_GAP_BLOCKED_REASON = "worker_assignment_gap"
 WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND = "worker_assignment_gap_sustained"
 WORKER_ASSIGNMENT_GAP_REQUIRED_TICKS = 100
 ASSIGNED_WORKER_TASK_NAMES = ("harvest", "transfer", "build", "repair", "upgrade")
+BUILD_BLOCKED_REASON_PATHS = (
+    ("buildBlockedReason",),
+    ("resources", "productiveEnergy", "buildBlockedReason"),
+    ("construction", "buildBlockedReason"),
+)
 WORKER_ASSIGNMENT_BLOCKED_WORKER_STRING_FIELDS = (
     "name",
     "task",
@@ -1432,11 +1437,7 @@ def tick_number(value: Any) -> int | None:
 def runtime_build_blocked_reason(room: dict[str, Any] | None) -> str | None:
     if not isinstance(room, dict):
         return None
-    for path in (
-        ("buildBlockedReason",),
-        ("resources", "productiveEnergy", "buildBlockedReason"),
-        ("construction", "buildBlockedReason"),
-    ):
+    for path in BUILD_BLOCKED_REASON_PATHS:
         value = nested_value(room, *path)
         if isinstance(value, str) and value:
             return value
@@ -1462,13 +1463,38 @@ def runtime_assigned_worker_task_count(room: dict[str, Any]) -> int | float:
     return sum(number_value(task_counts.get(task_name)) or 0 for task_name in ASSIGNED_WORKER_TASK_NAMES)
 
 
+def runtime_assigned_productive_worker_count(room: dict[str, Any]) -> int | float | None:
+    return first_number_value(
+        room,
+        ("assignedWorkerCount",),
+        ("resources", "productiveEnergy", "assignedWorkerCount"),
+        ("productiveEnergy", "assignedWorkerCount"),
+    )
+
+
 def runtime_worker_assignment_recovered(room: dict[str, Any] | None) -> bool:
     if not isinstance(room, dict):
         return False
     worker_count = number_value(room.get("workerCount"))
     if worker_count is not None and worker_count <= 0:
         return False
-    return runtime_assigned_worker_task_count(room) > 0
+    productive_worker_count = runtime_assigned_productive_worker_count(room)
+    deadlock_ticks = runtime_construction_deadlock_ticks(room)
+    return (
+        runtime_assigned_worker_task_count(room) > 0
+        or (productive_worker_count is not None and productive_worker_count > 0)
+        or (deadlock_ticks is not None and deadlock_ticks <= 0)
+    )
+
+
+def runtime_reports_worker_assignment_gap(room: dict[str, Any] | None) -> bool:
+    if not isinstance(room, dict):
+        return False
+    return any(nested_value(room, *path) == WORKER_ASSIGNMENT_GAP_BLOCKED_REASON for path in BUILD_BLOCKED_REASON_PATHS)
+
+
+def runtime_worker_assignment_gap_recovered(room: dict[str, Any] | None) -> bool:
+    return not runtime_reports_worker_assignment_gap(room) and runtime_worker_assignment_recovered(room)
 
 
 def build_extension_count_zero_at_rcl_ge_2_reason(ref: RoomRef, metrics: RoomSummaryMetrics) -> dict[str, Any]:
@@ -1501,9 +1527,11 @@ def worker_assignment_gap_active(
     site_count = runtime_construction_site_count(runtime_room)
     if site_count is None:
         site_count = len(metrics.construction_sites)
-    if runtime_worker_assignment_recovered(runtime_room):
-        return False, None, site_count
     blocked_reason = runtime_build_blocked_reason(runtime_room) or metrics.build_blocked_reason
+    if runtime_reports_worker_assignment_gap(runtime_room):
+        blocked_reason = WORKER_ASSIGNMENT_GAP_BLOCKED_REASON
+    elif runtime_worker_assignment_gap_recovered(runtime_room):
+        return False, None, site_count
     return blocked_reason == WORKER_ASSIGNMENT_GAP_BLOCKED_REASON and site_count > 0, blocked_reason, site_count
 
 

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -50,6 +50,7 @@ EXTENSION_COUNT_ZERO_AT_RCL_GE_2_KIND = "extension_count_zero_at_rcl_ge_2"
 WORKER_ASSIGNMENT_GAP_BLOCKED_REASON = "worker_assignment_gap"
 WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND = "worker_assignment_gap_sustained"
 WORKER_ASSIGNMENT_GAP_REQUIRED_TICKS = 100
+ASSIGNED_WORKER_TASK_NAMES = ("harvest", "transfer", "build", "repair", "upgrade")
 WORKER_ASSIGNMENT_BLOCKED_WORKER_STRING_FIELDS = (
     "name",
     "task",
@@ -1456,6 +1457,20 @@ def runtime_construction_site_count(room: dict[str, Any] | None) -> int | float 
     return None
 
 
+def runtime_assigned_worker_task_count(room: dict[str, Any]) -> int | float:
+    task_counts = as_dict(room.get("taskCounts"))
+    return sum(number_value(task_counts.get(task_name)) or 0 for task_name in ASSIGNED_WORKER_TASK_NAMES)
+
+
+def runtime_worker_assignment_recovered(room: dict[str, Any] | None) -> bool:
+    if not isinstance(room, dict):
+        return False
+    worker_count = number_value(room.get("workerCount"))
+    if worker_count is not None and worker_count <= 0:
+        return False
+    return runtime_assigned_worker_task_count(room) > 0
+
+
 def build_extension_count_zero_at_rcl_ge_2_reason(ref: RoomRef, metrics: RoomSummaryMetrics) -> dict[str, Any]:
     return {
         "kind": EXTENSION_COUNT_ZERO_AT_RCL_GE_2_KIND,
@@ -1483,10 +1498,12 @@ def worker_assignment_gap_active(
     runtime_room: dict[str, Any] | None,
     metrics: RoomSummaryMetrics,
 ) -> tuple[bool, str | None, int | float]:
-    blocked_reason = runtime_build_blocked_reason(runtime_room) or metrics.build_blocked_reason
     site_count = runtime_construction_site_count(runtime_room)
     if site_count is None:
         site_count = len(metrics.construction_sites)
+    if runtime_worker_assignment_recovered(runtime_room):
+        return False, None, site_count
+    blocked_reason = runtime_build_blocked_reason(runtime_room) or metrics.build_blocked_reason
     return blocked_reason == WORKER_ASSIGNMENT_GAP_BLOCKED_REASON and site_count > 0, blocked_reason, site_count
 
 
@@ -3072,7 +3089,11 @@ def runtime_summary_room_matches(room: dict[str, Any], ref: RoomRef) -> bool:
     room_ref = room.get("room")
     if isinstance(room_ref, str) and room_ref == ref.key:
         return True
-    return runtime_summary_room_name(room) == ref.room and runtime_summary_room_shard(room) == ref.shard
+    room_name = runtime_summary_room_name(room)
+    shard = runtime_summary_room_shard(room)
+    if room_name != ref.room:
+        return False
+    return shard is None or shard == ref.shard
 
 
 def runtime_summary_room_has_worker_idle_fields(room: dict[str, Any]) -> bool:

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -3085,7 +3085,14 @@ def runtime_summary_room_shard(room: dict[str, Any]) -> str | None:
     return None
 
 
-def runtime_summary_room_matches(room: dict[str, Any], ref: RoomRef) -> bool:
+def ambiguous_runtime_room_names(refs: list[RoomRef]) -> set[str]:
+    shards_by_room: dict[str, set[str]] = {}
+    for ref in refs:
+        shards_by_room.setdefault(ref.room, set()).add(ref.shard)
+    return {room for room, shards in shards_by_room.items() if len(shards) > 1}
+
+
+def runtime_summary_room_matches(room: dict[str, Any], ref: RoomRef, ambiguous_room_names: set[str]) -> bool:
     room_ref = room.get("room")
     if isinstance(room_ref, str) and room_ref == ref.key:
         return True
@@ -3093,7 +3100,9 @@ def runtime_summary_room_matches(room: dict[str, Any], ref: RoomRef) -> bool:
     shard = runtime_summary_room_shard(room)
     if room_name != ref.room:
         return False
-    return shard is None or shard == ref.shard
+    if shard is not None:
+        return shard == ref.shard
+    return room_name not in ambiguous_room_names
 
 
 def runtime_summary_room_has_worker_idle_fields(room: dict[str, Any]) -> bool:
@@ -3151,6 +3160,7 @@ def load_latest_runtime_room_summaries(
         warnings.append(f"runtime-summary scan unavailable: {short_text(exc, 140)}")
         return {}
 
+    ambiguous_room_names = ambiguous_runtime_room_names(refs)
     result: dict[str, dict[str, Any]] = {}
     for path in paths:
         try:
@@ -3167,7 +3177,7 @@ def load_latest_runtime_room_summaries(
                 if not runtime_summary_room_has_worker_idle_fields(room):
                     continue
                 for ref in refs:
-                    if ref.key in result or not runtime_summary_room_matches(room, ref):
+                    if ref.key in result or not runtime_summary_room_matches(room, ref, ambiguous_room_names):
                         continue
                     result[ref.key] = room
                     break

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -50,6 +50,9 @@ EXTENSION_COUNT_ZERO_AT_RCL_GE_2_KIND = "extension_count_zero_at_rcl_ge_2"
 WORKER_ASSIGNMENT_GAP_BLOCKED_REASON = "worker_assignment_gap"
 WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND = "worker_assignment_gap_sustained"
 WORKER_ASSIGNMENT_GAP_REQUIRED_TICKS = 100
+WORKER_ASSIGNMENT_GAP_RECOVERY_TICK_TOLERANCE = 0
+RUNTIME_SUMMARY_TICK_METADATA_KEY = "__runtimeSummaryTick"
+RUNTIME_SUMMARY_ARTIFACT_TIMESTAMP_METADATA_KEY = "__runtimeSummaryArtifactTimestamp"
 ASSIGNED_WORKER_TASK_NAMES = ("harvest", "transfer", "build", "repair", "upgrade")
 BUILD_BLOCKED_REASON_PATHS = (
     ("buildBlockedReason",),
@@ -1504,6 +1507,23 @@ def runtime_worker_assignment_gap_recovered(room: dict[str, Any] | None) -> bool
     return not runtime_reports_worker_assignment_gap(room) and runtime_worker_assignment_recovered(room)
 
 
+def runtime_summary_room_tick(room: dict[str, Any] | None) -> int | None:
+    if not isinstance(room, dict):
+        return None
+    return tick_number(room.get(RUNTIME_SUMMARY_TICK_METADATA_KEY))
+
+
+def runtime_worker_assignment_gap_recovery_is_fresh(
+    room: dict[str, Any] | None,
+    current_tick_value: Any,
+) -> bool:
+    current_tick = tick_number(current_tick_value)
+    room_tick = runtime_summary_room_tick(room)
+    if current_tick is None or room_tick is None:
+        return False
+    return room_tick + WORKER_ASSIGNMENT_GAP_RECOVERY_TICK_TOLERANCE >= current_tick
+
+
 def build_extension_count_zero_at_rcl_ge_2_reason(ref: RoomRef, metrics: RoomSummaryMetrics) -> dict[str, Any]:
     return {
         "kind": EXTENSION_COUNT_ZERO_AT_RCL_GE_2_KIND,
@@ -1530,14 +1550,21 @@ def detect_extension_count_zero_at_rcl_ge_2_reason(ref: RoomRef, metrics: RoomSu
 def worker_assignment_gap_active(
     runtime_room: dict[str, Any] | None,
     metrics: RoomSummaryMetrics,
+    current_tick_value: Any,
 ) -> tuple[bool, str | None, int | float]:
+    metrics_site_count = len(metrics.construction_sites)
     site_count = runtime_construction_site_count(runtime_room)
     if site_count is None:
-        site_count = len(metrics.construction_sites)
+        site_count = metrics_site_count
     blocked_reason = runtime_build_blocked_reason(runtime_room) or metrics.build_blocked_reason
     if runtime_reports_worker_assignment_gap(runtime_room):
         blocked_reason = WORKER_ASSIGNMENT_GAP_BLOCKED_REASON
     elif runtime_worker_assignment_gap_recovered(runtime_room):
+        if (
+            metrics.build_blocked_reason == WORKER_ASSIGNMENT_GAP_BLOCKED_REASON
+            and not runtime_worker_assignment_gap_recovery_is_fresh(runtime_room, current_tick_value)
+        ):
+            return metrics_site_count > 0, metrics.build_blocked_reason, metrics_site_count
         return False, None, site_count
     return blocked_reason == WORKER_ASSIGNMENT_GAP_BLOCKED_REASON and site_count > 0, blocked_reason, site_count
 
@@ -1600,7 +1627,11 @@ def detect_worker_assignment_gap_sustained_reason(
     previous_rule_state: Any,
     current_tick_value: Any,
 ) -> tuple[dict[str, Any] | None, dict[str, int] | int]:
-    active, blocked_reason, construction_site_count = worker_assignment_gap_active(runtime_room, metrics)
+    active, blocked_reason, construction_site_count = worker_assignment_gap_active(
+        runtime_room,
+        metrics,
+        current_tick_value,
+    )
     current_tick = tick_number(current_tick_value)
     if not active or current_tick is None:
         return None, 0
@@ -3238,6 +3269,17 @@ def runtime_summary_candidate_key(
     )
 
 
+def runtime_summary_room_with_metadata(payload: dict[str, Any], path: Path, room: dict[str, Any]) -> dict[str, Any]:
+    result = dict(room)
+    tick = runtime_summary_payload_tick(payload)
+    if tick is not None:
+        result[RUNTIME_SUMMARY_TICK_METADATA_KEY] = tick
+    timestamp = runtime_summary_artifact_timestamp(path)
+    if timestamp is not None:
+        result[RUNTIME_SUMMARY_ARTIFACT_TIMESTAMP_METADATA_KEY] = timestamp
+    return result
+
+
 def load_latest_runtime_room_summaries(
     runtime_summary_dir: Path,
     refs: list[RoomRef],
@@ -3283,7 +3325,7 @@ def load_latest_runtime_room_summaries(
                     candidate_key = runtime_summary_candidate_key(payload, path, line_index, room)
                     if candidate_key <= result_keys.get(ref.key, (False, -1, False, -1.0, -1, -1, "")):
                         continue
-                    result[ref.key] = room
+                    result[ref.key] = runtime_summary_room_with_metadata(payload, path, room)
                     result_keys[ref.key] = candidate_key
                     break
 

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -703,6 +703,24 @@ def overview_rooms(overview: Any, shard: str) -> list[str]:
     return [room for room in rooms if isinstance(room, str)]
 
 
+def overview_room_refs(overview: Any) -> list[RoomRef]:
+    if not isinstance(overview, dict):
+        return []
+    shards = overview.get("shards")
+    if not isinstance(shards, dict):
+        return []
+
+    refs: list[RoomRef] = []
+    for shard in sorted(shards):
+        shard_info = shards.get(shard)
+        if not isinstance(shard_info, dict):
+            continue
+        for room in shard_info.get("rooms") or []:
+            if isinstance(room, str):
+                refs.append(RoomRef(shard=shard, room=room))
+    return refs
+
+
 def gametime_from_overview(overview: Any, shard: str) -> int | str | None:
     if not isinstance(overview, dict):
         return None
@@ -715,7 +733,7 @@ def gametime_from_overview(overview: Any, shard: str) -> int | str | None:
     return shard_info.get("gametime")
 
 
-def discover_owned_rooms(ctx: RuntimeContext, forced_room: RoomRef | None) -> tuple[list[RoomRef], Any, list[str]]:
+def discover_owned_rooms(ctx: RuntimeContext, forced_room: RoomRef | None) -> tuple[list[RoomRef], Any, list[str], list[RoomRef]]:
     warnings: list[str] = []
     overview: Any = None
     try:
@@ -723,27 +741,16 @@ def discover_owned_rooms(ctx: RuntimeContext, forced_room: RoomRef | None) -> tu
     except Exception as exc:  # noqa: BLE001 - sanitized in user payload
         warnings.append(f"owned room discovery unavailable: {short_text(exc, 140)}")
 
+    overview_refs = overview_room_refs(overview)
     if forced_room:
-        return [forced_room], overview, warnings
+        return [forced_room], overview, warnings, overview_refs
 
-    rooms: list[RoomRef] = []
-    if isinstance(overview, dict):
-        shards = overview.get("shards")
-        if isinstance(shards, dict):
-            for shard in sorted(shards):
-                shard_info = shards.get(shard)
-                if not isinstance(shard_info, dict):
-                    continue
-                for room in shard_info.get("rooms") or []:
-                    if isinstance(room, str):
-                        rooms.append(RoomRef(shard=shard, room=room))
-
-    if rooms:
-        return rooms, overview, warnings
+    if overview_refs:
+        return overview_refs, overview, warnings, overview_refs
 
     fallback = RoomRef(ctx.default_shard, ctx.default_room)
     warnings.append(f"falling back to configured room {fallback.key}")
-    return [fallback], overview, warnings
+    return [fallback], overview, warnings, [fallback]
 
 
 def terrain_cache_path(cache_dir: Path, ref: RoomRef) -> Path:
@@ -863,9 +870,9 @@ async def fetch_room_event(ctx: RuntimeContext, ref: RoomRef) -> dict[str, Any]:
     raise RuntimeError(f"no room snapshot event received for {ref.key}")
 
 
-def collect_snapshots(ctx: RuntimeContext, room_arg: str | None) -> tuple[list[RoomSnapshot], list[str]]:
+def collect_snapshots(ctx: RuntimeContext, room_arg: str | None) -> tuple[list[RoomSnapshot], list[str], list[RoomRef]]:
     forced_room = parse_room_arg(room_arg, ctx.default_shard)
-    refs, overview, warnings = discover_owned_rooms(ctx, forced_room)
+    refs, overview, warnings, overview_refs = discover_owned_rooms(ctx, forced_room)
     configured_owner, configured_owner_id = user_identity(ctx, warnings)
     configured_owner = configured_owner or overview_username(overview)
     snapshots: list[RoomSnapshot] = []
@@ -915,7 +922,7 @@ def collect_snapshots(ctx: RuntimeContext, room_arg: str | None) -> tuple[list[R
 
     if not snapshots:
         raise RuntimeError("no room snapshots collected")
-    return snapshots, warnings
+    return snapshots, warnings, overview_refs
 
 
 def detect_hostile_creeps(objects: dict[str, dict[str, Any]], owner_username: str | None) -> list[dict[str, Any]]:
@@ -3178,6 +3185,7 @@ def load_latest_runtime_room_summaries(
     runtime_summary_dir: Path,
     refs: list[RoomRef],
     warnings: list[str],
+    disambiguation_refs: list[RoomRef] | None = None,
 ) -> dict[str, dict[str, Any]]:
     if not refs or not runtime_summary_dir.exists():
         return {}
@@ -3188,7 +3196,7 @@ def load_latest_runtime_room_summaries(
         warnings.append(f"runtime-summary scan unavailable: {short_text(exc, 140)}")
         return {}
 
-    ambiguous_room_names = ambiguous_runtime_room_names(refs)
+    ambiguous_room_names = ambiguous_runtime_room_names([*refs, *(disambiguation_refs or [])])
     result: dict[str, dict[str, Any]] = {}
     for path in paths:
         try:
@@ -4132,7 +4140,7 @@ def command_health_gate(args: argparse.Namespace) -> int:
 
 def command_summary(args: argparse.Namespace) -> int:
     ctx = context_from_env(args.world_profile)
-    snapshots, warnings = collect_snapshots(ctx, args.room)
+    snapshots, warnings, _overview_refs = collect_snapshots(ctx, args.room)
     images: list[str] = []
     room_summaries: list[dict[str, Any]] = []
     out_dir = Path(args.out_dir)
@@ -4168,11 +4176,12 @@ def command_summary(args: argparse.Namespace) -> int:
 
 def command_alert(args: argparse.Namespace) -> int:
     ctx = context_from_env(args.world_profile)
-    snapshots, warnings = collect_snapshots(ctx, args.room)
+    snapshots, warnings, overview_refs = collect_snapshots(ctx, args.room)
     runtime_room_summaries = load_latest_runtime_room_summaries(
         Path(args.runtime_summary_dir).expanduser(),
         [snapshot.ref for snapshot in snapshots],
         warnings,
+        disambiguation_refs=overview_refs,
     )
     state = load_state(ctx.state_file)
     rooms_state = state.get("rooms")

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -1377,6 +1377,46 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         self.assertNotIn(monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND, [reason["kind"] for reason in emitted])
         self.assertEqual(next_state["rule_counts"][monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND], 0)
 
+    def test_room_only_console_summary_does_not_match_ambiguous_tracked_shards(self) -> None:
+        payload = {
+            "type": "runtime-summary",
+            "tick": 995550,
+            "rooms": [
+                {
+                    "roomName": "E29N55",
+                    "workerCount": 3,
+                    "taskCounts": {"harvest": 9, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0, "none": 0},
+                },
+                {
+                    "roomName": "E29N55",
+                    "shard": "shardSeason",
+                    "workerCount": 2,
+                    "taskCounts": {"harvest": 2, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0, "none": 0},
+                },
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_dir = Path(temp_dir)
+            (runtime_dir / "runtime-summary-console-20260516T000000Z.log").write_text(
+                "#runtime-summary " + json.dumps(payload) + "\n",
+                encoding="utf-8",
+            )
+            warnings: list[str] = []
+
+            runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                runtime_dir,
+                [
+                    monitor.RoomRef(shard="shardX", room="E29N55"),
+                    monitor.RoomRef(shard="shardSeason", room="E29N55"),
+                ],
+                warnings,
+            )
+
+        self.assertEqual(warnings, [])
+        self.assertNotIn("shardX/E29N55", runtime_rooms)
+        self.assertEqual(runtime_rooms["shardSeason/E29N55"]["taskCounts"]["harvest"], 2)
+
     def test_runtime_summary_loader_ignores_behavior_only_pathing_totals(self) -> None:
         payload = {
             "type": "runtime-summary",

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -1297,7 +1297,7 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
             self.assertEqual(written.name, target.with_name(f"{target.stem}-2{target.suffix}").name)
             self.assertTrue(written.read_text(encoding="utf-8").startswith("#runtime-summary "))
 
-    def test_room_only_console_summary_clears_stale_worker_assignment_gap(self) -> None:
+    def test_older_room_only_console_summary_does_not_override_newer_monitor_gap(self) -> None:
         console_payload = {
             "type": "runtime-summary",
             "tick": 995540,
@@ -1337,6 +1337,67 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             runtime_dir = Path(temp_dir)
             (runtime_dir / "runtime-summary-console-20260515T234005Z.log").write_text(
+                "#runtime-summary " + json.dumps(console_payload) + "\n",
+                encoding="utf-8",
+            )
+            (runtime_dir / "runtime-summary-monitor-20260515T234012Z.log").write_text(
+                "#runtime-summary " + json.dumps(monitor_payload) + "\n",
+                encoding="utf-8",
+            )
+            warnings: list[str] = []
+
+            runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                runtime_dir,
+                [monitor.RoomRef(shard="shardX", room="E29N55")],
+                warnings,
+            )
+
+        self.assertEqual(warnings, [])
+        runtime_room = runtime_rooms["shardX/E29N55"]
+        self.assertEqual(runtime_room["taskCounts"]["harvest"], 0)
+        self.assertEqual(runtime_room["constructionDeadlockTicks"], 1)
+        self.assertEqual(runtime_room["buildBlockedReason"], monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON)
+
+    def test_fresh_room_only_console_summary_clears_stale_worker_assignment_gap(self) -> None:
+        console_payload = {
+            "type": "runtime-summary",
+            "tick": 995548,
+            "rooms": [
+                {
+                    "roomName": "E29N55",
+                    "energyBufferHealth": {"currentEnergy": 300, "threshold": 227, "healthy": True},
+                    "workerCount": 3,
+                    "taskCounts": {"harvest": 2, "transfer": 0, "build": 0, "repair": 0, "upgrade": 1, "none": 0},
+                    "constructionSiteCount": 11,
+                    "constructionDeadlockTicks": 0,
+                    "resources": {
+                        "productiveEnergy": {
+                            "constructionSiteCount": 11,
+                            "constructionDeadlockTicks": 0,
+                        }
+                    },
+                }
+            ],
+        }
+        monitor_payload = {
+            "type": "runtime-summary",
+            "tick": 995544,
+            "rooms": [
+                {
+                    "roomName": "E29N55",
+                    "shard": "shardX",
+                    "workerCount": 3,
+                    "taskCounts": {"harvest": 0, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0, "none": 0},
+                    "constructionSiteCount": 11,
+                    "constructionDeadlockTicks": 1,
+                    "buildBlockedReason": monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON,
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_dir = Path(temp_dir)
+            (runtime_dir / "runtime-summary-console-20260515T234020Z.log").write_text(
                 "#runtime-summary " + json.dumps(console_payload) + "\n",
                 encoding="utf-8",
             )
@@ -1535,6 +1596,42 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
                     monitor.RoomRef(shard="shardX", room="E29N55"),
                     monitor.RoomRef(shard="shardSeason", room="E29N55"),
                 ],
+            )
+
+        self.assertEqual(runtime_rooms, {})
+        self.assertEqual(warnings, [])
+
+    def test_room_only_console_summary_does_not_match_payload_cross_shard_collision(self) -> None:
+        payload = {
+            "type": "runtime-summary",
+            "tick": 995550,
+            "rooms": [
+                {
+                    "roomName": "E29N55",
+                    "workerCount": 3,
+                    "taskCounts": {"harvest": 9, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0, "none": 0},
+                },
+                {
+                    "roomName": "E29N55",
+                    "shard": "shardSeason",
+                    "workerCount": 2,
+                    "taskCounts": {"harvest": 2, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0, "none": 0},
+                },
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_dir = Path(temp_dir)
+            (runtime_dir / "runtime-summary-console-20260516T000000Z.log").write_text(
+                "#runtime-summary " + json.dumps(payload) + "\n",
+                encoding="utf-8",
+            )
+            warnings: list[str] = []
+
+            runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                runtime_dir,
+                [monitor.RoomRef(shard="shardX", room="E29N55")],
+                warnings,
             )
 
         self.assertEqual(runtime_rooms, {})

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -1419,6 +1419,8 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         self.assertEqual(runtime_room["constructionDeadlockTicks"], 0)
         self.assertIsNone(runtime_room.get("buildBlockedReason"))
         self.assertNotIn("buildBlockedReason", runtime_room["resources"]["productiveEnergy"])
+        self.assertEqual(runtime_room[monitor.RUNTIME_SUMMARY_TICK_METADATA_KEY], 995548)
+        self.assertIn(monitor.RUNTIME_SUMMARY_ARTIFACT_TIMESTAMP_METADATA_KEY, runtime_room)
 
         snapshot = monitor.RoomSnapshot(
             ref=monitor.RoomRef(shard="shardX", room="E29N55"),
@@ -1494,6 +1496,54 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         self.assertEqual(suppressed, [])
         self.assertNotIn(monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND, [reason["kind"] for reason in emitted])
         self.assertEqual(next_state["rule_counts"][monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND], 0)
+
+    def test_stale_recovered_summary_does_not_clear_newer_worker_assignment_gap(self) -> None:
+        console_payload = {
+            "type": "runtime-summary",
+            "tick": 995548,
+            "rooms": [
+                {
+                    "roomName": "E29N55",
+                    "workerCount": 3,
+                    "taskCounts": {"harvest": 2, "transfer": 0, "build": 0, "repair": 0, "upgrade": 1, "none": 0},
+                    "constructionSiteCount": 0,
+                    "constructionDeadlockTicks": 0,
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_dir = Path(temp_dir)
+            (runtime_dir / "runtime-summary-console-20260515T234020Z.log").write_text(
+                "#runtime-summary " + json.dumps(console_payload) + "\n",
+                encoding="utf-8",
+            )
+            warnings: list[str] = []
+
+            runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                runtime_dir,
+                [monitor.RoomRef(shard="shardX", room="E29N55")],
+                warnings,
+            )
+
+        self.assertEqual(warnings, [])
+        runtime_room = runtime_rooms["shardX/E29N55"]
+        self.assertEqual(runtime_room[monitor.RUNTIME_SUMMARY_TICK_METADATA_KEY], 995548)
+
+        reason, next_state = monitor.detect_worker_assignment_gap_sustained_reason(
+            monitor.RoomRef(shard="shardX", room="E29N55"),
+            runtime_room,
+            make_worker_assignment_gap_metrics(),
+            {"start_tick": 995500, "last_tick": 995600, "consecutive_ticks": 100},
+            995650,
+        )
+
+        self.assertIsNotNone(reason)
+        assert reason is not None
+        self.assertEqual(reason["kind"], monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND)
+        self.assertEqual(reason["buildBlockedReason"], monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON)
+        self.assertEqual(reason["constructionSiteCount"], 1)
+        self.assertEqual(next_state["consecutive_ticks"], 150)
 
     def test_live_productive_energy_worker_assignment_gap_stays_active_with_other_tasks(self) -> None:
         runtime_room = {

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -1239,6 +1239,144 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
             self.assertEqual(written.name, target.with_name(f"{target.stem}-2{target.suffix}").name)
             self.assertTrue(written.read_text(encoding="utf-8").startswith("#runtime-summary "))
 
+    def test_room_only_console_summary_clears_stale_worker_assignment_gap(self) -> None:
+        console_payload = {
+            "type": "runtime-summary",
+            "tick": 995540,
+            "rooms": [
+                {
+                    "roomName": "E29N55",
+                    "energyBufferHealth": {"currentEnergy": 300, "threshold": 227, "healthy": True},
+                    "workerCount": 3,
+                    "taskCounts": {"harvest": 2, "transfer": 0, "build": 0, "repair": 0, "upgrade": 1, "none": 0},
+                    "constructionSiteCount": 11,
+                    "constructionDeadlockTicks": 0,
+                    "buildBlockedReason": None,
+                    "resources": {
+                        "productiveEnergy": {
+                            "constructionSiteCount": 11,
+                            "constructionDeadlockTicks": 0,
+                            "buildBlockedReason": monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON,
+                        }
+                    },
+                }
+            ],
+        }
+        monitor_payload = {
+            "type": "runtime-summary",
+            "tick": 995544,
+            "rooms": [
+                {
+                    "roomName": "E29N55",
+                    "shard": "shardX",
+                    "workerCount": 3,
+                    "taskCounts": {"harvest": 0, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0, "none": 0},
+                    "constructionSiteCount": 11,
+                    "constructionDeadlockTicks": 1,
+                    "buildBlockedReason": monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON,
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_dir = Path(temp_dir)
+            (runtime_dir / "runtime-summary-console-20260515T234005Z.log").write_text(
+                "#runtime-summary " + json.dumps(console_payload) + "\n",
+                encoding="utf-8",
+            )
+            (runtime_dir / "runtime-summary-monitor-20260515T234012Z.log").write_text(
+                "#runtime-summary " + json.dumps(monitor_payload) + "\n",
+                encoding="utf-8",
+            )
+            warnings: list[str] = []
+
+            runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                runtime_dir,
+                [monitor.RoomRef(shard="shardX", room="E29N55")],
+                warnings,
+            )
+
+        self.assertEqual(warnings, [])
+        runtime_room = runtime_rooms["shardX/E29N55"]
+        self.assertEqual(runtime_room["taskCounts"]["harvest"], 2)
+        self.assertEqual(runtime_room["constructionDeadlockTicks"], 0)
+        self.assertIsNone(runtime_room["buildBlockedReason"])
+
+        snapshot = monitor.RoomSnapshot(
+            ref=monitor.RoomRef(shard="shardX", room="E29N55"),
+            terrain="0" * monitor.TERRAIN_CELLS,
+            objects=monitor.normalize_objects(
+                {
+                    "spawn1": {
+                        "type": "spawn",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "x": 17,
+                        "y": 24,
+                        "hits": 5000,
+                        "hitsMax": 5000,
+                    },
+                    "extension1": {
+                        "type": "extension",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "x": 18,
+                        "y": 24,
+                        "hits": 1000,
+                        "hitsMax": 1000,
+                    },
+                    "ctrl": {
+                        "type": "controller",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "level": 2,
+                        "x": 5,
+                        "y": 36,
+                    },
+                    "worker-1": {"type": "creep", "my": True, "owner": {"username": "lanyusea"}, "name": "worker-1"},
+                    "worker-2": {"type": "creep", "my": True, "owner": {"username": "lanyusea"}, "name": "worker-2"},
+                    "worker-3": {"type": "creep", "my": True, "owner": {"username": "lanyusea"}, "name": "worker-3"},
+                    "site1": {
+                        "type": "constructionSite",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "structureType": "road",
+                        "progress": 0,
+                        "progressTotal": 50,
+                        "x": 19,
+                        "y": 24,
+                    },
+                }
+            ),
+            tick=995546,
+            owner="lanyusea",
+            info={"energyAvailable": 300},
+            expected_owner="lanyusea",
+        )
+        previous_state = {
+            "baseline_established": True,
+            "owner": "lanyusea",
+            "rule_counts": {
+                monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND: {
+                    "start_tick": 988884,
+                    "last_tick": 995520,
+                    "consecutive_ticks": 6636,
+                }
+            },
+        }
+
+        emitted, suppressed, next_state = monitor.evaluate_room_alert(
+            snapshot,
+            previous_state,
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_room,
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertNotIn(monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND, [reason["kind"] for reason in emitted])
+        self.assertEqual(next_state["rule_counts"][monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND], 0)
+
     def test_runtime_summary_loader_ignores_behavior_only_pathing_totals(self) -> None:
         payload = {
             "type": "runtime-summary",

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -200,6 +200,26 @@ def make_snapshot(objects: dict[str, dict[str, object]]) -> monitor.RoomSnapshot
     )
 
 
+def make_worker_assignment_gap_metrics() -> monitor.RoomSummaryMetrics:
+    return monitor.RoomSummaryMetrics(
+        structures=[],
+        controller_summary={},
+        owned_creep_objects=[],
+        task_counts={"harvest": 0, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0},
+        construction_sites=[{"type": "constructionSite"}],
+        pending_build_progress=50,
+        build_carried_energy=0,
+        build_blocked_reason=monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON,
+        construction_deadlock_ticks=1,
+        extension_count=1,
+        extension_capacity_contribution=50,
+        stored_energy=0,
+        cpu_used=None,
+        cpu_bucket=None,
+        rcl_level=2,
+    )
+
+
 class WorldProfileDefaultsTest(unittest.TestCase):
     def test_persistent_profile_preserves_monitor_defaults(self) -> None:
         self.assertEqual(monitor.DEFAULT_OUT_DIR, Path("/root/screeps/runtime-artifacts/screeps-monitor"))
@@ -1251,12 +1271,10 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
                     "taskCounts": {"harvest": 2, "transfer": 0, "build": 0, "repair": 0, "upgrade": 1, "none": 0},
                     "constructionSiteCount": 11,
                     "constructionDeadlockTicks": 0,
-                    "buildBlockedReason": None,
                     "resources": {
                         "productiveEnergy": {
                             "constructionSiteCount": 11,
                             "constructionDeadlockTicks": 0,
-                            "buildBlockedReason": monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON,
                         }
                     },
                 }
@@ -1300,7 +1318,8 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         runtime_room = runtime_rooms["shardX/E29N55"]
         self.assertEqual(runtime_room["taskCounts"]["harvest"], 2)
         self.assertEqual(runtime_room["constructionDeadlockTicks"], 0)
-        self.assertIsNone(runtime_room["buildBlockedReason"])
+        self.assertIsNone(runtime_room.get("buildBlockedReason"))
+        self.assertNotIn("buildBlockedReason", runtime_room["resources"]["productiveEnergy"])
 
         snapshot = monitor.RoomSnapshot(
             ref=monitor.RoomRef(shard="shardX", room="E29N55"),
@@ -1376,6 +1395,38 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         self.assertEqual(suppressed, [])
         self.assertNotIn(monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND, [reason["kind"] for reason in emitted])
         self.assertEqual(next_state["rule_counts"][monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND], 0)
+
+    def test_live_productive_energy_worker_assignment_gap_stays_active_with_other_tasks(self) -> None:
+        runtime_room = {
+            "roomName": "E29N55",
+            "shard": "shardX",
+            "workerCount": 3,
+            "taskCounts": {"harvest": 1, "transfer": 1, "build": 0, "repair": 0, "upgrade": 1, "none": 0},
+            "constructionSiteCount": 11,
+            "constructionDeadlockTicks": 2,
+            "resources": {
+                "productiveEnergy": {
+                    "assignedWorkerCount": 1,
+                    "constructionSiteCount": 11,
+                    "constructionDeadlockTicks": 2,
+                    "buildBlockedReason": monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON,
+                }
+            },
+        }
+
+        reason, next_state = monitor.detect_worker_assignment_gap_sustained_reason(
+            monitor.RoomRef(shard="shardX", room="E29N55"),
+            runtime_room,
+            make_worker_assignment_gap_metrics(),
+            {"start_tick": 1000, "last_tick": 1099, "consecutive_ticks": 99},
+            1101,
+        )
+
+        self.assertIsNotNone(reason)
+        assert reason is not None
+        self.assertEqual(reason["kind"], monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND)
+        self.assertEqual(reason["buildBlockedReason"], monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON)
+        self.assertEqual(next_state["consecutive_ticks"], 101)
 
     def test_room_only_console_summary_does_not_match_ambiguous_tracked_shards(self) -> None:
         payload = {

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -315,6 +315,44 @@ class WorldProfileDefaultsTest(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 monitor.build_parser().parse_args(["summary"])
 
+    def test_forced_room_discovery_preserves_overview_refs_for_summary_disambiguation(self) -> None:
+        ctx = monitor.RuntimeContext(
+            base_http="https://screeps.com",
+            token="token",
+            default_shard="shardX",
+            default_room="E29N55",
+            owner=None,
+            owner_id=None,
+            state_file=Path("/tmp/state.json"),
+            cache_dir=Path("/tmp/cache"),
+            debounce_seconds=300,
+            collection_attempts=1,
+            collection_retry_delay_seconds=0,
+        )
+        overview = {
+            "shards": {
+                "shardSeason": {"rooms": ["E29N55"]},
+                "shardX": {"rooms": ["E29N55"]},
+            }
+        }
+
+        with mock.patch.object(monitor, "get_json", return_value=overview):
+            rooms, returned_overview, warnings, overview_refs = monitor.discover_owned_rooms(
+                ctx,
+                monitor.RoomRef(shard="shardX", room="E29N55"),
+            )
+
+        self.assertEqual(rooms, [monitor.RoomRef(shard="shardX", room="E29N55")])
+        self.assertIs(returned_overview, overview)
+        self.assertEqual(warnings, [])
+        self.assertEqual(
+            overview_refs,
+            [
+                monitor.RoomRef(shard="shardSeason", room="E29N55"),
+                monitor.RoomRef(shard="shardX", room="E29N55"),
+            ],
+        )
+
 
 class TacticalResponseBridgeTest(unittest.TestCase):
     def test_no_alert_fixture_is_machine_readable_silent(self) -> None:
@@ -1467,6 +1505,40 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         self.assertEqual(warnings, [])
         self.assertNotIn("shardX/E29N55", runtime_rooms)
         self.assertEqual(runtime_rooms["shardSeason/E29N55"]["taskCounts"]["harvest"], 2)
+
+    def test_room_only_console_summary_uses_overview_refs_for_forced_room_disambiguation(self) -> None:
+        payload = {
+            "type": "runtime-summary",
+            "tick": 995550,
+            "rooms": [
+                {
+                    "roomName": "E29N55",
+                    "workerCount": 3,
+                    "taskCounts": {"harvest": 9, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0, "none": 0},
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_dir = Path(temp_dir)
+            (runtime_dir / "runtime-summary-console-20260516T000000Z.log").write_text(
+                "#runtime-summary " + json.dumps(payload) + "\n",
+                encoding="utf-8",
+            )
+            warnings: list[str] = []
+
+            runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                runtime_dir,
+                [monitor.RoomRef(shard="shardX", room="E29N55")],
+                warnings,
+                disambiguation_refs=[
+                    monitor.RoomRef(shard="shardX", room="E29N55"),
+                    monitor.RoomRef(shard="shardSeason", room="E29N55"),
+                ],
+            )
+
+        self.assertEqual(runtime_rooms, {})
+        self.assertEqual(warnings, [])
 
     def test_runtime_summary_loader_ignores_behavior_only_pathing_totals(self) -> None:
         payload = {


### PR DESCRIPTION
## Summary
- Suppresses `worker_assignment_gap_sustained` when fresh runtime-summary telemetry shows recovered worker assignments for the same room.
- Loosens runtime-summary room matching for shard-less console summaries so E29N55 console captures can override stale fallback monitor inference.
- Adds regression coverage for the post-#1115 case where bot console task counts are healthy but fallback monitor state carried the old sustained gap.

## Verification
- `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py`
- `python3 scripts/test_screeps_runtime_monitor_tactical_response.py` (36 tests)
- `git diff --check`

Fixes #1116
Refs #1113
