### PR TITLE
fix(rl): self-heal Tencent batch SSH known_hosts

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -118,6 +118,12 @@ class Controller:
             raise BatchRunError("public IP is not known yet")
         return f"{self.args.worker_user}@{self.public_ip}"
 
+    def ssh_connect_options(self) -> tuple[str, ...]:
+        return (
+            *SSH_CONNECT_OPTIONS,
+            "-o", f"UserKnownHostsFile={self.known_hosts_path}",
+        )
+
     def record_step(self, name: str, started: float, ok: bool, cp: subprocess.CompletedProcess[str] | None = None, **detail: Any) -> None:
         stdout_tail = tail_text(cp.stdout) if cp is not None else None
         stderr_tail = tail_text(cp.stderr) if cp is not None else None
@@ -218,7 +224,7 @@ class Controller:
         cmd = [
             "ssh",
             "-i", self.args.ssh_key,
-            *SSH_CONNECT_OPTIONS,
+            *self.ssh_connect_options(),
             self.ssh_target,
             remote_command,
         ]
@@ -230,7 +236,7 @@ class Controller:
             [
                 "scp",
                 "-i", self.args.ssh_key,
-                *SSH_CONNECT_OPTIONS,
+                *self.ssh_connect_options(),
                 str(local_path),
                 f"{self.ssh_target}:{remote_path}",
             ],
@@ -244,7 +250,7 @@ class Controller:
             [
                 "scp",
                 "-i", self.args.ssh_key,
-                *SSH_CONNECT_OPTIONS,
+                *self.ssh_connect_options(),
                 f"{self.ssh_target}:{remote_path}",
                 str(local_path),
             ],

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -35,6 +35,7 @@ DEFAULT_TCCLI = Path("/root/.hermes/hermes-agent/venv/bin/tccli")
 DEFAULT_BILLING_GUARD = Path("/root/.hermes/scripts/screeps-tencent-billing-guard.py")
 DEFAULT_SECRET_ENV = Path("/root/.secret/.env")
 DEFAULT_SSH_KEY = Path("/root/.ssh/id_ed25519")
+DEFAULT_KNOWN_HOSTS = Path("/root/.ssh/known_hosts")
 DEFAULT_REGION = "ap-singapore"
 DEFAULT_ASG_ID = "asg-csw592ro"
 DEFAULT_CONTROLLER_IP = "43.128.104.34/32"
@@ -93,6 +94,7 @@ class Controller:
     public_ip: str | None = None
     private_ip: str | None = None
     steps: list[StepRecord] = field(default_factory=list)
+    known_hosts_cleaned_public_ips: set[str] = field(default_factory=set, repr=False)
     started_at: str = field(default_factory=lambda: utc_now_iso())
     finished_at: str | None = None
     final_status: str = "unknown"
@@ -105,6 +107,10 @@ class Controller:
     @property
     def remote_dir(self) -> str:
         return f"{self.args.remote_base.rstrip('/')}/{self.run_id}"
+
+    @property
+    def known_hosts_path(self) -> Path:
+        return Path(getattr(self.args, "known_hosts_path", DEFAULT_KNOWN_HOSTS))
 
     @property
     def ssh_target(self) -> str:
@@ -244,6 +250,28 @@ class Controller:
             ],
             timeout=timeout,
         )
+
+    def clear_worker_known_host(self) -> None:
+        if not self.public_ip:
+            return
+        if self.public_ip in self.known_hosts_cleaned_public_ips:
+            return
+        self.known_hosts_cleaned_public_ips.add(self.public_ip)
+        cmd = ["ssh-keygen", "-R", self.public_ip, "-f", str(self.known_hosts_path)]
+        started = time.time()
+        try:
+            cp = subprocess.run(
+                cmd,
+                text=True,
+                capture_output=True,
+                cwd=str(REPO_ROOT),
+                timeout=30,
+                check=False,
+            )
+        except OSError as error:
+            cp = subprocess.CompletedProcess(cmd, 127, "", f"{type(error).__name__}: {error}")
+        ok = cp.returncode == 0
+        self.record_step("clear_worker_known_host", started, ok, cp, argv=redacted_argv(cmd))
 
     def experiment_card_path(self) -> Path:
         return self.artifact_dir / "experiment_card.json"
@@ -491,6 +519,7 @@ class Controller:
                     self.instance_id = cvm.get("InstanceId")
                     self.public_ip = public_ips[0]
                     self.private_ip = private_ips[0] if private_ips else None
+                    self.clear_worker_known_host()
                     if self.wait_for_ssh():
                         self.result["worker"] = {
                             "instanceId": self.instance_id,

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -267,6 +267,11 @@ class Controller:
                 timeout=30,
                 check=False,
             )
+        except subprocess.TimeoutExpired as error:
+            stdout = error.output.decode("utf-8", errors="replace") if isinstance(error.output, bytes) else (error.output or "")
+            stderr = error.stderr.decode("utf-8", errors="replace") if isinstance(error.stderr, bytes) else (error.stderr or "")
+            stderr = "\n".join(part for part in (f"{type(error).__name__}: {error}", stderr) if part)
+            cp = subprocess.CompletedProcess(cmd, 124, stdout, stderr)
         except OSError as error:
             cp = subprocess.CompletedProcess(cmd, 127, "", f"{type(error).__name__}: {error}")
         ok = cp.returncode == 0

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -256,7 +256,6 @@ class Controller:
             return
         if self.public_ip in self.known_hosts_cleaned_public_ips:
             return
-        self.known_hosts_cleaned_public_ips.add(self.public_ip)
         cmd = ["ssh-keygen", "-R", self.public_ip, "-f", str(self.known_hosts_path)]
         started = time.time()
         try:
@@ -272,6 +271,8 @@ class Controller:
             cp = subprocess.CompletedProcess(cmd, 127, "", f"{type(error).__name__}: {error}")
         ok = cp.returncode == 0
         self.record_step("clear_worker_known_host", started, ok, cp, argv=redacted_argv(cmd))
+        if ok:
+            self.known_hosts_cleaned_public_ips.add(self.public_ip)
 
     def experiment_card_path(self) -> Path:
         return self.artifact_dir / "experiment_card.json"

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -589,6 +589,69 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertFalse(clear_steps[0].ok)
         self.assertEqual(controller.result["worker"]["publicIp"], "203.0.113.10")
 
+    def test_scale_up_retries_failed_known_host_cleanup_for_same_ip(self) -> None:
+        args = controller_args()
+        events: list[tuple[str, object]] = []
+
+        class FakeController(runner.Controller):
+            def tccli(self, name: str, *params: str, check: bool = True, timeout: int = 90) -> dict[str, object]:
+                return {}
+
+            def describe_asg_instances(self) -> list[dict[str, object]]:
+                return [{"InstanceId": "ins-test"}]
+
+            def describe_cvm_instances(self, instance_ids: list[str]) -> list[dict[str, object]]:
+                return [
+                    {
+                        "InstanceId": "ins-test",
+                        "InstanceState": "RUNNING",
+                        "PublicIpAddresses": ["203.0.113.10"],
+                        "PrivateIpAddresses": ["10.0.0.10"],
+                        "InstanceType": "S5.SMALL1",
+                    }
+                ]
+
+            def latest_scale_out_failure(self, *, after_epoch: float) -> dict[str, object] | None:
+                return None
+
+            def wait_for_ssh(self) -> bool:
+                events.append(("wait_for_ssh", {"public_ip": self.public_ip}))
+                return len([event for event in events if event[0] == "wait_for_ssh"]) >= 2
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
+            controller = FakeController(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
+            cleanup_results = [
+                subprocess.CompletedProcess(["ssh-keygen"], 255, "", "permission denied\n"),
+                subprocess.CompletedProcess(["ssh-keygen"], 0, "removed\n", ""),
+            ]
+
+            def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                events.append(("clear_known_host", {"cmd": cmd, "public_ip": controller.public_ip}))
+                result = cleanup_results.pop(0)
+                return subprocess.CompletedProcess(cmd, result.returncode, result.stdout, result.stderr)
+
+            with (
+                mock.patch.object(runner.subprocess, "run", side_effect=fake_run),
+                mock.patch.object(runner.time, "sleep", return_value=None),
+            ):
+                controller.scale_up_and_wait()
+
+        self.assertEqual(
+            [event[0] for event in events],
+            ["clear_known_host", "wait_for_ssh", "clear_known_host", "wait_for_ssh"],
+        )
+        cleanup_events = [event[1] for event in events if event[0] == "clear_known_host"]
+        self.assertEqual(len(cleanup_events), 2)
+        for cleanup_event in cleanup_events:
+            self.assertIsInstance(cleanup_event, dict)
+            self.assertEqual(cleanup_event["public_ip"], "203.0.113.10")
+            self.assertEqual(cleanup_event["cmd"], ["ssh-keygen", "-R", "203.0.113.10", "-f", args.known_hosts_path])
+        clear_steps = [step for step in controller.steps if step.name == "clear_worker_known_host"]
+        self.assertEqual([step.ok for step in clear_steps], [False, True])
+        self.assertIn("203.0.113.10", controller.known_hosts_cleaned_public_ips)
+        self.assertEqual(controller.result["worker"]["publicIp"], "203.0.113.10")
+
     def test_clear_known_host_skips_when_public_ip_is_missing(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             controller = runner.Controller(args=controller_args(), run_id="run-test", artifact_dir=Path(temp_dir))

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -494,6 +494,139 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 with self.assertRaisesRegex(runner.BatchRunError, pattern):
                     runner.validate_scale_proof_result(malformed, 5)
 
+    def test_scale_up_clears_known_host_once_before_first_ssh_probe(self) -> None:
+        args = controller_args()
+        events: list[tuple[str, object]] = []
+
+        class FakeController(runner.Controller):
+            def tccli(self, name: str, *params: str, check: bool = True, timeout: int = 90) -> dict[str, object]:
+                return {}
+
+            def describe_asg_instances(self) -> list[dict[str, object]]:
+                return [{"InstanceId": "ins-test"}]
+
+            def describe_cvm_instances(self, instance_ids: list[str]) -> list[dict[str, object]]:
+                return [
+                    {
+                        "InstanceId": "ins-test",
+                        "InstanceState": "RUNNING",
+                        "PublicIpAddresses": ["203.0.113.10"],
+                        "PrivateIpAddresses": ["10.0.0.10"],
+                        "InstanceType": "S5.SMALL1",
+                    }
+                ]
+
+            def latest_scale_out_failure(self, *, after_epoch: float) -> dict[str, object] | None:
+                return None
+
+            def wait_for_ssh(self) -> bool:
+                events.append(("wait_for_ssh", {"public_ip": self.public_ip, "steps": [step.name for step in self.steps]}))
+                return len([event for event in events if event[0] == "wait_for_ssh"]) >= 2
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
+            controller = FakeController(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
+
+            def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                events.append(("clear_known_host", {"cmd": cmd, "public_ip": controller.public_ip}))
+                return subprocess.CompletedProcess(cmd, 0, "removed\n", "")
+
+            with (
+                mock.patch.object(runner.subprocess, "run", side_effect=fake_run),
+                mock.patch.object(runner.time, "sleep", return_value=None),
+            ):
+                controller.scale_up_and_wait()
+
+        self.assertEqual([event[0] for event in events], ["clear_known_host", "wait_for_ssh", "wait_for_ssh"])
+        clear_event = events[0][1]
+        self.assertIsInstance(clear_event, dict)
+        self.assertEqual(clear_event["public_ip"], "203.0.113.10")
+        self.assertEqual(clear_event["cmd"], ["ssh-keygen", "-R", "203.0.113.10", "-f", args.known_hosts_path])
+        first_probe_event = events[1][1]
+        self.assertIsInstance(first_probe_event, dict)
+        self.assertEqual(first_probe_event["public_ip"], "203.0.113.10")
+        self.assertIn("clear_worker_known_host", first_probe_event["steps"])
+        self.assertEqual([step.name for step in controller.steps].count("clear_worker_known_host"), 1)
+
+    def test_scale_up_known_host_cleanup_failure_does_not_raise(self) -> None:
+        args = controller_args()
+
+        class FakeController(runner.Controller):
+            def tccli(self, name: str, *params: str, check: bool = True, timeout: int = 90) -> dict[str, object]:
+                return {}
+
+            def describe_asg_instances(self) -> list[dict[str, object]]:
+                return [{"InstanceId": "ins-test"}]
+
+            def describe_cvm_instances(self, instance_ids: list[str]) -> list[dict[str, object]]:
+                return [
+                    {
+                        "InstanceId": "ins-test",
+                        "InstanceState": "RUNNING",
+                        "PublicIpAddresses": ["203.0.113.10"],
+                        "PrivateIpAddresses": [],
+                    }
+                ]
+
+            def latest_scale_out_failure(self, *, after_epoch: float) -> dict[str, object] | None:
+                return None
+
+            def wait_for_ssh(self) -> bool:
+                return True
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
+            controller = FakeController(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
+            with mock.patch.object(
+                runner.subprocess,
+                "run",
+                return_value=subprocess.CompletedProcess(["ssh-keygen"], 255, "", "host not found\n"),
+            ):
+                controller.scale_up_and_wait()
+
+        clear_steps = [step for step in controller.steps if step.name == "clear_worker_known_host"]
+        self.assertEqual(len(clear_steps), 1)
+        self.assertFalse(clear_steps[0].ok)
+        self.assertEqual(controller.result["worker"]["publicIp"], "203.0.113.10")
+
+    def test_clear_known_host_skips_when_public_ip_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            controller = runner.Controller(args=controller_args(), run_id="run-test", artifact_dir=Path(temp_dir))
+            with mock.patch.object(runner.subprocess, "run") as run:
+                controller.clear_worker_known_host()
+
+        run.assert_not_called()
+        self.assertFalse([step for step in controller.steps if step.name == "clear_worker_known_host"])
+
+    def test_ssh_and_scp_commands_keep_accept_new_host_key_option(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            controller = runner.Controller(args=controller_args(), run_id="run-test", artifact_dir=Path(temp_dir))
+            controller.public_ip = "203.0.113.10"
+            commands: list[list[str]] = []
+
+            def capture_run_cp(
+                name: str,
+                cmd: list[str],
+                *,
+                check: bool = True,
+                timeout: int | None = None,
+                cwd: Path | None = None,
+                input_text: str | None = None,
+                env: dict[str, str] | None = None,
+            ) -> subprocess.CompletedProcess[str]:
+                commands.append(cmd)
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+
+            with mock.patch.object(controller, "run_cp", side_effect=capture_run_cp):
+                controller.ssh_cmd("ssh_probe", "true")
+                controller.scp_to_worker("upload", Path(temp_dir) / "local.txt", "/remote/local.txt")
+                controller.scp_from_worker("download", "/remote/out.txt", Path(temp_dir) / "out" / "out.txt")
+
+        for cmd in commands:
+            with self.subTest(command=cmd[0]):
+                self.assertIn("BatchMode=yes", cmd)
+                self.assertIn("StrictHostKeyChecking=accept-new", cmd)
+
     def test_safe_extract_tar_rejects_traversal_and_special_entries(self) -> None:
         cases = [
             ("../escape", lambda tar: add_file(tar, "../escape")),

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -709,9 +709,16 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
 
     def test_ssh_and_scp_commands_keep_accept_new_host_key_option(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
-            controller = runner.Controller(args=controller_args(), run_id="run-test", artifact_dir=Path(temp_dir))
+            args = controller_args()
+            args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
             controller.public_ip = "203.0.113.10"
+            cleanup_commands: list[list[str]] = []
             commands: list[list[str]] = []
+
+            def capture_subprocess_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                cleanup_commands.append(cmd)
+                return subprocess.CompletedProcess(cmd, 0, "", "")
 
             def capture_run_cp(
                 name: str,
@@ -726,15 +733,21 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 commands.append(cmd)
                 return subprocess.CompletedProcess(cmd, 0, "", "")
 
-            with mock.patch.object(controller, "run_cp", side_effect=capture_run_cp):
+            with (
+                mock.patch.object(runner.subprocess, "run", side_effect=capture_subprocess_run),
+                mock.patch.object(controller, "run_cp", side_effect=capture_run_cp),
+            ):
+                controller.clear_worker_known_host()
                 controller.ssh_cmd("ssh_probe", "true")
                 controller.scp_to_worker("upload", Path(temp_dir) / "local.txt", "/remote/local.txt")
                 controller.scp_from_worker("download", "/remote/out.txt", Path(temp_dir) / "out" / "out.txt")
 
+        self.assertEqual(cleanup_commands, [["ssh-keygen", "-R", "203.0.113.10", "-f", args.known_hosts_path]])
         for cmd in commands:
             with self.subTest(command=cmd[0]):
                 self.assertIn("BatchMode=yes", cmd)
                 self.assertIn("StrictHostKeyChecking=accept-new", cmd)
+                self.assertIn(f"UserKnownHostsFile={args.known_hosts_path}", cmd)
 
     def test_safe_extract_tar_rejects_traversal_and_special_entries(self) -> None:
         cases = [

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -496,6 +496,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
 
     def test_scale_up_clears_known_host_once_before_first_ssh_probe(self) -> None:
         args = controller_args()
+        args.scale_timeout_seconds = 5
         events: list[tuple[str, object]] = []
 
         class FakeController(runner.Controller):
@@ -589,8 +590,53 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertFalse(clear_steps[0].ok)
         self.assertEqual(controller.result["worker"]["publicIp"], "203.0.113.10")
 
+    def test_scale_up_known_host_cleanup_timeout_does_not_raise_or_mark_cleaned(self) -> None:
+        args = controller_args()
+
+        class FakeController(runner.Controller):
+            def tccli(self, name: str, *params: str, check: bool = True, timeout: int = 90) -> dict[str, object]:
+                return {}
+
+            def describe_asg_instances(self) -> list[dict[str, object]]:
+                return [{"InstanceId": "ins-test"}]
+
+            def describe_cvm_instances(self, instance_ids: list[str]) -> list[dict[str, object]]:
+                return [
+                    {
+                        "InstanceId": "ins-test",
+                        "InstanceState": "RUNNING",
+                        "PublicIpAddresses": ["203.0.113.10"],
+                        "PrivateIpAddresses": [],
+                    }
+                ]
+
+            def latest_scale_out_failure(self, *, after_epoch: float) -> dict[str, object] | None:
+                return None
+
+            def wait_for_ssh(self) -> bool:
+                return True
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
+            controller = FakeController(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
+            with mock.patch.object(
+                runner.subprocess,
+                "run",
+                side_effect=subprocess.TimeoutExpired(["ssh-keygen"], 30, output="", stderr="timed out\n"),
+            ):
+                controller.scale_up_and_wait()
+
+        clear_steps = [step for step in controller.steps if step.name == "clear_worker_known_host"]
+        self.assertEqual(len(clear_steps), 1)
+        self.assertFalse(clear_steps[0].ok)
+        self.assertEqual(clear_steps[0].returncode, 124)
+        self.assertIn("TimeoutExpired", clear_steps[0].stderr_tail or "")
+        self.assertNotIn("203.0.113.10", controller.known_hosts_cleaned_public_ips)
+        self.assertEqual(controller.result["worker"]["publicIp"], "203.0.113.10")
+
     def test_scale_up_retries_failed_known_host_cleanup_for_same_ip(self) -> None:
         args = controller_args()
+        args.scale_timeout_seconds = 5
         events: list[tuple[str, object]] = []
 
         class FakeController(runner.Controller):


### PR DESCRIPTION
## Domain / Kind
- Domain: RL flywheel
- Kind: bug / recurrence-prevention

## Linked issue
Fixes #1182

## Summary
- Adds a best-effort `ssh-keygen -R` self-heal step before Tencent batch worker SSH probing.
- Records the cleanup as `clear_worker_known_host` in controller summary steps.
- Aligns cleanup and SSH/SCP probes on the same `UserKnownHostsFile=<known_hosts_path>`.
- Adds targeted tests for ordering, non-fatal cleanup failure, retry-after-failed-cleanup, cleanup timeout handling, missing public IP skip, custom known_hosts path alignment, and preservation of `StrictHostKeyChecking=accept-new`.

## Runtime / deployment impact
- Offline Tencent batch runner only; no Screeps official MMO writes and no live bot behavior changes.
- The cleanup is nonfatal: failure/timeout is recorded as a controller step and SSH probing still proceeds.
- A failed or timed-out cleanup is retried on the same public IP before the next probe loop; successful cleanup is deduped for the IP.
- SSH/SCP now use the same `known_hosts_path` that cleanup mutates, so custom controller paths cannot silently diverge.

## Secrets / unsafe paths
- No secrets touched or printed.
- No runtime artifacts committed.
- No official MMO writes; `liveEffect=false` / `officialMmoWrites=false` remains enforced by the RL training lane.

## Review triage
- CodeRabbit line 257-260: `FIX`, P1 recurrence-prevention. `cfdb1eb` only marks an IP cleaned after successful `ssh-keygen` and adds failed-cleanup retry coverage.
- CodeRabbit line 261-271: `FIX`, P1 robustness. `ad3c8fa` converts `subprocess.TimeoutExpired` into a failed `clear_worker_known_host` step (returncode 124), keeps cleanup nonfatal, and does not mark IP cleaned.
- CodeRabbit test timeout comments: `FIX`, CI/test robustness. Retry-order tests now use explicit `scale_timeout_seconds=5`.
- CodeRabbit custom known_hosts path comment: `FIX`, P1 recurrence-prevention. `1475b3e` wires `UserKnownHostsFile=<self.known_hosts_path>` into ssh/scp commands and adds coverage that cleanup/probes use the same file.
- Docstring coverage warning: `ADVISORY_ONLY`; this script/test file style does not use per-function docstrings and the warning is not critical under the Screeps review severity policy.

## Verification
- [x] `git diff --check`
- [x] `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- [x] `python3 scripts/test_screeps_tencent_batch_rl_runner.py` (33 tests OK)
- [x] GitHub Actions `Verify prod TypeScript, Jest, and bundle` — waiting/green checked separately on exact head before merge.
- [ ] Project `screeps` fields refreshed — controller will set in the merge gate run.
