### PR TITLE
fix(rl): prove true-gradient policy updates

### DIFF
--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -68,6 +68,7 @@ POLICY_GRADIENT_SIMULATION_TICKS = POLICY_GRADIENT_MIN_SIMULATION_TICKS
 POLICY_GRADIENT_SIMULATION_REPETITIONS = 5
 POLICY_GRADIENT_UPDATE_ALGORITHM = "reinforce_v1"
 POLICY_GRADIENT_UPDATE_LEARNING_RATE = 1
+POLICY_GRADIENT_UPDATE_ESTIMATOR = "score_function_reinforce_v1"
 LOOP_A_LOCAL_FALLBACK_TICKS = POLICY_GRADIENT_MIN_SIMULATION_TICKS
 LOOP_A_LOCAL_FALLBACK_MAX_TICKS = 5000
 LOOP_A_LOCAL_FALLBACK_REPETITIONS = 5
@@ -798,7 +799,7 @@ def policy_gradient_block(registry_path: Path) -> JsonObject:
         "policy_update": {
             "algorithm": POLICY_GRADIENT_UPDATE_ALGORITHM,
             "learning_rate": POLICY_GRADIENT_UPDATE_LEARNING_RATE,
-            "estimator": "score_function_reinforce_v1",
+            "estimator": POLICY_GRADIENT_UPDATE_ESTIMATOR,
             "bounded_integer_step": True,
         },
         "runner_support": {
@@ -1647,6 +1648,8 @@ def validate_policy_gradient(raw: Any) -> None:
             raise CardValidationError(f"duplicate policy_gradient candidatePolicyId: {candidate_policy_id}")
         candidate_ids.add(candidate_policy_id)
 
+    validate_policy_gradient_update(first_present(raw, ("policy_update", "policyUpdate")))
+
     support = first_present(raw, ("runner_support", "runnerSupport"))
     if not isinstance(support, dict):
         raise CardValidationError("policy_gradient.runner_support must be a JSON object")
@@ -1672,6 +1675,29 @@ def validate_policy_gradient(raw: Any) -> None:
     safety = raw.get("safety")
     if safety is not None:
         validate_safety({"safety": safety})
+
+
+def validate_policy_gradient_update(raw: Any) -> None:
+    if not isinstance(raw, dict):
+        raise CardValidationError("policy_gradient.policy_update must be a JSON object")
+    algorithm = first_present(raw, ("algorithm", "policy_update_algorithm", "policyUpdateAlgorithm"))
+    if algorithm != POLICY_GRADIENT_UPDATE_ALGORITHM:
+        raise CardValidationError(
+            f"policy_gradient.policy_update.algorithm must be {POLICY_GRADIENT_UPDATE_ALGORITHM}"
+        )
+    learning_rate = first_present(raw, ("learning_rate", "learningRate"))
+    if not is_finite_number(learning_rate) or float(learning_rate) != float(POLICY_GRADIENT_UPDATE_LEARNING_RATE):
+        raise CardValidationError(
+            f"policy_gradient.policy_update.learning_rate must be {POLICY_GRADIENT_UPDATE_LEARNING_RATE}"
+        )
+    estimator = raw.get("estimator")
+    if estimator != POLICY_GRADIENT_UPDATE_ESTIMATOR:
+        raise CardValidationError(
+            f"policy_gradient.policy_update.estimator must be {POLICY_GRADIENT_UPDATE_ESTIMATOR}"
+        )
+    bounded_step = first_present(raw, ("bounded_integer_step", "boundedIntegerStep"))
+    if bounded_step is not True:
+        raise CardValidationError("policy_gradient.policy_update.bounded_integer_step must be true")
 
 
 def validate_policy_gradient_strategy_variants(policy_gradient: Any, strategy_variants: Any) -> None:

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -66,6 +66,8 @@ MULTI_TIER_ACTIVE_IMPLEMENTATION_STATUS = "active_fixture_validated"
 POLICY_GRADIENT_MIN_SIMULATION_TICKS = 500
 POLICY_GRADIENT_SIMULATION_TICKS = POLICY_GRADIENT_MIN_SIMULATION_TICKS
 POLICY_GRADIENT_SIMULATION_REPETITIONS = 5
+POLICY_GRADIENT_UPDATE_ALGORITHM = "reinforce_v1"
+POLICY_GRADIENT_UPDATE_LEARNING_RATE = 1
 LOOP_A_LOCAL_FALLBACK_TICKS = POLICY_GRADIENT_MIN_SIMULATION_TICKS
 LOOP_A_LOCAL_FALLBACK_MAX_TICKS = 5000
 LOOP_A_LOCAL_FALLBACK_REPETITIONS = 5
@@ -793,6 +795,12 @@ def policy_gradient_block(registry_path: Path) -> JsonObject:
         "owning_issues": ["#1032", "#879", "#924"],
         "learnable_parameters": construction_priority_learnable_parameters(registry_path),
         "candidate_parameter_vectors": candidates,
+        "policy_update": {
+            "algorithm": POLICY_GRADIENT_UPDATE_ALGORITHM,
+            "learning_rate": POLICY_GRADIENT_UPDATE_LEARNING_RATE,
+            "estimator": "score_function_reinforce_v1",
+            "bounded_integer_step": True,
+        },
         "runner_support": {
             "inline_candidates_applied_to_simulator": False,
             "simulator_variant_transport": "variant_ids_only",

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -1065,6 +1065,44 @@ class RlExperimentCardTest(unittest.TestCase):
         ):
             card_helper.validate_card(card)
 
+    def test_validate_policy_gradient_rejects_malformed_policy_update(self) -> None:
+        cases = (
+            ("missing policy_update", None, None, "policy_gradient.policy_update must be a JSON object"),
+            (
+                "non-object policy_update",
+                "__policy_update__",
+                [],
+                "policy_gradient.policy_update must be a JSON object",
+            ),
+            ("unsupported algorithm", "algorithm", "finite_difference", "policy_update.algorithm must be reinforce_v1"),
+            ("unsafe learning rate", "learning_rate", 0, "policy_update.learning_rate must be 1"),
+            (
+                "unsupported estimator",
+                "estimator",
+                "rank_weighted",
+                "policy_update.estimator must be score_function_reinforce_v1",
+            ),
+            ("unbounded step", "bounded_integer_step", False, "policy_update.bounded_integer_step must be true"),
+        )
+        for label, field, value, expected_error in cases:
+            with self.subTest(label=label):
+                card = card_helper.build_card(
+                    dataset_run_id="rl-policy-gradient-update-contract",
+                    code_commit="f" * 40,
+                    training_approach="policy_gradient",
+                    created_at="2026-05-17T00:25:00Z",
+                )
+                policy_gradient = card["policy_gradient"]
+                if field is None:
+                    policy_gradient.pop("policy_update")
+                elif field == "__policy_update__":
+                    policy_gradient["policy_update"] = value
+                else:
+                    policy_gradient["policy_update"][field] = value
+
+                with self.assertRaisesRegex(card_helper.CardValidationError, expected_error):
+                    card_helper.validate_card(card)
+
     def test_validate_policy_gradient_rejects_unsupported_runner_transport(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-policy-gradient-runner-transport",

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -108,6 +108,9 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertTrue(card["conservative_actions_only"])
         self.assertTrue(card["ood_rejection"])
         self.assertEqual(policy_gradient["target_family"], "construction-priority")
+        self.assertEqual(policy_gradient["policy_update"]["algorithm"], "reinforce_v1")
+        self.assertEqual(policy_gradient["policy_update"]["learning_rate"], 1)
+        self.assertEqual(policy_gradient["policy_update"]["estimator"], "score_function_reinforce_v1")
         runner_support = policy_gradient["runner_support"]
         self.assertEqual(
             learnable_names,

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -1239,6 +1239,69 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(artifact["parameterEvidence"]["returnSampleCount"], 8)
         self.assertEqual(artifact["parameterEvidence"]["returnBaseline"], update["returnSummary"]["baseline"])
 
+    def test_loop_a_true_gradient_card_takes_bounded_step_on_small_safe_advantage(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-loop-a-true-gradient-proof",
+            code_commit="9" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-18T05:25:00Z",
+            simulation_repetitions=1,
+            loop_a_card_supply=True,
+        )
+        variant_ids = [variant["id"] for variant in card["strategy_variants"]]
+
+        def result_for(variant_id: str) -> JsonObject:
+            result = variant_result(variant_id, [])
+            result["metrics"] = {
+                "territoryDelta": 0.4 if variant_id.endswith("territory-seed.v1") else 0,
+                "storedEnergyDelta": 0,
+                "collectedEnergy": 0,
+                "hostileKills": 0,
+                "ownLosses": 0,
+                "initialRoomStates": {
+                    "E1S1": room("E1S1", spawns=1, creeps=1, energy=100),
+                },
+                "finalRoomStates": {
+                    "E1S1": room("E1S1", spawns=1, creeps=1, energy=100),
+                },
+            }
+            return result
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                out_dir,
+                report_id="loop-a-true-gradient-proof",
+                generated_at="2026-05-18T05:30:00Z",
+                simulator_runner=MockSimulator({variant_id: result_for(variant_id) for variant_id in variant_ids}),
+            )
+            persisted = read_json(out_dir / "loop-a-true-gradient-proof.json")
+            artifact = read_json(Path(report["policyUpdateArtifactPath"]))
+
+        self.assertEqual(report["policyUpdateIterations"], 1)
+        self.assertEqual(persisted["policyUpdateIterations"], 1)
+        self.assertEqual(report["policyUpdateAlgorithm"], runner.TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM)
+        self.assertTrue(report["trueGradient"])
+        self.assertEqual(report["policyGradient"]["policy_update"]["learning_rate"], 1)
+        update = report["policyUpdate"]
+        self.assertEqual(update["iterations"], 1)
+        self.assertEqual(update["policyUpdateAlgorithm"], runner.TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM)
+        self.assertTrue(update["trueGradient"])
+        self.assertEqual(update["learningRate"], 1)
+        self.assertEqual(update["selectedRewardTierByParameter"]["territorySignalWeight"], "territory")
+        self.assertEqual(update["parameterDelta"]["territorySignalWeight"], 1)
+        self.assertFalse(update["liveEffect"])
+        self.assertFalse(update["officialMmoWrites"])
+        self.assertFalse(update["officialMmoWritesAllowed"])
+        self.assertEqual(artifact["candidatePolicyId"], report["policyUpdateCandidatePolicyId"])
+        self.assertEqual(artifact["parameters"], update["updatedParameters"])
+        self.assertTrue(artifact["trueGradient"])
+        self.assertFalse(artifact["officialMmoWrites"])
+
     def test_policy_gradient_computes_and_persists_bounded_policy_update(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-policy-gradient-update",

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -1505,6 +1505,8 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(generate_cmd[generate_cmd.index("--scenario-id") + 1], runner.MULTI_TIER_SCENARIO_ID)
         self.assertIn("--require-multi-tier-scenario", generate_cmd)
         self.assertEqual(card["scenario"]["scenario_id"], runner.MULTI_TIER_SCENARIO_ID)
+        self.assertEqual(card["policy_gradient"]["policy_update"]["algorithm"], "reinforce_v1")
+        self.assertEqual(card["policy_gradient"]["policy_update"]["learning_rate"], 1)
         self.assertTrue(card["scenario"]["capabilities"]["hostile_combat_signal"])
         self.assertEqual(card["scenario"]["evidence"]["adjacent_room"], "E2S1")
         self.assertEqual(card["scenario"]["evidence"]["hostile_creep_count"], 2)


### PR DESCRIPTION
## Summary
- Makes Loop A policy-gradient cards/reports prove true-gradient policy-update settings and nonzero update iterations.
- Adds focused tests across experiment-card generation, training runner reporting, and Tencent preflight card defaults.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_experiment_card.py scripts/test_screeps_rl_experiment_card.py scripts/test_screeps_rl_training_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts/test_screeps_rl_experiment_card.py scripts/test_screeps_rl_training_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`

Closes #1210

Safety: offline/private/shadow training metadata/reporting only; no official MMO writes, no paid Tencent scale-out.
