### PR TITLE
fix(rl): restore fallback experiment card supply

### DIFF
--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -19,6 +19,7 @@ from typing import Any, Sequence, TextIO
 TRAINING_APPROACHES = ("bandit", "evolutionary", "policy_gradient")
 DATASET_RUN_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 E1_POSTMERGE_DATASET_GATE_ID_RE = re.compile(r"^gate-\d{8}T\d{6}Z-postmerge\d+$")
+E1_CURRENT_DATASET_GATE_ID_RE = re.compile(r"^gate-\d{8}T\d{6}Z$")
 COMMIT_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
 ISO_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
 STRATEGY_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
@@ -53,7 +54,8 @@ DEFAULT_SIMULATION_OUT_DIR = REPO_ROOT / "runtime-artifacts" / "rl-simulator"
 DEFAULT_EXPERIMENT_CARD_DIR = REPO_ROOT / "runtime-artifacts" / "rl-experiment-cards"
 DEFAULT_DATASET_GATE_ROOT = REPO_ROOT / "runtime-artifacts" / "rl-dataset-gates"
 DEFAULT_CONTROL_LOOP_GATE_ROOT = REPO_ROOT / "runtime-artifacts" / "rl-control-loop"
-DEFAULT_DATASET_GATE_ROOTS = (DEFAULT_DATASET_GATE_ROOT, DEFAULT_CONTROL_LOOP_GATE_ROOT)
+DEFAULT_GATE_DATA_ROOT = REPO_ROOT / "gate-data"
+DEFAULT_DATASET_GATE_ROOTS = (DEFAULT_DATASET_GATE_ROOT, DEFAULT_CONTROL_LOOP_GATE_ROOT, DEFAULT_GATE_DATA_ROOT)
 DEFAULT_TRAINING_REPORT_ROOT = REPO_ROOT / "runtime-artifacts" / "rl-training"
 DEFAULT_LOOP_A_LOCAL_FALLBACK_CARD_PATH = DEFAULT_EXPERIMENT_CARD_DIR / "experiment_card.json"
 DEFAULT_STRATEGY_REGISTRY_PATH = REPO_ROOT / "prod" / "src" / "strategy" / "strategyRegistry.ts"
@@ -1391,17 +1393,19 @@ def iter_canonical_dataset_gate_report_paths(gate_roots: Sequence[Path]) -> list
     for root in gate_roots:
         if not root.exists():
             continue
-        for path in child_gate_report_paths(root):
-            if is_canonical_dataset_gate_report_path(path, root):
-                paths.add(path)
+        scan_roots = [root, root / "gate-data"]
         if root.name == "runtime-artifacts":
             for child_name in ("rl-dataset-gates", "rl-control-loop"):
-                child = root / child_name
-                if not child.exists():
-                    continue
-                for path in child_gate_report_paths(child):
-                    if is_canonical_dataset_gate_report_path(path, root):
-                        paths.add(path)
+                scan_roots.append(root / child_name)
+            scan_roots.append(root / "rl-control-loop" / "gate-data")
+        seen_scan_roots: set[Path] = set()
+        for scan_root in scan_roots:
+            if scan_root in seen_scan_roots or not scan_root.exists():
+                continue
+            seen_scan_roots.add(scan_root)
+            for path in child_gate_report_paths(scan_root):
+                if is_canonical_dataset_gate_report_path(path, root):
+                    paths.add(path)
     return sorted(paths)
 
 
@@ -1422,30 +1426,66 @@ def is_canonical_dataset_gate_report_path(path: Path, gate_root: Path) -> bool:
         return False
     if len(relative_path.parts) == 2:
         return relative_path.parts[0] != "gate-data"
+    if len(relative_path.parts) == 3:
+        return relative_path.parts[0] in {"rl-dataset-gates", "rl-control-loop", "gate-data"}
     return (
-        len(relative_path.parts) == 3
-        and relative_path.parts[0] in {"rl-dataset-gates", "rl-control-loop"}
-        and relative_path.parts[1] != "gate-data"
+        len(relative_path.parts) == 4
+        and relative_path.parts[0] == "rl-control-loop"
+        and relative_path.parts[1] == "gate-data"
     )
 
 
 def is_acceptable_dataset_gate_report(payload: Any, path: Path | None = None) -> bool:
     if not isinstance(payload, dict) or payload.get("type") != SOURCE_GATE_TYPE:
         return False
-    if not is_e1_postmerge_dataset_gate_report(payload, path):
+    if is_e1_postmerge_dataset_gate_report(payload, path):
+        if payload.get("ok") is True:
+            return True
+        return is_degraded_e1_gate_acceptable(payload, path)
+    if is_e1_current_dataset_gate_report(payload, path):
+        return is_fully_accepted_e1_current_gate(payload)
+    return False
+
+
+def is_fully_accepted_e1_current_gate(payload: JsonObject) -> bool:
+    if payload.get("ok") is not True:
         return False
-    if payload.get("ok") is True:
+    dataset_status = dataset_gate_status(payload)
+    if dataset_status is not None and dataset_status != "pass":
+        return False
+    quality_status = quality_checks_status(payload)
+    if quality_status is not None and quality_status != "pass":
+        return False
+    sample_count = dataset_gate_sample_count(payload)
+    acceptance_rate = explicit_dataset_gate_acceptance_rate(payload)
+    return sample_count is not None and sample_count > 0 and acceptance_rate == 1.0
+
+
+def is_e1_current_dataset_gate_report(payload: JsonObject, path: Path | None = None) -> bool:
+    gate_id = dataset_gate_id(payload)
+    if gate_id is None or E1_CURRENT_DATASET_GATE_ID_RE.fullmatch(gate_id) is None:
+        return False
+    return gate_report_path_matches_payload(payload, path)
+
+
+def gate_report_path_matches_payload(payload: JsonObject, path: Path | None) -> bool:
+    if path is None:
         return True
-    return is_degraded_e1_gate_acceptable(payload, path)
+    gate_id = dataset_gate_id(payload)
+    if gate_id is not None and path.parent.name == gate_id:
+        return True
+    try:
+        dataset_run_id = accepted_dataset_run_id(payload)
+    except CardValidationError:
+        dataset_run_id = None
+    return dataset_run_id is not None and path.parent.name == dataset_run_id and "gate-data" in path.parts
 
 
 def is_e1_postmerge_dataset_gate_report(payload: JsonObject, path: Path | None = None) -> bool:
     gate_id = dataset_gate_id(payload)
     if gate_id is None or E1_POSTMERGE_DATASET_GATE_ID_RE.fullmatch(gate_id) is None:
         return False
-    if path is not None and path.parent.name != gate_id:
-        return False
-    return True
+    return gate_report_path_matches_payload(payload, path)
 
 
 def dataset_gate_id(payload: JsonObject) -> str | None:
@@ -1487,6 +1527,8 @@ def is_quality_only_blocking_reason(reason: Any) -> bool:
 def dataset_gate_status(payload: JsonObject) -> str | None:
     dataset_gate = payload.get("datasetGate")
     status = dataset_gate.get("status") if isinstance(dataset_gate, dict) else None
+    if status is None:
+        status = payload.get("datasetGateStatus")
     return status if isinstance(status, str) else None
 
 
@@ -1496,7 +1538,35 @@ def shadow_evaluation_status(payload: JsonObject) -> str | None:
     return status if isinstance(status, str) else None
 
 
-def dataset_gate_acceptance_rate(payload: JsonObject) -> float | None:
+def quality_checks_status(payload: JsonObject) -> str | None:
+    quality = payload.get("quality_checks")
+    if not isinstance(quality, dict):
+        quality = payload.get("qualityChecks")
+    status = quality.get("status") if isinstance(quality, dict) else None
+    if status is None:
+        status = payload.get("qualityChecksStatus")
+    return status if isinstance(status, str) else None
+
+
+def dataset_gate_sample_count(payload: JsonObject) -> int | None:
+    dataset = payload.get("dataset")
+    if isinstance(dataset, dict) and isinstance(dataset.get("sampleCount"), int):
+        return dataset["sampleCount"]
+    dataset_gate = payload.get("datasetGate")
+    if isinstance(dataset_gate, dict) and isinstance(dataset_gate.get("sampleCount"), int):
+        return dataset_gate["sampleCount"]
+    quality = payload.get("quality_checks")
+    if not isinstance(quality, dict):
+        quality = payload.get("qualityChecks")
+    if isinstance(quality, dict):
+        accepted = quality.get("samples_accepted", quality.get("samplesAccepted"))
+        rejected = quality.get("samples_rejected", quality.get("samplesRejected"))
+        if isinstance(accepted, int) and isinstance(rejected, int):
+            return accepted + rejected
+    return None
+
+
+def explicit_dataset_gate_acceptance_rate(payload: JsonObject) -> float | None:
     blocking_reasons = payload.get("blockingReasons")
     reasons = blocking_reasons if isinstance(blocking_reasons, list) else []
     for reason in reasons:
@@ -1507,11 +1577,33 @@ def dataset_gate_acceptance_rate(payload: JsonObject) -> float | None:
         if isinstance(accepted, int) and isinstance(rejected, int) and accepted + rejected > 0:
             return accepted / (accepted + rejected)
     quality = payload.get("quality_checks")
+    if not isinstance(quality, dict):
+        quality = payload.get("qualityChecks")
     if isinstance(quality, dict):
-        accepted = quality.get("samples_accepted")
-        rejected = quality.get("samples_rejected")
+        accepted = quality.get("samples_accepted", quality.get("samplesAccepted"))
+        rejected = quality.get("samples_rejected", quality.get("samplesRejected"))
         if isinstance(accepted, int) and isinstance(rejected, int) and accepted + rejected > 0:
             return accepted / (accepted + rejected)
+        acceptance_rate = quality.get("acceptance_rate", quality.get("acceptanceRate"))
+        if is_finite_number(acceptance_rate):
+            return float(acceptance_rate)
+    dataset_gate = payload.get("datasetGate")
+    if isinstance(dataset_gate, dict):
+        accepted = dataset_gate.get("samplesAccepted")
+        rejected = dataset_gate.get("samplesRejected")
+        if isinstance(accepted, int) and isinstance(rejected, int) and accepted + rejected > 0:
+            return accepted / (accepted + rejected)
+    accepted = payload.get("samplesAccepted")
+    rejected = payload.get("samplesRejected")
+    if isinstance(accepted, int) and isinstance(rejected, int) and accepted + rejected > 0:
+        return accepted / (accepted + rejected)
+    return None
+
+
+def dataset_gate_acceptance_rate(payload: JsonObject) -> float | None:
+    explicit = explicit_dataset_gate_acceptance_rate(payload)
+    if explicit is not None:
+        return explicit
     if payload.get("ok") is True:
         return 1.0
     return None
@@ -2056,7 +2148,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help=(
             "Root scanned by --from-latest-accepted-dataset. Defaults to "
-            f"{DEFAULT_DATASET_GATE_ROOT} plus {DEFAULT_CONTROL_LOOP_GATE_ROOT}."
+            f"{DEFAULT_DATASET_GATE_ROOT}, {DEFAULT_CONTROL_LOOP_GATE_ROOT}, and {DEFAULT_GATE_DATA_ROOT}."
         ),
     )
     parser.add_argument(

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -76,6 +76,7 @@ LOOP_A_LOCAL_FALLBACK_MAX_TICKS = 5000
 LOOP_A_LOCAL_FALLBACK_REPETITIONS = 5
 LOOP_A_LOCAL_FALLBACK_WORKERS = 5
 DEGRADED_E1_GATE_MIN_ACCEPTANCE_RATE = 0.95
+E1_CURRENT_GATE_FULL_ACCEPTANCE_ABS_TOL = 1e-9
 
 JsonObject = dict[str, Any]
 
@@ -1458,7 +1459,12 @@ def is_fully_accepted_e1_current_gate(payload: JsonObject) -> bool:
         return False
     sample_count = dataset_gate_sample_count(payload)
     acceptance_rate = explicit_dataset_gate_acceptance_rate(payload)
-    return sample_count is not None and sample_count > 0 and acceptance_rate == 1.0
+    return (
+        sample_count is not None
+        and sample_count > 0
+        and acceptance_rate is not None
+        and math.isclose(acceptance_rate, 1.0, rel_tol=0.0, abs_tol=E1_CURRENT_GATE_FULL_ACCEPTANCE_ABS_TOL)
+    )
 
 
 def is_e1_current_dataset_gate_report(payload: JsonObject, path: Path | None = None) -> bool:
@@ -1478,7 +1484,7 @@ def gate_report_path_matches_payload(payload: JsonObject, path: Path | None) -> 
         dataset_run_id = accepted_dataset_run_id(payload)
     except CardValidationError:
         dataset_run_id = None
-    return dataset_run_id is not None and path.parent.name == dataset_run_id and "gate-data" in path.parts
+    return dataset_run_id is not None and path.parent.name == dataset_run_id
 
 
 def is_e1_postmerge_dataset_gate_report(payload: JsonObject, path: Path | None = None) -> bool:

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -812,6 +812,202 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertFalse(selected["gate_report_ok"])
         self.assertTrue(selected["gate_report_path"].endswith("rl-control-loop/gate-20260517T181846Z-postmerge1176/gate_report.json"))
 
+    def test_loop_a_local_fallback_selects_latest_full_e1_gate_data_card(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runtime_root = root / "runtime-artifacts"
+            stale_gate = runtime_root / "rl-dataset-gates" / "rl-gate-93bf1aa18b62-shadow" / "gate_report.json"
+            wrong_stream_gate = runtime_root / "rl-control-loop" / "gate-20260519T081500Z" / "gate_report.json"
+            gate_id = "gate-20260519T074023Z"
+            dataset_run_id = "rl-eae3fd9655bf"
+            control_loop_gate = runtime_root / "rl-control-loop" / gate_id / "gate_report.json"
+            gate_data_gate = runtime_root / "rl-control-loop" / "gate-data" / dataset_run_id / "gate_report.json"
+            output_path = root / "runtime-artifacts" / "rl-experiment-cards" / "experiment_card.json"
+            stale_gate.parent.mkdir(parents=True)
+            wrong_stream_gate.parent.mkdir(parents=True)
+            control_loop_gate.parent.mkdir(parents=True)
+            gate_data_gate.parent.mkdir(parents=True)
+            stale_gate.write_text(
+                json.dumps(
+                    {
+                        "type": card_helper.SOURCE_GATE_TYPE,
+                        "ok": True,
+                        "gateId": "rl-gate-93bf1aa18b62-shadow",
+                        "createdAt": "2026-05-14T04:22:20Z",
+                        "dataset": {"runId": "rl-stale-hash", "sampleCount": 200},
+                        "datasetGate": {"status": "pass", "sampleCount": 200},
+                        "quality_checks": {
+                            "status": "pass",
+                            "samples_accepted": 200,
+                            "samples_rejected": 0,
+                            "acceptance_rate": 1.0,
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            wrong_stream_gate.write_text(
+                json.dumps(
+                    {
+                        "type": card_helper.SOURCE_GATE_TYPE,
+                        "ok": True,
+                        "gateId": "gate-20260519T081500Z",
+                        "createdAt": "2026-05-19T08:15:00Z",
+                        "dataset": {"runId": "rl-newer-without-quality-counts", "sampleCount": 200},
+                        "datasetGate": {"status": "pass", "sampleCount": 200},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            gate_payload = {
+                "type": card_helper.SOURCE_GATE_TYPE,
+                "ok": True,
+                "gateId": gate_id,
+                "createdAt": "2026-05-19T07:40:23Z",
+                "dataset": {
+                    "ok": True,
+                    "runId": dataset_run_id,
+                    "sampleCount": 200,
+                    "outDir": f"gate-data/{dataset_run_id}",
+                },
+                "datasetGate": {"status": "pass", "sampleCount": 200},
+                "quality_checks": {
+                    "status": "pass",
+                    "samples_accepted": 200,
+                    "samples_rejected": 0,
+                    "acceptance_rate": 1.0,
+                },
+                "shadowEvaluation": {"status": "pass", "ok": True},
+            }
+            control_loop_gate.write_text(json.dumps(gate_payload), encoding="utf-8")
+            gate_data_gate.write_text(json.dumps(gate_payload), encoding="utf-8")
+            os.utime(control_loop_gate, (1_779_171_623, 1_779_171_623))
+            os.utime(gate_data_gate, (1_779_171_624, 1_779_171_624))
+
+            selected = card_helper.select_accepted_dataset_gate(runtime_root)
+            stdout = io.StringIO()
+            exit_code = card_helper.main(
+                [
+                    "--loop-a-local-fallback",
+                    "--dataset-gate-root",
+                    str(runtime_root),
+                    "--code-commit",
+                    "8" * 40,
+                    "--created-at",
+                    "2026-05-19T08:20:00Z",
+                    "--output",
+                    str(output_path),
+                ],
+                stdout=stdout,
+                stderr=io.StringIO(),
+                repo_root=REPO_ROOT,
+            )
+            summary = json.loads(stdout.getvalue())
+            generated = json.loads(output_path.read_text(encoding="utf-8"))
+            selected_stdout = io.StringIO()
+            selected_exit_code = card_helper.main(
+                [
+                    "--select-loop-a-card",
+                    "--card-dir",
+                    str(output_path.parent),
+                    "--training-report-dir",
+                    str(root / "runtime-artifacts" / "rl-training"),
+                ],
+                stdout=selected_stdout,
+                stderr=io.StringIO(),
+                repo_root=REPO_ROOT,
+            )
+            selected_card = json.loads(selected_stdout.getvalue())
+
+        self.assertEqual(selected["gate_id"], gate_id)
+        self.assertEqual(selected["dataset_run_id"], dataset_run_id)
+        self.assertTrue(selected["gate_report_path"].endswith(f"rl-control-loop/gate-data/{dataset_run_id}/gate_report.json"))
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(summary["source_gate"]["gate_id"], gate_id)
+        self.assertEqual(summary["source_gate"]["dataset_run_id"], dataset_run_id)
+        self.assertTrue(summary["source_gate"]["gate_report_path"].endswith(f"rl-control-loop/gate-data/{dataset_run_id}/gate_report.json"))
+        self.assertEqual(generated["dataset_run_id"], dataset_run_id)
+        self.assertEqual(generated["source_gate"]["gate_id"], gate_id)
+        self.assertEqual(generated["training_approach"], "policy_gradient")
+        self.assertEqual(generated["status"], "shadow")
+        self.assertFalse(generated["liveEffect"])
+        self.assertFalse(generated["officialMmoWrites"])
+        self.assertFalse(generated["officialMmoWritesAllowed"])
+        self.assertTrue(generated["conservative_actions_only"])
+        self.assertTrue(generated["ood_rejection"])
+        self.assertFalse(generated["safety"]["liveEffect"])
+        self.assertFalse(generated["safety"]["officialMmoWrites"])
+        self.assertFalse(generated["safety"]["officialMmoWritesAllowed"])
+        self.assertTrue(generated["safety"]["conservative_actions_only"])
+        self.assertTrue(generated["safety"]["ood_rejection"])
+        self.assertEqual(generated["scenario"]["scenario_id"], card_helper.MULTI_TIER_SCENARIO_ID)
+        self.assertTrue(card_helper.is_loop_a_card_available_for_training(generated))
+        self.assertEqual(selected_exit_code, 0)
+        self.assertEqual(selected_card["card_path"], str(output_path))
+
+    def test_loop_a_local_fallback_without_full_e1_gate_stays_blocked(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runtime_root = root / "runtime-artifacts"
+            stale_gate = runtime_root / "rl-dataset-gates" / "rl-gate-stale" / "gate_report.json"
+            partial_gate = runtime_root / "rl-control-loop" / "gate-20260519T081500Z" / "gate_report.json"
+            output_path = root / "runtime-artifacts" / "rl-experiment-cards" / "experiment_card.json"
+            stale_gate.parent.mkdir(parents=True)
+            partial_gate.parent.mkdir(parents=True)
+            stale_gate.write_text(
+                json.dumps(
+                    {
+                        "type": card_helper.SOURCE_GATE_TYPE,
+                        "ok": True,
+                        "gateId": "rl-gate-stale",
+                        "createdAt": "2026-05-14T04:22:20Z",
+                        "dataset": {"runId": "rl-stale-gate"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            partial_gate.write_text(
+                json.dumps(
+                    {
+                        "type": card_helper.SOURCE_GATE_TYPE,
+                        "ok": True,
+                        "gateId": "gate-20260519T081500Z",
+                        "createdAt": "2026-05-19T08:15:00Z",
+                        "dataset": {"runId": "rl-partial-e1", "sampleCount": 200},
+                        "datasetGate": {"status": "pass", "sampleCount": 200},
+                        "quality_checks": {
+                            "status": "fail",
+                            "samples_accepted": 199,
+                            "samples_rejected": 1,
+                            "acceptance_rate": 0.995,
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            stderr = io.StringIO()
+
+            exit_code = card_helper.main(
+                [
+                    "--loop-a-local-fallback",
+                    "--dataset-gate-root",
+                    str(runtime_root),
+                    "--code-commit",
+                    "8" * 40,
+                    "--created-at",
+                    "2026-05-19T08:20:00Z",
+                    "--output",
+                    str(output_path),
+                ],
+                stdout=io.StringIO(),
+                stderr=stderr,
+                repo_root=REPO_ROOT,
+            )
+
+        self.assertEqual(exit_code, 2)
+        self.assertFalse(output_path.exists())
+        self.assertIn("no accepted dataset gate", stderr.getvalue())
+
     def test_latest_accepted_dataset_rejects_degraded_non_postmerge_gate(self) -> None:
         payload = {
             "type": card_helper.SOURCE_GATE_TYPE,

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -945,6 +945,65 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(selected_exit_code, 0)
         self.assertEqual(selected_card["card_path"], str(output_path))
 
+    def test_loop_a_local_fallback_accepts_e1_gate_by_dataset_run_id_outside_gate_data(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runtime_root = root / "runtime-artifacts"
+            gate_id = "gate-20260519T074023Z"
+            dataset_run_id = "rl-e1-current-canonical"
+            gate_path = runtime_root / "rl-control-loop" / dataset_run_id / "gate_report.json"
+            gate_path.parent.mkdir(parents=True)
+            gate_payload = {
+                "type": card_helper.SOURCE_GATE_TYPE,
+                "ok": True,
+                "gateId": gate_id,
+                "createdAt": "2026-05-19T07:40:23Z",
+                "dataset": {"ok": True, "runId": dataset_run_id, "sampleCount": 200},
+                "datasetGate": {"status": "pass", "sampleCount": 200},
+                "quality_checks": {
+                    "status": "pass",
+                    "samples_accepted": 200,
+                    "samples_rejected": 0,
+                    "acceptance_rate": 1.0,
+                },
+                "shadowEvaluation": {"status": "pass", "ok": True},
+            }
+            gate_path.write_text(json.dumps(gate_payload), encoding="utf-8")
+
+            selected = card_helper.select_accepted_dataset_gate(runtime_root)
+
+        self.assertEqual(selected["gate_id"], gate_id)
+        self.assertEqual(selected["dataset_run_id"], dataset_run_id)
+        self.assertTrue(selected["gate_report_path"].endswith(f"rl-control-loop/{dataset_run_id}/gate_report.json"))
+
+    def test_e1_current_gate_accepts_float_near_one_but_rejects_partial_rate(self) -> None:
+        gate_id = "gate-20260519T074023Z"
+        dataset_run_id = "rl-e1-current-rate"
+        near_full_payload = {
+            "type": card_helper.SOURCE_GATE_TYPE,
+            "ok": True,
+            "gateId": gate_id,
+            "createdAt": "2026-05-19T07:40:23Z",
+            "dataset": {"ok": True, "runId": dataset_run_id, "sampleCount": 200},
+            "datasetGate": {"status": "pass", "sampleCount": 200},
+            "quality_checks": {
+                "status": "pass",
+                "acceptance_rate": 0.9999999999999999,
+            },
+            "shadowEvaluation": {"status": "pass", "ok": True},
+        }
+        partial_payload = {
+            **near_full_payload,
+            "dataset": {"ok": True, "runId": "rl-e1-current-partial", "sampleCount": 200},
+            "quality_checks": {
+                "status": "pass",
+                "acceptance_rate": 0.995,
+            },
+        }
+
+        self.assertTrue(card_helper.is_acceptable_dataset_gate_report(near_full_payload))
+        self.assertFalse(card_helper.is_acceptable_dataset_gate_report(partial_payload))
+
     def test_loop_a_local_fallback_without_full_e1_gate_stays_blocked(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary
- Restores Loop A/local fallback experiment-card supply from the freshest accepted E1 gate data.
- Extends gate selection to prefer current control-loop gate data over stale hashed `rl-dataset-gates` artifacts.
- Adds regression coverage for generating/selecting a shadow-safe fallback card from `gate-20260519T074023Z`-style artifacts and for staying blocked when no full accepted E1 gate exists.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_experiment_card.py scripts/screeps_rl_training_runner.py scripts/screeps_rl_dashboard.py scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_rl_experiment_card.py`
- `python3 -m unittest scripts.test_screeps_rl_experiment_card` — 44 tests OK

## Safety
- RL fallback card remains shadow/offline only.
- No official MMO writes, no deploy, no Tencent paid run.

Closes #1216
