### PR TITLE
fix(rl): stabilize scenario fixture summary selection

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -1836,12 +1836,18 @@ def _disable_launcher_auto_map_import(smoke: Any, cfg: Any) -> bool:
     return True
 
 
+def _is_default_map_source_file(map_source_file: Path) -> bool:
+    requested = map_source_file.expanduser().resolve(strict=False)
+    default = DEFAULT_MAP_SOURCE_FILE.expanduser().resolve(strict=False)
+    return requested == default
+
+
 def _resolve_smoke_map_source_file(map_source_file: Path) -> Path | None:
     """Use the local map when present, otherwise let private-smoke fetch its default map."""
     resolved = map_source_file.expanduser()
     if resolved.is_file():
         return resolved
-    if resolved.resolve(strict=False) == DEFAULT_MAP_SOURCE_FILE.expanduser().resolve(strict=False):
+    if _is_default_map_source_file(resolved):
         return None
     raise RuntimeError(f"map source file is not a file: {resolved}")
 
@@ -2778,6 +2784,7 @@ def _run_variant(
     compose: list[str] | None = None
     try:
         smoke = _load_private_smoke_module()
+        summarize_prepared_map = _is_default_map_source_file(map_source_file)
         smoke_map_source_file = _resolve_smoke_map_source_file(map_source_file)
         smoke_map_url = str(getattr(smoke, "DEFAULT_MAP_URL", "")) if smoke_map_source_file is None else ""
         http_port, cli_port = _select_run_ports(
@@ -2840,7 +2847,10 @@ def _run_variant(
             mod_path=repair_mod_path,
         )
         smoke.prepare_map(cfg)
-        scenario_map_source_file = smoke_map_source_file or cfg.map_path
+        if summarize_prepared_map:
+            scenario_map_source_file = cfg.map_path
+        else:
+            scenario_map_source_file = smoke_map_source_file or cfg.map_path
         fixture_room_summaries = _private_map_fixture_room_summaries(scenario_map_source_file)
         fixture_room_names = list(fixture_room_summaries)
         _debug_worker_phase(worker_index, variant_id, "after prepare_map", map_path=str(scenario_map_source_file))

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1651,25 +1651,129 @@ cli:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             code_path = root / "main.js"
+            default_map_path = root / "maps" / "map-0b6758af.json"
+            expected_prepared_map = (
+                root
+                / "out"
+                / "prepared-fixture"
+                / "workers"
+                / "rl-sim-worker-prepared-fixture-00"
+                / "maps"
+                / "map-0b6758af.json"
+            )
+            code_path.write_text("module.exports.loop = function() {};", encoding="utf-8")
+            default_map_path.parent.mkdir(parents=True, exist_ok=True)
+            default_map_path.write_text("{\"terrain\": []}", encoding="utf-8")
+
+            with mock.patch("screeps_rl_simulator_harness.DEFAULT_MAP_SOURCE_FILE", default_map_path):
+                with mock.patch("screeps_rl_simulator_harness._load_private_smoke_module", return_value=FakeSmoke()):
+                    result = harness._run_variant(
+                        0,
+                        "baseline",
+                        run_id="prepared-fixture",
+                        ticks=1,
+                        room="E1S1",
+                        shard="shardX",
+                        branch="activeWorld",
+                        code_path=code_path,
+                        map_source_file=default_map_path,
+                        out_dir=root / "out",
+                    )
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["scenario"]["mapArtifact"]["sourcePath"], str(expected_prepared_map))
+        self.assertEqual(result["scenarioFixture"]["roomCount"], 2)
+        self.assertEqual(result["scenarioFixture"]["ownedRoomCount"], 1)
+        self.assertTrue(result["scenarioFixture"]["objectiveSignalPresent"])
+
+    def test_run_variant_preserves_explicit_source_fixture_summary(self) -> None:
+        run_command_calls = 0
+        fixture_path = Path("scripts/fixtures/rl/multi-tier-territory-combat-v0.map.json")
+
+        class FakeSmokeConfig:
+            def __init__(self, **kwargs: object) -> None:
+                for key, value in kwargs.items():
+                    setattr(self, key, value)
+
+            @property
+            def map_path(self) -> Path:
+                return self.work_dir / "maps" / "map-0b6758af.json"
+
+        class FakeSmoke:
+            SmokeConfig = FakeSmokeConfig
+
+            def required_env_errors(self, cfg: FakeSmokeConfig) -> list[str]:
+                return []
+
+            def assert_safe_work_dir(self, work_dir: Path) -> None:
+                return None
+
+            def preflight_host_ports(self, cfg: FakeSmokeConfig) -> dict[str, object]:
+                return {"checks": [{"available": True}]}
+
+            def find_compose_command(self) -> list[str]:
+                return ["compose"]
+
+            def prepare_work_dir(self, cfg: FakeSmokeConfig) -> None:
+                return None
+
+            def write_generated_text(self, work_dir: Path, path: Path, text: str) -> None:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(text, encoding="utf-8")
+
+            def prepare_map(self, cfg: FakeSmokeConfig) -> None:
+                cfg.map_path.parent.mkdir(parents=True, exist_ok=True)
+                cfg.map_path.write_text(
+                    json.dumps(
+                        {
+                            "type": harness.PRIVATE_MAP_FIXTURE_TYPE,
+                            "owner": {"id": "owner-1", "username": "rl-sim"},
+                            "rooms": [
+                                {
+                                    "room": "W1N1",
+                                    "objects": [
+                                        {"type": "controller", "level": 1, "user": "owner-1"},
+                                        {"type": "spawn", "user": "owner-1"},
+                                    ],
+                                }
+                            ],
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+
+            def run_command(self, command: list[str], cfg: FakeSmokeConfig, timeout: int) -> dict[str, object]:
+                _ = command, cfg, timeout
+                nonlocal run_command_calls
+                run_command_calls += 1
+                if run_command_calls == 1:
+                    raise RuntimeError("stop after explicit fixture parse")
+                return {"returncode": 0}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            code_path = root / "main.js"
             code_path.write_text("module.exports.loop = function() {};", encoding="utf-8")
 
             with mock.patch("screeps_rl_simulator_harness._load_private_smoke_module", return_value=FakeSmoke()):
                 result = harness._run_variant(
                     0,
                     "baseline",
-                    run_id="prepared-fixture",
+                    run_id="explicit-fixture",
                     ticks=1,
                     room="E1S1",
                     shard="shardX",
                     branch="activeWorld",
                     code_path=code_path,
-                    map_source_file=harness.DEFAULT_MAP_SOURCE_FILE,
+                    map_source_file=fixture_path,
                     out_dir=root / "out",
                 )
 
         self.assertFalse(result["ok"])
-        self.assertEqual(result["scenarioFixture"]["roomCount"], 2)
-        self.assertEqual(result["scenarioFixture"]["ownedRoomCount"], 1)
+        self.assertEqual(result["scenario"]["mapArtifact"]["sourcePath"], str(fixture_path))
+        self.assertEqual(result["scenarioFixture"]["rooms"], ["E1S1", "E2S1"])
+        self.assertEqual(result["scenarioFixture"]["hostileCreeps"], 2)
+        self.assertEqual(result["scenarioFixture"]["hostileStructures"], 1)
         self.assertTrue(result["scenarioFixture"]["objectiveSignalPresent"])
 
     def test_run_variant_rewrites_launcher_config_before_compose_start(self) -> None:


### PR DESCRIPTION
## Summary
- fixes the post-#1214 simulator-harness regression where the default map file existing in the repo caused `_run_variant` to summarize the source map instead of the prepared private-smoke map
- keeps explicit non-default fixture maps (for example `multi-tier-territory-combat-v0`) summarized from the explicit source path
- adds regression coverage for both default-map and explicit-fixture selection

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py`
- `python3 -m unittest scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py` (120 tests)

Advances #1203 (does not close; bounded/full Tencent run + Loop A/B ingestion still required).
