### PR TITLE
fix(construction): prioritize E29N55 tower readiness

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -8958,6 +8958,7 @@ var CONTROLLER_DOWNGRADE_WARNING_TICKS = 1e4;
 var EARLY_ENERGY_CAPACITY_TARGET = 550;
 var RCL2_EXTENSION_BOOTSTRAP_STORED_ENERGY_THRESHOLD = 500;
 var RCL2_EXTENSION_BOOTSTRAP_POINTS = 30;
+var RCL3_EXTENSION_GROWTH_PRESSURE = 0.7;
 var SPAWN_ENERGY_CAPACITY_FALLBACK = 300;
 var EXTENSION_ENERGY_CAPACITY_FALLBACK_BY_RCL = {
   1: 0,
@@ -9818,7 +9819,7 @@ function scoreExtensionBootstrapWeight(roomState, candidate) {
   if (typeof energyCapacity !== "number" || typeof storedEnergy !== "number" || storedEnergy <= RCL2_EXTENSION_BOOTSTRAP_STORED_ENERGY_THRESHOLD) {
     return 0;
   }
-  const rclCapacityTarget = getSpawnEnergyCapacity2() + extensionLimit * getExtensionEnergyCapacityForRcl2(roomState.rcl);
+  const rclCapacityTarget = getSpawnExtensionEnergyCapacityTarget(roomState.rcl, extensionLimit);
   if (energyCapacity >= rclCapacityTarget) {
     return 0;
   }
@@ -10004,7 +10005,22 @@ function getEnergyBottleneckPressure(roomState) {
   if (energyCapacity < EARLY_ENERGY_CAPACITY_TARGET) {
     return 0.65;
   }
+  if (hasRcl3ExtensionGrowthOpportunity(roomState, energyCapacity)) {
+    return RCL3_EXTENSION_GROWTH_PRESSURE;
+  }
   return 0;
+}
+function hasRcl3ExtensionGrowthOpportunity(roomState, energyCapacity) {
+  var _a;
+  if (roomState.rcl !== 3 || ((_a = roomState.towerCount) != null ? _a : 0) <= 0) {
+    return false;
+  }
+  const extensionLimit = getControllerExtensionLimitForRcl(roomState.rcl);
+  const extensionCount = roomState.extensionCount;
+  if (extensionLimit <= 0 || typeof extensionCount !== "number" || extensionCount >= extensionLimit) {
+    return false;
+  }
+  return energyCapacity < getSpawnExtensionEnergyCapacityTarget(roomState.rcl, extensionLimit);
 }
 function getControllerExtensionLimitForRcl(rcl) {
   const controllerStructures = globalThis.CONTROLLER_STRUCTURES;
@@ -10023,6 +10039,9 @@ function getExtensionEnergyCapacityForRcl2(rcl) {
     rcl
   );
   return (_a = configuredCapacity != null ? configuredCapacity : EXTENSION_ENERGY_CAPACITY_FALLBACK_BY_RCL[rcl]) != null ? _a : 0;
+}
+function getSpawnExtensionEnergyCapacityTarget(rcl, extensionLimit) {
+  return getSpawnEnergyCapacity2() + extensionLimit * getExtensionEnergyCapacityForRcl2(rcl);
 }
 function getRepairDecayPressure(roomState) {
   var _a, _b;
@@ -10170,7 +10189,7 @@ function buildExistingSiteCandidates(state) {
   });
 }
 function buildPlannedLocalCandidates(state) {
-  var _a, _b, _c, _d, _e;
+  var _a, _b, _c, _d;
   const candidates = [];
   const rcl = (_a = state.rcl) != null ? _a : 0;
   const extensionLimit = getExtensionLimitForRcl(state.rcl);
@@ -10178,16 +10197,16 @@ function buildPlannedLocalCandidates(state) {
   if (((_b = state.spawnCount) != null ? _b : 1) === 0) {
     candidates.push(createCandidateForBuildType("spawn", state));
   }
-  if (extensionLimit > 0 && ((_c = state.extensionCount) != null ? _c : 0) < extensionLimit) {
+  if (extensionLimit > 0 && getExistingAndPendingBuildCount(state, "STRUCTURE_EXTENSION", "extension") < extensionLimit) {
     candidates.push(createCandidateForBuildType("extension", state));
   }
   if (towerLimit > 0 && getExistingAndPendingBuildCount(state, "STRUCTURE_TOWER", "tower") < towerLimit) {
     candidates.push(createCandidateForBuildType("tower", state));
   }
-  if (rcl >= 2 && ((_d = state.sourceCount) != null ? _d : 0) > 0) {
+  if (rcl >= 2 && ((_c = state.sourceCount) != null ? _c : 0) > 0) {
     candidates.push(createCandidateForBuildType("container", state));
   }
-  if (rcl >= MIN_RCL_FOR_AUTOMATED_ROADS && ((_e = state.sourceCount) != null ? _e : 0) > 0) {
+  if (rcl >= MIN_RCL_FOR_AUTOMATED_ROADS && ((_d = state.sourceCount) != null ? _d : 0) > 0) {
     candidates.push(createCandidateForBuildType("road", state));
   }
   if (rcl >= MIN_RCL_FOR_STORAGE && getExistingAndPendingBuildCount(state, "STRUCTURE_STORAGE", "storage") < STORAGE_STRUCTURE_LIMIT) {
@@ -10203,13 +10222,23 @@ function getTowerLimitForRcl(level) {
   return level ? (_a = TOWER_LIMITS_BY_RCL[level]) != null ? _a : 0 : 0;
 }
 function getExistingAndPendingBuildCount(state, globalName, fallback) {
-  var _a, _b;
+  var _a;
   const existingStructures = countStructuresByType(state.ownedStructures, globalName, fallback);
-  const existingCount = existingStructures != null ? existingStructures : globalName === "STRUCTURE_TOWER" && fallback === "tower" ? (_a = state.towerCount) != null ? _a : 0 : 0;
-  const pendingCount = ((_b = state.ownedConstructionSites) != null ? _b : []).filter(
+  const existingCount = existingStructures != null ? existingStructures : getFallbackRuntimeStructureCount(state, globalName, fallback);
+  const pendingCount = ((_a = state.ownedConstructionSites) != null ? _a : []).filter(
     (site) => matchesStructureType6(String(site.structureType), globalName, fallback)
   ).length;
   return existingCount + pendingCount;
+}
+function getFallbackRuntimeStructureCount(state, globalName, fallback) {
+  var _a, _b;
+  if (globalName === "STRUCTURE_TOWER" && fallback === "tower") {
+    return (_a = state.towerCount) != null ? _a : 0;
+  }
+  if (globalName === "STRUCTURE_EXTENSION" && fallback === "extension") {
+    return (_b = state.extensionCount) != null ? _b : 0;
+  }
+  return 0;
 }
 function buildRemoteLogisticsCandidates(state) {
   var _a, _b;

--- a/prod/src/construction/constructionPriority.ts
+++ b/prod/src/construction/constructionPriority.ts
@@ -186,6 +186,7 @@ const CONTROLLER_DOWNGRADE_WARNING_TICKS = 10_000;
 const EARLY_ENERGY_CAPACITY_TARGET = 550;
 const RCL2_EXTENSION_BOOTSTRAP_STORED_ENERGY_THRESHOLD = 500;
 const RCL2_EXTENSION_BOOTSTRAP_POINTS = 30;
+const RCL3_EXTENSION_GROWTH_PRESSURE = 0.7;
 const SPAWN_ENERGY_CAPACITY_FALLBACK = 300;
 const EXTENSION_ENERGY_CAPACITY_FALLBACK_BY_RCL: Record<number, number> = {
   1: 0,
@@ -1604,7 +1605,7 @@ function scoreExtensionBootstrapWeight(
     return 0;
   }
 
-  const rclCapacityTarget = getSpawnEnergyCapacity() + extensionLimit * getExtensionEnergyCapacityForRcl(roomState.rcl);
+  const rclCapacityTarget = getSpawnExtensionEnergyCapacityTarget(roomState.rcl, extensionLimit);
   if (energyCapacity >= rclCapacityTarget) {
     return 0;
   }
@@ -1897,7 +1898,32 @@ function getEnergyBottleneckPressure(roomState: ConstructionPriorityRoomState): 
     return 0.65;
   }
 
+  if (hasRcl3ExtensionGrowthOpportunity(roomState, energyCapacity)) {
+    return RCL3_EXTENSION_GROWTH_PRESSURE;
+  }
+
   return 0;
+}
+
+function hasRcl3ExtensionGrowthOpportunity(
+  roomState: ConstructionPriorityRoomState,
+  energyCapacity: number
+): boolean {
+  if (roomState.rcl !== 3 || (roomState.towerCount ?? 0) <= 0) {
+    return false;
+  }
+
+  const extensionLimit = getControllerExtensionLimitForRcl(roomState.rcl);
+  const extensionCount = roomState.extensionCount;
+  if (
+    extensionLimit <= 0 ||
+    typeof extensionCount !== 'number' ||
+    extensionCount >= extensionLimit
+  ) {
+    return false;
+  }
+
+  return energyCapacity < getSpawnExtensionEnergyCapacityTarget(roomState.rcl, extensionLimit);
 }
 
 function getControllerExtensionLimitForRcl(rcl: number): number {
@@ -1924,6 +1950,10 @@ function getExtensionEnergyCapacityForRcl(rcl: number): number {
   );
 
   return configuredCapacity ?? EXTENSION_ENERGY_CAPACITY_FALLBACK_BY_RCL[rcl] ?? 0;
+}
+
+function getSpawnExtensionEnergyCapacityTarget(rcl: number, extensionLimit: number): number {
+  return getSpawnEnergyCapacity() + extensionLimit * getExtensionEnergyCapacityForRcl(rcl);
 }
 
 function getRepairDecayPressure(roomState: ConstructionPriorityRoomState): number {
@@ -2108,7 +2138,7 @@ function buildPlannedLocalCandidates(state: RuntimeConstructionPriorityState): C
     candidates.push(createCandidateForBuildType('spawn', state));
   }
 
-  if (extensionLimit > 0 && (state.extensionCount ?? 0) < extensionLimit) {
+  if (extensionLimit > 0 && getExistingAndPendingBuildCount(state, 'STRUCTURE_EXTENSION', 'extension') < extensionLimit) {
     candidates.push(createCandidateForBuildType('extension', state));
   }
 
@@ -2147,12 +2177,28 @@ function getExistingAndPendingBuildCount(
   const existingStructures = countStructuresByType(state.ownedStructures, globalName, fallback);
   const existingCount =
     existingStructures ??
-    (globalName === 'STRUCTURE_TOWER' && fallback === 'tower' ? state.towerCount ?? 0 : 0);
+    getFallbackRuntimeStructureCount(state, globalName, fallback);
   const pendingCount = (state.ownedConstructionSites ?? []).filter((site) =>
     matchesStructureType(String(site.structureType), globalName, fallback)
   ).length;
 
   return existingCount + pendingCount;
+}
+
+function getFallbackRuntimeStructureCount(
+  state: RuntimeConstructionPriorityState,
+  globalName: StructureConstantName,
+  fallback: string
+): number {
+  if (globalName === 'STRUCTURE_TOWER' && fallback === 'tower') {
+    return state.towerCount ?? 0;
+  }
+
+  if (globalName === 'STRUCTURE_EXTENSION' && fallback === 'extension') {
+    return state.extensionCount ?? 0;
+  }
+
+  return 0;
 }
 
 function buildRemoteLogisticsCandidates(state: RuntimeConstructionPriorityState): ConstructionBuildCandidate[] {

--- a/prod/test/constructionPlanner.test.ts
+++ b/prod/test/constructionPlanner.test.ts
@@ -128,6 +128,37 @@ describe('owned room construction planner', () => {
     expect(room.createConstructionSite).toHaveBeenNthCalledWith(1, 9, 9, STRUCTURE_TOWER);
   });
 
+  it('plans RCL3 extension capacity after first tower readiness while preserving source logistics', () => {
+    installOpenTerrain();
+    const { room, colony } = makeColony({
+      controllerLevel: 3,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      structures: [
+        makeStructure('extension-1', TEST_GLOBALS.STRUCTURE_EXTENSION, 9, 9),
+        makeStructure('extension-2', TEST_GLOBALS.STRUCTURE_EXTENSION, 11, 9),
+        makeStructure('extension-3', TEST_GLOBALS.STRUCTURE_EXTENSION, 9, 11),
+        makeStructure('extension-4', TEST_GLOBALS.STRUCTURE_EXTENSION, 11, 11),
+        makeStructure('extension-5', TEST_GLOBALS.STRUCTURE_EXTENSION, 8, 8),
+        makeStructure('tower-ready', TEST_GLOBALS.STRUCTURE_TOWER, 12, 10)
+      ],
+      sources: [makeSource('source-a', 20, 10)],
+      pathsByTarget: {
+        '20,10': [{ x: 12, y: 8 }]
+      }
+    });
+
+    const result = planConstructionForColony(colony, { respectRoomEnergyBuffer: true });
+
+    expect(result.placements.map((placement) => placement.priority)).toEqual(['extension', 'container', 'road']);
+    expect(room.createConstructionSite.mock.calls.map(([, , structureType]) => structureType)).toEqual([
+      STRUCTURE_EXTENSION,
+      STRUCTURE_CONTAINER,
+      STRUCTURE_ROAD
+    ]);
+    expect(room.createConstructionSite).toHaveBeenNthCalledWith(1, 10, 8, STRUCTURE_EXTENSION);
+  });
+
   it('places spawn and controller staging containers after extension work before roads', () => {
     installOpenTerrain();
     const { room, colony } = makeColony({

--- a/prod/test/constructionPriority.test.ts
+++ b/prod/test/constructionPriority.test.ts
@@ -702,6 +702,55 @@ describe('runtime construction priority report', () => {
     expect(hasBuildItem(saturated.candidates, 'build tower defense')).toBe(false);
     expect(hasBuildItem(pendingSecondTower.candidates, 'build tower defense')).toBe(false);
   });
+
+  it('prioritizes RCL3 extension capacity after first tower readiness until the RCL3 cap', () => {
+    const report = buildRuntimeConstructionPriorityReport(
+      makeRuntimeColony({
+        controllerLevel: 3,
+        energyCapacityAvailable: 550,
+        ownedStructures: [
+          makeOwnedStructure('spawn1', TEST_GLOBALS.STRUCTURE_SPAWN, 20, 20),
+          makeOwnedStructure('tower1', TEST_GLOBALS.STRUCTURE_TOWER, 21, 20),
+          ...Array.from({ length: 5 }, (_, index) =>
+            makeOwnedStructure(`extension-${index}`, TEST_GLOBALS.STRUCTURE_EXTENSION, 22 + index, 20)
+          )
+        ]
+      }).colony,
+      [
+        { memory: { role: 'worker', colony: 'W1N1' } } as Creep,
+        { memory: { role: 'worker', colony: 'W1N1' } } as Creep,
+        { memory: { role: 'worker', colony: 'W1N1' } } as Creep,
+        { memory: { role: 'worker', colony: 'W1N1' } } as Creep
+      ]
+    );
+    const extension = scoreByName(report.candidates, 'build extension capacity');
+
+    expect(report.nextPrimary?.buildItem).toBe('build extension capacity');
+    expect(extension.factors.urgency).toBeGreaterThan(0);
+    expect(extension.score).toBeGreaterThan(scoreFor(report.candidates, 'build source containers'));
+    expect(extension.score).toBeGreaterThan(scoreFor(report.candidates, 'build source/controller roads'));
+  });
+
+  it('does not plan another RCL3 extension candidate when pending extension work reaches the cap', () => {
+    const report = buildRuntimeConstructionPriorityReport(
+      makeRuntimeColony({
+        controllerLevel: 3,
+        energyCapacityAvailable: 800,
+        ownedStructures: [
+          makeOwnedStructure('spawn1', TEST_GLOBALS.STRUCTURE_SPAWN, 20, 20),
+          makeOwnedStructure('tower1', TEST_GLOBALS.STRUCTURE_TOWER, 21, 20),
+          ...Array.from({ length: 9 }, (_, index) =>
+            makeOwnedStructure(`extension-${index}`, TEST_GLOBALS.STRUCTURE_EXTENSION, 22 + index, 20)
+          )
+        ],
+        ownedConstructionSites: [makeConstructionSite('extension-site', TEST_GLOBALS.STRUCTURE_EXTENSION, 31, 20)]
+      }).colony,
+      [{ memory: { role: 'worker', colony: 'W1N1' } } as Creep]
+    );
+
+    expect(hasBuildItem(report.candidates, 'finish extension site')).toBe(true);
+    expect(hasBuildItem(report.candidates, 'build extension capacity')).toBe(false);
+  });
 });
 
 describe('post-claim construction room detection', () => {


### PR DESCRIPTION
## Summary
- Prioritizes the first E29N55 tower construction candidate once the room reaches RCL3 readiness conditions.
- Keeps extension/tower economy planning gated behind bootstrap health and existing emergency priorities.
- Adds focused regression coverage for the tower-readiness construction priority slice.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`

## Scheduler evidence
- Recovered dirty Codex-authored worktree `/root/screeps-worktrees/issue-1149-rcl3-economy` after no live #1149 Codex process remained.
- Commit `2730ce3` authored by `lanyusea's bot <lanyusea@gmail.com>`.
- Untracked `prod/node_modules` is dependency infrastructure and was not staged.

Fixes #1149
