### PR TITLE
feat(rl): add policy-family routing for RL flywheel

### DIFF
--- a/docs/ops/rl-act-loop-feedback.md
+++ b/docs/ops/rl-act-loop-feedback.md
@@ -7,6 +7,7 @@ Primary artifacts:
 - `scripts/screeps_rl_act_loop_planner.py`
 - `scripts/test_screeps_rl_act_loop_planner.py`
 - `scripts/fixtures/rl/act-loop-mixed-unproven-policy-advantage.json`
+- `docs/ops/rl-policy-family-flywheel.md`
 - `docs/ops/rl-reward-decision-registry.md`
 - `docs/ops/rl-training-reward-workflow.md`
 
@@ -35,13 +36,15 @@ The planner only reads JSON and writes JSON. It does not call GitHub, Screeps of
 
 Each plan emits:
 
-- `finding`: stable finding id, title, source artifact, evidence window, primary `classification`, secondary classifications, metric evidence, and missing scenario capabilities when present.
+- `finding`: stable finding id, title, source artifact, evidence window, primary `classification`, secondary classifications, metric evidence, policy-family route metadata, and missing scenario capabilities when present.
 - `nextRewardDecision`: a #907-style reward decision record route when the finding is a `reward_gap`.
 - `nextScenarioDelta`: a private/shadow scenario or fixture delta when the finding is a `scenario_gap`.
 - `nextPolicyDelta`: a named policy parameter surface with explicit bounds when the finding is a `policy_parameterization_gap`.
 - `nextExperimentCardDelta`: the card-helper-compatible shadow training delta that consumes reward/scenario/policy changes.
 - `feedbackIngestion`: current state for finding -> decision -> card -> training -> scorecard -> rollout feedback.
 - `decision`, `status`, and `blockingReasons`: fields that the SQLite/Grafana ingestion path can count through `metric_iteration_decisions`.
+
+Policy-family routing follows `docs/ops/rl-policy-family-flywheel.md`: no new cron lanes, flexible `policyFamily` / `topAgent` / `rolePolicy` fields, and fallback only from known `parameterSurface` names such as `construction-priority -> top.construction`.
 
 Allowed classifications:
 

--- a/docs/ops/rl-domain-roadmap.md
+++ b/docs/ops/rl-domain-roadmap.md
@@ -17,6 +17,8 @@ This domain exists to change game strategy, not merely to produce papers. The pa
 
 Canonical current strategy paper: `docs/research/2026-05-19-screeps-rl-flywheel-strategy-paper.md`. The older `docs/research/2026-04-29-screeps-rl-self-evolving-strategy-paper.md` remains the research foundation, but the 2026-05-19 paper is the operational source of truth for active #879 flywheel design, safety gates, observability, scale thresholds, and maintenance expectations.
 
+Canonical policy-family routing contract: `docs/ops/rl-policy-family-flywheel.md`. #879 remains on the existing cron and GitHub Project machinery while findings, Act-loop deltas, Loop A, Loop B, steward decisions, continuation work, scorecards, canaries, and feedback preserve `policyFamily` metadata for the multi-agent hierarchy.
+
 ## Safety boundary
 
 No learned or tuned policy may directly control official MMO creep intents, spawn intents, construction intents, market orders, Memory writes, or RawMemory commands until all gates pass:
@@ -62,6 +64,8 @@ These gates are the active roadmap mapping for the current RL flywheel reset. A 
 | G7 Canonical strategy maintenance | #1241 | RL flywheel | `docs/research/2026-05-19-screeps-rl-flywheel-strategy-paper.md` is published and future strategy changes update it or explicitly state why not | agent continuity |
 
 Smoke-scale evidence cannot close scale-first training work. The current `5 workers x 5 repetitions x 500 ticks = 25 env rows / 12,500 simulator ticks` shape is smoke-only; validation requires >=200 env rows and >=200k ticks, and #1236 owns the minimum acceptable 8c16g utilization ladder.
+
+Policy-family-aware #879 execution starts with `top.construction` as the existing `construction-priority` bridge and `role.worker-task` as the first lower-level surface. These labels are routing metadata only; reward, scorecard, canary, rollout, and feedback gates remain unchanged.
 
 ## Current issue map
 

--- a/docs/ops/rl-policy-family-flywheel.md
+++ b/docs/ops/rl-policy-family-flywheel.md
@@ -1,0 +1,75 @@
+# RL Policy-Family Flywheel
+
+Status: canonical policy-family routing contract for the #879 RL flywheel.
+
+## No-New-Cron Rule
+
+Policy-family routing does not create new cron jobs, Discord thread jobs, or parallel registries. Existing runtime artifact collection, E1 dataset labeling, Gameplay Evolution review, Act-loop planning, Loop A training, Loop B online advantage review, RL steward cadence, continuation worker, scorecard, canary, and feedback jobs remain the execution surfaces.
+
+The routing layer is metadata only. It must not change official MMO behavior, make official writes, alter rewards without a #907-style decision, or claim rollout/policy improvement without scorecard and canary evidence.
+
+## Flow
+
+```text
+runtime artifacts
+  -> E1 labels with policy-family metadata
+  -> Gameplay Evolution / Act route
+  -> Loop A training ledger by family
+  -> Loop B online advantage by family
+  -> RL steward chooses the next family, gate, or blocker
+  -> continuation worker keeps GitHub Issue/PR/Project execution unchanged
+  -> scorecard, canary, and feedback gates remain mandatory
+```
+
+The Act route may carry `policyFamily`, `topAgent`, `rolePolicy`, and nested `route` or `routing` metadata. Downstream artifacts should preserve those fields alongside the existing classification, parameter-surface, reward-decision, scenario, and experiment-card data.
+
+## Initial Families
+
+Top-level policy families:
+
+- `top.bootstrap`
+- `top.economy`
+- `top.construction`
+- `top.upgrade`
+- `top.defense`
+- `top.remote-expansion`
+- `top.offense`
+
+Role and lower-level policy families:
+
+- `role.worker-task`
+- `role.tower-action`
+- `role.hauler-routing`
+- `role.builder-repair`
+- `role.upgrader-budget`
+- `role.defender-micro`
+- `role.attacker-micro`
+
+`top.offense` and `role.attacker-micro` stay offline/private-only until later owner-approved gates explicitly permit broader use.
+
+## MVP Surface
+
+The first durable slice is plumbing, not a behavior rollout.
+
+- `top.construction` bridges the existing `construction-priority` candidate stream into the top-level hierarchy.
+- `role.worker-task` is the first low-level policy surface for later dataset, training, scorecard, and canary work.
+- `role.tower-action` is recognized as a route fallback for tower-action policy-surface findings, but it does not authorize live tower behavior changes.
+
+When explicit route fields are absent, the only initial fallback mappings are:
+
+| Parameter surface | Policy family |
+| --- | --- |
+| `construction-priority` | `top.construction` |
+| `worker-task` | `role.worker-task` |
+| `tower-action` | `role.tower-action` |
+
+All other parameter surfaces keep the existing `parameterSurface` behavior without inventing a policy-family route.
+
+## Gates
+
+Reward, scorecard, canary, and feedback gates remain mandatory for every policy family:
+
+- Reward changes still require the #907 decision registry and evidence before training use.
+- Training output remains offline/shadow/private until candidate-vs-baseline scorecard evidence exists.
+- Canary and rollback evidence are required before any official MMO influence.
+- Feedback ingestion must link the finding, decision/card, training report, scorecard, and rollout feedback state before a family can be treated as self-iterating.

--- a/scripts/screeps_rl_act_loop_planner.py
+++ b/scripts/screeps_rl_act_loop_planner.py
@@ -590,7 +590,7 @@ def infer_policy_surface(raw: JsonObject) -> str:
 
 def explicit_policy_route(raw: JsonObject) -> JsonObject:
     route: JsonObject = {}
-    for field in ("policyFamily", "topAgent", "rolePolicy"):
+    for field in POLICY_ROUTE_FIELDS:
         value = first_text(raw, POLICY_ROUTE_ALIASES[field])
         if value:
             route[field] = value
@@ -609,14 +609,16 @@ def explicit_policy_route(raw: JsonObject) -> JsonObject:
 
 
 def infer_policy_route(raw: JsonObject) -> JsonObject:
-    explicit = explicit_policy_route(raw)
-    if explicit:
-        return explicit
+    route = explicit_policy_route(raw)
+    if "policyFamily" in route:
+        return route
     surface = explicit_policy_surface(raw)
     if not surface:
-        return {}
+        return route
     policy_family = POLICY_FAMILY_FALLBACKS.get(normalize_key(surface))
-    return {"policyFamily": policy_family} if policy_family else {}
+    if policy_family:
+        route["policyFamily"] = policy_family
+    return route
 
 
 def infer_policy_bounds(raw: JsonObject, surface: str) -> list[JsonObject]:

--- a/scripts/screeps_rl_act_loop_planner.py
+++ b/scripts/screeps_rl_act_loop_planner.py
@@ -47,6 +47,23 @@ POLICY_SURFACE_NAME_ALIASES = (
     "targetFamily",
     "target_family",
 )
+POLICY_ROUTE_FIELDS = ("policyFamily", "topAgent", "rolePolicy", "level")
+POLICY_ROUTE_ALIASES: dict[str, tuple[str, ...]] = {
+    "policyFamily": (
+        "policyFamily",
+        "policy_family",
+        "targetPolicyFamily",
+        "target_policy_family",
+    ),
+    "topAgent": ("topAgent", "top_agent"),
+    "rolePolicy": ("rolePolicy", "role_policy"),
+    "level": ("level",),
+}
+POLICY_FAMILY_FALLBACKS = {
+    "constructionpriority": "top.construction",
+    "workertask": "role.worker-task",
+    "toweraction": "role.tower-action",
+}
 
 JsonObject = dict[str, Any]
 
@@ -524,7 +541,7 @@ def infer_target_scenario_id(raw: JsonObject) -> str:
     return infer_source_scenario_id(raw) or DEFAULT_SCENARIO_ID
 
 
-def infer_policy_surface(raw: JsonObject) -> str:
+def explicit_policy_surface(raw: JsonObject) -> str | None:
     explicit = first_named_text(
         raw,
         (
@@ -556,12 +573,50 @@ def infer_policy_surface(raw: JsonObject) -> str:
     )
     if nested:
         return nested
+    return None
+
+
+def infer_policy_surface(raw: JsonObject) -> str:
+    explicit = explicit_policy_surface(raw)
+    if explicit:
+        return explicit
     blob = text_blob(raw)
     if "construction" in blob or "build" in blob:
         return "construction-priority"
     if "expansion" in blob or "reserve" in blob or "remote" in blob:
         return "expansion-remote"
     return "unspecified-policy-surface"
+
+
+def explicit_policy_route(raw: JsonObject) -> JsonObject:
+    route: JsonObject = {}
+    for field in ("policyFamily", "topAgent", "rolePolicy"):
+        value = first_text(raw, POLICY_ROUTE_ALIASES[field])
+        if value:
+            route[field] = value
+
+    for container_key in ("route", "routing"):
+        container = as_dict(lookup(raw, (container_key,)))
+        if not container:
+            continue
+        for field in POLICY_ROUTE_FIELDS:
+            if field in route:
+                continue
+            value = first_text(container, POLICY_ROUTE_ALIASES[field])
+            if value:
+                route[field] = value
+    return route
+
+
+def infer_policy_route(raw: JsonObject) -> JsonObject:
+    explicit = explicit_policy_route(raw)
+    if explicit:
+        return explicit
+    surface = explicit_policy_surface(raw)
+    if not surface:
+        return {}
+    policy_family = POLICY_FAMILY_FALLBACKS.get(normalize_key(surface))
+    return {"policyFamily": policy_family} if policy_family else {}
 
 
 def infer_policy_bounds(raw: JsonObject, surface: str) -> list[JsonObject]:
@@ -705,6 +760,7 @@ def build_finding_summary(
     metric_evidence = collect_metric_evidence(raw)
     if metric_evidence:
         finding["metricEvidence"] = metric_evidence
+    finding.update(infer_policy_route(raw))
     return finding
 
 
@@ -797,6 +853,7 @@ def build_policy_delta(raw: JsonObject, *, finding: JsonObject) -> JsonObject | 
     surface = infer_policy_surface(raw)
     bounds = infer_policy_bounds(raw, surface)
     candidate_id = first_text(raw, ("candidatePolicyId", "candidateId", "candidate_id", "strategyVariantId"))
+    policy_route = infer_policy_route(raw)
     delta: JsonObject = {
         "action": "bound_policy_parameter_surface",
         "parameterSurface": surface,
@@ -807,6 +864,7 @@ def build_policy_delta(raw: JsonObject, *, finding: JsonObject) -> JsonObject | 
         "shadowOnly": True,
         "safety": dict(SAFETY_BLOCK),
     }
+    delta.update(policy_route)
     if candidate_id:
         delta["candidatePolicyId"] = candidate_id
     return delta
@@ -852,6 +910,9 @@ def build_experiment_card_delta(
             "parameterSurface": policy_delta["parameterSurface"],
             "bounds": policy_delta["bounds"],
         }
+        for field in POLICY_ROUTE_FIELDS:
+            if field in policy_delta:
+                deltas["policy"][field] = policy_delta[field]
         if "candidatePolicyId" in policy_delta:
             deltas["policy"]["candidatePolicyId"] = policy_delta["candidatePolicyId"]
 
@@ -933,13 +994,18 @@ def build_feedback_state(
     scorecard_state = feedback_link_state(scorecard_id, planned=False)
     rollout_state = feedback_link_state(rollout_id, planned=False)
 
+    finding_state: JsonObject = {
+        "state": "observed",
+        "id": finding["id"],
+        "classification": finding["classification"],
+        "sourceArtifact": finding.get("sourceArtifact"),
+    }
+    for field in POLICY_ROUTE_FIELDS:
+        if field in finding:
+            finding_state[field] = finding[field]
+
     return {
-        "finding": {
-            "state": "observed",
-            "id": finding["id"],
-            "classification": finding["classification"],
-            "sourceArtifact": finding.get("sourceArtifact"),
-        },
+        "finding": finding_state,
         "decision": decision_state,
         "experimentCard": card_state,
         "training": training_state,

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -88,6 +88,7 @@ class StrategyVariant:
     parameters: JsonObject
     candidate_policy_id: str | None = None
     family: str | None = None
+    policy_family: str | None = None
     parameter_evidence: JsonObject | None = None
     rollout_status: str | None = None
     source_strategy_id: str | None = None
@@ -105,6 +106,8 @@ class StrategyVariant:
             payload["candidatePolicyId"] = self.candidate_policy_id
         if self.family:
             payload["family"] = self.family
+        if self.policy_family:
+            payload["policyFamily"] = self.policy_family
         if self.parameter_evidence is not None:
             payload["parameterEvidence"] = copy.deepcopy(self.parameter_evidence)
         if self.rollout_status:
@@ -429,6 +432,7 @@ def expand_scale_environment_strategy_variants(
                 parameters=copy.deepcopy(base.parameters),
                 candidate_policy_id=base.candidate_policy_id,
                 family=base.family,
+                policy_family=base.policy_family,
                 parameter_evidence=copy.deepcopy(base.parameter_evidence),
                 rollout_status=base.rollout_status,
                 source_strategy_id=base.source_strategy_id,
@@ -466,6 +470,11 @@ def normalize_variant(raw: Any, registry: dict[str, StrategyVariant]) -> Strateg
     if source_strategy_id is not None:
         validate_strategy_id(source_strategy_id)
     family = text_or_none(raw.get("family")) or (registry_variant.family if registry_variant else None)
+    policy_family = (
+        text_or_none(raw.get("policyFamily"))
+        or text_or_none(raw.get("policy_family"))
+        or (registry_variant.policy_family if registry_variant else None)
+    )
     parameter_evidence = first_mapping(raw, ("parameterEvidence", "parameter_evidence"))
     rollout_status = (
         text_or_none(raw.get("rolloutStatus"))
@@ -478,6 +487,7 @@ def normalize_variant(raw: Any, registry: dict[str, StrategyVariant]) -> Strateg
         parameters=dict(sorted(parameters.items())),
         candidate_policy_id=candidate_policy_id,
         family=family,
+        policy_family=policy_family,
         parameter_evidence=copy.deepcopy(parameter_evidence) if parameter_evidence is not None else None,
         rollout_status=rollout_status,
         source_strategy_id=source_strategy_id,
@@ -507,6 +517,7 @@ def load_strategy_registry(path: Path) -> dict[str, StrategyVariant]:
             id=variant_id,
             parameters=parameters,
             family=regex_group(r"\bfamily:\s*['\"]([^'\"]+)['\"]", block),
+            policy_family=regex_group(r"\bpolicyFamily:\s*['\"]([^'\"]+)['\"]", block),
             rollout_status=regex_group(r"\brolloutStatus:\s*['\"]([^'\"]+)['\"]", block),
             title=regex_group(r"\btitle:\s*['\"]([^'\"]+)['\"]", block),
             source="registry",
@@ -1292,6 +1303,9 @@ def build_training_report(
         "policyUpdateCandidatePolicyId": None,
         "trueGradient": False,
         "modelFamilies": sorted({text for text in (result.get("family") for result in results) if isinstance(text, str)}),
+        "policyFamilies": sorted(
+            {text for text in (result.get("policyFamily") for result in results) if isinstance(text, str)}
+        ),
         "modelReports": model_reports,
         "kpiSummary": build_kpi_summary(scored_results),
         "warnings": warnings,
@@ -3065,6 +3079,8 @@ def summarize_variant(
             for run in runs
         ],
     }
+    if variant.policy_family:
+        summary["policyFamily"] = variant.policy_family
     if variant.candidate_policy_id:
         summary["candidatePolicyId"] = variant.candidate_policy_id
     if variant.source_strategy_id:
@@ -4175,6 +4191,8 @@ def rank_variant_results(results: Sequence[JsonObject]) -> list[JsonObject]:
                 "ok": result["ok"],
             }
         )
+        if isinstance(result.get("policyFamily"), str):
+            ranking[-1]["policyFamily"] = result["policyFamily"]
     return ranking
 
 

--- a/scripts/test_screeps_rl_act_loop_planner.py
+++ b/scripts/test_screeps_rl_act_loop_planner.py
@@ -387,6 +387,111 @@ class ScreepsRlActLoopPlannerTest(unittest.TestCase):
                     expected_surface,
                 )
 
+    def test_explicit_policy_route_fields_propagate_through_policy_outputs(self) -> None:
+        plan = planner.build_plan(
+            {
+                "title": "Worker-task route should remain machine-readable",
+                "classification": "policy_parameterization_gap",
+                "onlineUtilityStatus": "UNPROVEN",
+                "target_policy_family": "role.worker-task",
+                "routing": {
+                    "topAgent": "top.economy",
+                    "rolePolicy": "role.worker-task",
+                    "level": "role",
+                },
+                "parameterSurface": {
+                    "name": "worker-task",
+                    "bounds": [
+                        {
+                            "name": "repairVsBuildWeight",
+                            "min": 0,
+                            "max": 1,
+                            "step": 0.1,
+                        }
+                    ],
+                },
+            }
+        )
+
+        expected_route = {
+            "policyFamily": "role.worker-task",
+            "topAgent": "top.economy",
+            "rolePolicy": "role.worker-task",
+            "level": "role",
+        }
+        policy_card_delta = plan["nextExperimentCardDelta"]["deltas"]["policy"]
+        feedback_finding = plan["feedbackIngestion"]["finding"]
+        for field, expected in expected_route.items():
+            with self.subTest(field=field):
+                self.assertEqual(plan["finding"][field], expected)
+                self.assertEqual(plan["nextPolicyDelta"][field], expected)
+                self.assertEqual(policy_card_delta[field], expected)
+                self.assertEqual(feedback_finding[field], expected)
+
+    def test_nested_route_object_policy_family_propagates_through_policy_outputs(self) -> None:
+        plan = planner.build_plan(
+            {
+                "title": "Construction route object should remain machine-readable",
+                "classification": "policy_parameterization_gap",
+                "onlineUtilityStatus": "UNPROVEN",
+                "route": {
+                    "policyFamily": "top.construction",
+                    "topAgent": "top.construction",
+                    "level": "top",
+                },
+                "parameterSurface": {
+                    "name": "construction-priority",
+                    "bounds": [
+                        {
+                            "name": "territorySignalWeight",
+                            "min": 0,
+                            "max": 10,
+                            "step": 1,
+                        }
+                    ],
+                },
+            }
+        )
+
+        policy_card_delta = plan["nextExperimentCardDelta"]["deltas"]["policy"]
+        self.assertEqual(plan["finding"]["policyFamily"], "top.construction")
+        self.assertEqual(plan["nextPolicyDelta"]["policyFamily"], "top.construction")
+        self.assertEqual(policy_card_delta["policyFamily"], "top.construction")
+        self.assertEqual(plan["feedbackIngestion"]["finding"]["policyFamily"], "top.construction")
+        self.assertEqual(policy_card_delta["level"], "top")
+
+    def test_construction_priority_falls_back_to_top_construction_policy_family(self) -> None:
+        plan = planner.build_plan(
+            {
+                "title": "Construction-priority should route through the construction top family",
+                "classification": "policy_parameterization_gap",
+                "onlineUtilityStatus": "UNPROVEN",
+                "parameterSurface": {
+                    "name": "construction-priority",
+                    "bounds": [
+                        {
+                            "name": "riskPenalty",
+                            "min": 0,
+                            "max": 10,
+                            "step": 1,
+                        }
+                    ],
+                },
+            }
+        )
+
+        self.assertEqual(plan["status"], "ACT_DELTA_READY")
+        self.assertEqual(plan["finding"]["policyFamily"], "top.construction")
+        self.assertEqual(plan["nextPolicyDelta"]["policyFamily"], "top.construction")
+        self.assertEqual(
+            plan["nextExperimentCardDelta"]["deltas"]["policy"]["policyFamily"],
+            "top.construction",
+        )
+        self.assertEqual(plan["feedbackIngestion"]["finding"]["policyFamily"], "top.construction")
+        self.assertIsNone(plan["nextRewardDecision"])
+        self.assertNotIn("rewardDecision", plan["nextExperimentCardDelta"]["deltas"])
+        self.assertNotIn("cron", json.dumps(plan, sort_keys=True).lower())
+
     def test_nested_policy_surface_without_bounds_stays_route_required(self) -> None:
         plan = planner.build_plan(
             {

--- a/scripts/test_screeps_rl_act_loop_planner.py
+++ b/scripts/test_screeps_rl_act_loop_planner.py
@@ -492,6 +492,117 @@ class ScreepsRlActLoopPlannerTest(unittest.TestCase):
         self.assertNotIn("rewardDecision", plan["nextExperimentCardDelta"]["deltas"])
         self.assertNotIn("cron", json.dumps(plan, sort_keys=True).lower())
 
+    def test_partial_explicit_route_backfills_construction_policy_family(self) -> None:
+        cases = (
+            (
+                "top-agent-role-policy",
+                {
+                    "topAgent": "top.economy",
+                    "rolePolicy": "role.builder",
+                },
+                {
+                    "policyFamily": "top.construction",
+                    "topAgent": "top.economy",
+                    "rolePolicy": "role.builder",
+                },
+            ),
+            (
+                "top-level-level",
+                {
+                    "level": "top",
+                },
+                {
+                    "policyFamily": "top.construction",
+                    "level": "top",
+                },
+            ),
+        )
+
+        for label, route_fields, expected_route in cases:
+            with self.subTest(label=label):
+                plan = planner.build_plan(
+                    {
+                        "title": f"Partial route {label} should keep construction policy family",
+                        "classification": "policy_parameterization_gap",
+                        "onlineUtilityStatus": "UNPROVEN",
+                        **route_fields,
+                        "parameterSurface": {
+                            "name": "construction-priority",
+                            "bounds": [
+                                {
+                                    "name": "riskPenalty",
+                                    "min": 0,
+                                    "max": 10,
+                                    "step": 1,
+                                }
+                            ],
+                        },
+                    }
+                )
+
+                self.assertEqual(plan["status"], "ACT_DELTA_READY")
+                policy_card_delta = plan["nextExperimentCardDelta"]["deltas"]["policy"]
+                feedback_finding = plan["feedbackIngestion"]["finding"]
+                for field, expected in expected_route.items():
+                    self.assertEqual(plan["finding"][field], expected)
+                    self.assertEqual(plan["nextPolicyDelta"][field], expected)
+                    self.assertEqual(policy_card_delta[field], expected)
+                    self.assertEqual(feedback_finding[field], expected)
+
+    def test_explicit_policy_family_is_not_overwritten_by_surface_fallback(self) -> None:
+        plan = planner.build_plan(
+            {
+                "title": "Explicit family should win over construction surface fallback",
+                "classification": "policy_parameterization_gap",
+                "onlineUtilityStatus": "UNPROVEN",
+                "policyFamily": "role.custom-construction",
+                "parameterSurface": {
+                    "name": "construction-priority",
+                    "bounds": [
+                        {
+                            "name": "riskPenalty",
+                            "min": 0,
+                            "max": 10,
+                            "step": 1,
+                        }
+                    ],
+                },
+            }
+        )
+
+        policy_card_delta = plan["nextExperimentCardDelta"]["deltas"]["policy"]
+        self.assertEqual(plan["finding"]["policyFamily"], "role.custom-construction")
+        self.assertEqual(plan["nextPolicyDelta"]["policyFamily"], "role.custom-construction")
+        self.assertEqual(policy_card_delta["policyFamily"], "role.custom-construction")
+        self.assertEqual(plan["feedbackIngestion"]["finding"]["policyFamily"], "role.custom-construction")
+
+    def test_unmapped_policy_surface_does_not_invent_policy_family(self) -> None:
+        plan = planner.build_plan(
+            {
+                "title": "Expansion risk surface keeps parameter-surface routing only",
+                "classification": "policy_parameterization_gap",
+                "onlineUtilityStatus": "UNPROVEN",
+                "parameterSurface": {
+                    "name": "expansion-risk-window",
+                    "bounds": [
+                        {
+                            "name": "reservationRiskWeight",
+                            "min": 0,
+                            "max": 5,
+                            "step": 0.5,
+                        }
+                    ],
+                },
+            }
+        )
+
+        self.assertEqual(plan["status"], "ACT_DELTA_READY")
+        policy_card_delta = plan["nextExperimentCardDelta"]["deltas"]["policy"]
+        self.assertNotIn("policyFamily", plan["finding"])
+        self.assertNotIn("policyFamily", plan["nextPolicyDelta"])
+        self.assertNotIn("policyFamily", policy_card_delta)
+        self.assertNotIn("policyFamily", plan["feedbackIngestion"]["finding"])
+
     def test_nested_policy_surface_without_bounds_stays_route_required(self) -> None:
         plan = planner.build_plan(
             {

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -1299,6 +1299,37 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(report["ranking"][0]["rewardTuple"][1], 0)
         self.assertEqual(report["statisticalComparison"]["pairwise"][0]["firstDifferingTier"], "resources")
 
+    def test_inline_policy_family_is_preserved_in_report_surfaces(self) -> None:
+        card = base_card()
+        card["strategy_variants"][0]["policyFamily"] = "top.construction"
+        card["strategy_variants"][1]["policy_family"] = "role.worker-task"
+        start = tick(1, [room("W1N1", energy=100)])
+        baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=300, harvested=100)])])
+        candidate = variant_result("candidate", [start, tick(2, [room("W1N1", energy=900, harvested=100)])])
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="policy-family-report",
+                simulator_runner=MockSimulator({"baseline": baseline, "candidate": candidate}),
+            )
+
+        strategy_by_id = {item["id"]: item for item in report["strategyVariants"]}
+        result_by_id = {item["variantId"]: item for item in report["variantResults"]}
+        ranking_by_id = {item["variantId"]: item for item in report["ranking"]}
+        self.assertEqual(strategy_by_id["baseline"]["policyFamily"], "top.construction")
+        self.assertEqual(strategy_by_id["candidate"]["policyFamily"], "role.worker-task")
+        self.assertEqual(result_by_id["baseline"]["policyFamily"], "top.construction")
+        self.assertEqual(result_by_id["candidate"]["policyFamily"], "role.worker-task")
+        self.assertEqual(ranking_by_id["baseline"]["policyFamily"], "top.construction")
+        self.assertEqual(ranking_by_id["candidate"]["policyFamily"], "role.worker-task")
+        self.assertEqual(report["policyFamilies"], ["role.worker-task", "top.construction"])
+        self.assertEqual(report["modelFamilies"], ["test-family"])
+
     def test_equal_reward_tuple_does_not_count_as_top_change(self) -> None:
         start = tick(1, [room("W1N1", energy=100)])
         finish = tick(2, [room("W1N1", energy=300, harvested=100)])


### PR DESCRIPTION
## Summary
- Add the canonical `docs/ops/rl-policy-family-flywheel.md` contract for the approved multi-agent / policy-family RL flywheel direction.
- Extend the Act-loop planner to preserve flexible `policyFamily`, `topAgent`, `rolePolicy`, and nested `route` / `routing` metadata through finding, policy delta, experiment-card delta, and feedback ingestion outputs.
- Extend offline training reports to preserve inline variant `policyFamily` metadata across strategy variants, variant results, ranking entries, and report-level `policyFamilies`.

## Operating constraint
No new cron jobs, Discord thread jobs, official MMO behavior changes, reward changes, or rollout claims were added. This is local/offline metadata plumbing only.

## Verification
- `python3 -m py_compile scripts/screeps_rl_act_loop_planner.py scripts/test_screeps_rl_act_loop_planner.py scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_training_runner.py`
- `python3 -m unittest scripts/test_screeps_rl_act_loop_planner.py -v`
- `python3 -m unittest scripts/test_screeps_rl_training_runner.py -v`
- `git diff --check`

Fixes #1307
Refs #879, #1028, #1032, #1240
