### PR TITLE
fix(rl): restore live observability dashboard health

### DIFF
--- a/docs/ops/rl-live-dashboard-runbook.md
+++ b/docs/ops/rl-live-dashboard-runbook.md
@@ -1,6 +1,6 @@
 # RL Live Dashboard Runbook
 
-Status: issue #1184 live observability surface for the #879 RL evidence loop.
+Status: issue #1237 live observability surface for the #879 RL evidence loop. This supersedes the one-time #1184 local foundation without reopening it.
 
 This repository keeps the Grafana JSON dashboard in `docs/ops/grafana/`, but the checked-in live surface is a dependency-light local service so it does not require a Grafana SQLite plugin, external network access, or secrets.
 
@@ -18,10 +18,10 @@ Refresh the SQLite store with the existing ingestor:
 npm run rl-metrics-refresh
 ```
 
-Start the live dashboard and refresh once before serving:
+Start the live dashboard. The npm command refreshes once before serving and then refreshes SQLite every 300 seconds while the process is running:
 
 ```bash
-npm run rl-dashboard-live -- --refresh-on-start
+npm run rl-dashboard-live
 ```
 
 Default dashboard URL:
@@ -48,6 +48,16 @@ Equivalent direct check:
 python3 scripts/screeps_rl_live_dashboard.py healthcheck --url http://127.0.0.1:8790/healthz
 ```
 
+Expected healthy output includes JSON with `"ok": true` and `"message": "OK"`. The command checks the running local dashboard, so start `npm run rl-dashboard-live` first.
+
+For a one-shot foreground start with an explicit cadence:
+
+```bash
+python3 scripts/screeps_rl_live_dashboard.py serve \
+  --refresh-on-start \
+  --auto-refresh-seconds 300
+```
+
 Trigger a local refresh through the running service only after starting it with `--enable-refresh-endpoint`:
 
 ```bash
@@ -67,6 +77,21 @@ The live page and `/api/summary` cover:
 | Tencent batch utilization | Latest controller summaries under `runtime-artifacts/tencent-cloud/batch-runs/`. |
 | Safety flags | Tencent run safety flags, required scorecard evidence, scorecard safety regressions, and card-supply status. |
 | SQLite freshness | Required table presence, row counts, and latest observation timestamp from `rl_metrics.sqlite`. |
+| #879 flywheel stages | Explicit construction-landed, training-running, online-proven, and self-iterating states. |
+| Project gates | Local evidence status for #879, #1032, #1229, #1233, and #1234. |
+| #924 scorecard | Latest scorecard status, required actions, missing evidence, safety regressions, candidate, and baseline. |
+
+Owner evidence for #879 can be copied from `/api/summary`:
+
+```text
+dashboardUrl
+db.path
+db.latestObservedAt
+db.tables
+refresh.lastRefreshAt
+```
+
+The same fields are visible on the HTML dashboard under Metrics Store and SQLite Table Counts.
 
 The static HTML dashboard remains available through:
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "rl-dashboard": "python3 scripts/screeps_rl_dashboard.py",
-    "rl-dashboard-live": "python3 scripts/screeps_rl_live_dashboard.py serve",
+    "rl-dashboard-live": "python3 scripts/screeps_rl_live_dashboard.py serve --refresh-on-start --auto-refresh-seconds 300",
     "rl-dashboard-live:health": "python3 scripts/screeps_rl_live_dashboard.py healthcheck",
     "rl-metrics-refresh": "python3 scripts/screeps_rl_metrics_ingestor.py ingest-artifacts"
   },

--- a/scripts/screeps_rl_live_dashboard.py
+++ b/scripts/screeps_rl_live_dashboard.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Iterable, Iterator, Sequence
 from urllib.parse import urlparse
 
 import screeps_rl_dashboard as static_dashboard
@@ -58,6 +58,7 @@ RUNTIME_INJECTION_SCOPE_KEYS = {"candidateparameterscope"}
 RUNTIME_INJECTION_METADATA_ONLY_VALUES = {"metadataonly"}
 
 JsonObject = dict[str, Any]
+ArtifactJson = tuple[Path, JsonObject, datetime]
 
 
 @dataclass(frozen=True)
@@ -407,6 +408,20 @@ def health_from_db_summary(db: JsonObject) -> JsonObject:
     }
 
 
+def health_with_refresh(db_health: JsonObject, refresh: JsonObject) -> JsonObject:
+    failures = list(as_list(db_health.get("failures")))
+    if refresh.get("mode") == "auto" and (
+        refresh.get("lastRefreshOk") is not True or not refresh.get("lastRefreshAt")
+    ):
+        failures.append("auto-refresh has not completed successfully")
+    ok = not failures
+    return {
+        "ok": ok,
+        "status": "ok" if ok else "degraded",
+        "failures": failures,
+    }
+
+
 def default_ingest_paths(artifact_root: Path) -> list[Path]:
     return [artifact_root / subdir for subdir in DEFAULT_ARTIFACT_SUBDIRS]
 
@@ -599,8 +614,7 @@ def safety_summary(dashboard: JsonObject, tencent: JsonObject, scorecard: JsonOb
     }
 
 
-def scan_artifact_json(artifact_root: Path) -> list[tuple[Path, JsonObject, datetime]]:
-    artifacts: list[tuple[Path, JsonObject, datetime]] = []
+def scan_artifact_json(artifact_root: Path) -> Iterator[ArtifactJson]:
     roots = (
         artifact_root / "rl-control-loop",
         artifact_root / "rl-training",
@@ -615,52 +629,76 @@ def scan_artifact_json(artifact_root: Path) -> list[tuple[Path, JsonObject, date
             payload = load_json_object(path)
             if payload is None:
                 continue
-            artifacts.append((path, payload, artifact_timestamp(path, payload)))
-    return sorted(artifacts, key=lambda item: item[2], reverse=True)
+            yield path, payload, artifact_timestamp(path, payload)
 
 
-def runtime_candidate_injection_summary(artifact_root: Path, repo_root: Path) -> JsonObject:
-    explicit_false: list[JsonObject] = []
-    metadata_only: list[JsonObject] = []
-    for path, payload, timestamp in scan_artifact_json(artifact_root):
-        for node in iter_json_objects(payload):
-            for key, value in node.items():
-                normalized = normalized_key(key)
-                if normalized in RUNTIME_INJECTION_TRUE_KEYS and value is True:
-                    return {
+def newest_summary(current: JsonObject | None, candidate: JsonObject | None) -> JsonObject | None:
+    if candidate is None:
+        return current
+    if current is None:
+        return candidate
+    current_timestamp = parse_iso_datetime(current.get("updatedAt"))
+    candidate_timestamp = parse_iso_datetime(candidate.get("updatedAt"))
+    if current_timestamp is None:
+        return candidate
+    if candidate_timestamp is None:
+        return current
+    return candidate if candidate_timestamp > current_timestamp else current
+
+
+def runtime_candidate_injection_from_artifact(
+    path: Path,
+    payload: JsonObject,
+    timestamp: datetime,
+    repo_root: Path,
+) -> JsonObject | None:
+    blocked: JsonObject | None = None
+    ok: JsonObject | None = None
+    display_path = safe_display_path(path, repo_root)
+    updated_at = display_timestamp(timestamp)
+    for node in iter_json_objects(payload):
+        for key, value in node.items():
+            normalized = normalized_key(key)
+            if normalized in RUNTIME_INJECTION_TRUE_KEYS:
+                if value is True and ok is None:
+                    ok = {
                         "status": "OK",
                         "evidence": f"{key}=true",
-                        "latestPath": safe_display_path(path, repo_root),
-                        "updatedAt": display_timestamp(timestamp),
+                        "latestPath": display_path,
+                        "updatedAt": updated_at,
                     }
-                if normalized in RUNTIME_INJECTION_TRUE_KEYS and value is False:
-                    explicit_false.append(
-                        {
-                            "field": key,
-                            "value": value,
-                            "path": safe_display_path(path, repo_root),
-                            "updatedAt": display_timestamp(timestamp),
-                        }
-                    )
-                if normalized in RUNTIME_INJECTION_SCOPE_KEYS:
-                    scope = text_value(value)
-                    if scope is not None and normalized_key(scope) in RUNTIME_INJECTION_METADATA_ONLY_VALUES:
-                        metadata_only.append(
-                            {
-                                "field": key,
-                                "value": value,
-                                "path": safe_display_path(path, repo_root),
-                                "updatedAt": display_timestamp(timestamp),
-                            }
-                        )
-    if explicit_false or metadata_only:
-        evidence = explicit_false[0] if explicit_false else metadata_only[0]
-        return {
-            "status": "BLOCKED",
-            "evidence": f"{evidence['field']}={evidence['value']}",
-            "latestPath": evidence["path"],
-            "updatedAt": evidence["updatedAt"],
-        }
+                if value is False and blocked is None:
+                    blocked = {
+                        "status": "BLOCKED",
+                        "evidence": f"{key}={value}",
+                        "latestPath": display_path,
+                        "updatedAt": updated_at,
+                    }
+            if normalized in RUNTIME_INJECTION_SCOPE_KEYS:
+                scope = text_value(value)
+                if (
+                    scope is not None
+                    and normalized_key(scope) in RUNTIME_INJECTION_METADATA_ONLY_VALUES
+                    and blocked is None
+                ):
+                    blocked = {
+                        "status": "BLOCKED",
+                        "evidence": f"{key}={value}",
+                        "latestPath": display_path,
+                        "updatedAt": updated_at,
+                    }
+    return blocked or ok
+
+
+def runtime_candidate_injection_summary_from_artifacts(
+    artifacts: Iterable[ArtifactJson],
+    repo_root: Path,
+) -> JsonObject:
+    latest: JsonObject | None = None
+    for path, payload, timestamp in artifacts:
+        latest = newest_summary(latest, runtime_candidate_injection_from_artifact(path, payload, timestamp, repo_root))
+    if latest is not None:
+        return latest
     return {
         "status": "N/A",
         "evidence": "no runtime candidate injection evidence found",
@@ -669,48 +707,101 @@ def runtime_candidate_injection_summary(artifact_root: Path, repo_root: Path) ->
     }
 
 
-def zero_iteration_policy_update_summary(artifact_root: Path, repo_root: Path) -> JsonObject:
-    for path, payload, timestamp in scan_artifact_json(artifact_root):
-        for node in iter_json_objects(payload):
-            iterations = node.get("policyUpdateIterations")
-            policy_update = node.get("policyUpdate")
-            if iterations is None and not isinstance(policy_update, dict):
-                continue
-            if iterations == 0:
-                if not isinstance(policy_update, dict):
-                    return {
-                        "status": "OK",
-                        "evidence": "zero policy updates with no update artifact",
-                        "latestPath": safe_display_path(path, repo_root),
-                        "updatedAt": display_timestamp(timestamp),
-                    }
-                skipped = text_value(policy_update.get("skippedReason"))
-                if skipped and not node.get("policyUpdateArtifactPath"):
-                    return {
-                        "status": "OK",
-                        "evidence": f"safe zero-iteration no-op: {skipped}",
-                        "latestPath": safe_display_path(path, repo_root),
-                        "updatedAt": display_timestamp(timestamp),
-                    }
+def runtime_candidate_injection_summary(artifact_root: Path, repo_root: Path) -> JsonObject:
+    return runtime_candidate_injection_summary_from_artifacts(scan_artifact_json(artifact_root), repo_root)
+
+
+def zero_iteration_policy_update_from_artifact(
+    path: Path,
+    payload: JsonObject,
+    timestamp: datetime,
+    repo_root: Path,
+) -> JsonObject | None:
+    display_path = safe_display_path(path, repo_root)
+    updated_at = display_timestamp(timestamp)
+    for node in iter_json_objects(payload):
+        iterations = node.get("policyUpdateIterations")
+        policy_update = node.get("policyUpdate")
+        if iterations is None and not isinstance(policy_update, dict):
+            continue
+        if iterations == 0:
+            if not isinstance(policy_update, dict):
                 return {
-                    "status": "BLOCKED",
-                    "evidence": "zero-iteration policy update lacks safe skippedReason or has update artifact",
-                    "latestPath": safe_display_path(path, repo_root),
-                    "updatedAt": display_timestamp(timestamp),
+                    "status": "OK",
+                    "evidence": "zero policy updates with no update artifact",
+                    "latestPath": display_path,
+                    "updatedAt": updated_at,
                 }
-            if isinstance(iterations, (int, float)) and iterations > 0:
+            skipped = text_value(policy_update.get("skippedReason"))
+            if skipped and not node.get("policyUpdateArtifactPath"):
                 return {
-                    "status": "N/A",
-                    "evidence": f"latest policy update had {iterations} iteration(s)",
-                    "latestPath": safe_display_path(path, repo_root),
-                    "updatedAt": display_timestamp(timestamp),
+                    "status": "OK",
+                    "evidence": f"safe zero-iteration no-op: {skipped}",
+                    "latestPath": display_path,
+                    "updatedAt": updated_at,
                 }
+            return {
+                "status": "BLOCKED",
+                "evidence": "zero-iteration policy update lacks safe skippedReason or has update artifact",
+                "latestPath": display_path,
+                "updatedAt": updated_at,
+            }
+        if isinstance(iterations, (int, float)) and iterations > 0:
+            return {
+                "status": "N/A",
+                "evidence": f"latest policy update had {iterations} iteration(s)",
+                "latestPath": display_path,
+                "updatedAt": updated_at,
+            }
+    return None
+
+
+def zero_iteration_policy_update_summary_from_artifacts(
+    artifacts: Iterable[ArtifactJson],
+    repo_root: Path,
+) -> JsonObject:
+    latest: JsonObject | None = None
+    for path, payload, timestamp in artifacts:
+        latest = newest_summary(latest, zero_iteration_policy_update_from_artifact(path, payload, timestamp, repo_root))
+    if latest is not None:
+        return latest
     return {
         "status": "N/A",
         "evidence": "no policy update evidence found",
         "latestPath": None,
         "updatedAt": None,
     }
+
+
+def zero_iteration_policy_update_summary(artifact_root: Path, repo_root: Path) -> JsonObject:
+    return zero_iteration_policy_update_summary_from_artifacts(scan_artifact_json(artifact_root), repo_root)
+
+
+def artifact_evidence_summaries(artifact_root: Path, repo_root: Path) -> tuple[JsonObject, JsonObject]:
+    injection: JsonObject | None = None
+    zero_iteration: JsonObject | None = None
+    for path, payload, timestamp in scan_artifact_json(artifact_root):
+        injection = newest_summary(injection, runtime_candidate_injection_from_artifact(path, payload, timestamp, repo_root))
+        zero_iteration = newest_summary(
+            zero_iteration,
+            zero_iteration_policy_update_from_artifact(path, payload, timestamp, repo_root),
+        )
+    return (
+        injection
+        or {
+            "status": "N/A",
+            "evidence": "no runtime candidate injection evidence found",
+            "latestPath": None,
+            "updatedAt": None,
+        },
+        zero_iteration
+        or {
+            "status": "N/A",
+            "evidence": "no policy update evidence found",
+            "latestPath": None,
+            "updatedAt": None,
+        },
+    )
 
 
 def policy_status_is_online_proven(status: Any) -> bool:
@@ -777,6 +868,7 @@ def project_gate_summary(
     stage_statuses = {stage.get("stage"): stage.get("status") for stage in flywheel_stages}
     scale = latest_batch_scale(tencent)
     auto_refresh_ok = refresh.get("mode") == "auto" and refresh.get("autoRefreshSeconds")
+    successful_refresh = refresh.get("lastRefreshOk") is True and bool(refresh.get("lastRefreshAt"))
     refresh_cadence = (
         f"{refresh.get('autoRefreshSeconds')}s"
         if refresh.get("autoRefreshSeconds")
@@ -813,11 +905,15 @@ def project_gate_summary(
         {
             "issue": "#1233",
             "gate": "autonomous compute cadence",
-            "status": "OK" if auto_refresh_ok and tencent.get("hasData") else "BLOCKED",
-            "evidence": f"autoRefresh={refresh_cadence}; tencentRuns={tencent.get('runCount', 0)}",
+            "status": "OK" if auto_refresh_ok and successful_refresh and tencent.get("hasData") else "BLOCKED",
+            "evidence": (
+                f"autoRefresh={refresh_cadence}; lastRefreshOk={refresh.get('lastRefreshOk')}; "
+                f"lastRefreshAt={display_timestamp(refresh.get('lastRefreshAt'))}; "
+                f"tencentRuns={tencent.get('runCount', 0)}"
+            ),
             "nextAction": "keep dashboard auto-refresh and compute evidence alive"
-            if auto_refresh_ok and tencent.get("hasData")
-            else "restore recurring refresh/compute evidence",
+            if auto_refresh_ok and successful_refresh and tencent.get("hasData")
+            else "restore recurring refresh/compute evidence and confirm lastRefreshOk",
         },
         {
             "issue": "#1234",
@@ -856,8 +952,7 @@ def build_live_summary(
     scorecard = latest_scorecard_summary(artifact_root, repo_root)
     tencent = tencent_batch_summary(artifact_root, repo_root)
     safety = safety_summary(dashboard, tencent, scorecard)
-    injection = runtime_candidate_injection_summary(artifact_root, repo_root)
-    zero_iteration = zero_iteration_policy_update_summary(artifact_root, repo_root)
+    injection, zero_iteration = artifact_evidence_summaries(artifact_root, repo_root)
     flywheel_stages = flywheel_stage_summary(db=db, dashboard=dashboard, scorecard=scorecard, safety=safety)
     project_gates = project_gate_summary(
         flywheel_stages=flywheel_stages,
@@ -1234,16 +1329,20 @@ class LiveDashboardRequestHandler(BaseHTTPRequestHandler):
             self.write_json(HTTPStatus.OK, self.summary())
             return
         if parsed.path == "/healthz":
-            summary = self.summary()
-            status = HTTPStatus.OK if summary["health"]["ok"] else HTTPStatus.SERVICE_UNAVAILABLE
+            config = self.server.config
+            generated = utc_now_iso()
+            db = sqlite_summary(config.db_path, config.repo_root)
+            refresh = self.server.refresh_snapshot()
+            health = health_with_refresh(health_from_db_summary(db), refresh)
+            status = HTTPStatus.OK if health["ok"] else HTTPStatus.SERVICE_UNAVAILABLE
             self.write_json(
                 status,
-                summary["health"]
+                health
                 | {
-                    "message": "OK" if summary["health"]["ok"] else "DEGRADED",
-                    "db": summary["db"],
-                    "refresh": summary["refresh"],
-                    "generatedAt": summary["generatedAt"],
+                    "message": "OK" if health["ok"] else "DEGRADED",
+                    "db": db,
+                    "refresh": refresh,
+                    "generatedAt": generated,
                 },
             )
             return
@@ -1261,8 +1360,11 @@ class LiveDashboardRequestHandler(BaseHTTPRequestHandler):
             try:
                 refresh = refresh_metrics(self.server.config.db_path, self.server.config.artifact_root)
             except Exception as error:  # pragma: no cover - defensive handler boundary
-                self.write_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"ok": False, "error": str(error)})
+                refresh = {"ok": False, "error": str(error)}
+                self.server.record_refresh(refresh)
+                self.write_json(HTTPStatus.INTERNAL_SERVER_ERROR, refresh)
                 return
+        self.server.record_refresh(refresh)
         if not refresh_succeeded(refresh):
             self.write_json(
                 HTTPStatus.INTERNAL_SERVER_ERROR,

--- a/scripts/screeps_rl_live_dashboard.py
+++ b/scripts/screeps_rl_live_dashboard.py
@@ -129,7 +129,7 @@ class LiveDashboardHTTPServer(ThreadingHTTPServer):
                         refresh = refresh_metrics(self.config.db_path, self.config.artifact_root)
                     except Exception as error:  # pragma: no cover - defensive background loop boundary
                         refresh = {"ok": False, "error": str(error)}
-                self.record_refresh(refresh)
+                    self.record_refresh(refresh)
 
         self.refresh_thread = threading.Thread(target=refresh_loop, daemon=True, name="rl-dashboard-refresh")
         self.refresh_thread.start()
@@ -962,6 +962,7 @@ def build_live_summary(
     generated_at: str | None = None,
     dashboard_url: str | None = None,
     refresh: JsonObject | None = None,
+    db_summary: JsonObject | None = None,
 ) -> JsonObject:
     generated = generated_at or utc_now_iso()
     refresh_summary: JsonObject = refresh or {
@@ -972,7 +973,7 @@ def build_live_summary(
         "lastRefresh": None,
         "nextRefreshAt": None,
     }
-    db = sqlite_summary(db_path, repo_root)
+    db = db_summary if db_summary is not None else sqlite_summary(db_path, repo_root)
     health = health_with_refresh(health_from_db_summary(db), refresh_summary)
     raw_dashboard = static_dashboard.build_dashboard(repo_root=repo_root, artifact_root=artifact_root, generated_at=generated)
     dashboard = dashboard_json_safe(raw_dashboard, repo_root)
@@ -1358,9 +1359,10 @@ class LiveDashboardRequestHandler(BaseHTTPRequestHandler):
         if parsed.path == "/healthz":
             config = self.server.config
             generated = utc_now_iso()
-            db = sqlite_summary(config.db_path, config.repo_root)
-            refresh = self.server.refresh_snapshot()
-            health = health_with_refresh(health_from_db_summary(db), refresh)
+            with self.server.refresh_lock:
+                db = sqlite_summary(config.db_path, config.repo_root)
+                refresh = self.server.refresh_snapshot()
+                health = health_with_refresh(health_from_db_summary(db), refresh)
             status = HTTPStatus.OK if health["ok"] else HTTPStatus.SERVICE_UNAVAILABLE
             self.write_json(
                 status,
@@ -1383,15 +1385,17 @@ class LiveDashboardRequestHandler(BaseHTTPRequestHandler):
         if not self.server.config.enable_refresh_endpoint:
             self.write_json(HTTPStatus.FORBIDDEN, {"ok": False, "error": "refresh endpoint disabled"})
             return
+        refresh_raised = False
         with self.server.refresh_lock:
             try:
                 refresh = refresh_metrics(self.server.config.db_path, self.server.config.artifact_root)
             except Exception as error:  # pragma: no cover - defensive handler boundary
                 refresh = {"ok": False, "error": str(error)}
-                self.server.record_refresh(refresh)
-                self.write_json(HTTPStatus.INTERNAL_SERVER_ERROR, refresh)
-                return
-        self.server.record_refresh(refresh)
+                refresh_raised = True
+            self.server.record_refresh(refresh)
+        if refresh_raised:
+            self.write_json(HTTPStatus.INTERNAL_SERVER_ERROR, refresh)
+            return
         if not refresh_succeeded(refresh):
             self.write_json(
                 HTTPStatus.INTERNAL_SERVER_ERROR,
@@ -1406,12 +1410,16 @@ class LiveDashboardRequestHandler(BaseHTTPRequestHandler):
     def summary(self) -> JsonObject:
         config = self.server.config
         host, port = self.server.server_address[:2]
+        with self.server.refresh_lock:
+            db = sqlite_summary(config.db_path, config.repo_root)
+            refresh = self.server.refresh_snapshot()
         return build_live_summary(
             config.repo_root,
             config.artifact_root,
             config.db_path,
             dashboard_url=format_dashboard_url(str(host), int(port)),
-            refresh=self.server.refresh_snapshot(),
+            refresh=refresh,
+            db_summary=db,
         )
 
     def write_json(self, status: HTTPStatus, payload: JsonObject) -> None:

--- a/scripts/screeps_rl_live_dashboard.py
+++ b/scripts/screeps_rl_live_dashboard.py
@@ -13,7 +13,7 @@ import urllib.error
 import urllib.request
 from collections import Counter
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -28,6 +28,7 @@ import screeps_rl_scale_gates as scale_gates
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8790
 DEFAULT_REFRESH_SECONDS = 60
+DEFAULT_AUTO_REFRESH_SECONDS = 300
 DEFAULT_HEALTHCHECK_URL = f"http://{DEFAULT_HOST}:{DEFAULT_PORT}/healthz"
 REQUIRED_TABLES = (
     "metric_definitions",
@@ -47,6 +48,14 @@ DEFAULT_ARTIFACT_SUBDIRS = (
     "rl-training",
 )
 REQUIRED_TENCENT_SAFETY_FIELDS = ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed")
+REQUIRED_TENCENT_SHADOW_SAFETY_FIELDS = ("conservative_actions_only", "ood_rejection")
+RUNTIME_INJECTION_TRUE_KEYS = {
+    "runtimeparameterinjection",
+    "inlinecandidatesruntimeinjected",
+    "inlinecandidatesappliedtosimulator",
+}
+RUNTIME_INJECTION_SCOPE_KEYS = {"candidateparameterscope"}
+RUNTIME_INJECTION_METADATA_ONLY_VALUES = {"metadataonly"}
 
 JsonObject = dict[str, Any]
 
@@ -58,11 +67,13 @@ class LiveDashboardConfig:
     db_path: Path
     refresh_seconds: int = DEFAULT_REFRESH_SECONDS
     enable_refresh_endpoint: bool = False
+    auto_refresh_seconds: int = 0
 
 
 class LiveDashboardHTTPServer(ThreadingHTTPServer):
     config: LiveDashboardConfig
     refresh_lock: threading.Lock
+    refresh_state_lock: threading.Lock
 
     def __init__(
         self,
@@ -73,10 +84,72 @@ class LiveDashboardHTTPServer(ThreadingHTTPServer):
         super().__init__(server_address, handler_class)
         self.config = config
         self.refresh_lock = threading.Lock()
+        self.refresh_state_lock = threading.Lock()
+        self.refresh_stop = threading.Event()
+        self.refresh_thread: threading.Thread | None = None
+        self.refresh_state: JsonObject = {
+            "mode": "auto" if config.auto_refresh_seconds > 0 else "manual",
+            "autoRefreshSeconds": config.auto_refresh_seconds if config.auto_refresh_seconds > 0 else None,
+            "lastRefreshAt": None,
+            "lastRefreshOk": None,
+            "lastRefresh": None,
+            "nextRefreshAt": utc_iso_after(config.auto_refresh_seconds)
+            if config.auto_refresh_seconds > 0
+            else None,
+        }
+        if config.auto_refresh_seconds > 0:
+            self.start_auto_refresh()
+
+    def record_refresh(self, refresh: JsonObject, refreshed_at: str | None = None) -> None:
+        timestamp = refreshed_at or utc_now_iso()
+        with self.refresh_state_lock:
+            self.refresh_state["lastRefreshAt"] = timestamp
+            self.refresh_state["lastRefreshOk"] = refresh_succeeded(refresh)
+            self.refresh_state["lastRefresh"] = dashboard_json_safe(refresh, self.config.repo_root)
+            self.refresh_state["nextRefreshAt"] = (
+                utc_iso_after(self.config.auto_refresh_seconds)
+                if self.config.auto_refresh_seconds > 0
+                else None
+            )
+
+    def refresh_snapshot(self) -> JsonObject:
+        with self.refresh_state_lock:
+            return dict(self.refresh_state)
+
+    def start_auto_refresh(self) -> None:
+        if self.refresh_thread is not None:
+            return
+
+        def refresh_loop() -> None:
+            while not self.refresh_stop.wait(self.config.auto_refresh_seconds):
+                with self.refresh_lock:
+                    try:
+                        refresh = refresh_metrics(self.config.db_path, self.config.artifact_root)
+                    except Exception as error:  # pragma: no cover - defensive background loop boundary
+                        refresh = {"ok": False, "error": str(error)}
+                self.record_refresh(refresh)
+
+        self.refresh_thread = threading.Thread(target=refresh_loop, daemon=True, name="rl-dashboard-refresh")
+        self.refresh_thread.start()
+
+    def server_close(self) -> None:
+        self.refresh_stop.set()
+        if self.refresh_thread is not None:
+            self.refresh_thread.join(timeout=2)
+            self.refresh_thread = None
+        super().server_close()
 
 
 def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def utc_iso_from_datetime(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def utc_iso_after(seconds: int) -> str:
+    return utc_iso_from_datetime(datetime.now(timezone.utc) + timedelta(seconds=seconds))
 
 
 def parse_iso_datetime(value: Any) -> datetime | None:
@@ -97,10 +170,33 @@ def parse_iso_datetime(value: Any) -> datetime | None:
 def display_timestamp(value: Any) -> str:
     parsed = parse_iso_datetime(value)
     if parsed is not None:
-        return parsed.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+        return utc_iso_from_datetime(parsed)
     if isinstance(value, datetime):
-        return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+        return utc_iso_from_datetime(value)
     return str(value) if value not in (None, "") else "N/A"
+
+
+def seconds_since(value: Any, *, now: Any | None = None) -> int | None:
+    parsed = parse_iso_datetime(value)
+    current = parse_iso_datetime(now) if now is not None else datetime.now(timezone.utc)
+    if parsed is None or current is None:
+        return None
+    return max(0, int((current - parsed).total_seconds()))
+
+
+def age_label(value: Any, *, now: Any | None = None) -> str:
+    age_seconds = seconds_since(value, now=now)
+    if age_seconds is None:
+        return "N/A"
+    if age_seconds < 120:
+        return f"{age_seconds}s"
+    minutes = age_seconds // 60
+    if minutes < 120:
+        return f"{minutes}m"
+    hours = minutes // 60
+    if hours < 72:
+        return f"{hours}h"
+    return f"{hours // 24}d"
 
 
 def repo_root_from_script() -> Path:
@@ -141,6 +237,69 @@ def load_json_object(path: Path) -> JsonObject | None:
     except (OSError, json.JSONDecodeError):
         return None
     return parsed if isinstance(parsed, dict) else None
+
+
+def as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def text_value(value: Any) -> str | None:
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return str(value)
+    return None
+
+
+def normalized_key(value: Any) -> str:
+    return "".join(character.lower() for character in str(value) if character.isalnum())
+
+
+def iter_json_objects(value: Any) -> list[JsonObject]:
+    objects: list[JsonObject] = []
+
+    def visit(node: Any) -> None:
+        if isinstance(node, dict):
+            objects.append(node)
+            for nested in node.values():
+                if isinstance(nested, (dict, list)):
+                    visit(nested)
+        elif isinstance(node, list):
+            for nested in node:
+                if isinstance(nested, (dict, list)):
+                    visit(nested)
+
+    visit(value)
+    return objects
+
+
+def compact_value(value: Any, *, limit: int = 160) -> str:
+    if value in (None, "", [], {}):
+        return "N/A"
+    if isinstance(value, str):
+        text = value
+    else:
+        text = json.dumps(value, sort_keys=True, ensure_ascii=True)
+    return text if len(text) <= limit else text[: limit - 3] + "..."
+
+
+def compact_sequence(value: Any, *, limit: int = 3) -> str:
+    if isinstance(value, dict):
+        items = [f"{key}:{item}" for key, item in value.items()]
+    elif isinstance(value, list):
+        items = [compact_value(item, limit=80) for item in value]
+    else:
+        text = compact_value(value)
+        return text
+    if not items:
+        return "N/A"
+    suffix = "" if len(items) <= limit else f" (+{len(items) - limit} more)"
+    return "; ".join(items[:limit]) + suffix
 
 
 def artifact_timestamp(path: Path, payload: JsonObject) -> datetime:
@@ -262,6 +421,17 @@ def refresh_succeeded(refresh: JsonObject) -> bool:
     return refresh.get("ok") is True
 
 
+def collect_values_by_key(value: Any, key_names: set[str], *, limit: int = 12) -> list[Any]:
+    found: list[Any] = []
+    for node in iter_json_objects(value):
+        for key, raw in node.items():
+            if normalized_key(key) in key_names and raw not in (None, "", [], {}):
+                found.append(raw)
+                if len(found) >= limit:
+                    return found
+    return found
+
+
 def latest_scorecard_summary(artifact_root: Path, repo_root: Path) -> JsonObject:
     latest = latest_json_artifact(
         artifact_root / "rl-control-loop" / "scorecards",
@@ -276,9 +446,14 @@ def latest_scorecard_summary(artifact_root: Path, repo_root: Path) -> JsonObject
             "updatedAt": None,
             "safetyRegressions": [],
             "requiredActions": [],
+            "missingEvidence": ["scorecard artifact missing"],
         }
     path, payload, timestamp = latest
     overall_gate = payload.get("overallGate") if isinstance(payload.get("overallGate"), dict) else {}
+    missing_evidence = collect_values_by_key(
+        payload,
+        {"missingevidence", "missingevidences", "missingrequiredevidence"},
+    )
     return {
         "hasData": True,
         "status": overall_gate.get("status") or overall_gate.get("decision") or payload.get("status") or "UNKNOWN",
@@ -289,6 +464,7 @@ def latest_scorecard_summary(artifact_root: Path, repo_root: Path) -> JsonObject
         "updatedAt": display_timestamp(timestamp),
         "safetyRegressions": overall_gate.get("safetyRegressions") or payload.get("safetyRegressions") or [],
         "requiredActions": payload.get("requiredActions") or [],
+        "missingEvidence": missing_evidence,
     }
 
 
@@ -399,6 +575,13 @@ def safety_summary(dashboard: JsonObject, tencent: JsonObject, scorecard: JsonOb
             value = tencent_safety[field]
             if value is not False:
                 unsafe_flags.append({"source": "tencent", "field": field, "value": value})
+        for field in REQUIRED_TENCENT_SHADOW_SAFETY_FIELDS:
+            if field not in tencent_safety:
+                unsafe_flags.append({"source": "tencent", "field": field, "value": "missing"})
+                continue
+            value = tencent_safety[field]
+            if value is not True:
+                unsafe_flags.append({"source": "tencent", "field": field, "value": value})
     if not scorecard.get("hasData"):
         unsafe_flags.append({"source": "scorecard", "field": "summary", "value": "missing"})
     else:
@@ -411,7 +594,241 @@ def safety_summary(dashboard: JsonObject, tencent: JsonObject, scorecard: JsonOb
         "cardSupplyStatus": card_supply.get("status"),
         "cardSupplySeverity": card_supply.get("severity"),
         "fallbackStatus": card_supply.get("fallbackStatus"),
+        "conservativeActionsOnly": tencent_safety.get("conservative_actions_only"),
+        "oodRejection": tencent_safety.get("ood_rejection"),
     }
+
+
+def scan_artifact_json(artifact_root: Path) -> list[tuple[Path, JsonObject, datetime]]:
+    artifacts: list[tuple[Path, JsonObject, datetime]] = []
+    roots = (
+        artifact_root / "rl-control-loop",
+        artifact_root / "rl-training",
+        artifact_root / "tencent-cloud" / "batch-runs",
+    )
+    for root in roots:
+        if not root.exists():
+            continue
+        for path in root.rglob("*.json"):
+            if not path.is_file():
+                continue
+            payload = load_json_object(path)
+            if payload is None:
+                continue
+            artifacts.append((path, payload, artifact_timestamp(path, payload)))
+    return sorted(artifacts, key=lambda item: item[2], reverse=True)
+
+
+def runtime_candidate_injection_summary(artifact_root: Path, repo_root: Path) -> JsonObject:
+    explicit_false: list[JsonObject] = []
+    metadata_only: list[JsonObject] = []
+    for path, payload, timestamp in scan_artifact_json(artifact_root):
+        for node in iter_json_objects(payload):
+            for key, value in node.items():
+                normalized = normalized_key(key)
+                if normalized in RUNTIME_INJECTION_TRUE_KEYS and value is True:
+                    return {
+                        "status": "OK",
+                        "evidence": f"{key}=true",
+                        "latestPath": safe_display_path(path, repo_root),
+                        "updatedAt": display_timestamp(timestamp),
+                    }
+                if normalized in RUNTIME_INJECTION_TRUE_KEYS and value is False:
+                    explicit_false.append(
+                        {
+                            "field": key,
+                            "value": value,
+                            "path": safe_display_path(path, repo_root),
+                            "updatedAt": display_timestamp(timestamp),
+                        }
+                    )
+                if normalized in RUNTIME_INJECTION_SCOPE_KEYS:
+                    scope = text_value(value)
+                    if scope is not None and normalized_key(scope) in RUNTIME_INJECTION_METADATA_ONLY_VALUES:
+                        metadata_only.append(
+                            {
+                                "field": key,
+                                "value": value,
+                                "path": safe_display_path(path, repo_root),
+                                "updatedAt": display_timestamp(timestamp),
+                            }
+                        )
+    if explicit_false or metadata_only:
+        evidence = explicit_false[0] if explicit_false else metadata_only[0]
+        return {
+            "status": "BLOCKED",
+            "evidence": f"{evidence['field']}={evidence['value']}",
+            "latestPath": evidence["path"],
+            "updatedAt": evidence["updatedAt"],
+        }
+    return {
+        "status": "N/A",
+        "evidence": "no runtime candidate injection evidence found",
+        "latestPath": None,
+        "updatedAt": None,
+    }
+
+
+def zero_iteration_policy_update_summary(artifact_root: Path, repo_root: Path) -> JsonObject:
+    for path, payload, timestamp in scan_artifact_json(artifact_root):
+        for node in iter_json_objects(payload):
+            iterations = node.get("policyUpdateIterations")
+            policy_update = node.get("policyUpdate")
+            if iterations is None and not isinstance(policy_update, dict):
+                continue
+            if iterations == 0:
+                if not isinstance(policy_update, dict):
+                    return {
+                        "status": "OK",
+                        "evidence": "zero policy updates with no update artifact",
+                        "latestPath": safe_display_path(path, repo_root),
+                        "updatedAt": display_timestamp(timestamp),
+                    }
+                skipped = text_value(policy_update.get("skippedReason"))
+                if skipped and not node.get("policyUpdateArtifactPath"):
+                    return {
+                        "status": "OK",
+                        "evidence": f"safe zero-iteration no-op: {skipped}",
+                        "latestPath": safe_display_path(path, repo_root),
+                        "updatedAt": display_timestamp(timestamp),
+                    }
+                return {
+                    "status": "BLOCKED",
+                    "evidence": "zero-iteration policy update lacks safe skippedReason or has update artifact",
+                    "latestPath": safe_display_path(path, repo_root),
+                    "updatedAt": display_timestamp(timestamp),
+                }
+            if isinstance(iterations, (int, float)) and iterations > 0:
+                return {
+                    "status": "N/A",
+                    "evidence": f"latest policy update had {iterations} iteration(s)",
+                    "latestPath": safe_display_path(path, repo_root),
+                    "updatedAt": display_timestamp(timestamp),
+                }
+    return {
+        "status": "N/A",
+        "evidence": "no policy update evidence found",
+        "latestPath": None,
+        "updatedAt": None,
+    }
+
+
+def policy_status_is_online_proven(status: Any) -> bool:
+    return str(status or "").upper() in {"PROVEN", "VALIDATED", "PROMOTABLE", "ADVANTAGE", "ROLLOUT_APPROVED"}
+
+
+def flywheel_stage_summary(
+    *,
+    db: JsonObject,
+    dashboard: JsonObject,
+    scorecard: JsonObject,
+    safety: JsonObject,
+) -> list[JsonObject]:
+    training = as_dict(dashboard.get("training"))
+    policy = as_dict(dashboard.get("policy"))
+    iteration_count = as_dict(db.get("tables")).get("metric_iteration_decisions")
+    stages = [
+        {
+            "stage": "construction-landed",
+            "status": "OK" if db.get("schemaReady") else "BLOCKED",
+            "evidence": "live dashboard service and SQLite schema are available"
+            if db.get("schemaReady")
+            else "SQLite schema is not ready",
+        },
+        {
+            "stage": "training-running",
+            "status": "OK" if training.get("hasComputeEvidence") else "BLOCKED",
+            "evidence": as_dict(training.get("computeEvidence")).get("classification") or training.get("blocker") or "N/A",
+        },
+        {
+            "stage": "online-proven",
+            "status": "OK" if policy_status_is_online_proven(policy.get("status")) else "BLOCKED",
+            "evidence": f"onlineUtilityStatus={policy.get('status') or 'N/A'}",
+        },
+        {
+            "stage": "self-iterating",
+            "status": "OK"
+            if isinstance(iteration_count, int)
+            and iteration_count > 0
+            and scorecard.get("hasData")
+            and safety.get("status") == "OK"
+            else "BLOCKED",
+            "evidence": (
+                f"iteration decisions={iteration_count}; scorecard={scorecard.get('status')}; safety={safety.get('status')}"
+            ),
+        },
+    ]
+    return stages
+
+
+def latest_batch_scale(tencent: JsonObject) -> JsonObject:
+    latest = as_dict(tencent.get("latest"))
+    return as_dict(latest.get("batchScale"))
+
+
+def project_gate_summary(
+    *,
+    flywheel_stages: Sequence[JsonObject],
+    tencent: JsonObject,
+    injection: JsonObject,
+    zero_iteration: JsonObject,
+    refresh: JsonObject,
+) -> list[JsonObject]:
+    stage_statuses = {stage.get("stage"): stage.get("status") for stage in flywheel_stages}
+    scale = latest_batch_scale(tencent)
+    auto_refresh_ok = refresh.get("mode") == "auto" and refresh.get("autoRefreshSeconds")
+    refresh_cadence = (
+        f"{refresh.get('autoRefreshSeconds')}s"
+        if refresh.get("autoRefreshSeconds")
+        else "off"
+    )
+    all_stages_ok = all(status == "OK" for status in stage_statuses.values())
+    return [
+        {
+            "issue": "#879",
+            "gate": "recurring RL flywheel",
+            "status": "OK" if all_stages_ok else "BLOCKED",
+            "evidence": ", ".join(f"{key}={value}" for key, value in stage_statuses.items()),
+            "nextAction": "clear blocked flywheel stages" if not all_stages_ok else "keep evidence fresh",
+        },
+        {
+            "issue": "#1032",
+            "gate": "scale-first training",
+            "status": "OK" if scale.get("scaleFirstEligible") is True else "BLOCKED",
+            "evidence": (
+                f"batchClass={scale.get('batchClass', 'N/A')}; rows={scale.get('environmentRows', 'N/A')}; "
+                f"ticks={scale.get('simulatorTicks', 'N/A')}"
+            ),
+            "nextAction": "run validation-or-larger batch" if scale.get("scaleFirstEligible") is not True else "score candidate",
+        },
+        {
+            "issue": "#1229",
+            "gate": "runtime candidate injection",
+            "status": injection.get("status"),
+            "evidence": injection.get("evidence"),
+            "nextAction": "prove candidate params affect simulator/runtime behavior"
+            if injection.get("status") != "OK"
+            else "use injected candidate in scorecard",
+        },
+        {
+            "issue": "#1233",
+            "gate": "autonomous compute cadence",
+            "status": "OK" if auto_refresh_ok and tencent.get("hasData") else "BLOCKED",
+            "evidence": f"autoRefresh={refresh_cadence}; tencentRuns={tencent.get('runCount', 0)}",
+            "nextAction": "keep dashboard auto-refresh and compute evidence alive"
+            if auto_refresh_ok and tencent.get("hasData")
+            else "restore recurring refresh/compute evidence",
+        },
+        {
+            "issue": "#1234",
+            "gate": "zero-iteration no-op policy update",
+            "status": zero_iteration.get("status"),
+            "evidence": zero_iteration.get("evidence"),
+            "nextAction": "preserve safe no-op semantics"
+            if zero_iteration.get("status") == "OK"
+            else "verify latest zero-iteration policyUpdate evidence",
+        },
+    ]
 
 
 def build_live_summary(
@@ -421,8 +838,17 @@ def build_live_summary(
     *,
     generated_at: str | None = None,
     dashboard_url: str | None = None,
+    refresh: JsonObject | None = None,
 ) -> JsonObject:
     generated = generated_at or utc_now_iso()
+    refresh_summary: JsonObject = refresh or {
+        "mode": "manual",
+        "autoRefreshSeconds": None,
+        "lastRefreshAt": None,
+        "lastRefreshOk": None,
+        "lastRefresh": None,
+        "nextRefreshAt": None,
+    }
     db = sqlite_summary(db_path, repo_root)
     health = health_from_db_summary(db)
     raw_dashboard = static_dashboard.build_dashboard(repo_root=repo_root, artifact_root=artifact_root, generated_at=generated)
@@ -430,6 +856,16 @@ def build_live_summary(
     scorecard = latest_scorecard_summary(artifact_root, repo_root)
     tencent = tencent_batch_summary(artifact_root, repo_root)
     safety = safety_summary(dashboard, tencent, scorecard)
+    injection = runtime_candidate_injection_summary(artifact_root, repo_root)
+    zero_iteration = zero_iteration_policy_update_summary(artifact_root, repo_root)
+    flywheel_stages = flywheel_stage_summary(db=db, dashboard=dashboard, scorecard=scorecard, safety=safety)
+    project_gates = project_gate_summary(
+        flywheel_stages=flywheel_stages,
+        tencent=tencent,
+        injection=injection,
+        zero_iteration=zero_iteration,
+        refresh=refresh_summary,
+    )
     loop_a = {
         "environment": dashboard.get("simulator", {}),
         "training": dashboard.get("training", {}),
@@ -447,6 +883,11 @@ def build_live_summary(
         "dashboardUrl": dashboard_url or format_dashboard_url(DEFAULT_HOST, DEFAULT_PORT),
         "health": health,
         "db": db,
+        "refresh": refresh_summary,
+        "flywheelStages": flywheel_stages,
+        "projectGates": project_gates,
+        "runtimeCandidateInjection": injection,
+        "zeroIterationPolicyUpdate": zero_iteration,
         "lanes": dashboard.get("lanes", []),
         "e1Gate": dashboard.get("gate"),
         "loopA": loop_a,
@@ -512,6 +953,11 @@ def render_live_html(summary: JsonObject, config: LiveDashboardConfig) -> str:
     latest_batch_scale = latest_tencent.get("batchScale") if isinstance(latest_tencent.get("batchScale"), dict) else {}
     safety = summary.get("safety") if isinstance(summary.get("safety"), dict) else {}
     db = summary.get("db") if isinstance(summary.get("db"), dict) else {}
+    refresh = summary.get("refresh") if isinstance(summary.get("refresh"), dict) else {}
+    flywheel_stages = [row for row in summary.get("flywheelStages", []) if isinstance(row, dict)]
+    project_gates = [row for row in summary.get("projectGates", []) if isinstance(row, dict)]
+    policy = loop_b.get("policy") if isinstance(loop_b.get("policy"), dict) else {}
+    policy_metrics = [row for row in policy.get("metrics", []) if isinstance(row, dict)]
 
     lane_rows = [
         (
@@ -528,14 +974,27 @@ def render_live_html(summary: JsonObject, config: LiveDashboardConfig) -> str:
         ("Path", h(db.get("path"))),
         ("Exists", render_status("OK" if db.get("exists") else "missing")),
         ("Schema", render_status("OK" if db.get("schemaReady") else "incomplete")),
+        ("Size bytes", h(format_value(db.get("sizeBytes")))),
         ("Latest observation", h(display_timestamp(db.get("latestObservedAt")))),
+        ("Observation age", h(age_label(db.get("latestObservedAt"), now=summary.get("generatedAt")))),
+        ("Last refresh", h(display_timestamp(refresh.get("lastRefreshAt")))),
+        ("Refresh mode", h(refresh.get("mode") or "manual")),
+        ("Auto refresh seconds", h(format_value(refresh.get("autoRefreshSeconds")))),
+        ("Next refresh", h(display_timestamp(refresh.get("nextRefreshAt")))),
+    ]
+    db_table_rows = [
+        (h(table_name), h("missing" if count is None else count))
+        for table_name, count in as_dict(db.get("tables")).items()
     ]
     e1_rows = [
         ("Status", render_status(e1.get("status"))),
+        ("Latest gate", h(display_timestamp(e1.get("timestamp")))),
+        ("Gate age", h(age_label(e1.get("timestamp"), now=summary.get("generatedAt")))),
         ("Acceptance", h(percent_value(e1.get("acceptanceRate")))),
         ("Sample count", h(format_value(e1.get("sampleCount")))),
         ("Accepted", h(format_value(e1.get("samplesAccepted")))),
         ("Rejected", h(format_value(e1.get("samplesRejected")))),
+        ("Rejection reasons", h(compact_sequence(e1.get("rejectionReasons")))),
         ("Source", h(e1.get("displayPath") or "N/A")),
     ]
     loop_a_rows = [
@@ -545,13 +1004,20 @@ def render_live_html(summary: JsonObject, config: LiveDashboardConfig) -> str:
         ("Training status", render_status(training.get("status"))),
         ("Episodes", h(format_value(training.get("episodes")))),
         ("Policy updates", h(format_value(training.get("policyUpdates")))),
+        ("Compute evidence", h(as_dict(training.get("computeEvidence")).get("classification") or "N/A")),
+        ("Batch class", h(latest_batch_scale.get("batchClass") or "N/A")),
+        ("Anomalies", h(compact_sequence(environment.get("failureModes")))),
+        ("Blocker", h(training.get("blocker") or "N/A")),
     ]
     loop_b_rows = [
         ("Online utility", render_status(loop_b.get("onlineUtilityStatus"))),
-        ("Candidate", h(loop_b.get("policy", {}).get("candidate") if isinstance(loop_b.get("policy"), dict) else "N/A")),
-        ("Baseline", h(loop_b.get("policy", {}).get("baseline") if isinstance(loop_b.get("policy"), dict) else "N/A")),
+        ("Candidate", h(policy.get("candidate") or "N/A")),
+        ("Baseline", h(policy.get("baseline") or "N/A")),
+        ("Advantages", h(compact_sequence([row for row in policy_metrics if str(row.get("status", "")).upper() in {"ADVANTAGE", "IMPROVED"}]))),
+        ("Regressions", h(compact_sequence([row for row in policy_metrics if str(row.get("status", "")).upper() in {"REGRESSED", "REGRESSION"}]))),
         ("Scorecard", render_status(scorecard.get("status"))),
         ("Scorecard run", h(scorecard.get("runId") or "N/A")),
+        ("Safety regressions", h(compact_sequence(scorecard.get("safetyRegressions")))),
     ]
     tencent_rows = [
         ("Runs", h(format_value(tencent.get("runCount")))),
@@ -566,6 +1032,10 @@ def render_live_html(summary: JsonObject, config: LiveDashboardConfig) -> str:
         ("Latest env rows", h(latest_batch_scale.get("environmentRows", "N/A"))),
         ("Latest simulator ticks", h(latest_batch_scale.get("simulatorTicks", "N/A"))),
         ("Scale-first eligible", h(latest_batch_scale.get("scaleFirstEligible", "N/A"))),
+        ("Wall clock seconds", h(format_value(latest_batch_scale.get("wallClockSeconds")))),
+        ("ASG active seconds", h(format_value(latest_batch_scale.get("asgActiveSeconds")))),
+        ("Utilization ratio", h(format_value(latest_batch_scale.get("utilizationRatio")))),
+        ("Cost estimate", h(compact_value(latest_batch_scale.get("costEstimate")))),
         ("Scale down attempted", h(latest_tencent.get("safety", {}).get("scaleDownAttempted") if isinstance(latest_tencent.get("safety"), dict) else "N/A")),
     ]
     safety_rows = [
@@ -576,8 +1046,34 @@ def render_live_html(summary: JsonObject, config: LiveDashboardConfig) -> str:
             "officialMmoWritesAllowed",
             h(safety.get("tencent", {}).get("officialMmoWritesAllowed") if isinstance(safety.get("tencent"), dict) else "N/A"),
         ),
+        ("conservative_actions_only", h(safety.get("conservativeActionsOnly", "N/A"))),
+        ("ood_rejection", h(safety.get("oodRejection", "N/A"))),
         ("Card supply", h(safety.get("cardSupplyStatus") or "N/A")),
         ("Unsafe flags", h(len(safety.get("unsafeFlags", [])))),
+    ]
+    scorecard_rows = [
+        ("Status", render_status(scorecard.get("status"))),
+        ("Run", h(scorecard.get("runId") or "N/A")),
+        ("Candidate", h(scorecard.get("candidate") or "N/A")),
+        ("Baseline", h(scorecard.get("baseline") or "N/A")),
+        ("Updated", h(display_timestamp(scorecard.get("updatedAt")))),
+        ("Missing evidence", h(compact_sequence(scorecard.get("missingEvidence")))),
+        ("Required actions", h(compact_sequence(scorecard.get("requiredActions")))),
+        ("Source", h(scorecard.get("latestPath") or "N/A")),
+    ]
+    stage_rows = [
+        (h(row.get("stage")), render_status(row.get("status")), h(row.get("evidence") or "N/A"))
+        for row in flywheel_stages
+    ]
+    project_gate_rows = [
+        (
+            h(row.get("issue")),
+            h(row.get("gate")),
+            render_status(row.get("status")),
+            h(row.get("evidence") or "N/A"),
+            h(row.get("nextAction") or "N/A"),
+        )
+        for row in project_gates
     ]
 
     return f"""<!doctype html>
@@ -692,9 +1188,19 @@ def render_live_html(summary: JsonObject, config: LiveDashboardConfig) -> str:
   </section>
 
   <div class="grid two">
+    <section class="panel"><h2>#879 Flywheel Stage Proof</h2>{table(("Stage", "Status", "Evidence"), stage_rows)}</section>
+    <section class="panel"><h2>Project Gate Status</h2>{table(("Issue", "Gate", "Status", "Evidence", "Next action"), project_gate_rows)}</section>
+  </div>
+
+  <div class="grid two">
     <section class="panel"><h2>Metrics Store</h2>{table(("Item", "Value"), db_rows)}</section>
     <section class="panel"><h2>E1 Gate Acceptance</h2>{table(("Item", "Value"), e1_rows)}</section>
   </div>
+
+  <section class="panel grid">
+    <h2>SQLite Table Counts</h2>
+    {table(("Table", "Rows"), db_table_rows)}
+  </section>
 
   <div class="grid two">
     <section class="panel"><h2>Loop A Env Ticks Episodes</h2>{table(("Item", "Value"), loop_a_rows)}</section>
@@ -705,6 +1211,11 @@ def render_live_html(summary: JsonObject, config: LiveDashboardConfig) -> str:
     <section class="panel"><h2>Tencent Batch Utilization</h2>{table(("Item", "Value"), tencent_rows)}</section>
     <section class="panel"><h2>Safety Flags</h2>{table(("Item", "Value"), safety_rows)}</section>
   </div>
+
+  <section class="panel grid">
+    <h2>#924 Scorecard Status</h2>
+    {table(("Item", "Value"), scorecard_rows)}
+  </section>
 </main>
 </body>
 </html>
@@ -725,7 +1236,16 @@ class LiveDashboardRequestHandler(BaseHTTPRequestHandler):
         if parsed.path == "/healthz":
             summary = self.summary()
             status = HTTPStatus.OK if summary["health"]["ok"] else HTTPStatus.SERVICE_UNAVAILABLE
-            self.write_json(status, summary["health"] | {"db": summary["db"], "generatedAt": summary["generatedAt"]})
+            self.write_json(
+                status,
+                summary["health"]
+                | {
+                    "message": "OK" if summary["health"]["ok"] else "DEGRADED",
+                    "db": summary["db"],
+                    "refresh": summary["refresh"],
+                    "generatedAt": summary["generatedAt"],
+                },
+            )
             return
         self.write_json(HTTPStatus.NOT_FOUND, {"ok": False, "error": "not found"})
 
@@ -762,6 +1282,7 @@ class LiveDashboardRequestHandler(BaseHTTPRequestHandler):
             config.artifact_root,
             config.db_path,
             dashboard_url=format_dashboard_url(str(host), int(port)),
+            refresh=self.server.refresh_snapshot(),
         )
 
     def write_json(self, status: HTTPStatus, payload: JsonObject) -> None:
@@ -795,6 +1316,7 @@ def build_config(args: argparse.Namespace) -> LiveDashboardConfig:
         db_path=db_path,
         refresh_seconds=args.refresh_seconds,
         enable_refresh_endpoint=bool(getattr(args, "enable_refresh_endpoint", False)),
+        auto_refresh_seconds=max(0, int(getattr(args, "auto_refresh_seconds", 0) or 0)),
     )
 
 
@@ -830,6 +1352,15 @@ def build_parser() -> argparse.ArgumentParser:
     serve.add_argument("--port", type=int, default=DEFAULT_PORT, help="Bind port.")
     serve.add_argument("--refresh-on-start", action="store_true", help="Run the metrics ingestor before serving.")
     serve.add_argument(
+        "--auto-refresh-seconds",
+        type=int,
+        default=0,
+        help=(
+            "Refresh the SQLite metrics store in the background while serving. "
+            f"Use {DEFAULT_AUTO_REFRESH_SECONDS} for the standard owner-facing local surface."
+        ),
+    )
+    serve.add_argument(
         "--enable-refresh-endpoint",
         action="store_true",
         help="Enable POST /refresh. Disabled by default because it mutates the local SQLite metrics store.",
@@ -853,6 +1384,8 @@ def run_healthcheck(url: str, timeout: float) -> int:
         with urllib.request.urlopen(url, timeout=timeout) as response:
             payload = json.loads(response.read().decode("utf-8"))
             ok = bool(payload.get("ok"))
+            if ok and "message" not in payload:
+                payload["message"] = "OK"
             print(json.dumps(payload, sort_keys=True))
             return 0 if ok else 1
     except urllib.error.HTTPError as error:
@@ -879,6 +1412,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(json.dumps(build_live_summary(config.repo_root, config.artifact_root, config.db_path), sort_keys=True))
         return 0
     if args.command == "serve":
+        initial_refresh: JsonObject | None = None
         if args.refresh_on_start:
             refresh = refresh_metrics(config.db_path, config.artifact_root)
             if not refresh_succeeded(refresh):
@@ -887,7 +1421,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                     file=sys.stderr,
                 )
                 return 1
+            initial_refresh = refresh
         server = make_server(args.host, args.port, config)
+        if initial_refresh is not None:
+            server.record_refresh(initial_refresh)
         host, port = server.server_address
         print(f"Serving Screeps RL live dashboard at {format_dashboard_url(str(host), int(port))}")
         try:

--- a/scripts/screeps_rl_live_dashboard.py
+++ b/scripts/screeps_rl_live_dashboard.py
@@ -56,6 +56,7 @@ RUNTIME_INJECTION_TRUE_KEYS = {
 }
 RUNTIME_INJECTION_SCOPE_KEYS = {"candidateparameterscope"}
 RUNTIME_INJECTION_METADATA_ONLY_VALUES = {"metadataonly"}
+SUMMARY_STATUS_PRIORITY = {"BLOCKED": 2, "OK": 1, "N/A": 0}
 
 JsonObject = dict[str, Any]
 ArtifactJson = tuple[Path, JsonObject, datetime]
@@ -620,16 +621,34 @@ def scan_artifact_json(artifact_root: Path) -> Iterator[ArtifactJson]:
         artifact_root / "rl-training",
         artifact_root / "tencent-cloud" / "batch-runs",
     )
+    paths: list[Path] = []
     for root in roots:
         if not root.exists():
             continue
         for path in root.rglob("*.json"):
             if not path.is_file():
                 continue
-            payload = load_json_object(path)
-            if payload is None:
-                continue
-            yield path, payload, artifact_timestamp(path, payload)
+            paths.append(path)
+    for path in sorted(paths, key=lambda candidate: candidate.as_posix()):
+        payload = load_json_object(path)
+        if payload is None:
+            continue
+        yield path, payload, artifact_timestamp(path, payload)
+
+
+def summary_status_priority(summary: JsonObject) -> int:
+    return SUMMARY_STATUS_PRIORITY.get(str(summary.get("status") or "").upper(), 0)
+
+
+def summary_tie_key(summary: JsonObject) -> str:
+    for key in ("latestPath", "path", "runId", "id", "name", "evidence"):
+        value = summary.get(key)
+        if value not in (None, ""):
+            return str(value)
+    try:
+        return json.dumps(summary, sort_keys=True, ensure_ascii=True)
+    except TypeError:
+        return str(summary)
 
 
 def newest_summary(current: JsonObject | None, candidate: JsonObject | None) -> JsonObject | None:
@@ -643,7 +662,15 @@ def newest_summary(current: JsonObject | None, candidate: JsonObject | None) -> 
         return candidate
     if candidate_timestamp is None:
         return current
-    return candidate if candidate_timestamp > current_timestamp else current
+    if candidate_timestamp > current_timestamp:
+        return candidate
+    if candidate_timestamp < current_timestamp:
+        return current
+    current_priority = summary_status_priority(current)
+    candidate_priority = summary_status_priority(candidate)
+    if candidate_priority != current_priority:
+        return candidate if candidate_priority > current_priority else current
+    return candidate if summary_tie_key(candidate) > summary_tie_key(current) else current
 
 
 def runtime_candidate_injection_from_artifact(
@@ -946,7 +973,7 @@ def build_live_summary(
         "nextRefreshAt": None,
     }
     db = sqlite_summary(db_path, repo_root)
-    health = health_from_db_summary(db)
+    health = health_with_refresh(health_from_db_summary(db), refresh_summary)
     raw_dashboard = static_dashboard.build_dashboard(repo_root=repo_root, artifact_root=artifact_root, generated_at=generated)
     dashboard = dashboard_json_safe(raw_dashboard, repo_root)
     scorecard = latest_scorecard_summary(artifact_root, repo_root)

--- a/scripts/test_screeps_rl_live_dashboard.py
+++ b/scripts/test_screeps_rl_live_dashboard.py
@@ -394,6 +394,51 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
         self.assertTrue(summary["latestPath"].endswith("new-blocked.json"))
         self.assertEqual(summary["updatedAt"], "2026-05-18T10:10:00Z")
 
+    def test_equal_timestamp_artifact_gate_ties_are_conservative(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            artifact_root = repo_root / "runtime-artifacts"
+            timestamp = "2026-05-18T10:10:00Z"
+            write_json(
+                artifact_root / "rl-control-loop" / "a-runtime-success.json",
+                {
+                    "createdAt": timestamp,
+                    "runtime_parameter_injection": True,
+                },
+            )
+            write_json(
+                artifact_root / "rl-control-loop" / "z-runtime-blocked.json",
+                {
+                    "createdAt": timestamp,
+                    "runtime_parameter_injection": False,
+                },
+            )
+            write_json(
+                artifact_root / "rl-control-loop" / "a-zero-safe.json",
+                {
+                    "createdAt": timestamp,
+                    "policyUpdateIterations": 0,
+                    "policyUpdate": {"skippedReason": "no samples"},
+                },
+            )
+            write_json(
+                artifact_root / "rl-control-loop" / "z-zero-blocked.json",
+                {
+                    "createdAt": timestamp,
+                    "policyUpdateIterations": 0,
+                    "policyUpdate": {},
+                },
+            )
+
+            injection = live.runtime_candidate_injection_summary(artifact_root, repo_root)
+            zero_iteration = live.zero_iteration_policy_update_summary(artifact_root, repo_root)
+
+        self.assertEqual(injection["status"], "BLOCKED")
+        self.assertEqual(injection["evidence"], "runtime_parameter_injection=False")
+        self.assertTrue(injection["latestPath"].endswith("z-runtime-blocked.json"))
+        self.assertEqual(zero_iteration["status"], "BLOCKED")
+        self.assertTrue(zero_iteration["latestPath"].endswith("z-zero-blocked.json"))
+
     def test_health_helper_requires_successful_auto_refresh(self) -> None:
         health = live.health_with_refresh(
             {"ok": True, "status": "ok", "failures": []},
@@ -507,6 +552,7 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
                 )
                 host, port = server.server_address
                 status, health = get_json_url(f"http://{host}:{port}/healthz")
+                summary = read_json_url(f"http://{host}:{port}/api/summary")
             finally:
                 server.shutdown()
                 server.server_close()
@@ -517,6 +563,10 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
         self.assertEqual(health["message"], "DEGRADED")
         self.assertIn("auto-refresh has not completed successfully", health["failures"])
         self.assertFalse(health["refresh"]["lastRefreshOk"])
+        self.assertFalse(summary["health"]["ok"])
+        self.assertEqual(summary["health"]["status"], "degraded")
+        self.assertIn("auto-refresh has not completed successfully", summary["health"]["failures"])
+        self.assertFalse(summary["refresh"]["lastRefreshOk"])
 
     def test_auto_refresh_state_is_exposed(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_live_dashboard.py
+++ b/scripts/test_screeps_rl_live_dashboard.py
@@ -77,6 +77,12 @@ def write_live_artifacts(root: Path) -> None:
                 "simulatorTicksRun": 1400,
             },
             "environmentExecution": {"completed": 2, "failed": 0, "lastNewRunAt": "2026-05-18T10:05:00Z"},
+            "policyGradient": {
+                "runner_support": {
+                    "runtime_parameter_injection": False,
+                    "candidate_parameter_scope": "metadata_only",
+                }
+            },
             "createdAt": "2026-05-18T10:05:00Z",
         },
     )
@@ -116,13 +122,32 @@ def write_live_artifacts(root: Path) -> None:
             "instanceId": "ins-live",
             "workerUser": "screeps-batch",
             "inputs": {"ticks": 500, "workers": 5, "repetitions": 5},
+            "batchScale": {
+                "environmentRows": 25,
+                "simulatorTicks": 12500,
+                "wallClockSeconds": 420,
+                "asgActiveSeconds": 600,
+                "costEstimate": {"currency": "USD", "amount": 1.23},
+            },
             "safety": {
                 "liveEffect": False,
                 "officialMmoWrites": False,
                 "officialMmoWritesAllowed": False,
+                "conservative_actions_only": True,
+                "ood_rejection": True,
                 "billingGuardBeforeScale": True,
                 "scaleDownAttempted": True,
             },
+        },
+    )
+    write_json(
+        root / "rl-control-loop" / "decision.json",
+        {
+            "type": "screeps-rl-iteration-decision",
+            "decisionId": "decision-live",
+            "decision": "hold",
+            "feedbackIngestion": {"findingId": "finding-live"},
+            "createdAt": "2026-05-18T10:08:30Z",
         },
     )
     (root / "rl-training").mkdir(parents=True, exist_ok=True)
@@ -212,14 +237,26 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
         self.assertEqual(summary["tencentBatch"]["latest"]["batchScale"]["batchClass"], "smoke")
         self.assertEqual(summary["tencentBatch"]["latest"]["batchScale"]["environmentRows"], 25)
         self.assertEqual(summary["tencentBatch"]["latest"]["batchScale"]["simulatorTicks"], 12500)
+        self.assertEqual(summary["tencentBatch"]["latest"]["batchScale"]["asgActiveSeconds"], 600.0)
+        self.assertEqual(summary["tencentBatch"]["latest"]["batchScale"]["utilizationRatio"], 0.7)
         self.assertFalse(summary["tencentBatch"]["latest"]["batchScale"]["scaleFirstEligible"])
         self.assertEqual(summary["safety"]["status"], "OK")
+        self.assertTrue(summary["safety"]["conservativeActionsOnly"])
+        self.assertTrue(summary["safety"]["oodRejection"])
+        self.assertEqual(summary["runtimeCandidateInjection"]["status"], "BLOCKED")
+        self.assertEqual(summary["zeroIterationPolicyUpdate"]["status"], "N/A")
+        self.assertEqual(summary["flywheelStages"][0]["stage"], "construction-landed")
+        self.assertIn("#879", {row["issue"] for row in summary["projectGates"]})
         self.assertIn("E1 Gate Acceptance", html)
         self.assertIn("Loop A Env Ticks Episodes", html)
         self.assertIn("Loop B Utility Scorecard", html)
         self.assertIn("Tencent Batch Utilization", html)
         self.assertIn("Latest batch class", html)
         self.assertIn("Safety Flags", html)
+        self.assertIn("#879 Flywheel Stage Proof", html)
+        self.assertIn("Project Gate Status", html)
+        self.assertIn("SQLite Table Counts", html)
+        self.assertIn("#924 Scorecard Status", html)
 
     def test_missing_tencent_safety_object_blocks_dashboard(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -245,7 +282,10 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
             if flag.get("source") == "tencent" and flag.get("value") == "missing"
         }
         self.assertEqual(summary["safety"]["status"], "BLOCKED")
-        self.assertEqual(missing_fields, set(live.REQUIRED_TENCENT_SAFETY_FIELDS))
+        self.assertEqual(
+            missing_fields,
+            set(live.REQUIRED_TENCENT_SAFETY_FIELDS) | set(live.REQUIRED_TENCENT_SHADOW_SAFETY_FIELDS),
+        )
 
     def test_missing_tencent_safety_field_blocks_dashboard(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -339,9 +379,46 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
                 thread.join(timeout=5)
 
         self.assertTrue(health["ok"])
+        self.assertEqual(health["message"], "OK")
         self.assertEqual(summary["type"], "screeps-rl-live-dashboard")
         self.assertEqual(summary["dashboardUrl"], f"http://{host}:{port}/")
         self.assertEqual(summary["e1Gate"]["gateId"], "e1-live")
+
+    def test_auto_refresh_state_is_exposed(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            artifact_root = repo_root / "runtime-artifacts"
+            db_path = repo_root / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite"
+            write_live_artifacts(artifact_root)
+            live.refresh_metrics(db_path, artifact_root)
+            config = live.LiveDashboardConfig(
+                repo_root=repo_root,
+                artifact_root=artifact_root,
+                db_path=db_path,
+                auto_refresh_seconds=60,
+            )
+            try:
+                server = live.make_server("127.0.0.1", 0, config)
+            except OSError as error:
+                self.skipTest(f"socket creation is unavailable in this sandbox: {error}")
+            try:
+                server.record_refresh({"ok": True, "files_scanned": 1}, refreshed_at="2026-05-18T10:09:00Z")
+                summary = live.build_live_summary(
+                    repo_root,
+                    artifact_root,
+                    db_path,
+                    generated_at="2026-05-18T10:09:30Z",
+                    refresh=server.refresh_snapshot(),
+                )
+                html = live.render_live_html(summary, config)
+            finally:
+                server.server_close()
+
+        self.assertEqual(summary["refresh"]["mode"], "auto")
+        self.assertEqual(summary["refresh"]["autoRefreshSeconds"], 60)
+        self.assertTrue(summary["refresh"]["lastRefreshOk"])
+        self.assertIn("Last refresh", html)
+        self.assertIn("Auto refresh seconds", html)
 
     def test_refresh_endpoint_is_disabled_by_default(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_live_dashboard.py
+++ b/scripts/test_screeps_rl_live_dashboard.py
@@ -568,6 +568,45 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
         self.assertIn("auto-refresh has not completed successfully", summary["health"]["failures"])
         self.assertFalse(summary["refresh"]["lastRefreshOk"])
 
+    def test_summary_and_healthz_read_sqlite_under_refresh_lock(self) -> None:
+        original_sqlite_summary = live.sqlite_summary
+        observed_locked_reads: list[bool] = []
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            artifact_root = repo_root / "runtime-artifacts"
+            db_path = repo_root / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite"
+            write_live_artifacts(artifact_root)
+            live.refresh_metrics(db_path, artifact_root)
+            config = live.LiveDashboardConfig(repo_root=repo_root, artifact_root=artifact_root, db_path=db_path)
+            try:
+                server = live.make_server("127.0.0.1", 0, config)
+            except OSError as error:
+                self.skipTest(f"socket creation is unavailable in this sandbox: {error}")
+
+            def locked_sqlite_summary(db_path_arg: Path, repo_root_arg: Path) -> JsonObject:
+                observed_locked_reads.append(server.refresh_lock.locked())
+                return original_sqlite_summary(db_path_arg, repo_root_arg)
+
+            live.sqlite_summary = locked_sqlite_summary
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            try:
+                host, port = server.server_address
+                status, health = get_json_url(f"http://{host}:{port}/healthz")
+                summary = read_json_url(f"http://{host}:{port}/api/summary")
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=5)
+                live.sqlite_summary = original_sqlite_summary
+
+        self.assertEqual(status, 200)
+        self.assertTrue(health["ok"])
+        self.assertTrue(summary["health"]["ok"])
+        self.assertGreaterEqual(len(observed_locked_reads), 2)
+        self.assertTrue(all(observed_locked_reads))
+
     def test_auto_refresh_state_is_exposed(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             repo_root = Path(temp_dir)

--- a/scripts/test_screeps_rl_live_dashboard.py
+++ b/scripts/test_screeps_rl_live_dashboard.py
@@ -166,6 +166,19 @@ def read_json_url(url: str, timeout: float = 1.0) -> JsonObject:
     return payload
 
 
+def get_json_url(url: str, timeout: float = 1.0) -> tuple[int, JsonObject]:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            status = response.status
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        status = error.code
+        payload = json.loads(error.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise AssertionError(f"expected JSON object from {url}")
+    return status, payload
+
+
 def post_json_url(url: str, timeout: float = 1.0) -> tuple[int, JsonObject]:
     request = urllib.request.Request(url, data=b"", method="POST")
     try:
@@ -355,6 +368,90 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
             summary["safety"]["unsafeFlags"],
         )
 
+    def test_runtime_candidate_injection_uses_newest_relevant_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            artifact_root = repo_root / "runtime-artifacts"
+            write_json(
+                artifact_root / "rl-control-loop" / "old-success.json",
+                {
+                    "createdAt": "2026-05-18T10:00:00Z",
+                    "runtime_parameter_injection": True,
+                },
+            )
+            write_json(
+                artifact_root / "rl-control-loop" / "new-blocked.json",
+                {
+                    "createdAt": "2026-05-18T10:10:00Z",
+                    "runtime_parameter_injection": False,
+                },
+            )
+
+            summary = live.runtime_candidate_injection_summary(artifact_root, repo_root)
+
+        self.assertEqual(summary["status"], "BLOCKED")
+        self.assertEqual(summary["evidence"], "runtime_parameter_injection=False")
+        self.assertTrue(summary["latestPath"].endswith("new-blocked.json"))
+        self.assertEqual(summary["updatedAt"], "2026-05-18T10:10:00Z")
+
+    def test_health_helper_requires_successful_auto_refresh(self) -> None:
+        health = live.health_with_refresh(
+            {"ok": True, "status": "ok", "failures": []},
+            {
+                "mode": "auto",
+                "autoRefreshSeconds": 60,
+                "lastRefreshAt": "2026-05-18T10:09:00Z",
+                "lastRefreshOk": False,
+            },
+        )
+
+        self.assertFalse(health["ok"])
+        self.assertEqual(health["status"], "degraded")
+        self.assertIn("auto-refresh has not completed successfully", health["failures"])
+
+    def test_project_gate_requires_successful_auto_refresh(self) -> None:
+        flywheel_stages = [{"stage": "construction-landed", "status": "OK"}]
+        tencent = {
+            "hasData": True,
+            "runCount": 1,
+            "latest": {"batchScale": {"scaleFirstEligible": True}},
+        }
+        injection = {"status": "OK", "evidence": "runtime_parameter_injection=true"}
+        zero_iteration = {"status": "OK", "evidence": "safe zero-iteration no-op: no update"}
+        pending_refresh = {
+            "mode": "auto",
+            "autoRefreshSeconds": 60,
+            "lastRefreshAt": None,
+            "lastRefreshOk": None,
+        }
+        successful_refresh = {
+            "mode": "auto",
+            "autoRefreshSeconds": 60,
+            "lastRefreshAt": "2026-05-18T10:09:00Z",
+            "lastRefreshOk": True,
+        }
+
+        pending_gates = live.project_gate_summary(
+            flywheel_stages=flywheel_stages,
+            tencent=tencent,
+            injection=injection,
+            zero_iteration=zero_iteration,
+            refresh=pending_refresh,
+        )
+        successful_gates = live.project_gate_summary(
+            flywheel_stages=flywheel_stages,
+            tencent=tencent,
+            injection=injection,
+            zero_iteration=zero_iteration,
+            refresh=successful_refresh,
+        )
+
+        pending_gate = {gate["issue"]: gate for gate in pending_gates}["#1233"]
+        successful_gate = {gate["issue"]: gate for gate in successful_gates}["#1233"]
+        self.assertEqual(pending_gate["status"], "BLOCKED")
+        self.assertEqual(successful_gate["status"], "OK")
+        self.assertIn("lastRefreshOk=True", successful_gate["evidence"])
+
     def test_health_and_summary_endpoints_are_startable(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             repo_root = Path(temp_dir)
@@ -384,6 +481,43 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
         self.assertEqual(summary["dashboardUrl"], f"http://{host}:{port}/")
         self.assertEqual(summary["e1Gate"]["gateId"], "e1-live")
 
+    def test_healthz_fails_when_auto_refresh_failed(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            artifact_root = repo_root / "runtime-artifacts"
+            db_path = repo_root / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite"
+            write_live_artifacts(artifact_root)
+            live.refresh_metrics(db_path, artifact_root)
+            config = live.LiveDashboardConfig(
+                repo_root=repo_root,
+                artifact_root=artifact_root,
+                db_path=db_path,
+                auto_refresh_seconds=60,
+            )
+            try:
+                server = live.make_server("127.0.0.1", 0, config)
+            except OSError as error:
+                self.skipTest(f"socket creation is unavailable in this sandbox: {error}")
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            try:
+                server.record_refresh(
+                    {"ok": False, "error": "ingestor soft failure"},
+                    refreshed_at="2026-05-18T10:09:00Z",
+                )
+                host, port = server.server_address
+                status, health = get_json_url(f"http://{host}:{port}/healthz")
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=5)
+
+        self.assertEqual(status, 503)
+        self.assertFalse(health["ok"])
+        self.assertEqual(health["message"], "DEGRADED")
+        self.assertIn("auto-refresh has not completed successfully", health["failures"])
+        self.assertFalse(health["refresh"]["lastRefreshOk"])
+
     def test_auto_refresh_state_is_exposed(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             repo_root = Path(temp_dir)
@@ -402,6 +536,13 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
             except OSError as error:
                 self.skipTest(f"socket creation is unavailable in this sandbox: {error}")
             try:
+                pending_summary = live.build_live_summary(
+                    repo_root,
+                    artifact_root,
+                    db_path,
+                    generated_at="2026-05-18T10:08:30Z",
+                    refresh=server.refresh_snapshot(),
+                )
                 server.record_refresh({"ok": True, "files_scanned": 1}, refreshed_at="2026-05-18T10:09:00Z")
                 summary = live.build_live_summary(
                     repo_root,
@@ -417,6 +558,11 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
         self.assertEqual(summary["refresh"]["mode"], "auto")
         self.assertEqual(summary["refresh"]["autoRefreshSeconds"], 60)
         self.assertTrue(summary["refresh"]["lastRefreshOk"])
+        pending_gates = {gate["issue"]: gate for gate in pending_summary["projectGates"]}
+        refreshed_gates = {gate["issue"]: gate for gate in summary["projectGates"]}
+        self.assertEqual(pending_gates["#1233"]["status"], "BLOCKED")
+        self.assertEqual(refreshed_gates["#1233"]["status"], "OK")
+        self.assertIn("lastRefreshOk=True", refreshed_gates["#1233"]["evidence"])
         self.assertIn("Last refresh", html)
         self.assertIn("Auto refresh seconds", html)
 
@@ -485,6 +631,47 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
         self.assertFalse(payload["ok"])
         self.assertEqual(payload["error"], "refresh failed")
         self.assertEqual(payload["refresh"]["error"], "ingestor soft failure")
+        self.assertFalse(payload["summary"]["refresh"]["lastRefreshOk"])
+        self.assertEqual(payload["summary"]["refresh"]["lastRefresh"]["error"], "ingestor soft failure")
+
+    def test_refresh_endpoint_records_successful_refresh_state(self) -> None:
+        original_refresh_metrics = live.refresh_metrics
+
+        def successful_refresh_metrics(db_path: Path, artifact_root: Path, paths: Any = None) -> JsonObject:
+            return {"ok": True, "files_scanned": 7}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            artifact_root = repo_root / "runtime-artifacts"
+            db_path = repo_root / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite"
+            write_live_artifacts(artifact_root)
+            config = live.LiveDashboardConfig(
+                repo_root=repo_root,
+                artifact_root=artifact_root,
+                db_path=db_path,
+                enable_refresh_endpoint=True,
+            )
+            try:
+                server = live.make_server("127.0.0.1", 0, config)
+            except OSError as error:
+                self.skipTest(f"socket creation is unavailable in this sandbox: {error}")
+            live.refresh_metrics = successful_refresh_metrics
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            try:
+                host, port = server.server_address
+                wait_for_json_url(f"http://{host}:{port}/api/summary")
+                status, payload = post_json_url(f"http://{host}:{port}/refresh")
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=5)
+                live.refresh_metrics = original_refresh_metrics
+
+        self.assertEqual(status, 200)
+        self.assertTrue(payload["ok"])
+        self.assertTrue(payload["summary"]["refresh"]["lastRefreshOk"])
+        self.assertEqual(payload["summary"]["refresh"]["lastRefresh"]["files_scanned"], 7)
 
     def test_refresh_on_start_returns_failure_when_refresh_reports_not_ok(self) -> None:
         original_refresh_metrics = live.refresh_metrics


### PR DESCRIPTION
## Summary

- restores the lightweight local RL live dashboard as an owner-facing health surface for #879/#1237
- adds auto-refresh state, `/healthz` evidence, SQLite freshness/table counts, flywheel stage/gate summaries, and #879/#1032/#1229/#1233/#1234 gate visibility
- updates the runbook and npm script so `npm run rl-dashboard-live` refreshes on start and every 300 seconds

## Verification

Controller-side recovery verification passed after the Codex implementation got stuck in a post-verification diff-output loop:

- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_live_dashboard.py scripts/test_screeps_rl_live_dashboard.py`
- `python3 scripts/test_screeps_rl_live_dashboard.py` — 10 tests OK
- `npm run rl-metrics-refresh` — `ok=true`
- bounded local server smoke on port 8791: `/healthz` returned `ok=true`, `message=OK`, SQLite table counts, `refresh.mode=auto`, `lastRefreshOk=true`, `autoRefreshSeconds=300`
- final `git diff --check`

Commit: `a5f301507f7f8787daf452e50093f1ded7da82cc` by `lanyusea's bot <lanyusea@gmail.com>`.

Closes #1237.
