### PR TITLE
fix: default Loop A preflight to multi-tier policy gradient

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -2198,6 +2198,8 @@ def apply_cli_scenario_defaults(args: argparse.Namespace) -> argparse.Namespace:
 def explicit_cli_option_dests(argv: Sequence[str]) -> set[str]:
     explicit: set[str] = set()
     for token in argv:
+        if token == "--":
+            break
         for option, dest in CLI_EXPLICIT_OPTION_DESTS.items():
             if token == option or token.startswith(option + "="):
                 explicit.add(dest)
@@ -2261,7 +2263,10 @@ def create_repo_bundle(package: Path) -> None:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Run bounded Screeps RL training on one Tencent ASG worker.")
+    parser = argparse.ArgumentParser(
+        description="Run bounded Screeps RL training on one Tencent ASG worker.",
+        allow_abbrev=False,
+    )
     parser.add_argument("command", choices=("run-single", "preflight"))
     parser.add_argument("--run-id", default=default_run_id())
     parser.add_argument("--region", default=DEFAULT_REGION)

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -131,6 +131,20 @@ ZERO_ITERATION_POLICY_UPDATE_FORBIDDEN_KEYS = {
     "updatedParameters",
     "updated_parameters",
 }
+CLI_EXPLICIT_OPTION_DESTS = {
+    "--training-approach": "training_approach",
+    "--scenario-id": "scenario_id",
+    "--require-multi-tier-scenario": "require_multi_tier_scenario",
+    "--ticks": "ticks",
+    "--workers": "workers",
+    "--scale-environments": "scale_environments",
+    "--repetitions": "repetitions",
+}
+PREFLIGHT_MODE_OPTION_DESTS = frozenset((
+    "training_approach",
+    "scenario_id",
+    "require_multi_tier_scenario",
+))
 
 
 class BatchRunError(RuntimeError):
@@ -2160,8 +2174,18 @@ def validate_static_inputs(args: argparse.Namespace, run_id: str) -> None:
 
 
 def apply_cli_scenario_defaults(args: argparse.Namespace) -> argparse.Namespace:
+    explicit_options = set(getattr(args, "explicit_cli_options", ()))
+    command = getattr(args, "command", None)
+    explicit_preflight_mode = bool(explicit_options.intersection(PREFLIGHT_MODE_OPTION_DESTS))
+    if command == "preflight" and not explicit_preflight_mode:
+        args.training_approach = "policy_gradient"
+        args.scenario_id = MULTI_TIER_SCENARIO_ID
+        args.require_multi_tier_scenario = True
+        return args
     if getattr(args, "scenario_id", None) is None:
-        if args.training_approach == "policy_gradient":
+        if args.training_approach == "policy_gradient" or (
+            command == "preflight" and getattr(args, "require_multi_tier_scenario", False)
+        ):
             args.scenario_id = MULTI_TIER_SCENARIO_ID
             args.require_multi_tier_scenario = True
         else:
@@ -2169,6 +2193,15 @@ def apply_cli_scenario_defaults(args: argparse.Namespace) -> argparse.Namespace:
     elif args.scenario_id == MULTI_TIER_SCENARIO_ID:
         args.require_multi_tier_scenario = True
     return args
+
+
+def explicit_cli_option_dests(argv: Sequence[str]) -> set[str]:
+    explicit: set[str] = set()
+    for token in argv:
+        for option, dest in CLI_EXPLICIT_OPTION_DESTS.items():
+            if token == option or token.startswith(option + "="):
+                explicit.add(dest)
+    return explicit
 
 
 def list_tracked_bundle_paths() -> list[str]:
@@ -2277,10 +2310,17 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: list[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
+def parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    args = build_parser().parse_args(raw_argv)
+    args.explicit_cli_options = explicit_cli_option_dests(raw_argv)
     args.preflight_only = args.command == "preflight"
     apply_cli_scenario_defaults(args)
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_cli_args(argv)
     run_id = args.run_id
     artifact_dir = (REPO_ROOT / args.artifact_root / run_id).resolve()
     controller = Controller(args=args, run_id=run_id, artifact_dir=artifact_dir)

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -292,6 +292,39 @@ def strip_tencent_guard_location_evidence(summary_path: Path) -> None:
 
 
 class TencentBatchRlRunnerTest(unittest.TestCase):
+    def run_stubbed_preflight(
+        self,
+        args: argparse.Namespace,
+        artifact_dir: Path,
+    ) -> tuple[list[str], runner.Controller, dict[str, object], dict[str, object]]:
+        events: list[str] = []
+
+        class FakeController(runner.Controller):
+            def ensure_map_present(self) -> None:
+                events.append("map")
+
+            def ensure_dist_present(self) -> None:
+                events.append("dist")
+
+            def run_billing_guard(self) -> None:
+                events.append("billing")
+
+            def verify_security_group(self) -> None:
+                events.append("security_group")
+
+            def generate_experiment_card(self) -> None:
+                events.append("experiment_card")
+
+            def scale_up_and_wait(self) -> None:
+                events.append("scale_up")
+
+        controller = FakeController(args=args, run_id=args.run_id, artifact_dir=artifact_dir)
+        with mock.patch.object(runner, "validate_static_inputs", return_value=None):
+            controller.run()
+        guard = json.loads((artifact_dir / "launch_guard.json").read_text(encoding="utf-8"))
+        summary = json.loads((artifact_dir / "controller-summary.json").read_text(encoding="utf-8"))
+        return events, controller, guard, summary
+
     def test_security_group_guard_accepts_single_controller_ssh_rule(self) -> None:
         ingress = [
             {"Action": "ACCEPT", "Protocol": "TCP", "Port": "22", "CidrBlock": CONTROLLER_IP},
@@ -1116,6 +1149,100 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(guard["currentLaunch"]["fixtureEvidence"]["hostileCreepCount"], 2)
         self.assertEqual(guard["currentLaunch"]["fixtureEvidence"]["hostileSpawnCount"], 1)
         self.assertEqual(guard["evidence"]["count"], 0)
+
+    def test_no_arg_preflight_defaults_to_multi_tier_policy_gradient_without_repeat_guard(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for run_id in ("tencent-pg-1", "tencent-pg-2", "tencent-pg-3"):
+                write_tencent_guard_summary(artifact_root, run_id)
+            args = runner.parse_cli_args([
+                "preflight",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            events, controller, guard, summary = self.run_stubbed_preflight(args, artifact_dir)
+
+        self.assertEqual(args.training_approach, "policy_gradient")
+        self.assertEqual(args.scenario_id, runner.MULTI_TIER_SCENARIO_ID)
+        self.assertTrue(args.require_multi_tier_scenario)
+        self.assertEqual(controller.final_status, "preflight_ok")
+        self.assertEqual(summary["finalStatus"], "preflight_ok")
+        self.assertEqual(summary["inputs"]["trainingApproach"], "policy_gradient")
+        self.assertEqual(summary["inputs"]["scenarioId"], runner.MULTI_TIER_SCENARIO_ID)
+        self.assertTrue(summary["inputs"]["requireMultiTierScenario"])
+        self.assertFalse(guard["blocked"])
+        self.assertEqual(guard["status"], "clear")
+        self.assertFalse(guard["currentLaunch"]["isE1S1SingleRoomNoHostile"])
+        self.assertEqual(guard["currentLaunch"]["scenarioId"], runner.MULTI_TIER_SCENARIO_ID)
+        self.assertEqual(guard["currentLaunch"]["effectiveTicks"], runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS)
+        self.assertEqual(guard["evidence"]["count"], 0)
+        self.assertIn("experiment_card", events)
+        self.assertNotIn("scale_up", events)
+
+    def test_explicit_e1s1_bandit_preflight_still_triggers_repeat_guard(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for run_id in ("tencent-pg-1", "tencent-pg-2", "tencent-pg-3"):
+                write_tencent_guard_summary(artifact_root, run_id)
+            args = runner.parse_cli_args([
+                "preflight",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "bandit",
+                "--scenario-id",
+                runner.DEFAULT_SCENARIO_ID,
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            events, controller, guard, summary = self.run_stubbed_preflight(args, artifact_dir)
+
+        self.assertEqual(args.training_approach, "bandit")
+        self.assertEqual(args.scenario_id, runner.DEFAULT_SCENARIO_ID)
+        self.assertEqual(events, [])
+        self.assertEqual(controller.final_status, runner.E1S1_REPEAT_GUARD_FINAL_STATUS)
+        self.assertEqual(summary["finalStatus"], runner.E1S1_REPEAT_GUARD_FINAL_STATUS)
+        self.assertTrue(guard["blocked"])
+        self.assertEqual(guard["currentLaunch"]["scenarioId"], runner.DEFAULT_SCENARIO_ID)
+        self.assertTrue(guard["currentLaunch"]["isE1S1SingleRoomNoHostile"])
+        self.assertEqual(guard["currentLaunch"]["trainingApproach"], "bandit")
+        self.assertEqual(guard["evidence"]["count"], 3)
+
+    def test_explicit_multi_tier_preflight_includes_fixture_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            args = runner.parse_cli_args([
+                "preflight",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            events, controller, guard, summary = self.run_stubbed_preflight(args, artifact_dir)
+
+        self.assertEqual(controller.final_status, "preflight_ok")
+        self.assertEqual(summary["inputs"]["scenarioId"], runner.MULTI_TIER_SCENARIO_ID)
+        self.assertTrue(summary["inputs"]["requireMultiTierScenario"])
+        self.assertFalse(guard["blocked"])
+        self.assertEqual(guard["currentLaunch"]["scenarioId"], runner.MULTI_TIER_SCENARIO_ID)
+        self.assertTrue(guard["currentLaunch"]["requireMultiTierScenario"])
+        self.assertEqual(guard["currentLaunch"]["fixtureEvidence"]["adjacentRoom"], "E2S1")
+        self.assertEqual(guard["currentLaunch"]["fixtureEvidence"]["hostileCreepCount"], 2)
+        self.assertEqual(guard["currentLaunch"]["fixtureEvidence"]["hostileSpawnCount"], 1)
+        self.assertIn("experiment_card", events)
+        self.assertNotIn("scale_up", events)
 
     def test_preflight_repeat_launch_guard_writes_skip_artifact_without_remote_side_effects(self) -> None:
         events: list[str] = []

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -1183,6 +1183,35 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertIn("experiment_card", events)
         self.assertNotIn("scale_up", events)
 
+    def test_cli_rejects_abbreviated_training_approach_option(self) -> None:
+        with mock.patch("sys.stderr", new=io.StringIO()):
+            with self.assertRaises(SystemExit) as raised:
+                runner.parse_cli_args(["preflight", "--training-app", "bandit"])
+
+        self.assertNotEqual(raised.exception.code, 0)
+
+    def test_explicit_cli_option_dests_stops_at_option_separator(self) -> None:
+        self.assertEqual(
+            runner.explicit_cli_option_dests([
+                "preflight",
+                "--training-approach=bandit",
+                "--",
+                "--scenario-id",
+                runner.DEFAULT_SCENARIO_ID,
+            ]),
+            {"training_approach"},
+        )
+        self.assertEqual(
+            runner.explicit_cli_option_dests([
+                "preflight",
+                "--",
+                "--training-approach",
+                "bandit",
+                f"--scenario-id={runner.DEFAULT_SCENARIO_ID}",
+            ]),
+            set(),
+        )
+
     def test_explicit_e1s1_bandit_preflight_still_triggers_repeat_guard(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             artifact_root = Path(temp_dir) / "batch-runs"


### PR DESCRIPTION
## Summary
- Default the no-arg `preflight` path to the active `policy_gradient` multi-tier scenario (`multi-tier-territory-combat-v0`).
- Preserve explicit E1S1/bandit smoke invocations and keep the E1S1 repeat-launch guard active for those explicit requests.
- Add targeted runner tests for no-arg preflight, explicit E1S1 guard behavior, and explicit multi-tier fixture evidence.

## Safety
- Offline/private preflight only: no remote scale-out, no official MMO writes.
- Explicit CLI overrides remain respected for scenario/training/ticks/workers/scale-environments/repetitions.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py scripts/screeps_rl_experiment_card.py scripts/test_screeps_rl_experiment_card.py`
- `python3 -m unittest scripts/test_screeps_rl_experiment_card.py scripts/test_screeps_tencent_batch_rl_runner.py` (99 tests OK)
- Direct no-arg preflight smoke with temp artifact root: `finalStatus=preflight_ok`, `trainingApproach=policy_gradient`, `scenarioId=multi-tier-territory-combat-v0`, `requireMultiTierScenario=true`, `blocked=false`, `effectiveTicks=500`, fixture evidence present.

Closes/advances #1203.
