### PR TITLE
fix(rl): preserve failed scale-proof report evidence

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -1557,6 +1557,19 @@ tar -czf remote-artifacts.tar.gz \
         batch_scale = batch_scale_summary_from_training_report(data, artifact_count)
         scale_environments = resolve_scale_environment_count(self.args)
         scale_validation = data.get("scaleValidation")
+        report_summary = {
+            "path": str(report),
+            "reportId": data.get("reportId"),
+            "generatedAt": data.get("generatedAt"),
+            "experimentCard": data.get("experimentCard"),
+            **safety_flags,
+            "artifactCount": artifact_count,
+            "batchScale": batch_scale,
+            "warnings": data.get("warnings"),
+            "simulation": data.get("simulation"),
+            "scaleValidation": scale_validation,
+        }
+        self.result["trainingReport"] = report_summary
         if scale_environments is not None:
             validate_scale_proof_result(scale_validation, scale_environments, repetitions=self.args.repetitions)
         runtime_parameter_injection = verified_remote_runtime_parameter_injection(
@@ -1582,13 +1595,7 @@ tar -czf remote-artifacts.tar.gz \
             artifact_dir=self.artifact_dir,
         )
         self.result["trainingReport"] = {
-            "path": str(report),
-            "reportId": data.get("reportId"),
-            "generatedAt": data.get("generatedAt"),
-            "experimentCard": data.get("experimentCard"),
-            **safety_flags,
-            "artifactCount": artifact_count,
-            "batchScale": batch_scale,
+            **report_summary,
             "changedTopCount": data.get("changedTopCount"),
             "activationProof": data.get("activationProof"),
             "runtimeParameterInjection": runtime_parameter_injection,
@@ -1598,9 +1605,6 @@ tar -czf remote-artifacts.tar.gz \
             "candidateScorecards": candidate_scorecards,
             **policy_update_fields,
             "ranking": data.get("ranking"),
-            "warnings": data.get("warnings"),
-            "simulation": data.get("simulation"),
-            "scaleValidation": scale_validation,
         }
 
     def describe_asg_group_summary(self) -> dict[str, Any]:
@@ -4193,7 +4197,30 @@ def validate_scale_proof_result(raw: Any, expected_environments: int, *, repetit
     if successful < minimum:
         raise BatchRunError(f"scale proof success count invalid: {successful!r} < {minimum}")
     if raw.get("ok") is not True:
-        raise BatchRunError("scale proof did not satisfy success criteria")
+        raise BatchRunError(
+            "scale proof did not satisfy success criteria: "
+            + scale_proof_failure_summary(raw, minimum=minimum)
+        )
+
+
+def scale_proof_failure_summary(raw: dict[str, Any], *, minimum: int) -> str:
+    details = [
+        f"successfulEnvironments={raw.get('successfulEnvironments')!r}",
+        f"totalEnvironments={raw.get('totalEnvironments')!r}",
+        f"minimumSuccessfulEnvironments={minimum!r}",
+        f"remoteOk={raw.get('ok')!r}",
+    ]
+    per_run_failures: list[str] = []
+    for item in list_value(raw.get("perRun")):
+        if not isinstance(item, dict) or item.get("ok") is True:
+            continue
+        run_id = text_value(item.get("runId")) or "<unknown>"
+        successful = item.get("successfulEnvironments")
+        total = item.get("totalEnvironments")
+        per_run_failures.append(f"{run_id}:{successful!r}/{total!r}")
+    if per_run_failures:
+        details.append("perRunFailures=" + ",".join(per_run_failures[:5]))
+    return "; ".join(details)
 
 
 def validate_static_inputs(args: argparse.Namespace, run_id: str) -> None:

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -4065,6 +4065,14 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
 
             with self.assertRaisesRegex(runner.BatchRunError, "scale proof success count"):
                 controller.verify_remote_training_report()
+            self.assertEqual(controller.result["trainingReport"]["artifactCount"], 5)
+            self.assertEqual(
+                controller.result["trainingReport"]["scaleValidation"]["successfulEnvironments"],
+                3,
+            )
+            execution = runner.controller_execution_summary(args, controller.steps, controller.result, False, None)
+            self.assertTrue(execution["trainingReportProduced"])
+            self.assertEqual(execution["environmentsRun"], 5)
 
             data = json.loads(report.read_text(encoding="utf-8"))
             data["scaleValidation"]["ok"] = True
@@ -4109,6 +4117,26 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
 
             controller.verify_remote_training_report()
 
+            data["scaleValidation"]["ok"] = False
+            data["scaleValidation"]["perRun"] = [
+                {
+                    "ok": False,
+                    "runId": "run-test-r01",
+                    "successfulEnvironments": 3,
+                    "totalEnvironments": 5,
+                }
+            ]
+            report.write_text(json.dumps(data), encoding="utf-8")
+            with self.assertRaisesRegex(
+                runner.BatchRunError,
+                "perRunFailures=run-test-r01:3/5",
+            ):
+                controller.verify_remote_training_report()
+            self.assertEqual(controller.result["trainingReport"]["artifactCount"], 25)
+            self.assertEqual(controller.result["trainingReport"]["scaleValidation"]["successfulEnvironments"], 24)
+
+            data["scaleValidation"]["ok"] = True
+            data["scaleValidation"].pop("perRun")
             data["scaleValidation"]["totalEnvironments"] = 24
             report.write_text(json.dumps(data), encoding="utf-8")
             with self.assertRaisesRegex(runner.BatchRunError, "scale proof environment count"):


### PR DESCRIPTION
Refs #1404.

## Summary
- Preserve collected remote training report evidence in controller summaries before scale-proof validation can fail.
- Add scale-proof failure diagnostics for successful/total environment counts and per-run failures.
- Add regression tests covering partial scale-proof reports so failed runs no longer look like zero-environment/no-report executions.

## Triage
- Triage artifact: `/tmp/issue1404-scale-proof-triage.md`
- Classification: `FIX`
- Evidence: `tencent-pg-20260524t222505z` and `tencent-pg-20260524t225504z` produced remote training reports with 23/25 and 22/25 successful environments, but controller summaries recorded `trainingReportProduced=false` / `environmentsRun=0` because the report was not summarized before scale-proof validation raised.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts.test_screeps_tencent_batch_rl_runner.TencentBatchRlRunnerTest.test_verify_remote_training_report_requires_scale_proof_success_for_workers_five scripts.test_screeps_tencent_batch_rl_runner.TencentBatchRlRunnerTest.test_verify_remote_training_report_accepts_repeated_scale_proof_totals -q`

## Safety / rollout
- No official MMO writes; offline/private RL tooling only.
- Do not launch additional paid Tencent runs until active run `tencent-pg-20260524t233505z` finishes/scale-downs and this PR is reviewed/merged.
- Issue #1404 should remain open until post-merge Loop A/Loop B evidence confirms failed scale-proof runs preserve report evidence and the remaining worker-launch failure is either resolved or narrowed.