### PR TITLE
fix(rl): classify Tencent internal card supply

### DIFF
--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -45,6 +45,35 @@ CARD_SUPPLY_BLOCKER_MARKERS = (
     "standalonecardsupply",
     "cardsupplystarvation",
 )
+CARD_SUPPLY_BLOCKER_FIELD_MARKERS = (
+    "loopacardpathstalledcycles",
+    "loopacardpipelinestalled",
+    "cardpipelinestalled",
+    "nostandaloneexperimentcard",
+    "nounconsumedexperimentcard",
+    "standalonecardsupply",
+    "cardsupplystarvation",
+)
+CARD_SUPPLY_BLOCKER_TEXT_FIELDS = (
+    "trainingBlocker",
+    "nextTrainingCapabilityAction",
+    "blocker",
+    "activeBlocker",
+    "cardSupplyBlocker",
+    "requiredAction",
+    "nextAction",
+)
+CARD_SUPPLY_BLOCKER_OBJECT_FIELDS = ("evidenceWindows",)
+INACTIVE_CARD_SUPPLY_BLOCKER_VALUES = (
+    "",
+    "0",
+    "false",
+    "inactive",
+    "na",
+    "none",
+    "null",
+    "resolved",
+)
 TIMESTAMP_KEYS = (
     "createdAt",
     "producedAt",
@@ -421,8 +450,7 @@ def card_supply_from_training_report(path: Path, warnings: list[str], repo_root:
     if artifact is None:
         return None
     payload = artifact.payload
-    safety = {field: payload.get(field) for field in SAFETY_FALSE_FIELDS}
-    if any(value is not False for value in safety.values()):
+    if not safety_flags_are_shadow(payload):
         return None
     card = as_dict(payload.get("experimentCard"))
     if not valid_policy_gradient_card(card, reward_container=payload):
@@ -953,9 +981,57 @@ def card_supply_from_training_payload(payload: JsonObject, path: Path | None) ->
     return None
 
 
-def card_supply_blocker_text_present(payload: JsonObject) -> bool:
-    text = normalized_key(canonical_json(payload))
+def card_supply_blocker_marker_present(value: Any) -> bool:
+    text = normalized_key(canonical_json(value))
     return any(marker in text for marker in CARD_SUPPLY_BLOCKER_MARKERS)
+
+
+def card_supply_blocker_value_active(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    numeric = number_value(value)
+    if numeric is not None:
+        return numeric > 0
+    if isinstance(value, str):
+        return normalized_key(value) not in INACTIVE_CARD_SUPPLY_BLOCKER_VALUES
+    if isinstance(value, (dict, list)):
+        return bool(value)
+    return True
+
+
+def active_card_supply_blocker_field_present(payload: JsonObject) -> bool:
+    for key, value in payload.items():
+        normalized = normalized_key(str(key))
+        if (
+            normalized in CARD_SUPPLY_BLOCKER_FIELD_MARKERS
+            and card_supply_blocker_value_active(value)
+        ):
+            return True
+    return False
+
+
+def card_supply_blocker_text_present(payload: JsonObject) -> bool:
+    for field in CARD_SUPPLY_BLOCKER_TEXT_FIELDS:
+        if card_supply_blocker_marker_present(payload.get(field)):
+            return True
+    if active_card_supply_blocker_field_present(payload):
+        return True
+    for field in CARD_SUPPLY_BLOCKER_OBJECT_FIELDS:
+        if active_card_supply_blocker_field_present(as_dict(payload.get(field))):
+            return True
+    return False
+
+
+def clear_satisfied_card_supply_blocker(blocker: str | None, card_supply: JsonObject) -> str | None:
+    if (
+        card_supply.get("status") == "PRIMARY_SATISFIED"
+        and blocker
+        and card_supply_blocker_marker_present(blocker)
+    ):
+        return None
+    return blocker
 
 
 def reconcile_card_supply_for_training(
@@ -1026,6 +1102,7 @@ def training_execution(
         tencent_internal_card_supply=tencent_internal_card_supply,
     )
     blocker = text_value(payload.get("trainingBlocker")) or text_value(payload.get("nextTrainingCapabilityAction"))
+    blocker = clear_satisfied_card_supply_blocker(blocker, card_supply)
     if (
         payload.get("trainingDidRun") is not True
         and card_supply.get("status") == "BLOCKED"

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -480,44 +480,104 @@ def card_supply_from_training_report(path: Path, warnings: list[str], repo_root:
     )
 
 
-def card_supply_from_controller_summary(
-    artifact: LoadedArtifact,
+def card_supply_candidates_from_tencent_run_dir(
+    run_dir: Path,
     warnings: list[str],
     repo_root: Path,
-) -> JsonObject | None:
-    payload = artifact.payload
-    if payload.get("type") != "screeps-tencent-batch-rl-run" and "tencent-cloud" not in str(artifact.path):
-        return None
-    run_id = tencent_summary_run_id(payload, artifact.path)
+    *,
+    run_id: str,
+    summary_artifact: LoadedArtifact | None = None,
+) -> list[JsonObject]:
     candidates: list[JsonObject] = []
 
-    output_card = as_dict(as_dict(payload.get("outputs")).get("experimentCard"))
-    if valid_policy_gradient_card(output_card):
-        candidates.append(
-            loop_a_card_supply_summary(
-                card=output_card,
-                path=artifact.path,
-                source="tencent_controller_summary",
-                run_id=run_id,
+    if summary_artifact is not None:
+        output_card = as_dict(as_dict(summary_artifact.payload.get("outputs")).get("experimentCard"))
+        if valid_policy_gradient_card(output_card):
+            candidates.append(
+                loop_a_card_supply_summary(
+                    card=output_card,
+                    path=summary_artifact.path,
+                    source="tencent_controller_summary",
+                    run_id=run_id,
+                )
             )
-        )
 
-    full_card = artifact.path.parent / "experiment_card.json"
+    full_card = run_dir / "experiment_card.json"
     if full_card.is_file():
         evidence = card_supply_from_full_card(full_card, warnings, repo_root, run_id=run_id)
         if evidence is not None:
             candidates.append(evidence)
 
-    report_dir = artifact.path.parent / "remote" / "runtime-artifacts" / "rl-training"
+    report_dir = run_dir / "remote" / "runtime-artifacts" / "rl-training"
     if report_dir.is_dir():
         for report in sorted(report_dir.glob("*.json")):
             evidence = card_supply_from_training_report(report, warnings, repo_root, run_id=run_id)
             if evidence is not None:
                 candidates.append(evidence)
 
+    return candidates
+
+
+def card_supply_candidates_from_controller_summary(
+    artifact: LoadedArtifact,
+    warnings: list[str],
+    repo_root: Path,
+) -> list[JsonObject]:
+    payload = artifact.payload
+    if payload.get("type") != "screeps-tencent-batch-rl-run" and "tencent-cloud" not in str(artifact.path):
+        return []
+    run_id = tencent_summary_run_id(payload, artifact.path)
+    return card_supply_candidates_from_tencent_run_dir(
+        artifact.path.parent,
+        warnings,
+        repo_root,
+        run_id=run_id,
+        summary_artifact=artifact,
+    )
+
+
+def card_supply_from_controller_summary(
+    artifact: LoadedArtifact,
+    warnings: list[str],
+    repo_root: Path,
+) -> JsonObject | None:
+    candidates = card_supply_candidates_from_controller_summary(artifact, warnings, repo_root)
     if not candidates:
         return None
     return max(candidates, key=card_supply_candidate_key)
+
+
+def discover_tencent_internal_card_supply_candidates(
+    artifact_root: Path,
+    *,
+    warnings: list[str],
+    repo_root: Path,
+) -> list[JsonObject]:
+    candidates: list[JsonObject] = []
+    root = artifact_root / "tencent-cloud" / "batch-runs"
+    seen_run_dirs: set[Path] = set()
+
+    for path in existing_globs(root, ("*/controller-summary.json",)):
+        artifact = load_artifact(path, warnings, repo_root)
+        if artifact is None:
+            continue
+        candidates.extend(card_supply_candidates_from_controller_summary(artifact, warnings, repo_root))
+        seen_run_dirs.add(path.parent)
+
+    if root.is_dir():
+        for run_dir in sorted(path for path in root.iterdir() if path.is_dir()):
+            if run_dir in seen_run_dirs:
+                continue
+            candidates.extend(
+                card_supply_candidates_from_tencent_run_dir(
+                    run_dir,
+                    warnings,
+                    repo_root,
+                    run_id=run_dir.name,
+                )
+            )
+
+    return sorted(candidates, key=card_supply_candidate_key, reverse=True)
 
 
 def discover_tencent_internal_card_supply(
@@ -526,24 +586,14 @@ def discover_tencent_internal_card_supply(
     warnings: list[str],
     repo_root: Path,
 ) -> JsonObject | None:
-    candidates: list[tuple[datetime, str, JsonObject]] = []
-    root = artifact_root / "tencent-cloud" / "batch-runs"
-    for path in existing_globs(root, ("*/controller-summary.json",)):
-        artifact = load_artifact(path, warnings, repo_root)
-        if artifact is None:
-            continue
-        evidence = card_supply_from_controller_summary(artifact, warnings, repo_root)
-        if evidence is None:
-            continue
-        created = parse_iso_datetime(text_value(evidence.get("createdAt")) or "") or artifact.timestamp
-        candidates.append((created, str(path), evidence))
+    candidates = discover_tencent_internal_card_supply_candidates(
+        artifact_root,
+        warnings=warnings,
+        repo_root=repo_root,
+    )
     if not candidates:
         return None
-    candidates.sort(
-        key=lambda item: (card_supply_available_for_training(item[2]), item[0], item[1]),
-        reverse=True,
-    )
-    return candidates[0][2]
+    return candidates[0]
 
 
 def nested_value(value: Any, path: Sequence[str]) -> Any:
@@ -1030,6 +1080,44 @@ def tencent_card_identity_candidates(value: Any) -> list[dict[str, set[str]]]:
     return candidates
 
 
+def coherent_tencent_card_identity(value: JsonObject) -> dict[str, set[str]] | None:
+    identity = tencent_card_identity_values(value)
+    if all(len(identity[field]) == 1 for field in TENCENT_CARD_IDENTITY_FIELDS):
+        return identity
+    return None
+
+
+def training_payload_tencent_card_identities(payload: JsonObject) -> list[dict[str, set[str]]]:
+    identities: list[dict[str, set[str]]] = []
+
+    def add_identity(value: Any) -> None:
+        if not isinstance(value, dict):
+            return
+        identity = coherent_tencent_card_identity(value)
+        if identity is not None and identity not in identities:
+            identities.append(identity)
+
+    training_artifacts = as_dict(payload.get("trainingArtifacts"))
+    for key, value in training_artifacts.items():
+        if normalized_key(str(key)) in {
+            "tencentinternalcardsupply",
+            "tencentcardsupply",
+            "tencentcardidentity",
+        }:
+            add_identity(value)
+    add_identity(training_artifacts)
+
+    for key, value in payload.items():
+        if normalized_key(str(key)) in {
+            "tencentinternalcardsupply",
+            "tencentcardsupply",
+            "tencentcardidentity",
+        }:
+            add_identity(value)
+    add_identity(payload)
+    return identities
+
+
 def card_supply_identity(card_supply: JsonObject) -> dict[str, str | None]:
     supply = as_dict(card_supply.get("cardSupply"))
     return {
@@ -1056,11 +1144,10 @@ def training_payload_matches_tencent_card_supply(
     payload: JsonObject,
     card_supply: JsonObject,
 ) -> bool:
-    artifact_identities = tencent_card_identity_candidates(as_dict(payload.get("trainingArtifacts")))
-    if any(tencent_card_identity_matches_supply(identity, card_supply) for identity in artifact_identities):
-        return True
-    payload_identities = tencent_card_identity_candidates(payload)
-    return any(tencent_card_identity_matches_supply(identity, card_supply) for identity in payload_identities)
+    return any(
+        tencent_card_identity_matches_supply(identity, card_supply)
+        for identity in training_payload_tencent_card_identities(payload)
+    )
 
 
 def card_supply_blocker_marker_present(value: Any) -> bool:
@@ -1168,11 +1255,65 @@ def card_supply_candidate_key(card_supply: JsonObject) -> tuple[int, datetime, s
     )
 
 
+def training_card_supply_candidate_rank(card_supply: JsonObject) -> int:
+    supply = as_dict(card_supply.get("cardSupply"))
+    if supply.get("state") == "consumed":
+        return 4
+    return card_supply_candidate_rank(card_supply)
+
+
+def training_card_supply_candidate_key(card_supply: JsonObject) -> tuple[int, datetime, str, str]:
+    created = parse_iso_datetime(text_value(card_supply.get("createdAt")) or "")
+    if created is None:
+        created = datetime.min.replace(tzinfo=timezone.utc)
+    return (
+        training_card_supply_candidate_rank(card_supply),
+        created,
+        text_value(card_supply.get("source")) or "",
+        text_value(card_supply.get("path")) or "",
+    )
+
+
+def combined_tencent_card_supply_candidates(
+    tencent_internal_card_supply: JsonObject | None,
+    tencent_internal_card_supply_candidates: Sequence[JsonObject] | None,
+) -> list[JsonObject]:
+    candidates = list(tencent_internal_card_supply_candidates or [])
+    if tencent_internal_card_supply is not None:
+        candidates.append(tencent_internal_card_supply)
+    return candidates
+
+
+def best_available_tencent_card_supply(candidates: Sequence[JsonObject]) -> JsonObject | None:
+    available = [candidate for candidate in candidates if card_supply_available_for_training(candidate)]
+    if not available:
+        return None
+    return max(available, key=card_supply_candidate_key)
+
+
+def matching_tencent_card_supply_for_training(
+    payload: JsonObject,
+    candidates: Sequence[JsonObject],
+) -> JsonObject | None:
+    identities = training_payload_tencent_card_identities(payload)
+    if not identities:
+        return None
+    matches = [
+        candidate
+        for candidate in candidates
+        if any(tencent_card_identity_matches_supply(identity, candidate) for identity in identities)
+    ]
+    if not matches:
+        return None
+    return max(matches, key=training_card_supply_candidate_key)
+
+
 def reconcile_card_supply_for_training(
     payload: JsonObject,
     *,
     latest_path: Path | None,
     tencent_internal_card_supply: JsonObject | None,
+    tencent_internal_card_supply_candidates: Sequence[JsonObject] | None = None,
 ) -> JsonObject:
     artifact_count = number_value(payload.get("artifactCount"))
     iteration = as_dict(payload.get("iterationExecution"))
@@ -1187,17 +1328,18 @@ def reconcile_card_supply_for_training(
     embedded_supply = card_supply_from_training_payload(payload, latest_path)
     if training_did_run and embedded_supply is not None:
         return embedded_supply
-    if (
-        tencent_internal_card_supply is not None
-        and (
-            (not training_did_run and card_supply_available_for_training(tencent_internal_card_supply))
-            or (
-                training_did_run
-                and training_payload_matches_tencent_card_supply(payload, tencent_internal_card_supply)
-            )
-        )
-    ):
-        return dict(tencent_internal_card_supply)
+    tencent_candidates = combined_tencent_card_supply_candidates(
+        tencent_internal_card_supply,
+        tencent_internal_card_supply_candidates,
+    )
+    if not training_did_run:
+        available_supply = best_available_tencent_card_supply(tencent_candidates)
+        if available_supply is not None:
+            return dict(available_supply)
+    else:
+        matching_supply = matching_tencent_card_supply_for_training(payload, tencent_candidates)
+        if matching_supply is not None:
+            return dict(matching_supply)
     if training_did_run:
         return {
             "status": "DEGRADED",
@@ -1218,6 +1360,7 @@ def training_execution(
     latest_training: LoadedArtifact | None,
     *,
     tencent_internal_card_supply: JsonObject | None = None,
+    tencent_internal_card_supply_candidates: Sequence[JsonObject] | None = None,
 ) -> JsonObject:
     if latest_training is None:
         return {
@@ -1243,6 +1386,7 @@ def training_execution(
         payload,
         latest_path=latest_training.path,
         tencent_internal_card_supply=tencent_internal_card_supply,
+        tencent_internal_card_supply_candidates=tencent_internal_card_supply_candidates,
     )
     blocker = text_value(payload.get("trainingBlocker")) or text_value(payload.get("nextTrainingCapabilityAction"))
     blocker = clear_satisfied_card_supply_blocker(blocker, card_supply)
@@ -1473,13 +1617,18 @@ def build_dashboard(repo_root: Path, artifact_root: Path, generated_at: str) -> 
         latest_metrics=latest_metrics,
     )
     gate = latest_gate(gates)
-    tencent_card_supply = discover_tencent_internal_card_supply(
+    tencent_card_supply_candidates = discover_tencent_internal_card_supply_candidates(
         artifact_root,
         warnings=warnings,
         repo_root=repo_root,
     )
+    tencent_card_supply = tencent_card_supply_candidates[0] if tencent_card_supply_candidates else None
     simulator = simulator_health(artifact_root, repo_root=repo_root, warnings=warnings, latest_training=latest_training)
-    training = training_execution(latest_training, tencent_internal_card_supply=tencent_card_supply)
+    training = training_execution(
+        latest_training,
+        tencent_internal_card_supply=tencent_card_supply,
+        tencent_internal_card_supply_candidates=tencent_card_supply_candidates,
+    )
     policy = policy_advantage(latest_policy, latest_metrics, training=training)
     conclusions = conclusion_summary(conclusion_artifact)
     lanes = lane_statuses(gate, simulator, training, policy)

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -29,6 +29,22 @@ LANES = (
     ("E5", "rollout"),
 )
 SECRET_PATH_MARKERS = ("token", "secret", "password", "steam_key", ".screepsrc")
+SAFETY_FALSE_FIELDS = ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed")
+SAFETY_TRUE_FIELDS = ("conservative_actions_only", "ood_rejection")
+REWARD_COMPONENT_ORDER = ("reliability", "territory", "resources", "kills")
+LOOP_A_CARD_SUPPLY_TYPE = "screeps-rl-loop-a-card-supply"
+LOOP_A_CARD_SUPPLY_CONSUMER = "loop-a-policy-gradient"
+LOOP_A_CARD_SUPPLY_STATES = ("available", "consumed")
+CARD_SUPPLY_BLOCKER_MARKERS = (
+    "loopacardpathstalledcycles",
+    "loopacardpipelinestalled",
+    "cardpipelinestalled",
+    "nostandaloneexperimentcard",
+    "nounconsumedexperimentcard",
+    "standaloneexperimentcard",
+    "standalonecardsupply",
+    "cardsupplystarvation",
+)
 TIMESTAMP_KEYS = (
     "createdAt",
     "producedAt",
@@ -50,6 +66,10 @@ class LoadedArtifact:
 
 def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, ensure_ascii=True, default=str)
 
 
 def repo_root_from_script() -> Path:
@@ -234,6 +254,248 @@ def as_dict(value: Any) -> JsonObject:
 
 def as_list(value: Any) -> list[Any]:
     return value if isinstance(value, list) else []
+
+
+def first_present(value: JsonObject, keys: Sequence[str]) -> Any:
+    for key in keys:
+        if key in value:
+            return value[key]
+    return None
+
+
+def card_training_approach(card: JsonObject) -> str | None:
+    return text_value(first_present(card, ("training_approach", "trainingApproach")))
+
+
+def card_supply_metadata(card: JsonObject) -> JsonObject:
+    return as_dict(first_present(card, ("card_supply", "cardSupply")))
+
+
+def safety_flags_are_shadow(raw: JsonObject) -> bool:
+    safety = as_dict(raw.get("safety"))
+    if not safety:
+        return False
+    for field in SAFETY_FALSE_FIELDS:
+        if safety.get(field) is not False:
+            return False
+        if field in raw and raw[field] is not False:
+            return False
+    for field in SAFETY_TRUE_FIELDS:
+        if safety.get(field) is not True:
+            return False
+        if field in raw and raw[field] is not True:
+            return False
+    return True
+
+
+def reward_model_is_lexicographic(raw: JsonObject) -> bool:
+    reward = as_dict(first_present(raw, ("reward_model", "rewardModel")))
+    if not reward:
+        return False
+    if reward.get("type") != "lexicographic":
+        return False
+    order = first_present(reward, ("component_order", "componentOrder"))
+    if order != list(REWARD_COMPONENT_ORDER):
+        return False
+    scalar_authorized = first_present(
+        reward,
+        ("scalar_weighted_sum_authorized", "scalarWeightedSumAuthorized"),
+    )
+    return scalar_authorized is False
+
+
+def valid_loop_a_card_supply(card: JsonObject) -> bool:
+    supply = card_supply_metadata(card)
+    if not supply:
+        return False
+    if supply.get("type") != LOOP_A_CARD_SUPPLY_TYPE:
+        return False
+    if supply.get("consumer") != LOOP_A_CARD_SUPPLY_CONSUMER:
+        return False
+    if supply.get("state") not in LOOP_A_CARD_SUPPLY_STATES:
+        return False
+    if supply.get("training_approach") != card_training_approach(card):
+        return False
+    if supply.get("safety_status") != "shadow" or supply.get("status_field") != "status":
+        return False
+    state = supply.get("state")
+    if state == "available":
+        return (
+            card.get("status") == "shadow"
+            and card_training_approach(card) == "policy_gradient"
+            and supply.get("available_for_training") is True
+            and supply.get("consumed_at") is None
+            and supply.get("consumed_by_report_id") is None
+        )
+    return (
+        supply.get("available_for_training") is False
+        and isinstance(supply.get("consumed_at"), str)
+        and isinstance(supply.get("consumed_by_report_id"), str)
+        and bool(supply.get("consumed_by_report_id"))
+    )
+
+
+def policy_gradient_metadata_present(card: JsonObject) -> bool:
+    return isinstance(first_present(card, ("policy_gradient", "policyGradient")), dict)
+
+
+def valid_policy_gradient_card(card: JsonObject, *, reward_container: JsonObject | None = None) -> bool:
+    if card.get("status") != "shadow":
+        return False
+    if card_training_approach(card) != "policy_gradient":
+        return False
+    if not safety_flags_are_shadow(card):
+        return False
+    if not policy_gradient_metadata_present(card):
+        return False
+    return reward_model_is_lexicographic(card) or (
+        reward_container is not None and reward_model_is_lexicographic(reward_container)
+    )
+
+
+def loop_a_card_supply_summary(
+    *,
+    card: JsonObject,
+    path: Path | None,
+    source: str,
+    run_id: str | None = None,
+) -> JsonObject:
+    supply = card_supply_metadata(card)
+    has_supply = valid_loop_a_card_supply(card)
+    summary: JsonObject = {
+        "status": "PRIMARY_SATISFIED",
+        "classification": "TENCENT_INTERNAL_POLICY_GRADIENT_PRIMARY",
+        "source": source,
+        "severity": "OK",
+        "fallbackStatus": "DEGRADED",
+        "fallbackSeverity": "P2",
+        "fallbackReason": "Standalone experiment-card availability is a local fallback path; Tencent internal policy-gradient card evidence satisfies primary training supply.",
+        "cardId": first_present(card, ("card_id", "cardId")),
+        "createdAt": first_present(card, ("created_at", "createdAt")),
+        "datasetRunId": first_present(card, ("dataset_run_id", "datasetRunId")),
+        "trainingApproach": card_training_approach(card),
+        "path": str(path) if path is not None else None,
+        "runId": run_id,
+        "hasLoopACardSupplyMetadata": has_supply,
+    }
+    if supply:
+        summary["cardSupply"] = supply
+    if not has_supply:
+        summary["metadataNote"] = (
+            "Valid legacy Tencent internal policy-gradient card evidence has no explicit Loop A card_supply "
+            "metadata; generated Tencent cards should include it going forward."
+        )
+    return summary
+
+
+def blocked_card_supply_summary(reason: str | None = None) -> JsonObject:
+    return {
+        "status": "BLOCKED",
+        "classification": "CARD_SUPPLY_BLOCKED",
+        "source": None,
+        "severity": "P0",
+        "reason": reason or "No valid standalone or Tencent internal policy-gradient card supply evidence.",
+    }
+
+
+def tencent_summary_run_id(payload: JsonObject, path: Path) -> str:
+    return text_value(payload.get("runId")) or path.parent.name
+
+
+def card_supply_from_full_card(path: Path, warnings: list[str], repo_root: Path, *, run_id: str) -> JsonObject | None:
+    artifact = load_artifact(path, warnings, repo_root)
+    if artifact is None:
+        return None
+    if not valid_policy_gradient_card(artifact.payload):
+        return None
+    return loop_a_card_supply_summary(
+        card=artifact.payload,
+        path=artifact.path,
+        source="tencent_internal_experiment_card",
+        run_id=run_id,
+    )
+
+
+def card_supply_from_training_report(path: Path, warnings: list[str], repo_root: Path, *, run_id: str) -> JsonObject | None:
+    artifact = load_artifact(path, warnings, repo_root)
+    if artifact is None:
+        return None
+    payload = artifact.payload
+    safety = {field: payload.get(field) for field in SAFETY_FALSE_FIELDS}
+    if any(value is not False for value in safety.values()):
+        return None
+    card = as_dict(payload.get("experimentCard"))
+    if not valid_policy_gradient_card(card, reward_container=payload):
+        return None
+    return loop_a_card_supply_summary(
+        card=card,
+        path=artifact.path,
+        source="tencent_internal_training_report",
+        run_id=run_id,
+    )
+
+
+def card_supply_from_controller_summary(
+    artifact: LoadedArtifact,
+    warnings: list[str],
+    repo_root: Path,
+) -> JsonObject | None:
+    payload = artifact.payload
+    if payload.get("type") != "screeps-tencent-batch-rl-run" and "tencent-cloud" not in str(artifact.path):
+        return None
+    run_id = tencent_summary_run_id(payload, artifact.path)
+    candidates: list[JsonObject] = []
+
+    output_card = as_dict(as_dict(payload.get("outputs")).get("experimentCard"))
+    if valid_policy_gradient_card(output_card):
+        candidates.append(
+            loop_a_card_supply_summary(
+                card=output_card,
+                path=artifact.path,
+                source="tencent_controller_summary",
+                run_id=run_id,
+            )
+        )
+
+    full_card = artifact.path.parent / "experiment_card.json"
+    if full_card.is_file():
+        evidence = card_supply_from_full_card(full_card, warnings, repo_root, run_id=run_id)
+        if evidence is not None:
+            candidates.append(evidence)
+
+    report_dir = artifact.path.parent / "remote" / "runtime-artifacts" / "rl-training"
+    if report_dir.is_dir():
+        for report in sorted(report_dir.glob("*.json")):
+            evidence = card_supply_from_training_report(report, warnings, repo_root, run_id=run_id)
+            if evidence is not None:
+                candidates.append(evidence)
+
+    if not candidates:
+        return None
+    return candidates[-1]
+
+
+def discover_tencent_internal_card_supply(
+    artifact_root: Path,
+    *,
+    warnings: list[str],
+    repo_root: Path,
+) -> JsonObject | None:
+    candidates: list[tuple[datetime, str, JsonObject]] = []
+    root = artifact_root / "tencent-cloud" / "batch-runs"
+    for path in existing_globs(root, ("*/controller-summary.json",)):
+        artifact = load_artifact(path, warnings, repo_root)
+        if artifact is None:
+            continue
+        evidence = card_supply_from_controller_summary(artifact, warnings, repo_root)
+        if evidence is None:
+            continue
+        created = parse_iso_datetime(text_value(evidence.get("createdAt")) or "") or artifact.timestamp
+        candidates.append((created, str(path), evidence))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    return candidates[0][2]
 
 
 def nested_value(value: Any, path: Sequence[str]) -> Any:
@@ -679,7 +941,65 @@ def simulator_health(
     }
 
 
-def training_execution(latest_training: LoadedArtifact | None) -> JsonObject:
+def card_supply_from_training_payload(payload: JsonObject, path: Path | None) -> JsonObject | None:
+    card = as_dict(payload.get("experimentCard"))
+    if valid_policy_gradient_card(card, reward_container=payload):
+        return loop_a_card_supply_summary(
+            card=card,
+            path=path,
+            source="training_report_experiment_card",
+            run_id=text_value(payload.get("reportId")),
+        )
+    return None
+
+
+def card_supply_blocker_text_present(payload: JsonObject) -> bool:
+    text = normalized_key(canonical_json(payload))
+    return any(marker in text for marker in CARD_SUPPLY_BLOCKER_MARKERS)
+
+
+def reconcile_card_supply_for_training(
+    payload: JsonObject,
+    *,
+    latest_path: Path | None,
+    tencent_internal_card_supply: JsonObject | None,
+) -> JsonObject:
+    artifact_count = number_value(payload.get("artifactCount"))
+    iteration = as_dict(payload.get("iterationExecution"))
+    episodes_run = number_value(iteration.get("episodesRun"))
+    policy_updates = number_value(iteration.get("policyUpdateIterations"))
+    training_did_run = (
+        payload.get("trainingDidRun") is True
+        or (artifact_count or 0) > 0
+        or (episodes_run or 0) > 0
+        or (policy_updates or 0) > 0
+    )
+    embedded_supply = card_supply_from_training_payload(payload, latest_path)
+    if training_did_run and embedded_supply is not None:
+        return embedded_supply
+    if training_did_run and tencent_internal_card_supply is not None:
+        return dict(tencent_internal_card_supply)
+    if training_did_run:
+        return {
+            "status": "DEGRADED",
+            "classification": "TRAINING_RAN_WITHOUT_STRUCTURED_CARD_SUPPLY_EVIDENCE",
+            "source": None,
+            "severity": "P2",
+            "fallbackStatus": "DEGRADED",
+            "fallbackSeverity": "P2",
+            "reason": (
+                "Training ran, but no structured safety-validated Tencent or standalone card evidence was found "
+                "for dashboard reconciliation."
+            ),
+        }
+    return blocked_card_supply_summary()
+
+
+def training_execution(
+    latest_training: LoadedArtifact | None,
+    *,
+    tencent_internal_card_supply: JsonObject | None = None,
+) -> JsonObject:
     if latest_training is None:
         return {
             "hasData": False,
@@ -689,6 +1009,7 @@ def training_execution(latest_training: LoadedArtifact | None) -> JsonObject:
             "timestamp": None,
             "blocker": "No training ledger found.",
             "latestPath": None,
+            "cardSupply": blocked_card_supply_summary("No training ledger found."),
         }
     payload = latest_training.payload
     iteration = as_dict(payload.get("iterationExecution"))
@@ -699,6 +1020,18 @@ def training_execution(latest_training: LoadedArtifact | None) -> JsonObject:
     updates = number_value(iteration.get("policyUpdateIterations"))
     if updates is None:
         updates = number_value(metrics_feed.get("policyUpdateIterations"))
+    card_supply = reconcile_card_supply_for_training(
+        payload,
+        latest_path=latest_training.path,
+        tencent_internal_card_supply=tencent_internal_card_supply,
+    )
+    blocker = text_value(payload.get("trainingBlocker")) or text_value(payload.get("nextTrainingCapabilityAction"))
+    if (
+        payload.get("trainingDidRun") is not True
+        and card_supply.get("status") == "BLOCKED"
+        and not blocker
+    ):
+        blocker = text_value(card_supply.get("reason"))
     return {
         "hasData": True,
         "status": text_value(payload.get("status")) or ("RUN" if payload.get("trainingDidRun") else "NOT_RUN"),
@@ -706,8 +1039,9 @@ def training_execution(latest_training: LoadedArtifact | None) -> JsonObject:
         "episodes": episodes,
         "policyUpdates": updates,
         "timestamp": latest_training.timestamp,
-        "blocker": text_value(payload.get("trainingBlocker")) or text_value(payload.get("nextTrainingCapabilityAction")),
+        "blocker": blocker,
         "latestPath": latest_training.path,
+        "cardSupply": card_supply,
     }
 
 
@@ -721,7 +1055,35 @@ def metric_observation_map(latest_metrics: LoadedArtifact | None) -> dict[str, J
     return observations
 
 
-def policy_advantage(latest_policy: LoadedArtifact | None, latest_metrics: LoadedArtifact | None) -> JsonObject:
+def card_supply_finding_for_policy(payload: JsonObject, training: JsonObject | None) -> JsonObject | None:
+    if not card_supply_blocker_text_present(payload):
+        return None
+    card_supply = as_dict((training or {}).get("cardSupply"))
+    if card_supply.get("status") == "PRIMARY_SATISFIED":
+        return {
+            "status": "FALLBACK_DEGRADED",
+            "severity": "P2",
+            "classification": "STANDALONE_CARD_SUPPLY_FALLBACK_DEGRADED",
+            "reason": (
+                "Policy report references standalone Loop A card-path stall, but valid Tencent internal "
+                "policy-gradient card evidence satisfies the primary training card supply."
+            ),
+            "primarySupply": card_supply,
+        }
+    return {
+        "status": "BLOCKED",
+        "severity": "P0",
+        "classification": "CARD_SUPPLY_BLOCKER_ACTIVE",
+        "reason": "Policy report references Loop A card supply stall and no valid primary card evidence was found.",
+    }
+
+
+def policy_advantage(
+    latest_policy: LoadedArtifact | None,
+    latest_metrics: LoadedArtifact | None,
+    *,
+    training: JsonObject | None = None,
+) -> JsonObject:
     observations = metric_observation_map(latest_metrics)
     if latest_policy is None:
         return {
@@ -733,6 +1095,7 @@ def policy_advantage(latest_policy: LoadedArtifact | None, latest_metrics: Loade
             "latestPath": None,
             "metrics": [],
             "shadowMetrics": shadow_metrics(observations),
+            "cardSupplyFinding": None,
         }
 
     payload = latest_policy.payload
@@ -763,6 +1126,7 @@ def policy_advantage(latest_policy: LoadedArtifact | None, latest_metrics: Loade
         "latestPath": latest_policy.path,
         "metrics": metrics[:8],
         "shadowMetrics": shadow_metrics(observations),
+        "cardSupplyFinding": card_supply_finding_for_policy(payload, training),
     }
 
 
@@ -889,9 +1253,14 @@ def build_dashboard(repo_root: Path, artifact_root: Path, generated_at: str) -> 
         latest_metrics=latest_metrics,
     )
     gate = latest_gate(gates)
+    tencent_card_supply = discover_tencent_internal_card_supply(
+        artifact_root,
+        warnings=warnings,
+        repo_root=repo_root,
+    )
     simulator = simulator_health(artifact_root, repo_root=repo_root, warnings=warnings, latest_training=latest_training)
-    training = training_execution(latest_training)
-    policy = policy_advantage(latest_policy, latest_metrics)
+    training = training_execution(latest_training, tencent_internal_card_supply=tencent_card_supply)
+    policy = policy_advantage(latest_policy, latest_metrics, training=training)
     conclusions = conclusion_summary(conclusion_artifact)
     lanes = lane_statuses(gate, simulator, training, policy)
 
@@ -912,6 +1281,7 @@ def build_dashboard(repo_root: Path, artifact_root: Path, generated_at: str) -> 
         "simulator": simulator,
         "training": training,
         "policy": policy,
+        "cardSupply": training.get("cardSupply"),
     }
 
 
@@ -1023,10 +1393,19 @@ def render_simulator(simulator: JsonObject, repo_root: Path) -> str:
 
 
 def render_training(training: JsonObject, repo_root: Path) -> str:
+    card_supply = as_dict(training.get("cardSupply"))
+    card_supply_status = "N/A"
+    if card_supply:
+        card_supply_status = (
+            f"{card_supply.get('status', 'N/A')} / "
+            f"fallback {card_supply.get('fallbackStatus', 'N/A')} "
+            f"({card_supply.get('fallbackSeverity', card_supply.get('severity', 'N/A'))})"
+        )
     rows = [
         f"<tr><td>Status</td><td>{h(training.get('status', 'N/A'))}</td></tr>",
         f"<tr><td>Episodes</td><td>{h(format_count(training.get('episodes')))}</td></tr>",
         f"<tr><td>Policy updates</td><td>{h(format_count(training.get('policyUpdates')))}</td></tr>",
+        f"<tr><td>Card supply</td><td>{h(card_supply_status)}</td></tr>",
         f"<tr><td>Last ledger timestamp</td><td>{h(display_timestamp(training.get('timestamp')))}</td></tr>",
         f"<tr><td>Blocker</td><td>{h(shorten(training.get('blocker') or 'N/A', 260))}</td></tr>",
     ]
@@ -1049,6 +1428,7 @@ def render_policy(policy: JsonObject, repo_root: Path) -> str:
             "</tr>"
         )
     shadow = as_dict(policy.get("shadowMetrics"))
+    card_supply_finding = as_dict(policy.get("cardSupplyFinding"))
     shadow_rows = [
         f"<tr><td>changedTopCount</td><td>{h(format_count(shadow.get('changedTopCount')))}</td></tr>",
         f"<tr><td>rankingDiffCount</td><td>{h(format_count(shadow.get('rankingDiffCount')))}</td></tr>",
@@ -1057,6 +1437,11 @@ def render_policy(policy: JsonObject, repo_root: Path) -> str:
         f"<tr><td>shadow kills KPI</td><td>{h(format_count(shadow.get('kills')))}</td></tr>",
         f"<tr><td>shadow reliability passed</td><td>{h(display_value(shadow.get('reliabilityPassed')))}</td></tr>",
     ]
+    if card_supply_finding:
+        shadow_rows.append(
+            f"<tr><td>card supply finding</td><td>{h(card_supply_finding.get('status', 'N/A'))} "
+            f"{h(card_supply_finding.get('severity', 'N/A'))}</td></tr>"
+        )
     meta = (
         f"Status: {h(policy.get('status', 'N/A'))} | Candidate: {h(policy.get('candidate', 'N/A'))} | "
         f"Baseline: {h(policy.get('baseline', 'N/A'))} | "

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -981,6 +981,11 @@ def card_supply_from_training_payload(payload: JsonObject, path: Path | None) ->
     return None
 
 
+def training_payload_references_tencent_card(payload: JsonObject) -> bool:
+    artifacts = as_dict(payload.get("trainingArtifacts"))
+    return "tencent" in normalized_key(canonical_json(artifacts))
+
+
 def card_supply_blocker_marker_present(value: Any) -> bool:
     text = normalized_key(canonical_json(value))
     return any(marker in text for marker in CARD_SUPPLY_BLOCKER_MARKERS)
@@ -996,8 +1001,10 @@ def card_supply_blocker_value_active(value: Any) -> bool:
         return numeric > 0
     if isinstance(value, str):
         return normalized_key(value) not in INACTIVE_CARD_SUPPLY_BLOCKER_VALUES
-    if isinstance(value, (dict, list)):
-        return bool(value)
+    if isinstance(value, dict):
+        return any(card_supply_blocker_value_active(item) for item in value.values())
+    if isinstance(value, list):
+        return any(card_supply_blocker_value_active(item) for item in value)
     return True
 
 
@@ -1053,7 +1060,10 @@ def reconcile_card_supply_for_training(
     embedded_supply = card_supply_from_training_payload(payload, latest_path)
     if training_did_run and embedded_supply is not None:
         return embedded_supply
-    if tencent_internal_card_supply is not None:
+    if (
+        tencent_internal_card_supply is not None
+        and (not training_did_run or training_payload_references_tencent_card(payload))
+    ):
         return dict(tencent_internal_card_supply)
     if training_did_run:
         return {

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -522,7 +522,10 @@ def discover_tencent_internal_card_supply(
         candidates.append((created, str(path), evidence))
     if not candidates:
         return None
-    candidates.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    candidates.sort(
+        key=lambda item: (card_supply_available_for_training(item[2]), item[0], item[1]),
+        reverse=True,
+    )
     return candidates[0][2]
 
 

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -36,6 +36,11 @@ LOOP_A_CARD_SUPPLY_TYPE = "screeps-rl-loop-a-card-supply"
 LOOP_A_CARD_SUPPLY_CONSUMER = "loop-a-policy-gradient"
 LOOP_A_CARD_SUPPLY_STATES = ("available", "consumed")
 TENCENT_CARD_IDENTITY_FIELDS = ("runId", "cardId", "datasetRunId")
+TENCENT_CARD_SUPPLY_SOURCES = (
+    "tencent_controller_summary",
+    "tencent_internal_experiment_card",
+    "tencent_internal_training_report",
+)
 TENCENT_CARD_IDENTITY_KEYS = {
     "batchrunid": "runId",
     "runid": "runId",
@@ -512,7 +517,7 @@ def card_supply_from_controller_summary(
 
     if not candidates:
         return None
-    return candidates[-1]
+    return max(candidates, key=card_supply_candidate_key)
 
 
 def discover_tencent_internal_card_supply(
@@ -996,16 +1001,25 @@ def card_supply_from_training_payload(payload: JsonObject, path: Path | None) ->
     return None
 
 
-def tencent_card_identity_values(value: Any) -> dict[str, set[str]]:
+def tencent_card_identity_values(value: JsonObject) -> dict[str, set[str]]:
     identity: dict[str, set[str]] = {field: set() for field in TENCENT_CARD_IDENTITY_FIELDS}
+    for key, raw in value.items():
+        field = TENCENT_CARD_IDENTITY_KEYS.get(normalized_key(str(key)))
+        raw_text = text_value(raw)
+        if field is not None and raw_text is not None:
+            identity[field].add(raw_text)
+    return identity
+
+
+def tencent_card_identity_candidates(value: Any) -> list[dict[str, set[str]]]:
+    candidates: list[dict[str, set[str]]] = []
 
     def visit(node: Any) -> None:
         if isinstance(node, dict):
-            for key, raw in node.items():
-                field = TENCENT_CARD_IDENTITY_KEYS.get(normalized_key(str(key)))
-                raw_text = text_value(raw)
-                if field is not None and raw_text is not None:
-                    identity[field].add(raw_text)
+            identity = tencent_card_identity_values(node)
+            if any(identity[field] for field in TENCENT_CARD_IDENTITY_FIELDS):
+                candidates.append(identity)
+            for raw in node.values():
                 if isinstance(raw, (dict, list)):
                     visit(raw)
         elif isinstance(node, list):
@@ -1013,7 +1027,7 @@ def tencent_card_identity_values(value: Any) -> dict[str, set[str]]:
                 visit(item)
 
     visit(value)
-    return identity
+    return candidates
 
 
 def card_supply_identity(card_supply: JsonObject) -> dict[str, str | None]:
@@ -1042,11 +1056,11 @@ def training_payload_matches_tencent_card_supply(
     payload: JsonObject,
     card_supply: JsonObject,
 ) -> bool:
-    artifact_identity = tencent_card_identity_values(as_dict(payload.get("trainingArtifacts")))
-    if tencent_card_identity_matches_supply(artifact_identity, card_supply):
+    artifact_identities = tencent_card_identity_candidates(as_dict(payload.get("trainingArtifacts")))
+    if any(tencent_card_identity_matches_supply(identity, card_supply) for identity in artifact_identities):
         return True
-    payload_identity = tencent_card_identity_values(payload)
-    return tencent_card_identity_matches_supply(payload_identity, card_supply)
+    payload_identities = tencent_card_identity_candidates(payload)
+    return any(tencent_card_identity_matches_supply(identity, card_supply) for identity in payload_identities)
 
 
 def card_supply_blocker_marker_present(value: Any) -> bool:
@@ -1106,12 +1120,51 @@ def clear_satisfied_card_supply_blocker(blocker: str | None, card_supply: JsonOb
 
 def card_supply_available_for_training(card_supply: JsonObject) -> bool:
     supply = as_dict(card_supply.get("cardSupply"))
+    if not supply:
+        if "cardSupply" in card_supply:
+            return False
+        return legacy_tencent_card_supply_available_for_training(card_supply)
     return (
         card_supply.get("status") == "PRIMARY_SATISFIED"
         and supply.get("state") == "available"
         and supply.get("available_for_training") is True
         and supply.get("consumed_at") is None
         and supply.get("consumed_by_report_id") is None
+    )
+
+
+def legacy_tencent_card_supply_available_for_training(card_supply: JsonObject) -> bool:
+    return (
+        card_supply.get("status") == "PRIMARY_SATISFIED"
+        and card_supply.get("classification") == "TENCENT_INTERNAL_POLICY_GRADIENT_PRIMARY"
+        and card_supply.get("source") in TENCENT_CARD_SUPPLY_SOURCES
+        and card_supply.get("hasLoopACardSupplyMetadata") is False
+        and text_value(card_supply.get("runId")) is not None
+        and text_value(card_supply.get("cardId")) is not None
+        and text_value(card_supply.get("datasetRunId")) is not None
+    )
+
+
+def card_supply_candidate_rank(card_supply: JsonObject) -> int:
+    supply = as_dict(card_supply.get("cardSupply"))
+    if card_supply_available_for_training(card_supply):
+        if supply.get("state") == "available":
+            return 3
+        return 2
+    if supply.get("state") == "consumed":
+        return 1
+    return 0
+
+
+def card_supply_candidate_key(card_supply: JsonObject) -> tuple[int, datetime, str, str]:
+    created = parse_iso_datetime(text_value(card_supply.get("createdAt")) or "")
+    if created is None:
+        created = datetime.min.replace(tzinfo=timezone.utc)
+    return (
+        card_supply_candidate_rank(card_supply),
+        created,
+        text_value(card_supply.get("source")) or "",
+        text_value(card_supply.get("path")) or "",
     )
 
 

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -1041,6 +1041,17 @@ def clear_satisfied_card_supply_blocker(blocker: str | None, card_supply: JsonOb
     return blocker
 
 
+def card_supply_available_for_training(card_supply: JsonObject) -> bool:
+    supply = as_dict(card_supply.get("cardSupply"))
+    return (
+        card_supply.get("status") == "PRIMARY_SATISFIED"
+        and supply.get("state") == "available"
+        and supply.get("available_for_training") is True
+        and supply.get("consumed_at") is None
+        and supply.get("consumed_by_report_id") is None
+    )
+
+
 def reconcile_card_supply_for_training(
     payload: JsonObject,
     *,
@@ -1062,7 +1073,10 @@ def reconcile_card_supply_for_training(
         return embedded_supply
     if (
         tencent_internal_card_supply is not None
-        and (not training_did_run or training_payload_references_tencent_card(payload))
+        and (
+            (not training_did_run and card_supply_available_for_training(tencent_internal_card_supply))
+            or (training_did_run and training_payload_references_tencent_card(payload))
+        )
     ):
         return dict(tencent_internal_card_supply)
     if training_did_run:

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -35,6 +35,18 @@ REWARD_COMPONENT_ORDER = ("reliability", "territory", "resources", "kills")
 LOOP_A_CARD_SUPPLY_TYPE = "screeps-rl-loop-a-card-supply"
 LOOP_A_CARD_SUPPLY_CONSUMER = "loop-a-policy-gradient"
 LOOP_A_CARD_SUPPLY_STATES = ("available", "consumed")
+TENCENT_CARD_IDENTITY_FIELDS = ("runId", "cardId", "datasetRunId")
+TENCENT_CARD_IDENTITY_KEYS = {
+    "batchrunid": "runId",
+    "runid": "runId",
+    "tencentbatchrunid": "runId",
+    "tencentrunid": "runId",
+    "cardid": "cardId",
+    "experimentcardid": "cardId",
+    "tencentcardid": "cardId",
+    "datasetrunid": "datasetRunId",
+    "tencentdatasetrunid": "datasetRunId",
+}
 CARD_SUPPLY_BLOCKER_MARKERS = (
     "loopacardpathstalledcycles",
     "loopacardpipelinestalled",
@@ -984,9 +996,57 @@ def card_supply_from_training_payload(payload: JsonObject, path: Path | None) ->
     return None
 
 
-def training_payload_references_tencent_card(payload: JsonObject) -> bool:
-    artifacts = as_dict(payload.get("trainingArtifacts"))
-    return "tencent" in normalized_key(canonical_json(artifacts))
+def tencent_card_identity_values(value: Any) -> dict[str, set[str]]:
+    identity: dict[str, set[str]] = {field: set() for field in TENCENT_CARD_IDENTITY_FIELDS}
+
+    def visit(node: Any) -> None:
+        if isinstance(node, dict):
+            for key, raw in node.items():
+                field = TENCENT_CARD_IDENTITY_KEYS.get(normalized_key(str(key)))
+                raw_text = text_value(raw)
+                if field is not None and raw_text is not None:
+                    identity[field].add(raw_text)
+                if isinstance(raw, (dict, list)):
+                    visit(raw)
+        elif isinstance(node, list):
+            for item in node:
+                visit(item)
+
+    visit(value)
+    return identity
+
+
+def card_supply_identity(card_supply: JsonObject) -> dict[str, str | None]:
+    supply = as_dict(card_supply.get("cardSupply"))
+    return {
+        "runId": text_value(card_supply.get("runId")),
+        "cardId": text_value(card_supply.get("cardId")),
+        "datasetRunId": text_value(card_supply.get("datasetRunId"))
+        or text_value(first_present(supply, ("dataset_run_id", "datasetRunId"))),
+    }
+
+
+def tencent_card_identity_matches_supply(
+    identity: dict[str, set[str]],
+    card_supply: JsonObject,
+) -> bool:
+    supply_identity = card_supply_identity(card_supply)
+    for field in TENCENT_CARD_IDENTITY_FIELDS:
+        supply_value = supply_identity.get(field)
+        if supply_value is None or identity.get(field, set()) != {supply_value}:
+            return False
+    return True
+
+
+def training_payload_matches_tencent_card_supply(
+    payload: JsonObject,
+    card_supply: JsonObject,
+) -> bool:
+    artifact_identity = tencent_card_identity_values(as_dict(payload.get("trainingArtifacts")))
+    if tencent_card_identity_matches_supply(artifact_identity, card_supply):
+        return True
+    payload_identity = tencent_card_identity_values(payload)
+    return tencent_card_identity_matches_supply(payload_identity, card_supply)
 
 
 def card_supply_blocker_marker_present(value: Any) -> bool:
@@ -1078,7 +1138,10 @@ def reconcile_card_supply_for_training(
         tencent_internal_card_supply is not None
         and (
             (not training_did_run and card_supply_available_for_training(tencent_internal_card_supply))
-            or (training_did_run and training_payload_references_tencent_card(payload))
+            or (
+                training_did_run
+                and training_payload_matches_tencent_card_supply(payload, tencent_internal_card_supply)
+            )
         )
     ):
         return dict(tencent_internal_card_supply)

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -977,7 +977,7 @@ def reconcile_card_supply_for_training(
     embedded_supply = card_supply_from_training_payload(payload, latest_path)
     if training_did_run and embedded_supply is not None:
         return embedded_supply
-    if training_did_run and tencent_internal_card_supply is not None:
+    if tencent_internal_card_supply is not None:
         return dict(tencent_internal_card_supply)
     if training_did_run:
         return {

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -436,6 +436,8 @@ class Controller:
             "--scenario-id", getattr(self.args, "scenario_id", DEFAULT_SCENARIO_ID),
             "--output", str(card),
         ]
+        if self.args.training_approach == "policy_gradient":
+            cmd.append("--loop-a-policy-gradient-supply")
         if getattr(self.args, "require_multi_tier_scenario", False):
             cmd.append("--require-multi-tier-scenario")
         cp = self.run_cp(
@@ -483,7 +485,19 @@ class Controller:
             [sys.executable, "scripts/screeps_rl_experiment_card.py", "--validate", "--input", str(card)],
             timeout=60,
         )
-        self.result["experimentCard"] = {"path": str(card), "createdAt": created_at, "cardId": payload.get("card_id")}
+        experiment_card_summary = {
+            "path": str(card),
+            "createdAt": created_at,
+            "cardId": payload.get("card_id"),
+            "trainingApproach": payload.get("training_approach"),
+            "status": payload.get("status"),
+            "safety": payload.get("safety"),
+            "rewardModel": payload.get("reward_model"),
+        }
+        card_supply = payload.get("card_supply")
+        if isinstance(card_supply, dict):
+            experiment_card_summary["cardSupply"] = card_supply
+        self.result["experimentCard"] = experiment_card_summary
         if scale_environments is not None:
             self.write_scale_proof_spec(scale_environments=scale_environments, experiment_card=payload)
 
@@ -1450,8 +1464,11 @@ def build_scale_proof_spec(
         "experimentCardPath": str(experiment_card_path),
         "experimentCard": {
             "cardId": experiment_card.get("card_id"),
+            "trainingApproach": experiment_card.get("training_approach"),
             "status": experiment_card.get("status"),
             "safety": experiment_card.get("safety"),
+            "rewardModel": experiment_card.get("reward_model"),
+            "cardSupply": experiment_card.get("card_supply"),
             "scenario": experiment_card.get("scenario"),
         },
         "scaleProof": {

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -194,6 +194,51 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(policy["cardSupplyFinding"]["status"], "FALLBACK_DEGRADED")
         self.assertEqual(policy["cardSupplyFinding"]["severity"], "P2")
 
+    def test_non_tencent_training_run_without_embedded_supply_stays_degraded(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_dir = root / "tencent-cloud" / "batch-runs" / "tencent-pg-unrelated"
+            write_json(
+                run_dir / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-unrelated",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-accepted-123456789abc"}},
+                },
+            )
+            write_json(run_dir / "experiment_card.json", policy_gradient_card())
+            card_supply = dashboard.discover_tencent_internal_card_supply(
+                root,
+                warnings=[],
+                repo_root=root,
+            )
+            self.assertIsNotNone(card_supply)
+            assert card_supply is not None
+
+            training = dashboard.training_execution(
+                loaded_artifact(
+                    root / "rl-control-loop" / "training-ledger.json",
+                    {
+                        "type": "screeps-rl-training-execution-ledger",
+                        "status": "RUN_WITH_ANOMALY",
+                        "trainingDidRun": True,
+                        "artifactCount": 1,
+                        "trainingArtifacts": {
+                            "experimentCard": "Local standalone experiment card missing card supply",
+                            "experimentCardPath": "runtime-artifacts/rl-control-loop/experiment-card.json",
+                        },
+                    },
+                ),
+                tencent_internal_card_supply=card_supply,
+            )
+
+        self.assertEqual(training["cardSupply"]["status"], "DEGRADED")
+        self.assertEqual(
+            training["cardSupply"]["classification"],
+            "TRAINING_RAN_WITHOUT_STRUCTURED_CARD_SUPPLY_EVIDENCE",
+        )
+        self.assertEqual(training["cardSupply"]["severity"], "P2")
+
     def test_tencent_training_report_with_nested_safety_satisfies_card_supply(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -270,6 +315,55 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
             )
 
         self.assertIsNone(policy["cardSupplyFinding"])
+
+    def test_resolved_structured_evidence_window_does_not_create_card_supply_finding(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            policy = dashboard.policy_advantage(
+                loaded_artifact(
+                    root / "rl-control-loop" / "policy-advantage.json",
+                    {
+                        "type": "screeps-rl-policy-online-advantage-report",
+                        "onlineUtilityStatus": "UNPROVEN",
+                        "candidatePolicyId": "candidate",
+                        "baselinePolicyId": "incumbent",
+                        "evidenceWindows": {
+                            "loopACardPathStalledCycles": {"status": "resolved", "count": 0},
+                            "cardPipelineStalled": [{"status": "resolved"}, {"count": 0}],
+                        },
+                    },
+                ),
+                None,
+                training=None,
+            )
+
+        self.assertIsNone(policy["cardSupplyFinding"])
+
+    def test_active_nested_structured_evidence_window_creates_card_supply_finding(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            policy = dashboard.policy_advantage(
+                loaded_artifact(
+                    root / "rl-control-loop" / "policy-advantage.json",
+                    {
+                        "type": "screeps-rl-policy-online-advantage-report",
+                        "onlineUtilityStatus": "UNPROVEN",
+                        "candidatePolicyId": "candidate",
+                        "baselinePolicyId": "incumbent",
+                        "evidenceWindows": {
+                            "loopACardPathStalledCycles": {
+                                "history": [{"status": "resolved", "count": 0}],
+                                "current": {"count": 2},
+                            }
+                        },
+                    },
+                ),
+                None,
+                training=None,
+            )
+
+        self.assertEqual(policy["cardSupplyFinding"]["status"], "BLOCKED")
+        self.assertEqual(policy["cardSupplyFinding"]["severity"], "P0")
 
     def test_tencent_internal_card_evidence_requires_safety_fields(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -28,6 +28,9 @@ def policy_gradient_card(
     safe: bool = True,
     include_card_supply: bool = True,
     card_supply_state: str = "available",
+    card_id: str = "rl-exp-rl-accepted-123456789abc",
+    dataset_run_id: str = "rl-accepted",
+    created_at: str = "2026-05-18T10:35:11Z",
 ) -> JsonObject:
     safety = {
         "conservative_actions_only": safe,
@@ -37,11 +40,11 @@ def policy_gradient_card(
         "ood_rejection": safe,
     }
     card: JsonObject = {
-        "card_id": "rl-exp-rl-accepted-123456789abc",
+        "card_id": card_id,
         "code_commit": "1" * 40,
         "conservative_actions_only": safe,
-        "created_at": "2026-05-18T10:35:11Z",
-        "dataset_run_id": "rl-accepted",
+        "created_at": created_at,
+        "dataset_run_id": dataset_run_id,
         "liveEffect": False,
         "officialMmoWrites": False,
         "officialMmoWritesAllowed": False,
@@ -71,9 +74,9 @@ def policy_gradient_card(
             "consumer": "loop-a-policy-gradient",
             "state": card_supply_state,
             "available_for_training": available_for_training,
-            "dataset_run_id": card["dataset_run_id"],
+            "dataset_run_id": dataset_run_id,
             "training_approach": card["training_approach"],
-            "created_at": card["created_at"],
+            "created_at": created_at,
             "status_field": "status",
             "safety_status": "shadow",
             "consumed_at": consumed_at,
@@ -646,6 +649,251 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(card_supply["cardSupply"]["state"], "available")
         self.assertEqual(training["cardSupply"]["status"], "PRIMARY_SATISFIED")
         self.assertIsNone(training["blocker"])
+
+    def test_training_identity_matches_consumed_report_over_unrelated_available_run(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            available_run = root / "tencent-cloud" / "batch-runs" / "tencent-pg-available-a"
+            consumed_run = root / "tencent-cloud" / "batch-runs" / "tencent-pg-consumed-b"
+            write_json(
+                available_run / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-available-a",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-available-aaaaaaaaaaaa"}},
+                },
+            )
+            write_json(
+                available_run / "experiment_card.json",
+                policy_gradient_card(
+                    card_id="rl-exp-rl-available-aaaaaaaaaaaa",
+                    dataset_run_id="rl-available",
+                ),
+            )
+            write_json(
+                consumed_run / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-consumed-b",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-consumed-bbbbbbbbbbbb"}},
+                },
+            )
+            consumed_card = policy_gradient_card(
+                card_supply_state="consumed",
+                card_id="rl-exp-rl-consumed-bbbbbbbbbbbb",
+                dataset_run_id="rl-consumed",
+                created_at="2026-05-18T10:45:11Z",
+            )
+            write_json(
+                consumed_run / "remote" / "runtime-artifacts" / "rl-training" / "report-consumed.json",
+                {
+                    "type": "screeps-rl-training-execution-report",
+                    "reportId": "report-consumed-card",
+                    "status": "shadow",
+                    "safety": consumed_card["safety"],
+                    "experimentCard": consumed_card,
+                },
+            )
+
+            candidates = dashboard.discover_tencent_internal_card_supply_candidates(
+                root,
+                warnings=[],
+                repo_root=root,
+            )
+            training = dashboard.training_execution(
+                loaded_artifact(
+                    root / "rl-control-loop" / "training-ledger.json",
+                    {
+                        "type": "screeps-rl-training-execution-ledger",
+                        "status": "RUN",
+                        "trainingDidRun": True,
+                        "artifactCount": 1,
+                        "trainingArtifacts": {
+                            "tencentInternalCardSupply": {
+                                "runId": "tencent-pg-consumed-b",
+                                "cardId": "rl-exp-rl-consumed-bbbbbbbbbbbb",
+                                "datasetRunId": "rl-consumed",
+                            },
+                        },
+                    },
+                ),
+                tencent_internal_card_supply_candidates=candidates,
+            )
+
+        self.assertEqual(training["cardSupply"]["status"], "PRIMARY_SATISFIED")
+        self.assertEqual(training["cardSupply"]["runId"], "tencent-pg-consumed-b")
+        self.assertEqual(training["cardSupply"]["source"], "tencent_internal_training_report")
+        self.assertEqual(training["cardSupply"]["cardSupply"]["state"], "consumed")
+
+    def test_training_identity_prefers_consumed_report_over_stale_available_same_run_card(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_dir = root / "tencent-cloud" / "batch-runs" / "tencent-pg-same-card"
+            write_json(
+                run_dir / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-same-card",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-same-cccccccccccc"}},
+                },
+            )
+            write_json(
+                run_dir / "experiment_card.json",
+                policy_gradient_card(
+                    card_id="rl-exp-rl-same-cccccccccccc",
+                    dataset_run_id="rl-same",
+                    created_at="2026-05-18T10:35:11Z",
+                ),
+            )
+            consumed_card = policy_gradient_card(
+                card_supply_state="consumed",
+                card_id="rl-exp-rl-same-cccccccccccc",
+                dataset_run_id="rl-same",
+                created_at="2026-05-18T10:45:11Z",
+            )
+            write_json(
+                run_dir / "remote" / "runtime-artifacts" / "rl-training" / "report-consumed.json",
+                {
+                    "type": "screeps-rl-training-execution-report",
+                    "reportId": "report-consumed-card",
+                    "status": "shadow",
+                    "safety": consumed_card["safety"],
+                    "experimentCard": consumed_card,
+                },
+            )
+
+            candidates = dashboard.discover_tencent_internal_card_supply_candidates(
+                root,
+                warnings=[],
+                repo_root=root,
+            )
+            training = dashboard.training_execution(
+                loaded_artifact(
+                    root / "rl-control-loop" / "training-ledger.json",
+                    {
+                        "type": "screeps-rl-training-execution-ledger",
+                        "status": "RUN",
+                        "trainingDidRun": True,
+                        "artifactCount": 1,
+                        "trainingArtifacts": {
+                            "tencentInternalCardSupply": {
+                                "runId": "tencent-pg-same-card",
+                                "cardId": "rl-exp-rl-same-cccccccccccc",
+                                "datasetRunId": "rl-same",
+                            },
+                        },
+                    },
+                ),
+                tencent_internal_card_supply_candidates=candidates,
+            )
+
+        self.assertEqual(training["cardSupply"]["status"], "PRIMARY_SATISFIED")
+        self.assertEqual(training["cardSupply"]["source"], "tencent_internal_training_report")
+        self.assertEqual(training["cardSupply"]["cardSupply"]["state"], "consumed")
+
+    def test_not_run_candidate_list_prefers_available_over_consumed(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            available_run = root / "tencent-cloud" / "batch-runs" / "tencent-pg-available-a"
+            consumed_run = root / "tencent-cloud" / "batch-runs" / "tencent-pg-consumed-b"
+            write_json(
+                available_run / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-available-a",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-available-aaaaaaaaaaaa"}},
+                },
+            )
+            write_json(
+                available_run / "experiment_card.json",
+                policy_gradient_card(
+                    card_id="rl-exp-rl-available-aaaaaaaaaaaa",
+                    dataset_run_id="rl-available",
+                ),
+            )
+            write_json(
+                consumed_run / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-consumed-b",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-consumed-bbbbbbbbbbbb"}},
+                },
+            )
+            write_json(
+                consumed_run / "experiment_card.json",
+                policy_gradient_card(
+                    card_supply_state="consumed",
+                    card_id="rl-exp-rl-consumed-bbbbbbbbbbbb",
+                    dataset_run_id="rl-consumed",
+                    created_at="2026-05-18T10:45:11Z",
+                ),
+            )
+
+            candidates = dashboard.discover_tencent_internal_card_supply_candidates(
+                root,
+                warnings=[],
+                repo_root=root,
+            )
+            training = dashboard.training_execution(
+                loaded_artifact(
+                    root / "rl-control-loop" / "training-ledger.json",
+                    {
+                        "type": "screeps-rl-training-execution-ledger",
+                        "status": "NOT_RUN",
+                        "trainingDidRun": False,
+                        "trainingBlocker": "NO_UNCONSUMED_EXPERIMENT_CARD",
+                    },
+                ),
+                tencent_internal_card_supply_candidates=candidates,
+            )
+
+        self.assertEqual(training["cardSupply"]["status"], "PRIMARY_SATISFIED")
+        self.assertEqual(training["cardSupply"]["runId"], "tencent-pg-available-a")
+        self.assertEqual(training["cardSupply"]["cardSupply"]["state"], "available")
+        self.assertIsNone(training["blocker"])
+
+    def test_not_run_candidate_list_consumed_only_stays_blocked(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_dir = root / "tencent-cloud" / "batch-runs" / "tencent-pg-consumed-only"
+            write_json(
+                run_dir / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-consumed-only",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-consumed-bbbbbbbbbbbb"}},
+                },
+            )
+            write_json(
+                run_dir / "experiment_card.json",
+                policy_gradient_card(
+                    card_supply_state="consumed",
+                    card_id="rl-exp-rl-consumed-bbbbbbbbbbbb",
+                    dataset_run_id="rl-consumed",
+                ),
+            )
+
+            candidates = dashboard.discover_tencent_internal_card_supply_candidates(
+                root,
+                warnings=[],
+                repo_root=root,
+            )
+            training = dashboard.training_execution(
+                loaded_artifact(
+                    root / "rl-control-loop" / "training-ledger.json",
+                    {
+                        "type": "screeps-rl-training-execution-ledger",
+                        "status": "NOT_RUN",
+                        "trainingDidRun": False,
+                        "trainingBlocker": "NO_UNCONSUMED_EXPERIMENT_CARD",
+                    },
+                ),
+                tencent_internal_card_supply_candidates=candidates,
+            )
+
+        self.assertEqual(training["cardSupply"]["status"], "BLOCKED")
+        self.assertEqual(training["cardSupply"]["severity"], "P0")
+        self.assertEqual(training["blocker"], "NO_UNCONSUMED_EXPERIMENT_CARD")
 
     def test_non_tencent_training_run_without_embedded_supply_stays_degraded(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -190,8 +190,44 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(training["status"], "NOT_RUN")
         self.assertEqual(training["cardSupply"]["status"], "PRIMARY_SATISFIED")
         self.assertEqual(training["cardSupply"]["severity"], "OK")
+        self.assertIsNone(training["blocker"])
         self.assertEqual(policy["cardSupplyFinding"]["status"], "FALLBACK_DEGRADED")
         self.assertEqual(policy["cardSupplyFinding"]["severity"], "P2")
+
+    def test_tencent_training_report_with_nested_safety_satisfies_card_supply(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_dir = root / "tencent-cloud" / "batch-runs" / "tencent-pg-report"
+            write_json(
+                run_dir / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-report",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-accepted-123456789abc"}},
+                },
+            )
+            card = policy_gradient_card()
+            write_json(
+                run_dir / "remote" / "runtime-artifacts" / "rl-training" / "report.json",
+                {
+                    "type": "screeps-rl-training-execution-report",
+                    "reportId": "report-nested-safety",
+                    "status": "shadow",
+                    "safety": card["safety"],
+                    "experimentCard": card,
+                },
+            )
+
+            card_supply = dashboard.discover_tencent_internal_card_supply(
+                root,
+                warnings=[],
+                repo_root=root,
+            )
+
+        self.assertIsNotNone(card_supply)
+        assert card_supply is not None
+        self.assertEqual(card_supply["source"], "tencent_internal_training_report")
+        self.assertEqual(card_supply["status"], "PRIMARY_SATISFIED")
 
     def test_missing_training_and_card_evidence_keeps_card_supply_blocker(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -212,6 +248,28 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(training["cardSupply"]["status"], "BLOCKED")
         self.assertEqual(training["cardSupply"]["severity"], "P0")
         self.assertEqual(training["blocker"], "NO_UNCONSUMED_EXPERIMENT_CARD")
+
+    def test_policy_history_text_does_not_create_card_supply_finding(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            policy = dashboard.policy_advantage(
+                loaded_artifact(
+                    root / "rl-control-loop" / "policy-advantage.json",
+                    {
+                        "type": "screeps-rl-policy-online-advantage-report",
+                        "onlineUtilityStatus": "UNPROVEN",
+                        "candidatePolicyId": "candidate",
+                        "baselinePolicyId": "incumbent",
+                        "notes": [
+                            "Resolved prior standaloneExperimentCard cardPipelineStalled finding after Tencent supply."
+                        ],
+                    },
+                ),
+                None,
+                training=None,
+            )
+
+        self.assertIsNone(policy["cardSupplyFinding"])
 
     def test_tencent_internal_card_evidence_requires_safety_fields(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -201,6 +201,57 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         )
         self.assertNotEqual(training["cardSupply"].get("source"), "tencent_internal_experiment_card")
 
+    def test_matching_tencent_identity_ignores_unrelated_historical_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_dir = root / "tencent-cloud" / "batch-runs" / "tencent-pg-current"
+            write_json(
+                run_dir / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-current",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-accepted-123456789abc"}},
+                },
+            )
+            write_json(run_dir / "experiment_card.json", policy_gradient_card())
+            card_supply = dashboard.discover_tencent_internal_card_supply(
+                root,
+                warnings=[],
+                repo_root=root,
+            )
+            self.assertIsNotNone(card_supply)
+            assert card_supply is not None
+
+            training = dashboard.training_execution(
+                loaded_artifact(
+                    root / "rl-control-loop" / "training-ledger.json",
+                    {
+                        "type": "screeps-rl-training-execution-ledger",
+                        "status": "RUN_WITH_ANOMALY",
+                        "trainingDidRun": True,
+                        "artifactCount": 1,
+                        "trainingArtifacts": {
+                            "tencentInternalCardSupply": {
+                                "runId": "tencent-pg-current",
+                                "cardId": "rl-exp-rl-accepted-123456789abc",
+                                "datasetRunId": "rl-accepted",
+                            },
+                            "historicalArtifacts": [
+                                {
+                                    "runId": "tencent-pg-historical",
+                                    "cardId": "rl-exp-rl-old-000000000000",
+                                    "datasetRunId": "rl-old",
+                                }
+                            ],
+                        },
+                    },
+                ),
+                tencent_internal_card_supply=card_supply,
+            )
+
+        self.assertEqual(training["cardSupply"]["status"], "PRIMARY_SATISFIED")
+        self.assertEqual(training["cardSupply"]["source"], "tencent_internal_experiment_card")
+
     def test_mismatched_tencent_training_identity_does_not_borrow_latest_card_supply(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -352,6 +403,47 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(policy["cardSupplyFinding"]["status"], "FALLBACK_DEGRADED")
         self.assertEqual(policy["cardSupplyFinding"]["severity"], "P2")
 
+    def test_legacy_metadata_less_tencent_card_satisfies_not_run_training_ledger(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_dir = root / "tencent-cloud" / "batch-runs" / "tencent-pg-legacy"
+            write_json(
+                run_dir / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-legacy",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-accepted-123456789abc"}},
+                },
+            )
+            write_json(run_dir / "experiment_card.json", policy_gradient_card(include_card_supply=False))
+
+            card_supply = dashboard.discover_tencent_internal_card_supply(
+                root,
+                warnings=[],
+                repo_root=root,
+            )
+            self.assertIsNotNone(card_supply)
+            assert card_supply is not None
+
+            training = dashboard.training_execution(
+                loaded_artifact(
+                    root / "rl-control-loop" / "training-ledger.json",
+                    {
+                        "type": "screeps-rl-training-execution-ledger",
+                        "status": "NOT_RUN",
+                        "trainingDidRun": False,
+                        "trainingBlocker": "NO_UNCONSUMED_EXPERIMENT_CARD",
+                    },
+                ),
+                tencent_internal_card_supply=card_supply,
+            )
+
+        self.assertEqual(card_supply["hasLoopACardSupplyMetadata"], False)
+        self.assertEqual(training["status"], "NOT_RUN")
+        self.assertEqual(training["cardSupply"]["status"], "PRIMARY_SATISFIED")
+        self.assertEqual(training["cardSupply"]["severity"], "OK")
+        self.assertIsNone(training["blocker"])
+
     def test_consumed_tencent_card_does_not_clear_not_run_card_blocker(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -407,6 +499,101 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(training["blocker"], "NO_UNCONSUMED_EXPERIMENT_CARD")
         self.assertEqual(policy["cardSupplyFinding"]["status"], "BLOCKED")
         self.assertEqual(policy["cardSupplyFinding"]["severity"], "P0")
+
+    def test_single_run_candidate_selection_prefers_available_card_over_later_consumed_report(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_dir = root / "tencent-cloud" / "batch-runs" / "tencent-pg-mixed"
+            write_json(
+                run_dir / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-mixed",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-accepted-123456789abc"}},
+                },
+            )
+            write_json(run_dir / "experiment_card.json", policy_gradient_card())
+            consumed_card = policy_gradient_card(card_supply_state="consumed")
+            consumed_card["created_at"] = "2026-05-18T10:45:11Z"
+            consumed_card["card_supply"]["created_at"] = consumed_card["created_at"]
+            write_json(
+                run_dir / "remote" / "runtime-artifacts" / "rl-training" / "report-consumed.json",
+                {
+                    "type": "screeps-rl-training-execution-report",
+                    "reportId": "report-consumed-card",
+                    "status": "shadow",
+                    "safety": consumed_card["safety"],
+                    "experimentCard": consumed_card,
+                },
+            )
+
+            card_supply = dashboard.discover_tencent_internal_card_supply(
+                root,
+                warnings=[],
+                repo_root=root,
+            )
+
+        self.assertIsNotNone(card_supply)
+        assert card_supply is not None
+        self.assertEqual(card_supply["runId"], "tencent-pg-mixed")
+        self.assertEqual(card_supply["source"], "tencent_internal_experiment_card")
+        self.assertEqual(card_supply["cardSupply"]["state"], "available")
+
+    def test_single_run_legacy_card_beats_later_consumed_report_for_not_run(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_dir = root / "tencent-cloud" / "batch-runs" / "tencent-pg-legacy-mixed"
+            write_json(
+                run_dir / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-legacy-mixed",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-accepted-123456789abc"}},
+                },
+            )
+            write_json(run_dir / "experiment_card.json", policy_gradient_card(include_card_supply=False))
+            consumed_card = policy_gradient_card(card_supply_state="consumed")
+            consumed_card["created_at"] = "2026-05-18T10:45:11Z"
+            consumed_card["card_supply"]["created_at"] = consumed_card["created_at"]
+            write_json(
+                run_dir / "remote" / "runtime-artifacts" / "rl-training" / "report-consumed.json",
+                {
+                    "type": "screeps-rl-training-execution-report",
+                    "reportId": "report-consumed-card",
+                    "status": "shadow",
+                    "safety": consumed_card["safety"],
+                    "experimentCard": consumed_card,
+                },
+            )
+
+            card_supply = dashboard.discover_tencent_internal_card_supply(
+                root,
+                warnings=[],
+                repo_root=root,
+            )
+            self.assertIsNotNone(card_supply)
+            assert card_supply is not None
+
+            training = dashboard.training_execution(
+                loaded_artifact(
+                    root / "rl-control-loop" / "training-ledger.json",
+                    {
+                        "type": "screeps-rl-training-execution-ledger",
+                        "status": "NOT_RUN",
+                        "trainingDidRun": False,
+                        "trainingBlocker": "NO_UNCONSUMED_EXPERIMENT_CARD",
+                    },
+                ),
+                tencent_internal_card_supply=card_supply,
+            )
+
+        self.assertEqual(card_supply["source"], "tencent_internal_experiment_card")
+        self.assertEqual(card_supply["hasLoopACardSupplyMetadata"], False)
+        self.assertNotIn("cardSupply", card_supply)
+        self.assertEqual(training["status"], "NOT_RUN")
+        self.assertEqual(training["cardSupply"]["status"], "PRIMARY_SATISFIED")
+        self.assertEqual(training["cardSupply"]["severity"], "OK")
+        self.assertIsNone(training["blocker"])
 
     def test_discovery_prefers_available_card_supply_over_newer_consumed_card(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -264,6 +264,58 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(policy["cardSupplyFinding"]["status"], "BLOCKED")
         self.assertEqual(policy["cardSupplyFinding"]["severity"], "P0")
 
+    def test_discovery_prefers_available_card_supply_over_newer_consumed_card(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            older_run = root / "tencent-cloud" / "batch-runs" / "tencent-pg-older-available"
+            newer_run = root / "tencent-cloud" / "batch-runs" / "tencent-pg-newer-consumed"
+            write_json(
+                older_run / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-older-available",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-accepted-123456789abc"}},
+                },
+            )
+            write_json(older_run / "experiment_card.json", policy_gradient_card())
+            newer_card = policy_gradient_card(card_supply_state="consumed")
+            newer_card["created_at"] = "2026-05-18T10:45:11Z"
+            newer_card["card_supply"]["created_at"] = newer_card["created_at"]
+            write_json(
+                newer_run / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-newer-consumed",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-accepted-123456789abc"}},
+                },
+            )
+            write_json(newer_run / "experiment_card.json", newer_card)
+
+            card_supply = dashboard.discover_tencent_internal_card_supply(
+                root,
+                warnings=[],
+                repo_root=root,
+            )
+            self.assertIsNotNone(card_supply)
+            assert card_supply is not None
+            training = dashboard.training_execution(
+                loaded_artifact(
+                    root / "rl-control-loop" / "training-ledger.json",
+                    {
+                        "type": "screeps-rl-training-execution-ledger",
+                        "status": "NOT_RUN",
+                        "trainingDidRun": False,
+                        "trainingBlocker": "NO_UNCONSUMED_EXPERIMENT_CARD",
+                    },
+                ),
+                tencent_internal_card_supply=card_supply,
+            )
+
+        self.assertEqual(card_supply["runId"], "tencent-pg-older-available")
+        self.assertEqual(card_supply["cardSupply"]["state"], "available")
+        self.assertEqual(training["cardSupply"]["status"], "PRIMARY_SATISFIED")
+        self.assertIsNone(training["blocker"])
+
     def test_non_tencent_training_run_without_embedded_supply_stays_degraded(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -23,7 +23,12 @@ def write_json(path: Path, payload: JsonObject) -> None:
     path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
 
 
-def policy_gradient_card(*, safe: bool = True, include_card_supply: bool = True) -> JsonObject:
+def policy_gradient_card(
+    *,
+    safe: bool = True,
+    include_card_supply: bool = True,
+    card_supply_state: str = "available",
+) -> JsonObject:
     safety = {
         "conservative_actions_only": safe,
         "liveEffect": False,
@@ -52,18 +57,27 @@ def policy_gradient_card(*, safe: bool = True, include_card_supply: bool = True)
         "training_approach": "policy_gradient",
     }
     if include_card_supply:
+        consumed_at = None
+        consumed_by_report_id = None
+        available_for_training = True
+        if card_supply_state == "consumed":
+            consumed_at = "2026-05-18T10:38:11Z"
+            consumed_by_report_id = "report-consumed-card"
+            available_for_training = False
+        elif card_supply_state != "available":
+            raise ValueError(f"unknown card_supply_state: {card_supply_state}")
         card["card_supply"] = {
             "type": "screeps-rl-loop-a-card-supply",
             "consumer": "loop-a-policy-gradient",
-            "state": "available",
-            "available_for_training": True,
+            "state": card_supply_state,
+            "available_for_training": available_for_training,
             "dataset_run_id": card["dataset_run_id"],
             "training_approach": card["training_approach"],
             "created_at": card["created_at"],
             "status_field": "status",
             "safety_status": "shadow",
-            "consumed_at": None,
-            "consumed_by_report_id": None,
+            "consumed_at": consumed_at,
+            "consumed_by_report_id": consumed_by_report_id,
         }
     return card
 
@@ -193,6 +207,62 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertIsNone(training["blocker"])
         self.assertEqual(policy["cardSupplyFinding"]["status"], "FALLBACK_DEGRADED")
         self.assertEqual(policy["cardSupplyFinding"]["severity"], "P2")
+
+    def test_consumed_tencent_card_does_not_clear_not_run_card_blocker(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_dir = root / "tencent-cloud" / "batch-runs" / "tencent-pg-consumed"
+            write_json(
+                run_dir / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-consumed",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-accepted-123456789abc"}},
+                },
+            )
+            write_json(run_dir / "experiment_card.json", policy_gradient_card(card_supply_state="consumed"))
+
+            card_supply = dashboard.discover_tencent_internal_card_supply(
+                root,
+                warnings=[],
+                repo_root=root,
+            )
+            self.assertIsNotNone(card_supply)
+            assert card_supply is not None
+
+            training = dashboard.training_execution(
+                loaded_artifact(
+                    root / "rl-control-loop" / "training-ledger.json",
+                    {
+                        "type": "screeps-rl-training-execution-ledger",
+                        "status": "NOT_RUN",
+                        "trainingDidRun": False,
+                        "trainingBlocker": "NO_UNCONSUMED_EXPERIMENT_CARD",
+                    },
+                ),
+                tencent_internal_card_supply=card_supply,
+            )
+            policy = dashboard.policy_advantage(
+                loaded_artifact(
+                    root / "rl-control-loop" / "policy-advantage.json",
+                    {
+                        "type": "screeps-rl-policy-online-advantage-report",
+                        "onlineUtilityStatus": "UNPROVEN",
+                        "candidatePolicyId": "NO_STABLE_CANDIDATE",
+                        "baselinePolicyId": "incumbent",
+                        "evidenceWindows": {"loopACardPathStalledCycles": 17},
+                    },
+                ),
+                None,
+                training=training,
+            )
+
+        self.assertEqual(training["status"], "NOT_RUN")
+        self.assertEqual(training["cardSupply"]["status"], "BLOCKED")
+        self.assertEqual(training["cardSupply"]["severity"], "P0")
+        self.assertEqual(training["blocker"], "NO_UNCONSUMED_EXPERIMENT_CARD")
+        self.assertEqual(policy["cardSupplyFinding"]["status"], "BLOCKED")
+        self.assertEqual(policy["cardSupplyFinding"]["severity"], "P0")
 
     def test_non_tencent_training_run_without_embedded_supply_stays_degraded(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -123,7 +123,11 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
                         "status": "RUN_WITH_ANOMALY",
                         "trainingDidRun": True,
                         "trainingArtifacts": {
-                            "experimentCard": "Tencent batch generates internal cards per run",
+                            "tencentInternalCardSupply": {
+                                "runId": "tencent-pg-test",
+                                "cardId": "rl-exp-rl-accepted-123456789abc",
+                                "datasetRunId": "rl-accepted",
+                            },
                             "experimentCardPath": None,
                         },
                     },
@@ -151,6 +155,146 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertNotEqual(training["cardSupply"]["severity"], "P0")
         self.assertEqual(policy["cardSupplyFinding"]["status"], "FALLBACK_DEGRADED")
         self.assertEqual(policy["cardSupplyFinding"]["severity"], "P2")
+
+    def test_generic_tencent_training_text_does_not_borrow_latest_card_supply(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_dir = root / "tencent-cloud" / "batch-runs" / "tencent-pg-generic"
+            write_json(
+                run_dir / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-generic",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-accepted-123456789abc"}},
+                },
+            )
+            write_json(run_dir / "experiment_card.json", policy_gradient_card())
+            card_supply = dashboard.discover_tencent_internal_card_supply(
+                root,
+                warnings=[],
+                repo_root=root,
+            )
+            self.assertIsNotNone(card_supply)
+            assert card_supply is not None
+
+            training = dashboard.training_execution(
+                loaded_artifact(
+                    root / "rl-control-loop" / "training-ledger.json",
+                    {
+                        "type": "screeps-rl-training-execution-ledger",
+                        "status": "RUN_WITH_ANOMALY",
+                        "trainingDidRun": True,
+                        "artifactCount": 1,
+                        "trainingArtifacts": {
+                            "experimentCard": "Tencent batch generates internal cards per run",
+                            "experimentCardPath": None,
+                        },
+                    },
+                ),
+                tencent_internal_card_supply=card_supply,
+            )
+
+        self.assertEqual(training["cardSupply"]["status"], "DEGRADED")
+        self.assertEqual(
+            training["cardSupply"]["classification"],
+            "TRAINING_RAN_WITHOUT_STRUCTURED_CARD_SUPPLY_EVIDENCE",
+        )
+        self.assertNotEqual(training["cardSupply"].get("source"), "tencent_internal_experiment_card")
+
+    def test_mismatched_tencent_training_identity_does_not_borrow_latest_card_supply(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_dir = root / "tencent-cloud" / "batch-runs" / "tencent-pg-latest"
+            write_json(
+                run_dir / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-latest",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-accepted-123456789abc"}},
+                },
+            )
+            write_json(run_dir / "experiment_card.json", policy_gradient_card())
+            card_supply = dashboard.discover_tencent_internal_card_supply(
+                root,
+                warnings=[],
+                repo_root=root,
+            )
+            self.assertIsNotNone(card_supply)
+            assert card_supply is not None
+
+            training = dashboard.training_execution(
+                loaded_artifact(
+                    root / "rl-control-loop" / "training-ledger.json",
+                    {
+                        "type": "screeps-rl-training-execution-ledger",
+                        "status": "RUN_WITH_ANOMALY",
+                        "trainingDidRun": True,
+                        "artifactCount": 1,
+                        "trainingArtifacts": {
+                            "tencentInternalCardSupply": {
+                                "runId": "tencent-pg-different",
+                                "cardId": "rl-exp-rl-accepted-123456789abc",
+                                "datasetRunId": "rl-accepted",
+                            },
+                        },
+                    },
+                ),
+                tencent_internal_card_supply=card_supply,
+            )
+
+        self.assertEqual(training["cardSupply"]["status"], "DEGRADED")
+        self.assertEqual(
+            training["cardSupply"]["classification"],
+            "TRAINING_RAN_WITHOUT_STRUCTURED_CARD_SUPPLY_EVIDENCE",
+        )
+        self.assertNotEqual(training["cardSupply"].get("source"), "tencent_internal_experiment_card")
+
+    def test_partial_tencent_training_identity_does_not_borrow_latest_card_supply(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_dir = root / "tencent-cloud" / "batch-runs" / "tencent-pg-partial"
+            write_json(
+                run_dir / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-partial",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-accepted-123456789abc"}},
+                },
+            )
+            write_json(run_dir / "experiment_card.json", policy_gradient_card())
+            card_supply = dashboard.discover_tencent_internal_card_supply(
+                root,
+                warnings=[],
+                repo_root=root,
+            )
+            self.assertIsNotNone(card_supply)
+            assert card_supply is not None
+
+            training = dashboard.training_execution(
+                loaded_artifact(
+                    root / "rl-control-loop" / "training-ledger.json",
+                    {
+                        "type": "screeps-rl-training-execution-ledger",
+                        "status": "RUN_WITH_ANOMALY",
+                        "trainingDidRun": True,
+                        "artifactCount": 1,
+                        "trainingArtifacts": {
+                            "tencentInternalCardSupply": {
+                                "runId": "tencent-pg-partial",
+                                "cardId": "rl-exp-rl-accepted-123456789abc",
+                            },
+                        },
+                    },
+                ),
+                tencent_internal_card_supply=card_supply,
+            )
+
+        self.assertEqual(training["cardSupply"]["status"], "DEGRADED")
+        self.assertEqual(
+            training["cardSupply"]["classification"],
+            "TRAINING_RAN_WITHOUT_STRUCTURED_CARD_SUPPLY_EVIDENCE",
+        )
+        self.assertNotEqual(training["cardSupply"].get("source"), "tencent_internal_experiment_card")
 
     def test_tencent_internal_card_satisfies_stale_not_run_training_ledger(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -138,6 +138,61 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(policy["cardSupplyFinding"]["status"], "FALLBACK_DEGRADED")
         self.assertEqual(policy["cardSupplyFinding"]["severity"], "P2")
 
+    def test_tencent_internal_card_satisfies_stale_not_run_training_ledger(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_dir = root / "tencent-cloud" / "batch-runs" / "tencent-pg-stale"
+            write_json(
+                run_dir / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-stale",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-accepted-123456789abc"}},
+                },
+            )
+            write_json(run_dir / "experiment_card.json", policy_gradient_card())
+
+            card_supply = dashboard.discover_tencent_internal_card_supply(
+                root,
+                warnings=[],
+                repo_root=root,
+            )
+            self.assertIsNotNone(card_supply)
+            assert card_supply is not None
+
+            training = dashboard.training_execution(
+                loaded_artifact(
+                    root / "rl-control-loop" / "training-ledger.json",
+                    {
+                        "type": "screeps-rl-training-execution-ledger",
+                        "status": "NOT_RUN",
+                        "trainingDidRun": False,
+                        "trainingBlocker": "NO_UNCONSUMED_EXPERIMENT_CARD",
+                    },
+                ),
+                tencent_internal_card_supply=card_supply,
+            )
+            policy = dashboard.policy_advantage(
+                loaded_artifact(
+                    root / "rl-control-loop" / "policy-advantage.json",
+                    {
+                        "type": "screeps-rl-policy-online-advantage-report",
+                        "onlineUtilityStatus": "UNPROVEN",
+                        "candidatePolicyId": "NO_STABLE_CANDIDATE",
+                        "baselinePolicyId": "incumbent",
+                        "evidenceWindows": {"loopACardPathStalledCycles": 17},
+                    },
+                ),
+                None,
+                training=training,
+            )
+
+        self.assertEqual(training["status"], "NOT_RUN")
+        self.assertEqual(training["cardSupply"]["status"], "PRIMARY_SATISFIED")
+        self.assertEqual(training["cardSupply"]["severity"], "OK")
+        self.assertEqual(policy["cardSupplyFinding"]["status"], "FALLBACK_DEGRADED")
+        self.assertEqual(policy["cardSupplyFinding"]["severity"], "P2")
+
     def test_missing_training_and_card_evidence_keeps_card_supply_blocker(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import screeps_rl_dashboard as dashboard
+
+
+JsonObject = dict[str, Any]
+
+
+def write_json(path: Path, payload: JsonObject) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
+
+def policy_gradient_card(*, safe: bool = True, include_card_supply: bool = True) -> JsonObject:
+    safety = {
+        "conservative_actions_only": safe,
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+        "ood_rejection": safe,
+    }
+    card: JsonObject = {
+        "card_id": "rl-exp-rl-accepted-123456789abc",
+        "code_commit": "1" * 40,
+        "conservative_actions_only": safe,
+        "created_at": "2026-05-18T10:35:11Z",
+        "dataset_run_id": "rl-accepted",
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+        "ood_rejection": safe,
+        "policy_gradient": {"target_family": "construction-priority"},
+        "reward_model": {
+            "component_order": ["reliability", "territory", "resources", "kills"],
+            "scalar_weighted_sum_authorized": False,
+            "type": "lexicographic",
+        },
+        "safety": safety,
+        "status": "shadow",
+        "training_approach": "policy_gradient",
+    }
+    if include_card_supply:
+        card["card_supply"] = {
+            "type": "screeps-rl-loop-a-card-supply",
+            "consumer": "loop-a-policy-gradient",
+            "state": "available",
+            "available_for_training": True,
+            "dataset_run_id": card["dataset_run_id"],
+            "training_approach": card["training_approach"],
+            "created_at": card["created_at"],
+            "status_field": "status",
+            "safety_status": "shadow",
+            "consumed_at": None,
+            "consumed_by_report_id": None,
+        }
+    return card
+
+
+def loaded_artifact(path: Path, payload: JsonObject) -> dashboard.LoadedArtifact:
+    return dashboard.LoadedArtifact(
+        path=path,
+        payload=payload,
+        timestamp=datetime(2026, 5, 18, 10, 40, 0, tzinfo=timezone.utc),
+    )
+
+
+class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
+    def test_tencent_internal_card_downgrades_standalone_stall_to_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_dir = root / "tencent-cloud" / "batch-runs" / "tencent-pg-test"
+            write_json(
+                run_dir / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-test",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-accepted-123456789abc"}},
+                },
+            )
+            write_json(run_dir / "experiment_card.json", policy_gradient_card())
+
+            warnings: list[str] = []
+            card_supply = dashboard.discover_tencent_internal_card_supply(
+                root,
+                warnings=warnings,
+                repo_root=root,
+            )
+            self.assertEqual(warnings, [])
+            self.assertIsNotNone(card_supply)
+            assert card_supply is not None
+
+            training = dashboard.training_execution(
+                loaded_artifact(
+                    root / "rl-control-loop" / "training-ledger.json",
+                    {
+                        "type": "screeps-rl-training-execution-ledger",
+                        "status": "RUN_WITH_ANOMALY",
+                        "trainingDidRun": True,
+                        "trainingArtifacts": {
+                            "experimentCard": "Tencent batch generates internal cards per run",
+                            "experimentCardPath": None,
+                        },
+                    },
+                ),
+                tencent_internal_card_supply=card_supply,
+            )
+            policy = dashboard.policy_advantage(
+                loaded_artifact(
+                    root / "rl-control-loop" / "policy-advantage.json",
+                    {
+                        "type": "screeps-rl-policy-online-advantage-report",
+                        "onlineUtilityStatus": "UNPROVEN",
+                        "candidatePolicyId": "NO_STABLE_CANDIDATE",
+                        "baselinePolicyId": "incumbent",
+                        "evidenceWindows": {"loopACardPathStalledCycles": 17},
+                    },
+                ),
+                None,
+                training=training,
+            )
+
+        self.assertEqual(training["cardSupply"]["status"], "PRIMARY_SATISFIED")
+        self.assertEqual(training["cardSupply"]["fallbackStatus"], "DEGRADED")
+        self.assertEqual(training["cardSupply"]["fallbackSeverity"], "P2")
+        self.assertNotEqual(training["cardSupply"]["severity"], "P0")
+        self.assertEqual(policy["cardSupplyFinding"]["status"], "FALLBACK_DEGRADED")
+        self.assertEqual(policy["cardSupplyFinding"]["severity"], "P2")
+
+    def test_missing_training_and_card_evidence_keeps_card_supply_blocker(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            training = dashboard.training_execution(
+                loaded_artifact(
+                    root / "rl-control-loop" / "training-ledger.json",
+                    {
+                        "type": "screeps-rl-training-execution-ledger",
+                        "status": "NOT_RUN",
+                        "trainingDidRun": False,
+                        "trainingBlocker": "NO_UNCONSUMED_EXPERIMENT_CARD",
+                    },
+                ),
+                tencent_internal_card_supply=None,
+            )
+
+        self.assertEqual(training["cardSupply"]["status"], "BLOCKED")
+        self.assertEqual(training["cardSupply"]["severity"], "P0")
+        self.assertEqual(training["blocker"], "NO_UNCONSUMED_EXPERIMENT_CARD")
+
+    def test_tencent_internal_card_evidence_requires_safety_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_dir = root / "tencent-cloud" / "batch-runs" / "tencent-pg-unsafe"
+            write_json(
+                run_dir / "controller-summary.json",
+                {"type": "screeps-tencent-batch-rl-run", "runId": "tencent-pg-unsafe"},
+            )
+            write_json(run_dir / "experiment_card.json", policy_gradient_card(safe=False))
+
+            card_supply = dashboard.discover_tencent_internal_card_supply(
+                root,
+                warnings=[],
+                repo_root=root,
+            )
+
+        self.assertIsNone(card_supply)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -936,12 +936,28 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             controller = runner.Controller(args=args, run_id="run-test", artifact_dir=root)
+            observed_cmds: list[list[str]] = []
 
             def fake_run_cp(name: str, cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                observed_cmds.append(cmd)
                 if name == "generate_experiment_card":
                     output = Path(cmd[cmd.index("--output") + 1])
                     payload = generated_experiment_card()
                     payload["training_approach"] = "policy_gradient"
+                    if "--loop-a-policy-gradient-supply" in cmd:
+                        payload["card_supply"] = {
+                            "type": "screeps-rl-loop-a-card-supply",
+                            "consumer": "loop-a-policy-gradient",
+                            "state": "available",
+                            "available_for_training": True,
+                            "dataset_run_id": payload["dataset_run_id"],
+                            "training_approach": payload["training_approach"],
+                            "created_at": payload["created_at"],
+                            "status_field": "status",
+                            "safety_status": "shadow",
+                            "consumed_at": None,
+                            "consumed_by_report_id": None,
+                        }
                     payload["simulation"]["ticks"] = 100
                     payload["simulation"]["workers"] = 1
                     payload["simulation"]["repetitions"] = 1
@@ -955,11 +971,18 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             spec = json.loads((root / "scale_proof_spec.json").read_text(encoding="utf-8"))
 
         self.assertEqual(card["training_approach"], "policy_gradient")
+        self.assertIn("--loop-a-policy-gradient-supply", observed_cmds[0])
+        self.assertEqual(card["card_supply"]["type"], "screeps-rl-loop-a-card-supply")
+        self.assertEqual(card["card_supply"]["consumer"], "loop-a-policy-gradient")
+        self.assertTrue(card["card_supply"]["available_for_training"])
         self.assertEqual(card["simulation"]["ticks"], 500)
         self.assertEqual(card["simulation"]["workers"], 5)
         self.assertEqual(card["simulation"]["repetitions"], 5)
         self.assertFalse(card["officialMmoWrites"])
         self.assertFalse(card["officialMmoWritesAllowed"])
+        self.assertEqual(controller.result["experimentCard"]["trainingApproach"], "policy_gradient")
+        self.assertEqual(controller.result["experimentCard"]["cardSupply"]["state"], "available")
+        self.assertEqual(spec["experimentCard"]["cardSupply"]["state"], "available")
         self.assertEqual(spec["scaleProof"]["remoteRunnerContract"]["cardSimulationFields"]["ticks"], 500)
 
     def test_generate_experiment_card_passes_multi_tier_scenario_request(self) -> None:


### PR DESCRIPTION
## Summary
- Teach the RL dashboard to treat valid Tencent internal policy-gradient experiment cards/training reports as the primary Loop A card-supply evidence.
- Downgrade standalone-card absence to fallback degradation when Tencent internal card supply is present, instead of leaving it as a P0 blocker.
- Add card-supply metadata to Tencent batch-generated experiment cards and cover safe/unsafe evidence paths in tests.

Closes #1194

## Verification
- `python3 -m py_compile scripts/screeps_rl_dashboard.py scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_rl_dashboard.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m pytest scripts/test_screeps_rl_dashboard.py scripts/test_screeps_tencent_batch_rl_runner.py -q` — 50 passed, 47 subtests passed
- `git diff --check`
- `python3 scripts/screeps_rl_dashboard.py --repo-root /root/screeps-worktrees/issue-1194-card-supply --artifact-root /root/screeps/runtime-artifacts --output /tmp/rl-dashboard-1194.html` — PASS; output contains `PRIMARY_SATISFIED`

## Safety
- Offline/RL observability only; no official MMO writes and no live learned-policy control.
- Existing strict card safety checks remain required before Tencent internal card evidence is accepted.