### PR TITLE
feat(rl): add live metrics dashboard service

### DIFF
--- a/docs/ops/rl-gameplay-metrics-taxonomy.md
+++ b/docs/ops/rl-gameplay-metrics-taxonomy.md
@@ -18,6 +18,12 @@ python3 scripts/screeps_rl_metrics_ingestor.py ingest-artifacts
 python3 scripts/screeps_rl_metrics_ingestor.py summarize
 ```
 
+Live dashboard runbook:
+
+```text
+docs/ops/rl-live-dashboard-runbook.md
+```
+
 Default source roots:
 
 ```text

--- a/docs/ops/rl-live-dashboard-runbook.md
+++ b/docs/ops/rl-live-dashboard-runbook.md
@@ -1,0 +1,104 @@
+# RL Live Dashboard Runbook
+
+Status: issue #1184 live observability surface for the #879 RL evidence loop.
+
+This repository keeps the Grafana JSON dashboard in `docs/ops/grafana/`, but the checked-in live surface is a dependency-light local service so it does not require a Grafana SQLite plugin, external network access, or secrets.
+
+## Operator Commands
+
+Metrics database:
+
+```text
+runtime-artifacts/rl-metrics/rl_metrics.sqlite
+```
+
+Refresh the SQLite store with the existing ingestor:
+
+```bash
+npm run rl-metrics-refresh
+```
+
+Start the live dashboard and refresh once before serving:
+
+```bash
+npm run rl-dashboard-live -- --refresh-on-start
+```
+
+Default dashboard URL:
+
+```text
+http://127.0.0.1:8790/
+```
+
+Machine-readable summary:
+
+```text
+http://127.0.0.1:8790/api/summary
+```
+
+Health check:
+
+```bash
+npm run rl-dashboard-live:health
+```
+
+Equivalent direct check:
+
+```bash
+python3 scripts/screeps_rl_live_dashboard.py healthcheck --url http://127.0.0.1:8790/healthz
+```
+
+Trigger a local refresh through the running service:
+
+```bash
+curl -fsS -X POST http://127.0.0.1:8790/refresh
+```
+
+## Dashboard Coverage
+
+The live page and `/api/summary` cover:
+
+| Area | Source |
+| --- | --- |
+| E1 gate acceptance | Latest dataset gate artifact discovered by `scripts/screeps_rl_dashboard.py`. |
+| Loop A env/ticks/episodes | Simulator run summaries or training-ledger aggregate fields. |
+| Loop B online utility | Policy online advantage ledger status and candidate/baseline fields. |
+| Loop B scorecard | Latest `runtime-artifacts/rl-control-loop/scorecards/*.json`. |
+| Tencent batch utilization | Latest controller summaries under `runtime-artifacts/tencent-cloud/batch-runs/`. |
+| Safety flags | Tencent run safety flags, scorecard safety regressions, and card-supply status. |
+| SQLite freshness | Required table presence, row counts, and latest observation timestamp from `rl_metrics.sqlite`. |
+
+The static HTML dashboard remains available through:
+
+```bash
+npm run rl-dashboard
+```
+
+That writes:
+
+```text
+runtime-artifacts/rl-dashboard.html
+```
+
+## Health Semantics
+
+`/healthz` returns HTTP 200 only when:
+
+- `runtime-artifacts/rl-metrics/rl_metrics.sqlite` exists;
+- all required ingestor tables exist;
+- SQLite can be opened and queried.
+
+It returns HTTP 503 with JSON failure details when the database is missing, unreadable, or schema-incomplete. Missing E1/Loop A/Loop B/Tencent evidence is shown as dashboard data quality rather than process health, because the server can be healthy while the RL pipeline is blocked.
+
+## Failure Modes
+
+| Symptom | Likely cause | Recovery |
+| --- | --- | --- |
+| `/healthz` reports `metrics database missing` | Ingestor has not been run in this worktree. | Run `npm run rl-metrics-refresh` or restart with `--refresh-on-start`. |
+| `/healthz` reports schema incomplete | Old or corrupt `rl_metrics.sqlite`. | Move the stale DB aside and run `npm run rl-metrics-refresh`. |
+| E1 gate is `N/A` or `BLOCKED` | No current gate artifact under `runtime-artifacts/rl-dataset-gates` or `rl-control-loop`. | Re-run the shadow-eval/gate producer and refresh metrics. |
+| Loop A env/ticks/episodes are missing | No simulator run summaries and no training ledger aggregate. | Re-run the training execution ledger or simulator harness, then refresh. |
+| Loop B online utility is `N/A` or `UNPROVEN` | Policy advantage ledger has not proven candidate utility. | Re-run the policy online advantage ledger after fresh Loop A evidence. |
+| Scorecard is `N/A` | No scorecard JSON has been generated. | Run the scorecard producer for the candidate/baseline bundle. |
+| Tencent latest run is active or scale-down is false | Controller summary was partial or did not record final cleanup. | Inspect the latest `controller-summary.json` and verify ASG desired capacity outside this dashboard. |
+| Safety status is `BLOCKED` | A Tencent safety flag was not false or scorecard safety regressions exist. | Treat as a rollout blocker; inspect the listed unsafe flag before generating new training evidence. |

--- a/docs/ops/rl-live-dashboard-runbook.md
+++ b/docs/ops/rl-live-dashboard-runbook.md
@@ -48,7 +48,7 @@ Equivalent direct check:
 python3 scripts/screeps_rl_live_dashboard.py healthcheck --url http://127.0.0.1:8790/healthz
 ```
 
-Trigger a local refresh through the running service:
+Trigger a local refresh through the running service only after starting it with `--enable-refresh-endpoint`:
 
 ```bash
 curl -fsS -X POST http://127.0.0.1:8790/refresh
@@ -65,7 +65,7 @@ The live page and `/api/summary` cover:
 | Loop B online utility | Policy online advantage ledger status and candidate/baseline fields. |
 | Loop B scorecard | Latest `runtime-artifacts/rl-control-loop/scorecards/*.json`. |
 | Tencent batch utilization | Latest controller summaries under `runtime-artifacts/tencent-cloud/batch-runs/`. |
-| Safety flags | Tencent run safety flags, scorecard safety regressions, and card-supply status. |
+| Safety flags | Tencent run safety flags, required scorecard evidence, scorecard safety regressions, and card-supply status. |
 | SQLite freshness | Required table presence, row counts, and latest observation timestamp from `rl_metrics.sqlite`. |
 
 The static HTML dashboard remains available through:
@@ -101,4 +101,4 @@ It returns HTTP 503 with JSON failure details when the database is missing, unre
 | Loop B online utility is `N/A` or `UNPROVEN` | Policy advantage ledger has not proven candidate utility. | Re-run the policy online advantage ledger after fresh Loop A evidence. |
 | Scorecard is `N/A` | No scorecard JSON has been generated. | Run the scorecard producer for the candidate/baseline bundle. |
 | Tencent latest run is active or scale-down is false | Controller summary was partial or did not record final cleanup. | Inspect the latest `controller-summary.json` and verify ASG desired capacity outside this dashboard. |
-| Safety status is `BLOCKED` | A Tencent safety flag was not false or scorecard safety regressions exist. | Treat as a rollout blocker; inspect the listed unsafe flag before generating new training evidence. |
+| Safety status is `BLOCKED` | Tencent controller evidence or scorecard evidence is missing, a Tencent safety flag was not false, or scorecard safety regressions exist. | Treat as a rollout blocker; inspect the listed unsafe flag before generating new training evidence. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "private": true,
   "scripts": {
-    "rl-dashboard": "python3 scripts/screeps_rl_dashboard.py"
+    "rl-dashboard": "python3 scripts/screeps_rl_dashboard.py",
+    "rl-dashboard-live": "python3 scripts/screeps_rl_live_dashboard.py serve",
+    "rl-dashboard-live:health": "python3 scripts/screeps_rl_live_dashboard.py healthcheck",
+    "rl-metrics-refresh": "python3 scripts/screeps_rl_metrics_ingestor.py ingest-artifacts"
   },
   "devDependencies": {
     "playwright": "1.59.1"

--- a/scripts/screeps_rl_live_dashboard.py
+++ b/scripts/screeps_rl_live_dashboard.py
@@ -56,6 +56,7 @@ class LiveDashboardConfig:
     artifact_root: Path
     db_path: Path
     refresh_seconds: int = DEFAULT_REFRESH_SECONDS
+    enable_refresh_endpoint: bool = False
 
 
 class LiveDashboardHTTPServer(ThreadingHTTPServer):
@@ -256,6 +257,10 @@ def refresh_metrics(db_path: Path, artifact_root: Path, paths: Sequence[Path] | 
     return {"ok": True, "db": str(db_path), "paths": [str(path) for path in ingest_paths], **result}
 
 
+def refresh_succeeded(refresh: JsonObject) -> bool:
+    return refresh.get("ok") is True
+
+
 def latest_scorecard_summary(artifact_root: Path, repo_root: Path) -> JsonObject:
     latest = latest_json_artifact(
         artifact_root / "rl-control-loop" / "scorecards",
@@ -330,7 +335,9 @@ def safety_summary(dashboard: JsonObject, tencent: JsonObject, scorecard: JsonOb
     latest_tencent = tencent.get("latest") if isinstance(tencent.get("latest"), dict) else {}
     tencent_safety = latest_tencent.get("safety") if isinstance(latest_tencent.get("safety"), dict) else {}
     unsafe_flags: list[JsonObject] = []
-    if latest_tencent:
+    if not latest_tencent:
+        unsafe_flags.append({"source": "tencent", "field": "controllerSummary", "value": "missing"})
+    else:
         for field in REQUIRED_TENCENT_SAFETY_FIELDS:
             if field not in tencent_safety:
                 unsafe_flags.append({"source": "tencent", "field": field, "value": "missing"})
@@ -338,8 +345,11 @@ def safety_summary(dashboard: JsonObject, tencent: JsonObject, scorecard: JsonOb
             value = tencent_safety[field]
             if value is not False:
                 unsafe_flags.append({"source": "tencent", "field": field, "value": value})
-    for regression in scorecard.get("safetyRegressions", []):
-        unsafe_flags.append({"source": "scorecard", "field": "safetyRegression", "value": regression})
+    if not scorecard.get("hasData"):
+        unsafe_flags.append({"source": "scorecard", "field": "summary", "value": "missing"})
+    else:
+        for regression in scorecard.get("safetyRegressions", []):
+            unsafe_flags.append({"source": "scorecard", "field": "safetyRegression", "value": regression})
     return {
         "status": "OK" if not unsafe_flags else "BLOCKED",
         "unsafeFlags": unsafe_flags,
@@ -662,12 +672,21 @@ class LiveDashboardRequestHandler(BaseHTTPRequestHandler):
         if parsed.path != "/refresh":
             self.write_json(HTTPStatus.NOT_FOUND, {"ok": False, "error": "not found"})
             return
+        if not self.server.config.enable_refresh_endpoint:
+            self.write_json(HTTPStatus.FORBIDDEN, {"ok": False, "error": "refresh endpoint disabled"})
+            return
         with self.server.refresh_lock:
             try:
                 refresh = refresh_metrics(self.server.config.db_path, self.server.config.artifact_root)
             except Exception as error:  # pragma: no cover - defensive handler boundary
                 self.write_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"ok": False, "error": str(error)})
                 return
+        if not refresh_succeeded(refresh):
+            self.write_json(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                {"ok": False, "error": "refresh failed", "refresh": refresh, "summary": self.summary()},
+            )
+            return
         self.write_json(HTTPStatus.OK, {"ok": True, "refresh": refresh, "summary": self.summary()})
 
     def log_message(self, format: str, *args: Any) -> None:
@@ -713,6 +732,7 @@ def build_config(args: argparse.Namespace) -> LiveDashboardConfig:
         artifact_root=artifact_root,
         db_path=db_path,
         refresh_seconds=args.refresh_seconds,
+        enable_refresh_endpoint=bool(getattr(args, "enable_refresh_endpoint", False)),
     )
 
 
@@ -747,6 +767,11 @@ def build_parser() -> argparse.ArgumentParser:
     serve.add_argument("--host", default=DEFAULT_HOST, help="Bind host.")
     serve.add_argument("--port", type=int, default=DEFAULT_PORT, help="Bind port.")
     serve.add_argument("--refresh-on-start", action="store_true", help="Run the metrics ingestor before serving.")
+    serve.add_argument(
+        "--enable-refresh-endpoint",
+        action="store_true",
+        help="Enable POST /refresh. Disabled by default because it mutates the local SQLite metrics store.",
+    )
 
     refresh = subparsers.add_parser("refresh", help="refresh the SQLite metrics database with the ingestor")
     add_common_args(refresh)
@@ -787,13 +812,19 @@ def main(argv: Sequence[str] | None = None) -> int:
         paths = [resolve_path(path, config.repo_root) for path in args.paths]
         result = refresh_metrics(config.db_path, config.artifact_root, paths)
         print(json.dumps(result, sort_keys=True))
-        return 0
+        return 0 if refresh_succeeded(result) else 1
     if args.command == "summary":
         print(json.dumps(build_live_summary(config.repo_root, config.artifact_root, config.db_path), sort_keys=True))
         return 0
     if args.command == "serve":
         if args.refresh_on_start:
-            refresh_metrics(config.db_path, config.artifact_root)
+            refresh = refresh_metrics(config.db_path, config.artifact_root)
+            if not refresh_succeeded(refresh):
+                print(
+                    json.dumps({"ok": False, "error": "refresh-on-start failed", "refresh": refresh}, sort_keys=True),
+                    file=sys.stderr,
+                )
+                return 1
         server = make_server(args.host, args.port, config)
         host, port = server.server_address
         print(f"Serving Screeps RL live dashboard at {format_dashboard_url(str(host), int(port))}")

--- a/scripts/screeps_rl_live_dashboard.py
+++ b/scripts/screeps_rl_live_dashboard.py
@@ -45,6 +45,7 @@ DEFAULT_ARTIFACT_SUBDIRS = (
     "rl-control-loop",
     "rl-training",
 )
+REQUIRED_TENCENT_SAFETY_FIELDS = ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed")
 
 JsonObject = dict[str, Any]
 
@@ -328,11 +329,15 @@ def safety_summary(dashboard: JsonObject, tencent: JsonObject, scorecard: JsonOb
     card_supply = dashboard.get("cardSupply") if isinstance(dashboard.get("cardSupply"), dict) else {}
     latest_tencent = tencent.get("latest") if isinstance(tencent.get("latest"), dict) else {}
     tencent_safety = latest_tencent.get("safety") if isinstance(latest_tencent.get("safety"), dict) else {}
-    unsafe_flags = []
-    for field in ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed"):
-        value = tencent_safety.get(field)
-        if value is not False and value is not None:
-            unsafe_flags.append({"source": "tencent", "field": field, "value": value})
+    unsafe_flags: list[JsonObject] = []
+    if latest_tencent:
+        for field in REQUIRED_TENCENT_SAFETY_FIELDS:
+            if field not in tencent_safety:
+                unsafe_flags.append({"source": "tencent", "field": field, "value": "missing"})
+                continue
+            value = tencent_safety[field]
+            if value is not False:
+                unsafe_flags.append({"source": "tencent", "field": field, "value": value})
     for regression in scorecard.get("safetyRegressions", []):
         unsafe_flags.append({"source": "scorecard", "field": "safetyRegression", "value": regression})
     return {

--- a/scripts/screeps_rl_live_dashboard.py
+++ b/scripts/screeps_rl_live_dashboard.py
@@ -113,6 +113,11 @@ def safe_display_path(path: Path | str | None, repo_root: Path) -> str:
     return static_dashboard.safe_display_path(path, repo_root)
 
 
+def format_dashboard_url(host: str, port: int) -> str:
+    display_host = f"[{host}]" if ":" in host and not host.startswith("[") else host
+    return f"http://{display_host}:{port}/"
+
+
 def dashboard_json_safe(value: Any, repo_root: Path) -> Any:
     if isinstance(value, Path):
         return safe_display_path(value, repo_root)
@@ -346,6 +351,7 @@ def build_live_summary(
     db_path: Path,
     *,
     generated_at: str | None = None,
+    dashboard_url: str | None = None,
 ) -> JsonObject:
     generated = generated_at or utc_now_iso()
     db = sqlite_summary(db_path, repo_root)
@@ -369,7 +375,7 @@ def build_live_summary(
         "generatedAt": generated,
         "repoRoot": safe_display_path(repo_root, repo_root),
         "artifactRoot": safe_display_path(artifact_root, repo_root),
-        "dashboardUrl": f"http://{DEFAULT_HOST}:{DEFAULT_PORT}/",
+        "dashboardUrl": dashboard_url or format_dashboard_url(DEFAULT_HOST, DEFAULT_PORT),
         "health": health,
         "db": db,
         "lanes": dashboard.get("lanes", []),
@@ -664,7 +670,13 @@ class LiveDashboardRequestHandler(BaseHTTPRequestHandler):
 
     def summary(self) -> JsonObject:
         config = self.server.config
-        return build_live_summary(config.repo_root, config.artifact_root, config.db_path)
+        host, port = self.server.server_address[:2]
+        return build_live_summary(
+            config.repo_root,
+            config.artifact_root,
+            config.db_path,
+            dashboard_url=format_dashboard_url(str(host), int(port)),
+        )
 
     def write_json(self, status: HTTPStatus, payload: JsonObject) -> None:
         body = (json.dumps(payload, sort_keys=True, ensure_ascii=True) + "\n").encode("utf-8")
@@ -779,7 +791,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             refresh_metrics(config.db_path, config.artifact_root)
         server = make_server(args.host, args.port, config)
         host, port = server.server_address
-        print(f"Serving Screeps RL live dashboard at http://{host}:{port}/")
+        print(f"Serving Screeps RL live dashboard at {format_dashboard_url(str(host), int(port))}")
         try:
             server.serve_forever()
         except KeyboardInterrupt:

--- a/scripts/screeps_rl_live_dashboard.py
+++ b/scripts/screeps_rl_live_dashboard.py
@@ -1,0 +1,794 @@
+#!/usr/bin/env python3
+"""Serve a local live RL dashboard backed by the RL metrics SQLite store."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import sqlite3
+import sys
+import threading
+import urllib.error
+import urllib.request
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Sequence
+from urllib.parse import urlparse
+
+import screeps_rl_dashboard as static_dashboard
+import screeps_rl_metrics_ingestor as metrics_ingestor
+
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8790
+DEFAULT_REFRESH_SECONDS = 60
+DEFAULT_HEALTHCHECK_URL = f"http://{DEFAULT_HOST}:{DEFAULT_PORT}/healthz"
+REQUIRED_TABLES = (
+    "metric_definitions",
+    "metric_observations",
+    "runtime_room_metrics",
+    "gameplay_behavior_findings",
+    "metric_coverage_gaps",
+    "rl_dataset_gate_metrics",
+    "rl_training_execution_metrics",
+    "rl_policy_advantage_metrics",
+    "metric_iteration_decisions",
+)
+DEFAULT_ARTIFACT_SUBDIRS = (
+    "runtime-summary-console",
+    "rl-dataset-gates",
+    "rl-control-loop",
+    "rl-training",
+)
+
+JsonObject = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class LiveDashboardConfig:
+    repo_root: Path
+    artifact_root: Path
+    db_path: Path
+    refresh_seconds: int = DEFAULT_REFRESH_SECONDS
+
+
+class LiveDashboardHTTPServer(ThreadingHTTPServer):
+    config: LiveDashboardConfig
+    refresh_lock: threading.Lock
+
+    def __init__(
+        self,
+        server_address: tuple[str, int],
+        handler_class: type[BaseHTTPRequestHandler],
+        config: LiveDashboardConfig,
+    ) -> None:
+        super().__init__(server_address, handler_class)
+        self.config = config
+        self.refresh_lock = threading.Lock()
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def parse_iso_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def display_timestamp(value: Any) -> str:
+    parsed = parse_iso_datetime(value)
+    if parsed is not None:
+        return parsed.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return str(value) if value not in (None, "") else "N/A"
+
+
+def repo_root_from_script() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def resolve_path(path: Path, repo_root: Path) -> Path:
+    expanded = path.expanduser()
+    return expanded if expanded.is_absolute() else repo_root / expanded
+
+
+def safe_display_path(path: Path | str | None, repo_root: Path) -> str:
+    return static_dashboard.safe_display_path(path, repo_root)
+
+
+def dashboard_json_safe(value: Any, repo_root: Path) -> Any:
+    if isinstance(value, Path):
+        return safe_display_path(value, repo_root)
+    if isinstance(value, datetime):
+        return display_timestamp(value)
+    if isinstance(value, Counter):
+        return dict(value)
+    if isinstance(value, dict):
+        return {str(key): dashboard_json_safe(item, repo_root) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [dashboard_json_safe(item, repo_root) for item in value]
+    return value
+
+
+def load_json_object(path: Path) -> JsonObject | None:
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def artifact_timestamp(path: Path, payload: JsonObject) -> datetime:
+    for key in ("finishedAt", "createdAt", "updatedAt", "generatedAt", "startedAt", "timestamp"):
+        parsed = parse_iso_datetime(payload.get(key))
+        if parsed is not None:
+            return parsed
+    try:
+        return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+    except OSError:
+        return datetime.fromtimestamp(0, tz=timezone.utc)
+
+
+def latest_json_artifact(root: Path, patterns: Sequence[str]) -> tuple[Path, JsonObject, datetime] | None:
+    candidates: list[tuple[Path, JsonObject, datetime]] = []
+    if not root.exists():
+        return None
+    for pattern in patterns:
+        for path in root.glob(pattern):
+            if not path.is_file():
+                continue
+            payload = load_json_object(path)
+            if payload is None:
+                continue
+            candidates.append((path, payload, artifact_timestamp(path, payload)))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda item: item[2])
+
+
+def db_latest_timestamp(conn: sqlite3.Connection, table_name: str, column_name: str) -> str | None:
+    try:
+        row = conn.execute(f"SELECT MAX({column_name}) FROM {table_name}").fetchone()
+    except sqlite3.Error:
+        return None
+    return row[0] if row and row[0] else None
+
+
+def sqlite_summary(db_path: Path, repo_root: Path) -> JsonObject:
+    expanded = db_path.expanduser()
+    summary: JsonObject = {
+        "path": safe_display_path(expanded, repo_root),
+        "exists": expanded.exists(),
+        "sizeBytes": None,
+        "schemaReady": False,
+        "tables": {},
+        "latestObservedAt": None,
+        "error": None,
+    }
+    if not expanded.exists():
+        summary["error"] = "metrics database does not exist"
+        return summary
+
+    try:
+        summary["sizeBytes"] = expanded.stat().st_size
+    except OSError as error:
+        summary["error"] = f"cannot stat metrics database: {error}"
+        return summary
+
+    try:
+        with sqlite3.connect(str(expanded)) as conn:
+            conn.row_factory = sqlite3.Row
+            tables = {
+                row["name"]
+                for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+            }
+            counts: dict[str, int | None] = {}
+            for table in REQUIRED_TABLES:
+                if table not in tables:
+                    counts[table] = None
+                    continue
+                counts[table] = int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+            timestamps = [
+                db_latest_timestamp(conn, "metric_observations", "observed_at"),
+                db_latest_timestamp(conn, "runtime_room_metrics", "observed_at"),
+                db_latest_timestamp(conn, "gameplay_behavior_findings", "first_seen_at"),
+                db_latest_timestamp(conn, "metric_coverage_gaps", "observed_at"),
+                db_latest_timestamp(conn, "rl_dataset_gate_metrics", "observed_at"),
+                db_latest_timestamp(conn, "rl_training_execution_metrics", "observed_at"),
+                db_latest_timestamp(conn, "rl_policy_advantage_metrics", "observed_at"),
+                db_latest_timestamp(conn, "metric_iteration_decisions", "created_at"),
+            ]
+            valid_timestamps = [timestamp for timestamp in timestamps if timestamp]
+            summary["schemaReady"] = all(table in tables for table in REQUIRED_TABLES)
+            summary["tables"] = counts
+            summary["latestObservedAt"] = max(valid_timestamps) if valid_timestamps else None
+    except sqlite3.Error as error:
+        summary["error"] = f"cannot read metrics database: {error}"
+    return summary
+
+
+def health_from_db_summary(db: JsonObject) -> JsonObject:
+    failures: list[str] = []
+    if not db.get("exists"):
+        failures.append("metrics database missing")
+    if db.get("error"):
+        failures.append(str(db["error"]))
+    if db.get("exists") and not db.get("schemaReady"):
+        failures.append("metrics database schema is incomplete")
+    ok = not failures
+    return {
+        "ok": ok,
+        "status": "ok" if ok else "degraded",
+        "failures": failures,
+    }
+
+
+def default_ingest_paths(artifact_root: Path) -> list[Path]:
+    return [artifact_root / subdir for subdir in DEFAULT_ARTIFACT_SUBDIRS]
+
+
+def refresh_metrics(db_path: Path, artifact_root: Path, paths: Sequence[Path] | None = None) -> JsonObject:
+    ingest_paths = list(paths) if paths is not None and len(paths) > 0 else default_ingest_paths(artifact_root)
+    result = metrics_ingestor.ingest_artifacts(db_path, ingest_paths)
+    return {"ok": True, "db": str(db_path), "paths": [str(path) for path in ingest_paths], **result}
+
+
+def latest_scorecard_summary(artifact_root: Path, repo_root: Path) -> JsonObject:
+    latest = latest_json_artifact(
+        artifact_root / "rl-control-loop" / "scorecards",
+        ("*.json",),
+    )
+    if latest is None:
+        return {
+            "hasData": False,
+            "status": "N/A",
+            "runId": "N/A",
+            "latestPath": None,
+            "updatedAt": None,
+            "safetyRegressions": [],
+            "requiredActions": [],
+        }
+    path, payload, timestamp = latest
+    overall_gate = payload.get("overallGate") if isinstance(payload.get("overallGate"), dict) else {}
+    return {
+        "hasData": True,
+        "status": overall_gate.get("status") or overall_gate.get("decision") or payload.get("status") or "UNKNOWN",
+        "runId": payload.get("runId") or path.stem,
+        "candidate": payload.get("candidatePolicyId") or payload.get("candidateId"),
+        "baseline": payload.get("baselinePolicyId") or payload.get("baselineId"),
+        "latestPath": safe_display_path(path, repo_root),
+        "updatedAt": display_timestamp(timestamp),
+        "safetyRegressions": overall_gate.get("safetyRegressions") or payload.get("safetyRegressions") or [],
+        "requiredActions": payload.get("requiredActions") or [],
+    }
+
+
+def tencent_batch_summary(artifact_root: Path, repo_root: Path) -> JsonObject:
+    root = artifact_root / "tencent-cloud" / "batch-runs"
+    runs: list[JsonObject] = []
+    if root.exists():
+        for path in sorted(root.glob("*/controller-summary.json")):
+            payload = load_json_object(path)
+            if payload is None:
+                continue
+            runs.append(
+                {
+                    "runId": payload.get("runId") or path.parent.name,
+                    "finalStatus": payload.get("finalStatus") or "unknown",
+                    "partial": payload.get("partial"),
+                    "startedAt": payload.get("startedAt"),
+                    "finishedAt": payload.get("finishedAt"),
+                    "instanceId": payload.get("instanceId"),
+                    "workerUser": payload.get("workerUser"),
+                    "inputs": payload.get("inputs") if isinstance(payload.get("inputs"), dict) else {},
+                    "safety": payload.get("safety") if isinstance(payload.get("safety"), dict) else {},
+                    "path": safe_display_path(path, repo_root),
+                    "timestamp": display_timestamp(artifact_timestamp(path, payload)),
+                }
+            )
+    latest = max(runs, key=lambda item: item["timestamp"]) if runs else None
+    active = [
+        run
+        for run in runs
+        if run.get("partial") is True or str(run.get("finalStatus", "")).lower() in {"unknown", "running"}
+    ]
+    completed = [run for run in runs if str(run.get("finalStatus", "")).lower() in {"completed", "success", "ok"}]
+    return {
+        "hasData": bool(runs),
+        "runCount": len(runs),
+        "activeRunCount": len(active),
+        "completedRunCount": len(completed),
+        "latest": latest,
+    }
+
+
+def safety_summary(dashboard: JsonObject, tencent: JsonObject, scorecard: JsonObject) -> JsonObject:
+    card_supply = dashboard.get("cardSupply") if isinstance(dashboard.get("cardSupply"), dict) else {}
+    latest_tencent = tencent.get("latest") if isinstance(tencent.get("latest"), dict) else {}
+    tencent_safety = latest_tencent.get("safety") if isinstance(latest_tencent.get("safety"), dict) else {}
+    unsafe_flags = []
+    for field in ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed"):
+        value = tencent_safety.get(field)
+        if value is not False and value is not None:
+            unsafe_flags.append({"source": "tencent", "field": field, "value": value})
+    for regression in scorecard.get("safetyRegressions", []):
+        unsafe_flags.append({"source": "scorecard", "field": "safetyRegression", "value": regression})
+    return {
+        "status": "OK" if not unsafe_flags else "BLOCKED",
+        "unsafeFlags": unsafe_flags,
+        "tencent": tencent_safety,
+        "cardSupplyStatus": card_supply.get("status"),
+        "cardSupplySeverity": card_supply.get("severity"),
+        "fallbackStatus": card_supply.get("fallbackStatus"),
+    }
+
+
+def build_live_summary(
+    repo_root: Path,
+    artifact_root: Path,
+    db_path: Path,
+    *,
+    generated_at: str | None = None,
+) -> JsonObject:
+    generated = generated_at or utc_now_iso()
+    db = sqlite_summary(db_path, repo_root)
+    health = health_from_db_summary(db)
+    raw_dashboard = static_dashboard.build_dashboard(repo_root=repo_root, artifact_root=artifact_root, generated_at=generated)
+    dashboard = dashboard_json_safe(raw_dashboard, repo_root)
+    scorecard = latest_scorecard_summary(artifact_root, repo_root)
+    tencent = tencent_batch_summary(artifact_root, repo_root)
+    safety = safety_summary(dashboard, tencent, scorecard)
+    loop_a = {
+        "environment": dashboard.get("simulator", {}),
+        "training": dashboard.get("training", {}),
+    }
+    loop_b = {
+        "onlineUtilityStatus": dashboard.get("policy", {}).get("status"),
+        "policy": dashboard.get("policy", {}),
+        "scorecard": scorecard,
+    }
+    return {
+        "type": "screeps-rl-live-dashboard",
+        "generatedAt": generated,
+        "repoRoot": safe_display_path(repo_root, repo_root),
+        "artifactRoot": safe_display_path(artifact_root, repo_root),
+        "dashboardUrl": f"http://{DEFAULT_HOST}:{DEFAULT_PORT}/",
+        "health": health,
+        "db": db,
+        "lanes": dashboard.get("lanes", []),
+        "e1Gate": dashboard.get("gate"),
+        "loopA": loop_a,
+        "loopB": loop_b,
+        "tencentBatch": tencent,
+        "safety": safety,
+        "warnings": dashboard.get("warnings", []),
+    }
+
+
+def h(value: Any) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def format_value(value: Any) -> str:
+    if value is None:
+        return "N/A"
+    if isinstance(value, float):
+        return f"{value:.3f}"
+    return str(value)
+
+
+def percent_value(value: Any) -> str:
+    if isinstance(value, (int, float)):
+        return f"{value * 100:.1f}%"
+    return "N/A"
+
+
+def status_class(status: Any) -> str:
+    text = str(status or "unknown").lower()
+    if text in {"ok", "pass", "passed", "proven", "validated", "promotable", "completed", "success"}:
+        return "ok"
+    if text in {"degraded", "unknown", "unproven", "inconclusive", "n/a"}:
+        return "warn"
+    return "bad"
+
+
+def render_status(status: Any) -> str:
+    return f'<span class="status {status_class(status)}">{h(status or "N/A")}</span>'
+
+
+def table(headers: Sequence[str], rows: Sequence[Sequence[Any]], empty_label: str = "No data") -> str:
+    header_html = "".join(f"<th>{h(header)}</th>" for header in headers)
+    if not rows:
+        body = f'<tr><td colspan="{len(headers)}" class="muted">{h(empty_label)}</td></tr>'
+    else:
+        body = "\n".join(
+            "<tr>" + "".join(f"<td>{cell}</td>" for cell in row) + "</tr>"
+            for row in rows
+        )
+    return f"<table><thead><tr>{header_html}</tr></thead><tbody>{body}</tbody></table>"
+
+
+def render_live_html(summary: JsonObject, config: LiveDashboardConfig) -> str:
+    e1 = summary.get("e1Gate") if isinstance(summary.get("e1Gate"), dict) else {}
+    loop_a = summary.get("loopA") if isinstance(summary.get("loopA"), dict) else {}
+    environment = loop_a.get("environment") if isinstance(loop_a.get("environment"), dict) else {}
+    training = loop_a.get("training") if isinstance(loop_a.get("training"), dict) else {}
+    loop_b = summary.get("loopB") if isinstance(summary.get("loopB"), dict) else {}
+    scorecard = loop_b.get("scorecard") if isinstance(loop_b.get("scorecard"), dict) else {}
+    tencent = summary.get("tencentBatch") if isinstance(summary.get("tencentBatch"), dict) else {}
+    latest_tencent = tencent.get("latest") if isinstance(tencent.get("latest"), dict) else {}
+    safety = summary.get("safety") if isinstance(summary.get("safety"), dict) else {}
+    db = summary.get("db") if isinstance(summary.get("db"), dict) else {}
+
+    lane_rows = [
+        (
+            h(row.get("lane")),
+            h(row.get("name")),
+            render_status(row.get("status")),
+            h(row.get("latestArtifact") or "N/A"),
+            h(row.get("blocker") or "N/A"),
+        )
+        for row in summary.get("lanes", [])
+        if isinstance(row, dict)
+    ]
+    db_rows = [
+        ("Path", h(db.get("path"))),
+        ("Exists", render_status("OK" if db.get("exists") else "missing")),
+        ("Schema", render_status("OK" if db.get("schemaReady") else "incomplete")),
+        ("Latest observation", h(display_timestamp(db.get("latestObservedAt")))),
+    ]
+    e1_rows = [
+        ("Status", render_status(e1.get("status"))),
+        ("Acceptance", h(percent_value(e1.get("acceptanceRate")))),
+        ("Sample count", h(format_value(e1.get("sampleCount")))),
+        ("Accepted", h(format_value(e1.get("samplesAccepted")))),
+        ("Rejected", h(format_value(e1.get("samplesRejected")))),
+        ("Source", h(e1.get("displayPath") or "N/A")),
+    ]
+    loop_a_rows = [
+        ("Environments succeeded", h(format_value(environment.get("succeeded")))),
+        ("Environments failed", h(format_value(environment.get("failed")))),
+        ("Ticks run", h(format_value(environment.get("ticksRun")))),
+        ("Training status", render_status(training.get("status"))),
+        ("Episodes", h(format_value(training.get("episodes")))),
+        ("Policy updates", h(format_value(training.get("policyUpdates")))),
+    ]
+    loop_b_rows = [
+        ("Online utility", render_status(loop_b.get("onlineUtilityStatus"))),
+        ("Candidate", h(loop_b.get("policy", {}).get("candidate") if isinstance(loop_b.get("policy"), dict) else "N/A")),
+        ("Baseline", h(loop_b.get("policy", {}).get("baseline") if isinstance(loop_b.get("policy"), dict) else "N/A")),
+        ("Scorecard", render_status(scorecard.get("status"))),
+        ("Scorecard run", h(scorecard.get("runId") or "N/A")),
+    ]
+    tencent_rows = [
+        ("Runs", h(format_value(tencent.get("runCount")))),
+        ("Active runs", h(format_value(tencent.get("activeRunCount")))),
+        ("Completed runs", h(format_value(tencent.get("completedRunCount")))),
+        ("Latest run", h(latest_tencent.get("runId") or "N/A")),
+        ("Latest status", render_status(latest_tencent.get("finalStatus"))),
+        ("Scale down attempted", h(latest_tencent.get("safety", {}).get("scaleDownAttempted") if isinstance(latest_tencent.get("safety"), dict) else "N/A")),
+    ]
+    safety_rows = [
+        ("Status", render_status(safety.get("status"))),
+        ("liveEffect", h(safety.get("tencent", {}).get("liveEffect") if isinstance(safety.get("tencent"), dict) else "N/A")),
+        ("officialMmoWrites", h(safety.get("tencent", {}).get("officialMmoWrites") if isinstance(safety.get("tencent"), dict) else "N/A")),
+        (
+            "officialMmoWritesAllowed",
+            h(safety.get("tencent", {}).get("officialMmoWritesAllowed") if isinstance(safety.get("tencent"), dict) else "N/A"),
+        ),
+        ("Card supply", h(safety.get("cardSupplyStatus") or "N/A")),
+        ("Unsafe flags", h(len(safety.get("unsafeFlags", [])))),
+    ]
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="refresh" content="{h(config.refresh_seconds)}">
+  <title>Screeps RL Live Dashboard</title>
+  <style>
+    :root {{
+      color-scheme: dark;
+      --bg: #0b1014;
+      --panel: #111920;
+      --panel-2: #0f151b;
+      --text: #dbe5ee;
+      --muted: #90a0ad;
+      --border: #253440;
+      --ok: #49c185;
+      --warn: #e5b84c;
+      --bad: #ff6a6a;
+      --accent: #8ab4f8;
+    }}
+    * {{ box-sizing: border-box; }}
+    body {{
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+      font-size: 13px;
+      line-height: 1.45;
+    }}
+    main {{
+      width: min(1500px, calc(100vw - 32px));
+      margin: 0 auto;
+      padding: 18px 0 32px;
+    }}
+    header {{
+      display: grid;
+      gap: 8px;
+      padding-bottom: 14px;
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 14px;
+    }}
+    h1, h2 {{
+      margin: 0;
+      letter-spacing: 0;
+    }}
+    h1 {{ font-size: 22px; }}
+    h2 {{ font-size: 15px; margin-bottom: 10px; }}
+    .meta, .muted {{ color: var(--muted); margin: 0 0 10px; }}
+    .grid {{ display: grid; gap: 12px; margin-bottom: 12px; }}
+    .two {{ grid-template-columns: repeat(2, minmax(0, 1fr)); }}
+    .three {{ grid-template-columns: repeat(3, minmax(0, 1fr)); }}
+    .panel {{
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 12px;
+      overflow: hidden;
+    }}
+    table {{
+      width: 100%;
+      border-collapse: collapse;
+      table-layout: fixed;
+      background: var(--panel-2);
+      border: 1px solid var(--border);
+    }}
+    th, td {{
+      border-bottom: 1px solid var(--border);
+      padding: 6px 8px;
+      text-align: left;
+      vertical-align: top;
+      overflow-wrap: anywhere;
+    }}
+    th {{
+      color: #b8c7d6;
+      background: #16212b;
+    }}
+    tr:last-child td {{ border-bottom: 0; }}
+    .status {{
+      display: inline-block;
+      min-width: 70px;
+      border-radius: 4px;
+      padding: 2px 6px;
+      color: #091015;
+      text-align: center;
+      font-weight: 700;
+    }}
+    .ok {{ background: var(--ok); }}
+    .warn {{ background: var(--warn); }}
+    .bad {{ background: var(--bad); }}
+    code {{ color: var(--accent); }}
+    @media (max-width: 900px) {{
+      main {{ width: calc(100vw - 20px); }}
+      .two, .three {{ grid-template-columns: 1fr; }}
+      body {{ font-size: 12px; }}
+    }}
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>Screeps RL Live Dashboard</h1>
+    <p class="meta">Generated {h(summary.get("generatedAt"))}. Auto-refreshes every {h(config.refresh_seconds)}s. JSON: <code>/api/summary</code>. Health: <code>/healthz</code>.</p>
+    <p class="meta">DB {h(db.get("path"))}; artifacts {h(summary.get("artifactRoot"))}.</p>
+  </header>
+
+  <section class="panel grid">
+    <h2>Lane Status</h2>
+    {table(("Lane", "Name", "Status", "Latest artifact", "Blocker"), lane_rows)}
+  </section>
+
+  <div class="grid two">
+    <section class="panel"><h2>Metrics Store</h2>{table(("Item", "Value"), db_rows)}</section>
+    <section class="panel"><h2>E1 Gate Acceptance</h2>{table(("Item", "Value"), e1_rows)}</section>
+  </div>
+
+  <div class="grid two">
+    <section class="panel"><h2>Loop A Env Ticks Episodes</h2>{table(("Item", "Value"), loop_a_rows)}</section>
+    <section class="panel"><h2>Loop B Utility Scorecard</h2>{table(("Item", "Value"), loop_b_rows)}</section>
+  </div>
+
+  <div class="grid two">
+    <section class="panel"><h2>Tencent Batch Utilization</h2>{table(("Item", "Value"), tencent_rows)}</section>
+    <section class="panel"><h2>Safety Flags</h2>{table(("Item", "Value"), safety_rows)}</section>
+  </div>
+</main>
+</body>
+</html>
+"""
+
+
+class LiveDashboardRequestHandler(BaseHTTPRequestHandler):
+    server: LiveDashboardHTTPServer
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        if parsed.path in ("", "/"):
+            self.write_html(HTTPStatus.OK, render_live_html(self.summary(), self.server.config))
+            return
+        if parsed.path == "/api/summary":
+            self.write_json(HTTPStatus.OK, self.summary())
+            return
+        if parsed.path == "/healthz":
+            summary = self.summary()
+            status = HTTPStatus.OK if summary["health"]["ok"] else HTTPStatus.SERVICE_UNAVAILABLE
+            self.write_json(status, summary["health"] | {"db": summary["db"], "generatedAt": summary["generatedAt"]})
+            return
+        self.write_json(HTTPStatus.NOT_FOUND, {"ok": False, "error": "not found"})
+
+    def do_POST(self) -> None:
+        parsed = urlparse(self.path)
+        if parsed.path != "/refresh":
+            self.write_json(HTTPStatus.NOT_FOUND, {"ok": False, "error": "not found"})
+            return
+        with self.server.refresh_lock:
+            try:
+                refresh = refresh_metrics(self.server.config.db_path, self.server.config.artifact_root)
+            except Exception as error:  # pragma: no cover - defensive handler boundary
+                self.write_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"ok": False, "error": str(error)})
+                return
+        self.write_json(HTTPStatus.OK, {"ok": True, "refresh": refresh, "summary": self.summary()})
+
+    def log_message(self, format: str, *args: Any) -> None:
+        sys.stderr.write("%s - - [%s] %s\n" % (self.address_string(), self.log_date_time_string(), format % args))
+
+    def summary(self) -> JsonObject:
+        config = self.server.config
+        return build_live_summary(config.repo_root, config.artifact_root, config.db_path)
+
+    def write_json(self, status: HTTPStatus, payload: JsonObject) -> None:
+        body = (json.dumps(payload, sort_keys=True, ensure_ascii=True) + "\n").encode("utf-8")
+        self.send_response(status.value)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def write_html(self, status: HTTPStatus, body_text: str) -> None:
+        body = body_text.encode("utf-8")
+        self.send_response(status.value)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def make_server(host: str, port: int, config: LiveDashboardConfig) -> LiveDashboardHTTPServer:
+    return LiveDashboardHTTPServer((host, port), LiveDashboardRequestHandler, config)
+
+
+def build_config(args: argparse.Namespace) -> LiveDashboardConfig:
+    repo_root = args.repo_root.expanduser().resolve()
+    artifact_root = resolve_path(args.artifact_root, repo_root).resolve()
+    db_path = resolve_path(args.db, repo_root)
+    return LiveDashboardConfig(
+        repo_root=repo_root,
+        artifact_root=artifact_root,
+        db_path=db_path,
+        refresh_seconds=args.refresh_seconds,
+    )
+
+
+def add_common_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--repo-root", type=Path, default=repo_root_from_script(), help="Repository root.")
+    parser.add_argument(
+        "--artifact-root",
+        type=Path,
+        default=Path("runtime-artifacts"),
+        help="Runtime artifact root. Defaults to <repo>/runtime-artifacts.",
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=metrics_ingestor.DEFAULT_DB_PATH,
+        help="RL metrics SQLite path.",
+    )
+    parser.add_argument(
+        "--refresh-seconds",
+        type=int,
+        default=DEFAULT_REFRESH_SECONDS,
+        help="HTML meta-refresh interval in seconds.",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Serve or inspect the local Screeps RL live dashboard.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    serve = subparsers.add_parser("serve", help="serve the live dashboard over HTTP")
+    add_common_args(serve)
+    serve.add_argument("--host", default=DEFAULT_HOST, help="Bind host.")
+    serve.add_argument("--port", type=int, default=DEFAULT_PORT, help="Bind port.")
+    serve.add_argument("--refresh-on-start", action="store_true", help="Run the metrics ingestor before serving.")
+
+    refresh = subparsers.add_parser("refresh", help="refresh the SQLite metrics database with the ingestor")
+    add_common_args(refresh)
+    refresh.add_argument("paths", nargs="*", type=Path, help="Optional artifact files/directories to ingest.")
+
+    summary = subparsers.add_parser("summary", help="print the live dashboard summary JSON")
+    add_common_args(summary)
+
+    health = subparsers.add_parser("healthcheck", help="check a running dashboard /healthz endpoint")
+    health.add_argument("--url", default=DEFAULT_HEALTHCHECK_URL, help="Health URL.")
+    health.add_argument("--timeout", type=float, default=5.0, help="HTTP timeout seconds.")
+    return parser
+
+
+def run_healthcheck(url: str, timeout: float) -> int:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+            ok = bool(payload.get("ok"))
+            print(json.dumps(payload, sort_keys=True))
+            return 0 if ok else 1
+    except urllib.error.HTTPError as error:
+        body = error.read().decode("utf-8", errors="replace")
+        print(body.strip() or json.dumps({"ok": False, "status": error.code}))
+        return 1
+    except (OSError, json.JSONDecodeError) as error:
+        print(json.dumps({"ok": False, "error": str(error)}, sort_keys=True))
+        return 1
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "healthcheck":
+        return run_healthcheck(args.url, args.timeout)
+
+    config = build_config(args)
+    if args.command == "refresh":
+        paths = [resolve_path(path, config.repo_root) for path in args.paths]
+        result = refresh_metrics(config.db_path, config.artifact_root, paths)
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    if args.command == "summary":
+        print(json.dumps(build_live_summary(config.repo_root, config.artifact_root, config.db_path), sort_keys=True))
+        return 0
+    if args.command == "serve":
+        if args.refresh_on_start:
+            refresh_metrics(config.db_path, config.artifact_root)
+        server = make_server(args.host, args.port, config)
+        host, port = server.server_address
+        print(f"Serving Screeps RL live dashboard at http://{host}:{port}/")
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            print("Stopping Screeps RL live dashboard.")
+        finally:
+            server.server_close()
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_screeps_rl_live_dashboard.py
+++ b/scripts/test_screeps_rl_live_dashboard.py
@@ -140,6 +140,20 @@ def read_json_url(url: str, timeout: float = 1.0) -> JsonObject:
     return payload
 
 
+def post_json_url(url: str, timeout: float = 1.0) -> tuple[int, JsonObject]:
+    request = urllib.request.Request(url, data=b"", method="POST")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            status = response.status
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        status = error.code
+        payload = json.loads(error.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise AssertionError(f"expected JSON object from {url}")
+    return status, payload
+
+
 def wait_for_json_url(url: str, timeout_seconds: float = 5.0) -> JsonObject:
     deadline = time.monotonic() + timeout_seconds
     last_error: Exception | None = None
@@ -251,6 +265,50 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
             summary["safety"]["unsafeFlags"],
         )
 
+    def test_missing_tencent_controller_summary_blocks_dashboard(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            artifact_root = repo_root / "runtime-artifacts"
+            db_path = repo_root / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite"
+            write_live_artifacts(artifact_root)
+            controller_summary = artifact_root / "tencent-cloud" / "batch-runs" / "tencent-live" / "controller-summary.json"
+            controller_summary.unlink()
+
+            summary = live.build_live_summary(
+                repo_root,
+                artifact_root,
+                db_path,
+                generated_at="2026-05-18T10:09:00Z",
+            )
+
+        self.assertEqual(summary["safety"]["status"], "BLOCKED")
+        self.assertIn(
+            {"source": "tencent", "field": "controllerSummary", "value": "missing"},
+            summary["safety"]["unsafeFlags"],
+        )
+
+    def test_missing_scorecard_summary_blocks_dashboard(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            artifact_root = repo_root / "runtime-artifacts"
+            db_path = repo_root / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite"
+            write_live_artifacts(artifact_root)
+            scorecard = artifact_root / "rl-control-loop" / "scorecards" / "scorecard.json"
+            scorecard.unlink()
+
+            summary = live.build_live_summary(
+                repo_root,
+                artifact_root,
+                db_path,
+                generated_at="2026-05-18T10:09:00Z",
+            )
+
+        self.assertEqual(summary["safety"]["status"], "BLOCKED")
+        self.assertIn(
+            {"source": "scorecard", "field": "summary", "value": "missing"},
+            summary["safety"]["unsafeFlags"],
+        )
+
     def test_health_and_summary_endpoints_are_startable(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             repo_root = Path(temp_dir)
@@ -278,6 +336,104 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
         self.assertEqual(summary["type"], "screeps-rl-live-dashboard")
         self.assertEqual(summary["dashboardUrl"], f"http://{host}:{port}/")
         self.assertEqual(summary["e1Gate"]["gateId"], "e1-live")
+
+    def test_refresh_endpoint_is_disabled_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            artifact_root = repo_root / "runtime-artifacts"
+            db_path = repo_root / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite"
+            write_live_artifacts(artifact_root)
+            config = live.LiveDashboardConfig(repo_root=repo_root, artifact_root=artifact_root, db_path=db_path)
+            try:
+                server = live.make_server("127.0.0.1", 0, config)
+            except OSError as error:
+                self.skipTest(f"socket creation is unavailable in this sandbox: {error}")
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            try:
+                host, port = server.server_address
+                wait_for_json_url(f"http://{host}:{port}/api/summary")
+                status, payload = post_json_url(f"http://{host}:{port}/refresh")
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=5)
+
+        self.assertEqual(status, 403)
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["error"], "refresh endpoint disabled")
+        self.assertFalse(db_path.exists())
+
+    def test_refresh_endpoint_propagates_soft_refresh_failure(self) -> None:
+        original_refresh_metrics = live.refresh_metrics
+
+        def failing_refresh_metrics(db_path: Path, artifact_root: Path, paths: Any = None) -> JsonObject:
+            return {"ok": False, "error": "ingestor soft failure"}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            artifact_root = repo_root / "runtime-artifacts"
+            db_path = repo_root / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite"
+            write_live_artifacts(artifact_root)
+            config = live.LiveDashboardConfig(
+                repo_root=repo_root,
+                artifact_root=artifact_root,
+                db_path=db_path,
+                enable_refresh_endpoint=True,
+            )
+            try:
+                server = live.make_server("127.0.0.1", 0, config)
+            except OSError as error:
+                self.skipTest(f"socket creation is unavailable in this sandbox: {error}")
+            live.refresh_metrics = failing_refresh_metrics
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            try:
+                host, port = server.server_address
+                wait_for_json_url(f"http://{host}:{port}/api/summary")
+                status, payload = post_json_url(f"http://{host}:{port}/refresh")
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=5)
+                live.refresh_metrics = original_refresh_metrics
+
+        self.assertEqual(status, 500)
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["error"], "refresh failed")
+        self.assertEqual(payload["refresh"]["error"], "ingestor soft failure")
+
+    def test_refresh_on_start_returns_failure_when_refresh_reports_not_ok(self) -> None:
+        original_refresh_metrics = live.refresh_metrics
+
+        def failing_refresh_metrics(db_path: Path, artifact_root: Path, paths: Any = None) -> JsonObject:
+            return {"ok": False, "error": "ingestor soft failure"}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            artifact_root = repo_root / "runtime-artifacts"
+            db_path = repo_root / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite"
+            write_live_artifacts(artifact_root)
+            live.refresh_metrics = failing_refresh_metrics
+            try:
+                exit_code = live.main(
+                    [
+                        "serve",
+                        "--repo-root",
+                        str(repo_root),
+                        "--artifact-root",
+                        str(artifact_root),
+                        "--db",
+                        str(db_path),
+                        "--refresh-on-start",
+                        "--port",
+                        "0",
+                    ]
+                )
+            finally:
+                live.refresh_metrics = original_refresh_metrics
+
+        self.assertEqual(exit_code, 1)
 
 
 if __name__ == "__main__":

--- a/scripts/test_screeps_rl_live_dashboard.py
+++ b/scripts/test_screeps_rl_live_dashboard.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+import threading
+import unittest
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import screeps_rl_live_dashboard as live
+
+
+JsonObject = dict[str, Any]
+
+
+def write_json(path: Path, payload: JsonObject) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
+
+def write_runtime_summary(path: Path) -> None:
+    payload = {
+        "type": "runtime-summary",
+        "tick": 12345,
+        "shard": "shardX",
+        "cpu": {"bucket": 9000, "used": 7.5},
+        "reliability": {"loopExceptionCount": 0, "telemetrySilenceTicks": 0},
+        "rooms": [
+            {
+                "roomName": "E29N55",
+                "controller": {"my": True, "level": 3},
+                "rclLevel": 3,
+                "workerCount": 4,
+                "spawnStatus": [{"name": "Spawn1", "status": "idle"}],
+                "taskCounts": {"harvest": 1, "build": 1, "upgrade": 2},
+                "energyAvailable": 300,
+                "resources": {"storedEnergy": 900, "workerCarriedEnergy": 50},
+                "combat": {"hostileCreepCount": 0},
+                "structures": {"spawn": 1, "tower": 1, "rampart": 0},
+            }
+        ],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"#runtime-summary {json.dumps(payload, sort_keys=True)}\n", encoding="utf-8")
+
+
+def write_live_artifacts(root: Path) -> None:
+    write_runtime_summary(root / "runtime-summary-console" / "runtime.log")
+    write_json(
+        root / "rl-dataset-gates" / "e1-live" / "gate_summary.json",
+        {
+            "type": "screeps-rl-dataset-evaluation-gate",
+            "gateId": "e1-live",
+            "datasetGate": {"status": "pass", "sampleCount": 100},
+            "quality_checks": {"status": "pass", "samples_accepted": 95, "samples_rejected": 5},
+            "createdAt": "2026-05-18T10:00:00Z",
+        },
+    )
+    write_json(
+        root / "rl-control-loop" / "training-ledger.json",
+        {
+            "type": "screeps-rl-training-execution-ledger",
+            "status": "RUN",
+            "trainingDidRun": True,
+            "iterationExecution": {
+                "episodesRun": 7,
+                "policyUpdateIterations": 3,
+                "simulatorTicksRun": 1400,
+            },
+            "environmentExecution": {"completed": 2, "failed": 0, "lastNewRunAt": "2026-05-18T10:05:00Z"},
+            "createdAt": "2026-05-18T10:05:00Z",
+        },
+    )
+    write_json(
+        root / "rl-control-loop" / "policy-advantage.json",
+        {
+            "type": "screeps-rl-policy-online-advantage-report",
+            "onlineUtilityStatus": "PROVEN",
+            "candidatePolicyId": "candidate-policy",
+            "baselinePolicyId": "incumbent-policy",
+            "metricsByCategory": {
+                "territory": {"status": "ADVANTAGE", "candidateValue": 3, "baselineValue": 2, "delta": 1},
+            },
+            "createdAt": "2026-05-18T10:06:00Z",
+        },
+    )
+    write_json(
+        root / "rl-control-loop" / "scorecards" / "scorecard.json",
+        {
+            "type": "screeps-rl-evaluation-scorecard",
+            "runId": "scorecard-live",
+            "overallGate": {"status": "PASS", "safetyRegressions": []},
+            "requiredActions": [],
+            "createdAt": "2026-05-18T10:07:00Z",
+        },
+    )
+    write_json(
+        root / "tencent-cloud" / "batch-runs" / "tencent-live" / "controller-summary.json",
+        {
+            "type": "screeps-tencent-batch-rl-run",
+            "runId": "tencent-live",
+            "startedAt": "2026-05-18T10:01:00Z",
+            "finishedAt": "2026-05-18T10:08:00Z",
+            "finalStatus": "completed",
+            "partial": False,
+            "instanceId": "ins-live",
+            "workerUser": "screeps-batch",
+            "inputs": {"ticks": 500, "workers": 5, "repetitions": 5},
+            "safety": {
+                "liveEffect": False,
+                "officialMmoWrites": False,
+                "officialMmoWritesAllowed": False,
+                "billingGuardBeforeScale": True,
+                "scaleDownAttempted": True,
+            },
+        },
+    )
+    (root / "rl-training").mkdir(parents=True, exist_ok=True)
+
+
+def count_rows(db_path: Path, table: str) -> int:
+    with sqlite3.connect(db_path) as conn:
+        return int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+
+
+class ScreepsRlLiveDashboardTest(unittest.TestCase):
+    def test_refresh_is_repeatable_and_summary_covers_live_observability(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            artifact_root = repo_root / "runtime-artifacts"
+            db_path = repo_root / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite"
+            write_live_artifacts(artifact_root)
+
+            first_refresh = live.refresh_metrics(db_path, artifact_root)
+            first_counts = {
+                table: count_rows(db_path, table)
+                for table in ("metric_observations", "rl_dataset_gate_metrics", "metric_coverage_gaps")
+            }
+            second_refresh = live.refresh_metrics(db_path, artifact_root)
+            second_counts = {
+                table: count_rows(db_path, table)
+                for table in ("metric_observations", "rl_dataset_gate_metrics", "metric_coverage_gaps")
+            }
+            summary = live.build_live_summary(
+                repo_root,
+                artifact_root,
+                db_path,
+                generated_at="2026-05-18T10:09:00Z",
+            )
+            html = live.render_live_html(
+                summary,
+                live.LiveDashboardConfig(repo_root=repo_root, artifact_root=artifact_root, db_path=db_path),
+            )
+
+        self.assertTrue(first_refresh["ok"])
+        self.assertTrue(second_refresh["ok"])
+        self.assertEqual(second_counts, first_counts)
+        self.assertTrue(summary["health"]["ok"])
+        self.assertEqual(summary["e1Gate"]["acceptanceRate"], 0.95)
+        self.assertEqual(summary["loopA"]["environment"]["ticksRun"], 1400)
+        self.assertEqual(summary["loopA"]["training"]["episodes"], 7.0)
+        self.assertEqual(summary["loopB"]["onlineUtilityStatus"], "PROVEN")
+        self.assertEqual(summary["loopB"]["scorecard"]["status"], "PASS")
+        self.assertEqual(summary["tencentBatch"]["latest"]["runId"], "tencent-live")
+        self.assertEqual(summary["safety"]["status"], "OK")
+        self.assertIn("E1 Gate Acceptance", html)
+        self.assertIn("Loop A Env Ticks Episodes", html)
+        self.assertIn("Loop B Utility Scorecard", html)
+        self.assertIn("Tencent Batch Utilization", html)
+        self.assertIn("Safety Flags", html)
+
+    def test_health_and_summary_endpoints_are_startable(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            artifact_root = repo_root / "runtime-artifacts"
+            db_path = repo_root / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite"
+            write_live_artifacts(artifact_root)
+            live.refresh_metrics(db_path, artifact_root)
+            config = live.LiveDashboardConfig(repo_root=repo_root, artifact_root=artifact_root, db_path=db_path)
+            try:
+                server = live.make_server("127.0.0.1", 0, config)
+            except PermissionError:
+                self.skipTest("socket creation is unavailable in this sandbox")
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            try:
+                host, port = server.server_address
+                with urllib.request.urlopen(f"http://{host}:{port}/healthz", timeout=5) as response:
+                    health = json.loads(response.read().decode("utf-8"))
+                with urllib.request.urlopen(f"http://{host}:{port}/api/summary", timeout=5) as response:
+                    summary = json.loads(response.read().decode("utf-8"))
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=5)
+
+        self.assertTrue(health["ok"])
+        self.assertEqual(summary["type"], "screeps-rl-live-dashboard")
+        self.assertEqual(summary["e1Gate"]["gateId"], "e1-live")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_screeps_rl_live_dashboard.py
+++ b/scripts/test_screeps_rl_live_dashboard.py
@@ -6,6 +6,8 @@ import sqlite3
 import sys
 import tempfile
 import threading
+import time
+import urllib.error
 import unittest
 import urllib.request
 from pathlib import Path
@@ -130,6 +132,29 @@ def count_rows(db_path: Path, table: str) -> int:
         return int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
 
 
+def read_json_url(url: str, timeout: float = 1.0) -> JsonObject:
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise AssertionError(f"expected JSON object from {url}")
+    return payload
+
+
+def wait_for_json_url(url: str, timeout_seconds: float = 5.0) -> JsonObject:
+    deadline = time.monotonic() + timeout_seconds
+    last_error: Exception | None = None
+    while True:
+        try:
+            return read_json_url(url)
+        except urllib.error.HTTPError:
+            raise
+        except (OSError, json.JSONDecodeError) as error:
+            last_error = error
+            if time.monotonic() >= deadline:
+                raise AssertionError(f"server did not become ready at {url}: {last_error}") from last_error
+            time.sleep(0.05)
+
+
 class ScreepsRlLiveDashboardTest(unittest.TestCase):
     def test_refresh_is_repeatable_and_summary_covers_live_observability(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -186,16 +211,14 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
             config = live.LiveDashboardConfig(repo_root=repo_root, artifact_root=artifact_root, db_path=db_path)
             try:
                 server = live.make_server("127.0.0.1", 0, config)
-            except PermissionError:
-                self.skipTest("socket creation is unavailable in this sandbox")
+            except OSError as error:
+                self.skipTest(f"socket creation is unavailable in this sandbox: {error}")
             thread = threading.Thread(target=server.serve_forever, daemon=True)
             thread.start()
             try:
                 host, port = server.server_address
-                with urllib.request.urlopen(f"http://{host}:{port}/healthz", timeout=5) as response:
-                    health = json.loads(response.read().decode("utf-8"))
-                with urllib.request.urlopen(f"http://{host}:{port}/api/summary", timeout=5) as response:
-                    summary = json.loads(response.read().decode("utf-8"))
+                health = wait_for_json_url(f"http://{host}:{port}/healthz")
+                summary = read_json_url(f"http://{host}:{port}/api/summary")
             finally:
                 server.shutdown()
                 server.server_close()
@@ -203,6 +226,7 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
 
         self.assertTrue(health["ok"])
         self.assertEqual(summary["type"], "screeps-rl-live-dashboard")
+        self.assertEqual(summary["dashboardUrl"], f"http://{host}:{port}/")
         self.assertEqual(summary["e1Gate"]["gateId"], "e1-live")
 
 

--- a/scripts/test_screeps_rl_live_dashboard.py
+++ b/scripts/test_screeps_rl_live_dashboard.py
@@ -201,6 +201,56 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
         self.assertIn("Tencent Batch Utilization", html)
         self.assertIn("Safety Flags", html)
 
+    def test_missing_tencent_safety_object_blocks_dashboard(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            artifact_root = repo_root / "runtime-artifacts"
+            db_path = repo_root / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite"
+            write_live_artifacts(artifact_root)
+            controller_summary = artifact_root / "tencent-cloud" / "batch-runs" / "tencent-live" / "controller-summary.json"
+            payload = json.loads(controller_summary.read_text(encoding="utf-8"))
+            payload.pop("safety")
+            write_json(controller_summary, payload)
+
+            summary = live.build_live_summary(
+                repo_root,
+                artifact_root,
+                db_path,
+                generated_at="2026-05-18T10:09:00Z",
+            )
+
+        missing_fields = {
+            flag["field"]
+            for flag in summary["safety"]["unsafeFlags"]
+            if flag.get("source") == "tencent" and flag.get("value") == "missing"
+        }
+        self.assertEqual(summary["safety"]["status"], "BLOCKED")
+        self.assertEqual(missing_fields, set(live.REQUIRED_TENCENT_SAFETY_FIELDS))
+
+    def test_missing_tencent_safety_field_blocks_dashboard(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            artifact_root = repo_root / "runtime-artifacts"
+            db_path = repo_root / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite"
+            write_live_artifacts(artifact_root)
+            controller_summary = artifact_root / "tencent-cloud" / "batch-runs" / "tencent-live" / "controller-summary.json"
+            payload = json.loads(controller_summary.read_text(encoding="utf-8"))
+            payload["safety"].pop("officialMmoWritesAllowed")
+            write_json(controller_summary, payload)
+
+            summary = live.build_live_summary(
+                repo_root,
+                artifact_root,
+                db_path,
+                generated_at="2026-05-18T10:09:00Z",
+            )
+
+        self.assertEqual(summary["safety"]["status"], "BLOCKED")
+        self.assertIn(
+            {"source": "tencent", "field": "officialMmoWritesAllowed", "value": "missing"},
+            summary["safety"]["unsafeFlags"],
+        )
+
     def test_health_and_summary_endpoints_are_startable(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             repo_root = Path(temp_dir)


### PR DESCRIPTION
## Summary
- Adds a lightweight live RL dashboard service backed by the existing SQLite metrics DB.
- Adds health/API endpoints and focused unit tests for the live surface.
- Documents the runbook and links the live dashboard metrics into the RL gameplay metrics taxonomy.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_live_dashboard.py scripts/test_screeps_rl_live_dashboard.py`
- `python3 -m unittest scripts/test_screeps_rl_live_dashboard.py`

Closes #1184

Safety: dashboard/read-only observability only; no official MMO writes, no paid Tencent scale-out.
