### PR TITLE
feat(rl): generate fresh E1 gated 500 tick cards

### DIFF
--- a/docs/ops/rl-training-reward-workflow.md
+++ b/docs/ops/rl-training-reward-workflow.md
@@ -38,19 +38,20 @@ Dry-run generation is allowed for pipeline checks:
 python3 scripts/screeps_rl_experiment_card.py --dry-run --dataset-run-id rl-000000000000
 ```
 
-Generate the Loop A local-fallback card from an accepted dataset gate, such as
-`rl-gate-93bf1aa18b62` under `runtime-artifacts/rl-dataset-gates`. Use
-`--source-gate-id` with a gate whose `gate_report.json` has `ok: true` and a dataset run ID.
+Generate the Loop A local-fallback card from the newest acceptable E1/postmerge dataset gate.
+By default the helper scans both `runtime-artifacts/rl-dataset-gates` and
+`runtime-artifacts/rl-control-loop` so fresh control-loop gate evidence can supersede stale
+historical gate IDs. Use `--source-gate-id` only for an explicit reproducibility run with a
+gate whose `gate_report.json` has a dataset run ID and passes the structural/shadow safety gates.
 This output is runtime-only because `runtime-artifacts/` is ignored;
 `--loop-a-local-fallback` writes the card to
 `runtime-artifacts/rl-experiment-cards/experiment_card.json` by default and prints a compact
-summary to stdout:
+summary to stdout. Policy-gradient fallback cards are generated at a 500-tick floor with
+5 workers and 5 repetitions:
 
 ```bash
 python3 scripts/screeps_rl_experiment_card.py \
-  --loop-a-local-fallback \
-  --source-gate-id rl-gate-93bf1aa18b62 \
-  --dataset-gate-root runtime-artifacts/rl-dataset-gates
+  --loop-a-local-fallback
 ```
 
 Validate an existing card:

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -17,6 +17,7 @@ from typing import Any, Sequence, TextIO
 
 TRAINING_APPROACHES = ("bandit", "evolutionary", "policy_gradient")
 DATASET_RUN_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+E1_POSTMERGE_DATASET_GATE_ID_RE = re.compile(r"^gate-\d{8}T\d{6}Z-postmerge\d+$")
 COMMIT_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
 ISO_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
 STRATEGY_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
@@ -832,7 +833,7 @@ def select_accepted_dataset_gate(gate_root: Path | Sequence[Path], gate_id: str 
             payload = load_json(path)
         except CardValidationError:
             continue
-        if not is_acceptable_dataset_gate_report(payload):
+        if not is_acceptable_dataset_gate_report(payload, path):
             continue
         try:
             selected_gate_id = accepted_dataset_gate_id(payload, path)
@@ -927,15 +928,36 @@ def is_canonical_dataset_gate_report_path(path: Path, gate_root: Path) -> bool:
     )
 
 
-def is_acceptable_dataset_gate_report(payload: Any) -> bool:
+def is_acceptable_dataset_gate_report(payload: Any, path: Path | None = None) -> bool:
     if not isinstance(payload, dict) or payload.get("type") != SOURCE_GATE_TYPE:
+        return False
+    if not is_e1_postmerge_dataset_gate_report(payload, path):
         return False
     if payload.get("ok") is True:
         return True
-    return is_degraded_e1_gate_acceptable(payload)
+    return is_degraded_e1_gate_acceptable(payload, path)
 
 
-def is_degraded_e1_gate_acceptable(payload: JsonObject) -> bool:
+def is_e1_postmerge_dataset_gate_report(payload: JsonObject, path: Path | None = None) -> bool:
+    gate_id = dataset_gate_id(payload)
+    if gate_id is None or E1_POSTMERGE_DATASET_GATE_ID_RE.fullmatch(gate_id) is None:
+        return False
+    if path is not None and path.parent.name != gate_id:
+        return False
+    return True
+
+
+def dataset_gate_id(payload: JsonObject) -> str | None:
+    for key in ("gateId", "gate_id"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def is_degraded_e1_gate_acceptable(payload: JsonObject, path: Path | None = None) -> bool:
+    if not is_e1_postmerge_dataset_gate_report(payload, path):
+        return False
     blocking_reasons = payload.get("blockingReasons")
     if not isinstance(blocking_reasons, list) or not blocking_reasons:
         return False

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, TextIO
+from typing import Any, Sequence, TextIO
 
 
 TRAINING_APPROACHES = ("bandit", "evolutionary", "policy_gradient")
@@ -42,17 +42,22 @@ DEFAULT_SIMULATION_MAP_SOURCE_FILE = REPO_ROOT / "maps" / "map-0b6758af.json"
 DEFAULT_SIMULATION_OUT_DIR = REPO_ROOT / "runtime-artifacts" / "rl-simulator"
 DEFAULT_EXPERIMENT_CARD_DIR = REPO_ROOT / "runtime-artifacts" / "rl-experiment-cards"
 DEFAULT_DATASET_GATE_ROOT = REPO_ROOT / "runtime-artifacts" / "rl-dataset-gates"
+DEFAULT_CONTROL_LOOP_GATE_ROOT = REPO_ROOT / "runtime-artifacts" / "rl-control-loop"
+DEFAULT_DATASET_GATE_ROOTS = (DEFAULT_DATASET_GATE_ROOT, DEFAULT_CONTROL_LOOP_GATE_ROOT)
 DEFAULT_TRAINING_REPORT_ROOT = REPO_ROOT / "runtime-artifacts" / "rl-training"
 DEFAULT_LOOP_A_LOCAL_FALLBACK_CARD_PATH = DEFAULT_EXPERIMENT_CARD_DIR / "experiment_card.json"
 DEFAULT_STRATEGY_REGISTRY_PATH = REPO_ROOT / "prod" / "src" / "strategy" / "strategyRegistry.ts"
 DEFAULT_SIMULATION_TICKS = 50
 DEFAULT_SIMULATION_REPETITIONS = 1
 DEFAULT_SIMULATION_WORKERS = 1
-POLICY_GRADIENT_SIMULATION_TICKS = 100
+POLICY_GRADIENT_MIN_SIMULATION_TICKS = 500
+POLICY_GRADIENT_SIMULATION_TICKS = POLICY_GRADIENT_MIN_SIMULATION_TICKS
 POLICY_GRADIENT_SIMULATION_REPETITIONS = 5
-LOOP_A_LOCAL_FALLBACK_TICKS = 200
+LOOP_A_LOCAL_FALLBACK_TICKS = POLICY_GRADIENT_MIN_SIMULATION_TICKS
+LOOP_A_LOCAL_FALLBACK_MAX_TICKS = 5000
 LOOP_A_LOCAL_FALLBACK_REPETITIONS = 5
 LOOP_A_LOCAL_FALLBACK_WORKERS = 5
+DEGRADED_E1_GATE_MIN_ACCEPTANCE_RATE = 0.95
 
 JsonObject = dict[str, Any]
 
@@ -244,10 +249,13 @@ def build_card(
         simulation_repetitions if simulation_repetitions is not None else default_repetitions,
         "simulation.repetitions",
     )
+    default_workers = LOOP_A_LOCAL_FALLBACK_WORKERS if loop_a_card_supply else DEFAULT_SIMULATION_WORKERS
     workers = require_positive_int(
-        simulation_workers if simulation_workers is not None else DEFAULT_SIMULATION_WORKERS,
+        simulation_workers if simulation_workers is not None else default_workers,
         "simulation.workers",
     )
+    if training_approach == "policy_gradient":
+        ticks = max(ticks, POLICY_GRADIENT_MIN_SIMULATION_TICKS)
 
     commit_prefix = code_commit[:12].lower()
     card = {
@@ -305,12 +313,16 @@ def source_gate_block(
     dataset_run_id: str,
     gate_report_path: Path,
     created_at: str | None,
+    gate_report_ok: bool | None = None,
+    acceptance_rate: float | None = None,
+    dataset_gate_status: str | None = None,
+    shadow_evaluation_status: str | None = None,
 ) -> JsonObject:
     validate_gate_id(gate_id)
     validate_dataset_run_id(dataset_run_id)
     if created_at is not None:
         validate_created_at(created_at)
-    return {
+    block: JsonObject = {
         "type": SOURCE_GATE_TYPE,
         "gate_id": gate_id,
         "dataset_run_id": dataset_run_id,
@@ -318,6 +330,15 @@ def source_gate_block(
         "created_at": created_at,
         "ok": True,
     }
+    if gate_report_ok is not None:
+        block["gate_report_ok"] = gate_report_ok
+    if acceptance_rate is not None:
+        block["quality_acceptance_rate"] = round(acceptance_rate, 6)
+    if dataset_gate_status is not None:
+        block["dataset_gate_status"] = dataset_gate_status
+    if shadow_evaluation_status is not None:
+        block["shadow_evaluation_status"] = shadow_evaluation_status
+    return block
 
 
 def require_positive_int(value: Any, label: str) -> int:
@@ -621,13 +642,15 @@ def validate_card(raw: Any) -> None:
     validate_source_gate(raw)
     strategy_variants = first_present(raw, ("strategy_variants", "strategyVariants", "variants"))
     validate_strategy_variants(strategy_variants)
-    validate_simulation(first_present(raw, ("simulation", "simulator")))
+    simulation = first_present(raw, ("simulation", "simulator"))
+    validate_simulation(simulation)
     policy_gradient = first_present(raw, ("policy_gradient", "policyGradient"))
     if training_approach == "policy_gradient" and policy_gradient is None:
         raise CardValidationError("policy_gradient metadata is required when training_approach is policy_gradient")
     if policy_gradient is not None:
         validate_policy_gradient(policy_gradient)
     if training_approach == "policy_gradient":
+        validate_policy_gradient_simulation(simulation)
         validate_policy_gradient_strategy_variants(policy_gradient, strategy_variants)
 
 
@@ -794,21 +817,22 @@ def loop_a_selection_summary(path: Path, card: JsonObject, consumed_card_ids: se
     }
 
 
-def select_accepted_dataset_gate(gate_root: Path, gate_id: str | None = None) -> JsonObject:
+def select_accepted_dataset_gate(gate_root: Path | Sequence[Path], gate_id: str | None = None) -> JsonObject:
     if gate_id is not None:
         validate_gate_id(gate_id)
-    candidates: list[tuple[str, float, str, str, Path]] = []
-    if not gate_root.exists():
-        raise CardValidationError(f"dataset gate root does not exist: {gate_root}")
-    for gate_dir in sorted(gate_root.iterdir()):
-        path = gate_dir / DATASET_GATE_REPORT_FILENAME
-        if not is_canonical_dataset_gate_report_path(path, gate_root):
-            continue
+    candidates: list[tuple[str, float, str, str, Path, JsonObject]] = []
+    roots = dataset_gate_roots(gate_root)
+    existing_roots = [root for root in roots if root.exists()]
+    if not existing_roots:
+        raise CardValidationError(
+            "dataset gate root does not exist: " + ", ".join(str(root) for root in roots)
+        )
+    for path in iter_canonical_dataset_gate_report_paths(existing_roots):
         try:
             payload = load_json(path)
         except CardValidationError:
             continue
-        if not isinstance(payload, dict) or payload.get("ok") is not True or payload.get("type") != SOURCE_GATE_TYPE:
+        if not is_acceptable_dataset_gate_report(payload):
             continue
         try:
             selected_gate_id = accepted_dataset_gate_id(payload, path)
@@ -821,19 +845,70 @@ def select_accepted_dataset_gate(gate_root: Path, gate_id: str | None = None) ->
             mtime = path.stat().st_mtime
         except (CardValidationError, OSError):
             continue
-        candidates.append((created_at or "", mtime, selected_gate_id, run_id, path))
+        candidates.append(
+            (
+                created_at or "",
+                mtime,
+                selected_gate_id,
+                run_id,
+                path,
+                source_gate_block(
+                    gate_id=selected_gate_id,
+                    dataset_run_id=run_id,
+                    gate_report_path=path,
+                    created_at=created_at or None,
+                    gate_report_ok=payload.get("ok") is True,
+                    acceptance_rate=dataset_gate_acceptance_rate(payload),
+                    dataset_gate_status=dataset_gate_status(payload),
+                    shadow_evaluation_status=shadow_evaluation_status(payload),
+                ),
+            )
+        )
     if not candidates:
         if gate_id is not None:
-            raise CardValidationError(f"no accepted dataset gate {gate_id} with datasetRunId found under {gate_root}")
-        raise CardValidationError(f"no accepted dataset gate with datasetRunId found under {gate_root}")
+            raise CardValidationError(
+                f"no accepted dataset gate {gate_id} with datasetRunId found under "
+                + ", ".join(str(root) for root in roots)
+            )
+        raise CardValidationError(
+            "no accepted dataset gate with datasetRunId found under "
+            + ", ".join(str(root) for root in roots)
+        )
     candidates.sort(key=lambda item: (item[0], item[1], item[2], str(item[4])), reverse=True)
-    created_at, _, selected_gate_id, run_id, path = candidates[0]
-    return source_gate_block(
-        gate_id=selected_gate_id,
-        dataset_run_id=run_id,
-        gate_report_path=path,
-        created_at=created_at or None,
-    )
+    return candidates[0][5]
+
+
+def dataset_gate_roots(gate_root: Path | Sequence[Path]) -> list[Path]:
+    if isinstance(gate_root, Path):
+        return [gate_root]
+    return [Path(root) for root in gate_root]
+
+
+def iter_canonical_dataset_gate_report_paths(gate_roots: Sequence[Path]) -> list[Path]:
+    paths: set[Path] = set()
+    for root in gate_roots:
+        if not root.exists():
+            continue
+        for path in child_gate_report_paths(root):
+            if is_canonical_dataset_gate_report_path(path, root):
+                paths.add(path)
+        if root.name == "runtime-artifacts":
+            for child_name in ("rl-dataset-gates", "rl-control-loop"):
+                child = root / child_name
+                if not child.exists():
+                    continue
+                for path in child_gate_report_paths(child):
+                    if is_canonical_dataset_gate_report_path(path, root):
+                        paths.add(path)
+    return sorted(paths)
+
+
+def child_gate_report_paths(root: Path) -> list[Path]:
+    try:
+        children = sorted(root.iterdir())
+    except OSError:
+        return []
+    return [child / DATASET_GATE_REPORT_FILENAME for child in children]
 
 
 def is_canonical_dataset_gate_report_path(path: Path, gate_root: Path) -> bool:
@@ -841,7 +916,82 @@ def is_canonical_dataset_gate_report_path(path: Path, gate_root: Path) -> bool:
         relative_path = path.relative_to(gate_root)
     except ValueError:
         return False
-    return len(relative_path.parts) == 2 and relative_path.name == DATASET_GATE_REPORT_FILENAME
+    if relative_path.name != DATASET_GATE_REPORT_FILENAME:
+        return False
+    if len(relative_path.parts) == 2:
+        return relative_path.parts[0] != "gate-data"
+    return (
+        len(relative_path.parts) == 3
+        and relative_path.parts[0] in {"rl-dataset-gates", "rl-control-loop"}
+        and relative_path.parts[1] != "gate-data"
+    )
+
+
+def is_acceptable_dataset_gate_report(payload: Any) -> bool:
+    if not isinstance(payload, dict) or payload.get("type") != SOURCE_GATE_TYPE:
+        return False
+    if payload.get("ok") is True:
+        return True
+    return is_degraded_e1_gate_acceptable(payload)
+
+
+def is_degraded_e1_gate_acceptable(payload: JsonObject) -> bool:
+    blocking_reasons = payload.get("blockingReasons")
+    if not isinstance(blocking_reasons, list) or not blocking_reasons:
+        return False
+    if any(not is_quality_only_blocking_reason(reason) for reason in blocking_reasons):
+        return False
+    if dataset_gate_status(payload) != "pass" or shadow_evaluation_status(payload) != "pass":
+        return False
+    dataset = payload.get("dataset")
+    if not isinstance(dataset, dict) or dataset.get("ok") is not True:
+        return False
+    sample_count = dataset.get("sampleCount")
+    if not isinstance(sample_count, int) or sample_count <= 0:
+        return False
+    acceptance_rate = dataset_gate_acceptance_rate(payload)
+    return acceptance_rate is not None and acceptance_rate >= DEGRADED_E1_GATE_MIN_ACCEPTANCE_RATE
+
+
+def is_quality_only_blocking_reason(reason: Any) -> bool:
+    return (
+        isinstance(reason, dict)
+        and reason.get("gate") == "quality_checks"
+        and reason.get("name") == "sample_quality"
+    )
+
+
+def dataset_gate_status(payload: JsonObject) -> str | None:
+    dataset_gate = payload.get("datasetGate")
+    status = dataset_gate.get("status") if isinstance(dataset_gate, dict) else None
+    return status if isinstance(status, str) else None
+
+
+def shadow_evaluation_status(payload: JsonObject) -> str | None:
+    shadow = payload.get("shadowEvaluation")
+    status = shadow.get("status") if isinstance(shadow, dict) else None
+    return status if isinstance(status, str) else None
+
+
+def dataset_gate_acceptance_rate(payload: JsonObject) -> float | None:
+    blocking_reasons = payload.get("blockingReasons")
+    reasons = blocking_reasons if isinstance(blocking_reasons, list) else []
+    for reason in reasons:
+        if not isinstance(reason, dict) or reason.get("gate") != "quality_checks":
+            continue
+        accepted = reason.get("samplesAccepted")
+        rejected = reason.get("samplesRejected")
+        if isinstance(accepted, int) and isinstance(rejected, int) and accepted + rejected > 0:
+            return accepted / (accepted + rejected)
+    quality = payload.get("quality_checks")
+    if isinstance(quality, dict):
+        accepted = quality.get("samples_accepted")
+        rejected = quality.get("samples_rejected")
+        if isinstance(accepted, int) and isinstance(rejected, int) and accepted + rejected > 0:
+            return accepted / (accepted + rejected)
+    if payload.get("ok") is True:
+        return 1.0
+    return None
 
 
 def latest_accepted_dataset_run_id(gate_root: Path) -> str:
@@ -1110,6 +1260,16 @@ def validate_simulation(raw: Any) -> None:
             raise CardValidationError(f"simulation.{field} must be a non-empty string")
 
 
+def validate_policy_gradient_simulation(raw: Any) -> None:
+    if not isinstance(raw, dict):
+        raise CardValidationError("simulation must be a JSON object")
+    ticks = positive_int(raw.get("ticks"))
+    if ticks is None or ticks < POLICY_GRADIENT_MIN_SIMULATION_TICKS:
+        raise CardValidationError(
+            f"policy_gradient cards require simulation.ticks >= {POLICY_GRADIENT_MIN_SIMULATION_TICKS}"
+        )
+
+
 def positive_int(value: Any) -> int | None:
     if isinstance(value, bool):
         return None
@@ -1203,6 +1363,16 @@ def loop_a_local_fallback_value(value: int | None, *, default: int, maximum: int
     return resolved
 
 
+def resolve_dataset_gate_roots(gate_root: Path | None, repo: Path) -> list[Path]:
+    if gate_root is not None:
+        expanded = gate_root.expanduser()
+        return [expanded if expanded.is_absolute() else (repo / expanded)]
+    return [
+        repo / root.relative_to(REPO_ROOT)
+        for root in DEFAULT_DATASET_GATE_ROOTS
+    ]
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Generate or validate offline/shadow Screeps RL experiment cards.",
@@ -1235,7 +1405,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--ticks",
         type=positive_int_arg,
         help=(
-            "Simulation ticks to request. Defaults to 50, or 100 for policy_gradient cards."
+            "Simulation ticks to request. Defaults to 50, or 500 for policy_gradient cards."
         ),
     )
     parser.add_argument(
@@ -1269,7 +1439,7 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Write a standalone Loop A local-fallback experiment_card.json from an accepted "
             "dataset gate. Implies policy_gradient card supply and defaults to 5 workers, "
-            "5 repetitions, and 200 ticks."
+            "5 repetitions, and 500 ticks."
         ),
     )
     parser.add_argument(
@@ -1284,8 +1454,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--dataset-gate-root",
         type=Path,
-        default=DEFAULT_DATASET_GATE_ROOT,
-        help=f"Root scanned by --from-latest-accepted-dataset. Default: {DEFAULT_DATASET_GATE_ROOT}.",
+        default=None,
+        help=(
+            "Root scanned by --from-latest-accepted-dataset. Defaults to "
+            f"{DEFAULT_DATASET_GATE_ROOT} plus {DEFAULT_CONTROL_LOOP_GATE_ROOT}."
+        ),
     )
     parser.add_argument(
         "--select-loop-a-card",
@@ -1377,10 +1550,11 @@ def main(
 
         dataset_run_id = args.dataset_run_id
         source_gate = None
+        dataset_gate_roots = resolve_dataset_gate_roots(args.dataset_gate_root, repo)
         if args.from_latest_accepted_dataset and dataset_run_id is not None:
             raise CardValidationError("--from-latest-accepted-dataset cannot be combined with --dataset-run-id")
         if args.source_gate_id is not None:
-            source_gate = select_accepted_dataset_gate(args.dataset_gate_root, args.source_gate_id)
+            source_gate = select_accepted_dataset_gate(dataset_gate_roots, args.source_gate_id)
             source_dataset_run_id = str(source_gate["dataset_run_id"])
             if dataset_run_id is not None and dataset_run_id != source_dataset_run_id:
                 raise CardValidationError("--dataset-run-id must match --source-gate-id dataset_run_id")
@@ -1391,7 +1565,7 @@ def main(
                     "--from-latest-accepted-dataset or --loop-a-local-fallback cannot be combined "
                     "with --dataset-run-id"
                 )
-            source_gate = select_accepted_dataset_gate(args.dataset_gate_root)
+            source_gate = select_accepted_dataset_gate(dataset_gate_roots)
             dataset_run_id = str(source_gate["dataset_run_id"])
         if dataset_run_id is None:
             if not args.dry_run:
@@ -1407,7 +1581,7 @@ def main(
             simulation_ticks = loop_a_local_fallback_value(
                 args.ticks,
                 default=LOOP_A_LOCAL_FALLBACK_TICKS,
-                maximum=LOOP_A_LOCAL_FALLBACK_TICKS,
+                maximum=LOOP_A_LOCAL_FALLBACK_MAX_TICKS,
                 label="ticks",
             )
             simulation_repetitions = loop_a_local_fallback_value(

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -44,6 +44,7 @@ DEFAULT_REMOTE_BASE = "/opt/screeps-batch/jobs"
 DEFAULT_ARTIFACT_ROOT = Path("runtime-artifacts/tencent-cloud/batch-runs")
 MAX_SCALE_PROOF_WORKERS = 16
 SCALE_PROOF_SUCCESS_RATE = 0.8
+POLICY_GRADIENT_MIN_SIMULATION_TICKS = 500
 RUN_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]{2,80}$")
 SSH_CONNECT_OPTIONS = (
     "-o", "BatchMode=yes",
@@ -172,7 +173,7 @@ class Controller:
             "inputs": {
                 "datasetRunId": self.args.dataset_run_id,
                 "experimentCard": str(self.experiment_card_path()),
-                "ticks": self.args.ticks,
+                "ticks": effective_training_ticks(self.args),
                 "workers": self.args.workers,
                 "repetitions": self.args.repetitions,
                 "trainingApproach": self.args.training_approach,
@@ -398,9 +399,10 @@ class Controller:
         # Apply bounded-run overrides after generation; keep schema-valid fields.
         payload = json.loads(card.read_text(encoding="utf-8"))
         simulation = payload.setdefault("simulation", {})
+        ticks = effective_training_ticks(self.args)
         scale_environments = resolve_scale_environment_count(self.args)
         simulation.update({
-            "ticks": self.args.ticks,
+            "ticks": ticks,
             "workers": self.args.workers,
             "repetitions": self.args.repetitions,
             "host_port_start": self.args.host_port_start,
@@ -1164,6 +1166,13 @@ def resolve_scale_environment_count(args: argparse.Namespace) -> int | None:
     return workers if workers > 1 else None
 
 
+def effective_training_ticks(args: argparse.Namespace) -> int:
+    ticks = int(getattr(args, "ticks", 1))
+    if getattr(args, "training_approach", None) == "policy_gradient":
+        return max(ticks, POLICY_GRADIENT_MIN_SIMULATION_TICKS)
+    return ticks
+
+
 def minimum_successful_environments(environment_count: int) -> int:
     return math.ceil(environment_count * SCALE_PROOF_SUCCESS_RATE)
 
@@ -1201,6 +1210,7 @@ def build_scale_proof_spec(
                 "trainingRunner": "scripts/screeps_rl_training_runner.py",
                 "simulatorHarness": "scripts/screeps_rl_simulator_harness.py",
                 "cardSimulationFields": {
+                    "ticks": effective_training_ticks(args),
                     "workers": args.workers,
                     "scale_environments": scale_environments,
                     "min_concurrent_environments": scale_environments,
@@ -1365,7 +1375,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--ssh-key", default=str(DEFAULT_SSH_KEY))
     parser.add_argument("--dataset-run-id", default="rl-3d29e8b9397d")
     parser.add_argument("--training-approach", default="bandit", choices=("bandit", "evolutionary", "policy_gradient"))
-    parser.add_argument("--ticks", type=int, default=50)
+    parser.add_argument("--ticks", type=int, default=50, help="Simulator ticks; policy_gradient runs are floored to 500.")
     parser.add_argument("--workers", type=int, default=1)
     parser.add_argument(
         "--scale-environments",

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -93,7 +93,7 @@ class RlExperimentCardTest(unittest.TestCase):
         learnable_names = [item["name"] for item in policy_gradient["learnable_parameters"]]
 
         self.assertEqual(card["training_approach"], "policy_gradient")
-        self.assertEqual(config.ticks, 100)
+        self.assertEqual(config.ticks, 500)
         self.assertEqual(config.repetitions, 5)
         self.assertFalse(card["liveEffect"])
         self.assertFalse(card["officialMmoWrites"])
@@ -144,10 +144,14 @@ class RlExperimentCardTest(unittest.TestCase):
 
         card_helper.validate_card(card)
         runner.validate_experiment_card(card)
+        config = runner.simulation_config_from_card(card)
 
         supply = card["card_supply"]
         self.assertEqual(card["status"], "shadow")
         self.assertEqual(card["training_approach"], "policy_gradient")
+        self.assertEqual(config.ticks, 500)
+        self.assertEqual(config.workers, 5)
+        self.assertEqual(config.repetitions, 5)
         self.assertEqual(supply["state"], "available")
         self.assertTrue(supply["available_for_training"])
         self.assertEqual(supply["consumer"], "loop-a-policy-gradient")
@@ -198,10 +202,21 @@ class RlExperimentCardTest(unittest.TestCase):
                 json.dumps(
                     {
                         "type": card_helper.SOURCE_GATE_TYPE,
-                        "ok": True,
-                        "gateId": "newer",
+                        "ok": False,
+                        "gateId": "gate-20260517T181846Z-postmerge1176",
                         "createdAt": "2026-05-17T02:00:00Z",
-                        "dataset": {"runId": "rl-accepted-newer"},
+                        "dataset": {"ok": True, "runId": "rl-accepted-newer", "sampleCount": 200},
+                        "datasetGate": {"status": "pass"},
+                        "shadowEvaluation": {"status": "pass", "ok": True},
+                        "blockingReasons": [
+                            {
+                                "gate": "quality_checks",
+                                "name": "sample_quality",
+                                "status": "fail",
+                                "samplesAccepted": 191,
+                                "samplesRejected": 9,
+                            }
+                        ],
                     }
                 ),
                 encoding="utf-8",
@@ -242,10 +257,16 @@ class RlExperimentCardTest(unittest.TestCase):
 
         self.assertEqual(exit_code, 0)
         self.assertEqual(summary["dataset_run_id"], "rl-accepted-newer")
+        self.assertEqual(summary["source_gate"]["gate_id"], "gate-20260517T181846Z-postmerge1176")
+        self.assertFalse(summary["source_gate"]["gate_report_ok"])
+        self.assertGreaterEqual(summary["source_gate"]["quality_acceptance_rate"], 0.95)
         self.assertEqual(summary["card_supply"]["state"], "available")
         self.assertEqual(generated["dataset_run_id"], "rl-accepted-newer")
         self.assertEqual(generated["training_approach"], "policy_gradient")
         self.assertEqual(generated["status"], "shadow")
+        self.assertEqual(generated["simulation"]["ticks"], 500)
+        self.assertEqual(generated["simulation"]["workers"], 5)
+        self.assertEqual(generated["simulation"]["repetitions"], 5)
         self.assertTrue(card_helper.is_loop_a_card_available_for_training(generated))
 
     def test_cli_writes_loop_a_local_fallback_standalone_card_from_requested_gate(self) -> None:
@@ -300,6 +321,20 @@ class RlExperimentCardTest(unittest.TestCase):
             )
             summary = json.loads(stdout.getvalue())
             generated = json.loads(output_path.read_text(encoding="utf-8"))
+            selected_stdout = io.StringIO()
+            selected_exit_code = card_helper.main(
+                [
+                    "--select-loop-a-card",
+                    "--card-dir",
+                    str(output_path.parent),
+                    "--training-report-dir",
+                    str(root / "runtime-artifacts" / "rl-training"),
+                ],
+                stdout=selected_stdout,
+                stderr=io.StringIO(),
+                repo_root=REPO_ROOT,
+            )
+            selected = json.loads(selected_stdout.getvalue())
 
         self.assertEqual(exit_code, 0)
         self.assertEqual(output_path.name, "experiment_card.json")
@@ -316,7 +351,7 @@ class RlExperimentCardTest(unittest.TestCase):
         config = runner.simulation_config_from_card(generated)
         self.assertEqual(config.workers, 5)
         self.assertEqual(config.repetitions, 5)
-        self.assertEqual(config.ticks, 200)
+        self.assertEqual(config.ticks, 500)
 
         supply = generated["card_supply"]
         self.assertEqual(generated["status"], "shadow")
@@ -325,6 +360,9 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertIsNone(supply["consumed_at"])
         self.assertIsNone(supply["consumed_by_report_id"])
         self.assertTrue(card_helper.is_loop_a_card_available_for_training(generated))
+        self.assertEqual(selected_exit_code, 0)
+        self.assertEqual(selected["card_path"], str(output_path))
+        self.assertEqual(selected["card_supply"]["state"], "available")
         for field in ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed"):
             self.assertFalse(generated[field])
             self.assertFalse(generated["safety"][field])
@@ -475,6 +513,57 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(selected["gate_id"], "rl-gate-real")
         self.assertEqual(selected["dataset_run_id"], "rl-accepted-real")
         self.assertTrue(selected["gate_report_path"].endswith("gates/rl-gate-real/gate_report.json"))
+
+    def test_latest_accepted_dataset_scans_control_loop_postmerge_gate_over_stale_dataset_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runtime_root = root / "runtime-artifacts"
+            stale_gate = runtime_root / "rl-dataset-gates" / "rl-gate-stale" / "gate_report.json"
+            fresh_gate = runtime_root / "rl-control-loop" / "gate-20260517T181846Z-postmerge1176" / "gate_report.json"
+            stale_gate.parent.mkdir(parents=True)
+            fresh_gate.parent.mkdir(parents=True)
+            stale_gate.write_text(
+                json.dumps(
+                    {
+                        "type": card_helper.SOURCE_GATE_TYPE,
+                        "ok": True,
+                        "gateId": "rl-gate-stale",
+                        "createdAt": "2026-05-14T04:22:20Z",
+                        "dataset": {"runId": "rl-stale-gate"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            fresh_gate.write_text(
+                json.dumps(
+                    {
+                        "type": card_helper.SOURCE_GATE_TYPE,
+                        "ok": False,
+                        "gateId": "gate-20260517T181846Z-postmerge1176",
+                        "createdAt": "2026-05-17T18:18:47Z",
+                        "dataset": {"ok": True, "runId": "rl-fresh-postmerge", "sampleCount": 200},
+                        "datasetGate": {"status": "pass"},
+                        "shadowEvaluation": {"status": "pass", "ok": True},
+                        "blockingReasons": [
+                            {
+                                "gate": "quality_checks",
+                                "name": "sample_quality",
+                                "status": "fail",
+                                "samplesAccepted": 191,
+                                "samplesRejected": 9,
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            selected = card_helper.select_accepted_dataset_gate(runtime_root)
+
+        self.assertEqual(selected["gate_id"], "gate-20260517T181846Z-postmerge1176")
+        self.assertEqual(selected["dataset_run_id"], "rl-fresh-postmerge")
+        self.assertFalse(selected["gate_report_ok"])
+        self.assertTrue(selected["gate_report_path"].endswith("rl-control-loop/gate-20260517T181846Z-postmerge1176/gate_report.json"))
 
     def test_latest_accepted_dataset_skips_gate_deleted_during_scan(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -737,8 +826,20 @@ class RlExperimentCardTest(unittest.TestCase):
         )
         config = runner.simulation_config_from_card(card)
 
-        self.assertGreaterEqual(config.ticks, 100)
+        self.assertGreaterEqual(config.ticks, 500)
         self.assertGreaterEqual(config.repetitions, 5)
+
+    def test_validate_rejects_policy_gradient_below_long_horizon_floor(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-short-horizon",
+            code_commit="1" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-17T00:25:00Z",
+        )
+        card["simulation"]["ticks"] = 499
+
+        with self.assertRaisesRegex(card_helper.CardValidationError, "simulation\\.ticks >= 500"):
+            card_helper.validate_card(card)
 
     def test_policy_gradient_rejects_stale_strategy_variant_candidate_policy_id(self) -> None:
         card = card_helper.build_card(
@@ -879,7 +980,7 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         runner.validate_experiment_card(generated)
 
-    def test_cli_generation_accepts_policy_gradient_ticks_and_repetitions(self) -> None:
+    def test_cli_generation_floors_policy_gradient_ticks_and_accepts_repetitions(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             output_path = Path(temp_dir) / "card.json"
             exit_code = card_helper.main(
@@ -908,7 +1009,7 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         runner.validate_experiment_card(generated)
         config = runner.simulation_config_from_card(generated)
-        self.assertEqual(config.ticks, 125)
+        self.assertEqual(config.ticks, 500)
         self.assertEqual(config.repetitions, 6)
         self.assertEqual(generated["training_approach"], "policy_gradient")
         self.assertEqual(generated["policy_gradient"]["target_family"], "construction-priority")

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -181,7 +181,7 @@ class RlExperimentCardTest(unittest.TestCase):
             gate_root = root / "gates"
             card_dir = root / "cards"
             older_gate = gate_root / "older" / "gate_report.json"
-            newer_gate = gate_root / "newer" / "gate_report.json"
+            newer_gate = gate_root / "gate-20260517T181846Z-postmerge1176" / "gate_report.json"
             failed_gate = gate_root / "failed" / "gate_report.json"
             older_gate.parent.mkdir(parents=True)
             newer_gate.parent.mkdir(parents=True)
@@ -273,7 +273,7 @@ class RlExperimentCardTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             gate_root = root / "gates"
-            gate_id = "rl-gate-93bf1aa18b62"
+            gate_id = "gate-20260518T025000Z-postmerge1188"
             dataset_run_id = "rl-ebf33fae619f"
             gate_path = gate_root / gate_id / "gate_report.json"
             output_path = root / "runtime-artifacts" / "rl-experiment-cards" / "experiment_card.json"
@@ -444,8 +444,10 @@ class RlExperimentCardTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             gate_root = root / "gates"
-            valid_gate = gate_root / "valid" / "gate_report.json"
-            malformed_gate = gate_root / "malformed" / "gate_report.json"
+            valid_gate_id = "gate-20260517T010000Z-postmerge1188"
+            malformed_gate_id = "gate-20260517T020000Z-postmerge1188"
+            valid_gate = gate_root / valid_gate_id / "gate_report.json"
+            malformed_gate = gate_root / malformed_gate_id / "gate_report.json"
             valid_gate.parent.mkdir(parents=True)
             malformed_gate.parent.mkdir(parents=True)
             valid_gate.write_text(
@@ -453,7 +455,7 @@ class RlExperimentCardTest(unittest.TestCase):
                     {
                         "type": card_helper.SOURCE_GATE_TYPE,
                         "ok": True,
-                        "gateId": "valid",
+                        "gateId": valid_gate_id,
                         "createdAt": "2026-05-17T01:00:00Z",
                         "dataset": {"runId": "rl-accepted-valid"},
                     }
@@ -465,7 +467,7 @@ class RlExperimentCardTest(unittest.TestCase):
                     {
                         "type": card_helper.SOURCE_GATE_TYPE,
                         "ok": True,
-                        "gateId": "malformed",
+                        "gateId": malformed_gate_id,
                         "createdAt": "2026-05-17T02:00:00Z",
                         "dataset": {"runId": "invalid run id"},
                     }
@@ -481,9 +483,11 @@ class RlExperimentCardTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             gate_root = root / "gates"
-            valid_gate = gate_root / "rl-gate-real" / "gate_report.json"
-            nested_artifact = gate_root / "rl-gate-real" / "nested" / "artifact.json"
-            nested_named_report = gate_root / "rl-gate-real" / "nested" / "gate_report.json"
+            valid_gate_id = "gate-20260517T010000Z-postmerge1188"
+            nested_gate_id = "gate-20260517T030000Z-postmerge1188"
+            valid_gate = gate_root / valid_gate_id / "gate_report.json"
+            nested_artifact = gate_root / valid_gate_id / "nested" / "artifact.json"
+            nested_named_report = gate_root / valid_gate_id / "nested" / "gate_report.json"
             valid_gate.parent.mkdir(parents=True)
             nested_artifact.parent.mkdir(parents=True)
             valid_gate.write_text(
@@ -491,7 +495,7 @@ class RlExperimentCardTest(unittest.TestCase):
                     {
                         "type": card_helper.SOURCE_GATE_TYPE,
                         "ok": True,
-                        "gateId": "rl-gate-real",
+                        "gateId": valid_gate_id,
                         "createdAt": "2026-05-17T01:00:00Z",
                         "dataset": {"runId": "rl-accepted-real"},
                     }
@@ -501,7 +505,7 @@ class RlExperimentCardTest(unittest.TestCase):
             nested_payload = {
                 "type": card_helper.SOURCE_GATE_TYPE,
                 "ok": True,
-                "gateId": "rl-gate-nested",
+                "gateId": nested_gate_id,
                 "createdAt": "2026-05-17T03:00:00Z",
                 "datasetRunId": "rl-accepted-nested",
             }
@@ -510,17 +514,19 @@ class RlExperimentCardTest(unittest.TestCase):
 
             selected = card_helper.select_accepted_dataset_gate(gate_root)
 
-        self.assertEqual(selected["gate_id"], "rl-gate-real")
+        self.assertEqual(selected["gate_id"], valid_gate_id)
         self.assertEqual(selected["dataset_run_id"], "rl-accepted-real")
-        self.assertTrue(selected["gate_report_path"].endswith("gates/rl-gate-real/gate_report.json"))
+        self.assertTrue(selected["gate_report_path"].endswith(f"gates/{valid_gate_id}/gate_report.json"))
 
     def test_latest_accepted_dataset_scans_control_loop_postmerge_gate_over_stale_dataset_gate(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             runtime_root = root / "runtime-artifacts"
             stale_gate = runtime_root / "rl-dataset-gates" / "rl-gate-stale" / "gate_report.json"
+            newer_wrong_stream_gate = runtime_root / "rl-control-loop" / "gate-20260518T063310Z" / "gate_report.json"
             fresh_gate = runtime_root / "rl-control-loop" / "gate-20260517T181846Z-postmerge1176" / "gate_report.json"
             stale_gate.parent.mkdir(parents=True)
+            newer_wrong_stream_gate.parent.mkdir(parents=True)
             fresh_gate.parent.mkdir(parents=True)
             stale_gate.write_text(
                 json.dumps(
@@ -530,6 +536,18 @@ class RlExperimentCardTest(unittest.TestCase):
                         "gateId": "rl-gate-stale",
                         "createdAt": "2026-05-14T04:22:20Z",
                         "dataset": {"runId": "rl-stale-gate"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            newer_wrong_stream_gate.write_text(
+                json.dumps(
+                    {
+                        "type": card_helper.SOURCE_GATE_TYPE,
+                        "ok": True,
+                        "gateId": "gate-20260518T063310Z",
+                        "createdAt": "2026-05-18T06:33:10Z",
+                        "dataset": {"runId": "rl-wrong-stream-newer"},
                     }
                 ),
                 encoding="utf-8",
@@ -565,12 +583,46 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertFalse(selected["gate_report_ok"])
         self.assertTrue(selected["gate_report_path"].endswith("rl-control-loop/gate-20260517T181846Z-postmerge1176/gate_report.json"))
 
+    def test_latest_accepted_dataset_rejects_degraded_non_postmerge_gate(self) -> None:
+        payload = {
+            "type": card_helper.SOURCE_GATE_TYPE,
+            "ok": False,
+            "gateId": "gate-20260518T063310Z",
+            "createdAt": "2026-05-18T06:33:10Z",
+            "dataset": {"ok": True, "runId": "rl-wrong-stream-degraded", "sampleCount": 200},
+            "datasetGate": {"status": "pass"},
+            "shadowEvaluation": {"status": "pass", "ok": True},
+            "blockingReasons": [
+                {
+                    "gate": "quality_checks",
+                    "name": "sample_quality",
+                    "status": "fail",
+                    "samplesAccepted": 191,
+                    "samplesRejected": 9,
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runtime_root = root / "runtime-artifacts"
+            gate_path = runtime_root / "rl-control-loop" / "gate-20260518T063310Z" / "gate_report.json"
+            gate_path.parent.mkdir(parents=True)
+            gate_path.write_text(json.dumps(payload), encoding="utf-8")
+
+            with self.assertRaisesRegex(card_helper.CardValidationError, "no accepted dataset gate"):
+                card_helper.select_accepted_dataset_gate(runtime_root)
+
+        self.assertFalse(card_helper.is_acceptable_dataset_gate_report(payload))
+        self.assertFalse(card_helper.is_degraded_e1_gate_acceptable(payload))
+
     def test_latest_accepted_dataset_skips_gate_deleted_during_scan(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             gate_root = root / "gates"
-            valid_gate = gate_root / "valid" / "gate_report.json"
-            vanished_gate = gate_root / "vanished" / "gate_report.json"
+            valid_gate_id = "gate-20260517T010000Z-postmerge1188"
+            vanished_gate_id = "gate-20260517T020000Z-postmerge1188"
+            valid_gate = gate_root / valid_gate_id / "gate_report.json"
+            vanished_gate = gate_root / vanished_gate_id / "gate_report.json"
             valid_gate.parent.mkdir(parents=True)
             vanished_gate.parent.mkdir(parents=True)
             valid_gate.write_text(
@@ -578,7 +630,7 @@ class RlExperimentCardTest(unittest.TestCase):
                     {
                         "type": card_helper.SOURCE_GATE_TYPE,
                         "ok": True,
-                        "gateId": "valid",
+                        "gateId": valid_gate_id,
                         "createdAt": "2026-05-17T01:00:00Z",
                         "dataset": {"runId": "rl-accepted-valid"},
                     }
@@ -590,7 +642,7 @@ class RlExperimentCardTest(unittest.TestCase):
                     {
                         "type": card_helper.SOURCE_GATE_TYPE,
                         "ok": True,
-                        "gateId": "vanished",
+                        "gateId": vanished_gate_id,
                         "createdAt": "2026-05-17T02:00:00Z",
                         "dataset": {"runId": "rl-accepted-vanished"},
                     }

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -895,7 +895,7 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(report["policyGradient"]["target_family"], "construction-priority")
         self.assertFalse(report["policyGradient"]["runner_support"]["inline_candidates_applied_to_simulator"])
         self.assertTrue(report["policyGradient"]["runner_support"]["report_preserves_candidate_parameters"])
-        self.assertEqual(simulator.calls[0]["ticks"], 100)
+        self.assertEqual(simulator.calls[0]["ticks"], 500)
         self.assertEqual(simulator.calls[0]["variants"], variant_ids)
         self.assertEqual(
             [variant["candidatePolicyId"] for variant in report["strategyVariants"]],

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -377,6 +377,41 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertFalse(spec["safety"]["officialMmoWritesAllowed"])
         self.assertEqual(controller.steps[-1].name, "write_scale_proof_spec")
 
+    def test_generate_policy_gradient_experiment_card_floors_tencent_ticks_to_long_horizon(self) -> None:
+        args = controller_args()
+        args.training_approach = "policy_gradient"
+        args.ticks = 200
+        args.workers = 5
+        args.repetitions = 5
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=root)
+
+            def fake_run_cp(name: str, cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                if name == "generate_experiment_card":
+                    output = Path(cmd[cmd.index("--output") + 1])
+                    payload = generated_experiment_card()
+                    payload["training_approach"] = "policy_gradient"
+                    payload["simulation"]["ticks"] = 100
+                    payload["simulation"]["workers"] = 1
+                    payload["simulation"]["repetitions"] = 1
+                    output.write_text(json.dumps(payload), encoding="utf-8")
+                return subprocess.CompletedProcess(cmd, 0, "{}", "")
+
+            with mock.patch.object(controller, "run_cp", side_effect=fake_run_cp):
+                controller.generate_experiment_card()
+
+            card = json.loads((root / "experiment_card.json").read_text(encoding="utf-8"))
+            spec = json.loads((root / "scale_proof_spec.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(card["training_approach"], "policy_gradient")
+        self.assertEqual(card["simulation"]["ticks"], 500)
+        self.assertEqual(card["simulation"]["workers"], 5)
+        self.assertEqual(card["simulation"]["repetitions"], 5)
+        self.assertFalse(card["officialMmoWrites"])
+        self.assertFalse(card["officialMmoWritesAllowed"])
+        self.assertEqual(spec["scaleProof"]["remoteRunnerContract"]["cardSimulationFields"]["ticks"], 500)
+
     def test_verify_remote_training_report_requires_scale_proof_success_for_workers_five(self) -> None:
         args = controller_args()
         args.workers = 5


### PR DESCRIPTION
## Summary
- Generate Loop A local-fallback cards from the newest acceptable E1/postmerge dataset gate across both dataset-gate and RL control-loop artifact roots.
- Raise policy-gradient fallback cards to a 500-tick floor with 5 workers / 5 repetitions for the next Tencent/Loop A validation slice.
- Preserve offline/shadow safety fields and extend tests for degraded-but-accepted E1 gate selection, 500-tick policy-gradient cards, and Tencent runner scale proof accounting.

Fixes #1188

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_experiment_card.py scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_rl_experiment_card.py scripts/test_screeps_rl_training_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m pytest scripts/test_screeps_rl_experiment_card.py scripts/test_screeps_rl_training_runner.py scripts/test_screeps_tencent_batch_rl_runner.py -q` → 99 passed, 29 subtests passed

## Safety
- Offline/shadow card generation only.
- No official MMO writes; `liveEffect=false`, `officialMmoWrites=false`, and `officialMmoWritesAllowed=false` remain required by card validation.
- Runtime artifacts remain ignored; this PR changes generator/tests/docs only.
