### PR TITLE
fix(rl): scan hash-backed runtime consumption evidence

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -1198,14 +1198,12 @@ local function pushRuntimePolicyParameterCandidate(source, value, depth, ownerMa
 end
 local function hashFieldMayContainRuntimePolicyParameters(fieldText)
   local fieldLower = string.lower(fieldText)
-  return string.find(fieldLower, "memory", 1, true) ~= nil
-    or string.find(fieldLower, "runtime", 1, true) ~= nil
+  return string.find(fieldLower, "runtime", 1, true) ~= nil
     or fieldText == "data"
     or fieldText == "value"
 end
 local function scanHashMemoryFields(keyText, key, ownerMatched)
   local hashCursor = "0"
-  local keyMayContainMemory = string.find(string.lower(keyText), "memory", 1, true) ~= nil
   repeat
     local result = redis.call("HSCAN", key, hashCursor, "COUNT", 100)
     hashCursor = result[1]
@@ -1213,8 +1211,9 @@ local function scanHashMemoryFields(keyText, key, ownerMatched)
     for index = 1, #fields, 2 do
       local fieldText = tostring(fields[index])
       local value = fields[index + 1]
-      local fieldOwnerMatched = ownerMatched or keyMatchesExpectedUsername(fieldText)
-      if keyMayContainMemory or hashFieldMayContainRuntimePolicyParameters(fieldText) or ownerMatched or fieldOwnerMatched then
+      local fieldMatchesExpectedUsername = keyMatchesExpectedUsername(fieldText)
+      local fieldOwnerMatched = ownerMatched or fieldMatchesExpectedUsername
+      if hashFieldMayContainRuntimePolicyParameters(fieldText) or fieldMatchesExpectedUsername then
         pushRuntimePolicyParameterCandidate(
           "redis." .. keyText .. "." .. fieldText,
           value,

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -1351,8 +1351,6 @@ return cjson.encode({
         and not _runtime_parameter_consumption_matches_injection(evidence, injection)
         and isinstance(payload, dict)
         and payload.get("genericScanRan") is False
-        and payload.get("candidateLimitReached") is not True
-        and payload.get("hashScanBudgetExhausted") is not True
     ):
         generic_payload = _collect_redis_runtime_parameter_payload(
             smoke,

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -1021,13 +1021,20 @@ def _collect_redis_runtime_parameter_consumption_evidence(
         return None
     eval_script = """
 local expectedUsername = tostring(ARGV[1] or "")
-local cursor = "0"
 local candidates = {}
 local seen = {}
 local candidateLimit = 32
 local candidateMaxDepth = 6
+local hscanCountLimit = 32
+local maxHashHscanCalls = 8
+local maxHashFields = 256
 local scanMode = tostring(ARGV[2] or "auto")
 local genericScanRan = false
+local hashScanBudgetExhausted = false
+local hashScanStats = {scannedFields = 0, skippedFields = 0}
+local function candidateLimitReached()
+  return #candidates >= candidateLimit
+end
 local nestedRuntimePolicyParameterKeys = {
   "__SCREEPS_RL_RUNTIME_POLICY_PARAMETER_CONSUMPTION__",
   "runtimeParameterConsumption",
@@ -1120,7 +1127,7 @@ local function candidateMatchesExpectedOwner(value, ownerMatched)
   return ownerMatched
 end
 local function appendRuntimePolicyParameterCandidate(source, value, ownerMatched)
-  if #candidates >= candidateLimit then
+  if candidateLimitReached() then
     return
   end
   if not candidateMatchesExpectedOwner(value, ownerMatched) then
@@ -1133,7 +1140,7 @@ local function appendRuntimePolicyParameterCandidate(source, value, ownerMatched
   table.insert(candidates, candidate)
 end
 local function pushRuntimePolicyParameterEvidence(source, value, depth, ownerMatched)
-  if depth > candidateMaxDepth or #candidates >= candidateLimit then
+  if depth > candidateMaxDepth or candidateLimitReached() then
     return
   end
   local decoded = decodedRuntimePolicyParameterValue(value)
@@ -1179,7 +1186,7 @@ local function pushRuntimePolicyParameterEvidence(source, value, depth, ownerMat
         depth + 1,
         nextOwnerMatched
       )
-      if #candidates >= candidateLimit then
+      if candidateLimitReached() then
         return
       end
     end
@@ -1187,7 +1194,7 @@ local function pushRuntimePolicyParameterEvidence(source, value, depth, ownerMat
   if decoded[1] ~= nil then
     for index, item in ipairs(decoded) do
       pushRuntimePolicyParameterEvidence(source .. "[" .. tostring(index) .. "]", item, depth + 1, nextOwnerMatched)
-      if #candidates >= candidateLimit then
+      if candidateLimitReached() then
         return
       end
     end
@@ -1204,11 +1211,31 @@ local function hashFieldMayContainRuntimePolicyParameters(fieldText)
 end
 local function scanHashMemoryFields(keyText, key, ownerMatched)
   local hashCursor = "0"
-  repeat
-    local result = redis.call("HSCAN", key, hashCursor, "COUNT", 100)
+  local hscanCallCount = 0
+  local scannedCount = 0
+  while hscanCallCount == 0 or hashCursor ~= "0" do
+    if candidateLimitReached() then
+      return
+    end
+    if hscanCallCount >= maxHashHscanCalls or scannedCount >= maxHashFields then
+      hashScanBudgetExhausted = true
+      return
+    end
+    hscanCallCount = hscanCallCount + 1
+    local result = redis.call("HSCAN", key, hashCursor, "COUNT", hscanCountLimit)
     hashCursor = result[1]
     local fields = result[2]
     for index = 1, #fields, 2 do
+      if candidateLimitReached() then
+        return
+      end
+      if scannedCount >= maxHashFields then
+        hashScanBudgetExhausted = true
+        hashScanStats.skippedFields = hashScanStats.skippedFields + math.floor((#fields - index + 1) / 2)
+        return
+      end
+      scannedCount = scannedCount + 1
+      hashScanStats.scannedFields = hashScanStats.scannedFields + 1
       local fieldText = tostring(fields[index])
       local value = fields[index + 1]
       local fieldMatchesExpectedUsername = keyMatchesExpectedUsername(fieldText)
@@ -1221,18 +1248,24 @@ local function scanHashMemoryFields(keyText, key, ownerMatched)
           fieldOwnerMatched
         )
       end
-      if #candidates >= candidateLimit then
+      if candidateLimitReached() then
         return
       end
     end
-  until hashCursor == "0"
+  end
 end
 local function scanMemoryPattern(pattern, skipExpectedUsernameKeys)
-  cursor = "0"
+  local cursor = "0"
   repeat
+    if candidateLimitReached() or hashScanBudgetExhausted then
+      return
+    end
     local result = redis.call("SCAN", cursor, "MATCH", pattern, "COUNT", 100)
     cursor = result[1]
     for _, key in ipairs(result[2]) do
+      if candidateLimitReached() or hashScanBudgetExhausted then
+        return
+      end
       local keyText = tostring(key)
       local keyLower = string.lower(keyText)
       local ownerMatched = keyMatchesExpectedUsername(keyText)
@@ -1251,11 +1284,14 @@ local function scanMemoryPattern(pattern, skipExpectedUsernameKeys)
         end
       end
     end
-  until cursor == "0"
+  until cursor == "0" or candidateLimitReached() or hashScanBudgetExhausted
 end
 local function scanGenericMemoryPatterns(skipExpectedUsernameKeys)
   genericScanRan = true
   for _, pattern in ipairs({"*memory*", "*Memory*"}) do
+    if candidateLimitReached() or hashScanBudgetExhausted then
+      return
+    end
     scanMemoryPattern(pattern, skipExpectedUsernameKeys or false)
   end
 end
@@ -1273,13 +1309,25 @@ if scanMode == "generic" then
   scanGenericMemoryPatterns(true)
 else
   for _, pattern in ipairs(scanPatterns) do
+    if candidateLimitReached() or hashScanBudgetExhausted then
+      break
+    end
     scanMemoryPattern(pattern, false)
   end
   if #candidates == 0 then
-    scanGenericMemoryPatterns(false)
+    if not candidateLimitReached() and not hashScanBudgetExhausted then
+      scanGenericMemoryPatterns(false)
+    end
   end
 end
-return cjson.encode({ok = true, candidates = candidates, genericScanRan = genericScanRan})
+return cjson.encode({
+  ok = true,
+  candidates = candidates,
+  genericScanRan = genericScanRan,
+  candidateLimitReached = candidateLimitReached(),
+  hashScanBudgetExhausted = hashScanBudgetExhausted,
+  hashScanStats = hashScanStats,
+})
 """.strip()
     username = text_or_none(getattr(cfg, "username", None))
     if username is None:
@@ -1303,6 +1351,8 @@ return cjson.encode({ok = true, candidates = candidates, genericScanRan = generi
         and not _runtime_parameter_consumption_matches_injection(evidence, injection)
         and isinstance(payload, dict)
         and payload.get("genericScanRan") is False
+        and payload.get("candidateLimitReached") is not True
+        and payload.get("hashScanBudgetExhausted") is not True
     ):
         generic_payload = _collect_redis_runtime_parameter_payload(
             smoke,

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -1196,6 +1196,38 @@ end
 local function pushRuntimePolicyParameterCandidate(source, value, depth, ownerMatched)
   pushRuntimePolicyParameterEvidence(source, value, depth or 0, ownerMatched or false)
 end
+local function hashFieldMayContainRuntimePolicyParameters(fieldText)
+  local fieldLower = string.lower(fieldText)
+  return string.find(fieldLower, "memory", 1, true) ~= nil
+    or string.find(fieldLower, "runtime", 1, true) ~= nil
+    or fieldText == "data"
+    or fieldText == "value"
+end
+local function scanHashMemoryFields(keyText, key, ownerMatched)
+  local hashCursor = "0"
+  local keyMayContainMemory = string.find(string.lower(keyText), "memory", 1, true) ~= nil
+  repeat
+    local result = redis.call("HSCAN", key, hashCursor, "COUNT", 100)
+    hashCursor = result[1]
+    local fields = result[2]
+    for index = 1, #fields, 2 do
+      local fieldText = tostring(fields[index])
+      local value = fields[index + 1]
+      local fieldOwnerMatched = ownerMatched or keyMatchesExpectedUsername(fieldText)
+      if keyMayContainMemory or hashFieldMayContainRuntimePolicyParameters(fieldText) or ownerMatched or fieldOwnerMatched then
+        pushRuntimePolicyParameterCandidate(
+          "redis." .. keyText .. "." .. fieldText,
+          value,
+          0,
+          fieldOwnerMatched
+        )
+      end
+      if #candidates >= candidateLimit then
+        return
+      end
+    end
+  until hashCursor == "0"
+end
 local function scanMemoryPattern(pattern, skipExpectedUsernameKeys)
   cursor = "0"
   repeat
@@ -1215,6 +1247,8 @@ local function scanMemoryPattern(pattern, skipExpectedUsernameKeys)
         if keyType == "string" then
           local value = redis.call("GET", key)
           pushRuntimePolicyParameterCandidate("redis." .. keyText, value, 0, ownerMatched)
+        elseif keyType == "hash" then
+          scanHashMemoryFields(keyText, key, ownerMatched)
         end
       end
     end

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -2975,7 +2975,7 @@ cli:
         self.assertIn("skipExpectedUsernameKeys", eval_script)
         self.assertIn("genericScanRan", eval_script)
 
-    def test_redis_runtime_parameter_consumption_collector_skips_generic_after_lua_scan_stop(self) -> None:
+    def test_redis_runtime_parameter_consumption_collector_scans_generic_after_lua_scan_stop(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         stale = self.runtime_parameter_consumption_evidence(injection)
         stale["owner"] = "bot"
@@ -3039,9 +3039,88 @@ cli:
                     injection,
                 )
 
-                self.assertEqual(extracted, stale)
-                self.assertEqual(len(smoke.commands), 1)
+                self.assertEqual(extracted, matching)
+                self.assertEqual(len(smoke.commands), 2)
                 self.assertEqual(smoke.commands[0][-2:], ["0", "bot"])
+                self.assertEqual(smoke.commands[1][-3:], ["0", "bot", "generic"])
+
+    def test_redis_runtime_parameter_consumption_collector_limits_generic_after_noisy_lua_scan_stop(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        stale_candidates = []
+        for index in range(32):
+            stale = self.runtime_parameter_consumption_evidence(injection)
+            stale["owner"] = "bot"
+            stale["strategyVariantId"] = f"stale-variant-{index}"
+            stale_candidates.append({
+                "source": f"redis.memory:bot.rlRuntimePolicyParameters.{index}",
+                "value": stale,
+            })
+
+        class FakeConfig:
+            shard = "shardX"
+            username = "bot"
+
+        class FakeSmoke:
+            commands: list[list[str]]
+
+            def __init__(self, stop_flag: str) -> None:
+                self.commands = []
+                self.stop_flag = stop_flag
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout, output_limit
+                self.commands.append(command)
+                if command[-1] == "generic":
+                    return {
+                        "returncode": 0,
+                        "output_excerpt": json.dumps({
+                            "ok": True,
+                            "genericScanRan": True,
+                            "candidateLimitReached": True,
+                            "hashScanBudgetExhausted": False,
+                            "candidates": [],
+                        }),
+                    }
+                return {
+                    "returncode": 0,
+                    "output_excerpt": json.dumps({
+                        "ok": True,
+                        "genericScanRan": False,
+                        "candidateLimitReached": self.stop_flag == "candidateLimitReached",
+                        "hashScanBudgetExhausted": self.stop_flag == "hashScanBudgetExhausted",
+                        "hashScanStats": {"scannedFields": 256, "skippedFields": 1024},
+                        "candidates": stale_candidates,
+                    }),
+                }
+
+        for stop_flag in ("candidateLimitReached", "hashScanBudgetExhausted"):
+            with self.subTest(stop_flag=stop_flag):
+                smoke = FakeSmoke(stop_flag)
+
+                extracted = harness._collect_redis_runtime_parameter_consumption_evidence(
+                    smoke,
+                    ["docker", "compose"],
+                    FakeConfig(),
+                    None,
+                    injection,
+                )
+
+                self.assertEqual(extracted, stale_candidates[0]["value"])
+                self.assertEqual(len(smoke.commands), 2)
+                self.assertEqual(smoke.commands[0][-2:], ["0", "bot"])
+                self.assertEqual(smoke.commands[1][-3:], ["0", "bot", "generic"])
+                eval_script = smoke.commands[1][smoke.commands[1].index("EVAL") + 1]
+                self.assertIn("local candidateLimit = 32", eval_script)
+                self.assertIn("local maxHashHscanCalls = 8", eval_script)
+                self.assertIn("local maxHashFields = 256", eval_script)
+                self.assertIn('scanMode == "generic"', eval_script)
 
     def test_redis_runtime_parameter_consumption_collector_fails_closed_without_proof(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -2456,6 +2456,61 @@ cli:
         self.assertNotIn("KEYS", eval_script)
         self.assertNotIn('table.insert(candidates, {source = "redis." .. keyText, value = value})', eval_script)
 
+    def test_redis_runtime_parameter_consumption_collector_reads_hash_backed_memory(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+        evidence["user"] = "bot"
+
+        class FakeConfig:
+            shard = "shardX"
+            username = "bot"
+
+        class FakeSmoke:
+            command: list[str] | None = None
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout, output_limit
+                self.command = command
+                eval_script = command[-3]
+                candidates: list[dict[str, object]] = []
+                if (
+                    'keyType == "hash"' in eval_script
+                    and "scanHashMemoryFields" in eval_script
+                    and "HSCAN" in eval_script
+                ):
+                    candidates.append({
+                        "source": "redis.memory:bot.rlRuntimePolicyParameters",
+                        "value": evidence,
+                    })
+                return {
+                    "returncode": 0,
+                    "output_excerpt": json.dumps({"ok": True, "candidates": candidates}),
+                }
+
+        smoke = FakeSmoke()
+
+        extracted = harness._collect_redis_runtime_parameter_consumption_evidence(
+            smoke,
+            ["docker", "compose"],
+            FakeConfig(),
+            None,
+            injection,
+        )
+
+        self.assertEqual(extracted, evidence)
+        self.assertIsNotNone(smoke.command)
+        eval_script = smoke.command[-3] if smoke.command is not None else ""
+        self.assertIn("scanHashMemoryFields", eval_script)
+        self.assertIn("hashFieldMayContainRuntimePolicyParameters", eval_script)
+        self.assertIn("HSCAN", eval_script)
+
     def test_redis_runtime_parameter_consumption_collector_requires_configured_username(self) -> None:
         class FakeConfig:
             shard = "shardX"

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -2511,6 +2511,50 @@ cli:
         self.assertIn("hashFieldMayContainRuntimePolicyParameters", eval_script)
         self.assertIn("HSCAN", eval_script)
 
+    def test_redis_runtime_parameter_consumption_collector_filters_hash_fields_before_decode(self) -> None:
+        class FakeConfig:
+            shard = "shardX"
+            username = "bot"
+
+        class FakeSmoke:
+            command: list[str] | None = None
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout, output_limit
+                self.command = command
+                return {"returncode": 0, "output_excerpt": json.dumps({"ok": True, "candidates": []})}
+
+        smoke = FakeSmoke()
+
+        extracted = harness._collect_redis_runtime_parameter_consumption_evidence(
+            smoke,
+            ["docker", "compose"],
+            FakeConfig(),
+            None,
+        )
+
+        self.assertIsNone(extracted)
+        self.assertIsNotNone(smoke.command)
+        eval_script = smoke.command[-3] if smoke.command is not None else ""
+        self.assertIn('string.find(fieldLower, "runtime", 1, true) ~= nil', eval_script)
+        self.assertIn('or fieldText == "data"', eval_script)
+        self.assertIn('or fieldText == "value"', eval_script)
+        self.assertIn("fieldMatchesExpectedUsername = keyMatchesExpectedUsername(fieldText)", eval_script)
+        self.assertIn(
+            "if hashFieldMayContainRuntimePolicyParameters(fieldText) or fieldMatchesExpectedUsername then",
+            eval_script,
+        )
+        self.assertNotIn('string.find(fieldLower, "memory"', eval_script)
+        self.assertNotIn("keyMayContainMemory", eval_script)
+        self.assertNotIn("or ownerMatched or fieldOwnerMatched", eval_script)
+
     def test_redis_runtime_parameter_consumption_collector_requires_configured_username(self) -> None:
         class FakeConfig:
             shard = "shardX"

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -2467,6 +2467,7 @@ cli:
 
         class FakeSmoke:
             command: list[str] | None = None
+            output_excerpt: str | None = None
 
             def run_command(
                 self,
@@ -2480,18 +2481,42 @@ cli:
                 self.command = command
                 eval_script = command[-3]
                 candidates: list[dict[str, object]] = []
-                if (
-                    'keyType == "hash"' in eval_script
-                    and "scanHashMemoryFields" in eval_script
-                    and "HSCAN" in eval_script
-                ):
-                    candidates.append({
-                        "source": "redis.memory:bot.rlRuntimePolicyParameters",
-                        "value": evidence,
-                    })
+                bounded_hash_scan_supported = all(
+                    token in eval_script
+                    for token in (
+                        'keyType == "hash"',
+                        "scanHashMemoryFields",
+                        "hscanCountLimit = 32",
+                        "maxHashHscanCalls = 8",
+                        "maxHashFields = 256",
+                        "scannedCount",
+                        "hashScanStats.scannedFields",
+                        "hashScanStats.skippedFields",
+                        'redis.call("HSCAN", key, hashCursor, "COUNT", hscanCountLimit)',
+                        "candidateLimitReached()",
+                    )
+                )
+                if bounded_hash_scan_supported:
+                    simulated_more_than_limit_fields = [
+                        {
+                            "source": f"redis.memory:bot.rlRuntimePolicyParameters.{index}",
+                            "value": evidence,
+                        }
+                        for index in range(40)
+                    ]
+                    candidates.extend(simulated_more_than_limit_fields[:32])
+                self.output_excerpt = json.dumps({
+                    "ok": True,
+                    "candidates": candidates,
+                    "candidateLimitReached": len(candidates) >= 32,
+                    "hashScanStats": {
+                        "scannedFields": len(candidates),
+                        "skippedFields": 40 - len(candidates),
+                    },
+                })
                 return {
                     "returncode": 0,
-                    "output_excerpt": json.dumps({"ok": True, "candidates": candidates}),
+                    "output_excerpt": self.output_excerpt,
                 }
 
         smoke = FakeSmoke()
@@ -2510,6 +2535,23 @@ cli:
         self.assertIn("scanHashMemoryFields", eval_script)
         self.assertIn("hashFieldMayContainRuntimePolicyParameters", eval_script)
         self.assertIn("HSCAN", eval_script)
+        self.assertIn("local hscanCountLimit = 32", eval_script)
+        self.assertIn("local maxHashHscanCalls = 8", eval_script)
+        self.assertIn("local maxHashFields = 256", eval_script)
+        self.assertIn('redis.call("HSCAN", key, hashCursor, "COUNT", hscanCountLimit)', eval_script)
+        self.assertIn('while hscanCallCount == 0 or hashCursor ~= "0" do', eval_script)
+        self.assertIn("if scannedCount >= maxHashFields then", eval_script)
+        self.assertIn("if candidateLimitReached() then", eval_script)
+        self.assertIn("hashScanBudgetExhausted = true", eval_script)
+        self.assertIn("hashScanStats.scannedFields", eval_script)
+        self.assertIn("hashScanStats.skippedFields", eval_script)
+        self.assertIn("candidateLimitReached = candidateLimitReached()", eval_script)
+        self.assertIn("hashScanStats = hashScanStats", eval_script)
+        self.assertIsNotNone(smoke.output_excerpt)
+        output = json.loads(smoke.output_excerpt or "{}")
+        self.assertLessEqual(len(output["candidates"]), 32)
+        self.assertEqual(output["hashScanStats"]["scannedFields"], 32)
+        self.assertEqual(output["hashScanStats"]["skippedFields"], 8)
 
     def test_redis_runtime_parameter_consumption_collector_filters_hash_fields_before_decode(self) -> None:
         class FakeConfig:
@@ -2932,6 +2974,74 @@ cli:
         self.assertIn('scanMode == "generic"', eval_script)
         self.assertIn("skipExpectedUsernameKeys", eval_script)
         self.assertIn("genericScanRan", eval_script)
+
+    def test_redis_runtime_parameter_consumption_collector_skips_generic_after_lua_scan_stop(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        stale = self.runtime_parameter_consumption_evidence(injection)
+        stale["owner"] = "bot"
+        stale["strategyVariantId"] = "stale-variant"
+        matching = self.runtime_parameter_consumption_evidence(injection)
+        matching["owner"] = "bot"
+
+        class FakeConfig:
+            shard = "shardX"
+            username = "bot"
+
+        class FakeSmoke:
+            commands: list[list[str]]
+
+            def __init__(self, stop_flag: str) -> None:
+                self.commands = []
+                self.stop_flag = stop_flag
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout, output_limit
+                self.commands.append(command)
+                if command[-1] == "generic":
+                    return {
+                        "returncode": 0,
+                        "output_excerpt": json.dumps({
+                            "ok": True,
+                            "genericScanRan": True,
+                            "candidates": [{"source": "redis.Memory", "value": matching}],
+                        }),
+                    }
+                return {
+                    "returncode": 0,
+                    "output_excerpt": json.dumps({
+                        "ok": True,
+                        "genericScanRan": False,
+                        "candidateLimitReached": self.stop_flag == "candidateLimitReached",
+                        "hashScanBudgetExhausted": self.stop_flag == "hashScanBudgetExhausted",
+                        "hashScanStats": {"scannedFields": 256, "skippedFields": 1},
+                        "candidates": [
+                            {"source": "redis.memory:bot.rlRuntimePolicyParameters", "value": stale}
+                        ],
+                    }),
+                }
+
+        for stop_flag in ("candidateLimitReached", "hashScanBudgetExhausted"):
+            with self.subTest(stop_flag=stop_flag):
+                smoke = FakeSmoke(stop_flag)
+
+                extracted = harness._collect_redis_runtime_parameter_consumption_evidence(
+                    smoke,
+                    ["docker", "compose"],
+                    FakeConfig(),
+                    None,
+                    injection,
+                )
+
+                self.assertEqual(extracted, stale)
+                self.assertEqual(len(smoke.commands), 1)
+                self.assertEqual(smoke.commands[0][-2:], ["0", "bot"])
 
     def test_redis_runtime_parameter_consumption_collector_fails_closed_without_proof(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()


### PR DESCRIPTION
## Summary
- Fixes a post-merge #1299 validation miss where runtime-injected candidate parameters were uploaded, but private-server runtime consumption evidence stayed at `runtimeParameterConsumption=false` / `consumedVariantCount=0`.
- Extends the simulator harness Redis evidence probe to scan hash-backed memory keys with `HSCAN`, while still routing candidates through the existing strict owner/type/hash validation.
- Adds regression coverage for hash-backed runtime consumption evidence.

## Evidence
- Failed validation run: `runtime-artifacts/tencent-cloud/batch-runs/tencent-pg-20260523t041004z/controller-summary.json`
- Training report: `runtime-artifacts/tencent-cloud/batch-runs/tencent-pg-20260523t041004z/remote/runtime-artifacts/rl-training/tencent-pg-20260523t041004z.json`
- Result: `finalStatus=completed`, `environmentsRun=25`, `artifactCount=24`, `policyUpdateIterations=1`, injection present, but consumption false.

## Verification
- `python3 -m py_compile scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_training_runner.py scripts/screeps_rl_simulator_harness.py scripts/test_screeps_rl_simulator_harness.py`
- `python3 -m pytest scripts/test_screeps_rl_training_runner.py scripts/test_screeps_rl_simulator_harness.py -q` (`220 passed, 41 subtests`)
- `git diff --check`

Refs #1299
Refs #879
Refs #1032
Refs #1233
