### PR TITLE
fix(tasks): bound healthy RCL3 routine repairs

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -27330,7 +27330,15 @@ function shouldDeferRoutineRepairToCoveredRcl3ControllerProgress(creep, controll
   return !isUrgentRepairTargetForControllerProgressBudget(repairTarget) && shouldDeferCoveredRcl3RoutineRepairToControllerProgress(creep, controller, constructionSites);
 }
 function shouldDeferCoveredRcl3RoutineRepairToControllerProgress(creep, controller, constructionSites) {
-  return shouldBoundHealthyRcl3RoutineRepairs(creep, controller, constructionSites) && hasSameRoomWorkerAssignedToTask(creep.room, creep, "repair");
+  return shouldBoundHealthyRcl3RoutineRepairs(creep, controller, constructionSites) && hasSameRoomLoadedRepairCoverage(creep);
+}
+function hasSameRoomLoadedRepairCoverage(creep) {
+  return getSameRoomLoadedWorkers(creep).some(
+    (worker) => {
+      var _a, _b;
+      return !isSameCreep(worker, creep) && worker.spawning !== true && ((_b = (_a = worker.memory) == null ? void 0 : _a.task) == null ? void 0 : _b.type) === "repair" && getActiveWorkParts2(worker) > 0;
+    }
+  );
 }
 function shouldBoundHealthyRcl3RoutineRepairs(creep, controller, constructionSites) {
   return (controller == null ? void 0 : controller.my) === true && getControllerLevel(controller) === 3 && canLevelUpController2(controller) && constructionSites.length === 0 && !hasVisibleHostilePresence3(creep.room) && hasHealthyRoomEnergyBuffer(creep.room) && getSameRoomLoadedWorkers(creep).length >= MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -25525,6 +25525,11 @@ function selectNearbyProductiveEnergySinkTask(creep, constructionSites, controll
     return null;
   }
   const constructionPriorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  const shouldDeferCoveredRcl3RoutineRepair = shouldDeferCoveredRcl3RoutineRepairToControllerProgress(
+    creep,
+    controller,
+    constructionSites
+  );
   const candidates = [
     ...constructionSites.filter(
       (site) => canSpendCreepEnergyOnConstructionSite(creep, site, constructionPriorityContext) && hasUnreservedConstructionProgress(creep, site, constructionReservationContext)
@@ -25538,7 +25543,7 @@ function selectNearbyProductiveEnergySinkTask(creep, constructionSites, controll
       )
     ),
     ...findVisibleRoomStructures(creep.room).filter(
-      (structure) => isRoutineRepairTargetForWorker(creep, structure) && !shouldDeferRoutineRepairToCoveredRcl3ControllerProgress(creep, controller, constructionSites, structure)
+      (structure) => isRoutineRepairTargetForWorker(creep, structure) && (!shouldDeferCoveredRcl3RoutineRepair || isUrgentRepairTargetForControllerProgressBudget(structure))
     ).map(
       (structure) => createProductiveEnergySinkCandidate(
         creep,
@@ -27322,7 +27327,10 @@ function selectAvailableRoutineRepairTarget(creep, repairTargets) {
   return (_a = repairTargets.find((structure) => hasRoutineRepairAssignmentCapacity(creep, structure))) != null ? _a : null;
 }
 function shouldDeferRoutineRepairToCoveredRcl3ControllerProgress(creep, controller, constructionSites, repairTarget) {
-  return !isUrgentRepairTargetForControllerProgressBudget(repairTarget) && shouldBoundHealthyRcl3RoutineRepairs(creep, controller, constructionSites) && hasSameRoomWorkerAssignedToTask(creep.room, creep, "repair");
+  return !isUrgentRepairTargetForControllerProgressBudget(repairTarget) && shouldDeferCoveredRcl3RoutineRepairToControllerProgress(creep, controller, constructionSites);
+}
+function shouldDeferCoveredRcl3RoutineRepairToControllerProgress(creep, controller, constructionSites) {
+  return shouldBoundHealthyRcl3RoutineRepairs(creep, controller, constructionSites) && hasSameRoomWorkerAssignedToTask(creep.room, creep, "repair");
 }
 function shouldBoundHealthyRcl3RoutineRepairs(creep, controller, constructionSites) {
   return (controller == null ? void 0 : controller.my) === true && getControllerLevel(controller) === 3 && canLevelUpController2(controller) && constructionSites.length === 0 && !hasVisibleHostilePresence3(creep.room) && hasHealthyRoomEnergyBuffer(creep.room) && getSameRoomLoadedWorkers(creep).length >= MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -23750,7 +23750,12 @@ function selectHeuristicWorkerTask(creep) {
     return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: constructionSite.id });
   }
   const routineBarrierMaintenanceTarget = selectRoutineBarrierMaintenanceRepairTarget(creep);
-  if (routineBarrierMaintenanceTarget) {
+  if (routineBarrierMaintenanceTarget && !shouldDeferRoutineRepairToCoveredRcl3ControllerProgress(
+    creep,
+    controller,
+    constructionSites,
+    routineBarrierMaintenanceTarget
+  )) {
     return applyMinimumUsefulLoadPolicy(creep, {
       type: "repair",
       targetId: routineBarrierMaintenanceTarget.id
@@ -23784,7 +23789,7 @@ function selectHeuristicWorkerTask(creep) {
     return canLevelUpController2(controller) ? applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id }) : null;
   }
   const repairTarget = selectRepairTarget(creep);
-  if (repairTarget) {
+  if (repairTarget && !shouldDeferRoutineRepairToCoveredRcl3ControllerProgress(creep, controller, constructionSites, repairTarget)) {
     return applyMinimumUsefulLoadPolicy(creep, { type: "repair", targetId: repairTarget.id });
   }
   const interRoomEnergyHaulTask = selectInterRoomEnergyHaulingTask(creep, carriedEnergy);
@@ -25532,7 +25537,9 @@ function selectNearbyProductiveEnergySinkTask(creep, constructionSites, controll
         canCompleteConstructionSiteWithCarriedEnergy(creep, site, constructionReservationContext)
       )
     ),
-    ...findVisibleRoomStructures(creep.room).filter((structure) => isRoutineRepairTargetForWorker(creep, structure)).map(
+    ...findVisibleRoomStructures(creep.room).filter(
+      (structure) => isRoutineRepairTargetForWorker(creep, structure) && !shouldDeferRoutineRepairToCoveredRcl3ControllerProgress(creep, controller, constructionSites, structure)
+    ).map(
       (structure) => createProductiveEnergySinkCandidate(
         creep,
         structure,
@@ -27313,6 +27320,15 @@ function computeRoutineRampartMaintenanceRepairTargets(room) {
 function selectAvailableRoutineRepairTarget(creep, repairTargets) {
   var _a;
   return (_a = repairTargets.find((structure) => hasRoutineRepairAssignmentCapacity(creep, structure))) != null ? _a : null;
+}
+function shouldDeferRoutineRepairToCoveredRcl3ControllerProgress(creep, controller, constructionSites, repairTarget) {
+  return !isUrgentRepairTargetForControllerProgressBudget(repairTarget) && shouldBoundHealthyRcl3RoutineRepairs(creep, controller, constructionSites) && hasSameRoomWorkerAssignedToTask(creep.room, creep, "repair");
+}
+function shouldBoundHealthyRcl3RoutineRepairs(creep, controller, constructionSites) {
+  return (controller == null ? void 0 : controller.my) === true && getControllerLevel(controller) === 3 && canLevelUpController2(controller) && constructionSites.length === 0 && !hasVisibleHostilePresence3(creep.room) && hasHealthyRoomEnergyBuffer(creep.room) && getSameRoomLoadedWorkers(creep).length >= MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS;
+}
+function isUrgentRepairTargetForControllerProgressBudget(repairTarget) {
+  return isUrgentBarrierRepairTarget(repairTarget) || isCriticalOwnedSpawnRepairTarget(repairTarget) || isRoadOrContainerRepairTarget(repairTarget) && getHitsRatio(repairTarget) <= CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO;
 }
 function canSelectRoutineBarrierMaintenanceRepairTarget(room) {
   var _a;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -3518,6 +3518,11 @@ function selectNearbyProductiveEnergySinkTask(
   }
 
   const constructionPriorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  const shouldDeferCoveredRcl3RoutineRepair = shouldDeferCoveredRcl3RoutineRepairToControllerProgress(
+    creep,
+    controller,
+    constructionSites
+  );
   const candidates = [
     ...constructionSites
       .filter(
@@ -3538,7 +3543,8 @@ function selectNearbyProductiveEnergySinkTask(
       .filter(
         (structure): structure is RepairableWorkerStructure =>
           isRoutineRepairTargetForWorker(creep, structure) &&
-          !shouldDeferRoutineRepairToCoveredRcl3ControllerProgress(creep, controller, constructionSites, structure)
+          (!shouldDeferCoveredRcl3RoutineRepair ||
+            isUrgentRepairTargetForControllerProgressBudget(structure))
       )
       .map((structure) =>
         createProductiveEnergySinkCandidate(
@@ -6427,6 +6433,16 @@ function shouldDeferRoutineRepairToCoveredRcl3ControllerProgress(
 ): boolean {
   return (
     !isUrgentRepairTargetForControllerProgressBudget(repairTarget) &&
+    shouldDeferCoveredRcl3RoutineRepairToControllerProgress(creep, controller, constructionSites)
+  );
+}
+
+function shouldDeferCoveredRcl3RoutineRepairToControllerProgress(
+  creep: Creep,
+  controller: StructureController | undefined,
+  constructionSites: ConstructionSite[]
+): boolean {
+  return (
     shouldBoundHealthyRcl3RoutineRepairs(creep, controller, constructionSites) &&
     hasSameRoomWorkerAssignedToTask(creep.room, creep, 'repair')
   );

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -6444,7 +6444,17 @@ function shouldDeferCoveredRcl3RoutineRepairToControllerProgress(
 ): boolean {
   return (
     shouldBoundHealthyRcl3RoutineRepairs(creep, controller, constructionSites) &&
-    hasSameRoomWorkerAssignedToTask(creep.room, creep, 'repair')
+    hasSameRoomLoadedRepairCoverage(creep)
+  );
+}
+
+function hasSameRoomLoadedRepairCoverage(creep: Creep): boolean {
+  return getSameRoomLoadedWorkers(creep).some(
+    (worker) =>
+      !isSameCreep(worker, creep) &&
+      worker.spawning !== true &&
+      worker.memory?.task?.type === 'repair' &&
+      getActiveWorkParts(worker) > 0
   );
 }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -739,7 +739,15 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
   }
 
   const routineBarrierMaintenanceTarget = selectRoutineBarrierMaintenanceRepairTarget(creep);
-  if (routineBarrierMaintenanceTarget) {
+  if (
+    routineBarrierMaintenanceTarget &&
+    !shouldDeferRoutineRepairToCoveredRcl3ControllerProgress(
+      creep,
+      controller,
+      constructionSites,
+      routineBarrierMaintenanceTarget
+    )
+  ) {
     return applyMinimumUsefulLoadPolicy(creep, {
       type: 'repair',
       targetId: routineBarrierMaintenanceTarget.id as Id<Structure>
@@ -786,7 +794,10 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
   }
 
   const repairTarget = selectRepairTarget(creep);
-  if (repairTarget) {
+  if (
+    repairTarget &&
+    !shouldDeferRoutineRepairToCoveredRcl3ControllerProgress(creep, controller, constructionSites, repairTarget)
+  ) {
     return applyMinimumUsefulLoadPolicy(creep, { type: 'repair', targetId: repairTarget.id as Id<Structure> });
   }
 
@@ -3524,7 +3535,11 @@ function selectNearbyProductiveEnergySinkTask(
         )
       ),
     ...findVisibleRoomStructures(creep.room)
-      .filter((structure) => isRoutineRepairTargetForWorker(creep, structure))
+      .filter(
+        (structure): structure is RepairableWorkerStructure =>
+          isRoutineRepairTargetForWorker(creep, structure) &&
+          !shouldDeferRoutineRepairToCoveredRcl3ControllerProgress(creep, controller, constructionSites, structure)
+      )
       .map((structure) =>
         createProductiveEnergySinkCandidate(
           creep,
@@ -6402,6 +6417,44 @@ function selectAvailableRoutineRepairTarget<T extends RepairableWorkerStructure>
   repairTargets: T[]
 ): T | null {
   return repairTargets.find((structure) => hasRoutineRepairAssignmentCapacity(creep, structure)) ?? null;
+}
+
+function shouldDeferRoutineRepairToCoveredRcl3ControllerProgress(
+  creep: Creep,
+  controller: StructureController | undefined,
+  constructionSites: ConstructionSite[],
+  repairTarget: RepairableWorkerStructure
+): boolean {
+  return (
+    !isUrgentRepairTargetForControllerProgressBudget(repairTarget) &&
+    shouldBoundHealthyRcl3RoutineRepairs(creep, controller, constructionSites) &&
+    hasSameRoomWorkerAssignedToTask(creep.room, creep, 'repair')
+  );
+}
+
+function shouldBoundHealthyRcl3RoutineRepairs(
+  creep: Creep,
+  controller: StructureController | undefined,
+  constructionSites: ConstructionSite[]
+): boolean {
+  return (
+    controller?.my === true &&
+    getControllerLevel(controller) === 3 &&
+    canLevelUpController(controller) &&
+    constructionSites.length === 0 &&
+    !hasVisibleHostilePresence(creep.room) &&
+    hasHealthyRoomEnergyBuffer(creep.room) &&
+    getSameRoomLoadedWorkers(creep).length >= MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS
+  );
+}
+
+function isUrgentRepairTargetForControllerProgressBudget(repairTarget: RepairableWorkerStructure): boolean {
+  return (
+    isUrgentBarrierRepairTarget(repairTarget) ||
+    isCriticalOwnedSpawnRepairTarget(repairTarget) ||
+    (isRoadOrContainerRepairTarget(repairTarget) &&
+      getHitsRatio(repairTarget) <= CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO)
+  );
 }
 
 function canSelectRoutineBarrierMaintenanceRepairTarget(room: Room): boolean {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -2376,6 +2376,98 @@ describe('runWorker', () => {
     expect(workers.every((worker) => (worker.transfer as jest.Mock).mock.calls.length === 0)).toBe(true);
   });
 
+  it('bounds healthy E29N55 RCL3 routine repair saturation after construction clears', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      progress: 1_000,
+      progressTotal: 135_000,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000,
+      pos: { x: 25, y: 25, roomName: 'E29N55' } as RoomPosition
+    } as StructureController;
+    const spawn = {
+      id: 'spawn1',
+      name: 'Spawn1',
+      my: true,
+      structureType: 'spawn',
+      spawning: null,
+      pos: { x: 17, y: 24, roomName: 'E29N55' } as RoomPosition,
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(300),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      }
+    } as unknown as StructureSpawn;
+    const repairTargets = Array.from({ length: 4 }, (_, index) => ({
+      id: `wall-routine-${index + 1}`,
+      structureType: 'constructedWall',
+      hits: IDLE_RAMPART_REPAIR_HITS_CEILING - 300 - index,
+      hitsMax: 300_000_000,
+      pos: { x: 20 + index, y: 23, roomName: 'E29N55' } as RoomPosition
+    })) as unknown as StructureWall[];
+    const workers: Creep[] = [];
+    const room = {
+      name: 'E29N55',
+      energyAvailable: 800,
+      energyCapacityAvailable: 800,
+      controller,
+      find: jest.fn((type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [];
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return workers;
+        }
+
+        if (type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES) {
+          const structures = [spawn, ...repairTargets] as unknown as AnyOwnedStructure[];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const makeWorker = (index: number): Creep =>
+      ({
+        name: `worker-E29N55-${index}`,
+        memory: {
+          role: 'worker',
+          colony: 'E29N55',
+          task: { type: 'repair', targetId: `wall-routine-${index}` as Id<Structure> }
+        },
+        store: {
+          getUsedCapacity: jest.fn().mockReturnValue(50),
+          getFreeCapacity: jest.fn().mockReturnValue(0),
+          getCapacity: jest.fn().mockReturnValue(50)
+        },
+        pos: { getRangeTo: jest.fn().mockReturnValue(4) },
+        room,
+        repair: jest.fn().mockReturnValue(0),
+        upgradeController: jest.fn().mockReturnValue(ERR_NOT_IN_RANGE),
+        moveTo: jest.fn()
+      }) as unknown as Creep;
+    workers.push(...Array.from({ length: 4 }, (_, index) => makeWorker(index + 1)));
+    const objectsById = new Map<string, StructureController | StructureSpawn | StructureWall>([
+      ['controller1', controller],
+      ['spawn1', spawn],
+      ...repairTargets.map((target) => [String(target.id), target] as [string, StructureWall])
+    ]);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 1_040_188,
+      creeps: Object.fromEntries(workers.map((worker) => [worker.name, worker])),
+      getObjectById: jest.fn((id: string) => objectsById.get(id) ?? null)
+    };
+
+    workers.forEach(runWorker);
+
+    const assignedTasks = workers.map((worker) => worker.memory.task?.type);
+    expect(assignedTasks.filter((task) => task === 'repair')).toHaveLength(1);
+    expect(assignedTasks.filter((task) => task === 'upgrade')).toHaveLength(3);
+    expect(workers.filter((worker) => (worker.upgradeController as jest.Mock).mock.calls.length > 0)).toHaveLength(3);
+    expect(workers.filter((worker) => (worker.repair as jest.Mock).mock.calls.length > 0)).toHaveLength(1);
+  });
+
   it('keeps emergency spawn-extension refill ahead of E29N55 construction backlog balancing', () => {
     const site = {
       id: 'tower-site1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -13673,6 +13673,70 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'container-critical' });
   });
 
+  it('keeps urgent RCL3 barrier repair ahead of controller progress when routine repair is already covered', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const urgentWall = makeStructure(
+      'wall-urgent',
+      'constructedWall' as StructureConstant,
+      BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING - 1,
+      300_000_000
+    );
+    const room = makeWorkerTaskRoom({
+      controller,
+      energyAvailable: 800,
+      energyCapacityAvailable: 800,
+      structures: [urgentWall]
+    });
+    const repairer = makeLoadedWorker(room, { type: 'repair', targetId: 'wall-urgent' as Id<Structure> });
+    const creep = {
+      name: 'UrgentRepairWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ Repairer: repairer, UrgentRepairWorker: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'wall-urgent' });
+  });
+
+  it('keeps RCL3 construction before bounded routine barrier repair', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const extensionSite = { id: 'extension-site1', my: true, structureType: 'extension' } as ConstructionSite;
+    const routineWall = makeStructure(
+      'wall-routine',
+      'constructedWall' as StructureConstant,
+      IDLE_RAMPART_REPAIR_HITS_CEILING - 300,
+      300_000_000
+    );
+    const room = makeWorkerTaskRoom({
+      constructionSites: [extensionSite],
+      controller,
+      energyAvailable: 800,
+      energyCapacityAvailable: 800,
+      structures: [routineWall]
+    });
+    const repairer = makeLoadedWorker(room, { type: 'repair', targetId: 'wall-routine' as Id<Structure> });
+    const creep = {
+      name: 'BuilderWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ Repairer: repairer, BuilderWorker: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'extension-site1' });
+  });
+
   it('chooses repair targets deterministically and avoids hostile structures', () => {
     const controller = { id: 'controller1', my: true } as StructureController;
     const hostileRampart = makeStructure('rampart-hostile', 'rampart' as StructureConstant, 100, 1_000, {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -13654,6 +13654,58 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
+  it('does not defer RCL3 routine repair to an empty worker with stale repair memory', () => {
+    const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 1_000, {
+      my: true
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const routineRoad = makeStructure('road-routine', 'road' as StructureConstant, 4_000, 5_000);
+    const room = makeWorkerTaskRoom({
+      controller,
+      energyAvailable: 800,
+      energyCapacityAvailable: 800,
+      structures: [storage, routineRoad]
+    });
+    const getRangeTo = jest.fn((target: RoomObject) => {
+      const ranges: Record<string, number> = {
+        'road-routine': 2,
+        controller1: 8
+      };
+      return ranges[String((target as { id?: string }).id)] ?? 99;
+    });
+    const emptyStaleRepairer = {
+      name: 'EmptyStaleRepairer',
+      memory: { role: 'worker', task: { type: 'repair', targetId: 'old-road' as Id<Structure> } },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      room
+    } as unknown as Creep;
+    const idleLoadedWorker = {
+      name: 'IdleLoadedWorker',
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    const creep = {
+      name: 'RepairCandidate',
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo },
+      room
+    } as unknown as Creep;
+    setGameCreeps({
+      EmptyStaleRepairer: emptyStaleRepairer,
+      IdleLoadedWorker: idleLoadedWorker,
+      RepairCandidate: creep
+    });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'road-routine' });
+  });
+
   it('keeps critical container repair ahead of routine assignment caps', () => {
     const controller = { id: 'controller1', my: true } as StructureController;
     const container = makeStructure('container-critical', 'container' as StructureConstant, 500, 2_000);


### PR DESCRIPTION
## Summary
- Bounds healthy RCL3 routine repair saturation so covered repair floors do not consume every loaded worker after construction clears.
- Preserves urgent barrier/spawn/critical road-container repair ahead of controller progress.
- Adds task/runner regression tests for E29N55 RCL3 repair-vs-upgrade balance.

Closes #1165

## Verification
- Controller verified in `/root/screeps-worktrees/issue-1165-repair-upgrade-balance/prod`:
  - `npm run typecheck`
  - `npm test -- --runInBand` (98 suites, 1924 tests passed)
  - `npm run build`

## Notes
- `prod/node_modules` is an untracked local symlink/dependency tree and is not staged.
- Commit authored by `lanyusea's bot <lanyusea@gmail.com>`.
