### PR TITLE
feat(telemetry): expose E29N56 scout-only gate proof

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -34809,7 +34809,7 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     ...territoryExpansion.candidates.length > 0 ? { territoryExpansion } : {},
     ...buildTerritoryIntentSummary(colony.room.name, roleCounts),
     ...buildTerritoryExecutionHintSummary(colony.room.name),
-    ...buildTerritoryScoutSummary(colony.room.name),
+    ...buildTerritoryScoutSummary(colony),
     ...buildPostClaimBootstrapSummary(colony.room.name)
   };
 }
@@ -34854,17 +34854,62 @@ function buildTerritoryExecutionHintSummary(colonyName) {
   const territoryExecutionHints = getActiveTerritoryFollowUpExecutionHints(colonyName);
   return territoryExecutionHints.length > 0 ? { territoryExecutionHints } : {};
 }
-function buildTerritoryScoutSummary(colonyName) {
+function buildTerritoryScoutSummary(colony) {
+  const colonyName = colony.room.name;
   const summary = getTerritoryScoutSummary(colonyName);
-  if (!summary) {
+  const scoutOnlyTargets = buildScoutOnlyTargetSummaries(colony, summary);
+  if (!summary && scoutOnlyTargets.length === 0) {
     return {};
   }
   return {
     territoryScout: {
-      ...summary.attempts.length > 0 ? { attempts: summary.attempts } : {},
-      ...summary.intel.length > 0 ? { intel: summary.intel } : {}
+      ...summary && summary.attempts.length > 0 ? { attempts: summary.attempts } : {},
+      ...summary && summary.intel.length > 0 ? { intel: summary.intel } : {},
+      ...scoutOnlyTargets.length > 0 ? { scoutOnlyTargets } : {}
     }
   };
+}
+function buildScoutOnlyTargetSummaries(colony, summary) {
+  var _a, _b;
+  const colonyName = colony.room.name;
+  const attemptsByRoom = new Map(((_a = summary == null ? void 0 : summary.attempts) != null ? _a : []).map((attempt) => [attempt.roomName, attempt]));
+  const intelByRoom = new Map(((_b = summary == null ? void 0 : summary.intel) != null ? _b : []).map((intel) => [intel.roomName, intel]));
+  const seenRooms = /* @__PURE__ */ new Set();
+  return getTerritoryExpansionScoutTargets(colonyName).flatMap((target) => {
+    if (target.colony !== colonyName || target.scoutOnly !== true || seenRooms.has(target.roomName)) {
+      return [];
+    }
+    seenRooms.add(target.roomName);
+    const attempt = attemptsByRoom.get(target.roomName);
+    const intel = intelByRoom.get(target.roomName);
+    const gateOpen = isPassiveScoutGateOpen(colony, target.roomName);
+    return [
+      {
+        colony: colonyName,
+        roomName: target.roomName,
+        recommendedAction: "scout",
+        gateOpen,
+        status: getScoutOnlyTargetStatus(gateOpen, attempt, intel),
+        ...(attempt == null ? void 0 : attempt.requestedAt) !== void 0 ? { requestedAt: attempt.requestedAt } : {},
+        ...(attempt == null ? void 0 : attempt.updatedAt) !== void 0 ? { updatedAt: attempt.updatedAt } : {},
+        ...(attempt == null ? void 0 : attempt.attemptCount) !== void 0 ? { attemptCount: attempt.attemptCount } : {},
+        ...(intel == null ? void 0 : intel.updatedAt) !== void 0 ? { intelUpdatedAt: intel.updatedAt } : {},
+        ...(intel == null ? void 0 : intel.sourceCount) !== void 0 ? { sourceCount: intel.sourceCount } : {},
+        ...(intel == null ? void 0 : intel.hostileCreepCount) !== void 0 ? { hostileCreepCount: intel.hostileCreepCount } : {},
+        ...(intel == null ? void 0 : intel.hostileStructureCount) !== void 0 ? { hostileStructureCount: intel.hostileStructureCount } : {},
+        ...(intel == null ? void 0 : intel.hostileSpawnCount) !== void 0 ? { hostileSpawnCount: intel.hostileSpawnCount } : {}
+      }
+    ];
+  });
+}
+function getScoutOnlyTargetStatus(gateOpen, attempt, intel) {
+  if (attempt) {
+    return attempt.status;
+  }
+  if (intel) {
+    return "observed";
+  }
+  return gateOpen ? "pending" : "blocked";
 }
 function summarizeSpawn(spawn) {
   if (!spawn.spawning) {

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -29,6 +29,8 @@ import {
 } from '../territory/territoryPlanner';
 import { getPostClaimBootstrapSummary, type PostClaimBootstrapSummary } from '../territory/postClaimBootstrap';
 import { getTerritoryScoutSummary } from '../territory/scoutIntel';
+import { getTerritoryExpansionScoutTargets } from '../territory/expansionConfig';
+import { isPassiveScoutGateOpen } from '../territory/passiveScoutGate';
 import {
   checkEnergyBufferForCapacityEnablingConstruction,
   checkEnergyBufferForConstructionSpending,
@@ -283,6 +285,25 @@ interface RuntimeRoomSummary {
 interface RuntimeTerritoryScoutSummary {
   attempts?: TerritoryScoutAttemptMemory[];
   intel?: TerritoryScoutIntelMemory[];
+  scoutOnlyTargets?: RuntimeTerritoryScoutOnlyTargetSummary[];
+}
+
+type RuntimeTerritoryScoutOnlyTargetStatus = TerritoryScoutAttemptStatus | 'pending' | 'blocked';
+
+interface RuntimeTerritoryScoutOnlyTargetSummary {
+  colony: string;
+  roomName: string;
+  recommendedAction: 'scout';
+  gateOpen: boolean;
+  status: RuntimeTerritoryScoutOnlyTargetStatus;
+  requestedAt?: number;
+  updatedAt?: number;
+  attemptCount?: number;
+  intelUpdatedAt?: number;
+  sourceCount?: number;
+  hostileCreepCount?: number;
+  hostileStructureCount?: number;
+  hostileSpawnCount?: number;
 }
 
 interface RuntimeControllerSummary {
@@ -874,7 +895,7 @@ function summarizeRoom(
     ...(territoryExpansion.candidates.length > 0 ? { territoryExpansion } : {}),
     ...buildTerritoryIntentSummary(colony.room.name, roleCounts),
     ...buildTerritoryExecutionHintSummary(colony.room.name),
-    ...buildTerritoryScoutSummary(colony.room.name),
+    ...buildTerritoryScoutSummary(colony),
     ...buildPostClaimBootstrapSummary(colony.room.name)
   };
 }
@@ -951,18 +972,75 @@ function buildTerritoryExecutionHintSummary(
   return territoryExecutionHints.length > 0 ? { territoryExecutionHints } : {};
 }
 
-function buildTerritoryScoutSummary(colonyName: string): { territoryScout?: RuntimeTerritoryScoutSummary } {
+function buildTerritoryScoutSummary(colony: ColonySnapshot): { territoryScout?: RuntimeTerritoryScoutSummary } {
+  const colonyName = colony.room.name;
   const summary = getTerritoryScoutSummary(colonyName);
-  if (!summary) {
+  const scoutOnlyTargets = buildScoutOnlyTargetSummaries(colony, summary);
+  if (!summary && scoutOnlyTargets.length === 0) {
     return {};
   }
 
   return {
     territoryScout: {
-      ...(summary.attempts.length > 0 ? { attempts: summary.attempts } : {}),
-      ...(summary.intel.length > 0 ? { intel: summary.intel } : {})
+      ...(summary && summary.attempts.length > 0 ? { attempts: summary.attempts } : {}),
+      ...(summary && summary.intel.length > 0 ? { intel: summary.intel } : {}),
+      ...(scoutOnlyTargets.length > 0 ? { scoutOnlyTargets } : {})
     }
   };
+}
+
+function buildScoutOnlyTargetSummaries(
+  colony: ColonySnapshot,
+  summary: ReturnType<typeof getTerritoryScoutSummary>
+): RuntimeTerritoryScoutOnlyTargetSummary[] {
+  const colonyName = colony.room.name;
+  const attemptsByRoom = new Map((summary?.attempts ?? []).map((attempt) => [attempt.roomName, attempt]));
+  const intelByRoom = new Map((summary?.intel ?? []).map((intel) => [intel.roomName, intel]));
+  const seenRooms = new Set<string>();
+
+  return getTerritoryExpansionScoutTargets(colonyName).flatMap((target) => {
+    if (target.colony !== colonyName || target.scoutOnly !== true || seenRooms.has(target.roomName)) {
+      return [];
+    }
+    seenRooms.add(target.roomName);
+
+    const attempt = attemptsByRoom.get(target.roomName);
+    const intel = intelByRoom.get(target.roomName);
+    const gateOpen = isPassiveScoutGateOpen(colony, target.roomName);
+    return [
+      {
+        colony: colonyName,
+        roomName: target.roomName,
+        recommendedAction: 'scout' as const,
+        gateOpen,
+        status: getScoutOnlyTargetStatus(gateOpen, attempt, intel),
+        ...(attempt?.requestedAt !== undefined ? { requestedAt: attempt.requestedAt } : {}),
+        ...(attempt?.updatedAt !== undefined ? { updatedAt: attempt.updatedAt } : {}),
+        ...(attempt?.attemptCount !== undefined ? { attemptCount: attempt.attemptCount } : {}),
+        ...(intel?.updatedAt !== undefined ? { intelUpdatedAt: intel.updatedAt } : {}),
+        ...(intel?.sourceCount !== undefined ? { sourceCount: intel.sourceCount } : {}),
+        ...(intel?.hostileCreepCount !== undefined ? { hostileCreepCount: intel.hostileCreepCount } : {}),
+        ...(intel?.hostileStructureCount !== undefined ? { hostileStructureCount: intel.hostileStructureCount } : {}),
+        ...(intel?.hostileSpawnCount !== undefined ? { hostileSpawnCount: intel.hostileSpawnCount } : {})
+      }
+    ];
+  });
+}
+
+function getScoutOnlyTargetStatus(
+  gateOpen: boolean,
+  attempt: TerritoryScoutAttemptMemory | undefined,
+  intel: TerritoryScoutIntelMemory | undefined
+): RuntimeTerritoryScoutOnlyTargetStatus {
+  if (attempt) {
+    return attempt.status;
+  }
+
+  if (intel) {
+    return 'observed';
+  }
+
+  return gateOpen ? 'pending' : 'blocked';
 }
 
 function summarizeSpawn(spawn: StructureSpawn): RuntimeSpawnStatus {

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -2366,6 +2366,82 @@ describe('runtime telemetry summaries', () => {
     });
   });
 
+  it('emits healthy E29N55 E29N56 scout-only gate proof without reserve or claim targets', () => {
+    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL, roomName: 'E29N55' });
+    const room = colony.room as Room & { find: jest.Mock; energyAvailable: number; energyCapacityAvailable: number };
+    const controller = room.controller as StructureController & { level: number; ticksToDowngrade: number };
+    const spawn = colony.spawns[0] as StructureSpawn & { my?: boolean; isActive?: jest.Mock };
+    const tower = {
+      id: 'tower1',
+      my: true,
+      structureType: TEST_GLOBALS.STRUCTURE_TOWER,
+      store: makeEnergyStore(500)
+    };
+
+    room.energyAvailable = 800;
+    room.energyCapacityAvailable = 800;
+    controller.level = 3;
+    controller.ticksToDowngrade = 20_000;
+    colony.energyAvailable = 800;
+    colony.energyCapacityAvailable = 800;
+    spawn.my = true;
+    spawn.spawning = null;
+    spawn.isActive = jest.fn(() => true);
+    room.find.mockImplementation((findType: number): unknown[] => {
+      switch (findType) {
+        case TEST_GLOBALS.FIND_STRUCTURES:
+        case TEST_GLOBALS.FIND_MY_STRUCTURES:
+          return [spawn, tower];
+        case TEST_GLOBALS.FIND_SOURCES:
+          return [{ id: 'source1' }, { id: 'source2' }];
+        case TEST_GLOBALS.FIND_HOSTILE_CREEPS:
+        case TEST_GLOBALS.FIND_HOSTILE_STRUCTURES:
+          return [];
+        default:
+          return [];
+      }
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      runtime: {
+        currentRoomName: 'E29N55'
+      },
+      territory: {}
+    };
+    (Game as Partial<Game>).map = {
+      describeExits: jest.fn(() => ({
+        '1': 'E29N56',
+        '3': 'E30N55',
+        '5': 'E29N54',
+        '7': 'E28N55'
+      })),
+      findRoute: jest.fn(() => [{ exit: 1, room: 'E29N56' }]),
+      getRoomTerrain: jest.fn(() => ({ get: jest.fn(() => 0) }))
+    } as unknown as GameMap;
+
+    emitRuntimeSummary([colony], [], [], { persistOccupationRecommendations: false });
+
+    const payload = parseLoggedSummary();
+    const [summaryRoom] = payload.rooms as Array<Record<string, unknown>>;
+    const territoryScout = summaryRoom.territoryScout as Record<string, unknown>;
+    expect(territoryScout.scoutOnlyTargets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          colony: 'E29N55',
+          roomName: 'E29N56',
+          recommendedAction: 'scout',
+          gateOpen: true,
+          status: 'pending'
+        })
+      ])
+    );
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(
+      (Memory.territory?.intents ?? []).filter(
+        (intent) => intent.action === 'claim' || intent.action === 'reserve'
+      )
+    ).toEqual([]);
+  });
+
   it('keeps emission gating deterministic', () => {
     expect(shouldEmitRuntimeSummary(1, [])).toBe(false);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [])).toBe(true);


### PR DESCRIPTION
## Summary
- Adds runtime telemetry for E29N55 → E29N56 scout-only target gate state.
- Emits `territoryScout.scoutOnlyTargets` with gate status, attempt/intel evidence, and `recommendedAction: scout`.
- Adds a regression test proving the healthy RCL3/tower state reports E29N56 as scout-only without creating reserve/claim targets.

Closes #1164

## Verification
- Controller verified in `/root/screeps-worktrees/issue-1164-e29n56-scout/prod`:
  - `npm run typecheck`
  - `npm test -- --runInBand` (98 suites, 1922 tests passed)
  - `npm run build`

## Notes
- `prod/node_modules` is an untracked local symlink/dependency tree and is not staged.
- Commit authored by `lanyusea's bot <lanyusea@gmail.com>`.
