### PR TITLE
fix(roadmap): tolerate inaccessible Codex session cache

### DIFF
--- a/scripts/generate-roadmap-page.py
+++ b/scripts/generate-roadmap-page.py
@@ -3830,7 +3830,8 @@ def summarize_codex_sessions(
 ) -> CodexSessionMetrics:
     window_start, window_end = delivery_metric_window(generated_at, window_days)
     apply_window = generated_at is not None
-    if not session_root.exists():
+
+    def unavailable_metrics() -> CodexSessionMetrics:
         return CodexSessionMetrics(
             0,
             0,
@@ -3844,6 +3845,9 @@ def summarize_codex_sessions(
             source_root=session_root,
             source_exists=False,
         )
+
+    if not path_exists_without_error(session_root):
+        return unavailable_metrics()
 
     attribution = attribution or build_repo_attribution(None, None)
     session_count = 0
@@ -3860,7 +3864,11 @@ def summarize_codex_sessions(
     longest_elapsed_seconds = 0
     captured_times: list[datetime] = []
     counted_ids: list[str] = []
-    for path in sorted(session_root.glob(f"**/{CODEX_SESSION_PATTERN}")):
+    try:
+        session_paths = sorted(session_root.glob(f"**/{CODEX_SESSION_PATTERN}"))
+    except OSError:
+        return unavailable_metrics()
+    for path in session_paths:
         if not path.is_file():
             continue
         candidate_count += 1

--- a/scripts/test_generate_roadmap_page.py
+++ b/scripts/test_generate_roadmap_page.py
@@ -1037,6 +1037,41 @@ class GenerateRoadmapPageTest(unittest.TestCase):
         self.assertEqual(cards_by_label["Longest Codex run"]["rawValueSeconds"], 1800)
         self.assertIn("maximum first-to-last JSONL timestamp span", cards_by_label["Longest Codex run"]["detail"])
 
+    def test_codex_session_summary_permission_error_is_unavailable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            codex_root = Path("/root/.codex/sessions")
+            original_exists = type(codex_root).exists
+
+            def inaccessible_exists(path: Path) -> bool:
+                if path == codex_root:
+                    raise PermissionError("permission denied")
+                return original_exists(path)
+
+            attribution = roadmap.build_repo_attribution(repo_root, {"fullName": "lanyusea/screeps"})
+            with (
+                patch.object(roadmap, "CODEX_SESSION_ROOT", codex_root),
+                patch.object(type(codex_root), "exists", inaccessible_exists),
+            ):
+                metrics = roadmap.summarize_codex_sessions(
+                    roadmap.CODEX_SESSION_ROOT,
+                    attribution,
+                    GENERATED_AT,
+                )
+
+        self.assertEqual(metrics.session_count, 0)
+        self.assertEqual(metrics.token_session_count, 0)
+        self.assertEqual(metrics.timed_session_count, 0)
+        self.assertIsNone(metrics.total_tokens)
+        self.assertIsNone(metrics.elapsed_seconds)
+        self.assertIsNone(metrics.longest_elapsed_seconds)
+        self.assertEqual(metrics.candidate_count, 0)
+        self.assertEqual(metrics.readable_count, 0)
+        self.assertEqual(metrics.attributed_count, 0)
+        self.assertEqual(metrics.counted_ids, ())
+        self.assertEqual(metrics.source_root, codex_root)
+        self.assertFalse(metrics.source_exists)
+
     def test_cron_run_delta_resets_when_source_root_changes(self) -> None:
         window_start = datetime(2026, 5, 1, tzinfo=timezone.utc)
         window_end = datetime(2026, 5, 8, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- treat inaccessible `/root/.codex/sessions` the same as a missing Codex session cache during roadmap Pages generation
- guard recursive Codex session globbing against `OSError`
- add a regression test for PermissionError on the Codex session cache

## Verification
- `python3 -m py_compile scripts/generate-roadmap-page.py scripts/check-roadmap-pages-freshness.py scripts/check-roadmap-kpi-placeholders.py`
- `python3 -m unittest scripts/test_generate_roadmap_page.py scripts/test_roadmap_pages_contract.py scripts/test_check_roadmap_pages_freshness.py -v` (51 tests)
- `python3 scripts/check-roadmap-pages-freshness.py . --max-age-hours 168 --require-live-github`
- `python3 -B scripts/check-roadmap-kpi-placeholders.py .`

Follow-up to PR #1382 after workflow run 26353844183 failed on `PermissionError: '/root/.codex/sessions'`.

Refs #1379
