### PR TITLE
feat(rl): add policy-gradient experiment cards

### DIFF
--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -33,8 +33,74 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_SIMULATION_CODE_PATH = REPO_ROOT / "prod" / "dist" / "main.js"
 DEFAULT_SIMULATION_MAP_SOURCE_FILE = REPO_ROOT / "maps" / "map-0b6758af.json"
 DEFAULT_SIMULATION_OUT_DIR = REPO_ROOT / "runtime-artifacts" / "rl-simulator"
+DEFAULT_STRATEGY_REGISTRY_PATH = REPO_ROOT / "prod" / "src" / "strategy" / "strategyRegistry.ts"
+DEFAULT_SIMULATION_TICKS = 50
+DEFAULT_SIMULATION_REPETITIONS = 1
+DEFAULT_SIMULATION_WORKERS = 1
+POLICY_GRADIENT_SIMULATION_TICKS = 100
+POLICY_GRADIENT_SIMULATION_REPETITIONS = 5
 
 JsonObject = dict[str, Any]
+
+CONSTRUCTION_PRIORITY_FAMILY = "construction-priority"
+CONSTRUCTION_PRIORITY_REGISTRY_IDS = (
+    "construction-priority.incumbent.v1",
+    "construction-priority.territory-shadow.v1",
+)
+CONSTRUCTION_PRIORITY_KNOBS: tuple[JsonObject, ...] = (
+    {
+        "name": "baseScoreWeight",
+        "min": 0,
+        "max": 3,
+        "step": 0.1,
+        "description": "Weight applied to the already-emitted incumbent construction score.",
+    },
+    {
+        "name": "territorySignalWeight",
+        "min": 0,
+        "max": 30,
+        "step": 1,
+        "description": "Weight for territory-first expected KPI signals.",
+    },
+    {
+        "name": "resourceSignalWeight",
+        "min": 0,
+        "max": 30,
+        "step": 1,
+        "description": "Weight for resource-scaling expected KPI signals.",
+    },
+    {
+        "name": "killSignalWeight",
+        "min": 0,
+        "max": 30,
+        "step": 1,
+        "description": "Weight for enemy-kill or defense-posture signals.",
+    },
+    {
+        "name": "riskPenalty",
+        "min": 0,
+        "max": 30,
+        "step": 1,
+        "description": "Penalty per visible risk or blocking precondition.",
+    },
+)
+CONSTRUCTION_PRIORITY_KNOB_NAMES = tuple(str(knob["name"]) for knob in CONSTRUCTION_PRIORITY_KNOBS)
+CONSTRUCTION_PRIORITY_FALLBACK_DEFAULTS: dict[str, JsonObject] = {
+    "construction-priority.incumbent.v1": {
+        "baseScoreWeight": 1,
+        "territorySignalWeight": 6,
+        "resourceSignalWeight": 4,
+        "killSignalWeight": 6,
+        "riskPenalty": 4,
+    },
+    "construction-priority.territory-shadow.v1": {
+        "baseScoreWeight": 1,
+        "territorySignalWeight": 22,
+        "resourceSignalWeight": 3,
+        "killSignalWeight": 5,
+        "riskPenalty": 4,
+    },
+}
 
 
 class CardValidationError(ValueError):
@@ -105,17 +171,22 @@ def safety_block() -> JsonObject:
     }
 
 
-def simulation_block() -> JsonObject:
+def simulation_block(
+    *,
+    ticks: int = DEFAULT_SIMULATION_TICKS,
+    workers: int = DEFAULT_SIMULATION_WORKERS,
+    repetitions: int = DEFAULT_SIMULATION_REPETITIONS,
+) -> JsonObject:
     return {
         "branch": "$activeWorld",
         "code_path": str(DEFAULT_SIMULATION_CODE_PATH),
         "map_source_file": str(DEFAULT_SIMULATION_MAP_SOURCE_FILE),
-        "repetitions": 1,
+        "repetitions": repetitions,
         "room": "E1S1",
         "shard": "shardX",
         "simulator_out_dir": str(DEFAULT_SIMULATION_OUT_DIR),
-        "ticks": 50,
-        "workers": 1,
+        "ticks": ticks,
+        "workers": workers,
     }
 
 
@@ -125,12 +196,32 @@ def build_card(
     code_commit: str,
     training_approach: str,
     created_at: str,
+    simulation_ticks: int | None = None,
+    simulation_repetitions: int | None = None,
+    simulation_workers: int | None = None,
+    registry_path: Path | None = None,
 ) -> JsonObject:
     validate_dataset_run_id(dataset_run_id)
     validate_code_commit(code_commit)
     validate_created_at(created_at)
     if training_approach not in TRAINING_APPROACHES:
         raise CardValidationError(f"training_approach must be one of: {', '.join(TRAINING_APPROACHES)}")
+
+    default_ticks = POLICY_GRADIENT_SIMULATION_TICKS if training_approach == "policy_gradient" else DEFAULT_SIMULATION_TICKS
+    default_repetitions = (
+        POLICY_GRADIENT_SIMULATION_REPETITIONS
+        if training_approach == "policy_gradient"
+        else DEFAULT_SIMULATION_REPETITIONS
+    )
+    ticks = require_positive_int(simulation_ticks if simulation_ticks is not None else default_ticks, "simulation.ticks")
+    repetitions = require_positive_int(
+        simulation_repetitions if simulation_repetitions is not None else default_repetitions,
+        "simulation.repetitions",
+    )
+    workers = require_positive_int(
+        simulation_workers if simulation_workers is not None else DEFAULT_SIMULATION_WORKERS,
+        "simulation.workers",
+    )
 
     commit_prefix = code_commit[:12].lower()
     card = {
@@ -145,13 +236,241 @@ def build_card(
         "ood_rejection": True,
         "reward_model": reward_model(),
         "safety": safety_block(),
-        "simulation": simulation_block(),
+        "simulation": simulation_block(ticks=ticks, workers=workers, repetitions=repetitions),
         "status": "shadow",
         "strategy_variants": list(DEFAULT_STRATEGY_VARIANTS),
         "training_approach": training_approach,
     }
+    if training_approach == "policy_gradient":
+        policy_gradient = policy_gradient_block(registry_path or DEFAULT_STRATEGY_REGISTRY_PATH)
+        card["policy_gradient"] = policy_gradient
+        card["strategy_variants"] = policy_gradient_strategy_variants(policy_gradient)
     validate_card(card)
     return card
+
+
+def require_positive_int(value: Any, label: str) -> int:
+    parsed = positive_int(value)
+    if parsed is None:
+        raise CardValidationError(f"{label} must be a positive integer")
+    return parsed
+
+
+def repo_relative(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def policy_gradient_block(registry_path: Path) -> JsonObject:
+    candidates = policy_gradient_candidate_vectors(registry_path)
+    return {
+        "type": "construction-priority-policy-gradient-card",
+        "target_family": CONSTRUCTION_PRIORITY_FAMILY,
+        "candidate_policy_id_field": "candidatePolicyId",
+        "source_registry": repo_relative(registry_path),
+        "owning_issues": ["#1032", "#879", "#924"],
+        "learnable_parameters": construction_priority_learnable_parameters(registry_path),
+        "candidate_parameter_vectors": candidates,
+        "runner_support": {
+            "inline_candidates_applied_to_simulator": False,
+            "simulator_variant_transport": "variant_ids_only",
+            "report_preserves_candidate_parameters": True,
+            "candidate_policy_id_preserved": True,
+            "limitation": (
+                "scripts/screeps_rl_training_runner.py currently sends simulator variants by id only; "
+                "inline policy-gradient parameter vectors are preserved in card/report artifacts as offline evidence."
+            ),
+        },
+        "safety": safety_block(),
+    }
+
+
+def construction_priority_learnable_parameters(registry_path: Path) -> list[JsonObject]:
+    registry_source = repo_relative(registry_path)
+    return [
+        {
+            **dict(knob),
+            "source": f"{registry_source} knobBounds",
+            "family": CONSTRUCTION_PRIORITY_FAMILY,
+        }
+        for knob in CONSTRUCTION_PRIORITY_KNOBS
+    ]
+
+
+def policy_gradient_strategy_variants(policy_gradient: JsonObject) -> list[JsonObject]:
+    candidates = policy_gradient.get("candidate_parameter_vectors")
+    if not isinstance(candidates, list):
+        return []
+    variants: list[JsonObject] = []
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            continue
+        strategy_variant_id = candidate.get("strategyVariantId")
+        if not isinstance(strategy_variant_id, str):
+            continue
+        variants.append(
+            {
+                "id": strategy_variant_id,
+                "candidatePolicyId": candidate.get("candidatePolicyId"),
+                "sourceStrategyId": candidate.get("sourceStrategyId"),
+                "family": candidate.get("family"),
+                "rolloutStatus": candidate.get("rolloutStatus"),
+                "title": candidate.get("title"),
+                "trainingRole": "policy_gradient_candidate",
+                "parameters": candidate.get("parameters"),
+                "parameterEvidence": candidate.get("parameterEvidence"),
+            }
+        )
+    return variants
+
+
+def policy_gradient_candidate_vectors(registry_path: Path) -> list[JsonObject]:
+    registry_defaults = construction_priority_registry_defaults(registry_path)
+    incumbent_id = "construction-priority.incumbent.v1"
+    territory_id = "construction-priority.territory-shadow.v1"
+    incumbent = registry_defaults[incumbent_id]
+    territory = registry_defaults[territory_id]
+    candidates = [
+        policy_gradient_candidate(
+            candidate_policy_id="construction-priority.pg.incumbent-seed.v1",
+            source_strategy_id=incumbent_id,
+            rollout_status="incumbent",
+            title="Policy-gradient incumbent construction-priority seed",
+            parameters=incumbent,
+            derivation="registry defaultValues seed",
+            registry_path=registry_path,
+        ),
+        policy_gradient_candidate(
+            candidate_policy_id="construction-priority.pg.territory-seed.v1",
+            source_strategy_id=territory_id,
+            rollout_status="shadow",
+            title="Policy-gradient territory construction-priority seed",
+            parameters=territory,
+            derivation="registry defaultValues seed",
+            registry_path=registry_path,
+        ),
+        policy_gradient_candidate(
+            candidate_policy_id="construction-priority.pg.resource-seed.v1",
+            source_strategy_id=incumbent_id,
+            rollout_status="shadow",
+            title="Policy-gradient resource construction-priority seed",
+            parameters=bounded_construction_priority_parameters(
+                {
+                    **incumbent,
+                    "territorySignalWeight": 10,
+                    "resourceSignalWeight": 18,
+                    "killSignalWeight": 4,
+                    "riskPenalty": 4,
+                }
+            ),
+            derivation="bounded registry-knob perturbation from incumbent defaultValues",
+            registry_path=registry_path,
+        ),
+        policy_gradient_candidate(
+            candidate_policy_id="construction-priority.pg.risk-aware-seed.v1",
+            source_strategy_id=territory_id,
+            rollout_status="shadow",
+            title="Policy-gradient risk-aware construction-priority seed",
+            parameters=bounded_construction_priority_parameters(
+                {
+                    **territory,
+                    "territorySignalWeight": 18,
+                    "resourceSignalWeight": 5,
+                    "killSignalWeight": 6,
+                    "riskPenalty": 10,
+                }
+            ),
+            derivation="bounded registry-knob perturbation from territory-shadow defaultValues",
+            registry_path=registry_path,
+        ),
+    ]
+    return candidates
+
+
+def policy_gradient_candidate(
+    *,
+    candidate_policy_id: str,
+    source_strategy_id: str,
+    rollout_status: str,
+    title: str,
+    parameters: JsonObject,
+    derivation: str,
+    registry_path: Path,
+) -> JsonObject:
+    parameter_vector = bounded_construction_priority_parameters(parameters)
+    return {
+        "candidatePolicyId": candidate_policy_id,
+        "strategyVariantId": candidate_policy_id,
+        "sourceStrategyId": source_strategy_id,
+        "family": CONSTRUCTION_PRIORITY_FAMILY,
+        "rolloutStatus": rollout_status,
+        "title": title,
+        "parameters": parameter_vector,
+        "parameterEvidence": {
+            "sourceRegistry": repo_relative(registry_path),
+            "sourceStrategyId": source_strategy_id,
+            "learnableKnobs": list(CONSTRUCTION_PRIORITY_KNOB_NAMES),
+            "derivation": derivation,
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+        },
+    }
+
+
+def construction_priority_registry_defaults(registry_path: Path) -> dict[str, JsonObject]:
+    defaults = {
+        variant_id: dict(parameters)
+        for variant_id, parameters in CONSTRUCTION_PRIORITY_FALLBACK_DEFAULTS.items()
+    }
+    try:
+        import screeps_rl_training_runner as training_runner
+
+        registry = training_runner.load_strategy_registry(registry_path)
+    except Exception:
+        return defaults
+    for variant_id in CONSTRUCTION_PRIORITY_REGISTRY_IDS:
+        variant = registry.get(variant_id)
+        if variant is None:
+            continue
+        parameters = construction_priority_parameters_or_none(variant.parameters)
+        if parameters is not None:
+            defaults[variant_id] = parameters
+    return defaults
+
+
+def construction_priority_parameters_or_none(raw: Any) -> JsonObject | None:
+    if not isinstance(raw, dict):
+        return None
+    parameters: JsonObject = {}
+    for knob in CONSTRUCTION_PRIORITY_KNOB_NAMES:
+        value = raw.get(knob)
+        if not is_finite_number(value):
+            return None
+        parameters[knob] = value
+    return bounded_construction_priority_parameters(parameters)
+
+
+def bounded_construction_priority_parameters(raw: JsonObject) -> JsonObject:
+    bounded: JsonObject = {}
+    for knob in CONSTRUCTION_PRIORITY_KNOBS:
+        name = str(knob["name"])
+        value = raw.get(name)
+        if not is_finite_number(value):
+            raise CardValidationError(f"construction-priority parameter {name} must be a finite number")
+        minimum = float(knob["min"])
+        maximum = float(knob["max"])
+        numeric = float(value)
+        if numeric < minimum or numeric > maximum:
+            raise CardValidationError(f"construction-priority parameter {name} must be within registry knob bounds")
+        bounded[name] = int(numeric) if numeric.is_integer() else numeric
+    return bounded
+
+
+def is_finite_number(value: Any) -> bool:
+    return not isinstance(value, bool) and isinstance(value, (int, float)) and math.isfinite(float(value))
 
 
 def load_json(path: Path) -> Any:
@@ -203,6 +522,11 @@ def validate_card(raw: Any) -> None:
     validate_reward_model(raw.get("reward_model"))
     validate_strategy_variants(first_present(raw, ("strategy_variants", "strategyVariants", "variants")))
     validate_simulation(first_present(raw, ("simulation", "simulator")))
+    policy_gradient = first_present(raw, ("policy_gradient", "policyGradient"))
+    if training_approach == "policy_gradient" and policy_gradient is None:
+        raise CardValidationError("policy_gradient metadata is required when training_approach is policy_gradient")
+    if policy_gradient is not None:
+        validate_policy_gradient(policy_gradient)
 
 
 def require_string(raw: JsonObject, field: str) -> str:
@@ -226,6 +550,8 @@ def validate_safety(raw: JsonObject) -> None:
     for field in SAFETY_TRUE_FIELDS:
         if safety.get(field) is not True:
             raise CardValidationError(f"safety.{field} must be true")
+        if field in raw and raw[field] is not True:
+            raise CardValidationError(f"{field} must be true when present")
 
 
 def validate_reward_model(raw: Any) -> None:
@@ -271,6 +597,81 @@ def validate_strategy_variants(raw: Any) -> None:
 def validate_strategy_id(value: str, label: str) -> None:
     if not STRATEGY_ID_RE.fullmatch(value) or value in {".", ".."}:
         raise CardValidationError(f"{label} may contain only letters, numbers, dot, colon, underscore, and hyphen")
+
+
+def validate_policy_gradient(raw: Any) -> None:
+    if not isinstance(raw, dict):
+        raise CardValidationError("policy_gradient must be a JSON object")
+    if raw.get("target_family", raw.get("targetFamily")) != CONSTRUCTION_PRIORITY_FAMILY:
+        raise CardValidationError("policy_gradient.target_family must be construction-priority")
+    learnable = first_present(raw, ("learnable_parameters", "learnableParameters"))
+    if not isinstance(learnable, list):
+        raise CardValidationError("policy_gradient.learnable_parameters must be a list")
+    learnable_names = []
+    for index, item in enumerate(learnable):
+        if not isinstance(item, dict):
+            raise CardValidationError(f"policy_gradient.learnable_parameters[{index}] must be an object")
+        name = item.get("name")
+        if not isinstance(name, str):
+            raise CardValidationError(f"policy_gradient.learnable_parameters[{index}].name must be a string")
+        learnable_names.append(name)
+    if learnable_names != list(CONSTRUCTION_PRIORITY_KNOB_NAMES):
+        raise CardValidationError("policy_gradient.learnable_parameters must match construction-priority registry knobs")
+
+    candidates = first_present(raw, ("candidate_parameter_vectors", "candidateParameterVectors"))
+    if not isinstance(candidates, list) or len(candidates) == 0:
+        raise CardValidationError("policy_gradient.candidate_parameter_vectors must contain at least one vector")
+    candidate_ids: set[str] = set()
+    for index, candidate in enumerate(candidates):
+        validate_policy_gradient_candidate(candidate, index)
+        assert isinstance(candidate, dict)
+        candidate_policy_id = candidate["candidatePolicyId"]
+        if candidate_policy_id in candidate_ids:
+            raise CardValidationError(f"duplicate policy_gradient candidatePolicyId: {candidate_policy_id}")
+        candidate_ids.add(candidate_policy_id)
+
+    support = first_present(raw, ("runner_support", "runnerSupport"))
+    if not isinstance(support, dict):
+        raise CardValidationError("policy_gradient.runner_support must be a JSON object")
+    inline_applied = first_present(support, ("inline_candidates_applied_to_simulator", "inlineCandidatesAppliedToSimulator"))
+    if inline_applied is not False:
+        raise CardValidationError("policy_gradient.runner_support.inline_candidates_applied_to_simulator must be false")
+    preserves_parameters = first_present(
+        support,
+        ("report_preserves_candidate_parameters", "reportPreservesCandidateParameters"),
+    )
+    if preserves_parameters is not True:
+        raise CardValidationError("policy_gradient.runner_support.report_preserves_candidate_parameters must be true")
+
+    safety = raw.get("safety")
+    if safety is not None:
+        validate_safety({"safety": safety})
+
+
+def validate_policy_gradient_candidate(raw: Any, index: int) -> None:
+    if not isinstance(raw, dict):
+        raise CardValidationError(f"policy_gradient.candidate_parameter_vectors[{index}] must be an object")
+    for field in ("candidatePolicyId", "strategyVariantId", "sourceStrategyId", "family", "rolloutStatus"):
+        value = raw.get(field)
+        if not isinstance(value, str) or not value:
+            raise CardValidationError(f"policy_gradient.candidate_parameter_vectors[{index}].{field} must be a string")
+    validate_strategy_id(raw["candidatePolicyId"], f"policy_gradient.candidate_parameter_vectors[{index}].candidatePolicyId")
+    validate_strategy_id(raw["strategyVariantId"], f"policy_gradient.candidate_parameter_vectors[{index}].strategyVariantId")
+    validate_strategy_id(raw["sourceStrategyId"], f"policy_gradient.candidate_parameter_vectors[{index}].sourceStrategyId")
+    if raw["family"] != CONSTRUCTION_PRIORITY_FAMILY:
+        raise CardValidationError(f"policy_gradient.candidate_parameter_vectors[{index}].family must be construction-priority")
+    parameters = raw.get("parameters")
+    if not isinstance(parameters, dict):
+        raise CardValidationError(f"policy_gradient.candidate_parameter_vectors[{index}].parameters must be an object")
+    for knob in CONSTRUCTION_PRIORITY_KNOB_NAMES:
+        if knob not in parameters:
+            raise CardValidationError(
+                f"policy_gradient.candidate_parameter_vectors[{index}].parameters.{knob} is required"
+            )
+        if not is_finite_number(parameters[knob]):
+            raise CardValidationError(
+                f"policy_gradient.candidate_parameter_vectors[{index}].parameters.{knob} must be a finite number"
+            )
 
 
 def first_present(raw: JsonObject, keys: tuple[str, ...]) -> Any:
@@ -356,6 +757,16 @@ def run_self_test(stdout: TextIO) -> int:
     return 0
 
 
+def positive_int_arg(raw: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be a positive integer") from error
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return value
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Generate or validate offline/shadow Screeps RL experiment cards.",
@@ -383,6 +794,25 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--created-at",
         help="ISO UTC timestamp to record. Defaults to current UTC second.",
+    )
+    parser.add_argument(
+        "--ticks",
+        type=positive_int_arg,
+        help=(
+            "Simulation ticks to request. Defaults to 50, or 100 for policy_gradient cards."
+        ),
+    )
+    parser.add_argument(
+        "--repetitions",
+        type=positive_int_arg,
+        help=(
+            "Simulation repetitions to request. Defaults to 1, or 5 for policy_gradient cards."
+        ),
+    )
+    parser.add_argument(
+        "--workers",
+        type=positive_int_arg,
+        help="Simulator worker count to request. Defaults to 1.",
     )
     parser.add_argument(
         "--dry-run",
@@ -440,6 +870,9 @@ def main(
             code_commit=args.code_commit or git_commit(repo),
             training_approach=args.training_approach,
             created_at=args.created_at or utc_now_iso(),
+            simulation_ticks=args.ticks,
+            simulation_repetitions=args.repetitions,
+            simulation_workers=args.workers,
         )
         write_output(card, args.output, stdout)
         return 0

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -85,6 +85,9 @@ CONSTRUCTION_PRIORITY_KNOBS: tuple[JsonObject, ...] = (
     },
 )
 CONSTRUCTION_PRIORITY_KNOB_NAMES = tuple(str(knob["name"]) for knob in CONSTRUCTION_PRIORITY_KNOBS)
+CONSTRUCTION_PRIORITY_PARAMETER_LIMITS = {
+    str(knob["name"]): (float(knob["min"]), float(knob["max"])) for knob in CONSTRUCTION_PRIORITY_KNOBS
+}
 CONSTRUCTION_PRIORITY_FALLBACK_DEFAULTS: dict[str, JsonObject] = {
     "construction-priority.incumbent.v1": {
         "baseScoreWeight": 1,
@@ -425,16 +428,20 @@ def construction_priority_registry_defaults(registry_path: Path) -> dict[str, Js
         variant_id: dict(parameters)
         for variant_id, parameters in CONSTRUCTION_PRIORITY_FALLBACK_DEFAULTS.items()
     }
-    try:
-        import screeps_rl_training_runner as training_runner
-
-        registry = training_runner.load_strategy_registry(registry_path)
-    except Exception:
+    if not registry_path.exists():
         return defaults
+
+    import screeps_rl_training_runner as training_runner
+
+    registry = training_runner.load_strategy_registry(registry_path)
+    missing = [variant_id for variant_id in CONSTRUCTION_PRIORITY_REGISTRY_IDS if variant_id not in registry]
+    if missing:
+        missing_list = ", ".join(missing)
+        raise CardValidationError(
+            f"strategy registry {repo_relative(registry_path)} is missing construction-priority variants: {missing_list}"
+        )
     for variant_id in CONSTRUCTION_PRIORITY_REGISTRY_IDS:
-        variant = registry.get(variant_id)
-        if variant is None:
-            continue
+        variant = registry[variant_id]
         parameters = construction_priority_parameters_or_none(variant.parameters)
         if parameters is not None:
             defaults[variant_id] = parameters
@@ -458,15 +465,23 @@ def bounded_construction_priority_parameters(raw: JsonObject) -> JsonObject:
     for knob in CONSTRUCTION_PRIORITY_KNOBS:
         name = str(knob["name"])
         value = raw.get(name)
-        if not is_finite_number(value):
-            raise CardValidationError(f"construction-priority parameter {name} must be a finite number")
-        minimum = float(knob["min"])
-        maximum = float(knob["max"])
-        numeric = float(value)
-        if numeric < minimum or numeric > maximum:
-            raise CardValidationError(f"construction-priority parameter {name} must be within registry knob bounds")
+        numeric = validate_construction_priority_parameter_value(
+            value,
+            name,
+            f"construction-priority parameter {name}",
+        )
         bounded[name] = int(numeric) if numeric.is_integer() else numeric
     return bounded
+
+
+def validate_construction_priority_parameter_value(value: Any, knob: str, label: str) -> float:
+    if not is_finite_number(value):
+        raise CardValidationError(f"{label} must be a finite number")
+    minimum, maximum = CONSTRUCTION_PRIORITY_PARAMETER_LIMITS[knob]
+    numeric = float(value)
+    if numeric < minimum or numeric > maximum:
+        raise CardValidationError(f"{label} must be within registry knob bounds")
+    return numeric
 
 
 def is_finite_number(value: Any) -> bool:
@@ -668,10 +683,11 @@ def validate_policy_gradient_candidate(raw: Any, index: int) -> None:
             raise CardValidationError(
                 f"policy_gradient.candidate_parameter_vectors[{index}].parameters.{knob} is required"
             )
-        if not is_finite_number(parameters[knob]):
-            raise CardValidationError(
-                f"policy_gradient.candidate_parameter_vectors[{index}].parameters.{knob} must be a finite number"
-            )
+        validate_construction_priority_parameter_value(
+            parameters[knob],
+            knob,
+            f"policy_gradient.candidate_parameter_vectors[{index}].parameters.{knob}",
+        )
 
 
 def first_present(raw: JsonObject, keys: tuple[str, ...]) -> Any:

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -658,12 +658,21 @@ def validate_policy_gradient(raw: Any) -> None:
     inline_applied = first_present(support, ("inline_candidates_applied_to_simulator", "inlineCandidatesAppliedToSimulator"))
     if inline_applied is not False:
         raise CardValidationError("policy_gradient.runner_support.inline_candidates_applied_to_simulator must be false")
+    transport = first_present(support, ("simulator_variant_transport", "simulatorVariantTransport"))
+    if transport != "variant_ids_only":
+        raise CardValidationError("policy_gradient.runner_support.simulator_variant_transport must be variant_ids_only")
     preserves_parameters = first_present(
         support,
         ("report_preserves_candidate_parameters", "reportPreservesCandidateParameters"),
     )
     if preserves_parameters is not True:
         raise CardValidationError("policy_gradient.runner_support.report_preserves_candidate_parameters must be true")
+    preserves_candidate_policy_id = first_present(
+        support,
+        ("candidate_policy_id_preserved", "candidatePolicyIdPreserved"),
+    )
+    if preserves_candidate_policy_id is not True:
+        raise CardValidationError("policy_gradient.runner_support.candidate_policy_id_preserved must be true")
 
     safety = raw.get("safety")
     if safety is not None:

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -443,8 +443,12 @@ def construction_priority_registry_defaults(registry_path: Path) -> dict[str, Js
     for variant_id in CONSTRUCTION_PRIORITY_REGISTRY_IDS:
         variant = registry[variant_id]
         parameters = construction_priority_parameters_or_none(variant.parameters)
-        if parameters is not None:
-            defaults[variant_id] = parameters
+        if parameters is None:
+            raise CardValidationError(
+                f"strategy registry {repo_relative(registry_path)} variant {variant_id} "
+                "must define finite construction-priority parameters"
+            )
+        defaults[variant_id] = parameters
     return defaults
 
 
@@ -535,13 +539,16 @@ def validate_card(raw: Any) -> None:
 
     validate_safety(raw)
     validate_reward_model(raw.get("reward_model"))
-    validate_strategy_variants(first_present(raw, ("strategy_variants", "strategyVariants", "variants")))
+    strategy_variants = first_present(raw, ("strategy_variants", "strategyVariants", "variants"))
+    validate_strategy_variants(strategy_variants)
     validate_simulation(first_present(raw, ("simulation", "simulator")))
     policy_gradient = first_present(raw, ("policy_gradient", "policyGradient"))
     if training_approach == "policy_gradient" and policy_gradient is None:
         raise CardValidationError("policy_gradient metadata is required when training_approach is policy_gradient")
     if policy_gradient is not None:
         validate_policy_gradient(policy_gradient)
+    if training_approach == "policy_gradient":
+        validate_policy_gradient_strategy_variants(policy_gradient, strategy_variants)
 
 
 def require_string(raw: JsonObject, field: str) -> str:
@@ -661,6 +668,52 @@ def validate_policy_gradient(raw: Any) -> None:
     safety = raw.get("safety")
     if safety is not None:
         validate_safety({"safety": safety})
+
+
+def validate_policy_gradient_strategy_variants(policy_gradient: Any, strategy_variants: Any) -> None:
+    if not isinstance(policy_gradient, dict):
+        return
+    candidates = first_present(policy_gradient, ("candidate_parameter_vectors", "candidateParameterVectors"))
+    if not isinstance(candidates, list) or not isinstance(strategy_variants, list):
+        return
+    if len(strategy_variants) != len(candidates):
+        raise CardValidationError(
+            "strategy_variants must mirror policy_gradient.candidate_parameter_vectors for policy_gradient cards"
+        )
+
+    seen_strategy_variant_ids: set[str] = set()
+    for index, candidate in enumerate(candidates):
+        if not isinstance(candidate, dict):
+            continue
+        strategy_variant = strategy_variants[index]
+        if not isinstance(strategy_variant, dict):
+            raise CardValidationError(
+                f"strategy_variants[{index}] must be an inline policy-gradient candidate variant"
+            )
+        expected_variant_id = candidate.get("strategyVariantId")
+        expected_candidate_policy_id = candidate.get("candidatePolicyId")
+        variant_id = strategy_variant.get("id")
+        if variant_id != expected_variant_id:
+            raise CardValidationError(
+                f"strategy_variants[{index}].id must match "
+                f"policy_gradient.candidate_parameter_vectors[{index}].strategyVariantId"
+            )
+        if variant_id in seen_strategy_variant_ids:
+            raise CardValidationError(f"duplicate policy_gradient strategyVariantId: {variant_id}")
+        seen_strategy_variant_ids.add(variant_id)
+
+        candidate_policy_id = first_present(strategy_variant, ("candidatePolicyId", "candidate_policy_id"))
+        if candidate_policy_id != expected_candidate_policy_id:
+            raise CardValidationError(
+                f"strategy_variants[{index}].candidatePolicyId must match "
+                f"policy_gradient.candidate_parameter_vectors[{index}].candidatePolicyId"
+            )
+        parameters = first_present(strategy_variant, ("parameters", "params", "defaultValues", "default_values"))
+        if parameters != candidate.get("parameters"):
+            raise CardValidationError(
+                f"strategy_variants[{index}].parameters must match "
+                f"policy_gradient.candidate_parameter_vectors[{index}].parameters"
+            )
 
 
 def validate_policy_gradient_candidate(raw: Any, index: int) -> None:

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -50,10 +50,14 @@ class StrategyVariant:
 
     id: str
     parameters: JsonObject
+    candidate_policy_id: str | None = None
     family: str | None = None
+    parameter_evidence: JsonObject | None = None
     rollout_status: str | None = None
+    source_strategy_id: str | None = None
     source: str = "inline"
     title: str | None = None
+    training_role: str | None = None
 
     def to_json(self) -> JsonObject:
         payload: JsonObject = {
@@ -61,12 +65,20 @@ class StrategyVariant:
             "parameters": self.parameters,
             "source": self.source,
         }
+        if self.candidate_policy_id:
+            payload["candidatePolicyId"] = self.candidate_policy_id
         if self.family:
             payload["family"] = self.family
+        if self.parameter_evidence is not None:
+            payload["parameterEvidence"] = copy.deepcopy(self.parameter_evidence)
         if self.rollout_status:
             payload["rolloutStatus"] = self.rollout_status
+        if self.source_strategy_id:
+            payload["sourceStrategyId"] = self.source_strategy_id
         if self.title:
             payload["title"] = self.title
+        if self.training_role:
+            payload["trainingRole"] = self.training_role
         return payload
 
 
@@ -330,10 +342,14 @@ def expand_scale_environment_strategy_variants(
             StrategyVariant(
                 id=variant_id,
                 parameters=copy.deepcopy(base.parameters),
+                candidate_policy_id=base.candidate_policy_id,
                 family=base.family,
+                parameter_evidence=copy.deepcopy(base.parameter_evidence),
                 rollout_status=base.rollout_status,
+                source_strategy_id=base.source_strategy_id,
                 source=base.source,
                 title=(base.title + suffix) if base.title else None,
+                training_role=base.training_role,
             )
         )
     return expanded
@@ -358,7 +374,14 @@ def normalize_variant(raw: Any, registry: dict[str, StrategyVariant]) -> Strateg
         source = registry_variant.source
     if parameters is None:
         parameters = {}
+    candidate_policy_id = text_or_none(raw.get("candidatePolicyId")) or text_or_none(raw.get("candidate_policy_id"))
+    if candidate_policy_id is not None:
+        validate_strategy_id(candidate_policy_id)
+    source_strategy_id = text_or_none(raw.get("sourceStrategyId")) or text_or_none(raw.get("source_strategy_id"))
+    if source_strategy_id is not None:
+        validate_strategy_id(source_strategy_id)
     family = text_or_none(raw.get("family")) or (registry_variant.family if registry_variant else None)
+    parameter_evidence = first_mapping(raw, ("parameterEvidence", "parameter_evidence"))
     rollout_status = (
         text_or_none(raw.get("rolloutStatus"))
         or text_or_none(raw.get("rollout_status"))
@@ -368,10 +391,14 @@ def normalize_variant(raw: Any, registry: dict[str, StrategyVariant]) -> Strateg
     return StrategyVariant(
         id=variant_id,
         parameters=dict(sorted(parameters.items())),
+        candidate_policy_id=candidate_policy_id,
         family=family,
+        parameter_evidence=copy.deepcopy(parameter_evidence) if parameter_evidence is not None else None,
         rollout_status=rollout_status,
+        source_strategy_id=source_strategy_id,
         source=source,
         title=title,
+        training_role=text_or_none(raw.get("trainingRole")) or text_or_none(raw.get("training_role")),
     )
 
 
@@ -896,6 +923,7 @@ def build_training_report(
     ranking_diff_count = sum(1 for item in pairwise if item.get("winner") and item["winner"] not in incumbent_ids)
     warnings = build_report_warnings(results, simulator_runs)
     scale_validation = build_scale_validation_summary(simulator_runs, config)
+    policy_gradient = policy_gradient_metadata_from_card(card)
 
     report = {
         "type": REPORT_TYPE,
@@ -964,6 +992,8 @@ def build_training_report(
     }
     if scale_validation is not None:
         report["scaleValidation"] = scale_validation
+    if policy_gradient is not None:
+        report["policyGradient"] = policy_gradient
     return report
 
 
@@ -1046,7 +1076,7 @@ def summarize_variant(
     reward_tuple[0] = reliability_score(scored_run_count=len(run_metrics), total_run_count=len(runs))
     metrics = aggregate_metrics(run_metrics)
     metrics["reliability"]["score"] = reward_tuple[0]
-    return {
+    summary: JsonObject = {
         "variantId": variant.id,
         "family": variant.family,
         "rolloutStatus": variant.rollout_status,
@@ -1072,6 +1102,15 @@ def summarize_variant(
             for run in runs
         ],
     }
+    if variant.candidate_policy_id:
+        summary["candidatePolicyId"] = variant.candidate_policy_id
+    if variant.source_strategy_id:
+        summary["sourceStrategyId"] = variant.source_strategy_id
+    if variant.parameter_evidence is not None:
+        summary["parameterEvidence"] = copy.deepcopy(variant.parameter_evidence)
+    if variant.training_role:
+        summary["trainingRole"] = variant.training_role
+    return summary
 
 
 def compute_run_metrics(run: JsonObject, reward_options: JsonObject) -> JsonObject:
@@ -1804,7 +1843,7 @@ def build_report_warnings(results: Sequence[JsonObject], simulator_runs: Sequenc
 
 
 def summarize_card(card: JsonObject, path: Path) -> JsonObject:
-    return {
+    summary = {
         "path": dataset_export.display_path(path),
         "cardId": card.get("card_id", card.get("cardId")),
         "datasetRunId": card.get("dataset_run_id", card.get("datasetRunId")),
@@ -1813,6 +1852,17 @@ def summarize_card(card: JsonObject, path: Path) -> JsonObject:
         "status": card.get("status", "shadow"),
         "safety": card.get("safety"),
     }
+    policy_gradient = policy_gradient_metadata_from_card(card)
+    if policy_gradient is not None:
+        summary["policyGradient"] = policy_gradient
+    return summary
+
+
+def policy_gradient_metadata_from_card(card: JsonObject) -> JsonObject | None:
+    raw = card.get("policy_gradient", card.get("policyGradient"))
+    if not isinstance(raw, dict):
+        return None
+    return copy.deepcopy(raw)
 
 
 def safety_metadata() -> JsonObject:

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -7,6 +7,7 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -128,6 +129,66 @@ class RlExperimentCardTest(unittest.TestCase):
             self.assertEqual(set(candidate["parameters"]), set(learnable_names))
             self.assertFalse(candidate["parameterEvidence"]["liveEffect"])
             self.assertFalse(candidate["parameterEvidence"]["officialMmoWrites"])
+
+    def test_policy_gradient_missing_registry_uses_fallback_defaults(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            card = card_helper.build_card(
+                dataset_run_id="rl-policy-gradient-missing-registry",
+                code_commit="f" * 40,
+                training_approach="policy_gradient",
+                created_at="2026-05-17T00:25:00Z",
+                registry_path=Path(temp_dir) / "missing-registry.ts",
+            )
+
+        card_helper.validate_card(card)
+        candidates = card["policy_gradient"]["candidate_parameter_vectors"]
+        self.assertEqual(candidates[0]["parameters"]["territorySignalWeight"], 6)
+        self.assertEqual(candidates[1]["parameters"]["territorySignalWeight"], 22)
+
+    def test_policy_gradient_existing_registry_must_include_construction_priority_variants(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry_path = Path(temp_dir) / "strategyRegistry.ts"
+            registry_path.write_text("export const STRATEGY_REGISTRY = [];\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(card_helper.CardValidationError, "missing construction-priority variants"):
+                card_helper.build_card(
+                    dataset_run_id="rl-policy-gradient-empty-registry",
+                    code_commit="f" * 40,
+                    training_approach="policy_gradient",
+                    created_at="2026-05-17T00:25:00Z",
+                    registry_path=registry_path,
+                )
+
+    def test_policy_gradient_registry_loader_errors_surface(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry_path = Path(temp_dir) / "strategyRegistry.ts"
+            registry_path.write_text("export const STRATEGY_REGISTRY = [];\n", encoding="utf-8")
+
+            with mock.patch.object(runner, "load_strategy_registry", side_effect=RuntimeError("registry broke")):
+                with self.assertRaisesRegex(RuntimeError, "registry broke"):
+                    card_helper.build_card(
+                        dataset_run_id="rl-policy-gradient-loader-error",
+                        code_commit="f" * 40,
+                        training_approach="policy_gradient",
+                        created_at="2026-05-17T00:25:00Z",
+                        registry_path=registry_path,
+                    )
+
+    def test_validate_policy_gradient_rejects_out_of_range_candidate_parameters(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-bounds",
+            code_commit="f" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-17T00:25:00Z",
+        )
+        candidate = card["policy_gradient"]["candidate_parameter_vectors"][0]
+        candidate["parameters"]["territorySignalWeight"] = 31
+
+        with self.assertRaisesRegex(
+            card_helper.CardValidationError,
+            "candidate_parameter_vectors\\[0\\].parameters.territorySignalWeight must be within registry knob bounds",
+        ):
+            card_helper.validate_card(card)
 
     def test_default_policy_gradient_card_requests_loop_a_run_floor(self) -> None:
         card = card_helper.build_card(

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -70,6 +70,77 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(config.repetitions, 1)
         self.assertEqual(config.branch, "$activeWorld")
 
+    def test_policy_gradient_construction_priority_card_is_runner_valid(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-000001",
+            code_commit="f" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-17T00:25:00Z",
+            simulation_ticks=100,
+            simulation_repetitions=5,
+        )
+
+        card_helper.validate_card(card)
+        runner.validate_experiment_card(card)
+        variants = runner.load_strategy_variants(
+            card,
+            registry_path=REPO_ROOT / "prod" / "src" / "strategy" / "strategyRegistry.ts",
+        )
+        config = runner.simulation_config_from_card(card)
+        policy_gradient = card["policy_gradient"]
+        candidates = policy_gradient["candidate_parameter_vectors"]
+        learnable_names = [item["name"] for item in policy_gradient["learnable_parameters"]]
+
+        self.assertEqual(card["training_approach"], "policy_gradient")
+        self.assertEqual(config.ticks, 100)
+        self.assertEqual(config.repetitions, 5)
+        self.assertFalse(card["liveEffect"])
+        self.assertFalse(card["officialMmoWrites"])
+        self.assertFalse(card["officialMmoWritesAllowed"])
+        self.assertTrue(card["conservative_actions_only"])
+        self.assertTrue(card["ood_rejection"])
+        self.assertEqual(policy_gradient["target_family"], "construction-priority")
+        self.assertEqual(
+            learnable_names,
+            [
+                "baseScoreWeight",
+                "territorySignalWeight",
+                "resourceSignalWeight",
+                "killSignalWeight",
+                "riskPenalty",
+            ],
+        )
+        self.assertFalse(policy_gradient["runner_support"]["inline_candidates_applied_to_simulator"])
+        self.assertTrue(policy_gradient["runner_support"]["report_preserves_candidate_parameters"])
+        self.assertEqual(
+            [candidate["candidatePolicyId"] for candidate in candidates],
+            [
+                "construction-priority.pg.incumbent-seed.v1",
+                "construction-priority.pg.territory-seed.v1",
+                "construction-priority.pg.resource-seed.v1",
+                "construction-priority.pg.risk-aware-seed.v1",
+            ],
+        )
+        self.assertEqual([variant.candidate_policy_id for variant in variants], [candidate["candidatePolicyId"] for candidate in candidates])
+        self.assertEqual(variants[0].parameters["baseScoreWeight"], 1)
+        self.assertEqual(variants[1].parameters["territorySignalWeight"], 22)
+        for candidate in candidates:
+            self.assertEqual(set(candidate["parameters"]), set(learnable_names))
+            self.assertFalse(candidate["parameterEvidence"]["liveEffect"])
+            self.assertFalse(candidate["parameterEvidence"]["officialMmoWrites"])
+
+    def test_default_policy_gradient_card_requests_loop_a_run_floor(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-defaults",
+            code_commit="1" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-17T00:25:00Z",
+        )
+        config = runner.simulation_config_from_card(card)
+
+        self.assertGreaterEqual(config.ticks, 100)
+        self.assertGreaterEqual(config.repetitions, 5)
+
     def test_generated_simulation_paths_are_harness_defaults_from_arbitrary_cwd(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-cwd-safe-000000",
@@ -140,6 +211,20 @@ class RlExperimentCardTest(unittest.TestCase):
                 self.assertEqual(config.repetitions, 1)
                 self.assertEqual(config.host_port_start, 24125)
 
+    def test_validate_rejects_top_level_true_safety_regression(self) -> None:
+        for field in ("conservative_actions_only", "ood_rejection"):
+            with self.subTest(field=field):
+                card = card_helper.build_card(
+                    dataset_run_id=f"rl-safety-{field}",
+                    code_commit="2" * 40,
+                    training_approach="policy_gradient",
+                    created_at="2026-05-17T00:25:00Z",
+                )
+                card[field] = False
+
+                with self.assertRaisesRegex(card_helper.CardValidationError, f"{field} must be true"):
+                    card_helper.validate_card(card)
+
     def test_cli_generation_outputs_training_runner_valid_card(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             output_path = Path(temp_dir) / "card.json"
@@ -162,6 +247,40 @@ class RlExperimentCardTest(unittest.TestCase):
 
         self.assertEqual(exit_code, 0)
         runner.validate_experiment_card(generated)
+
+    def test_cli_generation_accepts_policy_gradient_ticks_and_repetitions(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "card.json"
+            exit_code = card_helper.main(
+                [
+                    "--dataset-run-id",
+                    "rl-policy-gradient-cli",
+                    "--code-commit",
+                    "3" * 40,
+                    "--training-approach",
+                    "policy_gradient",
+                    "--created-at",
+                    "2026-05-17T00:25:00Z",
+                    "--ticks",
+                    "125",
+                    "--repetitions",
+                    "6",
+                    "--output",
+                    str(output_path),
+                ],
+                stdout=io.StringIO(),
+                stderr=io.StringIO(),
+                repo_root=REPO_ROOT,
+            )
+            generated = json.loads(output_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, 0)
+        runner.validate_experiment_card(generated)
+        config = runner.simulation_config_from_card(generated)
+        self.assertEqual(config.ticks, 125)
+        self.assertEqual(config.repetitions, 6)
+        self.assertEqual(generated["training_approach"], "policy_gradient")
+        self.assertEqual(generated["policy_gradient"]["target_family"], "construction-priority")
 
 
 if __name__ == "__main__":

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -159,6 +159,35 @@ class RlExperimentCardTest(unittest.TestCase):
                     registry_path=registry_path,
                 )
 
+    def test_policy_gradient_existing_registry_must_include_valid_construction_priority_parameters(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry_path = Path(temp_dir) / "strategyRegistry.ts"
+            registry_path.write_text("export const STRATEGY_REGISTRY = [];\n", encoding="utf-8")
+            incumbent_id = "construction-priority.incumbent.v1"
+            territory_id = "construction-priority.territory-shadow.v1"
+            incumbent_parameters = dict(card_helper.CONSTRUCTION_PRIORITY_FALLBACK_DEFAULTS[incumbent_id])
+            del incumbent_parameters["riskPenalty"]
+            registry = {
+                incumbent_id: runner.StrategyVariant(id=incumbent_id, parameters=incumbent_parameters),
+                territory_id: runner.StrategyVariant(
+                    id=territory_id,
+                    parameters=dict(card_helper.CONSTRUCTION_PRIORITY_FALLBACK_DEFAULTS[territory_id]),
+                ),
+            }
+
+            with mock.patch.object(runner, "load_strategy_registry", return_value=registry):
+                with self.assertRaisesRegex(
+                    card_helper.CardValidationError,
+                    "variant construction-priority\\.incumbent\\.v1 must define finite construction-priority parameters",
+                ):
+                    card_helper.build_card(
+                        dataset_run_id="rl-policy-gradient-invalid-registry-parameters",
+                        code_commit="f" * 40,
+                        training_approach="policy_gradient",
+                        created_at="2026-05-17T00:25:00Z",
+                        registry_path=registry_path,
+                    )
+
     def test_policy_gradient_registry_loader_errors_surface(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             registry_path = Path(temp_dir) / "strategyRegistry.ts"
@@ -201,6 +230,38 @@ class RlExperimentCardTest(unittest.TestCase):
 
         self.assertGreaterEqual(config.ticks, 100)
         self.assertGreaterEqual(config.repetitions, 5)
+
+    def test_policy_gradient_rejects_stale_strategy_variant_candidate_policy_id(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-stale-variant-id",
+            code_commit="4" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-17T00:25:00Z",
+        )
+        card["strategy_variants"][0]["candidatePolicyId"] = "construction-priority.pg.stale-seed.v1"
+
+        with self.assertRaisesRegex(
+            card_helper.CardValidationError,
+            "strategy_variants\\[0\\]\\.candidatePolicyId must match",
+        ):
+            card_helper.validate_card(card)
+
+    def test_policy_gradient_rejects_strategy_variant_parameter_divergence(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-stale-variant-parameters",
+            code_commit="5" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-17T00:25:00Z",
+        )
+        variant_parameters = dict(card["strategy_variants"][0]["parameters"])
+        variant_parameters["territorySignalWeight"] = 7
+        card["strategy_variants"][0]["parameters"] = variant_parameters
+
+        with self.assertRaisesRegex(
+            card_helper.CardValidationError,
+            "strategy_variants\\[0\\]\\.parameters must match",
+        ):
+            card_helper.validate_card(card)
 
     def test_generated_simulation_paths_are_harness_defaults_from_arbitrary_cwd(self) -> None:
         card = card_helper.build_card(

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -101,6 +101,7 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertTrue(card["conservative_actions_only"])
         self.assertTrue(card["ood_rejection"])
         self.assertEqual(policy_gradient["target_family"], "construction-priority")
+        runner_support = policy_gradient["runner_support"]
         self.assertEqual(
             learnable_names,
             [
@@ -111,8 +112,10 @@ class RlExperimentCardTest(unittest.TestCase):
                 "riskPenalty",
             ],
         )
-        self.assertFalse(policy_gradient["runner_support"]["inline_candidates_applied_to_simulator"])
-        self.assertTrue(policy_gradient["runner_support"]["report_preserves_candidate_parameters"])
+        self.assertFalse(runner_support["inline_candidates_applied_to_simulator"])
+        self.assertEqual(runner_support["simulator_variant_transport"], "variant_ids_only")
+        self.assertTrue(runner_support["report_preserves_candidate_parameters"])
+        self.assertTrue(runner_support["candidate_policy_id_preserved"])
         self.assertEqual(
             [candidate["candidatePolicyId"] for candidate in candidates],
             [
@@ -216,6 +219,36 @@ class RlExperimentCardTest(unittest.TestCase):
         with self.assertRaisesRegex(
             card_helper.CardValidationError,
             "candidate_parameter_vectors\\[0\\].parameters.territorySignalWeight must be within registry knob bounds",
+        ):
+            card_helper.validate_card(card)
+
+    def test_validate_policy_gradient_rejects_unsupported_runner_transport(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-runner-transport",
+            code_commit="f" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-17T00:25:00Z",
+        )
+        card["policy_gradient"]["runner_support"]["simulator_variant_transport"] = "inline_vectors"
+
+        with self.assertRaisesRegex(
+            card_helper.CardValidationError,
+            "runner_support.simulator_variant_transport must be variant_ids_only",
+        ):
+            card_helper.validate_card(card)
+
+    def test_validate_policy_gradient_rejects_unpreserved_candidate_policy_id(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-runner-candidate-id",
+            code_commit="f" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-17T00:25:00Z",
+        )
+        card["policy_gradient"]["runner_support"]["candidate_policy_id_preserved"] = False
+
+        with self.assertRaisesRegex(
+            card_helper.CardValidationError,
+            "runner_support.candidate_policy_id_preserved must be true",
         ):
             card_helper.validate_card(card)
 

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -14,6 +14,7 @@ from unittest import mock
 sys.path.insert(0, str(Path(__file__).parent))
 
 import screeps_rl_training_runner as runner
+import screeps_rl_experiment_card as card_helper
 
 
 JsonObject = dict[str, Any]
@@ -862,6 +863,57 @@ export const STRATEGY_REGISTRY = [
         self.assertTrue(str(report["reportPath"]).endswith("reports/format-check.json"))
         self.assertEqual(simulator.calls[0]["ticks"], 2)
         self.assertEqual(simulator.calls[0]["variants"], ["baseline", "candidate"])
+
+    def test_policy_gradient_report_preserves_candidate_parameter_evidence(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-report",
+            code_commit="b" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-17T00:25:00Z",
+            simulation_ticks=100,
+            simulation_repetitions=1,
+        )
+        variant_ids = [variant["id"] for variant in card["strategy_variants"]]
+        start = tick(1, [room("W1N1", energy=100)])
+        simulator = MockSimulator({
+            variant_id: variant_result(variant_id, [start, tick(2, [room("W1N1", energy=200)])])
+            for variant_id in variant_ids
+        })
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="policy-gradient-evidence",
+                simulator_runner=simulator,
+            )
+
+        self.assertEqual(report["experimentCard"]["trainingApproach"], "policy_gradient")
+        self.assertEqual(report["policyGradient"]["target_family"], "construction-priority")
+        self.assertFalse(report["policyGradient"]["runner_support"]["inline_candidates_applied_to_simulator"])
+        self.assertTrue(report["policyGradient"]["runner_support"]["report_preserves_candidate_parameters"])
+        self.assertEqual(simulator.calls[0]["ticks"], 100)
+        self.assertEqual(simulator.calls[0]["variants"], variant_ids)
+        self.assertEqual(
+            [variant["candidatePolicyId"] for variant in report["strategyVariants"]],
+            [candidate["candidatePolicyId"] for candidate in card["policy_gradient"]["candidate_parameter_vectors"]],
+        )
+        first_result = report["variantResults"][0]
+        self.assertEqual(first_result["candidatePolicyId"], "construction-priority.pg.incumbent-seed.v1")
+        self.assertEqual(
+            set(first_result["parameters"]),
+            {
+                "baseScoreWeight",
+                "territorySignalWeight",
+                "resourceSignalWeight",
+                "killSignalWeight",
+                "riskPenalty",
+            },
+        )
+        self.assertEqual(first_result["parameterEvidence"]["sourceStrategyId"], "construction-priority.incumbent.v1")
 
     def test_report_id_with_dots_is_normalized_for_simulator_run_id(self) -> None:
         start = tick(1, [room("W1N1", energy=100)])


### PR DESCRIPTION
## Summary
- Adds policy-gradient experiment-card generation support for learnable RL construction-priority candidates.
- Extends the RL training runner to preserve/propagate policy-gradient candidate metadata.
- Adds targeted tests for experiment-card safety fields, candidate metadata, and runner handling.

## Context
Refs #1032 and #879. This converts the latest Loop A `NO_UNCONSUMED_EXPERIMENT_CARD` / policy-candidate gap into a concrete RL construction PR.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_experiment_card.py scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_experiment_card.py scripts/test_screeps_rl_training_runner.py`
- `python3 -m pytest scripts/test_screeps_rl_experiment_card.py scripts/test_screeps_rl_training_runner.py -q` — 41 passed, 17 subtests passed

## Safety
- RL/shadow/private-only construction; no official MMO write path changed.
- No secrets printed or committed.
