### PR TITLE
fix(rl): emit runtime parameter consumption evidence

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -46685,6 +46685,7 @@ function getGameTime45() {
 var RUNTIME_POLICY_PARAMETERS_GLOBAL = "__SCREEPS_RL_RUNTIME_POLICY_PARAMETERS__";
 var RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL = "__SCREEPS_RL_RUNTIME_POLICY_PARAMETER_CONSUMPTION__";
 var RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER = "screeps-rl-runtime-policy-parameters-consumer-v1";
+var RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION = "v1";
 var RUNTIME_POLICY_PARAMETER_CONSUMPTION_LOG_PREFIX = "#runtime-parameter-consumption ";
 function applyRuntimePolicyParametersToRegistry(registry) {
   var _a;
@@ -46746,8 +46747,7 @@ function applyRuntimePolicyParametersToRegistry(registry) {
 function createRuntimePolicyParameterConsumptionRecorder() {
   const payload = readRuntimePolicyParameterPayload();
   const parameters = payload ? normalizeRuntimePolicyParameters(payload.parameters) : null;
-  const materializedStrategyIds = runtimeMaterializedStrategyIds(payload, parameters);
-  const appliedStrategyIds = new Set(materializedStrategyIds);
+  const appliedStrategyIds = /* @__PURE__ */ new Set();
   return {
     recordStrategyRuntimeUse(entry) {
       if (!payload || !parameters) {
@@ -46780,7 +46780,7 @@ function createRuntimePolicyParameterConsumptionRecorder() {
         consumed,
         parameters,
         appliedStrategyIds: observedStrategyIds,
-        reason: consumed ? materializedStrategyIds.length > 0 ? "runtime policy parameter payload was materialized into the tick runtime strategy registry" : void 0 : "runtime policy parameter payload was not used by tick runtime strategy evaluation"
+        reason: consumed ? "runtime policy parameter payload was used by tick runtime strategy evaluation" : "runtime policy parameter payload was not used by tick runtime strategy evaluation"
       });
     }
   };
@@ -46799,15 +46799,13 @@ function persistRuntimePolicyParameterConsumptionEvidence(evidence) {
   emitRuntimePolicyParameterConsumptionEvidence(persistedEvidence);
 }
 function readRuntimePolicyParameterPayload() {
-  const root = globalThis;
-  const raw = root[RUNTIME_POLICY_PARAMETERS_GLOBAL];
-  if (!isRecord41(raw)) {
-    return null;
+  for (const root of runtimeGlobalRoots()) {
+    const raw = root[RUNTIME_POLICY_PARAMETERS_GLOBAL];
+    if (isRecord41(raw) && raw.runtimeParameterInjection === true && raw.candidateParameterScope === "runtime_injected") {
+      return raw;
+    }
   }
-  if (raw.runtimeParameterInjection !== true || raw.candidateParameterScope !== "runtime_injected") {
-    return null;
-  }
-  return raw;
+  return null;
 }
 function normalizeRuntimePolicyParameters(raw) {
   if (!isRecord41(raw)) {
@@ -46849,11 +46847,12 @@ function strategyEntryUsesRuntimeParameters(entry, parameters) {
   return true;
 }
 function buildConsumptionEvidence(options) {
-  var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j;
+  var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n;
   const runtimeParameterInjection = ((_a = options.payload) == null ? void 0 : _a.runtimeParameterInjection) === true && ((_b = options.payload) == null ? void 0 : _b.candidateParameterScope) === "runtime_injected";
   return {
     type: "screeps-rl-runtime-policy-parameter-consumption",
     consumerMarker: RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER,
+    consumerVersion: RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION,
     runtimeParameterInjection,
     consumed: options.consumed,
     ...textOrUndefined((_c = options.payload) == null ? void 0 : _c.strategyVariantId) ? { strategyVariantId: textOrUndefined((_d = options.payload) == null ? void 0 : _d.strategyVariantId) } : {},
@@ -46861,6 +46860,8 @@ function buildConsumptionEvidence(options) {
     ...textOrUndefined((_g = options.payload) == null ? void 0 : _g.family) ? { family: textOrUndefined((_h = options.payload) == null ? void 0 : _h.family) } : {},
     ...options.parameters ? { parameters: options.parameters } : {},
     ...textOrUndefined((_i = options.payload) == null ? void 0 : _i.parametersSha256) ? { parametersSha256: textOrUndefined((_j = options.payload) == null ? void 0 : _j.parametersSha256) } : {},
+    ...options.consumed && textOrUndefined((_k = options.payload) == null ? void 0 : _k.strategyVariantId) ? { consumedStrategyVariantId: textOrUndefined((_l = options.payload) == null ? void 0 : _l.strategyVariantId) } : {},
+    ...options.consumed && textOrUndefined((_m = options.payload) == null ? void 0 : _m.parametersSha256) ? { consumedParametersSha256: textOrUndefined((_n = options.payload) == null ? void 0 : _n.parametersSha256) } : {},
     appliedStrategyIds: [...options.appliedStrategyIds].sort(),
     ...options.reason ? { reason: options.reason } : {},
     liveEffect: false,
@@ -46869,55 +46870,9 @@ function buildConsumptionEvidence(options) {
   };
 }
 function publishRuntimePolicyParameterConsumptionEvidence(evidence) {
-  const root = globalThis;
-  root[RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL] = evidence;
-}
-function readPublishedRuntimePolicyParameterConsumptionEvidence() {
-  const root = globalThis;
-  const evidence = root[RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL];
-  return isRuntimePolicyParameterConsumptionEvidence(evidence) ? evidence : null;
-}
-function runtimeMaterializedStrategyIds(payload, parameters) {
-  if (!payload || !parameters) {
-    return [];
+  for (const root of runtimeGlobalRoots()) {
+    root[RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL] = evidence;
   }
-  const evidence = readPublishedRuntimePolicyParameterConsumptionEvidence();
-  if (!evidence || evidence.runtimeParameterInjection !== true || evidence.consumed === true || evidence.appliedStrategyIds.length === 0 || !runtimePolicyParameterEvidenceMatchesPayload(evidence, payload, parameters)) {
-    return [];
-  }
-  return [...evidence.appliedStrategyIds].sort();
-}
-function runtimePolicyParameterEvidenceMatchesPayload(evidence, payload, parameters) {
-  if (!sameOptionalText(evidence.strategyVariantId, payload.strategyVariantId)) {
-    return false;
-  }
-  if (!sameOptionalText(evidence.candidatePolicyId, payload.candidatePolicyId)) {
-    return false;
-  }
-  if (!sameOptionalText(evidence.family, payload.family)) {
-    return false;
-  }
-  if (!sameOptionalText(evidence.parametersSha256, payload.parametersSha256)) {
-    return false;
-  }
-  if (!evidence.parameters) {
-    return false;
-  }
-  return sameStrategyKnobValues(evidence.parameters, parameters);
-}
-function sameStrategyKnobValues(left, right) {
-  const leftKeys = Object.keys(left).sort();
-  const rightKeys = Object.keys(right).sort();
-  if (leftKeys.length !== rightKeys.length) {
-    return false;
-  }
-  return leftKeys.every((key, index) => key === rightKeys[index] && left[key] === right[key]);
-}
-function isRuntimePolicyParameterConsumptionEvidence(value) {
-  if (!isRecord41(value)) {
-    return false;
-  }
-  return value.type === "screeps-rl-runtime-policy-parameter-consumption" && value.consumerMarker === RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER && typeof value.runtimeParameterInjection === "boolean" && typeof value.consumed === "boolean" && Array.isArray(value.appliedStrategyIds);
 }
 function emitRuntimePolicyParameterConsumptionEvidence(evidence) {
   if (evidence.runtimeParameterInjection !== true) {
@@ -46944,7 +46899,7 @@ function shouldCarryRuntimePolicyParameterConsumptionEvidence(evidence, previous
   if (!evidence.parameters || !previous.parameters) {
     return false;
   }
-  if (evidence.consumerMarker !== RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER || previous.consumerMarker !== RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER) {
+  if (evidence.consumerMarker !== RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER || previous.consumerMarker !== RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER || evidence.consumerVersion !== RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION || previous.consumerVersion !== RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION) {
     return false;
   }
   const currentHash = textOrUndefined(evidence.parametersSha256);
@@ -46996,6 +46951,20 @@ function runtimeMemoryRoot() {
     root.Memory = {};
   }
   return root.Memory;
+}
+function runtimeGlobalRoots() {
+  const roots = [];
+  const root = globalThis;
+  addRuntimeGlobalRoot(roots, globalThis);
+  addRuntimeGlobalRoot(roots, root.global);
+  addRuntimeGlobalRoot(roots, root.self);
+  return roots;
+}
+function addRuntimeGlobalRoot(roots, value) {
+  if (!isRecord41(value) || roots.includes(value)) {
+    return;
+  }
+  roots.push(value);
 }
 function runtimeTick() {
   var _a, _b;
@@ -47633,14 +47602,18 @@ var recentKpiWindows = {};
 var baselineKpiWindows = {};
 function loop() {
   const runtimePolicyParameterConsumption = createRuntimePolicyParameterConsumptionRecorder();
-  const summary = kernel.run({
-    strategyRegistry: strategyRegistryState.entries,
-    ...runtimePolicyParameterPlanningEnabled ? {
-      runtimeStrategyConstructionEnabled: true,
-      onStrategyRegistryRuntimeUse: runtimePolicyParameterConsumption.recordStrategyRuntimeUse
-    } : {}
-  });
-  persistRuntimePolicyParameterConsumptionEvidence(runtimePolicyParameterConsumption.buildEvidence());
+  let summary;
+  try {
+    summary = kernel.run({
+      strategyRegistry: strategyRegistryState.entries,
+      ...runtimePolicyParameterPlanningEnabled ? {
+        runtimeStrategyConstructionEnabled: true,
+        onStrategyRegistryRuntimeUse: runtimePolicyParameterConsumption.recordStrategyRuntimeUse
+      } : {}
+    });
+  } finally {
+    persistRuntimePolicyParameterConsumptionEvidence(runtimePolicyParameterConsumption.buildEvidence());
+  }
   strategyRegistryState.entries = runStrategyRolloutMonitoring(summary, strategyRegistryState.entries);
 }
 function runStrategyRolloutMonitoring(summary, registry) {

--- a/prod/src/main.ts
+++ b/prod/src/main.ts
@@ -49,16 +49,20 @@ const baselineKpiWindows: KpiWindowHistory = {};
 
 export function loop(): void {
   const runtimePolicyParameterConsumption = createRuntimePolicyParameterConsumptionRecorder();
-  const summary = kernel.run({
-    strategyRegistry: strategyRegistryState.entries,
-    ...(runtimePolicyParameterPlanningEnabled
-      ? {
-          runtimeStrategyConstructionEnabled: true,
-          onStrategyRegistryRuntimeUse: runtimePolicyParameterConsumption.recordStrategyRuntimeUse
-        }
-      : {})
-  });
-  persistRuntimePolicyParameterConsumptionEvidence(runtimePolicyParameterConsumption.buildEvidence());
+  let summary: RuntimeSummary | undefined;
+  try {
+    summary = kernel.run({
+      strategyRegistry: strategyRegistryState.entries,
+      ...(runtimePolicyParameterPlanningEnabled
+        ? {
+            runtimeStrategyConstructionEnabled: true,
+            onStrategyRegistryRuntimeUse: runtimePolicyParameterConsumption.recordStrategyRuntimeUse
+          }
+        : {})
+    });
+  } finally {
+    persistRuntimePolicyParameterConsumptionEvidence(runtimePolicyParameterConsumption.buildEvidence());
+  }
   strategyRegistryState.entries = runStrategyRolloutMonitoring(summary, strategyRegistryState.entries);
 }
 

--- a/prod/src/strategy/runtimePolicyParameters.ts
+++ b/prod/src/strategy/runtimePolicyParameters.ts
@@ -3,11 +3,13 @@ import type { StrategyKnobValue, StrategyRegistryEntry } from './strategyRegistr
 export const RUNTIME_POLICY_PARAMETERS_GLOBAL = '__SCREEPS_RL_RUNTIME_POLICY_PARAMETERS__';
 export const RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL = '__SCREEPS_RL_RUNTIME_POLICY_PARAMETER_CONSUMPTION__';
 export const RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER = 'screeps-rl-runtime-policy-parameters-consumer-v1';
+export const RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION = 'v1';
 export const RUNTIME_POLICY_PARAMETER_CONSUMPTION_LOG_PREFIX = '#runtime-parameter-consumption ';
 
 export interface RuntimePolicyParameterConsumptionEvidence {
   type: 'screeps-rl-runtime-policy-parameter-consumption';
   consumerMarker: typeof RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER;
+  consumerVersion: typeof RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION;
   runtimeParameterInjection: boolean;
   consumed: boolean;
   strategyVariantId?: string;
@@ -15,6 +17,8 @@ export interface RuntimePolicyParameterConsumptionEvidence {
   family?: string;
   parameters?: Record<string, StrategyKnobValue>;
   parametersSha256?: string;
+  consumedStrategyVariantId?: string;
+  consumedParametersSha256?: string;
   appliedStrategyIds: string[];
   reason?: string;
   liveEffect: false;
@@ -118,8 +122,7 @@ export function applyRuntimePolicyParametersToRegistry(
 export function createRuntimePolicyParameterConsumptionRecorder(): RuntimePolicyParameterConsumptionRecorder {
   const payload = readRuntimePolicyParameterPayload();
   const parameters = payload ? normalizeRuntimePolicyParameters(payload.parameters) : null;
-  const materializedStrategyIds = runtimeMaterializedStrategyIds(payload, parameters);
-  const appliedStrategyIds = new Set<string>(materializedStrategyIds);
+  const appliedStrategyIds = new Set<string>();
 
   return {
     recordStrategyRuntimeUse(entry: StrategyRegistryEntry): void {
@@ -157,9 +160,7 @@ export function createRuntimePolicyParameterConsumptionRecorder(): RuntimePolicy
         parameters,
         appliedStrategyIds: observedStrategyIds,
         reason: consumed
-          ? materializedStrategyIds.length > 0
-            ? 'runtime policy parameter payload was materialized into the tick runtime strategy registry'
-            : undefined
+          ? 'runtime policy parameter payload was used by tick runtime strategy evaluation'
           : 'runtime policy parameter payload was not used by tick runtime strategy evaluation'
       });
     }
@@ -184,15 +185,18 @@ export function persistRuntimePolicyParameterConsumptionEvidence(
 }
 
 function readRuntimePolicyParameterPayload(): RuntimePolicyParameterPayload | null {
-  const root = globalThis as typeof globalThis & Record<string, unknown>;
-  const raw = root[RUNTIME_POLICY_PARAMETERS_GLOBAL];
-  if (!isRecord(raw)) {
-    return null;
+  for (const root of runtimeGlobalRoots()) {
+    const raw = root[RUNTIME_POLICY_PARAMETERS_GLOBAL];
+    if (
+      isRecord(raw) &&
+      raw.runtimeParameterInjection === true &&
+      raw.candidateParameterScope === 'runtime_injected'
+    ) {
+      return raw;
+    }
   }
-  if (raw.runtimeParameterInjection !== true || raw.candidateParameterScope !== 'runtime_injected') {
-    return null;
-  }
-  return raw;
+
+  return null;
 }
 
 function normalizeRuntimePolicyParameters(raw: unknown): Record<string, StrategyKnobValue> | null {
@@ -262,6 +266,7 @@ function buildConsumptionEvidence(options: {
   return {
     type: 'screeps-rl-runtime-policy-parameter-consumption',
     consumerMarker: RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER,
+    consumerVersion: RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION,
     runtimeParameterInjection,
     consumed: options.consumed,
     ...(textOrUndefined(options.payload?.strategyVariantId)
@@ -275,6 +280,12 @@ function buildConsumptionEvidence(options: {
     ...(textOrUndefined(options.payload?.parametersSha256)
       ? { parametersSha256: textOrUndefined(options.payload?.parametersSha256) }
       : {}),
+    ...(options.consumed && textOrUndefined(options.payload?.strategyVariantId)
+      ? { consumedStrategyVariantId: textOrUndefined(options.payload?.strategyVariantId) }
+      : {}),
+    ...(options.consumed && textOrUndefined(options.payload?.parametersSha256)
+      ? { consumedParametersSha256: textOrUndefined(options.payload?.parametersSha256) }
+      : {}),
     appliedStrategyIds: [...options.appliedStrategyIds].sort(),
     ...(options.reason ? { reason: options.reason } : {}),
     liveEffect: false,
@@ -286,73 +297,9 @@ function buildConsumptionEvidence(options: {
 function publishRuntimePolicyParameterConsumptionEvidence(
   evidence: RuntimePolicyParameterConsumptionEvidence
 ): void {
-  const root = globalThis as typeof globalThis & Record<string, unknown>;
-  root[RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL] = evidence;
-}
-
-function readPublishedRuntimePolicyParameterConsumptionEvidence(): RuntimePolicyParameterConsumptionEvidence | null {
-  const root = globalThis as typeof globalThis & Record<string, unknown>;
-  const evidence = root[RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL];
-  return isRuntimePolicyParameterConsumptionEvidence(evidence) ? evidence : null;
-}
-
-function runtimeMaterializedStrategyIds(
-  payload: RuntimePolicyParameterPayload | null,
-  parameters: Record<string, StrategyKnobValue> | null
-): string[] {
-  if (!payload || !parameters) {
-    return [];
+  for (const root of runtimeGlobalRoots()) {
+    root[RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL] = evidence;
   }
-
-  const evidence = readPublishedRuntimePolicyParameterConsumptionEvidence();
-  if (
-    !evidence ||
-    evidence.runtimeParameterInjection !== true ||
-    evidence.consumed === true ||
-    evidence.appliedStrategyIds.length === 0 ||
-    !runtimePolicyParameterEvidenceMatchesPayload(evidence, payload, parameters)
-  ) {
-    return [];
-  }
-
-  return [...evidence.appliedStrategyIds].sort();
-}
-
-function runtimePolicyParameterEvidenceMatchesPayload(
-  evidence: RuntimePolicyParameterConsumptionEvidence,
-  payload: RuntimePolicyParameterPayload,
-  parameters: Record<string, StrategyKnobValue>
-): boolean {
-  if (!sameOptionalText(evidence.strategyVariantId, payload.strategyVariantId)) {
-    return false;
-  }
-  if (!sameOptionalText(evidence.candidatePolicyId, payload.candidatePolicyId)) {
-    return false;
-  }
-  if (!sameOptionalText(evidence.family, payload.family)) {
-    return false;
-  }
-  if (!sameOptionalText(evidence.parametersSha256, payload.parametersSha256)) {
-    return false;
-  }
-  if (!evidence.parameters) {
-    return false;
-  }
-
-  return sameStrategyKnobValues(evidence.parameters, parameters);
-}
-
-function sameStrategyKnobValues(
-  left: Record<string, StrategyKnobValue>,
-  right: Record<string, StrategyKnobValue>
-): boolean {
-  const leftKeys = Object.keys(left).sort();
-  const rightKeys = Object.keys(right).sort();
-  if (leftKeys.length !== rightKeys.length) {
-    return false;
-  }
-
-  return leftKeys.every((key, index) => key === rightKeys[index] && left[key] === right[key]);
 }
 
 function isRuntimePolicyParameterConsumptionEvidence(
@@ -365,6 +312,7 @@ function isRuntimePolicyParameterConsumptionEvidence(
   return (
     value.type === 'screeps-rl-runtime-policy-parameter-consumption' &&
     value.consumerMarker === RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER &&
+    value.consumerVersion === RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION &&
     typeof value.runtimeParameterInjection === 'boolean' &&
     typeof value.consumed === 'boolean' &&
     Array.isArray(value.appliedStrategyIds)
@@ -409,7 +357,9 @@ function shouldCarryRuntimePolicyParameterConsumptionEvidence(
   }
   if (
     evidence.consumerMarker !== RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER ||
-    previous.consumerMarker !== RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER
+    previous.consumerMarker !== RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER ||
+    evidence.consumerVersion !== RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION ||
+    previous.consumerVersion !== RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION
   ) {
     return false;
   }
@@ -476,6 +426,24 @@ function runtimeMemoryRoot(): RuntimeMemory {
     root.Memory = {};
   }
   return root.Memory;
+}
+
+function runtimeGlobalRoots(): Array<Record<string, unknown>> {
+  const roots: Array<Record<string, unknown>> = [];
+  const root = globalThis as typeof globalThis & { global?: unknown; self?: unknown };
+  addRuntimeGlobalRoot(roots, globalThis);
+  addRuntimeGlobalRoot(roots, root.global);
+  addRuntimeGlobalRoot(roots, root.self);
+
+  return roots;
+}
+
+function addRuntimeGlobalRoot(roots: Array<Record<string, unknown>>, value: unknown): void {
+  if (!isRecord(value) || roots.includes(value)) {
+    return;
+  }
+
+  roots.push(value);
 }
 
 function runtimeTick(): number {

--- a/prod/test/runtimePolicyParameters.test.ts
+++ b/prod/test/runtimePolicyParameters.test.ts
@@ -2,6 +2,7 @@ import {
   RUNTIME_POLICY_PARAMETER_CONSUMPTION_LOG_PREFIX,
   RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL,
   RUNTIME_POLICY_PARAMETERS_GLOBAL,
+  RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION,
   applyRuntimePolicyParametersToRegistry,
   createRuntimePolicyParameterConsumptionRecorder,
   persistRuntimePolicyParameterConsumptionEvidence
@@ -12,6 +13,7 @@ describe('runtime policy parameters', () => {
   afterEach(() => {
     delete (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETERS_GLOBAL];
     delete (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL];
+    delete (globalThis as Record<string, unknown>).self;
     delete (globalThis as { Memory?: unknown }).Memory;
     delete (globalThis as { Game?: unknown }).Game;
   });
@@ -99,6 +101,32 @@ describe('runtime policy parameters', () => {
     }
   });
 
+  it('reads private-simulator payloads from alternate Screeps global roots', () => {
+    (globalThis as Record<string, unknown>).self = {
+      [RUNTIME_POLICY_PARAMETERS_GLOBAL]: {
+        runtimeParameterInjection: true,
+        candidateParameterScope: 'runtime_injected',
+        strategyVariantId: 'construction-priority.pg.territory-seed.v1',
+        candidatePolicyId: 'construction-priority.pg.territory-seed.v1',
+        sourceStrategyId: 'construction-priority.territory-shadow.v1',
+        family: 'construction-priority',
+        parameters: {
+          territorySignalWeight: 29
+        },
+        parametersSha256: 'alternate-root-sha'
+      }
+    };
+
+    const result = applyRuntimePolicyParametersToRegistry(DEFAULT_STRATEGY_REGISTRY);
+
+    expect(result.evidence).toMatchObject({
+      runtimeParameterInjection: true,
+      consumed: false,
+      parametersSha256: 'alternate-root-sha',
+      appliedStrategyIds: ['construction-priority.territory-shadow.v1']
+    });
+  });
+
   it('does not fan out explicit candidate payloads to every family sibling', () => {
     (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETERS_GLOBAL] = {
       runtimeParameterInjection: true,
@@ -126,7 +154,7 @@ describe('runtime policy parameters', () => {
     ).toBe(true);
   });
 
-  it('marks consumption after runtime-injected parameters are materialized into the tick registry', () => {
+  it('marks consumption after tick-time planning uses runtime-injected parameters', () => {
     (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETERS_GLOBAL] = {
       runtimeParameterInjection: true,
       candidateParameterScope: 'runtime_injected',
@@ -149,10 +177,10 @@ describe('runtime policy parameters', () => {
 
     expect(recorder.buildEvidence()).toMatchObject({
       runtimeParameterInjection: true,
-      consumed: true,
-      reason: 'runtime policy parameter payload was materialized into the tick runtime strategy registry',
+      consumed: false,
+      reason: 'runtime policy parameter payload was not used by tick runtime strategy evaluation',
       parametersSha256: 'runtime-use-sha',
-      appliedStrategyIds: ['construction-priority.incumbent.v1'],
+      appliedStrategyIds: [],
       parameters: {
         territorySignalWeight: 29
       }
@@ -164,7 +192,11 @@ describe('runtime policy parameters', () => {
     expect(recorder.buildEvidence()).toMatchObject({
       runtimeParameterInjection: true,
       consumed: true,
+      reason: 'runtime policy parameter payload was used by tick runtime strategy evaluation',
+      consumerVersion: RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION,
       parametersSha256: 'runtime-use-sha',
+      consumedParametersSha256: 'runtime-use-sha',
+      consumedStrategyVariantId: 'construction-priority.pg.territory-seed.v1',
       appliedStrategyIds: ['construction-priority.incumbent.v1'],
       parameters: {
         territorySignalWeight: 29
@@ -172,7 +204,7 @@ describe('runtime policy parameters', () => {
     });
   });
 
-  it('does not carry materialized registry evidence across a different injected payload', () => {
+  it('does not infer consumption from a different injected payload', () => {
     (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETERS_GLOBAL] = {
       runtimeParameterInjection: true,
       candidateParameterScope: 'runtime_injected',
@@ -316,6 +348,7 @@ describe('runtime policy parameters', () => {
       persistRuntimePolicyParameterConsumptionEvidence({
         type: 'screeps-rl-runtime-policy-parameter-consumption',
         consumerMarker: 'screeps-rl-runtime-policy-parameters-consumer-v1',
+        consumerVersion: 'v1',
         runtimeParameterInjection: false,
         consumed: false,
         appliedStrategyIds: [],
@@ -328,6 +361,7 @@ describe('runtime policy parameters', () => {
       const evidence = {
         type: 'screeps-rl-runtime-policy-parameter-consumption' as const,
         consumerMarker: 'screeps-rl-runtime-policy-parameters-consumer-v1' as const,
+        consumerVersion: 'v1' as const,
         runtimeParameterInjection: true,
         consumed: true,
         strategyVariantId: 'construction-priority.pg.territory-seed.v1',

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -661,7 +661,6 @@ def runtime_parameter_consumption_check(
         "type": RUNTIME_PARAMETER_CONSUMPTION_TYPE,
         "schemaVersion": SCHEMA_VERSION,
         "consumerMarker": RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER,
-        "consumerVersion": RUNTIME_PARAMETER_INJECTION_CONSUMER_VERSION,
         "runtimeParameterConsumption": False,
         "runtimeParameterInjectionStatus": injection.get("status"),
         "strategyVariantId": injection.get("strategyVariantId"),
@@ -707,6 +706,7 @@ def runtime_parameter_consumption_check(
     payload = {
         **{key: value for key, value in base.items() if value is not None},
         "status": "consumed",
+        "consumerVersion": text_or_none(evidence.get("consumerVersion")),
         "runtimeParameterConsumption": True,
         "consumed": True,
         "source": text_or_none(evidence.get("source")) or "runtime_policy_parameter_consumption",
@@ -734,11 +734,11 @@ def apply_runtime_parameter_consumption_to_injection(
         updated["runtimeParameterConsumptionSource"] = consumption.get("source")
     if consumption.get("evaluatedParametersSha256"):
         updated["evaluatedParametersSha256"] = consumption.get("evaluatedParametersSha256")
-    if consumption.get("consumerVersion"):
+    if consumption.get("status") == "consumed" and consumption.get("consumerVersion"):
         updated["runtimeParameterConsumerVersion"] = consumption.get("consumerVersion")
-    if consumption.get("consumedParametersSha256"):
+    if consumption.get("status") == "consumed" and consumption.get("consumedParametersSha256"):
         updated["consumedParametersSha256"] = consumption.get("consumedParametersSha256")
-    if consumption.get("consumedStrategyVariantId"):
+    if consumption.get("status") == "consumed" and consumption.get("consumedStrategyVariantId"):
         updated["consumedStrategyVariantId"] = consumption.get("consumedStrategyVariantId")
     return updated
 
@@ -2804,7 +2804,7 @@ def _run_runtime_parameter_injection_summary(variant_results: Sequence[JsonObjec
                 "reason": "variant result did not include runtime parameter injection evidence",
             })
             continue
-        rows.append({
+        row = {
             "variantId": item.get("variant_id", item.get("variantId")),
             "status": injection.get("status"),
             "runtimeParameterInjection": injection.get("runtimeParameterInjection") is True,
@@ -2813,11 +2813,16 @@ def _run_runtime_parameter_injection_summary(variant_results: Sequence[JsonObjec
             "runtimeParameterConsumptionStatus": injection.get("runtimeParameterConsumptionStatus"),
             "candidateParameterScope": injection.get("candidateParameterScope"),
             "parametersSha256": injection.get("parametersSha256"),
-            "consumedParametersSha256": injection.get("consumedParametersSha256"),
-            "consumedStrategyVariantId": injection.get("consumedStrategyVariantId"),
-            "runtimeParameterConsumerVersion": injection.get("runtimeParameterConsumerVersion"),
             "reason": injection.get("runtimeParameterConsumptionReason", injection.get("reason")),
-        })
+        }
+        for field in (
+            "consumedParametersSha256",
+            "consumedStrategyVariantId",
+            "runtimeParameterConsumerVersion",
+        ):
+            if injection.get(field) is not None:
+                row[field] = injection.get(field)
+        rows.append(row)
     injected = sum(1 for row in rows if row.get("runtimeParameterInjection") is True)
     consumed = sum(1 for row in rows if row.get("runtimeParameterConsumption") is True)
     attempted_runtime = any(_runtime_parameter_summary_row_indicates_runtime_attempt(row) for row in rows)

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -96,6 +96,7 @@ RUNTIME_PARAMETER_INJECTION_GLOBAL = "__SCREEPS_RL_RUNTIME_POLICY_PARAMETERS__"
 RUNTIME_PARAMETER_CONSUMPTION_GLOBAL = "__SCREEPS_RL_RUNTIME_POLICY_PARAMETER_CONSUMPTION__"
 RUNTIME_PARAMETER_CONSUMPTION_TYPE = "screeps-rl-runtime-policy-parameter-consumption"
 RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER = "screeps-rl-runtime-policy-parameters-consumer-v1"
+RUNTIME_PARAMETER_INJECTION_CONSUMER_VERSION = "v1"
 RUNTIME_PARAMETER_CONSUMPTION_LOG_PREFIX = "#runtime-parameter-consumption "
 STRICT_DIRECTIVE_PREFIX_RE = re.compile(
     r"\A(\ufeff?(?:(?:\s+)|(?://[^\r\n]*(?:\r?\n|$))|(?:/\*.*?\*/))*"
@@ -600,9 +601,13 @@ def apply_runtime_parameter_injection_to_code(code_text: str, injection: JsonObj
         "liveEffect=false officialMmoWrites=false officialMmoWritesAllowed=false */\n"
         "(function(){\n"
         f"  var payload = {json.dumps(runtime_payload, sort_keys=True, separators=(',', ':'), ensure_ascii=True)};\n"
-        "  var root = typeof globalThis !== 'undefined' ? globalThis : "
-        "(typeof global !== 'undefined' ? global : this);\n"
-        f"  root[{json.dumps(RUNTIME_PARAMETER_INJECTION_GLOBAL)}] = payload;\n"
+        "  var roots = [];\n"
+        "  function addRoot(root) { if (root && roots.indexOf(root) < 0) roots.push(root); }\n"
+        "  if (typeof globalThis !== 'undefined') addRoot(globalThis);\n"
+        "  if (typeof global !== 'undefined') addRoot(global);\n"
+        "  if (typeof self !== 'undefined') addRoot(self);\n"
+        "  addRoot(this);\n"
+        f"  for (var index = 0; index < roots.length; index += 1) roots[index][{json.dumps(RUNTIME_PARAMETER_INJECTION_GLOBAL)}] = payload;\n"
         "})();\n"
     )
     insert_at = runtime_parameter_injection_insert_index(code_text)
@@ -656,6 +661,7 @@ def runtime_parameter_consumption_check(
         "type": RUNTIME_PARAMETER_CONSUMPTION_TYPE,
         "schemaVersion": SCHEMA_VERSION,
         "consumerMarker": RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER,
+        "consumerVersion": RUNTIME_PARAMETER_INJECTION_CONSUMER_VERSION,
         "runtimeParameterConsumption": False,
         "runtimeParameterInjectionStatus": injection.get("status"),
         "strategyVariantId": injection.get("strategyVariantId"),
@@ -706,6 +712,9 @@ def runtime_parameter_consumption_check(
         "source": text_or_none(evidence.get("source")) or "runtime_policy_parameter_consumption",
         "evaluatedParameters": parameters,
         "evaluatedParametersSha256": parameters_hash,
+        "consumedParametersSha256": text_or_none(evidence.get("consumedParametersSha256")) or parameters_hash,
+        "consumedStrategyVariantId": text_or_none(evidence.get("consumedStrategyVariantId"))
+        or text_or_none(evidence.get("strategyVariantId")),
         "appliedStrategyIds": copy.deepcopy(evidence.get("appliedStrategyIds", [])),
         "evidence": copy.deepcopy(evidence),
     }
@@ -725,6 +734,12 @@ def apply_runtime_parameter_consumption_to_injection(
         updated["runtimeParameterConsumptionSource"] = consumption.get("source")
     if consumption.get("evaluatedParametersSha256"):
         updated["evaluatedParametersSha256"] = consumption.get("evaluatedParametersSha256")
+    if consumption.get("consumerVersion"):
+        updated["runtimeParameterConsumerVersion"] = consumption.get("consumerVersion")
+    if consumption.get("consumedParametersSha256"):
+        updated["consumedParametersSha256"] = consumption.get("consumedParametersSha256")
+    if consumption.get("consumedStrategyVariantId"):
+        updated["consumedStrategyVariantId"] = consumption.get("consumedStrategyVariantId")
     return updated
 
 
@@ -736,6 +751,11 @@ def runtime_parameter_consumption_validation_error(
         return "runtime policy parameter evidence had the wrong type"
     if evidence.get("consumerMarker") != RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER:
         return "runtime policy parameter evidence did not come from the expected consumer"
+    observed_version = text_or_none(evidence.get("consumerVersion"))
+    if observed_version is None:
+        return "runtime policy parameter evidence did not include a consumer version"
+    if observed_version != RUNTIME_PARAMETER_INJECTION_CONSUMER_VERSION:
+        return "runtime policy parameter evidence came from an unsupported consumer version"
     if evidence.get("consumed") is not True or evidence.get("runtimeParameterInjection") is not True:
         return "runtime policy parameter evidence did not mark the payload consumed"
     parameters = evidence.get("parameters")
@@ -747,6 +767,17 @@ def runtime_parameter_consumption_validation_error(
         return "runtime policy parameter evidence parameters could not be hashed"
     if expected_hash is not None and observed_hash != expected_hash:
         return "runtime policy parameter evidence parameters disagreed with injected parameters"
+    consumed_hash = text_or_none(evidence.get("consumedParametersSha256"))
+    if consumed_hash is None:
+        return "runtime policy parameter evidence did not include a consumed parameter hash"
+    if expected_hash is not None and consumed_hash != expected_hash:
+        return "runtime policy parameter evidence consumed parameter hash disagreed with injected parameters"
+    consumed_variant_id = text_or_none(evidence.get("consumedStrategyVariantId"))
+    expected_variant_id = text_or_none(injection.get("strategyVariantId"))
+    if consumed_variant_id is None:
+        return "runtime policy parameter evidence did not include a consumed strategy variant id"
+    if expected_variant_id is not None and consumed_variant_id != expected_variant_id:
+        return "runtime policy parameter evidence consumed strategy variant id disagreed with injected parameters"
     for field in ("strategyVariantId", "candidatePolicyId", "family"):
         expected = text_or_none(injection.get(field))
         observed = text_or_none(evidence.get(field))
@@ -2782,6 +2813,9 @@ def _run_runtime_parameter_injection_summary(variant_results: Sequence[JsonObjec
             "runtimeParameterConsumptionStatus": injection.get("runtimeParameterConsumptionStatus"),
             "candidateParameterScope": injection.get("candidateParameterScope"),
             "parametersSha256": injection.get("parametersSha256"),
+            "consumedParametersSha256": injection.get("consumedParametersSha256"),
+            "consumedStrategyVariantId": injection.get("consumedStrategyVariantId"),
+            "runtimeParameterConsumerVersion": injection.get("runtimeParameterConsumerVersion"),
             "reason": injection.get("runtimeParameterConsumptionReason", injection.get("reason")),
         })
     injected = sum(1 for row in rows if row.get("runtimeParameterInjection") is True)

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -4507,6 +4507,9 @@ def summarize_runtime_parameter_injection_attempt(
         row["runtimeParameterConsumptionStatus"] = consumption.get("status")
         row["runtimeParameterConsumptionSource"] = consumption.get("source")
         row["runtimeParameterConsumer"] = consumption.get("consumerMarker")
+        row["runtimeParameterConsumerVersion"] = consumption.get("consumerVersion")
+        row["consumedParametersSha256"] = consumption.get("consumedParametersSha256")
+        row["consumedStrategyVariantId"] = consumption.get("consumedStrategyVariantId")
         applied_strategy_ids = consumption.get("appliedStrategyIds")
         if isinstance(applied_strategy_ids, list):
             row["appliedStrategyIds"] = [
@@ -4732,8 +4735,11 @@ def summarize_variant_runtime_parameter_injection(
         for field in (
             "runtimeParameterConsumptionSource",
             "runtimeParameterConsumer",
+            "runtimeParameterConsumerVersion",
             "evaluatedParametersSource",
             "evaluatedParametersSha256",
+            "consumedParametersSha256",
+            "consumedStrategyVariantId",
             "appliedStrategyIds",
         ):
             if field in first_injected:

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1539,6 +1539,8 @@ cli:
         self.assertNotEqual(base_upload, territory_upload)
         self.assertTrue(base_upload.startswith('"use strict";\n'))
         self.assertIn(harness.RUNTIME_PARAMETER_INJECTION_GLOBAL, base_upload)
+        self.assertIn("function addRoot(root)", base_upload)
+        self.assertIn("typeof global !== 'undefined'", base_upload)
         self.assertIn('"territorySignalWeight":6', base_upload)
         self.assertNotIn('"territorySignalWeight":22', base_upload)
         self.assertIn('"territorySignalWeight":22', territory_upload)
@@ -1698,10 +1700,15 @@ cli:
 
         self.assertEqual(consumption["status"], "consumed")
         self.assertTrue(consumption["runtimeParameterConsumption"])
+        self.assertEqual(consumption["consumerVersion"], harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_VERSION)
         self.assertEqual(consumption["evaluatedParameters"], injection["parameters"])
         self.assertEqual(consumption["evaluatedParametersSha256"], injection["parametersSha256"])
+        self.assertEqual(consumption["consumedParametersSha256"], injection["parametersSha256"])
+        self.assertEqual(consumption["consumedStrategyVariantId"], injection["strategyVariantId"])
         self.assertTrue(updated["runtimeParameterConsumption"])
         self.assertEqual(updated["runtimeParameterConsumptionStatus"], "consumed")
+        self.assertEqual(updated["runtimeParameterConsumerVersion"], harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_VERSION)
+        self.assertEqual(updated["consumedParametersSha256"], injection["parametersSha256"])
 
     def test_runtime_parameter_consumption_accepts_javascript_numeric_canonicalization(self) -> None:
         variant = {
@@ -3299,6 +3306,9 @@ cli:
         self.assertEqual(summary["runtimeParameterConsumptionStatus"], "partial")
         self.assertEqual(summary["consumedVariantCount"], 1)
         self.assertEqual(summary["variantCount"], 2)
+        self.assertEqual(summary["variants"][0]["runtimeParameterConsumerVersion"], harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_VERSION)
+        self.assertEqual(summary["variants"][0]["consumedParametersSha256"], consumed_injection["parametersSha256"])
+        self.assertEqual(summary["variants"][0]["consumedStrategyVariantId"], consumed_injection["strategyVariantId"])
 
     def uploaded_runtime_parameter_injection(self) -> harness.JsonObject:
         base_code = (
@@ -3326,6 +3336,7 @@ cli:
         return {
             "type": harness.RUNTIME_PARAMETER_CONSUMPTION_TYPE,
             "consumerMarker": harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER,
+            "consumerVersion": harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_VERSION,
             "runtimeParameterInjection": True,
             "consumed": True,
             "strategyVariantId": injection["strategyVariantId"],
@@ -3333,6 +3344,8 @@ cli:
             "family": injection["family"],
             "parameters": copy.deepcopy(injection["parameters"]),
             "parametersSha256": injection["parametersSha256"],
+            "consumedStrategyVariantId": injection["strategyVariantId"],
+            "consumedParametersSha256": injection["parametersSha256"],
             "appliedStrategyIds": [injection["strategyVariantId"]],
             "liveEffect": False,
             "officialMmoWrites": False,

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1540,7 +1540,10 @@ cli:
         self.assertTrue(base_upload.startswith('"use strict";\n'))
         self.assertIn(harness.RUNTIME_PARAMETER_INJECTION_GLOBAL, base_upload)
         self.assertIn("function addRoot(root)", base_upload)
+        self.assertIn("typeof globalThis !== 'undefined'", base_upload)
         self.assertIn("typeof global !== 'undefined'", base_upload)
+        self.assertIn("typeof self !== 'undefined'", base_upload)
+        self.assertIn("addRoot(this)", base_upload)
         self.assertIn('"territorySignalWeight":6', base_upload)
         self.assertNotIn('"territorySignalWeight":22', base_upload)
         self.assertIn('"territorySignalWeight":22', territory_upload)
@@ -1690,6 +1693,10 @@ cli:
         self.assertFalse(updated["runtimeParameterConsumption"])
         self.assertEqual(updated["runtimeParameterConsumptionStatus"], "missing")
         self.assertIn("did not expose", consumption["reason"])
+        self.assertNotIn("consumerVersion", consumption)
+        self.assertNotIn("runtimeParameterConsumerVersion", updated)
+        self.assertNotIn("consumedParametersSha256", updated)
+        self.assertNotIn("consumedStrategyVariantId", updated)
 
     def test_runtime_parameter_consumption_accepts_matching_memory_evidence(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
@@ -1787,6 +1794,22 @@ cli:
         self.assertFalse(consumption["runtimeParameterConsumption"])
         self.assertIn("disagreed", consumption["reason"])
         self.assertNotEqual(consumption["evaluatedParametersSha256"], injection["parametersSha256"])
+
+    def test_runtime_parameter_consumption_rejects_consumer_version_mismatch(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+        evidence["consumerVersion"] = "runtime-policy-v0"
+
+        consumption = harness.runtime_parameter_consumption_check(injection, evidence)
+        updated = harness.apply_runtime_parameter_consumption_to_injection(injection, consumption)
+
+        self.assertEqual(consumption["status"], "invalid")
+        self.assertFalse(consumption["runtimeParameterConsumption"])
+        self.assertIn("consumer version", consumption["reason"])
+        self.assertNotIn("consumerVersion", consumption)
+        self.assertNotIn("runtimeParameterConsumerVersion", updated)
+        self.assertNotIn("consumedParametersSha256", updated)
+        self.assertNotIn("consumedStrategyVariantId", updated)
 
     def test_runtime_parameter_consumption_extracts_memory_payload(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
@@ -3309,6 +3332,11 @@ cli:
         self.assertEqual(summary["variants"][0]["runtimeParameterConsumerVersion"], harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_VERSION)
         self.assertEqual(summary["variants"][0]["consumedParametersSha256"], consumed_injection["parametersSha256"])
         self.assertEqual(summary["variants"][0]["consumedStrategyVariantId"], consumed_injection["strategyVariantId"])
+        self.assertFalse(summary["variants"][1]["runtimeParameterConsumption"])
+        self.assertEqual(summary["variants"][1]["runtimeParameterConsumptionStatus"], "missing")
+        self.assertNotIn("runtimeParameterConsumerVersion", summary["variants"][1])
+        self.assertNotIn("consumedParametersSha256", summary["variants"][1])
+        self.assertNotIn("consumedStrategyVariantId", summary["variants"][1])
 
     def uploaded_runtime_parameter_injection(self) -> harness.JsonObject:
         base_code = (

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -281,6 +281,7 @@ class MockSimulator:
                 consumption_evidence = {
                     "type": runner.simulator_harness.RUNTIME_PARAMETER_CONSUMPTION_TYPE,
                     "consumerMarker": runner.simulator_harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER,
+                    "consumerVersion": runner.simulator_harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_VERSION,
                     "runtimeParameterInjection": True,
                     "consumed": True,
                     "strategyVariantId": variant_id,
@@ -288,6 +289,8 @@ class MockSimulator:
                     "family": variant_config.get("family"),
                     "parameters": evaluated_parameters,
                     "parametersSha256": result["runtimeParameterInjection"].get("parametersSha256"),
+                    "consumedStrategyVariantId": variant_id,
+                    "consumedParametersSha256": result["runtimeParameterInjection"].get("parametersSha256"),
                     "appliedStrategyIds": [variant_id],
                     "liveEffect": False,
                     "officialMmoWrites": False,
@@ -3815,6 +3818,16 @@ export const STRATEGY_REGISTRY = [
                 for result in report["variantResults"]
             )
         )
+        self.assertTrue(
+            all(
+                attempt.get("runtimeParameterConsumerVersion")
+                == runner.simulator_harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_VERSION
+                and attempt.get("consumedParametersSha256") == attempt.get("parametersSha256")
+                and isinstance(attempt.get("consumedStrategyVariantId"), str)
+                for result in report["variantResults"]
+                for attempt in result["runtimeParameterInjection"]["attempts"]
+            )
+        )
         self.assertTrue(all("evaluatedParameters" in result for result in report["variantResults"]))
         self.assertFalse(report["officialMmoWritesAllowed"])
         self.assertFalse(persisted["officialMmoWritesAllowed"])
@@ -4310,6 +4323,15 @@ export const STRATEGY_REGISTRY = [
         self.assertFalse(report["policyUpdate"]["promotionGate"]["runtimeParameterConsumption"])
         self.assertFalse(report["policyUpdate"]["promotionGate"]["loopAPromotionEligible"])
         self.assertFalse(report["policyUpdate"]["promotionGate"]["loopBPromotionEligible"])
+        self.assertTrue(
+            all(
+                "consumedParametersSha256" not in attempt
+                and "consumedStrategyVariantId" not in attempt
+                and "runtimeParameterConsumerVersion" not in attempt
+                for result in report["variantResults"]
+                for attempt in result["runtimeParameterInjection"]["attempts"]
+            )
+        )
         self.assertNotIn("policyUpdateArtifactPath", report)
         self.assertFalse(report["liveEffect"])
         self.assertFalse(report["officialMmoWrites"])


### PR DESCRIPTION
## Summary
- emit tick-time runtime policy parameter consumption evidence from the bot/runtime path when injected candidates are loaded
- collect consumption proof in the simulator/training reports without treating injection alone as trusted evidence
- preserve the negative path: promotion remains blocked when candidate parameters are injected but not consumed

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py`
- `python3 -m unittest scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py` (229 tests)
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (101 suites / 2034 tests)
- `cd prod && npm run build`

## Safety
- No official MMO writes or live learned-policy control are introduced.
- Runtime consumption evidence is simulator/private/shadow-only and keeps promotion blocked when evidence is absent.
- `prod/dist/main.js` was regenerated from source with the normal build.

Refs #1299
Refs #1337
Refs #1032
Refs #879
