### PR TITLE
fix(rl): classify Tencent training scale gates

### DIFF
--- a/scripts/screeps_rl_live_dashboard.py
+++ b/scripts/screeps_rl_live_dashboard.py
@@ -22,6 +22,7 @@ from urllib.parse import urlparse
 
 import screeps_rl_dashboard as static_dashboard
 import screeps_rl_metrics_ingestor as metrics_ingestor
+import screeps_rl_scale_gates as scale_gates
 
 
 DEFAULT_HOST = "127.0.0.1"
@@ -300,6 +301,7 @@ def tencent_batch_summary(artifact_root: Path, repo_root: Path) -> JsonObject:
             if payload is None:
                 continue
             compute_evidence = static_dashboard.compute_evidence_summary(payload)
+            batch_scale = tencent_batch_scale(payload)
             runs.append(
                 {
                     "runId": payload.get("runId") or path.parent.name,
@@ -313,6 +315,7 @@ def tencent_batch_summary(artifact_root: Path, repo_root: Path) -> JsonObject:
                     "safety": payload.get("safety") if isinstance(payload.get("safety"), dict) else {},
                     "computeEvidence": compute_evidence,
                     "computeClassification": compute_evidence.get("classification"),
+                    "batchScale": batch_scale,
                     "blocker": compute_evidence.get("blocker"),
                     "path": safe_display_path(path, repo_root),
                     "timestamp": display_timestamp(artifact_timestamp(path, payload)),
@@ -336,6 +339,49 @@ def tencent_batch_summary(artifact_root: Path, repo_root: Path) -> JsonObject:
         "preflightOnlyRunCount": len(preflight_only),
         "latest": latest,
     }
+
+
+def tencent_batch_scale(payload: JsonObject) -> JsonObject:
+    for candidate in (
+        payload.get("batchScale"),
+        static_dashboard.nested_value(payload, ("outputs", "trainingReport", "batchScale")),
+    ):
+        if isinstance(candidate, dict):
+            rows = scale_gates.non_negative_int(candidate.get("environmentRows"))
+            ticks = scale_gates.non_negative_int(candidate.get("simulatorTicks"))
+            if rows is not None and ticks is not None:
+                return scale_gates.build_batch_scale_summary(
+                    environment_rows=rows,
+                    simulator_ticks=ticks,
+                    wall_clock_seconds=candidate.get("wallClockSeconds"),
+                    asg_active_seconds=candidate.get("asgActiveSeconds"),
+                    cost_estimate=candidate.get("costEstimate"),
+                    basis=str(candidate.get("basis") or "controller_summary"),
+                )
+    inputs = payload.get("inputs") if isinstance(payload.get("inputs"), dict) else {}
+    planned = inputs.get("plannedBatchScale")
+    if isinstance(planned, dict):
+        rows = scale_gates.non_negative_int(planned.get("environmentRows"))
+        ticks = scale_gates.non_negative_int(planned.get("simulatorTicks"))
+        if rows is not None and ticks is not None:
+            return scale_gates.build_batch_scale_summary(
+                environment_rows=rows,
+                simulator_ticks=ticks,
+                basis="planned_inputs",
+            )
+    workers = (
+        scale_gates.non_negative_int(inputs.get("scaleEnvironments"))
+        or scale_gates.non_negative_int(inputs.get("workers"))
+        or 0
+    )
+    repetitions = scale_gates.non_negative_int(inputs.get("repetitions")) or 1
+    ticks_per_row = scale_gates.non_negative_int(inputs.get("ticks")) or 0
+    environment_rows = workers * repetitions
+    return scale_gates.build_batch_scale_summary(
+        environment_rows=environment_rows,
+        simulator_ticks=environment_rows * ticks_per_row,
+        basis="legacy_inputs",
+    )
 
 
 def safety_summary(dashboard: JsonObject, tencent: JsonObject, scorecard: JsonObject) -> JsonObject:
@@ -463,6 +509,7 @@ def render_live_html(summary: JsonObject, config: LiveDashboardConfig) -> str:
     scorecard = loop_b.get("scorecard") if isinstance(loop_b.get("scorecard"), dict) else {}
     tencent = summary.get("tencentBatch") if isinstance(summary.get("tencentBatch"), dict) else {}
     latest_tencent = tencent.get("latest") if isinstance(tencent.get("latest"), dict) else {}
+    latest_batch_scale = latest_tencent.get("batchScale") if isinstance(latest_tencent.get("batchScale"), dict) else {}
     safety = summary.get("safety") if isinstance(summary.get("safety"), dict) else {}
     db = summary.get("db") if isinstance(summary.get("db"), dict) else {}
 
@@ -515,6 +562,10 @@ def render_live_html(summary: JsonObject, config: LiveDashboardConfig) -> str:
         ("Latest run", h(latest_tencent.get("runId") or "N/A")),
         ("Latest status", render_status(latest_tencent.get("finalStatus"))),
         ("Latest compute evidence", h(latest_tencent.get("computeClassification") or "N/A")),
+        ("Latest batch class", h(latest_batch_scale.get("batchClass") or "N/A")),
+        ("Latest env rows", h(latest_batch_scale.get("environmentRows", "N/A"))),
+        ("Latest simulator ticks", h(latest_batch_scale.get("simulatorTicks", "N/A"))),
+        ("Scale-first eligible", h(latest_batch_scale.get("scaleFirstEligible", "N/A"))),
         ("Scale down attempted", h(latest_tencent.get("safety", {}).get("scaleDownAttempted") if isinstance(latest_tencent.get("safety"), dict) else "N/A")),
     ]
     safety_rows = [

--- a/scripts/screeps_rl_scale_gates.py
+++ b/scripts/screeps_rl_scale_gates.py
@@ -93,9 +93,12 @@ def batch_scale_thresholds() -> JsonObject:
             "operator": "OR",
         },
         BATCH_CLASS_INTERMEDIATE: {
-            "environmentRows": f">={SMOKE_ENVIRONMENT_ROWS} and <{VALIDATION_ENVIRONMENT_ROWS}",
-            "simulatorTicks": f">={SMOKE_SIMULATOR_TICKS} and <{VALIDATION_SIMULATOR_TICKS}",
-            "operator": "above smoke but below validation",
+            "environmentRows": f">={SMOKE_ENVIRONMENT_ROWS}",
+            "simulatorTicks": f">={SMOKE_SIMULATOR_TICKS}",
+            "operator": (
+                f"AND with (environmentRows <{VALIDATION_ENVIRONMENT_ROWS} "
+                f"OR simulatorTicks <{VALIDATION_SIMULATOR_TICKS})"
+            ),
         },
         BATCH_CLASS_VALIDATION: {
             "environmentRows": f">={VALIDATION_ENVIRONMENT_ROWS}",

--- a/scripts/screeps_rl_scale_gates.py
+++ b/scripts/screeps_rl_scale_gates.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Scale classification gates for offline Screeps RL training batches."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+
+SMOKE_ENVIRONMENT_ROWS = 50
+SMOKE_SIMULATOR_TICKS = 50_000
+VALIDATION_ENVIRONMENT_ROWS = 200
+VALIDATION_SIMULATOR_TICKS = 200_000
+NORMAL_SCALE_ENVIRONMENT_ROWS = 400
+NORMAL_SCALE_SIMULATOR_TICKS = 400_000
+LARGE_CAMPAIGN_ENVIRONMENT_ROWS = 800
+LARGE_CAMPAIGN_SIMULATOR_TICKS = 1_600_000
+
+BATCH_CLASS_SMOKE = "smoke"
+BATCH_CLASS_INTERMEDIATE = "intermediate"
+BATCH_CLASS_VALIDATION = "validation"
+BATCH_CLASS_NORMAL_SCALE = "normal-scale"
+BATCH_CLASS_LARGE_CAMPAIGN = "large-campaign"
+SCALE_FIRST_BATCH_CLASSES = {
+    BATCH_CLASS_VALIDATION,
+    BATCH_CLASS_NORMAL_SCALE,
+    BATCH_CLASS_LARGE_CAMPAIGN,
+}
+
+JsonObject = dict[str, Any]
+
+
+def classify_batch_scale(environment_rows: int, simulator_ticks: int) -> str:
+    """Classify a training batch from executed environment rows and simulator ticks."""
+    rows = require_non_negative_int(environment_rows, "environment_rows")
+    ticks = require_non_negative_int(simulator_ticks, "simulator_ticks")
+    if rows < SMOKE_ENVIRONMENT_ROWS or ticks < SMOKE_SIMULATOR_TICKS:
+        return BATCH_CLASS_SMOKE
+    if rows >= LARGE_CAMPAIGN_ENVIRONMENT_ROWS and ticks >= LARGE_CAMPAIGN_SIMULATOR_TICKS:
+        return BATCH_CLASS_LARGE_CAMPAIGN
+    if rows >= NORMAL_SCALE_ENVIRONMENT_ROWS and ticks >= NORMAL_SCALE_SIMULATOR_TICKS:
+        return BATCH_CLASS_NORMAL_SCALE
+    if rows >= VALIDATION_ENVIRONMENT_ROWS and ticks >= VALIDATION_SIMULATOR_TICKS:
+        return BATCH_CLASS_VALIDATION
+    return BATCH_CLASS_INTERMEDIATE
+
+
+def scale_first_eligible(batch_class: str) -> bool:
+    return batch_class in SCALE_FIRST_BATCH_CLASSES
+
+
+def build_batch_scale_summary(
+    *,
+    environment_rows: int,
+    simulator_ticks: int,
+    wall_clock_seconds: float | int | None = None,
+    asg_active_seconds: float | int | None = None,
+    cost_estimate: Any | None = None,
+    basis: str | None = None,
+) -> JsonObject:
+    """Return report-ready batch scale evidence with optional utilization fields."""
+    rows = require_non_negative_int(environment_rows, "environment_rows")
+    ticks = require_non_negative_int(simulator_ticks, "simulator_ticks")
+    batch_class = classify_batch_scale(rows, ticks)
+    summary: JsonObject = {
+        "batchClass": batch_class,
+        "environmentRows": rows,
+        "simulatorTicks": ticks,
+        "scaleFirstEligible": scale_first_eligible(batch_class),
+        "scaleFirstMinimumClass": BATCH_CLASS_VALIDATION,
+        "thresholds": batch_scale_thresholds(),
+    }
+    if basis:
+        summary["basis"] = basis
+    wall_seconds = non_negative_float(wall_clock_seconds)
+    if wall_seconds is not None:
+        summary["wallClockSeconds"] = round_float(wall_seconds)
+    active_seconds = non_negative_float(asg_active_seconds)
+    if active_seconds is not None:
+        summary["asgActiveSeconds"] = round_float(active_seconds)
+    if wall_seconds is not None and active_seconds is not None and active_seconds > 0:
+        summary["utilizationRatio"] = round_float(wall_seconds / active_seconds)
+    if cost_estimate is not None:
+        summary["costEstimate"] = cost_estimate
+    return summary
+
+
+def batch_scale_thresholds() -> JsonObject:
+    return {
+        BATCH_CLASS_SMOKE: {
+            "environmentRows": f"<{SMOKE_ENVIRONMENT_ROWS}",
+            "simulatorTicks": f"<{SMOKE_SIMULATOR_TICKS}",
+            "operator": "OR",
+        },
+        BATCH_CLASS_INTERMEDIATE: {
+            "environmentRows": f">={SMOKE_ENVIRONMENT_ROWS} and <{VALIDATION_ENVIRONMENT_ROWS}",
+            "simulatorTicks": f">={SMOKE_SIMULATOR_TICKS} and <{VALIDATION_SIMULATOR_TICKS}",
+            "operator": "above smoke but below validation",
+        },
+        BATCH_CLASS_VALIDATION: {
+            "environmentRows": f">={VALIDATION_ENVIRONMENT_ROWS}",
+            "simulatorTicks": f">={VALIDATION_SIMULATOR_TICKS}",
+            "operator": "AND",
+        },
+        BATCH_CLASS_NORMAL_SCALE: {
+            "environmentRows": f">={NORMAL_SCALE_ENVIRONMENT_ROWS}",
+            "simulatorTicks": f">={NORMAL_SCALE_SIMULATOR_TICKS}",
+            "operator": "AND",
+        },
+        BATCH_CLASS_LARGE_CAMPAIGN: {
+            "environmentRows": f">={LARGE_CAMPAIGN_ENVIRONMENT_ROWS}",
+            "simulatorTicks": f">={LARGE_CAMPAIGN_SIMULATOR_TICKS}",
+            "operator": "AND",
+        },
+    }
+
+
+def require_non_negative_int(value: Any, label: str) -> int:
+    parsed = non_negative_int(value)
+    if parsed is None:
+        raise ValueError(f"{label} must be a non-negative integer")
+    return parsed
+
+
+def non_negative_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and value >= 0:
+        return value
+    if isinstance(value, float) and math.isfinite(value) and value.is_integer() and value >= 0:
+        return int(value)
+    if isinstance(value, str):
+        try:
+            parsed = int(value)
+        except ValueError:
+            return None
+        return parsed if parsed >= 0 else None
+    return None
+
+
+def non_negative_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)) and math.isfinite(value) and value >= 0:
+        return float(value)
+    if isinstance(value, str):
+        try:
+            parsed = float(value)
+        except ValueError:
+            return None
+        return parsed if math.isfinite(parsed) and parsed >= 0 else None
+    return None
+
+
+def round_float(value: float) -> float:
+    return round(float(value), 6)

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -25,6 +25,7 @@ from screeps_rl_experiment_card import (
 import screeps_rl_dataset_export as dataset_export
 import screeps_secret_env
 import screeps_rl_simulator_harness as simulator_harness
+import screeps_rl_scale_gates as scale_gates
 
 
 SCHEMA_VERSION = 1
@@ -1009,6 +1010,13 @@ def build_training_report(
     ranking_diff_count = sum(1 for item in pairwise if item.get("winner") and item["winner"] not in incumbent_ids)
     warnings = build_report_warnings(results, simulator_runs)
     scale_validation = build_scale_validation_summary(simulator_runs, config)
+    artifact_count = sum(result["sampleCount"] for result in results)
+    batch_scale = scale_gates.build_batch_scale_summary(
+        environment_rows=artifact_count,
+        simulator_ticks=training_simulator_ticks(simulator_runs),
+        wall_clock_seconds=training_wall_clock_seconds(simulator_runs),
+        basis="training_report",
+    )
     policy_gradient = policy_gradient_metadata_from_card(card)
     if (
         policy_gradient is not None
@@ -1064,7 +1072,8 @@ def build_training_report(
         "strategyVariants": [variant.to_json() for variant in variants],
         "candidateStrategyIds": [variant.id for variant in variants],
         "incumbentStrategyIds": incumbent_ids,
-        "artifactCount": sum(result["sampleCount"] for result in results),
+        "artifactCount": artifact_count,
+        "batchScale": batch_scale,
         "variantResults": results,
         "ranking": ranking,
         "statisticalComparison": {
@@ -1124,6 +1133,50 @@ def build_training_report(
             report["policyUpdateCandidatePolicyId"] = text_or_none(next_candidate_policy.get("candidatePolicyId"))
         report["policyUpdate"] = policy_update
     return report
+
+
+def training_simulator_ticks(simulator_runs: Sequence[JsonObject]) -> int:
+    total = 0
+    for run in simulator_runs:
+        run_total = int_or_none(run.get("total_ticks", run.get("totalTicks"))) if isinstance(run, dict) else None
+        if run_total is not None:
+            total += run_total
+            continue
+        variants = run.get("variants") if isinstance(run, dict) else None
+        if not isinstance(variants, list):
+            continue
+        for variant in variants:
+            if not isinstance(variant, dict):
+                continue
+            total += int_or_none(variant.get("ticks_run", variant.get("ticksRun"))) or 0
+    return total
+
+
+def training_wall_clock_seconds(simulator_runs: Sequence[JsonObject]) -> float | None:
+    total = 0.0
+    observed = False
+    for run in simulator_runs:
+        if not isinstance(run, dict):
+            continue
+        run_wall = number_or_none(run.get("wallClockSeconds", run.get("wall_clock_seconds")))
+        if run_wall is not None:
+            total += float(run_wall)
+            observed = True
+            continue
+        variants = run.get("variants")
+        if not isinstance(variants, list):
+            continue
+        variant_wall = [
+            float(value)
+            for variant in variants
+            if isinstance(variant, dict)
+            for value in [number_or_none(variant.get("wall_clock_seconds", variant.get("wallClockSeconds")))]
+            if value is not None
+        ]
+        if variant_wall:
+            total += max(variant_wall)
+            observed = True
+    return total if observed else None
 
 
 def build_policy_update(
@@ -3303,6 +3356,7 @@ def build_generation_summary(report: JsonObject) -> JsonObject:
         "incumbentStrategyIds": report["incumbentStrategyIds"],
         "topVariantId": report["ranking"][0]["variantId"] if report["ranking"] else None,
         "artifactCount": report["artifactCount"],
+        "batchScale": copy.deepcopy(report.get("batchScale")),
         "changedTopCount": report["changedTopCount"],
         "policyUpdateIterations": report.get("policyUpdateIterations", 0),
         "policyUpdateAlgorithm": report.get("policyUpdateAlgorithm"),

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -41,6 +41,7 @@ from screeps_rl_experiment_card import (
     multi_tier_scenario_fixture_summary,
     scenario_supports_multi_tier_policy_comparison,
 )
+import screeps_rl_scale_gates as scale_gates
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_TCCLI = Path("/root/.hermes/hermes-agent/venv/bin/tccli")
@@ -224,6 +225,7 @@ class Controller:
         training_report = self.result.get("trainingReport")
         report_safety = training_report if isinstance(training_report, dict) else {}
         execution = controller_execution_summary(self.args, self.steps, self.result, self.scaled_up, self.instance_id)
+        batch_scale = controller_batch_scale_summary(self.args, self.steps, self.result)
         payload = {
             "type": "screeps-tencent-batch-rl-run",
             "schemaVersion": 1,
@@ -241,6 +243,7 @@ class Controller:
             "remoteDir": self.remote_dir,
             "localArtifactDir": str(self.artifact_dir),
             "execution": execution,
+            "batchScale": batch_scale,
             "safety": {
                 "liveEffect": report_safety.get("liveEffect", False),
                 "officialMmoWrites": report_safety.get("officialMmoWrites", False),
@@ -262,6 +265,7 @@ class Controller:
                 "trainingApproach": self.args.training_approach,
                 "scenarioId": getattr(self.args, "scenario_id", DEFAULT_SCENARIO_ID),
                 "requireMultiTierScenario": getattr(self.args, "require_multi_tier_scenario", False),
+                "plannedBatchScale": planned_batch_scale_from_args(self.args),
             },
             "outputs": self.result,
             "steps": [step.__dict__ for step in self.steps],
@@ -906,6 +910,7 @@ tar -czf remote-artifacts.tar.gz \
         artifact_count = data.get("artifactCount")
         if not isinstance(artifact_count, int) or artifact_count <= 0:
             raise BatchRunError(f"remote training artifactCount invalid: {artifact_count!r}")
+        batch_scale = batch_scale_summary_from_training_report(data, artifact_count)
         scale_environments = resolve_scale_environment_count(self.args)
         scale_validation = data.get("scaleValidation")
         if scale_environments is not None:
@@ -916,6 +921,7 @@ tar -czf remote-artifacts.tar.gz \
             "reportId": data.get("reportId"),
             **safety_flags,
             "artifactCount": artifact_count,
+            "batchScale": batch_scale,
             "changedTopCount": data.get("changedTopCount"),
             **policy_update_fields,
             "ranking": data.get("ranking"),
@@ -1068,6 +1074,165 @@ def controller_execution_summary(
         "artifactCount": training_report_data.get("artifactCount"),
         "environmentsRun": environments_run,
     }
+
+
+def controller_batch_scale_summary(
+    args: argparse.Namespace,
+    steps: Sequence[StepRecord],
+    result: dict[str, Any],
+) -> dict[str, Any]:
+    training_report = result.get("trainingReport")
+    report_data = training_report if isinstance(training_report, dict) else {}
+    report_scale = dict_value(report_data.get("batchScale"))
+    planned_scale = planned_batch_scale_from_args(args)
+    basis = "training_report" if report_scale is not None else "requested_inputs"
+    source = report_scale or planned_scale
+    environment_rows = scale_gates.non_negative_int(source.get("environmentRows")) or 0
+    simulator_ticks = scale_gates.non_negative_int(source.get("simulatorTicks")) or 0
+    wall_seconds = remote_training_wall_seconds(steps)
+    if wall_seconds is None:
+        wall_seconds = scale_gates.non_negative_float(source.get("wallClockSeconds"))
+    cost_estimate = cost_estimate_from_result(result)
+    if cost_estimate is None:
+        cost_estimate = source.get("costEstimate")
+    return scale_gates.build_batch_scale_summary(
+        environment_rows=environment_rows,
+        simulator_ticks=simulator_ticks,
+        wall_clock_seconds=wall_seconds,
+        asg_active_seconds=asg_active_seconds(steps),
+        cost_estimate=cost_estimate,
+        basis=basis,
+    )
+
+
+def planned_batch_scale_from_args(args: argparse.Namespace) -> dict[str, Any]:
+    repetitions = max(1, int(getattr(args, "repetitions", 1) or 1))
+    environment_count = resolve_scale_environment_count(args)
+    if environment_count is None:
+        environment_count = max(1, int(getattr(args, "workers", 1) or 1))
+    environment_rows = environment_count * repetitions
+    return scale_gates.build_batch_scale_summary(
+        environment_rows=environment_rows,
+        simulator_ticks=environment_rows * effective_training_ticks(args),
+        basis="requested_inputs",
+    )
+
+
+def batch_scale_summary_from_training_report(
+    data: dict[str, Any],
+    artifact_count: int,
+) -> dict[str, Any]:
+    raw_batch_scale = dict_value(data.get("batchScale"))
+    environment_rows = (
+        scale_gates.non_negative_int(path_value(raw_batch_scale, "environmentRows"))
+        if raw_batch_scale is not None
+        else None
+    )
+    simulator_ticks = (
+        scale_gates.non_negative_int(path_value(raw_batch_scale, "simulatorTicks"))
+        if raw_batch_scale is not None
+        else None
+    )
+    wall_seconds = (
+        scale_gates.non_negative_float(path_value(raw_batch_scale, "wallClockSeconds"))
+        if raw_batch_scale is not None
+        else None
+    )
+    if environment_rows is None:
+        environment_rows = artifact_count
+    if simulator_ticks is None:
+        simulator_ticks = training_report_simulator_ticks(data, environment_rows)
+    return scale_gates.build_batch_scale_summary(
+        environment_rows=environment_rows,
+        simulator_ticks=simulator_ticks,
+        wall_clock_seconds=wall_seconds,
+        basis="training_report",
+    )
+
+
+def training_report_simulator_ticks(data: dict[str, Any], environment_rows: int) -> int:
+    total = 0
+    for result in list_value(data.get("variantResults")):
+        if not isinstance(result, dict):
+            continue
+        for run in list_value(result.get("runs")):
+            if not isinstance(run, dict):
+                continue
+            total += scale_gates.non_negative_int(run.get("ticksRun", run.get("ticks_run"))) or 0
+    if total > 0:
+        return total
+    ticks_per_row = scale_gates.non_negative_int(path_value(data, "simulation", "ticks")) or 0
+    return environment_rows * ticks_per_row
+
+
+def remote_training_wall_seconds(steps: Sequence[StepRecord]) -> float | None:
+    durations = [
+        duration
+        for step in steps
+        if step.name == "remote_training"
+        for duration in [step_duration_seconds(step)]
+        if duration is not None
+    ]
+    return sum(durations) if durations else None
+
+
+def asg_active_seconds(steps: Sequence[StepRecord]) -> float | None:
+    starts = [
+        value
+        for step in steps
+        if step.name == "scale_up"
+        for value in [parse_iso_epoch(step.started_at)]
+        if value is not None
+    ]
+    ends = [
+        value
+        for step in steps
+        if step.name == "scale_down"
+        for value in [parse_iso_epoch(step.ended_at)]
+        if value is not None
+    ]
+    if not starts or not ends:
+        return None
+    active = max(ends) - min(starts)
+    return active if active >= 0 else None
+
+
+def step_duration_seconds(step: StepRecord) -> float | None:
+    started = parse_iso_epoch(step.started_at)
+    ended = parse_iso_epoch(step.ended_at)
+    if started is None or ended is None:
+        return None
+    duration = ended - started
+    return duration if duration >= 0 else None
+
+
+def parse_iso_epoch(value: Any) -> float | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return dt.datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def cost_estimate_from_result(result: dict[str, Any]) -> Any | None:
+    guard = dict_value(result.get("billingGuard"))
+    if guard is None:
+        return None
+    for path in (
+        ("costEstimate",),
+        ("cost_estimate",),
+        ("estimatedCost",),
+        ("estimated_cost",),
+        ("estimatedCostUsd",),
+        ("estimatedCostCny",),
+        ("maxCostUsd",),
+        ("max_cost_usd",),
+    ):
+        value = path_value(guard, *path)
+        if value is not None:
+            return value
+    return None
 
 
 def training_environments_run(training_report: dict[str, Any]) -> int:

--- a/scripts/test_screeps_rl_live_dashboard.py
+++ b/scripts/test_screeps_rl_live_dashboard.py
@@ -209,11 +209,16 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
         self.assertEqual(summary["loopB"]["onlineUtilityStatus"], "PROVEN")
         self.assertEqual(summary["loopB"]["scorecard"]["status"], "PASS")
         self.assertEqual(summary["tencentBatch"]["latest"]["runId"], "tencent-live")
+        self.assertEqual(summary["tencentBatch"]["latest"]["batchScale"]["batchClass"], "smoke")
+        self.assertEqual(summary["tencentBatch"]["latest"]["batchScale"]["environmentRows"], 25)
+        self.assertEqual(summary["tencentBatch"]["latest"]["batchScale"]["simulatorTicks"], 12500)
+        self.assertFalse(summary["tencentBatch"]["latest"]["batchScale"]["scaleFirstEligible"])
         self.assertEqual(summary["safety"]["status"], "OK")
         self.assertIn("E1 Gate Acceptance", html)
         self.assertIn("Loop A Env Ticks Episodes", html)
         self.assertIn("Loop B Utility Scorecard", html)
         self.assertIn("Tencent Batch Utilization", html)
+        self.assertIn("Latest batch class", html)
         self.assertIn("Safety Flags", html)
 
     def test_missing_tencent_safety_object_blocks_dashboard(self) -> None:

--- a/scripts/test_screeps_rl_scale_gates.py
+++ b/scripts/test_screeps_rl_scale_gates.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import screeps_rl_scale_gates as gates
+
+
+class RlScaleGatesTest(unittest.TestCase):
+    def test_classifies_threshold_boundaries(self) -> None:
+        cases = (
+            ("env-row-smoke", 49, 1_600_000, "smoke"),
+            ("tick-smoke", 800, 49_999, "smoke"),
+            ("minimum-intermediate", 50, 50_000, "intermediate"),
+            ("env-row-below-validation", 199, 1_600_000, "intermediate"),
+            ("tick-below-validation", 800, 199_999, "intermediate"),
+            ("validation-floor", 200, 200_000, "validation"),
+            ("env-row-below-normal", 399, 400_000, "validation"),
+            ("tick-below-normal", 400, 399_999, "validation"),
+            ("normal-scale-floor", 400, 400_000, "normal-scale"),
+            ("env-row-below-large", 799, 1_600_000, "normal-scale"),
+            ("tick-below-large", 800, 1_599_999, "normal-scale"),
+            ("large-campaign-floor", 800, 1_600_000, "large-campaign"),
+        )
+        for name, rows, ticks, expected in cases:
+            with self.subTest(name=name):
+                self.assertEqual(gates.classify_batch_scale(rows, ticks), expected)
+
+    def test_only_validation_and_larger_batches_are_scale_first_eligible(self) -> None:
+        self.assertFalse(gates.scale_first_eligible("smoke"))
+        self.assertFalse(gates.scale_first_eligible("intermediate"))
+        self.assertTrue(gates.scale_first_eligible("validation"))
+        self.assertTrue(gates.scale_first_eligible("normal-scale"))
+        self.assertTrue(gates.scale_first_eligible("large-campaign"))
+
+    def test_summary_includes_utilization_when_wall_and_asg_time_are_available(self) -> None:
+        summary = gates.build_batch_scale_summary(
+            environment_rows=200,
+            simulator_ticks=200_000,
+            wall_clock_seconds=120,
+            asg_active_seconds=600,
+            cost_estimate={"currency": "USD", "amount": 0.25},
+        )
+
+        self.assertEqual(summary["batchClass"], "validation")
+        self.assertTrue(summary["scaleFirstEligible"])
+        self.assertEqual(summary["utilizationRatio"], 0.2)
+        self.assertEqual(summary["costEstimate"], {"currency": "USD", "amount": 0.25})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_screeps_rl_scale_gates.py
+++ b/scripts/test_screeps_rl_scale_gates.py
@@ -37,6 +37,16 @@ class RlScaleGatesTest(unittest.TestCase):
         self.assertTrue(gates.scale_first_eligible("normal-scale"))
         self.assertTrue(gates.scale_first_eligible("large-campaign"))
 
+    def test_intermediate_threshold_descriptor_matches_classifier_logic(self) -> None:
+        threshold = gates.batch_scale_thresholds()["intermediate"]
+
+        self.assertEqual(threshold["environmentRows"], ">=50")
+        self.assertEqual(threshold["simulatorTicks"], ">=50000")
+        self.assertEqual(
+            threshold["operator"],
+            "AND with (environmentRows <200 OR simulatorTicks <200000)",
+        )
+
     def test_summary_includes_utilization_when_wall_and_asg_time_are_available(self) -> None:
         summary = gates.build_batch_scale_summary(
             environment_rows=200,

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -254,6 +254,28 @@ class RlTrainingRunnerTest(unittest.TestCase):
             report["warnings"],
         )
 
+    def test_training_report_classifies_default_smoke_batch_scale(self) -> None:
+        start = tick(1, [room("W1N1", energy=100)])
+        baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200)])])
+        candidate = variant_result("candidate", [start, tick(2, [room("W1N1", energy=250)])])
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            write_json(card_path, base_card())
+            report = runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="smoke-batch-scale",
+                simulator_runner=MockSimulator({"baseline": baseline, "candidate": candidate}),
+            )
+
+        self.assertEqual(report["batchScale"]["batchClass"], "smoke")
+        self.assertEqual(report["batchScale"]["environmentRows"], 2)
+        self.assertEqual(report["batchScale"]["simulatorTicks"], 4)
+        self.assertFalse(report["batchScale"]["scaleFirstEligible"])
+        self.assertEqual(runner.build_generation_summary(report)["batchScale"]["batchClass"], "smoke")
+
     def test_multi_tier_activation_proof_blocks_when_fixture_signal_has_no_objective_movement(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-training-multitier-blocked",

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -1018,6 +1018,45 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 "runtime-artifacts/rl-training/policy-candidates/run-test-next-policy.json",
             )
             self.assertFalse(summary["outputs"]["trainingReport"]["policyUpdate"]["liveEffect"])
+            self.assertEqual(summary["outputs"]["trainingReport"]["batchScale"]["batchClass"], "smoke")
+            self.assertFalse(summary["outputs"]["trainingReport"]["batchScale"]["scaleFirstEligible"])
+            self.assertEqual(summary["batchScale"]["batchClass"], "smoke")
+
+    def test_verify_remote_training_report_records_smoke_batch_scale_from_simulator_ticks(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            report = runner.remote_training_report_path(root, "run-test")
+            report.parent.mkdir(parents=True, exist_ok=True)
+            report.write_text(
+                json.dumps(
+                    {
+                        "reportId": "run-test",
+                        "liveEffect": False,
+                        "officialMmoWrites": False,
+                        "officialMmoWritesAllowed": False,
+                        "artifactCount": 5,
+                        "simulation": {"ticks": 500},
+                        "variantResults": [
+                            {"variantId": f"variant-{index}", "runs": [{"ticksRun": 500, "ok": True}]}
+                            for index in range(5)
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            controller = runner.Controller(args=controller_args(), run_id="run-test", artifact_dir=root)
+            controller.verify_remote_training_report()
+            controller.write_summary()
+
+            summary = json.loads((root / "controller-summary.json").read_text(encoding="utf-8"))
+
+        batch_scale = summary["outputs"]["trainingReport"]["batchScale"]
+        self.assertEqual(batch_scale["batchClass"], "smoke")
+        self.assertEqual(batch_scale["environmentRows"], 5)
+        self.assertEqual(batch_scale["simulatorTicks"], 2500)
+        self.assertFalse(batch_scale["scaleFirstEligible"])
+        self.assertEqual(summary["batchScale"]["batchClass"], "smoke")
+        self.assertEqual(summary["batchScale"]["basis"], "training_report")
 
     def test_e1s1_repeat_launch_guard_blocks_after_three_dead_tier_runs(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- Adds a reusable RL scale-gate classifier for Tencent/runner evidence so smoke-sized runs cannot be mislabeled as scale-first training.
- Wires batch class / scale evidence into RL training, Tencent batch, and dashboard/report surfaces.
- Adds focused tests for threshold boundaries and report wiring.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_scale_gates.py scripts/screeps_rl_live_dashboard.py scripts/screeps_rl_training_runner.py scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_rl_scale_gates.py scripts/test_screeps_rl_live_dashboard.py scripts/test_screeps_rl_training_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts.test_screeps_rl_scale_gates scripts.test_screeps_rl_live_dashboard scripts.test_screeps_rl_training_runner scripts.test_screeps_tencent_batch_rl_runner -v` (133 tests)

## Safety
- Classification/reporting only; no official MMO writes.
- Keeps `liveEffect=false`, `officialMmoWrites=false`, and `officialMmoWritesAllowed=false` as required safety boundaries.

Fixes #1236
Updates #1032
Updates #879
