### PR TITLE
fix(territory): convert E29N56 scout intel to remote intent

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3883,7 +3883,8 @@ function normalizeTerritoryIntent(rawIntent) {
     ...rawIntent.requiresControllerPressure === true ? { requiresControllerPressure: true } : {},
     ...followUp ? { followUp } : {},
     ...isPositiveFiniteNumber(rawIntent.postClaimBootstrapReserveEnergy) ? { postClaimBootstrapReserveEnergy: Math.floor(rawIntent.postClaimBootstrapReserveEnergy) } : {},
-    ...suspended ? { suspended } : {}
+    ...suspended ? { suspended } : {},
+    ...isTerritoryExpansionCandidateBlockReason(rawIntent.blockReason) ? { blockReason: rawIntent.blockReason } : {}
   };
 }
 function normalizeTerritoryIntentSuspension(rawSuspension) {
@@ -3924,6 +3925,9 @@ function isTerritoryIntentStatus(status) {
 }
 function isTerritoryIntentSuppressionReason(reason) {
   return reason === "deadZoneTarget" || reason === "deadZoneRoute" || reason === "controllerLevel";
+}
+function isTerritoryExpansionCandidateBlockReason(reason) {
+  return reason === "insufficientEvidence" || reason === "targetUnavailable" || reason === "targetHostile" || reason === "controllerMissing" || reason === "controllerOwned" || reason === "controllerReserved" || reason === "sourcesMissing" || reason === "controllerRangeMissing" || reason === "terrainMissing" || reason === "energyCapacityLow" || reason === "energyBufferLow" || reason === "cpuBucketLow" || reason === "homeAlertActive" || reason === "controllerLevelLow" || reason === "homeDowngradeGuard" || reason === "postClaimBootstrapActive" || reason === "gclInsufficient" || reason === "roomLimitReached" || reason === "routeUnavailable";
 }
 function isTerritoryFollowUpSource(source) {
   return source === "satisfiedClaimAdjacent" || source === "satisfiedReserveAdjacent" || source === "activeReserveAdjacent";
@@ -16757,6 +16761,7 @@ var TERRITORY_ROUTE_DISTANCE_SEPARATOR3 = ">";
 var TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET = 2;
 var TERRITORY_SCOUT_BODY_COST2 = 50;
 var TERRITORY_SCOUT_INTEL_PLANNING_TTL = 1e4;
+var SCOUT_ONLY_REMOTE_MIN_CPU_BUCKET = 500;
 var OCCUPATION_RECOMMENDATION_TARGET_CREATOR2 = "occupationRecommendation";
 var REMOTE_MINING_SOURCE_CONTAINER_MIN_RCL = 0;
 var MAX_CONTROLLER_LEVEL = 8;
@@ -16790,7 +16795,8 @@ function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime, options
     ...target.createdBy ? { createdBy: target.createdBy } : {},
     ...selection.requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...selection.followUp ? { followUp: selection.followUp } : {},
-    ...selection.postClaimBootstrapReserveEnergy ? { postClaimBootstrapReserveEnergy: selection.postClaimBootstrapReserveEnergy } : {}
+    ...selection.postClaimBootstrapReserveEnergy ? { postClaimBootstrapReserveEnergy: selection.postClaimBootstrapReserveEnergy } : {},
+    ...selection.blockReason ? { blockReason: selection.blockReason } : {}
   };
   if (selection.routeDistance !== void 0) {
     territoryIntentRouteDistances.set(plan, selection.routeDistance);
@@ -17821,6 +17827,7 @@ function toSelectedTerritoryTarget(candidate, routeDistanceLookupContext) {
     ...candidate.routeDistance !== void 0 ? { routeDistance: candidate.routeDistance } : {},
     ...candidate.recoveredFollowUp ? { recoveredFollowUp: true } : {},
     ...typeof candidate.recoveredFollowUpSuppressedAt === "number" ? { recoveredFollowUpSuppressedAt: candidate.recoveredFollowUpSuppressedAt } : {},
+    ...candidate.blockReason ? { blockReason: candidate.blockReason } : {},
     ...routeDistanceLookupContext ? { routeDistanceLookupContext } : {}
   } : null;
 }
@@ -18766,22 +18773,51 @@ function applyOccupationRecommendationScores(colony, roleCounts, workerTarget, c
       ...typeof ((_b = colony.room.controller) == null ? void 0 : _b.ticksToDowngrade) === "number" ? { ticksToDowngrade: colony.room.controller.ticksToDowngrade } : {},
       candidates: [buildOccupationRecommendationCandidate(candidate, gameTime)]
     }).candidates[0];
-    if (!recommendation || recommendation.evidenceStatus === "unavailable") {
+    if (!recommendation) {
       return [];
+    }
+    if (recommendation.evidenceStatus === "unavailable") {
+      recordConfiguredScoutOnlyRemoteConversionBlock(
+        colony,
+        candidate,
+        recommendation,
+        getUnavailableScoutOnlyRemoteConversionBlockReason(recommendation),
+        gameTime
+      );
+      return [];
+    }
+    const scoutOnlyRemoteConversionBlockReason = getScoutOnlyRemoteConversionBlockReason(
+      colony,
+      candidate,
+      recommendation,
+      gameTime
+    );
+    if (scoutOnlyRemoteConversionBlockReason) {
+      recordConfiguredScoutOnlyRemoteConversionBlock(
+        colony,
+        candidate,
+        recommendation,
+        scoutOnlyRemoteConversionBlockReason,
+        gameTime
+      );
+      if (isScoutOnlyRemoteConversionHardHoldReason(scoutOnlyRemoteConversionBlockReason)) {
+        return [];
+      }
     }
     return [
       applyOccupationRecommendationScore(
         candidate,
         recommendation,
         roleCounts,
-        adjacentControllerProgressReady
+        adjacentControllerProgressReady,
+        scoutOnlyRemoteConversionBlockReason
       )
     ];
   });
 }
-function applyOccupationRecommendationScore(candidate, recommendation, roleCounts, adjacentControllerProgressReady) {
+function applyOccupationRecommendationScore(candidate, recommendation, roleCounts, adjacentControllerProgressReady, blockReason = null) {
   var _a;
-  const intentAction = getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts);
+  const intentAction = getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts, blockReason);
   const requiresControllerPressure = isTerritoryControlAction3(intentAction) && candidate.requiresControllerPressure === true;
   const commitTarget = recommendation.evidenceStatus === "sufficient" && intentAction !== "scout" && (candidate.commitTarget || isScoutedAdjacentControlCandidate(candidate) || isConfiguredScoutOnlyRemoteConversionCandidate(candidate, intentAction));
   const target = getRecommendedTerritoryTarget(candidate.target, recommendation, intentAction);
@@ -18810,6 +18846,7 @@ function applyOccupationRecommendationScore(candidate, recommendation, roleCount
     recommendationEvidenceStatus: recommendation.evidenceStatus,
     ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...safeAdjacentControllerProgress ? { safeAdjacentControllerProgress: true } : {},
+    ...blockReason ? { blockReason } : {},
     ...renewalTicksToEnd !== null ? { renewalTicksToEnd } : {}
   };
 }
@@ -18832,9 +18869,12 @@ function getTerritoryCandidateRecommendationScore(candidate, recommendation) {
 function isSafeAdjacentControllerProgressCandidate(candidate, recommendation, intentAction, adjacentControllerProgressReady) {
   return adjacentControllerProgressReady && candidate.source === "adjacent" && candidate.target.action === "reserve" && intentAction === "reserve" && candidate.commitTarget === true && candidate.routeDistance === 1 && recommendation.evidenceStatus === "sufficient" && isTerritoryTargetVisible(candidate.target);
 }
-function getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts) {
+function getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts, blockReason = null) {
   if (isAutoClaimApprovedTerritoryCandidate(candidate)) {
     return candidate.intentAction;
+  }
+  if (blockReason !== null && isConfiguredScoutOnlyRemoteConversionTarget(candidate)) {
+    return "scout";
   }
   if (isConfiguredScoutOnlyExpansionTarget(candidate.target) && (recommendation.evidenceStatus !== "sufficient" || !isAutonomousTerritoryControlAllowedForColonyName(candidate.target.colony))) {
     return "scout";
@@ -18869,7 +18909,122 @@ function isConfiguredScoutOnlyExpansionTarget(target) {
   return isConfiguredExpansionScoutOnlyTarget(target.colony, target.roomName);
 }
 function isConfiguredScoutOnlyRemoteConversionCandidate(candidate, intentAction) {
-  return isConfiguredScoutOnlyExpansionCandidate(candidate) && candidate.target.action === "reserve" && intentAction === "reserve" && candidate.routeDistance !== void 0 && candidate.routeDistance <= 1;
+  return isConfiguredScoutOnlyExpansionCandidate(candidate) && isConfiguredScoutOnlyRemoteConversionTarget(candidate) && intentAction === "reserve";
+}
+function isConfiguredScoutOnlyRemoteConversionTarget(candidate) {
+  return isConfiguredScoutOnlyExpansionTarget(candidate.target) && candidate.target.action === "reserve" && candidate.routeDistance !== void 0 && candidate.routeDistance <= 1;
+}
+function getScoutOnlyRemoteConversionBlockReason(colony, candidate, recommendation, gameTime) {
+  if (!isConfiguredScoutOnlyRemoteConversionTarget(candidate) || recommendation.evidenceStatus !== "sufficient" || recommendation.action !== "reserve") {
+    return null;
+  }
+  if (recommendation.requiresControllerPressure === true) {
+    return "controllerReserved";
+  }
+  if (!isAutonomousTerritoryControlAllowedForColony(colony)) {
+    return "controllerLevelLow";
+  }
+  if (isScoutOnlyRemoteHomeAlertActive(colony, gameTime)) {
+    return "homeAlertActive";
+  }
+  if (isCpuBucketBelowScoutOnlyRemoteFloor()) {
+    return "cpuBucketLow";
+  }
+  if (!isScoutOnlyRemoteEnergyBufferReady(colony)) {
+    return "energyBufferLow";
+  }
+  return null;
+}
+function getUnavailableScoutOnlyRemoteConversionBlockReason(recommendation) {
+  var _a, _b;
+  if (((_a = recommendation.hostileCreepCount) != null ? _a : 0) > 0 || ((_b = recommendation.hostileStructureCount) != null ? _b : 0) > 0 || recommendation.risks.some((risk) => risk.includes("hostile presence"))) {
+    return "targetHostile";
+  }
+  if (recommendation.risks.some(
+    (risk) => risk.includes("enemy-owned controller") || risk.includes("controller owned by another account")
+  )) {
+    return "controllerOwned";
+  }
+  if (recommendation.risks.some((risk) => risk.includes("controller reserved by another account"))) {
+    return "controllerReserved";
+  }
+  if (recommendation.risks.some((risk) => risk.includes("has no controller"))) {
+    return "controllerMissing";
+  }
+  if (recommendation.risks.some((risk) => risk.includes("no known route"))) {
+    return "routeUnavailable";
+  }
+  if (recommendation.risks.some((risk) => risk.includes("source count evidence missing"))) {
+    return "sourcesMissing";
+  }
+  return "targetUnavailable";
+}
+function isScoutOnlyRemoteConversionHardHoldReason(reason) {
+  return reason === "controllerReserved" || reason === "energyBufferLow" || reason === "cpuBucketLow" || reason === "homeAlertActive";
+}
+function recordConfiguredScoutOnlyRemoteConversionBlock(colony, candidate, recommendation, blockReason, gameTime) {
+  var _a;
+  if (!blockReason || !isConfiguredScoutOnlyRemoteConversionTarget(candidate)) {
+    return;
+  }
+  const territoryMemory = getWritableTerritoryMemoryRecord6();
+  if (!territoryMemory) {
+    return;
+  }
+  const colonyName = colony.room.name;
+  const roomName = candidate.target.roomName;
+  const existingCandidates = Array.isArray(territoryMemory.expansionCandidates) ? territoryMemory.expansionCandidates.filter(
+    (rawCandidate) => isRecord19(rawCandidate)
+  ) : [];
+  const existingIndex = existingCandidates.findIndex(
+    (rawCandidate) => rawCandidate.colony === colonyName && rawCandidate.roomName === roomName
+  );
+  const existingCandidate = existingIndex >= 0 ? existingCandidates[existingIndex] : void 0;
+  const nextCandidate = {
+    colony: colonyName,
+    roomName,
+    rank: (_a = existingCandidate == null ? void 0 : existingCandidate.rank) != null ? _a : 1,
+    score: Math.round(recommendation.score),
+    evidenceStatus: recommendation.evidenceStatus,
+    visible: isVisibleRoomKnown(roomName),
+    updatedAt: gameTime,
+    adjacentToOwnedRoom: candidate.routeDistance === void 0 || candidate.routeDistance <= 1,
+    scoutOnly: true,
+    ...recommendation.evidenceStatus === "sufficient" ? { recommendedAction: "scout" } : {},
+    blockReason,
+    ...candidate.routeDistance !== void 0 ? { routeDistance: candidate.routeDistance } : {},
+    ...recommendation.controllerId ? { controllerId: recommendation.controllerId } : {},
+    ...recommendation.sourceCount !== void 0 ? { sourceCount: recommendation.sourceCount } : {},
+    ...recommendation.hostileCreepCount !== void 0 ? { hostileCreepCount: recommendation.hostileCreepCount } : {},
+    ...recommendation.hostileStructureCount !== void 0 ? { hostileStructureCount: recommendation.hostileStructureCount } : {},
+    ...recommendation.requiresControllerPressure === true ? { requiresControllerPressure: true } : {},
+    ...recommendation.risks.length > 0 ? { risks: recommendation.risks } : {},
+    ...recommendation.preconditions.length > 0 ? { preconditions: recommendation.preconditions } : {},
+    ...recommendation.evidence.length > 0 ? { rationale: recommendation.evidence } : {}
+  };
+  if (existingIndex >= 0) {
+    existingCandidates[existingIndex] = nextCandidate;
+  } else {
+    existingCandidates.unshift(nextCandidate);
+  }
+  territoryMemory.expansionCandidates = existingCandidates;
+}
+function isScoutOnlyRemoteHomeAlertActive(colony, gameTime) {
+  return isVisibleRoomUnsafe(colony.room) || isColonyRoomThreatened(colony.room.name, gameTime);
+}
+function isCpuBucketBelowScoutOnlyRemoteFloor() {
+  var _a, _b;
+  const bucket = (_b = (_a = globalThis.Game) == null ? void 0 : _a.cpu) == null ? void 0 : _b.bucket;
+  return typeof bucket === "number" && Number.isFinite(bucket) && bucket < SCOUT_ONLY_REMOTE_MIN_CPU_BUCKET;
+}
+function isScoutOnlyRemoteEnergyBufferReady(colony) {
+  if (colony.energyAvailable < TERRITORY_CONTROLLER_BODY_COST) {
+    return false;
+  }
+  if (colony.spawns.length === 0) {
+    return true;
+  }
+  return colony.energyAvailable - TERRITORY_CONTROLLER_BODY_COST >= getSpawnEnergyBufferRequirement(colony.room, colony.spawns);
 }
 function isUnscoutedAdjacentReservationCandidate(candidate) {
   return isAdjacentRoomReservationReserveSelection(candidate);
@@ -19354,7 +19509,8 @@ function recordTerritoryIntent(plan, status, gameTime, seededTarget = null, rout
     ...plan.controllerId ? { controllerId: plan.controllerId } : {},
     ...plan.requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...plan.followUp ? { followUp: plan.followUp } : {},
-    ...plan.postClaimBootstrapReserveEnergy ? { postClaimBootstrapReserveEnergy: plan.postClaimBootstrapReserveEnergy } : {}
+    ...plan.postClaimBootstrapReserveEnergy ? { postClaimBootstrapReserveEnergy: plan.postClaimBootstrapReserveEnergy } : {},
+    ...plan.blockReason ? { blockReason: plan.blockReason } : {}
   };
   upsertTerritoryIntent4(intents, nextIntent);
   recordTerritoryClaimState(plan, status, gameTime);
@@ -35987,7 +36143,7 @@ function isExpansionCandidateRecommendedAction2(action) {
   return action === "claim" || action === "reserve" || action === "scout";
 }
 function isExpansionCandidateBlockReason(reason) {
-  return reason === "insufficientEvidence" || reason === "targetUnavailable" || reason === "targetHostile" || reason === "controllerMissing" || reason === "controllerOwned" || reason === "controllerReserved" || reason === "sourcesMissing" || reason === "controllerRangeMissing" || reason === "terrainMissing" || reason === "energyCapacityLow" || reason === "controllerLevelLow" || reason === "homeDowngradeGuard" || reason === "postClaimBootstrapActive" || reason === "gclInsufficient" || reason === "roomLimitReached" || reason === "routeUnavailable";
+  return reason === "insufficientEvidence" || reason === "targetUnavailable" || reason === "targetHostile" || reason === "controllerMissing" || reason === "controllerOwned" || reason === "controllerReserved" || reason === "sourcesMissing" || reason === "controllerRangeMissing" || reason === "terrainMissing" || reason === "energyCapacityLow" || reason === "energyBufferLow" || reason === "cpuBucketLow" || reason === "homeAlertActive" || reason === "controllerLevelLow" || reason === "homeDowngradeGuard" || reason === "postClaimBootstrapActive" || reason === "gclInsufficient" || reason === "roomLimitReached" || reason === "routeUnavailable";
 }
 function getScoutOnlyTargetStatus(gateOpen, attempt, intel) {
   if (attempt) {

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -1175,6 +1175,9 @@ function isExpansionCandidateBlockReason(
     reason === 'controllerRangeMissing' ||
     reason === 'terrainMissing' ||
     reason === 'energyCapacityLow' ||
+    reason === 'energyBufferLow' ||
+    reason === 'cpuBucketLow' ||
+    reason === 'homeAlertActive' ||
     reason === 'controllerLevelLow' ||
     reason === 'homeDowngradeGuard' ||
     reason === 'postClaimBootstrapActive' ||

--- a/prod/src/territory/territoryMemoryUtils.ts
+++ b/prod/src/territory/territoryMemoryUtils.ts
@@ -41,7 +41,10 @@ export function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMem
     ...(isPositiveFiniteNumber(rawIntent.postClaimBootstrapReserveEnergy)
       ? { postClaimBootstrapReserveEnergy: Math.floor(rawIntent.postClaimBootstrapReserveEnergy) }
       : {}),
-    ...(suspended ? { suspended } : {})
+    ...(suspended ? { suspended } : {}),
+    ...(isTerritoryExpansionCandidateBlockReason(rawIntent.blockReason)
+      ? { blockReason: rawIntent.blockReason }
+      : {})
   };
 }
 
@@ -105,6 +108,32 @@ function isTerritoryIntentStatus(status: unknown): status is TerritoryIntentMemo
 
 function isTerritoryIntentSuppressionReason(reason: unknown): reason is TerritoryIntentSuppressionReason {
   return reason === 'deadZoneTarget' || reason === 'deadZoneRoute' || reason === 'controllerLevel';
+}
+
+function isTerritoryExpansionCandidateBlockReason(
+  reason: unknown
+): reason is TerritoryExpansionCandidateBlockReason {
+  return (
+    reason === 'insufficientEvidence' ||
+    reason === 'targetUnavailable' ||
+    reason === 'targetHostile' ||
+    reason === 'controllerMissing' ||
+    reason === 'controllerOwned' ||
+    reason === 'controllerReserved' ||
+    reason === 'sourcesMissing' ||
+    reason === 'controllerRangeMissing' ||
+    reason === 'terrainMissing' ||
+    reason === 'energyCapacityLow' ||
+    reason === 'energyBufferLow' ||
+    reason === 'cpuBucketLow' ||
+    reason === 'homeAlertActive' ||
+    reason === 'controllerLevelLow' ||
+    reason === 'homeDowngradeGuard' ||
+    reason === 'postClaimBootstrapActive' ||
+    reason === 'gclInsufficient' ||
+    reason === 'roomLimitReached' ||
+    reason === 'routeUnavailable'
+  );
 }
 
 function isTerritoryFollowUpSource(source: unknown): source is TerritoryFollowUpSource {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -49,6 +49,8 @@ import {
   isAutonomousTerritoryControlAllowedForColony,
   isAutonomousTerritoryControlAllowedForColonyName
 } from './controlGate';
+import { getSpawnEnergyBufferRequirement } from '../economy/spawnEnergyBuffer';
+import { isColonyRoomThreatened } from '../defense/colonyThreats';
 
 export const TERRITORY_CLAIMER_ROLE = 'claimer';
 export const TERRITORY_SCOUT_ROLE = 'scout';
@@ -104,6 +106,7 @@ const TERRITORY_ROUTE_DISTANCE_SEPARATOR = '>';
 const TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET = 2;
 const TERRITORY_SCOUT_BODY_COST = 50;
 const TERRITORY_SCOUT_INTEL_PLANNING_TTL = 10_000;
+const SCOUT_ONLY_REMOTE_MIN_CPU_BUCKET = 500;
 const OCCUPATION_RECOMMENDATION_TARGET_CREATOR: TerritoryTargetMemory['createdBy'] = 'occupationRecommendation';
 const REMOTE_MINING_SOURCE_CONTAINER_MIN_RCL = 0;
 const MAX_CONTROLLER_LEVEL = 8;
@@ -118,6 +121,7 @@ export interface TerritoryIntentPlan {
   followUp?: TerritoryFollowUpMemory;
   postClaimBootstrapReserveEnergy?: number;
   routeDistance?: number;
+  blockReason?: TerritoryExpansionCandidateBlockReason;
 }
 
 export interface TerritoryIntentProgressSummary {
@@ -171,6 +175,7 @@ interface SelectedTerritoryTarget {
   recoveredFollowUp?: boolean;
   recoveredFollowUpSuppressedAt?: number;
   routeDistanceLookupContext?: RouteDistanceLookupContext;
+  blockReason?: TerritoryExpansionCandidateBlockReason;
 }
 
 type TerritoryCandidateSource =
@@ -195,6 +200,7 @@ interface ScoredTerritoryTarget extends SelectedTerritoryTarget {
   immediateControllerFollowUp?: boolean;
   occupationActionableTicks?: number;
   safeAdjacentControllerProgress?: boolean;
+  blockReason?: TerritoryExpansionCandidateBlockReason;
 }
 
 type TerritoryTargetVisibilityState = 'available' | 'satisfied' | 'unavailable';
@@ -264,7 +270,8 @@ export function planTerritoryIntent(
     ...(selection.followUp ? { followUp: selection.followUp } : {}),
     ...(selection.postClaimBootstrapReserveEnergy
       ? { postClaimBootstrapReserveEnergy: selection.postClaimBootstrapReserveEnergy }
-      : {})
+      : {}),
+    ...(selection.blockReason ? { blockReason: selection.blockReason } : {})
   };
 
   if (selection.routeDistance !== undefined) {
@@ -1692,6 +1699,7 @@ function toSelectedTerritoryTarget(
         ...(typeof candidate.recoveredFollowUpSuppressedAt === 'number'
           ? { recoveredFollowUpSuppressedAt: candidate.recoveredFollowUpSuppressedAt }
           : {}),
+        ...(candidate.blockReason ? { blockReason: candidate.blockReason } : {}),
         ...(routeDistanceLookupContext ? { routeDistanceLookupContext } : {})
       }
     : null;
@@ -3283,8 +3291,38 @@ function applyOccupationRecommendationScores(
       candidates: [buildOccupationRecommendationCandidate(candidate, gameTime)]
     }).candidates[0];
 
-    if (!recommendation || recommendation.evidenceStatus === 'unavailable') {
+    if (!recommendation) {
       return [];
+    }
+
+    if (recommendation.evidenceStatus === 'unavailable') {
+      recordConfiguredScoutOnlyRemoteConversionBlock(
+        colony,
+        candidate,
+        recommendation,
+        getUnavailableScoutOnlyRemoteConversionBlockReason(recommendation),
+        gameTime
+      );
+      return [];
+    }
+
+    const scoutOnlyRemoteConversionBlockReason = getScoutOnlyRemoteConversionBlockReason(
+      colony,
+      candidate,
+      recommendation,
+      gameTime
+    );
+    if (scoutOnlyRemoteConversionBlockReason) {
+      recordConfiguredScoutOnlyRemoteConversionBlock(
+        colony,
+        candidate,
+        recommendation,
+        scoutOnlyRemoteConversionBlockReason,
+        gameTime
+      );
+      if (isScoutOnlyRemoteConversionHardHoldReason(scoutOnlyRemoteConversionBlockReason)) {
+        return [];
+      }
     }
 
     return [
@@ -3292,7 +3330,8 @@ function applyOccupationRecommendationScores(
         candidate,
         recommendation,
         roleCounts,
-        adjacentControllerProgressReady
+        adjacentControllerProgressReady,
+        scoutOnlyRemoteConversionBlockReason
       )
     ];
   });
@@ -3302,9 +3341,10 @@ function applyOccupationRecommendationScore(
   candidate: ScoredTerritoryTarget,
   recommendation: OccupationRecommendationScore,
   roleCounts: RoleCounts,
-  adjacentControllerProgressReady: boolean
+  adjacentControllerProgressReady: boolean,
+  blockReason: TerritoryExpansionCandidateBlockReason | null = null
 ): ScoredTerritoryTarget {
-  const intentAction = getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts);
+  const intentAction = getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts, blockReason);
   const requiresControllerPressure =
     isTerritoryControlAction(intentAction) && candidate.requiresControllerPressure === true;
   const commitTarget =
@@ -3340,6 +3380,7 @@ function applyOccupationRecommendationScore(
     recommendationEvidenceStatus: recommendation.evidenceStatus,
     ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(safeAdjacentControllerProgress ? { safeAdjacentControllerProgress: true } : {}),
+    ...(blockReason ? { blockReason } : {}),
     ...(renewalTicksToEnd !== null ? { renewalTicksToEnd } : {})
   };
 }
@@ -3399,10 +3440,15 @@ function isSafeAdjacentControllerProgressCandidate(
 function getRecommendedTerritoryIntentAction(
   candidate: ScoredTerritoryTarget,
   recommendation: OccupationRecommendationScore,
-  roleCounts: RoleCounts
+  roleCounts: RoleCounts,
+  blockReason: TerritoryExpansionCandidateBlockReason | null = null
 ): TerritoryIntentAction {
   if (isAutoClaimApprovedTerritoryCandidate(candidate)) {
     return candidate.intentAction;
+  }
+
+  if (blockReason !== null && isConfiguredScoutOnlyRemoteConversionTarget(candidate)) {
+    return 'scout';
   }
 
   if (
@@ -3461,10 +3507,188 @@ function isConfiguredScoutOnlyRemoteConversionCandidate(
 ): boolean {
   return (
     isConfiguredScoutOnlyExpansionCandidate(candidate) &&
+    isConfiguredScoutOnlyRemoteConversionTarget(candidate) &&
+    intentAction === 'reserve'
+  );
+}
+
+function isConfiguredScoutOnlyRemoteConversionTarget(candidate: ScoredTerritoryTarget): boolean {
+  return (
+    isConfiguredScoutOnlyExpansionTarget(candidate.target) &&
     candidate.target.action === 'reserve' &&
-    intentAction === 'reserve' &&
     candidate.routeDistance !== undefined &&
     candidate.routeDistance <= 1
+  );
+}
+
+function getScoutOnlyRemoteConversionBlockReason(
+  colony: ColonySnapshot,
+  candidate: ScoredTerritoryTarget,
+  recommendation: OccupationRecommendationScore,
+  gameTime: number
+): TerritoryExpansionCandidateBlockReason | null {
+  if (
+    !isConfiguredScoutOnlyRemoteConversionTarget(candidate) ||
+    recommendation.evidenceStatus !== 'sufficient' ||
+    recommendation.action !== 'reserve'
+  ) {
+    return null;
+  }
+
+  if (recommendation.requiresControllerPressure === true) {
+    return 'controllerReserved';
+  }
+
+  if (!isAutonomousTerritoryControlAllowedForColony(colony)) {
+    return 'controllerLevelLow';
+  }
+
+  if (isScoutOnlyRemoteHomeAlertActive(colony, gameTime)) {
+    return 'homeAlertActive';
+  }
+
+  if (isCpuBucketBelowScoutOnlyRemoteFloor()) {
+    return 'cpuBucketLow';
+  }
+
+  if (!isScoutOnlyRemoteEnergyBufferReady(colony)) {
+    return 'energyBufferLow';
+  }
+
+  return null;
+}
+
+function getUnavailableScoutOnlyRemoteConversionBlockReason(
+  recommendation: OccupationRecommendationScore
+): TerritoryExpansionCandidateBlockReason {
+  if (
+    (recommendation.hostileCreepCount ?? 0) > 0 ||
+    (recommendation.hostileStructureCount ?? 0) > 0 ||
+    recommendation.risks.some((risk) => risk.includes('hostile presence'))
+  ) {
+    return 'targetHostile';
+  }
+
+  if (
+    recommendation.risks.some(
+      (risk) => risk.includes('enemy-owned controller') || risk.includes('controller owned by another account')
+    )
+  ) {
+    return 'controllerOwned';
+  }
+
+  if (recommendation.risks.some((risk) => risk.includes('controller reserved by another account'))) {
+    return 'controllerReserved';
+  }
+
+  if (recommendation.risks.some((risk) => risk.includes('has no controller'))) {
+    return 'controllerMissing';
+  }
+
+  if (recommendation.risks.some((risk) => risk.includes('no known route'))) {
+    return 'routeUnavailable';
+  }
+
+  if (recommendation.risks.some((risk) => risk.includes('source count evidence missing'))) {
+    return 'sourcesMissing';
+  }
+
+  return 'targetUnavailable';
+}
+
+function isScoutOnlyRemoteConversionHardHoldReason(reason: TerritoryExpansionCandidateBlockReason): boolean {
+  return (
+    reason === 'controllerReserved' ||
+    reason === 'energyBufferLow' ||
+    reason === 'cpuBucketLow' ||
+    reason === 'homeAlertActive'
+  );
+}
+
+function recordConfiguredScoutOnlyRemoteConversionBlock(
+  colony: ColonySnapshot,
+  candidate: ScoredTerritoryTarget,
+  recommendation: OccupationRecommendationScore,
+  blockReason: TerritoryExpansionCandidateBlockReason | null,
+  gameTime: number
+): void {
+  if (!blockReason || !isConfiguredScoutOnlyRemoteConversionTarget(candidate)) {
+    return;
+  }
+
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return;
+  }
+
+  const colonyName = colony.room.name;
+  const roomName = candidate.target.roomName;
+  const existingCandidates = Array.isArray(territoryMemory.expansionCandidates)
+    ? territoryMemory.expansionCandidates.filter((rawCandidate): rawCandidate is TerritoryExpansionCandidateMemory =>
+        isRecord(rawCandidate)
+      )
+    : [];
+  const existingIndex = existingCandidates.findIndex(
+    (rawCandidate) => rawCandidate.colony === colonyName && rawCandidate.roomName === roomName
+  );
+  const existingCandidate = existingIndex >= 0 ? existingCandidates[existingIndex] : undefined;
+  const nextCandidate: TerritoryExpansionCandidateMemory = {
+    colony: colonyName,
+    roomName,
+    rank: existingCandidate?.rank ?? 1,
+    score: Math.round(recommendation.score),
+    evidenceStatus: recommendation.evidenceStatus,
+    visible: isVisibleRoomKnown(roomName),
+    updatedAt: gameTime,
+    adjacentToOwnedRoom: candidate.routeDistance === undefined || candidate.routeDistance <= 1,
+    scoutOnly: true,
+    ...(recommendation.evidenceStatus === 'sufficient' ? { recommendedAction: 'scout' as const } : {}),
+    blockReason,
+    ...(candidate.routeDistance !== undefined ? { routeDistance: candidate.routeDistance } : {}),
+    ...(recommendation.controllerId ? { controllerId: recommendation.controllerId } : {}),
+    ...(recommendation.sourceCount !== undefined ? { sourceCount: recommendation.sourceCount } : {}),
+    ...(recommendation.hostileCreepCount !== undefined
+      ? { hostileCreepCount: recommendation.hostileCreepCount }
+      : {}),
+    ...(recommendation.hostileStructureCount !== undefined
+      ? { hostileStructureCount: recommendation.hostileStructureCount }
+      : {}),
+    ...(recommendation.requiresControllerPressure === true ? { requiresControllerPressure: true } : {}),
+    ...(recommendation.risks.length > 0 ? { risks: recommendation.risks } : {}),
+    ...(recommendation.preconditions.length > 0 ? { preconditions: recommendation.preconditions } : {}),
+    ...(recommendation.evidence.length > 0 ? { rationale: recommendation.evidence } : {})
+  };
+
+  if (existingIndex >= 0) {
+    existingCandidates[existingIndex] = nextCandidate;
+  } else {
+    existingCandidates.unshift(nextCandidate);
+  }
+
+  territoryMemory.expansionCandidates = existingCandidates;
+}
+
+function isScoutOnlyRemoteHomeAlertActive(colony: ColonySnapshot, gameTime: number): boolean {
+  return isVisibleRoomUnsafe(colony.room) || isColonyRoomThreatened(colony.room.name, gameTime);
+}
+
+function isCpuBucketBelowScoutOnlyRemoteFloor(): boolean {
+  const bucket = (globalThis as { Game?: Partial<Game> }).Game?.cpu?.bucket;
+  return typeof bucket === 'number' && Number.isFinite(bucket) && bucket < SCOUT_ONLY_REMOTE_MIN_CPU_BUCKET;
+}
+
+function isScoutOnlyRemoteEnergyBufferReady(colony: ColonySnapshot): boolean {
+  if (colony.energyAvailable < TERRITORY_CONTROLLER_BODY_COST) {
+    return false;
+  }
+
+  if (colony.spawns.length === 0) {
+    return true;
+  }
+
+  return (
+    colony.energyAvailable - TERRITORY_CONTROLLER_BODY_COST >=
+    getSpawnEnergyBufferRequirement(colony.room, colony.spawns)
   );
 }
 
@@ -4260,7 +4484,8 @@ function recordTerritoryIntent(
     ...(plan.followUp ? { followUp: plan.followUp } : {}),
     ...(plan.postClaimBootstrapReserveEnergy
       ? { postClaimBootstrapReserveEnergy: plan.postClaimBootstrapReserveEnergy }
-      : {})
+      : {}),
+    ...(plan.blockReason ? { blockReason: plan.blockReason } : {})
   };
 
   upsertTerritoryIntent(intents, nextIntent);

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -693,6 +693,9 @@ declare global {
     | 'controllerRangeMissing'
     | 'terrainMissing'
     | 'energyCapacityLow'
+    | 'energyBufferLow'
+    | 'cpuBucketLow'
+    | 'homeAlertActive'
     | 'controllerLevelLow'
     | 'homeDowngradeGuard'
     | 'postClaimBootstrapActive'
@@ -832,6 +835,7 @@ declare global {
     followUp?: TerritoryFollowUpMemory;
     postClaimBootstrapReserveEnergy?: number;
     suspended?: TerritoryIntentSuspensionMemory;
+    blockReason?: TerritoryExpansionCandidateBlockReason;
   }
 
   interface TerritoryIntentSuspensionMemory {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -844,7 +844,8 @@ describe('planTerritoryIntent', () => {
     ).toEqual({
       colony: 'E29N55',
       targetRoom: 'E29N56',
-      action: 'scout'
+      action: 'scout',
+      blockReason: 'controllerLevelLow'
     });
     expect(Memory.territory?.targets).toBeUndefined();
     expect(
@@ -856,9 +857,17 @@ describe('planTerritoryIntent', () => {
         targetRoom: 'E29N56',
         action: 'scout',
         status: 'planned',
-        updatedAt: gameTime
+        updatedAt: gameTime,
+        blockReason: 'controllerLevelLow'
       }
     ]);
+    expect(Memory.territory?.expansionCandidates?.[0]).toMatchObject({
+      colony: 'E29N55',
+      roomName: 'E29N56',
+      scoutOnly: true,
+      recommendedAction: 'scout',
+      blockReason: 'controllerLevelLow'
+    });
   });
 
   it('converts fresh safe E29N56 scout-only evidence into a reserve target at RCL5', () => {
@@ -999,9 +1008,17 @@ describe('planTerritoryIntent', () => {
         targetRoom: 'E29N56',
         action: 'scout',
         status: 'planned',
-        updatedAt: gameTime
+        updatedAt: gameTime,
+        blockReason: 'controllerLevelLow'
       }
     ]);
+    expect(Memory.territory?.expansionCandidates?.[0]).toMatchObject({
+      colony: 'E29N55',
+      roomName: 'E29N56',
+      scoutOnly: true,
+      recommendedAction: 'scout',
+      blockReason: 'controllerLevelLow'
+    });
   });
 
   it.each([
@@ -1009,7 +1026,8 @@ describe('planTerritoryIntent', () => {
       'hostile creep',
       {
         hostileCreepCount: 1
-      }
+      },
+      'targetHostile'
     ],
     [
       'foreign reservation',
@@ -1019,7 +1037,8 @@ describe('planTerritoryIntent', () => {
           my: false,
           reservationUsername: 'enemy'
         }
-      }
+      },
+      'controllerReserved'
     ],
     [
       'foreign ownership',
@@ -1029,9 +1048,10 @@ describe('planTerritoryIntent', () => {
           my: false,
           ownerUsername: 'enemy'
         }
-      }
+      },
+      'controllerOwned'
     ]
-  ] as const)('does not convert E29N56 scout-only evidence when %s is present', (_label, intelOverrides) => {
+  ] as const)('does not convert E29N56 scout-only evidence when %s is present', (_label, intelOverrides, blockReason) => {
     const colony = makeSafeColony({
       roomName: 'E29N55',
       controller: {
@@ -1074,7 +1094,133 @@ describe('planTerritoryIntent', () => {
     expect(plan).toBeNull();
     expect(Memory.territory?.targets).toBeUndefined();
     expect(Memory.territory?.intents).toBeUndefined();
+    expect(Memory.territory?.expansionCandidates?.[0]).toMatchObject({
+      colony: 'E29N55',
+      roomName: 'E29N56',
+      scoutOnly: true,
+      blockReason
+    });
   });
+
+  it.each([
+    [
+      'low home spawn buffer',
+      {
+        energyAvailable: 1_000,
+        energyCapacityAvailable: 1_800,
+        withSpawn: true
+      },
+      {},
+      'energyBufferLow'
+    ],
+    [
+      'low CPU bucket',
+      {
+        energyAvailable: 1_800,
+        energyCapacityAvailable: 1_800
+      },
+      { cpu: { bucket: 499 } },
+      'cpuBucketLow'
+    ],
+    [
+      'active home alert',
+      {
+        energyAvailable: 1_800,
+        energyCapacityAvailable: 1_800
+      },
+      {
+        defense: {
+          colonyThreats: {
+            updatedAt: 6_805,
+            rooms: {
+              E29N55: {
+                roomName: 'E29N55',
+                level: 'hostile_present' as DefenseThreatLevel,
+                updatedAt: 6_805,
+                hostileCreepCount: 1,
+                hostileStructureCount: 0,
+                damagedCriticalStructureCount: 0
+              }
+            }
+          }
+        }
+      },
+      'homeAlertActive'
+    ]
+  ] as const)(
+    'holds E29N56 scout-only conversion on %s with a block reason',
+    (_label, homeState, runtimeState, blockReason) => {
+      const colony = makeSafeColony({
+        roomName: 'E29N55',
+        controller: {
+          my: true,
+          owner: { username: 'me' },
+          level: 5,
+          ticksToDowngrade: 10_000
+        } as StructureController,
+        energyAvailable: homeState.energyAvailable,
+        energyCapacityAvailable: homeState.energyCapacityAvailable
+      });
+      if ('withSpawn' in homeState && homeState.withSpawn === true) {
+        colony.spawns = [
+          {
+            name: 'Spawn1',
+            room: colony.room,
+            spawning: null
+          } as StructureSpawn
+        ];
+      }
+      const gameTime = 6_805;
+      (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+        runtime: {
+          currentRoomName: 'E29N55'
+        },
+        ...('defense' in runtimeState ? { defense: runtimeState.defense } : {}),
+        territory: {
+          scoutIntel: {
+            'E29N55>E29N56': makeScoutIntel('E29N56', gameTime - 1, {
+              colony: 'E29N55',
+              controller: { id: 'controller-E29N56' as Id<StructureController>, my: false },
+              sourceIds: ['source1'],
+              sourceCount: 1,
+              sourceAccessPoints: 1
+            })
+          }
+        }
+      };
+      (globalThis as unknown as { Game: Partial<Game> }).Game = {
+        time: gameTime,
+        ...('cpu' in runtimeState ? { cpu: runtimeState.cpu as CPU } : {}),
+        rooms: {
+          E29N55: colony.room
+        },
+        map: {
+          describeExits: jest.fn(() => ({ '1': 'E29N56' })),
+          findRoute: jest.fn((_fromRoom: string, toRoom: string) => [{ exit: 1, room: toRoom }])
+        } as unknown as GameMap
+      };
+      const cappedScoutRoleCounts = {
+        worker: 4,
+        claimer: 0,
+        scout: 2,
+        scoutsByTargetRoom: { E29N54: 1, E28N55: 1 },
+        claimersByTargetRoom: {}
+      };
+
+      expect(
+        planTerritoryIntent(colony, cappedScoutRoleCounts, 4, gameTime)
+      ).toBeNull();
+      expect(Memory.territory?.targets).toBeUndefined();
+      expect(Memory.territory?.intents).toBeUndefined();
+      expect(Memory.territory?.expansionCandidates?.[0]).toMatchObject({
+        colony: 'E29N55',
+        roomName: 'E29N56',
+        scoutOnly: true,
+        recommendedAction: 'scout',
+        blockReason
+      });
+    }
+  );
 
   it.each([
     [


### PR DESCRIPTION
## Summary
- Converts E29N56 from scout-only intel into a bounded RCL5 remote/reserve intent path when scout evidence is sufficient.
- Adds machine-readable hold/deny reasons for below-RCL5, hostile/foreign-reserved, buffer/CPU/alert/risk conditions.
- Extends territory telemetry/memory and tests; rebuilds Screeps bundle.

Fixes #1285

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (101 suites, 2000 tests)
- `cd prod && npm run build`

## Safety
- No official MMO writes or deploy performed.
- No secret values printed.
- No proactive player attacks; remote intent remains guarded by RCL5+ and safety/risk checks.
