### PR TITLE
fix(rl): self-heal Tencent SSH host keys

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -77,9 +77,11 @@ SSH_CONNECT_OPTIONS = (
     "-o", "ConnectTimeout=10",
     "-o", "ServerAliveInterval=15",
     "-o", "ServerAliveCountMax=8",
-    "-o", "StrictHostKeyChecking=accept-new",
+    "-o", "StrictHostKeyChecking=yes",
 )
 KNOWN_HOSTS_CLEANUP_TIMEOUT_SECONDS = 30
+KNOWN_HOSTS_KEYSCAN_TIMEOUT_SECONDS = 15
+SSH_HOST_KEY_TYPES = ("ed25519", "ecdsa", "rsa")
 HOST_KEY_ALGORITHM_RE = (
     r"(?:ssh-rsa(?:-cert-v01@openssh\.com)?|"
     r"ssh-dss(?:-cert-v01@openssh\.com)?|"
@@ -89,6 +91,17 @@ HOST_KEY_ALGORITHM_RE = (
     r"sk-ecdsa-sha2-nistp256(?:@openssh\.com|-cert-v01@openssh\.com))"
 )
 HOST_KEY_BLOB_RE = re.compile(rf"\b{HOST_KEY_ALGORITHM_RE}\s+[A-Za-z0-9+/=]+")
+HOST_KEY_TYPE_RE = re.compile(rf"^{HOST_KEY_ALGORITHM_RE}$")
+SSH_HOST_KEY_MISMATCH_RE = re.compile(
+    r"(?:REMOTE HOST IDENTIFICATION HAS CHANGED|Host key verification failed|Offending .* key in)",
+    re.IGNORECASE,
+)
+SSH_NETWORK_UNREACHABLE_RE = re.compile(
+    r"(?:Connection refused|Connection timed out|No route to host|Network is unreachable|"
+    r"Operation timed out|Connection reset by peer|Connection closed by remote host|"
+    r"kex_exchange_identification:.*closed|Could not resolve hostname|Name or service not known)",
+    re.IGNORECASE,
+)
 SECRET_ASSIGNMENT_RE = re.compile(
     r"(?i)\b(?:STEAM_KEY|TOKEN|SECRET|PASSWORD|PRIVATE_KEY|TENCENTCLOUD_SECRET_KEY|TENCENT_SECRET_KEY)=\S+"
 )
@@ -210,6 +223,15 @@ class StepRecord:
     detail: dict[str, Any] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class KnownHostPrepareResult:
+    ok: bool
+    status: str
+    retryable: bool = False
+    reason: str = ""
+    host_key_count: int = 0
+
+
 @dataclass
 class Controller:
     args: argparse.Namespace
@@ -221,6 +243,7 @@ class Controller:
     private_ip: str | None = None
     steps: list[StepRecord] = field(default_factory=list)
     known_hosts_cleaned_public_ips: set[str] = field(default_factory=set, repr=False)
+    known_hosts_prepared_public_ips: set[str] = field(default_factory=set, repr=False)
     started_at: str = field(default_factory=lambda: utc_now_iso())
     finished_at: str | None = None
     final_status: str = "unknown"
@@ -360,8 +383,15 @@ class Controller:
         except json.JSONDecodeError as error:
             raise BatchRunError(f"{name} returned non-JSON output: {error}") from error
 
-    def ssh_cmd(self, name: str, remote_command: str, *, check: bool = True, timeout: int | None = 600) -> subprocess.CompletedProcess[str]:
-        self.clear_worker_known_host()
+    def ssh_cmd(
+        self,
+        name: str,
+        remote_command: str,
+        *,
+        check: bool = True,
+        timeout: int | None = 600,
+        prepare_known_host: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
         cmd = [
             "ssh",
             "-i", self.args.ssh_key,
@@ -369,10 +399,27 @@ class Controller:
             self.ssh_target,
             remote_command,
         ]
+        if prepare_known_host:
+            prepare_result = self.prepare_worker_known_host()
+            if not prepare_result.ok:
+                cp = ssh_prepare_failure_completed_process(cmd, prepare_result)
+                started = time.time()
+                self.record_step(
+                    name,
+                    started,
+                    False,
+                    cp,
+                    argv=redacted_argv(cmd),
+                    sshFailureClass=prepare_result.status,
+                    retryable=prepare_result.retryable,
+                )
+                if check:
+                    raise BatchRunError(ssh_prepare_failure_message(name, prepare_result))
+                return cp
         return self.run_cp(name, cmd, check=check, timeout=timeout)
 
     def scp_to_worker(self, name: str, local_path: Path, remote_path: str, *, timeout: int = 300) -> None:
-        self.clear_worker_known_host()
+        self.require_worker_known_host_prepared(name)
         self.run_cp(
             name,
             [
@@ -386,7 +433,7 @@ class Controller:
         )
 
     def scp_from_worker(self, name: str, remote_path: str, local_path: Path, *, timeout: int = 900) -> None:
-        self.clear_worker_known_host()
+        self.require_worker_known_host_prepared(name)
         local_path.parent.mkdir(parents=True, exist_ok=True)
         self.run_cp(
             name,
@@ -399,6 +446,180 @@ class Controller:
             ],
             timeout=timeout,
         )
+
+    def require_worker_known_host_prepared(self, operation_name: str) -> None:
+        result = self.prepare_worker_known_host()
+        if result.ok:
+            return
+        raise BatchRunError(ssh_prepare_failure_message(operation_name, result))
+
+    def prepare_worker_known_host(self) -> KnownHostPrepareResult:
+        if not self.public_ip:
+            return KnownHostPrepareResult(True, "skipped_no_public_ip")
+        if self.public_ip in self.known_hosts_prepared_public_ips:
+            return KnownHostPrepareResult(True, "already_prepared")
+
+        scan_result, scanned_lines = self.scan_worker_host_keys()
+        if not scan_result.ok:
+            return scan_result
+
+        known_hosts = self.known_hosts_path
+        started = time.time()
+        try:
+            known_hosts.parent.mkdir(parents=True, exist_ok=True)
+            known_hosts.touch(exist_ok=True)
+            current_lines = known_host_lines_for_host(known_hosts, self.public_ip)
+        except OSError as error:
+            cp = subprocess.CompletedProcess(
+                ["prepare-known-hosts", self.public_ip, str(known_hosts)],
+                127,
+                "",
+                f"{type(error).__name__}: {error}",
+            )
+            self.record_step(
+                "prepare_worker_known_host",
+                started,
+                False,
+                sanitized_known_hosts_completed_process(cp),
+                publicIp=self.public_ip,
+                knownHostsFile=str(known_hosts),
+                status="host_key_self_healing_failed",
+                retryable=False,
+            )
+            return KnownHostPrepareResult(
+                False,
+                "host_key_self_healing_failed",
+                reason=tail_text(str(error)),
+                host_key_count=len(scanned_lines),
+            )
+
+        if set(current_lines) == set(scanned_lines):
+            self.record_step(
+                "prepare_worker_known_host",
+                started,
+                True,
+                None,
+                publicIp=self.public_ip,
+                knownHostsFile=str(known_hosts),
+                status="existing_known_host",
+                hostKeyCount=len(scanned_lines),
+            )
+            self.mark_worker_known_host_prepared()
+            return KnownHostPrepareResult(True, "existing_known_host", host_key_count=len(scanned_lines))
+
+        return self.install_worker_known_host(scanned_lines, had_plain_entry=bool(current_lines))
+
+    def scan_worker_host_keys(self) -> tuple[KnownHostPrepareResult, list[str]]:
+        if not self.public_ip:
+            return KnownHostPrepareResult(True, "skipped_no_public_ip"), []
+        cmd = [
+            "ssh-keyscan",
+            "-T",
+            str(KNOWN_HOSTS_KEYSCAN_TIMEOUT_SECONDS),
+            "-t",
+            ",".join(SSH_HOST_KEY_TYPES),
+            self.public_ip,
+        ]
+        started = time.time()
+        try:
+            cp = subprocess.run(
+                cmd,
+                text=True,
+                capture_output=True,
+                cwd=str(REPO_ROOT),
+                timeout=KNOWN_HOSTS_KEYSCAN_TIMEOUT_SECONDS + 5,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as error:
+            stdout_raw = getattr(error, "stdout", None)
+            if stdout_raw is None:
+                stdout_raw = getattr(error, "output", None)
+            stderr_raw = getattr(error, "stderr", None)
+            stdout = decode_subprocess_text(stdout_raw)
+            stderr = decode_subprocess_text(stderr_raw)
+            stderr = "\n".join(part for part in (f"{type(error).__name__}: {error}", stderr) if part)
+            cp = subprocess.CompletedProcess(cmd, 124, stdout, stderr)
+        except OSError as error:
+            cp = subprocess.CompletedProcess(cmd, 127, "", f"{type(error).__name__}: {error}")
+
+        scanned_lines = normalize_ssh_keyscan_lines(self.public_ip, cp.stdout)
+        result = classify_host_keyscan_result(cp, scanned_lines)
+        self.record_step(
+            "scan_worker_host_key",
+            started,
+            result.ok,
+            sanitized_known_hosts_completed_process(cp),
+            argv=redacted_argv(cmd),
+            publicIp=self.public_ip,
+            knownHostsFile=str(self.known_hosts_path),
+            status=result.status,
+            retryable=result.retryable,
+            hostKeyCount=len(scanned_lines),
+        )
+        return result, scanned_lines
+
+    def install_worker_known_host(self, scanned_lines: Sequence[str], *, had_plain_entry: bool) -> KnownHostPrepareResult:
+        known_hosts = self.known_hosts_path
+        cmd = ["ssh-keygen", "-R", self.public_ip or "", "-f", str(known_hosts)]
+        started = time.time()
+        try:
+            known_hosts.parent.mkdir(parents=True, exist_ok=True)
+            known_hosts.touch(exist_ok=True)
+            cp = subprocess.run(
+                cmd,
+                text=True,
+                capture_output=True,
+                cwd=str(REPO_ROOT),
+                timeout=KNOWN_HOSTS_CLEANUP_TIMEOUT_SECONDS,
+                check=False,
+            )
+            if cp.returncode == 0:
+                with known_hosts.open("a", encoding="utf-8") as handle:
+                    for line in scanned_lines:
+                        handle.write(line.rstrip("\n") + "\n")
+        except subprocess.TimeoutExpired as error:
+            stdout_raw = getattr(error, "stdout", None)
+            if stdout_raw is None:
+                stdout_raw = getattr(error, "output", None)
+            stderr_raw = getattr(error, "stderr", None)
+            stdout = decode_subprocess_text(stdout_raw)
+            stderr = decode_subprocess_text(stderr_raw)
+            stderr = "\n".join(part for part in (f"{type(error).__name__}: {error}", stderr) if part)
+            cp = subprocess.CompletedProcess(cmd, 124, stdout, stderr)
+        except OSError as error:
+            cp = subprocess.CompletedProcess(cmd, 127, "", f"{type(error).__name__}: {error}")
+
+        ok = cp.returncode == 0
+        status = "rotated_known_host" if had_plain_entry or ssh_keygen_removed_host(cp) else "new_known_host"
+        if not ok:
+            status = "host_key_self_healing_failed"
+        self.record_step(
+            "install_worker_known_host",
+            started,
+            ok,
+            sanitized_known_hosts_completed_process(cp),
+            argv=redacted_argv(cmd),
+            publicIp=self.public_ip,
+            knownHostsFile=str(known_hosts),
+            status=status,
+            retryable=False,
+            hostKeyCount=len(scanned_lines),
+        )
+        if not ok:
+            return KnownHostPrepareResult(
+                False,
+                "host_key_self_healing_failed",
+                reason=tail_text(cp.stderr or cp.stdout),
+                host_key_count=len(scanned_lines),
+            )
+        self.mark_worker_known_host_prepared()
+        return KnownHostPrepareResult(True, status, host_key_count=len(scanned_lines))
+
+    def mark_worker_known_host_prepared(self) -> None:
+        if not self.public_ip:
+            return
+        self.known_hosts_prepared_public_ips.add(self.public_ip)
+        self.known_hosts_cleaned_public_ips.add(self.public_ip)
 
     def clear_worker_known_host(self) -> bool:
         if not self.public_ip:
@@ -798,7 +1019,9 @@ class Controller:
                     self.instance_id = cvm.get("InstanceId")
                     self.public_ip = public_ips[0]
                     self.private_ip = private_ips[0] if private_ips else None
-                    self.clear_worker_known_host()
+                    known_host = self.prepare_worker_known_host()
+                    if not known_host.ok and not known_host.retryable:
+                        raise BatchRunError(ssh_prepare_failure_message("ssh_probe", known_host))
                     if self.wait_for_ssh():
                         self.result["worker"] = {
                             "instanceId": self.instance_id,
@@ -821,6 +1044,13 @@ class Controller:
             cp = self.ssh_cmd("ssh_probe", "true", check=False, timeout=30)
             if cp.returncode == 0:
                 return True
+            failure_class = classify_ssh_process_failure(cp)
+            if failure_class == "host_key_mismatch":
+                if self.public_ip:
+                    self.known_hosts_prepared_public_ips.discard(self.public_ip)
+                    self.known_hosts_cleaned_public_ips.discard(self.public_ip)
+            elif failure_class == "host_key_self_healing_failed":
+                raise BatchRunError(f"SSH known_hosts self-healing failed before probe: {tail_text(cp.stderr or cp.stdout)}")
             time.sleep(10)
         return False
 
@@ -1166,6 +1396,111 @@ def sanitize_known_hosts_cleanup_text(raw: str | bytes | None) -> str:
         return f"{key}=[REDACTED]"
 
     return SECRET_ASSIGNMENT_RE.sub(redact_secret, text)
+
+
+def sanitized_known_hosts_completed_process(cp: subprocess.CompletedProcess[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        cp.args,
+        cp.returncode,
+        sanitize_known_hosts_cleanup_text(cp.stdout),
+        sanitize_known_hosts_cleanup_text(cp.stderr),
+    )
+
+
+def normalize_ssh_keyscan_lines(public_ip: str, raw: str | bytes | None) -> list[str]:
+    text = decode_subprocess_text(raw)
+    lines: list[str] = []
+    seen: set[str] = set()
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) < 3 or not HOST_KEY_TYPE_RE.match(parts[1]):
+            continue
+        hosts = parts[0].split(",")
+        if public_ip not in hosts and f"[{public_ip}]:22" not in hosts:
+            continue
+        normalized = f"{public_ip} {parts[1]} {parts[2]}"
+        if normalized not in seen:
+            seen.add(normalized)
+            lines.append(normalized)
+    return lines
+
+
+def known_host_lines_for_host(known_hosts: Path, public_ip: str) -> list[str]:
+    if not known_hosts.is_file():
+        return []
+    lines: list[str] = []
+    seen: set[str] = set()
+    for raw_line in known_hosts.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if parts and parts[0].startswith("@"):
+            parts = parts[1:]
+        if len(parts) < 3 or not HOST_KEY_TYPE_RE.match(parts[1]):
+            continue
+        hosts = parts[0].split(",")
+        if public_ip not in hosts and f"[{public_ip}]:22" not in hosts:
+            continue
+        normalized = f"{public_ip} {parts[1]} {parts[2]}"
+        if normalized not in seen:
+            seen.add(normalized)
+            lines.append(normalized)
+    return lines
+
+
+def classify_host_keyscan_result(
+    cp: subprocess.CompletedProcess[str],
+    scanned_lines: Sequence[str],
+) -> KnownHostPrepareResult:
+    if scanned_lines:
+        return KnownHostPrepareResult(True, "host_key_scanned", host_key_count=len(scanned_lines))
+    combined = "\n".join(part for part in (cp.stderr, cp.stdout) if part)
+    if cp.returncode == 124 or SSH_NETWORK_UNREACHABLE_RE.search(combined):
+        return KnownHostPrepareResult(
+            False,
+            "network_unreachable",
+            retryable=True,
+            reason=tail_text(sanitize_known_hosts_cleanup_text(combined)),
+        )
+    status = "host_key_self_healing_failed"
+    reason = tail_text(sanitize_known_hosts_cleanup_text(combined)) or f"ssh-keyscan exited {cp.returncode} without host keys"
+    return KnownHostPrepareResult(False, status, retryable=False, reason=reason)
+
+
+def classify_ssh_process_failure(cp: subprocess.CompletedProcess[str]) -> str:
+    if cp.returncode == 0:
+        return "ok"
+    combined = "\n".join(part for part in (cp.stderr, cp.stdout) if part)
+    if SSH_HOST_KEY_MISMATCH_RE.search(combined):
+        return "host_key_mismatch"
+    if "host_key_self_healing_failed" in combined:
+        return "host_key_self_healing_failed"
+    if SSH_NETWORK_UNREACHABLE_RE.search(combined) or "network_unreachable" in combined:
+        return "network_unreachable"
+    return "ssh_failed"
+
+
+def ssh_keygen_removed_host(cp: subprocess.CompletedProcess[str]) -> bool:
+    combined = "\n".join(part for part in (cp.stdout, cp.stderr) if part).lower()
+    return " found:" in combined or " updated." in combined
+
+
+def ssh_prepare_failure_completed_process(
+    cmd: Sequence[str],
+    result: KnownHostPrepareResult,
+) -> subprocess.CompletedProcess[str]:
+    stderr = f"{result.status}: {result.reason}".strip()
+    return subprocess.CompletedProcess(list(cmd), 255, "", stderr)
+
+
+def ssh_prepare_failure_message(operation_name: str, result: KnownHostPrepareResult) -> str:
+    if result.retryable or result.status == "network_unreachable":
+        return f"{operation_name} skipped: worker network unreachable before SSH host-key verification: {result.reason}"
+    return f"{operation_name} blocked: SSH known_hosts self-healing failed: {result.reason}"
 
 
 def redacted_argv(argv: Sequence[str]) -> list[str]:

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -3898,232 +3898,139 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 with self.assertRaisesRegex(runner.BatchRunError, pattern):
                     runner.validate_scale_proof_result(malformed, 5)
 
-    def test_scale_up_clears_known_host_once_before_first_ssh_probe(self) -> None:
-        args = controller_args()
-        args.scale_timeout_seconds = 5
-        events: list[tuple[str, object]] = []
-
-        class FakeController(runner.Controller):
-            def tccli(self, name: str, *params: str, check: bool = True, timeout: int = 90) -> dict[str, object]:
-                return {}
-
-            def describe_asg_instances(self) -> list[dict[str, object]]:
-                return [{"InstanceId": "ins-test"}]
-
-            def describe_cvm_instances(self, instance_ids: list[str]) -> list[dict[str, object]]:
-                return [
-                    {
-                        "InstanceId": "ins-test",
-                        "InstanceState": "RUNNING",
-                        "PublicIpAddresses": ["203.0.113.10"],
-                        "PrivateIpAddresses": ["10.0.0.10"],
-                        "InstanceType": "S5.SMALL1",
-                    }
-                ]
-
-            def latest_scale_out_failure(self, *, after_epoch: float) -> dict[str, object] | None:
-                return None
-
-            def wait_for_ssh(self) -> bool:
-                events.append(("wait_for_ssh", {"public_ip": self.public_ip, "steps": [step.name for step in self.steps]}))
-                return len([event for event in events if event[0] == "wait_for_ssh"]) >= 2
-
+    def test_prepare_worker_known_host_keeps_existing_entry_before_ssh_probe(self) -> None:
+        current_key = "203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIcurrent"
         with tempfile.TemporaryDirectory() as temp_dir:
+            args = controller_args()
             args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
-            controller = FakeController(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
+            known_hosts = Path(args.known_hosts_path)
+            known_hosts.write_text(current_key + "\n", encoding="utf-8")
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
+            controller.public_ip = "203.0.113.10"
 
-            def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
-                events.append(("clear_known_host", {"cmd": cmd, "public_ip": controller.public_ip}))
-                return subprocess.CompletedProcess(cmd, 0, "removed\n", "")
-
-            with (
-                mock.patch.object(runner.subprocess, "run", side_effect=fake_run),
-                mock.patch.object(runner.time, "sleep", return_value=None),
-            ):
-                controller.scale_up_and_wait()
-
-        self.assertEqual([event[0] for event in events], ["clear_known_host", "wait_for_ssh", "wait_for_ssh"])
-        clear_event = events[0][1]
-        self.assertIsInstance(clear_event, dict)
-        self.assertEqual(clear_event["public_ip"], "203.0.113.10")
-        self.assertEqual(clear_event["cmd"], ["ssh-keygen", "-R", "203.0.113.10", "-f", args.known_hosts_path])
-        first_probe_event = events[1][1]
-        self.assertIsInstance(first_probe_event, dict)
-        self.assertEqual(first_probe_event["public_ip"], "203.0.113.10")
-        self.assertIn("clear_worker_known_host", first_probe_event["steps"])
-        self.assertEqual([step.name for step in controller.steps].count("clear_worker_known_host"), 1)
-
-    def test_scale_up_known_host_cleanup_failure_does_not_raise(self) -> None:
-        args = controller_args()
-
-        class FakeController(runner.Controller):
-            def tccli(self, name: str, *params: str, check: bool = True, timeout: int = 90) -> dict[str, object]:
-                return {}
-
-            def describe_asg_instances(self) -> list[dict[str, object]]:
-                return [{"InstanceId": "ins-test"}]
-
-            def describe_cvm_instances(self, instance_ids: list[str]) -> list[dict[str, object]]:
-                return [
-                    {
-                        "InstanceId": "ins-test",
-                        "InstanceState": "RUNNING",
-                        "PublicIpAddresses": ["203.0.113.10"],
-                        "PrivateIpAddresses": [],
-                    }
-                ]
-
-            def latest_scale_out_failure(self, *, after_epoch: float) -> dict[str, object] | None:
-                return None
-
-            def wait_for_ssh(self) -> bool:
-                return True
-
-        with tempfile.TemporaryDirectory() as temp_dir:
-            args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
-            controller = FakeController(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
             with mock.patch.object(
                 runner.subprocess,
                 "run",
-                return_value=subprocess.CompletedProcess(["ssh-keygen"], 255, "", "host not found\n"),
-            ):
-                controller.scale_up_and_wait()
+                return_value=subprocess.CompletedProcess(["ssh-keyscan"], 0, current_key + "\n", ""),
+            ) as run:
+                result = controller.prepare_worker_known_host()
 
-        clear_steps = [step for step in controller.steps if step.name == "clear_worker_known_host"]
-        self.assertEqual(len(clear_steps), 1)
-        self.assertFalse(clear_steps[0].ok)
-        self.assertNotIn("203.0.113.10", controller.known_hosts_cleaned_public_ips)
-        self.assertEqual(controller.result["knownHostsCleanupWarnings"][0]["returncode"], 255)
-        self.assertEqual(controller.result["worker"]["publicIp"], "203.0.113.10")
+            self.assertTrue(result.ok)
+            self.assertEqual(result.status, "existing_known_host")
+            self.assertEqual(known_hosts.read_text(encoding="utf-8"), current_key + "\n")
+            self.assertEqual(run.call_count, 1)
+            self.assertEqual(run.call_args.args[0][0], "ssh-keyscan")
 
-    def test_scale_up_known_host_cleanup_timeout_does_not_raise_or_mark_cleaned(self) -> None:
-        args = controller_args()
+        self.assertEqual([step.name for step in controller.steps], ["scan_worker_host_key", "prepare_worker_known_host"])
+        self.assertIn("203.0.113.10", controller.known_hosts_prepared_public_ips)
 
-        class FakeController(runner.Controller):
-            def tccli(self, name: str, *params: str, check: bool = True, timeout: int = 90) -> dict[str, object]:
-                return {}
-
-            def describe_asg_instances(self) -> list[dict[str, object]]:
-                return [{"InstanceId": "ins-test"}]
-
-            def describe_cvm_instances(self, instance_ids: list[str]) -> list[dict[str, object]]:
-                return [
-                    {
-                        "InstanceId": "ins-test",
-                        "InstanceState": "RUNNING",
-                        "PublicIpAddresses": ["203.0.113.10"],
-                        "PrivateIpAddresses": [],
-                    }
-                ]
-
-            def latest_scale_out_failure(self, *, after_epoch: float) -> dict[str, object] | None:
-                return None
-
-            def wait_for_ssh(self) -> bool:
-                return True
-
+    def test_prepare_worker_known_host_rotates_stale_entry_before_ssh_probe(self) -> None:
+        stale_key = "203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIstale"
+        current_key = "203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIcurrent"
         with tempfile.TemporaryDirectory() as temp_dir:
+            args = controller_args()
             args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
-            controller = FakeController(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
-            timeout_stdout = (
-                b"line=203.0.113.10 ssh-ed25519-cert-v01@openssh.com "
-                b"AAAAC3NzaC1lZDI1NTE5LWNlcnQtimeoutkey\n"
-                b"STEAM_KEY=timeout-steam-secret\n"
-            )
-            timeout_stderr = b"TOKEN=timeout-token-secret\ntimed out\n"
-            with mock.patch.object(
-                runner.subprocess,
-                "run",
-                side_effect=subprocess.TimeoutExpired(["ssh-keygen"], 30, output=timeout_stdout, stderr=timeout_stderr),
-            ):
-                controller.scale_up_and_wait()
-
-        clear_steps = [step for step in controller.steps if step.name == "clear_worker_known_host"]
-        self.assertEqual(len(clear_steps), 1)
-        self.assertFalse(clear_steps[0].ok)
-        self.assertEqual(clear_steps[0].returncode, 124)
-        self.assertIn("TimeoutExpired", clear_steps[0].stderr_tail or "")
-        self.assertNotIn("203.0.113.10", controller.known_hosts_cleaned_public_ips)
-        self.assertEqual(controller.result["knownHostsCleanupWarnings"][0]["returncode"], 124)
-        self.assertEqual(controller.result["worker"]["publicIp"], "203.0.113.10")
-        combined = json.dumps(
-            {
-                "steps": [step.__dict__ for step in controller.steps],
-                "result": controller.result,
-            },
-            sort_keys=True,
-        )
-        self.assertIn("[REDACTED_HOST_KEY]", combined)
-        self.assertIn("STEAM_KEY=[REDACTED]", combined)
-        self.assertIn("TOKEN=[REDACTED]", combined)
-        self.assertNotIn("AAAAC3NzaC1lZDI1NTE5LWNlcnQtimeoutkey", combined)
-        self.assertNotIn("ssh-ed25519-cert-v01@openssh.com", combined)
-        self.assertNotIn("timeout-steam-secret", combined)
-        self.assertNotIn("timeout-token-secret", combined)
-
-    def test_scale_up_retries_failed_known_host_cleanup_for_same_ip(self) -> None:
-        args = controller_args()
-        args.scale_timeout_seconds = 5
-        events: list[tuple[str, object]] = []
-
-        class FakeController(runner.Controller):
-            def tccli(self, name: str, *params: str, check: bool = True, timeout: int = 90) -> dict[str, object]:
-                return {}
-
-            def describe_asg_instances(self) -> list[dict[str, object]]:
-                return [{"InstanceId": "ins-test"}]
-
-            def describe_cvm_instances(self, instance_ids: list[str]) -> list[dict[str, object]]:
-                return [
-                    {
-                        "InstanceId": "ins-test",
-                        "InstanceState": "RUNNING",
-                        "PublicIpAddresses": ["203.0.113.10"],
-                        "PrivateIpAddresses": ["10.0.0.10"],
-                        "InstanceType": "S5.SMALL1",
-                    }
-                ]
-
-            def latest_scale_out_failure(self, *, after_epoch: float) -> dict[str, object] | None:
-                return None
-
-            def wait_for_ssh(self) -> bool:
-                events.append(("wait_for_ssh", {"public_ip": self.public_ip}))
-                return len([event for event in events if event[0] == "wait_for_ssh"]) >= 2
-
-        with tempfile.TemporaryDirectory() as temp_dir:
-            args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
-            controller = FakeController(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
-            cleanup_results = [
-                subprocess.CompletedProcess(["ssh-keygen"], 255, "", "permission denied\n"),
-                subprocess.CompletedProcess(["ssh-keygen"], 0, "removed\n", ""),
-            ]
+            known_hosts = Path(args.known_hosts_path)
+            known_hosts.write_text(stale_key + "\n", encoding="utf-8")
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
+            controller.public_ip = "203.0.113.10"
 
             def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
-                events.append(("clear_known_host", {"cmd": cmd, "public_ip": controller.public_ip}))
-                result = cleanup_results.pop(0)
-                return subprocess.CompletedProcess(cmd, result.returncode, result.stdout, result.stderr)
+                if cmd[0] == "ssh-keyscan":
+                    return subprocess.CompletedProcess(cmd, 0, current_key + "\n", "")
+                if cmd[0] == "ssh-keygen":
+                    known_hosts.write_text("", encoding="utf-8")
+                    stdout = "# Host 203.0.113.10 found: line 1\nknown_hosts updated.\n"
+                    return subprocess.CompletedProcess(cmd, 0, stdout, "")
+                raise AssertionError(cmd)
+
+            with mock.patch.object(runner.subprocess, "run", side_effect=fake_run):
+                result = controller.prepare_worker_known_host()
+
+            self.assertTrue(result.ok)
+            self.assertEqual(result.status, "rotated_known_host")
+            self.assertEqual(known_hosts.read_text(encoding="utf-8"), current_key + "\n")
+
+        self.assertEqual([step.name for step in controller.steps], ["scan_worker_host_key", "install_worker_known_host"])
+        self.assertEqual(controller.steps[-1].detail["status"], "rotated_known_host")
+        self.assertIn("203.0.113.10", controller.known_hosts_prepared_public_ips)
+
+    def test_prepare_worker_known_host_installs_new_worker_entry_before_ssh_probe(self) -> None:
+        current_key = "203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIcurrent"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args = controller_args()
+            args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
+            known_hosts = Path(args.known_hosts_path)
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
+            controller.public_ip = "203.0.113.10"
+
+            def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                if cmd[0] == "ssh-keyscan":
+                    return subprocess.CompletedProcess(cmd, 0, current_key + "\n", "")
+                if cmd[0] == "ssh-keygen":
+                    return subprocess.CompletedProcess(cmd, 0, "Host 203.0.113.10 not found\n", "")
+                raise AssertionError(cmd)
+
+            with mock.patch.object(runner.subprocess, "run", side_effect=fake_run):
+                result = controller.prepare_worker_known_host()
+
+            self.assertTrue(result.ok)
+            self.assertEqual(result.status, "new_known_host")
+            self.assertEqual(known_hosts.read_text(encoding="utf-8"), current_key + "\n")
+
+        self.assertEqual([step.name for step in controller.steps], ["scan_worker_host_key", "install_worker_known_host"])
+        self.assertEqual(controller.steps[-1].detail["status"], "new_known_host")
+        self.assertIn("203.0.113.10", controller.known_hosts_prepared_public_ips)
+
+    def test_prepare_worker_known_host_failure_is_not_reported_as_network_unreachable(self) -> None:
+        current_key = "203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIcurrent"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args = controller_args()
+            args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
+            controller.public_ip = "203.0.113.10"
+
+            def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                if cmd[0] == "ssh-keyscan":
+                    return subprocess.CompletedProcess(cmd, 0, current_key + "\n", "")
+                if cmd[0] == "ssh-keygen":
+                    return subprocess.CompletedProcess(cmd, 13, "", "permission denied\n")
+                raise AssertionError(cmd)
+
+            with mock.patch.object(runner.subprocess, "run", side_effect=fake_run):
+                result = controller.prepare_worker_known_host()
+
+        self.assertFalse(result.ok)
+        self.assertFalse(result.retryable)
+        self.assertEqual(result.status, "host_key_self_healing_failed")
+        self.assertEqual(controller.steps[-1].detail["status"], "host_key_self_healing_failed")
+        self.assertIn("SSH known_hosts self-healing failed", runner.ssh_prepare_failure_message("ssh_probe", result))
+        self.assertNotIn("network unreachable", runner.ssh_prepare_failure_message("ssh_probe", result))
+
+    def test_wait_for_ssh_reports_unreachable_worker_without_host_key_self_heal_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args = controller_args()
+            args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
+            controller.public_ip = "203.0.113.10"
+
+            def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                stderr = "connect to address 203.0.113.10 port 22: Connection refused\n"
+                return subprocess.CompletedProcess(cmd, 1, "", stderr)
 
             with (
                 mock.patch.object(runner.subprocess, "run", side_effect=fake_run),
+                mock.patch.object(runner.time, "time", side_effect=[100.0, 101.0, 102.0, 103.0, 600.0]),
                 mock.patch.object(runner.time, "sleep", return_value=None),
             ):
-                controller.scale_up_and_wait()
+                reachable = controller.wait_for_ssh()
 
-        self.assertEqual(
-            [event[0] for event in events],
-            ["clear_known_host", "wait_for_ssh", "clear_known_host", "wait_for_ssh"],
-        )
-        cleanup_events = [event[1] for event in events if event[0] == "clear_known_host"]
-        self.assertEqual(len(cleanup_events), 2)
-        for cleanup_event in cleanup_events:
-            self.assertIsInstance(cleanup_event, dict)
-            self.assertEqual(cleanup_event["public_ip"], "203.0.113.10")
-            self.assertEqual(cleanup_event["cmd"], ["ssh-keygen", "-R", "203.0.113.10", "-f", args.known_hosts_path])
-        clear_steps = [step for step in controller.steps if step.name == "clear_worker_known_host"]
-        self.assertEqual([step.ok for step in clear_steps], [False, True])
-        self.assertIn("203.0.113.10", controller.known_hosts_cleaned_public_ips)
-        self.assertEqual(controller.result["worker"]["publicIp"], "203.0.113.10")
+        self.assertFalse(reachable)
+        self.assertEqual([step.name for step in controller.steps], ["scan_worker_host_key", "ssh_probe"])
+        self.assertEqual(controller.steps[0].detail["status"], "network_unreachable")
+        self.assertTrue(controller.steps[0].detail["retryable"])
+        self.assertEqual(controller.steps[1].detail["sshFailureClass"], "network_unreachable")
+        self.assertNotIn("203.0.113.10", controller.known_hosts_prepared_public_ips)
 
     def test_clear_known_host_skips_when_public_ip_is_missing(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -4134,7 +4041,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         run.assert_not_called()
         self.assertFalse([step for step in controller.steps if step.name == "clear_worker_known_host"])
 
-    def test_ssh_and_scp_commands_auto_cleanup_and_use_consistent_known_hosts_path(self) -> None:
+    def test_ssh_and_scp_commands_prepare_and_use_consistent_known_hosts_path(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             args = controller_args()
             args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
@@ -4142,14 +4049,8 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             self.assertEqual(parsed.known_hosts_path, args.known_hosts_path)
             controller = runner.Controller(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
             controller.public_ip = "203.0.113.10"
-            events: list[tuple[str, list[str]]] = []
-            cleanup_commands: list[list[str]] = []
+            controller.known_hosts_prepared_public_ips.add("203.0.113.10")
             commands: list[list[str]] = []
-
-            def capture_subprocess_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
-                events.append(("cleanup", cmd))
-                cleanup_commands.append(cmd)
-                return subprocess.CompletedProcess(cmd, 0, "", "")
 
             def capture_run_cp(
                 name: str,
@@ -4161,24 +4062,19 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 input_text: str | None = None,
                 env: dict[str, str] | None = None,
             ) -> subprocess.CompletedProcess[str]:
-                events.append(("command", cmd))
                 commands.append(cmd)
                 return subprocess.CompletedProcess(cmd, 0, "", "")
 
-            with (
-                mock.patch.object(runner.subprocess, "run", side_effect=capture_subprocess_run),
-                mock.patch.object(controller, "run_cp", side_effect=capture_run_cp),
-            ):
+            with mock.patch.object(controller, "run_cp", side_effect=capture_run_cp):
                 controller.ssh_cmd("ssh_probe", "true")
                 controller.scp_to_worker("upload", Path(temp_dir) / "local.txt", "/remote/local.txt")
                 controller.scp_from_worker("download", "/remote/out.txt", Path(temp_dir) / "out" / "out.txt")
 
-        self.assertEqual(cleanup_commands, [["ssh-keygen", "-R", "203.0.113.10", "-f", args.known_hosts_path]])
-        self.assertEqual([event[0] for event in events], ["cleanup", "command", "command", "command"])
+        self.assertEqual(len(commands), 3)
         for cmd in commands:
             with self.subTest(command=cmd[0]):
                 self.assertIn("BatchMode=yes", cmd)
-                self.assertIn("StrictHostKeyChecking=accept-new", cmd)
+                self.assertIn("StrictHostKeyChecking=yes", cmd)
                 self.assertIn(f"UserKnownHostsFile={args.known_hosts_path}", cmd)
 
     def test_known_host_cleanup_warning_redacts_secret_and_host_key_output(self) -> None:


### PR DESCRIPTION
## Summary
- Adds proactive Tencent worker SSH known_hosts preparation using `ssh-keyscan` before probe/transfer.
- Classifies SSH failures so network/unreachable workers are separated from host-key mismatch/self-healing failures.
- Updates focused batch-runner tests for existing known hosts, rotated hosts, new workers, and unreachable workers.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts.test_screeps_tencent_batch_rl_runner -q` (99 tests OK)

## Notes
- No Tencent/cloud/paid compute was launched by this implementation.
- Controller recovered the commit with a narrow Codex commit-only run after the initial Codex session exited with verified dirty changes.

Refs #1278
Refs #879
Refs #1032
Refs #1233
