### PR TITLE
fix(rl): persist scorecard evidence for training reports

### DIFF
--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -2084,7 +2084,7 @@ def materialize_candidate_scorecard_artifact(
     out_dir: Path,
     secret_values: Sequence[str],
 ) -> None:
-    """Persist a #924 scorecard for runtime-injected policy-gradient rankings."""
+    """Persist a #924 scorecard for completed policy-gradient rankings."""
     if not isinstance(report.get("policyGradient"), dict):
         return
 
@@ -2092,7 +2092,7 @@ def materialize_candidate_scorecard_artifact(
     report["candidateScorecard"] = readiness
     report["scorecardId"] = readiness.get("scorecardId")
     report["scorecardArtifactPath"] = readiness.get("scorecardArtifactPath")
-    if readiness.get("status") != "ready":
+    if readiness.get("status") not in {"ready", "materialized"}:
         return
 
     candidate_id = text_or_none(readiness.get("candidateStrategyId"))
@@ -2231,44 +2231,56 @@ def build_candidate_scorecard_readiness(report: JsonObject) -> JsonObject:
             missing_prerequisite="candidate_baseline_ranking",
         )
     candidate_id, baseline_id, candidate_rank, baseline_rank = pair
-    if not runtime_ready:
-        classification = candidate_scorecard_runtime_blocker(runtime_parameter_injection)
-        return {
-            **candidate_scorecard_blocked_payload(
-                report,
-                classification=classification,
-                reason=candidate_scorecard_runtime_blocker_reason(runtime_parameter_injection),
-                missing_prerequisite="runtime_parameter_injection",
-            ),
-            "candidateStrategyId": candidate_id,
-            "baselineStrategyId": baseline_id,
-            "candidateRank": candidate_rank,
-            "baselineRank": baseline_rank,
-        }
-
     scorecard_id = candidate_scorecard_id(report, candidate_id, baseline_id)
     injected_count = runtime_injected_variant_count(runtime_parameter_injection)
-    return {
+    if runtime_ready:
+        status = "ready"
+        classification = "runtime_injected_candidate_scorecard_ready"
+        reason = None
+        next_action = None
+    else:
+        status = "materialized"
+        classification = candidate_scorecard_materialized_classification(runtime_parameter_injection)
+        reason = (
+            f"{candidate_scorecard_runtime_blocker_reason(runtime_parameter_injection)}; "
+            "candidate-vs-baseline scorecard will be materialized from completed offline ranking/KPI "
+            "evidence but cannot pass the runtime candidate gate"
+        )
+        next_action = (
+            "inject candidate parameters into private-simulator runtime inputs before promotion; "
+            "retain this scorecard as offline/private evidence"
+        )
+    payload: JsonObject = {
         "type": "screeps-rl-candidate-vs-baseline-scorecard-readiness",
         "schemaVersion": SCHEMA_VERSION,
-        "status": "ready",
-        "classification": "runtime_injected_candidate_scorecard_ready",
+        "status": status,
+        "classification": classification,
         "scorecardId": scorecard_id,
         "scorecardArtifactPath": None,
         "candidateStrategyId": candidate_id,
         "baselineStrategyId": baseline_id,
         "candidateRank": candidate_rank,
         "baselineRank": baseline_rank,
-        "runtimeParameterInjection": True,
+        "runtimeParameterInjection": runtime_ready,
         "injectedVariantCount": injected_count,
         "candidateParameterScope": runtime_parameter_scope(runtime_parameter_injection),
         "scorecardUsable": True,
-        "validationScaleComputeBlocked": False,
+        "validationScaleComputeBlocked": not runtime_ready,
         "liveEffect": False,
         "officialMmoWrites": False,
         "officialMmoWritesAllowed": False,
         "safety": safety_metadata(),
     }
+    if reason is not None:
+        payload["missingPrerequisite"] = "runtime_parameter_injection"
+        payload["reason"] = reason
+    if next_action is not None:
+        payload["nextAction"] = next_action
+    return payload
+
+
+def candidate_scorecard_materialized_classification(value: Any) -> str:
+    return f"{candidate_scorecard_runtime_blocker(value)}_scorecard_materialized"
 
 
 def candidate_scorecard_blocked_payload(

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -2135,7 +2135,7 @@ def materialize_candidate_scorecard_artifact(
         result=candidate_result,
         role="candidate",
         peer_variant_id=baseline_id,
-        runtime_parameter_injection=report.get("runtimeParameterInjection"),
+        runtime_parameter_injection=candidate_scorecard_runtime_parameter_injection(report, candidate_id),
     )
     baseline_projection = scorecard_projection_payload(
         report,
@@ -2221,8 +2221,7 @@ def mark_candidate_scorecard_materialization_failed(report: JsonObject, error: E
 
 def build_candidate_scorecard_readiness(report: JsonObject) -> JsonObject:
     pair = candidate_scorecard_pair(report)
-    runtime_parameter_injection = report.get("runtimeParameterInjection")
-    runtime_ready = scorecard_runtime_injection_ready(runtime_parameter_injection)
+    report_runtime_parameter_injection = report.get("runtimeParameterInjection")
     if pair is None:
         return candidate_scorecard_blocked_payload(
             report,
@@ -2232,7 +2231,10 @@ def build_candidate_scorecard_readiness(report: JsonObject) -> JsonObject:
         )
     candidate_id, baseline_id, candidate_rank, baseline_rank = pair
     scorecard_id = candidate_scorecard_id(report, candidate_id, baseline_id)
+    runtime_parameter_injection = candidate_scorecard_runtime_parameter_injection(report, candidate_id)
+    runtime_ready = scorecard_runtime_injection_ready(runtime_parameter_injection)
     injected_count = runtime_injected_variant_count(runtime_parameter_injection)
+    report_injected_count = runtime_injected_variant_count(report_runtime_parameter_injection)
     if runtime_ready:
         status = "ready"
         classification = "runtime_injected_candidate_scorecard_ready"
@@ -2264,6 +2266,8 @@ def build_candidate_scorecard_readiness(report: JsonObject) -> JsonObject:
         "runtimeParameterInjection": runtime_ready,
         "injectedVariantCount": injected_count,
         "candidateParameterScope": runtime_parameter_scope(runtime_parameter_injection),
+        "reportRuntimeParameterInjection": scorecard_runtime_injection_ready(report_runtime_parameter_injection),
+        "reportInjectedVariantCount": report_injected_count,
         "scorecardUsable": True,
         "validationScaleComputeBlocked": not runtime_ready,
         "liveEffect": False,
@@ -2334,6 +2338,15 @@ def candidate_scorecard_pair(report: JsonObject) -> tuple[str, str, int | None, 
         int_or_none(candidate_item.get("rank")),
         int_or_none(baseline_item.get("rank")),
     )
+
+
+def candidate_scorecard_runtime_parameter_injection(report: JsonObject, candidate_id: str) -> Any:
+    candidate_result = variant_result_by_id(report, candidate_id)
+    if isinstance(candidate_result, dict):
+        runtime_parameter_injection = candidate_result.get("runtimeParameterInjection")
+        if isinstance(runtime_parameter_injection, dict):
+            return runtime_parameter_injection
+    return report.get("runtimeParameterInjection")
 
 
 def scorecard_runtime_injection_ready(value: Any) -> bool:

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -2166,8 +2166,17 @@ def verified_remote_candidate_scorecard(
     )
     scorecard_usable = required_bool(raw.get("scorecardUsable"), "candidateScorecard.scorecardUsable")
     injected_count = required_non_negative_int(raw.get("injectedVariantCount"), "candidateScorecard.injectedVariantCount")
+    top_level_runtime_injected = (
+        runtime_parameter_injection is not None
+        and runtime_parameter_injection.get("runtimeParameterInjection") is True
+    )
+    top_level_status = (
+        runtime_parameter_injection.get("status")
+        if isinstance(runtime_parameter_injection, dict)
+        else None
+    )
     if status == "ready":
-        if runtime_parameter_injection is None or runtime_parameter_injection.get("runtimeParameterInjection") is not True:
+        if not top_level_runtime_injected:
             raise BatchRunError("remote candidateScorecard is ready without runtimeParameterInjection proof")
         if not runtime_injected:
             raise BatchRunError("remote candidateScorecard ready status requires runtimeParameterInjection=true")
@@ -2191,39 +2200,44 @@ def verified_remote_candidate_scorecard(
                 f"remote candidate scorecard artifact was not collected: "
                 f"{rel_scorecard_artifact_path.as_posix()}"
             )
+    elif status == "materialized":
+        if top_level_runtime_injected or runtime_injected:
+            raise BatchRunError(
+                "remote candidateScorecard materialized status requires incomplete runtimeParameterInjection proof"
+            )
+        if not validation_blocked:
+            raise BatchRunError("remote candidateScorecard materialized status requires validation-scale blocked")
+        if not scorecard_usable:
+            raise BatchRunError("remote candidateScorecard materialized status requires scorecardUsable=true")
+        nested_scorecard_id = required_non_empty_text(raw.get("scorecardId"), "candidateScorecard.scorecardId")
+        top_level_scorecard_id = required_non_empty_text(scorecard_id, "scorecardId")
+        if nested_scorecard_id != top_level_scorecard_id:
+            raise BatchRunError("remote candidateScorecard.scorecardId disagrees with scorecardId")
+        rel_scorecard_artifact_path = safe_candidate_scorecard_artifact_path(scorecard_artifact_path)
+        local_scorecard_artifact_path = collected_remote_candidate_scorecard_artifact_path(
+            artifact_dir,
+            rel_scorecard_artifact_path,
+        )
+        if not local_scorecard_artifact_path.is_file():
+            raise BatchRunError(
+                f"remote candidate scorecard artifact was not collected: "
+                f"{rel_scorecard_artifact_path.as_posix()}"
+            )
     elif status == "blocked":
         classification = raw.get("classification")
         materialization_failed = classification == "candidate_scorecard_materialization_failed"
-        top_level_runtime_injected = (
-            runtime_parameter_injection is not None
-            and runtime_parameter_injection.get("runtimeParameterInjection") is True
-        )
-        top_level_status = (
-            runtime_parameter_injection.get("status")
-            if isinstance(runtime_parameter_injection, dict)
-            else None
-        )
         if runtime_injected and not materialization_failed:
             raise BatchRunError("remote candidateScorecard blocked status requires runtimeParameterInjection=false")
         if top_level_runtime_injected and not materialization_failed:
             raise BatchRunError(
                 "remote candidateScorecard blocked status contradicts top-level runtimeParameterInjection proof"
             )
-        if materialization_failed:
-            if (
-                runtime_parameter_injection is None
-                or runtime_parameter_injection.get("runtimeParameterInjection") is not True
-                or not runtime_injected
-            ):
-                raise BatchRunError("remote candidateScorecard materialization failure requires runtimeParameterInjection proof")
-            if injected_count <= 0:
-                raise BatchRunError("remote candidateScorecard materialization failure requires positive injectedVariantCount")
-        elif top_level_status == "partial":
+        if top_level_status == "partial" and not materialization_failed:
             if injected_count <= 0:
                 raise BatchRunError(
                     "remote candidateScorecard blocked partial injection requires positive injectedVariantCount"
                 )
-        elif injected_count != 0:
+        elif not materialization_failed and injected_count != 0:
             raise BatchRunError("remote candidateScorecard blocked status requires injectedVariantCount=0")
         if not validation_blocked:
             raise BatchRunError("remote candidateScorecard blocked status requires validationScaleComputeBlocked=true")

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -2175,8 +2175,14 @@ def verified_remote_candidate_scorecard(
         if isinstance(runtime_parameter_injection, dict)
         else None
     )
+    top_level_injected_count = (
+        runtime_parameter_injection.get("injectedVariantCount", 0)
+        if isinstance(runtime_parameter_injection, dict)
+        else 0
+    )
+    top_level_runtime_partially_injected = top_level_status == "partial" and top_level_injected_count > 0
     if status == "ready":
-        if not top_level_runtime_injected:
+        if not top_level_runtime_injected and not top_level_runtime_partially_injected:
             raise BatchRunError("remote candidateScorecard is ready without runtimeParameterInjection proof")
         if not runtime_injected:
             raise BatchRunError("remote candidateScorecard ready status requires runtimeParameterInjection=true")
@@ -2186,6 +2192,10 @@ def verified_remote_candidate_scorecard(
             raise BatchRunError("remote candidateScorecard ready status requires scorecardUsable=true")
         if injected_count <= 0:
             raise BatchRunError("remote candidateScorecard ready status requires positive injectedVariantCount")
+        if top_level_runtime_partially_injected and injected_count > top_level_injected_count:
+            raise BatchRunError(
+                "remote candidateScorecard ready status exceeds top-level runtimeParameterInjection injectedVariantCount"
+            )
         nested_scorecard_id = required_non_empty_text(raw.get("scorecardId"), "candidateScorecard.scorecardId")
         top_level_scorecard_id = required_non_empty_text(scorecard_id, "scorecardId")
         if nested_scorecard_id != top_level_scorecard_id:
@@ -2204,6 +2214,10 @@ def verified_remote_candidate_scorecard(
         if top_level_runtime_injected or runtime_injected:
             raise BatchRunError(
                 "remote candidateScorecard materialized status requires incomplete runtimeParameterInjection proof"
+            )
+        if injected_count != 0:
+            raise BatchRunError(
+                "remote candidateScorecard materialized status requires injectedVariantCount=0"
             )
         if not validation_blocked:
             raise BatchRunError("remote candidateScorecard materialized status requires validation-scale blocked")

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -1600,21 +1600,34 @@ export const STRATEGY_REGISTRY = [
         )
         variant_ids = [variant["id"] for variant in card["strategy_variants"]]
         start = tick(1, [room("W1N1", energy=100)])
-        simulator = MockSimulator({
-            variant_id: variant_result(variant_id, [start, tick(2, [room("W1N1", energy=200)])])
-            for variant_id in variant_ids
-        })
+        simulator_results: dict[str, JsonObject] = {}
+        for variant_id in variant_ids:
+            if variant_id.endswith("territory-seed.v1"):
+                simulator_results[variant_id] = variant_result(
+                    variant_id,
+                    [start, tick(2, [room("W1N1", energy=150), room("W1N2", energy=100)])],
+                )
+            else:
+                simulator_results[variant_id] = variant_result(
+                    variant_id,
+                    [start, tick(2, [room("W1N1", energy=200)])],
+                )
+        simulator = MockSimulator(simulator_results)
 
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             card_path = root / "card.json"
+            out_dir = root / "reports"
             write_json(card_path, card)
             report = runner.run_training_experiment(
                 card_path,
-                root / "reports",
+                out_dir,
                 report_id="policy-gradient-evidence",
                 simulator_runner=simulator,
             )
+            scorecard_path = Path(report["scorecardArtifactPath"])
+            scorecard_path_exists = scorecard_path.exists()
+            scorecard_payload = read_json(scorecard_path)
 
         self.assertEqual(report["experimentCard"]["trainingApproach"], "policy_gradient")
         self.assertEqual(report["policyGradient"]["target_family"], "construction-priority")
@@ -1622,15 +1635,21 @@ export const STRATEGY_REGISTRY = [
         self.assertFalse(report["trueGradient"])
         self.assertEqual(report["runtimeParameterInjection"]["status"], "metadata_only")
         self.assertFalse(report["runtimeParameterInjection"]["runtimeParameterInjection"])
-        self.assertIsNone(report["scorecardId"])
-        self.assertEqual(report["candidateScorecard"]["status"], "blocked")
+        self.assertIsNotNone(report["scorecardId"])
+        self.assertEqual(report["candidateScorecard"]["status"], "materialized")
         self.assertEqual(
             report["candidateScorecard"]["classification"],
-            "runtime_parameter_injection_metadata_only",
+            "runtime_parameter_injection_metadata_only_scorecard_materialized",
         )
         self.assertEqual(report["candidateScorecard"]["missingPrerequisite"], "runtime_parameter_injection")
         self.assertTrue(report["candidateScorecard"]["validationScaleComputeBlocked"])
-        self.assertFalse(report["candidateScorecard"]["scorecardUsable"])
+        self.assertTrue(report["candidateScorecard"]["scorecardUsable"])
+        self.assertTrue(scorecard_path_exists)
+        self.assertEqual(scorecard_payload["runId"], report["scorecardId"])
+        self.assertFalse(
+            scorecard_payload["overallGate"]["runtimeCandidateGate"]["runtimeParameterInjection"]
+        )
+        self.assertFalse(report["candidateScorecard"]["overallGate"]["runtimeParameterInjectionProven"])
         self.assertFalse(report["policyGradient"]["runner_support"]["inline_candidates_applied_to_simulator"])
         self.assertFalse(report["policyGradient"]["runner_support"]["runtime_parameter_injection"])
         self.assertEqual(report["policyGradient"]["runner_support"]["candidate_parameter_scope"], "metadata_only")

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -1202,6 +1202,46 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             ):
                 controller.verify_remote_training_report()
 
+    def test_verify_remote_training_report_accepts_materialized_metadata_only_scorecard(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            data = training_report_with_ready_runtime_scorecard()
+            data["runtimeParameterInjection"] = {
+                "status": "metadata_only",
+                "runtimeParameterInjection": False,
+                "policyUpdateEligible": False,
+                "candidateParameterScope": "metadata_only",
+                "injectedVariantCount": 0,
+                "liveEffect": False,
+                "officialMmoWrites": False,
+                "officialMmoWritesAllowed": False,
+            }
+            data["candidateScorecard"] = {
+                "status": "materialized",
+                "classification": "runtime_parameter_injection_metadata_only_scorecard_materialized",
+                "scorecardId": "rl-scorecard-run-test",
+                "runtimeParameterInjection": False,
+                "injectedVariantCount": 0,
+                "candidateParameterScope": "metadata_only",
+                "missingPrerequisite": "runtime_parameter_injection",
+                "validationScaleComputeBlocked": True,
+                "scorecardUsable": True,
+            }
+            report = runner.remote_training_report_path(root, "run-test")
+            report.parent.mkdir(parents=True, exist_ok=True)
+            report.write_text(json.dumps(data), encoding="utf-8")
+            write_ready_runtime_scorecard_artifact(root)
+            controller = runner.Controller(args=controller_args(), run_id="run-test", artifact_dir=root)
+
+            controller.verify_remote_training_report()
+
+        training_report = controller.result["trainingReport"]
+        self.assertEqual(training_report["scorecardId"], "rl-scorecard-run-test")
+        self.assertEqual(training_report["candidateScorecard"]["status"], "materialized")
+        self.assertTrue(training_report["candidateScorecard"]["validationScaleComputeBlocked"])
+        self.assertTrue(training_report["candidateScorecard"]["scorecardUsable"])
+        self.assertFalse(training_report["candidateScorecard"]["runtimeParameterInjection"])
+
     def test_verify_remote_training_report_rejects_malformed_runtime_parameter_injection_evidence(self) -> None:
         def injection_patch(
             *,
@@ -1360,10 +1400,20 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(verified["candidateParameterScope"], "runtime_injected")
         self.assertEqual(verified["candidateStrategyId"], "candidate")
 
-    def test_verify_remote_training_report_rejects_materialization_failure_without_nested_injection_proof(self) -> None:
+    def test_verify_remote_training_report_accepts_materialization_failure_without_runtime_injection_proof(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             data = training_report_with_ready_runtime_scorecard()
+            data["runtimeParameterInjection"] = {
+                "status": "metadata_only",
+                "runtimeParameterInjection": False,
+                "policyUpdateEligible": False,
+                "candidateParameterScope": "metadata_only",
+                "injectedVariantCount": 0,
+                "liveEffect": False,
+                "officialMmoWrites": False,
+                "officialMmoWritesAllowed": False,
+            }
             data["scorecardId"] = None
             data["scorecardArtifactPath"] = None
             data["candidateScorecard"] = {
@@ -1371,8 +1421,8 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 "classification": "candidate_scorecard_materialization_failed",
                 "scorecardId": None,
                 "runtimeParameterInjection": False,
-                "injectedVariantCount": 1,
-                "candidateParameterScope": "runtime_injected",
+                "injectedVariantCount": 0,
+                "candidateParameterScope": "metadata_only",
                 "candidateStrategyId": "candidate",
                 "baselineStrategyId": "baseline",
                 "candidateRank": 1,
@@ -1386,11 +1436,12 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             report.write_text(json.dumps(data), encoding="utf-8")
             controller = runner.Controller(args=controller_args(), run_id="run-test", artifact_dir=root)
 
-            with self.assertRaisesRegex(
-                runner.BatchRunError,
-                "materialization failure requires runtimeParameterInjection proof",
-            ):
-                controller.verify_remote_training_report()
+            controller.verify_remote_training_report()
+
+        verified = controller.result["trainingReport"]["candidateScorecard"]
+        self.assertEqual(verified["classification"], "candidate_scorecard_materialization_failed")
+        self.assertFalse(verified["runtimeParameterInjection"])
+        self.assertEqual(verified["candidateParameterScope"], "metadata_only")
 
     def test_verify_remote_training_report_accepts_blocked_partial_runtime_injection_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -1663,17 +1714,18 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                                 "officialMmoWrites": False,
                                 "officialMmoWritesAllowed": False,
                             },
-                            "scorecardId": None,
-                            "scorecardArtifactPath": None,
+                            "scorecardId": "rl-scorecard-run-test",
+                            "scorecardArtifactPath": READY_RUNTIME_SCORECARD_PATH,
                             "candidateScorecard": {
-                                "status": "blocked",
-                                "classification": "runtime_parameter_injection_metadata_only",
-                                "scorecardId": None,
+                                "status": "materialized",
+                                "classification": "runtime_parameter_injection_metadata_only_scorecard_materialized",
+                                "scorecardId": "rl-scorecard-run-test",
                                 "runtimeParameterInjection": False,
                                 "injectedVariantCount": 0,
+                                "candidateParameterScope": "metadata_only",
                                 "missingPrerequisite": "runtime_parameter_injection",
                                 "validationScaleComputeBlocked": True,
-                                "scorecardUsable": False,
+                                "scorecardUsable": True,
                             },
                             "policyUpdateIterations": 0,
                             "policyUpdate": policy_update,
@@ -1681,6 +1733,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                     ),
                     encoding="utf-8",
                 )
+                write_ready_runtime_scorecard_artifact(self.artifact_dir)
 
             def scale_down(self) -> None:
                 self.record_step("scale_down", 101.0, True, desiredCapacity=0)
@@ -1718,10 +1771,10 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertIsNone(training_report["policyUpdateArtifactPath"])
         self.assertFalse(training_report["runtimeParameterInjection"]["runtimeParameterInjection"])
         self.assertEqual(training_report["runtimeParameterInjection"]["injectedVariantCount"], 0)
-        self.assertIsNone(training_report["scorecardId"])
-        self.assertEqual(training_report["candidateScorecard"]["status"], "blocked")
+        self.assertEqual(training_report["scorecardId"], "rl-scorecard-run-test")
+        self.assertEqual(training_report["candidateScorecard"]["status"], "materialized")
         self.assertTrue(training_report["candidateScorecard"]["validationScaleComputeBlocked"])
-        self.assertFalse(training_report["candidateScorecard"]["scorecardUsable"])
+        self.assertTrue(training_report["candidateScorecard"]["scorecardUsable"])
         self.assertEqual(training_report["policyUpdate"]["metadataCandidateCount"], 5)
         self.assertFalse(training_report["policyUpdate"]["parameterEvidence"]["policyUpdateEligible"])
         self.assertNotIn("nextCandidatePolicy", training_report["policyUpdate"])

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -1202,6 +1202,53 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             ):
                 controller.verify_remote_training_report()
 
+    def test_verify_remote_training_report_accepts_ready_scorecard_with_candidate_scoped_partial_runtime_evidence(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            data = training_report_with_ready_runtime_scorecard()
+            data["runtimeParameterInjection"] = {
+                "status": "partial",
+                "runtimeParameterInjection": False,
+                "policyUpdateEligible": False,
+                "candidateParameterScope": "partial_runtime_injection",
+                "injectedVariantCount": 1,
+                "liveEffect": False,
+                "officialMmoWrites": False,
+                "officialMmoWritesAllowed": False,
+                "variants": [
+                    {"variantId": "candidate", "runtimeParameterInjection": True},
+                    {"variantId": "loser", "runtimeParameterInjection": False},
+                ],
+            }
+            data["candidateScorecard"] = {
+                "status": "ready",
+                "classification": "runtime_injected_candidate_scorecard_ready",
+                "scorecardId": "rl-scorecard-run-test",
+                "runtimeParameterInjection": True,
+                "injectedVariantCount": 1,
+                "candidateParameterScope": "runtime_injected",
+                "reportRuntimeParameterInjection": False,
+                "reportInjectedVariantCount": 1,
+                "validationScaleComputeBlocked": False,
+                "scorecardUsable": True,
+            }
+            report = runner.remote_training_report_path(root, "run-test")
+            report.parent.mkdir(parents=True, exist_ok=True)
+            report.write_text(json.dumps(data), encoding="utf-8")
+            write_ready_runtime_scorecard_artifact(root)
+            controller = runner.Controller(args=controller_args(), run_id="run-test", artifact_dir=root)
+
+            controller.verify_remote_training_report()
+
+        training_report = controller.result["trainingReport"]
+        self.assertEqual(training_report["runtimeParameterInjection"]["status"], "partial")
+        self.assertFalse(training_report["runtimeParameterInjection"]["runtimeParameterInjection"])
+        self.assertEqual(training_report["candidateScorecard"]["status"], "ready")
+        self.assertTrue(training_report["candidateScorecard"]["runtimeParameterInjection"])
+        self.assertFalse(training_report["candidateScorecard"]["validationScaleComputeBlocked"])
+
     def test_verify_remote_training_report_accepts_materialized_metadata_only_scorecard(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -1241,6 +1288,43 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertTrue(training_report["candidateScorecard"]["validationScaleComputeBlocked"])
         self.assertTrue(training_report["candidateScorecard"]["scorecardUsable"])
         self.assertFalse(training_report["candidateScorecard"]["runtimeParameterInjection"])
+
+    def test_verify_remote_training_report_rejects_materialized_scorecard_with_injected_count(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            data = training_report_with_ready_runtime_scorecard()
+            data["runtimeParameterInjection"] = {
+                "status": "metadata_only",
+                "runtimeParameterInjection": False,
+                "policyUpdateEligible": False,
+                "candidateParameterScope": "metadata_only",
+                "injectedVariantCount": 0,
+                "liveEffect": False,
+                "officialMmoWrites": False,
+                "officialMmoWritesAllowed": False,
+            }
+            data["candidateScorecard"] = {
+                "status": "materialized",
+                "classification": "runtime_parameter_injection_metadata_only_scorecard_materialized",
+                "scorecardId": "rl-scorecard-run-test",
+                "runtimeParameterInjection": False,
+                "injectedVariantCount": 1,
+                "candidateParameterScope": "metadata_only",
+                "missingPrerequisite": "runtime_parameter_injection",
+                "validationScaleComputeBlocked": True,
+                "scorecardUsable": True,
+            }
+            report = runner.remote_training_report_path(root, "run-test")
+            report.parent.mkdir(parents=True, exist_ok=True)
+            report.write_text(json.dumps(data), encoding="utf-8")
+            write_ready_runtime_scorecard_artifact(root)
+            controller = runner.Controller(args=controller_args(), run_id="run-test", artifact_dir=root)
+
+            with self.assertRaisesRegex(
+                runner.BatchRunError,
+                "materialized status requires injectedVariantCount=0",
+            ):
+                controller.verify_remote_training_report()
 
     def test_verify_remote_training_report_rejects_malformed_runtime_parameter_injection_evidence(self) -> None:
         def injection_patch(

--- a/scripts/tests/test_rl_scorecard.py
+++ b/scripts/tests/test_rl_scorecard.py
@@ -10,6 +10,7 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import screeps_rl_scorecard as scorecard
+import screeps_rl_training_runner as training_runner
 
 
 JsonObject = dict[str, Any]
@@ -287,6 +288,60 @@ def test_runtime_injected_loop_b_scorecard_reports_mixed_contract_status(tmp_pat
     assert report["dimensions"]["resources_economy"]["status"] == "regressed"
     assert report["dimensions"]["combat"]["status"] == "improved"
     assert report["candidate"]["runtimeParameterInjection"]["status"] == "injected"
+
+
+def test_candidate_scorecard_readiness_uses_selected_candidate_runtime_evidence() -> None:
+    report = {
+        "reportId": "multi-candidate-selected-runtime-ready",
+        "ranking": [
+            {"variantId": "candidate.v1", "rank": 1},
+            {"variantId": "baseline.v1", "rank": 2},
+            {"variantId": "loser.v1", "rank": 3},
+        ],
+        "incumbentStrategyIds": ["baseline.v1"],
+        "runtimeParameterInjection": {
+            "status": "partial",
+            "runtimeParameterInjection": False,
+            "candidateParameterScope": "partial_runtime_injection",
+            "injectedVariantCount": 1,
+            "variants": [
+                {"variantId": "candidate.v1", "runtimeParameterInjection": True},
+                {"variantId": "loser.v1", "runtimeParameterInjection": False},
+            ],
+        },
+        "variantResults": [
+            {
+                "variantId": "candidate.v1",
+                "runtimeParameterInjection": {
+                    "status": "injected",
+                    "runtimeParameterInjection": True,
+                    "candidateParameterScope": "runtime_injected",
+                },
+            },
+            {"variantId": "baseline.v1"},
+            {
+                "variantId": "loser.v1",
+                "runtimeParameterInjection": {
+                    "status": "metadata_only",
+                    "runtimeParameterInjection": False,
+                    "candidateParameterScope": "metadata_only",
+                },
+            },
+        ],
+    }
+
+    readiness = training_runner.build_candidate_scorecard_readiness(report)
+
+    assert readiness["status"] == "ready"
+    assert readiness["classification"] == "runtime_injected_candidate_scorecard_ready"
+    assert readiness["runtimeParameterInjection"] is True
+    assert readiness["injectedVariantCount"] == 1
+    assert readiness["candidateParameterScope"] == "runtime_injected"
+    assert readiness["reportRuntimeParameterInjection"] is False
+    assert readiness["reportInjectedVariantCount"] == 1
+    assert readiness["validationScaleComputeBlocked"] is False
+    assert readiness["scorecardUsable"] is True
+    assert "missingPrerequisite" not in readiness
 
 
 def test_delta_only_safety_floor_metric_does_not_create_false_rollback(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Persist candidate-vs-baseline scorecard artifacts for eligible RL training reports.
- Thread scorecard IDs/paths and runtime parameter injection evidence into Tencent batch controller summaries.
- Add regression coverage for scorecard persistence, collected-artifact requirements, and metadata-only runtime-injection classifications.

## Verification
- `python3 -m py_compile scripts/screeps_rl_training_runner.py scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_rl_training_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts.test_screeps_rl_training_runner scripts.test_screeps_tencent_batch_rl_runner -v` — 145 tests OK
- `git diff --check`

## Safety
- Offline/private RL tooling only.
- No official MMO writes, no deploy, and no paid Tencent compute launched by this PR.
- Active Tencent run `tencent-pg-20260520t161004z` is separate and remains to be digested after completion/scale-down.

Fixes #1271
Relates #879
Relates #1032
Relates #1233
Relates #924
