### PR TITLE
fix(rl): unblock multi-tier activation proof kills

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -3306,11 +3306,24 @@ def project_multi_tier_policy_activation_metrics(metrics: JsonObject, activation
         return projected
     if any(safety.get(field) is True for field in ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed")):
         return projected
-    evidence = activation.get("projectedEvidence")
-    if not isinstance(evidence, dict):
-        return projected
-    projected_kills = _extract_int(evidence.get("projectedHostileKills")) or 0
-    if projected_kills <= 0:
+
+    evidence_source = "projectedEvidence"
+    evidence = activation.get(evidence_source)
+    if isinstance(evidence, dict):
+        activation_kills = _extract_int(evidence.get("projectedHostileKills")) or 0
+    else:
+        evidence_source = "observedEvidence"
+        evidence = activation.get(evidence_source)
+        if not isinstance(evidence, dict):
+            return projected
+        initial_hostiles = _extract_int(evidence.get("initialHostileCount"))
+        final_hostiles = _extract_int(evidence.get("finalHostileCount"))
+        activation_kills = (
+            max(0, initial_hostiles - final_hostiles)
+            if initial_hostiles is not None and final_hostiles is not None
+            else 0
+        )
+    if activation_kills <= 0:
         return projected
 
     combat = projected.setdefault("combat", {})
@@ -3320,7 +3333,7 @@ def project_multi_tier_policy_activation_metrics(metrics: JsonObject, activation
     existing_hostile_kills = _extract_int(projected.get("hostileKills"))
     if existing_hostile_kills is None:
         existing_hostile_kills = _extract_int(combat.get("hostileKills")) or 0
-    hostile_kills = max(existing_hostile_kills, projected_kills)
+    hostile_kills = max(existing_hostile_kills, activation_kills)
     own_losses = _extract_int(projected.get("ownLosses"))
     if own_losses is None:
         own_losses = _extract_int(combat.get("ownLosses")) or 0
@@ -3333,23 +3346,29 @@ def project_multi_tier_policy_activation_metrics(metrics: JsonObject, activation
 
     target_room = evidence.get("targetRoom")
     final_room_states = projected.get("finalRoomStates")
-    if isinstance(target_room, str) and isinstance(final_room_states, dict):
+    if evidence_source == "projectedEvidence" and isinstance(target_room, str) and isinstance(final_room_states, dict):
         final_summary = final_room_states.get(target_room)
         if isinstance(final_summary, dict):
             final_combat = final_summary.setdefault("combat", {})
             if isinstance(final_combat, dict):
                 hostile_creeps = _extract_int(final_combat.get("hostileCreeps")) or 0
                 if hostile_creeps > 0:
-                    final_combat["hostileCreeps"] = max(0, hostile_creeps - projected_kills)
-    projected["policyActivation"] = {
+                    final_combat["hostileCreeps"] = max(0, hostile_creeps - activation_kills)
+    policy_activation: JsonObject = {
         "type": activation.get("type"),
         "strategyVariantId": activation.get("strategyVariantId"),
         "executionAction": activation.get("executionAction"),
         "objectiveSignalSource": activation.get("objectiveSignalSource"),
         "targetRoom": activation.get("targetRoom"),
-        "projectedHostileKills": projected_kills,
+        "hostileKills": hostile_kills,
+        "hostileKillsSource": evidence_source,
         "safety": copy.deepcopy(safety),
     }
+    if evidence_source == "projectedEvidence":
+        policy_activation["projectedHostileKills"] = activation_kills
+    else:
+        policy_activation["observedHostileKills"] = activation_kills
+    projected["policyActivation"] = policy_activation
     return projected
 
 

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -3307,15 +3307,10 @@ def project_multi_tier_policy_activation_metrics(metrics: JsonObject, activation
     if any(safety.get(field) is True for field in ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed")):
         return projected
 
-    evidence_source = "projectedEvidence"
+    evidence_source = "observedEvidence"
     evidence = activation.get(evidence_source)
+    activation_kills = 0
     if isinstance(evidence, dict):
-        activation_kills = _extract_int(evidence.get("projectedHostileKills")) or 0
-    else:
-        evidence_source = "observedEvidence"
-        evidence = activation.get(evidence_source)
-        if not isinstance(evidence, dict):
-            return projected
         initial_hostiles = _extract_int(evidence.get("initialHostileCount"))
         final_hostiles = _extract_int(evidence.get("finalHostileCount"))
         activation_kills = (
@@ -3323,6 +3318,12 @@ def project_multi_tier_policy_activation_metrics(metrics: JsonObject, activation
             if initial_hostiles is not None and final_hostiles is not None
             else 0
         )
+    if activation_kills <= 0:
+        evidence_source = "projectedEvidence"
+        evidence = activation.get(evidence_source)
+        if not isinstance(evidence, dict):
+            return projected
+        activation_kills = _extract_int(evidence.get("projectedHostileKills")) or 0
     if activation_kills <= 0:
         return projected
 
@@ -3346,14 +3347,19 @@ def project_multi_tier_policy_activation_metrics(metrics: JsonObject, activation
 
     target_room = evidence.get("targetRoom")
     final_room_states = projected.get("finalRoomStates")
-    if evidence_source == "projectedEvidence" and isinstance(target_room, str) and isinstance(final_room_states, dict):
+    if isinstance(target_room, str) and isinstance(final_room_states, dict):
         final_summary = final_room_states.get(target_room)
         if isinstance(final_summary, dict):
             final_combat = final_summary.setdefault("combat", {})
             if isinstance(final_combat, dict):
-                hostile_creeps = _extract_int(final_combat.get("hostileCreeps")) or 0
-                if hostile_creeps > 0:
-                    final_combat["hostileCreeps"] = max(0, hostile_creeps - activation_kills)
+                final_hostile_count = _extract_int(evidence.get("finalHostileCount"))
+                if final_hostile_count is not None:
+                    hostile_structures = _extract_int(final_combat.get("hostileStructures")) or 0
+                    final_combat["hostileCreeps"] = max(0, final_hostile_count - hostile_structures)
+                elif evidence_source == "projectedEvidence":
+                    hostile_creeps = _extract_int(final_combat.get("hostileCreeps")) or 0
+                    if hostile_creeps > 0:
+                        final_combat["hostileCreeps"] = max(0, hostile_creeps - activation_kills)
     policy_activation: JsonObject = {
         "type": activation.get("type"),
         "strategyVariantId": activation.get("strategyVariantId"),

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -2338,7 +2338,7 @@ def multi_tier_activation_sample_trace(
         },
     }
     if policy_activation is not None:
-        trace["policyActivation"] = {
+        trace_policy_activation = {
             "type": policy_activation.get("type"),
             "policyAction": policy_activation.get("policyAction"),
             "executionAction": policy_activation.get("executionAction"),
@@ -2349,6 +2349,11 @@ def multi_tier_activation_sample_trace(
             "threshold": policy_activation.get("threshold"),
             "reason": policy_activation.get("reason"),
         }
+        activation_metrics = projected_activation if projected_activation is not None else policy_activation
+        for field in ("hostileKills", "hostileKillsSource", "projectedHostileKills", "observedHostileKills"):
+            if field in activation_metrics:
+                trace_policy_activation[field] = activation_metrics.get(field)
+        trace["policyActivation"] = trace_policy_activation
     if projected_evidence is not None:
         trace["projectedEvidence"] = {
             "mode": projected_evidence.get("mode"),

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1312,6 +1312,7 @@ cli:
         self.assertEqual(projected_metrics["combat"]["hostileKills"], 1)
         self.assertEqual(projected_metrics["combatDelta"], 1)
         self.assertEqual(projected_metrics["policyActivation"]["targetRoom"], "E2S1")
+        self.assertEqual(projected_metrics["policyActivation"]["hostileKillsSource"], "projectedEvidence")
         self.assertEqual(tick_log, before_tick_log)
         self.assertEqual(base_metrics["hostileKills"], 0)
         self.assertFalse(activation["safety"]["liveEffect"])
@@ -1365,6 +1366,13 @@ cli:
                 "finalHostileCount": 2,
                 "hostileCountReduced": True,
             },
+            "projectedEvidence": {
+                "targetRoom": "E2S1",
+                "initialHostileCount": 3,
+                "finalHostileCount": 3,
+                "projectedHostileKills": 0,
+                "hostileCountReduced": False,
+            },
             "safety": {
                 "liveEffect": False,
                 "officialMmoWrites": False,
@@ -1381,7 +1389,7 @@ cli:
             "finalRoomStates": {
                 "E2S1": {
                     "combat": {
-                        "hostileCreeps": 2,
+                        "hostileCreeps": 99,
                     },
                 },
             },

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1352,6 +1352,50 @@ cli:
         self.assertEqual(projected["combat"]["ownLosses"], 0)
         self.assertEqual(projected["combatDelta"], 1)
 
+    def test_multi_tier_policy_activation_observed_reduction_overrides_explicit_zero_metrics(self) -> None:
+        activation = {
+            "type": "screeps-rl-multi-tier-policy-activation",
+            "strategyVariantId": "candidate",
+            "executionAction": "engage-hostiles",
+            "objectiveSignalSource": "tick_log",
+            "targetRoom": "E2S1",
+            "observedEvidence": {
+                "targetRoom": "E2S1",
+                "initialHostileCount": 3,
+                "finalHostileCount": 2,
+                "hostileCountReduced": True,
+            },
+            "safety": {
+                "liveEffect": False,
+                "officialMmoWrites": False,
+                "officialMmoWritesAllowed": False,
+            },
+        }
+        metrics = {
+            "hostileKills": 0,
+            "ownLosses": 0,
+            "combat": {
+                "hostileKills": 0,
+                "ownLosses": 0,
+            },
+            "finalRoomStates": {
+                "E2S1": {
+                    "combat": {
+                        "hostileCreeps": 2,
+                    },
+                },
+            },
+        }
+
+        projected = harness.project_multi_tier_policy_activation_metrics(metrics, activation)
+
+        self.assertEqual(projected["hostileKills"], 1)
+        self.assertEqual(projected["combat"]["hostileKills"], 1)
+        self.assertEqual(projected["combatDelta"], 1)
+        self.assertEqual(projected["policyActivation"]["observedHostileKills"], 1)
+        self.assertEqual(projected["policyActivation"]["hostileKillsSource"], "observedEvidence")
+        self.assertEqual(projected["finalRoomStates"]["E2S1"]["combat"]["hostileCreeps"], 2)
+
     def test_multi_tier_policy_activation_stays_inactive_for_low_territory_candidate(self) -> None:
         fixture_path = Path("scripts/fixtures/rl/multi-tier-territory-combat-v0.map.json")
         fixture_summaries = harness._private_map_fixture_room_summaries(fixture_path)

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -646,6 +646,7 @@ class RlTrainingRunnerTest(unittest.TestCase):
         trace = territory_result["multiTierActivationTraces"][0]
         self.assertEqual(trace["metricsSource"], "simulator_policy_activation")
         self.assertEqual(trace["policyActivation"]["objectiveSignalSource"], "tick_log")
+        self.assertEqual(trace["policyActivation"]["hostileKillsSource"], "observedEvidence")
         self.assertTrue(trace["observedEvidence"]["hostileCountReduced"])
 
     def test_multi_tier_activation_proof_passes_with_offline_policy_activation_projection(self) -> None:
@@ -697,6 +698,7 @@ class RlTrainingRunnerTest(unittest.TestCase):
         territory_trace = territory_result["multiTierActivationTraces"][0]
         self.assertEqual(territory_trace["metricsSource"], "simulator_policy_activation")
         self.assertEqual(territory_trace["policyActivation"]["objectiveSignalSource"], "offline_shadow_projection")
+        self.assertEqual(territory_trace["policyActivation"]["hostileKillsSource"], "projectedEvidence")
         self.assertEqual(territory_trace["projectedEvidence"]["projectedHostileKills"], 1)
         self.assertEqual(
             proof["variants"][1]["activationTraces"][0]["policyActivation"]["targetRoom"],

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -564,9 +564,15 @@ class RlTrainingRunnerTest(unittest.TestCase):
         )
         variant_ids = [variant["id"] for variant in card["strategy_variants"]]
         start = tick(1, [room("E1S1", energy=100), hostile_fixture_room()])
-        finish = tick(2, [room("E1S1", energy=150), hostile_fixture_room(hostile_creeps=1)])
         simulator_results: dict[str, JsonObject] = {}
         for index, variant_id in enumerate(variant_ids):
+            finish = tick(
+                2,
+                [
+                    room("E1S1", energy=150),
+                    hostile_fixture_room(hostile_creeps=1 if index == 0 else 2),
+                ],
+            )
             result = variant_result(variant_id, [start, finish])
             result["metrics"] = {"territoryDelta": 2, "hostileKills": 1 if index == 0 else 0}
             simulator_results[variant_id] = result
@@ -587,6 +593,60 @@ class RlTrainingRunnerTest(unittest.TestCase):
         self.assertTrue(proof["ok"])
         self.assertEqual(proof["passingVariants"], [variant_ids[0]])
         self.assertNotIn("blocker", proof)
+
+    def test_multi_tier_activation_proof_derives_kills_from_observed_hostile_reduction(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-training-multitier-observed-reduction",
+            code_commit="b" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-18T10:25:30Z",
+            scenario_id=card_helper.MULTI_TIER_SCENARIO_ID,
+            require_multi_tier_scenario=True,
+        )
+        simulator_results: dict[str, JsonObject] = {}
+        for variant in card["strategy_variants"]:
+            variant_id = variant["id"]
+            reduced_hostiles = variant_id == "construction-priority.pg.territory-seed.v1"
+            tick_log = [
+                tick(1, [room("E1S1", energy=100), hostile_fixture_room()]),
+                tick(
+                    2,
+                    [
+                        room("E1S1", energy=150),
+                        hostile_fixture_room(hostile_creeps=1 if reduced_hostiles else 2),
+                    ],
+                ),
+            ]
+            result = variant_result(variant_id, tick_log)
+            result["metrics"] = {"territoryDelta": 2, "hostileKills": 0, "ownLosses": 0}
+            simulator_results[variant_id] = result
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="multi-tier-observed-reduction",
+                simulator_runner=MockSimulator(simulator_results),
+            )
+
+        proof = report["activationProof"]
+        self.assertEqual(proof["status"], "passed")
+        self.assertEqual(proof["passingVariants"], ["construction-priority.pg.territory-seed.v1"])
+        territory_result = next(
+            result
+            for result in report["variantResults"]
+            if result["variantId"] == "construction-priority.pg.territory-seed.v1"
+        )
+        self.assertEqual(territory_result["metrics"]["kills"]["hostileKills"], 1)
+        self.assertEqual(territory_result["multiTierActivationSamples"][0]["hostileKills"], 1)
+        self.assertTrue(territory_result["multiTierActivationSamples"][0]["passesActivation"])
+        trace = territory_result["multiTierActivationTraces"][0]
+        self.assertEqual(trace["metricsSource"], "simulator_policy_activation")
+        self.assertEqual(trace["policyActivation"]["objectiveSignalSource"], "tick_log")
+        self.assertTrue(trace["observedEvidence"]["hostileCountReduced"])
 
     def test_multi_tier_activation_proof_passes_with_offline_policy_activation_projection(self) -> None:
         card = card_helper.build_card(


### PR DESCRIPTION
## Summary
- Fixes #1248.
- Allows the multi-tier activation proof to treat simulator-observed hostile reduction as engagement evidence when direct kill accounting remains zero.
- Adds regression coverage in the simulator harness and training runner paths for zero-kill simulator engagement.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py`
- `python3 -m unittest scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py -v` (157 tests OK)

## Notes
- Triage artifact: `/tmp/issue1248-activation-proof-triage.md` (not staged).
- Commit: `fd3dc258` authored by `lanyusea's bot <lanyusea@gmail.com>`.
