### PR TITLE
fix(defense): gate E29N55 bootstrap on defense floor

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1534,7 +1534,7 @@ function isBootstrapDefenseFloorSatisfiedForTerritory(room) {
   return assessBootstrapDefenseFloorReadiness(room).ready;
 }
 function shouldUseBootstrapDefenseFloorRepairCap(room) {
-  return shouldGateTerritoryOnBootstrapDefenseFloor(room);
+  return shouldGateTerritoryOnBootstrapDefenseFloor(room) && !hasVisibleHostilePresence(room);
 }
 function buildDefenderBody(energyAvailable, hostileCount) {
   const desiredPatternCount = Math.max(
@@ -1849,6 +1849,9 @@ function getBootstrapDefenseFloorLookups(room) {
 }
 function canAssessBootstrapDefenseFloor(room) {
   return typeof room.find === "function" && getGlobalNumber2("FIND_STRUCTURES") !== null && getGlobalNumber2("FIND_CONSTRUCTION_SITES") !== null;
+}
+function hasVisibleHostilePresence(room) {
+  return findRoomObjects3(room, "FIND_HOSTILE_CREEPS").length > 0 || findRoomObjects3(room, "FIND_HOSTILE_STRUCTURES").length > 0;
 }
 function createBootstrapDefenseFloorLookups(room) {
   const structures = findRoomObjects3(room, "FIND_STRUCTURES").filter((structure) => isPositionInRoom(structure.pos, room.name));
@@ -2962,7 +2965,7 @@ function assessColonyStage(input) {
   const survivalWorkerFloor = Math.max(1, Math.min(BOOTSTRAP_WORKER_FLOOR, Math.max(workerTarget, 1)));
   const hostilePresence = ((_d = input.hostileCreepCount) != null ? _d : 0) > 0 || ((_e = input.hostileStructureCount) != null ? _e : 0) > 0;
   const controllerDowngradeGuard = isControllerDowngradeGuardActive(input.controller);
-  const defenseFloorReady = input.defenseFloorReady !== false;
+  const defenseFloorReady = input.defenseFloorReady === true;
   const bootstrapCreepFloor = totalCreeps < BOOTSTRAP_MIN_CREEPS;
   const bootstrapSpawnEnergy = spawnEnergyAvailable < BOOTSTRAP_MIN_SPAWN_ENERGY;
   const bootstrapRecovery = input.previousMode === "BOOTSTRAP" && !bootstrapCreepFloor && !bootstrapSpawnEnergy && !hasBootstrapExitStability(totalCreeps, spawnEnergyAvailable, energyCapacityAvailable);
@@ -3094,6 +3097,7 @@ function recordClaimedRoomBootstrapStage(roomName, tick = getGameTime8()) {
     spawnEnergyAvailable: getRoomEnergyAvailable(room),
     previousMode: getPersistedRoomStageMode(room),
     controller: getControllerSurvivalState(room.controller),
+    defenseFloorReady: isBootstrapDefenseFloorSatisfiedForTerritory(room),
     hostileCreepCount: countRoomFind(room, "FIND_HOSTILE_CREEPS"),
     hostileStructureCount: countRoomFind(room, "FIND_HOSTILE_STRUCTURES")
   });
@@ -12696,7 +12700,7 @@ function shouldSignOwnedRoomController(room, controller = room == null ? void 0 
 }
 function isOwnedRoomControllerSigningSafe(room, controller = room == null ? void 0 : room.controller) {
   var _a;
-  return Boolean(room) && (controller == null ? void 0 : controller.my) === true && ((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my) === true && room.controller.id === controller.id && !hasVisibleHostilePresence(room);
+  return Boolean(room) && (controller == null ? void 0 : controller.my) === true && ((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my) === true && room.controller.id === controller.id && !hasVisibleHostilePresence2(room);
 }
 function shouldSignReservedController(controller, actorUsername, gameTime = getGameTime17()) {
   return Boolean(
@@ -12766,7 +12770,7 @@ function getControllerRoom(creep, controller) {
   var _a;
   return (_a = controller == null ? void 0 : controller.room) != null ? _a : creep.room;
 }
-function hasVisibleHostilePresence(room) {
+function hasVisibleHostilePresence2(room) {
   return findRoomObjects16(room, "FIND_HOSTILE_CREEPS").length > 0 || findRoomObjects16(room, "FIND_HOSTILE_STRUCTURES").length > 0;
 }
 function findRoomObjects16(room, globalName) {
@@ -23819,7 +23823,7 @@ function selectUpgraderBoostEnergyAcquisitionTask(creep, controller) {
   }
   const context = {
     creepOwnerUsername: getCreepOwnerUsername2(creep),
-    hasHostilePresence: hasVisibleHostilePresence2(creep.room),
+    hasHostilePresence: hasVisibleHostilePresence3(creep.room),
     room: creep.room
   };
   const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
@@ -23844,7 +23848,7 @@ function selectUpgraderBoostEnergyAcquisitionTask(creep, controller) {
   return candidates.sort(compareWorkerEnergyAcquisitionCandidates)[0].task;
 }
 function isUpgraderBoostActive(creep, controller) {
-  return isUpgraderCreep(creep) && !hasVisibleHostilePresence2(creep.room) && isControllerNearLevelUp(controller);
+  return isUpgraderCreep(creep) && !hasVisibleHostilePresence3(creep.room) && isControllerNearLevelUp(controller);
 }
 function isUpgraderCreep(creep) {
   var _a, _b, _c, _d;
@@ -23965,7 +23969,7 @@ function hasLowWorkerThroughputRecoveryPressure(creep) {
   var _a;
   const room = creep.room;
   const controller = room.controller;
-  if (((_a = creep.memory) == null ? void 0 : _a.role) !== "worker" || (controller == null ? void 0 : controller.my) !== true || getControllerLevel(controller) > 2 || shouldGuardControllerDowngrade2(controller) || hasVisibleHostilePresence2(room)) {
+  if (((_a = creep.memory) == null ? void 0 : _a.role) !== "worker" || (controller == null ? void 0 : controller.my) !== true || getControllerLevel(controller) > 2 || shouldGuardControllerDowngrade2(controller) || hasVisibleHostilePresence3(room)) {
     return false;
   }
   const energyAvailable = getRoomEnergyAvailable9(room);
@@ -24024,7 +24028,7 @@ function hasEmergencySpawnExtensionRefillDemand(creep) {
   return hasTrueLowLoadSpawnExtensionRefillEmergency(creep);
 }
 function hasTrueLowLoadSpawnExtensionRefillEmergency(creep) {
-  if (hasVisibleHostilePresence2(creep.room)) {
+  if (hasVisibleHostilePresence3(creep.room)) {
     return true;
   }
   if (isControllerDowngradeImminentForLowLoadReturn(creep.room.controller)) {
@@ -24111,7 +24115,7 @@ function applyMinimumUsefulLoadPolicy(creep, task) {
   if (!getLowLoadWorkerEnergyContext(creep)) {
     return task;
   }
-  if (hasVisibleHostilePresence2(creep.room)) {
+  if (hasVisibleHostilePresence3(creep.room)) {
     recordLowLoadReturnTelemetry(creep, task, "hostileSafety");
     return task;
   }
@@ -24126,7 +24130,7 @@ function applyMinimumUsefulSpawnExtensionDeliveryPolicy(creep, task) {
   if (!getLowLoadWorkerEnergyContext(creep)) {
     return task;
   }
-  if (hasVisibleHostilePresence2(creep.room)) {
+  if (hasVisibleHostilePresence3(creep.room)) {
     recordLowLoadReturnTelemetry(creep, task, "hostileSafety");
     return task;
   }
@@ -24262,7 +24266,7 @@ function isSpawnExtensionThroughputBottlenecked(room) {
 function selectStorageForSpawnExtensionRefill(creep) {
   const context = {
     creepOwnerUsername: getCreepOwnerUsername2(creep),
-    hasHostilePresence: hasVisibleHostilePresence2(creep.room),
+    hasHostilePresence: hasVisibleHostilePresence3(creep.room),
     room: creep.room
   };
   const storageSources = findVisibleRoomStructures(creep.room).filter(
@@ -25673,7 +25677,7 @@ function matchesStructureType18(actual, globalName, fallback) {
 function selectStoredEnergySource(creep) {
   const context = {
     creepOwnerUsername: getCreepOwnerUsername2(creep),
-    hasHostilePresence: hasVisibleHostilePresence2(creep.room),
+    hasHostilePresence: hasVisibleHostilePresence3(creep.room),
     room: creep.room
   };
   const storedEnergySources = findVisibleRoomStructures(creep.room).filter(
@@ -25805,7 +25809,7 @@ function selectConstructionBacklogEnergyAcquisitionTask(creep) {
 function findBuilderEnergyAcquisitionCandidates(creep, constructionSite) {
   const context = {
     creepOwnerUsername: getCreepOwnerUsername2(creep),
-    hasHostilePresence: hasVisibleHostilePresence2(creep.room),
+    hasHostilePresence: hasVisibleHostilePresence3(creep.room),
     room: creep.room
   };
   const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
@@ -26186,7 +26190,7 @@ function selectLowLoadWorkerEnergyContinuationCandidate(creep, maximumRange = LO
   );
 }
 function shouldKeepLowLoadWorkerAcquiringEnergy(creep) {
-  return getLowLoadWorkerEnergyContext(creep) !== null && !hasVisibleHostilePresence2(creep.room);
+  return getLowLoadWorkerEnergyContext(creep) !== null && !hasVisibleHostilePresence3(creep.room);
 }
 function selectLowLoadWorkerEnergyYieldAwareCandidate(creep, candidates, defaultCandidate, maximumRange) {
   const currentCandidate = selectCurrentLowLoadWorkerEnergyAcquisitionCandidate(creep, maximumRange);
@@ -26316,7 +26320,7 @@ function isSafePersistedLowLoadWorkerWithdrawSource(creep, source) {
   const room = (_a = source.room) != null ? _a : creep.room;
   return isSafeStoredEnergySource(source, {
     creepOwnerUsername: getCreepOwnerUsername2(creep),
-    hasHostilePresence: hasVisibleHostilePresence2(room),
+    hasHostilePresence: hasVisibleHostilePresence3(room),
     room
   });
 }
@@ -26458,7 +26462,7 @@ function createSpawnRecoveryHarvestCandidate(creep, source, energySink, assignme
 function findWorkerEnergyAcquisitionCandidates(creep, options = {}) {
   const context = {
     creepOwnerUsername: getCreepOwnerUsername2(creep),
-    hasHostilePresence: hasVisibleHostilePresence2(creep.room),
+    hasHostilePresence: hasVisibleHostilePresence3(creep.room),
     room: creep.room
   };
   const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
@@ -27009,7 +27013,7 @@ function getCreepOwnerUsername2(creep) {
   const username = (_a = creep.owner) == null ? void 0 : _a.username;
   return typeof username === "string" && username.length > 0 ? username : null;
 }
-function hasVisibleHostilePresence2(room) {
+function hasVisibleHostilePresence3(room) {
   return findHostileCreeps3(room).length > 0 || findHostileStructures3(room).length > 0;
 }
 function findHostileCreeps3(room) {
@@ -27092,7 +27096,7 @@ function computeRoutineRampartMaintenanceRepairTarget(room) {
 }
 function canSelectRoutineBarrierMaintenanceRepairTarget(room) {
   var _a;
-  return ((_a = room.controller) == null ? void 0 : _a.my) === true && !hasVisibleHostilePresence2(room) && checkEnergyBufferForConstructionSpending(room);
+  return ((_a = room.controller) == null ? void 0 : _a.my) === true && !hasVisibleHostilePresence3(room) && checkEnergyBufferForConstructionSpending(room);
 }
 function selectCriticalInfrastructureRepairTarget(creep) {
   var _a;
@@ -27127,7 +27131,7 @@ function selectCriticalOwnedSpawnRepairTarget(creep, visibleStructures = findVis
 }
 function canRepairRemoteCriticalRoadInfrastructure(creep) {
   var _a;
-  if (!isRemoteTerritoryLogisticsRoom(creep.room) || hasVisibleHostilePresence2(creep.room)) {
+  if (!isRemoteTerritoryLogisticsRoom(creep.room) || hasVisibleHostilePresence3(creep.room)) {
     return false;
   }
   const controller = creep.room.controller;
@@ -27297,7 +27301,7 @@ function selectRcl3DefenseUnlockUpgradeTask(creep, controller) {
   return { type: "upgrade", targetId: controller.id };
 }
 function shouldUpgradeForRcl3DefenseUnlock(creep, controller) {
-  return (controller == null ? void 0 : controller.my) === true && controller.level === 2 && shouldGateTerritoryOnBootstrapDefenseFloor(creep.room) && isWorkerInColonyRoom(creep) && getUsedEnergy2(creep) > 0 && !hasVisibleHostilePresence2(creep.room) && !shouldGuardControllerDowngrade2(controller) && !isControllerUpgradeSaturated(creep, controller);
+  return (controller == null ? void 0 : controller.my) === true && controller.level === 2 && shouldGateTerritoryOnBootstrapDefenseFloor(creep.room) && isWorkerInColonyRoom(creep) && getUsedEnergy2(creep) > 0 && !hasVisibleHostilePresence3(creep.room) && !shouldGuardControllerDowngrade2(controller) && !isControllerUpgradeSaturated(creep, controller, { ignoreTerritoryExpansionPressure: true });
 }
 function shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) {
   const carriedEnergy = getUsedEnergy2(creep);
@@ -27497,12 +27501,12 @@ function hasNonControllerWorkerEnergyDemand(creep) {
   return selectCriticalInfrastructureRepairTarget(creep) !== null || selectRepairTarget(creep) !== null || selectRoutineBarrierMaintenanceRepairTarget(creep) !== null;
 }
 function hasPostConstructionControllerUpgradeEnergy(creep, controller) {
-  return isLowRclControllerProgressTarget(controller) && !hasVisibleHostilePresence2(creep.room) && !hasVisibleOwnedConstructionDemand(creep.room) && (findWorkerEnergyAcquisitionCandidates(creep).length > 0 || hasFullRoomEnergyForControllerProgress(creep.room));
+  return isLowRclControllerProgressTarget(controller) && !hasVisibleHostilePresence3(creep.room) && !hasVisibleOwnedConstructionDemand(creep.room) && (findWorkerEnergyAcquisitionCandidates(creep).length > 0 || hasFullRoomEnergyForControllerProgress(creep.room));
 }
 function isLowRclControllerProgressTarget(controller) {
   return canLevelUpController2(controller) && controller.level >= 2 && controller.level <= 3;
 }
-function isControllerUpgradeSaturated(creep, controller) {
+function isControllerUpgradeSaturated(creep, controller, options = {}) {
   if (controller.my !== true || shouldGuardControllerDowngrade2(controller)) {
     return false;
   }
@@ -27518,7 +27522,7 @@ function isControllerUpgradeSaturated(creep, controller) {
     getControllerProgressWorkerLimit(
       creep,
       loadedWorkers.length,
-      hasActiveTerritoryExpansionPressure(creep)
+      options.ignoreTerritoryExpansionPressure !== true && hasActiveTerritoryExpansionPressure(creep)
     )
   );
   return otherControllerUpgraders >= controllerProgressWorkerLimit;
@@ -27564,7 +27568,7 @@ function selectSource2ControllerLaneHarvestSource(creep) {
   return topology.source;
 }
 function getSource2ControllerLaneTopology(room, controller) {
-  if (controller.my !== true || typeof controller.level !== "number" || controller.level < 2 || getRoomObjectPosition5(controller) === null || !isHomeRoomName(room, controller) || hasVisibleHostilePresence2(room)) {
+  if (controller.my !== true || typeof controller.level !== "number" || controller.level < 2 || getRoomObjectPosition5(controller) === null || !isHomeRoomName(room, controller) || hasVisibleHostilePresence3(room)) {
     return null;
   }
   const source = getSource2(room);
@@ -27905,7 +27909,7 @@ function findSourceContainerWithdrawCandidates(creep) {
     );
     if (candidate && isSafeStoredEnergySource(sourceContainer, {
       creepOwnerUsername: getCreepOwnerUsername2(creep),
-      hasHostilePresence: hasVisibleHostilePresence2(sourceRoom),
+      hasHostilePresence: hasVisibleHostilePresence3(sourceRoom),
       room: sourceRoom
     })) {
       candidates.push(candidate);
@@ -30408,7 +30412,7 @@ function getEnergyHaulingBacklogThreshold(room, options) {
 function shouldUseEarlyRclControllerRunwayThreshold(room) {
   var _a, _b, _c;
   const controllerLevel = normalizeNonNegativeInteger11((_b = (_a = room.controller) == null ? void 0 : _a.level) != null ? _b : 0);
-  return ((_c = room.controller) == null ? void 0 : _c.my) === true && controllerLevel >= EARLY_RCL_CONTROLLER_RUNWAY_MIN_RCL && controllerLevel <= EARLY_RCL_CONTROLLER_RUNWAY_MAX_RCL && !hasVisibleHostilePresence3(room) && !hasVisibleConstructionDemand(room) && !hasDurableEnergyStore(room) && hasEarlyRclRunwayDeliveryCapacity(room);
+  return ((_c = room.controller) == null ? void 0 : _c.my) === true && controllerLevel >= EARLY_RCL_CONTROLLER_RUNWAY_MIN_RCL && controllerLevel <= EARLY_RCL_CONTROLLER_RUNWAY_MAX_RCL && !hasVisibleHostilePresence4(room) && !hasVisibleConstructionDemand(room) && !hasDurableEnergyStore(room) && hasEarlyRclRunwayDeliveryCapacity(room);
 }
 function hasEarlyRclRunwayDeliveryCapacity(room) {
   return findEnergyHaulingDeliveryTargets(room).some(
@@ -30421,7 +30425,7 @@ function hasDurableEnergyStore(room) {
 function hasVisibleConstructionDemand(room) {
   return findRoomObjects23(room, "FIND_MY_CONSTRUCTION_SITES").length > 0 || findRoomObjects23(room, "FIND_CONSTRUCTION_SITES").some((site) => site.my !== false);
 }
-function hasVisibleHostilePresence3(room) {
+function hasVisibleHostilePresence4(room) {
   return findRoomObjects23(room, "FIND_HOSTILE_CREEPS").length > 0 || findRoomObjects23(room, "FIND_HOSTILE_STRUCTURES").length > 0;
 }
 function countActiveLocalEnergyHaulers(roomName) {
@@ -35712,7 +35716,7 @@ function summarizeSurvival(colony, roleCounts) {
   };
 }
 function shouldReportRuntimeDefenseFloor(defenseFloor) {
-  return defenseFloor.assessable && (defenseFloor.anchors.length > 0 || defenseFloor.rcl >= 3);
+  return defenseFloor.assessable;
 }
 function toRuntimeDefenseFloorSummary(defenseFloor) {
   return {
@@ -40810,7 +40814,8 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
   }
 }
 function shouldHoldTerritoryScout(colonyStageAssessment) {
-  return (colonyStageAssessment == null ? void 0 : colonyStageAssessment.mode) === "BOOTSTRAP" || (colonyStageAssessment == null ? void 0 : colonyStageAssessment.mode) === "DEFENSE" || (colonyStageAssessment == null ? void 0 : colonyStageAssessment.suppressionReasons.includes("defenseFloor")) === true;
+  var _a;
+  return (colonyStageAssessment == null ? void 0 : colonyStageAssessment.mode) === "BOOTSTRAP" || (colonyStageAssessment == null ? void 0 : colonyStageAssessment.mode) === "DEFENSE" || ((_a = colonyStageAssessment == null ? void 0 : colonyStageAssessment.suppressionReasons) == null ? void 0 : _a.includes("defenseFloor")) === true;
 }
 function logBestClaimTarget(homeRoom) {
   if (isJestRuntime()) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1289,6 +1289,117 @@ function getGameTime3() {
   return typeof ((_a = globalThis.Game) == null ? void 0 : _a.time) === "number" ? (_b = globalThis.Game.time) != null ? _b : 0 : 0;
 }
 
+// src/config/roomSelection.ts
+var ACTIVE_OFFICIAL_ROOM_SELECTION = {
+  branch: "main",
+  shard: "shardX",
+  roomName: "E29N55",
+  spawn: {
+    name: "Spawn1",
+    x: 17,
+    y: 24
+  }
+};
+var OFFICIAL_ROOM_CANDIDATES = [
+  {
+    shard: ACTIVE_OFFICIAL_ROOM_SELECTION.shard,
+    roomName: ACTIVE_OFFICIAL_ROOM_SELECTION.roomName,
+    status: "active",
+    spawn: ACTIVE_OFFICIAL_ROOM_SELECTION.spawn,
+    notes: "Current official MMO room selected after the W3N9 room_dead recovery."
+  },
+  {
+    shard: "shardX",
+    roomName: "W3N9",
+    status: "fallback",
+    spawn: { name: "Spawn1", x: 35, y: 23 },
+    notes: "Previous official target retained only as a fallback/audit candidate."
+  },
+  {
+    shard: "shardX",
+    roomName: "E19S57",
+    status: "fallback",
+    notes: "Prior recovery candidate from the owner-approved fallback sequence."
+  },
+  {
+    shard: "shardX",
+    roomName: "E26S49",
+    status: "fallback",
+    notes: "Prior official room and fallback candidate; not an active default."
+  },
+  {
+    shard: "shardX",
+    roomName: "E17S59",
+    status: "fallback",
+    notes: "Legacy expansion/logistics root retained as a non-active fallback candidate."
+  }
+];
+var REPLACED_ACTIVE_OFFICIAL_ROOM_NAMES = OFFICIAL_ROOM_CANDIDATES.filter((candidate) => candidate.status !== "active").map((candidate) => candidate.roomName);
+var ACTIVE_OFFICIAL_SHARDS = [ACTIVE_OFFICIAL_ROOM_SELECTION.shard];
+var ACTIVE_OFFICIAL_ROOM_NAMES = [ACTIVE_OFFICIAL_ROOM_SELECTION.roomName];
+var LOGISTICS_ROOM_SELECTION = {
+  corridorRooms: ["E17S58", "E17S59", "E18S59"],
+  safeTransitRooms: ["E17S59"],
+  localFirstEnergyRooms: ["E17S58", "E18S59"],
+  localFirstSourceRoom: "E17S59",
+  prioritizedExportRoutes: [{ sourceRoom: "E17S59", targetRoom: "E18S59" }]
+};
+var activeRoom = ACTIVE_OFFICIAL_ROOM_SELECTION.roomName;
+var TERRITORY_EXPANSION_ROOM_SELECTION = {
+  scoutTargets: [
+    {
+      colony: activeRoom,
+      roomName: "E29N54",
+      nearestOwnedRoom: activeRoom,
+      nearestOwnedRoomDistance: 1,
+      routeDistance: 1,
+      adjacentToOwnedRoom: true,
+      scoutOnly: true
+    },
+    {
+      colony: activeRoom,
+      roomName: "E30N55",
+      nearestOwnedRoom: activeRoom,
+      nearestOwnedRoomDistance: 1,
+      routeDistance: 1,
+      adjacentToOwnedRoom: true,
+      scoutOnly: true
+    },
+    {
+      colony: LOGISTICS_ROOM_SELECTION.localFirstSourceRoom,
+      roomName: "E18S59",
+      nearestOwnedRoom: LOGISTICS_ROOM_SELECTION.localFirstSourceRoom,
+      nearestOwnedRoomDistance: 1,
+      routeDistance: 1,
+      adjacentToOwnedRoom: true
+    },
+    {
+      colony: LOGISTICS_ROOM_SELECTION.localFirstSourceRoom,
+      roomName: "E17S60",
+      nearestOwnedRoom: LOGISTICS_ROOM_SELECTION.localFirstEnergyRooms[0],
+      nearestOwnedRoomDistance: 1,
+      routeDistance: 2,
+      adjacentToOwnedRoom: true
+    }
+  ]
+};
+var PRODUCTION_ROOM_SELECTION_LITERAL_NAMES = Array.from(/* @__PURE__ */ new Set([
+  ACTIVE_OFFICIAL_ROOM_SELECTION.shard,
+  ACTIVE_OFFICIAL_ROOM_SELECTION.roomName,
+  ...OFFICIAL_ROOM_CANDIDATES.map((candidate) => candidate.roomName),
+  ...OFFICIAL_ROOM_CANDIDATES.map((candidate) => candidate.shard),
+  ...LOGISTICS_ROOM_SELECTION.corridorRooms,
+  ...LOGISTICS_ROOM_SELECTION.safeTransitRooms,
+  ...LOGISTICS_ROOM_SELECTION.localFirstEnergyRooms,
+  LOGISTICS_ROOM_SELECTION.localFirstSourceRoom,
+  ...LOGISTICS_ROOM_SELECTION.prioritizedExportRoutes.flatMap((route) => [route.sourceRoom, route.targetRoom]),
+  ...TERRITORY_EXPANSION_ROOM_SELECTION.scoutTargets.flatMap((target) => [
+    target.colony,
+    target.roomName,
+    target.nearestOwnedRoom
+  ])
+]));
+
 // src/defense/defensePlanner.ts
 var DEFENDER_ROLE = "defender";
 var DEFENDER_BODY_PATTERN = ["tough", "attack", "move"];
@@ -1301,8 +1412,10 @@ var CRITICAL_SPAWN_LOSS_HITS_RATIO = 0.25;
 var TOWER_CONTROLLER_THREAT_RANGE = 3;
 var TOWER_STRUCTURE_THREAT_RANGE = 3;
 var BOOTSTRAP_DEFENSE_FLOOR_MIN_RCL = 2;
+var BOOTSTRAP_DEFENSE_FLOOR_MAX_TERRITORY_GATE_RCL = 3;
 var BOOTSTRAP_DEFENSE_FLOOR_MAX_SITES_PER_TICK = 2;
 var BOOTSTRAP_DEFENSE_FLOOR_REQUIRED_WALL_ANCHORS = 1;
+var BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING = 25e3;
 var ROOM_EDGE_MIN = 1;
 var ROOM_EDGE_MAX = 48;
 var DEFAULT_TERRAIN_WALL_MASK = 1;
@@ -1359,7 +1472,46 @@ function assessBootstrapDefenseFloor(room) {
     missingAnchors,
     ready: spawnRampartReady && wallAnchorCount >= requiredWallAnchors,
     spawnRampartReady,
+    requiredWallAnchorCount: requiredWallAnchors,
     wallAnchorCount
+  };
+}
+function assessBootstrapDefenseFloorReadiness(room) {
+  const rcl = getOwnedRoomRcl(room);
+  const assessable = canAssessBootstrapDefenseFloor(room);
+  if (!assessable || rcl < BOOTSTRAP_DEFENSE_FLOOR_MIN_RCL) {
+    return {
+      anchors: [],
+      missingAnchors: [],
+      ready: true,
+      spawnRampartReady: true,
+      requiredWallAnchorCount: 0,
+      wallAnchorCount: 0,
+      assessable,
+      anchorReady: true,
+      pendingTowerCount: 0,
+      repairHitsCeiling: BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING,
+      rcl,
+      towerCount: 0,
+      towerReady: true
+    };
+  }
+  const anchorAssessment = assessBootstrapDefenseFloor(room);
+  const lookups = getBootstrapDefenseFloorLookups(room);
+  const towerCount = getOwnedStructuresByType(room, lookups, "STRUCTURE_TOWER").length;
+  const pendingTowerCount = getConstructionSitesByType(room, lookups, "STRUCTURE_TOWER").length;
+  const towerReady = rcl !== 3 || towerCount > 0;
+  const anchorReady = anchorAssessment.anchors.length === 0 || anchorAssessment.ready;
+  return {
+    ...anchorAssessment,
+    ready: anchorReady && towerReady,
+    assessable,
+    anchorReady,
+    pendingTowerCount,
+    repairHitsCeiling: BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING,
+    rcl,
+    towerCount,
+    towerReady
   };
 }
 function planBootstrapDefenseFloorPlacements(room, options = {}) {
@@ -1374,6 +1526,15 @@ function planBootstrapDefenseFloorPlacements(room, options = {}) {
     return [];
   }
   return assessBootstrapDefenseFloor(room).missingAnchors.slice(0, maxPlacements);
+}
+function isBootstrapDefenseFloorSatisfiedForTerritory(room) {
+  if (!shouldGateTerritoryOnBootstrapDefenseFloor(room)) {
+    return true;
+  }
+  return assessBootstrapDefenseFloorReadiness(room).ready;
+}
+function shouldUseBootstrapDefenseFloorRepairCap(room) {
+  return shouldGateTerritoryOnBootstrapDefenseFloor(room);
 }
 function buildDefenderBody(energyAvailable, hostileCount) {
   const desiredPatternCount = Math.max(
@@ -1588,6 +1749,20 @@ function selectPrimaryOwnedSpawn(room, lookups) {
   }).sort((left, right) => getObjectId2(left).localeCompare(getObjectId2(right)));
   return (_a = spawns[0]) != null ? _a : null;
 }
+function shouldGateTerritoryOnBootstrapDefenseFloor(room) {
+  const rcl = getOwnedRoomRcl(room);
+  if (rcl < BOOTSTRAP_DEFENSE_FLOOR_MIN_RCL || rcl > BOOTSTRAP_DEFENSE_FLOOR_MAX_TERRITORY_GATE_RCL || !canAssessBootstrapDefenseFloor(room) || room.name !== ACTIVE_OFFICIAL_ROOM_SELECTION.roomName) {
+    return false;
+  }
+  return hasActiveOfficialSpawn(room, getBootstrapDefenseFloorLookups(room));
+}
+function hasActiveOfficialSpawn(room, lookups) {
+  const expectedSpawn = ACTIVE_OFFICIAL_ROOM_SELECTION.spawn;
+  return getOwnedStructuresByType(room, lookups, "STRUCTURE_SPAWN").some((spawn) => {
+    var _a;
+    return ((_a = spawn.pos) == null ? void 0 : _a.roomName) === room.name && spawn.pos.x === expectedSpawn.x && spawn.pos.y === expectedSpawn.y;
+  });
+}
 function selectSpawnWallAnchorPositions(room, spawnPosition, lookups) {
   const positions = [];
   for (const [dx, dy] of SPAWN_WALL_ANCHOR_OFFSETS) {
@@ -1672,6 +1847,9 @@ function getBootstrapDefenseFloorLookups(room) {
   bootstrapDefenseFloorLookupCache.set(room, lookups);
   return lookups;
 }
+function canAssessBootstrapDefenseFloor(room) {
+  return typeof room.find === "function" && getGlobalNumber2("FIND_STRUCTURES") !== null && getGlobalNumber2("FIND_CONSTRUCTION_SITES") !== null;
+}
 function createBootstrapDefenseFloorLookups(room) {
   const structures = findRoomObjects3(room, "FIND_STRUCTURES").filter((structure) => isPositionInRoom(structure.pos, room.name));
   const constructionSites = findRoomObjects3(room, "FIND_CONSTRUCTION_SITES").filter((site) => isPositionInRoom(site.pos, room.name));
@@ -1705,6 +1883,10 @@ function getStructuresAtPosition(lookups, position) {
 function getConstructionSitesAtPosition(lookups, position) {
   var _a;
   return (_a = lookups.constructionSitesByPosition.get(getPositionKey(position))) != null ? _a : [];
+}
+function getConstructionSitesByType(room, lookups, structureGlobal) {
+  const structureType = getStructureConstant(structureGlobal);
+  return lookups.constructionSites.filter((site) => site.structureType === structureType && isPositionInRoom(site.pos, room.name));
 }
 function isStructureType(structureType, structureGlobal) {
   return structureType === getStructureConstant(structureGlobal);
@@ -2780,11 +2962,12 @@ function assessColonyStage(input) {
   const survivalWorkerFloor = Math.max(1, Math.min(BOOTSTRAP_WORKER_FLOOR, Math.max(workerTarget, 1)));
   const hostilePresence = ((_d = input.hostileCreepCount) != null ? _d : 0) > 0 || ((_e = input.hostileStructureCount) != null ? _e : 0) > 0;
   const controllerDowngradeGuard = isControllerDowngradeGuardActive(input.controller);
+  const defenseFloorReady = input.defenseFloorReady !== false;
   const bootstrapCreepFloor = totalCreeps < BOOTSTRAP_MIN_CREEPS;
   const bootstrapSpawnEnergy = spawnEnergyAvailable < BOOTSTRAP_MIN_SPAWN_ENERGY;
   const bootstrapRecovery = input.previousMode === "BOOTSTRAP" && !bootstrapCreepFloor && !bootstrapSpawnEnergy && !hasBootstrapExitStability(totalCreeps, spawnEnergyAvailable, energyCapacityAvailable);
   const bootstrap = bootstrapCreepFloor || bootstrapSpawnEnergy || bootstrapRecovery;
-  const territoryReady = !bootstrap && !hostilePresence && workerCapacity >= workerTarget && energyCapacityAvailable >= TERRITORY_CONTROLLER_BODY_COST && isControllerTerritoryReady(input.controller) && !controllerDowngradeGuard;
+  const territoryReady = !bootstrap && !hostilePresence && workerCapacity >= workerTarget && energyCapacityAvailable >= TERRITORY_CONTROLLER_BODY_COST && isControllerTerritoryReady(input.controller) && defenseFloorReady && !controllerDowngradeGuard;
   const mode = selectColonyMode({ bootstrap, hostilePresence, territoryReady });
   return {
     mode,
@@ -2805,6 +2988,7 @@ function assessColonyStage(input) {
       bootstrapSpawnEnergy,
       controller: input.controller,
       controllerDowngradeGuard,
+      defenseFloorReady,
       energyCapacityAvailable,
       hostilePresence,
       mode,
@@ -2826,6 +3010,7 @@ function assessColonySnapshotStage(colony, roleCounts) {
     spawnEnergyAvailable: colony.energyAvailable,
     previousMode,
     controller: getControllerSurvivalState(colony.room.controller),
+    defenseFloorReady: isBootstrapDefenseFloorSatisfiedForTerritory(colony.room),
     hostileCreepCount: countRoomFind(colony.room, "FIND_HOSTILE_CREEPS"),
     hostileStructureCount: countRoomFind(colony.room, "FIND_HOSTILE_STRUCTURES")
   });
@@ -2966,6 +3151,9 @@ function getSuppressionReasons(input) {
   }
   if (input.controllerDowngradeGuard) {
     reasons.push("controllerDowngradeGuard");
+  }
+  if (!input.defenseFloorReady) {
+    reasons.push("defenseFloor");
   }
   if (input.hostilePresence) {
     reasons.push("defense");
@@ -15553,6 +15741,9 @@ function isTerritoryHomeSafe(colony, roleCounts, workerTarget, options = {}) {
   if ((controller == null ? void 0 : controller.my) !== true || typeof controller.level !== "number" || controller.level < 2) {
     return false;
   }
+  if (!isBootstrapDefenseFloorSatisfiedForTerritory(colony.room)) {
+    return false;
+  }
   return typeof controller.ticksToDowngrade !== "number" || controller.ticksToDowngrade > TERRITORY_DOWNGRADE_GUARD_TICKS;
 }
 function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime, options = {}) {
@@ -23327,6 +23518,10 @@ function selectHeuristicWorkerTask(creep) {
   if (controllerSustainUpgradeTask) {
     return applyMinimumUsefulLoadPolicy(creep, controllerSustainUpgradeTask);
   }
+  const rcl3DefenseUnlockUpgradeTask = selectRcl3DefenseUnlockUpgradeTask(creep, controller);
+  if (rcl3DefenseUnlockUpgradeTask) {
+    return applyMinimumUsefulLoadPolicy(creep, rcl3DefenseUnlockUpgradeTask);
+  }
   const constructionPriorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
   const highImpactConstructionSite = selectUnreservedConstructionSite(
     creep,
@@ -27051,9 +27246,16 @@ function isWorkerRepairTargetComplete(structure) {
 }
 function getWorkerRepairHitsCeiling(structure) {
   if (isWorkerBarrierRepairStructure(structure)) {
+    if (shouldUseBootstrapDefenseFloorRepairCap(getStructureRoom(structure))) {
+      return Math.min(structure.hitsMax, BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING);
+    }
     return Math.min(structure.hitsMax, IDLE_RAMPART_REPAIR_HITS_CEILING2);
   }
   return structure.hitsMax;
+}
+function getStructureRoom(structure) {
+  var _a;
+  return (_a = structure.room) != null ? _a : {};
 }
 function isWorkerBarrierRepairStructure(structure) {
   return matchesStructureType18(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure) || matchesStructureType18(structure.structureType, "STRUCTURE_WALL", "constructedWall");
@@ -27087,6 +27289,15 @@ function shouldGuardControllerDowngrade2(controller) {
 }
 function shouldRushRcl1Controller(controller) {
   return controller.my === true && controller.level === 1;
+}
+function selectRcl3DefenseUnlockUpgradeTask(creep, controller) {
+  if (!shouldUpgradeForRcl3DefenseUnlock(creep, controller)) {
+    return null;
+  }
+  return { type: "upgrade", targetId: controller.id };
+}
+function shouldUpgradeForRcl3DefenseUnlock(creep, controller) {
+  return (controller == null ? void 0 : controller.my) === true && controller.level === 2 && shouldGateTerritoryOnBootstrapDefenseFloor(creep.room) && isWorkerInColonyRoom(creep) && getUsedEnergy2(creep) > 0 && !hasVisibleHostilePresence2(creep.room) && !shouldGuardControllerDowngrade2(controller) && !isControllerUpgradeSaturated(creep, controller);
 }
 function shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) {
   const carriedEnergy = getUsedEnergy2(creep);
@@ -33264,7 +33475,7 @@ function getTerritoryIntentPlanningOptions(context) {
   return shouldPlanLocalStableTerritoryScout(context) ? { scoutOnly: true } : null;
 }
 function shouldPlanLocalStableTerritoryScout(context) {
-  return context.survival.mode === "LOCAL_STABLE" && context.options.workersOnly !== true && context.workerCapacity >= context.workerTarget && context.colony.energyCapacityAvailable >= TERRITORY_SCOUT_BODY_COST && context.colony.energyAvailable >= TERRITORY_SCOUT_BODY_COST;
+  return context.survival.mode === "LOCAL_STABLE" && !context.survival.suppressionReasons.includes("defenseFloor") && context.options.workersOnly !== true && context.workerCapacity >= context.workerTarget && context.colony.energyCapacityAvailable >= TERRITORY_SCOUT_BODY_COST && context.colony.energyAvailable >= TERRITORY_SCOUT_BODY_COST;
 }
 function planControllerUpgradeSurplusSpawn(context) {
   if (!shouldSpawnControllerUpgradeSurplusWorker(context)) {
@@ -35490,12 +35701,33 @@ function summarizeConstructionPriority(colony, colonyWorkers) {
 }
 function summarizeSurvival(colony, roleCounts) {
   const assessment = assessColonySnapshotSurvival(colony, roleCounts);
+  const defenseFloor = assessBootstrapDefenseFloorReadiness(colony.room);
   return {
     mode: assessment.mode,
     workerCapacity: assessment.workerCapacity,
     workerTarget: assessment.workerTarget,
     survivalWorkerFloor: assessment.survivalWorkerFloor,
-    ...assessment.suppressionReasons.length > 0 ? { suppressionReasons: assessment.suppressionReasons } : {}
+    ...assessment.suppressionReasons.length > 0 ? { suppressionReasons: assessment.suppressionReasons } : {},
+    ...shouldReportRuntimeDefenseFloor(defenseFloor) ? { defenseFloor: toRuntimeDefenseFloorSummary(defenseFloor) } : {}
+  };
+}
+function shouldReportRuntimeDefenseFloor(defenseFloor) {
+  return defenseFloor.assessable && (defenseFloor.anchors.length > 0 || defenseFloor.rcl >= 3);
+}
+function toRuntimeDefenseFloorSummary(defenseFloor) {
+  return {
+    ready: defenseFloor.ready,
+    assessable: defenseFloor.assessable,
+    rcl: defenseFloor.rcl,
+    anchorReady: defenseFloor.anchorReady,
+    towerReady: defenseFloor.towerReady,
+    towerCount: defenseFloor.towerCount,
+    pendingTowerCount: defenseFloor.pendingTowerCount,
+    spawnRampartReady: defenseFloor.spawnRampartReady,
+    wallAnchorCount: defenseFloor.wallAnchorCount,
+    requiredWallAnchorCount: defenseFloor.requiredWallAnchorCount,
+    missingAnchorCount: defenseFloor.missingAnchors.length,
+    repairHitsCeiling: defenseFloor.repairHitsCeiling
   };
 }
 function toRuntimeConstructionPriorityCandidateSummary(score) {
@@ -40478,7 +40710,7 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
   }
   const colonyStageAssessment = getRecordedColonyStageAssessment(creep.memory.colony);
   if (assignment.action === "scout") {
-    if ((colonyStageAssessment == null ? void 0 : colonyStageAssessment.mode) === "BOOTSTRAP" || (colonyStageAssessment == null ? void 0 : colonyStageAssessment.mode) === "DEFENSE") {
+    if (shouldHoldTerritoryScout(colonyStageAssessment)) {
       return;
     }
   } else if (suppressesTerritoryWork(colonyStageAssessment)) {
@@ -40576,6 +40808,9 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
   if (assignment.action === "claim" && CLAIM_FATAL_RESULT_CODES.has(result) || assignment.action === "reserve" && RESERVE_FATAL_RESULT_CODES.has(result)) {
     suppressTerritoryAssignment(creep, assignment);
   }
+}
+function shouldHoldTerritoryScout(colonyStageAssessment) {
+  return (colonyStageAssessment == null ? void 0 : colonyStageAssessment.mode) === "BOOTSTRAP" || (colonyStageAssessment == null ? void 0 : colonyStageAssessment.mode) === "DEFENSE" || (colonyStageAssessment == null ? void 0 : colonyStageAssessment.suppressionReasons.includes("defenseFloor")) === true;
 }
 function logBestClaimTarget(homeRoom) {
   if (isJestRuntime()) {
@@ -44493,117 +44728,6 @@ function getDefenseEventPriority(event) {
 function getGameTime43() {
   return typeof Game !== "undefined" && typeof Game.time === "number" ? Game.time : 0;
 }
-
-// src/config/roomSelection.ts
-var ACTIVE_OFFICIAL_ROOM_SELECTION = {
-  branch: "main",
-  shard: "shardX",
-  roomName: "E29N55",
-  spawn: {
-    name: "Spawn1",
-    x: 17,
-    y: 24
-  }
-};
-var OFFICIAL_ROOM_CANDIDATES = [
-  {
-    shard: ACTIVE_OFFICIAL_ROOM_SELECTION.shard,
-    roomName: ACTIVE_OFFICIAL_ROOM_SELECTION.roomName,
-    status: "active",
-    spawn: ACTIVE_OFFICIAL_ROOM_SELECTION.spawn,
-    notes: "Current official MMO room selected after the W3N9 room_dead recovery."
-  },
-  {
-    shard: "shardX",
-    roomName: "W3N9",
-    status: "fallback",
-    spawn: { name: "Spawn1", x: 35, y: 23 },
-    notes: "Previous official target retained only as a fallback/audit candidate."
-  },
-  {
-    shard: "shardX",
-    roomName: "E19S57",
-    status: "fallback",
-    notes: "Prior recovery candidate from the owner-approved fallback sequence."
-  },
-  {
-    shard: "shardX",
-    roomName: "E26S49",
-    status: "fallback",
-    notes: "Prior official room and fallback candidate; not an active default."
-  },
-  {
-    shard: "shardX",
-    roomName: "E17S59",
-    status: "fallback",
-    notes: "Legacy expansion/logistics root retained as a non-active fallback candidate."
-  }
-];
-var REPLACED_ACTIVE_OFFICIAL_ROOM_NAMES = OFFICIAL_ROOM_CANDIDATES.filter((candidate) => candidate.status !== "active").map((candidate) => candidate.roomName);
-var ACTIVE_OFFICIAL_SHARDS = [ACTIVE_OFFICIAL_ROOM_SELECTION.shard];
-var ACTIVE_OFFICIAL_ROOM_NAMES = [ACTIVE_OFFICIAL_ROOM_SELECTION.roomName];
-var LOGISTICS_ROOM_SELECTION = {
-  corridorRooms: ["E17S58", "E17S59", "E18S59"],
-  safeTransitRooms: ["E17S59"],
-  localFirstEnergyRooms: ["E17S58", "E18S59"],
-  localFirstSourceRoom: "E17S59",
-  prioritizedExportRoutes: [{ sourceRoom: "E17S59", targetRoom: "E18S59" }]
-};
-var activeRoom = ACTIVE_OFFICIAL_ROOM_SELECTION.roomName;
-var TERRITORY_EXPANSION_ROOM_SELECTION = {
-  scoutTargets: [
-    {
-      colony: activeRoom,
-      roomName: "E29N54",
-      nearestOwnedRoom: activeRoom,
-      nearestOwnedRoomDistance: 1,
-      routeDistance: 1,
-      adjacentToOwnedRoom: true,
-      scoutOnly: true
-    },
-    {
-      colony: activeRoom,
-      roomName: "E30N55",
-      nearestOwnedRoom: activeRoom,
-      nearestOwnedRoomDistance: 1,
-      routeDistance: 1,
-      adjacentToOwnedRoom: true,
-      scoutOnly: true
-    },
-    {
-      colony: LOGISTICS_ROOM_SELECTION.localFirstSourceRoom,
-      roomName: "E18S59",
-      nearestOwnedRoom: LOGISTICS_ROOM_SELECTION.localFirstSourceRoom,
-      nearestOwnedRoomDistance: 1,
-      routeDistance: 1,
-      adjacentToOwnedRoom: true
-    },
-    {
-      colony: LOGISTICS_ROOM_SELECTION.localFirstSourceRoom,
-      roomName: "E17S60",
-      nearestOwnedRoom: LOGISTICS_ROOM_SELECTION.localFirstEnergyRooms[0],
-      nearestOwnedRoomDistance: 1,
-      routeDistance: 2,
-      adjacentToOwnedRoom: true
-    }
-  ]
-};
-var PRODUCTION_ROOM_SELECTION_LITERAL_NAMES = Array.from(/* @__PURE__ */ new Set([
-  ACTIVE_OFFICIAL_ROOM_SELECTION.shard,
-  ACTIVE_OFFICIAL_ROOM_SELECTION.roomName,
-  ...OFFICIAL_ROOM_CANDIDATES.map((candidate) => candidate.roomName),
-  ...OFFICIAL_ROOM_CANDIDATES.map((candidate) => candidate.shard),
-  ...LOGISTICS_ROOM_SELECTION.corridorRooms,
-  ...LOGISTICS_ROOM_SELECTION.safeTransitRooms,
-  ...LOGISTICS_ROOM_SELECTION.localFirstEnergyRooms,
-  LOGISTICS_ROOM_SELECTION.localFirstSourceRoom,
-  ...LOGISTICS_ROOM_SELECTION.prioritizedExportRoutes.flatMap((route) => [route.sourceRoom, route.targetRoom]),
-  ...TERRITORY_EXPANSION_ROOM_SELECTION.scoutTargets.flatMap((target) => [
-    target.colony,
-    target.roomName,
-    target.nearestOwnedRoom
-  ])
-]));
 
 // src/strategy/strategyRegistry.ts
 var STRATEGY_REGISTRY_SCHEMA_VERSION = 1;

--- a/prod/src/colony/colonyStage.ts
+++ b/prod/src/colony/colonyStage.ts
@@ -112,7 +112,7 @@ export function assessColonyStage(input: ColonyStageInput): ColonyStageAssessmen
   const survivalWorkerFloor = Math.max(1, Math.min(BOOTSTRAP_WORKER_FLOOR, Math.max(workerTarget, 1)));
   const hostilePresence = (input.hostileCreepCount ?? 0) > 0 || (input.hostileStructureCount ?? 0) > 0;
   const controllerDowngradeGuard = isControllerDowngradeGuardActive(input.controller);
-  const defenseFloorReady = input.defenseFloorReady !== false;
+  const defenseFloorReady = input.defenseFloorReady === true;
   const bootstrapCreepFloor = totalCreeps < BOOTSTRAP_MIN_CREEPS;
   const bootstrapSpawnEnergy = spawnEnergyAvailable < BOOTSTRAP_MIN_SPAWN_ENERGY;
   const bootstrapRecovery =
@@ -304,6 +304,7 @@ export function recordClaimedRoomBootstrapStage(
     spawnEnergyAvailable: getRoomEnergyAvailable(room),
     previousMode: getPersistedRoomStageMode(room),
     controller: getControllerSurvivalState(room.controller),
+    defenseFloorReady: isBootstrapDefenseFloorSatisfiedForTerritory(room),
     hostileCreepCount: countRoomFind(room, 'FIND_HOSTILE_CREEPS'),
     hostileStructureCount: countRoomFind(room, 'FIND_HOSTILE_STRUCTURES')
   });

--- a/prod/src/colony/colonyStage.ts
+++ b/prod/src/colony/colonyStage.ts
@@ -1,5 +1,6 @@
 import type { RoleCounts } from '../creeps/roleCounts';
 import { getWorkerCapacity } from '../creeps/roleCounts';
+import { isBootstrapDefenseFloorSatisfiedForTerritory } from '../defense/defensePlanner';
 import { getRoomMinerThroughput } from '../economy/minerThroughput';
 import { TERRITORY_CONTROLLER_BODY_COST } from '../spawn/bodyBuilder';
 import type { ColonySnapshot } from './colonyRegistry';
@@ -13,6 +14,7 @@ export type ColonyStageSuppressionReason =
   | 'bootstrapRecovery'
   | 'localWorkerRecovery'
   | 'controllerDowngradeGuard'
+  | 'defenseFloor'
   | 'territoryEnergyCapacity'
   | 'controllerLevel'
   | 'defense';
@@ -39,6 +41,7 @@ export interface ColonyStageInput {
     level?: number;
     ticksToDowngrade?: number;
   };
+  defenseFloorReady?: boolean;
   hostileCreepCount?: number;
   hostileStructureCount?: number;
 }
@@ -109,6 +112,7 @@ export function assessColonyStage(input: ColonyStageInput): ColonyStageAssessmen
   const survivalWorkerFloor = Math.max(1, Math.min(BOOTSTRAP_WORKER_FLOOR, Math.max(workerTarget, 1)));
   const hostilePresence = (input.hostileCreepCount ?? 0) > 0 || (input.hostileStructureCount ?? 0) > 0;
   const controllerDowngradeGuard = isControllerDowngradeGuardActive(input.controller);
+  const defenseFloorReady = input.defenseFloorReady !== false;
   const bootstrapCreepFloor = totalCreeps < BOOTSTRAP_MIN_CREEPS;
   const bootstrapSpawnEnergy = spawnEnergyAvailable < BOOTSTRAP_MIN_SPAWN_ENERGY;
   const bootstrapRecovery =
@@ -123,6 +127,7 @@ export function assessColonyStage(input: ColonyStageInput): ColonyStageAssessmen
     workerCapacity >= workerTarget &&
     energyCapacityAvailable >= TERRITORY_CONTROLLER_BODY_COST &&
     isControllerTerritoryReady(input.controller) &&
+    defenseFloorReady &&
     !controllerDowngradeGuard;
   const mode = selectColonyMode({ bootstrap, hostilePresence, territoryReady });
 
@@ -145,6 +150,7 @@ export function assessColonyStage(input: ColonyStageInput): ColonyStageAssessmen
       bootstrapSpawnEnergy,
       controller: input.controller,
       controllerDowngradeGuard,
+      defenseFloorReady,
       energyCapacityAvailable,
       hostilePresence,
       mode,
@@ -173,6 +179,7 @@ export function assessColonySnapshotStage(
     spawnEnergyAvailable: colony.energyAvailable,
     previousMode,
     controller: getControllerSurvivalState(colony.room.controller),
+    defenseFloorReady: isBootstrapDefenseFloorSatisfiedForTerritory(colony.room),
     hostileCreepCount: countRoomFind(colony.room, 'FIND_HOSTILE_CREEPS'),
     hostileStructureCount: countRoomFind(colony.room, 'FIND_HOSTILE_STRUCTURES')
   });
@@ -374,6 +381,7 @@ function getSuppressionReasons(input: {
   bootstrapSpawnEnergy: boolean;
   controller?: ColonyStageInput['controller'];
   controllerDowngradeGuard: boolean;
+  defenseFloorReady: boolean;
   energyCapacityAvailable: number;
   hostilePresence: boolean;
   mode: ColonyStage;
@@ -403,6 +411,10 @@ function getSuppressionReasons(input: {
 
   if (input.controllerDowngradeGuard) {
     reasons.push('controllerDowngradeGuard');
+  }
+
+  if (!input.defenseFloorReady) {
+    reasons.push('defenseFloor');
   }
 
   if (input.hostilePresence) {

--- a/prod/src/defense/defensePlanner.ts
+++ b/prod/src/defense/defensePlanner.ts
@@ -1,3 +1,5 @@
+import { ACTIVE_OFFICIAL_ROOM_SELECTION } from '../config/roomSelection';
+
 export const DEFENDER_ROLE = 'defender';
 
 const DEFENDER_BODY_PATTERN: BodyPartConstant[] = ['tough', 'attack', 'move'];
@@ -10,8 +12,10 @@ export const CRITICAL_SPAWN_LOSS_HITS_RATIO = 0.25;
 export const TOWER_CONTROLLER_THREAT_RANGE = 3;
 export const TOWER_STRUCTURE_THREAT_RANGE = 3;
 export const BOOTSTRAP_DEFENSE_FLOOR_MIN_RCL = 2;
+export const BOOTSTRAP_DEFENSE_FLOOR_MAX_TERRITORY_GATE_RCL = 3;
 export const BOOTSTRAP_DEFENSE_FLOOR_MAX_SITES_PER_TICK = 2;
 export const BOOTSTRAP_DEFENSE_FLOOR_REQUIRED_WALL_ANCHORS = 1;
+export const BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING = 25_000;
 
 export type DefenseTarget = Creep | Structure;
 export type BootstrapDefenseFloorAnchorKind =
@@ -68,11 +72,22 @@ export interface BootstrapDefenseFloorAssessment {
   missingAnchors: BootstrapDefenseFloorAnchor[];
   ready: boolean;
   spawnRampartReady: boolean;
+  requiredWallAnchorCount: number;
   wallAnchorCount: number;
 }
 
 export interface BootstrapDefenseFloorOptions {
   maxPlacements?: number;
+}
+
+export interface BootstrapDefenseFloorReadiness extends BootstrapDefenseFloorAssessment {
+  assessable: boolean;
+  anchorReady: boolean;
+  pendingTowerCount: number;
+  repairHitsCeiling: number;
+  rcl: number;
+  towerCount: number;
+  towerReady: boolean;
 }
 
 interface CandidatePosition {
@@ -163,7 +178,49 @@ export function assessBootstrapDefenseFloor(room: Room): BootstrapDefenseFloorAs
       spawnRampartReady &&
       wallAnchorCount >= requiredWallAnchors,
     spawnRampartReady,
+    requiredWallAnchorCount: requiredWallAnchors,
     wallAnchorCount
+  };
+}
+
+export function assessBootstrapDefenseFloorReadiness(room: Room): BootstrapDefenseFloorReadiness {
+  const rcl = getOwnedRoomRcl(room);
+  const assessable = canAssessBootstrapDefenseFloor(room);
+  if (!assessable || rcl < BOOTSTRAP_DEFENSE_FLOOR_MIN_RCL) {
+    return {
+      anchors: [],
+      missingAnchors: [],
+      ready: true,
+      spawnRampartReady: true,
+      requiredWallAnchorCount: 0,
+      wallAnchorCount: 0,
+      assessable,
+      anchorReady: true,
+      pendingTowerCount: 0,
+      repairHitsCeiling: BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING,
+      rcl,
+      towerCount: 0,
+      towerReady: true
+    };
+  }
+
+  const anchorAssessment = assessBootstrapDefenseFloor(room);
+  const lookups = getBootstrapDefenseFloorLookups(room);
+  const towerCount = getOwnedStructuresByType<StructureTower>(room, lookups, 'STRUCTURE_TOWER').length;
+  const pendingTowerCount = getConstructionSitesByType(room, lookups, 'STRUCTURE_TOWER').length;
+  const towerReady = rcl !== 3 || towerCount > 0;
+  const anchorReady = anchorAssessment.anchors.length === 0 || anchorAssessment.ready;
+
+  return {
+    ...anchorAssessment,
+    ready: anchorReady && towerReady,
+    assessable,
+    anchorReady,
+    pendingTowerCount,
+    repairHitsCeiling: BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING,
+    rcl,
+    towerCount,
+    towerReady
   };
 }
 
@@ -188,6 +245,18 @@ export function planBootstrapDefenseFloorPlacements(
 
 export function isBootstrapDefenseFloorReady(room: Room): boolean {
   return assessBootstrapDefenseFloor(room).ready;
+}
+
+export function isBootstrapDefenseFloorSatisfiedForTerritory(room: Room): boolean {
+  if (!shouldGateTerritoryOnBootstrapDefenseFloor(room)) {
+    return true;
+  }
+
+  return assessBootstrapDefenseFloorReadiness(room).ready;
+}
+
+export function shouldUseBootstrapDefenseFloorRepairCap(room: Room): boolean {
+  return shouldGateTerritoryOnBootstrapDefenseFloor(room);
 }
 
 export function buildDefenderBody(energyAvailable: number, hostileCount: number): BodyPartConstant[] {
@@ -487,6 +556,30 @@ function selectPrimaryOwnedSpawn(room: Room, lookups: BootstrapDefenseFloorLooku
   return spawns[0] ?? null;
 }
 
+export function shouldGateTerritoryOnBootstrapDefenseFloor(room: Room): boolean {
+  const rcl = getOwnedRoomRcl(room);
+  if (
+    rcl < BOOTSTRAP_DEFENSE_FLOOR_MIN_RCL ||
+    rcl > BOOTSTRAP_DEFENSE_FLOOR_MAX_TERRITORY_GATE_RCL ||
+    !canAssessBootstrapDefenseFloor(room) ||
+    room.name !== ACTIVE_OFFICIAL_ROOM_SELECTION.roomName
+  ) {
+    return false;
+  }
+
+  return hasActiveOfficialSpawn(room, getBootstrapDefenseFloorLookups(room));
+}
+
+function hasActiveOfficialSpawn(room: Room, lookups: BootstrapDefenseFloorLookups): boolean {
+  const expectedSpawn = ACTIVE_OFFICIAL_ROOM_SELECTION.spawn;
+  return getOwnedStructuresByType<StructureSpawn>(room, lookups, 'STRUCTURE_SPAWN')
+    .some((spawn) => (
+      spawn.pos?.roomName === room.name &&
+      spawn.pos.x === expectedSpawn.x &&
+      spawn.pos.y === expectedSpawn.y
+    ));
+}
+
 function selectSpawnWallAnchorPositions(
   room: Room,
   spawnPosition: RoomPosition,
@@ -648,6 +741,14 @@ function getBootstrapDefenseFloorLookups(room: Room): BootstrapDefenseFloorLooku
   return lookups;
 }
 
+function canAssessBootstrapDefenseFloor(room: Room): boolean {
+  return (
+    typeof room.find === 'function' &&
+    getGlobalNumber('FIND_STRUCTURES') !== null &&
+    getGlobalNumber('FIND_CONSTRUCTION_SITES') !== null
+  );
+}
+
 function createBootstrapDefenseFloorLookups(room: Room): BootstrapDefenseFloorLookups {
   const structures = findRoomObjects<Structure>(room, 'FIND_STRUCTURES')
     .filter((structure) => isPositionInRoom(structure.pos, room.name));
@@ -693,6 +794,16 @@ function getConstructionSitesAtPosition(
   position: CandidatePosition
 ): ConstructionSite[] {
   return lookups.constructionSitesByPosition.get(getPositionKey(position)) ?? [];
+}
+
+function getConstructionSitesByType<T extends ConstructionSite>(
+  room: Room,
+  lookups: BootstrapDefenseFloorLookups,
+  structureGlobal: StructureConstantGlobal
+): T[] {
+  const structureType = getStructureConstant(structureGlobal);
+  return lookups.constructionSites
+    .filter((site) => site.structureType === structureType && isPositionInRoom(site.pos, room.name)) as T[];
 }
 
 function isStructureType(

--- a/prod/src/defense/defensePlanner.ts
+++ b/prod/src/defense/defensePlanner.ts
@@ -103,7 +103,11 @@ interface BootstrapDefenseFloorLookups {
   constructionSitesByPosition: Map<string, ConstructionSite[]>;
 }
 
-type FindConstantGlobal = 'FIND_STRUCTURES' | 'FIND_CONSTRUCTION_SITES';
+type FindConstantGlobal =
+  | 'FIND_STRUCTURES'
+  | 'FIND_CONSTRUCTION_SITES'
+  | 'FIND_HOSTILE_CREEPS'
+  | 'FIND_HOSTILE_STRUCTURES';
 type StructureConstantGlobal =
   | 'STRUCTURE_SPAWN'
   | 'STRUCTURE_CONTAINER'
@@ -256,7 +260,7 @@ export function isBootstrapDefenseFloorSatisfiedForTerritory(room: Room): boolea
 }
 
 export function shouldUseBootstrapDefenseFloorRepairCap(room: Room): boolean {
-  return shouldGateTerritoryOnBootstrapDefenseFloor(room);
+  return shouldGateTerritoryOnBootstrapDefenseFloor(room) && !hasVisibleHostilePresence(room);
 }
 
 export function buildDefenderBody(energyAvailable: number, hostileCount: number): BodyPartConstant[] {
@@ -746,6 +750,13 @@ function canAssessBootstrapDefenseFloor(room: Room): boolean {
     typeof room.find === 'function' &&
     getGlobalNumber('FIND_STRUCTURES') !== null &&
     getGlobalNumber('FIND_CONSTRUCTION_SITES') !== null
+  );
+}
+
+function hasVisibleHostilePresence(room: Room): boolean {
+  return (
+    findRoomObjects<Creep>(room, 'FIND_HOSTILE_CREEPS').length > 0 ||
+    findRoomObjects<Structure>(room, 'FIND_HOSTILE_STRUCTURES').length > 0
   );
 }
 

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -1458,6 +1458,7 @@ function getTerritoryIntentPlanningOptions(
 function shouldPlanLocalStableTerritoryScout(context: SpawnPlanningContext): boolean {
   return (
     context.survival.mode === 'LOCAL_STABLE' &&
+    !context.survival.suppressionReasons.includes('defenseFloor') &&
     context.options.workersOnly !== true &&
     context.workerCapacity >= context.workerTarget &&
     context.colony.energyCapacityAvailable >= TERRITORY_SCOUT_BODY_COST &&

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -23,6 +23,11 @@ import {
 } from '../construction/criticalRoads';
 import { isColonyRoomThreatened } from '../defense/colonyThreats';
 import {
+  BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING,
+  shouldGateTerritoryOnBootstrapDefenseFloor,
+  shouldUseBootstrapDefenseFloorRepairCap
+} from '../defense/defensePlanner';
+import {
   CONSTRUCTION_SITE_IMPACT_PRIORITY,
   DEFAULT_REASONABLE_CONSTRUCTION_SITE_RANGE,
   getConstructionSiteImpactPriority,
@@ -689,6 +694,11 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
   const controllerSustainUpgradeTask = selectControllerSustainUpgradeTask(creep, controller);
   if (controllerSustainUpgradeTask) {
     return applyMinimumUsefulLoadPolicy(creep, controllerSustainUpgradeTask);
+  }
+
+  const rcl3DefenseUnlockUpgradeTask = selectRcl3DefenseUnlockUpgradeTask(creep, controller);
+  if (rcl3DefenseUnlockUpgradeTask) {
+    return applyMinimumUsefulLoadPolicy(creep, rcl3DefenseUnlockUpgradeTask);
   }
 
   const constructionPriorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
@@ -6592,10 +6602,18 @@ export function isWorkerRepairTargetComplete(structure: Structure): boolean {
 
 function getWorkerRepairHitsCeiling(structure: Structure): number {
   if (isWorkerBarrierRepairStructure(structure)) {
+    if (shouldUseBootstrapDefenseFloorRepairCap(getStructureRoom(structure))) {
+      return Math.min(structure.hitsMax, BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING);
+    }
+
     return Math.min(structure.hitsMax, IDLE_RAMPART_REPAIR_HITS_CEILING);
   }
 
   return structure.hitsMax;
+}
+
+function getStructureRoom(structure: Structure): Room {
+  return (structure as Structure & { room?: Room }).room ?? ({} as Room);
 }
 
 function isWorkerBarrierRepairStructure(structure: Structure): boolean {
@@ -6652,6 +6670,33 @@ function shouldGuardControllerDowngrade(controller: StructureController | undefi
 
 function shouldRushRcl1Controller(controller: StructureController): boolean {
   return controller.my === true && controller.level === 1;
+}
+
+function selectRcl3DefenseUnlockUpgradeTask(
+  creep: Creep,
+  controller: StructureController | undefined
+): Extract<CreepTaskMemory, { type: 'upgrade' }> | null {
+  if (!shouldUpgradeForRcl3DefenseUnlock(creep, controller)) {
+    return null;
+  }
+
+  return { type: 'upgrade', targetId: controller.id };
+}
+
+function shouldUpgradeForRcl3DefenseUnlock(
+  creep: Creep,
+  controller: StructureController | undefined
+): controller is StructureController {
+  return (
+    controller?.my === true &&
+    controller.level === 2 &&
+    shouldGateTerritoryOnBootstrapDefenseFloor(creep.room) &&
+    isWorkerInColonyRoom(creep) &&
+    getUsedEnergy(creep) > 0 &&
+    !hasVisibleHostilePresence(creep.room) &&
+    !shouldGuardControllerDowngrade(controller) &&
+    !isControllerUpgradeSaturated(creep, controller)
+  );
 }
 
 export function shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep: Creep): boolean {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -6695,7 +6695,7 @@ function shouldUpgradeForRcl3DefenseUnlock(
     getUsedEnergy(creep) > 0 &&
     !hasVisibleHostilePresence(creep.room) &&
     !shouldGuardControllerDowngrade(controller) &&
-    !isControllerUpgradeSaturated(creep, controller)
+    !isControllerUpgradeSaturated(creep, controller, { ignoreTerritoryExpansionPressure: true })
   );
 }
 
@@ -7010,7 +7010,11 @@ function isLowRclControllerProgressTarget(controller: StructureController): bool
   return canLevelUpController(controller) && controller.level >= 2 && controller.level <= 3;
 }
 
-function isControllerUpgradeSaturated(creep: Creep, controller: StructureController): boolean {
+function isControllerUpgradeSaturated(
+  creep: Creep,
+  controller: StructureController,
+  options: { ignoreTerritoryExpansionPressure?: boolean } = {}
+): boolean {
   if (controller.my !== true || shouldGuardControllerDowngrade(controller)) {
     return false;
   }
@@ -7028,7 +7032,7 @@ function isControllerUpgradeSaturated(creep: Creep, controller: StructureControl
     getControllerProgressWorkerLimit(
       creep,
       loadedWorkers.length,
-      hasActiveTerritoryExpansionPressure(creep)
+      options.ignoreTerritoryExpansionPressure !== true && hasActiveTerritoryExpansionPressure(creep)
     )
   );
 

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -43,6 +43,10 @@ import {
   type SourceContainerCoverageSummary
 } from '../economy/sourceContainerPlanner';
 import {
+  assessBootstrapDefenseFloorReadiness,
+  type BootstrapDefenseFloorReadiness
+} from '../defense/defensePlanner';
+import {
   summarizeAndResetCreepBehaviorTelemetry,
   type RuntimeBehaviorSummary as LegacyRuntimeBehaviorSummary,
   type RuntimeEnergyAcquisitionMethodDistribution
@@ -625,6 +629,22 @@ interface RuntimeSurvivalSummary {
   workerTarget: number;
   survivalWorkerFloor: number;
   suppressionReasons?: ColonySuppressionReason[];
+  defenseFloor?: RuntimeDefenseFloorSummary;
+}
+
+interface RuntimeDefenseFloorSummary {
+  ready: boolean;
+  assessable: boolean;
+  rcl: number;
+  anchorReady: boolean;
+  towerReady: boolean;
+  towerCount: number;
+  pendingTowerCount: number;
+  spawnRampartReady: boolean;
+  wallAnchorCount: number;
+  requiredWallAnchorCount: number;
+  missingAnchorCount: number;
+  repairHitsCeiling: number;
 }
 
 interface RuntimeRoomEventMetrics {
@@ -2574,13 +2594,40 @@ function summarizeConstructionPriority(
 
 function summarizeSurvival(colony: ColonySnapshot, roleCounts: RoleCounts): RuntimeSurvivalSummary {
   const assessment = assessColonySnapshotSurvival(colony, roleCounts);
+  const defenseFloor = assessBootstrapDefenseFloorReadiness(colony.room);
 
   return {
     mode: assessment.mode,
     workerCapacity: assessment.workerCapacity,
     workerTarget: assessment.workerTarget,
     survivalWorkerFloor: assessment.survivalWorkerFloor,
-    ...(assessment.suppressionReasons.length > 0 ? { suppressionReasons: assessment.suppressionReasons } : {})
+    ...(assessment.suppressionReasons.length > 0 ? { suppressionReasons: assessment.suppressionReasons } : {}),
+    ...(shouldReportRuntimeDefenseFloor(defenseFloor)
+      ? { defenseFloor: toRuntimeDefenseFloorSummary(defenseFloor) }
+      : {})
+  };
+}
+
+function shouldReportRuntimeDefenseFloor(defenseFloor: BootstrapDefenseFloorReadiness): boolean {
+  return defenseFloor.assessable && (defenseFloor.anchors.length > 0 || defenseFloor.rcl >= 3);
+}
+
+function toRuntimeDefenseFloorSummary(
+  defenseFloor: BootstrapDefenseFloorReadiness
+): RuntimeDefenseFloorSummary {
+  return {
+    ready: defenseFloor.ready,
+    assessable: defenseFloor.assessable,
+    rcl: defenseFloor.rcl,
+    anchorReady: defenseFloor.anchorReady,
+    towerReady: defenseFloor.towerReady,
+    towerCount: defenseFloor.towerCount,
+    pendingTowerCount: defenseFloor.pendingTowerCount,
+    spawnRampartReady: defenseFloor.spawnRampartReady,
+    wallAnchorCount: defenseFloor.wallAnchorCount,
+    requiredWallAnchorCount: defenseFloor.requiredWallAnchorCount,
+    missingAnchorCount: defenseFloor.missingAnchors.length,
+    repairHitsCeiling: defenseFloor.repairHitsCeiling
   };
 }
 

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -2609,7 +2609,7 @@ function summarizeSurvival(colony: ColonySnapshot, roleCounts: RoleCounts): Runt
 }
 
 function shouldReportRuntimeDefenseFloor(defenseFloor: BootstrapDefenseFloorReadiness): boolean {
-  return defenseFloor.assessable && (defenseFloor.anchors.length > 0 || defenseFloor.rcl >= 3);
+  return defenseFloor.assessable;
 }
 
 function toRuntimeDefenseFloorSummary(

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -28,6 +28,7 @@ import {
   isRouteBlockedByKnownDeadZone,
   refreshVisibleRoomDeadZoneMemory
 } from '../defense/deadZone';
+import { isBootstrapDefenseFloorSatisfiedForTerritory } from '../defense/defensePlanner';
 import { planSourceContainerConstruction } from '../construction/sourceContainerPlanner';
 import {
   findSourceContainer,
@@ -1114,6 +1115,10 @@ export function isTerritoryHomeSafe(
 
   const controller = colony.room.controller;
   if (controller?.my !== true || typeof controller.level !== 'number' || controller.level < 2) {
+    return false;
+  }
+
+  if (!isBootstrapDefenseFloorSatisfiedForTerritory(colony.room)) {
     return false;
   }
 

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -66,7 +66,7 @@ export function runTerritoryControllerCreep(
 
   const colonyStageAssessment = getRecordedColonyStageAssessment(creep.memory.colony);
   if (assignment.action === 'scout') {
-    if (colonyStageAssessment?.mode === 'BOOTSTRAP' || colonyStageAssessment?.mode === 'DEFENSE') {
+    if (shouldHoldTerritoryScout(colonyStageAssessment)) {
       return;
     }
   } else if (suppressesTerritoryWork(colonyStageAssessment)) {
@@ -202,6 +202,16 @@ export function runTerritoryControllerCreep(
   ) {
     suppressTerritoryAssignment(creep, assignment);
   }
+}
+
+function shouldHoldTerritoryScout(
+  colonyStageAssessment: ReturnType<typeof getRecordedColonyStageAssessment>
+): boolean {
+  return (
+    colonyStageAssessment?.mode === 'BOOTSTRAP' ||
+    colonyStageAssessment?.mode === 'DEFENSE' ||
+    colonyStageAssessment?.suppressionReasons.includes('defenseFloor') === true
+  );
 }
 
 export function logBestClaimTarget(homeRoom: Room): string | null {

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -210,7 +210,7 @@ function shouldHoldTerritoryScout(
   return (
     colonyStageAssessment?.mode === 'BOOTSTRAP' ||
     colonyStageAssessment?.mode === 'DEFENSE' ||
-    colonyStageAssessment?.suppressionReasons.includes('defenseFloor') === true
+    colonyStageAssessment?.suppressionReasons?.includes('defenseFloor') === true
   );
 }
 

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -741,6 +741,7 @@ declare global {
       | 'bootstrapRecovery'
       | 'localWorkerRecovery'
       | 'controllerDowngradeGuard'
+      | 'defenseFloor'
       | 'territoryEnergyCapacity'
       | 'controllerLevel'
       | 'defense'

--- a/prod/test/colonyExpansionPlanner.test.ts
+++ b/prod/test/colonyExpansionPlanner.test.ts
@@ -46,6 +46,7 @@ describe('colony expansion planner', () => {
       workerTarget: 3,
       energyAvailable: 650,
       energyCapacityAvailable: 650,
+      defenseFloorReady: true,
       controller: { my: true, level: 3, ticksToDowngrade: 10_000 }
     });
     const selectedScore = scoreClaimTarget('W1N2', colony.room).score;
@@ -108,6 +109,7 @@ describe('colony expansion planner', () => {
       workerTarget: 3,
       energyAvailable: 650,
       energyCapacityAvailable: 650,
+      defenseFloorReady: true,
       controller: { my: true, level: 3, ticksToDowngrade: 10_000 }
     });
     const selectedScore = scoreClaimTarget('W1N2', colony.room).score;
@@ -204,6 +206,7 @@ describe('colony expansion planner', () => {
       workerTarget: 3,
       energyAvailable: 650,
       energyCapacityAvailable: 650,
+      defenseFloorReady: true,
       controller: { my: true, level: 3, ticksToDowngrade: 10_000 }
     });
 
@@ -253,6 +256,7 @@ describe('colony expansion planner', () => {
       workerTarget: 3,
       energyAvailable: 1_000,
       energyCapacityAvailable: 1_000,
+      defenseFloorReady: true,
       controller: { my: true, level: 3, ticksToDowngrade: 10_000 }
     });
     const duplicateScore = scoreClaimTarget('W2N1', colony.room).score;
@@ -300,6 +304,7 @@ describe('colony expansion planner', () => {
       workerTarget: 3,
       energyAvailable: 650,
       energyCapacityAvailable: 650,
+      defenseFloorReady: true,
       controller: { my: true, level: 3, ticksToDowngrade: 10_000 }
     });
     const eligibleScore = scoreClaimTarget('W2N1', colony.room).score;
@@ -343,6 +348,7 @@ describe('colony expansion planner', () => {
       workerTarget: 3,
       energyAvailable: 650,
       energyCapacityAvailable: 650,
+      defenseFloorReady: true,
       controller: { my: true, level: 3, ticksToDowngrade: 10_000 }
     });
 

--- a/prod/test/colonyStage.test.ts
+++ b/prod/test/colonyStage.test.ts
@@ -131,6 +131,26 @@ describe('colony bootstrap stage', () => {
     });
   });
 
+  it('holds territory readiness while the local defense floor is missing', () => {
+    const assessment = assessColonyStage({
+      roomName: 'E29N55',
+      totalCreeps: 9,
+      workerCapacity: 4,
+      workerTarget: 4,
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      defenseFloorReady: false,
+      controller: { my: true, level: 3, ticksToDowngrade: 10_000 }
+    });
+
+    expect(assessment).toMatchObject({
+      mode: 'LOCAL_STABLE',
+      territoryReady: false,
+      suppressionReasons: ['defenseFloor']
+    });
+    expect(suppressesTerritoryWork(assessment)).toBe(true);
+  });
+
   it('orders spawn tiers from emergency bootstrap through territory work', () => {
     expect(getColonySpawnPriorityTiers()).toEqual([
       'emergencyBootstrap',

--- a/prod/test/colonyStage.test.ts
+++ b/prod/test/colonyStage.test.ts
@@ -103,6 +103,7 @@ describe('colony bootstrap stage', () => {
         workerTarget: 4,
         energyAvailable: 800,
         energyCapacityAvailable: 800,
+        defenseFloorReady: true,
         previousMode: 'BOOTSTRAP',
         controller: { my: true, level: 3, ticksToDowngrade: 10_000 }
       })
@@ -122,6 +123,7 @@ describe('colony bootstrap stage', () => {
         workerTarget: 4,
         energyAvailable: 400,
         energyCapacityAvailable: 400,
+        defenseFloorReady: true,
         previousMode: 'BOOTSTRAP',
         controller: { my: true, level: 3, ticksToDowngrade: 10_000 }
       })
@@ -149,6 +151,24 @@ describe('colony bootstrap stage', () => {
       suppressionReasons: ['defenseFloor']
     });
     expect(suppressesTerritoryWork(assessment)).toBe(true);
+  });
+
+  it('fails closed when defense floor readiness is not wired', () => {
+    expect(
+      assessColonyStage({
+        roomName: 'E29N55',
+        totalCreeps: 9,
+        workerCapacity: 4,
+        workerTarget: 4,
+        energyAvailable: 650,
+        energyCapacityAvailable: 650,
+        controller: { my: true, level: 3, ticksToDowngrade: 10_000 }
+      })
+    ).toMatchObject({
+      mode: 'LOCAL_STABLE',
+      territoryReady: false,
+      suppressionReasons: ['defenseFloor']
+    });
   });
 
   it('orders spawn tiers from emergency bootstrap through territory work', () => {

--- a/prod/test/colonySurvivalMode.test.ts
+++ b/prod/test/colonySurvivalMode.test.ts
@@ -36,6 +36,7 @@ describe('assessColonySurvival', () => {
         workerCapacity: 3,
         workerTarget: 4,
         energyCapacityAvailable: 650,
+        defenseFloorReady: true,
         controller: { my: true, level: 3, ticksToDowngrade: 10_000 }
       })
     ).toMatchObject({
@@ -51,6 +52,7 @@ describe('assessColonySurvival', () => {
         workerCapacity: 4,
         workerTarget: 4,
         energyCapacityAvailable: 650,
+        defenseFloorReady: true,
         controller: { my: true, level: 3, ticksToDowngrade: 10_000 }
       })
     ).toMatchObject({
@@ -68,6 +70,7 @@ describe('assessColonySurvival', () => {
         workerTarget: 4,
         energyCapacityAvailable: 650,
         controller: { my: true, level: 3, ticksToDowngrade: 10_000 },
+        defenseFloorReady: true,
         hostileCreepCount: 1
       })
     ).toMatchObject({

--- a/prod/test/defensePlanner.test.ts
+++ b/prod/test/defensePlanner.test.ts
@@ -1,6 +1,8 @@
 import {
   assessBootstrapDefenseFloor,
+  assessBootstrapDefenseFloorReadiness,
   buildDefenderBody,
+  BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING,
   getDesiredDefenderCount,
   hasDefensePressure,
   planBootstrapDefenseFloorPlacements,
@@ -266,6 +268,63 @@ describe('defensePlanner', () => {
     expect(assessment.spawnRampartReady).toBe(true);
     expect(assessment.wallAnchorCount).toBe(0);
     expect(assessment.ready).toBe(true);
+  });
+
+  it('keeps the bootstrap defense floor compact with low early repair caps', () => {
+    const room = makeDefenseRoom();
+
+    const placements = planBootstrapDefenseFloorPlacements(room, { maxPlacements: 10 });
+    const readiness = assessBootstrapDefenseFloorReadiness(room);
+
+    expect(placements.map((placement) => placement.kind)).toEqual([
+      'spawnRampart',
+      'spawnWall',
+      'spawnWall',
+      'controllerRampart'
+    ]);
+    expect(readiness).toMatchObject({
+      ready: false,
+      assessable: true,
+      anchorReady: false,
+      towerReady: true,
+      requiredWallAnchorCount: 1,
+      wallAnchorCount: 0,
+      repairHitsCeiling: BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING
+    });
+  });
+
+  it('requires an owned tower at RCL3 before territory work is defense-ready', () => {
+    const coveredAnchors = [
+      makeDefenseStructure('spawn-rampart', TEST_GLOBALS.STRUCTURE_RAMPART, 10, 10),
+      makeDefenseStructure('wall-blocker-a', TEST_GLOBALS.STRUCTURE_WALL, 9, 9),
+      makeDefenseStructure('wall-blocker-b', TEST_GLOBALS.STRUCTURE_WALL, 11, 9),
+      makeDefenseStructure('wall-blocker-c', TEST_GLOBALS.STRUCTURE_WALL, 9, 11),
+      makeDefenseStructure('wall-blocker-d', TEST_GLOBALS.STRUCTURE_WALL, 11, 11)
+    ];
+    const roomWithoutTower = makeDefenseRoom({
+      controllerLevel: 3,
+      structures: coveredAnchors
+    });
+    const roomWithTower = makeDefenseRoom({
+      controllerLevel: 3,
+      structures: [
+        ...coveredAnchors,
+        makeDefenseStructure('tower1', TEST_GLOBALS.STRUCTURE_TOWER, 12, 10, 'W1N1', true)
+      ]
+    });
+
+    expect(assessBootstrapDefenseFloorReadiness(roomWithoutTower)).toMatchObject({
+      ready: false,
+      anchorReady: true,
+      towerCount: 0,
+      towerReady: false
+    });
+    expect(assessBootstrapDefenseFloorReadiness(roomWithTower)).toMatchObject({
+      ready: true,
+      anchorReady: true,
+      towerCount: 1,
+      towerReady: true
+    });
   });
 
   it('caches visible structure and construction-site lookups for defense-floor assessment', () => {

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -257,7 +257,21 @@ describe('runtime telemetry summaries', () => {
             workerCapacity: 2,
             workerTarget: 4,
             survivalWorkerFloor: 3,
-            suppressionReasons: ['bootstrapWorkerFloor', 'spawnEnergyCritical']
+            suppressionReasons: ['bootstrapWorkerFloor', 'spawnEnergyCritical'],
+            defenseFloor: {
+              ready: true,
+              assessable: true,
+              rcl: 2,
+              anchorReady: true,
+              towerReady: true,
+              towerCount: 0,
+              pendingTowerCount: 0,
+              spawnRampartReady: false,
+              wallAnchorCount: 0,
+              requiredWallAnchorCount: 0,
+              missingAnchorCount: 0,
+              repairHitsCeiling: 25_000
+            }
           },
           territoryRecommendation: {
             candidates: [],
@@ -271,6 +285,37 @@ describe('runtime telemetry summaries', () => {
         bucket: 9000
       }
     });
+  });
+
+  it('reports assessable bootstrap defense floor telemetry before anchors exist', () => {
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      roomName: 'E29N55',
+      structures: [
+        {
+          id: 'spawn1',
+          structureType: TEST_GLOBALS.STRUCTURE_SPAWN,
+          my: true,
+          pos: { x: 17, y: 24, roomName: 'E29N55' },
+          store: makeEnergyStore(50)
+        }
+      ]
+    });
+
+    emitRuntimeSummary([colony], []);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<{ survival: { defenseFloor: { missingAnchorCount: number } } }>;
+    expect(room.survival.defenseFloor).toMatchObject({
+      ready: false,
+      assessable: true,
+      rcl: 2,
+      anchorReady: false,
+      towerReady: true,
+      towerCount: 0,
+      pendingTowerCount: 0
+    });
+    expect(room.survival.defenseFloor.missingAnchorCount).toBeGreaterThan(0);
   });
 
   it('does not emit on non-cadence ticks without events', () => {

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -4908,6 +4908,50 @@ describe('planSpawn', () => {
     ]);
   });
 
+  it('holds E29N55 scout-only execution while RCL3 tower defense is missing', () => {
+    (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 11;
+    (globalThis as unknown as { STRUCTURE_RAMPART: StructureConstant }).STRUCTURE_RAMPART = 'rampart';
+    (globalThis as unknown as { STRUCTURE_WALL: StructureConstant }).STRUCTURE_WALL = 'constructedWall';
+    const { colony } = makeColony({
+      roomName: 'E29N55',
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: {
+        my: true,
+        level: 3,
+        ticksToDowngrade: 10_000,
+        pos: { x: 25, y: 25, roomName: 'E29N55' } as RoomPosition
+      } as StructureController,
+      structures: [
+        {
+          id: 'spawn1',
+          structureType: 'spawn',
+          my: true,
+          pos: { x: 17, y: 24, roomName: 'E29N55' }
+        } as AnyStructure,
+        {
+          id: 'spawn-rampart',
+          structureType: 'rampart',
+          my: true,
+          pos: { x: 17, y: 24, roomName: 'E29N55' }
+        } as AnyStructure,
+        {
+          id: 'spawn-wall',
+          structureType: 'constructedWall',
+          pos: { x: 16, y: 23, roomName: 'E29N55' }
+        } as AnyStructure
+      ]
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    installRuntimeCurrentRoom('E29N55');
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: { E29N55: colony.room }
+    };
+
+    expect(planSpawn(colony, { worker: 6, claimer: 0, claimersByTargetRoom: {} }, 968_802)).toBeNull();
+    expect(Memory.territory?.intents).toBeUndefined();
+  });
+
   it('spawns a minimal claimer for E17S58 after scout intel and claim capacity are ready', () => {
     const { colony, spawn } = makeColony({
       roomName: 'E17S59',

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -72,6 +72,66 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('holds configured territory execution while an E29N55-like RCL3 room has no tower', () => {
+    const globals = globalThis as unknown as {
+      FIND_STRUCTURES: number;
+      FIND_CONSTRUCTION_SITES: number;
+      STRUCTURE_SPAWN: StructureConstant;
+      STRUCTURE_RAMPART: StructureConstant;
+      STRUCTURE_WALL: StructureConstant;
+      STRUCTURE_TOWER: StructureConstant;
+    };
+    globals.FIND_STRUCTURES = 10;
+    globals.FIND_CONSTRUCTION_SITES = 11;
+    globals.STRUCTURE_SPAWN = 'spawn';
+    globals.STRUCTURE_RAMPART = 'rampart';
+    globals.STRUCTURE_WALL = 'constructedWall';
+    globals.STRUCTURE_TOWER = 'tower';
+    const roomName = 'E29N55';
+    const controller = {
+      id: 'controller-e29n55',
+      my: true,
+      owner: { username: 'me' },
+      level: 3,
+      ticksToDowngrade: 10_000,
+      pos: makeRoomPosition(25, 25, roomName)
+    } as StructureController;
+    const structures = [
+      makeStructure('Spawn1', 'spawn', 17, 24, roomName, true),
+      makeStructure('spawn-rampart', 'rampart', 17, 24, roomName, true),
+      makeStructure('spawn-wall', 'constructedWall', 16, 23, roomName)
+    ];
+    const room = {
+      name: roomName,
+      controller,
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      find: jest.fn((findType: number) => {
+        if (findType === globals.FIND_STRUCTURES) {
+          return structures;
+        }
+        if (findType === globals.FIND_CONSTRUCTION_SITES) {
+          return [];
+        }
+        return [];
+      })
+    } as unknown as Room;
+    const colony = {
+      room,
+      spawns: [structures[0] as StructureSpawn],
+      energyAvailable: 650,
+      energyCapacityAvailable: 650
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: roomName, roomName: 'E29N56', action: 'reserve' }]
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 4, claimer: 0, claimersByTargetRoom: {} }, 4, 1000)).toBeNull();
+    expect(Memory.territory?.intents).toBeUndefined();
+  });
+
   it('keeps source-owned territory intents separate from unowned progress records', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
@@ -7230,4 +7290,24 @@ function makeSafeColony({
     energyAvailable,
     energyCapacityAvailable
   };
+}
+
+function makeRoomPosition(x: number, y: number, roomName: string): RoomPosition {
+  return { x, y, roomName } as RoomPosition;
+}
+
+function makeStructure(
+  id: string,
+  structureType: StructureConstant,
+  x: number,
+  y: number,
+  roomName: string,
+  my?: boolean
+): Structure {
+  return {
+    id,
+    structureType,
+    my,
+    pos: makeRoomPosition(x, y, roomName)
+  } as unknown as Structure;
 }

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -306,6 +306,38 @@ describe('runTerritoryControllerCreep', () => {
     expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'scout' });
   });
 
+  it('holds scout execution while local stability is blocked by the defense floor', () => {
+    recordColonyStageAssessment(
+      'W1N1',
+      {
+        mode: 'LOCAL_STABLE',
+        stage: 'LOCAL_STABLE',
+        roomName: 'W1N1',
+        totalCreeps: 4,
+        spawnEnergyAvailable: 650,
+        workerCapacity: 4,
+        workerTarget: 4,
+        survivalWorkerFloor: 3,
+        bootstrapRecovery: false,
+        controllerDowngradeGuard: false,
+        hostilePresence: false,
+        territoryReady: false,
+        suppressionReasons: ['defenseFloor']
+      },
+      500
+    );
+    const creep = {
+      memory: { role: 'scout', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'scout' } },
+      room: { name: 'W1N1' },
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'scout' });
+  });
+
   it('reserves the target room controller and moves into range when needed', () => {
     const controller = { id: 'controller1', my: false } as StructureController;
     const creep = {

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -338,6 +338,35 @@ describe('runTerritoryControllerCreep', () => {
     expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'scout' });
   });
 
+  it('treats missing stage suppression reasons as empty for scout holds', () => {
+    recordColonyStageAssessment(
+      'W1N1',
+      {
+        mode: 'LOCAL_STABLE',
+        stage: 'LOCAL_STABLE',
+        roomName: 'W1N1',
+        totalCreeps: 4,
+        spawnEnergyAvailable: 650,
+        workerCapacity: 4,
+        workerTarget: 4,
+        survivalWorkerFloor: 3,
+        bootstrapRecovery: false,
+        controllerDowngradeGuard: false,
+        hostilePresence: false,
+        territoryReady: false
+      } as Parameters<typeof recordColonyStageAssessment>[1],
+      500
+    );
+    const creep = {
+      memory: { role: 'scout', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'scout' } },
+      room: { name: 'W1N1' },
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    expect(() => runTerritoryControllerCreep(creep)).not.toThrow();
+    expect(creep.moveTo).toHaveBeenCalledWith({ x: 25, y: 25, roomName: 'W1N2' });
+  });
+
   it('reserves the target room controller and moves into range when needed', () => {
     const controller = { id: 'controller1', my: false } as StructureController;
     const creep = {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -478,6 +478,7 @@ function recordSurvivalMode(
   const assessment = assessColonySurvival({
     roomName: 'W1N1',
     energyCapacityAvailable: 650,
+    defenseFloorReady: true,
     controller: { my: true, level: 3, ticksToDowngrade: 10_000 },
     ...inputByMode
   });
@@ -7059,6 +7060,46 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
+  it('keeps RCL2 defense unlock upgrading despite active territory pressure', () => {
+    const roadSite = { id: 'road-site', structureType: 'road' } as ConstructionSite;
+    const activeSpawn = makeStructure('spawn1', 'spawn' as StructureConstant, 5_000, 5_000, {
+      my: true,
+      pos: makeRoomPosition(17, 24, 'E29N55')
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N55',
+      controller,
+      constructionSites: [roadSite],
+      energyAvailable: 300,
+      energyCapacityAvailable: 300,
+      structures: [activeSpawn]
+    });
+    const creep = {
+      name: 'BootstrapWorker',
+      memory: { role: 'worker', colony: 'E29N55' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'E29N55', targetRoom: 'E29N56', action: 'scout', status: 'planned', updatedAt: 301 }]
+      }
+    };
+    setGameCreeps({
+      Upgrader: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }),
+      BuilderA: makeLoadedWorker(room),
+      BuilderB: makeLoadedWorker(room)
+    });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
   it('preserves RCL2 capacity construction before controller progress for tower unlock', () => {
     const extensionSite = { id: 'extension-site', structureType: 'extension' } as ConstructionSite;
     const activeSpawn = makeStructure('spawn1', 'spawn' as StructureConstant, 5_000, 5_000, {
@@ -7144,6 +7185,59 @@ describe('selectWorkerTask', () => {
 
     expect(isWorkerRepairTargetComplete(rampartAtCap)).toBe(true);
     expect(isWorkerRepairTargetComplete(rampartBelowCap)).toBe(false);
+  });
+
+  it('keeps threatened bootstrap barriers repairable above the defense floor cap while hostiles are visible', () => {
+    const structures: AnyStructure[] = [];
+    const room = makeWorkerTaskRoom({
+      controller: {
+        id: 'controller1',
+        my: true,
+        level: 2,
+        ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+      } as StructureController,
+      hostileCreeps: [{ id: 'hostile1' } as Creep],
+      name: 'E29N55',
+      structures
+    });
+    const spawn = makeStructure('spawn1', 'spawn' as StructureConstant, 5_000, 5_000, {
+      my: true,
+      pos: makeRoomPosition(17, 24, 'E29N55')
+    });
+    const wallAtCap = makeStructure(
+      'wall-at-cap',
+      'constructedWall' as StructureConstant,
+      BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING,
+      300_000_000,
+      { pos: makeRoomPosition(16, 23, 'E29N55'), room }
+    );
+    structures.push(spawn, wallAtCap);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      defense: {
+        colonyThreats: {
+          updatedAt: 302,
+          rooms: {
+            E29N55: {
+              roomName: 'E29N55',
+              level: 'hostile_present',
+              updatedAt: 302,
+              hostileCreepCount: 1,
+              hostileStructureCount: 0,
+              damagedCriticalStructureCount: 0
+            }
+          }
+        }
+      }
+    };
+    const creep = {
+      memory: { role: 'worker', colony: 'E29N55' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 302 };
+
+    expect(isWorkerRepairTargetComplete(wallAtCap)).toBe(false);
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'wall-at-cap' });
   });
 
   it('spends carried energy productively when another worker covers the low tower refill', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -23,9 +23,11 @@ import {
   canUpgradeController,
   isUpgraderBoostActive,
   selectWorkerEnergyCriticalAcquisitionTask,
+  isWorkerRepairTargetComplete,
   selectWorkerTask,
   shouldSwitchLowLoadWorkerEnergyAcquisitionTaskForYield
 } from '../src/tasks/workerTasks';
+import { BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING } from '../src/defense/defensePlanner';
 import type { ColonySnapshot } from '../src/colony/colonyRegistry';
 import {
   emitRuntimeSummary,
@@ -7026,6 +7028,122 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'e17s58-tower-low' });
+  });
+
+  it('keeps RCL2 controller progress ahead of generic construction for tower unlock', () => {
+    const roadSite = { id: 'road-site', structureType: 'road' } as ConstructionSite;
+    const activeSpawn = makeStructure('spawn1', 'spawn' as StructureConstant, 5_000, 5_000, {
+      my: true,
+      pos: makeRoomPosition(17, 24, 'E29N55')
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      name: 'BootstrapWorker',
+      memory: { role: 'worker', colony: 'E29N55' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        name: 'E29N55',
+        controller,
+        constructionSites: [roadSite],
+        energyAvailable: 300,
+        energyCapacityAvailable: 300,
+        structures: [activeSpawn]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('preserves RCL2 capacity construction before controller progress for tower unlock', () => {
+    const extensionSite = { id: 'extension-site', structureType: 'extension' } as ConstructionSite;
+    const activeSpawn = makeStructure('spawn1', 'spawn' as StructureConstant, 5_000, 5_000, {
+      my: true,
+      pos: makeRoomPosition(17, 24, 'E29N55')
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      name: 'BootstrapWorker',
+      memory: { role: 'worker', colony: 'E29N55' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        name: 'E29N55',
+        controller,
+        constructionSites: [extensionSite],
+        energyAvailable: 300,
+        energyCapacityAvailable: 300,
+        structures: [activeSpawn]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'extension-site' });
+  });
+
+  it('keeps low tower refill ahead of generic repairs', () => {
+    const lowTower = makeTowerEnergySink('tower-low', TOWER_REFILL_ENERGY_FLOOR - 1, 501);
+    const damagedRoad = makeStructure('road-damaged', 'road' as StructureConstant, 1_000, 5_000);
+    const creep = {
+      name: 'TowerRefiller',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        controller: {
+          id: 'controller1',
+          my: true,
+          level: 3,
+          ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+        } as StructureController,
+        myStructures: [lowTower as AnyOwnedStructure],
+        structures: [damagedRoad]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'tower-low' });
+  });
+
+  it('caps bootstrap barrier repairs at the defense floor ceiling', () => {
+    const structures: AnyStructure[] = [];
+    const room = makeWorkerTaskRoom({
+      controller: {
+        id: 'controller1',
+        my: true,
+        level: 2,
+        ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+      } as StructureController,
+      name: 'E29N55',
+      structures
+    });
+    const spawn = makeStructure('spawn1', 'spawn' as StructureConstant, 5_000, 5_000, {
+      my: true,
+      pos: makeRoomPosition(17, 24, 'E29N55')
+    });
+    const rampartAtCap = makeStructure(
+      'rampart-at-cap',
+      'rampart' as StructureConstant,
+      BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING,
+      300_000,
+      { my: true, pos: makeRoomPosition(17, 24, 'E29N55'), room }
+    );
+    const rampartBelowCap = makeStructure(
+      'rampart-below-cap',
+      'rampart' as StructureConstant,
+      BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING - 1,
+      300_000,
+      { my: true, pos: makeRoomPosition(17, 24, 'E29N55'), room }
+    );
+    structures.push(spawn, rampartAtCap, rampartBelowCap);
+
+    expect(isWorkerRepairTargetComplete(rampartAtCap)).toBe(true);
+    expect(isWorkerRepairTargetComplete(rampartBelowCap)).toBe(false);
   });
 
   it('spends carried energy productively when another worker covers the low tower refill', () => {


### PR DESCRIPTION
## Summary
- add an E29N55 bootstrap defense-floor gate that suppresses live territory execution until compact local defense prerequisites are met
- require RCL3 tower readiness for defense floor completion, prioritize tower refill, and cap early barrier repairs to avoid energy starvation
- keep enough RCL2 controller progress toward tower unlock while preserving capacity construction, telemetry, spawn-tier, and territory-runner evidence
- add regression coverage for defense readiness, tower refill, repair caps, spawn planning, colony-stage suppression, and territory execution holds

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (98 suites / 1894 tests passed)
- `cd prod && npm run build`

Closes #1125

Post-merge acceptance: deploy to official MMO and verify E29N55 remains alive while defense-floor telemetry shows compact anchors/tower readiness and live expansion/remote execution remains held until the floor is satisfied.