### PR TITLE
fix(rl): filter incomplete postdeploy samples from E1 gate

### DIFF
--- a/scripts/screeps_rl_dataset_export.py
+++ b/scripts/screeps_rl_dataset_export.py
@@ -40,7 +40,7 @@ DEFAULT_SAMPLE_LIMIT = 200
 DEFAULT_EVAL_RATIO = 0.2
 INCOMPLETE_DERIVED_RUNTIME_SUMMARY_SKIP_REASON = "incomplete_derived_runtime_summary"
 DERIVED_RUNTIME_SOURCE_MARKERS = ("screeps-runtime-monitor", "screeps-runtime-monitor-json")
-DERIVED_RUNTIME_PATH_MARKERS = ("postdeploy", "runtime-summary-monitor", "latest-summary-output")
+DERIVED_RUNTIME_BASENAME_PREFIXES = ("postdeploy-observation", "runtime-summary-monitor", "latest-summary-output")
 RUN_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 ROOM_RE = re.compile(r"^(?:(?P<shard>[^/]+)/)?(?P<room>[WE]\d+[NS]\d+)$")
 SECRET_TEXT_RE = re.compile(
@@ -660,8 +660,12 @@ def is_derived_postdeploy_or_monitor_record(record: ArtifactRecord) -> bool:
     if record.artifact_kind == "monitor-summary-json":
         return True
 
-    source_text = f"{record.source.path}\n{record.source.display_path}".lower()
-    return any(marker in source_text for marker in DERIVED_RUNTIME_PATH_MARKERS)
+    source_names = {Path(record.source.path).name.lower(), Path(record.source.display_path).name.lower()}
+    return any(
+        source_name.startswith(prefix)
+        for source_name in source_names
+        for prefix in DERIVED_RUNTIME_BASENAME_PREFIXES
+    )
 
 
 def derived_room_has_console_gate_fields(room: JsonObject) -> bool:

--- a/scripts/screeps_rl_dataset_export.py
+++ b/scripts/screeps_rl_dataset_export.py
@@ -38,6 +38,9 @@ DEFAULT_OUT_DIR = Path("runtime-artifacts/rl-datasets")
 DEFAULT_MAX_FILE_BYTES = 5 * 1024 * 1024
 DEFAULT_SAMPLE_LIMIT = 200
 DEFAULT_EVAL_RATIO = 0.2
+INCOMPLETE_DERIVED_RUNTIME_SUMMARY_SKIP_REASON = "incomplete_derived_runtime_summary"
+DERIVED_RUNTIME_SOURCE_MARKERS = ("screeps-runtime-monitor", "screeps-runtime-monitor-json")
+DERIVED_RUNTIME_PATH_MARKERS = ("postdeploy", "runtime-summary-monitor", "latest-summary-output")
 RUN_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 ROOM_RE = re.compile(r"^(?:(?P<shard>[^/]+)/)?(?P<room>[WE]\d+[NS]\d+)$")
 SECRET_TEXT_RE = re.compile(
@@ -590,6 +593,112 @@ def record_sort_key(record: ArtifactRecord) -> tuple[str, int, str, str]:
     )
 
 
+def filter_incomplete_derived_runtime_records(scan: ScanResult) -> None:
+    filtered_records: list[ArtifactRecord] = []
+    for record in scan.records:
+        filtered_record, skipped_rooms = prune_incomplete_derived_runtime_record(record)
+        if not skipped_rooms:
+            filtered_records.append(record)
+            continue
+
+        scan.skipped_files.append(
+            {
+                "path": record.source.display_path,
+                "reason": INCOMPLETE_DERIVED_RUNTIME_SUMMARY_SKIP_REASON,
+                "artifactKind": record.artifact_kind,
+                "lineNumber": record.line_number,
+                "skippedRooms": skipped_rooms,
+            }
+        )
+        if filtered_record is not None:
+            filtered_records.append(filtered_record)
+
+    scan.records = filtered_records
+
+
+def prune_incomplete_derived_runtime_record(record: ArtifactRecord) -> tuple[ArtifactRecord | None, list[str]]:
+    if not is_derived_postdeploy_or_monitor_record(record):
+        return record, []
+
+    rooms = record.payload.get("rooms")
+    if not isinstance(rooms, list):
+        return record, []
+
+    kept_rooms: list[JsonObject] = []
+    skipped_rooms: list[str] = []
+    for room in rooms:
+        if not isinstance(room, dict):
+            continue
+        if derived_room_has_console_gate_fields(room):
+            kept_rooms.append(room)
+            continue
+        room_name = room.get("roomName")
+        skipped_rooms.append(room_name if isinstance(room_name, str) and room_name else "unknown")
+
+    if not skipped_rooms:
+        return record, []
+    if not kept_rooms:
+        return None, skipped_rooms
+
+    payload = dict(record.payload)
+    payload["rooms"] = kept_rooms
+    return (
+        ArtifactRecord(
+            source=record.source,
+            artifact_kind=record.artifact_kind,
+            payload=payload,
+            line_number=record.line_number,
+        ),
+        skipped_rooms,
+    )
+
+
+def is_derived_postdeploy_or_monitor_record(record: ArtifactRecord) -> bool:
+    source_value = record.payload.get("source")
+    if isinstance(source_value, str) and any(marker in source_value.lower() for marker in DERIVED_RUNTIME_SOURCE_MARKERS):
+        return True
+    if record.artifact_kind == "monitor-summary-json":
+        return True
+
+    source_text = f"{record.source.path}\n{record.source.display_path}".lower()
+    return any(marker in source_text for marker in DERIVED_RUNTIME_PATH_MARKERS)
+
+
+def derived_room_has_console_gate_fields(room: JsonObject) -> bool:
+    task_counts = room.get("taskCounts")
+    has_task_counts = isinstance(task_counts, dict) and any(is_number(value) for value in task_counts.values())
+    has_energy_field = any(
+        is_number(nested_get(room, path))
+        for path in (
+            ("energyAvailable",),
+            ("resources", "storedEnergy"),
+            ("resources", "workerCarriedEnergy"),
+        )
+    )
+    has_creep_ownership = any(
+        is_number(nested_get(room, path))
+        for path in (
+            ("workerCount",),
+            ("ownedCreeps",),
+            ("ownedCreepCount",),
+            ("creeps",),
+            ("owned_creeps",),
+        )
+    )
+    has_spawn_ownership = isinstance(room.get("spawnStatus"), list) or any(
+        is_number(nested_get(room, path))
+        for path in (
+            ("monitor", "ownedSpawnCount"),
+            ("ownedSpawns",),
+            ("ownedSpawnCount",),
+            ("spawnCount",),
+            ("spawns",),
+            ("owned_spawns",),
+        )
+    )
+    return has_task_counts and has_energy_field and has_creep_ownership and has_spawn_ownership
+
+
 def build_dataset(
     paths: Sequence[str],
     out_dir: Path,
@@ -605,6 +714,7 @@ def build_dataset(
     resolved_bot_commit = bot_commit or git_commit(repo)
     resolved_out_dir = out_dir.expanduser()
     scan = collect_artifact_records(paths, max_file_bytes=max_file_bytes, excluded_roots=[resolved_out_dir])
+    filter_incomplete_derived_runtime_records(scan)
     rows = build_tick_rows(scan.records, resolved_bot_commit, sample_limit, eval_ratio_value, split_seed)
     resolved_run_id = run_id or deterministic_run_id(scan, rows, resolved_bot_commit, sample_limit, eval_ratio_value, split_seed)
     validate_run_id(resolved_run_id)

--- a/scripts/test_screeps_rl_dataset_export.py
+++ b/scripts/test_screeps_rl_dataset_export.py
@@ -292,6 +292,36 @@ class RlDatasetExportTest(unittest.TestCase):
         self.assertEqual(source_index["skippedFiles"][0]["reason"], "incomplete_derived_runtime_summary")
         self.assertEqual(source_index["skippedFiles"][0]["artifactKind"], "monitor-summary-json")
 
+    def test_incomplete_postdeploy_runtime_summary_json_is_filtered_by_basename(self) -> None:
+        runtime_payload = {
+            "type": "runtime-summary",
+            "tick": 123,
+            "rooms": [
+                {
+                    "roomName": "E29N55",
+                    "workerCount": 9,
+                    "spawnStatus": [{"name": "Spawn1", "status": "idle"}],
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact = root / "postdeploy-observation-20260517T140626Z.json"
+            artifact.write_text(json.dumps(runtime_payload, sort_keys=True), encoding="utf-8")
+            out_dir = root / "datasets"
+
+            summary = exporter.build_dataset([str(artifact)], out_dir, run_id="postdeploy-run", bot_commit="d" * 40)
+            rows = read_ndjson(out_dir / "postdeploy-run" / "ticks.ndjson")
+            source_index = read_json(out_dir / "postdeploy-run" / "source_index.json")
+
+        self.assertEqual(summary["sampleCount"], 0)
+        self.assertEqual(summary["runtimeSummaryArtifactCount"], 0)
+        self.assertEqual(len(rows), 0)
+        self.assertEqual(source_index["matchedArtifactCount"], 0)
+        self.assertEqual(source_index["skippedFiles"][0]["reason"], "incomplete_derived_runtime_summary")
+        self.assertEqual(source_index["skippedFiles"][0]["artifactKind"], "runtime-summary-json")
+
     def test_strategy_shadow_report_metadata_is_indexed_without_raw_report_copy(self) -> None:
         runtime_payload = {
             "type": "runtime-summary",

--- a/scripts/test_screeps_rl_dataset_export.py
+++ b/scripts/test_screeps_rl_dataset_export.py
@@ -258,7 +258,7 @@ class RlDatasetExportTest(unittest.TestCase):
         self.assertEqual(summary["sampleCount"], 1)
         self.assertEqual(summary["runtimeSummaryArtifactCount"], 1)
 
-    def test_monitor_summary_json_is_converted_to_sample(self) -> None:
+    def test_incomplete_postdeploy_monitor_summary_json_is_filtered_from_samples(self) -> None:
         monitor_payload = {
             "ok": True,
             "mode": "summary",
@@ -277,21 +277,20 @@ class RlDatasetExportTest(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
-            artifact = root / "monitor.json"
+            artifact = root / "postdeploy-observation-20260517T140626Z.json"
             artifact.write_text(json.dumps(monitor_payload, sort_keys=True), encoding="utf-8")
             out_dir = root / "datasets"
 
-            exporter.build_dataset([str(artifact)], out_dir, run_id="monitor-run", bot_commit="c" * 40)
+            summary = exporter.build_dataset([str(artifact)], out_dir, run_id="monitor-run", bot_commit="c" * 40)
             rows = read_ndjson(out_dir / "monitor-run" / "ticks.ndjson")
+            source_index = read_json(out_dir / "monitor-run" / "source_index.json")
 
-        self.assertEqual(len(rows), 1)
-        row = rows[0]
-        self.assertEqual(row["source"]["artifactKind"], "monitor-summary-json")
-        self.assertEqual(row["observation"]["roomName"], "E26S49")
-        self.assertEqual(row["observation"]["shard"], "shardX")
-        self.assertEqual(row["observation"]["workers"]["count"], 3)
-        self.assertEqual(row["observation"]["combat"]["hostileCreepCount"], 2)
-        self.assertEqual(row["observation"]["monitor"]["ownedSpawnCount"], 1)
+        self.assertEqual(summary["sampleCount"], 0)
+        self.assertEqual(summary["runtimeSummaryArtifactCount"], 0)
+        self.assertEqual(len(rows), 0)
+        self.assertEqual(source_index["matchedArtifactCount"], 0)
+        self.assertEqual(source_index["skippedFiles"][0]["reason"], "incomplete_derived_runtime_summary")
+        self.assertEqual(source_index["skippedFiles"][0]["artifactKind"], "monitor-summary-json")
 
     def test_strategy_shadow_report_metadata_is_indexed_without_raw_report_copy(self) -> None:
         runtime_payload = {

--- a/scripts/test_screeps_rl_dataset_gate.py
+++ b/scripts/test_screeps_rl_dataset_gate.py
@@ -68,6 +68,24 @@ def runtime_payload(tick: int, stored_energy: int = 1000) -> JsonObject:
     }
 
 
+def incomplete_postdeploy_monitor_payload(tick: int = 1056627) -> JsonObject:
+    return {
+        "ok": True,
+        "mode": "summary",
+        "room_summaries": [
+            {
+                "room": "shardX/E29N55",
+                "tick": tick,
+                "objects": 68,
+                "structures": 56,
+                "owned_creeps": 9,
+                "owned_spawns": 1,
+                "hostiles": 0,
+            }
+        ],
+    }
+
+
 def baseline_kpi_window() -> JsonObject:
     return {
         "type": "screeps-rl-kpi-window",
@@ -205,7 +223,7 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
     def test_run_rejects_dead_room_dataset_samples(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
-            artifact = root / "runtime.log"
+            artifact = root / "runtime-summary-console-20260517T000000Z.log"
             dead_room = runtime_payload(100, stored_energy=0)
             room = dead_room["rooms"][0]
             room["roomName"] = "E29N55"
@@ -242,6 +260,37 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
         self.assertIn("no_owned_creeps", report["quality_checks"]["rejection_reasons"])
         self.assertIn("no_owned_spawns", report["quality_checks"]["rejection_reasons"])
         self.assertTrue(any(reason["gate"] == "quality_checks" for reason in report["blockingReasons"]))
+
+    def test_run_filters_incomplete_postdeploy_monitor_artifact_without_quality_rejection(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            console_artifact = root / "runtime-summary-console-20260517T140000Z.log"
+            valid_home_room = runtime_payload(1056600)
+            valid_home_room["rooms"][0]["roomName"] = "E29N55"
+            console_artifact.write_text(runtime_line(valid_home_room), encoding="utf-8")
+
+            postdeploy_artifact = root / "postdeploy-observation-20260517T140626Z.json"
+            write_json(postdeploy_artifact, incomplete_postdeploy_monitor_payload())
+
+            report = gate.run_gate(
+                [str(console_artifact), str(postdeploy_artifact)],
+                out_dir=root / "gates",
+                gate_id="gate-filter-postdeploy",
+                created_at="2026-05-17T14:10:00Z",
+                dataset_out_dir=root / "datasets",
+                skip_shadow_report=True,
+                bot_commit="1" * 40,
+                eval_ratio_value=0,
+                repo_root=Path.cwd(),
+            )
+
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["dataset"]["sampleCount"], 1)
+        self.assertEqual(report["quality_checks"]["status"], "pass")
+        self.assertEqual(report["quality_checks"]["samples_accepted"], 1)
+        self.assertEqual(report["quality_checks"]["samples_rejected"], 0)
+        self.assertNotIn("no_room_energy", report["quality_checks"]["rejection_reasons"])
+        self.assertNotIn("no_harvest_or_upgrade_task", report["quality_checks"]["rejection_reasons"])
 
     def test_run_allows_non_home_room_without_owned_spawns(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_dataset_gate.py
+++ b/scripts/test_screeps_rl_dataset_gate.py
@@ -261,6 +261,41 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
         self.assertIn("no_owned_spawns", report["quality_checks"]["rejection_reasons"])
         self.assertTrue(any(reason["gate"] == "quality_checks" for reason in report["blockingReasons"]))
 
+    def test_run_rejects_dead_room_console_capture_under_postdeploy_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact = root / "postdeploy" / "runtime-summary-console-20260517T000000Z.log"
+            artifact.parent.mkdir(parents=True)
+            dead_room = runtime_payload(100, stored_energy=0)
+            room = dead_room["rooms"][0]
+            room["roomName"] = "E29N55"
+            room["workerCount"] = 0
+            room["spawnStatus"] = []
+            room["taskCounts"] = {"harvest": 0, "upgrade": 0, "none": 0}
+            room.pop("energyAvailable", None)
+            room["resources"].pop("storedEnergy", None)
+            room["resources"].pop("workerCarriedEnergy", None)
+            artifact.write_text(runtime_line(dead_room), encoding="utf-8")
+
+            report = gate.run_gate(
+                [str(artifact)],
+                out_dir=root / "gates",
+                gate_id="gate-dead-room-postdeploy-console",
+                created_at="2026-05-17T14:20:00Z",
+                dataset_out_dir=root / "datasets",
+                skip_shadow_report=True,
+                bot_commit="e" * 40,
+                eval_ratio_value=0,
+                repo_root=Path.cwd(),
+            )
+
+        self.assertFalse(report["ok"])
+        self.assertEqual(report["dataset"]["sampleCount"], 1)
+        self.assertEqual(report["quality_checks"]["status"], "fail")
+        self.assertEqual(report["quality_checks"]["samples_rejected"], 1)
+        self.assertIn("no_room_energy", report["quality_checks"]["rejection_reasons"])
+        self.assertIn("no_harvest_or_upgrade_task", report["quality_checks"]["rejection_reasons"])
+
     def test_run_filters_incomplete_postdeploy_monitor_artifact_without_quality_rejection(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary
- Filters incomplete derived postdeploy/runtime-monitor artifacts before E1 dataset row construction.
- Preserves valid console runtime-summary captures and real invalid console-sample quality rejections.
- Adds targeted regression coverage for the false `no_room_energy` / `no_harvest_or_upgrade_task` poisoning case from the latest E1 run.

Fixes #1175

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_dataset_export.py scripts/test_screeps_rl_dataset_export.py scripts/test_screeps_rl_dataset_gate.py`
- `python3 -m unittest scripts.test_screeps_rl_dataset_export scripts.test_screeps_rl_dataset_gate` (19 tests)

## Safety
- RL data-quality change only.
- No official MMO writes or deploys.
- No secrets printed.
