### PR TITLE
fix(rl): canonicalize runtime parameter hashes

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -777,14 +777,13 @@ def canonical_runtime_parameter_value(value: Any) -> Any:
     if isinstance(value, bool):
         return value
     if isinstance(value, float) and math.isfinite(value):
-        rounded = round(value)
-        if abs(value - rounded) < 1e-9:
-            return int(rounded)
+        if value.is_integer():
+            return int(value)
         return value
     if isinstance(value, dict):
         return {
             key: canonical_runtime_parameter_value(item)
-            for key, item in sorted(value.items())
+            for key, item in value.items()
             if isinstance(key, str)
         }
     if isinstance(value, list):

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -545,7 +545,7 @@ def runtime_parameter_injection_for_variant(
     strategy_variant: Mapping[str, Any],
 ) -> JsonObject:
     """Build the offline-only policy-parameter payload injected into a private simulator code upload."""
-    parameters = _strategy_variant_parameters(dict(strategy_variant))
+    parameters = canonical_runtime_parameter_value(_strategy_variant_parameters(dict(strategy_variant)))
     if not parameters:
         return {
             "type": RUNTIME_PARAMETER_INJECTION_TYPE,
@@ -577,9 +577,7 @@ def runtime_parameter_injection_for_variant(
         "sourceStrategyId": strategy_variant.get("sourceStrategyId"),
         "family": strategy_variant.get("family"),
         "parameters": copy.deepcopy(parameters),
-        "parametersSha256": hashlib.sha256(
-            json.dumps(parameters, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
-        ).hexdigest(),
+        "parametersSha256": runtime_parameter_parameters_hash(parameters),
         "liveEffect": False,
         "officialMmoWrites": False,
         "officialMmoWritesAllowed": False,
@@ -764,9 +762,34 @@ def runtime_consumption_parameters_hash(evidence: JsonObject) -> str | None:
     parameters = evidence.get("parameters")
     if not isinstance(parameters, dict):
         return None
+    return runtime_parameter_parameters_hash(parameters)
+
+
+def runtime_parameter_parameters_hash(parameters: JsonObject) -> str:
+    normalized = canonical_runtime_parameter_value(parameters)
     return hashlib.sha256(
-        json.dumps(parameters, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+        json.dumps(normalized, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
     ).hexdigest()
+
+
+def canonical_runtime_parameter_value(value: Any) -> Any:
+    """Normalize JSON-safe values to the numeric shape emitted by JavaScript JSON.stringify."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float) and math.isfinite(value):
+        rounded = round(value)
+        if abs(value - rounded) < 1e-9:
+            return int(rounded)
+        return value
+    if isinstance(value, dict):
+        return {
+            key: canonical_runtime_parameter_value(item)
+            for key, item in sorted(value.items())
+            if isinstance(key, str)
+        }
+    if isinstance(value, list):
+        return [canonical_runtime_parameter_value(item) for item in value]
+    return value
 
 
 def runtime_parameter_record_matches_username(value: Any, username: str | None) -> bool:

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -199,6 +199,10 @@ def canonical_hash(value: Any) -> str:
     ).hexdigest()
 
 
+def runtime_parameter_parameters_hash(parameters: JsonObject) -> str:
+    return simulator_harness.runtime_parameter_parameters_hash(parameters)
+
+
 def ensure_steam_key_for_training(
     *,
     simulator_runner: SimulatorRunner,
@@ -4196,9 +4200,9 @@ def summarize_runtime_parameter_injection_attempt(
         return {key: value for key, value in row.items() if value is not None}
 
     evaluated_parameters = copy.deepcopy(raw_parameters)
-    evaluated_hash = canonical_hash(evaluated_parameters)
+    evaluated_hash = runtime_parameter_parameters_hash(evaluated_parameters)
     injected_hash = text_or_none(injection.get("parametersSha256"))
-    card_hash = canonical_hash(variant.parameters)
+    card_hash = runtime_parameter_parameters_hash(variant.parameters)
     if injected_hash is not None and evaluated_hash != injected_hash:
         row["runtimeParameterInjection"] = False
         row["runtimeParameterConsumption"] = False
@@ -4288,7 +4292,7 @@ def summarize_variant_runtime_parameter_injection(
             "attemptCount": len(attempts),
             "successfulAttemptCount": 0,
             "attempts": attempts,
-            "parametersSha256": canonical_hash(variant.parameters),
+            "parametersSha256": runtime_parameter_parameters_hash(variant.parameters),
             "reason": reason,
             "liveEffect": False,
             "officialMmoWrites": False,
@@ -4366,7 +4370,7 @@ def summarize_variant_runtime_parameter_injection(
         "attemptCount": len(attempts),
         "successfulAttemptCount": len(successful_attempts),
         "attempts": attempts,
-        "parametersSha256": canonical_hash(variant.parameters),
+        "parametersSha256": runtime_parameter_parameters_hash(variant.parameters),
         "runtimeParameterConsumption": runtime_injected and consumed_attempt_count == len(eligible_attempts),
         "runtimeParameterConsumptionStatus": runtime_parameter_consumption_rollup_status(eligible_attempts),
         "consumedAttemptCount": consumed_attempt_count,

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1703,6 +1703,46 @@ cli:
         self.assertTrue(updated["runtimeParameterConsumption"])
         self.assertEqual(updated["runtimeParameterConsumptionStatus"], "consumed")
 
+    def test_runtime_parameter_consumption_accepts_javascript_numeric_canonicalization(self) -> None:
+        variant = {
+            "id": "construction-priority.pg.territory-seed.v1",
+            "candidatePolicyId": "construction-priority.pg.territory-seed.v1",
+            "family": "construction-priority",
+            "parameters": {
+                "baseScoreWeight": 1.0,
+                "territorySignalWeight": 22.0,
+                "resourceSignalWeight": 3.0,
+                "killSignalWeight": 5.0,
+                "riskPenalty": 4.0,
+            },
+        }
+        base_code = (
+            '"use strict";\n'
+            f'var runtimePolicyConsumer = "{harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER}";\n'
+            "module.exports.loop = function loop() { return 1; };\n"
+        )
+        injection = harness.runtime_parameter_injection_for_variant(variant["id"], variant)
+        upload = harness.apply_runtime_parameter_injection_to_code(base_code, injection)
+        injection = harness.mark_runtime_parameter_injection_uploaded(injection, code_text=upload)
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+        evidence["parameters"] = {
+            "baseScoreWeight": 1,
+            "territorySignalWeight": 22,
+            "resourceSignalWeight": 3,
+            "killSignalWeight": 5,
+            "riskPenalty": 4,
+        }
+
+        consumption = harness.runtime_parameter_consumption_check(injection, evidence)
+
+        self.assertEqual(injection["parameters"], evidence["parameters"])
+        self.assertEqual(consumption["status"], "consumed")
+        self.assertTrue(consumption["runtimeParameterConsumption"])
+        self.assertEqual(consumption["evaluatedParametersSha256"], injection["parametersSha256"])
+        self.assertFalse(consumption["liveEffect"])
+        self.assertFalse(consumption["officialMmoWrites"])
+        self.assertFalse(consumption["officialMmoWritesAllowed"])
+
     def test_runtime_parameter_consumption_rejects_parameter_drift(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         evidence = self.runtime_parameter_consumption_evidence(injection)

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1743,6 +1743,29 @@ cli:
         self.assertFalse(consumption["officialMmoWrites"])
         self.assertFalse(consumption["officialMmoWritesAllowed"])
 
+    def test_runtime_parameter_canonicalization_preserves_tiny_floats_and_mixed_keys(self) -> None:
+        parameters = {
+            "tinyNonZeroWeight": 1e-10,
+            "integralWeight": 4.0,
+            "nested": [{"tinyNonZeroWeight": -1e-10, "integralWeight": 5.0, 7: "ignored"}],
+            3: "ignored",
+        }
+
+        canonical = harness.canonical_runtime_parameter_value(parameters)
+        parameters_hash = harness.runtime_parameter_parameters_hash(parameters)
+
+        self.assertEqual(canonical["tinyNonZeroWeight"], 1e-10)
+        self.assertNotEqual(canonical["tinyNonZeroWeight"], 0)
+        self.assertIs(type(canonical["integralWeight"]), int)
+        self.assertEqual(canonical["integralWeight"], 4)
+        self.assertEqual(canonical["nested"][0]["tinyNonZeroWeight"], -1e-10)
+        self.assertNotEqual(canonical["nested"][0]["tinyNonZeroWeight"], 0)
+        self.assertIs(type(canonical["nested"][0]["integralWeight"]), int)
+        self.assertEqual(canonical["nested"][0]["integralWeight"], 5)
+        self.assertNotIn(3, canonical)
+        self.assertNotIn(7, canonical["nested"][0])
+        self.assertIsInstance(parameters_hash, str)
+
     def test_runtime_parameter_consumption_rejects_parameter_drift(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         evidence = self.runtime_parameter_consumption_evidence(injection)

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -355,6 +355,29 @@ class RlTrainingRunnerTest(unittest.TestCase):
         simulator(run_id="second", variants=["control"], variant_configs=variant_configs)
         self.assertEqual(simulator.last_uploaded_code_by_variant, {})
 
+    def test_runtime_parameter_hash_preserves_tiny_floats_and_mixed_keys(self) -> None:
+        parameters = {
+            "tinyNonZeroWeight": 1e-10,
+            "integralWeight": 6.0,
+            "nested": [{"tinyNonZeroWeight": -1e-10, "integralWeight": 7.0, 8: "ignored"}],
+            9: "ignored",
+        }
+
+        canonical = runner.simulator_harness.canonical_runtime_parameter_value(parameters)
+        parameters_hash = runner.runtime_parameter_parameters_hash(parameters)
+
+        self.assertEqual(canonical["tinyNonZeroWeight"], 1e-10)
+        self.assertNotEqual(canonical["tinyNonZeroWeight"], 0)
+        self.assertIs(type(canonical["integralWeight"]), int)
+        self.assertEqual(canonical["integralWeight"], 6)
+        self.assertEqual(canonical["nested"][0]["tinyNonZeroWeight"], -1e-10)
+        self.assertNotEqual(canonical["nested"][0]["tinyNonZeroWeight"], 0)
+        self.assertIs(type(canonical["nested"][0]["integralWeight"]), int)
+        self.assertEqual(canonical["nested"][0]["integralWeight"], 7)
+        self.assertNotIn(9, canonical)
+        self.assertNotIn(8, canonical["nested"][0])
+        self.assertIsInstance(parameters_hash, str)
+
     def test_experiment_card_validation_requires_conservative_and_ood_safety_flags(self) -> None:
         for field in ("conservative_actions_only", "ood_rejection"):
             with self.subTest(field=field):

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -215,6 +215,7 @@ class MockSimulator:
         include_runtime_consumption_evidence: bool = True,
         include_runtime_consumption_parameters: bool = True,
         evaluated_parameters_by_variant: dict[str, JsonObject] | None = None,
+        js_runtime_numeric_canonicalization: bool = False,
     ) -> None:
         self.results_by_variant = results_by_variant
         self.inject_runtime_parameters = inject_runtime_parameters
@@ -222,6 +223,7 @@ class MockSimulator:
         self.include_runtime_consumption_evidence = include_runtime_consumption_evidence
         self.include_runtime_consumption_parameters = include_runtime_consumption_parameters
         self.evaluated_parameters_by_variant = evaluated_parameters_by_variant or {}
+        self.js_runtime_numeric_canonicalization = js_runtime_numeric_canonicalization
         self.calls: list[JsonObject] = []
         self.last_variants: list[JsonObject] = []
         self.last_uploaded_code_by_variant: dict[str, str] = {}
@@ -265,6 +267,10 @@ class MockSimulator:
                             f"runtime injection test expected parameters for {variant_id}, got {variant_config!r}"
                         )
                     evaluated_parameters = copy.deepcopy(parameters)
+                if self.js_runtime_numeric_canonicalization:
+                    evaluated_parameters = runner.simulator_harness.canonical_runtime_parameter_value(
+                        evaluated_parameters
+                    )
                 consumption_evidence = {
                     "type": runner.simulator_harness.RUNTIME_PARAMETER_CONSUMPTION_TYPE,
                     "consumerMarker": runner.simulator_harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER,
@@ -3709,6 +3715,80 @@ export const STRATEGY_REGISTRY = [
             "eligible_with_evaluated_runtime_parameters",
         )
 
+    def test_runtime_injected_reinforce_consumes_js_canonical_numeric_parameters(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-js-canonical-consumed",
+            code_commit="f" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-23T02:45:00Z",
+            simulation_ticks=100,
+            simulation_repetitions=1,
+        )
+        for candidate in card["policy_gradient"]["candidate_parameter_vectors"]:
+            candidate["parameters"] = {
+                key: float(value) if isinstance(value, int) and not isinstance(value, bool) else value
+                for key, value in candidate["parameters"].items()
+            }
+        variant_ids = [variant["id"] for variant in card["strategy_variants"]]
+        start = tick(1, [room("W1N1", energy=100)])
+        simulator_results: dict[str, JsonObject] = {}
+        for variant_id in variant_ids:
+            if variant_id.endswith("territory-seed.v1"):
+                simulator_results[variant_id] = variant_result(
+                    variant_id,
+                    [start, tick(2, [room("W1N1", energy=150), room("W1N2", energy=100)])],
+                )
+            elif variant_id.endswith("resource-seed.v1"):
+                simulator_results[variant_id] = variant_result(
+                    variant_id,
+                    [start, tick(2, [room("W1N1", energy=2400, harvested=1000)])],
+                )
+            else:
+                simulator_results[variant_id] = variant_result(
+                    variant_id,
+                    [start, tick(2, [room("W1N1", energy=200)])],
+                )
+        simulator = MockSimulator(
+            simulator_results,
+            inject_runtime_parameters=True,
+            js_runtime_numeric_canonicalization=True,
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="policy-gradient-js-canonical-consumed",
+                generated_at="2026-05-23T02:50:00Z",
+                simulator_runner=simulator,
+            )
+
+        self.assertTrue(report["runtimeParameterInjection"]["runtimeParameterInjection"])
+        self.assertTrue(report["runtimeParameterInjection"]["runtimeParameterConsumption"])
+        self.assertGreater(report["runtimeParameterInjection"]["consumedVariantCount"], 0)
+        self.assertEqual(report["runtimeParameterInjection"]["runtimeParameterConsumptionStatus"], "consumed")
+        self.assertTrue(report["policyGradient"]["runner_support"]["runtime_parameter_consumption"])
+        self.assertTrue(report["policyUpdate"]["runtimeParameterConsumption"])
+        self.assertFalse(report["liveEffect"])
+        self.assertFalse(report["officialMmoWrites"])
+        self.assertFalse(report["officialMmoWritesAllowed"])
+        self.assertTrue(
+            all(
+                result["runtimeParameterInjection"]["runtimeParameterConsumption"]
+                for result in report["variantResults"]
+            )
+        )
+        self.assertTrue(
+            all(
+                result["runtimeParameterInjection"]["evaluatedParameters"]
+                == runner.simulator_harness.canonical_runtime_parameter_value(result["parameters"])
+                for result in report["variantResults"]
+            )
+        )
+
     def test_scorecard_materialization_error_blocks_scorecard_without_crashing(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-policy-gradient-scorecard-error",
@@ -3923,6 +4003,14 @@ export const STRATEGY_REGISTRY = [
             report["runtimeParameterInjection"]["runtimeParameterConsumptionStatus"],
             "missing_runtime_parameter_consumption",
         )
+        self.assertIn("not every candidate reported consumption", report["runtimeParameterInjection"]["reason"])
+        self.assertTrue(
+            all(
+                "did not all report consumed runtime policy parameter evidence"
+                in result["runtimeParameterInjection"]["reason"]
+                for result in report["variantResults"]
+            )
+        )
         self.assertEqual(report["policyUpdateIterations"], 0)
         self.assertEqual(
             report["policyUpdate"]["skippedReason"],
@@ -3948,6 +4036,12 @@ export const STRATEGY_REGISTRY = [
         self.assertFalse(report["policyUpdate"]["promotionGate"]["loopAPromotionEligible"])
         self.assertFalse(report["policyUpdate"]["promotionGate"]["loopBPromotionEligible"])
         self.assertNotIn("policyUpdateArtifactPath", report)
+        self.assertFalse(report["liveEffect"])
+        self.assertFalse(report["officialMmoWrites"])
+        self.assertFalse(report["officialMmoWritesAllowed"])
+        self.assertFalse(report["policyUpdate"]["liveEffect"])
+        self.assertFalse(report["policyUpdate"]["officialMmoWrites"])
+        self.assertFalse(report["policyUpdate"]["officialMmoWritesAllowed"])
         self.assertTrue(all("evaluatedParameters" in result for result in simulator.last_variants))
         self.assertTrue(all("runtimeParameterConsumption" not in result for result in simulator.last_variants))
 


### PR DESCRIPTION
## Summary
- Canonicalizes runtime policy-gradient parameter payloads before hashing so Python-injected evidence can match JavaScript runtime consumption when integral floats serialize as JSON integers.
- Reuses the canonical hash for both injection and consumption proof paths.
- Adds targeted regression coverage for canonical hashing and runtime-consumption evidence.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py`
- `python3 -m pytest scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py -q` — 217 passed, 41 subtests passed

Refs #1299
