### PR TITLE
fix(rl): prove runtime parameter consumption

### DIFF
--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -1882,7 +1882,11 @@ def training_execution(
         episodes = number_value(metrics_feed.get("episodesRun"))
     updates = number_value(iteration.get("policyUpdateIterations"))
     if updates is None:
+        updates = number_value(payload.get("policyUpdateIterations"))
+    if updates is None:
         updates = number_value(metrics_feed.get("policyUpdateIterations"))
+    policy_update = as_dict(payload.get("policyUpdate"))
+    promotion_gate = as_dict(payload.get("policyUpdatePromotionGate")) or as_dict(policy_update.get("promotionGate"))
     card_supply = reconcile_card_supply_for_training(
         payload,
         latest_path=latest_training.path,
@@ -1920,6 +1924,9 @@ def training_execution(
         "trainingDidRun": payload.get("trainingDidRun"),
         "episodes": episodes,
         "policyUpdates": updates,
+        "policyUpdatePromotionGate": promotion_gate or None,
+        "policyUpdatePromotionStatus": text_value(promotion_gate.get("status")),
+        "runtimeConsumedPolicyUpdate": promotion_gate.get("runtimeParameterConsumption") is True,
         "timestamp": latest_training.timestamp,
         "blocker": blocker,
         "latestPath": latest_training.path,

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -2397,6 +2397,7 @@ def render_simulator(simulator: JsonObject, repo_root: Path) -> str:
 def render_training(training: JsonObject, repo_root: Path) -> str:
     card_supply = as_dict(training.get("cardSupply"))
     compute_evidence = as_dict(training.get("computeEvidence"))
+    promotion_status = text_value(training.get("policyUpdatePromotionStatus")) or "N/A"
     card_supply_status = "N/A"
     if card_supply:
         card_supply_status = (
@@ -2408,6 +2409,9 @@ def render_training(training: JsonObject, repo_root: Path) -> str:
         f"<tr><td>Status</td><td>{h(training.get('status', 'N/A'))}</td></tr>",
         f"<tr><td>Episodes</td><td>{h(format_count(training.get('episodes')))}</td></tr>",
         f"<tr><td>Policy updates</td><td>{h(format_count(training.get('policyUpdates')))}</td></tr>",
+        f"<tr><td>Promotion gate status</td><td>{h(promotion_status)}</td></tr>",
+        "<tr><td>Runtime-consumed policy update</td>"
+        f"<td>{h(display_value(training.get('runtimeConsumedPolicyUpdate')))}</td></tr>",
         f"<tr><td>Compute evidence</td><td>{h(compute_evidence.get('classification', 'N/A'))}</td></tr>",
         f"<tr><td>Card supply</td><td>{h(card_supply_status)}</td></tr>",
         f"<tr><td>Last ledger timestamp</td><td>{h(display_timestamp(training.get('timestamp')))}</td></tr>",

--- a/scripts/screeps_rl_live_dashboard.py
+++ b/scripts/screeps_rl_live_dashboard.py
@@ -973,6 +973,19 @@ def zero_iteration_policy_update_from_artifact(
                 "updatedAt": updated_at,
             }
         if isinstance(iterations, (int, float)) and iterations > 0:
+            promotion_gate = None
+            if isinstance(node.get("policyUpdatePromotionGate"), dict):
+                promotion_gate = node.get("policyUpdatePromotionGate")
+            elif isinstance(policy_update, dict) and isinstance(policy_update.get("promotionGate"), dict):
+                promotion_gate = policy_update.get("promotionGate")
+            if isinstance(promotion_gate, dict) and promotion_gate.get("runtimeParameterConsumption") is False:
+                status = text_value(promotion_gate.get("status")) or "blocked_runtime_parameter_consumption_missing"
+                return {
+                    "status": "BLOCKED",
+                    "evidence": f"policy update non-promotional: {status}",
+                    "latestPath": display_path,
+                    "updatedAt": updated_at,
+                }
             return {
                 "status": "N/A",
                 "evidence": f"latest policy update had {iterations} iteration(s)",

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -4938,6 +4938,10 @@ def policy_update_runtime_injection_ready_parameter_evidence(
             "inlineCandidatesRuntimeInjected",
         ),
     ) is True
+    consumption_status = text_or_none(
+        first_present(support, ("runtime_parameter_consumption_status", "runtimeParameterConsumptionStatus"))
+    )
+    runtime_consumption = consumption_status == "consumed"
     runtime_metadata_fallback = policy_gradient_allows_runtime_metadata_policy_update(policy_gradient)
     candidate_count_ready = len(candidates) >= policy_gradient_candidate_vector_count(policy_gradient)
     eligible = (
@@ -4949,7 +4953,7 @@ def policy_update_runtime_injection_ready_parameter_evidence(
     payload: JsonObject = {
         "candidateParameterScope": scope,
         "runtimeParameterInjection": runtime_injection,
-        "runtimeParameterConsumption": runtime_injection,
+        "runtimeParameterConsumption": runtime_consumption,
         "policyUpdateEligible": eligible,
         "candidateCount": len(candidates),
         "metadataCandidateCount": policy_gradient_candidate_vector_count(policy_gradient),
@@ -4961,9 +4965,6 @@ def policy_update_runtime_injection_ready_parameter_evidence(
             else "blocked_until_runtime_parameter_evidence"
         ),
     }
-    consumption_status = text_or_none(
-        first_present(support, ("runtime_parameter_consumption_status", "runtimeParameterConsumptionStatus"))
-    )
     if consumption_status is not None:
         payload["runtimeParameterConsumptionStatus"] = consumption_status
     if eligible:

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -47,6 +47,13 @@ RUNTIME_PARAMETER_INJECTION_INCOMPLETE_SKIP_REASON = "runtime_parameter_injectio
 POLICY_UPDATE_ARTIFACT_DIR = "policy-candidates"
 CANDIDATE_SCORECARD_ARTIFACT_DIR = "candidate-scorecards"
 MULTI_CANDIDATE_SCORECARD_SET_TYPE = "screeps-rl-multi-candidate-scorecard-set"
+POLICY_UPDATE_PROMOTION_GATE_TYPE = "screeps-rl-policy-update-promotion-gate"
+POLICY_UPDATE_CONSUMPTION_MODE_RUNTIME_CONSUMED = "runtime_consumed"
+POLICY_UPDATE_CONSUMPTION_MODE_SCORECARD_NON_CONSUMED = (
+    "runtime_injected_scorecard_metadata_non_promotional"
+)
+POLICY_UPDATE_CONSUMPTION_MODE_METADATA_ONLY = "metadata_only_non_promotional"
+POLICY_UPDATE_CONSUMPTION_MODE_INCOMPLETE = "runtime_parameter_evidence_incomplete_non_promotional"
 REWARD_TIERS = ("reliability", "territory", "resources", "kills")
 MULTI_TIER_ACTIVATION_PROOF_TYPE = "screeps-rl-multi-tier-activation-proof"
 MULTI_TIER_ACTIVATION_AUDIT_TYPE = "screeps-rl-multi-tier-activation-audit"
@@ -1330,6 +1337,9 @@ def build_training_report(
         next_candidate_policy = policy_update.get("nextCandidatePolicy")
         if isinstance(next_candidate_policy, dict):
             report["policyUpdateCandidatePolicyId"] = text_or_none(next_candidate_policy.get("candidatePolicyId"))
+        promotion_gate = policy_update.get("promotionGate")
+        if isinstance(promotion_gate, dict):
+            report["policyUpdatePromotionGate"] = copy.deepcopy(promotion_gate)
         report["policyUpdate"] = policy_update
     return report
 
@@ -1432,20 +1442,24 @@ def build_rank_weighted_finite_difference_policy_update(
     if not parameter_space:
         return {**base, "skippedReason": "missing_policy_parameter_space"}
     if policy_gradient_candidate_parameters_metadata_only(policy_gradient):
+        parameter_evidence = policy_update_metadata_only_parameter_evidence()
         return {
             **base,
             "skippedReason": METADATA_ONLY_POLICY_UPDATE_SKIP_REASON,
             "candidateCount": 0,
             "metadataCandidateCount": policy_gradient_candidate_vector_count(policy_gradient),
-            "parameterEvidence": policy_update_metadata_only_parameter_evidence(),
+            "parameterEvidence": parameter_evidence,
+            "promotionGate": policy_update_promotion_gate(parameter_evidence, policy_update_generated=False),
         }
     if policy_gradient_requires_runtime_parameter_evidence(policy_gradient) and len(candidates) < policy_gradient_candidate_vector_count(policy_gradient):
+        parameter_evidence = policy_update_runtime_injection_incomplete_parameter_evidence(policy_gradient)
         return {
             **base,
             "skippedReason": RUNTIME_PARAMETER_INJECTION_INCOMPLETE_SKIP_REASON,
             "candidateCount": len(candidates),
             "metadataCandidateCount": policy_gradient_candidate_vector_count(policy_gradient),
-            "parameterEvidence": policy_update_runtime_injection_incomplete_parameter_evidence(policy_gradient),
+            "parameterEvidence": parameter_evidence,
+            "promotionGate": policy_update_promotion_gate(parameter_evidence, policy_update_generated=False),
         }
     if len(candidates) < 2:
         return {**base, "skippedReason": "fewer_than_two_scored_policy_candidates", "candidateCount": len(candidates)}
@@ -1506,6 +1520,7 @@ def build_rank_weighted_finite_difference_policy_update(
             "candidateRewards": [policy_update_candidate_summary(row) for row in candidates],
             "learningRate": learning_rate,
             "gradient": gradient,
+            "promotionGate": policy_update_promotion_gate(parameter_evidence, policy_update_generated=False),
         }
 
     if not any(abs(float(value)) > 0 for value in parameter_delta.values()):
@@ -1518,6 +1533,7 @@ def build_rank_weighted_finite_difference_policy_update(
             "candidateRewards": [policy_update_candidate_summary(row) for row in candidates],
             "learningRate": learning_rate,
             "gradient": gradient,
+            "promotionGate": policy_update_promotion_gate(parameter_evidence, policy_update_generated=False),
         }
 
     candidate_policy_id = updated_candidate_policy_id(
@@ -1525,6 +1541,7 @@ def build_rank_weighted_finite_difference_policy_update(
         report_id=report_id,
         parameters=updated_parameters,
     )
+    promotion_gate = policy_update_promotion_gate(parameter_evidence, policy_update_generated=True)
     next_candidate_policy = {
         "type": "screeps-rl-next-candidate-policy",
         "schemaVersion": SCHEMA_VERSION,
@@ -1542,6 +1559,10 @@ def build_rank_weighted_finite_difference_policy_update(
         "sourceAnchorStrategyVariantId": anchor.get("strategyVariantId"),
         "policyUpdateIterations": 1,
         "parameters": updated_parameters,
+        "runtimeParameterConsumption": promotion_gate["runtimeParameterConsumption"],
+        "runtimeParameterConsumptionStatus": promotion_gate["runtimeParameterConsumptionStatus"],
+        "consumptionMode": promotion_gate["consumptionMode"],
+        "promotionGate": copy.deepcopy(promotion_gate),
         "parameterEvidence": {
             "derivation": "rank-weighted bounded finite-difference update from offline simulator rollout rewards",
             "targetFamily": target_family,
@@ -1553,6 +1574,9 @@ def build_rank_weighted_finite_difference_policy_update(
             "candidateCount": len(candidates),
             "policyUpdateAlgorithm": RANK_WEIGHTED_FINITE_DIFFERENCE_ALGORITHM,
             "trueGradient": False,
+            "runtimeParameterConsumption": promotion_gate["runtimeParameterConsumption"],
+            "runtimeParameterConsumptionStatus": promotion_gate["runtimeParameterConsumptionStatus"],
+            "consumptionMode": promotion_gate["consumptionMode"],
             "liveEffect": False,
             "officialMmoWrites": False,
             "officialMmoWritesAllowed": False,
@@ -1577,6 +1601,10 @@ def build_rank_weighted_finite_difference_policy_update(
         "gradient": gradient,
         "parameterDelta": parameter_delta,
         "updatedParameters": updated_parameters,
+        "runtimeParameterConsumption": promotion_gate["runtimeParameterConsumption"],
+        "runtimeParameterConsumptionStatus": promotion_gate["runtimeParameterConsumptionStatus"],
+        "consumptionMode": promotion_gate["consumptionMode"],
+        "promotionGate": promotion_gate,
         "nextCandidatePolicy": next_candidate_policy,
     }
 
@@ -1595,20 +1623,24 @@ def build_reinforce_policy_update(
     if not parameter_space:
         return {**base, "skippedReason": "missing_policy_parameter_space"}
     if policy_gradient_candidate_parameters_metadata_only(policy_gradient):
+        parameter_evidence = policy_update_metadata_only_parameter_evidence()
         return {
             **base,
             "skippedReason": METADATA_ONLY_POLICY_UPDATE_SKIP_REASON,
             "candidateCount": 0,
             "metadataCandidateCount": policy_gradient_candidate_vector_count(policy_gradient),
-            "parameterEvidence": policy_update_metadata_only_parameter_evidence(),
+            "parameterEvidence": parameter_evidence,
+            "promotionGate": policy_update_promotion_gate(parameter_evidence, policy_update_generated=False),
         }
     if policy_gradient_requires_runtime_parameter_evidence(policy_gradient) and len(candidates) < policy_gradient_candidate_vector_count(policy_gradient):
+        parameter_evidence = policy_update_runtime_injection_incomplete_parameter_evidence(policy_gradient)
         return {
             **base,
             "skippedReason": RUNTIME_PARAMETER_INJECTION_INCOMPLETE_SKIP_REASON,
             "candidateCount": len(candidates),
             "metadataCandidateCount": policy_gradient_candidate_vector_count(policy_gradient),
-            "parameterEvidence": policy_update_runtime_injection_incomplete_parameter_evidence(policy_gradient),
+            "parameterEvidence": parameter_evidence,
+            "promotionGate": policy_update_promotion_gate(parameter_evidence, policy_update_generated=False),
         }
     if len(candidates) < 2:
         return {**base, "skippedReason": "fewer_than_two_scored_policy_candidates", "candidateCount": len(candidates)}
@@ -1677,6 +1709,7 @@ def build_reinforce_policy_update(
             "learningRate": learning_rate,
             "gradient": gradient,
             "returnSummary": return_summary,
+            "promotionGate": policy_update_promotion_gate(parameter_evidence, policy_update_generated=False),
         }
 
     if not any(abs(float(value)) > 0 for value in parameter_delta.values()):
@@ -1689,6 +1722,7 @@ def build_reinforce_policy_update(
             "candidateRewards": [policy_update_candidate_summary(row) for row in candidates],
             "learningRate": learning_rate,
             "gradient": gradient,
+            "promotionGate": policy_update_promotion_gate(parameter_evidence, policy_update_generated=False),
         }
 
     candidate_policy_id = updated_candidate_policy_id(
@@ -1696,6 +1730,7 @@ def build_reinforce_policy_update(
         report_id=report_id,
         parameters=updated_parameters,
     )
+    promotion_gate = policy_update_promotion_gate(parameter_evidence, policy_update_generated=True)
     next_candidate_policy = {
         "type": "screeps-rl-next-candidate-policy",
         "schemaVersion": SCHEMA_VERSION,
@@ -1713,6 +1748,10 @@ def build_reinforce_policy_update(
         "sourceAnchorStrategyVariantId": anchor.get("strategyVariantId"),
         "policyUpdateIterations": 1,
         "parameters": updated_parameters,
+        "runtimeParameterConsumption": promotion_gate["runtimeParameterConsumption"],
+        "runtimeParameterConsumptionStatus": promotion_gate["runtimeParameterConsumptionStatus"],
+        "consumptionMode": promotion_gate["consumptionMode"],
+        "promotionGate": copy.deepcopy(promotion_gate),
         "parameterEvidence": {
             "derivation": (
                 "deterministic REINFORCE score-function estimate from offline simulator "
@@ -1731,6 +1770,9 @@ def build_reinforce_policy_update(
             "candidateCount": len(candidates),
             "policyUpdateAlgorithm": TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM,
             "trueGradient": True,
+            "runtimeParameterConsumption": promotion_gate["runtimeParameterConsumption"],
+            "runtimeParameterConsumptionStatus": promotion_gate["runtimeParameterConsumptionStatus"],
+            "consumptionMode": promotion_gate["consumptionMode"],
             "liveEffect": False,
             "officialMmoWrites": False,
             "officialMmoWritesAllowed": False,
@@ -1758,6 +1800,10 @@ def build_reinforce_policy_update(
         "selectedRewardTierByParameter": selected_reward_tier_by_parameter,
         "parameterDelta": parameter_delta,
         "updatedParameters": updated_parameters,
+        "runtimeParameterConsumption": promotion_gate["runtimeParameterConsumption"],
+        "runtimeParameterConsumptionStatus": promotion_gate["runtimeParameterConsumptionStatus"],
+        "consumptionMode": promotion_gate["consumptionMode"],
+        "promotionGate": promotion_gate,
         "nextCandidatePolicy": next_candidate_policy,
     }
 
@@ -2428,7 +2474,7 @@ def build_candidate_scorecard_readiness_for_pair(
             "evidence but cannot pass the runtime candidate gate"
         )
         next_action = (
-            "inject candidate parameters into private-simulator runtime inputs before promotion; "
+            f"{candidate_scorecard_runtime_next_action(runtime_parameter_injection)}; "
             "retain this scorecard as offline/private evidence"
         )
     payload: JsonObject = {
@@ -2456,7 +2502,7 @@ def build_candidate_scorecard_readiness_for_pair(
         "safety": safety_metadata(),
     }
     if reason is not None:
-        payload["missingPrerequisite"] = "runtime_parameter_injection"
+        payload["missingPrerequisite"] = candidate_scorecard_runtime_missing_prerequisite(runtime_parameter_injection)
         payload["reason"] = reason
     if next_action is not None:
         payload["nextAction"] = next_action
@@ -2669,6 +2715,8 @@ def candidate_scorecard_runtime_blocker(value: Any) -> str:
         return "runtime_parameter_injection_missing"
     status = text_or_none(value.get("status"))
     scope = runtime_parameter_scope(value)
+    if candidate_scorecard_runtime_consumption_missing(value):
+        return "runtime_parameter_consumption_missing"
     if status == "metadata_only" or scope == "metadata_only":
         return "runtime_parameter_injection_metadata_only"
     if status == "partial" or scope == "partial_runtime_injection":
@@ -2678,6 +2726,8 @@ def candidate_scorecard_runtime_blocker(value: Any) -> str:
 
 def candidate_scorecard_runtime_blocker_reason(value: Any) -> str:
     if isinstance(value, dict):
+        if candidate_scorecard_runtime_consumption_missing(value):
+            return "candidate-vs-baseline scorecard requires tick-time runtime policy parameter consumption evidence"
         reason = text_or_none(value.get("reason"))
         if reason is not None:
             return reason
@@ -2686,6 +2736,28 @@ def candidate_scorecard_runtime_blocker_reason(value: Any) -> str:
         if status == "metadata_only" or scope == "metadata_only":
             return "candidate parameters were metadata-only and were not injected into simulator runtime inputs"
     return "candidate-vs-baseline scorecard requires runtime parameter injection evidence with injectedVariantCount > 0"
+
+
+def candidate_scorecard_runtime_consumption_missing(value: JsonObject) -> bool:
+    scope = runtime_parameter_scope(value)
+    consumption_status = text_or_none(value.get("runtimeParameterConsumptionStatus"))
+    return (
+        scope == "runtime_injected"
+        and value.get("runtimeParameterConsumption") is not True
+        and consumption_status in {"missing", "missing_runtime_parameter_consumption"}
+    )
+
+
+def candidate_scorecard_runtime_missing_prerequisite(value: Any) -> str:
+    if isinstance(value, dict) and candidate_scorecard_runtime_consumption_missing(value):
+        return "runtime_parameter_consumption"
+    return "runtime_parameter_injection"
+
+
+def candidate_scorecard_runtime_next_action(value: Any) -> str:
+    if isinstance(value, dict) and candidate_scorecard_runtime_consumption_missing(value):
+        return "emit tick-time runtime policy parameter consumption evidence before promotion"
+    return "inject candidate parameters into private-simulator runtime inputs before promotion"
 
 
 def candidate_scorecard_id(report: JsonObject, candidate_id: str, baseline_id: str) -> str:
@@ -4740,12 +4812,88 @@ def policy_update_metadata_only_parameter_evidence() -> JsonObject:
     return {
         "candidateParameterScope": "metadata_only",
         "runtimeParameterInjection": False,
+        "runtimeParameterConsumption": False,
         "policyUpdateEligible": False,
         "reason": (
             "candidate rewards were produced by the shared uploaded bot artifact; inline parameter vectors "
             "were not injected into simulator runtime behavior"
         ),
     }
+
+
+def policy_update_promotion_gate(
+    parameter_evidence: JsonObject,
+    *,
+    policy_update_generated: bool,
+) -> JsonObject:
+    """Classify whether a policy update has tick-time runtime consumption proof."""
+    runtime_injection = parameter_evidence.get("runtimeParameterInjection") is True
+    runtime_consumed = parameter_evidence.get("runtimeParameterConsumption") is True
+    eligibility_mode = text_or_none(parameter_evidence.get("eligibilityMode"))
+    scope = text_or_none(parameter_evidence.get("candidateParameterScope")) or "metadata_only"
+    consumption_status = text_or_none(parameter_evidence.get("runtimeParameterConsumptionStatus"))
+
+    if runtime_consumed:
+        consumption_mode = POLICY_UPDATE_CONSUMPTION_MODE_RUNTIME_CONSUMED
+        status = "runtime_consumed_shadow_candidate"
+        missing_prerequisites: list[str] = []
+        reason = (
+            "tick-time runtime policy parameter consumption proof is present; candidate remains "
+            "offline/shadow and still requires normal scorecard and rollout gates before any live effect"
+        )
+    elif eligibility_mode == "runtime_injected_metadata_scorecard_ranking":
+        consumption_mode = POLICY_UPDATE_CONSUMPTION_MODE_SCORECARD_NON_CONSUMED
+        status = "blocked_runtime_parameter_consumption_missing"
+        missing_prerequisites = ["runtime_parameter_consumption"]
+        reason = (
+            "#924-compatible scorecard metadata produced an offline true-gradient candidate, but "
+            "#907 change-control semantics block Loop A/Loop B promotion until tick-time runtime "
+            "policy parameter consumption evidence is present"
+        )
+    elif scope == "metadata_only":
+        consumption_mode = POLICY_UPDATE_CONSUMPTION_MODE_METADATA_ONLY
+        status = "blocked_runtime_parameter_injection_missing"
+        missing_prerequisites = ["runtime_parameter_injection", "runtime_parameter_consumption"]
+        reason = (
+            "candidate parameters were metadata-only and cannot be promoted or classified as "
+            "runtime-consumed without runtime injection and consumption evidence"
+        )
+    else:
+        consumption_mode = POLICY_UPDATE_CONSUMPTION_MODE_INCOMPLETE
+        status = "blocked_runtime_parameter_consumption_missing"
+        missing_prerequisites = ["runtime_parameter_consumption"]
+        reason = (
+            "runtime parameter evidence is incomplete; Loop A/Loop B must not classify the update "
+            "as runtime-consumed or promotional"
+        )
+
+    runtime_consumed_promotion_eligible = runtime_consumed
+    payload: JsonObject = {
+        "type": POLICY_UPDATE_PROMOTION_GATE_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "status": status,
+        "consumptionMode": consumption_mode,
+        "policyUpdateGenerated": policy_update_generated,
+        "runtimeParameterInjection": runtime_injection,
+        "runtimeParameterConsumption": runtime_consumed,
+        "runtimeParameterConsumptionStatus": consumption_status or ("consumed" if runtime_consumed else "missing"),
+        "candidateParameterScope": scope,
+        "runtimeConsumedPromotionEligible": runtime_consumed_promotion_eligible,
+        "loopAPromotionEligible": runtime_consumed_promotion_eligible,
+        "loopBPromotionEligible": runtime_consumed_promotion_eligible,
+        "missingPrerequisites": missing_prerequisites,
+        "reason": reason,
+        "validationText": (
+            "#924 scorecards and #907 change-control require tick-time runtime parameter "
+            "consumption proof before Loop A or Loop B can treat a policy update as "
+            "runtime-consumed or promotional."
+        ),
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+        "safety": safety_metadata(),
+    }
+    return payload
 
 
 def policy_update_runtime_injection_incomplete_parameter_evidence(policy_gradient: JsonObject) -> JsonObject:
@@ -4763,6 +4911,7 @@ def policy_update_runtime_injection_incomplete_parameter_evidence(policy_gradien
             ),
         )
         is True,
+        "runtimeParameterConsumption": False,
         "policyUpdateEligible": False,
         "reason": (
             "policy-gradient rewards were not backed by complete evaluated runtime parameter evidence "
@@ -4800,6 +4949,7 @@ def policy_update_runtime_injection_ready_parameter_evidence(
     payload: JsonObject = {
         "candidateParameterScope": scope,
         "runtimeParameterInjection": runtime_injection,
+        "runtimeParameterConsumption": runtime_injection,
         "policyUpdateEligible": eligible,
         "candidateCount": len(candidates),
         "metadataCandidateCount": policy_gradient_candidate_vector_count(policy_gradient),
@@ -4925,6 +5075,7 @@ def build_generation_summary(report: JsonObject) -> JsonObject:
         "policyUpdateAlgorithm": report.get("policyUpdateAlgorithm"),
         "policyUpdateCandidatePolicyId": report.get("policyUpdateCandidatePolicyId"),
         "policyUpdateArtifactPath": report.get("policyUpdateArtifactPath"),
+        "policyUpdatePromotionGate": copy.deepcopy(report.get("policyUpdatePromotionGate")),
         "trueGradient": report.get("trueGradient", False),
         "runtimeParameterInjection": copy.deepcopy(report.get("runtimeParameterInjection")),
         "scorecardId": report.get("scorecardId"),

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -2664,11 +2664,23 @@ def validate_policy_update_promotion_gate(
     missing_prerequisites = required_text_list(raw.get("missingPrerequisites"), f"{label}.missingPrerequisites")
     required_non_empty_text(raw.get("validationText"), f"{label}.validationText")
 
-    top_level_consumed = (
+    top_level_consumed = False
+    if (
         isinstance(runtime_parameter_injection, dict)
         and runtime_parameter_injection.get("runtimeParameterInjection") is True
-        and runtime_parameter_injection.get("runtimeParameterConsumption") is True
-    )
+    ):
+        if "runtimeParameterConsumption" not in runtime_parameter_injection:
+            raise BatchRunError(
+                "remote runtimeParameterInjection.runtimeParameterConsumption must be present when "
+                "runtime injection is proven"
+            )
+        top_level_consumed = (
+            required_bool(
+                runtime_parameter_injection.get("runtimeParameterConsumption"),
+                "runtimeParameterInjection.runtimeParameterConsumption",
+            )
+            is True
+        )
     if top_level_consumed:
         if not runtime_consumed:
             raise BatchRunError(f"remote {label} contradicts consumed runtimeParameterInjection proof")

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -137,6 +137,7 @@ ZERO_ITERATION_POLICY_UPDATE_ALLOWED_KEYS = {
     "officialMmoWrites",
     "officialMmoWritesAllowed",
     "parameterEvidence",
+    "promotionGate",
     "safety",
     "schemaVersion",
     "skippedReason",
@@ -988,8 +989,13 @@ tar -czf remote-artifacts.tar.gz \
         scale_validation = data.get("scaleValidation")
         if scale_environments is not None:
             validate_scale_proof_result(scale_validation, scale_environments, repetitions=self.args.repetitions)
-        policy_update_fields = verified_remote_policy_update_fields(data, safety_flags, self.artifact_dir)
         runtime_parameter_injection = verified_remote_runtime_parameter_injection(data.get("runtimeParameterInjection"))
+        policy_update_fields = verified_remote_policy_update_fields(
+            data,
+            safety_flags,
+            self.artifact_dir,
+            runtime_parameter_injection=runtime_parameter_injection,
+        )
         candidate_scorecard = verified_remote_candidate_scorecard(
             data.get("candidateScorecard"),
             runtime_parameter_injection=runtime_parameter_injection,
@@ -2058,6 +2064,8 @@ def verified_remote_policy_update_fields(
     data: dict[str, Any],
     top_level_safety: dict[str, Any],
     artifact_dir: Path,
+    *,
+    runtime_parameter_injection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     iterations = policy_update_iterations(data.get("policyUpdateIterations"), "policyUpdateIterations")
     safe_policy_update = validated_remote_policy_update(data.get("policyUpdate"), top_level_safety)
@@ -2084,7 +2092,10 @@ def verified_remote_policy_update_fields(
     if iterations <= 0:
         raise BatchRunError("remote policyUpdateIterations must be positive when policyUpdate claims an update")
 
-    validate_positive_policy_update(safe_policy_update)
+    validate_positive_policy_update(
+        safe_policy_update,
+        runtime_parameter_injection=runtime_parameter_injection,
+    )
     nested_iterations = policy_update_iterations(safe_policy_update.get("iterations"), "policyUpdate.iterations")
     if nested_iterations != iterations:
         raise BatchRunError(
@@ -2112,10 +2123,12 @@ def verified_remote_policy_update_fields(
         local_artifact_path,
         rel_artifact_path,
         updated_parameters,
+        safe_policy_update.get("promotionGate"),
     )
     return {
         "policyUpdateIterations": iterations,
         "policyUpdateArtifactPath": rel_artifact_path.as_posix(),
+        "policyUpdatePromotionGate": copy.deepcopy(safe_policy_update.get("promotionGate")),
         "policyUpdate": safe_policy_update,
     }
 
@@ -2571,7 +2584,11 @@ def policy_update_iterations(raw: Any, label: str) -> int:
     raise BatchRunError(f"remote {label} invalid: {raw!r}")
 
 
-def validate_positive_policy_update(raw: Any) -> None:
+def validate_positive_policy_update(
+    raw: Any,
+    *,
+    runtime_parameter_injection: dict[str, Any] | None = None,
+) -> None:
     if not isinstance(raw, dict):
         raise BatchRunError("remote policyUpdate must be an object when policyUpdateIterations is positive")
     iterations = policy_update_iterations(raw.get("iterations"), "policyUpdate.iterations")
@@ -2583,6 +2600,16 @@ def validate_positive_policy_update(raw: Any) -> None:
     require_explicit_false_policy_update_safety_flags(raw, "policyUpdate")
     require_explicit_false_policy_update_safety_flags(next_candidate_policy, "policyUpdate.nextCandidatePolicy")
     validate_positive_policy_update_parameter_change(raw, next_candidate_policy)
+    validate_policy_update_promotion_gate(
+        raw.get("promotionGate"),
+        runtime_parameter_injection=runtime_parameter_injection,
+        label="policyUpdate.promotionGate",
+    )
+    validate_policy_update_promotion_gate(
+        next_candidate_policy.get("promotionGate"),
+        runtime_parameter_injection=runtime_parameter_injection,
+        label="policyUpdate.nextCandidatePolicy.promotionGate",
+    )
 
 
 def validate_positive_policy_update_parameter_change(
@@ -2616,6 +2643,55 @@ def validate_positive_policy_update_parameter_change(
         raise BatchRunError("remote policyUpdate.parameterDelta must include at least one non-zero change")
 
 
+def validate_policy_update_promotion_gate(
+    raw: Any,
+    *,
+    runtime_parameter_injection: dict[str, Any] | None,
+    label: str,
+) -> None:
+    if not isinstance(raw, dict):
+        raise BatchRunError(f"remote {label} must be an object when policyUpdateIterations is positive")
+    require_explicit_false_policy_update_safety_flags(raw, label)
+    status = required_non_empty_text(raw.get("status"), f"{label}.status")
+    consumption_mode = required_non_empty_text(raw.get("consumptionMode"), f"{label}.consumptionMode")
+    runtime_consumed = required_bool(raw.get("runtimeParameterConsumption"), f"{label}.runtimeParameterConsumption")
+    loop_a = required_bool(raw.get("loopAPromotionEligible"), f"{label}.loopAPromotionEligible")
+    loop_b = required_bool(raw.get("loopBPromotionEligible"), f"{label}.loopBPromotionEligible")
+    runtime_consumed_promotion = required_bool(
+        raw.get("runtimeConsumedPromotionEligible"),
+        f"{label}.runtimeConsumedPromotionEligible",
+    )
+    missing_prerequisites = required_text_list(raw.get("missingPrerequisites"), f"{label}.missingPrerequisites")
+    required_non_empty_text(raw.get("validationText"), f"{label}.validationText")
+
+    top_level_consumed = (
+        isinstance(runtime_parameter_injection, dict)
+        and runtime_parameter_injection.get("runtimeParameterInjection") is True
+        and runtime_parameter_injection.get("runtimeParameterConsumption") is True
+    )
+    if top_level_consumed:
+        if not runtime_consumed:
+            raise BatchRunError(f"remote {label} contradicts consumed runtimeParameterInjection proof")
+        if consumption_mode != "runtime_consumed":
+            raise BatchRunError(f"remote {label} consumed mode must use runtime_consumed consumptionMode")
+        if missing_prerequisites:
+            raise BatchRunError(f"remote {label} consumed mode cannot declare missing prerequisites")
+        if not (loop_a and loop_b and runtime_consumed_promotion):
+            raise BatchRunError(f"remote {label} consumed mode must keep Loop A/B runtime-consumed gates eligible")
+        return
+
+    if runtime_consumed:
+        raise BatchRunError(f"remote {label} claims runtime consumption without top-level consumption proof")
+    if loop_a or loop_b or runtime_consumed_promotion:
+        raise BatchRunError(f"remote {label} non-consumed mode must block Loop A/B promotion")
+    if "runtime_parameter_consumption" not in missing_prerequisites:
+        raise BatchRunError(f"remote {label} non-consumed mode must require runtime_parameter_consumption")
+    if status != "blocked_runtime_parameter_consumption_missing":
+        raise BatchRunError(f"remote {label} non-consumed mode has unsafe status: {status!r}")
+    if consumption_mode == "runtime_consumed":
+        raise BatchRunError(f"remote {label} non-consumed mode cannot use runtime_consumed consumptionMode")
+
+
 def validate_policy_update_parameter_values(parameters: dict[str, Any], label: str) -> None:
     for value in parameters.values():
         if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(float(value)):
@@ -2626,6 +2702,7 @@ def validate_collected_policy_update_artifact_parameters(
     local_artifact_path: Path,
     rel_artifact_path: Path,
     updated_parameters: dict[str, Any],
+    promotion_gate: Any,
 ) -> None:
     try:
         with local_artifact_path.open(encoding="utf-8") as artifact_file:
@@ -2645,6 +2722,11 @@ def validate_collected_policy_update_artifact_parameters(
     if artifact_parameters != updated_parameters:
         raise BatchRunError(
             "remote policy update artifact parameters disagree with policyUpdate.updatedParameters: "
+            f"{rel_artifact_path.as_posix()}"
+        )
+    if promotion_gate is not None and artifact.get("promotionGate") != promotion_gate:
+        raise BatchRunError(
+            "remote policy update artifact promotionGate disagrees with policyUpdate.promotionGate: "
             f"{rel_artifact_path.as_posix()}"
         )
 

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -337,6 +337,11 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         )
         self.assertFalse(training["runtimeConsumedPolicyUpdate"])
         self.assertEqual(training["policyUpdatePromotionGate"], promotion_gate)
+        html = dashboard.render_training(training, root)
+        self.assertIn("Promotion gate status", html)
+        self.assertIn("blocked_runtime_parameter_consumption_missing", html)
+        self.assertIn("Runtime-consumed policy update", html)
+        self.assertIn("False", html)
 
     def test_tencent_internal_card_downgrades_standalone_stall_to_fallback(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -302,6 +302,42 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(card_supply["fallbackStatus"], "DEGRADED")
         self.assertIsNone(training["blocker"])
 
+    def test_training_execution_surfaces_non_consumed_policy_update_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            promotion_gate = {
+                "status": "blocked_runtime_parameter_consumption_missing",
+                "runtimeParameterConsumption": False,
+                "loopAPromotionEligible": False,
+                "loopBPromotionEligible": False,
+            }
+            training = dashboard.training_execution(
+                loaded_artifact(
+                    root / "rl-control-loop" / "training-ledger.json",
+                    {
+                        "type": "screeps-rl-training-execution-ledger",
+                        "status": "RUN",
+                        "trainingDidRun": True,
+                        "artifactCount": 1,
+                        "policyUpdateIterations": 1,
+                        "policyUpdatePromotionGate": promotion_gate,
+                        "controllerSummary": {
+                            "finalStatus": "completed",
+                            "instanceId": "ins-test",
+                            "environmentsRun": 1,
+                        },
+                    },
+                )
+            )
+
+        self.assertEqual(training["policyUpdates"], 1)
+        self.assertEqual(
+            training["policyUpdatePromotionStatus"],
+            "blocked_runtime_parameter_consumption_missing",
+        )
+        self.assertFalse(training["runtimeConsumedPolicyUpdate"])
+        self.assertEqual(training["policyUpdatePromotionGate"], promotion_gate)
+
     def test_tencent_internal_card_downgrades_standalone_stall_to_fallback(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_live_dashboard.py
+++ b/scripts/test_screeps_rl_live_dashboard.py
@@ -511,6 +511,33 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
         self.assertEqual(zero_iteration["status"], "BLOCKED")
         self.assertTrue(zero_iteration["latestPath"].endswith("z-zero-blocked.json"))
 
+    def test_positive_non_consumed_policy_update_is_blocked_as_non_promotional(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            artifact_root = repo_root / "runtime-artifacts"
+            write_json(
+                artifact_root / "rl-training" / "non-consumed-update.json",
+                {
+                    "createdAt": "2026-05-18T10:15:00Z",
+                    "policyUpdateIterations": 1,
+                    "policyUpdate": {
+                        "iterations": 1,
+                        "promotionGate": {
+                            "status": "blocked_runtime_parameter_consumption_missing",
+                            "runtimeParameterConsumption": False,
+                        },
+                    },
+                },
+            )
+
+            zero_iteration = live.zero_iteration_policy_update_summary(artifact_root, repo_root)
+
+        self.assertEqual(zero_iteration["status"], "BLOCKED")
+        self.assertEqual(
+            zero_iteration["evidence"],
+            "policy update non-promotional: blocked_runtime_parameter_consumption_missing",
+        )
+
     def test_health_helper_requires_successful_auto_refresh(self) -> None:
         health = live.health_with_refresh(
             {"ok": True, "status": "ok", "failures": []},

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -1675,6 +1675,12 @@ export const STRATEGY_REGISTRY = [
         self.assertTrue(report["policyGradient"]["runner_support"]["report_preserves_candidate_parameters"])
         self.assertEqual(report["policyUpdateIterations"], 0)
         self.assertEqual(report["policyUpdate"]["skippedReason"], runner.METADATA_ONLY_POLICY_UPDATE_SKIP_REASON)
+        self.assertEqual(
+            report["policyUpdate"]["promotionGate"]["status"],
+            "blocked_runtime_parameter_injection_missing",
+        )
+        self.assertFalse(report["policyUpdate"]["promotionGate"]["loopAPromotionEligible"])
+        self.assertFalse(report["policyUpdate"]["promotionGate"]["loopBPromotionEligible"])
         self.assertNotIn("policyUpdateArtifactPath", report)
         self.assertEqual(simulator.calls[0]["ticks"], 500)
         self.assertEqual(simulator.calls[0]["variants"], variant_ids)
@@ -2558,7 +2564,12 @@ export const STRATEGY_REGISTRY = [
         update = report["policyUpdate"]
         self.assertEqual(update["algorithm"], runner.TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM)
         self.assertEqual(update["candidateCount"], len(variant_ids))
+        self.assertTrue(update["runtimeParameterConsumption"])
+        self.assertEqual(update["consumptionMode"], runner.POLICY_UPDATE_CONSUMPTION_MODE_RUNTIME_CONSUMED)
+        self.assertTrue(update["promotionGate"]["loopAPromotionEligible"])
+        self.assertTrue(update["promotionGate"]["loopBPromotionEligible"])
         self.assertFalse(update["nextCandidatePolicy"]["officialMmoWritesAllowed"])
+        self.assertEqual(update["nextCandidatePolicy"]["promotionGate"], update["promotionGate"])
         self.assertFalse(update["liveEffect"])
         self.assertFalse(update["officialMmoWrites"])
         self.assertFalse(update["officialMmoWritesAllowed"])
@@ -2858,6 +2869,9 @@ export const STRATEGY_REGISTRY = [
             report["policyUpdate"]["parameterEvidence"]["eligibilityMode"],
             "runtime_injected_metadata_scorecard_ranking",
         )
+        self.assertFalse(report["policyUpdate"]["promotionGate"]["runtimeParameterConsumption"])
+        self.assertFalse(report["policyUpdate"]["promotionGate"]["loopAPromotionEligible"])
+        self.assertFalse(report["policyUpdate"]["promotionGate"]["loopBPromotionEligible"])
         self.assertNotIn("policyUpdateArtifactPath", report)
         self.assertTrue(all("evaluatedParameters" in result for result in simulator.last_variants))
         self.assertTrue(all("runtimeParameterConsumption" not in result for result in simulator.last_variants))
@@ -2924,6 +2938,11 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(persisted["policyUpdateIterations"], 1)
         self.assertTrue(report["trueGradient"])
         self.assertEqual(report["candidateScorecard"]["status"], "materialized")
+        self.assertEqual(
+            report["candidateScorecard"]["classification"],
+            "runtime_parameter_consumption_missing_scorecard_materialized",
+        )
+        self.assertEqual(report["candidateScorecard"]["missingPrerequisite"], "runtime_parameter_consumption")
         self.assertTrue(report["candidateScorecard"]["validationScaleComputeBlocked"])
         self.assertTrue(report["candidateScorecard"]["scorecardUsable"])
         self.assertIsNotNone(report["candidateScorecard"]["candidateRank"])
@@ -2941,8 +2960,22 @@ export const STRATEGY_REGISTRY = [
             update["parameterEvidence"]["eligibilityMode"],
             "runtime_injected_metadata_scorecard_ranking",
         )
+        self.assertFalse(update["runtimeParameterConsumption"])
+        self.assertEqual(
+            update["consumptionMode"],
+            runner.POLICY_UPDATE_CONSUMPTION_MODE_SCORECARD_NON_CONSUMED,
+        )
+        self.assertEqual(
+            update["promotionGate"]["status"],
+            "blocked_runtime_parameter_consumption_missing",
+        )
+        self.assertFalse(update["promotionGate"]["runtimeConsumedPromotionEligible"])
+        self.assertFalse(update["promotionGate"]["loopAPromotionEligible"])
+        self.assertFalse(update["promotionGate"]["loopBPromotionEligible"])
+        self.assertEqual(update["promotionGate"]["missingPrerequisites"], ["runtime_parameter_consumption"])
         self.assertTrue(any(abs(float(value)) > 0 for value in update["parameterDelta"].values()))
         self.assertEqual(artifact["parameters"], update["updatedParameters"])
+        self.assertEqual(artifact["promotionGate"], update["promotionGate"])
         self.assertFalse(artifact["liveEffect"])
         self.assertFalse(artifact["officialMmoWrites"])
         self.assertFalse(artifact["officialMmoWritesAllowed"])

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -2350,6 +2350,67 @@ export const STRATEGY_REGISTRY = [
         self.assertFalse(update["nextCandidatePolicy"]["officialMmoWrites"])
         self.assertFalse(update["nextCandidatePolicy"]["officialMmoWritesAllowed"])
 
+    def test_ready_parameter_evidence_does_not_alias_injection_to_consumption(self) -> None:
+        policy_gradient = {
+            "runner_support": {
+                "runtime_parameter_injection": True,
+                "inline_candidates_runtime_injected": True,
+                "candidate_parameter_scope": "runtime_injected",
+                "simulator_variant_transport": "variant_ids_with_runtime_injected_parameters",
+                "policy_update_reward_use": "eligible_with_evaluated_runtime_parameters",
+                "runtime_parameter_consumption_status": "missing_runtime_parameter_consumption",
+            },
+            "candidateParameterVectors": [
+                {"strategyVariantId": "variant-a"},
+                {"strategyVariantId": "variant-b"},
+            ],
+        }
+
+        evidence = runner.policy_update_runtime_injection_ready_parameter_evidence(
+            policy_gradient,
+            [{"strategyVariantId": "variant-a"}, {"strategyVariantId": "variant-b"}],
+        )
+        gate = runner.policy_update_promotion_gate(evidence, policy_update_generated=True)
+
+        self.assertTrue(evidence["runtimeParameterInjection"])
+        self.assertFalse(evidence["runtimeParameterConsumption"])
+        self.assertTrue(evidence["policyUpdateEligible"])
+        self.assertEqual(evidence["runtimeParameterConsumptionStatus"], "missing_runtime_parameter_consumption")
+        self.assertEqual(gate["status"], "blocked_runtime_parameter_consumption_missing")
+        self.assertFalse(gate["runtimeConsumedPromotionEligible"])
+        self.assertFalse(gate["loopAPromotionEligible"])
+        self.assertFalse(gate["loopBPromotionEligible"])
+
+    def test_ready_parameter_evidence_accepts_consumed_runtime_status(self) -> None:
+        policy_gradient = {
+            "runner_support": {
+                "runtime_parameter_injection": True,
+                "inline_candidates_runtime_injected": True,
+                "candidate_parameter_scope": "runtime_injected",
+                "simulator_variant_transport": "variant_ids_with_runtime_injected_parameters",
+                "policy_update_reward_use": "eligible_with_evaluated_runtime_parameters",
+                "runtime_parameter_consumption_status": "consumed",
+            },
+            "candidateParameterVectors": [
+                {"strategyVariantId": "variant-a"},
+                {"strategyVariantId": "variant-b"},
+            ],
+        }
+
+        evidence = runner.policy_update_runtime_injection_ready_parameter_evidence(
+            policy_gradient,
+            [{"strategyVariantId": "variant-a"}, {"strategyVariantId": "variant-b"}],
+        )
+        gate = runner.policy_update_promotion_gate(evidence, policy_update_generated=True)
+
+        self.assertTrue(evidence["runtimeParameterInjection"])
+        self.assertTrue(evidence["runtimeParameterConsumption"])
+        self.assertTrue(evidence["policyUpdateEligible"])
+        self.assertEqual(gate["status"], "runtime_consumed_shadow_candidate")
+        self.assertTrue(gate["runtimeConsumedPromotionEligible"])
+        self.assertTrue(gate["loopAPromotionEligible"])
+        self.assertTrue(gate["loopBPromotionEligible"])
+
     def test_reinforce_reward_evidence_without_runtime_transport_stays_noop(self) -> None:
         policy_gradient = {
             "targetFamily": "test-family",

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -178,13 +178,13 @@ def ready_runtime_parameter_injection() -> dict[str, object]:
 
 def missing_consumption_runtime_parameter_injection() -> dict[str, object]:
     return {
-        "status": "not_injected",
-        "runtimeParameterInjection": False,
+        "status": "injected",
+        "runtimeParameterInjection": True,
         "runtimeParameterConsumption": False,
         "runtimeParameterConsumptionStatus": "missing_runtime_parameter_consumption",
         "policyUpdateEligible": False,
         "candidateParameterScope": "runtime_injected",
-        "injectedVariantCount": 0,
+        "injectedVariantCount": 1,
         "consumedVariantCount": 0,
         "liveEffect": False,
         "officialMmoWrites": False,
@@ -198,7 +198,10 @@ def write_policy_update_artifact(
     parameters: object,
     promotion_gate: object | None = None,
 ) -> None:
-    payload = {"parameters": parameters, "promotionGate": promotion_gate or runtime_consumed_promotion_gate()}
+    payload = {
+        "parameters": parameters,
+        "promotionGate": runtime_consumed_promotion_gate() if promotion_gate is None else promotion_gate,
+    }
     write_text(root / "remote" / artifact_path, json.dumps(payload, sort_keys=True) + "\n")
 
 
@@ -786,6 +789,15 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             with self.subTest(raw=raw), self.assertRaisesRegex(runner.BatchRunError, expected_error):
                 runner.safe_policy_update_artifact_path(raw)
 
+    def test_write_policy_update_artifact_preserves_intentional_falsy_promotion_gate(self) -> None:
+        artifact_path = "runtime-artifacts/rl-training/policy-candidates/run-test-next-policy.json"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            write_policy_update_artifact(root, artifact_path, {"territorySignalWeight": 7}, promotion_gate=False)
+            payload = json.loads((root / "remote" / artifact_path).read_text(encoding="utf-8"))
+
+        self.assertIs(payload["promotionGate"], False)
+
     def test_verified_remote_policy_update_accepts_empty_zero_iteration_update(self) -> None:
         top_level_safety = {
             "liveEffect": False,
@@ -1079,6 +1091,40 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertFalse(promotion_gate["loopAPromotionEligible"])
         self.assertFalse(promotion_gate["loopBPromotionEligible"])
         self.assertEqual(promotion_gate["missingPrerequisites"], ["runtime_parameter_consumption"])
+
+    def test_verified_remote_policy_update_rejects_missing_consumption_key_for_injected_proof(self) -> None:
+        artifact_path = "runtime-artifacts/rl-training/policy-candidates/run-test-next-policy.json"
+        top_level_safety = {
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+        }
+        policy_update = positive_policy_update(artifact_path)
+        gate = non_consumed_promotion_gate()
+        policy_update["promotionGate"] = copy.deepcopy(gate)
+        next_candidate = policy_update["nextCandidatePolicy"]
+        assert isinstance(next_candidate, dict)
+        next_candidate["promotionGate"] = copy.deepcopy(gate)
+        runtime_parameter_injection = missing_consumption_runtime_parameter_injection()
+        runtime_parameter_injection.pop("runtimeParameterConsumption")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            write_policy_update_artifact(root, artifact_path, policy_update["updatedParameters"], gate)
+
+            with self.assertRaisesRegex(
+                runner.BatchRunError,
+                "runtimeParameterInjection.runtimeParameterConsumption",
+            ):
+                runner.verified_remote_policy_update_fields(
+                    {
+                        "policyUpdateIterations": 1,
+                        "policyUpdateArtifactPath": artifact_path,
+                        "policyUpdate": policy_update,
+                    },
+                    top_level_safety,
+                    root,
+                    runtime_parameter_injection=runtime_parameter_injection,
+                )
 
     def test_verified_remote_policy_update_rejects_non_consumed_scorecard_update_claiming_runtime_consumption(
         self,

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -114,8 +114,92 @@ def write_candidate_scorecard_set_artifacts(root: Path, scorecard_set: object) -
             write_text(root / "remote" / artifact_path, "{}\n")
 
 
-def write_policy_update_artifact(root: Path, artifact_path: str, parameters: object) -> None:
-    write_text(root / "remote" / artifact_path, json.dumps({"parameters": parameters}, sort_keys=True) + "\n")
+def runtime_consumed_promotion_gate() -> dict[str, object]:
+    return {
+        "type": "screeps-rl-policy-update-promotion-gate",
+        "schemaVersion": 1,
+        "status": "runtime_consumed_shadow_candidate",
+        "consumptionMode": "runtime_consumed",
+        "policyUpdateGenerated": True,
+        "runtimeParameterInjection": True,
+        "runtimeParameterConsumption": True,
+        "runtimeParameterConsumptionStatus": "consumed",
+        "candidateParameterScope": "runtime_injected",
+        "runtimeConsumedPromotionEligible": True,
+        "loopAPromotionEligible": True,
+        "loopBPromotionEligible": True,
+        "missingPrerequisites": [],
+        "reason": "tick-time runtime policy parameter consumption proof is present",
+        "validationText": (
+            "#924 scorecards and #907 change-control require tick-time runtime parameter "
+            "consumption proof before Loop A or Loop B can treat a policy update as "
+            "runtime-consumed or promotional."
+        ),
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+    }
+
+
+def non_consumed_promotion_gate() -> dict[str, object]:
+    gate = runtime_consumed_promotion_gate()
+    gate.update(
+        {
+            "status": "blocked_runtime_parameter_consumption_missing",
+            "consumptionMode": "runtime_injected_scorecard_metadata_non_promotional",
+            "runtimeParameterInjection": False,
+            "runtimeParameterConsumption": False,
+            "runtimeParameterConsumptionStatus": "missing_runtime_parameter_consumption",
+            "runtimeConsumedPromotionEligible": False,
+            "loopAPromotionEligible": False,
+            "loopBPromotionEligible": False,
+            "missingPrerequisites": ["runtime_parameter_consumption"],
+            "reason": "scorecard metadata update is non-promotional without runtime consumption proof",
+        }
+    )
+    return gate
+
+
+def ready_runtime_parameter_injection() -> dict[str, object]:
+    return {
+        "status": "injected",
+        "runtimeParameterInjection": True,
+        "runtimeParameterConsumption": True,
+        "runtimeParameterConsumptionStatus": "consumed",
+        "policyUpdateEligible": True,
+        "candidateParameterScope": "runtime_injected",
+        "injectedVariantCount": 1,
+        "consumedVariantCount": 1,
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+    }
+
+
+def missing_consumption_runtime_parameter_injection() -> dict[str, object]:
+    return {
+        "status": "not_injected",
+        "runtimeParameterInjection": False,
+        "runtimeParameterConsumption": False,
+        "runtimeParameterConsumptionStatus": "missing_runtime_parameter_consumption",
+        "policyUpdateEligible": False,
+        "candidateParameterScope": "runtime_injected",
+        "injectedVariantCount": 0,
+        "consumedVariantCount": 0,
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+    }
+
+
+def write_policy_update_artifact(
+    root: Path,
+    artifact_path: str,
+    parameters: object,
+    promotion_gate: object | None = None,
+) -> None:
+    payload = {"parameters": parameters, "promotionGate": promotion_gate or runtime_consumed_promotion_gate()}
+    write_text(root / "remote" / artifact_path, json.dumps(payload, sort_keys=True) + "\n")
 
 
 def positive_policy_update(artifact_path: str) -> dict[str, object]:
@@ -126,6 +210,7 @@ def positive_policy_update(artifact_path: str) -> dict[str, object]:
         "killSignalWeight": 6,
         "riskPenalty": 4,
     }
+    promotion_gate = runtime_consumed_promotion_gate()
     return {
         "iterations": 1,
         "liveEffect": False,
@@ -140,8 +225,10 @@ def positive_policy_update(artifact_path: str) -> dict[str, object]:
             "killSignalWeight": 0,
             "riskPenalty": 0,
         },
+        "promotionGate": copy.deepcopy(promotion_gate),
         "nextCandidatePolicy": {
             "parameters": copy.deepcopy(updated_parameters),
+            "promotionGate": copy.deepcopy(promotion_gate),
             "liveEffect": False,
             "officialMmoWrites": False,
             "officialMmoWritesAllowed": False,
@@ -241,9 +328,12 @@ def training_report_with_ready_runtime_scorecard() -> dict[str, object]:
         "runtimeParameterInjection": {
             "status": "injected",
             "runtimeParameterInjection": True,
+            "runtimeParameterConsumption": True,
+            "runtimeParameterConsumptionStatus": "consumed",
             "policyUpdateEligible": True,
             "candidateParameterScope": "runtime_injected",
             "injectedVariantCount": 1,
+            "consumedVariantCount": 1,
             "liveEffect": False,
             "officialMmoWrites": False,
             "officialMmoWritesAllowed": False,
@@ -945,13 +1035,79 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                     },
                     top_level_safety,
                     root,
+                    runtime_parameter_injection=ready_runtime_parameter_injection(),
                 ),
+                {
+                    "policyUpdateIterations": 1,
+                    "policyUpdateArtifactPath": artifact_path,
+                    "policyUpdatePromotionGate": policy_update["promotionGate"],
+                    "policyUpdate": policy_update,
+                },
+            )
+
+    def test_verified_remote_policy_update_accepts_non_consumed_scorecard_update_as_non_promotional(self) -> None:
+        artifact_path = "runtime-artifacts/rl-training/policy-candidates/run-test-next-policy.json"
+        top_level_safety = {
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+        }
+        policy_update = positive_policy_update(artifact_path)
+        gate = non_consumed_promotion_gate()
+        policy_update["promotionGate"] = copy.deepcopy(gate)
+        next_candidate = policy_update["nextCandidatePolicy"]
+        assert isinstance(next_candidate, dict)
+        next_candidate["promotionGate"] = copy.deepcopy(gate)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            write_policy_update_artifact(root, artifact_path, policy_update["updatedParameters"], gate)
+
+            verified = runner.verified_remote_policy_update_fields(
                 {
                     "policyUpdateIterations": 1,
                     "policyUpdateArtifactPath": artifact_path,
                     "policyUpdate": policy_update,
                 },
+                top_level_safety,
+                root,
+                runtime_parameter_injection=missing_consumption_runtime_parameter_injection(),
             )
+
+        promotion_gate = verified["policyUpdatePromotionGate"]
+        assert isinstance(promotion_gate, dict)
+        self.assertFalse(promotion_gate["runtimeParameterConsumption"])
+        self.assertFalse(promotion_gate["loopAPromotionEligible"])
+        self.assertFalse(promotion_gate["loopBPromotionEligible"])
+        self.assertEqual(promotion_gate["missingPrerequisites"], ["runtime_parameter_consumption"])
+
+    def test_verified_remote_policy_update_rejects_non_consumed_scorecard_update_claiming_runtime_consumption(
+        self,
+    ) -> None:
+        artifact_path = "runtime-artifacts/rl-training/policy-candidates/run-test-next-policy.json"
+        top_level_safety = {
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+        }
+        policy_update = positive_policy_update(artifact_path)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            write_policy_update_artifact(root, artifact_path, policy_update["updatedParameters"])
+
+            with self.assertRaisesRegex(
+                runner.BatchRunError,
+                "claims runtime consumption without top-level consumption proof",
+            ):
+                runner.verified_remote_policy_update_fields(
+                    {
+                        "policyUpdateIterations": 1,
+                        "policyUpdateArtifactPath": artifact_path,
+                        "policyUpdate": policy_update,
+                    },
+                    top_level_safety,
+                    root,
+                    runtime_parameter_injection=missing_consumption_runtime_parameter_injection(),
+                )
 
     def test_verified_remote_policy_update_rejects_non_numeric_policy_parameter_values(self) -> None:
         artifact_path = "runtime-artifacts/rl-training/policy-candidates/run-test-next-policy.json"
@@ -1036,6 +1192,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                     },
                     top_level_safety,
                     root,
+                    runtime_parameter_injection=ready_runtime_parameter_injection(),
                 )
 
     def test_verified_remote_policy_update_rejects_positive_update_without_parameter_change(self) -> None:
@@ -1249,6 +1406,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                         "officialMmoWrites": False,
                         "officialMmoWritesAllowed": False,
                         "artifactCount": 1,
+                        "runtimeParameterInjection": ready_runtime_parameter_injection(),
                         "policyUpdateIterations": 1,
                         "policyUpdateArtifactPath": "runtime-artifacts/rl-training/policy-candidates/run-test-next-policy.json",
                         "policyUpdate": positive_policy_update(
@@ -1294,7 +1452,12 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         for data, expected_error in cases:
             with self.subTest(expected_error=expected_error), tempfile.TemporaryDirectory() as temp_dir:
                 with self.assertRaisesRegex(runner.BatchRunError, expected_error):
-                    runner.verified_remote_policy_update_fields(data, top_level_safety, Path(temp_dir))
+                    runner.verified_remote_policy_update_fields(
+                        data,
+                        top_level_safety,
+                        Path(temp_dir),
+                        runtime_parameter_injection=ready_runtime_parameter_injection(),
+                    )
 
     def test_verify_remote_training_report_records_safety_flags_in_summary(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -1325,9 +1488,12 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                             "type": "screeps-rl-runtime-parameter-injection",
                             "status": "injected",
                             "runtimeParameterInjection": True,
+                            "runtimeParameterConsumption": True,
+                            "runtimeParameterConsumptionStatus": "consumed",
                             "policyUpdateEligible": True,
                             "candidateParameterScope": "runtime_injected",
                             "injectedVariantCount": 1,
+                            "consumedVariantCount": 1,
                             "liveEffect": False,
                             "officialMmoWrites": False,
                             "officialMmoWritesAllowed": False,


### PR DESCRIPTION
## Summary
- adds machine-readable runtime-parameter consumption proof fields for scorecarded RL policy updates
- surfaces the proof through RL dashboard/live-dashboard summaries and Tencent batch controller summaries
- adds regression coverage for consumption evidence, dashboard propagation, and Tencent summary preservation

## Verification
- `git diff --check HEAD~1..HEAD`
- `python3 -m py_compile scripts/screeps_rl_dashboard.py scripts/screeps_rl_live_dashboard.py scripts/screeps_rl_training_runner.py scripts/screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts/test_screeps_rl_dashboard.py scripts/test_screeps_rl_live_dashboard.py scripts/test_screeps_rl_training_runner.py scripts/test_screeps_tencent_batch_rl_runner.py` — 226 tests OK

## Safety
- offline/RL evidence only; no official MMO learned-policy writes
- no production Screeps bundle changes

Refs #1301
Refs #879
