### PR TITLE
fix(rl): emit runtime parameter consumption evidence

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -46641,6 +46641,7 @@ function getGameTime45() {
 var RUNTIME_POLICY_PARAMETERS_GLOBAL = "__SCREEPS_RL_RUNTIME_POLICY_PARAMETERS__";
 var RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL = "__SCREEPS_RL_RUNTIME_POLICY_PARAMETER_CONSUMPTION__";
 var RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER = "screeps-rl-runtime-policy-parameters-consumer-v1";
+var RUNTIME_POLICY_PARAMETER_CONSUMPTION_LOG_PREFIX = "#runtime-parameter-consumption ";
 function applyRuntimePolicyParametersToRegistry(registry) {
   var _a;
   const clonedRegistry = registry.map(cloneStrategyRegistryEntry);
@@ -46750,6 +46751,7 @@ function persistRuntimePolicyParameterConsumptionEvidence(evidence) {
     tick: runtimeTick()
   };
   publishRuntimePolicyParameterConsumptionEvidence(persistedEvidence);
+  emitRuntimePolicyParameterConsumptionEvidence(persistedEvidence);
 }
 function readRuntimePolicyParameterPayload() {
   const root = globalThis;
@@ -46824,6 +46826,15 @@ function buildConsumptionEvidence(options) {
 function publishRuntimePolicyParameterConsumptionEvidence(evidence) {
   const root = globalThis;
   root[RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL] = evidence;
+}
+function emitRuntimePolicyParameterConsumptionEvidence(evidence) {
+  if (evidence.runtimeParameterInjection !== true) {
+    return;
+  }
+  try {
+    console.log(`${RUNTIME_POLICY_PARAMETER_CONSUMPTION_LOG_PREFIX}${JSON.stringify(evidence)}`);
+  } catch (_error) {
+  }
 }
 function stickyRuntimePolicyParameterConsumptionEvidence(evidence, previous) {
   if (evidence.consumed || !shouldCarryRuntimePolicyParameterConsumptionEvidence(evidence, previous)) {

--- a/prod/src/strategy/runtimePolicyParameters.ts
+++ b/prod/src/strategy/runtimePolicyParameters.ts
@@ -3,6 +3,7 @@ import type { StrategyKnobValue, StrategyRegistryEntry } from './strategyRegistr
 export const RUNTIME_POLICY_PARAMETERS_GLOBAL = '__SCREEPS_RL_RUNTIME_POLICY_PARAMETERS__';
 export const RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL = '__SCREEPS_RL_RUNTIME_POLICY_PARAMETER_CONSUMPTION__';
 export const RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER = 'screeps-rl-runtime-policy-parameters-consumer-v1';
+export const RUNTIME_POLICY_PARAMETER_CONSUMPTION_LOG_PREFIX = '#runtime-parameter-consumption ';
 
 export interface RuntimePolicyParameterConsumptionEvidence {
   type: 'screeps-rl-runtime-policy-parameter-consumption';
@@ -176,6 +177,7 @@ export function persistRuntimePolicyParameterConsumptionEvidence(
     tick: runtimeTick()
   };
   publishRuntimePolicyParameterConsumptionEvidence(persistedEvidence);
+  emitRuntimePolicyParameterConsumptionEvidence(persistedEvidence);
 }
 
 function readRuntimePolicyParameterPayload(): RuntimePolicyParameterPayload | null {
@@ -283,6 +285,18 @@ function publishRuntimePolicyParameterConsumptionEvidence(
 ): void {
   const root = globalThis as typeof globalThis & Record<string, unknown>;
   root[RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL] = evidence;
+}
+
+function emitRuntimePolicyParameterConsumptionEvidence(evidence: RuntimePolicyParameterConsumptionEvidence): void {
+  if (evidence.runtimeParameterInjection !== true) {
+    return;
+  }
+
+  try {
+    console.log(`${RUNTIME_POLICY_PARAMETER_CONSUMPTION_LOG_PREFIX}${JSON.stringify(evidence)}`);
+  } catch (_error) {
+    // Runtime evidence is also persisted to Memory/global; logging must never affect the tick.
+  }
 }
 
 function stickyRuntimePolicyParameterConsumptionEvidence(

--- a/prod/test/runtimePolicyParameters.test.ts
+++ b/prod/test/runtimePolicyParameters.test.ts
@@ -1,4 +1,5 @@
 import {
+  RUNTIME_POLICY_PARAMETER_CONSUMPTION_LOG_PREFIX,
   RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL,
   RUNTIME_POLICY_PARAMETERS_GLOBAL,
   applyRuntimePolicyParametersToRegistry,
@@ -67,6 +68,7 @@ describe('runtime policy parameters', () => {
   });
 
   it('preserves runtime-injected but non-consumed evidence for diagnostics', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
     (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETERS_GLOBAL] = {
       runtimeParameterInjection: true,
       candidateParameterScope: 'runtime_injected',
@@ -79,18 +81,22 @@ describe('runtime policy parameters', () => {
       parametersSha256: 'miss-sha'
     };
 
-    const result = applyRuntimePolicyParametersToRegistry(DEFAULT_STRATEGY_REGISTRY);
-    persistRuntimePolicyParameterConsumptionEvidence(result.evidence);
+    try {
+      const result = applyRuntimePolicyParametersToRegistry(DEFAULT_STRATEGY_REGISTRY);
+      persistRuntimePolicyParameterConsumptionEvidence(result.evidence);
 
-    expect(result.evidence).toMatchObject({
-      runtimeParameterInjection: true,
-      consumed: false,
-      reason: 'runtime policy parameter payload did not match any strategy registry entry',
-      parametersSha256: 'miss-sha'
-    });
-    expect(
-      (globalThis as { Memory?: { rlRuntimePolicyParameters?: unknown } }).Memory?.rlRuntimePolicyParameters
-    ).toMatchObject(result.evidence);
+      expect(result.evidence).toMatchObject({
+        runtimeParameterInjection: true,
+        consumed: false,
+        reason: 'runtime policy parameter payload did not match any strategy registry entry',
+        parametersSha256: 'miss-sha'
+      });
+      expect(
+        (globalThis as { Memory?: { rlRuntimePolicyParameters?: unknown } }).Memory?.rlRuntimePolicyParameters
+      ).toMatchObject(result.evidence);
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 
   it('does not fan out explicit candidate payloads to every family sibling', () => {
@@ -189,6 +195,7 @@ describe('runtime policy parameters', () => {
   });
 
   it('keeps consumed evidence sticky across ticks for the same injected payload', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
     (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETERS_GLOBAL] = {
       runtimeParameterInjection: true,
       candidateParameterScope: 'runtime_injected',
@@ -201,59 +208,107 @@ describe('runtime policy parameters', () => {
       },
       parametersSha256: 'runtime-use-sha'
     };
-    const patched = applyRuntimePolicyParametersToRegistry(DEFAULT_STRATEGY_REGISTRY).registry;
-    const usedEntry = patched.find((entry) => entry.id === 'construction-priority.incumbent.v1');
-    const consumedRecorder = createRuntimePolicyParameterConsumptionRecorder();
+    try {
+      const patched = applyRuntimePolicyParametersToRegistry(DEFAULT_STRATEGY_REGISTRY).registry;
+      const usedEntry = patched.find((entry) => entry.id === 'construction-priority.incumbent.v1');
+      const consumedRecorder = createRuntimePolicyParameterConsumptionRecorder();
 
-    expect(usedEntry).toBeDefined();
-    consumedRecorder.recordStrategyRuntimeUse(usedEntry!);
-    (globalThis as { Game?: Partial<Game> }).Game = { time: 10 };
-    persistRuntimePolicyParameterConsumptionEvidence(consumedRecorder.buildEvidence());
+      expect(usedEntry).toBeDefined();
+      consumedRecorder.recordStrategyRuntimeUse(usedEntry!);
+      (globalThis as { Game?: Partial<Game> }).Game = { time: 10 };
+      persistRuntimePolicyParameterConsumptionEvidence(consumedRecorder.buildEvidence());
 
-    const missingTickRecorder = createRuntimePolicyParameterConsumptionRecorder();
-    (globalThis as { Game?: Partial<Game> }).Game = { time: 11 };
-    persistRuntimePolicyParameterConsumptionEvidence(missingTickRecorder.buildEvidence());
+      const missingTickRecorder = createRuntimePolicyParameterConsumptionRecorder();
+      (globalThis as { Game?: Partial<Game> }).Game = { time: 11 };
+      persistRuntimePolicyParameterConsumptionEvidence(missingTickRecorder.buildEvidence());
 
-    expect(
-      (globalThis as { Memory?: { rlRuntimePolicyParameters?: unknown } }).Memory?.rlRuntimePolicyParameters
-    ).toMatchObject({
-      runtimeParameterInjection: true,
-      consumed: true,
-      parametersSha256: 'runtime-use-sha',
-      appliedStrategyIds: ['construction-priority.incumbent.v1'],
-      tick: 11
-    });
-    expect(
-      (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL]
-    ).toMatchObject({
-      consumed: true,
-      parametersSha256: 'runtime-use-sha',
-      appliedStrategyIds: ['construction-priority.incumbent.v1']
-    });
+      expect(
+        (globalThis as { Memory?: { rlRuntimePolicyParameters?: unknown } }).Memory?.rlRuntimePolicyParameters
+      ).toMatchObject({
+        runtimeParameterInjection: true,
+        consumed: true,
+        parametersSha256: 'runtime-use-sha',
+        appliedStrategyIds: ['construction-priority.incumbent.v1'],
+        tick: 11
+      });
+      expect(
+        (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL]
+      ).toMatchObject({
+        consumed: true,
+        parametersSha256: 'runtime-use-sha',
+        appliedStrategyIds: ['construction-priority.incumbent.v1']
+      });
 
-    (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETERS_GLOBAL] = {
-      runtimeParameterInjection: true,
-      candidateParameterScope: 'runtime_injected',
-      strategyVariantId: 'construction-priority.pg.territory-seed.v1',
-      candidatePolicyId: 'construction-priority.pg.territory-seed.v1',
-      sourceStrategyId: 'construction-priority.incumbent.v1',
-      family: 'construction-priority',
-      parameters: {
-        territorySignalWeight: 30
-      },
-      parametersSha256: 'runtime-use-sha-2'
-    };
-    (globalThis as { Game?: Partial<Game> }).Game = { time: 12 };
-    persistRuntimePolicyParameterConsumptionEvidence(createRuntimePolicyParameterConsumptionRecorder().buildEvidence());
+      (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETERS_GLOBAL] = {
+        runtimeParameterInjection: true,
+        candidateParameterScope: 'runtime_injected',
+        strategyVariantId: 'construction-priority.pg.territory-seed.v1',
+        candidatePolicyId: 'construction-priority.pg.territory-seed.v1',
+        sourceStrategyId: 'construction-priority.incumbent.v1',
+        family: 'construction-priority',
+        parameters: {
+          territorySignalWeight: 30
+        },
+        parametersSha256: 'runtime-use-sha-2'
+      };
+      (globalThis as { Game?: Partial<Game> }).Game = { time: 12 };
+      persistRuntimePolicyParameterConsumptionEvidence(createRuntimePolicyParameterConsumptionRecorder().buildEvidence());
 
-    expect(
-      (globalThis as { Memory?: { rlRuntimePolicyParameters?: unknown } }).Memory?.rlRuntimePolicyParameters
-    ).toMatchObject({
-      runtimeParameterInjection: true,
-      consumed: false,
-      parametersSha256: 'runtime-use-sha-2',
-      appliedStrategyIds: [],
-      tick: 12
-    });
+      expect(
+        (globalThis as { Memory?: { rlRuntimePolicyParameters?: unknown } }).Memory?.rlRuntimePolicyParameters
+      ).toMatchObject({
+        runtimeParameterInjection: true,
+        consumed: false,
+        parametersSha256: 'runtime-use-sha-2',
+        appliedStrategyIds: [],
+        tick: 12
+      });
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('emits tick-time consumption evidence only for runtime-injected payloads', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    try {
+      persistRuntimePolicyParameterConsumptionEvidence({
+        type: 'screeps-rl-runtime-policy-parameter-consumption',
+        consumerMarker: 'screeps-rl-runtime-policy-parameters-consumer-v1',
+        runtimeParameterInjection: false,
+        consumed: false,
+        appliedStrategyIds: [],
+        liveEffect: false,
+        officialMmoWrites: false,
+        officialMmoWritesAllowed: false
+      });
+      expect(logSpy).not.toHaveBeenCalled();
+
+      const evidence = {
+        type: 'screeps-rl-runtime-policy-parameter-consumption' as const,
+        consumerMarker: 'screeps-rl-runtime-policy-parameters-consumer-v1' as const,
+        runtimeParameterInjection: true,
+        consumed: true,
+        strategyVariantId: 'construction-priority.pg.territory-seed.v1',
+        candidatePolicyId: 'construction-priority.pg.territory-seed.v1',
+        family: 'construction-priority',
+        parameters: { territorySignalWeight: 29 },
+        parametersSha256: 'runtime-use-sha',
+        appliedStrategyIds: ['construction-priority.incumbent.v1'],
+        liveEffect: false as const,
+        officialMmoWrites: false as const,
+        officialMmoWritesAllowed: false as const
+      };
+
+      persistRuntimePolicyParameterConsumptionEvidence(evidence);
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      const line = String(logSpy.mock.calls[0][0]);
+      expect(line.startsWith(RUNTIME_POLICY_PARAMETER_CONSUMPTION_LOG_PREFIX)).toBe(true);
+      expect(JSON.parse(line.slice(RUNTIME_POLICY_PARAMETER_CONSUMPTION_LOG_PREFIX.length))).toMatchObject(
+        evidence
+      );
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 });

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -96,6 +96,7 @@ RUNTIME_PARAMETER_INJECTION_GLOBAL = "__SCREEPS_RL_RUNTIME_POLICY_PARAMETERS__"
 RUNTIME_PARAMETER_CONSUMPTION_GLOBAL = "__SCREEPS_RL_RUNTIME_POLICY_PARAMETER_CONSUMPTION__"
 RUNTIME_PARAMETER_CONSUMPTION_TYPE = "screeps-rl-runtime-policy-parameter-consumption"
 RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER = "screeps-rl-runtime-policy-parameters-consumer-v1"
+RUNTIME_PARAMETER_CONSUMPTION_LOG_PREFIX = "#runtime-parameter-consumption "
 STRICT_DIRECTIVE_PREFIX_RE = re.compile(
     r"\A(\ufeff?(?:(?:\s+)|(?://[^\r\n]*(?:\r?\n|$))|(?:/\*.*?\*/))*"
     r"(?:(?:['\"]use strict['\"]\s*;?\s*)+))",
@@ -853,6 +854,7 @@ def collect_runtime_parameter_consumption_evidence(
     errors: list[str] = []
     collectors = [
         ("Memory.rlRuntimePolicyParameters", _collect_http_runtime_parameter_consumption_evidence),
+        ("console.runtimePolicyParameterConsumption", _collect_console_runtime_parameter_consumption_evidence),
         ("redis.Memory.rlRuntimePolicyParameters", _collect_redis_runtime_parameter_consumption_evidence),
         ("mongo.Memory.rlRuntimePolicyParameters", _collect_mongo_runtime_parameter_consumption_evidence),
     ]
@@ -915,6 +917,67 @@ def _collect_http_runtime_parameter_consumption_evidence(
         if evidence is not None:
             return evidence
     return None
+
+
+def _collect_console_runtime_parameter_consumption_evidence(
+    smoke: Any,
+    compose: Sequence[str] | None,
+    cfg: Any,
+    token: str | None,
+    injection: JsonObject | None = None,
+) -> JsonObject | None:
+    _ = token
+    if compose is None:
+        return None
+    run_command = getattr(smoke, "run_command", None)
+    if not callable(run_command):
+        return None
+    result = run_command(
+        [*compose, "logs", "--no-color", "--tail", "1200"],
+        cfg,
+        timeout=60,
+        output_limit=200000,
+    )
+    if result.get("returncode") != 0:
+        return None
+    return runtime_parameter_consumption_evidence_from_console_output(
+        result.get("output_excerpt", ""),
+        injection=injection,
+    )
+
+
+def runtime_parameter_consumption_evidence_from_console_output(
+    output: Any,
+    *,
+    injection: JsonObject | None = None,
+) -> JsonObject | None:
+    fallback: JsonObject | None = None
+    for line in reversed(str(output).splitlines()):
+        payload = runtime_parameter_consumption_payload_from_console_line(line)
+        if payload is None:
+            continue
+        evidence = find_runtime_parameter_consumption_evidence(payload, injection=injection)
+        if evidence is None:
+            continue
+        if injection is not None and runtime_parameter_consumption_validation_error(injection, evidence) is None:
+            return evidence
+        if fallback is None:
+            fallback = evidence
+    return fallback
+
+
+def runtime_parameter_consumption_payload_from_console_line(line: str) -> JsonObject | None:
+    marker_index = line.find(RUNTIME_PARAMETER_CONSUMPTION_LOG_PREFIX)
+    if marker_index < 0:
+        return None
+    json_text = line[marker_index + len(RUNTIME_PARAMETER_CONSUMPTION_LOG_PREFIX):].strip()
+    if not json_text:
+        return None
+    try:
+        payload = json.loads(json_text)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
 
 
 def _collect_redis_runtime_parameter_consumption_evidence(

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -939,7 +939,14 @@ def _collect_console_runtime_parameter_consumption_evidence(
         output_limit=200000,
     )
     if result.get("returncode") != 0:
-        return None
+        output = result.get("output_excerpt")
+        if not output:
+            output = "\n".join(str(part) for part in (result.get("stdout"), result.get("stderr")) if part)
+        raise RuntimeError(
+            "console runtime-parameter probe failed: "
+            f"exit={result.get('returncode')} "
+            f"output={_safe_text(output, 240)}"
+        )
     return runtime_parameter_consumption_evidence_from_console_output(
         result.get("output_excerpt", ""),
         injection=injection,

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1732,6 +1732,63 @@ cli:
 
         self.assertEqual(extracted, evidence)
 
+    def test_console_runtime_parameter_consumption_collector_reads_tick_time_evidence(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        matching = self.runtime_parameter_consumption_evidence(injection)
+        stale = self.runtime_parameter_consumption_evidence(injection)
+        stale["candidatePolicyId"] = "stale-policy"
+        log_output = "\n".join(
+            [
+                "screeps-1  | booted",
+                f"screeps-1  | {harness.RUNTIME_PARAMETER_CONSUMPTION_LOG_PREFIX}"
+                f"{json.dumps(matching, sort_keys=True)}",
+                f"screeps-1  | {harness.RUNTIME_PARAMETER_CONSUMPTION_LOG_PREFIX}"
+                f"{json.dumps(stale, sort_keys=True)}",
+            ]
+        )
+
+        class FakeSmoke:
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = command, cfg, timeout, output_limit
+                return {"returncode": 0, "output_excerpt": log_output}
+
+        extracted = harness._collect_console_runtime_parameter_consumption_evidence(
+            FakeSmoke(),
+            ["docker", "compose"],
+            object(),
+            None,
+            injection,
+        )
+
+        self.assertEqual(extracted, matching)
+
+    def test_console_runtime_parameter_consumption_non_consumed_evidence_fails_closed(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+        evidence["consumed"] = False
+        log_output = (
+            f"{harness.RUNTIME_PARAMETER_CONSUMPTION_LOG_PREFIX}"
+            f"{json.dumps(evidence, sort_keys=True)}"
+        )
+
+        extracted = harness.runtime_parameter_consumption_evidence_from_console_output(
+            log_output,
+            injection=injection,
+        )
+        consumption = harness.runtime_parameter_consumption_check(injection, extracted)
+
+        self.assertIsNotNone(extracted)
+        self.assertEqual(consumption["status"], "invalid")
+        self.assertFalse(consumption["runtimeParameterConsumption"])
+        self.assertIn("did not mark the payload consumed", consumption["reason"])
+
     def test_http_runtime_parameter_consumption_collector_falls_back_to_full_memory(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         evidence = self.runtime_parameter_consumption_evidence(injection)
@@ -2082,6 +2139,45 @@ cli:
             errors[0],
         )
         self.assertIn("strategyVariantId disagreed", errors[0])
+
+    def test_runtime_parameter_consumption_collection_accepts_console_tick_evidence(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+
+        with (
+            mock.patch.object(
+                harness,
+                "_collect_http_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ),
+            mock.patch.object(
+                harness,
+                "_collect_console_runtime_parameter_consumption_evidence",
+                return_value=evidence,
+            ),
+            mock.patch.object(
+                harness,
+                "_collect_redis_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ),
+            mock.patch.object(
+                harness,
+                "_collect_mongo_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ),
+        ):
+            extracted, errors = harness.collect_runtime_parameter_consumption_evidence(
+                object(),
+                ["docker", "compose"],
+                object(),
+                None,
+                injection,
+            )
+
+        expected = copy.deepcopy(evidence)
+        expected["source"] = "console.runtimePolicyParameterConsumption"
+        self.assertEqual(extracted, expected)
+        self.assertEqual(errors, [])
 
     def test_runtime_parameter_consumption_collection_surfaces_invalid_only_evidence(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -2179,6 +2179,52 @@ cli:
         self.assertEqual(extracted, expected)
         self.assertEqual(errors, [])
 
+    def test_runtime_parameter_consumption_collection_records_console_probe_error(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+
+        class FakeSmoke:
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = command, cfg, timeout, output_limit
+                return {"returncode": 17, "output_excerpt": "compose logs failed"}
+
+        with (
+            mock.patch.object(
+                harness,
+                "_collect_http_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ),
+            mock.patch.object(
+                harness,
+                "_collect_redis_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ),
+            mock.patch.object(
+                harness,
+                "_collect_mongo_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ),
+        ):
+            evidence, errors = harness.collect_runtime_parameter_consumption_evidence(
+                FakeSmoke(),
+                ["docker", "compose"],
+                object(),
+                None,
+                injection,
+            )
+
+        self.assertIsNone(evidence)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("console.runtimePolicyParameterConsumption failed", errors[0])
+        self.assertIn("console runtime-parameter probe failed: exit=17", errors[0])
+        self.assertIn("compose logs failed", errors[0])
+
     def test_runtime_parameter_consumption_collection_surfaces_invalid_only_evidence(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         stale = self.runtime_parameter_consumption_evidence(injection)


### PR DESCRIPTION
## Summary
- emits runtime policy-parameter consumption evidence to a Screeps console marker when runtime injection is active
- teaches the simulator harness to recover that console marker from compose logs as a runtime-consumption evidence source
- adds focused TypeScript/Python tests and rebuilds the Screeps bundle

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/test_screeps_rl_simulator_harness.py`
- `python3 -m pytest scripts/test_screeps_rl_simulator_harness.py -q` — 111 passed, 25 subtests passed
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 101 suites / 2026 tests passed
- `cd prod && npm run build`

## Issue / operations
Refs #1299.

This is a recovery PR from a prior Codex-authored dirty worktree. The controller verified the full diff and recovered commit `de8f03e8` with Codex authorship (`lanyusea's bot <lanyusea@gmail.com>`). Do not close #1299 on merge alone; the issue remains in validation until a post-merge Loop A/B or Tencent/local run proves runtimeParameterConsumption/consumedVariantCount/trustedGradientUpdate.
