### PR TITLE
chore: remove obsolete AGENT.md pointer

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -107,10 +107,6 @@ reviews:
         secret-handling mistakes, contradictory merge/review gates, or context loss that would cause autonomous agents to make
         wrong production decisions. Ignore grammar and style.
 
-    - path: "AGENT.md"
-      instructions: |
-        Ensure this remains only a pointer to `AGENTS.md`; do not duplicate long-lived project instructions here.
-
     - path: "AGENTS.md"
       instructions: |
         Review for critical contradictions with repository operating rules: worktree-only changes, Codex ownership of `prod/`
@@ -180,7 +176,6 @@ knowledge_base:
     enabled: true
     filePatterns:
       - AGENTS.md
-      - AGENT.md
       - docs/ops/codex-skills.md
       - .gemini/styleguide.md
       - .coderabbit.yaml

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -31,4 +31,4 @@ Repository context:
 - Durable docs live under `docs/`.
 - Generated Screeps bundle is `prod/dist/main.js`; it should be produced by `npm run build`, not hand-edited.
 - Expected verification from `prod/`: `npm run typecheck`, `npm test -- --runInBand`, `npm run build`.
-- AI/agent project instructions live in root `AGENTS.md`; singular `AGENT.md` is only a pointer.
+- AI/agent project instructions live in root `AGENTS.md`.

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,5 +1,0 @@
-# Agent Instructions Pointer
-
-Use `AGENTS.md` as the canonical project instructions for Codex, CodeRabbit, Gemini, Hermes, and other AI agents.
-
-This file intentionally stays short to avoid divergent long-lived rules.


### PR DESCRIPTION
## Summary

- Delete the root `AGENT.md` pointer file created in PR #1124.
- Remove active `.coderabbit.yaml` references to `AGENT.md` from path instructions and `knowledge_base.code_guidelines.filePatterns`.
- Update `.gemini/styleguide.md` so it only names `AGENTS.md` as the agent instruction source.
- Corrected Hermes memory and the local `vibe-coding-review-configs` skill so this pointer is not recreated for Screeps.

Closes #1132

## Rationale

The owner confirmed no Screeps agent depends on `AGENT.md`; all agents use `AGENTS.md`. The prior pointer was unnecessary noise and a mistake.

## Verification

- `.coderabbit.yaml` YAML parse: PASS
- `.gemini/config.yaml` YAML parse: PASS
- Live CodeRabbit v2 schema validation for `.coderabbit.yaml`: PASS
- `AGENT.md` root existence check: PASS (absent)
- Active repository `AGENT.md` reference scan excluding generated historical `docs/roadmap-data.json`: PASS (none)
- `git diff --check`: PASS

## Merge gate reminder

Do not merge until the repository gate is satisfied in the same run: >=15 minutes since PR creation, live checks green, review threads resolved, merge state current, and Project Evidence/Next action refreshed.
