### PR TITLE
fix(rl): tolerate transient ssh-keyscan gaps

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -81,6 +81,7 @@ SSH_CONNECT_OPTIONS = (
 )
 KNOWN_HOSTS_CLEANUP_TIMEOUT_SECONDS = 30
 KNOWN_HOSTS_KEYSCAN_TIMEOUT_SECONDS = 15
+KNOWN_HOSTS_KEYSCAN_RETRY_DELAYS_SECONDS = (2.0, 5.0)
 SSH_HOST_KEY_TYPES = ("ed25519", "ecdsa", "rsa")
 HOST_KEY_ALGORITHM_RE = (
     r"(?:ssh-rsa(?:-cert-v01@openssh\.com)?|"
@@ -267,9 +268,14 @@ class Controller:
             raise BatchRunError("public IP is not known yet")
         return f"{self.args.worker_user}@{self.public_ip}"
 
-    def ssh_connect_options(self) -> tuple[str, ...]:
+    def ssh_connect_options(self, *, strict_host_key_checking: str = "yes") -> tuple[str, ...]:
+        options = list(SSH_CONNECT_OPTIONS)
+        for index, option in enumerate(options):
+            if option.startswith("StrictHostKeyChecking="):
+                options[index] = f"StrictHostKeyChecking={strict_host_key_checking}"
+                break
         return (
-            *SSH_CONNECT_OPTIONS,
+            *options,
             "-o", f"UserKnownHostsFile={self.known_hosts_path}",
         )
 
@@ -461,6 +467,8 @@ class Controller:
 
         scan_result, scanned_lines = self.scan_worker_host_keys()
         if not scan_result.ok:
+            if scan_result.status == "host_key_scan_unavailable":
+                return self.prepare_worker_known_host_without_keyscan(scan_result)
             return scan_result
 
         known_hosts = self.known_hosts_path
@@ -520,6 +528,119 @@ class Controller:
             ",".join(SSH_HOST_KEY_TYPES),
             self.public_ip,
         ]
+        attempts = len(KNOWN_HOSTS_KEYSCAN_RETRY_DELAYS_SECONDS) + 1
+        for attempt in range(1, attempts + 1):
+            started = time.time()
+            try:
+                cp = subprocess.run(
+                    cmd,
+                    text=True,
+                    capture_output=True,
+                    cwd=str(REPO_ROOT),
+                    timeout=KNOWN_HOSTS_KEYSCAN_TIMEOUT_SECONDS + 5,
+                    check=False,
+                )
+            except subprocess.TimeoutExpired as error:
+                stdout_raw = getattr(error, "stdout", None)
+                if stdout_raw is None:
+                    stdout_raw = getattr(error, "output", None)
+                stderr_raw = getattr(error, "stderr", None)
+                stdout = decode_subprocess_text(stdout_raw)
+                stderr = decode_subprocess_text(stderr_raw)
+                stderr = "\n".join(part for part in (f"{type(error).__name__}: {error}", stderr) if part)
+                cp = subprocess.CompletedProcess(cmd, 124, stdout, stderr)
+            except OSError as error:
+                cp = subprocess.CompletedProcess(cmd, 127, "", f"{type(error).__name__}: {error}")
+
+            scanned_lines = normalize_ssh_keyscan_lines(self.public_ip, cp.stdout)
+            result = classify_host_keyscan_result(cp, scanned_lines)
+            self.record_step(
+                "scan_worker_host_key",
+                started,
+                result.ok,
+                sanitized_known_hosts_completed_process(cp),
+                argv=redacted_argv(cmd),
+                publicIp=self.public_ip,
+                knownHostsFile=str(self.known_hosts_path),
+                status=result.status,
+                retryable=result.retryable,
+                hostKeyCount=len(scanned_lines),
+                attempt=attempt,
+                attempts=attempts,
+            )
+            if result.ok or result.status != "host_key_scan_unavailable" or attempt == attempts:
+                return result, scanned_lines
+            time.sleep(KNOWN_HOSTS_KEYSCAN_RETRY_DELAYS_SECONDS[attempt - 1])
+
+        return KnownHostPrepareResult(False, "host_key_scan_unavailable", retryable=True), []
+
+    def prepare_worker_known_host_without_keyscan(self, scan_result: KnownHostPrepareResult) -> KnownHostPrepareResult:
+        known_hosts = self.known_hosts_path
+        started = time.time()
+        try:
+            known_hosts.parent.mkdir(parents=True, exist_ok=True)
+            known_hosts.touch(exist_ok=True)
+            current_lines = known_host_lines_for_host(known_hosts, self.public_ip or "")
+        except OSError as error:
+            cp = subprocess.CompletedProcess(
+                ["prepare-known-hosts", self.public_ip or "", str(known_hosts)],
+                127,
+                "",
+                f"{type(error).__name__}: {error}",
+            )
+            self.record_step(
+                "prepare_worker_known_host",
+                started,
+                False,
+                sanitized_known_hosts_completed_process(cp),
+                publicIp=self.public_ip,
+                knownHostsFile=str(known_hosts),
+                status="host_key_self_healing_failed",
+                retryable=False,
+                keyscanStatus=scan_result.status,
+            )
+            return KnownHostPrepareResult(
+                False,
+                "host_key_self_healing_failed",
+                reason=tail_text(str(error)),
+            )
+
+        if current_lines:
+            self.record_step(
+                "prepare_worker_known_host",
+                started,
+                True,
+                None,
+                publicIp=self.public_ip,
+                knownHostsFile=str(known_hosts),
+                status="existing_known_host_keyscan_unavailable",
+                keyscanStatus=scan_result.status,
+                hostKeyCount=len(current_lines),
+            )
+            self.mark_worker_known_host_prepared()
+            return KnownHostPrepareResult(
+                True,
+                "existing_known_host_keyscan_unavailable",
+                reason=scan_result.reason,
+                host_key_count=len(current_lines),
+            )
+
+        if not self.clear_worker_known_host():
+            return KnownHostPrepareResult(
+                False,
+                "host_key_self_healing_failed",
+                reason="ssh-keygen failed while clearing stale known_hosts before accept-new fallback",
+            )
+        return self.accept_new_worker_known_host(scan_result)
+
+    def accept_new_worker_known_host(self, scan_result: KnownHostPrepareResult) -> KnownHostPrepareResult:
+        cmd = [
+            "ssh",
+            "-i", self.args.ssh_key,
+            *self.ssh_connect_options(strict_host_key_checking="accept-new"),
+            self.ssh_target,
+            "true",
+        ]
         started = time.time()
         try:
             cp = subprocess.run(
@@ -527,7 +648,7 @@ class Controller:
                 text=True,
                 capture_output=True,
                 cwd=str(REPO_ROOT),
-                timeout=KNOWN_HOSTS_KEYSCAN_TIMEOUT_SECONDS + 5,
+                timeout=30,
                 check=False,
             )
         except subprocess.TimeoutExpired as error:
@@ -542,21 +663,30 @@ class Controller:
         except OSError as error:
             cp = subprocess.CompletedProcess(cmd, 127, "", f"{type(error).__name__}: {error}")
 
-        scanned_lines = normalize_ssh_keyscan_lines(self.public_ip, cp.stdout)
-        result = classify_host_keyscan_result(cp, scanned_lines)
+        ok = cp.returncode == 0
+        failure_class = classify_ssh_process_failure(cp)
+        retryable = not ok and cp.returncode not in {127} and failure_class != "host_key_mismatch"
+        status = "accepted_new_known_host" if ok else "host_key_accept_new_unavailable"
+        if not ok and not retryable:
+            status = "host_key_self_healing_failed"
         self.record_step(
-            "scan_worker_host_key",
+            "accept_new_worker_known_host",
             started,
-            result.ok,
+            ok,
             sanitized_known_hosts_completed_process(cp),
             argv=redacted_argv(cmd),
             publicIp=self.public_ip,
             knownHostsFile=str(self.known_hosts_path),
-            status=result.status,
-            retryable=result.retryable,
-            hostKeyCount=len(scanned_lines),
+            status=status,
+            retryable=retryable,
+            sshFailureClass=failure_class,
+            keyscanStatus=scan_result.status,
         )
-        return result, scanned_lines
+        if ok:
+            self.mark_worker_known_host_prepared()
+            return KnownHostPrepareResult(True, status)
+        reason = tail_text(sanitize_known_hosts_cleanup_text(cp.stderr or cp.stdout)) or scan_result.reason
+        return KnownHostPrepareResult(False, status, retryable=retryable, reason=reason)
 
     def install_worker_known_host(self, scanned_lines: Sequence[str], *, had_plain_entry: bool) -> KnownHostPrepareResult:
         known_hosts = self.known_hosts_path
@@ -1049,6 +1179,7 @@ class Controller:
                 if self.public_ip:
                     self.known_hosts_prepared_public_ips.discard(self.public_ip)
                     self.known_hosts_cleaned_public_ips.discard(self.public_ip)
+                    self.clear_worker_known_host()
             elif failure_class == "host_key_self_healing_failed":
                 raise BatchRunError(f"SSH known_hosts self-healing failed before probe: {tail_text(cp.stderr or cp.stdout)}")
             time.sleep(10)
@@ -1466,6 +1597,9 @@ def classify_host_keyscan_result(
             retryable=True,
             reason=tail_text(sanitize_known_hosts_cleanup_text(combined)),
         )
+    if cp.returncode in {0, 1}:
+        reason = tail_text(sanitize_known_hosts_cleanup_text(combined)) or f"ssh-keyscan exited {cp.returncode} without host keys"
+        return KnownHostPrepareResult(False, "host_key_scan_unavailable", retryable=True, reason=reason)
     status = "host_key_self_healing_failed"
     reason = tail_text(sanitize_known_hosts_cleanup_text(combined)) or f"ssh-keyscan exited {cp.returncode} without host keys"
     return KnownHostPrepareResult(False, status, retryable=False, reason=reason)
@@ -1498,8 +1632,10 @@ def ssh_prepare_failure_completed_process(
 
 
 def ssh_prepare_failure_message(operation_name: str, result: KnownHostPrepareResult) -> str:
-    if result.retryable or result.status == "network_unreachable":
+    if result.status == "network_unreachable":
         return f"{operation_name} skipped: worker network unreachable before SSH host-key verification: {result.reason}"
+    if result.retryable:
+        return f"{operation_name} skipped: SSH host-key verification not ready: {result.reason}"
     return f"{operation_name} blocked: SSH known_hosts self-healing failed: {result.reason}"
 
 

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -3982,6 +3982,99 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(controller.steps[-1].detail["status"], "new_known_host")
         self.assertIn("203.0.113.10", controller.known_hosts_prepared_public_ips)
 
+    def test_prepare_worker_known_host_retries_empty_keyscan_before_installing_key(self) -> None:
+        current_key = "203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIcurrent"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args = controller_args()
+            args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
+            known_hosts = Path(args.known_hosts_path)
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
+            controller.public_ip = "203.0.113.10"
+            keyscan_calls = 0
+
+            def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                nonlocal keyscan_calls
+                if cmd[0] == "ssh-keyscan":
+                    keyscan_calls += 1
+                    if keyscan_calls < 3:
+                        return subprocess.CompletedProcess(cmd, 1, "", "")
+                    return subprocess.CompletedProcess(cmd, 0, current_key + "\n", "")
+                if cmd[0] == "ssh-keygen":
+                    return subprocess.CompletedProcess(cmd, 0, "Host 203.0.113.10 not found\n", "")
+                raise AssertionError(cmd)
+
+            with (
+                mock.patch.object(runner.subprocess, "run", side_effect=fake_run),
+                mock.patch.object(runner.time, "sleep", return_value=None) as sleep,
+            ):
+                result = controller.prepare_worker_known_host()
+
+            self.assertTrue(result.ok)
+            self.assertEqual(result.status, "new_known_host")
+            self.assertEqual(known_hosts.read_text(encoding="utf-8"), current_key + "\n")
+
+        self.assertEqual(keyscan_calls, 3)
+        sleep.assert_has_calls([mock.call(2.0), mock.call(5.0)])
+        scan_steps = [step for step in controller.steps if step.name == "scan_worker_host_key"]
+        self.assertEqual([step.detail["attempt"] for step in scan_steps], [1, 2, 3])
+        self.assertEqual([step.detail["status"] for step in scan_steps[:2]], ["host_key_scan_unavailable"] * 2)
+        self.assertTrue(all(step.detail["retryable"] for step in scan_steps[:2]))
+        self.assertEqual(controller.steps[-1].detail["status"], "new_known_host")
+        self.assertIn("203.0.113.10", controller.known_hosts_prepared_public_ips)
+
+    def test_prepare_worker_known_host_accept_new_fallback_after_empty_keyscan_attempts(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args = controller_args()
+            args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
+            known_hosts = Path(args.known_hosts_path)
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
+            controller.public_ip = "203.0.113.10"
+            commands: list[list[str]] = []
+
+            def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                commands.append(cmd)
+                if cmd[0] == "ssh-keyscan":
+                    return subprocess.CompletedProcess(cmd, 1, "", "")
+                if cmd[0] == "ssh-keygen":
+                    known_hosts.write_text("", encoding="utf-8")
+                    return subprocess.CompletedProcess(cmd, 0, "Host 203.0.113.10 not found\n", "")
+                if cmd[0] == "ssh":
+                    known_hosts.write_text(
+                        "203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIaccepted\n",
+                        encoding="utf-8",
+                    )
+                    return subprocess.CompletedProcess(cmd, 0, "", "Warning: Permanently added host.\n")
+                raise AssertionError(cmd)
+
+            with (
+                mock.patch.object(runner.subprocess, "run", side_effect=fake_run),
+                mock.patch.object(runner.time, "sleep", return_value=None) as sleep,
+            ):
+                result = controller.prepare_worker_known_host()
+
+            self.assertTrue(result.ok)
+            self.assertEqual(result.status, "accepted_new_known_host")
+
+        sleep.assert_has_calls([mock.call(2.0), mock.call(5.0)])
+        self.assertEqual(
+            [step.name for step in controller.steps],
+            [
+                "scan_worker_host_key",
+                "scan_worker_host_key",
+                "scan_worker_host_key",
+                "clear_worker_known_host",
+                "accept_new_worker_known_host",
+            ],
+        )
+        self.assertTrue(all(step.detail["retryable"] for step in controller.steps[:3]))
+        ssh_commands = [cmd for cmd in commands if cmd[0] == "ssh"]
+        self.assertEqual(len(ssh_commands), 1)
+        self.assertIn("StrictHostKeyChecking=accept-new", ssh_commands[0])
+        self.assertIn(f"UserKnownHostsFile={args.known_hosts_path}", ssh_commands[0])
+        self.assertNotIn("StrictHostKeyChecking=no", ssh_commands[0])
+        self.assertEqual(controller.steps[-1].detail["status"], "accepted_new_known_host")
+        self.assertIn("203.0.113.10", controller.known_hosts_prepared_public_ips)
+
     def test_prepare_worker_known_host_failure_is_not_reported_as_network_unreachable(self) -> None:
         current_key = "203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIcurrent"
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- Harden Tencent SSH host-key preparation against transient `ssh-keyscan` exit-1/no-host-key windows.
- Add bounded retry/fallback handling that preserves host-key checking and surfaces clear failure reasons after bounded attempts.
- Add regression coverage for the `ssh-keyscan exited 1 without host keys` recurrence from #1278.

## Evidence
- Recurrence artifacts: `runtime-artifacts/tencent-cloud/batch-runs/tencent-pg-20260522t233005z/controller-summary.json`, `tencent-pg-20260522t233504z`, `tencent-pg-20260522t234006z`.
- All three failed before any environment started with `BatchRunError: ssh_probe blocked: SSH known_hosts self-healing failed: ssh-keyscan exited 1 without host keys`.
- This is a private/offline RL runner fix only; no official MMO learned-policy writes and no deploy workflow was run.

## Verification
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts.test_screeps_tencent_batch_rl_runner -q` — 101 tests OK
- `git diff --check`

Refs #1278
Refs #1299
Refs #879
Refs #1032
Refs #1233
