### PR TITLE
fix(rl): distinguish Tencent preflight from compute runs

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -223,6 +223,7 @@ class Controller:
     def write_summary(self, *, partial: bool = False) -> None:
         training_report = self.result.get("trainingReport")
         report_safety = training_report if isinstance(training_report, dict) else {}
+        execution = controller_execution_summary(self.args, self.steps, self.result, self.scaled_up, self.instance_id)
         payload = {
             "type": "screeps-tencent-batch-rl-run",
             "schemaVersion": 1,
@@ -239,6 +240,7 @@ class Controller:
             "privateIp": self.private_ip,
             "remoteDir": self.remote_dir,
             "localArtifactDir": str(self.artifact_dir),
+            "execution": execution,
             "safety": {
                 "liveEffect": report_safety.get("liveEffect", False),
                 "officialMmoWrites": report_safety.get("officialMmoWrites", False),
@@ -249,6 +251,9 @@ class Controller:
                 "secretsPrinted": False,
             },
             "inputs": {
+                "command": getattr(self.args, "command", None),
+                "executionMode": execution["mode"],
+                "preflightOnly": execution["preflightOnly"],
                 "datasetRunId": self.args.dataset_run_id,
                 "experimentCard": str(self.experiment_card_path()),
                 "ticks": effective_training_ticks(self.args),
@@ -991,8 +996,9 @@ def utc_now_iso() -> str:
     return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
-def default_run_id() -> str:
-    return "tencent-single-" + dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dt%H%M%sz")
+def default_run_id(command: str = "run-single") -> str:
+    prefix = "tencent-preflight-" if command == "preflight" else "tencent-single-"
+    return prefix + dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dt%H%M%sz")
 
 
 def canonical_json(value: Any) -> str:
@@ -1027,6 +1033,54 @@ def unwrap_response(data: Any) -> dict[str, Any]:
     if isinstance(data, dict):
         return data
     return {}
+
+
+def controller_execution_summary(
+    args: argparse.Namespace,
+    steps: Sequence[StepRecord],
+    result: dict[str, Any],
+    scaled_up: bool,
+    instance_id: str | None,
+) -> dict[str, Any]:
+    step_names = {step.name for step in steps}
+    training_report = result.get("trainingReport")
+    training_report_data = training_report if isinstance(training_report, dict) else {}
+    training_report_produced = bool(
+        training_report_data.get("path")
+        or training_report_data.get("reportId")
+        or training_report_data.get("artifactCount")
+    )
+    scale_out_attempted = scaled_up or "scale_up" in step_names or instance_id is not None
+    remote_training_attempted = "remote_training" in step_names
+    compute_attempted = scale_out_attempted or remote_training_attempted or training_report_produced
+    environments_run = training_environments_run(training_report_data)
+    preflight_only = bool(getattr(args, "preflight_only", False))
+    return {
+        "command": getattr(args, "command", None),
+        "mode": "preflight" if preflight_only else "compute",
+        "preflightOnly": preflight_only,
+        "computeAttempted": compute_attempted,
+        "scaleOutAttempted": scale_out_attempted,
+        "remoteTrainingAttempted": remote_training_attempted,
+        "trainingReportProduced": training_report_produced,
+        "trainingReportPath": training_report_data.get("path"),
+        "trainingReportId": training_report_data.get("reportId"),
+        "artifactCount": training_report_data.get("artifactCount"),
+        "environmentsRun": environments_run,
+    }
+
+
+def training_environments_run(training_report: dict[str, Any]) -> int:
+    scale_validation = training_report.get("scaleValidation")
+    if isinstance(scale_validation, dict):
+        for key in ("totalEnvironments", "successfulEnvironments"):
+            value = scale_validation.get(key)
+            if isinstance(value, int) and value >= 0:
+                return value
+    artifact_count = training_report.get("artifactCount")
+    if isinstance(artifact_count, int) and artifact_count >= 0:
+        return artifact_count
+    return 0
 
 
 def remote_training_report_path(artifact_dir: Path, run_id: str) -> Path:
@@ -2176,8 +2230,8 @@ def validate_static_inputs(args: argparse.Namespace, run_id: str) -> None:
 def apply_cli_scenario_defaults(args: argparse.Namespace) -> argparse.Namespace:
     explicit_options = set(getattr(args, "explicit_cli_options", ()))
     command = getattr(args, "command", None)
-    explicit_preflight_mode = bool(explicit_options.intersection(PREFLIGHT_MODE_OPTION_DESTS))
-    if command == "preflight" and not explicit_preflight_mode:
+    explicit_launch_mode = bool(explicit_options.intersection(PREFLIGHT_MODE_OPTION_DESTS))
+    if command in {"preflight", "run-single"} and not explicit_launch_mode:
         args.training_approach = "policy_gradient"
         args.scenario_id = MULTI_TIER_SCENARIO_ID
         args.require_multi_tier_scenario = True
@@ -2268,7 +2322,7 @@ def build_parser() -> argparse.ArgumentParser:
         allow_abbrev=False,
     )
     parser.add_argument("command", choices=("run-single", "preflight"))
-    parser.add_argument("--run-id", default=default_run_id())
+    parser.add_argument("--run-id", default=None)
     parser.add_argument("--region", default=DEFAULT_REGION)
     parser.add_argument("--asg-id", default=DEFAULT_ASG_ID)
     parser.add_argument("--security-group-id", default="sg-5n5bqvbk")
@@ -2319,6 +2373,8 @@ def parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
     raw_argv = list(sys.argv[1:] if argv is None else argv)
     args = build_parser().parse_args(raw_argv)
     args.explicit_cli_options = explicit_cli_option_dests(raw_argv)
+    if args.run_id is None:
+        args.run_id = default_run_id(args.command)
     args.preflight_only = args.command == "preflight"
     apply_cli_scenario_defaults(args)
     return args

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -1169,8 +1169,19 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(args.training_approach, "policy_gradient")
         self.assertEqual(args.scenario_id, runner.MULTI_TIER_SCENARIO_ID)
         self.assertTrue(args.require_multi_tier_scenario)
+        self.assertFalse(args.run_id.startswith("tencent-single-"))
         self.assertEqual(controller.final_status, "preflight_ok")
         self.assertEqual(summary["finalStatus"], "preflight_ok")
+        self.assertEqual(summary["execution"]["command"], "preflight")
+        self.assertEqual(summary["execution"]["mode"], "preflight")
+        self.assertTrue(summary["execution"]["preflightOnly"])
+        self.assertFalse(summary["execution"]["computeAttempted"])
+        self.assertFalse(summary["execution"]["scaleOutAttempted"])
+        self.assertFalse(summary["execution"]["remoteTrainingAttempted"])
+        self.assertFalse(summary["execution"]["trainingReportProduced"])
+        self.assertEqual(summary["execution"]["environmentsRun"], 0)
+        self.assertEqual(summary["inputs"]["command"], "preflight")
+        self.assertTrue(summary["inputs"]["preflightOnly"])
         self.assertEqual(summary["inputs"]["trainingApproach"], "policy_gradient")
         self.assertEqual(summary["inputs"]["scenarioId"], runner.MULTI_TIER_SCENARIO_ID)
         self.assertTrue(summary["inputs"]["requireMultiTierScenario"])
@@ -1182,6 +1193,25 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(guard["evidence"]["count"], 0)
         self.assertIn("experiment_card", events)
         self.assertNotIn("scale_up", events)
+
+    def test_no_arg_run_single_defaults_to_multi_tier_policy_gradient_compute_mode(self) -> None:
+        args = runner.parse_cli_args(["run-single"])
+
+        self.assertEqual(args.command, "run-single")
+        self.assertFalse(args.preflight_only)
+        self.assertTrue(args.run_id.startswith("tencent-single-"))
+        self.assertEqual(args.training_approach, "policy_gradient")
+        self.assertEqual(args.scenario_id, runner.MULTI_TIER_SCENARIO_ID)
+        self.assertTrue(args.require_multi_tier_scenario)
+        self.assertEqual(runner.effective_training_ticks(args), runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS)
+
+    def test_preflight_command_uses_preflight_run_id_prefix(self) -> None:
+        args = runner.parse_cli_args(["preflight"])
+
+        self.assertEqual(args.command, "preflight")
+        self.assertTrue(args.preflight_only)
+        self.assertTrue(args.run_id.startswith("tencent-preflight-"))
+        self.assertFalse(args.run_id.startswith("tencent-single-"))
 
     def test_cli_rejects_abbreviated_training_approach_option(self) -> None:
         with mock.patch("sys.stderr", new=io.StringIO()):
@@ -1264,6 +1294,9 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(controller.final_status, "preflight_ok")
         self.assertEqual(summary["inputs"]["scenarioId"], runner.MULTI_TIER_SCENARIO_ID)
         self.assertTrue(summary["inputs"]["requireMultiTierScenario"])
+        self.assertEqual(summary["execution"]["mode"], "preflight")
+        self.assertFalse(summary["execution"]["computeAttempted"])
+        self.assertFalse(summary["execution"]["trainingReportProduced"])
         self.assertFalse(guard["blocked"])
         self.assertEqual(guard["currentLaunch"]["scenarioId"], runner.MULTI_TIER_SCENARIO_ID)
         self.assertTrue(guard["currentLaunch"]["requireMultiTierScenario"])
@@ -1272,6 +1305,8 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(guard["currentLaunch"]["fixtureEvidence"]["hostileSpawnCount"], 1)
         self.assertIn("experiment_card", events)
         self.assertNotIn("scale_up", events)
+        self.assertNotIn("bootstrap", events)
+        self.assertNotIn("remote_training", events)
 
     def test_preflight_repeat_launch_guard_writes_skip_artifact_without_remote_side_effects(self) -> None:
         events: list[str] = []
@@ -1320,6 +1355,126 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(summary["finalStatus"], runner.E1S1_REPEAT_GUARD_FINAL_STATUS)
         self.assertFalse(summary["safety"]["scaleDownAttempted"])
         self.assertEqual(summary["outputs"]["launchGuard"]["status"], "blocked")
+        self.assertEqual(summary["execution"]["mode"], "preflight")
+        self.assertFalse(summary["execution"]["computeAttempted"])
+        self.assertFalse(summary["execution"]["scaleOutAttempted"])
+
+    def test_multi_tier_run_single_proceeds_past_preflight_into_mocked_compute_path(self) -> None:
+        events: list[str] = []
+
+        class FakeController(runner.Controller):
+            def ensure_map_present(self) -> None:
+                events.append("map")
+
+            def ensure_dist_present(self) -> None:
+                events.append("dist")
+
+            def run_billing_guard(self) -> None:
+                events.append("billing")
+
+            def verify_security_group(self) -> None:
+                events.append("security_group")
+
+            def generate_experiment_card(self) -> None:
+                events.append("experiment_card")
+
+            def scale_up_and_wait(self) -> None:
+                events.append("scale_up")
+                self.scaled_up = True
+                self.instance_id = "ins-test"
+                self.public_ip = "203.0.113.10"
+                self.record_step("scale_up", 100.0, True, desiredCapacity=1)
+
+            def verify_worker_security(self) -> None:
+                events.append("worker_security")
+
+            def bootstrap_worker(self) -> None:
+                events.append("bootstrap")
+
+            def transfer_repo_bundle(self) -> None:
+                events.append("repo_bundle")
+
+            def transfer_secret_env(self) -> None:
+                events.append("secret_env")
+
+            def run_remote_training(self) -> None:
+                events.append("remote_training")
+                self.record_step("remote_training", 101.0, True, reportId=self.run_id)
+
+            def collect_remote_artifacts(self) -> None:
+                events.append("collect_artifacts")
+
+            def verify_remote_training_report(self) -> None:
+                events.append("verify_training_report")
+                self.result["trainingReport"] = {
+                    "path": str(self.artifact_dir / "remote" / "runtime-artifacts" / "rl-training" / f"{self.run_id}.json"),
+                    "reportId": self.run_id,
+                    "liveEffect": False,
+                    "officialMmoWrites": False,
+                    "officialMmoWritesAllowed": False,
+                    "artifactCount": 5,
+                    "scaleValidation": {
+                        "ok": True,
+                        "totalEnvironments": 5,
+                        "successfulEnvironments": 5,
+                        "minimumSuccessfulEnvironments": 4,
+                    },
+                }
+
+            def scale_down(self) -> None:
+                events.append("scale_down")
+                self.record_step("scale_down", 102.0, True, desiredCapacity=0)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                "500",
+                "--workers",
+                "1",
+            ])
+            artifact_dir = artifact_root / "new-run"
+            controller = FakeController(args=args, run_id=args.run_id, artifact_dir=artifact_dir)
+
+            with mock.patch.object(runner, "validate_static_inputs", return_value=None):
+                controller.run()
+
+            guard = json.loads((artifact_dir / "launch_guard.json").read_text(encoding="utf-8"))
+            summary = json.loads((artifact_dir / "controller-summary.json").read_text(encoding="utf-8"))
+
+        self.assertFalse(args.preflight_only)
+        self.assertFalse(guard["blocked"])
+        self.assertEqual(controller.final_status, "completed")
+        self.assertEqual(summary["finalStatus"], "completed")
+        self.assertNotEqual(summary["finalStatus"], "preflight_ok")
+        self.assertEqual(summary["inputs"]["command"], "run-single")
+        self.assertFalse(summary["inputs"]["preflightOnly"])
+        self.assertEqual(summary["inputs"]["scenarioId"], runner.MULTI_TIER_SCENARIO_ID)
+        self.assertEqual(summary["execution"]["command"], "run-single")
+        self.assertEqual(summary["execution"]["mode"], "compute")
+        self.assertFalse(summary["execution"]["preflightOnly"])
+        self.assertTrue(summary["execution"]["computeAttempted"])
+        self.assertTrue(summary["execution"]["scaleOutAttempted"])
+        self.assertTrue(summary["execution"]["remoteTrainingAttempted"])
+        self.assertTrue(summary["execution"]["trainingReportProduced"])
+        self.assertEqual(summary["execution"]["trainingReportId"], "new-run")
+        self.assertEqual(summary["execution"]["artifactCount"], 5)
+        self.assertEqual(summary["execution"]["environmentsRun"], 5)
+        self.assertEqual(summary["instanceId"], "ins-test")
+        self.assertIn("scale_up", events)
+        self.assertIn("bootstrap", events)
+        self.assertIn("remote_training", events)
+        self.assertIn("verify_training_report", events)
+        self.assertLess(events.index("experiment_card"), events.index("scale_up"))
 
     def test_static_validation_accepts_bounded_multi_worker_scale_proof(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- Make `run-single` default to the multi-tier policy-gradient scenario instead of remaining a preflight-only path.
- Add explicit execution metadata to Tencent RL controller summaries so Loop A/B can distinguish preflight-only runs from actual compute attempts.
- Prefix preflight run IDs separately and add tests for compute-path progression and summary evidence.

## Verification
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts.test_screeps_tencent_batch_rl_runner -v` — 63 tests OK
- `git diff --check`

## Safety
- Offline/Tencent RL controller code only; no official MMO writes or Screeps deploy.
- Does not print or commit secrets.

Refs #1203, #879, #1032.
