### PR TITLE
fix(rl): restore runtime consumption trust evidence

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -1076,6 +1076,28 @@ local nestedRuntimePolicyParameterKeys = {
   "value",
   "evidence",
 }
+local function runtimePolicyParameterContainerKey(keyText)
+  local keyLower = string.lower(keyText)
+  return string.find(keyLower, "runtime", 1, true) ~= nil
+    or keyText == "data"
+    or keyText == "value"
+    or keyText == "memory"
+    or keyText == "Memory"
+    or keyText == "$activeWorld"
+    or keyText == "activeWorld"
+    or string.match(keyText, "^[Ss]hard[%w_-]+$") ~= nil
+end
+local function predefinedRuntimePolicyParameterKey(keyText)
+  if keyText == "rlRuntimePolicyParameters" then
+    return true
+  end
+  for _, nestedKey in ipairs(nestedRuntimePolicyParameterKeys) do
+    if keyText == nestedKey then
+      return true
+    end
+  end
+  return false
+end
 local function decodedRuntimePolicyParameterValue(value)
   if type(value) == "table" then
     return value
@@ -1222,6 +1244,18 @@ local function pushRuntimePolicyParameterEvidence(source, value, depth, ownerMat
       end
     end
   end
+  for key, item in pairs(decoded) do
+    if
+      type(key) == "string"
+      and runtimePolicyParameterContainerKey(key)
+      and not predefinedRuntimePolicyParameterKey(key)
+    then
+      pushRuntimePolicyParameterEvidence(source .. "." .. key, item, depth + 1, nextOwnerMatched)
+      if candidateLimitReached() then
+        return
+      end
+    end
+  end
   if decoded[1] ~= nil then
     for index, item in ipairs(decoded) do
       pushRuntimePolicyParameterEvidence(source .. "[" .. tostring(index) .. "]", item, depth + 1, nextOwnerMatched)
@@ -1235,10 +1269,7 @@ local function pushRuntimePolicyParameterCandidate(source, value, depth, ownerMa
   pushRuntimePolicyParameterEvidence(source, value, depth or 0, ownerMatched or false)
 end
 local function hashFieldMayContainRuntimePolicyParameters(fieldText)
-  local fieldLower = string.lower(fieldText)
-  return string.find(fieldLower, "runtime", 1, true) ~= nil
-    or fieldText == "data"
-    or fieldText == "value"
+  return runtimePolicyParameterContainerKey(fieldText)
 end
 local function scanHashMemoryFields(keyText, key, ownerMatched)
   local hashCursor = "0"
@@ -1456,7 +1487,9 @@ def _collect_mongo_runtime_parameter_consumption_evidence(
 const smokeDb = db.getSiblingDB({json.dumps(cfg.mongo_db)});
 const user = smokeDb.getCollection('users').findOne({{username: {json.dumps(cfg.username)}}});
 const candidates = [];
+const candidateLimit = 32;
 const pushCandidate = (source, value) => {{
+  if (candidates.length >= candidateLimit) return;
   if (value === undefined || value === null) return;
   candidates.push({{source, value}});
 }};
@@ -1464,14 +1497,50 @@ const parseJson = value => {{
   if (typeof value !== 'string') return value;
   try {{ return JSON.parse(value); }} catch (err) {{ return value; }}
 }};
-const pushRuntimePolicyParameterCandidate = (source, value) => {{
+const fieldMayContainRuntimePolicyParameters = key => {{
+  if (typeof key !== 'string' || !key) return false;
+  const lower = key.toLowerCase();
+  return lower.includes('runtime')
+    || key === 'data'
+    || key === 'value'
+    || key === 'memory'
+    || key === 'Memory'
+    || key === '$activeWorld'
+    || key === 'activeWorld'
+    || /^shard[\\w-]*$/i.test(key);
+}};
+const pushRuntimePolicyParameterCandidate = (source, value, depth = 0) => {{
+  if (depth > 6 || candidates.length >= candidateLimit) return;
   const parsed = parseJson(value);
   if (!parsed || typeof parsed !== 'object') return;
   if (parsed.type === {json.dumps(RUNTIME_PARAMETER_CONSUMPTION_TYPE)}) {{
     pushCandidate(source, parsed);
   }}
-  if (parsed.rlRuntimePolicyParameters !== undefined) {{
-    pushCandidate(source + '.rlRuntimePolicyParameters', parsed.rlRuntimePolicyParameters);
+  for (const key of [
+    {json.dumps(RUNTIME_PARAMETER_CONSUMPTION_GLOBAL)},
+    'rlRuntimePolicyParameters',
+    'runtimeParameterConsumption',
+    'runtimePolicyParameterConsumption',
+    'data',
+    'memory',
+    'Memory',
+    'value',
+    'evidence'
+  ]) {{
+    if (parsed[key] !== undefined) {{
+      pushRuntimePolicyParameterCandidate(source + '.' + key, parsed[key], depth + 1);
+    }}
+  }}
+  for (const [key, nested] of Object.entries(parsed)) {{
+    if (fieldMayContainRuntimePolicyParameters(key)) {{
+      pushRuntimePolicyParameterCandidate(source + '.' + key, nested, depth + 1);
+    }}
+    if (candidates.length >= candidateLimit) return;
+  }}
+  if (Array.isArray(parsed.candidates)) {{
+    parsed.candidates.forEach((item, index) => {{
+      pushRuntimePolicyParameterCandidate(source + '.candidates[' + index + ']', item, depth + 1);
+    }});
   }}
 }};
 if (user) {{

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -1509,6 +1509,17 @@ const fieldMayContainRuntimePolicyParameters = key => {{
     || key === 'activeWorld'
     || /^shard[\\w-]*$/i.test(key);
 }};
+const predefinedKeys = new Set([
+  {json.dumps(RUNTIME_PARAMETER_CONSUMPTION_GLOBAL)},
+  'rlRuntimePolicyParameters',
+  'runtimeParameterConsumption',
+  'runtimePolicyParameterConsumption',
+  'data',
+  'memory',
+  'Memory',
+  'value',
+  'evidence'
+]);
 const pushRuntimePolicyParameterCandidate = (source, value, depth = 0) => {{
   if (depth > 6 || candidates.length >= candidateLimit) return;
   const parsed = parseJson(value);
@@ -1516,28 +1527,23 @@ const pushRuntimePolicyParameterCandidate = (source, value, depth = 0) => {{
   if (parsed.type === {json.dumps(RUNTIME_PARAMETER_CONSUMPTION_TYPE)}) {{
     pushCandidate(source, parsed);
   }}
-  for (const key of [
-    {json.dumps(RUNTIME_PARAMETER_CONSUMPTION_GLOBAL)},
-    'rlRuntimePolicyParameters',
-    'runtimeParameterConsumption',
-    'runtimePolicyParameterConsumption',
-    'data',
-    'memory',
-    'Memory',
-    'value',
-    'evidence'
-  ]) {{
+  for (const key of predefinedKeys) {{
     if (parsed[key] !== undefined) {{
       pushRuntimePolicyParameterCandidate(source + '.' + key, parsed[key], depth + 1);
     }}
   }}
   for (const [key, nested] of Object.entries(parsed)) {{
-    if (fieldMayContainRuntimePolicyParameters(key)) {{
+    if (!predefinedKeys.has(key) && fieldMayContainRuntimePolicyParameters(key)) {{
       pushRuntimePolicyParameterCandidate(source + '.' + key, nested, depth + 1);
     }}
     if (candidates.length >= candidateLimit) return;
   }}
-  if (Array.isArray(parsed.candidates)) {{
+  if (Array.isArray(parsed)) {{
+    for (let index = 0; index < parsed.length; index += 1) {{
+      pushRuntimePolicyParameterCandidate(source + '[' + index + ']', parsed[index], depth + 1);
+      if (candidates.length >= candidateLimit) return;
+    }}
+  }} else if (Array.isArray(parsed.candidates)) {{
     parsed.candidates.forEach((item, index) => {{
       pushRuntimePolicyParameterCandidate(source + '.candidates[' + index + ']', item, depth + 1);
     }});

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -2615,9 +2615,9 @@ cli:
         self.assertIsNone(extracted)
         self.assertIsNotNone(smoke.command)
         eval_script = smoke.command[-3] if smoke.command is not None else ""
-        self.assertIn('string.find(fieldLower, "runtime", 1, true) ~= nil', eval_script)
-        self.assertIn('or fieldText == "data"', eval_script)
-        self.assertIn('or fieldText == "value"', eval_script)
+        self.assertIn('string.find(keyLower, "runtime", 1, true) ~= nil', eval_script)
+        self.assertIn('or keyText == "data"', eval_script)
+        self.assertIn('or keyText == "value"', eval_script)
         self.assertIn("fieldMatchesExpectedUsername = keyMatchesExpectedUsername(fieldText)", eval_script)
         self.assertIn(
             "if hashFieldMayContainRuntimePolicyParameters(fieldText) or fieldMatchesExpectedUsername then",
@@ -2626,6 +2626,112 @@ cli:
         self.assertNotIn('string.find(fieldLower, "memory"', eval_script)
         self.assertNotIn("keyMayContainMemory", eval_script)
         self.assertNotIn("or ownerMatched or fieldOwnerMatched", eval_script)
+
+    def test_redis_runtime_parameter_consumption_collector_reads_shard_hash_memory_fields(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+
+        class FakeConfig:
+            shard = "shardX"
+            username = "bot"
+
+        class FakeSmoke:
+            command: list[str] | None = None
+            output_excerpt: str | None = None
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout, output_limit
+                self.command = command
+                eval_script = command[-3]
+                supports_shard_hash_memory = (
+                    "hashFieldMayContainRuntimePolicyParameters(fieldText)" in eval_script
+                    and 'string.match(keyText, "^[Ss]hard[%w_-]+$") ~= nil' in eval_script
+                    and 'keyText == "$activeWorld"' in eval_script
+                )
+                candidates = []
+                if supports_shard_hash_memory:
+                    candidates.append({
+                        "source": "redis.memory:bot.shardX.rlRuntimePolicyParameters",
+                        "value": evidence,
+                    })
+                self.output_excerpt = json.dumps({"ok": True, "candidates": candidates})
+                return {"returncode": 0, "output_excerpt": self.output_excerpt}
+
+        smoke = FakeSmoke()
+
+        extracted = harness._collect_redis_runtime_parameter_consumption_evidence(
+            smoke,
+            ["docker", "compose"],
+            FakeConfig(),
+            None,
+            injection,
+        )
+
+        self.assertEqual(extracted, evidence)
+        self.assertIsNotNone(smoke.command)
+        eval_script = smoke.command[-3] if smoke.command is not None else ""
+        self.assertIn('keyText == "$activeWorld"', eval_script)
+        self.assertIn('string.match(keyText, "^[Ss]hard[%w_-]+$") ~= nil', eval_script)
+
+    def test_redis_runtime_parameter_consumption_collector_reads_shard_string_memory_containers(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+
+        class FakeConfig:
+            shard = "shardX"
+            username = "bot"
+
+        class FakeSmoke:
+            command: list[str] | None = None
+            output_excerpt: str | None = None
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout, output_limit
+                self.command = command
+                eval_script = command[-3]
+                supports_shard_containers = (
+                    "runtimePolicyParameterContainerKey(key)" in eval_script
+                    and "pushRuntimePolicyParameterEvidence(source .. \".\" .. key" in eval_script
+                    and 'string.match(keyText, "^[Ss]hard[%w_-]+$") ~= nil' in eval_script
+                )
+                candidates = []
+                if supports_shard_containers:
+                    candidates.append({
+                        "source": "redis.memory:bot.data.shardX.rlRuntimePolicyParameters",
+                        "value": evidence,
+                    })
+                self.output_excerpt = json.dumps({"ok": True, "candidates": candidates})
+                return {"returncode": 0, "output_excerpt": self.output_excerpt}
+
+        smoke = FakeSmoke()
+
+        extracted = harness._collect_redis_runtime_parameter_consumption_evidence(
+            smoke,
+            ["docker", "compose"],
+            FakeConfig(),
+            None,
+            injection,
+        )
+
+        self.assertEqual(extracted, evidence)
+        self.assertIsNotNone(smoke.command)
+        eval_script = smoke.command[-3] if smoke.command is not None else ""
+        self.assertIn("runtimePolicyParameterContainerKey(key)", eval_script)
+        self.assertIn("pushRuntimePolicyParameterEvidence(source .. \".\" .. key", eval_script)
 
     def test_redis_runtime_parameter_consumption_collector_requires_configured_username(self) -> None:
         class FakeConfig:
@@ -3278,6 +3384,60 @@ cli:
         self.assertNotIn("pushCandidate('users.memory', user.memory)", eval_script)
         self.assertNotIn("pushCandidate(collectionName, record)", eval_script)
         self.assertIn("rlRuntimePolicyParameters", eval_script)
+
+    def test_mongo_runtime_parameter_consumption_collector_reads_shard_memory_containers(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+
+        class FakeConfig:
+            mongo_db = "screeps"
+            username = "bot"
+            shard = "shardX"
+
+        class FakeSmoke:
+            command: list[str] | None = None
+            output_excerpt: str | None = None
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout, output_limit
+                self.command = command
+                eval_script = command[-1]
+                supports_shard_containers = (
+                    "/^shard[\\w-]*$/i.test(key)" in eval_script
+                    and "key === '$activeWorld'" in eval_script
+                    and "pushRuntimePolicyParameterCandidate(source + '.' + key, nested, depth + 1)" in eval_script
+                )
+                candidates = []
+                if supports_shard_containers:
+                    candidates.append({
+                        "source": "users.memory.data.shardX.rlRuntimePolicyParameters",
+                        "value": evidence,
+                    })
+                self.output_excerpt = json.dumps({"ok": True, "candidates": candidates})
+                return {"returncode": 0, "output_excerpt": self.output_excerpt}
+
+        smoke = FakeSmoke()
+
+        extracted = harness._collect_mongo_runtime_parameter_consumption_evidence(
+            smoke,
+            ["docker", "compose"],
+            FakeConfig(),
+            None,
+            injection,
+        )
+
+        self.assertEqual(extracted, evidence)
+        self.assertIsNotNone(smoke.command)
+        eval_script = smoke.command[-1] if smoke.command is not None else ""
+        self.assertIn("/^shard[\\w-]*$/i.test(key)", eval_script)
+        self.assertIn("key === '$activeWorld'", eval_script)
 
     def test_runtime_parameter_summary_separates_upload_from_consumption(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -3439,6 +3439,116 @@ cli:
         self.assertIn("/^shard[\\w-]*$/i.test(key)", eval_script)
         self.assertIn("key === '$activeWorld'", eval_script)
 
+    def test_mongo_runtime_parameter_consumption_collector_dedupes_predefined_keys(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        matching = self.runtime_parameter_consumption_evidence(injection)
+        stale = self.runtime_parameter_consumption_evidence(injection)
+        stale["parameters"] = {
+            **stale["parameters"],
+            "territorySignalWeight": stale["parameters"]["territorySignalWeight"] + 1,
+        }
+
+        class FakeConfig:
+            mongo_db = "screeps"
+            username = "bot"
+            shard = "shardX"
+
+        class FakeSmoke:
+            command: list[str] | None = None
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout, output_limit
+                self.command = command
+                eval_script = command[-1]
+                has_predefined_key_guard = (
+                    "const predefinedKeys = new Set([" in eval_script
+                    and "!predefinedKeys.has(key) && fieldMayContainRuntimePolicyParameters(key)" in eval_script
+                )
+                candidates = [
+                    {
+                        "source": f"users.memory.data.rlRuntimePolicyParameters.{index}",
+                        "value": stale,
+                    }
+                    for index in range(32)
+                ]
+                if has_predefined_key_guard:
+                    candidates = [
+                        *candidates[:31],
+                        {"source": "users.memory.runtimeEvidence", "value": matching},
+                    ]
+                return {"returncode": 0, "output_excerpt": json.dumps({"ok": True, "candidates": candidates})}
+
+        smoke = FakeSmoke()
+
+        extracted = harness._collect_mongo_runtime_parameter_consumption_evidence(
+            smoke,
+            ["docker", "compose"],
+            FakeConfig(),
+            None,
+            injection,
+        )
+
+        self.assertEqual(extracted, matching)
+        self.assertIsNotNone(smoke.command)
+        eval_script = smoke.command[-1] if smoke.command is not None else ""
+        self.assertIn("const predefinedKeys = new Set([", eval_script)
+        self.assertIn("!predefinedKeys.has(key) && fieldMayContainRuntimePolicyParameters(key)", eval_script)
+
+    def test_mongo_runtime_parameter_consumption_collector_traverses_array_payloads(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+
+        class FakeConfig:
+            mongo_db = "screeps"
+            username = "bot"
+            shard = "shardX"
+
+        class FakeSmoke:
+            command: list[str] | None = None
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout, output_limit
+                self.command = command
+                eval_script = command[-1]
+                supports_array_payloads = (
+                    "Array.isArray(parsed)" in eval_script
+                    and "source + '[' + index + ']'" in eval_script
+                )
+                candidates = []
+                if supports_array_payloads:
+                    candidates.append({"source": "users.memory[0]", "value": evidence})
+                return {"returncode": 0, "output_excerpt": json.dumps({"ok": True, "candidates": candidates})}
+
+        smoke = FakeSmoke()
+
+        extracted = harness._collect_mongo_runtime_parameter_consumption_evidence(
+            smoke,
+            ["docker", "compose"],
+            FakeConfig(),
+            None,
+            injection,
+        )
+
+        self.assertEqual(extracted, evidence)
+        self.assertIsNotNone(smoke.command)
+        eval_script = smoke.command[-1] if smoke.command is not None else ""
+        self.assertIn("Array.isArray(parsed)", eval_script)
+        self.assertIn("source + '[' + index + ']'", eval_script)
+
     def test_runtime_parameter_summary_separates_upload_from_consumption(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         consumption = harness.runtime_parameter_consumption_check(injection, None)


### PR DESCRIPTION
## Summary
- restore runtime-parameter consumption evidence collection from shard/activeWorld memory containers in the private simulator harness
- add bounded Redis/Mongo traversal for hash-backed and nested memory evidence shapes
- add regressions for Redis shard hash fields, Redis shard string containers, and Mongo shard memory containers

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/test_screeps_rl_simulator_harness.py`
- `python3 -m unittest scripts.test_screeps_rl_simulator_harness` (122 tests OK)
- `python3 -m unittest scripts.test_screeps_rl_training_runner.RlTrainingRunnerTest.test_runtime_injected_reinforce_parameters_create_candidate_update_artifact scripts.test_screeps_rl_training_runner.RlTrainingRunnerTest.test_runtime_injected_metadata_ranking_materializes_reinforce_update_without_consumption_probe` (2 tests OK)

## Evidence
- Triage note: `/tmp/issue1299-runtime-consumption-codex-triage.md`
- Source Loop A ledger: `runtime-artifacts/rl-control-loop/20260523T175107Z-training-ledger.json`

Refs #1299
