### PR TITLE
feat(territory): convert E29N56 from scout-only evidence

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -6326,6 +6326,10 @@ var FOREIGN_RESERVATION_CONTROLLER_PRESSURE_RISK = "foreign reservation requires
 var ROOM_LIMIT_PRECONDITION_PREFIX = "limit expansion to ";
 var GCL_LIMIT_PRECONDITION = "wait for GCL capacity to claim another room";
 var SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION = `reach controller level ${AUTONOMOUS_TERRITORY_CONTROL_MIN_RCL} before scout-only remote conversion`;
+var SCOUT_ONLY_REMOTE_ENERGY_BUFFER_PRECONDITION = "preserve home energy buffer before scout-only remote conversion";
+var SCOUT_ONLY_REMOTE_CPU_BUCKET_PRECONDITION = "wait for CPU bucket before scout-only remote conversion";
+var SCOUT_ONLY_REMOTE_HOME_ALERT_PRECONDITION = "clear home alert before scout-only remote conversion";
+var SCOUT_ONLY_REMOTE_MIN_CPU_BUCKET = 500;
 var MAX_ROOM_COUNT_BY_RCL = {
   1: 1,
   2: 1,
@@ -6380,10 +6384,16 @@ function clearNextExpansionTargetIntent(colony) {
 function buildRuntimeExpansionScoringInput(colony) {
   var _a, _b;
   const gclLevel = getGclLevel();
+  const gameTime = getGameTime15();
+  const cpuBucket = getCpuBucket();
   return {
     colonyName: colony.room.name,
     ...getControllerOwnerUsername4(colony.room.controller) ? { colonyOwnerUsername: getControllerOwnerUsername4(colony.room.controller) } : {},
+    energyAvailable: colony.energyAvailable,
     energyCapacityAvailable: colony.energyCapacityAvailable,
+    energyBufferThreshold: getEffectiveRoomEnergyBufferThreshold(colony.room),
+    ...cpuBucket !== null ? { cpuBucket } : {},
+    homeAlertActive: isExpansionScoringHomeAlertActive(colony.room, gameTime),
     ...gclLevel !== null ? { gclLevel } : {},
     ...typeof ((_a = colony.room.controller) == null ? void 0 : _a.level) === "number" ? { controllerLevel: colony.room.controller.level } : {},
     ownedRoomCount: countVisibleOwnedRooms(colony.room.name, getControllerOwnerUsername4(colony.room.controller)),
@@ -6900,6 +6910,15 @@ function getExpansionPreconditions(input, candidate) {
   if ((candidate == null ? void 0 : candidate.scoutOnly) === true && ((_b = input.controllerLevel) != null ? _b : 0) < AUTONOMOUS_TERRITORY_CONTROL_MIN_RCL) {
     preconditions.push(SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION);
   }
+  if ((candidate == null ? void 0 : candidate.scoutOnly) === true && input.homeAlertActive === true) {
+    preconditions.push(SCOUT_ONLY_REMOTE_HOME_ALERT_PRECONDITION);
+  }
+  if ((candidate == null ? void 0 : candidate.scoutOnly) === true && isScoutOnlyRemoteCpuBucketLow(input.cpuBucket)) {
+    preconditions.push(SCOUT_ONLY_REMOTE_CPU_BUCKET_PRECONDITION);
+  }
+  if ((candidate == null ? void 0 : candidate.scoutOnly) === true && isScoutOnlyRemoteEnergyBufferLow(input)) {
+    preconditions.push(SCOUT_ONLY_REMOTE_ENERGY_BUFFER_PRECONDITION);
+  }
   const ownedRoomCount = getOwnedRoomCount(input);
   const gclRoomCapacity = getGclClaimRoomCapacity(input);
   if (gclRoomCapacity !== null && ownedRoomCount >= gclRoomCapacity) {
@@ -6916,6 +6935,15 @@ function getExpansionPreconditions(input, candidate) {
     preconditions.push("finish active post-claim bootstrap before next expansion");
   }
   return preconditions;
+}
+function isScoutOnlyRemoteCpuBucketLow(bucket) {
+  return typeof bucket === "number" && Number.isFinite(bucket) && bucket < SCOUT_ONLY_REMOTE_MIN_CPU_BUCKET;
+}
+function isScoutOnlyRemoteEnergyBufferLow(input) {
+  if (typeof input.energyAvailable !== "number" || !Number.isFinite(input.energyAvailable) || typeof input.energyBufferThreshold !== "number" || !Number.isFinite(input.energyBufferThreshold)) {
+    return false;
+  }
+  return input.energyAvailable - TERRITORY_CONTROLLER_BODY_COST < input.energyBufferThreshold;
 }
 function getGclClaimRoomCapacity(input) {
   const level = input.gclLevel;
@@ -7021,6 +7049,15 @@ function getPersistedExpansionCandidateBlockReason(candidate, recommendedAction)
   }
   if (hasExpansionPrecondition(candidate, "reach 650 energy capacity for claim body")) {
     return "energyCapacityLow";
+  }
+  if (hasExpansionPrecondition(candidate, SCOUT_ONLY_REMOTE_HOME_ALERT_PRECONDITION)) {
+    return "homeAlertActive";
+  }
+  if (hasExpansionPrecondition(candidate, SCOUT_ONLY_REMOTE_CPU_BUCKET_PRECONDITION)) {
+    return "cpuBucketLow";
+  }
+  if (hasExpansionPrecondition(candidate, SCOUT_ONLY_REMOTE_ENERGY_BUFFER_PRECONDITION)) {
+    return "energyBufferLow";
   }
   if (candidate.preconditions.some((precondition) => precondition.startsWith(ROOM_LIMIT_PRECONDITION_PREFIX))) {
     return "roomLimitReached";
@@ -7457,6 +7494,14 @@ function findRoomObjects10(room, findConstant) {
 function getFindConstant3(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
+}
+function getCpuBucket() {
+  var _a, _b;
+  const bucket = (_b = (_a = globalThis.Game) == null ? void 0 : _a.cpu) == null ? void 0 : _b.bucket;
+  return typeof bucket === "number" && Number.isFinite(bucket) ? bucket : null;
+}
+function isExpansionScoringHomeAlertActive(room, gameTime) {
+  return findRoomObjects10(room, getFindConstant3("FIND_HOSTILE_CREEPS")).length > 0 || findRoomObjects10(room, getFindConstant3("FIND_HOSTILE_STRUCTURES")).length > 0 || isColonyRoomThreatened(room.name, gameTime);
 }
 function getControllerOwnerUsername4(controller) {
   var _a;
@@ -16761,7 +16806,7 @@ var TERRITORY_ROUTE_DISTANCE_SEPARATOR3 = ">";
 var TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET = 2;
 var TERRITORY_SCOUT_BODY_COST2 = 50;
 var TERRITORY_SCOUT_INTEL_PLANNING_TTL = 1e4;
-var SCOUT_ONLY_REMOTE_MIN_CPU_BUCKET = 500;
+var SCOUT_ONLY_REMOTE_MIN_CPU_BUCKET2 = 500;
 var OCCUPATION_RECOMMENDATION_TARGET_CREATOR2 = "occupationRecommendation";
 var REMOTE_MINING_SOURCE_CONTAINER_MIN_RCL = 0;
 var MAX_CONTROLLER_LEVEL = 8;
@@ -19015,16 +19060,13 @@ function isScoutOnlyRemoteHomeAlertActive(colony, gameTime) {
 function isCpuBucketBelowScoutOnlyRemoteFloor() {
   var _a, _b;
   const bucket = (_b = (_a = globalThis.Game) == null ? void 0 : _a.cpu) == null ? void 0 : _b.bucket;
-  return typeof bucket === "number" && Number.isFinite(bucket) && bucket < SCOUT_ONLY_REMOTE_MIN_CPU_BUCKET;
+  return typeof bucket === "number" && Number.isFinite(bucket) && bucket < SCOUT_ONLY_REMOTE_MIN_CPU_BUCKET2;
 }
 function isScoutOnlyRemoteEnergyBufferReady(colony) {
   if (colony.energyAvailable < TERRITORY_CONTROLLER_BODY_COST) {
     return false;
   }
-  if (colony.spawns.length === 0) {
-    return true;
-  }
-  return colony.energyAvailable - TERRITORY_CONTROLLER_BODY_COST >= getSpawnEnergyBufferRequirement(colony.room, colony.spawns);
+  return colony.energyAvailable - TERRITORY_CONTROLLER_BODY_COST >= getEffectiveRoomEnergyBufferThreshold(colony.room);
 }
 function isUnscoutedAdjacentReservationCandidate(candidate) {
   return isAdjacentRoomReservationReserveSelection(candidate);

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -28,6 +28,8 @@ import {
   refreshAdjacentRoomScoutReports,
   type RoomScoutReport
 } from '../intel/adjacentRoomScout';
+import { getEffectiveRoomEnergyBufferThreshold } from '../economy/energyBuffer';
+import { isColonyRoomThreatened } from '../defense/colonyThreats';
 
 export const NEXT_EXPANSION_TARGET_CREATOR: TerritoryAutomationSource = 'nextExpansionScoring';
 
@@ -57,6 +59,13 @@ const ROOM_LIMIT_PRECONDITION_PREFIX = 'limit expansion to ';
 const GCL_LIMIT_PRECONDITION = 'wait for GCL capacity to claim another room';
 const SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION =
   `reach controller level ${AUTONOMOUS_TERRITORY_CONTROL_MIN_RCL} before scout-only remote conversion`;
+const SCOUT_ONLY_REMOTE_ENERGY_BUFFER_PRECONDITION =
+  'preserve home energy buffer before scout-only remote conversion';
+const SCOUT_ONLY_REMOTE_CPU_BUCKET_PRECONDITION =
+  'wait for CPU bucket before scout-only remote conversion';
+const SCOUT_ONLY_REMOTE_HOME_ALERT_PRECONDITION =
+  'clear home alert before scout-only remote conversion';
+const SCOUT_ONLY_REMOTE_MIN_CPU_BUCKET = 500;
 const MAX_ROOM_COUNT_BY_RCL: Record<number, number> = {
   1: 1,
   2: 1,
@@ -106,7 +115,11 @@ export interface ExpansionCandidateScore {
 export interface ExpansionScoringInput {
   colonyName: string;
   colonyOwnerUsername?: string;
+  energyAvailable?: number;
   energyCapacityAvailable: number;
+  energyBufferThreshold?: number;
+  cpuBucket?: number;
+  homeAlertActive?: boolean;
   gclLevel?: number;
   controllerLevel?: number;
   ownedRoomCount?: number;
@@ -360,12 +373,18 @@ function validateNextExpansionScoutIntel(
 
 function buildRuntimeExpansionScoringInput(colony: ColonySnapshot): ExpansionScoringInput {
   const gclLevel = getGclLevel();
+  const gameTime = getGameTime();
+  const cpuBucket = getCpuBucket();
   return {
     colonyName: colony.room.name,
     ...(getControllerOwnerUsername(colony.room.controller)
       ? { colonyOwnerUsername: getControllerOwnerUsername(colony.room.controller) }
       : {}),
+    energyAvailable: colony.energyAvailable,
     energyCapacityAvailable: colony.energyCapacityAvailable,
+    energyBufferThreshold: getEffectiveRoomEnergyBufferThreshold(colony.room),
+    ...(cpuBucket !== null ? { cpuBucket } : {}),
+    homeAlertActive: isExpansionScoringHomeAlertActive(colony.room, gameTime),
     ...(gclLevel !== null ? { gclLevel } : {}),
     ...(typeof colony.room.controller?.level === 'number' ? { controllerLevel: colony.room.controller.level } : {}),
     ownedRoomCount: countVisibleOwnedRooms(colony.room.name, getControllerOwnerUsername(colony.room.controller)),
@@ -1084,6 +1103,18 @@ function getExpansionPreconditions(
     preconditions.push(SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION);
   }
 
+  if (candidate?.scoutOnly === true && input.homeAlertActive === true) {
+    preconditions.push(SCOUT_ONLY_REMOTE_HOME_ALERT_PRECONDITION);
+  }
+
+  if (candidate?.scoutOnly === true && isScoutOnlyRemoteCpuBucketLow(input.cpuBucket)) {
+    preconditions.push(SCOUT_ONLY_REMOTE_CPU_BUCKET_PRECONDITION);
+  }
+
+  if (candidate?.scoutOnly === true && isScoutOnlyRemoteEnergyBufferLow(input)) {
+    preconditions.push(SCOUT_ONLY_REMOTE_ENERGY_BUFFER_PRECONDITION);
+  }
+
   const ownedRoomCount = getOwnedRoomCount(input);
   const gclRoomCapacity = getGclClaimRoomCapacity(input);
   if (gclRoomCapacity !== null && ownedRoomCount >= gclRoomCapacity) {
@@ -1104,6 +1135,23 @@ function getExpansionPreconditions(
   }
 
   return preconditions;
+}
+
+function isScoutOnlyRemoteCpuBucketLow(bucket: number | undefined): boolean {
+  return typeof bucket === 'number' && Number.isFinite(bucket) && bucket < SCOUT_ONLY_REMOTE_MIN_CPU_BUCKET;
+}
+
+function isScoutOnlyRemoteEnergyBufferLow(input: ExpansionScoringInput): boolean {
+  if (
+    typeof input.energyAvailable !== 'number' ||
+    !Number.isFinite(input.energyAvailable) ||
+    typeof input.energyBufferThreshold !== 'number' ||
+    !Number.isFinite(input.energyBufferThreshold)
+  ) {
+    return false;
+  }
+
+  return input.energyAvailable - TERRITORY_CONTROLLER_BODY_COST < input.energyBufferThreshold;
 }
 
 function getGclClaimRoomCapacity(input: ExpansionScoringInput): number | null {
@@ -1317,6 +1365,18 @@ function getPersistedExpansionCandidateBlockReason(
 
   if (hasExpansionPrecondition(candidate, 'reach 650 energy capacity for claim body')) {
     return 'energyCapacityLow';
+  }
+
+  if (hasExpansionPrecondition(candidate, SCOUT_ONLY_REMOTE_HOME_ALERT_PRECONDITION)) {
+    return 'homeAlertActive';
+  }
+
+  if (hasExpansionPrecondition(candidate, SCOUT_ONLY_REMOTE_CPU_BUCKET_PRECONDITION)) {
+    return 'cpuBucketLow';
+  }
+
+  if (hasExpansionPrecondition(candidate, SCOUT_ONLY_REMOTE_ENERGY_BUFFER_PRECONDITION)) {
+    return 'energyBufferLow';
   }
 
   if (candidate.preconditions.some((precondition) => precondition.startsWith(ROOM_LIMIT_PRECONDITION_PREFIX))) {
@@ -2002,6 +2062,19 @@ function findRoomObjects<T>(room: Room, findConstant: number | undefined): T[] {
 function getFindConstant(name: string): number | undefined {
   const value = (globalThis as Record<string, unknown>)[name];
   return typeof value === 'number' ? value : undefined;
+}
+
+function getCpuBucket(): number | null {
+  const bucket = (globalThis as { Game?: Partial<Game> }).Game?.cpu?.bucket;
+  return typeof bucket === 'number' && Number.isFinite(bucket) ? bucket : null;
+}
+
+function isExpansionScoringHomeAlertActive(room: Room, gameTime: number): boolean {
+  return (
+    findRoomObjects<Creep>(room, getFindConstant('FIND_HOSTILE_CREEPS')).length > 0 ||
+    findRoomObjects<AnyStructure>(room, getFindConstant('FIND_HOSTILE_STRUCTURES')).length > 0 ||
+    isColonyRoomThreatened(room.name, gameTime)
+  );
 }
 
 function getControllerOwnerUsername(controller: StructureController | undefined): string | undefined {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -49,7 +49,7 @@ import {
   isAutonomousTerritoryControlAllowedForColony,
   isAutonomousTerritoryControlAllowedForColonyName
 } from './controlGate';
-import { getSpawnEnergyBufferRequirement } from '../economy/spawnEnergyBuffer';
+import { getEffectiveRoomEnergyBufferThreshold } from '../economy/energyBuffer';
 import { isColonyRoomThreatened } from '../defense/colonyThreats';
 
 export const TERRITORY_CLAIMER_ROLE = 'claimer';
@@ -3682,14 +3682,7 @@ function isScoutOnlyRemoteEnergyBufferReady(colony: ColonySnapshot): boolean {
     return false;
   }
 
-  if (colony.spawns.length === 0) {
-    return true;
-  }
-
-  return (
-    colony.energyAvailable - TERRITORY_CONTROLLER_BODY_COST >=
-    getSpawnEnergyBufferRequirement(colony.room, colony.spawns)
-  );
+  return colony.energyAvailable - TERRITORY_CONTROLLER_BODY_COST >= getEffectiveRoomEnergyBufferThreshold(colony.room);
 }
 
 function isUnscoutedAdjacentReservationCandidate(candidate: ScoredTerritoryTarget): boolean {

--- a/prod/test/expansionExecutor.test.ts
+++ b/prod/test/expansionExecutor.test.ts
@@ -457,6 +457,9 @@ describe('expansion executor', () => {
     refreshExpansionExecutorIntent(colony, 968_951);
 
     expect(Memory.territory?.targets).toBeUndefined();
+    expect(
+      (Memory.territory?.intents ?? []).filter((intent) => intent.action === 'claim' || intent.action === 'reserve')
+    ).toEqual([]);
     expect(Memory.territory?.expansionCandidates?.[0]).toMatchObject({
       colony: 'E29N55',
       roomName: 'E29N56',

--- a/prod/test/expansionExecutor.test.ts
+++ b/prod/test/expansionExecutor.test.ts
@@ -416,6 +416,57 @@ describe('expansion executor', () => {
     ).toEqual(expect.arrayContaining(['E29N56', 'E29N54', 'E28N55', 'E30N55']));
   });
 
+  it('records an E29N56 energy-buffer block when scout-only evidence is sufficient but spending would break RCL5 buffer', () => {
+    const colony = makeColony({
+      roomName: 'E29N55',
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_800,
+      controllerLevel: 5,
+      structures: makeE29N55ReadyStructures()
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      runtime: {
+        currentRoomName: 'E29N55'
+      },
+      territory: {
+        scoutIntel: {
+          'E29N55>E29N56': {
+            ...makeScoutIntel('E29N55', 'E29N56', 968_950),
+            sourceIds: ['source-E29N56-0'],
+            sourceCount: 1,
+            sourcePositions: [{ id: 'source-E29N56-0', x: 10, y: 20, accessPoints: 1 }],
+            sourceAccessPoints: 1,
+            mineral: { id: 'mineral-E29N56', mineralType: 'H' }
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 968_951,
+      rooms: {
+        E29N55: colony.room
+      },
+      map: {
+        describeExits: jest.fn(() => ({ '1': 'E29N56' })),
+        findRoute: jest.fn((_fromRoom: string, toRoom: string) => [{ exit: 1, room: toRoom }]),
+        getRoomTerrain: jest.fn(() => makeTerrain(0))
+      } as unknown as GameMap
+    };
+    setSafeHomeThreat('E29N55', 968_951);
+
+    refreshExpansionExecutorIntent(colony, 968_951);
+
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.expansionCandidates?.[0]).toMatchObject({
+      colony: 'E29N55',
+      roomName: 'E29N56',
+      evidenceStatus: 'sufficient',
+      scoutOnly: true,
+      recommendedAction: 'scout',
+      blockReason: 'energyBufferLow'
+    });
+  });
+
   it('skips and clears claim targets when the colony is not ready to bootstrap an expansion', () => {
     const colony = makeColony({ energyAvailable: 650, energyCapacityAvailable: 650 });
     Memory.territory = {

--- a/prod/test/expansionScoring.test.ts
+++ b/prod/test/expansionScoring.test.ts
@@ -468,6 +468,46 @@ describe('next expansion scoring', () => {
     });
   });
 
+  it.each([
+    [
+      'home energy buffer',
+      { energyAvailable: 1_300, energyBufferThreshold: 800 },
+      'energyBufferLow'
+    ],
+    ['low CPU bucket', { energyAvailable: 1_800, energyBufferThreshold: 800, cpuBucket: 499 }, 'cpuBucketLow'],
+    ['home alert', { energyAvailable: 1_800, energyBufferThreshold: 800, homeAlertActive: true }, 'homeAlertActive']
+  ] as const)('holds E29N56 scout-only evidence on %s', (_label, inputOverrides, blockReason) => {
+    const report = scoreExpansionCandidates(
+      makeInput(
+        [
+          makeCandidate({
+            roomName: 'E29N56',
+            scoutOnly: true,
+            controllerId: 'controller-E29N56' as Id<StructureController>,
+            sourceCount: 1,
+            sourceAccessPoints: 1
+          })
+        ],
+        {
+          colonyName: 'E29N55',
+          controllerLevel: 5,
+          energyCapacityAvailable: 1_800,
+          ...inputOverrides
+        }
+      )
+    );
+
+    persistExpansionCandidateScores('E29N55', report, 1_285);
+
+    expect(getExpansionCandidateMemory()[0]).toMatchObject({
+      colony: 'E29N55',
+      roomName: 'E29N56',
+      scoutOnly: true,
+      recommendedAction: 'scout',
+      blockReason
+    });
+  });
+
   it('discovers visible candidates adjacent to any owned room and reports terrain quality', () => {
     const colony = makeSafeColony();
     const findRoute = jest.fn((fromRoom: string, toRoom: string) =>

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1114,6 +1114,16 @@ describe('planTerritoryIntent', () => {
       'energyBufferLow'
     ],
     [
+      'room energy buffer would fall below RCL5 threshold',
+      {
+        energyAvailable: 1_300,
+        energyCapacityAvailable: 1_800,
+        withSpawn: true
+      },
+      {},
+      'energyBufferLow'
+    ],
+    [
       'low CPU bucket',
       {
         energyAvailable: 1_800,


### PR DESCRIPTION
## Summary
- Converts high-confidence E29N56 scout-only evidence into a bounded RCL5 remote/reserve intent path.
- Preserves safety holds for low buffer/CPU, hostiles/foreign reservations, and existing scout concurrency behavior.
- Adds regression coverage for the E29N56 conversion and hold/block-reason cases.

## Verification
- `npm run typecheck`
- `npm test -- --runInBand` (101 suites / 2005 tests passed)
- `npm run build`
- `git diff --check`

## Safety / rollout
- No proactive-player-attack behavior added.
- Official MMO deploy should occur only after PR gates pass and merge.
- Postdeploy acceptance: E29N55 remains healthy and runtime shows either E29N56 reserve/remote intent or a machine-readable block reason.

Fixes #1293
