### PR TITLE
fix(rl): route policy-gradient proof to multi-tier scenario

### DIFF
--- a/docs/ops/rl-training-reward-workflow.md
+++ b/docs/ops/rl-training-reward-workflow.md
@@ -51,8 +51,15 @@ summary to stdout. Policy-gradient fallback cards are generated at a 500-tick fl
 
 ```bash
 python3 scripts/screeps_rl_experiment_card.py \
-  --loop-a-local-fallback
+  --loop-a-local-fallback \
+  --scenario-id multi-tier-territory-combat-v0 \
+  --require-multi-tier-scenario
 ```
+
+Loop A policy-gradient proof card generation defaults to the multi-tier scenario and rejects an
+explicit E1S1 single-room fallback. Its card must reference
+`scripts/fixtures/rl/multi-tier-territory-combat-v0.map.json` and expose adjacent-room hostile
+fixture counts.
 
 Validate an existing card:
 

--- a/docs/ops/tencent-batch-rl-runbook.md
+++ b/docs/ops/tencent-batch-rl-runbook.md
@@ -24,17 +24,27 @@ Preflight, without creating a worker:
 ```bash
 cd /root/screeps
 python3 scripts/screeps_tencent_batch_rl_runner.py preflight \
-  --run-id tencent-single-preflight-$(date -u +%Y%m%dt%H%M%Sz | tr 'TZ' 'tz')
+  --run-id tencent-multitier-preflight-$(date -u +%Y%m%dt%H%M%Sz | tr 'TZ' 'tz') \
+  --training-approach policy_gradient \
+  --scenario-id multi-tier-territory-combat-v0 \
+  --require-multi-tier-scenario
 ```
 
-Single-worker validation run:
+Single-worker policy-gradient validation run:
 
 ```bash
 cd /root/screeps
 python3 scripts/screeps_tencent_batch_rl_runner.py run-single \
-  --run-id tencent-single-$(date -u +%Y%m%dt%H%M%Sz | tr 'TZ' 'tz') \
-  --ticks 50 --workers 1 --repetitions 1
+  --run-id tencent-multitier-$(date -u +%Y%m%dt%H%M%Sz | tr 'TZ' 'tz') \
+  --training-approach policy_gradient \
+  --scenario-id multi-tier-territory-combat-v0 \
+  --require-multi-tier-scenario \
+  --ticks 500 --workers 5 --repetitions 5
 ```
+
+The policy-gradient path must use `scripts/fixtures/rl/multi-tier-territory-combat-v0.map.json`.
+The runner validates adjacent-room hostile fixture evidence before scale-up and rejects E1S1-only
+policy-gradient proof requests.
 
 The runner writes controller evidence under:
 

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -1875,6 +1875,18 @@ def loop_a_local_fallback_value(value: int | None, *, default: int, maximum: int
     return resolved
 
 
+def resolve_cli_scenario_request(args: argparse.Namespace) -> tuple[str, bool]:
+    scenario_id = args.scenario_id
+    require_multi_tier = bool(args.require_multi_tier_scenario)
+    if args.loop_a_local_fallback or args.loop_a_policy_gradient_supply:
+        if scenario_id is None:
+            return MULTI_TIER_SCENARIO_ID, True
+        if scenario_id != MULTI_TIER_SCENARIO_ID:
+            raise CardValidationError("Loop A policy-gradient proof requires the multi-tier territory/combat scenario")
+        return scenario_id, True
+    return scenario_id or DEFAULT_SCENARIO_ID, require_multi_tier
+
+
 def resolve_dataset_gate_roots(gate_root: Path | None, repo: Path) -> list[Path]:
     if gate_root is not None:
         expanded = gate_root.expanduser()
@@ -1935,10 +1947,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--scenario-id",
         choices=SCENARIO_IDS,
-        default=DEFAULT_SCENARIO_ID,
+        default=None,
         help=(
-            "Scenario metadata to attach. Default classifies the E1S1 smoke map as single-room/no-hostile; "
-            f"use {MULTI_TIER_SCENARIO_ID} to request the active adjacent-room hostile fixture."
+            "Scenario metadata to attach. Default classifies regular cards as E1S1 single-room/no-hostile; "
+            f"Loop A policy-gradient proof cards default to {MULTI_TIER_SCENARIO_ID}."
         ),
     )
     parser.add_argument(
@@ -2122,6 +2134,7 @@ def main(
                 maximum=LOOP_A_LOCAL_FALLBACK_WORKERS,
                 label="workers",
             )
+        scenario_id, require_multi_tier_scenario = resolve_cli_scenario_request(args)
         card = build_card(
             dataset_run_id=dataset_run_id,
             code_commit=args.code_commit or git_commit(repo),
@@ -2132,8 +2145,8 @@ def main(
             simulation_workers=simulation_workers,
             loop_a_card_supply=loop_a_card_supply,
             source_gate=source_gate,
-            scenario_id=args.scenario_id,
-            require_multi_tier_scenario=args.require_multi_tier_scenario,
+            scenario_id=scenario_id,
+            require_multi_tier_scenario=require_multi_tier_scenario,
         )
         if args.loop_a_local_fallback:
             output_path = args.output or repo / DEFAULT_LOOP_A_LOCAL_FALLBACK_CARD_PATH.relative_to(REPO_ROOT)

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -32,10 +32,14 @@ from pathlib import Path
 from typing import Any, Sequence
 
 from screeps_rl_experiment_card import (
+    CardValidationError,
     DEFAULT_SCENARIO_ID,
+    MULTI_TIER_ACTIVE_IMPLEMENTATION_STATUS,
     MULTI_TIER_SCENARIO_ID,
     MULTI_TIER_SIMULATION_MAP_SOURCE_REL,
     SCENARIO_IDS,
+    multi_tier_scenario_fixture_summary,
+    scenario_supports_multi_tier_policy_comparison,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -61,9 +65,11 @@ E1S1_REPEAT_GUARD_RECENT_SUMMARY_LIMIT = 20
 E1S1_REPEAT_GUARD_DEAD_TERRITORY = 2
 E1S1_REPEAT_GUARD_DEAD_KILLS = 0
 E1S1_REPEAT_GUARD_NEXT_ACTION = (
-    f"use --scenario-id {MULTI_TIER_SCENARIO_ID} --require-multi-tier-scenario after PR #1195; "
+    f"use --scenario-id {MULTI_TIER_SCENARIO_ID} --require-multi-tier-scenario after PR #1204; "
     "do not launch another E1S1-only Tencent batch"
 )
+DEFAULT_SIMULATION_MAP_SOURCE_REL = "maps/map-0b6758af.json"
+DEFAULT_SIMULATION_ROOM = "E1S1"
 RUN_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]{2,80}$")
 SSH_CONNECT_OPTIONS = (
     "-o", "BatchMode=yes",
@@ -435,7 +441,22 @@ class Controller:
                 self.final_status = "completed_scale_down_failed"
 
     def ensure_map_present(self) -> None:
-        target = REPO_ROOT / "maps" / "map-0b6758af.json"
+        scenario_id = scenario_id_from_args(self.args)
+        target = scenario_map_source_path(scenario_id)
+        if scenario_id == MULTI_TIER_SCENARIO_ID:
+            evidence = multi_tier_launch_fixture_evidence()
+            self.record_step(
+                "map_preflight",
+                time.time(),
+                True,
+                path=str(target),
+                scenarioId=scenario_id,
+                roomCount=evidence["roomCount"],
+                adjacentRoom=evidence["adjacentRoom"],
+                hostileCreepCount=evidence["hostileCreepCount"],
+                hostileSpawnCount=evidence["hostileSpawnCount"],
+            )
+            return
         if target.is_file():
             self.record_step("map_preflight", time.time(), True, path=str(target))
             return
@@ -485,18 +506,20 @@ class Controller:
     def generate_experiment_card(self) -> None:
         card = self.experiment_card_path()
         created_at = utc_now_iso()
+        scenario_id = scenario_id_from_args(self.args)
+        require_multi_tier_scenario = require_multi_tier_scenario_from_args(self.args, scenario_id)
         cmd = [
             sys.executable,
             "scripts/screeps_rl_experiment_card.py",
             "--dataset-run-id", self.args.dataset_run_id,
             "--training-approach", self.args.training_approach,
             "--created-at", created_at,
-            "--scenario-id", getattr(self.args, "scenario_id", DEFAULT_SCENARIO_ID),
+            "--scenario-id", scenario_id,
             "--output", str(card),
         ]
         if self.args.training_approach == "policy_gradient":
             cmd.append("--loop-a-policy-gradient-supply")
-        if getattr(self.args, "require_multi_tier_scenario", False):
+        if require_multi_tier_scenario:
             cmd.append("--require-multi-tier-scenario")
         cp = self.run_cp(
             "generate_experiment_card",
@@ -509,12 +532,7 @@ class Controller:
         simulation = payload.setdefault("simulation", {})
         ticks = effective_training_ticks(self.args)
         scale_environments = resolve_scale_environment_count(self.args)
-        scenario_id = getattr(self.args, "scenario_id", DEFAULT_SCENARIO_ID)
-        map_source_file = (
-            MULTI_TIER_SIMULATION_MAP_SOURCE_REL
-            if scenario_id == MULTI_TIER_SCENARIO_ID
-            else "maps/map-0b6758af.json"
-        )
+        map_source_file = scenario_map_source_file(scenario_id)
         simulation.update({
             "ticks": ticks,
             "workers": self.args.workers,
@@ -542,6 +560,11 @@ class Controller:
             })
         if self.args.variant:
             payload["strategy_variants"] = self.args.variant
+        validate_requested_experiment_card_scenario(
+            payload,
+            requested_scenario_id=scenario_id,
+            require_multi_tier_scenario=require_multi_tier_scenario,
+        )
         payload["run_id"] = self.run_id
         card.write_text(canonical_json(payload), encoding="utf-8")
         self.run_cp(
@@ -1043,20 +1066,24 @@ def build_e1s1_repeat_launch_guard(
 
 
 def e1s1_repeat_guard_current_launch(args: argparse.Namespace) -> dict[str, Any]:
-    scenario_id = getattr(args, "scenario_id", DEFAULT_SCENARIO_ID)
-    return {
+    scenario_id = scenario_id_from_args(args)
+    current_launch = {
         "scenarioId": scenario_id,
         "isE1S1SingleRoomNoHostile": scenario_id == DEFAULT_SCENARIO_ID,
         "requiredScenarioId": MULTI_TIER_SCENARIO_ID,
+        "requireMultiTierScenario": require_multi_tier_scenario_from_args(args, scenario_id),
         "requestedTicks": getattr(args, "ticks", None),
         "effectiveTicks": effective_training_ticks(args),
         "trainingApproach": getattr(args, "training_approach", None),
         "workers": getattr(args, "workers", None),
         "repetitions": getattr(args, "repetitions", None),
         "preflightOnly": bool(getattr(args, "preflight_only", False)),
-        "mapSourceFile": "maps/map-0b6758af.json",
-        "room": "E1S1",
+        "mapSourceFile": scenario_map_source_file(scenario_id),
+        "room": scenario_anchor_room(scenario_id),
     }
+    if scenario_id == MULTI_TIER_SCENARIO_ID:
+        current_launch["fixtureEvidence"] = multi_tier_launch_fixture_evidence()
+    return current_launch
 
 
 def recent_e1s1_dead_tier_evidence(args: argparse.Namespace, artifact_dir: Path) -> list[dict[str, Any]]:
@@ -1916,6 +1943,68 @@ def minimum_successful_environments(environment_count: int) -> int:
     return math.ceil(environment_count * SCALE_PROOF_SUCCESS_RATE)
 
 
+def scenario_id_from_args(args: argparse.Namespace) -> str:
+    return getattr(args, "scenario_id", None) or DEFAULT_SCENARIO_ID
+
+
+def require_multi_tier_scenario_from_args(args: argparse.Namespace, scenario_id: str | None = None) -> bool:
+    resolved_scenario_id = scenario_id or scenario_id_from_args(args)
+    return bool(getattr(args, "require_multi_tier_scenario", False)) or resolved_scenario_id == MULTI_TIER_SCENARIO_ID
+
+
+def scenario_map_source_file(scenario_id: str) -> str:
+    return MULTI_TIER_SIMULATION_MAP_SOURCE_REL if scenario_id == MULTI_TIER_SCENARIO_ID else DEFAULT_SIMULATION_MAP_SOURCE_REL
+
+
+def scenario_anchor_room(scenario_id: str) -> str:
+    return DEFAULT_SIMULATION_ROOM
+
+
+def scenario_map_source_path(scenario_id: str) -> Path:
+    return REPO_ROOT / scenario_map_source_file(scenario_id)
+
+
+def multi_tier_launch_fixture_evidence() -> dict[str, Any]:
+    fixture_path = scenario_map_source_path(MULTI_TIER_SCENARIO_ID)
+    try:
+        summary = multi_tier_scenario_fixture_summary(fixture_path)
+    except CardValidationError as error:
+        raise BatchRunError(str(error)) from error
+    return {
+        "implementationStatus": MULTI_TIER_ACTIVE_IMPLEMENTATION_STATUS,
+        "anchorRoom": summary["anchorRoom"],
+        "adjacentRoom": summary["adjacentRoom"],
+        "adjacentRooms": summary["adjacentRooms"],
+        "roomCount": summary["roomCount"],
+        "hostileFixture": "adjacent_room_hostile_spawn_and_creeps",
+        "hostileCreepCount": summary["adjacentHostileCreepCount"],
+        "hostileStructureCount": summary["adjacentHostileStructureCount"],
+        "hostileSpawnCount": summary["adjacentHostileSpawnCount"],
+        "ownAnchorSpawnCount": summary["anchorOwnSpawnCount"],
+        "ownAnchorCreepCount": summary["anchorOwnCreepCount"],
+        "fixtureSha256": summary["fixtureSha256"],
+        "mapSourceFile": scenario_map_source_file(MULTI_TIER_SCENARIO_ID),
+    }
+
+
+def validate_requested_experiment_card_scenario(
+    payload: dict[str, Any],
+    *,
+    requested_scenario_id: str,
+    require_multi_tier_scenario: bool,
+) -> None:
+    scenario = payload.get("scenario")
+    if not isinstance(scenario, dict):
+        raise BatchRunError("generated experiment card is missing scenario metadata")
+    observed_scenario_id = text_value(scenario.get("scenario_id")) or text_value(scenario.get("scenarioId"))
+    if observed_scenario_id != requested_scenario_id:
+        raise BatchRunError(
+            f"generated experiment card scenario mismatch: {observed_scenario_id!r} != {requested_scenario_id!r}"
+        )
+    if require_multi_tier_scenario and not scenario_supports_multi_tier_policy_comparison(scenario):
+        raise BatchRunError("generated experiment card lacks active multi-tier hostile fixture evidence")
+
+
 def build_scale_proof_spec(
     *,
     args: argparse.Namespace,
@@ -1925,6 +2014,23 @@ def build_scale_proof_spec(
     scale_environments: int,
     experiment_card: dict[str, Any],
 ) -> dict[str, Any]:
+    scenario_id = scenario_id_from_args(args)
+    fixture_evidence = (
+        multi_tier_launch_fixture_evidence()
+        if scenario_id == MULTI_TIER_SCENARIO_ID
+        else None
+    )
+    card_simulation_fields: dict[str, Any] = {
+        "ticks": effective_training_ticks(args),
+        "workers": args.workers,
+        "scale_environments": scale_environments,
+        "min_concurrent_environments": scale_environments,
+        "scenario_id": scenario_id,
+        "room": scenario_anchor_room(scenario_id),
+        "map_source_file": scenario_map_source_file(scenario_id),
+    }
+    if fixture_evidence is not None:
+        card_simulation_fields["fixtureEvidence"] = fixture_evidence
     return {
         "type": "screeps-tencent-batch-rl-scale-proof-spec",
         "schemaVersion": 1,
@@ -1952,13 +2058,7 @@ def build_scale_proof_spec(
             "remoteRunnerContract": {
                 "trainingRunner": "scripts/screeps_rl_training_runner.py",
                 "simulatorHarness": "scripts/screeps_rl_simulator_harness.py",
-                "cardSimulationFields": {
-                    "ticks": effective_training_ticks(args),
-                    "workers": args.workers,
-                    "scale_environments": scale_environments,
-                    "min_concurrent_environments": scale_environments,
-                    "scenario_id": getattr(args, "scenario_id", DEFAULT_SCENARIO_ID),
-                },
+                "cardSimulationFields": card_simulation_fields,
             },
         },
         "asg": {
@@ -2043,13 +2143,32 @@ def validate_static_inputs(args: argparse.Namespace, run_id: str) -> None:
             raise BatchRunError("workers must be at least scale environments for concurrent scale proof")
     if args.repetitions < 1 or args.ticks < 1:
         raise BatchRunError("ticks and repetitions must be positive")
-    scenario_id = getattr(args, "scenario_id", DEFAULT_SCENARIO_ID)
+    scenario_id = scenario_id_from_args(args)
     if scenario_id not in SCENARIO_IDS:
         raise BatchRunError(f"scenario id must be one of: {', '.join(SCENARIO_IDS)}")
     if getattr(args, "require_multi_tier_scenario", False) and scenario_id != MULTI_TIER_SCENARIO_ID:
         raise BatchRunError("multi-tier policy comparisons require the multi-tier territory/combat scenario id")
+    if getattr(args, "training_approach", None) == "policy_gradient" and scenario_id != MULTI_TIER_SCENARIO_ID:
+        raise BatchRunError(
+            f"policy_gradient Tencent proof requires --scenario-id {MULTI_TIER_SCENARIO_ID} "
+            "--require-multi-tier-scenario"
+        )
+    if scenario_id == MULTI_TIER_SCENARIO_ID:
+        multi_tier_launch_fixture_evidence()
     if not args.controller_ip.endswith("/32"):
         raise BatchRunError("controller IP must be a /32 CIDR")
+
+
+def apply_cli_scenario_defaults(args: argparse.Namespace) -> argparse.Namespace:
+    if getattr(args, "scenario_id", None) is None:
+        if args.training_approach == "policy_gradient":
+            args.scenario_id = MULTI_TIER_SCENARIO_ID
+            args.require_multi_tier_scenario = True
+        else:
+            args.scenario_id = DEFAULT_SCENARIO_ID
+    elif args.scenario_id == MULTI_TIER_SCENARIO_ID:
+        args.require_multi_tier_scenario = True
+    return args
 
 
 def list_tracked_bundle_paths() -> list[str]:
@@ -2134,7 +2253,15 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--repetitions", type=int, default=1)
     parser.add_argument("--host-port-start", type=int, default=24125)
-    parser.add_argument("--scenario-id", choices=SCENARIO_IDS, default=DEFAULT_SCENARIO_ID)
+    parser.add_argument(
+        "--scenario-id",
+        choices=SCENARIO_IDS,
+        default=None,
+        help=(
+            "Scenario to exercise. Defaults to E1S1 for non-policy-gradient smoke runs and "
+            f"{MULTI_TIER_SCENARIO_ID} for policy_gradient proof runs."
+        ),
+    )
     parser.add_argument(
         "--require-multi-tier-scenario",
         action="store_true",
@@ -2153,6 +2280,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     args.preflight_only = args.command == "preflight"
+    apply_cli_scenario_defaults(args)
     run_id = args.run_id
     artifact_dir = (REPO_ROOT / args.artifact_root / run_id).resolve()
     controller = Controller(args=args, run_id=run_id, artifact_dir=artifact_dir)

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -439,6 +439,8 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(generated["simulation"]["ticks"], 500)
         self.assertEqual(generated["simulation"]["workers"], 5)
         self.assertEqual(generated["simulation"]["repetitions"], 5)
+        self.assertEqual(generated["scenario"]["scenario_id"], card_helper.MULTI_TIER_SCENARIO_ID)
+        self.assertEqual(generated["scenario"]["evidence"]["hostile_spawn_count"], 1)
         self.assertTrue(card_helper.is_loop_a_card_available_for_training(generated))
 
     def test_cli_writes_loop_a_local_fallback_standalone_card_from_requested_gate(self) -> None:
@@ -519,6 +521,12 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(generated["source_gate"]["dataset_run_id"], dataset_run_id)
         self.assertEqual(generated["training_approach"], "policy_gradient")
         self.assertEqual(generated["policy_gradient"]["target_family"], "construction-priority")
+        self.assertEqual(generated["scenario"]["scenario_id"], card_helper.MULTI_TIER_SCENARIO_ID)
+        self.assertTrue(generated["scenario"]["suitability"]["multi_tier_policy_comparison"])
+        self.assertEqual(generated["scenario"]["evidence"]["adjacent_room"], "E2S1")
+        self.assertEqual(generated["scenario"]["evidence"]["hostile_creep_count"], 2)
+        self.assertEqual(generated["scenario"]["evidence"]["hostile_spawn_count"], 1)
+        self.assertEqual(Path(generated["simulation"]["map_source_file"]), card_helper.MULTI_TIER_SIMULATION_MAP_SOURCE_FILE)
 
         config = runner.simulation_config_from_card(generated)
         self.assertEqual(config.workers, 5)
@@ -548,6 +556,49 @@ class RlExperimentCardTest(unittest.TestCase):
             nested_live_regression["safety"][field] = True
             with self.assertRaises(card_helper.CardValidationError):
                 card_helper.validate_card(nested_live_regression)
+
+    def test_loop_a_local_fallback_rejects_explicit_single_room_scenario(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            gate_root = root / "gates"
+            gate_id = "gate-20260518T025000Z-postmerge1188"
+            gate_path = gate_root / gate_id / "gate_report.json"
+            gate_path.parent.mkdir(parents=True)
+            gate_path.write_text(
+                json.dumps(
+                    {
+                        "type": "screeps-rl-dataset-evaluation-gate",
+                        "ok": True,
+                        "gateId": gate_id,
+                        "createdAt": "2026-05-18T02:50:00Z",
+                        "dataset": {"runId": "rl-ebf33fae619f", "sampleCount": 200},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            stderr = io.StringIO()
+
+            exit_code = card_helper.main(
+                [
+                    "--loop-a-local-fallback",
+                    "--source-gate-id",
+                    gate_id,
+                    "--dataset-gate-root",
+                    str(gate_root),
+                    "--scenario-id",
+                    card_helper.DEFAULT_SCENARIO_ID,
+                    "--code-commit",
+                    "7" * 40,
+                    "--created-at",
+                    "2026-05-18T03:12:00Z",
+                ],
+                stdout=io.StringIO(),
+                stderr=stderr,
+                repo_root=REPO_ROOT,
+            )
+
+        self.assertEqual(exit_code, 2)
+        self.assertIn("Loop A policy-gradient proof requires", stderr.getvalue())
 
     def test_source_gate_block_uses_stable_provenance_path(self) -> None:
         gate_id = "rl-gate-93bf1aa18b62"

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -20,6 +20,7 @@ from unittest import mock
 sys.path.insert(0, str(Path(__file__).parent))
 
 import screeps_tencent_batch_rl_runner as runner
+import screeps_rl_experiment_card as card_helper
 
 
 CONTROLLER_IP = "43.128.104.34/32"
@@ -1109,6 +1110,11 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
 
         self.assertFalse(guard["blocked"])
         self.assertEqual(guard["currentLaunch"]["scenarioId"], runner.MULTI_TIER_SCENARIO_ID)
+        self.assertTrue(guard["currentLaunch"]["requireMultiTierScenario"])
+        self.assertEqual(guard["currentLaunch"]["mapSourceFile"], runner.MULTI_TIER_SIMULATION_MAP_SOURCE_REL)
+        self.assertEqual(guard["currentLaunch"]["fixtureEvidence"]["adjacentRoom"], "E2S1")
+        self.assertEqual(guard["currentLaunch"]["fixtureEvidence"]["hostileCreepCount"], 2)
+        self.assertEqual(guard["currentLaunch"]["fixtureEvidence"]["hostileSpawnCount"], 1)
         self.assertEqual(guard["evidence"]["count"], 0)
 
     def test_preflight_repeat_launch_guard_writes_skip_artifact_without_remote_side_effects(self) -> None:
@@ -1190,6 +1196,28 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
 
             args.scenario_id = runner.MULTI_TIER_SCENARIO_ID
             runner.validate_static_inputs(args, "run-test")
+
+            args.training_approach = "policy_gradient"
+            args.scenario_id = runner.DEFAULT_SCENARIO_ID
+            args.require_multi_tier_scenario = False
+            with self.assertRaisesRegex(runner.BatchRunError, "policy_gradient Tencent proof requires"):
+                runner.validate_static_inputs(args, "run-test")
+
+            args.scenario_id = runner.MULTI_TIER_SCENARIO_ID
+            args.require_multi_tier_scenario = True
+            runner.validate_static_inputs(args, "run-test")
+
+    def test_policy_gradient_cli_defaults_to_multi_tier_required_scenario(self) -> None:
+        args = runner.build_parser().parse_args([
+            "preflight",
+            "--training-approach",
+            "policy_gradient",
+        ])
+
+        runner.apply_cli_scenario_defaults(args)
+
+        self.assertEqual(args.scenario_id, runner.MULTI_TIER_SCENARIO_ID)
+        self.assertTrue(args.require_multi_tier_scenario)
 
     def test_generate_experiment_card_writes_multi_environment_scale_proof_spec(self) -> None:
         args = controller_args()
@@ -1288,6 +1316,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
     def test_generate_experiment_card_passes_multi_tier_scenario_request(self) -> None:
         args = controller_args()
         args.training_approach = "policy_gradient"
+        args.workers = 5
         args.scenario_id = runner.MULTI_TIER_SCENARIO_ID
         args.require_multi_tier_scenario = True
         observed_cmds: list[list[str]] = []
@@ -1299,22 +1328,14 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 observed_cmds.append(cmd)
                 if name == "generate_experiment_card":
                     output = Path(cmd[cmd.index("--output") + 1])
-                    payload = generated_experiment_card()
-                    payload["training_approach"] = "policy_gradient"
-                    payload["scenario"]["scenario_id"] = runner.MULTI_TIER_SCENARIO_ID
-                    payload["scenario"]["scenario_tier"] = "multi_tier_policy_comparison"
-                    payload["scenario"]["capabilities"] = {
-                        "multi_room_capable": True,
-                        "adjacent_room_territory_signal": True,
-                        "hostile_combat_signal": True,
-                        "multi_tier_policy_comparison": True,
-                    }
-                    payload["scenario"]["suitability"] = {
-                        "multi_tier_policy_comparison": True,
-                        "territory_combat_differentiation": True,
-                        "classification": "suitable_for_multi_tier_policy_comparison",
-                        "reasons": [],
-                    }
+                    payload = card_helper.build_card(
+                        dataset_run_id="dataset-test",
+                        code_commit="a" * 40,
+                        training_approach="policy_gradient",
+                        created_at="2026-05-18T10:18:00Z",
+                        scenario_id=runner.MULTI_TIER_SCENARIO_ID,
+                        require_multi_tier_scenario=True,
+                    )
                     output.write_text(json.dumps(payload), encoding="utf-8")
                 return subprocess.CompletedProcess(cmd, 0, "{}", "")
 
@@ -1322,14 +1343,27 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 controller.generate_experiment_card()
 
             card = json.loads((root / "experiment_card.json").read_text(encoding="utf-8"))
+            spec = json.loads((root / "scale_proof_spec.json").read_text(encoding="utf-8"))
 
         generate_cmd = observed_cmds[0]
         self.assertEqual(generate_cmd[generate_cmd.index("--scenario-id") + 1], runner.MULTI_TIER_SCENARIO_ID)
         self.assertIn("--require-multi-tier-scenario", generate_cmd)
         self.assertEqual(card["scenario"]["scenario_id"], runner.MULTI_TIER_SCENARIO_ID)
         self.assertTrue(card["scenario"]["capabilities"]["hostile_combat_signal"])
+        self.assertEqual(card["scenario"]["evidence"]["adjacent_room"], "E2S1")
+        self.assertEqual(card["scenario"]["evidence"]["hostile_creep_count"], 2)
+        self.assertEqual(card["scenario"]["evidence"]["hostile_spawn_count"], 1)
         self.assertEqual(card["simulation"]["map_source_file"], runner.MULTI_TIER_SIMULATION_MAP_SOURCE_REL)
         self.assertEqual(card["scenario"]["evidence"]["map_source_file"], runner.MULTI_TIER_SIMULATION_MAP_SOURCE_REL)
+        self.assertEqual(spec["experimentCard"]["scenario"]["scenario_id"], runner.MULTI_TIER_SCENARIO_ID)
+        self.assertEqual(
+            spec["scaleProof"]["remoteRunnerContract"]["cardSimulationFields"]["map_source_file"],
+            runner.MULTI_TIER_SIMULATION_MAP_SOURCE_REL,
+        )
+        self.assertEqual(
+            spec["scaleProof"]["remoteRunnerContract"]["cardSimulationFields"]["fixtureEvidence"]["hostileSpawnCount"],
+            1,
+        )
         self.assertFalse(card["safety"]["officialMmoWritesAllowed"])
 
     def test_verify_remote_training_report_requires_scale_proof_success_for_workers_five(self) -> None:
@@ -1985,6 +2019,29 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(controller.steps[1].detail["path"], str(root / "prod" / "dist" / "main.js"))
         self.assertNotIn("detail", controller.steps[0].detail)
         self.assertNotIn("detail", controller.steps[1].detail)
+
+    def test_multi_tier_map_preflight_validates_fixture_without_e1s1_map(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            fixture_path = root / runner.MULTI_TIER_SIMULATION_MAP_SOURCE_REL
+            fixture_path.parent.mkdir(parents=True)
+            fixture_path.write_text(
+                card_helper.MULTI_TIER_SIMULATION_MAP_SOURCE_FILE.read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+            args = controller_args()
+            args.scenario_id = runner.MULTI_TIER_SCENARIO_ID
+            args.require_multi_tier_scenario = True
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=root / "artifacts")
+
+            with mock.patch.object(runner, "REPO_ROOT", root):
+                controller.ensure_map_present()
+
+            self.assertEqual(controller.steps[0].detail["path"], str(fixture_path))
+            self.assertEqual(controller.steps[0].detail["scenarioId"], runner.MULTI_TIER_SCENARIO_ID)
+            self.assertEqual(controller.steps[0].detail["adjacentRoom"], "E2S1")
+            self.assertEqual(controller.steps[0].detail["hostileCreepCount"], 2)
+            self.assertFalse((root / "maps" / "map-0b6758af.json").exists())
 
     def test_latest_scale_out_failure_ignores_failures_before_run_start(self) -> None:
         class FakeController(runner.Controller):


### PR DESCRIPTION
## Summary
- Route Loop A / policy-gradient proof cards to `multi-tier-territory-combat-v0` by default, rejecting explicit E1S1 fallback for policy-gradient proof generation.
- Wire Tencent batch runner scenario defaults/preflight/map evidence to the active multi-tier fixture instead of the E1S1 single-room map.
- Add targeted tests and runbook docs so future preflight/card generation exposes adjacent-room hostile fixture evidence and fails when multi-tier scenario validation is missing.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_experiment_card.py scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_rl_experiment_card.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts/test_screeps_rl_experiment_card.py scripts/test_screeps_tencent_batch_rl_runner.py` — 96 tests OK

## Safety / rollout
- Offline/private RL only; no official MMO writes, no deploy, no paid Tencent/cloud launch in this PR.
- Tencent utilization controller remains in dry-run hold until this lands and a local/private proof shows actual multi-tier activation (`territory > 2` or `kills > 0`).
- This PR is the follow-up after #1204: #1204 made the fixture real; this routes the proof/preflight path away from E1S1 so the fixture is actually exercised.

Refs #1203
Refs #1032
Refs #879
