### PR TITLE
fix: prioritize threatened rampart repairs

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -24985,6 +24985,13 @@ function selectHeuristicWorkerTask(creep) {
   const hasMissingSpawnRecoveryConstructionSite = ownedSpawnCount === 0 && constructionSites.some(isSpawnConstructionSite);
   const canPrioritizeEmergencyWorkBeforeBootstrapSpawnRecovery = !hasMissingSpawnRecoveryConstructionSite && (!bootstrapNonCriticalWorkSuppressed || (ownedSpawnCount != null ? ownedSpawnCount : 0) > 0);
   if (canPrioritizeEmergencyWorkBeforeBootstrapSpawnRecovery) {
+    const threatenedBarrierRepairTarget2 = selectThreatenedBarrierRepairTarget(creep);
+    if (threatenedBarrierRepairTarget2) {
+      return applyMinimumUsefulLoadPolicy(creep, {
+        type: "repair",
+        targetId: threatenedBarrierRepairTarget2.id
+      });
+    }
     const emergencySpawnOrExtensionRefillTask = selectEmergencySpawnExtensionRefillTask(
       creep,
       spawnOrExtensionEnergySink

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -24992,18 +24992,18 @@ function selectHeuristicWorkerTask(creep) {
     if (emergencySpawnOrExtensionRefillTask) {
       return emergencySpawnOrExtensionRefillTask;
     }
-    const threatenedBarrierRepairTarget2 = selectThreatenedBarrierRepairTarget(creep);
-    if (threatenedBarrierRepairTarget2) {
-      return applyMinimumUsefulLoadPolicy(creep, {
-        type: "repair",
-        targetId: threatenedBarrierRepairTarget2.id
-      });
-    }
     const emergencyRampartRepairTarget = selectEmergencyOwnedRampartRepairTarget(creep);
     if (emergencyRampartRepairTarget) {
       return applyMinimumUsefulLoadPolicy(creep, {
         type: "repair",
         targetId: emergencyRampartRepairTarget.id
+      });
+    }
+    const threatenedBarrierRepairTarget2 = selectThreatenedBarrierRepairTarget(creep);
+    if (threatenedBarrierRepairTarget2) {
+      return applyMinimumUsefulLoadPolicy(creep, {
+        type: "repair",
+        targetId: threatenedBarrierRepairTarget2.id
       });
     }
   }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -24985,19 +24985,19 @@ function selectHeuristicWorkerTask(creep) {
   const hasMissingSpawnRecoveryConstructionSite = ownedSpawnCount === 0 && constructionSites.some(isSpawnConstructionSite);
   const canPrioritizeEmergencyWorkBeforeBootstrapSpawnRecovery = !hasMissingSpawnRecoveryConstructionSite && (!bootstrapNonCriticalWorkSuppressed || (ownedSpawnCount != null ? ownedSpawnCount : 0) > 0);
   if (canPrioritizeEmergencyWorkBeforeBootstrapSpawnRecovery) {
-    const threatenedBarrierRepairTarget2 = selectThreatenedBarrierRepairTarget(creep);
-    if (threatenedBarrierRepairTarget2) {
-      return applyMinimumUsefulLoadPolicy(creep, {
-        type: "repair",
-        targetId: threatenedBarrierRepairTarget2.id
-      });
-    }
     const emergencySpawnOrExtensionRefillTask = selectEmergencySpawnExtensionRefillTask(
       creep,
       spawnOrExtensionEnergySink
     );
     if (emergencySpawnOrExtensionRefillTask) {
       return emergencySpawnOrExtensionRefillTask;
+    }
+    const threatenedBarrierRepairTarget2 = selectThreatenedBarrierRepairTarget(creep);
+    if (threatenedBarrierRepairTarget2) {
+      return applyMinimumUsefulLoadPolicy(creep, {
+        type: "repair",
+        targetId: threatenedBarrierRepairTarget2.id
+      });
     }
     const emergencyRampartRepairTarget = selectEmergencyOwnedRampartRepairTarget(creep);
     if (emergencyRampartRepairTarget) {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -510,6 +510,14 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     !hasMissingSpawnRecoveryConstructionSite &&
     (!bootstrapNonCriticalWorkSuppressed || (ownedSpawnCount ?? 0) > 0);
   if (canPrioritizeEmergencyWorkBeforeBootstrapSpawnRecovery) {
+    const threatenedBarrierRepairTarget = selectThreatenedBarrierRepairTarget(creep);
+    if (threatenedBarrierRepairTarget) {
+      return applyMinimumUsefulLoadPolicy(creep, {
+        type: 'repair',
+        targetId: threatenedBarrierRepairTarget.id as Id<Structure>
+      });
+    }
+
     const emergencySpawnOrExtensionRefillTask = selectEmergencySpawnExtensionRefillTask(
       creep,
       spawnOrExtensionEnergySink

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -518,19 +518,19 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
       return emergencySpawnOrExtensionRefillTask;
     }
 
-    const threatenedBarrierRepairTarget = selectThreatenedBarrierRepairTarget(creep);
-    if (threatenedBarrierRepairTarget) {
-      return applyMinimumUsefulLoadPolicy(creep, {
-        type: 'repair',
-        targetId: threatenedBarrierRepairTarget.id as Id<Structure>
-      });
-    }
-
     const emergencyRampartRepairTarget = selectEmergencyOwnedRampartRepairTarget(creep);
     if (emergencyRampartRepairTarget) {
       return applyMinimumUsefulLoadPolicy(creep, {
         type: 'repair',
         targetId: emergencyRampartRepairTarget.id as Id<Structure>
+      });
+    }
+
+    const threatenedBarrierRepairTarget = selectThreatenedBarrierRepairTarget(creep);
+    if (threatenedBarrierRepairTarget) {
+      return applyMinimumUsefulLoadPolicy(creep, {
+        type: 'repair',
+        targetId: threatenedBarrierRepairTarget.id as Id<Structure>
       });
     }
   }

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -510,20 +510,20 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     !hasMissingSpawnRecoveryConstructionSite &&
     (!bootstrapNonCriticalWorkSuppressed || (ownedSpawnCount ?? 0) > 0);
   if (canPrioritizeEmergencyWorkBeforeBootstrapSpawnRecovery) {
-    const threatenedBarrierRepairTarget = selectThreatenedBarrierRepairTarget(creep);
-    if (threatenedBarrierRepairTarget) {
-      return applyMinimumUsefulLoadPolicy(creep, {
-        type: 'repair',
-        targetId: threatenedBarrierRepairTarget.id as Id<Structure>
-      });
-    }
-
     const emergencySpawnOrExtensionRefillTask = selectEmergencySpawnExtensionRefillTask(
       creep,
       spawnOrExtensionEnergySink
     );
     if (emergencySpawnOrExtensionRefillTask) {
       return emergencySpawnOrExtensionRefillTask;
+    }
+
+    const threatenedBarrierRepairTarget = selectThreatenedBarrierRepairTarget(creep);
+    if (threatenedBarrierRepairTarget) {
+      return applyMinimumUsefulLoadPolicy(creep, {
+        type: 'repair',
+        targetId: threatenedBarrierRepairTarget.id as Id<Structure>
+      });
     }
 
     const emergencyRampartRepairTarget = selectEmergencyOwnedRampartRepairTarget(creep);

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -8181,6 +8181,56 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
   });
 
+  it('repairs threatened ramparts before emergency spawn refill', () => {
+    recordSurvivalMode('BOOTSTRAP', 1429);
+    const structures: AnyStructure[] = [];
+    const spawn = makeEnergySinkWithEnergy('spawn1', 'spawn' as StructureConstant, 50, 250);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      controller,
+      energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+      energyCapacityAvailable: 550,
+      hostileCreeps: [{ id: 'hostile1' } as Creep],
+      myStructures: [spawn as AnyOwnedStructure],
+      structures
+    });
+    const rampart = makeStructure(
+      'rampart-under-attack',
+      'rampart' as StructureConstant,
+      IDLE_RAMPART_REPAIR_HITS_CEILING - 3_559,
+      300_000,
+      { my: true, room }
+    );
+    structures.push(rampart);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      defense: {
+        colonyThreats: {
+          updatedAt: 1429,
+          rooms: {
+            W1N1: {
+              roomName: 'W1N1',
+              level: 'hostile_present',
+              updatedAt: 1429,
+              hostileCreepCount: 1,
+              hostileStructureCount: 0,
+              damagedCriticalStructureCount: 0
+            }
+          }
+        }
+      }
+    };
+
+    expect(selectWorkerTask(makeLoadedWorker(room))).toEqual({
+      type: 'repair',
+      targetId: 'rampart-under-attack'
+    });
+  });
+
   it('keeps normal construction ahead of non-emergency rampart maintenance', () => {
     const site = { id: 'wall-site1', my: true, structureType: 'constructedWall' } as ConstructionSite;
     const controller = {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -8228,6 +8228,109 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(makeLoadedWorker(room))).toEqual({ type: 'transfer', targetId: 'spawn1' });
   });
 
+  it.each([
+    [
+      'wall',
+      makeStructure('wall-lower-ratio', 'constructedWall' as StructureConstant, 1, 300_000_000)
+    ],
+    [
+      'rampart',
+      makeStructure('rampart-lower-ratio', 'rampart' as StructureConstant, 100_000, 300_000_000, {
+        my: true
+      })
+    ]
+  ])('keeps emergency rampart repair before threatened lower-ratio %s', (_label, threatenedBarrier) => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const emergencyRampart = makeStructure(
+      'rampart-emergency',
+      'rampart' as StructureConstant,
+      EMERGENCY_RAMPART_REPAIR_HITS_CEILING,
+      300_000,
+      { my: true }
+    );
+    const room = makeWorkerTaskRoom({
+      controller,
+      energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+      energyCapacityAvailable: 550,
+      structures: [emergencyRampart, threatenedBarrier]
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      defense: {
+        colonyThreats: {
+          updatedAt: 1431,
+          rooms: {
+            W1N1: {
+              roomName: 'W1N1',
+              level: 'hostile_present',
+              updatedAt: 1431,
+              hostileCreepCount: 1,
+              hostileStructureCount: 0,
+              damagedCriticalStructureCount: 0
+            }
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 1431 };
+
+    expect(selectWorkerTask(makeLoadedWorker(room))).toEqual({
+      type: 'repair',
+      targetId: 'rampart-emergency'
+    });
+  });
+
+  it('repairs threatened barriers before non-emergency refill and routine repair', () => {
+    const structures: AnyStructure[] = [];
+    const spawn = makeEnergySinkWithEnergy('spawn1', 'spawn' as StructureConstant, 150, 150);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      controller,
+      energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+      energyCapacityAvailable: 550,
+      hostileCreeps: [{ id: 'hostile1' } as Creep],
+      myStructures: [spawn as AnyOwnedStructure],
+      structures
+    });
+    const threatenedWall = makeStructure(
+      'wall-threatened',
+      'constructedWall' as StructureConstant,
+      IDLE_RAMPART_REPAIR_HITS_CEILING - 3_559,
+      300_000_000
+    );
+    const road = makeStructure('road-damaged', 'road' as StructureConstant, 3_000, 5_000);
+    structures.push(threatenedWall, road);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      defense: {
+        colonyThreats: {
+          updatedAt: 1432,
+          rooms: {
+            W1N1: {
+              roomName: 'W1N1',
+              level: 'hostile_present',
+              updatedAt: 1432,
+              hostileCreepCount: 1,
+              hostileStructureCount: 0,
+              damagedCriticalStructureCount: 0
+            }
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 1432 };
+
+    expect(selectWorkerTask(makeLoadedWorker(room))).toEqual({ type: 'repair', targetId: 'wall-threatened' });
+  });
+
   it('repairs threatened ramparts before non-emergency spawn refill', () => {
     recordSurvivalMode('BOOTSTRAP', 1430);
     const structures: AnyStructure[] = [];

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -8181,7 +8181,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
   });
 
-  it('repairs threatened ramparts before emergency spawn refill', () => {
+  it('keeps emergency spawn refill before threatened rampart repair', () => {
     recordSurvivalMode('BOOTSTRAP', 1429);
     const structures: AnyStructure[] = [];
     const spawn = makeEnergySinkWithEnergy('spawn1', 'spawn' as StructureConstant, 50, 250);
@@ -8216,6 +8216,53 @@ describe('selectWorkerTask', () => {
               roomName: 'W1N1',
               level: 'hostile_present',
               updatedAt: 1429,
+              hostileCreepCount: 1,
+              hostileStructureCount: 0,
+              damagedCriticalStructureCount: 0
+            }
+          }
+        }
+      }
+    };
+
+    expect(selectWorkerTask(makeLoadedWorker(room))).toEqual({ type: 'transfer', targetId: 'spawn1' });
+  });
+
+  it('repairs threatened ramparts before non-emergency spawn refill', () => {
+    recordSurvivalMode('BOOTSTRAP', 1430);
+    const structures: AnyStructure[] = [];
+    const spawn = makeEnergySinkWithEnergy('spawn1', 'spawn' as StructureConstant, 150, 150);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      controller,
+      energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+      energyCapacityAvailable: 550,
+      hostileCreeps: [{ id: 'hostile1' } as Creep],
+      myStructures: [spawn as AnyOwnedStructure],
+      structures
+    });
+    const rampart = makeStructure(
+      'rampart-under-attack',
+      'rampart' as StructureConstant,
+      IDLE_RAMPART_REPAIR_HITS_CEILING - 3_559,
+      300_000,
+      { my: true, room }
+    );
+    structures.push(rampart);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      defense: {
+        colonyThreats: {
+          updatedAt: 1430,
+          rooms: {
+            W1N1: {
+              roomName: 'W1N1',
+              level: 'hostile_present',
+              updatedAt: 1430,
               hostileCreepCount: 1,
               hostileStructureCount: 0,
               damagedCriticalStructureCount: 0


### PR DESCRIPTION
## Summary
- Prioritizes threatened rampart repairs when a loaded worker is in a room with active hostile pressure.
- Preserves existing non-threat behavior that keeps emergency refill ahead of routine rampart maintenance.
- Adds regression coverage for the E29N56 rampart-damage recurrence path and rebuilds the Screeps bundle.

Refs #1429

## Verification
Controller-side verification from `/root/screeps-worktrees/issue-1429-rampart-damage/prod` passed:
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` (102 suites / 2040 tests)
- `npm run build`

Codex triage artifact: `/tmp/issue1429-rampart-triage.md`.

## Deployment / acceptance note
This changes `prod/` runtime behavior and `prod/dist/main.js`; after merge it needs the normal official-MMO deploy floor and post-deploy runtime monitor confirmation before #1429 is closed.
