### PR TITLE
fix(rl): self-heal Tencent known hosts

### DIFF
--- a/scripts/screeps_rl_live_dashboard.py
+++ b/scripts/screeps_rl_live_dashboard.py
@@ -105,6 +105,18 @@ HOST_KEY_SELF_HEAL_RETRY_STATUSES = {
     "host_key_scan_unavailable",
 }
 HOST_KEY_SELF_HEAL_FAILURE_STATUSES = {"host_key_self_healing_failed"}
+HOST_KEY_SELF_HEAL_UNAVAILABLE_STATUSES = {"host_key_self_healing_unavailable"}
+HOST_KEY_SELF_HEAL_UNSAFE_STATUSES = {"host_key_unverified_existing_entry_blocked"}
+HOST_KEY_SELF_HEAL_BLOCKED_STATUSES = (
+    HOST_KEY_SELF_HEAL_FAILURE_STATUSES
+    | HOST_KEY_SELF_HEAL_UNAVAILABLE_STATUSES
+    | HOST_KEY_SELF_HEAL_UNSAFE_STATUSES
+)
+HOST_KEY_SELF_HEAL_BLOCKED_CLASSIFICATIONS = {
+    "host_key_self_healing_failed": "SSH_HOST_KEY_SELF_HEALING_FAILED",
+    "host_key_self_healing_unavailable": "SSH_HOST_KEY_SELF_HEALING_UNAVAILABLE",
+    "host_key_unverified_existing_entry_blocked": "SSH_HOST_KEY_SELF_HEALING_UNSAFE",
+}
 HOST_KEY_SELF_HEAL_STEP_NAMES = {
     "accept_new_worker_known_host",
     "clear_worker_known_host",
@@ -824,9 +836,10 @@ def classify_tencent_batch_run_state(payload: JsonObject, *, now: Any | None = N
         "action": "none",
     }
     if known_hosts_self_heal.get("status") == "BLOCKED":
+        classification = text_value(known_hosts_self_heal.get("classification")) or "SSH_HOST_KEY_SELF_HEALING_FAILED"
         state.update(
             {
-                "status": "SSH_HOST_KEY_SELF_HEALING_FAILED",
+                "status": classification,
                 "handoffRequired": True,
                 "handoffSeverity": "P1",
                 "action": "inspect Tencent known_hosts self-heal failure before retrying SSH work",
@@ -1004,7 +1017,7 @@ def known_hosts_self_heal_summary(payload: JsonObject) -> JsonObject:
             name not in HOST_KEY_SELF_HEAL_STEP_NAMES
             and status not in HOST_KEY_SELF_HEAL_SUCCESS_STATUSES
             and status not in HOST_KEY_SELF_HEAL_RETRY_STATUSES
-            and status not in HOST_KEY_SELF_HEAL_FAILURE_STATUSES
+            and status not in HOST_KEY_SELF_HEAL_BLOCKED_STATUSES
         ):
             continue
         detail = as_dict(step.get("detail"))
@@ -1030,18 +1043,35 @@ def known_hosts_self_heal_summary(payload: JsonObject) -> JsonObject:
 
     retry_records = [record for record in records if record.get("status") in HOST_KEY_SELF_HEAL_RETRY_STATUSES]
     success_records = [record for record in records if record.get("status") in HOST_KEY_SELF_HEAL_SUCCESS_STATUSES]
-    failure_records = [record for record in records if record.get("status") in HOST_KEY_SELF_HEAL_FAILURE_STATUSES]
+    blocked_records = [record for record in records if record.get("status") in HOST_KEY_SELF_HEAL_BLOCKED_STATUSES]
     last_success = success_records[-1] if success_records else None
-    last_failure = failure_records[-1] if failure_records else None
-    if last_failure is not None and (last_success is None or last_failure["index"] > last_success["index"]):
+    last_blocked = blocked_records[-1] if blocked_records else None
+    if last_blocked is not None and (last_success is None or last_blocked["index"] > last_success["index"]):
+        blocked_status = text_value(last_blocked.get("status")) or "host_key_self_healing_failed"
+        classification = HOST_KEY_SELF_HEAL_BLOCKED_CLASSIFICATIONS.get(
+            blocked_status,
+            "SSH_HOST_KEY_SELF_HEALING_FAILED",
+        )
+        if blocked_status in HOST_KEY_SELF_HEAL_UNAVAILABLE_STATUSES:
+            evidence = (
+                "known_hosts self-healing still unavailable after "
+                f"{len(retry_records)} retry/status attempt(s); latestStatus={blocked_status}"
+            )
+        elif blocked_status in HOST_KEY_SELF_HEAL_UNSAFE_STATUSES:
+            evidence = (
+                "known_hosts self-healing blocked an unsafe host-key state after "
+                f"{len(retry_records)} retry/status attempt(s); latestStatus={blocked_status}"
+            )
+        else:
+            evidence = (
+                "known_hosts self-healing failed after "
+                f"{len(retry_records)} retry/status attempt(s); latestStatus={blocked_status}"
+            )
         return {
             "status": "BLOCKED",
-            "classification": "SSH_HOST_KEY_SELF_HEALING_FAILED",
+            "classification": classification,
             "handoffRequired": True,
-            "evidence": (
-                "known_hosts self-healing failed after "
-                f"{len(retry_records)} retry/status attempt(s); latestStatus={last_failure.get('status')}"
-            ),
+            "evidence": evidence,
             "steps": records,
         }
     if retry_records and last_success is not None:

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -543,13 +543,27 @@ class Controller:
             return KnownHostPrepareResult(False, "host_key_self_healing_failed", reason="public IP is not known")
         self.known_hosts_prepared_public_ips.discard(self.public_ip)
         self.known_hosts_cleaned_public_ips.discard(self.public_ip)
+        if not self.clear_worker_known_host():
+            return KnownHostPrepareResult(
+                False,
+                "host_key_self_healing_failed",
+                reason="ssh-keygen failed while clearing stale known_hosts after host-key mismatch",
+            )
         scan_result, scanned_lines = self.scan_worker_host_keys()
         if not scan_result.ok:
-            reason = "host-key mismatch remains blocked because ssh-keyscan could not verify replacement keys"
+            reason = (
+                "host-key mismatch remains blocked after clearing stale known_hosts entry "
+                "because ssh-keyscan could not verify replacement keys"
+            )
             if scan_result.reason:
                 reason = f"{reason}: {scan_result.reason}"
-            return KnownHostPrepareResult(False, "host_key_self_healing_failed", reason=reason)
-        return self.install_worker_known_host(scanned_lines, had_plain_entry=False)
+            status = (
+                "host_key_self_healing_unavailable"
+                if scan_result.status == "host_key_scan_unavailable"
+                else "host_key_self_healing_failed"
+            )
+            return KnownHostPrepareResult(False, status, retryable=False, reason=reason)
+        return self.install_worker_known_host(scanned_lines, had_plain_entry=True)
 
     def scp_to_worker(self, name: str, local_path: Path, remote_path: str, *, timeout: int = 300) -> None:
         self.require_worker_known_host_prepared(name)
@@ -733,24 +747,40 @@ class Controller:
             )
 
         if current_lines:
+            if not self.clear_worker_known_host():
+                return KnownHostPrepareResult(
+                    False,
+                    "host_key_self_healing_failed",
+                    reason="ssh-keygen failed while clearing stale known_hosts before replacement keyscan",
+                )
+            rescan_result, rescanned_lines = self.scan_worker_host_keys()
+            if rescan_result.ok:
+                return self.install_worker_known_host(rescanned_lines, had_plain_entry=True)
+            status = (
+                "host_key_unverified_existing_entry_blocked"
+                if rescan_result.status == "host_key_scan_unavailable"
+                else "host_key_self_healing_failed"
+            )
+            reason = (
+                "existing known_hosts entry was not trusted after ssh-keyscan returned no replacement keys"
+            )
+            if rescan_result.reason:
+                reason = f"{reason}: {rescan_result.reason}"
             self.record_step(
                 "prepare_worker_known_host",
                 started,
-                True,
+                False,
                 None,
                 publicIp=self.public_ip,
                 knownHostsFile=str(known_hosts),
-                status="existing_known_host_keyscan_unavailable",
-                keyscanStatus=scan_result.status,
-                hostKeyCount=len(current_lines),
+                status=status,
+                retryable=False,
+                keyscanStatus=rescan_result.status,
+                staleKnownHostRemoved=True,
+                unsafeExistingKnownHostBlocked=True,
+                hostKeyCount=0,
             )
-            self.mark_worker_known_host_prepared()
-            return KnownHostPrepareResult(
-                True,
-                "existing_known_host_keyscan_unavailable",
-                reason=scan_result.reason,
-                host_key_count=len(current_lines),
-            )
+            return KnownHostPrepareResult(False, status, retryable=False, reason=reason)
 
         if not self.clear_worker_known_host():
             return KnownHostPrepareResult(
@@ -1828,7 +1858,11 @@ def classify_ssh_process_failure(cp: subprocess.CompletedProcess[str]) -> str:
     combined = "\n".join(part for part in (cp.stderr, cp.stdout) if part)
     if SSH_HOST_KEY_MISMATCH_RE.search(combined):
         return "host_key_mismatch"
-    if "host_key_self_healing_failed" in combined:
+    if (
+        "host_key_self_healing_failed" in combined
+        or "host_key_self_healing_unavailable" in combined
+        or "host_key_unverified_existing_entry_blocked" in combined
+    ):
         return "host_key_self_healing_failed"
     if SSH_NETWORK_UNREACHABLE_RE.search(combined) or "network_unreachable" in combined:
         return "network_unreachable"
@@ -1851,6 +1885,10 @@ def ssh_prepare_failure_completed_process(
 def ssh_prepare_failure_message(operation_name: str, result: KnownHostPrepareResult) -> str:
     if result.status == "network_unreachable":
         return f"{operation_name} skipped: worker network unreachable before SSH host-key verification: {result.reason}"
+    if result.status == "host_key_self_healing_unavailable":
+        return f"{operation_name} blocked: SSH known_hosts self-healing could not verify replacement keys: {result.reason}"
+    if result.status == "host_key_unverified_existing_entry_blocked":
+        return f"{operation_name} blocked: SSH known_hosts self-healing refused an unverified existing entry: {result.reason}"
     if result.retryable:
         return f"{operation_name} skipped: SSH host-key verification not ready: {result.reason}"
     return f"{operation_name} blocked: SSH known_hosts self-healing failed: {result.reason}"

--- a/scripts/test_screeps_rl_live_dashboard.py
+++ b/scripts/test_screeps_rl_live_dashboard.py
@@ -850,6 +850,140 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
         self.assertEqual(state["handoffSeverity"], "P1")
         self.assertEqual(state["knownHostsSelfHeal"]["classification"], "SSH_HOST_KEY_SELF_HEALING_FAILED")
 
+    def test_known_hosts_stale_clear_rescan_success_is_recovered(self) -> None:
+        payload = {
+            "type": "screeps-tencent-batch-rl-run",
+            "runId": "tencent-pg-host-key-recovered",
+            "startedAt": "2026-05-23T12:10:05Z",
+            "finishedAt": None,
+            "partial": True,
+            "finalStatus": "running",
+            "controllerProcess": {"pid": 1205},
+            "inputs": {"executionTimeouts": {"totalSeconds": 12300}},
+            "execution": {
+                "environmentsRun": 0,
+                "artifactCount": 0,
+                "trainingReportProduced": False,
+            },
+            "steps": [
+                {
+                    "name": "scan_worker_host_key",
+                    "ok": False,
+                    "detail": {"status": "host_key_scan_unavailable", "retryable": True, "attempt": 1},
+                },
+                {
+                    "name": "clear_worker_known_host",
+                    "ok": True,
+                    "detail": {"warning": False},
+                },
+                {
+                    "name": "scan_worker_host_key",
+                    "ok": True,
+                    "detail": {"status": "host_key_scanned", "retryable": False, "attempt": 1},
+                },
+                {
+                    "name": "install_worker_known_host",
+                    "ok": True,
+                    "detail": {"status": "rotated_known_host", "hostKeyCount": 3},
+                },
+            ],
+        }
+
+        state = live.classify_tencent_batch_run_state(payload, now="2026-05-23T12:20:00Z")
+
+        self.assertEqual(state["status"], "TRAINING_IN_PROGRESS")
+        self.assertFalse(state["handoffRequired"])
+        known_hosts = state["knownHostsSelfHeal"]
+        self.assertEqual(known_hosts["status"], "OK")
+        self.assertEqual(known_hosts["classification"], "SSH_HOST_KEY_SELF_HEALING_RECOVERED")
+        self.assertIn("recovered via rotated_known_host", known_hosts["evidence"])
+
+    def test_known_hosts_still_unavailable_after_stale_clear_requires_specific_handoff(self) -> None:
+        payload = {
+            "type": "screeps-tencent-batch-rl-run",
+            "runId": "tencent-pg-host-key-unavailable",
+            "startedAt": "2026-05-23T12:10:05Z",
+            "finishedAt": "2026-05-23T12:12:05Z",
+            "partial": False,
+            "finalStatus": "failed",
+            "steps": [
+                {
+                    "name": "scan_worker_host_key",
+                    "ok": False,
+                    "detail": {"status": "host_key_scan_unavailable", "retryable": True, "attempt": 1},
+                },
+                {
+                    "name": "clear_worker_known_host",
+                    "ok": True,
+                    "detail": {"warning": False},
+                },
+                {
+                    "name": "scan_worker_host_key",
+                    "ok": False,
+                    "detail": {"status": "host_key_scan_unavailable", "retryable": True, "attempt": 1},
+                },
+                {
+                    "name": "prepare_worker_known_host",
+                    "ok": False,
+                    "detail": {
+                        "status": "host_key_self_healing_unavailable",
+                        "retryable": False,
+                        "staleKnownHostRemoved": True,
+                        "unsafeExistingKnownHostBlocked": True,
+                    },
+                },
+            ],
+        }
+
+        state = live.classify_tencent_batch_run_state(payload, now="2026-05-23T12:20:00Z")
+
+        self.assertEqual(state["status"], "SSH_HOST_KEY_SELF_HEALING_UNAVAILABLE")
+        self.assertTrue(state["handoffRequired"])
+        self.assertEqual(state["handoffSeverity"], "P1")
+        known_hosts = state["knownHostsSelfHeal"]
+        self.assertEqual(known_hosts["classification"], "SSH_HOST_KEY_SELF_HEALING_UNAVAILABLE")
+        self.assertIn("still unavailable", known_hosts["evidence"])
+
+    def test_known_hosts_unverified_existing_entry_requires_unsafe_handoff(self) -> None:
+        payload = {
+            "type": "screeps-tencent-batch-rl-run",
+            "runId": "tencent-pg-host-key-unsafe",
+            "startedAt": "2026-05-23T12:10:05Z",
+            "finishedAt": "2026-05-23T12:12:05Z",
+            "partial": False,
+            "finalStatus": "failed",
+            "steps": [
+                {
+                    "name": "scan_worker_host_key",
+                    "ok": False,
+                    "detail": {"status": "host_key_scan_unavailable", "retryable": True, "attempt": 1},
+                },
+                {
+                    "name": "clear_worker_known_host",
+                    "ok": True,
+                    "detail": {"warning": False},
+                },
+                {
+                    "name": "prepare_worker_known_host",
+                    "ok": False,
+                    "detail": {
+                        "status": "host_key_unverified_existing_entry_blocked",
+                        "retryable": False,
+                        "staleKnownHostRemoved": True,
+                        "unsafeExistingKnownHostBlocked": True,
+                    },
+                },
+            ],
+        }
+
+        state = live.classify_tencent_batch_run_state(payload, now="2026-05-23T12:20:00Z")
+
+        self.assertEqual(state["status"], "SSH_HOST_KEY_SELF_HEALING_UNSAFE")
+        self.assertTrue(state["handoffRequired"])
+        known_hosts = state["knownHostsSelfHeal"]
+        self.assertEqual(known_hosts["classification"], "SSH_HOST_KEY_SELF_HEALING_UNSAFE")
+        self.assertIn("unsafe host-key state", known_hosts["evidence"])
+
     def test_health_helper_requires_successful_auto_refresh(self) -> None:
         health = live.health_with_refresh(
             {"ok": True, "status": "ok", "failures": []},

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -4277,6 +4277,91 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(controller.steps[-1].detail["status"], "new_known_host")
         self.assertIn("203.0.113.10", controller.known_hosts_prepared_public_ips)
 
+    def test_prepare_worker_known_host_clears_stale_entry_and_rescans_after_empty_keyscan(self) -> None:
+        stale_key = "203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIstale"
+        current_key = "203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIcurrent"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args = controller_args()
+            args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
+            known_hosts = Path(args.known_hosts_path)
+            known_hosts.write_text(stale_key + "\n", encoding="utf-8")
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
+            controller.public_ip = "203.0.113.10"
+            keyscan_calls = 0
+
+            def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                nonlocal keyscan_calls
+                if cmd[0] == "ssh-keyscan":
+                    keyscan_calls += 1
+                    if keyscan_calls <= 3:
+                        return subprocess.CompletedProcess(cmd, 1, "", "")
+                    return subprocess.CompletedProcess(cmd, 0, current_key + "\n", "")
+                if cmd[0] == "ssh-keygen":
+                    known_hosts.write_text("", encoding="utf-8")
+                    return subprocess.CompletedProcess(cmd, 0, "# Host 203.0.113.10 found: line 1\nknown_hosts updated.\n", "")
+                raise AssertionError(cmd)
+
+            with (
+                mock.patch.object(runner.subprocess, "run", side_effect=fake_run),
+                mock.patch.object(runner.time, "sleep", return_value=None) as sleep,
+            ):
+                result = controller.prepare_worker_known_host()
+
+            self.assertTrue(result.ok)
+            self.assertEqual(result.status, "rotated_known_host")
+            self.assertEqual(known_hosts.read_text(encoding="utf-8"), current_key + "\n")
+
+        self.assertEqual(keyscan_calls, 4)
+        sleep.assert_has_calls([mock.call(2.0), mock.call(5.0)])
+        self.assertEqual(
+            [step.name for step in controller.steps],
+            [
+                "scan_worker_host_key",
+                "scan_worker_host_key",
+                "scan_worker_host_key",
+                "clear_worker_known_host",
+                "scan_worker_host_key",
+                "install_worker_known_host",
+            ],
+        )
+        self.assertEqual(controller.steps[3].detail["warning"], False)
+        self.assertEqual(controller.steps[-1].detail["status"], "rotated_known_host")
+        self.assertIn("203.0.113.10", controller.known_hosts_prepared_public_ips)
+
+    def test_prepare_worker_known_host_blocks_unverified_existing_entry_when_rescan_stays_empty(self) -> None:
+        stale_key = "203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIstale"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args = controller_args()
+            args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
+            known_hosts = Path(args.known_hosts_path)
+            known_hosts.write_text(stale_key + "\n", encoding="utf-8")
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
+            controller.public_ip = "203.0.113.10"
+
+            def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                if cmd[0] == "ssh-keyscan":
+                    return subprocess.CompletedProcess(cmd, 1, "", "")
+                if cmd[0] == "ssh-keygen":
+                    known_hosts.write_text("", encoding="utf-8")
+                    return subprocess.CompletedProcess(cmd, 0, "# Host 203.0.113.10 found: line 1\nknown_hosts updated.\n", "")
+                raise AssertionError(cmd)
+
+            with (
+                mock.patch.object(runner.subprocess, "run", side_effect=fake_run),
+                mock.patch.object(runner.time, "sleep", return_value=None),
+            ):
+                result = controller.prepare_worker_known_host()
+
+            self.assertFalse(result.ok)
+            self.assertFalse(result.retryable)
+            self.assertEqual(result.status, "host_key_unverified_existing_entry_blocked")
+            self.assertEqual(known_hosts.read_text(encoding="utf-8"), "")
+
+        self.assertEqual(controller.steps[-1].detail["status"], "host_key_unverified_existing_entry_blocked")
+        self.assertTrue(controller.steps[-1].detail["staleKnownHostRemoved"])
+        self.assertTrue(controller.steps[-1].detail["unsafeExistingKnownHostBlocked"])
+        self.assertNotIn("203.0.113.10", controller.known_hosts_prepared_public_ips)
+
     def test_prepare_worker_known_host_accept_new_fallback_after_empty_keyscan_attempts(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             args = controller_args()
@@ -4490,6 +4575,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(
             [step.name for step in controller.steps],
             [
+                "clear_worker_known_host",
                 "scan_worker_host_key",
                 "scan_worker_host_key",
                 "scan_worker_host_key",
@@ -4528,6 +4614,9 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
 
             def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
                 nonlocal keyscan_calls
+                if cmd[0] == "ssh-keygen":
+                    known_hosts.write_text("", encoding="utf-8")
+                    return subprocess.CompletedProcess(cmd, 0, "# Host 203.0.113.10 found: line 1\nknown_hosts updated.\n", "")
                 if cmd[0] == "ssh-keyscan":
                     keyscan_calls += 1
                     return subprocess.CompletedProcess(cmd, 1, "", "")
@@ -4541,9 +4630,9 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 cp = controller.ssh_cmd("ssh_probe", "true", check=False)
 
             self.assertEqual(cp.returncode, 255)
-            self.assertIn("host_key_self_healing_failed", cp.stderr)
+            self.assertIn("host_key_self_healing_unavailable", cp.stderr)
             self.assertIn("host-key mismatch remains blocked", cp.stderr)
-            self.assertEqual(known_hosts.read_text(encoding="utf-8"), stale_key + "\n")
+            self.assertEqual(known_hosts.read_text(encoding="utf-8"), "")
 
         self.assertEqual(keyscan_calls, 3)
         sleep.assert_has_calls([mock.call(2.0), mock.call(5.0)])
@@ -4551,13 +4640,14 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(
             [step.name for step in controller.steps],
             [
+                "clear_worker_known_host",
                 "scan_worker_host_key",
                 "scan_worker_host_key",
                 "scan_worker_host_key",
                 "ssh_probe",
             ],
         )
-        self.assertEqual(controller.steps[-1].detail["sshFailureClass"], "host_key_self_healing_failed")
+        self.assertEqual(controller.steps[-1].detail["sshFailureClass"], "host_key_self_healing_unavailable")
         self.assertFalse(controller.steps[-1].detail["retryable"])
         self.assertNotIn("203.0.113.10", controller.known_hosts_prepared_public_ips)
 
@@ -4617,7 +4707,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 self.assertNotIn("StrictHostKeyChecking=accept-new", cmd)
         self.assertEqual(
             [step.name for step in controller.steps],
-            ["scan_worker_host_key", "install_worker_known_host"],
+            ["clear_worker_known_host", "scan_worker_host_key", "install_worker_known_host"],
         )
         self.assertIn("203.0.113.10", controller.known_hosts_prepared_public_ips)
 


### PR DESCRIPTION
## Summary
- Adds bounded Tencent known_hosts self-healing when ssh-keyscan returns no keys for an instance with a stale/rotated host entry.
- Preserves strict host-key safety by clearing only the targeted host entry, rescanning, and classifying unsafe/unavailable states instead of disabling checks globally.
- Extends the RL live-dashboard classifier/tests so Loop A can distinguish self-healed, unavailable, and unsafe known_hosts outcomes.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/screeps_rl_live_dashboard.py`
- `python3 -m unittest scripts.test_screeps_tencent_batch_rl_runner scripts.test_screeps_rl_live_dashboard` — PASS, 147 tests in 8.409s

## Safety / operations
- No Tencent paid compute was launched or stopped by this PR.
- Active runner `tencent-pg-20260524t111444z` remains a scheduler/compute follow-up outside this PR.
- The issue should stay open until a later Loop A ledger clears `SSH_HOST_KEY_SELF_HEALING_GAP` or cites this actioned fix.

Refs #1394
