### PR TITLE
fix(tasks): stabilize source throughput

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -23145,6 +23145,7 @@ var LOW_LOAD_CONTROLLER_DOWNGRADE_IMMINENT_TICKS = 1e3;
 var LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
 var LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE = 6;
 var LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE = 12;
+var LOW_LOAD_SOURCE_LOGISTICS_CONTINUATION_MAX_RANGE = LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE;
 var ROUTINE_REPAIR_MIN_HITS_DEFICIT = 500;
 var ROUTINE_REPAIR_MIN_HITS_DEFICIT_RATIO = 0.1;
 var ROUTINE_REPAIR_MAX_RANGE = 5;
@@ -24119,12 +24120,32 @@ function applyMinimumUsefulLoadPolicy(creep, task) {
     recordLowLoadReturnTelemetry(creep, task, "hostileSafety");
     return task;
   }
-  const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(creep);
+  const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(
+    creep,
+    getLowLoadWorkerEnergyContinuationRange(creep, task)
+  );
   if (lowLoadEnergyContinuationTask) {
     return lowLoadEnergyContinuationTask;
   }
   recordLowLoadReturnTelemetry(creep, task, "noReachableEnergy");
   return task;
+}
+function getLowLoadWorkerEnergyContinuationRange(creep, task) {
+  return shouldUseExtendedLowLoadSourceLogisticsContinuation(creep, task) ? LOW_LOAD_SOURCE_LOGISTICS_CONTINUATION_MAX_RANGE : LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE;
+}
+function shouldUseExtendedLowLoadSourceLogisticsContinuation(creep, task) {
+  return task.type === "build" && hasHealthyRoomEnergyBuffer(creep.room) && !hasEmergencySpawnExtensionRefillDemand(creep) && isSourceLogisticsConstructionTask(creep, task);
+}
+function isSourceLogisticsConstructionTask(creep, task) {
+  const site = getGameObjectById2(String(task.targetId));
+  if (!site) {
+    return false;
+  }
+  const priority = getConstructionSiteImpactPriority(
+    site,
+    buildWorkerConstructionSiteImpactPriorityContext(creep, [site])
+  );
+  return priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.sourceContainer || priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedSourceContainer || priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.criticalRoad || priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedCriticalRoad;
 }
 function applyMinimumUsefulSpawnExtensionDeliveryPolicy(creep, task) {
   if (!getLowLoadWorkerEnergyContext(creep)) {
@@ -26141,8 +26162,8 @@ function shouldSwitchLowLoadWorkerEnergyAcquisitionTaskForYield(creep, currentTa
   const selectedCandidate = createLowLoadWorkerEnergyAcquisitionCandidateForTask(creep, selectedTask);
   return currentCandidate !== null && selectedCandidate !== null && isLowLoadWorkerEnergyYieldSwitchBetter(creep, currentCandidate, selectedCandidate);
 }
-function selectLowLoadWorkerEnergyContinuationTask(creep) {
-  const candidate = selectLowLoadWorkerEnergyContinuationCandidate(creep);
+function selectLowLoadWorkerEnergyContinuationTask(creep, maximumRange = LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE) {
+  const candidate = selectLowLoadWorkerEnergyContinuationCandidate(creep, maximumRange);
   if (!candidate) {
     return null;
   }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -24134,7 +24134,7 @@ function getLowLoadWorkerEnergyContinuationRange(creep, task) {
   return shouldUseExtendedLowLoadSourceLogisticsContinuation(creep, task) ? LOW_LOAD_SOURCE_LOGISTICS_CONTINUATION_MAX_RANGE : LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE;
 }
 function shouldUseExtendedLowLoadSourceLogisticsContinuation(creep, task) {
-  return task.type === "build" && hasHealthyRoomEnergyBuffer(creep.room) && !hasEmergencySpawnExtensionRefillDemand(creep) && isSourceLogisticsConstructionTask(creep, task);
+  return task.type === "build" && isSourceLogisticsConstructionTask(creep, task) && hasHealthyRoomEnergyBuffer(creep.room) && !hasEmergencySpawnExtensionRefillDemand(creep);
 }
 function isSourceLogisticsConstructionTask(creep, task) {
   const site = getGameObjectById2(String(task.targetId));

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -94,6 +94,7 @@ export const LOW_LOAD_CONTROLLER_DOWNGRADE_IMMINENT_TICKS = 1_000;
 export const LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
 export const LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE = 6;
 export const LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE = 12;
+const LOW_LOAD_SOURCE_LOGISTICS_CONTINUATION_MAX_RANGE = LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE;
 export const ROUTINE_REPAIR_MIN_HITS_DEFICIT = 500;
 export const ROUTINE_REPAIR_MIN_HITS_DEFICIT_RATIO = 0.1;
 export const ROUTINE_REPAIR_MAX_RANGE = 5;
@@ -1637,13 +1638,55 @@ function applyMinimumUsefulLoadPolicy(
     return task;
   }
 
-  const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(creep);
+  const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(
+    creep,
+    getLowLoadWorkerEnergyContinuationRange(creep, task)
+  );
   if (lowLoadEnergyContinuationTask) {
     return lowLoadEnergyContinuationTask;
   }
 
   recordLowLoadReturnTelemetry(creep, task, 'noReachableEnergy');
   return task;
+}
+
+function getLowLoadWorkerEnergyContinuationRange(creep: Creep, task: WorkerEnergySpendingTask): number {
+  return shouldUseExtendedLowLoadSourceLogisticsContinuation(creep, task)
+    ? LOW_LOAD_SOURCE_LOGISTICS_CONTINUATION_MAX_RANGE
+    : LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE;
+}
+
+function shouldUseExtendedLowLoadSourceLogisticsContinuation(
+  creep: Creep,
+  task: WorkerEnergySpendingTask
+): boolean {
+  return (
+    task.type === 'build' &&
+    hasHealthyRoomEnergyBuffer(creep.room) &&
+    !hasEmergencySpawnExtensionRefillDemand(creep) &&
+    isSourceLogisticsConstructionTask(creep, task)
+  );
+}
+
+function isSourceLogisticsConstructionTask(
+  creep: Creep,
+  task: Extract<CreepTaskMemory, { type: 'build' }>
+): boolean {
+  const site = getGameObjectById<ConstructionSite>(String(task.targetId));
+  if (!site) {
+    return false;
+  }
+
+  const priority = getConstructionSiteImpactPriority(
+    site,
+    buildWorkerConstructionSiteImpactPriorityContext(creep, [site])
+  );
+  return (
+    priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.sourceContainer ||
+    priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedSourceContainer ||
+    priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.criticalRoad ||
+    priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedCriticalRoad
+  );
 }
 
 function applyMinimumUsefulSpawnExtensionDeliveryPolicy(
@@ -4869,8 +4912,11 @@ export function shouldSwitchLowLoadWorkerEnergyAcquisitionTaskForYield(
   );
 }
 
-function selectLowLoadWorkerEnergyContinuationTask(creep: Creep): LowLoadWorkerEnergyAcquisitionTask | null {
-  const candidate = selectLowLoadWorkerEnergyContinuationCandidate(creep);
+function selectLowLoadWorkerEnergyContinuationTask(
+  creep: Creep,
+  maximumRange = LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE
+): LowLoadWorkerEnergyAcquisitionTask | null {
+  const candidate = selectLowLoadWorkerEnergyContinuationCandidate(creep, maximumRange);
   if (!candidate) {
     return null;
   }

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1662,9 +1662,9 @@ function shouldUseExtendedLowLoadSourceLogisticsContinuation(
 ): boolean {
   return (
     task.type === 'build' &&
+    isSourceLogisticsConstructionTask(creep, task) &&
     hasHealthyRoomEnergyBuffer(creep.room) &&
-    !hasEmergencySpawnExtensionRefillDemand(creep) &&
-    isSourceLogisticsConstructionTask(creep, task)
+    !hasEmergencySpawnExtensionRefillDemand(creep)
   );
 }
 

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -108,6 +108,12 @@ function setSourceContainerHarvester(room: Room, sourceId: string): void {
   });
 }
 
+function expectLowLoadSourceLogisticsContinuationRangeToBeExtended(): void {
+  expect(LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE).toBeGreaterThan(
+    LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE
+  );
+}
+
 function makeStructure(
   id: string,
   structureType: StructureConstant,
@@ -9665,6 +9671,8 @@ describe('selectWorkerTask', () => {
   });
 
   it('keeps E29N55 low-load source-container builders acquiring before healthy-buffer build trips', () => {
+    expectLowLoadSourceLogisticsContinuationRangeToBeExtended();
+
     const source = makeSource('source1', 20, 10, 'E29N55');
     const sourceContainerSite = {
       id: 'source-container-site1',
@@ -9727,6 +9735,8 @@ describe('selectWorkerTask', () => {
   });
 
   it('uses reachable source-container energy before low-load critical road build trips in healthy E29N55', () => {
+    expectLowLoadSourceLogisticsContinuationRangeToBeExtended();
+
     const source = makeSource('source1', 20, 10, 'E29N55');
     const sourceContainer = makeStoredEnergyStructure('source-container1', 'container' as StructureConstant, 250, {
       pos: makeRoomPosition(20, 11, 'E29N55')

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -9664,6 +9664,135 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-critical-site1' });
   });
 
+  it('keeps E29N55 low-load source-container builders acquiring before healthy-buffer build trips', () => {
+    const source = makeSource('source1', 20, 10, 'E29N55');
+    const sourceContainerSite = {
+      id: 'source-container-site1',
+      structureType: 'container',
+      pos: makeRoomPosition(20, 11, 'E29N55')
+    } as ConstructionSite;
+    const fullSpawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 0, {
+      pos: makeRoomPosition(17, 24, 'E29N55')
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const capacity = 50;
+    const carriedEnergy = Math.ceil(capacity * MINIMUM_USEFUL_LOAD_RATIO) - 1;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N55',
+      constructionSites: [sourceContainerSite],
+      controller,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      myStructures: [fullSpawn as AnyOwnedStructure],
+      sources: [source]
+    });
+    const creep = {
+      name: 'SourceLogisticsBuilder',
+      memory: { role: 'worker', colony: 'E29N55' },
+      store: {
+        getCapacity: jest.fn().mockReturnValue(capacity),
+        getUsedCapacity: jest.fn().mockReturnValue(carriedEnergy),
+        getFreeCapacity: jest.fn().mockReturnValue(capacity - carriedEnergy)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => {
+          const ranges: Record<string, number> = {
+            source1: LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE - 2,
+            'source-container-site1': 2
+          };
+          return ranges[String(target.id)] ?? 99;
+        })
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ SourceLogisticsBuilder: creep });
+    setGameObjectsById([sourceContainerSite], { time: 1_141 });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'nearbyEnergyChoice',
+      tick: 1_141,
+      carriedEnergy,
+      freeCapacity: capacity - carriedEnergy,
+      selectedTask: 'harvest',
+      targetId: 'source1',
+      energy: 300,
+      range: LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE - 2
+    });
+  });
+
+  it('uses reachable source-container energy before low-load critical road build trips in healthy E29N55', () => {
+    const source = makeSource('source1', 20, 10, 'E29N55');
+    const sourceContainer = makeStoredEnergyStructure('source-container1', 'container' as StructureConstant, 250, {
+      pos: makeRoomPosition(20, 11, 'E29N55')
+    });
+    const roadSite = {
+      id: 'road-critical-site1',
+      structureType: 'road',
+      pos: makeRoomPosition(12, 10, 'E29N55')
+    } as ConstructionSite;
+    const fullSpawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 0, {
+      pos: makeRoomPosition(10, 10, 'E29N55')
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const capacity = 50;
+    const carriedEnergy = Math.ceil(capacity * MINIMUM_USEFUL_LOAD_RATIO) - 1;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N55',
+      constructionSites: [roadSite],
+      controller,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      myStructures: [fullSpawn as AnyOwnedStructure],
+      sources: [source],
+      structures: [sourceContainer as AnyStructure]
+    });
+    const creep = {
+      name: 'RoadLogisticsBuilder',
+      memory: { role: 'worker', colony: 'E29N55' },
+      store: {
+        getCapacity: jest.fn().mockReturnValue(capacity),
+        getUsedCapacity: jest.fn().mockReturnValue(carriedEnergy),
+        getFreeCapacity: jest.fn().mockReturnValue(capacity - carriedEnergy)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => {
+          const ranges: Record<string, number> = {
+            'road-critical-site1': 2,
+            'source-container1': LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE - 2,
+            source1: LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE
+          };
+          return ranges[String(target.id)] ?? 99;
+        })
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ RoadLogisticsBuilder: creep });
+    setGameObjectsById([roadSite, sourceContainer], { time: 1_142 });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'source-container1' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'nearbyEnergyChoice',
+      tick: 1_142,
+      carriedEnergy,
+      freeCapacity: capacity - carriedEnergy,
+      selectedTask: 'withdraw',
+      targetId: 'source-container1',
+      energy: 250,
+      range: LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE - 2
+    });
+  });
+
   it('builds an extension finishable with Screeps build power before a closer unfinished extension', () => {
     (globalThis as unknown as { BUILD_POWER: number }).BUILD_POWER = 5;
     const nearExtensionSite = {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -108,10 +108,14 @@ function setSourceContainerHarvester(room: Room, sourceId: string): void {
   });
 }
 
-function expectLowLoadSourceLogisticsContinuationRangeToBeExtended(): void {
+function expectLowLoadSourceLogisticsContinuationRangeToBeExtended(): number {
+  const extendedOnlyRange = LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE + 1;
+  expect(extendedOnlyRange).toBeGreaterThan(LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE);
+  expect(extendedOnlyRange).toBeLessThan(LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE);
   expect(LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE).toBeGreaterThan(
     LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE
   );
+  return extendedOnlyRange;
 }
 
 function makeStructure(
@@ -9671,7 +9675,7 @@ describe('selectWorkerTask', () => {
   });
 
   it('keeps E29N55 low-load source-container builders acquiring before healthy-buffer build trips', () => {
-    expectLowLoadSourceLogisticsContinuationRangeToBeExtended();
+    const extendedOnlyRange = expectLowLoadSourceLogisticsContinuationRangeToBeExtended();
 
     const source = makeSource('source1', 20, 10, 'E29N55');
     const sourceContainerSite = {
@@ -9710,7 +9714,7 @@ describe('selectWorkerTask', () => {
       pos: {
         getRangeTo: jest.fn((target: { id?: string }) => {
           const ranges: Record<string, number> = {
-            source1: LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE - 2,
+            source1: extendedOnlyRange,
             'source-container-site1': 2
           };
           return ranges[String(target.id)] ?? 99;
@@ -9730,12 +9734,12 @@ describe('selectWorkerTask', () => {
       selectedTask: 'harvest',
       targetId: 'source1',
       energy: 300,
-      range: LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE - 2
+      range: extendedOnlyRange
     });
   });
 
   it('uses reachable source-container energy before low-load critical road build trips in healthy E29N55', () => {
-    expectLowLoadSourceLogisticsContinuationRangeToBeExtended();
+    const extendedOnlyRange = expectLowLoadSourceLogisticsContinuationRangeToBeExtended();
 
     const source = makeSource('source1', 20, 10, 'E29N55');
     const sourceContainer = makeStoredEnergyStructure('source-container1', 'container' as StructureConstant, 250, {
@@ -9779,7 +9783,7 @@ describe('selectWorkerTask', () => {
         getRangeTo: jest.fn((target: { id?: string }) => {
           const ranges: Record<string, number> = {
             'road-critical-site1': 2,
-            'source-container1': LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE - 2,
+            'source-container1': extendedOnlyRange,
             source1: LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE
           };
           return ranges[String(target.id)] ?? 99;
@@ -9799,7 +9803,7 @@ describe('selectWorkerTask', () => {
       selectedTask: 'withdraw',
       targetId: 'source-container1',
       energy: 250,
-      range: LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE - 2
+      range: extendedOnlyRange
     });
   });
 


### PR DESCRIPTION
## Summary
- Prioritizes E29N55 source-container/road throughput behavior for the bootstrap stage.
- Adds regression coverage for source-throughput task assignment behavior.
- Regenerates `prod/dist/main.js` from the verified source changes.

## Test plan
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (98 suites / 1904 tests passed)
- `cd prod && npm run build`

Closes #1141
