### PR TITLE
fix(rl): require fresh E1 gate card inputs

### DIFF
--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -2562,12 +2562,11 @@ def main(
         dataset_run_id = args.dataset_run_id
         source_gate = None
         dataset_gate_roots = resolve_dataset_gate_roots(args.dataset_gate_root, repo)
-        dataset_gate_reference_time = args.created_at or utc_now_iso()
-        dataset_gate_max_age_hours = (
-            E1_GATE_FRESHNESS_HOURS
-            if args.source_gate_id is None and (args.from_latest_accepted_dataset or args.loop_a_local_fallback)
-            else None
+        requires_fresh_automatic_gate = args.source_gate_id is None and (
+            args.from_latest_accepted_dataset or args.loop_a_local_fallback
         )
+        dataset_gate_reference_time = utc_now_iso() if requires_fresh_automatic_gate else None
+        dataset_gate_max_age_hours = E1_GATE_FRESHNESS_HOURS if requires_fresh_automatic_gate else None
         if args.from_latest_accepted_dataset and dataset_run_id is not None:
             raise CardValidationError("--from-latest-accepted-dataset cannot be combined with --dataset-run-id")
         if args.source_gate_id is not None:

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -20,6 +20,7 @@ TRAINING_APPROACHES = ("bandit", "evolutionary", "policy_gradient")
 DATASET_RUN_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 E1_POSTMERGE_DATASET_GATE_ID_RE = re.compile(r"^gate-\d{8}T\d{6}Z-postmerge\d+$")
 E1_CURRENT_DATASET_GATE_ID_RE = re.compile(r"^gate-\d{8}T\d{6}Z$")
+E1_HASH_DATASET_GATE_ID_RE = re.compile(r"^rl-gate-[0-9a-f]{12}$")
 COMMIT_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
 ISO_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
 STRATEGY_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
@@ -77,6 +78,7 @@ LOOP_A_LOCAL_FALLBACK_REPETITIONS = 5
 LOOP_A_LOCAL_FALLBACK_WORKERS = 5
 DEGRADED_E1_GATE_MIN_ACCEPTANCE_RATE = 0.95
 E1_CURRENT_GATE_FULL_ACCEPTANCE_ABS_TOL = 1e-9
+E1_GATE_FRESHNESS_HOURS = 36.0
 
 JsonObject = dict[str, Any]
 
@@ -1362,40 +1364,46 @@ def loop_a_selection_summary(path: Path, card: JsonObject, consumed_card_ids: se
     return summary
 
 
-def select_accepted_dataset_gate(gate_root: Path | Sequence[Path], gate_id: str | None = None) -> JsonObject:
+def select_accepted_dataset_gate(
+    gate_root: Path | Sequence[Path],
+    gate_id: str | None = None,
+    *,
+    reference_time: str | datetime | None = None,
+    max_age_hours: float | None = None,
+) -> JsonObject:
     if gate_id is not None:
         validate_gate_id(gate_id)
-    candidates: list[tuple[int, str, float, str, str, Path, JsonObject]] = []
+    candidates: list[tuple[float, str, int, str, str, Path, JsonObject]] = []
+    stale_accepted: list[JsonObject] = []
     roots = dataset_gate_roots(gate_root)
     existing_roots = [root for root in roots if root.exists()]
     if not existing_roots:
         raise CardValidationError(
             "dataset gate root does not exist: " + ", ".join(str(root) for root in roots)
         )
-    for path in iter_canonical_dataset_gate_report_paths(existing_roots):
-        try:
-            payload = load_json(path)
-        except CardValidationError:
+    reference_dt = normalize_reference_time(reference_time)
+    reports = scan_dataset_gate_reports(existing_roots, gate_id=gate_id, reference_time=reference_dt)
+    for report in reports:
+        if not report.get("acceptable"):
             continue
-        if not is_acceptable_dataset_gate_report(payload, path):
-            continue
+        path = report["path"]
+        payload = report["payload"]
         try:
-            selected_gate_id = accepted_dataset_gate_id(payload, path)
-            if gate_id is not None and selected_gate_id != gate_id:
-                continue
-            run_id = accepted_dataset_run_id(payload)
-            if run_id is None:
-                continue
-            created_at = accepted_dataset_created_at(payload)
+            selected_gate_id = str(report["gate_id"])
+            run_id = str(report["dataset_run_id"])
+            created_at = report.get("created_at")
             quality_rank = dataset_gate_quality_rank(payload, path)
-            mtime = path.stat().st_mtime
-        except (CardValidationError, OSError):
+            mtime = float(report.get("mtime") or 0.0)
+        except (KeyError, TypeError, ValueError):
+            continue
+        if max_age_hours is not None and dataset_gate_report_is_stale(report, max_age_hours):
+            stale_accepted.append(report)
             continue
         candidates.append(
             (
-                quality_rank,
-                created_at or "",
                 mtime,
+                str(created_at or ""),
+                quality_rank,
                 selected_gate_id,
                 run_id,
                 path,
@@ -1412,17 +1420,233 @@ def select_accepted_dataset_gate(gate_root: Path | Sequence[Path], gate_id: str 
             )
         )
     if not candidates:
-        if gate_id is not None:
-            raise CardValidationError(
-                f"no accepted dataset gate {gate_id} with datasetRunId found under "
-                + ", ".join(str(root) for root in roots)
-            )
-        raise CardValidationError(
-            "no accepted dataset gate with datasetRunId found under "
-            + ", ".join(str(root) for root in roots)
-        )
+        raise CardValidationError(dataset_gate_selection_error(roots, reports, stale_accepted, gate_id, max_age_hours))
     candidates.sort(key=lambda item: (item[0], item[1], item[2], item[3], str(item[5])), reverse=True)
     return candidates[0][6]
+
+
+def normalize_reference_time(value: str | datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc) if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+    return parse_iso_utc_timestamp(value)
+
+
+def parse_iso_utc_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or ISO_TIMESTAMP_RE.fullmatch(value) is None:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def scan_dataset_gate_reports(
+    gate_roots: Sequence[Path],
+    *,
+    gate_id: str | None = None,
+    reference_time: datetime | None = None,
+) -> list[JsonObject]:
+    reports: list[JsonObject] = []
+    for path in iter_canonical_dataset_gate_report_paths(gate_roots):
+        try:
+            payload = load_json(path)
+        except CardValidationError:
+            continue
+        info = dataset_gate_report_info(payload, path, reference_time=reference_time)
+        if gate_id is not None and info.get("gate_id") != gate_id:
+            continue
+        reports.append(info)
+    return reports
+
+
+def dataset_gate_report_info(payload: Any, path: Path, *, reference_time: datetime | None = None) -> JsonObject:
+    payload_dict: JsonObject = payload if isinstance(payload, dict) else {}
+    gate_id = dataset_gate_id(payload_dict) or path.parent.name
+    run_id = accepted_dataset_run_id_or_none(payload_dict)
+    created_at = accepted_dataset_created_at(payload_dict)
+    created_dt = parse_iso_utc_timestamp(created_at)
+    mtime = dataset_gate_report_mtime(path)
+    mtime_dt = datetime.fromtimestamp(mtime, tz=timezone.utc) if mtime is not None else None
+    gate_dt = created_dt or mtime_dt
+    age_hours = None
+    if reference_time is not None and gate_dt is not None:
+        age_hours = (reference_time - gate_dt).total_seconds() / 3600
+    sample_count = dataset_gate_sample_count(payload_dict)
+    acceptance_rate = dataset_gate_acceptance_rate(payload_dict)
+    acceptable = False
+    if isinstance(payload, dict):
+        try:
+            acceptable = is_acceptable_dataset_gate_report(payload, path) and run_id is not None
+        except CardValidationError:
+            acceptable = False
+    usable = (
+        isinstance(payload, dict)
+        and payload.get("type") == SOURCE_GATE_TYPE
+        and run_id is not None
+        and isinstance(sample_count, int)
+        and sample_count > 0
+    )
+    return {
+        "path": path,
+        "payload": payload_dict,
+        "gate_id": gate_id,
+        "dataset_run_id": run_id,
+        "created_at": created_at,
+        "mtime": mtime,
+        "mtime_at": display_datetime(mtime_dt),
+        "gate_time": display_datetime(gate_dt),
+        "age_hours": age_hours,
+        "sample_count": sample_count,
+        "acceptance_rate": acceptance_rate,
+        "acceptable": acceptable,
+        "usable": usable,
+        "classification": dataset_gate_report_classification(payload_dict, path, acceptable=acceptable),
+    }
+
+
+def dataset_gate_report_mtime(path: Path) -> float | None:
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return None
+
+
+def display_datetime(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def dataset_gate_report_is_stale(report: JsonObject, max_age_hours: float) -> bool:
+    age = report.get("age_hours")
+    return is_finite_number(age) and float(age) > max_age_hours
+
+
+def dataset_gate_report_classification(payload: JsonObject, path: Path, *, acceptable: bool) -> str:
+    if payload.get("type") != SOURCE_GATE_TYPE:
+        return "not_dataset_gate_report"
+    sample_count = dataset_gate_sample_count(payload)
+    if sample_count == 0:
+        return "zero_sample_gate"
+    if sample_count is None:
+        return "missing_sample_count"
+    if accepted_dataset_run_id_or_none(payload) is None:
+        return "missing_dataset_run_id"
+    if acceptable:
+        return "accepted"
+    acceptance_rate = dataset_gate_acceptance_rate(payload)
+    if acceptance_rate is not None and acceptance_rate < DEGRADED_E1_GATE_MIN_ACCEPTANCE_RATE:
+        return "acceptance_below_threshold"
+    dataset_status = dataset_gate_status(payload)
+    if dataset_status is not None and dataset_status != "pass":
+        return f"dataset_gate_{dataset_status}"
+    if not gate_data_current_report_source(payload, path) and not is_e1_postmerge_dataset_gate_report(payload, path):
+        return "not_current_e1_gate_data"
+    return "incomplete_or_unaccepted_gate"
+
+
+def accepted_dataset_run_id_or_none(payload: JsonObject) -> str | None:
+    try:
+        return accepted_dataset_run_id(payload)
+    except CardValidationError:
+        return None
+
+
+def dataset_gate_selection_error(
+    roots: Sequence[Path],
+    reports: Sequence[JsonObject],
+    stale_accepted: Sequence[JsonObject],
+    gate_id: str | None,
+    max_age_hours: float | None,
+) -> str:
+    if gate_id is not None:
+        prefix = f"no accepted dataset gate {gate_id} with datasetRunId found under "
+    elif max_age_hours is not None:
+        prefix = "no accepted dataset gate with datasetRunId found under "
+    else:
+        prefix = "no accepted dataset gate with datasetRunId found under "
+    details = [prefix + ", ".join(str(root) for root in roots)]
+    if max_age_hours is not None:
+        details.append(f"fresh gate required within {max_age_hours:g}h")
+    newest = newest_gate_report_by_mtime(reports)
+    newest_usable = newest_usable_gate_report(reports)
+    newest_stale = newest_gate_report_by_mtime(stale_accepted)
+    if newest is not None:
+        details.append("newest gate by mtime " + format_gate_report_diagnostic(newest))
+    if newest_usable is not None:
+        usable_text = "newest nonzero gate " + format_gate_report_diagnostic(newest_usable)
+        if max_age_hours is not None and dataset_gate_report_is_stale(newest_usable, max_age_hours):
+            usable_text += f" is stale (age {format_hours(newest_usable.get('age_hours'))} > {max_age_hours:g}h)"
+        details.append(usable_text)
+    if newest_stale is not None:
+        details.append(
+            "newest accepted gate is stale "
+            + format_gate_report_diagnostic(newest_stale)
+            + f" (age {format_hours(newest_stale.get('age_hours'))} > {max_age_hours:g}h)"
+        )
+    if max_age_hours is not None:
+        details.append(
+            "regenerate the E1 gate so the newest gate has nonzero samples and "
+            f">={format_percent(DEGRADED_E1_GATE_MIN_ACCEPTANCE_RATE)} quality acceptance within {max_age_hours:g}h"
+        )
+    return "; ".join(details)
+
+
+def newest_gate_report_by_mtime(reports: Sequence[JsonObject]) -> JsonObject | None:
+    candidates = [report for report in reports if is_finite_number(report.get("mtime"))]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda report: float(report.get("mtime") or 0.0))
+
+
+def newest_usable_gate_report(reports: Sequence[JsonObject]) -> JsonObject | None:
+    usable = [report for report in reports if report.get("usable") is True and is_finite_number(report.get("mtime"))]
+    if not usable:
+        return None
+    return max(usable, key=lambda report: float(report.get("mtime") or 0.0))
+
+
+def format_gate_report_diagnostic(report: JsonObject) -> str:
+    parts = [
+        str(report.get("gate_id") or "unknown-gate"),
+        f"classification={report.get('classification')}",
+        f"samples={format_optional_number(report.get('sample_count'))}",
+    ]
+    acceptance = report.get("acceptance_rate")
+    if acceptance is not None:
+        parts.append(f"acceptance={format_percent(acceptance)}")
+        if is_finite_number(acceptance) and float(acceptance) < DEGRADED_E1_GATE_MIN_ACCEPTANCE_RATE:
+            parts.append(f"below {format_percent(DEGRADED_E1_GATE_MIN_ACCEPTANCE_RATE)}")
+    if report.get("gate_time") is not None:
+        parts.append(f"gateTime={report['gate_time']}")
+    if report.get("mtime_at") is not None:
+        parts.append(f"mtime={report['mtime_at']}")
+    path = report.get("path")
+    if isinstance(path, Path):
+        parts.append(f"path={path}")
+    return "(" + ", ".join(parts) + ")"
+
+
+def format_optional_number(value: Any) -> str:
+    if value is None:
+        return "unknown"
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def format_hours(value: Any) -> str:
+    if not is_finite_number(value):
+        return "unknown"
+    return f"{float(value):.1f}h"
+
+
+def format_percent(value: Any) -> str:
+    if not is_finite_number(value):
+        return "unknown"
+    return f"{float(value) * 100:.1f}%"
 
 
 def dataset_gate_roots(gate_root: Path | Sequence[Path]) -> list[Path]:
@@ -1485,7 +1709,7 @@ def is_acceptable_dataset_gate_report(payload: Any, path: Path | None = None) ->
         if payload.get("ok") is True:
             return True
         return is_degraded_e1_gate_acceptable(payload, path)
-    if is_e1_current_dataset_gate_report(payload, path):
+    if is_e1_current_dataset_gate_report(payload, path) or is_canonical_e1_current_gate_data_report(payload, path):
         if is_fully_accepted_e1_current_gate(payload):
             return True
         return is_degraded_e1_gate_acceptable(payload, path)
@@ -1580,8 +1804,20 @@ def is_degraded_e1_gate_acceptable(payload: JsonObject, path: Path | None = None
 
 
 def is_canonical_e1_current_gate_data_report(payload: JsonObject, path: Path | None = None) -> bool:
-    if not is_e1_current_dataset_gate_report(payload, path):
+    gate_id = dataset_gate_id(payload)
+    if gate_id is None:
         return False
+    if (
+        E1_CURRENT_DATASET_GATE_ID_RE.fullmatch(gate_id) is None
+        and E1_HASH_DATASET_GATE_ID_RE.fullmatch(gate_id) is None
+    ):
+        return False
+    if not gate_report_path_matches_payload(payload, path):
+        return False
+    return gate_data_current_report_source(payload, path)
+
+
+def gate_data_current_report_source(payload: JsonObject, path: Path | None = None) -> bool:
     if path is not None and "gate-data" in path.parts:
         return True
     outputs = payload.get("outputs")
@@ -2319,10 +2555,21 @@ def main(
         dataset_run_id = args.dataset_run_id
         source_gate = None
         dataset_gate_roots = resolve_dataset_gate_roots(args.dataset_gate_root, repo)
+        dataset_gate_reference_time = args.created_at or utc_now_iso()
+        dataset_gate_max_age_hours = (
+            E1_GATE_FRESHNESS_HOURS
+            if args.source_gate_id is not None or args.from_latest_accepted_dataset or args.loop_a_local_fallback
+            else None
+        )
         if args.from_latest_accepted_dataset and dataset_run_id is not None:
             raise CardValidationError("--from-latest-accepted-dataset cannot be combined with --dataset-run-id")
         if args.source_gate_id is not None:
-            source_gate = select_accepted_dataset_gate(dataset_gate_roots, args.source_gate_id)
+            source_gate = select_accepted_dataset_gate(
+                dataset_gate_roots,
+                args.source_gate_id,
+                reference_time=dataset_gate_reference_time,
+                max_age_hours=dataset_gate_max_age_hours,
+            )
             source_dataset_run_id = str(source_gate["dataset_run_id"])
             if dataset_run_id is not None and dataset_run_id != source_dataset_run_id:
                 raise CardValidationError("--dataset-run-id must match --source-gate-id dataset_run_id")
@@ -2333,7 +2580,11 @@ def main(
                     "--from-latest-accepted-dataset or --loop-a-local-fallback cannot be combined "
                     "with --dataset-run-id"
                 )
-            source_gate = select_accepted_dataset_gate(dataset_gate_roots)
+            source_gate = select_accepted_dataset_gate(
+                dataset_gate_roots,
+                reference_time=dataset_gate_reference_time,
+                max_age_hours=dataset_gate_max_age_hours,
+            )
             dataset_run_id = str(source_gate["dataset_run_id"])
         if dataset_run_id is None:
             if not args.dry_run:

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -2558,7 +2558,7 @@ def main(
         dataset_gate_reference_time = args.created_at or utc_now_iso()
         dataset_gate_max_age_hours = (
             E1_GATE_FRESHNESS_HOURS
-            if args.source_gate_id is not None or args.from_latest_accepted_dataset or args.loop_a_local_fallback
+            if args.source_gate_id is None and (args.from_latest_accepted_dataset or args.loop_a_local_fallback)
             else None
         )
         if args.from_latest_accepted_dataset and dataset_run_id is not None:

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -1272,10 +1272,61 @@ class RlExperimentCardTest(unittest.TestCase):
         error = stderr.getvalue()
         self.assertEqual(exit_code, 2)
         self.assertFalse(output_path.exists())
+        self.assertIn("fresh gate required within 36h", error)
         self.assertIn("newest accepted gate is stale", error)
         self.assertIn(gate_id, error)
         self.assertIn("classification=accepted", error)
         self.assertIn("age 62.0h > 36h", error)
+
+    def test_cli_accepts_explicit_stale_source_gate_for_replay(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            gate_root = root / "gates"
+            card_dir = root / "cards"
+            gate_id = "gate-20260518T025000Z-postmerge1188"
+            dataset_run_id = "rl-explicit-stale-replay"
+            gate_path = gate_root / gate_id / "gate_report.json"
+            gate_path.parent.mkdir(parents=True)
+            gate_path.write_text(
+                json.dumps(
+                    {
+                        "type": card_helper.SOURCE_GATE_TYPE,
+                        "ok": True,
+                        "gateId": gate_id,
+                        "createdAt": "2026-05-19T00:00:00Z",
+                        "dataset": {"ok": True, "runId": dataset_run_id, "sampleCount": 200},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            stdout = io.StringIO()
+
+            exit_code = card_helper.main(
+                [
+                    "--source-gate-id",
+                    gate_id,
+                    "--dataset-gate-root",
+                    str(gate_root),
+                    "--code-commit",
+                    "8" * 40,
+                    "--created-at",
+                    "2026-05-21T14:00:00Z",
+                    "--output-dir",
+                    str(card_dir),
+                ],
+                stdout=stdout,
+                stderr=io.StringIO(),
+                repo_root=REPO_ROOT,
+            )
+            summary = json.loads(stdout.getvalue())
+            generated = json.loads(Path(summary["path"]).read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(summary["dataset_run_id"], dataset_run_id)
+        self.assertEqual(summary["source_gate"]["gate_id"], gate_id)
+        self.assertEqual(summary["source_gate"]["dataset_run_id"], dataset_run_id)
+        self.assertEqual(generated["dataset_run_id"], dataset_run_id)
+        self.assertEqual(generated["source_gate"]["gate_id"], gate_id)
 
     def test_loop_a_local_fallback_accepts_e1_gate_by_dataset_run_id_outside_gate_data(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -1069,6 +1069,214 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(summary["source_gate"]["gate_id"], gate_id)
         self.assertEqual(summary["source_gate"]["dataset_run_id"], dataset_run_id)
 
+    def test_loop_a_local_fallback_accepts_fresh_hash_gate_data_when_complete(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runtime_root = root / "runtime-artifacts"
+            gate_id = "rl-gate-fb6d68b8c4d8"
+            dataset_run_id = "rl-fresh-hash-gate"
+            gate_path = runtime_root / "rl-control-loop" / "gate-data" / gate_id / "gate_report.json"
+            output_path = runtime_root / "rl-experiment-cards" / "experiment_card.json"
+            gate_path.parent.mkdir(parents=True)
+            gate_path.write_text(
+                json.dumps(
+                    {
+                        "type": card_helper.SOURCE_GATE_TYPE,
+                        "ok": True,
+                        "gateId": gate_id,
+                        "createdAt": "2026-05-21T13:00:00Z",
+                        "dataset": {"ok": True, "runId": dataset_run_id, "sampleCount": 200},
+                        "datasetGate": {"status": "pass", "sampleCount": 200},
+                        "quality_checks": {
+                            "status": "pass",
+                            "samples_accepted": 200,
+                            "samples_rejected": 0,
+                            "acceptance_rate": 1.0,
+                        },
+                        "shadowEvaluation": {"status": "pass", "ok": True},
+                        "outputs": {"gateDir": f"runtime-artifacts/rl-control-loop/gate-data/{gate_id}"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            selected = card_helper.select_accepted_dataset_gate(
+                runtime_root,
+                reference_time="2026-05-21T14:00:00Z",
+                max_age_hours=card_helper.E1_GATE_FRESHNESS_HOURS,
+            )
+            stdout = io.StringIO()
+            exit_code = card_helper.main(
+                [
+                    "--loop-a-local-fallback",
+                    "--dataset-gate-root",
+                    str(runtime_root),
+                    "--code-commit",
+                    "8" * 40,
+                    "--created-at",
+                    "2026-05-21T14:00:00Z",
+                    "--output",
+                    str(output_path),
+                ],
+                stdout=stdout,
+                stderr=io.StringIO(),
+                repo_root=REPO_ROOT,
+            )
+            summary = json.loads(stdout.getvalue())
+
+        self.assertEqual(selected["gate_id"], gate_id)
+        self.assertEqual(selected["dataset_run_id"], dataset_run_id)
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(summary["source_gate"]["gate_id"], gate_id)
+        self.assertEqual(summary["source_gate"]["dataset_run_id"], dataset_run_id)
+
+    def test_loop_a_local_fallback_reports_zero_sample_newest_gate_and_stale_nonzero_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runtime_root = root / "runtime-artifacts"
+            stale_gate = runtime_root / "rl-dataset-gates" / "rl-gate-db16ca9c3de7" / "gate_report.json"
+            zero_gate_id = "rl-gate-fb6d68b8c4d8"
+            zero_gate = runtime_root / "rl-control-loop" / "gate-data" / zero_gate_id / "gate_report.json"
+            output_path = runtime_root / "rl-experiment-cards" / "experiment_card.json"
+            stale_gate.parent.mkdir(parents=True)
+            zero_gate.parent.mkdir(parents=True)
+            stale_gate.write_text(
+                json.dumps(
+                    {
+                        "type": card_helper.SOURCE_GATE_TYPE,
+                        "ok": False,
+                        "gateId": "rl-gate-db16ca9c3de7",
+                        "createdAt": "2026-05-11T14:23:09Z",
+                        "dataset": {"ok": True, "runId": "rl-stale-nonzero", "sampleCount": 200},
+                        "datasetGate": {"status": "pass", "sampleCount": 200},
+                        "quality_checks": {
+                            "status": "fail",
+                            "samples_accepted": 126,
+                            "samples_rejected": 74,
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            zero_gate.write_text(
+                json.dumps(
+                    {
+                        "type": card_helper.SOURCE_GATE_TYPE,
+                        "ok": False,
+                        "gateId": zero_gate_id,
+                        "createdAt": "2026-05-21T13:53:08Z",
+                        "dataset": {"ok": False, "runId": "rl-zero-sample", "sampleCount": 0},
+                        "datasetGate": {"status": "fail", "sampleCount": 0},
+                        "quality_checks": {
+                            "status": "fail",
+                            "samples_accepted": 0,
+                            "samples_rejected": 0,
+                            "acceptance_rate": None,
+                        },
+                        "blockingReasons": [
+                            {
+                                "gate": "dataset",
+                                "name": "minimum_samples",
+                                "status": "fail",
+                                "actual": 0,
+                                "required": 1,
+                            }
+                        ],
+                        "outputs": {"gateDir": f"runtime-artifacts/rl-control-loop/gate-data/{zero_gate_id}"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            os.utime(stale_gate, (1_779_000_000, 1_779_000_000))
+            os.utime(zero_gate, (1_779_100_000, 1_779_100_000))
+            stderr = io.StringIO()
+
+            exit_code = card_helper.main(
+                [
+                    "--loop-a-local-fallback",
+                    "--dataset-gate-root",
+                    str(runtime_root),
+                    "--code-commit",
+                    "8" * 40,
+                    "--created-at",
+                    "2026-05-21T14:10:00Z",
+                    "--output",
+                    str(output_path),
+                ],
+                stdout=io.StringIO(),
+                stderr=stderr,
+                repo_root=REPO_ROOT,
+            )
+
+        error = stderr.getvalue()
+        self.assertEqual(exit_code, 2)
+        self.assertFalse(output_path.exists())
+        self.assertIn("newest gate by mtime", error)
+        self.assertIn(zero_gate_id, error)
+        self.assertIn("classification=zero_sample_gate", error)
+        self.assertIn("newest nonzero gate", error)
+        self.assertIn("rl-gate-db16ca9c3de7", error)
+        self.assertIn("classification=acceptance_below_threshold", error)
+        self.assertIn("acceptance=63.0%", error)
+        self.assertIn("below 95.0%", error)
+        self.assertIn("is stale", error)
+
+    def test_loop_a_local_fallback_blocks_stale_accepted_gate_without_fresh_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runtime_root = root / "runtime-artifacts"
+            gate_id = "rl-gate-db16ca9c3de7"
+            gate_path = runtime_root / "rl-control-loop" / "gate-data" / gate_id / "gate_report.json"
+            output_path = runtime_root / "rl-experiment-cards" / "experiment_card.json"
+            gate_path.parent.mkdir(parents=True)
+            gate_path.write_text(
+                json.dumps(
+                    {
+                        "type": card_helper.SOURCE_GATE_TYPE,
+                        "ok": True,
+                        "gateId": gate_id,
+                        "createdAt": "2026-05-19T00:00:00Z",
+                        "dataset": {"ok": True, "runId": "rl-stale-accepted", "sampleCount": 200},
+                        "datasetGate": {"status": "pass", "sampleCount": 200},
+                        "quality_checks": {
+                            "status": "pass",
+                            "samples_accepted": 200,
+                            "samples_rejected": 0,
+                            "acceptance_rate": 1.0,
+                        },
+                        "shadowEvaluation": {"status": "pass", "ok": True},
+                        "outputs": {"gateDir": f"runtime-artifacts/rl-control-loop/gate-data/{gate_id}"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            stderr = io.StringIO()
+
+            exit_code = card_helper.main(
+                [
+                    "--loop-a-local-fallback",
+                    "--dataset-gate-root",
+                    str(runtime_root),
+                    "--code-commit",
+                    "8" * 40,
+                    "--created-at",
+                    "2026-05-21T14:00:00Z",
+                    "--output",
+                    str(output_path),
+                ],
+                stdout=io.StringIO(),
+                stderr=stderr,
+                repo_root=REPO_ROOT,
+            )
+
+        error = stderr.getvalue()
+        self.assertEqual(exit_code, 2)
+        self.assertFalse(output_path.exists())
+        self.assertIn("newest accepted gate is stale", error)
+        self.assertIn(gate_id, error)
+        self.assertIn("classification=accepted", error)
+        self.assertIn("age 62.0h > 36h", error)
+
     def test_loop_a_local_fallback_accepts_e1_gate_by_dataset_run_id_outside_gate_data(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -414,23 +414,24 @@ class RlExperimentCardTest(unittest.TestCase):
             )
             stdout = io.StringIO()
 
-            exit_code = card_helper.main(
-                [
-                    "--loop-a-policy-gradient-supply",
-                    "--from-latest-accepted-dataset",
-                    "--dataset-gate-root",
-                    str(gate_root),
-                    "--code-commit",
-                    "6" * 40,
-                    "--created-at",
-                    "2026-05-17T02:05:00Z",
-                    "--output-dir",
-                    str(card_dir),
-                ],
-                stdout=stdout,
-                stderr=io.StringIO(),
-                repo_root=REPO_ROOT,
-            )
+            with mock.patch.object(card_helper, "utc_now_iso", return_value="2026-05-17T03:00:00Z"):
+                exit_code = card_helper.main(
+                    [
+                        "--loop-a-policy-gradient-supply",
+                        "--from-latest-accepted-dataset",
+                        "--dataset-gate-root",
+                        str(gate_root),
+                        "--code-commit",
+                        "6" * 40,
+                        "--created-at",
+                        "2026-05-17T02:05:00Z",
+                        "--output-dir",
+                        str(card_dir),
+                    ],
+                    stdout=stdout,
+                    stderr=io.StringIO(),
+                    repo_root=REPO_ROOT,
+                )
             summary = json.loads(stdout.getvalue())
             generated = json.loads(Path(summary["path"]).read_text(encoding="utf-8"))
 
@@ -925,22 +926,23 @@ class RlExperimentCardTest(unittest.TestCase):
 
             selected = card_helper.select_accepted_dataset_gate(runtime_root)
             stdout = io.StringIO()
-            exit_code = card_helper.main(
-                [
-                    "--loop-a-local-fallback",
-                    "--dataset-gate-root",
-                    str(runtime_root),
-                    "--code-commit",
-                    "8" * 40,
-                    "--created-at",
-                    "2026-05-19T08:20:00Z",
-                    "--output",
-                    str(output_path),
-                ],
-                stdout=stdout,
-                stderr=io.StringIO(),
-                repo_root=REPO_ROOT,
-            )
+            with mock.patch.object(card_helper, "utc_now_iso", return_value="2026-05-19T08:20:00Z"):
+                exit_code = card_helper.main(
+                    [
+                        "--loop-a-local-fallback",
+                        "--dataset-gate-root",
+                        str(runtime_root),
+                        "--code-commit",
+                        "8" * 40,
+                        "--created-at",
+                        "2026-05-19T08:20:00Z",
+                        "--output",
+                        str(output_path),
+                    ],
+                    stdout=stdout,
+                    stderr=io.StringIO(),
+                    repo_root=REPO_ROOT,
+                )
             summary = json.loads(stdout.getvalue())
             generated = json.loads(output_path.read_text(encoding="utf-8"))
             selected_stdout = io.StringIO()
@@ -1041,22 +1043,23 @@ class RlExperimentCardTest(unittest.TestCase):
 
             selected = card_helper.select_accepted_dataset_gate(runtime_root)
             stdout = io.StringIO()
-            exit_code = card_helper.main(
-                [
-                    "--loop-a-local-fallback",
-                    "--dataset-gate-root",
-                    str(runtime_root),
-                    "--code-commit",
-                    "8" * 40,
-                    "--created-at",
-                    "2026-05-19T08:20:00Z",
-                    "--output",
-                    str(output_path),
-                ],
-                stdout=stdout,
-                stderr=io.StringIO(),
-                repo_root=REPO_ROOT,
-            )
+            with mock.patch.object(card_helper, "utc_now_iso", return_value="2026-05-19T08:20:00Z"):
+                exit_code = card_helper.main(
+                    [
+                        "--loop-a-local-fallback",
+                        "--dataset-gate-root",
+                        str(runtime_root),
+                        "--code-commit",
+                        "8" * 40,
+                        "--created-at",
+                        "2026-05-19T08:20:00Z",
+                        "--output",
+                        str(output_path),
+                    ],
+                    stdout=stdout,
+                    stderr=io.StringIO(),
+                    repo_root=REPO_ROOT,
+                )
             summary = json.loads(stdout.getvalue())
 
         self.assertTrue(card_helper.is_degraded_e1_gate_acceptable(fresh_gate_payload, gate_data_gate))
@@ -1106,22 +1109,23 @@ class RlExperimentCardTest(unittest.TestCase):
                 max_age_hours=card_helper.E1_GATE_FRESHNESS_HOURS,
             )
             stdout = io.StringIO()
-            exit_code = card_helper.main(
-                [
-                    "--loop-a-local-fallback",
-                    "--dataset-gate-root",
-                    str(runtime_root),
-                    "--code-commit",
-                    "8" * 40,
-                    "--created-at",
-                    "2026-05-21T14:00:00Z",
-                    "--output",
-                    str(output_path),
-                ],
-                stdout=stdout,
-                stderr=io.StringIO(),
-                repo_root=REPO_ROOT,
-            )
+            with mock.patch.object(card_helper, "utc_now_iso", return_value="2026-05-21T14:00:00Z"):
+                exit_code = card_helper.main(
+                    [
+                        "--loop-a-local-fallback",
+                        "--dataset-gate-root",
+                        str(runtime_root),
+                        "--code-commit",
+                        "8" * 40,
+                        "--created-at",
+                        "2026-05-21T14:00:00Z",
+                        "--output",
+                        str(output_path),
+                    ],
+                    stdout=stdout,
+                    stderr=io.StringIO(),
+                    repo_root=REPO_ROOT,
+                )
             summary = json.loads(stdout.getvalue())
 
         self.assertEqual(selected["gate_id"], gate_id)
@@ -1304,22 +1308,23 @@ class RlExperimentCardTest(unittest.TestCase):
             os.utime(zero_gate, (1_779_100_000, 1_779_100_000))
             stderr = io.StringIO()
 
-            exit_code = card_helper.main(
-                [
-                    "--loop-a-local-fallback",
-                    "--dataset-gate-root",
-                    str(runtime_root),
-                    "--code-commit",
-                    "8" * 40,
-                    "--created-at",
-                    "2026-05-21T14:10:00Z",
-                    "--output",
-                    str(output_path),
-                ],
-                stdout=io.StringIO(),
-                stderr=stderr,
-                repo_root=REPO_ROOT,
-            )
+            with mock.patch.object(card_helper, "utc_now_iso", return_value="2026-05-21T14:10:00Z"):
+                exit_code = card_helper.main(
+                    [
+                        "--loop-a-local-fallback",
+                        "--dataset-gate-root",
+                        str(runtime_root),
+                        "--code-commit",
+                        "8" * 40,
+                        "--created-at",
+                        "2026-05-21T14:10:00Z",
+                        "--output",
+                        str(output_path),
+                    ],
+                    stdout=io.StringIO(),
+                    stderr=stderr,
+                    repo_root=REPO_ROOT,
+                )
 
         error = stderr.getvalue()
         self.assertEqual(exit_code, 2)
@@ -1334,7 +1339,7 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertIn("below 95.0%", error)
         self.assertIn("is stale", error)
 
-    def test_loop_a_local_fallback_blocks_stale_accepted_gate_without_fresh_gate(self) -> None:
+    def test_loop_a_local_fallback_blocks_stale_accepted_gate_despite_backdated_created_at(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             runtime_root = root / "runtime-artifacts"
@@ -1365,22 +1370,23 @@ class RlExperimentCardTest(unittest.TestCase):
             )
             stderr = io.StringIO()
 
-            exit_code = card_helper.main(
-                [
-                    "--loop-a-local-fallback",
-                    "--dataset-gate-root",
-                    str(runtime_root),
-                    "--code-commit",
-                    "8" * 40,
-                    "--created-at",
-                    "2026-05-21T14:00:00Z",
-                    "--output",
-                    str(output_path),
-                ],
-                stdout=io.StringIO(),
-                stderr=stderr,
-                repo_root=REPO_ROOT,
-            )
+            with mock.patch.object(card_helper, "utc_now_iso", return_value="2026-05-21T14:00:00Z"):
+                exit_code = card_helper.main(
+                    [
+                        "--loop-a-local-fallback",
+                        "--dataset-gate-root",
+                        str(runtime_root),
+                        "--code-commit",
+                        "8" * 40,
+                        "--created-at",
+                        "2026-05-19T01:00:00Z",
+                        "--output",
+                        str(output_path),
+                    ],
+                    stdout=io.StringIO(),
+                    stderr=stderr,
+                    repo_root=REPO_ROOT,
+                )
 
         error = stderr.getvalue()
         self.assertEqual(exit_code, 2)
@@ -1389,6 +1395,50 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertIn("newest accepted gate is stale", error)
         self.assertIn(gate_id, error)
         self.assertIn("classification=accepted", error)
+        self.assertIn("age 62.0h > 36h", error)
+
+    def test_from_latest_accepted_dataset_blocks_stale_gate_despite_backdated_created_at(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            gate_root = root / "gates"
+            gate_id = "gate-20260519T000000Z-postmerge1188"
+            gate_path = gate_root / gate_id / "gate_report.json"
+            gate_path.parent.mkdir(parents=True)
+            gate_path.write_text(
+                json.dumps(
+                    {
+                        "type": card_helper.SOURCE_GATE_TYPE,
+                        "ok": True,
+                        "gateId": gate_id,
+                        "createdAt": "2026-05-19T00:00:00Z",
+                        "dataset": {"ok": True, "runId": "rl-stale-from-latest", "sampleCount": 200},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            stderr = io.StringIO()
+
+            with mock.patch.object(card_helper, "utc_now_iso", return_value="2026-05-21T14:00:00Z"):
+                exit_code = card_helper.main(
+                    [
+                        "--from-latest-accepted-dataset",
+                        "--dataset-gate-root",
+                        str(gate_root),
+                        "--code-commit",
+                        "8" * 40,
+                        "--created-at",
+                        "2026-05-19T01:00:00Z",
+                    ],
+                    stdout=io.StringIO(),
+                    stderr=stderr,
+                    repo_root=REPO_ROOT,
+                )
+
+        error = stderr.getvalue()
+        self.assertEqual(exit_code, 2)
+        self.assertIn("fresh gate required within 36h", error)
+        self.assertIn("newest accepted gate is stale", error)
+        self.assertIn(gate_id, error)
         self.assertIn("age 62.0h > 36h", error)
 
     def test_cli_accepts_explicit_stale_source_gate_for_replay(self) -> None:
@@ -1414,23 +1464,24 @@ class RlExperimentCardTest(unittest.TestCase):
             )
             stdout = io.StringIO()
 
-            exit_code = card_helper.main(
-                [
-                    "--source-gate-id",
-                    gate_id,
-                    "--dataset-gate-root",
-                    str(gate_root),
-                    "--code-commit",
-                    "8" * 40,
-                    "--created-at",
-                    "2026-05-21T14:00:00Z",
-                    "--output-dir",
-                    str(card_dir),
-                ],
-                stdout=stdout,
-                stderr=io.StringIO(),
-                repo_root=REPO_ROOT,
-            )
+            with mock.patch.object(card_helper, "utc_now_iso", return_value="2026-05-25T00:00:00Z"):
+                exit_code = card_helper.main(
+                    [
+                        "--source-gate-id",
+                        gate_id,
+                        "--dataset-gate-root",
+                        str(gate_root),
+                        "--code-commit",
+                        "8" * 40,
+                        "--created-at",
+                        "2026-05-21T14:00:00Z",
+                        "--output-dir",
+                        str(card_dir),
+                    ],
+                    stdout=stdout,
+                    stderr=io.StringIO(),
+                    repo_root=REPO_ROOT,
+                )
             summary = json.loads(stdout.getvalue())
             generated = json.loads(Path(summary["path"]).read_text(encoding="utf-8"))
 
@@ -1542,22 +1593,23 @@ class RlExperimentCardTest(unittest.TestCase):
             )
             stderr = io.StringIO()
 
-            exit_code = card_helper.main(
-                [
-                    "--loop-a-local-fallback",
-                    "--dataset-gate-root",
-                    str(runtime_root),
-                    "--code-commit",
-                    "8" * 40,
-                    "--created-at",
-                    "2026-05-19T08:20:00Z",
-                    "--output",
-                    str(output_path),
-                ],
-                stdout=io.StringIO(),
-                stderr=stderr,
-                repo_root=REPO_ROOT,
-            )
+            with mock.patch.object(card_helper, "utc_now_iso", return_value="2026-05-19T08:20:00Z"):
+                exit_code = card_helper.main(
+                    [
+                        "--loop-a-local-fallback",
+                        "--dataset-gate-root",
+                        str(runtime_root),
+                        "--code-commit",
+                        "8" * 40,
+                        "--created-at",
+                        "2026-05-19T08:20:00Z",
+                        "--output",
+                        str(output_path),
+                    ],
+                    stdout=io.StringIO(),
+                    stderr=stderr,
+                    repo_root=REPO_ROOT,
+                )
 
         self.assertEqual(exit_code, 2)
         self.assertFalse(output_path.exists())


### PR DESCRIPTION
## Summary
- require fresh/full E1 gate evidence when selecting Loop A local fallback experiment cards
- preserve multi-tier policy-gradient scenario validation while rejecting stale or degraded gate sources
- add focused unit coverage for fresh gate selection and stale low-acceptance recurrence cases

## Verification
- `python3 -m py_compile scripts/screeps_rl_experiment_card.py scripts/test_screeps_rl_experiment_card.py`
- `python3 -m unittest scripts.test_screeps_rl_experiment_card -v` (53 tests)
- `git diff --check`

## Safety
- Offline RL tooling only; no official MMO writes or deploys.
- Excludes untracked recovery infrastructure (`.git-local`).

Closes #1303
