### PR TITLE
fix(rl): prove runtime parameter consumption telemetry

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35906,7 +35906,8 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
         persistOccupationRecommendations,
         (_b = eventMetricsByRoom.get(colony.room.name)) != null ? _b : {},
         shouldBuildStructureSnapshot(tick),
-        options.strategyRegistry
+        options.strategyRegistry,
+        options.onStrategyRegistryRuntimeUse
       );
     }
   );
@@ -35979,7 +35980,7 @@ function buildRoomEventMetricsByRoom(colonies, refillTargetIdsByRoom) {
   }
   return eventMetricsByRoom;
 }
-function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, eventMetrics, includeStructureSnapshot, strategyRegistry) {
+function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, eventMetrics, includeStructureSnapshot, strategyRegistry, onStrategyRegistryRuntimeUse) {
   const tick = getGameTime32();
   const colonyWorkers = colonyCreeps.filter((creep) => creep.memory.role === "worker");
   const roleCounts = countCreepsByRole(colonyCreeps, colony.room.name);
@@ -36019,7 +36020,12 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     ...buildControllerSummary(colony.room),
     resources,
     combat: summarizeCombat(colony.room, eventMetrics.combat),
-    constructionPriority: summarizeConstructionPriority(colony, colonyWorkers, strategyRegistry),
+    constructionPriority: summarizeConstructionPriority(
+      colony,
+      colonyWorkers,
+      strategyRegistry,
+      onStrategyRegistryRuntimeUse
+    ),
     survival: summarizeSurvival(colony, roleCounts),
     territoryRecommendation,
     ...territoryExpansion.candidates.length > 0 ? { territoryExpansion } : {},
@@ -37261,15 +37267,30 @@ function summarizeCombat(room, events) {
     ...events ? { events } : {}
   };
 }
-function summarizeConstructionPriority(colony, colonyWorkers, strategyRegistry) {
+function summarizeConstructionPriority(colony, colonyWorkers, strategyRegistry, onStrategyRegistryRuntimeUse) {
   const strategyEntry = selectConstructionPriorityStrategyRegistryEntry(strategyRegistry);
+  const strategyParameters = constructionPriorityStrategyParametersFromEntry(strategyEntry);
   const report = buildRuntimeConstructionPriorityReport(colony, colonyWorkers, {
-    strategyParameters: constructionPriorityStrategyParametersFromEntry(strategyEntry)
+    strategyParameters
   });
+  if (strategyEntry && strategyParameters) {
+    recordStrategyRegistryRuntimeUse2(strategyEntry, onStrategyRegistryRuntimeUse);
+  }
   return {
     candidates: report.candidates.map(toRuntimeConstructionPriorityCandidateSummary),
     nextPrimary: report.nextPrimary ? toRuntimeConstructionPriorityCandidateSummary(report.nextPrimary) : null
   };
+}
+function recordStrategyRegistryRuntimeUse2(strategyEntry, onStrategyRegistryRuntimeUse) {
+  if (!onStrategyRegistryRuntimeUse) {
+    return;
+  }
+  try {
+    onStrategyRegistryRuntimeUse(strategyEntry);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(`[runtime-summary] strategy registry runtime-use hook failed: ${message}`);
+  }
 }
 function summarizeSurvival(colony, roleCounts) {
   const assessment = assessColonySnapshotSurvival(colony, roleCounts);
@@ -45487,7 +45508,8 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
   }
   return emitRuntimeSummary(colonies, creeps, telemetryEvents, {
     persistOccupationRecommendations: false,
-    strategyRegistry: options.strategyRegistry
+    strategyRegistry: options.strategyRegistry,
+    onStrategyRegistryRuntimeUse: options.onStrategyRegistryRuntimeUse
   });
 }
 function ensureLocalWorkerColonyMemory(colonies, creeps) {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -345,7 +345,8 @@ export function runEconomy(
 
   return emitRuntimeSummary(colonies, creeps, telemetryEvents, {
     persistOccupationRecommendations: false,
-    strategyRegistry: options.strategyRegistry
+    strategyRegistry: options.strategyRegistry,
+    onStrategyRegistryRuntimeUse: options.onStrategyRegistryRuntimeUse
   });
 }
 

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -776,7 +776,8 @@ export function emitRuntimeSummary(
       persistOccupationRecommendations,
       eventMetricsByRoom.get(colony.room.name) ?? {},
       shouldBuildStructureSnapshot(tick),
-      options.strategyRegistry
+      options.strategyRegistry,
+      options.onStrategyRegistryRuntimeUse
     )
   );
   const summary: RuntimeSummary = {
@@ -875,7 +876,8 @@ function summarizeRoom(
   persistOccupationRecommendations: boolean,
   eventMetrics: RuntimeRoomEventMetrics,
   includeStructureSnapshot: boolean,
-  strategyRegistry: StrategyRegistryEntry[] | undefined
+  strategyRegistry: StrategyRegistryEntry[] | undefined,
+  onStrategyRegistryRuntimeUse: ((entry: StrategyRegistryEntry) => void) | undefined
 ): RuntimeRoomSummary {
   const tick = getGameTime();
   const colonyWorkers = colonyCreeps.filter((creep) => creep.memory.role === 'worker');
@@ -917,7 +919,12 @@ function summarizeRoom(
     ...buildControllerSummary(colony.room),
     resources,
     combat: summarizeCombat(colony.room, eventMetrics.combat),
-    constructionPriority: summarizeConstructionPriority(colony, colonyWorkers, strategyRegistry),
+    constructionPriority: summarizeConstructionPriority(
+      colony,
+      colonyWorkers,
+      strategyRegistry,
+      onStrategyRegistryRuntimeUse
+    ),
     survival: summarizeSurvival(colony, roleCounts),
     territoryRecommendation,
     ...(territoryExpansion.candidates.length > 0 ? { territoryExpansion } : {}),
@@ -2821,17 +2828,38 @@ function summarizeCombat(room: Room, events: RuntimeCombatEventSummary | undefin
 function summarizeConstructionPriority(
   colony: ColonySnapshot,
   colonyWorkers: Creep[],
-  strategyRegistry: StrategyRegistryEntry[] | undefined
+  strategyRegistry: StrategyRegistryEntry[] | undefined,
+  onStrategyRegistryRuntimeUse: ((entry: StrategyRegistryEntry) => void) | undefined
 ): RuntimeConstructionPrioritySummary {
   const strategyEntry = selectConstructionPriorityStrategyRegistryEntry(strategyRegistry);
+  const strategyParameters = constructionPriorityStrategyParametersFromEntry(strategyEntry);
   const report = buildRuntimeConstructionPriorityReport(colony, colonyWorkers, {
-    strategyParameters: constructionPriorityStrategyParametersFromEntry(strategyEntry)
+    strategyParameters
   });
+  if (strategyEntry && strategyParameters) {
+    recordStrategyRegistryRuntimeUse(strategyEntry, onStrategyRegistryRuntimeUse);
+  }
 
   return {
     candidates: report.candidates.map(toRuntimeConstructionPriorityCandidateSummary),
     nextPrimary: report.nextPrimary ? toRuntimeConstructionPriorityCandidateSummary(report.nextPrimary) : null
   };
+}
+
+function recordStrategyRegistryRuntimeUse(
+  strategyEntry: StrategyRegistryEntry,
+  onStrategyRegistryRuntimeUse: ((entry: StrategyRegistryEntry) => void) | undefined
+): void {
+  if (!onStrategyRegistryRuntimeUse) {
+    return;
+  }
+
+  try {
+    onStrategyRegistryRuntimeUse(strategyEntry);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(`[runtime-summary] strategy registry runtime-use hook failed: ${message}`);
+  }
 }
 
 function summarizeSurvival(colony: ColonySnapshot, roleCounts: RoleCounts): RuntimeSurvivalSummary {

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -10,6 +10,13 @@ import { recordCreepBehaviorIdle } from '../src/telemetry/behaviorTelemetry';
 import { CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD } from '../src/tasks/workerTasks';
 import { OCCUPIED_CONTROLLER_SIGN_TEXT } from '../src/territory/controllerSigning';
 import { DEFAULT_STRATEGY_REGISTRY } from '../src/strategy/strategyRegistry';
+import {
+  RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL,
+  RUNTIME_POLICY_PARAMETERS_GLOBAL,
+  applyRuntimePolicyParametersToRegistry,
+  createRuntimePolicyParameterConsumptionRecorder,
+  persistRuntimePolicyParameterConsumptionEvidence
+} from '../src/strategy/runtimePolicyParameters';
 
 const TEST_GLOBALS = {
   FIND_STRUCTURES: 101,
@@ -2529,7 +2536,7 @@ describe('runtime telemetry summaries', () => {
     ).toBe(true);
   });
 
-  it('does not report construction-priority runtime use from summary-only scoring', () => {
+  it('reports construction-priority runtime use from runtime summary scoring', () => {
     const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
     const onStrategyRegistryRuntimeUse = jest.fn();
 
@@ -2538,7 +2545,66 @@ describe('runtime telemetry summaries', () => {
       onStrategyRegistryRuntimeUse
     });
 
-    expect(onStrategyRegistryRuntimeUse).not.toHaveBeenCalled();
+    expect(onStrategyRegistryRuntimeUse).toHaveBeenCalledTimes(1);
+    expect(onStrategyRegistryRuntimeUse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'construction-priority.incumbent.v1',
+        family: 'construction-priority'
+      })
+    );
+  });
+
+  it('persists consumed runtime parameter evidence when summary scoring uses patched parameters', () => {
+    const parameters = {
+      baseScoreWeight: 1,
+      territorySignalWeight: 29,
+      resourceSignalWeight: 3,
+      killSignalWeight: 5,
+      riskPenalty: 4
+    };
+    const parametersSha256 = '8af0d62c55553bc05b705c43d7388473ddaf8191a1d64b6937f1fb230efb7c2f';
+    (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETERS_GLOBAL] = {
+      runtimeParameterInjection: true,
+      candidateParameterScope: 'runtime_injected',
+      strategyVariantId: 'construction-priority.pg.territory-seed.v1',
+      candidatePolicyId: 'construction-priority.pg.territory-seed.v1',
+      sourceStrategyId: 'construction-priority.incumbent.v1',
+      family: 'construction-priority',
+      parameters,
+      parametersSha256
+    };
+    const runtimePolicyParameters = applyRuntimePolicyParametersToRegistry(DEFAULT_STRATEGY_REGISTRY);
+    const recorder = createRuntimePolicyParameterConsumptionRecorder();
+    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
+
+    emitRuntimeSummary([colony], [], [], {
+      persistOccupationRecommendations: false,
+      strategyRegistry: runtimePolicyParameters.registry,
+      onStrategyRegistryRuntimeUse: recorder.recordStrategyRuntimeUse
+    });
+    persistRuntimePolicyParameterConsumptionEvidence(recorder.buildEvidence());
+
+    expect(
+      (globalThis as { Memory?: { rlRuntimePolicyParameters?: unknown } }).Memory?.rlRuntimePolicyParameters
+    ).toMatchObject({
+      runtimeParameterInjection: true,
+      consumed: true,
+      parameters,
+      parametersSha256,
+      appliedStrategyIds: ['construction-priority.incumbent.v1'],
+      liveEffect: false,
+      officialMmoWrites: false,
+      officialMmoWritesAllowed: false,
+      tick: RUNTIME_SUMMARY_INTERVAL
+    });
+    expect(
+      (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL]
+    ).toMatchObject({
+      consumed: true,
+      parameters,
+      parametersSha256,
+      appliedStrategyIds: ['construction-priority.incumbent.v1']
+    });
   });
 
   function parseLoggedSummary(): Record<string, unknown> {
@@ -2586,6 +2652,8 @@ function clearRuntimeTelemetryGlobals(): void {
   }
   delete globals.Game;
   delete globals.Memory;
+  delete globals[RUNTIME_POLICY_PARAMETERS_GLOBAL];
+  delete globals[RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL];
 }
 
 function installRuntimeTelemetryMemory(): void {


### PR DESCRIPTION
## Summary
- add runtime policy-parameter consumption telemetry to the runtime summary path
- expose whether scorecarded candidate parameters were consumed during simulation/runtime execution
- add unit coverage for the new telemetry fields and keep the bundled Screeps artifact synchronized

## Verification
- `npm run typecheck`
- `npm test -- --runInBand` (101 suites, 2006 tests)
- `npm run build`
- `git diff --check`

## Safety
- Offline/private RL validation support; no official MMO learned-policy writes.
- `prod/dist/main.js` regenerated via build.
- Excludes untracked recovery/dependency infrastructure (`.git-local`, `prod/node_modules`).

Closes #1301
