### PR TITLE
fix(rl): generate training-runner compliant experiment cards

### DIFF
--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -29,6 +29,10 @@ DEFAULT_STRATEGY_VARIANTS = (
     "expansion-remote.incumbent.v1",
     "expansion-remote.territory-shadow.v1",
 )
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_SIMULATION_CODE_PATH = REPO_ROOT / "prod" / "dist" / "main.js"
+DEFAULT_SIMULATION_MAP_SOURCE_FILE = REPO_ROOT / "maps" / "map-0b6758af.json"
+DEFAULT_SIMULATION_OUT_DIR = REPO_ROOT / "runtime-artifacts" / "rl-simulator"
 
 JsonObject = dict[str, Any]
 
@@ -104,12 +108,12 @@ def safety_block() -> JsonObject:
 def simulation_block() -> JsonObject:
     return {
         "branch": "$activeWorld",
-        "code_path": "prod/dist/main.js",
-        "map_source_file": "maps/map-0b6758af.json",
+        "code_path": str(DEFAULT_SIMULATION_CODE_PATH),
+        "map_source_file": str(DEFAULT_SIMULATION_MAP_SOURCE_FILE),
         "repetitions": 1,
         "room": "E1S1",
         "shard": "shardX",
-        "simulator_out_dir": "runtime-artifacts/rl-simulator",
+        "simulator_out_dir": str(DEFAULT_SIMULATION_OUT_DIR),
         "ticks": 50,
         "workers": 1,
     }

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import re
 import subprocess
 import sys
@@ -196,8 +197,8 @@ def validate_card(raw: Any) -> None:
 
     validate_safety(raw)
     validate_reward_model(raw.get("reward_model"))
-    validate_strategy_variants(raw.get("strategy_variants"))
-    validate_simulation(raw.get("simulation"))
+    validate_strategy_variants(first_present(raw, ("strategy_variants", "strategyVariants", "variants")))
+    validate_simulation(first_present(raw, ("simulation", "simulator")))
 
 
 def require_string(raw: JsonObject, field: str) -> str:
@@ -268,16 +269,31 @@ def validate_strategy_id(value: str, label: str) -> None:
         raise CardValidationError(f"{label} may contain only letters, numbers, dot, colon, underscore, and hyphen")
 
 
+def first_present(raw: JsonObject, keys: tuple[str, ...]) -> Any:
+    for key in keys:
+        if key in raw:
+            return raw[key]
+    return None
+
+
 def validate_simulation(raw: Any) -> None:
     if not isinstance(raw, dict):
         raise CardValidationError("simulation must be a JSON object")
     for field in ("ticks", "workers", "repetitions"):
         if positive_int(raw.get(field)) is None:
             raise CardValidationError(f"simulation.{field} must be a positive integer")
-    if "host_port_start" in raw and positive_int(raw.get("host_port_start")) is None:
+    host_port_start = first_present(raw, ("host_port_start", "hostPortStart"))
+    if host_port_start is not None and positive_int(host_port_start) is None:
         raise CardValidationError("simulation.host_port_start must be a positive integer")
-    for field in ("room", "shard", "branch", "code_path", "map_source_file", "simulator_out_dir"):
-        value = raw.get(field)
+    for field, aliases in (
+        ("room", ("room",)),
+        ("shard", ("shard",)),
+        ("branch", ("branch",)),
+        ("code_path", ("code_path", "codePath")),
+        ("map_source_file", ("map_source_file", "mapSourceFile")),
+        ("simulator_out_dir", ("simulator_out_dir", "simulatorOutDir")),
+    ):
+        value = first_present(raw, aliases)
         if not isinstance(value, str) or not value:
             raise CardValidationError(f"simulation.{field} must be a non-empty string")
 
@@ -287,6 +303,8 @@ def positive_int(value: Any) -> int | None:
         return None
     if isinstance(value, int) and value > 0:
         return value
+    if isinstance(value, float) and math.isfinite(value) and value.is_integer() and value > 0:
+        return int(value)
     return None
 
 

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -18,9 +18,16 @@ TRAINING_APPROACHES = ("bandit", "evolutionary", "policy_gradient")
 DATASET_RUN_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 COMMIT_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
 ISO_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+STRATEGY_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
 DRY_RUN_DATASET_RUN_ID = "rl-dry-run-000000000000"
 SAFETY_FALSE_FIELDS = ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed")
 SAFETY_TRUE_FIELDS = ("ood_rejection", "conservative_actions_only")
+DEFAULT_STRATEGY_VARIANTS = (
+    "construction-priority.incumbent.v1",
+    "construction-priority.territory-shadow.v1",
+    "expansion-remote.incumbent.v1",
+    "expansion-remote.territory-shadow.v1",
+)
 
 JsonObject = dict[str, Any]
 
@@ -93,6 +100,20 @@ def safety_block() -> JsonObject:
     }
 
 
+def simulation_block() -> JsonObject:
+    return {
+        "branch": "$activeWorld",
+        "code_path": "prod/dist/main.js",
+        "map_source_file": "maps/map-0b6758af.json",
+        "repetitions": 1,
+        "room": "E1S1",
+        "shard": "shardX",
+        "simulator_out_dir": "runtime-artifacts/rl-simulator",
+        "ticks": 50,
+        "workers": 1,
+    }
+
+
 def build_card(
     *,
     dataset_run_id: str,
@@ -110,11 +131,18 @@ def build_card(
     card = {
         "card_id": f"rl-exp-{dataset_run_id}-{commit_prefix}",
         "code_commit": code_commit.lower(),
+        "conservative_actions_only": True,
         "created_at": created_at,
         "dataset_run_id": dataset_run_id,
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+        "ood_rejection": True,
         "reward_model": reward_model(),
         "safety": safety_block(),
+        "simulation": simulation_block(),
         "status": "shadow",
+        "strategy_variants": list(DEFAULT_STRATEGY_VARIANTS),
         "training_approach": training_approach,
     }
     validate_card(card)
@@ -168,6 +196,8 @@ def validate_card(raw: Any) -> None:
 
     validate_safety(raw)
     validate_reward_model(raw.get("reward_model"))
+    validate_strategy_variants(raw.get("strategy_variants"))
+    validate_simulation(raw.get("simulation"))
 
 
 def require_string(raw: JsonObject, field: str) -> str:
@@ -216,6 +246,48 @@ def validate_reward_model(raw: Any) -> None:
         raise CardValidationError("reward_model weights must be strictly lexicographic")
     if raw.get("scalar_weighted_sum_authorized") is not False:
         raise CardValidationError("reward_model.scalar_weighted_sum_authorized must be false")
+
+
+def validate_strategy_variants(raw: Any) -> None:
+    if not isinstance(raw, list) or len(raw) == 0:
+        raise CardValidationError("strategy_variants must contain at least one registry id or inline variant")
+    for index, item in enumerate(raw):
+        if isinstance(item, str):
+            validate_strategy_id(item, f"strategy_variants[{index}]")
+            continue
+        if not isinstance(item, dict):
+            raise CardValidationError(f"strategy_variants[{index}] must be a string or JSON object")
+        variant_id = item.get("id")
+        if not isinstance(variant_id, str) or not variant_id:
+            raise CardValidationError(f"strategy_variants[{index}].id must be a non-empty string")
+        validate_strategy_id(variant_id, f"strategy_variants[{index}].id")
+
+
+def validate_strategy_id(value: str, label: str) -> None:
+    if not STRATEGY_ID_RE.fullmatch(value) or value in {".", ".."}:
+        raise CardValidationError(f"{label} may contain only letters, numbers, dot, colon, underscore, and hyphen")
+
+
+def validate_simulation(raw: Any) -> None:
+    if not isinstance(raw, dict):
+        raise CardValidationError("simulation must be a JSON object")
+    for field in ("ticks", "workers", "repetitions"):
+        if positive_int(raw.get(field)) is None:
+            raise CardValidationError(f"simulation.{field} must be a positive integer")
+    if "host_port_start" in raw and positive_int(raw.get("host_port_start")) is None:
+        raise CardValidationError("simulation.host_port_start must be a positive integer")
+    for field in ("room", "shard", "branch", "code_path", "map_source_file", "simulator_out_dir"):
+        value = raw.get(field)
+        if not isinstance(value, str) or not value:
+            raise CardValidationError(f"simulation.{field} must be a non-empty string")
+
+
+def positive_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and value > 0:
+        return value
+    return None
 
 
 def write_output(payload: Any, output: Path | None, stdout: TextIO) -> None:

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -514,6 +514,8 @@ def positive_int_value(value: Any) -> int | None:
         return None
     if isinstance(value, int) and value > 0:
         return value
+    if isinstance(value, float) and math.isfinite(value) and value.is_integer() and value > 0:
+        return int(value)
     if isinstance(value, str):
         try:
             parsed = int(value)

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import screeps_rl_experiment_card as card_helper
+import screeps_rl_training_runner as runner
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class RlExperimentCardTest(unittest.TestCase):
+    def test_generated_card_is_training_runner_valid(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-3d29e8b9397d",
+            code_commit="a" * 40,
+            training_approach="bandit",
+            created_at="2026-05-16T10:09:35Z",
+        )
+
+        card_helper.validate_card(card)
+        runner.validate_experiment_card(card)
+        variants = runner.load_strategy_variants(
+            card,
+            registry_path=REPO_ROOT / "prod" / "src" / "strategy" / "strategyRegistry.ts",
+        )
+        config = runner.simulation_config_from_card(card)
+
+        self.assertEqual(card["status"], "shadow")
+        self.assertFalse(card["liveEffect"])
+        self.assertFalse(card["officialMmoWrites"])
+        self.assertFalse(card["officialMmoWritesAllowed"])
+        self.assertTrue(card["conservative_actions_only"])
+        self.assertTrue(card["ood_rejection"])
+        self.assertEqual(card["reward_model"]["component_order"], ["reliability", "territory", "resources", "kills"])
+        self.assertFalse(card["reward_model"]["scalar_weighted_sum_authorized"])
+        self.assertEqual(
+            [variant.id for variant in variants],
+            [
+                "construction-priority.incumbent.v1",
+                "construction-priority.territory-shadow.v1",
+                "expansion-remote.incumbent.v1",
+                "expansion-remote.territory-shadow.v1",
+            ],
+        )
+        self.assertEqual(config.ticks, 50)
+        self.assertEqual(config.workers, 1)
+        self.assertEqual(config.repetitions, 1)
+
+    def test_validate_rejects_header_only_card(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-3d29e8b9397d",
+            code_commit="b" * 40,
+            training_approach="bandit",
+            created_at="2026-05-16T10:09:35Z",
+        )
+        del card["strategy_variants"]
+
+        with self.assertRaisesRegex(card_helper.CardValidationError, "strategy_variants must contain"):
+            card_helper.validate_card(card)
+
+    def test_cli_generation_outputs_training_runner_valid_card(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "card.json"
+            exit_code = card_helper.main(
+                [
+                    "--dataset-run-id",
+                    "rl-3d29e8b9397d",
+                    "--code-commit",
+                    "c" * 40,
+                    "--created-at",
+                    "2026-05-16T10:09:35Z",
+                    "--output",
+                    str(output_path),
+                ],
+                stdout=io.StringIO(),
+                stderr=io.StringIO(),
+                repo_root=REPO_ROOT,
+            )
+            generated = json.loads(output_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, 0)
+        runner.validate_experiment_card(generated)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -67,6 +67,40 @@ class RlExperimentCardTest(unittest.TestCase):
         with self.assertRaisesRegex(card_helper.CardValidationError, "strategy_variants must contain"):
             card_helper.validate_card(card)
 
+    def test_validate_accepts_training_runner_aliases_and_integer_floats(self) -> None:
+        for variant_field in ("strategyVariants", "variants"):
+            with self.subTest(variant_field=variant_field):
+                card = card_helper.build_card(
+                    dataset_run_id=f"rl-alias-{variant_field}",
+                    code_commit="d" * 40,
+                    training_approach="bandit",
+                    created_at="2026-05-16T10:09:35Z",
+                )
+                variants = card.pop("strategy_variants")
+                simulation = card.pop("simulation")
+                card[variant_field] = variants
+                card["simulator"] = {
+                    "ticks": 50.0,
+                    "workers": 1.0,
+                    "repetitions": 1.0,
+                    "hostPortStart": 24125.0,
+                    "room": simulation["room"],
+                    "shard": simulation["shard"],
+                    "branch": simulation["branch"],
+                    "codePath": simulation["code_path"],
+                    "mapSourceFile": simulation["map_source_file"],
+                    "simulatorOutDir": simulation["simulator_out_dir"],
+                }
+
+                card_helper.validate_card(card)
+                runner.validate_experiment_card(card)
+                config = runner.simulation_config_from_card(card)
+
+                self.assertEqual(config.ticks, 50)
+                self.assertEqual(config.workers, 1)
+                self.assertEqual(config.repetitions, 1)
+                self.assertEqual(config.host_port_start, 24125)
+
     def test_cli_generation_outputs_training_runner_valid_card(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             output_path = Path(temp_dir) / "card.json"

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import sys
 import tempfile
 import unittest
@@ -11,6 +12,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
 import screeps_rl_experiment_card as card_helper
+import screeps_rl_simulator_harness as harness
 import screeps_rl_training_runner as runner
 
 
@@ -54,6 +56,32 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(config.ticks, 50)
         self.assertEqual(config.workers, 1)
         self.assertEqual(config.repetitions, 1)
+        self.assertEqual(config.branch, "$activeWorld")
+
+    def test_generated_simulation_paths_are_harness_defaults_from_arbitrary_cwd(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-cwd-safe-000000",
+            code_commit="e" * 40,
+            training_approach="bandit",
+            created_at="2026-05-16T10:09:35Z",
+        )
+
+        original_cwd = Path.cwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            try:
+                os.chdir(temp_dir)
+                config = runner.simulation_config_from_card(card)
+            finally:
+                os.chdir(original_cwd)
+
+        self.assertEqual(config.branch, harness.DEFAULT_ACTIVE_WORLD_BRANCH)
+        self.assertEqual(config.map_source_file, harness.DEFAULT_MAP_SOURCE_FILE)
+        self.assertTrue(config.map_source_file.is_absolute())
+        self.assertEqual(config.code_path, harness.DEFAULT_CODE_PATH)
+        self.assertTrue(config.code_path.is_absolute())
+        self.assertTrue(config.code_path.is_file())
+        self.assertEqual(config.simulator_out_dir, REPO_ROOT / "runtime-artifacts" / "rl-simulator")
+        self.assertTrue(config.simulator_out_dir.is_absolute())
 
     def test_validate_rejects_header_only_card(self) -> None:
         card = card_helper.build_card(

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -20,6 +20,18 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 class RlExperimentCardTest(unittest.TestCase):
+    def assert_map_source_uses_harness_default_sentinel(self, map_source_file: Path) -> None:
+        self.assertEqual(map_source_file, harness.DEFAULT_MAP_SOURCE_FILE)
+        self.assertTrue(map_source_file.is_absolute())
+
+        # The default map path is a harness sentinel. It may be absent because
+        # the harness then asks private-smoke to fetch its default map.
+        smoke_map_source_file = harness._resolve_smoke_map_source_file(map_source_file)
+        if map_source_file.is_file():
+            self.assertEqual(smoke_map_source_file, map_source_file)
+        else:
+            self.assertIsNone(smoke_map_source_file)
+
     def test_generated_card_is_training_runner_valid(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-3d29e8b9397d",
@@ -75,8 +87,7 @@ class RlExperimentCardTest(unittest.TestCase):
                 os.chdir(original_cwd)
 
         self.assertEqual(config.branch, harness.DEFAULT_ACTIVE_WORLD_BRANCH)
-        self.assertEqual(config.map_source_file, harness.DEFAULT_MAP_SOURCE_FILE)
-        self.assertTrue(config.map_source_file.is_absolute())
+        self.assert_map_source_uses_harness_default_sentinel(config.map_source_file)
         self.assertEqual(config.code_path, harness.DEFAULT_CODE_PATH)
         self.assertTrue(config.code_path.is_absolute())
         self.assertTrue(config.code_path.is_file())


### PR DESCRIPTION
## Summary
- Extends the RL experiment-card generator so generated cards include top-level safety flags, strategy variants, and simulation configuration accepted by the training runner.
- Adds Python regression tests proving generated cards validate through both the card helper and training runner.
- Generated and validated a fresh shadow Loop A card artifact for the current main commit.

## Fresh card artifact
- `/root/screeps/runtime-artifacts/rl-experiment-cards/rl-exp-rl-3d29e8b9397d-aed4a7c87ebd-20260516T151326Z.json`
- Card id: `rl-exp-rl-3d29e8b9397d-aed4a7c87ebd`
- Safety: `liveEffect=false`, `officialMmoWrites=false`, `officialMmoWritesAllowed=false`, `conservative_actions_only=true`, `ood_rejection=true`, lexicographic reward order `reliability > territory > resources > kills`.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_experiment_card.py scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_experiment_card.py`
- `python3 scripts/test_screeps_rl_experiment_card.py`
- `python3 scripts/screeps_rl_experiment_card.py --validate --input /root/screeps/runtime-artifacts/rl-experiment-cards/rl-exp-rl-3d29e8b9397d-aed4a7c87ebd-20260516T151326Z.json`
- training-runner `validate_experiment_card(...)` on the generated artifact.

## Scheduler evidence
- Recovered dirty Codex-authored worktree `/root/screeps-worktrees/issue-1150-loopa-card` after the live Codex process exited without committing.
- Commit `82872a0` authored by `lanyusea's bot <lanyusea@gmail.com>`.

Fixes #1150
