### PR TITLE
fix(runtime): tame E29N55 rampart decay alerts

### DIFF
--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -44,6 +44,7 @@ DEFAULT_ROOM = world_profiles.PERSISTENT_DEFAULTS.room
 WORLD_PROFILE_ENV = world_profiles.WORLD_PROFILE_ENV
 RAMPART_DECAY_HITS_PER_EVENT = 300
 RAMPART_DECAY_EVENT_TICKS = 100
+RAMPART_DECAY_RECENT_HOSTILE_TICKS = RAMPART_DECAY_EVENT_TICKS
 RAMPART_SAFE_DECAY_HITS_FLOOR = 10_000
 RAMPART_CRITICAL_DAMAGE_DELTA = 5_000
 RUNTIME_SUMMARY_PREFIX = "#runtime-summary "
@@ -1709,13 +1710,40 @@ def expected_rampart_decay_delta(previous_room_state: dict[str, Any], current_ti
     return decay_events * RAMPART_DECAY_HITS_PER_EVENT
 
 
+def previous_room_state_has_recent_visible_hostiles(
+    previous_room_state: dict[str, Any], current_tick_value: Any
+) -> bool:
+    current_tick = tick_number(current_tick_value)
+    previous_tick = tick_number(previous_room_state.get("tick"))
+    previous_visible_hostiles = previous_room_state.get("visible_hostile_creeps")
+    had_visible_hostiles = (
+        not isinstance(previous_visible_hostiles, bool)
+        and isinstance(previous_visible_hostiles, (int, float))
+        and previous_visible_hostiles > 0
+    )
+
+    last_visible_hostile_tick = tick_number(previous_room_state.get("last_visible_hostile_tick"))
+    if last_visible_hostile_tick is None and had_visible_hostiles:
+        last_visible_hostile_tick = previous_tick
+    if last_visible_hostile_tick is None:
+        return False
+
+    if current_tick is None:
+        current_tick = previous_tick
+    if current_tick is None:
+        return True
+    if current_tick < last_visible_hostile_tick:
+        return False
+    return current_tick - last_visible_hostile_tick <= RAMPART_DECAY_RECENT_HOSTILE_TICKS
+
+
 def is_expected_safe_rampart_decay_reason(
     reason: dict[str, Any],
     previous_room_state: dict[str, Any],
     current_tick_value: Any,
     has_visible_hostiles: bool,
 ) -> bool:
-    if has_visible_hostiles:
+    if has_visible_hostiles or previous_room_state_has_recent_visible_hostiles(previous_room_state, current_tick_value):
         return False
     if alert_reason_kind(reason) != "structure_damage":
         return False
@@ -1729,7 +1757,7 @@ def is_expected_safe_rampart_decay_reason(
         return False
 
     return (
-        current_hits >= RAMPART_SAFE_DECAY_HITS_FLOOR
+        current_hits > RAMPART_SAFE_DECAY_HITS_FLOOR
         and 0 < delta <= expected_rampart_decay_delta(previous_room_state, current_tick_value)
     )
 
@@ -1754,11 +1782,15 @@ def build_next_room_state(
     now: int,
     owned_creeps: int,
     owned_spawns: int,
+    visible_hostile_creeps: int,
 ) -> dict[str, Any]:
     structures = previous_structures if should_preserve_previous_baseline(previous_structures, current_structures, detected) else current_structures
     previous_owner = previous_room_state.get("owner")
     owner = snapshot.owner or (previous_owner if should_preserve_previous_baseline(previous_structures, current_structures, detected) else None)
-    return {
+    last_visible_hostile_tick = (
+        snapshot.tick if visible_hostile_creeps > 0 else previous_room_state.get("last_visible_hostile_tick")
+    )
+    next_state = {
         "baseline_established": True,
         "observed_at": now,
         "tick": snapshot.tick,
@@ -1771,7 +1803,11 @@ def build_next_room_state(
         "structures": structures,
         "alerts": alerts,
         "rule_counts": rule_counts,
+        "visible_hostile_creeps": visible_hostile_creeps,
     }
+    if last_visible_hostile_tick is not None:
+        next_state["last_visible_hostile_tick"] = last_visible_hostile_tick
+    return next_state
 
 
 def evaluate_room_alert(
@@ -1959,6 +1995,7 @@ def evaluate_room_alert(
         now,
         current_owned_creeps,
         current_owned_spawns,
+        len(visible_hostiles),
     )
     return emitted, suppressed, next_state
 

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -2459,15 +2459,14 @@ def category_severity(category: str, reason: dict[str, Any]) -> str:
     if category == "owned_structure_damage":
         structure_type = str(reason.get("structure_type") or reason.get("structureType") or "").lower()
         hits = number_from_reason(reason, "current_hits", "currentHits", "hits")
+        hits_max = number_from_reason(reason, "hitsMax", "hits_max")
         if structure_type == "rampart":
             delta = number_from_reason(reason, "delta")
             if hits is not None and hits <= RAMPART_SAFE_DECAY_HITS_FLOOR:
                 return "critical"
             if delta is not None and delta >= RAMPART_CRITICAL_DAMAGE_DELTA:
                 return "critical"
-            return severity
 
-        hits_max = number_from_reason(reason, "hitsMax", "hits_max")
         if hits is not None and hits_max and hits / hits_max <= 0.25:
             return "critical"
     return severity

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -1721,10 +1721,10 @@ def previous_room_state_has_recent_visible_hostiles(
         and isinstance(previous_visible_hostiles, (int, float))
         and previous_visible_hostiles > 0
     )
+    if had_visible_hostiles:
+        return True
 
     last_visible_hostile_tick = tick_number(previous_room_state.get("last_visible_hostile_tick"))
-    if last_visible_hostile_tick is None and had_visible_hostiles:
-        last_visible_hostile_tick = previous_tick
     if last_visible_hostile_tick is None:
         return False
 

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -42,6 +42,10 @@ DEFAULT_COLLECTION_RETRY_DELAY_SECONDS = 5
 DEFAULT_SHARD = world_profiles.PERSISTENT_DEFAULTS.shard
 DEFAULT_ROOM = world_profiles.PERSISTENT_DEFAULTS.room
 WORLD_PROFILE_ENV = world_profiles.WORLD_PROFILE_ENV
+RAMPART_DECAY_HITS_PER_EVENT = 300
+RAMPART_DECAY_EVENT_TICKS = 100
+RAMPART_SAFE_DECAY_HITS_FLOOR = 10_000
+RAMPART_CRITICAL_DAMAGE_DELTA = 5_000
 RUNTIME_SUMMARY_PREFIX = "#runtime-summary "
 WORKER_IDLE_COLLAPSE_KIND = "worker_idle_collapse"
 WORKER_IDLE_COLLAPSE_TICK_THRESHOLD = 20
@@ -1694,6 +1698,42 @@ def should_bypass_alert_debounce(reason: dict[str, Any]) -> bool:
     return alert_reason_kind(reason) in DEBOUNCE_BYPASS_REASON_KINDS
 
 
+def expected_rampart_decay_delta(previous_room_state: dict[str, Any], current_tick_value: Any) -> int:
+    previous_tick = tick_number(previous_room_state.get("tick"))
+    current_tick = tick_number(current_tick_value)
+    if previous_tick is None or current_tick is None or current_tick < previous_tick:
+        return RAMPART_DECAY_HITS_PER_EVENT
+
+    elapsed_ticks = max(1, current_tick - previous_tick)
+    decay_events = max(1, (elapsed_ticks + RAMPART_DECAY_EVENT_TICKS - 1) // RAMPART_DECAY_EVENT_TICKS)
+    return decay_events * RAMPART_DECAY_HITS_PER_EVENT
+
+
+def is_expected_safe_rampart_decay_reason(
+    reason: dict[str, Any],
+    previous_room_state: dict[str, Any],
+    current_tick_value: Any,
+    has_visible_hostiles: bool,
+) -> bool:
+    if has_visible_hostiles:
+        return False
+    if alert_reason_kind(reason) != "structure_damage":
+        return False
+    structure_type = str(reason.get("structure_type") or reason.get("structureType") or "").lower()
+    if structure_type != "rampart":
+        return False
+
+    current_hits = number_from_reason(reason, "current_hits", "currentHits", "hits")
+    delta = number_from_reason(reason, "delta")
+    if current_hits is None or delta is None:
+        return False
+
+    return (
+        current_hits >= RAMPART_SAFE_DECAY_HITS_FLOOR
+        and 0 < delta <= expected_rampart_decay_delta(previous_room_state, current_tick_value)
+    )
+
+
 def should_preserve_previous_baseline(
     previous_structures: dict[str, Any], current_structures: dict[str, dict[str, Any]], reasons: list[dict[str, Any]]
 ) -> bool:
@@ -1764,7 +1804,8 @@ def evaluate_room_alert(
     previous_spawn_count = previous_critical_spawn_count(previous_structures)
     detected: list[dict[str, Any]] = []
 
-    for hostile in detect_hostile_creeps(snapshot.objects, snapshot.owner):
+    visible_hostiles = detect_hostile_creeps(snapshot.objects, snapshot.owner)
+    for hostile in visible_hostiles:
         detected.append(build_hostile_reason(snapshot.ref, hostile))
 
     if expected_owner and snapshot.owner != expected_owner:
@@ -1882,6 +1923,19 @@ def evaluate_room_alert(
     suppressed: list[dict[str, Any]] = []
     alerts = dict(previous_alerts)
     for reason in detected:
+        if is_expected_safe_rampart_decay_reason(
+            reason,
+            previous_room_state,
+            snapshot.tick,
+            has_visible_hostiles=bool(visible_hostiles),
+        ):
+            suppressed_reason = dict(reason)
+            suppressed_reason["suppression_reason"] = "expected_rampart_decay"
+            suppressed_reason["expected_decay_delta"] = expected_rampart_decay_delta(previous_room_state, snapshot.tick)
+            suppressed_reason["safe_hits_floor"] = RAMPART_SAFE_DECAY_HITS_FLOOR
+            suppressed.append(suppressed_reason)
+            continue
+
         signature = str(reason.get("signature"))
         last_seen = alerts.get(signature)
         if (
@@ -2403,7 +2457,16 @@ def category_severity(category: str, reason: dict[str, Any]) -> str:
         if ticks is not None and ticks <= 2000:
             return "critical"
     if category == "owned_structure_damage":
+        structure_type = str(reason.get("structure_type") or reason.get("structureType") or "").lower()
         hits = number_from_reason(reason, "current_hits", "currentHits", "hits")
+        if structure_type == "rampart":
+            delta = number_from_reason(reason, "delta")
+            if hits is not None and hits <= RAMPART_SAFE_DECAY_HITS_FLOOR:
+                return "critical"
+            if delta is not None and delta >= RAMPART_CRITICAL_DAMAGE_DELTA:
+                return "critical"
+            return severity
+
         hits_max = number_from_reason(reason, "hitsMax", "hits_max")
         if hits is not None and hits_max and hits / hits_max <= 0.25:
             return "critical"

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -1752,8 +1752,11 @@ def is_expected_safe_rampart_decay_reason(
         return False
 
     current_hits = number_from_reason(reason, "current_hits", "currentHits", "hits")
+    hits_max = number_from_reason(reason, "hitsMax", "hits_max")
     delta = number_from_reason(reason, "delta")
     if current_hits is None or delta is None:
+        return False
+    if hits_max is not None and hits_max > 0 and current_hits / hits_max <= 0.25:
         return False
     if delta >= RAMPART_CRITICAL_DAMAGE_DELTA:
         return False

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -1755,6 +1755,8 @@ def is_expected_safe_rampart_decay_reason(
     delta = number_from_reason(reason, "delta")
     if current_hits is None or delta is None:
         return False
+    if delta >= RAMPART_CRITICAL_DAMAGE_DELTA:
+        return False
 
     return (
         current_hits > RAMPART_SAFE_DECAY_HITS_FLOOR

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -1702,10 +1702,10 @@ def should_bypass_alert_debounce(reason: dict[str, Any]) -> bool:
 def expected_rampart_decay_delta(previous_room_state: dict[str, Any], current_tick_value: Any) -> int:
     previous_tick = tick_number(previous_room_state.get("tick"))
     current_tick = tick_number(current_tick_value)
-    if previous_tick is None or current_tick is None or current_tick < previous_tick:
-        return RAMPART_DECAY_HITS_PER_EVENT
+    if previous_tick is None or current_tick is None or current_tick <= previous_tick:
+        return 0
 
-    elapsed_ticks = max(1, current_tick - previous_tick)
+    elapsed_ticks = current_tick - previous_tick
     decay_events = max(1, (elapsed_ticks + RAMPART_DECAY_EVENT_TICKS - 1) // RAMPART_DECAY_EVENT_TICKS)
     return decay_events * RAMPART_DECAY_HITS_PER_EVENT
 

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -1752,11 +1752,8 @@ def is_expected_safe_rampart_decay_reason(
         return False
 
     current_hits = number_from_reason(reason, "current_hits", "currentHits", "hits")
-    hits_max = number_from_reason(reason, "hitsMax", "hits_max")
     delta = number_from_reason(reason, "delta")
     if current_hits is None or delta is None:
-        return False
-    if hits_max is not None and hits_max > 0 and current_hits / hits_max <= 0.25:
         return False
     if delta >= RAMPART_CRITICAL_DAMAGE_DELTA:
         return False
@@ -2508,8 +2505,7 @@ def category_severity(category: str, reason: dict[str, Any]) -> str:
                 return "critical"
             if delta is not None and delta >= RAMPART_CRITICAL_DAMAGE_DELTA:
                 return "critical"
-
-        if hits is not None and hits_max and hits / hits_max <= 0.25:
+        elif hits is not None and hits_max and hits / hits_max <= 0.25:
             return "critical"
     return severity
 

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -827,6 +827,7 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         decay = monitor.RAMPART_DECAY_HITS_PER_EVENT
         safe_floor = monitor.RAMPART_SAFE_DECAY_HITS_FLOOR
         healthy_hits = safe_floor + 1
+        healthy_hits_max = 30_000
         previous = {
             "baseline_established": True,
             "tick": 1014519,
@@ -846,7 +847,7 @@ class TacticalResponseBridgeTest(unittest.TestCase):
                     "x": 8,
                     "y": 24,
                     "hits": healthy_hits + decay,
-                    "hitsMax": 300000,
+                    "hitsMax": healthy_hits_max,
                     "owned": True,
                     "damageable": True,
                     "critical": False,
@@ -871,7 +872,7 @@ class TacticalResponseBridgeTest(unittest.TestCase):
                     "x": 8,
                     "y": 24,
                     "hits": healthy_hits,
-                    "hitsMax": 300000,
+                    "hitsMax": healthy_hits_max,
                 },
             },
             tick=1014619,
@@ -981,26 +982,84 @@ class TacticalResponseBridgeTest(unittest.TestCase):
                 self.assertEqual([reason["kind"] for reason in emitted], ["structure_damage"])
                 self.assertEqual(emitted[0]["structure_type"], "rampart")
 
-    def test_low_relative_health_rampart_damage_is_critical(self) -> None:
-        reason = {
-            "kind": "structure_damage",
-            "room": "shardX/E26S49",
-            "object_id": "rampart1",
-            "structure_type": "rampart",
-            "current_hits": 1_000_000,
-            "hitsMax": 300_000_000,
-            "delta": 300,
-            "message": "owned rampart at 8,24 lost 300 hits",
+    def test_low_relative_health_expected_rampart_decay_still_alerts_p0(self) -> None:
+        decay = monitor.RAMPART_DECAY_HITS_PER_EVENT
+        current_hits = 20_000
+        hits_max = 300_000_000
+        previous_tick = 6000
+        current_tick = previous_tick + monitor.RAMPART_DECAY_EVENT_TICKS
+        previous = {
+            "baseline_established": True,
+            "tick": previous_tick,
+            "structures": {
+                "spawn1": {
+                    "type": "spawn",
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                    "owned": True,
+                    "damageable": True,
+                    "critical": True,
+                },
+                "rampart1": {
+                    "type": "rampart",
+                    "x": 8,
+                    "y": 24,
+                    "hits": current_hits + decay,
+                    "hitsMax": hits_max,
+                    "owned": True,
+                    "damageable": True,
+                    "critical": False,
+                },
+            },
         }
+        snapshot = make_snapshot(
+            {
+                "spawn1": {
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                },
+                "rampart1": {
+                    "type": "rampart",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 8,
+                    "y": 24,
+                    "hits": current_hits,
+                    "hitsMax": hits_max,
+                },
+            },
+            tick=current_tick,
+        )
 
-        self.assertGreater(reason["current_hits"], monitor.RAMPART_SAFE_DECAY_HITS_FLOOR)
+        self.assertGreater(current_hits, monitor.RAMPART_SAFE_DECAY_HITS_FLOOR)
+        self.assertLessEqual(current_hits / hits_max, 0.25)
+        self.assertEqual(monitor.expected_rampart_decay_delta(previous, current_tick), decay)
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            snapshot,
+            previous,
+            now=100,
+            debounce_seconds=300,
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertEqual([reason["kind"] for reason in emitted], ["structure_damage"])
+        self.assertEqual(emitted[0]["structure_type"], "rampart")
+        self.assertEqual(emitted[0]["current_hits"], current_hits)
+        self.assertEqual(emitted[0]["delta"], decay)
 
         report = monitor.build_tactical_response_report(
             {
                 "ok": True,
                 "mode": "alert",
                 "alert": True,
-                "reasons": [reason],
+                "reasons": emitted,
                 "rooms": ["shardX/E26S49"],
             }
         )

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -825,9 +825,8 @@ class TacticalResponseBridgeTest(unittest.TestCase):
 
     def test_expected_safe_rampart_decay_is_suppressed(self) -> None:
         decay = monitor.RAMPART_DECAY_HITS_PER_EVENT
-        safe_floor = monitor.RAMPART_SAFE_DECAY_HITS_FLOOR
-        healthy_hits = safe_floor + 1
-        healthy_hits_max = 30_000
+        healthy_hits = monitor.RAMPART_SAFE_DECAY_HITS_FLOOR + 10_000
+        healthy_hits_max = 300_000_000
         previous = {
             "baseline_established": True,
             "tick": 1014519,
@@ -878,6 +877,7 @@ class TacticalResponseBridgeTest(unittest.TestCase):
             tick=1014619,
         )
 
+        self.assertLessEqual(healthy_hits / healthy_hits_max, 0.25)
         emitted, suppressed, next_state = monitor.evaluate_room_alert(
             snapshot,
             previous,
@@ -889,6 +889,7 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(len(suppressed), 1)
         self.assertEqual(suppressed[0]["suppression_reason"], "expected_rampart_decay")
         self.assertEqual(suppressed[0]["safe_hits_floor"], monitor.RAMPART_SAFE_DECAY_HITS_FLOOR)
+        self.assertEqual(suppressed[0]["delta"], decay)
         self.assertEqual(next_state["structures"]["rampart1"]["hits"], healthy_hits)
 
         report = monitor.build_tactical_response_report(
@@ -982,93 +983,43 @@ class TacticalResponseBridgeTest(unittest.TestCase):
                 self.assertEqual([reason["kind"] for reason in emitted], ["structure_damage"])
                 self.assertEqual(emitted[0]["structure_type"], "rampart")
 
-    def test_low_relative_health_expected_rampart_decay_still_alerts_p0(self) -> None:
+    def test_low_relative_health_rampart_damage_is_not_critical_from_percentage(self) -> None:
         decay = monitor.RAMPART_DECAY_HITS_PER_EVENT
         current_hits = 20_000
         hits_max = 300_000_000
-        previous_tick = 6000
-        current_tick = previous_tick + monitor.RAMPART_DECAY_EVENT_TICKS
-        previous = {
-            "baseline_established": True,
-            "tick": previous_tick,
-            "structures": {
-                "spawn1": {
-                    "type": "spawn",
-                    "x": 25,
-                    "y": 25,
-                    "hits": 5000,
-                    "hitsMax": 5000,
-                    "owned": True,
-                    "damageable": True,
-                    "critical": True,
-                },
-                "rampart1": {
-                    "type": "rampart",
-                    "x": 8,
-                    "y": 24,
-                    "hits": current_hits + decay,
-                    "hitsMax": hits_max,
-                    "owned": True,
-                    "damageable": True,
-                    "critical": False,
-                },
-            },
+        reason = {
+            "kind": "structure_damage",
+            "room": "shardX/E26S49",
+            "object_id": "rampart1",
+            "structure_type": "rampart",
+            "x": 8,
+            "y": 24,
+            "current_hits": current_hits,
+            "hitsMax": hits_max,
+            "delta": decay,
+            "message": "rampart hits decreased 20300->20000 at 8,24",
         }
-        snapshot = make_snapshot(
-            {
-                "spawn1": {
-                    "type": "spawn",
-                    "my": True,
-                    "owner": {"username": "owner"},
-                    "x": 25,
-                    "y": 25,
-                    "hits": 5000,
-                    "hitsMax": 5000,
-                },
-                "rampart1": {
-                    "type": "rampart",
-                    "my": True,
-                    "owner": {"username": "owner"},
-                    "x": 8,
-                    "y": 24,
-                    "hits": current_hits,
-                    "hitsMax": hits_max,
-                },
-            },
-            tick=current_tick,
-        )
 
         self.assertGreater(current_hits, monitor.RAMPART_SAFE_DECAY_HITS_FLOOR)
         self.assertLessEqual(current_hits / hits_max, 0.25)
-        self.assertEqual(monitor.expected_rampart_decay_delta(previous, current_tick), decay)
-        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
-            snapshot,
-            previous,
-            now=100,
-            debounce_seconds=300,
-        )
-
-        self.assertEqual(suppressed, [])
-        self.assertEqual([reason["kind"] for reason in emitted], ["structure_damage"])
-        self.assertEqual(emitted[0]["structure_type"], "rampart")
-        self.assertEqual(emitted[0]["current_hits"], current_hits)
-        self.assertEqual(emitted[0]["delta"], decay)
+        self.assertLess(decay, monitor.RAMPART_CRITICAL_DAMAGE_DELTA)
+        self.assertEqual(monitor.category_severity("owned_structure_damage", reason), "high")
 
         report = monitor.build_tactical_response_report(
             {
                 "ok": True,
                 "mode": "alert",
                 "alert": True,
-                "reasons": emitted,
+                "reasons": [reason],
                 "rooms": ["shardX/E26S49"],
             }
         )
 
         self.assertTrue(report["emergency"])
-        self.assertEqual(report["severity"], "critical")
-        self.assertEqual(report["priority"], "P0")
-        self.assertEqual(report["triggers"][0]["severity"], "critical")
-        self.assertEqual(report["triggers"][0]["priority"], "P0")
+        self.assertEqual(report["severity"], "high")
+        self.assertEqual(report["priority"], "P1")
+        self.assertEqual(report["triggers"][0]["severity"], "high")
+        self.assertEqual(report["triggers"][0]["priority"], "P1")
 
     def test_exact_safe_floor_rampart_decay_still_alerts_p0(self) -> None:
         decay = monitor.RAMPART_DECAY_HITS_PER_EVENT

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -1366,6 +1366,77 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(suppressed, [])
         self.assertEqual([reason["kind"] for reason in emitted], ["structure_damage"])
 
+    def test_previous_visible_hostile_keeps_rampart_damage_alertable_beyond_recent_window(self) -> None:
+        decay = monitor.RAMPART_DECAY_HITS_PER_EVENT
+        safe_floor = monitor.RAMPART_SAFE_DECAY_HITS_FLOOR
+        healthy_hits = safe_floor + 1
+        previous_tick = 6000
+        current_tick = previous_tick + monitor.RAMPART_DECAY_RECENT_HOSTILE_TICKS + 1
+        previous = {
+            "baseline_established": True,
+            "tick": previous_tick,
+            "visible_hostile_creeps": 1,
+            "last_visible_hostile_tick": previous_tick,
+            "structures": {
+                "spawn1": {
+                    "type": "spawn",
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                    "owned": True,
+                    "damageable": True,
+                    "critical": True,
+                },
+                "rampart1": {
+                    "type": "rampart",
+                    "x": 8,
+                    "y": 24,
+                    "hits": healthy_hits + decay,
+                    "hitsMax": 300000,
+                    "owned": True,
+                    "damageable": True,
+                    "critical": False,
+                },
+            },
+        }
+        snapshot = make_snapshot(
+            {
+                "spawn1": {
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                },
+                "rampart1": {
+                    "type": "rampart",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 8,
+                    "y": 24,
+                    "hits": healthy_hits,
+                    "hitsMax": 300000,
+                },
+            },
+            tick=current_tick,
+        )
+
+        self.assertGreater(current_tick - previous_tick, monitor.RAMPART_DECAY_RECENT_HOSTILE_TICKS)
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            snapshot,
+            previous,
+            now=100,
+            debounce_seconds=300,
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertEqual([reason["kind"] for reason in emitted], ["structure_damage"])
+        self.assertEqual(emitted[0]["structure_type"], "rampart")
+        self.assertEqual(emitted[0]["delta"], decay)
+
     def test_report_is_json_serializable(self) -> None:
         rendered = json.dumps(monitor.build_tactical_response_report(HOSTILE_ALERT_FIXTURE), sort_keys=True)
 

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -189,7 +189,7 @@ def clean_private_smoke_fixture() -> dict[str, object]:
     }
 
 
-def make_snapshot(objects: dict[str, dict[str, object]], tick: int = 1) -> monitor.RoomSnapshot:
+def make_snapshot(objects: dict[str, dict[str, object]], tick: int | str | None = 1) -> monitor.RoomSnapshot:
     return monitor.RoomSnapshot(
         ref=monitor.RoomRef("shardX", "E26S49"),
         terrain="0" * monitor.TERRAIN_CELLS,
@@ -905,6 +905,81 @@ class TacticalResponseBridgeTest(unittest.TestCase):
 
         self.assertFalse(report["emergency"])
         self.assertTrue(report["silent"])
+
+    def test_unknown_or_non_advancing_rampart_decay_ticks_do_not_suppress_damage(self) -> None:
+        decay = monitor.RAMPART_DECAY_HITS_PER_EVENT
+        safe_floor = monitor.RAMPART_SAFE_DECAY_HITS_FLOOR
+        healthy_hits = safe_floor + 1
+        cases = (
+            ("missing_previous_tick", {}, 1014619),
+            ("missing_current_tick", {"tick": 1014519}, None),
+            ("regressed_current_tick", {"tick": 1014619}, 1014519),
+            ("unchanged_current_tick", {"tick": 1014519}, 1014519),
+        )
+
+        for name, tick_fields, current_tick in cases:
+            with self.subTest(name=name):
+                previous = {
+                    "baseline_established": True,
+                    **tick_fields,
+                    "structures": {
+                        "spawn1": {
+                            "type": "spawn",
+                            "x": 25,
+                            "y": 25,
+                            "hits": 5000,
+                            "hitsMax": 5000,
+                            "owned": True,
+                            "damageable": True,
+                            "critical": True,
+                        },
+                        "rampart1": {
+                            "type": "rampart",
+                            "x": 8,
+                            "y": 24,
+                            "hits": healthy_hits + decay,
+                            "hitsMax": 300000,
+                            "owned": True,
+                            "damageable": True,
+                            "critical": False,
+                        },
+                    },
+                }
+                snapshot = make_snapshot(
+                    {
+                        "spawn1": {
+                            "type": "spawn",
+                            "my": True,
+                            "owner": {"username": "owner"},
+                            "x": 25,
+                            "y": 25,
+                            "hits": 5000,
+                            "hitsMax": 5000,
+                        },
+                        "rampart1": {
+                            "type": "rampart",
+                            "my": True,
+                            "owner": {"username": "owner"},
+                            "x": 8,
+                            "y": 24,
+                            "hits": healthy_hits,
+                            "hitsMax": 300000,
+                        },
+                    },
+                    tick=current_tick,
+                )
+
+                self.assertEqual(monitor.expected_rampart_decay_delta(previous, current_tick), 0)
+                emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+                    snapshot,
+                    previous,
+                    now=100,
+                    debounce_seconds=300,
+                )
+
+                self.assertEqual(suppressed, [])
+                self.assertEqual([reason["kind"] for reason in emitted], ["structure_damage"])
+                self.assertEqual(emitted[0]["structure_type"], "rampart")
 
     def test_low_relative_health_rampart_damage_is_critical(self) -> None:
         reason = {

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -824,6 +824,9 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(report["triggers"][0]["severity"], "critical")
 
     def test_expected_safe_rampart_decay_is_suppressed(self) -> None:
+        decay = monitor.RAMPART_DECAY_HITS_PER_EVENT
+        safe_floor = monitor.RAMPART_SAFE_DECAY_HITS_FLOOR
+        healthy_hits = safe_floor + 1
         previous = {
             "baseline_established": True,
             "tick": 1014519,
@@ -842,7 +845,7 @@ class TacticalResponseBridgeTest(unittest.TestCase):
                     "type": "rampart",
                     "x": 8,
                     "y": 24,
-                    "hits": 10401,
+                    "hits": healthy_hits + decay,
                     "hitsMax": 300000,
                     "owned": True,
                     "damageable": True,
@@ -867,7 +870,7 @@ class TacticalResponseBridgeTest(unittest.TestCase):
                     "owner": {"username": "owner"},
                     "x": 8,
                     "y": 24,
-                    "hits": 10101,
+                    "hits": healthy_hits,
                     "hitsMax": 300000,
                 },
             },
@@ -885,7 +888,7 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(len(suppressed), 1)
         self.assertEqual(suppressed[0]["suppression_reason"], "expected_rampart_decay")
         self.assertEqual(suppressed[0]["safe_hits_floor"], monitor.RAMPART_SAFE_DECAY_HITS_FLOOR)
-        self.assertEqual(next_state["structures"]["rampart1"]["hits"], 10101)
+        self.assertEqual(next_state["structures"]["rampart1"]["hits"], healthy_hits)
 
         report = monitor.build_tactical_response_report(
             {
@@ -933,7 +936,9 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(report["triggers"][0]["severity"], "critical")
         self.assertEqual(report["triggers"][0]["priority"], "P0")
 
-    def test_low_rampart_decay_below_safe_floor_still_alerts_p0(self) -> None:
+    def test_exact_safe_floor_rampart_decay_still_alerts_p0(self) -> None:
+        decay = monitor.RAMPART_DECAY_HITS_PER_EVENT
+        safe_floor = monitor.RAMPART_SAFE_DECAY_HITS_FLOOR
         previous = {
             "baseline_established": True,
             "tick": 2000,
@@ -952,7 +957,7 @@ class TacticalResponseBridgeTest(unittest.TestCase):
                     "type": "rampart",
                     "x": 8,
                     "y": 24,
-                    "hits": 10200,
+                    "hits": safe_floor + decay,
                     "hitsMax": 300000,
                     "owned": True,
                     "damageable": True,
@@ -977,7 +982,7 @@ class TacticalResponseBridgeTest(unittest.TestCase):
                     "owner": {"username": "owner"},
                     "x": 8,
                     "y": 24,
-                    "hits": 9900,
+                    "hits": safe_floor,
                     "hitsMax": 300000,
                 },
             },
@@ -1009,6 +1014,10 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(report["priority"], "P0")
 
     def test_large_rampart_drop_still_alerts_p0(self) -> None:
+        decay = monitor.RAMPART_DECAY_HITS_PER_EVENT
+        safe_floor = monitor.RAMPART_SAFE_DECAY_HITS_FLOOR
+        current_hits = safe_floor + decay * 10
+        large_delta = monitor.RAMPART_CRITICAL_DAMAGE_DELTA + decay
         previous = {
             "baseline_established": True,
             "tick": 3000,
@@ -1027,7 +1036,7 @@ class TacticalResponseBridgeTest(unittest.TestCase):
                     "type": "rampart",
                     "x": 8,
                     "y": 24,
-                    "hits": 60000,
+                    "hits": current_hits + large_delta,
                     "hitsMax": 300000,
                     "owned": True,
                     "damageable": True,
@@ -1052,7 +1061,7 @@ class TacticalResponseBridgeTest(unittest.TestCase):
                     "owner": {"username": "owner"},
                     "x": 8,
                     "y": 24,
-                    "hits": 54500,
+                    "hits": current_hits,
                     "hitsMax": 300000,
                 },
             },
@@ -1067,7 +1076,7 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         )
 
         self.assertEqual(suppressed, [])
-        self.assertEqual(emitted[0]["delta"], 5500)
+        self.assertEqual(emitted[0]["delta"], large_delta)
 
         report = monitor.build_tactical_response_report(
             {
@@ -1084,6 +1093,9 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(report["priority"], "P0")
 
     def test_visible_hostile_keeps_rampart_damage_alertable(self) -> None:
+        decay = monitor.RAMPART_DECAY_HITS_PER_EVENT
+        safe_floor = monitor.RAMPART_SAFE_DECAY_HITS_FLOOR
+        healthy_hits = safe_floor + 1
         previous = {
             "baseline_established": True,
             "tick": 4000,
@@ -1102,7 +1114,7 @@ class TacticalResponseBridgeTest(unittest.TestCase):
                     "type": "rampart",
                     "x": 8,
                     "y": 24,
-                    "hits": 10401,
+                    "hits": healthy_hits + decay,
                     "hitsMax": 300000,
                     "owned": True,
                     "damageable": True,
@@ -1127,7 +1139,7 @@ class TacticalResponseBridgeTest(unittest.TestCase):
                     "owner": {"username": "owner"},
                     "x": 8,
                     "y": 24,
-                    "hits": 10101,
+                    "hits": healthy_hits,
                     "hitsMax": 300000,
                 },
                 "hostile1": {
@@ -1148,7 +1160,74 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         )
 
         self.assertEqual(suppressed, [])
-        self.assertEqual([reason["kind"] for reason in emitted], ["hostile_creep", "structure_damage"])
+        self.assertCountEqual([reason["kind"] for reason in emitted], ["hostile_creep", "structure_damage"])
+
+    def test_recent_hostile_keeps_rampart_damage_alertable_after_leaving(self) -> None:
+        decay = monitor.RAMPART_DECAY_HITS_PER_EVENT
+        safe_floor = monitor.RAMPART_SAFE_DECAY_HITS_FLOOR
+        healthy_hits = safe_floor + 1
+        previous_tick = 5000
+        previous = {
+            "baseline_established": True,
+            "tick": previous_tick,
+            "visible_hostile_creeps": 1,
+            "last_visible_hostile_tick": previous_tick,
+            "structures": {
+                "spawn1": {
+                    "type": "spawn",
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                    "owned": True,
+                    "damageable": True,
+                    "critical": True,
+                },
+                "rampart1": {
+                    "type": "rampart",
+                    "x": 8,
+                    "y": 24,
+                    "hits": healthy_hits + decay,
+                    "hitsMax": 300000,
+                    "owned": True,
+                    "damageable": True,
+                    "critical": False,
+                },
+            },
+        }
+        snapshot = make_snapshot(
+            {
+                "spawn1": {
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                },
+                "rampart1": {
+                    "type": "rampart",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 8,
+                    "y": 24,
+                    "hits": healthy_hits,
+                    "hitsMax": 300000,
+                },
+            },
+            tick=previous_tick + monitor.RAMPART_DECAY_EVENT_TICKS,
+        )
+
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            snapshot,
+            previous,
+            now=100,
+            debounce_seconds=300,
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertEqual([reason["kind"] for reason in emitted], ["structure_damage"])
 
     def test_report_is_json_serializable(self) -> None:
         rendered = json.dumps(monitor.build_tactical_response_report(HOSTILE_ALERT_FIXTURE), sort_keys=True)

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -903,6 +903,36 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertFalse(report["emergency"])
         self.assertTrue(report["silent"])
 
+    def test_low_relative_health_rampart_damage_is_critical(self) -> None:
+        reason = {
+            "kind": "structure_damage",
+            "room": "shardX/E26S49",
+            "object_id": "rampart1",
+            "structure_type": "rampart",
+            "current_hits": 1_000_000,
+            "hitsMax": 300_000_000,
+            "delta": 300,
+            "message": "owned rampart at 8,24 lost 300 hits",
+        }
+
+        self.assertGreater(reason["current_hits"], monitor.RAMPART_SAFE_DECAY_HITS_FLOOR)
+
+        report = monitor.build_tactical_response_report(
+            {
+                "ok": True,
+                "mode": "alert",
+                "alert": True,
+                "reasons": [reason],
+                "rooms": ["shardX/E26S49"],
+            }
+        )
+
+        self.assertTrue(report["emergency"])
+        self.assertEqual(report["severity"], "critical")
+        self.assertEqual(report["priority"], "P0")
+        self.assertEqual(report["triggers"][0]["severity"], "critical")
+        self.assertEqual(report["triggers"][0]["priority"], "P0")
+
     def test_low_rampart_decay_below_safe_floor_still_alerts_p0(self) -> None:
         previous = {
             "baseline_established": True,

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -189,12 +189,12 @@ def clean_private_smoke_fixture() -> dict[str, object]:
     }
 
 
-def make_snapshot(objects: dict[str, dict[str, object]]) -> monitor.RoomSnapshot:
+def make_snapshot(objects: dict[str, dict[str, object]], tick: int = 1) -> monitor.RoomSnapshot:
     return monitor.RoomSnapshot(
         ref=monitor.RoomRef("shardX", "E26S49"),
         terrain="0" * monitor.TERRAIN_CELLS,
         objects=monitor.normalize_objects(objects),
-        tick=1,
+        tick=tick,
         owner="owner",
         info={},
     )
@@ -822,6 +822,303 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(report["severity"], "critical")
         self.assertIn("owned_structure_damage", report["categories"])
         self.assertEqual(report["triggers"][0]["severity"], "critical")
+
+    def test_expected_safe_rampart_decay_is_suppressed(self) -> None:
+        previous = {
+            "baseline_established": True,
+            "tick": 1014519,
+            "structures": {
+                "spawn1": {
+                    "type": "spawn",
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                    "owned": True,
+                    "damageable": True,
+                    "critical": True,
+                },
+                "rampart1": {
+                    "type": "rampart",
+                    "x": 8,
+                    "y": 24,
+                    "hits": 10401,
+                    "hitsMax": 300000,
+                    "owned": True,
+                    "damageable": True,
+                    "critical": False,
+                },
+            },
+        }
+        snapshot = make_snapshot(
+            {
+                "spawn1": {
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                },
+                "rampart1": {
+                    "type": "rampart",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 8,
+                    "y": 24,
+                    "hits": 10101,
+                    "hitsMax": 300000,
+                },
+            },
+            tick=1014619,
+        )
+
+        emitted, suppressed, next_state = monitor.evaluate_room_alert(
+            snapshot,
+            previous,
+            now=100,
+            debounce_seconds=300,
+        )
+
+        self.assertEqual(emitted, [])
+        self.assertEqual(len(suppressed), 1)
+        self.assertEqual(suppressed[0]["suppression_reason"], "expected_rampart_decay")
+        self.assertEqual(suppressed[0]["safe_hits_floor"], monitor.RAMPART_SAFE_DECAY_HITS_FLOOR)
+        self.assertEqual(next_state["structures"]["rampart1"]["hits"], 10101)
+
+        report = monitor.build_tactical_response_report(
+            {
+                "ok": True,
+                "mode": "alert",
+                "alert": False,
+                "reasons": emitted,
+                "suppressed": True,
+                "suppressed_count": len(suppressed),
+                "suppressed_reasons": suppressed,
+                "rooms": ["shardX/E26S49"],
+            }
+        )
+
+        self.assertFalse(report["emergency"])
+        self.assertTrue(report["silent"])
+
+    def test_low_rampart_decay_below_safe_floor_still_alerts_p0(self) -> None:
+        previous = {
+            "baseline_established": True,
+            "tick": 2000,
+            "structures": {
+                "spawn1": {
+                    "type": "spawn",
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                    "owned": True,
+                    "damageable": True,
+                    "critical": True,
+                },
+                "rampart1": {
+                    "type": "rampart",
+                    "x": 8,
+                    "y": 24,
+                    "hits": 10200,
+                    "hitsMax": 300000,
+                    "owned": True,
+                    "damageable": True,
+                    "critical": False,
+                },
+            },
+        }
+        snapshot = make_snapshot(
+            {
+                "spawn1": {
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                },
+                "rampart1": {
+                    "type": "rampart",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 8,
+                    "y": 24,
+                    "hits": 9900,
+                    "hitsMax": 300000,
+                },
+            },
+            tick=2100,
+        )
+
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            snapshot,
+            previous,
+            now=100,
+            debounce_seconds=300,
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertEqual([reason["kind"] for reason in emitted], ["structure_damage"])
+
+        report = monitor.build_tactical_response_report(
+            {
+                "ok": True,
+                "mode": "alert",
+                "alert": True,
+                "reasons": emitted,
+                "rooms": ["shardX/E26S49"],
+            }
+        )
+
+        self.assertTrue(report["emergency"])
+        self.assertEqual(report["severity"], "critical")
+        self.assertEqual(report["priority"], "P0")
+
+    def test_large_rampart_drop_still_alerts_p0(self) -> None:
+        previous = {
+            "baseline_established": True,
+            "tick": 3000,
+            "structures": {
+                "spawn1": {
+                    "type": "spawn",
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                    "owned": True,
+                    "damageable": True,
+                    "critical": True,
+                },
+                "rampart1": {
+                    "type": "rampart",
+                    "x": 8,
+                    "y": 24,
+                    "hits": 60000,
+                    "hitsMax": 300000,
+                    "owned": True,
+                    "damageable": True,
+                    "critical": False,
+                },
+            },
+        }
+        snapshot = make_snapshot(
+            {
+                "spawn1": {
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                },
+                "rampart1": {
+                    "type": "rampart",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 8,
+                    "y": 24,
+                    "hits": 54500,
+                    "hitsMax": 300000,
+                },
+            },
+            tick=3001,
+        )
+
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            snapshot,
+            previous,
+            now=100,
+            debounce_seconds=300,
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertEqual(emitted[0]["delta"], 5500)
+
+        report = monitor.build_tactical_response_report(
+            {
+                "ok": True,
+                "mode": "alert",
+                "alert": True,
+                "reasons": emitted,
+                "rooms": ["shardX/E26S49"],
+            }
+        )
+
+        self.assertTrue(report["emergency"])
+        self.assertEqual(report["severity"], "critical")
+        self.assertEqual(report["priority"], "P0")
+
+    def test_visible_hostile_keeps_rampart_damage_alertable(self) -> None:
+        previous = {
+            "baseline_established": True,
+            "tick": 4000,
+            "structures": {
+                "spawn1": {
+                    "type": "spawn",
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                    "owned": True,
+                    "damageable": True,
+                    "critical": True,
+                },
+                "rampart1": {
+                    "type": "rampart",
+                    "x": 8,
+                    "y": 24,
+                    "hits": 10401,
+                    "hitsMax": 300000,
+                    "owned": True,
+                    "damageable": True,
+                    "critical": False,
+                },
+            },
+        }
+        snapshot = make_snapshot(
+            {
+                "spawn1": {
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                },
+                "rampart1": {
+                    "type": "rampart",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 8,
+                    "y": 24,
+                    "hits": 10101,
+                    "hitsMax": 300000,
+                },
+                "hostile1": {
+                    "type": "creep",
+                    "owner": {"username": "Invader"},
+                    "x": 9,
+                    "y": 24,
+                },
+            },
+            tick=4100,
+        )
+
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            snapshot,
+            previous,
+            now=100,
+            debounce_seconds=300,
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertEqual([reason["kind"] for reason in emitted], ["hostile_creep", "structure_damage"])
 
     def test_report_is_json_serializable(self) -> None:
         rendered = json.dumps(monitor.build_tactical_response_report(HOSTILE_ALERT_FIXTURE), sort_keys=True)

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -1018,9 +1018,11 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         safe_floor = monitor.RAMPART_SAFE_DECAY_HITS_FLOOR
         current_hits = safe_floor + decay * 10
         large_delta = monitor.RAMPART_CRITICAL_DAMAGE_DELTA + decay
+        previous_tick = 3000
+        current_tick = previous_tick + monitor.RAMPART_DECAY_EVENT_TICKS * 18
         previous = {
             "baseline_established": True,
-            "tick": 3000,
+            "tick": previous_tick,
             "structures": {
                 "spawn1": {
                     "type": "spawn",
@@ -1065,8 +1067,9 @@ class TacticalResponseBridgeTest(unittest.TestCase):
                     "hitsMax": 300000,
                 },
             },
-            tick=3001,
+            tick=current_tick,
         )
+        self.assertGreaterEqual(monitor.expected_rampart_decay_delta(previous, current_tick), large_delta)
 
         emitted, suppressed, _next_state = monitor.evaluate_room_alert(
             snapshot,


### PR DESCRIPTION
## Summary

Fixes #1144.

This PR tames repeated P0 runtime-alert churn from normal E29N55 rampart decay while preserving real tactical alerts:
- expected 300-hit rampart decay at safe hit levels is suppressed/debounced;
- hostile-adjacent or critical/large structure damage still emits alerts;
- focused monitor tactical-response tests cover safe decay suppression and real-damage emission.

## Evidence

Fresh scheduler monitor before this PR:
- `runtime-artifacts/screeps-monitor/scheduler-check-20260516T111924Z/`
- `health_rc=1`, `health_gate.ok=false`, `alert=true`, `tactical_response.emergency=true`
- E29N55 alive: `owned_spawns=1`, `owned_creeps=13`, `hostiles=0`, tick `1014616`

## Verification

Controller-side verification on exact commit `ebf1718df4828d40f61e192d79beb3c7dca6a052`:
- `git diff --check`
- `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py`
- `python3 -m unittest scripts.test_screeps_runtime_monitor_tactical_response` — 56 tests OK

## Safety

No production bot behavior or official MMO write path changed. Runtime monitor still alerts on hostile-backed or critical/large structure damage.
