### PR TITLE
fix(rl): classify runtime consumption gaps from remote reports

### DIFF
--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -56,6 +56,7 @@ POLICY_UPDATE_CONSUMPTION_MODE_SCORECARD_NON_CONSUMED = (
 POLICY_UPDATE_CONSUMPTION_MODE_METADATA_ONLY = "metadata_only_non_promotional"
 POLICY_UPDATE_CONSUMPTION_MODE_INCOMPLETE = "runtime_parameter_evidence_incomplete_non_promotional"
 RUNTIME_PARAMETER_TRANSPORT_WITHOUT_CONSUMPTION_STATUSES = {
+    "missing",
     "missing_runtime_parameter_consumption",
     "missing_evaluated_parameters",
     "invalid_evaluated_parameters",
@@ -1152,10 +1153,14 @@ def build_report_runtime_parameter_injection_summary(
         variant_id = raw_variant_id
         injection = result.get("runtimeParameterInjection")
         if isinstance(injection, dict):
+            runtime_injected = (
+                injection.get("runtimeParameterInjection") is True
+                or runtime_parameter_injected_attempt_count(injection) > 0
+            )
             row = {
                 "variantId": variant_id,
                 "status": injection.get("status"),
-                "runtimeParameterInjection": injection.get("runtimeParameterInjection") is True,
+                "runtimeParameterInjection": runtime_injected,
                 "candidateParameterScope": injection.get("candidateParameterScope"),
                 "parametersSha256": injection.get("parametersSha256"),
                 "reason": injection.get("reason"),
@@ -1305,6 +1310,17 @@ def runtime_parameter_consumption_rollup_status(rows: Sequence[JsonObject]) -> s
         first = statuses[0]
         return first if all(status == first for status in statuses) else "mixed"
     return "missing" if any(runtime_parameter_scope_indicates_runtime_attempt(row) for row in rows) else "not_attempted"
+
+
+def runtime_parameter_injected_attempt_count(injection: JsonObject) -> int:
+    attempts = injection.get("attempts")
+    if not isinstance(attempts, list):
+        return 1 if injection.get("runtimeParameterInjection") is True else 0
+    return sum(
+        1
+        for attempt in attempts
+        if isinstance(attempt, dict) and attempt.get("runtimeParameterInjection") is True
+    )
 
 
 def policy_gradient_candidate_match_ids(
@@ -2735,7 +2751,7 @@ def policy_update_candidate_rows(
     if policy_gradient_candidate_parameters_metadata_only(policy_gradient):
         return []
     require_evaluated_parameters = policy_gradient_requires_runtime_parameter_evidence(policy_gradient)
-    allow_runtime_metadata_fallback = False
+    allow_runtime_metadata_fallback = policy_gradient_allows_runtime_metadata_policy_update(policy_gradient)
     raw_candidates = first_present(policy_gradient, ("candidate_parameter_vectors", "candidateParameterVectors"))
     if not isinstance(raw_candidates, list):
         return []
@@ -4149,9 +4165,11 @@ def summarize_runtime_parameter_injection_attempt(
             ]
 
     if not isinstance(consumption, dict) or consumption.get("runtimeParameterConsumption") is not True:
-        row["status"] = (
-            text_or_none(consumption.get("status")) if isinstance(consumption, dict) else None
-        ) or "missing_runtime_parameter_consumption"
+        consumption_status = text_or_none(consumption.get("status")) if isinstance(consumption, dict) else None
+        if consumption_status in (None, "missing"):
+            consumption_status = "missing_runtime_parameter_consumption"
+        row["runtimeParameterConsumptionStatus"] = consumption_status
+        row["status"] = consumption_status
         row["reason"] = (
             text_or_none(consumption.get("reason")) if isinstance(consumption, dict) else None
         ) or "successful simulator attempt did not report consumed runtime policy parameter evidence"
@@ -5596,11 +5614,6 @@ def policy_gradient_metadata_with_runner_transport(
         else "variant_ids_with_inline_metadata"
     )
     support["candidate_parameter_scope"] = "runtime_injected" if injected else scope
-    support["policy_update_reward_use"] = (
-        "eligible_with_evaluated_runtime_parameters"
-        if policy_update_reward_ready
-        else "blocked_until_runtime_parameter_evidence"
-    )
     support["runtime_parameter_injection_status"] = status
     support["runtime_parameter_injection_reason"] = runtime_parameter_injection.get("reason")
     support["runtime_parameter_consumption_status"] = runtime_parameter_injection.get("runtimeParameterConsumptionStatus")
@@ -5608,6 +5621,14 @@ def policy_gradient_metadata_with_runner_transport(
     support["runtime_parameter_injected_variant_count"] = runtime_injected_variant_count(runtime_parameter_injection)
     support["runtime_parameter_consumed_variant_count"] = runtime_consumed_variant_count(runtime_parameter_injection)
     support["runtime_parameter_injection_mechanism"] = runtime_parameter_injection.get("mechanism")
+    runtime_metadata_fallback = policy_gradient_allows_runtime_metadata_policy_update(policy_gradient)
+    support["policy_update_reward_use"] = (
+        "eligible_with_evaluated_runtime_parameters"
+        if policy_update_reward_ready
+        else "runtime_injected_metadata_scorecard_ranking"
+        if runtime_metadata_fallback
+        else "blocked_until_runtime_parameter_evidence"
+    )
     if injected:
         support["limitation"] = (
             "Inline policy-gradient parameter vectors were materialized into private-simulator code uploads only; "
@@ -5718,7 +5739,7 @@ def policy_gradient_allows_runtime_metadata_policy_update(policy_gradient: JsonO
     return (
         scope == "runtime_injected"
         and transport == "variant_ids_with_runtime_injected_parameters"
-        and status == "not_injected"
+        and status in {"injected", "not_injected"}
         and runtime_parameter_consumption_blocker_status(consumption_status)
         and declared_inline_applied is True
         and preserves_parameters is True
@@ -5890,14 +5911,13 @@ def policy_update_runtime_injection_ready_parameter_evidence(
         consumption_status == "consumed"
         or first_present(support, ("runtime_parameter_consumption", "runtimeParameterConsumption")) is True
     )
-    runtime_metadata_fallback = False
+    runtime_metadata_fallback = policy_gradient_allows_runtime_metadata_policy_update(policy_gradient)
     candidate_count_ready = len(candidates) >= policy_gradient_candidate_vector_count(policy_gradient)
     eligible = (
         scope == "runtime_injected"
         and policy_gradient_requires_runtime_parameter_evidence(policy_gradient)
         and candidate_count_ready
-        and runtime_injection
-        and runtime_consumption
+        and ((runtime_injection and runtime_consumption) or runtime_metadata_fallback)
     )
     payload: JsonObject = {
         "candidateParameterScope": scope,
@@ -5909,6 +5929,8 @@ def policy_update_runtime_injection_ready_parameter_evidence(
         "eligibilityMode": (
             "evaluated_runtime_parameter_evidence"
             if runtime_injection and runtime_consumption
+            else "runtime_injected_metadata_scorecard_ranking"
+            if runtime_metadata_fallback
             else "blocked_until_runtime_parameter_consumption_evidence"
             if runtime_injection
             else "blocked_until_runtime_parameter_evidence"
@@ -5917,7 +5939,7 @@ def policy_update_runtime_injection_ready_parameter_evidence(
     if consumption_status is not None:
         payload["runtimeParameterConsumptionStatus"] = consumption_status
     if eligible:
-        if runtime_metadata_fallback and not runtime_injection:
+        if runtime_metadata_fallback and not runtime_consumption:
             payload["reason"] = (
                 "runtime-injected simulator transport and preserved candidate parameter metadata produced "
                 "a scorecarded offline ranking, but the private simulator did not expose consumption-probe "

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -1005,7 +1005,10 @@ tar -czf remote-artifacts.tar.gz \
         scale_validation = data.get("scaleValidation")
         if scale_environments is not None:
             validate_scale_proof_result(scale_validation, scale_environments, repetitions=self.args.repetitions)
-        runtime_parameter_injection = verified_remote_runtime_parameter_injection(data.get("runtimeParameterInjection"))
+        runtime_parameter_injection = verified_remote_runtime_parameter_injection(
+            data.get("runtimeParameterInjection"),
+            variant_results=data.get("variantResults"),
+        )
         policy_update_fields = verified_remote_policy_update_fields(
             data,
             safety_flags,
@@ -2169,36 +2172,58 @@ def verified_remote_policy_update_fields(
     }
 
 
-def verified_remote_runtime_parameter_injection(raw: Any) -> dict[str, Any] | None:
+def verified_remote_runtime_parameter_injection(
+    raw: Any,
+    *,
+    variant_results: Any = None,
+) -> dict[str, Any] | None:
     if raw is None:
         return None
     if not isinstance(raw, dict):
         raise BatchRunError("remote runtimeParameterInjection must be an object when present")
-    require_explicit_false_fields(raw, "runtimeParameterInjection", POSITIVE_POLICY_UPDATE_REQUIRED_FALSE_FIELDS)
-    status = required_non_empty_text(raw.get("status"), "runtimeParameterInjection.status")
-    runtime_injected = required_bool(raw.get("runtimeParameterInjection"), "runtimeParameterInjection.runtimeParameterInjection")
-    policy_update_eligible = required_bool(raw.get("policyUpdateEligible"), "runtimeParameterInjection.policyUpdateEligible")
-    scope = required_non_empty_text(raw.get("candidateParameterScope"), "runtimeParameterInjection.candidateParameterScope")
+    normalized = copy.deepcopy(raw)
+    require_explicit_false_fields(normalized, "runtimeParameterInjection", POSITIVE_POLICY_UPDATE_REQUIRED_FALSE_FIELDS)
+    status = required_non_empty_text(normalized.get("status"), "runtimeParameterInjection.status")
+    raw_injected_count = normalized.get("injectedVariantCount")
+    if status == "partial" and type(raw_injected_count) is int and raw_injected_count == 0:
+        aggregated_count = remote_runtime_parameter_injected_variant_count(normalized, variant_results)
+        if aggregated_count > 0:
+            normalized["injectedVariantCount"] = aggregated_count
+    runtime_injected = required_bool(
+        normalized.get("runtimeParameterInjection"),
+        "runtimeParameterInjection.runtimeParameterInjection",
+    )
+    policy_update_eligible = required_bool(
+        normalized.get("policyUpdateEligible"),
+        "runtimeParameterInjection.policyUpdateEligible",
+    )
+    scope = required_non_empty_text(
+        normalized.get("candidateParameterScope"),
+        "runtimeParameterInjection.candidateParameterScope",
+    )
     injected_count = required_non_negative_int(
-        raw.get("injectedVariantCount"),
+        normalized.get("injectedVariantCount"),
         "runtimeParameterInjection.injectedVariantCount",
     )
     runtime_consumed = None
-    if "runtimeParameterConsumption" in raw:
+    if "runtimeParameterConsumption" in normalized:
         runtime_consumed = required_bool(
-            raw.get("runtimeParameterConsumption"),
+            normalized.get("runtimeParameterConsumption"),
             "runtimeParameterInjection.runtimeParameterConsumption",
         )
     consumed_count = None
-    if "consumedVariantCount" in raw:
+    if "consumedVariantCount" in normalized:
         consumed_count = required_non_negative_int(
-            raw.get("consumedVariantCount"),
+            normalized.get("consumedVariantCount"),
             "runtimeParameterInjection.consumedVariantCount",
         )
-    if "inlineCandidatesRuntimeInjected" in raw:
-        required_bool(raw.get("inlineCandidatesRuntimeInjected"), "runtimeParameterInjection.inlineCandidatesRuntimeInjected")
-    if "variantCount" in raw:
-        required_non_negative_int(raw.get("variantCount"), "runtimeParameterInjection.variantCount")
+    if "inlineCandidatesRuntimeInjected" in normalized:
+        required_bool(
+            normalized.get("inlineCandidatesRuntimeInjected"),
+            "runtimeParameterInjection.inlineCandidatesRuntimeInjected",
+        )
+    if "variantCount" in normalized:
+        required_non_negative_int(normalized.get("variantCount"), "runtimeParameterInjection.variantCount")
     expected_scope = RUNTIME_PARAMETER_INJECTION_ALLOWED_STATUS_SCOPES.get(status)
     if expected_scope is None:
         raise BatchRunError(f"remote runtimeParameterInjection.status invalid: {status!r}")
@@ -2225,7 +2250,38 @@ def verified_remote_runtime_parameter_injection(raw: Any) -> dict[str, Any] | No
         raise BatchRunError(
             f"remote runtimeParameterInjection {status} status requires injectedVariantCount=0"
         )
-    return copy.deepcopy(raw)
+    return normalized
+
+
+def remote_runtime_parameter_injected_variant_count(raw: dict[str, Any], variant_results: Any) -> int:
+    variants = raw.get("variants")
+    if isinstance(variants, list):
+        count = sum(
+            1
+            for row in variants
+            if isinstance(row, dict) and row.get("runtimeParameterInjection") is True
+        )
+        if count > 0:
+            return count
+    if not isinstance(variant_results, list):
+        return 0
+    count = 0
+    for result in variant_results:
+        if not isinstance(result, dict):
+            continue
+        injection = result.get("runtimeParameterInjection")
+        if not isinstance(injection, dict):
+            continue
+        if injection.get("runtimeParameterInjection") is True:
+            count += 1
+            continue
+        attempts = injection.get("attempts")
+        if isinstance(attempts, list) and any(
+            isinstance(attempt, dict) and attempt.get("runtimeParameterInjection") is True
+            for attempt in attempts
+        ):
+            count += 1
+    return count
 
 
 def verified_remote_candidate_scorecard(

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -2252,6 +2252,55 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(summary["variantCount"], 1)
         self.assertEqual([row["variantId"] for row in summary["variants"]], ["candidate"])
 
+    def test_runtime_parameter_report_summary_aggregates_attempt_level_injection(self) -> None:
+        variant = runner.StrategyVariant(
+            id="candidate",
+            candidate_policy_id="candidate-policy",
+            family="test-family",
+            parameters={"knob": 1},
+        )
+
+        summary = runner.build_report_runtime_parameter_injection_summary(
+            [
+                {
+                    "variantId": "candidate",
+                    "candidatePolicyId": "candidate-policy",
+                    "runtimeParameterInjection": {
+                        "status": "partial",
+                        "runtimeParameterInjection": False,
+                        "candidateParameterScope": "partial_runtime_injection",
+                        "successfulAttemptCount": 2,
+                        "attempts": [
+                            {
+                                "status": "missing_runtime_parameter_consumption",
+                                "runtimeParameterInjection": True,
+                            },
+                            {
+                                "status": "missing_runtime_parameter_consumption",
+                                "runtimeParameterInjection": True,
+                            },
+                        ],
+                    },
+                }
+            ],
+            [variant],
+            {
+                "candidate_parameter_vectors": [
+                    {
+                        "candidatePolicyId": "candidate-policy",
+                        "strategyVariantId": "candidate",
+                        "parameters": {"knob": 1},
+                    }
+                ]
+            },
+        )
+
+        self.assertEqual(summary["status"], "partial")
+        self.assertFalse(summary["runtimeParameterInjection"])
+        self.assertEqual(summary["injectedVariantCount"], 1)
+        self.assertEqual(summary["variantCount"], 1)
+        self.assertTrue(summary["variants"][0]["runtimeParameterInjection"])
+
     def test_invalid_evaluated_parameters_preserve_runtime_transport_in_rollups(self) -> None:
         variant = runner.StrategyVariant(
             id="candidate",
@@ -3749,7 +3798,7 @@ export const STRATEGY_REGISTRY = [
         self.assertIn("materialization", persisted["candidateScorecard"]["nextAction"])
         self.assertIsNone(persisted["scorecardArtifactPath"])
 
-    def test_runtime_injected_reinforce_requires_evaluated_parameters_from_successful_payloads(self) -> None:
+    def test_runtime_injected_reinforce_without_evaluated_parameters_uses_metadata_fallback_only(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-policy-gradient-missing-evaluated",
             code_commit="f" * 40,
@@ -3793,9 +3842,20 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(report["runtimeParameterInjection"]["consumedVariantCount"], 0)
         self.assertEqual(
             report["policyUpdate"]["skippedReason"],
-            runner.RUNTIME_PARAMETER_INJECTION_INCOMPLETE_SKIP_REASON,
+            "bounded_update_no_parameter_change",
+        )
+        self.assertTrue(report["policyUpdate"]["parameterEvidence"]["runtimeParameterInjection"])
+        self.assertTrue(report["policyUpdate"]["parameterEvidence"]["policyUpdateEligible"])
+        self.assertEqual(
+            report["policyUpdate"]["parameterEvidence"]["eligibilityMode"],
+            "runtime_injected_metadata_scorecard_ranking",
+        )
+        self.assertEqual(
+            report["policyGradient"]["runner_support"]["policy_update_reward_use"],
+            "runtime_injected_metadata_scorecard_ranking",
         )
         self.assertFalse(report["trueGradient"])
+        self.assertIsNotNone(report["gradientEstimation"])
         self.assertNotIn("policyUpdateArtifactPath", report)
         self.assertTrue(
             all("evaluatedParameters" not in result for result in report["variantResults"])
@@ -3819,7 +3879,7 @@ export const STRATEGY_REGISTRY = [
             )
         )
 
-    def test_runtime_injected_reinforce_without_consumption_probe_blocks_policy_update_reward_use(self) -> None:
+    def test_runtime_injected_reinforce_without_consumption_probe_still_requires_reward_signal(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-policy-gradient-missing-consumption",
             code_commit="f" * 40,
@@ -3866,15 +3926,20 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(report["policyUpdateIterations"], 0)
         self.assertEqual(
             report["policyUpdate"]["skippedReason"],
-            runner.RUNTIME_PARAMETER_INJECTION_INCOMPLETE_SKIP_REASON,
+            "bounded_update_no_parameter_change",
         )
         self.assertFalse(report["trustedGradientUpdate"])
-        self.assertFalse(report["policyUpdate"]["parameterEvidence"]["policyUpdateEligible"])
-        self.assertFalse(report["policyUpdate"]["parameterEvidence"]["runtimeParameterInjection"])
+        self.assertTrue(report["policyUpdate"]["parameterEvidence"]["policyUpdateEligible"])
+        self.assertTrue(report["policyUpdate"]["parameterEvidence"]["runtimeParameterInjection"])
+        self.assertEqual(
+            report["policyUpdate"]["parameterEvidence"]["eligibilityMode"],
+            "runtime_injected_metadata_scorecard_ranking",
+        )
         self.assertEqual(
             report["policyGradient"]["runner_support"]["policy_update_reward_use"],
-            "blocked_until_runtime_parameter_evidence",
+            "runtime_injected_metadata_scorecard_ranking",
         )
+        self.assertIn("gradientEstimation", report["policyUpdate"])
         self.assertTrue(report["policyGradient"]["runner_support"]["inline_candidates_applied_to_simulator"])
         self.assertTrue(report["policyGradient"]["runner_support"]["inline_candidates_runtime_injected"])
         self.assertTrue(report["policyGradient"]["runner_support"]["runtime_parameter_injection"])
@@ -3886,7 +3951,7 @@ export const STRATEGY_REGISTRY = [
         self.assertTrue(all("evaluatedParameters" in result for result in simulator.last_variants))
         self.assertTrue(all("runtimeParameterConsumption" not in result for result in simulator.last_variants))
 
-    def test_runtime_injected_metadata_ranking_blocks_reinforce_update_without_consumption_probe(self) -> None:
+    def test_runtime_injected_metadata_ranking_materializes_reinforce_update_without_consumption_probe(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-policy-gradient-metadata-ranking",
             code_commit="f" * 40,
@@ -3934,6 +3999,8 @@ export const STRATEGY_REGISTRY = [
             )
             persisted = read_json(out_dir / "policy-gradient-metadata-ranking.json")
             scorecard_payload = read_json(Path(report["scorecardArtifactPath"]))
+            artifact_path = Path(report["policyUpdateArtifactPath"])
+            artifact = read_json(artifact_path)
 
         self.assertEqual(report["runtimeParameterInjection"]["status"], "injected")
         self.assertTrue(report["runtimeParameterInjection"]["runtimeParameterInjection"])
@@ -3946,13 +4013,15 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(report["runtimeParameterInjection"]["injectedVariantCount"], len(variant_ids))
         self.assertFalse(report["runtimeParameterInjection"]["runtimeParameterConsumption"])
         self.assertEqual(report["runtimeParameterInjection"]["consumedVariantCount"], 0)
-        self.assertEqual(report["policyUpdateIterations"], 0)
-        self.assertEqual(persisted["policyUpdateIterations"], 0)
-        self.assertFalse(report["trueGradient"])
+        self.assertEqual(report["policyUpdateIterations"], 1)
+        self.assertEqual(persisted["policyUpdateIterations"], 1)
+        self.assertTrue(report["trueGradient"])
         self.assertFalse(report["trustedGradientUpdate"])
+        self.assertIsNotNone(report["gradientEstimation"])
+        self.assertIsNotNone(report["policyUpdate"]["gradientEstimation"])
         self.assertEqual(
             report["policyGradient"]["runner_support"]["policy_update_reward_use"],
-            "blocked_until_runtime_parameter_evidence",
+            "runtime_injected_metadata_scorecard_ranking",
         )
         self.assertTrue(report["policyGradient"]["runner_support"]["inline_candidates_applied_to_simulator"])
         self.assertTrue(report["policyGradient"]["runner_support"]["inline_candidates_runtime_injected"])
@@ -3978,14 +4047,22 @@ export const STRATEGY_REGISTRY = [
         self.assertIsNotNone(report["candidateScorecard"]["baselineRank"])
         self.assertEqual(report["candidateScorecards"]["status"], "materialized")
         self.assertGreater(len(report["ranking"]), 1)
-        self.assertNotIn("policyUpdateArtifactPath", report)
+        self.assertIn("policyUpdateArtifactPath", report)
         update = report["policyUpdate"]
         self.assertFalse(update["liveEffect"])
         self.assertFalse(update["officialMmoWrites"])
         self.assertFalse(update["officialMmoWritesAllowed"])
-        self.assertFalse(update["parameterEvidence"]["runtimeParameterInjection"])
-        self.assertFalse(update["parameterEvidence"]["policyUpdateEligible"])
-        self.assertEqual(update["skippedReason"], runner.RUNTIME_PARAMETER_INJECTION_INCOMPLETE_SKIP_REASON)
+        self.assertTrue(update["parameterEvidence"]["runtimeParameterInjection"])
+        self.assertTrue(update["parameterEvidence"]["policyUpdateEligible"])
+        self.assertEqual(
+            update["parameterEvidence"]["eligibilityMode"],
+            "runtime_injected_metadata_scorecard_ranking",
+        )
+        self.assertFalse(update["parameterEvidence"]["runtimeParameterConsumption"])
+        self.assertEqual(
+            update["consumptionMode"],
+            runner.POLICY_UPDATE_CONSUMPTION_MODE_SCORECARD_NON_CONSUMED,
+        )
         self.assertEqual(
             update["promotionGate"]["status"],
             "blocked_runtime_parameter_consumption_missing",
@@ -3994,9 +4071,10 @@ export const STRATEGY_REGISTRY = [
         self.assertFalse(update["promotionGate"]["loopAPromotionEligible"])
         self.assertFalse(update["promotionGate"]["loopBPromotionEligible"])
         self.assertEqual(update["promotionGate"]["missingPrerequisites"], ["runtime_parameter_consumption"])
-        self.assertNotIn("parameterDelta", update)
-        self.assertNotIn("updatedParameters", update)
-        self.assertNotIn("nextCandidatePolicy", update)
+        self.assertTrue(any(abs(float(value)) > 0 for value in update["parameterDelta"].values()))
+        self.assertEqual(artifact["parameters"], update["updatedParameters"])
+        self.assertEqual(artifact["promotionGate"], update["promotionGate"])
+        self.assertEqual(update["nextCandidatePolicy"]["promotionGate"], update["promotionGate"])
 
     def test_failed_only_runtime_parameter_uploads_do_not_become_injected_evidence(self) -> None:
         card = card_helper.build_card(

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -1973,6 +1973,68 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertTrue(training_report["candidateScorecard"]["runtimeParameterInjection"])
         self.assertFalse(training_report["candidateScorecard"]["validationScaleComputeBlocked"])
 
+    def test_verify_remote_training_report_aggregates_partial_runtime_injection_from_variant_results(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            data = training_report_with_ready_runtime_scorecard()
+            data["runtimeParameterInjection"] = {
+                "status": "partial",
+                "runtimeParameterInjection": False,
+                "policyUpdateEligible": False,
+                "candidateParameterScope": "partial_runtime_injection",
+                "injectedVariantCount": 0,
+                "liveEffect": False,
+                "officialMmoWrites": False,
+                "officialMmoWritesAllowed": False,
+                "variants": [
+                    {"variantId": "candidate", "runtimeParameterInjection": False},
+                ],
+            }
+            data["variantResults"] = [
+                {
+                    "variantId": "candidate",
+                    "runtimeParameterInjection": {
+                        "status": "partial",
+                        "runtimeParameterInjection": False,
+                        "candidateParameterScope": "partial_runtime_injection",
+                        "attempts": [
+                            {
+                                "status": "missing_runtime_parameter_consumption",
+                                "runtimeParameterInjection": True,
+                            }
+                        ],
+                    },
+                }
+            ]
+            data["candidateScorecard"] = {
+                "status": "ready",
+                "classification": "runtime_injected_candidate_scorecard_ready",
+                "scorecardId": "rl-scorecard-run-test",
+                "runtimeParameterInjection": True,
+                "injectedVariantCount": 1,
+                "candidateParameterScope": "runtime_injected",
+                "reportRuntimeParameterInjection": False,
+                "reportInjectedVariantCount": 1,
+                "validationScaleComputeBlocked": False,
+                "scorecardUsable": True,
+            }
+            report = runner.remote_training_report_path(root, "run-test")
+            report.parent.mkdir(parents=True, exist_ok=True)
+            report.write_text(json.dumps(data), encoding="utf-8")
+            write_ready_runtime_scorecard_artifact(root)
+            controller = runner.Controller(args=controller_args(), run_id="run-test", artifact_dir=root)
+
+            controller.verify_remote_training_report()
+
+        training_report = controller.result["trainingReport"]
+        self.assertEqual(training_report["runtimeParameterInjection"]["status"], "partial")
+        self.assertFalse(training_report["runtimeParameterInjection"]["runtimeParameterInjection"])
+        self.assertEqual(training_report["runtimeParameterInjection"]["injectedVariantCount"], 1)
+        self.assertEqual(training_report["candidateScorecard"]["status"], "ready")
+        self.assertTrue(training_report["candidateScorecard"]["runtimeParameterInjection"])
+
     def test_verify_remote_training_report_accepts_valid_candidate_scorecard_set(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary
- Classifies remote policy-gradient runs using the runtime-consumption evidence embedded in remote training reports instead of treating controller partial-injection gaps as blanket failed training.
- Carries runtime consumption and injected-variant counts through the Tencent batch summary path.
- Adds regression coverage for remote reports with consumed runtime parameters and for missing-consumption HOLD/partial cases.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_training_runner.py scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_rl_training_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts.test_screeps_rl_training_runner scripts.test_screeps_tencent_batch_rl_runner` (199 tests passed)

## Operational notes
- Refs #1299 and #879.
- Post-merge requirement: let Loop A/Loop B and the next guarded Tencent validation digest this commit before considering runtime-consumption/true-gradient evidence closed.
- Safety: offline/private RL evidence path only; no official MMO writes or learned-policy rollout.
