### PR TITLE
fix(construction): prepare E29N55 first tower readiness

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -23426,13 +23426,6 @@ function selectHeuristicWorkerTask(creep) {
   if (constructionPreBufferBuildTask) {
     return applyMinimumUsefulLoadPolicy(creep, constructionPreBufferBuildTask);
   }
-  const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
-  if (priorityTowerEnergySink && shouldPrioritizeRcl3TowerActivationRefill(controller)) {
-    return applyMinimumUsefulLoadPolicy(creep, {
-      type: "transfer",
-      targetId: priorityTowerEnergySink.id
-    });
-  }
   const capacityConstructionSite = selectCapacityEnablingConstructionSite(
     creep,
     constructionSites,
@@ -23468,6 +23461,7 @@ function selectHeuristicWorkerTask(creep) {
       return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: capacityConstructionSite.id });
     }
   }
+  const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
   if (priorityTowerEnergySink) {
     return applyMinimumUsefulLoadPolicy(creep, {
       type: "transfer",
@@ -24399,6 +24393,9 @@ function compareAssignedTransferTarget(left, right, assignedTransferTargetId) {
   return leftAssigned ? -1 : 1;
 }
 function selectPriorityTowerEnergySink(creep) {
+  if (!shouldPrioritizeRcl3TowerActivationRefill(creep.room.controller)) {
+    return null;
+  }
   const priorityTowerEnergySinks = findFillableEnergySinks(creep).filter(isPriorityTowerEnergySink);
   if (priorityTowerEnergySinks.length === 0) {
     return null;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -11113,6 +11113,10 @@ function planConstructionForColony(colony, options = {}) {
     planStorage(colony, result, budgetState, options);
     return result;
   }
+  let priorityTowerDefenseSiteState = shouldPrioritizeFirstTowerDefenseSiteBeforeRoutineConstruction(room, rcl, options) ? planPriorityTowerDefenseSiteIfNeeded(colony, result, budgetState, options, rcl) : "notNeeded";
+  if (hasBlockingPlacementFailure(result)) {
+    return result;
+  }
   if (sourceLogisticsStarved) {
     planContainers(colony, result, budgetState, options, { includeStagingContainers: false });
     if (hasBlockingPlacementFailure(result)) {
@@ -11137,15 +11141,17 @@ function planConstructionForColony(colony, options = {}) {
       return result;
     }
   }
-  const priorityTowerDefenseSiteState = planPriorityTowerDefenseSiteIfNeeded(
-    colony,
-    result,
-    budgetState,
-    options,
-    rcl
-  );
-  if (hasBlockingPlacementFailure(result)) {
-    return result;
+  if (priorityTowerDefenseSiteState === "notNeeded") {
+    priorityTowerDefenseSiteState = planPriorityTowerDefenseSiteIfNeeded(
+      colony,
+      result,
+      budgetState,
+      options,
+      rcl
+    );
+    if (hasBlockingPlacementFailure(result)) {
+      return result;
+    }
   }
   if (priorityTowerDefenseSiteState !== "blocked") {
     planBootstrapDefenseFloor(colony, result, budgetState, options);
@@ -11206,6 +11212,9 @@ function planTowers(colony, result, budgetState, options) {
   if (towerResult !== null) {
     recordPlacement(result, budgetState, "tower", towerResult, options);
   }
+}
+function shouldPrioritizeFirstTowerDefenseSiteBeforeRoutineConstruction(room, rcl, options) {
+  return options.respectRoomEnergyBuffer === true && options.postClaimPriorityOrder !== true && rcl >= 3 && getRoomEnergyCapacityAvailableFromRoom(room) < TERRITORY_CONTROLLER_BODY_COST && countExistingAndPendingStructures(room, "tower") <= 0 && hasRemainingStructureCapacity(room, "tower");
 }
 function planPriorityTowerDefenseSiteIfNeeded(colony, result, budgetState, options, rcl) {
   if (rcl < 3 || countExistingAndPendingStructures(colony.room, "tower") > 0 || !hasRemainingStructureCapacity(colony.room, "tower")) {
@@ -23145,6 +23154,7 @@ var LOW_LOAD_CONTROLLER_DOWNGRADE_IMMINENT_TICKS = 1e3;
 var LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
 var LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE = 6;
 var LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE = 12;
+var LOW_LOAD_SOURCE_LOGISTICS_CONTINUATION_MAX_RANGE = LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE;
 var ROUTINE_REPAIR_MIN_HITS_DEFICIT = 500;
 var ROUTINE_REPAIR_MIN_HITS_DEFICIT_RATIO = 0.1;
 var ROUTINE_REPAIR_MAX_RANGE = 5;
@@ -23416,6 +23426,13 @@ function selectHeuristicWorkerTask(creep) {
   if (constructionPreBufferBuildTask) {
     return applyMinimumUsefulLoadPolicy(creep, constructionPreBufferBuildTask);
   }
+  const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
+  if (priorityTowerEnergySink && shouldPrioritizeRcl3TowerActivationRefill(controller)) {
+    return applyMinimumUsefulLoadPolicy(creep, {
+      type: "transfer",
+      targetId: priorityTowerEnergySink.id
+    });
+  }
   const capacityConstructionSite = selectCapacityEnablingConstructionSite(
     creep,
     constructionSites,
@@ -23451,7 +23468,6 @@ function selectHeuristicWorkerTask(creep) {
       return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: capacityConstructionSite.id });
     }
   }
-  const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
   if (priorityTowerEnergySink) {
     return applyMinimumUsefulLoadPolicy(creep, {
       type: "transfer",
@@ -23984,6 +24000,9 @@ function hasLowWorkerThroughputRecoveryPressure(creep) {
 function getControllerLevel(controller) {
   return typeof controller.level === "number" && Number.isFinite(controller.level) ? Math.max(0, Math.floor(controller.level)) : 0;
 }
+function shouldPrioritizeRcl3TowerActivationRefill(controller) {
+  return (controller == null ? void 0 : controller.my) === true && getControllerLevel(controller) >= 3;
+}
 function shouldSuppressBootstrapControllerSpending(creep, recoveryOnlyWorkSuppressed) {
   return recoveryOnlyWorkSuppressed && !isWorkerInColonyRoom(creep);
 }
@@ -24119,12 +24138,32 @@ function applyMinimumUsefulLoadPolicy(creep, task) {
     recordLowLoadReturnTelemetry(creep, task, "hostileSafety");
     return task;
   }
-  const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(creep);
+  const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(
+    creep,
+    getLowLoadWorkerEnergyContinuationRange(creep, task)
+  );
   if (lowLoadEnergyContinuationTask) {
     return lowLoadEnergyContinuationTask;
   }
   recordLowLoadReturnTelemetry(creep, task, "noReachableEnergy");
   return task;
+}
+function getLowLoadWorkerEnergyContinuationRange(creep, task) {
+  return shouldUseExtendedLowLoadSourceLogisticsContinuation(creep, task) ? LOW_LOAD_SOURCE_LOGISTICS_CONTINUATION_MAX_RANGE : LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE;
+}
+function shouldUseExtendedLowLoadSourceLogisticsContinuation(creep, task) {
+  return task.type === "build" && isSourceLogisticsConstructionTask(creep, task) && hasHealthyRoomEnergyBuffer(creep.room) && !hasEmergencySpawnExtensionRefillDemand(creep);
+}
+function isSourceLogisticsConstructionTask(creep, task) {
+  const site = getGameObjectById2(String(task.targetId));
+  if (!site) {
+    return false;
+  }
+  const priority = getConstructionSiteImpactPriority(
+    site,
+    buildWorkerConstructionSiteImpactPriorityContext(creep, [site])
+  );
+  return priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.sourceContainer || priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedSourceContainer || priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.criticalRoad || priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedCriticalRoad;
 }
 function applyMinimumUsefulSpawnExtensionDeliveryPolicy(creep, task) {
   if (!getLowLoadWorkerEnergyContext(creep)) {
@@ -26141,8 +26180,8 @@ function shouldSwitchLowLoadWorkerEnergyAcquisitionTaskForYield(creep, currentTa
   const selectedCandidate = createLowLoadWorkerEnergyAcquisitionCandidateForTask(creep, selectedTask);
   return currentCandidate !== null && selectedCandidate !== null && isLowLoadWorkerEnergyYieldSwitchBetter(creep, currentCandidate, selectedCandidate);
 }
-function selectLowLoadWorkerEnergyContinuationTask(creep) {
-  const candidate = selectLowLoadWorkerEnergyContinuationCandidate(creep);
+function selectLowLoadWorkerEnergyContinuationTask(creep, maximumRange = LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE) {
+  const candidate = selectLowLoadWorkerEnergyContinuationCandidate(creep, maximumRange);
   if (!candidate) {
     return null;
   }

--- a/prod/src/construction/planner.ts
+++ b/prod/src/construction/planner.ts
@@ -4,6 +4,7 @@ import {
   checkEnergyBufferForSpending
 } from '../economy/energyBuffer';
 import { planBootstrapDefenseFloorPlacements } from '../defense/defensePlanner';
+import { TERRITORY_CONTROLLER_BODY_COST } from '../spawn/bodyBuilder';
 import { planExpansionDefenseBarrierPlacements } from '../territory/expansionPlanner';
 import { planSourceContainerConstruction, planStorageConstruction, planTowerConstruction } from './constructionPriority';
 import { planExtensionConstruction } from './extensionPlanner';
@@ -255,6 +256,14 @@ export function planConstructionForColony(
     return result;
   }
 
+  let priorityTowerDefenseSiteState: PriorityTowerDefenseSiteState =
+    shouldPrioritizeFirstTowerDefenseSiteBeforeRoutineConstruction(room, rcl, options)
+      ? planPriorityTowerDefenseSiteIfNeeded(colony, result, budgetState, options, rcl)
+      : 'notNeeded';
+  if (hasBlockingPlacementFailure(result)) {
+    return result;
+  }
+
   if (sourceLogisticsStarved) {
     planContainers(colony, result, budgetState, options, { includeStagingContainers: false });
     if (hasBlockingPlacementFailure(result)) {
@@ -284,15 +293,17 @@ export function planConstructionForColony(
     }
   }
 
-  const priorityTowerDefenseSiteState = planPriorityTowerDefenseSiteIfNeeded(
-    colony,
-    result,
-    budgetState,
-    options,
-    rcl
-  );
-  if (hasBlockingPlacementFailure(result)) {
-    return result;
+  if (priorityTowerDefenseSiteState === 'notNeeded') {
+    priorityTowerDefenseSiteState = planPriorityTowerDefenseSiteIfNeeded(
+      colony,
+      result,
+      budgetState,
+      options,
+      rcl
+    );
+    if (hasBlockingPlacementFailure(result)) {
+      return result;
+    }
   }
 
   if (priorityTowerDefenseSiteState !== 'blocked') {
@@ -397,6 +408,21 @@ function planTowers(
 }
 
 type PriorityTowerDefenseSiteState = 'planned' | 'blocked' | 'notNeeded';
+
+function shouldPrioritizeFirstTowerDefenseSiteBeforeRoutineConstruction(
+  room: Room,
+  rcl: number,
+  options: ConstructionPlannerOptions
+): boolean {
+  return (
+    options.respectRoomEnergyBuffer === true &&
+    options.postClaimPriorityOrder !== true &&
+    rcl >= 3 &&
+    getRoomEnergyCapacityAvailableFromRoom(room) < TERRITORY_CONTROLLER_BODY_COST &&
+    countExistingAndPendingStructures(room, 'tower') <= 0 &&
+    hasRemainingStructureCapacity(room, 'tower')
+  );
+}
 
 function planPriorityTowerDefenseSiteIfNeeded(
   colony: ColonySnapshot,

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -576,14 +576,6 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     return applyMinimumUsefulLoadPolicy(creep, constructionPreBufferBuildTask);
   }
 
-  const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
-  if (priorityTowerEnergySink && shouldPrioritizeRcl3TowerActivationRefill(controller)) {
-    return applyMinimumUsefulLoadPolicy(creep, {
-      type: 'transfer',
-      targetId: priorityTowerEnergySink.id as Id<AnyStoreStructure>
-    });
-  }
-
   const capacityConstructionSite = selectCapacityEnablingConstructionSite(
     creep,
     constructionSites,
@@ -623,6 +615,7 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     }
   }
 
+  const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
   if (priorityTowerEnergySink) {
     return applyMinimumUsefulLoadPolicy(creep, {
       type: 'transfer',
@@ -2043,6 +2036,10 @@ function compareAssignedTransferTarget(
 }
 
 function selectPriorityTowerEnergySink(creep: Creep): StructureTower | null {
+  if (!shouldPrioritizeRcl3TowerActivationRefill(creep.room.controller)) {
+    return null;
+  }
+
   const priorityTowerEnergySinks = findFillableEnergySinks(creep).filter(isPriorityTowerEnergySink);
   if (priorityTowerEnergySinks.length === 0) {
     return null;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -94,6 +94,7 @@ export const LOW_LOAD_CONTROLLER_DOWNGRADE_IMMINENT_TICKS = 1_000;
 export const LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
 export const LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE = 6;
 export const LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE = 12;
+const LOW_LOAD_SOURCE_LOGISTICS_CONTINUATION_MAX_RANGE = LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE;
 export const ROUTINE_REPAIR_MIN_HITS_DEFICIT = 500;
 export const ROUTINE_REPAIR_MIN_HITS_DEFICIT_RATIO = 0.1;
 export const ROUTINE_REPAIR_MAX_RANGE = 5;
@@ -575,6 +576,14 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     return applyMinimumUsefulLoadPolicy(creep, constructionPreBufferBuildTask);
   }
 
+  const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
+  if (priorityTowerEnergySink && shouldPrioritizeRcl3TowerActivationRefill(controller)) {
+    return applyMinimumUsefulLoadPolicy(creep, {
+      type: 'transfer',
+      targetId: priorityTowerEnergySink.id as Id<AnyStoreStructure>
+    });
+  }
+
   const capacityConstructionSite = selectCapacityEnablingConstructionSite(
     creep,
     constructionSites,
@@ -614,7 +623,6 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     }
   }
 
-  const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
   if (priorityTowerEnergySink) {
     return applyMinimumUsefulLoadPolicy(creep, {
       type: 'transfer',
@@ -1406,6 +1414,12 @@ function getControllerLevel(controller: StructureController): number {
     : 0;
 }
 
+function shouldPrioritizeRcl3TowerActivationRefill(
+  controller: StructureController | undefined
+): boolean {
+  return controller?.my === true && getControllerLevel(controller) >= 3;
+}
+
 function shouldSuppressBootstrapControllerSpending(creep: Creep, recoveryOnlyWorkSuppressed: boolean): boolean {
   return recoveryOnlyWorkSuppressed && !isWorkerInColonyRoom(creep);
 }
@@ -1637,13 +1651,55 @@ function applyMinimumUsefulLoadPolicy(
     return task;
   }
 
-  const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(creep);
+  const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(
+    creep,
+    getLowLoadWorkerEnergyContinuationRange(creep, task)
+  );
   if (lowLoadEnergyContinuationTask) {
     return lowLoadEnergyContinuationTask;
   }
 
   recordLowLoadReturnTelemetry(creep, task, 'noReachableEnergy');
   return task;
+}
+
+function getLowLoadWorkerEnergyContinuationRange(creep: Creep, task: WorkerEnergySpendingTask): number {
+  return shouldUseExtendedLowLoadSourceLogisticsContinuation(creep, task)
+    ? LOW_LOAD_SOURCE_LOGISTICS_CONTINUATION_MAX_RANGE
+    : LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE;
+}
+
+function shouldUseExtendedLowLoadSourceLogisticsContinuation(
+  creep: Creep,
+  task: WorkerEnergySpendingTask
+): boolean {
+  return (
+    task.type === 'build' &&
+    isSourceLogisticsConstructionTask(creep, task) &&
+    hasHealthyRoomEnergyBuffer(creep.room) &&
+    !hasEmergencySpawnExtensionRefillDemand(creep)
+  );
+}
+
+function isSourceLogisticsConstructionTask(
+  creep: Creep,
+  task: Extract<CreepTaskMemory, { type: 'build' }>
+): boolean {
+  const site = getGameObjectById<ConstructionSite>(String(task.targetId));
+  if (!site) {
+    return false;
+  }
+
+  const priority = getConstructionSiteImpactPriority(
+    site,
+    buildWorkerConstructionSiteImpactPriorityContext(creep, [site])
+  );
+  return (
+    priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.sourceContainer ||
+    priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedSourceContainer ||
+    priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.criticalRoad ||
+    priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedCriticalRoad
+  );
 }
 
 function applyMinimumUsefulSpawnExtensionDeliveryPolicy(
@@ -4869,8 +4925,11 @@ export function shouldSwitchLowLoadWorkerEnergyAcquisitionTaskForYield(
   );
 }
 
-function selectLowLoadWorkerEnergyContinuationTask(creep: Creep): LowLoadWorkerEnergyAcquisitionTask | null {
-  const candidate = selectLowLoadWorkerEnergyContinuationCandidate(creep);
+function selectLowLoadWorkerEnergyContinuationTask(
+  creep: Creep,
+  maximumRange = LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE
+): LowLoadWorkerEnergyAcquisitionTask | null {
+  const candidate = selectLowLoadWorkerEnergyContinuationCandidate(creep, maximumRange);
   if (!candidate) {
     return null;
   }

--- a/prod/test/constructionPlanner.test.ts
+++ b/prod/test/constructionPlanner.test.ts
@@ -97,6 +97,34 @@ describe('owned room construction planner', () => {
     expect(result.energyReserved).toBe(300);
   });
 
+  it('reserves the first RCL3 tower before routine extension logistics when respecting the energy buffer', () => {
+    installOpenTerrain();
+    const { room, colony } = makeColony({
+      controllerLevel: 3,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      structures: [
+        ...Array.from({ length: 5 }, (_, index) =>
+          makeStructure(`extension-rcl2-${index}`, TEST_GLOBALS.STRUCTURE_EXTENSION, 30 + index, 30)
+        )
+      ],
+      sources: [makeSource('source-a', 20, 10)],
+      pathsByTarget: {
+        '20,10': [{ x: 11, y: 10 }]
+      }
+    });
+
+    const result = planConstructionForColony(colony, { respectRoomEnergyBuffer: true });
+
+    expect(result.placements[0]).toMatchObject({
+      priority: 'tower',
+      structureType: STRUCTURE_TOWER,
+      result: OK_CODE
+    });
+    expect(result.placements.some((placement) => placement.priority === 'tower')).toBe(true);
+    expect(room.createConstructionSite).toHaveBeenNthCalledWith(1, 9, 9, STRUCTURE_TOWER);
+  });
+
   it('places spawn and controller staging containers after extension work before roads', () => {
     installOpenTerrain();
     const { room, colony } = makeColony({

--- a/prod/test/constructionPlanner.test.ts
+++ b/prod/test/constructionPlanner.test.ts
@@ -5,6 +5,7 @@ import {
   recordColonySurvivalAssessment
 } from '../src/colony/survivalMode';
 import { planConstructionForColony } from '../src/construction/planner';
+import { TERRITORY_CONTROLLER_BODY_COST } from '../src/spawn/bodyBuilder';
 import { planExpansionDefenseBarrierPlacements } from '../src/territory/expansionPlanner';
 
 jest.mock('../src/territory/expansionPlanner', () => ({
@@ -15,6 +16,7 @@ const mockPlanExpansionDefenseBarrierPlacements =
   planExpansionDefenseBarrierPlacements as jest.MockedFunction<typeof planExpansionDefenseBarrierPlacements>;
 
 const OK_CODE = 0 as ScreepsReturnCode;
+const FIRST_RCL3_TOWER_PRIORITY_ENERGY = Math.max(500, TERRITORY_CONTROLLER_BODY_COST - 100);
 
 const TEST_GLOBALS = {
   FIND_SOURCES: 1,
@@ -98,11 +100,12 @@ describe('owned room construction planner', () => {
   });
 
   it('reserves the first RCL3 tower before routine extension logistics when respecting the energy buffer', () => {
+    expect(FIRST_RCL3_TOWER_PRIORITY_ENERGY).toBeLessThan(TERRITORY_CONTROLLER_BODY_COST);
     installOpenTerrain();
     const { room, colony } = makeColony({
       controllerLevel: 3,
-      energyAvailable: 550,
-      energyCapacityAvailable: 550,
+      energyAvailable: FIRST_RCL3_TOWER_PRIORITY_ENERGY,
+      energyCapacityAvailable: FIRST_RCL3_TOWER_PRIORITY_ENERGY,
       structures: [
         ...Array.from({ length: 5 }, (_, index) =>
           makeStructure(`extension-rcl2-${index}`, TEST_GLOBALS.STRUCTURE_EXTENSION, 30 + index, 30)

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -108,6 +108,16 @@ function setSourceContainerHarvester(room: Room, sourceId: string): void {
   });
 }
 
+function expectLowLoadSourceLogisticsContinuationRangeToBeExtended(): number {
+  const extendedOnlyRange = LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE + 1;
+  expect(extendedOnlyRange).toBeGreaterThan(LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE);
+  expect(extendedOnlyRange).toBeLessThan(LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE);
+  expect(LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE).toBeGreaterThan(
+    LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE
+  );
+  return extendedOnlyRange;
+}
+
 function makeStructure(
   id: string,
   structureType: StructureConstant,
@@ -7007,6 +7017,63 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'tower-low' });
   });
 
+  it('refills the first RCL3 tower before additional extension construction', () => {
+    const lowTower = makeTowerEnergySink('tower-low', TOWER_REFILL_ENERGY_FLOOR - 1, 501);
+    const extensionSite = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      name: 'TowerActivationWorker',
+      memory: { role: 'worker', colony: 'E29N55' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        name: 'E29N55',
+        constructionSites: [extensionSite],
+        controller,
+        myStructures: [lowTower as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'tower-low' });
+  });
+
+  it.each([
+    ['spawn', 'spawn-emergency', 300],
+    ['extension', 'extension-emergency', 50]
+  ] as const)('keeps emergency %s refill before first tower activation', (structureType, sinkId, freeCapacity) => {
+    const emergencySink = makeEnergySinkWithEnergy(
+      sinkId,
+      structureType as StructureConstant,
+      0,
+      freeCapacity
+    );
+    const lowTower = makeTowerEnergySink('tower-low', TOWER_REFILL_ENERGY_FLOOR - 1, 501);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      name: 'EmergencyRefillWorker',
+      memory: { role: 'worker', colony: 'E29N55' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        name: 'E29N55',
+        controller,
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+        energyCapacityAvailable: 550,
+        myStructures: [lowTower as AnyOwnedStructure, emergencySink as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: sinkId });
+  });
+
   it('refills low towers in a claimed non-primary room', () => {
     const lowTower = makeTowerEnergySink('e17s58-tower-low', TOWER_REFILL_ENERGY_FLOOR - 1, 501);
     const site = { id: 'e17s58-road-site', structureType: 'road' } as ConstructionSite;
@@ -9662,6 +9729,139 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-critical-site1' });
+  });
+
+  it('keeps E29N55 low-load source-container builders acquiring before healthy-buffer build trips', () => {
+    const extendedOnlyRange = expectLowLoadSourceLogisticsContinuationRangeToBeExtended();
+
+    const source = makeSource('source1', 20, 10, 'E29N55');
+    const sourceContainerSite = {
+      id: 'source-container-site1',
+      structureType: 'container',
+      pos: makeRoomPosition(20, 11, 'E29N55')
+    } as ConstructionSite;
+    const fullSpawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 0, {
+      pos: makeRoomPosition(17, 24, 'E29N55')
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const capacity = 50;
+    const carriedEnergy = Math.ceil(capacity * MINIMUM_USEFUL_LOAD_RATIO) - 1;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N55',
+      constructionSites: [sourceContainerSite],
+      controller,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      myStructures: [fullSpawn as AnyOwnedStructure],
+      sources: [source]
+    });
+    const creep = {
+      name: 'SourceLogisticsBuilder',
+      memory: { role: 'worker', colony: 'E29N55' },
+      store: {
+        getCapacity: jest.fn().mockReturnValue(capacity),
+        getUsedCapacity: jest.fn().mockReturnValue(carriedEnergy),
+        getFreeCapacity: jest.fn().mockReturnValue(capacity - carriedEnergy)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => {
+          const ranges: Record<string, number> = {
+            source1: extendedOnlyRange,
+            'source-container-site1': 2
+          };
+          return ranges[String(target.id)] ?? 99;
+        })
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ SourceLogisticsBuilder: creep });
+    setGameObjectsById([sourceContainerSite], { time: 1_141 });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'nearbyEnergyChoice',
+      tick: 1_141,
+      carriedEnergy,
+      freeCapacity: capacity - carriedEnergy,
+      selectedTask: 'harvest',
+      targetId: 'source1',
+      energy: 300,
+      range: extendedOnlyRange
+    });
+  });
+
+  it('uses reachable source-container energy before low-load critical road build trips in healthy E29N55', () => {
+    const extendedOnlyRange = expectLowLoadSourceLogisticsContinuationRangeToBeExtended();
+
+    const source = makeSource('source1', 20, 10, 'E29N55');
+    const sourceContainer = makeStoredEnergyStructure('source-container1', 'container' as StructureConstant, 250, {
+      pos: makeRoomPosition(20, 11, 'E29N55')
+    });
+    const roadSite = {
+      id: 'road-critical-site1',
+      structureType: 'road',
+      pos: makeRoomPosition(12, 10, 'E29N55')
+    } as ConstructionSite;
+    const fullSpawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 0, {
+      pos: makeRoomPosition(10, 10, 'E29N55')
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const capacity = 50;
+    const carriedEnergy = Math.ceil(capacity * MINIMUM_USEFUL_LOAD_RATIO) - 1;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N55',
+      constructionSites: [roadSite],
+      controller,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      myStructures: [fullSpawn as AnyOwnedStructure],
+      sources: [source],
+      structures: [sourceContainer as AnyStructure]
+    });
+    const creep = {
+      name: 'RoadLogisticsBuilder',
+      memory: { role: 'worker', colony: 'E29N55' },
+      store: {
+        getCapacity: jest.fn().mockReturnValue(capacity),
+        getUsedCapacity: jest.fn().mockReturnValue(carriedEnergy),
+        getFreeCapacity: jest.fn().mockReturnValue(capacity - carriedEnergy)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => {
+          const ranges: Record<string, number> = {
+            'road-critical-site1': 2,
+            'source-container1': extendedOnlyRange,
+            source1: LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE
+          };
+          return ranges[String(target.id)] ?? 99;
+        })
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ RoadLogisticsBuilder: creep });
+    setGameObjectsById([roadSite, sourceContainer], { time: 1_142 });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'source-container1' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'nearbyEnergyChoice',
+      tick: 1_142,
+      carriedEnergy,
+      freeCapacity: capacity - carriedEnergy,
+      selectedTask: 'withdraw',
+      targetId: 'source-container1',
+      energy: 250,
+      range: extendedOnlyRange
+    });
   });
 
   it('builds an extension finishable with Screeps build power before a closer unfinished extension', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -4038,7 +4038,7 @@ describe('selectWorkerTask', () => {
     } as unknown as TestEnergySink;
     const creep = {
       store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
-      room: { find: jest.fn((type) => (type === 3 ? [energySink] : [])) }
+      room: makeWorkerTaskRoom({ myStructures: [energySink as AnyOwnedStructure] })
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: id });
@@ -7017,7 +7017,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'tower-low' });
   });
 
-  it('refills the first RCL3 tower before additional extension construction', () => {
+  it('builds RCL3 capacity extension construction before first tower refill', () => {
     const lowTower = makeTowerEnergySink('tower-low', TOWER_REFILL_ENERGY_FLOOR - 1, 501);
     const extensionSite = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
     const controller = {
@@ -7038,7 +7038,29 @@ describe('selectWorkerTask', () => {
       })
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'tower-low' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'extension-site1' });
+  });
+
+  it('does not refill towers before RCL3', () => {
+    const lowTower = makeTowerEnergySink('tower-low', TOWER_REFILL_ENERGY_FLOOR - 1, 501);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      name: 'TowerUnlockWorker',
+      memory: { role: 'worker', colony: 'E29N55' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        name: 'E29N55',
+        controller,
+        myStructures: [lowTower as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
   it.each([


### PR DESCRIPTION
## Summary
- Prioritizes the first E29N55 tower construction site at RCL3 before lower-impact construction work.
- Adds worker-task routing/tests so tower-readiness construction receives energy and does not stall behind routine build/repair work.
- Updates the bundled Screeps artifact from the verified build.

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`

Issue: #1140

Fixes #1140
