### PR TITLE
fix(rl): gate policy updates on runtime parameter transport

### DIFF
--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -1448,6 +1448,20 @@ def build_rank_weighted_finite_difference_policy_update(
             "gradient": gradient,
         }
 
+    parameter_evidence = policy_update_runtime_injection_ready_parameter_evidence(policy_gradient, candidates)
+    if parameter_evidence.get("policyUpdateEligible") is not True:
+        return {
+            **base,
+            "skippedReason": RUNTIME_PARAMETER_INJECTION_INCOMPLETE_SKIP_REASON,
+            "candidateCount": len(candidates),
+            "metadataCandidateCount": policy_gradient_candidate_vector_count(policy_gradient),
+            "parameterEvidence": parameter_evidence,
+            "anchor": policy_update_candidate_summary(anchor),
+            "candidateRewards": [policy_update_candidate_summary(row) for row in candidates],
+            "learningRate": learning_rate,
+            "gradient": gradient,
+        }
+
     candidate_policy_id = updated_candidate_policy_id(
         target_family=target_family,
         report_id=report_id,
@@ -1498,6 +1512,7 @@ def build_rank_weighted_finite_difference_policy_update(
         "learningRate": learning_rate,
         "parameterSpace": copy.deepcopy(parameter_space),
         "candidateCount": len(candidates),
+        "parameterEvidence": parameter_evidence,
         "anchor": policy_update_candidate_summary(anchor),
         "candidateRewards": [policy_update_candidate_summary(row) for row in candidates],
         "advantageByStrategyVariantId": advantages,
@@ -1602,6 +1617,21 @@ def build_reinforce_policy_update(
             "gradient": gradient,
         }
 
+    parameter_evidence = policy_update_runtime_injection_ready_parameter_evidence(policy_gradient, candidates)
+    if parameter_evidence.get("policyUpdateEligible") is not True:
+        return {
+            **base,
+            "skippedReason": RUNTIME_PARAMETER_INJECTION_INCOMPLETE_SKIP_REASON,
+            "candidateCount": len(candidates),
+            "metadataCandidateCount": policy_gradient_candidate_vector_count(policy_gradient),
+            "parameterEvidence": parameter_evidence,
+            "anchor": policy_update_candidate_summary(anchor),
+            "candidateRewards": [policy_update_candidate_summary(row) for row in candidates],
+            "learningRate": learning_rate,
+            "gradient": gradient,
+            "returnSummary": return_summary,
+        }
+
     candidate_policy_id = updated_candidate_policy_id(
         target_family=target_family,
         report_id=report_id,
@@ -1660,6 +1690,7 @@ def build_reinforce_policy_update(
         "learningRate": learning_rate,
         "parameterSpace": copy.deepcopy(parameter_space),
         "candidateCount": len(candidates),
+        "parameterEvidence": parameter_evidence,
         "anchor": policy_update_candidate_summary(anchor),
         "candidateRewards": [policy_update_candidate_summary(row) for row in candidates],
         "returnSummary": return_summary,
@@ -4596,6 +4627,49 @@ def policy_update_runtime_injection_incomplete_parameter_evidence(policy_gradien
             "for every candidate variant"
         ),
     }
+
+
+def policy_update_runtime_injection_ready_parameter_evidence(
+    policy_gradient: JsonObject,
+    candidates: Sequence[JsonObject],
+) -> JsonObject:
+    support = first_mapping(policy_gradient, ("runner_support", "runnerSupport")) or {}
+    scope = (
+        first_present(support, ("candidate_parameter_scope", "candidateParameterScope"))
+        or "runtime_injected"
+    )
+    runtime_injection = first_present(
+        support,
+        (
+            "runtime_parameter_injection",
+            "runtimeParameterInjection",
+            "inline_candidates_runtime_injected",
+            "inlineCandidatesRuntimeInjected",
+        ),
+    ) is True
+    eligible = (
+        runtime_injection
+        and scope == "runtime_injected"
+        and policy_gradient_requires_runtime_parameter_evidence(policy_gradient)
+        and len(candidates) >= policy_gradient_candidate_vector_count(policy_gradient)
+    )
+    payload: JsonObject = {
+        "candidateParameterScope": scope,
+        "runtimeParameterInjection": runtime_injection,
+        "policyUpdateEligible": eligible,
+        "candidateCount": len(candidates),
+        "metadataCandidateCount": policy_gradient_candidate_vector_count(policy_gradient),
+    }
+    if eligible:
+        payload["reason"] = (
+            "scored candidate rewards were backed by complete evaluated runtime parameter evidence"
+        )
+    else:
+        payload["reason"] = (
+            "policy updates require runtime-injected candidate parameter transport and complete "
+            "evaluated runtime parameter evidence"
+        )
+    return payload
 
 
 def safety_metadata() -> JsonObject:

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -1437,17 +1437,6 @@ def build_rank_weighted_finite_difference_policy_update(
         updated_parameters[name] = updated
         parameter_delta[name] = round_policy_number(float(updated) - anchor_value)
 
-    if not any(abs(float(value)) > 0 for value in parameter_delta.values()):
-        return {
-            **base,
-            "skippedReason": "bounded_update_no_parameter_change",
-            "candidateCount": len(candidates),
-            "anchor": policy_update_candidate_summary(anchor),
-            "candidateRewards": [policy_update_candidate_summary(row) for row in candidates],
-            "learningRate": learning_rate,
-            "gradient": gradient,
-        }
-
     parameter_evidence = policy_update_runtime_injection_ready_parameter_evidence(policy_gradient, candidates)
     if parameter_evidence.get("policyUpdateEligible") is not True:
         return {
@@ -1456,6 +1445,17 @@ def build_rank_weighted_finite_difference_policy_update(
             "candidateCount": len(candidates),
             "metadataCandidateCount": policy_gradient_candidate_vector_count(policy_gradient),
             "parameterEvidence": parameter_evidence,
+            "anchor": policy_update_candidate_summary(anchor),
+            "candidateRewards": [policy_update_candidate_summary(row) for row in candidates],
+            "learningRate": learning_rate,
+            "gradient": gradient,
+        }
+
+    if not any(abs(float(value)) > 0 for value in parameter_delta.values()):
+        return {
+            **base,
+            "skippedReason": "bounded_update_no_parameter_change",
+            "candidateCount": len(candidates),
             "anchor": policy_update_candidate_summary(anchor),
             "candidateRewards": [policy_update_candidate_summary(row) for row in candidates],
             "learningRate": learning_rate,
@@ -1606,17 +1606,6 @@ def build_reinforce_policy_update(
         samples=samples,
         baseline=return_baseline,
     )
-    if not any(abs(float(value)) > 0 for value in parameter_delta.values()):
-        return {
-            **base,
-            "skippedReason": "bounded_update_no_parameter_change",
-            "candidateCount": len(candidates),
-            "anchor": policy_update_candidate_summary(anchor),
-            "candidateRewards": [policy_update_candidate_summary(row) for row in candidates],
-            "learningRate": learning_rate,
-            "gradient": gradient,
-        }
-
     parameter_evidence = policy_update_runtime_injection_ready_parameter_evidence(policy_gradient, candidates)
     if parameter_evidence.get("policyUpdateEligible") is not True:
         return {
@@ -1630,6 +1619,17 @@ def build_reinforce_policy_update(
             "learningRate": learning_rate,
             "gradient": gradient,
             "returnSummary": return_summary,
+        }
+
+    if not any(abs(float(value)) > 0 for value in parameter_delta.values()):
+        return {
+            **base,
+            "skippedReason": "bounded_update_no_parameter_change",
+            "candidateCount": len(candidates),
+            "anchor": policy_update_candidate_summary(anchor),
+            "candidateRewards": [policy_update_candidate_summary(row) for row in candidates],
+            "learningRate": learning_rate,
+            "gradient": gradient,
         }
 
     candidate_policy_id = updated_candidate_policy_id(

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -141,6 +141,7 @@ ZERO_ITERATION_POLICY_UPDATE_ALLOWED_KEYS = {
     "schemaVersion",
     "skippedReason",
     "targetFamily",
+    "returnSummary",
     "type",
 }
 ZERO_ITERATION_POLICY_UPDATE_FORBIDDEN_KEYS = {

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -2139,6 +2139,120 @@ export const STRATEGY_REGISTRY = [
         self.assertNotIn("updatedParameters", update)
         self.assertNotIn("parameterDelta", update)
 
+    def test_rank_weighted_clamped_noop_without_runtime_transport_reports_incomplete_evidence(self) -> None:
+        policy_gradient = {
+            "targetFamily": "test-family",
+            "policyUpdate": {
+                "algorithm": runner.RANK_WEIGHTED_FINITE_DIFFERENCE_ALGORITHM,
+                "learning_rate": 1,
+            },
+            "learnableParameters": [{"name": "territorySignalWeight", "min": 0, "max": 30}],
+            "candidateParameterVectors": [
+                {
+                    "candidatePolicyId": "candidate-a",
+                    "strategyVariantId": "variant-a",
+                    "rolloutStatus": "incumbent",
+                    "parameters": {"territorySignalWeight": 30.0},
+                },
+                {
+                    "candidatePolicyId": "candidate-b",
+                    "strategyVariantId": "variant-b",
+                    "rolloutStatus": "shadow",
+                    "parameters": {"territorySignalWeight": 29.0},
+                },
+            ],
+        }
+        results = [
+            {
+                "variantId": "variant-a",
+                "sampleCount": 1,
+                "reward": {"tuple": [1, 0, 0, 0]},
+                "parameters": {"territorySignalWeight": 30.0},
+            },
+            {
+                "variantId": "variant-b",
+                "sampleCount": 1,
+                "reward": {"tuple": [0, 0, 0, 0]},
+                "parameters": {"territorySignalWeight": 29.0},
+            },
+        ]
+
+        update = runner.build_policy_update(
+            policy_gradient=policy_gradient,
+            results=results,
+            report_id="policy-gradient-clamped-noop",
+            generated_at="2026-05-17T03:30:00Z",
+        )
+
+        self.assertEqual(update["iterations"], 0)
+        self.assertEqual(update["skippedReason"], runner.RUNTIME_PARAMETER_INJECTION_INCOMPLETE_SKIP_REASON)
+        self.assertEqual(update["candidateCount"], 2)
+        self.assertEqual(update["metadataCandidateCount"], 2)
+        self.assertEqual(update["gradient"], {"territorySignalWeight": 1})
+        self.assertFalse(update["parameterEvidence"]["runtimeParameterInjection"])
+        self.assertFalse(update["parameterEvidence"]["policyUpdateEligible"])
+        self.assertNotIn("returnSummary", update)
+        self.assertNotIn("nextCandidatePolicy", update)
+        self.assertNotIn("updatedParameters", update)
+        self.assertNotIn("parameterDelta", update)
+
+    def test_reinforce_clamped_noop_without_runtime_transport_reports_incomplete_evidence(self) -> None:
+        policy_gradient = {
+            "targetFamily": "test-family",
+            "policyUpdate": {
+                "algorithm": runner.TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM,
+                "learning_rate": 1,
+            },
+            "learnableParameters": [{"name": "territorySignalWeight", "min": 0, "max": 30}],
+            "candidateParameterVectors": [
+                {
+                    "candidatePolicyId": "candidate-a",
+                    "strategyVariantId": "variant-a",
+                    "rolloutStatus": "incumbent",
+                    "parameters": {"territorySignalWeight": 30.0},
+                },
+                {
+                    "candidatePolicyId": "candidate-b",
+                    "strategyVariantId": "variant-b",
+                    "rolloutStatus": "shadow",
+                    "parameters": {"territorySignalWeight": 29.0},
+                },
+            ],
+        }
+        results = [
+            {
+                "variantId": "variant-a",
+                "sampleCount": 1,
+                "reward": {"tuple": [1, 0, 0, 0]},
+                "parameters": {"territorySignalWeight": 30.0},
+            },
+            {
+                "variantId": "variant-b",
+                "sampleCount": 1,
+                "reward": {"tuple": [0, 0, 0, 0]},
+                "parameters": {"territorySignalWeight": 29.0},
+            },
+        ]
+
+        update = runner.build_policy_update(
+            policy_gradient=policy_gradient,
+            results=results,
+            report_id="policy-gradient-reinforce-clamped-noop",
+            generated_at="2026-05-17T03:30:00Z",
+        )
+
+        self.assertEqual(update["iterations"], 0)
+        self.assertEqual(update["skippedReason"], runner.RUNTIME_PARAMETER_INJECTION_INCOMPLETE_SKIP_REASON)
+        self.assertEqual(update["candidateCount"], 2)
+        self.assertEqual(update["metadataCandidateCount"], 2)
+        self.assertEqual(update["gradient"], {"territorySignalWeight": 0.008333})
+        self.assertFalse(update["parameterEvidence"]["runtimeParameterInjection"])
+        self.assertFalse(update["parameterEvidence"]["policyUpdateEligible"])
+        self.assertEqual(update["returnSummary"]["sampleCount"], 2)
+        self.assertNotIn("nextCandidatePolicy", update)
+        self.assertNotIn("updatedParameters", update)
+        self.assertNotIn("parameterDelta", update)
+
     def test_reinforce_small_gradient_preserves_nonzero_continuous_candidate_delta(self) -> None:
         policy_gradient = {
             "targetFamily": "test-family",

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -2146,6 +2146,14 @@ export const STRATEGY_REGISTRY = [
                 "algorithm": runner.TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM,
                 "learning_rate": 0.25,
             },
+            "runner_support": {
+                "runtime_parameter_injection": True,
+                "inline_candidates_runtime_injected": True,
+                "inline_candidates_applied_to_simulator": True,
+                "candidate_parameter_scope": "runtime_injected",
+                "simulator_variant_transport": "variant_ids_with_runtime_injected_parameters",
+                "policy_update_reward_use": "eligible_with_evaluated_runtime_parameters",
+            },
             "learnableParameters": [{"name": "territorySignalWeight", "min": 0, "max": 30, "step": 1}],
             "candidateParameterVectors": [
                 {
@@ -2189,6 +2197,8 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(update["gradient"], {"territorySignalWeight": 0.0085})
         self.assertEqual(update["parameterDelta"], {"territorySignalWeight": 0.06375})
         self.assertEqual(update["updatedParameters"], {"territorySignalWeight": 6.06375})
+        self.assertTrue(update["parameterEvidence"]["policyUpdateEligible"])
+        self.assertTrue(update["parameterEvidence"]["runtimeParameterInjection"])
         self.assertEqual(
             update["nextCandidatePolicy"]["parameterEvidence"]["parameterDelta"],
             {"territorySignalWeight": 0.06375},
@@ -2200,6 +2210,58 @@ export const STRATEGY_REGISTRY = [
         self.assertFalse(update["nextCandidatePolicy"]["liveEffect"])
         self.assertFalse(update["nextCandidatePolicy"]["officialMmoWrites"])
         self.assertFalse(update["nextCandidatePolicy"]["officialMmoWritesAllowed"])
+
+    def test_reinforce_reward_evidence_without_runtime_transport_stays_noop(self) -> None:
+        policy_gradient = {
+            "targetFamily": "test-family",
+            "policyUpdate": {
+                "algorithm": runner.TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM,
+                "learning_rate": 0.25,
+            },
+            "learnableParameters": [{"name": "territorySignalWeight", "min": 0, "max": 30, "step": 1}],
+            "candidateParameterVectors": [
+                {
+                    "candidatePolicyId": "candidate-a",
+                    "strategyVariantId": "variant-a",
+                    "rolloutStatus": "incumbent",
+                    "parameters": {"territorySignalWeight": 6.0},
+                },
+                {
+                    "candidatePolicyId": "candidate-b",
+                    "strategyVariantId": "variant-b",
+                    "rolloutStatus": "shadow",
+                    "parameters": {"territorySignalWeight": 7.0},
+                },
+            ],
+        }
+        results = [
+            {
+                "variantId": "variant-a",
+                "sampleCount": 1,
+                "reward": {"tuple": [0, 0, 0, 0]},
+                "evaluatedParameters": {"territorySignalWeight": 6.0},
+            },
+            {
+                "variantId": "variant-b",
+                "sampleCount": 1,
+                "reward": {"tuple": [1.02, 0, 0, 0]},
+                "evaluatedParameters": {"territorySignalWeight": 7.0},
+            },
+        ]
+
+        update = runner.build_policy_update(
+            policy_gradient=policy_gradient,
+            results=results,
+            report_id="policy-gradient-metadata-reward-only",
+            generated_at="2026-05-17T03:30:00Z",
+        )
+
+        self.assertEqual(update["iterations"], 0)
+        self.assertEqual(update["skippedReason"], runner.RUNTIME_PARAMETER_INJECTION_INCOMPLETE_SKIP_REASON)
+        self.assertFalse(update["parameterEvidence"]["policyUpdateEligible"])
+        self.assertFalse(update["parameterEvidence"]["runtimeParameterInjection"])
+        self.assertNotIn("nextCandidatePolicy", update)
+        self.assertNotIn("updatedParameters", update)
 
     def test_policy_update_bounds_preserve_continuous_values_without_step_quantizing(self) -> None:
         spec = {"min": 0, "max": 30, "step": 1}


### PR DESCRIPTION
## Summary
- Adds a runtime-parameter-transport eligibility gate before true-gradient policy-update payloads are emitted.
- Keeps reward evidence with metadata-only candidate vectors as an explicit no-op instead of creating `nextCandidatePolicy` / `updatedParameters` without proven runtime injection.
- Allows zero-iteration Tencent policy-update reports to carry `returnSummary` evidence while preserving the no-op safety validator.

Fixes #1264

## Test plan
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_training_runner.py scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_rl_training_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m pytest scripts/test_screeps_rl_training_runner.py scripts/test_screeps_tencent_batch_rl_runner.py -q` — 154 passed, 81 subtests passed

## Safety
- Offline/private RL tooling only; no official MMO learned-policy write path is enabled.
- Runtime parameter injection must be explicitly proven before true-gradient updates become eligible.
