### PR TITLE
fix(rl): consume injected runtime policy parameters

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -46799,11 +46799,31 @@ function persistRuntimePolicyParameterConsumptionEvidence(evidence) {
   emitRuntimePolicyParameterConsumptionEvidence(persistedEvidence);
 }
 function readRuntimePolicyParameterPayload() {
+  const lexicalPayload = runtimePolicyParameterPayloadFromValue(readLexicalRuntimePolicyParameterPayload());
+  if (lexicalPayload) {
+    return lexicalPayload;
+  }
   for (const root of runtimeGlobalRoots()) {
-    const raw = root[RUNTIME_POLICY_PARAMETERS_GLOBAL];
-    if (isRecord41(raw) && raw.runtimeParameterInjection === true && raw.candidateParameterScope === "runtime_injected") {
-      return raw;
+    const payload = runtimePolicyParameterPayloadFromValue(root[RUNTIME_POLICY_PARAMETERS_GLOBAL]);
+    if (payload) {
+      return payload;
     }
+  }
+  return null;
+}
+function readLexicalRuntimePolicyParameterPayload() {
+  try {
+    if (typeof __SCREEPS_RL_RUNTIME_POLICY_PARAMETERS__ !== "undefined") {
+      return __SCREEPS_RL_RUNTIME_POLICY_PARAMETERS__;
+    }
+  } catch (_error) {
+    return void 0;
+  }
+  return void 0;
+}
+function runtimePolicyParameterPayloadFromValue(value) {
+  if (isRecord41(value) && value.runtimeParameterInjection === true && value.candidateParameterScope === "runtime_injected") {
+    return value;
   }
   return null;
 }

--- a/prod/src/strategy/runtimePolicyParameters.ts
+++ b/prod/src/strategy/runtimePolicyParameters.ts
@@ -6,6 +6,8 @@ export const RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER = 'screeps-rl-runtime-pol
 export const RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION = 'v1';
 export const RUNTIME_POLICY_PARAMETER_CONSUMPTION_LOG_PREFIX = '#runtime-parameter-consumption ';
 
+declare const __SCREEPS_RL_RUNTIME_POLICY_PARAMETERS__: unknown;
+
 export interface RuntimePolicyParameterConsumptionEvidence {
   type: 'screeps-rl-runtime-policy-parameter-consumption';
   consumerMarker: typeof RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER;
@@ -185,17 +187,40 @@ export function persistRuntimePolicyParameterConsumptionEvidence(
 }
 
 function readRuntimePolicyParameterPayload(): RuntimePolicyParameterPayload | null {
+  const lexicalPayload = runtimePolicyParameterPayloadFromValue(readLexicalRuntimePolicyParameterPayload());
+  if (lexicalPayload) {
+    return lexicalPayload;
+  }
+
   for (const root of runtimeGlobalRoots()) {
-    const raw = root[RUNTIME_POLICY_PARAMETERS_GLOBAL];
-    if (
-      isRecord(raw) &&
-      raw.runtimeParameterInjection === true &&
-      raw.candidateParameterScope === 'runtime_injected'
-    ) {
-      return raw;
+    const payload = runtimePolicyParameterPayloadFromValue(root[RUNTIME_POLICY_PARAMETERS_GLOBAL]);
+    if (payload) {
+      return payload;
     }
   }
 
+  return null;
+}
+
+function readLexicalRuntimePolicyParameterPayload(): unknown {
+  try {
+    if (typeof __SCREEPS_RL_RUNTIME_POLICY_PARAMETERS__ !== 'undefined') {
+      return __SCREEPS_RL_RUNTIME_POLICY_PARAMETERS__;
+    }
+  } catch (_error) {
+    return undefined;
+  }
+  return undefined;
+}
+
+function runtimePolicyParameterPayloadFromValue(value: unknown): RuntimePolicyParameterPayload | null {
+  if (
+    isRecord(value) &&
+    value.runtimeParameterInjection === true &&
+    value.candidateParameterScope === 'runtime_injected'
+  ) {
+    return value;
+  }
   return null;
 }
 

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -624,11 +624,13 @@ def apply_runtime_parameter_injection_to_code(code_text: str, injection: JsonObj
     runtime_payload["status"] = "injected"
     runtime_payload["runtimeParameterInjection"] = True
     runtime_payload["inlineCandidatesRuntimeInjected"] = True
+    payload_json = json.dumps(runtime_payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
     prelude = (
         "/* screeps-rl private-simulator runtime parameter injection; "
         "liveEffect=false officialMmoWrites=false officialMmoWritesAllowed=false */\n"
+        f"var {RUNTIME_PARAMETER_INJECTION_GLOBAL} = {payload_json};\n"
         "(function(){\n"
-        f"  var payload = {json.dumps(runtime_payload, sort_keys=True, separators=(',', ':'), ensure_ascii=True)};\n"
+        f"  var payload = {RUNTIME_PARAMETER_INJECTION_GLOBAL};\n"
         "  var roots = [];\n"
         "  function addRoot(root) { if (root && roots.indexOf(root) < 0) roots.push(root); }\n"
         "  if (typeof globalThis !== 'undefined') addRoot(globalThis);\n"

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1599,6 +1599,8 @@ cli:
         self.assertNotEqual(base_upload, territory_upload)
         self.assertTrue(base_upload.startswith('"use strict";\n'))
         self.assertIn(harness.RUNTIME_PARAMETER_INJECTION_GLOBAL, base_upload)
+        self.assertIn(f"var {harness.RUNTIME_PARAMETER_INJECTION_GLOBAL} =", base_upload)
+        self.assertIn(f"var payload = {harness.RUNTIME_PARAMETER_INJECTION_GLOBAL};", base_upload)
         self.assertIn("function addRoot(root)", base_upload)
         self.assertIn("typeof globalThis !== 'undefined'", base_upload)
         self.assertIn("typeof global !== 'undefined'", base_upload)


### PR DESCRIPTION
## Summary
- reads the runtime-policy payload from the lexical simulator prelude binding before falling back to global roots
- emits the simulator prelude payload into `__SCREEPS_RL_RUNTIME_POLICY_PARAMETERS__` so the bundled consumer can observe injected variants in private-simulator runs
- adds focused regression assertions for the emitted lexical payload and regenerates `prod/dist/main.js`

## Validation
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/test_screeps_rl_simulator_harness.py`
- `python3 -m unittest scripts.test_screeps_rl_simulator_harness.RlSimulatorHarnessTest.test_runtime_parameter_injection_changes_private_runtime_code_input`
- `python3 -m unittest -k runtime_parameter_injection scripts.test_screeps_rl_simulator_harness`
- `cd prod && npm run typecheck && npm test -- --runInBand && npm run build` — 102 suites / 2038 tests passed

## Safety / rollout
- Analysis/private-simulator path only; no official MMO writes by this PR alone.
- #1299 remains open after merge until a post-fix Tencent run from the merged commit proves `runtimeParameterConsumption=true` and `consumedVariantCount>0`.

Refs #1299
Refs #879
Refs #1032
Refs #1233
