### PR TITLE
fix(rl): allow scorecarded policy updates

### DIFF
--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -1513,6 +1513,7 @@ def build_rank_weighted_finite_difference_policy_update(
             **base,
             "skippedReason": "bounded_update_no_parameter_change",
             "candidateCount": len(candidates),
+            "parameterEvidence": parameter_evidence,
             "anchor": policy_update_candidate_summary(anchor),
             "candidateRewards": [policy_update_candidate_summary(row) for row in candidates],
             "learningRate": learning_rate,
@@ -1683,6 +1684,7 @@ def build_reinforce_policy_update(
             **base,
             "skippedReason": "bounded_update_no_parameter_change",
             "candidateCount": len(candidates),
+            "parameterEvidence": parameter_evidence,
             "anchor": policy_update_candidate_summary(anchor),
             "candidateRewards": [policy_update_candidate_summary(row) for row in candidates],
             "learningRate": learning_rate,
@@ -1871,6 +1873,7 @@ def policy_update_candidate_rows(
     if policy_gradient_candidate_parameters_metadata_only(policy_gradient):
         return []
     require_evaluated_parameters = policy_gradient_requires_runtime_parameter_evidence(policy_gradient)
+    allow_runtime_metadata_fallback = policy_gradient_allows_runtime_metadata_policy_update(policy_gradient)
     raw_candidates = first_present(policy_gradient, ("candidate_parameter_vectors", "candidateParameterVectors"))
     if not isinstance(raw_candidates, list):
         return []
@@ -1901,6 +1904,7 @@ def policy_update_candidate_rows(
             card_parameters=card_parameters,
             parameter_space=parameter_space,
             require_evaluated_parameters=require_evaluated_parameters,
+            allow_runtime_metadata_fallback=allow_runtime_metadata_fallback,
         )
         if parameters is None:
             continue
@@ -1930,6 +1934,7 @@ def policy_update_evaluated_parameters(
     card_parameters: JsonObject | None,
     parameter_space: dict[str, JsonObject],
     require_evaluated_parameters: bool = False,
+    allow_runtime_metadata_fallback: bool = False,
 ) -> JsonObject | None:
     evaluated: list[JsonObject] = []
     missing_evaluated: list[str] = []
@@ -1970,7 +1975,7 @@ def policy_update_evaluated_parameters(
             )
         return copy.deepcopy(first)
 
-    if require_evaluated_parameters:
+    if require_evaluated_parameters and not allow_runtime_metadata_fallback:
         return None
     return copy.deepcopy(card_parameters) if card_parameters is not None else None
 
@@ -4604,6 +4609,7 @@ def policy_gradient_metadata_with_runner_transport(
     )
     support["runtime_parameter_injection_status"] = status
     support["runtime_parameter_injection_reason"] = runtime_parameter_injection.get("reason")
+    support["runtime_parameter_consumption_status"] = runtime_parameter_injection.get("runtimeParameterConsumptionStatus")
     support["runtime_parameter_injection_mechanism"] = runtime_parameter_injection.get("mechanism")
     if injected:
         support["limitation"] = (
@@ -4688,6 +4694,41 @@ def policy_gradient_requires_runtime_parameter_evidence(policy_gradient: JsonObj
     )
 
 
+def policy_gradient_allows_runtime_metadata_policy_update(policy_gradient: JsonObject) -> bool:
+    support = first_mapping(policy_gradient, ("runner_support", "runnerSupport"))
+    if support is None:
+        return False
+    scope = text_or_none(first_present(support, ("candidate_parameter_scope", "candidateParameterScope")))
+    transport = text_or_none(first_present(support, ("simulator_variant_transport", "simulatorVariantTransport")))
+    status = text_or_none(
+        first_present(support, ("runtime_parameter_injection_status", "runtimeParameterInjectionStatus"))
+    )
+    consumption_status = text_or_none(
+        first_present(support, ("runtime_parameter_consumption_status", "runtimeParameterConsumptionStatus"))
+    )
+    declared_inline_applied = first_present(
+        support,
+        ("declaredInlineCandidatesAppliedToSimulator", "declared_inline_candidates_applied_to_simulator"),
+    )
+    preserves_parameters = first_present(
+        support,
+        ("report_preserves_candidate_parameters", "reportPreservesCandidateParameters"),
+    )
+    preserves_candidate_policy_id = first_present(
+        support,
+        ("candidate_policy_id_preserved", "candidatePolicyIdPreserved"),
+    )
+    return (
+        scope == "runtime_injected"
+        and transport == "variant_ids_with_runtime_injected_parameters"
+        and status == "not_injected"
+        and consumption_status in {"missing", "missing_runtime_parameter_consumption"}
+        and declared_inline_applied is True
+        and preserves_parameters is True
+        and preserves_candidate_policy_id is True
+    )
+
+
 def policy_gradient_candidate_vector_count(policy_gradient: JsonObject) -> int:
     candidates = first_present(policy_gradient, ("candidate_parameter_vectors", "candidateParameterVectors"))
     if not isinstance(candidates, list):
@@ -4748,11 +4789,13 @@ def policy_update_runtime_injection_ready_parameter_evidence(
             "inlineCandidatesRuntimeInjected",
         ),
     ) is True
+    runtime_metadata_fallback = policy_gradient_allows_runtime_metadata_policy_update(policy_gradient)
+    candidate_count_ready = len(candidates) >= policy_gradient_candidate_vector_count(policy_gradient)
     eligible = (
-        runtime_injection
-        and scope == "runtime_injected"
+        scope == "runtime_injected"
         and policy_gradient_requires_runtime_parameter_evidence(policy_gradient)
-        and len(candidates) >= policy_gradient_candidate_vector_count(policy_gradient)
+        and candidate_count_ready
+        and (runtime_injection or runtime_metadata_fallback)
     )
     payload: JsonObject = {
         "candidateParameterScope": scope,
@@ -4760,11 +4803,30 @@ def policy_update_runtime_injection_ready_parameter_evidence(
         "policyUpdateEligible": eligible,
         "candidateCount": len(candidates),
         "metadataCandidateCount": policy_gradient_candidate_vector_count(policy_gradient),
+        "eligibilityMode": (
+            "evaluated_runtime_parameter_evidence"
+            if runtime_injection
+            else "runtime_injected_metadata_scorecard_ranking"
+            if runtime_metadata_fallback
+            else "blocked_until_runtime_parameter_evidence"
+        ),
     }
+    consumption_status = text_or_none(
+        first_present(support, ("runtime_parameter_consumption_status", "runtimeParameterConsumptionStatus"))
+    )
+    if consumption_status is not None:
+        payload["runtimeParameterConsumptionStatus"] = consumption_status
     if eligible:
-        payload["reason"] = (
-            "scored candidate rewards were backed by complete evaluated runtime parameter evidence"
-        )
+        if runtime_metadata_fallback and not runtime_injection:
+            payload["reason"] = (
+                "runtime-injected simulator transport and preserved candidate parameter metadata produced "
+                "a scorecarded offline ranking, but the private simulator did not expose consumption-probe "
+                "evidence; the bounded update remains offline/shadow only"
+            )
+        else:
+            payload["reason"] = (
+                "scored candidate rewards were backed by complete evaluated runtime parameter evidence"
+            )
     else:
         payload["reason"] = (
             "policy updates require runtime-injected candidate parameter transport and complete "

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -2558,6 +2558,36 @@ def validate_positive_policy_update(raw: Any) -> None:
         raise BatchRunError("remote policyUpdate.nextCandidatePolicy must be an object when policyUpdateIterations is positive")
     require_explicit_false_policy_update_safety_flags(raw, "policyUpdate")
     require_explicit_false_policy_update_safety_flags(next_candidate_policy, "policyUpdate.nextCandidatePolicy")
+    validate_positive_policy_update_parameter_change(raw, next_candidate_policy)
+
+
+def validate_positive_policy_update_parameter_change(
+    raw: dict[str, Any],
+    next_candidate_policy: dict[str, Any],
+) -> None:
+    updated_parameters = raw.get("updatedParameters")
+    if not isinstance(updated_parameters, dict) or not updated_parameters:
+        raise BatchRunError("remote policyUpdate.updatedParameters must be a non-empty object when policyUpdateIterations is positive")
+    next_parameters = next_candidate_policy.get("parameters")
+    if not isinstance(next_parameters, dict) or not next_parameters:
+        raise BatchRunError(
+            "remote policyUpdate.nextCandidatePolicy.parameters must be a non-empty object when policyUpdateIterations is positive"
+        )
+    if next_parameters != updated_parameters:
+        raise BatchRunError("remote policyUpdate.nextCandidatePolicy.parameters disagree with policyUpdate.updatedParameters")
+    parameter_delta = raw.get("parameterDelta")
+    if not isinstance(parameter_delta, dict) or not parameter_delta:
+        raise BatchRunError("remote policyUpdate.parameterDelta must be a non-empty object when policyUpdateIterations is positive")
+    changed = False
+    for name, delta in parameter_delta.items():
+        if name not in updated_parameters:
+            raise BatchRunError("remote policyUpdate.parameterDelta contains a parameter absent from updatedParameters")
+        if isinstance(delta, bool) or not isinstance(delta, (int, float)) or not math.isfinite(float(delta)):
+            raise BatchRunError("remote policyUpdate.parameterDelta values must be finite numbers")
+        if abs(float(delta)) > 0:
+            changed = True
+    if not changed:
+        raise BatchRunError("remote policyUpdate.parameterDelta must include at least one non-zero change")
 
 
 def require_explicit_false_policy_update_safety_flags(raw: dict[str, Any], label: str) -> None:

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -2089,6 +2089,14 @@ def verified_remote_policy_update_fields(
     local_artifact_path = collected_remote_policy_update_artifact_path(artifact_dir, rel_artifact_path)
     if not local_artifact_path.is_file():
         raise BatchRunError(f"remote policy update artifact was not collected: {rel_artifact_path.as_posix()}")
+    updated_parameters = safe_policy_update.get("updatedParameters")
+    if not isinstance(updated_parameters, dict):
+        raise BatchRunError("remote policyUpdate.updatedParameters must be an object when policyUpdateIterations is positive")
+    validate_collected_policy_update_artifact_parameters(
+        local_artifact_path,
+        rel_artifact_path,
+        updated_parameters,
+    )
     return {
         "policyUpdateIterations": iterations,
         "policyUpdateArtifactPath": rel_artifact_path.as_posix(),
@@ -2575,6 +2583,8 @@ def validate_positive_policy_update_parameter_change(
         )
     if next_parameters != updated_parameters:
         raise BatchRunError("remote policyUpdate.nextCandidatePolicy.parameters disagree with policyUpdate.updatedParameters")
+    validate_policy_update_parameter_values(updated_parameters, "policyUpdate.updatedParameters")
+    validate_policy_update_parameter_values(next_parameters, "policyUpdate.nextCandidatePolicy.parameters")
     parameter_delta = raw.get("parameterDelta")
     if not isinstance(parameter_delta, dict) or not parameter_delta:
         raise BatchRunError("remote policyUpdate.parameterDelta must be a non-empty object when policyUpdateIterations is positive")
@@ -2588,6 +2598,39 @@ def validate_positive_policy_update_parameter_change(
             changed = True
     if not changed:
         raise BatchRunError("remote policyUpdate.parameterDelta must include at least one non-zero change")
+
+
+def validate_policy_update_parameter_values(parameters: dict[str, Any], label: str) -> None:
+    for value in parameters.values():
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(float(value)):
+            raise BatchRunError(f"remote {label} values must be finite numbers")
+
+
+def validate_collected_policy_update_artifact_parameters(
+    local_artifact_path: Path,
+    rel_artifact_path: Path,
+    updated_parameters: dict[str, Any],
+) -> None:
+    try:
+        with local_artifact_path.open(encoding="utf-8") as artifact_file:
+            artifact = json.load(artifact_file)
+    except OSError as exc:
+        raise BatchRunError(f"remote policy update artifact is not readable: {rel_artifact_path.as_posix()}") from exc
+    except json.JSONDecodeError as exc:
+        raise BatchRunError(f"remote policy update artifact is not valid JSON: {rel_artifact_path.as_posix()}") from exc
+    if not isinstance(artifact, dict):
+        raise BatchRunError(f"remote policy update artifact must be a JSON object: {rel_artifact_path.as_posix()}")
+    artifact_parameters = artifact.get("parameters")
+    if not isinstance(artifact_parameters, dict) or not artifact_parameters:
+        raise BatchRunError(
+            f"remote policy update artifact parameters must be a non-empty object: {rel_artifact_path.as_posix()}"
+        )
+    validate_policy_update_parameter_values(artifact_parameters, "policyUpdateArtifactPath.parameters")
+    if artifact_parameters != updated_parameters:
+        raise BatchRunError(
+            "remote policy update artifact parameters disagree with policyUpdate.updatedParameters: "
+            f"{rel_artifact_path.as_posix()}"
+        )
 
 
 def require_explicit_false_policy_update_safety_flags(raw: dict[str, Any], label: str) -> None:

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -2808,7 +2808,7 @@ export const STRATEGY_REGISTRY = [
             )
         )
 
-    def test_runtime_injected_reinforce_requires_explicit_consumption_evidence(self) -> None:
+    def test_runtime_injected_reinforce_without_consumption_probe_still_requires_reward_signal(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-policy-gradient-missing-consumption",
             code_commit="f" * 40,
@@ -2851,11 +2851,101 @@ export const STRATEGY_REGISTRY = [
             "missing_runtime_parameter_consumption",
         )
         self.assertEqual(report["policyUpdateIterations"], 0)
-        self.assertFalse(report["policyUpdate"]["parameterEvidence"]["policyUpdateEligible"])
+        self.assertEqual(report["policyUpdate"]["skippedReason"], "bounded_update_no_parameter_change")
+        self.assertTrue(report["policyUpdate"]["parameterEvidence"]["policyUpdateEligible"])
         self.assertFalse(report["policyUpdate"]["parameterEvidence"]["runtimeParameterInjection"])
+        self.assertEqual(
+            report["policyUpdate"]["parameterEvidence"]["eligibilityMode"],
+            "runtime_injected_metadata_scorecard_ranking",
+        )
         self.assertNotIn("policyUpdateArtifactPath", report)
         self.assertTrue(all("evaluatedParameters" in result for result in simulator.last_variants))
         self.assertTrue(all("runtimeParameterConsumption" not in result for result in simulator.last_variants))
+
+    def test_runtime_injected_metadata_ranking_materializes_reinforce_update_without_consumption_probe(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-metadata-ranking",
+            code_commit="f" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-17T07:02:00Z",
+            simulation_ticks=100,
+            simulation_repetitions=1,
+        )
+        variant_ids = [variant["id"] for variant in card["strategy_variants"]]
+        start = tick(1, [room("W1N1", energy=100)])
+        simulator_results: dict[str, JsonObject] = {}
+        for variant_id in variant_ids:
+            if variant_id.endswith("territory-seed.v1"):
+                simulator_results[variant_id] = variant_result(
+                    variant_id,
+                    [start, tick(2, [room("W1N1", energy=150), room("W1N2", energy=100)])],
+                )
+            elif variant_id.endswith("resource-seed.v1"):
+                simulator_results[variant_id] = variant_result(
+                    variant_id,
+                    [start, tick(2, [room("W1N1", energy=2400, harvested=1000)])],
+                )
+            else:
+                simulator_results[variant_id] = variant_result(
+                    variant_id,
+                    [start, tick(2, [room("W1N1", energy=200)])],
+                )
+        simulator = MockSimulator(
+            simulator_results,
+            inject_runtime_parameters=True,
+            include_runtime_consumption_evidence=False,
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                out_dir,
+                report_id="policy-gradient-metadata-ranking",
+                generated_at="2026-05-17T07:03:00Z",
+                simulator_runner=simulator,
+            )
+            persisted = read_json(out_dir / "policy-gradient-metadata-ranking.json")
+            artifact_path = Path(report["policyUpdateArtifactPath"])
+            artifact = read_json(artifact_path)
+
+        self.assertEqual(report["runtimeParameterInjection"]["status"], "not_injected")
+        self.assertFalse(report["runtimeParameterInjection"]["runtimeParameterInjection"])
+        self.assertFalse(report["runtimeParameterInjection"]["policyUpdateEligible"])
+        self.assertEqual(report["runtimeParameterInjection"]["candidateParameterScope"], "runtime_injected")
+        self.assertEqual(
+            report["runtimeParameterInjection"]["runtimeParameterConsumptionStatus"],
+            "missing_runtime_parameter_consumption",
+        )
+        self.assertEqual(report["policyUpdateIterations"], 1)
+        self.assertEqual(persisted["policyUpdateIterations"], 1)
+        self.assertTrue(report["trueGradient"])
+        self.assertEqual(report["candidateScorecard"]["status"], "materialized")
+        self.assertTrue(report["candidateScorecard"]["validationScaleComputeBlocked"])
+        self.assertTrue(report["candidateScorecard"]["scorecardUsable"])
+        self.assertIsNotNone(report["candidateScorecard"]["candidateRank"])
+        self.assertIsNotNone(report["candidateScorecard"]["baselineRank"])
+        self.assertEqual(report["candidateScorecards"]["status"], "materialized")
+        self.assertGreater(len(report["ranking"]), 1)
+        self.assertIn("policyUpdateArtifactPath", report)
+        update = report["policyUpdate"]
+        self.assertFalse(update["liveEffect"])
+        self.assertFalse(update["officialMmoWrites"])
+        self.assertFalse(update["officialMmoWritesAllowed"])
+        self.assertFalse(update["parameterEvidence"]["runtimeParameterInjection"])
+        self.assertTrue(update["parameterEvidence"]["policyUpdateEligible"])
+        self.assertEqual(
+            update["parameterEvidence"]["eligibilityMode"],
+            "runtime_injected_metadata_scorecard_ranking",
+        )
+        self.assertTrue(any(abs(float(value)) > 0 for value in update["parameterDelta"].values()))
+        self.assertEqual(artifact["parameters"], update["updatedParameters"])
+        self.assertFalse(artifact["liveEffect"])
+        self.assertFalse(artifact["officialMmoWrites"])
+        self.assertFalse(artifact["officialMmoWritesAllowed"])
 
     def test_failed_only_runtime_parameter_uploads_do_not_become_injected_evidence(self) -> None:
         card = card_helper.build_card(

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -963,6 +963,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             for label, policy_update, expected_error in cases:
+                write_policy_update_artifact(root, artifact_path, policy_update["updatedParameters"])
                 with self.subTest(label=label), self.assertRaisesRegex(
                     runner.BatchRunError,
                     re.escape(expected_error),

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -114,6 +114,37 @@ def write_candidate_scorecard_set_artifacts(root: Path, scorecard_set: object) -
             write_text(root / "remote" / artifact_path, "{}\n")
 
 
+def positive_policy_update(artifact_path: str) -> dict[str, object]:
+    updated_parameters = {
+        "baseScoreWeight": 1,
+        "territorySignalWeight": 7,
+        "resourceSignalWeight": 4,
+        "killSignalWeight": 6,
+        "riskPenalty": 4,
+    }
+    return {
+        "iterations": 1,
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+        "artifactPath": artifact_path,
+        "updatedParameters": updated_parameters,
+        "parameterDelta": {
+            "baseScoreWeight": 0,
+            "territorySignalWeight": 1,
+            "resourceSignalWeight": 0,
+            "killSignalWeight": 0,
+            "riskPenalty": 0,
+        },
+        "nextCandidatePolicy": {
+            "parameters": copy.deepcopy(updated_parameters),
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+        },
+    }
+
+
 def decode_remote_bash_lc(remote_command: str) -> str:
     tokens = shlex.split(remote_command)
     script_arg = tokens[tokens.index("-lc") + 1]
@@ -865,18 +896,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             "officialMmoWrites": False,
             "officialMmoWritesAllowed": False,
         }
-        policy_update = {
-            "iterations": 1,
-            "liveEffect": False,
-            "officialMmoWrites": False,
-            "officialMmoWritesAllowed": False,
-            "artifactPath": artifact_path,
-            "nextCandidatePolicy": {
-                "liveEffect": False,
-                "officialMmoWrites": False,
-                "officialMmoWritesAllowed": False,
-            },
-        }
+        policy_update = positive_policy_update(artifact_path)
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             write_text(root / "remote" / artifact_path, "{}\n")
@@ -898,6 +918,46 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 },
             )
 
+    def test_verified_remote_policy_update_rejects_positive_update_without_parameter_change(self) -> None:
+        artifact_path = "runtime-artifacts/rl-training/policy-candidates/run-test-next-policy.json"
+        top_level_safety = {
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+        }
+        cases = (
+            ("updatedParameters", {**positive_policy_update(artifact_path), "updatedParameters": {}}),
+            (
+                "nextCandidatePolicy.parameters",
+                {
+                    **positive_policy_update(artifact_path),
+                    "nextCandidatePolicy": {
+                        "liveEffect": False,
+                        "officialMmoWrites": False,
+                        "officialMmoWritesAllowed": False,
+                    },
+                },
+            ),
+            ("at least one non-zero change", {**positive_policy_update(artifact_path), "parameterDelta": {"territorySignalWeight": 0}}),
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            write_text(root / "remote" / artifact_path, "{}\n")
+            for expected_error, policy_update in cases:
+                with self.subTest(expected_error=expected_error), self.assertRaisesRegex(
+                    runner.BatchRunError,
+                    re.escape(expected_error),
+                ):
+                    runner.verified_remote_policy_update_fields(
+                        {
+                            "policyUpdateIterations": 1,
+                            "policyUpdateArtifactPath": artifact_path,
+                            "policyUpdate": policy_update,
+                        },
+                        top_level_safety,
+                        root,
+                    )
+
     def test_verified_remote_policy_update_rejects_positive_update_without_explicit_policy_update_safety_flags(self) -> None:
         artifact_path = "runtime-artifacts/rl-training/policy-candidates/run-test-next-policy.json"
         top_level_safety = {
@@ -907,18 +967,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         }
 
         def valid_policy_update() -> dict[str, object]:
-            return {
-                "iterations": 1,
-                "liveEffect": False,
-                "officialMmoWrites": False,
-                "officialMmoWritesAllowed": False,
-                "artifactPath": artifact_path,
-                "nextCandidatePolicy": {
-                    "liveEffect": False,
-                    "officialMmoWrites": False,
-                    "officialMmoWritesAllowed": False,
-                },
-            }
+            return positive_policy_update(artifact_path)
 
         missing_live_effect = valid_policy_update()
         missing_live_effect.pop("liveEffect")
@@ -955,18 +1004,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         }
 
         def valid_policy_update() -> dict[str, object]:
-            return {
-                "iterations": 1,
-                "liveEffect": False,
-                "officialMmoWrites": False,
-                "officialMmoWritesAllowed": False,
-                "artifactPath": artifact_path,
-                "nextCandidatePolicy": {
-                    "liveEffect": False,
-                    "officialMmoWrites": False,
-                    "officialMmoWritesAllowed": False,
-                },
-            }
+            return positive_policy_update(artifact_path)
 
         missing_writes = valid_policy_update()
         next_candidate = missing_writes["nextCandidatePolicy"]
@@ -1093,17 +1131,9 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                         "artifactCount": 1,
                         "policyUpdateIterations": 1,
                         "policyUpdateArtifactPath": "runtime-artifacts/rl-training/policy-candidates/run-test-next-policy.json",
-                        "policyUpdate": {
-                            "iterations": 1,
-                            "liveEffect": False,
-                            "officialMmoWrites": False,
-                            "officialMmoWritesAllowed": False,
-                            "nextCandidatePolicy": {
-                                "liveEffect": False,
-                                "officialMmoWrites": False,
-                                "officialMmoWritesAllowed": False,
-                            },
-                        },
+                        "policyUpdate": positive_policy_update(
+                            "runtime-artifacts/rl-training/policy-candidates/run-test-next-policy.json"
+                        ),
                     }
                 ),
                 encoding="utf-8",
@@ -1125,18 +1155,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 {
                     "policyUpdateIterations": 5,
                     "policyUpdateArtifactPath": artifact_path,
-                    "policyUpdate": {
-                        "iterations": 1,
-                        "liveEffect": False,
-                        "officialMmoWrites": False,
-                        "officialMmoWritesAllowed": False,
-                        "artifactPath": artifact_path,
-                        "nextCandidatePolicy": {
-                            "liveEffect": False,
-                            "officialMmoWrites": False,
-                            "officialMmoWritesAllowed": False,
-                        },
-                    },
+                    "policyUpdate": positive_policy_update(artifact_path),
                 },
                 "policyUpdate.iterations disagrees",
             ),
@@ -1145,16 +1164,8 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                     "policyUpdateIterations": 1,
                     "policyUpdateArtifactPath": artifact_path,
                     "policyUpdate": {
-                        "iterations": 1,
-                        "liveEffect": False,
-                        "officialMmoWrites": False,
-                        "officialMmoWritesAllowed": False,
+                        **positive_policy_update(artifact_path),
                         "artifactPath": "runtime-artifacts/rl-training/policy-candidates/other-next-policy.json",
-                        "nextCandidatePolicy": {
-                            "liveEffect": False,
-                            "officialMmoWrites": False,
-                            "officialMmoWritesAllowed": False,
-                        },
                     },
                 },
                 "policyUpdate.artifactPath disagrees",
@@ -1212,17 +1223,9 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                         },
                         "policyUpdateIterations": 1,
                         "policyUpdateArtifactPath": "runtime-artifacts/rl-training/policy-candidates/run-test-next-policy.json",
-                        "policyUpdate": {
-                            "iterations": 1,
-                            "liveEffect": False,
-                            "officialMmoWrites": False,
-                            "officialMmoWritesAllowed": False,
-                            "nextCandidatePolicy": {
-                                "liveEffect": False,
-                                "officialMmoWrites": False,
-                                "officialMmoWritesAllowed": False,
-                            },
-                        },
+                        "policyUpdate": positive_policy_update(
+                            "runtime-artifacts/rl-training/policy-candidates/run-test-next-policy.json"
+                        ),
                     }
                 ),
                 encoding="utf-8",

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -114,6 +114,10 @@ def write_candidate_scorecard_set_artifacts(root: Path, scorecard_set: object) -
             write_text(root / "remote" / artifact_path, "{}\n")
 
 
+def write_policy_update_artifact(root: Path, artifact_path: str, parameters: object) -> None:
+    write_text(root / "remote" / artifact_path, json.dumps({"parameters": parameters}, sort_keys=True) + "\n")
+
+
 def positive_policy_update(artifact_path: str) -> dict[str, object]:
     updated_parameters = {
         "baseScoreWeight": 1,
@@ -899,7 +903,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         policy_update = positive_policy_update(artifact_path)
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
-            write_text(root / "remote" / artifact_path, "{}\n")
+            write_policy_update_artifact(root, artifact_path, policy_update["updatedParameters"])
 
             self.assertEqual(
                 runner.verified_remote_policy_update_fields(
@@ -917,6 +921,90 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                     "policyUpdate": policy_update,
                 },
             )
+
+    def test_verified_remote_policy_update_rejects_non_numeric_policy_parameter_values(self) -> None:
+        artifact_path = "runtime-artifacts/rl-training/policy-candidates/run-test-next-policy.json"
+        top_level_safety = {
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+        }
+
+        cases = []
+        for label, value in (
+            ("string", "7"),
+            ("bool", True),
+            ("infinity", float("inf")),
+        ):
+            policy_update = positive_policy_update(artifact_path)
+            updated_parameters = policy_update["updatedParameters"]
+            assert isinstance(updated_parameters, dict)
+            updated_parameters["territorySignalWeight"] = value
+            policy_update["nextCandidatePolicy"] = {
+                **policy_update["nextCandidatePolicy"],
+                "parameters": copy.deepcopy(updated_parameters),
+            }
+            cases.append((label, policy_update, "policyUpdate.updatedParameters values must be finite numbers"))
+
+        next_bool_policy_update = positive_policy_update(artifact_path)
+        next_candidate = next_bool_policy_update["nextCandidatePolicy"]
+        assert isinstance(next_candidate, dict)
+        next_parameters = next_candidate["parameters"]
+        assert isinstance(next_parameters, dict)
+        next_parameters["baseScoreWeight"] = True
+        cases.append(
+            (
+                "next candidate bool",
+                next_bool_policy_update,
+                "policyUpdate.nextCandidatePolicy.parameters values must be finite numbers",
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            for label, policy_update, expected_error in cases:
+                with self.subTest(label=label), self.assertRaisesRegex(
+                    runner.BatchRunError,
+                    re.escape(expected_error),
+                ):
+                    runner.verified_remote_policy_update_fields(
+                        {
+                            "policyUpdateIterations": 1,
+                            "policyUpdateArtifactPath": artifact_path,
+                            "policyUpdate": policy_update,
+                        },
+                        top_level_safety,
+                        root,
+                    )
+
+    def test_verified_remote_policy_update_rejects_stale_persisted_artifact_parameters(self) -> None:
+        artifact_path = "runtime-artifacts/rl-training/policy-candidates/run-test-next-policy.json"
+        top_level_safety = {
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+        }
+        policy_update = positive_policy_update(artifact_path)
+        stale_parameters = copy.deepcopy(policy_update["updatedParameters"])
+        assert isinstance(stale_parameters, dict)
+        stale_parameters["territorySignalWeight"] = 6
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            write_policy_update_artifact(root, artifact_path, stale_parameters)
+
+            with self.assertRaisesRegex(
+                runner.BatchRunError,
+                "policy update artifact parameters disagree with policyUpdate.updatedParameters",
+            ):
+                runner.verified_remote_policy_update_fields(
+                    {
+                        "policyUpdateIterations": 1,
+                        "policyUpdateArtifactPath": artifact_path,
+                        "policyUpdate": policy_update,
+                    },
+                    top_level_safety,
+                    root,
+                )
 
     def test_verified_remote_policy_update_rejects_positive_update_without_parameter_change(self) -> None:
         artifact_path = "runtime-artifacts/rl-training/policy-candidates/run-test-next-policy.json"
@@ -1181,6 +1269,8 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             root = Path(temp_dir)
             report = runner.remote_training_report_path(root, "run-test")
             report.parent.mkdir(parents=True, exist_ok=True)
+            policy_artifact_path = "runtime-artifacts/rl-training/policy-candidates/run-test-next-policy.json"
+            policy_update = positive_policy_update(policy_artifact_path)
             report.write_text(
                 json.dumps(
                     {
@@ -1222,15 +1312,13 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                             "scorecardUsable": True,
                         },
                         "policyUpdateIterations": 1,
-                        "policyUpdateArtifactPath": "runtime-artifacts/rl-training/policy-candidates/run-test-next-policy.json",
-                        "policyUpdate": positive_policy_update(
-                            "runtime-artifacts/rl-training/policy-candidates/run-test-next-policy.json"
-                        ),
+                        "policyUpdateArtifactPath": policy_artifact_path,
+                        "policyUpdate": policy_update,
                     }
                 ),
                 encoding="utf-8",
             )
-            write_text(root / "remote" / "runtime-artifacts" / "rl-training" / "policy-candidates" / "run-test-next-policy.json", "{}\n")
+            write_policy_update_artifact(root, policy_artifact_path, policy_update["updatedParameters"])
             write_ready_runtime_scorecard_artifact(root)
             controller = runner.Controller(args=controller_args(), run_id="run-test", artifact_dir=root)
             controller.verify_remote_training_report()


### PR DESCRIPTION
## Summary
- restores a bounded policy-update path when scorecarded runtime-injected candidate metadata is preserved but the private simulator still lacks a consumption-probe surface
- keeps the report honest by marking the eligibility mode as `runtime_injected_metadata_scorecard_ranking` rather than claiming direct runtime consumption evidence
- strengthens Tencent batch validation so positive policy updates require non-empty updated parameters, matching next-policy parameters, and at least one non-zero parameter delta

Fixes #1295

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_training_runner.py scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_rl_training_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts/test_screeps_rl_training_runner.py scripts/test_screeps_tencent_batch_rl_runner.py` — 160 tests OK
- `git merge-base --is-ancestor origin/main HEAD`

## Safety
- No paid Tencent compute launched by this PR.
- No official Screeps API calls or official MMO writes.
- Policy artifacts remain offline/shadow-only and require explicit false `liveEffect`, `officialMmoWrites`, and `officialMmoWritesAllowed` safety flags.
