### PR TITLE
fix(rl): restore Loop A consumable card supply

### DIFF
--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -23,6 +23,11 @@ STRATEGY_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
 DRY_RUN_DATASET_RUN_ID = "rl-dry-run-000000000000"
 SAFETY_FALSE_FIELDS = ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed")
 SAFETY_TRUE_FIELDS = ("ood_rejection", "conservative_actions_only")
+LOOP_A_CARD_SUPPLY_TYPE = "screeps-rl-loop-a-card-supply"
+LOOP_A_CARD_SUPPLY_CONSUMER = "loop-a-policy-gradient"
+LOOP_A_CARD_SUPPLY_AVAILABLE = "available"
+LOOP_A_CARD_SUPPLY_CONSUMED = "consumed"
+LOOP_A_CARD_SUPPLY_STATES = (LOOP_A_CARD_SUPPLY_AVAILABLE, LOOP_A_CARD_SUPPLY_CONSUMED)
 DEFAULT_STRATEGY_VARIANTS = (
     "construction-priority.incumbent.v1",
     "construction-priority.territory-shadow.v1",
@@ -33,6 +38,9 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_SIMULATION_CODE_PATH = REPO_ROOT / "prod" / "dist" / "main.js"
 DEFAULT_SIMULATION_MAP_SOURCE_FILE = REPO_ROOT / "maps" / "map-0b6758af.json"
 DEFAULT_SIMULATION_OUT_DIR = REPO_ROOT / "runtime-artifacts" / "rl-simulator"
+DEFAULT_EXPERIMENT_CARD_DIR = REPO_ROOT / "runtime-artifacts" / "rl-experiment-cards"
+DEFAULT_DATASET_GATE_ROOT = REPO_ROOT / "runtime-artifacts" / "rl-dataset-gates"
+DEFAULT_TRAINING_REPORT_ROOT = REPO_ROOT / "runtime-artifacts" / "rl-training"
 DEFAULT_STRATEGY_REGISTRY_PATH = REPO_ROOT / "prod" / "src" / "strategy" / "strategyRegistry.ts"
 DEFAULT_SIMULATION_TICKS = 50
 DEFAULT_SIMULATION_REPETITIONS = 1
@@ -203,12 +211,15 @@ def build_card(
     simulation_repetitions: int | None = None,
     simulation_workers: int | None = None,
     registry_path: Path | None = None,
+    loop_a_card_supply: bool = False,
 ) -> JsonObject:
     validate_dataset_run_id(dataset_run_id)
     validate_code_commit(code_commit)
     validate_created_at(created_at)
     if training_approach not in TRAINING_APPROACHES:
         raise CardValidationError(f"training_approach must be one of: {', '.join(TRAINING_APPROACHES)}")
+    if loop_a_card_supply and training_approach != "policy_gradient":
+        raise CardValidationError("Loop A card supply requires training_approach=policy_gradient")
 
     default_ticks = POLICY_GRADIENT_SIMULATION_TICKS if training_approach == "policy_gradient" else DEFAULT_SIMULATION_TICKS
     default_repetitions = (
@@ -248,8 +259,30 @@ def build_card(
         policy_gradient = policy_gradient_block(registry_path or DEFAULT_STRATEGY_REGISTRY_PATH)
         card["policy_gradient"] = policy_gradient
         card["strategy_variants"] = policy_gradient_strategy_variants(policy_gradient)
+    if loop_a_card_supply:
+        card["card_supply"] = loop_a_card_supply_block(
+            dataset_run_id=dataset_run_id,
+            training_approach=training_approach,
+            created_at=created_at,
+        )
     validate_card(card)
     return card
+
+
+def loop_a_card_supply_block(*, dataset_run_id: str, training_approach: str, created_at: str) -> JsonObject:
+    return {
+        "type": LOOP_A_CARD_SUPPLY_TYPE,
+        "consumer": LOOP_A_CARD_SUPPLY_CONSUMER,
+        "state": LOOP_A_CARD_SUPPLY_AVAILABLE,
+        "available_for_training": True,
+        "dataset_run_id": dataset_run_id,
+        "training_approach": training_approach,
+        "created_at": created_at,
+        "status_field": "status",
+        "safety_status": "shadow",
+        "consumed_at": None,
+        "consumed_by_report_id": None,
+    }
 
 
 def require_positive_int(value: Any, label: str) -> int:
@@ -539,6 +572,7 @@ def validate_card(raw: Any) -> None:
 
     validate_safety(raw)
     validate_reward_model(raw.get("reward_model"))
+    validate_card_supply(raw)
     strategy_variants = first_present(raw, ("strategy_variants", "strategyVariants", "variants"))
     validate_strategy_variants(strategy_variants)
     validate_simulation(first_present(raw, ("simulation", "simulator")))
@@ -549,6 +583,176 @@ def validate_card(raw: Any) -> None:
         validate_policy_gradient(policy_gradient)
     if training_approach == "policy_gradient":
         validate_policy_gradient_strategy_variants(policy_gradient, strategy_variants)
+
+
+def validate_card_supply(card: JsonObject) -> None:
+    raw = first_present(card, ("card_supply", "cardSupply"))
+    if raw is None:
+        return
+    if not isinstance(raw, dict):
+        raise CardValidationError("card_supply must be a JSON object")
+    if raw.get("type") != LOOP_A_CARD_SUPPLY_TYPE:
+        raise CardValidationError(f"card_supply.type must be {LOOP_A_CARD_SUPPLY_TYPE}")
+    if raw.get("consumer") != LOOP_A_CARD_SUPPLY_CONSUMER:
+        raise CardValidationError(f"card_supply.consumer must be {LOOP_A_CARD_SUPPLY_CONSUMER}")
+    state = raw.get("state")
+    if state not in LOOP_A_CARD_SUPPLY_STATES:
+        raise CardValidationError("card_supply.state must be available or consumed")
+    if raw.get("dataset_run_id") != card.get("dataset_run_id"):
+        raise CardValidationError("card_supply.dataset_run_id must match dataset_run_id")
+    if raw.get("training_approach") != card.get("training_approach"):
+        raise CardValidationError("card_supply.training_approach must match training_approach")
+    if raw.get("safety_status") != "shadow":
+        raise CardValidationError("card_supply.safety_status must be shadow")
+    if raw.get("status_field") != "status":
+        raise CardValidationError("card_supply.status_field must be status")
+    created_at = raw.get("created_at")
+    if not isinstance(created_at, str):
+        raise CardValidationError("card_supply.created_at must be an ISO UTC timestamp")
+    validate_created_at(created_at)
+
+    if state == LOOP_A_CARD_SUPPLY_AVAILABLE:
+        if card.get("status") != "shadow":
+            raise CardValidationError("available Loop A card supply requires status=shadow")
+        if card.get("training_approach") != "policy_gradient":
+            raise CardValidationError("available Loop A card supply requires training_approach=policy_gradient")
+        if raw.get("available_for_training") is not True:
+            raise CardValidationError("card_supply.available_for_training must be true for available supply")
+        if raw.get("consumed_at") is not None:
+            raise CardValidationError("available Loop A card supply must not set consumed_at")
+        if raw.get("consumed_by_report_id") is not None:
+            raise CardValidationError("available Loop A card supply must not set consumed_by_report_id")
+    else:
+        if raw.get("available_for_training") is not False:
+            raise CardValidationError("consumed Loop A card supply must set available_for_training=false")
+        consumed_at = raw.get("consumed_at")
+        if not isinstance(consumed_at, str):
+            raise CardValidationError("consumed Loop A card supply requires consumed_at")
+        validate_created_at(consumed_at)
+        if not isinstance(raw.get("consumed_by_report_id"), str) or not raw.get("consumed_by_report_id"):
+            raise CardValidationError("consumed Loop A card supply requires consumed_by_report_id")
+
+
+def is_loop_a_card_available_for_training(card: JsonObject, consumed_card_ids: set[str] | None = None) -> bool:
+    try:
+        validate_card(card)
+    except CardValidationError:
+        return False
+    supply = first_present(card, ("card_supply", "cardSupply"))
+    if not isinstance(supply, dict):
+        return False
+    card_id = card.get("card_id")
+    if consumed_card_ids is not None and isinstance(card_id, str) and card_id in consumed_card_ids:
+        return False
+    return (
+        card.get("status") == "shadow"
+        and card.get("training_approach") == "policy_gradient"
+        and supply.get("state") == LOOP_A_CARD_SUPPLY_AVAILABLE
+        and supply.get("available_for_training") is True
+        and supply.get("consumer") == LOOP_A_CARD_SUPPLY_CONSUMER
+    )
+
+
+def consumed_card_ids_from_training_reports(report_root: Path) -> set[str]:
+    consumed: set[str] = set()
+    if not report_root.exists():
+        return consumed
+    for path in sorted(report_root.rglob("*.json")):
+        try:
+            payload = load_json(path)
+        except CardValidationError:
+            continue
+        if not isinstance(payload, dict) or payload.get("type") != "screeps-rl-training-report":
+            continue
+        card = payload.get("experimentCard")
+        if not isinstance(card, dict):
+            continue
+        card_id = card.get("cardId", card.get("card_id"))
+        if isinstance(card_id, str) and card_id:
+            consumed.add(card_id)
+    return consumed
+
+
+def select_loop_a_card_supply(card_dir: Path, training_report_root: Path) -> JsonObject | None:
+    consumed_card_ids = consumed_card_ids_from_training_reports(training_report_root)
+    candidates: list[tuple[str, str, Path, JsonObject]] = []
+    if not card_dir.exists():
+        return None
+    for path in sorted(card_dir.rglob("*.json")):
+        try:
+            card = load_json(path)
+        except CardValidationError:
+            continue
+        if not isinstance(card, dict):
+            continue
+        if not is_loop_a_card_available_for_training(card, consumed_card_ids):
+            continue
+        created_at = str(card.get("created_at") or "")
+        card_id = str(card.get("card_id") or "")
+        candidates.append((created_at, card_id, path, card))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: (item[0], item[1], str(item[2])), reverse=True)
+    _, _, path, card = candidates[0]
+    return loop_a_selection_summary(path, card, consumed_card_ids)
+
+
+def loop_a_selection_summary(path: Path, card: JsonObject, consumed_card_ids: set[str]) -> JsonObject:
+    return {
+        "ok": True,
+        "card_path": str(path),
+        "card_id": card.get("card_id"),
+        "dataset_run_id": card.get("dataset_run_id"),
+        "training_approach": card.get("training_approach"),
+        "status": card.get("status"),
+        "card_supply": first_present(card, ("card_supply", "cardSupply")),
+        "consumed_card_count": len(consumed_card_ids),
+    }
+
+
+def latest_accepted_dataset_run_id(gate_root: Path) -> str:
+    candidates: list[tuple[str, float, str, Path]] = []
+    if not gate_root.exists():
+        raise CardValidationError(f"dataset gate root does not exist: {gate_root}")
+    for path in sorted(gate_root.rglob("*.json")):
+        try:
+            payload = load_json(path)
+        except CardValidationError:
+            continue
+        if not isinstance(payload, dict) or payload.get("ok") is not True:
+            continue
+        run_id = accepted_dataset_run_id(payload)
+        if run_id is None:
+            continue
+        created_at = accepted_dataset_created_at(payload)
+        mtime = path.stat().st_mtime
+        candidates.append((created_at or "", mtime, run_id, path))
+    if not candidates:
+        raise CardValidationError(f"no accepted dataset gate with datasetRunId found under {gate_root}")
+    candidates.sort(key=lambda item: (item[0], item[1], str(item[3])), reverse=True)
+    return candidates[0][2]
+
+
+def accepted_dataset_run_id(payload: JsonObject) -> str | None:
+    direct = payload.get("datasetRunId")
+    if isinstance(direct, str) and direct:
+        validate_dataset_run_id(direct)
+        return direct
+    dataset = payload.get("dataset")
+    if isinstance(dataset, dict):
+        run_id = dataset.get("runId")
+        if isinstance(run_id, str) and run_id:
+            validate_dataset_run_id(run_id)
+            return run_id
+    return None
+
+
+def accepted_dataset_created_at(payload: JsonObject) -> str | None:
+    for key in ("createdAt", "generatedAt"):
+        value = payload.get(key)
+        if isinstance(value, str) and ISO_TIMESTAMP_RE.fullmatch(value):
+            return value
+    return None
 
 
 def require_string(raw: JsonObject, field: str) -> str:
@@ -802,7 +1006,7 @@ def write_output(payload: Any, output: Path | None, stdout: TextIO) -> None:
 
 def validation_summary(card: JsonObject) -> JsonObject:
     safety = card.get("safety") if isinstance(card.get("safety"), dict) else {}
-    return {
+    summary = {
         "card_id": card.get("card_id"),
         "dataset_run_id": card.get("dataset_run_id"),
         "ok": True,
@@ -812,6 +1016,19 @@ def validation_summary(card: JsonObject) -> JsonObject:
         },
         "status": card.get("status"),
     }
+    card_supply = first_present(card, ("card_supply", "cardSupply"))
+    if isinstance(card_supply, dict):
+        summary["card_supply"] = card_supply
+        summary["loop_a_available_for_training"] = is_loop_a_card_available_for_training(card)
+    return summary
+
+
+def generated_card_summary(card: JsonObject, output_path: Path) -> JsonObject:
+    summary = validation_summary(card)
+    summary["path"] = str(output_path)
+    summary["created_at"] = card.get("created_at")
+    summary["training_approach"] = card.get("training_approach")
+    return summary
 
 
 def run_self_test(stdout: TextIO) -> int:
@@ -898,6 +1115,42 @@ def build_parser() -> argparse.ArgumentParser:
         help="Generate a synthetic offline card without requiring a real dataset run artifact.",
     )
     parser.add_argument(
+        "--loop-a-policy-gradient-supply",
+        action="store_true",
+        help=(
+            "Generate an offline/shadow policy_gradient card with explicit Loop A "
+            "available-for-training supply metadata."
+        ),
+    )
+    parser.add_argument(
+        "--from-latest-accepted-dataset",
+        action="store_true",
+        help="Use the latest accepted dataset gate under --dataset-gate-root as dataset_run_id.",
+    )
+    parser.add_argument(
+        "--dataset-gate-root",
+        type=Path,
+        default=DEFAULT_DATASET_GATE_ROOT,
+        help=f"Root scanned by --from-latest-accepted-dataset. Default: {DEFAULT_DATASET_GATE_ROOT}.",
+    )
+    parser.add_argument(
+        "--select-loop-a-card",
+        action="store_true",
+        help="Select the newest Loop A card_supply.available card not already referenced by a training report.",
+    )
+    parser.add_argument(
+        "--card-dir",
+        type=Path,
+        default=DEFAULT_EXPERIMENT_CARD_DIR,
+        help=f"Experiment card directory scanned by --select-loop-a-card. Default: {DEFAULT_EXPERIMENT_CARD_DIR}.",
+    )
+    parser.add_argument(
+        "--training-report-dir",
+        type=Path,
+        default=DEFAULT_TRAINING_REPORT_ROOT,
+        help=f"Training report directory scanned by --select-loop-a-card. Default: {DEFAULT_TRAINING_REPORT_ROOT}.",
+    )
+    parser.add_argument(
         "--validate",
         action="store_true",
         help="Validate an existing card JSON instead of generating one.",
@@ -911,6 +1164,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--output",
         type=Path,
         help="Write generated card or validation summary to this path instead of stdout.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Write generated card to <output-dir>/<card_id>.json and print a compact summary.",
     )
     return parser
 
@@ -929,6 +1187,28 @@ def main(
         if args.command == "self-test":
             return run_self_test(stdout)
 
+        if args.output is not None and args.output_dir is not None:
+            raise CardValidationError("--output and --output-dir are mutually exclusive")
+
+        if args.select_loop_a_card:
+            if args.validate:
+                raise CardValidationError("--select-loop-a-card cannot be combined with --validate")
+            selected = select_loop_a_card_supply(args.card_dir, args.training_report_dir)
+            if selected is None:
+                write_output(
+                    {
+                        "ok": False,
+                        "reason": "NO_AVAILABLE_LOOP_A_CARD",
+                        "card_dir": str(args.card_dir),
+                        "training_report_dir": str(args.training_report_dir),
+                    },
+                    args.output,
+                    stdout,
+                )
+                return 1
+            write_output(selected, args.output, stdout)
+            return 0
+
         if args.validate:
             if args.input is None:
                 raise CardValidationError("--validate requires --input")
@@ -938,20 +1218,31 @@ def main(
             return 0
 
         dataset_run_id = args.dataset_run_id
+        if args.from_latest_accepted_dataset:
+            if dataset_run_id is not None:
+                raise CardValidationError("--from-latest-accepted-dataset cannot be combined with --dataset-run-id")
+            dataset_run_id = latest_accepted_dataset_run_id(args.dataset_gate_root)
         if dataset_run_id is None:
             if not args.dry_run:
                 raise CardValidationError("--dataset-run-id is required unless --dry-run is used")
             dataset_run_id = DRY_RUN_DATASET_RUN_ID
 
+        training_approach = "policy_gradient" if args.loop_a_policy_gradient_supply else args.training_approach
         card = build_card(
             dataset_run_id=dataset_run_id,
             code_commit=args.code_commit or git_commit(repo),
-            training_approach=args.training_approach,
+            training_approach=training_approach,
             created_at=args.created_at or utc_now_iso(),
             simulation_ticks=args.ticks,
             simulation_repetitions=args.repetitions,
             simulation_workers=args.workers,
+            loop_a_card_supply=args.loop_a_policy_gradient_supply,
         )
+        if args.output_dir is not None:
+            output_path = args.output_dir / f"{card['card_id']}.json"
+            write_output(card, output_path, stdout)
+            stdout.write(canonical_json(generated_card_summary(card, output_path)))
+            return 0
         write_output(card, args.output, stdout)
         return 0
     except CardValidationError as error:

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -667,10 +667,21 @@ def consumed_card_ids_from_training_reports(report_root: Path) -> set[str]:
         card = payload.get("experimentCard")
         if not isinstance(card, dict):
             continue
+        card_supply = first_present(card, ("cardSupply", "card_supply"))
+        if not is_loop_a_card_supply_metadata(card_supply):
+            continue
         card_id = card.get("cardId", card.get("card_id"))
         if isinstance(card_id, str) and card_id:
             consumed.add(card_id)
     return consumed
+
+
+def is_loop_a_card_supply_metadata(raw: Any) -> bool:
+    return (
+        isinstance(raw, dict)
+        and raw.get("type") == LOOP_A_CARD_SUPPLY_TYPE
+        and raw.get("consumer") == LOOP_A_CARD_SUPPLY_CONSUMER
+    )
 
 
 def select_loop_a_card_supply(card_dir: Path, training_report_root: Path) -> JsonObject | None:
@@ -721,11 +732,14 @@ def latest_accepted_dataset_run_id(gate_root: Path) -> str:
             continue
         if not isinstance(payload, dict) or payload.get("ok") is not True:
             continue
-        run_id = accepted_dataset_run_id(payload)
-        if run_id is None:
+        try:
+            run_id = accepted_dataset_run_id(payload)
+            if run_id is None:
+                continue
+            created_at = accepted_dataset_created_at(payload)
+            mtime = path.stat().st_mtime
+        except (CardValidationError, OSError):
             continue
-        created_at = accepted_dataset_created_at(payload)
-        mtime = path.stat().st_mtime
         candidates.append((created_at or "", mtime, run_id, path))
     if not candidates:
         raise CardValidationError(f"no accepted dataset gate with datasetRunId found under {gate_root}")

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -34,8 +34,14 @@ STEAM_KEY_ENV_FILE_ENV = "SCREEPS_RL_STEAM_KEY_ENV_FILE"
 REWARD_TIERS = ("reliability", "territory", "resources", "kills")
 SAFETY_FALSE_FIELDS = ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed")
 SAFETY_TRUE_FIELDS = ("conservative_actions_only", "ood_rejection")
+LOOP_A_CARD_SUPPLY_TYPE = "screeps-rl-loop-a-card-supply"
+LOOP_A_CARD_SUPPLY_CONSUMER = "loop-a-policy-gradient"
+LOOP_A_CARD_SUPPLY_AVAILABLE = "available"
+LOOP_A_CARD_SUPPLY_CONSUMED = "consumed"
+LOOP_A_CARD_SUPPLY_STATES = (LOOP_A_CARD_SUPPLY_AVAILABLE, LOOP_A_CARD_SUPPLY_CONSUMED)
 REPORT_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 STRATEGY_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
+ISO_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
 JsonObject = dict[str, Any]
 SimulatorRunner = Callable[..., JsonObject]
 
@@ -254,6 +260,8 @@ def validate_experiment_card(card: JsonObject) -> None:
     if scalar_authorized is not False:
         raise TrainingCardError("reward_model.scalar_weighted_sum_authorized must be false")
 
+    validate_card_supply(card)
+
     raw_variants = raw_variant_definitions(card)
     if not isinstance(raw_variants, list) or len(raw_variants) == 0:
         raise TrainingCardError("experiment card must define at least one strategy variant")
@@ -277,6 +285,52 @@ def validate_experiment_card(card: JsonObject) -> None:
         and positive_int_value(simulation.get("host_port_start", simulation.get("hostPortStart"))) is None
     ):
         raise TrainingCardError("simulation.host_port_start must be a positive integer")
+
+
+def validate_card_supply(card: JsonObject) -> None:
+    raw = card.get("card_supply", card.get("cardSupply"))
+    if raw is None:
+        return
+    if not isinstance(raw, dict):
+        raise TrainingCardError("card_supply must be an object")
+    if raw.get("type") != LOOP_A_CARD_SUPPLY_TYPE:
+        raise TrainingCardError(f"card_supply.type must be {LOOP_A_CARD_SUPPLY_TYPE}")
+    if raw.get("consumer") != LOOP_A_CARD_SUPPLY_CONSUMER:
+        raise TrainingCardError(f"card_supply.consumer must be {LOOP_A_CARD_SUPPLY_CONSUMER}")
+    state = raw.get("state")
+    if state not in LOOP_A_CARD_SUPPLY_STATES:
+        raise TrainingCardError("card_supply.state must be available or consumed")
+    if raw.get("dataset_run_id") != card.get("dataset_run_id", card.get("datasetRunId")):
+        raise TrainingCardError("card_supply.dataset_run_id must match dataset_run_id")
+    if raw.get("training_approach") != card.get("training_approach", card.get("trainingApproach")):
+        raise TrainingCardError("card_supply.training_approach must match training_approach")
+    if raw.get("safety_status") != "shadow":
+        raise TrainingCardError("card_supply.safety_status must be shadow")
+    if raw.get("status_field") != "status":
+        raise TrainingCardError("card_supply.status_field must be status")
+    created_at = raw.get("created_at")
+    if not isinstance(created_at, str) or not ISO_TIMESTAMP_RE.fullmatch(created_at):
+        raise TrainingCardError("card_supply.created_at must be an ISO UTC timestamp")
+
+    if state == LOOP_A_CARD_SUPPLY_AVAILABLE:
+        if card.get("status") != "shadow":
+            raise TrainingCardError("available Loop A card supply requires status=shadow")
+        if card.get("training_approach", card.get("trainingApproach")) != "policy_gradient":
+            raise TrainingCardError("available Loop A card supply requires training_approach=policy_gradient")
+        if raw.get("available_for_training") is not True:
+            raise TrainingCardError("card_supply.available_for_training must be true for available supply")
+        if raw.get("consumed_at") is not None:
+            raise TrainingCardError("available Loop A card supply must not set consumed_at")
+        if raw.get("consumed_by_report_id") is not None:
+            raise TrainingCardError("available Loop A card supply must not set consumed_by_report_id")
+    else:
+        if raw.get("available_for_training") is not False:
+            raise TrainingCardError("consumed Loop A card supply must set available_for_training=false")
+        consumed_at = raw.get("consumed_at")
+        if not isinstance(consumed_at, str) or not ISO_TIMESTAMP_RE.fullmatch(consumed_at):
+            raise TrainingCardError("consumed Loop A card supply requires consumed_at")
+        if not isinstance(raw.get("consumed_by_report_id"), str) or not raw.get("consumed_by_report_id"):
+            raise TrainingCardError("consumed Loop A card supply requires consumed_by_report_id")
 
 
 def raw_variant_definitions(card: JsonObject) -> Any:
@@ -1855,6 +1909,9 @@ def summarize_card(card: JsonObject, path: Path) -> JsonObject:
     policy_gradient = policy_gradient_metadata_from_card(card)
     if policy_gradient is not None:
         summary["policyGradient"] = policy_gradient
+    card_supply = card.get("card_supply", card.get("cardSupply"))
+    if isinstance(card_supply, dict):
+        summary["cardSupply"] = copy.deepcopy(card_supply)
     return summary
 
 

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -133,6 +133,155 @@ class RlExperimentCardTest(unittest.TestCase):
             self.assertFalse(candidate["parameterEvidence"]["liveEffect"])
             self.assertFalse(candidate["parameterEvidence"]["officialMmoWrites"])
 
+    def test_loop_a_policy_gradient_supply_card_remains_shadow_and_available(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-loop-a-supply-000001",
+            code_commit="f" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-17T01:25:00Z",
+            loop_a_card_supply=True,
+        )
+
+        card_helper.validate_card(card)
+        runner.validate_experiment_card(card)
+
+        supply = card["card_supply"]
+        self.assertEqual(card["status"], "shadow")
+        self.assertEqual(card["training_approach"], "policy_gradient")
+        self.assertEqual(supply["state"], "available")
+        self.assertTrue(supply["available_for_training"])
+        self.assertEqual(supply["consumer"], "loop-a-policy-gradient")
+        self.assertEqual(supply["safety_status"], "shadow")
+        self.assertTrue(card_helper.is_loop_a_card_available_for_training(card))
+        self.assertFalse(card["liveEffect"])
+        self.assertFalse(card["officialMmoWrites"])
+        self.assertFalse(card["officialMmoWritesAllowed"])
+        self.assertTrue(card["conservative_actions_only"])
+        self.assertTrue(card["ood_rejection"])
+        self.assertEqual(card["reward_model"]["component_order"], ["reliability", "territory", "resources", "kills"])
+        self.assertFalse(card["reward_model"]["scalar_weighted_sum_authorized"])
+
+    def test_loop_a_supply_rejects_bandit_card(self) -> None:
+        with self.assertRaisesRegex(card_helper.CardValidationError, "requires training_approach=policy_gradient"):
+            card_helper.build_card(
+                dataset_run_id="rl-loop-a-bandit",
+                code_commit="f" * 40,
+                training_approach="bandit",
+                created_at="2026-05-17T01:25:00Z",
+                loop_a_card_supply=True,
+            )
+
+    def test_cli_generates_loop_a_supply_from_latest_accepted_dataset(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            gate_root = root / "gates"
+            card_dir = root / "cards"
+            older_gate = gate_root / "older" / "gate_report.json"
+            newer_gate = gate_root / "newer" / "gate_report.json"
+            failed_gate = gate_root / "failed" / "gate_report.json"
+            older_gate.parent.mkdir(parents=True)
+            newer_gate.parent.mkdir(parents=True)
+            failed_gate.parent.mkdir(parents=True)
+            older_gate.write_text(
+                json.dumps(
+                    {
+                        "ok": True,
+                        "createdAt": "2026-05-17T01:00:00Z",
+                        "dataset": {"runId": "rl-accepted-older"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            newer_gate.write_text(
+                json.dumps(
+                    {
+                        "ok": True,
+                        "createdAt": "2026-05-17T02:00:00Z",
+                        "dataset": {"runId": "rl-accepted-newer"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            failed_gate.write_text(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "createdAt": "2026-05-17T03:00:00Z",
+                        "dataset": {"runId": "rl-rejected-newest"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            stdout = io.StringIO()
+
+            exit_code = card_helper.main(
+                [
+                    "--loop-a-policy-gradient-supply",
+                    "--from-latest-accepted-dataset",
+                    "--dataset-gate-root",
+                    str(gate_root),
+                    "--code-commit",
+                    "6" * 40,
+                    "--created-at",
+                    "2026-05-17T02:05:00Z",
+                    "--output-dir",
+                    str(card_dir),
+                ],
+                stdout=stdout,
+                stderr=io.StringIO(),
+                repo_root=REPO_ROOT,
+            )
+            summary = json.loads(stdout.getvalue())
+            generated = json.loads(Path(summary["path"]).read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(summary["dataset_run_id"], "rl-accepted-newer")
+        self.assertEqual(summary["card_supply"]["state"], "available")
+        self.assertEqual(generated["dataset_run_id"], "rl-accepted-newer")
+        self.assertEqual(generated["training_approach"], "policy_gradient")
+        self.assertEqual(generated["status"], "shadow")
+        self.assertTrue(card_helper.is_loop_a_card_available_for_training(generated))
+
+    def test_select_loop_a_card_skips_training_report_consumed_card(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_dir = root / "cards"
+            report_dir = root / "reports"
+            card_dir.mkdir()
+            consumed = card_helper.build_card(
+                dataset_run_id="rl-loop-a-consumed",
+                code_commit="1" * 40,
+                training_approach="policy_gradient",
+                created_at="2026-05-17T02:00:00Z",
+                loop_a_card_supply=True,
+            )
+            available = card_helper.build_card(
+                dataset_run_id="rl-loop-a-available",
+                code_commit="2" * 40,
+                training_approach="policy_gradient",
+                created_at="2026-05-17T01:00:00Z",
+                loop_a_card_supply=True,
+            )
+            (card_dir / "consumed.json").write_text(json.dumps(consumed), encoding="utf-8")
+            (card_dir / "available.json").write_text(json.dumps(available), encoding="utf-8")
+            report_dir.mkdir()
+            (report_dir / "training.json").write_text(
+                json.dumps(
+                    {
+                        "type": "screeps-rl-training-report",
+                        "experimentCard": {"cardId": consumed["card_id"]},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            selected = card_helper.select_loop_a_card_supply(card_dir, report_dir)
+
+        self.assertIsNotNone(selected)
+        assert selected is not None
+        self.assertEqual(selected["card_id"], available["card_id"])
+        self.assertEqual(selected["card_supply"]["state"], "available")
+
     def test_policy_gradient_missing_registry_uses_fallback_defaults(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             card = card_helper.build_card(

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -242,6 +242,79 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(generated["status"], "shadow")
         self.assertTrue(card_helper.is_loop_a_card_available_for_training(generated))
 
+    def test_latest_accepted_dataset_skips_malformed_accepted_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            gate_root = root / "gates"
+            valid_gate = gate_root / "valid" / "gate_report.json"
+            malformed_gate = gate_root / "malformed" / "gate_report.json"
+            valid_gate.parent.mkdir(parents=True)
+            malformed_gate.parent.mkdir(parents=True)
+            valid_gate.write_text(
+                json.dumps(
+                    {
+                        "ok": True,
+                        "createdAt": "2026-05-17T01:00:00Z",
+                        "dataset": {"runId": "rl-accepted-valid"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            malformed_gate.write_text(
+                json.dumps(
+                    {
+                        "ok": True,
+                        "createdAt": "2026-05-17T02:00:00Z",
+                        "dataset": {"runId": "invalid run id"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            selected = card_helper.latest_accepted_dataset_run_id(gate_root)
+
+        self.assertEqual(selected, "rl-accepted-valid")
+
+    def test_latest_accepted_dataset_skips_gate_deleted_during_scan(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            gate_root = root / "gates"
+            valid_gate = gate_root / "valid" / "gate_report.json"
+            vanished_gate = gate_root / "vanished" / "gate_report.json"
+            valid_gate.parent.mkdir(parents=True)
+            vanished_gate.parent.mkdir(parents=True)
+            valid_gate.write_text(
+                json.dumps(
+                    {
+                        "ok": True,
+                        "createdAt": "2026-05-17T01:00:00Z",
+                        "dataset": {"runId": "rl-accepted-valid"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            vanished_gate.write_text(
+                json.dumps(
+                    {
+                        "ok": True,
+                        "createdAt": "2026-05-17T02:00:00Z",
+                        "dataset": {"runId": "rl-accepted-vanished"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            original_stat = Path.stat
+
+            def stat_or_raise(path: Path, *args: object, **kwargs: object) -> os.stat_result:
+                if path == vanished_gate:
+                    raise OSError("deleted during scan")
+                return original_stat(path, *args, **kwargs)
+
+            with mock.patch.object(Path, "stat", stat_or_raise):
+                selected = card_helper.latest_accepted_dataset_run_id(gate_root)
+
+        self.assertEqual(selected, "rl-accepted-valid")
+
     def test_select_loop_a_card_skips_training_report_consumed_card(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -269,7 +342,10 @@ class RlExperimentCardTest(unittest.TestCase):
                 json.dumps(
                     {
                         "type": "screeps-rl-training-report",
-                        "experimentCard": {"cardId": consumed["card_id"]},
+                        "experimentCard": {
+                            "cardId": consumed["card_id"],
+                            "cardSupply": consumed["card_supply"],
+                        },
                     }
                 ),
                 encoding="utf-8",
@@ -281,6 +357,52 @@ class RlExperimentCardTest(unittest.TestCase):
         assert selected is not None
         self.assertEqual(selected["card_id"], available["card_id"])
         self.assertEqual(selected["card_supply"]["state"], "available")
+
+    def test_select_loop_a_card_ignores_non_loop_a_training_report_with_same_card_id(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_dir = root / "cards"
+            report_dir = root / "reports"
+            card_dir.mkdir()
+            report_dir.mkdir()
+            available = card_helper.build_card(
+                dataset_run_id="rl-loop-a-available",
+                code_commit="2" * 40,
+                training_approach="policy_gradient",
+                created_at="2026-05-17T01:00:00Z",
+                loop_a_card_supply=True,
+            )
+            (card_dir / "available.json").write_text(json.dumps(available), encoding="utf-8")
+            (report_dir / "bare-card-id.json").write_text(
+                json.dumps(
+                    {
+                        "type": "screeps-rl-training-report",
+                        "experimentCard": {"cardId": available["card_id"]},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (report_dir / "wrong-supply-type.json").write_text(
+                json.dumps(
+                    {
+                        "type": "screeps-rl-training-report",
+                        "experimentCard": {
+                            "cardId": available["card_id"],
+                            "cardSupply": {
+                                "type": "unrelated-supply",
+                                "consumer": "loop-a-policy-gradient",
+                            },
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            selected = card_helper.select_loop_a_card_supply(card_dir, report_dir)
+
+        self.assertIsNotNone(selected)
+        assert selected is not None
+        self.assertEqual(selected["card_id"], available["card_id"])
 
     def test_policy_gradient_missing_registry_uses_fallback_defaults(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -915,6 +915,71 @@ export const STRATEGY_REGISTRY = [
         )
         self.assertEqual(first_result["parameterEvidence"]["sourceStrategyId"], "construction-priority.incumbent.v1")
 
+    def test_loop_a_supply_report_preserves_card_supply_and_is_discoverably_consumed(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-loop-a-runner-report",
+            code_commit="c" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-17T02:25:00Z",
+            simulation_repetitions=1,
+            loop_a_card_supply=True,
+        )
+        variant_ids = [variant["id"] for variant in card["strategy_variants"]]
+        start = tick(1, [room("W1N1", energy=100)])
+        simulator = MockSimulator({
+            variant_id: variant_result(variant_id, [start, tick(2, [room("W1N1", energy=200)])])
+            for variant_id in variant_ids
+        })
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_dir = root / "cards"
+            report_dir = root / "reports"
+            card_dir.mkdir()
+            card_path = card_dir / "card.json"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                report_dir,
+                report_id="loop-a-supply-report",
+                simulator_runner=simulator,
+            )
+            selected_after_report = card_helper.select_loop_a_card_supply(card_dir, report_dir)
+
+        self.assertEqual(report["experimentCard"]["status"], "shadow")
+        self.assertEqual(report["experimentCard"]["cardSupply"]["state"], "available")
+        self.assertEqual(report["experimentCard"]["cardSupply"]["consumer"], "loop-a-policy-gradient")
+        self.assertIsNone(selected_after_report)
+        self.assertFalse(report["liveEffect"])
+        self.assertFalse(report["officialMmoWrites"])
+        self.assertFalse(report["officialMmoWritesAllowed"])
+        self.assertTrue(report["safety"]["conservative_actions_only"])
+        self.assertTrue(report["safety"]["ood_rejection"])
+        self.assertEqual(report["rewardModel"]["componentOrder"], ["reliability", "territory", "resources", "kills"])
+        self.assertFalse(report["rewardModel"]["scalarWeightedSumAuthorized"])
+
+    def test_loop_a_available_supply_requires_policy_gradient(self) -> None:
+        card = base_card()
+        card["card_supply"] = {
+            "type": "screeps-rl-loop-a-card-supply",
+            "consumer": "loop-a-policy-gradient",
+            "state": "available",
+            "available_for_training": True,
+            "dataset_run_id": card["dataset_run_id"],
+            "training_approach": card["training_approach"],
+            "created_at": "2026-05-17T02:25:00Z",
+            "status_field": "status",
+            "safety_status": "shadow",
+            "consumed_at": None,
+            "consumed_by_report_id": None,
+        }
+
+        with self.assertRaisesRegex(
+            runner.TrainingCardError,
+            "available Loop A card supply requires training_approach=policy_gradient",
+        ):
+            runner.validate_experiment_card(card)
+
     def test_report_id_with_dots_is_normalized_for_simulator_run_id(self) -> None:
         start = tick(1, [room("W1N1", energy=100)])
         baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200)])])


### PR DESCRIPTION
## Summary
- Adds explicit Loop A card-supply metadata for policy-gradient experiment cards while preserving `status: shadow` safety semantics.
- Adds helpers/CLI support to generate a fresh Loop A supply card from the latest accepted dataset gate and to select an available card while skipping cards already represented in training reports.
- Validates card-supply invariants in the experiment card generator and training runner so Loop A can distinguish consumable training cards from completed shadow evidence.

Closes #1180
Updates #1032
Updates #879

## Verification
- `python3 -m py_compile scripts/screeps_rl_experiment_card.py scripts/screeps_rl_training_runner.py`
- `python3 -m pytest scripts/test_screeps_rl_experiment_card.py scripts/test_screeps_rl_training_runner.py -q` — 56 passed, 17 subtests passed
- `git diff --check`

## Safety
- Offline/shadow-only card supply metadata; no official MMO API calls, no Tencent/cloud batch launch, no secret access.
- Safety invariants remain false for `liveEffect`, `officialMmoWrites`, and `officialMmoWritesAllowed`; conservative/ood and lexicographic reward checks are covered by tests.
