### PR TITLE
fix(rl): filter stale non-current E1 gate samples

### DIFF
--- a/scripts/screeps_rl_dataset_export.py
+++ b/scripts/screeps_rl_dataset_export.py
@@ -722,8 +722,12 @@ def filter_stale_non_current_console_capture_records(
     home_room: str,
     created_at: str | None = None,
 ) -> None:
-    reference_at = created_at or latest_console_capture_reference_at(scan.records)
+    fallback_reference_at = latest_console_capture_reference_at(scan.records)
+    reference_at = created_at or fallback_reference_at
     reference = parse_iso_utc_timestamp(reference_at)
+    if reference is None and created_at is not None:
+        reference_at = fallback_reference_at
+        reference = parse_iso_utc_timestamp(reference_at)
     if reference is None:
         return
 

--- a/scripts/screeps_rl_dataset_export.py
+++ b/scripts/screeps_rl_dataset_export.py
@@ -15,10 +15,12 @@ import sys
 import tempfile
 import time
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Sequence, TextIO
 
 import screeps_runtime_kpi_reducer as reducer
+import screeps_world_profiles as world_profiles
 
 
 SCHEMA_VERSION = 1
@@ -39,13 +41,19 @@ DEFAULT_MAX_FILE_BYTES = 5 * 1024 * 1024
 DEFAULT_SAMPLE_LIMIT = 200
 DEFAULT_EVAL_RATIO = 0.2
 INCOMPLETE_DERIVED_RUNTIME_SUMMARY_SKIP_REASON = "incomplete_derived_runtime_summary"
+STALE_NON_CURRENT_CONSOLE_CAPTURE_SKIP_REASON = "stale_non_current_room_console_capture"
+STALE_CONSOLE_CAPTURE_SOURCE_AGE_HOURS = 24.0
+SKIPPED_SAMPLE_LOG_LIMIT = 50
 DERIVED_RUNTIME_SOURCE_MARKERS = ("screeps-runtime-monitor", "screeps-runtime-monitor-json")
 DERIVED_RUNTIME_BASENAME_PREFIXES = ("postdeploy-observation", "runtime-summary-monitor", "latest-summary-output")
+CONSOLE_CAPTURE_SOURCE_MARKER = "runtime-summary-console"
 RUN_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 ROOM_RE = re.compile(r"^(?:(?P<shard>[^/]+)/)?(?P<room>[WE]\d+[NS]\d+)$")
+SOURCE_TIMESTAMP_RE = re.compile(r"(\d{8}T\d{6}Z)")
 SECRET_TEXT_RE = re.compile(
     r"(?i)(x-token|authorization|token|password|secret|steam[_-]?key)\s*[:=]\s*(?:bearer\s+)?[^,\s}\"']+"
 )
+HOME_ROOM_ENV_VAR = "SCREEPS_HOME_ROOM"
 SECRET_ENV_NAMES = (
     "SCREEPS_AUTH_TOKEN",
     "STEAM_KEY",
@@ -80,6 +88,7 @@ class ScanResult:
     records: list[ArtifactRecord] = field(default_factory=list)
     strategy_shadow_reports: list[JsonObject] = field(default_factory=list)
     skipped_files: list[JsonObject] = field(default_factory=list)
+    skipped_samples: list[JsonObject] = field(default_factory=list)
     scanned_files: int = 0
 
     def skip(self, path: Path | str, reason: str, **details: Any) -> None:
@@ -138,6 +147,10 @@ def redact_text(text: str) -> str:
 
 def configured_secret_values() -> list[str]:
     return [os.environ.get(name, "") for name in SECRET_ENV_NAMES]
+
+
+def configured_home_room() -> str:
+    return os.environ.get(HOME_ROOM_ENV_VAR, "").strip() or world_profiles.PERSISTENT_DEFAULTS.room
 
 
 def sha256_bytes(data: bytes) -> str:
@@ -703,6 +716,152 @@ def derived_room_has_console_gate_fields(room: JsonObject) -> bool:
     return has_task_counts and has_energy_field and has_creep_ownership and has_spawn_ownership
 
 
+def filter_stale_non_current_console_capture_records(
+    scan: ScanResult,
+    *,
+    home_room: str,
+    created_at: str | None = None,
+) -> None:
+    reference_at = created_at or latest_console_capture_reference_at(scan.records)
+    reference = parse_iso_utc_timestamp(reference_at)
+    if reference is None:
+        return
+
+    filtered_records: list[ArtifactRecord] = []
+    for record in scan.records:
+        filtered_record, skipped_samples = prune_stale_non_current_console_capture_record(
+            record,
+            home_room=home_room,
+            reference=reference,
+            reference_at=reference_at,
+        )
+        scan.skipped_samples.extend(skipped_samples)
+        if filtered_record is not None:
+            filtered_records.append(filtered_record)
+
+    scan.records = filtered_records
+
+
+def prune_stale_non_current_console_capture_record(
+    record: ArtifactRecord,
+    *,
+    home_room: str,
+    reference: datetime,
+    reference_at: str | None,
+) -> tuple[ArtifactRecord | None, list[JsonObject]]:
+    if not is_console_capture_record(record):
+        return record, []
+
+    source_timestamp = record_source_timestamp(record)
+    if source_timestamp is None:
+        return record, []
+
+    source_age = source_age_hours(source_timestamp, reference)
+    if source_age < STALE_CONSOLE_CAPTURE_SOURCE_AGE_HOURS:
+        return record, []
+
+    rooms = record.payload.get("rooms")
+    if not isinstance(rooms, list):
+        return record, []
+
+    kept_rooms: list[JsonObject] = []
+    skipped_samples: list[JsonObject] = []
+    for room in rooms:
+        if not isinstance(room, dict):
+            continue
+        room_name = room.get("roomName")
+        if isinstance(room_name, str) and room_name and room_name != home_room:
+            skipped_samples.append(
+                {
+                    "reason": STALE_NON_CURRENT_CONSOLE_CAPTURE_SKIP_REASON,
+                    "path": record.source.display_path,
+                    "artifactKind": record.artifact_kind,
+                    "lineNumber": record.line_number,
+                    "tick": number_or_none(record.payload.get("tick")),
+                    "roomName": room_name,
+                    "homeRoom": home_room,
+                    "sourceTimestamp": isoformat_utc(source_timestamp),
+                    "sourceAgeHours": source_age,
+                    "staleSourceAgeHours": STALE_CONSOLE_CAPTURE_SOURCE_AGE_HOURS,
+                    "sourceWindowReferenceAt": reference_at,
+                }
+            )
+            continue
+        kept_rooms.append(room)
+
+    if not skipped_samples:
+        return record, []
+    if not kept_rooms:
+        return None, skipped_samples
+
+    payload = dict(record.payload)
+    payload["rooms"] = kept_rooms
+    return (
+        ArtifactRecord(
+            source=record.source,
+            artifact_kind=record.artifact_kind,
+            payload=payload,
+            line_number=record.line_number,
+        ),
+        skipped_samples,
+    )
+
+
+def is_console_capture_record(record: ArtifactRecord) -> bool:
+    source_text = f"{record.source.path}\n{record.source.display_path}".lower().replace("\\", "/")
+    return CONSOLE_CAPTURE_SOURCE_MARKER in source_text
+
+
+def latest_console_capture_reference_at(records: Sequence[ArtifactRecord]) -> str | None:
+    timestamps = [
+        timestamp
+        for record in records
+        if is_console_capture_record(record)
+        for timestamp in [record_source_timestamp(record)]
+        if timestamp is not None
+    ]
+    if not timestamps:
+        return None
+    return isoformat_utc(max(timestamps))
+
+
+def record_source_timestamp(record: ArtifactRecord) -> datetime | None:
+    return source_timestamp_from_path(record.source.path) or source_timestamp_from_path(record.source.display_path)
+
+
+def source_timestamp_from_path(path: str | None) -> datetime | None:
+    if not path:
+        return None
+    match = SOURCE_TIMESTAMP_RE.search(path)
+    if match is None:
+        return None
+    try:
+        return datetime.strptime(match.group(1), "%Y%m%dT%H%M%SZ").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def parse_iso_utc_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def source_age_hours(source_timestamp: datetime, reference: datetime) -> float:
+    age_hours = (reference - source_timestamp).total_seconds() / 3600
+    return round(max(0.0, age_hours), 3)
+
+
+def isoformat_utc(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
 def build_dataset(
     paths: Sequence[str],
     out_dir: Path,
@@ -713,12 +872,16 @@ def build_dataset(
     eval_ratio_value: float = DEFAULT_EVAL_RATIO,
     split_seed: str = "screeps-rl-v1",
     repo_root: Path | None = None,
+    created_at: str | None = None,
+    home_room: str | None = None,
 ) -> JsonObject:
     repo = repo_root or Path.cwd()
     resolved_bot_commit = bot_commit or git_commit(repo)
     resolved_out_dir = out_dir.expanduser()
+    resolved_home_room = home_room or configured_home_room()
     scan = collect_artifact_records(paths, max_file_bytes=max_file_bytes, excluded_roots=[resolved_out_dir])
     filter_incomplete_derived_runtime_records(scan)
+    filter_stale_non_current_console_capture_records(scan, home_room=resolved_home_room, created_at=created_at)
     rows = build_tick_rows(scan.records, resolved_bot_commit, sample_limit, eval_ratio_value, split_seed)
     resolved_run_id = run_id or deterministic_run_id(scan, rows, resolved_bot_commit, sample_limit, eval_ratio_value, split_seed)
     validate_run_id(resolved_run_id)
@@ -783,6 +946,7 @@ def build_dataset(
         "runtimeSummaryArtifactCount": len(scan.records),
         "strategyShadowReportCount": len(scan.strategy_shadow_reports),
         "skippedFileCount": len(scan.skipped_files),
+        **build_skipped_sample_summary(scan),
         "splitCounts": split_counts,
         "files": files,
     }
@@ -1094,6 +1258,40 @@ def runtime_lines_from_records(records: Sequence[ArtifactRecord]) -> list[str]:
     ]
 
 
+def build_skipped_sample_summary(scan: ScanResult) -> JsonObject:
+    skipped_samples = sorted_skipped_samples(scan)
+    return {
+        "skippedSampleCount": len(scan.skipped_samples),
+        "skippedSampleReasons": count_skipped_sample_field(scan, "reason"),
+        "skippedSampleRooms": count_skipped_sample_field(scan, "roomName"),
+        "skippedSampleSources": count_skipped_sample_field(scan, "path"),
+        "skippedSamples": skipped_samples[:SKIPPED_SAMPLE_LOG_LIMIT],
+        "skippedSampleLogLimit": SKIPPED_SAMPLE_LOG_LIMIT,
+        "skippedSamplesTruncated": max(0, len(skipped_samples) - SKIPPED_SAMPLE_LOG_LIMIT),
+    }
+
+
+def sorted_skipped_samples(scan: ScanResult) -> list[JsonObject]:
+    return sorted(
+        scan.skipped_samples,
+        key=lambda item: (
+            str(item.get("reason", "")),
+            str(item.get("path", "")),
+            str(item.get("lineNumber", "")),
+            str(item.get("roomName", "")),
+        ),
+    )
+
+
+def count_skipped_sample_field(scan: ScanResult, field_name: str) -> JsonObject:
+    counts: dict[str, int] = {}
+    for sample in scan.skipped_samples:
+        value = sample.get(field_name)
+        key = value if isinstance(value, str) and value else "unknown"
+        counts[key] = counts.get(key, 0) + 1
+    return dict(sorted(counts.items(), key=lambda item: (-item[1], item[0])))
+
+
 def build_source_index(scan: ScanResult) -> JsonObject:
     return {
         "type": "screeps-rl-source-index",
@@ -1113,6 +1311,7 @@ def build_source_index(scan: ScanResult) -> JsonObject:
         ],
         "strategyShadowReports": scan.strategy_shadow_reports,
         "skippedFiles": sorted(scan.skipped_files, key=lambda item: (item.get("path", ""), item.get("reason", ""))),
+        "skippedSamples": sorted_skipped_samples(scan),
     }
 
 
@@ -1201,6 +1400,7 @@ def build_run_manifest(
             "matchedArtifactCount": len(scan.records),
             "strategyShadowReportCount": len(scan.strategy_shadow_reports),
             "skippedFileCount": len(scan.skipped_files),
+            **build_skipped_sample_summary(scan),
         },
         "strategy": {
             "registryPath": "prod/src/strategy/strategyRegistry.ts",

--- a/scripts/screeps_rl_dataset_gate.py
+++ b/scripts/screeps_rl_dataset_gate.py
@@ -772,6 +772,8 @@ def evaluate_dataset_readiness(
         "sourceArtifactCount": dataset_summary.get("sourceArtifactCount"),
         "runtimeSummaryArtifactCount": dataset_summary.get("runtimeSummaryArtifactCount"),
         "strategyShadowReportCount": dataset_summary.get("strategyShadowReportCount"),
+        "skippedSampleCount": dataset_summary.get("skippedSampleCount"),
+        "skippedSampleReasons": dataset_summary.get("skippedSampleReasons"),
         "splitCounts": dataset_summary.get("splitCounts"),
         "runId": dataset_summary.get("runId"),
         "runDir": dataset_export.display_path(file_paths["runDir"]),
@@ -1062,6 +1064,7 @@ def run_gate(
     repo = (repo_root or Path.cwd()).expanduser().resolve()
     created = created_at or utc_now_iso()
     resolved_bot_commit = bot_commit or dataset_export.git_commit(repo)
+    resolved_home_room = configured_home_room()
     resolved_gate_id = gate_id or default_gate_id(
         created_at=created,
         input_paths=paths,
@@ -1111,6 +1114,8 @@ def run_gate(
         eval_ratio_value=eval_ratio_value,
         split_seed=split_seed,
         repo_root=repo,
+        created_at=created,
+        home_room=resolved_home_room,
     )
     file_paths = dataset_file_paths(resolved_dataset_out_dir, str(dataset_summary["runId"]), dataset_summary["files"])
     run_manifest = load_json(file_paths["runManifest"])
@@ -1125,7 +1130,7 @@ def run_gate(
         ticks_count,
         min_samples=min_samples,
     )
-    quality_checks = evaluate_quality_checks(file_paths["ticks"], created_at=created)
+    quality_checks = evaluate_quality_checks(file_paths["ticks"], home_room=resolved_home_room, created_at=created)
     floors = metric_floors(
         min_reliability=min_reliability,
         min_owned_rooms=min_owned_rooms,

--- a/scripts/screeps_rl_dataset_gate.py
+++ b/scripts/screeps_rl_dataset_gate.py
@@ -1063,6 +1063,8 @@ def run_gate(
 ) -> JsonObject:
     repo = (repo_root or Path.cwd()).expanduser().resolve()
     created = created_at or utc_now_iso()
+    if parse_iso_utc_timestamp(created) is None:
+        raise DatasetGateError("--created-at must be a valid ISO-8601 UTC timestamp")
     resolved_bot_commit = bot_commit or dataset_export.git_commit(repo)
     resolved_home_room = configured_home_room()
     resolved_gate_id = gate_id or default_gate_id(

--- a/scripts/test_screeps_rl_dataset_export.py
+++ b/scripts/test_screeps_rl_dataset_export.py
@@ -258,6 +258,82 @@ class RlDatasetExportTest(unittest.TestCase):
         self.assertEqual(summary["sampleCount"], 1)
         self.assertEqual(summary["runtimeSummaryArtifactCount"], 1)
 
+    def test_stale_non_current_console_capture_sample_is_filtered_with_evidence(self) -> None:
+        stale_payload = {
+            "type": "runtime-summary",
+            "tick": 786180,
+            "rooms": [{"roomName": "E26S48", "resources": {"storedEnergy": 0}}],
+        }
+        current_payload = {
+            "type": "runtime-summary",
+            "tick": 1056600,
+            "rooms": [{"roomName": "E29N55", "resources": {"storedEnergy": 250}}],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            stale_artifact = root / "runtime-summary-console-20260510T173515Z.log"
+            current_artifact = root / "runtime-summary-console-20260521T025000Z.log"
+            stale_artifact.write_text(runtime_line(stale_payload), encoding="utf-8")
+            current_artifact.write_text(runtime_line(current_payload), encoding="utf-8")
+            out_dir = root / "datasets"
+
+            summary = exporter.build_dataset(
+                [str(stale_artifact), str(current_artifact)],
+                out_dir,
+                run_id="stale-filter-run",
+                bot_commit="1" * 40,
+                eval_ratio_value=0,
+                created_at="2026-05-21T03:03:07Z",
+                home_room="E29N55",
+            )
+            rows = read_ndjson(out_dir / "stale-filter-run" / "ticks.ndjson")
+            source_index = read_json(out_dir / "stale-filter-run" / "source_index.json")
+            run_manifest = read_json(out_dir / "stale-filter-run" / "run_manifest.json")
+
+        self.assertEqual(summary["sampleCount"], 1)
+        self.assertEqual(summary["runtimeSummaryArtifactCount"], 1)
+        self.assertEqual(summary["skippedSampleCount"], 1)
+        self.assertEqual(
+            summary["skippedSampleReasons"],
+            {exporter.STALE_NON_CURRENT_CONSOLE_CAPTURE_SKIP_REASON: 1},
+        )
+        self.assertEqual(rows[0]["observation"]["roomName"], "E29N55")
+        skipped_sample = source_index["skippedSamples"][0]
+        self.assertEqual(skipped_sample["reason"], exporter.STALE_NON_CURRENT_CONSOLE_CAPTURE_SKIP_REASON)
+        self.assertEqual(skipped_sample["roomName"], "E26S48")
+        self.assertEqual(skipped_sample["homeRoom"], "E29N55")
+        self.assertGreater(skipped_sample["sourceAgeHours"], 24)
+        self.assertEqual(run_manifest["source"]["skippedSampleCount"], 1)
+
+    def test_fresh_current_home_console_capture_sample_remains_eligible(self) -> None:
+        payload = {
+            "type": "runtime-summary",
+            "tick": 1056600,
+            "rooms": [{"roomName": "E29N55", "resources": {"storedEnergy": 250}}],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact = root / "runtime-summary-console-20260521T025000Z.log"
+            artifact.write_text(runtime_line(payload), encoding="utf-8")
+            out_dir = root / "datasets"
+
+            summary = exporter.build_dataset(
+                [str(artifact)],
+                out_dir,
+                run_id="fresh-home-run",
+                bot_commit="2" * 40,
+                eval_ratio_value=0,
+                created_at="2026-05-21T03:03:07Z",
+                home_room="E29N55",
+            )
+            rows = read_ndjson(out_dir / "fresh-home-run" / "ticks.ndjson")
+
+        self.assertEqual(summary["sampleCount"], 1)
+        self.assertEqual(summary["skippedSampleCount"], 0)
+        self.assertEqual(rows[0]["observation"]["roomName"], "E29N55")
+
     def test_incomplete_postdeploy_monitor_summary_json_is_filtered_from_samples(self) -> None:
         monitor_payload = {
             "ok": True,

--- a/scripts/test_screeps_rl_dataset_export.py
+++ b/scripts/test_screeps_rl_dataset_export.py
@@ -306,6 +306,54 @@ class RlDatasetExportTest(unittest.TestCase):
         self.assertGreater(skipped_sample["sourceAgeHours"], 24)
         self.assertEqual(run_manifest["source"]["skippedSampleCount"], 1)
 
+    def test_malformed_created_at_uses_console_capture_reference_for_stale_filter(self) -> None:
+        stale_payload = {
+            "type": "runtime-summary",
+            "tick": 786180,
+            "rooms": [{"roomName": "E26S48", "resources": {"storedEnergy": 0}}],
+        }
+        current_payload = {
+            "type": "runtime-summary",
+            "tick": 1056600,
+            "rooms": [{"roomName": "E29N55", "resources": {"storedEnergy": 250}}],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            stale_artifact = root / "runtime-summary-console-20260510T173515Z.log"
+            current_artifact = root / "runtime-summary-console-20260521T025000Z.log"
+            stale_artifact.write_text(runtime_line(stale_payload), encoding="utf-8")
+            current_artifact.write_text(runtime_line(current_payload), encoding="utf-8")
+            out_dir = root / "datasets"
+
+            summary = exporter.build_dataset(
+                [str(stale_artifact), str(current_artifact)],
+                out_dir,
+                run_id="stale-filter-invalid-created-at-run",
+                bot_commit="1" * 40,
+                eval_ratio_value=0,
+                created_at="INVALID_TIMESTAMP",
+                home_room="E29N55",
+            )
+            rows = read_ndjson(out_dir / "stale-filter-invalid-created-at-run" / "ticks.ndjson")
+            source_index = read_json(out_dir / "stale-filter-invalid-created-at-run" / "source_index.json")
+            run_manifest = read_json(out_dir / "stale-filter-invalid-created-at-run" / "run_manifest.json")
+
+        self.assertEqual(summary["sampleCount"], 1)
+        self.assertEqual(summary["skippedSampleCount"], 1)
+        self.assertEqual(
+            summary["skippedSampleReasons"],
+            {exporter.STALE_NON_CURRENT_CONSOLE_CAPTURE_SKIP_REASON: 1},
+        )
+        self.assertEqual(rows[0]["observation"]["roomName"], "E29N55")
+        skipped_sample = source_index["skippedSamples"][0]
+        self.assertEqual(skipped_sample["reason"], exporter.STALE_NON_CURRENT_CONSOLE_CAPTURE_SKIP_REASON)
+        self.assertEqual(skipped_sample["roomName"], "E26S48")
+        self.assertEqual(skipped_sample["homeRoom"], "E29N55")
+        self.assertGreater(skipped_sample["sourceAgeHours"], 24)
+        self.assertEqual(skipped_sample["sourceWindowReferenceAt"], "2026-05-21T02:50:00Z")
+        self.assertEqual(run_manifest["source"]["skippedSampleCount"], 1)
+
     def test_fresh_current_home_console_capture_sample_remains_eligible(self) -> None:
         payload = {
             "type": "runtime-summary",

--- a/scripts/test_screeps_rl_dataset_gate.py
+++ b/scripts/test_screeps_rl_dataset_gate.py
@@ -296,10 +296,10 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
         self.assertIn("no_room_energy", report["quality_checks"]["rejection_reasons"])
         self.assertIn("no_harvest_or_upgrade_task", report["quality_checks"]["rejection_reasons"])
 
-    def test_run_classifies_stale_non_current_room_quality_tail_without_passing_gate(self) -> None:
+    def test_run_excludes_stale_non_current_console_capture_before_quality_acceptance(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
-            artifact = root / "runtime-summary-console-20260510T173515Z.log"
+            stale_artifact = root / "runtime-summary-console-20260510T173515Z.log"
             stale_room = runtime_payload(786180, stored_energy=0)
             room = stale_room["rooms"][0]
             room["roomName"] = "E26S48"
@@ -308,40 +308,42 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
             room["taskCounts"] = {"harvest": 0, "upgrade": 0, "none": 0}
             room["energyAvailable"] = 0
             room["resources"]["workerCarriedEnergy"] = 0
-            artifact.write_text(runtime_line(stale_room), encoding="utf-8")
+            stale_artifact.write_text(runtime_line(stale_room), encoding="utf-8")
+
+            current_artifact = root / "runtime-summary-console-20260521T025000Z.log"
+            current_room = runtime_payload(1056600, stored_energy=250)
+            current_room["rooms"][0]["roomName"] = "E29N55"
+            current_artifact.write_text(runtime_line(current_room), encoding="utf-8")
 
             report = gate.run_gate(
-                [str(artifact)],
+                [str(stale_artifact), str(current_artifact)],
                 out_dir=root / "gates",
-                gate_id="gate-stale-non-current-tail",
-                created_at="2026-05-18T20:16:17Z",
+                gate_id="gate-stale-non-current-filter",
+                created_at="2026-05-21T03:03:07Z",
                 dataset_out_dir=root / "datasets",
                 skip_shadow_report=True,
                 bot_commit="a" * 40,
                 eval_ratio_value=0,
                 repo_root=Path.cwd(),
             )
+            saved_report = read_json(root / "gates" / "gate-stale-non-current-filter" / "gate_report.json")
 
         quality = report["quality_checks"]
-        tail = quality["tail_classification"]
-        self.assertFalse(report["ok"])
-        self.assertEqual(quality["status"], "fail")
-        self.assertEqual(quality["samples_rejected"], 1)
-        self.assertEqual(quality["acceptance_rate"], 0.0)
-        self.assertEqual(tail["status"], "blocked")
-        self.assertEqual(tail["primary_cause"], "stale_non_current_room_quality_tail")
-        self.assertEqual(tail["blocker"], "dataset_contains_stale_non_current_room_loss_samples")
-        self.assertFalse(tail["parser_or_instrumentation_gap_suspected"])
-        self.assertEqual(tail["stale_source_sample_count"], 1)
-        self.assertEqual(tail["non_current_room_sample_count"], 1)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["dataset"]["sampleCount"], 1)
+        self.assertEqual(report["dataset"]["skippedSampleCount"], 1)
         self.assertEqual(
-            quality["rejected_sample_classifications"],
-            {"stale_non_current_room_empty_or_lost": 1},
+            report["dataset"]["skippedSampleReasons"],
+            {gate.dataset_export.STALE_NON_CURRENT_CONSOLE_CAPTURE_SKIP_REASON: 1},
         )
-        self.assertGreater(quality["rejected_samples"][0]["sourceAgeHours"], 24)
-        blocking = next(reason for reason in report["blockingReasons"] if reason["gate"] == "quality_checks")
-        self.assertEqual(blocking["tailClassification"]["primary_cause"], "stale_non_current_room_quality_tail")
-        self.assertEqual(blocking["acceptanceRate"], 0.0)
+        skipped_sample = report["dataset"]["skippedSamples"][0]
+        self.assertEqual(skipped_sample["roomName"], "E26S48")
+        self.assertGreater(skipped_sample["sourceAgeHours"], 24)
+        self.assertEqual(quality["status"], "pass")
+        self.assertEqual(quality["samples_accepted"], 1)
+        self.assertEqual(quality["samples_rejected"], 0)
+        self.assertEqual(quality["acceptance_rate"], 1.0)
+        self.assertEqual(saved_report["dataset"]["skippedSamples"][0]["roomName"], "E26S48")
 
     def test_run_filters_incomplete_postdeploy_monitor_artifact_without_quality_rejection(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_dataset_gate.py
+++ b/scripts/test_screeps_rl_dataset_gate.py
@@ -315,17 +315,18 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
             current_room["rooms"][0]["roomName"] = "E29N55"
             current_artifact.write_text(runtime_line(current_room), encoding="utf-8")
 
-            report = gate.run_gate(
-                [str(stale_artifact), str(current_artifact)],
-                out_dir=root / "gates",
-                gate_id="gate-stale-non-current-filter",
-                created_at="2026-05-21T03:03:07Z",
-                dataset_out_dir=root / "datasets",
-                skip_shadow_report=True,
-                bot_commit="a" * 40,
-                eval_ratio_value=0,
-                repo_root=Path.cwd(),
-            )
+            with mock.patch.dict(gate.os.environ, {"SCREEPS_HOME_ROOM": "E29N55"}, clear=False):
+                report = gate.run_gate(
+                    [str(stale_artifact), str(current_artifact)],
+                    out_dir=root / "gates",
+                    gate_id="gate-stale-non-current-filter",
+                    created_at="2026-05-21T03:03:07Z",
+                    dataset_out_dir=root / "datasets",
+                    skip_shadow_report=True,
+                    bot_commit="a" * 40,
+                    eval_ratio_value=0,
+                    repo_root=Path.cwd(),
+                )
             saved_report = read_json(root / "gates" / "gate-stale-non-current-filter" / "gate_report.json")
 
         quality = report["quality_checks"]
@@ -344,6 +345,28 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
         self.assertEqual(quality["samples_rejected"], 0)
         self.assertEqual(quality["acceptance_rate"], 1.0)
         self.assertEqual(saved_report["dataset"]["skippedSamples"][0]["roomName"], "E26S48")
+
+    def test_run_rejects_malformed_created_at_before_stale_age_logic(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact = root / "runtime-summary-console-20260521T025000Z.log"
+            artifact.write_text(runtime_line(runtime_payload(1056600)), encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                gate.DatasetGateError,
+                "--created-at must be a valid ISO-8601 UTC timestamp",
+            ):
+                gate.run_gate(
+                    [str(artifact)],
+                    out_dir=root / "gates",
+                    gate_id="gate-invalid-created-at",
+                    created_at="INVALID_TIMESTAMP",
+                    dataset_out_dir=root / "datasets",
+                    skip_shadow_report=True,
+                    bot_commit="a" * 40,
+                    eval_ratio_value=0,
+                    repo_root=Path.cwd(),
+                )
 
     def test_run_filters_incomplete_postdeploy_monitor_artifact_without_quality_rejection(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- Filters stale non-current-room console samples out of E1 dataset/gate quality accounting while preserving current-room samples.
- Records skipped stale-sample evidence so future gate reports show the room, age, and skip reason instead of silently contaminating quality results.
- Adds focused regression tests for stale old non-current-room captures and current-room eligibility.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_dataset_export.py scripts/screeps_rl_dataset_gate.py`
- `python3 -m unittest scripts.test_screeps_rl_dataset_export scripts.test_screeps_rl_dataset_gate` (24 tests OK)

Closes #1288
