### PR TITLE
fix(rl): recover runtime parameter consumption from mongo console

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -98,6 +98,8 @@ RUNTIME_PARAMETER_CONSUMPTION_TYPE = "screeps-rl-runtime-policy-parameter-consum
 RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER = "screeps-rl-runtime-policy-parameters-consumer-v1"
 RUNTIME_PARAMETER_INJECTION_CONSUMER_VERSION = "v1"
 RUNTIME_PARAMETER_CONSUMPTION_LOG_PREFIX = "#runtime-parameter-consumption "
+MONGO_CONSOLE_RUNTIME_PARAMETER_OUTPUT_LIMIT = 200000
+MONGO_CONSOLE_RUNTIME_PARAMETER_PAYLOAD_LIMIT = 180000
 STRICT_DIRECTIVE_PREFIX_RE = re.compile(
     r"\A(\ufeff?(?:(?:\s+)|(?://[^\r\n]*(?:\r?\n|$))|(?:/\*.*?\*/))*"
     r"(?:(?:['\"]use strict['\"]\s*;?\s*)+))",
@@ -1068,6 +1070,7 @@ const candidateLimit = 200;
 const collectionLimit = 24;
 const documentLimit = 200;
 const stringLimit = 4000;
+const payloadLimit = {MONGO_CONSOLE_RUNTIME_PARAMETER_PAYLOAD_LIMIT};
 const pushLine = value => {{
   if (lines.length >= candidateLimit || typeof value !== 'string' || !value.includes(marker)) return;
   lines.push(value.slice(0, stringLimit));
@@ -1106,42 +1109,78 @@ const collectionNames = smokeDb.getCollectionNames()
 let scannedCollections = 0;
 let scannedDocuments = 0;
 const scanCollection = (collectionName, query) => {{
-  if (lines.length >= candidateLimit) return;
+  if (lines.length >= candidateLimit) return false;
+  const beforeLineCount = lines.length;
   const collection = smokeDb.getCollection(collectionName);
   const cursor = collection.find(query || {{}}).sort({{_id: -1}}).limit(documentLimit);
   while (cursor.hasNext() && lines.length < candidateLimit) {{
     scannedDocuments += 1;
     scanValue(cursor.next());
   }}
+  return lines.length > beforeLineCount;
 }};
 for (const collectionName of collectionNames) {{
   scannedCollections += 1;
   try {{
+    let collectionAddedLines = false;
     if (userClauses.length > 0) {{
-      scanCollection(collectionName, {{$or: userClauses}});
+      collectionAddedLines = scanCollection(collectionName, {{$or: userClauses}}) || collectionAddedLines;
     }}
-    if (lines.length === 0) {{
+    if (!collectionAddedLines && lines.length < candidateLimit) {{
       scanCollection(collectionName, {{}});
     }}
   }} catch (err) {{}}
   if (lines.length >= candidateLimit) break;
 }}
-print(JSON.stringify({{
+const makePayload = () => ({{
   ok: true,
   lines,
   scannedCollections,
   scannedDocuments,
   collectionNames,
-}}));
+}});
+let payload = makePayload();
+let jsonText = JSON.stringify(payload);
+while (jsonText.length > payloadLimit && lines.length > 0) {{
+  lines.pop();
+  payload = makePayload();
+  jsonText = JSON.stringify(payload);
+}}
+if (jsonText.length > payloadLimit) {{
+  payload = {{
+    ok: true,
+    lines: [],
+    scannedCollections,
+    scannedDocuments,
+    collectionNames: [],
+  }};
+  jsonText = JSON.stringify(payload);
+}}
+print(jsonText);
 """.strip()
     command = [*compose, "exec", "-T", "mongo", "mongosh", "--quiet", "--eval", eval_script]
-    result = smoke.run_command(command, cfg, timeout=60, output_limit=200000)
+    result = smoke.run_command(
+        command,
+        cfg,
+        timeout=60,
+        output_limit=MONGO_CONSOLE_RUNTIME_PARAMETER_OUTPUT_LIMIT,
+    )
     if result.get("returncode") != 0:
-        return None
+        output = result.get("output_excerpt")
+        if not output:
+            output = "\n".join(str(part) for part in (result.get("stdout"), result.get("stderr")) if part)
+        raise RuntimeError(
+            "mongo console runtime-parameter probe failed: "
+            f"exit={result.get('returncode')} "
+            f"output={_safe_text(output, 240)}"
+        )
     try:
         payload = _json_payload_from_command_output(result.get("output_excerpt", ""))
-    except (IndexError, json.JSONDecodeError):
-        return None
+    except (IndexError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            "mongo console runtime-parameter probe returned malformed JSON: "
+            f"{_safe_text(result.get('output_excerpt', ''), 240)}"
+        ) from exc
     lines = payload.get("lines") if isinstance(payload, dict) else None
     if not isinstance(lines, list):
         return None

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -943,6 +943,10 @@ def collect_runtime_parameter_consumption_evidence(
     collectors = [
         ("Memory.rlRuntimePolicyParameters", _collect_http_runtime_parameter_consumption_evidence),
         ("console.runtimePolicyParameterConsumption", _collect_console_runtime_parameter_consumption_evidence),
+        (
+            "mongo.console.runtimePolicyParameterConsumption",
+            _collect_mongo_console_runtime_parameter_consumption_evidence,
+        ),
         ("redis.Memory.rlRuntimePolicyParameters", _collect_redis_runtime_parameter_consumption_evidence),
         ("mongo.Memory.rlRuntimePolicyParameters", _collect_mongo_runtime_parameter_consumption_evidence),
     ]
@@ -1039,6 +1043,110 @@ def _collect_console_runtime_parameter_consumption_evidence(
         result.get("output_excerpt", ""),
         injection=injection,
     )
+
+
+def _collect_mongo_console_runtime_parameter_consumption_evidence(
+    smoke: Any,
+    compose: Sequence[str] | None,
+    cfg: Any,
+    token: str | None,
+    injection: JsonObject | None = None,
+) -> JsonObject | None:
+    _ = token
+    if compose is None:
+        return None
+    mongo_db = text_or_none(getattr(cfg, "mongo_db", None))
+    username = text_or_none(getattr(cfg, "username", None))
+    if mongo_db is None or username is None:
+        return None
+    eval_script = f"""
+const smokeDb = db.getSiblingDB({json.dumps(mongo_db)});
+const user = smokeDb.getCollection('users').findOne({{username: {json.dumps(username)}}}, {{_id: 1, username: 1}});
+const marker = {json.dumps(RUNTIME_PARAMETER_CONSUMPTION_LOG_PREFIX)};
+const lines = [];
+const candidateLimit = 200;
+const collectionLimit = 24;
+const documentLimit = 200;
+const stringLimit = 4000;
+const pushLine = value => {{
+  if (lines.length >= candidateLimit || typeof value !== 'string' || !value.includes(marker)) return;
+  lines.push(value.slice(0, stringLimit));
+}};
+const scanValue = (value, depth = 0) => {{
+  if (lines.length >= candidateLimit || value === null || value === undefined || depth > 6) return;
+  if (typeof value === 'string') {{
+    pushLine(value);
+    return;
+  }}
+  if (Array.isArray(value)) {{
+    for (const item of value) {{
+      scanValue(item, depth + 1);
+      if (lines.length >= candidateLimit) return;
+    }}
+    return;
+  }}
+  if (typeof value === 'object') {{
+    for (const item of Object.values(value)) {{
+      scanValue(item, depth + 1);
+      if (lines.length >= candidateLimit) return;
+    }}
+  }}
+}};
+const userClauses = [];
+if (user) {{
+  userClauses.push({{user: user._id}});
+  userClauses.push({{user: String(user._id)}});
+  userClauses.push({{username: user.username}});
+  userClauses.push({{'user.username': user.username}});
+  userClauses.push({{'owner.username': user.username}});
+}}
+const collectionNames = smokeDb.getCollectionNames()
+  .filter(name => /console|log/i.test(name))
+  .slice(0, collectionLimit);
+let scannedCollections = 0;
+let scannedDocuments = 0;
+const scanCollection = (collectionName, query) => {{
+  if (lines.length >= candidateLimit) return;
+  const collection = smokeDb.getCollection(collectionName);
+  const cursor = collection.find(query || {{}}).sort({{_id: -1}}).limit(documentLimit);
+  while (cursor.hasNext() && lines.length < candidateLimit) {{
+    scannedDocuments += 1;
+    scanValue(cursor.next());
+  }}
+}};
+for (const collectionName of collectionNames) {{
+  scannedCollections += 1;
+  try {{
+    if (userClauses.length > 0) {{
+      scanCollection(collectionName, {{$or: userClauses}});
+    }}
+    if (lines.length === 0) {{
+      scanCollection(collectionName, {{}});
+    }}
+  }} catch (err) {{}}
+  if (lines.length >= candidateLimit) break;
+}}
+print(JSON.stringify({{
+  ok: true,
+  lines,
+  scannedCollections,
+  scannedDocuments,
+  collectionNames,
+}}));
+""".strip()
+    command = [*compose, "exec", "-T", "mongo", "mongosh", "--quiet", "--eval", eval_script]
+    result = smoke.run_command(command, cfg, timeout=60, output_limit=200000)
+    if result.get("returncode") != 0:
+        return None
+    try:
+        payload = _json_payload_from_command_output(result.get("output_excerpt", ""))
+    except (IndexError, json.JSONDecodeError):
+        return None
+    lines = payload.get("lines") if isinstance(payload, dict) else None
+    if not isinstance(lines, list):
+        return None
+    output = "\n".join(line for line in lines if isinstance(line, str))
+    return runtime_parameter_consumption_evidence_from_console_output(output, injection=injection)
 
 
 def runtime_parameter_consumption_evidence_from_console_output(

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -2339,6 +2339,85 @@ cli:
         self.assertEqual(extracted, expected)
         self.assertEqual(errors, [])
 
+    def test_runtime_parameter_consumption_collection_accepts_mongo_console_tick_evidence(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+        line = harness.RUNTIME_PARAMETER_CONSUMPTION_LOG_PREFIX + json.dumps(evidence, sort_keys=True)
+
+        class FakeConfig:
+            mongo_db = "screeps"
+            username = "bot"
+            shard = "shardX"
+
+        class FakeSmoke:
+            command: list[str] | None = None
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout, output_limit
+                self.command = command
+                if "logs" in command:
+                    return {"returncode": 0, "output_excerpt": "private server logs without Screeps console output"}
+                if "mongosh" in command:
+                    return {
+                        "returncode": 0,
+                        "output_excerpt": json.dumps({
+                            "ok": True,
+                            "lines": ["noise", line],
+                            "collectionNames": ["users.console"],
+                        }),
+                    }
+                raise AssertionError(command)
+
+        with (
+            mock.patch.object(
+                harness,
+                "_collect_http_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ),
+            mock.patch.object(
+                harness,
+                "_collect_redis_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ),
+            mock.patch.object(
+                harness,
+                "_collect_mongo_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ),
+        ):
+            extracted, errors = harness.collect_runtime_parameter_consumption_evidence(
+                FakeSmoke(),
+                ["docker", "compose"],
+                FakeConfig(),
+                None,
+                injection,
+            )
+
+        expected = copy.deepcopy(evidence)
+        expected["source"] = "mongo.console.runtimePolicyParameterConsumption"
+        self.assertEqual(extracted, expected)
+        self.assertEqual(errors, [])
+
+        consumption = harness.runtime_parameter_consumption_check(injection, extracted)
+        updated = harness.apply_runtime_parameter_consumption_to_injection(injection, consumption)
+        summary = harness._run_runtime_parameter_injection_summary([
+            {
+                "variant_id": "construction-priority.pg.territory-seed.v1",
+                "runtimeParameterInjection": updated,
+            }
+        ])
+
+        self.assertTrue(summary["runtimeParameterConsumption"])
+        self.assertEqual(summary["consumedVariantCount"], 1)
+        self.assertEqual(summary["runtimeParameterConsumptionStatus"], "consumed")
+
     def test_runtime_parameter_consumption_collection_records_console_probe_error(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
 

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -2418,6 +2418,230 @@ cli:
         self.assertEqual(summary["consumedVariantCount"], 1)
         self.assertEqual(summary["runtimeParameterConsumptionStatus"], "consumed")
 
+    def test_mongo_console_runtime_parameter_consumption_collector_bounds_payload_before_output_limit(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+        line = harness.RUNTIME_PARAMETER_CONSUMPTION_LOG_PREFIX + json.dumps(evidence, sort_keys=True)
+        unbounded_payload = json.dumps({
+            "ok": True,
+            "lines": ["x" * 4000 for _ in range(200)],
+            "scannedCollections": 24,
+            "scannedDocuments": 200,
+            "collectionNames": ["users.console"],
+        })
+
+        class FakeConfig:
+            mongo_db = "screeps"
+            username = "bot"
+            shard = "shardX"
+
+        captured: dict[str, object] = {}
+
+        class FakeSmoke:
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout
+                captured["eval_script"] = command[-1]
+                captured["output_limit"] = output_limit
+                return {
+                    "returncode": 0,
+                    "output_excerpt": json.dumps({
+                        "ok": True,
+                        "lines": [line],
+                        "collectionNames": ["users.console"],
+                    }),
+                }
+
+        extracted = harness._collect_mongo_console_runtime_parameter_consumption_evidence(
+            FakeSmoke(),
+            ["docker", "compose"],
+            FakeConfig(),
+            None,
+            injection,
+        )
+
+        self.assertEqual(extracted, evidence)
+        self.assertGreater(len(unbounded_payload), harness.MONGO_CONSOLE_RUNTIME_PARAMETER_OUTPUT_LIMIT)
+        self.assertEqual(captured["output_limit"], harness.MONGO_CONSOLE_RUNTIME_PARAMETER_OUTPUT_LIMIT)
+        self.assertLess(
+            harness.MONGO_CONSOLE_RUNTIME_PARAMETER_PAYLOAD_LIMIT,
+            harness.MONGO_CONSOLE_RUNTIME_PARAMETER_OUTPUT_LIMIT,
+        )
+        eval_script = str(captured["eval_script"])
+        self.assertIn(
+            f"const payloadLimit = {harness.MONGO_CONSOLE_RUNTIME_PARAMETER_PAYLOAD_LIMIT};",
+            eval_script,
+        )
+        self.assertIn("while (jsonText.length > payloadLimit && lines.length > 0)", eval_script)
+        self.assertIn("lines.pop();", eval_script)
+        self.assertIn("print(jsonText);", eval_script)
+
+    def test_mongo_console_runtime_parameter_consumption_collector_falls_back_per_collection(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+
+        class FakeConfig:
+            mongo_db = "screeps"
+            username = "bot"
+            shard = "shardX"
+
+        captured: dict[str, object] = {}
+
+        class FakeSmoke:
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout, output_limit
+                captured["eval_script"] = command[-1]
+                return {
+                    "returncode": 0,
+                    "output_excerpt": json.dumps({
+                        "ok": True,
+                        "lines": [],
+                        "collectionNames": ["users.console", "rooms.log"],
+                    }),
+                }
+
+        extracted = harness._collect_mongo_console_runtime_parameter_consumption_evidence(
+            FakeSmoke(),
+            ["docker", "compose"],
+            FakeConfig(),
+            None,
+            injection,
+        )
+
+        self.assertIsNone(extracted)
+        eval_script = str(captured["eval_script"])
+        self.assertIn("const beforeLineCount = lines.length;", eval_script)
+        self.assertIn("return lines.length > beforeLineCount;", eval_script)
+        self.assertIn("let collectionAddedLines = false;", eval_script)
+        self.assertIn(
+            "collectionAddedLines = scanCollection(collectionName, {$or: userClauses}) || collectionAddedLines;",
+            eval_script,
+        )
+        self.assertIn("if (!collectionAddedLines && lines.length < candidateLimit)", eval_script)
+        self.assertNotIn("if (lines.length === 0)", eval_script)
+
+    def test_runtime_parameter_consumption_collection_records_mongo_console_probe_error(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+
+        class FakeConfig:
+            mongo_db = "screeps"
+            username = "bot"
+            shard = "shardX"
+
+        class FakeSmoke:
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout, output_limit
+                if "logs" in command:
+                    return {"returncode": 0, "output_excerpt": "private server logs without Screeps console output"}
+                if "mongosh" in command:
+                    return {"returncode": 17, "output_excerpt": "mongosh console query failed"}
+                raise AssertionError(command)
+
+        with (
+            mock.patch.object(
+                harness,
+                "_collect_http_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ),
+            mock.patch.object(
+                harness,
+                "_collect_redis_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ),
+            mock.patch.object(
+                harness,
+                "_collect_mongo_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ),
+        ):
+            evidence, errors = harness.collect_runtime_parameter_consumption_evidence(
+                FakeSmoke(),
+                ["docker", "compose"],
+                FakeConfig(),
+                None,
+                injection,
+            )
+
+        self.assertIsNone(evidence)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("mongo.console.runtimePolicyParameterConsumption failed", errors[0])
+        self.assertIn("mongo console runtime-parameter probe failed: exit=17", errors[0])
+        self.assertIn("mongosh console query failed", errors[0])
+
+    def test_runtime_parameter_consumption_collection_records_mongo_console_malformed_json(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+
+        class FakeConfig:
+            mongo_db = "screeps"
+            username = "bot"
+            shard = "shardX"
+
+        class FakeSmoke:
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+                output_limit: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout, output_limit
+                if "logs" in command:
+                    return {"returncode": 0, "output_excerpt": "private server logs without Screeps console output"}
+                if "mongosh" in command:
+                    return {"returncode": 0, "output_excerpt": "not-json"}
+                raise AssertionError(command)
+
+        with (
+            mock.patch.object(
+                harness,
+                "_collect_http_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ),
+            mock.patch.object(
+                harness,
+                "_collect_redis_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ),
+            mock.patch.object(
+                harness,
+                "_collect_mongo_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ),
+        ):
+            evidence, errors = harness.collect_runtime_parameter_consumption_evidence(
+                FakeSmoke(),
+                ["docker", "compose"],
+                FakeConfig(),
+                None,
+                injection,
+            )
+
+        self.assertIsNone(evidence)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("mongo.console.runtimePolicyParameterConsumption failed", errors[0])
+        self.assertIn("mongo console runtime-parameter probe returned malformed JSON", errors[0])
+        self.assertIn("not-json", errors[0])
+
     def test_runtime_parameter_consumption_collection_records_console_probe_error(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
 


### PR DESCRIPTION
## Summary
- Adds a private-simulator fallback that scans Mongo-backed console/log collections for `#runtime-parameter-consumption` evidence when HTTP/Redis/Memory probes do not expose consumed runtime policy parameters.
- Keeps the path offline/private-simulator only: no official MMO writes and no learned policy activation.
- Adds a focused regression proving injected policy parameters become `runtimeParameterConsumption=true` / `consumedVariantCount=1` when the evidence is found through Mongo console output.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/test_screeps_rl_simulator_harness.py`
- `python3 -m unittest scripts.test_screeps_rl_simulator_harness.RlSimulatorHarnessTest.test_runtime_parameter_consumption_collection_accepts_mongo_console_tick_evidence -q`
- `python3 -m unittest scripts.test_screeps_rl_simulator_harness -q`

Refs #1299
