### PR TITLE
fix(rl): prove runtime parameter consumption

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -564,6 +564,8 @@ def runtime_parameter_injection_for_variant(
             "safety": safety_metadata(),
         }
 
+    source_strategy_id = _runtime_parameter_source_strategy_id(strategy_variant)
+    parameter_evidence = strategy_variant.get("parameterEvidence")
     payload = {
         "type": RUNTIME_PARAMETER_INJECTION_TYPE,
         "schemaVersion": SCHEMA_VERSION,
@@ -575,8 +577,9 @@ def runtime_parameter_injection_for_variant(
         "globalName": RUNTIME_PARAMETER_INJECTION_GLOBAL,
         "strategyVariantId": variant_id,
         "candidatePolicyId": strategy_variant.get("candidatePolicyId"),
-        "sourceStrategyId": strategy_variant.get("sourceStrategyId"),
+        "sourceStrategyId": source_strategy_id,
         "family": strategy_variant.get("family"),
+        "parameterEvidence": copy.deepcopy(parameter_evidence) if isinstance(parameter_evidence, dict) else None,
         "parameters": copy.deepcopy(parameters),
         "parametersSha256": runtime_parameter_parameters_hash(parameters),
         "liveEffect": False,
@@ -585,6 +588,26 @@ def runtime_parameter_injection_for_variant(
         "safety": safety_metadata(),
     }
     return {key: value for key, value in payload.items() if value is not None}
+
+
+def _runtime_parameter_source_strategy_id(strategy_variant: Mapping[str, Any]) -> str | None:
+    direct = strategy_variant.get("sourceStrategyId")
+    if isinstance(direct, str) and direct:
+        return direct
+    snake = strategy_variant.get("source_strategy_id")
+    if isinstance(snake, str) and snake:
+        return snake
+    evidence = strategy_variant.get("parameterEvidence")
+    if not isinstance(evidence, Mapping):
+        evidence = strategy_variant.get("parameter_evidence")
+    if isinstance(evidence, Mapping):
+        evidence_source = evidence.get("sourceStrategyId")
+        if isinstance(evidence_source, str) and evidence_source:
+            return evidence_source
+        evidence_snake = evidence.get("source_strategy_id")
+        if isinstance(evidence_snake, str) and evidence_snake:
+            return evidence_snake
+    return None
 
 
 def apply_runtime_parameter_injection_to_code(code_text: str, injection: JsonObject) -> str:
@@ -2887,6 +2910,9 @@ def _run_runtime_parameter_injection_summary(variant_results: Sequence[JsonObjec
             "runtimeParameterConsumption": injection.get("runtimeParameterConsumption") is True,
             "runtimeParameterConsumptionStatus": injection.get("runtimeParameterConsumptionStatus"),
             "candidateParameterScope": injection.get("candidateParameterScope"),
+            "candidatePolicyId": injection.get("candidatePolicyId"),
+            "sourceStrategyId": injection.get("sourceStrategyId"),
+            "family": injection.get("family"),
             "parametersSha256": injection.get("parametersSha256"),
             "reason": injection.get("runtimeParameterConsumptionReason", injection.get("reason")),
         }

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -565,7 +565,12 @@ def runtime_parameter_injection_for_variant(
         }
 
     source_strategy_id = _runtime_parameter_source_strategy_id(strategy_variant)
+    candidate_policy_id = strategy_variant.get("candidatePolicyId")
+    if candidate_policy_id is None:
+        candidate_policy_id = strategy_variant.get("candidate_policy_id")
     parameter_evidence = strategy_variant.get("parameterEvidence")
+    if not isinstance(parameter_evidence, Mapping):
+        parameter_evidence = strategy_variant.get("parameter_evidence")
     payload = {
         "type": RUNTIME_PARAMETER_INJECTION_TYPE,
         "schemaVersion": SCHEMA_VERSION,
@@ -576,10 +581,10 @@ def runtime_parameter_injection_for_variant(
         "mechanism": RUNTIME_PARAMETER_INJECTION_MECHANISM,
         "globalName": RUNTIME_PARAMETER_INJECTION_GLOBAL,
         "strategyVariantId": variant_id,
-        "candidatePolicyId": strategy_variant.get("candidatePolicyId"),
+        "candidatePolicyId": candidate_policy_id,
         "sourceStrategyId": source_strategy_id,
         "family": strategy_variant.get("family"),
-        "parameterEvidence": copy.deepcopy(parameter_evidence) if isinstance(parameter_evidence, dict) else None,
+        "parameterEvidence": copy.deepcopy(dict(parameter_evidence)) if isinstance(parameter_evidence, Mapping) else None,
         "parameters": copy.deepcopy(parameters),
         "parametersSha256": runtime_parameter_parameters_hash(parameters),
         "liveEffect": False,

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -1181,8 +1181,11 @@ def build_report_runtime_parameter_injection_summary(
                 "reason": injection.get("reason"),
             }
             for field in ("candidatePolicyId", "sourceStrategyId", "family"):
-                if injection.get(field) is not None:
-                    row[field] = copy.deepcopy(injection.get(field))
+                value = injection.get(field)
+                if value is None:
+                    value = result.get(field)
+                if value is not None:
+                    row[field] = copy.deepcopy(value)
             for field in (
                 "runtimeParameterConsumption",
                 "runtimeParameterConsumptionStatus",

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -1180,6 +1180,9 @@ def build_report_runtime_parameter_injection_summary(
                 "parametersSha256": injection.get("parametersSha256"),
                 "reason": injection.get("reason"),
             }
+            for field in ("candidatePolicyId", "sourceStrategyId", "family"):
+                if injection.get(field) is not None:
+                    row[field] = copy.deepcopy(injection.get(field))
             for field in (
                 "runtimeParameterConsumption",
                 "runtimeParameterConsumptionStatus",
@@ -4549,6 +4552,9 @@ def summarize_runtime_parameter_injection_attempt(
         "status": injection.get("status"),
         "runtimeParameterInjection": False,
         "candidateParameterScope": injection.get("candidateParameterScope"),
+        "candidatePolicyId": injection.get("candidatePolicyId"),
+        "sourceStrategyId": injection.get("sourceStrategyId"),
+        "family": injection.get("family"),
         "parametersSha256": injection.get("parametersSha256"),
         "reason": injection.get("reason"),
     }
@@ -4768,11 +4774,16 @@ def summarize_variant_runtime_parameter_injection(
         scope = "runtime_injected" if attempted_runtime else "metadata_only"
         evaluated_parameters = None
 
+    candidate_policy_id = variant.candidate_policy_id or first_attempt_text(attempts, "candidatePolicyId")
+    source_strategy_id = variant.source_strategy_id or first_attempt_text(attempts, "sourceStrategyId")
+    family = variant.family or first_attempt_text(attempts, "family")
     payload: JsonObject = {
         "type": simulator_harness.RUNTIME_PARAMETER_INJECTION_TYPE,
         "schemaVersion": SCHEMA_VERSION,
         "strategyVariantId": variant.id,
-        "candidatePolicyId": variant.candidate_policy_id,
+        "candidatePolicyId": candidate_policy_id,
+        "sourceStrategyId": source_strategy_id,
+        "family": family,
         "status": status,
         "runtimeParameterInjection": runtime_injected,
         "inlineCandidatesRuntimeInjected": runtime_injected,
@@ -4808,6 +4819,14 @@ def summarize_variant_runtime_parameter_injection(
             if field in first_injected:
                 payload[field] = copy.deepcopy(first_injected.get(field))
     return {key: value for key, value in payload.items() if value is not None}
+
+
+def first_attempt_text(attempts: Sequence[JsonObject], field: str) -> str | None:
+    for attempt in attempts:
+        value = text_or_none(attempt.get(field))
+        if value is not None:
+            return value
+    return None
 
 
 def finalize_multi_tier_policy_activation_run(

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 import threading
 import unittest
+from collections import UserDict
 from pathlib import Path
 from unittest import mock
 
@@ -1502,6 +1503,57 @@ cli:
         self.assertFalse(injection["liveEffect"])
         self.assertFalse(injection["officialMmoWrites"])
         self.assertFalse(injection["officialMmoWritesAllowed"])
+
+    def test_runtime_parameter_injection_preserves_metadata_aliases_and_mapping_evidence(self) -> None:
+        parameters = {
+            "baseScoreWeight": 1,
+            "territorySignalWeight": 22,
+            "resourceSignalWeight": 3,
+            "killSignalWeight": 5,
+            "riskPenalty": 4,
+        }
+        expected_policy_id = "construction-priority.pg.territory-seed.v1"
+        expected_source_id = "construction-priority.territory-shadow.v1"
+        cases = [
+            (
+                "snake-case aliases",
+                {
+                    "candidate_policy_id": expected_policy_id,
+                    "parameter_evidence": {
+                        "source_strategy_id": expected_source_id,
+                        "sampleCount": 3,
+                    },
+                },
+            ),
+            (
+                "mapping evidence",
+                {
+                    "candidatePolicyId": expected_policy_id,
+                    "parameterEvidence": UserDict(
+                        {
+                            "sourceStrategyId": expected_source_id,
+                            "sampleCount": 3,
+                        }
+                    ),
+                },
+            ),
+        ]
+
+        for label, metadata in cases:
+            with self.subTest(label=label):
+                variant = {
+                    "id": expected_policy_id,
+                    "family": "construction-priority",
+                    "parameters": parameters,
+                    **metadata,
+                }
+                injection = harness.runtime_parameter_injection_for_variant(variant["id"], variant)
+
+                self.assertEqual(injection["candidatePolicyId"], expected_policy_id)
+                self.assertEqual(injection["sourceStrategyId"], expected_source_id)
+                self.assertIsInstance(injection["parameterEvidence"], dict)
+                self.assertEqual(injection["parameterEvidence"]["sampleCount"], 3)
+                json.dumps(injection["parameterEvidence"])
 
     def test_runtime_parameter_injection_changes_private_runtime_code_input(self) -> None:
         base_code = (

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1477,6 +1477,9 @@ cli:
                     "title": "Policy-gradient territory seed scale environment 1",
                     "candidatePolicyId": "construction-priority.pg.territory-seed.v1",
                     "family": "construction-priority",
+                    "parameterEvidence": {
+                        "sourceStrategyId": "construction-priority.territory-shadow.v1",
+                    },
                     "parameters": parameters,
                 }
             },
@@ -1489,6 +1492,11 @@ cli:
         self.assertEqual(config["defaultValues"], parameters)
         self.assertEqual(injection["status"], "prepared")
         self.assertEqual(injection["candidateParameterScope"], "runtime_injected")
+        self.assertEqual(injection["sourceStrategyId"], "construction-priority.territory-shadow.v1")
+        self.assertEqual(
+            injection["parameterEvidence"]["sourceStrategyId"],
+            "construction-priority.territory-shadow.v1",
+        )
         self.assertEqual(injection["parameters"], parameters)
         self.assertNotIn("reason", injection)
         self.assertFalse(injection["liveEffect"])

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -2209,6 +2209,38 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(summary["variantCount"], 1)
         self.assertEqual([row["variantId"] for row in summary["variants"]], ["variant-a"])
 
+    def test_runtime_parameter_report_summary_preserves_sparse_injection_provenance(self) -> None:
+        summary = runner.build_report_runtime_parameter_injection_summary(
+            [
+                {
+                    "variantId": "variant-a",
+                    "candidatePolicyId": "candidate-a",
+                    "sourceStrategyId": "source-a",
+                    "family": "test-family",
+                    "runtimeParameterInjection": {
+                        "status": "partial",
+                        "runtimeParameterInjection": False,
+                        "candidateParameterScope": "partial_runtime_injection",
+                        "reason": "successful simulator attempt did not report consumption",
+                    },
+                },
+            ],
+            [
+                runner.StrategyVariant(
+                    id="variant-a",
+                    candidate_policy_id="candidate-a",
+                    source_strategy_id="source-a",
+                    family="test-family",
+                    parameters={"knob": 1},
+                )
+            ],
+        )
+
+        row = summary["variants"][0]
+        self.assertEqual(row["candidatePolicyId"], "candidate-a")
+        self.assertEqual(row["sourceStrategyId"], "source-a")
+        self.assertEqual(row["family"], "test-family")
+
     def test_policy_update_candidate_rows_accepts_candidate_policy_id_only_vectors(self) -> None:
         parameter_space = {"knob": {"min": 0, "max": 10}}
         rows = runner.policy_update_candidate_rows(

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -4146,6 +4146,10 @@ export const STRATEGY_REGISTRY = [
             base_id: runner.canonical_hash(parameters)
             for base_id, parameters in expected_parameters_by_base_id.items()
         }
+        expected_source_by_base_id = {
+            candidate["strategyVariantId"]: candidate["sourceStrategyId"]
+            for candidate in card["policy_gradient"]["candidate_parameter_vectors"]
+        }
         observed_hashes_by_base_id: dict[str, str] = {}
         for scaled_variant_id in expanded_ids:
             scaled_config = runner.simulator_harness.strategy_variant_config_by_id(
@@ -4159,6 +4163,7 @@ export const STRATEGY_REGISTRY = [
                 runner.canonical_hash(scaled_config["parameters"]),
                 expected_hashes_by_base_id[base_variant_id],
             )
+            self.assertEqual(scaled_config["sourceStrategyId"], expected_source_by_base_id[base_variant_id])
             self.assertEqual(scaled_config["scaleEnvironment"]["baseVariantId"], base_variant_id)
             observed_hashes_by_base_id[base_variant_id] = runner.canonical_hash(
                 scaled_config["parameters"]
@@ -4169,6 +4174,23 @@ export const STRATEGY_REGISTRY = [
         self.assertTrue(report["runtimeParameterInjection"]["runtimeParameterInjection"])
         self.assertEqual(report["runtimeParameterInjection"]["candidateParameterScope"], "runtime_injected")
         self.assertEqual(report["runtimeParameterInjection"]["injectedVariantCount"], len(expanded_ids))
+        report_rows = {
+            row["variantId"]: row
+            for row in report["runtimeParameterInjection"]["variants"]
+        }
+        self.assertEqual(
+            report_rows["construction-priority.pg.resource-seed.v1.scale-env-03"]["sourceStrategyId"],
+            "construction-priority.incumbent.v1",
+        )
+        resource_result = next(
+            item
+            for item in report["variantResults"]
+            if item["variantId"] == "construction-priority.pg.resource-seed.v1.scale-env-03"
+        )
+        self.assertEqual(
+            resource_result["runtimeParameterInjection"]["sourceStrategyId"],
+            "construction-priority.incumbent.v1",
+        )
         self.assertTrue(report["runtimeParameterInjection"]["policyUpdateEligible"])
         self.assertEqual(report["policyGradient"]["runner_support"]["candidate_parameter_scope"], "runtime_injected")
         self.assertTrue(report["policyUpdate"]["parameterEvidence"]["runtimeParameterInjection"])


### PR DESCRIPTION
## Summary

Refs #1299.

- propagate policy-gradient `sourceStrategyId` into runtime-parameter injection payloads, including scaled private-simulator variants derived from candidate cards
- carry candidate/source/family metadata into runtime-injection report rows and variant-level summaries so scorecard materialization can match consumed runtime evidence back to the source strategy
- add regression coverage for the post-#1366 failure where runtime injection was true but consumption stayed false because the injected payload no longer matched the runtime strategy registry

## Verification

Controller-side verification on commit `35904130edfdb84ae4bd475edec5d33f22a9806f`:

```text
git diff --check HEAD^..HEAD
python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py
python3 -m unittest scripts.test_screeps_rl_simulator_harness scripts.test_screeps_rl_training_runner
```

Result: 238 unittest tests passed.

## Notes

No new Tencent/local paid training run was launched. Follow-up validation should rerun/observe the existing RL validation flow after this lands to confirm future scorecards report `runtimeParameterConsumption=true` or a machine-readable no-op classification instead of `runtime_parameter_consumption_missing_scorecard_materialized`.
