### PR TITLE
chore: harden aggressive review triage

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,28 +2,42 @@
 language: en-US
 early_access: false
 
-tone_instructions: "Be concise and direct. Focus on critical correctness, runtime safety, and secret-safety issues."
+# CodeRabbit schema currently supports profile=assertive as the strongest review profile.
+tone_instructions: "Use a Linus Torvalds-style tone: blunt, skeptical, correctness-first, no praise padding. Hunt serious bugs hard; criticize code and failure modes, not people. No profanity/slurs. Separate blockers from advisory noise."
 
 chat:
   auto_reply: true
 
 reviews:
   profile: assertive
-  request_changes_workflow: false
+  request_changes_workflow: true
   high_level_summary: true
+  high_level_summary_instructions: |
+    Skip cheerleading. Summarize the riskiest correctness, runtime, deployment, security, and secret-safety concerns first.
+    If a finding is speculative or advisory, say so plainly instead of presenting it as a required fix.
   high_level_summary_in_walkthrough: true
   poem: false
   review_status: true
-  review_details: false
+  review_details: true
+  commit_status: true
+  fail_commit_status: false
   collapse_walkthrough: true
   changed_files_summary: true
   sequence_diagrams: false
+  estimate_code_review_effort: true
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
+  enable_prompt_for_ai_agents: true
 
   auto_review:
     enabled: true
     drafts: false
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 0
     base_branches:
-      - main
+      - ".*"
     ignore_title_keywords:
       - WIP
       - DO NOT REVIEW
@@ -43,42 +57,55 @@ reviews:
     - "!**/*.gif"
     - "!**/*.svg"
     - "!prod/dist/**"
-    - "!prod/package-lock.json"
 
   path_instructions:
+    - path: "**/*"
+      instructions: |
+        Be aggressive at discovering real failure modes: runtime correctness, deployability, broken tests, secret leaks,
+        unsafe automation, stale operational targets, and high-confidence data/state corruption risks. Do not waste review
+        comments on style, naming, formatting, preference refactors, generic cleanup, or grammar unless they hide a real failure.
+        Treat findings as hypotheses with evidence: state the concrete execution path, affected invariant, and why the issue
+        matters now. Separate critical blockers from advisory/non-blocking observations so Codex can triage honestly.
+
     - path: "prod/src/**/*.{ts,tsx,js,jsx}"
       instructions: |
-        Review only for critical issues likely to break Screeps runtime behavior, deployment, or secret safety.
-        Focus on:
-        - uncaught tick-loop exceptions or code paths that can halt exported loop execution;
-        - CPU/runaway loops, memory corruption, or incompatible Memory schema changes;
-        - spawn/economy deadlocks where the colony cannot recover workers or energy flow;
-        - invalid Screeps API assumptions, body construction, task state, or room/shard/branch handling;
-        - code that exposes auth tokens, room intelligence, or credentials.
-        Do not comment on style, naming, small refactors, or non-critical architecture preferences.
+        Review aggressively for Screeps production failures, especially:
+        - uncaught exported `loop` exceptions or per-tick state corruption;
+        - CPU/runaway loops, stale Memory migrations, incompatible creep/task memory, or broken cleanup;
+        - spawn/economy deadlocks, invalid body construction, `ERR_BUSY` loops, or no worker/energy recovery path;
+        - wrong shard/room/spawn assumptions, including stale room literals outside central strategy configuration;
+        - unsafe official/private-server API assumptions, destructive calls, token exposure, or branch/room targeting errors.
+        Avoid comments for style, naming, micro-optimizations, or broad rewrites unless they directly create one of these failures.
 
     - path: "prod/test/**/*.{ts,tsx,js,jsx}"
       instructions: |
-        Review only for critical test issues: tests that falsely pass despite runtime-breaking behavior,
-        remove coverage for recovery/deployment-critical paths, or make the suite nondeterministic/flaky enough
-        to block safe releases. Ignore style-only or minor organization concerns.
+        Review aggressively for tests that create false confidence: mocks that hide Screeps runtime failures, assertions that
+        no longer protect spawn recovery/deployment/Memory compatibility, nondeterminism that can block safe releases, or tests
+        that encode stale room/shard/spawn assumptions. Ignore organization/style-only test preferences.
 
-    - path: "prod/{package.json,tsconfig*.json,jest.config.cjs}"
+    - path: "prod/{package.json,package-lock.json,tsconfig*.json,jest.config.cjs}"
       instructions: |
-        Review only for critical build/test/deploy breakage: incompatible TypeScript/Jest/esbuild settings,
-        missing Screeps type support, broken npm scripts, or dependency changes that prevent producing a single
-        valid Screeps `main` bundle.
+        Review aggressively for build/test/deploy breakage: incompatible TypeScript/Jest/esbuild settings, missing Screeps
+        type/runtime support, broken npm scripts, lockfile/package drift, dependency supply-chain risk, or anything preventing
+        deterministic `npm ci`, `npm run typecheck`, `npm test -- --runInBand`, or a single valid Screeps `main` bundle.
+
+    - path: ".github/workflows/**/*"
+      instructions: |
+        Review aggressively for CI/deploy hazards: missing required checks, wrong Node/npm install behavior, unsafe permissions,
+        secret exposure, deployment on the wrong branch, stale branch protection assumptions, or checks that can pass while the
+        Screeps bundle/test/typecheck path is broken.
 
     - path: "scripts/**/*"
       instructions: |
-        Review only for critical operational issues: leaked secrets, destructive API calls, incorrect Discord/runtime
-        alert behavior, missing no-alert silence semantics, broken private-server smoke workflow, or unreadable generated
-        room artifacts that would mislead operations.
+        Review aggressively for operational failures: leaked secrets, destructive API calls, wrong branch/shard/room targeting,
+        incorrect Discord/runtime alert routing, alert spam or missed hostile/damage/bot-failure signals, broken private-server
+        smoke workflows, or unreadable/generated room artifacts that would mislead operations.
 
     - path: "docs/**/*"
       instructions: |
-        Review only for critical factual or operational errors that would cause unsafe deployment, wrong shard/room/branch
-        targeting, secret-handling mistakes, or serious context-loss in autonomous execution. Ignore grammar and style.
+        Review only for operationally critical factual errors: stale shard/room/spawn facts, unsafe deployment instructions,
+        secret-handling mistakes, contradictory merge/review gates, or context loss that would cause autonomous agents to make
+        wrong production decisions. Ignore grammar and style.
 
     - path: "AGENT.md"
       instructions: |
@@ -86,17 +113,74 @@ reviews:
 
     - path: "AGENTS.md"
       instructions: |
-        Review for critical contradictions with repository operating rules: worktree-only changes, Codex ownership of
-        `prod/` implementation, secret handling, verification commands, and critical-only review policy.
+        Review for critical contradictions with repository operating rules: worktree-only changes, Codex ownership of `prod/`
+        implementation, secret handling, verification commands, merge gates, and the rule that aggressive automated review is
+        discovery input only. Codex must triage every CodeRabbit/Gemini finding before changing code.
+
+    - path: "docs/ops/codex-skills.md"
+      instructions: |
+        Review for contradictions in Codex review-fix workflow. It must require exact-head review context, per-finding triage,
+        and a real decision before edits: FIX only when valid, reasonable, necessary, actionable, and critical; otherwise resolve
+        as false-positive, stale/outdated, advisory-only, or owner-decision with evidence.
+
+    - path: ".coderabbit.yaml"
+      instructions: |
+        Review for CodeRabbit schema validity and strategy drift. The config should keep assertive issue discovery, Linus-style
+        blunt technical tone, static/security tooling, and explicit safeguards against blindly implementing bot suggestions.
+
+    - path: ".gemini/{config.yaml,styleguide.md}"
+      instructions: |
+        Review for Gemini config/styleguide drift: CRITICAL threshold must remain intentional, current official target is shard
+        `shardX` room `E29N55` with `Spawn1` at `(17,24)`, and Gemini findings must still go through Codex triage before fixes.
+
+  pre_merge_checks:
+    custom_checks:
+      - mode: warning
+        name: Bot feedback triage
+        instructions: |
+          If the PR contains CodeRabbit/Gemini findings, pass only when the PR discussion or body records Codex triage for each
+          active finding: source/thread, classification, criticality, evidence, action, and verification. If no automated review
+          finding exists yet, pass. Do not require code changes for findings classified as false-positive, stale/outdated,
+          advisory-only, or owner-decision.
+      - mode: warning
+        name: Screeps verification evidence
+        instructions: |
+          Pass when the PR records appropriate verification evidence: docs/config-only changes must show YAML/schema or syntax
+          validation; production changes must show `npm run typecheck`, `npm test -- --runInBand`, and `npm run build` from
+          `prod/`. Fail only for missing evidence that would make the merge gate unsafe.
+
+  tools:
+    ast-grep:
+      essential_rules: true
+    shellcheck:
+      enabled: true
+    actionlint:
+      enabled: true
+    yamllint:
+      enabled: true
+    gitleaks:
+      enabled: true
+    trufflehog:
+      enabled: true
+    semgrep:
+      enabled: true
+    osvScanner:
+      enabled: true
 
 knowledge_base:
   learnings:
     scope: auto
   issues:
     scope: auto
+  pull_requests:
+    scope: auto
+  web_search:
+    enabled: true
   code_guidelines:
     enabled: true
     filePatterns:
       - AGENTS.md
       - AGENT.md
       - docs/ops/codex-skills.md
+      - .gemini/styleguide.md
+      - .coderabbit.yaml

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -8,11 +8,13 @@ A critical issue is one that is likely to cause at least one of:
 - Colony unrecoverability, including spawn/economy deadlocks or worker recovery failure.
 - Broken build, typecheck, test, bundling, upload, or official/private-server deployment path.
 - Secret leakage or unsafe handling of Screeps auth tokens, Steam keys, private-server credentials, or API responses.
-- Destructive or wrong-target operations involving branch `main`, shard `shardX`, room `E48S28`, or spawn placement.
+- Destructive or wrong-target operations involving branch `main`, shard `shardX`, room `E29N55`, or `Spawn1` at `(17,24)`.
 - Runtime monitoring false negatives/false positives that could hide hostiles, damage, or bot failure, or spam alert channels.
 - Memory schema/task-state incompatibility that breaks existing Screeps `Memory` or creep behavior.
 
 Do not comment on style, naming, formatting, minor refactors, docs wording, small performance ideas, or speculative architecture unless the issue directly creates a critical risk above.
+
+Gemini comments are discovery input, not repair instructions. Codex must triage every Gemini/CodeRabbit finding against the latest head, tests, Screeps semantics, and `AGENTS.md`; only findings that are valid, necessary, actionable, and critical should produce code changes.
 
 If no critical issue is present, avoid inline comments.
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,5 @@
+# Agent Instructions Pointer
+
+Use `AGENTS.md` as the canonical project instructions for Codex, CodeRabbit, Gemini, Hermes, and other AI agents.
+
+This file intentionally stays short to avoid divergent long-lived rules.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ This repository builds and operates a Screeps: World bot. Use this file as the c
 - Do not edit or commit directly on `main`. Use a topic branch in a git worktree, normally under `~/screeps-worktrees/<topic>`.
 - Production/test/build code changes under `prod/` must be implemented through the Codex CLI coding agent when this project is being operated by Hermes. Hermes may edit docs/config directly, but Codex owns production code implementation commits.
 - A Codex coding task is not complete until the change is verified, committed, pushed, reviewed by the automated review gate, and merged to `main` when it creates a PR. If a PR is superseded, close it with a PR comment explaining the replacement. The review gate uses the owner-approved automated口径: CodeRabbit/Gemini no blocking findings, resolved/outdated discussions, green required checks, and the required elapsed window; formal GitHub approval is not required unless a later owner decision changes it.
-- CodeRabbit may run in assertive/aggressive mode. Treat automated review feedback as input to a Codex triage loop, not as commands to blindly edit code. For every active CodeRabbit/Gemini review body, PR comment, or review thread, provide Codex the exact finding plus current diff/context and have it classify the item as: actionable critical fix, non-critical/advisory, false positive, stale/outdated, or owner-decision needed. Actionable critical findings get the smallest verified patch on the PR branch; non-actionable or stale findings get a concise evidence comment and explicit thread resolution via GitHub/GraphQL after verification. Do not merge while an active automated finding is pending, untriaged, or unresolved.
+- CodeRabbit may run in assertive/aggressive mode. Aggressive automated review is for discovery, not automatic implementation: treat every CodeRabbit/Gemini finding as an allegation until Codex verifies it against the current head, diff context, tests, Screeps semantics, and this severity policy. For every active review body, PR comment, or review thread, provide Codex the exact finding plus current context and require a short triage record: `source/thread`, `classification`, `criticality`, `evidence`, `action`, and `verification`. Classifications are: `FIX`, `RESOLVE_FALSE_POSITIVE`, `RESOLVE_STALE_OR_OUTDATED`, `ADVISORY_ONLY`, or `OWNER_DECISION`. `FIX` means the finding is valid, reasonable, necessary, actionable, and critical; those get the smallest verified patch on the PR branch. Valid but non-critical suggestions remain advisory and must not churn code just to appease a bot. Non-actionable or stale findings get concise evidence and explicit thread resolution via GitHub/GraphQL after verification. Do not merge while an active automated finding is pending, untriaged, or unresolved.
 - **Merge gate — mandatory pre-merge checklist.** Before merging any PR, every autonomous finisher (scheduler, Codex, QA agent, or main agent) MUST:
   1. Compute elapsed time: `now - PR.createdAt`. Reject merge if under 15 minutes. Use `gh pr view <PR> --json createdAt` and compare to current UTC. Do not rely on memory or session clocks — compute fresh each time.
   2. Re-query live checks: `gh pr checks <PR>`. All required checks must be green/pass. Do not merge on stale or cached check state.
@@ -76,11 +76,13 @@ Prioritize issues that can break runtime correctness or safe operations:
 
 ## Review severity policy
 
-For PR review tasks, **only report critical issues**: bugs or risks that are likely to cause data loss, deployment failure, runtime crashes, incorrect gameplay automation, secret leakage, or security exposure.
+For Codex/Hermes PR review tasks, **only report critical issues**: bugs or risks that are likely to cause data loss, deployment failure, runtime crashes, incorrect gameplay automation, secret leakage, or security exposure.
+
+Automated review bots may be configured more assertively to discover candidate risks, but their comments are not repair instructions. Codex/Hermes repair decisions remain critical-only: a finding is fixed only when it is valid, reasonable, necessary, actionable, and critical under this policy.
 
 Do not leave comments for style, formatting, naming, small refactors, documentation phrasing, speculative architecture, or minor test preferences unless they mask a critical failure.
 
-When responding to CodeRabbit assertive/aggressive-mode feedback, do not assume every finding is valid. Codex must state why each item is fixed, resolved as stale/outdated, or resolved as non-actionable before the controller closes the thread/comment.
+When responding to CodeRabbit assertive/aggressive-mode feedback, do not assume every finding is valid. Codex must state why each item is fixed, resolved as false-positive, resolved as stale/outdated, advisory-only, or owner-decision before the controller closes the thread/comment.
 
 When reviewing, use this compact format:
 

--- a/docs/ops/codex-skills.md
+++ b/docs/ops/codex-skills.md
@@ -97,26 +97,27 @@ No critical issues found.
 
 ## Skill 3a — Automated review feedback triage
 
-Use when a PR has CodeRabbit/Gemini comments, review threads, or top-level review bodies, especially while CodeRabbit is in assertive/aggressive mode.
+Use when a PR has CodeRabbit/Gemini comments, review threads, or top-level review bodies, especially while CodeRabbit is in assertive/aggressive mode. Aggressive automated review is for discovery, not automatic implementation: every finding is an allegation until Codex proves it against the latest code and project policy.
 
 Controller workflow:
 
 1. Re-query the live PR head SHA, checks/statuses, comments, reviews, and GraphQL review threads.
-2. Give Codex the exact finding text, URLs/thread IDs, current diff, relevant file context, and project review severity policy.
-3. Require Codex to classify each finding:
-   - `FIX` — critical and actionable; implement the smallest patch and run verification.
+2. Give Codex the exact finding text, URLs/thread IDs, current diff, relevant file context, current test/build status, and project review severity policy.
+3. Require Codex to record for each finding: `source/thread`, `classification`, `criticality`, `evidence`, `action`, and `verification`.
+4. Require Codex to classify each finding:
+   - `FIX` — valid, reasonable, necessary, actionable, and critical; implement the smallest patch and run verification.
    - `RESOLVE_FALSE_POSITIVE` — contradicted by current code/tests/Screeps semantics.
    - `RESOLVE_STALE_OR_OUTDATED` — already fixed on the latest head or no longer applies.
-   - `ADVISORY_ONLY` — style/preference/non-critical optimization that should not churn code.
+   - `ADVISORY_ONLY` — valid or plausible, but non-critical style/preference/optimization/cleanup that should not churn code.
    - `OWNER_DECISION` — would change strategy, reward policy, live deployment, secrets, or another owner-controlled choice.
-4. For `FIX`, keep changes in the PR branch, commit with the required Codex author, push, then rerun controller verification and exact-head QA.
-5. For `RESOLVE_FALSE_POSITIVE`, `RESOLVE_STALE_OR_OUTDATED`, or `ADVISORY_ONLY`, post concise evidence when useful and resolve the GitHub review thread/comment with GraphQL/`gh` after verifying it is safe. Do not add code just to appease a non-critical bot suggestion.
-6. Do not merge while CodeRabbit/Gemini is pending, while a fresh top-level review body contains untriaged actionable language, or while unresolved active review threads remain.
+5. For `FIX`, keep changes in the PR branch, commit with the required Codex author, push, then rerun controller verification and exact-head QA.
+6. For `RESOLVE_FALSE_POSITIVE`, `RESOLVE_STALE_OR_OUTDATED`, or `ADVISORY_ONLY`, post concise evidence when useful and resolve the GitHub review thread/comment with GraphQL/`gh` after verifying it is safe. Do not add code just to appease a non-critical bot suggestion.
+7. Do not merge while CodeRabbit/Gemini is pending, while a fresh top-level review body contains untriaged actionable language, or while unresolved active review threads remain.
 
 Prompt clause for Codex review-fix runs:
 
 ```text
-Triage the automated review feedback first. Not every CodeRabbit/Gemini finding is valid or worth changing. For each finding, classify it as FIX, RESOLVE_FALSE_POSITIVE, RESOLVE_STALE_OR_OUTDATED, ADVISORY_ONLY, or OWNER_DECISION. Only implement FIX items that are critical under AGENTS.md; otherwise explain the evidence the controller should use to resolve the thread/comment without code churn.
+Triage the automated review feedback first. Not every CodeRabbit/Gemini finding is valid, reasonable, necessary, or worth changing. For each finding, record `source/thread`, `classification`, `criticality`, `evidence`, `action`, and `verification`, then classify it as FIX, RESOLVE_FALSE_POSITIVE, RESOLVE_STALE_OR_OUTDATED, ADVISORY_ONLY, or OWNER_DECISION. Only implement FIX items that are valid, actionable, and critical under AGENTS.md; otherwise explain the evidence the controller should use to resolve the thread/comment without code churn.
 ```
 
 ## Skill 4 — Screeps operations/documentation updates


### PR DESCRIPTION
## Summary

- Switch CodeRabbit to a more assertive review strategy: Linus Torvalds-style blunt technical tone, request-changes workflow, incremental reviews without auto-pause, broader base branch coverage, review details, high-risk summary guidance, and static/security tooling.
- Strengthen path instructions so CodeRabbit hunts aggressively for Screeps runtime/deploy/security/state failures while separating blockers from advisory noise.
- Harden Codex triage guardrails in `AGENTS.md` and `docs/ops/codex-skills.md`: every CodeRabbit/Gemini finding must get source/thread, classification, criticality, evidence, action, and verification; only valid/reasonable/necessary/actionable/critical findings become `FIX` code changes.
- Fix stale Gemini target context from `E48S28` to `E29N55` / `Spawn1` `(17,24)` and add the missing `AGENT.md` pointer referenced by review config.

Closes #1123

## Review strategy notes

- CodeRabbit schema currently supports `reviews.profile: assertive` as the strongest valid profile, so this keeps `assertive` rather than inventing an invalid `aggressive` enum.
- `request_changes_workflow: true` makes automated review more forceful, but the repo rules still require Codex triage before any review-fix code change. Bot comments are discovery input, not repair instructions.
- `prod/dist/**` remains excluded because generated bundle drift is better enforced through build verification; `prod/package-lock.json` is now reviewed for dependency/install/supply-chain risks.

## Verification

- `python3` YAML parse for `.coderabbit.yaml` and `.gemini/config.yaml`: PASS
- Live CodeRabbit v2 schema validation for `.coderabbit.yaml`: PASS
- `tone_instructions` length check against schema max 250: PASS (217 chars)
- `git diff --check`: PASS
- `AGENT.md` pointer existence check: PASS

## Merge gate reminder

Do not merge until the repository gate is satisfied in the same run: >=15 minutes since PR creation, live checks green, review threads resolved, merge state current, and Project Evidence/Next action refreshed.
