### PR TITLE
fix(monitor): suppress recovered worker gap recurrence

### DIFF
--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -3409,11 +3409,21 @@ def is_worker_creep(creep: dict[str, Any]) -> bool:
     return role is not None and role.lower() == "worker"
 
 
+def is_worker_assignment_task_type(task_type: str | None) -> bool:
+    return task_type is not None and task_type.strip().lower() in ASSIGNED_WORKER_TASK_NAMES
+
+
 def creep_has_assignment_evidence(creep: dict[str, Any]) -> bool:
-    return creep_role(creep) is not None or creep_task_type(creep) is not None
+    return is_worker_creep(creep) or is_worker_assignment_task_type(creep_task_type(creep))
 
 
-def worker_assignment_evidence_available(owned_creeps: list[dict[str, Any]]) -> bool:
+def worker_assignment_evidence_available(
+    owned_creeps: list[dict[str, Any]],
+    explicit_blocked_workers: list[dict[str, Any]] | None,
+    explicit_blocked_detail: str | None,
+) -> bool:
+    if explicit_blocked_detail is not None or bool(explicit_blocked_workers):
+        return True
     return any(creep_has_assignment_evidence(creep) for creep in owned_creeps)
 
 
@@ -3875,7 +3885,12 @@ def compute_room_summary_metrics(snapshot: RoomSnapshot) -> RoomSummaryMetrics:
     ]
     construction_sites = owned_construction_sites(snapshot)
     task_counts = worker_task_counts(owned_creep_objects)
-    assignment_evidence_available = worker_assignment_evidence_available(owned_creep_objects)
+    info = snapshot.info if isinstance(snapshot.info, dict) else {}
+    assignment_evidence_available = worker_assignment_evidence_available(
+        owned_creep_objects,
+        explicit_worker_assignment_blocked_workers(info),
+        explicit_worker_assignment_blocked_detail(info),
+    )
     pending_build_progress = sum(construction_site_pending_progress(site) for site in construction_sites)
     build_carried_energy = sum(carried_energy(creep) for creep in owned_creep_objects if creep_has_build_task(creep))
     extension_count, extension_capacity_contribution = room_extension_metrics(structures, snapshot.owner)

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -3304,6 +3304,8 @@ def runtime_summary_room_with_metadata(payload: dict[str, Any], path: Path, room
     source = payload.get("source")
     if isinstance(source, str) and source:
         result[RUNTIME_SUMMARY_SOURCE_METADATA_KEY] = source
+    elif path.name.startswith("runtime-summary-monitor-"):
+        result[RUNTIME_SUMMARY_SOURCE_METADATA_KEY] = MONITOR_RUNTIME_SUMMARY_SOURCE
     return result
 
 

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -3424,7 +3424,7 @@ def worker_assignment_evidence_available(
 ) -> bool:
     if explicit_blocked_detail is not None or bool(explicit_blocked_workers):
         return True
-    return any(creep_has_assignment_evidence(creep) for creep in owned_creeps)
+    return not owned_creeps or any(creep_has_assignment_evidence(creep) for creep in owned_creeps)
 
 
 def behavior_pathing_totals(source: dict[str, Any]) -> dict[str, int | float]:

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -3446,7 +3446,7 @@ def worker_assignment_evidence_available(
 ) -> bool:
     if explicit_blocked_detail is not None or bool(explicit_blocked_workers):
         return True
-    return not owned_creeps or any(creep_has_assignment_evidence(creep) for creep in owned_creeps)
+    return any(creep_has_assignment_evidence(creep) for creep in owned_creeps)
 
 
 def behavior_pathing_totals(source: dict[str, Any]) -> dict[str, int | float]:

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -53,6 +53,8 @@ WORKER_ASSIGNMENT_GAP_REQUIRED_TICKS = 100
 WORKER_ASSIGNMENT_GAP_RECOVERY_TICK_TOLERANCE = 0
 RUNTIME_SUMMARY_TICK_METADATA_KEY = "__runtimeSummaryTick"
 RUNTIME_SUMMARY_ARTIFACT_TIMESTAMP_METADATA_KEY = "__runtimeSummaryArtifactTimestamp"
+RUNTIME_SUMMARY_SOURCE_METADATA_KEY = "__runtimeSummarySource"
+MONITOR_RUNTIME_SUMMARY_SOURCE = "screeps-runtime-monitor"
 ASSIGNED_WORKER_TASK_NAMES = ("harvest", "transfer", "build", "repair", "upgrade")
 BUILD_BLOCKED_REASON_PATHS = (
     ("buildBlockedReason",),
@@ -486,6 +488,7 @@ class RoomSummaryMetrics:
     controller_summary: dict[str, Any]
     owned_creep_objects: list[dict[str, Any]]
     task_counts: dict[str, int]
+    worker_assignment_evidence_available: bool
     construction_sites: list[dict[str, Any]]
     pending_build_progress: int | float
     build_carried_energy: int | float
@@ -1482,8 +1485,24 @@ def runtime_assigned_productive_worker_count(room: dict[str, Any]) -> int | floa
     )
 
 
+def runtime_worker_assignment_evidence_available(room: dict[str, Any] | None) -> bool:
+    if not isinstance(room, dict):
+        return True
+    for path in (
+        ("workerAssignmentEvidenceAvailable",),
+        ("resources", "productiveEnergy", "workerAssignmentEvidenceAvailable"),
+        ("productiveEnergy", "workerAssignmentEvidenceAvailable"),
+    ):
+        value = nested_value(room, *path)
+        if isinstance(value, bool):
+            return value
+    return room.get(RUNTIME_SUMMARY_SOURCE_METADATA_KEY) != MONITOR_RUNTIME_SUMMARY_SOURCE
+
+
 def runtime_worker_assignment_recovered(room: dict[str, Any] | None) -> bool:
     if not isinstance(room, dict):
+        return False
+    if not runtime_worker_assignment_evidence_available(room):
         return False
     worker_count = number_value(room.get("workerCount"))
     if worker_count is not None and worker_count <= 0:
@@ -1499,6 +1518,8 @@ def runtime_worker_assignment_recovered(room: dict[str, Any] | None) -> bool:
 
 def runtime_reports_worker_assignment_gap(room: dict[str, Any] | None) -> bool:
     if not isinstance(room, dict):
+        return False
+    if not runtime_worker_assignment_evidence_available(room):
         return False
     return any(nested_value(room, *path) == WORKER_ASSIGNMENT_GAP_BLOCKED_REASON for path in BUILD_BLOCKED_REASON_PATHS)
 
@@ -1556,10 +1577,12 @@ def worker_assignment_gap_active(
     site_count = runtime_construction_site_count(runtime_room)
     if site_count is None:
         site_count = metrics_site_count
-    blocked_reason = runtime_build_blocked_reason(runtime_room) or metrics.build_blocked_reason
+    runtime_assignment_evidence_available = runtime_worker_assignment_evidence_available(runtime_room)
+    runtime_blocked_reason = runtime_build_blocked_reason(runtime_room) if runtime_assignment_evidence_available else None
+    blocked_reason = runtime_blocked_reason or metrics.build_blocked_reason
     if runtime_reports_worker_assignment_gap(runtime_room):
         blocked_reason = WORKER_ASSIGNMENT_GAP_BLOCKED_REASON
-    elif runtime_worker_assignment_gap_recovered(runtime_room):
+    elif runtime_assignment_evidence_available and runtime_worker_assignment_gap_recovered(runtime_room):
         if (
             metrics.build_blocked_reason == WORKER_ASSIGNMENT_GAP_BLOCKED_REASON
             and not runtime_worker_assignment_gap_recovery_is_fresh(runtime_room, current_tick_value)
@@ -3078,6 +3101,7 @@ def room_summary(snapshot: RoomSnapshot, image: str | None = None) -> dict[str, 
         "expected_owner": snapshot.expected_owner,
         "expected_owner_id": snapshot.expected_owner_id,
         "taskCounts": metrics.task_counts,
+        "workerAssignmentEvidenceAvailable": metrics.worker_assignment_evidence_available,
         "pendingBuildProgress": metrics.pending_build_progress,
         "buildCarriedEnergy": metrics.build_carried_energy,
         "constructionDeadlockTicks": metrics.construction_deadlock_ticks,
@@ -3277,6 +3301,9 @@ def runtime_summary_room_with_metadata(payload: dict[str, Any], path: Path, room
     timestamp = runtime_summary_artifact_timestamp(path)
     if timestamp is not None:
         result[RUNTIME_SUMMARY_ARTIFACT_TIMESTAMP_METADATA_KEY] = timestamp
+    source = payload.get("source")
+    if isinstance(source, str) and source:
+        result[RUNTIME_SUMMARY_SOURCE_METADATA_KEY] = source
     return result
 
 
@@ -3380,6 +3407,14 @@ def creep_role(creep: dict[str, Any]) -> str | None:
 def is_worker_creep(creep: dict[str, Any]) -> bool:
     role = creep_role(creep)
     return role is not None and role.lower() == "worker"
+
+
+def creep_has_assignment_evidence(creep: dict[str, Any]) -> bool:
+    return creep_role(creep) is not None or creep_task_type(creep) is not None
+
+
+def worker_assignment_evidence_available(owned_creeps: list[dict[str, Any]]) -> bool:
+    return any(creep_has_assignment_evidence(creep) for creep in owned_creeps)
 
 
 def behavior_pathing_totals(source: dict[str, Any]) -> dict[str, int | float]:
@@ -3760,6 +3795,7 @@ def build_blocked_reason(
     pending_build_progress: int | float,
     construction_site_count: int,
     build_carried_energy: int | float,
+    assignment_evidence_available: bool,
 ) -> str | None:
     if construction_site_count <= 0 or pending_build_progress <= 0:
         return "no_construction_sites"
@@ -3781,6 +3817,8 @@ def build_blocked_reason(
         )
     ):
         return "energy_buffer_blocked"
+    if not assignment_evidence_available:
+        return None
     return "worker_assignment_gap"
 
 
@@ -3788,6 +3826,7 @@ def construction_deadlock_ticks(
     snapshot: RoomSnapshot,
     task_counts: dict[str, int],
     construction_site_count: int,
+    assignment_evidence_available: bool,
 ) -> int | float:
     explicit = first_number_value(
         snapshot.info,
@@ -3798,6 +3837,8 @@ def construction_deadlock_ticks(
     )
     if explicit is not None:
         return explicit
+    if not assignment_evidence_available:
+        return 0
     return 1 if task_counts.get("build", 0) == 0 and construction_site_count > 0 else 0
 
 
@@ -3834,6 +3875,7 @@ def compute_room_summary_metrics(snapshot: RoomSnapshot) -> RoomSummaryMetrics:
     ]
     construction_sites = owned_construction_sites(snapshot)
     task_counts = worker_task_counts(owned_creep_objects)
+    assignment_evidence_available = worker_assignment_evidence_available(owned_creep_objects)
     pending_build_progress = sum(construction_site_pending_progress(site) for site in construction_sites)
     build_carried_energy = sum(carried_energy(creep) for creep in owned_creep_objects if creep_has_build_task(creep))
     extension_count, extension_capacity_contribution = room_extension_metrics(structures, snapshot.owner)
@@ -3849,6 +3891,7 @@ def compute_room_summary_metrics(snapshot: RoomSnapshot) -> RoomSummaryMetrics:
         controller_summary=controller_summary,
         owned_creep_objects=owned_creep_objects,
         task_counts=task_counts,
+        worker_assignment_evidence_available=assignment_evidence_available,
         construction_sites=construction_sites,
         pending_build_progress=pending_build_progress,
         build_carried_energy=build_carried_energy,
@@ -3857,11 +3900,13 @@ def compute_room_summary_metrics(snapshot: RoomSnapshot) -> RoomSummaryMetrics:
             pending_build_progress,
             len(construction_sites),
             build_carried_energy,
+            assignment_evidence_available,
         ),
         construction_deadlock_ticks=construction_deadlock_ticks(
             snapshot,
             task_counts,
             len(construction_sites),
+            assignment_evidence_available,
         ),
         extension_count=extension_count,
         extension_capacity_contribution=extension_capacity_contribution,
@@ -3926,6 +3971,7 @@ def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
         "buildCarriedEnergy": metrics.build_carried_energy,
         "constructionDeadlockTicks": metrics.construction_deadlock_ticks,
         "constructionSiteCount": len(metrics.construction_sites),
+        "workerAssignmentEvidenceAvailable": metrics.worker_assignment_evidence_available,
         "buildBlockedReason": metrics.build_blocked_reason,
         **assignment_blocked_fields,
     }
@@ -3934,6 +3980,7 @@ def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
         "roomName": snapshot.ref.room,
         "shard": snapshot.ref.shard,
         "taskCounts": metrics.task_counts,
+        "workerAssignmentEvidenceAvailable": metrics.worker_assignment_evidence_available,
         "pendingBuildProgress": metrics.pending_build_progress,
         "buildCarriedEnergy": metrics.build_carried_energy,
         "constructionDeadlockTicks": metrics.construction_deadlock_ticks,
@@ -3981,7 +4028,7 @@ def runtime_summary_payload_from_snapshots(snapshots: list[RoomSnapshot]) -> dic
         "tick": max(ticks) if ticks else None,
         "rooms": [runtime_summary_room(snapshot) for snapshot in snapshots],
         "cpu": {"used": cpu_used, "bucket": cpu_bucket},
-        "source": "screeps-runtime-monitor",
+        "source": MONITOR_RUNTIME_SUMMARY_SOURCE,
     }
 
 

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -61,6 +61,21 @@ BUILD_BLOCKED_REASON_PATHS = (
     ("resources", "productiveEnergy", "buildBlockedReason"),
     ("construction", "buildBlockedReason"),
 )
+WORKER_ASSIGNMENT_EVIDENCE_AVAILABLE_PATHS = (
+    ("workerAssignmentEvidenceAvailable",),
+    ("resources", "productiveEnergy", "workerAssignmentEvidenceAvailable"),
+    ("productiveEnergy", "workerAssignmentEvidenceAvailable"),
+)
+WORKER_ASSIGNMENT_BLOCKED_DETAIL_EVIDENCE_PATHS = (
+    ("workerAssignmentBlockedDetail",),
+    ("resources", "productiveEnergy", "workerAssignmentBlockedDetail"),
+    ("productiveEnergy", "workerAssignmentBlockedDetail"),
+)
+WORKER_ASSIGNMENT_BLOCKED_WORKERS_EVIDENCE_PATHS = (
+    ("workerAssignmentBlockedWorkers",),
+    ("resources", "productiveEnergy", "workerAssignmentBlockedWorkers"),
+    ("productiveEnergy", "workerAssignmentBlockedWorkers"),
+)
 WORKER_ASSIGNMENT_BLOCKED_WORKER_STRING_FIELDS = (
     "name",
     "task",
@@ -1488,14 +1503,19 @@ def runtime_assigned_productive_worker_count(room: dict[str, Any]) -> int | floa
 def runtime_worker_assignment_evidence_available(room: dict[str, Any] | None) -> bool:
     if not isinstance(room, dict):
         return True
-    for path in (
-        ("workerAssignmentEvidenceAvailable",),
-        ("resources", "productiveEnergy", "workerAssignmentEvidenceAvailable"),
-        ("productiveEnergy", "workerAssignmentEvidenceAvailable"),
-    ):
+    for path in WORKER_ASSIGNMENT_EVIDENCE_AVAILABLE_PATHS:
         value = nested_value(room, *path)
         if isinstance(value, bool):
             return value
+    for path in WORKER_ASSIGNMENT_BLOCKED_DETAIL_EVIDENCE_PATHS:
+        if string_value(nested_value(room, *path)) is not None:
+            return True
+    for path in WORKER_ASSIGNMENT_BLOCKED_WORKERS_EVIDENCE_PATHS:
+        value = nested_value(room, *path)
+        if not isinstance(value, list):
+            continue
+        if any(sanitized_worker_assignment_blocked_worker(item) is not None for item in value):
+            return True
     return room.get(RUNTIME_SUMMARY_SOURCE_METADATA_KEY) != MONITOR_RUNTIME_SUMMARY_SOURCE
 
 

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -1173,6 +1173,65 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         )
         self.assertEqual(payload["rooms"][0]["resources"]["productiveEnergy"]["constructionDeadlockTicks"], 1)
 
+    def test_runtime_summary_payload_classifies_zero_owned_creep_spawn_deadlock_as_assignment_gap(self) -> None:
+        snapshot = monitor.RoomSnapshot(
+            ref=monitor.RoomRef(shard="shardX", room="E29N55"),
+            terrain="0" * monitor.TERRAIN_CELLS,
+            objects=monitor.normalize_objects(
+                {
+                    "spawn-1": {
+                        "_id": "spawn-1",
+                        "type": "spawn",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "name": "Spawn1",
+                        "hits": 5000,
+                        "hitsMax": 5000,
+                    },
+                    "site-1": {
+                        "_id": "site-1",
+                        "type": "constructionSite",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "structureType": "extension",
+                        "progress": 0,
+                        "progressTotal": 50,
+                    },
+                }
+            ),
+            tick=999274,
+            owner="lanyusea",
+            info={"energyAvailable": 300},
+        )
+
+        payload = monitor.runtime_summary_payload_from_snapshots([snapshot])
+        room = payload["rooms"][0]
+        productive_energy = room["resources"]["productiveEnergy"]
+        summary = monitor.room_summary(snapshot)
+
+        self.assertEqual(summary["owned_spawns"], 1)
+        self.assertEqual(summary["owned_creeps"], 0)
+        self.assertTrue(room["workerAssignmentEvidenceAvailable"])
+        self.assertTrue(productive_energy["workerAssignmentEvidenceAvailable"])
+        self.assertEqual(room["buildBlockedReason"], monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON)
+        self.assertEqual(productive_energy["buildBlockedReason"], monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON)
+        self.assertEqual(room["constructionDeadlockTicks"], 1)
+        self.assertEqual(productive_energy["constructionDeadlockTicks"], 1)
+
+        reason, next_state = monitor.detect_worker_assignment_gap_sustained_reason(
+            snapshot.ref,
+            None,
+            monitor.compute_room_summary_metrics(snapshot),
+            {"start_tick": 999100, "last_tick": 999200, "consecutive_ticks": 100},
+            snapshot.tick,
+        )
+
+        self.assertIsNotNone(reason)
+        assert reason is not None
+        self.assertEqual(reason["kind"], monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND)
+        self.assertEqual(reason["buildBlockedReason"], monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON)
+        self.assertEqual(next_state["consecutive_ticks"], 174)
+
     def test_runtime_summary_payload_does_not_classify_worker_gap_without_assignment_evidence(self) -> None:
         snapshot = monitor.RoomSnapshot(
             ref=monitor.RoomRef(shard="shardX", room="E29N55"),

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -1225,6 +1225,126 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         self.assertEqual(room["constructionDeadlockTicks"], 0)
         self.assertNotIn("buildBlockedReason", room)
         self.assertNotIn("buildBlockedReason", productive_energy)
+        reason, next_state = monitor.detect_worker_assignment_gap_sustained_reason(
+            snapshot.ref,
+            None,
+            monitor.compute_room_summary_metrics(snapshot),
+            {"start_tick": 999100, "last_tick": 999200, "consecutive_ticks": 100},
+            snapshot.tick,
+        )
+        self.assertIsNone(reason)
+        self.assertEqual(next_state, 0)
+
+    def test_runtime_summary_payload_ignores_non_worker_assignment_evidence(self) -> None:
+        snapshot = monitor.RoomSnapshot(
+            ref=monitor.RoomRef(shard="shardX", room="E29N55"),
+            terrain="0" * monitor.TERRAIN_CELLS,
+            objects=monitor.normalize_objects(
+                {
+                    "site-1": {
+                        "_id": "site-1",
+                        "type": "constructionSite",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "structureType": "extension",
+                        "progress": 0,
+                        "progressTotal": 50,
+                    },
+                    "claimer-1": {
+                        "_id": "claimer-1",
+                        "type": "creep",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "name": "claimer-E29N55-1",
+                        "memory": {"role": "claimer", "task": {"type": "claim", "targetId": "controller1"}},
+                        "store": {"energy": 0, "capacity": 0},
+                    },
+                }
+            ),
+            tick=999272,
+            owner="lanyusea",
+            info={"energyAvailable": 333},
+        )
+
+        payload = monitor.runtime_summary_payload_from_snapshots([snapshot])
+        room = payload["rooms"][0]
+        productive_energy = room["resources"]["productiveEnergy"]
+
+        self.assertFalse(room["workerAssignmentEvidenceAvailable"])
+        self.assertFalse(productive_energy["workerAssignmentEvidenceAvailable"])
+        self.assertEqual(
+            room["taskCounts"],
+            {"harvest": 0, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0, "none": 0},
+        )
+        self.assertEqual(room["constructionDeadlockTicks"], 0)
+        self.assertNotIn("buildBlockedReason", room)
+        self.assertNotIn("buildBlockedReason", productive_energy)
+
+    def test_runtime_summary_payload_uses_explicit_blocked_worker_telemetry_as_assignment_evidence(self) -> None:
+        explicit_workers = [
+            {
+                "name": "WorkerA",
+                "task": "upgrade",
+                "carriedEnergy": 50,
+                "freeCapacity": 0,
+                "buildBlockedReason": "build_blocked_controller_progress_preferred",
+                "repairBlockedReason": "repair_blocked_build_backlog_first",
+            }
+        ]
+        snapshot = monitor.RoomSnapshot(
+            ref=monitor.RoomRef(shard="shardX", room="E29N55"),
+            terrain="0" * monitor.TERRAIN_CELLS,
+            objects=monitor.normalize_objects(
+                {
+                    "site-1": {
+                        "_id": "site-1",
+                        "type": "constructionSite",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "structureType": "extension",
+                        "progress": 0,
+                        "progressTotal": 50,
+                    }
+                }
+            ),
+            tick=999273,
+            owner="lanyusea",
+            info={
+                "energyAvailable": 333,
+                "resources": {
+                    "productiveEnergy": {
+                        "workerAssignmentBlockedDetail": "spawn_reserving_energy",
+                        "workerAssignmentBlockedWorkers": explicit_workers,
+                    }
+                },
+            },
+        )
+
+        payload = monitor.runtime_summary_payload_from_snapshots([snapshot])
+        room = payload["rooms"][0]
+        productive_energy = room["resources"]["productiveEnergy"]
+
+        self.assertTrue(room["workerAssignmentEvidenceAvailable"])
+        self.assertTrue(productive_energy["workerAssignmentEvidenceAvailable"])
+        self.assertEqual(room["buildBlockedReason"], monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON)
+        self.assertEqual(productive_energy["buildBlockedReason"], monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON)
+        self.assertEqual(room["constructionDeadlockTicks"], 1)
+        self.assertEqual(productive_energy["constructionDeadlockTicks"], 1)
+        self.assertEqual(room["workerAssignmentBlockedDetail"], "spawn_reserving_energy")
+        self.assertEqual(productive_energy["workerAssignmentBlockedDetail"], "spawn_reserving_energy")
+        self.assertEqual(room["workerAssignmentBlockedWorkers"], explicit_workers)
+        self.assertEqual(productive_energy["workerAssignmentBlockedWorkers"], explicit_workers)
+        reason, next_state = monitor.detect_worker_assignment_gap_sustained_reason(
+            snapshot.ref,
+            None,
+            monitor.compute_room_summary_metrics(snapshot),
+            {"start_tick": 999100, "last_tick": 999200, "consecutive_ticks": 100},
+            snapshot.tick,
+        )
+        self.assertIsNotNone(reason)
+        assert reason is not None
+        self.assertEqual(reason["kind"], monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND)
+        self.assertEqual(next_state["consecutive_ticks"], 173)
 
     def test_runtime_summary_payload_includes_worker_dispatch_diagnostics(self) -> None:
         snapshot = monitor.RoomSnapshot(

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -206,6 +206,7 @@ def make_worker_assignment_gap_metrics() -> monitor.RoomSummaryMetrics:
         controller_summary={},
         owned_creep_objects=[],
         task_counts={"harvest": 0, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0},
+        worker_assignment_evidence_available=True,
         construction_sites=[{"type": "constructionSite"}],
         pending_build_progress=50,
         build_carried_energy=0,
@@ -1141,7 +1142,20 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
                         "structureType": "extension",
                         "progress": 0,
                         "progressTotal": 50,
-                    }
+                    },
+                    "worker-1": {
+                        "_id": "worker-1",
+                        "type": "creep",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "name": "worker-E26S49-1",
+                        "body": [
+                            {"type": "work", "hits": 100},
+                            {"type": "carry", "hits": 100},
+                        ],
+                        "store": {"energy": 0, "capacity": 50},
+                        "memory": {"role": "worker"},
+                    },
                 }
             ),
             tick=265632,
@@ -1158,6 +1172,59 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
             "worker_assignment_gap",
         )
         self.assertEqual(payload["rooms"][0]["resources"]["productiveEnergy"]["constructionDeadlockTicks"], 1)
+
+    def test_runtime_summary_payload_does_not_classify_worker_gap_without_assignment_evidence(self) -> None:
+        snapshot = monitor.RoomSnapshot(
+            ref=monitor.RoomRef(shard="shardX", room="E29N55"),
+            terrain="0" * monitor.TERRAIN_CELLS,
+            objects=monitor.normalize_objects(
+                {
+                    "site-1": {
+                        "_id": "site-1",
+                        "type": "constructionSite",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "structureType": "extension",
+                        "progress": 0,
+                        "progressTotal": 50,
+                    },
+                    "creep-1": {
+                        "_id": "creep-1",
+                        "type": "creep",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "name": "worker-E29N55-1",
+                        "store": {"energy": 12, "capacity": 50},
+                    },
+                    "creep-2": {
+                        "_id": "creep-2",
+                        "type": "creep",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "name": "worker-E29N55-2",
+                        "store": {"energy": 36, "capacity": 50},
+                    },
+                }
+            ),
+            tick=999271,
+            owner="lanyusea",
+            info={"energyAvailable": 333},
+        )
+
+        payload = monitor.runtime_summary_payload_from_snapshots([snapshot])
+        room = payload["rooms"][0]
+        productive_energy = room["resources"]["productiveEnergy"]
+
+        self.assertFalse(room["workerAssignmentEvidenceAvailable"])
+        self.assertFalse(productive_energy["workerAssignmentEvidenceAvailable"])
+        self.assertEqual(
+            room["taskCounts"],
+            {"harvest": 0, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0, "none": 0},
+        )
+        self.assertEqual(room["resources"]["workerCarriedEnergy"], 48)
+        self.assertEqual(room["constructionDeadlockTicks"], 0)
+        self.assertNotIn("buildBlockedReason", room)
+        self.assertNotIn("buildBlockedReason", productive_energy)
 
     def test_runtime_summary_payload_includes_worker_dispatch_diagnostics(self) -> None:
         snapshot = monitor.RoomSnapshot(
@@ -1320,11 +1387,13 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         }
         monitor_payload = {
             "type": "runtime-summary",
+            "source": monitor.MONITOR_RUNTIME_SUMMARY_SOURCE,
             "tick": 995544,
             "rooms": [
                 {
                     "roomName": "E29N55",
                     "shard": "shardX",
+                    "workerAssignmentEvidenceAvailable": True,
                     "workerCount": 3,
                     "taskCounts": {"harvest": 0, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0, "none": 0},
                     "constructionSiteCount": 11,
@@ -1381,11 +1450,13 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         }
         monitor_payload = {
             "type": "runtime-summary",
+            "source": monitor.MONITOR_RUNTIME_SUMMARY_SOURCE,
             "tick": 995544,
             "rooms": [
                 {
                     "roomName": "E29N55",
                     "shard": "shardX",
+                    "workerAssignmentEvidenceAvailable": True,
                     "workerCount": 3,
                     "taskCounts": {"harvest": 0, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0, "none": 0},
                     "constructionSiteCount": 11,
@@ -1481,6 +1552,128 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
                     "start_tick": 988884,
                     "last_tick": 995520,
                     "consecutive_ticks": 6636,
+                }
+            },
+        }
+
+        emitted, suppressed, next_state = monitor.evaluate_room_alert(
+            snapshot,
+            previous_state,
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_room,
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertNotIn(monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND, [reason["kind"] for reason in emitted])
+        self.assertEqual(next_state["rule_counts"][monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND], 0)
+
+    def test_monitor_summary_without_assignment_evidence_does_not_sustain_worker_gap(self) -> None:
+        monitor_payload = {
+            "type": "runtime-summary",
+            "source": monitor.MONITOR_RUNTIME_SUMMARY_SOURCE,
+            "tick": 999271,
+            "rooms": [
+                {
+                    "roomName": "E29N55",
+                    "shard": "shardX",
+                    "taskCounts": {"harvest": 0, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0, "none": 0},
+                    "constructionSiteCount": 9,
+                    "constructionDeadlockTicks": 1,
+                    "buildBlockedReason": monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON,
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_dir = Path(temp_dir)
+            (runtime_dir / "runtime-summary-monitor-20260516T020155Z.log").write_text(
+                "#runtime-summary " + json.dumps(monitor_payload) + "\n",
+                encoding="utf-8",
+            )
+            warnings: list[str] = []
+
+            runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                runtime_dir,
+                [monitor.RoomRef(shard="shardX", room="E29N55")],
+                warnings,
+            )
+
+        self.assertEqual(warnings, [])
+        runtime_room = runtime_rooms["shardX/E29N55"]
+        self.assertEqual(
+            runtime_room[monitor.RUNTIME_SUMMARY_SOURCE_METADATA_KEY],
+            monitor.MONITOR_RUNTIME_SUMMARY_SOURCE,
+        )
+
+        snapshot = monitor.RoomSnapshot(
+            ref=monitor.RoomRef(shard="shardX", room="E29N55"),
+            terrain="0" * monitor.TERRAIN_CELLS,
+            objects=monitor.normalize_objects(
+                {
+                    "spawn1": {
+                        "type": "spawn",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "x": 17,
+                        "y": 24,
+                        "hits": 5000,
+                        "hitsMax": 5000,
+                    },
+                    "extension1": {
+                        "type": "extension",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "x": 18,
+                        "y": 24,
+                        "hits": 1000,
+                        "hitsMax": 1000,
+                    },
+                    "ctrl": {
+                        "type": "controller",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "level": 2,
+                        "x": 5,
+                        "y": 36,
+                    },
+                    "worker-1": {
+                        "type": "creep",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "name": "worker-1",
+                    },
+                    "worker-2": {
+                        "type": "creep",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "name": "worker-2",
+                    },
+                    "site1": {
+                        "type": "constructionSite",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "structureType": "road",
+                        "progress": 0,
+                        "progressTotal": 50,
+                        "x": 19,
+                        "y": 24,
+                    },
+                }
+            ),
+            tick=999274,
+            owner="lanyusea",
+            info={"energyAvailable": 333},
+            expected_owner="lanyusea",
+        )
+        previous_state = {
+            "baseline_established": True,
+            "owner": "lanyusea",
+            "rule_counts": {
+                monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND: {
+                    "start_tick": 988884,
+                    "last_tick": 999271,
+                    "consecutive_ticks": 10387,
                 }
             },
         }

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -1783,6 +1783,7 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
             runtime_room[monitor.RUNTIME_SUMMARY_SOURCE_METADATA_KEY],
             monitor.MONITOR_RUNTIME_SUMMARY_SOURCE,
         )
+        self.assertFalse(monitor.runtime_worker_assignment_evidence_available(runtime_room))
 
         snapshot = monitor.RoomSnapshot(
             ref=monitor.RoomRef(shard="shardX", room="E29N55"),
@@ -1867,6 +1868,183 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         self.assertEqual(suppressed, [])
         self.assertNotIn(monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND, [reason["kind"] for reason in emitted])
         self.assertEqual(next_state["rule_counts"][monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND], 0)
+
+    def test_legacy_monitor_summary_blocked_worker_paths_count_as_assignment_evidence(self) -> None:
+        blocked_worker = {"name": "WorkerA", "task": "upgrade"}
+        cases = {
+            "root detail": {"workerAssignmentBlockedDetail": "spawn_reserving_energy"},
+            "resources workers": {
+                "resources": {"productiveEnergy": {"workerAssignmentBlockedWorkers": [blocked_worker]}}
+            },
+            "legacy productive detail": {
+                "productiveEnergy": {"workerAssignmentBlockedDetail": "spawn_reserving_energy"}
+            },
+        }
+
+        for name, fields in cases.items():
+            with self.subTest(name=name):
+                runtime_room = {
+                    "roomName": "E29N55",
+                    "shard": "shardX",
+                    monitor.RUNTIME_SUMMARY_SOURCE_METADATA_KEY: monitor.MONITOR_RUNTIME_SUMMARY_SOURCE,
+                    **fields,
+                }
+
+                self.assertTrue(monitor.runtime_worker_assignment_evidence_available(runtime_room))
+
+    def test_legacy_monitor_summary_blocked_worker_detail_sustains_worker_gap_alert(self) -> None:
+        blocked_workers = [{"name": "WorkerA", "task": "upgrade", "carriedEnergy": 50}]
+        monitor_payload = {
+            "type": "runtime-summary",
+            "tick": 999274,
+            "rooms": [
+                {
+                    "roomName": "E29N55",
+                    "shard": "shardX",
+                    "taskCounts": {"harvest": 0, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0, "none": 0},
+                    "constructionSiteCount": 9,
+                    "constructionDeadlockTicks": 1,
+                    "resources": {
+                        "productiveEnergy": {
+                            "buildBlockedReason": monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON,
+                            "workerAssignmentBlockedDetail": "spawn_reserving_energy",
+                            "workerAssignmentBlockedWorkers": blocked_workers,
+                        }
+                    },
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_dir = Path(temp_dir)
+            (runtime_dir / "runtime-summary-monitor-20260516T020200Z.log").write_text(
+                "#runtime-summary " + json.dumps(monitor_payload) + "\n",
+                encoding="utf-8",
+            )
+            warnings: list[str] = []
+
+            runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                runtime_dir,
+                [monitor.RoomRef(shard="shardX", room="E29N55")],
+                warnings,
+            )
+
+        self.assertEqual(warnings, [])
+        runtime_room = runtime_rooms["shardX/E29N55"]
+        self.assertNotIn("workerAssignmentEvidenceAvailable", runtime_room)
+        self.assertTrue(monitor.runtime_worker_assignment_evidence_available(runtime_room))
+        self.assertTrue(monitor.runtime_reports_worker_assignment_gap(runtime_room))
+
+        snapshot = monitor.RoomSnapshot(
+            ref=monitor.RoomRef(shard="shardX", room="E29N55"),
+            terrain="0" * monitor.TERRAIN_CELLS,
+            objects=monitor.normalize_objects(
+                {
+                    "spawn1": {
+                        "type": "spawn",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "x": 17,
+                        "y": 24,
+                        "hits": 5000,
+                        "hitsMax": 5000,
+                    },
+                    "extension1": {
+                        "type": "extension",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "x": 18,
+                        "y": 24,
+                        "hits": 1000,
+                        "hitsMax": 1000,
+                    },
+                    "ctrl": {
+                        "type": "controller",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "level": 2,
+                        "x": 5,
+                        "y": 36,
+                    },
+                    "worker-1": {"type": "creep", "my": True, "owner": {"username": "lanyusea"}, "name": "worker-1"},
+                    "worker-2": {"type": "creep", "my": True, "owner": {"username": "lanyusea"}, "name": "worker-2"},
+                    "site1": {
+                        "type": "constructionSite",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "structureType": "road",
+                        "progress": 0,
+                        "progressTotal": 50,
+                        "x": 19,
+                        "y": 24,
+                    },
+                }
+            ),
+            tick=999274,
+            owner="lanyusea",
+            info={"energyAvailable": 333},
+            expected_owner="lanyusea",
+        )
+        previous_state = {
+            "baseline_established": True,
+            "owner": "lanyusea",
+            "rule_counts": {
+                monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND: {
+                    "start_tick": 999100,
+                    "last_tick": 999200,
+                    "consecutive_ticks": 100,
+                }
+            },
+        }
+
+        emitted, suppressed, next_state = monitor.evaluate_room_alert(
+            snapshot,
+            previous_state,
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_room,
+        )
+
+        self.assertEqual(suppressed, [])
+        worker_gap_reasons = [
+            reason for reason in emitted if reason["kind"] == monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND
+        ]
+        self.assertEqual(len(worker_gap_reasons), 1)
+        self.assertEqual(
+            worker_gap_reasons[0]["buildBlockedReason"],
+            monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON,
+        )
+        self.assertEqual(
+            next_state["rule_counts"][monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND]["consecutive_ticks"],
+            174,
+        )
+
+    def test_legacy_monitor_summary_blocked_worker_detail_allows_worker_gap_recovery(self) -> None:
+        runtime_room = {
+            "roomName": "E29N55",
+            "shard": "shardX",
+            monitor.RUNTIME_SUMMARY_SOURCE_METADATA_KEY: monitor.MONITOR_RUNTIME_SUMMARY_SOURCE,
+            monitor.RUNTIME_SUMMARY_TICK_METADATA_KEY: 1101,
+            "workerCount": 3,
+            "taskCounts": {"harvest": 1, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0, "none": 0},
+            "constructionSiteCount": 9,
+            "constructionDeadlockTicks": 0,
+            "workerAssignmentBlockedDetail": "spawn_reserving_energy",
+        }
+
+        self.assertTrue(monitor.runtime_worker_assignment_evidence_available(runtime_room))
+        self.assertTrue(monitor.runtime_worker_assignment_gap_recovered(runtime_room))
+
+        reason, next_state = monitor.detect_worker_assignment_gap_sustained_reason(
+            monitor.RoomRef(shard="shardX", room="E29N55"),
+            runtime_room,
+            make_worker_assignment_gap_metrics(),
+            {"start_tick": 1000, "last_tick": 1100, "consecutive_ticks": 100},
+            1101,
+        )
+
+        self.assertIsNone(reason)
+        self.assertEqual(next_state, 0)
 
     def test_stale_recovered_summary_does_not_clear_newer_worker_assignment_gap(self) -> None:
         console_payload = {

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -1747,10 +1747,9 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         self.assertNotIn(monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND, [reason["kind"] for reason in emitted])
         self.assertEqual(next_state["rule_counts"][monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND], 0)
 
-    def test_monitor_summary_without_assignment_evidence_does_not_sustain_worker_gap(self) -> None:
+    def test_legacy_monitor_summary_without_assignment_evidence_does_not_sustain_worker_gap(self) -> None:
         monitor_payload = {
             "type": "runtime-summary",
-            "source": monitor.MONITOR_RUNTIME_SUMMARY_SOURCE,
             "tick": 999271,
             "rooms": [
                 {

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -1173,7 +1173,7 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         )
         self.assertEqual(payload["rooms"][0]["resources"]["productiveEnergy"]["constructionDeadlockTicks"], 1)
 
-    def test_runtime_summary_payload_classifies_zero_owned_creep_spawn_deadlock_as_assignment_gap(self) -> None:
+    def test_runtime_summary_payload_keeps_zero_owned_creeps_assignment_evidence_free(self) -> None:
         snapshot = monitor.RoomSnapshot(
             ref=monitor.RoomRef(shard="shardX", room="E29N55"),
             terrain="0" * monitor.TERRAIN_CELLS,
@@ -1211,12 +1211,12 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
 
         self.assertEqual(summary["owned_spawns"], 1)
         self.assertEqual(summary["owned_creeps"], 0)
-        self.assertTrue(room["workerAssignmentEvidenceAvailable"])
-        self.assertTrue(productive_energy["workerAssignmentEvidenceAvailable"])
-        self.assertEqual(room["buildBlockedReason"], monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON)
-        self.assertEqual(productive_energy["buildBlockedReason"], monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON)
-        self.assertEqual(room["constructionDeadlockTicks"], 1)
-        self.assertEqual(productive_energy["constructionDeadlockTicks"], 1)
+        self.assertFalse(room["workerAssignmentEvidenceAvailable"])
+        self.assertFalse(productive_energy["workerAssignmentEvidenceAvailable"])
+        self.assertNotIn("buildBlockedReason", room)
+        self.assertNotIn("buildBlockedReason", productive_energy)
+        self.assertEqual(room["constructionDeadlockTicks"], 0)
+        self.assertEqual(productive_energy["constructionDeadlockTicks"], 0)
 
         reason, next_state = monitor.detect_worker_assignment_gap_sustained_reason(
             snapshot.ref,
@@ -1226,11 +1226,45 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
             snapshot.tick,
         )
 
-        self.assertIsNotNone(reason)
-        assert reason is not None
-        self.assertEqual(reason["kind"], monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND)
-        self.assertEqual(reason["buildBlockedReason"], monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON)
-        self.assertEqual(next_state["consecutive_ticks"], 174)
+        self.assertIsNone(reason)
+        self.assertEqual(next_state, 0)
+
+    def test_zero_owned_creeps_without_spawn_still_routes_to_room_dead(self) -> None:
+        snapshot = monitor.RoomSnapshot(
+            ref=monitor.RoomRef(shard="shardX", room="E29N55"),
+            terrain="0" * monitor.TERRAIN_CELLS,
+            objects=monitor.normalize_objects(
+                {
+                    "site-1": {
+                        "_id": "site-1",
+                        "type": "constructionSite",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "structureType": "extension",
+                        "progress": 0,
+                        "progressTotal": 50,
+                    },
+                }
+            ),
+            tick=999274,
+            owner="lanyusea",
+            info={"energyAvailable": 300},
+            expected_owner="lanyusea",
+        )
+
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            snapshot,
+            {"baseline_established": True, "owner": "lanyusea"},
+            now=100,
+            debounce_seconds=300,
+        )
+        report = monitor.build_tactical_response_report({"ok": True, "mode": "alert", "alert": True, "reasons": emitted})
+
+        self.assertEqual(suppressed, [])
+        self.assertIn("room_dead", [reason["kind"] for reason in emitted])
+        self.assertNotIn(monitor.WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND, [reason["kind"] for reason in emitted])
+        self.assertIn("room_dead", report["categories"])
+        self.assertIn("spawn_collapse", report["categories"])
 
     def test_runtime_summary_payload_does_not_classify_worker_gap_without_assignment_evidence(self) -> None:
         snapshot = monitor.RoomSnapshot(


### PR DESCRIPTION
## Summary
- Treat runtime summaries produced by the HTTP monitor itself as lacking authoritative worker-assignment evidence unless they explicitly carry assignment evidence.
- Prevent stale `worker_assignment_gap` state from continuing to emit a P0 alert when the only fresh source is monitor-origin fallback data with no worker assignment telemetry.
- Add regression coverage for recovered console data, stale recovered summaries, and monitor-origin summary snapshots.

## Root-cause classification
This lane classified #1119 as a runtime-monitor false-positive recurrence, not a confirmed production bot assignment failure. The fresh HTTP monitor snapshot had all taskCounts zero, while the latest real console summary showed active `harvest/build/upgrade` tasks. The fix keeps true worker-gap alerts intact when authoritative assignment evidence exists.

## Verification
- `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py`
- `python3 -m pytest scripts/test_screeps_runtime_monitor_tactical_response.py -q` — 45 passed
- `python3 -m pytest scripts/test_screeps_runtime_monitor_tactical_response.py scripts/test_screeps_runtime_summary_console_capture.py -q` — 59 passed
- `git diff --check`

Refs #1119
