### PR TITLE
fix(rl): canonicalize E1 gate data consumption

### DIFF
--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -16,6 +16,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 
+import screeps_rl_experiment_card as experiment_card
+
 
 JsonObject = dict[str, Any]
 
@@ -101,6 +103,7 @@ TIMESTAMP_KEYS = (
     "lastSeenAt",
 )
 FILENAME_TIMESTAMP_RE = re.compile(r"(\d{8}T\d{4,6}Z)")
+GATE_ID_TIMESTAMP_RE = re.compile(r"gate-(\d{8}T\d{6}Z)")
 PREFLIGHT_FINAL_STATUS_KEYS = {
     "preflight",
     "preflightok",
@@ -228,6 +231,19 @@ def timestamp_from_filename(path: Path) -> datetime | None:
         except ValueError:
             continue
     return None
+
+
+def timestamp_from_gate_id(payload: JsonObject) -> datetime | None:
+    gate_id = first_text(payload, (("gateId",), ("gate_id",), ("e1Gate", "gateId")))
+    if gate_id is None:
+        return None
+    match = GATE_ID_TIMESTAMP_RE.search(gate_id)
+    if match is None:
+        return None
+    try:
+        return datetime.strptime(match.group(1), "%Y%m%dT%H%M%SZ").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
 
 
 def artifact_timestamp(path: Path, payload: JsonObject) -> datetime:
@@ -1166,6 +1182,9 @@ def extract_gate_info(payload: JsonObject, source_path: Path, source_label: str,
             ("acceptanceRate",),
             ("acceptance_rate",),
             ("latestGateAcceptanceRate",),
+            ("qualityAcceptanceRate",),
+            ("quality_checks", "acceptance_rate"),
+            ("qualityChecks", "acceptanceRate"),
             ("e1Gate", "acceptanceRate"),
         ),
     )
@@ -1189,11 +1208,14 @@ def extract_gate_info(payload: JsonObject, source_path: Path, source_label: str,
         )
         or ("pass" if payload.get("ok") is True else "fail" if payload.get("ok") is False else None)
     )
+    if status not in {"pass", "passed", "ok"} and gate_payload_is_acceptable(payload, source_path):
+        status = "pass"
     reasons = collect_rejection_reasons(payload)
     timestamp = (
         parse_iso_datetime(payload.get("gateCreatedAt"))
         or parse_iso_datetime(payload.get("createdAt"))
         or parse_iso_datetime(payload.get("window"))
+        or timestamp_from_gate_id(payload)
         or artifact_timestamp(source_path, payload)
     )
 
@@ -1213,6 +1235,13 @@ def extract_gate_info(payload: JsonObject, source_path: Path, source_label: str,
         "sourceLabel": source_label,
         "displayPath": safe_display_path(source_path, repo_root),
     }
+
+
+def gate_payload_is_acceptable(payload: JsonObject, source_path: Path) -> bool:
+    try:
+        return experiment_card.is_acceptable_dataset_gate_report(payload, source_path)
+    except experiment_card.CardValidationError:
+        return False
 
 
 def gate_info_from_metrics_observations(artifact: LoadedArtifact, repo_root: Path) -> JsonObject | None:
@@ -1252,7 +1281,17 @@ def discover_gate_infos(
 
     gate_paths = []
     gate_paths.extend(existing_globs(artifact_root / "rl-dataset-gates", ("*/gate_summary.json", "*/gate_report.json")))
-    gate_paths.extend(existing_globs(artifact_root / "rl-control-loop", ("*gate*.json", "*/gate_summary.json", "*/gate_report.json")))
+    gate_paths.extend(
+        existing_globs(
+            artifact_root / "rl-control-loop",
+            (
+                "*/gate_summary.json",
+                "*/gate_report.json",
+                "gate-data/*/gate_summary.json",
+                "gate-data/*/gate_report.json",
+            ),
+        )
+    )
     gate_paths.extend(existing_globs(artifact_root / "screeps-monitor", ("*gate*.json", "*/gate*.json", "*/*/gate*.json")))
 
     for path in gate_paths:

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -1444,7 +1444,9 @@ def is_acceptable_dataset_gate_report(payload: Any, path: Path | None = None) ->
             return True
         return is_degraded_e1_gate_acceptable(payload, path)
     if is_e1_current_dataset_gate_report(payload, path):
-        return is_fully_accepted_e1_current_gate(payload)
+        if is_fully_accepted_e1_current_gate(payload):
+            return True
+        return is_degraded_e1_gate_acceptable(payload, path)
     return False
 
 
@@ -1503,7 +1505,10 @@ def dataset_gate_id(payload: JsonObject) -> str | None:
 
 
 def is_degraded_e1_gate_acceptable(payload: JsonObject, path: Path | None = None) -> bool:
-    if not is_e1_postmerge_dataset_gate_report(payload, path):
+    if not (
+        is_e1_postmerge_dataset_gate_report(payload, path)
+        or is_canonical_e1_current_gate_data_report(payload, path)
+    ):
         return False
     blocking_reasons = payload.get("blockingReasons")
     if not isinstance(blocking_reasons, list) or not blocking_reasons:
@@ -1520,6 +1525,16 @@ def is_degraded_e1_gate_acceptable(payload: JsonObject, path: Path | None = None
         return False
     acceptance_rate = dataset_gate_acceptance_rate(payload)
     return acceptance_rate is not None and acceptance_rate >= DEGRADED_E1_GATE_MIN_ACCEPTANCE_RATE
+
+
+def is_canonical_e1_current_gate_data_report(payload: JsonObject, path: Path | None = None) -> bool:
+    if not is_e1_current_dataset_gate_report(payload, path):
+        return False
+    if path is not None and "gate-data" in path.parts:
+        return True
+    outputs = payload.get("outputs")
+    gate_dir = outputs.get("gateDir") if isinstance(outputs, dict) else None
+    return isinstance(gate_dir, str) and "gate-data/" in gate_dir.replace("\\", "/")
 
 
 def is_quality_only_blocking_reason(reason: Any) -> bool:

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -103,6 +103,93 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertTrue(dashboard.value_has_reference(["0", "2.5"]))
         self.assertTrue(dashboard.value_has_reference("training-report-a"))
 
+    def test_dashboard_prefers_fresh_acceptable_gate_data_over_stale_dataset_gate_and_embedded_ledger_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            write_json(
+                artifact_root / "rl-dataset-gates" / "rl-gate-db16ca9c3de7" / "gate_report.json",
+                {
+                    "type": "screeps-rl-dataset-evaluation-gate",
+                    "ok": False,
+                    "gateId": "rl-gate-db16ca9c3de7",
+                    "createdAt": "2026-05-11T14:23:09Z",
+                    "dataset": {"ok": True, "runId": "rl-stale", "sampleCount": 200},
+                    "datasetGate": {"status": "pass", "sampleCount": 200},
+                    "quality_checks": {
+                        "status": "fail",
+                        "samples_accepted": 126,
+                        "samples_rejected": 74,
+                    },
+                },
+            )
+            gate_id = "gate-20260518T201617Z"
+            dataset_run_id = "rl-3f50bf443ad6"
+            write_json(
+                artifact_root / "rl-control-loop" / "gate-data" / gate_id / "gate_report.json",
+                {
+                    "type": "screeps-rl-dataset-evaluation-gate",
+                    "ok": False,
+                    "gateId": gate_id,
+                    "createdAt": "2026-05-18T20:16:18Z",
+                    "dataset": {"ok": True, "runId": dataset_run_id, "sampleCount": 200},
+                    "datasetGate": {"status": "pass", "sampleCount": 200},
+                    "shadowEvaluation": {"status": "pass", "ok": True},
+                    "blockingReasons": [
+                        {
+                            "gate": "quality_checks",
+                            "name": "sample_quality",
+                            "status": "fail",
+                            "samplesAccepted": 191,
+                            "samplesRejected": 9,
+                        }
+                    ],
+                    "outputs": {"gateDir": f"runtime-artifacts/rl-control-loop/gate-data/{gate_id}"},
+                },
+            )
+            write_json(
+                artifact_root / "rl-control-loop" / "gate-20260519T074023Z-shadow.json",
+                {
+                    "type": "screeps-strategy-shadow-report",
+                    "createdAt": "2026-05-19T07:40:24Z",
+                    "reportId": "gate-20260519T074023Z-shadow",
+                    "ok": True,
+                },
+            )
+            write_json(
+                artifact_root / "rl-control-loop" / "20260519T091400Z-training-ledger.json",
+                {
+                    "type": "screeps-rl-training-execution-ledger",
+                    "createdAt": "2026-05-19T09:14:00Z",
+                    "status": "RUN_WITH_ANOMALY",
+                    "trainingDidRun": True,
+                    "e1Gate": {
+                        "gateId": gate_id,
+                        "ok": False,
+                        "datasetRunId": dataset_run_id,
+                        "sampleCount": 200,
+                        "acceptanceRate": 0.955,
+                        "blockingReasons": [
+                            "quality_checks: 9 rejected samples"
+                        ],
+                    },
+                },
+            )
+
+            summary = dashboard.build_dashboard(
+                repo_root=root,
+                artifact_root=artifact_root,
+                generated_at="2026-05-19T09:20:00Z",
+            )
+
+        gate = summary["gate"]
+        self.assertEqual(gate["gateId"], gate_id)
+        self.assertEqual(gate["status"], "pass")
+        self.assertEqual(gate["acceptanceRate"], 0.955)
+        self.assertTrue(str(gate["sourcePath"]).endswith(f"rl-control-loop/gate-data/{gate_id}/gate_report.json"))
+        e1_lane = next(item for item in summary["lanes"] if item["lane"] == "E1")
+        self.assertEqual(e1_lane["status"], "OK")
+
     def test_tencent_internal_card_downgrades_standalone_stall_to_fallback(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -945,6 +945,91 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(selected_exit_code, 0)
         self.assertEqual(selected_card["card_path"], str(output_path))
 
+    def test_loop_a_local_fallback_accepts_quality_only_gate_data_tail_over_stale_dataset_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runtime_root = root / "runtime-artifacts"
+            stale_gate = runtime_root / "rl-dataset-gates" / "rl-gate-db16ca9c3de7" / "gate_report.json"
+            gate_id = "gate-20260518T201617Z"
+            dataset_run_id = "rl-3f50bf443ad6"
+            gate_data_gate = runtime_root / "rl-control-loop" / "gate-data" / gate_id / "gate_report.json"
+            output_path = runtime_root / "rl-experiment-cards" / "experiment_card.json"
+            stale_gate.parent.mkdir(parents=True)
+            gate_data_gate.parent.mkdir(parents=True)
+            stale_gate.write_text(
+                json.dumps(
+                    {
+                        "type": card_helper.SOURCE_GATE_TYPE,
+                        "ok": False,
+                        "gateId": "rl-gate-db16ca9c3de7",
+                        "createdAt": "2026-05-11T14:23:09Z",
+                        "dataset": {"ok": True, "runId": "rl-stale", "sampleCount": 200},
+                        "datasetGate": {"status": "pass", "sampleCount": 200},
+                        "quality_checks": {
+                            "status": "fail",
+                            "samples_accepted": 126,
+                            "samples_rejected": 74,
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            fresh_gate_payload = {
+                "type": card_helper.SOURCE_GATE_TYPE,
+                "ok": False,
+                "gateId": gate_id,
+                "createdAt": "2026-05-18T20:16:18Z",
+                "dataset": {"ok": True, "runId": dataset_run_id, "sampleCount": 200},
+                "datasetGate": {"status": "pass", "sampleCount": 200},
+                "shadowEvaluation": {"status": "pass", "ok": True},
+                "blockingReasons": [
+                    {
+                        "gate": "quality_checks",
+                        "name": "sample_quality",
+                        "status": "fail",
+                        "samplesAccepted": 191,
+                        "samplesRejected": 9,
+                        "rejectionReasons": {
+                            "no_harvest_or_upgrade_task": 9,
+                            "no_owned_creeps": 4,
+                            "no_room_energy": 6,
+                        },
+                    }
+                ],
+                "outputs": {"gateDir": f"runtime-artifacts/rl-control-loop/gate-data/{gate_id}"},
+            }
+            gate_data_gate.write_text(json.dumps(fresh_gate_payload), encoding="utf-8")
+
+            selected = card_helper.select_accepted_dataset_gate(runtime_root)
+            stdout = io.StringIO()
+            exit_code = card_helper.main(
+                [
+                    "--loop-a-local-fallback",
+                    "--dataset-gate-root",
+                    str(runtime_root),
+                    "--code-commit",
+                    "8" * 40,
+                    "--created-at",
+                    "2026-05-19T08:20:00Z",
+                    "--output",
+                    str(output_path),
+                ],
+                stdout=stdout,
+                stderr=io.StringIO(),
+                repo_root=REPO_ROOT,
+            )
+            summary = json.loads(stdout.getvalue())
+
+        self.assertTrue(card_helper.is_degraded_e1_gate_acceptable(fresh_gate_payload, gate_data_gate))
+        self.assertEqual(selected["gate_id"], gate_id)
+        self.assertEqual(selected["dataset_run_id"], dataset_run_id)
+        self.assertFalse(selected["gate_report_ok"])
+        self.assertEqual(selected["quality_acceptance_rate"], 0.955)
+        self.assertTrue(selected["gate_report_path"].endswith(f"rl-control-loop/gate-data/{gate_id}/gate_report.json"))
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(summary["source_gate"]["gate_id"], gate_id)
+        self.assertEqual(summary["source_gate"]["dataset_run_id"], dataset_run_id)
+
     def test_loop_a_local_fallback_accepts_e1_gate_by_dataset_run_id_outside_gate_data(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_live_dashboard.py
+++ b/scripts/test_screeps_rl_live_dashboard.py
@@ -87,6 +87,7 @@ def write_live_artifacts(root: Path) -> None:
             "onlineUtilityStatus": "PROVEN",
             "candidatePolicyId": "candidate-policy",
             "baselinePolicyId": "incumbent-policy",
+            "trainingReportIds": ["training-report-tencent-test"],
             "metricsByCategory": {
                 "territory": {"status": "ADVANTAGE", "candidateValue": 3, "baselineValue": 2, "delta": 1},
             },


### PR DESCRIPTION
Closes #1224.

## Summary
- Prefer canonical `runtime-artifacts/rl-control-loop/gate-data/*/gate_report.json` gate data over stale `rl-dataset-gates` artifacts in the RL dashboard.
- Treat acceptable quality-only current gate-data reports as usable E1 evidence, including gate-id timestamp fallback.
- Add regression coverage for stale dataset-gate vs fresh canonical gate-data selection and local fallback card acceptance.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_dashboard.py scripts/screeps_rl_experiment_card.py`
- `python3 -m pytest scripts/test_screeps_rl_dashboard.py scripts/test_screeps_rl_experiment_card.py scripts/test_screeps_rl_live_dashboard.py -q` → 94 passed, 19 subtests passed

## Safety
- Offline/script-only RL evidence routing change.
- No official MMO writes, no deploy, no secrets.
