### PR TITLE
fix(rl): gate active training datasets

### DIFF
--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -1370,9 +1370,11 @@ def select_accepted_dataset_gate(
     *,
     reference_time: str | datetime | None = None,
     max_age_hours: float | None = None,
+    dataset_run_ids: Sequence[str] | None = None,
 ) -> JsonObject:
     if gate_id is not None:
         validate_gate_id(gate_id)
+    required_dataset_run_ids = normalize_dataset_run_ids(dataset_run_ids)
     candidates: list[tuple[int, float, str, str, str, Path, JsonObject]] = []
     stale_accepted: list[JsonObject] = []
     roots = dataset_gate_roots(gate_root)
@@ -1387,7 +1389,12 @@ def select_accepted_dataset_gate(
     if max_age_hours is not None and reference_dt is None:
         raise CardValidationError("dataset gate freshness requires a reference time")
     reports = scan_dataset_gate_reports(existing_roots, gate_id=gate_id, reference_time=reference_dt)
-    for report in reports:
+    matching_reports = [
+        report
+        for report in reports
+        if required_dataset_run_ids is None or report.get("dataset_run_id") in required_dataset_run_ids
+    ]
+    for report in matching_reports:
         if not report.get("acceptable"):
             continue
         path = report["path"]
@@ -1427,7 +1434,16 @@ def select_accepted_dataset_gate(
             )
         )
     if not candidates:
-        raise CardValidationError(dataset_gate_selection_error(roots, reports, stale_accepted, gate_id, max_age_hours))
+        raise CardValidationError(
+            dataset_gate_selection_error(
+                roots,
+                matching_reports,
+                stale_accepted,
+                gate_id,
+                max_age_hours,
+                required_dataset_run_ids,
+            )
+        )
     candidates.sort(key=lambda item: (item[0], item[1], item[2], item[3], str(item[5])), reverse=True)
     return candidates[0][6]
 
@@ -1567,13 +1583,15 @@ def dataset_gate_selection_error(
     stale_accepted: Sequence[JsonObject],
     gate_id: str | None,
     max_age_hours: float | None,
+    dataset_run_ids: Sequence[str] | None = None,
 ) -> str:
+    dataset_filter = f" with datasetRunId in {', '.join(dataset_run_ids)}" if dataset_run_ids else ""
     if gate_id is not None:
-        prefix = f"no accepted dataset gate {gate_id} with datasetRunId found under "
+        prefix = f"no accepted dataset gate {gate_id}{dataset_filter} found under "
     elif max_age_hours is not None:
-        prefix = "no accepted dataset gate with datasetRunId found under "
+        prefix = f"no accepted dataset gate{dataset_filter} found under "
     else:
-        prefix = "no accepted dataset gate with datasetRunId found under "
+        prefix = f"no accepted dataset gate{dataset_filter} found under "
     details = [prefix + ", ".join(str(root) for root in roots)]
     if max_age_hours is not None:
         details.append(f"fresh gate required within {max_age_hours:g}h")
@@ -1658,8 +1676,30 @@ def format_percent(value: Any) -> str:
 
 def dataset_gate_roots(gate_root: Path | Sequence[Path]) -> list[Path]:
     if isinstance(gate_root, Path):
-        return [gate_root]
-    return [Path(root) for root in gate_root]
+        roots = [gate_root]
+    else:
+        roots = [Path(root) for root in gate_root]
+
+    expanded: list[Path] = []
+    for root in roots:
+        if root not in expanded:
+            expanded.append(root)
+        if root.name == "rl-dataset-gates":
+            control_loop_root = root.parent / "rl-control-loop"
+            if control_loop_root not in expanded:
+                expanded.append(control_loop_root)
+    return expanded
+
+
+def normalize_dataset_run_ids(dataset_run_ids: Sequence[str] | None) -> tuple[str, ...] | None:
+    if dataset_run_ids is None:
+        return None
+    normalized: list[str] = []
+    for run_id in dataset_run_ids:
+        validate_dataset_run_id(run_id)
+        if run_id not in normalized:
+            normalized.append(run_id)
+    return tuple(normalized) if normalized else None
 
 
 def iter_canonical_dataset_gate_report_paths(gate_roots: Sequence[Path]) -> list[Path]:

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -1365,7 +1365,7 @@ def loop_a_selection_summary(path: Path, card: JsonObject, consumed_card_ids: se
 
 
 def select_accepted_dataset_gate(
-    gate_root: Path | Sequence[Path],
+    gate_root: Path | str | Sequence[Path | str],
     gate_id: str | None = None,
     *,
     reference_time: str | datetime | None = None,
@@ -1674,9 +1674,9 @@ def format_percent(value: Any) -> str:
     return f"{float(value) * 100:.1f}%"
 
 
-def dataset_gate_roots(gate_root: Path | Sequence[Path]) -> list[Path]:
-    if isinstance(gate_root, Path):
-        roots = [gate_root]
+def dataset_gate_roots(gate_root: Path | str | Sequence[Path | str]) -> list[Path]:
+    if isinstance(gate_root, (Path, str)):
+        roots = [Path(gate_root)]
     else:
         roots = [Path(root) for root in gate_root]
 
@@ -1699,7 +1699,7 @@ def normalize_dataset_run_ids(dataset_run_ids: Sequence[str] | None) -> tuple[st
         validate_dataset_run_id(run_id)
         if run_id not in normalized:
             normalized.append(run_id)
-    return tuple(normalized) if normalized else None
+    return tuple(normalized)
 
 
 def iter_canonical_dataset_gate_report_paths(gate_roots: Sequence[Path]) -> list[Path]:
@@ -1965,7 +1965,7 @@ def dataset_gate_acceptance_rate(payload: JsonObject) -> float | None:
     return None
 
 
-def latest_accepted_dataset_run_id(gate_root: Path) -> str:
+def latest_accepted_dataset_run_id(gate_root: Path | str) -> str:
     return str(select_accepted_dataset_gate(gate_root)["dataset_run_id"])
 
 

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -33,6 +33,29 @@ class RlExperimentCardTest(unittest.TestCase):
         else:
             self.assertIsNone(smoke_map_source_file)
 
+    def write_current_accepted_gate(self, path: Path, *, gate_id: str, dataset_run_id: str) -> None:
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "type": card_helper.SOURCE_GATE_TYPE,
+                    "ok": True,
+                    "gateId": gate_id,
+                    "createdAt": "2026-05-22T18:31:50Z",
+                    "dataset": {"ok": True, "runId": dataset_run_id, "sampleCount": 200},
+                    "datasetGate": {"status": "pass", "sampleCount": 200},
+                    "quality_checks": {
+                        "status": "pass",
+                        "samples_accepted": 200,
+                        "samples_rejected": 0,
+                        "acceptance_rate": 1.0,
+                    },
+                    "shadowEvaluation": {"status": "pass", "ok": True},
+                }
+            ),
+            encoding="utf-8",
+        )
+
     def test_generated_card_is_training_runner_valid(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-3d29e8b9397d",
@@ -1301,6 +1324,40 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(selected["gate_id"], "gate-20260522T183117Z")
         self.assertEqual(selected["dataset_run_id"], "rl-2e60b187e8a4")
         self.assertTrue(selected["gate_report_path"].endswith("rl-control-loop/gate-20260522T183117Z/gate_report.json"))
+
+    def test_dataset_gate_selection_accepts_string_gate_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            gate_root = root / "gates"
+            gate_id = "gate-20260522T183117Z"
+            dataset_run_id = "rl-string-root"
+            gate_path = gate_root / gate_id / "gate_report.json"
+            self.write_current_accepted_gate(gate_path, gate_id=gate_id, dataset_run_id=dataset_run_id)
+
+            selected = card_helper.select_accepted_dataset_gate(
+                str(gate_root),
+                reference_time="2026-05-22T21:20:47Z",
+                max_age_hours=card_helper.E1_GATE_FRESHNESS_HOURS,
+            )
+
+        self.assertEqual(selected["gate_id"], gate_id)
+        self.assertEqual(selected["dataset_run_id"], dataset_run_id)
+
+    def test_dataset_gate_selection_empty_dataset_run_ids_match_no_gates(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            gate_root = root / "gates"
+            gate_id = "gate-20260522T183117Z"
+            gate_path = gate_root / gate_id / "gate_report.json"
+            self.write_current_accepted_gate(gate_path, gate_id=gate_id, dataset_run_id="rl-active-training")
+
+            with self.assertRaisesRegex(card_helper.CardValidationError, "no accepted dataset gate"):
+                card_helper.select_accepted_dataset_gate(
+                    gate_root,
+                    reference_time="2026-05-22T21:20:47Z",
+                    max_age_hours=card_helper.E1_GATE_FRESHNESS_HOURS,
+                    dataset_run_ids=[],
+                )
 
     def test_dataset_gate_selection_reports_missing_requested_training_dataset(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -1247,6 +1247,101 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(selected["dataset_run_id"], "rl-full-quality")
         self.assertEqual(selected["quality_acceptance_rate"], 1.0)
 
+    def test_dataset_gate_selection_expands_legacy_root_and_prefers_requested_training_dataset(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runtime_root = root / "runtime-artifacts"
+            legacy_gate_root = runtime_root / "rl-dataset-gates"
+            legacy_gate_root.mkdir(parents=True)
+            active_gate = runtime_root / "rl-control-loop" / "gate-20260522T183117Z" / "gate_report.json"
+            newer_non_training_gate = (
+                runtime_root / "rl-control-loop" / "gate-20260522T190000Z" / "gate_report.json"
+            )
+            active_gate.parent.mkdir(parents=True)
+            newer_non_training_gate.parent.mkdir(parents=True)
+            active_payload = {
+                "type": card_helper.SOURCE_GATE_TYPE,
+                "ok": True,
+                "gateId": "gate-20260522T183117Z",
+                "createdAt": "2026-05-22T18:31:50Z",
+                "dataset": {"ok": True, "runId": "rl-2e60b187e8a4", "sampleCount": 200},
+                "datasetGate": {"status": "pass", "sampleCount": 200},
+                "quality_checks": {
+                    "status": "pass",
+                    "samples_accepted": 200,
+                    "samples_rejected": 0,
+                    "acceptance_rate": 1.0,
+                },
+                "shadowEvaluation": {"status": "pass", "ok": True},
+            }
+            non_training_payload = {
+                **active_payload,
+                "gateId": "gate-20260522T190000Z",
+                "createdAt": "2026-05-22T19:00:00Z",
+                "dataset": {"ok": True, "runId": "rl-newer-non-training", "sampleCount": 200},
+            }
+            active_gate.write_text(json.dumps(active_payload), encoding="utf-8")
+            newer_non_training_gate.write_text(json.dumps(non_training_payload), encoding="utf-8")
+            os.utime(active_gate, (1_779_474_752, 1_779_474_752))
+            os.utime(newer_non_training_gate, (1_779_476_400, 1_779_476_400))
+
+            unfiltered = card_helper.select_accepted_dataset_gate(
+                legacy_gate_root,
+                reference_time="2026-05-22T21:20:47Z",
+                max_age_hours=card_helper.E1_GATE_FRESHNESS_HOURS,
+            )
+            selected = card_helper.select_accepted_dataset_gate(
+                legacy_gate_root,
+                reference_time="2026-05-22T21:20:47Z",
+                max_age_hours=card_helper.E1_GATE_FRESHNESS_HOURS,
+                dataset_run_ids=["rl-2e60b187e8a4"],
+            )
+
+        self.assertEqual(unfiltered["dataset_run_id"], "rl-newer-non-training")
+        self.assertEqual(selected["gate_id"], "gate-20260522T183117Z")
+        self.assertEqual(selected["dataset_run_id"], "rl-2e60b187e8a4")
+        self.assertTrue(selected["gate_report_path"].endswith("rl-control-loop/gate-20260522T183117Z/gate_report.json"))
+
+    def test_dataset_gate_selection_reports_missing_requested_training_dataset(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runtime_root = root / "runtime-artifacts"
+            legacy_gate_root = runtime_root / "rl-dataset-gates"
+            other_gate = runtime_root / "rl-control-loop" / "gate-20260522T190000Z" / "gate_report.json"
+            legacy_gate_root.mkdir(parents=True)
+            other_gate.parent.mkdir(parents=True)
+            other_gate.write_text(
+                json.dumps(
+                    {
+                        "type": card_helper.SOURCE_GATE_TYPE,
+                        "ok": True,
+                        "gateId": "gate-20260522T190000Z",
+                        "createdAt": "2026-05-22T19:00:00Z",
+                        "dataset": {"ok": True, "runId": "rl-other-training", "sampleCount": 200},
+                        "datasetGate": {"status": "pass", "sampleCount": 200},
+                        "quality_checks": {
+                            "status": "pass",
+                            "samples_accepted": 200,
+                            "samples_rejected": 0,
+                            "acceptance_rate": 1.0,
+                        },
+                        "shadowEvaluation": {"status": "pass", "ok": True},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                card_helper.CardValidationError,
+                "datasetRunId in rl-missing-active",
+            ):
+                card_helper.select_accepted_dataset_gate(
+                    legacy_gate_root,
+                    reference_time="2026-05-22T21:20:47Z",
+                    max_age_hours=card_helper.E1_GATE_FRESHNESS_HOURS,
+                    dataset_run_ids=["rl-missing-active"],
+                )
+
     def test_loop_a_local_fallback_reports_zero_sample_newest_gate_and_stale_nonzero_gate(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary
- Fixes Loop A/E1 active dataset gate selection so legacy gate-root callers also scan the control-loop gate stream.
- Adds active dataset filtering coverage so Loop A does not fall back to stale unrelated `rl-gate-db16ca9c3de7` when fresh accepted gates exist for the datasets actually used by training.
- Records #1333 triage evidence in `/tmp/issue-1333-codex-triage.md` (controller artifact, not committed).

## Evidence
- Latest Loop A ledger: `runtime-artifacts/rl-control-loop/20260522T212047Z-training-ledger.json`.
- Codex found fresh 100% accepted gates for all five active datasets, including `rl-2e60b187e8a4 -> gate-20260522T183117Z`.

## Test plan
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_experiment_card.py scripts/test_screeps_rl_experiment_card.py`
- `python3 -m pytest scripts/test_screeps_rl_experiment_card.py -q` (60 passed, 13 subtests)

Refs #1333
Refs #879
Refs #1032
Refs #1233
