### PR TITLE
feat(rl): add multi-tier training scenario metadata

### DIFF
--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -24,6 +24,10 @@ STRATEGY_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
 DRY_RUN_DATASET_RUN_ID = "rl-dry-run-000000000000"
 SAFETY_FALSE_FIELDS = ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed")
 SAFETY_TRUE_FIELDS = ("ood_rejection", "conservative_actions_only")
+SCENARIO_METADATA_TYPE = "screeps-rl-training-scenario"
+DEFAULT_SCENARIO_ID = "e1s1-single-room-no-hostile"
+MULTI_TIER_SCENARIO_ID = "multi-tier-territory-combat-v0"
+SCENARIO_IDS = (DEFAULT_SCENARIO_ID, MULTI_TIER_SCENARIO_ID)
 LOOP_A_CARD_SUPPLY_TYPE = "screeps-rl-loop-a-card-supply"
 LOOP_A_CARD_SUPPLY_CONSUMER = "loop-a-policy-gradient"
 LOOP_A_CARD_SUPPLY_AVAILABLE = "available"
@@ -218,6 +222,85 @@ def simulation_block(
     }
 
 
+def scenario_metadata_block(*, scenario_id: str = DEFAULT_SCENARIO_ID) -> JsonObject:
+    if scenario_id == DEFAULT_SCENARIO_ID:
+        return {
+            "type": SCENARIO_METADATA_TYPE,
+            "scenario_id": DEFAULT_SCENARIO_ID,
+            "scenario_tier": "single_room_smoke",
+            "label": "E1S1 single-room no-hostile smoke scenario",
+            "capabilities": {
+                "multi_room_capable": False,
+                "adjacent_room_territory_signal": False,
+                "hostile_combat_signal": False,
+                "multi_tier_policy_comparison": False,
+            },
+            "suitability": {
+                "multi_tier_policy_comparison": False,
+                "territory_combat_differentiation": False,
+                "classification": "not_suitable_for_territory_combat_differentiation",
+                "reasons": [
+                    "single-room E1S1 map has no adjacent-room expansion signal",
+                    "default smoke fixture has no hostile/combat signal",
+                ],
+            },
+            "evidence": {
+                "anchor_room": "E1S1",
+                "room_count": 1,
+                "hostile_fixture": "none",
+                "map_source_file": str(DEFAULT_SIMULATION_MAP_SOURCE_FILE),
+            },
+            "safety": safety_block(),
+        }
+    if scenario_id == MULTI_TIER_SCENARIO_ID:
+        return {
+            "type": SCENARIO_METADATA_TYPE,
+            "scenario_id": MULTI_TIER_SCENARIO_ID,
+            "scenario_tier": "multi_tier_policy_comparison",
+            "label": "Guarded multi-room territory plus hostile-combat training scenario",
+            "capabilities": {
+                "multi_room_capable": True,
+                "adjacent_room_territory_signal": True,
+                "hostile_combat_signal": True,
+                "multi_tier_policy_comparison": True,
+            },
+            "suitability": {
+                "multi_tier_policy_comparison": True,
+                "territory_combat_differentiation": True,
+                "classification": "suitable_for_multi_tier_policy_comparison",
+                "reasons": [],
+            },
+            "evidence": {
+                "anchor_room": "E1S1",
+                "minimum_room_count": 2,
+                "requires_adjacent_room": True,
+                "requires_hostile_fixture": True,
+                "map_source_file": str(DEFAULT_SIMULATION_MAP_SOURCE_FILE),
+                "implementation_status": "metadata_only_guarded",
+                "execution_guard": "private multi-room hostile fixture must confirm these capabilities before live training use",
+            },
+            "safety": safety_block(),
+        }
+    raise CardValidationError(f"scenario_id must be one of: {', '.join(SCENARIO_IDS)}")
+
+
+def scenario_supports_multi_tier_policy_comparison(raw: Any) -> bool:
+    if not isinstance(raw, dict):
+        return False
+    capabilities = raw.get("capabilities")
+    suitability = raw.get("suitability")
+    if not isinstance(capabilities, dict) or not isinstance(suitability, dict):
+        return False
+    return (
+        capabilities.get("multi_room_capable") is True
+        and capabilities.get("adjacent_room_territory_signal") is True
+        and capabilities.get("hostile_combat_signal") is True
+        and capabilities.get("multi_tier_policy_comparison") is True
+        and suitability.get("multi_tier_policy_comparison") is True
+        and suitability.get("territory_combat_differentiation") is True
+    )
+
+
 def build_card(
     *,
     dataset_run_id: str,
@@ -230,6 +313,8 @@ def build_card(
     registry_path: Path | None = None,
     loop_a_card_supply: bool = False,
     source_gate: JsonObject | None = None,
+    scenario_id: str = DEFAULT_SCENARIO_ID,
+    require_multi_tier_scenario: bool = False,
 ) -> JsonObject:
     validate_dataset_run_id(dataset_run_id)
     validate_code_commit(code_commit)
@@ -257,6 +342,11 @@ def build_card(
     )
     if training_approach == "policy_gradient":
         ticks = max(ticks, POLICY_GRADIENT_MIN_SIMULATION_TICKS)
+    scenario = scenario_metadata_block(scenario_id=scenario_id)
+    if require_multi_tier_scenario and not scenario_supports_multi_tier_policy_comparison(scenario):
+        raise CardValidationError(
+            "multi-tier policy comparisons require a scenario with adjacent-room territory and hostile combat signals"
+        )
 
     commit_prefix = code_commit[:12].lower()
     card = {
@@ -270,6 +360,7 @@ def build_card(
         "officialMmoWritesAllowed": False,
         "ood_rejection": True,
         "reward_model": reward_model(),
+        "scenario": scenario,
         "safety": safety_block(),
         "simulation": simulation_block(ticks=ticks, workers=workers, repetitions=repetitions),
         "status": "shadow",
@@ -641,6 +732,7 @@ def validate_card(raw: Any) -> None:
     validate_reward_model(raw.get("reward_model"))
     validate_card_supply(raw)
     validate_source_gate(raw)
+    validate_scenario(raw)
     strategy_variants = first_present(raw, ("strategy_variants", "strategyVariants", "variants"))
     validate_strategy_variants(strategy_variants)
     simulation = first_present(raw, ("simulation", "simulator"))
@@ -730,6 +822,55 @@ def validate_source_gate(card: JsonObject) -> None:
         validate_created_at(created_at)
 
 
+def validate_scenario(card: JsonObject) -> None:
+    raw = first_present(card, ("scenario", "trainingScenario"))
+    if raw is None:
+        return
+    if not isinstance(raw, dict):
+        raise CardValidationError("scenario must be a JSON object")
+    if raw.get("type") != SCENARIO_METADATA_TYPE:
+        raise CardValidationError(f"scenario.type must be {SCENARIO_METADATA_TYPE}")
+    scenario_id = raw.get("scenario_id", raw.get("scenarioId"))
+    if scenario_id not in SCENARIO_IDS:
+        raise CardValidationError(f"scenario.scenario_id must be one of: {', '.join(SCENARIO_IDS)}")
+    if not isinstance(raw.get("scenario_tier", raw.get("scenarioTier")), str):
+        raise CardValidationError("scenario.scenario_tier must be a string")
+    capabilities = raw.get("capabilities")
+    if not isinstance(capabilities, dict):
+        raise CardValidationError("scenario.capabilities must be a JSON object")
+    for field in (
+        "multi_room_capable",
+        "adjacent_room_territory_signal",
+        "hostile_combat_signal",
+        "multi_tier_policy_comparison",
+    ):
+        if capabilities.get(field) not in (True, False):
+            raise CardValidationError(f"scenario.capabilities.{field} must be a boolean")
+    suitability = raw.get("suitability")
+    if not isinstance(suitability, dict):
+        raise CardValidationError("scenario.suitability must be a JSON object")
+    for field in ("multi_tier_policy_comparison", "territory_combat_differentiation"):
+        if suitability.get(field) not in (True, False):
+            raise CardValidationError(f"scenario.suitability.{field} must be a boolean")
+    if not isinstance(suitability.get("classification"), str) or not suitability.get("classification"):
+        raise CardValidationError("scenario.suitability.classification must be a non-empty string")
+    reasons = suitability.get("reasons")
+    if not isinstance(reasons, list) or any(not isinstance(reason, str) for reason in reasons):
+        raise CardValidationError("scenario.suitability.reasons must be a list of strings")
+    if not scenario_supports_multi_tier_policy_comparison(raw) and suitability.get("multi_tier_policy_comparison") is True:
+        raise CardValidationError(
+            "scenario marked multi-tier suitable without multi-room, territory, and hostile combat capabilities"
+        )
+    scenario_safety = raw.get("safety")
+    if isinstance(scenario_safety, dict):
+        for field in SAFETY_FALSE_FIELDS:
+            if scenario_safety.get(field) is not False:
+                raise CardValidationError(f"scenario.safety.{field} must be false")
+        for field in SAFETY_TRUE_FIELDS:
+            if scenario_safety.get(field) is not True:
+                raise CardValidationError(f"scenario.safety.{field} must be true")
+
+
 def is_loop_a_card_available_for_training(card: JsonObject, consumed_card_ids: set[str] | None = None) -> bool:
     try:
         validate_card(card)
@@ -814,6 +955,7 @@ def loop_a_selection_summary(path: Path, card: JsonObject, consumed_card_ids: se
         "training_approach": card.get("training_approach"),
         "status": card.get("status"),
         "card_supply": first_present(card, ("card_supply", "cardSupply")),
+        "scenario": first_present(card, ("scenario", "trainingScenario")),
         "consumed_card_count": len(consumed_card_ids),
     }
 
@@ -1323,6 +1465,10 @@ def validation_summary(card: JsonObject) -> JsonObject:
         },
         "status": card.get("status"),
     }
+    scenario = first_present(card, ("scenario", "trainingScenario"))
+    if isinstance(scenario, dict):
+        summary["scenario"] = scenario
+        summary["multi_tier_policy_comparison_suitable"] = scenario_supports_multi_tier_policy_comparison(scenario)
     card_supply = first_present(card, ("card_supply", "cardSupply"))
     if isinstance(card_supply, dict):
         summary["card_supply"] = card_supply
@@ -1441,6 +1587,20 @@ def build_parser() -> argparse.ArgumentParser:
         "--workers",
         type=positive_int_arg,
         help="Simulator worker count to request. Defaults to 1.",
+    )
+    parser.add_argument(
+        "--scenario-id",
+        choices=SCENARIO_IDS,
+        default=DEFAULT_SCENARIO_ID,
+        help=(
+            "Scenario metadata to attach. Default classifies the E1S1 smoke map as single-room/no-hostile; "
+            f"use {MULTI_TIER_SCENARIO_ID} to request the guarded multi-tier metadata surface."
+        ),
+    )
+    parser.add_argument(
+        "--require-multi-tier-scenario",
+        action="store_true",
+        help="Reject cards whose scenario lacks adjacent-room territory and hostile combat signals.",
     )
     parser.add_argument(
         "--dry-run",
@@ -1628,6 +1788,8 @@ def main(
             simulation_workers=simulation_workers,
             loop_a_card_supply=loop_a_card_supply,
             source_gate=source_gate,
+            scenario_id=args.scenario_id,
+            require_multi_tier_scenario=args.require_multi_tier_scenario,
         )
         if args.loop_a_local_fallback:
             output_path = args.output or repo / DEFAULT_LOOP_A_LOCAL_FALLBACK_CARD_PATH.relative_to(REPO_ROOT)

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -822,22 +822,34 @@ def validate_source_gate(card: JsonObject) -> None:
         validate_created_at(created_at)
 
 
-def validate_scenario(card: JsonObject) -> None:
+def validate_scenario_metadata(
+    card: JsonObject,
+    *,
+    error_cls: type[ValueError] = CardValidationError,
+    require_presence: bool = False,
+    require_scenario_tier: bool = False,
+    json_object_wording: bool = False,
+) -> None:
+    object_noun = "JSON object" if json_object_wording else "object"
+    article = "a" if json_object_wording else "an"
+
     raw = first_present(card, ("scenario", "trainingScenario"))
     if raw is None:
+        if require_presence:
+            raise error_cls("scenario metadata is required")
         return
     if not isinstance(raw, dict):
-        raise CardValidationError("scenario must be a JSON object")
+        raise error_cls(f"scenario must be {article} {object_noun}")
     if raw.get("type") != SCENARIO_METADATA_TYPE:
-        raise CardValidationError(f"scenario.type must be {SCENARIO_METADATA_TYPE}")
+        raise error_cls(f"scenario.type must be {SCENARIO_METADATA_TYPE}")
     scenario_id = raw.get("scenario_id", raw.get("scenarioId"))
     if scenario_id not in SCENARIO_IDS:
-        raise CardValidationError(f"scenario.scenario_id must be one of: {', '.join(SCENARIO_IDS)}")
-    if not isinstance(raw.get("scenario_tier", raw.get("scenarioTier")), str):
-        raise CardValidationError("scenario.scenario_tier must be a string")
+        raise error_cls(f"scenario.scenario_id must be one of: {', '.join(SCENARIO_IDS)}")
+    if require_scenario_tier and not isinstance(raw.get("scenario_tier", raw.get("scenarioTier")), str):
+        raise error_cls("scenario.scenario_tier must be a string")
     capabilities = raw.get("capabilities")
     if not isinstance(capabilities, dict):
-        raise CardValidationError("scenario.capabilities must be a JSON object")
+        raise error_cls(f"scenario.capabilities must be {article} {object_noun}")
     for field in (
         "multi_room_capable",
         "adjacent_room_territory_signal",
@@ -845,30 +857,34 @@ def validate_scenario(card: JsonObject) -> None:
         "multi_tier_policy_comparison",
     ):
         if capabilities.get(field) not in (True, False):
-            raise CardValidationError(f"scenario.capabilities.{field} must be a boolean")
+            raise error_cls(f"scenario.capabilities.{field} must be a boolean")
     suitability = raw.get("suitability")
     if not isinstance(suitability, dict):
-        raise CardValidationError("scenario.suitability must be a JSON object")
+        raise error_cls(f"scenario.suitability must be {article} {object_noun}")
     for field in ("multi_tier_policy_comparison", "territory_combat_differentiation"):
         if suitability.get(field) not in (True, False):
-            raise CardValidationError(f"scenario.suitability.{field} must be a boolean")
+            raise error_cls(f"scenario.suitability.{field} must be a boolean")
     if not isinstance(suitability.get("classification"), str) or not suitability.get("classification"):
-        raise CardValidationError("scenario.suitability.classification must be a non-empty string")
+        raise error_cls("scenario.suitability.classification must be a non-empty string")
     reasons = suitability.get("reasons")
     if not isinstance(reasons, list) or any(not isinstance(reason, str) for reason in reasons):
-        raise CardValidationError("scenario.suitability.reasons must be a list of strings")
+        raise error_cls("scenario.suitability.reasons must be a list of strings")
     if not scenario_supports_multi_tier_policy_comparison(raw) and suitability.get("multi_tier_policy_comparison") is True:
-        raise CardValidationError(
+        raise error_cls(
             "scenario marked multi-tier suitable without multi-room, territory, and hostile combat capabilities"
         )
     scenario_safety = raw.get("safety")
     if isinstance(scenario_safety, dict):
         for field in SAFETY_FALSE_FIELDS:
             if scenario_safety.get(field) is not False:
-                raise CardValidationError(f"scenario.safety.{field} must be false")
+                raise error_cls(f"scenario.safety.{field} must be false")
         for field in SAFETY_TRUE_FIELDS:
             if scenario_safety.get(field) is not True:
-                raise CardValidationError(f"scenario.safety.{field} must be true")
+                raise error_cls(f"scenario.safety.{field} must be true")
+
+
+def validate_scenario(card: JsonObject) -> None:
+    validate_scenario_metadata(card, require_scenario_tier=True, json_object_wording=True)
 
 
 def is_loop_a_card_available_for_training(card: JsonObject, consumed_card_ids: set[str] | None = None) -> bool:

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -37,6 +37,8 @@ POLICY_UPDATE_ARTIFACT_DIR = "policy-candidates"
 REWARD_TIERS = ("reliability", "territory", "resources", "kills")
 SAFETY_FALSE_FIELDS = ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed")
 SAFETY_TRUE_FIELDS = ("conservative_actions_only", "ood_rejection")
+SCENARIO_METADATA_TYPE = "screeps-rl-training-scenario"
+SCENARIO_IDS = ("e1s1-single-room-no-hostile", "multi-tier-territory-combat-v0")
 LOOP_A_CARD_SUPPLY_TYPE = "screeps-rl-loop-a-card-supply"
 LOOP_A_CARD_SUPPLY_CONSUMER = "loop-a-policy-gradient"
 LOOP_A_CARD_SUPPLY_AVAILABLE = "available"
@@ -264,6 +266,7 @@ def validate_experiment_card(card: JsonObject) -> None:
         raise TrainingCardError("reward_model.scalar_weighted_sum_authorized must be false")
 
     validate_card_supply(card)
+    validate_scenario_metadata(card)
 
     raw_variants = raw_variant_definitions(card)
     if not isinstance(raw_variants, list) or len(raw_variants) == 0:
@@ -334,6 +337,70 @@ def validate_card_supply(card: JsonObject) -> None:
             raise TrainingCardError("consumed Loop A card supply requires consumed_at")
         if not isinstance(raw.get("consumed_by_report_id"), str) or not raw.get("consumed_by_report_id"):
             raise TrainingCardError("consumed Loop A card supply requires consumed_by_report_id")
+
+
+def validate_scenario_metadata(card: JsonObject) -> None:
+    raw = card.get("scenario", card.get("trainingScenario"))
+    if raw is None:
+        return
+    if not isinstance(raw, dict):
+        raise TrainingCardError("scenario must be an object")
+    if raw.get("type") != SCENARIO_METADATA_TYPE:
+        raise TrainingCardError(f"scenario.type must be {SCENARIO_METADATA_TYPE}")
+    scenario_id = raw.get("scenario_id", raw.get("scenarioId"))
+    if scenario_id not in SCENARIO_IDS:
+        raise TrainingCardError(f"scenario.scenario_id must be one of: {', '.join(SCENARIO_IDS)}")
+    capabilities = raw.get("capabilities")
+    if not isinstance(capabilities, dict):
+        raise TrainingCardError("scenario.capabilities must be an object")
+    for field in (
+        "multi_room_capable",
+        "adjacent_room_territory_signal",
+        "hostile_combat_signal",
+        "multi_tier_policy_comparison",
+    ):
+        if capabilities.get(field) not in (True, False):
+            raise TrainingCardError(f"scenario.capabilities.{field} must be a boolean")
+    suitability = raw.get("suitability")
+    if not isinstance(suitability, dict):
+        raise TrainingCardError("scenario.suitability must be an object")
+    for field in ("multi_tier_policy_comparison", "territory_combat_differentiation"):
+        if suitability.get(field) not in (True, False):
+            raise TrainingCardError(f"scenario.suitability.{field} must be a boolean")
+    if not isinstance(suitability.get("classification"), str) or not suitability.get("classification"):
+        raise TrainingCardError("scenario.suitability.classification must be a non-empty string")
+    reasons = suitability.get("reasons")
+    if not isinstance(reasons, list) or any(not isinstance(reason, str) for reason in reasons):
+        raise TrainingCardError("scenario.suitability.reasons must be a list of strings")
+    if not scenario_supports_multi_tier_policy_comparison(raw) and suitability.get("multi_tier_policy_comparison") is True:
+        raise TrainingCardError(
+            "scenario marked multi-tier suitable without multi-room, territory, and hostile combat capabilities"
+        )
+    scenario_safety = raw.get("safety")
+    if isinstance(scenario_safety, dict):
+        for field in SAFETY_FALSE_FIELDS:
+            if scenario_safety.get(field) is not False:
+                raise TrainingCardError(f"scenario.safety.{field} must be false")
+        for field in SAFETY_TRUE_FIELDS:
+            if scenario_safety.get(field) is not True:
+                raise TrainingCardError(f"scenario.safety.{field} must be true")
+
+
+def scenario_supports_multi_tier_policy_comparison(raw: Any) -> bool:
+    if not isinstance(raw, dict):
+        return False
+    capabilities = raw.get("capabilities")
+    suitability = raw.get("suitability")
+    if not isinstance(capabilities, dict) or not isinstance(suitability, dict):
+        return False
+    return (
+        capabilities.get("multi_room_capable") is True
+        and capabilities.get("adjacent_room_territory_signal") is True
+        and capabilities.get("hostile_combat_signal") is True
+        and capabilities.get("multi_tier_policy_comparison") is True
+        and suitability.get("multi_tier_policy_comparison") is True
+        and suitability.get("territory_combat_differentiation") is True
+    )
 
 
 def raw_variant_definitions(card: JsonObject) -> Any:
@@ -987,6 +1054,15 @@ def build_training_report(
     warnings = build_report_warnings(results, simulator_runs)
     scale_validation = build_scale_validation_summary(simulator_runs, config)
     policy_gradient = policy_gradient_metadata_from_card(card)
+    scenario = scenario_metadata_from_card(card)
+    if (
+        policy_gradient is not None
+        and scenario is not None
+        and not scenario_supports_multi_tier_policy_comparison(scenario)
+    ):
+        warnings.append(
+            "experiment card scenario is classified as not suitable for multi-tier territory/combat policy comparison"
+        )
 
     report = {
         "type": REPORT_TYPE,
@@ -1054,6 +1130,8 @@ def build_training_report(
         "kpiSummary": build_kpi_summary(scored_results),
         "warnings": warnings,
     }
+    if scenario is not None:
+        report["scenario"] = scenario
     if scale_validation is not None:
         report["scaleValidation"] = scale_validation
     if policy_gradient is not None:
@@ -2344,7 +2422,18 @@ def summarize_card(card: JsonObject, path: Path) -> JsonObject:
     card_supply = card.get("card_supply", card.get("cardSupply"))
     if isinstance(card_supply, dict):
         summary["cardSupply"] = copy.deepcopy(card_supply)
+    scenario = scenario_metadata_from_card(card)
+    if scenario is not None:
+        summary["scenario"] = scenario
+        summary["multiTierPolicyComparisonSuitable"] = scenario_supports_multi_tier_policy_comparison(scenario)
     return summary
+
+
+def scenario_metadata_from_card(card: JsonObject) -> JsonObject | None:
+    raw = card.get("scenario", card.get("trainingScenario"))
+    if not isinstance(raw, dict):
+        return None
+    return copy.deepcopy(raw)
 
 
 def policy_gradient_metadata_from_card(card: JsonObject) -> JsonObject | None:

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -18,6 +18,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Sequence, TextIO
 
+from screeps_rl_experiment_card import (
+    scenario_supports_multi_tier_policy_comparison,
+    validate_scenario_metadata,
+)
 import screeps_rl_dataset_export as dataset_export
 import screeps_secret_env
 import screeps_rl_simulator_harness as simulator_harness
@@ -37,8 +41,6 @@ POLICY_UPDATE_ARTIFACT_DIR = "policy-candidates"
 REWARD_TIERS = ("reliability", "territory", "resources", "kills")
 SAFETY_FALSE_FIELDS = ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed")
 SAFETY_TRUE_FIELDS = ("conservative_actions_only", "ood_rejection")
-SCENARIO_METADATA_TYPE = "screeps-rl-training-scenario"
-SCENARIO_IDS = ("e1s1-single-room-no-hostile", "multi-tier-territory-combat-v0")
 LOOP_A_CARD_SUPPLY_TYPE = "screeps-rl-loop-a-card-supply"
 LOOP_A_CARD_SUPPLY_CONSUMER = "loop-a-policy-gradient"
 LOOP_A_CARD_SUPPLY_AVAILABLE = "available"
@@ -266,7 +268,7 @@ def validate_experiment_card(card: JsonObject) -> None:
         raise TrainingCardError("reward_model.scalar_weighted_sum_authorized must be false")
 
     validate_card_supply(card)
-    validate_scenario_metadata(card)
+    validate_scenario_metadata(card, error_cls=TrainingCardError, require_presence=True)
 
     raw_variants = raw_variant_definitions(card)
     if not isinstance(raw_variants, list) or len(raw_variants) == 0:
@@ -337,70 +339,6 @@ def validate_card_supply(card: JsonObject) -> None:
             raise TrainingCardError("consumed Loop A card supply requires consumed_at")
         if not isinstance(raw.get("consumed_by_report_id"), str) or not raw.get("consumed_by_report_id"):
             raise TrainingCardError("consumed Loop A card supply requires consumed_by_report_id")
-
-
-def validate_scenario_metadata(card: JsonObject) -> None:
-    raw = card.get("scenario", card.get("trainingScenario"))
-    if raw is None:
-        return
-    if not isinstance(raw, dict):
-        raise TrainingCardError("scenario must be an object")
-    if raw.get("type") != SCENARIO_METADATA_TYPE:
-        raise TrainingCardError(f"scenario.type must be {SCENARIO_METADATA_TYPE}")
-    scenario_id = raw.get("scenario_id", raw.get("scenarioId"))
-    if scenario_id not in SCENARIO_IDS:
-        raise TrainingCardError(f"scenario.scenario_id must be one of: {', '.join(SCENARIO_IDS)}")
-    capabilities = raw.get("capabilities")
-    if not isinstance(capabilities, dict):
-        raise TrainingCardError("scenario.capabilities must be an object")
-    for field in (
-        "multi_room_capable",
-        "adjacent_room_territory_signal",
-        "hostile_combat_signal",
-        "multi_tier_policy_comparison",
-    ):
-        if capabilities.get(field) not in (True, False):
-            raise TrainingCardError(f"scenario.capabilities.{field} must be a boolean")
-    suitability = raw.get("suitability")
-    if not isinstance(suitability, dict):
-        raise TrainingCardError("scenario.suitability must be an object")
-    for field in ("multi_tier_policy_comparison", "territory_combat_differentiation"):
-        if suitability.get(field) not in (True, False):
-            raise TrainingCardError(f"scenario.suitability.{field} must be a boolean")
-    if not isinstance(suitability.get("classification"), str) or not suitability.get("classification"):
-        raise TrainingCardError("scenario.suitability.classification must be a non-empty string")
-    reasons = suitability.get("reasons")
-    if not isinstance(reasons, list) or any(not isinstance(reason, str) for reason in reasons):
-        raise TrainingCardError("scenario.suitability.reasons must be a list of strings")
-    if not scenario_supports_multi_tier_policy_comparison(raw) and suitability.get("multi_tier_policy_comparison") is True:
-        raise TrainingCardError(
-            "scenario marked multi-tier suitable without multi-room, territory, and hostile combat capabilities"
-        )
-    scenario_safety = raw.get("safety")
-    if isinstance(scenario_safety, dict):
-        for field in SAFETY_FALSE_FIELDS:
-            if scenario_safety.get(field) is not False:
-                raise TrainingCardError(f"scenario.safety.{field} must be false")
-        for field in SAFETY_TRUE_FIELDS:
-            if scenario_safety.get(field) is not True:
-                raise TrainingCardError(f"scenario.safety.{field} must be true")
-
-
-def scenario_supports_multi_tier_policy_comparison(raw: Any) -> bool:
-    if not isinstance(raw, dict):
-        return False
-    capabilities = raw.get("capabilities")
-    suitability = raw.get("suitability")
-    if not isinstance(capabilities, dict) or not isinstance(suitability, dict):
-        return False
-    return (
-        capabilities.get("multi_room_capable") is True
-        and capabilities.get("adjacent_room_territory_signal") is True
-        and capabilities.get("hostile_combat_signal") is True
-        and capabilities.get("multi_tier_policy_comparison") is True
-        and suitability.get("multi_tier_policy_comparison") is True
-        and suitability.get("territory_combat_differentiation") is True
-    )
 
 
 def raw_variant_definitions(card: JsonObject) -> Any:

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -31,6 +31,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Sequence
 
+from screeps_rl_experiment_card import DEFAULT_SCENARIO_ID, MULTI_TIER_SCENARIO_ID, SCENARIO_IDS
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_TCCLI = Path("/root/.hermes/hermes-agent/venv/bin/tccli")
 DEFAULT_BILLING_GUARD = Path("/root/.hermes/scripts/screeps-tencent-billing-guard.py")
@@ -46,9 +48,6 @@ DEFAULT_ARTIFACT_ROOT = Path("runtime-artifacts/tencent-cloud/batch-runs")
 MAX_SCALE_PROOF_WORKERS = 16
 SCALE_PROOF_SUCCESS_RATE = 0.8
 POLICY_GRADIENT_MIN_SIMULATION_TICKS = 500
-DEFAULT_SCENARIO_ID = "e1s1-single-room-no-hostile"
-MULTI_TIER_SCENARIO_ID = "multi-tier-territory-combat-v0"
-SCENARIO_IDS = (DEFAULT_SCENARIO_ID, MULTI_TIER_SCENARIO_ID)
 RUN_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]{2,80}$")
 SSH_CONNECT_OPTIONS = (
     "-o", "BatchMode=yes",

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -46,6 +46,9 @@ DEFAULT_ARTIFACT_ROOT = Path("runtime-artifacts/tencent-cloud/batch-runs")
 MAX_SCALE_PROOF_WORKERS = 16
 SCALE_PROOF_SUCCESS_RATE = 0.8
 POLICY_GRADIENT_MIN_SIMULATION_TICKS = 500
+DEFAULT_SCENARIO_ID = "e1s1-single-room-no-hostile"
+MULTI_TIER_SCENARIO_ID = "multi-tier-territory-combat-v0"
+SCENARIO_IDS = (DEFAULT_SCENARIO_ID, MULTI_TIER_SCENARIO_ID)
 RUN_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]{2,80}$")
 SSH_CONNECT_OPTIONS = (
     "-o", "BatchMode=yes",
@@ -217,6 +220,8 @@ class Controller:
                 "workers": self.args.workers,
                 "repetitions": self.args.repetitions,
                 "trainingApproach": self.args.training_approach,
+                "scenarioId": getattr(self.args, "scenario_id", DEFAULT_SCENARIO_ID),
+                "requireMultiTierScenario": getattr(self.args, "require_multi_tier_scenario", False),
             },
             "outputs": self.result,
             "steps": [step.__dict__ for step in self.steps],
@@ -423,16 +428,20 @@ class Controller:
     def generate_experiment_card(self) -> None:
         card = self.experiment_card_path()
         created_at = utc_now_iso()
+        cmd = [
+            sys.executable,
+            "scripts/screeps_rl_experiment_card.py",
+            "--dataset-run-id", self.args.dataset_run_id,
+            "--training-approach", self.args.training_approach,
+            "--created-at", created_at,
+            "--scenario-id", getattr(self.args, "scenario_id", DEFAULT_SCENARIO_ID),
+            "--output", str(card),
+        ]
+        if getattr(self.args, "require_multi_tier_scenario", False):
+            cmd.append("--require-multi-tier-scenario")
         cp = self.run_cp(
             "generate_experiment_card",
-            [
-                sys.executable,
-                "scripts/screeps_rl_experiment_card.py",
-                "--dataset-run-id", self.args.dataset_run_id,
-                "--training-approach", self.args.training_approach,
-                "--created-at", created_at,
-                "--output", str(card),
-            ],
+            cmd,
             timeout=60,
         )
         del cp  # step is already recorded
@@ -454,6 +463,12 @@ class Controller:
             # .git, so git check-ignore cannot prove safety there.
             "simulator_out_dir": f"{self.remote_dir}/simulator-artifacts",
         })
+        scenario = payload.get("scenario")
+        if isinstance(scenario, dict):
+            evidence = scenario.setdefault("evidence", {})
+            if isinstance(evidence, dict):
+                evidence["anchor_room"] = simulation.get("room", evidence.get("anchor_room"))
+                evidence["map_source_file"] = simulation["map_source_file"]
         if scale_environments is not None:
             simulation.update({
                 "scale_environments": scale_environments,
@@ -1438,6 +1453,7 @@ def build_scale_proof_spec(
             "cardId": experiment_card.get("card_id"),
             "status": experiment_card.get("status"),
             "safety": experiment_card.get("safety"),
+            "scenario": experiment_card.get("scenario"),
         },
         "scaleProof": {
             "mode": "single_tencent_asg_worker_multi_environment",
@@ -1456,6 +1472,7 @@ def build_scale_proof_spec(
                     "workers": args.workers,
                     "scale_environments": scale_environments,
                     "min_concurrent_environments": scale_environments,
+                    "scenario_id": getattr(args, "scenario_id", DEFAULT_SCENARIO_ID),
                 },
             },
         },
@@ -1541,6 +1558,11 @@ def validate_static_inputs(args: argparse.Namespace, run_id: str) -> None:
             raise BatchRunError("workers must be at least scale environments for concurrent scale proof")
     if args.repetitions < 1 or args.ticks < 1:
         raise BatchRunError("ticks and repetitions must be positive")
+    scenario_id = getattr(args, "scenario_id", DEFAULT_SCENARIO_ID)
+    if scenario_id not in SCENARIO_IDS:
+        raise BatchRunError(f"scenario id must be one of: {', '.join(SCENARIO_IDS)}")
+    if getattr(args, "require_multi_tier_scenario", False) and scenario_id != MULTI_TIER_SCENARIO_ID:
+        raise BatchRunError("multi-tier policy comparisons require the multi-tier territory/combat scenario id")
     if not args.controller_ip.endswith("/32"):
         raise BatchRunError("controller IP must be a /32 CIDR")
 
@@ -1627,6 +1649,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--repetitions", type=int, default=1)
     parser.add_argument("--host-port-start", type=int, default=24125)
+    parser.add_argument("--scenario-id", choices=SCENARIO_IDS, default=DEFAULT_SCENARIO_ID)
+    parser.add_argument(
+        "--require-multi-tier-scenario",
+        action="store_true",
+        help="Reject Tencent policy comparison cards unless the scenario has territory and combat signals.",
+    )
     parser.add_argument("--variant", action="append", help="Strategy variant id; repeat to override generated card variants.")
     parser.add_argument("--artifact-root", type=Path, default=DEFAULT_ARTIFACT_ROOT)
     parser.add_argument("--scale-timeout-seconds", type=int, default=900)

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -70,6 +70,13 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(config.workers, 1)
         self.assertEqual(config.repetitions, 1)
         self.assertEqual(config.branch, "$activeWorld")
+        self.assertEqual(card["scenario"]["scenario_id"], card_helper.DEFAULT_SCENARIO_ID)
+        self.assertFalse(card["scenario"]["capabilities"]["adjacent_room_territory_signal"])
+        self.assertFalse(card["scenario"]["capabilities"]["hostile_combat_signal"])
+        self.assertEqual(
+            card["scenario"]["suitability"]["classification"],
+            "not_suitable_for_territory_combat_differentiation",
+        )
 
     def test_policy_gradient_construction_priority_card_is_runner_valid(self) -> None:
         card = card_helper.build_card(
@@ -132,6 +139,83 @@ class RlExperimentCardTest(unittest.TestCase):
             self.assertEqual(set(candidate["parameters"]), set(learnable_names))
             self.assertFalse(candidate["parameterEvidence"]["liveEffect"])
             self.assertFalse(candidate["parameterEvidence"]["officialMmoWrites"])
+        self.assertFalse(card_helper.scenario_supports_multi_tier_policy_comparison(card["scenario"]))
+
+    def test_multi_tier_policy_gradient_card_records_scenario_capabilities(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-multitier",
+            code_commit="c" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-18T10:15:00Z",
+            scenario_id=card_helper.MULTI_TIER_SCENARIO_ID,
+            require_multi_tier_scenario=True,
+        )
+
+        card_helper.validate_card(card)
+        runner.validate_experiment_card(card)
+        scenario = card["scenario"]
+
+        self.assertEqual(scenario["scenario_id"], card_helper.MULTI_TIER_SCENARIO_ID)
+        self.assertTrue(scenario["capabilities"]["multi_room_capable"])
+        self.assertTrue(scenario["capabilities"]["adjacent_room_territory_signal"])
+        self.assertTrue(scenario["capabilities"]["hostile_combat_signal"])
+        self.assertTrue(scenario["suitability"]["multi_tier_policy_comparison"])
+        self.assertTrue(card_helper.scenario_supports_multi_tier_policy_comparison(scenario))
+        self.assertEqual(scenario["evidence"]["implementation_status"], "metadata_only_guarded")
+        for field in ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed"):
+            self.assertFalse(card[field])
+            self.assertFalse(card["safety"][field])
+            self.assertFalse(scenario["safety"][field])
+
+    def test_multi_tier_requirement_rejects_single_room_no_hostile_scenario(self) -> None:
+        with self.assertRaisesRegex(card_helper.CardValidationError, "multi-tier policy comparisons require"):
+            card_helper.build_card(
+                dataset_run_id="rl-policy-gradient-bad-scenario",
+                code_commit="d" * 40,
+                training_approach="policy_gradient",
+                created_at="2026-05-18T10:16:00Z",
+                require_multi_tier_scenario=True,
+            )
+
+    def test_cli_can_request_multi_tier_policy_gradient_scenario(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        exit_code = card_helper.main(
+            [
+                "--dry-run",
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                card_helper.MULTI_TIER_SCENARIO_ID,
+                "--require-multi-tier-scenario",
+                "--code-commit",
+                "9" * 40,
+                "--created-at",
+                "2026-05-18T10:18:00Z",
+            ],
+            stdout=stdout,
+            stderr=stderr,
+            repo_root=REPO_ROOT,
+        )
+        generated = json.loads(stdout.getvalue())
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(generated["scenario"]["scenario_id"], card_helper.MULTI_TIER_SCENARIO_ID)
+        self.assertTrue(generated["scenario"]["suitability"]["multi_tier_policy_comparison"])
+        self.assertEqual(stderr.getvalue(), "")
+
+    def test_scenario_validation_rejects_inconsistent_multi_tier_claim(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-inconsistent",
+            code_commit="e" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-18T10:17:00Z",
+        )
+        card["scenario"]["suitability"]["multi_tier_policy_comparison"] = True
+
+        with self.assertRaisesRegex(card_helper.CardValidationError, "marked multi-tier suitable"):
+            card_helper.validate_card(card)
 
     def test_loop_a_policy_gradient_supply_card_remains_shadow_and_available(self) -> None:
         card = card_helper.build_card(

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -56,6 +56,7 @@ def base_card(variant_ids: list[str] | None = None) -> JsonObject:
             "resource_normalizer": 1000,
             "scalar_weighted_sum_authorized": False,
         },
+        "scenario": card_helper.scenario_metadata_block(),
         "simulation": {
             "ticks": 2,
             "workers": 1,
@@ -181,6 +182,13 @@ class RlTrainingRunnerTest(unittest.TestCase):
             runner.TrainingCardError,
             "reward_model.component_order must preserve reliability, territory, resources, kills",
         ):
+            runner.validate_experiment_card(card)
+
+    def test_experiment_card_validation_requires_scenario_metadata(self) -> None:
+        card = base_card()
+        del card["scenario"]
+
+        with self.assertRaisesRegex(runner.TrainingCardError, "scenario metadata is required"):
             runner.validate_experiment_card(card)
 
     def test_experiment_card_validation_rejects_inconsistent_scenario_suitability(self) -> None:
@@ -495,6 +503,22 @@ safety:
   officialMmoWritesAllowed: false
   ood_rejection: true
   conservative_actions_only: true
+scenario:
+  type: screeps-rl-training-scenario
+  scenario_id: e1s1-single-room-no-hostile
+  scenario_tier: single_room_smoke
+  capabilities:
+    multi_room_capable: false
+    adjacent_room_territory_signal: false
+    hostile_combat_signal: false
+    multi_tier_policy_comparison: false
+  suitability:
+    multi_tier_policy_comparison: false
+    territory_combat_differentiation: false
+    classification: not_suitable_for_territory_combat_differentiation
+    reasons:
+      - single-room E1S1 map has no adjacent-room expansion signal
+      - default smoke fixture has no hostile/combat signal
 reward_model:
   type: lexicographic
   component_order:

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -183,6 +183,55 @@ class RlTrainingRunnerTest(unittest.TestCase):
         ):
             runner.validate_experiment_card(card)
 
+    def test_experiment_card_validation_rejects_inconsistent_scenario_suitability(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-training-scenario-invalid",
+            code_commit="a" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-18T10:20:00Z",
+        )
+        card["scenario"]["suitability"]["multi_tier_policy_comparison"] = True
+
+        with self.assertRaisesRegex(runner.TrainingCardError, "marked multi-tier suitable"):
+            runner.validate_experiment_card(card)
+
+    def test_training_report_carries_single_room_scenario_classification(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-training-scenario-report",
+            code_commit="b" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-18T10:21:00Z",
+        )
+        variant_ids = [variant["id"] for variant in card["strategy_variants"]]
+        start = tick(1, [room("E1S1", energy=100)])
+        finish = tick(2, [room("E1S1", energy=150)])
+        simulator = MockSimulator({
+            variant_id: variant_result(variant_id, [start, finish])
+            for variant_id in variant_ids
+        })
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="scenario-classification",
+                simulator_runner=simulator,
+            )
+
+        self.assertEqual(report["scenario"]["scenario_id"], card_helper.DEFAULT_SCENARIO_ID)
+        self.assertFalse(report["experimentCard"]["multiTierPolicyComparisonSuitable"])
+        self.assertEqual(
+            report["scenario"]["suitability"]["classification"],
+            "not_suitable_for_territory_combat_differentiation",
+        )
+        self.assertIn(
+            "experiment card scenario is classified as not suitable for multi-tier territory/combat policy comparison",
+            report["warnings"],
+        )
+
     def test_steam_key_env_var_wins_over_env_file(self) -> None:
         env_secret = "env-secret-token-123456"
         file_secret = "file-secret-token-123456"

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -59,6 +59,8 @@ def controller_args() -> argparse.Namespace:
         scale_timeout_seconds=1,
         secret_env="/tmp/secret.env",
         security_group_id="sg-test",
+        scenario_id=runner.DEFAULT_SCENARIO_ID,
+        require_multi_tier_scenario=False,
         ssh_key="/tmp/id_ed25519",
         tccli="/bin/tccli",
         ticks=1,
@@ -126,6 +128,37 @@ def generated_experiment_card() -> dict[str, object]:
             "code_path": "prod/dist/main.js",
             "map_source_file": "maps/map-0b6758af.json",
             "simulator_out_dir": "runtime-artifacts/rl-simulator",
+        },
+        "scenario": {
+            "type": "screeps-rl-training-scenario",
+            "scenario_id": runner.DEFAULT_SCENARIO_ID,
+            "scenario_tier": "single_room_smoke",
+            "label": "E1S1 single-room no-hostile smoke scenario",
+            "capabilities": {
+                "multi_room_capable": False,
+                "adjacent_room_territory_signal": False,
+                "hostile_combat_signal": False,
+                "multi_tier_policy_comparison": False,
+            },
+            "suitability": {
+                "multi_tier_policy_comparison": False,
+                "territory_combat_differentiation": False,
+                "classification": "not_suitable_for_territory_combat_differentiation",
+                "reasons": ["single-room", "no-hostile"],
+            },
+            "evidence": {
+                "anchor_room": "E1S1",
+                "room_count": 1,
+                "hostile_fixture": "none",
+                "map_source_file": "maps/map-0b6758af.json",
+            },
+            "safety": {
+                "liveEffect": False,
+                "officialMmoWrites": False,
+                "officialMmoWritesAllowed": False,
+                "ood_rejection": True,
+                "conservative_actions_only": True,
+            },
         },
         "strategy_variants": ["construction-priority.incumbent.v1"],
     }
@@ -849,6 +882,15 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             with self.assertRaisesRegex(runner.BatchRunError, "workers must be between"):
                 runner.validate_static_inputs(args, "run-test")
 
+            args.workers = 1
+            args.require_multi_tier_scenario = True
+            args.scenario_id = runner.DEFAULT_SCENARIO_ID
+            with self.assertRaisesRegex(runner.BatchRunError, "multi-tier policy comparisons require"):
+                runner.validate_static_inputs(args, "run-test")
+
+            args.scenario_id = runner.MULTI_TIER_SCENARIO_ID
+            runner.validate_static_inputs(args, "run-test")
+
     def test_generate_experiment_card_writes_multi_environment_scale_proof_spec(self) -> None:
         args = controller_args()
         args.workers = 5
@@ -875,8 +917,10 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(card["simulation"]["workers"], 5)
         self.assertEqual(card["simulation"]["scale_environments"], 5)
         self.assertEqual(card["simulation"]["min_concurrent_environments"], 5)
+        self.assertEqual(card["scenario"]["evidence"]["map_source_file"], "maps/map-0b6758af.json")
         self.assertEqual(spec["scaleProof"]["mode"], "single_tencent_asg_worker_multi_environment")
         self.assertEqual(spec["scaleProof"]["successCriteria"]["minimumSuccessfulEnvironments"], 4)
+        self.assertEqual(spec["experimentCard"]["scenario"]["scenario_id"], runner.DEFAULT_SCENARIO_ID)
         self.assertEqual(spec["asg"]["desiredCapacityDuringRun"], 1)
         self.assertEqual(spec["asg"]["cleanupDesiredCapacity"], 0)
         self.assertTrue(spec["safety"]["billingGuardBeforeScale"])
@@ -917,6 +961,51 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertFalse(card["officialMmoWrites"])
         self.assertFalse(card["officialMmoWritesAllowed"])
         self.assertEqual(spec["scaleProof"]["remoteRunnerContract"]["cardSimulationFields"]["ticks"], 500)
+
+    def test_generate_experiment_card_passes_multi_tier_scenario_request(self) -> None:
+        args = controller_args()
+        args.training_approach = "policy_gradient"
+        args.scenario_id = runner.MULTI_TIER_SCENARIO_ID
+        args.require_multi_tier_scenario = True
+        observed_cmds: list[list[str]] = []
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=root)
+
+            def fake_run_cp(name: str, cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                observed_cmds.append(cmd)
+                if name == "generate_experiment_card":
+                    output = Path(cmd[cmd.index("--output") + 1])
+                    payload = generated_experiment_card()
+                    payload["training_approach"] = "policy_gradient"
+                    payload["scenario"]["scenario_id"] = runner.MULTI_TIER_SCENARIO_ID
+                    payload["scenario"]["scenario_tier"] = "multi_tier_policy_comparison"
+                    payload["scenario"]["capabilities"] = {
+                        "multi_room_capable": True,
+                        "adjacent_room_territory_signal": True,
+                        "hostile_combat_signal": True,
+                        "multi_tier_policy_comparison": True,
+                    }
+                    payload["scenario"]["suitability"] = {
+                        "multi_tier_policy_comparison": True,
+                        "territory_combat_differentiation": True,
+                        "classification": "suitable_for_multi_tier_policy_comparison",
+                        "reasons": [],
+                    }
+                    output.write_text(json.dumps(payload), encoding="utf-8")
+                return subprocess.CompletedProcess(cmd, 0, "{}", "")
+
+            with mock.patch.object(controller, "run_cp", side_effect=fake_run_cp):
+                controller.generate_experiment_card()
+
+            card = json.loads((root / "experiment_card.json").read_text(encoding="utf-8"))
+
+        generate_cmd = observed_cmds[0]
+        self.assertEqual(generate_cmd[generate_cmd.index("--scenario-id") + 1], runner.MULTI_TIER_SCENARIO_ID)
+        self.assertIn("--require-multi-tier-scenario", generate_cmd)
+        self.assertEqual(card["scenario"]["scenario_id"], runner.MULTI_TIER_SCENARIO_ID)
+        self.assertTrue(card["scenario"]["capabilities"]["hostile_combat_signal"])
+        self.assertFalse(card["safety"]["officialMmoWritesAllowed"])
 
     def test_verify_remote_training_report_requires_scale_proof_success_for_workers_five(self) -> None:
         args = controller_args()


### PR DESCRIPTION
## Summary
- Adds explicit RL training scenario metadata for the default E1S1 single-room/no-hostile smoke scenario and a guarded multi-tier territory/combat scenario surface.
- Lets experiment-card generation and Tencent batch runs request/reject multi-tier policy-comparison scenarios.
- Carries scenario suitability/classification into validation summaries, training reports, and scale-proof specs so Loop B can distinguish E1S1/no-hostile runs from multi-tier evidence.

## Test plan
- `python3 -m py_compile scripts/screeps_rl_experiment_card.py scripts/screeps_rl_training_runner.py scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_rl_experiment_card.py scripts/test_screeps_rl_training_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m pytest scripts/test_screeps_rl_experiment_card.py scripts/test_screeps_rl_training_runner.py scripts/test_screeps_tencent_batch_rl_runner.py -q` — 125 passed, 64 subtests passed
- `git diff --check`

## Safety
- Offline/private RL metadata/config only.
- Preserves `liveEffect=false`, `officialMmoWrites=false`, `officialMmoWritesAllowed=false`, `conservative_actions_only=true`, and `ood_rejection=true`.
- No official MMO writes.

Closes #1193
