### PR TITLE
feat(rl): support Tencent multi-worker batch scale proof

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -341,7 +341,9 @@ def expand_scale_environment_variants(variant_ids: Sequence[str], environment_co
     The run harness historically mapped concurrency to strategy variant rows. A
     scale proof may need five private-server environments while only comparing
     the two default construction-priority variants, so this expansion creates
-    unique environment row ids backed by the selected base variants.
+    unique environment row ids backed by the selected base variants. The
+    requested count is a replica budget, not permission to drop selected
+    strategy variants.
     """
     variants = [variant_id for variant_id in variant_ids if isinstance(variant_id, str) and variant_id]
     if environment_count is None:
@@ -350,12 +352,13 @@ def expand_scale_environment_variants(variant_ids: Sequence[str], environment_co
         raise ValueError("environment_count must be a positive integer")
     if not variants:
         raise ValueError("at least one strategy variant is required")
-    if environment_count == len(variants):
+    row_count = max(environment_count, len(variants))
+    if row_count == len(variants):
         return list(variants)
-    width = max(2, len(str(environment_count)))
+    width = max(2, len(str(row_count)))
     return [
         f"{variants[index % len(variants)]}.scale-env-{index + 1:0{width}d}"
-        for index in range(environment_count)
+        for index in range(row_count)
     ]
 
 

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -83,9 +83,11 @@ class SimulationConfig:
     code_path: Path
     map_source_file: Path
     simulator_out_dir: Path
+    scale_environments: int | None = None
+    min_concurrent_environments: int | None = None
 
     def to_json(self) -> JsonObject:
-        return {
+        payload: JsonObject = {
             "ticks": self.ticks,
             "workers": self.workers,
             "repetitions": self.repetitions,
@@ -97,6 +99,11 @@ class SimulationConfig:
             "mapSourceFile": str(self.map_source_file),
             "simulatorOutDir": str(self.simulator_out_dir),
         }
+        if self.scale_environments is not None:
+            payload["scaleEnvironments"] = self.scale_environments
+        if self.min_concurrent_environments is not None:
+            payload["minConcurrentEnvironments"] = self.min_concurrent_environments
+        return payload
 
 
 def utc_now_iso() -> str:
@@ -243,6 +250,13 @@ def validate_experiment_card(card: JsonObject) -> None:
         raise TrainingCardError("simulation.ticks must be a positive integer")
     if "workers" in simulation and positive_int_value(simulation["workers"]) is None:
         raise TrainingCardError("simulation.workers must be a positive integer")
+    for field, aliases in (
+        ("scale_environments", ("scale_environments", "scaleEnvironments")),
+        ("min_concurrent_environments", ("min_concurrent_environments", "minConcurrentEnvironments")),
+    ):
+        value = first_present(simulation, aliases)
+        if value is not None and positive_int_value(value) is None:
+            raise TrainingCardError(f"simulation.{field} must be a positive integer")
     if "repetitions" in simulation and positive_int_value(simulation["repetitions"]) is None:
         raise TrainingCardError("simulation.repetitions must be a positive integer")
     if (
@@ -267,6 +281,13 @@ def raw_mapping(value: Any, label: str) -> JsonObject:
     return value
 
 
+def first_present(raw: JsonObject, keys: Sequence[str]) -> Any:
+    for key in keys:
+        if key in raw:
+            return raw[key]
+    return None
+
+
 def load_strategy_variants(card: JsonObject, registry_path: Path | None = None) -> list[StrategyVariant]:
     """Resolve strategy variants from the TS registry and inline card definitions."""
     registry = load_strategy_registry(registry_path or simulator_harness.DEFAULT_STRATEGY_REGISTRY_PATH)
@@ -279,6 +300,42 @@ def load_strategy_variants(card: JsonObject, registry_path: Path | None = None) 
         seen.add(variant.id)
         variants.append(variant)
     return variants
+
+
+def expand_scale_environment_strategy_variants(
+    variants: Sequence[StrategyVariant],
+    environment_count: int | None,
+) -> list[StrategyVariant]:
+    """Clone strategy metadata into unique simulator rows for scale validation."""
+    if environment_count is None:
+        return list(variants)
+    expanded_ids = simulator_harness.expand_scale_environment_variants(
+        [variant.id for variant in variants],
+        environment_count,
+    )
+    variants_by_id = {variant.id: variant for variant in variants}
+    expanded: list[StrategyVariant] = []
+    for variant_id in expanded_ids:
+        base_id = simulator_harness.scale_environment_base_variant_id(variant_id)
+        base = variants_by_id.get(base_id)
+        if base is None:
+            raise TrainingCardError(f"scale environment base variant {base_id!r} was not found")
+        if variant_id == base.id:
+            expanded.append(base)
+            continue
+        environment_index = simulator_harness.scale_environment_index(variant_id)
+        suffix = f" scale environment {environment_index}" if environment_index is not None else " scale environment"
+        expanded.append(
+            StrategyVariant(
+                id=variant_id,
+                parameters=dict(base.parameters),
+                family=base.family,
+                rollout_status=base.rollout_status,
+                source=base.source,
+                title=(base.title + suffix) if base.title else None,
+            )
+        )
+    return expanded
 
 
 def normalize_variant(raw: Any, registry: dict[str, StrategyVariant]) -> StrategyVariant:
@@ -506,6 +563,12 @@ def simulation_config_from_card(card: JsonObject) -> SimulationConfig:
             or text_or_none(simulation.get("simulatorOutDir"))
             or simulator_harness.DEFAULT_RUN_OUT_DIR
         ),
+        scale_environments=positive_int_value(
+            simulation.get("scale_environments", simulation.get("scaleEnvironments"))
+        ),
+        min_concurrent_environments=positive_int_value(
+            simulation.get("min_concurrent_environments", simulation.get("minConcurrentEnvironments"))
+        ),
     )
 
 
@@ -576,6 +639,7 @@ def run_training_experiment(
     card = load_experiment_card(card_path)
     variants = load_strategy_variants(card, registry_path=registry_path)
     config = simulation_config_from_card(card)
+    variants = expand_scale_environment_strategy_variants(variants, config.scale_environments)
     reward_options = reward_options_from_card(card)
     resolved_report_id = report_id or default_report_id(card, variants, config)
     validate_report_id(resolved_report_id)
@@ -622,6 +686,7 @@ def execute_simulator_runs(
     base_run_id = normalize_simulator_run_id(raw_run_id)
     runs: list[JsonObject] = []
     effective_workers = max(1, min(config.workers, len(variant_ids)))
+    min_concurrent_environments = config.min_concurrent_environments or config.scale_environments or 0
     for repetition in range(config.repetitions):
         run_id = base_run_id if config.repetitions == 1 else f"{base_run_id}-r{repetition + 1:02d}"
         host_port_start = simulator_repetition_host_port_start(
@@ -642,6 +707,7 @@ def execute_simulator_runs(
                 branch=config.branch,
                 code_path=config.code_path,
                 map_source_file=config.map_source_file,
+                min_concurrent_environments=min_concurrent_environments,
             )
         )
     return runs
@@ -704,6 +770,43 @@ def unsafe_simulator_flags(payload: JsonObject, label: str) -> list[str]:
     return unsafe
 
 
+def build_scale_validation_summary(
+    simulator_runs: Sequence[JsonObject],
+    config: SimulationConfig,
+) -> JsonObject | None:
+    target = config.min_concurrent_environments or config.scale_environments
+    if target is None:
+        return None
+    minimum_successful = math.ceil(target * simulator_harness.RUN_SCALE_VALIDATION_TARGET_SUCCESS_RATE)
+    run_summaries: list[JsonObject] = []
+    total_environments = 0
+    successful_environments = 0
+    for index, run in enumerate(simulator_runs):
+        variants = run.get("variants") if isinstance(run, dict) else None
+        rows = [item for item in variants if isinstance(item, dict)] if isinstance(variants, list) else []
+        successful = sum(1 for item in rows if item.get("ok") is True)
+        total = len(rows)
+        total_environments += total
+        successful_environments += successful
+        run_summaries.append({
+            "runId": run.get("runId") if isinstance(run, dict) else f"run[{index}]",
+            "totalEnvironments": total,
+            "successfulEnvironments": successful,
+            "ok": total >= target and successful >= minimum_successful,
+        })
+    return {
+        "ok": bool(run_summaries) and all(item["ok"] for item in run_summaries),
+        "targetEnvironments": target,
+        "minimumSuccessRate": simulator_harness.RUN_SCALE_VALIDATION_TARGET_SUCCESS_RATE,
+        "minimumSuccessfulEnvironments": minimum_successful,
+        "totalEnvironments": total_environments,
+        "successfulEnvironments": successful_environments,
+        "failedEnvironments": total_environments - successful_environments,
+        "repetitions": len(run_summaries),
+        "perRun": run_summaries,
+    }
+
+
 def build_training_report(
     *,
     card: JsonObject,
@@ -732,8 +835,9 @@ def build_training_report(
     changed_top_count = 1 if changed_top else 0
     ranking_diff_count = sum(1 for item in pairwise if item.get("winner") and item["winner"] not in incumbent_ids)
     warnings = build_report_warnings(results, simulator_runs)
+    scale_validation = build_scale_validation_summary(simulator_runs, config)
 
-    return {
+    report = {
         "type": REPORT_TYPE,
         "schemaVersion": SCHEMA_VERSION,
         "reportId": report_id,
@@ -798,6 +902,9 @@ def build_training_report(
         "kpiSummary": build_kpi_summary(scored_results),
         "warnings": warnings,
     }
+    if scale_validation is not None:
+        report["scaleValidation"] = scale_validation
+    return report
 
 
 def collect_variant_runs(
@@ -1715,7 +1822,7 @@ def write_json_atomic(path: Path, payload: Any) -> None:
 
 
 def build_generation_summary(report: JsonObject) -> JsonObject:
-    return {
+    summary = {
         "ok": True,
         "type": SUMMARY_TYPE,
         "schemaVersion": SCHEMA_VERSION,
@@ -1730,6 +1837,9 @@ def build_generation_summary(report: JsonObject) -> JsonObject:
         "changedTopCount": report["changedTopCount"],
         "warnings": report["warnings"],
     }
+    if "scaleValidation" in report:
+        summary["scaleValidation"] = report["scaleValidation"]
+    return summary
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import hashlib
 import json
 import math
@@ -328,7 +329,7 @@ def expand_scale_environment_strategy_variants(
         expanded.append(
             StrategyVariant(
                 id=variant_id,
-                parameters=dict(base.parameters),
+                parameters=copy.deepcopy(base.parameters),
                 family=base.family,
                 rollout_status=base.rollout_status,
                 source=base.source,
@@ -784,8 +785,12 @@ def build_scale_validation_summary(
     for index, run in enumerate(simulator_runs):
         variants = run.get("variants") if isinstance(run, dict) else None
         rows = [item for item in variants if isinstance(item, dict)] if isinstance(variants, list) else []
-        successful = sum(1 for item in rows if item.get("ok") is True)
-        total = len(rows)
+        env_success: dict[str, bool] = {}
+        for item in rows:
+            environment_id = scale_validation_environment_id(item)
+            env_success[environment_id] = env_success.get(environment_id, False) or item.get("ok") is True
+        successful = sum(1 for ok in env_success.values() if ok)
+        total = len(env_success)
         total_environments += total
         successful_environments += successful
         run_summaries.append({
@@ -805,6 +810,61 @@ def build_scale_validation_summary(
         "repetitions": len(run_summaries),
         "perRun": run_summaries,
     }
+
+
+def scale_validation_environment_id(variant: JsonObject) -> str:
+    """Return a stable per-run environment id for scale-proof row counting."""
+    for key in ("environmentId", "envId", "environment", "slot"):
+        if key in variant and usable_environment_id_value(variant[key]):
+            return f"{key}:{stable_identity_text(variant[key])}"
+
+    for container in scale_validation_environment_containers(variant):
+        for key in (
+            "environmentId",
+            "envId",
+            "environment",
+            "slot",
+            "environmentIndex",
+            "environment_index",
+            "index",
+        ):
+            if key in container and usable_environment_id_value(container[key]):
+                return f"{key}:{stable_identity_text(container[key])}"
+
+    for key in ("variant_id", "variantId", "id"):
+        value = variant.get(key)
+        if isinstance(value, str) and value:
+            return f"{key}:{value}"
+
+    return "row:" + stable_identity_text(variant)
+
+
+def usable_environment_id_value(value: Any) -> bool:
+    return value is not None and not (isinstance(value, str) and not value)
+
+
+def scale_validation_environment_containers(variant: JsonObject) -> list[JsonObject]:
+    containers: list[JsonObject] = []
+    for key in ("scaleEnvironment", "scale_environment"):
+        value = variant.get(key)
+        if isinstance(value, dict):
+            containers.append(value)
+    for key in ("strategyVariant", "strategy_variant"):
+        value = variant.get(key)
+        if not isinstance(value, dict):
+            continue
+        for nested_key in ("scaleEnvironment", "scale_environment"):
+            nested = value.get(nested_key)
+            if isinstance(nested, dict):
+                containers.append(nested)
+    return containers
+
+
+def stable_identity_text(value: Any) -> str:
+    try:
+        return canonical_hash(value)
+    except (TypeError, ValueError):
+        return hashlib.sha256(repr(value).encode("utf-8")).hexdigest()
 
 
 def build_training_report(

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -2,9 +2,10 @@
 """Run bounded Screeps RL training on a Tencent Cloud ASG batch worker.
 
 This controller-side tool keeps the ASG at desired=0 by default, scales one
-worker for a single offline/private training job, copies a redacted repo bundle
-and local STEAM_KEY env file over SSH, collects artifacts, and always attempts to
-scale the ASG back to zero.
+worker for offline/private training, copies a redacted repo bundle and local
+STEAM_KEY env file over SSH, collects artifacts, and always attempts to scale
+the ASG back to zero. Multi-worker RL scale proof requests are bounded to
+multiple concurrent simulator environments on that single paid ASG worker.
 
 No secret values are printed or persisted in controller summaries.
 """
@@ -14,6 +15,7 @@ import argparse
 import base64
 import datetime as dt
 import json
+import math
 import os
 import re
 import shlex
@@ -39,6 +41,8 @@ DEFAULT_CONTROLLER_IP = "43.128.104.34/32"
 DEFAULT_WORKER_USER = "screeps-batch"
 DEFAULT_REMOTE_BASE = "/opt/screeps-batch/jobs"
 DEFAULT_ARTIFACT_ROOT = Path("runtime-artifacts/tencent-cloud/batch-runs")
+MAX_SCALE_PROOF_WORKERS = 16
+SCALE_PROOF_SUCCESS_RATE = 0.8
 RUN_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]{2,80}$")
 SSH_CONNECT_OPTIONS = (
     "-o", "BatchMode=yes",
@@ -244,6 +248,9 @@ class Controller:
     def experiment_card_path(self) -> Path:
         return self.artifact_dir / "experiment_card.json"
 
+    def scale_proof_spec_path(self) -> Path:
+        return self.artifact_dir / "scale_proof_spec.json"
+
     def run(self) -> None:
         self.artifact_dir.mkdir(parents=True, exist_ok=True)
         validate_static_inputs(self.args, self.run_id)
@@ -351,6 +358,7 @@ class Controller:
         # Apply bounded-run overrides after generation; keep schema-valid fields.
         payload = json.loads(card.read_text(encoding="utf-8"))
         simulation = payload.setdefault("simulation", {})
+        scale_environments = resolve_scale_environment_count(self.args)
         simulation.update({
             "ticks": self.args.ticks,
             "workers": self.args.workers,
@@ -364,6 +372,12 @@ class Controller:
             # .git, so git check-ignore cannot prove safety there.
             "simulator_out_dir": f"{self.remote_dir}/simulator-artifacts",
         })
+        if scale_environments is not None:
+            simulation.update({
+                "scale_environments": scale_environments,
+                "min_concurrent_environments": scale_environments,
+                "scale_proof_mode": "single_tencent_asg_worker_multi_environment",
+            })
         if self.args.variant:
             payload["strategy_variants"] = self.args.variant
         payload["run_id"] = self.run_id
@@ -374,6 +388,36 @@ class Controller:
             timeout=60,
         )
         self.result["experimentCard"] = {"path": str(card), "createdAt": created_at, "cardId": payload.get("card_id")}
+        if scale_environments is not None:
+            self.write_scale_proof_spec(scale_environments=scale_environments, experiment_card=payload)
+
+    def write_scale_proof_spec(self, *, scale_environments: int, experiment_card: dict[str, Any]) -> None:
+        started = time.time()
+        spec_path = self.scale_proof_spec_path()
+        spec = build_scale_proof_spec(
+            args=self.args,
+            run_id=self.run_id,
+            artifact_dir=self.artifact_dir,
+            experiment_card_path=self.experiment_card_path(),
+            scale_environments=scale_environments,
+            experiment_card=experiment_card,
+        )
+        spec_path.write_text(canonical_json(spec), encoding="utf-8")
+        self.result["scaleProofSpec"] = {
+            "path": str(spec_path),
+            "mode": spec["scaleProof"]["mode"],
+            "requestedWorkers": self.args.workers,
+            "scaleEnvironments": scale_environments,
+            "minimumSuccessfulEnvironments": spec["scaleProof"]["successCriteria"]["minimumSuccessfulEnvironments"],
+        }
+        self.record_step(
+            "write_scale_proof_spec",
+            started,
+            True,
+            path=str(spec_path),
+            workers=self.args.workers,
+            scaleEnvironments=scale_environments,
+        )
 
     def describe_asg_instances(self) -> list[dict[str, Any]]:
         filters = json.dumps([{"Name": "auto-scaling-group-id", "Values": [self.args.asg_id]}])
@@ -574,8 +618,10 @@ print(json.dumps({
   'changedTopCount': d.get('changedTopCount'),
   'warnings': d.get('warnings'),
   'simulation': d.get('simulation'),
+  'scaleValidation': d.get('scaleValidation'),
   'liveEffect': d.get('liveEffect'),
   'officialMmoWrites': d.get('officialMmoWrites'),
+  'officialMmoWritesAllowed': d.get('officialMmoWritesAllowed'),
 }, indent=2, sort_keys=True))
 PY
 """.strip()
@@ -640,6 +686,10 @@ tar -czf remote-artifacts.tar.gz \
         artifact_count = data.get("artifactCount")
         if not isinstance(artifact_count, int) or artifact_count <= 0:
             raise BatchRunError(f"remote training artifactCount invalid: {artifact_count!r}")
+        scale_environments = resolve_scale_environment_count(self.args)
+        scale_validation = data.get("scaleValidation")
+        if scale_environments is not None:
+            validate_scale_proof_result(scale_validation, scale_environments)
         self.result["trainingReport"] = {
             "path": str(report),
             "reportId": data.get("reportId"),
@@ -649,6 +699,7 @@ tar -czf remote-artifacts.tar.gz \
             "ranking": data.get("ranking"),
             "warnings": data.get("warnings"),
             "simulation": data.get("simulation"),
+            "scaleValidation": scale_validation,
         }
 
     def describe_asg_group_summary(self) -> dict[str, Any]:
@@ -1064,6 +1115,90 @@ def bash_lc(script: str) -> str:
     return "bash -lc " + shlex.quote(f"printf %s {shlex.quote(encoded)} | base64 -d | bash")
 
 
+def resolve_scale_environment_count(args: argparse.Namespace) -> int | None:
+    explicit = getattr(args, "scale_environments", None)
+    if explicit is not None:
+        return explicit
+    workers = getattr(args, "workers", 1)
+    return workers if workers > 1 else None
+
+
+def minimum_successful_environments(environment_count: int) -> int:
+    return math.ceil(environment_count * SCALE_PROOF_SUCCESS_RATE)
+
+
+def build_scale_proof_spec(
+    *,
+    args: argparse.Namespace,
+    run_id: str,
+    artifact_dir: Path,
+    experiment_card_path: Path,
+    scale_environments: int,
+    experiment_card: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "type": "screeps-tencent-batch-rl-scale-proof-spec",
+        "schemaVersion": 1,
+        "runId": run_id,
+        "artifactDir": str(artifact_dir),
+        "experimentCardPath": str(experiment_card_path),
+        "experimentCard": {
+            "cardId": experiment_card.get("card_id"),
+            "status": experiment_card.get("status"),
+            "safety": experiment_card.get("safety"),
+        },
+        "scaleProof": {
+            "mode": "single_tencent_asg_worker_multi_environment",
+            "requestedWorkers": args.workers,
+            "scaleEnvironments": scale_environments,
+            "minConcurrentEnvironments": scale_environments,
+            "successCriteria": {
+                "minimumSuccessRate": SCALE_PROOF_SUCCESS_RATE,
+                "minimumSuccessfulEnvironments": minimum_successful_environments(scale_environments),
+            },
+            "remoteRunnerContract": {
+                "trainingRunner": "scripts/screeps_rl_training_runner.py",
+                "simulatorHarness": "scripts/screeps_rl_simulator_harness.py",
+                "cardSimulationFields": {
+                    "workers": args.workers,
+                    "scale_environments": scale_environments,
+                    "min_concurrent_environments": scale_environments,
+                },
+            },
+        },
+        "asg": {
+            "autoScalingGroupId": args.asg_id,
+            "desiredCapacityDuringRun": 1,
+            "cleanupDesiredCapacity": 0,
+        },
+        "safety": {
+            "status": "shadow",
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+            "billingGuardBeforeScale": True,
+            "sshControllerOnlyExpected": args.controller_ip,
+            "secretsPrinted": False,
+        },
+    }
+
+
+def validate_scale_proof_result(raw: Any, expected_environments: int) -> None:
+    if not isinstance(raw, dict):
+        raise BatchRunError("remote training report missing scaleValidation for multi-worker proof")
+    total = raw.get("totalEnvironments")
+    successful = raw.get("successfulEnvironments")
+    minimum = raw.get("minimumSuccessfulEnvironments")
+    if not isinstance(total, int) or total < expected_environments:
+        raise BatchRunError(f"scale proof environment count invalid: {total!r} < {expected_environments}")
+    if not isinstance(minimum, int):
+        minimum = minimum_successful_environments(expected_environments)
+    if not isinstance(successful, int) or successful < minimum:
+        raise BatchRunError(f"scale proof success count invalid: {successful!r} < {minimum}")
+    if raw.get("ok") is not True:
+        raise BatchRunError("scale proof did not satisfy success criteria")
+
+
 def validate_static_inputs(args: argparse.Namespace, run_id: str) -> None:
     if not RUN_ID_RE.fullmatch(run_id):
         raise BatchRunError("run id must be lowercase and contain only letters, numbers, dot, underscore, hyphen")
@@ -1076,8 +1211,14 @@ def validate_static_inputs(args: argparse.Namespace, run_id: str) -> None:
         path = Path(path_text)
         if not path.exists():
             raise BatchRunError(f"{path_label} path does not exist: {path}")
-    if args.workers != 1:
-        raise BatchRunError("this bounded validation runner only supports --workers 1")
+    if args.workers < 1 or args.workers > MAX_SCALE_PROOF_WORKERS:
+        raise BatchRunError(f"workers must be between 1 and {MAX_SCALE_PROOF_WORKERS}")
+    scale_environments = resolve_scale_environment_count(args)
+    if scale_environments is not None:
+        if scale_environments < 1 or scale_environments > MAX_SCALE_PROOF_WORKERS:
+            raise BatchRunError(f"scale environments must be between 1 and {MAX_SCALE_PROOF_WORKERS}")
+        if args.workers < scale_environments:
+            raise BatchRunError("workers must be at least scale environments for concurrent scale proof")
     if args.repetitions < 1 or args.ticks < 1:
         raise BatchRunError("ticks and repetitions must be positive")
     if not args.controller_ip.endswith("/32"):
@@ -1141,7 +1282,7 @@ def create_repo_bundle(package: Path) -> None:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Run a bounded Screeps RL training job on one Tencent ASG worker.")
+    parser = argparse.ArgumentParser(description="Run bounded Screeps RL training on one Tencent ASG worker.")
     parser.add_argument("command", choices=("run-single", "preflight"))
     parser.add_argument("--run-id", default=default_run_id())
     parser.add_argument("--region", default=DEFAULT_REGION)
@@ -1158,6 +1299,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--training-approach", default="bandit", choices=("bandit", "evolutionary", "policy_gradient"))
     parser.add_argument("--ticks", type=int, default=50)
     parser.add_argument("--workers", type=int, default=1)
+    parser.add_argument(
+        "--scale-environments",
+        type=int,
+        default=None,
+        help="Unique concurrent simulator environment rows for scale proof. Defaults to --workers when --workers > 1.",
+    )
     parser.add_argument("--repetitions", type=int, default=1)
     parser.add_argument("--host-port-start", type=int, default=24125)
     parser.add_argument("--variant", action="append", help="Strategy variant id; repeat to override generated card variants.")

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -1188,11 +1188,15 @@ def validate_scale_proof_result(raw: Any, expected_environments: int) -> None:
         raise BatchRunError("remote training report missing scaleValidation for multi-worker proof")
     total = raw.get("totalEnvironments")
     successful = raw.get("successfulEnvironments")
-    minimum = raw.get("minimumSuccessfulEnvironments")
+    reported_minimum = raw.get("minimumSuccessfulEnvironments")
+    local_minimum = minimum_successful_environments(expected_environments)
     if not isinstance(total, int) or total < expected_environments:
         raise BatchRunError(f"scale proof environment count invalid: {total!r} < {expected_environments}")
-    if not isinstance(minimum, int):
-        minimum = minimum_successful_environments(expected_environments)
+    minimum = (
+        max(local_minimum, reported_minimum)
+        if isinstance(reported_minimum, int)
+        else local_minimum
+    )
     if not isinstance(successful, int) or successful < minimum:
         raise BatchRunError(f"scale proof success count invalid: {successful!r} < {minimum}")
     if raw.get("ok") is not True:

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -1190,14 +1190,22 @@ def validate_scale_proof_result(raw: Any, expected_environments: int) -> None:
     successful = raw.get("successfulEnvironments")
     reported_minimum = raw.get("minimumSuccessfulEnvironments")
     local_minimum = minimum_successful_environments(expected_environments)
-    if not isinstance(total, int) or total < expected_environments:
-        raise BatchRunError(f"scale proof environment count invalid: {total!r} < {expected_environments}")
+    if not isinstance(total, int) or total != expected_environments:
+        raise BatchRunError(
+            f"scale proof environment count invalid: {total!r} must equal {expected_environments}"
+        )
+    if isinstance(reported_minimum, int) and not 0 <= reported_minimum <= total:
+        raise BatchRunError(
+            f"scale proof minimum success count invalid: {reported_minimum!r} outside 0..{total}"
+        )
     minimum = (
         max(local_minimum, reported_minimum)
         if isinstance(reported_minimum, int)
         else local_minimum
     )
-    if not isinstance(successful, int) or successful < minimum:
+    if not isinstance(successful, int) or not 0 <= successful <= total:
+        raise BatchRunError(f"scale proof success count invalid: {successful!r} outside 0..{total}")
+    if successful < minimum:
         raise BatchRunError(f"scale proof success count invalid: {successful!r} < {minimum}")
     if raw.get("ok") is not True:
         raise BatchRunError("scale proof did not satisfy success criteria")

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -916,6 +916,66 @@ export const STRATEGY_REGISTRY = [
             for right_ports in reserved_ports_by_repetition[left_index + 1 :]:
                 self.assertTrue(left_ports.isdisjoint(right_ports))
 
+    def test_scale_environment_expansion_deep_copies_nested_variant_parameters(self) -> None:
+        base = runner.StrategyVariant(
+            id="baseline",
+            parameters={"nested": {"threshold": 1}, "weights": [1, 2]},
+            title="Baseline",
+        )
+
+        expanded = runner.expand_scale_environment_strategy_variants([base], 2)
+        expanded[0].parameters["nested"]["threshold"] = 99
+        expanded[0].parameters["weights"].append(3)
+
+        self.assertEqual([variant.id for variant in expanded], ["baseline.scale-env-01", "baseline.scale-env-02"])
+        self.assertEqual(base.parameters, {"nested": {"threshold": 1}, "weights": [1, 2]})
+        self.assertEqual(expanded[1].parameters, {"nested": {"threshold": 1}, "weights": [1, 2]})
+
+    def test_scale_validation_deduplicates_environment_slots_per_run(self) -> None:
+        card = base_card(["baseline"])
+        card["simulation"]["scale_environments"] = 3
+        config = runner.simulation_config_from_card(card)
+
+        summary = runner.build_scale_validation_summary(
+            [
+                {
+                    "runId": "explicit-env-run",
+                    "variants": [
+                        {"variant_id": "a", "environmentId": "env-a", "ok": False},
+                        {"variant_id": "b", "environmentId": "env-a", "ok": True},
+                        {"variant_id": "c", "environmentId": "env-b", "ok": True},
+                        {"variant_id": "d", "environmentId": "env-c", "ok": True},
+                        {"variant_id": "e", "environmentId": "env-c", "ok": False},
+                    ],
+                },
+                {
+                    "runId": "variant-id-fallback-run",
+                    "variants": [
+                        {"variant_id": "baseline.scale-env-01", "ok": False},
+                        {"variant_id": "baseline.scale-env-01", "ok": True},
+                        {"variant_id": "baseline.scale-env-02", "ok": False},
+                        {"variant_id": "baseline.scale-env-03", "ok": True},
+                        {"variant_id": "baseline.scale-env-03", "ok": False},
+                    ],
+                },
+            ],
+            config,
+        )
+
+        self.assertIsNotNone(summary)
+        assert summary is not None
+        self.assertFalse(summary["ok"])
+        self.assertEqual(summary["totalEnvironments"], 6)
+        self.assertEqual(summary["successfulEnvironments"], 5)
+        self.assertEqual(summary["failedEnvironments"], 1)
+        self.assertEqual(summary["minimumSuccessfulEnvironments"], 3)
+        self.assertEqual(summary["perRun"][0]["totalEnvironments"], 3)
+        self.assertEqual(summary["perRun"][0]["successfulEnvironments"], 3)
+        self.assertTrue(summary["perRun"][0]["ok"])
+        self.assertEqual(summary["perRun"][1]["totalEnvironments"], 3)
+        self.assertEqual(summary["perRun"][1]["successfulEnvironments"], 2)
+        self.assertFalse(summary["perRun"][1]["ok"])
+
     def test_scale_environment_card_expands_variants_and_records_success_threshold(self) -> None:
         expanded_ids = runner.simulator_harness.expand_scale_environment_variants(["baseline", "candidate"], 5)
         start = tick(1, [room("W1N1", energy=100)])

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -1007,6 +1007,37 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(report["scaleValidation"]["successfulEnvironments"], 5)
         self.assertEqual(report["simulation"]["scaleEnvironments"], 5)
 
+    def test_scale_environment_card_preserves_variants_when_scale_count_is_smaller(self) -> None:
+        variant_ids = ["baseline", "candidate", "expansion", "defense", "economy", "remote"]
+        start = tick(1, [room("W1N1", energy=100)])
+        simulator = MockSimulator({
+            variant_id: variant_result(variant_id, [start, tick(2, [room("W1N1", energy=200 + index)])])
+            for index, variant_id in enumerate(variant_ids)
+        })
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            card = base_card(variant_ids)
+            card["simulation"]["workers"] = 5
+            card["simulation"]["scale_environments"] = 5
+            card["simulation"]["min_concurrent_environments"] = 5
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="scale-env-preserves-all-variants",
+                simulator_runner=simulator,
+            )
+
+        self.assertEqual(simulator.calls[0]["variants"], variant_ids)
+        self.assertEqual(simulator.calls[0]["workers"], 5)
+        self.assertEqual([result["variantId"] for result in report["variantResults"]], variant_ids)
+        self.assertEqual({item["variantId"] for item in report["ranking"]}, set(variant_ids))
+        self.assertTrue(report["scaleValidation"]["ok"])
+        self.assertEqual(report["scaleValidation"]["targetEnvironments"], 5)
+        self.assertEqual(report["scaleValidation"]["totalEnvironments"], len(variant_ids))
+
     def test_unsafe_simulator_flags_fail_before_report_is_persisted(self) -> None:
         start = tick(1, [room("W1N1", energy=100)])
         baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200)])])

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -916,6 +916,37 @@ export const STRATEGY_REGISTRY = [
             for right_ports in reserved_ports_by_repetition[left_index + 1 :]:
                 self.assertTrue(left_ports.isdisjoint(right_ports))
 
+    def test_scale_environment_card_expands_variants_and_records_success_threshold(self) -> None:
+        expanded_ids = runner.simulator_harness.expand_scale_environment_variants(["baseline", "candidate"], 5)
+        start = tick(1, [room("W1N1", energy=100)])
+        simulator = MockSimulator({
+            variant_id: variant_result(variant_id, [start, tick(2, [room("W1N1", energy=200)])])
+            for variant_id in expanded_ids
+        })
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            card = base_card()
+            card["simulation"]["workers"] = 5
+            card["simulation"]["scale_environments"] = 5
+            card["simulation"]["min_concurrent_environments"] = 5
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="scale-env-proof",
+                simulator_runner=simulator,
+            )
+
+        self.assertEqual(simulator.calls[0]["variants"], expanded_ids)
+        self.assertEqual(simulator.calls[0]["workers"], 5)
+        self.assertEqual(simulator.calls[0]["min_concurrent_environments"], 5)
+        self.assertTrue(report["scaleValidation"]["ok"])
+        self.assertEqual(report["scaleValidation"]["minimumSuccessfulEnvironments"], 4)
+        self.assertEqual(report["scaleValidation"]["successfulEnvironments"], 5)
+        self.assertEqual(report["simulation"]["scaleEnvironments"], 5)
+
     def test_unsafe_simulator_flags_fail_before_report_is_persisted(self) -> None:
         start = tick(1, [room("W1N1", energy=100)])
         baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200)])])

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -409,6 +409,12 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
 
             data = json.loads(report.read_text(encoding="utf-8"))
             data["scaleValidation"]["ok"] = True
+            data["scaleValidation"]["minimumSuccessfulEnvironments"] = 1
+            report.write_text(json.dumps(data), encoding="utf-8")
+            with self.assertRaisesRegex(runner.BatchRunError, "scale proof success count"):
+                controller.verify_remote_training_report()
+
+            data["scaleValidation"]["ok"] = True
             data["scaleValidation"]["successfulEnvironments"] = 4
             report.write_text(json.dumps(data), encoding="utf-8")
             controller.verify_remote_training_report()

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -44,17 +44,27 @@ def write_tar(path: Path, callback: Callable[[tarfile.TarFile], None]) -> None:
 def controller_args() -> argparse.Namespace:
     return argparse.Namespace(
         asg_id="asg-test",
+        billing_guard="/bin/billing-guard",
         bootstrap_timeout_seconds=1,
         controller_ip=CONTROLLER_IP,
         dataset_run_id="dataset-test",
+        host_port_start=24125,
         preflight_only=False,
         region="ap-singapore",
         remote_base="/opt/screeps-batch/jobs",
         repetitions=1,
         scale_down_timeout_seconds=1,
+        scale_environments=None,
+        scale_timeout_seconds=1,
+        secret_env="/tmp/secret.env",
+        security_group_id="sg-test",
+        ssh_key="/tmp/id_ed25519",
         tccli="/bin/tccli",
         ticks=1,
         training_approach="bandit",
+        training_timeout_seconds=1,
+        transfer_timeout_seconds=1,
+        variant=None,
         worker_user="screeps-batch",
         workers=1,
     )
@@ -74,6 +84,50 @@ def decode_remote_bash_lc(remote_command: str) -> str:
     script_arg = tokens[tokens.index("-lc") + 1]
     script_tokens = shlex.split(script_arg)
     return base64.b64decode(script_tokens[2]).decode("utf-8")
+
+
+def generated_experiment_card() -> dict[str, object]:
+    return {
+        "card_id": "rl-exp-dataset-test-000000000000",
+        "dataset_run_id": "dataset-test",
+        "code_commit": "0" * 40,
+        "created_at": "2026-05-17T00:00:00Z",
+        "status": "shadow",
+        "training_approach": "bandit",
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+        "safety": {
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+            "ood_rejection": True,
+            "conservative_actions_only": True,
+        },
+        "reward_model": {
+            "type": "lexicographic",
+            "component_order": ["reliability", "territory", "resources", "kills"],
+            "component_weights": {
+                "alpha_reliability": 1000000000,
+                "beta_territory": 1000000,
+                "gamma_resources": 1000,
+                "delta_kills": 1,
+            },
+            "scalar_weighted_sum_authorized": False,
+        },
+        "simulation": {
+            "ticks": 50,
+            "workers": 1,
+            "repetitions": 1,
+            "room": "E1S1",
+            "shard": "shardX",
+            "branch": "$activeWorld",
+            "code_path": "prod/dist/main.js",
+            "map_source_file": "maps/map-0b6758af.json",
+            "simulator_out_dir": "runtime-artifacts/rl-simulator",
+        },
+        "strategy_variants": ["construction-priority.incumbent.v1"],
+    }
 
 
 class TencentBatchRlRunnerTest(unittest.TestCase):
@@ -266,6 +320,101 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 },
             )
 
+    def test_static_validation_accepts_bounded_multi_worker_scale_proof(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            args = controller_args()
+            args.tccli = str(root / "tccli")
+            args.billing_guard = str(root / "billing-guard.py")
+            args.ssh_key = str(root / "id_ed25519")
+            args.secret_env = str(root / ".env")
+            args.workers = 5
+            for path in (args.tccli, args.billing_guard, args.ssh_key, args.secret_env):
+                write_text(Path(path))
+
+            runner.validate_static_inputs(args, "run-test")
+
+            args.scale_environments = 6
+            with self.assertRaisesRegex(runner.BatchRunError, "workers must be at least scale environments"):
+                runner.validate_static_inputs(args, "run-test")
+
+            args.scale_environments = None
+            args.workers = runner.MAX_SCALE_PROOF_WORKERS + 1
+            with self.assertRaisesRegex(runner.BatchRunError, "workers must be between"):
+                runner.validate_static_inputs(args, "run-test")
+
+    def test_generate_experiment_card_writes_multi_environment_scale_proof_spec(self) -> None:
+        args = controller_args()
+        args.workers = 5
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=root)
+
+            def fake_run_cp(name: str, cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                if name == "generate_experiment_card":
+                    output = Path(cmd[cmd.index("--output") + 1])
+                    output.write_text(json.dumps(generated_experiment_card()), encoding="utf-8")
+                return subprocess.CompletedProcess(cmd, 0, "{}", "")
+
+            with mock.patch.object(controller, "run_cp", side_effect=fake_run_cp):
+                controller.generate_experiment_card()
+
+            card = json.loads((root / "experiment_card.json").read_text(encoding="utf-8"))
+            spec = json.loads((root / "scale_proof_spec.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(card["status"], "shadow")
+        self.assertFalse(card["liveEffect"])
+        self.assertFalse(card["officialMmoWrites"])
+        self.assertFalse(card["officialMmoWritesAllowed"])
+        self.assertEqual(card["simulation"]["workers"], 5)
+        self.assertEqual(card["simulation"]["scale_environments"], 5)
+        self.assertEqual(card["simulation"]["min_concurrent_environments"], 5)
+        self.assertEqual(spec["scaleProof"]["mode"], "single_tencent_asg_worker_multi_environment")
+        self.assertEqual(spec["scaleProof"]["successCriteria"]["minimumSuccessfulEnvironments"], 4)
+        self.assertEqual(spec["asg"]["desiredCapacityDuringRun"], 1)
+        self.assertEqual(spec["asg"]["cleanupDesiredCapacity"], 0)
+        self.assertTrue(spec["safety"]["billingGuardBeforeScale"])
+        self.assertFalse(spec["safety"]["officialMmoWritesAllowed"])
+        self.assertEqual(controller.steps[-1].name, "write_scale_proof_spec")
+
+    def test_verify_remote_training_report_requires_scale_proof_success_for_workers_five(self) -> None:
+        args = controller_args()
+        args.workers = 5
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            report = runner.remote_training_report_path(root, "run-test")
+            report.parent.mkdir(parents=True, exist_ok=True)
+            report.write_text(
+                json.dumps(
+                    {
+                        "reportId": "run-test",
+                        "liveEffect": False,
+                        "officialMmoWrites": False,
+                        "officialMmoWritesAllowed": False,
+                        "artifactCount": 5,
+                        "scaleValidation": {
+                            "ok": False,
+                            "totalEnvironments": 5,
+                            "successfulEnvironments": 3,
+                            "minimumSuccessfulEnvironments": 4,
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=root)
+
+            with self.assertRaisesRegex(runner.BatchRunError, "scale proof success count"):
+                controller.verify_remote_training_report()
+
+            data = json.loads(report.read_text(encoding="utf-8"))
+            data["scaleValidation"]["ok"] = True
+            data["scaleValidation"]["successfulEnvironments"] = 4
+            report.write_text(json.dumps(data), encoding="utf-8")
+            controller.verify_remote_training_report()
+
+        self.assertEqual(controller.result["trainingReport"]["scaleValidation"]["successfulEnvironments"], 4)
+
     def test_safe_extract_tar_rejects_traversal_and_special_entries(self) -> None:
         cases = [
             ("../escape", lambda tar: add_file(tar, "../escape")),
@@ -434,6 +583,59 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertIn("scale_down timeout", controller.result["scaleDownError"])
         self.assertEqual(summary["steps"][-1]["name"], "scale_down")
         self.assertFalse(summary["steps"][-1]["ok"])
+
+    def test_controller_run_scales_down_after_multi_worker_training_failure(self) -> None:
+        class FakeController(runner.Controller):
+            def ensure_map_present(self) -> None:
+                pass
+
+            def ensure_dist_present(self) -> None:
+                pass
+
+            def run_billing_guard(self) -> None:
+                pass
+
+            def verify_security_group(self) -> None:
+                pass
+
+            def generate_experiment_card(self) -> None:
+                pass
+
+            def scale_up_and_wait(self) -> None:
+                self.scaled_up = True
+
+            def verify_worker_security(self) -> None:
+                pass
+
+            def bootstrap_worker(self) -> None:
+                pass
+
+            def transfer_repo_bundle(self) -> None:
+                pass
+
+            def transfer_secret_env(self) -> None:
+                pass
+
+            def run_remote_training(self) -> None:
+                raise runner.BatchRunError("training failed")
+
+            def scale_down(self) -> None:
+                self.record_step("scale_down", 100.0, True, desiredCapacity=0)
+
+        args = controller_args()
+        args.workers = 5
+        with tempfile.TemporaryDirectory() as temp_dir:
+            controller = FakeController(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
+            with mock.patch.object(runner, "validate_static_inputs", return_value=None):
+                with self.assertRaisesRegex(runner.BatchRunError, "training failed"):
+                    controller.run()
+            summary = json.loads((Path(temp_dir) / "controller-summary.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(controller.final_status, "failed")
+        self.assertEqual(summary["finalStatus"], "failed")
+        self.assertTrue(summary["safety"]["scaleDownAttempted"])
+        self.assertEqual(summary["steps"][-1]["name"], "scale_down")
+        self.assertEqual(summary["steps"][-1]["detail"]["desiredCapacity"], 0)
 
     def test_main_exits_nonzero_when_controller_cleanup_failed(self) -> None:
         class FakeController:

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -421,6 +421,43 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
 
         self.assertEqual(controller.result["trainingReport"]["scaleValidation"]["successfulEnvironments"], 4)
 
+    def test_scale_proof_result_rejects_malformed_remote_counts(self) -> None:
+        valid = {
+            "ok": True,
+            "totalEnvironments": 5,
+            "successfulEnvironments": 4,
+            "minimumSuccessfulEnvironments": 4,
+        }
+        runner.validate_scale_proof_result(valid, 5)
+
+        cases = [
+            (
+                "inflated-total",
+                {"totalEnvironments": 9, "successfulEnvironments": 9},
+                "scale proof environment count",
+            ),
+            (
+                "successes-above-total",
+                {"successfulEnvironments": 6},
+                "scale proof success count",
+            ),
+            (
+                "minimum-above-total",
+                {"minimumSuccessfulEnvironments": 6},
+                "scale proof minimum success count",
+            ),
+            (
+                "minimum-below-zero",
+                {"minimumSuccessfulEnvironments": -1},
+                "scale proof minimum success count",
+            ),
+        ]
+        for name, updates, pattern in cases:
+            with self.subTest(name=name):
+                malformed = {**valid, **updates}
+                with self.assertRaisesRegex(runner.BatchRunError, pattern):
+                    runner.validate_scale_proof_result(malformed, 5)
+
     def test_safe_extract_tar_rejects_traversal_and_special_entries(self) -> None:
         cases = [
             ("../escape", lambda tar: add_file(tar, "../escape")),


### PR DESCRIPTION
Closes #1156.

Unblocks #1033 by extending the Tencent batch RL runner path toward the required 5+ concurrent-environment scale proof.

## Summary
- Extends the Tencent batch runner / training runner integration for multi-worker scale-proof support.
- Adds regression coverage for the batch runner and training-runner experiment-card path.
- Keeps the work offline/private/shadow only; no official MMO writes or learned-policy rollout.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_training_runner.py scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_rl_training_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m pytest scripts/test_screeps_tencent_batch_rl_runner.py scripts/test_screeps_rl_training_runner.py -q` (53 passed / 18 subtests passed)

## Safety
- No secrets printed or committed.
- No cloud scale-up executed by this PR.
- No official MMO deploy or live policy control.
