### PR TITLE
fix(rl): require compute evidence in Loop B reports

### DIFF
--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -1770,6 +1770,7 @@ def policy_compute_evidence(payload: JsonObject, training: JsonObject | None) ->
     if (
         evidence.get("hasCompute") is not True
         and training_evidence.get("classification") == "PREFLIGHT_ONLY_VALIDATION"
+        and identity_match is not None
     ):
         return {
             "hasCompute": False,

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -136,6 +136,28 @@ POLICY_ADVANTAGE_METRIC_STATUS_KEYS = {
     "validated",
     "win",
 }
+POLICY_TRAINING_IDENTITY_KEYS = {
+    "report": {
+        "reportid",
+        "trainingreport",
+        "trainingreportid",
+        "trainingreportids",
+        "trainingreportpath",
+        "trainingreportpaths",
+        "trainingreports",
+    },
+    "run": {
+        "batchrunid",
+        "runid",
+        "tencentbatchrunid",
+        "tencentrunid",
+        "trainingrunid",
+    },
+    "instance": {
+        "controllerinstanceid",
+        "instanceid",
+    },
+}
 STRONG_TRAINING_REPORT_KEYS = {
     "trainingreport",
     "trainingreportid",
@@ -510,6 +532,52 @@ def compute_evidence_summary(payload: JsonObject) -> JsonObject:
         "signals": signals[:12],
         "blocker": blocker,
     }
+
+
+def identity_text_values(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped:
+            yield stripped
+    elif isinstance(value, list):
+        for item in value:
+            yield from identity_text_values(item)
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from identity_text_values(item)
+
+
+def collect_policy_training_identities(payload: JsonObject) -> JsonObject:
+    identities: dict[str, list[str]] = {}
+    seen: set[tuple[str, str]] = set()
+    for node in iter_json_objects(payload):
+        for key, raw in node.items():
+            normalized = normalized_key(str(key))
+            for kind, identity_keys in POLICY_TRAINING_IDENTITY_KEYS.items():
+                if normalized not in identity_keys:
+                    continue
+                for value in identity_text_values(raw):
+                    seen_key = (kind, value)
+                    if seen_key in seen:
+                        continue
+                    seen.add(seen_key)
+                    identities.setdefault(kind, []).append(value)
+    return identities
+
+
+def policy_training_identity_match(payload: JsonObject, training: JsonObject | None) -> JsonObject | None:
+    policy_identities = collect_policy_training_identities(payload)
+    training_identities = as_dict((training or {}).get("identity"))
+    for kind, policy_values in policy_identities.items():
+        training_values = {
+            value
+            for value in as_list(training_identities.get(kind))
+            if isinstance(value, str) and value
+        }
+        for value in policy_values:
+            if value in training_values:
+                return {"kind": kind, "value": value}
+    return None
 
 
 def card_training_approach(card: JsonObject) -> str | None:
@@ -1584,6 +1652,7 @@ def training_execution(
                 "signals": [],
                 "blocker": "No training ledger found.",
             },
+            "identity": {},
         }
     payload = latest_training.payload
     compute_evidence = compute_evidence_summary(payload)
@@ -1637,6 +1706,7 @@ def training_execution(
         "cardSupply": card_supply,
         "hasComputeEvidence": compute_evidence.get("hasCompute") is True,
         "computeEvidence": compute_evidence,
+        "identity": collect_policy_training_identities(payload),
     }
 
 
@@ -1676,12 +1746,19 @@ def card_supply_finding_for_policy(payload: JsonObject, training: JsonObject | N
 def policy_compute_evidence(payload: JsonObject, training: JsonObject | None) -> JsonObject:
     evidence = compute_evidence_summary(payload)
     training_evidence = as_dict((training or {}).get("computeEvidence"))
-    if training_evidence.get("hasCompute") is True:
+    identity_match = policy_training_identity_match(payload, training)
+    if training_evidence.get("hasCompute") is True and identity_match is not None:
         signals = list(as_list(evidence.get("signals")))
         signals.append(
             {
                 "field": "training.computeEvidence",
                 "value": training_evidence.get("classification") or "COMPUTE_CONFIRMED",
+            }
+        )
+        signals.append(
+            {
+                "field": f"policy.trainingIdentity.{identity_match['kind']}",
+                "value": identity_match["value"],
             }
         )
         return {

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -1938,7 +1938,7 @@ def lane_statuses(
     policy_updates = number_value(training.get("policyUpdates"))
     if not training.get("hasData"):
         lanes.append(lane("E4", "training", "BLOCKED", None, "No training ledger found."))
-    elif training.get("hasComputeEvidence") is True or (episodes or 0) > 0 or (policy_updates or 0) > 0:
+    elif training.get("hasComputeEvidence") is True:
         lanes.append(lane("E4", "training", "OK", training.get("latestPath"), "None"))
     elif training_status in {"NOT_RUN", "BLOCKED", "PREFLIGHT_ONLY"}:
         lanes.append(lane("E4", "training", "BLOCKED", training.get("latestPath"), training.get("blocker") or "Training not running."))

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -1757,7 +1757,7 @@ def training_execution(
         and not blocker
     ):
         blocker = text_value(card_supply.get("reason"))
-    raw_status = text_value(payload.get("status")) or ("RUN" if payload.get("trainingDidRun") else "NOT_RUN")
+    raw_status = non_blank_text_value(payload.get("status")) or ("RUN" if payload.get("trainingDidRun") else "NOT_RUN")
     effective_status = raw_status
     training_claims_compute = (
         payload.get("trainingDidRun") is True
@@ -1933,7 +1933,11 @@ def policy_advantage(
             if isinstance(value, dict):
                 metrics.append({"category": key, "status": value.get("advantage", "UNKNOWN"), "delta": value.get("delta")})
 
-    raw_status = text_value(payload.get("onlineUtilityStatus")) or text_value(payload.get("status")) or "UNKNOWN"
+    raw_status = (
+        non_blank_text_value(payload.get("onlineUtilityStatus"))
+        or non_blank_text_value(payload.get("status"))
+        or "UNKNOWN"
+    )
     compute_evidence = policy_compute_evidence(payload, training)
     has_compute = compute_evidence.get("hasCompute") is True
     requires_compute = policy_requires_compute(raw_status, metrics)

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -539,7 +539,7 @@ def compute_evidence_summary(payload: JsonObject) -> JsonObject:
     preflight_only = preflight_marker_present(payload) and not strong_signals
     weak_signals = [] if preflight_only else collect_weak_compute_evidence(payload)
     signals = strong_signals + weak_signals
-    if signals:
+    if strong_signals:
         classification = "COMPUTE_CONFIRMED"
         blocker = None
     elif preflight_only:
@@ -555,7 +555,7 @@ def compute_evidence_summary(payload: JsonObject) -> JsonObject:
             "or controller execution/provisioning beyond preflight."
         )
     return {
-        "hasCompute": bool(signals),
+        "hasCompute": bool(strong_signals),
         "classification": classification,
         "signals": signals[:12],
         "blocker": blocker,

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -108,6 +108,7 @@ PREFLIGHT_FINAL_STATUS_KEYS = {
     "preflightpassed",
     "preflightvalidated",
 }
+CONTROLLER_COMPUTE_FINAL_STATUS_KEYS = {"running", "completed", "success", "ok"}
 TRAINING_COMPUTE_CLAIM_STATUS_KEYS = {
     "run",
     "running",
@@ -486,9 +487,10 @@ def collect_strong_compute_evidence(payload: JsonObject) -> list[JsonObject]:
             continue
         instance_id = text_value(first_present(node, ("instanceId", "instance_id")))
         worker_user = text_value(first_present(node, ("workerUser", "worker_user")))
-        if instance_id is not None:
+        has_compute_status = final_status in CONTROLLER_COMPUTE_FINAL_STATUS_KEYS
+        if instance_id is not None and has_compute_status:
             add("controllerSummary.instanceId", "present")
-        elif worker_user is not None and final_status in {"running", "completed", "success", "ok"}:
+        elif worker_user is not None and has_compute_status:
             add("controllerSummary.workerUser", "present")
 
     return signals

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -101,6 +101,62 @@ TIMESTAMP_KEYS = (
     "lastSeenAt",
 )
 FILENAME_TIMESTAMP_RE = re.compile(r"(\d{8}T\d{4,6}Z)")
+PREFLIGHT_FINAL_STATUS_KEYS = {
+    "preflight",
+    "preflightok",
+    "preflightonly",
+    "preflightpassed",
+    "preflightvalidated",
+}
+TRAINING_COMPUTE_CLAIM_STATUS_KEYS = {
+    "run",
+    "running",
+    "runwithanomaly",
+    "completed",
+    "success",
+    "ok",
+    "traininginflight",
+    "computeready",
+}
+POLICY_COMPUTE_CLAIM_STATUS_KEYS = {
+    "advantage",
+    "approved",
+    "computeready",
+    "pass",
+    "promotable",
+    "proven",
+    "rolloutapproved",
+    "validated",
+}
+POLICY_ADVANTAGE_METRIC_STATUS_KEYS = {
+    "advantage",
+    "better",
+    "promotable",
+    "proven",
+    "validated",
+    "win",
+}
+STRONG_TRAINING_REPORT_KEYS = {
+    "trainingreport",
+    "trainingreportid",
+    "trainingreportids",
+    "trainingreportpath",
+    "trainingreportpaths",
+    "trainingreports",
+}
+ENVIRONMENT_RUN_COUNT_KEYS = {
+    "completedenvironmentruns",
+    "completedenvironments",
+    "environmentruns",
+    "environmentscompleted",
+    "environmentsrun",
+}
+WEAK_COMPUTE_COUNT_KEYS = {
+    "artifactcount",
+    "episodesrun",
+    "policyupdateiterations",
+    "simulatorticksrun",
+}
 
 
 @dataclass(frozen=True)
@@ -307,6 +363,153 @@ def first_present(value: JsonObject, keys: Sequence[str]) -> Any:
         if key in value:
             return value[key]
     return None
+
+
+def iter_json_objects(value: Any) -> Iterable[JsonObject]:
+    if isinstance(value, dict):
+        yield value
+        for item in value.values():
+            yield from iter_json_objects(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from iter_json_objects(item)
+
+
+def value_has_reference(value: Any) -> bool:
+    if isinstance(value, str):
+        return bool(value)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return True
+    if isinstance(value, dict):
+        return any(value_has_reference(item) for item in value.values())
+    if isinstance(value, list):
+        return any(value_has_reference(item) for item in value)
+    return False
+
+
+def positive_count(value: Any) -> int | None:
+    parsed = int_value(value)
+    if parsed is None or parsed <= 0:
+        return None
+    return parsed
+
+
+def status_key(value: Any) -> str:
+    raw = text_value(value)
+    return normalized_key(raw) if raw is not None else ""
+
+
+def controller_summary_final_status_key(node: JsonObject) -> str:
+    return status_key(first_present(node, ("finalStatus", "final_status")))
+
+
+def node_looks_like_controller_summary(node: JsonObject) -> bool:
+    if node.get("type") == "screeps-tencent-batch-rl-run":
+        return True
+    return any(key in node for key in ("finalStatus", "final_status")) and any(
+        key in node for key in ("instanceId", "instance_id", "environmentsRun", "outputs")
+    )
+
+
+def preflight_marker_present(payload: JsonObject) -> bool:
+    return any(
+        controller_summary_final_status_key(node) in PREFLIGHT_FINAL_STATUS_KEYS
+        for node in iter_json_objects(payload)
+    )
+
+
+def collect_strong_compute_evidence(payload: JsonObject) -> list[JsonObject]:
+    signals: list[JsonObject] = []
+    seen: set[tuple[str, str]] = set()
+
+    def add(field: str, value: Any) -> None:
+        key = (field, str(value))
+        if key in seen:
+            return
+        seen.add(key)
+        signals.append({"field": field, "value": value})
+
+    for node in iter_json_objects(payload):
+        for key, raw in node.items():
+            normalized = normalized_key(str(key))
+            if normalized in STRONG_TRAINING_REPORT_KEYS and value_has_reference(raw):
+                add(str(key), "present")
+            if normalized in ENVIRONMENT_RUN_COUNT_KEYS:
+                count = positive_count(raw)
+                if count is not None:
+                    add(str(key), count)
+            if normalized == "environmentexecution":
+                execution = as_dict(raw)
+                completed = (
+                    positive_count(execution.get("completed"))
+                    or positive_count(execution.get("Completed"))
+                    or positive_count(execution.get("completedCount"))
+                )
+                if completed is not None:
+                    add("environmentExecution.completed", completed)
+
+        if not node_looks_like_controller_summary(node):
+            continue
+        final_status = controller_summary_final_status_key(node)
+        if final_status in PREFLIGHT_FINAL_STATUS_KEYS:
+            continue
+        instance_id = text_value(first_present(node, ("instanceId", "instance_id")))
+        worker_user = text_value(first_present(node, ("workerUser", "worker_user")))
+        if instance_id is not None:
+            add("controllerSummary.instanceId", "present")
+        elif worker_user is not None and final_status in {"running", "completed", "success", "ok"}:
+            add("controllerSummary.workerUser", "present")
+
+    return signals
+
+
+def collect_weak_compute_evidence(payload: JsonObject) -> list[JsonObject]:
+    signals: list[JsonObject] = []
+    seen: set[tuple[str, str]] = set()
+
+    def add(field: str, value: Any) -> None:
+        key = (field, str(value))
+        if key in seen:
+            return
+        seen.add(key)
+        signals.append({"field": field, "value": value})
+
+    for node in iter_json_objects(payload):
+        for key, raw in node.items():
+            normalized = normalized_key(str(key))
+            if normalized in WEAK_COMPUTE_COUNT_KEYS:
+                count = positive_count(raw)
+                if count is not None:
+                    add(str(key), count)
+    return signals
+
+
+def compute_evidence_summary(payload: JsonObject) -> JsonObject:
+    strong_signals = collect_strong_compute_evidence(payload)
+    preflight_only = preflight_marker_present(payload) and not strong_signals
+    weak_signals = [] if preflight_only else collect_weak_compute_evidence(payload)
+    signals = strong_signals + weak_signals
+    if signals:
+        classification = "COMPUTE_CONFIRMED"
+        blocker = None
+    elif preflight_only:
+        classification = "PREFLIGHT_ONLY_VALIDATION"
+        blocker = (
+            "Preflight-only controller validation found; no training report, environment completion, "
+            "or provisioned compute evidence is present."
+        )
+    else:
+        classification = "MISSING_COMPUTE_EVIDENCE"
+        blocker = (
+            "No real compute evidence found; require training report IDs, completed environments, "
+            "or controller execution/provisioning beyond preflight."
+        )
+    return {
+        "hasCompute": bool(signals),
+        "classification": classification,
+        "signals": signals[:12],
+        "blocker": blocker,
+    }
 
 
 def card_training_approach(card: JsonObject) -> str | None:
@@ -1315,12 +1518,13 @@ def reconcile_card_supply_for_training(
     tencent_internal_card_supply: JsonObject | None,
     tencent_internal_card_supply_candidates: Sequence[JsonObject] | None = None,
 ) -> JsonObject:
+    compute_evidence = compute_evidence_summary(payload)
     artifact_count = number_value(payload.get("artifactCount"))
     iteration = as_dict(payload.get("iterationExecution"))
     episodes_run = number_value(iteration.get("episodesRun"))
     policy_updates = number_value(iteration.get("policyUpdateIterations"))
-    training_did_run = (
-        payload.get("trainingDidRun") is True
+    training_did_run = compute_evidence.get("classification") != "PREFLIGHT_ONLY_VALIDATION" and (
+        compute_evidence.get("hasCompute") is True
         or (artifact_count or 0) > 0
         or (episodes_run or 0) > 0
         or (policy_updates or 0) > 0
@@ -1366,14 +1570,23 @@ def training_execution(
         return {
             "hasData": False,
             "status": "N/A",
+            "rawStatus": "N/A",
             "episodes": None,
             "policyUpdates": None,
             "timestamp": None,
             "blocker": "No training ledger found.",
             "latestPath": None,
             "cardSupply": blocked_card_supply_summary("No training ledger found."),
+            "hasComputeEvidence": False,
+            "computeEvidence": {
+                "hasCompute": False,
+                "classification": "MISSING_COMPUTE_EVIDENCE",
+                "signals": [],
+                "blocker": "No training ledger found.",
+            },
         }
     payload = latest_training.payload
+    compute_evidence = compute_evidence_summary(payload)
     iteration = as_dict(payload.get("iterationExecution"))
     metrics_feed = as_dict(as_dict(payload.get("metricsFeed")).get("forIssue906"))
     episodes = number_value(iteration.get("episodesRun"))
@@ -1396,9 +1609,25 @@ def training_execution(
         and not blocker
     ):
         blocker = text_value(card_supply.get("reason"))
+    raw_status = text_value(payload.get("status")) or ("RUN" if payload.get("trainingDidRun") else "NOT_RUN")
+    effective_status = raw_status
+    training_claims_compute = (
+        payload.get("trainingDidRun") is True
+        or status_key(raw_status) in TRAINING_COMPUTE_CLAIM_STATUS_KEYS
+        or (episodes or 0) > 0
+        or (updates or 0) > 0
+    )
+    if training_claims_compute and compute_evidence.get("hasCompute") is not True:
+        effective_status = (
+            "PREFLIGHT_ONLY"
+            if compute_evidence.get("classification") == "PREFLIGHT_ONLY_VALIDATION"
+            else "BLOCKED"
+        )
+        blocker = text_value(compute_evidence.get("blocker")) or blocker
     return {
         "hasData": True,
-        "status": text_value(payload.get("status")) or ("RUN" if payload.get("trainingDidRun") else "NOT_RUN"),
+        "status": effective_status,
+        "rawStatus": raw_status,
         "trainingDidRun": payload.get("trainingDidRun"),
         "episodes": episodes,
         "policyUpdates": updates,
@@ -1406,6 +1635,8 @@ def training_execution(
         "blocker": blocker,
         "latestPath": latest_training.path,
         "cardSupply": card_supply,
+        "hasComputeEvidence": compute_evidence.get("hasCompute") is True,
+        "computeEvidence": compute_evidence,
     }
 
 
@@ -1442,6 +1673,58 @@ def card_supply_finding_for_policy(payload: JsonObject, training: JsonObject | N
     }
 
 
+def policy_compute_evidence(payload: JsonObject, training: JsonObject | None) -> JsonObject:
+    evidence = compute_evidence_summary(payload)
+    training_evidence = as_dict((training or {}).get("computeEvidence"))
+    if training_evidence.get("hasCompute") is True:
+        signals = list(as_list(evidence.get("signals")))
+        signals.append(
+            {
+                "field": "training.computeEvidence",
+                "value": training_evidence.get("classification") or "COMPUTE_CONFIRMED",
+            }
+        )
+        return {
+            "hasCompute": True,
+            "classification": "COMPUTE_CONFIRMED",
+            "signals": signals[:12],
+            "blocker": None,
+        }
+    if (
+        evidence.get("hasCompute") is not True
+        and training_evidence.get("classification") == "PREFLIGHT_ONLY_VALIDATION"
+    ):
+        return {
+            "hasCompute": False,
+            "classification": "PREFLIGHT_ONLY_VALIDATION",
+            "signals": [],
+            "blocker": training_evidence.get("blocker") or evidence.get("blocker"),
+        }
+    return evidence
+
+
+def metric_status_claims_advantage(metric: JsonObject) -> bool:
+    return status_key(metric.get("status")) in POLICY_ADVANTAGE_METRIC_STATUS_KEYS
+
+
+def policy_requires_compute(status: str, metrics: Sequence[JsonObject]) -> bool:
+    return (
+        status_key(status) in POLICY_COMPUTE_CLAIM_STATUS_KEYS
+        or any(metric_status_claims_advantage(metric) for metric in metrics)
+    )
+
+
+def guard_policy_metrics_for_compute(metrics: Sequence[JsonObject], has_compute: bool) -> list[JsonObject]:
+    guarded: list[JsonObject] = []
+    for metric in metrics:
+        item = dict(metric)
+        if not has_compute and metric_status_claims_advantage(item):
+            item["rawStatus"] = item.get("status")
+            item["status"] = "BLOCKED_NO_COMPUTE"
+        guarded.append(item)
+    return guarded
+
+
 def policy_advantage(
     latest_policy: LoadedArtifact | None,
     latest_metrics: LoadedArtifact | None,
@@ -1453,6 +1736,7 @@ def policy_advantage(
         return {
             "hasData": False,
             "status": "N/A",
+            "rawStatus": "N/A",
             "candidate": "N/A",
             "baseline": "N/A",
             "timestamp": None,
@@ -1460,6 +1744,14 @@ def policy_advantage(
             "metrics": [],
             "shadowMetrics": shadow_metrics(observations),
             "cardSupplyFinding": None,
+            "hasComputeEvidence": False,
+            "computeEvidence": {
+                "hasCompute": False,
+                "classification": "MISSING_COMPUTE_EVIDENCE",
+                "signals": [],
+                "blocker": "No policy advantage artifact found.",
+            },
+            "blocker": "No policy advantage artifact found.",
         }
 
     payload = latest_policy.payload
@@ -1481,16 +1773,30 @@ def policy_advantage(
             if isinstance(value, dict):
                 metrics.append({"category": key, "status": value.get("advantage", "UNKNOWN"), "delta": value.get("delta")})
 
+    raw_status = text_value(payload.get("onlineUtilityStatus")) or text_value(payload.get("status")) or "UNKNOWN"
+    compute_evidence = policy_compute_evidence(payload, training)
+    has_compute = compute_evidence.get("hasCompute") is True
+    requires_compute = policy_requires_compute(raw_status, metrics)
+    status = raw_status
+    blocker = None
+    if requires_compute and not has_compute:
+        status = "BLOCKED"
+        blocker = text_value(compute_evidence.get("blocker"))
+    guarded_metrics = guard_policy_metrics_for_compute(metrics[:8], has_compute)
     return {
         "hasData": True,
-        "status": text_value(payload.get("onlineUtilityStatus")) or text_value(payload.get("status")) or "UNKNOWN",
+        "status": status,
+        "rawStatus": raw_status,
         "candidate": text_value(payload.get("candidatePolicyId")) or "N/A",
         "baseline": text_value(payload.get("baselinePolicyId")) or "N/A",
         "timestamp": latest_policy.timestamp,
         "latestPath": latest_policy.path,
-        "metrics": metrics[:8],
+        "metrics": guarded_metrics,
         "shadowMetrics": shadow_metrics(observations),
         "cardSupplyFinding": card_supply_finding_for_policy(payload, training),
+        "hasComputeEvidence": has_compute,
+        "computeEvidence": compute_evidence,
+        "blocker": blocker,
     }
 
 
@@ -1543,6 +1849,8 @@ def lane_statuses(
         lanes.append(lane("E3", "strategy comparison", "BLOCKED", None, "No policy advantage artifact found."))
     elif policy_status in {"PROVEN", "VALIDATED", "PROMOTABLE", "ADVANTAGE"}:
         lanes.append(lane("E3", "strategy comparison", "OK", policy.get("latestPath"), "None"))
+    elif policy_status == "BLOCKED":
+        lanes.append(lane("E3", "strategy comparison", "BLOCKED", policy.get("latestPath"), policy.get("blocker") or "Policy advantage is blocked."))
     elif policy_status == "UNPROVEN":
         lanes.append(lane("E3", "strategy comparison", "BLOCKED", policy.get("latestPath"), "Policy advantage remains UNPROVEN."))
     else:
@@ -1553,9 +1861,9 @@ def lane_statuses(
     policy_updates = number_value(training.get("policyUpdates"))
     if not training.get("hasData"):
         lanes.append(lane("E4", "training", "BLOCKED", None, "No training ledger found."))
-    elif training.get("trainingDidRun") is True or (episodes or 0) > 0 or (policy_updates or 0) > 0:
+    elif training.get("hasComputeEvidence") is True or (episodes or 0) > 0 or (policy_updates or 0) > 0:
         lanes.append(lane("E4", "training", "OK", training.get("latestPath"), "None"))
-    elif training_status in {"NOT_RUN", "BLOCKED"}:
+    elif training_status in {"NOT_RUN", "BLOCKED", "PREFLIGHT_ONLY"}:
         lanes.append(lane("E4", "training", "BLOCKED", training.get("latestPath"), training.get("blocker") or "Training not running."))
     else:
         lanes.append(lane("E4", "training", "DEGRADED", training.get("latestPath"), training.get("blocker") or training_status))
@@ -1564,6 +1872,8 @@ def lane_statuses(
         lanes.append(lane("E5", "rollout", "BLOCKED", None, "No rollout evidence found."))
     elif policy_status in {"PROVEN", "VALIDATED", "PROMOTABLE", "ROLLOUT_APPROVED"}:
         lanes.append(lane("E5", "rollout", "OK", policy.get("latestPath"), "None"))
+    elif policy_status == "BLOCKED":
+        lanes.append(lane("E5", "rollout", "BLOCKED", policy.get("latestPath"), policy.get("blocker") or "Rollout blocked until compute evidence exists."))
     elif policy_status == "UNPROVEN":
         lanes.append(lane("E5", "rollout", "BLOCKED", policy.get("latestPath"), "Rollout blocked until policy advantage is proven."))
     else:
@@ -1763,6 +2073,7 @@ def render_simulator(simulator: JsonObject, repo_root: Path) -> str:
 
 def render_training(training: JsonObject, repo_root: Path) -> str:
     card_supply = as_dict(training.get("cardSupply"))
+    compute_evidence = as_dict(training.get("computeEvidence"))
     card_supply_status = "N/A"
     if card_supply:
         card_supply_status = (
@@ -1774,6 +2085,7 @@ def render_training(training: JsonObject, repo_root: Path) -> str:
         f"<tr><td>Status</td><td>{h(training.get('status', 'N/A'))}</td></tr>",
         f"<tr><td>Episodes</td><td>{h(format_count(training.get('episodes')))}</td></tr>",
         f"<tr><td>Policy updates</td><td>{h(format_count(training.get('policyUpdates')))}</td></tr>",
+        f"<tr><td>Compute evidence</td><td>{h(compute_evidence.get('classification', 'N/A'))}</td></tr>",
         f"<tr><td>Card supply</td><td>{h(card_supply_status)}</td></tr>",
         f"<tr><td>Last ledger timestamp</td><td>{h(display_timestamp(training.get('timestamp')))}</td></tr>",
         f"<tr><td>Blocker</td><td>{h(shorten(training.get('blocker') or 'N/A', 260))}</td></tr>",
@@ -1798,7 +2110,9 @@ def render_policy(policy: JsonObject, repo_root: Path) -> str:
         )
     shadow = as_dict(policy.get("shadowMetrics"))
     card_supply_finding = as_dict(policy.get("cardSupplyFinding"))
+    compute_evidence = as_dict(policy.get("computeEvidence"))
     shadow_rows = [
+        f"<tr><td>compute evidence</td><td>{h(compute_evidence.get('classification', 'N/A'))}</td></tr>",
         f"<tr><td>changedTopCount</td><td>{h(format_count(shadow.get('changedTopCount')))}</td></tr>",
         f"<tr><td>rankingDiffCount</td><td>{h(format_count(shadow.get('rankingDiffCount')))}</td></tr>",
         f"<tr><td>shadow territory KPI</td><td>{h(format_count(shadow.get('territory')))}</td></tr>",

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -399,7 +399,14 @@ def iter_json_objects(value: Any) -> Iterable[JsonObject]:
 
 def value_has_reference(value: Any) -> bool:
     if isinstance(value, str):
-        return bool(value)
+        text = value.strip()
+        if not text:
+            return False
+        try:
+            parsed = float(text)
+        except ValueError:
+            return True
+        return math.isfinite(parsed) and parsed > 0
     if isinstance(value, (int, float)) and not isinstance(value, bool):
         return value > 0
     if isinstance(value, dict):

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -436,7 +436,8 @@ def node_looks_like_controller_summary(node: JsonObject) -> bool:
 
 def preflight_marker_present(payload: JsonObject) -> bool:
     return any(
-        controller_summary_final_status_key(node) in PREFLIGHT_FINAL_STATUS_KEYS
+        node_looks_like_controller_summary(node)
+        and controller_summary_final_status_key(node) in PREFLIGHT_FINAL_STATUS_KEYS
         for node in iter_json_objects(payload)
     )
 

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -535,6 +535,53 @@ def compute_evidence_summary(payload: JsonObject) -> JsonObject:
     }
 
 
+def strong_compute_evidence_summary(payload: JsonObject) -> JsonObject:
+    signals = collect_strong_compute_evidence(payload)
+    if signals:
+        return {
+            "hasCompute": True,
+            "classification": "COMPUTE_CONFIRMED",
+            "signals": signals[:12],
+            "blocker": None,
+        }
+    if preflight_marker_present(payload):
+        return {
+            "hasCompute": False,
+            "classification": "PREFLIGHT_ONLY_VALIDATION",
+            "signals": [],
+            "blocker": (
+                "Preflight-only controller validation found; no training report, environment completion, "
+                "or provisioned compute evidence is present."
+            ),
+        }
+    return {
+        "hasCompute": False,
+        "classification": "MISSING_COMPUTE_EVIDENCE",
+        "signals": [],
+        "blocker": (
+            "No real compute evidence found; require training report IDs, completed environments, "
+            "or controller execution/provisioning beyond preflight."
+        ),
+    }
+
+
+def compute_evidence_summary_has_strong_signal(summary: JsonObject) -> bool:
+    for signal in as_list(summary.get("signals")):
+        field = text_value(as_dict(signal).get("field"))
+        if field is None:
+            continue
+        if field in {
+            "environmentExecution.completed",
+            "controllerSummary.instanceId",
+            "controllerSummary.workerUser",
+        }:
+            return True
+        normalized = normalized_key(field)
+        if normalized in STRONG_TRAINING_REPORT_KEYS or normalized in ENVIRONMENT_RUN_COUNT_KEYS:
+            return True
+    return False
+
+
 def identity_text_values(value: Any) -> Iterable[str]:
     if isinstance(value, str):
         stripped = value.strip()
@@ -1745,10 +1792,14 @@ def card_supply_finding_for_policy(payload: JsonObject, training: JsonObject | N
 
 
 def policy_compute_evidence(payload: JsonObject, training: JsonObject | None) -> JsonObject:
-    evidence = compute_evidence_summary(payload)
+    evidence = strong_compute_evidence_summary(payload)
     training_evidence = as_dict((training or {}).get("computeEvidence"))
     identity_match = policy_training_identity_match(payload, training)
-    if training_evidence.get("hasCompute") is True and identity_match is not None:
+    if (
+        training_evidence.get("hasCompute") is True
+        and compute_evidence_summary_has_strong_signal(training_evidence)
+        and identity_match is not None
+    ):
         signals = list(as_list(evidence.get("signals")))
         signals.append(
             {

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -429,7 +429,8 @@ def node_looks_like_controller_summary(node: JsonObject) -> bool:
     if node.get("type") == "screeps-tencent-batch-rl-run":
         return True
     return any(key in node for key in ("finalStatus", "final_status")) and any(
-        key in node for key in ("instanceId", "instance_id", "environmentsRun", "outputs")
+        key in node
+        for key in ("instanceId", "instance_id", "workerUser", "worker_user", "environmentsRun", "outputs")
     )
 
 

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -438,7 +438,16 @@ def node_looks_like_controller_summary(node: JsonObject) -> bool:
         return True
     return any(key in node for key in ("finalStatus", "final_status")) and any(
         key in node
-        for key in ("instanceId", "instance_id", "workerUser", "worker_user", "environmentsRun", "outputs")
+        for key in (
+            "instanceId",
+            "instance_id",
+            "workerUser",
+            "worker_user",
+            "environmentsRun",
+            "environmentExecution",
+            "environment_execution",
+            "outputs",
+        )
     )
 
 
@@ -448,6 +457,14 @@ def preflight_marker_present(payload: JsonObject) -> bool:
         and controller_summary_final_status_key(node) in PREFLIGHT_FINAL_STATUS_KEYS
         for node in iter_json_objects(payload)
     )
+
+
+def non_blank_text_value(value: Any) -> str | None:
+    text = text_value(value)
+    if text is None:
+        return None
+    stripped = text.strip()
+    return stripped or None
 
 
 def collect_strong_compute_evidence(payload: JsonObject) -> list[JsonObject]:
@@ -485,8 +502,8 @@ def collect_strong_compute_evidence(payload: JsonObject) -> list[JsonObject]:
         final_status = controller_summary_final_status_key(node)
         if final_status in PREFLIGHT_FINAL_STATUS_KEYS:
             continue
-        instance_id = text_value(first_present(node, ("instanceId", "instance_id")))
-        worker_user = text_value(first_present(node, ("workerUser", "worker_user")))
+        instance_id = non_blank_text_value(first_present(node, ("instanceId", "instance_id")))
+        worker_user = non_blank_text_value(first_present(node, ("workerUser", "worker_user")))
         has_compute_status = final_status in CONTROLLER_COMPUTE_FINAL_STATUS_KEYS
         if instance_id is not None and has_compute_status:
             add("controllerSummary.instanceId", "present")
@@ -1644,17 +1661,19 @@ def reconcile_card_supply_for_training(
     tencent_internal_card_supply: JsonObject | None,
     tencent_internal_card_supply_candidates: Sequence[JsonObject] | None = None,
 ) -> JsonObject:
-    compute_evidence = compute_evidence_summary(payload)
+    compute_evidence = strong_compute_evidence_summary(payload)
     artifact_count = number_value(payload.get("artifactCount"))
     iteration = as_dict(payload.get("iterationExecution"))
     episodes_run = number_value(iteration.get("episodesRun"))
     policy_updates = number_value(iteration.get("policyUpdateIterations"))
-    training_did_run = compute_evidence.get("classification") != "PREFLIGHT_ONLY_VALIDATION" and (
-        compute_evidence.get("hasCompute") is True
+    training_claims_compute = (
+        payload.get("trainingDidRun") is True
+        or status_key(payload.get("status")) in TRAINING_COMPUTE_CLAIM_STATUS_KEYS
         or (artifact_count or 0) > 0
         or (episodes_run or 0) > 0
         or (policy_updates or 0) > 0
     )
+    training_did_run = compute_evidence.get("hasCompute") is True
     embedded_supply = card_supply_from_training_payload(payload, latest_path)
     if training_did_run and embedded_supply is not None:
         return embedded_supply
@@ -1663,6 +1682,8 @@ def reconcile_card_supply_for_training(
         tencent_internal_card_supply_candidates,
     )
     if not training_did_run:
+        if training_claims_compute:
+            return blocked_card_supply_summary(text_value(compute_evidence.get("blocker")))
         available_supply = best_available_tencent_card_supply(tencent_candidates)
         if available_supply is not None:
             return dict(available_supply)
@@ -1744,12 +1765,11 @@ def training_execution(
         or (episodes or 0) > 0
         or (updates or 0) > 0
     )
-    if training_claims_compute and compute_evidence.get("hasCompute") is not True:
-        effective_status = (
-            "PREFLIGHT_ONLY"
-            if compute_evidence.get("classification") == "PREFLIGHT_ONLY_VALIDATION"
-            else "BLOCKED"
-        )
+    if compute_evidence.get("classification") == "PREFLIGHT_ONLY_VALIDATION":
+        effective_status = "PREFLIGHT_ONLY"
+        blocker = text_value(compute_evidence.get("blocker")) or blocker
+    elif training_claims_compute and compute_evidence.get("hasCompute") is not True:
+        effective_status = "BLOCKED"
         blocker = text_value(compute_evidence.get("blocker")) or blocker
     return {
         "hasData": True,

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -401,7 +401,7 @@ def value_has_reference(value: Any) -> bool:
     if isinstance(value, str):
         return bool(value)
     if isinstance(value, (int, float)) and not isinstance(value, bool):
-        return True
+        return value > 0
     if isinstance(value, dict):
         return any(value_has_reference(item) for item in value.values())
     if isinstance(value, list):

--- a/scripts/screeps_rl_live_dashboard.py
+++ b/scripts/screeps_rl_live_dashboard.py
@@ -299,6 +299,7 @@ def tencent_batch_summary(artifact_root: Path, repo_root: Path) -> JsonObject:
             payload = load_json_object(path)
             if payload is None:
                 continue
+            compute_evidence = static_dashboard.compute_evidence_summary(payload)
             runs.append(
                 {
                     "runId": payload.get("runId") or path.parent.name,
@@ -310,6 +311,9 @@ def tencent_batch_summary(artifact_root: Path, repo_root: Path) -> JsonObject:
                     "workerUser": payload.get("workerUser"),
                     "inputs": payload.get("inputs") if isinstance(payload.get("inputs"), dict) else {},
                     "safety": payload.get("safety") if isinstance(payload.get("safety"), dict) else {},
+                    "computeEvidence": compute_evidence,
+                    "computeClassification": compute_evidence.get("classification"),
+                    "blocker": compute_evidence.get("blocker"),
                     "path": safe_display_path(path, repo_root),
                     "timestamp": display_timestamp(artifact_timestamp(path, payload)),
                 }
@@ -321,11 +325,15 @@ def tencent_batch_summary(artifact_root: Path, repo_root: Path) -> JsonObject:
         if run.get("partial") is True or str(run.get("finalStatus", "")).lower() in {"unknown", "running"}
     ]
     completed = [run for run in runs if str(run.get("finalStatus", "")).lower() in {"completed", "success", "ok"}]
+    compute_confirmed = [run for run in runs if run.get("computeClassification") == "COMPUTE_CONFIRMED"]
+    preflight_only = [run for run in runs if run.get("computeClassification") == "PREFLIGHT_ONLY_VALIDATION"]
     return {
         "hasData": bool(runs),
         "runCount": len(runs),
         "activeRunCount": len(active),
         "completedRunCount": len(completed),
+        "computeConfirmedRunCount": len(compute_confirmed),
+        "preflightOnlyRunCount": len(preflight_only),
         "latest": latest,
     }
 
@@ -502,8 +510,11 @@ def render_live_html(summary: JsonObject, config: LiveDashboardConfig) -> str:
         ("Runs", h(format_value(tencent.get("runCount")))),
         ("Active runs", h(format_value(tencent.get("activeRunCount")))),
         ("Completed runs", h(format_value(tencent.get("completedRunCount")))),
+        ("Compute-confirmed runs", h(format_value(tencent.get("computeConfirmedRunCount")))),
+        ("Preflight-only validations", h(format_value(tencent.get("preflightOnlyRunCount")))),
         ("Latest run", h(latest_tencent.get("runId") or "N/A")),
         ("Latest status", render_status(latest_tencent.get("finalStatus"))),
+        ("Latest compute evidence", h(latest_tencent.get("computeClassification") or "N/A")),
         ("Scale down attempted", h(latest_tencent.get("safety", {}).get("scaleDownAttempted") if isinstance(latest_tencent.get("safety"), dict) else "N/A")),
     ]
     safety_rows = [

--- a/scripts/screeps_rl_scorecard.py
+++ b/scripts/screeps_rl_scorecard.py
@@ -24,6 +24,28 @@ DEFAULT_OUT_DIR = Path("runtime-artifacts/rl-control-loop/scorecards")
 RUNTIME_SUMMARY_PREFIX = "#runtime-summary "
 EPSILON = 1e-9
 MAX_REFERENCED_ARTIFACTS = 200
+PREFLIGHT_FINAL_STATUS_KEYS = {
+    "preflight",
+    "preflightok",
+    "preflightonly",
+    "preflightpassed",
+    "preflightvalidated",
+}
+STRONG_TRAINING_REPORT_KEYS = {
+    "trainingreport",
+    "trainingreportid",
+    "trainingreportids",
+    "trainingreportpath",
+    "trainingreportpaths",
+    "trainingreports",
+}
+ENVIRONMENT_RUN_COUNT_KEYS = {
+    "completedenvironmentruns",
+    "completedenvironments",
+    "environmentruns",
+    "environmentscompleted",
+    "environmentsrun",
+}
 
 STATUS_IMPROVED = "improved"
 STATUS_NEUTRAL = "neutral"
@@ -252,6 +274,86 @@ def first_number(raw: Any, paths: Sequence[tuple[str, ...]]) -> float | None:
 
 def normalized_key(value: str) -> str:
     return "".join(character for character in value.lower() if character.isalnum())
+
+
+def iter_json_objects(value: Any) -> Iterable[JsonObject]:
+    if isinstance(value, dict):
+        yield value
+        for item in value.values():
+            yield from iter_json_objects(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from iter_json_objects(item)
+
+
+def value_has_reference(value: Any) -> bool:
+    if isinstance(value, str):
+        return bool(value)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return True
+    if isinstance(value, dict):
+        return any(value_has_reference(item) for item in value.values())
+    if isinstance(value, list):
+        return any(value_has_reference(item) for item in value)
+    return False
+
+
+def positive_count(value: Any) -> int | None:
+    parsed = number_value(value)
+    if parsed is None or parsed <= 0:
+        return None
+    return int(parsed)
+
+
+def controller_summary_final_status_key(node: JsonObject) -> str:
+    raw = text_value(path_value(node, ("finalStatus",))) or text_value(path_value(node, ("final_status",)))
+    return normalized_key(raw) if raw is not None else ""
+
+
+def node_looks_like_controller_summary(node: JsonObject) -> bool:
+    if node.get("type") == "screeps-tencent-batch-rl-run":
+        return True
+    return any(key in node for key in ("finalStatus", "final_status")) and any(
+        key in node for key in ("instanceId", "instance_id", "environmentsRun", "outputs")
+    )
+
+
+def preflight_marker_present(payload: JsonObject) -> bool:
+    return any(
+        controller_summary_final_status_key(node) in PREFLIGHT_FINAL_STATUS_KEYS
+        for node in iter_json_objects(payload)
+    )
+
+
+def real_compute_evidence_present(payload: JsonObject) -> bool:
+    for node in iter_json_objects(payload):
+        for key, raw in node.items():
+            normalized = normalized_key(str(key))
+            if normalized in STRONG_TRAINING_REPORT_KEYS and value_has_reference(raw):
+                return True
+            if normalized in ENVIRONMENT_RUN_COUNT_KEYS and positive_count(raw) is not None:
+                return True
+            if normalized == "environmentexecution":
+                execution = as_dict(raw)
+                if (
+                    positive_count(execution.get("completed")) is not None
+                    or positive_count(execution.get("Completed")) is not None
+                    or positive_count(execution.get("completedCount")) is not None
+                ):
+                    return True
+
+        if not node_looks_like_controller_summary(node):
+            continue
+        final_status = controller_summary_final_status_key(node)
+        if final_status in PREFLIGHT_FINAL_STATUS_KEYS:
+            continue
+        if text_value(node.get("instanceId")) is not None or text_value(node.get("instance_id")) is not None:
+            return True
+    return False
+
+
+def preflight_only_compute_payload(payload: JsonObject) -> bool:
+    return preflight_marker_present(payload) and not real_compute_evidence_present(payload)
 
 
 def find_first_number_by_keys(value: Any, key_names: Sequence[str]) -> float | None:
@@ -667,6 +769,9 @@ def normalized_status(payload: JsonObject) -> str | None:
 
 
 def ingest_training_or_advantage(accumulator: MetricAccumulator, payload: JsonObject, source: str) -> None:
+    if preflight_only_compute_payload(payload):
+        return
+
     for result in as_list(payload.get("variantResults")):
         if not isinstance(result, dict):
             continue

--- a/scripts/screeps_rl_scorecard.py
+++ b/scripts/screeps_rl_scorecard.py
@@ -322,7 +322,8 @@ def node_looks_like_controller_summary(node: JsonObject) -> bool:
 
 def preflight_marker_present(payload: JsonObject) -> bool:
     return any(
-        controller_summary_final_status_key(node) in PREFLIGHT_FINAL_STATUS_KEYS
+        node_looks_like_controller_summary(node)
+        and controller_summary_final_status_key(node) in PREFLIGHT_FINAL_STATUS_KEYS
         for node in iter_json_objects(payload)
     )
 

--- a/scripts/screeps_rl_scorecard.py
+++ b/scripts/screeps_rl_scorecard.py
@@ -357,10 +357,14 @@ def real_compute_evidence_present(payload: JsonObject) -> bool:
         final_status = controller_summary_final_status_key(node)
         if final_status in PREFLIGHT_FINAL_STATUS_KEYS:
             continue
-        if text_value(node.get("instanceId")) is not None or text_value(node.get("instance_id")) is not None:
+        has_compute_status = final_status in CONTROLLER_COMPUTE_FINAL_STATUS_KEYS
+        if (
+            has_compute_status
+            and (text_value(node.get("instanceId")) is not None or text_value(node.get("instance_id")) is not None)
+        ):
             return True
         worker_user = text_value(node.get("workerUser")) or text_value(node.get("worker_user"))
-        if worker_user is not None and final_status in CONTROLLER_COMPUTE_FINAL_STATUS_KEYS:
+        if worker_user is not None and has_compute_status:
             return True
     return False
 

--- a/scripts/screeps_rl_scorecard.py
+++ b/scripts/screeps_rl_scorecard.py
@@ -290,7 +290,7 @@ def value_has_reference(value: Any) -> bool:
     if isinstance(value, str):
         return bool(value)
     if isinstance(value, (int, float)) and not isinstance(value, bool):
-        return True
+        return value > 0
     if isinstance(value, dict):
         return any(value_has_reference(item) for item in value.values())
     if isinstance(value, list):

--- a/scripts/screeps_rl_scorecard.py
+++ b/scripts/screeps_rl_scorecard.py
@@ -720,8 +720,10 @@ def ingest_json_artifact(accumulator: MetricAccumulator, payload: JsonObject, pa
     kind = artifact_kind(path, payload)
     if kind in {"evaluation_gate", "shadow_eval", "conclusion_registry"}:
         ingest_gate_or_shadow(accumulator, payload, source)
-    if kind in {"training_ledger", "policy_advantage"}:
+    if kind == "training_ledger":
         ingest_training_or_advantage(accumulator, payload, source)
+    if kind == "policy_advantage":
+        ingest_training_or_advantage(accumulator, payload, source, require_compute=True)
     if kind == "postdeploy_summary":
         ingest_postdeploy(accumulator, payload, source)
     if payload.get("type") == "runtime-kpi-report":
@@ -768,8 +770,14 @@ def normalized_status(payload: JsonObject) -> str | None:
     return None
 
 
-def ingest_training_or_advantage(accumulator: MetricAccumulator, payload: JsonObject, source: str) -> None:
-    if preflight_only_compute_payload(payload):
+def ingest_training_or_advantage(
+    accumulator: MetricAccumulator,
+    payload: JsonObject,
+    source: str,
+    *,
+    require_compute: bool = False,
+) -> None:
+    if preflight_only_compute_payload(payload) or (require_compute and not real_compute_evidence_present(payload)):
         return
 
     for result in as_list(payload.get("variantResults")):

--- a/scripts/screeps_rl_scorecard.py
+++ b/scripts/screeps_rl_scorecard.py
@@ -31,6 +31,7 @@ PREFLIGHT_FINAL_STATUS_KEYS = {
     "preflightpassed",
     "preflightvalidated",
 }
+CONTROLLER_COMPUTE_FINAL_STATUS_KEYS = {"running", "completed", "success", "ok"}
 STRONG_TRAINING_REPORT_KEYS = {
     "trainingreport",
     "trainingreportid",
@@ -314,7 +315,8 @@ def node_looks_like_controller_summary(node: JsonObject) -> bool:
     if node.get("type") == "screeps-tencent-batch-rl-run":
         return True
     return any(key in node for key in ("finalStatus", "final_status")) and any(
-        key in node for key in ("instanceId", "instance_id", "environmentsRun", "outputs")
+        key in node
+        for key in ("instanceId", "instance_id", "workerUser", "worker_user", "environmentsRun", "outputs")
     )
 
 
@@ -348,6 +350,9 @@ def real_compute_evidence_present(payload: JsonObject) -> bool:
         if final_status in PREFLIGHT_FINAL_STATUS_KEYS:
             continue
         if text_value(node.get("instanceId")) is not None or text_value(node.get("instance_id")) is not None:
+            return True
+        worker_user = text_value(node.get("workerUser")) or text_value(node.get("worker_user"))
+        if worker_user is not None and final_status in CONTROLLER_COMPUTE_FINAL_STATUS_KEYS:
             return True
     return False
 

--- a/scripts/screeps_rl_scorecard.py
+++ b/scripts/screeps_rl_scorecard.py
@@ -323,7 +323,16 @@ def node_looks_like_controller_summary(node: JsonObject) -> bool:
         return True
     return any(key in node for key in ("finalStatus", "final_status")) and any(
         key in node
-        for key in ("instanceId", "instance_id", "workerUser", "worker_user", "environmentsRun", "outputs")
+        for key in (
+            "instanceId",
+            "instance_id",
+            "workerUser",
+            "worker_user",
+            "environmentsRun",
+            "environmentExecution",
+            "environment_execution",
+            "outputs",
+        )
     )
 
 
@@ -333,6 +342,14 @@ def preflight_marker_present(payload: JsonObject) -> bool:
         and controller_summary_final_status_key(node) in PREFLIGHT_FINAL_STATUS_KEYS
         for node in iter_json_objects(payload)
     )
+
+
+def non_blank_text_value(value: Any) -> str | None:
+    text = text_value(value)
+    if text is None:
+        return None
+    stripped = text.strip()
+    return stripped or None
 
 
 def real_compute_evidence_present(payload: JsonObject) -> bool:
@@ -360,10 +377,13 @@ def real_compute_evidence_present(payload: JsonObject) -> bool:
         has_compute_status = final_status in CONTROLLER_COMPUTE_FINAL_STATUS_KEYS
         if (
             has_compute_status
-            and (text_value(node.get("instanceId")) is not None or text_value(node.get("instance_id")) is not None)
+            and (
+                non_blank_text_value(node.get("instanceId")) is not None
+                or non_blank_text_value(node.get("instance_id")) is not None
+            )
         ):
             return True
-        worker_user = text_value(node.get("workerUser")) or text_value(node.get("worker_user"))
+        worker_user = non_blank_text_value(node.get("workerUser")) or non_blank_text_value(node.get("worker_user"))
         if worker_user is not None and has_compute_status:
             return True
     return False

--- a/scripts/screeps_rl_scorecard.py
+++ b/scripts/screeps_rl_scorecard.py
@@ -289,7 +289,14 @@ def iter_json_objects(value: Any) -> Iterable[JsonObject]:
 
 def value_has_reference(value: Any) -> bool:
     if isinstance(value, str):
-        return bool(value)
+        text = value.strip()
+        if not text:
+            return False
+        try:
+            parsed = float(text)
+        except ValueError:
+            return True
+        return math.isfinite(parsed) and parsed > 0
     if isinstance(value, (int, float)) and not isinstance(value, bool):
         return value > 0
     if isinstance(value, dict):

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -1144,6 +1144,50 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(lanes["E4"]["status"], "BLOCKED")
         self.assertEqual(lanes["E5"]["status"], "BLOCKED")
 
+    def test_weak_policy_counters_do_not_unblock_policy_claims(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            write_json(
+                artifact_root / "rl-control-loop" / "policy-advantage.json",
+                {
+                    "type": "screeps-rl-policy-online-advantage-report",
+                    "onlineUtilityStatus": "PROVEN",
+                    "candidatePolicyId": "candidate",
+                    "baselinePolicyId": "incumbent",
+                    "artifactCount": 1,
+                    "iterationExecution": {
+                        "episodesRun": 12,
+                        "policyUpdateIterations": 3,
+                    },
+                    "metricsByCategory": {
+                        "resources": {
+                            "status": "ADVANTAGE",
+                            "candidateValue": 10,
+                            "baselineValue": 5,
+                            "delta": 5,
+                        },
+                    },
+                    "createdAt": "2026-05-19T00:02:00Z",
+                },
+            )
+            report = dashboard.build_dashboard(
+                repo_root=root,
+                artifact_root=artifact_root,
+                generated_at="2026-05-19T00:03:00Z",
+            )
+
+        lanes = {item["lane"]: item for item in report["lanes"]}
+        self.assertEqual(report["policy"]["rawStatus"], "PROVEN")
+        self.assertEqual(report["policy"]["status"], "BLOCKED")
+        self.assertFalse(report["policy"]["hasComputeEvidence"])
+        self.assertEqual(report["policy"]["metrics"][0]["rawStatus"], "ADVANTAGE")
+        self.assertEqual(report["policy"]["metrics"][0]["status"], "BLOCKED_NO_COMPUTE")
+        self.assertEqual(report["policy"]["computeEvidence"]["classification"], "MISSING_COMPUTE_EVIDENCE")
+        self.assertEqual(report["policy"]["computeEvidence"]["signals"], [])
+        self.assertEqual(lanes["E3"]["status"], "BLOCKED")
+        self.assertEqual(lanes["E5"]["status"], "BLOCKED")
+
     def test_unrelated_training_compute_does_not_unblock_preflight_policy_claims(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -1078,8 +1078,8 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
                     "trainingDidRun": True,
                     "trainingReportIds": 0,
                     "iterationExecution": {
-                        "episodesRun": 1,
-                        "policyUpdateIterations": 1,
+                        "episodesRun": 0,
+                        "policyUpdateIterations": 0,
                     },
                     "environmentExecution": {"completed": 0, "failed": 0},
                     "controllerSummary": {

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -1204,6 +1204,55 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(lanes["E3"]["status"], "BLOCKED")
         self.assertEqual(lanes["E5"]["status"], "BLOCKED")
 
+    def test_unrelated_preflight_training_does_not_set_policy_preflight_blocker(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            write_json(
+                artifact_root / "rl-control-loop" / "training-ledger.json",
+                {
+                    "type": "screeps-rl-training-execution-ledger",
+                    "runId": "preflight-training-run",
+                    "status": "RUN",
+                    "trainingDidRun": True,
+                    "controllerSummary": {
+                        "finalStatus": "preflight_ok",
+                        "instanceId": None,
+                        "environmentsRun": 0,
+                    },
+                    "createdAt": "2026-05-19T00:01:00Z",
+                },
+            )
+            write_json(
+                artifact_root / "rl-control-loop" / "policy-advantage.json",
+                {
+                    "type": "screeps-rl-policy-online-advantage-report",
+                    "runId": "unrelated-policy-run",
+                    "onlineUtilityStatus": "PROVEN",
+                    "candidatePolicyId": "candidate",
+                    "baselinePolicyId": "incumbent",
+                    "metricsByCategory": {
+                        "resources": {
+                            "status": "ADVANTAGE",
+                            "candidateValue": 10,
+                            "baselineValue": 5,
+                            "delta": 5,
+                        },
+                    },
+                    "createdAt": "2026-05-19T00:02:00Z",
+                },
+            )
+            report = dashboard.build_dashboard(
+                repo_root=root,
+                artifact_root=artifact_root,
+                generated_at="2026-05-19T00:03:00Z",
+            )
+
+        self.assertEqual(report["policy"]["status"], "BLOCKED")
+        self.assertFalse(report["policy"]["hasComputeEvidence"])
+        self.assertEqual(report["policy"]["computeEvidence"]["classification"], "MISSING_COMPUTE_EVIDENCE")
+        self.assertIn("No real compute evidence", report["policy"]["computeEvidence"]["blocker"])
+
     def test_policy_local_compute_evidence_unblocks_policy_claims(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -1144,6 +1144,50 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(lanes["E4"]["status"], "BLOCKED")
         self.assertEqual(lanes["E5"]["status"], "BLOCKED")
 
+    def test_unrelated_nested_preflight_status_does_not_create_preflight_blocker(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            write_json(
+                artifact_root / "rl-control-loop" / "policy-advantage.json",
+                {
+                    "type": "screeps-rl-policy-online-advantage-report",
+                    "onlineUtilityStatus": "PROVEN",
+                    "candidatePolicyId": "candidate",
+                    "baselinePolicyId": "incumbent",
+                    "validation": {
+                        "status": {
+                            "finalStatus": "preflight_ok",
+                            "source": "unrelated schema status",
+                        }
+                    },
+                    "metricsByCategory": {
+                        "resources": {
+                            "status": "ADVANTAGE",
+                            "candidateValue": 10,
+                            "baselineValue": 5,
+                            "delta": 5,
+                        },
+                    },
+                    "createdAt": "2026-05-19T00:02:00Z",
+                },
+            )
+            report = dashboard.build_dashboard(
+                repo_root=root,
+                artifact_root=artifact_root,
+                generated_at="2026-05-19T00:03:00Z",
+            )
+
+        lanes = {item["lane"]: item for item in report["lanes"]}
+        self.assertEqual(report["policy"]["rawStatus"], "PROVEN")
+        self.assertEqual(report["policy"]["status"], "BLOCKED")
+        self.assertFalse(report["policy"]["hasComputeEvidence"])
+        self.assertEqual(report["policy"]["computeEvidence"]["classification"], "MISSING_COMPUTE_EVIDENCE")
+        self.assertIn("No real compute evidence", report["policy"]["computeEvidence"]["blocker"])
+        self.assertNotIn("Preflight-only", report["policy"]["computeEvidence"]["blocker"])
+        self.assertEqual(lanes["E3"]["status"], "BLOCKED")
+        self.assertEqual(lanes["E5"]["status"], "BLOCKED")
+
     def test_weak_policy_counters_do_not_unblock_policy_claims(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -1076,7 +1076,7 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
                     "type": "screeps-rl-training-execution-ledger",
                     "status": "RUN",
                     "trainingDidRun": True,
-                    "trainingReportIds": [],
+                    "trainingReportIds": 0,
                     "environmentExecution": {"completed": 0, "failed": 0},
                     "controllerSummary": {
                         "finalStatus": "preflight_ok",
@@ -1093,6 +1093,7 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
                     "onlineUtilityStatus": "PROVEN",
                     "candidatePolicyId": "candidate",
                     "baselinePolicyId": "incumbent",
+                    "trainingReportIds": 0,
                     "metricsByCategory": {
                         "resources": {
                             "status": "ADVANTAGE",

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -1128,6 +1128,164 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(lanes["E4"]["status"], "BLOCKED")
         self.assertEqual(lanes["E5"]["status"], "BLOCKED")
 
+    def test_unrelated_training_compute_does_not_unblock_preflight_policy_claims(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            write_json(
+                artifact_root / "rl-control-loop" / "training-ledger.json",
+                {
+                    "type": "screeps-rl-training-execution-ledger",
+                    "status": "RUN",
+                    "trainingDidRun": True,
+                    "trainingReportIds": ["training-report-a"],
+                    "environmentExecution": {"completed": 2, "failed": 0},
+                    "controllerSummary": {
+                        "finalStatus": "completed",
+                        "instanceId": "ins-training-a",
+                        "environmentsRun": 2,
+                    },
+                    "createdAt": "2026-05-19T00:01:00Z",
+                },
+            )
+            write_json(
+                artifact_root / "rl-control-loop" / "policy-advantage.json",
+                {
+                    "type": "screeps-rl-policy-online-advantage-report",
+                    "onlineUtilityStatus": "PROVEN",
+                    "candidatePolicyId": "candidate",
+                    "baselinePolicyId": "incumbent",
+                    "metricsByCategory": {
+                        "resources": {
+                            "status": "ADVANTAGE",
+                            "candidateValue": 10,
+                            "baselineValue": 5,
+                            "delta": 5,
+                        },
+                    },
+                    "controllerSummary": {
+                        "finalStatus": "preflight_ok",
+                        "instanceId": None,
+                        "environmentsRun": 0,
+                    },
+                    "createdAt": "2026-05-19T00:02:00Z",
+                },
+            )
+            report = dashboard.build_dashboard(
+                repo_root=root,
+                artifact_root=artifact_root,
+                generated_at="2026-05-19T00:03:00Z",
+            )
+
+        lanes = {item["lane"]: item for item in report["lanes"]}
+        self.assertEqual(report["training"]["status"], "RUN")
+        self.assertTrue(report["training"]["hasComputeEvidence"])
+        self.assertEqual(report["policy"]["rawStatus"], "PROVEN")
+        self.assertEqual(report["policy"]["status"], "BLOCKED")
+        self.assertFalse(report["policy"]["hasComputeEvidence"])
+        self.assertEqual(report["policy"]["metrics"][0]["status"], "BLOCKED_NO_COMPUTE")
+        self.assertEqual(report["policy"]["computeEvidence"]["classification"], "PREFLIGHT_ONLY_VALIDATION")
+        self.assertEqual(lanes["E3"]["status"], "BLOCKED")
+        self.assertEqual(lanes["E5"]["status"], "BLOCKED")
+
+    def test_policy_local_compute_evidence_unblocks_policy_claims(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            write_json(
+                artifact_root / "rl-control-loop" / "policy-advantage.json",
+                {
+                    "type": "screeps-rl-policy-online-advantage-report",
+                    "onlineUtilityStatus": "PROVEN",
+                    "candidatePolicyId": "candidate",
+                    "baselinePolicyId": "incumbent",
+                    "trainingReportIds": ["policy-local-report"],
+                    "metricsByCategory": {
+                        "resources": {
+                            "status": "ADVANTAGE",
+                            "candidateValue": 10,
+                            "baselineValue": 5,
+                            "delta": 5,
+                        },
+                    },
+                    "createdAt": "2026-05-19T00:02:00Z",
+                },
+            )
+            report = dashboard.build_dashboard(
+                repo_root=root,
+                artifact_root=artifact_root,
+                generated_at="2026-05-19T00:03:00Z",
+            )
+
+        lanes = {item["lane"]: item for item in report["lanes"]}
+        self.assertEqual(report["policy"]["status"], "PROVEN")
+        self.assertTrue(report["policy"]["hasComputeEvidence"])
+        self.assertEqual(report["policy"]["metrics"][0]["status"], "ADVANTAGE")
+        self.assertEqual(report["policy"]["computeEvidence"]["classification"], "COMPUTE_CONFIRMED")
+        self.assertEqual(lanes["E3"]["status"], "OK")
+        self.assertEqual(lanes["E5"]["status"], "OK")
+
+    def test_policy_training_identity_match_can_use_training_compute_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            write_json(
+                artifact_root / "rl-control-loop" / "training-ledger.json",
+                {
+                    "type": "screeps-rl-training-execution-ledger",
+                    "runId": "shared-training-run",
+                    "status": "RUN",
+                    "trainingDidRun": True,
+                    "environmentExecution": {"completed": 1, "failed": 0},
+                    "controllerSummary": {
+                        "finalStatus": "completed",
+                        "instanceId": "ins-shared",
+                        "environmentsRun": 1,
+                    },
+                    "createdAt": "2026-05-19T00:01:00Z",
+                },
+            )
+            write_json(
+                artifact_root / "rl-control-loop" / "policy-advantage.json",
+                {
+                    "type": "screeps-rl-policy-online-advantage-report",
+                    "runId": "shared-training-run",
+                    "onlineUtilityStatus": "PROVEN",
+                    "candidatePolicyId": "candidate",
+                    "baselinePolicyId": "incumbent",
+                    "metricsByCategory": {
+                        "resources": {
+                            "status": "ADVANTAGE",
+                            "candidateValue": 10,
+                            "baselineValue": 5,
+                            "delta": 5,
+                        },
+                    },
+                    "controllerSummary": {
+                        "finalStatus": "preflight_ok",
+                        "instanceId": None,
+                        "environmentsRun": 0,
+                    },
+                    "createdAt": "2026-05-19T00:02:00Z",
+                },
+            )
+            report = dashboard.build_dashboard(
+                repo_root=root,
+                artifact_root=artifact_root,
+                generated_at="2026-05-19T00:03:00Z",
+            )
+
+        lanes = {item["lane"]: item for item in report["lanes"]}
+        signal_fields = {item["field"] for item in report["policy"]["computeEvidence"]["signals"]}
+        self.assertEqual(report["policy"]["status"], "PROVEN")
+        self.assertTrue(report["policy"]["hasComputeEvidence"])
+        self.assertEqual(report["policy"]["metrics"][0]["status"], "ADVANTAGE")
+        self.assertEqual(report["policy"]["computeEvidence"]["classification"], "COMPUTE_CONFIRMED")
+        self.assertIn("training.computeEvidence", signal_fields)
+        self.assertIn("policy.trainingIdentity.run", signal_fields)
+        self.assertEqual(lanes["E3"]["status"], "OK")
+        self.assertEqual(lanes["E5"]["status"], "OK")
+
     def test_tencent_internal_card_evidence_requires_safety_fields(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -1077,6 +1077,10 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
                     "status": "RUN",
                     "trainingDidRun": True,
                     "trainingReportIds": 0,
+                    "iterationExecution": {
+                        "episodesRun": 1,
+                        "policyUpdateIterations": 1,
+                    },
                     "environmentExecution": {"completed": 0, "failed": 0},
                     "controllerSummary": {
                         "finalStatus": "preflight_ok",
@@ -1120,6 +1124,17 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(report["training"]["status"], "PREFLIGHT_ONLY")
         self.assertFalse(report["training"]["hasComputeEvidence"])
         self.assertEqual(report["training"]["computeEvidence"]["classification"], "PREFLIGHT_ONLY_VALIDATION")
+        for blocker in (
+            report["training"]["blocker"],
+            report["training"]["computeEvidence"]["blocker"],
+            report["policy"]["blocker"],
+            report["policy"]["computeEvidence"]["blocker"],
+            lanes["E3"]["blocker"],
+            lanes["E4"]["blocker"],
+            lanes["E5"]["blocker"],
+        ):
+            self.assertIsInstance(blocker, str)
+            self.assertIn("Preflight-only", blocker)
         self.assertEqual(report["policy"]["rawStatus"], "PROVEN")
         self.assertEqual(report["policy"]["status"], "BLOCKED")
         self.assertEqual(report["policy"]["metrics"][0]["rawStatus"], "ADVANTAGE")

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -1066,6 +1066,68 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(policy["cardSupplyFinding"]["status"], "BLOCKED")
         self.assertEqual(policy["cardSupplyFinding"]["severity"], "P0")
 
+    def test_preflight_only_loop_b_evidence_blocks_compute_claims(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            write_json(
+                artifact_root / "rl-control-loop" / "training-ledger.json",
+                {
+                    "type": "screeps-rl-training-execution-ledger",
+                    "status": "RUN",
+                    "trainingDidRun": True,
+                    "trainingReportIds": [],
+                    "environmentExecution": {"completed": 0, "failed": 0},
+                    "controllerSummary": {
+                        "finalStatus": "preflight_ok",
+                        "instanceId": None,
+                        "environmentsRun": 0,
+                    },
+                    "createdAt": "2026-05-19T00:01:00Z",
+                },
+            )
+            write_json(
+                artifact_root / "rl-control-loop" / "policy-advantage.json",
+                {
+                    "type": "screeps-rl-policy-online-advantage-report",
+                    "onlineUtilityStatus": "PROVEN",
+                    "candidatePolicyId": "candidate",
+                    "baselinePolicyId": "incumbent",
+                    "metricsByCategory": {
+                        "resources": {
+                            "status": "ADVANTAGE",
+                            "candidateValue": 10,
+                            "baselineValue": 5,
+                            "delta": 5,
+                        },
+                    },
+                    "controllerSummary": {
+                        "finalStatus": "preflight_ok",
+                        "instanceId": None,
+                        "environmentsRun": 0,
+                    },
+                    "createdAt": "2026-05-19T00:02:00Z",
+                },
+            )
+            report = dashboard.build_dashboard(
+                repo_root=root,
+                artifact_root=artifact_root,
+                generated_at="2026-05-19T00:03:00Z",
+            )
+
+        lanes = {item["lane"]: item for item in report["lanes"]}
+        self.assertEqual(report["training"]["status"], "PREFLIGHT_ONLY")
+        self.assertFalse(report["training"]["hasComputeEvidence"])
+        self.assertEqual(report["training"]["computeEvidence"]["classification"], "PREFLIGHT_ONLY_VALIDATION")
+        self.assertEqual(report["policy"]["rawStatus"], "PROVEN")
+        self.assertEqual(report["policy"]["status"], "BLOCKED")
+        self.assertEqual(report["policy"]["metrics"][0]["rawStatus"], "ADVANTAGE")
+        self.assertEqual(report["policy"]["metrics"][0]["status"], "BLOCKED_NO_COMPUTE")
+        self.assertEqual(report["policy"]["computeEvidence"]["classification"], "PREFLIGHT_ONLY_VALIDATION")
+        self.assertEqual(lanes["E3"]["status"], "BLOCKED")
+        self.assertEqual(lanes["E4"]["status"], "BLOCKED")
+        self.assertEqual(lanes["E5"]["status"], "BLOCKED")
+
     def test_tencent_internal_card_evidence_requires_safety_fields(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -1290,6 +1290,48 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(lanes["E3"]["status"], "OK")
         self.assertEqual(lanes["E5"]["status"], "OK")
 
+    def test_policy_worker_user_controller_summary_unblocks_policy_claims(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            write_json(
+                artifact_root / "rl-control-loop" / "policy-advantage.json",
+                {
+                    "type": "screeps-rl-policy-online-advantage-report",
+                    "onlineUtilityStatus": "PROVEN",
+                    "candidatePolicyId": "candidate",
+                    "baselinePolicyId": "incumbent",
+                    "metricsByCategory": {
+                        "resources": {
+                            "status": "ADVANTAGE",
+                            "candidateValue": 10,
+                            "baselineValue": 5,
+                            "delta": 5,
+                        },
+                    },
+                    "controllerSummary": {
+                        "finalStatus": "completed",
+                        "workerUser": "tencent-worker",
+                    },
+                    "createdAt": "2026-05-19T00:02:00Z",
+                },
+            )
+            report = dashboard.build_dashboard(
+                repo_root=root,
+                artifact_root=artifact_root,
+                generated_at="2026-05-19T00:03:00Z",
+            )
+
+        lanes = {item["lane"]: item for item in report["lanes"]}
+        signal_fields = {item["field"] for item in report["policy"]["computeEvidence"]["signals"]}
+        self.assertEqual(report["policy"]["status"], "PROVEN")
+        self.assertTrue(report["policy"]["hasComputeEvidence"])
+        self.assertEqual(report["policy"]["metrics"][0]["status"], "ADVANTAGE")
+        self.assertEqual(report["policy"]["computeEvidence"]["classification"], "COMPUTE_CONFIRMED")
+        self.assertIn("controllerSummary.workerUser", signal_fields)
+        self.assertEqual(lanes["E3"]["status"], "OK")
+        self.assertEqual(lanes["E5"]["status"], "OK")
+
     def test_policy_training_identity_match_can_use_training_compute_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -94,6 +94,15 @@ def loaded_artifact(path: Path, payload: JsonObject) -> dashboard.LoadedArtifact
 
 
 class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
+    def test_value_has_reference_parses_numeric_strings(self) -> None:
+        self.assertFalse(dashboard.value_has_reference("0"))
+        self.assertFalse(dashboard.value_has_reference("0.0"))
+        self.assertFalse(dashboard.value_has_reference(["0"]))
+        self.assertFalse(dashboard.value_has_reference({"ids": ["0", {"fallback": "0.0"}]}))
+        self.assertTrue(dashboard.value_has_reference("1"))
+        self.assertTrue(dashboard.value_has_reference(["0", "2.5"]))
+        self.assertTrue(dashboard.value_has_reference("training-report-a"))
+
     def test_tencent_internal_card_downgrades_standalone_stall_to_fallback(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -1187,6 +1196,59 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertNotIn("Preflight-only", report["policy"]["computeEvidence"]["blocker"])
         self.assertEqual(lanes["E3"]["status"], "BLOCKED")
         self.assertEqual(lanes["E5"]["status"], "BLOCKED")
+
+    def test_zero_string_policy_report_ids_do_not_confirm_compute(self) -> None:
+        cases: tuple[tuple[str, Any], ...] = (
+            ("string-zero", "0"),
+            ("string-float-zero", "0.0"),
+            ("list-string-zero", ["0"]),
+            ("nested-string-zero", {"ids": ["0", {"fallback": "0.0"}]}),
+        )
+        for case, training_report_ids in cases:
+            with self.subTest(case=case):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    root = Path(temp_dir)
+                    artifact_root = root / "runtime-artifacts"
+                    write_json(
+                        artifact_root / "rl-control-loop" / "policy-advantage.json",
+                        {
+                            "type": "screeps-rl-policy-online-advantage-report",
+                            "onlineUtilityStatus": "PROVEN",
+                            "candidatePolicyId": "candidate",
+                            "baselinePolicyId": "incumbent",
+                            "trainingReportIds": training_report_ids,
+                            "metricsByCategory": {
+                                "resources": {
+                                    "status": "ADVANTAGE",
+                                    "candidateValue": 10,
+                                    "baselineValue": 5,
+                                    "delta": 5,
+                                },
+                            },
+                            "controllerSummary": {
+                                "finalStatus": "preflight_ok",
+                                "instanceId": None,
+                                "environmentsRun": 0,
+                            },
+                            "createdAt": "2026-05-19T00:02:00Z",
+                        },
+                    )
+                    report = dashboard.build_dashboard(
+                        repo_root=root,
+                        artifact_root=artifact_root,
+                        generated_at="2026-05-19T00:03:00Z",
+                    )
+
+                lanes = {item["lane"]: item for item in report["lanes"]}
+                self.assertEqual(report["policy"]["rawStatus"], "PROVEN")
+                self.assertEqual(report["policy"]["status"], "BLOCKED")
+                self.assertFalse(report["policy"]["hasComputeEvidence"])
+                self.assertEqual(report["policy"]["metrics"][0]["rawStatus"], "ADVANTAGE")
+                self.assertEqual(report["policy"]["metrics"][0]["status"], "BLOCKED_NO_COMPUTE")
+                self.assertEqual(report["policy"]["computeEvidence"]["classification"], "PREFLIGHT_ONLY_VALIDATION")
+                self.assertEqual(report["policy"]["computeEvidence"]["signals"], [])
+                self.assertEqual(lanes["E3"]["status"], "BLOCKED")
+                self.assertEqual(lanes["E5"]["status"], "BLOCKED")
 
     def test_weak_policy_counters_do_not_unblock_policy_claims(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -134,6 +134,7 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
                         "type": "screeps-rl-training-execution-ledger",
                         "status": "RUN_WITH_ANOMALY",
                         "trainingDidRun": True,
+                        "trainingReportIds": ["training-report-tencent-test"],
                         "trainingArtifacts": {
                             "tencentInternalCardSupply": {
                                 "runId": "tencent-pg-test",
@@ -196,6 +197,7 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
                         "type": "screeps-rl-training-execution-ledger",
                         "status": "RUN_WITH_ANOMALY",
                         "trainingDidRun": True,
+                        "trainingReportIds": ["training-report-generic"],
                         "artifactCount": 1,
                         "trainingArtifacts": {
                             "experimentCard": "Tencent batch generates internal cards per run",
@@ -241,6 +243,7 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
                         "type": "screeps-rl-training-execution-ledger",
                         "status": "RUN_WITH_ANOMALY",
                         "trainingDidRun": True,
+                        "trainingReportIds": ["training-report-current"],
                         "artifactCount": 1,
                         "trainingArtifacts": {
                             "tencentInternalCardSupply": {
@@ -292,6 +295,7 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
                         "type": "screeps-rl-training-execution-ledger",
                         "status": "RUN_WITH_ANOMALY",
                         "trainingDidRun": True,
+                        "trainingReportIds": ["training-report-mismatched"],
                         "artifactCount": 1,
                         "trainingArtifacts": {
                             "tencentInternalCardSupply": {
@@ -340,6 +344,7 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
                         "type": "screeps-rl-training-execution-ledger",
                         "status": "RUN_WITH_ANOMALY",
                         "trainingDidRun": True,
+                        "trainingReportIds": ["training-report-partial"],
                         "artifactCount": 1,
                         "trainingArtifacts": {
                             "tencentInternalCardSupply": {
@@ -716,6 +721,7 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
                         "type": "screeps-rl-training-execution-ledger",
                         "status": "RUN",
                         "trainingDidRun": True,
+                        "trainingReportIds": ["training-report-consumed-b"],
                         "artifactCount": 1,
                         "trainingArtifacts": {
                             "tencentInternalCardSupply": {
@@ -783,6 +789,7 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
                         "type": "screeps-rl-training-execution-ledger",
                         "status": "RUN",
                         "trainingDidRun": True,
+                        "trainingReportIds": ["training-report-same-card"],
                         "artifactCount": 1,
                         "trainingArtifacts": {
                             "tencentInternalCardSupply": {
@@ -932,6 +939,7 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
                         "type": "screeps-rl-training-execution-ledger",
                         "status": "RUN_WITH_ANOMALY",
                         "trainingDidRun": True,
+                        "trainingReportIds": ["training-report-local-card-missing"],
                         "artifactCount": 1,
                         "trainingArtifacts": {
                             "experimentCard": "Local standalone experiment card missing card supply",
@@ -1153,6 +1161,38 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(lanes["E4"]["status"], "BLOCKED")
         self.assertEqual(lanes["E5"]["status"], "BLOCKED")
 
+    def test_preflight_training_without_run_claim_keeps_compute_blocker(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            write_json(
+                artifact_root / "rl-control-loop" / "training-ledger.json",
+                {
+                    "type": "screeps-rl-training-execution-ledger",
+                    "status": "NOT_RUN",
+                    "trainingDidRun": False,
+                    "trainingBlocker": "NO_UNCONSUMED_EXPERIMENT_CARD",
+                    "controllerSummary": {
+                        "finalStatus": "preflight_ok",
+                        "environmentExecution": {"completed": 0},
+                    },
+                    "createdAt": "2026-05-19T00:01:00Z",
+                },
+            )
+            report = dashboard.build_dashboard(
+                repo_root=root,
+                artifact_root=artifact_root,
+                generated_at="2026-05-19T00:03:00Z",
+            )
+
+        lanes = {item["lane"]: item for item in report["lanes"]}
+        self.assertEqual(report["training"]["rawStatus"], "NOT_RUN")
+        self.assertEqual(report["training"]["status"], "PREFLIGHT_ONLY")
+        self.assertFalse(report["training"]["hasComputeEvidence"])
+        self.assertEqual(report["training"]["computeEvidence"]["classification"], "PREFLIGHT_ONLY_VALIDATION")
+        self.assertIn("Preflight-only", report["training"]["blocker"])
+        self.assertIn("Preflight-only", lanes["E4"]["blocker"])
+
     def test_unrelated_nested_preflight_status_does_not_create_preflight_blocker(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -1291,6 +1331,94 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(report["policy"]["metrics"][0]["status"], "BLOCKED_NO_COMPUTE")
         self.assertEqual(report["policy"]["computeEvidence"]["classification"], "MISSING_COMPUTE_EVIDENCE")
         self.assertEqual(report["policy"]["computeEvidence"]["signals"], [])
+        self.assertEqual(lanes["E3"]["status"], "BLOCKED")
+        self.assertEqual(lanes["E5"]["status"], "BLOCKED")
+
+    def test_weak_training_counters_do_not_mark_card_supply_training_run(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_dir = root / "tencent-cloud" / "batch-runs" / "tencent-pg-weak"
+            write_json(
+                run_dir / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-weak",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-accepted-123456789abc"}},
+                },
+            )
+            write_json(run_dir / "experiment_card.json", policy_gradient_card())
+            card_supply = dashboard.discover_tencent_internal_card_supply(
+                root,
+                warnings=[],
+                repo_root=root,
+            )
+            self.assertIsNotNone(card_supply)
+            assert card_supply is not None
+
+            training = dashboard.training_execution(
+                loaded_artifact(
+                    root / "rl-control-loop" / "training-ledger.json",
+                    {
+                        "type": "screeps-rl-training-execution-ledger",
+                        "status": "RUN_WITH_ANOMALY",
+                        "trainingDidRun": True,
+                        "artifactCount": 1,
+                        "iterationExecution": {
+                            "episodesRun": 12,
+                            "policyUpdateIterations": 3,
+                        },
+                        "trainingArtifacts": {
+                            "experimentCard": "Tencent batch generates internal cards per run",
+                            "experimentCardPath": None,
+                        },
+                    },
+                ),
+                tencent_internal_card_supply=card_supply,
+            )
+
+        self.assertEqual(training["cardSupply"]["status"], "BLOCKED")
+        self.assertEqual(training["cardSupply"]["classification"], "CARD_SUPPLY_BLOCKED")
+        self.assertIn("No real compute evidence", training["cardSupply"]["reason"])
+        self.assertNotEqual(training["cardSupply"].get("source"), "tencent_internal_experiment_card")
+
+    def test_blank_executor_identity_does_not_unblock_policy_claims(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            write_json(
+                artifact_root / "rl-control-loop" / "policy-advantage.json",
+                {
+                    "type": "screeps-rl-policy-online-advantage-report",
+                    "onlineUtilityStatus": "PROVEN",
+                    "candidatePolicyId": "candidate",
+                    "baselinePolicyId": "incumbent",
+                    "metricsByCategory": {
+                        "resources": {
+                            "status": "ADVANTAGE",
+                            "candidateValue": 10,
+                            "baselineValue": 5,
+                            "delta": 5,
+                        },
+                    },
+                    "controllerSummary": {
+                        "finalStatus": "running",
+                        "instanceId": " ",
+                        "workerUser": "\t",
+                    },
+                    "createdAt": "2026-05-19T00:02:00Z",
+                },
+            )
+            report = dashboard.build_dashboard(
+                repo_root=root,
+                artifact_root=artifact_root,
+                generated_at="2026-05-19T00:03:00Z",
+            )
+
+        lanes = {item["lane"]: item for item in report["lanes"]}
+        self.assertEqual(report["policy"]["status"], "BLOCKED")
+        self.assertFalse(report["policy"]["hasComputeEvidence"])
+        self.assertEqual(report["policy"]["metrics"][0]["status"], "BLOCKED_NO_COMPUTE")
+        self.assertEqual(report["policy"]["computeEvidence"]["classification"], "MISSING_COMPUTE_EVIDENCE")
         self.assertEqual(lanes["E3"]["status"], "BLOCKED")
         self.assertEqual(lanes["E5"]["status"], "BLOCKED")
 

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -1482,6 +1482,53 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(lanes["E3"]["status"], "OK")
         self.assertEqual(lanes["E5"]["status"], "OK")
 
+    def test_failed_controller_instance_id_does_not_unblock_policy_claims(self) -> None:
+        for final_status in ("failed", "signal_15"):
+            with self.subTest(final_status=final_status):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    root = Path(temp_dir)
+                    artifact_root = root / "runtime-artifacts"
+                    write_json(
+                        artifact_root / "rl-control-loop" / "policy-advantage.json",
+                        {
+                            "type": "screeps-rl-policy-online-advantage-report",
+                            "onlineUtilityStatus": "PROVEN",
+                            "candidatePolicyId": "candidate",
+                            "baselinePolicyId": "incumbent",
+                            "trainingReportIds": "0",
+                            "environmentExecution": {"completed": 0, "failed": 1},
+                            "metricsByCategory": {
+                                "resources": {
+                                    "status": "ADVANTAGE",
+                                    "candidateValue": 10,
+                                    "baselineValue": 5,
+                                    "delta": 5,
+                                },
+                            },
+                            "controllerSummary": {
+                                "finalStatus": final_status,
+                                "instanceId": "ins-failed",
+                                "environmentsRun": 0,
+                            },
+                            "createdAt": "2026-05-19T00:02:00Z",
+                        },
+                    )
+                    report = dashboard.build_dashboard(
+                        repo_root=root,
+                        artifact_root=artifact_root,
+                        generated_at="2026-05-19T00:03:00Z",
+                    )
+
+                lanes = {item["lane"]: item for item in report["lanes"]}
+                self.assertEqual(report["policy"]["rawStatus"], "PROVEN")
+                self.assertEqual(report["policy"]["status"], "BLOCKED")
+                self.assertFalse(report["policy"]["hasComputeEvidence"])
+                self.assertEqual(report["policy"]["metrics"][0]["status"], "BLOCKED_NO_COMPUTE")
+                self.assertEqual(report["policy"]["computeEvidence"]["classification"], "MISSING_COMPUTE_EVIDENCE")
+                self.assertEqual(report["policy"]["computeEvidence"]["signals"], [])
+                self.assertEqual(lanes["E3"]["status"], "BLOCKED")
+                self.assertEqual(lanes["E5"]["status"], "BLOCKED")
+
     def test_policy_training_identity_match_can_use_training_compute_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -1193,6 +1193,45 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertIn("Preflight-only", report["training"]["blocker"])
         self.assertIn("Preflight-only", lanes["E4"]["blocker"])
 
+    def test_blank_compute_statuses_fall_back_before_lane_gating(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            write_json(
+                artifact_root / "rl-control-loop" / "training-ledger.json",
+                {
+                    "type": "screeps-rl-training-execution-ledger",
+                    "status": "   ",
+                    "trainingDidRun": False,
+                    "createdAt": "2026-05-19T00:01:00Z",
+                },
+            )
+            write_json(
+                artifact_root / "rl-control-loop" / "policy-advantage.json",
+                {
+                    "type": "screeps-rl-policy-online-advantage-report",
+                    "onlineUtilityStatus": "\t",
+                    "status": "PROVEN",
+                    "candidatePolicyId": "candidate",
+                    "baselinePolicyId": "incumbent",
+                    "createdAt": "2026-05-19T00:02:00Z",
+                },
+            )
+            report = dashboard.build_dashboard(
+                repo_root=root,
+                artifact_root=artifact_root,
+                generated_at="2026-05-19T00:03:00Z",
+            )
+
+        lanes = {item["lane"]: item for item in report["lanes"]}
+        self.assertEqual(report["training"]["rawStatus"], "NOT_RUN")
+        self.assertEqual(report["training"]["status"], "NOT_RUN")
+        self.assertEqual(report["policy"]["rawStatus"], "PROVEN")
+        self.assertEqual(report["policy"]["status"], "BLOCKED")
+        self.assertEqual(lanes["E3"]["status"], "BLOCKED")
+        self.assertEqual(lanes["E4"]["status"], "BLOCKED")
+        self.assertEqual(lanes["E5"]["status"], "BLOCKED")
+
     def test_unrelated_nested_preflight_status_does_not_create_preflight_blocker(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -1380,6 +1380,13 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(training["cardSupply"]["classification"], "CARD_SUPPLY_BLOCKED")
         self.assertIn("No real compute evidence", training["cardSupply"]["reason"])
         self.assertNotEqual(training["cardSupply"].get("source"), "tencent_internal_experiment_card")
+        self.assertEqual(training["status"], "BLOCKED")
+        self.assertFalse(training["hasComputeEvidence"])
+        self.assertFalse(training["computeEvidence"]["hasCompute"])
+        self.assertEqual(training["computeEvidence"]["classification"], "MISSING_COMPUTE_EVIDENCE")
+        self.assertNotEqual(training["computeEvidence"]["classification"], "COMPUTE_CONFIRMED")
+        signal_fields = {item["field"] for item in training["computeEvidence"]["signals"]}
+        self.assertEqual(signal_fields, {"artifactCount", "episodesRun", "policyUpdateIterations"})
 
     def test_blank_executor_identity_does_not_unblock_policy_claims(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_scorecard.py
+++ b/scripts/test_screeps_rl_scorecard.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import screeps_rl_scorecard as scorecard
+
+
+JsonObject = dict[str, Any]
+
+
+class ScreepsRlScorecardComputeEvidenceTest(unittest.TestCase):
+    def test_value_has_reference_parses_numeric_strings(self) -> None:
+        self.assertFalse(scorecard.value_has_reference("0"))
+        self.assertFalse(scorecard.value_has_reference("0.0"))
+        self.assertFalse(scorecard.value_has_reference(["0"]))
+        self.assertFalse(scorecard.value_has_reference({"ids": ["0", {"fallback": "0.0"}]}))
+        self.assertTrue(scorecard.value_has_reference("1"))
+        self.assertTrue(scorecard.value_has_reference(["0", "2.5"]))
+        self.assertTrue(scorecard.value_has_reference("training-report-a"))
+
+    def test_failed_controller_instance_id_does_not_count_as_real_compute(self) -> None:
+        for final_status in ("failed", "signal_15"):
+            with self.subTest(final_status=final_status):
+                payload: JsonObject = {
+                    "type": "screeps-rl-policy-online-advantage-report",
+                    "onlineUtilityStatus": "PROVEN",
+                    "trainingReportIds": "0",
+                    "advantageResources": 5,
+                    "environmentExecution": {"completed": 0, "failed": 1},
+                    "controllerSummary": {
+                        "finalStatus": final_status,
+                        "instanceId": "ins-failed",
+                        "environmentsRun": 0,
+                    },
+                }
+
+                self.assertFalse(scorecard.real_compute_evidence_present(payload))
+
+                accumulator = scorecard.MetricAccumulator()
+                scorecard.ingest_training_or_advantage(
+                    accumulator,
+                    payload,
+                    "policy-advantage.json",
+                    require_compute=True,
+                )
+                self.assertEqual(accumulator.summarize(), {})
+
+    def test_completed_controller_instance_id_counts_as_real_compute(self) -> None:
+        payload: JsonObject = {
+            "type": "screeps-rl-policy-online-advantage-report",
+            "onlineUtilityStatus": "PROVEN",
+            "environmentExecution": {"completed": 0, "failed": 0},
+            "controllerSummary": {
+                "finalStatus": "completed",
+                "instanceId": "ins-completed",
+                "environmentsRun": 0,
+            },
+        }
+
+        self.assertTrue(scorecard.real_compute_evidence_present(payload))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_screeps_rl_scorecard.py
+++ b/scripts/test_screeps_rl_scorecard.py
@@ -52,6 +52,20 @@ class ScreepsRlScorecardComputeEvidenceTest(unittest.TestCase):
                 )
                 self.assertEqual(accumulator.summarize(), {})
 
+    def test_environment_execution_shape_marks_preflight_only_payload(self) -> None:
+        payload: JsonObject = {
+            "type": "screeps-rl-training-execution-ledger",
+            "finalStatus": "preflight_ok",
+            "environmentExecution": {"completed": 0},
+            "advantageResources": 5,
+        }
+
+        self.assertTrue(scorecard.preflight_only_compute_payload(payload))
+
+        accumulator = scorecard.MetricAccumulator()
+        scorecard.ingest_training_or_advantage(accumulator, payload, "training-ledger.json")
+        self.assertEqual(accumulator.summarize(), {})
+
     def test_completed_controller_instance_id_counts_as_real_compute(self) -> None:
         payload: JsonObject = {
             "type": "screeps-rl-policy-online-advantage-report",
@@ -65,6 +79,29 @@ class ScreepsRlScorecardComputeEvidenceTest(unittest.TestCase):
         }
 
         self.assertTrue(scorecard.real_compute_evidence_present(payload))
+
+    def test_blank_executor_identity_does_not_count_as_real_compute(self) -> None:
+        payload: JsonObject = {
+            "type": "screeps-rl-policy-online-advantage-report",
+            "onlineUtilityStatus": "PROVEN",
+            "advantageResources": 5,
+            "controllerSummary": {
+                "finalStatus": "running",
+                "instanceId": " ",
+                "workerUser": "\t",
+            },
+        }
+
+        self.assertFalse(scorecard.real_compute_evidence_present(payload))
+
+        accumulator = scorecard.MetricAccumulator()
+        scorecard.ingest_training_or_advantage(
+            accumulator,
+            payload,
+            "policy-advantage.json",
+            require_compute=True,
+        )
+        self.assertEqual(accumulator.summarize(), {})
 
 
 if __name__ == "__main__":

--- a/scripts/test_screeps_rl_scorecard.py
+++ b/scripts/test_screeps_rl_scorecard.py
@@ -55,8 +55,10 @@ class ScreepsRlScorecardComputeEvidenceTest(unittest.TestCase):
     def test_environment_execution_shape_marks_preflight_only_payload(self) -> None:
         payload: JsonObject = {
             "type": "screeps-rl-training-execution-ledger",
-            "finalStatus": "preflight_ok",
-            "environmentExecution": {"completed": 0},
+            "controllerSummary": {
+                "finalStatus": "preflight_ok",
+                "environmentExecution": {"completed": 0},
+            },
             "advantageResources": 5,
         }
 

--- a/scripts/tests/test_rl_scorecard.py
+++ b/scripts/tests/test_rl_scorecard.py
@@ -216,41 +216,42 @@ def test_scorecard_is_inconclusive_when_gameplay_evidence_is_absent(tmp_path: Pa
 
 
 def test_scorecard_ignores_preflight_only_policy_advantage_as_compute(tmp_path: Path) -> None:
-    baseline = tmp_path / "baseline"
-    candidate = tmp_path / "candidate"
-    baseline.mkdir()
-    candidate.mkdir()
-    for root, resources in ((baseline, 1), (candidate, 10)):
-        write_json(
-            root / "policy-advantage.json",
-            {
-                "type": "screeps-rl-policy-advantage-report",
-                "reportId": f"preflight-{root.name}",
-                "advantageResources": resources,
-                "trainingReportIds": [],
-                "environmentExecution": {"completed": 0},
-                "controllerSummary": {
-                    "finalStatus": "preflight_ok",
-                    "instanceId": None,
-                    "environmentsRun": 0,
+    for case, training_report_ids in (("empty-list", []), ("scalar-zero", 0)):
+        baseline = tmp_path / case / "baseline"
+        candidate = tmp_path / case / "candidate"
+        baseline.mkdir(parents=True)
+        candidate.mkdir(parents=True)
+        for root, resources in ((baseline, 1), (candidate, 10)):
+            write_json(
+                root / "policy-advantage.json",
+                {
+                    "type": "screeps-rl-policy-advantage-report",
+                    "reportId": f"preflight-{root.name}",
+                    "advantageResources": resources,
+                    "trainingReportIds": training_report_ids,
+                    "environmentExecution": {"completed": 0},
+                    "controllerSummary": {
+                        "finalStatus": "preflight_ok",
+                        "instanceId": None,
+                        "environmentsRun": 0,
+                    },
                 },
-            },
+            )
+
+        report = scorecard.build_scorecard(
+            candidate_path=candidate,
+            baseline_path=baseline,
+            repo_root=tmp_path,
+            timestamp="2026-05-19T00:00:00Z",
+            run_id=f"scorecard-preflight-only-{case}",
         )
 
-    report = scorecard.build_scorecard(
-        candidate_path=candidate,
-        baseline_path=baseline,
-        repo_root=tmp_path,
-        timestamp="2026-05-19T00:00:00Z",
-        run_id="scorecard-preflight-only",
-    )
-
-    resources = report["dimensions"]["resources_economy"]
-    self_metric = next(metric for metric in resources["metrics"] if metric["metric"] == "productive_energy")
-    assert resources["status"] == "inconclusive"
-    assert self_metric["candidate"] is None
-    assert self_metric["baseline"] is None
-    assert "productive_energy" in resources["missingEvidence"]
+        resources = report["dimensions"]["resources_economy"]
+        self_metric = next(metric for metric in resources["metrics"] if metric["metric"] == "productive_energy")
+        assert resources["status"] == "inconclusive"
+        assert self_metric["candidate"] is None
+        assert self_metric["baseline"] is None
+        assert "productive_energy" in resources["missingEvidence"]
 
 
 def test_cli_writes_scorecard_json(tmp_path: Path) -> None:

--- a/scripts/tests/test_rl_scorecard.py
+++ b/scripts/tests/test_rl_scorecard.py
@@ -327,9 +327,53 @@ def test_scorecard_preflight_marker_requires_controller_summary_shape() -> None:
             "environmentsRun": 0,
         },
     }
+    environment_execution_summary = {
+        "type": "screeps-rl-training-report",
+        "controllerSummary": {
+            "finalStatus": "preflight_ok",
+            "environmentExecution": {"completed": 0},
+        },
+    }
 
     assert not scorecard.preflight_only_compute_payload(unrelated_status)
     assert scorecard.preflight_only_compute_payload(controller_summary)
+    assert scorecard.preflight_only_compute_payload(environment_execution_summary)
+
+
+def test_scorecard_ignores_blank_executor_identity_without_compute(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline"
+    candidate = tmp_path / "candidate"
+    baseline.mkdir()
+    candidate.mkdir()
+    for root, resources in ((baseline, 1), (candidate, 10)):
+        write_json(
+            root / "policy-advantage.json",
+            {
+                "type": "screeps-rl-policy-advantage-report",
+                "reportId": f"blank-executor-{root.name}",
+                "advantageResources": resources,
+                "controllerSummary": {
+                    "finalStatus": "running",
+                    "instanceId": " ",
+                    "workerUser": "\t",
+                },
+            },
+        )
+
+    report = scorecard.build_scorecard(
+        candidate_path=candidate,
+        baseline_path=baseline,
+        repo_root=tmp_path,
+        timestamp="2026-05-19T00:00:00Z",
+        run_id="scorecard-blank-executor",
+    )
+
+    resources = report["dimensions"]["resources_economy"]
+    self_metric = next(metric for metric in resources["metrics"] if metric["metric"] == "productive_energy")
+    assert resources["status"] == "inconclusive"
+    assert self_metric["candidate"] is None
+    assert self_metric["baseline"] is None
+    assert "productive_energy" in resources["missingEvidence"]
 
 
 def test_scorecard_ignores_policy_advantage_without_compute_evidence(tmp_path: Path) -> None:

--- a/scripts/tests/test_rl_scorecard.py
+++ b/scripts/tests/test_rl_scorecard.py
@@ -285,6 +285,42 @@ def test_scorecard_ignores_policy_advantage_without_compute_evidence(tmp_path: P
     assert "productive_energy" in resources["missingEvidence"]
 
 
+def test_scorecard_accepts_worker_user_controller_summary_compute_evidence(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline"
+    candidate = tmp_path / "candidate"
+    baseline.mkdir()
+    candidate.mkdir()
+    for root, resources in ((baseline, 1), (candidate, 10)):
+        write_json(
+            root / "policy-advantage.json",
+            {
+                "type": "screeps-rl-policy-advantage-report",
+                "reportId": f"worker-compute-{root.name}",
+                "advantageResources": resources,
+                "controllerSummary": {
+                    "finalStatus": "completed",
+                    "workerUser": "tencent-worker",
+                    "environmentsRun": 0,
+                },
+            },
+        )
+
+    report = scorecard.build_scorecard(
+        candidate_path=candidate,
+        baseline_path=baseline,
+        repo_root=tmp_path,
+        timestamp="2026-05-19T00:00:00Z",
+        run_id="scorecard-worker-user-compute",
+    )
+
+    resources = report["dimensions"]["resources_economy"]
+    self_metric = next(metric for metric in resources["metrics"] if metric["metric"] == "productive_energy")
+    assert resources["status"] == "improved"
+    assert self_metric["candidate"] == 10
+    assert self_metric["baseline"] == 1
+    assert "productive_energy" not in resources["missingEvidence"]
+
+
 def test_cli_writes_scorecard_json(tmp_path: Path) -> None:
     baseline = write_bundle(tmp_path / "baseline", candidate=False)
     candidate = write_bundle(tmp_path / "candidate", candidate=True)

--- a/scripts/tests/test_rl_scorecard.py
+++ b/scripts/tests/test_rl_scorecard.py
@@ -254,6 +254,37 @@ def test_scorecard_ignores_preflight_only_policy_advantage_as_compute(tmp_path: 
         assert "productive_energy" in resources["missingEvidence"]
 
 
+def test_scorecard_ignores_policy_advantage_without_compute_evidence(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline"
+    candidate = tmp_path / "candidate"
+    baseline.mkdir()
+    candidate.mkdir()
+    for root, resources in ((baseline, 1), (candidate, 10)):
+        write_json(
+            root / "policy-advantage.json",
+            {
+                "type": "screeps-rl-policy-advantage-report",
+                "reportId": f"no-compute-{root.name}",
+                "advantageResources": resources,
+            },
+        )
+
+    report = scorecard.build_scorecard(
+        candidate_path=candidate,
+        baseline_path=baseline,
+        repo_root=tmp_path,
+        timestamp="2026-05-19T00:00:00Z",
+        run_id="scorecard-no-compute-policy-advantage",
+    )
+
+    resources = report["dimensions"]["resources_economy"]
+    self_metric = next(metric for metric in resources["metrics"] if metric["metric"] == "productive_energy")
+    assert resources["status"] == "inconclusive"
+    assert self_metric["candidate"] is None
+    assert self_metric["baseline"] is None
+    assert "productive_energy" in resources["missingEvidence"]
+
+
 def test_cli_writes_scorecard_json(tmp_path: Path) -> None:
     baseline = write_bundle(tmp_path / "baseline", candidate=False)
     candidate = write_bundle(tmp_path / "candidate", candidate=True)

--- a/scripts/tests/test_rl_scorecard.py
+++ b/scripts/tests/test_rl_scorecard.py
@@ -254,6 +254,29 @@ def test_scorecard_ignores_preflight_only_policy_advantage_as_compute(tmp_path: 
         assert "productive_energy" in resources["missingEvidence"]
 
 
+def test_scorecard_preflight_marker_requires_controller_summary_shape() -> None:
+    unrelated_status = {
+        "type": "screeps-rl-training-report",
+        "validation": {
+            "status": {
+                "finalStatus": "preflight_ok",
+                "source": "unrelated schema status",
+            }
+        },
+    }
+    controller_summary = {
+        "type": "screeps-rl-training-report",
+        "controllerSummary": {
+            "finalStatus": "preflight_ok",
+            "instanceId": None,
+            "environmentsRun": 0,
+        },
+    }
+
+    assert not scorecard.preflight_only_compute_payload(unrelated_status)
+    assert scorecard.preflight_only_compute_payload(controller_summary)
+
+
 def test_scorecard_ignores_policy_advantage_without_compute_evidence(tmp_path: Path) -> None:
     baseline = tmp_path / "baseline"
     candidate = tmp_path / "candidate"

--- a/scripts/tests/test_rl_scorecard.py
+++ b/scripts/tests/test_rl_scorecard.py
@@ -215,8 +215,25 @@ def test_scorecard_is_inconclusive_when_gameplay_evidence_is_absent(tmp_path: Pa
     assert report["dimensions"]["combat"]["status"] == "neutral"
 
 
+def test_value_has_reference_parses_numeric_strings() -> None:
+    assert not scorecard.value_has_reference("0")
+    assert not scorecard.value_has_reference("0.0")
+    assert not scorecard.value_has_reference(["0"])
+    assert not scorecard.value_has_reference({"ids": ["0", {"fallback": "0.0"}]})
+    assert scorecard.value_has_reference("1")
+    assert scorecard.value_has_reference(["0", "2.5"])
+    assert scorecard.value_has_reference("training-report-a")
+
+
 def test_scorecard_ignores_preflight_only_policy_advantage_as_compute(tmp_path: Path) -> None:
-    for case, training_report_ids in (("empty-list", []), ("scalar-zero", 0)):
+    for case, training_report_ids in (
+        ("empty-list", []),
+        ("scalar-zero", 0),
+        ("string-zero", "0"),
+        ("string-float-zero", "0.0"),
+        ("list-string-zero", ["0"]),
+        ("nested-string-zero", {"ids": ["0", {"fallback": "0.0"}]}),
+    ):
         baseline = tmp_path / case / "baseline"
         candidate = tmp_path / case / "candidate"
         baseline.mkdir(parents=True)
@@ -252,6 +269,44 @@ def test_scorecard_ignores_preflight_only_policy_advantage_as_compute(tmp_path: 
         assert self_metric["candidate"] is None
         assert self_metric["baseline"] is None
         assert "productive_energy" in resources["missingEvidence"]
+
+
+def test_scorecard_accepts_nonzero_string_training_report_ids_as_compute(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline"
+    candidate = tmp_path / "candidate"
+    baseline.mkdir()
+    candidate.mkdir()
+    for root, resources in ((baseline, 1), (candidate, 10)):
+        write_json(
+            root / "policy-advantage.json",
+            {
+                "type": "screeps-rl-policy-advantage-report",
+                "reportId": f"nonzero-training-id-{root.name}",
+                "advantageResources": resources,
+                "trainingReportIds": ["0", "2"],
+                "environmentExecution": {"completed": 0},
+                "controllerSummary": {
+                    "finalStatus": "preflight_ok",
+                    "instanceId": None,
+                    "environmentsRun": 0,
+                },
+            },
+        )
+
+    report = scorecard.build_scorecard(
+        candidate_path=candidate,
+        baseline_path=baseline,
+        repo_root=tmp_path,
+        timestamp="2026-05-19T00:00:00Z",
+        run_id="scorecard-nonzero-string-training-id",
+    )
+
+    resources = report["dimensions"]["resources_economy"]
+    self_metric = next(metric for metric in resources["metrics"] if metric["metric"] == "productive_energy")
+    assert resources["status"] == "improved"
+    assert self_metric["candidate"] == 10
+    assert self_metric["baseline"] == 1
+    assert "productive_energy" not in resources["missingEvidence"]
 
 
 def test_scorecard_preflight_marker_requires_controller_summary_shape() -> None:

--- a/scripts/tests/test_rl_scorecard.py
+++ b/scripts/tests/test_rl_scorecard.py
@@ -215,6 +215,44 @@ def test_scorecard_is_inconclusive_when_gameplay_evidence_is_absent(tmp_path: Pa
     assert report["dimensions"]["combat"]["status"] == "neutral"
 
 
+def test_scorecard_ignores_preflight_only_policy_advantage_as_compute(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline"
+    candidate = tmp_path / "candidate"
+    baseline.mkdir()
+    candidate.mkdir()
+    for root, resources in ((baseline, 1), (candidate, 10)):
+        write_json(
+            root / "policy-advantage.json",
+            {
+                "type": "screeps-rl-policy-advantage-report",
+                "reportId": f"preflight-{root.name}",
+                "advantageResources": resources,
+                "trainingReportIds": [],
+                "environmentExecution": {"completed": 0},
+                "controllerSummary": {
+                    "finalStatus": "preflight_ok",
+                    "instanceId": None,
+                    "environmentsRun": 0,
+                },
+            },
+        )
+
+    report = scorecard.build_scorecard(
+        candidate_path=candidate,
+        baseline_path=baseline,
+        repo_root=tmp_path,
+        timestamp="2026-05-19T00:00:00Z",
+        run_id="scorecard-preflight-only",
+    )
+
+    resources = report["dimensions"]["resources_economy"]
+    self_metric = next(metric for metric in resources["metrics"] if metric["metric"] == "productive_energy")
+    assert resources["status"] == "inconclusive"
+    assert self_metric["candidate"] is None
+    assert self_metric["baseline"] is None
+    assert "productive_energy" in resources["missingEvidence"]
+
+
 def test_cli_writes_scorecard_json(tmp_path: Path) -> None:
     baseline = write_bundle(tmp_path / "baseline", candidate=False)
     candidate = write_bundle(tmp_path / "candidate", candidate=True)


### PR DESCRIPTION
## Summary
- Add compute-evidence classification to RL scorecard/reporting so preflight-only Tencent summaries are not treated as training execution.
- Surface preflight-only blockers in dashboard/live-dashboard records instead of candidate-advantage or compute-ready language.
- Add focused regression coverage for preflight-only summaries, scorecard decision behavior, and dashboard record status.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_dashboard.py scripts/screeps_rl_live_dashboard.py scripts/screeps_rl_scorecard.py scripts/test_screeps_rl_dashboard.py scripts/tests/test_rl_scorecard.py`
- `python3 -m unittest scripts.test_screeps_rl_dashboard scripts.tests.test_rl_scorecard` — 28 tests OK

## Safety
- Offline/reporting scripts only; no official MMO writes or deployment behavior.
- Does not print or commit secrets.

Fixes #1217
Refs #879, #1032, #1203.

