### PR TITLE
fix(rl): activate multi-tier scenario proof signal

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -105,6 +105,7 @@ RUN_FAILURE_TYPE = "screeps-rl-simulator-run-failure"
 RUN_DOCKER_CLEANUP_TIMEOUT_SECONDS = 90
 SIMULATOR_REPAIR_MOD_FILENAME = "rl-simulator-harness-repair.js"
 OWNED_ROOM_SCORECARD_TYPE = "screeps-rl-simulator-owned-room-scorecard"
+PRIVATE_MAP_FIXTURE_TYPE = "screeps-rl-private-map-fixture"
 _WORKER_PHASE_DEBUG_DISABLED = False
 SCALE_ENVIRONMENT_VARIANT_RE = re.compile(r"^(?P<base>.+)\.scale-env-(?P<index>\d{2,})$")
 HARNESS_EXCLUDED_DIRECTORY_NAMES = ("node_modules", ".git", "__pycache__")
@@ -2316,6 +2317,154 @@ def _room_scorecard_from_summary(room_name: str, summary: JsonObject) -> JsonObj
     }
 
 
+def _private_map_fixture_rooms(map_source_file: Path) -> dict[str, JsonObject]:
+    """Return room payloads from a local private-map fixture, if the map uses that schema."""
+    try:
+        raw = json.loads(map_source_file.expanduser().read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return {}
+    if not isinstance(raw, dict) or raw.get("type") != PRIVATE_MAP_FIXTURE_TYPE:
+        return {}
+    rooms = raw.get("rooms")
+    result: dict[str, JsonObject] = {}
+    if isinstance(rooms, dict):
+        for room_name, payload in rooms.items():
+            if isinstance(room_name, str) and room_name and isinstance(payload, dict):
+                result[room_name] = payload
+    elif isinstance(rooms, list):
+        for payload in rooms:
+            if not isinstance(payload, dict):
+                continue
+            room_name = text_or_none(payload.get("roomName")) or text_or_none(payload.get("room"))
+            if room_name:
+                result[room_name] = payload
+    return result
+
+
+def _fixture_room_objects(room_payload: JsonObject, room_name: str) -> list[JsonObject]:
+    objects: list[JsonObject] = []
+    for key in ("objects", "creeps", "structures"):
+        value = room_payload.get(key)
+        if not isinstance(value, list):
+            continue
+        for item in value:
+            if not isinstance(item, dict):
+                continue
+            normalized = dict(item)
+            if key == "creeps":
+                normalized.setdefault("type", "creep")
+            elif key == "structures":
+                normalized.setdefault("type", normalized.get("structureType"))
+            normalized.setdefault("room", room_name)
+            objects.append(normalized)
+    return objects
+
+
+def _private_map_fixture_room_summaries(map_source_file: Path) -> dict[str, JsonObject]:
+    """Build sanitized room summaries for scenario fixture rooms missing from private APIs."""
+    rooms = _private_map_fixture_rooms(map_source_file)
+    if not rooms:
+        return {}
+    try:
+        raw = json.loads(map_source_file.expanduser().read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        raw = {}
+    owner = raw.get("owner") if isinstance(raw, dict) and isinstance(raw.get("owner"), dict) else {}
+    owner_id = text_or_none(owner.get("id")) if isinstance(owner, dict) else None
+    owner_username = text_or_none(owner.get("username")) if isinstance(owner, dict) else None
+    user: JsonObject = {}
+    if owner_id is not None:
+        user["id"] = owner_id
+    if owner_username is not None:
+        user["username"] = owner_username
+
+    summaries: dict[str, JsonObject] = {}
+    for room_name, room_payload in sorted(rooms.items()):
+        room_data: JsonObject = {
+            "room": room_name,
+            "objects": _fixture_room_objects(room_payload, room_name),
+        }
+        if user:
+            room_data["user"] = user
+            room_data["ownerId"] = owner_id
+            room_data["owner"] = owner_username or owner_id
+        summary = _summarize_room_state({"room": room_name, "roomData": room_data}, room_name)
+        summary["stateSource"] = "map-fixture"
+        summaries[room_name] = summary
+    return summaries
+
+
+def _room_summary_has_observable_state(summary: Any) -> bool:
+    if not isinstance(summary, dict):
+        return False
+    if isinstance(summary.get("controller"), dict):
+        return True
+    for key in ("creeps", "ownedCreeps", "ownStructures", "hostileCreeps", "hostileStructures"):
+        if (_extract_int(summary.get(key)) or 0) > 0:
+            return True
+    for key in ("structures", "structureCounts", "ownStructureCounts", "ownCreepRoles", "creepCounts"):
+        value = summary.get(key)
+        if isinstance(value, dict) and value:
+            return True
+    combat = summary.get("combat")
+    if isinstance(combat, dict):
+        return any((_extract_int(value) or 0) > 0 for value in combat.values())
+    return False
+
+
+def _merge_fixture_room_summaries_into_tick(
+    tick_entry: JsonObject,
+    fixture_room_summaries: dict[str, JsonObject],
+) -> list[str]:
+    if not fixture_room_summaries:
+        return []
+    rooms = tick_entry.setdefault("rooms", {})
+    if not isinstance(rooms, dict):
+        rooms = {}
+        tick_entry["rooms"] = rooms
+    merged: list[str] = []
+    for room_name, summary in fixture_room_summaries.items():
+        existing = rooms.get(room_name)
+        if _room_summary_has_observable_state(existing):
+            continue
+        rooms[room_name] = copy.deepcopy(summary)
+        merged.append(room_name)
+    if merged:
+        sources = tick_entry.setdefault("roomStateSources", [])
+        if isinstance(sources, list) and "map-fixture" not in sources:
+            sources.append("map-fixture")
+        tick_entry["fixtureRoomState"] = {
+            "source": "map-source",
+            "rooms": sorted(fixture_room_summaries),
+            "mergedRooms": merged,
+        }
+    return merged
+
+
+def build_scenario_fixture_objective_summary(fixture_room_summaries: dict[str, JsonObject]) -> JsonObject | None:
+    if not fixture_room_summaries:
+        return None
+    hostile_creeps = 0
+    hostile_structures = 0
+    owned_rooms = 0
+    for summary in fixture_room_summaries.values():
+        if summary.get("owned") is True:
+            owned_rooms += 1
+        combat = summary.get("combat")
+        if isinstance(combat, dict):
+            hostile_creeps += _extract_int(combat.get("hostileCreeps")) or 0
+            hostile_structures += _extract_int(combat.get("hostileStructures")) or 0
+    return {
+        "type": PRIVATE_MAP_FIXTURE_TYPE,
+        "roomCount": len(fixture_room_summaries),
+        "rooms": sorted(fixture_room_summaries),
+        "ownedRoomCount": owned_rooms,
+        "hostileCreeps": hostile_creeps,
+        "hostileStructures": hostile_structures,
+        "objectiveSignalPresent": len(fixture_room_summaries) >= 2 and (hostile_creeps > 0 or hostile_structures > 0),
+    }
+
+
 def build_variant_owned_room_scorecard(variant_result: JsonObject) -> JsonObject:
     tick_log = variant_result.get("tick_log", variant_result.get("tickLog"))
     ticks = [tick for tick in tick_log if isinstance(tick, dict)] if isinstance(tick_log, list) else []
@@ -2488,24 +2637,33 @@ def _fetch_room_overviews(
     token: str,
     rooms: Sequence[str],
     shard: str,
+    optional_rooms: Sequence[str] = (),
 ) -> tuple[str, dict[str, Any]]:
     payloads: dict[str, Any] = {}
-    for room_name in rooms:
-        room_overview = smoke.http_json(
-            "GET",
-            cfg.server_url,
-            "/api/game/room-overview",
-            params={"room": room_name, "shard": shard},
-            headers=smoke.token_headers(token),
-            timeout=RUN_API_TIMEOUT_SECONDS,
-        )
-        token = smoke.update_token_from_headers(token, room_overview.headers)
-        if isinstance(room_overview.payload, dict) and not smoke.api_dict_succeeded(room_overview):
-            raise RuntimeError(
-                f"/api/game/room-overview returned unusable payload for {room_name}: "
-                f"{_safe_redact_smoke_payload(room_overview.payload)}"
+    required = set(rooms)
+    for room_name in _dedupe_room_names([*rooms, *optional_rooms]):
+        try:
+            room_overview = smoke.http_json(
+                "GET",
+                cfg.server_url,
+                "/api/game/room-overview",
+                params={"room": room_name, "shard": shard},
+                headers=smoke.token_headers(token),
+                timeout=RUN_API_TIMEOUT_SECONDS,
             )
-        payloads[room_name] = room_overview.payload
+            token = smoke.update_token_from_headers(token, room_overview.headers)
+            if isinstance(room_overview.payload, dict) and not smoke.api_dict_succeeded(room_overview):
+                if room_name not in required:
+                    continue
+                raise RuntimeError(
+                    f"/api/game/room-overview returned unusable payload for {room_name}: "
+                    f"{_safe_redact_smoke_payload(room_overview.payload)}"
+                )
+            payloads[room_name] = room_overview.payload
+        except Exception:
+            if room_name in required:
+                raise
+            continue
     return token, payloads
 
 
@@ -2517,6 +2675,8 @@ def _run_one_tick(
     shard: str,
     previous_tick: int | None,
     timeout_seconds: float,
+    fixture_room_names: Sequence[str] = (),
+    fixture_room_summaries: dict[str, JsonObject] | None = None,
 ) -> tuple[str, int | None, JsonObject]:
     deadline = time.time() + timeout_seconds
     while time.time() < deadline:
@@ -2539,7 +2699,16 @@ def _run_one_tick(
             continue
         if previous_tick is None or current_tick > previous_tick:
             visible_rooms = _visible_room_names(overview_result.payload, shard, room)
-            token, room_overviews = _fetch_room_overviews(cfg, smoke, token, visible_rooms, shard)
+            scenario_rooms = [fixture_room for fixture_room in fixture_room_names if fixture_room not in visible_rooms]
+            tick_rooms = _dedupe_room_names([*visible_rooms, *scenario_rooms])
+            token, room_overviews = _fetch_room_overviews(
+                cfg,
+                smoke,
+                token,
+                visible_rooms,
+                shard,
+                optional_rooms=scenario_rooms,
+            )
             tick_entry = _build_tick_entry(
                 shard,
                 room,
@@ -2547,8 +2716,10 @@ def _run_one_tick(
                 overview_result.payload,
                 terrain_result.payload,
                 room_overviews,
-                visible_rooms,
+                tick_rooms,
             )
+            if fixture_room_summaries:
+                _merge_fixture_room_summaries_into_tick(tick_entry, fixture_room_summaries)
             return token, current_tick, tick_entry
         time.sleep(RUN_TICK_POLL_SECONDS)
     raise RuntimeError(f"timed out waiting for tick progression after {timeout_seconds}s")
@@ -2589,6 +2760,8 @@ def _run_variant(
     evidence_errors: list[str] = []
     launcher_auto_map_import_disabled = False
     scenario_map_source_file = map_source_file
+    fixture_room_summaries = _private_map_fixture_room_summaries(map_source_file)
+    fixture_room_names = list(fixture_room_summaries)
     compose: list[str] | None = None
     try:
         smoke = _load_private_smoke_module()
@@ -2783,6 +2956,8 @@ def _run_variant(
                 shard,
                 previous_tick,
                 timeout_seconds=RUN_TICK_TIMEOUT_SECONDS,
+                fixture_room_names=fixture_room_names,
+                fixture_room_summaries=fixture_room_summaries,
             )
             previous_tick = observed_tick if observed_tick is not None else previous_tick
             variant_ticks.append(tick_entry)
@@ -2844,6 +3019,7 @@ def _run_variant(
         "requestedBranch": branch,
         "terrainReady": terrain_ready,
         "mongoRoomEvidence": mongo_room_evidence,
+        "scenarioFixture": build_scenario_fixture_objective_summary(fixture_room_summaries),
         "launcherRepairMod": str(repair_mod_path) if repair_mod_path is not None else None,
         "launcherAutoMapImportDisabled": launcher_auto_map_import_disabled,
     }

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -2565,6 +2565,16 @@ def _room_overview_payloads(room_overviews: Any, room_names: Sequence[str], anch
     return {anchor_room: room_overviews}
 
 
+def _exception_headers(exc: BaseException) -> dict[str, str] | None:
+    for source in (exc, getattr(exc, "response", None), getattr(exc, "result", None)):
+        headers = getattr(source, "headers", None)
+        if isinstance(headers, dict):
+            return {str(key): str(value) for key, value in headers.items()}
+        if hasattr(headers, "items"):
+            return {str(key): str(value) for key, value in headers.items()}
+    return None
+
+
 def _wait_for_http_with_smoke(cfg: Any, smoke: Any, timeout_seconds: int = RUN_PHASE_TIMEOUT_SECONDS) -> None:
     smoke.wait_for_http(cfg, timeout=timeout_seconds)
 
@@ -2660,7 +2670,10 @@ def _fetch_room_overviews(
                     f"{_safe_redact_smoke_payload(room_overview.payload)}"
                 )
             payloads[room_name] = room_overview.payload
-        except Exception:
+        except Exception as exc:
+            headers = _exception_headers(exc)
+            if headers is not None:
+                token = smoke.update_token_from_headers(token, headers)
             if room_name in required:
                 raise
             continue

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -2773,8 +2773,8 @@ def _run_variant(
     evidence_errors: list[str] = []
     launcher_auto_map_import_disabled = False
     scenario_map_source_file = map_source_file
-    fixture_room_summaries = _private_map_fixture_room_summaries(map_source_file)
-    fixture_room_names = list(fixture_room_summaries)
+    fixture_room_summaries: dict[str, JsonObject] = {}
+    fixture_room_names: list[str] = []
     compose: list[str] | None = None
     try:
         smoke = _load_private_smoke_module()
@@ -2841,6 +2841,8 @@ def _run_variant(
         )
         smoke.prepare_map(cfg)
         scenario_map_source_file = smoke_map_source_file or cfg.map_path
+        fixture_room_summaries = _private_map_fixture_room_summaries(scenario_map_source_file)
+        fixture_room_names = list(fixture_room_summaries)
         _debug_worker_phase(worker_index, variant_id, "after prepare_map", map_path=str(scenario_map_source_file))
 
         # Reset server-owned state by removing any leftover stack and volumes first.

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -2778,7 +2778,9 @@ def build_multi_tier_activation_proof(
         "ok": status == "passed",
         "scenarioId": scenario.get("scenario_id", scenario.get("scenarioId")) if isinstance(scenario, dict) else None,
         "criteria": {
-            "operator": "or",
+            "operator": "and",
+            "objectiveSignalMustBeObserved": True,
+            "activationScoreOperator": "or",
             "territoryScoreMustExceed": MULTI_TIER_TERRITORY_ACTIVATION_THRESHOLD,
             "hostileKillsMustExceed": MULTI_TIER_HOSTILE_KILLS_ACTIVATION_THRESHOLD,
             "requiredForPaidTencentValidation": True,
@@ -2829,10 +2831,11 @@ def multi_tier_activation_variant_row(result: JsonObject) -> JsonObject:
         objective_phase_signal_observed(objective, "initial")
         or objective_phase_signal_observed(objective, "final")
     )
-    passes = (
+    activation_score_passes = (
         float(territory_score) > MULTI_TIER_TERRITORY_ACTIVATION_THRESHOLD
         or float(hostile_kills) > MULTI_TIER_HOSTILE_KILLS_ACTIVATION_THRESHOLD
     )
+    passes = observed and activation_score_passes
     return {
         "variantId": result.get("variantId"),
         "sampleCount": result.get("sampleCount", 0),

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -1910,6 +1910,10 @@ def summarize_variant(
     reward_tuple[0] = reliability_score(scored_run_count=len(run_metrics), total_run_count=len(runs))
     metrics = aggregate_metrics(run_metrics)
     metrics["reliability"]["score"] = reward_tuple[0]
+    activation_samples = [
+        multi_tier_activation_metric_evidence(metric, sample_index=index)
+        for index, metric in enumerate(run_metrics)
+    ]
     summary: JsonObject = {
         "variantId": variant.id,
         "family": variant.family,
@@ -1926,6 +1930,7 @@ def summarize_variant(
             "sampleStdDev": reward_sample_stddev(run_metrics_by_attempt),
         },
         "metrics": metrics,
+        "multiTierActivationSamples": activation_samples,
         "runs": [
             {
                 "variantRunId": run.get("variant_run_id", run.get("variantRunId")),
@@ -2155,8 +2160,14 @@ def room_has_own_controller(summary: JsonObject) -> bool:
     if isinstance(controller, dict):
         if controller.get("my") is True or controller.get("owned") is True:
             return True
+        if controller.get("my") is False or controller.get("owned") is False:
+            return False
         owner = controller.get("owner")
         if isinstance(owner, str) and owner in {"me", "self", "owned"}:
+            return True
+        if isinstance(owner, str) and owner.strip():
+            return True
+        if isinstance(owner, dict) and any(text_or_none(owner.get(key)) for key in ("username", "name", "id", "_id")):
             return True
     return False
 
@@ -2768,7 +2779,8 @@ def build_multi_tier_activation_proof(
     if not scenario_supports_multi_tier_policy_comparison(scenario):
         return None
     rows = [multi_tier_activation_variant_row(result) for result in results]
-    passed_rows = [row for row in rows if row["passesActivation"]]
+    usable_rows = [row for row in rows if (int_or_none(row.get("sampleCount")) or 0) > 0]
+    passed_rows = [row for row in usable_rows if row["passesActivation"]]
     transport_observed = any(row["objectiveSignalObserved"] for row in rows)
     status = "passed" if passed_rows else "blocked"
     proof: JsonObject = {
@@ -2800,28 +2812,54 @@ def build_multi_tier_activation_proof(
     if passed_rows:
         proof["passingVariants"] = [row["variantId"] for row in passed_rows]
     else:
-        classification = (
-            "SIMULATOR_OBJECTIVE_SIGNAL_NOT_ACTIVATED"
-            if transport_observed
-            else "SIMULATOR_FIXTURE_SIGNAL_NOT_TRANSPORTED"
-        )
+        if not usable_rows:
+            classification = "SIMULATOR_NO_SUCCESSFUL_SAMPLES"
+            evidence = "no successful simulator samples were available for multi-tier activation proof"
+        elif transport_observed:
+            classification = "SIMULATOR_OBJECTIVE_SIGNAL_NOT_ACTIVATED"
+            evidence = (
+                "multi-tier fixture signal reached variant metrics, but no single successful sample exceeded "
+                f"territory score {MULTI_TIER_TERRITORY_ACTIVATION_THRESHOLD} or hostile kills "
+                f"{MULTI_TIER_HOSTILE_KILLS_ACTIVATION_THRESHOLD}"
+            )
+        else:
+            classification = "SIMULATOR_FIXTURE_SIGNAL_NOT_TRANSPORTED"
+            evidence = "multi-tier card fixture evidence did not reach variant objective metrics"
         proof["blocker"] = {
             "classification": classification,
             "criticality": "P0",
-            "evidence": (
-                "multi-tier fixture signal reached variant metrics, but no variant exceeded territory score "
-                f"{MULTI_TIER_TERRITORY_ACTIVATION_THRESHOLD} or hostile kills "
-                f"{MULTI_TIER_HOSTILE_KILLS_ACTIVATION_THRESHOLD}"
-                if transport_observed
-                else "multi-tier card fixture evidence did not reach variant objective metrics"
-            ),
+            "evidence": evidence,
             "action": "repair local/private simulator objective activation before paid Tencent validation",
         }
     return proof
 
 
 def multi_tier_activation_variant_row(result: JsonObject) -> JsonObject:
+    raw_samples = result.get("multiTierActivationSamples")
+    samples = [sample for sample in raw_samples if isinstance(sample, dict)] if isinstance(raw_samples, list) else []
     metrics = result.get("metrics") if isinstance(result.get("metrics"), dict) else {}
+    aggregate_evidence = multi_tier_activation_metric_evidence(metrics) if metrics else empty_multi_tier_activation_evidence()
+    sample_count = int_or_none(result.get("sampleCount")) or 0
+    evidence_samples = samples or ([aggregate_evidence] if sample_count > 0 and metrics else [])
+    territory_score = aggregate_evidence["territoryScore"]
+    hostile_kills = aggregate_evidence["hostileKills"]
+    observed = any(sample.get("objectiveSignalObserved") is True for sample in evidence_samples)
+    passes = any(sample.get("passesActivation") is True for sample in evidence_samples)
+    objective = metrics.get("objectiveSignal") if isinstance(metrics.get("objectiveSignal"), dict) else {}
+    return {
+        "variantId": result.get("variantId"),
+        "sampleCount": result.get("sampleCount", 0),
+        "territoryScore": round_float(territory_score),
+        "hostileKills": round_float(hostile_kills),
+        "objectiveSignalObserved": observed,
+        "passesActivation": passes,
+        "activationSampleCount": len(evidence_samples),
+        "activationSamples": copy.deepcopy(evidence_samples),
+        "objectiveSignal": copy.deepcopy(objective),
+    }
+
+
+def multi_tier_activation_metric_evidence(metrics: JsonObject, *, sample_index: int | None = None) -> JsonObject:
     territory = metrics.get("territory") if isinstance(metrics.get("territory"), dict) else {}
     kills = metrics.get("kills") if isinstance(metrics.get("kills"), dict) else {}
     objective = metrics.get("objectiveSignal") if isinstance(metrics.get("objectiveSignal"), dict) else {}
@@ -2835,15 +2873,25 @@ def multi_tier_activation_variant_row(result: JsonObject) -> JsonObject:
         float(territory_score) > MULTI_TIER_TERRITORY_ACTIVATION_THRESHOLD
         or float(hostile_kills) > MULTI_TIER_HOSTILE_KILLS_ACTIVATION_THRESHOLD
     )
-    passes = observed and activation_score_passes
-    return {
-        "variantId": result.get("variantId"),
-        "sampleCount": result.get("sampleCount", 0),
+    evidence: JsonObject = {
         "territoryScore": round_float(territory_score),
         "hostileKills": round_float(hostile_kills),
         "objectiveSignalObserved": observed,
-        "passesActivation": passes,
-        "objectiveSignal": copy.deepcopy(objective),
+        "activationScorePasses": activation_score_passes,
+        "passesActivation": observed and activation_score_passes,
+    }
+    if sample_index is not None:
+        evidence["sampleIndex"] = sample_index
+    return evidence
+
+
+def empty_multi_tier_activation_evidence() -> JsonObject:
+    return {
+        "territoryScore": 0,
+        "hostileKills": 0,
+        "objectiveSignalObserved": False,
+        "activationScorePasses": False,
+        "passesActivation": False,
     }
 
 
@@ -2996,8 +3044,13 @@ def write_json_atomic(path: Path, payload: Any) -> None:
 
 
 def build_generation_summary(report: JsonObject) -> JsonObject:
+    activation_proof = report.get("activationProof")
+    summary_ok = not (
+        isinstance(activation_proof, dict)
+        and (activation_proof.get("ok") is False or isinstance(activation_proof.get("blocker"), dict))
+    )
     summary = {
-        "ok": True,
+        "ok": summary_ok,
         "type": SUMMARY_TYPE,
         "schemaVersion": SCHEMA_VERSION,
         "reportId": report["reportId"],
@@ -3018,8 +3071,8 @@ def build_generation_summary(report: JsonObject) -> JsonObject:
     }
     if "scaleValidation" in report:
         summary["scaleValidation"] = report["scaleValidation"]
-    if "activationProof" in report:
-        proof = report["activationProof"]
+    if isinstance(activation_proof, dict):
+        proof = activation_proof
         summary["activationProof"] = {
             "status": proof.get("status"),
             "ok": proof.get("ok"),

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -2826,10 +2826,8 @@ def multi_tier_activation_variant_row(result: JsonObject) -> JsonObject:
     territory_score = number_or_none(territory.get("delta")) or 0
     hostile_kills = number_or_none(kills.get("hostileKills")) or 0
     observed = (
-        objective.get("initialObjectiveSignalPresent") is True
-        or objective.get("finalObjectiveSignalPresent") is True
-        or (number_or_none(objective.get("initialObservedRoomCount")) or 0) >= 2
-        or (number_or_none(objective.get("finalObservedRoomCount")) or 0) >= 2
+        objective_phase_signal_observed(objective, "initial")
+        or objective_phase_signal_observed(objective, "final")
     )
     passes = (
         float(territory_score) > MULTI_TIER_TERRITORY_ACTIVATION_THRESHOLD
@@ -2844,6 +2842,15 @@ def multi_tier_activation_variant_row(result: JsonObject) -> JsonObject:
         "passesActivation": passes,
         "objectiveSignal": copy.deepcopy(objective),
     }
+
+
+def objective_phase_signal_observed(objective: JsonObject, phase: str) -> bool:
+    if objective.get(f"{phase}ObjectiveSignalPresent") is True:
+        return True
+    observed_rooms = number_or_none(objective.get(f"{phase}ObservedRoomCount")) or 0
+    hostile_creeps = number_or_none(objective.get(f"{phase}HostileCreeps")) or 0
+    hostile_structures = number_or_none(objective.get(f"{phase}HostileStructures")) or 0
+    return observed_rooms >= 2 and (hostile_creeps > 0 or hostile_structures > 0)
 
 
 def multi_tier_fixture_evidence(scenario: JsonObject | None) -> JsonObject:

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -42,6 +42,9 @@ POLICY_UPDATE_ALGORITHM = RANK_WEIGHTED_FINITE_DIFFERENCE_ALGORITHM
 DEFAULT_POLICY_UPDATE_ALGORITHM = TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM
 POLICY_UPDATE_ARTIFACT_DIR = "policy-candidates"
 REWARD_TIERS = ("reliability", "territory", "resources", "kills")
+MULTI_TIER_ACTIVATION_PROOF_TYPE = "screeps-rl-multi-tier-activation-proof"
+MULTI_TIER_TERRITORY_ACTIVATION_THRESHOLD = 2
+MULTI_TIER_HOSTILE_KILLS_ACTIVATION_THRESHOLD = 0
 SAFETY_FALSE_FIELDS = ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed")
 SAFETY_TRUE_FIELDS = ("conservative_actions_only", "ood_rejection")
 LOOP_A_CARD_SUPPLY_TYPE = "screeps-rl-loop-a-card-supply"
@@ -1076,6 +1079,18 @@ def build_training_report(
     }
     if scenario is not None:
         report["scenario"] = scenario
+        activation_proof = build_multi_tier_activation_proof(
+            results=results,
+            scenario=scenario,
+            kpi_summary=report["kpiSummary"],
+        )
+        if activation_proof is not None:
+            report["activationProof"] = activation_proof
+            if activation_proof["status"] == "blocked":
+                warnings.append(
+                    "multi-tier activation proof blocked: "
+                    f"{activation_proof['blocker']['classification']}"
+                )
     if scale_validation is not None:
         report["scaleValidation"] = scale_validation
     if policy_gradient is not None:
@@ -2021,6 +2036,8 @@ def compute_run_metrics(run: JsonObject, reward_options: JsonObject) -> JsonObje
     )
 
     reliability = 0 if run.get("ok") is False else 1
+    initial_objective_signal = room_objective_signal(initial_rooms)
+    final_objective_signal = room_objective_signal(final_rooms)
     reward_tuple = [
         reliability,
         round_float(territory_delta),
@@ -2062,6 +2079,33 @@ def compute_run_metrics(run: JsonObject, reward_options: JsonObject) -> JsonObje
             "hostileKills": round_float(hostile_kills),
             "ownLosses": round_float(own_losses),
         },
+        "objectiveSignal": {
+            "initialObservedRoomCount": len(initial_rooms),
+            "finalObservedRoomCount": len(final_rooms),
+            "initialRooms": sorted(initial_rooms),
+            "finalRooms": sorted(final_rooms),
+            "initialHostileCreeps": initial_objective_signal["hostileCreeps"],
+            "finalHostileCreeps": final_objective_signal["hostileCreeps"],
+            "initialHostileStructures": initial_objective_signal["hostileStructures"],
+            "finalHostileStructures": final_objective_signal["hostileStructures"],
+            "initialObjectiveSignalPresent": initial_objective_signal["objectiveSignalPresent"],
+            "finalObjectiveSignalPresent": final_objective_signal["objectiveSignalPresent"],
+        },
+    }
+
+
+def room_objective_signal(rooms: dict[str, JsonObject]) -> JsonObject:
+    hostile_creeps = 0.0
+    hostile_structures = 0.0
+    for summary in rooms.values():
+        combat = summary.get("combat")
+        if isinstance(combat, dict):
+            hostile_creeps += number_or_none(combat.get("hostileCreeps")) or 0.0
+            hostile_structures += number_or_none(combat.get("hostileStructures")) or 0.0
+    return {
+        "hostileCreeps": round_float(hostile_creeps),
+        "hostileStructures": round_float(hostile_structures),
+        "objectiveSignalPresent": len(rooms) >= 2 and (hostile_creeps > 0 or hostile_structures > 0),
     }
 
 
@@ -2093,17 +2137,8 @@ def normalize_room_map(raw: Any) -> dict[str, JsonObject]:
 
 
 def is_claimed_room(summary: JsonObject) -> bool:
-    if summary.get("claimed") is True or summary.get("owned") is True or summary.get("my") is True:
+    if room_has_own_controller(summary):
         return True
-    controller = summary.get("controller")
-    if isinstance(controller, dict):
-        if controller.get("my") is True or controller.get("owned") is True:
-            return True
-        owner = controller.get("owner")
-        if isinstance(owner, str) and owner:
-            return True
-        if isinstance(owner, dict) and owner:
-            return True
     if spawn_count(summary) > 0 and controller_level(summary) > 0:
         return True
     return False
@@ -2113,8 +2148,33 @@ def room_survived(summary: JsonObject) -> bool:
     return spawn_count(summary) > 0 and creep_count(summary) > 0
 
 
+def room_has_own_controller(summary: JsonObject) -> bool:
+    if summary.get("claimed") is True or summary.get("owned") is True or summary.get("my") is True:
+        return True
+    controller = summary.get("controller")
+    if isinstance(controller, dict):
+        if controller.get("my") is True or controller.get("owned") is True:
+            return True
+        owner = controller.get("owner")
+        if isinstance(owner, str) and owner in {"me", "self", "owned"}:
+            return True
+    return False
+
+
 def spawn_count(summary: JsonObject) -> int:
-    for key in ("owned_spawns", "ownedSpawnCount", "spawnCount", "spawns"):
+    for key in ("owned_spawns", "ownedSpawnCount", "ownSpawnCount"):
+        value = int_or_none(summary.get(key))
+        if value is not None:
+            return value
+    structures = summary.get("ownStructureCounts")
+    if isinstance(structures, dict):
+        for key in ("spawn", "STRUCTURE_SPAWN"):
+            value = int_or_none(structures.get(key))
+            if value is not None:
+                return value
+    if not room_has_own_controller(summary):
+        return 0
+    for key in ("spawnCount", "spawns"):
         value = int_or_none(summary.get(key))
         if value is not None:
             return value
@@ -2128,7 +2188,18 @@ def spawn_count(summary: JsonObject) -> int:
 
 
 def creep_count(summary: JsonObject) -> int:
-    for key in ("owned_creeps", "ownedCreeps", "ownedCreepCount", "creeps", "workerCount"):
+    for key in ("owned_creeps", "ownedCreeps", "ownedCreepCount"):
+        value = int_or_none(summary.get(key))
+        if value is not None:
+            return value
+    roles = summary.get("ownCreepRoles")
+    if isinstance(roles, dict):
+        role_total = sum(int_or_none(value) or 0 for value in roles.values())
+        if role_total > 0:
+            return role_total
+    if not room_has_own_controller(summary):
+        return 0
+    for key in ("creeps", "workerCount"):
         value = int_or_none(summary.get(key))
         if value is not None:
             return value
@@ -2343,6 +2414,7 @@ def aggregate_metrics(metrics: Sequence[JsonObject]) -> JsonObject:
             "territory": empty_territory_metrics(),
             "resources": empty_resource_metrics(),
             "kills": empty_kill_metrics(),
+            "objectiveSignal": empty_objective_signal_metrics(),
         }
     return {
         "reliability": {
@@ -2389,6 +2461,38 @@ def aggregate_metrics(metrics: Sequence[JsonObject]) -> JsonObject:
             "hostileKills": mean_component(metrics, "kills", "hostileKills"),
             "ownLosses": mean_component(metrics, "kills", "ownLosses"),
         },
+        "objectiveSignal": {
+            "initialObservedRoomCount": mean_component(metrics, "objectiveSignal", "initialObservedRoomCount"),
+            "finalObservedRoomCount": mean_component(metrics, "objectiveSignal", "finalObservedRoomCount"),
+            "initialHostileCreeps": mean_component(metrics, "objectiveSignal", "initialHostileCreeps"),
+            "finalHostileCreeps": mean_component(metrics, "objectiveSignal", "finalHostileCreeps"),
+            "initialHostileStructures": mean_component(metrics, "objectiveSignal", "initialHostileStructures"),
+            "finalHostileStructures": mean_component(metrics, "objectiveSignal", "finalHostileStructures"),
+            "initialObjectiveSignalPresent": any(
+                metric["objectiveSignal"].get("initialObjectiveSignalPresent") is True
+                for metric in metrics
+            ),
+            "finalObjectiveSignalPresent": any(
+                metric["objectiveSignal"].get("finalObjectiveSignalPresent") is True
+                for metric in metrics
+            ),
+            "initialRooms": sorted(
+                {
+                    room
+                    for metric in metrics
+                    for room in metric["objectiveSignal"].get("initialRooms", [])
+                    if isinstance(room, str)
+                }
+            ),
+            "finalRooms": sorted(
+                {
+                    room
+                    for metric in metrics
+                    for room in metric["objectiveSignal"].get("finalRooms", [])
+                    if isinstance(room, str)
+                }
+            ),
+        },
     }
 
 
@@ -2423,6 +2527,21 @@ def empty_resource_metrics() -> JsonObject:
 
 def empty_kill_metrics() -> JsonObject:
     return {"delta": 0, "hostileKills": 0, "ownLosses": 0}
+
+
+def empty_objective_signal_metrics() -> JsonObject:
+    return {
+        "initialObservedRoomCount": 0,
+        "finalObservedRoomCount": 0,
+        "initialRooms": [],
+        "finalRooms": [],
+        "initialHostileCreeps": 0,
+        "finalHostileCreeps": 0,
+        "initialHostileStructures": 0,
+        "finalHostileStructures": 0,
+        "initialObjectiveSignalPresent": False,
+        "finalObjectiveSignalPresent": False,
+    }
 
 
 def mean_component(metrics: Sequence[JsonObject], component: str, field: str) -> float | int:
@@ -2640,6 +2759,108 @@ def build_kpi_summary(results: Sequence[JsonObject]) -> JsonObject:
     }
 
 
+def build_multi_tier_activation_proof(
+    *,
+    results: Sequence[JsonObject],
+    scenario: JsonObject | None,
+    kpi_summary: JsonObject,
+) -> JsonObject | None:
+    if not scenario_supports_multi_tier_policy_comparison(scenario):
+        return None
+    rows = [multi_tier_activation_variant_row(result) for result in results]
+    passed_rows = [row for row in rows if row["passesActivation"]]
+    transport_observed = any(row["objectiveSignalObserved"] for row in rows)
+    status = "passed" if passed_rows else "blocked"
+    proof: JsonObject = {
+        "type": MULTI_TIER_ACTIVATION_PROOF_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "status": status,
+        "ok": status == "passed",
+        "scenarioId": scenario.get("scenario_id", scenario.get("scenarioId")) if isinstance(scenario, dict) else None,
+        "criteria": {
+            "operator": "or",
+            "territoryScoreMustExceed": MULTI_TIER_TERRITORY_ACTIVATION_THRESHOLD,
+            "hostileKillsMustExceed": MULTI_TIER_HOSTILE_KILLS_ACTIVATION_THRESHOLD,
+            "requiredForPaidTencentValidation": True,
+        },
+        "fixtureEvidence": multi_tier_fixture_evidence(scenario),
+        "transport": {
+            "objectiveSignalObserved": transport_observed,
+            "classification": "observed_in_variant_metrics" if transport_observed else "not_observed_in_variant_metrics",
+        },
+        "bestObserved": {
+            "territoryScore": max((float(row["territoryScore"]) for row in rows), default=0.0),
+            "hostileKills": max((float(row["hostileKills"]) for row in rows), default=0.0),
+            "kpiSummary": copy.deepcopy(kpi_summary),
+        },
+        "variants": rows,
+    }
+    if passed_rows:
+        proof["passingVariants"] = [row["variantId"] for row in passed_rows]
+    else:
+        classification = (
+            "SIMULATOR_OBJECTIVE_SIGNAL_NOT_ACTIVATED"
+            if transport_observed
+            else "SIMULATOR_FIXTURE_SIGNAL_NOT_TRANSPORTED"
+        )
+        proof["blocker"] = {
+            "classification": classification,
+            "criticality": "P0",
+            "evidence": (
+                "multi-tier fixture signal reached variant metrics, but no variant exceeded territory score "
+                f"{MULTI_TIER_TERRITORY_ACTIVATION_THRESHOLD} or hostile kills "
+                f"{MULTI_TIER_HOSTILE_KILLS_ACTIVATION_THRESHOLD}"
+                if transport_observed
+                else "multi-tier card fixture evidence did not reach variant objective metrics"
+            ),
+            "action": "repair local/private simulator objective activation before paid Tencent validation",
+        }
+    return proof
+
+
+def multi_tier_activation_variant_row(result: JsonObject) -> JsonObject:
+    metrics = result.get("metrics") if isinstance(result.get("metrics"), dict) else {}
+    territory = metrics.get("territory") if isinstance(metrics.get("territory"), dict) else {}
+    kills = metrics.get("kills") if isinstance(metrics.get("kills"), dict) else {}
+    objective = metrics.get("objectiveSignal") if isinstance(metrics.get("objectiveSignal"), dict) else {}
+    territory_score = number_or_none(territory.get("delta")) or 0
+    hostile_kills = number_or_none(kills.get("hostileKills")) or 0
+    observed = (
+        objective.get("initialObjectiveSignalPresent") is True
+        or objective.get("finalObjectiveSignalPresent") is True
+        or (number_or_none(objective.get("initialObservedRoomCount")) or 0) >= 2
+        or (number_or_none(objective.get("finalObservedRoomCount")) or 0) >= 2
+    )
+    passes = (
+        float(territory_score) > MULTI_TIER_TERRITORY_ACTIVATION_THRESHOLD
+        or float(hostile_kills) > MULTI_TIER_HOSTILE_KILLS_ACTIVATION_THRESHOLD
+    )
+    return {
+        "variantId": result.get("variantId"),
+        "sampleCount": result.get("sampleCount", 0),
+        "territoryScore": round_float(territory_score),
+        "hostileKills": round_float(hostile_kills),
+        "objectiveSignalObserved": observed,
+        "passesActivation": passes,
+        "objectiveSignal": copy.deepcopy(objective),
+    }
+
+
+def multi_tier_fixture_evidence(scenario: JsonObject | None) -> JsonObject:
+    evidence = scenario.get("evidence") if isinstance(scenario, dict) and isinstance(scenario.get("evidence"), dict) else {}
+    return {
+        "roomCount": evidence.get("room_count", evidence.get("roomCount")),
+        "anchorRoom": evidence.get("anchor_room", evidence.get("anchorRoom")),
+        "adjacentRoom": evidence.get("adjacent_room", evidence.get("adjacentRoom")),
+        "adjacentRooms": copy.deepcopy(evidence.get("adjacent_rooms", evidence.get("adjacentRooms"))),
+        "hostileCreepCount": evidence.get("hostile_creep_count", evidence.get("hostileCreepCount")),
+        "hostileStructureCount": evidence.get("hostile_structure_count", evidence.get("hostileStructureCount")),
+        "hostileSpawnCount": evidence.get("hostile_spawn_count", evidence.get("hostileSpawnCount")),
+        "mapSourceFile": evidence.get("map_source_file", evidence.get("mapSourceFile")),
+        "implementationStatus": evidence.get("implementation_status", evidence.get("implementationStatus")),
+    }
+
+
 def build_report_warnings(results: Sequence[JsonObject], simulator_runs: Sequence[JsonObject]) -> list[str]:
     warnings: list[str] = []
     for result in results:
@@ -2787,6 +3008,15 @@ def build_generation_summary(report: JsonObject) -> JsonObject:
     }
     if "scaleValidation" in report:
         summary["scaleValidation"] = report["scaleValidation"]
+    if "activationProof" in report:
+        proof = report["activationProof"]
+        summary["activationProof"] = {
+            "status": proof.get("status"),
+            "ok": proof.get("ok"),
+            "blocker": copy.deepcopy(proof.get("blocker")) if isinstance(proof.get("blocker"), dict) else None,
+            "passingVariants": copy.deepcopy(proof.get("passingVariants", [])),
+            "bestObserved": copy.deepcopy(proof.get("bestObserved", {})),
+        }
     return summary
 
 

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1569,6 +1569,109 @@ cli:
         )
         self.assertTrue(str(result["launcherRepairMod"]).endswith(harness.SIMULATOR_REPAIR_MOD_FILENAME))
 
+    def test_run_variant_reads_fixture_summary_from_prepared_default_map(self) -> None:
+        run_command_calls = 0
+
+        class FakeSmokeConfig:
+            def __init__(self, **kwargs: object) -> None:
+                for key, value in kwargs.items():
+                    setattr(self, key, value)
+
+            @property
+            def map_path(self) -> Path:
+                return self.work_dir / "maps" / "map-0b6758af.json"
+
+        class FakeSmoke:
+            SmokeConfig = FakeSmokeConfig
+            DEFAULT_MAP_URL = "https://example.invalid/default-map.json"
+
+            def required_env_errors(self, cfg: FakeSmokeConfig) -> list[str]:
+                return []
+
+            def assert_safe_work_dir(self, work_dir: Path) -> None:
+                return None
+
+            def preflight_host_ports(self, cfg: FakeSmokeConfig) -> dict[str, object]:
+                return {"checks": [{"available": True}]}
+
+            def find_compose_command(self) -> list[str]:
+                return ["compose"]
+
+            def prepare_work_dir(self, cfg: FakeSmokeConfig) -> None:
+                return None
+
+            def write_generated_text(self, work_dir: Path, path: Path, text: str) -> None:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(text, encoding="utf-8")
+
+            def prepare_map(self, cfg: FakeSmokeConfig) -> None:
+                cfg.map_path.parent.mkdir(parents=True, exist_ok=True)
+                cfg.map_path.write_text(
+                    json.dumps(
+                        {
+                            "type": harness.PRIVATE_MAP_FIXTURE_TYPE,
+                            "owner": {"id": "owner-1", "username": "rl-sim"},
+                            "rooms": [
+                                {
+                                    "room": "E1S1",
+                                    "objects": [
+                                        {"type": "controller", "level": 1, "user": "owner-1"},
+                                        {"type": "spawn", "user": "owner-1"},
+                                        {"type": "creep", "user": "owner-1"},
+                                    ],
+                                },
+                                {
+                                    "room": "E2S1",
+                                    "objects": [
+                                        {
+                                            "type": "controller",
+                                            "level": 2,
+                                            "my": False,
+                                            "user": "invader",
+                                            "owner": {"username": "Invader"},
+                                        },
+                                        {"type": "creep", "user": "invader"},
+                                        {"type": "spawn", "user": "invader"},
+                                    ],
+                                },
+                            ],
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+
+            def run_command(self, command: list[str], cfg: FakeSmokeConfig, timeout: int) -> dict[str, object]:
+                _ = command, cfg, timeout
+                nonlocal run_command_calls
+                run_command_calls += 1
+                if run_command_calls == 1:
+                    raise RuntimeError("stop after prepared fixture parse")
+                return {"returncode": 0}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            code_path = root / "main.js"
+            code_path.write_text("module.exports.loop = function() {};", encoding="utf-8")
+
+            with mock.patch("screeps_rl_simulator_harness._load_private_smoke_module", return_value=FakeSmoke()):
+                result = harness._run_variant(
+                    0,
+                    "baseline",
+                    run_id="prepared-fixture",
+                    ticks=1,
+                    room="E1S1",
+                    shard="shardX",
+                    branch="activeWorld",
+                    code_path=code_path,
+                    map_source_file=harness.DEFAULT_MAP_SOURCE_FILE,
+                    out_dir=root / "out",
+                )
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["scenarioFixture"]["roomCount"], 2)
+        self.assertEqual(result["scenarioFixture"]["ownedRoomCount"], 1)
+        self.assertTrue(result["scenarioFixture"]["objectiveSignalPresent"])
+
     def test_run_variant_rewrites_launcher_config_before_compose_start(self) -> None:
         events: list[str] = []
 

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -966,6 +966,53 @@ cli:
         self.assertEqual(metrics["finalRooms"]["roomCount"], 2)
         self.assertEqual(metrics["combat"]["peakHostileCreeps"], 2)
 
+    def test_fetch_room_overviews_rotates_token_when_optional_room_fetch_raises(self) -> None:
+        class Result:
+            def __init__(self, payload: object, headers: dict[str, str] | None = None) -> None:
+                self.payload = payload
+                self.headers = headers or {}
+
+        class OptionalRoomError(RuntimeError):
+            def __init__(self) -> None:
+                super().__init__("optional room unavailable")
+                self.headers = {"X-Token": "token-from-optional-error"}
+
+        class FakeSmoke:
+            def token_headers(self, token: str) -> dict[str, str]:
+                return {"X-Token": token}
+
+            def update_token_from_headers(self, token: str, headers: dict[str, str]) -> str:
+                for key, value in headers.items():
+                    if key.lower() == "x-token":
+                        return value
+                return token
+
+            def api_dict_succeeded(self, result: Result) -> bool:
+                return isinstance(result.payload, dict) and result.payload.get("ok") == 1
+
+            def http_json(self, method: str, base_url: str, path: str, **kwargs: object) -> Result:
+                _ = method, base_url, path
+                params = kwargs.get("params")
+                room_name = params.get("room") if isinstance(params, dict) else None
+                if room_name == "E2S1":
+                    raise OptionalRoomError()
+                return Result(
+                    {"ok": 1, "room": room_name, "roomData": {}},
+                    {"X-Token": "token-after-required-room"},
+                )
+
+        token, payloads = harness._fetch_room_overviews(
+            argparse.Namespace(server_url="http://127.0.0.1"),
+            FakeSmoke(),
+            "initial-token",
+            ["E1S1"],
+            "shardX",
+            optional_rooms=["E2S1"],
+        )
+
+        self.assertEqual(token, "token-from-optional-error")
+        self.assertEqual(sorted(payloads), ["E1S1"])
+
     def test_build_tick_entry_normalizes_private_object_maps_into_owned_scorecard_fields(self) -> None:
         tick_entry = harness._build_tick_entry(
             "shardX",

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -931,6 +931,41 @@ cli:
         self.assertEqual(tick_entry["overview"]["roomCount"], 1)
         self.assertEqual(tick_entry["rooms"]["E1S1"]["structures"]["spawn"], 1)
 
+    def test_multi_tier_fixture_rooms_merge_into_tick_when_private_api_lacks_visibility(self) -> None:
+        fixture_path = Path("scripts/fixtures/rl/multi-tier-territory-combat-v0.map.json")
+        fixture_summaries = harness._private_map_fixture_room_summaries(fixture_path)
+        tick_entry = harness._build_tick_entry(
+            "shardX",
+            "E1S1",
+            43,
+            {"ok": 1, "rooms": ["E1S1"]},
+            {"terrain": [{"room": "E1S1", "terrain": "0" * 2500}]},
+            {
+                "E1S1": {
+                    "room": "E1S1",
+                    "roomData": {
+                        "user": {"id": "user-1", "username": "rl-sim"},
+                        "objects": [
+                            {"type": "spawn", "user": "user-1", "store": {"energy": 300}},
+                            {"type": "creep", "user": "user-1", "memory": {"role": "worker"}},
+                        ],
+                    },
+                }
+            },
+            ["E1S1", "E2S1"],
+        )
+
+        merged = harness._merge_fixture_room_summaries_into_tick(tick_entry, fixture_summaries)
+
+        self.assertIn("E2S1", merged)
+        self.assertIn("map-fixture", tick_entry["roomStateSources"])
+        self.assertEqual(tick_entry["rooms"]["E2S1"]["combat"]["hostileCreeps"], 2)
+        self.assertEqual(tick_entry["rooms"]["E2S1"]["combat"]["hostileStructures"], 1)
+        self.assertFalse(tick_entry["rooms"]["E2S1"]["owned"])
+        metrics = harness.build_variant_metrics([tick_entry])
+        self.assertEqual(metrics["finalRooms"]["roomCount"], 2)
+        self.assertEqual(metrics["combat"]["peakHostileCreeps"], 2)
+
     def test_build_tick_entry_normalizes_private_object_maps_into_owned_scorecard_fields(self) -> None:
         tick_entry = harness._build_tick_entry(
             "shardX",

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -118,6 +118,20 @@ def room(
     return payload
 
 
+def hostile_fixture_room(room_name: str = "E2S1", *, hostile_creeps: int = 2, hostile_structures: int = 1) -> JsonObject:
+    return {
+        "roomName": room_name,
+        "controller": {"level": 2, "my": False, "owner": {"username": "Invader"}},
+        "structures": {"spawn": hostile_structures},
+        "creeps": hostile_creeps,
+        "combat": {
+            "hostileCreeps": hostile_creeps,
+            "hostileStructures": hostile_structures,
+            "events": {},
+        },
+    }
+
+
 def tick(tick_number: int, rooms: list[JsonObject]) -> JsonObject:
     return {
         "tick": tick_number,
@@ -239,6 +253,80 @@ class RlTrainingRunnerTest(unittest.TestCase):
             "experiment card scenario is classified as not suitable for multi-tier territory/combat policy comparison",
             report["warnings"],
         )
+
+    def test_multi_tier_activation_proof_blocks_when_fixture_signal_has_no_objective_movement(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-training-multitier-blocked",
+            code_commit="b" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-18T10:21:00Z",
+            scenario_id=card_helper.MULTI_TIER_SCENARIO_ID,
+            require_multi_tier_scenario=True,
+        )
+        variant_ids = [variant["id"] for variant in card["strategy_variants"]]
+        start = tick(1, [room("E1S1", energy=100), hostile_fixture_room()])
+        finish = tick(2, [room("E1S1", energy=150), hostile_fixture_room()])
+        simulator_results: dict[str, JsonObject] = {}
+        for variant_id in variant_ids:
+            result = variant_result(variant_id, [start, finish])
+            result["metrics"] = {"territoryDelta": 2, "hostileKills": 0}
+            simulator_results[variant_id] = result
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="multi-tier-blocked",
+                simulator_runner=MockSimulator(simulator_results),
+            )
+
+        proof = report["activationProof"]
+        self.assertEqual(proof["status"], "blocked")
+        self.assertEqual(proof["blocker"]["classification"], "SIMULATOR_OBJECTIVE_SIGNAL_NOT_ACTIVATED")
+        self.assertTrue(proof["transport"]["objectiveSignalObserved"])
+        self.assertEqual(proof["bestObserved"]["territoryScore"], 2.0)
+        self.assertEqual(proof["bestObserved"]["hostileKills"], 0.0)
+        self.assertEqual(report["variantResults"][0]["metrics"]["territory"]["ownedRoomCount"], 1)
+        self.assertEqual(report["variantResults"][0]["metrics"]["objectiveSignal"]["finalObservedRoomCount"], 2)
+        self.assertIn("multi-tier activation proof blocked", report["warnings"][-1])
+
+    def test_multi_tier_activation_proof_passes_when_variant_has_hostile_kill_signal(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-training-multitier-passed",
+            code_commit="b" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-18T10:22:00Z",
+            scenario_id=card_helper.MULTI_TIER_SCENARIO_ID,
+            require_multi_tier_scenario=True,
+        )
+        variant_ids = [variant["id"] for variant in card["strategy_variants"]]
+        start = tick(1, [room("E1S1", energy=100), hostile_fixture_room()])
+        finish = tick(2, [room("E1S1", energy=150), hostile_fixture_room(hostile_creeps=1)])
+        simulator_results: dict[str, JsonObject] = {}
+        for index, variant_id in enumerate(variant_ids):
+            result = variant_result(variant_id, [start, finish])
+            result["metrics"] = {"territoryDelta": 2, "hostileKills": 1 if index == 0 else 0}
+            simulator_results[variant_id] = result
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="multi-tier-passed",
+                simulator_runner=MockSimulator(simulator_results),
+            )
+
+        proof = report["activationProof"]
+        self.assertEqual(proof["status"], "passed")
+        self.assertTrue(proof["ok"])
+        self.assertEqual(proof["passingVariants"], [variant_ids[0]])
+        self.assertNotIn("blocker", proof)
 
     def test_steam_key_env_var_wins_over_env_file(self) -> None:
         env_secret = "env-secret-token-123456"

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -292,6 +292,7 @@ class RlTrainingRunnerTest(unittest.TestCase):
         self.assertEqual(report["variantResults"][0]["metrics"]["territory"]["ownedRoomCount"], 1)
         self.assertEqual(report["variantResults"][0]["metrics"]["objectiveSignal"]["finalObservedRoomCount"], 2)
         self.assertIn("multi-tier activation proof blocked", report["warnings"][-1])
+        self.assertFalse(runner.build_generation_summary(report)["ok"])
 
     def test_multi_tier_activation_proof_requires_hostile_signal_for_transport(self) -> None:
         card = card_helper.build_card(
@@ -380,6 +381,86 @@ class RlTrainingRunnerTest(unittest.TestCase):
         self.assertEqual(proof["bestObserved"]["hostileKills"], 1.0)
         self.assertNotIn("passingVariants", proof)
         self.assertEqual(proof["blocker"]["classification"], "SIMULATOR_FIXTURE_SIGNAL_NOT_TRANSPORTED")
+
+    def test_multi_tier_activation_proof_rejects_stitched_sample_average(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-training-multitier-stitched-samples",
+            code_commit="b" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-18T10:24:00Z",
+            scenario_id=card_helper.MULTI_TIER_SCENARIO_ID,
+            require_multi_tier_scenario=True,
+        )
+        variant = runner.StrategyVariant(id="candidate", family="test-family", parameters={})
+        transport_only = variant_result(
+            "candidate",
+            [
+                tick(1, [room("E1S1", energy=100), hostile_fixture_room()]),
+                tick(2, [room("E1S1", energy=100), hostile_fixture_room()]),
+            ],
+        )
+        transport_only["metrics"] = {"territoryDelta": 0, "hostileKills": 0}
+        score_only = variant_result(
+            "candidate",
+            [
+                tick(3, [room("E1S1", energy=100)]),
+                tick(4, [room("E1S1", energy=100)]),
+            ],
+        )
+        score_only["metrics"] = {"territoryDelta": 6, "hostileKills": 0}
+        result = runner.summarize_variant(
+            variant,
+            [transport_only, score_only],
+            {"resourceNormalizer": 1000},
+        )
+
+        proof = runner.build_multi_tier_activation_proof(
+            results=[result],
+            scenario=card["scenario"],
+            kpi_summary={},
+        )
+
+        self.assertIsNotNone(proof)
+        if proof is None:
+            self.fail("expected multi-tier activation proof")
+        self.assertEqual(proof["status"], "blocked")
+        self.assertTrue(proof["transport"]["objectiveSignalObserved"])
+        self.assertFalse(proof["variants"][0]["passesActivation"])
+        self.assertEqual(proof["variants"][0]["activationSampleCount"], 2)
+        self.assertEqual(
+            [sample["passesActivation"] for sample in proof["variants"][0]["activationSamples"]],
+            [False, False],
+        )
+        self.assertEqual(proof["bestObserved"]["territoryScore"], 3.0)
+        self.assertEqual(proof["blocker"]["classification"], "SIMULATOR_OBJECTIVE_SIGNAL_NOT_ACTIVATED")
+
+    def test_multi_tier_activation_proof_reports_missing_samples_separately(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-training-multitier-no-samples",
+            code_commit="b" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-18T10:25:00Z",
+            scenario_id=card_helper.MULTI_TIER_SCENARIO_ID,
+            require_multi_tier_scenario=True,
+        )
+        proof = runner.build_multi_tier_activation_proof(
+            results=[
+                {
+                    "variantId": "candidate",
+                    "sampleCount": 0,
+                    "metrics": runner.aggregate_metrics([]),
+                }
+            ],
+            scenario=card["scenario"],
+            kpi_summary={},
+        )
+
+        self.assertIsNotNone(proof)
+        if proof is None:
+            self.fail("expected multi-tier activation proof")
+        self.assertEqual(proof["status"], "blocked")
+        self.assertEqual(proof["blocker"]["classification"], "SIMULATOR_NO_SUCCESSFUL_SAMPLES")
+        self.assertIn("no successful simulator samples", proof["blocker"]["evidence"])
 
     def test_multi_tier_activation_proof_passes_when_variant_has_hostile_kill_signal(self) -> None:
         card = card_helper.build_card(
@@ -664,6 +745,23 @@ class RlTrainingRunnerTest(unittest.TestCase):
         self.assertEqual(metrics["territory"]["ownedRoomCount"], 1)
         self.assertEqual(metrics["territory"]["rclLevels"], {"E1S1": 2})
         self.assertEqual(metrics["resources"]["storedEnergyDelta"], 50)
+
+    def test_run_metrics_count_owned_controller_owner_object_without_my_flag(self) -> None:
+        owned_room = room("E1S1", spawns=1, creeps=2, energy=300, rcl=2)
+        owned_room["controller"] = {"level": 2, "owner": {"username": "rl-sim"}}
+        run = variant_result(
+            "candidate",
+            [
+                tick(1, [owned_room]),
+                tick(2, [owned_room]),
+            ],
+        )
+
+        metrics = runner.compute_run_metrics(run, {"resourceNormalizer": 1000})
+
+        self.assertEqual(metrics["territory"]["ownedRoomCount"], 1)
+        self.assertEqual(metrics["territory"]["survivedEndRooms"], ["E1S1"])
+        self.assertEqual(metrics["territory"]["rclLevels"], {"E1S1": 2})
 
     def test_experiment_card_loading_and_validation_accepts_yaml_inline_variants(self) -> None:
         yaml_text = """

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -335,6 +335,52 @@ class RlTrainingRunnerTest(unittest.TestCase):
         self.assertFalse(proof["variants"][0]["objectiveSignalObserved"])
         self.assertEqual(proof["blocker"]["classification"], "SIMULATOR_FIXTURE_SIGNAL_NOT_TRANSPORTED")
 
+    def test_multi_tier_activation_proof_rejects_legacy_progress_without_transport(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-training-multitier-legacy-progress",
+            code_commit="b" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-18T10:23:00Z",
+            scenario_id=card_helper.MULTI_TIER_SCENARIO_ID,
+            require_multi_tier_scenario=True,
+        )
+        proof = runner.build_multi_tier_activation_proof(
+            results=[
+                {
+                    "variantId": "candidate",
+                    "sampleCount": 1,
+                    "metrics": {
+                        "territory": {"delta": 3},
+                        "kills": {"hostileKills": 1},
+                        "objectiveSignal": {
+                            "initialObservedRoomCount": 2,
+                            "finalObservedRoomCount": 2,
+                            "initialHostileCreeps": 0,
+                            "finalHostileCreeps": 0,
+                            "initialHostileStructures": 0,
+                            "finalHostileStructures": 0,
+                            "initialObjectiveSignalPresent": False,
+                            "finalObjectiveSignalPresent": False,
+                        },
+                    },
+                }
+            ],
+            scenario=card["scenario"],
+            kpi_summary={},
+        )
+
+        self.assertIsNotNone(proof)
+        if proof is None:
+            self.fail("expected multi-tier activation proof")
+        self.assertEqual(proof["status"], "blocked")
+        self.assertFalse(proof["ok"])
+        self.assertFalse(proof["transport"]["objectiveSignalObserved"])
+        self.assertFalse(proof["variants"][0]["passesActivation"])
+        self.assertEqual(proof["bestObserved"]["territoryScore"], 3.0)
+        self.assertEqual(proof["bestObserved"]["hostileKills"], 1.0)
+        self.assertNotIn("passingVariants", proof)
+        self.assertEqual(proof["blocker"]["classification"], "SIMULATOR_FIXTURE_SIGNAL_NOT_TRANSPORTED")
+
     def test_multi_tier_activation_proof_passes_when_variant_has_hostile_kill_signal(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-training-multitier-passed",

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -293,6 +293,48 @@ class RlTrainingRunnerTest(unittest.TestCase):
         self.assertEqual(report["variantResults"][0]["metrics"]["objectiveSignal"]["finalObservedRoomCount"], 2)
         self.assertIn("multi-tier activation proof blocked", report["warnings"][-1])
 
+    def test_multi_tier_activation_proof_requires_hostile_signal_for_transport(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-training-multitier-missing-fixture-signal",
+            code_commit="b" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-18T10:22:00Z",
+            scenario_id=card_helper.MULTI_TIER_SCENARIO_ID,
+            require_multi_tier_scenario=True,
+        )
+        proof = runner.build_multi_tier_activation_proof(
+            results=[
+                {
+                    "variantId": "candidate",
+                    "sampleCount": 1,
+                    "metrics": {
+                        "territory": {"delta": 2},
+                        "kills": {"hostileKills": 0},
+                        "objectiveSignal": {
+                            "initialObservedRoomCount": 2,
+                            "finalObservedRoomCount": 2,
+                            "initialHostileCreeps": 0,
+                            "finalHostileCreeps": 0,
+                            "initialHostileStructures": 0,
+                            "finalHostileStructures": 0,
+                            "initialObjectiveSignalPresent": False,
+                            "finalObjectiveSignalPresent": False,
+                        },
+                    },
+                }
+            ],
+            scenario=card["scenario"],
+            kpi_summary={},
+        )
+
+        self.assertIsNotNone(proof)
+        if proof is None:
+            self.fail("expected multi-tier activation proof")
+        self.assertFalse(proof["transport"]["objectiveSignalObserved"])
+        self.assertEqual(proof["transport"]["classification"], "not_observed_in_variant_metrics")
+        self.assertFalse(proof["variants"][0]["objectiveSignalObserved"])
+        self.assertEqual(proof["blocker"]["classification"], "SIMULATOR_FIXTURE_SIGNAL_NOT_TRANSPORTED")
+
     def test_multi_tier_activation_proof_passes_when_variant_has_hostile_kill_signal(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-training-multitier-passed",


### PR DESCRIPTION
## Summary
- Advances #1203 (does not close; bounded/full run + Loop A/B ingestion still required).
- Adds explicit multi-tier activation proof reporting for RL training runs.
- Merges private map fixture room summaries into simulator tick output so adjacent hostile-room fixture data is visible when the private API lacks room visibility.
- Adds blocker/pass classifications proving whether territory/combat objective signal is activated before paid scale-out.

## Verification steps
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py`
- `python3 -m unittest scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py` (111 tests OK)

## Safety note
- Local/private simulator evidence only; no official MMO writes and no paid Tencent scale-out are performed by this PR.
- `prod/node_modules` remains untracked dependency infrastructure and is not staged.

