### PR TITLE
fix(rl): preserve conclusion registry entries across gate updates

### DIFF
--- a/scripts/rl_conclusion_registry.py
+++ b/scripts/rl_conclusion_registry.py
@@ -104,6 +104,8 @@ def normalize_conclusions(value: Any) -> dict[str, JsonObject]:
             raise ConclusionRegistryError("each conclusion record must have a non-empty conclusionId")
         record = dict(item)
         record["conclusionId"] = conclusion_id
+        if conclusion_id in records:
+            raise ConclusionRegistryError(f"duplicate conclusionId {conclusion_id!r} in conclusions payload")
         records[conclusion_id] = record
     return records
 

--- a/scripts/rl_conclusion_registry.py
+++ b/scripts/rl_conclusion_registry.py
@@ -125,7 +125,11 @@ def merge_registry_payload(
     existing_records = normalize_conclusions(existing_payload.get("conclusions"))
     incoming_records = normalize_conclusions(producer_conclusions)
 
-    merged = dict(existing_records)
+    merged = {
+        conclusion_id: record
+        for conclusion_id, record in existing_records.items()
+        if conclusion_id in incoming_records or record.get("ownerCron") != owner_cron
+    }
     new_count = 0
     closed_this_window = 0
     for conclusion_id, incoming in incoming_records.items():

--- a/scripts/rl_conclusion_registry.py
+++ b/scripts/rl_conclusion_registry.py
@@ -3,9 +3,12 @@
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
+import stat
 import tempfile
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -27,12 +30,18 @@ def canonical_json(value: Any) -> str:
 
 def write_json_atomic(path: Path, payload: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        existing_mode = stat.S_IMODE(path.stat().st_mode)
+    except FileNotFoundError:
+        existing_mode = None
     temp_fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
     temp_path = Path(temp_name)
     try:
         with os.fdopen(temp_fd, "w", encoding="utf-8") as handle:
             temp_fd = -1
             handle.write(canonical_json(payload))
+        if existing_mode is not None:
+            os.chmod(temp_path, existing_mode)
         os.replace(temp_path, path)
     finally:
         if temp_fd != -1:
@@ -44,6 +53,18 @@ def write_json_atomic(path: Path, payload: Any) -> None:
             temp_path.unlink()
         except FileNotFoundError:
             pass
+
+
+@contextmanager
+def locked_registry(path: Path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_name(f".{path.name}.lock")
+    with lock_path.open("a+", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
 def load_registry(path: Path) -> JsonObject:
@@ -116,7 +137,7 @@ def merge_registry_payload(
 
         previous = existing_records.get(conclusion_id)
         previous_owner = previous.get("ownerCron") if isinstance(previous, dict) else None
-        if previous is not None and previous_owner != owner_cron:
+        if previous is not None and previous_owner is not None and previous_owner != owner_cron:
             raise ConclusionRegistryError(
                 f"refusing to overwrite conclusion {conclusion_id} owned by {previous_owner!r}"
             )
@@ -157,10 +178,13 @@ def summarize_conclusions(
     closed_this_window: int = 0,
 ) -> JsonObject:
     status_counts = {status: 0 for status in CONCLUSION_STATUSES}
+    unknown_count = 0
     for record in records.values():
         status = str(record.get("status", "UNKNOWN")).upper()
         if status in status_counts:
             status_counts[status] += 1
+        else:
+            unknown_count += 1
 
     return {
         "total": len(records),
@@ -170,6 +194,7 @@ def summarize_conclusions(
         "validating": status_counts["VALIDATING"],
         "closedThisWindow": closed_this_window,
         "staleOrEscalated": status_counts["STALE"] + status_counts["ESCALATED"],
+        "unknown": unknown_count,
     }
 
 
@@ -181,12 +206,13 @@ def merge_registry_file(
     updated_at: str,
     updated_by: str | None = None,
 ) -> JsonObject:
-    merged = merge_registry_payload(
-        load_registry(path),
-        producer_conclusions,
-        owner_cron=owner_cron,
-        updated_at=updated_at,
-        updated_by=updated_by,
-    )
-    write_json_atomic(path, merged)
+    with locked_registry(path):
+        merged = merge_registry_payload(
+            load_registry(path),
+            producer_conclusions,
+            owner_cron=owner_cron,
+            updated_at=updated_at,
+            updated_by=updated_by,
+        )
+        write_json_atomic(path, merged)
     return merged

--- a/scripts/rl_conclusion_registry.py
+++ b/scripts/rl_conclusion_registry.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Read-modify-write helpers for the RL conclusion registry."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Sequence
+
+
+SCHEMA_VERSION = 1
+REGISTRY_TYPE = "rl-conclusion-registry"
+CONCLUSION_STATUSES = ("OPEN", "STALE", "ACTIONED", "VALIDATING", "CLOSED", "ESCALATED")
+
+JsonObject = dict[str, Any]
+
+
+class ConclusionRegistryError(ValueError):
+    """Raised when a conclusion registry update would lose or corrupt records."""
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+
+
+def write_json_atomic(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(temp_fd, "w", encoding="utf-8") as handle:
+            temp_fd = -1
+            handle.write(canonical_json(payload))
+        os.replace(temp_path, path)
+    finally:
+        if temp_fd != -1:
+            try:
+                os.close(temp_fd)
+            except OSError:
+                pass
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def load_registry(path: Path) -> JsonObject:
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except OSError as error:
+        raise ConclusionRegistryError(f"could not read conclusion registry {path}: {error}") from error
+    except json.JSONDecodeError as error:
+        raise ConclusionRegistryError(f"conclusion registry {path} is not valid JSON: {error}") from error
+    if not isinstance(parsed, dict):
+        raise ConclusionRegistryError(f"conclusion registry {path} must contain a JSON object")
+    return parsed
+
+
+def normalize_conclusions(value: Any) -> dict[str, JsonObject]:
+    if value is None:
+        return {}
+    if isinstance(value, dict) and "conclusions" in value and "conclusionId" not in value:
+        return normalize_conclusions(value.get("conclusions"))
+
+    items: list[tuple[str | None, Any]]
+    if isinstance(value, dict):
+        items = [(key, item) for key, item in value.items()]
+    elif isinstance(value, list):
+        items = [(None, item) for item in value]
+    else:
+        raise ConclusionRegistryError("conclusions must be a list or object keyed by conclusionId")
+
+    records: dict[str, JsonObject] = {}
+    for key, item in items:
+        if not isinstance(item, dict):
+            raise ConclusionRegistryError("each conclusion record must be a JSON object")
+        conclusion_id = item.get("conclusionId") if isinstance(item.get("conclusionId"), str) else key
+        if not isinstance(conclusion_id, str) or not conclusion_id:
+            raise ConclusionRegistryError("each conclusion record must have a non-empty conclusionId")
+        record = dict(item)
+        record["conclusionId"] = conclusion_id
+        records[conclusion_id] = record
+    return records
+
+
+def merge_registry_payload(
+    existing: JsonObject | None,
+    producer_conclusions: Sequence[JsonObject] | JsonObject,
+    *,
+    owner_cron: str,
+    updated_at: str,
+    updated_by: str | None = None,
+) -> JsonObject:
+    if not owner_cron:
+        raise ConclusionRegistryError("owner_cron must be non-empty")
+    if not updated_at:
+        raise ConclusionRegistryError("updated_at must be non-empty")
+
+    existing_payload = existing or {}
+    existing_records = normalize_conclusions(existing_payload.get("conclusions"))
+    incoming_records = normalize_conclusions(producer_conclusions)
+
+    merged = dict(existing_records)
+    new_count = 0
+    closed_this_window = 0
+    for conclusion_id, incoming in incoming_records.items():
+        incoming_owner = incoming.get("ownerCron")
+        if isinstance(incoming_owner, str) and incoming_owner != owner_cron:
+            raise ConclusionRegistryError(
+                f"conclusion {conclusion_id} is owned by {incoming_owner}, not producer {owner_cron}"
+            )
+
+        previous = existing_records.get(conclusion_id)
+        previous_owner = previous.get("ownerCron") if isinstance(previous, dict) else None
+        if previous is not None and previous_owner != owner_cron:
+            raise ConclusionRegistryError(
+                f"refusing to overwrite conclusion {conclusion_id} owned by {previous_owner!r}"
+            )
+
+        if previous is None:
+            new_count += 1
+        if (
+            previous is not None
+            and str(previous.get("status", "")).upper() != "CLOSED"
+            and str(incoming.get("status", "")).upper() == "CLOSED"
+        ):
+            closed_this_window += 1
+
+        next_record = dict(incoming)
+        next_record["conclusionId"] = conclusion_id
+        next_record["ownerCron"] = owner_cron
+        next_record.setdefault("lastSeenAt", updated_at)
+        merged[conclusion_id] = next_record
+
+    return {
+        "schemaVersion": existing_payload.get("schemaVersion", SCHEMA_VERSION),
+        "registryType": existing_payload.get("registryType", REGISTRY_TYPE),
+        "lastUpdatedAt": updated_at,
+        "updatedBy": updated_by or owner_cron,
+        "conclusions": merged,
+        "summary": summarize_conclusions(
+            merged,
+            new_count=new_count,
+            closed_this_window=closed_this_window,
+        ),
+    }
+
+
+def summarize_conclusions(
+    records: dict[str, JsonObject],
+    *,
+    new_count: int = 0,
+    closed_this_window: int = 0,
+) -> JsonObject:
+    status_counts = {status: 0 for status in CONCLUSION_STATUSES}
+    for record in records.values():
+        status = str(record.get("status", "UNKNOWN")).upper()
+        if status in status_counts:
+            status_counts[status] += 1
+
+    return {
+        "total": len(records),
+        "new": new_count,
+        "open": status_counts["OPEN"],
+        "actioned": status_counts["ACTIONED"],
+        "validating": status_counts["VALIDATING"],
+        "closedThisWindow": closed_this_window,
+        "staleOrEscalated": status_counts["STALE"] + status_counts["ESCALATED"],
+    }
+
+
+def merge_registry_file(
+    path: Path,
+    producer_conclusions: Sequence[JsonObject] | JsonObject,
+    *,
+    owner_cron: str,
+    updated_at: str,
+    updated_by: str | None = None,
+) -> JsonObject:
+    merged = merge_registry_payload(
+        load_registry(path),
+        producer_conclusions,
+        owner_cron=owner_cron,
+        updated_at=updated_at,
+        updated_by=updated_by,
+    )
+    write_json_atomic(path, merged)
+    return merged

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -1137,7 +1137,9 @@ def conclusion_summary(artifact: LoadedArtifact | None) -> JsonObject:
             "hasData": False,
         }
 
-    conclusions = [item for item in as_list(artifact.payload.get("conclusions")) if isinstance(item, dict)]
+    raw_conclusions = artifact.payload.get("conclusions")
+    conclusion_values = raw_conclusions.values() if isinstance(raw_conclusions, dict) else as_list(raw_conclusions)
+    conclusions = [item for item in conclusion_values if isinstance(item, dict)]
     counts = Counter(str(item.get("status", "UNKNOWN")).upper() for item in conclusions)
     p0_unresolved = [
         item

--- a/scripts/screeps_rl_dataset_gate.py
+++ b/scripts/screeps_rl_dataset_gate.py
@@ -18,6 +18,7 @@ from typing import Any, Sequence, TextIO
 import screeps_rl_dataset_export as dataset_export
 import screeps_rl_mmo_validator as mmo_validator
 import screeps_rl_rollout_manager as rollout_manager
+import rl_conclusion_registry as conclusion_registry
 import screeps_world_profiles as world_profiles
 import screeps_strategy_shadow_report as shadow_report
 
@@ -27,6 +28,8 @@ CONTRACT_TYPE = "screeps-rl-dataset-evaluation-gate-contract"
 REPORT_TYPE = "screeps-rl-dataset-evaluation-gate"
 SUMMARY_TYPE = "screeps-rl-dataset-evaluation-gate-summary"
 DEFAULT_OUT_DIR = Path("runtime-artifacts/rl-dataset-gates")
+DEFAULT_CONCLUSION_REGISTRY = Path("runtime-artifacts/rl-control-loop/conclusion-registry.json")
+E1_OWNER_CRON = "d6cff532edd4"
 DEFAULT_MIN_SAMPLES = 1
 DEFAULT_SHADOW_ARTIFACT_LIMIT = 200
 QUALITY_REJECTED_SAMPLE_LOG_LIMIT = 50
@@ -178,6 +181,12 @@ def build_contract() -> JsonObject:
                 "default": DEFAULT_HOME_ROOM,
                 "contract": "only the configured home room is expected to have owned spawns",
             },
+            "conclusionRegistry": {
+                "flag": "--conclusion-registry",
+                "required": False,
+                "defaultWhenOutDirIsGateData": str(DEFAULT_CONCLUSION_REGISTRY),
+                "contract": "read-modify-write merge keyed by conclusionId; non-E1 ownerCron records are preserved",
+            },
         },
         "outputs": {
             "directory": "runtime-artifacts/rl-dataset-gates/<gate-id>/",
@@ -191,6 +200,7 @@ def build_contract() -> JsonObject:
                 "runtime-artifacts/rl-datasets/<run-id>/",
                 "runtime-artifacts/strategy-shadow/<report-id>.json unless --skip-shadow-report is used",
                 "historical validation report when --candidate-config is supplied",
+                "runtime-artifacts/rl-control-loop/conclusion-registry.json when --conclusion-registry is supplied or --out-dir is runtime-artifacts/rl-control-loop/gate-data",
             ],
         },
         "gateChecks": {
@@ -1003,6 +1013,7 @@ def build_summary(report: JsonObject) -> JsonObject:
     historical = report.get("historicalValidation") if isinstance(report.get("historicalValidation"), dict) else {}
     predefined = report.get("predefinedMetricGate") if isinstance(report.get("predefinedMetricGate"), dict) else {}
     rollout = report.get("rolloutGate") if isinstance(report.get("rolloutGate"), dict) else {}
+    registry = report.get("conclusionRegistry") if isinstance(report.get("conclusionRegistry"), dict) else {}
     return {
         "ok": report.get("ok") is True,
         "type": SUMMARY_TYPE,
@@ -1026,8 +1037,170 @@ def build_summary(report: JsonObject) -> JsonObject:
         "predefinedMetricGateStatus": predefined.get("status"),
         "rolloutGateStatus": rollout.get("status"),
         "rolloutDecision": rollout.get("decision"),
+        "conclusionRegistryPath": registry.get("path"),
+        "conclusionRegistrySummary": registry.get("summary"),
         "blockingReasons": report.get("blockingReasons", []),
     }
+
+
+def inferred_conclusion_registry_path(out_dir: Path) -> Path | None:
+    resolved = out_dir.expanduser().resolve()
+    if resolved.name == "gate-data" and resolved.parent.name == "rl-control-loop":
+        return resolved.parent / "conclusion-registry.json"
+    return None
+
+
+def resolve_conclusion_registry_path(
+    conclusion_registry_path: Path | None,
+    out_dir: Path,
+    repo_root: Path,
+) -> Path | None:
+    if conclusion_registry_path is not None:
+        return resolve_path_against_repo(conclusion_registry_path, repo_root)
+    return inferred_conclusion_registry_path(out_dir)
+
+
+def source_artifacts_for_report(report: JsonObject) -> list[str]:
+    outputs = report.get("outputs") if isinstance(report.get("outputs"), dict) else {}
+    candidates = [report.get("reportPath"), outputs.get("reportPath"), outputs.get("gateDir")]
+    artifacts: list[str] = []
+    seen: set[str] = set()
+    for value in candidates:
+        if not isinstance(value, str) or not value or value in seen:
+            continue
+        seen.add(value)
+        artifacts.append(value)
+    return artifacts
+
+
+def e1_gate_conclusions(report: JsonObject, *, updated_at: str) -> list[JsonObject]:
+    gate_id = str(report.get("gateId") or "unknown")
+    source_artifacts = source_artifacts_for_report(report)
+    dataset = report.get("dataset") if isinstance(report.get("dataset"), dict) else {}
+    dataset_gate = report.get("datasetGate") if isinstance(report.get("datasetGate"), dict) else {}
+    quality = report.get("quality_checks") if isinstance(report.get("quality_checks"), dict) else {}
+    shadow = report.get("shadowEvaluation") if isinstance(report.get("shadowEvaluation"), dict) else {}
+    predefined = report.get("predefinedMetricGate") if isinstance(report.get("predefinedMetricGate"), dict) else {}
+
+    samples_accepted = quality.get("samples_accepted")
+    samples_rejected = quality.get("samples_rejected")
+    gate_ok = report.get("ok") is True
+    records: list[JsonObject] = [
+        {
+            "conclusionId": "E1-GATE-STATUS",
+            "sourceArtifacts": source_artifacts,
+            "category": "gate-status",
+            "severity": "P3" if gate_ok else "P1",
+            "statement": (
+                f"E1 shadow-eval gate {gate_id} {'PASSED' if gate_ok else 'BLOCKED'}: "
+                f"{samples_accepted if samples_accepted is not None else 'unknown'} accepted, "
+                f"{samples_rejected if samples_rejected is not None else 'unknown'} rejected."
+            ),
+            "status": "CLOSED" if gate_ok else "OPEN",
+            "closureAction": "Gate report and metrics persisted." if gate_ok else None,
+            "linkedIssues": ["#879", "#893", "#906"],
+            "requiredLandingEvidence": "Gate report JSON persisted and dashboard/metrics ingest can read it.",
+            "sustainedOutputRule": "Gate must keep passing with acceptance >= 0.95 on the next E1 run.",
+            "nextVerification": updated_at,
+            "lastSeenAt": updated_at,
+            "staleAfterHours": 48,
+            "gateId": gate_id,
+        }
+    ]
+
+    split_counts = dataset.get("splitCounts") if isinstance(dataset.get("splitCounts"), dict) else {}
+    eval_count = split_counts.get("eval")
+    if isinstance(eval_count, int):
+        records.append(
+            {
+                "conclusionId": "E1-EVAL-SAMPLE-LIMITED",
+                "sourceArtifacts": source_artifacts,
+                "category": "data-quality",
+                "severity": "P2",
+                "statement": f"Eval split has {eval_count} samples. Statistical power is limited below 50 samples.",
+                "status": "OPEN" if eval_count < 50 else "CLOSED",
+                "closureAction": "Eval split reached at least 50 samples." if eval_count >= 50 else None,
+                "linkedIssues": ["#879", "#893"],
+                "requiredLandingEvidence": "Eval set >= 50 samples or explicit owner/steward acceptance.",
+                "sustainedOutputRule": "Flag on every E1 run while eval samples remain below 50.",
+                "nextVerification": updated_at,
+                "lastSeenAt": updated_at,
+                "staleAfterHours": 72,
+                "gateId": gate_id,
+            }
+        )
+
+    if predefined.get("status") == "not_configured":
+        normalized = predefined.get("normalizedCurrent") if isinstance(predefined.get("normalizedCurrent"), dict) else {}
+        metrics = normalized.get("metrics") if isinstance(normalized.get("metrics"), dict) else {}
+        records.append(
+            {
+                "conclusionId": "E1-PREDEFINED-METRIC-NOT-CONFIGURED",
+                "sourceArtifacts": source_artifacts,
+                "category": "configuration-gap",
+                "severity": "P2",
+                "statement": (
+                    "Predefined metric gate not configured"
+                    f" (territory={metrics.get('territory')}, resources={metrics.get('resources')}, "
+                    f"kills={metrics.get('kills')}, reliability={metrics.get('reliability')})."
+                ),
+                "status": "OPEN",
+                "closureAction": None,
+                "linkedIssues": ["#893", "#906"],
+                "requiredLandingEvidence": "Metric floors configured in a future E1 gate run.",
+                "sustainedOutputRule": "Flag on every E1 run until metric floors are configured.",
+                "nextVerification": updated_at,
+                "lastSeenAt": updated_at,
+                "staleAfterHours": 72,
+                "gateId": gate_id,
+            }
+        )
+
+    shadow_status = shadow.get("status")
+    if shadow_status not in (None, "skipped"):
+        records.append(
+            {
+                "conclusionId": "E1-SHADOW-EVAL-STATUS",
+                "sourceArtifacts": [value for value in [shadow.get("reportPath"), *source_artifacts] if isinstance(value, str)],
+                "category": "strategy-eval",
+                "severity": "P3" if shadow_status == "pass" else "P1",
+                "statement": f"Shadow eval status is {shadow_status}; ranking context evidence remains gate-owned.",
+                "status": "CLOSED" if shadow_status == "pass" else "OPEN",
+                "closureAction": "Shadow report generated without blocking regression." if shadow_status == "pass" else None,
+                "linkedIssues": ["#879", "#893"],
+                "requiredLandingEvidence": "Shadow report with non-regressing candidate-vs-incumbent evidence.",
+                "sustainedOutputRule": "Reopen if shadow evaluation fails or reports unsafe/live-write flags.",
+                "nextVerification": updated_at,
+                "lastSeenAt": updated_at,
+                "staleAfterHours": 48,
+                "gateId": gate_id,
+            }
+        )
+
+    if dataset_gate.get("status") == "pass" and quality.get("status") == "pass":
+        records.append(
+            {
+                "conclusionId": "E1-CONSOLE-CAPTURE-FLOWING",
+                "sourceArtifacts": source_artifacts,
+                "category": "data-quality",
+                "severity": "P2",
+                "statement": (
+                    "Console capture pipeline is flowing: "
+                    f"{dataset_gate.get('sampleCount', dataset.get('sampleCount', 'unknown'))} samples accepted by the dataset gate."
+                ),
+                "status": "CLOSED",
+                "closureAction": "Dataset and quality gates passed.",
+                "linkedIssues": ["#879", "#893"],
+                "requiredLandingEvidence": "Two consecutive gate runs with acceptable quality and sample counts.",
+                "sustainedOutputRule": "Reopen if quality acceptance drops below 0.95.",
+                "nextVerification": updated_at,
+                "lastSeenAt": updated_at,
+                "staleAfterHours": 48,
+                "gateId": gate_id,
+            }
+        )
+
+    return records
 
 
 def run_gate(
@@ -1059,6 +1232,7 @@ def run_gate(
     min_owned_rooms: float | None = None,
     min_resource_score: float | None = None,
     min_kills_score: float | None = None,
+    conclusion_registry_path: Path | None = None,
     repo_root: Path | None = None,
 ) -> JsonObject:
     repo = (repo_root or Path.cwd()).expanduser().resolve()
@@ -1077,7 +1251,8 @@ def run_gate(
     )
     validate_gate_id(resolved_gate_id)
 
-    gate_dir = resolve_path_against_repo(out_dir, repo) / resolved_gate_id
+    resolved_out_dir = resolve_path_against_repo(out_dir, repo)
+    gate_dir = resolved_out_dir / resolved_gate_id
     resolved_dataset_out_dir = resolve_path_against_repo(dataset_out_dir, repo)
     resolved_shadow_out_dir = resolve_path_against_repo(shadow_out_dir, repo)
     resolved_dist_path = resolve_path_against_repo(dist_path, repo)
@@ -1201,6 +1376,26 @@ def run_gate(
     report["ok"] = not report["blockingReasons"]
     report["reportPath"] = dataset_export.display_path(report_path)
 
+    resolved_conclusion_registry_path = resolve_conclusion_registry_path(
+        conclusion_registry_path,
+        resolved_out_dir,
+        repo,
+    )
+    if resolved_conclusion_registry_path is not None:
+        merged_registry = conclusion_registry.merge_registry_file(
+            resolved_conclusion_registry_path,
+            e1_gate_conclusions(report, updated_at=created),
+            owner_cron=E1_OWNER_CRON,
+            updated_at=created,
+            updated_by=E1_OWNER_CRON,
+        )
+        report["outputs"]["conclusionRegistryPath"] = dataset_export.display_path(resolved_conclusion_registry_path)
+        report["conclusionRegistry"] = {
+            "path": dataset_export.display_path(resolved_conclusion_registry_path),
+            "ownerCron": E1_OWNER_CRON,
+            "summary": merged_registry.get("summary"),
+        }
+
     summary = build_summary(report)
     write_json_atomic(report_path, report)
     write_json_atomic(gate_dir / "gate_summary.json", summary)
@@ -1254,6 +1449,14 @@ def build_parser() -> argparse.ArgumentParser:
     run.add_argument("--min-owned-rooms", type=non_negative_number, help="Optional current owned-room floor.")
     run.add_argument("--min-resource-score", type=non_negative_number, help="Optional current resource-score floor.")
     run.add_argument("--min-kills-score", type=non_negative_number, help="Optional current kills-score floor.")
+    run.add_argument(
+        "--conclusion-registry",
+        type=Path,
+        help=(
+            "Optional conclusion registry path. If omitted, gate-data out dirs under "
+            "runtime-artifacts/rl-control-loop infer conclusion-registry.json."
+        ),
+    )
     run.add_argument("--print-report", action="store_true", help="Print the full gate report instead of the compact summary.")
     return parser
 
@@ -1304,12 +1507,13 @@ def main(argv: list[str] | None = None, stdout: TextIO = sys.stdout, stderr: Tex
                 min_owned_rooms=args.min_owned_rooms,
                 min_resource_score=args.min_resource_score,
                 min_kills_score=args.min_kills_score,
+                conclusion_registry_path=args.conclusion_registry,
             )
             stdout.write(canonical_json(report if args.print_report else build_summary(report)))
             return 0 if report.get("ok") is True else 1
 
         parser.error(f"unsupported command: {args.command}")
-    except DatasetGateError as error:
+    except (DatasetGateError, conclusion_registry.ConclusionRegistryError) as error:
         stderr.write(f"error: {error}\n")
         return 2
     except (RuntimeError, OSError, mmo_validator.ValidationConfigError) as error:

--- a/scripts/screeps_rl_dataset_gate.py
+++ b/scripts/screeps_rl_dataset_gate.py
@@ -1381,6 +1381,11 @@ def run_gate(
         resolved_out_dir,
         repo,
     )
+    summary_path = gate_dir / "gate_summary.json"
+    summary = build_summary(report)
+    write_json_atomic(report_path, report)
+    write_json_atomic(summary_path, summary)
+
     if resolved_conclusion_registry_path is not None:
         merged_registry = conclusion_registry.merge_registry_file(
             resolved_conclusion_registry_path,
@@ -1395,10 +1400,10 @@ def run_gate(
             "ownerCron": E1_OWNER_CRON,
             "summary": merged_registry.get("summary"),
         }
+        summary = build_summary(report)
+        write_json_atomic(report_path, report)
+        write_json_atomic(summary_path, summary)
 
-    summary = build_summary(report)
-    write_json_atomic(report_path, report)
-    write_json_atomic(gate_dir / "gate_summary.json", summary)
     dataset_export.assert_no_secret_leak(gate_dir, dataset_export.configured_secret_values())
     return report
 

--- a/scripts/test_rl_conclusion_registry.py
+++ b/scripts/test_rl_conclusion_registry.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 import json
+import os
+import stat
 import sys
 import tempfile
 import unittest
 from pathlib import Path
 from typing import Any
+from unittest import mock
 
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -73,6 +76,94 @@ class RlConclusionRegistryTest(unittest.TestCase):
         self.assertEqual(merged["summary"]["new"], 1)
         self.assertEqual(merged["summary"]["closedThisWindow"], 1)
         self.assertEqual(merged["summary"]["actioned"], 1)
+
+    def test_merge_allows_updating_legacy_records_missing_owner_cron(self) -> None:
+        existing = {
+            "schemaVersion": 1,
+            "registryType": "rl-conclusion-registry",
+            "conclusions": {
+                "E1-GATE-STATUS": {
+                    "conclusionId": "E1-GATE-STATUS",
+                    "status": "OPEN",
+                    "statement": "Legacy E1 gate failed before ownerCron existed.",
+                },
+            },
+        }
+
+        merged = registry.merge_registry_payload(
+            existing,
+            [
+                {
+                    "conclusionId": "E1-GATE-STATUS",
+                    "status": "CLOSED",
+                    "statement": "Current E1 gate passed.",
+                },
+            ],
+            owner_cron="d6cff532edd4",
+            updated_at="2026-05-23T00:00:00Z",
+        )
+
+        conclusion = merged["conclusions"]["E1-GATE-STATUS"]
+        self.assertEqual(conclusion["status"], "CLOSED")
+        self.assertEqual(conclusion["statement"], "Current E1 gate passed.")
+        self.assertEqual(conclusion["ownerCron"], "d6cff532edd4")
+        self.assertEqual(merged["summary"]["closedThisWindow"], 1)
+
+    def test_summary_counts_missing_or_invalid_status_as_unknown(self) -> None:
+        merged = registry.merge_registry_payload(
+            {},
+            [
+                {"conclusionId": "MISSING-STATUS", "statement": "Missing status."},
+                {"conclusionId": "INVALID-STATUS", "status": "deferred", "statement": "Invalid status."},
+            ],
+            owner_cron="d6cff532edd4",
+            updated_at="2026-05-23T00:00:00Z",
+        )
+
+        self.assertEqual(merged["summary"]["total"], 2)
+        self.assertEqual(merged["summary"]["unknown"], 2)
+
+    @unittest.skipIf(os.name == "nt", "POSIX file mode preservation test")
+    def test_merge_registry_file_preserves_existing_permissions(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "conclusion-registry.json"
+            path.write_text(
+                registry.canonical_json(
+                    {
+                        "schemaVersion": 1,
+                        "registryType": "rl-conclusion-registry",
+                        "conclusions": {},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            os.chmod(path, 0o640)
+
+            registry.merge_registry_file(
+                path,
+                [{"conclusionId": "E1-GATE-STATUS", "status": "CLOSED", "statement": "E1 passed."}],
+                owner_cron="d6cff532edd4",
+                updated_at="2026-05-23T00:00:00Z",
+            )
+
+            self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o640)
+
+    def test_merge_registry_file_uses_exclusive_sidecar_lock(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "conclusion-registry.json"
+
+            with mock.patch.object(registry.fcntl, "flock", wraps=registry.fcntl.flock) as flock:
+                registry.merge_registry_file(
+                    path,
+                    [{"conclusionId": "E1-GATE-STATUS", "status": "CLOSED", "statement": "E1 passed."}],
+                    owner_cron="d6cff532edd4",
+                    updated_at="2026-05-23T00:00:00Z",
+                )
+
+            self.assertEqual(
+                [call.args[1] for call in flock.call_args_list],
+                [registry.fcntl.LOCK_EX, registry.fcntl.LOCK_UN],
+            )
 
     def test_merge_rejects_cross_owner_conclusion_id_collision_without_rewriting_file(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_rl_conclusion_registry.py
+++ b/scripts/test_rl_conclusion_registry.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import rl_conclusion_registry as registry
+
+
+JsonObject = dict[str, Any]
+
+
+def read_json(path: Path) -> JsonObject:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class RlConclusionRegistryTest(unittest.TestCase):
+    def test_merge_preserves_non_owner_records_and_updates_e1_records(self) -> None:
+        existing = {
+            "schemaVersion": 1,
+            "registryType": "rl-conclusion-registry",
+            "lastUpdatedAt": "2026-05-22T22:00:00Z",
+            "updatedBy": "steward",
+            "conclusions": {
+                "LOOP-B-OPEN": {
+                    "conclusionId": "LOOP-B-OPEN",
+                    "ownerCron": "01609968392a",
+                    "status": "ACTIONED",
+                    "statement": "Loop B conclusion remains unresolved.",
+                },
+                "E1-GATE-STATUS": {
+                    "conclusionId": "E1-GATE-STATUS",
+                    "ownerCron": "d6cff532edd4",
+                    "status": "OPEN",
+                    "statement": "Old E1 gate failed.",
+                },
+            },
+        }
+
+        merged = registry.merge_registry_payload(
+            existing,
+            [
+                {
+                    "conclusionId": "E1-GATE-STATUS",
+                    "status": "CLOSED",
+                    "statement": "New E1 gate passed.",
+                },
+                {
+                    "conclusionId": "E1-EVAL-SAMPLE-LIMITED",
+                    "status": "OPEN",
+                    "statement": "Eval sample remains limited.",
+                },
+            ],
+            owner_cron="d6cff532edd4",
+            updated_at="2026-05-23T00:00:00Z",
+            updated_by="d6cff532edd4",
+        )
+
+        conclusions = merged["conclusions"]
+        self.assertEqual(conclusions["LOOP-B-OPEN"]["statement"], "Loop B conclusion remains unresolved.")
+        self.assertEqual(conclusions["LOOP-B-OPEN"]["ownerCron"], "01609968392a")
+        self.assertEqual(conclusions["E1-GATE-STATUS"]["status"], "CLOSED")
+        self.assertEqual(conclusions["E1-GATE-STATUS"]["ownerCron"], "d6cff532edd4")
+        self.assertEqual(conclusions["E1-EVAL-SAMPLE-LIMITED"]["ownerCron"], "d6cff532edd4")
+        self.assertEqual(merged["summary"]["total"], 3)
+        self.assertEqual(merged["summary"]["new"], 1)
+        self.assertEqual(merged["summary"]["closedThisWindow"], 1)
+        self.assertEqual(merged["summary"]["actioned"], 1)
+
+    def test_merge_rejects_cross_owner_conclusion_id_collision_without_rewriting_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "conclusion-registry.json"
+            original = {
+                "schemaVersion": 1,
+                "registryType": "rl-conclusion-registry",
+                "conclusions": {
+                    "SHARED-ID": {
+                        "conclusionId": "SHARED-ID",
+                        "ownerCron": "01609968392a",
+                        "status": "OPEN",
+                        "statement": "Loop B owns this ID.",
+                    }
+                },
+            }
+            path.write_text(registry.canonical_json(original), encoding="utf-8")
+
+            with self.assertRaises(registry.ConclusionRegistryError):
+                registry.merge_registry_file(
+                    path,
+                    [{"conclusionId": "SHARED-ID", "status": "CLOSED", "statement": "E1 collision."}],
+                    owner_cron="d6cff532edd4",
+                    updated_at="2026-05-23T00:00:00Z",
+                )
+
+            self.assertEqual(read_json(path), original)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_rl_conclusion_registry.py
+++ b/scripts/test_rl_conclusion_registry.py
@@ -77,6 +77,51 @@ class RlConclusionRegistryTest(unittest.TestCase):
         self.assertEqual(merged["summary"]["closedThisWindow"], 1)
         self.assertEqual(merged["summary"]["actioned"], 1)
 
+    def test_merge_prunes_omitted_records_owned_by_current_owner_only(self) -> None:
+        existing = {
+            "schemaVersion": 1,
+            "registryType": "rl-conclusion-registry",
+            "conclusions": {
+                "E1-STALE-OMITTED": {
+                    "conclusionId": "E1-STALE-OMITTED",
+                    "ownerCron": "d6cff532edd4",
+                    "status": "OPEN",
+                    "statement": "Previous E1 conditional conclusion no longer emitted.",
+                },
+                "LOOP-B-OMITTED": {
+                    "conclusionId": "LOOP-B-OMITTED",
+                    "ownerCron": "01609968392a",
+                    "status": "ACTIONED",
+                    "statement": "Different owner conclusion remains active.",
+                },
+                "LEGACY-UNOWNED-OMITTED": {
+                    "conclusionId": "LEGACY-UNOWNED-OMITTED",
+                    "status": "OPEN",
+                    "statement": "Legacy unowned conclusion is preserved until explicitly claimed.",
+                },
+            },
+        }
+
+        merged = registry.merge_registry_payload(
+            existing,
+            [
+                {
+                    "conclusionId": "E1-GATE-STATUS",
+                    "status": "CLOSED",
+                    "statement": "Current E1 gate passed.",
+                },
+            ],
+            owner_cron="d6cff532edd4",
+            updated_at="2026-05-23T00:00:00Z",
+        )
+
+        conclusions = merged["conclusions"]
+        self.assertNotIn("E1-STALE-OMITTED", conclusions)
+        self.assertEqual(conclusions["LOOP-B-OMITTED"]["ownerCron"], "01609968392a")
+        self.assertNotIn("ownerCron", conclusions["LEGACY-UNOWNED-OMITTED"])
+        self.assertEqual(conclusions["E1-GATE-STATUS"]["ownerCron"], "d6cff532edd4")
+        self.assertEqual(merged["summary"]["total"], 3)
+
     def test_merge_allows_updating_legacy_records_missing_owner_cron(self) -> None:
         existing = {
             "schemaVersion": 1,

--- a/scripts/test_rl_conclusion_registry.py
+++ b/scripts/test_rl_conclusion_registry.py
@@ -168,6 +168,23 @@ class RlConclusionRegistryTest(unittest.TestCase):
         self.assertEqual(merged["summary"]["total"], 2)
         self.assertEqual(merged["summary"]["unknown"], 2)
 
+    def test_normalize_conclusions_rejects_duplicate_conclusion_ids(self) -> None:
+        with self.assertRaisesRegex(registry.ConclusionRegistryError, "DUPLICATE-ID"):
+            registry.normalize_conclusions(
+                [
+                    {"conclusionId": "DUPLICATE-ID", "status": "OPEN"},
+                    {"conclusionId": "DUPLICATE-ID", "status": "CLOSED"},
+                ]
+            )
+
+        with self.assertRaisesRegex(registry.ConclusionRegistryError, "DUPLICATE-ID"):
+            registry.normalize_conclusions(
+                {
+                    "FIRST-KEY": {"conclusionId": "DUPLICATE-ID", "status": "OPEN"},
+                    "SECOND-KEY": {"conclusionId": "DUPLICATE-ID", "status": "CLOSED"},
+                }
+            )
+
     @unittest.skipIf(os.name == "nt", "POSIX file mode preservation test")
     def test_merge_registry_file_preserves_existing_permissions(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -104,6 +104,36 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertTrue(dashboard.value_has_reference(["0", "2.5"]))
         self.assertTrue(dashboard.value_has_reference("training-report-a"))
 
+    def test_conclusion_summary_counts_mapping_registry_shape(self) -> None:
+        artifact = loaded_artifact(
+            Path("runtime-artifacts/rl-control-loop/conclusion-registry.json"),
+            {
+                "conclusions": {
+                    "LOOP-B-ACTIONED": {
+                        "conclusionId": "LOOP-B-ACTIONED",
+                        "status": "ACTIONED",
+                        "severity": "P0",
+                        "statement": "Loop B still validating.",
+                        "lastSeenAt": "2026-05-23T00:00:00Z",
+                    },
+                    "E1-OPEN": {
+                        "conclusionId": "E1-OPEN",
+                        "status": "OPEN",
+                        "severity": "P0",
+                        "statement": "E1 still needs closure evidence.",
+                        "lastSeenAt": "2026-05-23T00:01:00Z",
+                    },
+                }
+            },
+        )
+
+        summary = dashboard.conclusion_summary(artifact)
+
+        self.assertEqual(summary["counts"]["OPEN"], 1)
+        self.assertEqual(summary["counts"]["ACTIONED"], 1)
+        self.assertEqual(summary["counts"]["CLOSED"], 0)
+        self.assertEqual([item["conclusionId"] for item in summary["p0Unresolved"]], ["E1-OPEN"])
+
     def test_dashboard_prefers_fresh_acceptable_gate_data_over_stale_dataset_gate_and_embedded_ledger_gate(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_dataset_gate.py
+++ b/scripts/test_screeps_rl_dataset_gate.py
@@ -540,6 +540,99 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
         self.assertIn("E1-CONSOLE-CAPTURE-FLOWING", conclusions)
         self.assertEqual(saved_registry["summary"]["total"], len(conclusions))
 
+    def test_gate_updates_legacy_e1_conclusion_missing_owner_cron(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            control_loop = artifact_root / "rl-control-loop"
+            registry_path = control_loop / "conclusion-registry.json"
+            write_json(
+                registry_path,
+                {
+                    "schemaVersion": 1,
+                    "registryType": "rl-conclusion-registry",
+                    "lastUpdatedAt": "2026-05-22T22:00:00Z",
+                    "updatedBy": "legacy-gate",
+                    "conclusions": {
+                        "E1-GATE-STATUS": {
+                            "conclusionId": "E1-GATE-STATUS",
+                            "status": "OPEN",
+                            "statement": "Legacy E1 gate failed before ownerCron existed.",
+                        },
+                    },
+                },
+            )
+            artifact = root / "runtime.log"
+            artifact.write_text(runtime_line(runtime_payload(100)), encoding="utf-8")
+
+            with mock.patch.dict(gate.os.environ, {"SCREEPS_HOME_ROOM": "E26S49"}):
+                report = gate.run_gate(
+                    [str(artifact)],
+                    out_dir=control_loop / "gate-data",
+                    gate_id="gate-e1-legacy-owner",
+                    created_at="2026-05-23T00:00:00Z",
+                    dataset_out_dir=artifact_root / "rl-datasets",
+                    skip_shadow_report=True,
+                    bot_commit="d" * 40,
+                    eval_ratio_value=0,
+                    repo_root=root,
+                )
+
+            saved_registry = read_json(registry_path)
+
+        self.assertTrue(report["ok"])
+        conclusion = saved_registry["conclusions"]["E1-GATE-STATUS"]
+        self.assertEqual(conclusion["ownerCron"], gate.E1_OWNER_CRON)
+        self.assertEqual(conclusion["status"], "CLOSED")
+        self.assertNotEqual(conclusion["statement"], "Legacy E1 gate failed before ownerCron existed.")
+
+    def test_gate_does_not_update_registry_when_initial_summary_write_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            control_loop = artifact_root / "rl-control-loop"
+            registry_path = control_loop / "conclusion-registry.json"
+            original_registry = {
+                "schemaVersion": 1,
+                "registryType": "rl-conclusion-registry",
+                "lastUpdatedAt": "2026-05-22T22:00:00Z",
+                "updatedBy": gate.E1_OWNER_CRON,
+                "conclusions": {
+                    "E1-GATE-STATUS": {
+                        "conclusionId": "E1-GATE-STATUS",
+                        "ownerCron": gate.E1_OWNER_CRON,
+                        "status": "OPEN",
+                        "statement": "Previous E1 gate failed.",
+                    },
+                },
+            }
+            write_json(registry_path, original_registry)
+            artifact = root / "runtime.log"
+            artifact.write_text(runtime_line(runtime_payload(100)), encoding="utf-8")
+            original_write_json_atomic = gate.write_json_atomic
+
+            def fail_summary_write(path: Path, payload: JsonObject) -> None:
+                if path.name == "gate_summary.json":
+                    raise OSError("simulated summary write failure")
+                original_write_json_atomic(path, payload)
+
+            with mock.patch.dict(gate.os.environ, {"SCREEPS_HOME_ROOM": "E26S49"}):
+                with mock.patch.object(gate, "write_json_atomic", side_effect=fail_summary_write):
+                    with self.assertRaises(OSError):
+                        gate.run_gate(
+                            [str(artifact)],
+                            out_dir=control_loop / "gate-data",
+                            gate_id="gate-summary-write-fails",
+                            created_at="2026-05-23T00:00:00Z",
+                            dataset_out_dir=artifact_root / "rl-datasets",
+                            skip_shadow_report=True,
+                            bot_commit="e" * 40,
+                            eval_ratio_value=0,
+                            repo_root=root,
+                        )
+
+            self.assertEqual(read_json(registry_path), original_registry)
+
     def test_cli_returns_nonzero_when_predefined_metric_floor_fails(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_dataset_gate.py
+++ b/scripts/test_screeps_rl_dataset_gate.py
@@ -481,6 +481,65 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
         self.assertEqual(report["quality_checks"]["samples_rejected"], 1)
         self.assertIn("no_owned_spawns", report["quality_checks"]["rejection_reasons"])
 
+    def test_gate_data_out_dir_merges_e1_conclusions_without_dropping_loop_b_records(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            control_loop = artifact_root / "rl-control-loop"
+            registry_path = control_loop / "conclusion-registry.json"
+            write_json(
+                registry_path,
+                {
+                    "schemaVersion": 1,
+                    "registryType": "rl-conclusion-registry",
+                    "lastUpdatedAt": "2026-05-22T22:00:00Z",
+                    "updatedBy": "01609968392a",
+                    "conclusions": {
+                        "LOOP-B-ACTIONED": {
+                            "conclusionId": "LOOP-B-ACTIONED",
+                            "ownerCron": "01609968392a",
+                            "status": "ACTIONED",
+                            "statement": "Loop B action still needs validation.",
+                        },
+                        "E1-GATE-STATUS": {
+                            "conclusionId": "E1-GATE-STATUS",
+                            "ownerCron": gate.E1_OWNER_CRON,
+                            "status": "OPEN",
+                            "statement": "Previous E1 gate failed.",
+                        },
+                    },
+                },
+            )
+            artifact = root / "runtime.log"
+            artifact.write_text(runtime_line(runtime_payload(100)), encoding="utf-8")
+
+            with mock.patch.dict(gate.os.environ, {"SCREEPS_HOME_ROOM": "E26S49"}):
+                report = gate.run_gate(
+                    [str(artifact)],
+                    out_dir=control_loop / "gate-data",
+                    gate_id="gate-e1-merge",
+                    created_at="2026-05-23T00:00:00Z",
+                    dataset_out_dir=artifact_root / "rl-datasets",
+                    skip_shadow_report=True,
+                    bot_commit="c" * 40,
+                    eval_ratio_value=0,
+                    repo_root=root,
+                )
+
+            saved_registry = read_json(registry_path)
+            saved_summary = read_json(control_loop / "gate-data" / "gate-e1-merge" / "gate_summary.json")
+
+        self.assertIn("conclusionRegistry", report)
+        self.assertEqual(report["conclusionRegistry"]["ownerCron"], gate.E1_OWNER_CRON)
+        self.assertEqual(saved_summary["conclusionRegistrySummary"]["total"], len(saved_registry["conclusions"]))
+        conclusions = saved_registry["conclusions"]
+        self.assertEqual(conclusions["LOOP-B-ACTIONED"]["statement"], "Loop B action still needs validation.")
+        self.assertEqual(conclusions["LOOP-B-ACTIONED"]["ownerCron"], "01609968392a")
+        self.assertNotEqual(conclusions["E1-GATE-STATUS"]["statement"], "Previous E1 gate failed.")
+        self.assertEqual(conclusions["E1-GATE-STATUS"]["ownerCron"], gate.E1_OWNER_CRON)
+        self.assertIn("E1-CONSOLE-CAPTURE-FLOWING", conclusions)
+        self.assertEqual(saved_registry["summary"]["total"], len(conclusions))
+
     def test_cli_returns_nonzero_when_predefined_metric_floor_fails(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_dataset_gate.py
+++ b/scripts/test_screeps_rl_dataset_gate.py
@@ -507,6 +507,12 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
                             "status": "OPEN",
                             "statement": "Previous E1 gate failed.",
                         },
+                        "E1-SHADOW-EVAL-STATUS": {
+                            "conclusionId": "E1-SHADOW-EVAL-STATUS",
+                            "ownerCron": gate.E1_OWNER_CRON,
+                            "status": "OPEN",
+                            "statement": "Previous E1 shadow eval failed.",
+                        },
                     },
                 },
             )
@@ -537,6 +543,7 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
         self.assertEqual(conclusions["LOOP-B-ACTIONED"]["ownerCron"], "01609968392a")
         self.assertNotEqual(conclusions["E1-GATE-STATUS"]["statement"], "Previous E1 gate failed.")
         self.assertEqual(conclusions["E1-GATE-STATUS"]["ownerCron"], gate.E1_OWNER_CRON)
+        self.assertNotIn("E1-SHADOW-EVAL-STATUS", conclusions)
         self.assertIn("E1-CONSOLE-CAPTURE-FLOWING", conclusions)
         self.assertEqual(saved_registry["summary"]["total"], len(conclusions))
 


### PR DESCRIPTION
## Summary
- Adds a shared RL conclusion-registry merge helper so E1 gate updates preserve non-E1 Loop B/steward conclusions instead of replacing the registry map.
- Updates dataset-gate writes to merge by `conclusionId` and keep existing records from other owner crons.
- Updates dashboard counting to handle mapping-shaped conclusion registries and adds regression coverage.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/rl_conclusion_registry.py scripts/screeps_rl_dataset_gate.py scripts/screeps_rl_dashboard.py`
- `python3 -m unittest scripts.test_rl_conclusion_registry scripts.test_screeps_rl_dataset_gate scripts.test_screeps_rl_dashboard -q` — 57 tests OK

## Safety
- Offline/RL artifact handling only; no official MMO code deploy required.
- Controller preserved Codex authorship on commit `313453e4c3ba32352a6e4646737a10f3afbe0d8f`.

Fixes #1341
Refs #893
Refs #879
