### PR TITLE
fix(construction): seed first claimed-room extension below reserve

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -13948,15 +13948,25 @@ function planBootstrapExtension(colony, result, budgetState, options) {
   if (countPendingConstructionSites(colony.room, "extension") > 0) {
     return false;
   }
-  if (!canReserveBootstrapExtensionEnergy(colony.room, budgetState, options)) {
+  const canReserveEnergy = canReserveBootstrapExtensionEnergy(colony.room, budgetState, options);
+  if (!canReserveEnergy && !shouldSeedFirstRcl2ExtensionSiteWithoutReservation(colony)) {
     return false;
   }
   const extensionResult = planExtensionConstruction(colony);
   if (extensionResult !== null) {
-    recordPlacement(result, budgetState, "extension", extensionResult, options);
+    recordPlacement(
+      result,
+      budgetState,
+      "extension",
+      extensionResult,
+      canReserveEnergy ? options : { ...options, siteEnergyReservation: 0 }
+    );
     return true;
   }
   return false;
+}
+function shouldSeedFirstRcl2ExtensionSiteWithoutReservation(colony) {
+  return getOwnedRoomRcl6(colony.room) === 2 && hasOwnedSpawn(colony) && countExistingStructures(colony.room, "extension") <= 0 && hasRemainingStructureCapacity(colony.room, "extension");
 }
 function canReserveBootstrapExtensionEnergy(room, budgetState, options) {
   const reservation = getConstructionEnergyReservation("extension", options);
@@ -13965,6 +13975,9 @@ function canReserveBootstrapExtensionEnergy(room, budgetState, options) {
   }
   if (budgetState.energyReserved + reservation > budgetState.energyBudget) {
     return false;
+  }
+  if (options.respectRoomEnergyBuffer !== true) {
+    return true;
   }
   return checkEnergyBufferForExtensionConstruction(room, budgetState.energyReserved + reservation);
 }
@@ -14349,10 +14362,13 @@ function hasBlockingPlacementFailure(result) {
   return lastPlacement !== void 0 && lastPlacement.result !== getOkCode5();
 }
 function hasSpawnCoverage2(colony) {
+  return hasOwnedSpawn(colony) || countPendingConstructionSites(colony.room, "spawn") > 0;
+}
+function hasOwnedSpawn(colony) {
   return colony.spawns.some((spawn) => {
     var _a;
     return ((_a = spawn.room) == null ? void 0 : _a.name) === colony.room.name;
-  }) || countExistingStructures(colony.room, "spawn") > 0 || countPendingConstructionSites(colony.room, "spawn") > 0;
+  }) || countExistingStructures(colony.room, "spawn") > 0;
 }
 function hasCompleteSourceContainerCoverage(room) {
   const sources = getSortedSources3(room);
@@ -22017,7 +22033,7 @@ function isSourceHarvestSufficient(source, harvestCoverageRatio) {
   return normalizeNonNegativeNumber2(source.harvestEnergyPerTick) >= regenEnergyPerTick * harvestCoverageRatio;
 }
 function hasSpawnCollapseRisk(room, threshold) {
-  if (threshold <= 0 || !hasOwnedSpawn(room)) {
+  if (threshold <= 0 || !hasOwnedSpawn2(room)) {
     return false;
   }
   const energyCapacity = normalizeNonNegativeInteger8(room.energyCapacityAvailable);
@@ -22027,7 +22043,7 @@ function hasSpawnCollapseRisk(room, threshold) {
 function hasUnmetSpawnEnergyReservation(room) {
   return getRoomSpawnEnergyReservationState(room).unmetReservedEnergy > 0;
 }
-function hasOwnedSpawn(room) {
+function hasOwnedSpawn2(room) {
   return findOwnedRoomStructures(room).some(
     (structure) => matchesStructureType14(structure.structureType, "STRUCTURE_SPAWN", "spawn")
   );
@@ -22687,7 +22703,7 @@ function hasPostClaimSpawnConstructionImportPressure(roomName) {
   if (!record || record.status !== "spawnSitePending" || ((_d = record.spawnSite) == null ? void 0 : _d.roomName) !== roomName) {
     return false;
   }
-  return !hasOwnedSpawn2(getVisibleRoom7(roomName));
+  return !hasOwnedSpawn3(getVisibleRoom7(roomName));
 }
 function getSpawnSupportExportableEnergy(state) {
   if (state.capacity <= 0 || state.importDemand > 0) {
@@ -22794,7 +22810,7 @@ function hasCriticalSpawnEnergyPressure(roomName) {
   if (!room) {
     return false;
   }
-  return hasOwnedSpawn2(room) && getRoomSpawnEnergyBufferNeed(room).criticalDeficit > 0;
+  return hasOwnedSpawn3(room) && getRoomSpawnEnergyBufferNeed(room).criticalDeficit > 0;
 }
 function selectPlannedTransferReason(importer) {
   if (importer.spawnEnergyBufferDeficit > 0) {
@@ -22802,7 +22818,7 @@ function selectPlannedTransferReason(importer) {
   }
   return hasPostClaimSpawnConstructionImportPressure(importer.roomName) ? "post-claim-spawn-construction" : "storage-balance";
 }
-function hasOwnedSpawn2(room) {
+function hasOwnedSpawn3(room) {
   var _a, _b;
   if (!room) {
     return false;

--- a/prod/src/construction/planner.ts
+++ b/prod/src/construction/planner.ts
@@ -408,17 +408,33 @@ function planBootstrapExtension(
     return false;
   }
 
-  if (!canReserveBootstrapExtensionEnergy(colony.room, budgetState, options)) {
+  const canReserveEnergy = canReserveBootstrapExtensionEnergy(colony.room, budgetState, options);
+  if (!canReserveEnergy && !shouldSeedFirstRcl2ExtensionSiteWithoutReservation(colony)) {
     return false;
   }
 
   const extensionResult = planExtensionConstruction(colony);
   if (extensionResult !== null) {
-    recordPlacement(result, budgetState, 'extension', extensionResult, options);
+    recordPlacement(
+      result,
+      budgetState,
+      'extension',
+      extensionResult,
+      canReserveEnergy ? options : { ...options, siteEnergyReservation: 0 }
+    );
     return true;
   }
 
   return false;
+}
+
+function shouldSeedFirstRcl2ExtensionSiteWithoutReservation(colony: ColonySnapshot): boolean {
+  return (
+    getOwnedRoomRcl(colony.room) === 2 &&
+    hasOwnedSpawn(colony) &&
+    countExistingStructures(colony.room, 'extension') <= 0 &&
+    hasRemainingStructureCapacity(colony.room, 'extension')
+  );
 }
 
 function canReserveBootstrapExtensionEnergy(
@@ -433,6 +449,10 @@ function canReserveBootstrapExtensionEnergy(
 
   if (budgetState.energyReserved + reservation > budgetState.energyBudget) {
     return false;
+  }
+
+  if (options.respectRoomEnergyBuffer !== true) {
+    return true;
   }
 
   return checkEnergyBufferForExtensionConstruction(room, budgetState.energyReserved + reservation);
@@ -1005,9 +1025,15 @@ function hasBlockingPlacementFailure(result: RoomConstructionPlannerResult): boo
 
 function hasSpawnCoverage(colony: ColonySnapshot): boolean {
   return (
-    colony.spawns.some((spawn) => spawn.room?.name === colony.room.name) ||
-    countExistingStructures(colony.room, 'spawn') > 0 ||
+    hasOwnedSpawn(colony) ||
     countPendingConstructionSites(colony.room, 'spawn') > 0
+  );
+}
+
+function hasOwnedSpawn(colony: ColonySnapshot): boolean {
+  return (
+    colony.spawns.some((spawn) => spawn.room?.name === colony.room.name) ||
+    countExistingStructures(colony.room, 'spawn') > 0
   );
 }
 

--- a/prod/test/claimedRoomPlanner.test.ts
+++ b/prod/test/claimedRoomPlanner.test.ts
@@ -108,6 +108,28 @@ describe('claimed room construction planner', () => {
     expect(room.createConstructionSite).toHaveBeenCalledWith(33, 21, STRUCTURE_EXTENSION);
   });
 
+  it('seeds an E29N56 RCL2 first extension site below the energy reserve without reserving energy', () => {
+    const { room, colony } = makeColony({
+      roomName: 'E29N56',
+      controllerLevel: 2,
+      energyAvailable: 206,
+      energyCapacityAvailable: 300,
+      spawnPosition: { x: 17, y: 24 },
+      constructionSites: [
+        makeConstructionSite('source-container-site', TEST_GLOBALS.STRUCTURE_CONTAINER, 21, 21, 'E29N56')
+      ],
+      sources: []
+    });
+
+    const result = planClaimedRoomConstruction(colony);
+
+    expect(result.yielded).toBe(false);
+    expect(result.placements.map((placement) => placement.priority)).toEqual(['extension']);
+    expect(result.energyReserved).toBe(0);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(16, 23, STRUCTURE_EXTENSION);
+  });
+
   it('seeds a deferred RCL2 claimed room extension when spawn coverage already exists', () => {
     const { room, colony } = makeColony({
       roomName: 'E29N57',
@@ -361,6 +383,7 @@ interface MakeColonyOptions {
   includeSpawn?: boolean;
   sources: Source[];
   structures?: Structure[];
+  constructionSites?: ConstructionSite[];
   pathsByTarget?: Record<string, TestPosition[]>;
 }
 
@@ -378,7 +401,7 @@ class MockCostMatrix {
 }
 
 function makeColony(options: MakeColonyOptions): { room: MockRoom; colony: ColonySnapshot } {
-  const constructionSites: ConstructionSite[] = [];
+  const constructionSites: ConstructionSite[] = [...(options.constructionSites ?? [])];
   const roomName = options.roomName ?? 'W2N1';
   const controller = {
     id: 'controller1',

--- a/prod/test/constructionPlanner.test.ts
+++ b/prod/test/constructionPlanner.test.ts
@@ -596,7 +596,7 @@ describe('owned room construction planner', () => {
     expect(room.createConstructionSite).toHaveBeenCalledWith(9, 9, STRUCTURE_EXTENSION);
   });
 
-  it('does not reserve spawn-only bootstrap extension construction below worker spawn energy', () => {
+  it('seeds spawn-only bootstrap extension construction below worker spawn energy without reserving it', () => {
     installOpenTerrain();
     recordBootstrapSurvivalMode();
     const { room, colony } = makeColony({
@@ -611,8 +611,10 @@ describe('owned room construction planner', () => {
 
     const result = planConstructionForColony(colony, { respectRoomEnergyBuffer: true });
 
-    expect(result.placements).toEqual([]);
-    expect(room.createConstructionSite).not.toHaveBeenCalled();
+    expect(result.placements.map((placement) => placement.priority)).toEqual(['extension']);
+    expect(result.energyReserved).toBe(0);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(9, 9, STRUCTURE_EXTENSION);
   });
 
   it('does not start duplicate extension sites during spawn-only bootstrap', () => {


### PR DESCRIPTION
## Summary
- Allows the first RCL2 extension construction site in claimed rooms with spawn coverage even when the worker-spawn energy reserve is not yet met.
- Records that bootstrap placement without reserving energy, preserving survival energy while still seeding the extension site.
- Adds/updates planner coverage for the E29N56 first-extension case and owned-room spawn-only bootstrap behavior.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (101 suites / 2024 tests)
- `cd prod && npm run build`

## Runtime evidence
- Fresh scheduler-side runtime summary after the incident: `runtime-artifacts/runtime-summary-console/runtime-summary-monitor-20260522T124730Z.log` shows `shardX/E29N56` at RCL2 with `extensionConstructionSiteCount=1`, no hostiles.
- Latest runtime-alert text check: `/root/.hermes/cron/output/1df5ef0c3835/2026-05-22_20-48-00.md` response is `[SILENT]`.

Closes #1326
