### PR TITLE
fix(rl): inject candidate parameters in simulator runtime

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -400,40 +400,58 @@ def _normalized_inline_strategy_variant_config(variant_id: str, raw_config: Mapp
     return config
 
 
+def _scale_environment_strategy_variant_config(
+    variant_id: str,
+    base_config: Mapping[str, Any],
+    *,
+    rewrite_label: bool = True,
+) -> JsonObject:
+    base_variant_id = scale_environment_base_variant_id(variant_id)
+    environment_index = scale_environment_index(variant_id)
+    config = copy.deepcopy(dict(base_config))
+    config["id"] = variant_id
+    if rewrite_label or not isinstance(config.get("label"), str) or not config["label"]:
+        base_label = config.get("label") if isinstance(config.get("label"), str) else base_variant_id
+        config["label"] = (
+            f"{base_label} scale environment {environment_index}"
+            if environment_index is not None
+            else f"{base_label} scale environment"
+        )
+    config["sourceVariantId"] = base_variant_id
+    config["scaleEnvironment"] = {
+        "enabled": True,
+        "environmentIndex": environment_index,
+        "baseVariantId": base_variant_id,
+        "purpose": "unique simulator environment row for concurrent E2 scale validation",
+    }
+    config["safety"] = {
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+    }
+    return config
+
+
 def strategy_variant_config_by_id(
     variant_id: str,
     variant_configs: Mapping[str, JsonObject] | None = None,
 ) -> JsonObject:
     """Return bounded public config for a strategy variant id."""
     base_variant_id = scale_environment_base_variant_id(variant_id)
-    if base_variant_id != variant_id:
-        base_config = strategy_variant_config_by_id(base_variant_id, variant_configs=variant_configs)
-        environment_index = scale_environment_index(variant_id)
-        base_label = base_config.get("label") if isinstance(base_config.get("label"), str) else base_variant_id
-        config = copy.deepcopy(base_config)
-        config["id"] = variant_id
-        config["label"] = (
-            f"{base_label} scale environment {environment_index}"
-            if environment_index is not None
-            else f"{base_label} scale environment"
-        )
-        config["sourceVariantId"] = base_variant_id
-        config["scaleEnvironment"] = {
-            "enabled": True,
-            "environmentIndex": environment_index,
-            "baseVariantId": base_variant_id,
-            "purpose": "unique simulator environment row for concurrent E2 scale validation",
-        }
-        config["safety"] = {
-            "liveEffect": False,
-            "officialMmoWrites": False,
-            "officialMmoWritesAllowed": False,
-        }
-        return config
     if variant_configs is not None:
         override = variant_configs.get(variant_id)
         if isinstance(override, dict):
-            return _normalized_inline_strategy_variant_config(variant_id, override)
+            config = _normalized_inline_strategy_variant_config(variant_id, override)
+            if base_variant_id != variant_id:
+                return _scale_environment_strategy_variant_config(
+                    variant_id,
+                    config,
+                    rewrite_label=False,
+                )
+            return config
+    if base_variant_id != variant_id:
+        base_config = strategy_variant_config_by_id(base_variant_id, variant_configs=variant_configs)
+        return _scale_environment_strategy_variant_config(variant_id, base_config)
     for config in DEFAULT_STRATEGY_VARIANT_CONFIGS:
         if config.get("id") == variant_id:
             return copy.deepcopy(config)

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1458,6 +1458,43 @@ cli:
         self.assertFalse(config["safety"]["liveEffect"])
         self.assertFalse(config["safety"]["officialMmoWrites"])
 
+    def test_inline_scale_environment_variant_config_preserves_runtime_parameters(self) -> None:
+        base_variant_id = "construction-priority.pg.territory-seed.v1"
+        scale_variant_id = f"{base_variant_id}.scale-env-01"
+        parameters = {
+            "baseScoreWeight": 1,
+            "territorySignalWeight": 22,
+            "resourceSignalWeight": 3,
+            "killSignalWeight": 5,
+            "riskPenalty": 4,
+        }
+
+        config = harness.strategy_variant_config_by_id(
+            scale_variant_id,
+            variant_configs={
+                scale_variant_id: {
+                    "id": scale_variant_id,
+                    "title": "Policy-gradient territory seed scale environment 1",
+                    "candidatePolicyId": "construction-priority.pg.territory-seed.v1",
+                    "family": "construction-priority",
+                    "parameters": parameters,
+                }
+            },
+        )
+        injection = harness.runtime_parameter_injection_for_variant(scale_variant_id, config)
+
+        self.assertEqual(config["sourceVariantId"], base_variant_id)
+        self.assertEqual(config["scaleEnvironment"]["environmentIndex"], 1)
+        self.assertEqual(config["parameters"], parameters)
+        self.assertEqual(config["defaultValues"], parameters)
+        self.assertEqual(injection["status"], "prepared")
+        self.assertEqual(injection["candidateParameterScope"], "runtime_injected")
+        self.assertEqual(injection["parameters"], parameters)
+        self.assertNotIn("reason", injection)
+        self.assertFalse(injection["liveEffect"])
+        self.assertFalse(injection["officialMmoWrites"])
+        self.assertFalse(injection["officialMmoWritesAllowed"])
+
     def test_runtime_parameter_injection_changes_private_runtime_code_input(self) -> None:
         base_code = (
             '"use strict";\n'

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -175,7 +175,10 @@ class MockSimulator:
         for variant_id in kwargs["variants"]:
             result = copy.deepcopy(self.results_by_variant[variant_id])
             if self.inject_runtime_parameters:
-                variant_config = kwargs["variant_configs"][variant_id]
+                variant_config = runner.simulator_harness.strategy_variant_config_by_id(
+                    variant_id,
+                    variant_configs=kwargs["variant_configs"],
+                )
                 injection = runner.simulator_harness.runtime_parameter_injection_for_variant(variant_id, variant_config)
                 code_text = runner.simulator_harness.apply_runtime_parameter_injection_to_code(
                     "\n".join(
@@ -195,7 +198,7 @@ class MockSimulator:
                     code_text=code_text,
                 )
                 evaluated_parameters = copy.deepcopy(
-                    self.evaluated_parameters_by_variant.get(variant_id, variant_config["parameters"])
+                    self.evaluated_parameters_by_variant.get(variant_id, variant_config.get("parameters", {}))
                 )
                 consumption_evidence = {
                     "type": runner.simulator_harness.RUNTIME_PARAMETER_CONSUMPTION_TYPE,
@@ -2533,6 +2536,82 @@ export const STRATEGY_REGISTRY = [
         self.assertFalse(update["liveEffect"])
         self.assertFalse(update["officialMmoWrites"])
         self.assertFalse(update["officialMmoWritesAllowed"])
+
+    def test_scaled_policy_gradient_runtime_injection_uses_card_candidate_parameters(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-scaled-injected",
+            code_commit="f" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-17T06:35:00Z",
+            simulation_ticks=100,
+            simulation_repetitions=1,
+        )
+        variant_ids = [variant["id"] for variant in card["strategy_variants"]]
+        expanded_ids = runner.simulator_harness.expand_scale_environment_variants(variant_ids, 5)
+        card["simulation"]["workers"] = 5
+        card["simulation"]["scale_environments"] = 5
+        card["simulation"]["min_concurrent_environments"] = 5
+        start = tick(1, [room("W1N1", energy=100)])
+        simulator_results: dict[str, JsonObject] = {}
+        for variant_id in expanded_ids:
+            base_id = runner.simulator_harness.scale_environment_base_variant_id(variant_id)
+            if base_id.endswith("territory-seed.v1"):
+                simulator_results[variant_id] = variant_result(
+                    variant_id,
+                    [start, tick(2, [room("W1N1", energy=150), room("W1N2", energy=100)])],
+                )
+            elif base_id.endswith("resource-seed.v1"):
+                simulator_results[variant_id] = variant_result(
+                    variant_id,
+                    [start, tick(2, [room("W1N1", energy=2400, harvested=1000)])],
+                )
+            else:
+                simulator_results[variant_id] = variant_result(
+                    variant_id,
+                    [start, tick(2, [room("W1N1", energy=200)])],
+                )
+        simulator = MockSimulator(simulator_results, inject_runtime_parameters=True)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                out_dir,
+                report_id="policy-gradient-scaled-injected",
+                generated_at="2026-05-17T06:40:00Z",
+                simulator_runner=simulator,
+            )
+
+        scaled_variant_id = expanded_ids[0]
+        scaled_config = runner.simulator_harness.strategy_variant_config_by_id(
+            scaled_variant_id,
+            variant_configs=simulator.calls[0]["variant_configs"],
+        )
+        base_variant_id = runner.simulator_harness.scale_environment_base_variant_id(scaled_variant_id)
+        base_parameters = next(
+            variant["parameters"]
+            for variant in card["strategy_variants"]
+            if variant["id"] == base_variant_id
+        )
+        self.assertEqual(simulator.calls[0]["variants"], expanded_ids)
+        self.assertEqual(scaled_config["parameters"], base_parameters)
+        self.assertEqual(scaled_config["scaleEnvironment"]["baseVariantId"], base_variant_id)
+        self.assertEqual(report["runtimeParameterInjection"]["status"], "injected")
+        self.assertTrue(report["runtimeParameterInjection"]["runtimeParameterInjection"])
+        self.assertEqual(report["runtimeParameterInjection"]["candidateParameterScope"], "runtime_injected")
+        self.assertEqual(report["runtimeParameterInjection"]["injectedVariantCount"], len(expanded_ids))
+        self.assertTrue(report["runtimeParameterInjection"]["policyUpdateEligible"])
+        self.assertEqual(report["policyGradient"]["runner_support"]["candidate_parameter_scope"], "runtime_injected")
+        self.assertTrue(report["policyUpdate"]["parameterEvidence"]["runtimeParameterInjection"])
+        self.assertTrue(report["policyUpdate"]["parameterEvidence"]["policyUpdateEligible"])
+        self.assertEqual(report["policyUpdateIterations"], 1)
+        self.assertTrue(report["trueGradient"])
+        self.assertFalse(report["policyUpdate"]["liveEffect"])
+        self.assertFalse(report["policyUpdate"]["officialMmoWrites"])
+        self.assertFalse(report["policyUpdate"]["officialMmoWritesAllowed"])
 
     def test_scorecard_materialization_error_blocks_scorecard_without_crashing(self) -> None:
         card = card_helper.build_card(

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -197,9 +197,15 @@ class MockSimulator:
                     injection,
                     code_text=code_text,
                 )
-                evaluated_parameters = copy.deepcopy(
-                    self.evaluated_parameters_by_variant.get(variant_id, variant_config.get("parameters", {}))
-                )
+                if variant_id in self.evaluated_parameters_by_variant:
+                    evaluated_parameters = copy.deepcopy(self.evaluated_parameters_by_variant[variant_id])
+                else:
+                    parameters = variant_config.get("parameters")
+                    if not isinstance(parameters, dict) or not parameters:
+                        raise AssertionError(
+                            f"runtime injection test expected parameters for {variant_id}, got {variant_config!r}"
+                        )
+                    evaluated_parameters = copy.deepcopy(parameters)
                 consumption_evidence = {
                     "type": runner.simulator_harness.RUNTIME_PARAMETER_CONSUMPTION_TYPE,
                     "consumerMarker": runner.simulator_harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER,
@@ -2585,20 +2591,34 @@ export const STRATEGY_REGISTRY = [
                 simulator_runner=simulator,
             )
 
-        scaled_variant_id = expanded_ids[0]
-        scaled_config = runner.simulator_harness.strategy_variant_config_by_id(
-            scaled_variant_id,
-            variant_configs=simulator.calls[0]["variant_configs"],
-        )
-        base_variant_id = runner.simulator_harness.scale_environment_base_variant_id(scaled_variant_id)
-        base_parameters = next(
-            variant["parameters"]
-            for variant in card["strategy_variants"]
-            if variant["id"] == base_variant_id
-        )
         self.assertEqual(simulator.calls[0]["variants"], expanded_ids)
-        self.assertEqual(scaled_config["parameters"], base_parameters)
-        self.assertEqual(scaled_config["scaleEnvironment"]["baseVariantId"], base_variant_id)
+        expected_parameters_by_base_id = {
+            candidate["strategyVariantId"]: candidate["parameters"]
+            for candidate in card["policy_gradient"]["candidate_parameter_vectors"]
+        }
+        expected_hashes_by_base_id = {
+            base_id: runner.canonical_hash(parameters)
+            for base_id, parameters in expected_parameters_by_base_id.items()
+        }
+        observed_hashes_by_base_id: dict[str, str] = {}
+        for scaled_variant_id in expanded_ids:
+            scaled_config = runner.simulator_harness.strategy_variant_config_by_id(
+                scaled_variant_id,
+                variant_configs=simulator.calls[0]["variant_configs"],
+            )
+            base_variant_id = runner.simulator_harness.scale_environment_base_variant_id(scaled_variant_id)
+            self.assertIn(base_variant_id, expected_parameters_by_base_id)
+            self.assertEqual(scaled_config["parameters"], expected_parameters_by_base_id[base_variant_id])
+            self.assertEqual(
+                runner.canonical_hash(scaled_config["parameters"]),
+                expected_hashes_by_base_id[base_variant_id],
+            )
+            self.assertEqual(scaled_config["scaleEnvironment"]["baseVariantId"], base_variant_id)
+            observed_hashes_by_base_id[base_variant_id] = runner.canonical_hash(
+                scaled_config["parameters"]
+            )
+        self.assertEqual(observed_hashes_by_base_id, expected_hashes_by_base_id)
+        self.assertEqual(len(set(expected_hashes_by_base_id.values())), len(expected_hashes_by_base_id))
         self.assertEqual(report["runtimeParameterInjection"]["status"], "injected")
         self.assertTrue(report["runtimeParameterInjection"]["runtimeParameterInjection"])
         self.assertEqual(report["runtimeParameterInjection"]["candidateParameterScope"], "runtime_injected")


### PR DESCRIPTION
## Summary
- wires policy-gradient candidate parameter vectors into simulator runtime variant metadata before private/offline runs
- records runtime parameter injection evidence in harness reports so policy updates can distinguish true runtime candidates from metadata-only cards
- adds focused simulator/training-runner tests for injected parameters, metadata-only fallback, and policy-update eligibility

## Safety
- Offline/private simulator path only.
- Preserves `liveEffect=false`, `officialMmoWrites=false`, `officialMmoWritesAllowed=false` safety boundaries.
- No paid Tencent, SSH, deploy, or official MMO writes were run by this PR.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py`
- `python3 -m pytest scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py -q` — 168 passed, 23 subtests passed in 6.23s

Fixes #1283
