### PR TITLE
fix(rl): emit runtime parameter consumption evidence

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -47593,19 +47593,19 @@ function buildRolloutDetails(strategyId, historicalReplay, failedPrerequisites) 
 var kernel = new Kernel();
 var strategyRolloutConfig = DEFAULT_KPI_ROLLOUT_MONITOR_CONFIG;
 var kpiWindowMaxLength = 120;
-var runtimePolicyParameters = applyRuntimePolicyParametersToRegistry(DEFAULT_STRATEGY_REGISTRY);
-var runtimePolicyParameterPlanningEnabled = runtimePolicyParameters.evidence.runtimeParameterInjection === true && runtimePolicyParameters.evidence.appliedStrategyIds.length > 0;
 var strategyRegistryState = {
-  entries: runtimePolicyParameters.registry
+  entries: DEFAULT_STRATEGY_REGISTRY
 };
 var recentKpiWindows = {};
 var baselineKpiWindows = {};
 function loop() {
+  const runtimePolicyParameters = applyRuntimePolicyParametersToRegistry(strategyRegistryState.entries);
+  const runtimePolicyParameterPlanningEnabled = runtimePolicyParameters.evidence.runtimeParameterInjection === true && runtimePolicyParameters.evidence.appliedStrategyIds.length > 0;
   const runtimePolicyParameterConsumption = createRuntimePolicyParameterConsumptionRecorder();
   let summary;
   try {
     summary = kernel.run({
-      strategyRegistry: strategyRegistryState.entries,
+      strategyRegistry: runtimePolicyParameters.registry,
       ...runtimePolicyParameterPlanningEnabled ? {
         runtimeStrategyConstructionEnabled: true,
         onStrategyRegistryRuntimeUse: runtimePolicyParameterConsumption.recordStrategyRuntimeUse
@@ -47614,7 +47614,7 @@ function loop() {
   } finally {
     persistRuntimePolicyParameterConsumptionEvidence(runtimePolicyParameterConsumption.buildEvidence());
   }
-  strategyRegistryState.entries = runStrategyRolloutMonitoring(summary, strategyRegistryState.entries);
+  strategyRegistryState.entries = runStrategyRolloutMonitoring(summary, runtimePolicyParameters.registry);
 }
 function runStrategyRolloutMonitoring(summary, registry) {
   let workingRegistry = applyPendingRollbacks(registry);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -47600,21 +47600,24 @@ var recentKpiWindows = {};
 var baselineKpiWindows = {};
 function loop() {
   const runtimePolicyParameters = applyRuntimePolicyParametersToRegistry(strategyRegistryState.entries);
-  const runtimePolicyParameterPlanningEnabled = runtimePolicyParameters.evidence.runtimeParameterInjection === true && runtimePolicyParameters.evidence.appliedStrategyIds.length > 0;
+  const hasPatchedRuntimeStrategies = runtimePolicyParameters.evidence.appliedStrategyIds.length > 0;
+  const runtimePolicyParameterPlanningEnabled = runtimePolicyParameters.evidence.runtimeParameterInjection === true && hasPatchedRuntimeStrategies;
   const runtimePolicyParameterConsumption = createRuntimePolicyParameterConsumptionRecorder();
   let summary;
   try {
     summary = kernel.run({
       strategyRegistry: runtimePolicyParameters.registry,
       ...runtimePolicyParameterPlanningEnabled ? {
-        runtimeStrategyConstructionEnabled: true,
+        runtimeStrategyConstructionEnabled: true
+      } : {},
+      ...hasPatchedRuntimeStrategies ? {
         onStrategyRegistryRuntimeUse: runtimePolicyParameterConsumption.recordStrategyRuntimeUse
       } : {}
     });
   } finally {
     persistRuntimePolicyParameterConsumptionEvidence(runtimePolicyParameterConsumption.buildEvidence());
   }
-  strategyRegistryState.entries = runStrategyRolloutMonitoring(summary, runtimePolicyParameters.registry);
+  strategyRegistryState.entries = runStrategyRolloutMonitoring(summary, strategyRegistryState.entries);
 }
 function runStrategyRolloutMonitoring(summary, registry) {
   let workingRegistry = applyPendingRollbacks(registry);

--- a/prod/src/main.ts
+++ b/prod/src/main.ts
@@ -37,22 +37,22 @@ export { DEFAULT_VARIANCE_CONFIG, VarianceConfig, injectStrategyVariance } from 
 const kernel = new Kernel();
 const strategyRolloutConfig = DEFAULT_KPI_ROLLOUT_MONITOR_CONFIG;
 const kpiWindowMaxLength = 120;
-const runtimePolicyParameters = applyRuntimePolicyParametersToRegistry(DEFAULT_STRATEGY_REGISTRY);
-const runtimePolicyParameterPlanningEnabled =
-  runtimePolicyParameters.evidence.runtimeParameterInjection === true &&
-  runtimePolicyParameters.evidence.appliedStrategyIds.length > 0;
 const strategyRegistryState = {
-  entries: runtimePolicyParameters.registry
+  entries: DEFAULT_STRATEGY_REGISTRY
 };
 const recentKpiWindows: KpiWindowHistory = {};
 const baselineKpiWindows: KpiWindowHistory = {};
 
 export function loop(): void {
+  const runtimePolicyParameters = applyRuntimePolicyParametersToRegistry(strategyRegistryState.entries);
+  const runtimePolicyParameterPlanningEnabled =
+    runtimePolicyParameters.evidence.runtimeParameterInjection === true &&
+    runtimePolicyParameters.evidence.appliedStrategyIds.length > 0;
   const runtimePolicyParameterConsumption = createRuntimePolicyParameterConsumptionRecorder();
   let summary: RuntimeSummary | undefined;
   try {
     summary = kernel.run({
-      strategyRegistry: strategyRegistryState.entries,
+      strategyRegistry: runtimePolicyParameters.registry,
       ...(runtimePolicyParameterPlanningEnabled
         ? {
             runtimeStrategyConstructionEnabled: true,
@@ -63,7 +63,7 @@ export function loop(): void {
   } finally {
     persistRuntimePolicyParameterConsumptionEvidence(runtimePolicyParameterConsumption.buildEvidence());
   }
-  strategyRegistryState.entries = runStrategyRolloutMonitoring(summary, strategyRegistryState.entries);
+  strategyRegistryState.entries = runStrategyRolloutMonitoring(summary, runtimePolicyParameters.registry);
 }
 
 function runStrategyRolloutMonitoring(

--- a/prod/src/main.ts
+++ b/prod/src/main.ts
@@ -45,9 +45,9 @@ const baselineKpiWindows: KpiWindowHistory = {};
 
 export function loop(): void {
   const runtimePolicyParameters = applyRuntimePolicyParametersToRegistry(strategyRegistryState.entries);
+  const hasPatchedRuntimeStrategies = runtimePolicyParameters.evidence.appliedStrategyIds.length > 0;
   const runtimePolicyParameterPlanningEnabled =
-    runtimePolicyParameters.evidence.runtimeParameterInjection === true &&
-    runtimePolicyParameters.evidence.appliedStrategyIds.length > 0;
+    runtimePolicyParameters.evidence.runtimeParameterInjection === true && hasPatchedRuntimeStrategies;
   const runtimePolicyParameterConsumption = createRuntimePolicyParameterConsumptionRecorder();
   let summary: RuntimeSummary | undefined;
   try {
@@ -55,7 +55,11 @@ export function loop(): void {
       strategyRegistry: runtimePolicyParameters.registry,
       ...(runtimePolicyParameterPlanningEnabled
         ? {
-            runtimeStrategyConstructionEnabled: true,
+            runtimeStrategyConstructionEnabled: true
+          }
+        : {}),
+      ...(hasPatchedRuntimeStrategies
+        ? {
             onStrategyRegistryRuntimeUse: runtimePolicyParameterConsumption.recordStrategyRuntimeUse
           }
         : {})
@@ -63,7 +67,7 @@ export function loop(): void {
   } finally {
     persistRuntimePolicyParameterConsumptionEvidence(runtimePolicyParameterConsumption.buildEvidence());
   }
-  strategyRegistryState.entries = runStrategyRolloutMonitoring(summary, runtimePolicyParameters.registry);
+  strategyRegistryState.entries = runStrategyRolloutMonitoring(summary, strategyRegistryState.entries);
 }
 
 function runStrategyRolloutMonitoring(

--- a/prod/test/mainRuntimePolicyParameters.test.ts
+++ b/prod/test/mainRuntimePolicyParameters.test.ts
@@ -1,5 +1,9 @@
 import type { KernelRunOptions } from '../src/kernel/Kernel';
+import type { StrategyRegistryEntry } from '../src/strategy/strategyRegistry';
+import { DEFAULT_STRATEGY_REGISTRY } from '../src/strategy/strategyRegistry';
 import {
+  RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER,
+  RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION,
   RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL,
   RUNTIME_POLICY_PARAMETERS_GLOBAL
 } from '../src/strategy/runtimePolicyParameters';
@@ -16,6 +20,7 @@ describe('main runtime policy parameter consumption', () => {
     logSpy.mockRestore();
     jest.resetModules();
     jest.dontMock('../src/kernel/Kernel');
+    jest.dontMock('../src/strategy/runtimePolicyParameters');
     delete (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETERS_GLOBAL];
     delete (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL];
     delete (globalThis as { Memory?: unknown }).Memory;
@@ -102,6 +107,163 @@ describe('main runtime policy parameter consumption', () => {
       tick: 20
     });
   });
+
+  it('keeps runtime-injected registry patches ephemeral after the payload is removed', () => {
+    installScreepsGlobals();
+    const run = jest.fn((_options: KernelRunOptions = {}) => makeRuntimeSummary());
+    mockKernel(run);
+    let main: typeof import('../src/main') | undefined;
+    jest.isolateModules(() => {
+      main = jest.requireActual<typeof import('../src/main')>('../src/main');
+    });
+
+    installRuntimePolicyPayload({ sourceStrategyId: 'construction-priority.territory-shadow.v1' });
+    main?.loop();
+
+    delete (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETERS_GLOBAL];
+    (globalThis as unknown as { Game: Partial<Game> }).Game.time = 21;
+    main?.loop();
+
+    const firstTickOptions = run.mock.calls[0]?.[0];
+    const secondTickOptions = run.mock.calls[1]?.[0];
+    const firstTickIncumbent = firstTickOptions?.strategyRegistry?.find(
+      (candidate) => candidate.id === 'construction-priority.incumbent.v1'
+    );
+    const firstTickShadowCandidate = firstTickOptions?.strategyRegistry?.find(
+      (candidate) => candidate.id === 'construction-priority.territory-shadow.v1'
+    );
+    const secondTickIncumbent = secondTickOptions?.strategyRegistry?.find(
+      (candidate) => candidate.id === 'construction-priority.incumbent.v1'
+    );
+    const secondTickShadowCandidate = secondTickOptions?.strategyRegistry?.find(
+      (candidate) => candidate.id === 'construction-priority.territory-shadow.v1'
+    );
+
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(firstTickIncumbent).toMatchObject({
+      rolloutStatus: 'shadow',
+      defaultValues: expect.objectContaining({ territorySignalWeight: 6 })
+    });
+    expect(firstTickShadowCandidate).toMatchObject({
+      rolloutStatus: 'incumbent',
+      defaultValues: expect.objectContaining({ territorySignalWeight: 29 })
+    });
+    expect(secondTickOptions).not.toHaveProperty('runtimeStrategyConstructionEnabled');
+    expect(secondTickIncumbent).toMatchObject({
+      rolloutStatus: 'incumbent',
+      defaultValues: expect.objectContaining({ territorySignalWeight: 6 })
+    });
+    expect(secondTickShadowCandidate).toMatchObject({
+      rolloutStatus: 'shadow',
+      defaultValues: expect.objectContaining({ territorySignalWeight: 22 })
+    });
+  });
+
+  it('records runtime use when patched strategy ids exist without enabling runtime planning', () => {
+    installScreepsGlobals();
+    const sourceEntry = DEFAULT_STRATEGY_REGISTRY.find(
+      (candidate) => candidate.id === 'construction-priority.incumbent.v1'
+    );
+    expect(sourceEntry).toBeDefined();
+    const patchedEntry: StrategyRegistryEntry = {
+      ...sourceEntry!,
+      defaultValues: {
+        ...sourceEntry!.defaultValues,
+        territorySignalWeight: 29
+      }
+    };
+    const registry = [patchedEntry];
+    let consumed = false;
+    const recordStrategyRuntimeUse = jest.fn((entry: StrategyRegistryEntry) => {
+      consumed = entry.id === patchedEntry.id;
+    });
+    const buildEvidence = jest.fn(() => ({
+      type: 'screeps-rl-runtime-policy-parameter-consumption' as const,
+      consumerMarker: RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER,
+      consumerVersion: RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION,
+      runtimeParameterInjection: false,
+      consumed,
+      strategyVariantId: 'construction-priority.pg.territory-seed.v1',
+      candidatePolicyId: 'construction-priority.pg.territory-seed.v1',
+      family: 'construction-priority',
+      parameters: { territorySignalWeight: 29 },
+      parametersSha256: 'flagless-runtime-use-sha',
+      ...(consumed
+        ? {
+            consumedStrategyVariantId: 'construction-priority.pg.territory-seed.v1',
+            consumedParametersSha256: 'flagless-runtime-use-sha'
+          }
+        : {}),
+      appliedStrategyIds: consumed ? [patchedEntry.id] : [],
+      reason: consumed
+        ? 'runtime policy parameter payload was used by tick runtime strategy evaluation'
+        : 'runtime policy parameter payload was not used by tick runtime strategy evaluation',
+      liveEffect: false as const,
+      officialMmoWrites: false as const,
+      officialMmoWritesAllowed: false as const
+    }));
+    const persistRuntimePolicyParameterConsumptionEvidence = jest.fn();
+    jest.doMock('../src/strategy/runtimePolicyParameters', () => {
+      const actual = jest.requireActual<typeof import('../src/strategy/runtimePolicyParameters')>(
+        '../src/strategy/runtimePolicyParameters'
+      );
+      return {
+        ...actual,
+        applyRuntimePolicyParametersToRegistry: jest.fn(() => ({
+          registry,
+          evidence: {
+            type: 'screeps-rl-runtime-policy-parameter-consumption',
+            consumerMarker: RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER,
+            consumerVersion: RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION,
+            runtimeParameterInjection: false,
+            consumed: false,
+            strategyVariantId: 'construction-priority.pg.territory-seed.v1',
+            candidatePolicyId: 'construction-priority.pg.territory-seed.v1',
+            family: 'construction-priority',
+            parameters: { territorySignalWeight: 29 },
+            parametersSha256: 'flagless-runtime-use-sha',
+            appliedStrategyIds: [patchedEntry.id],
+            reason: 'runtime policy parameter payload matched registry entries; awaiting tick runtime strategy evaluation',
+            liveEffect: false,
+            officialMmoWrites: false,
+            officialMmoWritesAllowed: false
+          }
+        })),
+        createRuntimePolicyParameterConsumptionRecorder: jest.fn(() => ({
+          recordStrategyRuntimeUse,
+          buildEvidence
+        })),
+        persistRuntimePolicyParameterConsumptionEvidence
+      };
+    });
+    const run = jest.fn((options: KernelRunOptions = {}) => {
+      const entry = options.strategyRegistry?.find((candidate) => candidate.id === patchedEntry.id);
+      if (entry) {
+        options.onStrategyRegistryRuntimeUse?.(entry);
+      }
+      return makeRuntimeSummary();
+    });
+    mockKernel(run);
+    let main: typeof import('../src/main') | undefined;
+    jest.isolateModules(() => {
+      main = jest.requireActual<typeof import('../src/main')>('../src/main');
+    });
+
+    main?.loop();
+
+    const options = run.mock.calls[0]?.[0];
+    expect(options).not.toHaveProperty('runtimeStrategyConstructionEnabled');
+    expect(options?.onStrategyRegistryRuntimeUse).toBe(recordStrategyRuntimeUse);
+    expect(recordStrategyRuntimeUse).toHaveBeenCalledWith(patchedEntry);
+    expect(persistRuntimePolicyParameterConsumptionEvidence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeParameterInjection: false,
+        consumed: true,
+        appliedStrategyIds: [patchedEntry.id],
+        consumedParametersSha256: 'flagless-runtime-use-sha'
+      })
+    );
+  });
 });
 
 function mockKernel(run: jest.Mock<RuntimeSummary, [KernelRunOptions?]>): void {
@@ -120,7 +282,7 @@ function installScreepsGlobals(): void {
   };
 }
 
-function installRuntimePolicyPayload(): void {
+function installRuntimePolicyPayload(overrides: Record<string, unknown> = {}): void {
   (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETERS_GLOBAL] = {
     runtimeParameterInjection: true,
     candidateParameterScope: 'runtime_injected',
@@ -135,7 +297,8 @@ function installRuntimePolicyPayload(): void {
       killSignalWeight: 5,
       riskPenalty: 4
     },
-    parametersSha256: 'runtime-use-sha'
+    parametersSha256: 'runtime-use-sha',
+    ...overrides
   };
 }
 

--- a/prod/test/mainRuntimePolicyParameters.test.ts
+++ b/prod/test/mainRuntimePolicyParameters.test.ts
@@ -1,0 +1,148 @@
+import type { KernelRunOptions } from '../src/kernel/Kernel';
+import {
+  RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL,
+  RUNTIME_POLICY_PARAMETERS_GLOBAL
+} from '../src/strategy/runtimePolicyParameters';
+import type { RuntimeSummary } from '../src/telemetry/runtimeSummary';
+
+describe('main runtime policy parameter consumption', () => {
+  let logSpy: jest.SpyInstance<void, [message?: unknown, ...optionalParams: unknown[]]>;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    jest.resetModules();
+    jest.dontMock('../src/kernel/Kernel');
+    delete (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETERS_GLOBAL];
+    delete (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL];
+    delete (globalThis as { Memory?: unknown }).Memory;
+    delete (globalThis as { Game?: unknown }).Game;
+  });
+
+  it('consumes a private-simulator payload that appears after module initialization', () => {
+    installScreepsGlobals();
+    const run = jest.fn((options: KernelRunOptions = {}) => {
+      const entry = options.strategyRegistry?.find(
+        (candidate) => candidate.id === 'construction-priority.incumbent.v1'
+      );
+      if (entry) {
+        options.onStrategyRegistryRuntimeUse?.(entry);
+      }
+      return makeRuntimeSummary();
+    });
+    mockKernel(run);
+    let main: typeof import('../src/main') | undefined;
+    jest.isolateModules(() => {
+      main = jest.requireActual<typeof import('../src/main')>('../src/main');
+    });
+
+    installRuntimePolicyPayload();
+    main?.loop();
+
+    expect(run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeStrategyConstructionEnabled: true,
+        strategyRegistry: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'construction-priority.incumbent.v1',
+            defaultValues: expect.objectContaining({ territorySignalWeight: 29 })
+          })
+        ])
+      })
+    );
+    expect(
+      (globalThis as { Memory?: { rlRuntimePolicyParameters?: unknown } }).Memory?.rlRuntimePolicyParameters
+    ).toMatchObject({
+      runtimeParameterInjection: true,
+      consumed: true,
+      strategyVariantId: 'construction-priority.pg.territory-seed.v1',
+      consumedStrategyVariantId: 'construction-priority.pg.territory-seed.v1',
+      parametersSha256: 'runtime-use-sha',
+      consumedParametersSha256: 'runtime-use-sha',
+      appliedStrategyIds: ['construction-priority.incumbent.v1'],
+      liveEffect: false,
+      officialMmoWrites: false,
+      officialMmoWritesAllowed: false,
+      tick: 20
+    });
+  });
+
+  it('keeps injected runtime evidence unconsumed when the tick does not use the patched strategy', () => {
+    installScreepsGlobals();
+    const run = jest.fn((_options: KernelRunOptions = {}) => makeRuntimeSummary());
+    mockKernel(run);
+    let main: typeof import('../src/main') | undefined;
+    jest.isolateModules(() => {
+      main = jest.requireActual<typeof import('../src/main')>('../src/main');
+    });
+
+    installRuntimePolicyPayload();
+    main?.loop();
+
+    expect(run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeStrategyConstructionEnabled: true
+      })
+    );
+    expect(
+      (globalThis as { Memory?: { rlRuntimePolicyParameters?: unknown } }).Memory?.rlRuntimePolicyParameters
+    ).toMatchObject({
+      runtimeParameterInjection: true,
+      consumed: false,
+      strategyVariantId: 'construction-priority.pg.territory-seed.v1',
+      parametersSha256: 'runtime-use-sha',
+      appliedStrategyIds: [],
+      reason: 'runtime policy parameter payload was not used by tick runtime strategy evaluation',
+      liveEffect: false,
+      officialMmoWrites: false,
+      officialMmoWritesAllowed: false,
+      tick: 20
+    });
+  });
+});
+
+function mockKernel(run: jest.Mock<RuntimeSummary, [KernelRunOptions?]>): void {
+  jest.doMock('../src/kernel/Kernel', () => ({
+    Kernel: jest.fn().mockImplementation(() => ({ run }))
+  }));
+}
+
+function installScreepsGlobals(): void {
+  (globalThis as unknown as { Memory: Memory }).Memory = {} as Memory;
+  (globalThis as unknown as { Game: Partial<Game> }).Game = {
+    creeps: {},
+    rooms: {},
+    spawns: {},
+    time: 20
+  };
+}
+
+function installRuntimePolicyPayload(): void {
+  (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETERS_GLOBAL] = {
+    runtimeParameterInjection: true,
+    candidateParameterScope: 'runtime_injected',
+    strategyVariantId: 'construction-priority.pg.territory-seed.v1',
+    candidatePolicyId: 'construction-priority.pg.territory-seed.v1',
+    sourceStrategyId: 'construction-priority.incumbent.v1',
+    family: 'construction-priority',
+    parameters: {
+      baseScoreWeight: 1,
+      territorySignalWeight: 29,
+      resourceSignalWeight: 3,
+      killSignalWeight: 5,
+      riskPenalty: 4
+    },
+    parametersSha256: 'runtime-use-sha'
+  };
+}
+
+function makeRuntimeSummary(): RuntimeSummary {
+  return {
+    type: 'runtime-summary',
+    tick: 20,
+    rooms: []
+  };
+}


### PR DESCRIPTION
## Summary
- Emits runtime-side RL policy-parameter consumption evidence from the Screeps tick loop when runtime policy parameters are present.
- Adds deterministic Jest coverage for consumed-variant telemetry and the no-parameters path.
- Rebuilds the bundled Screeps artifact.

## Linked issue
Refs #1299

## Safety
- Offline/shadow telemetry evidence only; no official MMO learned-policy writes are introduced.
- Official target remains `main / shardX / E29N55`.

## Verification
Controller-side verification before commit:
- `git diff --check` — PASS
- `cd prod && npm run typecheck` — PASS
- `cd prod && npm test -- --runInBand` — PASS (102 suites, 2036 tests)
- `cd prod && npm run build` — PASS

## Next gate
- Wait for exact-head prod-ci and CodeRabbit/Gemini.
- Re-query GraphQL review threads and Project fields.
- Do not run paid validation compute until this lands; after merge, launch one guarded post-fix RL validation run and require `runtimeParameterConsumption=true` / `consumedVariantCount>0` before unblocking #1337.
