### PR TITLE
fix(rl): prove runtime parameter injection

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -12588,11 +12588,11 @@ function planRuntimeStrategyPrioritizedConstruction(colony, result, budgetState,
     return false;
   }
   const report = buildRuntimeConstructionPriorityReport(colony, options.creeps, { strategyParameters });
+  recordStrategyRegistryRuntimeUse(options, strategyEntry);
   const priorities = runtimeConstructionPlannerPriorityOrder(report, { sourceLogisticsStarved });
   if (priorities.length === 0) {
     return false;
   }
-  recordStrategyRegistryRuntimeUse(options, strategyEntry);
   let activePriorityTowerDefenseSiteState = priorityTowerDefenseSiteState;
   for (const priority of priorities) {
     activePriorityTowerDefenseSiteState = planRuntimeConstructionPlannerPriority(
@@ -46395,15 +46395,12 @@ function createRuntimePolicyParameterConsumptionRecorder() {
   };
 }
 function persistRuntimePolicyParameterConsumptionEvidence(evidence) {
-  const root = globalThis;
-  if (!root.Memory) {
-    root.Memory = {};
-  }
+  const memory = runtimeMemoryRoot();
   const persistedEvidence = stickyRuntimePolicyParameterConsumptionEvidence(
     evidence,
-    root.Memory.rlRuntimePolicyParameters
+    memory.rlRuntimePolicyParameters
   );
-  root.Memory.rlRuntimePolicyParameters = {
+  memory.rlRuntimePolicyParameters = {
     ...persistedEvidence,
     tick: runtimeTick()
   };
@@ -46542,8 +46539,21 @@ function cloneStrategyRegistryEntry(entry) {
 function textOrUndefined(value) {
   return typeof value === "string" && value.length > 0 ? value : void 0;
 }
+function runtimeMemoryRoot() {
+  if (typeof Memory !== "undefined") {
+    return Memory;
+  }
+  const root = globalThis;
+  if (!root.Memory) {
+    root.Memory = {};
+  }
+  return root.Memory;
+}
 function runtimeTick() {
   var _a, _b;
+  if (typeof Game !== "undefined" && typeof Game.time === "number") {
+    return Game.time;
+  }
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.time) != null ? _b : 0;
 }
 function isRecord41(value) {

--- a/prod/src/construction/planner.ts
+++ b/prod/src/construction/planner.ts
@@ -572,12 +572,12 @@ function planRuntimeStrategyPrioritizedConstruction(
   }
 
   const report = buildRuntimeConstructionPriorityReport(colony, options.creeps, { strategyParameters });
+  recordStrategyRegistryRuntimeUse(options, strategyEntry);
   const priorities = runtimeConstructionPlannerPriorityOrder(report, { sourceLogisticsStarved });
   if (priorities.length === 0) {
     return false;
   }
 
-  recordStrategyRegistryRuntimeUse(options, strategyEntry);
   let activePriorityTowerDefenseSiteState = priorityTowerDefenseSiteState;
   for (const priority of priorities) {
     activePriorityTowerDefenseSiteState = planRuntimeConstructionPlannerPriority(

--- a/prod/src/strategy/runtimePolicyParameters.ts
+++ b/prod/src/strategy/runtimePolicyParameters.ts
@@ -165,16 +165,13 @@ export function createRuntimePolicyParameterConsumptionRecorder(): RuntimePolicy
 export function persistRuntimePolicyParameterConsumptionEvidence(
   evidence: RuntimePolicyParameterConsumptionEvidence
 ): void {
-  const root = globalThis as typeof globalThis & { Memory?: RuntimeMemory };
-  if (!root.Memory) {
-    root.Memory = {};
-  }
+  const memory = runtimeMemoryRoot();
 
   const persistedEvidence = stickyRuntimePolicyParameterConsumptionEvidence(
     evidence,
-    root.Memory.rlRuntimePolicyParameters
+    memory.rlRuntimePolicyParameters
   );
-  root.Memory.rlRuntimePolicyParameters = {
+  memory.rlRuntimePolicyParameters = {
     ...persistedEvidence,
     tick: runtimeTick()
   };
@@ -371,7 +368,22 @@ function textOrUndefined(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
+function runtimeMemoryRoot(): RuntimeMemory {
+  if (typeof Memory !== 'undefined') {
+    return Memory as RuntimeMemory;
+  }
+
+  const root = globalThis as typeof globalThis & { Memory?: RuntimeMemory };
+  if (!root.Memory) {
+    root.Memory = {};
+  }
+  return root.Memory;
+}
+
 function runtimeTick(): number {
+  if (typeof Game !== 'undefined' && typeof Game.time === 'number') {
+    return Game.time;
+  }
   return (globalThis as { Game?: Partial<Game> }).Game?.time ?? 0;
 }
 

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -809,14 +809,17 @@ def _collect_http_runtime_parameter_consumption_evidence(
         {"shard": cfg.shard},
         {},
     ):
-        result = smoke.http_json(
-            "GET",
-            cfg.server_url,
-            "/api/user/memory",
-            headers=smoke.token_headers(token),
-            params=params,
-            timeout=RUN_PHASE_TIMEOUT_SECONDS,
-        )
+        try:
+            result = smoke.http_json(
+                "GET",
+                cfg.server_url,
+                "/api/user/memory",
+                headers=smoke.token_headers(token),
+                params=params,
+                timeout=RUN_API_TIMEOUT_SECONDS,
+            )
+        except Exception:  # noqa: BLE001 - one degraded memory probe must not block remaining shapes
+            continue
         if result.status != 200:
             continue
         evidence = find_runtime_parameter_consumption_evidence(result.payload, injection=injection)

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -803,17 +803,26 @@ def _collect_http_runtime_parameter_consumption_evidence(
     _ = compose
     if token is None:
         return None
-    result = smoke.http_json(
-        "GET",
-        cfg.server_url,
-        "/api/user/memory",
-        headers=smoke.token_headers(token),
-        params={"path": "rlRuntimePolicyParameters", "shard": cfg.shard},
-        timeout=RUN_PHASE_TIMEOUT_SECONDS,
-    )
-    if result.status != 200:
-        return None
-    return find_runtime_parameter_consumption_evidence(result.payload, injection=injection)
+    for params in (
+        {"path": "rlRuntimePolicyParameters", "shard": cfg.shard},
+        {"path": "rlRuntimePolicyParameters"},
+        {"shard": cfg.shard},
+        {},
+    ):
+        result = smoke.http_json(
+            "GET",
+            cfg.server_url,
+            "/api/user/memory",
+            headers=smoke.token_headers(token),
+            params=params,
+            timeout=RUN_PHASE_TIMEOUT_SECONDS,
+        )
+        if result.status != 200:
+            continue
+        evidence = find_runtime_parameter_consumption_evidence(result.payload, injection=injection)
+        if evidence is not None:
+            return evidence
+    return None
 
 
 def _collect_mongo_runtime_parameter_consumption_evidence(

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -998,14 +998,26 @@ def build_report_runtime_parameter_injection_summary(
         variant_id = raw_variant_id
         injection = result.get("runtimeParameterInjection")
         if isinstance(injection, dict):
-            rows.append({
+            row = {
                 "variantId": variant_id,
                 "status": injection.get("status"),
                 "runtimeParameterInjection": injection.get("runtimeParameterInjection") is True,
                 "candidateParameterScope": injection.get("candidateParameterScope"),
                 "parametersSha256": injection.get("parametersSha256"),
                 "reason": injection.get("reason"),
-            })
+            }
+            for field in (
+                "runtimeParameterConsumption",
+                "runtimeParameterConsumptionStatus",
+                "runtimeParameterConsumptionSource",
+                "runtimeParameterConsumer",
+                "evaluatedParametersSource",
+                "evaluatedParametersSha256",
+                "appliedStrategyIds",
+            ):
+                if field in injection:
+                    row[field] = copy.deepcopy(injection.get(field))
+            rows.append(row)
         else:
             rows.append({
                 "variantId": variant_id,
@@ -1024,20 +1036,30 @@ def build_report_runtime_parameter_injection_summary(
         })
 
     injected_count = sum(1 for row in rows if row.get("runtimeParameterInjection") is True)
+    consumed_count = sum(
+        1
+        for row in rows
+        if row.get("runtimeParameterInjection") is True and row.get("runtimeParameterConsumption") is True
+    )
     partial_count = sum(
         1
         for row in rows
         if row.get("status") == "partial" or row.get("candidateParameterScope") == "partial_runtime_injection"
     )
     attempted_runtime_count = sum(1 for row in rows if runtime_parameter_scope_indicates_runtime_attempt(row))
-    if rows and injected_count == len(rows):
+    complete_runtime_evidence = bool(rows) and injected_count == len(rows) and consumed_count == len(rows)
+    if complete_runtime_evidence:
         status = "injected"
         reason = None
         eligible = True
         scope = "runtime_injected"
     elif injected_count > 0 or partial_count > 0:
         status = "partial"
-        reason = "not every candidate variant had runtime-injected parameter evidence"
+        reason = (
+            "not every candidate variant had consumed runtime-injected parameter evidence"
+            if injected_count == len(rows)
+            else "not every candidate variant had runtime-injected parameter evidence"
+        )
         eligible = False
         scope = "partial_runtime_injection"
     elif attempted_runtime_count > 0:
@@ -1064,6 +1086,9 @@ def build_report_runtime_parameter_injection_summary(
         "policyUpdateEligible": eligible,
         "variantCount": len(rows),
         "injectedVariantCount": injected_count,
+        "runtimeParameterConsumption": consumed_count > 0,
+        "runtimeParameterConsumptionStatus": runtime_parameter_consumption_rollup_status(rows),
+        "consumedVariantCount": consumed_count,
         "variants": rows,
         "liveEffect": False,
         "officialMmoWrites": False,
@@ -1073,6 +1098,38 @@ def build_report_runtime_parameter_injection_summary(
     if reason:
         payload["reason"] = reason
     return payload
+
+
+def runtime_parameter_consumption_rollup_status(rows: Sequence[JsonObject]) -> str:
+    if not rows:
+        return "missing"
+    consumed = sum(
+        1
+        for row in rows
+        if row.get("runtimeParameterInjection") is True and row.get("runtimeParameterConsumption") is True
+    )
+    if consumed == len(rows):
+        return "consumed"
+    if consumed > 0:
+        return "partial"
+    statuses = [
+        text_or_none(
+            row.get("runtimeParameterConsumptionStatus")
+            if "runtimeParameterConsumptionStatus" in row
+            else row.get("status")
+        )
+        for row in rows
+        if text_or_none(
+            row.get("runtimeParameterConsumptionStatus")
+            if "runtimeParameterConsumptionStatus" in row
+            else row.get("status")
+        )
+        is not None
+    ]
+    if statuses:
+        first = statuses[0]
+        return first if all(status == first for status in statuses) else "mixed"
+    return "missing" if any(runtime_parameter_scope_indicates_runtime_attempt(row) for row in rows) else "not_attempted"
 
 
 def policy_gradient_candidate_match_ids(policy_gradient: JsonObject | None) -> dict[str, str]:
@@ -3028,20 +3085,26 @@ def multi_tier_activation_sample_trace(
     return trace
 
 
-def runtime_evaluated_parameter_source(run: JsonObject) -> tuple[str, Any] | None:
+def runtime_parameter_consumption_from_run(run: JsonObject) -> JsonObject | None:
     consumption = run.get("runtimeParameterConsumption")
-    if isinstance(consumption, dict) and consumption.get("runtimeParameterConsumption") is True:
-        parameters = consumption.get("evaluatedParameters")
-        if isinstance(parameters, dict):
-            return "runtimeParameterConsumption.evaluatedParameters", parameters
+    if isinstance(consumption, dict):
+        return consumption
 
     nested_injection = run.get("runtimeParameterInjection")
     if isinstance(nested_injection, dict):
         nested_consumption = nested_injection.get("runtimeParameterConsumptionEvidence")
-        if isinstance(nested_consumption, dict) and nested_consumption.get("runtimeParameterConsumption") is True:
-            parameters = nested_consumption.get("evaluatedParameters")
-            if isinstance(parameters, dict):
-                return "runtimeParameterInjection.runtimeParameterConsumptionEvidence.evaluatedParameters", parameters
+        if isinstance(nested_consumption, dict):
+            return nested_consumption
+
+    return None
+
+
+def runtime_evaluated_parameter_source(run: JsonObject) -> tuple[str, Any] | None:
+    consumption = runtime_parameter_consumption_from_run(run)
+    if isinstance(consumption, dict) and consumption.get("runtimeParameterConsumption") is True:
+        parameters = consumption.get("evaluatedParameters")
+        if isinstance(parameters, dict):
+            return "runtimeParameterConsumption.evaluatedParameters", parameters
 
     source = text_or_none(run.get("evaluatedParametersSource", run.get("evaluated_parameters_source")))
     if source in {
@@ -3114,9 +3177,29 @@ def summarize_runtime_parameter_injection_attempt(
         )
         return {key: value for key, value in row.items() if value is not None}
 
+    consumption = runtime_parameter_consumption_from_run(run)
+    if isinstance(consumption, dict):
+        row["runtimeParameterConsumption"] = consumption.get("runtimeParameterConsumption") is True
+        row["runtimeParameterConsumptionStatus"] = consumption.get("status")
+        row["runtimeParameterConsumptionSource"] = consumption.get("source")
+        row["runtimeParameterConsumer"] = consumption.get("consumerMarker")
+        applied_strategy_ids = consumption.get("appliedStrategyIds")
+        if isinstance(applied_strategy_ids, list):
+            row["appliedStrategyIds"] = [
+                strategy_id for strategy_id in applied_strategy_ids if isinstance(strategy_id, str)
+            ]
+
+    if not isinstance(consumption, dict) or consumption.get("runtimeParameterConsumption") is not True:
+        row["status"] = (
+            text_or_none(consumption.get("status")) if isinstance(consumption, dict) else None
+        ) or "missing_runtime_parameter_consumption"
+        row["reason"] = (
+            text_or_none(consumption.get("reason")) if isinstance(consumption, dict) else None
+        ) or "successful simulator attempt did not report consumed runtime policy parameter evidence"
+        return {key: value for key, value in row.items() if value is not None}
+
     source = runtime_evaluated_parameter_source(run)
     if source is None:
-        consumption = run.get("runtimeParameterConsumption")
         if isinstance(consumption, dict) and text_or_none(consumption.get("reason")):
             row["status"] = text_or_none(consumption.get("status")) or "missing_evaluated_parameters"
             row["reason"] = text_or_none(consumption.get("reason"))
@@ -3229,6 +3312,11 @@ def summarize_variant_runtime_parameter_injection(
 
     eligible_attempts = successful_attempts
     injected = [row for row in eligible_attempts if row.get("runtimeParameterInjection") is True]
+    consumed_attempt_count = sum(
+        1
+        for row in eligible_attempts
+        if row.get("runtimeParameterInjection") is True and row.get("runtimeParameterConsumption") is True
+    )
     if eligible_attempts and len(injected) == len(eligible_attempts):
         status = "injected"
         reason = None
@@ -3272,6 +3360,9 @@ def summarize_variant_runtime_parameter_injection(
         "successfulAttemptCount": len(successful_attempts),
         "attempts": attempts,
         "parametersSha256": canonical_hash(variant.parameters),
+        "runtimeParameterConsumption": runtime_injected and consumed_attempt_count == len(eligible_attempts),
+        "runtimeParameterConsumptionStatus": runtime_parameter_consumption_rollup_status(eligible_attempts),
+        "consumedAttemptCount": consumed_attempt_count,
         "liveEffect": False,
         "officialMmoWrites": False,
         "officialMmoWritesAllowed": False,
@@ -3280,6 +3371,16 @@ def summarize_variant_runtime_parameter_injection(
         payload["reason"] = reason
     if runtime_injected and isinstance(evaluated_parameters, dict):
         payload["evaluatedParameters"] = evaluated_parameters
+        first_injected = injected[0]
+        for field in (
+            "runtimeParameterConsumptionSource",
+            "runtimeParameterConsumer",
+            "evaluatedParametersSource",
+            "evaluatedParametersSha256",
+            "appliedStrategyIds",
+        ):
+            if field in first_injected:
+                payload[field] = copy.deepcopy(first_injected.get(field))
     return {key: value for key, value in payload.items() if value is not None}
 
 

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1790,6 +1790,112 @@ cli:
             ],
         )
 
+    def test_http_runtime_parameter_consumption_collector_continues_after_probe_failures(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+
+        class Result:
+            def __init__(self, status: int, payload: object) -> None:
+                self.status = status
+                self.payload = payload
+
+        class FakeConfig:
+            server_url = "http://sim.local"
+            shard = "shardX"
+
+        class ProbeTransportError(RuntimeError):
+            pass
+
+        class FakeSmoke:
+            calls: list[dict[str, object]] = []
+
+            def token_headers(self, token: str) -> dict[str, str]:
+                return {"X-Token": token}
+
+            def http_json(
+                self,
+                method: str,
+                base_url: str,
+                path: str,
+                *,
+                headers: dict[str, str],
+                params: dict[str, object],
+                timeout: int,
+            ) -> Result:
+                _ = method, base_url, path, headers, timeout
+                self.calls.append(dict(params))
+                if len(self.calls) == 1:
+                    raise ProbeTransportError("probe endpoint timed out")
+                if len(self.calls) == 2:
+                    return Result(503, {"ok": 0})
+                return Result(200, {
+                    "ok": 1,
+                    "data": json.dumps({"rlRuntimePolicyParameters": evidence}, sort_keys=True),
+                })
+
+        smoke = FakeSmoke()
+
+        extracted = harness._collect_http_runtime_parameter_consumption_evidence(
+            smoke,
+            None,
+            FakeConfig(),
+            "token",
+            injection,
+        )
+
+        self.assertEqual(extracted, evidence)
+        self.assertEqual(
+            smoke.calls,
+            [
+                {"path": "rlRuntimePolicyParameters", "shard": "shardX"},
+                {"path": "rlRuntimePolicyParameters"},
+                {"shard": "shardX"},
+            ],
+        )
+
+    def test_http_runtime_parameter_consumption_collector_uses_bounded_probe_timeout(self) -> None:
+        class Result:
+            status = 404
+            payload: object = {"ok": 0}
+
+        class FakeConfig:
+            server_url = "http://sim.local"
+            shard = "shardX"
+
+        class FakeSmoke:
+            timeouts: list[int] = []
+
+            def token_headers(self, token: str) -> dict[str, str]:
+                return {"X-Token": token}
+
+            def http_json(
+                self,
+                method: str,
+                base_url: str,
+                path: str,
+                *,
+                headers: dict[str, str],
+                params: dict[str, object],
+                timeout: int,
+            ) -> Result:
+                _ = method, base_url, path, headers, params
+                self.timeouts.append(timeout)
+                return Result()
+
+        smoke = FakeSmoke()
+
+        extracted = harness._collect_http_runtime_parameter_consumption_evidence(
+            smoke,
+            None,
+            FakeConfig(),
+            "token",
+        )
+
+        self.assertIsNone(extracted)
+        self.assertEqual(smoke.timeouts, [harness.RUN_API_TIMEOUT_SECONDS] * 4)
+        self.assertLess(max(smoke.timeouts), harness.RUN_PHASE_TIMEOUT_SECONDS)
+        self.assertLess(sum(smoke.timeouts), harness.RUN_PHASE_TIMEOUT_SECONDS)
+
     def test_runtime_parameter_consumption_prefers_matching_evidence(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         stale = self.runtime_parameter_consumption_evidence(injection)

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1732,6 +1732,64 @@ cli:
 
         self.assertEqual(extracted, evidence)
 
+    def test_http_runtime_parameter_consumption_collector_falls_back_to_full_memory(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+
+        class Result:
+            def __init__(self, payload: object) -> None:
+                self.status = 200
+                self.payload = payload
+
+        class FakeConfig:
+            server_url = "http://sim.local"
+            shard = "shardX"
+
+        class FakeSmoke:
+            calls: list[dict[str, object]] = []
+
+            def token_headers(self, token: str) -> dict[str, str]:
+                return {"X-Token": token}
+
+            def http_json(
+                self,
+                method: str,
+                base_url: str,
+                path: str,
+                *,
+                headers: dict[str, str],
+                params: dict[str, object],
+                timeout: int,
+            ) -> Result:
+                _ = method, base_url, path, headers, timeout
+                self.calls.append(dict(params))
+                if params.get("path") == "rlRuntimePolicyParameters":
+                    return Result({"ok": 1, "data": None})
+                return Result({
+                    "ok": 1,
+                    "data": json.dumps({"rlRuntimePolicyParameters": evidence}, sort_keys=True),
+                })
+
+        smoke = FakeSmoke()
+
+        extracted = harness._collect_http_runtime_parameter_consumption_evidence(
+            smoke,
+            None,
+            FakeConfig(),
+            "token",
+            injection,
+        )
+
+        self.assertEqual(extracted, evidence)
+        self.assertEqual(
+            smoke.calls,
+            [
+                {"path": "rlRuntimePolicyParameters", "shard": "shardX"},
+                {"path": "rlRuntimePolicyParameters"},
+                {"shard": "shardX"},
+            ],
+        )
+
     def test_runtime_parameter_consumption_prefers_matching_evidence(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         stale = self.runtime_parameter_consumption_evidence(injection)

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -158,12 +158,14 @@ class MockSimulator:
         *,
         inject_runtime_parameters: bool = False,
         include_evaluated_parameters: bool = True,
+        include_runtime_consumption_evidence: bool = True,
         include_runtime_consumption_parameters: bool = True,
         evaluated_parameters_by_variant: dict[str, JsonObject] | None = None,
     ) -> None:
         self.results_by_variant = results_by_variant
         self.inject_runtime_parameters = inject_runtime_parameters
         self.include_evaluated_parameters = include_evaluated_parameters
+        self.include_runtime_consumption_evidence = include_runtime_consumption_evidence
         self.include_runtime_consumption_parameters = include_runtime_consumption_parameters
         self.evaluated_parameters_by_variant = evaluated_parameters_by_variant or {}
         self.calls: list[JsonObject] = []
@@ -221,15 +223,19 @@ class MockSimulator:
                     "officialMmoWrites": False,
                     "officialMmoWritesAllowed": False,
                 }
-                result["runtimeParameterConsumption"] = runner.simulator_harness.runtime_parameter_consumption_check(
-                    result["runtimeParameterInjection"],
-                    consumption_evidence,
-                )
-                if not self.include_runtime_consumption_parameters:
-                    result["runtimeParameterConsumption"].pop("evaluatedParameters", None)
-                    result["runtimeParameterConsumption"].pop("evaluatedParametersSha256", None)
+                if self.include_runtime_consumption_evidence:
+                    result["runtimeParameterConsumption"] = runner.simulator_harness.runtime_parameter_consumption_check(
+                        result["runtimeParameterInjection"],
+                        consumption_evidence,
+                    )
+                    if not self.include_runtime_consumption_parameters:
+                        result["runtimeParameterConsumption"].pop("evaluatedParameters", None)
+                        result["runtimeParameterConsumption"].pop("evaluatedParametersSha256", None)
                 if self.include_evaluated_parameters:
-                    if result["runtimeParameterConsumption"].get("runtimeParameterConsumption") is True:
+                    if (
+                        isinstance(result.get("runtimeParameterConsumption"), dict)
+                        and result["runtimeParameterConsumption"].get("runtimeParameterConsumption") is True
+                    ) or not self.include_runtime_consumption_evidence:
                         result["evaluatedParameters"] = copy.deepcopy(evaluated_parameters)
                         result["evaluatedParametersSource"] = "runtime_parameter_consumption"
             variants.append(result)
@@ -1970,6 +1976,8 @@ export const STRATEGY_REGISTRY = [
                     "runtimeParameterInjection": {
                         "status": "injected",
                         "runtimeParameterInjection": True,
+                        "runtimeParameterConsumption": True,
+                        "runtimeParameterConsumptionStatus": "consumed",
                         "candidateParameterScope": "runtime_injected",
                         "parametersSha256": "candidate-sha",
                     },
@@ -2001,6 +2009,8 @@ export const STRATEGY_REGISTRY = [
 
         self.assertEqual(summary["status"], "injected")
         self.assertTrue(summary["runtimeParameterInjection"])
+        self.assertTrue(summary["runtimeParameterConsumption"])
+        self.assertEqual(summary["consumedVariantCount"], 1)
         self.assertEqual(summary["variantCount"], 1)
         self.assertEqual([row["variantId"] for row in summary["variants"]], ["candidate"])
 
@@ -2511,6 +2521,9 @@ export const STRATEGY_REGISTRY = [
 
         self.assertEqual(report["runtimeParameterInjection"]["status"], "injected")
         self.assertTrue(report["runtimeParameterInjection"]["runtimeParameterInjection"])
+        self.assertTrue(report["runtimeParameterInjection"]["runtimeParameterConsumption"])
+        self.assertEqual(report["runtimeParameterInjection"]["runtimeParameterConsumptionStatus"], "consumed")
+        self.assertEqual(report["runtimeParameterInjection"]["consumedVariantCount"], len(variant_ids))
         self.assertIsNotNone(report["scorecardId"])
         self.assertEqual(report["candidateScorecard"]["status"], "ready")
         self.assertTrue(report["candidateScorecard"]["runtimeParameterInjection"])
@@ -2532,6 +2545,13 @@ export const STRATEGY_REGISTRY = [
         self.assertTrue(artifact_dir_exists)
         self.assertTrue(artifact_path_exists)
         self.assertTrue(all(result["runtimeParameterInjection"]["runtimeParameterInjection"] for result in report["variantResults"]))
+        self.assertTrue(all(result["runtimeParameterInjection"]["runtimeParameterConsumption"] for result in report["variantResults"]))
+        self.assertTrue(
+            all(
+                result["runtimeParameterInjection"]["runtimeParameterConsumptionStatus"] == "consumed"
+                for result in report["variantResults"]
+            )
+        )
         self.assertTrue(all("evaluatedParameters" in result for result in report["variantResults"]))
         self.assertFalse(report["officialMmoWritesAllowed"])
         self.assertFalse(persisted["officialMmoWritesAllowed"])
@@ -2787,6 +2807,55 @@ export const STRATEGY_REGISTRY = [
                 for result in simulator.last_variants
             )
         )
+
+    def test_runtime_injected_reinforce_requires_explicit_consumption_evidence(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-missing-consumption",
+            code_commit="f" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-17T06:55:00Z",
+            simulation_ticks=100,
+            simulation_repetitions=1,
+        )
+        variant_ids = [variant["id"] for variant in card["strategy_variants"]]
+        start = tick(1, [room("W1N1", energy=100)])
+        simulator_results = {
+            variant_id: variant_result(variant_id, [start, tick(2, [room("W1N1", energy=200)])])
+            for variant_id in variant_ids
+        }
+        simulator = MockSimulator(
+            simulator_results,
+            inject_runtime_parameters=True,
+            include_runtime_consumption_evidence=False,
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="policy-gradient-missing-consumption",
+                generated_at="2026-05-17T07:00:00Z",
+                simulator_runner=simulator,
+            )
+
+        self.assertEqual(report["runtimeParameterInjection"]["status"], "not_injected")
+        self.assertFalse(report["runtimeParameterInjection"]["runtimeParameterInjection"])
+        self.assertFalse(report["runtimeParameterInjection"]["policyUpdateEligible"])
+        self.assertEqual(report["runtimeParameterInjection"]["candidateParameterScope"], "runtime_injected")
+        self.assertEqual(report["runtimeParameterInjection"]["injectedVariantCount"], 0)
+        self.assertEqual(
+            report["runtimeParameterInjection"]["runtimeParameterConsumptionStatus"],
+            "missing_runtime_parameter_consumption",
+        )
+        self.assertEqual(report["policyUpdateIterations"], 0)
+        self.assertFalse(report["policyUpdate"]["parameterEvidence"]["policyUpdateEligible"])
+        self.assertFalse(report["policyUpdate"]["parameterEvidence"]["runtimeParameterInjection"])
+        self.assertNotIn("policyUpdateArtifactPath", report)
+        self.assertTrue(all("evaluatedParameters" in result for result in simulator.last_variants))
+        self.assertTrue(all("runtimeParameterConsumption" not in result for result in simulator.last_variants))
 
     def test_failed_only_runtime_parameter_uploads_do_not_become_injected_evidence(self) -> None:
         card = card_helper.build_card(


### PR DESCRIPTION
## Summary
- Proves runtime RL policy parameter injection end-to-end by recording selected policy variants into runtime policy metadata and downstream RL dataset exports/gates.
- Adds dataset/export fields and guardrails so training summaries can prove `runtimeParameterInjection`, `injectedVariantCount`, and consumed experiment-card state instead of relying on static metadata.
- Extends simulator/training runner tests around runtime injection and policy-gradient validation.

Fixes #1290

## Verification
- `python3 -m py_compile scripts/screeps_rl_dataset_export.py scripts/screeps_rl_dataset_gate.py scripts/screeps_rl_simulator_harness.py scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_dataset_export.py scripts/test_screeps_rl_dataset_gate.py scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py`
- `python3 -m unittest scripts/test_screeps_rl_dataset_export.py scripts/test_screeps_rl_dataset_gate.py scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py` (196 tests)
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (101 suites / 2000 tests)
- `cd prod && npm run build`
- `git diff --check`

## Safety / operations
- No official MMO writes are introduced by this PR.
- Active Tencent run `tencent-pg-20260521t062005z` was already in progress when this PR was opened; no duplicate paid compute was launched for this PR. Next steward should digest that run and wait for scale-down before starting another validation.
