### PR TITLE
fix(defense): prioritize critical rampart repairs

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -24757,6 +24757,7 @@ function getGameTick2() {
 var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
 var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 var CRITICAL_SPAWN_REPAIR_HITS_RATIO = 0.25;
+var EMERGENCY_RAMPART_REPAIR_HITS_CEILING = 1e4;
 var IDLE_RAMPART_REPAIR_HITS_CEILING2 = 121e3;
 var TOWER_REFILL_ENERGY_FLOOR = 500;
 var CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
@@ -24980,6 +24981,20 @@ function selectHeuristicWorkerTask(creep) {
   const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
   const constructionReservationContext = constructionSites.length > 0 ? createConstructionReservationContext(creep.room) : createEmptyConstructionReservationContext();
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
+  const emergencySpawnOrExtensionRefillTask = selectEmergencySpawnExtensionRefillTask(
+    creep,
+    spawnOrExtensionEnergySink
+  );
+  if (emergencySpawnOrExtensionRefillTask) {
+    return emergencySpawnOrExtensionRefillTask;
+  }
+  const emergencyRampartRepairTarget = selectEmergencyOwnedRampartRepairTarget(creep);
+  if (emergencyRampartRepairTarget) {
+    return applyMinimumUsefulLoadPolicy(creep, {
+      type: "repair",
+      targetId: emergencyRampartRepairTarget.id
+    });
+  }
   const bootstrapExtensionConstructionSite = selectBootstrapExtensionConstructionSiteBeforeRefill(
     creep,
     constructionSites,
@@ -25503,6 +25518,20 @@ function isUpgraderBoostStoredEnergySource(source) {
 function selectFirstEnergySinkByStableId(energySinks) {
   var _a;
   return (_a = [...energySinks].sort(compareEnergySinkId)[0]) != null ? _a : null;
+}
+function selectEmergencySpawnExtensionRefillTask(creep, spawnOrExtensionEnergySink) {
+  if (!spawnOrExtensionEnergySink || !hasEmergencySpawnExtensionRefillDemand(creep)) {
+    return null;
+  }
+  const refillTask = {
+    type: "transfer",
+    targetId: spawnOrExtensionEnergySink.id
+  };
+  if (isCriticalSpawnEnergySink(spawnOrExtensionEnergySink)) {
+    recordSpawnCriticalRefillTelemetry(creep, spawnOrExtensionEnergySink);
+  }
+  recordLowLoadReturnTelemetry(creep, refillTask, "emergencySpawnExtensionRefill");
+  return refillTask;
 }
 function selectBootstrapSurvivalSpendingTask(creep, controller, constructionSites, constructionReservationContext, recoveryOnlyWorkSuppressed) {
   if (controller && shouldRushRcl1Controller(controller) && canLevelUpController2(controller) && !shouldSuppressBootstrapControllerSpending(creep, recoveryOnlyWorkSuppressed)) {
@@ -28815,6 +28844,13 @@ function selectCriticalOwnedSpawnRepairTarget(creep, visibleStructures = findVis
   }
   return (_b = visibleStructures.filter(isCriticalOwnedSpawnRepairTarget).sort(compareRepairTargets)[0]) != null ? _b : null;
 }
+function selectEmergencyOwnedRampartRepairTarget(creep) {
+  var _a, _b;
+  if (((_a = creep.room.controller) == null ? void 0 : _a.my) !== true) {
+    return null;
+  }
+  return (_b = findVisibleRoomStructures(creep.room).filter(isEmergencyOwnedRampartRepairTarget).sort(compareRepairTargets)[0]) != null ? _b : null;
+}
 function canRepairRemoteCriticalRoadInfrastructure(creep) {
   var _a;
   if (!isRemoteTerritoryLogisticsRoom(creep.room) || hasVisibleHostilePresence3(creep.room)) {
@@ -28927,6 +28963,9 @@ function isWallRepairTarget(structure) {
 }
 function isCriticalOwnedSpawnRepairTarget(structure) {
   return isOwnedSpawnRepairTarget(structure) && !isWorkerRepairTargetComplete(structure) && getHitsRatio(structure) <= CRITICAL_SPAWN_REPAIR_HITS_RATIO;
+}
+function isEmergencyOwnedRampartRepairTarget(structure) {
+  return matchesStructureType18(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure) && !isWorkerRepairTargetComplete(structure) && structure.hits <= EMERGENCY_RAMPART_REPAIR_HITS_CEILING;
 }
 function isOwnedSpawnRepairTarget(structure) {
   return isSpawnRepairTarget(structure) && structure.my === true;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -24833,7 +24833,7 @@ function selectWorkerTask(creep) {
   return selectWorkerTaskWithBcFallback(creep, heuristicTask);
 }
 function selectHeuristicWorkerTask(creep) {
-  var _a;
+  var _a, _b;
   const survivalAssessment = getWorkerColonySurvivalAssessment(creep);
   const territoryWorkSuppressed = suppressesTerritoryWork(survivalAssessment);
   const bootstrapNonCriticalWorkSuppressed = suppressesBootstrapNonCriticalWork(survivalAssessment);
@@ -24981,19 +24981,22 @@ function selectHeuristicWorkerTask(creep) {
   const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
   const constructionReservationContext = constructionSites.length > 0 ? createConstructionReservationContext(creep.room) : createEmptyConstructionReservationContext();
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
-  const emergencySpawnOrExtensionRefillTask = selectEmergencySpawnExtensionRefillTask(
-    creep,
-    spawnOrExtensionEnergySink
-  );
-  if (emergencySpawnOrExtensionRefillTask) {
-    return emergencySpawnOrExtensionRefillTask;
-  }
-  const emergencyRampartRepairTarget = selectEmergencyOwnedRampartRepairTarget(creep);
-  if (emergencyRampartRepairTarget) {
-    return applyMinimumUsefulLoadPolicy(creep, {
-      type: "repair",
-      targetId: emergencyRampartRepairTarget.id
-    });
+  const canPrioritizeEmergencyWorkBeforeBootstrapSpawnRecovery = !bootstrapNonCriticalWorkSuppressed || ((_b = getOwnedSpawnCount(creep.room)) != null ? _b : 0) > 0;
+  if (canPrioritizeEmergencyWorkBeforeBootstrapSpawnRecovery) {
+    const emergencySpawnOrExtensionRefillTask = selectEmergencySpawnExtensionRefillTask(
+      creep,
+      spawnOrExtensionEnergySink
+    );
+    if (emergencySpawnOrExtensionRefillTask) {
+      return emergencySpawnOrExtensionRefillTask;
+    }
+    const emergencyRampartRepairTarget = selectEmergencyOwnedRampartRepairTarget(creep);
+    if (emergencyRampartRepairTarget) {
+      return applyMinimumUsefulLoadPolicy(creep, {
+        type: "repair",
+        targetId: emergencyRampartRepairTarget.id
+      });
+    }
   }
   const bootstrapExtensionConstructionSite = selectBootstrapExtensionConstructionSiteBeforeRefill(
     creep,
@@ -25019,7 +25022,7 @@ function selectHeuristicWorkerTask(creep) {
       return applyMinimumUsefulLoadPolicy(creep, productiveTaskBeforeIdleRefill);
     }
   }
-  if (spawnOrExtensionEnergySink) {
+  if (spawnOrExtensionEnergySink && canPrioritizeEmergencyWorkBeforeBootstrapSpawnRecovery) {
     const spawnOrExtensionRefillTask = {
       type: "transfer",
       targetId: spawnOrExtensionEnergySink.id

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -24833,7 +24833,7 @@ function selectWorkerTask(creep) {
   return selectWorkerTaskWithBcFallback(creep, heuristicTask);
 }
 function selectHeuristicWorkerTask(creep) {
-  var _a, _b;
+  var _a;
   const survivalAssessment = getWorkerColonySurvivalAssessment(creep);
   const territoryWorkSuppressed = suppressesTerritoryWork(survivalAssessment);
   const bootstrapNonCriticalWorkSuppressed = suppressesBootstrapNonCriticalWork(survivalAssessment);
@@ -24981,7 +24981,9 @@ function selectHeuristicWorkerTask(creep) {
   const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
   const constructionReservationContext = constructionSites.length > 0 ? createConstructionReservationContext(creep.room) : createEmptyConstructionReservationContext();
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
-  const canPrioritizeEmergencyWorkBeforeBootstrapSpawnRecovery = !bootstrapNonCriticalWorkSuppressed || ((_b = getOwnedSpawnCount(creep.room)) != null ? _b : 0) > 0;
+  const ownedSpawnCount = getOwnedSpawnCount(creep.room);
+  const hasMissingSpawnRecoveryConstructionSite = ownedSpawnCount === 0 && constructionSites.some(isSpawnConstructionSite);
+  const canPrioritizeEmergencyWorkBeforeBootstrapSpawnRecovery = !hasMissingSpawnRecoveryConstructionSite && (!bootstrapNonCriticalWorkSuppressed || (ownedSpawnCount != null ? ownedSpawnCount : 0) > 0);
   if (canPrioritizeEmergencyWorkBeforeBootstrapSpawnRecovery) {
     const emergencySpawnOrExtensionRefillTask = selectEmergencySpawnExtensionRefillTask(
       creep,

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -502,20 +502,24 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
       ? createConstructionReservationContext(creep.room)
       : createEmptyConstructionReservationContext();
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
-  const emergencySpawnOrExtensionRefillTask = selectEmergencySpawnExtensionRefillTask(
-    creep,
-    spawnOrExtensionEnergySink
-  );
-  if (emergencySpawnOrExtensionRefillTask) {
-    return emergencySpawnOrExtensionRefillTask;
-  }
+  const canPrioritizeEmergencyWorkBeforeBootstrapSpawnRecovery =
+    !bootstrapNonCriticalWorkSuppressed || (getOwnedSpawnCount(creep.room) ?? 0) > 0;
+  if (canPrioritizeEmergencyWorkBeforeBootstrapSpawnRecovery) {
+    const emergencySpawnOrExtensionRefillTask = selectEmergencySpawnExtensionRefillTask(
+      creep,
+      spawnOrExtensionEnergySink
+    );
+    if (emergencySpawnOrExtensionRefillTask) {
+      return emergencySpawnOrExtensionRefillTask;
+    }
 
-  const emergencyRampartRepairTarget = selectEmergencyOwnedRampartRepairTarget(creep);
-  if (emergencyRampartRepairTarget) {
-    return applyMinimumUsefulLoadPolicy(creep, {
-      type: 'repair',
-      targetId: emergencyRampartRepairTarget.id as Id<Structure>
-    });
+    const emergencyRampartRepairTarget = selectEmergencyOwnedRampartRepairTarget(creep);
+    if (emergencyRampartRepairTarget) {
+      return applyMinimumUsefulLoadPolicy(creep, {
+        type: 'repair',
+        targetId: emergencyRampartRepairTarget.id as Id<Structure>
+      });
+    }
   }
 
   const bootstrapExtensionConstructionSite = selectBootstrapExtensionConstructionSiteBeforeRefill(
@@ -548,7 +552,7 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     }
   }
 
-  if (spawnOrExtensionEnergySink) {
+  if (spawnOrExtensionEnergySink && canPrioritizeEmergencyWorkBeforeBootstrapSpawnRecovery) {
     const spawnOrExtensionRefillTask: Extract<CreepTaskMemory, { type: 'transfer' }> = {
       type: 'transfer',
       targetId: spawnOrExtensionEnergySink.id as Id<AnyStoreStructure>

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -83,6 +83,7 @@ import { selectWorkerTaskWithBcFallback } from '../rl/workerTaskPolicy';
 export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
 export const CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 export const CRITICAL_SPAWN_REPAIR_HITS_RATIO = 0.25;
+export const EMERGENCY_RAMPART_REPAIR_HITS_CEILING = 10_000;
 export const IDLE_RAMPART_REPAIR_HITS_CEILING = 121_000;
 export const TOWER_REFILL_ENERGY_FLOOR = 500;
 export const CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
@@ -501,6 +502,22 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
       ? createConstructionReservationContext(creep.room)
       : createEmptyConstructionReservationContext();
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
+  const emergencySpawnOrExtensionRefillTask = selectEmergencySpawnExtensionRefillTask(
+    creep,
+    spawnOrExtensionEnergySink
+  );
+  if (emergencySpawnOrExtensionRefillTask) {
+    return emergencySpawnOrExtensionRefillTask;
+  }
+
+  const emergencyRampartRepairTarget = selectEmergencyOwnedRampartRepairTarget(creep);
+  if (emergencyRampartRepairTarget) {
+    return applyMinimumUsefulLoadPolicy(creep, {
+      type: 'repair',
+      targetId: emergencyRampartRepairTarget.id as Id<Structure>
+    });
+  }
+
   const bootstrapExtensionConstructionSite = selectBootstrapExtensionConstructionSiteBeforeRefill(
     creep,
     constructionSites,
@@ -1244,6 +1261,25 @@ function isUpgraderBoostStoredEnergySource(
 
 function selectFirstEnergySinkByStableId<T extends FillableEnergySink>(energySinks: T[]): T | null {
   return [...energySinks].sort(compareEnergySinkId)[0] ?? null;
+}
+
+function selectEmergencySpawnExtensionRefillTask(
+  creep: Creep,
+  spawnOrExtensionEnergySink: StructureSpawn | StructureExtension | null
+): CreepTaskMemory | null {
+  if (!spawnOrExtensionEnergySink || !hasEmergencySpawnExtensionRefillDemand(creep)) {
+    return null;
+  }
+
+  const refillTask: Extract<CreepTaskMemory, { type: 'transfer' }> = {
+    type: 'transfer',
+    targetId: spawnOrExtensionEnergySink.id as Id<AnyStoreStructure>
+  };
+  if (isCriticalSpawnEnergySink(spawnOrExtensionEnergySink)) {
+    recordSpawnCriticalRefillTelemetry(creep, spawnOrExtensionEnergySink);
+  }
+  recordLowLoadReturnTelemetry(creep, refillTask, 'emergencySpawnExtensionRefill');
+  return refillTask;
 }
 
 function selectBootstrapSurvivalSpendingTask(
@@ -6534,6 +6570,16 @@ function selectCriticalOwnedSpawnRepairTarget(
   return visibleStructures.filter(isCriticalOwnedSpawnRepairTarget).sort(compareRepairTargets)[0] ?? null;
 }
 
+function selectEmergencyOwnedRampartRepairTarget(creep: Creep): StructureRampart | null {
+  if (creep.room.controller?.my !== true) {
+    return null;
+  }
+
+  return findVisibleRoomStructures(creep.room)
+    .filter(isEmergencyOwnedRampartRepairTarget)
+    .sort(compareRepairTargets)[0] ?? null;
+}
+
 function canRepairRemoteCriticalRoadInfrastructure(creep: Creep): boolean {
   if (!isRemoteTerritoryLogisticsRoom(creep.room) || hasVisibleHostilePresence(creep.room)) {
     return false;
@@ -6734,6 +6780,15 @@ function isCriticalOwnedSpawnRepairTarget(structure: AnyStructure): structure is
     isOwnedSpawnRepairTarget(structure) &&
     !isWorkerRepairTargetComplete(structure) &&
     getHitsRatio(structure) <= CRITICAL_SPAWN_REPAIR_HITS_RATIO
+  );
+}
+
+function isEmergencyOwnedRampartRepairTarget(structure: AnyStructure): structure is StructureRampart {
+  return (
+    matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart') &&
+    isOwnedRampart(structure) &&
+    !isWorkerRepairTargetComplete(structure) &&
+    structure.hits <= EMERGENCY_RAMPART_REPAIR_HITS_CEILING
   );
 }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -502,8 +502,12 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
       ? createConstructionReservationContext(creep.room)
       : createEmptyConstructionReservationContext();
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
+  const ownedSpawnCount = getOwnedSpawnCount(creep.room);
+  const hasMissingSpawnRecoveryConstructionSite =
+    ownedSpawnCount === 0 && constructionSites.some(isSpawnConstructionSite);
   const canPrioritizeEmergencyWorkBeforeBootstrapSpawnRecovery =
-    !bootstrapNonCriticalWorkSuppressed || (getOwnedSpawnCount(creep.room) ?? 0) > 0;
+    !hasMissingSpawnRecoveryConstructionSite &&
+    (!bootstrapNonCriticalWorkSuppressed || (ownedSpawnCount ?? 0) > 0);
   if (canPrioritizeEmergencyWorkBeforeBootstrapSpawnRecovery) {
     const emergencySpawnOrExtensionRefillTask = selectEmergencySpawnExtensionRefillTask(
       creep,

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -8060,6 +8060,38 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'spawn-site1' });
   });
 
+  it('keeps missing spawn construction before emergency rampart repair outside bootstrap', () => {
+    recordSurvivalMode('LOCAL_STABLE');
+    const spawnSite = { id: 'spawn-site1', structureType: 'spawn' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const rampart = makeStructure(
+      'rampart-emergency',
+      'rampart' as StructureConstant,
+      EMERGENCY_RAMPART_REPAIR_HITS_CEILING,
+      300_000,
+      { my: true }
+    );
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [spawnSite],
+        controller,
+        energyAvailable: 650,
+        energyCapacityAvailable: 650,
+        myStructures: [],
+        structures: [rampart]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'spawn-site1' });
+  });
+
   it('keeps missing spawn construction before emergency extension refill during bootstrap', () => {
     recordSurvivalMode('BOOTSTRAP');
     const spawnSite = { id: 'spawn-site1', structureType: 'spawn' } as ConstructionSite;

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -3,6 +3,7 @@ import {
   CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD,
   CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO,
   CRITICAL_SPAWN_REPAIR_HITS_RATIO,
+  EMERGENCY_RAMPART_REPAIR_HITS_CEILING,
   IDLE_RAMPART_REPAIR_HITS_CEILING,
   BUILDER_DROPPED_PICKUP_RANGE,
   BUILDER_STORAGE_WITHDRAW_MIN,
@@ -8025,6 +8026,97 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'road-critical' });
+  });
+
+  it('repairs unsafe owned ramparts before bootstrap extension construction', () => {
+    recordSurvivalMode('BOOTSTRAP');
+    const site = { id: 'extension-site1', my: true, structureType: 'extension' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const rampart = makeStructure(
+      'rampart-emergency',
+      'rampart' as StructureConstant,
+      301,
+      300_000,
+      { my: true }
+    );
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller,
+        energyAvailable: 300,
+        energyCapacityAvailable: 300,
+        structures: [rampart]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'rampart-emergency' });
+  });
+
+  it('keeps emergency spawn refill before unsafe rampart repair', () => {
+    const spawn = makeEnergySinkWithEnergy('spawn1', 'spawn' as StructureConstant, 50, 250);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const rampart = makeStructure(
+      'rampart-emergency',
+      'rampart' as StructureConstant,
+      301,
+      300_000,
+      { my: true }
+    );
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        controller,
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+        energyCapacityAvailable: 550,
+        myStructures: [spawn as AnyOwnedStructure],
+        structures: [rampart]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+  });
+
+  it('keeps normal construction ahead of non-emergency rampart maintenance', () => {
+    const site = { id: 'wall-site1', my: true, structureType: 'constructedWall' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const rampart = makeStructure(
+      'rampart-non-emergency',
+      'rampart' as StructureConstant,
+      EMERGENCY_RAMPART_REPAIR_HITS_CEILING + 1,
+      300_000,
+      { my: true }
+    );
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller,
+        energyAvailable: 550,
+        energyCapacityAvailable: 550,
+        structures: [rampart]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'wall-site1' });
   });
 
   it('suppresses remote critical infrastructure repair during bootstrap', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -8028,9 +8028,67 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'road-critical' });
   });
 
+  it('keeps missing spawn construction before emergency rampart repair during bootstrap', () => {
+    recordSurvivalMode('BOOTSTRAP');
+    const spawnSite = { id: 'spawn-site1', structureType: 'spawn' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const rampart = makeStructure(
+      'rampart-emergency',
+      'rampart' as StructureConstant,
+      EMERGENCY_RAMPART_REPAIR_HITS_CEILING,
+      300_000,
+      { my: true }
+    );
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [spawnSite],
+        controller,
+        energyAvailable: 0,
+        energyCapacityAvailable: 650,
+        myStructures: [],
+        structures: [rampart]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'spawn-site1' });
+  });
+
+  it('keeps missing spawn construction before emergency extension refill during bootstrap', () => {
+    recordSurvivalMode('BOOTSTRAP');
+    const spawnSite = { id: 'spawn-site1', structureType: 'spawn' } as ConstructionSite;
+    const extension = makeEnergySinkWithEnergy('extension1', 'extension' as StructureConstant, 0, 50);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [spawnSite],
+        controller,
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+        energyCapacityAvailable: 650,
+        myStructures: [extension as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'spawn-site1' });
+  });
+
   it('repairs unsafe owned ramparts before bootstrap extension construction', () => {
     recordSurvivalMode('BOOTSTRAP');
     const site = { id: 'extension-site1', my: true, structureType: 'extension' } as ConstructionSite;
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0);
     const controller = {
       id: 'controller1',
       my: true,
@@ -8040,7 +8098,7 @@ describe('selectWorkerTask', () => {
     const rampart = makeStructure(
       'rampart-emergency',
       'rampart' as StructureConstant,
-      301,
+      EMERGENCY_RAMPART_REPAIR_HITS_CEILING,
       300_000,
       { my: true }
     );
@@ -8052,6 +8110,7 @@ describe('selectWorkerTask', () => {
         controller,
         energyAvailable: 300,
         energyCapacityAvailable: 300,
+        myStructures: [fullSpawn as AnyOwnedStructure],
         structures: [rampart]
       })
     } as unknown as Creep;
@@ -8060,6 +8119,7 @@ describe('selectWorkerTask', () => {
   });
 
   it('keeps emergency spawn refill before unsafe rampart repair', () => {
+    recordSurvivalMode('BOOTSTRAP');
     const spawn = makeEnergySinkWithEnergy('spawn1', 'spawn' as StructureConstant, 50, 250);
     const controller = {
       id: 'controller1',
@@ -8070,7 +8130,7 @@ describe('selectWorkerTask', () => {
     const rampart = makeStructure(
       'rampart-emergency',
       'rampart' as StructureConstant,
-      301,
+      EMERGENCY_RAMPART_REPAIR_HITS_CEILING,
       300_000,
       { my: true }
     );


### PR DESCRIPTION
## Summary
- prioritizes critical low-hit owned ramparts/structures before ordinary construction/upgrade work
- keeps emergency spawn-site and controller-downgrade safeguards ahead of the new repair path
- adds focused worker-task coverage and rebuilds the Screeps bundle

## Incident evidence
- Runtime alert output: `/root/.hermes/cron/output/1df5ef0c3835/2026-05-23_03-06-38.md`
- Monitor artifacts: `/root/screeps/runtime-artifacts/screeps-monitor/runtime-alert-20260522T190430Z/`
- E29N57 is alive (`owned_spawns=1`, `owned_creeps>0`, `hostiles=0`) but low-hit rampart damage persisted, so this is a self-actionable P0 repair-priority hotfix rather than an owner respawn/retarget decision.

## Verification
- `git diff --check`
- `git diff --cached --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 101 suites / 2029 tests passed
- `cd prod && npm run build`

Refs #1334
