### PR TITLE
docs(rl): register construction neglect reward decision

### DIFF
--- a/docs/ops/examples/rl-reward-decisions/RD-0004-construction-backlog-build-zero.json
+++ b/docs/ops/examples/rl-reward-decisions/RD-0004-construction-backlog-build-zero.json
@@ -1,0 +1,104 @@
+{
+  "rewardDecisionId": "RD-0004-construction-backlog-build-zero",
+  "title": "Proposal: construction neglect penalty for build-zero backlog",
+  "state": "proposed",
+  "linkedGitHubIssue": "https://github.com/lanyusea/screeps/issues/1024",
+  "linkedMetricEvidence": [
+    "https://github.com/lanyusea/screeps/issues/906",
+    "https://github.com/lanyusea/screeps/issues/907",
+    "https://github.com/lanyusea/screeps/issues/924",
+    "https://github.com/lanyusea/screeps/issues/1023",
+    "Gameplay Evolution Review 2026-05-14 08:07: build=0 while constructionSiteCount=10 across ticks 917318-918948; pendingBuildProgress frozen near 13200; buildBlockedReason=build_blocked_controller_progress_preferred."
+  ],
+  "linkedDashboardPanels": [
+    "runtime summary: constructionSiteCount",
+    "runtime summary: taskCounts.build",
+    "runtime summary: constructionDeadlockTicks",
+    "planned #924 candidate-vs-baseline construction scorecard"
+  ],
+  "problemStatement": "Historical runtime evidence shows construction sites remaining visible while no workers are assigned to build. In the cited window, upgrade selection won while constructionSiteCount stayed positive and pendingBuildProgress did not move, creating a training signal that can reinforce construction deadlock.",
+  "hypothesis": "Adding a construction-neglect penalty when constructionSiteCount > 0 and taskCounts.build == 0 will create offline selection pressure against policies that ignore available construction work, while preserving higher-priority safety gates and emergency spawn/refill behavior.",
+  "currentRewardCoverage": "Runtime telemetry exposes constructionSiteCount, taskCounts.build, pendingBuildProgress, buildCarriedEnergy, buildBlockedReason, and constructionDeadlockTicks. No accepted reward component currently penalizes constructionSiteCount > 0 with taskCounts.build == 0, and this record does not authorize live reward or policy writes.",
+  "proposedChangeType": "add_component",
+  "component": "construction_neglect_penalty",
+  "direction": "lower_is_better for construction deadlock; apply a negative reward proportional to constructionSiteCount only when constructionSiteCount > 0 and taskCounts.build == 0",
+  "expectedBehaviorChange": "In offline or shadow reward evaluation, candidate policies should rank below baseline when they leave build assignment at zero while construction sites exist, and should rank above comparable policies when they assign at least one worker to build without regressing safety, territory, or resource scorecard dimensions.",
+  "riskAndRegressions": [
+    "A penalty that is too strong can over-prioritize construction over spawn refill, controller downgrade safety, or emergency recovery.",
+    "A penalty that ignores energy availability can punish correct waiting during genuine energy starvation.",
+    "A proportional site-count penalty can overreact to many low-priority sites unless scorecard validation checks construction priority and resource health."
+  ],
+  "validationWindows": [
+    {
+      "name": "historical_shadow_reward_replay",
+      "minimumDurationHours": 8,
+      "requiredEvidence": [
+        "qualifying windows where constructionSiteCount > 0",
+        "taskCounts.build distribution in those windows",
+        "constructionDeadlockTicks",
+        "pendingBuildProgress or built progress delta",
+        "buildCarriedEnergy",
+        "spawn/refill health",
+        "controller downgrade safety",
+        "liveEffect:false",
+        "officialMmoWrites:false"
+      ]
+    },
+    {
+      "name": "candidate_vs_baseline_scorecard",
+      "minimumDurationHours": 0,
+      "requiredEvidence": [
+        "#924 scorecard comparing the penalized candidate against the incumbent baseline",
+        "candidate ranking changes attributable to construction-neglect penalty",
+        "reliability non-regression",
+        "territory/resource non-regression after higher-priority gates",
+        "officialMmoWritesAllowed:false"
+      ]
+    }
+  ],
+  "acceptanceCriteria": [
+    "A #924 candidate-vs-baseline scorecard exists for the penalized reward candidate and the incumbent baseline.",
+    "In qualifying windows with constructionSiteCount > 0, the candidate keeps constructionDeadlockTicks below 100 and does not regress versus baseline.",
+    "The candidate ranking favors policies with taskCounts.build > 0 over policies with taskCounts.build == 0 when constructionSiteCount > 0 and safety, territory, and resource metrics are comparable.",
+    "Build progress, build-carried energy, or built progress improves versus baseline in qualifying construction-backlog windows.",
+    "Worker count, spawn/refill throughput, controller downgrade safety, CPU bucket, and reliability do not regress versus baseline.",
+    "All validation artifacts preserve liveEffect:false, officialMmoWrites:false, and officialMmoWritesAllowed:false."
+  ],
+  "rollbackCriteria": [
+    "Reject or reduce the penalty if spawn/refill throughput regresses versus baseline.",
+    "Reject or reduce the penalty if controller downgrade safety worsens or upgrade progress is starved during safe construction windows.",
+    "Reject or gate the penalty if it punishes correct no-build behavior during genuine energy starvation or no-valid-builder windows.",
+    "Reject the candidate if the #924 scorecard shows any reliability, territory, resource, or CPU regression that is not explicitly accepted by owner review.",
+    "Owner rejects, suspends, or supersedes the decision."
+  ],
+  "safety": {
+    "liveEffect": false,
+    "officialMmoWrites": false,
+    "officialMmoWritesAllowed": false,
+    "memoryWritesAllowed": false,
+    "rawMemoryWritesAllowed": false,
+    "rawCreepIntentControl": false,
+    "spawnIntentControl": false,
+    "constructionIntentControl": false,
+    "marketIntentControl": false
+  },
+  "stewardDecision": {
+    "state": "needs_shadow_scorecard",
+    "decidedBy": null,
+    "decidedAt": null,
+    "notes": "Proposal only. Issue #1024 supplies historical evidence; acceptance requires offline/shadow replay plus a #924 candidate-vs-baseline scorecard."
+  },
+  "ownerDecision": {
+    "state": "not_requested",
+    "decidedBy": null,
+    "decidedAt": null,
+    "notes": "No accepted reward change and no live official MMO authority."
+  },
+  "linkedPRs": [],
+  "linkedTrainingRuns": [],
+  "linkedPolicyEvaluations": [
+    "pending: #924 candidate-vs-baseline scorecard for construction-neglect penalty"
+  ],
+  "createdAt": "2026-05-16T00:00:00Z",
+  "updatedAt": "2026-05-16T00:00:00Z"
+}

--- a/docs/ops/examples/rl-reward-decisions/RD-0004-construction-backlog-build-zero.json
+++ b/docs/ops/examples/rl-reward-decisions/RD-0004-construction-backlog-build-zero.json
@@ -1,5 +1,5 @@
 {
-  "rewardDecisionId": "RD-0004-construction-backlog-build-zero",
+  "rewardDecisionId": "RD-V3-004-constructionNeglectPenalty",
   "title": "Proposal: construction neglect penalty for build-zero backlog",
   "state": "proposed",
   "linkedGitHubIssue": "https://github.com/lanyusea/screeps/issues/1024",
@@ -20,7 +20,7 @@
   "hypothesis": "Adding a construction-neglect penalty when constructionSiteCount > 0 and taskCounts.build == 0 will create offline selection pressure against policies that ignore available construction work, while preserving higher-priority safety gates and emergency spawn/refill behavior.",
   "currentRewardCoverage": "Runtime telemetry exposes constructionSiteCount, taskCounts.build, pendingBuildProgress, buildCarriedEnergy, buildBlockedReason, and constructionDeadlockTicks. No accepted reward component currently penalizes constructionSiteCount > 0 with taskCounts.build == 0, and this record does not authorize live reward or policy writes.",
   "proposedChangeType": "add_component",
-  "component": "construction_neglect_penalty",
+  "component": "construction-neglect-penalty",
   "direction": "lower_is_better for construction deadlock; apply a negative reward proportional to constructionSiteCount only when constructionSiteCount > 0 and taskCounts.build == 0",
   "expectedBehaviorChange": "In offline or shadow reward evaluation, candidate policies should rank below baseline when they leave build assignment at zero while construction sites exist, and should rank above comparable policies when they assign at least one worker to build without regressing safety, territory, or resource scorecard dimensions.",
   "riskAndRegressions": [

--- a/docs/ops/examples/rl-reward-decisions/RD-V3-004-constructionNeglectPenalty.json
+++ b/docs/ops/examples/rl-reward-decisions/RD-V3-004-constructionNeglectPenalty.json
@@ -14,7 +14,7 @@
     "runtime summary: constructionSiteCount",
     "runtime summary: taskCounts.build",
     "runtime summary: constructionDeadlockTicks",
-    "planned #924 candidate-vs-baseline construction scorecard"
+    "planned #924-compatible candidate-vs-baseline construction scorecard"
   ],
   "problemStatement": "Historical runtime evidence shows construction sites remaining visible while no workers are assigned to build. In the cited window, upgrade selection won while constructionSiteCount stayed positive and pendingBuildProgress did not move, creating a training signal that can reinforce construction deadlock.",
   "hypothesis": "Adding a construction-neglect penalty when constructionSiteCount > 0 and taskCounts.build == 0 will create offline selection pressure against policies that ignore available construction work, while preserving higher-priority safety gates and emergency spawn/refill behavior.",
@@ -35,7 +35,7 @@
       "requiredEvidence": [
         "qualifying windows where constructionSiteCount > 0",
         "taskCounts.build distribution in those windows",
-        "constructionDeadlockTicks",
+        "per-room non-overlapping 5-minute qualifying windows where constructionSiteCount > 0, using maximum constructionDeadlockTicks per room/window",
         "pendingBuildProgress or built progress delta",
         "buildCarriedEnergy",
         "spawn/refill health",
@@ -46,10 +46,11 @@
     },
     {
       "name": "candidate_vs_baseline_scorecard",
-      "minimumDurationHours": 0,
+      "minimumDurationHours": 8,
       "requiredEvidence": [
-        "#924 scorecard comparing the penalized candidate against the incumbent baseline",
+        "#924-compatible scorecard artifact comparing the penalized candidate against the incumbent baseline over the same 8-hour historical shadow replay horizon",
         "candidate ranking changes attributable to construction-neglect penalty",
+        "per-room non-overlapping 5-minute qualifying windows where constructionSiteCount > 0, using maximum constructionDeadlockTicks per room/window",
         "reliability non-regression",
         "territory/resource non-regression after higher-priority gates",
         "officialMmoWritesAllowed:false"
@@ -57,8 +58,8 @@
     }
   ],
   "acceptanceCriteria": [
-    "A #924 candidate-vs-baseline scorecard exists for the penalized reward candidate and the incumbent baseline.",
-    "In qualifying windows with constructionSiteCount > 0, the candidate keeps constructionDeadlockTicks below 100 and does not regress versus baseline.",
+    "A future generated #924-compatible candidate-vs-baseline scorecard artifact exists for the penalized reward candidate and the incumbent baseline; #924 is the source scorecard contract and its closure is not acceptance for #1024.",
+    "For every room and every non-overlapping 5-minute qualifying window within the replay/scorecard horizon where constructionSiteCount > 0, use the maximum constructionDeadlockTicks in that room/window; the candidate max must stay below 100 in every room/window and must not regress versus baseline.",
     "The candidate ranking favors policies with taskCounts.build > 0 over policies with taskCounts.build == 0 when constructionSiteCount > 0 and safety, territory, and resource metrics are comparable.",
     "Build progress, build-carried energy, or built progress improves versus baseline in qualifying construction-backlog windows.",
     "Worker count, spawn/refill throughput, controller downgrade safety, CPU bucket, and reliability do not regress versus baseline.",
@@ -68,7 +69,7 @@
     "Reject or reduce the penalty if spawn/refill throughput regresses versus baseline.",
     "Reject or reduce the penalty if controller downgrade safety worsens or upgrade progress is starved during safe construction windows.",
     "Reject or gate the penalty if it punishes correct no-build behavior during genuine energy starvation or no-valid-builder windows.",
-    "Reject the candidate if the #924 scorecard shows any reliability, territory, resource, or CPU regression that is not explicitly accepted by owner review.",
+    "Reject the candidate if the #924-compatible scorecard shows any reliability, territory, resource, or CPU regression that is not explicitly accepted by owner review.",
     "Owner rejects, suspends, or supersedes the decision."
   ],
   "safety": {
@@ -86,7 +87,7 @@
     "state": "needs_shadow_scorecard",
     "decidedBy": null,
     "decidedAt": null,
-    "notes": "Proposal only. Issue #1024 supplies historical evidence; acceptance requires offline/shadow replay plus a #924 candidate-vs-baseline scorecard."
+    "notes": "Proposal only. Issue #1024 supplies historical evidence. Issue #924 is the source scorecard contract; acceptance for #1024 still requires a future generated #924-compatible candidate-vs-baseline scorecard artifact for this candidate."
   },
   "ownerDecision": {
     "state": "not_requested",
@@ -97,7 +98,7 @@
   "linkedPRs": [],
   "linkedTrainingRuns": [],
   "linkedPolicyEvaluations": [
-    "pending: #924 candidate-vs-baseline scorecard for construction-neglect penalty"
+    "pending: future generated #924-compatible candidate-vs-baseline scorecard artifact for construction-neglect penalty"
   ],
   "createdAt": "2026-05-16T00:00:00Z",
   "updatedAt": "2026-05-16T00:00:00Z"

--- a/docs/ops/examples/rl-reward-decisions/README.md
+++ b/docs/ops/examples/rl-reward-decisions/README.md
@@ -15,3 +15,4 @@ Current examples:
 - `RD-0001-defense-construction.json`
 - `RD-0002-worker-load-efficiency.json`
 - `RD-0003-stuck-actionless-creeps.json`
+- `RD-0004-construction-backlog-build-zero.json`

--- a/docs/ops/examples/rl-reward-decisions/README.md
+++ b/docs/ops/examples/rl-reward-decisions/README.md
@@ -15,4 +15,4 @@ Current examples:
 - `RD-0001-defense-construction.json`
 - `RD-0002-worker-load-efficiency.json`
 - `RD-0003-stuck-actionless-creeps.json`
-- `RD-0004-construction-backlog-build-zero.json`
+- `RD-V3-004-constructionNeglectPenalty.json`

--- a/docs/ops/rl-reward-decision-log.md
+++ b/docs/ops/rl-reward-decision-log.md
@@ -70,7 +70,7 @@ The JSON template is `docs/ops/templates/rl-reward-decision.template.json`.
 | `RD-0001-defense-construction` | `proposed` | missing or late defense construction | needs metric evidence; not accepted | #907, #906 |
 | `RD-0002-worker-load-efficiency` | `proposed` | tiny-load returns such as 2/50 energy | needs metric evidence; not accepted | #907, #906 |
 | `RD-0003-stuck-actionless-creeps` | `proposed` | stuck/actionless creeps | needs metric evidence; not accepted | #907, #906 |
-| `RD-0004-construction-backlog-build-zero` | `proposed` | `build=0` with construction backlog | needs metric evidence; not accepted | #907, #906 |
+| `RD-0004-construction-backlog-build-zero` | `proposed` | `build=0` with construction backlog | needs offline/shadow replay plus #924 scorecard; not accepted | #1024, #907, #906, #924 |
 | `RD-0005-expansion-without-spawn` | `proposed` | claim/expansion room with 0 spawns after grace window | needs metric evidence; not accepted | #907, #906 |
 | `RD-0006-metric-and-reliability-gates` | `proposed` | CPU, reliability, or missing metrics | needs metric evidence; not accepted | #907, #906 |
 
@@ -109,11 +109,14 @@ The JSON template is `docs/ops/templates/rl-reward-decision.template.json`.
 ### RD-0004-construction-backlog-build-zero
 
 - State: `proposed`
-- Linked issue: https://github.com/lanyusea/screeps/issues/907
+- Linked issue: https://github.com/lanyusea/screeps/issues/1024
+- Change-control reference: https://github.com/lanyusea/screeps/issues/907
 - Linked metric taxonomy: https://github.com/lanyusea/screeps/issues/906
-- Problem: `build=0` while construction backlog exists can block territory and resource progression.
-- Possible Act choice: add or adjust `construction_progress` reward or a backlog gate for priority site classes.
-- Evidence needed: site backlog by type, build work ticks, worker task counts, energy availability, spawn queue pressure.
+- Linked scorecard gate: https://github.com/lanyusea/screeps/issues/924
+- Problem: `build=0` while construction backlog exists can block territory and resource progression; issue #1024 records `build=0` with `constructionSiteCount=10` across ticks 917318-918948 and frozen `pendingBuildProgress` near 13200.
+- Possible Act choice: add a shadow/offline `construction_neglect_penalty` when `constructionSiteCount > 0` and `taskCounts.build == 0`, with negative reward proportional to construction site count.
+- Evidence needed: historical shadow replay, construction-deadlock tick counts, build assignment distribution, build progress or build-carried energy, spawn/refill health, controller downgrade safety, and a #924 candidate-vs-baseline scorecard.
+- Safety flags: `liveEffect:false`, `officialMmoWrites:false`, and `officialMmoWritesAllowed:false`; this decision does not authorize learned-policy live writes.
 - Acceptance status: not accepted; proposal only.
 
 ### RD-0005-expansion-without-spawn

--- a/docs/ops/rl-reward-decision-log.md
+++ b/docs/ops/rl-reward-decision-log.md
@@ -70,7 +70,7 @@ The JSON template is `docs/ops/templates/rl-reward-decision.template.json`.
 | `RD-0001-defense-construction` | `proposed` | missing or late defense construction | needs metric evidence; not accepted | #907, #906 |
 | `RD-0002-worker-load-efficiency` | `proposed` | tiny-load returns such as 2/50 energy | needs metric evidence; not accepted | #907, #906 |
 | `RD-0003-stuck-actionless-creeps` | `proposed` | stuck/actionless creeps | needs metric evidence; not accepted | #907, #906 |
-| `RD-0004-construction-backlog-build-zero` | `proposed` | `build=0` with construction backlog | needs offline/shadow replay plus #924 scorecard; not accepted | #1024, #907, #906, #924 |
+| `RD-V3-004-constructionNeglectPenalty` | `proposed` | `build=0` with construction backlog | needs offline/shadow replay plus future #924-compatible scorecard artifact; not accepted | #1024, #907, #906, #924 |
 | `RD-0005-expansion-without-spawn` | `proposed` | claim/expansion room with 0 spawns after grace window | needs metric evidence; not accepted | #907, #906 |
 | `RD-0006-metric-and-reliability-gates` | `proposed` | CPU, reliability, or missing metrics | needs metric evidence; not accepted | #907, #906 |
 
@@ -106,7 +106,7 @@ The JSON template is `docs/ops/templates/rl-reward-decision.template.json`.
 - Evidence needed: idle/actionless ticks, repeated position evidence, action result codes, task memory, target validity, CPU bucket.
 - Acceptance status: not accepted; proposal only.
 
-### RD-0004-construction-backlog-build-zero
+### RD-V3-004-constructionNeglectPenalty
 
 - State: `proposed`
 - Linked issue: https://github.com/lanyusea/screeps/issues/1024
@@ -115,7 +115,7 @@ The JSON template is `docs/ops/templates/rl-reward-decision.template.json`.
 - Linked scorecard gate: https://github.com/lanyusea/screeps/issues/924
 - Problem: `build=0` while construction backlog exists can block territory and resource progression; issue #1024 records `build=0` with `constructionSiteCount=10` across ticks 917318-918948 and frozen `pendingBuildProgress` near 13200.
 - Possible Act choice: add a shadow/offline `construction_neglect_penalty` when `constructionSiteCount > 0` and `taskCounts.build == 0`, with negative reward proportional to construction site count.
-- Evidence needed: historical shadow replay, construction-deadlock tick counts, build assignment distribution, build progress or build-carried energy, spawn/refill health, controller downgrade safety, and a #924 candidate-vs-baseline scorecard.
+- Evidence needed: historical shadow replay, construction-deadlock tick counts, build assignment distribution, build progress or build-carried energy, spawn/refill health, controller downgrade safety, and a future generated #924-compatible candidate-vs-baseline scorecard artifact. Issue #924 is the source scorecard contract; its closure is not acceptance for #1024.
 - Safety flags: `liveEffect:false`, `officialMmoWrites:false`, and `officialMmoWritesAllowed:false`; this decision does not authorize learned-policy live writes.
 - Acceptance status: not accepted; proposal only.
 

--- a/docs/ops/rl-reward-decision-log.md
+++ b/docs/ops/rl-reward-decision-log.md
@@ -114,7 +114,7 @@ The JSON template is `docs/ops/templates/rl-reward-decision.template.json`.
 - Linked metric taxonomy: https://github.com/lanyusea/screeps/issues/906
 - Linked scorecard gate: https://github.com/lanyusea/screeps/issues/924
 - Problem: `build=0` while construction backlog exists can block territory and resource progression; issue #1024 records `build=0` with `constructionSiteCount=10` across ticks 917318-918948 and frozen `pendingBuildProgress` near 13200.
-- Possible Act choice: add a shadow/offline `construction_neglect_penalty` when `constructionSiteCount > 0` and `taskCounts.build == 0`, with negative reward proportional to construction site count.
+- Possible Act choice: add a shadow/offline `construction-neglect-penalty` when `constructionSiteCount > 0` and `taskCounts.build == 0`, with negative reward proportional to construction site count.
 - Evidence needed: historical shadow replay, construction-deadlock tick counts, build assignment distribution, build progress or build-carried energy, spawn/refill health, controller downgrade safety, and a future generated #924-compatible candidate-vs-baseline scorecard artifact. Issue #924 is the source scorecard contract; its closure is not acceptance for #1024.
 - Safety flags: `liveEffect:false`, `officialMmoWrites:false`, and `officialMmoWritesAllowed:false`; this decision does not authorize learned-policy live writes.
 - Acceptance status: not accepted; proposal only.

--- a/docs/ops/rl-reward-decision-registry.md
+++ b/docs/ops/rl-reward-decision-registry.md
@@ -8,7 +8,7 @@ Canonical PDCA Act-loop registry for RL reward components, weights, penalties, v
 - **Previous reward-decision issue:** #907, closed after PR #961 merged
 - **Umbrella:** #879 (ALL IN RL)
 - **Machine-readable schema:** `docs/ops/rl-reward-schema.yaml` (v1, #967)
-- **Last updated:** 2026-05-12
+- **Last updated:** 2026-05-16
 
 ## Purpose
 
@@ -75,7 +75,9 @@ The v3 registry references only code paths verified against `prod/src/` on 2026-
 
 ## Pending Decisions
 
-Source for all three pending records: Gameplay Evolution Review output `2026-05-12_17-45-46.md`, section "Game behavior rationality analysis (PDCA #906/#907/#924)" and "Reward decision items for #907".
+Source for the first three pending records: Gameplay Evolution Review output `2026-05-12_17-45-46.md`, section "Game behavior rationality analysis (PDCA #906/#907/#924)" and "Reward decision items for #907".
+
+Source for `RD-V3-004-constructionNeglectPenalty`: issue #1024 and Gameplay Evolution Review 2026-05-14 08:07, following the #907 change-control framework and #924 scorecard gate.
 
 ### RD-V3-001-workerLoadEfficiency
 
@@ -122,6 +124,21 @@ Source for all three pending records: Gameplay Evolution Review output `2026-05-
 | `rollback_conditions` | Disable or reject if valid stationary workers are penalized, false-positive rate exceeds 10%, pathing becomes overly conservative, CPU use increases materially, or work/energy-delivery metrics regress. |
 | `implementation_tracking` | Container issue #963; previous registry PR #961; implementation PR TBD; metric taxonomy link #906; previous reward-decision container #907. |
 
+### RD-V3-004-constructionNeglectPenalty
+
+| Field | Value |
+| --- | --- |
+| `decision_id` | `RD-V3-004-constructionNeglectPenalty` |
+| `component_id` | `construction-neglect-penalty` |
+| `status` | `PROPOSED` |
+| `source` | Issue #1024; Gameplay Evolution Review 2026-05-14 08:07; follow-up to #907 with #924 scorecard gate. |
+| `hypothesis` | Penalizing `taskCounts.build == 0` when `constructionSiteCount > 0` will reduce construction deadlock learned from upgrade-preferred windows without weakening higher-priority survival gates. |
+| `current_metric_coverage` | Partial but sufficient for a shadow decision record. Runtime telemetry exposes `constructionSiteCount`, `taskCounts.build`, `pendingBuildProgress`, `buildCarriedEnergy`, `buildBlockedReason`, and `constructionDeadlockTicks`. Acceptance still requires candidate-vs-baseline scorecard evidence rather than prose intuition. |
+| `required_code_changes` | Add or derive an offline/shadow reward feature only: negative reward proportional to `constructionSiteCount` when `constructionSiteCount > 0` and `taskCounts.build == 0`. Preserve `liveEffect=false`, `officialMmoWrites=false`, and `officialMmoWritesAllowed=false`; do not make learned-policy live writes. |
+| `validation_criteria` | In historical shadow replay and #924 candidate-vs-baseline scorecard windows with `constructionSiteCount > 0`, candidate `constructionDeadlockTicks` stays below 100 and does not regress versus baseline, policy ranking favors `taskCounts.build > 0` over build-zero candidates, build progress or build-carried energy improves, and reliability, spawn/refill health, controller downgrade safety, CPU, territory, and resource metrics do not regress. |
+| `rollback_conditions` | Disable, reduce, or reject if construction is over-prioritized at the expense of spawn/refill throughput, controller downgrade safety, emergency recovery, valid energy-starvation waiting, reliability, CPU, territory, or resource scorecard dimensions. |
+| `implementation_tracking` | Issue #1024; previous reward-decision container #907; metric taxonomy link #906; candidate-vs-baseline scorecard link #924; construction diagnosis link #1023; decision JSON `docs/ops/examples/rl-reward-decisions/RD-0004-construction-backlog-build-zero.json`. |
+
 ## Registered Components
 
 These are registry entries from v2 or this v3 Act container. `PROPOSED` entries are not accepted reward defaults.
@@ -131,6 +148,7 @@ These are registry entries from v2 or this v3 Act container. `PROPOSED` entries 
 | `worker-load-efficiency` | `RD-V3-001-workerLoadEfficiency` | penalty | `-0.1` candidate from v2 | logistics | `PROPOSED` | Pending v3 code and validation. |
 | `build-allocation-minimum` | `RD-V3-002-buildAllocationMinimum` | reward | `+0.05` candidate from v2 | resources | `PROPOSED` | Pending v3 code and validation. |
 | `stuck-penalty` | `RD-V3-003-verifyStuckPenalty` | penalty | `-0.02` per stuck tick candidate from v2 | reliability | `PROPOSED` | Pending v3 verification and possible implementation. |
+| `construction-neglect-penalty` | `RD-V3-004-constructionNeglectPenalty` | penalty | proportional to `constructionSiteCount`, coefficient TBD | resources | `PROPOSED` | Pending offline/shadow replay and #924 scorecard; no live writes. |
 | `territory-expansion-reward` | TBD | reward | TBD | territory | `PROPOSED` | Placeholder from v2 linked to #958; outside the 2026-05-12 pending Act batch. |
 
 ## Integration Points
@@ -148,6 +166,8 @@ These are registry entries from v2 or this v3 Act container. `PROPOSED` entries 
 - #906 - Gameplay metric taxonomy and coverage gaps
 - #907 - Previous reward-decision container, closed after #961
 - #924 - Candidate-vs-baseline scorecard
+- #1023 - Construction deadlock diagnosis with 3 identified gates
+- #1024 - P1 construction-neglect reward decision for `build=0` with construction sites
 - #958 - Expansion initiation gap and territory reward placeholder
 - #959 - RL reward decision registry v2 issue
 - #961 - Merged v2 registry PR

--- a/docs/ops/rl-reward-decision-registry.md
+++ b/docs/ops/rl-reward-decision-registry.md
@@ -77,7 +77,7 @@ The v3 registry references only code paths verified against `prod/src/` on 2026-
 
 Source for the first three pending records: Gameplay Evolution Review output `2026-05-12_17-45-46.md`, section "Game behavior rationality analysis (PDCA #906/#907/#924)" and "Reward decision items for #907".
 
-Source for `RD-V3-004-constructionNeglectPenalty`: issue #1024 and Gameplay Evolution Review 2026-05-14 08:07, following the #907 change-control framework and #924 scorecard gate.
+Source for `RD-V3-004-constructionNeglectPenalty`: issue #1024 and Gameplay Evolution Review 2026-05-14 08:07, following the #907 change-control framework and #924 as the source scorecard contract. A future generated #924-compatible scorecard artifact is still required for #1024 acceptance.
 
 ### RD-V3-001-workerLoadEfficiency
 
@@ -131,13 +131,13 @@ Source for `RD-V3-004-constructionNeglectPenalty`: issue #1024 and Gameplay Evol
 | `decision_id` | `RD-V3-004-constructionNeglectPenalty` |
 | `component_id` | `construction-neglect-penalty` |
 | `status` | `PROPOSED` |
-| `source` | Issue #1024; Gameplay Evolution Review 2026-05-14 08:07; follow-up to #907 with #924 scorecard gate. |
+| `source` | Issue #1024; Gameplay Evolution Review 2026-05-14 08:07; follow-up to #907 with #924 as the source scorecard contract. |
 | `hypothesis` | Penalizing `taskCounts.build == 0` when `constructionSiteCount > 0` will reduce construction deadlock learned from upgrade-preferred windows without weakening higher-priority survival gates. |
 | `current_metric_coverage` | Partial but sufficient for a shadow decision record. Runtime telemetry exposes `constructionSiteCount`, `taskCounts.build`, `pendingBuildProgress`, `buildCarriedEnergy`, `buildBlockedReason`, and `constructionDeadlockTicks`. Acceptance still requires candidate-vs-baseline scorecard evidence rather than prose intuition. |
 | `required_code_changes` | Add or derive an offline/shadow reward feature only: negative reward proportional to `constructionSiteCount` when `constructionSiteCount > 0` and `taskCounts.build == 0`. Preserve `liveEffect=false`, `officialMmoWrites=false`, and `officialMmoWritesAllowed=false`; do not make learned-policy live writes. |
-| `validation_criteria` | In historical shadow replay and #924 candidate-vs-baseline scorecard windows with `constructionSiteCount > 0`, candidate `constructionDeadlockTicks` stays below 100 and does not regress versus baseline, policy ranking favors `taskCounts.build > 0` over build-zero candidates, build progress or build-carried energy improves, and reliability, spawn/refill health, controller downgrade safety, CPU, territory, and resource metrics do not regress. |
+| `validation_criteria` | Historical shadow replay and a future generated #924-compatible candidate-vs-baseline scorecard artifact must cover the same 8-hour horizon. In every room and every non-overlapping 5-minute qualifying window where `constructionSiteCount > 0`, use max `constructionDeadlockTicks` per room/window; the candidate max must stay below 100 in every room/window and must not regress versus baseline. Policy ranking must favor `taskCounts.build > 0` over build-zero candidates, build progress or build-carried energy must improve, and reliability, spawn/refill health, controller downgrade safety, CPU, territory, and resource metrics must not regress. |
 | `rollback_conditions` | Disable, reduce, or reject if construction is over-prioritized at the expense of spawn/refill throughput, controller downgrade safety, emergency recovery, valid energy-starvation waiting, reliability, CPU, territory, or resource scorecard dimensions. |
-| `implementation_tracking` | Issue #1024; previous reward-decision container #907; metric taxonomy link #906; candidate-vs-baseline scorecard link #924; construction diagnosis link #1023; decision JSON `docs/ops/examples/rl-reward-decisions/RD-0004-construction-backlog-build-zero.json`. |
+| `implementation_tracking` | Issue #1024; previous reward-decision container #907; metric taxonomy link #906; candidate-vs-baseline scorecard contract #924; construction diagnosis link #1023; decision JSON `docs/ops/examples/rl-reward-decisions/RD-V3-004-constructionNeglectPenalty.json`. #924 closure is not acceptance for #1024; acceptance requires a future generated #924-compatible scorecard artifact for this candidate. |
 
 ## Registered Components
 
@@ -148,7 +148,7 @@ These are registry entries from v2 or this v3 Act container. `PROPOSED` entries 
 | `worker-load-efficiency` | `RD-V3-001-workerLoadEfficiency` | penalty | `-0.1` candidate from v2 | logistics | `PROPOSED` | Pending v3 code and validation. |
 | `build-allocation-minimum` | `RD-V3-002-buildAllocationMinimum` | reward | `+0.05` candidate from v2 | resources | `PROPOSED` | Pending v3 code and validation. |
 | `stuck-penalty` | `RD-V3-003-verifyStuckPenalty` | penalty | `-0.02` per stuck tick candidate from v2 | reliability | `PROPOSED` | Pending v3 verification and possible implementation. |
-| `construction-neglect-penalty` | `RD-V3-004-constructionNeglectPenalty` | penalty | proportional to `constructionSiteCount`, coefficient TBD | resources | `PROPOSED` | Pending offline/shadow replay and #924 scorecard; no live writes. |
+| `construction-neglect-penalty` | `RD-V3-004-constructionNeglectPenalty` | penalty | proportional to `constructionSiteCount`, coefficient TBD | resources | `PROPOSED` | Pending offline/shadow replay and future #924-compatible scorecard artifact; no live writes. |
 | `territory-expansion-reward` | TBD | reward | TBD | territory | `PROPOSED` | Placeholder from v2 linked to #958; outside the 2026-05-12 pending Act batch. |
 
 ## Integration Points

--- a/docs/ops/rl-reward-registry.yaml
+++ b/docs/ops/rl-reward-registry.yaml
@@ -7,7 +7,7 @@ schema:
   replaces:
     - "https://github.com/lanyusea/screeps/issues/907"
   created_date: "2026-05-13"
-  updated_date: "2026-05-13"
+  updated_date: "2026-05-16"
   status: "active"
   canonical_path: "docs/ops/rl-reward-registry.yaml"
 
@@ -175,6 +175,61 @@ entries:
     scope: "offline/shadow only until approved"
     current_code_reference: "prod/src/telemetry/behaviorTelemetry.ts records stuckTicks; no reward component found"
     notes: "This replaces the prior verify-stuck-penalty proposal with an explicit new proposed penalty."
+
+  - id: "RRD-2026-05-14-1024"
+    component_name: "constructionNeglectPenalty"
+    version: "v1"
+    change_type: "add"
+    component_kind: "penalty"
+    priority: "P1"
+    status: "proposed"
+    candidate_weight: null
+    candidate_formula: "negative reward proportional to constructionSiteCount when constructionSiteCount > 0 and taskCounts.build == 0"
+    candidate_predicate:
+      constructionSiteCount_gt: 0
+      taskCounts_build_eq: 0
+    evidence:
+      - "Issue #1024: build=0 while constructionSiteCount=10 across ticks 917318-918948."
+      - "Issue #1024: workers were dispatched to upgrade with buildBlockedReason=build_blocked_controller_progress_preferred while 10 construction sites existed."
+      - "Issue #1024: pendingBuildProgress was frozen near 13200 for an extended window."
+    hypothesis: >
+      Penalizing build=0 while construction sites exist will create offline
+      selection pressure against upgrade-preferred construction deadlock and
+      favor policies that assign at least one worker to build during buildable
+      windows, without bypassing higher-priority survival and resource gates.
+    validation_criteria:
+      - "Run historical shadow reward replay on windows where constructionSiteCount > 0."
+      - "#924 candidate-vs-baseline scorecard shows the penalized candidate ranks construction-assigning policies above build-zero policies under comparable safety, territory, and resource evidence."
+      - "constructionDeadlockTicks stays below 100 and does not regress versus baseline in qualifying windows."
+      - "Build progress, built progress, or buildCarriedEnergy improves versus baseline."
+      - "Worker count, spawn/refill throughput, controller downgrade safety, CPU bucket, reliability, territory, and resource metrics do not regress versus baseline."
+      - "Validation artifacts preserve liveEffect=false, officialMmoWrites=false, and officialMmoWritesAllowed=false."
+    rollback_condition:
+      - "Reject or reduce the penalty if workers over-prioritize construction at the expense of spawn/refill throughput."
+      - "Reject or reduce the penalty if controller downgrade safety or necessary upgrade progress regresses."
+      - "Reject or gate the penalty if it punishes valid no-build behavior during energy starvation or no-valid-builder windows."
+      - "Reject the candidate if the #924 scorecard reports reliability, territory, resource, or CPU regression not explicitly accepted by owner review."
+    linked_github_issue: "https://github.com/lanyusea/screeps/issues/1024"
+    related_github_issues:
+      - "https://github.com/lanyusea/screeps/issues/907"
+      - "https://github.com/lanyusea/screeps/issues/924"
+      - "https://github.com/lanyusea/screeps/issues/1023"
+      - "https://github.com/lanyusea/screeps/issues/906"
+    proposed_by: "Issue #1024; Gameplay Evolution Review 2026-05-14 08:07; RL Steward intake"
+    created_date: "2026-05-16"
+    scope: "offline/shadow reward decision only; no learned-policy live official MMO control"
+    safety:
+      liveEffect: false
+      officialMmoWrites: false
+      officialMmoWritesAllowed: false
+      memoryWritesAllowed: false
+      rawMemoryWritesAllowed: false
+      rawCreepIntentControl: false
+      spawnIntentControl: false
+      constructionIntentControl: false
+      marketIntentControl: false
+    decision_record: "docs/ops/examples/rl-reward-decisions/RD-0004-construction-backlog-build-zero.json"
+    notes: "This proposed registry entry does not authorize live reward defaults or official MMO writes."
 
   - id: "RRD-2026-05-13-003"
     component_name: "lowLoadHarvestPenalty"

--- a/docs/ops/rl-reward-registry.yaml
+++ b/docs/ops/rl-reward-registry.yaml
@@ -199,8 +199,8 @@ entries:
       windows, without bypassing higher-priority survival and resource gates.
     validation_criteria:
       - "Run historical shadow reward replay on windows where constructionSiteCount > 0."
-      - "#924 candidate-vs-baseline scorecard shows the penalized candidate ranks construction-assigning policies above build-zero policies under comparable safety, territory, and resource evidence."
-      - "constructionDeadlockTicks stays below 100 and does not regress versus baseline in qualifying windows."
+      - "A future generated #924-compatible candidate-vs-baseline scorecard artifact over the same 8-hour historical shadow replay horizon shows the penalized candidate ranks construction-assigning policies above build-zero policies under comparable safety, territory, and resource evidence; #924 is the source scorecard contract and its closure is not acceptance for #1024."
+      - "For every room and every non-overlapping 5-minute qualifying window where constructionSiteCount > 0, use maximum constructionDeadlockTicks per room/window; the candidate max stays below 100 in every room/window and does not regress versus baseline."
       - "Build progress, built progress, or buildCarriedEnergy improves versus baseline."
       - "Worker count, spawn/refill throughput, controller downgrade safety, CPU bucket, reliability, territory, and resource metrics do not regress versus baseline."
       - "Validation artifacts preserve liveEffect=false, officialMmoWrites=false, and officialMmoWritesAllowed=false."
@@ -208,7 +208,7 @@ entries:
       - "Reject or reduce the penalty if workers over-prioritize construction at the expense of spawn/refill throughput."
       - "Reject or reduce the penalty if controller downgrade safety or necessary upgrade progress regresses."
       - "Reject or gate the penalty if it punishes valid no-build behavior during energy starvation or no-valid-builder windows."
-      - "Reject the candidate if the #924 scorecard reports reliability, territory, resource, or CPU regression not explicitly accepted by owner review."
+      - "Reject the candidate if the #924-compatible scorecard reports reliability, territory, resource, or CPU regression not explicitly accepted by owner review."
     linked_github_issue: "https://github.com/lanyusea/screeps/issues/1024"
     related_github_issues:
       - "https://github.com/lanyusea/screeps/issues/907"
@@ -228,7 +228,7 @@ entries:
       spawnIntentControl: false
       constructionIntentControl: false
       marketIntentControl: false
-    decision_record: "docs/ops/examples/rl-reward-decisions/RD-0004-construction-backlog-build-zero.json"
+    decision_record: "docs/ops/examples/rl-reward-decisions/RD-V3-004-constructionNeglectPenalty.json"
     notes: "This proposed registry entry does not authorize live reward defaults or official MMO writes."
 
   - id: "RRD-2026-05-13-003"

--- a/docs/ops/rl-reward-schema.yaml
+++ b/docs/ops/rl-reward-schema.yaml
@@ -93,7 +93,11 @@ components:
     validation:
       metric: constructionDeadlockTicks
       threshold_lt: 100
-      scorecard: "#924 candidate-vs-baseline"
+      scorecard: "#924-compatible candidate-vs-baseline"
+      minimum_duration_hours: 8
+      window: "per-room non-overlapping 5-minute qualifying windows where constructionSiteCount > 0"
+      aggregation: "maximum constructionDeadlockTicks per room/window"
+      requirement: "candidate max below 100 in every room/window and no regression versus baseline"
     rollback:
       spawn_refill_regression: true
       controller_downgrade_regression: true

--- a/docs/ops/rl-reward-schema.yaml
+++ b/docs/ops/rl-reward-schema.yaml
@@ -5,8 +5,8 @@
 # Human-readable registry: docs/ops/rl-reward-decision-registry.md
 
 schema: 1
-source_issues: [967, 879]
-last_updated: "2026-05-12"
+source_issues: [967, 879, 1024]
+last_updated: "2026-05-16"
 
 # Reward components are additive: total_reward = sum(component_reward * weight)
 components:
@@ -75,6 +75,29 @@ components:
       captures_pct: 80
     rollback:
       false_positive_pct_gt: 10
+
+  # RD-V3-004 / #1024: Penalize build=0 when construction sites exist
+  - component_id: construction-neglect-penalty
+    decision_id: RD-V3-004-constructionNeglectPenalty
+    type: penalty
+    category: resources
+    status: PROPOSED
+    candidate_weight: null
+    hypothesis: >
+      Penalizing taskCounts.build == 0 when constructionSiteCount > 0 will
+      reduce construction deadlock learned from upgrade-preferred windows while
+      preserving higher-priority safety, territory, and resource gates.
+    predicate:
+      constructionSiteCount_gt: 0
+      taskCounts_build_eq: 0
+    validation:
+      metric: constructionDeadlockTicks
+      threshold_lt: 100
+      scorecard: "#924 candidate-vs-baseline"
+    rollback:
+      spawn_refill_regression: true
+      controller_downgrade_regression: true
+      valid_energy_starvation_false_positive: true
 
   # Territory expansion placeholder from v2 registry
   - component_id: territory-expansion-reward


### PR DESCRIPTION
## Summary
- Registers reward decision `RD-0004-construction-backlog-build-zero` / `RD-V3-004-constructionNeglectPenalty` for issue #1024.
- Defines the construction-neglect penalty proposal for `constructionSiteCount > 0 && taskCounts.build == 0`, proportional to construction site count.
- Adds validation/rollback gates requiring historical shadow replay, #924 candidate-vs-baseline scorecard evidence, `constructionDeadlockTicks < 100`, and non-regression for spawn/refill, controller safety, CPU, reliability, territory, and resources.
- Preserves safety flags: `liveEffect:false`, `officialMmoWrites:false`, `officialMmoWritesAllowed:false`; this PR is governance/decision-record only and does not authorize live MMO learned-policy writes.

## Verification
- `git diff --check`
- `python3 scripts/validate_rl_reward_decisions.py docs/ops/templates/rl-reward-decision.template.json docs/ops/examples/rl-reward-decisions`
- `python3 -m unittest scripts/test_validate_rl_reward_decisions.py`
- YAML/JSON parse smoke for `docs/ops/rl-reward-registry.yaml`, `docs/ops/rl-reward-schema.yaml`, and `docs/ops/examples/rl-reward-decisions/RD-0004-construction-backlog-build-zero.json`

Fixes #1024
Refs #907
Refs #924
Refs #879
Refs #906
Refs #1023
