### PR TITLE
fix(roadmap): refresh Pages artifacts through PRs

### DIFF
--- a/.github/workflows/roadmap-pages-refresh.yml
+++ b/.github/workflows/roadmap-pages-refresh.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   contents: write
   issues: read
-  pull-requests: read
+  pull-requests: write
   repository-projects: read
   pages: write
 
@@ -81,6 +81,7 @@ jobs:
       - name: Commit generated Pages artifacts
         id: commit
         run: |
+          refresh_branch="chore/roadmap-pages-refresh"
           git add docs/index.html docs/roadmap-data.json docs/roadmap-kpi.sqlite
           if git diff --cached --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -88,8 +89,37 @@ jobs:
             exit 0
           fi
           git commit -m "chore(roadmap): refresh Pages artifacts [skip ci]"
-          git push origin HEAD:main
+          git fetch origin "$refresh_branch" || true
+          git push --force-with-lease origin HEAD:"$refresh_branch"
           echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "branch=$refresh_branch" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update Pages refresh PR
+        if: steps.commit.outputs.changed == 'true'
+        run: |
+          refresh_branch="${{ steps.commit.outputs.branch }}"
+          pr_number="$(gh pr list --head "$refresh_branch" --state open --json number --jq '.[0].number // empty')"
+          body_file="$(mktemp)"
+          cat > "$body_file" <<'EOF'
+          Automated roadmap Pages artifact refresh.
+
+          This PR was opened by the scheduled `roadmap-pages-refresh` workflow because branch protection requires generated docs changes to pass through a pull request.
+
+          Verification already run in the workflow:
+          - generated `docs/index.html`, `docs/roadmap-data.json`, and `docs/roadmap-kpi.sqlite`
+          - `python3 scripts/check-roadmap-pages-freshness.py . --max-age-hours 2 --require-live-github`
+          EOF
+          if [ -n "$pr_number" ]; then
+            gh pr edit "$pr_number" --title "chore(roadmap): refresh Pages artifacts" --body-file "$body_file"
+            echo "Updated existing Pages refresh PR #$pr_number."
+          else
+            gh pr create \
+              --base main \
+              --head "$refresh_branch" \
+              --title "chore(roadmap): refresh Pages artifacts" \
+              --body-file "$body_file"
+          fi
 
       - name: Request legacy Pages rebuild
+        if: steps.commit.outputs.changed != 'true'
         run: gh api -X POST "repos/${GITHUB_REPOSITORY}/pages/builds" --silent

--- a/scripts/test_roadmap_pages_contract.py
+++ b/scripts/test_roadmap_pages_contract.py
@@ -68,14 +68,20 @@ class RoadmapPagesContractTests(unittest.TestCase):
                     self.assertNotIn(pattern, text)
                 self.assertIn(PAGES_URL, text)
 
-    def test_roadmap_pages_refresh_push_uses_safe_checkout_credentials(self) -> None:
+    def test_roadmap_pages_refresh_uses_pr_flow_for_generated_artifacts(self) -> None:
         text = self.read(Path(".github/workflows/roadmap-pages-refresh.yml"))
 
         self.assertNotIn("bearer ***", text)
         self.assertNotIn(".extraheader=AUTHORIZATION: bearer", text)
         self.assertIn("persist-credentials: true", text)
         self.assertIn("token: ${{ secrets.SCREEPS_ROADMAP_TOKEN || github.token }}", text)
-        self.assertIn("git push origin HEAD:main", text)
+        self.assertIn("pull-requests: write", text)
+        self.assertNotIn("git push origin HEAD:main", text)
+        self.assertIn('refresh_branch="chore/roadmap-pages-refresh"', text)
+        self.assertIn('git push --force-with-lease origin HEAD:"$refresh_branch"', text)
+        self.assertIn("gh pr list --head", text)
+        self.assertIn("gh pr create", text)
+        self.assertIn("gh pr edit", text)
 
     def test_roadmap_pages_refresh_collects_live_runtime_summary_before_generation(self) -> None:
         text = self.read(Path(".github/workflows/roadmap-pages-refresh.yml"))


### PR DESCRIPTION
## Summary
- route scheduled roadmap Pages artifact updates through a stable refresh PR instead of direct pushes to protected `main`
- grant the workflow `pull-requests: write` only for opening/updating that PR
- keep generated artifact scope limited to `docs/index.html`, `docs/roadmap-data.json`, and `docs/roadmap-kpi.sqlite`
- add/refresh contract coverage so this regression cannot return

## Test plan
- `git diff --check`
- `python3 -m py_compile scripts/generate-roadmap-page.py scripts/check-roadmap-pages-freshness.py scripts/check-roadmap-kpi-placeholders.py`
- `python3 -m unittest scripts/test_roadmap_pages_contract.py scripts/test_generate_roadmap_page.py scripts/test_check_roadmap_pages_freshness.py -v`
- `python3 scripts/check-roadmap-pages-freshness.py . --max-age-hours 168 --require-live-github`
- `python3 -B scripts/check-roadmap-kpi-placeholders.py .`
- local generator smoke with a real runtime summary artifact confirmed non-empty KPI samples

Refs #1379
