### PR TITLE
fix(roadmap): keep Pages runtime capture on writable paths

### DIFF
--- a/.github/workflows/roadmap-pages-refresh.yml
+++ b/.github/workflows/roadmap-pages-refresh.yml
@@ -25,6 +25,8 @@ jobs:
       GH_TOKEN: ${{ secrets.SCREEPS_ROADMAP_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.SCREEPS_ROADMAP_TOKEN }}
       SCREEPS_AUTH_TOKEN: ${{ secrets.SCREEPS_AUTH_TOKEN }}
+      SCREEPS_MONITOR_CACHE_DIR: runtime-artifacts/screeps-monitor/terrain-cache
+      SCREEPS_MONITOR_STATE_FILE: runtime-artifacts/screeps-monitor/state.json
       PAGES_REFRESH_BRANCH: automation/roadmap-pages-refresh
 
     steps:
@@ -65,10 +67,34 @@ jobs:
             echo "::warning::SCREEPS_AUTH_TOKEN is not configured; skipping live Screeps runtime summary capture."
             exit 0
           fi
+          set +e
           python3 scripts/screeps-runtime-monitor.py summary \
             --out-dir runtime-artifacts/screeps-monitor \
             --runtime-summary-out-dir runtime-artifacts/runtime-summary-console \
             > runtime-artifacts/screeps-monitor/summary.json
+          summary_status=$?
+          set -e
+          if [ "${summary_status}" -ne 0 ]; then
+            echo "::error::Live Screeps runtime summary capture failed; sanitized monitor payload follows."
+            python3 - <<'PY'
+          import json
+          from pathlib import Path
+          payload_path = Path("runtime-artifacts/screeps-monitor/summary.json")
+          try:
+              payload = json.loads(payload_path.read_text(encoding="utf-8"))
+          except Exception as exc:  # noqa: BLE001 - diagnostics only
+              print(f"summary_payload_unavailable={exc.__class__.__name__}: {exc}")
+          else:
+              print("summary_ok=", payload.get("ok"))
+              print("summary_mode=", payload.get("mode"))
+              print("summary_error=", payload.get("error"))
+              warnings = payload.get("warnings") if isinstance(payload.get("warnings"), list) else []
+              print("summary_warning_count=", len(warnings))
+              for warning in warnings[:12]:
+                  print("summary_warning=", str(warning)[:500])
+          PY
+            exit "${summary_status}"
+          fi
 
       - name: Generate roadmap Pages artifacts
         run: |

--- a/scripts/generate-roadmap-page.py
+++ b/scripts/generate-roadmap-page.py
@@ -1046,7 +1046,7 @@ def load_runtime_kpi_report(repo_root: Path, paths: Sequence[str] | None = None)
 
     input_paths = runtime_history_input_paths(repo_root) if paths is None else list(paths)
     data, error = run_json(
-        [sys.executable, str(script_path), "--format", "json", "--", *input_paths],
+        [sys.executable, str(script_path), "--format", "json", "--include-monitor-source", "--", *input_paths],
         repo_root,
         timeout=45,
     )
@@ -1612,7 +1612,7 @@ def load_runtime_artifact_metric_history(
     input_paths = runtime_history_input_paths(repo_root) if paths is None else list(paths)
     selected_world_id = runtime_kpi_bridge.normalize_world_id(world_id) or runtime_kpi_bridge.PERSISTENT_WORLD_ID
     try:
-        scan_result = runtime_kpi_bridge.collect_runtime_summary_lines(input_paths)
+        scan_result = runtime_kpi_bridge.collect_runtime_summary_lines(input_paths, include_monitor_source=True)
     except Exception as error:
         return {}, {
             "status": "unavailable",

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -951,7 +951,8 @@ def collect_snapshots(ctx: RuntimeContext, room_arg: str | None) -> tuple[list[R
             warnings.extend(room_warnings)
 
     if not snapshots:
-        raise RuntimeError("no room snapshots collected")
+        detail = "; ".join(warnings[-12:]) if warnings else "no collection warnings recorded"
+        raise RuntimeError(f"no room snapshots collected: {detail}")
     return snapshots, warnings, overview_refs
 
 

--- a/scripts/screeps_runtime_kpi_artifact_bridge.py
+++ b/scripts/screeps_runtime_kpi_artifact_bridge.py
@@ -75,7 +75,12 @@ def positive_int(value: str) -> int:
     return parsed
 
 
-def collect_runtime_summary_lines(paths: Sequence[str], max_file_bytes: int = DEFAULT_MAX_FILE_BYTES) -> ScanResult:
+def collect_runtime_summary_lines(
+    paths: Sequence[str],
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+    *,
+    include_monitor_source: bool = False,
+) -> ScanResult:
     input_paths = list(paths) if paths else list(DEFAULT_INPUT_PATHS)
     result = ScanResult(input_paths=input_paths)
 
@@ -86,12 +91,12 @@ def collect_runtime_summary_lines(paths: Sequence[str], max_file_bytes: int = DE
             continue
 
         if path.is_file():
-            scan_file(path, result, max_file_bytes)
+            scan_file(path, result, max_file_bytes, include_monitor_source=include_monitor_source)
             continue
 
         if path.is_dir():
             for file_path in iter_directory_files(path, result):
-                scan_file(file_path, result, max_file_bytes)
+                scan_file(file_path, result, max_file_bytes, include_monitor_source=include_monitor_source)
             continue
 
         result.skip(path, "not_file_or_directory")
@@ -119,12 +124,12 @@ def iter_directory_files(root: Path, result: ScanResult) -> list[Path]:
 _MONITOR_FILE_PREFIX = "runtime-summary-monitor-"
 
 
-def scan_file(path: Path, result: ScanResult, max_file_bytes: int) -> None:
+def scan_file(path: Path, result: ScanResult, max_file_bytes: int, *, include_monitor_source: bool = False) -> None:
     if path.is_symlink():
         result.skip(path, "symlink")
         return
 
-    if path.name.startswith(_MONITOR_FILE_PREFIX):
+    if path.name.startswith(_MONITOR_FILE_PREFIX) and not include_monitor_source:
         result.skip(path, "monitor_source")
         return
 
@@ -250,8 +255,17 @@ def re_search_timestamp(pattern: str, value: str) -> datetime | None:
         return None
 
 
-def build_bridge_report(paths: Sequence[str], max_file_bytes: int = DEFAULT_MAX_FILE_BYTES) -> JsonObject:
-    scan_result = collect_runtime_summary_lines(paths, max_file_bytes)
+def build_bridge_report(
+    paths: Sequence[str],
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+    *,
+    include_monitor_source: bool = False,
+) -> JsonObject:
+    scan_result = collect_runtime_summary_lines(
+        paths,
+        max_file_bytes,
+        include_monitor_source=include_monitor_source,
+    )
     report = reducer.reduce_runtime_kpis(scan_result.lines)
     report["source"] = scan_result.metadata()
     return report
@@ -290,12 +304,24 @@ def build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_MAX_FILE_BYTES,
         help=f"Skip files larger than this many bytes. Default: {DEFAULT_MAX_FILE_BYTES}.",
     )
+    parser.add_argument(
+        "--include-monitor-source",
+        action="store_true",
+        help=(
+            "Include runtime-summary-monitor-* files produced by the external room monitor. "
+            "They are skipped by default to keep generic scans/RL datasets from consuming monitor-only artifacts."
+        ),
+    )
     return parser
 
 
 def main(argv: list[str] | None = None, stdout: TextIO = sys.stdout) -> int:
     args = build_parser().parse_args(argv)
-    report = build_bridge_report(args.paths, max_file_bytes=args.max_file_bytes)
+    report = build_bridge_report(
+        args.paths,
+        max_file_bytes=args.max_file_bytes,
+        include_monitor_source=args.include_monitor_source,
+    )
     output = render_human(report) if args.format == "human" else reducer.render_json(report)
     stdout.write(output)
     stdout.write("\n")

--- a/scripts/test_generate_roadmap_page.py
+++ b/scripts/test_generate_roadmap_page.py
@@ -510,14 +510,14 @@ class GenerateRoadmapPageTest(unittest.TestCase):
                 captured["command"] = command
                 captured["cwd"] = cwd
                 captured["timeout"] = timeout
-                return {"type": "runtime-kpi-report", "source": {"inputPaths": command[5:]}}, None
+                return {"type": "runtime-kpi-report", "source": {"inputPaths": command[6:]}}, None
 
             with patch.object(roadmap, "run_json", side_effect=fake_run_json):
                 report = roadmap.load_runtime_kpi_report(repo_root)
 
         command = captured["command"]
-        self.assertEqual(command[:4], [sys.executable, str(script_path), "--format", "json"])
-        self.assertEqual(command[4:], ["--", str(repo_root / "runtime-artifacts")])
+        self.assertEqual(command[:5], [sys.executable, str(script_path), "--format", "json", "--include-monitor-source"])
+        self.assertEqual(command[5:], ["--", str(repo_root / "runtime-artifacts")])
         self.assertEqual(captured["cwd"], repo_root)
         self.assertEqual(captured["timeout"], 45)
         self.assertEqual(report["source"]["inputPaths"], [str(repo_root / "runtime-artifacts")])

--- a/scripts/test_roadmap_pages_contract.py
+++ b/scripts/test_roadmap_pages_contract.py
@@ -117,6 +117,9 @@ class RoadmapPagesContractTests(unittest.TestCase):
         text = self.read(Path(".github/workflows/roadmap-pages-refresh.yml"))
 
         self.assertIn("SCREEPS_AUTH_TOKEN: ${{ secrets.SCREEPS_AUTH_TOKEN }}", text)
+        self.assertIn("SCREEPS_MONITOR_CACHE_DIR: runtime-artifacts/screeps-monitor/terrain-cache", text)
+        self.assertIn("SCREEPS_MONITOR_STATE_FILE: runtime-artifacts/screeps-monitor/state.json", text)
+        self.assertNotIn("SCREEPS_MONITOR_CACHE_DIR: /root/", text)
         self.assertIn("mkdir -p runtime-artifacts/screeps-monitor runtime-artifacts/runtime-summary-console runtime-artifacts/cron-output", text)
         self.assertIn("python3 scripts/screeps-runtime-monitor.py summary", text)
         self.assertIn("--out-dir runtime-artifacts/screeps-monitor", text)

--- a/scripts/test_screeps_runtime_kpi_artifact_bridge.py
+++ b/scripts/test_screeps_runtime_kpi_artifact_bridge.py
@@ -40,6 +40,26 @@ class RuntimeKpiArtifactBridgeTest(unittest.TestCase):
         self.assertEqual(report["input"]["runtimeSummaryCount"], 1)
         self.assertEqual(report["territory"]["ownedRooms"]["latest"], ["W1N1"])
 
+    def test_monitor_source_files_are_skipped_by_default_but_can_be_included(self) -> None:
+        payload = {
+            "type": "runtime-summary",
+            "tick": 100,
+            "rooms": [{"roomName": "W1N1"}],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "runtime-summary-monitor-20260524T084732Z.log"
+            path.write_text(runtime_line(payload), encoding="utf-8")
+
+            default_report = bridge.build_bridge_report([str(path)])
+            included_report = bridge.build_bridge_report([str(path)], include_monitor_source=True)
+
+        self.assertEqual(default_report["source"]["matchedFiles"], 0)
+        self.assertEqual(default_report["source"]["skippedFiles"], [{"path": str(path), "reason": "monitor_source"}])
+        self.assertEqual(included_report["source"]["matchedFiles"], 1)
+        self.assertEqual(included_report["source"]["runtimeSummaryLines"], 1)
+        self.assertEqual(included_report["territory"]["ownedRooms"]["latest"], ["W1N1"])
+
     def test_ignores_embedded_runtime_summary_markers(self) -> None:
         embedded = {"type": "runtime-summary", "tick": 5, "rooms": [{"roomName": "W9N9"}]}
         accepted = {"type": "runtime-summary", "tick": 10, "rooms": [{"roomName": "W1N1"}]}


### PR DESCRIPTION
## Summary
- keeps the roadmap Pages workflow's live Screeps monitor cache/state under repo-local `runtime-artifacts/` paths instead of the GitHub runner's unwritable `/root/.hermes` default
- makes monitor capture failures print sanitized JSON diagnostics so future refresh failures are actionable instead of silent
- lets the roadmap KPI bridge include `runtime-summary-monitor-*` files only when Pages generation asks for them, preserving the default skip for generic/RL scans

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/generate-roadmap-page.py scripts/screeps_runtime_kpi_artifact_bridge.py scripts/check-roadmap-pages-freshness.py scripts/check-roadmap-kpi-placeholders.py`
- `python3 -m unittest scripts/test_roadmap_pages_contract.py scripts/test_screeps_runtime_kpi_artifact_bridge.py scripts/test_generate_roadmap_page.py -v`
- live branch workflow run 26356665968 proved the repo-local cache path fixes the Actions `Permission denied: /root/.hermes/screeps-runtime-monitor/terrain-cache` capture failure
- local end-to-end generation with a fresh monitor artifact now reports runtime source `matchedFiles=1`, `runtimeSummaryLines=1`, KPI cards `rt_status=observed`, and `observedDays=1`

Related to issue #1379. Does not close it until the regenerated Pages artifact PR is merged and live Pages data is verified.
