### PR TITLE
fix(rl): self-heal Tencent SSH host key mismatches

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -486,11 +486,62 @@ class Controller:
                 if check:
                     raise BatchRunError(ssh_prepare_failure_message(name, prepare_result))
                 return cp
-        return self.run_cp(name, cmd, check=check, timeout=timeout)
+        return self.run_worker_transport_cp(name, cmd, check=check, timeout=timeout)
+
+    def run_worker_transport_cp(
+        self,
+        name: str,
+        cmd: Sequence[str],
+        *,
+        check: bool = True,
+        timeout: int | None = 600,
+    ) -> subprocess.CompletedProcess[str]:
+        cp = self.run_cp(name, cmd, check=False, timeout=timeout)
+        if cp.returncode == 0:
+            return cp
+
+        if classify_ssh_process_failure(cp) == "host_key_mismatch":
+            heal_result = self.self_heal_worker_known_host_after_mismatch()
+            if heal_result.ok:
+                cp = self.run_cp(name, cmd, check=False, timeout=timeout)
+            else:
+                cp = ssh_prepare_failure_completed_process(cmd, heal_result)
+                started = time.time()
+                self.record_step(
+                    name,
+                    started,
+                    False,
+                    cp,
+                    argv=redacted_argv(cmd),
+                    sshFailureClass=heal_result.status,
+                    retryable=heal_result.retryable,
+                    selfHealedAfterHostKeyMismatch=False,
+                )
+                if check:
+                    raise BatchRunError(ssh_prepare_failure_message(name, heal_result))
+                return cp
+
+        if check and cp.returncode != 0:
+            raise BatchRunError(f"{name} failed with exit {cp.returncode}: {tail_text(cp.stderr or cp.stdout)}")
+        return cp
+
+    def self_heal_worker_known_host_after_mismatch(self) -> KnownHostPrepareResult:
+        if not self.public_ip:
+            return KnownHostPrepareResult(False, "host_key_self_healing_failed", reason="public IP is not known")
+        self.known_hosts_prepared_public_ips.discard(self.public_ip)
+        self.known_hosts_cleaned_public_ips.discard(self.public_ip)
+        if not self.clear_worker_known_host():
+            return KnownHostPrepareResult(
+                False,
+                "host_key_self_healing_failed",
+                reason="ssh-keygen failed while clearing stale known_hosts after host-key mismatch",
+            )
+        self.known_hosts_prepared_public_ips.discard(self.public_ip)
+        return self.prepare_worker_known_host()
 
     def scp_to_worker(self, name: str, local_path: Path, remote_path: str, *, timeout: int = 300) -> None:
         self.require_worker_known_host_prepared(name)
-        self.run_cp(
+        self.run_worker_transport_cp(
             name,
             [
                 "scp",
@@ -505,7 +556,7 @@ class Controller:
     def scp_from_worker(self, name: str, remote_path: str, local_path: Path, *, timeout: int = 900) -> None:
         self.require_worker_known_host_prepared(name)
         local_path.parent.mkdir(parents=True, exist_ok=True)
-        self.run_cp(
+        self.run_worker_transport_cp(
             name,
             [
                 "scp",

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -530,14 +530,13 @@ class Controller:
             return KnownHostPrepareResult(False, "host_key_self_healing_failed", reason="public IP is not known")
         self.known_hosts_prepared_public_ips.discard(self.public_ip)
         self.known_hosts_cleaned_public_ips.discard(self.public_ip)
-        if not self.clear_worker_known_host():
-            return KnownHostPrepareResult(
-                False,
-                "host_key_self_healing_failed",
-                reason="ssh-keygen failed while clearing stale known_hosts after host-key mismatch",
-            )
-        self.known_hosts_prepared_public_ips.discard(self.public_ip)
-        return self.prepare_worker_known_host()
+        scan_result, scanned_lines = self.scan_worker_host_keys()
+        if not scan_result.ok:
+            reason = "host-key mismatch remains blocked because ssh-keyscan could not verify replacement keys"
+            if scan_result.reason:
+                reason = f"{reason}: {scan_result.reason}"
+            return KnownHostPrepareResult(False, "host_key_self_healing_failed", reason=reason)
+        return self.install_worker_known_host(scanned_lines, had_plain_entry=False)
 
     def scp_to_worker(self, name: str, local_path: Path, remote_path: str, *, timeout: int = 300) -> None:
         self.require_worker_known_host_prepared(name)

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -4302,6 +4302,138 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 self.assertIn("StrictHostKeyChecking=yes", cmd)
                 self.assertIn(f"UserKnownHostsFile={args.known_hosts_path}", cmd)
 
+    def test_ssh_cmd_self_heals_mismatched_known_host_then_retries_strictly(self) -> None:
+        stale_key = "203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIstale"
+        current_key = "203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIcurrent"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args = controller_args()
+            args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
+            known_hosts = Path(args.known_hosts_path)
+            known_hosts.write_text(stale_key + "\n", encoding="utf-8")
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
+            controller.public_ip = "203.0.113.10"
+            controller.known_hosts_prepared_public_ips.add("203.0.113.10")
+            keyscan_calls = 0
+            operation_commands: list[list[str]] = []
+
+            def fake_run_cp(
+                name: str,
+                cmd: list[str],
+                *,
+                check: bool = True,
+                timeout: int | None = None,
+                cwd: Path | None = None,
+                input_text: str | None = None,
+                env: dict[str, str] | None = None,
+            ) -> subprocess.CompletedProcess[str]:
+                operation_commands.append(cmd)
+                if len(operation_commands) == 1:
+                    stderr = "REMOTE HOST IDENTIFICATION HAS CHANGED!\nOffending ED25519 key in known_hosts:1\n"
+                    return subprocess.CompletedProcess(cmd, 255, "", stderr)
+                return subprocess.CompletedProcess(cmd, 0, "ok\n", "")
+
+            def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                nonlocal keyscan_calls
+                if cmd[0] == "ssh-keygen":
+                    known_hosts.write_text("", encoding="utf-8")
+                    return subprocess.CompletedProcess(cmd, 0, "# Host 203.0.113.10 found: line 1\nknown_hosts updated.\n", "")
+                if cmd[0] == "ssh-keyscan":
+                    keyscan_calls += 1
+                    if keyscan_calls < 3:
+                        return subprocess.CompletedProcess(cmd, 1, "", "")
+                    return subprocess.CompletedProcess(cmd, 0, current_key + "\n", "")
+                raise AssertionError(cmd)
+
+            with (
+                mock.patch.object(controller, "run_cp", side_effect=fake_run_cp),
+                mock.patch.object(runner.subprocess, "run", side_effect=fake_run),
+                mock.patch.object(runner.time, "sleep", return_value=None) as sleep,
+            ):
+                cp = controller.ssh_cmd("ssh_probe", "true")
+
+            self.assertEqual(cp.returncode, 0)
+            self.assertEqual(known_hosts.read_text(encoding="utf-8"), current_key + "\n")
+
+        self.assertEqual(keyscan_calls, 3)
+        sleep.assert_has_calls([mock.call(2.0), mock.call(5.0)])
+        self.assertEqual([cmd[0] for cmd in operation_commands], ["ssh", "ssh"])
+        for cmd in operation_commands:
+            with self.subTest(command=cmd):
+                self.assertIn("StrictHostKeyChecking=yes", cmd)
+                self.assertIn(f"UserKnownHostsFile={args.known_hosts_path}", cmd)
+                self.assertNotIn("StrictHostKeyChecking=no", cmd)
+                self.assertNotIn("StrictHostKeyChecking=accept-new", cmd)
+        self.assertEqual(
+            [step.name for step in controller.steps],
+            [
+                "clear_worker_known_host",
+                "scan_worker_host_key",
+                "scan_worker_host_key",
+                "scan_worker_host_key",
+                "install_worker_known_host",
+            ],
+        )
+        self.assertIn("203.0.113.10", controller.known_hosts_prepared_public_ips)
+
+    def test_scp_to_worker_self_heals_mismatched_known_host_then_retries_strictly(self) -> None:
+        stale_key = "203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIstale"
+        current_key = "203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIcurrent"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args = controller_args()
+            args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
+            known_hosts = Path(args.known_hosts_path)
+            known_hosts.write_text(stale_key + "\n", encoding="utf-8")
+            local_path = Path(temp_dir) / "local.txt"
+            local_path.write_text("payload\n", encoding="utf-8")
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
+            controller.public_ip = "203.0.113.10"
+            controller.known_hosts_prepared_public_ips.add("203.0.113.10")
+            operation_commands: list[list[str]] = []
+
+            def fake_run_cp(
+                name: str,
+                cmd: list[str],
+                *,
+                check: bool = True,
+                timeout: int | None = None,
+                cwd: Path | None = None,
+                input_text: str | None = None,
+                env: dict[str, str] | None = None,
+            ) -> subprocess.CompletedProcess[str]:
+                operation_commands.append(cmd)
+                if len(operation_commands) == 1:
+                    return subprocess.CompletedProcess(cmd, 255, "", "Host key verification failed.\n")
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+
+            def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                if cmd[0] == "ssh-keygen":
+                    known_hosts.write_text("", encoding="utf-8")
+                    return subprocess.CompletedProcess(cmd, 0, "# Host 203.0.113.10 found: line 1\nknown_hosts updated.\n", "")
+                if cmd[0] == "ssh-keyscan":
+                    return subprocess.CompletedProcess(cmd, 0, current_key + "\n", "")
+                raise AssertionError(cmd)
+
+            with (
+                mock.patch.object(controller, "run_cp", side_effect=fake_run_cp),
+                mock.patch.object(runner.subprocess, "run", side_effect=fake_run),
+            ):
+                controller.scp_to_worker("upload", local_path, "/remote/local.txt")
+
+            self.assertEqual(known_hosts.read_text(encoding="utf-8"), current_key + "\n")
+
+        self.assertEqual([cmd[0] for cmd in operation_commands], ["scp", "scp"])
+        for cmd in operation_commands:
+            with self.subTest(command=cmd):
+                self.assertIn("StrictHostKeyChecking=yes", cmd)
+                self.assertIn(f"UserKnownHostsFile={args.known_hosts_path}", cmd)
+                self.assertNotIn("StrictHostKeyChecking=no", cmd)
+                self.assertNotIn("StrictHostKeyChecking=accept-new", cmd)
+        self.assertEqual(
+            [step.name for step in controller.steps],
+            ["clear_worker_known_host", "scan_worker_host_key", "install_worker_known_host"],
+        )
+        self.assertIn("203.0.113.10", controller.known_hosts_prepared_public_ips)
+
     def test_known_host_cleanup_warning_redacts_secret_and_host_key_output(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             args = controller_args()

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -4367,7 +4367,6 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(
             [step.name for step in controller.steps],
             [
-                "clear_worker_known_host",
                 "scan_worker_host_key",
                 "scan_worker_host_key",
                 "scan_worker_host_key",
@@ -4375,6 +4374,69 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             ],
         )
         self.assertIn("203.0.113.10", controller.known_hosts_prepared_public_ips)
+
+    def test_ssh_cmd_mismatch_blocks_accept_new_when_keyscan_unavailable(self) -> None:
+        stale_key = "203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIstale"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args = controller_args()
+            args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
+            known_hosts = Path(args.known_hosts_path)
+            known_hosts.write_text(stale_key + "\n", encoding="utf-8")
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
+            controller.public_ip = "203.0.113.10"
+            controller.known_hosts_prepared_public_ips.add("203.0.113.10")
+            keyscan_calls = 0
+            operation_commands: list[list[str]] = []
+
+            def fake_run_cp(
+                name: str,
+                cmd: list[str],
+                *,
+                check: bool = True,
+                timeout: int | None = None,
+                cwd: Path | None = None,
+                input_text: str | None = None,
+                env: dict[str, str] | None = None,
+            ) -> subprocess.CompletedProcess[str]:
+                self.assertIs(check, False)
+                operation_commands.append(cmd)
+                stderr = "REMOTE HOST IDENTIFICATION HAS CHANGED!\nOffending ED25519 key in known_hosts:1\n"
+                return subprocess.CompletedProcess(cmd, 255, "", stderr)
+
+            def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                nonlocal keyscan_calls
+                if cmd[0] == "ssh-keyscan":
+                    keyscan_calls += 1
+                    return subprocess.CompletedProcess(cmd, 1, "", "")
+                raise AssertionError(cmd)
+
+            with (
+                mock.patch.object(controller, "run_cp", side_effect=fake_run_cp),
+                mock.patch.object(runner.subprocess, "run", side_effect=fake_run),
+                mock.patch.object(runner.time, "sleep", return_value=None) as sleep,
+            ):
+                cp = controller.ssh_cmd("ssh_probe", "true", check=False)
+
+            self.assertEqual(cp.returncode, 255)
+            self.assertIn("host_key_self_healing_failed", cp.stderr)
+            self.assertIn("host-key mismatch remains blocked", cp.stderr)
+            self.assertEqual(known_hosts.read_text(encoding="utf-8"), stale_key + "\n")
+
+        self.assertEqual(keyscan_calls, 3)
+        sleep.assert_has_calls([mock.call(2.0), mock.call(5.0)])
+        self.assertEqual([cmd[0] for cmd in operation_commands], ["ssh"])
+        self.assertEqual(
+            [step.name for step in controller.steps],
+            [
+                "scan_worker_host_key",
+                "scan_worker_host_key",
+                "scan_worker_host_key",
+                "ssh_probe",
+            ],
+        )
+        self.assertEqual(controller.steps[-1].detail["sshFailureClass"], "host_key_self_healing_failed")
+        self.assertFalse(controller.steps[-1].detail["retryable"])
+        self.assertNotIn("203.0.113.10", controller.known_hosts_prepared_public_ips)
 
     def test_scp_to_worker_self_heals_mismatched_known_host_then_retries_strictly(self) -> None:
         stale_key = "203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIstale"
@@ -4432,7 +4494,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 self.assertNotIn("StrictHostKeyChecking=accept-new", cmd)
         self.assertEqual(
             [step.name for step in controller.steps],
-            ["clear_worker_known_host", "scan_worker_host_key", "install_worker_known_host"],
+            ["scan_worker_host_key", "install_worker_known_host"],
         )
         self.assertIn("203.0.113.10", controller.known_hosts_prepared_public_ips)
 

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -4326,6 +4326,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 input_text: str | None = None,
                 env: dict[str, str] | None = None,
             ) -> subprocess.CompletedProcess[str]:
+                self.assertIs(check, False)
                 operation_commands.append(cmd)
                 if len(operation_commands) == 1:
                     stderr = "REMOTE HOST IDENTIFICATION HAS CHANGED!\nOffending ED25519 key in known_hosts:1\n"
@@ -4400,6 +4401,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 input_text: str | None = None,
                 env: dict[str, str] | None = None,
             ) -> subprocess.CompletedProcess[str]:
+                self.assertIs(check, False)
                 operation_commands.append(cmd)
                 if len(operation_commands) == 1:
                     return subprocess.CompletedProcess(cmd, 255, "", "Host key verification failed.\n")


### PR DESCRIPTION
## Summary
- Adds a strict SSH/SCP transport retry path that detects host-key mismatch failures, clears the stale worker known_hosts entry, rescans the worker key, reinstalls it, and retries the original strict command.
- Routes `scp_to_worker` and `scp_from_worker` through the same self-healing transport path used by `ssh_cmd`.
- Adds focused regression coverage proving strict host-key checking remains enabled and no `accept-new` / disabled checking fallback is used.

## Verification
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts.test_screeps_tencent_batch_rl_runner -q` (107 tests OK)
- `git diff --check -- scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`

## Safety
- Offline/Tencent runner code only; no official MMO writes.
- No secrets printed; host-key output remains redacted in step summaries.
- Existing active Tencent batch `tencent-pg-20260523t221005z` was not interrupted and no duplicate paid compute was launched.

Fixes #1336
Refs #879 #1032 #1233 #893
