### PR TITLE
fix(agent-os): add scheduler report tripwire

### DIFF
--- a/docs/ops/agent-operating-system.md
+++ b/docs/ops/agent-operating-system.md
@@ -205,6 +205,14 @@ The scheduler runs these phases in order on every invocation:
 5. **Maximize safe parallelism without starvation.** Claim executable `Ready` issues up to capacity using the anti-starvation scheduling contract above: hard P0 incidents first; otherwise the guarded weighted cycle, P2 credit, 24-hour forced-P2 rule, and P1 domain-fairness layer. A 24-hour forced-P2 promotion is subordinate only to hard P0 and cannot be deferred by same-domain P1 gating, normal P1 sequencing, or PR-drain preference when the P2 item has an executable action. For P1, compute oldest executable Ready issue by Domain and serve an aged non-gameplay/owner-visible P1 before creating another new same-domain gameplay lane when the gameplay floor is already satisfied. Within each eligible priority bucket, prefer game-goal work in the order territory > resources > kills, then non-blocking foundation. Default assumption: different roadmap submodules are non-conflicting and should run in parallel via separate worktrees unless a concrete file/runtime/resource conflict is observed.
 6. **Refresh owner-visible state.** Update Issue/Project `Evidence` and `Next action`, write concise scheduler checkpoint output, and trigger/allow typed reporters to refresh roadmap/task views from GitHub state.
 
+Before the scheduler reports a run complete, run the PM defect tripwire against the final report/checkpoint text:
+
+```bash
+python3 scripts/check_scheduler_report_tripwire.py <scheduler-report.txt>
+```
+
+If the tripwire finds P0/P1 action-item, follow-up, blocker, defect, or gap prose without a same-item GitHub issue reference, the scheduler must stop completion reporting, create or update the GitHub issue and Project `screeps` fields, then rerun the check with the issue reference in the report item.
+
 #### Parallelism and conflict policy
 
 Default capacity targets:

--- a/scripts/check_scheduler_report_tripwire.py
+++ b/scripts/check_scheduler_report_tripwire.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Fail scheduler reports that leave P0/P1 action items as untracked prose."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence, TextIO
+
+
+PRIORITY_RE = re.compile(r"\bP([01])\b|\bpriority:p([01])\b", re.IGNORECASE)
+ANY_PRIORITY_RE = re.compile(r"\bP([0-3])\b|\bpriority:p([0-3])\b", re.IGNORECASE)
+ISSUE_REF_RE = re.compile(
+    r"(?<![\w/])#\d+\b|https://github\.com/[^\s)]+/[^\s)]+/issues/\d+\b",
+    re.IGNORECASE,
+)
+HEADING_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*$")
+LIST_ITEM_RE = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+")
+NEGATIVE_STATUS_RE = re.compile(
+    r"(?:\b(?:no|none|zero)\b.{0,80}\b(?:P0|P1|priority:p[01])\b.{0,80}\b"
+    r"(?:action|follow[- ]?up|gap|defect|blocker|untracked|prose[- ]?only)|"
+    r"\b(?:P0|P1|priority:p[01])\b.{0,80}\b(?:no|none|zero)\b.{0,80}\b"
+    r"(?:action|follow[- ]?up|gap|defect|blocker|untracked|prose[- ]?only))",
+    re.IGNORECASE,
+)
+ACTION_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\baction[- ]?items?\b",
+        r"\bfollow[- ]?ups?\b",
+        r"\bnext actions?\b",
+        r"\bTODO\b",
+        r"\bfix(?:es|ed)?\b",
+        r"\brepair(?:s|ed)?\b",
+        r"\bmitigat(?:e|es|ed|ion)\b",
+        r"\bresolv(?:e|es|ed)\b",
+        r"\bblock(?:er|ers|ed|ing)?\b",
+        r"\bgaps?\b",
+        r"\bdefects?\b",
+        r"\bregressions?\b",
+        r"\buntracked\b",
+        r"\bprose[- ]?only\b",
+        r"\bmissing (?:issue|project|github|tracking|work item)\b",
+        r"\bneeds? (?:issue|project|github|tracking|fix|repair|work|follow[- ]?up|"
+        r"owner[- ]?decision|implementation|codex|qa)\b",
+        r"\b(?:create|open|file|update|refresh|track) (?:a |an |the |this )?"
+        r"(?:github )?(?:issue|project item|work item|task|follow[- ]?up)\b",
+    )
+)
+
+
+@dataclass(frozen=True)
+class Block:
+    path: str
+    line: int
+    text: str
+    kind: str
+    context_priority: str | None
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    line: int
+    priority: str
+    phrase: str
+    text: str
+
+
+def priority_label(text: str) -> str | None:
+    match = PRIORITY_RE.search(text)
+    if not match:
+        return None
+    value = match.group(1) or match.group(2)
+    return f"P{value}"
+
+
+def priority_context_from_heading(
+    text: str,
+    *,
+    level: int,
+    previous: str | None,
+    previous_level: int | None,
+) -> tuple[str | None, int | None]:
+    priority = priority_label(text)
+    if priority:
+        return priority, level
+    if ANY_PRIORITY_RE.search(text):
+        return None, None
+    if previous is not None and previous_level is not None and level <= previous_level:
+        return None, None
+    return previous, previous_level
+
+
+def action_phrase(text: str) -> str | None:
+    for pattern in ACTION_PATTERNS:
+        match = pattern.search(text)
+        if match:
+            return match.group(0)
+    return None
+
+
+def compact(text: str, *, limit: int = 180) -> str:
+    rendered = " ".join(text.split())
+    if len(rendered) <= limit:
+        return rendered
+    return rendered[: limit - 3].rstrip() + "..."
+
+
+def iter_blocks(path: str, text: str) -> list[Block]:
+    blocks: list[Block] = []
+    pending_lines: list[str] = []
+    pending_start = 1
+    pending_kind = "paragraph"
+    active_priority: str | None = None
+    active_priority_level: int | None = None
+
+    def flush() -> None:
+        nonlocal pending_lines, pending_start, pending_kind
+        if not pending_lines:
+            return
+        blocks.append(
+            Block(
+                path=path,
+                line=pending_start,
+                text="\n".join(pending_lines),
+                kind=pending_kind,
+                context_priority=active_priority,
+            )
+        )
+        pending_lines = []
+
+    for line_number, raw_line in enumerate(text.splitlines(), start=1):
+        stripped = raw_line.strip()
+        if not stripped:
+            flush()
+            continue
+
+        heading = HEADING_RE.match(raw_line)
+        starts_list_item = LIST_ITEM_RE.match(raw_line) is not None
+        starts_new_block = bool(heading or starts_list_item)
+        if starts_new_block:
+            flush()
+            pending_start = line_number
+            pending_kind = "heading" if heading else "list-item"
+            pending_lines = [raw_line]
+            if heading:
+                active_priority, active_priority_level = priority_context_from_heading(
+                    heading.group(2),
+                    level=len(heading.group(1)),
+                    previous=active_priority,
+                    previous_level=active_priority_level,
+                )
+                flush()
+            continue
+
+        if not pending_lines:
+            pending_start = line_number
+            pending_kind = "paragraph"
+        pending_lines.append(raw_line)
+
+    flush()
+    return blocks
+
+
+def find_untracked_action_items(path: str, text: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for block in iter_blocks(path, text):
+        if block.kind == "heading" or NEGATIVE_STATUS_RE.search(block.text):
+            continue
+        priority = priority_label(block.text) or block.context_priority
+        if priority is None:
+            continue
+        phrase = action_phrase(block.text)
+        if phrase is None or ISSUE_REF_RE.search(block.text):
+            continue
+        findings.append(
+            Finding(
+                path=block.path,
+                line=block.line,
+                priority=priority,
+                phrase=phrase,
+                text=compact(block.text),
+            )
+        )
+    return findings
+
+
+def read_report(path: str, stdin: TextIO) -> str:
+    if path == "-":
+        return stdin.read()
+    return Path(path).read_text(encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Scan scheduler/report text for P0/P1 action-item prose that is not tied "
+            "to a GitHub issue reference."
+        )
+    )
+    parser.add_argument(
+        "reports",
+        nargs="*",
+        default=["-"],
+        help="report text files to scan, or '-' for stdin (default: stdin)",
+    )
+    return parser
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    stdin: TextIO | None = None,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+) -> int:
+    args = build_parser().parse_args(argv)
+    stdin = stdin or sys.stdin
+    stdout = stdout or sys.stdout
+    stderr = stderr or sys.stderr
+
+    findings: list[Finding] = []
+    for report in args.reports:
+        try:
+            findings.extend(find_untracked_action_items(report, read_report(report, stdin)))
+        except OSError as exc:
+            print(f"ERROR: failed to read {report}: {exc}", file=stderr)
+            return 2
+
+    if findings:
+        print("FAIL: scheduler report contains untracked P0/P1 action-item prose", file=stderr)
+        for finding in findings:
+            print(
+                f"ERROR: {finding.path}:{finding.line}: {finding.priority} '{finding.phrase}' "
+                f"needs a same-item GitHub issue reference: {finding.text}",
+                file=stderr,
+            )
+        print(
+            "Create/update the GitHub issue and Project item first, then link the item with "
+            "#<issue> or a GitHub issue URL before reporting completion.",
+            file=stderr,
+        )
+        return 1
+
+    print(f"PASS: scheduler report tripwire ({len(args.reports)} input(s))", file=stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_scheduler_report_tripwire.py
+++ b/scripts/check_scheduler_report_tripwire.py
@@ -14,7 +14,7 @@ from typing import Sequence, TextIO
 PRIORITY_RE = re.compile(r"\bP([01])\b|\bpriority:p([01])\b", re.IGNORECASE)
 ANY_PRIORITY_RE = re.compile(r"\bP([0-3])\b|\bpriority:p([0-3])\b", re.IGNORECASE)
 ISSUE_REF_RE = re.compile(
-    r"(?<![\w/])#\d+\b|https://github\.com/[^\s)]+/[^\s)]+/issues/\d+\b",
+    r"(?<![\w/])#\d+\b|https://github\.com/[^\s)]+/[^\s)]+/(?:issues|pull)/\d+\b",
     re.IGNORECASE,
 )
 HEADING_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*$")
@@ -192,14 +192,14 @@ def find_untracked_action_items(path: str, text: str) -> list[Finding]:
 def read_report(path: str, stdin: TextIO) -> str:
     if path == "-":
         return stdin.read()
-    return Path(path).read_text(encoding="utf-8")
+    return Path(path).read_text(encoding="utf-8", errors="replace")
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
             "Scan scheduler/report text for P0/P1 action-item prose that is not tied "
-            "to a GitHub issue reference."
+            "to a GitHub issue or pull request reference."
         )
     )
     parser.add_argument(
@@ -236,12 +236,12 @@ def main(
         for finding in findings:
             print(
                 f"ERROR: {finding.path}:{finding.line}: {finding.priority} '{finding.phrase}' "
-                f"needs a same-item GitHub issue reference: {finding.text}",
+                f"needs a same-item GitHub issue or pull request reference: {finding.text}",
                 file=stderr,
             )
         print(
             "Create/update the GitHub issue and Project item first, then link the item with "
-            "#<issue> or a GitHub issue URL before reporting completion.",
+            "#<issue>, a GitHub issue URL, or a GitHub pull request URL before reporting completion.",
             file=stderr,
         )
         return 1

--- a/scripts/test_check_scheduler_report_tripwire.py
+++ b/scripts/test_check_scheduler_report_tripwire.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import check_scheduler_report_tripwire as tripwire
+
+
+class SchedulerReportTripwireTest(unittest.TestCase):
+    def test_fails_p1_action_item_without_same_item_issue_reference(self) -> None:
+        report = """## P1 next actions
+- Repair the PM scheduler prose-only completion gap before the next run.
+"""
+
+        findings = tripwire.find_untracked_action_items("report.md", report)
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].line, 2)
+        self.assertEqual(findings[0].priority, "P1")
+        self.assertIn("prose-only", findings[0].text)
+
+    def test_accepts_issue_link_on_same_action_item(self) -> None:
+        report = """## P1 next actions
+- #1108 Repair the PM scheduler prose-only completion gap before the next run.
+- https://github.com/lanyusea/screeps/issues/1028 Refresh the no-prose-only gate evidence.
+"""
+
+        findings = tripwire.find_untracked_action_items("report.md", report)
+
+        self.assertEqual(findings, [])
+
+    def test_fails_inline_p0_gap_even_without_priority_heading(self) -> None:
+        report = "P0 action item: create GitHub issue for stale Project completion evidence.\n"
+
+        findings = tripwire.find_untracked_action_items("-", report)
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].priority, "P0")
+        self.assertIn("action item", findings[0].phrase.lower())
+
+    def test_ignores_lower_priority_and_negative_status_summaries(self) -> None:
+        report = """No P0/P1 action items remain untracked.
+
+## P2 next actions
+- Repair the dashboard placeholder after the current release gate.
+"""
+
+        findings = tripwire.find_untracked_action_items("report.md", report)
+
+        self.assertEqual(findings, [])
+
+    def test_priority_context_does_not_leak_to_sibling_heading(self) -> None:
+        report = """## P1 next actions
+- #1108 Repair the PM scheduler prose-only completion gap.
+
+## Completed
+- Fixed report wording in the posted summary.
+"""
+
+        findings = tripwire.find_untracked_action_items("report.md", report)
+
+        self.assertEqual(findings, [])
+
+    def test_cli_reports_failure_for_stdin(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        exit_code = tripwire.main(
+            ["-"],
+            stdin=io.StringIO("P1 follow-up: track the missing report gate.\n"),
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("FAIL: scheduler report contains untracked P0/P1", stderr.getvalue())
+        self.assertIn("-:1", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_scheduler_report_tripwire.py
+++ b/scripts/test_check_scheduler_report_tripwire.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import io
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -28,6 +29,15 @@ class SchedulerReportTripwireTest(unittest.TestCase):
         report = """## P1 next actions
 - #1108 Repair the PM scheduler prose-only completion gap before the next run.
 - https://github.com/lanyusea/screeps/issues/1028 Refresh the no-prose-only gate evidence.
+"""
+
+        findings = tripwire.find_untracked_action_items("report.md", report)
+
+        self.assertEqual(findings, [])
+
+    def test_accepts_pull_request_link_on_same_action_item(self) -> None:
+        report = """## P1 next actions
+- https://github.com/lanyusea/screeps/pull/1118 Repair the PM scheduler prose-only completion gap before the next run.
 """
 
         findings = tripwire.find_untracked_action_items("report.md", report)
@@ -81,6 +91,22 @@ class SchedulerReportTripwireTest(unittest.TestCase):
         self.assertEqual(stdout.getvalue(), "")
         self.assertIn("FAIL: scheduler report contains untracked P0/P1", stderr.getvalue())
         self.assertIn("-:1", stderr.getvalue())
+
+    def test_cli_replaces_invalid_utf8_file_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report_path = Path(tmpdir) / "report.md"
+            report_path.write_bytes(
+                b"## P1 next actions\n"
+                b"- #1108 Repair invalid byte \xff in the scheduler report.\n"
+            )
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+
+            exit_code = tripwire.main([str(report_path)], stdout=stdout, stderr=stderr)
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("PASS: scheduler report tripwire", stdout.getvalue())
+        self.assertEqual(stderr.getvalue(), "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds `scripts/check_scheduler_report_tripwire.py`, a reusable preflight that flags P0/P1 action-item/prose-only report lines unless they link to concrete GitHub issue numbers.
- Adds focused unit tests for prose-only failure, linked issue exemption, negative/no-gap wording, and priority context scoping.
- Documents the pre-final scheduler command in the agent operating-system runbook.

## Verification
- `python3 -m py_compile scripts/check_scheduler_report_tripwire.py scripts/test_check_scheduler_report_tripwire.py`
- `python3 scripts/test_check_scheduler_report_tripwire.py`
- `git diff --check`

Fixes #1108.
