### PR TITLE
fix(rl): collect Redis runtime parameter consumption

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -781,6 +781,7 @@ def collect_runtime_parameter_consumption_evidence(
         ("redis.Memory.rlRuntimePolicyParameters", _collect_redis_runtime_parameter_consumption_evidence),
         ("mongo.Memory.rlRuntimePolicyParameters", _collect_mongo_runtime_parameter_consumption_evidence),
     ]
+    invalid_evidence: JsonObject | None = None
     for source, collector in collectors:
         try:
             evidence = collector(smoke, compose, cfg, token, injection)
@@ -790,7 +791,19 @@ def collect_runtime_parameter_consumption_evidence(
         if evidence is not None:
             evidence = copy.deepcopy(evidence)
             evidence["source"] = source
+            if injection is not None:
+                validation_error = runtime_parameter_consumption_validation_error(injection, evidence)
+                if validation_error is not None:
+                    errors.append(
+                        f"{source} returned non-matching runtime parameter consumption evidence: "
+                        f"{validation_error}"
+                    )
+                    if invalid_evidence is None:
+                        invalid_evidence = evidence
+                    continue
             return evidence, errors
+    if invalid_evidence is not None:
+        return invalid_evidence, errors
     return None, errors
 
 

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -1213,11 +1213,18 @@ def _collect_redis_runtime_parameter_payload(
         command.append(scan_mode)
     result = smoke.run_command(command, cfg, timeout=60, output_limit=200000)
     if result.get("returncode") != 0:
-        return None
+        raise RuntimeError(
+            "redis runtime-parameter probe failed: "
+            f"exit={result.get('returncode')} "
+            f"output={_safe_text(result.get('output_excerpt', ''), 240)}"
+        )
     try:
         payload = _json_payload_from_command_output(result.get("output_excerpt", ""))
-    except (IndexError, json.JSONDecodeError):
-        return None
+    except (IndexError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            "redis runtime-parameter probe returned malformed JSON: "
+            f"{_safe_text(result.get('output_excerpt', ''), 240)}"
+        ) from exc
     return payload if isinstance(payload, dict) else None
 
 

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -778,6 +778,7 @@ def collect_runtime_parameter_consumption_evidence(
     errors: list[str] = []
     collectors = [
         ("Memory.rlRuntimePolicyParameters", _collect_http_runtime_parameter_consumption_evidence),
+        ("redis.Memory.rlRuntimePolicyParameters", _collect_redis_runtime_parameter_consumption_evidence),
         ("mongo.Memory.rlRuntimePolicyParameters", _collect_mongo_runtime_parameter_consumption_evidence),
     ]
     for source, collector in collectors:
@@ -826,6 +827,54 @@ def _collect_http_runtime_parameter_consumption_evidence(
         if evidence is not None:
             return evidence
     return None
+
+
+def _collect_redis_runtime_parameter_consumption_evidence(
+    smoke: Any,
+    compose: Sequence[str] | None,
+    cfg: Any,
+    token: str | None,
+    injection: JsonObject | None = None,
+) -> JsonObject | None:
+    _ = token
+    if compose is None:
+        return None
+    eval_script = """
+local cursor = "0"
+local candidates = {}
+local seen = {}
+for _, pattern in ipairs({"*memory*", "*Memory*"}) do
+  cursor = "0"
+  repeat
+    local result = redis.call("SCAN", cursor, "MATCH", pattern, "COUNT", 100)
+    cursor = result[1]
+    for _, key in ipairs(result[2]) do
+      local keyText = tostring(key)
+      local keyLower = string.lower(keyText)
+      if not seen[keyText] and string.find(keyLower, "memory", 1, true) then
+        seen[keyText] = true
+        local keyType = redis.call("TYPE", key).ok
+        if keyType == "string" then
+          local value = redis.call("GET", key)
+          if value then
+            table.insert(candidates, {source = "redis." .. keyText, value = value})
+          end
+        end
+      end
+    end
+  until cursor == "0"
+end
+return cjson.encode({ok = true, candidates = candidates})
+""".strip()
+    command = [*compose, "exec", "-T", "redis", "redis-cli", "--raw", "EVAL", eval_script, "0"]
+    result = smoke.run_command(command, cfg, timeout=60, output_limit=200000)
+    if result.get("returncode") != 0:
+        return None
+    try:
+        payload = _json_payload_from_command_output(result.get("output_excerpt", ""))
+    except (IndexError, json.JSONDecodeError):
+        return None
+    return find_runtime_parameter_consumption_evidence(payload, injection=injection)
 
 
 def _collect_mongo_runtime_parameter_consumption_evidence(
@@ -883,10 +932,14 @@ print(JSON.stringify({{ok: true, candidates}}));
     if result.get("returncode") != 0:
         return None
     try:
-        payload = json.loads(str(result.get("output_excerpt", "")).strip().splitlines()[-1])
+        payload = _json_payload_from_command_output(result.get("output_excerpt", ""))
     except (IndexError, json.JSONDecodeError):
         return None
     return find_runtime_parameter_consumption_evidence(payload, injection=injection)
+
+
+def _json_payload_from_command_output(output: Any) -> Any:
+    return json.loads(str(output).strip().splitlines()[-1])
 
 
 def find_runtime_parameter_consumption_evidence(

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -768,6 +768,47 @@ def runtime_consumption_parameters_hash(evidence: JsonObject) -> str | None:
     ).hexdigest()
 
 
+def runtime_parameter_record_matches_username(value: Any, username: str | None) -> bool:
+    expected = _non_empty_text(username)
+    if expected is None or not isinstance(value, dict):
+        return True
+    observed = _runtime_parameter_explicit_owner_username(value)
+    return observed is None or observed == expected
+
+
+def _runtime_parameter_explicit_owner_username(value: JsonObject) -> str | None:
+    for field in ("username", "ownerUsername", "owner_username", "userName", "user_name"):
+        observed = _non_empty_text(value.get(field))
+        if observed is not None:
+            return observed
+    for field in ("owner", "user"):
+        nested = value.get(field)
+        if isinstance(nested, dict):
+            observed = _runtime_parameter_nested_owner_username(nested)
+            if observed is not None:
+                return observed
+        elif field == "owner":
+            observed = _runtime_parameter_scalar_owner_username(nested)
+            if observed is not None:
+                return observed
+    return None
+
+
+def _runtime_parameter_nested_owner_username(value: JsonObject) -> str | None:
+    for field in ("username", "ownerUsername", "owner_username", "userName", "user_name", "name"):
+        observed = _non_empty_text(value.get(field))
+        if observed is not None:
+            return observed
+    return None
+
+
+def _runtime_parameter_scalar_owner_username(value: Any) -> str | None:
+    observed = _non_empty_text(value)
+    if observed is None or re.fullmatch(r"[0-9a-fA-F]{24}", observed):
+        return None
+    return observed
+
+
 def collect_runtime_parameter_consumption_evidence(
     smoke: Any,
     compose: Sequence[str] | None,
@@ -853,6 +894,7 @@ def _collect_redis_runtime_parameter_consumption_evidence(
     if compose is None:
         return None
     eval_script = """
+local expectedUsername = tostring(ARGV[1] or "")
 local cursor = "0"
 local candidates = {}
 local seen = {}
@@ -881,8 +923,58 @@ local function decodedRuntimePolicyParameterValue(value)
   end
   return nil
 end
+local function nonEmptyString(value)
+  if type(value) == "string" and value ~= "" then
+    return value
+  end
+  return nil
+end
+local function scalarOwnerUsername(value)
+  local text = nonEmptyString(value)
+  if text == nil then
+    return nil
+  end
+  if string.len(text) == 24 and string.match(text, "^[0-9a-fA-F]+$") then
+    return nil
+  end
+  return text
+end
+local function nestedOwnerUsername(value)
+  if type(value) ~= "table" then
+    return nil
+  end
+  return nonEmptyString(value.username)
+    or nonEmptyString(value.ownerUsername)
+    or nonEmptyString(value.owner_username)
+    or nonEmptyString(value.userName)
+    or nonEmptyString(value.user_name)
+    or nonEmptyString(value.name)
+end
+local function explicitOwnerUsername(value)
+  if type(value) ~= "table" then
+    return nil
+  end
+  return nonEmptyString(value.username)
+    or nonEmptyString(value.ownerUsername)
+    or nonEmptyString(value.owner_username)
+    or nonEmptyString(value.userName)
+    or nonEmptyString(value.user_name)
+    or nestedOwnerUsername(value.owner)
+    or nestedOwnerUsername(value.user)
+    or scalarOwnerUsername(value.owner)
+end
+local function hasDifferentExplicitOwner(value)
+  if expectedUsername == "" or type(value) ~= "table" then
+    return false
+  end
+  local observed = explicitOwnerUsername(value)
+  return observed ~= nil and observed ~= expectedUsername
+end
 local function appendRuntimePolicyParameterCandidate(source, value)
   if #candidates >= candidateLimit then
+    return
+  end
+  if hasDifferentExplicitOwner(value) then
     return
   end
   table.insert(candidates, {source = source, value = value})
@@ -893,6 +985,9 @@ local function pushRuntimePolicyParameterEvidence(source, value, depth)
   end
   local decoded = decodedRuntimePolicyParameterValue(value)
   if decoded == nil then
+    return
+  end
+  if hasDifferentExplicitOwner(decoded) then
     return
   end
   if decoded.type == "screeps-rl-runtime-policy-parameter-consumption" then
@@ -950,7 +1045,8 @@ for _, pattern in ipairs({"*memory*", "*Memory*"}) do
 end
 return cjson.encode({ok = true, candidates = candidates})
 """.strip()
-    command = [*compose, "exec", "-T", "redis", "redis-cli", "--raw", "EVAL", eval_script, "0"]
+    username = text_or_none(getattr(cfg, "username", None)) or ""
+    command = [*compose, "exec", "-T", "redis", "redis-cli", "--raw", "EVAL", eval_script, "0", username]
     result = smoke.run_command(command, cfg, timeout=60, output_limit=200000)
     if result.get("returncode") != 0:
         return None
@@ -958,7 +1054,11 @@ return cjson.encode({ok = true, candidates = candidates})
         payload = _json_payload_from_command_output(result.get("output_excerpt", ""))
     except (IndexError, json.JSONDecodeError):
         return None
-    return find_runtime_parameter_consumption_evidence(payload, injection=injection)
+    return find_runtime_parameter_consumption_evidence(
+        payload,
+        injection=injection,
+        owner_username=username,
+    )
 
 
 def _collect_mongo_runtime_parameter_consumption_evidence(
@@ -1030,9 +1130,10 @@ def find_runtime_parameter_consumption_evidence(
     payload: Any,
     *,
     injection: JsonObject | None = None,
+    owner_username: str | None = None,
 ) -> JsonObject | None:
     fallback: JsonObject | None = None
-    for candidate in iter_runtime_parameter_consumption_candidates(payload):
+    for candidate in iter_runtime_parameter_consumption_candidates(payload, owner_username=owner_username):
         if (
             isinstance(candidate, dict)
             and candidate.get("type") == RUNTIME_PARAMETER_CONSUMPTION_TYPE
@@ -1049,13 +1150,24 @@ def find_runtime_parameter_consumption_evidence(
     return fallback
 
 
-def iter_runtime_parameter_consumption_candidates(payload: Any, depth: int = 0) -> Iterable[Any]:
+def iter_runtime_parameter_consumption_candidates(
+    payload: Any,
+    depth: int = 0,
+    *,
+    owner_username: str | None = None,
+) -> Iterable[Any]:
     if depth > 4:
         return
     decoded = decode_runtime_parameter_jsonish(payload)
     if decoded is not payload:
-        yield from iter_runtime_parameter_consumption_candidates(decoded, depth + 1)
+        yield from iter_runtime_parameter_consumption_candidates(
+            decoded,
+            depth + 1,
+            owner_username=owner_username,
+        )
     if isinstance(payload, dict):
+        if not runtime_parameter_record_matches_username(payload, owner_username):
+            return
         yield payload
         for key in (
             RUNTIME_PARAMETER_CONSUMPTION_GLOBAL,
@@ -1069,14 +1181,26 @@ def iter_runtime_parameter_consumption_candidates(payload: Any, depth: int = 0) 
             "evidence",
         ):
             if key in payload:
-                yield from iter_runtime_parameter_consumption_candidates(payload[key], depth + 1)
+                yield from iter_runtime_parameter_consumption_candidates(
+                    payload[key],
+                    depth + 1,
+                    owner_username=owner_username,
+                )
         candidates = payload.get("candidates")
         if isinstance(candidates, list):
             for item in candidates:
-                yield from iter_runtime_parameter_consumption_candidates(item, depth + 1)
+                yield from iter_runtime_parameter_consumption_candidates(
+                    item,
+                    depth + 1,
+                    owner_username=owner_username,
+                )
     elif isinstance(payload, list):
         for item in payload:
-            yield from iter_runtime_parameter_consumption_candidates(item, depth + 1)
+            yield from iter_runtime_parameter_consumption_candidates(
+                item,
+                depth + 1,
+                owner_username=owner_username,
+            )
 
 
 def decode_runtime_parameter_jsonish(value: Any) -> Any:
@@ -5263,6 +5387,14 @@ def text_or_none(value: Any) -> str | None:
     if not isinstance(value, str):
         return None
     return dataset_export.redact_text(value)[:240]
+
+
+def _non_empty_text(value: Any) -> str | None:
+    text = text_or_none(value)
+    if text is None:
+        return None
+    stripped = text.strip()
+    return stripped or None
 
 
 def string_list(raw: Any, limit: int = 50) -> list[str]:

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -773,7 +773,15 @@ def runtime_parameter_record_matches_username(value: Any, username: str | None) 
     if expected is None or not isinstance(value, dict):
         return True
     observed = _runtime_parameter_explicit_owner_username(value)
-    return observed is None or observed == expected
+    return observed == expected
+
+
+def _runtime_parameter_record_has_different_username(value: Any, username: str | None) -> bool:
+    expected = _non_empty_text(username)
+    if expected is None or not isinstance(value, dict):
+        return False
+    observed = _runtime_parameter_explicit_owner_username(value)
+    return observed is not None and observed != expected
 
 
 def _runtime_parameter_explicit_owner_username(value: JsonObject) -> str | None:
@@ -787,7 +795,7 @@ def _runtime_parameter_explicit_owner_username(value: JsonObject) -> str | None:
             observed = _runtime_parameter_nested_owner_username(nested)
             if observed is not None:
                 return observed
-        elif field == "owner":
+        else:
             observed = _runtime_parameter_scalar_owner_username(nested)
             if observed is not None:
                 return observed
@@ -962,6 +970,7 @@ local function explicitOwnerUsername(value)
     or nestedOwnerUsername(value.owner)
     or nestedOwnerUsername(value.user)
     or scalarOwnerUsername(value.owner)
+    or scalarOwnerUsername(value.user)
 end
 local function hasDifferentExplicitOwner(value)
   if expectedUsername == "" or type(value) ~= "table" then
@@ -970,16 +979,38 @@ local function hasDifferentExplicitOwner(value)
   local observed = explicitOwnerUsername(value)
   return observed ~= nil and observed ~= expectedUsername
 end
-local function appendRuntimePolicyParameterCandidate(source, value)
+local function candidateValueForExpectedOwner(value, ownerMatched)
+  if expectedUsername == "" or type(value) ~= "table" then
+    return value
+  end
+  local observed = explicitOwnerUsername(value)
+  if observed ~= nil then
+    if observed == expectedUsername then
+      return value
+    end
+    return nil
+  end
+  if not ownerMatched then
+    return nil
+  end
+  local copied = {}
+  for key, item in pairs(value) do
+    copied[key] = item
+  end
+  copied.ownerUsername = expectedUsername
+  return copied
+end
+local function appendRuntimePolicyParameterCandidate(source, value, ownerMatched)
   if #candidates >= candidateLimit then
     return
   end
-  if hasDifferentExplicitOwner(value) then
+  local candidateValue = candidateValueForExpectedOwner(value, ownerMatched)
+  if candidateValue == nil then
     return
   end
-  table.insert(candidates, {source = source, value = value})
+  table.insert(candidates, {source = source, value = candidateValue})
 end
-local function pushRuntimePolicyParameterEvidence(source, value, depth)
+local function pushRuntimePolicyParameterEvidence(source, value, depth, ownerMatched)
   if depth > candidateMaxDepth or #candidates >= candidateLimit then
     return
   end
@@ -987,26 +1018,45 @@ local function pushRuntimePolicyParameterEvidence(source, value, depth)
   if decoded == nil then
     return
   end
+  local nextOwnerMatched = ownerMatched
+  if expectedUsername ~= "" then
+    local observed = explicitOwnerUsername(decoded)
+    if observed ~= nil then
+      if observed ~= expectedUsername then
+        return
+      end
+      nextOwnerMatched = true
+    end
+  end
   if hasDifferentExplicitOwner(decoded) then
     return
   end
   if decoded.type == "screeps-rl-runtime-policy-parameter-consumption" then
-    appendRuntimePolicyParameterCandidate(source, decoded)
+    appendRuntimePolicyParameterCandidate(source, decoded, nextOwnerMatched)
     return
   end
   local runtimePolicyParameters = decodedRuntimePolicyParameterValue(decoded.rlRuntimePolicyParameters)
   if runtimePolicyParameters ~= nil then
-    appendRuntimePolicyParameterCandidate(source .. ".rlRuntimePolicyParameters", runtimePolicyParameters)
+    appendRuntimePolicyParameterCandidate(
+      source .. ".rlRuntimePolicyParameters",
+      runtimePolicyParameters,
+      nextOwnerMatched
+    )
   end
   for _, key in ipairs(nestedRuntimePolicyParameterKeys) do
     if decoded[key] ~= nil then
-      pushRuntimePolicyParameterEvidence(source .. "." .. key, decoded[key], depth + 1)
+      pushRuntimePolicyParameterEvidence(source .. "." .. key, decoded[key], depth + 1, nextOwnerMatched)
     end
   end
   local nestedCandidates = decoded.candidates
   if type(nestedCandidates) == "table" then
     for index, item in ipairs(nestedCandidates) do
-      pushRuntimePolicyParameterEvidence(source .. ".candidates[" .. tostring(index) .. "]", item, depth + 1)
+      pushRuntimePolicyParameterEvidence(
+        source .. ".candidates[" .. tostring(index) .. "]",
+        item,
+        depth + 1,
+        nextOwnerMatched
+      )
       if #candidates >= candidateLimit then
         return
       end
@@ -1014,7 +1064,7 @@ local function pushRuntimePolicyParameterEvidence(source, value, depth)
   end
   if decoded[1] ~= nil then
     for index, item in ipairs(decoded) do
-      pushRuntimePolicyParameterEvidence(source .. "[" .. tostring(index) .. "]", item, depth + 1)
+      pushRuntimePolicyParameterEvidence(source .. "[" .. tostring(index) .. "]", item, depth + 1, nextOwnerMatched)
       if #candidates >= candidateLimit then
         return
       end
@@ -1022,7 +1072,7 @@ local function pushRuntimePolicyParameterEvidence(source, value, depth)
   end
 end
 local function pushRuntimePolicyParameterCandidate(source, value)
-  pushRuntimePolicyParameterEvidence(source, value, 0)
+  pushRuntimePolicyParameterEvidence(source, value, 0, false)
 end
 for _, pattern in ipairs({"*memory*", "*Memory*"}) do
   cursor = "0"
@@ -1166,9 +1216,10 @@ def iter_runtime_parameter_consumption_candidates(
             owner_username=owner_username,
         )
     if isinstance(payload, dict):
-        if not runtime_parameter_record_matches_username(payload, owner_username):
+        if _runtime_parameter_record_has_different_username(payload, owner_username):
             return
-        yield payload
+        if runtime_parameter_record_matches_username(payload, owner_username):
+            yield payload
         for key in (
             RUNTIME_PARAMETER_CONSUMPTION_GLOBAL,
             "rlRuntimePolicyParameters",

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -934,6 +934,8 @@ local candidates = {}
 local seen = {}
 local candidateLimit = 32
 local candidateMaxDepth = 6
+local scanMode = tostring(ARGV[2] or "auto")
+local genericScanRan = false
 local nestedRuntimePolicyParameterKeys = {
   "__SCREEPS_RL_RUNTIME_POLICY_PARAMETER_CONSUMPTION__",
   "runtimeParameterConsumption",
@@ -1102,7 +1104,7 @@ end
 local function pushRuntimePolicyParameterCandidate(source, value, depth, ownerMatched)
   pushRuntimePolicyParameterEvidence(source, value, depth or 0, ownerMatched or false)
 end
-local function scanMemoryPattern(pattern)
+local function scanMemoryPattern(pattern, skipExpectedUsernameKeys)
   cursor = "0"
   repeat
     local result = redis.call("SCAN", cursor, "MATCH", pattern, "COUNT", 100)
@@ -1110,16 +1112,27 @@ local function scanMemoryPattern(pattern)
     for _, key in ipairs(result[2]) do
       local keyText = tostring(key)
       local keyLower = string.lower(keyText)
-      if not seen[keyText] and string.find(keyLower, "memory", 1, true) then
+      local ownerMatched = keyMatchesExpectedUsername(keyText)
+      if
+        not seen[keyText]
+        and string.find(keyLower, "memory", 1, true)
+        and not (skipExpectedUsernameKeys and ownerMatched)
+      then
         seen[keyText] = true
         local keyType = redis.call("TYPE", key).ok
         if keyType == "string" then
           local value = redis.call("GET", key)
-          pushRuntimePolicyParameterCandidate("redis." .. keyText, value, 0, keyMatchesExpectedUsername(keyText))
+          pushRuntimePolicyParameterCandidate("redis." .. keyText, value, 0, ownerMatched)
         end
       end
     end
   until cursor == "0"
+end
+local function scanGenericMemoryPatterns(skipExpectedUsernameKeys)
+  genericScanRan = true
+  for _, pattern in ipairs({"*memory*", "*Memory*"}) do
+    scanMemoryPattern(pattern, skipExpectedUsernameKeys or false)
+  end
 end
 local scanPatterns = {}
 if expectedUsername ~= "" then
@@ -1131,20 +1144,73 @@ if expectedUsername ~= "" then
     "*" .. escapedUsername .. "*Memory*",
   }
 end
-for _, pattern in ipairs(scanPatterns) do
-  scanMemoryPattern(pattern)
-end
-if #candidates == 0 then
-  for _, pattern in ipairs({"*memory*", "*Memory*"}) do
-    scanMemoryPattern(pattern)
+if scanMode == "generic" then
+  scanGenericMemoryPatterns(true)
+else
+  for _, pattern in ipairs(scanPatterns) do
+    scanMemoryPattern(pattern, false)
+  end
+  if #candidates == 0 then
+    scanGenericMemoryPatterns(false)
   end
 end
-return cjson.encode({ok = true, candidates = candidates})
+return cjson.encode({ok = true, candidates = candidates, genericScanRan = genericScanRan})
 """.strip()
     username = text_or_none(getattr(cfg, "username", None))
     if username is None:
         return None
+    payload = _collect_redis_runtime_parameter_payload(
+        smoke,
+        compose,
+        cfg,
+        eval_script,
+        username,
+    )
+    if payload is None:
+        return None
+    evidence = find_runtime_parameter_consumption_evidence(
+        payload,
+        injection=injection,
+        owner_username=username,
+    )
+    if (
+        injection is not None
+        and not _runtime_parameter_consumption_matches_injection(evidence, injection)
+        and isinstance(payload, dict)
+        and payload.get("genericScanRan") is False
+    ):
+        generic_payload = _collect_redis_runtime_parameter_payload(
+            smoke,
+            compose,
+            cfg,
+            eval_script,
+            username,
+            scan_mode="generic",
+        )
+        generic_evidence = find_runtime_parameter_consumption_evidence(
+            generic_payload,
+            injection=injection,
+            owner_username=username,
+        )
+        if _runtime_parameter_consumption_matches_injection(generic_evidence, injection):
+            return generic_evidence
+        if evidence is None:
+            return generic_evidence
+    return evidence
+
+
+def _collect_redis_runtime_parameter_payload(
+    smoke: Any,
+    compose: Sequence[str],
+    cfg: Any,
+    eval_script: str,
+    username: str,
+    *,
+    scan_mode: str | None = None,
+) -> JsonObject | None:
     command = [*compose, "exec", "-T", "redis", "redis-cli", "--raw", "EVAL", eval_script, "0", username]
+    if scan_mode is not None:
+        command.append(scan_mode)
     result = smoke.run_command(command, cfg, timeout=60, output_limit=200000)
     if result.get("returncode") != 0:
         return None
@@ -1152,10 +1218,16 @@ return cjson.encode({ok = true, candidates = candidates})
         payload = _json_payload_from_command_output(result.get("output_excerpt", ""))
     except (IndexError, json.JSONDecodeError):
         return None
-    return find_runtime_parameter_consumption_evidence(
-        payload,
-        injection=injection,
-        owner_username=username,
+    return payload if isinstance(payload, dict) else None
+
+
+def _runtime_parameter_consumption_matches_injection(
+    evidence: JsonObject | None,
+    injection: JsonObject,
+) -> bool:
+    return (
+        evidence is not None
+        and runtime_parameter_consumption_validation_error(injection, evidence) is None
     )
 
 

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -856,6 +856,18 @@ def _collect_redis_runtime_parameter_consumption_evidence(
 local cursor = "0"
 local candidates = {}
 local seen = {}
+local candidateLimit = 32
+local candidateMaxDepth = 6
+local nestedRuntimePolicyParameterKeys = {
+  "__SCREEPS_RL_RUNTIME_POLICY_PARAMETER_CONSUMPTION__",
+  "runtimeParameterConsumption",
+  "runtimePolicyParameterConsumption",
+  "data",
+  "memory",
+  "Memory",
+  "value",
+  "evidence",
+}
 local function decodedRuntimePolicyParameterValue(value)
   if type(value) == "table" then
     return value
@@ -869,18 +881,53 @@ local function decodedRuntimePolicyParameterValue(value)
   end
   return nil
 end
-local function pushRuntimePolicyParameterCandidate(source, value)
+local function appendRuntimePolicyParameterCandidate(source, value)
+  if #candidates >= candidateLimit then
+    return
+  end
+  table.insert(candidates, {source = source, value = value})
+end
+local function pushRuntimePolicyParameterEvidence(source, value, depth)
+  if depth > candidateMaxDepth or #candidates >= candidateLimit then
+    return
+  end
   local decoded = decodedRuntimePolicyParameterValue(value)
   if decoded == nil then
     return
   end
   if decoded.type == "screeps-rl-runtime-policy-parameter-consumption" then
-    table.insert(candidates, {source = source, value = decoded})
+    appendRuntimePolicyParameterCandidate(source, decoded)
+    return
   end
   local runtimePolicyParameters = decodedRuntimePolicyParameterValue(decoded.rlRuntimePolicyParameters)
   if runtimePolicyParameters ~= nil then
-    table.insert(candidates, {source = source .. ".rlRuntimePolicyParameters", value = runtimePolicyParameters})
+    appendRuntimePolicyParameterCandidate(source .. ".rlRuntimePolicyParameters", runtimePolicyParameters)
   end
+  for _, key in ipairs(nestedRuntimePolicyParameterKeys) do
+    if decoded[key] ~= nil then
+      pushRuntimePolicyParameterEvidence(source .. "." .. key, decoded[key], depth + 1)
+    end
+  end
+  local nestedCandidates = decoded.candidates
+  if type(nestedCandidates) == "table" then
+    for index, item in ipairs(nestedCandidates) do
+      pushRuntimePolicyParameterEvidence(source .. ".candidates[" .. tostring(index) .. "]", item, depth + 1)
+      if #candidates >= candidateLimit then
+        return
+      end
+    end
+  end
+  if decoded[1] ~= nil then
+    for index, item in ipairs(decoded) do
+      pushRuntimePolicyParameterEvidence(source .. "[" .. tostring(index) .. "]", item, depth + 1)
+      if #candidates >= candidateLimit then
+        return
+      end
+    end
+  end
+end
+local function pushRuntimePolicyParameterCandidate(source, value)
+  pushRuntimePolicyParameterEvidence(source, value, 0)
 end
 for _, pattern in ipairs({"*memory*", "*Memory*"}) do
   cursor = "0"

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -843,6 +843,32 @@ def _collect_redis_runtime_parameter_consumption_evidence(
 local cursor = "0"
 local candidates = {}
 local seen = {}
+local function decodedRuntimePolicyParameterValue(value)
+  if type(value) == "table" then
+    return value
+  end
+  if type(value) ~= "string" then
+    return nil
+  end
+  local ok, decoded = pcall(cjson.decode, value)
+  if ok and type(decoded) == "table" then
+    return decoded
+  end
+  return nil
+end
+local function pushRuntimePolicyParameterCandidate(source, value)
+  local decoded = decodedRuntimePolicyParameterValue(value)
+  if decoded == nil then
+    return
+  end
+  if decoded.type == "screeps-rl-runtime-policy-parameter-consumption" then
+    table.insert(candidates, {source = source, value = decoded})
+  end
+  local runtimePolicyParameters = decodedRuntimePolicyParameterValue(decoded.rlRuntimePolicyParameters)
+  if runtimePolicyParameters ~= nil then
+    table.insert(candidates, {source = source .. ".rlRuntimePolicyParameters", value = runtimePolicyParameters})
+  end
+end
 for _, pattern in ipairs({"*memory*", "*Memory*"}) do
   cursor = "0"
   repeat
@@ -856,9 +882,7 @@ for _, pattern in ipairs({"*memory*", "*Memory*"}) do
         local keyType = redis.call("TYPE", key).ok
         if keyType == "string" then
           local value = redis.call("GET", key)
-          if value then
-            table.insert(candidates, {source = "redis." .. keyText, value = value})
-          end
+          pushRuntimePolicyParameterCandidate("redis." .. keyText, value)
         end
       end
     end

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -776,6 +776,21 @@ def runtime_parameter_record_matches_username(value: Any, username: str | None) 
     return observed == expected
 
 
+def _runtime_parameter_record_allowed_for_username(
+    value: Any,
+    username: str | None,
+    *,
+    owner_matched: bool = False,
+) -> bool:
+    expected = _non_empty_text(username)
+    if expected is None or not isinstance(value, dict):
+        return True
+    observed = _runtime_parameter_explicit_owner_username(value)
+    if observed is not None:
+        return observed == expected
+    return owner_matched
+
+
 def _runtime_parameter_record_has_different_username(value: Any, username: str | None) -> bool:
     expected = _non_empty_text(username)
     if expected is None or not isinstance(value, dict):
@@ -815,6 +830,17 @@ def _runtime_parameter_scalar_owner_username(value: Any) -> str | None:
     if observed is None or re.fullmatch(r"[0-9a-fA-F]{24}", observed):
         return None
     return observed
+
+
+def _runtime_parameter_redis_source_matches_username(value: JsonObject, username: str | None) -> bool:
+    expected = _non_empty_text(username)
+    source = _non_empty_text(value.get("source"))
+    if expected is None or source is None:
+        return False
+    if not source.startswith("redis.") or "memory" not in source.lower():
+        return False
+    username_pattern = rf"(?<![A-Za-z0-9_-]){re.escape(expected)}(?![A-Za-z0-9_-])"
+    return re.search(username_pattern, source) is not None
 
 
 def collect_runtime_parameter_consumption_evidence(
@@ -947,6 +973,13 @@ local function scalarOwnerUsername(value)
   end
   return text
 end
+local function keyMatchesExpectedUsername(keyText)
+  if expectedUsername == "" then
+    return false
+  end
+  local escaped = string.gsub(expectedUsername, "([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1")
+  return string.find(keyText, "%f[%w_%-]" .. escaped .. "%f[^%w_%-]") ~= nil
+end
 local function nestedOwnerUsername(value)
   if type(value) ~= "table" then
     return nil
@@ -979,36 +1012,28 @@ local function hasDifferentExplicitOwner(value)
   local observed = explicitOwnerUsername(value)
   return observed ~= nil and observed ~= expectedUsername
 end
-local function candidateValueForExpectedOwner(value, ownerMatched)
+local function candidateMatchesExpectedOwner(value, ownerMatched)
   if expectedUsername == "" or type(value) ~= "table" then
-    return value
+    return true
   end
   local observed = explicitOwnerUsername(value)
   if observed ~= nil then
-    if observed == expectedUsername then
-      return value
-    end
-    return nil
+    return observed == expectedUsername
   end
-  if not ownerMatched then
-    return nil
-  end
-  local copied = {}
-  for key, item in pairs(value) do
-    copied[key] = item
-  end
-  copied.ownerUsername = expectedUsername
-  return copied
+  return ownerMatched
 end
 local function appendRuntimePolicyParameterCandidate(source, value, ownerMatched)
   if #candidates >= candidateLimit then
     return
   end
-  local candidateValue = candidateValueForExpectedOwner(value, ownerMatched)
-  if candidateValue == nil then
+  if not candidateMatchesExpectedOwner(value, ownerMatched) then
     return
   end
-  table.insert(candidates, {source = source, value = candidateValue})
+  local candidate = {source = source, value = value}
+  if expectedUsername ~= "" and ownerMatched and explicitOwnerUsername(value) == nil then
+    candidate.ownerUsername = expectedUsername
+  end
+  table.insert(candidates, candidate)
 end
 local function pushRuntimePolicyParameterEvidence(source, value, depth, ownerMatched)
   if depth > candidateMaxDepth or #candidates >= candidateLimit then
@@ -1071,8 +1096,8 @@ local function pushRuntimePolicyParameterEvidence(source, value, depth, ownerMat
     end
   end
 end
-local function pushRuntimePolicyParameterCandidate(source, value)
-  pushRuntimePolicyParameterEvidence(source, value, 0, false)
+local function pushRuntimePolicyParameterCandidate(source, value, depth, ownerMatched)
+  pushRuntimePolicyParameterEvidence(source, value, depth or 0, ownerMatched or false)
 end
 for _, pattern in ipairs({"*memory*", "*Memory*"}) do
   cursor = "0"
@@ -1087,7 +1112,7 @@ for _, pattern in ipairs({"*memory*", "*Memory*"}) do
         local keyType = redis.call("TYPE", key).ok
         if keyType == "string" then
           local value = redis.call("GET", key)
-          pushRuntimePolicyParameterCandidate("redis." .. keyText, value)
+          pushRuntimePolicyParameterCandidate("redis." .. keyText, value, 0, keyMatchesExpectedUsername(keyText))
         end
       end
     end
@@ -1205,6 +1230,7 @@ def iter_runtime_parameter_consumption_candidates(
     depth: int = 0,
     *,
     owner_username: str | None = None,
+    owner_matched: bool = False,
 ) -> Iterable[Any]:
     if depth > 4:
         return
@@ -1214,11 +1240,21 @@ def iter_runtime_parameter_consumption_candidates(
             decoded,
             depth + 1,
             owner_username=owner_username,
+            owner_matched=owner_matched,
         )
     if isinstance(payload, dict):
         if _runtime_parameter_record_has_different_username(payload, owner_username):
             return
-        if runtime_parameter_record_matches_username(payload, owner_username):
+        next_owner_matched = (
+            owner_matched
+            or runtime_parameter_record_matches_username(payload, owner_username)
+            or _runtime_parameter_redis_source_matches_username(payload, owner_username)
+        )
+        if _runtime_parameter_record_allowed_for_username(
+            payload,
+            owner_username,
+            owner_matched=owner_matched,
+        ):
             yield payload
         for key in (
             RUNTIME_PARAMETER_CONSUMPTION_GLOBAL,
@@ -1236,6 +1272,7 @@ def iter_runtime_parameter_consumption_candidates(
                     payload[key],
                     depth + 1,
                     owner_username=owner_username,
+                    owner_matched=next_owner_matched,
                 )
         candidates = payload.get("candidates")
         if isinstance(candidates, list):
@@ -1244,6 +1281,7 @@ def iter_runtime_parameter_consumption_candidates(
                     item,
                     depth + 1,
                     owner_username=owner_username,
+                    owner_matched=next_owner_matched,
                 )
     elif isinstance(payload, list):
         for item in payload:
@@ -1251,6 +1289,7 @@ def iter_runtime_parameter_consumption_candidates(
                 item,
                 depth + 1,
                 owner_username=owner_username,
+                owner_matched=owner_matched,
             )
 
 

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -980,6 +980,9 @@ local function keyMatchesExpectedUsername(keyText)
   local escaped = string.gsub(expectedUsername, "([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1")
   return string.find(keyText, "%f[%w_%-]" .. escaped .. "%f[^%w_%-]") ~= nil
 end
+local function redisGlobLiteral(value)
+  return string.gsub(value, "([%*%?%[%]\\\\])", "\\%1")
+end
 local function nestedOwnerUsername(value)
   if type(value) ~= "table" then
     return nil
@@ -1099,7 +1102,7 @@ end
 local function pushRuntimePolicyParameterCandidate(source, value, depth, ownerMatched)
   pushRuntimePolicyParameterEvidence(source, value, depth or 0, ownerMatched or false)
 end
-for _, pattern in ipairs({"*memory*", "*Memory*"}) do
+local function scanMemoryPattern(pattern)
   cursor = "0"
   repeat
     local result = redis.call("SCAN", cursor, "MATCH", pattern, "COUNT", 100)
@@ -1118,9 +1121,29 @@ for _, pattern in ipairs({"*memory*", "*Memory*"}) do
     end
   until cursor == "0"
 end
+local scanPatterns = {}
+if expectedUsername ~= "" then
+  local escapedUsername = redisGlobLiteral(expectedUsername)
+  scanPatterns = {
+    "*memory*" .. escapedUsername .. "*",
+    "*Memory*" .. escapedUsername .. "*",
+    "*" .. escapedUsername .. "*memory*",
+    "*" .. escapedUsername .. "*Memory*",
+  }
+end
+for _, pattern in ipairs(scanPatterns) do
+  scanMemoryPattern(pattern)
+end
+if #candidates == 0 then
+  for _, pattern in ipairs({"*memory*", "*Memory*"}) do
+    scanMemoryPattern(pattern)
+  end
+end
 return cjson.encode({ok = true, candidates = candidates})
 """.strip()
-    username = text_or_none(getattr(cfg, "username", None)) or ""
+    username = text_or_none(getattr(cfg, "username", None))
+    if username is None:
+        return None
     command = [*compose, "exec", "-T", "redis", "redis-cli", "--raw", "EVAL", eval_script, "0", username]
     result = smoke.run_command(command, cfg, timeout=60, output_limit=200000)
     if result.get("returncode") != 0:

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1914,6 +1914,98 @@ cli:
 
         self.assertEqual(extracted, matching)
 
+    def test_runtime_parameter_consumption_collection_skips_stale_redis_for_valid_mongo(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        stale = self.runtime_parameter_consumption_evidence(injection)
+        stale["strategyVariantId"] = "stale-variant"
+        matching = self.runtime_parameter_consumption_evidence(injection)
+
+        with (
+            mock.patch.object(
+                harness,
+                "_collect_http_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ),
+            mock.patch.object(
+                harness,
+                "_collect_redis_runtime_parameter_consumption_evidence",
+                return_value=stale,
+            ),
+            mock.patch.object(
+                harness,
+                "_collect_mongo_runtime_parameter_consumption_evidence",
+                return_value=matching,
+            ),
+        ):
+            evidence, errors = harness.collect_runtime_parameter_consumption_evidence(
+                object(),
+                ["docker", "compose"],
+                object(),
+                None,
+                injection,
+            )
+
+        expected = copy.deepcopy(matching)
+        expected["source"] = "mongo.Memory.rlRuntimePolicyParameters"
+        self.assertEqual(evidence, expected)
+        self.assertEqual(len(errors), 1)
+        self.assertIn(
+            "redis.Memory.rlRuntimePolicyParameters returned non-matching runtime parameter consumption evidence",
+            errors[0],
+        )
+        self.assertIn("strategyVariantId disagreed", errors[0])
+
+    def test_runtime_parameter_consumption_collection_surfaces_invalid_only_evidence(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        stale = self.runtime_parameter_consumption_evidence(injection)
+        stale["parameters"] = {
+            **stale["parameters"],
+            "territorySignalWeight": stale["parameters"]["territorySignalWeight"] + 1,
+        }
+
+        with (
+            mock.patch.object(
+                harness,
+                "_collect_http_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ),
+            mock.patch.object(
+                harness,
+                "_collect_redis_runtime_parameter_consumption_evidence",
+                return_value=stale,
+            ),
+            mock.patch.object(
+                harness,
+                "_collect_mongo_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ),
+        ):
+            evidence, errors = harness.collect_runtime_parameter_consumption_evidence(
+                object(),
+                ["docker", "compose"],
+                object(),
+                None,
+                injection,
+            )
+
+        self.assertIsNotNone(evidence)
+        if evidence is None:
+            self.fail("expected invalid runtime parameter consumption evidence")
+        self.assertEqual(evidence["source"], "redis.Memory.rlRuntimePolicyParameters")
+        self.assertEqual(len(errors), 1)
+        self.assertIn("parameters disagreed", errors[0])
+
+        consumption = harness.runtime_parameter_consumption_check(
+            injection,
+            evidence,
+            source_errors=errors,
+        )
+
+        self.assertEqual(consumption["status"], "invalid")
+        self.assertFalse(consumption["runtimeParameterConsumption"])
+        self.assertEqual(consumption["source"], "redis.Memory.rlRuntimePolicyParameters")
+        self.assertIn("parameters disagreed", consumption["reason"])
+
     def test_redis_runtime_parameter_consumption_collector_reads_private_memory(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         evidence = self.runtime_parameter_consumption_evidence(injection)

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1996,6 +1996,52 @@ cli:
             )
         )
 
+    def test_ownerless_redis_runtime_consumption_requires_target_scoped_source(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        ownerless = self.runtime_parameter_consumption_evidence(injection)
+
+        cases: list[tuple[str, dict[str, object], harness.JsonObject | None]] = [
+            (
+                "unscoped-memory-key",
+                {"source": "redis.memory:unknown.rlRuntimePolicyParameters", "value": ownerless},
+                None,
+            ),
+            (
+                "other-user-memory-key",
+                {"source": "redis.memory:other.rlRuntimePolicyParameters", "value": ownerless},
+                None,
+            ),
+            (
+                "username-prefix-only",
+                {"source": "redis.memory:bot2.rlRuntimePolicyParameters", "value": ownerless},
+                None,
+            ),
+            (
+                "target-user-memory-key",
+                {"source": "redis.memory:bot.rlRuntimePolicyParameters", "value": ownerless},
+                ownerless,
+            ),
+            (
+                "target-user-wrapper",
+                {
+                    "source": "redis.memory:opaque.rlRuntimePolicyParameters",
+                    "ownerUsername": "bot",
+                    "value": ownerless,
+                },
+                ownerless,
+            ),
+        ]
+
+        for name, candidate, expected in cases:
+            with self.subTest(name=name):
+                extracted = harness.find_runtime_parameter_consumption_evidence(
+                    {"ok": True, "candidates": [candidate]},
+                    injection=injection,
+                    owner_username="bot",
+                )
+
+                self.assertEqual(extracted, expected)
+
     def test_runtime_parameter_consumption_collection_skips_stale_redis_for_valid_mongo(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         stale = self.runtime_parameter_consumption_evidence(injection)
@@ -2144,6 +2190,11 @@ cli:
         self.assertIn("SCAN", eval_script)
         self.assertIn("*memory*", eval_script)
         self.assertIn("*Memory*", eval_script)
+        self.assertIn("redisGlobLiteral", eval_script)
+        self.assertIn('"*memory*" .. escapedUsername .. "*"', eval_script)
+        self.assertIn('"*" .. escapedUsername .. "*Memory*"', eval_script)
+        self.assertIn("scanMemoryPattern(pattern)", eval_script)
+        self.assertIn("if #candidates == 0 then", eval_script)
         self.assertEqual(command[-2:], ["0", "bot"])
         self.assertIn("pcall(cjson.decode, value)", eval_script)
         self.assertIn('decoded.type == "screeps-rl-runtime-policy-parameter-consumption"', eval_script)
@@ -2155,6 +2206,110 @@ cli:
         self.assertIn("candidateMatchesExpectedOwner", eval_script)
         self.assertIn("candidate.ownerUsername = expectedUsername", eval_script)
         self.assertNotIn("KEYS", eval_script)
+        self.assertNotIn('table.insert(candidates, {source = "redis." .. keyText, value = value})', eval_script)
+
+    def test_redis_runtime_parameter_consumption_collector_requires_configured_username(self) -> None:
+        class FakeConfig:
+            shard = "shardX"
+
+        class FakeSmoke:
+            called = False
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = command, cfg, timeout, output_limit
+                self.called = True
+                return {"returncode": 0, "output_excerpt": "{}"}
+
+        smoke = FakeSmoke()
+
+        extracted = harness._collect_redis_runtime_parameter_consumption_evidence(
+            smoke,
+            ["docker", "compose"],
+            FakeConfig(),
+            None,
+        )
+
+        self.assertIsNone(extracted)
+        self.assertFalse(smoke.called)
+
+    def test_redis_runtime_parameter_consumption_collector_returns_minimal_policy_subobjects(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+
+        class FakeConfig:
+            shard = "shardX"
+            username = "bot"
+
+        class FakeSmoke:
+            command: list[str] | None = None
+            output_excerpt: str | None = None
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout
+                self.command = command
+                eval_script = command[-3]
+                raw_memory = {
+                    "creeps": {
+                        "Worker1": {
+                            "memory": {
+                                "role": "worker",
+                                "largeUnrelatedState": "x" * output_limit,
+                            },
+                        },
+                    },
+                    "rooms": {"E1S1": {"largeUnrelatedState": "y" * output_limit}},
+                    "rlRuntimePolicyParameters": evidence,
+                }
+                candidates: list[dict[str, object]] = []
+                if (
+                    "pcall(cjson.decode, value)" in eval_script
+                    and "decoded.rlRuntimePolicyParameters" in eval_script
+                    and 'return cjson.encode({ok = true, candidates = candidates})' in eval_script
+                ):
+                    candidates.append({
+                        "source": "redis.memory:bot.rlRuntimePolicyParameters",
+                        "ownerUsername": "bot",
+                        "value": raw_memory["rlRuntimePolicyParameters"],
+                    })
+                self.output_excerpt = json.dumps({"ok": True, "candidates": candidates})
+                return {"returncode": 0, "output_excerpt": self.output_excerpt}
+
+        smoke = FakeSmoke()
+
+        extracted = harness._collect_redis_runtime_parameter_consumption_evidence(
+            smoke,
+            ["docker", "compose"],
+            FakeConfig(),
+            None,
+            injection,
+        )
+
+        self.assertEqual(extracted, evidence)
+        self.assertIsNotNone(smoke.command)
+        self.assertIsNotNone(smoke.output_excerpt)
+        output_excerpt = smoke.output_excerpt or ""
+        self.assertLess(len(output_excerpt), 200000)
+        self.assertNotIn("largeUnrelatedState", output_excerpt)
+        self.assertNotIn("Worker1", output_excerpt)
+        eval_script = smoke.command[-3] if smoke.command is not None else ""
+        self.assertIn("pcall(cjson.decode, value)", eval_script)
+        self.assertIn("decoded.rlRuntimePolicyParameters", eval_script)
+        self.assertIn("scanPatterns = {", eval_script)
+        self.assertIn("if #candidates == 0 then", eval_script)
         self.assertNotIn('table.insert(candidates, {source = "redis." .. keyText, value = value})', eval_script)
 
     def test_redis_runtime_parameter_consumption_collector_extracts_nested_memory_evidence(self) -> None:

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -2193,7 +2193,7 @@ cli:
         self.assertIn("redisGlobLiteral", eval_script)
         self.assertIn('"*memory*" .. escapedUsername .. "*"', eval_script)
         self.assertIn('"*" .. escapedUsername .. "*Memory*"', eval_script)
-        self.assertIn("scanMemoryPattern(pattern)", eval_script)
+        self.assertIn("scanMemoryPattern(pattern, false)", eval_script)
         self.assertIn("if #candidates == 0 then", eval_script)
         self.assertEqual(command[-2:], ["0", "bot"])
         self.assertIn("pcall(cjson.decode, value)", eval_script)
@@ -2278,7 +2278,7 @@ cli:
                 if (
                     "pcall(cjson.decode, value)" in eval_script
                     and "decoded.rlRuntimePolicyParameters" in eval_script
-                    and 'return cjson.encode({ok = true, candidates = candidates})' in eval_script
+                    and "genericScanRan = genericScanRan" in eval_script
                 ):
                     candidates.append({
                         "source": "redis.memory:bot.rlRuntimePolicyParameters",
@@ -2518,6 +2518,73 @@ cli:
                 self.assertIsNotNone(smoke.command)
                 command = smoke.command if smoke.command is not None else []
                 self.assertEqual(command[-2:], ["0", "bot"])
+
+    def test_redis_runtime_parameter_consumption_collector_scans_generic_after_stale_target_hit(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        stale = self.runtime_parameter_consumption_evidence(injection)
+        stale["owner"] = "bot"
+        stale["strategyVariantId"] = "stale-variant"
+        matching = self.runtime_parameter_consumption_evidence(injection)
+        matching["owner"] = "bot"
+
+        class FakeConfig:
+            shard = "shardX"
+            username = "bot"
+
+        class FakeSmoke:
+            commands: list[list[str]]
+
+            def __init__(self) -> None:
+                self.commands = []
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout, output_limit
+                self.commands.append(command)
+                if command[-1] == "generic":
+                    return {
+                        "returncode": 0,
+                        "output_excerpt": json.dumps({
+                            "ok": True,
+                            "genericScanRan": True,
+                            "candidates": [{"source": "redis.Memory", "value": matching}],
+                        }),
+                    }
+                return {
+                    "returncode": 0,
+                    "output_excerpt": json.dumps({
+                        "ok": True,
+                        "genericScanRan": False,
+                        "candidates": [
+                            {"source": "redis.memory:bot.rlRuntimePolicyParameters", "value": stale}
+                        ],
+                    }),
+                }
+
+        smoke = FakeSmoke()
+
+        extracted = harness._collect_redis_runtime_parameter_consumption_evidence(
+            smoke,
+            ["docker", "compose"],
+            FakeConfig(),
+            None,
+            injection,
+        )
+
+        self.assertEqual(extracted, matching)
+        self.assertEqual(len(smoke.commands), 2)
+        self.assertEqual(smoke.commands[0][-2:], ["0", "bot"])
+        self.assertEqual(smoke.commands[1][-3:], ["0", "bot", "generic"])
+        eval_script = smoke.commands[0][smoke.commands[0].index("EVAL") + 1]
+        self.assertIn('scanMode == "generic"', eval_script)
+        self.assertIn("skipExpectedUsernameKeys", eval_script)
+        self.assertIn("genericScanRan", eval_script)
 
     def test_redis_runtime_parameter_consumption_collector_fails_closed_without_proof(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1940,8 +1940,8 @@ cli:
                         "ok": True,
                         "candidates": [
                             {
-                                "source": "redis.memory:user",
-                                "value": json.dumps({"rlRuntimePolicyParameters": evidence}, sort_keys=True),
+                                "source": "redis.memory:user.rlRuntimePolicyParameters",
+                                "value": evidence,
                             }
                         ],
                     }),
@@ -1960,12 +1960,96 @@ cli:
         self.assertEqual(extracted, evidence)
         self.assertIsNotNone(smoke.command)
         command = smoke.command if smoke.command is not None else []
+        self.assertEqual(command[:2], ["docker", "compose"])
+        self.assertIn("exec", command)
         self.assertIn("redis", command)
         self.assertIn("redis-cli", command)
-        self.assertIn("SCAN", command[-2])
-        self.assertIn("*memory*", command[-2])
-        self.assertIn("*Memory*", command[-2])
-        self.assertNotIn("KEYS", command[-2])
+        eval_script = command[-2]
+        self.assertIn("SCAN", eval_script)
+        self.assertIn("*memory*", eval_script)
+        self.assertIn("*Memory*", eval_script)
+        self.assertIn("pcall(cjson.decode, value)", eval_script)
+        self.assertIn('decoded.type == "screeps-rl-runtime-policy-parameter-consumption"', eval_script)
+        self.assertIn("decoded.rlRuntimePolicyParameters", eval_script)
+        self.assertNotIn("KEYS", eval_script)
+        self.assertNotIn('table.insert(candidates, {source = "redis." .. keyText, value = value})', eval_script)
+
+    def test_redis_runtime_parameter_consumption_collector_reads_direct_consumption_evidence(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+
+        class FakeConfig:
+            shard = "shardX"
+
+        class FakeSmoke:
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = command, cfg, timeout, output_limit
+                return {
+                    "returncode": 0,
+                    "output_excerpt": json.dumps({
+                        "ok": True,
+                        "candidates": [{"source": "redis.Memory:user", "value": evidence}],
+                    }),
+                }
+
+        extracted = harness._collect_redis_runtime_parameter_consumption_evidence(
+            FakeSmoke(),
+            ["docker", "compose"],
+            FakeConfig(),
+            None,
+            injection,
+        )
+
+        self.assertEqual(extracted, evidence)
+
+    def test_redis_runtime_parameter_consumption_collector_fails_closed_without_proof(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+
+        class FakeConfig:
+            shard = "shardX"
+
+        class FakeSmoke:
+            def __init__(self, output_excerpt: object) -> None:
+                self.output_excerpt = output_excerpt
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = command, cfg, timeout, output_limit
+                return {"returncode": 0, "output_excerpt": self.output_excerpt}
+
+        for output_excerpt in (
+            "not-json",
+            json.dumps({
+                "ok": True,
+                "candidates": [{"source": "redis.memory:user", "value": {"notRuntimeEvidence": True}}],
+            }),
+        ):
+            with self.subTest(output_excerpt=output_excerpt):
+                extracted = harness._collect_redis_runtime_parameter_consumption_evidence(
+                    FakeSmoke(output_excerpt),
+                    ["docker", "compose"],
+                    FakeConfig(),
+                    None,
+                    injection,
+                )
+                consumption = harness.runtime_parameter_consumption_check(injection, extracted)
+
+                self.assertIsNone(extracted)
+                self.assertEqual(consumption["status"], "missing")
+                self.assertFalse(consumption["runtimeParameterConsumption"])
 
     def test_mongo_runtime_parameter_consumption_collector_keeps_output_small(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1914,6 +1914,59 @@ cli:
 
         self.assertEqual(extracted, matching)
 
+    def test_redis_runtime_parameter_consumption_collector_reads_private_memory(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+
+        class FakeConfig:
+            shard = "shardX"
+
+        class FakeSmoke:
+            command: list[str] | None = None
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout, output_limit
+                self.command = command
+                return {
+                    "returncode": 0,
+                    "output_excerpt": json.dumps({
+                        "ok": True,
+                        "candidates": [
+                            {
+                                "source": "redis.memory:user",
+                                "value": json.dumps({"rlRuntimePolicyParameters": evidence}, sort_keys=True),
+                            }
+                        ],
+                    }),
+                }
+
+        smoke = FakeSmoke()
+
+        extracted = harness._collect_redis_runtime_parameter_consumption_evidence(
+            smoke,
+            ["docker", "compose"],
+            FakeConfig(),
+            None,
+            injection,
+        )
+
+        self.assertEqual(extracted, evidence)
+        self.assertIsNotNone(smoke.command)
+        command = smoke.command if smoke.command is not None else []
+        self.assertIn("redis", command)
+        self.assertIn("redis-cli", command)
+        self.assertIn("SCAN", command[-2])
+        self.assertIn("*memory*", command[-2])
+        self.assertIn("*Memory*", command[-2])
+        self.assertNotIn("KEYS", command[-2])
+
     def test_mongo_runtime_parameter_consumption_collector_keeps_output_small(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         evidence = self.runtime_parameter_consumption_evidence(injection)

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1934,6 +1934,54 @@ cli:
         )
         self.assertEqual(
             harness.find_runtime_parameter_consumption_evidence(
+                {"ok": True, "candidates": [{"source": "redis.memory:bot", "value": ownerless}]},
+                injection=injection,
+                owner_username="bot",
+            ),
+            ownerless,
+        )
+        self.assertEqual(
+            harness.find_runtime_parameter_consumption_evidence(
+                {
+                    "ok": True,
+                    "candidates": [
+                        {
+                            "source": "redis.memory:opaque",
+                            "ownerUsername": "bot",
+                            "value": ownerless,
+                        }
+                    ],
+                },
+                injection=injection,
+                owner_username="bot",
+            ),
+            ownerless,
+        )
+        self.assertIsNone(
+            harness.find_runtime_parameter_consumption_evidence(
+                {"ok": True, "candidates": [{"source": "redis.memory:bot2", "value": ownerless}]},
+                injection=injection,
+                owner_username="bot",
+            )
+        )
+        self.assertIsNone(
+            harness.find_runtime_parameter_consumption_evidence(
+                {
+                    "ok": True,
+                    "candidates": [
+                        {
+                            "source": "redis.memory:opaque",
+                            "ownerUsername": "other-bot",
+                            "value": ownerless,
+                        }
+                    ],
+                },
+                injection=injection,
+                owner_username="bot",
+            )
+        )
+        self.assertEqual(
+            harness.find_runtime_parameter_consumption_evidence(
                 {"ok": True, "candidates": [{"source": "redis.memory:bot", "value": current_user}]},
                 injection=injection,
                 owner_username="bot",
@@ -2103,7 +2151,9 @@ cli:
         self.assertIn("expectedUsername = tostring(ARGV[1] or \"\")", eval_script)
         self.assertIn("hasDifferentExplicitOwner", eval_script)
         self.assertIn("scalarOwnerUsername(value.user)", eval_script)
-        self.assertIn("candidateValueForExpectedOwner", eval_script)
+        self.assertIn("keyMatchesExpectedUsername(keyText)", eval_script)
+        self.assertIn("candidateMatchesExpectedOwner", eval_script)
+        self.assertIn("candidate.ownerUsername = expectedUsername", eval_script)
         self.assertNotIn("KEYS", eval_script)
         self.assertNotIn('table.insert(candidates, {source = "redis." .. keyText, value = value})', eval_script)
 
@@ -2276,6 +2326,16 @@ cli:
             (
                 "ownerless",
                 [{"source": "redis.memory:unknown.rlRuntimePolicyParameters", "value": ownerless}],
+                None,
+            ),
+            (
+                "ownerless-scoped-key",
+                [{"source": "redis.memory:bot.rlRuntimePolicyParameters", "value": ownerless}],
+                ownerless,
+            ),
+            (
+                "ownerless-key-token-prefix-only",
+                [{"source": "redis.memory:bot2.rlRuntimePolicyParameters", "value": ownerless}],
                 None,
             ),
             (

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -2066,6 +2066,82 @@ cli:
         self.assertNotIn("KEYS", eval_script)
         self.assertNotIn('table.insert(candidates, {source = "redis." .. keyText, value = value})', eval_script)
 
+    def test_redis_runtime_parameter_consumption_collector_extracts_nested_memory_evidence(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+
+        class FakeConfig:
+            shard = "shardX"
+
+        class FakeSmoke:
+            command: list[str] | None = None
+            output_excerpt: str | None = None
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout
+                self.command = command
+                eval_script = command[-2]
+                nested_prefilter_supported = all(
+                    token in eval_script
+                    for token in (
+                        "pushRuntimePolicyParameterEvidence",
+                        "runtimeParameterConsumption",
+                        "runtimePolicyParameterConsumption",
+                        "__SCREEPS_RL_RUNTIME_POLICY_PARAMETER_CONSUMPTION__",
+                        "candidateLimit = 32",
+                        "candidateMaxDepth = 6",
+                    )
+                )
+                raw_memory = {
+                    "creeps": {
+                        "Worker1": {
+                            "memory": {
+                                "role": "worker",
+                                "largeUnrelatedState": "x" * output_limit,
+                            },
+                        },
+                    },
+                    "runtimeParameterConsumption": evidence,
+                }
+                candidates = []
+                if nested_prefilter_supported:
+                    candidates.append({
+                        "source": "redis.memory:user.runtimeParameterConsumption",
+                        "value": raw_memory["runtimeParameterConsumption"],
+                    })
+                self.output_excerpt = json.dumps({"ok": True, "candidates": candidates})
+                return {"returncode": 0, "output_excerpt": self.output_excerpt}
+
+        smoke = FakeSmoke()
+
+        extracted = harness._collect_redis_runtime_parameter_consumption_evidence(
+            smoke,
+            ["docker", "compose"],
+            FakeConfig(),
+            None,
+            injection,
+        )
+
+        self.assertEqual(extracted, evidence)
+        self.assertIsNotNone(smoke.command)
+        self.assertIsNotNone(smoke.output_excerpt)
+        eval_script = smoke.command[-2] if smoke.command is not None else ""
+        output_excerpt = smoke.output_excerpt or ""
+        self.assertLess(len(output_excerpt), 200000)
+        self.assertNotIn("largeUnrelatedState", output_excerpt)
+        self.assertIn("nestedRuntimePolicyParameterKeys", eval_script)
+        self.assertIn("decoded.candidates", eval_script)
+        self.assertNotIn('table.insert(candidates, {source = "redis." .. keyText, value = value})', eval_script)
+        self.assertNotIn('source = source .. ".memory", value = decoded.memory', eval_script)
+        self.assertNotIn('source = source .. ".data", value = decoded.data', eval_script)
+
     def test_redis_runtime_parameter_consumption_collector_reads_direct_consumption_evidence(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         evidence = self.runtime_parameter_consumption_evidence(injection)

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1914,6 +1914,40 @@ cli:
 
         self.assertEqual(extracted, matching)
 
+    def test_runtime_parameter_consumption_owner_filter_requires_configured_owner(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        ownerless = self.runtime_parameter_consumption_evidence(injection)
+        current_user = self.runtime_parameter_consumption_evidence(injection)
+        current_user["user"] = "bot"
+        other_user = self.runtime_parameter_consumption_evidence(injection)
+        other_user["user"] = "other-bot"
+
+        self.assertFalse(harness.runtime_parameter_record_matches_username(ownerless, "bot"))
+        self.assertTrue(harness.runtime_parameter_record_matches_username(current_user, "bot"))
+        self.assertFalse(harness.runtime_parameter_record_matches_username(other_user, "bot"))
+        self.assertIsNone(
+            harness.find_runtime_parameter_consumption_evidence(
+                {"ok": True, "candidates": [{"source": "redis.memory:unknown", "value": ownerless}]},
+                injection=injection,
+                owner_username="bot",
+            )
+        )
+        self.assertEqual(
+            harness.find_runtime_parameter_consumption_evidence(
+                {"ok": True, "candidates": [{"source": "redis.memory:bot", "value": current_user}]},
+                injection=injection,
+                owner_username="bot",
+            ),
+            current_user,
+        )
+        self.assertIsNone(
+            harness.find_runtime_parameter_consumption_evidence(
+                {"ok": True, "candidates": [{"source": "redis.memory:other", "value": other_user}]},
+                injection=injection,
+                owner_username="bot",
+            )
+        )
+
     def test_runtime_parameter_consumption_collection_skips_stale_redis_for_valid_mongo(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         stale = self.runtime_parameter_consumption_evidence(injection)
@@ -2009,6 +2043,7 @@ cli:
     def test_redis_runtime_parameter_consumption_collector_reads_private_memory(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         evidence = self.runtime_parameter_consumption_evidence(injection)
+        evidence["user"] = "bot"
 
         class FakeConfig:
             shard = "shardX"
@@ -2067,12 +2102,15 @@ cli:
         self.assertIn("decoded.rlRuntimePolicyParameters", eval_script)
         self.assertIn("expectedUsername = tostring(ARGV[1] or \"\")", eval_script)
         self.assertIn("hasDifferentExplicitOwner", eval_script)
+        self.assertIn("scalarOwnerUsername(value.user)", eval_script)
+        self.assertIn("candidateValueForExpectedOwner", eval_script)
         self.assertNotIn("KEYS", eval_script)
         self.assertNotIn('table.insert(candidates, {source = "redis." .. keyText, value = value})', eval_script)
 
     def test_redis_runtime_parameter_consumption_collector_extracts_nested_memory_evidence(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         evidence = self.runtime_parameter_consumption_evidence(injection)
+        evidence["ownerUsername"] = "bot"
 
         class FakeConfig:
             shard = "shardX"
@@ -2150,6 +2188,7 @@ cli:
     def test_redis_runtime_parameter_consumption_collector_reads_direct_consumption_evidence(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         evidence = self.runtime_parameter_consumption_evidence(injection)
+        evidence["owner"] = "bot"
 
         class FakeConfig:
             shard = "shardX"
@@ -2187,9 +2226,11 @@ cli:
         injection = self.uploaded_runtime_parameter_injection()
         ownerless = self.runtime_parameter_consumption_evidence(injection)
         current_user = self.runtime_parameter_consumption_evidence(injection)
-        current_user["user"] = {"username": "bot"}
+        current_user["user"] = "bot"
+        nested_current_user = self.runtime_parameter_consumption_evidence(injection)
+        nested_current_user["user"] = {"username": "bot"}
         other_user = self.runtime_parameter_consumption_evidence(injection)
-        other_user["username"] = "other-bot"
+        other_user["user"] = "other-bot"
 
         class FakeConfig:
             shard = "shardX"
@@ -2228,9 +2269,14 @@ cli:
                 current_user,
             ),
             (
+                "nested-current-user",
+                [{"source": "redis.memory:bot.rlRuntimePolicyParameters", "value": nested_current_user}],
+                nested_current_user,
+            ),
+            (
                 "ownerless",
                 [{"source": "redis.memory:unknown.rlRuntimePolicyParameters", "value": ownerless}],
-                ownerless,
+                None,
             ),
             (
                 "skip-other-user-then-accept-current-user",

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -2134,6 +2134,49 @@ cli:
         self.assertEqual(consumption["source"], "redis.Memory.rlRuntimePolicyParameters")
         self.assertIn("parameters disagreed", consumption["reason"])
 
+    def test_runtime_parameter_consumption_collection_records_redis_probe_error(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+
+        with (
+            mock.patch.object(
+                harness,
+                "_collect_http_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ),
+            mock.patch.object(
+                harness,
+                "_collect_redis_runtime_parameter_consumption_evidence",
+                side_effect=RuntimeError("redis runtime-parameter probe returned malformed JSON: not-json"),
+            ),
+            mock.patch.object(
+                harness,
+                "_collect_mongo_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ),
+        ):
+            evidence, errors = harness.collect_runtime_parameter_consumption_evidence(
+                object(),
+                ["docker", "compose"],
+                object(),
+                None,
+                injection,
+            )
+
+        self.assertIsNone(evidence)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("redis.Memory.rlRuntimePolicyParameters failed", errors[0])
+        self.assertIn("malformed JSON", errors[0])
+
+        consumption = harness.runtime_parameter_consumption_check(
+            injection,
+            evidence,
+            source_errors=errors,
+        )
+
+        self.assertEqual(consumption["status"], "missing")
+        self.assertFalse(consumption["runtimeParameterConsumption"])
+        self.assertIn("redis.Memory.rlRuntimePolicyParameters failed", consumption["reason"])
+
     def test_redis_runtime_parameter_consumption_collector_reads_private_memory(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         evidence = self.runtime_parameter_consumption_evidence(injection)
@@ -2609,7 +2652,6 @@ cli:
                 return {"returncode": 0, "output_excerpt": self.output_excerpt}
 
         for output_excerpt in (
-            "not-json",
             json.dumps({
                 "ok": True,
                 "candidates": [{"source": "redis.memory:user", "value": {"notRuntimeEvidence": True}}],
@@ -2628,6 +2670,45 @@ cli:
                 self.assertIsNone(extracted)
                 self.assertEqual(consumption["status"], "missing")
                 self.assertFalse(consumption["runtimeParameterConsumption"])
+
+    def test_redis_runtime_parameter_consumption_collector_raises_on_probe_failure(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+
+        class FakeConfig:
+            shard = "shardX"
+            username = "bot"
+
+        class FakeSmoke:
+            def __init__(self, returncode: int, output_excerpt: object) -> None:
+                self.returncode = returncode
+                self.output_excerpt = output_excerpt
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = command, cfg, timeout, output_limit
+                return {"returncode": self.returncode, "output_excerpt": self.output_excerpt}
+
+        cases = [
+            ("nonzero-exit", 1, "ERR Lua execution failed", "redis runtime-parameter probe failed"),
+            ("malformed-json", 0, "not-json", "redis runtime-parameter probe returned malformed JSON"),
+        ]
+
+        for name, returncode, output_excerpt, expected_error in cases:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(RuntimeError, expected_error):
+                    harness._collect_redis_runtime_parameter_consumption_evidence(
+                        FakeSmoke(returncode, output_excerpt),
+                        ["docker", "compose"],
+                        FakeConfig(),
+                        None,
+                        injection,
+                    )
 
     def test_mongo_runtime_parameter_consumption_collector_keeps_output_small(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -2012,6 +2012,7 @@ cli:
 
         class FakeConfig:
             shard = "shardX"
+            username = "bot"
 
         class FakeSmoke:
             command: list[str] | None = None
@@ -2056,13 +2057,16 @@ cli:
         self.assertIn("exec", command)
         self.assertIn("redis", command)
         self.assertIn("redis-cli", command)
-        eval_script = command[-2]
+        eval_script = command[-3]
         self.assertIn("SCAN", eval_script)
         self.assertIn("*memory*", eval_script)
         self.assertIn("*Memory*", eval_script)
+        self.assertEqual(command[-2:], ["0", "bot"])
         self.assertIn("pcall(cjson.decode, value)", eval_script)
         self.assertIn('decoded.type == "screeps-rl-runtime-policy-parameter-consumption"', eval_script)
         self.assertIn("decoded.rlRuntimePolicyParameters", eval_script)
+        self.assertIn("expectedUsername = tostring(ARGV[1] or \"\")", eval_script)
+        self.assertIn("hasDifferentExplicitOwner", eval_script)
         self.assertNotIn("KEYS", eval_script)
         self.assertNotIn('table.insert(candidates, {source = "redis." .. keyText, value = value})', eval_script)
 
@@ -2072,6 +2076,7 @@ cli:
 
         class FakeConfig:
             shard = "shardX"
+            username = "bot"
 
         class FakeSmoke:
             command: list[str] | None = None
@@ -2087,7 +2092,7 @@ cli:
             ) -> dict[str, object]:
                 _ = cfg, timeout
                 self.command = command
-                eval_script = command[-2]
+                eval_script = command[-3]
                 nested_prefilter_supported = all(
                     token in eval_script
                     for token in (
@@ -2132,7 +2137,7 @@ cli:
         self.assertEqual(extracted, evidence)
         self.assertIsNotNone(smoke.command)
         self.assertIsNotNone(smoke.output_excerpt)
-        eval_script = smoke.command[-2] if smoke.command is not None else ""
+        eval_script = smoke.command[-3] if smoke.command is not None else ""
         output_excerpt = smoke.output_excerpt or ""
         self.assertLess(len(output_excerpt), 200000)
         self.assertNotIn("largeUnrelatedState", output_excerpt)
@@ -2148,6 +2153,7 @@ cli:
 
         class FakeConfig:
             shard = "shardX"
+            username = "bot"
 
         class FakeSmoke:
             def run_command(
@@ -2177,11 +2183,87 @@ cli:
 
         self.assertEqual(extracted, evidence)
 
+    def test_redis_runtime_parameter_consumption_collector_filters_explicit_other_owner(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        ownerless = self.runtime_parameter_consumption_evidence(injection)
+        current_user = self.runtime_parameter_consumption_evidence(injection)
+        current_user["user"] = {"username": "bot"}
+        other_user = self.runtime_parameter_consumption_evidence(injection)
+        other_user["username"] = "other-bot"
+
+        class FakeConfig:
+            shard = "shardX"
+            username = "bot"
+
+        class FakeSmoke:
+            command: list[str] | None = None
+
+            def __init__(self, candidates: list[dict[str, object]]) -> None:
+                self.candidates = candidates
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout, output_limit
+                self.command = command
+                return {
+                    "returncode": 0,
+                    "output_excerpt": json.dumps({"ok": True, "candidates": self.candidates}),
+                }
+
+        cases: list[tuple[str, list[dict[str, object]], harness.JsonObject | None]] = [
+            (
+                "other-user-only",
+                [{"source": "redis.memory:other.rlRuntimePolicyParameters", "value": other_user}],
+                None,
+            ),
+            (
+                "current-user",
+                [{"source": "redis.memory:bot.rlRuntimePolicyParameters", "value": current_user}],
+                current_user,
+            ),
+            (
+                "ownerless",
+                [{"source": "redis.memory:unknown.rlRuntimePolicyParameters", "value": ownerless}],
+                ownerless,
+            ),
+            (
+                "skip-other-user-then-accept-current-user",
+                [
+                    {"source": "redis.memory:other.rlRuntimePolicyParameters", "value": other_user},
+                    {"source": "redis.memory:bot.rlRuntimePolicyParameters", "value": current_user},
+                ],
+                current_user,
+            ),
+        ]
+
+        for name, candidates, expected in cases:
+            with self.subTest(name=name):
+                smoke = FakeSmoke(candidates)
+                extracted = harness._collect_redis_runtime_parameter_consumption_evidence(
+                    smoke,
+                    ["docker", "compose"],
+                    FakeConfig(),
+                    None,
+                    injection,
+                )
+
+                self.assertEqual(extracted, expected)
+                self.assertIsNotNone(smoke.command)
+                command = smoke.command if smoke.command is not None else []
+                self.assertEqual(command[-2:], ["0", "bot"])
+
     def test_redis_runtime_parameter_consumption_collector_fails_closed_without_proof(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
 
         class FakeConfig:
             shard = "shardX"
+            username = "bot"
 
         class FakeSmoke:
             def __init__(self, output_excerpt: object) -> None:

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -3017,6 +3017,7 @@ export const STRATEGY_REGISTRY = [
             persisted = read_json(out_dir / "policy-gradient-metadata-ranking.json")
             artifact_path = Path(report["policyUpdateArtifactPath"])
             artifact = read_json(artifact_path)
+            scorecard_payload = read_json(Path(report["scorecardArtifactPath"]))
 
         self.assertEqual(report["runtimeParameterInjection"]["status"], "not_injected")
         self.assertFalse(report["runtimeParameterInjection"]["runtimeParameterInjection"])
@@ -3035,6 +3036,12 @@ export const STRATEGY_REGISTRY = [
             "runtime_parameter_consumption_missing_scorecard_materialized",
         )
         self.assertEqual(report["candidateScorecard"]["missingPrerequisite"], "runtime_parameter_consumption")
+        self.assertEqual(report["candidateScorecard"]["overallGate"]["status"], "HOLD")
+        self.assertFalse(report["candidateScorecard"]["overallGate"]["runtimeParameterInjectionProven"])
+        self.assertEqual(scorecard_payload["overallGate"]["status"], "HOLD")
+        self.assertFalse(
+            scorecard_payload["overallGate"]["runtimeCandidateGate"]["runtimeParameterInjection"]
+        )
         self.assertTrue(report["candidateScorecard"]["validationScaleComputeBlocked"])
         self.assertTrue(report["candidateScorecard"]["scorecardUsable"])
         self.assertIsNotNone(report["candidateScorecard"]["candidateRank"])


### PR DESCRIPTION
## Summary
- adds a Redis-backed runtime parameter consumption collector for the private simulator harness so memory evidence stored outside HTTP/Mongo paths can be discovered
- reuses JSON payload parsing for Mongo/Redis collector output
- extends RL runner/scorecard tests to keep HOLD behavior explicit when consumption proof is absent

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py`
- `python3 -m unittest scripts.test_screeps_rl_simulator_harness.RlSimulatorHarnessTest.test_redis_runtime_parameter_consumption_collector_reads_private_memory scripts.test_screeps_rl_training_runner.RlTrainingRunnerTest.test_runtime_injected_reinforce_without_consumption_probe_still_requires_reward_signal scripts.test_screeps_rl_training_runner.RlTrainingRunnerTest.test_runtime_injected_metadata_ranking_materializes_reinforce_update_without_consumption_probe`

Fixes #1309

Controller evidence: commit `cbd75b93` authored by `lanyusea's bot <lanyusea@gmail.com>`; verification process `proc_9135afdd5655` completed 2026-05-21T18:09:52Z.