### PR TITLE
fix(roadmap): make Pages refresh collect live KPI data

### DIFF
--- a/.github/workflows/roadmap-pages-refresh.yml
+++ b/.github/workflows/roadmap-pages-refresh.yml
@@ -24,6 +24,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.SCREEPS_ROADMAP_TOKEN || github.token }}
       GITHUB_TOKEN: ${{ secrets.SCREEPS_ROADMAP_TOKEN || github.token }}
+      SCREEPS_AUTH_TOKEN: ${{ secrets.SCREEPS_AUTH_TOKEN }}
 
     steps:
       - name: Checkout main
@@ -47,12 +48,25 @@ jobs:
           git config user.email "lanyusea@gmail.com"
           git lfs install --local
 
+      - name: Capture live Screeps runtime summary
+        run: |
+          mkdir -p runtime-artifacts/screeps-monitor runtime-artifacts/runtime-summary-console runtime-artifacts/cron-output
+          if [ -z "${SCREEPS_AUTH_TOKEN:-}" ]; then
+            echo "::warning::SCREEPS_AUTH_TOKEN is not configured; skipping live Screeps runtime summary capture."
+            exit 0
+          fi
+          python3 scripts/screeps-runtime-monitor.py summary \
+            --out-dir runtime-artifacts/screeps-monitor \
+            --runtime-summary-out-dir runtime-artifacts/runtime-summary-console \
+            > runtime-artifacts/screeps-monitor/summary.json
+
       - name: Generate roadmap Pages artifacts
         run: |
           python3 scripts/generate-roadmap-page.py \
             --repo . \
             --docs-dir docs \
-            --db docs/roadmap-kpi.sqlite
+            --db docs/roadmap-kpi.sqlite \
+            --cron-output-root runtime-artifacts/cron-output
           rm -f docs/roadmap-kpi.sqlite-wal docs/roadmap-kpi.sqlite-shm
           test ! -e docs/roadmap-kpi.sqlite-wal
           test ! -e docs/roadmap-kpi.sqlite-shm

--- a/scripts/generate-roadmap-page.py
+++ b/scripts/generate-roadmap-page.py
@@ -31,6 +31,7 @@ DELIVERY_METRICS_WINDOW_DAYS = 7
 RUNTIME_ARTIFACT_SOURCE_KIND = "runtime-summary-artifact"
 RUNTIME_ARTIFACT_PATHS_ENV = "SCREEPS_ROADMAP_RUNTIME_ARTIFACT_PATHS"
 CRON_OUTPUT_ROOT_ENV = "SCREEPS_ROADMAP_CRON_OUTPUT_ROOT"
+SOURCE_EVIDENCE_METRIC_KEYS = frozenset({"runtime_summary_samples", "kpi_artifact_files"})
 DEFAULT_OWNER = "lanyusea"
 DEFAULT_REPO = "screeps"
 DEFAULT_PROJECT_NUMBER = 3
@@ -797,7 +798,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         write_metric_definitions(conn)
         migrate_legacy_kpi_samples(conn)
-        append_metric_samples(conn, generated_at, metrics)
+        if should_append_metric_samples(runtime_report, metrics):
+            append_metric_samples(conn, generated_at, metrics)
         history = load_metric_history(conn)
     finally:
         conn.close()
@@ -1538,6 +1540,26 @@ def append_metric_samples(conn: sqlite3.Connection, sampled_at: str, metrics: Se
     conn.commit()
 
 
+def should_append_metric_samples(runtime_report: JsonObject, metrics: Sequence[JsonObject]) -> bool:
+    if runtime_report_runtime_summary_count(runtime_report) <= 0:
+        return False
+    return any(is_observed_runtime_kpi_metric(metric) for metric in metrics)
+
+
+def runtime_report_runtime_summary_count(runtime_report: JsonObject) -> int:
+    source = runtime_report.get("source")
+    value = as_number(source.get("runtimeSummaryLines")) if isinstance(source, dict) else None
+    if value is None:
+        value = as_number(get_path(runtime_report, ("input", "runtimeSummaryCount")))
+    return max(0, int(value)) if value is not None else 0
+
+
+def is_observed_runtime_kpi_metric(metric: JsonObject) -> bool:
+    if metric.get("key") in SOURCE_EVIDENCE_METRIC_KEYS:
+        return False
+    return bool(metric.get("observed")) and chart_number(metric.get("value")) is not None
+
+
 def load_metric_history(conn: sqlite3.Connection) -> JsonObject:
     rows = conn.execute(
         """
@@ -1700,7 +1722,7 @@ def roadmap_cron_output_root(repo_root: Path, explicit_root: str | None = None) 
         return normalize_repo_scoped_path(repo_root, configured)
     if HERMES_CRON_OUTPUT_ROOT != HOST_HERMES_CRON_OUTPUT_ROOT:
         return HERMES_CRON_OUTPUT_ROOT
-    if HERMES_CRON_OUTPUT_ROOT.exists():
+    if path_exists_without_error(HERMES_CRON_OUTPUT_ROOT):
         return HERMES_CRON_OUTPUT_ROOT
     return repo_root / "runtime-artifacts" / "cron-output"
 
@@ -1710,6 +1732,13 @@ def normalize_repo_scoped_path(repo_root: Path, path_text: str) -> Path:
     if not path.is_absolute():
         path = repo_root / path
     return path
+
+
+def path_exists_without_error(path: Path) -> bool:
+    try:
+        return path.exists()
+    except OSError:
+        return False
 
 
 def runtime_history_input_path_labels(input_paths: Sequence[str]) -> list[str]:
@@ -2652,7 +2681,8 @@ def metric_history_values(history: JsonObject, metric_key: str, buckets: Sequenc
         sampled_at = parse_timestamp(str(point.get("sampledAt") or ""))
         if sampled_at is None:
             continue
-        latest_by_day[sampled_at.astimezone(CST).date()] = point
+        sampled_day = sampled_at.astimezone(CST).date()
+        latest_by_day[sampled_day] = preferred_daily_metric_point(latest_by_day.get(sampled_day), point)
 
     values: list[int | float | None] = []
     statuses: list[str] = []
@@ -2669,6 +2699,20 @@ def metric_history_values(history: JsonObject, metric_key: str, buckets: Sequenc
         else:
             values.append(None)
     return values, statuses
+
+
+def preferred_daily_metric_point(current: JsonObject | None, candidate: JsonObject) -> JsonObject:
+    if current is None:
+        return candidate
+
+    current_observed = bool(current.get("observed"))
+    candidate_observed = bool(candidate.get("observed"))
+    if current_observed != candidate_observed:
+        return candidate if candidate_observed else current
+
+    current_timestamp = parse_timestamp(str(current.get("sampledAt") or "")) or datetime.min.replace(tzinfo=timezone.utc)
+    candidate_timestamp = parse_timestamp(str(candidate.get("sampledAt") or "")) or datetime.min.replace(tzinfo=timezone.utc)
+    return candidate if candidate_timestamp >= current_timestamp else current
 
 
 def chart_number(value: Any) -> int | float | None:

--- a/scripts/test_generate_roadmap_page.py
+++ b/scripts/test_generate_roadmap_page.py
@@ -287,6 +287,42 @@ class GenerateRoadmapPageTest(unittest.TestCase):
         self.assertTrue(territory["history"]["insufficient"])
         self.assertIn("History collecting (2/7 days observed; insufficient for a complete 7d trend)", territory["footer"])
 
+    def test_metric_history_prefers_observed_point_over_later_unavailable_same_day(self) -> None:
+        history = {
+            "owned_rooms": [
+                metric_history_point("2026-05-01T12:00:00Z", 2),
+                {
+                    "sampledAt": "2026-05-01T18:00:00Z",
+                    "value": None,
+                    "instrumented": False,
+                    "observed": False,
+                    "status": "not instrumented",
+                },
+            ]
+        }
+
+        values, statuses = roadmap.metric_history_values(history, "owned_rooms", [datetime(2026, 5, 1).date()])
+
+        self.assertEqual(values, [2])
+        self.assertEqual(statuses, ["observed"])
+
+    def test_empty_runtime_report_samples_are_not_appended_to_history(self) -> None:
+        report = roadmap.empty_runtime_report("no runtime-summary artifacts")
+        metrics = roadmap.build_current_metrics(report)
+        conn = sqlite3.connect(":memory:")
+        conn.execute("PRAGMA foreign_keys=ON")
+        roadmap.ensure_schema(conn)
+        roadmap.write_metric_definitions(conn)
+        try:
+            if roadmap.should_append_metric_samples(report, metrics):
+                roadmap.append_metric_samples(conn, "2026-05-01T18:00:00Z", metrics)
+            history = roadmap.load_metric_history(conn)
+        finally:
+            conn.close()
+
+        self.assertFalse(roadmap.should_append_metric_samples(report, metrics))
+        self.assertEqual(history, {})
+
     def test_lfs_pointer_history_db_reports_cold_start_collecting_status(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             db_path = Path(tmp) / "docs" / "roadmap-kpi.sqlite"
@@ -429,6 +465,26 @@ class GenerateRoadmapPageTest(unittest.TestCase):
             with (
                 patch.object(roadmap, "HOST_HERMES_CRON_OUTPUT_ROOT", host_root),
                 patch.object(roadmap, "HERMES_CRON_OUTPUT_ROOT", host_root),
+            ):
+                path = roadmap.roadmap_cron_output_root(repo_root)
+
+        self.assertEqual(path, repo_root / "runtime-artifacts" / "cron-output")
+
+    def test_cron_output_root_permission_error_falls_back_to_repo_local_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            host_root = repo_root / "host-cron-output"
+            original_exists = type(host_root).exists
+
+            def inaccessible_exists(path: Path) -> bool:
+                if path == host_root:
+                    raise PermissionError("permission denied")
+                return original_exists(path)
+
+            with (
+                patch.object(roadmap, "HOST_HERMES_CRON_OUTPUT_ROOT", host_root),
+                patch.object(roadmap, "HERMES_CRON_OUTPUT_ROOT", host_root),
+                patch.object(type(host_root), "exists", inaccessible_exists),
             ):
                 path = roadmap.roadmap_cron_output_root(repo_root)
 

--- a/scripts/test_roadmap_pages_contract.py
+++ b/scripts/test_roadmap_pages_contract.py
@@ -77,6 +77,19 @@ class RoadmapPagesContractTests(unittest.TestCase):
         self.assertIn("token: ${{ secrets.SCREEPS_ROADMAP_TOKEN || github.token }}", text)
         self.assertIn("git push origin HEAD:main", text)
 
+    def test_roadmap_pages_refresh_collects_live_runtime_summary_before_generation(self) -> None:
+        text = self.read(Path(".github/workflows/roadmap-pages-refresh.yml"))
+
+        self.assertIn("SCREEPS_AUTH_TOKEN: ${{ secrets.SCREEPS_AUTH_TOKEN }}", text)
+        self.assertIn("mkdir -p runtime-artifacts/screeps-monitor runtime-artifacts/runtime-summary-console runtime-artifacts/cron-output", text)
+        self.assertIn("python3 scripts/screeps-runtime-monitor.py summary", text)
+        self.assertIn("--out-dir runtime-artifacts/screeps-monitor", text)
+        self.assertIn("--runtime-summary-out-dir runtime-artifacts/runtime-summary-console", text)
+        self.assertIn("> runtime-artifacts/screeps-monitor/summary.json", text)
+        self.assertIn("SCREEPS_AUTH_TOKEN is not configured; skipping live Screeps runtime summary capture.", text)
+        self.assertIn("--cron-output-root runtime-artifacts/cron-output", text)
+        self.assertNotIn("--room", text)
+
     def test_deploy_process_metric_rejects_bool_values(self) -> None:
         cards = [
             {"label": label, "value": True if label == "Deploys" else 1}


### PR DESCRIPTION
## Summary
- make the roadmap generator fall back to repo-local cron output when host Hermes cron output is inaccessible on GitHub-hosted runners
- avoid appending all-null runtime KPI samples that would mask same-day observed KPI history
- capture live Screeps runtime-summary artifacts in the scheduled Pages refresh workflow when `SCREEPS_AUTH_TOKEN` is available, and pass a repo-local `--cron-output-root`
- add regression coverage for the PermissionError fallback, observed KPI preservation, and workflow runtime-summary contract

## Verification
- `python3 -m py_compile scripts/generate-roadmap-page.py scripts/screeps_runtime_kpi_artifact_bridge.py scripts/check_cron_registry.py scripts/check-roadmap-pages-freshness.py scripts/check-roadmap-kpi-placeholders.py`
- `python3 -m unittest scripts/test_generate_roadmap_page.py scripts/test_check_cron_registry.py scripts/test_roadmap_pages_contract.py scripts/test_check_roadmap_pages_freshness.py -v` (53 tests)
- `python3 scripts/check_cron_registry.py --strict`
- `python3 scripts/check-roadmap-pages-freshness.py . --max-age-hours 168 --require-live-github`
- `python3 -B scripts/check-roadmap-kpi-placeholders.py .`
- temp generation from the worktree with a real runtime-summary console artifact from `/root/screeps/runtime-artifacts/.../runtime-summary-console-20260524T043202Z.log`: KPI cards became `collecting` with observed values for Territory/Resources/Combat from real reducer input

Refs #1379

