### PR TITLE
fix(rl): bound Tencent stuck-run age checks

### DIFF
--- a/scripts/screeps_rl_live_dashboard.py
+++ b/scripts/screeps_rl_live_dashboard.py
@@ -57,6 +57,29 @@ RUNTIME_INJECTION_TRUE_KEYS = {
 RUNTIME_INJECTION_SCOPE_KEYS = {"candidateparameterscope"}
 RUNTIME_INJECTION_METADATA_ONLY_VALUES = {"metadataonly"}
 SUMMARY_STATUS_PRIORITY = {"BLOCKED": 2, "OK": 1, "N/A": 0}
+TENCENT_ACTIVE_FINAL_STATUS_KEYS = {"", "unknown", "running", "inprogress"}
+TENCENT_TERMINAL_FINAL_STATUS_KEYS = {
+    "completed",
+    "completedscaledownfailed",
+    "failed",
+    "ok",
+    "preflightok",
+    "success",
+}
+TENCENT_TIMEOUT_TOTAL_KEYS = (
+    "totalSeconds",
+    "totalTimeoutSeconds",
+    "runTimeoutSeconds",
+    "timeoutSeconds",
+    "total",
+)
+TENCENT_TIMEOUT_COMPONENT_KEY_GROUPS = (
+    ("scaleTimeoutSeconds", "scale_timeout_seconds", "scale-timeout-seconds", "scale"),
+    ("scaleDownTimeoutSeconds", "scale_down_timeout_seconds", "scale-down-timeout-seconds", "scaleDown"),
+    ("bootstrapTimeoutSeconds", "bootstrap_timeout_seconds", "bootstrap-timeout-seconds", "bootstrap"),
+    ("trainingTimeoutSeconds", "training_timeout_seconds", "training-timeout-seconds", "training"),
+    ("transferTimeoutSeconds", "transfer_timeout_seconds", "transfer-timeout-seconds", "transfer"),
+)
 
 JsonObject = dict[str, Any]
 ArtifactJson = tuple[Path, JsonObject, datetime]
@@ -485,6 +508,10 @@ def latest_scorecard_summary(artifact_root: Path, repo_root: Path) -> JsonObject
 
 
 def tencent_batch_summary(artifact_root: Path, repo_root: Path) -> JsonObject:
+    return tencent_batch_summary_at(artifact_root, repo_root, now=None)
+
+
+def tencent_batch_summary_at(artifact_root: Path, repo_root: Path, *, now: Any | None) -> JsonObject:
     root = artifact_root / "tencent-cloud" / "batch-runs"
     runs: list[JsonObject] = []
     if root.exists():
@@ -494,6 +521,7 @@ def tencent_batch_summary(artifact_root: Path, repo_root: Path) -> JsonObject:
                 continue
             compute_evidence = static_dashboard.compute_evidence_summary(payload)
             batch_scale = tencent_batch_scale(payload)
+            runner_state = classify_tencent_batch_run_state(payload, now=now)
             runs.append(
                 {
                     "runId": payload.get("runId") or path.parent.name,
@@ -508,17 +536,18 @@ def tencent_batch_summary(artifact_root: Path, repo_root: Path) -> JsonObject:
                     "computeEvidence": compute_evidence,
                     "computeClassification": compute_evidence.get("classification"),
                     "batchScale": batch_scale,
+                    "runnerState": runner_state,
+                    "stateClassification": runner_state.get("status"),
+                    "activeAgeSeconds": runner_state.get("ageSeconds"),
+                    "declaredTimeoutSeconds": runner_state.get("timeoutSeconds"),
+                    "handoffRequired": runner_state.get("handoffRequired"),
                     "blocker": compute_evidence.get("blocker"),
                     "path": safe_display_path(path, repo_root),
                     "timestamp": display_timestamp(artifact_timestamp(path, payload)),
                 }
             )
     latest = max(runs, key=lambda item: item["timestamp"]) if runs else None
-    active = [
-        run
-        for run in runs
-        if run.get("partial") is True or str(run.get("finalStatus", "")).lower() in {"unknown", "running"}
-    ]
+    active = [run for run in runs if as_dict(run.get("runnerState")).get("active") is True]
     completed = [run for run in runs if str(run.get("finalStatus", "")).lower() in {"completed", "success", "ok"}]
     compute_confirmed = [run for run in runs if run.get("computeClassification") == "COMPUTE_CONFIRMED"]
     preflight_only = [run for run in runs if run.get("computeClassification") == "PREFLIGHT_ONLY_VALIDATION"]
@@ -531,6 +560,176 @@ def tencent_batch_summary(artifact_root: Path, repo_root: Path) -> JsonObject:
         "preflightOnlyRunCount": len(preflight_only),
         "latest": latest,
     }
+
+
+def classify_tencent_batch_run_state(payload: JsonObject, *, now: Any | None = None) -> JsonObject:
+    run_id = text_value(payload.get("runId")) or "unknown"
+    started_at = payload.get("startedAt")
+    age_seconds = seconds_since(started_at, now=now)
+    timeout_seconds = tencent_declared_timeout_seconds(payload)
+    progress = tencent_batch_progress(payload)
+    pid = tencent_controller_pid(payload)
+    active = tencent_batch_run_is_active(payload)
+    state: JsonObject = {
+        "runId": run_id,
+        "pid": pid,
+        "active": active,
+        "status": "TENCENT_BATCH_RUNNER_INACTIVE",
+        "startedAt": display_timestamp(started_at),
+        "ageSeconds": age_seconds,
+        "timeoutSeconds": timeout_seconds,
+        "timeoutKnown": timeout_seconds is not None,
+        "progress": progress,
+        "handoffRequired": False,
+        "action": "none",
+    }
+    if not active:
+        return state
+    if timeout_seconds is None or age_seconds is None or age_seconds <= timeout_seconds or progress.get("hasProgress") is True:
+        state.update(
+            {
+                "status": "TRAINING_IN_PROGRESS",
+                "action": "monitor",
+                "evidence": tencent_active_evidence(run_id, pid, age_seconds, timeout_seconds, progress),
+            }
+        )
+        return state
+    action = (
+        f"kill PID {pid} and scale down ASG to DesiredCapacity=0"
+        if pid is not None
+        else "scale down ASG to DesiredCapacity=0 after confirming the active runner process"
+    )
+    state.update(
+        {
+            "status": "TENCENT_BATCH_RUNNER_STUCK",
+            "handoffRequired": True,
+            "handoffSeverity": "P1",
+            "action": action,
+            "scaleDownAction": action,
+            "evidence": (
+                f"Active Tencent batch runner {run_id} (PID {pid if pid is not None else 'unknown'}) "
+                f"age={age_seconds}s exceeded declared timeout={timeout_seconds}s with no environments, "
+                "artifacts, or training report observed."
+            ),
+        }
+    )
+    return state
+
+
+def tencent_active_evidence(
+    run_id: str,
+    pid: int | None,
+    age_seconds: int | None,
+    timeout_seconds: int | None,
+    progress: JsonObject,
+) -> str:
+    pid_text = f", PID {pid}" if pid is not None else ""
+    timeout_text = f", timeout={timeout_seconds}s" if timeout_seconds is not None else ", timeout=unknown"
+    age_text = f"age={age_seconds}s" if age_seconds is not None else "age=unknown"
+    progress_text = "progress observed" if progress.get("hasProgress") is True else "no completed environments yet"
+    return f"Active Tencent batch runner {run_id}{pid_text}: {age_text}{timeout_text}; {progress_text}."
+
+
+def tencent_batch_run_is_active(payload: JsonObject) -> bool:
+    if parse_iso_datetime(payload.get("finishedAt")) is not None:
+        return False
+    final_status = normalized_key(text_value(payload.get("finalStatus")) or "")
+    if final_status in TENCENT_ACTIVE_FINAL_STATUS_KEYS:
+        return True
+    return payload.get("partial") is True and final_status not in TENCENT_TERMINAL_FINAL_STATUS_KEYS
+
+
+def tencent_declared_timeout_seconds(payload: JsonObject) -> int | None:
+    inputs = as_dict(payload.get("inputs"))
+    candidates = (
+        as_dict(inputs.get("executionTimeouts")),
+        as_dict(payload.get("executionTimeouts")),
+        as_dict(inputs.get("timeouts")),
+        as_dict(payload.get("timeouts")),
+        inputs,
+        payload,
+    )
+    for candidate in candidates:
+        total = seconds_value_for_keys(candidate, TENCENT_TIMEOUT_TOTAL_KEYS)
+        if total is not None and total > 0:
+            return total
+    for candidate in candidates:
+        components: list[int] = []
+        for keys in TENCENT_TIMEOUT_COMPONENT_KEY_GROUPS:
+            value = seconds_value_for_keys(candidate, keys)
+            if value is not None:
+                components.append(value)
+        if components:
+            return sum(components)
+    return None
+
+
+def seconds_value_for_keys(container: JsonObject, keys: Sequence[str]) -> int | None:
+    if not container:
+        return None
+    normalized_values = {normalized_key(key): value for key, value in container.items()}
+    for key in keys:
+        value = normalized_values.get(normalized_key(key))
+        parsed = static_dashboard.number_value(value)
+        if parsed is not None:
+            return max(0, int(parsed))
+    return None
+
+
+def tencent_batch_progress(payload: JsonObject) -> JsonObject:
+    execution = as_dict(payload.get("execution"))
+    outputs = as_dict(payload.get("outputs"))
+    training_report = as_dict(outputs.get("trainingReport"))
+    environments_run = first_tencent_number(
+        execution.get("environmentsRun"),
+        execution.get("environmentsCompleted"),
+        execution.get("completedEnvironments"),
+        training_report.get("environmentRows"),
+        training_report.get("environmentsRun"),
+    )
+    artifact_count = first_tencent_number(
+        execution.get("artifactCount"),
+        training_report.get("artifactCount"),
+        as_dict(outputs.get("remoteArtifacts")).get("artifactCount"),
+    )
+    training_report_produced = (
+        execution.get("trainingReportProduced") is True
+        or bool(training_report.get("reportId"))
+        or bool(training_report.get("path"))
+    )
+    has_progress = bool(
+        (environments_run is not None and environments_run > 0)
+        or (artifact_count is not None and artifact_count > 0)
+        or training_report_produced
+    )
+    return {
+        "hasProgress": has_progress,
+        "environmentsRun": environments_run,
+        "artifactCount": artifact_count,
+        "trainingReportProduced": training_report_produced,
+    }
+
+
+def first_tencent_number(*values: Any) -> int | None:
+    for value in values:
+        parsed = static_dashboard.number_value(value)
+        if parsed is not None:
+            return max(0, int(parsed))
+    return None
+
+
+def tencent_controller_pid(payload: JsonObject) -> int | None:
+    for container in (
+        payload,
+        as_dict(payload.get("controllerProcess")),
+        as_dict(payload.get("process")),
+        as_dict(payload.get("runnerProcess")),
+    ):
+        for key in ("pid", "controllerPid", "runnerPid"):
+            parsed = static_dashboard.int_value(container.get(key))
+            if parsed is not None and parsed > 0:
+                return parsed
+    return None
 
 
 def tencent_batch_scale(payload: JsonObject) -> JsonObject:
@@ -978,7 +1177,7 @@ def build_live_summary(
     raw_dashboard = static_dashboard.build_dashboard(repo_root=repo_root, artifact_root=artifact_root, generated_at=generated)
     dashboard = dashboard_json_safe(raw_dashboard, repo_root)
     scorecard = latest_scorecard_summary(artifact_root, repo_root)
-    tencent = tencent_batch_summary(artifact_root, repo_root)
+    tencent = tencent_batch_summary_at(artifact_root, repo_root, now=generated)
     safety = safety_summary(dashboard, tencent, scorecard)
     injection, zero_iteration = artifact_evidence_summaries(artifact_root, repo_root)
     flywheel_stages = flywheel_stage_summary(db=db, dashboard=dashboard, scorecard=scorecard, safety=safety)
@@ -1150,6 +1349,9 @@ def render_live_html(summary: JsonObject, config: LiveDashboardConfig) -> str:
         ("Preflight-only validations", h(format_value(tencent.get("preflightOnlyRunCount")))),
         ("Latest run", h(latest_tencent.get("runId") or "N/A")),
         ("Latest status", render_status(latest_tencent.get("finalStatus"))),
+        ("Latest runner state", render_status(latest_tencent.get("stateClassification"))),
+        ("Latest runner age seconds", h(format_value(latest_tencent.get("activeAgeSeconds")))),
+        ("Latest declared timeout seconds", h(format_value(latest_tencent.get("declaredTimeoutSeconds")))),
         ("Latest compute evidence", h(latest_tencent.get("computeClassification") or "N/A")),
         ("Latest batch class", h(latest_batch_scale.get("batchClass") or "N/A")),
         ("Latest env rows", h(latest_batch_scale.get("environmentRows", "N/A"))),

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -258,6 +258,9 @@ class Controller:
             "finishedAt": self.finished_at,
             "partial": partial,
             "finalStatus": self.final_status,
+            "controllerProcess": {
+                "pid": os.getpid(),
+            },
             "region": self.args.region,
             "autoScalingGroupId": self.args.asg_id,
             "workerUser": self.args.worker_user,
@@ -290,6 +293,7 @@ class Controller:
                 "scenarioId": getattr(self.args, "scenario_id", DEFAULT_SCENARIO_ID),
                 "requireMultiTierScenario": getattr(self.args, "require_multi_tier_scenario", False),
                 "plannedBatchScale": planned_batch_scale_from_args(self.args),
+                "executionTimeouts": controller_timeout_summary(self.args),
             },
             "outputs": self.result,
             "steps": [step.__dict__ for step in self.steps],
@@ -1213,6 +1217,18 @@ def controller_batch_scale_summary(
         cost_estimate=cost_estimate,
         basis=basis,
     )
+
+
+def controller_timeout_summary(args: argparse.Namespace) -> dict[str, int]:
+    timeouts = {
+        "scaleTimeoutSeconds": max(0, int(getattr(args, "scale_timeout_seconds", 0) or 0)),
+        "scaleDownTimeoutSeconds": max(0, int(getattr(args, "scale_down_timeout_seconds", 0) or 0)),
+        "bootstrapTimeoutSeconds": max(0, int(getattr(args, "bootstrap_timeout_seconds", 0) or 0)),
+        "trainingTimeoutSeconds": max(0, int(getattr(args, "training_timeout_seconds", 0) or 0)),
+        "transferTimeoutSeconds": max(0, int(getattr(args, "transfer_timeout_seconds", 0) or 0)),
+    }
+    timeouts["totalSeconds"] = sum(timeouts.values())
+    return timeouts
 
 
 def planned_batch_scale_from_args(args: argparse.Namespace) -> dict[str, Any]:

--- a/scripts/test_screeps_rl_live_dashboard.py
+++ b/scripts/test_screeps_rl_live_dashboard.py
@@ -209,6 +209,78 @@ def wait_for_json_url(url: str, timeout_seconds: float = 5.0) -> JsonObject:
 
 
 class ScreepsRlLiveDashboardTest(unittest.TestCase):
+    def test_tencent_active_run_within_declared_timeout_uses_utc_age(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_dir = root / "tencent-cloud" / "batch-runs" / "tencent-pg-20260521t084005z"
+            write_json(
+                run_dir / "controller-summary.json",
+                {
+                    "type": "screeps-tencent-batch-rl-run",
+                    "runId": "tencent-pg-20260521t084005z",
+                    "startedAt": "2026-05-21T08:40:06Z",
+                    "finishedAt": None,
+                    "partial": True,
+                    "finalStatus": "unknown",
+                    "controllerProcess": {"pid": 4185673},
+                    "inputs": {
+                        "executionTimeouts": {
+                            "trainingTimeoutSeconds": 7200,
+                            "scaleTimeoutSeconds": 1200,
+                            "scaleDownTimeoutSeconds": 900,
+                            "bootstrapTimeoutSeconds": 1800,
+                            "transferTimeoutSeconds": 1200,
+                        }
+                    },
+                    "execution": {
+                        "environmentsRun": 0,
+                        "artifactCount": 0,
+                        "trainingReportProduced": False,
+                    },
+                },
+            )
+
+            summary = live.tencent_batch_summary_at(root, root, now="2026-05-21T17:05:00+08:00")
+
+        latest = summary["latest"]
+        state = latest["runnerState"]
+        self.assertEqual(summary["activeRunCount"], 1)
+        self.assertEqual(latest["stateClassification"], "TRAINING_IN_PROGRESS")
+        self.assertEqual(state["ageSeconds"], 1494)
+        self.assertEqual(state["timeoutSeconds"], 12300)
+        self.assertFalse(state["handoffRequired"])
+        self.assertEqual(state["action"], "monitor")
+
+    def test_tencent_active_run_beyond_timeout_without_progress_reports_stuck_handoff(self) -> None:
+        payload = {
+            "type": "screeps-tencent-batch-rl-run",
+            "runId": "tencent-pg-20260521t091504z",
+            "startedAt": "2026-05-21T09:15:04Z",
+            "finishedAt": None,
+            "partial": True,
+            "finalStatus": "running",
+            "controllerProcess": {"pid": 49283},
+            "inputs": {"executionTimeouts": {"totalSeconds": 12300}},
+            "execution": {
+                "environmentsRun": 0,
+                "artifactCount": 0,
+                "trainingReportProduced": False,
+            },
+        }
+
+        state = live.classify_tencent_batch_run_state(payload, now="2026-05-21T12:40:05Z")
+
+        self.assertEqual(state["status"], "TENCENT_BATCH_RUNNER_STUCK")
+        self.assertEqual(state["runId"], "tencent-pg-20260521t091504z")
+        self.assertEqual(state["pid"], 49283)
+        self.assertEqual(state["ageSeconds"], 12301)
+        self.assertEqual(state["timeoutSeconds"], 12300)
+        self.assertTrue(state["handoffRequired"])
+        self.assertIn("kill PID 49283", state["action"])
+        self.assertIn("scale down ASG", state["action"])
+        self.assertIn("age=12301s", state["evidence"])
+        self.assertIn("timeout=12300s", state["evidence"])
+
     def test_refresh_is_repeatable_and_summary_covers_live_observability(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             repo_root = Path(temp_dir)

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -476,6 +476,37 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         summary = json.loads((artifact_dir / "controller-summary.json").read_text(encoding="utf-8"))
         return events, controller, guard, summary
 
+    def test_controller_summary_records_pid_and_declared_timeout_window(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args = controller_args()
+            args.scale_timeout_seconds = 1200
+            args.scale_down_timeout_seconds = 900
+            args.bootstrap_timeout_seconds = 1800
+            args.training_timeout_seconds = 7200
+            args.transfer_timeout_seconds = 1200
+            controller = runner.Controller(
+                args=args,
+                run_id="tencent-pg-20260521t091504z",
+                artifact_dir=Path(temp_dir) / "run",
+            )
+
+            controller.write_summary(partial=True)
+
+            summary = json.loads((controller.artifact_dir / "controller-summary.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(summary["controllerProcess"]["pid"], os.getpid())
+        self.assertEqual(
+            summary["inputs"]["executionTimeouts"],
+            {
+                "bootstrapTimeoutSeconds": 1800,
+                "scaleDownTimeoutSeconds": 900,
+                "scaleTimeoutSeconds": 1200,
+                "totalSeconds": 12300,
+                "trainingTimeoutSeconds": 7200,
+                "transferTimeoutSeconds": 1200,
+            },
+        )
+
     def test_security_group_guard_accepts_single_controller_ssh_rule(self) -> None:
         ingress = [
             {"Action": "ACCEPT", "Protocol": "TCP", "Port": "22", "CidrBlock": CONTROLLER_IP},


### PR DESCRIPTION
## Summary
- Adds UTC/declared-timeout classification for active Tencent batch runs so in-progress runs inside their timeout window remain `TRAINING_IN_PROGRESS` instead of false `TENCENT_BATCH_RUNNER_STUCK`.
- Persists controller PID and declared execution timeout windows in `controller-summary.json` for reliable handoff evidence.
- Adds regressions for the 2026-05-21 Tencent timestamp/UTC-boundary case and for stale runs beyond the declared timeout.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_live_dashboard.py scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_rl_live_dashboard.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts.test_screeps_rl_live_dashboard` — 19 tests OK
- `python3 -m unittest scripts.test_screeps_tencent_batch_rl_runner` — 81 tests OK

Fixes #1297

Operational note: this PR does not launch, kill, scale down, or otherwise touch Tencent compute. It only hardens repo-side classifier/evidence surfaces.
