### PR TITLE
fix(rl): inject policy-gradient vectors into simulator

### DIFF
--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -416,6 +416,88 @@ def load_strategy_variants(card: JsonObject, registry_path: Path | None = None) 
     return variants
 
 
+def apply_policy_gradient_candidate_vectors_to_variants(
+    card: JsonObject,
+    variants: Sequence[StrategyVariant],
+) -> list[StrategyVariant]:
+    """Use policy-gradient candidate vectors as the simulator runtime parameter source."""
+    policy_gradient = card.get("policy_gradient", card.get("policyGradient"))
+    if not isinstance(policy_gradient, dict):
+        return list(variants)
+    raw_candidates = first_present(policy_gradient, ("candidate_parameter_vectors", "candidateParameterVectors"))
+    if not isinstance(raw_candidates, list):
+        return list(variants)
+
+    candidates_by_id: dict[str, JsonObject] = {}
+    for raw_candidate in raw_candidates:
+        if not isinstance(raw_candidate, dict):
+            continue
+        candidate = raw_candidate
+        strategy_variant_id = text_or_none(candidate.get("strategyVariantId"))
+        candidate_policy_id = text_or_none(candidate.get("candidatePolicyId"))
+        if strategy_variant_id is not None:
+            candidates_by_id[strategy_variant_id] = candidate
+        if candidate_policy_id is not None:
+            candidates_by_id.setdefault(candidate_policy_id, candidate)
+    if not candidates_by_id:
+        return list(variants)
+
+    return [
+        policy_gradient_candidate_vector_variant(variant, candidates_by_id)
+        for variant in variants
+    ]
+
+
+def policy_gradient_candidate_vector_variant(
+    variant: StrategyVariant,
+    candidates_by_id: dict[str, JsonObject],
+) -> StrategyVariant:
+    candidate = candidates_by_id.get(variant.id)
+    if candidate is None and variant.candidate_policy_id is not None:
+        candidate = candidates_by_id.get(variant.candidate_policy_id)
+    if candidate is None:
+        return variant
+
+    raw_parameters = candidate.get("parameters")
+    parameters = (
+        dict(sorted(copy.deepcopy(raw_parameters).items()))
+        if isinstance(raw_parameters, dict)
+        else copy.deepcopy(variant.parameters)
+    )
+    parameter_evidence = first_mapping(candidate, ("parameterEvidence", "parameter_evidence"))
+    return StrategyVariant(
+        id=variant.id,
+        parameters=parameters,
+        candidate_policy_id=text_or_none(candidate.get("candidatePolicyId")) or variant.candidate_policy_id,
+        family=text_or_none(candidate.get("family")) or variant.family,
+        policy_family=(
+            text_or_none(candidate.get("policyFamily"))
+            or text_or_none(candidate.get("policy_family"))
+            or variant.policy_family
+        ),
+        parameter_evidence=copy.deepcopy(parameter_evidence)
+        if parameter_evidence is not None
+        else copy.deepcopy(variant.parameter_evidence),
+        rollout_status=(
+            text_or_none(candidate.get("rolloutStatus"))
+            or text_or_none(candidate.get("rollout_status"))
+            or variant.rollout_status
+        ),
+        source_strategy_id=(
+            text_or_none(candidate.get("sourceStrategyId"))
+            or text_or_none(candidate.get("source_strategy_id"))
+            or variant.source_strategy_id
+        ),
+        source=variant.source,
+        title=text_or_none(candidate.get("title")) or variant.title,
+        training_role=(
+            text_or_none(candidate.get("trainingRole"))
+            or text_or_none(candidate.get("training_role"))
+            or variant.training_role
+        ),
+    )
+
+
 def expand_scale_environment_strategy_variants(
     variants: Sequence[StrategyVariant],
     environment_count: int | None,
@@ -775,6 +857,7 @@ def run_training_experiment(
     """Run all card variants through the simulator harness and write a JSON report."""
     card = load_experiment_card(card_path)
     variants = load_strategy_variants(card, registry_path=registry_path)
+    variants = apply_policy_gradient_candidate_vectors_to_variants(card, variants)
     config = simulation_config_from_card(card)
     variants = expand_scale_environment_strategy_variants(variants, config.scale_environments)
     reward_options = reward_options_from_card(card)
@@ -2550,7 +2633,7 @@ def policy_update_candidate_rows(
     if policy_gradient_candidate_parameters_metadata_only(policy_gradient):
         return []
     require_evaluated_parameters = policy_gradient_requires_runtime_parameter_evidence(policy_gradient)
-    allow_runtime_metadata_fallback = policy_gradient_allows_runtime_metadata_policy_update(policy_gradient)
+    allow_runtime_metadata_fallback = False
     raw_candidates = first_present(policy_gradient, ("candidate_parameter_vectors", "candidateParameterVectors"))
     if not isinstance(raw_candidates, list):
         return []
@@ -5318,6 +5401,8 @@ def policy_gradient_metadata_with_runner_transport(
         return policy_gradient
 
     injected = runtime_parameter_injection.get("runtimeParameterInjection") is True
+    consumed = runtime_parameter_injection.get("runtimeParameterConsumption") is True
+    policy_update_reward_ready = injected and consumed
     status = text_or_none(runtime_parameter_injection.get("status"))
     scope = text_or_none(runtime_parameter_injection.get("candidateParameterScope")) or "metadata_only"
     attempted_runtime_injection = scope in {"runtime_injected", "partial_runtime_injection"} or status in {
@@ -5334,7 +5419,9 @@ def policy_gradient_metadata_with_runner_transport(
     )
     support["candidate_parameter_scope"] = "runtime_injected" if injected else scope
     support["policy_update_reward_use"] = (
-        "eligible_with_evaluated_runtime_parameters" if injected else "blocked_until_runtime_parameter_evidence"
+        "eligible_with_evaluated_runtime_parameters"
+        if policy_update_reward_ready
+        else "blocked_until_runtime_parameter_evidence"
     )
     support["runtime_parameter_injection_status"] = status
     support["runtime_parameter_injection_reason"] = runtime_parameter_injection.get("reason")
@@ -5618,13 +5705,14 @@ def policy_update_runtime_injection_ready_parameter_evidence(
         first_present(support, ("runtime_parameter_consumption_status", "runtimeParameterConsumptionStatus"))
     )
     runtime_consumption = consumption_status == "consumed"
-    runtime_metadata_fallback = policy_gradient_allows_runtime_metadata_policy_update(policy_gradient)
+    runtime_metadata_fallback = False
     candidate_count_ready = len(candidates) >= policy_gradient_candidate_vector_count(policy_gradient)
     eligible = (
         scope == "runtime_injected"
         and policy_gradient_requires_runtime_parameter_evidence(policy_gradient)
         and candidate_count_ready
-        and (runtime_injection or runtime_metadata_fallback)
+        and runtime_injection
+        and runtime_consumption
     )
     payload: JsonObject = {
         "candidateParameterScope": scope,
@@ -5635,9 +5723,9 @@ def policy_update_runtime_injection_ready_parameter_evidence(
         "metadataCandidateCount": policy_gradient_candidate_vector_count(policy_gradient),
         "eligibilityMode": (
             "evaluated_runtime_parameter_evidence"
+            if runtime_injection and runtime_consumption
+            else "blocked_until_runtime_parameter_consumption_evidence"
             if runtime_injection
-            else "runtime_injected_metadata_scorecard_ranking"
-            if runtime_metadata_fallback
             else "blocked_until_runtime_parameter_evidence"
         ),
     }

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -428,7 +428,31 @@ def apply_policy_gradient_candidate_vectors_to_variants(
     if not isinstance(raw_candidates, list):
         return list(variants)
 
-    candidates_by_id: dict[str, JsonObject] = {}
+    candidates_by_variant_id, candidates_by_policy_id = policy_gradient_candidate_vector_maps(policy_gradient)
+    if not candidates_by_variant_id and not candidates_by_policy_id:
+        return list(variants)
+
+    return [
+        policy_gradient_candidate_vector_variant(
+            variant,
+            candidates_by_variant_id,
+            candidates_by_policy_id,
+        )
+        for variant in variants
+    ]
+
+
+def policy_gradient_candidate_vector_maps(
+    policy_gradient: JsonObject | None,
+) -> tuple[dict[str, JsonObject], dict[str, JsonObject]]:
+    if policy_gradient is None:
+        return {}, {}
+    raw_candidates = first_present(policy_gradient, ("candidate_parameter_vectors", "candidateParameterVectors"))
+    if not isinstance(raw_candidates, list):
+        return {}, {}
+
+    candidates_by_variant_id: dict[str, JsonObject] = {}
+    candidates_by_policy_id: dict[str, JsonObject] = {}
     for raw_candidate in raw_candidates:
         if not isinstance(raw_candidate, dict):
             continue
@@ -436,25 +460,20 @@ def apply_policy_gradient_candidate_vectors_to_variants(
         strategy_variant_id = text_or_none(candidate.get("strategyVariantId"))
         candidate_policy_id = text_or_none(candidate.get("candidatePolicyId"))
         if strategy_variant_id is not None:
-            candidates_by_id[strategy_variant_id] = candidate
+            candidates_by_variant_id[strategy_variant_id] = candidate
         if candidate_policy_id is not None:
-            candidates_by_id.setdefault(candidate_policy_id, candidate)
-    if not candidates_by_id:
-        return list(variants)
-
-    return [
-        policy_gradient_candidate_vector_variant(variant, candidates_by_id)
-        for variant in variants
-    ]
+            candidates_by_policy_id.setdefault(candidate_policy_id, candidate)
+    return candidates_by_variant_id, candidates_by_policy_id
 
 
 def policy_gradient_candidate_vector_variant(
     variant: StrategyVariant,
-    candidates_by_id: dict[str, JsonObject],
+    candidates_by_variant_id: dict[str, JsonObject],
+    candidates_by_policy_id: dict[str, JsonObject],
 ) -> StrategyVariant:
-    candidate = candidates_by_id.get(variant.id)
+    candidate = candidates_by_variant_id.get(variant.id)
     if candidate is None and variant.candidate_policy_id is not None:
-        candidate = candidates_by_id.get(variant.candidate_policy_id)
+        candidate = candidates_by_policy_id.get(variant.candidate_policy_id)
     if candidate is None:
         return variant
 
@@ -1096,7 +1115,7 @@ def build_report_runtime_parameter_injection_summary(
     variants: Sequence[StrategyVariant],
     policy_gradient: JsonObject | None = None,
 ) -> JsonObject:
-    candidate_match_ids = policy_gradient_candidate_match_ids(policy_gradient)
+    candidate_match_ids = policy_gradient_candidate_match_ids(policy_gradient, variants)
     expected_ids = set(candidate_match_ids.values()) if candidate_match_ids else {variant.id for variant in variants}
     rows: list[JsonObject] = []
     observed_ids: set[str] = set()
@@ -1246,7 +1265,10 @@ def runtime_parameter_consumption_rollup_status(rows: Sequence[JsonObject]) -> s
     return "missing" if any(runtime_parameter_scope_indicates_runtime_attempt(row) for row in rows) else "not_attempted"
 
 
-def policy_gradient_candidate_match_ids(policy_gradient: JsonObject | None) -> dict[str, str]:
+def policy_gradient_candidate_match_ids(
+    policy_gradient: JsonObject | None,
+    variants: Sequence[StrategyVariant] = (),
+) -> dict[str, str]:
     if policy_gradient is None:
         return {}
     raw_candidates = first_present(policy_gradient, ("candidate_parameter_vectors", "candidateParameterVectors"))
@@ -1264,6 +1286,15 @@ def policy_gradient_candidate_match_ids(policy_gradient: JsonObject | None) -> d
         match_ids[expected_id] = expected_id
         if candidate_policy_id is not None:
             match_ids[candidate_policy_id] = expected_id
+    for variant in variants:
+        if variant.candidate_policy_id is None:
+            continue
+        expected_id = match_ids.get(variant.candidate_policy_id)
+        if expected_id is None:
+            continue
+        match_ids.setdefault(variant.id, expected_id)
+        base_variant_id = simulator_harness.scale_environment_base_variant_id(variant.id)
+        match_ids.setdefault(base_variant_id, expected_id)
     return match_ids
 
 
@@ -2643,7 +2674,15 @@ def policy_update_candidate_rows(
         if variant_id is None:
             continue
         base_id = simulator_harness.scale_environment_base_variant_id(variant_id)
-        result_groups.setdefault(base_id, []).append(result)
+        result_keys = {base_id}
+        candidate_policy_id = text_or_none(result.get("candidatePolicyId"))
+        runtime_injection = result.get("runtimeParameterInjection")
+        if candidate_policy_id is None and isinstance(runtime_injection, dict):
+            candidate_policy_id = text_or_none(runtime_injection.get("candidatePolicyId"))
+        if candidate_policy_id is not None:
+            result_keys.add(candidate_policy_id)
+        for result_key in result_keys:
+            result_groups.setdefault(result_key, []).append(result)
 
     rows: list[JsonObject] = []
     for candidate in raw_candidates:
@@ -2651,9 +2690,10 @@ def policy_update_candidate_rows(
             continue
         strategy_variant_id = text_or_none(candidate.get("strategyVariantId"))
         candidate_policy_id = text_or_none(candidate.get("candidatePolicyId"))
-        if strategy_variant_id is None:
+        candidate_match_id = strategy_variant_id or candidate_policy_id
+        if candidate_match_id is None:
             continue
-        summaries = result_groups.get(strategy_variant_id) or result_groups.get(candidate_policy_id or "") or []
+        summaries = result_groups.get(strategy_variant_id or "") or result_groups.get(candidate_policy_id or "") or []
         scored_summaries = [summary for summary in summaries if policy_reward_tuple_values(summary) is not None]
         if not scored_summaries:
             continue
@@ -2672,7 +2712,7 @@ def policy_update_candidate_rows(
         rows.append(
             {
                 "candidatePolicyId": candidate_policy_id,
-                "strategyVariantId": strategy_variant_id,
+                "strategyVariantId": candidate_match_id,
                 "sourceStrategyId": text_or_none(candidate.get("sourceStrategyId")),
                 "rolloutStatus": text_or_none(candidate.get("rolloutStatus")),
                 "parameters": parameters,

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -224,6 +224,7 @@ class MockSimulator:
         self.evaluated_parameters_by_variant = evaluated_parameters_by_variant or {}
         self.calls: list[JsonObject] = []
         self.last_variants: list[JsonObject] = []
+        self.last_uploaded_code_by_variant: dict[str, str] = {}
 
     def __call__(self, **kwargs: Any) -> JsonObject:
         self.calls.append(dict(kwargs))
@@ -249,6 +250,7 @@ class MockSimulator:
                     ),
                     injection,
                 )
+                self.last_uploaded_code_by_variant[variant_id] = code_text
                 result["runtimeParameterInjection"] = runner.simulator_harness.mark_runtime_parameter_injection_uploaded(
                     injection,
                     code_text=code_text,
@@ -2555,6 +2557,7 @@ export const STRATEGY_REGISTRY = [
                 "candidate_parameter_scope": "runtime_injected",
                 "simulator_variant_transport": "variant_ids_with_runtime_injected_parameters",
                 "policy_update_reward_use": "eligible_with_evaluated_runtime_parameters",
+                "runtime_parameter_consumption_status": "consumed",
             },
             "learnableParameters": [{"name": "territorySignalWeight", "min": 0, "max": 30, "step": 1}],
             "candidateParameterVectors": [
@@ -2637,7 +2640,11 @@ export const STRATEGY_REGISTRY = [
 
         self.assertTrue(evidence["runtimeParameterInjection"])
         self.assertFalse(evidence["runtimeParameterConsumption"])
-        self.assertTrue(evidence["policyUpdateEligible"])
+        self.assertFalse(evidence["policyUpdateEligible"])
+        self.assertEqual(
+            evidence["eligibilityMode"],
+            "blocked_until_runtime_parameter_consumption_evidence",
+        )
         self.assertEqual(evidence["runtimeParameterConsumptionStatus"], "missing_runtime_parameter_consumption")
         self.assertEqual(gate["status"], "blocked_runtime_parameter_consumption_missing")
         self.assertFalse(gate["runtimeConsumedPromotionEligible"])
@@ -3034,6 +3041,64 @@ export const STRATEGY_REGISTRY = [
         self.assertFalse(report["policyUpdate"]["officialMmoWrites"])
         self.assertFalse(report["policyUpdate"]["officialMmoWritesAllowed"])
 
+    def test_policy_gradient_candidate_vectors_feed_private_simulator_prelude(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-prelude-injected",
+            code_commit="f" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-22T02:55:00Z",
+            simulation_ticks=100,
+            simulation_repetitions=1,
+        )
+        target_candidate = card["policy_gradient"]["candidate_parameter_vectors"][1]
+        target_variant = next(
+            variant
+            for variant in card["strategy_variants"]
+            if variant["id"] == target_candidate["strategyVariantId"]
+        )
+        candidate_parameters = copy.deepcopy(target_candidate["parameters"])
+        stale_parameters = copy.deepcopy(candidate_parameters)
+        stale_parameters["territorySignalWeight"] = candidate_parameters["territorySignalWeight"] - 3
+        target_variant["parameters"] = stale_parameters
+        variant_ids = [variant["id"] for variant in card["strategy_variants"]]
+        start = tick(1, [room("W1N1", energy=100)])
+        simulator = MockSimulator(
+            {
+                variant_id: variant_result(variant_id, [start, tick(2, [room("W1N1", energy=200)])])
+                for variant_id in variant_ids
+            },
+            inject_runtime_parameters=True,
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="policy-gradient-prelude-injected",
+                generated_at="2026-05-22T03:00:00Z",
+                simulator_runner=simulator,
+            )
+
+        variant_config = simulator.calls[0]["variant_configs"][target_candidate["strategyVariantId"]]
+        uploaded_code = simulator.last_uploaded_code_by_variant[target_candidate["strategyVariantId"]]
+        candidate_fragment = f'"territorySignalWeight":{candidate_parameters["territorySignalWeight"]}'
+        stale_fragment = f'"territorySignalWeight":{stale_parameters["territorySignalWeight"]}'
+        self.assertEqual(variant_config["parameters"], candidate_parameters)
+        self.assertNotEqual(variant_config["parameters"], stale_parameters)
+        self.assertIn(runner.simulator_harness.RUNTIME_PARAMETER_INJECTION_GLOBAL, uploaded_code)
+        self.assertIn(candidate_fragment, uploaded_code)
+        self.assertNotIn(stale_fragment, uploaded_code)
+        self.assertEqual(report["runtimeParameterInjection"]["status"], "injected")
+        self.assertTrue(report["runtimeParameterInjection"]["runtimeParameterInjection"])
+        self.assertTrue(report["runtimeParameterInjection"]["runtimeParameterConsumption"])
+        self.assertEqual(
+            report["policyGradient"]["runner_support"]["policy_update_reward_use"],
+            "eligible_with_evaluated_runtime_parameters",
+        )
+
     def test_scorecard_materialization_error_blocks_scorecard_without_crashing(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-policy-gradient-scorecard-error",
@@ -3189,7 +3254,7 @@ export const STRATEGY_REGISTRY = [
             )
         )
 
-    def test_runtime_injected_reinforce_without_consumption_probe_still_requires_reward_signal(self) -> None:
+    def test_runtime_injected_reinforce_without_consumption_probe_blocks_policy_update_reward_use(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-policy-gradient-missing-consumption",
             code_commit="f" * 40,
@@ -3232,12 +3297,16 @@ export const STRATEGY_REGISTRY = [
             "missing_runtime_parameter_consumption",
         )
         self.assertEqual(report["policyUpdateIterations"], 0)
-        self.assertEqual(report["policyUpdate"]["skippedReason"], "bounded_update_no_parameter_change")
-        self.assertTrue(report["policyUpdate"]["parameterEvidence"]["policyUpdateEligible"])
+        self.assertEqual(
+            report["policyUpdate"]["skippedReason"],
+            runner.RUNTIME_PARAMETER_INJECTION_INCOMPLETE_SKIP_REASON,
+        )
+        self.assertFalse(report["trustedGradientUpdate"])
+        self.assertFalse(report["policyUpdate"]["parameterEvidence"]["policyUpdateEligible"])
         self.assertFalse(report["policyUpdate"]["parameterEvidence"]["runtimeParameterInjection"])
         self.assertEqual(
-            report["policyUpdate"]["parameterEvidence"]["eligibilityMode"],
-            "runtime_injected_metadata_scorecard_ranking",
+            report["policyGradient"]["runner_support"]["policy_update_reward_use"],
+            "blocked_until_runtime_parameter_evidence",
         )
         self.assertFalse(report["policyUpdate"]["promotionGate"]["runtimeParameterConsumption"])
         self.assertFalse(report["policyUpdate"]["promotionGate"]["loopAPromotionEligible"])
@@ -3246,7 +3315,7 @@ export const STRATEGY_REGISTRY = [
         self.assertTrue(all("evaluatedParameters" in result for result in simulator.last_variants))
         self.assertTrue(all("runtimeParameterConsumption" not in result for result in simulator.last_variants))
 
-    def test_runtime_injected_metadata_ranking_materializes_reinforce_update_without_consumption_probe(self) -> None:
+    def test_runtime_injected_metadata_ranking_blocks_reinforce_update_without_consumption_probe(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-policy-gradient-metadata-ranking",
             code_commit="f" * 40,
@@ -3293,8 +3362,6 @@ export const STRATEGY_REGISTRY = [
                 simulator_runner=simulator,
             )
             persisted = read_json(out_dir / "policy-gradient-metadata-ranking.json")
-            artifact_path = Path(report["policyUpdateArtifactPath"])
-            artifact = read_json(artifact_path)
             scorecard_payload = read_json(Path(report["scorecardArtifactPath"]))
 
         self.assertEqual(report["runtimeParameterInjection"]["status"], "not_injected")
@@ -3305,9 +3372,14 @@ export const STRATEGY_REGISTRY = [
             report["runtimeParameterInjection"]["runtimeParameterConsumptionStatus"],
             "missing_runtime_parameter_consumption",
         )
-        self.assertEqual(report["policyUpdateIterations"], 1)
-        self.assertEqual(persisted["policyUpdateIterations"], 1)
-        self.assertTrue(report["trueGradient"])
+        self.assertEqual(report["policyUpdateIterations"], 0)
+        self.assertEqual(persisted["policyUpdateIterations"], 0)
+        self.assertFalse(report["trueGradient"])
+        self.assertFalse(report["trustedGradientUpdate"])
+        self.assertEqual(
+            report["policyGradient"]["runner_support"]["policy_update_reward_use"],
+            "blocked_until_runtime_parameter_evidence",
+        )
         self.assertEqual(report["candidateScorecard"]["status"], "materialized")
         self.assertEqual(
             report["candidateScorecard"]["classification"],
@@ -3326,22 +3398,14 @@ export const STRATEGY_REGISTRY = [
         self.assertIsNotNone(report["candidateScorecard"]["baselineRank"])
         self.assertEqual(report["candidateScorecards"]["status"], "materialized")
         self.assertGreater(len(report["ranking"]), 1)
-        self.assertIn("policyUpdateArtifactPath", report)
+        self.assertNotIn("policyUpdateArtifactPath", report)
         update = report["policyUpdate"]
         self.assertFalse(update["liveEffect"])
         self.assertFalse(update["officialMmoWrites"])
         self.assertFalse(update["officialMmoWritesAllowed"])
         self.assertFalse(update["parameterEvidence"]["runtimeParameterInjection"])
-        self.assertTrue(update["parameterEvidence"]["policyUpdateEligible"])
-        self.assertEqual(
-            update["parameterEvidence"]["eligibilityMode"],
-            "runtime_injected_metadata_scorecard_ranking",
-        )
-        self.assertFalse(update["runtimeParameterConsumption"])
-        self.assertEqual(
-            update["consumptionMode"],
-            runner.POLICY_UPDATE_CONSUMPTION_MODE_SCORECARD_NON_CONSUMED,
-        )
+        self.assertFalse(update["parameterEvidence"]["policyUpdateEligible"])
+        self.assertEqual(update["skippedReason"], runner.RUNTIME_PARAMETER_INJECTION_INCOMPLETE_SKIP_REASON)
         self.assertEqual(
             update["promotionGate"]["status"],
             "blocked_runtime_parameter_consumption_missing",
@@ -3350,12 +3414,9 @@ export const STRATEGY_REGISTRY = [
         self.assertFalse(update["promotionGate"]["loopAPromotionEligible"])
         self.assertFalse(update["promotionGate"]["loopBPromotionEligible"])
         self.assertEqual(update["promotionGate"]["missingPrerequisites"], ["runtime_parameter_consumption"])
-        self.assertTrue(any(abs(float(value)) > 0 for value in update["parameterDelta"].values()))
-        self.assertEqual(artifact["parameters"], update["updatedParameters"])
-        self.assertEqual(artifact["promotionGate"], update["promotionGate"])
-        self.assertFalse(artifact["liveEffect"])
-        self.assertFalse(artifact["officialMmoWrites"])
-        self.assertFalse(artifact["officialMmoWritesAllowed"])
+        self.assertNotIn("parameterDelta", update)
+        self.assertNotIn("updatedParameters", update)
+        self.assertNotIn("nextCandidatePolicy", update)
 
     def test_failed_only_runtime_parameter_uploads_do_not_become_injected_evidence(self) -> None:
         card = card_helper.build_card(

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -228,6 +228,7 @@ class MockSimulator:
 
     def __call__(self, **kwargs: Any) -> JsonObject:
         self.calls.append(dict(kwargs))
+        self.last_uploaded_code_by_variant = {}
         variants: list[JsonObject] = []
         for variant_id in kwargs["variants"]:
             result = copy.deepcopy(self.results_by_variant[variant_id])
@@ -319,6 +320,35 @@ class RequiredSteamKeySimulator(MockSimulator):
 
 
 class RlTrainingRunnerTest(unittest.TestCase):
+    def test_mock_simulator_resets_uploaded_code_evidence_per_call(self) -> None:
+        start = tick(1, [room("W1N1", energy=100)])
+        simulator = MockSimulator(
+            {
+                "candidate": variant_result("candidate", [start]),
+                "control": variant_result("control", [start]),
+            },
+            inject_runtime_parameters=True,
+        )
+        variant_configs = {
+            "candidate": runner.StrategyVariant(
+                id="candidate",
+                family="test-family",
+                parameters={"knob": 1},
+            ).to_json(),
+            "control": runner.StrategyVariant(
+                id="control",
+                family="test-family",
+                parameters={"knob": 0},
+            ).to_json(),
+        }
+
+        simulator(run_id="first", variants=["candidate"], variant_configs=variant_configs)
+        self.assertIn("candidate", simulator.last_uploaded_code_by_variant)
+
+        simulator.inject_runtime_parameters = False
+        simulator(run_id="second", variants=["control"], variant_configs=variant_configs)
+        self.assertEqual(simulator.last_uploaded_code_by_variant, {})
+
     def test_experiment_card_validation_requires_conservative_and_ood_safety_flags(self) -> None:
         for field in ("conservative_actions_only", "ood_rejection"):
             with self.subTest(field=field):
@@ -2060,6 +2090,121 @@ export const STRATEGY_REGISTRY = [
                 ],
                 parameter_space,
             )
+
+    def test_policy_gradient_candidate_vector_lookup_keeps_variant_and_policy_ids_separate(self) -> None:
+        variants = [
+            runner.StrategyVariant(
+                id="foo",
+                candidate_policy_id="foo-policy",
+                family="test-family",
+                parameters={"knob": 1},
+            ),
+            runner.StrategyVariant(
+                id="bar",
+                candidate_policy_id="bar-policy",
+                family="test-family",
+                parameters={"knob": 2},
+            ),
+        ]
+        updated = runner.apply_policy_gradient_candidate_vectors_to_variants(
+            {
+                "policy_gradient": {
+                    "candidate_parameter_vectors": [
+                        {
+                            "candidatePolicyId": "foo",
+                            "strategyVariantId": "bar",
+                            "parameters": {"knob": 99},
+                        },
+                        {
+                            "candidatePolicyId": "foo-policy",
+                            "parameters": {"knob": 11},
+                        },
+                    ],
+                }
+            },
+            variants,
+        )
+
+        updated_by_id = {variant.id: variant for variant in updated}
+        self.assertEqual(updated_by_id["foo"].parameters, {"knob": 11})
+        self.assertEqual(updated_by_id["foo"].candidate_policy_id, "foo-policy")
+        self.assertEqual(updated_by_id["bar"].parameters, {"knob": 99})
+
+    def test_runtime_parameter_report_summary_matches_candidate_policy_only_vectors(self) -> None:
+        summary = runner.build_report_runtime_parameter_injection_summary(
+            [
+                {
+                    "variantId": "variant-a",
+                    "candidatePolicyId": "candidate-a",
+                    "runtimeParameterInjection": {
+                        "status": "injected",
+                        "runtimeParameterInjection": True,
+                        "runtimeParameterConsumption": True,
+                        "runtimeParameterConsumptionStatus": "consumed",
+                        "candidateParameterScope": "runtime_injected",
+                        "parametersSha256": "candidate-sha",
+                    },
+                },
+            ],
+            [
+                runner.StrategyVariant(
+                    id="variant-a",
+                    candidate_policy_id="candidate-a",
+                    family="test-family",
+                    parameters={"knob": 1},
+                )
+            ],
+            {
+                "candidate_parameter_vectors": [
+                    {
+                        "candidatePolicyId": "candidate-a",
+                        "parameters": {"knob": 1},
+                    }
+                ]
+            },
+        )
+
+        self.assertEqual(summary["status"], "injected")
+        self.assertTrue(summary["runtimeParameterInjection"])
+        self.assertTrue(summary["runtimeParameterConsumption"])
+        self.assertEqual(summary["variantCount"], 1)
+        self.assertEqual([row["variantId"] for row in summary["variants"]], ["variant-a"])
+
+    def test_policy_update_candidate_rows_accepts_candidate_policy_id_only_vectors(self) -> None:
+        parameter_space = {"knob": {"min": 0, "max": 10}}
+        rows = runner.policy_update_candidate_rows(
+            {
+                "runner_support": {
+                    "runtime_parameter_injection": True,
+                    "inline_candidates_runtime_injected": True,
+                    "candidate_parameter_scope": "runtime_injected",
+                    "policy_update_reward_use": "eligible_with_evaluated_runtime_parameters",
+                    "runtime_parameter_consumption_status": "consumed",
+                },
+                "candidate_parameter_vectors": [
+                    {
+                        "candidatePolicyId": "candidate-a",
+                        "parameters": {"knob": 4.2},
+                    },
+                ],
+            },
+            [
+                {
+                    "variantId": "variant-a",
+                    "candidatePolicyId": "candidate-a",
+                    "sampleCount": 1,
+                    "evaluatedParameters": {"knob": 4.2},
+                    "reward": {"tuple": [1, 0, 0, 0]},
+                }
+            ],
+            parameter_space,
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["candidatePolicyId"], "candidate-a")
+        self.assertEqual(rows[0]["strategyVariantId"], "candidate-a")
+        self.assertEqual(rows[0]["parameters"], {"knob": 4.2})
+        self.assertEqual(rows[0]["resultVariantIds"], ["variant-a"])
 
     def test_runtime_parameter_report_summary_uses_policy_gradient_candidate_ids(self) -> None:
         summary = runner.build_report_runtime_parameter_injection_summary(


### PR DESCRIPTION
## Summary
- Routes policy-gradient candidate parameter vectors into the private simulator variant prelude before scaling environments.
- Keeps policy update reward eligibility blocked until both runtime injection and runtime consumption evidence are present.
- Adds focused regression coverage for candidate-vector prelude injection and injection-without-consumption blocking.

## Verification
- `python3 -m py_compile scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_training_runner.py`
- `python3 -m unittest scripts.test_screeps_rl_training_runner -v` (91 tests OK)
- `git diff --check`
- `git diff --check HEAD~1..HEAD`

## Safety
- Offline/private RL runner change only; no production Screeps bundle, deploy workflow, or official MMO learned-policy write path changed.
- `liveEffect=false` / `officialMmoWrites=false` remains required for Tencent/private simulator runs.

Refs #1299
Refs #879
Refs #1032
Refs #1233
