### PR TITLE
fix(territory): convert E29N56 scout evidence into remote intent

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -18836,7 +18836,7 @@ function getRecommendedTerritoryIntentAction(candidate, recommendation, roleCoun
   if (isAutoClaimApprovedTerritoryCandidate(candidate)) {
     return candidate.intentAction;
   }
-  if (isConfiguredScoutOnlyExpansionCandidate(candidate) && (recommendation.evidenceStatus !== "sufficient" || !isAutonomousTerritoryControlAllowedForColonyName(candidate.target.colony))) {
+  if (isConfiguredScoutOnlyExpansionTarget(candidate.target) && (recommendation.evidenceStatus !== "sufficient" || !isAutonomousTerritoryControlAllowedForColonyName(candidate.target.colony))) {
     return "scout";
   }
   if (candidate.source === "occupationIntent" && isPersistedControllerFollowUpCandidate(candidate)) {
@@ -18863,10 +18863,13 @@ function getRecommendedTerritoryIntentAction(candidate, recommendation, roleCoun
   return recommendation.action === "reserve" ? "reserve" : candidate.intentAction;
 }
 function isConfiguredScoutOnlyExpansionCandidate(candidate) {
-  return candidate.source === "configuredExpansionScout" && isConfiguredExpansionScoutOnlyTarget(candidate.target.colony, candidate.target.roomName);
+  return candidate.source === "configuredExpansionScout" && isConfiguredScoutOnlyExpansionTarget(candidate.target);
+}
+function isConfiguredScoutOnlyExpansionTarget(target) {
+  return isConfiguredExpansionScoutOnlyTarget(target.colony, target.roomName);
 }
 function isConfiguredScoutOnlyRemoteConversionCandidate(candidate, intentAction) {
-  return isConfiguredScoutOnlyExpansionCandidate(candidate) && candidate.target.action === "reserve" && intentAction === "reserve" && (candidate.routeDistance === void 0 || candidate.routeDistance <= 1);
+  return isConfiguredScoutOnlyExpansionCandidate(candidate) && candidate.target.action === "reserve" && intentAction === "reserve" && candidate.routeDistance !== void 0 && candidate.routeDistance <= 1;
 }
 function isUnscoutedAdjacentReservationCandidate(candidate) {
   return isAdjacentRoomReservationReserveSelection(candidate);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -6319,7 +6319,9 @@ var SYNERGY_DUAL_SOURCE_GAP_BONUS = 80;
 var SYNERGY_SOURCE_DUPLICATE_PENALTY_PER_SOURCE = 40;
 var SYNERGY_DUAL_SOURCE_DUPLICATE_PENALTY = 80;
 var FOREIGN_RESERVATION_CONTROLLER_PRESSURE_RISK = "foreign reservation requires controller pressure";
+var ROOM_LIMIT_PRECONDITION_PREFIX = "limit expansion to ";
 var GCL_LIMIT_PRECONDITION = "wait for GCL capacity to claim another room";
+var SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION = `reach controller level ${AUTONOMOUS_TERRITORY_CONTROL_MIN_RCL} before scout-only remote conversion`;
 var MAX_ROOM_COUNT_BY_RCL = {
   1: 1,
   2: 1,
@@ -6617,7 +6619,7 @@ function scoreExpansionCandidate(input, candidate) {
   var _a, _b, _c;
   const rationale = [];
   const risks = [];
-  const preconditions = getExpansionPreconditions(input);
+  const preconditions = getExpansionPreconditions(input, candidate);
   let evidenceStatus = "sufficient";
   const visible = candidate.visible !== false;
   const scouted = candidate.scouted === true;
@@ -6697,7 +6699,7 @@ function scoreExpansionCandidate(input, candidate) {
   const score = calculateExpansionScore(input, candidate, evidenceStatus, synergy.score);
   const reservation = getReservationEvidence(input, candidate.controller);
   const requiresControllerPressure = (reservation == null ? void 0 : reservation.relation) === "foreign";
-  return {
+  const scoredCandidate = {
     roomName: candidate.roomName,
     score,
     synergyScore: synergy.score,
@@ -6722,6 +6724,12 @@ function scoreExpansionCandidate(input, candidate) {
     ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...candidate.scoutOnly === true ? { scoutOnly: true } : {}
   };
+  const recommendedAction = getPersistedExpansionCandidateRecommendedAction(scoredCandidate);
+  const blockReason = getPersistedExpansionCandidateBlockReason(scoredCandidate, recommendedAction);
+  return {
+    ...scoredCandidate,
+    ...blockReason ? { blockReason } : {}
+  };
 }
 function calculateExpansionScore(input, candidate, evidenceStatus, synergyScore = 0) {
   var _a, _b, _c;
@@ -6737,7 +6745,7 @@ function calculateExpansionScore(input, candidate, evidenceStatus, synergyScore 
   const hostilePenalty = ((_b = candidate.hostileCreepCount) != null ? _b : 0) * 240 + ((_c = candidate.hostileStructureCount) != null ? _c : 0) * 140;
   const unavailablePenalty = evidenceStatus === "unavailable" ? 2e3 : 0;
   const insufficientEvidencePenalty = evidenceStatus === "insufficient-evidence" ? 260 : 0;
-  const preconditionPenalty = getExpansionPreconditions(input).length * 120;
+  const preconditionPenalty = getExpansionPreconditions(input, candidate).length * 120;
   return Math.round(
     500 + sourceScore + dualSourceBonus + sourceAccessScore + proximityScore + terrainScore + reservationScore + distanceScore + adjacencyScore - foreignControllerPenalty - hostilePenalty - unavailablePenalty - insufficientEvidencePenalty - preconditionPenalty + synergyScore
   );
@@ -6876,14 +6884,17 @@ function getReservationEvidence(input, controller) {
     ...typeof controller.reservationTicksToEnd === "number" ? { ticksToEnd: controller.reservationTicksToEnd } : {}
   };
 }
-function getExpansionPreconditions(input) {
-  var _a, _b;
+function getExpansionPreconditions(input, candidate) {
+  var _a, _b, _c;
   const preconditions = [];
   if (input.energyCapacityAvailable < TERRITORY_CONTROLLER_BODY_COST) {
     preconditions.push("reach 650 energy capacity for claim body");
   }
   if (((_a = input.controllerLevel) != null ? _a : 0) < MIN_CONTROLLER_LEVEL) {
     preconditions.push("reach controller level 2 before expansion");
+  }
+  if ((candidate == null ? void 0 : candidate.scoutOnly) === true && ((_b = input.controllerLevel) != null ? _b : 0) < AUTONOMOUS_TERRITORY_CONTROL_MIN_RCL) {
+    preconditions.push(SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION);
   }
   const ownedRoomCount = getOwnedRoomCount(input);
   const gclRoomCapacity = getGclClaimRoomCapacity(input);
@@ -6897,7 +6908,7 @@ function getExpansionPreconditions(input) {
   if (typeof input.ticksToDowngrade === "number" && input.ticksToDowngrade <= DOWNGRADE_GUARD_TICKS) {
     preconditions.push("stabilize home controller downgrade timer");
   }
-  if (((_b = input.activePostClaimBootstrapCount) != null ? _b : 0) > 0) {
+  if (((_c = input.activePostClaimBootstrapCount) != null ? _c : 0) > 0) {
     preconditions.push("finish active post-claim bootstrap before next expansion");
   }
   return preconditions;
@@ -6914,6 +6925,9 @@ function getOwnedRoomCount(input) {
     return 1;
   }
   return Math.max(0, Math.floor(input.ownedRoomCount));
+}
+function isViableExpansionClaimCandidate(candidate) {
+  return candidate.scoutOnly !== true && isViableExpansionCandidate(candidate);
 }
 function isViableExpansionCandidate(candidate) {
   return candidate.evidenceStatus === "sufficient" && candidate.preconditions.length === 0 && typeof candidate.sourceCount === "number" && candidate.sourceCount > 0;
@@ -6934,7 +6948,9 @@ function persistExpansionCandidateScores(colony, report, gameTime) {
   territoryMemory.expansionCandidates = [...existingCandidates, ...nextCandidates];
 }
 function toPersistedExpansionCandidateMemory(colony, candidate, gameTime, rank) {
+  var _a;
   const recommendedAction = getPersistedExpansionCandidateRecommendedAction(candidate);
+  const blockReason = (_a = candidate.blockReason) != null ? _a : getPersistedExpansionCandidateBlockReason(candidate, recommendedAction);
   return {
     colony,
     roomName: candidate.roomName,
@@ -6946,6 +6962,7 @@ function toPersistedExpansionCandidateMemory(colony, candidate, gameTime, rank) 
     adjacentToOwnedRoom: candidate.adjacentToOwnedRoom,
     ...candidate.scoutOnly === true ? { scoutOnly: true } : {},
     ...recommendedAction ? { recommendedAction } : {},
+    ...blockReason ? { blockReason } : {},
     ...candidate.routeDistance !== void 0 ? { routeDistance: candidate.routeDistance } : {},
     ...candidate.nearestOwnedRoom ? { nearestOwnedRoom: candidate.nearestOwnedRoom } : {},
     ...candidate.nearestOwnedRoomDistance !== void 0 ? { nearestOwnedRoomDistance: candidate.nearestOwnedRoomDistance } : {},
@@ -6965,12 +6982,97 @@ function toPersistedExpansionCandidateMemory(colony, candidate, gameTime, rank) 
 }
 function getPersistedExpansionCandidateRecommendedAction(candidate) {
   if (candidate.scoutOnly === true) {
+    if (isViableScoutOnlyRemoteCandidate(candidate)) {
+      return "reserve";
+    }
     return candidate.evidenceStatus === "unavailable" ? void 0 : "scout";
   }
-  if (isViableExpansionCandidate(candidate)) {
+  if (isViableExpansionClaimCandidate(candidate)) {
     return "claim";
   }
   return candidate.evidenceStatus === "insufficient-evidence" && isScoutableNearbyExpansionCandidate(candidate) ? "scout" : void 0;
+}
+function isViableScoutOnlyRemoteCandidate(candidate) {
+  return candidate.scoutOnly === true && candidate.evidenceStatus === "sufficient" && hasScoutOnlyRemoteRelevantPrecondition(candidate) === false && candidate.requiresControllerPressure !== true && typeof candidate.sourceCount === "number" && candidate.sourceCount > 0 && isAdjacentScoutOnlyRemoteCandidate(candidate);
+}
+function isAdjacentScoutOnlyRemoteCandidate(candidate) {
+  return candidate.adjacentToOwnedRoom || typeof candidate.routeDistance === "number" && candidate.routeDistance <= 1 || typeof candidate.nearestOwnedRoomDistance === "number" && candidate.nearestOwnedRoomDistance <= 1;
+}
+function hasScoutOnlyRemoteRelevantPrecondition(candidate) {
+  return candidate.preconditions.some(isScoutOnlyRemoteRelevantPrecondition);
+}
+function isScoutOnlyRemoteRelevantPrecondition(precondition) {
+  return precondition !== GCL_LIMIT_PRECONDITION && !precondition.startsWith(ROOM_LIMIT_PRECONDITION_PREFIX);
+}
+function getPersistedExpansionCandidateBlockReason(candidate, recommendedAction) {
+  var _a, _b;
+  if (recommendedAction === "claim" || recommendedAction === "reserve") {
+    return void 0;
+  }
+  if (hasExpansionPrecondition(candidate, SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION)) {
+    return "controllerLevelLow";
+  }
+  if (hasExpansionPrecondition(candidate, "reach controller level 2 before expansion")) {
+    return "controllerLevelLow";
+  }
+  if (hasExpansionPrecondition(candidate, "reach 650 energy capacity for claim body")) {
+    return "energyCapacityLow";
+  }
+  if (candidate.preconditions.some((precondition) => precondition.startsWith(ROOM_LIMIT_PRECONDITION_PREFIX))) {
+    return "roomLimitReached";
+  }
+  if (hasExpansionPrecondition(candidate, GCL_LIMIT_PRECONDITION)) {
+    return "gclInsufficient";
+  }
+  if (hasExpansionPrecondition(candidate, "stabilize home controller downgrade timer")) {
+    return "homeDowngradeGuard";
+  }
+  if (hasExpansionPrecondition(candidate, "finish active post-claim bootstrap before next expansion")) {
+    return "postClaimBootstrapActive";
+  }
+  if (((_a = candidate.hostileCreepCount) != null ? _a : 0) > 0 || ((_b = candidate.hostileStructureCount) != null ? _b : 0) > 0) {
+    return "targetHostile";
+  }
+  if (candidate.risks.some((risk) => risk.includes("hostile presence"))) {
+    return "targetHostile";
+  }
+  if (candidate.requiresControllerPressure === true || candidate.risks.includes(FOREIGN_RESERVATION_CONTROLLER_PRESSURE_RISK)) {
+    return "controllerReserved";
+  }
+  if (candidate.risks.some((risk) => risk.includes("enemy-owned controller"))) {
+    return "controllerOwned";
+  }
+  if (candidate.risks.some((risk) => risk.includes("has no controller"))) {
+    return "controllerMissing";
+  }
+  if (candidate.risks.some((risk) => risk.includes("no known route"))) {
+    return "routeUnavailable";
+  }
+  if (typeof candidate.sourceCount !== "number" || candidate.sourceCount <= 0) {
+    return "sourcesMissing";
+  }
+  if (candidate.risks.some((risk) => risk.includes("source count evidence missing"))) {
+    return "sourcesMissing";
+  }
+  if (candidate.risks.some((risk) => risk.includes("controller evidence missing"))) {
+    return "controllerMissing";
+  }
+  if (candidate.risks.some((risk) => risk.includes("controller proximity evidence missing"))) {
+    return "controllerRangeMissing";
+  }
+  if (candidate.risks.some((risk) => risk.includes("terrain quality evidence missing"))) {
+    return "terrainMissing";
+  }
+  if (candidate.evidenceStatus === "insufficient-evidence") {
+    return "insufficientEvidence";
+  }
+  if (candidate.evidenceStatus === "unavailable") {
+    return "targetUnavailable";
+  }
+  return void 0;
+}
+function hasExpansionPrecondition(candidate, precondition) {
+  return candidate.preconditions.includes(precondition);
 }
 function pruneNextExpansionTargets(colony, activeTarget, territoryMemory = getTerritoryMemoryRecord3()) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
@@ -15808,7 +15910,7 @@ var EXPANSION_TRIGGER_THREAT_MEMORY_STALE_TICKS = 5;
 var EXPANSION_TRIGGER_DOWNGRADE_GUARD_TICKS = 5e3;
 var EXPANSION_PIPELINE_REEVALUATION_SEPARATOR = ">";
 var GCL_LIMIT_PRECONDITION2 = "wait for GCL capacity to claim another room";
-var ROOM_LIMIT_PRECONDITION_PREFIX = "limit expansion to ";
+var ROOM_LIMIT_PRECONDITION_PREFIX2 = "limit expansion to ";
 var MAX_ROOM_ENERGY_CAPACITY_BY_RCL = [0, 300, 550, 800, 1300, 1800, 2300, 5600, 12900];
 function refreshAutonomousExpansionPipeline(colony, report, gameTime = getGameTime22(), telemetryEvents = []) {
   const colonyName = colony.room.name;
@@ -16107,7 +16209,7 @@ function getTriggerSkipReason(colony, report, territoryMemory, gameTime) {
     return "gclInsufficient";
   }
   if (report.candidates.some(
-    (candidate) => candidate.preconditions.some((precondition) => precondition.startsWith(ROOM_LIMIT_PRECONDITION_PREFIX))
+    (candidate) => candidate.preconditions.some((precondition) => precondition.startsWith(ROOM_LIMIT_PRECONDITION_PREFIX2))
   )) {
     return "roomLimitReached";
   }
@@ -18369,7 +18471,7 @@ function getAdjacentReserveCandidates(colonyName, originRoomName, colonyOwnerUse
   const existingTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
   return adjacentRooms.flatMap((roomName, order) => {
     const target = { colony: colonyName, roomName, action: "reserve" };
-    if (roomName === colonyName || isConfiguredExpansionScoutOnlyTarget(colonyName, roomName) || existingTargetRooms.has(roomName) || isKnownDeadZoneRoom(roomName) || isTerritoryTargetSuppressed(target, intents, gameTime) || isTerritoryRoomSuspendedForColony(intents, colonyName, roomName, gameTime) || isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(intents, colonyName, roomName, "reserve", gameTime)) {
+    if (roomName === colonyName || existingTargetRooms.has(roomName) || isKnownDeadZoneRoom(roomName) || isTerritoryTargetSuppressed(target, intents, gameTime) || isTerritoryRoomSuspendedForColony(intents, colonyName, roomName, gameTime) || isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(intents, colonyName, roomName, "reserve", gameTime)) {
       return [];
     }
     const candidateState = getAdjacentReserveCandidateState(roomName, colonyOwnerUsername);
@@ -18681,7 +18783,7 @@ function applyOccupationRecommendationScore(candidate, recommendation, roleCount
   var _a;
   const intentAction = getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts);
   const requiresControllerPressure = isTerritoryControlAction3(intentAction) && candidate.requiresControllerPressure === true;
-  const commitTarget = recommendation.evidenceStatus === "sufficient" && intentAction !== "scout" && (candidate.commitTarget || isScoutedAdjacentControlCandidate(candidate));
+  const commitTarget = recommendation.evidenceStatus === "sufficient" && intentAction !== "scout" && (candidate.commitTarget || isScoutedAdjacentControlCandidate(candidate) || isConfiguredScoutOnlyRemoteConversionCandidate(candidate, intentAction));
   const target = getRecommendedTerritoryTarget(candidate.target, recommendation, intentAction);
   const nextSelection = {
     target,
@@ -18734,7 +18836,7 @@ function getRecommendedTerritoryIntentAction(candidate, recommendation, roleCoun
   if (isAutoClaimApprovedTerritoryCandidate(candidate)) {
     return candidate.intentAction;
   }
-  if (isConfiguredScoutOnlyExpansionCandidate(candidate)) {
+  if (isConfiguredScoutOnlyExpansionCandidate(candidate) && (recommendation.evidenceStatus !== "sufficient" || !isAutonomousTerritoryControlAllowedForColonyName(candidate.target.colony))) {
     return "scout";
   }
   if (candidate.source === "occupationIntent" && isPersistedControllerFollowUpCandidate(candidate)) {
@@ -18762,6 +18864,9 @@ function getRecommendedTerritoryIntentAction(candidate, recommendation, roleCoun
 }
 function isConfiguredScoutOnlyExpansionCandidate(candidate) {
   return candidate.source === "configuredExpansionScout" && isConfiguredExpansionScoutOnlyTarget(candidate.target.colony, candidate.target.roomName);
+}
+function isConfiguredScoutOnlyRemoteConversionCandidate(candidate, intentAction) {
+  return isConfiguredScoutOnlyExpansionCandidate(candidate) && candidate.target.action === "reserve" && intentAction === "reserve" && (candidate.routeDistance === void 0 || candidate.routeDistance <= 1);
 }
 function isUnscoutedAdjacentReservationCandidate(candidate) {
   return isAdjacentRoomReservationReserveSelection(candidate);
@@ -35825,20 +35930,24 @@ function buildScoutOnlyTargetSummaries(colony, summary) {
   const colonyName = colony.room.name;
   const attemptsByRoom = new Map(((_a = summary == null ? void 0 : summary.attempts) != null ? _a : []).map((attempt) => [attempt.roomName, attempt]));
   const intelByRoom = new Map(((_b = summary == null ? void 0 : summary.intel) != null ? _b : []).map((intel) => [intel.roomName, intel]));
+  const expansionCandidatesByRoom = getScoutOnlyExpansionCandidatesByRoom(colonyName);
   const seenRooms = /* @__PURE__ */ new Set();
   return getTerritoryExpansionScoutTargets(colonyName).flatMap((target) => {
+    var _a2;
     if (target.colony !== colonyName || target.scoutOnly !== true || seenRooms.has(target.roomName)) {
       return [];
     }
     seenRooms.add(target.roomName);
     const attempt = attemptsByRoom.get(target.roomName);
     const intel = intelByRoom.get(target.roomName);
+    const expansionCandidate = expansionCandidatesByRoom.get(target.roomName);
     const gateOpen = isPassiveScoutGateOpen(colony, target.roomName);
     return [
       {
         colony: colonyName,
         roomName: target.roomName,
-        recommendedAction: "scout",
+        recommendedAction: (_a2 = expansionCandidate == null ? void 0 : expansionCandidate.recommendedAction) != null ? _a2 : "scout",
+        ...(expansionCandidate == null ? void 0 : expansionCandidate.blockReason) ? { blockReason: expansionCandidate.blockReason } : {},
         gateOpen,
         status: getScoutOnlyTargetStatus(gateOpen, attempt, intel),
         ...(attempt == null ? void 0 : attempt.requestedAt) !== void 0 ? { requestedAt: attempt.requestedAt } : {},
@@ -35852,6 +35961,30 @@ function buildScoutOnlyTargetSummaries(colony, summary) {
       }
     ];
   });
+}
+function getScoutOnlyExpansionCandidatesByRoom(colonyName) {
+  var _a;
+  const candidates = (_a = Memory.territory) == null ? void 0 : _a.expansionCandidates;
+  if (!Array.isArray(candidates)) {
+    return /* @__PURE__ */ new Map();
+  }
+  const candidatesByRoom = /* @__PURE__ */ new Map();
+  for (const rawCandidate of candidates) {
+    if (!isRecord29(rawCandidate) || rawCandidate.colony !== colonyName || rawCandidate.scoutOnly !== true || !isNonEmptyString29(rawCandidate.roomName)) {
+      continue;
+    }
+    candidatesByRoom.set(rawCandidate.roomName, {
+      recommendedAction: isExpansionCandidateRecommendedAction2(rawCandidate.recommendedAction) ? rawCandidate.recommendedAction : "scout",
+      ...isExpansionCandidateBlockReason(rawCandidate.blockReason) ? { blockReason: rawCandidate.blockReason } : {}
+    });
+  }
+  return candidatesByRoom;
+}
+function isExpansionCandidateRecommendedAction2(action) {
+  return action === "claim" || action === "reserve" || action === "scout";
+}
+function isExpansionCandidateBlockReason(reason) {
+  return reason === "insufficientEvidence" || reason === "targetUnavailable" || reason === "targetHostile" || reason === "controllerMissing" || reason === "controllerOwned" || reason === "controllerReserved" || reason === "sourcesMissing" || reason === "controllerRangeMissing" || reason === "terrainMissing" || reason === "energyCapacityLow" || reason === "controllerLevelLow" || reason === "homeDowngradeGuard" || reason === "postClaimBootstrapActive" || reason === "gclInsufficient" || reason === "roomLimitReached" || reason === "routeUnavailable";
 }
 function getScoutOnlyTargetStatus(gateOpen, attempt, intel) {
   if (attempt) {

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -315,7 +315,8 @@ type RuntimeTerritoryScoutOnlyTargetStatus = TerritoryScoutAttemptStatus | 'pend
 interface RuntimeTerritoryScoutOnlyTargetSummary {
   colony: string;
   roomName: string;
-  recommendedAction: 'scout';
+  recommendedAction: TerritoryExpansionCandidateRecommendedAction;
+  blockReason?: TerritoryExpansionCandidateBlockReason;
   gateOpen: boolean;
   status: RuntimeTerritoryScoutOnlyTargetStatus;
   requestedAt?: number;
@@ -1085,6 +1086,7 @@ function buildScoutOnlyTargetSummaries(
   const colonyName = colony.room.name;
   const attemptsByRoom = new Map((summary?.attempts ?? []).map((attempt) => [attempt.roomName, attempt]));
   const intelByRoom = new Map((summary?.intel ?? []).map((intel) => [intel.roomName, intel]));
+  const expansionCandidatesByRoom = getScoutOnlyExpansionCandidatesByRoom(colonyName);
   const seenRooms = new Set<string>();
 
   return getTerritoryExpansionScoutTargets(colonyName).flatMap((target) => {
@@ -1095,12 +1097,14 @@ function buildScoutOnlyTargetSummaries(
 
     const attempt = attemptsByRoom.get(target.roomName);
     const intel = intelByRoom.get(target.roomName);
+    const expansionCandidate = expansionCandidatesByRoom.get(target.roomName);
     const gateOpen = isPassiveScoutGateOpen(colony, target.roomName);
     return [
       {
         colony: colonyName,
         roomName: target.roomName,
-        recommendedAction: 'scout' as const,
+        recommendedAction: expansionCandidate?.recommendedAction ?? 'scout',
+        ...(expansionCandidate?.blockReason ? { blockReason: expansionCandidate.blockReason } : {}),
         gateOpen,
         status: getScoutOnlyTargetStatus(gateOpen, attempt, intel),
         ...(attempt?.requestedAt !== undefined ? { requestedAt: attempt.requestedAt } : {}),
@@ -1114,6 +1118,70 @@ function buildScoutOnlyTargetSummaries(
       }
     ];
   });
+}
+
+function getScoutOnlyExpansionCandidatesByRoom(
+  colonyName: string
+): Map<string, Pick<TerritoryExpansionCandidateMemory, 'recommendedAction' | 'blockReason'>> {
+  const candidates = Memory.territory?.expansionCandidates;
+  if (!Array.isArray(candidates)) {
+    return new Map();
+  }
+
+  const candidatesByRoom = new Map<
+    string,
+    Pick<TerritoryExpansionCandidateMemory, 'recommendedAction' | 'blockReason'>
+  >();
+  for (const rawCandidate of candidates) {
+    if (
+      !isRecord(rawCandidate) ||
+      rawCandidate.colony !== colonyName ||
+      rawCandidate.scoutOnly !== true ||
+      !isNonEmptyString(rawCandidate.roomName)
+    ) {
+      continue;
+    }
+
+    candidatesByRoom.set(rawCandidate.roomName, {
+      recommendedAction: isExpansionCandidateRecommendedAction(rawCandidate.recommendedAction)
+        ? rawCandidate.recommendedAction
+        : 'scout',
+      ...(isExpansionCandidateBlockReason(rawCandidate.blockReason)
+        ? { blockReason: rawCandidate.blockReason }
+        : {})
+    });
+  }
+
+  return candidatesByRoom;
+}
+
+function isExpansionCandidateRecommendedAction(
+  action: unknown
+): action is TerritoryExpansionCandidateRecommendedAction {
+  return action === 'claim' || action === 'reserve' || action === 'scout';
+}
+
+function isExpansionCandidateBlockReason(
+  reason: unknown
+): reason is TerritoryExpansionCandidateBlockReason {
+  return (
+    reason === 'insufficientEvidence' ||
+    reason === 'targetUnavailable' ||
+    reason === 'targetHostile' ||
+    reason === 'controllerMissing' ||
+    reason === 'controllerOwned' ||
+    reason === 'controllerReserved' ||
+    reason === 'sourcesMissing' ||
+    reason === 'controllerRangeMissing' ||
+    reason === 'terrainMissing' ||
+    reason === 'energyCapacityLow' ||
+    reason === 'controllerLevelLow' ||
+    reason === 'homeDowngradeGuard' ||
+    reason === 'postClaimBootstrapActive' ||
+    reason === 'gclInsufficient' ||
+    reason === 'roomLimitReached' ||
+    reason === 'routeUnavailable'
+  );
 }
 
 function getScoutOnlyTargetStatus(

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -20,6 +20,7 @@ import {
   getTerritoryExpansionScoutTargets,
   type TerritoryExpansionScoutTargetConfig
 } from './expansionConfig';
+import { AUTONOMOUS_TERRITORY_CONTROL_MIN_RCL } from './controlGate';
 import { normalizeTerritoryIntents } from './territoryMemoryUtils';
 import { pruneLowerPriorityDuplicateClaimPlans } from './multiRoomTerritory';
 import {
@@ -54,6 +55,8 @@ const SYNERGY_DUAL_SOURCE_DUPLICATE_PENALTY = 80;
 const FOREIGN_RESERVATION_CONTROLLER_PRESSURE_RISK = 'foreign reservation requires controller pressure';
 const ROOM_LIMIT_PRECONDITION_PREFIX = 'limit expansion to ';
 const GCL_LIMIT_PRECONDITION = 'wait for GCL capacity to claim another room';
+const SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION =
+  `reach controller level ${AUTONOMOUS_TERRITORY_CONTROL_MIN_RCL} before scout-only remote conversion`;
 const MAX_ROOM_COUNT_BY_RCL: Record<number, number> = {
   1: 1,
   2: 1,
@@ -97,6 +100,7 @@ export interface ExpansionCandidateScore {
   reservation?: ExpansionReservationEvidence;
   requiresControllerPressure?: boolean;
   scoutOnly?: boolean;
+  blockReason?: TerritoryExpansionCandidateBlockReason;
 }
 
 export interface ExpansionScoringInput {
@@ -682,7 +686,7 @@ function scoreExpansionCandidate(
 ): ExpansionCandidateScore {
   const rationale: string[] = [];
   const risks: string[] = [];
-  const preconditions = getExpansionPreconditions(input);
+  const preconditions = getExpansionPreconditions(input, candidate);
   let evidenceStatus: ExpansionCandidateEvidenceStatus = 'sufficient';
   const visible = candidate.visible !== false;
   const scouted = candidate.scouted === true;
@@ -780,7 +784,7 @@ function scoreExpansionCandidate(
   const score = calculateExpansionScore(input, candidate, evidenceStatus, synergy.score);
   const reservation = getReservationEvidence(input, candidate.controller);
   const requiresControllerPressure = reservation?.relation === 'foreign';
-  return {
+  const scoredCandidate: ExpansionCandidateScore = {
     roomName: candidate.roomName,
     score,
     synergyScore: synergy.score,
@@ -808,6 +812,12 @@ function scoreExpansionCandidate(
     ...(reservation ? { reservation } : {}),
     ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(candidate.scoutOnly === true ? { scoutOnly: true } : {})
+  };
+  const recommendedAction = getPersistedExpansionCandidateRecommendedAction(scoredCandidate);
+  const blockReason = getPersistedExpansionCandidateBlockReason(scoredCandidate, recommendedAction);
+  return {
+    ...scoredCandidate,
+    ...(blockReason ? { blockReason } : {})
   };
 }
 
@@ -838,7 +848,7 @@ function calculateExpansionScore(
   const hostilePenalty = (candidate.hostileCreepCount ?? 0) * 240 + (candidate.hostileStructureCount ?? 0) * 140;
   const unavailablePenalty = evidenceStatus === 'unavailable' ? 2_000 : 0;
   const insufficientEvidencePenalty = evidenceStatus === 'insufficient-evidence' ? 260 : 0;
-  const preconditionPenalty = getExpansionPreconditions(input).length * 120;
+  const preconditionPenalty = getExpansionPreconditions(input, candidate).length * 120;
 
   return Math.round(
     500 +
@@ -1054,7 +1064,10 @@ function getReservationEvidence(
   };
 }
 
-function getExpansionPreconditions(input: ExpansionScoringInput): string[] {
+function getExpansionPreconditions(
+  input: ExpansionScoringInput,
+  candidate?: Pick<ExpansionCandidateInput, 'scoutOnly'>
+): string[] {
   const preconditions: string[] = [];
   if (input.energyCapacityAvailable < TERRITORY_CONTROLLER_BODY_COST) {
     preconditions.push('reach 650 energy capacity for claim body');
@@ -1062,6 +1075,13 @@ function getExpansionPreconditions(input: ExpansionScoringInput): string[] {
 
   if ((input.controllerLevel ?? 0) < MIN_CONTROLLER_LEVEL) {
     preconditions.push('reach controller level 2 before expansion');
+  }
+
+  if (
+    candidate?.scoutOnly === true &&
+    (input.controllerLevel ?? 0) < AUTONOMOUS_TERRITORY_CONTROL_MIN_RCL
+  ) {
+    preconditions.push(SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION);
   }
 
   const ownedRoomCount = getOwnedRoomCount(input);
@@ -1104,7 +1124,14 @@ function getOwnedRoomCount(input: ExpansionScoringInput): number {
 }
 
 function selectPersistableExpansionCandidate(report: ExpansionCandidateReport): ExpansionCandidateScore | null {
-  return report.candidates.find(isViableExpansionCandidate) ?? null;
+  return report.candidates.find(isViableExpansionClaimCandidate) ?? null;
+}
+
+function isViableExpansionClaimCandidate(candidate: ExpansionCandidateScore): boolean {
+  return (
+    candidate.scoutOnly !== true &&
+    isViableExpansionCandidate(candidate)
+  );
 }
 
 function isViableExpansionCandidate(candidate: ExpansionCandidateScore): boolean {
@@ -1184,6 +1211,7 @@ function toPersistedExpansionCandidateMemory(
   rank: number
 ): PersistedExpansionCandidateMemory {
   const recommendedAction = getPersistedExpansionCandidateRecommendedAction(candidate);
+  const blockReason = candidate.blockReason ?? getPersistedExpansionCandidateBlockReason(candidate, recommendedAction);
   return {
     colony,
     roomName: candidate.roomName,
@@ -1195,6 +1223,7 @@ function toPersistedExpansionCandidateMemory(
     adjacentToOwnedRoom: candidate.adjacentToOwnedRoom,
     ...(candidate.scoutOnly === true ? { scoutOnly: true } : {}),
     ...(recommendedAction ? { recommendedAction } : {}),
+    ...(blockReason ? { blockReason } : {}),
     ...(candidate.routeDistance !== undefined ? { routeDistance: candidate.routeDistance } : {}),
     ...(candidate.nearestOwnedRoom ? { nearestOwnedRoom: candidate.nearestOwnedRoom } : {}),
     ...(candidate.nearestOwnedRoomDistance !== undefined
@@ -1223,16 +1252,146 @@ function getPersistedExpansionCandidateRecommendedAction(
   candidate: ExpansionCandidateScore
 ): PersistedExpansionCandidateRecommendedAction | undefined {
   if (candidate.scoutOnly === true) {
+    if (isViableScoutOnlyRemoteCandidate(candidate)) {
+      return 'reserve';
+    }
+
     return candidate.evidenceStatus === 'unavailable' ? undefined : 'scout';
   }
 
-  if (isViableExpansionCandidate(candidate)) {
+  if (isViableExpansionClaimCandidate(candidate)) {
     return 'claim';
   }
 
   return candidate.evidenceStatus === 'insufficient-evidence' && isScoutableNearbyExpansionCandidate(candidate)
     ? 'scout'
     : undefined;
+}
+
+function isViableScoutOnlyRemoteCandidate(candidate: ExpansionCandidateScore): boolean {
+  return (
+    candidate.scoutOnly === true &&
+    candidate.evidenceStatus === 'sufficient' &&
+    hasScoutOnlyRemoteRelevantPrecondition(candidate) === false &&
+    candidate.requiresControllerPressure !== true &&
+    typeof candidate.sourceCount === 'number' &&
+    candidate.sourceCount > 0 &&
+    isAdjacentScoutOnlyRemoteCandidate(candidate)
+  );
+}
+
+function isAdjacentScoutOnlyRemoteCandidate(candidate: ExpansionCandidateScore): boolean {
+  return (
+    candidate.adjacentToOwnedRoom ||
+    (typeof candidate.routeDistance === 'number' && candidate.routeDistance <= 1) ||
+    (typeof candidate.nearestOwnedRoomDistance === 'number' && candidate.nearestOwnedRoomDistance <= 1)
+  );
+}
+
+function hasScoutOnlyRemoteRelevantPrecondition(candidate: ExpansionCandidateScore): boolean {
+  return candidate.preconditions.some(isScoutOnlyRemoteRelevantPrecondition);
+}
+
+function isScoutOnlyRemoteRelevantPrecondition(precondition: string): boolean {
+  return (
+    precondition !== GCL_LIMIT_PRECONDITION &&
+    !precondition.startsWith(ROOM_LIMIT_PRECONDITION_PREFIX)
+  );
+}
+
+function getPersistedExpansionCandidateBlockReason(
+  candidate: ExpansionCandidateScore,
+  recommendedAction: PersistedExpansionCandidateRecommendedAction | undefined
+): TerritoryExpansionCandidateBlockReason | undefined {
+  if (recommendedAction === 'claim' || recommendedAction === 'reserve') {
+    return undefined;
+  }
+
+  if (hasExpansionPrecondition(candidate, SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION)) {
+    return 'controllerLevelLow';
+  }
+
+  if (hasExpansionPrecondition(candidate, 'reach controller level 2 before expansion')) {
+    return 'controllerLevelLow';
+  }
+
+  if (hasExpansionPrecondition(candidate, 'reach 650 energy capacity for claim body')) {
+    return 'energyCapacityLow';
+  }
+
+  if (candidate.preconditions.some((precondition) => precondition.startsWith(ROOM_LIMIT_PRECONDITION_PREFIX))) {
+    return 'roomLimitReached';
+  }
+
+  if (hasExpansionPrecondition(candidate, GCL_LIMIT_PRECONDITION)) {
+    return 'gclInsufficient';
+  }
+
+  if (hasExpansionPrecondition(candidate, 'stabilize home controller downgrade timer')) {
+    return 'homeDowngradeGuard';
+  }
+
+  if (hasExpansionPrecondition(candidate, 'finish active post-claim bootstrap before next expansion')) {
+    return 'postClaimBootstrapActive';
+  }
+
+  if ((candidate.hostileCreepCount ?? 0) > 0 || (candidate.hostileStructureCount ?? 0) > 0) {
+    return 'targetHostile';
+  }
+
+  if (candidate.risks.some((risk) => risk.includes('hostile presence'))) {
+    return 'targetHostile';
+  }
+
+  if (candidate.requiresControllerPressure === true || candidate.risks.includes(FOREIGN_RESERVATION_CONTROLLER_PRESSURE_RISK)) {
+    return 'controllerReserved';
+  }
+
+  if (candidate.risks.some((risk) => risk.includes('enemy-owned controller'))) {
+    return 'controllerOwned';
+  }
+
+  if (candidate.risks.some((risk) => risk.includes('has no controller'))) {
+    return 'controllerMissing';
+  }
+
+  if (candidate.risks.some((risk) => risk.includes('no known route'))) {
+    return 'routeUnavailable';
+  }
+
+  if (typeof candidate.sourceCount !== 'number' || candidate.sourceCount <= 0) {
+    return 'sourcesMissing';
+  }
+
+  if (candidate.risks.some((risk) => risk.includes('source count evidence missing'))) {
+    return 'sourcesMissing';
+  }
+
+  if (candidate.risks.some((risk) => risk.includes('controller evidence missing'))) {
+    return 'controllerMissing';
+  }
+
+  if (candidate.risks.some((risk) => risk.includes('controller proximity evidence missing'))) {
+    return 'controllerRangeMissing';
+  }
+
+  if (candidate.risks.some((risk) => risk.includes('terrain quality evidence missing'))) {
+    return 'terrainMissing';
+  }
+
+  if (candidate.evidenceStatus === 'insufficient-evidence') {
+    return 'insufficientEvidence';
+  }
+
+  if (candidate.evidenceStatus === 'unavailable') {
+    return 'targetUnavailable';
+  }
+
+  return undefined;
+}
+
+function hasExpansionPrecondition(candidate: ExpansionCandidateScore, precondition: string): boolean {
+  return candidate.preconditions.includes(precondition);
 }
 
 function persistNextExpansionTarget(

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -3406,7 +3406,7 @@ function getRecommendedTerritoryIntentAction(
   }
 
   if (
-    isConfiguredScoutOnlyExpansionCandidate(candidate) &&
+    isConfiguredScoutOnlyExpansionTarget(candidate.target) &&
     (recommendation.evidenceStatus !== 'sufficient' ||
       !isAutonomousTerritoryControlAllowedForColonyName(candidate.target.colony))
   ) {
@@ -3448,10 +3448,11 @@ function getRecommendedTerritoryIntentAction(
 }
 
 function isConfiguredScoutOnlyExpansionCandidate(candidate: ScoredTerritoryTarget): boolean {
-  return (
-    candidate.source === 'configuredExpansionScout' &&
-    isConfiguredExpansionScoutOnlyTarget(candidate.target.colony, candidate.target.roomName)
-  );
+  return candidate.source === 'configuredExpansionScout' && isConfiguredScoutOnlyExpansionTarget(candidate.target);
+}
+
+function isConfiguredScoutOnlyExpansionTarget(target: TerritoryTargetMemory): boolean {
+  return isConfiguredExpansionScoutOnlyTarget(target.colony, target.roomName);
 }
 
 function isConfiguredScoutOnlyRemoteConversionCandidate(
@@ -3462,7 +3463,8 @@ function isConfiguredScoutOnlyRemoteConversionCandidate(
     isConfiguredScoutOnlyExpansionCandidate(candidate) &&
     candidate.target.action === 'reserve' &&
     intentAction === 'reserve' &&
-    (candidate.routeDistance === undefined || candidate.routeDistance <= 1)
+    candidate.routeDistance !== undefined &&
+    candidate.routeDistance <= 1
   );
 }
 

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -2818,7 +2818,6 @@ function getAdjacentReserveCandidates(
     const target: TerritoryTargetMemory = { colony: colonyName, roomName, action: 'reserve' };
     if (
       roomName === colonyName ||
-      isConfiguredExpansionScoutOnlyTarget(colonyName, roomName) ||
       existingTargetRooms.has(roomName) ||
       isKnownDeadZoneRoom(roomName) ||
       isTerritoryTargetSuppressed(target, intents, gameTime) ||
@@ -3311,7 +3310,9 @@ function applyOccupationRecommendationScore(
   const commitTarget =
     recommendation.evidenceStatus === 'sufficient' &&
     intentAction !== 'scout' &&
-    (candidate.commitTarget || isScoutedAdjacentControlCandidate(candidate));
+    (candidate.commitTarget ||
+      isScoutedAdjacentControlCandidate(candidate) ||
+      isConfiguredScoutOnlyRemoteConversionCandidate(candidate, intentAction));
   const target = getRecommendedTerritoryTarget(candidate.target, recommendation, intentAction);
   const nextSelection: SelectedTerritoryTarget = {
     target,
@@ -3404,7 +3405,11 @@ function getRecommendedTerritoryIntentAction(
     return candidate.intentAction;
   }
 
-  if (isConfiguredScoutOnlyExpansionCandidate(candidate)) {
+  if (
+    isConfiguredScoutOnlyExpansionCandidate(candidate) &&
+    (recommendation.evidenceStatus !== 'sufficient' ||
+      !isAutonomousTerritoryControlAllowedForColonyName(candidate.target.colony))
+  ) {
     return 'scout';
   }
 
@@ -3446,6 +3451,18 @@ function isConfiguredScoutOnlyExpansionCandidate(candidate: ScoredTerritoryTarge
   return (
     candidate.source === 'configuredExpansionScout' &&
     isConfiguredExpansionScoutOnlyTarget(candidate.target.colony, candidate.target.roomName)
+  );
+}
+
+function isConfiguredScoutOnlyRemoteConversionCandidate(
+  candidate: ScoredTerritoryTarget,
+  intentAction: TerritoryIntentAction
+): boolean {
+  return (
+    isConfiguredScoutOnlyExpansionCandidate(candidate) &&
+    candidate.target.action === 'reserve' &&
+    intentAction === 'reserve' &&
+    (candidate.routeDistance === undefined || candidate.routeDistance <= 1)
   );
 }
 

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -682,6 +682,23 @@ declare global {
     | 'sourcesMissing';
   type TerritoryExpansionCandidateEvidenceStatus = 'sufficient' | 'insufficient-evidence' | 'unavailable';
   type TerritoryExpansionCandidateRecommendedAction = 'claim' | 'reserve' | 'scout';
+  type TerritoryExpansionCandidateBlockReason =
+    | 'insufficientEvidence'
+    | 'targetUnavailable'
+    | 'targetHostile'
+    | 'controllerMissing'
+    | 'controllerOwned'
+    | 'controllerReserved'
+    | 'sourcesMissing'
+    | 'controllerRangeMissing'
+    | 'terrainMissing'
+    | 'energyCapacityLow'
+    | 'controllerLevelLow'
+    | 'homeDowngradeGuard'
+    | 'postClaimBootstrapActive'
+    | 'gclInsufficient'
+    | 'roomLimitReached'
+    | 'routeUnavailable';
   type TerritoryExpansionPipelineStage = 'scouting' | 'reserving' | 'claiming' | 'bootstrapping';
   type TerritoryExpansionPipelineStatus = 'active' | 'aborted' | 'completed';
   type TerritoryExpansionClaimState = 'scouted' | 'claiming' | 'claimed';
@@ -935,6 +952,7 @@ declare global {
     adjacentToOwnedRoom: boolean;
     scoutOnly?: boolean;
     recommendedAction?: TerritoryExpansionCandidateRecommendedAction;
+    blockReason?: TerritoryExpansionCandidateBlockReason;
     routeDistance?: number;
     nearestOwnedRoom?: string;
     nearestOwnedRoomDistance?: number;

--- a/prod/test/expansionScoring.test.ts
+++ b/prod/test/expansionScoring.test.ts
@@ -2,6 +2,7 @@ import type { ColonySnapshot } from '../src/colony/colonyRegistry';
 import {
   buildRuntimeExpansionCandidateReport,
   maxRoomsForRcl,
+  persistExpansionCandidateScores,
   refreshNextExpansionTargetSelection,
   scoreExpansionCandidates,
   selectExpansionScoutTargets,
@@ -288,6 +289,182 @@ describe('next expansion scoring', () => {
     expect(report.candidates.find((candidate) => candidate.roomName === 'W3N1')).toMatchObject({
       evidenceStatus: 'unavailable',
       risks: ['enemy-owned controller cannot be claimed safely']
+    });
+  });
+
+  it('promotes sufficient safe E29N56 scout-only evidence to reserve at RCL5', () => {
+    const report = scoreExpansionCandidates(
+      makeInput(
+        [
+          makeCandidate({
+            roomName: 'E29N56',
+            scoutOnly: true,
+            controllerId: 'controller-E29N56' as Id<StructureController>,
+            sourceCount: 1,
+            sourceAccessPoints: 1,
+            mineral: { mineralType: 'H' }
+          })
+        ],
+        {
+          colonyName: 'E29N55',
+          controllerLevel: 5,
+          energyCapacityAvailable: 1_800
+        }
+      )
+    );
+
+    expect(report.next).toMatchObject({
+      roomName: 'E29N56',
+      evidenceStatus: 'sufficient',
+      scoutOnly: true,
+      sourceCount: 1,
+      sourceAccessPoints: 1
+    });
+
+    persistExpansionCandidateScores('E29N55', report, 1_281);
+
+    expect(getExpansionCandidateMemory()[0]).toMatchObject({
+      colony: 'E29N55',
+      roomName: 'E29N56',
+      evidenceStatus: 'sufficient',
+      scoutOnly: true,
+      recommendedAction: 'reserve',
+      visible: true,
+      updatedAt: 1_281
+    });
+    expect(getExpansionCandidateMemory()[0]).not.toHaveProperty('blockReason');
+    expect(Memory.territory?.targets).toBeUndefined();
+  });
+
+  it('holds sufficient E29N56 scout-only evidence below RCL5 with a controller-level block reason', () => {
+    const report = scoreExpansionCandidates(
+      makeInput(
+        [
+          makeCandidate({
+            roomName: 'E29N56',
+            scoutOnly: true,
+            controllerId: 'controller-E29N56' as Id<StructureController>,
+            sourceCount: 1,
+            sourceAccessPoints: 1,
+            mineral: { mineralType: 'H' }
+          })
+        ],
+        {
+          colonyName: 'E29N55',
+          controllerLevel: 4,
+          energyCapacityAvailable: 1_800
+        }
+      )
+    );
+
+    persistExpansionCandidateScores('E29N55', report, 1_282);
+
+    expect(getExpansionCandidateMemory()[0]).toMatchObject({
+      colony: 'E29N55',
+      roomName: 'E29N56',
+      scoutOnly: true,
+      recommendedAction: 'scout',
+      blockReason: 'controllerLevelLow'
+    });
+  });
+
+  it.each([
+    [
+      'hostiles',
+      makeCandidate({
+        roomName: 'E29N56',
+        scoutOnly: true,
+        hostileCreepCount: 1,
+        sourceCount: 1,
+        sourceAccessPoints: 1
+      }),
+      undefined,
+      'targetHostile'
+    ],
+    [
+      'foreign reservation',
+      makeCandidate({
+        roomName: 'E29N56',
+        scoutOnly: true,
+        controller: { reservationUsername: 'enemy', reservationTicksToEnd: 4_000 },
+        sourceCount: 1,
+        sourceAccessPoints: 1
+      }),
+      'scout',
+      'controllerReserved'
+    ],
+    [
+      'foreign ownership',
+      makeCandidate({
+        roomName: 'E29N56',
+        scoutOnly: true,
+        controller: { ownerUsername: 'enemy' },
+        sourceCount: 1,
+        sourceAccessPoints: 1
+      }),
+      undefined,
+      'controllerOwned'
+    ]
+  ] as const)(
+    'holds E29N56 scout-only evidence when %s is present',
+    (_label, candidate, recommendedAction, blockReason) => {
+      const report = scoreExpansionCandidates(
+        makeInput([candidate], {
+          colonyName: 'E29N55',
+          controllerLevel: 5,
+          energyCapacityAvailable: 1_800
+        })
+      );
+
+      persistExpansionCandidateScores('E29N55', report, 1_283);
+
+      expect(getExpansionCandidateMemory()[0]).toMatchObject({
+        colony: 'E29N55',
+        roomName: 'E29N56',
+        scoutOnly: true,
+        blockReason
+      });
+      if (recommendedAction) {
+        expect(getExpansionCandidateMemory()[0]).toHaveProperty('recommendedAction', recommendedAction);
+      } else {
+        expect(getExpansionCandidateMemory()[0]).not.toHaveProperty('recommendedAction');
+      }
+    }
+  );
+
+  it.each([
+    ['low energy capacity', { energyCapacityAvailable: 300 }, 'energyCapacityLow'],
+    ['downgrade guard', { ticksToDowngrade: 100 }, 'homeDowngradeGuard'],
+    ['active post-claim bootstrap', { activePostClaimBootstrapCount: 1 }, 'postClaimBootstrapActive']
+  ] as const)('holds E29N56 scout-only evidence on %s', (_label, inputOverrides, blockReason) => {
+    const report = scoreExpansionCandidates(
+      makeInput(
+        [
+          makeCandidate({
+            roomName: 'E29N56',
+            scoutOnly: true,
+            controllerId: 'controller-E29N56' as Id<StructureController>,
+            sourceCount: 1,
+            sourceAccessPoints: 1
+          })
+        ],
+        {
+          colonyName: 'E29N55',
+          controllerLevel: 5,
+          energyCapacityAvailable: 1_800,
+          ...inputOverrides
+        }
+      )
+    );
+
+    persistExpansionCandidateScores('E29N55', report, 1_284);
+
+    expect(getExpansionCandidateMemory()[0]).toMatchObject({
+      colony: 'E29N55',
+      roomName: 'E29N56',
+      scoutOnly: true,
+      recommendedAction: 'scout',
+      blockReason
     });
   });
 
@@ -1617,27 +1794,33 @@ function makeRoomScoutReport(
 }
 
 function makeSafeColony({
-  controllerLevel = 6
+  roomName = 'W1N1',
+  controllerLevel = 6,
+  energyAvailable = 650,
+  energyCapacityAvailable = 650
 }: {
+  roomName?: string;
   controllerLevel?: number;
+  energyAvailable?: number;
+  energyCapacityAvailable?: number;
 } = {}): ColonySnapshot {
   const room = {
-    name: 'W1N1',
+    name: roomName,
     controller: {
       my: true,
       owner: { username: 'me' },
       level: controllerLevel,
       ticksToDowngrade: 10_000
     } as StructureController,
-    energyAvailable: 650,
-    energyCapacityAvailable: 650
+    energyAvailable,
+    energyCapacityAvailable
   } as unknown as Room;
 
   return {
     room,
     spawns: [],
-    energyAvailable: 650,
-    energyCapacityAvailable: 650
+    energyAvailable,
+    energyCapacityAvailable
   };
 }
 

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -957,9 +957,6 @@ describe('planTerritoryIntent', () => {
     });
     const gameTime = 6_802;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
-      runtime: {
-        currentRoomName: 'E29N55'
-      },
       territory: {
         scoutIntel: {
           'E29N55>E29N56': makeScoutIntel('E29N56', gameTime - 1, {
@@ -991,10 +988,20 @@ describe('planTerritoryIntent', () => {
     );
 
     expect(plan?.action).toBe('scout');
+    expect(plan?.targetRoom).toBe('E29N56');
     expect(Memory.territory?.targets).toBeUndefined();
     expect(
       (Memory.territory?.intents ?? []).filter((intent) => intent.action === 'claim' || intent.action === 'reserve')
     ).toEqual([]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'E29N55',
+        targetRoom: 'E29N56',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: gameTime
+      }
+    ]);
   });
 
   it.each([
@@ -1038,9 +1045,6 @@ describe('planTerritoryIntent', () => {
     });
     const gameTime = 6_803;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
-      runtime: {
-        currentRoomName: 'E29N55'
-      },
       territory: {
         scoutIntel: {
           'E29N55>E29N56': makeScoutIntel('E29N56', gameTime - 1, {
@@ -1067,18 +1071,9 @@ describe('planTerritoryIntent', () => {
 
     const plan = planTerritoryIntent(colony, { worker: 4, claimer: 0, claimersByTargetRoom: {} }, 4, gameTime);
 
-    expect(plan).not.toEqual(
-      expect.objectContaining({
-        targetRoom: 'E29N56',
-        action: 'reserve'
-      })
-    );
+    expect(plan).toBeNull();
     expect(Memory.territory?.targets).toBeUndefined();
-    expect(
-      (Memory.territory?.intents ?? []).filter(
-        (intent) => intent.targetRoom === 'E29N56' && intent.action === 'reserve'
-      )
-    ).toEqual([]);
+    expect(Memory.territory?.intents).toBeUndefined();
   });
 
   it.each([

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -861,6 +861,289 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('converts fresh safe E29N56 scout-only evidence into a reserve target at RCL5', () => {
+    const colony = makeSafeColony({
+      roomName: 'E29N55',
+      controller: {
+        my: true,
+        owner: { username: 'me' },
+        level: 5,
+        ticksToDowngrade: 10_000
+      } as StructureController,
+      energyAvailable: 1_800,
+      energyCapacityAvailable: 1_800
+    });
+    const gameTime = 6_801;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      runtime: {
+        currentRoomName: 'E29N55'
+      },
+      territory: {
+        scoutIntel: {
+          'E29N55>E29N56': makeScoutIntel('E29N56', gameTime - 1, {
+            colony: 'E29N55',
+            controller: { id: 'controller-E29N56' as Id<StructureController>, my: false },
+            sourceIds: ['source1'],
+            sourceCount: 1,
+            sourceAccessPoints: 1,
+            mineral: { id: 'mineral-E29N56', mineralType: 'H' }
+          })
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: gameTime,
+      rooms: {
+        E29N55: colony.room
+      },
+      map: {
+        describeExits: jest.fn((roomName: string) =>
+          roomName === 'E29N55' ? { '1': 'E29N56', '3': 'E30N55', '5': 'E29N54', '7': 'E28N55' } : {}
+        ),
+        findRoute: jest.fn((_fromRoom: string, toRoom: string) => [{ exit: 1, room: toRoom }])
+      } as unknown as GameMap
+    };
+
+    expect(
+      planTerritoryIntent(
+        colony,
+        {
+          worker: 4,
+          claimer: 0,
+          scout: 2,
+          scoutsByTargetRoom: { E29N54: 1, E28N55: 1 },
+          claimersByTargetRoom: {}
+        },
+        4,
+        gameTime
+      )
+    ).toEqual({
+      colony: 'E29N55',
+      targetRoom: 'E29N56',
+      action: 'reserve',
+      controllerId: 'controller-E29N56'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'E29N55',
+        roomName: 'E29N56',
+        action: 'reserve',
+        controllerId: 'controller-E29N56'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'E29N55',
+        targetRoom: 'E29N56',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: gameTime,
+        controllerId: 'controller-E29N56'
+      }
+    ]);
+  });
+
+  it('keeps fresh safe E29N56 scout-only evidence held below RCL5', () => {
+    const colony = makeSafeColony({
+      roomName: 'E29N55',
+      controller: {
+        my: true,
+        owner: { username: 'me' },
+        level: 4,
+        ticksToDowngrade: 10_000
+      } as StructureController,
+      energyAvailable: 1_800,
+      energyCapacityAvailable: 1_800
+    });
+    const gameTime = 6_802;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      runtime: {
+        currentRoomName: 'E29N55'
+      },
+      territory: {
+        scoutIntel: {
+          'E29N55>E29N56': makeScoutIntel('E29N56', gameTime - 1, {
+            colony: 'E29N55',
+            controller: { id: 'controller-E29N56' as Id<StructureController>, my: false },
+            sourceIds: ['source1'],
+            sourceCount: 1,
+            sourceAccessPoints: 1
+          })
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: gameTime,
+      rooms: {
+        E29N55: colony.room
+      },
+      map: {
+        describeExits: jest.fn(() => ({ '1': 'E29N56' })),
+        findRoute: jest.fn((_fromRoom: string, toRoom: string) => [{ exit: 1, room: toRoom }])
+      } as unknown as GameMap
+    };
+
+    const plan = planTerritoryIntent(
+      colony,
+      { worker: 4, claimer: 0, claimersByTargetRoom: {} },
+      4,
+      gameTime
+    );
+
+    expect(plan?.action).toBe('scout');
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(
+      (Memory.territory?.intents ?? []).filter((intent) => intent.action === 'claim' || intent.action === 'reserve')
+    ).toEqual([]);
+  });
+
+  it.each([
+    [
+      'hostile creep',
+      {
+        hostileCreepCount: 1
+      }
+    ],
+    [
+      'foreign reservation',
+      {
+        controller: {
+          id: 'controller-E29N56' as Id<StructureController>,
+          my: false,
+          reservationUsername: 'enemy'
+        }
+      }
+    ],
+    [
+      'foreign ownership',
+      {
+        controller: {
+          id: 'controller-E29N56' as Id<StructureController>,
+          my: false,
+          ownerUsername: 'enemy'
+        }
+      }
+    ]
+  ] as const)('does not convert E29N56 scout-only evidence when %s is present', (_label, intelOverrides) => {
+    const colony = makeSafeColony({
+      roomName: 'E29N55',
+      controller: {
+        my: true,
+        owner: { username: 'me' },
+        level: 5,
+        ticksToDowngrade: 10_000
+      } as StructureController,
+      energyAvailable: 1_800,
+      energyCapacityAvailable: 1_800
+    });
+    const gameTime = 6_803;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      runtime: {
+        currentRoomName: 'E29N55'
+      },
+      territory: {
+        scoutIntel: {
+          'E29N55>E29N56': makeScoutIntel('E29N56', gameTime - 1, {
+            colony: 'E29N55',
+            controller: { id: 'controller-E29N56' as Id<StructureController>, my: false },
+            sourceIds: ['source1'],
+            sourceCount: 1,
+            sourceAccessPoints: 1,
+            ...intelOverrides
+          })
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: gameTime,
+      rooms: {
+        E29N55: colony.room
+      },
+      map: {
+        describeExits: jest.fn(() => ({ '1': 'E29N56' })),
+        findRoute: jest.fn((_fromRoom: string, toRoom: string) => [{ exit: 1, room: toRoom }])
+      } as unknown as GameMap
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 4, claimer: 0, claimersByTargetRoom: {} }, 4, gameTime);
+
+    expect(plan).not.toEqual(
+      expect.objectContaining({
+        targetRoom: 'E29N56',
+        action: 'reserve'
+      })
+    );
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(
+      (Memory.territory?.intents ?? []).filter(
+        (intent) => intent.targetRoom === 'E29N56' && intent.action === 'reserve'
+      )
+    ).toEqual([]);
+  });
+
+  it.each([
+    [
+      'low energy capacity',
+      {
+        energyAvailable: 300,
+        energyCapacityAvailable: 300
+      }
+    ],
+    [
+      'downgrade guard',
+      {
+        energyAvailable: 1_800,
+        energyCapacityAvailable: 1_800,
+        ticksToDowngrade: TERRITORY_DOWNGRADE_GUARD_TICKS
+      }
+    ]
+  ] as const)('holds E29N56 scout-only conversion when the home %s is unhealthy', (_label, homeState) => {
+    const ticksToDowngrade = 'ticksToDowngrade' in homeState ? homeState.ticksToDowngrade : 10_000;
+    const colony = makeSafeColony({
+      roomName: 'E29N55',
+      controller: {
+        my: true,
+        owner: { username: 'me' },
+        level: 5,
+        ticksToDowngrade
+      } as StructureController,
+      energyAvailable: homeState.energyAvailable,
+      energyCapacityAvailable: homeState.energyCapacityAvailable
+    });
+    const gameTime = 6_804;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      runtime: {
+        currentRoomName: 'E29N55'
+      },
+      territory: {
+        scoutIntel: {
+          'E29N55>E29N56': makeScoutIntel('E29N56', gameTime - 1, {
+            colony: 'E29N55',
+            controller: { id: 'controller-E29N56' as Id<StructureController>, my: false },
+            sourceIds: ['source1'],
+            sourceCount: 1,
+            sourceAccessPoints: 1
+          })
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: gameTime,
+      rooms: {
+        E29N55: colony.room
+      },
+      map: {
+        describeExits: jest.fn(() => ({ '1': 'E29N56' })),
+        findRoute: jest.fn((_fromRoom: string, toRoom: string) => [{ exit: 1, room: toRoom }])
+      } as unknown as GameMap
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 4, claimer: 0, claimersByTargetRoom: {} }, 4, gameTime)
+    ).toBeNull();
+    expect(Memory.territory?.targets).toBeUndefined();
+  });
+
   it('refreshes stale expansion candidate scout intel before generic adjacent scouting', () => {
     const colony = makeSafeColony();
     const gameTime = 2_000;


### PR DESCRIPTION
## Summary
- converts sufficient safe E29N56 scout evidence into a bounded reserve/remote-mining intent path instead of leaving the room scout-only indefinitely
- adds explicit block-reason telemetry for RCL, safety, buffer/CPU/survival, and hostile/foreign-control holds
- preserves scout concurrency behavior and the exact controller sign contract (`by Hermes Screeps Project`)

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (101 suites, 1997 tests)
- `cd prod && npm run build`

## Safety
- no proactive player attacks
- holds on hostiles, ownership/foreign reservations, insufficient evidence, unhealthy home guardrails, or below-RCL5 state
- generated `prod/dist/main.js` rebuilt from source

Fixes #1281
