### PR TITLE
fix(runtime): throttle optional work under 20 CPU budget

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -24753,6 +24753,175 @@ function getGameTick2() {
   return typeof tick === "number" && Number.isFinite(tick) ? tick : 0;
 }
 
+// src/runtime/cpuBudget.ts
+var LOW_CPU_ACCOUNT_LIMIT = 20;
+var LOW_CPU_BUCKET_THRESHOLD = 1e3;
+var CRITICAL_CPU_BUCKET_THRESHOLD = 100;
+var DEGRADED_OPTIONAL_WORK_INTERVAL = 5;
+var DEGRADED_ROOM_OPTIONAL_WORK_INTERVAL = 3;
+var REPEATED_BUCKET_EMPTY_TICKS = 2;
+var SUSTAINED_OVER_LIMIT_TICKS = 2;
+var cpuTelemetryState = {
+  lowBucketTicks: 0,
+  bucketEmptyTicks: 0,
+  overLimitTicks: 0
+};
+function getRuntimeCpuBudget(game = getRuntimeGame()) {
+  return buildRuntimeCpuBudget(readRuntimeCpuSample(game));
+}
+function buildRuntimeCpuBudget(sample) {
+  const reasons = [];
+  const lowCpuLimit = sample.limit !== void 0 && sample.limit <= LOW_CPU_ACCOUNT_LIMIT;
+  if (lowCpuLimit) {
+    reasons.push("lowCpuLimit");
+  }
+  const criticalBucket = sample.bucket !== void 0 && sample.bucket <= CRITICAL_CPU_BUCKET_THRESHOLD;
+  if (criticalBucket) {
+    reasons.push("criticalBucket");
+  } else if (sample.bucket !== void 0 && sample.bucket < LOW_CPU_BUCKET_THRESHOLD) {
+    reasons.push("lowBucket");
+  }
+  if (sample.used !== void 0 && sample.limit !== void 0 && sample.limit > 0 && sample.used > sample.limit) {
+    reasons.push("usedOverLimit");
+  }
+  const critical = criticalBucket;
+  const degraded = critical || reasons.length > 0;
+  return {
+    tick: sample.tick,
+    sample,
+    pressure: critical ? "critical" : degraded ? "degraded" : "normal",
+    degraded,
+    critical,
+    lowCpuLimit,
+    reasons
+  };
+}
+function readRuntimeCpuSample(game = getRuntimeGame()) {
+  const cpu = game == null ? void 0 : game.cpu;
+  return {
+    tick: normalizeTick(game == null ? void 0 : game.time),
+    ...optionalFiniteNumber("used", readCpuUsed(cpu)),
+    ...optionalFiniteNumber("limit", cpu == null ? void 0 : cpu.limit),
+    ...optionalFiniteNumber("bucket", cpu == null ? void 0 : cpu.bucket),
+    ...optionalFiniteNumber("tickLimit", cpu == null ? void 0 : cpu.tickLimit)
+  };
+}
+function buildRuntimeCpuTelemetrySummary(sample = readRuntimeCpuSample()) {
+  if (sample.used === void 0 && sample.limit === void 0 && sample.bucket === void 0 && sample.tickLimit === void 0) {
+    resetRuntimeCpuTelemetryStateForTick(sample.tick);
+    return null;
+  }
+  const budget = buildRuntimeCpuBudget(sample);
+  const state = updateRuntimeCpuTelemetryState(sample);
+  const alerts = buildRuntimeCpuAlerts(sample, state);
+  return {
+    tick: sample.tick,
+    ...sample.used !== void 0 ? { used: sample.used } : {},
+    ...sample.limit !== void 0 ? { limit: sample.limit } : {},
+    ...sample.tickLimit !== void 0 ? { tickLimit: sample.tickLimit } : {},
+    ...sample.bucket !== void 0 ? { bucket: sample.bucket } : {},
+    pressure: budget.pressure,
+    ...budget.reasons.length > 0 ? { reasons: budget.reasons } : {},
+    ...alerts.length > 0 ? { alerts } : {},
+    ...state.lowBucketTicks > 0 ? { lowBucketTicks: state.lowBucketTicks } : {},
+    ...state.bucketEmptyTicks > 0 ? { bucketEmptyTicks: state.bucketEmptyTicks } : {},
+    ...state.overLimitTicks > 0 ? { overLimitTicks: state.overLimitTicks } : {}
+  };
+}
+function shouldRunOptionalCpuWork(budget, key, interval = DEGRADED_OPTIONAL_WORK_INTERVAL) {
+  if (!budget.degraded) {
+    return true;
+  }
+  if (budget.critical) {
+    return false;
+  }
+  return isCadenceTick(budget.tick, key, interval);
+}
+function shouldRunOptionalCpuRoomWork(budget, roomName, interval = DEGRADED_ROOM_OPTIONAL_WORK_INTERVAL) {
+  if (!budget.degraded) {
+    return true;
+  }
+  if (budget.critical) {
+    return false;
+  }
+  return isCadenceTick(budget.tick, roomName, interval);
+}
+function shouldThrottleRuntimeSummaryCadence(budget) {
+  return budget.lowCpuLimit;
+}
+function updateRuntimeCpuTelemetryState(sample) {
+  resetRuntimeCpuTelemetryStateForTick(sample.tick);
+  const lowBucket = sample.bucket !== void 0 && sample.bucket < LOW_CPU_BUCKET_THRESHOLD;
+  const bucketEmpty = sample.bucket !== void 0 && sample.bucket <= 0;
+  const overLimit = sample.used !== void 0 && sample.limit !== void 0 && sample.limit > 0 && sample.used > sample.limit;
+  cpuTelemetryState.lowBucketTicks = lowBucket ? cpuTelemetryState.lowBucketTicks + 1 : 0;
+  cpuTelemetryState.bucketEmptyTicks = bucketEmpty ? cpuTelemetryState.bucketEmptyTicks + 1 : 0;
+  cpuTelemetryState.overLimitTicks = overLimit ? cpuTelemetryState.overLimitTicks + 1 : 0;
+  return cpuTelemetryState;
+}
+function resetRuntimeCpuTelemetryStateForTick(tick) {
+  const lastTick = cpuTelemetryState.lastTick;
+  if (lastTick !== void 0 && tick > 0 && lastTick > 0 && tick !== lastTick + 1) {
+    cpuTelemetryState.lowBucketTicks = 0;
+    cpuTelemetryState.bucketEmptyTicks = 0;
+    cpuTelemetryState.overLimitTicks = 0;
+  }
+  if (lastTick !== void 0 && tick > 0 && lastTick > tick) {
+    cpuTelemetryState.lowBucketTicks = 0;
+    cpuTelemetryState.bucketEmptyTicks = 0;
+    cpuTelemetryState.overLimitTicks = 0;
+  }
+  cpuTelemetryState.lastTick = tick;
+}
+function buildRuntimeCpuAlerts(sample, state) {
+  const alerts = [];
+  if (state.bucketEmptyTicks >= REPEATED_BUCKET_EMPTY_TICKS) {
+    alerts.push("bucketEmptyRepeated");
+  }
+  if (sample.bucket !== void 0 && sample.bucket < LOW_CPU_BUCKET_THRESHOLD) {
+    alerts.push("lowBucket");
+  }
+  if (state.overLimitTicks >= SUSTAINED_OVER_LIMIT_TICKS) {
+    alerts.push("sustainedUsedOverLimit");
+  }
+  return alerts;
+}
+function isCadenceTick(tick, key, interval) {
+  const normalizedInterval = Math.max(1, Math.floor(interval));
+  if (tick <= 0) {
+    return false;
+  }
+  return (tick + stableHash(key)) % normalizedInterval === 0;
+}
+function stableHash(value) {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = hash * 31 + value.charCodeAt(index) >>> 0;
+  }
+  return hash;
+}
+function readCpuUsed(cpu) {
+  const getUsed = cpu == null ? void 0 : cpu.getUsed;
+  if (typeof getUsed !== "function") {
+    return void 0;
+  }
+  try {
+    const used = getUsed.call(cpu);
+    return typeof used === "number" && Number.isFinite(used) ? used : void 0;
+  } catch {
+    return void 0;
+  }
+}
+function optionalFiniteNumber(key, value) {
+  return typeof value === "number" && Number.isFinite(value) ? { [key]: value } : {};
+}
+function normalizeTick(value) {
+  return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+function getRuntimeGame() {
+  return globalThis.Game;
+}
+
 // src/tasks/workerTasks.ts
 var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
 var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
@@ -24829,8 +24998,20 @@ var routineBarrierMaintenanceRepairTargetCache = null;
 function selectWorkerTask(creep) {
   clearWorkerEfficiencyTelemetry(creep);
   const heuristicTask = selectHeuristicWorkerTask(creep);
+  if (getRuntimeCpuBudget().degraded) {
+    clearWorkerTaskShadowTelemetry(creep);
+    return heuristicTask;
+  }
   recordWorkerTaskBehaviorTrace(creep, heuristicTask);
   return selectWorkerTaskWithBcFallback(creep, heuristicTask);
+}
+function clearWorkerTaskShadowTelemetry(creep) {
+  const memory = creep.memory;
+  if (!memory) {
+    return;
+  }
+  delete memory.workerBehavior;
+  delete memory.workerTaskPolicyShadow;
 }
 function selectHeuristicWorkerTask(creep) {
   var _a;
@@ -36147,7 +36328,9 @@ function isRecord28(value) {
 
 // src/telemetry/runtimeSummary.ts
 var RUNTIME_SUMMARY_PREFIX = "#runtime-summary ";
+var RUNTIME_CPU_SUMMARY_PREFIX = "#cpu-summary ";
 var RUNTIME_SUMMARY_INTERVAL = 20;
+var DEGRADED_RUNTIME_SUMMARY_INTERVAL = RUNTIME_SUMMARY_INTERVAL * 5;
 var MAX_REPORTED_EVENTS = 10;
 var MAX_WORKER_EFFICIENCY_SAMPLES = 5;
 var MAX_WORKER_BEHAVIOR_SAMPLES = 10;
@@ -36173,7 +36356,9 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   }
   const tick = getGameTime32();
   resetCachedRefillTelemetryIfTickRewound(tick);
-  const emitsSummary = shouldEmitRuntimeSummary(tick, events);
+  const cpuBudget = getRuntimeCpuBudget();
+  const emitsSummary = shouldEmitRuntimeSummary(tick, events, cpuBudget);
+  const shouldRefreshRuntimeTelemetry = !shouldThrottleRuntimeSummaryCadence(cpuBudget) || emitsSummary;
   const creepsByColony = groupCreepsByColony(creeps, colonies);
   let refillTargetIdsByRoom = cachedRefillTargetIdsByRoom;
   let eventMetricsByRoom = cachedEventMetricsByRoom;
@@ -36184,21 +36369,25 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
     cachedEventMetricsByRoom = eventMetricsByRoom;
     cachedEventMetricsTick = tick;
   }
-  refreshRefillTelemetry(
-    colonies,
-    creepsByColony,
-    refillTargetIdsByRoom,
-    eventMetricsByRoom,
-    tick,
-    cachedEventMetricsTick
-  );
-  refreshConstructionDeadlockTelemetry(colonies, creepsByColony, tick);
+  if (shouldRefreshRuntimeTelemetry) {
+    refreshRefillTelemetry(
+      colonies,
+      creepsByColony,
+      refillTargetIdsByRoom,
+      eventMetricsByRoom,
+      tick,
+      cachedEventMetricsTick
+    );
+    refreshConstructionDeadlockTelemetry(colonies, creepsByColony, tick);
+  }
+  const cpuSummary = buildCpuSummary();
+  emitRuntimeCpuSummary(cpuSummary.cpu, tick);
   if (!emitsSummary) {
     return void 0;
   }
   const reportedEvents = events.slice(0, MAX_REPORTED_EVENTS);
   const persistOccupationRecommendations = options.persistOccupationRecommendations !== false;
-  const cpuSummary = buildCpuSummary();
+  const includeOptionalSummary = !shouldThrottleRuntimeSummaryCadence(cpuBudget) && !cpuBudget.critical;
   const rooms = colonies.map(
     (colony) => {
       var _a, _b;
@@ -36209,7 +36398,8 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
         (_b = eventMetricsByRoom.get(colony.room.name)) != null ? _b : {},
         shouldBuildStructureSnapshot(tick),
         options.strategyRegistry,
-        options.onStrategyRegistryRuntimeUse
+        options.onStrategyRegistryRuntimeUse,
+        includeOptionalSummary
       );
     }
   );
@@ -36224,8 +36414,12 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   console.log(`${RUNTIME_SUMMARY_PREFIX}${JSON.stringify(summary)}`);
   return summary;
 }
-function shouldEmitRuntimeSummary(tick, events) {
-  return events.length > 0 || tick > 0 && tick % RUNTIME_SUMMARY_INTERVAL === 0;
+function shouldEmitRuntimeSummary(tick, events, cpuBudget = getRuntimeCpuBudget()) {
+  if (events.length > 0) {
+    return true;
+  }
+  const interval = shouldThrottleRuntimeSummaryCadence(cpuBudget) ? DEGRADED_RUNTIME_SUMMARY_INTERVAL : RUNTIME_SUMMARY_INTERVAL;
+  return tick > 0 && tick % interval === 0;
 }
 function resetCachedRefillTelemetryIfTickRewound(tick) {
   if (cachedEventMetricsTick === void 0 || tick >= cachedEventMetricsTick) {
@@ -36285,7 +36479,7 @@ function buildRoomEventMetricsByRoom(colonies, refillTargetIdsByRoom) {
   }
   return eventMetricsByRoom;
 }
-function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, eventMetrics, includeStructureSnapshot, strategyRegistry, onStrategyRegistryRuntimeUse) {
+function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, eventMetrics, includeStructureSnapshot, strategyRegistry, onStrategyRegistryRuntimeUse, includeOptionalSummary) {
   const tick = getGameTime32();
   const colonyWorkers = colonyCreeps.filter((creep) => creep.memory.role === "worker");
   const roleCounts = countCreepsByRole(colonyCreeps, colony.room.name);
@@ -36321,26 +36515,26 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     taskCounts,
     constructionSiteCount: resources.productiveEnergy.constructionSiteCount,
     constructionDeadlockTicks,
-    ...summarizeRuntimeBehavior(colonyWorkers, colonyCreeps, tick),
+    ...includeOptionalSummary ? summarizeRuntimeBehavior(colonyWorkers, colonyCreeps, tick) : {},
     ...includeStructureSnapshot ? { structures: summarizeStructures(colony, colonyWorkers) } : {},
-    ...summarizeWorkerEfficiency(colonyWorkers, tick),
-    ...summarizeRefillTelemetry(colonyWorkers, tick),
+    ...includeOptionalSummary ? summarizeWorkerEfficiency(colonyWorkers, tick) : {},
+    ...includeOptionalSummary ? summarizeRefillTelemetry(colonyWorkers, tick) : {},
     ...summarizeSpawnCriticalRefill(colonyWorkers, tick),
     ...buildControllerSummary(colony.room),
     resources,
     combat: summarizeCombat(colony.room, eventMetrics.combat),
-    constructionPriority: summarizeConstructionPriority(
+    constructionPriority: includeOptionalSummary ? summarizeConstructionPriority(
       colony,
       colonyWorkers,
       strategyRegistry,
       onStrategyRegistryRuntimeUse
-    ),
+    ) : emptyConstructionPrioritySummary(),
     survival: summarizeSurvival(colony, roleCounts),
-    territoryRecommendation,
-    ...territoryExpansion.candidates.length > 0 ? { territoryExpansion } : {},
-    ...buildTerritoryIntentSummary(colony.room.name, roleCounts),
-    ...buildTerritoryExecutionHintSummary(colony.room.name),
-    ...buildTerritoryScoutSummary(colony, roleCounts),
+    territoryRecommendation: includeOptionalSummary ? territoryRecommendation : emptyTerritoryRecommendationReport(),
+    ...includeOptionalSummary && territoryExpansion.candidates.length > 0 ? { territoryExpansion } : {},
+    ...includeOptionalSummary ? buildTerritoryIntentSummary(colony.room.name, roleCounts) : {},
+    ...includeOptionalSummary ? buildTerritoryExecutionHintSummary(colony.room.name) : {},
+    ...includeOptionalSummary ? buildTerritoryScoutSummary(colony, roleCounts) : {},
     ...buildPostClaimBootstrapSummary(colony.room.name)
   };
 }
@@ -36352,6 +36546,19 @@ function summarizeWorkerAssignmentEvidence(tick, workerCount, assignedTaskCount,
     workerCount,
     assignedTaskCount,
     productiveAssignmentCount
+  };
+}
+function emptyConstructionPrioritySummary() {
+  return {
+    candidates: [],
+    nextPrimary: null
+  };
+}
+function emptyTerritoryRecommendationReport() {
+  return {
+    candidates: [],
+    next: null,
+    followUpIntent: null
   };
 }
 function countAssignedWorkerTasks(workers) {
@@ -38049,19 +38256,37 @@ function isRecord29(value) {
   return typeof value === "object" && value !== null;
 }
 function buildCpuSummary() {
-  const gameWithOptionalCpu = Game;
-  const cpu = gameWithOptionalCpu.cpu;
-  if (!cpu) {
+  const summary = buildRuntimeCpuTelemetrySummary();
+  if (!summary) {
     return {};
   }
-  const summary = {};
-  if (typeof cpu.getUsed === "function") {
-    summary.used = cpu.getUsed();
+  return { cpu: toRuntimeCpuSummary(summary) };
+}
+function toRuntimeCpuSummary(summary) {
+  return {
+    ...summary.used !== void 0 ? { used: summary.used } : {},
+    ...summary.limit !== void 0 ? { limit: summary.limit } : {},
+    ...summary.tickLimit !== void 0 ? { tickLimit: summary.tickLimit } : {},
+    ...summary.bucket !== void 0 ? { bucket: summary.bucket } : {},
+    ...summary.pressure !== "normal" ? { pressure: summary.pressure } : {},
+    ...summary.alerts ? { alerts: summary.alerts } : {},
+    ...summary.reasons ? { reasons: summary.reasons } : {},
+    ...summary.lowBucketTicks !== void 0 ? { lowBucketTicks: summary.lowBucketTicks } : {},
+    ...summary.bucketEmptyTicks !== void 0 ? { bucketEmptyTicks: summary.bucketEmptyTicks } : {},
+    ...summary.overLimitTicks !== void 0 ? { overLimitTicks: summary.overLimitTicks } : {}
+  };
+}
+function emitRuntimeCpuSummary(cpu, tick) {
+  if (!cpu || !shouldEmitRuntimeCpuSummary(cpu, tick)) {
+    return;
   }
-  if (typeof cpu.bucket === "number") {
-    summary.bucket = cpu.bucket;
+  console.log(`${RUNTIME_CPU_SUMMARY_PREFIX}${JSON.stringify(cpu)}`);
+}
+function shouldEmitRuntimeCpuSummary(cpu, tick) {
+  if (cpu.alerts && cpu.alerts.length > 0) {
+    return true;
   }
-  return Object.keys(summary).length > 0 ? { cpu: summary } : {};
+  return cpu.pressure !== void 0 && cpu.pressure !== "normal" && tick > 0 && tick % RUNTIME_SUMMARY_INTERVAL === 0;
 }
 function applyCpuSummaryToRooms(rooms, cpu) {
   if (!cpu || cpu.used === void 0 && cpu.bucket === void 0) {
@@ -38079,7 +38304,7 @@ function getGameTime32() {
 }
 
 // src/runtime/featureGates.ts
-function getRuntimeFeatureGates(game = getRuntimeGame()) {
+function getRuntimeFeatureGates(game = getRuntimeGame2()) {
   var _a, _b;
   const shardName = normalizeString((_a = game == null ? void 0 : game.shard) == null ? void 0 : _a.name);
   const shardType = normalizeString((_b = game == null ? void 0 : game.shard) == null ? void 0 : _b.type);
@@ -38096,17 +38321,17 @@ function getRuntimeFeatureGates(game = getRuntimeGame()) {
     labManagement: enabledInPersistent
   };
 }
-function getRuntimeGame() {
+function getRuntimeGame2() {
   return globalThis.Game;
 }
 function buildCpuMetadata(cpu) {
   return {
-    ...optionalFiniteNumber("limit", cpu == null ? void 0 : cpu.limit),
-    ...optionalFiniteNumber("bucket", cpu == null ? void 0 : cpu.bucket),
-    ...optionalFiniteNumber("tickLimit", cpu == null ? void 0 : cpu.tickLimit)
+    ...optionalFiniteNumber2("limit", cpu == null ? void 0 : cpu.limit),
+    ...optionalFiniteNumber2("bucket", cpu == null ? void 0 : cpu.bucket),
+    ...optionalFiniteNumber2("tickLimit", cpu == null ? void 0 : cpu.tickLimit)
   };
 }
-function optionalFiniteNumber(key, value) {
+function optionalFiniteNumber2(key, value) {
   return typeof value === "number" && Number.isFinite(value) ? { [key]: value } : {};
 }
 function normalizeString(value) {
@@ -45659,12 +45884,16 @@ var LOW_ROOM_ENERGY_TASK_PRIORITY_RATIO = 0.5;
 function runEconomy(preludeTelemetryEvents = [], options = {}) {
   var _a, _b, _c, _d;
   const featureGates = getRuntimeFeatureGates();
+  const cpuBudget = getRuntimeCpuBudget();
+  const runOptionalGlobalWork = shouldRunOptionalCpuWork(cpuBudget, "economy-global-optional");
   const creeps = Object.values(Game.creeps);
-  balanceStorage();
-  if (featureGates.terminalEnergyTransfers) {
+  if (runOptionalGlobalWork) {
+    balanceStorage();
+  }
+  if (runOptionalGlobalWork && featureGates.terminalEnergyTransfers) {
     manageTerminalEnergy();
   }
-  if (featureGates.marketTrading && Memory.enableMarketTrading === true && shouldRunMarketTrading(Game.time)) {
+  if (runOptionalGlobalWork && featureGates.marketTrading && Memory.enableMarketTrading === true && shouldRunMarketTrading(Game.time)) {
     runMarketTrading();
   }
   const ownedColonies = getOwnedColonies();
@@ -45683,6 +45912,7 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
   const postClaimBootstrapFocusRoomName = selectPostClaimBootstrapFocusRoomName(colonies);
   const controllerUpgradeTargetRooms = getControllerUpgradeTargetRooms2(colonies);
   for (const colony of colonies) {
+    const runOptionalRoomWork = shouldRunOptionalCpuRoomWork(cpuBudget, colony.room.name);
     recordSourceWorkloads(colony.room, creeps, Game.time);
     let roleCounts = getPlannedOrCurrentRoleCounts(creeps, colony.room.name, plannedRoleCountsByRoom);
     plannedRoleCountsByRoom.set(colony.room.name, roleCounts);
@@ -45706,7 +45936,9 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
       telemetryEvents,
       { focusRoomName: postClaimBootstrapFocusRoomName }
     );
-    refreshPostClaimDefenseConstruction(colony, { focusRoomName: postClaimBootstrapFocusRoomName });
+    if (shouldRunConstructionPlanning(cpuBudget, runOptionalRoomWork, survivalAssessment)) {
+      refreshPostClaimDefenseConstruction(colony, { focusRoomName: postClaimBootstrapFocusRoomName });
+    }
     const constructionOptions = {
       respectRoomEnergyBuffer: true,
       creeps,
@@ -45714,18 +45946,22 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
       runtimeStrategyConstructionEnabled: options.runtimeStrategyConstructionEnabled,
       onStrategyRegistryRuntimeUse: options.onStrategyRegistryRuntimeUse
     };
-    if (postClaimBootstrapRefresh.deferred === true) {
-      planDeferredClaimedRoomCapacityConstruction(colony, constructionOptions);
-    } else {
-      planClaimedRoomConstruction(colony, {
-        ...constructionOptions
-      });
+    if (shouldRunConstructionPlanning(cpuBudget, runOptionalRoomWork, survivalAssessment)) {
+      if (postClaimBootstrapRefresh.deferred === true) {
+        planDeferredClaimedRoomCapacityConstruction(colony, constructionOptions);
+      } else {
+        planClaimedRoomConstruction(colony, {
+          ...constructionOptions
+        });
+      }
     }
-    if (survivalAssessment.mode === "TERRITORY_READY") {
+    if (survivalAssessment.mode === "TERRITORY_READY" && shouldRunTerritoryPlanning(cpuBudget, runOptionalRoomWork)) {
       refreshRemoteMiningSetup(colony, Game.time, { focusRoomName: postClaimBootstrapFocusRoomName });
     }
-    refreshExecutableTerritoryRecommendation(colony, creeps, survivalAssessment.territoryReady, telemetryEvents);
-    if (survivalAssessment.territoryReady) {
+    if (shouldRunTerritoryPlanning(cpuBudget, runOptionalRoomWork)) {
+      refreshExecutableTerritoryRecommendation(colony, creeps, survivalAssessment.territoryReady, telemetryEvents);
+    }
+    if (survivalAssessment.territoryReady && shouldRunTerritoryPlanning(cpuBudget, runOptionalRoomWork)) {
       refreshClaimExecutionTargets({ colony: colony.room.name, gameTime: Game.time });
       refreshReserveExecutionTargets({ colony: colony.room.name, gameTime: Game.time });
     }
@@ -45798,17 +46034,25 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
       }
     }
     transferEnergy(colony.room);
-    manageStorage(colony.room);
-    refreshRoomEnergySurplusState(colony.room);
-    const labStructures = shouldRunLabManagement(colony.room, featureGates);
-    if (labStructures.length > 0) {
-      manageLabs(colony.room, { creeps, labs: labStructures });
+    if (runOptionalRoomWork) {
+      manageStorage(colony.room);
+      refreshRoomEnergySurplusState(colony.room);
+      const labStructures = shouldRunLabManagement(colony.room, featureGates);
+      if (labStructures.length > 0) {
+        manageLabs(colony.room, { creeps, labs: labStructures });
+      }
     }
-    recordStrategyRecommendationTelemetry(colony, creeps, telemetryEvents);
+    if (runOptionalRoomWork) {
+      recordStrategyRecommendationTelemetry(colony, creeps, telemetryEvents);
+    }
   }
-  ensureRemoteSourceContainersForAssignedHarvesters(creeps);
+  if (runOptionalGlobalWork) {
+    ensureRemoteSourceContainersForAssignedHarvesters(creeps);
+  }
   attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom);
-  attemptMineralHarvesterSpawns(colonies, creeps, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom);
+  if (runOptionalGlobalWork) {
+    attemptMineralHarvesterSpawns(colonies, creeps, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom);
+  }
   refreshSpawnEnergyReservationStates(colonies);
   refreshSpawnEnergyBufferStates(colonies, reservedSpawnEnergyByRoom);
   for (const creep of orderCreepsForEconomyTaskPriority(creeps)) {
@@ -45943,6 +46187,21 @@ function getCreepStoreAmount(creep, method) {
 function getResourceEnergyConstant() {
   var _a;
   return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
+}
+function shouldRunConstructionPlanning(cpuBudget, runOptionalRoomWork, survivalAssessment) {
+  if (!cpuBudget.degraded) {
+    return true;
+  }
+  if (cpuBudget.critical) {
+    return false;
+  }
+  return runOptionalRoomWork || survivalAssessment.mode === "BOOTSTRAP" || survivalAssessment.mode === "DEFENSE" || survivalAssessment.hostilePresence || survivalAssessment.controllerDowngradeGuard;
+}
+function shouldRunTerritoryPlanning(cpuBudget, runOptionalRoomWork) {
+  if (!cpuBudget.degraded) {
+    return true;
+  }
+  return !cpuBudget.critical && runOptionalRoomWork;
 }
 function shouldRunLabManagement(room, featureGates) {
   var _a, _b;
@@ -47628,6 +47887,7 @@ var strategyRegistryState = {
 var recentKpiWindows = {};
 var baselineKpiWindows = {};
 function loop() {
+  const cpuBudget = getRuntimeCpuBudget();
   const runtimePolicyParameters = applyRuntimePolicyParametersToRegistry(strategyRegistryState.entries);
   const hasPatchedRuntimeStrategies = runtimePolicyParameters.evidence.appliedStrategyIds.length > 0;
   const runtimePolicyParameterPlanningEnabled = runtimePolicyParameters.evidence.runtimeParameterInjection === true && hasPatchedRuntimeStrategies;
@@ -47651,7 +47911,9 @@ function loop() {
   } finally {
     persistRuntimePolicyParameterConsumptionEvidence(runtimePolicyParameterConsumption.buildEvidence());
   }
-  strategyRegistryState.entries = runStrategyRolloutMonitoring(summary, strategyRegistryState.entries);
+  if (!cpuBudget.degraded) {
+    strategyRegistryState.entries = runStrategyRolloutMonitoring(summary, strategyRegistryState.entries);
+  }
 }
 function recordAppliedRuntimePolicyParameterStrategies(registry, appliedStrategyIds, runtimePolicyParameterConsumption) {
   if (appliedStrategyIds.length === 0) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -24809,6 +24809,7 @@ function readRuntimeCpuSample(game = getRuntimeGame()) {
 function buildRuntimeCpuTelemetrySummary(sample = readRuntimeCpuSample()) {
   if (sample.used === void 0 && sample.limit === void 0 && sample.bucket === void 0 && sample.tickLimit === void 0) {
     resetRuntimeCpuTelemetryStateForTick(sample.tick);
+    clearRuntimeCpuTelemetryCounters();
     return null;
   }
   const budget = buildRuntimeCpuBudget(sample);
@@ -24862,16 +24863,17 @@ function updateRuntimeCpuTelemetryState(sample) {
 function resetRuntimeCpuTelemetryStateForTick(tick) {
   const lastTick = cpuTelemetryState.lastTick;
   if (lastTick !== void 0 && tick > 0 && lastTick > 0 && tick !== lastTick + 1) {
-    cpuTelemetryState.lowBucketTicks = 0;
-    cpuTelemetryState.bucketEmptyTicks = 0;
-    cpuTelemetryState.overLimitTicks = 0;
+    clearRuntimeCpuTelemetryCounters();
   }
   if (lastTick !== void 0 && tick > 0 && lastTick > tick) {
-    cpuTelemetryState.lowBucketTicks = 0;
-    cpuTelemetryState.bucketEmptyTicks = 0;
-    cpuTelemetryState.overLimitTicks = 0;
+    clearRuntimeCpuTelemetryCounters();
   }
   cpuTelemetryState.lastTick = tick;
+}
+function clearRuntimeCpuTelemetryCounters() {
+  cpuTelemetryState.lowBucketTicks = 0;
+  cpuTelemetryState.bucketEmptyTicks = 0;
+  cpuTelemetryState.overLimitTicks = 0;
 }
 function buildRuntimeCpuAlerts(sample, state) {
   const alerts = [];
@@ -24995,10 +24997,12 @@ var interRoomLiveTransferCandidateCache = null;
 var interRoomHaulReservationCache = null;
 var gameCreepsCache = null;
 var routineBarrierMaintenanceRepairTargetCache = null;
+var workerTaskSelectionTelemetrySuppressionDepth = 0;
 function selectWorkerTask(creep) {
-  clearWorkerEfficiencyTelemetry(creep);
-  const heuristicTask = selectHeuristicWorkerTask(creep);
-  if (getRuntimeCpuBudget().degraded) {
+  clearWorkerTaskSelectionTelemetry(creep);
+  const degraded = getRuntimeCpuBudget().degraded;
+  const heuristicTask = withWorkerTaskSelectionTelemetrySuppressed(degraded, () => selectHeuristicWorkerTask(creep));
+  if (degraded) {
     clearWorkerTaskShadowTelemetry(creep);
     return heuristicTask;
   }
@@ -25012,6 +25016,20 @@ function clearWorkerTaskShadowTelemetry(creep) {
   }
   delete memory.workerBehavior;
   delete memory.workerTaskPolicyShadow;
+}
+function withWorkerTaskSelectionTelemetrySuppressed(suppressTelemetry, selectTask) {
+  if (!suppressTelemetry) {
+    return selectTask();
+  }
+  workerTaskSelectionTelemetrySuppressionDepth += 1;
+  try {
+    return selectTask();
+  } finally {
+    workerTaskSelectionTelemetrySuppressionDepth -= 1;
+  }
+}
+function isWorkerTaskSelectionTelemetrySuppressed() {
+  return workerTaskSelectionTelemetrySuppressionDepth > 0;
 }
 function selectHeuristicWorkerTask(creep) {
   var _a;
@@ -26019,14 +26037,18 @@ function applyMinimumUsefulSpawnExtensionDeliveryPolicy(creep, task) {
 function hasKnownSpawnExtensionEnergyCapacity(room) {
   return getRoomEnergyCapacityAvailable7(room) !== null;
 }
-function clearWorkerEfficiencyTelemetry(creep) {
+function clearWorkerTaskSelectionTelemetry(creep) {
   const memory = creep.memory;
   if (memory) {
     delete memory.workerEfficiency;
+    delete memory.spawnCriticalRefill;
   }
 }
 function recordSpawnCriticalRefillTelemetry(creep, spawn) {
   var _a, _b;
+  if (isWorkerTaskSelectionTelemetrySuppressed()) {
+    return;
+  }
   const memory = creep.memory;
   if (!memory) {
     return;
@@ -26043,6 +26065,9 @@ function recordSpawnCriticalRefillTelemetry(creep, spawn) {
 }
 function recordNearbyEnergyChoiceTelemetry(creep, candidate) {
   var _a;
+  if (isWorkerTaskSelectionTelemetrySuppressed()) {
+    return;
+  }
   const context = getLowLoadWorkerEnergyContext(creep);
   const memory = creep.memory;
   if (!context || !memory) {
@@ -26061,6 +26086,9 @@ function recordNearbyEnergyChoiceTelemetry(creep, candidate) {
 }
 function recordLowLoadReturnTelemetry(creep, task, reason) {
   var _a;
+  if (isWorkerTaskSelectionTelemetrySuppressed()) {
+    return;
+  }
   const context = getLowLoadWorkerEnergyContext(creep);
   const memory = creep.memory;
   if (!context || !memory) {
@@ -36331,6 +36359,7 @@ var RUNTIME_SUMMARY_PREFIX = "#runtime-summary ";
 var RUNTIME_CPU_SUMMARY_PREFIX = "#cpu-summary ";
 var RUNTIME_SUMMARY_INTERVAL = 20;
 var DEGRADED_RUNTIME_SUMMARY_INTERVAL = RUNTIME_SUMMARY_INTERVAL * 5;
+var RUNTIME_CPU_SUMMARY_REPEAT_INTERVAL = DEGRADED_RUNTIME_SUMMARY_INTERVAL;
 var MAX_REPORTED_EVENTS = 10;
 var MAX_WORKER_EFFICIENCY_SAMPLES = 5;
 var MAX_WORKER_BEHAVIOR_SAMPLES = 10;
@@ -36347,6 +36376,7 @@ var OBSERVED_RAMPART_REPAIR_HITS_CEILING = 15e4;
 var WORKER_TASK_TYPES = ["harvest", "transfer", "build", "repair", "upgrade"];
 var PRODUCTIVE_WORKER_TASK_TYPES = ["build", "repair", "upgrade"];
 var DEFAULT_EXTENSION_ENERGY_CAPACITY = 50;
+var runtimeCpuSummaryEmissionState = {};
 var cachedRefillTargetIdsByRoom = /* @__PURE__ */ new Map();
 var cachedEventMetricsByRoom = /* @__PURE__ */ new Map();
 var cachedEventMetricsTick;
@@ -38277,16 +38307,49 @@ function toRuntimeCpuSummary(summary) {
   };
 }
 function emitRuntimeCpuSummary(cpu, tick) {
-  if (!cpu || !shouldEmitRuntimeCpuSummary(cpu, tick)) {
+  if (!cpu) {
+    recordRuntimeCpuSummarySignal(null, tick);
+    return;
+  }
+  if (!shouldEmitRuntimeCpuSummary(cpu, tick)) {
     return;
   }
   console.log(`${RUNTIME_CPU_SUMMARY_PREFIX}${JSON.stringify(cpu)}`);
 }
 function shouldEmitRuntimeCpuSummary(cpu, tick) {
-  if (cpu.alerts && cpu.alerts.length > 0) {
-    return true;
+  const signal = buildRuntimeCpuSummarySignal(cpu);
+  const previousSignal = getPreviousRuntimeCpuSummarySignal(tick);
+  recordRuntimeCpuSummarySignal(signal, tick);
+  if (!signal) {
+    return false;
   }
-  return cpu.pressure !== void 0 && cpu.pressure !== "normal" && tick > 0 && tick % RUNTIME_SUMMARY_INTERVAL === 0;
+  return signal !== previousSignal || isRuntimeCpuSummaryRepeatTick(tick);
+}
+function buildRuntimeCpuSummarySignal(cpu) {
+  const alerts = normalizeRuntimeCpuSummarySignalValues(cpu.alerts);
+  const reasons = normalizeRuntimeCpuSummarySignalValues(cpu.reasons);
+  const pressure = cpu.pressure && cpu.pressure !== "normal" ? cpu.pressure : void 0;
+  if (!pressure && alerts.length === 0 && reasons.length === 0) {
+    return null;
+  }
+  return `pressure:${pressure != null ? pressure : "normal"};alerts:${alerts.join(",")};reasons:${reasons.join(",")}`;
+}
+function normalizeRuntimeCpuSummarySignalValues(values) {
+  return values && values.length > 0 ? [...values].sort() : [];
+}
+function getPreviousRuntimeCpuSummarySignal(tick) {
+  if (runtimeCpuSummaryEmissionState.lastTick !== void 0 && tick > 0 && runtimeCpuSummaryEmissionState.lastTick > tick) {
+    runtimeCpuSummaryEmissionState = {};
+  }
+  return runtimeCpuSummaryEmissionState.lastSignal;
+}
+function recordRuntimeCpuSummarySignal(signal, tick) {
+  getPreviousRuntimeCpuSummarySignal(tick);
+  runtimeCpuSummaryEmissionState.lastSignal = signal;
+  runtimeCpuSummaryEmissionState.lastTick = tick;
+}
+function isRuntimeCpuSummaryRepeatTick(tick) {
+  return tick > 0 && tick % RUNTIME_CPU_SUMMARY_REPEAT_INTERVAL === 0;
 }
 function applyCpuSummaryToRooms(rooms, cpu) {
   if (!cpu || cpu.used === void 0 && cpu.bucket === void 0) {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -33,6 +33,12 @@ import {
 } from '../telemetry/runtimeSummary';
 import type { StrategyRegistryEntry } from '../strategy/strategyRegistry';
 import { getRuntimeFeatureGates, type RuntimeFeatureGates } from '../runtime/featureGates';
+import {
+  getRuntimeCpuBudget,
+  shouldRunOptionalCpuRoomWork,
+  shouldRunOptionalCpuWork,
+  type RuntimeCpuBudget
+} from '../runtime/cpuBudget';
 import { recordSourceWorkloads } from './sourceWorkload';
 import {
   ensureRemoteSourceContainersForAssignedHarvesters
@@ -155,12 +161,21 @@ export function runEconomy(
   options: EconomyRuntimeOptions = {}
 ): RuntimeSummary | undefined {
   const featureGates = getRuntimeFeatureGates();
+  const cpuBudget = getRuntimeCpuBudget();
+  const runOptionalGlobalWork = shouldRunOptionalCpuWork(cpuBudget, 'economy-global-optional');
   const creeps = Object.values(Game.creeps);
-  balanceStorage();
-  if (featureGates.terminalEnergyTransfers) {
+  if (runOptionalGlobalWork) {
+    balanceStorage();
+  }
+  if (runOptionalGlobalWork && featureGates.terminalEnergyTransfers) {
     manageTerminalEnergy();
   }
-  if (featureGates.marketTrading && Memory.enableMarketTrading === true && shouldRunMarketTrading(Game.time)) {
+  if (
+    runOptionalGlobalWork &&
+    featureGates.marketTrading &&
+    Memory.enableMarketTrading === true &&
+    shouldRunMarketTrading(Game.time)
+  ) {
     runMarketTrading();
   }
   const ownedColonies = getOwnedColonies();
@@ -180,6 +195,7 @@ export function runEconomy(
   const controllerUpgradeTargetRooms = getControllerUpgradeTargetRooms(colonies);
 
   for (const colony of colonies) {
+    const runOptionalRoomWork = shouldRunOptionalCpuRoomWork(cpuBudget, colony.room.name);
     recordSourceWorkloads(colony.room, creeps, Game.time);
     let roleCounts = getPlannedOrCurrentRoleCounts(creeps, colony.room.name, plannedRoleCountsByRoom);
     plannedRoleCountsByRoom.set(colony.room.name, roleCounts);
@@ -206,7 +222,9 @@ export function runEconomy(
       telemetryEvents,
       { focusRoomName: postClaimBootstrapFocusRoomName }
     );
-    refreshPostClaimDefenseConstruction(colony, { focusRoomName: postClaimBootstrapFocusRoomName });
+    if (shouldRunConstructionPlanning(cpuBudget, runOptionalRoomWork, survivalAssessment)) {
+      refreshPostClaimDefenseConstruction(colony, { focusRoomName: postClaimBootstrapFocusRoomName });
+    }
     const constructionOptions = {
       respectRoomEnergyBuffer: true,
       creeps,
@@ -214,18 +232,22 @@ export function runEconomy(
       runtimeStrategyConstructionEnabled: options.runtimeStrategyConstructionEnabled,
       onStrategyRegistryRuntimeUse: options.onStrategyRegistryRuntimeUse
     };
-    if (postClaimBootstrapRefresh.deferred === true) {
-      planDeferredClaimedRoomCapacityConstruction(colony, constructionOptions);
-    } else {
-      planClaimedRoomConstruction(colony, {
-        ...constructionOptions
-      });
+    if (shouldRunConstructionPlanning(cpuBudget, runOptionalRoomWork, survivalAssessment)) {
+      if (postClaimBootstrapRefresh.deferred === true) {
+        planDeferredClaimedRoomCapacityConstruction(colony, constructionOptions);
+      } else {
+        planClaimedRoomConstruction(colony, {
+          ...constructionOptions
+        });
+      }
     }
-    if (survivalAssessment.mode === 'TERRITORY_READY') {
+    if (survivalAssessment.mode === 'TERRITORY_READY' && shouldRunTerritoryPlanning(cpuBudget, runOptionalRoomWork)) {
       refreshRemoteMiningSetup(colony, Game.time, { focusRoomName: postClaimBootstrapFocusRoomName });
     }
-    refreshExecutableTerritoryRecommendation(colony, creeps, survivalAssessment.territoryReady, telemetryEvents);
-    if (survivalAssessment.territoryReady) {
+    if (shouldRunTerritoryPlanning(cpuBudget, runOptionalRoomWork)) {
+      refreshExecutableTerritoryRecommendation(colony, creeps, survivalAssessment.territoryReady, telemetryEvents);
+    }
+    if (survivalAssessment.territoryReady && shouldRunTerritoryPlanning(cpuBudget, runOptionalRoomWork)) {
       refreshClaimExecutionTargets({ colony: colony.room.name, gameTime: Game.time });
       refreshReserveExecutionTargets({ colony: colony.room.name, gameTime: Game.time });
     }
@@ -308,18 +330,26 @@ export function runEconomy(
     }
 
     transferLinkEnergy(colony.room);
-    manageStorage(colony.room);
-    refreshRoomEnergySurplusState(colony.room);
-    const labStructures = shouldRunLabManagement(colony.room, featureGates);
-    if (labStructures.length > 0) {
-      manageLabs(colony.room, { creeps, labs: labStructures });
+    if (runOptionalRoomWork) {
+      manageStorage(colony.room);
+      refreshRoomEnergySurplusState(colony.room);
+      const labStructures = shouldRunLabManagement(colony.room, featureGates);
+      if (labStructures.length > 0) {
+        manageLabs(colony.room, { creeps, labs: labStructures });
+      }
     }
-    recordStrategyRecommendationTelemetry(colony, creeps, telemetryEvents);
+    if (runOptionalRoomWork) {
+      recordStrategyRecommendationTelemetry(colony, creeps, telemetryEvents);
+    }
   }
 
-  ensureRemoteSourceContainersForAssignedHarvesters(creeps);
+  if (runOptionalGlobalWork) {
+    ensureRemoteSourceContainersForAssignedHarvesters(creeps);
+  }
   attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom);
-  attemptMineralHarvesterSpawns(colonies, creeps, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom);
+  if (runOptionalGlobalWork) {
+    attemptMineralHarvesterSpawns(colonies, creeps, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom);
+  }
   refreshSpawnEnergyReservationStates(colonies);
   refreshSpawnEnergyBufferStates(colonies, reservedSpawnEnergyByRoom);
 
@@ -490,6 +520,36 @@ function getCreepStoreAmount(
 
 function getResourceEnergyConstant(): ResourceConstant {
   return ((globalThis as unknown as { RESOURCE_ENERGY?: ResourceConstant }).RESOURCE_ENERGY ?? 'energy') as ResourceConstant;
+}
+
+function shouldRunConstructionPlanning(
+  cpuBudget: RuntimeCpuBudget,
+  runOptionalRoomWork: boolean,
+  survivalAssessment: ReturnType<typeof assessColonySnapshotSurvival>
+): boolean {
+  if (!cpuBudget.degraded) {
+    return true;
+  }
+
+  if (cpuBudget.critical) {
+    return false;
+  }
+
+  return (
+    runOptionalRoomWork ||
+    survivalAssessment.mode === 'BOOTSTRAP' ||
+    survivalAssessment.mode === 'DEFENSE' ||
+    survivalAssessment.hostilePresence ||
+    survivalAssessment.controllerDowngradeGuard
+  );
+}
+
+function shouldRunTerritoryPlanning(cpuBudget: RuntimeCpuBudget, runOptionalRoomWork: boolean): boolean {
+  if (!cpuBudget.degraded) {
+    return true;
+  }
+
+  return !cpuBudget.critical && runOptionalRoomWork;
 }
 
 function shouldRunLabManagement(room: Room, featureGates: RuntimeFeatureGates): StructureLab[] {

--- a/prod/src/main.ts
+++ b/prod/src/main.ts
@@ -18,6 +18,7 @@ import {
   persistRuntimePolicyParameterConsumptionEvidence
 } from './strategy/runtimePolicyParameters';
 import { type RuntimeSummary, RUNTIME_SUMMARY_PREFIX } from './telemetry/runtimeSummary';
+import { getRuntimeCpuBudget } from './runtime/cpuBudget';
 export {
   DEFAULT_STRATEGY_REGISTRY,
   STRATEGY_REGISTRY_SCHEMA_VERSION,
@@ -44,6 +45,7 @@ const recentKpiWindows: KpiWindowHistory = {};
 const baselineKpiWindows: KpiWindowHistory = {};
 
 export function loop(): void {
+  const cpuBudget = getRuntimeCpuBudget();
   const runtimePolicyParameters = applyRuntimePolicyParametersToRegistry(strategyRegistryState.entries);
   const hasPatchedRuntimeStrategies = runtimePolicyParameters.evidence.appliedStrategyIds.length > 0;
   const runtimePolicyParameterPlanningEnabled =
@@ -72,7 +74,9 @@ export function loop(): void {
   } finally {
     persistRuntimePolicyParameterConsumptionEvidence(runtimePolicyParameterConsumption.buildEvidence());
   }
-  strategyRegistryState.entries = runStrategyRolloutMonitoring(summary, strategyRegistryState.entries);
+  if (!cpuBudget.degraded) {
+    strategyRegistryState.entries = runStrategyRolloutMonitoring(summary, strategyRegistryState.entries);
+  }
 }
 
 function recordAppliedRuntimePolicyParameterStrategies(

--- a/prod/src/runtime/cpuBudget.ts
+++ b/prod/src/runtime/cpuBudget.ts
@@ -1,0 +1,298 @@
+export type RuntimeCpuPressure = 'normal' | 'degraded' | 'critical';
+export type RuntimeCpuPressureReason =
+  | 'lowCpuLimit'
+  | 'lowBucket'
+  | 'criticalBucket'
+  | 'usedOverLimit';
+export type RuntimeCpuAlert =
+  | 'bucketEmptyRepeated'
+  | 'lowBucket'
+  | 'sustainedUsedOverLimit';
+
+export interface RuntimeCpuSample {
+  tick: number;
+  used?: number;
+  limit?: number;
+  tickLimit?: number;
+  bucket?: number;
+}
+
+export interface RuntimeCpuBudget {
+  tick: number;
+  sample: RuntimeCpuSample;
+  pressure: RuntimeCpuPressure;
+  degraded: boolean;
+  critical: boolean;
+  lowCpuLimit: boolean;
+  reasons: RuntimeCpuPressureReason[];
+}
+
+export interface RuntimeCpuTelemetrySummary extends RuntimeCpuSample {
+  pressure: RuntimeCpuPressure;
+  alerts?: RuntimeCpuAlert[];
+  reasons?: RuntimeCpuPressureReason[];
+  lowBucketTicks?: number;
+  bucketEmptyTicks?: number;
+  overLimitTicks?: number;
+}
+
+interface RuntimeGameLike {
+  time?: unknown;
+  cpu?: {
+    getUsed?: unknown;
+    limit?: unknown;
+    bucket?: unknown;
+    tickLimit?: unknown;
+  };
+}
+
+interface RuntimeCpuTelemetryState {
+  lastTick?: number;
+  lowBucketTicks: number;
+  bucketEmptyTicks: number;
+  overLimitTicks: number;
+}
+
+export const LOW_CPU_ACCOUNT_LIMIT = 20;
+export const LOW_CPU_BUCKET_THRESHOLD = 1_000;
+export const CRITICAL_CPU_BUCKET_THRESHOLD = 100;
+export const DEGRADED_OPTIONAL_WORK_INTERVAL = 5;
+export const DEGRADED_ROOM_OPTIONAL_WORK_INTERVAL = 3;
+const REPEATED_BUCKET_EMPTY_TICKS = 2;
+const SUSTAINED_OVER_LIMIT_TICKS = 2;
+
+let cpuTelemetryState: RuntimeCpuTelemetryState = {
+  lowBucketTicks: 0,
+  bucketEmptyTicks: 0,
+  overLimitTicks: 0
+};
+
+export function getRuntimeCpuBudget(game: RuntimeGameLike | undefined = getRuntimeGame()): RuntimeCpuBudget {
+  return buildRuntimeCpuBudget(readRuntimeCpuSample(game));
+}
+
+export function buildRuntimeCpuBudget(sample: RuntimeCpuSample): RuntimeCpuBudget {
+  const reasons: RuntimeCpuPressureReason[] = [];
+  const lowCpuLimit = sample.limit !== undefined && sample.limit <= LOW_CPU_ACCOUNT_LIMIT;
+  if (lowCpuLimit) {
+    reasons.push('lowCpuLimit');
+  }
+
+  const criticalBucket = sample.bucket !== undefined && sample.bucket <= CRITICAL_CPU_BUCKET_THRESHOLD;
+  if (criticalBucket) {
+    reasons.push('criticalBucket');
+  } else if (sample.bucket !== undefined && sample.bucket < LOW_CPU_BUCKET_THRESHOLD) {
+    reasons.push('lowBucket');
+  }
+
+  if (
+    sample.used !== undefined &&
+    sample.limit !== undefined &&
+    sample.limit > 0 &&
+    sample.used > sample.limit
+  ) {
+    reasons.push('usedOverLimit');
+  }
+
+  const critical = criticalBucket;
+  const degraded = critical || reasons.length > 0;
+
+  return {
+    tick: sample.tick,
+    sample,
+    pressure: critical ? 'critical' : degraded ? 'degraded' : 'normal',
+    degraded,
+    critical,
+    lowCpuLimit,
+    reasons
+  };
+}
+
+export function readRuntimeCpuSample(game: RuntimeGameLike | undefined = getRuntimeGame()): RuntimeCpuSample {
+  const cpu = game?.cpu;
+  return {
+    tick: normalizeTick(game?.time),
+    ...optionalFiniteNumber('used', readCpuUsed(cpu)),
+    ...optionalFiniteNumber('limit', cpu?.limit),
+    ...optionalFiniteNumber('bucket', cpu?.bucket),
+    ...optionalFiniteNumber('tickLimit', cpu?.tickLimit)
+  };
+}
+
+export function buildRuntimeCpuTelemetrySummary(
+  sample: RuntimeCpuSample = readRuntimeCpuSample()
+): RuntimeCpuTelemetrySummary | null {
+  if (
+    sample.used === undefined &&
+    sample.limit === undefined &&
+    sample.bucket === undefined &&
+    sample.tickLimit === undefined
+  ) {
+    resetRuntimeCpuTelemetryStateForTick(sample.tick);
+    return null;
+  }
+
+  const budget = buildRuntimeCpuBudget(sample);
+  const state = updateRuntimeCpuTelemetryState(sample);
+  const alerts = buildRuntimeCpuAlerts(sample, state);
+
+  return {
+    tick: sample.tick,
+    ...(sample.used !== undefined ? { used: sample.used } : {}),
+    ...(sample.limit !== undefined ? { limit: sample.limit } : {}),
+    ...(sample.tickLimit !== undefined ? { tickLimit: sample.tickLimit } : {}),
+    ...(sample.bucket !== undefined ? { bucket: sample.bucket } : {}),
+    pressure: budget.pressure,
+    ...(budget.reasons.length > 0 ? { reasons: budget.reasons } : {}),
+    ...(alerts.length > 0 ? { alerts } : {}),
+    ...(state.lowBucketTicks > 0 ? { lowBucketTicks: state.lowBucketTicks } : {}),
+    ...(state.bucketEmptyTicks > 0 ? { bucketEmptyTicks: state.bucketEmptyTicks } : {}),
+    ...(state.overLimitTicks > 0 ? { overLimitTicks: state.overLimitTicks } : {})
+  };
+}
+
+export function shouldRunOptionalCpuWork(
+  budget: RuntimeCpuBudget,
+  key: string,
+  interval = DEGRADED_OPTIONAL_WORK_INTERVAL
+): boolean {
+  if (!budget.degraded) {
+    return true;
+  }
+
+  if (budget.critical) {
+    return false;
+  }
+
+  return isCadenceTick(budget.tick, key, interval);
+}
+
+export function shouldRunOptionalCpuRoomWork(
+  budget: RuntimeCpuBudget,
+  roomName: string,
+  interval = DEGRADED_ROOM_OPTIONAL_WORK_INTERVAL
+): boolean {
+  if (!budget.degraded) {
+    return true;
+  }
+
+  if (budget.critical) {
+    return false;
+  }
+
+  return isCadenceTick(budget.tick, roomName, interval);
+}
+
+export function shouldThrottleRuntimeSummaryCadence(budget: RuntimeCpuBudget): boolean {
+  return budget.lowCpuLimit;
+}
+
+export function resetRuntimeCpuTelemetryForTesting(): void {
+  cpuTelemetryState = {
+    lowBucketTicks: 0,
+    bucketEmptyTicks: 0,
+    overLimitTicks: 0
+  };
+}
+
+function updateRuntimeCpuTelemetryState(sample: RuntimeCpuSample): RuntimeCpuTelemetryState {
+  resetRuntimeCpuTelemetryStateForTick(sample.tick);
+
+  const lowBucket = sample.bucket !== undefined && sample.bucket < LOW_CPU_BUCKET_THRESHOLD;
+  const bucketEmpty = sample.bucket !== undefined && sample.bucket <= 0;
+  const overLimit =
+    sample.used !== undefined &&
+    sample.limit !== undefined &&
+    sample.limit > 0 &&
+    sample.used > sample.limit;
+
+  cpuTelemetryState.lowBucketTicks = lowBucket ? cpuTelemetryState.lowBucketTicks + 1 : 0;
+  cpuTelemetryState.bucketEmptyTicks = bucketEmpty ? cpuTelemetryState.bucketEmptyTicks + 1 : 0;
+  cpuTelemetryState.overLimitTicks = overLimit ? cpuTelemetryState.overLimitTicks + 1 : 0;
+  return cpuTelemetryState;
+}
+
+function resetRuntimeCpuTelemetryStateForTick(tick: number): void {
+  const lastTick = cpuTelemetryState.lastTick;
+  if (lastTick !== undefined && tick > 0 && lastTick > 0 && tick !== lastTick + 1) {
+    cpuTelemetryState.lowBucketTicks = 0;
+    cpuTelemetryState.bucketEmptyTicks = 0;
+    cpuTelemetryState.overLimitTicks = 0;
+  }
+
+  if (lastTick !== undefined && tick > 0 && lastTick > tick) {
+    cpuTelemetryState.lowBucketTicks = 0;
+    cpuTelemetryState.bucketEmptyTicks = 0;
+    cpuTelemetryState.overLimitTicks = 0;
+  }
+
+  cpuTelemetryState.lastTick = tick;
+}
+
+function buildRuntimeCpuAlerts(
+  sample: RuntimeCpuSample,
+  state: RuntimeCpuTelemetryState
+): RuntimeCpuAlert[] {
+  const alerts: RuntimeCpuAlert[] = [];
+  if (state.bucketEmptyTicks >= REPEATED_BUCKET_EMPTY_TICKS) {
+    alerts.push('bucketEmptyRepeated');
+  }
+
+  if (sample.bucket !== undefined && sample.bucket < LOW_CPU_BUCKET_THRESHOLD) {
+    alerts.push('lowBucket');
+  }
+
+  if (state.overLimitTicks >= SUSTAINED_OVER_LIMIT_TICKS) {
+    alerts.push('sustainedUsedOverLimit');
+  }
+
+  return alerts;
+}
+
+function isCadenceTick(tick: number, key: string, interval: number): boolean {
+  const normalizedInterval = Math.max(1, Math.floor(interval));
+  if (tick <= 0) {
+    return false;
+  }
+
+  return (tick + stableHash(key)) % normalizedInterval === 0;
+}
+
+function stableHash(value: string): number {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+  return hash;
+}
+
+function readCpuUsed(cpu: RuntimeGameLike['cpu']): number | undefined {
+  const getUsed = cpu?.getUsed;
+  if (typeof getUsed !== 'function') {
+    return undefined;
+  }
+
+  try {
+    const used = getUsed.call(cpu);
+    return typeof used === 'number' && Number.isFinite(used) ? used : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function optionalFiniteNumber<K extends keyof RuntimeCpuSample>(
+  key: K,
+  value: unknown
+): Pick<RuntimeCpuSample, K> | Record<string, never> {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? ({ [key]: value } as Pick<RuntimeCpuSample, K>)
+    : {};
+}
+
+function normalizeTick(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function getRuntimeGame(): RuntimeGameLike | undefined {
+  return (globalThis as { Game?: RuntimeGameLike }).Game;
+}

--- a/prod/src/runtime/cpuBudget.ts
+++ b/prod/src/runtime/cpuBudget.ts
@@ -129,6 +129,7 @@ export function buildRuntimeCpuTelemetrySummary(
     sample.tickLimit === undefined
   ) {
     resetRuntimeCpuTelemetryStateForTick(sample.tick);
+    clearRuntimeCpuTelemetryCounters();
     return null;
   }
 
@@ -215,18 +216,20 @@ function updateRuntimeCpuTelemetryState(sample: RuntimeCpuSample): RuntimeCpuTel
 function resetRuntimeCpuTelemetryStateForTick(tick: number): void {
   const lastTick = cpuTelemetryState.lastTick;
   if (lastTick !== undefined && tick > 0 && lastTick > 0 && tick !== lastTick + 1) {
-    cpuTelemetryState.lowBucketTicks = 0;
-    cpuTelemetryState.bucketEmptyTicks = 0;
-    cpuTelemetryState.overLimitTicks = 0;
+    clearRuntimeCpuTelemetryCounters();
   }
 
   if (lastTick !== undefined && tick > 0 && lastTick > tick) {
-    cpuTelemetryState.lowBucketTicks = 0;
-    cpuTelemetryState.bucketEmptyTicks = 0;
-    cpuTelemetryState.overLimitTicks = 0;
+    clearRuntimeCpuTelemetryCounters();
   }
 
   cpuTelemetryState.lastTick = tick;
+}
+
+function clearRuntimeCpuTelemetryCounters(): void {
+  cpuTelemetryState.lowBucketTicks = 0;
+  cpuTelemetryState.bucketEmptyTicks = 0;
+  cpuTelemetryState.overLimitTicks = 0;
 }
 
 function buildRuntimeCpuAlerts(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -306,11 +306,13 @@ let interRoomLiveTransferCandidateCache: LiveTransferCandidateCache | null = nul
 let interRoomHaulReservationCache: InterRoomHaulReservationCache | null = null;
 let gameCreepsCache: GameCreepsCache | null = null;
 let routineBarrierMaintenanceRepairTargetCache: RoutineBarrierMaintenanceRepairTargetCache | null = null;
+let workerTaskSelectionTelemetrySuppressionDepth = 0;
 
 export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
-  clearWorkerEfficiencyTelemetry(creep);
-  const heuristicTask = selectHeuristicWorkerTask(creep);
-  if (getRuntimeCpuBudget().degraded) {
+  clearWorkerTaskSelectionTelemetry(creep);
+  const degraded = getRuntimeCpuBudget().degraded;
+  const heuristicTask = withWorkerTaskSelectionTelemetrySuppressed(degraded, () => selectHeuristicWorkerTask(creep));
+  if (degraded) {
     clearWorkerTaskShadowTelemetry(creep);
     return heuristicTask;
   }
@@ -327,6 +329,23 @@ function clearWorkerTaskShadowTelemetry(creep: Creep): void {
 
   delete memory.workerBehavior;
   delete memory.workerTaskPolicyShadow;
+}
+
+function withWorkerTaskSelectionTelemetrySuppressed<T>(suppressTelemetry: boolean, selectTask: () => T): T {
+  if (!suppressTelemetry) {
+    return selectTask();
+  }
+
+  workerTaskSelectionTelemetrySuppressionDepth += 1;
+  try {
+    return selectTask();
+  } finally {
+    workerTaskSelectionTelemetrySuppressionDepth -= 1;
+  }
+}
+
+function isWorkerTaskSelectionTelemetrySuppressed(): boolean {
+  return workerTaskSelectionTelemetrySuppressionDepth > 0;
 }
 
 function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
@@ -1803,14 +1822,19 @@ function hasKnownSpawnExtensionEnergyCapacity(room: Room): boolean {
   return getRoomEnergyCapacityAvailable(room) !== null;
 }
 
-function clearWorkerEfficiencyTelemetry(creep: Creep): void {
+function clearWorkerTaskSelectionTelemetry(creep: Creep): void {
   const memory = creep.memory;
   if (memory) {
     delete memory.workerEfficiency;
+    delete memory.spawnCriticalRefill;
   }
 }
 
 function recordSpawnCriticalRefillTelemetry(creep: Creep, spawn: StructureSpawn): void {
+  if (isWorkerTaskSelectionTelemetrySuppressed()) {
+    return;
+  }
+
   const memory = creep.memory;
   if (!memory) {
     return;
@@ -1831,6 +1855,10 @@ function recordNearbyEnergyChoiceTelemetry(
   creep: Creep,
   candidate: LowLoadWorkerEnergyAcquisitionCandidate
 ): void {
+  if (isWorkerTaskSelectionTelemetrySuppressed()) {
+    return;
+  }
+
   const context = getLowLoadWorkerEnergyContext(creep);
   const memory = creep.memory;
   if (!context || !memory) {
@@ -1854,6 +1882,10 @@ function recordLowLoadReturnTelemetry(
   task: WorkerEnergySpendingTask,
   reason: WorkerEfficiencyLowLoadReturnReason
 ): void {
+  if (isWorkerTaskSelectionTelemetrySuppressed()) {
+    return;
+  }
+
   const context = getLowLoadWorkerEnergyContext(creep);
   const memory = creep.memory;
   if (!context || !memory) {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -78,6 +78,7 @@ import {
 import { SOURCE_HARVESTER_ROLE } from '../creeps/sourceHarvester';
 import { recordWorkerTaskBehaviorTrace } from '../rl/workerTaskBehavior';
 import { selectWorkerTaskWithBcFallback } from '../rl/workerTaskPolicy';
+import { getRuntimeCpuBudget } from '../runtime/cpuBudget';
 
 // Low-downgrade safety floor: enough buffer for worker travel/recovery without treating healthy controllers as urgent.
 export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
@@ -309,8 +310,23 @@ let routineBarrierMaintenanceRepairTargetCache: RoutineBarrierMaintenanceRepairT
 export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   clearWorkerEfficiencyTelemetry(creep);
   const heuristicTask = selectHeuristicWorkerTask(creep);
+  if (getRuntimeCpuBudget().degraded) {
+    clearWorkerTaskShadowTelemetry(creep);
+    return heuristicTask;
+  }
+
   recordWorkerTaskBehaviorTrace(creep, heuristicTask);
   return selectWorkerTaskWithBcFallback(creep, heuristicTask);
+}
+
+function clearWorkerTaskShadowTelemetry(creep: Creep): void {
+  const memory = creep.memory;
+  if (!memory) {
+    return;
+  }
+
+  delete memory.workerBehavior;
+  delete memory.workerTaskPolicyShadow;
 }
 
 function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -63,11 +63,22 @@ import {
   type RuntimeBehaviorSummary as LegacyRuntimeBehaviorSummary,
   type RuntimeEnergyAcquisitionMethodDistribution
 } from './behaviorTelemetry';
+import {
+  buildRuntimeCpuTelemetrySummary,
+  getRuntimeCpuBudget,
+  shouldThrottleRuntimeSummaryCadence,
+  type RuntimeCpuAlert,
+  type RuntimeCpuPressure,
+  type RuntimeCpuPressureReason,
+  type RuntimeCpuTelemetrySummary
+} from '../runtime/cpuBudget';
 
 type BehaviorTelemetrySummary = { behavior?: LegacyRuntimeBehaviorSummary };
 
 export const RUNTIME_SUMMARY_PREFIX = '#runtime-summary ';
+export const RUNTIME_CPU_SUMMARY_PREFIX = '#cpu-summary ';
 export const RUNTIME_SUMMARY_INTERVAL = 20;
+const DEGRADED_RUNTIME_SUMMARY_INTERVAL = RUNTIME_SUMMARY_INTERVAL * 5;
 const MAX_REPORTED_EVENTS = 10;
 const MAX_WORKER_EFFICIENCY_SAMPLES = 5;
 const MAX_WORKER_BEHAVIOR_SAMPLES = 10;
@@ -709,7 +720,15 @@ interface RuntimeRefillTransferEvent {
 
 interface RuntimeCpuSummary {
   used?: number;
+  limit?: number;
+  tickLimit?: number;
   bucket?: number;
+  pressure?: RuntimeCpuPressure;
+  alerts?: RuntimeCpuAlert[];
+  reasons?: RuntimeCpuPressureReason[];
+  lowBucketTicks?: number;
+  bucketEmptyTicks?: number;
+  overLimitTicks?: number;
 }
 
 export interface RuntimeSummary {
@@ -743,7 +762,9 @@ export function emitRuntimeSummary(
 
   const tick = getGameTime();
   resetCachedRefillTelemetryIfTickRewound(tick);
-  const emitsSummary = shouldEmitRuntimeSummary(tick, events);
+  const cpuBudget = getRuntimeCpuBudget();
+  const emitsSummary = shouldEmitRuntimeSummary(tick, events, cpuBudget);
+  const shouldRefreshRuntimeTelemetry = !shouldThrottleRuntimeSummaryCadence(cpuBudget) || emitsSummary;
   const creepsByColony = groupCreepsByColony(creeps, colonies);
   let refillTargetIdsByRoom = cachedRefillTargetIdsByRoom;
   let eventMetricsByRoom = cachedEventMetricsByRoom;
@@ -756,22 +777,27 @@ export function emitRuntimeSummary(
     cachedEventMetricsTick = tick;
   }
 
-  refreshRefillTelemetry(
-    colonies,
-    creepsByColony,
-    refillTargetIdsByRoom,
-    eventMetricsByRoom,
-    tick,
-    cachedEventMetricsTick
-  );
-  refreshConstructionDeadlockTelemetry(colonies, creepsByColony, tick);
+  if (shouldRefreshRuntimeTelemetry) {
+    refreshRefillTelemetry(
+      colonies,
+      creepsByColony,
+      refillTargetIdsByRoom,
+      eventMetricsByRoom,
+      tick,
+      cachedEventMetricsTick
+    );
+    refreshConstructionDeadlockTelemetry(colonies, creepsByColony, tick);
+  }
+
+  const cpuSummary = buildCpuSummary();
+  emitRuntimeCpuSummary(cpuSummary.cpu, tick);
   if (!emitsSummary) {
     return undefined;
   }
 
   const reportedEvents = events.slice(0, MAX_REPORTED_EVENTS);
   const persistOccupationRecommendations = options.persistOccupationRecommendations !== false;
-  const cpuSummary = buildCpuSummary();
+  const includeOptionalSummary = !shouldThrottleRuntimeSummaryCadence(cpuBudget) && !cpuBudget.critical;
   const rooms = colonies.map((colony) =>
     summarizeRoom(
       colony,
@@ -780,7 +806,8 @@ export function emitRuntimeSummary(
       eventMetricsByRoom.get(colony.room.name) ?? {},
       shouldBuildStructureSnapshot(tick),
       options.strategyRegistry,
-      options.onStrategyRegistryRuntimeUse
+      options.onStrategyRegistryRuntimeUse,
+      includeOptionalSummary
     )
   );
   const summary: RuntimeSummary = {
@@ -796,8 +823,19 @@ export function emitRuntimeSummary(
   return summary;
 }
 
-export function shouldEmitRuntimeSummary(tick: number, events: RuntimeTelemetryEvent[]): boolean {
-  return events.length > 0 || (tick > 0 && tick % RUNTIME_SUMMARY_INTERVAL === 0);
+export function shouldEmitRuntimeSummary(
+  tick: number,
+  events: RuntimeTelemetryEvent[],
+  cpuBudget = getRuntimeCpuBudget()
+): boolean {
+  if (events.length > 0) {
+    return true;
+  }
+
+  const interval = shouldThrottleRuntimeSummaryCadence(cpuBudget)
+    ? DEGRADED_RUNTIME_SUMMARY_INTERVAL
+    : RUNTIME_SUMMARY_INTERVAL;
+  return tick > 0 && tick % interval === 0;
 }
 
 function resetCachedRefillTelemetryIfTickRewound(tick: number): void {
@@ -884,7 +922,8 @@ function summarizeRoom(
   eventMetrics: RuntimeRoomEventMetrics,
   includeStructureSnapshot: boolean,
   strategyRegistry: StrategyRegistryEntry[] | undefined,
-  onStrategyRegistryRuntimeUse: ((entry: StrategyRegistryEntry) => void) | undefined
+  onStrategyRegistryRuntimeUse: ((entry: StrategyRegistryEntry) => void) | undefined,
+  includeOptionalSummary: boolean
 ): RuntimeRoomSummary {
   const tick = getGameTime();
   const colonyWorkers = colonyCreeps.filter((creep) => creep.memory.role === 'worker');
@@ -922,26 +961,28 @@ function summarizeRoom(
     taskCounts,
     constructionSiteCount: resources.productiveEnergy.constructionSiteCount,
     constructionDeadlockTicks,
-    ...summarizeRuntimeBehavior(colonyWorkers, colonyCreeps, tick),
+    ...(includeOptionalSummary ? summarizeRuntimeBehavior(colonyWorkers, colonyCreeps, tick) : {}),
     ...(includeStructureSnapshot ? { structures: summarizeStructures(colony, colonyWorkers) } : {}),
-    ...summarizeWorkerEfficiency(colonyWorkers, tick),
-    ...summarizeRefillTelemetry(colonyWorkers, tick),
+    ...(includeOptionalSummary ? summarizeWorkerEfficiency(colonyWorkers, tick) : {}),
+    ...(includeOptionalSummary ? summarizeRefillTelemetry(colonyWorkers, tick) : {}),
     ...summarizeSpawnCriticalRefill(colonyWorkers, tick),
     ...buildControllerSummary(colony.room),
     resources,
     combat: summarizeCombat(colony.room, eventMetrics.combat),
-    constructionPriority: summarizeConstructionPriority(
-      colony,
-      colonyWorkers,
-      strategyRegistry,
-      onStrategyRegistryRuntimeUse
-    ),
+    constructionPriority: includeOptionalSummary
+      ? summarizeConstructionPriority(
+          colony,
+          colonyWorkers,
+          strategyRegistry,
+          onStrategyRegistryRuntimeUse
+        )
+      : emptyConstructionPrioritySummary(),
     survival: summarizeSurvival(colony, roleCounts),
-    territoryRecommendation,
-    ...(territoryExpansion.candidates.length > 0 ? { territoryExpansion } : {}),
-    ...buildTerritoryIntentSummary(colony.room.name, roleCounts),
-    ...buildTerritoryExecutionHintSummary(colony.room.name),
-    ...buildTerritoryScoutSummary(colony, roleCounts),
+    territoryRecommendation: includeOptionalSummary ? territoryRecommendation : emptyTerritoryRecommendationReport(),
+    ...(includeOptionalSummary && territoryExpansion.candidates.length > 0 ? { territoryExpansion } : {}),
+    ...(includeOptionalSummary ? buildTerritoryIntentSummary(colony.room.name, roleCounts) : {}),
+    ...(includeOptionalSummary ? buildTerritoryExecutionHintSummary(colony.room.name) : {}),
+    ...(includeOptionalSummary ? buildTerritoryScoutSummary(colony, roleCounts) : {}),
     ...buildPostClaimBootstrapSummary(colony.room.name)
   };
 }
@@ -959,6 +1000,21 @@ function summarizeWorkerAssignmentEvidence(
     workerCount,
     assignedTaskCount,
     productiveAssignmentCount
+  };
+}
+
+function emptyConstructionPrioritySummary(): RuntimeConstructionPrioritySummary {
+  return {
+    candidates: [],
+    nextPrimary: null
+  };
+}
+
+function emptyTerritoryRecommendationReport(): OccupationRecommendationReport {
+  return {
+    candidates: [],
+    next: null,
+    followUpIntent: null
   };
 }
 
@@ -3496,27 +3552,43 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function buildCpuSummary(): { cpu?: RuntimeCpuSummary } {
-  const gameWithOptionalCpu = Game as Game & {
-    cpu?: {
-      getUsed?: () => number;
-      bucket?: number;
-    };
-  };
-  const cpu = gameWithOptionalCpu.cpu;
-  if (!cpu) {
+  const summary = buildRuntimeCpuTelemetrySummary();
+  if (!summary) {
     return {};
   }
 
-  const summary: RuntimeCpuSummary = {};
-  if (typeof cpu.getUsed === 'function') {
-    summary.used = cpu.getUsed();
+  return { cpu: toRuntimeCpuSummary(summary) };
+}
+
+function toRuntimeCpuSummary(summary: RuntimeCpuTelemetrySummary): RuntimeCpuSummary {
+  return {
+    ...(summary.used !== undefined ? { used: summary.used } : {}),
+    ...(summary.limit !== undefined ? { limit: summary.limit } : {}),
+    ...(summary.tickLimit !== undefined ? { tickLimit: summary.tickLimit } : {}),
+    ...(summary.bucket !== undefined ? { bucket: summary.bucket } : {}),
+    ...(summary.pressure !== 'normal' ? { pressure: summary.pressure } : {}),
+    ...(summary.alerts ? { alerts: summary.alerts } : {}),
+    ...(summary.reasons ? { reasons: summary.reasons } : {}),
+    ...(summary.lowBucketTicks !== undefined ? { lowBucketTicks: summary.lowBucketTicks } : {}),
+    ...(summary.bucketEmptyTicks !== undefined ? { bucketEmptyTicks: summary.bucketEmptyTicks } : {}),
+    ...(summary.overLimitTicks !== undefined ? { overLimitTicks: summary.overLimitTicks } : {})
+  };
+}
+
+function emitRuntimeCpuSummary(cpu: RuntimeCpuSummary | undefined, tick: number): void {
+  if (!cpu || !shouldEmitRuntimeCpuSummary(cpu, tick)) {
+    return;
   }
 
-  if (typeof cpu.bucket === 'number') {
-    summary.bucket = cpu.bucket;
+  console.log(`${RUNTIME_CPU_SUMMARY_PREFIX}${JSON.stringify(cpu)}`);
+}
+
+function shouldEmitRuntimeCpuSummary(cpu: RuntimeCpuSummary, tick: number): boolean {
+  if (cpu.alerts && cpu.alerts.length > 0) {
+    return true;
   }
 
-  return Object.keys(summary).length > 0 ? { cpu: summary } : {};
+  return cpu.pressure !== undefined && cpu.pressure !== 'normal' && tick > 0 && tick % RUNTIME_SUMMARY_INTERVAL === 0;
 }
 
 function applyCpuSummaryToRooms(

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -79,6 +79,7 @@ export const RUNTIME_SUMMARY_PREFIX = '#runtime-summary ';
 export const RUNTIME_CPU_SUMMARY_PREFIX = '#cpu-summary ';
 export const RUNTIME_SUMMARY_INTERVAL = 20;
 const DEGRADED_RUNTIME_SUMMARY_INTERVAL = RUNTIME_SUMMARY_INTERVAL * 5;
+const RUNTIME_CPU_SUMMARY_REPEAT_INTERVAL = DEGRADED_RUNTIME_SUMMARY_INTERVAL;
 const MAX_REPORTED_EVENTS = 10;
 const MAX_WORKER_EFFICIENCY_SAMPLES = 5;
 const MAX_WORKER_BEHAVIOR_SAMPLES = 10;
@@ -731,6 +732,11 @@ interface RuntimeCpuSummary {
   overLimitTicks?: number;
 }
 
+interface RuntimeCpuSummaryEmissionState {
+  lastSignal?: string | null;
+  lastTick?: number;
+}
+
 export interface RuntimeSummary {
   type: 'runtime-summary';
   tick: number;
@@ -745,6 +751,8 @@ interface RuntimeSummaryOptions {
   strategyRegistry?: StrategyRegistryEntry[];
   onStrategyRegistryRuntimeUse?: (entry: StrategyRegistryEntry) => void;
 }
+
+let runtimeCpuSummaryEmissionState: RuntimeCpuSummaryEmissionState = {};
 
 let cachedRefillTargetIdsByRoom = new Map<string, Set<string>>();
 let cachedEventMetricsByRoom = new Map<string, RuntimeRoomEventMetrics>();
@@ -836,6 +844,10 @@ export function shouldEmitRuntimeSummary(
     ? DEGRADED_RUNTIME_SUMMARY_INTERVAL
     : RUNTIME_SUMMARY_INTERVAL;
   return tick > 0 && tick % interval === 0;
+}
+
+export function resetRuntimeCpuSummaryEmissionForTesting(): void {
+  runtimeCpuSummaryEmissionState = {};
 }
 
 function resetCachedRefillTelemetryIfTickRewound(tick: number): void {
@@ -3576,7 +3588,12 @@ function toRuntimeCpuSummary(summary: RuntimeCpuTelemetrySummary): RuntimeCpuSum
 }
 
 function emitRuntimeCpuSummary(cpu: RuntimeCpuSummary | undefined, tick: number): void {
-  if (!cpu || !shouldEmitRuntimeCpuSummary(cpu, tick)) {
+  if (!cpu) {
+    recordRuntimeCpuSummarySignal(null, tick);
+    return;
+  }
+
+  if (!shouldEmitRuntimeCpuSummary(cpu, tick)) {
     return;
   }
 
@@ -3584,11 +3601,51 @@ function emitRuntimeCpuSummary(cpu: RuntimeCpuSummary | undefined, tick: number)
 }
 
 function shouldEmitRuntimeCpuSummary(cpu: RuntimeCpuSummary, tick: number): boolean {
-  if (cpu.alerts && cpu.alerts.length > 0) {
-    return true;
+  const signal = buildRuntimeCpuSummarySignal(cpu);
+  const previousSignal = getPreviousRuntimeCpuSummarySignal(tick);
+  recordRuntimeCpuSummarySignal(signal, tick);
+  if (!signal) {
+    return false;
   }
 
-  return cpu.pressure !== undefined && cpu.pressure !== 'normal' && tick > 0 && tick % RUNTIME_SUMMARY_INTERVAL === 0;
+  return signal !== previousSignal || isRuntimeCpuSummaryRepeatTick(tick);
+}
+
+function buildRuntimeCpuSummarySignal(cpu: RuntimeCpuSummary): string | null {
+  const alerts = normalizeRuntimeCpuSummarySignalValues(cpu.alerts);
+  const reasons = normalizeRuntimeCpuSummarySignalValues(cpu.reasons);
+  const pressure = cpu.pressure && cpu.pressure !== 'normal' ? cpu.pressure : undefined;
+  if (!pressure && alerts.length === 0 && reasons.length === 0) {
+    return null;
+  }
+
+  return `pressure:${pressure ?? 'normal'};alerts:${alerts.join(',')};reasons:${reasons.join(',')}`;
+}
+
+function normalizeRuntimeCpuSummarySignalValues(values: readonly string[] | undefined): string[] {
+  return values && values.length > 0 ? [...values].sort() : [];
+}
+
+function getPreviousRuntimeCpuSummarySignal(tick: number): string | null | undefined {
+  if (
+    runtimeCpuSummaryEmissionState.lastTick !== undefined &&
+    tick > 0 &&
+    runtimeCpuSummaryEmissionState.lastTick > tick
+  ) {
+    runtimeCpuSummaryEmissionState = {};
+  }
+
+  return runtimeCpuSummaryEmissionState.lastSignal;
+}
+
+function recordRuntimeCpuSummarySignal(signal: string | null, tick: number): void {
+  getPreviousRuntimeCpuSummarySignal(tick);
+  runtimeCpuSummaryEmissionState.lastSignal = signal;
+  runtimeCpuSummaryEmissionState.lastTick = tick;
+}
+
+function isRuntimeCpuSummaryRepeatTick(tick: number): boolean {
+  return tick > 0 && tick % RUNTIME_CPU_SUMMARY_REPEAT_INTERVAL === 0;
 }
 
 function applyCpuSummaryToRooms(

--- a/prod/test/cpuBudget.test.ts
+++ b/prod/test/cpuBudget.test.ts
@@ -1,0 +1,87 @@
+import {
+  buildRuntimeCpuBudget,
+  buildRuntimeCpuTelemetrySummary,
+  resetRuntimeCpuTelemetryForTesting,
+  shouldRunOptionalCpuRoomWork
+} from '../src/runtime/cpuBudget';
+
+describe('runtime CPU budget policy', () => {
+  afterEach(() => {
+    resetRuntimeCpuTelemetryForTesting();
+  });
+
+  it('keeps optional work enabled when CPU and bucket are healthy', () => {
+    const budget = buildRuntimeCpuBudget({
+      tick: 10,
+      used: 8,
+      limit: 100,
+      bucket: 9_000,
+      tickLimit: 500
+    });
+
+    expect(budget).toMatchObject({
+      pressure: 'normal',
+      degraded: false,
+      critical: false,
+      reasons: []
+    });
+    expect(shouldRunOptionalCpuRoomWork(budget, 'E29N55')).toBe(true);
+  });
+
+  it('degrades a 20 CPU account and round-robins optional room work', () => {
+    const decisions = [1, 2, 3].map((tick) =>
+      shouldRunOptionalCpuRoomWork(
+        buildRuntimeCpuBudget({
+          tick,
+          used: 6,
+          limit: 20,
+          bucket: 9_000,
+          tickLimit: 500
+        }),
+        'E29N55'
+      )
+    );
+
+    expect(
+      buildRuntimeCpuBudget({
+        tick: 1,
+        used: 6,
+        limit: 20,
+        bucket: 9_000,
+        tickLimit: 500
+      })
+    ).toMatchObject({
+      pressure: 'degraded',
+      degraded: true,
+      critical: false,
+      reasons: ['lowCpuLimit']
+    });
+    expect(decisions.filter(Boolean)).toHaveLength(1);
+  });
+
+  it('alerts on repeated empty bucket and sustained used-over-limit samples', () => {
+    buildRuntimeCpuTelemetrySummary({
+      tick: 30,
+      used: 24,
+      limit: 20,
+      bucket: 0,
+      tickLimit: 500
+    });
+
+    const summary = buildRuntimeCpuTelemetrySummary({
+      tick: 31,
+      used: 25,
+      limit: 20,
+      bucket: 0,
+      tickLimit: 500
+    });
+
+    expect(summary).toMatchObject({
+      pressure: 'critical',
+      lowBucketTicks: 2,
+      bucketEmptyTicks: 2,
+      overLimitTicks: 2,
+      alerts: expect.arrayContaining(['bucketEmptyRepeated', 'lowBucket', 'sustainedUsedOverLimit'])
+    });
+  });
+});

--- a/prod/test/cpuBudget.test.ts
+++ b/prod/test/cpuBudget.test.ts
@@ -84,4 +84,30 @@ describe('runtime CPU budget policy', () => {
       alerts: expect.arrayContaining(['bucketEmptyRepeated', 'lowBucket', 'sustainedUsedOverLimit'])
     });
   });
+
+  it('clears sustained alert streaks when a tick has no CPU sample fields', () => {
+    buildRuntimeCpuTelemetrySummary({
+      tick: 30,
+      used: 24,
+      limit: 20,
+      bucket: 0,
+      tickLimit: 500
+    });
+
+    expect(buildRuntimeCpuTelemetrySummary({ tick: 31 })).toBeNull();
+    const summary = buildRuntimeCpuTelemetrySummary({
+      tick: 32,
+      used: 25,
+      limit: 20,
+      bucket: 0,
+      tickLimit: 500
+    });
+
+    expect(summary).toMatchObject({
+      lowBucketTicks: 1,
+      bucketEmptyTicks: 1,
+      overLimitTicks: 1,
+      alerts: ['lowBucket']
+    });
+  });
 });

--- a/prod/test/cpuBudget.test.ts
+++ b/prod/test/cpuBudget.test.ts
@@ -6,6 +6,10 @@ import {
 } from '../src/runtime/cpuBudget';
 
 describe('runtime CPU budget policy', () => {
+  beforeEach(() => {
+    resetRuntimeCpuTelemetryForTesting();
+  });
+
   afterEach(() => {
     resetRuntimeCpuTelemetryForTesting();
   });

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -127,6 +127,39 @@ describe('runEconomy', () => {
     });
   });
 
+  it('keeps emergency worker spawning under a critical 20 CPU budget', () => {
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 300,
+      energyCapacityAvailable: 300,
+      controller: { my: true } as StructureController
+    } as Room;
+    const spawn = {
+      name: 'Spawn1',
+      room,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 124,
+      rooms: { W1N1: room },
+      spawns: { Spawn1: spawn },
+      creeps: {},
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(19),
+        limit: 20,
+        bucket: 0,
+        tickLimit: 500
+      } as unknown as CPU
+    };
+
+    runEconomy();
+
+    expect(spawn.spawnCreep).toHaveBeenCalledWith(['work', 'carry', 'move'], 'worker-W1N1-124', {
+      memory: { role: 'worker', colony: 'W1N1' }
+    });
+  });
+
   it('spawns an emergency bootstrap worker without requiring the energy buffer', () => {
     const room = {
       name: 'W1N1',

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -26,6 +26,7 @@ describe('runEconomy', () => {
   let logSpy: jest.SpyInstance<void, [message?: unknown, ...optionalParams: unknown[]]>;
 
   beforeEach(() => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
     logSpy = jest.spyOn(console, 'log').mockImplementation();
   });
 

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -4,6 +4,7 @@ import {
   RUNTIME_CPU_SUMMARY_PREFIX,
   RUNTIME_SUMMARY_INTERVAL,
   RUNTIME_SUMMARY_PREFIX,
+  resetRuntimeCpuSummaryEmissionForTesting,
   shouldEmitRuntimeSummary,
   type RuntimeTelemetryEvent
 } from '../src/telemetry/runtimeSummary';
@@ -57,12 +58,14 @@ describe('runtime telemetry summaries', () => {
   beforeEach(() => {
     clearRuntimeTelemetryGlobals();
     resetRuntimeCpuTelemetryForTesting();
+    resetRuntimeCpuSummaryEmissionForTesting();
     logSpy = jest.spyOn(console, 'log').mockImplementation();
   });
 
   afterEach(() => {
     logSpy.mockRestore();
     resetRuntimeCpuTelemetryForTesting();
+    resetRuntimeCpuSummaryEmissionForTesting();
     clearRuntimeTelemetryGlobals();
   });
 
@@ -369,6 +372,26 @@ describe('runtime telemetry summaries', () => {
       overLimitTicks: 2,
       alerts: expect.arrayContaining(['bucketEmptyRepeated', 'lowBucket', 'sustainedUsedOverLimit'])
     });
+  });
+
+  it('does not repeat unchanged compact CPU alerts every tick', () => {
+    const colony = makeColony({ time: 1 });
+    (Game as Partial<Game>).cpu = {
+      getUsed: jest.fn().mockReturnValue(24),
+      limit: 20,
+      bucket: 0,
+      tickLimit: 500
+    } as unknown as CPU;
+
+    emitRuntimeSummary([colony], []);
+    (Game as Partial<Game>).time = 2;
+    emitRuntimeSummary([colony], []);
+    logSpy.mockClear();
+    (Game as Partial<Game>).time = 3;
+
+    emitRuntimeSummary([colony], []);
+
+    expect(logSpy).not.toHaveBeenCalled();
   });
 
   it('reports per-creep behavior counters and resets emitted counters', () => {

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -1,11 +1,13 @@
 import type { ColonySnapshot } from '../src/colony/colonyRegistry';
 import {
   emitRuntimeSummary,
+  RUNTIME_CPU_SUMMARY_PREFIX,
   RUNTIME_SUMMARY_INTERVAL,
   RUNTIME_SUMMARY_PREFIX,
   shouldEmitRuntimeSummary,
   type RuntimeTelemetryEvent
 } from '../src/telemetry/runtimeSummary';
+import { resetRuntimeCpuTelemetryForTesting } from '../src/runtime/cpuBudget';
 import { recordCreepBehaviorIdle } from '../src/telemetry/behaviorTelemetry';
 import { CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD } from '../src/tasks/workerTasks';
 import { OCCUPIED_CONTROLLER_SIGN_TEXT } from '../src/territory/controllerSigning';
@@ -54,11 +56,13 @@ describe('runtime telemetry summaries', () => {
 
   beforeEach(() => {
     clearRuntimeTelemetryGlobals();
+    resetRuntimeCpuTelemetryForTesting();
     logSpy = jest.spyOn(console, 'log').mockImplementation();
   });
 
   afterEach(() => {
     logSpy.mockRestore();
+    resetRuntimeCpuTelemetryForTesting();
     clearRuntimeTelemetryGlobals();
   });
 
@@ -332,6 +336,39 @@ describe('runtime telemetry summaries', () => {
     emitRuntimeSummary([colony], []);
 
     expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('emits compact CPU alerts without a full room summary under degraded cadence', () => {
+    const colony = makeColony({ time: 1 });
+    (Game as Partial<Game>).cpu = {
+      getUsed: jest.fn().mockReturnValue(24),
+      limit: 20,
+      bucket: 0,
+      tickLimit: 500
+    } as unknown as CPU;
+
+    emitRuntimeSummary([colony], []);
+    logSpy.mockClear();
+    (Game as Partial<Game>).time = 2;
+
+    emitRuntimeSummary([colony], []);
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const [message] = logSpy.mock.calls[0];
+    expect(typeof message).toBe('string');
+    expect((message as string).startsWith(RUNTIME_CPU_SUMMARY_PREFIX)).toBe(true);
+    const payload = JSON.parse((message as string).slice(RUNTIME_CPU_SUMMARY_PREFIX.length)) as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      used: 24,
+      limit: 20,
+      tickLimit: 500,
+      bucket: 0,
+      pressure: 'critical',
+      lowBucketTicks: 2,
+      bucketEmptyTicks: 2,
+      overLimitTicks: 2,
+      alerts: expect.arrayContaining(['bucketEmptyRepeated', 'lowBucket', 'sustainedUsedOverLimit'])
+    });
   });
 
   it('reports per-creep behavior counters and resets emitted counters', () => {
@@ -3045,12 +3082,18 @@ describe('runtime telemetry summaries', () => {
   });
 
   function parseLoggedSummary(): Record<string, unknown> {
-    expect(logSpy).toHaveBeenCalledTimes(1);
-    const [message] = logSpy.mock.calls[0];
+    const runtimeSummaryMessages = logSpy.mock.calls
+      .map(([message]) => message)
+      .filter(
+        (message): message is string =>
+          typeof message === 'string' && message.startsWith(RUNTIME_SUMMARY_PREFIX)
+      );
+    expect(runtimeSummaryMessages).toHaveLength(1);
+    const message = runtimeSummaryMessages[0];
     expect(typeof message).toBe('string');
-    expect((message as string).startsWith(RUNTIME_SUMMARY_PREFIX)).toBe(true);
+    expect(message.startsWith(RUNTIME_SUMMARY_PREFIX)).toBe(true);
 
-    return JSON.parse((message as string).slice(RUNTIME_SUMMARY_PREFIX.length)) as Record<string, unknown>;
+    return JSON.parse(message.slice(RUNTIME_SUMMARY_PREFIX.length)) as Record<string, unknown>;
   }
 });
 

--- a/prod/test/seasonalRuntimeFeatureGates.test.ts
+++ b/prod/test/seasonalRuntimeFeatureGates.test.ts
@@ -100,6 +100,32 @@ describe('runEconomy Seasonal feature gates', () => {
     expect(deal).not.toHaveBeenCalled();
   });
 
+  it('skips market API calls when the persistent world CPU bucket is empty', () => {
+    const deal = jest.fn().mockReturnValue(OK_CODE);
+    const getAllOrders = makeMarketOrderGetter([
+      makeOrder({ id: 'buy-H', type: 'buy', resourceType: 'H', price: 2, roomName: 'W2N1' }),
+      makeOrder({ id: 'sell-H', type: 'sell', resourceType: 'H', price: 1, roomName: 'W3N1' })
+    ]);
+    installMarketEconomyGame({
+      time: MARKET_TRADING_INTERVAL * 8,
+      shard: { name: 'shard3', type: 'normal' },
+      deal,
+      getAllOrders
+    });
+    (Game as Partial<Game>).cpu = {
+      getUsed: jest.fn().mockReturnValue(19),
+      limit: 20,
+      bucket: 0,
+      tickLimit: 500
+    } as unknown as CPU;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = { enableMarketTrading: true };
+
+    runEconomy();
+
+    expect(getAllOrders).not.toHaveBeenCalled();
+    expect(deal).not.toHaveBeenCalled();
+  });
+
   it('skips terminal sends on Seasonal World in an imbalance that persistent worlds send', () => {
     const persistentSource = makeTerminalBalanceRoom({
       roomName: 'W1N1',
@@ -144,6 +170,33 @@ describe('runEconomy Seasonal feature gates', () => {
     runEconomy();
 
     expect(seasonalSource.terminal?.send).not.toHaveBeenCalled();
+  });
+
+  it('skips terminal sends when the persistent world CPU bucket is empty', () => {
+    const source = makeTerminalBalanceRoom({
+      roomName: 'W1N1',
+      storageEnergy: 100_000,
+      terminalEnergy: 80_000
+    });
+    const target = makeTerminalBalanceRoom({
+      roomName: 'W2N1',
+      storageEnergy: 10_000,
+      terminalEnergy: 20_000
+    });
+    installTerminalEconomyGame({
+      rooms: [source, target],
+      shard: { name: 'shard3', type: 'normal' }
+    });
+    (Game as Partial<Game>).cpu = {
+      getUsed: jest.fn().mockReturnValue(19),
+      limit: 20,
+      bucket: 0,
+      tickLimit: 500
+    } as unknown as CPU;
+
+    runEconomy();
+
+    expect(source.terminal?.send).not.toHaveBeenCalled();
   });
 
   it('keeps an empty-world Seasonal smoke path away from disabled APIs', () => {

--- a/prod/test/workerTaskPolicy.test.ts
+++ b/prod/test/workerTaskPolicy.test.ts
@@ -384,6 +384,56 @@ describe('worker task BC policy', () => {
     });
   });
 
+  it('keeps the heuristic task but skips BC shadow metadata under a 20 CPU budget', () => {
+    setWorkerTaskBcModelForTesting(TEST_MODEL);
+    installWorkerTaskGlobals();
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(300)
+      }
+    } as unknown as StructureSpawn;
+    const creep = {
+      name: 'Carrier',
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: {
+        name: 'W1N1',
+        find: jest.fn((type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return [creep];
+          }
+
+          return [];
+        })
+      }
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 123,
+      creeps: { Carrier: creep },
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(6),
+        limit: 20,
+        bucket: 9_000,
+        tickLimit: 500
+      } as unknown as CPU
+    };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(creep.memory.workerBehavior).toBeUndefined();
+    expect(creep.memory.workerTaskPolicyShadow).toBeUndefined();
+  });
+
   it('falls back to the heuristic when BC action disagrees', () => {
     setWorkerTaskBcModelForTesting({
       ...TEST_MODEL,

--- a/prod/test/workerTaskPolicy.test.ts
+++ b/prod/test/workerTaskPolicy.test.ts
@@ -332,7 +332,16 @@ describe('worker task BC policy', () => {
     } as unknown as StructureSpawn;
     const creep = {
       name: 'Carrier',
-      memory: { role: 'worker' },
+      memory: {
+        role: 'worker',
+        workerBehavior: { type: 'workerTaskBehavior', tick: 122 } as unknown as CreepMemory['workerBehavior'],
+        workerTaskPolicyShadow: {
+          type: 'workerTaskPolicyShadow',
+          tick: 122
+        } as unknown as CreepMemory['workerTaskPolicyShadow'],
+        workerEfficiency: { type: 'lowLoadReturn', tick: 122 } as unknown as CreepMemory['workerEfficiency'],
+        spawnCriticalRefill: { type: 'spawnCriticalRefill', tick: 122 } as unknown as CreepMemory['spawnCriticalRefill']
+      },
       store: {
         getUsedCapacity: jest.fn().mockReturnValue(50),
         getFreeCapacity: jest.fn().mockReturnValue(0)
@@ -397,7 +406,16 @@ describe('worker task BC policy', () => {
     } as unknown as StructureSpawn;
     const creep = {
       name: 'Carrier',
-      memory: { role: 'worker' },
+      memory: {
+        role: 'worker',
+        workerBehavior: { type: 'workerTaskBehavior', tick: 122 } as unknown as CreepMemory['workerBehavior'],
+        workerTaskPolicyShadow: {
+          type: 'workerTaskPolicyShadow',
+          tick: 122
+        } as unknown as CreepMemory['workerTaskPolicyShadow'],
+        workerEfficiency: { type: 'lowLoadReturn', tick: 122 } as unknown as CreepMemory['workerEfficiency'],
+        spawnCriticalRefill: { type: 'spawnCriticalRefill', tick: 122 } as unknown as CreepMemory['spawnCriticalRefill']
+      },
       store: {
         getUsedCapacity: jest.fn().mockReturnValue(50),
         getFreeCapacity: jest.fn().mockReturnValue(0)
@@ -429,9 +447,13 @@ describe('worker task BC policy', () => {
       } as unknown as CPU
     };
 
+    expect(creep.memory.workerBehavior).toBeDefined();
+    expect(creep.memory.workerTaskPolicyShadow).toBeDefined();
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
     expect(creep.memory.workerBehavior).toBeUndefined();
     expect(creep.memory.workerTaskPolicyShadow).toBeUndefined();
+    expect(creep.memory.workerEfficiency).toBeUndefined();
+    expect(creep.memory.spawnCriticalRefill).toBeUndefined();
   });
 
   it('falls back to the heuristic when BC action disagrees', () => {


### PR DESCRIPTION
Implements the first production-side CPU-budget hotfix for #1433.

## Summary
- Adds a runtime CPU budget policy for 20-CPU / low-bucket operation.
- Keeps survival-critical economy/spawn work eligible while throttling optional economy, worker sampling, and runtime-summary detail under CPU pressure.
- Adds CPU telemetry/alert fields and regression coverage for degraded and healthy modes.
- Rebuilds `prod/dist/main.js` from source.

## Verification
- `git diff --check`
- From `prod/`: `npm run typecheck`
- From `prod/`: `npm test -- --runInBand` (103 suites / 2052 tests passed)
- From `prod/`: `npm run build`

Refs #1433.

## Issue closure gate
- [ ] #1433: Hold open until PR merge, official deploy evidence, and post-deploy live CPU acceptance show zero bucket-empty console errors and safe bucket/CPU trend.
