### PR TITLE
fix(tasks): reduce E29N55 repair-target crowding

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -27112,16 +27112,16 @@ function selectThreatenedBarrierRepairTarget(creep) {
   return repairTargets.sort(compareRepairTargets)[0];
 }
 function selectRoutineBarrierMaintenanceRepairTarget(creep) {
-  return getRoutineBarrierMaintenanceRepairTarget(creep.room);
+  return selectAvailableRoutineRepairTarget(creep, getRoutineBarrierMaintenanceRepairTargets(creep.room));
 }
 function selectRoutineRampartMaintenanceRepairTarget(creep) {
-  return computeRoutineRampartMaintenanceRepairTarget(creep.room);
+  return selectAvailableRoutineRepairTarget(creep, computeRoutineRampartMaintenanceRepairTargets(creep.room));
 }
-function getRoutineBarrierMaintenanceRepairTarget(room) {
+function getRoutineBarrierMaintenanceRepairTargets(room) {
   const gameTick = getGameTick3();
   const roomName = getRoomName6(room);
   if (gameTick === null || roomName === null) {
-    return computeRoutineBarrierMaintenanceRepairTarget(room);
+    return computeRoutineBarrierMaintenanceRepairTargets(room);
   }
   const game = getGameReference();
   if (!routineBarrierMaintenanceRepairTargetCache || routineBarrierMaintenanceRepairTargetCache.tick !== gameTick || routineBarrierMaintenanceRepairTargetCache.game !== game) {
@@ -27133,31 +27133,35 @@ function getRoutineBarrierMaintenanceRepairTarget(room) {
   }
   const cachedEntry = routineBarrierMaintenanceRepairTargetCache.roomsByName.get(roomName);
   if ((cachedEntry == null ? void 0 : cachedEntry.room) === room) {
-    return cachedEntry.target;
+    return cachedEntry.targets;
   }
-  const target = computeRoutineBarrierMaintenanceRepairTarget(room);
-  routineBarrierMaintenanceRepairTargetCache.roomsByName.set(roomName, { room, target });
-  return target;
+  const targets = computeRoutineBarrierMaintenanceRepairTargets(room);
+  routineBarrierMaintenanceRepairTargetCache.roomsByName.set(roomName, { room, targets });
+  return targets;
 }
-function computeRoutineBarrierMaintenanceRepairTarget(room) {
+function computeRoutineBarrierMaintenanceRepairTargets(room) {
   if (!canSelectRoutineBarrierMaintenanceRepairTarget(room)) {
-    return null;
+    return [];
   }
   const repairTargets = findVisibleRoomStructures(room).filter(isRoutineBarrierMaintenanceRepairTarget);
   if (repairTargets.length === 0) {
-    return null;
+    return [];
   }
-  return repairTargets.sort(compareRepairTargets)[0];
+  return repairTargets.sort(compareRepairTargets);
 }
-function computeRoutineRampartMaintenanceRepairTarget(room) {
+function computeRoutineRampartMaintenanceRepairTargets(room) {
   if (!canSelectRoutineBarrierMaintenanceRepairTarget(room)) {
-    return null;
+    return [];
   }
   const repairTargets = findVisibleRoomStructures(room).filter(isRoutineRampartMaintenanceRepairTarget);
   if (repairTargets.length === 0) {
-    return null;
+    return [];
   }
-  return repairTargets.sort(compareRepairTargets)[0];
+  return repairTargets.sort(compareRepairTargets);
+}
+function selectAvailableRoutineRepairTarget(creep, repairTargets) {
+  var _a;
+  return (_a = repairTargets.find((structure) => hasRoutineRepairAssignmentCapacity(creep, structure))) != null ? _a : null;
 }
 function canSelectRoutineBarrierMaintenanceRepairTarget(room) {
   var _a;
@@ -27248,7 +27252,7 @@ function isRoutineRepairTargetForWorker(creep, structure) {
     return false;
   }
   if (isWorkerBarrierRepairStructure(structure)) {
-    return true;
+    return isUrgentBarrierRepairTarget(structure) || hasRoutineRepairAssignmentCapacity(creep, structure);
   }
   return hasMeaningfulRoutineRepairDeficit(structure) && isRoutineRepairTargetWithinOpportunisticRange(creep, structure) && hasRoutineRepairAssignmentCapacity(creep, structure);
 }
@@ -27262,7 +27266,10 @@ function isRoutineRepairTargetWithinOpportunisticRange(creep, structure) {
   return range === null || range <= ROUTINE_REPAIR_MAX_RANGE;
 }
 function hasRoutineRepairAssignmentCapacity(creep, structure) {
-  return isWorkerAssignedToRepairTarget(creep, structure) || !hasOtherWorkerAssignedToRepairTarget(creep, structure);
+  return isUrgentBarrierRepairTarget(structure) || isWorkerAssignedToRepairTarget(creep, structure) || !hasOtherWorkerAssignedToRepairTarget(creep, structure);
+}
+function isUrgentBarrierRepairTarget(structure) {
+  return isWorkerBarrierRepairStructure(structure) && structure.hits < Math.min(structure.hitsMax, BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING);
 }
 function hasOtherWorkerAssignedToRepairTarget(creep, structure) {
   return getRoomOwnedCreeps(creep.room).some(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -246,7 +246,7 @@ interface GameCreepsCache {
 
 interface RoutineBarrierMaintenanceRepairTargetCacheEntry {
   room: Room;
-  target: StructureRampart | StructureWall | null;
+  targets: Array<StructureRampart | StructureWall>;
 }
 
 interface RoutineBarrierMaintenanceRepairTargetCache {
@@ -6334,18 +6334,18 @@ function selectThreatenedBarrierRepairTarget(creep: Creep): StructureRampart | S
 }
 
 function selectRoutineBarrierMaintenanceRepairTarget(creep: Creep): StructureRampart | StructureWall | null {
-  return getRoutineBarrierMaintenanceRepairTarget(creep.room);
+  return selectAvailableRoutineRepairTarget(creep, getRoutineBarrierMaintenanceRepairTargets(creep.room));
 }
 
 function selectRoutineRampartMaintenanceRepairTarget(creep: Creep): StructureRampart | null {
-  return computeRoutineRampartMaintenanceRepairTarget(creep.room);
+  return selectAvailableRoutineRepairTarget(creep, computeRoutineRampartMaintenanceRepairTargets(creep.room));
 }
 
-function getRoutineBarrierMaintenanceRepairTarget(room: Room): StructureRampart | StructureWall | null {
+function getRoutineBarrierMaintenanceRepairTargets(room: Room): Array<StructureRampart | StructureWall> {
   const gameTick = getGameTick();
   const roomName = getRoomName(room);
   if (gameTick === null || roomName === null) {
-    return computeRoutineBarrierMaintenanceRepairTarget(room);
+    return computeRoutineBarrierMaintenanceRepairTargets(room);
   }
 
   const game = getGameReference();
@@ -6363,38 +6363,45 @@ function getRoutineBarrierMaintenanceRepairTarget(room: Room): StructureRampart 
 
   const cachedEntry = routineBarrierMaintenanceRepairTargetCache.roomsByName.get(roomName);
   if (cachedEntry?.room === room) {
-    return cachedEntry.target;
+    return cachedEntry.targets;
   }
 
-  const target = computeRoutineBarrierMaintenanceRepairTarget(room);
-  routineBarrierMaintenanceRepairTargetCache.roomsByName.set(roomName, { room, target });
-  return target;
+  const targets = computeRoutineBarrierMaintenanceRepairTargets(room);
+  routineBarrierMaintenanceRepairTargetCache.roomsByName.set(roomName, { room, targets });
+  return targets;
 }
 
-function computeRoutineBarrierMaintenanceRepairTarget(room: Room): StructureRampart | StructureWall | null {
+function computeRoutineBarrierMaintenanceRepairTargets(room: Room): Array<StructureRampart | StructureWall> {
   if (!canSelectRoutineBarrierMaintenanceRepairTarget(room)) {
-    return null;
+    return [];
   }
 
   const repairTargets = findVisibleRoomStructures(room).filter(isRoutineBarrierMaintenanceRepairTarget);
   if (repairTargets.length === 0) {
-    return null;
+    return [];
   }
 
-  return repairTargets.sort(compareRepairTargets)[0];
+  return repairTargets.sort(compareRepairTargets);
 }
 
-function computeRoutineRampartMaintenanceRepairTarget(room: Room): StructureRampart | null {
+function computeRoutineRampartMaintenanceRepairTargets(room: Room): StructureRampart[] {
   if (!canSelectRoutineBarrierMaintenanceRepairTarget(room)) {
-    return null;
+    return [];
   }
 
   const repairTargets = findVisibleRoomStructures(room).filter(isRoutineRampartMaintenanceRepairTarget);
   if (repairTargets.length === 0) {
-    return null;
+    return [];
   }
 
-  return repairTargets.sort(compareRepairTargets)[0];
+  return repairTargets.sort(compareRepairTargets);
+}
+
+function selectAvailableRoutineRepairTarget<T extends RepairableWorkerStructure>(
+  creep: Creep,
+  repairTargets: T[]
+): T | null {
+  return repairTargets.find((structure) => hasRoutineRepairAssignmentCapacity(creep, structure)) ?? null;
 }
 
 function canSelectRoutineBarrierMaintenanceRepairTarget(room: Room): boolean {
@@ -6535,7 +6542,7 @@ function isRoutineRepairTargetForWorker(
   }
 
   if (isWorkerBarrierRepairStructure(structure)) {
-    return true;
+    return isUrgentBarrierRepairTarget(structure) || hasRoutineRepairAssignmentCapacity(creep, structure);
   }
 
   return (
@@ -6565,8 +6572,16 @@ function isRoutineRepairTargetWithinOpportunisticRange(
 
 function hasRoutineRepairAssignmentCapacity(creep: Creep, structure: RepairableWorkerStructure): boolean {
   return (
+    isUrgentBarrierRepairTarget(structure) ||
     isWorkerAssignedToRepairTarget(creep, structure) ||
     !hasOtherWorkerAssignedToRepairTarget(creep, structure)
+  );
+}
+
+function isUrgentBarrierRepairTarget(structure: RepairableWorkerStructure): boolean {
+  return (
+    isWorkerBarrierRepairStructure(structure) &&
+    structure.hits < Math.min(structure.hitsMax, BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING)
   );
 }
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1590,6 +1590,81 @@ describe('runWorker', () => {
     expect(moveTo).toHaveBeenCalledWith(road, { range: 3 });
   });
 
+  it('assigns sequential workers to different routine rampart repairs without throwing', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const firstRampart = {
+      id: 'rampart-a',
+      structureType: 'rampart',
+      hits: IDLE_RAMPART_REPAIR_HITS_CEILING - 1_000,
+      hitsMax: 300_000,
+      my: true
+    } as StructureRampart;
+    const secondRampart = {
+      id: 'rampart-b',
+      structureType: 'rampart',
+      hits: IDLE_RAMPART_REPAIR_HITS_CEILING - 900,
+      hitsMax: 300_000,
+      my: true
+    } as StructureRampart;
+    const workers: Creep[] = [];
+    const room = {
+      name: 'W1N1',
+      controller,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      find: jest.fn((type: number) => {
+        if (type === FIND_STRUCTURES) {
+          return [firstRampart, secondRampart];
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return workers;
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const firstWorker = {
+      name: 'FirstWorker',
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      repair: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const secondWorker = {
+      name: 'SecondWorker',
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      repair: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    workers.push(firstWorker, secondWorker);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { FirstWorker: firstWorker, SecondWorker: secondWorker },
+      getObjectById: jest.fn((id: string) => (id === 'rampart-a' ? firstRampart : secondRampart)),
+      time: 801
+    };
+
+    expect(() => runWorker(firstWorker)).not.toThrow();
+    expect(() => runWorker(secondWorker)).not.toThrow();
+
+    expect(firstWorker.memory.task).toEqual({ type: 'repair', targetId: 'rampart-a' });
+    expect(secondWorker.memory.task).toEqual({ type: 'repair', targetId: 'rampart-b' });
+  });
+
   it('upgrades an existing upgrade target and moves when not in range', () => {
     const controller = { id: 'controller1' } as StructureController;
     const upgradeController = jest.fn().mockReturnValue(-9);

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1652,17 +1652,42 @@ describe('runWorker', () => {
       moveTo: jest.fn()
     } as unknown as Creep;
     workers.push(firstWorker, secondWorker);
+    const rampartsById = new Map<string, StructureRampart>([
+      [String(firstRampart.id), firstRampart],
+      [String(secondRampart.id), secondRampart]
+    ]);
+    const getObjectById = jest.fn((id: string) => rampartsById.get(id) ?? null);
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       creeps: { FirstWorker: firstWorker, SecondWorker: secondWorker },
-      getObjectById: jest.fn((id: string) => (id === 'rampart-a' ? firstRampart : secondRampart)),
+      getObjectById,
       time: 801
     };
 
     expect(() => runWorker(firstWorker)).not.toThrow();
     expect(() => runWorker(secondWorker)).not.toThrow();
 
-    expect(firstWorker.memory.task).toEqual({ type: 'repair', targetId: 'rampart-a' });
-    expect(secondWorker.memory.task).toEqual({ type: 'repair', targetId: 'rampart-b' });
+    const firstTask = firstWorker.memory.task;
+    const secondTask = secondWorker.memory.task;
+    expect(firstTask?.type).toBe('repair');
+    expect(secondTask?.type).toBe('repair');
+    if (firstTask?.type !== 'repair' || secondTask?.type !== 'repair') {
+      throw new Error('expected both workers to receive repair tasks');
+    }
+
+    expect(new Set([String(firstTask.targetId), String(secondTask.targetId)])).toEqual(
+      new Set([String(firstRampart.id), String(secondRampart.id)])
+    );
+
+    const firstRepairTarget = rampartsById.get(String(firstTask.targetId));
+    const secondRepairTarget = rampartsById.get(String(secondTask.targetId));
+    if (!firstRepairTarget || !secondRepairTarget) {
+      throw new Error('expected assigned repair targets to resolve through Game.getObjectById');
+    }
+
+    expect(getObjectById).toHaveBeenCalledWith(firstTask.targetId);
+    expect(getObjectById).toHaveBeenCalledWith(secondTask.targetId);
+    expect(firstWorker.repair).toHaveBeenCalledWith(firstRepairTarget);
+    expect(secondWorker.repair).toHaveBeenCalledWith(secondRepairTarget);
   });
 
   it('upgrades an existing upgrade target and moves when not in range', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -14081,6 +14081,119 @@ describe('selectWorkerTask', () => {
     expect(totalStructureFinds - firstWorkerStructureFinds).toBeLessThan(firstWorkerStructureFinds);
   });
 
+  it('distributes post-construction routine barrier repairs to uncovered targets', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const firstWall = makeStructure(
+      'wall-a',
+      'constructedWall' as StructureConstant,
+      IDLE_RAMPART_REPAIR_HITS_CEILING - 1_000,
+      300_000_000
+    );
+    const secondWall = makeStructure(
+      'wall-b',
+      'constructedWall' as StructureConstant,
+      IDLE_RAMPART_REPAIR_HITS_CEILING - 900,
+      300_000_000
+    );
+    const room = makeWorkerTaskRoom({
+      controller,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      structures: [firstWall, secondWall]
+    });
+    const repairer = makeLoadedWorker(room, { type: 'repair', targetId: 'wall-a' as Id<Structure> });
+    const creep = {
+      name: 'SecondWorker',
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ Repairer: repairer, SecondWorker: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'wall-b' });
+  });
+
+  it('keeps a covered post-construction routine barrier from consuming another worker', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const wall = makeStructure(
+      'wall-covered',
+      'constructedWall' as StructureConstant,
+      IDLE_RAMPART_REPAIR_HITS_CEILING - 1_000,
+      300_000_000
+    );
+    const room = makeWorkerTaskRoom({
+      controller,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      structures: [wall]
+    });
+    const repairer = makeLoadedWorker(room, { type: 'repair', targetId: 'wall-covered' as Id<Structure> });
+    const creep = {
+      name: 'SecondWorker',
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ Repairer: repairer, SecondWorker: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('preserves threatened barrier repair even when another worker is assigned', () => {
+    const controller = { id: 'controller1', my: true } as StructureController;
+    const wall = makeStructure(
+      'wall-threatened',
+      'constructedWall' as StructureConstant,
+      IDLE_RAMPART_REPAIR_HITS_CEILING - 1,
+      300_000_000
+    );
+    const room = makeWorkerTaskRoom({
+      controller,
+      name: 'W1N1',
+      structures: [wall]
+    });
+    const repairer = makeLoadedWorker(room, { type: 'repair', targetId: 'wall-threatened' as Id<Structure> });
+    const creep = {
+      name: 'SecondWorker',
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      defense: {
+        colonyThreats: {
+          updatedAt: 250,
+          rooms: {
+            W1N1: {
+              roomName: 'W1N1',
+              level: 'hostile_present',
+              updatedAt: 250,
+              hostileCreepCount: 1,
+              hostileStructureCount: 0,
+              damagedCriticalStructureCount: 0
+            }
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Repairer: repairer, SecondWorker: creep },
+      time: 250
+    };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'wall-threatened' });
+  });
+
   it('keeps managed controller upgrade when barrier maintenance would spend below the construction floor', () => {
     const controller = {
       id: 'controller1',


### PR DESCRIPTION
Closes #1158.

## Summary
- Reduces E29N55 repair-target crowding after construction backlog clears.
- Bounds repair reservation/target selection so workers spread across eligible repair work instead of piling onto one target.
- Adds focused worker-task/runner tests and keeps `prod/dist/main.js` synchronized.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (98 suites / 1917 tests passed)
- `cd prod && npm run build`
- post-commit `cd prod && npm run build && git diff --exit-code -- prod/dist/main.js`

## Safety
- No secrets, no deploy, no official MMO writes in this PR.
- Runtime-affecting Screeps bundle change; deployment floor must re-run official deploy after merge.
