### PR TITLE
fix(strategy): allow territory control from RCL5

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -16420,7 +16420,7 @@ function isExpansionClaimState(state) {
   return state === "scouted" || state === "claiming" || state === "claimed";
 }
 function isExpansionAbortReason(reason) {
-  return reason === "homeUnstable" || reason === "existingExpansion" || reason === "scoreBelowThreshold" || reason === "scoutTimedOut" || reason === "controllerMissing" || reason === "controllerOwned" || reason === "controllerReserved" || reason === "reservationLost" || reason === "targetHostile" || reason === "sourcesMissing" || reason === "controllerLevelGate";
+  return reason === "homeUnstable" || reason === "existingExpansion" || reason === "scoreBelowThreshold" || reason === "scoutTimedOut" || reason === "controllerMissing" || reason === "controllerOwned" || reason === "controllerReserved" || reason === "reservationLost" || reason === "targetHostile" || reason === "sourcesMissing" || reason === "rcl6Gate" || reason === "controllerLevelGate";
 }
 function isFiniteNumber9(value) {
   return typeof value === "number" && Number.isFinite(value);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3818,9 +3818,9 @@ function isNonEmptyString4(value) {
 }
 
 // src/territory/controlGate.ts
-var AUTONOMOUS_TERRITORY_CONTROL_MIN_RCL = 6;
+var AUTONOMOUS_TERRITORY_CONTROL_MIN_RCL = 5;
 var AUTONOMOUS_TERRITORY_CONTROL_SUPPRESSION_REASON = "controllerLevel";
-var AUTONOMOUS_TERRITORY_CONTROL_ABORT_REASON = "rcl6Gate";
+var AUTONOMOUS_TERRITORY_CONTROL_ABORT_REASON = "controllerLevelGate";
 function isAutonomousTerritoryControlAllowedForColony(colony) {
   return isAutonomousTerritoryControlAllowedForController(colony.room.controller);
 }
@@ -16420,7 +16420,7 @@ function isExpansionClaimState(state) {
   return state === "scouted" || state === "claiming" || state === "claimed";
 }
 function isExpansionAbortReason(reason) {
-  return reason === "homeUnstable" || reason === "existingExpansion" || reason === "scoreBelowThreshold" || reason === "scoutTimedOut" || reason === "controllerMissing" || reason === "controllerOwned" || reason === "controllerReserved" || reason === "reservationLost" || reason === "targetHostile" || reason === "sourcesMissing" || reason === "rcl6Gate";
+  return reason === "homeUnstable" || reason === "existingExpansion" || reason === "scoreBelowThreshold" || reason === "scoutTimedOut" || reason === "controllerMissing" || reason === "controllerOwned" || reason === "controllerReserved" || reason === "reservationLost" || reason === "targetHostile" || reason === "sourcesMissing" || reason === "controllerLevelGate";
 }
 function isFiniteNumber9(value) {
   return typeof value === "number" && Number.isFinite(value);

--- a/prod/src/territory/controlGate.ts
+++ b/prod/src/territory/controlGate.ts
@@ -1,9 +1,9 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
 
-export const AUTONOMOUS_TERRITORY_CONTROL_MIN_RCL = 6;
+export const AUTONOMOUS_TERRITORY_CONTROL_MIN_RCL = 5;
 export const AUTONOMOUS_TERRITORY_CONTROL_SUPPRESSION_REASON: TerritoryIntentSuppressionReason =
   'controllerLevel';
-export const AUTONOMOUS_TERRITORY_CONTROL_ABORT_REASON: TerritoryExpansionAbortReason = 'rcl6Gate';
+export const AUTONOMOUS_TERRITORY_CONTROL_ABORT_REASON: TerritoryExpansionAbortReason = 'controllerLevelGate';
 
 export function isAutonomousTerritoryControlAllowedForColony(colony: ColonySnapshot): boolean {
   return isAutonomousTerritoryControlAllowedForController(colony.room.controller);

--- a/prod/src/territory/expansionTrigger.ts
+++ b/prod/src/territory/expansionTrigger.ts
@@ -1179,7 +1179,7 @@ function isExpansionAbortReason(reason: unknown): reason is TerritoryExpansionAb
     reason === 'reservationLost' ||
     reason === 'targetHostile' ||
     reason === 'sourcesMissing' ||
-    reason === 'rcl6Gate'
+    reason === 'controllerLevelGate'
   );
 }
 

--- a/prod/src/territory/expansionTrigger.ts
+++ b/prod/src/territory/expansionTrigger.ts
@@ -1179,6 +1179,7 @@ function isExpansionAbortReason(reason: unknown): reason is TerritoryExpansionAb
     reason === 'reservationLost' ||
     reason === 'targetHostile' ||
     reason === 'sourcesMissing' ||
+    reason === 'rcl6Gate' ||
     reason === 'controllerLevelGate'
   );
 }

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -696,6 +696,7 @@ declare global {
     | 'reservationLost'
     | 'targetHostile'
     | 'sourcesMissing'
+    | 'rcl6Gate'
     | 'controllerLevelGate';
   type TerritoryPostClaimBootstrapStatus =
     | 'detected'

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -696,7 +696,7 @@ declare global {
     | 'reservationLost'
     | 'targetHostile'
     | 'sourcesMissing'
-    | 'rcl6Gate';
+    | 'controllerLevelGate';
   type TerritoryPostClaimBootstrapStatus =
     | 'detected'
     | 'spawnSitePending'

--- a/prod/test/colonyStage.test.ts
+++ b/prod/test/colonyStage.test.ts
@@ -193,7 +193,7 @@ describe('colony bootstrap stage', () => {
     }
   );
 
-  it('marks an RCL6 stable room as territory-ready', () => {
+  it('marks an RCL5 stable room as territory-ready', () => {
     expect(
       assessColonyStage({
         roomName: 'E29N55',
@@ -203,7 +203,7 @@ describe('colony bootstrap stage', () => {
         energyAvailable: 1300,
         energyCapacityAvailable: 1300,
         defenseFloorReady: true,
-        controller: { my: true, level: 6, ticksToDowngrade: 10_000 }
+        controller: { my: true, level: 5, ticksToDowngrade: 10_000 }
       })
     ).toMatchObject({
       mode: 'TERRITORY_READY',

--- a/prod/test/controlGate.test.ts
+++ b/prod/test/controlGate.test.ts
@@ -17,16 +17,16 @@ describe('autonomous territory control gate', () => {
     expect(isAutonomousTerritoryControlAllowedForColonyName('W1N1')).toBe(false);
   });
 
-  it('allows only visible owned colonies at or above RCL6', () => {
+  it('allows only visible owned colonies at or above RCL5', () => {
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       rooms: {
         W1N1: {
           name: 'W1N1',
-          controller: { my: true, level: 6 } as StructureController
+          controller: { my: true, level: 5 } as StructureController
         } as Room,
         W2N1: {
           name: 'W2N1',
-          controller: { my: true, level: 5 } as StructureController
+          controller: { my: true, level: 4 } as StructureController
         } as Room,
         W3N1: {
           name: 'W3N1',

--- a/prod/test/e26s50ClaimPipeline.test.ts
+++ b/prod/test/e26s50ClaimPipeline.test.ts
@@ -94,13 +94,13 @@ describe('E18S59 claim pipeline', () => {
     ]);
   });
 
-  it('does not trigger an E18S59 claim before RCL6 even when GCL capacity and claim energy are ready', () => {
-    (globalThis as { TERRITORY_EXPANSION_TRIGGER_MIN_RCL?: number }).TERRITORY_EXPANSION_TRIGGER_MIN_RCL = 5;
-    const threshold = getExpansionTriggerRequiredEnergy(6);
+  it('does not trigger an E18S59 claim before RCL5 even when GCL capacity and claim energy are ready', () => {
+    (globalThis as { TERRITORY_EXPANSION_TRIGGER_MIN_RCL?: number }).TERRITORY_EXPANSION_TRIGGER_MIN_RCL = 4;
+    const threshold = getExpansionTriggerRequiredEnergy(5);
     const colony = makeColony({
-      controllerLevel: 5,
+      controllerLevel: 4,
       energyAvailable: threshold,
-      energyCapacityAvailable: 2_300
+      energyCapacityAvailable: 1_800
     });
     setGame(colony, 827, { includeE17S58: true, gclLevel: 3 });
     setSafeHomeThreat('E17S59', 827);
@@ -126,12 +126,12 @@ describe('E18S59 claim pipeline', () => {
     expect(Memory.territory?.targets).toBeUndefined();
   });
 
-  it('skips the E18S59 trigger when current energy is below RCL6 expansion readiness', () => {
-    const threshold = getExpansionTriggerRequiredEnergy(6);
+  it('skips the E18S59 trigger when current energy is below RCL5 expansion readiness', () => {
+    const threshold = getExpansionTriggerRequiredEnergy(5);
     const colony = makeColony({
-      controllerLevel: 6,
+      controllerLevel: 5,
       energyAvailable: threshold - 1,
-      energyCapacityAvailable: 2_300
+      energyCapacityAvailable: 1_800
     });
     setGame(colony, 828, { includeE17S58: true, gclLevel: 3 });
     setSafeHomeThreat('E17S59', 828);

--- a/prod/test/expansionPlanner.test.ts
+++ b/prod/test/expansionPlanner.test.ts
@@ -419,7 +419,7 @@ describe('expansion planner', () => {
   });
 
   it('creates expansion targets and intents through territory planning', () => {
-    const { colony } = makeColony({ energyAvailable: 1_300, energyCapacityAvailable: 1_300 });
+    const { colony } = makeColony({ controllerLevel: 5, energyAvailable: 1_300, energyCapacityAvailable: 1_300 });
     installGame(colony, {
       gclLevel: 2,
       exits: { W1N1: { '3': 'W2N1' } },
@@ -464,9 +464,9 @@ describe('expansion planner', () => {
     ]);
   });
 
-  it('does not create expansion planner control intents before RCL6', () => {
+  it('does not create expansion planner control intents before RCL5', () => {
     const { colony } = makeColony({
-      controllerLevel: 5,
+      controllerLevel: 4,
       energyAvailable: 1_300,
       energyCapacityAvailable: 1_300
     });

--- a/prod/test/expansionTrigger.test.ts
+++ b/prod/test/expansionTrigger.test.ts
@@ -42,13 +42,13 @@ describe('autonomous expansion trigger pipeline', () => {
     expect(getExpansionTriggerRequiredEnergy(3)).toBeLessThanOrEqual(800);
   });
 
-  it('starts an RCL6 pipeline when room energy reaches the capped threshold', () => {
-    const threshold = getExpansionTriggerRequiredEnergy(6);
+  it('starts an RCL5 pipeline when room energy reaches the capped threshold', () => {
+    const threshold = getExpansionTriggerRequiredEnergy(5);
     const colony = makeColony({
       storageEnergy: 2_000,
-      rcl: 6,
+      rcl: 5,
       energyAvailable: threshold,
-      energyCapacityAvailable: 2300
+      energyCapacityAvailable: 1800
     });
     const report = makeReport([
       makeCandidate({ roomName: 'W2N1', controllerId: 'controller2' as Id<StructureController> })
@@ -75,13 +75,13 @@ describe('autonomous expansion trigger pipeline', () => {
     });
   });
 
-  it('waits at RCL6 when room energy is below the capped threshold', () => {
-    const threshold = getExpansionTriggerRequiredEnergy(6);
+  it('waits at RCL5 when room energy is below the capped threshold', () => {
+    const threshold = getExpansionTriggerRequiredEnergy(5);
     const colony = makeColony({
       storageEnergy: 2_000,
-      rcl: 6,
+      rcl: 5,
       energyAvailable: threshold - 1,
-      energyCapacityAvailable: 2300
+      energyCapacityAvailable: 1800
     });
     const report = makeReport([
       makeCandidate({ roomName: 'W2N1', controllerId: 'controller2' as Id<StructureController> })
@@ -103,14 +103,14 @@ describe('autonomous expansion trigger pipeline', () => {
     expect(Memory.territory?.expansionPipelines).toEqual({});
   });
 
-  it('does not start controller-control expansion before RCL6', () => {
-    (globalThis as { TERRITORY_EXPANSION_TRIGGER_MIN_RCL?: number }).TERRITORY_EXPANSION_TRIGGER_MIN_RCL = 5;
-    const threshold = getExpansionTriggerRequiredEnergy(6);
+  it('does not start controller-control expansion before RCL5', () => {
+    (globalThis as { TERRITORY_EXPANSION_TRIGGER_MIN_RCL?: number }).TERRITORY_EXPANSION_TRIGGER_MIN_RCL = 4;
+    const threshold = getExpansionTriggerRequiredEnergy(5);
     const colony = makeColony({
       storageEnergy: 2_000,
-      rcl: 5,
+      rcl: 4,
       energyAvailable: threshold,
-      energyCapacityAvailable: 2300
+      energyCapacityAvailable: 1800
     });
     const report = makeReport([
       makeCandidate({ roomName: 'W2N1', controllerId: 'controller2' as Id<StructureController> })
@@ -399,8 +399,8 @@ describe('autonomous expansion trigger pipeline', () => {
     expect(Memory.territory?.targets ?? []).toEqual([]);
   });
 
-  it('aborts active expansion pipelines before RCL6 and clears persisted control plans', () => {
-    const colony = makeColony({ storageEnergy: 2_000, rcl: 5, energyCapacityAvailable: 1800 });
+  it('aborts active expansion pipelines before RCL5 and clears persisted control plans', () => {
+    const colony = makeColony({ storageEnergy: 2_000, rcl: 4, energyCapacityAvailable: 1800 });
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       territory: {
         expansionPipelines: {
@@ -455,13 +455,13 @@ describe('autonomous expansion trigger pipeline', () => {
     });
     expect(Memory.territory?.expansionPipelines?.W1N1).toMatchObject({
       status: 'aborted',
-      abortReason: 'rcl6Gate',
+      abortReason: 'controllerLevelGate',
       abortedAt: 41
     });
     expect(Memory.territory?.targets ?? []).toEqual([]);
     expect(Memory.territory?.intents).toBeUndefined();
     expect(Memory.territory?.expansionReevaluations?.['W1N1>W2N1']).toMatchObject({
-      reason: 'rcl6Gate',
+      reason: 'controllerLevelGate',
       updatedAt: 41
     });
   });

--- a/prod/test/expansionTrigger.test.ts
+++ b/prod/test/expansionTrigger.test.ts
@@ -466,6 +466,48 @@ describe('autonomous expansion trigger pipeline', () => {
     });
   });
 
+  it('preserves a legacy RCL6 gate abort reason when normalizing persisted pipeline memory', () => {
+    const colony = makeColony({ storageEnergy: 2_000 });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        expansionPipelines: {
+          W1N1: {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            status: 'active',
+            stage: 'reserving',
+            score: 900,
+            threshold: 700,
+            startedAt: 40,
+            updatedAt: 40,
+            controllerId: 'controller2' as Id<StructureController>,
+            abortReason: 'rcl6Gate'
+          }
+        }
+      }
+    };
+    setSafeHomeThreat('W1N1', 42);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 42,
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeTargetRoom('W2N1', 'controller2' as Id<StructureController>)
+      }
+    };
+
+    expect(refreshAutonomousExpansionPipeline(colony, makeReport([]), 42)).toMatchObject({
+      status: 'planned',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      controllerId: 'controller2'
+    });
+    expect(Memory.territory?.expansionPipelines?.W1N1).toMatchObject({
+      status: 'active',
+      abortReason: 'rcl6Gate',
+      updatedAt: 42
+    });
+  });
+
   it('blocks new pipelines while claim work is already in flight', () => {
     const colony = makeColony({ storageEnergy: 2_000 });
     const report = makeReport([

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -1925,11 +1925,11 @@ describe('planSpawn', () => {
     });
   });
 
-  it('uses the home spawn for post-claim room defense even before RCL6 expansion control', () => {
+  it('uses the home spawn for post-claim room defense even before RCL5 expansion control', () => {
     const { colony, spawn } = makeColony({
       energyAvailable: 650,
       energyCapacityAvailable: 650,
-      controller: { my: true, level: 5, ticksToDowngrade: 10_000, owner: { username: 'player' } } as StructureController
+      controller: { my: true, level: 4, ticksToDowngrade: 10_000, owner: { username: 'player' } } as StructureController
     });
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       rooms: {
@@ -3053,12 +3053,12 @@ describe('planSpawn', () => {
     ]);
   });
 
-  it('suppresses stale controller-control intents before RCL6 without spawning a claimer', () => {
+  it('suppresses stale controller-control intents before RCL5 without spawning a claimer', () => {
     const { colony } = makeColony({
       sourceCount: 0,
       energyAvailable: 1_300,
       energyCapacityAvailable: 1_300,
-      controller: { my: true, level: 5, ticksToDowngrade: 10_000 } as StructureController
+      controller: { my: true, level: 4, ticksToDowngrade: 10_000 } as StructureController
     });
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       rooms: {

--- a/prod/test/strategyRecommender.test.ts
+++ b/prod/test/strategyRecommender.test.ts
@@ -104,7 +104,7 @@ describe('strategy recommender', () => {
   it('recommends safe remote targets for territory-ready rooms', () => {
     const recommendations = generateStrategyRecommendations({
       ...makeStableLowRclRoom(),
-      controllerLevel: 6,
+      controllerLevel: 5,
       workerCount: 4,
       territory: {
         remoteTargets: [
@@ -121,7 +121,7 @@ describe('strategy recommender', () => {
     );
   });
 
-  it.each([2, 3, 4, 5])(
+  it.each([2, 3, 4])(
     'does not recommend controller-control territory at RCL %i',
     (controllerLevel) => {
       const recommendations = generateStrategyRecommendations({

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -72,9 +72,9 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
-  it('suppresses controller-control territory intents before RCL6', () => {
+  it('suppresses controller-control territory intents before RCL5', () => {
     const colony = makeSafeColony({
-      controller: { my: true, owner: { username: 'me' }, level: 5, ticksToDowngrade: 10_000 } as StructureController,
+      controller: { my: true, owner: { username: 'me' }, level: 4, ticksToDowngrade: 10_000 } as StructureController,
       energyAvailable: 1300,
       energyCapacityAvailable: 1300
     });
@@ -125,10 +125,10 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
-  it('continues allowed scouting when the best control candidate is gated before RCL6', () => {
+  it('continues allowed scouting when the best control candidate is gated before RCL5', () => {
     const colony = makeSafeColony({
       roomName: 'E17S59',
-      controller: { my: true, owner: { username: 'me' }, level: 5, ticksToDowngrade: 10_000 } as StructureController
+      controller: { my: true, owner: { username: 'me' }, level: 4, ticksToDowngrade: 10_000 } as StructureController
     });
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       time: 841,
@@ -191,12 +191,12 @@ describe('planTerritoryIntent', () => {
   it.each([
     ['reserve', makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve')],
     ['claim', makeFollowUp('satisfiedClaimAdjacent', 'W1N2', 'claim')]
-  ] as const)('refreshes stale suppressed recovered %s follow-ups while controller work is gated before RCL6', (
+  ] as const)('refreshes stale suppressed recovered %s follow-ups while controller work is gated before RCL5', (
     action,
     followUp
   ) => {
     const colony = makeSafeColony({
-      controller: { my: true, owner: { username: 'me' }, level: 5, ticksToDowngrade: 10_000 } as StructureController,
+      controller: { my: true, owner: { username: 'me' }, level: 4, ticksToDowngrade: 10_000 } as StructureController,
       energyAvailable: 1300,
       energyCapacityAvailable: 1300
     });
@@ -252,9 +252,9 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
-  it('does not suppress visible-owned target controller work before RCL6', () => {
+  it('does not suppress visible-owned target controller work before RCL5', () => {
     const colony = makeSafeColony({
-      controller: { my: true, owner: { username: 'me' }, level: 5, ticksToDowngrade: 10_000 } as StructureController,
+      controller: { my: true, owner: { username: 'me' }, level: 4, ticksToDowngrade: 10_000 } as StructureController,
       energyAvailable: 1300,
       energyCapacityAvailable: 1300
     });
@@ -318,9 +318,9 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
-  it('keeps scout-only territory intelligence available before RCL6', () => {
+  it('keeps scout-only territory intelligence available before RCL5', () => {
     const colony = makeSafeColony({
-      controller: { my: true, owner: { username: 'me' }, level: 5, ticksToDowngrade: 10_000 } as StructureController
+      controller: { my: true, owner: { username: 'me' }, level: 4, ticksToDowngrade: 10_000 } as StructureController
     });
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       territory: {

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -123,14 +123,14 @@ describe('runTerritoryControllerCreep', () => {
     ]);
   });
 
-  it('suppresses stale controller-control assignments before RCL6 without moving or acting', () => {
+  it('suppresses stale controller-control assignments before RCL5 without moving or acting', () => {
     const controller = { id: 'controller1', my: false } as StructureController;
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       time: 502,
       rooms: {
         W1N1: {
           name: 'W1N1',
-          controller: { my: true, level: 5, ticksToDowngrade: 10_000 } as StructureController
+          controller: { my: true, level: 4, ticksToDowngrade: 10_000 } as StructureController
         } as Room,
         W1N2: {
           name: 'W1N2',


### PR DESCRIPTION
## Summary
- Move the central autonomous territory-control gate from RCL6 to RCL5 per the 2026-05-20 owner directive.
- Rename the expansion abort reason from the RCL6-specific `rcl6Gate` to `controllerLevelGate` so future suppression/reevaluation telemetry stays accurate.
- Update strategy, expansion, reserve/claim, spawn, runner, and stage tests so RCL4 remains fail-closed while RCL5+ is pass-open.

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` — 100 suites / 1968 tests passed
- `npm run build`

Fixes #1269
