### PR TITLE
fix(rl): emit direct runtime consumption evidence

### DIFF
--- a/scripts/screeps_rl_scorecard.py
+++ b/scripts/screeps_rl_scorecard.py
@@ -839,6 +839,8 @@ def extract_runtime_parameter_injection_evidence(payload: JsonObject, source: st
             "status": status,
             "runtimeParameterInjection": runtime_injection_bool(node),
             "runtimeParameterConsumption": consumed,
+            "runtimeParameterConsumptionSource": text_value(node.get("runtimeParameterConsumptionSource"))
+            or (text_value(node.get("source")) if is_consumption_node else None),
             "candidateParameterScope": text_value(node.get("candidateParameterScope"))
             or text_value(node.get("candidate_parameter_scope"))
             or ("runtime_injected" if is_consumption_node else None),
@@ -907,6 +909,7 @@ def summarize_runtime_parameter_injection(rows: Sequence[JsonObject]) -> JsonObj
             "status": row.get("status"),
             "runtimeParameterInjection": row.get("runtimeParameterInjection"),
             "runtimeParameterConsumption": row.get("runtimeParameterConsumption"),
+            "runtimeParameterConsumptionSource": row.get("runtimeParameterConsumptionSource"),
             "candidateParameterScope": row.get("candidateParameterScope"),
             "policyUpdateEligible": row.get("policyUpdateEligible"),
             "reason": row.get("reason"),
@@ -940,6 +943,15 @@ def summarize_runtime_parameter_injection(rows: Sequence[JsonObject]) -> JsonObj
         "candidateParameterScope": scope or ("runtime_injected" if eligible else "missing"),
         "evidence": evidence,
     }
+    consumption_source = first_text(
+        [
+            text_value(row.get("runtimeParameterConsumptionSource"))
+            for row in summary_rows
+            if row.get("runtimeParameterConsumptionSource")
+        ]
+    )
+    if consumption_source is not None:
+        payload["runtimeParameterConsumptionSource"] = consumption_source
     if reason:
         payload["reason"] = reason
     return payload

--- a/scripts/screeps_rl_scorecard.py
+++ b/scripts/screeps_rl_scorecard.py
@@ -943,10 +943,13 @@ def summarize_runtime_parameter_injection(rows: Sequence[JsonObject]) -> JsonObj
         "candidateParameterScope": scope or ("runtime_injected" if eligible else "missing"),
         "evidence": evidence,
     }
+    source_rows = eligible_rows or [
+        row for row in summary_rows if row.get("runtimeParameterConsumption") is True
+    ]
     consumption_source = first_text(
         [
             text_value(row.get("runtimeParameterConsumptionSource"))
-            for row in summary_rows
+            for row in source_rows
             if row.get("runtimeParameterConsumptionSource")
         ]
     )

--- a/scripts/screeps_rl_scorecard.py
+++ b/scripts/screeps_rl_scorecard.py
@@ -65,12 +65,13 @@ SCORECARD_STATUS_VALUES = (
     GATE_INCONCLUSIVE,
 )
 RUNTIME_PARAMETER_INJECTION_TYPE = "screeps-rl-runtime-parameter-injection"
+RUNTIME_PARAMETER_CONSUMPTION_TYPE = "screeps-rl-runtime-policy-parameter-consumption"
 RUNTIME_INJECTION_TRUE_KEYS = {
     "runtimeparameterinjection",
     "inlinecandidatesruntimeinjected",
     "inlinecandidatesappliedtosimulator",
 }
-RUNTIME_INJECTION_SUCCESS_STATUSES = {"injected", "ok", "pass", "passed", "success"}
+RUNTIME_INJECTION_SUCCESS_STATUSES = {"consumed", "injected", "ok", "pass", "passed", "success"}
 RUNTIME_INJECTION_BLOCKED_STATUSES = {
     "blocked",
     "failed",
@@ -811,28 +812,44 @@ def extract_runtime_parameter_injection_evidence(payload: JsonObject, source: st
     for node in iter_json_objects(payload):
         if not node_has_runtime_injection_evidence(node):
             continue
-        row: JsonObject = {
-            "source": source,
-            "summaryLevel": runtime_injection_summary_level(node),
-            "status": text_value(node.get("status"))
-            or text_value(node.get("runtimeParameterInjectionStatus"))
-            or text_value(node.get("runtime_parameter_injection_status")),
-            "runtimeParameterInjection": runtime_injection_bool(node),
-            "runtimeParameterConsumption": node.get("runtimeParameterConsumption")
+        is_consumption_node = node.get("type") == RUNTIME_PARAMETER_CONSUMPTION_TYPE
+        consumed = (
+            node.get("runtimeParameterConsumption")
             if isinstance(node.get("runtimeParameterConsumption"), bool)
             else node.get("runtime_parameter_consumption")
             if isinstance(node.get("runtime_parameter_consumption"), bool)
-            else None,
+            else node.get("consumed")
+            if is_consumption_node and isinstance(node.get("consumed"), bool)
+            else None
+        )
+        status = (
+            text_value(node.get("status"))
+            or text_value(node.get("runtimeParameterInjectionStatus"))
+            or text_value(node.get("runtime_parameter_injection_status"))
+            or ("consumed" if is_consumption_node and consumed is True else None)
+        )
+        consumed_variant_count = number_value(
+            node.get("consumedVariantCount", node.get("consumed_variant_count"))
+        )
+        if consumed_variant_count is None and is_consumption_node and consumed is True:
+            consumed_variant_count = 1
+        row: JsonObject = {
+            "source": source,
+            "summaryLevel": runtime_injection_summary_level(node),
+            "status": status,
+            "runtimeParameterInjection": runtime_injection_bool(node),
+            "runtimeParameterConsumption": consumed,
             "candidateParameterScope": text_value(node.get("candidateParameterScope"))
-            or text_value(node.get("candidate_parameter_scope")),
+            or text_value(node.get("candidate_parameter_scope"))
+            or ("runtime_injected" if is_consumption_node else None),
             "policyUpdateEligible": node.get("policyUpdateEligible")
             if isinstance(node.get("policyUpdateEligible"), bool)
+            else consumed
+            if is_consumption_node and consumed is True
             else None,
             "variantCount": number_value(node.get("variantCount")),
             "injectedVariantCount": number_value(node.get("injectedVariantCount")),
-            "consumedVariantCount": number_value(
-                node.get("consumedVariantCount", node.get("consumed_variant_count"))
-            ),
+            "consumedVariantCount": consumed_variant_count,
             "reason": text_value(node.get("reason")) or text_value(node.get("skippedReason")),
         }
         rows.append(row)
@@ -840,7 +857,7 @@ def extract_runtime_parameter_injection_evidence(payload: JsonObject, source: st
 
 
 def node_has_runtime_injection_evidence(node: JsonObject) -> bool:
-    if node.get("type") == RUNTIME_PARAMETER_INJECTION_TYPE:
+    if node.get("type") in {RUNTIME_PARAMETER_INJECTION_TYPE, RUNTIME_PARAMETER_CONSUMPTION_TYPE}:
         return True
     for key in node:
         if normalized_key(str(key)) in RUNTIME_INJECTION_TRUE_KEYS | {
@@ -853,7 +870,7 @@ def node_has_runtime_injection_evidence(node: JsonObject) -> bool:
 
 
 def runtime_injection_summary_level(node: JsonObject) -> str:
-    if node.get("type") == RUNTIME_PARAMETER_INJECTION_TYPE:
+    if node.get("type") in {RUNTIME_PARAMETER_INJECTION_TYPE, RUNTIME_PARAMETER_CONSUMPTION_TYPE}:
         return "summary"
     if any(key in node for key in ("variantCount", "injectedVariantCount", "policyUpdateEligible")):
         return "summary"

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -948,6 +948,12 @@ def runtime_parameter_consumption_check(
             payload["evaluatedParametersSha256"] = observed_hash
         if text_or_none(evidence.get("source")):
             payload["source"] = text_or_none(evidence.get("source"))
+        if isinstance(evidence.get("consumed"), bool):
+            payload["consumed"] = evidence.get("consumed")
+        if isinstance(evidence.get("directRuntimeEvaluation"), bool):
+            payload["directRuntimeEvaluation"] = evidence.get("directRuntimeEvaluation")
+        if text_or_none(evidence.get("consumptionMode")):
+            payload["consumptionMode"] = text_or_none(evidence.get("consumptionMode"))
         return payload
 
     parameters = copy.deepcopy(evidence["parameters"])
@@ -993,6 +999,83 @@ def direct_game_loop_runtime_parameter_consumption_evidence(
             break
     if consumed_tick is None:
         return None
+    for tick in reversed(ticks):
+        runtime_evidence = _direct_game_loop_runtime_parameter_signal(injection, tick, consumed_tick)
+        if runtime_evidence is not None:
+            return runtime_evidence
+    return _direct_game_loop_unproven_runtime_parameter_evidence(injection, consumed_tick)
+
+
+def _direct_game_loop_runtime_parameter_signal(
+    injection: JsonObject,
+    tick: JsonObject,
+    fallback_tick: int,
+) -> JsonObject | None:
+    evidence = find_runtime_parameter_consumption_evidence(tick, injection=injection)
+    if evidence is not None:
+        payload = copy.deepcopy(evidence)
+        payload["source"] = RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE
+        payload["consumptionMode"] = "direct_simulator_game_loop"
+        payload["directRuntimeEvaluation"] = True
+        payload.setdefault("liveEffect", False)
+        payload.setdefault("officialMmoWrites", False)
+        payload.setdefault("officialMmoWritesAllowed", False)
+        if _coerce_int(payload.get("tick")) is None:
+            tick_number = _coerce_int(tick.get("tick"))
+            payload["tick"] = tick_number if tick_number is not None else fallback_tick
+        return {key: value for key, value in payload.items() if value is not None}
+
+    signal_keys = {
+        "runtimeParameterConsumption",
+        "consumed",
+        "consumedParametersSha256",
+        "parametersSha256",
+        "consumedStrategyVariantId",
+        "strategyVariantId",
+    }
+    if not any(key in tick for key in signal_keys):
+        return None
+
+    expected_hash = text_or_none(injection.get("parametersSha256"))
+    expected_variant_id = text_or_none(injection.get("strategyVariantId"))
+    observed_hash = text_or_none(tick.get("consumedParametersSha256")) or text_or_none(tick.get("parametersSha256"))
+    observed_variant_id = text_or_none(tick.get("consumedStrategyVariantId")) or text_or_none(
+        tick.get("strategyVariantId")
+    )
+    consumed_flag = tick.get("runtimeParameterConsumption")
+    if not isinstance(consumed_flag, bool):
+        consumed_flag = tick.get("consumed") if isinstance(tick.get("consumed"), bool) else None
+    hash_matches = expected_hash is not None and observed_hash == expected_hash
+    variant_matches = expected_variant_id is None or observed_variant_id == expected_variant_id
+    if consumed_flag is False:
+        consumed = False
+    elif consumed_flag is True:
+        consumed = True
+    else:
+        consumed = hash_matches and observed_variant_id is not None and variant_matches
+    payload = _direct_game_loop_unproven_runtime_parameter_evidence(injection, fallback_tick)
+    payload["consumed"] = consumed
+    if hash_matches:
+        parameters = injection.get("parameters")
+        if isinstance(parameters, dict) and parameters:
+            payload["parameters"] = copy.deepcopy(parameters)
+            payload["parametersSha256"] = expected_hash
+    if observed_hash is not None:
+        payload["consumedParametersSha256"] = observed_hash
+    if observed_variant_id is not None:
+        payload["consumedStrategyVariantId"] = observed_variant_id
+    applied_strategy_ids = tick.get("appliedStrategyIds")
+    if isinstance(applied_strategy_ids, list):
+        payload["appliedStrategyIds"] = [
+            strategy_id for strategy_id in applied_strategy_ids if isinstance(strategy_id, str)
+        ]
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def _direct_game_loop_unproven_runtime_parameter_evidence(
+    injection: JsonObject,
+    consumed_tick: int,
+) -> JsonObject:
     applied_strategy_id = (
         text_or_none(injection.get("sourceStrategyId"))
         or text_or_none(injection.get("strategyVariantId"))
@@ -1004,14 +1087,10 @@ def direct_game_loop_runtime_parameter_consumption_evidence(
         "consumerMarker": RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER,
         "consumerVersion": RUNTIME_PARAMETER_INJECTION_CONSUMER_VERSION,
         "runtimeParameterInjection": True,
-        "consumed": True,
+        "consumed": False,
         "strategyVariantId": text_or_none(injection.get("strategyVariantId")),
         "candidatePolicyId": text_or_none(injection.get("candidatePolicyId")),
         "family": text_or_none(injection.get("family")),
-        "parameters": copy.deepcopy(parameters),
-        "parametersSha256": text_or_none(injection.get("parametersSha256")),
-        "consumedStrategyVariantId": text_or_none(injection.get("strategyVariantId")),
-        "consumedParametersSha256": text_or_none(injection.get("parametersSha256")),
         "appliedStrategyIds": [applied_strategy_id] if applied_strategy_id is not None else [],
         "source": RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE,
         "consumptionMode": "direct_simulator_game_loop",
@@ -1023,6 +1102,33 @@ def direct_game_loop_runtime_parameter_consumption_evidence(
     if consumed_tick >= 0:
         payload["tick"] = consumed_tick
     return {key: value for key, value in payload.items() if value is not None}
+
+
+def runtime_parameter_consumption_with_direct_game_loop_fallback(
+    injection: JsonObject,
+    consumption: JsonObject,
+    tick_log: Sequence[JsonObject],
+) -> JsonObject:
+    if consumption.get("runtimeParameterConsumption") is True:
+        return consumption
+    direct_evidence = direct_game_loop_runtime_parameter_consumption_evidence(injection, tick_log)
+    if direct_evidence is None:
+        return consumption
+    direct_consumption = runtime_parameter_consumption_check(injection, direct_evidence)
+    if (
+        direct_consumption.get("runtimeParameterConsumption") is True
+        or text_or_none(consumption.get("status")) in (None, "missing")
+    ):
+        for field, target in (
+            ("status", "fallbackRuntimeParameterConsumptionStatus"),
+            ("reason", "fallbackRuntimeParameterConsumptionReason"),
+            ("source", "fallbackRuntimeParameterConsumptionSource"),
+        ):
+            value = consumption.get(field)
+            if value is not None:
+                direct_consumption[target] = value
+        return direct_consumption
+    return consumption
 
 
 def apply_runtime_parameter_consumption_to_injection(
@@ -5277,18 +5383,11 @@ def _run_variant(
                 consumption_evidence,
                 source_errors=consumption_errors,
             )
-            if runtime_parameter_consumption.get("runtimeParameterConsumption") is not True:
-                direct_consumption_evidence = direct_game_loop_runtime_parameter_consumption_evidence(
-                    runtime_parameter_injection,
-                    variant_ticks,
-                )
-                if direct_consumption_evidence is not None:
-                    direct_runtime_parameter_consumption = runtime_parameter_consumption_check(
-                        runtime_parameter_injection,
-                        direct_consumption_evidence,
-                    )
-                    if direct_runtime_parameter_consumption.get("runtimeParameterConsumption") is True:
-                        runtime_parameter_consumption = direct_runtime_parameter_consumption
+            runtime_parameter_consumption = runtime_parameter_consumption_with_direct_game_loop_fallback(
+                runtime_parameter_injection,
+                runtime_parameter_consumption,
+                variant_ticks,
+            )
             runtime_parameter_injection = apply_runtime_parameter_consumption_to_injection(
                 runtime_parameter_injection,
                 runtime_parameter_consumption,

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -98,6 +98,7 @@ RUNTIME_PARAMETER_CONSUMPTION_TYPE = "screeps-rl-runtime-policy-parameter-consum
 RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER = "screeps-rl-runtime-policy-parameters-consumer-v1"
 RUNTIME_PARAMETER_INJECTION_CONSUMER_VERSION = "v1"
 RUNTIME_PARAMETER_CONSUMPTION_LOG_PREFIX = "#runtime-parameter-consumption "
+RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE = "private_simulator_game_loop_runtime_parameters"
 RUNTIME_PARAMETER_CONSUMPTION_CANDIDATE_MAX_DEPTH = 8
 MONGO_CONSOLE_RUNTIME_PARAMETER_OUTPUT_LIMIT = 200000
 MONGO_CONSOLE_RUNTIME_PARAMETER_PAYLOAD_LIMIT = 180000
@@ -969,6 +970,58 @@ def runtime_parameter_consumption_check(
     }
     if consumed_tick is not None and consumed_tick >= 0:
         payload["consumedTick"] = consumed_tick
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def direct_game_loop_runtime_parameter_consumption_evidence(
+    injection: JsonObject,
+    tick_log: Sequence[JsonObject],
+) -> JsonObject | None:
+    """Build direct consumption proof from a completed injected simulator game loop."""
+    if injection.get("status") != "injected" or injection.get("runtimeParameterInjection") is not True:
+        return None
+    parameters = injection.get("parameters")
+    if not isinstance(parameters, dict) or not parameters:
+        return None
+    ticks = [tick for tick in tick_log if isinstance(tick, dict)]
+    if not ticks:
+        return None
+    consumed_tick = None
+    for tick in reversed(ticks):
+        consumed_tick = _coerce_int(tick.get("tick"))
+        if consumed_tick is not None:
+            break
+    if consumed_tick is None:
+        return None
+    applied_strategy_id = (
+        text_or_none(injection.get("sourceStrategyId"))
+        or text_or_none(injection.get("strategyVariantId"))
+        or text_or_none(injection.get("candidatePolicyId"))
+    )
+    payload: JsonObject = {
+        "type": RUNTIME_PARAMETER_CONSUMPTION_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "consumerMarker": RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER,
+        "consumerVersion": RUNTIME_PARAMETER_INJECTION_CONSUMER_VERSION,
+        "runtimeParameterInjection": True,
+        "consumed": True,
+        "strategyVariantId": text_or_none(injection.get("strategyVariantId")),
+        "candidatePolicyId": text_or_none(injection.get("candidatePolicyId")),
+        "family": text_or_none(injection.get("family")),
+        "parameters": copy.deepcopy(parameters),
+        "parametersSha256": text_or_none(injection.get("parametersSha256")),
+        "consumedStrategyVariantId": text_or_none(injection.get("strategyVariantId")),
+        "consumedParametersSha256": text_or_none(injection.get("parametersSha256")),
+        "appliedStrategyIds": [applied_strategy_id] if applied_strategy_id is not None else [],
+        "source": RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE,
+        "consumptionMode": "direct_simulator_game_loop",
+        "directRuntimeEvaluation": True,
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+    }
+    if consumed_tick >= 0:
+        payload["tick"] = consumed_tick
     return {key: value for key, value in payload.items() if value is not None}
 
 
@@ -5224,6 +5277,18 @@ def _run_variant(
                 consumption_evidence,
                 source_errors=consumption_errors,
             )
+            if runtime_parameter_consumption.get("runtimeParameterConsumption") is not True:
+                direct_consumption_evidence = direct_game_loop_runtime_parameter_consumption_evidence(
+                    runtime_parameter_injection,
+                    variant_ticks,
+                )
+                if direct_consumption_evidence is not None:
+                    direct_runtime_parameter_consumption = runtime_parameter_consumption_check(
+                        runtime_parameter_injection,
+                        direct_consumption_evidence,
+                    )
+                    if direct_runtime_parameter_consumption.get("runtimeParameterConsumption") is True:
+                        runtime_parameter_consumption = direct_runtime_parameter_consumption
             runtime_parameter_injection = apply_runtime_parameter_consumption_to_injection(
                 runtime_parameter_injection,
                 runtime_parameter_consumption,

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -1115,10 +1115,7 @@ def runtime_parameter_consumption_with_direct_game_loop_fallback(
     if direct_evidence is None:
         return consumption
     direct_consumption = runtime_parameter_consumption_check(injection, direct_evidence)
-    if (
-        direct_consumption.get("runtimeParameterConsumption") is True
-        or text_or_none(consumption.get("status")) in (None, "missing")
-    ):
+    if direct_consumption.get("runtimeParameterConsumption") is True:
         for field, target in (
             ("status", "fallbackRuntimeParameterConsumptionStatus"),
             ("reason", "fallbackRuntimeParameterConsumptionReason"),
@@ -1128,6 +1125,16 @@ def runtime_parameter_consumption_with_direct_game_loop_fallback(
             if value is not None:
                 direct_consumption[target] = value
         return direct_consumption
+    if text_or_none(consumption.get("status")) in (None, "missing"):
+        preserved = copy.deepcopy(consumption)
+        preserved["directRuntimeEvaluation"] = direct_evidence.get("directRuntimeEvaluation") is True
+        consumption_mode = text_or_none(direct_evidence.get("consumptionMode"))
+        if consumption_mode is not None:
+            preserved["consumptionMode"] = consumption_mode
+        preserved["directRuntimeEvaluationStatus"] = direct_consumption.get("status")
+        if direct_consumption.get("reason") is not None:
+            preserved["directRuntimeEvaluationReason"] = direct_consumption.get("reason")
+        return preserved
     return consumption
 
 

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -672,6 +672,35 @@ def apply_runtime_parameter_injection_to_code(code_text: str, injection: JsonObj
         "    }\n"
         "    return null;\n"
         "  }\n"
+        "  function mirrorRuntimeConsumptionToObjectMemory(memory, evidence) {\n"
+        "    if (!memory || typeof memory !== 'object') return;\n"
+        "    var groups = ['creeps', 'spawns'];\n"
+        "    for (var groupIndex = 0; groupIndex < groups.length; groupIndex += 1) {\n"
+        "      var group = groups[groupIndex];\n"
+        "      var gameCollection = null;\n"
+        "      try { gameCollection = (typeof Game !== 'undefined' && Game) ? Game[group] : null; } catch (err) {}\n"
+        "      if (!gameCollection || typeof gameCollection !== 'object') continue;\n"
+        "      var names = [];\n"
+        "      for (var name in gameCollection) {\n"
+        "        if (Object.prototype.hasOwnProperty.call(gameCollection, name)) names.push(name);\n"
+        "      }\n"
+        "      names.sort();\n"
+        "      for (var nameIndex = 0; nameIndex < names.length; nameIndex += 1) {\n"
+        "        var objectName = names[nameIndex];\n"
+        "        var objectMemory = null;\n"
+        "        try {\n"
+        "          var gameObject = gameCollection[objectName];\n"
+        "          objectMemory = gameObject && gameObject.memory;\n"
+        "        } catch (err) {}\n"
+        "        if (!objectMemory || typeof objectMemory !== 'object') {\n"
+        "          if (!memory[group] || typeof memory[group] !== 'object') memory[group] = {};\n"
+        "          objectMemory = memory[group][objectName];\n"
+        "          if (!objectMemory || typeof objectMemory !== 'object') objectMemory = memory[group][objectName] = {};\n"
+        "        }\n"
+        "        objectMemory.rlRuntimePolicyParameters = copyEvidence(evidence);\n"
+        "      }\n"
+        "    }\n"
+        "  }\n"
         "  function isRuntimeConsumptionEvidence(value) {\n"
         "    return value && typeof value === 'object'\n"
         "      && value.type === consumptionType\n"
@@ -692,7 +721,10 @@ def apply_runtime_parameter_injection_to_code(code_text: str, injection: JsonObj
         "    }\n"
         "    try {\n"
         "      var memory = runtimeMemoryRoot();\n"
-        "      if (memory) memory.rlRuntimePolicyParameters = materialized;\n"
+        "      if (memory) {\n"
+        "        memory.rlRuntimePolicyParameters = materialized;\n"
+        "        mirrorRuntimeConsumptionToObjectMemory(memory, materialized);\n"
+        "      }\n"
         "    } catch (err) {}\n"
         "    try {\n"
         "      var serialized = JSON.stringify(materialized);\n"
@@ -763,6 +795,35 @@ def apply_runtime_parameter_injection_to_code(code_text: str, injection: JsonObj
         "    }\n"
         "    return null;\n"
         "  }\n"
+        "  function mirrorRuntimeConsumptionToObjectMemory(memory, evidence) {\n"
+        "    if (!memory || typeof memory !== 'object') return;\n"
+        "    var groups = ['creeps', 'spawns'];\n"
+        "    for (var groupIndex = 0; groupIndex < groups.length; groupIndex += 1) {\n"
+        "      var group = groups[groupIndex];\n"
+        "      var gameCollection = null;\n"
+        "      try { gameCollection = (typeof Game !== 'undefined' && Game) ? Game[group] : null; } catch (err) {}\n"
+        "      if (!gameCollection || typeof gameCollection !== 'object') continue;\n"
+        "      var names = [];\n"
+        "      for (var name in gameCollection) {\n"
+        "        if (Object.prototype.hasOwnProperty.call(gameCollection, name)) names.push(name);\n"
+        "      }\n"
+        "      names.sort();\n"
+        "      for (var nameIndex = 0; nameIndex < names.length; nameIndex += 1) {\n"
+        "        var objectName = names[nameIndex];\n"
+        "        var objectMemory = null;\n"
+        "        try {\n"
+        "          var gameObject = gameCollection[objectName];\n"
+        "          objectMemory = gameObject && gameObject.memory;\n"
+        "        } catch (err) {}\n"
+        "        if (!objectMemory || typeof objectMemory !== 'object') {\n"
+        "          if (!memory[group] || typeof memory[group] !== 'object') memory[group] = {};\n"
+        "          objectMemory = memory[group][objectName];\n"
+        "          if (!objectMemory || typeof objectMemory !== 'object') objectMemory = memory[group][objectName] = {};\n"
+        "        }\n"
+        "        objectMemory.rlRuntimePolicyParameters = copyEvidence(evidence);\n"
+        "      }\n"
+        "    }\n"
+        "  }\n"
         "  function lexicalConsumptionEvidence() {\n"
         f"    try {{ if (typeof {RUNTIME_PARAMETER_CONSUMPTION_GLOBAL} !== 'undefined') return {RUNTIME_PARAMETER_CONSUMPTION_GLOBAL}; }} catch (err) {{}}\n"
         "    return undefined;\n"
@@ -787,7 +848,10 @@ def apply_runtime_parameter_injection_to_code(code_text: str, injection: JsonObj
         "    }\n"
         "    try {\n"
         "      var memory = runtimeMemoryRoot();\n"
-        "      if (memory) memory.rlRuntimePolicyParameters = materialized;\n"
+        "      if (memory) {\n"
+        "        memory.rlRuntimePolicyParameters = materialized;\n"
+        "        mirrorRuntimeConsumptionToObjectMemory(memory, materialized);\n"
+        "      }\n"
         "    } catch (err) {}\n"
         "    try {\n"
         "      var serialized = JSON.stringify(materialized);\n"
@@ -1011,7 +1075,7 @@ def _direct_game_loop_runtime_parameter_signal(
     tick: JsonObject,
     fallback_tick: int,
 ) -> JsonObject | None:
-    evidence = find_runtime_parameter_consumption_evidence(tick, injection=injection)
+    evidence = _direct_game_loop_tick_runtime_parameter_evidence(injection, tick)
     if evidence is not None:
         payload = copy.deepcopy(evidence)
         payload["source"] = RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE
@@ -1070,6 +1134,32 @@ def _direct_game_loop_runtime_parameter_signal(
             strategy_id for strategy_id in applied_strategy_ids if isinstance(strategy_id, str)
         ]
     return {key: value for key, value in payload.items() if value is not None}
+
+
+def _direct_game_loop_tick_runtime_parameter_evidence(
+    injection: JsonObject,
+    tick: JsonObject,
+) -> JsonObject | None:
+    evidence = find_runtime_parameter_consumption_evidence(tick, injection=injection)
+    if evidence is not None:
+        return evidence
+    rooms = tick.get("rooms")
+    if isinstance(rooms, dict):
+        room_values = rooms.values()
+    elif isinstance(rooms, list):
+        room_values = rooms
+    else:
+        room_values = ()
+    fallback: JsonObject | None = None
+    for room_payload in room_values:
+        evidence = find_runtime_parameter_consumption_evidence(room_payload, injection=injection)
+        if evidence is None:
+            continue
+        if runtime_parameter_consumption_validation_error(injection, evidence) is None:
+            return evidence
+        if fallback is None:
+            fallback = evidence
+    return fallback
 
 
 def _direct_game_loop_unproven_runtime_parameter_evidence(
@@ -3215,6 +3305,28 @@ def _collect_combat_counts(
     return counts
 
 
+def _room_runtime_parameter_consumption_evidence(
+    normalized: JsonObject,
+    objects: Sequence[Any],
+) -> JsonObject | None:
+    for candidate in (
+        normalized.get("runtimeParameterConsumption"),
+        normalized.get("runtimePolicyParameterConsumption"),
+        normalized.get("rlRuntimePolicyParameters"),
+        normalized.get("memory"),
+        normalized.get("Memory"),
+        normalized.get("data"),
+    ):
+        evidence = find_runtime_parameter_consumption_evidence(candidate)
+        if evidence is not None:
+            return evidence
+    for item in objects:
+        evidence = find_runtime_parameter_consumption_evidence(item)
+        if evidence is not None:
+            return evidence
+    return None
+
+
 def _summarize_room_state(payload: dict[str, Any], room: str) -> JsonObject:
     normalized = _extract_room_payload(payload, room)
     objects = _payload_objects(normalized)
@@ -3270,7 +3382,7 @@ def _summarize_room_state(payload: dict[str, Any], room: str) -> JsonObject:
         "storedEnergy": stored_energy,
         **({"energyAvailable": energy} if energy is not None else {}),
     }
-    return {
+    summary = {
         "room": room,
         "roomName": room,
         "owned": owned,
@@ -3290,6 +3402,10 @@ def _summarize_room_state(payload: dict[str, Any], room: str) -> JsonObject:
         "resources": resources_summary,
         "combat": _collect_combat_counts(normalized, owner_id=owner_id, owner_username=owner_username),
     }
+    runtime_consumption = _room_runtime_parameter_consumption_evidence(normalized, objects)
+    if runtime_consumption is not None:
+        summary["runtimeParameterConsumption"] = runtime_consumption
+    return summary
 
 
 def _terrain_summary(payload: Any) -> JsonObject:

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -4588,6 +4588,35 @@ cli:
         self.assertNotIn("consumedParametersSha256", summary["variants"][1])
         self.assertNotIn("consumedStrategyVariantId", summary["variants"][1])
 
+    def test_direct_game_loop_runtime_parameter_consumption_evidence_validates(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = harness.direct_game_loop_runtime_parameter_consumption_evidence(
+            injection,
+            [{"tick": 19}, {"tick": 20, "rooms": {"W1N1": {"creeps": 1}}}],
+        )
+
+        self.assertIsNotNone(evidence)
+        assert evidence is not None
+        self.assertEqual(evidence["source"], harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE)
+        self.assertTrue(evidence["directRuntimeEvaluation"])
+        self.assertEqual(evidence["tick"], 20)
+        consumption = harness.runtime_parameter_consumption_check(injection, evidence)
+        self.assertTrue(consumption["runtimeParameterConsumption"])
+        self.assertEqual(consumption["status"], "consumed")
+        self.assertEqual(consumption["evaluatedParameters"], injection["parameters"])
+        self.assertEqual(consumption["source"], harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE)
+        self.assertFalse(consumption["officialMmoWrites"])
+
+    def test_direct_game_loop_runtime_parameter_consumption_requires_observed_tick(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+
+        self.assertIsNone(
+            harness.direct_game_loop_runtime_parameter_consumption_evidence(
+                injection,
+                [{"rooms": {"W1N1": {"creeps": 1}}}],
+            )
+        )
+
     def uploaded_runtime_parameter_injection(self) -> harness.JsonObject:
         base_code = (
             '"use strict";\n'

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -4592,7 +4592,16 @@ cli:
         injection = self.uploaded_runtime_parameter_injection()
         evidence = harness.direct_game_loop_runtime_parameter_consumption_evidence(
             injection,
-            [{"tick": 19}, {"tick": 20, "rooms": {"W1N1": {"creeps": 1}}}],
+            [
+                {"tick": 19},
+                {
+                    "tick": 20,
+                    "rooms": {"W1N1": {"creeps": 1}},
+                    "runtimeParameterConsumption": True,
+                    "consumedParametersSha256": injection["parametersSha256"],
+                    "consumedStrategyVariantId": injection["strategyVariantId"],
+                },
+            ],
         )
 
         self.assertIsNotNone(evidence)
@@ -4607,6 +4616,73 @@ cli:
         self.assertEqual(consumption["source"], harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE)
         self.assertFalse(consumption["officialMmoWrites"])
 
+    def test_direct_game_loop_runtime_parameter_consumption_without_runtime_signal_fails_closed(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = harness.direct_game_loop_runtime_parameter_consumption_evidence(
+            injection,
+            [{"tick": 20, "rooms": {"W1N1": {"creeps": 1}}}],
+        )
+
+        self.assertIsNotNone(evidence)
+        assert evidence is not None
+        self.assertEqual(evidence["source"], harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE)
+        self.assertTrue(evidence["directRuntimeEvaluation"])
+        self.assertFalse(evidence["consumed"])
+        self.assertEqual(evidence["tick"], 20)
+        self.assertNotIn("parameters", evidence)
+        self.assertNotIn("consumedParametersSha256", evidence)
+        consumption = harness.runtime_parameter_consumption_check(injection, evidence)
+        self.assertFalse(consumption["runtimeParameterConsumption"])
+        self.assertEqual(consumption["status"], "invalid")
+        self.assertEqual(consumption["source"], harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE)
+        self.assertIn("did not mark the payload consumed", consumption["reason"])
+
+    def test_direct_game_loop_runtime_parameter_consumption_preserves_false_signal(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = harness.direct_game_loop_runtime_parameter_consumption_evidence(
+            injection,
+            [
+                {
+                    "tick": 20,
+                    "runtimeParameterConsumption": False,
+                    "consumedParametersSha256": injection["parametersSha256"],
+                    "consumedStrategyVariantId": injection["strategyVariantId"],
+                }
+            ],
+        )
+
+        self.assertIsNotNone(evidence)
+        assert evidence is not None
+        self.assertFalse(evidence["consumed"])
+        consumption = harness.runtime_parameter_consumption_check(injection, evidence)
+        self.assertFalse(consumption["runtimeParameterConsumption"])
+        self.assertEqual(consumption["status"], "invalid")
+        self.assertEqual(consumption["source"], harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE)
+
+    def test_direct_game_loop_runtime_parameter_consumption_skips_non_numeric_trailing_ticks(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = harness.direct_game_loop_runtime_parameter_consumption_evidence(
+            injection,
+            [
+                {
+                    "tick": 20,
+                    "runtimeParameterConsumption": True,
+                    "consumedParametersSha256": injection["parametersSha256"],
+                    "consumedStrategyVariantId": injection["strategyVariantId"],
+                },
+                {"tick": "bad", "rooms": {"W1N1": {"creeps": 1}}},
+            ],
+        )
+
+        self.assertIsNotNone(evidence)
+        assert evidence is not None
+        self.assertEqual(evidence["source"], harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE)
+        self.assertTrue(evidence["directRuntimeEvaluation"])
+        self.assertEqual(evidence["tick"], 20)
+        consumption = harness.runtime_parameter_consumption_check(injection, evidence)
+        self.assertEqual(consumption["status"], "consumed")
+        self.assertEqual(consumption["evaluatedParameters"], injection["parameters"])
+
     def test_direct_game_loop_runtime_parameter_consumption_requires_observed_tick(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
 
@@ -4616,6 +4692,26 @@ cli:
                 [{"rooms": {"W1N1": {"creeps": 1}}}],
             )
         )
+
+    def test_direct_game_loop_fallback_preserves_invalid_standard_consumption_without_runtime_signal(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        invalid_evidence = self.runtime_parameter_consumption_evidence(injection)
+        invalid_evidence["parameters"] = {
+            **invalid_evidence["parameters"],
+            "territorySignalWeight": invalid_evidence["parameters"]["territorySignalWeight"] + 1,
+        }
+        invalid_consumption = harness.runtime_parameter_consumption_check(injection, invalid_evidence)
+
+        consumption = harness.runtime_parameter_consumption_with_direct_game_loop_fallback(
+            injection,
+            invalid_consumption,
+            [{"tick": 20, "rooms": {"W1N1": {"creeps": 1}}}],
+        )
+
+        self.assertEqual(consumption["status"], "invalid")
+        self.assertFalse(consumption["runtimeParameterConsumption"])
+        self.assertIn("disagreed", consumption["reason"])
+        self.assertNotEqual(consumption.get("source"), harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE)
 
     def uploaded_runtime_parameter_injection(self) -> harness.JsonObject:
         base_code = (

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -4713,6 +4713,29 @@ cli:
         self.assertIn("disagreed", consumption["reason"])
         self.assertNotEqual(consumption.get("source"), harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE)
 
+    def test_direct_game_loop_fallback_preserves_missing_collector_failure_without_runtime_signal(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        missing_consumption = harness.runtime_parameter_consumption_check(
+            injection,
+            None,
+            source_errors=["redis evidence unavailable"],
+        )
+
+        consumption = harness.runtime_parameter_consumption_with_direct_game_loop_fallback(
+            injection,
+            missing_consumption,
+            [{"tick": 20, "rooms": {"W1N1": {"creeps": 1}}}],
+        )
+
+        self.assertEqual(consumption["status"], "missing")
+        self.assertFalse(consumption["runtimeParameterConsumption"])
+        self.assertIn("redis evidence unavailable", consumption["reason"])
+        self.assertNotEqual(consumption.get("source"), harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE)
+        self.assertTrue(consumption["directRuntimeEvaluation"])
+        self.assertEqual(consumption["consumptionMode"], "direct_simulator_game_loop")
+        self.assertEqual(consumption["directRuntimeEvaluationStatus"], "invalid")
+        self.assertIn("did not mark the payload consumed", consumption["directRuntimeEvaluationReason"])
+
     def uploaded_runtime_parameter_injection(self) -> harness.JsonObject:
         base_code = (
             '"use strict";\n'

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -940,6 +940,56 @@ cli:
         self.assertEqual(tick_entry["overview"]["roomCount"], 1)
         self.assertEqual(tick_entry["rooms"]["E1S1"]["structures"]["spawn"], 1)
 
+    def test_build_tick_entry_extracts_runtime_consumption_from_object_memory(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+
+        tick_entry = harness._build_tick_entry(
+            "shardX",
+            "E1S1",
+            42,
+            {"ok": 1, "rooms": ["E1S1"], "gametime": 42},
+            {"terrain": [{"room": "E1S1", "terrain": "0" * 2500}]},
+            {
+                "E1S1": {
+                    "room": "E1S1",
+                    "roomData": {
+                        "user": {"id": "user-1", "username": "rl-sim"},
+                        "controller": {"level": 1, "my": True},
+                        "objects": [
+                            {
+                                "type": "creep",
+                                "user": "user-1",
+                                "memory": {
+                                    "role": "worker",
+                                    "rlRuntimePolicyParameters": evidence,
+                                },
+                            }
+                        ],
+                    },
+                }
+            },
+        )
+
+        room_summary = tick_entry["rooms"]["E1S1"]
+        self.assertEqual(
+            room_summary["runtimeParameterConsumption"]["consumedParametersSha256"],
+            injection["parametersSha256"],
+        )
+        direct_evidence = harness.direct_game_loop_runtime_parameter_consumption_evidence(
+            injection,
+            [tick_entry],
+        )
+        self.assertIsNotNone(direct_evidence)
+        assert direct_evidence is not None
+        consumption = harness.runtime_parameter_consumption_check(injection, direct_evidence)
+        self.assertEqual(consumption["status"], "consumed")
+        self.assertTrue(consumption["runtimeParameterConsumption"])
+        self.assertEqual(
+            consumption["source"],
+            harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE,
+        )
+
     def test_multi_tier_fixture_rooms_merge_into_tick_when_private_api_lacks_visibility(self) -> None:
         fixture_path = Path("scripts/fixtures/rl/multi-tier-territory-combat-v0.map.json")
         fixture_summaries = harness._private_map_fixture_room_summaries(fixture_path)
@@ -1813,6 +1863,67 @@ cli:
         consumption = harness.runtime_parameter_consumption_check(uploaded, extracted)
         self.assertTrue(consumption["runtimeParameterConsumption"])
         self.assertEqual(consumption["status"], "consumed")
+
+    @unittest.skipUnless(NODE_BIN is not None, "node is required to execute the injected bundle prelude")
+    def test_runtime_parameter_injection_prelude_mirrors_consumption_to_object_memory(self) -> None:
+        assert NODE_BIN is not None
+        variant = {
+            "id": "construction-priority.pg.territory-seed.v1",
+            "candidatePolicyId": "construction-priority.pg.territory-seed.v1",
+            "family": "construction-priority",
+            "parameters": {
+                "baseScoreWeight": 1,
+                "territorySignalWeight": 22,
+                "resourceSignalWeight": 3,
+                "killSignalWeight": 5,
+                "riskPenalty": 4,
+            },
+        }
+        injection = harness.runtime_parameter_injection_for_variant(variant["id"], variant)
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+        evidence_json = json.dumps(evidence, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        base_code = (
+            '"use strict";\n'
+            f'var runtimePolicyConsumer = "{harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER}";\n'
+            "module.exports.loop = function loop() {\n"
+            f"  globalThis[{json.dumps(harness.RUNTIME_PARAMETER_CONSUMPTION_GLOBAL)}] = {evidence_json};\n"
+            "};\n"
+        )
+        uploaded_code = harness.apply_runtime_parameter_injection_to_code(base_code, injection)
+        uploaded = harness.mark_runtime_parameter_injection_uploaded(injection, code_text=uploaded_code)
+        self.assertTrue(uploaded["runtimeParameterInjection"])
+
+        script = (
+            "const hostConsole = console;\n"
+            "const logs = [];\n"
+            "globalThis.Memory = {creeps: {Worker1: {role: 'worker'}}, spawns: {Spawn1: {}}};\n"
+            "globalThis.Game = {\n"
+            "  time: 77,\n"
+            "  creeps: {Worker1: {memory: globalThis.Memory.creeps.Worker1}},\n"
+            "  spawns: {Spawn1: {memory: globalThis.Memory.spawns.Spawn1}}\n"
+            "};\n"
+            "globalThis.console = {log: line => logs.push(String(line))};\n"
+            f"{uploaded_code}\n"
+            "module.exports.loop();\n"
+            "hostConsole.log(JSON.stringify({\n"
+            "  creep: globalThis.Memory.creeps.Worker1.rlRuntimePolicyParameters,\n"
+            "  spawn: globalThis.Memory.spawns.Spawn1.rlRuntimePolicyParameters,\n"
+            "  logs\n"
+            "}));\n"
+        )
+        result = subprocess.run(
+            [NODE_BIN, "-e", script],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+        payload = json.loads(result.stdout)
+        self.assertTrue(payload["creep"]["consumed"])
+        self.assertTrue(payload["spawn"]["consumed"])
+        self.assertEqual(payload["creep"]["tick"], 77)
+        self.assertEqual(payload["creep"]["consumedParametersSha256"], injection["parametersSha256"])
 
     @unittest.skipUnless(NODE_BIN is not None, "node is required to execute the injected bundle prelude")
     def test_runtime_parameter_injection_wraps_default_export_for_tick_consumption_evidence(self) -> None:
@@ -4733,6 +4844,59 @@ cli:
         self.assertNotEqual(consumption.get("source"), harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE)
         self.assertTrue(consumption["directRuntimeEvaluation"])
         self.assertEqual(consumption["consumptionMode"], "direct_simulator_game_loop")
+        self.assertEqual(consumption["directRuntimeEvaluationStatus"], "invalid")
+        self.assertIn("did not mark the payload consumed", consumption["directRuntimeEvaluationReason"])
+
+    def test_direct_game_loop_fallback_preserves_missing_failure_for_unconsumed_tick_memory(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        unconsumed_evidence = self.runtime_parameter_consumption_evidence(injection)
+        unconsumed_evidence["consumed"] = False
+        tick_entry = harness._build_tick_entry(
+            "shardX",
+            "E1S1",
+            20,
+            {"ok": 1, "rooms": ["E1S1"], "gametime": 20},
+            {"terrain": [{"room": "E1S1", "terrain": "0" * 2500}]},
+            {
+                "E1S1": {
+                    "room": "E1S1",
+                    "roomData": {
+                        "user": {"id": "user-1", "username": "rl-sim"},
+                        "controller": {"level": 1, "my": True},
+                        "objects": [
+                            {
+                                "type": "creep",
+                                "user": "user-1",
+                                "memory": {
+                                    "role": "worker",
+                                    "rlRuntimePolicyParameters": unconsumed_evidence,
+                                },
+                            }
+                        ],
+                    },
+                }
+            },
+        )
+        missing_consumption = harness.runtime_parameter_consumption_check(
+            injection,
+            None,
+            source_errors=["redis evidence unavailable"],
+        )
+
+        self.assertFalse(
+            tick_entry["rooms"]["E1S1"]["runtimeParameterConsumption"]["consumed"],
+        )
+        consumption = harness.runtime_parameter_consumption_with_direct_game_loop_fallback(
+            injection,
+            missing_consumption,
+            [tick_entry],
+        )
+
+        self.assertEqual(consumption["status"], "missing")
+        self.assertFalse(consumption["runtimeParameterConsumption"])
+        self.assertIn("redis evidence unavailable", consumption["reason"])
+        self.assertNotEqual(consumption.get("source"), harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE)
+        self.assertTrue(consumption["directRuntimeEvaluation"])
         self.assertEqual(consumption["directRuntimeEvaluationStatus"], "invalid")
         self.assertIn("did not mark the payload consumed", consumption["directRuntimeEvaluationReason"])
 

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -303,28 +303,49 @@ class MockSimulator:
                     tick_number = tick_log[-1].get("tick")
                     if isinstance(tick_number, int):
                         consumption_evidence["tick"] = tick_number
+                if self.include_direct_game_loop_consumption_evidence and isinstance(tick_log, list):
+                    for tick_entry in reversed(tick_log):
+                        tick_number = tick_entry.get("tick") if isinstance(tick_entry, dict) else None
+                        if isinstance(tick_number, int) and not isinstance(tick_number, bool):
+                            tick_entry["runtimeParameterConsumption"] = True
+                            tick_entry["consumedParametersSha256"] = result["runtimeParameterInjection"].get(
+                                "parametersSha256"
+                            )
+                            tick_entry["consumedStrategyVariantId"] = variant_id
+                            break
+                runtime_consumption = None
                 if self.include_runtime_consumption_evidence:
-                    result["runtimeParameterConsumption"] = runner.simulator_harness.runtime_parameter_consumption_check(
+                    runtime_consumption = runner.simulator_harness.runtime_parameter_consumption_check(
                         result["runtimeParameterInjection"],
                         consumption_evidence,
                     )
+                elif self.include_direct_game_loop_consumption_evidence:
+                    runtime_consumption = runner.simulator_harness.runtime_parameter_consumption_check(
+                        result["runtimeParameterInjection"],
+                        None,
+                    )
+                if runtime_consumption is not None and self.include_direct_game_loop_consumption_evidence:
+                    runtime_consumption = (
+                        runner.simulator_harness.runtime_parameter_consumption_with_direct_game_loop_fallback(
+                            result["runtimeParameterInjection"],
+                            runtime_consumption,
+                            tick_log if isinstance(tick_log, list) else [],
+                        )
+                    )
+                if runtime_consumption is not None:
+                    result["runtimeParameterConsumption"] = runtime_consumption
                     if not self.include_runtime_consumption_parameters:
                         result["runtimeParameterConsumption"].pop("evaluatedParameters", None)
                         result["runtimeParameterConsumption"].pop("evaluatedParametersSha256", None)
-                elif self.include_direct_game_loop_consumption_evidence:
-                    direct_evidence = runner.simulator_harness.direct_game_loop_runtime_parameter_consumption_evidence(
-                        result["runtimeParameterInjection"],
-                        tick_log if isinstance(tick_log, list) else [],
-                    )
-                    result["runtimeParameterConsumption"] = runner.simulator_harness.runtime_parameter_consumption_check(
-                        result["runtimeParameterInjection"],
-                        direct_evidence,
-                    )
                 if self.include_evaluated_parameters:
-                    if (
-                        isinstance(result.get("runtimeParameterConsumption"), dict)
-                        and result["runtimeParameterConsumption"].get("runtimeParameterConsumption") is True
-                    ) or not self.include_runtime_consumption_evidence:
+                    consumption = result.get("runtimeParameterConsumption")
+                    if isinstance(consumption, dict) and consumption.get("runtimeParameterConsumption") is True:
+                        consumed_parameters = consumption.get("evaluatedParameters")
+                        result["evaluatedParameters"] = copy.deepcopy(
+                            consumed_parameters if isinstance(consumed_parameters, dict) else evaluated_parameters
+                        )
+                        result["evaluatedParametersSource"] = "runtime_parameter_consumption"
+                    elif not self.include_runtime_consumption_evidence:
                         result["evaluatedParameters"] = copy.deepcopy(evaluated_parameters)
                         result["evaluatedParametersSource"] = "runtime_parameter_consumption"
             variants.append(result)
@@ -4681,11 +4702,17 @@ export const STRATEGY_REGISTRY = [
                     variant_id,
                     [start, tick(2, [room("W1N1", energy=200)])],
                 )
+        mismatched_standard_parameters: dict[str, JsonObject] = {}
+        for variant in card["strategy_variants"]:
+            parameters = copy.deepcopy(variant["parameters"])
+            parameters["territorySignalWeight"] = parameters["territorySignalWeight"] + 1
+            mismatched_standard_parameters[variant["id"]] = parameters
         simulator = MockSimulator(
             simulator_results,
             inject_runtime_parameters=True,
-            include_runtime_consumption_evidence=False,
+            include_runtime_consumption_evidence=True,
             include_direct_game_loop_consumption_evidence=True,
+            evaluated_parameters_by_variant=mismatched_standard_parameters,
         )
 
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -4711,6 +4738,10 @@ export const STRATEGY_REGISTRY = [
         self.assertTrue(report["candidateScorecard"]["runtimeParameterConsumption"])
         self.assertGreater(report["candidateScorecard"]["consumedVariantCount"], 0)
         self.assertTrue(scorecard_payload["overallGate"]["runtimeCandidateGate"]["runtimeParameterConsumption"])
+        self.assertEqual(
+            scorecard_payload["overallGate"]["runtimeCandidateGate"]["runtimeParameterConsumptionSource"],
+            runner.simulator_harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE,
+        )
         self.assertTrue(
             all(
                 result["runtimeParameterInjection"]["runtimeParameterConsumption"]
@@ -4722,6 +4753,12 @@ export const STRATEGY_REGISTRY = [
                 result["runtimeParameterInjection"]["runtimeParameterConsumptionSource"]
                 == runner.simulator_harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE
                 for result in report["variantResults"]
+            )
+        )
+        self.assertTrue(
+            all(
+                result["runtimeParameterConsumption"]["fallbackRuntimeParameterConsumptionStatus"] == "invalid"
+                for result in simulator.last_variants
             )
         )
         self.assertFalse(report["officialMmoWrites"])

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -221,6 +221,7 @@ class MockSimulator:
         include_evaluated_parameters: bool = True,
         include_runtime_consumption_evidence: bool = True,
         include_runtime_consumption_parameters: bool = True,
+        include_direct_game_loop_consumption_evidence: bool = False,
         evaluated_parameters_by_variant: dict[str, JsonObject] | None = None,
         js_runtime_numeric_canonicalization: bool = False,
     ) -> None:
@@ -229,6 +230,7 @@ class MockSimulator:
         self.include_evaluated_parameters = include_evaluated_parameters
         self.include_runtime_consumption_evidence = include_runtime_consumption_evidence
         self.include_runtime_consumption_parameters = include_runtime_consumption_parameters
+        self.include_direct_game_loop_consumption_evidence = include_direct_game_loop_consumption_evidence
         self.evaluated_parameters_by_variant = evaluated_parameters_by_variant or {}
         self.js_runtime_numeric_canonicalization = js_runtime_numeric_canonicalization
         self.calls: list[JsonObject] = []
@@ -309,6 +311,15 @@ class MockSimulator:
                     if not self.include_runtime_consumption_parameters:
                         result["runtimeParameterConsumption"].pop("evaluatedParameters", None)
                         result["runtimeParameterConsumption"].pop("evaluatedParametersSha256", None)
+                elif self.include_direct_game_loop_consumption_evidence:
+                    direct_evidence = runner.simulator_harness.direct_game_loop_runtime_parameter_consumption_evidence(
+                        result["runtimeParameterInjection"],
+                        tick_log if isinstance(tick_log, list) else [],
+                    )
+                    result["runtimeParameterConsumption"] = runner.simulator_harness.runtime_parameter_consumption_check(
+                        result["runtimeParameterInjection"],
+                        direct_evidence,
+                    )
                 if self.include_evaluated_parameters:
                     if (
                         isinstance(result.get("runtimeParameterConsumption"), dict)
@@ -4641,6 +4652,80 @@ export const STRATEGY_REGISTRY = [
         self.assertFalse(report["policyUpdate"]["officialMmoWritesAllowed"])
         self.assertTrue(all("evaluatedParameters" in result for result in simulator.last_variants))
         self.assertTrue(all("runtimeParameterConsumption" not in result for result in simulator.last_variants))
+
+    def test_direct_game_loop_consumption_evidence_reaches_training_report_and_scorecard(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-direct-consumption",
+            code_commit="f" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-25T14:31:00Z",
+            simulation_ticks=100,
+            simulation_repetitions=1,
+        )
+        variant_ids = [variant["id"] for variant in card["strategy_variants"]]
+        start = tick(1, [room("W1N1", energy=100)])
+        simulator_results: dict[str, JsonObject] = {}
+        for variant_id in variant_ids:
+            if variant_id.endswith("territory-seed.v1"):
+                simulator_results[variant_id] = variant_result(
+                    variant_id,
+                    [start, tick(2, [room("W1N1", energy=150), room("W1N2", energy=100)])],
+                )
+            elif variant_id.endswith("resource-seed.v1"):
+                simulator_results[variant_id] = variant_result(
+                    variant_id,
+                    [start, tick(2, [room("W1N1", energy=2400, harvested=1000)])],
+                )
+            else:
+                simulator_results[variant_id] = variant_result(
+                    variant_id,
+                    [start, tick(2, [room("W1N1", energy=200)])],
+                )
+        simulator = MockSimulator(
+            simulator_results,
+            inject_runtime_parameters=True,
+            include_runtime_consumption_evidence=False,
+            include_direct_game_loop_consumption_evidence=True,
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                out_dir,
+                report_id="policy-gradient-direct-consumption",
+                generated_at="2026-05-25T14:32:00Z",
+                simulator_runner=simulator,
+            )
+            scorecard_payload = read_json(Path(report["scorecardArtifactPath"]))
+
+        self.assertEqual(report["runtimeParameterInjection"]["status"], "injected")
+        self.assertTrue(report["runtimeParameterInjection"]["runtimeParameterInjection"])
+        self.assertTrue(report["runtimeParameterInjection"]["runtimeParameterConsumption"])
+        self.assertEqual(report["runtimeParameterInjection"]["runtimeParameterConsumptionStatus"], "consumed")
+        self.assertEqual(report["runtimeParameterInjection"]["consumedVariantCount"], len(variant_ids))
+        self.assertTrue(report["runtimeParameterInjection"]["policyUpdateEligible"])
+        self.assertTrue(report["candidateScorecard"]["runtimeParameterConsumption"])
+        self.assertGreater(report["candidateScorecard"]["consumedVariantCount"], 0)
+        self.assertTrue(scorecard_payload["overallGate"]["runtimeCandidateGate"]["runtimeParameterConsumption"])
+        self.assertTrue(
+            all(
+                result["runtimeParameterInjection"]["runtimeParameterConsumption"]
+                for result in report["variantResults"]
+            )
+        )
+        self.assertTrue(
+            all(
+                result["runtimeParameterInjection"]["runtimeParameterConsumptionSource"]
+                == runner.simulator_harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE
+                for result in report["variantResults"]
+            )
+        )
+        self.assertFalse(report["officialMmoWrites"])
+        self.assertFalse(report["policyUpdate"]["officialMmoWrites"])
 
     def test_runtime_injected_metadata_ranking_materializes_reinforce_update_without_consumption_probe(self) -> None:
         card = card_helper.build_card(

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -305,14 +305,24 @@ class MockSimulator:
                     if isinstance(tick_number, int):
                         consumption_evidence["tick"] = tick_number
                 if self.include_direct_game_loop_consumption_evidence and isinstance(tick_log, list):
+                    direct_tick_evidence = {
+                        **consumption_evidence,
+                        "parameters": copy.deepcopy(result["runtimeParameterInjection"].get("parameters")),
+                        "parametersSha256": result["runtimeParameterInjection"].get("parametersSha256"),
+                        "consumedParametersSha256": result["runtimeParameterInjection"].get("parametersSha256"),
+                    }
                     for tick_entry in reversed(tick_log):
                         tick_number = tick_entry.get("tick") if isinstance(tick_entry, dict) else None
                         if isinstance(tick_number, int) and not isinstance(tick_number, bool):
-                            tick_entry["runtimeParameterConsumption"] = True
-                            tick_entry["consumedParametersSha256"] = result["runtimeParameterInjection"].get(
-                                "parametersSha256"
-                            )
-                            tick_entry["consumedStrategyVariantId"] = variant_id
+                            direct_tick_evidence["tick"] = tick_number
+                            rooms = tick_entry.get("rooms")
+                            if isinstance(rooms, dict):
+                                for room_payload in rooms.values():
+                                    if isinstance(room_payload, dict):
+                                        room_payload["runtimeParameterConsumption"] = copy.deepcopy(
+                                            direct_tick_evidence
+                                        )
+                                        break
                             break
                 runtime_consumption = None
                 if self.include_runtime_consumption_evidence:

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -286,6 +286,7 @@ class MockSimulator:
                     "consumerVersion": runner.simulator_harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_VERSION,
                     "runtimeParameterInjection": True,
                     "consumed": True,
+                    "source": "runtime_policy_parameter_consumption",
                     "strategyVariantId": variant_id,
                     "candidatePolicyId": variant_config.get("candidatePolicyId"),
                     "family": variant_config.get("family"),
@@ -4758,6 +4759,20 @@ export const STRATEGY_REGISTRY = [
         self.assertTrue(
             all(
                 result["runtimeParameterConsumption"]["fallbackRuntimeParameterConsumptionStatus"] == "invalid"
+                for result in simulator.last_variants
+            )
+        )
+        self.assertTrue(
+            all(
+                result["runtimeParameterConsumption"]["fallbackRuntimeParameterConsumptionSource"]
+                == "runtime_policy_parameter_consumption"
+                for result in simulator.last_variants
+            )
+        )
+        self.assertTrue(
+            all(
+                "disagreed"
+                in result["runtimeParameterConsumption"]["fallbackRuntimeParameterConsumptionReason"]
                 for result in simulator.last_variants
             )
         )

--- a/scripts/tests/test_rl_scorecard.py
+++ b/scripts/tests/test_rl_scorecard.py
@@ -297,6 +297,37 @@ def test_runtime_consumption_evidence_counts_as_scorecard_runtime_proof() -> Non
     assert summary["policyUpdateEligible"] is True
 
 
+def test_runtime_consumption_source_comes_from_row_that_proved_consumption() -> None:
+    direct_source = training_runner.simulator_harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE
+    summary = scorecard.summarize_runtime_parameter_injection(
+        [
+            {
+                "summaryLevel": "summary",
+                "status": "invalid",
+                "runtimeParameterInjection": True,
+                "runtimeParameterConsumption": False,
+                "runtimeParameterConsumptionSource": "runtime_policy_parameter_consumption",
+                "candidateParameterScope": "runtime_injected",
+                "policyUpdateEligible": False,
+                "consumedVariantCount": 0,
+            },
+            {
+                "summaryLevel": "summary",
+                "status": "consumed",
+                "runtimeParameterInjection": True,
+                "runtimeParameterConsumption": True,
+                "runtimeParameterConsumptionSource": direct_source,
+                "candidateParameterScope": "runtime_injected",
+                "policyUpdateEligible": True,
+                "consumedVariantCount": 1,
+            },
+        ]
+    )
+
+    assert summary["runtimeParameterConsumption"] is True
+    assert summary["runtimeParameterConsumptionSource"] == direct_source
+
+
 def test_scorecard_fails_safety_regression_even_with_gameplay_gain(tmp_path: Path) -> None:
     baseline = write_bundle(tmp_path / "baseline", candidate=False)
     candidate = write_bundle(tmp_path / "candidate", candidate=True, safety_regression=True)

--- a/scripts/tests/test_rl_scorecard.py
+++ b/scripts/tests/test_rl_scorecard.py
@@ -261,6 +261,42 @@ def test_runtime_injection_extraction_supports_snake_case_consumed_variant_count
     assert summary["policyUpdateEligible"] is False
 
 
+def test_runtime_consumption_evidence_counts_as_scorecard_runtime_proof() -> None:
+    rows = scorecard.extract_runtime_parameter_injection_evidence(
+        {
+            "type": "runtime-summary",
+            "tick": 20,
+            "runtimeParameterConsumption": {
+                "type": "screeps-rl-runtime-policy-parameter-consumption",
+                "consumerMarker": "screeps-rl-runtime-policy-parameters-consumer-v1",
+                "consumerVersion": "v1",
+                "runtimeParameterInjection": True,
+                "consumed": True,
+                "strategyVariantId": "candidate.v1",
+                "parameters": {"territorySignalWeight": 29},
+                "consumedStrategyVariantId": "candidate.v1",
+                "consumedParametersSha256": "sha",
+                "appliedStrategyIds": ["construction-priority.incumbent.v1"],
+                "liveEffect": False,
+                "officialMmoWrites": False,
+                "officialMmoWritesAllowed": False,
+            },
+        },
+        "runtime.log",
+    )
+
+    summary = scorecard.summarize_runtime_parameter_injection(rows)
+
+    assert rows[0]["status"] == "consumed"
+    assert rows[0]["runtimeParameterInjection"] is True
+    assert rows[0]["runtimeParameterConsumption"] is True
+    assert rows[0]["consumedVariantCount"] == 1
+    assert summary["status"] == "injected"
+    assert summary["runtimeParameterInjection"] is True
+    assert summary["runtimeParameterConsumption"] is True
+    assert summary["policyUpdateEligible"] is True
+
+
 def test_scorecard_fails_safety_regression_even_with_gameplay_gain(tmp_path: Path) -> None:
     baseline = write_bundle(tmp_path / "baseline", candidate=False)
     candidate = write_bundle(tmp_path / "candidate", candidate=True, safety_regression=True)


### PR DESCRIPTION
## Summary
- Adds direct game-loop runtime-parameter consumption evidence for RL simulator runs.
- Propagates direct consumption proof into training reports and scorecards so #1299/#1431 no longer depends on the intermediate Memory-key consumer as the sole evidence path.
- Adds focused tests for direct consumption evidence in the simulator harness, training report, and scorecard extraction.

## Test plan
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_scorecard.py scripts/screeps_rl_simulator_harness.py scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py scripts/tests/test_rl_scorecard.py`
- `python3 -m pytest scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py scripts/tests/test_rl_scorecard.py -q` (`283 passed, 55 subtests passed in 14.41s`)

## Issue closure gate
- [ ] issue 1431 remains open for post-merge guarded Tencent smoke validation: require `runtimeParameterConsumption=true`, `consumedVariantCount>0`, and `officialMmoWrites=false` before closing.

Related to issue 1431, #1299, #879, #893, #907, #924, #1032, and #1337.
