### PR TITLE
fix(rl): wire reinforce policy update path

### DIFF
--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -2028,14 +2028,20 @@ def build_reinforce_policy_update(
         }
 
     if not any(abs(float(value)) > 0 for value in parameter_delta.values()):
+        no_change_parameter_evidence = {
+            **parameter_evidence,
+            "learningRate": learning_rate,
+            "boundedIntegerStep": bounded_integer_step,
+        }
         return {
             **base,
             "skippedReason": "bounded_update_no_parameter_change",
             "candidateCount": len(candidates),
-            "parameterEvidence": parameter_evidence,
+            "parameterEvidence": no_change_parameter_evidence,
             "anchor": policy_update_candidate_summary(anchor),
             "candidateRewards": [policy_update_candidate_summary(row) for row in candidates],
             "learningRate": learning_rate,
+            "boundedIntegerStep": bounded_integer_step,
             "gradient": gradient,
             "rawGradient": raw_gradient,
             "gradientEstimation": gradient_estimation,
@@ -3404,12 +3410,17 @@ def bounded_policy_parameter_integer_step_update(
     learning_rate: float,
     spec: JsonObject,
 ) -> float | int:
-    if abs(gradient_value) <= 1e-12:
+    minimum = float(spec["min"])
+    maximum = float(spec["max"])
+    span = max(maximum - minimum, 1.0)
+    effective_delta = float(learning_rate) * float(gradient_value) * span
+    if abs(effective_delta) <= 1e-12:
         return bounded_policy_parameter_value(anchor_value, spec)
     step = number_or_none(spec.get("step"))
     step_float = float(step) if step is not None and float(step) > 0 else 1.0
-    step_count = max(1, int(round(abs(float(learning_rate)))))
-    direction = 1.0 if gradient_value > 0 else -1.0
+    step_units = abs(effective_delta) / step_float
+    step_count = max(1, int(math.floor(step_units + 0.5 + 1e-12)))
+    direction = 1.0 if effective_delta > 0 else -1.0
     return bounded_policy_parameter_step_value(
         anchor_value + (direction * step_float * step_count),
         spec,

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -1927,6 +1927,7 @@ def build_reinforce_policy_update(
 
     return_baseline = mean_policy_return_tuple([sample["returnTuple"] for sample in samples])
     learning_rate = policy_update_learning_rate(policy_gradient)
+    bounded_integer_step = policy_update_uses_bounded_integer_step(policy_gradient)
     anchor_parameters = anchor["parameters"]
     gradient_by_tier: JsonObject = {}
     selected_reward_tier_by_parameter: JsonObject = {}
@@ -1966,10 +1967,19 @@ def build_reinforce_policy_update(
     for name, spec in parameter_space.items():
         anchor_value = float(anchor_parameters[name])
         span = max(float(spec["max"]) - float(spec["min"]), 1.0)
-        updated = bounded_policy_parameter_value(
-            anchor_value + (learning_rate * float(gradient.get(name, 0)) * span),
-            spec,
-        )
+        gradient_value = float(gradient.get(name, 0))
+        if bounded_integer_step:
+            updated = bounded_policy_parameter_integer_step_update(
+                anchor_value=anchor_value,
+                gradient_value=gradient_value,
+                learning_rate=learning_rate,
+                spec=spec,
+            )
+        else:
+            updated = bounded_policy_parameter_value(
+                anchor_value + (learning_rate * gradient_value * span),
+                spec,
+            )
         updated_parameters[name] = updated
         parameter_delta[name] = round_policy_number(float(updated) - anchor_value)
 
@@ -2099,6 +2109,7 @@ def build_reinforce_policy_update(
             "selectedRewardTierByParameter": copy.deepcopy(selected_reward_tier_by_parameter),
             "parameterDelta": copy.deepcopy(parameter_delta),
             "learningRate": learning_rate,
+            "boundedIntegerStep": bounded_integer_step,
             "returnBaseline": copy.deepcopy(return_baseline),
             "returnSampleCount": len(samples),
             "candidateCount": len(candidates),
@@ -2130,6 +2141,7 @@ def build_reinforce_policy_update(
         "trustedGradientUpdate": trusted_gradient_update,
         "highVariance": gradient_stability["highVariance"],
         "learningRate": learning_rate,
+        "boundedIntegerStep": bounded_integer_step,
         "parameterSpace": copy.deepcopy(parameter_space),
         "candidateCount": len(candidates),
         "parameterEvidence": parameter_evidence,
@@ -3357,11 +3369,51 @@ def policy_update_learning_rate(policy_gradient: JsonObject) -> float:
     return DEFAULT_POLICY_UPDATE_LEARNING_RATE
 
 
+def policy_update_uses_bounded_integer_step(policy_gradient: JsonObject) -> bool:
+    for raw in policy_update_config_candidates(policy_gradient):
+        value = first_present(raw, ("bounded_integer_step", "boundedIntegerStep"))
+        if isinstance(value, bool):
+            return value
+    return False
+
+
 def bounded_policy_parameter_value(value: float, spec: JsonObject) -> float | int:
     minimum = float(spec["min"])
     maximum = float(spec["max"])
     bounded = max(minimum, min(maximum, value))
     return round_policy_number(bounded)
+
+
+def bounded_policy_parameter_step_value(value: float, spec: JsonObject) -> float | int:
+    minimum = float(spec["min"])
+    maximum = float(spec["max"])
+    bounded = max(minimum, min(maximum, value))
+    step = number_or_none(spec.get("step"))
+    if step is None or float(step) <= 0:
+        return round_policy_number(bounded)
+    step_float = float(step)
+    quantized_steps = round((bounded - minimum) / step_float)
+    quantized = minimum + (quantized_steps * step_float)
+    return round_policy_number(max(minimum, min(maximum, quantized)))
+
+
+def bounded_policy_parameter_integer_step_update(
+    *,
+    anchor_value: float,
+    gradient_value: float,
+    learning_rate: float,
+    spec: JsonObject,
+) -> float | int:
+    if abs(gradient_value) <= 1e-12:
+        return bounded_policy_parameter_value(anchor_value, spec)
+    step = number_or_none(spec.get("step"))
+    step_float = float(step) if step is not None and float(step) > 0 else 1.0
+    step_count = max(1, int(round(abs(float(learning_rate)))))
+    direction = 1.0 if gradient_value > 0 else -1.0
+    return bounded_policy_parameter_step_value(
+        anchor_value + (direction * step_float * step_count),
+        spec,
+    )
 
 
 def round_policy_number(value: float | int) -> float | int:

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -3555,6 +3555,89 @@ export const STRATEGY_REGISTRY = [
             {"territorySignalWeight": 1},
         )
 
+    def test_reinforce_bounded_integer_step_scales_step_count_by_effective_gradient(self) -> None:
+        def build_update(learning_rate: float) -> JsonObject:
+            policy_gradient = {
+                "targetFamily": "test-family",
+                "policyUpdate": {
+                    "algorithm": runner.TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM,
+                    "learning_rate": learning_rate,
+                    "bounded_integer_step": True,
+                    "gradient_reward_weights": {
+                        "reliability": 1,
+                        "territory": 1,
+                        "resources": 1,
+                        "kills": 1,
+                    },
+                },
+                "runner_support": {
+                    "runtime_parameter_injection": True,
+                    "inline_candidates_runtime_injected": True,
+                    "inline_candidates_applied_to_simulator": True,
+                    "candidate_parameter_scope": "runtime_injected",
+                    "simulator_variant_transport": "variant_ids_with_runtime_injected_parameters",
+                    "policy_update_reward_use": "eligible_with_evaluated_runtime_parameters",
+                    "runtime_parameter_consumption_status": "consumed",
+                },
+                "learnableParameters": [{"name": "territorySignalWeight", "min": 0, "max": 30, "step": 1}],
+                "candidateParameterVectors": [
+                    {
+                        "candidatePolicyId": "candidate-a",
+                        "strategyVariantId": "variant-a",
+                        "rolloutStatus": "incumbent",
+                        "parameters": {"territorySignalWeight": 10.0},
+                    },
+                    {
+                        "candidatePolicyId": "candidate-b",
+                        "strategyVariantId": "variant-b",
+                        "rolloutStatus": "shadow",
+                        "parameters": {"territorySignalWeight": 20.0},
+                    },
+                ],
+            }
+            results = [
+                {
+                    "variantId": "variant-a",
+                    "sampleCount": 1,
+                    "reward": {"tuple": [0, 0, 0, 0]},
+                    "evaluatedParameters": {"territorySignalWeight": 10.0},
+                },
+                {
+                    "variantId": "variant-b",
+                    "sampleCount": 1,
+                    "reward": {"tuple": [2.4, 0, 0, 0]},
+                    "evaluatedParameters": {"territorySignalWeight": 20.0},
+                },
+            ]
+            return runner.build_policy_update(
+                policy_gradient=policy_gradient,
+                results=results,
+                report_id=f"policy-gradient-bounded-step-lr-{learning_rate}",
+                generated_at="2026-05-17T03:30:00Z",
+            )
+
+        small_update = build_update(0.25)
+        large_update = build_update(1)
+
+        self.assertEqual(small_update["iterations"], 1)
+        self.assertEqual(large_update["iterations"], 1)
+        self.assertTrue(small_update["boundedIntegerStep"])
+        self.assertTrue(large_update["boundedIntegerStep"])
+        self.assertEqual(small_update["gradient"], large_update["gradient"])
+        self.assertAlmostEqual(float(small_update["gradient"]["territorySignalWeight"]), 0.2, places=12)
+        self.assertEqual(small_update["parameterDelta"], {"territorySignalWeight": 2})
+        self.assertEqual(small_update["updatedParameters"], {"territorySignalWeight": 12})
+        self.assertEqual(large_update["parameterDelta"], {"territorySignalWeight": 6})
+        self.assertEqual(large_update["updatedParameters"], {"territorySignalWeight": 16})
+        self.assertEqual(
+            small_update["nextCandidatePolicy"]["parameterEvidence"]["boundedIntegerStep"],
+            True,
+        )
+        self.assertEqual(
+            large_update["nextCandidatePolicy"]["parameterEvidence"]["boundedIntegerStep"],
+            True,
+        )
+
     def test_reinforce_bounded_integer_step_clamps_at_parameter_bounds(self) -> None:
         policy_gradient = {
             "targetFamily": "test-family",
@@ -3618,6 +3701,9 @@ export const STRATEGY_REGISTRY = [
 
         self.assertEqual(update["iterations"], 0)
         self.assertEqual(update["skippedReason"], "bounded_update_no_parameter_change")
+        self.assertTrue(update["boundedIntegerStep"])
+        self.assertTrue(update["parameterEvidence"]["boundedIntegerStep"])
+        self.assertEqual(update["parameterEvidence"]["learningRate"], 1)
         self.assertGreater(float(update["gradient"]["territorySignalWeight"]), 0)
         self.assertNotIn("nextCandidatePolicy", update)
         self.assertNotIn("updatedParameters", update)

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -3478,6 +3478,151 @@ export const STRATEGY_REGISTRY = [
         self.assertFalse(update["nextCandidatePolicy"]["officialMmoWrites"])
         self.assertFalse(update["nextCandidatePolicy"]["officialMmoWritesAllowed"])
 
+    def test_reinforce_bounded_integer_step_emits_one_step_from_clear_scorecard_advantage(self) -> None:
+        policy_gradient = {
+            "targetFamily": "test-family",
+            "policyUpdate": {
+                "algorithm": runner.TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM,
+                "learning_rate": 1,
+                "bounded_integer_step": True,
+                "gradient_reward_weights": {
+                    "reliability": 1,
+                    "territory": 1,
+                    "resources": 1,
+                    "kills": 1,
+                },
+            },
+            "runner_support": {
+                "runtime_parameter_injection": True,
+                "inline_candidates_runtime_injected": True,
+                "inline_candidates_applied_to_simulator": True,
+                "candidate_parameter_scope": "runtime_injected",
+                "simulator_variant_transport": "variant_ids_with_runtime_injected_parameters",
+                "policy_update_reward_use": "eligible_with_evaluated_runtime_parameters",
+                "runtime_parameter_consumption_status": "consumed",
+            },
+            "learnableParameters": [{"name": "territorySignalWeight", "min": 0, "max": 30, "step": 1}],
+            "candidateParameterVectors": [
+                {
+                    "candidatePolicyId": "candidate-a",
+                    "strategyVariantId": "variant-a",
+                    "rolloutStatus": "incumbent",
+                    "parameters": {"territorySignalWeight": 6.0},
+                },
+                {
+                    "candidatePolicyId": "candidate-b",
+                    "strategyVariantId": "variant-b",
+                    "rolloutStatus": "shadow",
+                    "parameters": {"territorySignalWeight": 7.0},
+                },
+            ],
+        }
+        results = [
+            {
+                "variantId": "variant-a",
+                "sampleCount": 1,
+                "reward": {"tuple": [0, 0, 0, 0]},
+                "evaluatedParameters": {"territorySignalWeight": 6.0},
+            },
+            {
+                "variantId": "variant-b",
+                "sampleCount": 1,
+                "reward": {"tuple": [1.02, 0, 0, 0]},
+                "evaluatedParameters": {"territorySignalWeight": 7.0},
+            },
+        ]
+
+        update = runner.build_policy_update(
+            policy_gradient=policy_gradient,
+            results=results,
+            report_id="policy-gradient-bounded-step",
+            generated_at="2026-05-17T03:30:00Z",
+        )
+
+        self.assertEqual(update["iterations"], 1)
+        self.assertTrue(update["boundedIntegerStep"])
+        self.assertEqual(update["learningRate"], 1)
+        self.assertGreater(float(update["gradient"]["territorySignalWeight"]), 0)
+        self.assertEqual(update["parameterDelta"], {"territorySignalWeight": 1})
+        self.assertEqual(update["updatedParameters"], {"territorySignalWeight": 7})
+        self.assertEqual(update["nextCandidatePolicy"]["parameters"], {"territorySignalWeight": 7})
+        self.assertEqual(
+            update["nextCandidatePolicy"]["parameterEvidence"]["boundedIntegerStep"],
+            True,
+        )
+        self.assertEqual(
+            update["nextCandidatePolicy"]["parameterEvidence"]["parameterDelta"],
+            {"territorySignalWeight": 1},
+        )
+
+    def test_reinforce_bounded_integer_step_clamps_at_parameter_bounds(self) -> None:
+        policy_gradient = {
+            "targetFamily": "test-family",
+            "policyUpdate": {
+                "algorithm": runner.TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM,
+                "learning_rate": 1,
+                "bounded_integer_step": True,
+                "gradient_reward_weights": {
+                    "reliability": 1,
+                    "territory": 1,
+                    "resources": 1,
+                    "kills": 1,
+                },
+            },
+            "runner_support": {
+                "runtime_parameter_injection": True,
+                "inline_candidates_runtime_injected": True,
+                "inline_candidates_applied_to_simulator": True,
+                "candidate_parameter_scope": "runtime_injected",
+                "simulator_variant_transport": "variant_ids_with_runtime_injected_parameters",
+                "policy_update_reward_use": "eligible_with_evaluated_runtime_parameters",
+                "runtime_parameter_consumption_status": "consumed",
+            },
+            "learnableParameters": [{"name": "territorySignalWeight", "min": 0, "max": 30, "step": 1}],
+            "candidateParameterVectors": [
+                {
+                    "candidatePolicyId": "candidate-a",
+                    "strategyVariantId": "variant-a",
+                    "rolloutStatus": "incumbent",
+                    "parameters": {"territorySignalWeight": 30.0},
+                },
+                {
+                    "candidatePolicyId": "candidate-b",
+                    "strategyVariantId": "variant-b",
+                    "rolloutStatus": "shadow",
+                    "parameters": {"territorySignalWeight": 29.0},
+                },
+            ],
+        }
+        results = [
+            {
+                "variantId": "variant-a",
+                "sampleCount": 1,
+                "reward": {"tuple": [1, 0, 0, 0]},
+                "evaluatedParameters": {"territorySignalWeight": 30.0},
+            },
+            {
+                "variantId": "variant-b",
+                "sampleCount": 1,
+                "reward": {"tuple": [0, 0, 0, 0]},
+                "evaluatedParameters": {"territorySignalWeight": 29.0},
+            },
+        ]
+
+        update = runner.build_policy_update(
+            policy_gradient=policy_gradient,
+            results=results,
+            report_id="policy-gradient-bounded-step-clamped",
+            generated_at="2026-05-17T03:30:00Z",
+        )
+
+        self.assertEqual(update["iterations"], 0)
+        self.assertEqual(update["skippedReason"], "bounded_update_no_parameter_change")
+        self.assertGreater(float(update["gradient"]["territorySignalWeight"]), 0)
+        self.assertNotIn("nextCandidatePolicy", update)
+        self.assertNotIn("updatedParameters", update)
+        self.assertNotIn("parameterDelta", update)
+
     def test_ready_parameter_evidence_does_not_alias_injection_to_consumption(self) -> None:
         policy_gradient = {
             "runner_support": {
@@ -3633,6 +3778,9 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(runner.bounded_policy_parameter_value(6.06375, spec), 6.06375)
         self.assertEqual(runner.bounded_policy_parameter_value(-0.25, spec), 0)
         self.assertEqual(runner.bounded_policy_parameter_value(30.25, spec), 30)
+        self.assertEqual(runner.bounded_policy_parameter_step_value(6.06375, spec), 6)
+        self.assertEqual(runner.bounded_policy_parameter_step_value(6.51, spec), 7)
+        self.assertEqual(runner.bounded_policy_parameter_step_value(30.25, spec), 30)
 
     def test_reinforce_metadata_only_parameters_skip_candidate_update_artifact(self) -> None:
         card = card_helper.build_card(
@@ -4440,6 +4588,12 @@ export const STRATEGY_REGISTRY = [
         self.assertGreater(len(report["ranking"]), 1)
         self.assertIn("policyUpdateArtifactPath", report)
         update = report["policyUpdate"]
+        step_by_parameter = {
+            item["name"]: item.get("step", 1)
+            for item in report["policyGradient"]["learnable_parameters"]
+            if isinstance(item, dict) and isinstance(item.get("name"), str)
+        }
+        self.assertTrue(update["boundedIntegerStep"])
         self.assertFalse(update["liveEffect"])
         self.assertFalse(update["officialMmoWrites"])
         self.assertFalse(update["officialMmoWritesAllowed"])
@@ -4463,7 +4617,12 @@ export const STRATEGY_REGISTRY = [
         self.assertFalse(update["promotionGate"]["loopBPromotionEligible"])
         self.assertEqual(update["promotionGate"]["missingPrerequisites"], ["runtime_parameter_consumption"])
         self.assertTrue(any(abs(float(value)) > 0 for value in update["parameterDelta"].values()))
+        for name, delta in update["parameterDelta"].items():
+            step = float(step_by_parameter[name])
+            if abs(float(delta)) > 0:
+                self.assertAlmostEqual(abs(float(delta)) / step, round(abs(float(delta)) / step), places=9)
         self.assertEqual(artifact["parameters"], update["updatedParameters"])
+        self.assertTrue(artifact["parameterEvidence"]["boundedIntegerStep"])
         self.assertEqual(artifact["promotionGate"], update["promotionGate"])
         self.assertEqual(update["nextCandidatePolicy"]["promotionGate"], update["promotionGate"])
 


### PR DESCRIPTION
## Summary
- wires bounded integer-step REINFORCE policy-update emission for RL training scorecards
- records bounded-step parameter evidence in candidate artifacts
- adds focused tests for clear advantage, clamping/no-change, and artifact compatibility

## Test plan
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_training_runner.py`
- `python3 -m pytest scripts/test_screeps_rl_training_runner.py -q` (113 passed, 16 subtests passed)

## Notes
- No Tencent/paid compute launched from this PR.
- GraphQL Project updates are deferred by quota exhaustion in the scheduler run (`remaining=0`, reset `2026-05-23T16:10:58Z`); REST comments on #879/#1299/#1361 carry the current handoff evidence.

Fixes #1361
