### PR TITLE
fix(rl): enforce experiment card safety contract

### DIFF
--- a/scripts/screeps_rl_metrics_ingestor.py
+++ b/scripts/screeps_rl_metrics_ingestor.py
@@ -773,7 +773,9 @@ def training_report_component_order(payload: dict[str, object]) -> list[str]:
 
 def reward_component_order_for_tuple(explicit_order: list[str], tuple_length: int) -> list[str]:
     if explicit_order:
-        return explicit_order
+        if len(explicit_order) == tuple_length:
+            return explicit_order
+        return []
     if tuple_length == len(LEGACY_REWARD_COMPONENT_ORDER):
         return list(LEGACY_REWARD_COMPONENT_ORDER)
     return []

--- a/scripts/screeps_rl_metrics_ingestor.py
+++ b/scripts/screeps_rl_metrics_ingestor.py
@@ -667,6 +667,18 @@ DEDUPE_TABLE_KEYS = {
     ),
 }
 
+REWARD_COMPONENT_METRICS = (
+    ("territory", "rl.training.reward_territory"),
+    ("resources", "rl.training.reward_resources"),
+    ("kills", "rl.training.reward_kills"),
+)
+POLICY_ADVANTAGE_COMPONENT_METRICS = (
+    ("territory", "rl.policy.advantage_territory"),
+    ("resources", "rl.policy.advantage_resources"),
+    ("kills", "rl.policy.advantage_kills"),
+)
+LEGACY_REWARD_COMPONENT_ORDER = ("territory", "resources", "kills")
+
 
 def canonical_json(value: object) -> str:
     return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
@@ -741,6 +753,41 @@ def integer_value(value: object) -> int | None:
 
 def text_value(value: object) -> str | None:
     return value if isinstance(value, str) and value else None
+
+
+def component_order_from_mapping(mapping: dict[str, object]) -> list[str]:
+    raw_order = mapping.get("componentOrder")
+    if raw_order is None:
+        raw_order = mapping.get("component_order")
+    order = as_list(raw_order)
+    if not order or not all(isinstance(item, str) and item for item in order):
+        return []
+    return list(order)
+
+
+def training_report_component_order(payload: dict[str, object]) -> list[str]:
+    return component_order_from_mapping(as_dict(payload.get("rewardModel"))) or component_order_from_mapping(
+        as_dict(payload.get("reward_model"))
+    )
+
+
+def reward_component_order_for_tuple(explicit_order: list[str], tuple_length: int) -> list[str]:
+    if explicit_order:
+        return explicit_order
+    if tuple_length == len(LEGACY_REWARD_COMPONENT_ORDER):
+        return list(LEGACY_REWARD_COMPONENT_ORDER)
+    return []
+
+
+def reward_component_values(reward_tuple: list[object], component_order: list[str]) -> dict[str, float]:
+    values: dict[str, float] = {}
+    for index, component in enumerate(component_order):
+        if index >= len(reward_tuple):
+            continue
+        value = number_value(reward_tuple[index])
+        if value is not None:
+            values[component] = value
+    return values
 
 
 def nested_value(value: object, path: tuple[str, ...]) -> object:
@@ -2729,6 +2776,7 @@ def process_training_report(
     stats: dict[str, int],
 ) -> None:
     report_id = text_value(payload.get("reportId"))
+    report_component_order = training_report_component_order(payload)
     for result in as_list(payload.get("variantResults")):
         if not isinstance(result, dict):
             continue
@@ -2744,22 +2792,21 @@ def process_training_report(
         )
         reward = as_dict(result.get("reward"))
         reward_tuple = as_list(reward.get("tuple"))
-        for index, metric_name in enumerate(
-            (
-                "rl.training.reward_territory",
-                "rl.training.reward_resources",
-                "rl.training.reward_kills",
-            )
-        ):
-            if index < len(reward_tuple):
+        component_order = reward_component_order_for_tuple(
+            component_order_from_mapping(reward) or report_component_order,
+            len(reward_tuple),
+        )
+        component_values = reward_component_values(reward_tuple, component_order)
+        for component, metric_name in REWARD_COMPONENT_METRICS:
+            if component in component_values:
                 record_training_metric(
                     conn,
                     report_id=report_id,
                     variant_id=variant_id,
                     metric_name=metric_name,
-                    value=number_value(reward_tuple[index]),
+                    value=component_values[component],
                     source_artifact=source_artifact,
-                    evidence={"rewardTuple": reward_tuple},
+                    evidence={"rewardTuple": reward_tuple, "componentOrder": component_order},
                 )
 
     incumbent_ids = [item for item in as_list(payload.get("incumbentStrategyIds")) if isinstance(item, str)]
@@ -2770,24 +2817,34 @@ def process_training_report(
         best_tuple = reward_tuple_from_ranking_item(best)
         incumbent = first_incumbent_ranking(ranking, incumbent_ids)
         incumbent_tuple = reward_tuple_from_ranking_item(incumbent) if incumbent else []
-        for index, metric_name in enumerate(
-            (
-                "rl.policy.advantage_territory",
-                "rl.policy.advantage_resources",
-                "rl.policy.advantage_kills",
-            )
-        ):
-            if index < len(best_tuple) and index < len(incumbent_tuple):
+        best_reward = as_dict(best.get("reward"))
+        incumbent_reward = as_dict(incumbent.get("reward")) if incumbent else {}
+        component_order = reward_component_order_for_tuple(
+            component_order_from_mapping(best_reward)
+            or component_order_from_mapping(incumbent_reward)
+            or report_component_order,
+            max(len(best_tuple), len(incumbent_tuple)),
+        )
+        best_values = reward_component_values(best_tuple, component_order)
+        incumbent_values = reward_component_values(incumbent_tuple, component_order)
+        for component, metric_name in POLICY_ADVANTAGE_COMPONENT_METRICS:
+            best_value = best_values.get(component)
+            incumbent_value = incumbent_values.get(component)
+            if best_value is not None and incumbent_value is not None:
                 record_policy_advantage(
                     conn,
                     report_id=report_id,
                     candidate_id=candidate_id,
                     incumbent_id=text_value(incumbent.get("variantId")) if incumbent else None,
                     metric_name=metric_name,
-                    value=number_value(best_tuple[index]) - number_value(incumbent_tuple[index]),
+                    value=best_value - incumbent_value,
                     directionality="higher is better",
                     source_artifact=source_artifact,
-                    evidence={"bestRewardTuple": best_tuple, "incumbentRewardTuple": incumbent_tuple},
+                    evidence={
+                        "bestRewardTuple": best_tuple,
+                        "incumbentRewardTuple": incumbent_tuple,
+                        "componentOrder": component_order,
+                    },
                 )
     for metric_name, raw_value in (
         ("rl.training.changed_top_count", payload.get("changedTopCount")),
@@ -2806,18 +2863,13 @@ def process_training_report(
     stats["training_artifacts"] += 1
 
 
-def reward_tuple_from_ranking_item(item: dict[str, object] | None) -> list[float]:
+def reward_tuple_from_ranking_item(item: dict[str, object] | None) -> list[object]:
     if not isinstance(item, dict):
         return []
     raw_tuple = as_list(item.get("rewardTuple"))
     if not raw_tuple:
         raw_tuple = as_list(as_dict(item.get("reward")).get("tuple"))
-    values: list[float] = []
-    for raw_value in raw_tuple:
-        value = number_value(raw_value)
-        if value is not None:
-            values.append(value)
-    return values
+    return list(raw_tuple)
 
 
 def first_incumbent_ranking(ranking: list[dict[str, object]], incumbent_ids: list[str]) -> dict[str, object] | None:

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -809,13 +809,19 @@ def collect_variant_runs(
         if isinstance(run, dict):
             raw_variants = run.get("variants")
             if isinstance(raw_variants, list):
-                for raw_variant in raw_variants:
+                run_label = simulator_run_label(run, run_index)
+                for variant_index, raw_variant in enumerate(raw_variants):
                     if not isinstance(raw_variant, dict):
-                        continue
+                        raise RuntimeError(
+                            f"simulator run {run_label} emitted malformed variant row at "
+                            f"variant_index={variant_index}: raw_variant={raw_variant!r}"
+                        )
                     variant_id = raw_variant.get("variant_id", raw_variant.get("variantId"))
-                    if not isinstance(variant_id, str):
-                        continue
-                    run_label = simulator_run_label(run, run_index)
+                    if not isinstance(variant_id, str) or not variant_id:
+                        raise RuntimeError(
+                            f"simulator run {run_label} emitted malformed variant row at "
+                            f"variant_index={variant_index}: missing string variant id in raw_variant={raw_variant!r}"
+                        )
                     if variant_id not in expected_variant_id_set:
                         raise RuntimeError(
                             f"simulator run {run_label} emitted unexpected variant id {variant_id!r}"

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -691,7 +691,12 @@ def unsafe_simulator_flags(payload: JsonObject, label: str) -> list[str]:
     for field in ("liveEffect", "live_effect"):
         if payload.get(field) is True:
             unsafe.append(f"{label}.{field}=true")
-    for field in ("officialMmoWrites", "official_mmo_writes"):
+    for field in (
+        "officialMmoWrites",
+        "official_mmo_writes",
+        "officialMmoWritesAllowed",
+        "official_mmo_writes_allowed",
+    ):
         if payload.get(field) is True:
             unsafe.append(f"{label}.{field}=true")
     return unsafe

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -802,6 +802,7 @@ def collect_variant_runs(
     simulator_runs: Sequence[JsonObject],
     expected_variant_ids: Sequence[str],
 ) -> dict[str, list[JsonObject]]:
+    expected_variant_id_set = set(expected_variant_ids)
     collected: dict[str, list[JsonObject]] = {variant_id: [] for variant_id in expected_variant_ids}
     for run_index, run in enumerate(simulator_runs):
         emitted: dict[str, JsonObject] = {}
@@ -812,13 +813,30 @@ def collect_variant_runs(
                     if not isinstance(raw_variant, dict):
                         continue
                     variant_id = raw_variant.get("variant_id", raw_variant.get("variantId"))
-                    if isinstance(variant_id, str) and variant_id not in emitted:
-                        emitted[variant_id] = raw_variant
+                    if not isinstance(variant_id, str):
+                        continue
+                    run_label = simulator_run_label(run, run_index)
+                    if variant_id not in expected_variant_id_set:
+                        raise RuntimeError(
+                            f"simulator run {run_label} emitted unexpected variant id {variant_id!r}"
+                        )
+                    if variant_id in emitted:
+                        raise RuntimeError(
+                            f"simulator run {run_label} emitted duplicate variant id {variant_id!r}"
+                        )
+                    emitted[variant_id] = raw_variant
         for variant_id in expected_variant_ids:
             collected[variant_id].append(
                 emitted.get(variant_id) or missing_variant_attempt(run, variant_id, run_index)
             )
     return collected
+
+
+def simulator_run_label(run: JsonObject, run_index: int) -> str:
+    run_id = run.get("runId")
+    if isinstance(run_id, str) and run_id:
+        return f"{run_id} (run_index={run_index})"
+    return f"run[{run_index}]"
 
 
 def missing_variant_attempt(run: Any, variant_id: str, run_index: int) -> JsonObject:
@@ -1595,7 +1613,8 @@ def build_report_warnings(results: Sequence[JsonObject], simulator_runs: Sequenc
         excluded_run_count = int(result.get("excludedRunCount", 0))
         if excluded_run_count > 0:
             warnings.append(
-                f"variant {result['variantId']} excluded {excluded_run_count} failed simulator run(s) from reward scoring"
+                f"variant {result['variantId']} excluded {excluded_run_count} failed simulator run(s) "
+                "from sampleCount and non-reliability reward tiers; reliability scored them as 0"
             )
         elif result["sampleCount"] == 0:
             warnings.append(f"variant {result['variantId']} produced no simulator result")

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -708,7 +708,7 @@ def build_training_report(
     report_id: str,
     generated_at: str,
 ) -> JsonObject:
-    per_variant_runs = collect_variant_runs(simulator_runs)
+    per_variant_runs = collect_variant_runs(simulator_runs, [variant.id for variant in variants])
     results = [
         summarize_variant(variant, per_variant_runs.get(variant.id, []), reward_options)
         for variant in variants
@@ -793,21 +793,42 @@ def build_training_report(
     }
 
 
-def collect_variant_runs(simulator_runs: Sequence[JsonObject]) -> dict[str, list[JsonObject]]:
-    collected: dict[str, list[JsonObject]] = {}
-    for run in simulator_runs:
-        if not isinstance(run, dict):
-            continue
-        raw_variants = run.get("variants")
-        if not isinstance(raw_variants, list):
-            continue
-        for raw_variant in raw_variants:
-            if not isinstance(raw_variant, dict):
-                continue
-            variant_id = raw_variant.get("variant_id", raw_variant.get("variantId"))
-            if isinstance(variant_id, str):
-                collected.setdefault(variant_id, []).append(raw_variant)
+def collect_variant_runs(
+    simulator_runs: Sequence[JsonObject],
+    expected_variant_ids: Sequence[str],
+) -> dict[str, list[JsonObject]]:
+    collected: dict[str, list[JsonObject]] = {variant_id: [] for variant_id in expected_variant_ids}
+    for run_index, run in enumerate(simulator_runs):
+        emitted: dict[str, JsonObject] = {}
+        if isinstance(run, dict):
+            raw_variants = run.get("variants")
+            if isinstance(raw_variants, list):
+                for raw_variant in raw_variants:
+                    if not isinstance(raw_variant, dict):
+                        continue
+                    variant_id = raw_variant.get("variant_id", raw_variant.get("variantId"))
+                    if isinstance(variant_id, str) and variant_id not in emitted:
+                        emitted[variant_id] = raw_variant
+        for variant_id in expected_variant_ids:
+            collected[variant_id].append(
+                emitted.get(variant_id) or missing_variant_attempt(run, variant_id, run_index)
+            )
     return collected
+
+
+def missing_variant_attempt(run: Any, variant_id: str, run_index: int) -> JsonObject:
+    run_id = (
+        run.get("runId")
+        if isinstance(run, dict) and isinstance(run.get("runId"), str)
+        else f"run[{run_index}]"
+    )
+    return {
+        "variant_id": variant_id,
+        "variant_run_id": None,
+        "ticks_run": None,
+        "ok": False,
+        "error": f"variant result missing from simulator run {run_id}",
+    }
 
 
 def summarize_variant(

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -30,7 +30,9 @@ DEFAULT_RESOURCE_NORMALIZER = 1000.0
 DEFAULT_RUN_REPETITIONS = 1
 DEFAULT_STEAM_KEY_ENV_FILE = screeps_secret_env.DEFAULT_LOCAL_SECRET_ENV_FILE
 STEAM_KEY_ENV_FILE_ENV = "SCREEPS_RL_STEAM_KEY_ENV_FILE"
-REWARD_TIERS = ("territory", "resources", "kills")
+REWARD_TIERS = ("reliability", "territory", "resources", "kills")
+SAFETY_FALSE_FIELDS = ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed")
+SAFETY_TRUE_FIELDS = ("conservative_actions_only", "ood_rejection")
 REPORT_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 STRATEGY_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
 JsonObject = dict[str, Any]
@@ -200,26 +202,36 @@ def parse_yaml_card(text: str, path: Path) -> Any:
 
 
 def validate_experiment_card(card: JsonObject) -> None:
-    status = card.get("status", "shadow")
-    if status != "shadow":
+    if card.get("status") != "shadow":
         raise TrainingCardError("status must be shadow")
 
     safety = card.get("safety")
     if not isinstance(safety, dict):
         raise TrainingCardError("safety must be present and must be an object")
-    for field in ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed"):
+    for field in SAFETY_FALSE_FIELDS:
         if safety.get(field) is not False:
             raise TrainingCardError(f"safety.{field} must be false")
         if field in card and card[field] is not False:
             raise TrainingCardError(f"{field} must be false when present")
+    for field in SAFETY_TRUE_FIELDS:
+        if safety.get(field) is not True:
+            raise TrainingCardError(f"safety.{field} must be true")
+        if field in card and card[field] is not True:
+            raise TrainingCardError(f"{field} must be true when present")
 
     reward_model = card.get("reward_model", card.get("rewardModel"))
     if not isinstance(reward_model, dict):
         raise TrainingCardError("reward_model must be present and must be an object")
+    if reward_model.get("type") != "lexicographic":
+        raise TrainingCardError("reward_model.type must be lexicographic")
     order = reward_model.get("component_order", reward_model.get("componentOrder"))
-    if order not in (list(REWARD_TIERS), ["reliability", *REWARD_TIERS]):
-        raise TrainingCardError("reward_model.component_order must preserve territory, resources, kills")
-    if reward_model.get("scalar_weighted_sum_authorized", reward_model.get("scalarWeightedSumAuthorized", False)) is True:
+    if order != list(REWARD_TIERS):
+        raise TrainingCardError("reward_model.component_order must preserve reliability, territory, resources, kills")
+    scalar_authorized = reward_model.get(
+        "scalar_weighted_sum_authorized",
+        reward_model.get("scalarWeightedSumAuthorized"),
+    )
+    if scalar_authorized is not False:
         raise TrainingCardError("reward_model.scalar_weighted_sum_authorized must be false")
 
     raw_variants = raw_variant_definitions(card)
@@ -749,7 +761,7 @@ def build_training_report(
             "componentOrder": list(REWARD_TIERS),
             "resourceNormalizer": reward_options["resourceNormalizer"],
             "formula": (
-                "compare (roomsGained - roomsLost, "
+                "compare (successful simulator run share, roomsGained - roomsLost, "
                 "(storedEnergyDelta + collectedEnergy) / resourceNormalizer, "
                 "hostileKills - ownLosses) lexicographically"
             ),
@@ -807,6 +819,9 @@ def summarize_variant(
     excluded_run_count = len(runs) - len(scored_runs)
     run_metrics = [compute_run_metrics(run, reward_options) for run in scored_runs]
     reward_tuple = mean_reward_tuple(run_metrics)
+    reward_tuple[0] = reliability_score(scored_run_count=len(scored_runs), total_run_count=len(runs))
+    metrics = aggregate_metrics(run_metrics)
+    metrics["reliability"]["score"] = reward_tuple[0]
     return {
         "variantId": variant.id,
         "family": variant.family,
@@ -822,7 +837,7 @@ def summarize_variant(
             "samples": [metrics["rewardTuple"] for metrics in run_metrics],
             "sampleStdDev": reward_stddev(run_metrics),
         },
-        "metrics": aggregate_metrics(run_metrics),
+        "metrics": metrics,
         "runs": [
             {
                 "variantRunId": run.get("variant_run_id", run.get("variantRunId")),
@@ -923,9 +938,18 @@ def compute_run_metrics(run: JsonObject, reward_options: JsonObject) -> JsonObje
         default=hostile_kills - own_losses,
     )
 
-    reward_tuple = [round_float(territory_delta), round_float(resources_delta), round_float(combat_delta)]
+    reliability = 0 if run.get("ok") is False else 1
+    reward_tuple = [
+        reliability,
+        round_float(territory_delta),
+        round_float(resources_delta),
+        round_float(combat_delta),
+    ]
     return {
         "rewardTuple": reward_tuple,
+        "reliability": {
+            "score": reliability,
+        },
         "territory": {
             "delta": round_float(territory_delta),
             "ownedRoomCount": len(survived_end),
@@ -1188,26 +1212,36 @@ def round_float(value: float | int) -> float | int:
 
 def mean_reward_tuple(metrics: Sequence[JsonObject]) -> list[float | int]:
     if not metrics:
-        return [0, 0, 0]
+        return [0 for _tier in REWARD_TIERS]
     columns = list(zip(*(metric["rewardTuple"] for metric in metrics)))
     return [round_float(statistics.fmean(float(value) for value in column)) for column in columns]
 
 
 def reward_stddev(metrics: Sequence[JsonObject]) -> list[float | int]:
     if len(metrics) <= 1:
-        return [0, 0, 0]
+        return [0 for _tier in REWARD_TIERS]
     columns = list(zip(*(metric["rewardTuple"] for metric in metrics)))
     return [round_float(statistics.pstdev(float(value) for value in column)) for column in columns]
+
+
+def reliability_score(*, scored_run_count: int, total_run_count: int) -> float | int:
+    if total_run_count <= 0:
+        return 0
+    return round_float(scored_run_count / total_run_count)
 
 
 def aggregate_metrics(metrics: Sequence[JsonObject]) -> JsonObject:
     if not metrics:
         return {
+            "reliability": empty_reliability_metrics(),
             "territory": empty_territory_metrics(),
             "resources": empty_resource_metrics(),
             "kills": empty_kill_metrics(),
         }
     return {
+        "reliability": {
+            "score": mean_component(metrics, "reliability", "score"),
+        },
         "territory": {
             "delta": mean_component(metrics, "territory", "delta"),
             "ownedRoomCount": mean_component(metrics, "territory", "ownedRoomCount"),
@@ -1250,6 +1284,10 @@ def aggregate_metrics(metrics: Sequence[JsonObject]) -> JsonObject:
             "ownLosses": mean_component(metrics, "kills", "ownLosses"),
         },
     }
+
+
+def empty_reliability_metrics() -> JsonObject:
+    return {"score": 0}
 
 
 def empty_territory_metrics() -> JsonObject:
@@ -1305,12 +1343,7 @@ def aggregate_rcl_levels(metrics: Sequence[JsonObject]) -> JsonObject:
 def rank_variant_results(results: Sequence[JsonObject]) -> list[JsonObject]:
     sorted_results = sorted(
         results,
-        key=lambda item: (
-            float(item["reward"]["tuple"][0]),
-            float(item["reward"]["tuple"][1]),
-            float(item["reward"]["tuple"][2]),
-            item["variantId"],
-        ),
+        key=lambda item: (*tuple(float(value) for value in item["reward"]["tuple"]), item["variantId"]),
         reverse=True,
     )
     ranking: list[JsonObject] = []
@@ -1351,9 +1384,8 @@ def build_pairwise_comparisons(results: Sequence[JsonObject]) -> list[JsonObject
                     "winner": winner,
                     "firstDifferingTier": first_differing_tier(left["reward"]["tuple"], right["reward"]["tuple"]),
                     "delta": {
-                        "territory": round_float(float(left["reward"]["tuple"][0]) - float(right["reward"]["tuple"][0])),
-                        "resources": round_float(float(left["reward"]["tuple"][1]) - float(right["reward"]["tuple"][1])),
-                        "kills": round_float(float(left["reward"]["tuple"][2]) - float(right["reward"]["tuple"][2])),
+                        tier: round_float(float(left["reward"]["tuple"][index]) - float(right["reward"]["tuple"][index]))
+                        for index, tier in enumerate(REWARD_TIERS)
                     },
                 }
             )
@@ -1394,6 +1426,8 @@ def compare_reward_tuples(left: Sequence[Any], right: Sequence[Any]) -> int:
 
 def first_differing_tier(left: Sequence[Any], right: Sequence[Any]) -> str | None:
     for index, tier in enumerate(REWARD_TIERS):
+        if index >= len(left) or index >= len(right):
+            return tier
         if float(left[index]) != float(right[index]):
             return tier
     return None
@@ -1467,23 +1501,31 @@ def build_kpi_summary(results: Sequence[JsonObject]) -> JsonObject:
     if not results:
         return {}
     best = rank_variant_results(results)[0]
+    reward_index = {tier: index for index, tier in enumerate(REWARD_TIERS)}
     return {
+        "reliability": {
+            "score": best["rewardTuple"][reward_index["reliability"]],
+            "components": {
+                result["variantId"]: result["metrics"]["reliability"]["score"]
+                for result in results
+            },
+        },
         "territory": {
-            "score": best["rewardTuple"][0],
+            "score": best["rewardTuple"][reward_index["territory"]],
             "components": {
                 result["variantId"]: result["metrics"]["territory"]["delta"]
                 for result in results
             },
         },
         "resources": {
-            "score": best["rewardTuple"][1],
+            "score": best["rewardTuple"][reward_index["resources"]],
             "components": {
                 result["variantId"]: result["metrics"]["resources"]["delta"]
                 for result in results
             },
         },
         "kills": {
-            "score": best["rewardTuple"][2],
+            "score": best["rewardTuple"][reward_index["kills"]],
             "components": {
                 result["variantId"]: result["metrics"]["kills"]["delta"]
                 for result in results
@@ -1529,6 +1571,8 @@ def safety_metadata() -> JsonObject:
         "liveEffect": False,
         "officialMmoWrites": False,
         "officialMmoWritesAllowed": False,
+        "conservative_actions_only": True,
+        "ood_rejection": True,
         "officialMmoControl": False,
         "inputMode": "experiment card plus local private-server simulator harness output",
         "simulatorOnly": True,

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -815,11 +815,16 @@ def summarize_variant(
     runs: Sequence[JsonObject],
     reward_options: JsonObject,
 ) -> JsonObject:
-    scored_runs = [run for run in runs if run.get("ok") is True]
-    excluded_run_count = len(runs) - len(scored_runs)
-    run_metrics = [compute_run_metrics(run, reward_options) for run in scored_runs]
+    run_metrics_by_attempt: list[JsonObject | None] = []
+    for run in runs:
+        if run.get("ok") is True:
+            run_metrics_by_attempt.append(compute_run_metrics(run, reward_options))
+        else:
+            run_metrics_by_attempt.append(None)
+    run_metrics = [metrics for metrics in run_metrics_by_attempt if metrics is not None]
+    excluded_run_count = len(runs) - len(run_metrics)
     reward_tuple = mean_reward_tuple(run_metrics)
-    reward_tuple[0] = reliability_score(scored_run_count=len(scored_runs), total_run_count=len(runs))
+    reward_tuple[0] = reliability_score(scored_run_count=len(run_metrics), total_run_count=len(runs))
     metrics = aggregate_metrics(run_metrics)
     metrics["reliability"]["score"] = reward_tuple[0]
     return {
@@ -828,14 +833,14 @@ def summarize_variant(
         "rolloutStatus": variant.rollout_status,
         "sampleCount": len(run_metrics),
         "excludedRunCount": excluded_run_count,
-        "ok": bool(scored_runs) and excluded_run_count == 0,
+        "ok": bool(run_metrics) and excluded_run_count == 0,
         "parameters": variant.parameters,
         "reward": {
             "type": "lexicographic",
             "componentOrder": list(REWARD_TIERS),
             "tuple": reward_tuple,
-            "samples": [metrics["rewardTuple"] for metrics in run_metrics],
-            "sampleStdDev": reward_stddev(run_metrics),
+            "samples": reward_samples(run_metrics_by_attempt),
+            "sampleStdDev": reward_sample_stddev(run_metrics_by_attempt),
         },
         "metrics": metrics,
         "runs": [
@@ -1222,6 +1227,30 @@ def reward_stddev(metrics: Sequence[JsonObject]) -> list[float | int]:
         return [0 for _tier in REWARD_TIERS]
     columns = list(zip(*(metric["rewardTuple"] for metric in metrics)))
     return [round_float(statistics.pstdev(float(value) for value in column)) for column in columns]
+
+
+def reward_samples(metrics_by_attempt: Sequence[JsonObject | None]) -> list[list[Any]]:
+    samples: list[list[Any]] = []
+    for metrics in metrics_by_attempt:
+        if metrics is None:
+            samples.append([0, None, None, None])
+        else:
+            samples.append(list(metrics["rewardTuple"]))
+    return samples
+
+
+def reward_sample_stddev(metrics_by_attempt: Sequence[JsonObject | None]) -> list[float | int]:
+    scored_metrics = [metrics for metrics in metrics_by_attempt if metrics is not None]
+    sample_stddev = reward_stddev(scored_metrics)
+    reliability_values = [1 if metrics is not None else 0 for metrics in metrics_by_attempt]
+    sample_stddev[0] = component_stddev(reliability_values)
+    return sample_stddev
+
+
+def component_stddev(values: Sequence[float | int]) -> float | int:
+    if len(values) <= 1:
+        return 0
+    return round_float(statistics.pstdev(float(value) for value in values))
 
 
 def reliability_score(*, scored_run_count: int, total_run_count: int) -> float | int:

--- a/scripts/test_screeps_rl_metrics_ingestor.py
+++ b/scripts/test_screeps_rl_metrics_ingestor.py
@@ -468,6 +468,61 @@ class ScreepsRlMetricsIngestorTest(unittest.TestCase):
                 },
             )
 
+    def test_training_report_component_order_mismatch_suppresses_component_metrics(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            db_path = root / "rl_metrics.sqlite"
+            artifact_dir = root / "rl-training"
+            artifact_dir.mkdir(parents=True, exist_ok=True)
+            component_order = ["reliability", "territory", "resources", "kills"]
+            report = {
+                "type": "screeps-rl-training-report",
+                "reportId": "component-order-mismatch-report",
+                "rewardModel": {"componentOrder": component_order},
+                "incumbentStrategyIds": ["baseline"],
+                "variantResults": [
+                    {
+                        "variantId": "baseline",
+                        "sampleCount": 1,
+                        "reward": {"tuple": [5, 50, 0], "componentOrder": component_order},
+                    },
+                    {
+                        "variantId": "candidate",
+                        "sampleCount": 1,
+                        "reward": {"tuple": [7, 60, 3], "componentOrder": component_order},
+                    },
+                ],
+                "ranking": [
+                    {"variantId": "candidate", "rewardTuple": [7, 60, 3]},
+                    {"variantId": "baseline", "rewardTuple": [5, 50, 0]},
+                ],
+            }
+            (artifact_dir / "training-report.json").write_text(json.dumps(report), encoding="utf-8")
+
+            stats = ingestor.ingest_artifacts(db_path, [artifact_dir])
+
+            with sqlite3.connect(db_path) as conn:
+                reward_rows = conn.execute(
+                    """
+                    SELECT metric_name, value
+                    FROM rl_training_execution_metrics
+                    WHERE report_id = ? AND metric_name LIKE 'rl.training.reward_%'
+                    """,
+                    ("component-order-mismatch-report",),
+                ).fetchall()
+                advantage_rows = conn.execute(
+                    """
+                    SELECT metric_name, value
+                    FROM rl_policy_advantage_metrics
+                    WHERE report_id = ?
+                    """,
+                    ("component-order-mismatch-report",),
+                ).fetchall()
+
+            self.assertEqual(stats["training_artifacts"], 1)
+            self.assertEqual(reward_rows, [])
+            self.assertEqual(advantage_rows, [])
+
     def test_low_load_return_metric_creates_behavior_finding(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_metrics_ingestor.py
+++ b/scripts/test_screeps_rl_metrics_ingestor.py
@@ -393,6 +393,81 @@ class ScreepsRlMetricsIngestorTest(unittest.TestCase):
                 ],
             )
 
+    def test_training_report_component_order_maps_reward_and_policy_metrics(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            db_path = root / "rl_metrics.sqlite"
+            artifact_dir = root / "rl-training"
+            artifact_dir.mkdir(parents=True, exist_ok=True)
+            component_order = ["reliability", "territory", "resources", "kills"]
+            report = {
+                "type": "screeps-rl-training-report",
+                "reportId": "component-order-report",
+                "rewardModel": {"componentOrder": component_order},
+                "incumbentStrategyIds": ["baseline"],
+                "variantResults": [
+                    {
+                        "variantId": "baseline",
+                        "sampleCount": 1,
+                        "reward": {"tuple": [1, 5, 50, 0], "componentOrder": component_order},
+                    },
+                    {
+                        "variantId": "candidate",
+                        "sampleCount": 1,
+                        "reward": {"tuple": [1, 7, 60, 3], "componentOrder": component_order},
+                    },
+                ],
+                "ranking": [
+                    {"variantId": "candidate", "rewardTuple": [1, 7, 60, 3]},
+                    {"variantId": "baseline", "rewardTuple": [1, 5, 50, 0]},
+                ],
+            }
+            (artifact_dir / "training-report.json").write_text(json.dumps(report), encoding="utf-8")
+
+            stats = ingestor.ingest_artifacts(db_path, [artifact_dir])
+
+            with sqlite3.connect(db_path) as conn:
+                reward_rows = {
+                    row[0]: row[1]
+                    for row in conn.execute(
+                        """
+                        SELECT metric_name, value
+                        FROM rl_training_execution_metrics
+                        WHERE report_id = ? AND variant_id = ? AND metric_name LIKE 'rl.training.reward_%'
+                        """,
+                        ("component-order-report", "candidate"),
+                    ).fetchall()
+                }
+                advantage_rows = {
+                    row[0]: row[1]
+                    for row in conn.execute(
+                        """
+                        SELECT metric_name, value
+                        FROM rl_policy_advantage_metrics
+                        WHERE report_id = ? AND candidate_id = ? AND incumbent_id = ?
+                        """,
+                        ("component-order-report", "candidate", "baseline"),
+                    ).fetchall()
+                }
+
+            self.assertEqual(stats["training_artifacts"], 1)
+            self.assertEqual(
+                reward_rows,
+                {
+                    "rl.training.reward_territory": 7.0,
+                    "rl.training.reward_resources": 60.0,
+                    "rl.training.reward_kills": 3.0,
+                },
+            )
+            self.assertEqual(
+                advantage_rows,
+                {
+                    "rl.policy.advantage_territory": 2.0,
+                    "rl.policy.advantage_resources": 10.0,
+                    "rl.policy.advantage_kills": 3.0,
+                },
+            )
+
     def test_low_load_return_metric_creates_behavior_finding(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -813,26 +813,29 @@ export const STRATEGY_REGISTRY = [
         baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200)])])
         candidate = variant_result("candidate", [start, tick(2, [room("W1N1", energy=250)])])
 
-        class UnsafeSimulator(MockSimulator):
-            def __call__(self, **kwargs: Any) -> JsonObject:
-                result = super().__call__(**kwargs)
-                result["liveEffect"] = True
-                return result
+        for unsafe_field in ("liveEffect", "officialMmoWritesAllowed", "official_mmo_writes_allowed"):
+            with self.subTest(unsafe_field=unsafe_field), tempfile.TemporaryDirectory() as temp_dir:
+                root = Path(temp_dir)
+                card_path = root / "card.json"
+                out_dir = root / "reports"
+                report_id = f"unsafe-{unsafe_field}"
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-            root = Path(temp_dir)
-            card_path = root / "card.json"
-            out_dir = root / "reports"
-            write_json(card_path, base_card())
-            with self.assertRaisesRegex(RuntimeError, "liveEffect=true"):
-                runner.run_training_experiment(
-                    card_path,
-                    out_dir,
-                    report_id="unsafe-flags",
-                    simulator_runner=UnsafeSimulator({"baseline": baseline, "candidate": candidate}),
-                )
+                class UnsafeSimulator(MockSimulator):
+                    def __call__(self, **kwargs: Any) -> JsonObject:
+                        result = super().__call__(**kwargs)
+                        result[unsafe_field] = True
+                        return result
 
-            self.assertFalse((out_dir / "unsafe-flags.json").exists())
+                write_json(card_path, base_card())
+                with self.assertRaisesRegex(RuntimeError, f"{unsafe_field}=true"):
+                    runner.run_training_experiment(
+                        card_path,
+                        out_dir,
+                        report_id=report_id,
+                        simulator_runner=UnsafeSimulator({"baseline": baseline, "candidate": candidate}),
+                    )
+
+                self.assertFalse((out_dir / f"{report_id}.json").exists())
 
     def test_final_report_secret_scan_includes_steam_key_variant_errors(self) -> None:
         secret = "steam-secret-token-123456"

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -45,11 +45,12 @@ def base_card(variant_ids: list[str] | None = None) -> JsonObject:
         },
         "reward_model": {
             "type": "lexicographic",
-            "component_order": ["territory", "resources", "kills"],
+            "component_order": ["reliability", "territory", "resources", "kills"],
             "component_weights": {
-                "territory": 1000000,
-                "resources": 1000,
-                "kills": 1,
+                "alpha_reliability": 1000000000,
+                "beta_territory": 1000000,
+                "gamma_resources": 1000,
+                "delta_kills": 1,
             },
             "resource_normalizer": 1000,
             "scalar_weighted_sum_authorized": False,
@@ -162,6 +163,25 @@ class RequiredSteamKeySimulator(MockSimulator):
 
 
 class RlTrainingRunnerTest(unittest.TestCase):
+    def test_experiment_card_validation_requires_conservative_and_ood_safety_flags(self) -> None:
+        for field in ("conservative_actions_only", "ood_rejection"):
+            with self.subTest(field=field):
+                card = base_card()
+                del card["safety"][field]
+
+                with self.assertRaisesRegex(runner.TrainingCardError, f"safety.{field} must be true"):
+                    runner.validate_experiment_card(card)
+
+    def test_experiment_card_validation_rejects_missing_reliability_reward_tier(self) -> None:
+        card = base_card()
+        card["reward_model"]["component_order"] = ["territory", "resources", "kills"]
+
+        with self.assertRaisesRegex(
+            runner.TrainingCardError,
+            "reward_model.component_order must preserve reliability, territory, resources, kills",
+        ):
+            runner.validate_experiment_card(card)
+
     def test_steam_key_env_var_wins_over_env_file(self) -> None:
         env_secret = "env-secret-token-123456"
         file_secret = "file-secret-token-123456"
@@ -364,7 +384,11 @@ class RlTrainingRunnerTest(unittest.TestCase):
 
         self.assertEqual(report["ranking"][0]["variantId"], "candidate")
         self.assertEqual(report["variantResults"][1]["reward"]["tuple"][0], 1)
-        self.assertGreater(report["variantResults"][0]["reward"]["tuple"][1], report["variantResults"][1]["reward"]["tuple"][1])
+        self.assertEqual(report["variantResults"][1]["reward"]["tuple"][1], 1)
+        self.assertGreater(
+            report["variantResults"][0]["reward"]["tuple"][2],
+            report["variantResults"][1]["reward"]["tuple"][2],
+        )
         comparison = report["statisticalComparison"]["pairwise"][0]
         self.assertEqual(comparison["winner"], "candidate")
         self.assertEqual(comparison["firstDifferingTier"], "territory")
@@ -389,7 +413,8 @@ class RlTrainingRunnerTest(unittest.TestCase):
         self.assertEqual(metrics["territory"]["delta"], -1)
         self.assertEqual(metrics["territory"]["roomsLost"], 1)
         self.assertEqual(metrics["territory"]["collapsedClaimedRooms"], ["W1N2"])
-        self.assertEqual(metrics["rewardTuple"][0], -1)
+        self.assertEqual(metrics["rewardTuple"][0], 1)
+        self.assertEqual(metrics["rewardTuple"][1], -1)
 
     def test_run_metrics_prefer_harness_room_states_over_aggregate_room_counters(self) -> None:
         run = variant_result("candidate", [])
@@ -423,6 +448,7 @@ safety:
 reward_model:
   type: lexicographic
   component_order:
+    - reliability
     - territory
     - resources
     - kills
@@ -529,7 +555,8 @@ export const STRATEGY_REGISTRY = [
             )
 
         self.assertEqual(report["ranking"][0]["variantId"], "candidate")
-        self.assertEqual(report["ranking"][0]["rewardTuple"][0], 0)
+        self.assertEqual(report["ranking"][0]["rewardTuple"][0], 1)
+        self.assertEqual(report["ranking"][0]["rewardTuple"][1], 0)
         self.assertEqual(report["statisticalComparison"]["pairwise"][0]["firstDifferingTier"], "resources")
 
     def test_equal_reward_tuple_does_not_count_as_top_change(self) -> None:
@@ -587,6 +614,7 @@ export const STRATEGY_REGISTRY = [
         candidate_result = next(result for result in report["variantResults"] if result["variantId"] == "candidate")
         self.assertEqual(candidate_result["sampleCount"], 0)
         self.assertEqual(candidate_result["excludedRunCount"], 1)
+        self.assertEqual(candidate_result["metrics"]["reliability"]["score"], 0)
         self.assertEqual(candidate_result["reward"]["samples"], [])
         self.assertEqual([item["variantId"] for item in report["ranking"]], ["baseline"])
         self.assertNotIn("candidate", report["statisticalComparison"]["componentMeans"])
@@ -616,6 +644,11 @@ export const STRATEGY_REGISTRY = [
         self.assertFalse(persisted["liveEffect"])
         self.assertFalse(persisted["officialMmoWrites"])
         self.assertFalse(persisted["safety"]["liveApiCalls"])
+        self.assertTrue(persisted["safety"]["conservative_actions_only"])
+        self.assertTrue(persisted["safety"]["ood_rejection"])
+        self.assertEqual(persisted["rewardModel"]["componentOrder"], ["reliability", "territory", "resources", "kills"])
+        self.assertEqual(persisted["variantResults"][0]["reward"]["componentOrder"], ["reliability", "territory", "resources", "kills"])
+        self.assertEqual(persisted["kpiSummary"]["reliability"]["score"], 1)
         self.assertEqual(persisted["candidateStrategyIds"], ["baseline", "candidate"])
         self.assertEqual(persisted["incumbentStrategyIds"], ["baseline"])
         self.assertIn("modelReports", persisted)

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -618,7 +618,14 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(candidate_result["reward"]["samples"], [[0, None, None, None]])
         self.assertEqual([item["variantId"] for item in report["ranking"]], ["baseline"])
         self.assertNotIn("candidate", report["statisticalComparison"]["componentMeans"])
-        self.assertTrue(any("excluded 1 failed simulator run" in warning for warning in report["warnings"]))
+        self.assertTrue(
+            any(
+                "excluded 1 failed simulator run(s) from sampleCount and non-reliability reward tiers; "
+                "reliability scored them as 0" in warning
+                for warning in report["warnings"]
+            )
+        )
+        self.assertFalse(any("from reward scoring" in warning for warning in report["warnings"]))
 
     def test_reward_samples_include_failed_repetition_reliability(self) -> None:
         start = tick(1, [room("W1N1", energy=100)])
@@ -716,6 +723,53 @@ export const STRATEGY_REGISTRY = [
         self.assertGreater(ranking_by_variant["candidate"]["rank"], ranking_by_variant["baseline"]["rank"])
         self.assertNotEqual(ranking_by_variant["candidate"]["rewardTuple"][0], 1)
         self.assertEqual(report["statisticalComparison"]["pairwise"][0]["winner"], "baseline")
+
+    def test_duplicate_or_unexpected_variant_rows_fail_before_report_is_persisted(self) -> None:
+        start = tick(1, [room("W1N1", energy=100)])
+        baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200)])])
+        candidate = variant_result("candidate", [start, tick(2, [room("W1N1", energy=250)])])
+        duplicate_baseline = dict(baseline)
+        duplicate_baseline["variant_run_id"] = "run-baseline-duplicate"
+        unexpected = variant_result("intruder", [start, tick(2, [room("W1N1", energy=300)])])
+
+        cases = (
+            (
+                "duplicate-variant-row",
+                [baseline, duplicate_baseline, candidate],
+                r"duplicate-variant-row .*run_index=0.*duplicate variant id 'baseline'",
+            ),
+            (
+                "unexpected-variant-row",
+                [baseline, candidate, unexpected],
+                r"unexpected-variant-row .*run_index=0.*unexpected variant id 'intruder'",
+            ),
+        )
+        for report_id, variants, message_regex in cases:
+            with self.subTest(report_id=report_id), tempfile.TemporaryDirectory() as temp_dir:
+                root = Path(temp_dir)
+                card_path = root / "card.json"
+                out_dir = root / "reports"
+
+                class MalformedVariantSimulator:
+                    def __call__(self, **kwargs: Any) -> JsonObject:
+                        return {
+                            "type": "screeps-rl-simulator-run",
+                            "runId": kwargs["run_id"],
+                            "liveEffect": False,
+                            "officialMmoWrites": False,
+                            "variants": variants,
+                        }
+
+                write_json(card_path, base_card())
+                with self.assertRaisesRegex(RuntimeError, message_regex):
+                    runner.run_training_experiment(
+                        card_path,
+                        out_dir,
+                        report_id=report_id,
+                        simulator_runner=MalformedVariantSimulator(),
+                    )
+
+                self.assertFalse((out_dir / f"{report_id}.json").exists())
 
     def test_json_report_output_format_is_shadow_report_compatible(self) -> None:
         start = tick(1, [room("W1N1", energy=100, spawn_status="idle")])

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -615,10 +615,56 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(candidate_result["sampleCount"], 0)
         self.assertEqual(candidate_result["excludedRunCount"], 1)
         self.assertEqual(candidate_result["metrics"]["reliability"]["score"], 0)
-        self.assertEqual(candidate_result["reward"]["samples"], [])
+        self.assertEqual(candidate_result["reward"]["samples"], [[0, None, None, None]])
         self.assertEqual([item["variantId"] for item in report["ranking"]], ["baseline"])
         self.assertNotIn("candidate", report["statisticalComparison"]["componentMeans"])
         self.assertTrue(any("excluded 1 failed simulator run" in warning for warning in report["warnings"]))
+
+    def test_reward_samples_include_failed_repetition_reliability(self) -> None:
+        start = tick(1, [room("W1N1", energy=100)])
+        baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200)])])
+        successful_candidate = variant_result("candidate", [start, tick(2, [room("W1N1", energy=300)])])
+        failed_candidate = variant_result("candidate", [])
+        failed_candidate["variant_run_id"] = "run-candidate-failed"
+        failed_candidate["ok"] = False
+        failed_candidate["error"] = "simulator failed"
+
+        class FlakyRepetitionSimulator:
+            def __init__(self) -> None:
+                self.calls: list[JsonObject] = []
+
+            def __call__(self, **kwargs: Any) -> JsonObject:
+                self.calls.append(dict(kwargs))
+                candidate = successful_candidate if len(self.calls) == 1 else failed_candidate
+                return {
+                    "type": "screeps-rl-simulator-run",
+                    "runId": kwargs["run_id"],
+                    "liveEffect": False,
+                    "officialMmoWrites": False,
+                    "variants": [baseline, candidate],
+                }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            card = base_card()
+            card["simulation"]["repetitions"] = 2
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="flaky-reliability-samples",
+                simulator_runner=FlakyRepetitionSimulator(),
+            )
+
+        candidate_result = next(result for result in report["variantResults"] if result["variantId"] == "candidate")
+        self.assertEqual(candidate_result["sampleCount"], 1)
+        self.assertEqual(candidate_result["excludedRunCount"], 1)
+        self.assertEqual(candidate_result["reward"]["tuple"][0], 0.5)
+        self.assertEqual([sample[0] for sample in candidate_result["reward"]["samples"]], [1, 0])
+        self.assertEqual(candidate_result["reward"]["samples"][1], [0, None, None, None])
+        self.assertEqual(candidate_result["reward"]["sampleStdDev"][0], 0.5)
+        self.assertEqual(candidate_result["reward"]["sampleStdDev"][1:], [0, 0, 0])
 
     def test_json_report_output_format_is_shadow_report_compatible(self) -> None:
         start = tick(1, [room("W1N1", energy=100, spawn_status="idle")])

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -666,6 +666,57 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(candidate_result["reward"]["sampleStdDev"][0], 0.5)
         self.assertEqual(candidate_result["reward"]["sampleStdDev"][1:], [0, 0, 0])
 
+    def test_missing_variant_repetition_counts_as_unreliable_attempt(self) -> None:
+        start = tick(1, [room("W1N1", energy=100)])
+        baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200)])])
+        successful_candidate = variant_result("candidate", [start, tick(2, [room("W1N1", energy=10000)])])
+
+        class MissingCandidateRepetitionSimulator:
+            def __init__(self) -> None:
+                self.calls: list[JsonObject] = []
+
+            def __call__(self, **kwargs: Any) -> JsonObject:
+                self.calls.append(dict(kwargs))
+                variants = [baseline, successful_candidate] if len(self.calls) == 1 else [baseline]
+                return {
+                    "type": "screeps-rl-simulator-run",
+                    "runId": kwargs["run_id"],
+                    "liveEffect": False,
+                    "officialMmoWrites": False,
+                    "variants": variants,
+                }
+
+        simulator = MissingCandidateRepetitionSimulator()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            card = base_card()
+            card["simulation"]["repetitions"] = 2
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="missing-candidate-repetition",
+                simulator_runner=simulator,
+            )
+
+        candidate_result = next(result for result in report["variantResults"] if result["variantId"] == "candidate")
+        self.assertEqual(len(simulator.calls), 2)
+        self.assertEqual(candidate_result["sampleCount"], 1)
+        self.assertEqual(candidate_result["excludedRunCount"], 1)
+        self.assertEqual(candidate_result["reward"]["tuple"][0], 0.5)
+        self.assertEqual(candidate_result["metrics"]["reliability"]["score"], 0.5)
+        self.assertEqual([sample[0] for sample in candidate_result["reward"]["samples"]], [1, 0])
+        self.assertEqual(candidate_result["reward"]["samples"][1], [0, None, None, None])
+        self.assertIn("missing from simulator run", candidate_result["runs"][1]["error"])
+
+        ranking_by_variant = {item["variantId"]: item for item in report["ranking"]}
+        self.assertEqual([item["variantId"] for item in report["ranking"]], ["baseline", "candidate"])
+        self.assertEqual(ranking_by_variant["baseline"]["rank"], 1)
+        self.assertGreater(ranking_by_variant["candidate"]["rank"], ranking_by_variant["baseline"]["rank"])
+        self.assertNotEqual(ranking_by_variant["candidate"]["rewardTuple"][0], 1)
+        self.assertEqual(report["statisticalComparison"]["pairwise"][0]["winner"], "baseline")
+
     def test_json_report_output_format_is_shadow_report_compatible(self) -> None:
         start = tick(1, [room("W1N1", energy=100, spawn_status="idle")])
         baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200, spawn_status="spawning")])])

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -771,6 +771,60 @@ export const STRATEGY_REGISTRY = [
 
                 self.assertFalse((out_dir / f"{report_id}.json").exists())
 
+    def test_malformed_variant_rows_fail_before_report_is_persisted(self) -> None:
+        start = tick(1, [room("W1N1", energy=100)])
+        baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200)])])
+        candidate = variant_result("candidate", [start, tick(2, [room("W1N1", energy=250)])])
+
+        cases = (
+            (
+                "non-dict-variant-row",
+                [baseline, "not-a-dict", candidate],
+                r"non-dict-variant-row .*run_index=0.*variant_index=1.*raw_variant='not-a-dict'",
+            ),
+            (
+                "missing-variant-id",
+                [baseline, {"ticks": []}, candidate],
+                r"missing-variant-id .*run_index=0.*variant_index=1.*missing string variant id.*raw_variant=",
+            ),
+            (
+                "empty-variant-id",
+                [baseline, {"variant_id": "", "ticks": []}, candidate],
+                r"empty-variant-id .*run_index=0.*variant_index=1.*missing string variant id.*raw_variant=",
+            ),
+            (
+                "non-string-variant-id",
+                [baseline, {"variant_id": 7, "ticks": []}, candidate],
+                r"non-string-variant-id .*run_index=0.*variant_index=1.*missing string variant id.*raw_variant=",
+            ),
+        )
+        for report_id, variants, message_regex in cases:
+            with self.subTest(report_id=report_id), tempfile.TemporaryDirectory() as temp_dir:
+                root = Path(temp_dir)
+                card_path = root / "card.json"
+                out_dir = root / "reports"
+
+                class MalformedVariantSimulator:
+                    def __call__(self, **kwargs: Any) -> JsonObject:
+                        return {
+                            "type": "screeps-rl-simulator-run",
+                            "runId": kwargs["run_id"],
+                            "liveEffect": False,
+                            "officialMmoWrites": False,
+                            "variants": variants,
+                        }
+
+                write_json(card_path, base_card())
+                with self.assertRaisesRegex(RuntimeError, message_regex):
+                    runner.run_training_experiment(
+                        card_path,
+                        out_dir,
+                        report_id=report_id,
+                        simulator_runner=MalformedVariantSimulator(),
+                    )
+
+                self.assertFalse((out_dir / f"{report_id}.json").exists())
+
     def test_json_report_output_format_is_shadow_report_compatible(self) -> None:
         start = tick(1, [room("W1N1", energy=100, spawn_status="idle")])
         baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200, spawn_status="spawning")])])


### PR DESCRIPTION
## Summary
- Enforces the Loop A experiment-card safety/reward contract in the training runner.
- Requires shadow-only/no-official-write safety fields plus `conservative_actions_only=true`, `ood_rejection=true`, and lexicographic reward order `[reliability, territory, resources, kills]`.
- Extends focused runner tests for missing safety fields, missing reliability tier, and persisted report safety/reliability outputs.

## Test plan
- `python3 -m py_compile scripts/screeps_rl_experiment_card.py scripts/screeps_rl_training_runner.py`
- `python3 -m unittest scripts/test_screeps_rl_training_runner.py -q`
- `git diff --check`

Closes #1136
