### PR TITLE
feat(rl): add act-loop feedback planner

### DIFF
--- a/docs/ops/rl-act-loop-feedback.md
+++ b/docs/ops/rl-act-loop-feedback.md
@@ -1,0 +1,94 @@
+# RL Act-Loop Feedback Runbook
+
+Status: first offline planning surface for issue #1240.
+
+Primary artifacts:
+
+- `scripts/screeps_rl_act_loop_planner.py`
+- `scripts/test_screeps_rl_act_loop_planner.py`
+- `scripts/fixtures/rl/act-loop-mixed-unproven-policy-advantage.json`
+- `docs/ops/rl-reward-decision-registry.md`
+- `docs/ops/rl-training-reward-workflow.md`
+
+## Purpose
+
+The Act loop converts Loop B, policy-advantage, scorecard, or Gameplay Evolution findings into a structured next step:
+
+```text
+online/gameplay finding -> reward/scenario/policy hypothesis -> GitHub-managed decision -> experiment card delta -> training run -> scorecard -> rollout/feedback
+```
+
+Foundation issues #906, #907, and #924 are source contracts only. Their closure is not completion evidence for #1240. A current finding still needs an explicit decision, card delta, training artifact, scorecard, and rollout/feedback state.
+
+## Planner Contract
+
+Generate a deterministic offline plan:
+
+```bash
+python3 scripts/screeps_rl_act_loop_planner.py \
+  runtime-artifacts/rl-control-loop/policy-advantage.json \
+  --source-artifact runtime-artifacts/rl-control-loop/policy-advantage.json \
+  --output runtime-artifacts/rl-control-loop/act-loop-plan.json
+```
+
+The planner only reads JSON and writes JSON. It does not call GitHub, Screeps official APIs, private servers, Tencent compute, cron, deploy, or `prod/` runtime code.
+
+Each plan emits:
+
+- `finding`: stable finding id, title, source artifact, evidence window, primary `classification`, secondary classifications, metric evidence, and missing scenario capabilities when present.
+- `nextRewardDecision`: a #907-style reward decision record route when the finding is a `reward_gap`.
+- `nextScenarioDelta`: a private/shadow scenario or fixture delta when the finding is a `scenario_gap`.
+- `nextPolicyDelta`: a named policy parameter surface with explicit bounds when the finding is a `policy_parameterization_gap`.
+- `nextExperimentCardDelta`: the card-helper-compatible shadow training delta that consumes reward/scenario/policy changes.
+- `feedbackIngestion`: current state for finding -> decision -> card -> training -> scorecard -> rollout feedback.
+- `decision`, `status`, and `blockingReasons`: fields that the SQLite/Grafana ingestion path can count through `metric_iteration_decisions`.
+
+Allowed classifications:
+
+| Classification | Steward route |
+| --- | --- |
+| `data_quality` | Fix evidence, telemetry, compute, or artifact coverage before changing training. |
+| `scenario_gap` | Create or select a private/shadow scenario delta, then update the experiment card. |
+| `reward_gap` | Create or update a #907-style decision record before any reward training use. |
+| `policy_parameterization_gap` | Name the policy surface and bounds, then update the experiment card. |
+| `runtime_bug` | Route to a construction issue; do not disguise runtime fixes as reward tuning. |
+| `rollout_regression` | Preserve rollback evidence before any new training card changes. |
+
+## Steward Consumption
+
+Loop B and RL steward prompts should consume the structured fields directly:
+
+1. If `nextRewardDecision` is present, create or update the reward decision record first. Required fields are metric evidence, hypothesis, validation window, rollback condition, and candidate linkage.
+2. If `nextScenarioDelta` is present, apply it as an experiment-card delta or open a bounded construction issue for the missing fixture. Do not leave it as prose-only advice.
+3. If `nextPolicyDelta` is present, preserve `parameterSurface` and every bound in the experiment card or construction issue. Unbounded policy suggestions remain blocked.
+4. If `nextExperimentCardDelta` is present, generate or update a shadow/offline card with `scripts/screeps_rl_experiment_card.py`, then validate it before training.
+5. After training, update `feedbackIngestion.training`; after scorecard generation, update `feedbackIngestion.scorecard`; after rollout/rollback comparison, update `feedbackIngestion.rolloutFeedback`.
+
+All generated cards and decisions must keep:
+
+```json
+{
+  "liveEffect": false,
+  "officialMmoWrites": false,
+  "officialMmoWritesAllowed": false
+}
+```
+
+## Example
+
+The fixture `scripts/fixtures/rl/act-loop-mixed-unproven-policy-advantage.json` represents a MIXED/UNPROVEN Loop B policy-advantage finding. It is classified as `scenario_gap` with a secondary `policy_parameterization_gap`, producing:
+
+- `nextScenarioDelta.targetScenarioId = "multi-tier-territory-combat-v0"`
+- `nextPolicyDelta.parameterSurface = "construction-priority"` with bounded weights
+- `nextExperimentCardDelta.trainingApproach = "policy_gradient"`
+- no `nextRewardDecision`, because the evidence does not justify reward tuning yet
+
+## Verification
+
+Local checks for planner changes:
+
+```bash
+python3 -m py_compile scripts/screeps_rl_act_loop_planner.py scripts/test_screeps_rl_act_loop_planner.py
+python3 -m unittest scripts/test_screeps_rl_act_loop_planner.py -v
+git diff --check
+```

--- a/docs/ops/rl-training-reward-workflow.md
+++ b/docs/ops/rl-training-reward-workflow.md
@@ -15,7 +15,9 @@ Primary artifacts:
 - `scripts/screeps_rl_simulator_harness.py`
 - `scripts/screeps_rl_mmo_validator.py`
 - `scripts/screeps_rl_rollout_manager.py`
+- `scripts/screeps_rl_act_loop_planner.py`
 - `docs/ops/rl-rollout-rollback.md`
+- `docs/ops/rl-act-loop-feedback.md`
 
 ## Purpose
 
@@ -305,6 +307,7 @@ This workflow cannot promote a candidate to live influence by itself.
 ## Rollout And Feedback
 
 The L6 rollout workflow is documented in `docs/ops/rl-rollout-rollback.md`.
+The Act-loop feedback planner is documented in `docs/ops/rl-act-loop-feedback.md`.
 
 Minimum rollout command set:
 
@@ -315,16 +318,29 @@ python3 scripts/screeps_rl_rollout_manager.py rollback-check --baseline <baselin
 python3 scripts/screeps_rl_rollout_manager.py compare --pre <pre-kpi.json> --post <post-kpi.json>
 ```
 
+Loop B, policy-advantage, and Gameplay Evolution findings must first become a structured Act-loop plan before a steward turns them into training work:
+
+```bash
+python3 scripts/screeps_rl_act_loop_planner.py \
+  runtime-artifacts/rl-control-loop/policy-advantage.json \
+  --source-artifact runtime-artifacts/rl-control-loop/policy-advantage.json \
+  --output runtime-artifacts/rl-control-loop/act-loop-plan.json
+```
+
+Stewards consume `nextRewardDecision`, `nextScenarioDelta`, `nextPolicyDelta`, `nextExperimentCardDelta`, and `feedbackIngestion` from that output. Reward changes route through the #907-style decision registry. Scenario and policy changes must become experiment-card deltas or construction issues, not prose-only recommendations.
+
 ## Verification
 
 Local checks:
 
 ```bash
 python3 -m py_compile scripts/screeps_rl_experiment_card.py
+python3 -m py_compile scripts/screeps_rl_act_loop_planner.py
 python3 -m py_compile scripts/screeps_rl_training_runner.py
 python3 scripts/screeps_rl_experiment_card.py self-test
 python3 scripts/screeps_rl_experiment_card.py --dry-run --dataset-run-id rl-000000000000
 python3 scripts/screeps_rl_experiment_card.py --dry-run --dataset-run-id rl-000000000000 --output /tmp/test-card.json
 python3 scripts/screeps_rl_experiment_card.py --validate --input /tmp/test-card.json
+python3 -m unittest scripts/test_screeps_rl_act_loop_planner.py -v
 python3 -m unittest scripts/test_screeps_rl_training_runner.py -v
 ```

--- a/scripts/fixtures/rl/act-loop-mixed-unproven-policy-advantage.json
+++ b/scripts/fixtures/rl/act-loop-mixed-unproven-policy-advantage.json
@@ -1,0 +1,55 @@
+{
+  "type": "screeps-rl-policy-online-advantage-report",
+  "reportId": "loop-b-mixed-unproven-construction-priority",
+  "title": "Loop B construction-priority advantage is mixed on a single-room scenario",
+  "onlineUtilityStatus": "MIXED",
+  "candidateId": "construction-priority.pg.territory-seed.v1",
+  "incumbentId": "construction-priority.incumbent.v1",
+  "datasetRunId": "rl-loop-b-sample-000001",
+  "evidenceWindow": "2026-05-19T12:00:00Z..2026-05-19T20:00:00Z",
+  "scenarioEvidence": {
+    "scenarioId": "e1s1-single-room-no-hostile",
+    "missingCapabilities": [
+      "multi_room_capable",
+      "adjacent_room_territory_signal",
+      "hostile_combat_signal"
+    ]
+  },
+  "parameterSurface": {
+    "name": "construction-priority",
+    "bounds": [
+      {
+        "name": "territorySignalWeight",
+        "min": 12,
+        "max": 30,
+        "step": 1,
+        "reason": "Loop B cannot prove the territory-seed candidate until a multi-room scenario measures expansion survival."
+      },
+      {
+        "name": "riskPenalty",
+        "min": 4,
+        "max": 18,
+        "step": 1,
+        "reason": "Keep hostile-pressure and construction-risk behavior bounded while the scenario delta is shadow-only."
+      }
+    ]
+  },
+  "hypothesis": "The candidate is mixed because the current card is single-room and cannot distinguish territory retention, remote expansion, or hostile-combat pressure.",
+  "metricsByCategory": {
+    "territory": {
+      "status": "MIXED",
+      "advantageTerritory": 0,
+      "reason": "No adjacent-room survival signal exists in the source card."
+    },
+    "resources": {
+      "status": "UNPROVEN",
+      "advantageResources": 0
+    },
+    "kills": {
+      "status": "UNPROVEN",
+      "advantageKills": 0
+    }
+  },
+  "trainingReportId": "training-loop-b-sample-000001",
+  "scorecardId": "scorecard-loop-b-sample-000001"
+}

--- a/scripts/screeps_rl_act_loop_planner.py
+++ b/scripts/screeps_rl_act_loop_planner.py
@@ -25,6 +25,7 @@ CLASSIFICATIONS = (
     "runtime_bug",
     "rollout_regression",
 )
+BLOCKING_DELTA_CLASSIFICATIONS = {"data_quality", "runtime_bug"}
 REWARD_DECISION_REGISTRY = "docs/ops/rl-reward-decision-registry.md"
 REWARD_DECISION_TEMPLATE = "docs/ops/templates/rl-reward-decision.template.json"
 EXPERIMENT_CARD_HELPER = "scripts/screeps_rl_experiment_card.py"
@@ -236,6 +237,42 @@ def lookup(raw: JsonObject, aliases: Sequence[str]) -> Any:
 
 def first_text(raw: JsonObject, aliases: Sequence[str]) -> str | None:
     return text_value(lookup(raw, aliases))
+
+
+def identifier_text(value: Any) -> str | None:
+    if isinstance(value, dict):
+        return first_text(
+            value,
+            (
+                "id",
+                "artifactId",
+                "reportId",
+                "decisionId",
+                "componentDecisionId",
+                "experimentCardId",
+                "cardId",
+                "trainingRunId",
+                "trainingReportId",
+                "scorecardId",
+                "scorecardArtifact",
+                "rolloutId",
+                "path",
+            ),
+        )
+    if isinstance(value, (str, int, float)):
+        return format_value(value)
+    return None
+
+
+def first_identifier(raw: JsonObject, aliases: Sequence[str]) -> str | None:
+    value = lookup(raw, aliases)
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            identifier = identifier_text(item)
+            if identifier:
+                return identifier
+        return None
+    return identifier_text(value)
 
 
 def nested_lookup(raw: JsonObject, paths: Sequence[Sequence[str]]) -> Any:
@@ -582,16 +619,26 @@ def build_finding_summary(
     return finding
 
 
+def has_delta_blocker(classification: str, secondary: Sequence[str]) -> bool:
+    return classification in BLOCKING_DELTA_CLASSIFICATIONS or any(
+        item in BLOCKING_DELTA_CLASSIFICATIONS for item in secondary
+    )
+
+
 def needs_reward_decision(classification: str, secondary: Sequence[str]) -> bool:
+    if has_delta_blocker(classification, secondary):
+        return False
     return classification == "reward_gap" or "reward_gap" in secondary
 
 
 def needs_scenario_delta(classification: str, secondary: Sequence[str], raw: JsonObject) -> bool:
+    if has_delta_blocker(classification, secondary):
+        return False
     return classification == "scenario_gap" or "scenario_gap" in secondary or bool(infer_missing_capabilities(raw))
 
 
 def needs_policy_delta(classification: str, secondary: Sequence[str], raw: JsonObject) -> bool:
-    if classification in {"data_quality", "runtime_bug"}:
+    if has_delta_blocker(classification, secondary):
         return False
     status = status_key(first_text(raw, ("onlineUtilityStatus", "status", "rawStatus")))
     return (
@@ -752,14 +799,31 @@ def build_feedback_state(
     reward_decision: JsonObject | None,
     card_delta: JsonObject | None,
 ) -> JsonObject:
-    reward_decision_id = first_text(
+    reward_decision_id = first_identifier(
         raw,
-        ("rewardDecisionId", "reward_decision_id", "decisionId", "decision_id", "componentDecisionId"),
+        (
+            "rewardDecisionId",
+            "reward_decision_id",
+            "rewardDecisionIds",
+            "decisionId",
+            "decision_id",
+            "decisionIds",
+            "componentDecisionId",
+        ),
     )
-    experiment_card_id = first_text(raw, ("experimentCardId", "experiment_card_id", "cardId", "card_id"))
-    training_run_id = first_text(raw, ("trainingRunId", "training_run_id", "trainingReportId", "trainingReportIds"))
-    scorecard_id = first_text(raw, ("scorecardId", "scorecard_id", "scorecardArtifact", "scorecard"))
-    rollout_id = first_text(raw, ("rolloutId", "rollout_id"))
+    experiment_card_id = first_identifier(
+        raw,
+        ("experimentCardId", "experiment_card_id", "experimentCardIds", "cardId", "card_id", "cardIds"),
+    )
+    training_run_id = first_identifier(
+        raw,
+        ("trainingRunId", "training_run_id", "trainingReportId", "trainingReportIds", "trainingRunIds"),
+    )
+    scorecard_id = first_identifier(
+        raw,
+        ("scorecardId", "scorecard_id", "scorecardArtifact", "scorecard", "scorecardIds", "scorecards"),
+    )
+    rollout_id = first_identifier(raw, ("rolloutId", "rollout_id", "rolloutIds"))
 
     planned_decision_id = text_value(as_dict(reward_decision).get("componentId")) or f"act-decision:{finding['id']}"
     decision_state = feedback_link_state(
@@ -846,12 +910,17 @@ def build_plan(raw: JsonObject, *, source_artifact: str | None = None) -> JsonOb
         if needs_policy_delta(classification, secondary, raw)
         else None
     )
+    card_policy_delta = (
+        policy_delta
+        if policy_delta is not None and as_list(policy_delta.get("bounds"))
+        else None
+    )
     card_delta = build_experiment_card_delta(
         raw,
         finding=finding,
         reward_decision=reward_decision,
         scenario_delta=scenario_delta,
-        policy_delta=policy_delta,
+        policy_delta=card_policy_delta,
     )
     blocking_reasons = plan_blocking_reasons(
         classification=classification,
@@ -943,13 +1012,17 @@ def build_plans(document: Any, *, source_artifact: str | None = None) -> JsonObj
 
 
 def write_json_atomic(path: Path, payload: Any) -> None:
+    write_text_atomic(path, canonical_json(payload))
+
+
+def write_text_atomic(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temp_fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
     temp_path = Path(temp_name)
     try:
         with os.fdopen(temp_fd, "w", encoding="utf-8") as handle:
             temp_fd = -1
-            handle.write(canonical_json(payload))
+            handle.write(content)
         os.replace(temp_path, path)
     finally:
         if temp_fd != -1:
@@ -977,13 +1050,27 @@ def main(argv: Sequence[str] | None = None, *, stdout: TextIO = sys.stdout, stde
     args = parse_args(argv if argv is not None else sys.argv[1:])
     try:
         plan = build_plans(load_json(args.input_json), source_artifact=args.source_artifact)
-        if args.output:
-            write_json_atomic(args.output, plan)
-        else:
-            stdout.write(canonical_json(plan))
-        return 0
     except PlannerInputError as error:
         print(f"error: {error}", file=stderr)
+        return 1
+    except OSError as error:
+        print(f"error: I/O failure: {error}", file=stderr)
+        return 1
+
+    try:
+        rendered = canonical_json(plan)
+    except (TypeError, ValueError) as error:
+        print(f"error: failed to serialize plan JSON: {error}", file=stderr)
+        return 1
+
+    try:
+        if args.output:
+            write_text_atomic(args.output, rendered)
+        else:
+            stdout.write(rendered)
+        return 0
+    except OSError as error:
+        print(f"error: I/O failure: {error}", file=stderr)
         return 1
 
 

--- a/scripts/screeps_rl_act_loop_planner.py
+++ b/scripts/screeps_rl_act_loop_planner.py
@@ -33,6 +33,7 @@ SCORECARD_HELPER = "scripts/screeps_rl_scorecard.py"
 DEFAULT_SCENARIO_ID = "e1s1-single-room-no-hostile"
 MULTI_TIER_SCENARIO_ID = "multi-tier-territory-combat-v0"
 UNPROVEN_ONLINE_STATUSES = {"MIXED", "UNPROVEN", "INCONCLUSIVE", "BLOCKED", "BLOCKED_NO_COMPUTE"}
+BLOCKING_ONLINE_EVIDENCE_STATUSES = {"BLOCKED", "BLOCKED_NO_COMPUTE"}
 
 JsonObject = dict[str, Any]
 
@@ -265,14 +266,18 @@ def identifier_text(value: Any) -> str | None:
 
 
 def first_identifier(raw: JsonObject, aliases: Sequence[str]) -> str | None:
-    value = lookup(raw, aliases)
-    if isinstance(value, (list, tuple)):
-        for item in value:
-            identifier = identifier_text(item)
-            if identifier:
-                return identifier
-        return None
-    return identifier_text(value)
+    for alias in aliases:
+        value = lookup(raw, (alias,))
+        if isinstance(value, (list, tuple)):
+            for item in value:
+                identifier = identifier_text(item)
+                if identifier:
+                    return identifier
+            continue
+        identifier = identifier_text(value)
+        if identifier:
+            return identifier
+    return None
 
 
 def nested_lookup(raw: JsonObject, paths: Sequence[Sequence[str]]) -> Any:
@@ -302,6 +307,24 @@ def string_list(value: Any) -> list[str]:
 def status_key(raw: Any) -> str | None:
     text = text_value(raw)
     return text.upper().replace("-", "_") if text else None
+
+
+def has_blocking_evidence_gap(raw: JsonObject) -> bool:
+    statuses = {
+        status_key(lookup(raw, aliases))
+        for aliases in (
+            ("onlineUtilityStatus",),
+            ("onlineStatus",),
+            ("status",),
+            ("rawStatus",),
+        )
+    }
+    if statuses & BLOCKING_ONLINE_EVIDENCE_STATUSES:
+        return True
+    return any(
+        isinstance(status, str) and ("NO_COMPUTE" in status or "NO_EVIDENCE" in status)
+        for status in statuses
+    )
 
 
 def text_blob(raw: JsonObject) -> str:
@@ -335,7 +358,12 @@ def text_blob(raw: JsonObject) -> str:
 def infer_classification(raw: JsonObject) -> str:
     explicit = classification_key(lookup(raw, ("classification", "actLoopClassification", "findingClassification")))
     if explicit:
+        if explicit not in BLOCKING_DELTA_CLASSIFICATIONS and has_blocking_evidence_gap(raw):
+            return "data_quality"
         return explicit
+
+    if has_blocking_evidence_gap(raw):
+        return "data_quality"
 
     missing_capabilities = infer_missing_capabilities(raw)
     if missing_capabilities:

--- a/scripts/screeps_rl_act_loop_planner.py
+++ b/scripts/screeps_rl_act_loop_planner.py
@@ -34,6 +34,18 @@ DEFAULT_SCENARIO_ID = "e1s1-single-room-no-hostile"
 MULTI_TIER_SCENARIO_ID = "multi-tier-territory-combat-v0"
 UNPROVEN_ONLINE_STATUSES = {"MIXED", "UNPROVEN", "INCONCLUSIVE", "BLOCKED", "BLOCKED_NO_COMPUTE"}
 BLOCKING_ONLINE_EVIDENCE_STATUSES = {"BLOCKED", "BLOCKED_NO_COMPUTE"}
+POLICY_SURFACE_NAME_ALIASES = (
+    "name",
+    "id",
+    "surface",
+    "parameterSurface",
+    "policySurface",
+    "policy_surface",
+    "strategyFamily",
+    "family",
+    "targetFamily",
+    "target_family",
+)
 
 JsonObject = dict[str, Any]
 
@@ -293,6 +305,35 @@ def nested_lookup(raw: JsonObject, paths: Sequence[Sequence[str]]) -> Any:
     return None
 
 
+def named_text(value: Any, aliases: Sequence[str]) -> str | None:
+    text = text_value(value)
+    if text:
+        return text
+    if not isinstance(value, dict):
+        return None
+    for alias in aliases:
+        text = text_value(lookup(value, (alias,)))
+        if text:
+            return text
+    return None
+
+
+def first_named_text(raw: JsonObject, aliases: Sequence[str], name_aliases: Sequence[str]) -> str | None:
+    for alias in aliases:
+        text = named_text(lookup(raw, (alias,)), name_aliases)
+        if text:
+            return text
+    return None
+
+
+def first_nested_named_text(raw: JsonObject, paths: Sequence[Sequence[str]], name_aliases: Sequence[str]) -> str | None:
+    for path in paths:
+        text = named_text(nested_lookup(raw, (path,)), name_aliases)
+        if text:
+            return text
+    return None
+
+
 def string_list(value: Any) -> list[str]:
     if isinstance(value, str):
         text = text_value(value)
@@ -501,7 +542,7 @@ def infer_target_scenario_id(raw: JsonObject) -> str:
 
 
 def infer_policy_surface(raw: JsonObject) -> str:
-    explicit = first_text(
+    explicit = first_named_text(
         raw,
         (
             "parameterSurface",
@@ -510,21 +551,25 @@ def infer_policy_surface(raw: JsonObject) -> str:
             "strategyFamily",
             "family",
             "targetFamily",
+            "target_family",
         ),
+        POLICY_SURFACE_NAME_ALIASES,
     )
     if explicit:
         return explicit
-    nested = nested_lookup(
+    nested = first_nested_named_text(
         raw,
         (
             ("policyDelta", "parameterSurface"),
             ("policyDelta", "policySurface"),
-            ("parameterSurface", "name"),
+            ("policyDelta", "strategyFamily"),
+            ("parameterSurface",),
             ("policy", "target_family"),
         ),
+        POLICY_SURFACE_NAME_ALIASES,
     )
-    if text_value(nested):
-        return str(nested)
+    if nested:
+        return nested
     blob = text_blob(raw)
     if "construction" in blob or "build" in blob:
         return "construction-priority"
@@ -534,20 +579,21 @@ def infer_policy_surface(raw: JsonObject) -> str:
 
 
 def infer_policy_bounds(raw: JsonObject, surface: str) -> list[JsonObject]:
-    raw_bounds = lookup(raw, ("bounds", "parameterBounds", "policyBounds"))
-    if raw_bounds is None:
-        raw_bounds = nested_lookup(
-            raw,
-            (
-                ("policyDelta", "bounds"),
-                ("parameterSurface", "bounds"),
-                ("parameterSurface", "parameters"),
-                ("policy", "learnable_parameters"),
-            ),
-        )
-    bounds = normalize_bounds(raw_bounds)
-    if bounds:
-        return bounds
+    for raw_bounds in (
+        lookup(raw, ("bounds",)),
+        lookup(raw, ("parameterBounds",)),
+        lookup(raw, ("policyBounds",)),
+        nested_lookup(raw, (("policyDelta", "bounds"),)),
+        nested_lookup(raw, (("policyDelta", "parameterSurface", "bounds"),)),
+        nested_lookup(raw, (("policyDelta", "parameterSurface", "parameters"),)),
+        nested_lookup(raw, (("policyDelta", "parameterSurface"),)),
+        nested_lookup(raw, (("parameterSurface", "bounds"),)),
+        nested_lookup(raw, (("parameterSurface", "parameters"),)),
+        nested_lookup(raw, (("policy", "learnable_parameters"),)),
+    ):
+        bounds = normalize_bounds(raw_bounds)
+        if bounds:
+            return bounds
     if surface == "construction-priority":
         return [dict(item) for item in CONSTRUCTION_PRIORITY_BOUNDS]
     return []

--- a/scripts/screeps_rl_act_loop_planner.py
+++ b/scripts/screeps_rl_act_loop_planner.py
@@ -25,7 +25,7 @@ CLASSIFICATIONS = (
     "runtime_bug",
     "rollout_regression",
 )
-BLOCKING_DELTA_CLASSIFICATIONS = {"data_quality", "runtime_bug"}
+BLOCKING_DELTA_CLASSIFICATIONS = {"data_quality", "runtime_bug", "rollout_regression"}
 REWARD_DECISION_REGISTRY = "docs/ops/rl-reward-decision-registry.md"
 REWARD_DECISION_TEMPLATE = "docs/ops/templates/rl-reward-decision.template.json"
 EXPERIMENT_CARD_HELPER = "scripts/screeps_rl_experiment_card.py"

--- a/scripts/screeps_rl_act_loop_planner.py
+++ b/scripts/screeps_rl_act_loop_planner.py
@@ -34,6 +34,7 @@ DEFAULT_SCENARIO_ID = "e1s1-single-room-no-hostile"
 MULTI_TIER_SCENARIO_ID = "multi-tier-territory-combat-v0"
 UNPROVEN_ONLINE_STATUSES = {"MIXED", "UNPROVEN", "INCONCLUSIVE", "BLOCKED", "BLOCKED_NO_COMPUTE"}
 BLOCKING_ONLINE_EVIDENCE_STATUSES = {"BLOCKED", "BLOCKED_NO_COMPUTE"}
+ONLINE_STATUS_ALIASES = ("onlineUtilityStatus", "onlineStatus", "status", "rawStatus")
 POLICY_SURFACE_NAME_ALIASES = (
     "name",
     "id",
@@ -56,44 +57,6 @@ SAFETY_BLOCK: JsonObject = {
     "officialMmoWritesAllowed": False,
     "ood_rejection": True,
 }
-
-CONSTRUCTION_PRIORITY_BOUNDS: tuple[JsonObject, ...] = (
-    {
-        "name": "baseScoreWeight",
-        "min": 0,
-        "max": 3,
-        "step": 0.1,
-        "reason": "Preserve incumbent score influence without allowing it to dominate territory-first signals.",
-    },
-    {
-        "name": "territorySignalWeight",
-        "min": 0,
-        "max": 30,
-        "step": 1,
-        "reason": "Bound the first gameplay objective for territory expansion and retention.",
-    },
-    {
-        "name": "resourceSignalWeight",
-        "min": 0,
-        "max": 30,
-        "step": 1,
-        "reason": "Bound the second gameplay objective after territory is not worse.",
-    },
-    {
-        "name": "killSignalWeight",
-        "min": 0,
-        "max": 30,
-        "step": 1,
-        "reason": "Bound the third gameplay objective for hostile pressure response.",
-    },
-    {
-        "name": "riskPenalty",
-        "min": 0,
-        "max": 30,
-        "step": 1,
-        "reason": "Keep safety/risk penalties explicit for rollback and scorecard checks.",
-    },
-)
 
 CLASSIFICATION_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
     (
@@ -309,10 +272,16 @@ def named_text(value: Any, aliases: Sequence[str]) -> str | None:
     text = text_value(value)
     if text:
         return text
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            text = named_text(item, aliases)
+            if text:
+                return text
+        return None
     if not isinstance(value, dict):
         return None
     for alias in aliases:
-        text = text_value(lookup(value, (alias,)))
+        text = named_text(lookup(value, (alias,)), aliases)
         if text:
             return text
     return None
@@ -353,12 +322,7 @@ def status_key(raw: Any) -> str | None:
 def has_blocking_evidence_gap(raw: JsonObject) -> bool:
     statuses = {
         status_key(lookup(raw, aliases))
-        for aliases in (
-            ("onlineUtilityStatus",),
-            ("onlineStatus",),
-            ("status",),
-            ("rawStatus",),
-        )
+        for aliases in ((alias,) for alias in ONLINE_STATUS_ALIASES)
     }
     if statuses & BLOCKING_ONLINE_EVIDENCE_STATUSES:
         return True
@@ -378,7 +342,9 @@ def text_blob(raw: JsonObject) -> str:
         "hypothesis",
         "classification",
         "onlineUtilityStatus",
+        "onlineStatus",
         "status",
+        "rawStatus",
         "kpiDeltaObserved",
         "targetArea",
         "expectedKpiMovement",
@@ -415,7 +381,7 @@ def infer_classification(raw: JsonObject) -> str:
         if any(keyword in blob for keyword in keywords):
             return classification
 
-    if status_key(first_text(raw, ("onlineUtilityStatus", "onlineStatus", "status"))) in UNPROVEN_ONLINE_STATUSES:
+    if status_key(first_text(raw, ONLINE_STATUS_ALIASES)) in UNPROVEN_ONLINE_STATUSES:
         return "policy_parameterization_gap"
     return "data_quality"
 
@@ -424,11 +390,7 @@ def secondary_classifications(raw: JsonObject, primary: str) -> list[str]:
     blob = text_blob(raw)
     statuses = {
         status_key(lookup(raw, aliases))
-        for aliases in (
-            ("onlineUtilityStatus",),
-            ("status",),
-            ("rawStatus",),
-        )
+        for aliases in ((alias,) for alias in ONLINE_STATUS_ALIASES)
     }
     inferred: list[str] = []
     if primary != "policy_parameterization_gap" and (
@@ -475,7 +437,7 @@ def infer_finding_id(raw: JsonObject) -> str:
     stable = {
         "title": first_text(raw, ("title", "summary")),
         "window": first_text(raw, ("evidenceWindow", "window", "observedWindow")),
-        "status": first_text(raw, ("onlineUtilityStatus", "status")),
+        "status": first_text(raw, ONLINE_STATUS_ALIASES),
         "candidate": first_text(raw, ("candidateId", "candidate_id")),
         "incumbent": first_text(raw, ("incumbentId", "incumbent_id", "baselineId")),
     }
@@ -536,7 +498,8 @@ def infer_target_scenario_id(raw: JsonObject) -> str:
     if explicit:
         return explicit
     missing = infer_missing_capabilities(raw)
-    if missing or (infer_source_scenario_id(raw) == DEFAULT_SCENARIO_ID and status_key(raw.get("onlineUtilityStatus")) in UNPROVEN_ONLINE_STATUSES):
+    online_status = status_key(first_text(raw, ONLINE_STATUS_ALIASES))
+    if missing or (infer_source_scenario_id(raw) == DEFAULT_SCENARIO_ID and online_status in UNPROVEN_ONLINE_STATUSES):
         return MULTI_TIER_SCENARIO_ID
     return infer_source_scenario_id(raw) or DEFAULT_SCENARIO_ID
 
@@ -563,6 +526,9 @@ def infer_policy_surface(raw: JsonObject) -> str:
             ("policyDelta", "parameterSurface"),
             ("policyDelta", "policySurface"),
             ("policyDelta", "strategyFamily"),
+            ("policyDelta", "family"),
+            ("policyDelta", "targetFamily"),
+            ("policyDelta", "target_family"),
             ("parameterSurface",),
             ("policy", "target_family"),
         ),
@@ -587,16 +553,45 @@ def infer_policy_bounds(raw: JsonObject, surface: str) -> list[JsonObject]:
         nested_lookup(raw, (("policyDelta", "parameterSurface", "bounds"),)),
         nested_lookup(raw, (("policyDelta", "parameterSurface", "parameters"),)),
         nested_lookup(raw, (("policyDelta", "parameterSurface"),)),
+        nested_lookup(raw, (("policyDelta", "family"),)),
+        nested_lookup(raw, (("policyDelta", "targetFamily"),)),
+        nested_lookup(raw, (("policyDelta", "target_family"),)),
         nested_lookup(raw, (("parameterSurface", "bounds"),)),
         nested_lookup(raw, (("parameterSurface", "parameters"),)),
         nested_lookup(raw, (("policy", "learnable_parameters"),)),
     ):
-        bounds = normalize_bounds(raw_bounds)
-        if bounds:
-            return bounds
-    if surface == "construction-priority":
-        return [dict(item) for item in CONSTRUCTION_PRIORITY_BOUNDS]
+        for candidate in policy_bound_candidates(raw_bounds):
+            bounds = normalize_bounds(candidate)
+            if bounds:
+                return bounds
     return []
+
+
+def policy_bound_candidates(value: Any) -> list[Any]:
+    candidates = [value]
+    if isinstance(value, dict):
+        for alias in (
+            "bounds",
+            "parameters",
+            "parameterBounds",
+            "policyBounds",
+            "learnable_parameters",
+            "parameterSurface",
+            "policySurface",
+            "policy_surface",
+            "strategyFamily",
+            "family",
+            "targetFamily",
+            "target_family",
+        ):
+            nested = lookup(value, (alias,))
+            if nested is not None:
+                candidates.extend(policy_bound_candidates(nested))
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            if isinstance(item, (dict, list, tuple)):
+                candidates.extend(policy_bound_candidates(item))
+    return candidates
 
 
 def normalize_bounds(raw_bounds: Any) -> list[JsonObject]:
@@ -674,7 +669,7 @@ def build_finding_summary(
     for output_key, aliases in (
         ("sourceArtifact", ("sourceArtifact", "source_artifact", "sourceReviewArtifact", "reviewArtifact", "artifact")),
         ("evidenceWindow", ("evidenceWindow", "evidence_window", "window", "observedWindow")),
-        ("onlineUtilityStatus", ("onlineUtilityStatus", "onlineStatus", "status", "rawStatus")),
+        ("onlineUtilityStatus", ONLINE_STATUS_ALIASES),
         ("candidateId", ("candidateId", "candidate_id")),
         ("incumbentId", ("incumbentId", "incumbent_id", "baselineId", "baseline_id")),
         ("hypothesis", ("hypothesis",)),
@@ -714,7 +709,7 @@ def needs_scenario_delta(classification: str, secondary: Sequence[str], raw: Jso
 def needs_policy_delta(classification: str, secondary: Sequence[str], raw: JsonObject) -> bool:
     if has_delta_blocker(classification, secondary):
         return False
-    status = status_key(first_text(raw, ("onlineUtilityStatus", "status", "rawStatus")))
+    status = status_key(first_text(raw, ONLINE_STATUS_ALIASES))
     return (
         classification == "policy_parameterization_gap"
         or "policy_parameterization_gap" in secondary
@@ -795,6 +790,10 @@ def build_policy_delta(raw: JsonObject, *, finding: JsonObject) -> JsonObject | 
     if candidate_id:
         delta["candidatePolicyId"] = candidate_id
     return delta
+
+
+def has_missing_policy_bounds(policy_delta: JsonObject | None) -> bool:
+    return policy_delta is not None and not as_list(policy_delta.get("bounds"))
 
 
 def build_experiment_card_delta(
@@ -984,17 +983,16 @@ def build_plan(raw: JsonObject, *, source_artifact: str | None = None) -> JsonOb
         if needs_policy_delta(classification, secondary, raw)
         else None
     )
-    card_policy_delta = (
-        policy_delta
-        if policy_delta is not None and as_list(policy_delta.get("bounds"))
-        else None
-    )
-    card_delta = build_experiment_card_delta(
-        raw,
-        finding=finding,
-        reward_decision=reward_decision,
-        scenario_delta=scenario_delta,
-        policy_delta=card_policy_delta,
+    card_delta = (
+        None
+        if has_missing_policy_bounds(policy_delta)
+        else build_experiment_card_delta(
+            raw,
+            finding=finding,
+            reward_decision=reward_decision,
+            scenario_delta=scenario_delta,
+            policy_delta=policy_delta,
+        )
     )
     blocking_reasons = plan_blocking_reasons(
         classification=classification,

--- a/scripts/screeps_rl_act_loop_planner.py
+++ b/scripts/screeps_rl_act_loop_planner.py
@@ -1,0 +1,991 @@
+#!/usr/bin/env python3
+"""Plan offline RL Act-loop follow-up from gameplay or policy findings."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Sequence, TextIO
+
+
+PLAN_TYPE = "screeps-rl-act-loop-plan"
+BATCH_TYPE = "screeps-rl-act-loop-plan-batch"
+SCHEMA_VERSION = 1
+CLASSIFICATIONS = (
+    "data_quality",
+    "scenario_gap",
+    "reward_gap",
+    "policy_parameterization_gap",
+    "runtime_bug",
+    "rollout_regression",
+)
+REWARD_DECISION_REGISTRY = "docs/ops/rl-reward-decision-registry.md"
+REWARD_DECISION_TEMPLATE = "docs/ops/templates/rl-reward-decision.template.json"
+EXPERIMENT_CARD_HELPER = "scripts/screeps_rl_experiment_card.py"
+SCORECARD_HELPER = "scripts/screeps_rl_scorecard.py"
+DEFAULT_SCENARIO_ID = "e1s1-single-room-no-hostile"
+MULTI_TIER_SCENARIO_ID = "multi-tier-territory-combat-v0"
+UNPROVEN_ONLINE_STATUSES = {"MIXED", "UNPROVEN", "INCONCLUSIVE", "BLOCKED", "BLOCKED_NO_COMPUTE"}
+
+JsonObject = dict[str, Any]
+
+SAFETY_BLOCK: JsonObject = {
+    "conservative_actions_only": True,
+    "liveEffect": False,
+    "officialMmoWrites": False,
+    "officialMmoWritesAllowed": False,
+    "ood_rejection": True,
+}
+
+CONSTRUCTION_PRIORITY_BOUNDS: tuple[JsonObject, ...] = (
+    {
+        "name": "baseScoreWeight",
+        "min": 0,
+        "max": 3,
+        "step": 0.1,
+        "reason": "Preserve incumbent score influence without allowing it to dominate territory-first signals.",
+    },
+    {
+        "name": "territorySignalWeight",
+        "min": 0,
+        "max": 30,
+        "step": 1,
+        "reason": "Bound the first gameplay objective for territory expansion and retention.",
+    },
+    {
+        "name": "resourceSignalWeight",
+        "min": 0,
+        "max": 30,
+        "step": 1,
+        "reason": "Bound the second gameplay objective after territory is not worse.",
+    },
+    {
+        "name": "killSignalWeight",
+        "min": 0,
+        "max": 30,
+        "step": 1,
+        "reason": "Bound the third gameplay objective for hostile pressure response.",
+    },
+    {
+        "name": "riskPenalty",
+        "min": 0,
+        "max": 30,
+        "step": 1,
+        "reason": "Keep safety/risk penalties explicit for rollback and scorecard checks.",
+    },
+)
+
+CLASSIFICATION_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "runtime_bug",
+        (
+            "exception",
+            "traceback",
+            "crash",
+            "runtime bug",
+            "tick-loop",
+            "loop exception",
+            "uncaught",
+            "typeerror",
+        ),
+    ),
+    (
+        "rollout_regression",
+        (
+            "rollout regression",
+            "rolled back",
+            "rollback",
+            "post-rollout",
+            "canary regression",
+            "deployed candidate regressed",
+        ),
+    ),
+    (
+        "data_quality",
+        (
+            "data quality",
+            "missing telemetry",
+            "missing metric",
+            "no compute",
+            "preflight only",
+            "malformed",
+            "coverage gap",
+            "stale artifact",
+            "missing source",
+        ),
+    ),
+    (
+        "reward_gap",
+        (
+            "reward",
+            "lexicographic",
+            "score shaping",
+            "reward decision",
+            "reward gap",
+        ),
+    ),
+    (
+        "scenario_gap",
+        (
+            "scenario",
+            "fixture",
+            "single-room",
+            "multi-tier",
+            "adjacent room",
+            "hostile combat",
+            "private map",
+            "out-of-distribution",
+            "training coverage",
+        ),
+    ),
+    (
+        "policy_parameterization_gap",
+        (
+            "policy",
+            "parameter",
+            "bounds",
+            "candidate vector",
+            "policy gradient",
+            "knob",
+            "weight",
+            "mixed",
+            "unproven",
+        ),
+    ),
+)
+
+
+class PlannerInputError(ValueError):
+    """Raised when a finding cannot be converted into an Act-loop plan."""
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+
+
+def canonical_hash(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    ).hexdigest()
+
+
+def normalize_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", value.lower())
+
+
+def classification_key(value: Any) -> str | None:
+    text = text_value(value)
+    if not text:
+        return None
+    normalized = normalize_key(text)
+    for classification in CLASSIFICATIONS:
+        if normalize_key(classification) == normalized:
+            return classification
+    return None
+
+
+def as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def text_value(value: Any) -> str | None:
+    if isinstance(value, str):
+        stripped = " ".join(value.strip().split())
+        return stripped or None
+    return None
+
+
+def format_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, str):
+        return " ".join(value.strip().split())
+    if isinstance(value, list):
+        return "; ".join(format_value(item) for item in value if format_value(item))
+    if isinstance(value, dict):
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return str(value)
+
+
+def value_index(raw: JsonObject) -> dict[str, Any]:
+    return {normalize_key(str(key)): value for key, value in raw.items()}
+
+
+def lookup(raw: JsonObject, aliases: Sequence[str]) -> Any:
+    indexed = value_index(raw)
+    for alias in aliases:
+        key = normalize_key(alias)
+        if key in indexed:
+            return indexed[key]
+    return None
+
+
+def first_text(raw: JsonObject, aliases: Sequence[str]) -> str | None:
+    return text_value(lookup(raw, aliases))
+
+
+def nested_lookup(raw: JsonObject, paths: Sequence[Sequence[str]]) -> Any:
+    for path in paths:
+        current: Any = raw
+        for key in path:
+            if not isinstance(current, dict):
+                current = None
+                break
+            current = lookup(current, (key,))
+        if current is not None:
+            return current
+    return None
+
+
+def string_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        text = text_value(value)
+        return [text] if text else []
+    if isinstance(value, list):
+        return [item for item in (format_value(item) for item in value) if item]
+    if isinstance(value, tuple):
+        return [item for item in (format_value(item) for item in value) if item]
+    return []
+
+
+def status_key(raw: Any) -> str | None:
+    text = text_value(raw)
+    return text.upper().replace("-", "_") if text else None
+
+
+def text_blob(raw: JsonObject) -> str:
+    selected: list[str] = []
+    for key in (
+        "type",
+        "artifactType",
+        "title",
+        "summary",
+        "hypothesis",
+        "classification",
+        "onlineUtilityStatus",
+        "status",
+        "kpiDeltaObserved",
+        "targetArea",
+        "expectedKpiMovement",
+        "rollbackStopCondition",
+        "evidence",
+    ):
+        selected.append(format_value(lookup(raw, (key,))))
+    for nested in (
+        as_dict(raw.get("scenarioEvidence")),
+        as_dict(raw.get("scenario")),
+        as_dict(raw.get("policyDelta")),
+        as_dict(raw.get("parameterSurface")),
+    ):
+        selected.append(format_value(nested))
+    return " ".join(item.lower() for item in selected if item)
+
+
+def infer_classification(raw: JsonObject) -> str:
+    explicit = classification_key(lookup(raw, ("classification", "actLoopClassification", "findingClassification")))
+    if explicit:
+        return explicit
+
+    missing_capabilities = infer_missing_capabilities(raw)
+    if missing_capabilities:
+        return "scenario_gap"
+
+    blob = text_blob(raw)
+    for classification, keywords in CLASSIFICATION_KEYWORDS:
+        if any(keyword in blob for keyword in keywords):
+            return classification
+
+    if status_key(first_text(raw, ("onlineUtilityStatus", "onlineStatus", "status"))) in UNPROVEN_ONLINE_STATUSES:
+        return "policy_parameterization_gap"
+    return "data_quality"
+
+
+def secondary_classifications(raw: JsonObject, primary: str) -> list[str]:
+    blob = text_blob(raw)
+    statuses = {
+        status_key(lookup(raw, aliases))
+        for aliases in (
+            ("onlineUtilityStatus",),
+            ("status",),
+            ("rawStatus",),
+        )
+    }
+    inferred: list[str] = []
+    if primary != "policy_parameterization_gap" and (
+        statuses & UNPROVEN_ONLINE_STATUSES or any(token in blob for token in ("policy", "parameter", "bounds", "candidate"))
+    ):
+        inferred.append("policy_parameterization_gap")
+    if primary != "scenario_gap" and (
+        infer_missing_capabilities(raw) or any(token in blob for token in ("scenario", "fixture", "single-room", "multi-tier"))
+    ):
+        inferred.append("scenario_gap")
+    if primary != "reward_gap" and has_reward_signal(raw):
+        inferred.append("reward_gap")
+    return [item for index, item in enumerate(inferred) if item not in inferred[:index]]
+
+
+def has_reward_signal(raw: JsonObject) -> bool:
+    if classification_key(lookup(raw, ("classification", "actLoopClassification", "findingClassification"))) == "reward_gap":
+        return True
+    for aliases in (
+        ("rewardDecisionId", "reward_decision_id"),
+        ("rewardComponent", "reward_component"),
+        ("componentId", "component_id"),
+    ):
+        if first_text(raw, aliases):
+            return True
+    reward_text = " ".join(
+        format_value(lookup(raw, aliases)).lower()
+        for aliases in (
+            ("title", "summary", "findingTitle"),
+            ("hypothesis",),
+            ("kpiDeltaObserved",),
+            ("targetArea",),
+            ("expectedKpiMovement",),
+            ("rollbackStopCondition", "rollbackCondition"),
+        )
+    )
+    return any(token in reward_text for token in ("reward", "reward decision", "score shaping"))
+
+
+def infer_finding_id(raw: JsonObject) -> str:
+    explicit = first_text(raw, ("findingId", "finding_id", "reportId", "report_id", "id", "artifactId"))
+    if explicit:
+        return explicit
+    stable = {
+        "title": first_text(raw, ("title", "summary")),
+        "window": first_text(raw, ("evidenceWindow", "window", "observedWindow")),
+        "status": first_text(raw, ("onlineUtilityStatus", "status")),
+        "candidate": first_text(raw, ("candidateId", "candidate_id")),
+        "incumbent": first_text(raw, ("incumbentId", "incumbent_id", "baselineId")),
+    }
+    return f"act-finding-{canonical_hash(stable)[:12]}"
+
+
+def infer_title(raw: JsonObject, finding_id: str) -> str:
+    return first_text(raw, ("title", "summary", "findingTitle", "issueTitle")) or f"Act-loop finding {finding_id}"
+
+
+def infer_source_artifact(raw: JsonObject, source_artifact: str | None) -> str | None:
+    return source_artifact or first_text(
+        raw,
+        (
+            "sourceArtifact",
+            "source_artifact",
+            "sourceReviewArtifact",
+            "reviewArtifact",
+            "artifact",
+            "path",
+        ),
+    )
+
+
+def infer_missing_capabilities(raw: JsonObject) -> list[str]:
+    candidates: list[str] = []
+    for value in (
+        lookup(raw, ("missingCapabilities", "missing_capabilities")),
+        nested_lookup(raw, (("scenarioEvidence", "missingCapabilities"), ("scenario", "missingCapabilities"))),
+    ):
+        candidates.extend(string_list(value))
+
+    scenario = as_dict(raw.get("scenario"))
+    capabilities = as_dict(scenario.get("capabilities"))
+    if capabilities:
+        for capability in ("multi_room_capable", "adjacent_room_territory_signal", "hostile_combat_signal"):
+            if capabilities.get(capability) is False:
+                candidates.append(capability)
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for item in candidates:
+        key = item.strip()
+        if key and key not in seen:
+            normalized.append(key)
+            seen.add(key)
+    return normalized
+
+
+def infer_source_scenario_id(raw: JsonObject) -> str | None:
+    return first_text(raw, ("scenarioId", "scenario_id")) or text_value(
+        nested_lookup(raw, (("scenarioEvidence", "scenarioId"), ("scenario", "scenario_id"), ("scenario", "scenarioId")))
+    )
+
+
+def infer_target_scenario_id(raw: JsonObject) -> str:
+    explicit = first_text(raw, ("targetScenarioId", "nextScenarioId", "scenarioDeltaTarget"))
+    if explicit:
+        return explicit
+    missing = infer_missing_capabilities(raw)
+    if missing or (infer_source_scenario_id(raw) == DEFAULT_SCENARIO_ID and status_key(raw.get("onlineUtilityStatus")) in UNPROVEN_ONLINE_STATUSES):
+        return MULTI_TIER_SCENARIO_ID
+    return infer_source_scenario_id(raw) or DEFAULT_SCENARIO_ID
+
+
+def infer_policy_surface(raw: JsonObject) -> str:
+    explicit = first_text(
+        raw,
+        (
+            "parameterSurface",
+            "policySurface",
+            "policy_surface",
+            "strategyFamily",
+            "family",
+            "targetFamily",
+        ),
+    )
+    if explicit:
+        return explicit
+    nested = nested_lookup(
+        raw,
+        (
+            ("policyDelta", "parameterSurface"),
+            ("policyDelta", "policySurface"),
+            ("parameterSurface", "name"),
+            ("policy", "target_family"),
+        ),
+    )
+    if text_value(nested):
+        return str(nested)
+    blob = text_blob(raw)
+    if "construction" in blob or "build" in blob:
+        return "construction-priority"
+    if "expansion" in blob or "reserve" in blob or "remote" in blob:
+        return "expansion-remote"
+    return "unspecified-policy-surface"
+
+
+def infer_policy_bounds(raw: JsonObject, surface: str) -> list[JsonObject]:
+    raw_bounds = lookup(raw, ("bounds", "parameterBounds", "policyBounds"))
+    if raw_bounds is None:
+        raw_bounds = nested_lookup(
+            raw,
+            (
+                ("policyDelta", "bounds"),
+                ("parameterSurface", "bounds"),
+                ("parameterSurface", "parameters"),
+                ("policy", "learnable_parameters"),
+            ),
+        )
+    bounds = normalize_bounds(raw_bounds)
+    if bounds:
+        return bounds
+    if surface == "construction-priority":
+        return [dict(item) for item in CONSTRUCTION_PRIORITY_BOUNDS]
+    return []
+
+
+def normalize_bounds(raw_bounds: Any) -> list[JsonObject]:
+    if isinstance(raw_bounds, dict):
+        iterable = raw_bounds.get("parameters") or raw_bounds.get("bounds") or []
+    else:
+        iterable = raw_bounds
+    bounds: list[JsonObject] = []
+    for item in as_list(iterable):
+        if not isinstance(item, dict):
+            continue
+        name = first_text(item, ("name", "parameter", "key"))
+        if not name:
+            continue
+        bound: JsonObject = {"name": name}
+        for field in ("min", "max", "step"):
+            if item.get(field) is not None:
+                bound[field] = item[field]
+        reason = first_text(item, ("reason", "description", "rationale"))
+        if reason:
+            bound["reason"] = reason
+        bounds.append(bound)
+    return bounds
+
+
+def infer_component_id(raw: JsonObject, title: str) -> str:
+    explicit = first_text(raw, ("componentId", "component_id", "rewardComponent", "reward_component"))
+    if explicit:
+        return slug(explicit)
+    surface = infer_policy_surface(raw)
+    if surface != "unspecified-policy-surface":
+        return f"{slug(surface)}-reward-decision"
+    return slug(title)[:80] or "act-loop-reward-decision"
+
+
+def slug(value: str) -> str:
+    rendered = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return rendered or "unknown"
+
+
+def collect_metric_evidence(raw: JsonObject) -> JsonObject:
+    evidence: JsonObject = {}
+    for key in (
+        "metricsByCategory",
+        "metrics",
+        "kpiDeltaObserved",
+        "advantageTerritory",
+        "advantageResources",
+        "advantageKills",
+        "qualityChecks",
+        "quality_checks",
+        "blockingReasons",
+    ):
+        value = lookup(raw, (key,))
+        if value not in (None, "", [], {}):
+            evidence[key] = value
+    return evidence
+
+
+def build_finding_summary(
+    raw: JsonObject,
+    *,
+    classification: str,
+    secondary: Sequence[str],
+    finding_id: str,
+    title: str,
+    source_artifact: str | None,
+) -> JsonObject:
+    finding: JsonObject = {
+        "id": finding_id,
+        "title": title,
+        "classification": classification,
+        "secondaryClassifications": list(secondary),
+    }
+    for output_key, aliases in (
+        ("sourceArtifact", ("sourceArtifact", "source_artifact", "sourceReviewArtifact", "reviewArtifact", "artifact")),
+        ("evidenceWindow", ("evidenceWindow", "evidence_window", "window", "observedWindow")),
+        ("onlineUtilityStatus", ("onlineUtilityStatus", "onlineStatus", "status", "rawStatus")),
+        ("candidateId", ("candidateId", "candidate_id")),
+        ("incumbentId", ("incumbentId", "incumbent_id", "baselineId", "baseline_id")),
+        ("hypothesis", ("hypothesis",)),
+    ):
+        value = first_text(raw, aliases)
+        if value:
+            finding[output_key] = value
+    if source_artifact:
+        finding["sourceArtifact"] = source_artifact
+    missing_capabilities = infer_missing_capabilities(raw)
+    if missing_capabilities:
+        finding["missingCapabilities"] = missing_capabilities
+    metric_evidence = collect_metric_evidence(raw)
+    if metric_evidence:
+        finding["metricEvidence"] = metric_evidence
+    return finding
+
+
+def needs_reward_decision(classification: str, secondary: Sequence[str]) -> bool:
+    return classification == "reward_gap" or "reward_gap" in secondary
+
+
+def needs_scenario_delta(classification: str, secondary: Sequence[str], raw: JsonObject) -> bool:
+    return classification == "scenario_gap" or "scenario_gap" in secondary or bool(infer_missing_capabilities(raw))
+
+
+def needs_policy_delta(classification: str, secondary: Sequence[str], raw: JsonObject) -> bool:
+    if classification in {"data_quality", "runtime_bug"}:
+        return False
+    status = status_key(first_text(raw, ("onlineUtilityStatus", "status", "rawStatus")))
+    return (
+        classification == "policy_parameterization_gap"
+        or "policy_parameterization_gap" in secondary
+        or status in UNPROVEN_ONLINE_STATUSES
+    )
+
+
+def build_reward_decision(raw: JsonObject, *, finding: JsonObject, title: str) -> JsonObject | None:
+    component_id = infer_component_id(raw, title)
+    hypothesis = first_text(raw, ("hypothesis",)) or (
+        "Reward shaping may not currently distinguish the observed gameplay outcome; capture it as a proposed "
+        "GitHub-managed reward decision before it can affect training."
+    )
+    return {
+        "action": "create_or_update_reward_decision_record",
+        "decisionRecordStyle": "#907-style",
+        "registry": REWARD_DECISION_REGISTRY,
+        "template": REWARD_DECISION_TEMPLATE,
+        "status": "PROPOSED",
+        "componentId": component_id,
+        "sourceFindingId": finding["id"],
+        "sourceFindingClassification": finding["classification"],
+        "hypothesis": hypothesis,
+        "metricEvidence": collect_metric_evidence(raw),
+        "validationWindow": first_text(raw, ("evidenceWindow", "validationWindow", "observedWindow"))
+        or "TBD by steward before approval",
+        "rollbackCondition": first_text(raw, ("rollbackStopCondition", "rollbackCondition", "rollback_conditions"))
+        or "Reject or roll back if safety, reliability, territory, resources, or scorecard dimensions regress.",
+        "requiredFields": [
+            "metric evidence",
+            "hypothesis",
+            "validation window",
+            "rollback condition",
+            "candidate linkage",
+        ],
+        "safety": dict(SAFETY_BLOCK),
+    }
+
+
+def build_scenario_delta(raw: JsonObject, *, finding: JsonObject) -> JsonObject | None:
+    source_scenario_id = infer_source_scenario_id(raw)
+    target_scenario_id = infer_target_scenario_id(raw)
+    missing_capabilities = infer_missing_capabilities(raw)
+    required_capabilities = missing_capabilities or [
+        "multi_room_capable",
+        "adjacent_room_territory_signal",
+        "hostile_combat_signal",
+    ]
+    return {
+        "action": "add_or_select_private_training_scenario",
+        "sourceScenarioId": source_scenario_id,
+        "targetScenarioId": target_scenario_id,
+        "sourceFindingId": finding["id"],
+        "missingCapabilities": missing_capabilities,
+        "requiredCapabilities": required_capabilities,
+        "routing": "experiment_card_delta",
+        "constructionIssueIfMissing": "create bounded scenario-fixture construction issue instead of prose-only recommendation",
+        "privateOnly": True,
+        "shadowOnly": True,
+        "safety": dict(SAFETY_BLOCK),
+    }
+
+
+def build_policy_delta(raw: JsonObject, *, finding: JsonObject) -> JsonObject | None:
+    surface = infer_policy_surface(raw)
+    bounds = infer_policy_bounds(raw, surface)
+    candidate_id = first_text(raw, ("candidatePolicyId", "candidateId", "candidate_id", "strategyVariantId"))
+    delta: JsonObject = {
+        "action": "bound_policy_parameter_surface",
+        "parameterSurface": surface,
+        "sourceFindingId": finding["id"],
+        "bounds": bounds,
+        "boundsStatus": "present" if bounds else "missing",
+        "routing": "experiment_card_delta",
+        "shadowOnly": True,
+        "safety": dict(SAFETY_BLOCK),
+    }
+    if candidate_id:
+        delta["candidatePolicyId"] = candidate_id
+    return delta
+
+
+def build_experiment_card_delta(
+    raw: JsonObject,
+    *,
+    finding: JsonObject,
+    reward_decision: JsonObject | None,
+    scenario_delta: JsonObject | None,
+    policy_delta: JsonObject | None,
+) -> JsonObject | None:
+    if reward_decision is None and scenario_delta is None and policy_delta is None:
+        return None
+    training_approach = first_text(raw, ("trainingApproach", "training_approach"))
+    if not training_approach:
+        training_approach = "policy_gradient" if policy_delta is not None else "bandit"
+    dataset_run_id = first_text(raw, ("datasetRunId", "dataset_run_id")) or "TBD-by-training-steward"
+    target_scenario_id = (
+        text_value(as_dict(scenario_delta).get("targetScenarioId"))
+        if scenario_delta is not None
+        else infer_source_scenario_id(raw) or DEFAULT_SCENARIO_ID
+    )
+    deltas: JsonObject = {}
+    if reward_decision is not None:
+        deltas["rewardDecision"] = {
+            "componentId": reward_decision["componentId"],
+            "status": reward_decision["status"],
+            "registry": reward_decision["registry"],
+        }
+    if scenario_delta is not None:
+        deltas["scenario"] = {
+            "targetScenarioId": scenario_delta["targetScenarioId"],
+            "requiredCapabilities": scenario_delta["requiredCapabilities"],
+        }
+    if policy_delta is not None:
+        deltas["policy"] = {
+            "parameterSurface": policy_delta["parameterSurface"],
+            "bounds": policy_delta["bounds"],
+        }
+        if "candidatePolicyId" in policy_delta:
+            deltas["policy"]["candidatePolicyId"] = policy_delta["candidatePolicyId"]
+
+    return {
+        "action": "create_or_update_experiment_card_delta",
+        "cardHelper": EXPERIMENT_CARD_HELPER,
+        "scorecardHelper": SCORECARD_HELPER,
+        "sourceFindingId": finding["id"],
+        "datasetRunId": dataset_run_id,
+        "trainingApproach": training_approach,
+        "scenarioId": target_scenario_id,
+        "status": "shadow",
+        "deltas": deltas,
+        "requiredValidation": [
+            "validate generated experiment card",
+            "run offline/private training only",
+            "produce #924-compatible scorecard before rollout claims",
+        ],
+        "safety": dict(SAFETY_BLOCK),
+    }
+
+
+def feedback_link_state(identifier: str | None, *, planned: bool, planned_id: str | None = None) -> JsonObject:
+    if identifier:
+        return {"state": "linked", "id": identifier}
+    if planned:
+        item: JsonObject = {"state": "planned"}
+        if planned_id:
+            item["plannedId"] = planned_id
+        return item
+    return {"state": "missing"}
+
+
+def build_feedback_state(
+    raw: JsonObject,
+    *,
+    finding: JsonObject,
+    reward_decision: JsonObject | None,
+    card_delta: JsonObject | None,
+) -> JsonObject:
+    reward_decision_id = first_text(
+        raw,
+        ("rewardDecisionId", "reward_decision_id", "decisionId", "decision_id", "componentDecisionId"),
+    )
+    experiment_card_id = first_text(raw, ("experimentCardId", "experiment_card_id", "cardId", "card_id"))
+    training_run_id = first_text(raw, ("trainingRunId", "training_run_id", "trainingReportId", "trainingReportIds"))
+    scorecard_id = first_text(raw, ("scorecardId", "scorecard_id", "scorecardArtifact", "scorecard"))
+    rollout_id = first_text(raw, ("rolloutId", "rollout_id"))
+
+    planned_decision_id = text_value(as_dict(reward_decision).get("componentId")) or f"act-decision:{finding['id']}"
+    decision_state = feedback_link_state(
+        reward_decision_id,
+        planned=reward_decision is not None or card_delta is not None,
+        planned_id=planned_decision_id,
+    )
+    card_state = feedback_link_state(
+        experiment_card_id,
+        planned=card_delta is not None,
+        planned_id=text_value(as_dict(card_delta).get("datasetRunId")),
+    )
+    training_state = feedback_link_state(training_run_id, planned=False)
+    scorecard_state = feedback_link_state(scorecard_id, planned=False)
+    rollout_state = feedback_link_state(rollout_id, planned=False)
+
+    return {
+        "finding": {
+            "state": "observed",
+            "id": finding["id"],
+            "classification": finding["classification"],
+            "sourceArtifact": finding.get("sourceArtifact"),
+        },
+        "decision": decision_state,
+        "experimentCard": card_state,
+        "training": training_state,
+        "scorecard": scorecard_state,
+        "rolloutFeedback": rollout_state,
+    }
+
+
+def plan_blocking_reasons(
+    *,
+    classification: str,
+    reward_decision: JsonObject | None,
+    policy_delta: JsonObject | None,
+    card_delta: JsonObject | None,
+) -> list[str]:
+    reasons: list[str] = []
+    if classification == "data_quality":
+        reasons.append("data quality finding must be resolved or converted to evidence before training changes")
+    if classification == "runtime_bug":
+        reasons.append("runtime bug must route to a construction issue before reward/scenario/policy iteration")
+    if classification == "rollout_regression":
+        reasons.append("rollout regression must preserve rollback evidence before the next training card")
+    if reward_decision is not None:
+        reasons.append("reward changes require a GitHub-managed #907-style decision record before training use")
+    if policy_delta is not None and not as_list(policy_delta.get("bounds")):
+        reasons.append("policy parameterization change is missing named bounds")
+    if card_delta is None and classification not in {"data_quality", "runtime_bug", "rollout_regression"}:
+        reasons.append("finding did not produce an experiment-card delta")
+    return reasons
+
+
+def build_plan(raw: JsonObject, *, source_artifact: str | None = None) -> JsonObject:
+    if not isinstance(raw, dict):
+        raise PlannerInputError("finding must be a JSON object")
+    classification = infer_classification(raw)
+    secondary = secondary_classifications(raw, classification)
+    finding_id = infer_finding_id(raw)
+    title = infer_title(raw, finding_id)
+    resolved_source_artifact = infer_source_artifact(raw, source_artifact)
+    finding = build_finding_summary(
+        raw,
+        classification=classification,
+        secondary=secondary,
+        finding_id=finding_id,
+        title=title,
+        source_artifact=resolved_source_artifact,
+    )
+
+    reward_decision = (
+        build_reward_decision(raw, finding=finding, title=title)
+        if needs_reward_decision(classification, secondary)
+        else None
+    )
+    scenario_delta = (
+        build_scenario_delta(raw, finding=finding)
+        if needs_scenario_delta(classification, secondary, raw)
+        else None
+    )
+    policy_delta = (
+        build_policy_delta(raw, finding=finding)
+        if needs_policy_delta(classification, secondary, raw)
+        else None
+    )
+    card_delta = build_experiment_card_delta(
+        raw,
+        finding=finding,
+        reward_decision=reward_decision,
+        scenario_delta=scenario_delta,
+        policy_delta=policy_delta,
+    )
+    blocking_reasons = plan_blocking_reasons(
+        classification=classification,
+        reward_decision=reward_decision,
+        policy_delta=policy_delta,
+        card_delta=card_delta,
+    )
+    plan_id = f"act-plan-{canonical_hash({'finding': finding, 'classification': classification})[:12]}"
+    status = "ACT_DELTA_READY" if card_delta is not None else "ROUTE_REQUIRED"
+
+    return {
+        "type": PLAN_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "planId": plan_id,
+        "decision": "act_loop_planned",
+        "status": status,
+        "finding": finding,
+        "nextRewardDecision": reward_decision,
+        "nextScenarioDelta": scenario_delta,
+        "nextPolicyDelta": policy_delta,
+        "nextExperimentCardDelta": card_delta,
+        "feedbackIngestion": build_feedback_state(
+            raw,
+            finding=finding,
+            reward_decision=reward_decision,
+            card_delta=card_delta,
+        ),
+        "blockingReasons": blocking_reasons,
+        "safety": dict(SAFETY_BLOCK),
+    }
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise PlannerInputError(f"input file not found: {path}") from error
+    except json.JSONDecodeError as error:
+        raise PlannerInputError(f"invalid JSON in {path}: {error}") from error
+
+
+def raw_findings(document: Any) -> tuple[list[JsonObject], JsonObject]:
+    if isinstance(document, list):
+        findings = document
+        metadata: JsonObject = {}
+    elif isinstance(document, dict):
+        metadata = document
+        if isinstance(document.get("findings"), list):
+            findings = document["findings"]
+        else:
+            findings = [document]
+    else:
+        raise PlannerInputError("input must be a JSON object, JSON array, or object with findings[]")
+
+    result: list[JsonObject] = []
+    for index, item in enumerate(findings, start=1):
+        if not isinstance(item, dict):
+            raise PlannerInputError(f"finding {index}: expected object")
+        result.append(item)
+    if not result:
+        raise PlannerInputError("findings array is empty")
+    return result, metadata
+
+
+def build_plans(document: Any, *, source_artifact: str | None = None) -> JsonObject:
+    findings, metadata = raw_findings(document)
+    metadata_source = source_artifact or first_text(
+        metadata,
+        ("sourceArtifact", "source_artifact", "sourceReviewArtifact", "reviewArtifact", "artifact"),
+    )
+    plans = [build_plan(item, source_artifact=metadata_source) for item in findings]
+    if len(plans) == 1:
+        return plans[0]
+    return {
+        "type": BATCH_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "decision": "act_loop_planned",
+        "status": "ACT_DELTA_READY" if any(plan.get("nextExperimentCardDelta") for plan in plans) else "ROUTE_REQUIRED",
+        "plans": plans,
+        "blockingReasons": sorted(
+            {
+                reason
+                for plan in plans
+                for reason in as_list(plan.get("blockingReasons"))
+                if isinstance(reason, str)
+            }
+        ),
+    }
+
+
+def write_json_atomic(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(temp_fd, "w", encoding="utf-8") as handle:
+            temp_fd = -1
+            handle.write(canonical_json(payload))
+        os.replace(temp_path, path)
+    finally:
+        if temp_fd != -1:
+            try:
+                os.close(temp_fd)
+            except OSError:
+                pass
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Plan deterministic offline Act-loop deltas from policy advantage or gameplay findings."
+    )
+    parser.add_argument("input_json", type=Path, help="finding JSON, policy-advantage JSON, or object with findings[]")
+    parser.add_argument("--source-artifact", help="repo-relative source artifact path to attach to each finding")
+    parser.add_argument("--output", type=Path, help="write the plan JSON to this path instead of stdout")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None, *, stdout: TextIO = sys.stdout, stderr: TextIO = sys.stderr) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    try:
+        plan = build_plans(load_json(args.input_json), source_artifact=args.source_artifact)
+        if args.output:
+            write_json_atomic(args.output, plan)
+        else:
+            stdout.write(canonical_json(plan))
+        return 0
+    except PlannerInputError as error:
+        print(f"error: {error}", file=stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/screeps_rl_act_loop_planner.py
+++ b/scripts/screeps_rl_act_loop_planner.py
@@ -319,11 +319,16 @@ def status_key(raw: Any) -> str | None:
     return text.upper().replace("-", "_") if text else None
 
 
-def has_blocking_evidence_gap(raw: JsonObject) -> bool:
-    statuses = {
-        status_key(lookup(raw, aliases))
-        for aliases in ((alias,) for alias in ONLINE_STATUS_ALIASES)
+def online_status_keys(raw: JsonObject) -> set[str]:
+    return {
+        status
+        for alias in ONLINE_STATUS_ALIASES
+        if (status := status_key(lookup(raw, (alias,)))) is not None
     }
+
+
+def has_blocking_evidence_gap(raw: JsonObject) -> bool:
+    statuses = online_status_keys(raw)
     if statuses & BLOCKING_ONLINE_EVIDENCE_STATUSES:
         return True
     return any(
@@ -381,18 +386,33 @@ def infer_classification(raw: JsonObject) -> str:
         if any(keyword in blob for keyword in keywords):
             return classification
 
-    if status_key(first_text(raw, ONLINE_STATUS_ALIASES)) in UNPROVEN_ONLINE_STATUSES:
+    if online_status_keys(raw) & UNPROVEN_ONLINE_STATUSES:
         return "policy_parameterization_gap"
     return "data_quality"
 
 
+def explicit_secondary_classifications(raw: JsonObject, primary: str) -> list[str]:
+    explicit: list[str] = []
+    for alias in (
+        "secondaryClassifications",
+        "secondary_classifications",
+        "secondaryClassification",
+        "secondary_classification",
+        "secondary",
+    ):
+        value = lookup(raw, (alias,))
+        values = value if isinstance(value, (list, tuple)) else [value] if value is not None else []
+        for item in values:
+            classification = classification_key(item)
+            if classification and classification != primary:
+                explicit.append(classification)
+    return explicit
+
+
 def secondary_classifications(raw: JsonObject, primary: str) -> list[str]:
     blob = text_blob(raw)
-    statuses = {
-        status_key(lookup(raw, aliases))
-        for aliases in ((alias,) for alias in ONLINE_STATUS_ALIASES)
-    }
-    inferred: list[str] = []
+    statuses = online_status_keys(raw)
+    inferred = explicit_secondary_classifications(raw, primary)
     if primary != "policy_parameterization_gap" and (
         statuses & UNPROVEN_ONLINE_STATUSES or any(token in blob for token in ("policy", "parameter", "bounds", "candidate"))
     ):
@@ -498,8 +518,8 @@ def infer_target_scenario_id(raw: JsonObject) -> str:
     if explicit:
         return explicit
     missing = infer_missing_capabilities(raw)
-    online_status = status_key(first_text(raw, ONLINE_STATUS_ALIASES))
-    if missing or (infer_source_scenario_id(raw) == DEFAULT_SCENARIO_ID and online_status in UNPROVEN_ONLINE_STATUSES):
+    statuses = online_status_keys(raw)
+    if missing or (infer_source_scenario_id(raw) == DEFAULT_SCENARIO_ID and statuses & UNPROVEN_ONLINE_STATUSES):
         return MULTI_TIER_SCENARIO_ID
     return infer_source_scenario_id(raw) or DEFAULT_SCENARIO_ID
 
@@ -709,11 +729,11 @@ def needs_scenario_delta(classification: str, secondary: Sequence[str], raw: Jso
 def needs_policy_delta(classification: str, secondary: Sequence[str], raw: JsonObject) -> bool:
     if has_delta_blocker(classification, secondary):
         return False
-    status = status_key(first_text(raw, ONLINE_STATUS_ALIASES))
+    statuses = online_status_keys(raw)
     return (
         classification == "policy_parameterization_gap"
         or "policy_parameterization_gap" in secondary
-        or status in UNPROVEN_ONLINE_STATUSES
+        or bool(statuses & UNPROVEN_ONLINE_STATUSES)
     )
 
 
@@ -931,16 +951,17 @@ def build_feedback_state(
 def plan_blocking_reasons(
     *,
     classification: str,
+    secondary: Sequence[str],
     reward_decision: JsonObject | None,
     policy_delta: JsonObject | None,
     card_delta: JsonObject | None,
 ) -> list[str]:
     reasons: list[str] = []
-    if classification == "data_quality":
+    if classification == "data_quality" or "data_quality" in secondary:
         reasons.append("data quality finding must be resolved or converted to evidence before training changes")
-    if classification == "runtime_bug":
+    if classification == "runtime_bug" or "runtime_bug" in secondary:
         reasons.append("runtime bug must route to a construction issue before reward/scenario/policy iteration")
-    if classification == "rollout_regression":
+    if classification == "rollout_regression" or "rollout_regression" in secondary:
         reasons.append("rollout regression must preserve rollback evidence before the next training card")
     if reward_decision is not None:
         reasons.append("reward changes require a GitHub-managed #907-style decision record before training use")
@@ -983,19 +1004,17 @@ def build_plan(raw: JsonObject, *, source_artifact: str | None = None) -> JsonOb
         if needs_policy_delta(classification, secondary, raw)
         else None
     )
-    card_delta = (
-        None
-        if has_missing_policy_bounds(policy_delta)
-        else build_experiment_card_delta(
-            raw,
-            finding=finding,
-            reward_decision=reward_decision,
-            scenario_delta=scenario_delta,
-            policy_delta=policy_delta,
-        )
+    card_policy_delta = None if has_missing_policy_bounds(policy_delta) else policy_delta
+    card_delta = build_experiment_card_delta(
+        raw,
+        finding=finding,
+        reward_decision=reward_decision,
+        scenario_delta=scenario_delta,
+        policy_delta=card_policy_delta,
     )
     blocking_reasons = plan_blocking_reasons(
         classification=classification,
+        secondary=secondary,
         reward_decision=reward_decision,
         policy_delta=policy_delta,
         card_delta=card_delta,

--- a/scripts/test_screeps_rl_act_loop_planner.py
+++ b/scripts/test_screeps_rl_act_loop_planner.py
@@ -119,6 +119,25 @@ class ScreepsRlActLoopPlannerTest(unittest.TestCase):
         self.assertEqual(plan["feedbackIngestion"]["training"]["state"], "missing")
         self.assertTrue(any("data quality" in reason for reason in plan["blockingReasons"]))
 
+    def test_rollout_regression_with_signal_noise_still_blocks_all_deltas(self) -> None:
+        plan = planner.build_plan(
+            {
+                "title": "Rollout regression with scenario, reward, and policy hints",
+                "classification": "rollout_regression",
+                "missingCapabilities": ["multi_room_capable"],
+                "componentId": "construction-neglect-penalty",
+                "onlineUtilityStatus": "MIXED",
+                "parameterSurface": "construction-priority",
+            }
+        )
+
+        self.assertEqual(plan["status"], "ROUTE_REQUIRED")
+        self.assertIsNone(plan["nextRewardDecision"])
+        self.assertIsNone(plan["nextScenarioDelta"])
+        self.assertIsNone(plan["nextPolicyDelta"])
+        self.assertIsNone(plan["nextExperimentCardDelta"])
+        self.assertTrue(any("rollout regression" in reason for reason in plan["blockingReasons"]))
+
     def test_feedback_ingestion_links_first_usable_list_form_report_id(self) -> None:
         plan = planner.build_plan(
             {

--- a/scripts/test_screeps_rl_act_loop_planner.py
+++ b/scripts/test_screeps_rl_act_loop_planner.py
@@ -188,6 +188,54 @@ class ScreepsRlActLoopPlannerTest(unittest.TestCase):
         self.assertEqual(plan["nextPolicyDelta"]["boundsStatus"], "present")
         self.assertEqual(plan["nextExperimentCardDelta"]["scenarioId"], planner.MULTI_TIER_SCENARIO_ID)
 
+    def test_conflicting_status_aliases_preserve_raw_online_routing(self) -> None:
+        policy_plan = planner.build_plan(
+            {
+                "title": "Online assessment needs follow-up",
+                "status": "accepted",
+                "rawStatus": "INCONCLUSIVE",
+                "parameterSurface": {
+                    "name": "expansion-risk-window",
+                    "bounds": [
+                        {
+                            "name": "remoteRiskLimit",
+                            "min": 0,
+                            "max": 1,
+                            "step": 0.05,
+                        }
+                    ],
+                },
+            }
+        )
+
+        self.assertEqual(policy_plan["finding"]["classification"], "policy_parameterization_gap")
+        self.assertEqual(policy_plan["status"], "ACT_DELTA_READY")
+        self.assertEqual(policy_plan["nextPolicyDelta"]["parameterSurface"], "expansion-risk-window")
+
+        scenario_plan = planner.build_plan(
+            {
+                "title": "Single-room scenario has conflicting online status aliases",
+                "classification": "scenario_gap",
+                "scenarioId": planner.DEFAULT_SCENARIO_ID,
+                "status": "accepted",
+                "rawStatus": "UNPROVEN",
+                "parameterSurface": {
+                    "name": "expansion-risk-window",
+                    "bounds": [
+                        {
+                            "name": "remoteRiskLimit",
+                            "min": 0,
+                            "max": 1,
+                            "step": 0.05,
+                        }
+                    ],
+                },
+            }
+        )
+
+        self.assertEqual(scenario_plan["nextScenarioDelta"]["targetScenarioId"], planner.MULTI_TIER_SCENARIO_ID)
+        self.assertEqual(scenario_plan["nextExperimentCardDelta"]["scenarioId"], planner.MULTI_TIER_SCENARIO_ID)
+
     def test_rollout_regression_with_signal_noise_still_blocks_all_deltas(self) -> None:
         plan = planner.build_plan(
             {
@@ -200,6 +248,39 @@ class ScreepsRlActLoopPlannerTest(unittest.TestCase):
             }
         )
 
+        self.assertEqual(plan["status"], "ROUTE_REQUIRED")
+        self.assertIsNone(plan["nextRewardDecision"])
+        self.assertIsNone(plan["nextScenarioDelta"])
+        self.assertIsNone(plan["nextPolicyDelta"])
+        self.assertIsNone(plan["nextExperimentCardDelta"])
+        self.assertEqual(plan["feedbackIngestion"]["training"]["state"], "missing")
+        self.assertTrue(any("rollout regression" in reason for reason in plan["blockingReasons"]))
+
+    def test_explicit_secondary_blocker_suppresses_all_deltas(self) -> None:
+        plan = planner.build_plan(
+            {
+                "title": "Scenario gap is actually a rollout regression",
+                "classification": "scenario_gap",
+                "secondaryClassifications": ["rollout_regression"],
+                "missingCapabilities": ["multi_room_capable"],
+                "componentId": "construction-neglect-penalty",
+                "onlineUtilityStatus": "UNPROVEN",
+                "parameterSurface": {
+                    "name": "construction-priority",
+                    "bounds": [
+                        {
+                            "name": "territorySignalWeight",
+                            "min": 0,
+                            "max": 1,
+                            "step": 0.05,
+                        }
+                    ],
+                },
+            }
+        )
+
+        self.assertEqual(plan["finding"]["classification"], "scenario_gap")
+        self.assertIn("rollout_regression", plan["finding"]["secondaryClassifications"])
         self.assertEqual(plan["status"], "ROUTE_REQUIRED")
         self.assertIsNone(plan["nextRewardDecision"])
         self.assertIsNone(plan["nextScenarioDelta"])
@@ -357,7 +438,7 @@ class ScreepsRlActLoopPlannerTest(unittest.TestCase):
         self.assertIsNone(plan["nextExperimentCardDelta"])
         self.assertTrue(any("missing named bounds" in reason for reason in plan["blockingReasons"]))
 
-    def test_unbounded_construction_priority_policy_blocks_scenario_card_delta(self) -> None:
+    def test_unbounded_construction_priority_policy_preserves_scenario_card_delta(self) -> None:
         plan = planner.build_plan(
             {
                 "title": "Construction-priority scenario gap has no bounded parameters",
@@ -369,12 +450,31 @@ class ScreepsRlActLoopPlannerTest(unittest.TestCase):
             }
         )
 
-        self.assertEqual(plan["status"], "ROUTE_REQUIRED")
+        self.assertEqual(plan["status"], "ACT_DELTA_READY")
         self.assertEqual(plan["nextScenarioDelta"]["targetScenarioId"], planner.MULTI_TIER_SCENARIO_ID)
         self.assertEqual(plan["nextPolicyDelta"]["parameterSurface"], "construction-priority")
         self.assertEqual(plan["nextPolicyDelta"]["bounds"], [])
         self.assertEqual(plan["nextPolicyDelta"]["boundsStatus"], "missing")
-        self.assertIsNone(plan["nextExperimentCardDelta"])
+        self.assertEqual(plan["nextExperimentCardDelta"]["deltas"]["scenario"]["targetScenarioId"], planner.MULTI_TIER_SCENARIO_ID)
+        self.assertNotIn("policy", plan["nextExperimentCardDelta"]["deltas"])
+        self.assertTrue(any("missing named bounds" in reason for reason in plan["blockingReasons"]))
+
+    def test_missing_policy_bounds_preserve_reward_card_delta_without_policy_delta(self) -> None:
+        plan = planner.build_plan(
+            {
+                "title": "Reward gap has unbounded policy follow-up",
+                "classification": "reward_gap",
+                "componentId": "construction-neglect-penalty",
+                "onlineStatus": "UNPROVEN",
+                "parameterSurface": "construction-priority",
+            }
+        )
+
+        self.assertEqual(plan["status"], "ACT_DELTA_READY")
+        self.assertIsNotNone(plan["nextRewardDecision"])
+        self.assertEqual(plan["nextPolicyDelta"]["boundsStatus"], "missing")
+        self.assertIn("rewardDecision", plan["nextExperimentCardDelta"]["deltas"])
+        self.assertNotIn("policy", plan["nextExperimentCardDelta"]["deltas"])
         self.assertTrue(any("missing named bounds" in reason for reason in plan["blockingReasons"]))
 
     def test_cli_writes_deterministic_plan_without_github_or_mmo_actions(self) -> None:

--- a/scripts/test_screeps_rl_act_loop_planner.py
+++ b/scripts/test_screeps_rl_act_loop_planner.py
@@ -117,6 +117,14 @@ class ScreepsRlActLoopPlannerTest(unittest.TestCase):
                 "componentId": "construction-neglect-penalty",
                 "parameterSurface": "construction-priority",
             },
+            {
+                "title": "Aliased online status still blocks scenario gaps without compute evidence",
+                "classification": "scenario_gap",
+                "onlineStatus": "BLOCKED_NO_COMPUTE",
+                "missingCapabilities": ["multi_room_capable"],
+                "componentId": "construction-neglect-penalty",
+                "parameterSurface": "construction-priority",
+            },
         )
 
         for raw in cases:
@@ -152,6 +160,33 @@ class ScreepsRlActLoopPlannerTest(unittest.TestCase):
         self.assertIsNone(plan["nextExperimentCardDelta"])
         self.assertEqual(plan["feedbackIngestion"]["training"]["state"], "missing")
         self.assertTrue(any("data quality" in reason for reason in plan["blockingReasons"]))
+
+    def test_online_status_alias_selects_multi_tier_target_for_single_room_gap(self) -> None:
+        plan = planner.build_plan(
+            {
+                "title": "Single-room scenario still has unproven online utility",
+                "classification": "scenario_gap",
+                "scenarioId": planner.DEFAULT_SCENARIO_ID,
+                "onlineStatus": "UNPROVEN",
+                "parameterSurface": {
+                    "name": "expansion-risk-window",
+                    "bounds": [
+                        {
+                            "name": "remoteRiskLimit",
+                            "min": 0,
+                            "max": 1,
+                            "step": 0.05,
+                            "reason": "Keep unproven expansion routing bounded.",
+                        }
+                    ],
+                },
+            }
+        )
+
+        self.assertEqual(plan["nextScenarioDelta"]["targetScenarioId"], planner.MULTI_TIER_SCENARIO_ID)
+        self.assertEqual(plan["nextPolicyDelta"]["parameterSurface"], "expansion-risk-window")
+        self.assertEqual(plan["nextPolicyDelta"]["boundsStatus"], "present")
+        self.assertEqual(plan["nextExperimentCardDelta"]["scenarioId"], planner.MULTI_TIER_SCENARIO_ID)
 
     def test_rollout_regression_with_signal_noise_still_blocks_all_deltas(self) -> None:
         plan = planner.build_plan(
@@ -206,6 +241,71 @@ class ScreepsRlActLoopPlannerTest(unittest.TestCase):
             ["remoteRiskLimit"],
         )
 
+    def test_nested_policy_target_family_surface_and_bounds_are_honored(self) -> None:
+        cases = (
+            (
+                {
+                    "title": "Nested parameter surface family carries the explicit policy surface",
+                    "policyDelta": {
+                        "parameterSurface": {
+                            "targetFamily": {
+                                "name": "expansion-risk-window",
+                                "parameters": [
+                                    {
+                                        "name": "remoteRiskLimit",
+                                        "min": 0,
+                                        "max": 1,
+                                        "step": 0.05,
+                                        "reason": "Bound remote risk before expansion changes.",
+                                    }
+                                ],
+                            }
+                        }
+                    },
+                },
+                "expansion-risk-window",
+                "remoteRiskLimit",
+            ),
+            (
+                {
+                    "title": "Direct target family wrapper carries the explicit policy surface",
+                    "policyDelta": {
+                        "targetFamily": {
+                            "name": "spawn-energy-window",
+                            "parameters": [
+                                {
+                                    "name": "reservedSpawnEnergy",
+                                    "min": 0,
+                                    "max": 300,
+                                    "step": 50,
+                                    "reason": "Keep spawn recovery energy reserved.",
+                                }
+                            ],
+                        }
+                    },
+                },
+                "spawn-energy-window",
+                "reservedSpawnEnergy",
+            ),
+        )
+
+        for raw, expected_surface, expected_bound in cases:
+            with self.subTest(title=raw["title"]):
+                raw["classification"] = "policy_parameterization_gap"
+                raw["onlineUtilityStatus"] = "UNPROVEN"
+
+                plan = planner.build_plan(raw)
+
+                policy_delta = plan["nextPolicyDelta"]
+                self.assertEqual(plan["status"], "ACT_DELTA_READY")
+                self.assertEqual(policy_delta["parameterSurface"], expected_surface)
+                self.assertEqual(policy_delta["boundsStatus"], "present")
+                self.assertEqual(policy_delta["bounds"][0]["name"], expected_bound)
+                self.assertEqual(
+                    plan["nextExperimentCardDelta"]["deltas"]["policy"]["parameterSurface"],
+                    expected_surface,
+                )
+
     def test_nested_policy_surface_without_bounds_stays_route_required(self) -> None:
         plan = planner.build_plan(
             {
@@ -253,6 +353,26 @@ class ScreepsRlActLoopPlannerTest(unittest.TestCase):
         )
 
         self.assertEqual(plan["status"], "ROUTE_REQUIRED")
+        self.assertEqual(plan["nextPolicyDelta"]["boundsStatus"], "missing")
+        self.assertIsNone(plan["nextExperimentCardDelta"])
+        self.assertTrue(any("missing named bounds" in reason for reason in plan["blockingReasons"]))
+
+    def test_unbounded_construction_priority_policy_blocks_scenario_card_delta(self) -> None:
+        plan = planner.build_plan(
+            {
+                "title": "Construction-priority scenario gap has no bounded parameters",
+                "classification": "scenario_gap",
+                "onlineStatus": "UNPROVEN",
+                "scenarioId": planner.DEFAULT_SCENARIO_ID,
+                "missingCapabilities": ["multi_room_capable"],
+                "parameterSurface": "construction-priority",
+            }
+        )
+
+        self.assertEqual(plan["status"], "ROUTE_REQUIRED")
+        self.assertEqual(plan["nextScenarioDelta"]["targetScenarioId"], planner.MULTI_TIER_SCENARIO_ID)
+        self.assertEqual(plan["nextPolicyDelta"]["parameterSurface"], "construction-priority")
+        self.assertEqual(plan["nextPolicyDelta"]["bounds"], [])
         self.assertEqual(plan["nextPolicyDelta"]["boundsStatus"], "missing")
         self.assertIsNone(plan["nextExperimentCardDelta"])
         self.assertTrue(any("missing named bounds" in reason for reason in plan["blockingReasons"]))

--- a/scripts/test_screeps_rl_act_loop_planner.py
+++ b/scripts/test_screeps_rl_act_loop_planner.py
@@ -172,6 +172,60 @@ class ScreepsRlActLoopPlannerTest(unittest.TestCase):
         self.assertIsNone(plan["nextExperimentCardDelta"])
         self.assertTrue(any("rollout regression" in reason for reason in plan["blockingReasons"]))
 
+    def test_nested_policy_surface_name_and_bounds_are_honored(self) -> None:
+        plan = planner.build_plan(
+            {
+                "title": "Construction backlog policy family should use the explicit nested surface",
+                "classification": "policy_parameterization_gap",
+                "onlineUtilityStatus": "UNPROVEN",
+                "policyDelta": {
+                    "parameterSurface": {
+                        "name": "expansion-risk-window",
+                        "bounds": [
+                            {
+                                "name": "remoteRiskLimit",
+                                "min": 0,
+                                "max": 1,
+                                "step": 0.05,
+                                "reason": "Keep remote risk bounded before expansion changes.",
+                            }
+                        ],
+                    }
+                },
+            }
+        )
+
+        policy_delta = plan["nextPolicyDelta"]
+        self.assertEqual(plan["status"], "ACT_DELTA_READY")
+        self.assertEqual(policy_delta["parameterSurface"], "expansion-risk-window")
+        self.assertEqual(policy_delta["boundsStatus"], "present")
+        self.assertEqual(policy_delta["bounds"][0]["name"], "remoteRiskLimit")
+        self.assertEqual(plan["nextExperimentCardDelta"]["deltas"]["policy"]["parameterSurface"], "expansion-risk-window")
+        self.assertEqual(
+            [item["name"] for item in plan["nextExperimentCardDelta"]["deltas"]["policy"]["bounds"]],
+            ["remoteRiskLimit"],
+        )
+
+    def test_nested_policy_surface_without_bounds_stays_route_required(self) -> None:
+        plan = planner.build_plan(
+            {
+                "title": "Explicit nested expansion surface is still unbounded",
+                "classification": "policy_parameterization_gap",
+                "onlineUtilityStatus": "UNPROVEN",
+                "policyDelta": {
+                    "parameterSurface": {
+                        "name": "expansion-risk-window",
+                    }
+                },
+            }
+        )
+
+        self.assertEqual(plan["status"], "ROUTE_REQUIRED")
+        self.assertEqual(plan["nextPolicyDelta"]["parameterSurface"], "expansion-risk-window")
+        self.assertEqual(plan["nextPolicyDelta"]["boundsStatus"], "missing")
+        self.assertIsNone(plan["nextExperimentCardDelta"])
+        self.assertTrue(any("missing named bounds" in reason for reason in plan["blockingReasons"]))
+
     def test_feedback_ingestion_links_first_usable_list_form_report_id(self) -> None:
         plan = planner.build_plan(
             {

--- a/scripts/test_screeps_rl_act_loop_planner.py
+++ b/scripts/test_screeps_rl_act_loop_planner.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import screeps_rl_act_loop_planner as planner
+
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "rl" / "act-loop-mixed-unproven-policy-advantage.json"
+
+
+class ScreepsRlActLoopPlannerTest(unittest.TestCase):
+    def test_mixed_loop_b_policy_advantage_routes_to_scenario_policy_and_card_delta(self) -> None:
+        raw = planner.load_json(FIXTURE_PATH)
+
+        plan = planner.build_plans(raw, source_artifact=str(FIXTURE_PATH))
+
+        self.assertEqual(plan["type"], planner.PLAN_TYPE)
+        self.assertEqual(plan["decision"], "act_loop_planned")
+        self.assertEqual(plan["status"], "ACT_DELTA_READY")
+        self.assertEqual(plan["finding"]["classification"], "scenario_gap")
+        self.assertIn("policy_parameterization_gap", plan["finding"]["secondaryClassifications"])
+        self.assertIsNone(plan["nextRewardDecision"])
+
+        scenario_delta = plan["nextScenarioDelta"]
+        self.assertEqual(scenario_delta["targetScenarioId"], planner.MULTI_TIER_SCENARIO_ID)
+        self.assertEqual(scenario_delta["routing"], "experiment_card_delta")
+        self.assertTrue(scenario_delta["shadowOnly"])
+        self.assertFalse(scenario_delta["safety"]["officialMmoWrites"])
+
+        policy_delta = plan["nextPolicyDelta"]
+        self.assertEqual(policy_delta["parameterSurface"], "construction-priority")
+        self.assertEqual(policy_delta["boundsStatus"], "present")
+        self.assertEqual(
+            [item["name"] for item in policy_delta["bounds"]],
+            ["territorySignalWeight", "riskPenalty"],
+        )
+        self.assertFalse(policy_delta["safety"]["officialMmoWritesAllowed"])
+
+        card_delta = plan["nextExperimentCardDelta"]
+        self.assertEqual(card_delta["trainingApproach"], "policy_gradient")
+        self.assertEqual(card_delta["scenarioId"], planner.MULTI_TIER_SCENARIO_ID)
+        self.assertEqual(card_delta["datasetRunId"], "rl-loop-b-sample-000001")
+        self.assertEqual(card_delta["status"], "shadow")
+        self.assertEqual(card_delta["deltas"]["policy"]["parameterSurface"], "construction-priority")
+        self.assertFalse(card_delta["safety"]["liveEffect"])
+
+        feedback = plan["feedbackIngestion"]
+        self.assertEqual(feedback["finding"]["state"], "observed")
+        self.assertEqual(feedback["decision"]["state"], "planned")
+        self.assertEqual(feedback["decision"]["plannedId"], "act-decision:loop-b-mixed-unproven-construction-priority")
+        self.assertEqual(feedback["experimentCard"]["state"], "planned")
+        self.assertEqual(feedback["training"]["state"], "linked")
+        self.assertEqual(feedback["training"]["id"], "training-loop-b-sample-000001")
+        self.assertEqual(feedback["scorecard"]["state"], "linked")
+        self.assertEqual(feedback["scorecard"]["id"], "scorecard-loop-b-sample-000001")
+
+    def test_reward_gap_routes_through_reward_decision_record_before_card_use(self) -> None:
+        raw = {
+            "title": "Construction backlog has no reward pressure",
+            "classification": "reward_gap",
+            "componentId": "construction-neglect-penalty",
+            "evidenceWindow": "2026-05-18T00:00:00Z..2026-05-18T08:00:00Z",
+            "hypothesis": "Penalize build=0 when construction sites exist without weakening survival gates.",
+            "kpiDeltaObserved": "constructionSiteCount stayed positive while taskCounts.build stayed zero",
+        }
+
+        plan = planner.build_plan(raw, source_artifact="runtime-artifacts/rl-control-loop/reward-gap.json")
+
+        decision = plan["nextRewardDecision"]
+        self.assertEqual(decision["decisionRecordStyle"], "#907-style")
+        self.assertEqual(decision["registry"], planner.REWARD_DECISION_REGISTRY)
+        self.assertEqual(decision["componentId"], "construction-neglect-penalty")
+        self.assertIn("metric evidence", decision["requiredFields"])
+        self.assertFalse(decision["safety"]["officialMmoWrites"])
+        self.assertEqual(plan["nextExperimentCardDelta"]["deltas"]["rewardDecision"]["componentId"], "construction-neglect-penalty")
+        self.assertIn("#907-style", " ".join(plan["blockingReasons"]))
+
+    def test_data_quality_finding_does_not_emit_training_card_delta(self) -> None:
+        plan = planner.build_plan(
+            {
+                "title": "Policy advantage has no compute evidence",
+                "classification": "data_quality",
+                "onlineUtilityStatus": "BLOCKED_NO_COMPUTE",
+            }
+        )
+
+        self.assertEqual(plan["status"], "ROUTE_REQUIRED")
+        self.assertIsNone(plan["nextRewardDecision"])
+        self.assertIsNone(plan["nextScenarioDelta"])
+        self.assertIsNone(plan["nextExperimentCardDelta"])
+        self.assertEqual(plan["feedbackIngestion"]["training"]["state"], "missing")
+        self.assertTrue(any("data quality" in reason for reason in plan["blockingReasons"]))
+
+    def test_cli_writes_deterministic_plan_without_github_or_mmo_actions(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="act-loop-plan-") as temp_dir:
+            output = Path(temp_dir) / "plan.json"
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+
+            exit_code = planner.main(
+                [str(FIXTURE_PATH), "--source-artifact", "runtime-artifacts/rl-control-loop/policy-advantage.json", "--output", str(output)],
+                stdout=stdout,
+                stderr=stderr,
+            )
+
+            self.assertEqual(exit_code, 0, stderr.getvalue())
+            self.assertEqual(stdout.getvalue(), "")
+            first = json.loads(output.read_text(encoding="utf-8"))
+
+            exit_code = planner.main(
+                [str(FIXTURE_PATH), "--source-artifact", "runtime-artifacts/rl-control-loop/policy-advantage.json", "--output", str(output)],
+                stdout=stdout,
+                stderr=stderr,
+            )
+
+            self.assertEqual(exit_code, 0, stderr.getvalue())
+            second = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(first, second)
+            rendered = json.dumps(second, sort_keys=True)
+            self.assertIn('"officialMmoWrites": false', rendered)
+            self.assertNotIn("gh issue create", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_screeps_rl_act_loop_planner.py
+++ b/scripts/test_screeps_rl_act_loop_planner.py
@@ -100,6 +100,40 @@ class ScreepsRlActLoopPlannerTest(unittest.TestCase):
         self.assertEqual(plan["feedbackIngestion"]["training"]["state"], "missing")
         self.assertTrue(any("data quality" in reason for reason in plan["blockingReasons"]))
 
+    def test_no_compute_status_takes_precedence_over_missing_capabilities(self) -> None:
+        cases = (
+            {
+                "title": "Policy advantage has no compute evidence but lists scenario gaps",
+                "onlineUtilityStatus": "BLOCKED_NO_COMPUTE",
+                "missingCapabilities": ["multi_room_capable"],
+                "componentId": "construction-neglect-penalty",
+                "parameterSurface": "construction-priority",
+            },
+            {
+                "title": "Explicit scenario gap still lacks compute evidence",
+                "classification": "scenario_gap",
+                "onlineUtilityStatus": "BLOCKED_NO_COMPUTE",
+                "missingCapabilities": ["multi_room_capable"],
+                "componentId": "construction-neglect-penalty",
+                "parameterSurface": "construction-priority",
+            },
+        )
+
+        for raw in cases:
+            with self.subTest(title=raw["title"]):
+                plan = planner.build_plan(raw)
+
+                self.assertEqual(plan["finding"]["classification"], "data_quality")
+                self.assertIn("scenario_gap", plan["finding"]["secondaryClassifications"])
+                self.assertIn("policy_parameterization_gap", plan["finding"]["secondaryClassifications"])
+                self.assertEqual(plan["status"], "ROUTE_REQUIRED")
+                self.assertIsNone(plan["nextRewardDecision"])
+                self.assertIsNone(plan["nextScenarioDelta"])
+                self.assertIsNone(plan["nextPolicyDelta"])
+                self.assertIsNone(plan["nextExperimentCardDelta"])
+                self.assertEqual(plan["feedbackIngestion"]["training"]["state"], "missing")
+                self.assertTrue(any("data quality" in reason for reason in plan["blockingReasons"]))
+
     def test_blocked_classification_with_signal_noise_still_blocks_all_deltas(self) -> None:
         plan = planner.build_plan(
             {
@@ -143,7 +177,9 @@ class ScreepsRlActLoopPlannerTest(unittest.TestCase):
             {
                 "title": "Training report already exists",
                 "classification": "data_quality",
+                "trainingRunId": "",
                 "trainingReportIds": ["", "training-loop-b-sample-000002"],
+                "scorecardId": None,
                 "scorecardIds": [{"id": "scorecard-loop-b-sample-000002"}],
             }
         )

--- a/scripts/test_screeps_rl_act_loop_planner.py
+++ b/scripts/test_screeps_rl_act_loop_planner.py
@@ -7,6 +7,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).parent))
 
@@ -99,6 +100,54 @@ class ScreepsRlActLoopPlannerTest(unittest.TestCase):
         self.assertEqual(plan["feedbackIngestion"]["training"]["state"], "missing")
         self.assertTrue(any("data quality" in reason for reason in plan["blockingReasons"]))
 
+    def test_blocked_classification_with_signal_noise_still_blocks_all_deltas(self) -> None:
+        plan = planner.build_plan(
+            {
+                "title": "Telemetry missing with scenario and reward hints",
+                "classification": "data_quality",
+                "missingCapabilities": ["multi_room_capable"],
+                "componentId": "construction-neglect-penalty",
+                "onlineUtilityStatus": "BLOCKED_NO_COMPUTE",
+            }
+        )
+
+        self.assertEqual(plan["status"], "ROUTE_REQUIRED")
+        self.assertIsNone(plan["nextRewardDecision"])
+        self.assertIsNone(plan["nextScenarioDelta"])
+        self.assertIsNone(plan["nextPolicyDelta"])
+        self.assertIsNone(plan["nextExperimentCardDelta"])
+        self.assertEqual(plan["feedbackIngestion"]["training"]["state"], "missing")
+        self.assertTrue(any("data quality" in reason for reason in plan["blockingReasons"]))
+
+    def test_feedback_ingestion_links_first_usable_list_form_report_id(self) -> None:
+        plan = planner.build_plan(
+            {
+                "title": "Training report already exists",
+                "classification": "data_quality",
+                "trainingReportIds": ["", "training-loop-b-sample-000002"],
+                "scorecardIds": [{"id": "scorecard-loop-b-sample-000002"}],
+            }
+        )
+
+        self.assertEqual(plan["feedbackIngestion"]["training"]["state"], "linked")
+        self.assertEqual(plan["feedbackIngestion"]["training"]["id"], "training-loop-b-sample-000002")
+        self.assertEqual(plan["feedbackIngestion"]["scorecard"]["state"], "linked")
+        self.assertEqual(plan["feedbackIngestion"]["scorecard"]["id"], "scorecard-loop-b-sample-000002")
+
+    def test_unbounded_policy_only_finding_stays_route_required(self) -> None:
+        plan = planner.build_plan(
+            {
+                "title": "Expansion policy needs a new parameter surface",
+                "classification": "policy_parameterization_gap",
+                "parameterSurface": "expansion-risk-window",
+            }
+        )
+
+        self.assertEqual(plan["status"], "ROUTE_REQUIRED")
+        self.assertEqual(plan["nextPolicyDelta"]["boundsStatus"], "missing")
+        self.assertIsNone(plan["nextExperimentCardDelta"])
+        self.assertTrue(any("missing named bounds" in reason for reason in plan["blockingReasons"]))
+
     def test_cli_writes_deterministic_plan_without_github_or_mmo_actions(self) -> None:
         with tempfile.TemporaryDirectory(prefix="act-loop-plan-") as temp_dir:
             output = Path(temp_dir) / "plan.json"
@@ -127,6 +176,56 @@ class ScreepsRlActLoopPlannerTest(unittest.TestCase):
             rendered = json.dumps(second, sort_keys=True)
             self.assertIn('"officialMmoWrites": false', rendered)
             self.assertNotIn("gh issue create", rendered)
+
+    def test_cli_reports_malformed_json_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="act-loop-plan-") as temp_dir:
+            bad_input = Path(temp_dir) / "bad.json"
+            bad_input.write_text("{", encoding="utf-8")
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+
+            exit_code = planner.main([str(bad_input)], stdout=stdout, stderr=stderr)
+
+            self.assertEqual(exit_code, 1)
+            self.assertEqual(stdout.getvalue(), "")
+            self.assertIn("invalid JSON", stderr.getvalue())
+            self.assertNotIn("Traceback", stderr.getvalue())
+
+    def test_cli_reports_input_io_failures_without_traceback(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with mock.patch.object(planner, "load_json", side_effect=PermissionError("permission denied")):
+            exit_code = planner.main([str(FIXTURE_PATH)], stdout=stdout, stderr=stderr)
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("I/O failure", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
+
+    def test_cli_reports_output_write_failures_without_traceback(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with mock.patch.object(planner, "write_text_atomic", side_effect=OSError("permission denied")):
+            exit_code = planner.main([str(FIXTURE_PATH), "--output", "plan.json"], stdout=stdout, stderr=stderr)
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("I/O failure", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
+
+    def test_cli_reports_serialization_failures_without_traceback(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with mock.patch.object(planner, "build_plans", return_value={"bad": object()}):
+            exit_code = planner.main([str(FIXTURE_PATH)], stdout=stdout, stderr=stderr)
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("failed to serialize plan JSON", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes the first bounded implementation slice for #1240 by adding an offline RL Act-loop planner that turns Loop B / gameplay findings into structured Act-loop fields:

- `finding` classification and secondary classifications
- `nextRewardDecision`
- `nextScenarioDelta`
- `nextPolicyDelta`
- `nextExperimentCardDelta`
- `feedbackIngestion` links from finding -> decision -> experiment card -> training -> scorecard -> rollout feedback

This is analysis-only/offline plumbing. It does not call GitHub, Screeps official APIs, private servers, Tencent, cron, deploy, or `prod/` runtime code.

## Verification

Controller-side verification after rebasing onto current `origin/main`:

- `git diff --check` — PASS
- `python3 -m py_compile scripts/screeps_rl_act_loop_planner.py scripts/test_screeps_rl_act_loop_planner.py` — PASS
- `python3 -m unittest scripts/test_screeps_rl_act_loop_planner.py -v` — PASS (`4 tests`)
- `python3 scripts/screeps_rl_act_loop_planner.py scripts/fixtures/rl/act-loop-mixed-unproven-policy-advantage.json --source-artifact runtime-artifacts/rl-control-loop/policy-advantage.json --output /tmp/act-loop-plan-rebased.json` — PASS
- `python3 -m json.tool /tmp/act-loop-plan-rebased.json` — PASS

Commit: `d4c3388425f9b2324e5c7fa0826e402d30ff9619` by `lanyusea's bot <lanyusea@gmail.com>`.

## Safety

- Official MMO writes: false
- Live effect: false
- Deployment: none
- `prod/` runtime code: untouched

Fixes #1240
