### PR TITLE
fix(territory): keep E29N55 scout intel scout-only

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -16842,6 +16842,9 @@ function getRecommendedTerritoryIntentAction(candidate, recommendation, roleCoun
   if (isAutoClaimApprovedTerritoryCandidate(candidate)) {
     return candidate.intentAction;
   }
+  if (isConfiguredScoutOnlyExpansionCandidate(candidate)) {
+    return "scout";
+  }
   if (candidate.source === "occupationIntent" && isPersistedControllerFollowUpCandidate(candidate)) {
     return candidate.intentAction;
   }
@@ -16864,6 +16867,9 @@ function getRecommendedTerritoryIntentAction(candidate, recommendation, roleCoun
     return "claim";
   }
   return recommendation.action === "reserve" ? "reserve" : candidate.intentAction;
+}
+function isConfiguredScoutOnlyExpansionCandidate(candidate) {
+  return candidate.source === "configuredExpansionScout" && isConfiguredExpansionScoutOnlyTarget(candidate.target.colony, candidate.target.roomName);
 }
 function isUnscoutedAdjacentReservationCandidate(candidate) {
   return isAdjacentRoomReservationReserveSelection(candidate);

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -3152,6 +3152,10 @@ function getRecommendedTerritoryIntentAction(
     return candidate.intentAction;
   }
 
+  if (isConfiguredScoutOnlyExpansionCandidate(candidate)) {
+    return 'scout';
+  }
+
   if (candidate.source === 'occupationIntent' && isPersistedControllerFollowUpCandidate(candidate)) {
     return candidate.intentAction;
   }
@@ -3184,6 +3188,13 @@ function getRecommendedTerritoryIntentAction(
   }
 
   return recommendation.action === 'reserve' ? 'reserve' : candidate.intentAction;
+}
+
+function isConfiguredScoutOnlyExpansionCandidate(candidate: ScoredTerritoryTarget): boolean {
+  return (
+    candidate.source === 'configuredExpansionScout' &&
+    isConfiguredExpansionScoutOnlyTarget(candidate.target.colony, candidate.target.roomName)
+  );
 }
 
 function isUnscoutedAdjacentReservationCandidate(candidate: ScoredTerritoryTarget): boolean {

--- a/prod/test/territory/expansionConfig.test.ts
+++ b/prod/test/territory/expansionConfig.test.ts
@@ -10,8 +10,8 @@ describe('territory expansion config', () => {
     delete (globalThis as { Memory?: Partial<Memory> }).Memory;
   });
 
-  it('derives current-room scout-only neighbors from W3N9 without static tactical literals', () => {
-    expect(getCurrentRoomScoutOnlyAdjacentRoomNames('W3N9')).toEqual(['W3N10', 'W3N8', 'W4N9', 'W2N9']);
+  it('derives current-room scout-only neighbors from E29N55 without static tactical literals', () => {
+    expect(getCurrentRoomScoutOnlyAdjacentRoomNames('E29N55')).toEqual(['E29N56', 'E29N54', 'E28N55', 'E30N55']);
   });
 
   it('derives current-room scout-only neighbors across quadrant edges', () => {
@@ -57,10 +57,10 @@ describe('territory expansion config', () => {
   });
 
   it('merges explicit Memory scout targets with runtime current-room scout-only targets', () => {
-    const room = makeOwnedRoom('W3N9');
+    const room = makeOwnedRoom('E29N55');
     (globalThis as { Game: Partial<Game> }).Game = {
       rooms: {
-        W3N9: room
+        E29N55: room
       },
       spawns: {
         Spawn1: makeSpawn('Spawn1', room)
@@ -68,14 +68,14 @@ describe('territory expansion config', () => {
     };
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       runtime: {
-        currentRoomName: 'W3N9'
+        currentRoomName: 'E29N55'
       },
       territory: {
         expansionScoutTargets: [
           {
-            colony: 'W3N9',
-            roomName: 'W5N9',
-            nearestOwnedRoom: 'W3N9',
+            colony: 'E29N55',
+            roomName: 'E31N55',
+            nearestOwnedRoom: 'E29N55',
             nearestOwnedRoomDistance: 2,
             routeDistance: 2,
             adjacentToOwnedRoom: false
@@ -84,46 +84,46 @@ describe('territory expansion config', () => {
       }
     };
 
-    expect(getTerritoryExpansionScoutTargets('W3N9')).toEqual([
+    expect(getTerritoryExpansionScoutTargets('E29N55')).toEqual([
       {
-        colony: 'W3N9',
-        roomName: 'W5N9',
-        nearestOwnedRoom: 'W3N9',
+        colony: 'E29N55',
+        roomName: 'E31N55',
+        nearestOwnedRoom: 'E29N55',
         nearestOwnedRoomDistance: 2,
         routeDistance: 2,
         adjacentToOwnedRoom: false
       },
       {
-        colony: 'W3N9',
-        roomName: 'W3N10',
-        nearestOwnedRoom: 'W3N9',
+        colony: 'E29N55',
+        roomName: 'E29N56',
+        nearestOwnedRoom: 'E29N55',
         nearestOwnedRoomDistance: 1,
         routeDistance: 1,
         adjacentToOwnedRoom: true,
         scoutOnly: true
       },
       {
-        colony: 'W3N9',
-        roomName: 'W3N8',
-        nearestOwnedRoom: 'W3N9',
+        colony: 'E29N55',
+        roomName: 'E29N54',
+        nearestOwnedRoom: 'E29N55',
         nearestOwnedRoomDistance: 1,
         routeDistance: 1,
         adjacentToOwnedRoom: true,
         scoutOnly: true
       },
       {
-        colony: 'W3N9',
-        roomName: 'W4N9',
-        nearestOwnedRoom: 'W3N9',
+        colony: 'E29N55',
+        roomName: 'E28N55',
+        nearestOwnedRoom: 'E29N55',
         nearestOwnedRoomDistance: 1,
         routeDistance: 1,
         adjacentToOwnedRoom: true,
         scoutOnly: true
       },
       {
-        colony: 'W3N9',
-        roomName: 'W2N9',
-        nearestOwnedRoom: 'W3N9',
+        colony: 'E29N55',
+        roomName: 'E30N55',
+        nearestOwnedRoom: 'E29N55',
         nearestOwnedRoomDistance: 1,
         routeDistance: 1,
         adjacentToOwnedRoom: true,

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -354,6 +354,55 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('keeps stale E29N55 scout-only expansion intel out of reserve planning', () => {
+    const colony = makeSafeColony({ roomName: 'E29N55' });
+    const gameTime = 6_700;
+    const staleIntelUpdatedAt = gameTime - TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS - 1;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      runtime: {
+        currentRoomName: 'E29N55'
+      },
+      territory: {
+        scoutIntel: {
+          'E29N55>E29N54': makeScoutIntel('E29N54', staleIntelUpdatedAt, {
+            colony: 'E29N55',
+            controller: { id: 'controller-E29N54' as Id<StructureController>, my: false }
+          })
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: gameTime,
+      rooms: {
+        E29N55: colony.room
+      },
+      map: {
+        describeExits: jest.fn(() => ({}))
+      } as unknown as GameMap
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, gameTime)
+    ).toEqual({
+      colony: 'E29N55',
+      targetRoom: 'E29N54',
+      action: 'scout'
+    });
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(
+      (Memory.territory?.intents ?? []).filter((intent) => intent.action === 'claim' || intent.action === 'reserve')
+    ).toEqual([]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'E29N55',
+        targetRoom: 'E29N54',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: gameTime
+      }
+    ]);
+  });
+
   it('refreshes stale expansion candidate scout intel before generic adjacent scouting', () => {
     const colony = makeSafeColony();
     const gameTime = 2_000;


### PR DESCRIPTION
## Summary
- preserve configured E29N55 adjacent scout-only expansion targets as scout actions even when stale intel would otherwise promote them into reserve/claim planning
- update scout-only expansion configuration tests to the current official target room
- keep `prod/dist/main.js` synchronized with the TypeScript source

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (98 suites / 1882 tests passed)
- `cd prod && npm run build`

Closes #1128

Post-merge acceptance: after deploy, observe adjacent-room scout intel updates for E29N55 while no reserve/claim intent is created for scout-only neighbors until local recovery/defense gates are satisfied.