### PR TITLE
fix(monitor): keep high-health rampart damage at P1

### DIFF
--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -47,6 +47,7 @@ RAMPART_DECAY_EVENT_TICKS = 100
 RAMPART_DECAY_RECENT_HOSTILE_TICKS = RAMPART_DECAY_EVENT_TICKS
 RAMPART_SAFE_DECAY_HITS_FLOOR = 10_000
 RAMPART_CRITICAL_DAMAGE_DELTA = 5_000
+RAMPART_CRITICAL_DAMAGE_HITS_CEILING = 121_000
 RUNTIME_SUMMARY_PREFIX = "#runtime-summary "
 WORKER_IDLE_COLLAPSE_KIND = "worker_idle_collapse"
 WORKER_IDLE_COLLAPSE_TICK_THRESHOLD = 20
@@ -2503,7 +2504,12 @@ def category_severity(category: str, reason: dict[str, Any]) -> str:
             delta = number_from_reason(reason, "delta")
             if hits is not None and hits <= RAMPART_SAFE_DECAY_HITS_FLOOR:
                 return "critical"
-            if delta is not None and delta >= RAMPART_CRITICAL_DAMAGE_DELTA:
+            if (
+                hits is not None
+                and hits <= RAMPART_CRITICAL_DAMAGE_HITS_CEILING
+                and delta is not None
+                and delta >= RAMPART_CRITICAL_DAMAGE_DELTA
+            ):
                 return "critical"
         elif hits is not None and hits_max and hits / hits_max <= 0.25:
             return "critical"

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -1021,6 +1021,40 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(report["triggers"][0]["severity"], "high")
         self.assertEqual(report["triggers"][0]["priority"], "P1")
 
+    def test_high_health_large_rampart_drop_stays_p1(self) -> None:
+        reason = {
+            "kind": "structure_damage",
+            "room": "shardX/E29N55",
+            "object_id": "6a09deb5b2438b0a399c3f8e",
+            "structure_type": "rampart",
+            "x": 35,
+            "y": 29,
+            "previous_hits": 2_534_911,
+            "current_hits": 2_493_091,
+            "hitsMax": 3_000_000,
+            "delta": 41_820,
+            "message": "rampart hits decreased 2534911->2493091 at 35,29",
+        }
+
+        self.assertGreater(reason["current_hits"], monitor.RAMPART_CRITICAL_DAMAGE_HITS_CEILING)
+        self.assertEqual(monitor.category_severity("owned_structure_damage", reason), "high")
+
+        report = monitor.build_tactical_response_report(
+            {
+                "ok": True,
+                "mode": "alert",
+                "alert": True,
+                "reasons": [reason],
+                "rooms": ["shardX/E29N55"],
+            }
+        )
+
+        self.assertTrue(report["emergency"])
+        self.assertEqual(report["severity"], "high")
+        self.assertEqual(report["priority"], "P1")
+        self.assertEqual(report["triggers"][0]["severity"], "high")
+        self.assertEqual(report["triggers"][0]["priority"], "P1")
+
     def test_exact_safe_floor_rampart_decay_still_alerts_p0(self) -> None:
         decay = monitor.RAMPART_DECAY_HITS_PER_EVENT
         safe_floor = monitor.RAMPART_SAFE_DECAY_HITS_FLOOR
@@ -1155,6 +1189,7 @@ class TacticalResponseBridgeTest(unittest.TestCase):
             tick=current_tick,
         )
         self.assertGreaterEqual(monitor.expected_rampart_decay_delta(previous, current_tick), large_delta)
+        self.assertLessEqual(current_hits, monitor.RAMPART_CRITICAL_DAMAGE_HITS_CEILING)
 
         emitted, suppressed, _next_state = monitor.evaluate_room_alert(
             snapshot,


### PR DESCRIPTION
## Summary
- Fixes #1220 by downgrading high-health, unexplained rampart hit loss from P0/critical to P1/high while preserving P0 critical routing at or below the rampart safety floor.
- Adds regression coverage using the E29N55 rampart damage values from the runtime alert.
- Records Codex triage in `/tmp/issue1220-codex-triage.md`: classification `FIX`; the monitor classification risk was valid, while the observed high-health rampart loss was not a P0 gameplay emergency.

## Verification
- `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py`
- `python3 -m unittest scripts.test_screeps_runtime_monitor_tactical_response -v` (61 tests OK)
- `git diff --check`

Fixes #1220
