### PR TITLE
fix(rl): consume default-wrapped runtime parameters

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -1349,6 +1349,7 @@ local function runtimePolicyParameterContainerKey(keyText)
     or keyText == "Memory"
     or keyText == "$activeWorld"
     or keyText == "activeWorld"
+    or keyText == "default"
     or string.match(keyText, "^[Ss]hard[%w_-]+$") ~= nil
 end
 local function predefinedRuntimePolicyParameterKey(keyText)
@@ -1771,6 +1772,7 @@ const fieldMayContainRuntimePolicyParameters = key => {{
     || key === 'Memory'
     || key === '$activeWorld'
     || key === 'activeWorld'
+    || key === 'default'
     || /^shard[\\w-]*$/i.test(key);
 }};
 const predefinedKeys = new Set([
@@ -1965,7 +1967,7 @@ def runtime_parameter_container_key(key: str) -> bool:
     return (
         "runtime" in key_lower
         or "memory" in key_lower
-        or key_lower in {"data", "value", "memory", "$activeworld", "activeworld"}
+        or key_lower in {"data", "value", "memory", "$activeworld", "activeworld", "default"}
         or re.fullmatch(r"shard[\w_-]*", key_lower) is not None
     )
 

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -2062,6 +2062,39 @@ cli:
                 )
                 self.assertEqual(consumption["consumedParametersSha256"], injection["parametersSha256"])
 
+    def test_runtime_parameter_consumption_extracts_default_branch_wrapped_memory_payload(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+        payload = {
+            "ok": 1,
+            "data": json.dumps(
+                {
+                    "$activeWorld": {
+                        "default": {
+                            "shardX": json.dumps(
+                                {
+                                    "rlRuntimePolicyParameters": evidence,
+                                },
+                                sort_keys=True,
+                            )
+                        }
+                    }
+                },
+                sort_keys=True,
+            ),
+        }
+
+        extracted = harness.find_runtime_parameter_consumption_evidence(
+            payload,
+            injection=injection,
+        )
+        consumption = harness.runtime_parameter_consumption_check(injection, extracted)
+
+        self.assertEqual(extracted, evidence)
+        self.assertEqual(consumption["status"], "consumed")
+        self.assertTrue(consumption["runtimeParameterConsumption"])
+        self.assertEqual(consumption["evaluatedParameters"], injection["parameters"])
+
     def test_console_runtime_parameter_consumption_collector_reads_tick_time_evidence(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         matching = self.runtime_parameter_consumption_evidence(injection)
@@ -2245,6 +2278,72 @@ cli:
         self.assertEqual(smoke.calls, [{"path": "rlRuntimePolicyParameters", "shard": "shardX"}])
         self.assertTrue(consumption["runtimeParameterConsumption"])
         self.assertEqual(consumption["source"], "Memory.rlRuntimePolicyParameters")
+        self.assertTrue(summary["runtimeParameterConsumption"])
+        self.assertEqual(summary["consumedVariantCount"], 1)
+        self.assertEqual(summary["runtimeParameterConsumptionStatus"], "consumed")
+
+    def test_http_runtime_parameter_consumption_collection_materializes_default_branch_memory_evidence(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+        branch_wrapped_memory = {
+            "$activeWorld": {
+                "default": {
+                    "shardX": json.dumps(
+                        {
+                            "rlRuntimePolicyParameters": evidence,
+                        },
+                        sort_keys=True,
+                    )
+                }
+            }
+        }
+
+        class Result:
+            def __init__(self, payload: object) -> None:
+                self.status = 200
+                self.payload = payload
+
+        class FakeConfig:
+            server_url = "http://sim.local"
+            shard = "shardX"
+
+        class FakeSmoke:
+            def token_headers(self, token: str) -> dict[str, str]:
+                return {"X-Token": token}
+
+            def http_json(
+                self,
+                method: str,
+                base_url: str,
+                path: str,
+                *,
+                headers: dict[str, str],
+                params: dict[str, object],
+                timeout: int,
+            ) -> Result:
+                _ = method, base_url, path, headers, params, timeout
+                return Result({"ok": 1, "data": json.dumps(branch_wrapped_memory, sort_keys=True)})
+
+        extracted, errors = harness.collect_runtime_parameter_consumption_evidence(
+            FakeSmoke(),
+            None,
+            FakeConfig(),
+            "token",
+            injection,
+        )
+        consumption = harness.runtime_parameter_consumption_check(injection, extracted)
+        updated = harness.apply_runtime_parameter_consumption_to_injection(injection, consumption)
+        summary = harness._run_runtime_parameter_injection_summary([
+            {
+                "variant_id": injection["strategyVariantId"],
+                "runtimeParameterInjection": updated,
+            }
+        ])
+
+        expected = copy.deepcopy(evidence)
+        expected["source"] = "Memory.rlRuntimePolicyParameters"
+        self.assertEqual(extracted, expected)
+        self.assertEqual(errors, [])
         self.assertTrue(summary["runtimeParameterConsumption"])
         self.assertEqual(summary["consumedVariantCount"], 1)
         self.assertEqual(summary["runtimeParameterConsumptionStatus"], "consumed")
@@ -3319,11 +3418,12 @@ cli:
                     "runtimePolicyParameterContainerKey(key)" in eval_script
                     and "pushRuntimePolicyParameterEvidence(source .. \".\" .. key" in eval_script
                     and 'string.match(keyText, "^[Ss]hard[%w_-]+$") ~= nil' in eval_script
+                    and 'keyText == "default"' in eval_script
                 )
                 candidates = []
                 if supports_shard_containers:
                     candidates.append({
-                        "source": "redis.memory:bot.data.shardX.rlRuntimePolicyParameters",
+                        "source": "redis.memory:bot.data.default.shardX.rlRuntimePolicyParameters",
                         "value": evidence,
                     })
                 self.output_excerpt = json.dumps({"ok": True, "candidates": candidates})
@@ -3344,6 +3444,7 @@ cli:
         eval_script = smoke.command[-3] if smoke.command is not None else ""
         self.assertIn("runtimePolicyParameterContainerKey(key)", eval_script)
         self.assertIn("pushRuntimePolicyParameterEvidence(source .. \".\" .. key", eval_script)
+        self.assertIn('keyText == "default"', eval_script)
 
     def test_redis_runtime_parameter_consumption_collector_requires_configured_username(self) -> None:
         class FakeConfig:
@@ -4024,12 +4125,13 @@ cli:
                 supports_shard_containers = (
                     "/^shard[\\w-]*$/i.test(key)" in eval_script
                     and "key === '$activeWorld'" in eval_script
+                    and "key === 'default'" in eval_script
                     and "pushRuntimePolicyParameterCandidate(source + '.' + key, nested, depth + 1)" in eval_script
                 )
                 candidates = []
                 if supports_shard_containers:
                     candidates.append({
-                        "source": "users.memory.data.shardX.rlRuntimePolicyParameters",
+                        "source": "users.memory.data.default.shardX.rlRuntimePolicyParameters",
                         "value": evidence,
                     })
                 self.output_excerpt = json.dumps({"ok": True, "candidates": candidates})
@@ -4050,6 +4152,7 @@ cli:
         eval_script = smoke.command[-1] if smoke.command is not None else ""
         self.assertIn("/^shard[\\w-]*$/i.test(key)", eval_script)
         self.assertIn("key === '$activeWorld'", eval_script)
+        self.assertIn("key === 'default'", eval_script)
 
     def test_mongo_runtime_parameter_consumption_collector_dedupes_predefined_keys(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()


### PR DESCRIPTION
## Summary
- Teach runtime-parameter consumption evidence traversal to descend through `default` wrapper keys used by the post-#1425 Memory shape.
- Add regression coverage for default-wrapped Memory payloads across direct extraction, HTTP collection, Redis collection, and Mongo collection probes.
- Keeps consumption truthful: no synthetic success; `runtimeParameterConsumption` only becomes true when the extracted evidence matches the injected parameter hash.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/test_screeps_rl_simulator_harness.py`
- `python3 -m pytest scripts/test_screeps_rl_simulator_harness.py -k runtime_parameter_consumption -q` (46 passed, 91 deselected, 16 subtests)
- `python3 -m pytest scripts/test_screeps_rl_simulator_harness.py -q` (137 passed, 33 subtests)

## Safety
- No paid Tencent compute launched by this PR.
- No official MMO writes/deploys/learned-policy rollout.
- Post-merge validation still must inspect the next guarded Tencent/private-sim smoke for `runtimeParameterConsumption=true` and `consumedVariantCount>0`.

Related to issue #1299. Also updates evidence flow for #879/#1032/#1337, which remain held until post-merge consumption proof is observed.
