### PR TITLE
docs: enforce cron registry contract

### DIFF
--- a/docs/ops/agent-operating-system.md
+++ b/docs/ops/agent-operating-system.md
@@ -340,11 +340,13 @@ Behavior:
 
 Purpose: prevent typed channels from going stale when the continuation worker only delivers one final response to `#task-queue`.
 
-Configured reporters:
+Configured reporters use `docs/ops/cron-and-route-registry.md` as the only cadence source of truth. Current registry-backed schedules are:
 
-- `Screeps dev-log fanout reporter` → `discord:#dev-log`, every 20m;
-- `Screeps roadmap fanout reporter` → `discord:#roadmap`, every 20m;
-- `Screeps research-notes fanout reporter` → `discord:#research-notes`, every 20m.
+- `Screeps dev-log fanout reporter` → `discord:#dev-log`, `25,55 * * * *`;
+- `Screeps roadmap fanout reporter` → `discord:#roadmap`, `34 * * * *`;
+- `Screeps research-notes fanout reporter` → `discord:#research-notes`, `10,40 * * * *`.
+
+If live cadence or routing changes, update the cron registry first, then this summary if it is kept as a convenience copy.
 
 Behavior:
 

--- a/docs/ops/agent-operating-system.md
+++ b/docs/ops/agent-operating-system.md
@@ -100,6 +100,7 @@ Subagents must not independently update `#decisions`, `#roadmap`, or `#task-queu
 The main agent must maintain an internal operations monitor that checks:
 
 - scheduled jobs exist and are enabled;
+- live cron metadata matches the expected-state contract in `docs/ops/cron-and-route-registry.md`, verified with `python3 scripts/check_cron_registry.py --strict` when repo access is available;
 - continuation worker is running at the expected cadence, or is intentionally paused for maintenance/migration with that pause mirrored in GitHub Project `Status`, `Evidence`, and `Next action`;
 - checkpoint job exists;
 - job delivery targets are still correct;
@@ -198,7 +199,7 @@ The scheduler remains bounded: it must not wait on long-running Codex/QA process
 
 The scheduler runs these phases in order on every invocation:
 
-1. **Reconcile state.** Inspect `cronjob list`, background processes, `/root/.hermes/screeps-agent-registry.json` when present, git worktrees, open PRs, open roadmap issues, and GitHub Project `screeps` fields. Repair stale GitHub state before dispatching new work.
+1. **Reconcile state.** Inspect `cronjob list`, run or consume the cron-registry diff (`python3 scripts/check_cron_registry.py --strict` when available), inspect background processes, `/root/.hermes/screeps-agent-registry.json` when present, git worktrees, open PRs, open roadmap issues, and GitHub Project `screeps` fields. Repair stale GitHub state and hard P0 cron-registry drift before dispatching new work.
 2. **Close ready loops.** If a PR has completed QA, green required checks, resolved/outdated review threads, and the >=15 minute automated review gate, merge it, fast-forward `/root/screeps`, and set the linked issue/PR Project items to `Done` with evidence.
 3. **Handle completed dev agents.** For each finished dev/Codex process, verify commit/authorship, run required checks, push, create or update the PR, add the PR to Project `screeps`, set issue/PR status to `In review`, and dispatch on-demand QA.
 4. **Handle QA results.** If QA returns `PASS`, update the PR/issue Evidence and move the PR to merge-gate watch. If QA returns `REQUEST_CHANGES`, dispatch a review-fix dev/Codex agent and record the blocker.

--- a/docs/ops/cron-and-route-registry.md
+++ b/docs/ops/cron-and-route-registry.md
@@ -1,9 +1,24 @@
 # Screeps Cron and Route Registry
 
 Last updated: 2026-05-16
-Tracking issue: https://github.com/lanyusea/screeps/issues/620
+Tracking issues: https://github.com/lanyusea/screeps/issues/620, https://github.com/lanyusea/screeps/issues/1122
 
-This registry keeps the minimum cron/channel contract in one place. Cron prompts may embed short self-contained summaries, but their target/cadence/route expectations must match this file.
+This registry is the expected-state contract for Screeps/Hermes cron jobs and Discord delivery routes. It is not passive documentation: P0 monitor, scheduler, and acceptance checks must compare live cron metadata against this file with `scripts/check_cron_registry.py`.
+
+## Registry enforcement policy
+
+- The registry uses **方案 1** from the 2026-05-16 owner decision: keep the registry and make it machine/audit enforced.
+- Live cron metadata (`cronjob list` / `~/.hermes/cron/jobs.json`) says what currently exists; this registry says what should exist.
+- A job missing from live metadata, an unexpected recurring live job, wrong cadence, wrong delivery target, wrong provider/model, wrong repeat policy, wrong workdir, or paused expected job is Agent OS drift.
+- Drift is P0 when it affects scheduler, P0 monitor, runtime alerting, owner-decision routing, deploy/runtime safety, or GitHub/Project reconciliation.
+- Old cron outputs and reporter state files are caches/history, not authority.
+- Before changing any live cron definition, create a rollback snapshot of `~/.hermes/cron/jobs.json` and relevant docs; after changing, run `cronjob list` and `python3 scripts/check_cron_registry.py --strict`.
+
+Verification command:
+
+```bash
+python3 scripts/check_cron_registry.py --strict
+```
 
 ## Current target
 
@@ -41,32 +56,54 @@ Seasonal World reporting is also separate from the persistent/general Discord ro
 
 When using raw IDs and named channels together, this registry is the comparison source. Do not downgrade a thread target to a bare channel. Do not route Seasonal World routine/status/alert traffic into persistent MMO routes unless the message is an explicit cross-link to the Seasonal channel.
 
-## Active cron jobs
+## Expected recurring cron jobs
 
-| Job | ID | Schedule | Delivery | Purpose |
-| --- | --- | --- | --- | --- |
-| Screeps autonomous continuation worker | `f66ed36d7be0` | `8,28,48 * * * *` | `discord:#task-queue` | Dispatcher/reconciler for safe work lanes. Stable workdir: `/root/screeps`. |
-| Screeps P0 agent operations monitor | `75cedbb77150` | `7,37 * * * *` | `discord:1497820688843800776` | P0 autonomous-system health monitor. |
-| Screeps runtime room summary images | `befcbb7b2d60` | `58 * * * *` | `discord:1497588267057680385` | Runtime summary report/images for all owned rooms (auto-discovered via `/api/user/overview`). Include economy KPIs: total resources, energy output/collection, construction progress. |
-| Screeps runtime room alert text check | `1df5ef0c3835` | `1,16,31,46 * * * *` | `discord:1497588512436785284` | Runtime alert/tactical response and autonomous recovery for all owned rooms (auto-discovered via `/api/user/overview`); no-alert runs return exactly `[SILENT]`. |
-| Screeps dev-log fanout reporter | `d3bf35c278d5` | `25,55 * * * *` | `discord:#dev-log` | Dev log fanout from live repo/cron state. |
-| Screeps research-notes fanout reporter | `3c0d20aa2e45` | `10,40 * * * *` | `discord:#research-notes` | Research/RL progress fanout. |
-| Screeps roadmap fanout reporter | `92ca290f7996` | `34 * * * *` | `discord:#roadmap` | Roadmap/Pages image fanout; regenerate and include `runtime-artifacts/rl-dashboard.html` with the roadmap output. |
-| Screeps 6h development report | `dfcaf65d7ea7` | `47 */6 * * *` | `discord:1497587260835758222:1497833662241181746` | 6h health/progress report. |
-| Screeps Gameplay Evolution Review | `c7b3dda8f1ac` | `0 */8 * * *` | `discord:#task-queue` | 8h strategy review for current target `E29N55`. |
-| Screeps Gameplay Evolution Review decisions archive | `dc1c46787f2e` | `15 */8 * * *` | `discord:1497586175580311654` | Archive accepted strategy decisions/current strategy. |
-| Screeps RL flywheel steward | `aed8362e4501` | `17 */6 * * *` | `discord:#task-queue` | P1 RL flywheel progress lane. |
+The table below is machine-read by `scripts/check_cron_registry.py`. Keep one job per row and preserve the column names.
+
+Repeat policy values:
+
+- `forever` — live repeat should be `forever`.
+- `high-horizon` — live repeat may show consumed/limit such as `1276/999999`; the limit must remain high enough for effectively always-on infrastructure.
+- `once` — one-shot jobs only; do not use in this recurring table.
+
+| Job | ID | Schedule | Delivery | Provider | Model | Workdir | Repeat | Criticality | Purpose |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Screeps autonomous continuation worker | `f66ed36d7be0` | `8,28,48 * * * *` | `discord:#task-queue` | `openai-codex` | `gpt-5.5` | `/root/screeps` | `high-horizon` | P0 | Dispatcher/reconciler for safe work lanes. |
+| Screeps P0 agent operations monitor | `75cedbb77150` | `7,37 * * * *` | `discord:1497820688843800776` | `openai-codex` | `gpt-5.5` | `-` | `forever` | P0 | Autonomous-system health monitor and registry-drift detector. |
+| Screeps runtime room alert text check | `1df5ef0c3835` | `1,16,31,46 * * * *` | `discord:1497588512436785284` | `openai-codex` | `gpt-5.5` | `-` | `forever` | P0 | Runtime alert/tactical response for all owned rooms; no-alert runs return exactly `[SILENT]`. |
+| Screeps owner-decision escalation fanout | `bbc7f783075e` | `3,13,23,33,43,53 * * * *` | `discord:1497586175580311654` | `minimax-cn` | `MiniMax-M2.7` | `-` | `high-horizon` | P0 | Mirrors fresh unresolved owner-action decisions to the canonical decisions route. |
+| Screeps runtime room summary images | `befcbb7b2d60` | `58 * * * *` | `discord:1497588267057680385` | `minimax-cn` | `MiniMax-M2.7` | `-` | `high-horizon` | P1 | Runtime summary report/images for all owned rooms. |
+| Screeps console capture (live energy telemetry) | `7ee147327ba6` | `*/30 * * * *` | `local` | `minimax-cn` | `MiniMax-M2.7` | `-` | `forever` | P1 | Local bounded console/energy telemetry collector. |
+| Screeps dev-log fanout reporter | `d3bf35c278d5` | `25,55 * * * *` | `discord:#dev-log` | `minimax-cn` | `MiniMax-M2.7` | `-` | `forever` | P1 | Dev log fanout from live repo/cron state. |
+| Screeps research-notes fanout reporter | `3c0d20aa2e45` | `10,40 * * * *` | `discord:#research-notes` | `minimax-cn` | `MiniMax-M2.7` | `-` | `forever` | P1 | Research/RL progress fanout. |
+| Screeps roadmap fanout reporter | `92ca290f7996` | `34 * * * *` | `discord:#roadmap` | `minimax-cn` | `MiniMax-M2.7` | `-` | `high-horizon` | P1 | Roadmap/Pages image fanout; regenerate roadmap and RL dashboard artifacts. |
+| Screeps 6h development report | `dfcaf65d7ea7` | `47 */6 * * *` | `discord:1497587260835758222:1497833662241181746` | `minimax-cn` | `MiniMax-M2.7` | `-` | `high-horizon` | P1 | Threaded 6h health/progress report. |
+| Screeps Gameplay Evolution Review | `c7b3dda8f1ac` | `0 */8 * * *` | `discord:#task-queue` | `openai-codex` | `gpt-5.5` | `-` | `high-horizon` | P1 | 8h strategy review for current target `E29N55`. |
+| Screeps Gameplay Evolution Review decisions archive | `dc1c46787f2e` | `15 */8 * * *` | `discord:1497586175580311654` | `minimax-cn` | `MiniMax-M2.7` | `-` | `high-horizon` | P1 | Archive accepted strategy decisions/current strategy. |
+| Screeps RL flywheel steward | `aed8362e4501` | `17 */6 * * *` | `discord:#task-queue` | `openai-codex` | `gpt-5.5` | `/root/screeps` | `high-horizon` | P1 | RL flywheel stewardship and issue/Project reconciliation. |
+| Screeps RL shadow-eval pipeline | `d6cff532edd4` | `5 */6 * * *` | `discord:#task-queue` | `deepseek` | `deepseek-v4-pro` | `/root/screeps` | `high-horizon` | P1 | Shadow-eval ledger producer for RL candidate/baseline evidence. |
+| Screeps RL training execution ledger | `5c869e7d8a1d` | `29 */6 * * *` | `discord:#task-queue` | `deepseek` | `deepseek-v4-pro` | `/root/screeps` | `high-horizon` | P1 | Training execution ledger for offline/private RL campaigns. |
+| Screeps RL policy online advantage ledger | `01609968392a` | `43 */6 * * *` | `discord:#task-queue` | `deepseek` | `deepseek-v4-pro` | `/root/screeps` | `high-horizon` | P1 | Online advantage ledger comparing candidate policy signals against baseline. |
+| Hermes state daily backup | `bf68a3951853` | `0 4 * * *` | `local` | `minimax-cn` | `MiniMax-M2.7` | `-` | `forever` | Support | Daily private Hermes-state backup. |
+
+## Transient and retired cron jobs
+
+Transient one-shot jobs must have an expiry condition and tracking issue. They should be removed after execution or after the condition is superseded. A live transient job not listed in the recurring table is still drift unless its issue explicitly says it is active.
+
+| Job | ID | Status | Action |
+| --- | --- | --- | --- |
+| E29N55 postdeploy 15m observation | `6b006603d7fa` | Retired/stale one-shot from E29N55 recovery | Remove after backup; rely on recurring runtime summary/alert and explicit postdeploy artifacts instead. |
 
 ## Cron prompt drift rules
 
 - Every cron prompt that reasons about room state for gameplay/bot-deployment purposes must use `shardX/E29N55` as current target. Runtime monitoring/alerting jobs that auto-discover rooms via API are exempt from single-room targeting.
+- P0 monitor and continuation/scheduler jobs must consult the registry diff before reporting cron health as OK or dispatching unrelated non-urgent work.
 - Roadmap fanout job `92ca290f7996` must run `npm run rl-dashboard` from `/root/screeps` before rendering the roadmap image. Its final output must include the generated `runtime-artifacts/rl-dashboard.html` file in addition to the roadmap snapshot image, using the scheduler's native media attachment directive for the HTML artifact path.
 - Gameplay Evolution cadence is 8h, not 12h.
-- The P0 monitor should audit this registry's expected jobs and should not treat intentional schedule/debug changes as abnormal unless the current registry says they are unhealthy.
 - Reporter state files and old cron outputs are caches/history, not rules authority.
 - When scanning cron output, ignore prompt/system/skill sections unless explicitly auditing historical prompt drift.
 - Cron runs must not recursively schedule new cron jobs.
 - PR-draining/continuation cron prompts must include the CodeRabbit assertive-mode triage rule: use Codex to classify each automated review finding before choosing a patch or thread/comment resolution, and never merge with pending/untriaged CodeRabbit/Gemini feedback.
 - Cron prompt updates require a pre-change snapshot and post-change `cronjob list` verification.
 - Long-lived recurring Screeps jobs should be configured as `forever` or with a very high repeat horizon. A finite `999` cap on critical recurring jobs is abnormal because it can silently stop automation after enough successful runs.
-- Repo/worktree-manipulating cron jobs must keep a stable current directory. Use `/root/screeps` as the default controller cwd, prefer `git -C <path>` or subshells over persistent `cd`, and return to `/root/screeps` before deleting any linked worktree. The 2026-05-05 continuation-worker incident was caused by a deleted `/root/screeps-worktrees/rl-dataset-gate-409` cwd blocking later terminal/file calls in the same cron run.
+- Repo/worktree-manipulating cron jobs must keep a stable current directory. Use `/root/screeps` as the default controller cwd, prefer `git -C <path>` or subshells over persistent `cd`, and return to `/root/screeps` before deleting any linked worktree.

--- a/docs/ops/cron-and-route-registry.md
+++ b/docs/ops/cron-and-route-registry.md
@@ -12,7 +12,7 @@ This registry is the expected-state contract for Screeps/Hermes cron jobs and Di
 - A job missing from live metadata, an unexpected recurring live job, wrong cadence, wrong delivery target, wrong provider/model, wrong repeat policy, wrong workdir, or paused expected job is Agent OS drift.
 - Drift is P0 when it affects scheduler, P0 monitor, runtime alerting, owner-decision routing, deploy/runtime safety, or GitHub/Project reconciliation.
 - Old cron outputs and reporter state files are caches/history, not authority.
-- Before changing any live cron definition, create a rollback snapshot of `~/.hermes/cron/jobs.json` and relevant docs; after changing, run `cronjob list` and `python3 scripts/check_cron_registry.py --strict`.
+- Before changing any live cron definition, create a rollback snapshot of `~/.hermes/cron/jobs.json` and relevant docs; after changing, run `cronjob list` and `python3 scripts/check_cron_registry.py --strict`. Expected recurring jobs are healthy when `enabled=true` and state is either `scheduled` or transiently `running`; paused/disabled/error states are drift unless explicitly documented as an active maintenance window.
 
 Verification command:
 

--- a/docs/ops/cron-and-route-registry.md
+++ b/docs/ops/cron-and-route-registry.md
@@ -66,6 +66,8 @@ Repeat policy values:
 - `high-horizon` — live repeat may show consumed/limit such as `1276/999999`; the limit must remain high enough for effectively always-on infrastructure.
 - `once` — one-shot jobs only; do not use in this recurring table.
 
+`Workdir` uses `-` to mean an explicit expectation that the job has no durable cron workdir. This is different from "unknown": the verifier should flag a live workdir on a `-` row because shared workdirs can serialize otherwise independent jobs behind repo-bound workers.
+
 | Job | ID | Schedule | Delivery | Provider | Model | Workdir | Repeat | Criticality | Purpose |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Screeps autonomous continuation worker | `f66ed36d7be0` | `8,28,48 * * * *` | `discord:#task-queue` | `openai-codex` | `gpt-5.5` | `/root/screeps` | `high-horizon` | P0 | Dispatcher/reconciler for safe work lanes. |
@@ -76,7 +78,7 @@ Repeat policy values:
 | Screeps console capture (live energy telemetry) | `7ee147327ba6` | `*/30 * * * *` | `local` | `minimax-cn` | `MiniMax-M2.7` | `-` | `forever` | P1 | Local bounded console/energy telemetry collector. |
 | Screeps dev-log fanout reporter | `d3bf35c278d5` | `25,55 * * * *` | `discord:#dev-log` | `minimax-cn` | `MiniMax-M2.7` | `-` | `forever` | P1 | Dev log fanout from live repo/cron state. |
 | Screeps research-notes fanout reporter | `3c0d20aa2e45` | `10,40 * * * *` | `discord:#research-notes` | `minimax-cn` | `MiniMax-M2.7` | `-` | `forever` | P1 | Research/RL progress fanout. |
-| Screeps roadmap fanout reporter | `92ca290f7996` | `34 * * * *` | `discord:#roadmap` | `minimax-cn` | `MiniMax-M2.7` | `-` | `high-horizon` | P1 | Roadmap/Pages image fanout; regenerate roadmap and RL dashboard artifacts. |
+| Screeps roadmap fanout reporter | `92ca290f7996` | `34 * * * *` | `discord:#roadmap` | `minimax-cn` | `MiniMax-M2.7` | `-` | `high-horizon` | P1 | Roadmap/Pages image fanout; uses explicit `cd /root/screeps` in its prompt rather than a durable cron workdir. |
 | Screeps 6h development report | `dfcaf65d7ea7` | `47 */6 * * *` | `discord:1497587260835758222:1497833662241181746` | `minimax-cn` | `MiniMax-M2.7` | `-` | `high-horizon` | P1 | Threaded 6h health/progress report. |
 | Screeps Gameplay Evolution Review | `c7b3dda8f1ac` | `0 */8 * * *` | `discord:#task-queue` | `openai-codex` | `gpt-5.5` | `-` | `high-horizon` | P1 | 8h strategy review for current target `E29N55`. |
 | Screeps Gameplay Evolution Review decisions archive | `dc1c46787f2e` | `15 */8 * * *` | `discord:1497586175580311654` | `minimax-cn` | `MiniMax-M2.7` | `-` | `high-horizon` | P1 | Archive accepted strategy decisions/current strategy. |

--- a/docs/ops/cron-registry-enforcement-plan.md
+++ b/docs/ops/cron-registry-enforcement-plan.md
@@ -1,0 +1,149 @@
+# Cron Registry Enforcement and Cron Optimization Plan
+
+Tracking issue: https://github.com/lanyusea/screeps/issues/1122
+Owner decision: 2026-05-16 — keep the cron registry as **方案 1**, an enforced expected-state contract.
+
+## Goal
+
+Make Screeps/Hermes cron operation auditable, recoverable, and self-checking. The registry must not be passive prose. It must define the expected recurring cron surface, and live monitors/schedulers must compare live `cronjob list` / `~/.hermes/cron/jobs.json` against that expected state.
+
+## Scope
+
+This plan covers all current Screeps/Hermes cron optimization goals:
+
+1. **Expected-state baseline** — keep `docs/ops/cron-and-route-registry.md` as the durable contract for expected recurring jobs, delivery routes, cadence, model/provider, repeat policy, and workdir.
+2. **Machine verification** — provide a script that compares the registry against live Hermes cron metadata.
+3. **Prompt/monitor enforcement** — P0 monitor and scheduler must use the registry diff before declaring cron health or dispatching non-urgent work.
+4. **Backup and rollback** — every live cron mutation requires a pre-change snapshot of `~/.hermes/cron/jobs.json`, relevant docs, and git state.
+5. **Safe maintenance** — pause only the jobs that can race with the migration or prompt updates, and always mirror the pause in GitHub Project Evidence / Next action.
+6. **Drift cleanup** — remove stale one-shot/debug jobs; classify local/system jobs explicitly instead of letting them look like unexpected drift.
+7. **Cadence and route sanity** — preserve urgent alert cadence; keep summary/report/ledger jobs staggered; do not merge jobs with different urgency or delivery contracts.
+8. **Provider/model correctness** — registry must state provider+model together, because cron creation can otherwise pin incompatible providers.
+9. **Workdir serialization hygiene** — only jobs that need repo context should use `/root/screeps` workdir; simple local/script jobs should avoid unnecessary repo workdir serialization.
+10. **Final acceptance** — after changes, live cron metadata must match registry, high-risk jobs must be resumed, and at least one post-change monitor/scheduler validation signal must be recorded.
+
+## Non-goals
+
+- No production Screeps bot behavior change under `prod/`.
+- No secrets, auth tokens, or private env contents in docs, comments, logs, or committed files.
+- No broad consolidation of alert + summary jobs; urgency and delivery semantics stay separate.
+- No recursive cron creation from a cron-run session.
+
+## Source-of-truth hierarchy
+
+| Layer | Role |
+| --- | --- |
+| GitHub Issues / Project `screeps` | Source of truth for task state, blockers, evidence, and next action. |
+| Live Hermes cron metadata | Source of truth for what is currently scheduled/enabled/running. |
+| `docs/ops/cron-and-route-registry.md` | Expected-state contract for recurring jobs/routes/cadence. |
+| `scripts/check_cron_registry.py` | Machine diff between live state and expected contract. |
+| Old cron outputs / reporter state files | Historical cache only; never authoritative. |
+
+## Phase plan
+
+### Phase 0 — Safety snapshot and claim
+
+1. Refresh current time, git status, open PRs, active OS processes, and live cron metadata.
+2. Claim #1122 in Project `screeps` as `In progress` with exact Evidence / Next action.
+3. Create rollback snapshot containing:
+   - `~/.hermes/cron/jobs.json`
+   - `docs/ops/cron-and-route-registry.md`
+   - `docs/ops/agent-operating-system.md`
+   - `docs/ops/rules-registry.md`
+   - `AGENTS.md`
+   - safe cron metadata without prompt bodies
+   - git HEAD/status/worktree list
+4. Run the private Hermes state backup, verify the backup repo is clean and pushed.
+5. Only after backup, pause high-risk orchestrators that can race with the migration.
+
+Current Phase 0 evidence for this run:
+
+- Local snapshot: `/root/.hermes/backups/screeps-cron-registry-20260516T041847Z/`
+- `jobs.json` snapshot SHA256: `6efea5855e2505966967aa881e0a8c830e279ab5a566ec166779d184142f8dca`
+- Hermes-state backup commit: `b8a242c`
+- Paused during migration: `f66ed36d7be0`, `75cedbb77150`
+
+### Phase 1 — Registry normalization
+
+1. Replace passive “Active cron jobs” prose with an expected recurring job contract.
+2. Include every current always-on recurring job:
+   - continuation/scheduler
+   - P0 monitor
+   - runtime summary/alert
+   - typed fanouts/reports
+   - gameplay review + archive
+   - RL steward and ledgers
+   - owner-decision fanout
+   - console capture
+   - Hermes state backup
+3. Put one-shot/transient jobs in an explicit transient/retired section, not the recurring contract.
+4. Define repeat policy as `forever`, `high-horizon`, or `once` instead of copying the live consumed-count string.
+5. Define workdir expectations explicitly: `/root/screeps` only where repo context/serialization is needed; `-` where no workdir should be required.
+
+### Phase 2 — Machine verification
+
+1. Add `scripts/check_cron_registry.py`.
+2. Default behavior prints a safe summary and exits 0 so it can be used as cron context.
+3. `--strict` exits nonzero on drift and is used for acceptance checks.
+4. Detect at least:
+   - expected job missing
+   - unexpected live job
+   - disabled/paused expected job
+   - schedule mismatch
+   - delivery mismatch
+   - provider/model mismatch
+   - workdir mismatch
+   - repeat policy mismatch
+5. Store the command in docs and require P0 monitor/scheduler to consult it.
+
+### Phase 3 — Live cron cleanup and prompt/context enforcement
+
+1. Remove stale one-shot jobs only after rollback snapshot exists.
+2. Attach or require registry-diff context for the P0 monitor and scheduler.
+3. Preserve canonical cadence unless there is a separate owner decision:
+   - runtime alert: frequent and silent on no-alert
+   - runtime summary: hourly visual/report
+   - continuation worker: bounded dispatcher cadence
+   - RL ledgers: 6h staggered cadence
+4. Re-run `cronjob list` after every live cron mutation.
+5. Update Project Evidence / Next action with the mutation and rollback path.
+
+### Phase 4 — Validation
+
+Acceptance requires all of these:
+
+1. `python3 scripts/check_cron_registry.py --strict` passes against live `~/.hermes/cron/jobs.json`.
+2. High-risk paused jobs are resumed and show `enabled=true`, `state=scheduled`, future `next_run_at`, and no delivery error.
+3. No stale one-shot/debug cron remains unless explicitly listed as active transient with expiry and tracking issue.
+4. P0 monitor/scheduler have registry-diff context available or an explicit prompt requirement to run the diff.
+5. Repository verification passes:
+   - `python3 -m py_compile scripts/check_cron_registry.py`
+   - `git diff --check`
+6. GitHub #1122 and the PR Project items show current Status, Evidence, and Next action.
+7. A final acceptance report includes backup path, changed files, live cron diff result, paused/resumed jobs, removed stale jobs, and remaining risks.
+
+### Phase 5 — Rollback
+
+If a live cron mutation breaks scheduling or delivery:
+
+1. Pause only the affected job(s).
+2. Restore `~/.hermes/cron/jobs.json` from the local snapshot if required.
+3. Re-run `cronjob list` and compare safe metadata to the snapshot.
+4. Revert repo docs/script through the PR branch or a follow-up revert PR.
+5. Update #1122 Project Evidence / Next action with rollback status.
+6. Resume only after the expected-state diff is clean or the residual drift is intentionally documented.
+
+## Final delivery format
+
+The final report must include:
+
+```text
+Cron optimization acceptance:
+- registry decision: kept/enforced
+- backup: <path + jobs.json sha256 + hermes-state commit>
+- docs/script PR: <PR URL/state>
+- live mutations: <paused/resumed/removed/updated job ids>
+- registry diff: PASS/FAIL + counts
+- scheduler/P0 monitor state: <enabled/state/next_run_at>
+- remaining risk: <none or explicit issue>
+```

--- a/scripts/check_cron_registry.py
+++ b/scripts/check_cron_registry.py
@@ -152,12 +152,16 @@ def compare(expected: Dict[str, Dict[str, Optional[str]]], live: Dict[str, Dict[
         if not job:
             missing_expected.append({"id": jid, "job": spec.get("job")})
             continue
-        if job.get("enabled") is not True or job.get("state") != "scheduled":
+        # A recurring job can be healthy while it is actively executing. Treat
+        # both `scheduled` and `running` as acceptable enabled states so the
+        # monitor does not raise false drift during a legitimate run.
+        healthy_states = {"scheduled", "running"}
+        if job.get("enabled") is not True or job.get("state") not in healthy_states:
             mismatches.append({
                 "id": jid,
                 "job": spec.get("job") or job.get("name"),
                 "field": "enabled/state",
-                "expected": "enabled=true,state=scheduled",
+                "expected": "enabled=true,state in {scheduled,running}",
                 "live": f"enabled={job.get('enabled')},state={job.get('state')}",
             })
         checks = [

--- a/scripts/check_cron_registry.py
+++ b/scripts/check_cron_registry.py
@@ -79,6 +79,8 @@ def parse_registry(path: Path) -> Dict[str, Dict[str, Optional[str]]]:
         jid = empty_to_none(row.get("id"))
         if not jid:
             continue
+        if jid in rows:
+            raise ValueError(f"Duplicate cron job id in registry: {jid}")
         rows[jid] = {
             "job": empty_to_none(row.get("job")),
             "schedule": empty_to_none(row.get("schedule")),

--- a/scripts/check_cron_registry.py
+++ b/scripts/check_cron_registry.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Check live Hermes cron jobs against the Screeps cron registry.
+
+Default mode prints a safe summary and exits 0 so the script can be used as
+scheduled-job context. Use --strict for CI/acceptance: drift exits nonzero.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_REGISTRY = REPO_ROOT / "docs" / "ops" / "cron-and-route-registry.md"
+DEFAULT_JOBS = Path("/root/.hermes/cron/jobs.json")
+EXPECTED_SECTION = "## Expected recurring cron jobs"
+
+
+def strip_md(value: str) -> str:
+    value = value.strip()
+    if value.startswith("`") and value.endswith("`") and len(value) >= 2:
+        value = value[1:-1]
+    return value.strip()
+
+
+def empty_to_none(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    s = str(value).strip()
+    if not s or s == "-" or s.lower() == "null":
+        return None
+    return s
+
+
+def normalize_header(value: str) -> str:
+    return strip_md(value).lower().replace(" ", "_").replace("-", "_")
+
+
+def split_md_row(line: str) -> List[str]:
+    # The registry table intentionally avoids literal pipe characters inside
+    # cells, so a simple split is sufficient and easier to audit.
+    return [c.strip() for c in line.strip().strip("|").split("|")]
+
+
+def parse_registry(path: Path) -> Dict[str, Dict[str, Optional[str]]]:
+    text = path.read_text(encoding="utf-8")
+    in_expected = False
+    headers: Optional[List[str]] = None
+    rows: Dict[str, Dict[str, Optional[str]]] = {}
+
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if line.startswith("## "):
+            in_expected = line.strip() == EXPECTED_SECTION
+            headers = None
+            continue
+        if not in_expected or not line.startswith("|"):
+            continue
+        cols = split_md_row(line)
+        if not cols or all(set(c) <= {"-", ":"} for c in cols):
+            continue
+        if headers is None:
+            headers = [normalize_header(c) for c in cols]
+            continue
+        if len(cols) != len(headers):
+            raise ValueError(f"Malformed registry row has {len(cols)} cells, expected {len(headers)}: {line}")
+        row = {headers[i]: strip_md(cols[i]) for i in range(len(headers))}
+        jid = empty_to_none(row.get("id"))
+        if not jid:
+            continue
+        rows[jid] = {
+            "job": empty_to_none(row.get("job")),
+            "schedule": empty_to_none(row.get("schedule")),
+            "deliver": empty_to_none(row.get("delivery")),
+            "provider": empty_to_none(row.get("provider")),
+            "model": empty_to_none(row.get("model")),
+            "workdir": empty_to_none(row.get("workdir")),
+            "repeat": empty_to_none(row.get("repeat")),
+            "criticality": empty_to_none(row.get("criticality")),
+        }
+    if not rows:
+        raise ValueError(f"No expected cron rows parsed from {path}")
+    return rows
+
+
+def load_live_jobs(path: Path) -> Dict[str, Dict[str, Any]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    jobs = data.get("jobs") if isinstance(data, dict) else data
+    if isinstance(jobs, dict):
+        jobs = list(jobs.values())
+    if not isinstance(jobs, list):
+        raise ValueError(f"Unsupported jobs.json structure in {path}")
+    live: Dict[str, Dict[str, Any]] = {}
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        jid = job.get("id") or job.get("job_id")
+        if jid:
+            live[str(jid)] = job
+    return live
+
+
+def live_schedule(job: Dict[str, Any]) -> Optional[str]:
+    schedule = job.get("schedule")
+    if isinstance(schedule, dict):
+        return empty_to_none(schedule.get("display") or schedule.get("expr") or schedule.get("kind"))
+    return empty_to_none(schedule)
+
+
+def normalize_live_repeat(live_value: Any) -> str:
+    if isinstance(live_value, dict):
+        times = live_value.get("times")
+        completed = live_value.get("completed", 0)
+        if times is None:
+            return "forever"
+        return f"{completed}/{times}"
+    return empty_to_none(live_value) or ""
+
+
+def repeat_matches(expected: Optional[str], live_value: Any) -> Tuple[bool, str]:
+    exp = empty_to_none(expected)
+    live = normalize_live_repeat(live_value)
+    if not exp:
+        return True, live
+    if exp == "forever":
+        return live == "forever", live
+    if exp == "once":
+        return live == "once", live
+    if exp == "high-horizon":
+        if live == "forever":
+            return True, live
+        if live and "/" in live:
+            try:
+                _used, limit = live.split("/", 1)
+                return int(limit) >= 999999, live
+            except ValueError:
+                return False, live
+        return False, live
+    return exp == live, live
+
+
+def compare(expected: Dict[str, Dict[str, Optional[str]]], live: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
+    missing_expected: List[Dict[str, Any]] = []
+    unexpected_live: List[Dict[str, Any]] = []
+    mismatches: List[Dict[str, Any]] = []
+
+    for jid, spec in sorted(expected.items()):
+        job = live.get(jid)
+        if not job:
+            missing_expected.append({"id": jid, "job": spec.get("job")})
+            continue
+        if job.get("enabled") is not True or job.get("state") != "scheduled":
+            mismatches.append({
+                "id": jid,
+                "job": spec.get("job") or job.get("name"),
+                "field": "enabled/state",
+                "expected": "enabled=true,state=scheduled",
+                "live": f"enabled={job.get('enabled')},state={job.get('state')}",
+            })
+        checks = [
+            ("name", spec.get("job"), empty_to_none(job.get("name"))),
+            ("schedule", spec.get("schedule"), live_schedule(job)),
+            ("deliver", spec.get("deliver"), empty_to_none(job.get("deliver"))),
+            ("provider", spec.get("provider"), empty_to_none(job.get("provider"))),
+            ("model", spec.get("model"), empty_to_none(job.get("model"))),
+        ]
+        for field, exp, got in checks:
+            if exp and exp != got:
+                mismatches.append({
+                    "id": jid,
+                    "job": spec.get("job") or job.get("name"),
+                    "field": field,
+                    "expected": exp,
+                    "live": got,
+                })
+        expected_workdir = spec.get("workdir")
+        live_workdir = empty_to_none(job.get("workdir"))
+        if expected_workdir:
+            if expected_workdir != live_workdir:
+                mismatches.append({
+                    "id": jid,
+                    "job": spec.get("job") or job.get("name"),
+                    "field": "workdir",
+                    "expected": expected_workdir,
+                    "live": live_workdir,
+                })
+        elif live_workdir:
+            mismatches.append({
+                "id": jid,
+                "job": spec.get("job") or job.get("name"),
+                "field": "workdir",
+                "expected": None,
+                "live": live_workdir,
+            })
+        ok, live_repeat = repeat_matches(spec.get("repeat"), job.get("repeat"))
+        if not ok:
+            mismatches.append({
+                "id": jid,
+                "job": spec.get("job") or job.get("name"),
+                "field": "repeat",
+                "expected": spec.get("repeat"),
+                "live": live_repeat,
+            })
+
+    for jid, job in sorted(live.items()):
+        if jid not in expected:
+            unexpected_live.append({
+                "id": jid,
+                "job": job.get("name"),
+                "enabled": job.get("enabled"),
+                "state": job.get("state"),
+                "schedule": live_schedule(job),
+                "deliver": job.get("deliver"),
+            })
+
+    status = "PASS" if not missing_expected and not unexpected_live and not mismatches else "FAIL"
+    return {
+        "status": status,
+        "expected_count": len(expected),
+        "live_count": len(live),
+        "missing_expected": missing_expected,
+        "unexpected_live": unexpected_live,
+        "mismatches": mismatches,
+    }
+
+
+def print_text(result: Dict[str, Any]) -> None:
+    print(f"Cron registry check: {result['status']}")
+    print(f"- expected recurring jobs: {result['expected_count']}")
+    print(f"- live jobs: {result['live_count']}")
+    print(f"- missing expected: {len(result['missing_expected'])}")
+    for item in result["missing_expected"]:
+        print(f"  - {item['id']} {item.get('job')}")
+    print(f"- unexpected live: {len(result['unexpected_live'])}")
+    for item in result["unexpected_live"]:
+        print(f"  - {item['id']} {item.get('job')} enabled={item.get('enabled')} state={item.get('state')} schedule={item.get('schedule')}")
+    print(f"- mismatches: {len(result['mismatches'])}")
+    for item in result["mismatches"]:
+        print(f"  - {item['id']} {item.get('job')} {item['field']}: expected={item.get('expected')!r} live={item.get('live')!r}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY)
+    parser.add_argument("--jobs-json", type=Path, default=DEFAULT_JOBS)
+    parser.add_argument("--json", action="store_true", help="print machine-readable JSON")
+    parser.add_argument("--strict", action="store_true", help="exit nonzero on drift")
+    args = parser.parse_args()
+
+    expected = parse_registry(args.registry)
+    live = load_live_jobs(args.jobs_json)
+    result = compare(expected, live)
+
+    if args.json:
+        print(json.dumps(result, indent=2, ensure_ascii=False, sort_keys=True))
+    else:
+        print_text(result)
+
+    if args.strict and result["status"] != "PASS":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_cron_registry.py
+++ b/scripts/check_cron_registry.py
@@ -17,6 +17,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_REGISTRY = REPO_ROOT / "docs" / "ops" / "cron-and-route-registry.md"
 DEFAULT_JOBS = Path("/root/.hermes/cron/jobs.json")
 EXPECTED_SECTION = "## Expected recurring cron jobs"
+NO_WORKDIR = "__NO_DURABLE_CRON_WORKDIR__"
 
 
 def strip_md(value: str) -> str:
@@ -43,6 +44,13 @@ def split_md_row(line: str) -> List[str]:
     # The registry table intentionally avoids literal pipe characters inside
     # cells, so a simple split is sufficient and easier to audit.
     return [c.strip() for c in line.strip().strip("|").split("|")]
+
+
+def normalize_expected_workdir(value: Any) -> Optional[str]:
+    raw = strip_md(str(value)) if value is not None else ""
+    if not raw or raw in {"-", "—"} or raw.lower() == "null":
+        return NO_WORKDIR
+    return raw
 
 
 def parse_registry(path: Path) -> Dict[str, Dict[str, Optional[str]]]:
@@ -77,7 +85,7 @@ def parse_registry(path: Path) -> Dict[str, Dict[str, Optional[str]]]:
             "deliver": empty_to_none(row.get("delivery")),
             "provider": empty_to_none(row.get("provider")),
             "model": empty_to_none(row.get("model")),
-            "workdir": empty_to_none(row.get("workdir")),
+            "workdir": normalize_expected_workdir(row.get("workdir")),
             "repeat": empty_to_none(row.get("repeat")),
             "criticality": empty_to_none(row.get("criticality")),
         }
@@ -89,11 +97,17 @@ def parse_registry(path: Path) -> Dict[str, Dict[str, Optional[str]]]:
 def load_live_jobs(path: Path) -> Dict[str, Dict[str, Any]]:
     data = json.loads(path.read_text(encoding="utf-8"))
     jobs = data.get("jobs") if isinstance(data, dict) else data
+    live: Dict[str, Dict[str, Any]] = {}
     if isinstance(jobs, dict):
-        jobs = list(jobs.values())
+        iterator = jobs.items()
+        for key, job in iterator:
+            if not isinstance(job, dict):
+                continue
+            jid = job.get("id") or job.get("job_id") or key
+            live[str(jid)] = job
+        return live
     if not isinstance(jobs, list):
         raise ValueError(f"Unsupported jobs.json structure in {path}")
-    live: Dict[str, Dict[str, Any]] = {}
     for job in jobs:
         if not isinstance(job, dict):
             continue
@@ -182,7 +196,16 @@ def compare(expected: Dict[str, Dict[str, Optional[str]]], live: Dict[str, Dict[
                 })
         expected_workdir = spec.get("workdir")
         live_workdir = empty_to_none(job.get("workdir"))
-        if expected_workdir:
+        if expected_workdir == NO_WORKDIR:
+            if live_workdir:
+                mismatches.append({
+                    "id": jid,
+                    "job": spec.get("job") or job.get("name"),
+                    "field": "workdir",
+                    "expected": None,
+                    "live": live_workdir,
+                })
+        elif expected_workdir:
             if expected_workdir != live_workdir:
                 mismatches.append({
                     "id": jid,
@@ -191,14 +214,6 @@ def compare(expected: Dict[str, Dict[str, Optional[str]]], live: Dict[str, Dict[
                     "expected": expected_workdir,
                     "live": live_workdir,
                 })
-        elif live_workdir:
-            mismatches.append({
-                "id": jid,
-                "job": spec.get("job") or job.get("name"),
-                "field": "workdir",
-                "expected": None,
-                "live": live_workdir,
-            })
         ok, live_repeat = repeat_matches(spec.get("repeat"), job.get("repeat"))
         if not ok:
             mismatches.append({


### PR DESCRIPTION
## Summary
- Documents the owner-approved cron registry decision: keep registry as an enforced expected-state contract (方案 1).
- Rewrites `docs/ops/cron-and-route-registry.md` so all 17 recurring Hermes cron jobs are represented with expected schedule/delivery/model/provider/workdir metadata.
- Adds `scripts/check_cron_registry.py` to compare live `/root/.hermes/cron/jobs.json` against the registry and report missing, unexpected, and mismatched jobs.
- Updates the Agent OS contract so the scheduler/P0 monitor consume the registry diff during state reconciliation.

## Linked issue
Closes #1122

## Roadmap category
Agent OS / cron registry enforcement

## Safety / rollback
- Pre-change local rollback snapshot: `/root/.hermes/backups/screeps-cron-registry-20260516T041847Z/`.
- Hermes state backup script was run before live cron mutation.
- Stale one-shot cron `6b006603d7fa` was removed only after backup.
- Scheduler `f66ed36d7be0` and P0 monitor `75cedbb77150` are intentionally paused during migration and will be resumed after registry/script acceptance.

## Verification
- `py_compile` for `scripts/check_cron_registry.py` using `/tmp/check_cron_registry.pyc`.
- `python3 scripts/check_cron_registry.py` currently reports exactly the expected maintenance drift: only paused `f66ed36d7be0` and `75cedbb77150`; no missing or unexpected recurring jobs.
- `git diff --check`.

## Acceptance plan after merge
- Fast-forward `/root/screeps` to include the script.
- Attach the registry check script context to the scheduler/P0 monitor where supported.
- Resume `f66ed36d7be0` and `75cedbb77150`.
- Re-run `python3 scripts/check_cron_registry.py --strict`; acceptance requires PASS.
- Observe at least one post-resume cycle/metadata advancement or a manually triggered bounded run with `last_status=ok` and no delivery error.
