### PR TITLE
fix(territory): emit E29N56 intent past stale bootstrap blockers

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -6950,6 +6950,17 @@ function getActivePostClaimBootstrapBlockers(colonyName, gameTime = getGameTime1
     return blocker ? [blocker] : [];
   }).sort(comparePostClaimBootstrapBlockers);
 }
+function getIgnoredPostClaimBootstrapBlockers(colonyName, gameTime = getGameTime15()) {
+  var _a, _b;
+  const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
+  if (!isNonEmptyString10(colonyName) || !isRecord11(records)) {
+    return [];
+  }
+  return Object.values(records).flatMap((record) => {
+    const blocker = buildIgnoredPostClaimBootstrapBlockerSummary(record, colonyName, gameTime);
+    return blocker ? [blocker] : [];
+  }).sort(compareIgnoredPostClaimBootstrapBlockers);
+}
 function refreshPostClaimDefenseConstruction(colony, options = {}) {
   var _a;
   const roomName = colony.room.name;
@@ -7293,12 +7304,30 @@ function buildPostClaimBootstrapBlockerSummary(record, colonyName, gameTime) {
   if (!isAnyPostClaimBootstrapRecord(record) || record.colony !== colonyName || record.status === "ready" || !getVisibleOwnedRoom2(record.roomName)) {
     return null;
   }
-  const workerTarget = getPostClaimBootstrapWorkerTarget(record);
-  const spawnCount = countOwnedSpawnsInRoom(record.roomName);
-  const workerCount = countRoomWorkers(record.roomName);
-  if (spawnCount > 0 && workerCount >= workerTarget) {
+  const summary = buildPostClaimBootstrapBlockerState(record, gameTime);
+  if (summary.spawnCount > 0 && summary.workerCount >= summary.workerTarget) {
     return null;
   }
+  return summary;
+}
+function buildIgnoredPostClaimBootstrapBlockerSummary(record, colonyName, gameTime) {
+  if (!isAnyPostClaimBootstrapRecord(record) || record.colony !== colonyName) {
+    return null;
+  }
+  const summary = buildPostClaimBootstrapBlockerState(record, gameTime);
+  if (record.status === "ready") {
+    return { ...summary, reason: "ready" };
+  }
+  if (!getVisibleOwnedRoom2(record.roomName)) {
+    return { ...summary, reason: "notVisibleOwnedRoom" };
+  }
+  if (summary.spawnCount > 0 && summary.workerCount >= summary.workerTarget) {
+    return { ...summary, reason: "workerTargetSatisfied" };
+  }
+  return null;
+}
+function buildPostClaimBootstrapBlockerState(record, gameTime) {
+  const workerTarget = getPostClaimBootstrapWorkerTarget(record);
   return {
     colony: record.colony,
     roomName: record.roomName,
@@ -7306,12 +7335,15 @@ function buildPostClaimBootstrapBlockerSummary(record, colonyName, gameTime) {
     updatedAt: record.updatedAt,
     age: Math.max(0, Math.floor(gameTime - record.updatedAt)),
     workerTarget,
-    spawnCount,
-    workerCount
+    spawnCount: countOwnedSpawnsInRoom(record.roomName),
+    workerCount: countRoomWorkers(record.roomName)
   };
 }
 function comparePostClaimBootstrapBlockers(left, right) {
   return right.age - left.age || left.spawnCount - right.spawnCount || left.workerCount - right.workerCount || left.roomName.localeCompare(right.roomName);
+}
+function compareIgnoredPostClaimBootstrapBlockers(left, right) {
+  return comparePostClaimBootstrapBlockers(left, right) || left.reason.localeCompare(right.reason);
 }
 function comparePostClaimBootstrapRecordsForFocus(left, right) {
   return left.claimedAt - right.claimedAt || left.updatedAt - right.updatedAt || left.roomName.localeCompare(right.roomName);
@@ -7834,6 +7866,7 @@ function buildRuntimeExpansionScoringInput(colony) {
     ownedRoomCount: countVisibleOwnedRooms(colony.room.name, getControllerOwnerUsername4(colony.room.controller)),
     ...typeof ((_b = colony.room.controller) == null ? void 0 : _b.ticksToDowngrade) === "number" ? { ticksToDowngrade: colony.room.controller.ticksToDowngrade } : {},
     activePostClaimBootstrapBlockers: getActivePostClaimBootstrapBlockers(colony.room.name, gameTime),
+    ignoredPostClaimBootstrapBlockers: getIgnoredPostClaimBootstrapBlockers(colony.room.name, gameTime),
     claimedRooms: buildRuntimeClaimedRoomSynergyEvidence(
       colony.room,
       getControllerOwnerUsername4(colony.room.controller)
@@ -8069,6 +8102,7 @@ function scoreExpansionCandidate(input, candidate) {
   const rationale = [];
   const risks = [];
   const postClaimBootstrapBlocker = getActivePostClaimBootstrapBlocker(input);
+  const ignoredPostClaimBootstrapBlockers = candidate.scoutOnly === true ? getIgnoredPostClaimBootstrapBlockerSummaries(input) : [];
   const preconditions = getExpansionPreconditions(input, candidate);
   let evidenceStatus = "sufficient";
   const visible = candidate.visible !== false;
@@ -8173,7 +8207,8 @@ function scoreExpansionCandidate(input, candidate) {
     ...reservation ? { reservation } : {},
     ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...candidate.scoutOnly === true ? { scoutOnly: true } : {},
-    ...postClaimBootstrapBlocker ? { postClaimBootstrapBlocker } : {}
+    ...postClaimBootstrapBlocker ? { postClaimBootstrapBlocker } : {},
+    ...ignoredPostClaimBootstrapBlockers.length > 0 ? { ignoredPostClaimBootstrapBlockers } : {}
   };
   const recommendedAction = getPersistedExpansionCandidateRecommendedAction(scoredCandidate);
   const blockReason = getPersistedExpansionCandidateBlockReason(scoredCandidate, recommendedAction);
@@ -8380,6 +8415,9 @@ function getActivePostClaimBootstrapBlocker(input) {
   const blockers = input.activePostClaimBootstrapBlockers;
   return Array.isArray(blockers) && blockers.length > 0 ? blockers[0] : null;
 }
+function getIgnoredPostClaimBootstrapBlockerSummaries(input) {
+  return Array.isArray(input.ignoredPostClaimBootstrapBlockers) ? input.ignoredPostClaimBootstrapBlockers : [];
+}
 function isScoutOnlyRemoteCpuBucketLow(bucket) {
   return typeof bucket === "number" && Number.isFinite(bucket) && bucket < SCOUT_ONLY_REMOTE_MIN_CPU_BUCKET;
 }
@@ -8424,7 +8462,7 @@ function persistExpansionCandidateScores(colony, report, gameTime) {
   territoryMemory.expansionCandidates = [...existingCandidates, ...nextCandidates];
 }
 function toPersistedExpansionCandidateMemory(colony, candidate, gameTime, rank) {
-  var _a;
+  var _a, _b;
   const recommendedAction = getPersistedExpansionCandidateRecommendedAction(candidate);
   const blockReason = (_a = candidate.blockReason) != null ? _a : getPersistedExpansionCandidateBlockReason(candidate, recommendedAction);
   return {
@@ -8454,7 +8492,8 @@ function toPersistedExpansionCandidateMemory(colony, candidate, gameTime, rank) 
     ...candidate.risks.length > 0 ? { risks: candidate.risks } : {},
     ...candidate.preconditions.length > 0 ? { preconditions: candidate.preconditions } : {},
     ...candidate.rationale.length > 0 ? { rationale: candidate.rationale } : {},
-    ...candidate.postClaimBootstrapBlocker ? { postClaimBootstrapBlocker: candidate.postClaimBootstrapBlocker } : {}
+    ...candidate.postClaimBootstrapBlocker ? { postClaimBootstrapBlocker: candidate.postClaimBootstrapBlocker } : {},
+    ...((_b = candidate.ignoredPostClaimBootstrapBlockers) == null ? void 0 : _b.length) ? { ignoredPostClaimBootstrapBlockers: candidate.ignoredPostClaimBootstrapBlockers } : {}
   };
 }
 function getPersistedExpansionCandidateRecommendedAction(candidate) {
@@ -14813,8 +14852,10 @@ var ACTION_SCORE = {
   reserve: 800,
   scout: 420
 };
-function buildRuntimeOccupationRecommendationReport(colony, colonyWorkers) {
-  return scoreOccupationRecommendations(buildRuntimeOccupationRecommendationInput(colony, colonyWorkers));
+function buildRuntimeOccupationRecommendationReport(colony, colonyWorkers, expansionReport = buildPersistedScoutOnlyExpansionCandidateReport(colony.room.name)) {
+  return scoreOccupationRecommendations(
+    buildRuntimeOccupationRecommendationInput(colony, colonyWorkers, expansionReport)
+  );
 }
 function clearOccupationRecommendationFollowUpIntent(report) {
   report.followUpIntent = null;
@@ -15010,7 +15051,7 @@ function attachOccupationRecommendationReportColony(report, colonyName) {
   });
   return report;
 }
-function buildRuntimeOccupationRecommendationInput(colony, colonyWorkers) {
+function buildRuntimeOccupationRecommendationInput(colony, colonyWorkers, expansionReport) {
   var _a, _b;
   const colonyName = colony.room.name;
   return {
@@ -15020,10 +15061,11 @@ function buildRuntimeOccupationRecommendationInput(colony, colonyWorkers) {
     workerCount: colonyWorkers.length,
     ...typeof ((_a = colony.room.controller) == null ? void 0 : _a.level) === "number" ? { controllerLevel: colony.room.controller.level } : {},
     ...typeof ((_b = colony.room.controller) == null ? void 0 : _b.ticksToDowngrade) === "number" ? { ticksToDowngrade: colony.room.controller.ticksToDowngrade } : {},
-    candidates: buildRuntimeOccupationCandidates(colonyName)
+    candidates: buildRuntimeOccupationCandidates(colony, colonyWorkers, expansionReport)
   };
 }
-function buildRuntimeOccupationCandidates(colonyName) {
+function buildRuntimeOccupationCandidates(colony, colonyWorkers, expansionReport) {
+  const colonyName = colony.room.name;
   const candidatesByRoom = /* @__PURE__ */ new Map();
   const territoryMemory = getTerritoryMemoryRecord6();
   let order = 0;
@@ -15047,6 +15089,12 @@ function buildRuntimeOccupationCandidates(colonyName) {
       order += 1;
     }
   }
+  order = addScoutOnlyExpansionRemoteOccupationCandidates(
+    candidatesByRoom,
+    expansionReport,
+    colonyWorkers.length,
+    order
+  );
   for (const roomName of getAdjacentRoomNames4(colonyName)) {
     if (isConfiguredExpansionScoutOnlyTarget(colonyName, roomName)) {
       continue;
@@ -15065,6 +15113,102 @@ function buildRuntimeOccupationCandidates(colonyName) {
     order += 1;
   }
   return Array.from(candidatesByRoom.values()).map(enrichVisibleOccupationCandidate);
+}
+function addScoutOnlyExpansionRemoteOccupationCandidates(candidatesByRoom, expansionReport, workerCount, order) {
+  var _a, _b;
+  let nextOrder = order;
+  for (const candidate of expansionReport.candidates) {
+    if (!isActionableScoutOnlyExpansionRemoteCandidate(candidate, workerCount)) {
+      continue;
+    }
+    upsertOccupationCandidate(candidatesByRoom, {
+      roomName: candidate.roomName,
+      source: "configured",
+      order: nextOrder,
+      adjacent: candidate.adjacentToOwnedRoom,
+      visible: candidate.visible,
+      ...candidate.visible === false ? { scouted: true } : {},
+      actionHint: "reserve",
+      controller: buildScoutOnlyExpansionOccupationControllerEvidence(candidate),
+      ...candidate.controllerId ? { controllerId: candidate.controllerId } : {},
+      ...candidate.routeDistance !== void 0 ? { routeDistance: candidate.routeDistance } : {},
+      ...candidate.nearestOwnedRoomDistance !== void 0 ? { roadDistance: candidate.nearestOwnedRoomDistance } : candidate.routeDistance !== void 0 ? { roadDistance: candidate.routeDistance } : {},
+      sourceCount: candidate.sourceCount,
+      hostileCreepCount: (_a = candidate.hostileCreepCount) != null ? _a : 0,
+      hostileStructureCount: (_b = candidate.hostileStructureCount) != null ? _b : 0
+    });
+    nextOrder += 1;
+  }
+  return nextOrder;
+}
+function isActionableScoutOnlyExpansionRemoteCandidate(candidate, workerCount) {
+  var _a, _b;
+  return workerCount >= MIN_READY_WORKERS && candidate.scoutOnly === true && candidate.evidenceStatus === "sufficient" && candidate.blockReason === void 0 && candidate.requiresControllerPressure !== true && candidate.risks.length === 0 && candidate.preconditions.every(isScoutOnlyRemoteCompatibleExpansionPrecondition) && typeof candidate.sourceCount === "number" && candidate.sourceCount > 0 && ((_a = candidate.hostileCreepCount) != null ? _a : 0) === 0 && ((_b = candidate.hostileStructureCount) != null ? _b : 0) === 0 && isAdjacentScoutOnlyExpansionRemoteCandidate(candidate);
+}
+function isAdjacentScoutOnlyExpansionRemoteCandidate(candidate) {
+  return candidate.adjacentToOwnedRoom || typeof candidate.routeDistance === "number" && candidate.routeDistance <= 1 || typeof candidate.nearestOwnedRoomDistance === "number" && candidate.nearestOwnedRoomDistance <= 1;
+}
+function isScoutOnlyRemoteCompatibleExpansionPrecondition(precondition) {
+  return precondition === "wait for GCL capacity to claim another room" || precondition.startsWith("limit expansion to ");
+}
+function buildScoutOnlyExpansionOccupationControllerEvidence(candidate) {
+  const reservation = candidate.reservation;
+  return {
+    ...reservation ? { reservationUsername: reservation.username } : {},
+    ...(reservation == null ? void 0 : reservation.ticksToEnd) !== void 0 ? { reservationTicksToEnd: reservation.ticksToEnd } : {}
+  };
+}
+function buildPersistedScoutOnlyExpansionCandidateReport(colonyName) {
+  var _a;
+  const candidates = getPersistedScoutOnlyExpansionCandidates(colonyName);
+  return {
+    colonyName,
+    candidates,
+    next: (_a = candidates[0]) != null ? _a : null
+  };
+}
+function getPersistedScoutOnlyExpansionCandidates(colonyName) {
+  var _a;
+  const rawCandidates = (_a = getTerritoryMemoryRecord6()) == null ? void 0 : _a.expansionCandidates;
+  if (!Array.isArray(rawCandidates)) {
+    return [];
+  }
+  return rawCandidates.flatMap((rawCandidate) => {
+    const candidate = normalizePersistedScoutOnlyExpansionCandidate(rawCandidate, colonyName);
+    return candidate ? [candidate] : [];
+  });
+}
+function normalizePersistedScoutOnlyExpansionCandidate(rawCandidate, colonyName) {
+  if (!isRecord17(rawCandidate) || rawCandidate.colony !== colonyName || rawCandidate.scoutOnly !== true || !isNonEmptyString14(rawCandidate.roomName) || !isExpansionCandidateEvidenceStatus(rawCandidate.evidenceStatus)) {
+    return null;
+  }
+  return {
+    roomName: rawCandidate.roomName,
+    score: normalizeFiniteNumber(rawCandidate.score, 0),
+    synergyScore: 0,
+    evidenceStatus: rawCandidate.evidenceStatus,
+    visible: rawCandidate.visible === true,
+    rationale: normalizeStringArray(rawCandidate.rationale),
+    preconditions: normalizeStringArray(rawCandidate.preconditions),
+    risks: normalizeStringArray(rawCandidate.risks),
+    adjacentToOwnedRoom: rawCandidate.adjacentToOwnedRoom === true,
+    scoutOnly: true,
+    ...isExpansionCandidateBlockReason(rawCandidate.blockReason) ? { blockReason: rawCandidate.blockReason } : {},
+    ...isFiniteNumber7(rawCandidate.routeDistance) ? { routeDistance: rawCandidate.routeDistance } : {},
+    ...isNonEmptyString14(rawCandidate.nearestOwnedRoom) ? { nearestOwnedRoom: rawCandidate.nearestOwnedRoom } : {},
+    ...isFiniteNumber7(rawCandidate.nearestOwnedRoomDistance) ? { nearestOwnedRoomDistance: rawCandidate.nearestOwnedRoomDistance } : {},
+    ...isNonEmptyString14(rawCandidate.controllerId) ? { controllerId: rawCandidate.controllerId } : {},
+    ...isFiniteNumber7(rawCandidate.sourceCount) ? { sourceCount: rawCandidate.sourceCount } : {},
+    ...isFiniteNumber7(rawCandidate.hostileCreepCount) ? { hostileCreepCount: rawCandidate.hostileCreepCount } : {},
+    ...isFiniteNumber7(rawCandidate.hostileStructureCount) ? { hostileStructureCount: rawCandidate.hostileStructureCount } : {},
+    ...rawCandidate.requiresControllerPressure === true ? { requiresControllerPressure: true } : {}
+  };
+}
+function isExpansionCandidateEvidenceStatus(value) {
+  return value === "sufficient" || value === "insufficient-evidence" || value === "unavailable";
+}
+function isExpansionCandidateBlockReason(value) {
+  return value === "insufficientEvidence" || value === "targetUnavailable" || value === "targetHostile" || value === "controllerMissing" || value === "controllerOwned" || value === "controllerReserved" || value === "sourcesMissing" || value === "controllerRangeMissing" || value === "terrainMissing" || value === "energyCapacityLow" || value === "energyBufferLow" || value === "cpuBucketLow" || value === "homeAlertActive" || value === "controllerLevelLow" || value === "homeDowngradeGuard" || value === "postClaimBootstrapActive" || value === "gclInsufficient" || value === "roomLimitReached" || value === "routeUnavailable";
 }
 function upsertOccupationCandidate(candidatesByRoom, candidate) {
   const existing = candidatesByRoom.get(candidate.roomName);
@@ -15555,6 +15699,12 @@ function isNonEmptyString14(value) {
 }
 function isFiniteNumber7(value) {
   return typeof value === "number" && Number.isFinite(value);
+}
+function normalizeFiniteNumber(value, fallback) {
+  return isFiniteNumber7(value) ? value : fallback;
+}
+function normalizeStringArray(value) {
+  return Array.isArray(value) ? value.filter(isNonEmptyString14) : [];
 }
 
 // src/territory/controllerSigning.ts
@@ -36018,8 +36168,12 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
   const tick = getGameTime32();
   const colonyWorkers = colonyCreeps.filter((creep) => creep.memory.role === "worker");
   const roleCounts = countCreepsByRole(colonyCreeps, colony.room.name);
-  const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   const territoryExpansion = buildRuntimeExpansionCandidateReport(colony);
+  const territoryRecommendation = buildRuntimeOccupationRecommendationReport(
+    colony,
+    colonyWorkers,
+    territoryExpansion
+  );
   if (persistOccupationRecommendations) {
     persistOccupationRecommendationFollowUpIntent(territoryRecommendation, tick);
   }
@@ -36174,7 +36328,7 @@ function buildScoutOnlyTargetSummaries(colony, summary) {
   const expansionCandidatesByRoom = getScoutOnlyExpansionCandidatesByRoom(colonyName);
   const seenRooms = /* @__PURE__ */ new Set();
   return getTerritoryExpansionScoutTargets(colonyName).flatMap((target) => {
-    var _a2;
+    var _a2, _b2;
     if (target.colony !== colonyName || target.scoutOnly !== true || seenRooms.has(target.roomName)) {
       return [];
     }
@@ -36190,6 +36344,7 @@ function buildScoutOnlyTargetSummaries(colony, summary) {
         recommendedAction: (_a2 = expansionCandidate == null ? void 0 : expansionCandidate.recommendedAction) != null ? _a2 : "scout",
         ...(expansionCandidate == null ? void 0 : expansionCandidate.blockReason) ? { blockReason: expansionCandidate.blockReason } : {},
         ...(expansionCandidate == null ? void 0 : expansionCandidate.postClaimBootstrapBlocker) ? { postClaimBootstrapBlocker: expansionCandidate.postClaimBootstrapBlocker } : {},
+        ...((_b2 = expansionCandidate == null ? void 0 : expansionCandidate.ignoredPostClaimBootstrapBlockers) == null ? void 0 : _b2.length) ? { ignoredPostClaimBootstrapBlockers: expansionCandidate.ignoredPostClaimBootstrapBlockers } : {},
         gateOpen,
         status: getScoutOnlyTargetStatus(gateOpen, attempt, intel),
         ...(attempt == null ? void 0 : attempt.requestedAt) !== void 0 ? { requestedAt: attempt.requestedAt } : {},
@@ -36217,8 +36372,13 @@ function getScoutOnlyExpansionCandidatesByRoom(colonyName) {
     }
     candidatesByRoom.set(rawCandidate.roomName, {
       recommendedAction: isExpansionCandidateRecommendedAction2(rawCandidate.recommendedAction) ? rawCandidate.recommendedAction : "scout",
-      ...isExpansionCandidateBlockReason(rawCandidate.blockReason) ? { blockReason: rawCandidate.blockReason } : {},
-      ...isPostClaimBootstrapBlockerMemory(rawCandidate.postClaimBootstrapBlocker) ? { postClaimBootstrapBlocker: rawCandidate.postClaimBootstrapBlocker } : {}
+      ...isExpansionCandidateBlockReason2(rawCandidate.blockReason) ? { blockReason: rawCandidate.blockReason } : {},
+      ...isPostClaimBootstrapBlockerMemory(rawCandidate.postClaimBootstrapBlocker) ? { postClaimBootstrapBlocker: rawCandidate.postClaimBootstrapBlocker } : {},
+      ...Array.isArray(rawCandidate.ignoredPostClaimBootstrapBlockers) ? {
+        ignoredPostClaimBootstrapBlockers: rawCandidate.ignoredPostClaimBootstrapBlockers.filter(
+          isPostClaimBootstrapIgnoredBlockerMemory
+        )
+      } : {}
     });
   }
   return candidatesByRoom;
@@ -36226,13 +36386,23 @@ function getScoutOnlyExpansionCandidatesByRoom(colonyName) {
 function isPostClaimBootstrapBlockerMemory(value) {
   return isRecord29(value) && isNonEmptyString29(value.colony) && isNonEmptyString29(value.roomName) && isPostClaimBootstrapStatus2(value.status) && isFiniteNumber11(value.updatedAt) && isFiniteNumber11(value.age) && isFiniteNumber11(value.workerTarget) && isFiniteNumber11(value.spawnCount) && isFiniteNumber11(value.workerCount);
 }
+function isPostClaimBootstrapIgnoredBlockerMemory(value) {
+  if (!isRecord29(value)) {
+    return false;
+  }
+  const reason = value.reason;
+  return isPostClaimBootstrapBlockerMemory(value) && isPostClaimBootstrapIgnoredBlockerReason(reason);
+}
+function isPostClaimBootstrapIgnoredBlockerReason(value) {
+  return value === "ready" || value === "notVisibleOwnedRoom" || value === "workerTargetSatisfied";
+}
 function isPostClaimBootstrapStatus2(value) {
   return value === "detected" || value === "spawnSitePending" || value === "spawnSiteBlocked" || value === "spawningWorkers" || value === "ready";
 }
 function isExpansionCandidateRecommendedAction2(action) {
   return action === "claim" || action === "reserve" || action === "scout";
 }
-function isExpansionCandidateBlockReason(reason) {
+function isExpansionCandidateBlockReason2(reason) {
   return reason === "insufficientEvidence" || reason === "targetUnavailable" || reason === "targetHostile" || reason === "controllerMissing" || reason === "controllerOwned" || reason === "controllerReserved" || reason === "sourcesMissing" || reason === "controllerRangeMissing" || reason === "terrainMissing" || reason === "energyCapacityLow" || reason === "energyBufferLow" || reason === "cpuBucketLow" || reason === "homeAlertActive" || reason === "controllerLevelLow" || reason === "homeDowngradeGuard" || reason === "postClaimBootstrapActive" || reason === "gclInsufficient" || reason === "roomLimitReached" || reason === "routeUnavailable";
 }
 function getScoutOnlyTargetStatus(gateOpen, attempt, intel) {
@@ -42908,7 +43078,7 @@ function getExpansionExecutorCacheStateKey(colony, gameTime = getGameTime40()) {
     countActiveExpansionExecutorSpawns(colony),
     getExpansionExecutorVisibleHostileState(colony.room),
     getExpansionExecutorThreatState(colony.room.name, gameTime),
-    countActivePostClaimBootstraps(),
+    countActivePostClaimBootstraps(colony.room.name, gameTime),
     getAutonomousExpansionPipelineStateKey(colony.room.name),
     getLatestTerritoryScoutIntelUpdatedAt(colony.room.name)
   ].join("|");
@@ -43008,15 +43178,8 @@ function getGclLevel5() {
   const level = (_b = (_a = globalThis.Game) == null ? void 0 : _a.gcl) == null ? void 0 : _b.level;
   return typeof level === "number" && Number.isFinite(level) && level > 0 ? Math.floor(level) : null;
 }
-function countActivePostClaimBootstraps() {
-  var _a, _b;
-  const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord36(records)) {
-    return 0;
-  }
-  return Object.values(records).filter(
-    (record) => isRecord36(record) && record.status !== "ready"
-  ).length;
+function countActivePostClaimBootstraps(colonyName, gameTime) {
+  return getActivePostClaimBootstrapBlockers(colonyName, gameTime).length;
 }
 function getLatestTerritoryScoutIntelUpdatedAt(colony) {
   var _a, _b;
@@ -45792,6 +45955,7 @@ function refreshExecutableTerritoryRecommendation(colony, creeps, territoryReady
       refreshAdjacentRoomReservationIntent(colony, Game.time, { claimBlocker: "colonyUnstable" });
       return;
     }
+    report = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
     const colonyExpansionEvaluation = refreshColonyExpansionIntent(colony, { territoryReady }, Game.time);
     if (colonyExpansionEvaluation.status === "planned") {
       persistOccupationRecommendationFollowUpIntent(clearOccupationRecommendationFollowUpIntent(report), Game.time);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -15115,35 +15115,37 @@ function buildRuntimeOccupationCandidates(colony, colonyWorkers, expansionReport
   return Array.from(candidatesByRoom.values()).map(enrichVisibleOccupationCandidate);
 }
 function addScoutOnlyExpansionRemoteOccupationCandidates(candidatesByRoom, expansionReport, workerCount, order) {
-  var _a, _b;
   let nextOrder = order;
   for (const candidate of expansionReport.candidates) {
     if (!isActionableScoutOnlyExpansionRemoteCandidate(candidate, workerCount)) {
       continue;
     }
-    upsertOccupationCandidate(candidatesByRoom, {
-      roomName: candidate.roomName,
-      source: "configured",
-      order: nextOrder,
-      adjacent: candidate.adjacentToOwnedRoom,
-      visible: candidate.visible,
-      ...candidate.visible === false ? { scouted: true } : {},
-      actionHint: "reserve",
-      controller: buildScoutOnlyExpansionOccupationControllerEvidence(candidate),
-      ...candidate.controllerId ? { controllerId: candidate.controllerId } : {},
-      ...candidate.routeDistance !== void 0 ? { routeDistance: candidate.routeDistance } : {},
-      ...candidate.nearestOwnedRoomDistance !== void 0 ? { roadDistance: candidate.nearestOwnedRoomDistance } : candidate.routeDistance !== void 0 ? { roadDistance: candidate.routeDistance } : {},
-      sourceCount: candidate.sourceCount,
-      hostileCreepCount: (_a = candidate.hostileCreepCount) != null ? _a : 0,
-      hostileStructureCount: (_b = candidate.hostileStructureCount) != null ? _b : 0
-    });
+    upsertOccupationCandidate(
+      candidatesByRoom,
+      {
+        roomName: candidate.roomName,
+        source: "configured",
+        order: nextOrder,
+        adjacent: candidate.adjacentToOwnedRoom,
+        visible: candidate.visible,
+        ...candidate.visible === false ? { scouted: true } : {},
+        actionHint: "reserve",
+        controller: buildScoutOnlyExpansionOccupationControllerEvidence(candidate),
+        ...candidate.controllerId ? { controllerId: candidate.controllerId } : {},
+        ...candidate.routeDistance !== void 0 ? { routeDistance: candidate.routeDistance } : {},
+        ...candidate.nearestOwnedRoomDistance !== void 0 ? { roadDistance: candidate.nearestOwnedRoomDistance } : candidate.routeDistance !== void 0 ? { roadDistance: candidate.routeDistance } : {},
+        sourceCount: candidate.sourceCount,
+        hostileCreepCount: candidate.hostileCreepCount,
+        hostileStructureCount: candidate.hostileStructureCount
+      },
+      { preferCandidate: true }
+    );
     nextOrder += 1;
   }
   return nextOrder;
 }
 function isActionableScoutOnlyExpansionRemoteCandidate(candidate, workerCount) {
-  var _a, _b;
-  return workerCount >= MIN_READY_WORKERS && candidate.scoutOnly === true && candidate.evidenceStatus === "sufficient" && candidate.blockReason === void 0 && candidate.requiresControllerPressure !== true && candidate.risks.length === 0 && candidate.preconditions.every(isScoutOnlyRemoteCompatibleExpansionPrecondition) && typeof candidate.sourceCount === "number" && candidate.sourceCount > 0 && ((_a = candidate.hostileCreepCount) != null ? _a : 0) === 0 && ((_b = candidate.hostileStructureCount) != null ? _b : 0) === 0 && isAdjacentScoutOnlyExpansionRemoteCandidate(candidate);
+  return workerCount >= MIN_READY_WORKERS && candidate.scoutOnly === true && candidate.evidenceStatus === "sufficient" && candidate.blockReason === void 0 && candidate.requiresControllerPressure !== true && candidate.risks.length === 0 && candidate.preconditions.every(isScoutOnlyRemoteCompatibleExpansionPrecondition) && typeof candidate.sourceCount === "number" && candidate.sourceCount > 0 && typeof candidate.hostileCreepCount === "number" && typeof candidate.hostileStructureCount === "number" && candidate.hostileCreepCount === 0 && candidate.hostileStructureCount === 0 && isAdjacentScoutOnlyExpansionRemoteCandidate(candidate);
 }
 function isAdjacentScoutOnlyExpansionRemoteCandidate(candidate) {
   return candidate.adjacentToOwnedRoom || typeof candidate.routeDistance === "number" && candidate.routeDistance <= 1 || typeof candidate.nearestOwnedRoomDistance === "number" && candidate.nearestOwnedRoomDistance <= 1;
@@ -15210,10 +15212,19 @@ function isExpansionCandidateEvidenceStatus(value) {
 function isExpansionCandidateBlockReason(value) {
   return value === "insufficientEvidence" || value === "targetUnavailable" || value === "targetHostile" || value === "controllerMissing" || value === "controllerOwned" || value === "controllerReserved" || value === "sourcesMissing" || value === "controllerRangeMissing" || value === "terrainMissing" || value === "energyCapacityLow" || value === "energyBufferLow" || value === "cpuBucketLow" || value === "homeAlertActive" || value === "controllerLevelLow" || value === "homeDowngradeGuard" || value === "postClaimBootstrapActive" || value === "gclInsufficient" || value === "roomLimitReached" || value === "routeUnavailable";
 }
-function upsertOccupationCandidate(candidatesByRoom, candidate) {
+function upsertOccupationCandidate(candidatesByRoom, candidate, options = {}) {
   const existing = candidatesByRoom.get(candidate.roomName);
   if (!existing) {
     candidatesByRoom.set(candidate.roomName, candidate);
+    return;
+  }
+  if (options.preferCandidate === true) {
+    candidatesByRoom.set(candidate.roomName, {
+      ...existing,
+      ...candidate,
+      adjacent: existing.adjacent || candidate.adjacent,
+      order: Math.min(existing.order, candidate.order)
+    });
     return;
   }
   if (candidate.source === "configured" && existing.source !== "configured") {
@@ -36376,7 +36387,7 @@ function getScoutOnlyExpansionCandidatesByRoom(colonyName) {
       ...isPostClaimBootstrapBlockerMemory(rawCandidate.postClaimBootstrapBlocker) ? { postClaimBootstrapBlocker: rawCandidate.postClaimBootstrapBlocker } : {},
       ...Array.isArray(rawCandidate.ignoredPostClaimBootstrapBlockers) ? {
         ignoredPostClaimBootstrapBlockers: rawCandidate.ignoredPostClaimBootstrapBlockers.filter(
-          isPostClaimBootstrapIgnoredBlockerMemory
+          (blocker) => isPostClaimBootstrapIgnoredBlockerMemory(blocker) && blocker.colony === rawCandidate.colony
         )
       } : {}
     });

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -15219,12 +15219,16 @@ function upsertOccupationCandidate(candidatesByRoom, candidate, options = {}) {
     return;
   }
   if (options.preferCandidate === true) {
-    candidatesByRoom.set(candidate.roomName, {
+    const merged = {
       ...existing,
       ...candidate,
       adjacent: existing.adjacent || candidate.adjacent,
       order: Math.min(existing.order, candidate.order)
-    });
+    };
+    if (existing.routeDistance === null && candidate.routeDistance === void 0 && candidate.roadDistance !== void 0) {
+      delete merged.routeDistance;
+    }
+    candidatesByRoom.set(candidate.roomName, merged);
     return;
   }
   if (candidate.source === "configured" && existing.source !== "configured") {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -666,6 +666,7 @@ function refreshExecutableTerritoryRecommendation(
       return;
     }
 
+    report = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
     const colonyExpansionEvaluation = refreshColonyExpansionIntent(colony, { territoryReady }, Game.time);
     if (colonyExpansionEvaluation.status === 'planned') {
       persistOccupationRecommendationFollowUpIntent(clearOccupationRecommendationFollowUpIntent(report), Game.time);

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -319,6 +319,7 @@ interface RuntimeTerritoryScoutOnlyTargetSummary {
   recommendedAction: TerritoryExpansionCandidateRecommendedAction;
   blockReason?: TerritoryExpansionCandidateBlockReason;
   postClaimBootstrapBlocker?: TerritoryPostClaimBootstrapBlockerMemory;
+  ignoredPostClaimBootstrapBlockers?: TerritoryPostClaimBootstrapIgnoredBlockerMemory[];
   gateOpen: boolean;
   status: RuntimeTerritoryScoutOnlyTargetStatus;
   requestedAt?: number;
@@ -888,8 +889,12 @@ function summarizeRoom(
   const tick = getGameTime();
   const colonyWorkers = colonyCreeps.filter((creep) => creep.memory.role === 'worker');
   const roleCounts = countCreepsByRole(colonyCreeps, colony.room.name);
-  const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   const territoryExpansion = buildRuntimeExpansionCandidateReport(colony);
+  const territoryRecommendation = buildRuntimeOccupationRecommendationReport(
+    colony,
+    colonyWorkers,
+    territoryExpansion
+  );
   if (persistOccupationRecommendations) {
     persistOccupationRecommendationFollowUpIntent(territoryRecommendation, tick);
   }
@@ -1121,6 +1126,9 @@ function buildScoutOnlyTargetSummaries(
         ...(expansionCandidate?.postClaimBootstrapBlocker
           ? { postClaimBootstrapBlocker: expansionCandidate.postClaimBootstrapBlocker }
           : {}),
+        ...(expansionCandidate?.ignoredPostClaimBootstrapBlockers?.length
+          ? { ignoredPostClaimBootstrapBlockers: expansionCandidate.ignoredPostClaimBootstrapBlockers }
+          : {}),
         gateOpen,
         status: getScoutOnlyTargetStatus(gateOpen, attempt, intel),
         ...(attempt?.requestedAt !== undefined ? { requestedAt: attempt.requestedAt } : {}),
@@ -1140,7 +1148,13 @@ function getScoutOnlyExpansionCandidatesByRoom(
   colonyName: string
 ): Map<
   string,
-  Pick<TerritoryExpansionCandidateMemory, 'recommendedAction' | 'blockReason' | 'postClaimBootstrapBlocker'>
+  Pick<
+    TerritoryExpansionCandidateMemory,
+    | 'recommendedAction'
+    | 'blockReason'
+    | 'postClaimBootstrapBlocker'
+    | 'ignoredPostClaimBootstrapBlockers'
+  >
 > {
   const candidates = Memory.territory?.expansionCandidates;
   if (!Array.isArray(candidates)) {
@@ -1149,7 +1163,13 @@ function getScoutOnlyExpansionCandidatesByRoom(
 
   const candidatesByRoom = new Map<
     string,
-    Pick<TerritoryExpansionCandidateMemory, 'recommendedAction' | 'blockReason' | 'postClaimBootstrapBlocker'>
+    Pick<
+      TerritoryExpansionCandidateMemory,
+      | 'recommendedAction'
+      | 'blockReason'
+      | 'postClaimBootstrapBlocker'
+      | 'ignoredPostClaimBootstrapBlockers'
+    >
   >();
   for (const rawCandidate of candidates) {
     if (
@@ -1170,6 +1190,13 @@ function getScoutOnlyExpansionCandidatesByRoom(
         : {}),
       ...(isPostClaimBootstrapBlockerMemory(rawCandidate.postClaimBootstrapBlocker)
         ? { postClaimBootstrapBlocker: rawCandidate.postClaimBootstrapBlocker }
+        : {}),
+      ...(Array.isArray(rawCandidate.ignoredPostClaimBootstrapBlockers)
+        ? {
+            ignoredPostClaimBootstrapBlockers: rawCandidate.ignoredPostClaimBootstrapBlockers.filter(
+              isPostClaimBootstrapIgnoredBlockerMemory
+            )
+          }
         : {})
     });
   }
@@ -1191,6 +1218,23 @@ function isPostClaimBootstrapBlockerMemory(
     isFiniteNumber(value.spawnCount) &&
     isFiniteNumber(value.workerCount)
   );
+}
+
+function isPostClaimBootstrapIgnoredBlockerMemory(
+  value: unknown
+): value is TerritoryPostClaimBootstrapIgnoredBlockerMemory {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const reason = value.reason;
+  return isPostClaimBootstrapBlockerMemory(value) && isPostClaimBootstrapIgnoredBlockerReason(reason);
+}
+
+function isPostClaimBootstrapIgnoredBlockerReason(
+  value: unknown
+): value is TerritoryPostClaimBootstrapIgnoredBlockerReason {
+  return value === 'ready' || value === 'notVisibleOwnedRoom' || value === 'workerTargetSatisfied';
 }
 
 function isPostClaimBootstrapStatus(value: unknown): value is TerritoryPostClaimBootstrapStatus {

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -1194,7 +1194,8 @@ function getScoutOnlyExpansionCandidatesByRoom(
       ...(Array.isArray(rawCandidate.ignoredPostClaimBootstrapBlockers)
         ? {
             ignoredPostClaimBootstrapBlockers: rawCandidate.ignoredPostClaimBootstrapBlockers.filter(
-              isPostClaimBootstrapIgnoredBlockerMemory
+              (blocker): blocker is TerritoryPostClaimBootstrapIgnoredBlockerMemory =>
+                isPostClaimBootstrapIgnoredBlockerMemory(blocker) && blocker.colony === rawCandidate.colony
             )
           }
         : {})

--- a/prod/src/territory/expansionExecutor.ts
+++ b/prod/src/territory/expansionExecutor.ts
@@ -26,6 +26,7 @@ import {
 } from './roomScouting';
 import { getTerritoryScoutIntel } from './scoutIntel';
 import { logBestClaimTarget } from './territoryRunner';
+import { getActivePostClaimBootstrapBlockers } from './postClaimBootstrap';
 
 const EXPANSION_EXECUTOR_REFRESH_INTERVAL = 50;
 const EXPANSION_EXECUTOR_DOWNGRADE_GUARD_TICKS = 5_000;
@@ -272,7 +273,7 @@ function getExpansionExecutorCacheStateKey(colony: ColonySnapshot, gameTime = ge
     countActiveExpansionExecutorSpawns(colony),
     getExpansionExecutorVisibleHostileState(colony.room),
     getExpansionExecutorThreatState(colony.room.name, gameTime),
-    countActivePostClaimBootstraps(),
+    countActivePostClaimBootstraps(colony.room.name, gameTime),
     getAutonomousExpansionPipelineStateKey(colony.room.name),
     getLatestTerritoryScoutIntelUpdatedAt(colony.room.name)
   ].join('|');
@@ -400,15 +401,8 @@ function getGclLevel(): number | null {
   return typeof level === 'number' && Number.isFinite(level) && level > 0 ? Math.floor(level) : null;
 }
 
-function countActivePostClaimBootstraps(): number {
-  const records = (globalThis as { Memory?: Partial<Memory> }).Memory?.territory?.postClaimBootstraps;
-  if (!isRecord(records)) {
-    return 0;
-  }
-
-  return Object.values(records).filter(
-    (record) => isRecord(record) && record.status !== 'ready'
-  ).length;
+function countActivePostClaimBootstraps(colonyName: string, gameTime: number): number {
+  return getActivePostClaimBootstrapBlockers(colonyName, gameTime).length;
 }
 
 function getLatestTerritoryScoutIntelUpdatedAt(colony: string): number {

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -32,6 +32,8 @@ import { getEffectiveRoomEnergyBufferThreshold } from '../economy/energyBuffer';
 import { isColonyRoomThreatened } from '../defense/colonyThreats';
 import {
   getActivePostClaimBootstrapBlockers,
+  getIgnoredPostClaimBootstrapBlockers,
+  type PostClaimBootstrapIgnoredBlockerSummary,
   type PostClaimBootstrapBlockerSummary
 } from './postClaimBootstrap';
 
@@ -117,6 +119,7 @@ export interface ExpansionCandidateScore {
   scoutOnly?: boolean;
   blockReason?: TerritoryExpansionCandidateBlockReason;
   postClaimBootstrapBlocker?: PostClaimBootstrapBlockerSummary;
+  ignoredPostClaimBootstrapBlockers?: PostClaimBootstrapIgnoredBlockerSummary[];
 }
 
 export interface ExpansionScoringInput {
@@ -133,6 +136,7 @@ export interface ExpansionScoringInput {
   ticksToDowngrade?: number;
   activePostClaimBootstrapCount?: number;
   activePostClaimBootstrapBlockers?: PostClaimBootstrapBlockerSummary[];
+  ignoredPostClaimBootstrapBlockers?: PostClaimBootstrapIgnoredBlockerSummary[];
   claimedRooms?: ExpansionClaimedRoomInput[];
   candidates: ExpansionCandidateInput[];
 }
@@ -400,6 +404,7 @@ function buildRuntimeExpansionScoringInput(colony: ColonySnapshot): ExpansionSco
       ? { ticksToDowngrade: colony.room.controller.ticksToDowngrade }
       : {}),
     activePostClaimBootstrapBlockers: getActivePostClaimBootstrapBlockers(colony.room.name, gameTime),
+    ignoredPostClaimBootstrapBlockers: getIgnoredPostClaimBootstrapBlockers(colony.room.name, gameTime),
     claimedRooms: buildRuntimeClaimedRoomSynergyEvidence(
       colony.room,
       getControllerOwnerUsername(colony.room.controller)
@@ -714,6 +719,8 @@ function scoreExpansionCandidate(
   const rationale: string[] = [];
   const risks: string[] = [];
   const postClaimBootstrapBlocker = getActivePostClaimBootstrapBlocker(input);
+  const ignoredPostClaimBootstrapBlockers =
+    candidate.scoutOnly === true ? getIgnoredPostClaimBootstrapBlockerSummaries(input) : [];
   const preconditions = getExpansionPreconditions(input, candidate);
   let evidenceStatus: ExpansionCandidateEvidenceStatus = 'sufficient';
   const visible = candidate.visible !== false;
@@ -840,7 +847,10 @@ function scoreExpansionCandidate(
     ...(reservation ? { reservation } : {}),
     ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(candidate.scoutOnly === true ? { scoutOnly: true } : {}),
-    ...(postClaimBootstrapBlocker ? { postClaimBootstrapBlocker } : {})
+    ...(postClaimBootstrapBlocker ? { postClaimBootstrapBlocker } : {}),
+    ...(ignoredPostClaimBootstrapBlockers.length > 0
+      ? { ignoredPostClaimBootstrapBlockers }
+      : {})
   };
   const recommendedAction = getPersistedExpansionCandidateRecommendedAction(scoredCandidate);
   const blockReason = getPersistedExpansionCandidateBlockReason(scoredCandidate, recommendedAction);
@@ -1156,6 +1166,14 @@ function getActivePostClaimBootstrapBlocker(input: ExpansionScoringInput): PostC
   return Array.isArray(blockers) && blockers.length > 0 ? blockers[0] : null;
 }
 
+function getIgnoredPostClaimBootstrapBlockerSummaries(
+  input: ExpansionScoringInput
+): PostClaimBootstrapIgnoredBlockerSummary[] {
+  return Array.isArray(input.ignoredPostClaimBootstrapBlockers)
+    ? input.ignoredPostClaimBootstrapBlockers
+    : [];
+}
+
 function isScoutOnlyRemoteCpuBucketLow(bucket: number | undefined): boolean {
   return typeof bucket === 'number' && Number.isFinite(bucket) && bucket < SCOUT_ONLY_REMOTE_MIN_CPU_BUCKET;
 }
@@ -1314,6 +1332,9 @@ function toPersistedExpansionCandidateMemory(
     ...(candidate.rationale.length > 0 ? { rationale: candidate.rationale } : {}),
     ...(candidate.postClaimBootstrapBlocker
       ? { postClaimBootstrapBlocker: candidate.postClaimBootstrapBlocker }
+      : {}),
+    ...(candidate.ignoredPostClaimBootstrapBlockers?.length
+      ? { ignoredPostClaimBootstrapBlockers: candidate.ignoredPostClaimBootstrapBlockers }
       : {})
   };
 }

--- a/prod/src/territory/occupationRecommendation.ts
+++ b/prod/src/territory/occupationRecommendation.ts
@@ -705,12 +705,16 @@ function upsertOccupationCandidate(
   }
 
   if (options.preferCandidate === true) {
-    candidatesByRoom.set(candidate.roomName, {
+    const merged: OccupationRecommendationCandidateInput = {
       ...existing,
       ...candidate,
       adjacent: existing.adjacent || candidate.adjacent,
       order: Math.min(existing.order, candidate.order)
-    });
+    };
+    if (existing.routeDistance === null && candidate.routeDistance === undefined && candidate.roadDistance !== undefined) {
+      delete merged.routeDistance;
+    }
+    candidatesByRoom.set(candidate.roomName, merged);
     return;
   }
 

--- a/prod/src/territory/occupationRecommendation.ts
+++ b/prod/src/territory/occupationRecommendation.ts
@@ -514,26 +514,30 @@ function addScoutOnlyExpansionRemoteOccupationCandidates(
       continue;
     }
 
-    upsertOccupationCandidate(candidatesByRoom, {
-      roomName: candidate.roomName,
-      source: 'configured',
-      order: nextOrder,
-      adjacent: candidate.adjacentToOwnedRoom,
-      visible: candidate.visible,
-      ...(candidate.visible === false ? { scouted: true } : {}),
-      actionHint: 'reserve',
-      controller: buildScoutOnlyExpansionOccupationControllerEvidence(candidate),
-      ...(candidate.controllerId ? { controllerId: candidate.controllerId } : {}),
-      ...(candidate.routeDistance !== undefined ? { routeDistance: candidate.routeDistance } : {}),
-      ...(candidate.nearestOwnedRoomDistance !== undefined
-        ? { roadDistance: candidate.nearestOwnedRoomDistance }
-        : candidate.routeDistance !== undefined
-          ? { roadDistance: candidate.routeDistance }
-          : {}),
-      sourceCount: candidate.sourceCount,
-      hostileCreepCount: candidate.hostileCreepCount ?? 0,
-      hostileStructureCount: candidate.hostileStructureCount ?? 0
-    });
+    upsertOccupationCandidate(
+      candidatesByRoom,
+      {
+        roomName: candidate.roomName,
+        source: 'configured',
+        order: nextOrder,
+        adjacent: candidate.adjacentToOwnedRoom,
+        visible: candidate.visible,
+        ...(candidate.visible === false ? { scouted: true } : {}),
+        actionHint: 'reserve',
+        controller: buildScoutOnlyExpansionOccupationControllerEvidence(candidate),
+        ...(candidate.controllerId ? { controllerId: candidate.controllerId } : {}),
+        ...(candidate.routeDistance !== undefined ? { routeDistance: candidate.routeDistance } : {}),
+        ...(candidate.nearestOwnedRoomDistance !== undefined
+          ? { roadDistance: candidate.nearestOwnedRoomDistance }
+          : candidate.routeDistance !== undefined
+            ? { roadDistance: candidate.routeDistance }
+            : {}),
+        sourceCount: candidate.sourceCount,
+        hostileCreepCount: candidate.hostileCreepCount,
+        hostileStructureCount: candidate.hostileStructureCount
+      },
+      { preferCandidate: true }
+    );
     nextOrder += 1;
   }
 
@@ -543,7 +547,11 @@ function addScoutOnlyExpansionRemoteOccupationCandidates(
 function isActionableScoutOnlyExpansionRemoteCandidate(
   candidate: ExpansionCandidateScore,
   workerCount: number
-): candidate is ExpansionCandidateScore & { sourceCount: number } {
+): candidate is ExpansionCandidateScore & {
+  hostileCreepCount: number;
+  hostileStructureCount: number;
+  sourceCount: number;
+} {
   return (
     workerCount >= MIN_READY_WORKERS &&
     candidate.scoutOnly === true &&
@@ -554,8 +562,10 @@ function isActionableScoutOnlyExpansionRemoteCandidate(
     candidate.preconditions.every(isScoutOnlyRemoteCompatibleExpansionPrecondition) &&
     typeof candidate.sourceCount === 'number' &&
     candidate.sourceCount > 0 &&
-    (candidate.hostileCreepCount ?? 0) === 0 &&
-    (candidate.hostileStructureCount ?? 0) === 0 &&
+    typeof candidate.hostileCreepCount === 'number' &&
+    typeof candidate.hostileStructureCount === 'number' &&
+    candidate.hostileCreepCount === 0 &&
+    candidate.hostileStructureCount === 0 &&
     isAdjacentScoutOnlyExpansionRemoteCandidate(candidate)
   );
 }
@@ -685,11 +695,22 @@ function isExpansionCandidateBlockReason(value: unknown): value is TerritoryExpa
 
 function upsertOccupationCandidate(
   candidatesByRoom: Map<string, OccupationRecommendationCandidateInput>,
-  candidate: OccupationRecommendationCandidateInput
+  candidate: OccupationRecommendationCandidateInput,
+  options: { preferCandidate?: boolean } = {}
 ): void {
   const existing = candidatesByRoom.get(candidate.roomName);
   if (!existing) {
     candidatesByRoom.set(candidate.roomName, candidate);
+    return;
+  }
+
+  if (options.preferCandidate === true) {
+    candidatesByRoom.set(candidate.roomName, {
+      ...existing,
+      ...candidate,
+      adjacent: existing.adjacent || candidate.adjacent,
+      order: Math.min(existing.order, candidate.order)
+    });
     return;
   }
 

--- a/prod/src/territory/occupationRecommendation.ts
+++ b/prod/src/territory/occupationRecommendation.ts
@@ -1,5 +1,6 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
 import { isConfiguredExpansionScoutOnlyTarget } from './expansionConfig';
+import type { ExpansionCandidateReport, ExpansionCandidateScore } from './expansionScoring';
 import { normalizeTerritoryFollowUp, normalizeTerritoryIntents } from './territoryMemoryUtils';
 
 export type OccupationRecommendationAction = 'occupy' | 'reserve' | 'scout';
@@ -100,9 +101,12 @@ const ACTION_SCORE: Record<OccupationRecommendationAction, number> = {
 
 export function buildRuntimeOccupationRecommendationReport(
   colony: ColonySnapshot,
-  colonyWorkers: Creep[]
+  colonyWorkers: Creep[],
+  expansionReport: ExpansionCandidateReport = buildPersistedScoutOnlyExpansionCandidateReport(colony.room.name)
 ): OccupationRecommendationReport {
-  return scoreOccupationRecommendations(buildRuntimeOccupationRecommendationInput(colony, colonyWorkers));
+  return scoreOccupationRecommendations(
+    buildRuntimeOccupationRecommendationInput(colony, colonyWorkers, expansionReport)
+  );
 }
 
 export function clearOccupationRecommendationFollowUpIntent(
@@ -420,7 +424,8 @@ function attachOccupationRecommendationReportColony(
 
 function buildRuntimeOccupationRecommendationInput(
   colony: ColonySnapshot,
-  colonyWorkers: Creep[]
+  colonyWorkers: Creep[],
+  expansionReport: ExpansionCandidateReport
 ): OccupationRecommendationInput {
   const colonyName = colony.room.name;
   return {
@@ -432,11 +437,16 @@ function buildRuntimeOccupationRecommendationInput(
     ...(typeof colony.room.controller?.ticksToDowngrade === 'number'
       ? { ticksToDowngrade: colony.room.controller.ticksToDowngrade }
       : {}),
-    candidates: buildRuntimeOccupationCandidates(colonyName)
+    candidates: buildRuntimeOccupationCandidates(colony, colonyWorkers, expansionReport)
   };
 }
 
-function buildRuntimeOccupationCandidates(colonyName: string): OccupationRecommendationCandidateInput[] {
+function buildRuntimeOccupationCandidates(
+  colony: ColonySnapshot,
+  colonyWorkers: Creep[],
+  expansionReport: ExpansionCandidateReport
+): OccupationRecommendationCandidateInput[] {
+  const colonyName = colony.room.name;
   const candidatesByRoom = new Map<string, OccupationRecommendationCandidateInput>();
   const territoryMemory = getTerritoryMemoryRecord();
   let order = 0;
@@ -463,6 +473,13 @@ function buildRuntimeOccupationCandidates(colonyName: string): OccupationRecomme
     }
   }
 
+  order = addScoutOnlyExpansionRemoteOccupationCandidates(
+    candidatesByRoom,
+    expansionReport,
+    colonyWorkers.length,
+    order
+  );
+
   for (const roomName of getAdjacentRoomNames(colonyName)) {
     if (isConfiguredExpansionScoutOnlyTarget(colonyName, roomName)) {
       continue;
@@ -483,6 +500,187 @@ function buildRuntimeOccupationCandidates(colonyName: string): OccupationRecomme
   }
 
   return Array.from(candidatesByRoom.values()).map(enrichVisibleOccupationCandidate);
+}
+
+function addScoutOnlyExpansionRemoteOccupationCandidates(
+  candidatesByRoom: Map<string, OccupationRecommendationCandidateInput>,
+  expansionReport: ExpansionCandidateReport,
+  workerCount: number,
+  order: number
+): number {
+  let nextOrder = order;
+  for (const candidate of expansionReport.candidates) {
+    if (!isActionableScoutOnlyExpansionRemoteCandidate(candidate, workerCount)) {
+      continue;
+    }
+
+    upsertOccupationCandidate(candidatesByRoom, {
+      roomName: candidate.roomName,
+      source: 'configured',
+      order: nextOrder,
+      adjacent: candidate.adjacentToOwnedRoom,
+      visible: candidate.visible,
+      ...(candidate.visible === false ? { scouted: true } : {}),
+      actionHint: 'reserve',
+      controller: buildScoutOnlyExpansionOccupationControllerEvidence(candidate),
+      ...(candidate.controllerId ? { controllerId: candidate.controllerId } : {}),
+      ...(candidate.routeDistance !== undefined ? { routeDistance: candidate.routeDistance } : {}),
+      ...(candidate.nearestOwnedRoomDistance !== undefined
+        ? { roadDistance: candidate.nearestOwnedRoomDistance }
+        : candidate.routeDistance !== undefined
+          ? { roadDistance: candidate.routeDistance }
+          : {}),
+      sourceCount: candidate.sourceCount,
+      hostileCreepCount: candidate.hostileCreepCount ?? 0,
+      hostileStructureCount: candidate.hostileStructureCount ?? 0
+    });
+    nextOrder += 1;
+  }
+
+  return nextOrder;
+}
+
+function isActionableScoutOnlyExpansionRemoteCandidate(
+  candidate: ExpansionCandidateScore,
+  workerCount: number
+): candidate is ExpansionCandidateScore & { sourceCount: number } {
+  return (
+    workerCount >= MIN_READY_WORKERS &&
+    candidate.scoutOnly === true &&
+    candidate.evidenceStatus === 'sufficient' &&
+    candidate.blockReason === undefined &&
+    candidate.requiresControllerPressure !== true &&
+    candidate.risks.length === 0 &&
+    candidate.preconditions.every(isScoutOnlyRemoteCompatibleExpansionPrecondition) &&
+    typeof candidate.sourceCount === 'number' &&
+    candidate.sourceCount > 0 &&
+    (candidate.hostileCreepCount ?? 0) === 0 &&
+    (candidate.hostileStructureCount ?? 0) === 0 &&
+    isAdjacentScoutOnlyExpansionRemoteCandidate(candidate)
+  );
+}
+
+function isAdjacentScoutOnlyExpansionRemoteCandidate(candidate: ExpansionCandidateScore): boolean {
+  return (
+    candidate.adjacentToOwnedRoom ||
+    (typeof candidate.routeDistance === 'number' && candidate.routeDistance <= 1) ||
+    (typeof candidate.nearestOwnedRoomDistance === 'number' && candidate.nearestOwnedRoomDistance <= 1)
+  );
+}
+
+function isScoutOnlyRemoteCompatibleExpansionPrecondition(precondition: string): boolean {
+  return (
+    precondition === 'wait for GCL capacity to claim another room' ||
+    precondition.startsWith('limit expansion to ')
+  );
+}
+
+function buildScoutOnlyExpansionOccupationControllerEvidence(
+  candidate: ExpansionCandidateScore
+): OccupationControllerEvidence {
+  const reservation = candidate.reservation;
+  return {
+    ...(reservation ? { reservationUsername: reservation.username } : {}),
+    ...(reservation?.ticksToEnd !== undefined ? { reservationTicksToEnd: reservation.ticksToEnd } : {})
+  };
+}
+
+function buildPersistedScoutOnlyExpansionCandidateReport(colonyName: string): ExpansionCandidateReport {
+  const candidates = getPersistedScoutOnlyExpansionCandidates(colonyName);
+  return {
+    colonyName,
+    candidates,
+    next: candidates[0] ?? null
+  };
+}
+
+function getPersistedScoutOnlyExpansionCandidates(colonyName: string): ExpansionCandidateScore[] {
+  const rawCandidates = getTerritoryMemoryRecord()?.expansionCandidates;
+  if (!Array.isArray(rawCandidates)) {
+    return [];
+  }
+
+  return rawCandidates.flatMap((rawCandidate) => {
+    const candidate = normalizePersistedScoutOnlyExpansionCandidate(rawCandidate, colonyName);
+    return candidate ? [candidate] : [];
+  });
+}
+
+function normalizePersistedScoutOnlyExpansionCandidate(
+  rawCandidate: unknown,
+  colonyName: string
+): ExpansionCandidateScore | null {
+  if (
+    !isRecord(rawCandidate) ||
+    rawCandidate.colony !== colonyName ||
+    rawCandidate.scoutOnly !== true ||
+    !isNonEmptyString(rawCandidate.roomName) ||
+    !isExpansionCandidateEvidenceStatus(rawCandidate.evidenceStatus)
+  ) {
+    return null;
+  }
+
+  return {
+    roomName: rawCandidate.roomName,
+    score: normalizeFiniteNumber(rawCandidate.score, 0),
+    synergyScore: 0,
+    evidenceStatus: rawCandidate.evidenceStatus,
+    visible: rawCandidate.visible === true,
+    rationale: normalizeStringArray(rawCandidate.rationale),
+    preconditions: normalizeStringArray(rawCandidate.preconditions),
+    risks: normalizeStringArray(rawCandidate.risks),
+    adjacentToOwnedRoom: rawCandidate.adjacentToOwnedRoom === true,
+    scoutOnly: true,
+    ...(isExpansionCandidateBlockReason(rawCandidate.blockReason)
+      ? { blockReason: rawCandidate.blockReason }
+      : {}),
+    ...(isFiniteNumber(rawCandidate.routeDistance) ? { routeDistance: rawCandidate.routeDistance } : {}),
+    ...(isNonEmptyString(rawCandidate.nearestOwnedRoom)
+      ? { nearestOwnedRoom: rawCandidate.nearestOwnedRoom }
+      : {}),
+    ...(isFiniteNumber(rawCandidate.nearestOwnedRoomDistance)
+      ? { nearestOwnedRoomDistance: rawCandidate.nearestOwnedRoomDistance }
+      : {}),
+    ...(isNonEmptyString(rawCandidate.controllerId)
+      ? { controllerId: rawCandidate.controllerId as Id<StructureController> }
+      : {}),
+    ...(isFiniteNumber(rawCandidate.sourceCount) ? { sourceCount: rawCandidate.sourceCount } : {}),
+    ...(isFiniteNumber(rawCandidate.hostileCreepCount)
+      ? { hostileCreepCount: rawCandidate.hostileCreepCount }
+      : {}),
+    ...(isFiniteNumber(rawCandidate.hostileStructureCount)
+      ? { hostileStructureCount: rawCandidate.hostileStructureCount }
+      : {}),
+    ...(rawCandidate.requiresControllerPressure === true ? { requiresControllerPressure: true } : {})
+  };
+}
+
+function isExpansionCandidateEvidenceStatus(value: unknown): value is TerritoryExpansionCandidateEvidenceStatus {
+  return value === 'sufficient' || value === 'insufficient-evidence' || value === 'unavailable';
+}
+
+function isExpansionCandidateBlockReason(value: unknown): value is TerritoryExpansionCandidateBlockReason {
+  return (
+    value === 'insufficientEvidence' ||
+    value === 'targetUnavailable' ||
+    value === 'targetHostile' ||
+    value === 'controllerMissing' ||
+    value === 'controllerOwned' ||
+    value === 'controllerReserved' ||
+    value === 'sourcesMissing' ||
+    value === 'controllerRangeMissing' ||
+    value === 'terrainMissing' ||
+    value === 'energyCapacityLow' ||
+    value === 'energyBufferLow' ||
+    value === 'cpuBucketLow' ||
+    value === 'homeAlertActive' ||
+    value === 'controllerLevelLow' ||
+    value === 'homeDowngradeGuard' ||
+    value === 'postClaimBootstrapActive' ||
+    value === 'gclInsufficient' ||
+    value === 'roomLimitReached' ||
+    value === 'routeUnavailable'
+  );
 }
 
 function upsertOccupationCandidate(
@@ -1211,4 +1409,12 @@ function isNonEmptyString(value: unknown): value is string {
 
 function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
+}
+
+function normalizeFiniteNumber(value: unknown, fallback: number): number {
+  return isFiniteNumber(value) ? value : fallback;
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter(isNonEmptyString) : [];
 }

--- a/prod/src/territory/postClaimBootstrap.ts
+++ b/prod/src/territory/postClaimBootstrap.ts
@@ -165,6 +165,7 @@ export interface PostClaimDefenseConstructionRefreshResult {
 }
 
 export type PostClaimBootstrapBlockerSummary = TerritoryPostClaimBootstrapBlockerMemory;
+export type PostClaimBootstrapIgnoredBlockerSummary = TerritoryPostClaimBootstrapIgnoredBlockerMemory;
 
 export function recordPostClaimBootstrapClaimSuccess(
   input: {
@@ -386,6 +387,23 @@ export function getActivePostClaimBootstrapBlockers(
       return blocker ? [blocker] : [];
     })
     .sort(comparePostClaimBootstrapBlockers);
+}
+
+export function getIgnoredPostClaimBootstrapBlockers(
+  colonyName: string,
+  gameTime = getGameTime()
+): PostClaimBootstrapIgnoredBlockerSummary[] {
+  const records = (globalThis as { Memory?: Partial<Memory> }).Memory?.territory?.postClaimBootstraps;
+  if (!isNonEmptyString(colonyName) || !isRecord(records)) {
+    return [];
+  }
+
+  return Object.values(records)
+    .flatMap((record) => {
+      const blocker = buildIgnoredPostClaimBootstrapBlockerSummary(record, colonyName, gameTime);
+      return blocker ? [blocker] : [];
+    })
+    .sort(compareIgnoredPostClaimBootstrapBlockers);
 }
 
 export function refreshPostClaimDefenseConstruction(
@@ -854,13 +872,44 @@ function buildPostClaimBootstrapBlockerSummary(
     return null;
   }
 
-  const workerTarget = getPostClaimBootstrapWorkerTarget(record);
-  const spawnCount = countOwnedSpawnsInRoom(record.roomName);
-  const workerCount = countRoomWorkers(record.roomName);
-  if (spawnCount > 0 && workerCount >= workerTarget) {
+  const summary = buildPostClaimBootstrapBlockerState(record, gameTime);
+  if (summary.spawnCount > 0 && summary.workerCount >= summary.workerTarget) {
     return null;
   }
 
+  return summary;
+}
+
+function buildIgnoredPostClaimBootstrapBlockerSummary(
+  record: unknown,
+  colonyName: string,
+  gameTime: number
+): PostClaimBootstrapIgnoredBlockerSummary | null {
+  if (!isAnyPostClaimBootstrapRecord(record) || record.colony !== colonyName) {
+    return null;
+  }
+
+  const summary = buildPostClaimBootstrapBlockerState(record, gameTime);
+  if (record.status === 'ready') {
+    return { ...summary, reason: 'ready' };
+  }
+
+  if (!getVisibleOwnedRoom(record.roomName)) {
+    return { ...summary, reason: 'notVisibleOwnedRoom' };
+  }
+
+  if (summary.spawnCount > 0 && summary.workerCount >= summary.workerTarget) {
+    return { ...summary, reason: 'workerTargetSatisfied' };
+  }
+
+  return null;
+}
+
+function buildPostClaimBootstrapBlockerState(
+  record: TerritoryPostClaimBootstrapMemory,
+  gameTime: number
+): PostClaimBootstrapBlockerSummary {
+  const workerTarget = getPostClaimBootstrapWorkerTarget(record);
   return {
     colony: record.colony,
     roomName: record.roomName,
@@ -868,8 +917,8 @@ function buildPostClaimBootstrapBlockerSummary(
     updatedAt: record.updatedAt,
     age: Math.max(0, Math.floor(gameTime - record.updatedAt)),
     workerTarget,
-    spawnCount,
-    workerCount
+    spawnCount: countOwnedSpawnsInRoom(record.roomName),
+    workerCount: countRoomWorkers(record.roomName)
   };
 }
 
@@ -883,6 +932,13 @@ function comparePostClaimBootstrapBlockers(
     left.workerCount - right.workerCount ||
     left.roomName.localeCompare(right.roomName)
   );
+}
+
+function compareIgnoredPostClaimBootstrapBlockers(
+  left: PostClaimBootstrapIgnoredBlockerSummary,
+  right: PostClaimBootstrapIgnoredBlockerSummary
+): number {
+  return comparePostClaimBootstrapBlockers(left, right) || left.reason.localeCompare(right.reason);
 }
 
 function comparePostClaimBootstrapRecordsForFocus(

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -724,6 +724,10 @@ declare global {
     | 'spawnSiteBlocked'
     | 'spawningWorkers'
     | 'ready';
+  type TerritoryPostClaimBootstrapIgnoredBlockerReason =
+    | 'ready'
+    | 'notVisibleOwnedRoom'
+    | 'workerTargetSatisfied';
   type TerritoryExecutionHintReason =
     | 'controlEvidenceStillMissing'
     | 'followUpTargetStillUnseen'
@@ -973,6 +977,7 @@ declare global {
     preconditions?: string[];
     rationale?: string[];
     postClaimBootstrapBlocker?: TerritoryPostClaimBootstrapBlockerMemory;
+    ignoredPostClaimBootstrapBlockers?: TerritoryPostClaimBootstrapIgnoredBlockerMemory[];
   }
 
   interface TerritoryExpansionPipelineMemory {
@@ -1055,6 +1060,10 @@ declare global {
     workerTarget: number;
     spawnCount: number;
     workerCount: number;
+  }
+
+  interface TerritoryPostClaimBootstrapIgnoredBlockerMemory extends TerritoryPostClaimBootstrapBlockerMemory {
+    reason: TerritoryPostClaimBootstrapIgnoredBlockerReason;
   }
 
   interface TerritoryClaimedRoomBootstrapperMemory {

--- a/prod/test/occupationRecommendation.test.ts
+++ b/prod/test/occupationRecommendation.test.ts
@@ -6,6 +6,7 @@ import {
   type OccupationRecommendationInput,
   type OccupationRecommendationReport
 } from '../src/territory/occupationRecommendation';
+import type { ExpansionCandidateReport, ExpansionCandidateScore } from '../src/territory/expansionScoring';
 import { TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS } from '../src/territory/territoryPlanner';
 
 describe('occupation recommendation scoring', () => {
@@ -13,6 +14,9 @@ describe('occupation recommendation scoring', () => {
     delete (globalThis as { Game?: Partial<Game> }).Game;
     delete (globalThis as { Memory?: Partial<Memory> }).Memory;
     delete (globalThis as { ERR_NO_PATH?: ScreepsReturnCode }).ERR_NO_PATH;
+    delete (globalThis as { FIND_HOSTILE_CREEPS?: number }).FIND_HOSTILE_CREEPS;
+    delete (globalThis as { FIND_HOSTILE_STRUCTURES?: number }).FIND_HOSTILE_STRUCTURES;
+    delete (globalThis as { FIND_SOURCES?: number }).FIND_SOURCES;
   });
 
   it('keeps occupy recommendations ahead of richer reserve rooms', () => {
@@ -317,6 +321,70 @@ describe('occupation recommendation scoring', () => {
       routeDistance: 1
     });
     expect(report.next?.roomName).toBe('W2N1');
+  });
+
+  it('forces scout-only expansion conversions to reserve over stale configured claim targets', () => {
+    installRuntimeFindConstants();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: {
+        describeExits: jest.fn(() => ({}))
+      } as unknown as GameMap,
+      rooms: {
+        W2N1: makeVisibleRemoteRoom('W2N1')
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'claim' }]
+      }
+    };
+
+    const report = buildRuntimeOccupationRecommendationReport(
+      makeRuntimeColony(),
+      [{} as Creep, {} as Creep, {} as Creep],
+      makeScoutOnlyExpansionReport(makeScoutOnlyExpansionCandidate())
+    );
+
+    expect(report.next).toMatchObject({
+      roomName: 'W2N1',
+      action: 'reserve',
+      evidenceStatus: 'sufficient',
+      source: 'configured',
+      controllerId: 'controller-W2N1',
+      hostileCreepCount: 0,
+      hostileStructureCount: 0
+    });
+    expect(report.followUpIntent).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      controllerId: 'controller-W2N1'
+    });
+  });
+
+  it('does not convert scout-only expansion candidates with unknown hostile evidence', () => {
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: {
+        describeExits: jest.fn(() => ({}))
+      } as unknown as GameMap,
+      rooms: {}
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = { territory: {} };
+
+    const report = buildRuntimeOccupationRecommendationReport(
+      makeRuntimeColony(),
+      [{} as Creep, {} as Creep, {} as Creep],
+      makeScoutOnlyExpansionReport(
+        makeScoutOnlyExpansionCandidate({
+          hostileCreepCount: undefined,
+          hostileStructureCount: undefined
+        })
+      )
+    );
+
+    expect(report.candidates).toEqual([]);
+    expect(report.next).toBeNull();
+    expect(report.followUpIntent).toBeNull();
   });
 
   it('falls back to map route lookup for uncached nearest-owned road distance telemetry', () => {
@@ -1567,6 +1635,62 @@ function makeCandidate(
     ownedStructureCount: 0,
     ...overrides
   };
+}
+
+function makeScoutOnlyExpansionReport(candidate: ExpansionCandidateScore): ExpansionCandidateReport {
+  return {
+    colonyName: 'W1N1',
+    candidates: [candidate],
+    next: candidate
+  };
+}
+
+function makeScoutOnlyExpansionCandidate(
+  overrides: Partial<ExpansionCandidateScore> = {}
+): ExpansionCandidateScore {
+  return {
+    roomName: 'W2N1',
+    score: 900,
+    synergyScore: 0,
+    evidenceStatus: 'sufficient',
+    visible: false,
+    rationale: [],
+    preconditions: ['wait for GCL capacity to claim another room'],
+    risks: [],
+    routeDistance: 1,
+    nearestOwnedRoomDistance: 1,
+    adjacentToOwnedRoom: true,
+    controllerId: 'controller-W2N1' as Id<StructureController>,
+    sourceCount: 1,
+    hostileCreepCount: 0,
+    hostileStructureCount: 0,
+    scoutOnly: true,
+    ...overrides
+  };
+}
+
+function installRuntimeFindConstants(): void {
+  (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 101;
+  (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 102;
+  (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 103;
+}
+
+function makeVisibleRemoteRoom(roomName: string): Room {
+  return {
+    name: roomName,
+    controller: { id: `controller-${roomName}` as Id<StructureController>, my: false } as StructureController,
+    find: jest.fn((type: number): unknown[] => {
+      switch (type) {
+        case FIND_SOURCES:
+          return [{ id: `source-${roomName}` } as Source];
+        case FIND_HOSTILE_CREEPS:
+        case FIND_HOSTILE_STRUCTURES:
+          return [];
+        default:
+          return [];
+      }
+    })
+  } as unknown as Room;
 }
 
 function makeRuntimeColony(): { room: Room; spawns: StructureSpawn[]; energyAvailable: number; energyCapacityAvailable: number } {

--- a/prod/test/occupationRecommendation.test.ts
+++ b/prod/test/occupationRecommendation.test.ts
@@ -362,6 +362,48 @@ describe('occupation recommendation scoring', () => {
     });
   });
 
+  it('uses scout-only nearest-owned distance over stale configured no-route cache', () => {
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: {
+        describeExits: jest.fn(() => ({}))
+      } as unknown as GameMap,
+      rooms: {}
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'claim' }],
+        routeDistances: { 'W1N1>W2N1': null }
+      }
+    };
+
+    const report = buildRuntimeOccupationRecommendationReport(
+      makeRuntimeColony(),
+      [{} as Creep, {} as Creep, {} as Creep],
+      makeScoutOnlyExpansionReport(
+        makeScoutOnlyExpansionCandidate({
+          routeDistance: undefined,
+          nearestOwnedRoomDistance: 1
+        })
+      )
+    );
+
+    expect(report.next).toMatchObject({
+      roomName: 'W2N1',
+      action: 'reserve',
+      evidenceStatus: 'sufficient',
+      source: 'configured',
+      roadDistance: 1
+    });
+    expect(report.next).not.toHaveProperty('routeDistance');
+    expect(report.next?.risks).not.toContain('no known route from colony');
+    expect(report.followUpIntent).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      controllerId: 'controller-W2N1'
+    });
+  });
+
   it('does not convert scout-only expansion candidates with unknown hostile evidence', () => {
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       map: {

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -2519,6 +2519,394 @@ describe('runtime telemetry summaries', () => {
     ).toEqual([]);
   });
 
+  it('promotes sufficient E29N56 scout-only evidence into reserve intent past a superseded bootstrap record', () => {
+    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL, roomName: 'E29N55' });
+    const room = colony.room as Room & { find: jest.Mock; energyAvailable: number; energyCapacityAvailable: number };
+    const controller = room.controller as StructureController & { level: number; ticksToDowngrade: number };
+    const spawn = colony.spawns[0] as StructureSpawn & { my?: boolean; isActive?: jest.Mock };
+    const tower = {
+      id: 'tower1',
+      my: true,
+      structureType: TEST_GLOBALS.STRUCTURE_TOWER,
+      store: makeEnergyStore(500)
+    };
+
+    room.energyAvailable = 1_800;
+    room.energyCapacityAvailable = 1_800;
+    controller.level = 5;
+    controller.ticksToDowngrade = 20_000;
+    colony.energyAvailable = 1_800;
+    colony.energyCapacityAvailable = 1_800;
+    spawn.my = true;
+    spawn.spawning = null;
+    spawn.isActive = jest.fn(() => true);
+    room.find.mockImplementation((findType: number): unknown[] => {
+      switch (findType) {
+        case TEST_GLOBALS.FIND_STRUCTURES:
+        case TEST_GLOBALS.FIND_MY_STRUCTURES:
+          return [spawn, tower];
+        case TEST_GLOBALS.FIND_SOURCES:
+          return [{ id: 'source-home-a' }, { id: 'source-home-b' }];
+        case TEST_GLOBALS.FIND_HOSTILE_CREEPS:
+        case TEST_GLOBALS.FIND_HOSTILE_STRUCTURES:
+          return [];
+        default:
+          return [];
+      }
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      runtime: {
+        currentRoomName: 'E29N55'
+      },
+      territory: {
+        postClaimBootstraps: {
+          E29N54: {
+            colony: 'E29N55',
+            roomName: 'E29N54',
+            status: 'spawningWorkers',
+            claimedAt: RUNTIME_SUMMARY_INTERVAL - 1_000,
+            updatedAt: RUNTIME_SUMMARY_INTERVAL - 200,
+            workerTarget: 2
+          }
+        }
+      }
+    };
+    (Game.rooms as Record<string, Room>).E29N54 = makeRemoteRoom('E29N54', {
+      controller: { my: true } as StructureController
+    });
+    (Game.rooms as Record<string, Room>).E29N56 = makeRemoteRoom('E29N56', {
+      controller: {
+        id: 'controller-E29N56' as Id<StructureController>,
+        my: false,
+        pos: { x: 25, y: 25, roomName: 'E29N56' }
+      } as StructureController,
+      sourceCount: 1
+    });
+    (Game as Partial<Game>).map = {
+      describeExits: jest.fn(() => ({
+        '1': 'E29N56',
+        '3': 'E30N55',
+        '5': 'E29N54',
+        '7': 'E28N55'
+      })),
+      findRoute: jest.fn(() => [{ exit: 1, room: 'E29N56' }]),
+      getRoomTerrain: jest.fn(() => ({ get: jest.fn(() => 0) }))
+    } as unknown as GameMap;
+    (Game.spawns as Record<string, StructureSpawn>).BootstrapSpawn = {
+      room: { name: 'E29N54' } as Room
+    } as StructureSpawn;
+    (Game as Partial<Game>).creeps = {
+      BootstrapWorker1: makeWorker({ role: 'worker', colony: 'E29N54' }, 0, 'BootstrapWorker1'),
+      BootstrapWorker2: makeWorker(
+        {
+          role: 'worker',
+          colony: 'E29N55',
+          spawnSupport: { originRoom: 'E29N55', targetRoom: 'E29N54' }
+        },
+        0,
+        'BootstrapWorker2'
+      )
+    } as unknown as Game['creeps'];
+
+    emitRuntimeSummary(
+      [colony],
+      [
+        makeWorker({ role: 'worker', colony: 'E29N55' }, 0, 'Worker1'),
+        makeWorker({ role: 'worker', colony: 'E29N55' }, 0, 'Worker2'),
+        makeWorker({ role: 'worker', colony: 'E29N55' }, 0, 'Worker3'),
+        makeWorker({ role: 'worker', colony: 'E29N55' }, 0, 'Worker4')
+      ]
+    );
+
+    const payload = parseLoggedSummary();
+    const [summaryRoom] = payload.rooms as Array<Record<string, unknown>>;
+    const territoryExpansion = summaryRoom.territoryExpansion as Record<string, unknown>;
+    const expansionCandidate = (territoryExpansion.candidates as Array<Record<string, unknown>>).find(
+      (candidate) => candidate.roomName === 'E29N56'
+    );
+    const recommendation = summaryRoom.territoryRecommendation as Record<string, unknown>;
+
+    expect(expansionCandidate).toMatchObject({
+      roomName: 'E29N56',
+      evidenceStatus: 'sufficient',
+      scoutOnly: true,
+      sourceCount: 1,
+      hostileCreepCount: 0,
+      ignoredPostClaimBootstrapBlockers: [
+        {
+          colony: 'E29N55',
+          roomName: 'E29N54',
+          status: 'spawningWorkers',
+          reason: 'workerTargetSatisfied',
+          updatedAt: RUNTIME_SUMMARY_INTERVAL - 200,
+          age: 200,
+          workerTarget: 2,
+          spawnCount: 1,
+          workerCount: 2
+        }
+      ]
+    });
+    expect(expansionCandidate).not.toHaveProperty('blockReason');
+    expect(expansionCandidate).not.toHaveProperty('postClaimBootstrapBlocker');
+    expect(recommendation.next).toMatchObject({
+      roomName: 'E29N56',
+      action: 'reserve',
+      evidenceStatus: 'sufficient',
+      source: 'configured',
+      sourceCount: 1,
+      hostileCreepCount: 0,
+      routeDistance: 1
+    });
+    expect(recommendation.followUpIntent).toEqual({
+      colony: 'E29N55',
+      targetRoom: 'E29N56',
+      action: 'reserve',
+      controllerId: 'controller-E29N56'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'E29N55',
+        roomName: 'E29N56',
+        action: 'reserve',
+        createdBy: 'occupationRecommendation',
+        controllerId: 'controller-E29N56'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'E29N55',
+        targetRoom: 'E29N56',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: RUNTIME_SUMMARY_INTERVAL,
+        createdBy: 'occupationRecommendation',
+        controllerId: 'controller-E29N56'
+      }
+    ]);
+  });
+
+  it('keeps an active post-claim bootstrap as an actionable E29N56 blocker in runtime telemetry', () => {
+    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL, roomName: 'E29N55' });
+    const room = colony.room as Room & { find: jest.Mock; energyAvailable: number; energyCapacityAvailable: number };
+    const controller = room.controller as StructureController & { level: number; ticksToDowngrade: number };
+    const spawn = colony.spawns[0] as StructureSpawn & { my?: boolean; isActive?: jest.Mock };
+    const tower = {
+      id: 'tower1',
+      my: true,
+      structureType: TEST_GLOBALS.STRUCTURE_TOWER,
+      store: makeEnergyStore(500)
+    };
+
+    room.energyAvailable = 1_800;
+    room.energyCapacityAvailable = 1_800;
+    controller.level = 5;
+    controller.ticksToDowngrade = 20_000;
+    colony.energyAvailable = 1_800;
+    colony.energyCapacityAvailable = 1_800;
+    spawn.my = true;
+    spawn.spawning = null;
+    spawn.isActive = jest.fn(() => true);
+    room.find.mockImplementation((findType: number): unknown[] => {
+      switch (findType) {
+        case TEST_GLOBALS.FIND_STRUCTURES:
+        case TEST_GLOBALS.FIND_MY_STRUCTURES:
+          return [spawn, tower];
+        case TEST_GLOBALS.FIND_SOURCES:
+          return [{ id: 'source-home-a' }, { id: 'source-home-b' }];
+        case TEST_GLOBALS.FIND_HOSTILE_CREEPS:
+        case TEST_GLOBALS.FIND_HOSTILE_STRUCTURES:
+          return [];
+        default:
+          return [];
+      }
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      runtime: {
+        currentRoomName: 'E29N55'
+      },
+      territory: {
+        postClaimBootstraps: {
+          E29N54: {
+            colony: 'E29N55',
+            roomName: 'E29N54',
+            status: 'spawnSitePending',
+            claimedAt: RUNTIME_SUMMARY_INTERVAL - 1_000,
+            updatedAt: RUNTIME_SUMMARY_INTERVAL - 50,
+            workerTarget: 2
+          }
+        }
+      }
+    };
+    (Game.rooms as Record<string, Room>).E29N54 = makeRemoteRoom('E29N54', {
+      controller: { my: true } as StructureController
+    });
+    (Game.rooms as Record<string, Room>).E29N56 = makeRemoteRoom('E29N56', {
+      controller: {
+        id: 'controller-E29N56' as Id<StructureController>,
+        my: false,
+        pos: { x: 25, y: 25, roomName: 'E29N56' }
+      } as StructureController,
+      sourceCount: 1
+    });
+    (Game as Partial<Game>).map = {
+      describeExits: jest.fn(() => ({
+        '1': 'E29N56',
+        '3': 'E30N55',
+        '5': 'E29N54',
+        '7': 'E28N55'
+      })),
+      findRoute: jest.fn(() => [{ exit: 1, room: 'E29N56' }]),
+      getRoomTerrain: jest.fn(() => ({ get: jest.fn(() => 0) }))
+    } as unknown as GameMap;
+    (Game as Partial<Game>).creeps = {
+      BootstrapWorker1: makeWorker({ role: 'worker', colony: 'E29N54' }, 0, 'BootstrapWorker1')
+    } as unknown as Game['creeps'];
+
+    emitRuntimeSummary(
+      [colony],
+      [
+        makeWorker({ role: 'worker', colony: 'E29N55' }, 0, 'Worker1'),
+        makeWorker({ role: 'worker', colony: 'E29N55' }, 0, 'Worker2'),
+        makeWorker({ role: 'worker', colony: 'E29N55' }, 0, 'Worker3'),
+        makeWorker({ role: 'worker', colony: 'E29N55' }, 0, 'Worker4')
+      ],
+      [],
+      { persistOccupationRecommendations: false }
+    );
+
+    const payload = parseLoggedSummary();
+    const [summaryRoom] = payload.rooms as Array<Record<string, unknown>>;
+    const territoryExpansion = summaryRoom.territoryExpansion as Record<string, unknown>;
+    const expansionCandidate = (territoryExpansion.candidates as Array<Record<string, unknown>>).find(
+      (candidate) => candidate.roomName === 'E29N56'
+    );
+    const recommendation = summaryRoom.territoryRecommendation as Record<string, unknown>;
+
+    expect(expansionCandidate).toMatchObject({
+      roomName: 'E29N56',
+      evidenceStatus: 'sufficient',
+      scoutOnly: true,
+      blockReason: 'postClaimBootstrapActive',
+      postClaimBootstrapBlocker: {
+        colony: 'E29N55',
+        roomName: 'E29N54',
+        status: 'spawnSitePending',
+        updatedAt: RUNTIME_SUMMARY_INTERVAL - 50,
+        age: 50,
+        workerTarget: 2,
+        spawnCount: 0,
+        workerCount: 1
+      }
+    });
+    expect(expansionCandidate).not.toHaveProperty('ignoredPostClaimBootstrapBlockers');
+    expect(recommendation).toMatchObject({
+      candidates: [],
+      next: null,
+      followUpIntent: null
+    });
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.intents).toBeUndefined();
+  });
+
+  it('keeps E29N56 scout-only evidence out of reserve recommendations when CPU blocks conversion', () => {
+    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL, roomName: 'E29N55' });
+    const room = colony.room as Room & { find: jest.Mock; energyAvailable: number; energyCapacityAvailable: number };
+    const controller = room.controller as StructureController & { level: number; ticksToDowngrade: number };
+    const spawn = colony.spawns[0] as StructureSpawn & { my?: boolean; isActive?: jest.Mock };
+    const tower = {
+      id: 'tower1',
+      my: true,
+      structureType: TEST_GLOBALS.STRUCTURE_TOWER,
+      store: makeEnergyStore(500)
+    };
+
+    room.energyAvailable = 1_800;
+    room.energyCapacityAvailable = 1_800;
+    controller.level = 5;
+    controller.ticksToDowngrade = 20_000;
+    colony.energyAvailable = 1_800;
+    colony.energyCapacityAvailable = 1_800;
+    spawn.my = true;
+    spawn.spawning = null;
+    spawn.isActive = jest.fn(() => true);
+    room.find.mockImplementation((findType: number): unknown[] => {
+      switch (findType) {
+        case TEST_GLOBALS.FIND_STRUCTURES:
+        case TEST_GLOBALS.FIND_MY_STRUCTURES:
+          return [spawn, tower];
+        case TEST_GLOBALS.FIND_SOURCES:
+          return [{ id: 'source-home-a' }, { id: 'source-home-b' }];
+        case TEST_GLOBALS.FIND_HOSTILE_CREEPS:
+        case TEST_GLOBALS.FIND_HOSTILE_STRUCTURES:
+          return [];
+        default:
+          return [];
+      }
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      runtime: {
+        currentRoomName: 'E29N55'
+      },
+      territory: {}
+    };
+    (Game.rooms as Record<string, Room>).E29N56 = makeRemoteRoom('E29N56', {
+      controller: {
+        id: 'controller-E29N56' as Id<StructureController>,
+        my: false,
+        pos: { x: 25, y: 25, roomName: 'E29N56' }
+      } as StructureController,
+      sourceCount: 1
+    });
+    (Game as Partial<Game>).cpu = {
+      getUsed: jest.fn().mockReturnValue(4.2),
+      bucket: 499
+    } as unknown as CPU;
+    (Game as Partial<Game>).map = {
+      describeExits: jest.fn(() => ({
+        '1': 'E29N56',
+        '3': 'E30N55',
+        '5': 'E29N54',
+        '7': 'E28N55'
+      })),
+      findRoute: jest.fn(() => [{ exit: 1, room: 'E29N56' }]),
+      getRoomTerrain: jest.fn(() => ({ get: jest.fn(() => 0) }))
+    } as unknown as GameMap;
+
+    emitRuntimeSummary(
+      [colony],
+      [
+        makeWorker({ role: 'worker', colony: 'E29N55' }, 0, 'Worker1'),
+        makeWorker({ role: 'worker', colony: 'E29N55' }, 0, 'Worker2'),
+        makeWorker({ role: 'worker', colony: 'E29N55' }, 0, 'Worker3'),
+        makeWorker({ role: 'worker', colony: 'E29N55' }, 0, 'Worker4')
+      ],
+      [],
+      { persistOccupationRecommendations: false }
+    );
+
+    const payload = parseLoggedSummary();
+    const [summaryRoom] = payload.rooms as Array<Record<string, unknown>>;
+    const territoryExpansion = summaryRoom.territoryExpansion as Record<string, unknown>;
+    const expansionCandidate = (territoryExpansion.candidates as Array<Record<string, unknown>>).find(
+      (candidate) => candidate.roomName === 'E29N56'
+    );
+    const recommendation = summaryRoom.territoryRecommendation as Record<string, unknown>;
+
+    expect(expansionCandidate).toMatchObject({
+      roomName: 'E29N56',
+      evidenceStatus: 'sufficient',
+      scoutOnly: true,
+      blockReason: 'cpuBucketLow'
+    });
+    expect(recommendation).toMatchObject({
+      candidates: [],
+      next: null,
+      followUpIntent: null
+    });
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.intents).toBeUndefined();
+  });
+
   it('keeps emission gating deterministic', () => {
     expect(shouldEmitRuntimeSummary(1, [])).toBe(false);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [])).toBe(true);

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -2482,7 +2482,46 @@ describe('runtime telemetry summaries', () => {
       runtime: {
         currentRoomName: 'E29N55'
       },
-      territory: {}
+      territory: {
+        expansionCandidates: [
+          {
+            colony: 'E29N55',
+            roomName: 'E29N56',
+            rank: 1,
+            score: 120,
+            evidenceStatus: 'sufficient',
+            visible: false,
+            updatedAt: RUNTIME_SUMMARY_INTERVAL - 10,
+            adjacentToOwnedRoom: true,
+            scoutOnly: true,
+            recommendedAction: 'scout',
+            ignoredPostClaimBootstrapBlockers: [
+              {
+                colony: 'E29N55',
+                roomName: 'E29N54',
+                status: 'ready',
+                updatedAt: RUNTIME_SUMMARY_INTERVAL - 20,
+                age: 20,
+                workerTarget: 2,
+                spawnCount: 1,
+                workerCount: 2,
+                reason: 'ready'
+              },
+              {
+                colony: 'E28N55',
+                roomName: 'E28N54',
+                status: 'ready',
+                updatedAt: RUNTIME_SUMMARY_INTERVAL - 20,
+                age: 20,
+                workerTarget: 2,
+                spawnCount: 1,
+                workerCount: 2,
+                reason: 'ready'
+              }
+            ]
+          }
+        ]
+      }
     };
     (Game as Partial<Game>).map = {
       describeExits: jest.fn(() => ({
@@ -2500,6 +2539,7 @@ describe('runtime telemetry summaries', () => {
     const payload = parseLoggedSummary();
     const [summaryRoom] = payload.rooms as Array<Record<string, unknown>>;
     const territoryScout = summaryRoom.territoryScout as Record<string, unknown>;
+    const scoutOnlyTargets = territoryScout.scoutOnlyTargets as Array<Record<string, unknown>>;
     expect(territoryScout.scoutOnlyTargets).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -2511,6 +2551,15 @@ describe('runtime telemetry summaries', () => {
         })
       ])
     );
+    expect(scoutOnlyTargets.find((target) => target.roomName === 'E29N56')).toMatchObject({
+      ignoredPostClaimBootstrapBlockers: [
+        {
+          colony: 'E29N55',
+          roomName: 'E29N54',
+          reason: 'ready'
+        }
+      ]
+    });
     expect(Memory.territory?.targets).toBeUndefined();
     expect(
       (Memory.territory?.intents ?? []).filter(


### PR DESCRIPTION
## Summary
- converts stale/superseded post-claim bootstrap blockers into actionable telemetry instead of suppressing the safe adjacent E29N56 reserve/remote intent forever
- preserves active-bootstrap protection with explicit blocker details for post-deploy acceptance
- extends runtime-summary telemetry and regression tests for E29N56-style stale blocker vs real active blocker behavior
- keeps `prod/dist/main.js` synchronized from `npm --prefix prod run build`

Refs #1312

## Verification
Controller-side verification on the recovered Codex-authored tree:
- `git diff --check`
- `npm --prefix prod run typecheck`
- `npm --prefix prod test -- --runInBand` — 101 suites / 2015 tests
- `npm --prefix prod run build`

## Safety / acceptance
- No official MMO writes in this PR.
- After merge, the deploy floor must run the official Screeps deploy workflow for current `main` and archive evidence.
- Post-deploy acceptance requires one fresh runtime-summary window showing either E29N56 reserve/remote intent or exact valid blocker telemetry, while E29N55 remains healthy (`owned_spawns>=1`, `owned_creeps>=1`, hostiles `0`, alert `false`, energy buffer safe/recovering).

## Project state
- Issue #1312 Project fields were updated to `In progress` during recovery; this PR must be added to Project `screeps` and held in review until required checks, automated review, unresolved-thread, and elapsed-review gates pass.
