### PR TITLE
fix(rl): generate standalone Loop A fallback experiment cards

### DIFF
--- a/docs/ops/rl-training-reward-workflow.md
+++ b/docs/ops/rl-training-reward-workflow.md
@@ -38,9 +38,13 @@ Dry-run generation is allowed for pipeline checks:
 python3 scripts/screeps_rl_experiment_card.py --dry-run --dataset-run-id rl-000000000000
 ```
 
-Generate the Loop A local-fallback card from an accepted E1 gate. The output is runtime-only because
-`runtime-artifacts/` is ignored; by default this writes
-`runtime-artifacts/rl-experiment-cards/experiment_card.json`:
+Generate the Loop A local-fallback card from an accepted dataset gate, such as
+`rl-gate-93bf1aa18b62` under `runtime-artifacts/rl-dataset-gates`. Use
+`--source-gate-id` with a gate whose `gate_report.json` has `ok: true` and a dataset run ID.
+This output is runtime-only because `runtime-artifacts/` is ignored;
+`--loop-a-local-fallback` writes the card to
+`runtime-artifacts/rl-experiment-cards/experiment_card.json` by default and prints a compact
+summary to stdout:
 
 ```bash
 python3 scripts/screeps_rl_experiment_card.py \
@@ -72,7 +76,10 @@ python3 scripts/screeps_rl_mmo_validator.py \
   runtime-artifacts/
 ```
 
-The card is deterministic JSON. `card_id` is derived from `dataset_run_id` plus the first 12 hex characters of `code_commit`. Output goes to stdout unless `--output <path>` is provided.
+The card is deterministic JSON. `card_id` is derived from `dataset_run_id` plus the first 12 hex
+characters of `code_commit`. Regular generation without `--loop-a-local-fallback` prints the card to
+stdout unless `--output <path>` or `--output-dir <path>` is provided; `--output <path>` also
+overrides the local-fallback card path.
 
 ## Experiment Card Contract
 

--- a/docs/ops/rl-training-reward-workflow.md
+++ b/docs/ops/rl-training-reward-workflow.md
@@ -38,6 +38,17 @@ Dry-run generation is allowed for pipeline checks:
 python3 scripts/screeps_rl_experiment_card.py --dry-run --dataset-run-id rl-000000000000
 ```
 
+Generate the Loop A local-fallback card from an accepted E1 gate. The output is runtime-only because
+`runtime-artifacts/` is ignored; by default this writes
+`runtime-artifacts/rl-experiment-cards/experiment_card.json`:
+
+```bash
+python3 scripts/screeps_rl_experiment_card.py \
+  --loop-a-local-fallback \
+  --source-gate-id rl-gate-93bf1aa18b62 \
+  --dataset-gate-root runtime-artifacts/rl-dataset-gates
+```
+
 Validate an existing card:
 
 ```bash

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -312,7 +312,7 @@ def source_gate_block(
         "type": "screeps-rl-dataset-evaluation-gate",
         "gate_id": gate_id,
         "dataset_run_id": dataset_run_id,
-        "gate_report_path": str(gate_report_path),
+        "gate_report_path": stable_provenance_path(gate_report_path),
         "created_at": created_at,
         "ok": True,
     }
@@ -330,6 +330,16 @@ def repo_relative(path: Path) -> str:
         return str(path.resolve().relative_to(REPO_ROOT))
     except ValueError:
         return str(path)
+
+
+def stable_provenance_path(path: Path) -> str:
+    resolved = path.expanduser().resolve()
+    for root in (REPO_ROOT, Path.cwd()):
+        try:
+            return resolved.relative_to(root.expanduser().resolve()).as_posix()
+        except ValueError:
+            continue
+    return resolved.as_posix()
 
 
 def policy_gradient_block(registry_path: Path) -> JsonObject:
@@ -1175,7 +1185,7 @@ def positive_int_arg(raw: str) -> int:
 
 
 def loop_a_local_fallback_value(value: int | None, *, default: int, maximum: int, label: str) -> int:
-    resolved = default if value is None else value
+    resolved = default if value is None else max(value, default)
     if resolved > maximum:
         raise CardValidationError(f"Loop A local fallback {label} must be <= {maximum}")
     return resolved

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -1365,7 +1365,10 @@ def main(
             dataset_run_id = source_dataset_run_id
         elif args.from_latest_accepted_dataset or args.loop_a_local_fallback:
             if dataset_run_id is not None:
-                raise CardValidationError("--from-latest-accepted-dataset cannot be combined with --dataset-run-id")
+                raise CardValidationError(
+                    "--from-latest-accepted-dataset or --loop-a-local-fallback cannot be combined "
+                    "with --dataset-run-id"
+                )
             source_gate = select_accepted_dataset_gate(args.dataset_gate_root)
             dataset_run_id = str(source_gate["dataset_run_id"])
         if dataset_run_id is None:

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -41,12 +41,16 @@ DEFAULT_SIMULATION_OUT_DIR = REPO_ROOT / "runtime-artifacts" / "rl-simulator"
 DEFAULT_EXPERIMENT_CARD_DIR = REPO_ROOT / "runtime-artifacts" / "rl-experiment-cards"
 DEFAULT_DATASET_GATE_ROOT = REPO_ROOT / "runtime-artifacts" / "rl-dataset-gates"
 DEFAULT_TRAINING_REPORT_ROOT = REPO_ROOT / "runtime-artifacts" / "rl-training"
+DEFAULT_LOOP_A_LOCAL_FALLBACK_CARD_PATH = DEFAULT_EXPERIMENT_CARD_DIR / "experiment_card.json"
 DEFAULT_STRATEGY_REGISTRY_PATH = REPO_ROOT / "prod" / "src" / "strategy" / "strategyRegistry.ts"
 DEFAULT_SIMULATION_TICKS = 50
 DEFAULT_SIMULATION_REPETITIONS = 1
 DEFAULT_SIMULATION_WORKERS = 1
 POLICY_GRADIENT_SIMULATION_TICKS = 100
 POLICY_GRADIENT_SIMULATION_REPETITIONS = 5
+LOOP_A_LOCAL_FALLBACK_TICKS = 200
+LOOP_A_LOCAL_FALLBACK_REPETITIONS = 5
+LOOP_A_LOCAL_FALLBACK_WORKERS = 5
 
 JsonObject = dict[str, Any]
 
@@ -147,6 +151,11 @@ def validate_dataset_run_id(run_id: str) -> None:
         raise CardValidationError("dataset_run_id may contain only letters, numbers, dot, underscore, and hyphen")
 
 
+def validate_gate_id(gate_id: str) -> None:
+    if not DATASET_RUN_ID_RE.fullmatch(gate_id) or gate_id in {".", ".."}:
+        raise CardValidationError("gate_id may contain only letters, numbers, dot, underscore, and hyphen")
+
+
 def validate_code_commit(commit: str) -> None:
     if not COMMIT_RE.fullmatch(commit):
         raise CardValidationError("code_commit must be a hexadecimal commit SHA prefix or full SHA")
@@ -212,6 +221,7 @@ def build_card(
     simulation_workers: int | None = None,
     registry_path: Path | None = None,
     loop_a_card_supply: bool = False,
+    source_gate: JsonObject | None = None,
 ) -> JsonObject:
     validate_dataset_run_id(dataset_run_id)
     validate_code_commit(code_commit)
@@ -265,6 +275,8 @@ def build_card(
             training_approach=training_approach,
             created_at=created_at,
         )
+    if source_gate is not None:
+        card["source_gate"] = dict(source_gate)
     validate_card(card)
     return card
 
@@ -282,6 +294,27 @@ def loop_a_card_supply_block(*, dataset_run_id: str, training_approach: str, cre
         "safety_status": "shadow",
         "consumed_at": None,
         "consumed_by_report_id": None,
+    }
+
+
+def source_gate_block(
+    *,
+    gate_id: str,
+    dataset_run_id: str,
+    gate_report_path: Path,
+    created_at: str | None,
+) -> JsonObject:
+    validate_gate_id(gate_id)
+    validate_dataset_run_id(dataset_run_id)
+    if created_at is not None:
+        validate_created_at(created_at)
+    return {
+        "type": "screeps-rl-dataset-evaluation-gate",
+        "gate_id": gate_id,
+        "dataset_run_id": dataset_run_id,
+        "gate_report_path": str(gate_report_path),
+        "created_at": created_at,
+        "ok": True,
     }
 
 
@@ -573,6 +606,7 @@ def validate_card(raw: Any) -> None:
     validate_safety(raw)
     validate_reward_model(raw.get("reward_model"))
     validate_card_supply(raw)
+    validate_source_gate(raw)
     strategy_variants = first_present(raw, ("strategy_variants", "strategyVariants", "variants"))
     validate_strategy_variants(strategy_variants)
     validate_simulation(first_present(raw, ("simulation", "simulator")))
@@ -631,6 +665,33 @@ def validate_card_supply(card: JsonObject) -> None:
         validate_created_at(consumed_at)
         if not isinstance(raw.get("consumed_by_report_id"), str) or not raw.get("consumed_by_report_id"):
             raise CardValidationError("consumed Loop A card supply requires consumed_by_report_id")
+
+
+def validate_source_gate(card: JsonObject) -> None:
+    raw = first_present(card, ("source_gate", "sourceGate"))
+    if raw is None:
+        return
+    if not isinstance(raw, dict):
+        raise CardValidationError("source_gate must be a JSON object")
+    if raw.get("type") not in (None, "screeps-rl-dataset-evaluation-gate"):
+        raise CardValidationError("source_gate.type must be screeps-rl-dataset-evaluation-gate")
+    gate_id = first_present(raw, ("gate_id", "gateId"))
+    if not isinstance(gate_id, str) or not gate_id:
+        raise CardValidationError("source_gate.gate_id must be a non-empty string")
+    validate_gate_id(gate_id)
+    dataset_run_id = first_present(raw, ("dataset_run_id", "datasetRunId"))
+    if dataset_run_id != card.get("dataset_run_id"):
+        raise CardValidationError("source_gate.dataset_run_id must match dataset_run_id")
+    gate_report_path = first_present(raw, ("gate_report_path", "gateReportPath"))
+    if not isinstance(gate_report_path, str) or not gate_report_path:
+        raise CardValidationError("source_gate.gate_report_path must be a non-empty string")
+    if raw.get("ok") is not True:
+        raise CardValidationError("source_gate.ok must be true")
+    created_at = first_present(raw, ("created_at", "createdAt"))
+    if created_at is not None:
+        if not isinstance(created_at, str):
+            raise CardValidationError("source_gate.created_at must be an ISO UTC timestamp")
+        validate_created_at(created_at)
 
 
 def is_loop_a_card_available_for_training(card: JsonObject, consumed_card_ids: set[str] | None = None) -> bool:
@@ -721,8 +782,10 @@ def loop_a_selection_summary(path: Path, card: JsonObject, consumed_card_ids: se
     }
 
 
-def latest_accepted_dataset_run_id(gate_root: Path) -> str:
-    candidates: list[tuple[str, float, str, Path]] = []
+def select_accepted_dataset_gate(gate_root: Path, gate_id: str | None = None) -> JsonObject:
+    if gate_id is not None:
+        validate_gate_id(gate_id)
+    candidates: list[tuple[str, float, str, str, Path]] = []
     if not gate_root.exists():
         raise CardValidationError(f"dataset gate root does not exist: {gate_root}")
     for path in sorted(gate_root.rglob("*.json")):
@@ -733,6 +796,9 @@ def latest_accepted_dataset_run_id(gate_root: Path) -> str:
         if not isinstance(payload, dict) or payload.get("ok") is not True:
             continue
         try:
+            selected_gate_id = accepted_dataset_gate_id(payload, path)
+            if gate_id is not None and selected_gate_id != gate_id:
+                continue
             run_id = accepted_dataset_run_id(payload)
             if run_id is None:
                 continue
@@ -740,11 +806,34 @@ def latest_accepted_dataset_run_id(gate_root: Path) -> str:
             mtime = path.stat().st_mtime
         except (CardValidationError, OSError):
             continue
-        candidates.append((created_at or "", mtime, run_id, path))
+        candidates.append((created_at or "", mtime, selected_gate_id, run_id, path))
     if not candidates:
+        if gate_id is not None:
+            raise CardValidationError(f"no accepted dataset gate {gate_id} with datasetRunId found under {gate_root}")
         raise CardValidationError(f"no accepted dataset gate with datasetRunId found under {gate_root}")
-    candidates.sort(key=lambda item: (item[0], item[1], str(item[3])), reverse=True)
-    return candidates[0][2]
+    candidates.sort(key=lambda item: (item[0], item[1], item[2], str(item[4])), reverse=True)
+    created_at, _, selected_gate_id, run_id, path = candidates[0]
+    return source_gate_block(
+        gate_id=selected_gate_id,
+        dataset_run_id=run_id,
+        gate_report_path=path,
+        created_at=created_at or None,
+    )
+
+
+def latest_accepted_dataset_run_id(gate_root: Path) -> str:
+    return str(select_accepted_dataset_gate(gate_root)["dataset_run_id"])
+
+
+def accepted_dataset_gate_id(payload: JsonObject, path: Path) -> str:
+    for key in ("gateId", "gate_id"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            validate_gate_id(value)
+            return value
+    value = path.parent.name
+    validate_gate_id(value)
+    return value
 
 
 def accepted_dataset_run_id(payload: JsonObject) -> str | None:
@@ -1034,14 +1123,23 @@ def validation_summary(card: JsonObject) -> JsonObject:
     if isinstance(card_supply, dict):
         summary["card_supply"] = card_supply
         summary["loop_a_available_for_training"] = is_loop_a_card_available_for_training(card)
+    source_gate = first_present(card, ("source_gate", "sourceGate"))
+    if isinstance(source_gate, dict):
+        summary["source_gate"] = source_gate
     return summary
 
 
-def generated_card_summary(card: JsonObject, output_path: Path) -> JsonObject:
+def generated_card_summary(
+    card: JsonObject,
+    output_path: Path,
+    *,
+    loop_a_local_fallback: bool = False,
+) -> JsonObject:
     summary = validation_summary(card)
     summary["path"] = str(output_path)
     summary["created_at"] = card.get("created_at")
     summary["training_approach"] = card.get("training_approach")
+    summary["loop_a_local_fallback"] = loop_a_local_fallback
     return summary
 
 
@@ -1074,6 +1172,13 @@ def positive_int_arg(raw: str) -> int:
     if value <= 0:
         raise argparse.ArgumentTypeError("must be a positive integer")
     return value
+
+
+def loop_a_local_fallback_value(value: int | None, *, default: int, maximum: int, label: str) -> int:
+    resolved = default if value is None else value
+    if resolved > maximum:
+        raise CardValidationError(f"Loop A local fallback {label} must be <= {maximum}")
+    return resolved
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -1137,9 +1242,22 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--loop-a-local-fallback",
+        action="store_true",
+        help=(
+            "Write a standalone Loop A local-fallback experiment_card.json from an accepted "
+            "dataset gate. Implies policy_gradient card supply and defaults to 5 workers, "
+            "5 repetitions, and 200 ticks."
+        ),
+    )
+    parser.add_argument(
         "--from-latest-accepted-dataset",
         action="store_true",
         help="Use the latest accepted dataset gate under --dataset-gate-root as dataset_run_id.",
+    )
+    parser.add_argument(
+        "--source-gate-id",
+        help="Accepted dataset gate ID to use as source provenance for the generated card.",
     )
     parser.add_argument(
         "--dataset-gate-root",
@@ -1203,10 +1321,14 @@ def main(
 
         if args.output is not None and args.output_dir is not None:
             raise CardValidationError("--output and --output-dir are mutually exclusive")
+        if args.loop_a_local_fallback and args.output_dir is not None:
+            raise CardValidationError("--loop-a-local-fallback writes a standalone experiment_card.json; use --output")
+        if args.loop_a_local_fallback and args.dry_run:
+            raise CardValidationError("--loop-a-local-fallback requires an accepted dataset gate")
 
         if args.select_loop_a_card:
-            if args.validate:
-                raise CardValidationError("--select-loop-a-card cannot be combined with --validate")
+            if args.validate or args.loop_a_local_fallback:
+                raise CardValidationError("--select-loop-a-card cannot be combined with --validate or --loop-a-local-fallback")
             selected = select_loop_a_card_supply(args.card_dir, args.training_report_dir)
             if selected is None:
                 write_output(
@@ -1232,26 +1354,65 @@ def main(
             return 0
 
         dataset_run_id = args.dataset_run_id
-        if args.from_latest_accepted_dataset:
+        source_gate = None
+        if args.from_latest_accepted_dataset and dataset_run_id is not None:
+            raise CardValidationError("--from-latest-accepted-dataset cannot be combined with --dataset-run-id")
+        if args.source_gate_id is not None:
+            source_gate = select_accepted_dataset_gate(args.dataset_gate_root, args.source_gate_id)
+            source_dataset_run_id = str(source_gate["dataset_run_id"])
+            if dataset_run_id is not None and dataset_run_id != source_dataset_run_id:
+                raise CardValidationError("--dataset-run-id must match --source-gate-id dataset_run_id")
+            dataset_run_id = source_dataset_run_id
+        elif args.from_latest_accepted_dataset or args.loop_a_local_fallback:
             if dataset_run_id is not None:
                 raise CardValidationError("--from-latest-accepted-dataset cannot be combined with --dataset-run-id")
-            dataset_run_id = latest_accepted_dataset_run_id(args.dataset_gate_root)
+            source_gate = select_accepted_dataset_gate(args.dataset_gate_root)
+            dataset_run_id = str(source_gate["dataset_run_id"])
         if dataset_run_id is None:
             if not args.dry_run:
                 raise CardValidationError("--dataset-run-id is required unless --dry-run is used")
             dataset_run_id = DRY_RUN_DATASET_RUN_ID
 
-        training_approach = "policy_gradient" if args.loop_a_policy_gradient_supply else args.training_approach
+        loop_a_card_supply = args.loop_a_policy_gradient_supply or args.loop_a_local_fallback
+        training_approach = "policy_gradient" if loop_a_card_supply else args.training_approach
+        simulation_ticks = args.ticks
+        simulation_repetitions = args.repetitions
+        simulation_workers = args.workers
+        if args.loop_a_local_fallback:
+            simulation_ticks = loop_a_local_fallback_value(
+                args.ticks,
+                default=LOOP_A_LOCAL_FALLBACK_TICKS,
+                maximum=LOOP_A_LOCAL_FALLBACK_TICKS,
+                label="ticks",
+            )
+            simulation_repetitions = loop_a_local_fallback_value(
+                args.repetitions,
+                default=LOOP_A_LOCAL_FALLBACK_REPETITIONS,
+                maximum=LOOP_A_LOCAL_FALLBACK_REPETITIONS,
+                label="repetitions",
+            )
+            simulation_workers = loop_a_local_fallback_value(
+                args.workers,
+                default=LOOP_A_LOCAL_FALLBACK_WORKERS,
+                maximum=LOOP_A_LOCAL_FALLBACK_WORKERS,
+                label="workers",
+            )
         card = build_card(
             dataset_run_id=dataset_run_id,
             code_commit=args.code_commit or git_commit(repo),
             training_approach=training_approach,
             created_at=args.created_at or utc_now_iso(),
-            simulation_ticks=args.ticks,
-            simulation_repetitions=args.repetitions,
-            simulation_workers=args.workers,
-            loop_a_card_supply=args.loop_a_policy_gradient_supply,
+            simulation_ticks=simulation_ticks,
+            simulation_repetitions=simulation_repetitions,
+            simulation_workers=simulation_workers,
+            loop_a_card_supply=loop_a_card_supply,
+            source_gate=source_gate,
         )
+        if args.loop_a_local_fallback:
+            output_path = args.output or repo / DEFAULT_LOOP_A_LOCAL_FALLBACK_CARD_PATH.relative_to(REPO_ROOT)
+            write_output(card, output_path, stdout)
+            stdout.write(canonical_json(generated_card_summary(card, output_path, loop_a_local_fallback=True)))
+            return 0
         if args.output_dir is not None:
             output_path = args.output_dir / f"{card['card_id']}.json"
             write_output(card, output_path, stdout)

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -28,6 +28,8 @@ LOOP_A_CARD_SUPPLY_CONSUMER = "loop-a-policy-gradient"
 LOOP_A_CARD_SUPPLY_AVAILABLE = "available"
 LOOP_A_CARD_SUPPLY_CONSUMED = "consumed"
 LOOP_A_CARD_SUPPLY_STATES = (LOOP_A_CARD_SUPPLY_AVAILABLE, LOOP_A_CARD_SUPPLY_CONSUMED)
+SOURCE_GATE_TYPE = "screeps-rl-dataset-evaluation-gate"
+DATASET_GATE_REPORT_FILENAME = "gate_report.json"
 DEFAULT_STRATEGY_VARIANTS = (
     "construction-priority.incumbent.v1",
     "construction-priority.territory-shadow.v1",
@@ -309,7 +311,7 @@ def source_gate_block(
     if created_at is not None:
         validate_created_at(created_at)
     return {
-        "type": "screeps-rl-dataset-evaluation-gate",
+        "type": SOURCE_GATE_TYPE,
         "gate_id": gate_id,
         "dataset_run_id": dataset_run_id,
         "gate_report_path": stable_provenance_path(gate_report_path),
@@ -683,8 +685,8 @@ def validate_source_gate(card: JsonObject) -> None:
         return
     if not isinstance(raw, dict):
         raise CardValidationError("source_gate must be a JSON object")
-    if raw.get("type") not in (None, "screeps-rl-dataset-evaluation-gate"):
-        raise CardValidationError("source_gate.type must be screeps-rl-dataset-evaluation-gate")
+    if raw.get("type") != SOURCE_GATE_TYPE:
+        raise CardValidationError(f"source_gate.type must be {SOURCE_GATE_TYPE}")
     gate_id = first_present(raw, ("gate_id", "gateId"))
     if not isinstance(gate_id, str) or not gate_id:
         raise CardValidationError("source_gate.gate_id must be a non-empty string")
@@ -798,12 +800,15 @@ def select_accepted_dataset_gate(gate_root: Path, gate_id: str | None = None) ->
     candidates: list[tuple[str, float, str, str, Path]] = []
     if not gate_root.exists():
         raise CardValidationError(f"dataset gate root does not exist: {gate_root}")
-    for path in sorted(gate_root.rglob("*.json")):
+    for gate_dir in sorted(gate_root.iterdir()):
+        path = gate_dir / DATASET_GATE_REPORT_FILENAME
+        if not is_canonical_dataset_gate_report_path(path, gate_root):
+            continue
         try:
             payload = load_json(path)
         except CardValidationError:
             continue
-        if not isinstance(payload, dict) or payload.get("ok") is not True:
+        if not isinstance(payload, dict) or payload.get("ok") is not True or payload.get("type") != SOURCE_GATE_TYPE:
             continue
         try:
             selected_gate_id = accepted_dataset_gate_id(payload, path)
@@ -831,6 +836,14 @@ def select_accepted_dataset_gate(gate_root: Path, gate_id: str | None = None) ->
     )
 
 
+def is_canonical_dataset_gate_report_path(path: Path, gate_root: Path) -> bool:
+    try:
+        relative_path = path.relative_to(gate_root)
+    except ValueError:
+        return False
+    return len(relative_path.parts) == 2 and relative_path.name == DATASET_GATE_REPORT_FILENAME
+
+
 def latest_accepted_dataset_run_id(gate_root: Path) -> str:
     return str(select_accepted_dataset_gate(gate_root)["dataset_run_id"])
 
@@ -841,16 +854,15 @@ def accepted_dataset_gate_id(payload: JsonObject, path: Path) -> str:
         if isinstance(value, str) and value:
             validate_gate_id(value)
             return value
-    value = path.parent.name
-    validate_gate_id(value)
-    return value
+    raise CardValidationError(f"accepted dataset gate report {path} must include gateId")
 
 
 def accepted_dataset_run_id(payload: JsonObject) -> str | None:
-    direct = payload.get("datasetRunId")
-    if isinstance(direct, str) and direct:
-        validate_dataset_run_id(direct)
-        return direct
+    for key in ("datasetRunId", "dataset_run_id"):
+        direct = payload.get(key)
+        if isinstance(direct, str) and direct:
+            validate_dataset_run_id(direct)
+            return direct
     dataset = payload.get("dataset")
     if isinstance(dataset, dict):
         run_id = dataset.get("runId")

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -279,6 +279,12 @@ class RlExperimentCardTest(unittest.TestCase):
                     "7" * 40,
                     "--created-at",
                     "2026-05-18T03:12:00Z",
+                    "--ticks",
+                    "1",
+                    "--repetitions",
+                    "1",
+                    "--workers",
+                    "1",
                     "--output",
                     str(output_path),
                 ],
@@ -326,6 +332,48 @@ class RlExperimentCardTest(unittest.TestCase):
             nested_live_regression["safety"][field] = True
             with self.assertRaises(card_helper.CardValidationError):
                 card_helper.validate_card(nested_live_regression)
+
+    def test_source_gate_block_uses_stable_provenance_path(self) -> None:
+        gate_id = "rl-gate-93bf1aa18b62"
+        dataset_run_id = "rl-ebf33fae619f"
+        default_gate_path = card_helper.DEFAULT_DATASET_GATE_ROOT / gate_id / "gate_report.json"
+
+        default_block = card_helper.source_gate_block(
+            gate_id=gate_id,
+            dataset_run_id=dataset_run_id,
+            gate_report_path=default_gate_path,
+            created_at=None,
+        )
+
+        self.assertEqual(
+            default_block["gate_report_path"],
+            f"runtime-artifacts/rl-dataset-gates/{gate_id}/gate_report.json",
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(root)
+                relative_gate_path = Path("gates") / gate_id / "gate_report.json"
+                absolute_gate_path = root / relative_gate_path
+                relative_block = card_helper.source_gate_block(
+                    gate_id=gate_id,
+                    dataset_run_id=dataset_run_id,
+                    gate_report_path=relative_gate_path,
+                    created_at=None,
+                )
+                absolute_block = card_helper.source_gate_block(
+                    gate_id=gate_id,
+                    dataset_run_id=dataset_run_id,
+                    gate_report_path=absolute_gate_path,
+                    created_at=None,
+                )
+            finally:
+                os.chdir(old_cwd)
+
+        self.assertEqual(relative_block["gate_report_path"], f"gates/{gate_id}/gate_report.json")
+        self.assertEqual(absolute_block["gate_report_path"], relative_block["gate_report_path"])
 
     def test_latest_accepted_dataset_skips_malformed_accepted_gate(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -185,7 +185,9 @@ class RlExperimentCardTest(unittest.TestCase):
             older_gate.write_text(
                 json.dumps(
                     {
+                        "type": card_helper.SOURCE_GATE_TYPE,
                         "ok": True,
+                        "gateId": "older",
                         "createdAt": "2026-05-17T01:00:00Z",
                         "dataset": {"runId": "rl-accepted-older"},
                     }
@@ -195,7 +197,9 @@ class RlExperimentCardTest(unittest.TestCase):
             newer_gate.write_text(
                 json.dumps(
                     {
+                        "type": card_helper.SOURCE_GATE_TYPE,
                         "ok": True,
+                        "gateId": "newer",
                         "createdAt": "2026-05-17T02:00:00Z",
                         "dataset": {"runId": "rl-accepted-newer"},
                     }
@@ -205,7 +209,9 @@ class RlExperimentCardTest(unittest.TestCase):
             failed_gate.write_text(
                 json.dumps(
                     {
+                        "type": card_helper.SOURCE_GATE_TYPE,
                         "ok": False,
+                        "gateId": "failed",
                         "createdAt": "2026-05-17T03:00:00Z",
                         "dataset": {"runId": "rl-rejected-newest"},
                     }
@@ -375,6 +381,27 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(relative_block["gate_report_path"], f"gates/{gate_id}/gate_report.json")
         self.assertEqual(absolute_block["gate_report_path"], relative_block["gate_report_path"])
 
+    def test_validate_source_gate_requires_type(self) -> None:
+        gate_id = "rl-gate-93bf1aa18b62"
+        dataset_run_id = "rl-ebf33fae619f"
+        source_gate = card_helper.source_gate_block(
+            gate_id=gate_id,
+            dataset_run_id=dataset_run_id,
+            gate_report_path=Path("gates") / gate_id / "gate_report.json",
+            created_at=None,
+        )
+        card = card_helper.build_card(
+            dataset_run_id=dataset_run_id,
+            code_commit="8" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-18T03:15:00Z",
+            source_gate=source_gate,
+        )
+        del card["source_gate"]["type"]
+
+        with self.assertRaisesRegex(card_helper.CardValidationError, "source_gate.type"):
+            card_helper.validate_card(card)
+
     def test_latest_accepted_dataset_skips_malformed_accepted_gate(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -386,7 +413,9 @@ class RlExperimentCardTest(unittest.TestCase):
             valid_gate.write_text(
                 json.dumps(
                     {
+                        "type": card_helper.SOURCE_GATE_TYPE,
                         "ok": True,
+                        "gateId": "valid",
                         "createdAt": "2026-05-17T01:00:00Z",
                         "dataset": {"runId": "rl-accepted-valid"},
                     }
@@ -396,7 +425,9 @@ class RlExperimentCardTest(unittest.TestCase):
             malformed_gate.write_text(
                 json.dumps(
                     {
+                        "type": card_helper.SOURCE_GATE_TYPE,
                         "ok": True,
+                        "gateId": "malformed",
                         "createdAt": "2026-05-17T02:00:00Z",
                         "dataset": {"runId": "invalid run id"},
                     }
@@ -407,6 +438,43 @@ class RlExperimentCardTest(unittest.TestCase):
             selected = card_helper.latest_accepted_dataset_run_id(gate_root)
 
         self.assertEqual(selected, "rl-accepted-valid")
+
+    def test_latest_accepted_dataset_ignores_nested_non_gate_json(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            gate_root = root / "gates"
+            valid_gate = gate_root / "rl-gate-real" / "gate_report.json"
+            nested_artifact = gate_root / "rl-gate-real" / "nested" / "artifact.json"
+            nested_named_report = gate_root / "rl-gate-real" / "nested" / "gate_report.json"
+            valid_gate.parent.mkdir(parents=True)
+            nested_artifact.parent.mkdir(parents=True)
+            valid_gate.write_text(
+                json.dumps(
+                    {
+                        "type": card_helper.SOURCE_GATE_TYPE,
+                        "ok": True,
+                        "gateId": "rl-gate-real",
+                        "createdAt": "2026-05-17T01:00:00Z",
+                        "dataset": {"runId": "rl-accepted-real"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            nested_payload = {
+                "type": card_helper.SOURCE_GATE_TYPE,
+                "ok": True,
+                "gateId": "rl-gate-nested",
+                "createdAt": "2026-05-17T03:00:00Z",
+                "datasetRunId": "rl-accepted-nested",
+            }
+            nested_artifact.write_text(json.dumps(nested_payload), encoding="utf-8")
+            nested_named_report.write_text(json.dumps(nested_payload), encoding="utf-8")
+
+            selected = card_helper.select_accepted_dataset_gate(gate_root)
+
+        self.assertEqual(selected["gate_id"], "rl-gate-real")
+        self.assertEqual(selected["dataset_run_id"], "rl-accepted-real")
+        self.assertTrue(selected["gate_report_path"].endswith("gates/rl-gate-real/gate_report.json"))
 
     def test_latest_accepted_dataset_skips_gate_deleted_during_scan(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -419,7 +487,9 @@ class RlExperimentCardTest(unittest.TestCase):
             valid_gate.write_text(
                 json.dumps(
                     {
+                        "type": card_helper.SOURCE_GATE_TYPE,
                         "ok": True,
+                        "gateId": "valid",
                         "createdAt": "2026-05-17T01:00:00Z",
                         "dataset": {"runId": "rl-accepted-valid"},
                     }
@@ -429,7 +499,9 @@ class RlExperimentCardTest(unittest.TestCase):
             vanished_gate.write_text(
                 json.dumps(
                     {
+                        "type": card_helper.SOURCE_GATE_TYPE,
                         "ok": True,
+                        "gateId": "vanished",
                         "createdAt": "2026-05-17T02:00:00Z",
                         "dataset": {"runId": "rl-accepted-vanished"},
                     }

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -242,6 +242,86 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(generated["status"], "shadow")
         self.assertTrue(card_helper.is_loop_a_card_available_for_training(generated))
 
+    def test_cli_writes_loop_a_local_fallback_standalone_card_from_requested_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            gate_root = root / "gates"
+            gate_id = "rl-gate-93bf1aa18b62"
+            dataset_run_id = "rl-ebf33fae619f"
+            gate_path = gate_root / gate_id / "gate_report.json"
+            output_path = root / "runtime-artifacts" / "rl-experiment-cards" / "experiment_card.json"
+            gate_path.parent.mkdir(parents=True)
+            gate_path.write_text(
+                json.dumps(
+                    {
+                        "type": "screeps-rl-dataset-evaluation-gate",
+                        "ok": True,
+                        "gateId": gate_id,
+                        "createdAt": "2026-05-18T02:50:00Z",
+                        "dataset": {
+                            "runId": dataset_run_id,
+                            "sampleCount": 200,
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            stdout = io.StringIO()
+
+            exit_code = card_helper.main(
+                [
+                    "--loop-a-local-fallback",
+                    "--source-gate-id",
+                    gate_id,
+                    "--dataset-gate-root",
+                    str(gate_root),
+                    "--code-commit",
+                    "7" * 40,
+                    "--created-at",
+                    "2026-05-18T03:12:00Z",
+                    "--output",
+                    str(output_path),
+                ],
+                stdout=stdout,
+                stderr=io.StringIO(),
+                repo_root=REPO_ROOT,
+            )
+            summary = json.loads(stdout.getvalue())
+            generated = json.loads(output_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output_path.name, "experiment_card.json")
+        self.assertEqual(summary["path"], str(output_path))
+        self.assertTrue(summary["loop_a_local_fallback"])
+        self.assertEqual(summary["source_gate"]["gate_id"], gate_id)
+        self.assertEqual(summary["source_gate"]["dataset_run_id"], dataset_run_id)
+        self.assertEqual(generated["dataset_run_id"], dataset_run_id)
+        self.assertEqual(generated["source_gate"]["gate_id"], gate_id)
+        self.assertEqual(generated["source_gate"]["dataset_run_id"], dataset_run_id)
+        self.assertEqual(generated["training_approach"], "policy_gradient")
+        self.assertEqual(generated["policy_gradient"]["target_family"], "construction-priority")
+
+        config = runner.simulation_config_from_card(generated)
+        self.assertEqual(config.workers, 5)
+        self.assertEqual(config.repetitions, 5)
+        self.assertEqual(config.ticks, 200)
+
+        supply = generated["card_supply"]
+        self.assertEqual(generated["status"], "shadow")
+        self.assertEqual(supply["state"], "available")
+        self.assertTrue(supply["available_for_training"])
+        self.assertIsNone(supply["consumed_at"])
+        self.assertIsNone(supply["consumed_by_report_id"])
+        self.assertTrue(card_helper.is_loop_a_card_available_for_training(generated))
+        for field in ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed"):
+            self.assertFalse(generated[field])
+            self.assertFalse(generated["safety"][field])
+
+            live_regression = json.loads(json.dumps(generated))
+            live_regression[field] = True
+            with self.assertRaises(card_helper.CardValidationError):
+                card_helper.validate_card(live_regression)
+
     def test_latest_accepted_dataset_skips_malformed_accepted_gate(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -322,6 +322,11 @@ class RlExperimentCardTest(unittest.TestCase):
             with self.assertRaises(card_helper.CardValidationError):
                 card_helper.validate_card(live_regression)
 
+            nested_live_regression = json.loads(json.dumps(generated))
+            nested_live_regression["safety"][field] = True
+            with self.assertRaises(card_helper.CardValidationError):
+                card_helper.validate_card(nested_live_regression)
+
     def test_latest_accepted_dataset_skips_malformed_accepted_gate(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
Closes #1186.

## Summary
- adds standalone fallback Loop A experiment-card generation for local training fallback/card-supply recovery
- documents the fallback card workflow in the RL training/reward ops guide
- adds regression coverage for fallback-card selection/safety behavior

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_experiment_card.py scripts/test_screeps_rl_experiment_card.py`
- `python3 -m pytest scripts/test_screeps_rl_experiment_card.py -q` (26 passed, 4 subtests passed)

## Safety
- RL/control-plane only; no `prod/` runtime bot behavior changes
- fallback cards remain shadow/offline; no official MMO writes

## Orchestration note
GraphQL Project/review-thread queries were rate-limited during creation (`remaining=0`, reset ~2026-05-18T05:46Z); controller will reconcile PR Project fields and review-thread state after reset.
