### PR TITLE
fix(rl): preserve non-consumed runtime scorecards

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -2255,7 +2255,7 @@ def verified_remote_runtime_parameter_injection(
         raise BatchRunError("remote runtimeParameterInjection policyUpdateEligible requires runtimeParameterInjection=true")
     elif status == "injected":
         raise BatchRunError("remote runtimeParameterInjection status injected requires runtimeParameterInjection=true")
-    elif status == "partial" and injected_count == 0 and runtime_consumed is not False:
+    elif status == "partial" and injected_count == 0:
         raise BatchRunError("remote runtimeParameterInjection partial status requires positive injectedVariantCount")
     elif status in {"metadata_only", "not_injected"} and injected_count != 0:
         raise BatchRunError(

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -124,6 +124,17 @@ RUNTIME_PARAMETER_INJECTION_ALLOWED_STATUS_SCOPES = {
 }
 MULTI_CANDIDATE_SCORECARD_SET_TYPE = "screeps-rl-multi-candidate-scorecard-set"
 CANDIDATE_SCORECARD_SET_STATUSES = {"blocked", "materialized", "partial", "planned", "ready"}
+RUNTIME_PARAMETER_TRANSPORT_WITHOUT_CONSUMPTION_STATUSES = {
+    "missing",
+    "missing_runtime_parameter_consumption",
+    "missing_evaluated_parameters",
+    "invalid_evaluated_parameters",
+}
+RUNTIME_PARAMETER_CONSUMPTION_BLOCKER_STATUSES = {
+    "missing",
+    "mixed",
+    *RUNTIME_PARAMETER_TRANSPORT_WITHOUT_CONSUMPTION_STATUSES,
+}
 ZERO_ITERATION_POLICY_UPDATE_ALLOWED_KEYS = {
     "algorithm",
     "anchor",
@@ -2244,7 +2255,7 @@ def verified_remote_runtime_parameter_injection(
         raise BatchRunError("remote runtimeParameterInjection policyUpdateEligible requires runtimeParameterInjection=true")
     elif status == "injected":
         raise BatchRunError("remote runtimeParameterInjection status injected requires runtimeParameterInjection=true")
-    elif status == "partial" and injected_count == 0:
+    elif status == "partial" and injected_count == 0 and runtime_consumed is not False:
         raise BatchRunError("remote runtimeParameterInjection partial status requires positive injectedVariantCount")
     elif status in {"metadata_only", "not_injected"} and injected_count != 0:
         raise BatchRunError(
@@ -2284,6 +2295,19 @@ def remote_runtime_parameter_injected_variant_count(raw: dict[str, Any], variant
     return count
 
 
+def remote_runtime_parameter_consumption_blocked(raw: dict[str, Any] | None) -> bool:
+    if not isinstance(raw, dict):
+        return False
+    if text_value(raw.get("candidateParameterScope")) != "runtime_injected":
+        return False
+    if raw.get("runtimeParameterConsumption") is True:
+        return False
+    status = text_value(raw.get("runtimeParameterConsumptionStatus"))
+    if status in RUNTIME_PARAMETER_CONSUMPTION_BLOCKER_STATUSES:
+        return True
+    return raw.get("runtimeParameterConsumption") is False
+
+
 def verified_remote_candidate_scorecard(
     raw: Any,
     *,
@@ -2319,9 +2343,19 @@ def verified_remote_candidate_scorecard(
     )
     scorecard_usable = required_bool(raw.get("scorecardUsable"), "candidateScorecard.scorecardUsable")
     injected_count = required_non_negative_int(raw.get("injectedVariantCount"), "candidateScorecard.injectedVariantCount")
+    runtime_consumed = None
+    if "runtimeParameterConsumption" in raw:
+        runtime_consumed = required_bool(
+            raw.get("runtimeParameterConsumption"),
+            "candidateScorecard.runtimeParameterConsumption",
+        )
     top_level_runtime_injected = (
         runtime_parameter_injection is not None
         and runtime_parameter_injection.get("runtimeParameterInjection") is True
+    )
+    top_level_runtime_consumed = (
+        runtime_parameter_injection is not None
+        and runtime_parameter_injection.get("runtimeParameterConsumption") is True
     )
     top_level_status = (
         runtime_parameter_injection.get("status")
@@ -2370,6 +2404,10 @@ def verified_remote_candidate_scorecard(
             missing_prerequisite == "gradient_stability"
             or classification == "gradient_stability_untrusted_scorecard_materialized"
         )
+        consumption_blocked = (
+            missing_prerequisite == "runtime_parameter_consumption"
+            or classification == "runtime_parameter_consumption_missing_scorecard_materialized"
+        )
         if (
             missing_prerequisite == "gradient_stability"
             and classification not in (None, "gradient_stability_untrusted_scorecard_materialized")
@@ -2398,11 +2436,40 @@ def verified_remote_candidate_scorecard(
                 raise BatchRunError(
                     "remote candidateScorecard gradient-stability materialized status requires gradient_stability prerequisite"
                 )
+        elif consumption_blocked:
+            if (
+                missing_prerequisite == "runtime_parameter_consumption"
+                and classification not in (None, "runtime_parameter_consumption_missing_scorecard_materialized")
+            ) or (
+                classification == "runtime_parameter_consumption_missing_scorecard_materialized"
+                and missing_prerequisite not in (None, "runtime_parameter_consumption")
+            ):
+                raise BatchRunError(
+                    "remote candidateScorecard runtime-consumption materialized status has mismatched classification"
+                )
+            if runtime_consumed is True or top_level_runtime_consumed:
+                raise BatchRunError(
+                    "remote candidateScorecard runtime-consumption materialized status contradicts consumption proof"
+                )
+            candidate_scope = text_value(raw.get("candidateParameterScope"))
+            if not (
+                (runtime_consumed is False and candidate_scope == "runtime_injected")
+                or remote_runtime_parameter_consumption_blocked(runtime_parameter_injection)
+            ):
+                raise BatchRunError(
+                    "remote candidateScorecard runtime-consumption materialized status requires "
+                    "runtimeParameterConsumption=false proof"
+                )
+            if top_level_runtime_partially_injected and injected_count > top_level_injected_count:
+                raise BatchRunError(
+                    "remote candidateScorecard runtime-consumption materialized status exceeds "
+                    "top-level runtimeParameterInjection injectedVariantCount"
+                )
         elif top_level_runtime_injected or runtime_injected:
             raise BatchRunError(
                 "remote candidateScorecard materialized status requires incomplete runtimeParameterInjection proof"
             )
-        if not gradient_blocked and injected_count != 0:
+        if not gradient_blocked and not consumption_blocked and injected_count != 0:
             raise BatchRunError(
                 "remote candidateScorecard materialized status requires injectedVariantCount=0"
             )

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -2359,17 +2359,17 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(scorecard["overallGate"]["status"], "HOLD")
         self.assertEqual(training_report["candidateScorecards"]["status"], "materialized")
 
-    def test_verify_remote_training_report_preserves_partial_zero_count_consumption_gap(self) -> None:
+    def test_verify_remote_training_report_preserves_metadata_only_zero_count_runtime_injection_gap(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             data = training_report_with_ready_runtime_scorecard()
             data["runtimeParameterInjection"] = {
-                "status": "partial",
+                "status": "metadata_only",
                 "runtimeParameterInjection": False,
                 "runtimeParameterConsumption": False,
                 "runtimeParameterConsumptionStatus": "missing_runtime_parameter_consumption",
                 "policyUpdateEligible": False,
-                "candidateParameterScope": "partial_runtime_injection",
+                "candidateParameterScope": "metadata_only",
                 "injectedVariantCount": 0,
                 "consumedVariantCount": 0,
                 "liveEffect": False,
@@ -2378,13 +2378,13 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             }
             data["candidateScorecard"] = {
                 "status": "materialized",
-                "classification": "runtime_parameter_injection_partial_scorecard_materialized",
+                "classification": "runtime_parameter_injection_metadata_only_scorecard_materialized",
                 "scorecardId": "rl-scorecard-run-test",
                 "runtimeParameterInjection": False,
                 "runtimeParameterConsumption": False,
                 "injectedVariantCount": 0,
                 "consumedVariantCount": 0,
-                "candidateParameterScope": "partial_runtime_injection",
+                "candidateParameterScope": "metadata_only",
                 "missingPrerequisite": "runtime_parameter_injection",
                 "validationScaleComputeBlocked": True,
                 "scorecardUsable": True,
@@ -2398,7 +2398,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             controller.verify_remote_training_report()
 
         runtime_parameter_injection = controller.result["trainingReport"]["runtimeParameterInjection"]
-        self.assertEqual(runtime_parameter_injection["status"], "partial")
+        self.assertEqual(runtime_parameter_injection["status"], "metadata_only")
         self.assertFalse(runtime_parameter_injection["runtimeParameterConsumption"])
         self.assertEqual(runtime_parameter_injection["injectedVariantCount"], 0)
         self.assertEqual(
@@ -2673,6 +2673,25 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                     candidate_parameter_scope="partial_runtime_injection",
                     injected_variant_count=0,
                 ),
+                "partial status requires positive injectedVariantCount",
+            ),
+            (
+                "partial zero injected count with explicit consumption gap",
+                {
+                    "runtimeParameterInjection": {
+                        "status": "partial",
+                        "runtimeParameterInjection": False,
+                        "runtimeParameterConsumption": False,
+                        "runtimeParameterConsumptionStatus": "missing_runtime_parameter_consumption",
+                        "policyUpdateEligible": False,
+                        "candidateParameterScope": "partial_runtime_injection",
+                        "injectedVariantCount": 0,
+                        "consumedVariantCount": 0,
+                        "liveEffect": False,
+                        "officialMmoWrites": False,
+                        "officialMmoWritesAllowed": False,
+                    }
+                },
                 "partial status requires positive injectedVariantCount",
             ),
         )

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -2266,6 +2266,146 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 self.assertFalse(training_report["candidateScorecard"]["trustedGradientUpdate"])
                 self.assertTrue(training_report["candidateScorecard"]["highVariance"])
 
+    def test_verify_remote_training_report_preserves_non_consumed_materialized_scorecard(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            data = training_report_with_ready_runtime_scorecard()
+            data["runtimeParameterInjection"] = {
+                "status": "injected",
+                "runtimeParameterInjection": True,
+                "runtimeParameterConsumption": False,
+                "runtimeParameterConsumptionStatus": "missing_runtime_parameter_consumption",
+                "policyUpdateEligible": False,
+                "candidateParameterScope": "runtime_injected",
+                "injectedVariantCount": 5,
+                "consumedVariantCount": 0,
+                "liveEffect": False,
+                "officialMmoWrites": False,
+                "officialMmoWritesAllowed": False,
+            }
+            held_scorecard = {
+                "status": "materialized",
+                "classification": "runtime_parameter_consumption_missing_scorecard_materialized",
+                "scorecardId": "rl-scorecard-run-test",
+                "scorecardArtifactPath": READY_RUNTIME_SCORECARD_PATH,
+                "candidateStrategyId": "candidate",
+                "baselineStrategyId": "baseline",
+                "candidateRank": 1,
+                "baselineRank": 2,
+                "comparisonKey": "candidate::vs::baseline",
+                "runtimeParameterInjection": True,
+                "runtimeParameterConsumption": False,
+                "injectedVariantCount": 1,
+                "consumedVariantCount": 0,
+                "candidateParameterScope": "runtime_injected",
+                "reportRuntimeParameterInjection": True,
+                "reportRuntimeParameterConsumption": False,
+                "reportInjectedVariantCount": 5,
+                "reportConsumedVariantCount": 0,
+                "missingPrerequisite": "runtime_parameter_consumption",
+                "validationScaleComputeBlocked": True,
+                "scorecardUsable": True,
+                "overallGate": {
+                    "status": "HOLD",
+                    "runtimeParameterInjectionProven": False,
+                },
+                "liveEffect": False,
+                "officialMmoWrites": False,
+                "officialMmoWritesAllowed": False,
+            }
+            data["candidateScorecard"] = copy.deepcopy(held_scorecard)
+            data["candidateScorecards"] = {
+                "type": runner.MULTI_CANDIDATE_SCORECARD_SET_TYPE,
+                "schemaVersion": 1,
+                "status": "materialized",
+                "classification": "multi_candidate_scorecards_materialized",
+                "reportId": "run-test",
+                "comparisonCount": 1,
+                "candidateCount": 1,
+                "baselineCount": 1,
+                "candidateStrategyIds": ["candidate"],
+                "baselineStrategyIds": ["baseline"],
+                "selectedScorecardId": "rl-scorecard-run-test",
+                "materializedScorecardCount": 1,
+                "blockedComparisonCount": 0,
+                "readyComparisonCount": 0,
+                "validationScaleComputeBlocked": True,
+                "scorecardUsable": True,
+                "missingPrerequisites": ["runtime_parameter_consumption"],
+                "reasonCodes": ["runtime_parameter_consumption_missing_scorecard_materialized"],
+                "liveEffect": False,
+                "officialMmoWrites": False,
+                "officialMmoWritesAllowed": False,
+                "comparisons": [copy.deepcopy(held_scorecard)],
+            }
+            report = runner.remote_training_report_path(root, "run-test")
+            report.parent.mkdir(parents=True, exist_ok=True)
+            report.write_text(json.dumps(data), encoding="utf-8")
+            write_ready_runtime_scorecard_artifact(root)
+            controller = runner.Controller(args=controller_args(), run_id="run-test", artifact_dir=root)
+
+            controller.verify_remote_training_report()
+
+        training_report = controller.result["trainingReport"]
+        scorecard = training_report["candidateScorecard"]
+        self.assertEqual(scorecard["status"], "materialized")
+        self.assertEqual(
+            scorecard["classification"],
+            "runtime_parameter_consumption_missing_scorecard_materialized",
+        )
+        self.assertTrue(scorecard["runtimeParameterInjection"])
+        self.assertFalse(scorecard["runtimeParameterConsumption"])
+        self.assertEqual(scorecard["missingPrerequisite"], "runtime_parameter_consumption")
+        self.assertEqual(scorecard["overallGate"]["status"], "HOLD")
+        self.assertEqual(training_report["candidateScorecards"]["status"], "materialized")
+
+    def test_verify_remote_training_report_preserves_partial_zero_count_consumption_gap(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            data = training_report_with_ready_runtime_scorecard()
+            data["runtimeParameterInjection"] = {
+                "status": "partial",
+                "runtimeParameterInjection": False,
+                "runtimeParameterConsumption": False,
+                "runtimeParameterConsumptionStatus": "missing_runtime_parameter_consumption",
+                "policyUpdateEligible": False,
+                "candidateParameterScope": "partial_runtime_injection",
+                "injectedVariantCount": 0,
+                "consumedVariantCount": 0,
+                "liveEffect": False,
+                "officialMmoWrites": False,
+                "officialMmoWritesAllowed": False,
+            }
+            data["candidateScorecard"] = {
+                "status": "materialized",
+                "classification": "runtime_parameter_injection_partial_scorecard_materialized",
+                "scorecardId": "rl-scorecard-run-test",
+                "runtimeParameterInjection": False,
+                "runtimeParameterConsumption": False,
+                "injectedVariantCount": 0,
+                "consumedVariantCount": 0,
+                "candidateParameterScope": "partial_runtime_injection",
+                "missingPrerequisite": "runtime_parameter_injection",
+                "validationScaleComputeBlocked": True,
+                "scorecardUsable": True,
+            }
+            report = runner.remote_training_report_path(root, "run-test")
+            report.parent.mkdir(parents=True, exist_ok=True)
+            report.write_text(json.dumps(data), encoding="utf-8")
+            write_ready_runtime_scorecard_artifact(root)
+            controller = runner.Controller(args=controller_args(), run_id="run-test", artifact_dir=root)
+
+            controller.verify_remote_training_report()
+
+        runtime_parameter_injection = controller.result["trainingReport"]["runtimeParameterInjection"]
+        self.assertEqual(runtime_parameter_injection["status"], "partial")
+        self.assertFalse(runtime_parameter_injection["runtimeParameterConsumption"])
+        self.assertEqual(runtime_parameter_injection["injectedVariantCount"], 0)
+        self.assertEqual(
+            controller.result["trainingReport"]["candidateScorecard"]["missingPrerequisite"],
+            "runtime_parameter_injection",
+        )
+
     def test_verify_remote_training_report_rejects_gradient_materialized_scorecard_without_runtime_proof(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- Preserve remote training reports whose runtime parameter vectors were transported but not yet consumed by the simulator runtime.
- Treat non-consumed runtime scorecards as HOLD/non-promotional evidence instead of discarding the entire Tencent batch as failed.
- Add regression coverage for non-consumed materialized scorecards and partial zero-count consumption gaps.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts.test_screeps_tencent_batch_rl_runner -v` (98 tests)

## Safety
- No official MMO writes.
- Preserves `liveEffect=false`, `officialMmoWrites=false`, and HOLD/non-promotional semantics when runtime consumption proof is absent.
- Does not launch Tencent compute; current/next paid validation remains gated by the steward.

Refs #1299
Refs #879
Refs #1032
Refs #1233
