### PR TITLE
fix: seed deferred claimed room extensions

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -13922,6 +13922,28 @@ function planConstructionForColony(colony, options = {}) {
   planStorage(colony, result, budgetState, options);
   return result;
 }
+function planCapacityBootstrapExtensionForColony(colony, options = {}) {
+  const room = colony.room;
+  const rcl = getOwnedRoomRcl6(room);
+  const energyAvailable = getRoomEnergyAvailable8(colony);
+  const budgetState = {
+    energyBudget: Math.floor(energyAvailable * resolveEnergyBudgetRatio(options.energyBudgetRatio)),
+    energyReserved: 0
+  };
+  const result = {
+    roomName: room.name,
+    rcl,
+    energyAvailable,
+    energyBudget: budgetState.energyBudget,
+    energyReserved: 0,
+    placements: []
+  };
+  if (rcl !== 2 || typeof room.createConstructionSite !== "function" || !hasSpawnCoverage2(colony) || !shouldPrioritizeExtensionBootstrapConstruction(room, rcl, getRoomEnergyCapacityAvailable6(colony))) {
+    return result;
+  }
+  planBootstrapExtension(colony, result, budgetState, options);
+  return result;
+}
 function planBootstrapExtension(colony, result, budgetState, options) {
   if (countPendingConstructionSites(colony.room, "extension") > 0) {
     return false;
@@ -14739,6 +14761,23 @@ function planClaimedRoomConstruction(colony, options = {}) {
     return createEmptyClaimedRoomConstructionResult(colony, "noEnergyOrCreeps");
   }
   const result = planConstructionForColony(colony, buildClaimedRoomConstructionOptions(colony, options));
+  return {
+    ...result,
+    active: true,
+    yielded: false
+  };
+}
+function planDeferredClaimedRoomCapacityConstruction(colony, options = {}) {
+  if (!isClaimedRoomConstructionActive(colony.room)) {
+    return createEmptyClaimedRoomConstructionResult(colony, "inactive");
+  }
+  if (shouldYieldForUnavailableBuildResources(colony, options)) {
+    return createEmptyClaimedRoomConstructionResult(colony, "noEnergyOrCreeps");
+  }
+  const result = planCapacityBootstrapExtensionForColony(
+    colony,
+    buildClaimedRoomConstructionOptions(colony, options)
+  );
   return {
     ...result,
     active: true,
@@ -45601,13 +45640,18 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
       { focusRoomName: postClaimBootstrapFocusRoomName }
     );
     refreshPostClaimDefenseConstruction(colony, { focusRoomName: postClaimBootstrapFocusRoomName });
-    if (postClaimBootstrapRefresh.deferred !== true) {
+    const constructionOptions = {
+      respectRoomEnergyBuffer: true,
+      creeps,
+      strategyRegistry: options.strategyRegistry,
+      runtimeStrategyConstructionEnabled: options.runtimeStrategyConstructionEnabled,
+      onStrategyRegistryRuntimeUse: options.onStrategyRegistryRuntimeUse
+    };
+    if (postClaimBootstrapRefresh.deferred === true) {
+      planDeferredClaimedRoomCapacityConstruction(colony, constructionOptions);
+    } else {
       planClaimedRoomConstruction(colony, {
-        respectRoomEnergyBuffer: true,
-        creeps,
-        strategyRegistry: options.strategyRegistry,
-        runtimeStrategyConstructionEnabled: options.runtimeStrategyConstructionEnabled,
-        onStrategyRegistryRuntimeUse: options.onStrategyRegistryRuntimeUse
+        ...constructionOptions
       });
     }
     if (survivalAssessment.mode === "TERRITORY_READY") {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -13938,7 +13938,7 @@ function planCapacityBootstrapExtensionForColony(colony, options = {}) {
     energyReserved: 0,
     placements: []
   };
-  if (rcl !== 2 || typeof room.createConstructionSite !== "function" || !hasSpawnCoverage2(colony) || !shouldPrioritizeExtensionBootstrapConstruction(room, rcl, getRoomEnergyCapacityAvailable6(colony))) {
+  if (rcl !== 2 || typeof room.createConstructionSite !== "function" || !hasSpawnCoverage2(colony) || !hasRemainingStructureCapacity(room, "extension")) {
     return result;
   }
   planBootstrapExtension(colony, result, budgetState, options);

--- a/prod/src/construction/claimed-room-planner.ts
+++ b/prod/src/construction/claimed-room-planner.ts
@@ -1,5 +1,6 @@
 import { getOwnedColonies, type ColonySnapshot } from '../colony/colonyRegistry';
 import {
+  planCapacityBootstrapExtensionForColony,
   planConstructionForColony,
   type ConstructionPlannerOptions,
   type ConstructionPlannerResult,
@@ -59,6 +60,29 @@ export function planClaimedRoomConstruction(
   }
 
   const result = planConstructionForColony(colony, buildClaimedRoomConstructionOptions(colony, options));
+  return {
+    ...result,
+    active: true,
+    yielded: false
+  };
+}
+
+export function planDeferredClaimedRoomCapacityConstruction(
+  colony: ColonySnapshot,
+  options: ClaimedRoomConstructionPlannerOptions = {}
+): ClaimedRoomConstructionResult {
+  if (!isClaimedRoomConstructionActive(colony.room)) {
+    return createEmptyClaimedRoomConstructionResult(colony, 'inactive');
+  }
+
+  if (shouldYieldForUnavailableBuildResources(colony, options)) {
+    return createEmptyClaimedRoomConstructionResult(colony, 'noEnergyOrCreeps');
+  }
+
+  const result = planCapacityBootstrapExtensionForColony(
+    colony,
+    buildClaimedRoomConstructionOptions(colony, options)
+  );
   return {
     ...result,
     active: true,

--- a/prod/src/construction/planner.ts
+++ b/prod/src/construction/planner.ts
@@ -389,7 +389,7 @@ export function planCapacityBootstrapExtensionForColony(
     rcl !== 2 ||
     typeof room.createConstructionSite !== 'function' ||
     !hasSpawnCoverage(colony) ||
-    !shouldPrioritizeExtensionBootstrapConstruction(room, rcl, getRoomEnergyCapacityAvailable(colony))
+    !hasRemainingStructureCapacity(room, 'extension')
   ) {
     return result;
   }

--- a/prod/src/construction/planner.ts
+++ b/prod/src/construction/planner.ts
@@ -365,6 +365,39 @@ export function planConstructionForColony(
   return result;
 }
 
+export function planCapacityBootstrapExtensionForColony(
+  colony: ColonySnapshot,
+  options: ConstructionPlannerOptions = {}
+): RoomConstructionPlannerResult {
+  const room = colony.room;
+  const rcl = getOwnedRoomRcl(room);
+  const energyAvailable = getRoomEnergyAvailable(colony);
+  const budgetState: ConstructionBudgetState = {
+    energyBudget: Math.floor(energyAvailable * resolveEnergyBudgetRatio(options.energyBudgetRatio)),
+    energyReserved: 0
+  };
+  const result: RoomConstructionPlannerResult = {
+    roomName: room.name,
+    rcl,
+    energyAvailable,
+    energyBudget: budgetState.energyBudget,
+    energyReserved: 0,
+    placements: []
+  };
+
+  if (
+    rcl !== 2 ||
+    typeof room.createConstructionSite !== 'function' ||
+    !hasSpawnCoverage(colony) ||
+    !shouldPrioritizeExtensionBootstrapConstruction(room, rcl, getRoomEnergyCapacityAvailable(colony))
+  ) {
+    return result;
+  }
+
+  planBootstrapExtension(colony, result, budgetState, options);
+  return result;
+}
+
 function planBootstrapExtension(
   colony: ColonySnapshot,
   result: RoomConstructionPlannerResult,

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -6,7 +6,10 @@ import {
   persistColonyStageAssessment,
   recordColonySurvivalAssessment
 } from '../colony/colonyStage';
-import { planClaimedRoomConstruction } from '../construction/claimed-room-planner';
+import {
+  planClaimedRoomConstruction,
+  planDeferredClaimedRoomCapacityConstruction
+} from '../construction/claimed-room-planner';
 import { countCreepsByRole, getWorkerCapacity, type RoleCounts } from '../creeps/roleCounts';
 import { runWorker } from '../creeps/workerRunner';
 import { runUpgraderCreep, UPGRADER_ROLE } from '../creeps/upgraderRunner';
@@ -204,13 +207,18 @@ export function runEconomy(
       { focusRoomName: postClaimBootstrapFocusRoomName }
     );
     refreshPostClaimDefenseConstruction(colony, { focusRoomName: postClaimBootstrapFocusRoomName });
-    if (postClaimBootstrapRefresh.deferred !== true) {
+    const constructionOptions = {
+      respectRoomEnergyBuffer: true,
+      creeps,
+      strategyRegistry: options.strategyRegistry,
+      runtimeStrategyConstructionEnabled: options.runtimeStrategyConstructionEnabled,
+      onStrategyRegistryRuntimeUse: options.onStrategyRegistryRuntimeUse
+    };
+    if (postClaimBootstrapRefresh.deferred === true) {
+      planDeferredClaimedRoomCapacityConstruction(colony, constructionOptions);
+    } else {
       planClaimedRoomConstruction(colony, {
-        respectRoomEnergyBuffer: true,
-        creeps,
-        strategyRegistry: options.strategyRegistry,
-        runtimeStrategyConstructionEnabled: options.runtimeStrategyConstructionEnabled,
-        onStrategyRegistryRuntimeUse: options.onStrategyRegistryRuntimeUse
+        ...constructionOptions
       });
     }
     if (survivalAssessment.mode === 'TERRITORY_READY') {

--- a/prod/test/claimedRoomPlanner.test.ts
+++ b/prod/test/claimedRoomPlanner.test.ts
@@ -1,5 +1,8 @@
 import type { ColonySnapshot } from '../src/colony/colonyRegistry';
-import { planClaimedRoomConstruction } from '../src/construction/claimed-room-planner';
+import {
+  planClaimedRoomConstruction,
+  planDeferredClaimedRoomCapacityConstruction
+} from '../src/construction/claimed-room-planner';
 
 const OK_CODE = 0 as ScreepsReturnCode;
 
@@ -103,6 +106,41 @@ describe('claimed room construction planner', () => {
     expect(result.energyAvailable - result.energyReserved).toBe(200);
     expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
     expect(room.createConstructionSite).toHaveBeenCalledWith(33, 21, STRUCTURE_EXTENSION);
+  });
+
+  it('seeds a deferred RCL2 claimed room extension when spawn coverage already exists', () => {
+    const { room, colony } = makeColony({
+      roomName: 'E29N57',
+      controllerLevel: 2,
+      energyAvailable: 300,
+      energyCapacityAvailable: 300,
+      spawnPosition: { x: 17, y: 24 },
+      sources: []
+    });
+
+    const result = planDeferredClaimedRoomCapacityConstruction(colony);
+
+    expect(result.yielded).toBe(false);
+    expect(result.placements.map((placement) => placement.priority)).toEqual(['extension']);
+    expect(result.energyReserved).toBe(50);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(16, 23, STRUCTURE_EXTENSION);
+  });
+
+  it('does not let deferred capacity construction bypass missing-spawn recovery', () => {
+    const { room, colony } = makeColony({
+      roomName: 'E29N56',
+      controllerLevel: 2,
+      energyAvailable: 300,
+      energyCapacityAvailable: 300,
+      includeSpawn: false,
+      sources: []
+    });
+
+    const result = planDeferredClaimedRoomCapacityConstruction(colony);
+
+    expect(result.placements).toEqual([]);
+    expect(room.createConstructionSite).not.toHaveBeenCalled();
   });
 
   it('plans source containers before source-to-spawn roads in claimed rooms', () => {

--- a/prod/test/claimedRoomPlanner.test.ts
+++ b/prod/test/claimedRoomPlanner.test.ts
@@ -127,6 +127,44 @@ describe('claimed room construction planner', () => {
     expect(room.createConstructionSite).toHaveBeenCalledWith(16, 23, STRUCTURE_EXTENSION);
   });
 
+  it('continues seeding deferred RCL2 claimed room extensions after the first extension is built', () => {
+    const { room, colony } = makeColony({
+      roomName: 'E29N57',
+      controllerLevel: 2,
+      energyAvailable: 350,
+      energyCapacityAvailable: 350,
+      spawnPosition: { x: 17, y: 24 },
+      structures: [makeStructure('extension-1', TEST_GLOBALS.STRUCTURE_EXTENSION, 16, 23, 'E29N57')],
+      sources: []
+    });
+
+    const result = planDeferredClaimedRoomCapacityConstruction(colony);
+
+    expect(result.yielded).toBe(false);
+    expect(result.placements.map((placement) => placement.priority)).toEqual(['extension']);
+    expect(result.energyReserved).toBe(50);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(18, 23, STRUCTURE_EXTENSION);
+  });
+
+  it('stops deferred RCL2 claimed room extension seeding at the RCL2 extension limit', () => {
+    const { room, colony } = makeColony({
+      roomName: 'E29N57',
+      controllerLevel: 2,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      spawnPosition: { x: 17, y: 24 },
+      structures: makeExtensions(5, 'E29N57'),
+      sources: []
+    });
+
+    const result = planDeferredClaimedRoomCapacityConstruction(colony);
+
+    expect(result.yielded).toBe(false);
+    expect(result.placements).toEqual([]);
+    expect(room.createConstructionSite).not.toHaveBeenCalled();
+  });
+
   it('does not let deferred capacity construction bypass missing-spawn recovery', () => {
     const { room, colony } = makeColony({
       roomName: 'E29N56',

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -3127,6 +3127,177 @@ describe('runEconomy', () => {
     });
   });
 
+  it('seeds RCL2 extensions in a deferred post-claim room that already has a spawn', () => {
+    (globalThis as unknown as {
+      FIND_SOURCES: number;
+      FIND_MY_STRUCTURES: number;
+      FIND_STRUCTURES: number;
+      FIND_MY_CONSTRUCTION_SITES: number;
+      FIND_CONSTRUCTION_SITES: number;
+      LOOK_STRUCTURES: LOOK_STRUCTURES;
+      LOOK_CONSTRUCTION_SITES: LOOK_CONSTRUCTION_SITES;
+      STRUCTURE_SPAWN: StructureConstant;
+      STRUCTURE_EXTENSION: StructureConstant;
+      TERRAIN_MASK_WALL: number;
+      RESOURCE_ENERGY: ResourceConstant;
+      Memory: Partial<Memory>;
+    }).FIND_SOURCES = 1;
+    (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 2;
+    (globalThis as unknown as { FIND_STRUCTURES: number }).FIND_STRUCTURES = 3;
+    (globalThis as unknown as { FIND_MY_CONSTRUCTION_SITES: number }).FIND_MY_CONSTRUCTION_SITES = 4;
+    (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 5;
+    (globalThis as unknown as { LOOK_STRUCTURES: LOOK_STRUCTURES }).LOOK_STRUCTURES = 'structure';
+    (globalThis as unknown as { LOOK_CONSTRUCTION_SITES: LOOK_CONSTRUCTION_SITES }).LOOK_CONSTRUCTION_SITES =
+      'constructionSite';
+    (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
+    (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
+    (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+    (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          E29N56: {
+            colony: 'E29N55',
+            roomName: 'E29N56',
+            status: 'detected',
+            claimedAt: 970_100,
+            updatedAt: 970_100,
+            workerTarget: 2
+          },
+          E29N57: {
+            colony: 'E29N55',
+            roomName: 'E29N57',
+            status: 'spawningWorkers',
+            claimedAt: 970_200,
+            updatedAt: 970_200,
+            workerTarget: 2
+          }
+        }
+      }
+    };
+
+    const focusedConstructionSites: ConstructionSite[] = [];
+    const focusedRoom = {
+      name: 'E29N56',
+      energyAvailable: 0,
+      energyCapacityAvailable: 0,
+      controller: {
+        id: 'controller-e29n56',
+        my: true,
+        level: 1,
+        pos: { x: 25, y: 25, roomName: 'E29N56' }
+      } as StructureController,
+      find: jest.fn((type: number) => {
+        if (type === FIND_SOURCES) {
+          return [{ id: 'e29n56-source', pos: { x: 21, y: 21, roomName: 'E29N56' } } as Source];
+        }
+
+        if (type === FIND_MY_CONSTRUCTION_SITES || type === FIND_CONSTRUCTION_SITES) {
+          return focusedConstructionSites;
+        }
+
+        return [];
+      }),
+      lookForAtArea: jest.fn().mockReturnValue([]),
+      createConstructionSite: jest.fn((x: number, y: number, structureType: StructureConstant) => {
+        focusedConstructionSites.push({
+          id: `e29n56-site-${x}-${y}`,
+          structureType,
+          pos: { x, y, roomName: 'E29N56' } as RoomPosition
+        } as ConstructionSite);
+        return OK_CODE;
+      })
+    } as unknown as Room & { createConstructionSite: jest.Mock };
+
+    const deferredConstructionSites: ConstructionSite[] = [];
+    let deferredSpawn = {} as StructureSpawn;
+    const deferredRoom = {
+      name: 'E29N57',
+      energyAvailable: 300,
+      energyCapacityAvailable: 300,
+      controller: {
+        id: 'controller-e29n57',
+        my: true,
+        level: 2,
+        ticksToDowngrade: 10_000,
+        pos: { x: 25, y: 25, roomName: 'E29N57' }
+      } as StructureController,
+      find: jest.fn((type: number, options?: { filter?: (target: unknown) => boolean }) => {
+        if (type === FIND_SOURCES) {
+          return [{ id: 'e29n57-source', pos: { x: 20, y: 20, roomName: 'E29N57' } } as Source];
+        }
+
+        if (type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES) {
+          const structures = [deferredSpawn as unknown as Structure];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_MY_CONSTRUCTION_SITES || type === FIND_CONSTRUCTION_SITES) {
+          return deferredConstructionSites;
+        }
+
+        return [];
+      }),
+      lookForAtArea: jest.fn((lookType: LookConstant, top: number, left: number, bottom: number, right: number) => {
+        if (lookType === LOOK_STRUCTURES) {
+          return [{ x: 17, y: 24, structure: deferredSpawn }];
+        }
+
+        if (lookType === LOOK_CONSTRUCTION_SITES) {
+          return deferredConstructionSites.flatMap((site) =>
+            site.pos.x >= left && site.pos.x <= right && site.pos.y >= top && site.pos.y <= bottom
+              ? [{ x: site.pos.x, y: site.pos.y, constructionSite: site }]
+              : []
+          );
+        }
+
+        return [];
+      }),
+      createConstructionSite: jest.fn((x: number, y: number, structureType: StructureConstant) => {
+        deferredConstructionSites.push({
+          id: `e29n57-site-${x}-${y}`,
+          structureType,
+          pos: { x, y, roomName: 'E29N57' } as RoomPosition
+        } as ConstructionSite);
+        return OK_CODE;
+      })
+    } as unknown as Room & { createConstructionSite: jest.Mock };
+    deferredSpawn = {
+      id: 'spawn-e29n57',
+      name: 'SpawnE29N57',
+      room: deferredRoom,
+      structureType: 'spawn',
+      pos: { x: 17, y: 24, roomName: 'E29N57' } as RoomPosition,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 970_250,
+      rooms: { E29N56: focusedRoom, E29N57: deferredRoom },
+      spawns: { SpawnE29N57: deferredSpawn },
+      creeps: {},
+      map: {
+        getRoomTerrain: jest.fn().mockReturnValue({ get: jest.fn().mockReturnValue(0) }),
+        findRoute: jest.fn(() => [{ exit: 1, room: 'E29N56' }])
+      } as unknown as GameMap,
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+
+    runEconomy();
+
+    expect(focusedRoom.createConstructionSite).toHaveBeenCalledWith(23, 23, STRUCTURE_SPAWN);
+    expect(deferredRoom.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(deferredRoom.createConstructionSite).toHaveBeenCalledWith(16, 23, STRUCTURE_EXTENSION);
+    expect(Memory.territory?.postClaimBootstraps?.E29N56).toMatchObject({
+      status: 'spawnSitePending',
+      updatedAt: 970_250
+    });
+    expect(Memory.territory?.postClaimBootstraps?.E29N57).toMatchObject({
+      status: 'spawningWorkers',
+      updatedAt: 970_250
+    });
+  });
+
   it('emits spawn-site telemetry when a claimed room already has an active spawn site', () => {
     (globalThis as unknown as {
       FIND_MY_CONSTRUCTION_SITES: number;


### PR DESCRIPTION
## Summary
- Fixes #1322.
- Adds a bounded deferred post-claim capacity construction pass so a claimed RCL2 room with spawn coverage can seed bootstrap extension sites even while another claimed room remains the post-claim focus.
- Preserves missing-spawn recovery priority for focused rooms such as E29N56.
- Rebuilds `prod/dist/main.js`.

## Runtime evidence
Fresh alert evidence captured by the runtime-alert cron remains live before this fix:
- `/root/screeps/runtime-artifacts/screeps-monitor/runtime-alert-20260522T091958Z/summary.json`
- `/root/screeps/runtime-artifacts/screeps-monitor/runtime-alert-20260522T091958Z/alert.json`
- `/root/screeps/runtime-artifacts/screeps-monitor/runtime-alert-20260522T091958Z/health-gate.json`
- `/root/screeps/runtime-artifacts/screeps-monitor/runtime-alert-20260522T091958Z/tactical-response.json`

Key facts: `shardX/E29N57` is RCL2 with `owned_spawns=1`, `owned_creeps=5`, `extensionCount=0`, `constructionSiteCount=0`; `shardX/E29N56` is not room-dead because `owned_creeps=6` with active spawn construction progress.

## Verification
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 101 suites / 2021 tests passed
- `cd prod && npm run build`
- `git diff --check`

## Post-merge/deploy gate
After merge and official deploy, verify fresh monitor output for `shardX/E29N57` shows extension construction progress or `extensionCount>0`, and that `health_gate.ok` clears once the active alert condition is gone.
