### PR TITLE
fix(construction): keep claimed-room extension workers building

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -24987,7 +24987,7 @@ function selectHeuristicWorkerTask(creep) {
     survivalAssessment,
     controller
   );
-  if (bootstrapExtensionConstructionSite && !bootstrapNonCriticalWorkSuppressed && !shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) && !shouldKeepSpawnExtensionRefillBeforeBootstrapExtension(creep, spawnOrExtensionEnergySink)) {
+  if (bootstrapExtensionConstructionSite && !shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) && !shouldKeepSpawnExtensionRefillBeforeBootstrapExtension(creep, spawnOrExtensionEnergySink)) {
     return applyMinimumUsefulLoadPolicy(creep, {
       type: "build",
       targetId: bootstrapExtensionConstructionSite.id

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -510,7 +510,6 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
   );
   if (
     bootstrapExtensionConstructionSite &&
-    !bootstrapNonCriticalWorkSuppressed &&
     !shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) &&
     !shouldKeepSpawnExtensionRefillBeforeBootstrapExtension(creep, spawnOrExtensionEnergySink)
   ) {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -10496,6 +10496,46 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
   });
 
+  it('builds the first RCL2 bootstrap extension once another worker covers the spawn refill reserve', () => {
+    const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
+    const spawn = makeEnergySinkWithEnergy('spawn1', 'spawn' as StructureConstant, 250, 50);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [site],
+      controller,
+      energyAvailable: 250,
+      energyCapacityAvailable: 300,
+      myStructures: [spawn as AnyOwnedStructure]
+    });
+    const reservedRefiller = {
+      name: 'AReservedRefiller',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'transfer', targetId: 'spawn1' as Id<AnyStoreStructure> }
+      },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(100) },
+      pos: { getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'spawn1' ? 5 : 99)) },
+      room
+    } as unknown as Creep;
+    const creep = {
+      name: 'ZBootstrapBuilder',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'spawn1' ? 1 : 4)) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ AReservedRefiller: reservedRefiller, ZBootstrapBuilder: creep });
+    recordSurvivalMode('BOOTSTRAP');
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'extension-site1' });
+  });
+
   it('keeps extension refill active when urgent threshold has cleared before controller progress', () => {
     const extension = makeEnergySink('extension1', 'extension' as StructureConstant, 100);
     const controller = {


### PR DESCRIPTION
## Summary
- Keeps claimed-room extension construction available to workers after a first extension site has already been seeded.
- Adds regression coverage for claimed-room extension workers staying on build instead of dropping into non-build fallback while the extension site is still pending.
- Regenerates `prod/dist/main.js` from the verified source change.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (101 suites / 2025 tests passed)
- `cd prod && npm run build`

## Operational notes
- Refs #1326.
- Post-merge requirement: deploy current `main` to official MMO and capture fresh runtime-summary/runtime-alert evidence proving E29N56 extension bootstrap advances (`extensionCount` or extension build progress increases; no `extension_bootstrap_stalled`).
- Safety: official target remains `main / shardX / E29N55`; this PR changes worker task selection only.
