### PR TITLE
fix(rl): trace runtime parameter consumption evidence

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -1884,8 +1884,8 @@ def runtime_parameter_container_key(key: str) -> bool:
     return (
         "runtime" in key_lower
         or "memory" in key_lower
-        or key in {"data", "value", "memory", "Memory", "$activeWorld", "activeWorld"}
-        or re.fullmatch(r"[Ss]hard[\w_-]*", key) is not None
+        or key_lower in {"data", "value", "memory", "$activeworld", "activeworld"}
+        or re.fullmatch(r"shard[\w_-]*", key_lower) is not None
     )
 
 

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -98,6 +98,7 @@ RUNTIME_PARAMETER_CONSUMPTION_TYPE = "screeps-rl-runtime-policy-parameter-consum
 RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER = "screeps-rl-runtime-policy-parameters-consumer-v1"
 RUNTIME_PARAMETER_INJECTION_CONSUMER_VERSION = "v1"
 RUNTIME_PARAMETER_CONSUMPTION_LOG_PREFIX = "#runtime-parameter-consumption "
+RUNTIME_PARAMETER_CONSUMPTION_CANDIDATE_MAX_DEPTH = 8
 MONGO_CONSOLE_RUNTIME_PARAMETER_OUTPUT_LIMIT = 200000
 MONGO_CONSOLE_RUNTIME_PARAMETER_PAYLOAD_LIMIT = 180000
 STRICT_DIRECTIVE_PREFIX_RE = re.compile(
@@ -1795,7 +1796,7 @@ def iter_runtime_parameter_consumption_candidates(
     owner_username: str | None = None,
     owner_matched: bool = False,
 ) -> Iterable[Any]:
-    if depth > 4:
+    if depth > RUNTIME_PARAMETER_CONSUMPTION_CANDIDATE_MAX_DEPTH:
         return
     decoded = decode_runtime_parameter_jsonish(payload)
     if decoded is not payload:
@@ -1846,6 +1847,28 @@ def iter_runtime_parameter_consumption_candidates(
                     owner_username=owner_username,
                     owner_matched=next_owner_matched,
                 )
+        for key, item in payload.items():
+            if not isinstance(key, str) or not runtime_parameter_container_key(key):
+                continue
+            if key in (
+                RUNTIME_PARAMETER_CONSUMPTION_GLOBAL,
+                "rlRuntimePolicyParameters",
+                "runtimeParameterConsumption",
+                "runtimePolicyParameterConsumption",
+                "data",
+                "memory",
+                "Memory",
+                "value",
+                "evidence",
+                "candidates",
+            ):
+                continue
+            yield from iter_runtime_parameter_consumption_candidates(
+                item,
+                depth + 1,
+                owner_username=owner_username,
+                owner_matched=next_owner_matched,
+            )
     elif isinstance(payload, list):
         for item in payload:
             yield from iter_runtime_parameter_consumption_candidates(
@@ -1854,6 +1877,16 @@ def iter_runtime_parameter_consumption_candidates(
                 owner_username=owner_username,
                 owner_matched=owner_matched,
             )
+
+
+def runtime_parameter_container_key(key: str) -> bool:
+    key_lower = key.lower()
+    return (
+        "runtime" in key_lower
+        or "memory" in key_lower
+        or key in {"data", "value", "memory", "Memory", "$activeWorld", "activeWorld"}
+        or re.fullmatch(r"[Ss]hard[\w_-]*", key) is not None
+    )
 
 
 def decode_runtime_parameter_jsonish(value: Any) -> Any:

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1892,6 +1892,36 @@ cli:
 
         self.assertEqual(extracted, evidence)
 
+    def test_runtime_parameter_consumption_extracts_shard_wrapped_memory_payload(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+        payload = {
+            "ok": 1,
+            "data": json.dumps(
+                {
+                    "$activeWorld": {
+                        "shardX": json.dumps(
+                            {
+                                "Memory": {
+                                    "rlRuntimePolicyParameters": evidence,
+                                }
+                            },
+                            sort_keys=True,
+                        )
+                    }
+                },
+                sort_keys=True,
+            ),
+        }
+
+        extracted = harness.find_runtime_parameter_consumption_evidence(payload, injection=injection)
+        consumption = harness.runtime_parameter_consumption_check(injection, extracted)
+
+        self.assertEqual(extracted, evidence)
+        self.assertEqual(consumption["status"], "consumed")
+        self.assertEqual(consumption["consumedStrategyVariantId"], injection["strategyVariantId"])
+        self.assertEqual(consumption["consumedParametersSha256"], injection["parametersSha256"])
+
     def test_console_runtime_parameter_consumption_collector_reads_tick_time_evidence(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         matching = self.runtime_parameter_consumption_evidence(injection)
@@ -2006,6 +2036,78 @@ cli:
                 {"shard": "shardX"},
             ],
         )
+
+    def test_http_runtime_parameter_consumption_collection_materializes_shard_memory_evidence(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+        shard_memory = {
+            "$activeWorld": {
+                "shardX": json.dumps(
+                    {
+                        "rlRuntimePolicyParameters": evidence,
+                    },
+                    sort_keys=True,
+                )
+            }
+        }
+
+        class Result:
+            def __init__(self, payload: object) -> None:
+                self.status = 200
+                self.payload = payload
+
+        class FakeConfig:
+            server_url = "http://sim.local"
+            shard = "shardX"
+
+        class FakeSmoke:
+            calls: list[dict[str, object]] = []
+
+            def token_headers(self, token: str) -> dict[str, str]:
+                return {"X-Token": token}
+
+            def http_json(
+                self,
+                method: str,
+                base_url: str,
+                path: str,
+                *,
+                headers: dict[str, str],
+                params: dict[str, object],
+                timeout: int,
+            ) -> Result:
+                _ = method, base_url, path, headers, params, timeout
+                self.calls.append(dict(params))
+                return Result({"ok": 1, "data": json.dumps(shard_memory, sort_keys=True)})
+
+        smoke = FakeSmoke()
+
+        extracted, errors = harness.collect_runtime_parameter_consumption_evidence(
+            smoke,
+            None,
+            FakeConfig(),
+            "token",
+            injection,
+        )
+        consumption = harness.runtime_parameter_consumption_check(injection, extracted)
+        updated = harness.apply_runtime_parameter_consumption_to_injection(injection, consumption)
+        summary = harness._run_runtime_parameter_injection_summary([
+            {
+                "variant_id": injection["strategyVariantId"],
+                "runtimeParameterInjection": updated,
+            }
+        ])
+
+        expected = copy.deepcopy(evidence)
+        expected["source"] = "Memory.rlRuntimePolicyParameters"
+        self.assertEqual(extracted, expected)
+        self.assertEqual(errors, [])
+        self.assertEqual(smoke.calls, [{"path": "rlRuntimePolicyParameters", "shard": "shardX"}])
+        self.assertTrue(consumption["runtimeParameterConsumption"])
+        self.assertEqual(consumption["source"], "Memory.rlRuntimePolicyParameters")
+        self.assertTrue(summary["runtimeParameterConsumption"])
+        self.assertEqual(summary["consumedVariantCount"], 1)
+        self.assertEqual(summary["runtimeParameterConsumptionStatus"], "consumed")
 
     def test_http_runtime_parameter_consumption_collector_continues_after_probe_failures(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1895,32 +1895,40 @@ cli:
     def test_runtime_parameter_consumption_extracts_shard_wrapped_memory_payload(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         evidence = self.runtime_parameter_consumption_evidence(injection)
-        payload = {
-            "ok": 1,
-            "data": json.dumps(
-                {
-                    "$activeWorld": {
-                        "shardX": json.dumps(
-                            {
-                                "Memory": {
-                                    "rlRuntimePolicyParameters": evidence,
-                                }
-                            },
-                            sort_keys=True,
-                        )
-                    }
-                },
-                sort_keys=True,
-            ),
-        }
+        for shard_key in ("shardX", "SHARDX"):
+            with self.subTest(shard_key=shard_key):
+                payload = {
+                    "ok": 1,
+                    "data": json.dumps(
+                        {
+                            "$activeWorld": {
+                                shard_key: json.dumps(
+                                    {
+                                        "Memory": {
+                                            "rlRuntimePolicyParameters": evidence,
+                                        }
+                                    },
+                                    sort_keys=True,
+                                )
+                            }
+                        },
+                        sort_keys=True,
+                    ),
+                }
 
-        extracted = harness.find_runtime_parameter_consumption_evidence(payload, injection=injection)
-        consumption = harness.runtime_parameter_consumption_check(injection, extracted)
+                extracted = harness.find_runtime_parameter_consumption_evidence(
+                    payload,
+                    injection=injection,
+                )
+                consumption = harness.runtime_parameter_consumption_check(injection, extracted)
 
-        self.assertEqual(extracted, evidence)
-        self.assertEqual(consumption["status"], "consumed")
-        self.assertEqual(consumption["consumedStrategyVariantId"], injection["strategyVariantId"])
-        self.assertEqual(consumption["consumedParametersSha256"], injection["parametersSha256"])
+                self.assertEqual(extracted, evidence)
+                self.assertEqual(consumption["status"], "consumed")
+                self.assertEqual(
+                    consumption["consumedStrategyVariantId"],
+                    injection["strategyVariantId"],
+                )
+                self.assertEqual(consumption["consumedParametersSha256"], injection["parametersSha256"])
 
     def test_console_runtime_parameter_consumption_collector_reads_tick_time_evidence(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()


### PR DESCRIPTION
## Summary
- Extends runtime-parameter consumption evidence traversal to follow private-server / active-world / shard wrapper keys before reaching `Memory.rlRuntimePolicyParameters`.
- Adds focused tests for `$activeWorld -> shardX -> Memory.rlRuntimePolicyParameters` extraction and for materializing consumed evidence into `runtimeParameterConsumption=true` / `consumedVariantCount=1`.
- Writes/uses triage artifact `/tmp/issue1299-consumption-trace-triage.md` from the Codex implementation run.

## Issue closure gate
- [x] #1299 reference only: this PR provides code evidence for the consumption-trace fix, while the issue remains open for post-merge guarded Tencent smoke validation.
- Acceptance before moving #1299 to Done: a later smoke run must prove `runtimeParameterConsumption=true` and `consumedVariantCount>0`, and Loop B must consume that evidence.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/test_screeps_rl_simulator_harness.py`
- `python3 -m unittest scripts.test_screeps_rl_simulator_harness -q` — 133 tests OK

## Safety / operations
- Offline/private RL harness code only; no official MMO writes, deploys, or live learned-policy activation.
- No Tencent/batch compute was launched by this PR. Existing run `tencent-pg-20260524t222505z` remains the current compute lane to digest/scale down before any new paid run.
- Codex implementation session: `proc_27e55688e854`; commit-only recovery produced Codex-authored commit `bfc7b74a7d14ef50736e2abf15a380d4c2dc21be`.
