### PR TITLE
fix(rl): expose standalone card supply fallback

### DIFF
--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -37,6 +37,7 @@ REWARD_COMPONENT_ORDER = ("reliability", "territory", "resources", "kills")
 LOOP_A_CARD_SUPPLY_TYPE = "screeps-rl-loop-a-card-supply"
 LOOP_A_CARD_SUPPLY_CONSUMER = "loop-a-policy-gradient"
 LOOP_A_CARD_SUPPLY_STATES = ("available", "consumed")
+STANDALONE_CARD_SUPPLY_SOURCE = "standalone_experiment_card"
 TENCENT_CARD_IDENTITY_FIELDS = ("runId", "cardId", "datasetRunId")
 TENCENT_CARD_SUPPLY_SOURCES = (
     "tencent_controller_summary",
@@ -796,6 +797,27 @@ def loop_a_card_supply_summary(
     return summary
 
 
+def standalone_card_supply_summary(*, card: JsonObject, path: Path) -> JsonObject:
+    supply = card_supply_metadata(card)
+    return {
+        "status": "PRIMARY_SATISFIED",
+        "classification": "STANDALONE_POLICY_GRADIENT_FALLBACK_AVAILABLE",
+        "source": STANDALONE_CARD_SUPPLY_SOURCE,
+        "severity": "OK",
+        "fallbackStatus": "AVAILABLE",
+        "fallbackSeverity": "OK",
+        "fallbackReason": "A safety-validated standalone Loop A policy-gradient fallback card is available.",
+        "cardId": first_present(card, ("card_id", "cardId")),
+        "createdAt": first_present(card, ("created_at", "createdAt")),
+        "datasetRunId": first_present(card, ("dataset_run_id", "datasetRunId")),
+        "trainingApproach": card_training_approach(card),
+        "path": str(path),
+        "runId": None,
+        "hasLoopACardSupplyMetadata": True,
+        "cardSupply": supply,
+    }
+
+
 def blocked_card_supply_summary(reason: str | None = None) -> JsonObject:
     return {
         "status": "BLOCKED",
@@ -808,6 +830,45 @@ def blocked_card_supply_summary(reason: str | None = None) -> JsonObject:
 
 def tencent_summary_run_id(payload: JsonObject, path: Path) -> str:
     return text_value(payload.get("runId")) or path.parent.name
+
+
+def standalone_card_supply_from_card(
+    path: Path,
+    warnings: list[str],
+    repo_root: Path,
+    *,
+    consumed_card_ids: set[str],
+) -> JsonObject | None:
+    artifact = load_artifact(path, warnings, repo_root)
+    if artifact is None:
+        return None
+    if not experiment_card.is_loop_a_card_available_for_training(artifact.payload, consumed_card_ids):
+        return None
+    return standalone_card_supply_summary(card=artifact.payload, path=artifact.path)
+
+
+def discover_standalone_card_supply_candidates(
+    artifact_root: Path,
+    *,
+    warnings: list[str],
+    repo_root: Path,
+) -> list[JsonObject]:
+    card_dir = artifact_root / "rl-experiment-cards"
+    consumed_card_ids = experiment_card.consumed_card_ids_from_training_reports(artifact_root / "rl-training")
+    candidates = [
+        evidence
+        for path in existing_globs(card_dir, ("*.json",))
+        if (
+            evidence := standalone_card_supply_from_card(
+                path,
+                warnings,
+                repo_root,
+                consumed_card_ids=consumed_card_ids,
+            )
+        )
+        is not None
+    ]
+    return sorted(candidates, key=card_supply_candidate_key, reverse=True)
 
 
 def card_supply_from_full_card(path: Path, warnings: list[str], repo_root: Path, *, run_id: str) -> JsonObject | None:
@@ -1617,6 +1678,13 @@ def legacy_tencent_card_supply_available_for_training(card_supply: JsonObject) -
     )
 
 
+def standalone_card_supply_available_for_training(card_supply: JsonObject) -> bool:
+    return (
+        card_supply.get("source") == STANDALONE_CARD_SUPPLY_SOURCE
+        and card_supply_available_for_training(card_supply)
+    )
+
+
 def card_supply_candidate_rank(card_supply: JsonObject) -> int:
     supply = as_dict(card_supply.get("cardSupply"))
     if card_supply_available_for_training(card_supply):
@@ -1660,8 +1728,8 @@ def training_card_supply_candidate_key(card_supply: JsonObject) -> tuple[int, da
 
 
 def combined_tencent_card_supply_candidates(
-    tencent_internal_card_supply: JsonObject | None,
-    tencent_internal_card_supply_candidates: Sequence[JsonObject] | None,
+    tencent_internal_card_supply: JsonObject | None = None,
+    tencent_internal_card_supply_candidates: Sequence[JsonObject] | None = None,
 ) -> list[JsonObject]:
     candidates = list(tencent_internal_card_supply_candidates or [])
     if tencent_internal_card_supply is not None:
@@ -1669,11 +1737,33 @@ def combined_tencent_card_supply_candidates(
     return candidates
 
 
-def best_available_tencent_card_supply(candidates: Sequence[JsonObject]) -> JsonObject | None:
+def combined_card_supply_candidates(
+    standalone_card_supply: JsonObject | None = None,
+    standalone_card_supply_candidates: Sequence[JsonObject] | None = None,
+    tencent_internal_card_supply: JsonObject | None = None,
+    tencent_internal_card_supply_candidates: Sequence[JsonObject] | None = None,
+) -> list[JsonObject]:
+    candidates = list(standalone_card_supply_candidates or [])
+    if standalone_card_supply is not None:
+        candidates.append(standalone_card_supply)
+    candidates.extend(
+        combined_tencent_card_supply_candidates(
+            tencent_internal_card_supply,
+            tencent_internal_card_supply_candidates,
+        )
+    )
+    return candidates
+
+
+def best_available_card_supply(candidates: Sequence[JsonObject]) -> JsonObject | None:
     available = [candidate for candidate in candidates if card_supply_available_for_training(candidate)]
     if not available:
         return None
     return max(available, key=card_supply_candidate_key)
+
+
+def best_available_tencent_card_supply(candidates: Sequence[JsonObject]) -> JsonObject | None:
+    return best_available_card_supply(candidates)
 
 
 def matching_tencent_card_supply_for_training(
@@ -1697,6 +1787,8 @@ def reconcile_card_supply_for_training(
     payload: JsonObject,
     *,
     latest_path: Path | None,
+    standalone_card_supply: JsonObject | None = None,
+    standalone_card_supply_candidates: Sequence[JsonObject] | None = None,
     tencent_internal_card_supply: JsonObject | None,
     tencent_internal_card_supply_candidates: Sequence[JsonObject] | None = None,
 ) -> JsonObject:
@@ -1720,10 +1812,16 @@ def reconcile_card_supply_for_training(
         tencent_internal_card_supply,
         tencent_internal_card_supply_candidates,
     )
+    available_candidates = combined_card_supply_candidates(
+        standalone_card_supply,
+        standalone_card_supply_candidates,
+        tencent_internal_card_supply,
+        tencent_internal_card_supply_candidates,
+    )
     if not training_did_run:
         if training_claims_compute:
             return blocked_card_supply_summary(text_value(compute_evidence.get("blocker")))
-        available_supply = best_available_tencent_card_supply(tencent_candidates)
+        available_supply = best_available_card_supply(available_candidates)
         if available_supply is not None:
             return dict(available_supply)
     else:
@@ -1749,6 +1847,8 @@ def reconcile_card_supply_for_training(
 def training_execution(
     latest_training: LoadedArtifact | None,
     *,
+    standalone_card_supply: JsonObject | None = None,
+    standalone_card_supply_candidates: Sequence[JsonObject] | None = None,
     tencent_internal_card_supply: JsonObject | None = None,
     tencent_internal_card_supply_candidates: Sequence[JsonObject] | None = None,
 ) -> JsonObject:
@@ -1785,6 +1885,8 @@ def training_execution(
     card_supply = reconcile_card_supply_for_training(
         payload,
         latest_path=latest_training.path,
+        standalone_card_supply=standalone_card_supply,
+        standalone_card_supply_candidates=standalone_card_supply_candidates,
         tencent_internal_card_supply=tencent_internal_card_supply,
         tencent_internal_card_supply_candidates=tencent_internal_card_supply_candidates,
     )
@@ -1842,6 +1944,8 @@ def card_supply_finding_for_policy(payload: JsonObject, training: JsonObject | N
         return None
     card_supply = as_dict((training or {}).get("cardSupply"))
     if card_supply.get("status") == "PRIMARY_SATISFIED":
+        if standalone_card_supply_available_for_training(card_supply):
+            return None
         return {
             "status": "FALLBACK_DEGRADED",
             "severity": "P2",
@@ -2136,9 +2240,17 @@ def build_dashboard(repo_root: Path, artifact_root: Path, generated_at: str) -> 
         repo_root=repo_root,
     )
     tencent_card_supply = tencent_card_supply_candidates[0] if tencent_card_supply_candidates else None
+    standalone_card_supply_candidates = discover_standalone_card_supply_candidates(
+        artifact_root,
+        warnings=warnings,
+        repo_root=repo_root,
+    )
+    standalone_card_supply = standalone_card_supply_candidates[0] if standalone_card_supply_candidates else None
     simulator = simulator_health(artifact_root, repo_root=repo_root, warnings=warnings, latest_training=latest_training)
     training = training_execution(
         latest_training,
+        standalone_card_supply=standalone_card_supply,
+        standalone_card_supply_candidates=standalone_card_supply_candidates,
         tencent_internal_card_supply=tencent_card_supply,
         tencent_internal_card_supply_candidates=tencent_card_supply_candidates,
     )

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -1812,16 +1812,17 @@ def reconcile_card_supply_for_training(
         tencent_internal_card_supply,
         tencent_internal_card_supply_candidates,
     )
-    available_candidates = combined_card_supply_candidates(
-        standalone_card_supply,
-        standalone_card_supply_candidates,
-        tencent_internal_card_supply,
-        tencent_internal_card_supply_candidates,
-    )
     if not training_did_run:
         if training_claims_compute:
             return blocked_card_supply_summary(text_value(compute_evidence.get("blocker")))
-        available_supply = best_available_card_supply(available_candidates)
+        available_supply = best_available_tencent_card_supply(tencent_candidates)
+        if available_supply is None:
+            available_supply = best_available_card_supply(
+                combined_card_supply_candidates(
+                    standalone_card_supply,
+                    standalone_card_supply_candidates,
+                )
+            )
         if available_supply is not None:
             return dict(available_supply)
     else:

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -13,6 +13,7 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).parent))
 
 import screeps_rl_dashboard as dashboard
+import screeps_rl_experiment_card as card_helper
 
 
 JsonObject = dict[str, Any]
@@ -189,6 +190,57 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertTrue(str(gate["sourcePath"]).endswith(f"rl-control-loop/gate-data/{gate_id}/gate_report.json"))
         e1_lane = next(item for item in summary["lanes"] if item["lane"] == "E1")
         self.assertEqual(e1_lane["status"], "OK")
+
+    def test_standalone_fallback_card_clears_no_card_blocker_without_tencent(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            card = card_helper.build_card(
+                dataset_run_id="rl-current-standalone",
+                code_commit="2" * 40,
+                training_approach="policy_gradient",
+                created_at="2026-05-20T18:04:00Z",
+                scenario_id=card_helper.MULTI_TIER_SCENARIO_ID,
+                require_multi_tier_scenario=True,
+                loop_a_card_supply=True,
+            )
+            write_json(artifact_root / "rl-experiment-cards" / "experiment_card.json", card)
+            write_json(
+                artifact_root / "rl-control-loop" / "training-ledger.json",
+                {
+                    "type": "screeps-rl-training-execution-ledger",
+                    "status": "NOT_RUN",
+                    "trainingDidRun": False,
+                    "trainingBlocker": "NO_UNCONSUMED_EXPERIMENT_CARD",
+                    "createdAt": "2026-05-20T18:05:00Z",
+                },
+            )
+            write_json(
+                artifact_root / "rl-control-loop" / "policy-advantage.json",
+                {
+                    "type": "screeps-rl-policy-online-advantage-report",
+                    "onlineUtilityStatus": "UNPROVEN",
+                    "candidatePolicyId": "NO_STABLE_CANDIDATE",
+                    "baselinePolicyId": "incumbent",
+                    "evidenceWindows": {"loopACardPathStalledCycles": 17},
+                    "createdAt": "2026-05-20T18:06:00Z",
+                },
+            )
+
+            summary = dashboard.build_dashboard(
+                repo_root=root,
+                artifact_root=artifact_root,
+                generated_at="2026-05-20T18:07:00Z",
+            )
+
+        card_supply = summary["training"]["cardSupply"]
+        self.assertEqual(card_supply["status"], "PRIMARY_SATISFIED")
+        self.assertEqual(card_supply["classification"], "STANDALONE_POLICY_GRADIENT_FALLBACK_AVAILABLE")
+        self.assertEqual(card_supply["source"], "standalone_experiment_card")
+        self.assertEqual(card_supply["severity"], "OK")
+        self.assertEqual(card_supply["fallbackStatus"], "AVAILABLE")
+        self.assertIsNone(summary["training"]["blocker"])
+        self.assertIsNone(summary["policy"]["cardSupplyFinding"])
 
     def test_tencent_internal_card_downgrades_standalone_stall_to_fallback(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -242,6 +242,66 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertIsNone(summary["training"]["blocker"])
         self.assertIsNone(summary["policy"]["cardSupplyFinding"])
 
+    def test_not_run_prefers_tencent_supply_over_newer_standalone_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            standalone_card = card_helper.build_card(
+                dataset_run_id="rl-current-standalone",
+                code_commit="2" * 40,
+                training_approach="policy_gradient",
+                created_at="2026-05-20T18:04:00Z",
+                scenario_id=card_helper.MULTI_TIER_SCENARIO_ID,
+                require_multi_tier_scenario=True,
+                loop_a_card_supply=True,
+            )
+            write_json(root / "rl-experiment-cards" / "experiment_card.json", standalone_card)
+            run_dir = root / "tencent-cloud" / "batch-runs" / "tencent-pg-older-primary"
+            write_json(
+                run_dir / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-older-primary",
+                    "outputs": {"experimentCard": {"cardId": "rl-exp-rl-accepted-123456789abc"}},
+                },
+            )
+            write_json(
+                run_dir / "experiment_card.json",
+                policy_gradient_card(created_at="2026-05-18T10:35:11Z"),
+            )
+
+            standalone_candidates = dashboard.discover_standalone_card_supply_candidates(
+                root,
+                warnings=[],
+                repo_root=root,
+            )
+            tencent_candidates = dashboard.discover_tencent_internal_card_supply_candidates(
+                root,
+                warnings=[],
+                repo_root=root,
+            )
+            training = dashboard.training_execution(
+                loaded_artifact(
+                    root / "rl-control-loop" / "training-ledger.json",
+                    {
+                        "type": "screeps-rl-training-execution-ledger",
+                        "status": "NOT_RUN",
+                        "trainingDidRun": False,
+                        "trainingBlocker": "NO_UNCONSUMED_EXPERIMENT_CARD",
+                    },
+                ),
+                standalone_card_supply=standalone_candidates[0],
+                standalone_card_supply_candidates=standalone_candidates,
+                tencent_internal_card_supply=tencent_candidates[0],
+                tencent_internal_card_supply_candidates=tencent_candidates,
+            )
+
+        card_supply = training["cardSupply"]
+        self.assertEqual(card_supply["status"], "PRIMARY_SATISFIED")
+        self.assertEqual(card_supply["source"], "tencent_internal_experiment_card")
+        self.assertEqual(card_supply["runId"], "tencent-pg-older-primary")
+        self.assertEqual(card_supply["fallbackStatus"], "DEGRADED")
+        self.assertIsNone(training["blocker"])
+
     def test_tencent_internal_card_downgrades_standalone_stall_to_fallback(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -607,30 +607,43 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(exit_code, 2)
         self.assertIn("Loop A policy-gradient proof requires", stderr.getvalue())
 
-    def test_committed_loop_a_local_fallback_card_is_discoverable(self) -> None:
-        card_path = REPO_ROOT / "runtime-artifacts" / "rl-experiment-cards" / "experiment_card.json"
-        self.assertTrue(card_path.is_file())
-        card = json.loads(card_path.read_text(encoding="utf-8"))
-
-        card_helper.validate_card(card)
-        self.assertTrue(card_helper.is_loop_a_card_available_for_training(card))
-        self.assertEqual(card["training_approach"], "policy_gradient")
-        self.assertEqual(card["status"], "shadow")
-        self.assertFalse(card["liveEffect"])
-        self.assertFalse(card["officialMmoWrites"])
-        self.assertFalse(card["officialMmoWritesAllowed"])
-        self.assertTrue(card["conservative_actions_only"])
-        self.assertTrue(card["ood_rejection"])
-        self.assertEqual(card["reward_model"]["component_order"], ["reliability", "territory", "resources", "kills"])
-        self.assertFalse(card["reward_model"]["scalar_weighted_sum_authorized"])
-
+    def test_loop_a_local_fallback_card_is_discoverable_from_card_dir(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
-            selected = card_helper.select_loop_a_card_supply(card_path.parent, Path(temp_dir))
+            root = Path(temp_dir)
+            card_path = root / "runtime-artifacts" / "rl-experiment-cards" / "experiment_card.json"
+            card = card_helper.build_card(
+                dataset_run_id="rl-ebf33fae619f",
+                code_commit="7" * 40,
+                training_approach="policy_gradient",
+                created_at="2026-05-18T03:12:00Z",
+                scenario_id=card_helper.MULTI_TIER_SCENARIO_ID,
+                require_multi_tier_scenario=True,
+                loop_a_card_supply=True,
+            )
+            card_path.parent.mkdir(parents=True)
+            card_path.write_text(json.dumps(card, sort_keys=True), encoding="utf-8")
 
-        self.assertIsNotNone(selected)
-        assert selected is not None
-        self.assertEqual(selected["card_path"], str(card_path))
-        self.assertEqual(selected["card_supply"]["state"], "available")
+            card_helper.validate_card(card)
+            self.assertTrue(card_helper.is_loop_a_card_available_for_training(card))
+            self.assertEqual(card["training_approach"], "policy_gradient")
+            self.assertEqual(card["status"], "shadow")
+            self.assertFalse(card["liveEffect"])
+            self.assertFalse(card["officialMmoWrites"])
+            self.assertFalse(card["officialMmoWritesAllowed"])
+            self.assertTrue(card["conservative_actions_only"])
+            self.assertTrue(card["ood_rejection"])
+            self.assertEqual(card["reward_model"]["component_order"], ["reliability", "territory", "resources", "kills"])
+            self.assertFalse(card["reward_model"]["scalar_weighted_sum_authorized"])
+
+            selected = card_helper.select_loop_a_card_supply(
+                card_path.parent,
+                root / "runtime-artifacts" / "rl-training",
+            )
+
+            self.assertIsNotNone(selected)
+            assert selected is not None
+            self.assertEqual(selected["card_path"], str(card_path))
+            self.assertEqual(selected["card_supply"]["state"], "available")
 
     def test_source_gate_block_uses_stable_provenance_path(self) -> None:
         gate_id = "rl-gate-93bf1aa18b62"

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -607,6 +607,31 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(exit_code, 2)
         self.assertIn("Loop A policy-gradient proof requires", stderr.getvalue())
 
+    def test_committed_loop_a_local_fallback_card_is_discoverable(self) -> None:
+        card_path = REPO_ROOT / "runtime-artifacts" / "rl-experiment-cards" / "experiment_card.json"
+        self.assertTrue(card_path.is_file())
+        card = json.loads(card_path.read_text(encoding="utf-8"))
+
+        card_helper.validate_card(card)
+        self.assertTrue(card_helper.is_loop_a_card_available_for_training(card))
+        self.assertEqual(card["training_approach"], "policy_gradient")
+        self.assertEqual(card["status"], "shadow")
+        self.assertFalse(card["liveEffect"])
+        self.assertFalse(card["officialMmoWrites"])
+        self.assertFalse(card["officialMmoWritesAllowed"])
+        self.assertTrue(card["conservative_actions_only"])
+        self.assertTrue(card["ood_rejection"])
+        self.assertEqual(card["reward_model"]["component_order"], ["reliability", "territory", "resources", "kills"])
+        self.assertFalse(card["reward_model"]["scalar_weighted_sum_authorized"])
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            selected = card_helper.select_loop_a_card_supply(card_path.parent, Path(temp_dir))
+
+        self.assertIsNotNone(selected)
+        assert selected is not None
+        self.assertEqual(selected["card_path"], str(card_path))
+        self.assertEqual(selected["card_supply"]["state"], "available")
+
     def test_source_gate_block_uses_stable_provenance_path(self) -> None:
         gate_id = "rl-gate-93bf1aa18b62"
         dataset_run_id = "rl-ebf33fae619f"


### PR DESCRIPTION
## Summary
- Include standalone Loop A experiment-card supply candidates in the RL dashboard/card-supply reconciliation path.
- Treat safety-validated standalone cards as an available fallback when Tencent internal cards are absent or consumed.
- Add dashboard and experiment-card tests for standalone fallback discovery/consumption behavior.

Fixes #1266

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_dashboard.py scripts/screeps_rl_experiment_card.py`
- `python3 -m pytest scripts/test_screeps_rl_dashboard.py scripts/test_screeps_rl_experiment_card.py -q` (89 passed, 19 subtests passed)

## Safety
- Offline/shadow RL metadata only; no official MMO writes and no secrets printed.
- Controller will wait for CodeRabbit/Gemini/check gates before merge.
