### PR TITLE
fix(runtime): expose worker assignment evidence for construction triage

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -34308,15 +34308,22 @@ function buildRoomEventMetricsByRoom(colonies, refillTargetIdsByRoom) {
   return eventMetricsByRoom;
 }
 function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, eventMetrics, includeStructureSnapshot) {
+  const tick = getGameTime30();
   const colonyWorkers = colonyCreeps.filter((creep) => creep.memory.role === "worker");
   const roleCounts = countCreepsByRole(colonyCreeps, colony.room.name);
   const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   const territoryExpansion = buildRuntimeExpansionCandidateReport(colony);
   if (persistOccupationRecommendations) {
-    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime30());
+    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, tick);
   }
   const resources = summarizeResources(colony, colonyWorkers, colonyCreeps, eventMetrics.resources);
   const taskCounts = countWorkerTasks(colonyWorkers);
+  const workerAssignmentEvidence = summarizeWorkerAssignmentEvidence(
+    tick,
+    colonyWorkers.length,
+    taskCounts,
+    resources.productiveEnergy.assignedWorkerCount
+  );
   const constructionDeadlockTicks = getRoomConstructionDeadlockTicks(colony.room);
   return {
     roomName: colony.room.name,
@@ -34324,16 +34331,18 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     energyCapacity: colony.energyCapacityAvailable,
     energyBufferHealth: getRoomEnergyBufferHealth(colony.room),
     workerCount: colonyWorkers.length,
+    workerAssignmentEvidenceAvailable: true,
+    workerAssignmentEvidence,
     ...summarizeWorkerAssignmentBlockedRoomFields(resources.productiveEnergy),
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts,
     constructionSiteCount: resources.productiveEnergy.constructionSiteCount,
     constructionDeadlockTicks,
-    ...summarizeRuntimeBehavior(colonyWorkers, colonyCreeps, getGameTime30()),
+    ...summarizeRuntimeBehavior(colonyWorkers, colonyCreeps, tick),
     ...includeStructureSnapshot ? { structures: summarizeStructures(colony, colonyWorkers) } : {},
-    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime30()),
-    ...summarizeRefillTelemetry(colonyWorkers, getGameTime30()),
-    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime30()),
+    ...summarizeWorkerEfficiency(colonyWorkers, tick),
+    ...summarizeRefillTelemetry(colonyWorkers, tick),
+    ...summarizeSpawnCriticalRefill(colonyWorkers, tick),
     ...buildControllerSummary(colony.room),
     resources,
     combat: summarizeCombat(colony.room, eventMetrics.combat),
@@ -34346,6 +34355,19 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     ...buildTerritoryScoutSummary(colony.room.name),
     ...buildPostClaimBootstrapSummary(colony.room.name)
   };
+}
+function summarizeWorkerAssignmentEvidence(tick, workerCount, taskCounts, productiveAssignmentCount) {
+  return {
+    source: "runtime-summary",
+    available: true,
+    tick,
+    workerCount,
+    assignedTaskCount: sumAssignedWorkerTaskCounts(taskCounts),
+    productiveAssignmentCount
+  };
+}
+function sumAssignedWorkerTaskCounts(taskCounts) {
+  return WORKER_TASK_TYPES.reduce((total, taskType) => total + taskCounts[taskType], 0);
 }
 function summarizeWorkerAssignmentBlockedRoomFields(productiveEnergy) {
   return {
@@ -35089,6 +35111,7 @@ function summarizeProductiveEnergy(colony, colonyWorkers, constructionSites, roo
     events
   );
   return {
+    workerAssignmentEvidenceAvailable: true,
     ...productiveAssignments,
     constructionSiteCount: constructionSites.length,
     constructionDeadlockTicks: getRoomConstructionDeadlockTicks(colony.room),

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -34318,10 +34318,11 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
   }
   const resources = summarizeResources(colony, colonyWorkers, colonyCreeps, eventMetrics.resources);
   const taskCounts = countWorkerTasks(colonyWorkers);
+  const assignedTaskCount = countAssignedWorkerTasks(colonyWorkers);
   const workerAssignmentEvidence = summarizeWorkerAssignmentEvidence(
     tick,
     colonyWorkers.length,
-    taskCounts,
+    assignedTaskCount,
     resources.productiveEnergy.assignedWorkerCount
   );
   const constructionDeadlockTicks = getRoomConstructionDeadlockTicks(colony.room);
@@ -34356,18 +34357,18 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     ...buildPostClaimBootstrapSummary(colony.room.name)
   };
 }
-function summarizeWorkerAssignmentEvidence(tick, workerCount, taskCounts, productiveAssignmentCount) {
+function summarizeWorkerAssignmentEvidence(tick, workerCount, assignedTaskCount, productiveAssignmentCount) {
   return {
     source: "runtime-summary",
     available: true,
     tick,
     workerCount,
-    assignedTaskCount: sumAssignedWorkerTaskCounts(taskCounts),
+    assignedTaskCount,
     productiveAssignmentCount
   };
 }
-function sumAssignedWorkerTaskCounts(taskCounts) {
-  return WORKER_TASK_TYPES.reduce((total, taskType) => total + taskCounts[taskType], 0);
+function countAssignedWorkerTasks(workers) {
+  return workers.reduce((assignedCount, worker) => assignedCount + (getWorkerTaskType(worker) ? 1 : 0), 0);
 }
 function summarizeWorkerAssignmentBlockedRoomFields(productiveEnergy) {
   return {

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -245,6 +245,8 @@ interface RuntimeRoomSummary {
   cpuBucket?: number;
   energyBufferHealth: EnergyBufferHealth;
   workerCount: number;
+  workerAssignmentEvidenceAvailable: true;
+  workerAssignmentEvidence: RuntimeWorkerAssignmentEvidenceSummary;
   workerAssignmentBlockedDetail?: RuntimeWorkerAssignmentBlockedDetail;
   workerAssignmentBlockedWorkers?: RuntimeWorkerAssignmentBlockedWorkerDetail[];
   spawnStatus: RuntimeSpawnStatus[];
@@ -380,6 +382,7 @@ interface RuntimeEnergySurplusSummary {
 }
 
 interface RuntimeProductiveEnergySummary {
+  workerAssignmentEvidenceAvailable: true;
   assignedWorkerCount: number;
   assignedCarriedEnergy: number;
   buildCarriedEnergy: number;
@@ -393,6 +396,15 @@ interface RuntimeProductiveEnergySummary {
   workerAssignmentBlockedDetail?: RuntimeWorkerAssignmentBlockedDetail;
   workerAssignmentBlockedWorkers?: RuntimeWorkerAssignmentBlockedWorkerDetail[];
   controllerProgressRemaining?: number;
+}
+
+interface RuntimeWorkerAssignmentEvidenceSummary {
+  source: 'runtime-summary';
+  available: true;
+  tick: number;
+  workerCount: number;
+  assignedTaskCount: number;
+  productiveAssignmentCount: number;
 }
 
 interface RuntimeWorkerAssignmentBlockedWorkerDetail {
@@ -796,15 +808,22 @@ function summarizeRoom(
   eventMetrics: RuntimeRoomEventMetrics,
   includeStructureSnapshot: boolean
 ): RuntimeRoomSummary {
+  const tick = getGameTime();
   const colonyWorkers = colonyCreeps.filter((creep) => creep.memory.role === 'worker');
   const roleCounts = countCreepsByRole(colonyCreeps, colony.room.name);
   const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   const territoryExpansion = buildRuntimeExpansionCandidateReport(colony);
   if (persistOccupationRecommendations) {
-    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime());
+    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, tick);
   }
   const resources = summarizeResources(colony, colonyWorkers, colonyCreeps, eventMetrics.resources);
   const taskCounts = countWorkerTasks(colonyWorkers);
+  const workerAssignmentEvidence = summarizeWorkerAssignmentEvidence(
+    tick,
+    colonyWorkers.length,
+    taskCounts,
+    resources.productiveEnergy.assignedWorkerCount
+  );
   const constructionDeadlockTicks = getRoomConstructionDeadlockTicks(colony.room);
 
   return {
@@ -813,16 +832,18 @@ function summarizeRoom(
     energyCapacity: colony.energyCapacityAvailable,
     energyBufferHealth: getRoomEnergyBufferHealth(colony.room),
     workerCount: colonyWorkers.length,
+    workerAssignmentEvidenceAvailable: true,
+    workerAssignmentEvidence,
     ...summarizeWorkerAssignmentBlockedRoomFields(resources.productiveEnergy),
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts,
     constructionSiteCount: resources.productiveEnergy.constructionSiteCount,
     constructionDeadlockTicks,
-    ...summarizeRuntimeBehavior(colonyWorkers, colonyCreeps, getGameTime()),
+    ...summarizeRuntimeBehavior(colonyWorkers, colonyCreeps, tick),
     ...(includeStructureSnapshot ? { structures: summarizeStructures(colony, colonyWorkers) } : {}),
-    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime()),
-    ...summarizeRefillTelemetry(colonyWorkers, getGameTime()),
-    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime()),
+    ...summarizeWorkerEfficiency(colonyWorkers, tick),
+    ...summarizeRefillTelemetry(colonyWorkers, tick),
+    ...summarizeSpawnCriticalRefill(colonyWorkers, tick),
     ...buildControllerSummary(colony.room),
     resources,
     combat: summarizeCombat(colony.room, eventMetrics.combat),
@@ -835,6 +856,26 @@ function summarizeRoom(
     ...buildTerritoryScoutSummary(colony.room.name),
     ...buildPostClaimBootstrapSummary(colony.room.name)
   };
+}
+
+function summarizeWorkerAssignmentEvidence(
+  tick: number,
+  workerCount: number,
+  taskCounts: WorkerTaskCounts,
+  productiveAssignmentCount: number
+): RuntimeWorkerAssignmentEvidenceSummary {
+  return {
+    source: 'runtime-summary',
+    available: true,
+    tick,
+    workerCount,
+    assignedTaskCount: sumAssignedWorkerTaskCounts(taskCounts),
+    productiveAssignmentCount
+  };
+}
+
+function sumAssignedWorkerTaskCounts(taskCounts: WorkerTaskCounts): number {
+  return WORKER_TASK_TYPES.reduce((total, taskType) => total + taskCounts[taskType], 0);
 }
 
 function summarizeWorkerAssignmentBlockedRoomFields(
@@ -1988,6 +2029,7 @@ function summarizeProductiveEnergy(
   );
 
   return {
+    workerAssignmentEvidenceAvailable: true,
     ...productiveAssignments,
     constructionSiteCount: constructionSites.length,
     constructionDeadlockTicks: getRoomConstructionDeadlockTicks(colony.room),

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -818,10 +818,11 @@ function summarizeRoom(
   }
   const resources = summarizeResources(colony, colonyWorkers, colonyCreeps, eventMetrics.resources);
   const taskCounts = countWorkerTasks(colonyWorkers);
+  const assignedTaskCount = countAssignedWorkerTasks(colonyWorkers);
   const workerAssignmentEvidence = summarizeWorkerAssignmentEvidence(
     tick,
     colonyWorkers.length,
-    taskCounts,
+    assignedTaskCount,
     resources.productiveEnergy.assignedWorkerCount
   );
   const constructionDeadlockTicks = getRoomConstructionDeadlockTicks(colony.room);
@@ -861,7 +862,7 @@ function summarizeRoom(
 function summarizeWorkerAssignmentEvidence(
   tick: number,
   workerCount: number,
-  taskCounts: WorkerTaskCounts,
+  assignedTaskCount: number,
   productiveAssignmentCount: number
 ): RuntimeWorkerAssignmentEvidenceSummary {
   return {
@@ -869,13 +870,13 @@ function summarizeWorkerAssignmentEvidence(
     available: true,
     tick,
     workerCount,
-    assignedTaskCount: sumAssignedWorkerTaskCounts(taskCounts),
+    assignedTaskCount,
     productiveAssignmentCount
   };
 }
 
-function sumAssignedWorkerTaskCounts(taskCounts: WorkerTaskCounts): number {
-  return WORKER_TASK_TYPES.reduce((total, taskType) => total + taskCounts[taskType], 0);
+function countAssignedWorkerTasks(workers: Creep[]): number {
+  return workers.reduce((assignedCount, worker) => assignedCount + (getWorkerTaskType(worker) ? 1 : 0), 0);
 }
 
 function summarizeWorkerAssignmentBlockedRoomFields(

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -1132,6 +1132,56 @@ describe('runtime telemetry summaries', () => {
     expect(productiveEnergy.buildBlockedReason).toBe('worker_assignment_gap');
   });
 
+  it('counts non-display worker task assignments as assigned runtime evidence', () => {
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      includeEventLog: false
+    });
+    const workers = [
+      makeWorker(
+        { role: 'worker', colony: 'W1N1', task: { type: 'withdraw', targetId: 'storage1' as Id<AnyStoreStructure> } },
+        0,
+        'Withdrawer'
+      ),
+      makeWorker(
+        {
+          role: 'worker',
+          colony: 'W1N1',
+          task: { type: 'pickup', targetId: 'dropped-energy' as Id<Resource<ResourceConstant>> }
+        },
+        0,
+        'Picker'
+      ),
+      makeWorker(
+        {
+          role: 'worker',
+          colony: 'W1N1',
+          task: { type: 'signController', targetId: 'controller1' as Id<StructureController> }
+        },
+        0,
+        'Signer'
+      )
+    ];
+
+    emitRuntimeSummary([colony], workers);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.taskCounts).toMatchObject({
+      build: 0,
+      harvest: 0,
+      none: 3,
+      repair: 0,
+      transfer: 0,
+      upgrade: 0
+    });
+    expect(room.workerAssignmentEvidence).toMatchObject({
+      workerCount: 3,
+      assignedTaskCount: 3,
+      productiveAssignmentCount: 0
+    });
+  });
+
   it('counts visible same-room workers when colony memory is missing', () => {
     const constructionSite = {
       id: 'extension-site',
@@ -1341,6 +1391,19 @@ describe('runtime telemetry summaries', () => {
 
     const payload = parseLoggedSummary();
     const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.taskCounts).toMatchObject({
+      build: 0,
+      harvest: 0,
+      none: 1,
+      repair: 0,
+      transfer: 0,
+      upgrade: 0
+    });
+    expect(room.workerAssignmentEvidence).toMatchObject({
+      workerCount: 1,
+      assignedTaskCount: 1,
+      productiveAssignmentCount: 0
+    });
     expect((room.resources as Record<string, Record<string, unknown>>).productiveEnergy.buildBlockedReason).toBeUndefined();
   });
 

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -89,6 +89,15 @@ describe('runtime telemetry summaries', () => {
             healthy: true
           },
           workerCount: 2,
+          workerAssignmentEvidenceAvailable: true,
+          workerAssignmentEvidence: {
+            source: 'runtime-summary',
+            available: true,
+            tick: RUNTIME_SUMMARY_INTERVAL,
+            workerCount: 2,
+            assignedTaskCount: 1,
+            productiveAssignmentCount: 0
+          },
           spawnStatus: [
             {
               name: 'Spawn1',
@@ -138,6 +147,7 @@ describe('runtime telemetry summaries', () => {
               sourcesMissingContainers: 2
             },
             productiveEnergy: {
+              workerAssignmentEvidenceAvailable: true,
               assignedWorkerCount: 0,
               assignedCarriedEnergy: 0,
               buildCarriedEnergy: 0,
@@ -913,6 +923,7 @@ describe('runtime telemetry summaries', () => {
     const [room] = payload.rooms as Array<Record<string, unknown>>;
     expect(room.taskCounts).toMatchObject({ build: 1, repair: 1, upgrade: 1, transfer: 1, none: 0 });
     expect((room.resources as Record<string, unknown>).productiveEnergy).toEqual({
+      workerAssignmentEvidenceAvailable: true,
       assignedWorkerCount: 3,
       assignedCarriedEnergy: 70,
       buildCarriedEnergy: 40,
@@ -1082,6 +1093,43 @@ describe('runtime telemetry summaries', () => {
     expect((room.resources as Record<string, Record<string, unknown>>).productiveEnergy.buildBlockedReason).toBe(
       'worker_assignment_gap'
     );
+  });
+
+  it('marks zero assigned worker tasks as authoritative runtime evidence', () => {
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      roomName: 'E29N55',
+      includeEventLog: false,
+      constructionSites: [
+        { id: 'extension-site', structureType: TEST_GLOBALS.STRUCTURE_EXTENSION, progress: 0, progressTotal: 50 }
+      ]
+    });
+    const idleWorker = makeWorker({ role: 'worker', colony: 'E29N55' }, 0, 'worker-E29N55-idle');
+
+    emitRuntimeSummary([colony], [idleWorker]);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    const productiveEnergy = (room.resources as Record<string, Record<string, unknown>>).productiveEnergy;
+    expect(room.taskCounts).toMatchObject({
+      build: 0,
+      harvest: 0,
+      none: 1,
+      repair: 0,
+      transfer: 0,
+      upgrade: 0
+    });
+    expect(room.workerAssignmentEvidenceAvailable).toBe(true);
+    expect(room.workerAssignmentEvidence).toEqual({
+      source: 'runtime-summary',
+      available: true,
+      tick: RUNTIME_SUMMARY_INTERVAL,
+      workerCount: 1,
+      assignedTaskCount: 0,
+      productiveAssignmentCount: 0
+    });
+    expect(productiveEnergy.workerAssignmentEvidenceAvailable).toBe(true);
+    expect(productiveEnergy.buildBlockedReason).toBe('worker_assignment_gap');
   });
 
   it('counts visible same-room workers when colony memory is missing', () => {


### PR DESCRIPTION
## Summary
- expose authoritative worker-assignment evidence in runtime summaries so construction backlog triage can distinguish zero assigned worker tasks from missing telemetry
- add an E29N55-style regression covering idle worker + construction backlog evidence
- keep `prod/dist/main.js` synchronized with the TypeScript source

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (98 suites / 1882 tests passed)
- `cd prod && npm run build`

Closes #1127

Post-merge acceptance: observe a fresh runtime summary/Gameplay Evolution Review that reports worker assignment evidence for E29N55 construction backlog triage and confirm follow-up actions no longer depend on stale inferred worker-gap state.