### PR TITLE
fix(rl): self-heal Tencent runner SSH known hosts

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -79,6 +79,15 @@ SSH_CONNECT_OPTIONS = (
     "-o", "ServerAliveCountMax=8",
     "-o", "StrictHostKeyChecking=accept-new",
 )
+KNOWN_HOSTS_CLEANUP_TIMEOUT_SECONDS = 30
+HOST_KEY_ALGORITHM_RE = (
+    r"(?:ssh-rsa|ssh-dss|ssh-ed25519|ecdsa-sha2-nistp\d+|"
+    r"sk-ssh-ed25519@openssh\.com|sk-ecdsa-sha2-nistp256@openssh\.com)"
+)
+HOST_KEY_BLOB_RE = re.compile(rf"\b{HOST_KEY_ALGORITHM_RE}\s+[A-Za-z0-9+/=]+")
+SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(?:STEAM_KEY|TOKEN|SECRET|PASSWORD|PRIVATE_KEY|TENCENTCLOUD_SECRET_KEY|TENCENT_SECRET_KEY)=\S+"
+)
 BUNDLE_ALLOWLISTED_RUNTIME_FILES = ("maps/map-0b6758af.json",)
 BUNDLE_EXCLUDE_DIRS = {".git", "node_modules", "__pycache__", ".codex", ".codex-local-git", ".git-local"}
 BUNDLE_EXCLUDE_PREFIXES = (
@@ -192,7 +201,7 @@ class Controller:
 
     @property
     def known_hosts_path(self) -> Path:
-        return Path(getattr(self.args, "known_hosts_path", DEFAULT_KNOWN_HOSTS))
+        return Path(getattr(self.args, "known_hosts_path", DEFAULT_KNOWN_HOSTS)).expanduser()
 
     @property
     def ssh_target(self) -> str:
@@ -313,6 +322,7 @@ class Controller:
             raise BatchRunError(f"{name} returned non-JSON output: {error}") from error
 
     def ssh_cmd(self, name: str, remote_command: str, *, check: bool = True, timeout: int | None = 600) -> subprocess.CompletedProcess[str]:
+        self.clear_worker_known_host()
         cmd = [
             "ssh",
             "-i", self.args.ssh_key,
@@ -323,6 +333,7 @@ class Controller:
         return self.run_cp(name, cmd, check=check, timeout=timeout)
 
     def scp_to_worker(self, name: str, local_path: Path, remote_path: str, *, timeout: int = 300) -> None:
+        self.clear_worker_known_host()
         self.run_cp(
             name,
             [
@@ -336,6 +347,7 @@ class Controller:
         )
 
     def scp_from_worker(self, name: str, remote_path: str, local_path: Path, *, timeout: int = 900) -> None:
+        self.clear_worker_known_host()
         local_path.parent.mkdir(parents=True, exist_ok=True)
         self.run_cp(
             name,
@@ -349,20 +361,23 @@ class Controller:
             timeout=timeout,
         )
 
-    def clear_worker_known_host(self) -> None:
+    def clear_worker_known_host(self) -> bool:
         if not self.public_ip:
-            return
+            return True
         if self.public_ip in self.known_hosts_cleaned_public_ips:
-            return
-        cmd = ["ssh-keygen", "-R", self.public_ip, "-f", str(self.known_hosts_path)]
+            return True
+        known_hosts = self.known_hosts_path
+        cmd = ["ssh-keygen", "-R", self.public_ip, "-f", str(known_hosts)]
         started = time.time()
         try:
+            known_hosts.parent.mkdir(parents=True, exist_ok=True)
+            known_hosts.touch(exist_ok=True)
             cp = subprocess.run(
                 cmd,
                 text=True,
                 capture_output=True,
                 cwd=str(REPO_ROOT),
-                timeout=30,
+                timeout=KNOWN_HOSTS_CLEANUP_TIMEOUT_SECONDS,
                 check=False,
             )
         except subprocess.TimeoutExpired as error:
@@ -373,9 +388,36 @@ class Controller:
         except OSError as error:
             cp = subprocess.CompletedProcess(cmd, 127, "", f"{type(error).__name__}: {error}")
         ok = cp.returncode == 0
-        self.record_step("clear_worker_known_host", started, ok, cp, argv=redacted_argv(cmd))
+        record_cp = subprocess.CompletedProcess(
+            cp.args,
+            cp.returncode,
+            sanitize_known_hosts_cleanup_text(cp.stdout),
+            sanitize_known_hosts_cleanup_text(cp.stderr),
+        )
+        if not ok:
+            warnings = self.result.setdefault("knownHostsCleanupWarnings", [])
+            if isinstance(warnings, list):
+                warnings.append(
+                    {
+                        "publicIp": self.public_ip,
+                        "knownHostsFile": str(known_hosts),
+                        "returncode": cp.returncode,
+                        "stderrTail": tail_text(record_cp.stderr),
+                    }
+                )
+        self.record_step(
+            "clear_worker_known_host",
+            started,
+            ok,
+            record_cp,
+            argv=redacted_argv(cmd),
+            publicIp=self.public_ip,
+            knownHostsFile=str(known_hosts),
+            warning=not ok,
+        )
         if ok:
             self.known_hosts_cleaned_public_ips.add(self.public_ip)
+        return ok
 
     def experiment_card_path(self) -> Path:
         return self.artifact_dir / "experiment_card.json"
@@ -1024,6 +1066,20 @@ def tail_text(raw: str | None, limit: int = 3000) -> str:
         return ""
     text = raw.replace("\r", "")
     return text[-limit:]
+
+
+def sanitize_known_hosts_cleanup_text(raw: str | bytes | None) -> str:
+    if not raw:
+        return ""
+    text = raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else raw
+    text = text.replace("\r", "")
+    text = HOST_KEY_BLOB_RE.sub("[REDACTED_HOST_KEY]", text)
+
+    def redact_secret(match: re.Match[str]) -> str:
+        key, _value = match.group(0).split("=", 1)
+        return f"{key}=[REDACTED]"
+
+    return SECRET_ASSIGNMENT_RE.sub(redact_secret, text)
 
 
 def redacted_argv(argv: Sequence[str]) -> list[str]:
@@ -2506,6 +2562,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--billing-guard", default=str(DEFAULT_BILLING_GUARD))
     parser.add_argument("--secret-env", default=str(DEFAULT_SECRET_ENV))
     parser.add_argument("--ssh-key", default=str(DEFAULT_SSH_KEY))
+    parser.add_argument("--known-hosts-path", default=str(DEFAULT_KNOWN_HOSTS))
     parser.add_argument("--dataset-run-id", default="rl-3d29e8b9397d")
     parser.add_argument("--training-approach", default="bandit", choices=("bandit", "evolutionary", "policy_gradient"))
     parser.add_argument("--ticks", type=int, default=50, help="Simulator ticks; policy_gradient runs are floored to 500.")

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -81,8 +81,12 @@ SSH_CONNECT_OPTIONS = (
 )
 KNOWN_HOSTS_CLEANUP_TIMEOUT_SECONDS = 30
 HOST_KEY_ALGORITHM_RE = (
-    r"(?:ssh-rsa|ssh-dss|ssh-ed25519|ecdsa-sha2-nistp\d+|"
-    r"sk-ssh-ed25519@openssh\.com|sk-ecdsa-sha2-nistp256@openssh\.com)"
+    r"(?:ssh-rsa(?:-cert-v01@openssh\.com)?|"
+    r"ssh-dss(?:-cert-v01@openssh\.com)?|"
+    r"ssh-ed25519(?:-cert-v01@openssh\.com)?|"
+    r"ecdsa-sha2-nistp\d+(?:-cert-v01@openssh\.com)?|"
+    r"sk-ssh-ed25519(?:@openssh\.com|-cert-v01@openssh\.com)|"
+    r"sk-ecdsa-sha2-nistp256(?:@openssh\.com|-cert-v01@openssh\.com))"
 )
 HOST_KEY_BLOB_RE = re.compile(rf"\b{HOST_KEY_ALGORITHM_RE}\s+[A-Za-z0-9+/=]+")
 SECRET_ASSIGNMENT_RE = re.compile(
@@ -381,8 +385,12 @@ class Controller:
                 check=False,
             )
         except subprocess.TimeoutExpired as error:
-            stdout = error.output.decode("utf-8", errors="replace") if isinstance(error.output, bytes) else (error.output or "")
-            stderr = error.stderr.decode("utf-8", errors="replace") if isinstance(error.stderr, bytes) else (error.stderr or "")
+            stdout_raw = getattr(error, "stdout", None)
+            if stdout_raw is None:
+                stdout_raw = getattr(error, "output", None)
+            stderr_raw = getattr(error, "stderr", None)
+            stdout = decode_subprocess_text(stdout_raw)
+            stderr = decode_subprocess_text(stderr_raw)
             stderr = "\n".join(part for part in (f"{type(error).__name__}: {error}", stderr) if part)
             cp = subprocess.CompletedProcess(cmd, 124, stdout, stderr)
         except OSError as error:
@@ -1068,10 +1076,16 @@ def tail_text(raw: str | None, limit: int = 3000) -> str:
     return text[-limit:]
 
 
+def decode_subprocess_text(raw: str | bytes | None) -> str:
+    if not raw:
+        return ""
+    return raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else raw
+
+
 def sanitize_known_hosts_cleanup_text(raw: str | bytes | None) -> str:
     if not raw:
         return ""
-    text = raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else raw
+    text = decode_subprocess_text(raw)
     text = text.replace("\r", "")
     text = HOST_KEY_BLOB_RE.sub("[REDACTED_HOST_KEY]", text)
 

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -2159,10 +2159,16 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
             controller = FakeController(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
+            timeout_stdout = (
+                b"line=203.0.113.10 ssh-ed25519-cert-v01@openssh.com "
+                b"AAAAC3NzaC1lZDI1NTE5LWNlcnQtimeoutkey\n"
+                b"STEAM_KEY=timeout-steam-secret\n"
+            )
+            timeout_stderr = b"TOKEN=timeout-token-secret\ntimed out\n"
             with mock.patch.object(
                 runner.subprocess,
                 "run",
-                side_effect=subprocess.TimeoutExpired(["ssh-keygen"], 30, output="", stderr="timed out\n"),
+                side_effect=subprocess.TimeoutExpired(["ssh-keygen"], 30, output=timeout_stdout, stderr=timeout_stderr),
             ):
                 controller.scale_up_and_wait()
 
@@ -2174,6 +2180,20 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertNotIn("203.0.113.10", controller.known_hosts_cleaned_public_ips)
         self.assertEqual(controller.result["knownHostsCleanupWarnings"][0]["returncode"], 124)
         self.assertEqual(controller.result["worker"]["publicIp"], "203.0.113.10")
+        combined = json.dumps(
+            {
+                "steps": [step.__dict__ for step in controller.steps],
+                "result": controller.result,
+            },
+            sort_keys=True,
+        )
+        self.assertIn("[REDACTED_HOST_KEY]", combined)
+        self.assertIn("STEAM_KEY=[REDACTED]", combined)
+        self.assertIn("TOKEN=[REDACTED]", combined)
+        self.assertNotIn("AAAAC3NzaC1lZDI1NTE5LWNlcnQtimeoutkey", combined)
+        self.assertNotIn("ssh-ed25519-cert-v01@openssh.com", combined)
+        self.assertNotIn("timeout-steam-secret", combined)
+        self.assertNotIn("timeout-token-secret", combined)
 
     def test_scale_up_retries_failed_known_host_cleanup_for_same_ip(self) -> None:
         args = controller_args()
@@ -2301,8 +2321,16 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
             controller = runner.Controller(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
             controller.public_ip = "203.0.113.10"
-            stdout = "line=203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIhostkey comment\nSTEAM_KEY=steam-secret\n"
-            stderr = "TOKEN=token-secret\necdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYhostkey\n"
+            stdout = (
+                "line=203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIhostkey comment\n"
+                "line=203.0.113.10 ssh-rsa-cert-v01@openssh.com AAAAB3NzaC1yc2EtY2VydCcertkey comment\n"
+                "STEAM_KEY=steam-secret\n"
+            )
+            stderr = (
+                "TOKEN=token-secret\n"
+                "ecdsa-sha2-nistp256-cert-v01@openssh.com AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYtY2VydCcertkey\n"
+                "sk-ssh-ed25519-cert-v01@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5LWNlcnQcertkey\n"
+            )
 
             with mock.patch.object(
                 runner.subprocess,
@@ -2323,6 +2351,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertIn("STEAM_KEY=[REDACTED]", combined)
         self.assertIn("TOKEN=[REDACTED]", combined)
         self.assertNotIn("AAAA", combined)
+        self.assertNotIn("-cert-v01@openssh.com", combined)
         self.assertNotIn("steam-secret", combined)
         self.assertNotIn("token-secret", combined)
 

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -63,6 +63,7 @@ def controller_args() -> argparse.Namespace:
         security_group_id="sg-test",
         scenario_id=runner.DEFAULT_SCENARIO_ID,
         require_multi_tier_scenario=False,
+        known_hosts_path="/tmp/known_hosts",
         ssh_key="/tmp/id_ed25519",
         tccli="/bin/tccli",
         ticks=1,
@@ -2125,6 +2126,8 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         clear_steps = [step for step in controller.steps if step.name == "clear_worker_known_host"]
         self.assertEqual(len(clear_steps), 1)
         self.assertFalse(clear_steps[0].ok)
+        self.assertNotIn("203.0.113.10", controller.known_hosts_cleaned_public_ips)
+        self.assertEqual(controller.result["knownHostsCleanupWarnings"][0]["returncode"], 255)
         self.assertEqual(controller.result["worker"]["publicIp"], "203.0.113.10")
 
     def test_scale_up_known_host_cleanup_timeout_does_not_raise_or_mark_cleaned(self) -> None:
@@ -2169,6 +2172,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(clear_steps[0].returncode, 124)
         self.assertIn("TimeoutExpired", clear_steps[0].stderr_tail or "")
         self.assertNotIn("203.0.113.10", controller.known_hosts_cleaned_public_ips)
+        self.assertEqual(controller.result["knownHostsCleanupWarnings"][0]["returncode"], 124)
         self.assertEqual(controller.result["worker"]["publicIp"], "203.0.113.10")
 
     def test_scale_up_retries_failed_known_host_cleanup_for_same_ip(self) -> None:
@@ -2244,16 +2248,20 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         run.assert_not_called()
         self.assertFalse([step for step in controller.steps if step.name == "clear_worker_known_host"])
 
-    def test_ssh_and_scp_commands_keep_accept_new_host_key_option(self) -> None:
+    def test_ssh_and_scp_commands_auto_cleanup_and_use_consistent_known_hosts_path(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             args = controller_args()
             args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
+            parsed = runner.parse_cli_args(["preflight", "--known-hosts-path", args.known_hosts_path])
+            self.assertEqual(parsed.known_hosts_path, args.known_hosts_path)
             controller = runner.Controller(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
             controller.public_ip = "203.0.113.10"
+            events: list[tuple[str, list[str]]] = []
             cleanup_commands: list[list[str]] = []
             commands: list[list[str]] = []
 
             def capture_subprocess_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                events.append(("cleanup", cmd))
                 cleanup_commands.append(cmd)
                 return subprocess.CompletedProcess(cmd, 0, "", "")
 
@@ -2267,6 +2275,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 input_text: str | None = None,
                 env: dict[str, str] | None = None,
             ) -> subprocess.CompletedProcess[str]:
+                events.append(("command", cmd))
                 commands.append(cmd)
                 return subprocess.CompletedProcess(cmd, 0, "", "")
 
@@ -2274,17 +2283,48 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 mock.patch.object(runner.subprocess, "run", side_effect=capture_subprocess_run),
                 mock.patch.object(controller, "run_cp", side_effect=capture_run_cp),
             ):
-                controller.clear_worker_known_host()
                 controller.ssh_cmd("ssh_probe", "true")
                 controller.scp_to_worker("upload", Path(temp_dir) / "local.txt", "/remote/local.txt")
                 controller.scp_from_worker("download", "/remote/out.txt", Path(temp_dir) / "out" / "out.txt")
 
         self.assertEqual(cleanup_commands, [["ssh-keygen", "-R", "203.0.113.10", "-f", args.known_hosts_path]])
+        self.assertEqual([event[0] for event in events], ["cleanup", "command", "command", "command"])
         for cmd in commands:
             with self.subTest(command=cmd[0]):
                 self.assertIn("BatchMode=yes", cmd)
                 self.assertIn("StrictHostKeyChecking=accept-new", cmd)
                 self.assertIn(f"UserKnownHostsFile={args.known_hosts_path}", cmd)
+
+    def test_known_host_cleanup_warning_redacts_secret_and_host_key_output(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args = controller_args()
+            args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
+            controller.public_ip = "203.0.113.10"
+            stdout = "line=203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIhostkey comment\nSTEAM_KEY=steam-secret\n"
+            stderr = "TOKEN=token-secret\necdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYhostkey\n"
+
+            with mock.patch.object(
+                runner.subprocess,
+                "run",
+                return_value=subprocess.CompletedProcess(["ssh-keygen"], 255, stdout, stderr),
+            ):
+                controller.clear_worker_known_host()
+
+            combined = json.dumps(
+                {
+                    "steps": [step.__dict__ for step in controller.steps],
+                    "result": controller.result,
+                },
+                sort_keys=True,
+            )
+
+        self.assertIn("[REDACTED_HOST_KEY]", combined)
+        self.assertIn("STEAM_KEY=[REDACTED]", combined)
+        self.assertIn("TOKEN=[REDACTED]", combined)
+        self.assertNotIn("AAAA", combined)
+        self.assertNotIn("steam-secret", combined)
+        self.assertNotIn("token-secret", combined)
 
     def test_safe_extract_tar_rejects_traversal_and_special_entries(self) -> None:
         cases = [


### PR DESCRIPTION
## Summary
- Self-heals Tencent batch runner SSH known_hosts rotation by using one explicit known-hosts path consistently for cleanup, SSH, and SCP.
- Tracks cleanup success per host/path and does not mark a stale host key as cleaned when ssh-keygen fails or times out.
- Treats cleanup failure as a non-fatal warning so scale/wait retry paths can continue safely.
- Adds focused tests for path consistency, cleanup failure/timeout behavior, and SSH/SCP option propagation.

## Test plan
- `git diff --check`
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m pytest scripts/test_screeps_tencent_batch_rl_runner.py -q` (67 passed, 47 subtests passed)

## Controller notes
- Commit: `0000a628771d7fed43f56df8f86af96a0d8747bc`
- Author: `lanyusea's bot <lanyusea@gmail.com>`
- Safety: no secrets printed; no runtime artifacts staged; no production bot files touched.

Fixes #1255
