### PR TITLE
fix(rl): gate scale training on active code consumption smoke

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -939,6 +939,7 @@ def mark_runtime_parameter_injection_uploaded(
     injection: JsonObject,
     *,
     code_text: str,
+    upload_tick: Any | None = None,
 ) -> JsonObject:
     updated = copy.deepcopy(injection)
     if updated.get("status") == "prepared":
@@ -959,6 +960,13 @@ def mark_runtime_parameter_injection_uploaded(
         updated["inlineCandidatesRuntimeInjected"] = True
         updated["runtimeParameterConsumer"] = RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER
         updated["runtimeParameterConsumerObserved"] = True
+    uploaded_tick = _coerce_int(upload_tick)
+    if (
+        updated.get("status") == "injected"
+        and updated.get("runtimeParameterInjection") is True
+        and uploaded_tick is not None
+    ):
+        updated["tick"] = uploaded_tick
     return updated
 
 
@@ -1123,7 +1131,9 @@ def runtime_parameter_trainability_smoke_gate_error(
         if consumed_tick is None or consumed_tick <= 0:
             return "runtime-parameter trainability smoke gate failed: missing positive consumedTick"
         injection_tick = _coerce_int(runtime_parameter_injection.get("tick"))
-        if injection_tick is not None and consumed_tick <= injection_tick:
+        if injection_tick is None:
+            return "runtime-parameter trainability smoke gate failed: missing numeric injection tick"
+        if consumed_tick <= injection_tick:
             return (
                 "runtime-parameter trainability smoke gate failed: "
                 f"consumedTick={consumed_tick} did not advance beyond injection tick={injection_tick}"
@@ -5647,6 +5657,12 @@ def _run_variant(
         )
         token = smoke.update_token_from_headers(token, initial_state.headers)
         token, previous_tick = _read_current_gametime(cfg, smoke, token, shard, initial_state.payload)
+        runtime_parameter_injection = mark_runtime_parameter_injection_uploaded(
+            runtime_parameter_injection,
+            code_text=uploaded_code_text,
+            upload_tick=previous_tick,
+        )
+        write_json_atomic(safe_run_root / "runtime_parameter_injection.json", runtime_parameter_injection)
         _require_launcher_cli_success(smoke, compose, cfg, "system.resumeSimulation()", "resume simulator")
 
         for _ in range(ticks):

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -100,6 +100,7 @@ RUNTIME_PARAMETER_INJECTION_CONSUMER_VERSION = "v1"
 RUNTIME_PARAMETER_CONSUMPTION_LOG_PREFIX = "#runtime-parameter-consumption "
 RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE = "private_simulator_game_loop_runtime_parameters"
 RUNTIME_PARAMETER_CONSUMPTION_CANDIDATE_MAX_DEPTH = 8
+ACTIVE_CODE_READBACK_TYPE = "screeps-rl-private-simulator-active-code-readback"
 MONGO_CONSOLE_RUNTIME_PARAMETER_OUTPUT_LIMIT = 200000
 MONGO_CONSOLE_RUNTIME_PARAMETER_PAYLOAD_LIMIT = 180000
 STRICT_DIRECTIVE_PREFIX_RE = re.compile(
@@ -961,6 +962,98 @@ def mark_runtime_parameter_injection_uploaded(
 
 def runtime_parameter_injection_code_has_consumer(code_text: str) -> bool:
     return RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER in code_text
+
+
+def private_simulator_active_code_readback_summary(
+    uploaded_code_text: str,
+    payload: Any,
+    *,
+    branch: str,
+    http_status: int | None = None,
+) -> JsonObject:
+    """Compare private-server active ``main`` code to the just-uploaded injected payload."""
+    uploaded_data = uploaded_code_text.encode("utf-8")
+    uploaded_sha256 = hashlib.sha256(uploaded_data).hexdigest()
+    active_code: str | None = None
+    active_branch: str | None = None
+    status = "missing-payload"
+    if http_status is not None and (http_status < 200 or http_status >= 300):
+        status = "http-error"
+    elif isinstance(payload, dict):
+        branch_value = payload.get("branch")
+        active_branch = branch_value if isinstance(branch_value, str) else None
+        modules = payload.get("modules")
+        if not isinstance(modules, dict):
+            status = "missing-modules"
+        else:
+            main = modules.get("main")
+            if not isinstance(main, str):
+                status = "missing-main-module"
+            else:
+                active_code = main
+                status = "matched" if active_code == uploaded_code_text else "mismatch"
+
+    active_data = active_code.encode("utf-8") if active_code is not None else b""
+    active_sha256 = hashlib.sha256(active_data).hexdigest() if active_code is not None else None
+    payload_summary: JsonObject = {
+        "type": ACTIVE_CODE_READBACK_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "status": status,
+        "branch": branch,
+        "activeBranch": active_branch,
+        "module": "main",
+        "activeCodeMatchesUploaded": status == "matched",
+        "uploadedCodeBytes": len(uploaded_data),
+        "uploadedCodeSha256": uploaded_sha256,
+        "activeCodeBytes": len(active_data) if active_code is not None else None,
+        "activeCodeSha256": active_sha256,
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+    }
+    if http_status is not None:
+        payload_summary["httpStatus"] = http_status
+    return {key: value for key, value in payload_summary.items() if value is not None}
+
+
+def private_simulator_active_code_readback_error(readback: Any) -> str | None:
+    if not isinstance(readback, dict):
+        return "active private-server code readback was not recorded"
+    if readback.get("activeCodeMatchesUploaded") is True:
+        return None
+    status = text_or_none(readback.get("status")) or "unknown"
+    uploaded_sha = text_or_none(readback.get("uploadedCodeSha256")) or "unknown"
+    active_sha = text_or_none(readback.get("activeCodeSha256")) or "missing"
+    return (
+        "active private-server code hash verification failed: "
+        f"status={status} uploadedCodeSha256={uploaded_sha} activeCodeSha256={active_sha}"
+    )
+
+
+def runtime_parameter_trainability_smoke_gate_error(
+    *,
+    runtime_parameter_injection: JsonObject,
+    runtime_parameter_consumption: JsonObject,
+    ticks_run: int,
+    active_code_readback: JsonObject | None = None,
+) -> str | None:
+    """Return a blocking reason when a runtime-injected variant is not trainable."""
+    if runtime_parameter_injection.get("status") != "injected":
+        return None
+    if runtime_parameter_injection.get("runtimeParameterInjection") is not True:
+        return None
+    active_code_error = private_simulator_active_code_readback_error(active_code_readback)
+    if active_code_error is not None:
+        return active_code_error
+    if ticks_run < 1:
+        return "runtime-parameter trainability smoke gate did not execute a simulator tick"
+    if runtime_parameter_consumption.get("runtimeParameterConsumption") is True:
+        return None
+    status = text_or_none(runtime_parameter_consumption.get("status")) or "missing"
+    reason = text_or_none(runtime_parameter_consumption.get("reason")) or (
+        "one-tick simulator smoke did not expose consumed runtime policy parameter evidence"
+    )
+    return f"runtime-parameter trainability smoke gate failed: status={status}: {reason}"
 
 
 def runtime_parameter_consumption_check(
@@ -5270,6 +5363,7 @@ def _run_variant(
     fixture_room_names: list[str] = []
     compose: list[str] | None = None
     uploaded_code_text: str | None = None
+    active_code_readback: JsonObject | None = None
     try:
         smoke = _load_private_smoke_module()
         summarize_prepared_map = _is_default_map_source_file(map_source_file)
@@ -5442,6 +5536,26 @@ def _run_variant(
         )
         write_json_atomic(safe_run_root / "runtime_parameter_injection.json", runtime_parameter_injection)
 
+        roundtrip = smoke.http_json(
+            "GET",
+            cfg.server_url,
+            "/api/user/code",
+            headers=smoke.token_headers(token),
+            params={"branch": api_branch},
+            timeout=RUN_PHASE_TIMEOUT_SECONDS,
+        )
+        token = smoke.update_token_from_headers(token, roundtrip.headers)
+        active_code_readback = private_simulator_active_code_readback_summary(
+            uploaded_code_text,
+            roundtrip.payload,
+            branch=api_branch,
+            http_status=roundtrip.status,
+        )
+        write_json_atomic(safe_run_root / "active_code_readback.json", active_code_readback)
+        active_code_error = private_simulator_active_code_readback_error(active_code_readback)
+        if active_code_error is not None:
+            raise RuntimeError(active_code_error)
+
         place = smoke.http_json(
             "POST",
             cfg.server_url,
@@ -5517,6 +5631,14 @@ def _run_variant(
             )
             write_json_atomic(safe_run_root / "runtime_parameter_consumption.json", runtime_parameter_consumption)
             write_json_atomic(safe_run_root / "runtime_parameter_injection.json", runtime_parameter_injection)
+            smoke_gate_error = runtime_parameter_trainability_smoke_gate_error(
+                runtime_parameter_injection=runtime_parameter_injection,
+                runtime_parameter_consumption=runtime_parameter_consumption,
+                ticks_run=len(variant_ticks),
+                active_code_readback=active_code_readback,
+            )
+            if smoke_gate_error is not None:
+                errors.append(smoke_gate_error)
     except Exception as exc:  # noqa: BLE001 - collect the failure into a safe result
         errors.append(_safe_text(exc, 480))
         runtime_parameter_injection = mark_runtime_parameter_injection_failed(runtime_parameter_injection, exc)
@@ -5569,6 +5691,7 @@ def _run_variant(
         "policyActivation": None,
         "runtimeParameterInjection": runtime_parameter_injection,
         "runtimeParameterConsumption": runtime_parameter_consumption,
+        "activeCodeReadback": active_code_readback,
         "live_effect": False,
         "official_mmo_writes": False,
         "ok": False,

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -101,6 +101,7 @@ RUNTIME_PARAMETER_CONSUMPTION_LOG_PREFIX = "#runtime-parameter-consumption "
 RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE = "private_simulator_game_loop_runtime_parameters"
 RUNTIME_PARAMETER_CONSUMPTION_CANDIDATE_MAX_DEPTH = 8
 ACTIVE_CODE_READBACK_TYPE = "screeps-rl-private-simulator-active-code-readback"
+ACTIVE_CODE_READBACK_MAX_ATTEMPTS = 5
 MONGO_CONSOLE_RUNTIME_PARAMETER_OUTPUT_LIMIT = 200000
 MONGO_CONSOLE_RUNTIME_PARAMETER_PAYLOAD_LIMIT = 180000
 STRICT_DIRECTIVE_PREFIX_RE = re.compile(
@@ -991,7 +992,12 @@ def private_simulator_active_code_readback_summary(
                 status = "missing-main-module"
             else:
                 active_code = main
-                status = "matched" if active_code == uploaded_code_text else "mismatch"
+                if active_branch is None:
+                    status = "missing-branch"
+                elif active_branch != branch:
+                    status = "branch-mismatch"
+                else:
+                    status = "matched" if active_code == uploaded_code_text else "mismatch"
 
     active_data = active_code.encode("utf-8") if active_code is not None else b""
     active_sha256 = hashlib.sha256(active_data).hexdigest() if active_code is not None else None
@@ -1024,10 +1030,53 @@ def private_simulator_active_code_readback_error(readback: Any) -> str | None:
     status = text_or_none(readback.get("status")) or "unknown"
     uploaded_sha = text_or_none(readback.get("uploadedCodeSha256")) or "unknown"
     active_sha = text_or_none(readback.get("activeCodeSha256")) or "missing"
+    branch = text_or_none(readback.get("branch")) or "unknown"
+    active_branch = text_or_none(readback.get("activeBranch")) or "missing"
     return (
         "active private-server code hash verification failed: "
-        f"status={status} uploadedCodeSha256={uploaded_sha} activeCodeSha256={active_sha}"
+        f"status={status} branch={branch} activeBranch={active_branch} "
+        f"uploadedCodeSha256={uploaded_sha} activeCodeSha256={active_sha}"
     )
+
+
+def _poll_private_simulator_active_code_readback(
+    smoke: Any,
+    cfg: Any,
+    token: str,
+    uploaded_code_text: str,
+    *,
+    branch: str,
+    output_path: Path,
+) -> tuple[str, JsonObject]:
+    active_code_readback: JsonObject | None = None
+    active_code_error: str | None = None
+    for attempt in range(1, ACTIVE_CODE_READBACK_MAX_ATTEMPTS + 1):
+        roundtrip = smoke.http_json(
+            "GET",
+            cfg.server_url,
+            "/api/user/code",
+            headers=smoke.token_headers(token),
+            params={"branch": branch},
+            timeout=RUN_PHASE_TIMEOUT_SECONDS,
+        )
+        token = smoke.update_token_from_headers(token, roundtrip.headers)
+        active_code_readback = private_simulator_active_code_readback_summary(
+            uploaded_code_text,
+            roundtrip.payload,
+            branch=branch,
+            http_status=roundtrip.status,
+        )
+        active_code_readback["attempt"] = attempt
+        active_code_readback["maxAttempts"] = ACTIVE_CODE_READBACK_MAX_ATTEMPTS
+        write_json_atomic(output_path, active_code_readback)
+        active_code_error = private_simulator_active_code_readback_error(active_code_readback)
+        if active_code_error is None:
+            return token, active_code_readback
+        if attempt < ACTIVE_CODE_READBACK_MAX_ATTEMPTS:
+            time.sleep(RUN_TICK_POLL_SECONDS)
+    if active_code_error is not None:
+        raise RuntimeError(active_code_error)
+    raise RuntimeError("active private-server code readback failed without diagnostic")
 
 
 def runtime_parameter_trainability_smoke_gate_error(
@@ -5536,25 +5585,14 @@ def _run_variant(
         )
         write_json_atomic(safe_run_root / "runtime_parameter_injection.json", runtime_parameter_injection)
 
-        roundtrip = smoke.http_json(
-            "GET",
-            cfg.server_url,
-            "/api/user/code",
-            headers=smoke.token_headers(token),
-            params={"branch": api_branch},
-            timeout=RUN_PHASE_TIMEOUT_SECONDS,
-        )
-        token = smoke.update_token_from_headers(token, roundtrip.headers)
-        active_code_readback = private_simulator_active_code_readback_summary(
+        token, active_code_readback = _poll_private_simulator_active_code_readback(
+            smoke,
+            cfg,
+            token,
             uploaded_code_text,
-            roundtrip.payload,
             branch=api_branch,
-            http_status=roundtrip.status,
+            output_path=safe_run_root / "active_code_readback.json",
         )
-        write_json_atomic(safe_run_root / "active_code_readback.json", active_code_readback)
-        active_code_error = private_simulator_active_code_readback_error(active_code_readback)
-        if active_code_error is not None:
-            raise RuntimeError(active_code_error)
 
         place = smoke.http_json(
             "POST",

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -1001,9 +1001,7 @@ def private_simulator_active_code_readback_summary(
                 status = "missing-main-module"
             else:
                 active_code = main
-                if active_branch is None:
-                    status = "missing-branch"
-                elif active_branch != branch:
+                if active_branch is not None and active_branch != branch:
                     status = "branch-mismatch"
                 else:
                     status = "matched" if active_code == uploaded_code_text else "mismatch"
@@ -5310,6 +5308,48 @@ def _read_current_gametime(
     return token, stats_tick if stats_tick is not None else overview_tick
 
 
+def _capture_runtime_parameter_injection_tick(
+    cfg: Any,
+    smoke: Any,
+    token: str,
+    shard: str,
+    initial_overview_payload: Any,
+    *,
+    max_attempts: int = ACTIVE_CODE_READBACK_MAX_ATTEMPTS,
+) -> tuple[str, int]:
+    """Capture a numeric upload tick before runtime-injected code is allowed to run."""
+    overview_payload = initial_overview_payload
+    last_reason = "overview/stats response did not include a numeric gametime"
+    for attempt in range(1, max_attempts + 1):
+        if attempt > 1:
+            try:
+                overview_result = smoke.http_json(
+                    "GET",
+                    cfg.server_url,
+                    "/api/user/overview",
+                    headers=smoke.token_headers(token),
+                    timeout=RUN_API_TIMEOUT_SECONDS,
+                )
+                token = smoke.update_token_from_headers(token, overview_result.headers)
+                overview_payload = overview_result.payload
+            except Exception as exc:  # noqa: BLE001 - bounded retry before failing the smoke gate closed
+                last_reason = f"overview readback failed: {_safe_text(exc, 240)}"
+                if attempt < max_attempts:
+                    time.sleep(RUN_TICK_POLL_SECONDS)
+                    continue
+                break
+        token, current_tick = _read_current_gametime(cfg, smoke, token, shard, overview_payload)
+        if current_tick is not None:
+            return token, current_tick
+        last_reason = "overview/stats response did not include a numeric gametime"
+        if attempt < max_attempts:
+            time.sleep(RUN_TICK_POLL_SECONDS)
+    raise RuntimeError(
+        "failed to capture numeric injection tick before resuming simulation "
+        f"after {max_attempts} attempt(s): {last_reason}"
+    )
+
+
 def _safe_redact_smoke_payload(payload: Any) -> JsonObject:
     return {"ok": True, "payload": dataset_export.redact_text(json.dumps(payload, sort_keys=True, ensure_ascii=True))[:2000]}
 
@@ -5656,7 +5696,13 @@ def _run_variant(
             timeout=RUN_PHASE_TIMEOUT_SECONDS,
         )
         token = smoke.update_token_from_headers(token, initial_state.headers)
-        token, previous_tick = _read_current_gametime(cfg, smoke, token, shard, initial_state.payload)
+        token, previous_tick = _capture_runtime_parameter_injection_tick(
+            cfg,
+            smoke,
+            token,
+            shard,
+            initial_state.payload,
+        )
         runtime_parameter_injection = mark_runtime_parameter_injection_uploaded(
             runtime_parameter_injection,
             code_text=uploaded_code_text,

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -18,6 +18,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import traceback
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence, TextIO
@@ -1051,21 +1052,42 @@ def _poll_private_simulator_active_code_readback(
     active_code_readback: JsonObject | None = None
     active_code_error: str | None = None
     for attempt in range(1, ACTIVE_CODE_READBACK_MAX_ATTEMPTS + 1):
-        roundtrip = smoke.http_json(
-            "GET",
-            cfg.server_url,
-            "/api/user/code",
-            headers=smoke.token_headers(token),
-            params={"branch": branch},
-            timeout=RUN_PHASE_TIMEOUT_SECONDS,
-        )
-        token = smoke.update_token_from_headers(token, roundtrip.headers)
-        active_code_readback = private_simulator_active_code_readback_summary(
-            uploaded_code_text,
-            roundtrip.payload,
-            branch=branch,
-            http_status=roundtrip.status,
-        )
+        try:
+            roundtrip = smoke.http_json(
+                "GET",
+                cfg.server_url,
+                "/api/user/code",
+                headers=smoke.token_headers(token),
+                params={"branch": branch},
+                timeout=RUN_PHASE_TIMEOUT_SECONDS,
+            )
+            token = smoke.update_token_from_headers(token, roundtrip.headers)
+            active_code_readback = private_simulator_active_code_readback_summary(
+                uploaded_code_text,
+                roundtrip.payload,
+                branch=branch,
+                http_status=roundtrip.status,
+            )
+        except Exception as exc:  # noqa: BLE001 - active-code readback is a bounded retry gate
+            active_code_readback = {
+                "type": ACTIVE_CODE_READBACK_TYPE,
+                "schemaVersion": SCHEMA_VERSION,
+                "status": "transport-error",
+                "branch": branch,
+                "module": "main",
+                "activeCodeMatchesUploaded": False,
+                "uploadedCodeBytes": len(uploaded_code_text.encode("utf-8")),
+                "uploadedCodeSha256": hashlib.sha256(uploaded_code_text.encode("utf-8")).hexdigest(),
+                "error": _safe_text(exc, 360),
+                "exceptionType": type(exc).__name__,
+                "exceptionTraceback": _safe_text(
+                    "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+                    1200,
+                ),
+                "liveEffect": False,
+                "officialMmoWrites": False,
+                "officialMmoWritesAllowed": False,
+            }
         active_code_readback["attempt"] = attempt
         active_code_readback["maxAttempts"] = ACTIVE_CODE_READBACK_MAX_ATTEMPTS
         write_json_atomic(output_path, active_code_readback)
@@ -1097,6 +1119,15 @@ def runtime_parameter_trainability_smoke_gate_error(
     if ticks_run < 1:
         return "runtime-parameter trainability smoke gate did not execute a simulator tick"
     if runtime_parameter_consumption.get("runtimeParameterConsumption") is True:
+        consumed_tick = _coerce_int(runtime_parameter_consumption.get("consumedTick"))
+        if consumed_tick is None or consumed_tick <= 0:
+            return "runtime-parameter trainability smoke gate failed: missing positive consumedTick"
+        injection_tick = _coerce_int(runtime_parameter_injection.get("tick"))
+        if injection_tick is not None and consumed_tick <= injection_tick:
+            return (
+                "runtime-parameter trainability smoke gate failed: "
+                f"consumedTick={consumed_tick} did not advance beyond injection tick={injection_tick}"
+            )
         return None
     status = text_or_none(runtime_parameter_consumption.get("status")) or "missing"
     reason = text_or_none(runtime_parameter_consumption.get("reason")) or (

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -16,7 +16,7 @@ import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Sequence, TextIO
+from typing import Any, Callable, Mapping, Sequence, TextIO
 
 from screeps_rl_experiment_card import (
     scenario_supports_multi_tier_policy_comparison,
@@ -974,6 +974,14 @@ def execute_simulator_runs(
     runs: list[JsonObject] = []
     effective_workers = max(1, min(config.workers, len(variant_ids)))
     min_concurrent_environments = config.min_concurrent_environments or config.scale_environments or 0
+    maybe_run_pre_scale_trainability_smoke_gate(
+        simulator_runner=simulator_runner,
+        variants=variants,
+        variant_configs=variant_configs,
+        config=config,
+        base_run_id=base_run_id,
+        min_concurrent_environments=min_concurrent_environments,
+    )
     for repetition in range(config.repetitions):
         run_id = base_run_id if config.repetitions == 1 else f"{base_run_id}-r{repetition + 1:02d}"
         host_port_start = simulator_repetition_host_port_start(
@@ -999,6 +1007,87 @@ def execute_simulator_runs(
             )
         )
     return runs
+
+
+def maybe_run_pre_scale_trainability_smoke_gate(
+    *,
+    simulator_runner: SimulatorRunner,
+    variants: Sequence[StrategyVariant],
+    variant_configs: Mapping[str, JsonObject],
+    config: SimulationConfig,
+    base_run_id: str,
+    min_concurrent_environments: int,
+) -> JsonObject | None:
+    if simulator_runner is not simulator_harness.run_simulator:
+        return None
+    if min_concurrent_environments <= 0 and config.scale_environments is None:
+        return None
+    smoke_variant = pre_scale_trainability_smoke_variant(variants)
+    if smoke_variant is None:
+        return None
+    smoke_run_id = f"{base_run_id}-pre-scale-smoke"
+    smoke_run = simulator_runner(
+        ticks=1,
+        workers=1,
+        variants=[smoke_variant.id],
+        out_dir=config.simulator_out_dir,
+        run_id=smoke_run_id,
+        host_port_start=config.host_port_start,
+        room=config.room,
+        shard=config.shard,
+        branch=config.branch,
+        code_path=config.code_path,
+        map_source_file=config.map_source_file,
+        min_concurrent_environments=0,
+        variant_configs=variant_configs,
+    )
+    validate_pre_scale_trainability_smoke_gate(smoke_run, smoke_variant.id)
+    return smoke_run
+
+
+def pre_scale_trainability_smoke_variant(variants: Sequence[StrategyVariant]) -> StrategyVariant | None:
+    for variant in variants:
+        injection = simulator_harness.runtime_parameter_injection_for_variant(variant.id, variant.to_json())
+        if injection.get("candidateParameterScope") == "runtime_injected":
+            return variant
+    return None
+
+
+def validate_pre_scale_trainability_smoke_gate(smoke_run: JsonObject, variant_id: str) -> None:
+    variants = smoke_run.get("variants") if isinstance(smoke_run, dict) else None
+    rows = [item for item in variants if isinstance(item, dict)] if isinstance(variants, list) else []
+    row = next(
+        (
+            item
+            for item in rows
+            if text_or_none(item.get("variant_id")) == variant_id
+            or text_or_none(item.get("variantId")) == variant_id
+            or text_or_none(item.get("id")) == variant_id
+        ),
+        rows[0] if rows else None,
+    )
+    if row is None:
+        raise RuntimeError("pre-scale private-simulator trainability smoke gate produced no variant result")
+    if row.get("ok") is not True:
+        reason = text_or_none(row.get("error")) or "variant smoke result was not ok"
+        raise RuntimeError(f"pre-scale private-simulator trainability smoke gate failed: {reason}")
+    active_code_error = simulator_harness.private_simulator_active_code_readback_error(row.get("activeCodeReadback"))
+    if active_code_error is not None:
+        raise RuntimeError(f"pre-scale private-simulator trainability smoke gate failed: {active_code_error}")
+    injection = row.get("runtimeParameterInjection")
+    consumption = row.get("runtimeParameterConsumption")
+    if not isinstance(injection, dict) or injection.get("runtimeParameterInjection") is not True:
+        raise RuntimeError("pre-scale private-simulator trainability smoke gate did not inject runtime parameters")
+    if not isinstance(consumption, dict) or consumption.get("runtimeParameterConsumption") is not True:
+        status = text_or_none(consumption.get("status")) if isinstance(consumption, dict) else None
+        reason = text_or_none(consumption.get("reason")) if isinstance(consumption, dict) else None
+        detail = status or "missing"
+        if reason:
+            detail = f"{detail}: {reason}"
+        raise RuntimeError(
+            "pre-scale private-simulator trainability smoke gate did not prove runtime parameter consumption: "
+            f"{detail}"
+        )
 
 
 def simulator_repetition_host_port_start(base_host_port_start: int, repetition_index: int, effective_workers: int) -> int:

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -1103,7 +1103,12 @@ def validate_pre_scale_trainability_smoke_gate(smoke_run: JsonObject, variant_id
             "missing numeric consumedTick"
         )
     injection_tick = int_or_none(injection.get("tick"))
-    if injection_tick is not None and consumed_tick <= injection_tick:
+    if injection_tick is None:
+        raise RuntimeError(
+            "pre-scale private-simulator trainability smoke gate did not prove runtime parameter consumption: "
+            "missing numeric injection tick"
+        )
+    if consumed_tick <= injection_tick:
         raise RuntimeError(
             "pre-scale private-simulator trainability smoke gate did not prove runtime parameter consumption: "
             f"consumedTick={consumed_tick} did not advance beyond injection tick={injection_tick}"

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -1048,6 +1048,7 @@ def maybe_run_pre_scale_trainability_smoke_gate(
         min_concurrent_environments=0,
         variant_configs=variant_configs,
     )
+    assert_simulator_runs_shadow_safe([smoke_run])
     validate_pre_scale_trainability_smoke_gate(smoke_run, smoke_variant.id)
     return smoke_run
 
@@ -1096,7 +1097,7 @@ def validate_pre_scale_trainability_smoke_gate(smoke_run: JsonObject, variant_id
             f"{detail}"
         )
     consumed_tick = int_or_none(consumption.get("consumedTick"))
-    if consumed_tick is None:
+    if consumed_tick is None or consumed_tick <= 0:
         raise RuntimeError(
             "pre-scale private-simulator trainability smoke gate did not prove runtime parameter consumption: "
             "missing numeric consumedTick"

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -981,6 +981,7 @@ def execute_simulator_runs(
         config=config,
         base_run_id=base_run_id,
         min_concurrent_environments=min_concurrent_environments,
+        effective_workers=effective_workers,
     )
     for repetition in range(config.repetitions):
         run_id = base_run_id if config.repetitions == 1 else f"{base_run_id}-r{repetition + 1:02d}"
@@ -1017,6 +1018,7 @@ def maybe_run_pre_scale_trainability_smoke_gate(
     config: SimulationConfig,
     base_run_id: str,
     min_concurrent_environments: int,
+    effective_workers: int,
 ) -> JsonObject | None:
     if simulator_runner is not simulator_harness.run_simulator:
         return None
@@ -1026,13 +1028,18 @@ def maybe_run_pre_scale_trainability_smoke_gate(
     if smoke_variant is None:
         return None
     smoke_run_id = f"{base_run_id}-pre-scale-smoke"
+    smoke_host_port_start = simulator_repetition_host_port_start(
+        config.host_port_start,
+        config.repetitions,
+        effective_workers,
+    )
     smoke_run = simulator_runner(
         ticks=1,
         workers=1,
         variants=[smoke_variant.id],
         out_dir=config.simulator_out_dir,
         run_id=smoke_run_id,
-        host_port_start=config.host_port_start,
+        host_port_start=smoke_host_port_start,
         room=config.room,
         shard=config.shard,
         branch=config.branch,
@@ -1087,6 +1094,18 @@ def validate_pre_scale_trainability_smoke_gate(smoke_run: JsonObject, variant_id
         raise RuntimeError(
             "pre-scale private-simulator trainability smoke gate did not prove runtime parameter consumption: "
             f"{detail}"
+        )
+    consumed_tick = int_or_none(consumption.get("consumedTick"))
+    if consumed_tick is None:
+        raise RuntimeError(
+            "pre-scale private-simulator trainability smoke gate did not prove runtime parameter consumption: "
+            "missing numeric consumedTick"
+        )
+    injection_tick = int_or_none(injection.get("tick"))
+    if injection_tick is not None and consumed_tick <= injection_tick:
+        raise RuntimeError(
+            "pre-scale private-simulator trainability smoke gate did not prove runtime parameter consumption: "
+            f"consumedTick={consumed_tick} did not advance beyond injection tick={injection_tick}"
         )
 
 

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -1064,7 +1064,7 @@ def validate_pre_scale_trainability_smoke_gate(smoke_run: JsonObject, variant_id
             or text_or_none(item.get("variantId")) == variant_id
             or text_or_none(item.get("id")) == variant_id
         ),
-        rows[0] if rows else None,
+        None,
     )
     if row is None:
         raise RuntimeError("pre-scale private-simulator trainability smoke gate produced no variant result")

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -4726,12 +4726,28 @@ cli:
             branch="default",
             http_status=200,
         )
+        branch_mismatched = harness.private_simulator_active_code_readback_summary(
+            uploaded,
+            {"branch": "stale-branch", "modules": {"main": uploaded}},
+            branch="default",
+            http_status=200,
+        )
+        missing_branch = harness.private_simulator_active_code_readback_summary(
+            uploaded,
+            {"modules": {"main": uploaded}},
+            branch="default",
+            http_status=200,
+        )
 
         self.assertEqual(matched["status"], "matched")
         self.assertTrue(matched["activeCodeMatchesUploaded"])
         self.assertEqual(matched["uploadedCodeSha256"], matched["activeCodeSha256"])
         self.assertEqual(mismatched["status"], "mismatch")
         self.assertFalse(mismatched["activeCodeMatchesUploaded"])
+        self.assertEqual(branch_mismatched["status"], "branch-mismatch")
+        self.assertFalse(branch_mismatched["activeCodeMatchesUploaded"])
+        self.assertEqual(missing_branch["status"], "missing-branch")
+        self.assertFalse(missing_branch["activeCodeMatchesUploaded"])
         self.assertIn(
             "active private-server code hash verification failed",
             harness.private_simulator_active_code_readback_error(mismatched) or "",
@@ -4742,7 +4758,7 @@ cli:
         injection = self.uploaded_runtime_parameter_injection()
         readback = harness.private_simulator_active_code_readback_summary(
             code,
-            {"modules": {"main": code}},
+            {"branch": "default", "modules": {"main": code}},
             branch="default",
             http_status=200,
         )
@@ -5461,6 +5477,7 @@ cli:
             def __init__(self) -> None:
                 self.uploaded_branch: str | None = None
                 self.uploaded_code_text: str | None = None
+                self.code_readback_count = 0
                 self.runtime_payload: dict[str, object] | None = None
                 self.gametime = 0
                 self.room = "E1S1"
@@ -5602,12 +5619,16 @@ cli:
                     return Result(200, {"ok": 1, "token": "token"})
                 if path == "/api/user/code":
                     if method == "GET":
+                        self.code_readback_count += 1
+                        main_code = self.uploaded_code_text
+                        if self.code_readback_count == 1 and isinstance(main_code, str):
+                            main_code = f"{main_code}\n// stale readback"
                         return Result(
                             200,
                             {
                                 "ok": 1,
                                 "branch": self.uploaded_branch,
-                                "modules": {"main": self.uploaded_code_text},
+                                "modules": {"main": main_code},
                             },
                         )
                     return Result(200, {"ok": 1})
@@ -5664,29 +5685,31 @@ cli:
             map_path.write_text("{\"ok\": true}", encoding="utf-8")
             fake_smoke = FakeSmoke()
             with mock.patch("screeps_rl_simulator_harness._load_private_smoke_module", return_value=fake_smoke):
-                result = harness._run_variant(
-                    0,
-                    variant_id,
-                    run_id="runtime-consumption",
-                    ticks=1,
-                    room="E1S1",
-                    shard="shardX",
-                    branch="activeWorld",
-                    code_path=code_path,
-                    map_source_file=map_path,
-                    out_dir=root / "out",
-                    variant_configs={
-                        variant_id: {
-                            "id": variant_id,
-                            "candidatePolicyId": variant_id,
-                            "sourceStrategyId": "construction-priority.territory-shadow.v1",
-                            "family": "construction-priority",
-                            "parameters": parameters,
-                        }
-                    },
-                )
+                with mock.patch.object(harness.time, "sleep", return_value=None):
+                    result = harness._run_variant(
+                        0,
+                        variant_id,
+                        run_id="runtime-consumption",
+                        ticks=1,
+                        room="E1S1",
+                        shard="shardX",
+                        branch="activeWorld",
+                        code_path=code_path,
+                        map_source_file=map_path,
+                        out_dir=root / "out",
+                        variant_configs={
+                            variant_id: {
+                                "id": variant_id,
+                                "candidatePolicyId": variant_id,
+                                "sourceStrategyId": "construction-priority.territory-shadow.v1",
+                                "family": "construction-priority",
+                                "parameters": parameters,
+                            }
+                        },
+                    )
 
         self.assertEqual(fake_smoke.uploaded_branch, "default")
+        self.assertEqual(fake_smoke.code_readback_count, 2)
         self.assertTrue(result["ok"])
         self.assertEqual(result["scenario"]["activeWorldBranch"], "default")
         self.assertTrue(result["runtimeParameterInjection"]["runtimeParameterInjection"])
@@ -5694,6 +5717,7 @@ cli:
         self.assertEqual(result["runtimeParameterInjection"]["runtimeParameterConsumptionStatus"], "consumed")
         self.assertTrue(result["activeCodeReadback"]["activeCodeMatchesUploaded"])
         self.assertEqual(result["activeCodeReadback"]["status"], "matched")
+        self.assertEqual(result["activeCodeReadback"]["attempt"], 2)
         self.assertTrue(result["runtimeParameterConsumption"]["runtimeParameterConsumption"])
         self.assertEqual(result["runtimeParameterConsumption"]["source"], "Memory.rlRuntimePolicyParameters")
         self.assertEqual(result["runtimeParameterConsumption"]["evaluatedParameters"], parameters)

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -738,6 +738,9 @@ cli:
                 return {"email": cfg.email, "password": cfg.password}
 
             def build_code_payload(self, cfg: FakeSmokeConfig, code: str) -> dict[str, object]:
+                state = self._state(str(cfg.server_url))
+                state["uploaded_branch"] = cfg.branch
+                state["uploaded_code_text"] = code
                 return {"branch": cfg.branch, "modules": {"main": code}}
 
             def build_spawn_payload(self, cfg: FakeSmokeConfig) -> dict[str, object]:
@@ -769,7 +772,7 @@ cli:
                 }
 
             def http_json(self, method: str, base_url: str, path: str, *args: object, **kwargs: object) -> Result:
-                _ = method, args
+                _ = args
                 state = self._state(base_url)
                 room = str(state["room"])
                 username = str(state["username"])
@@ -780,6 +783,15 @@ cli:
                 if path == "/api/auth/signin":
                     return Result(200, {"ok": 1, "token": f"token-{base_url.rsplit(':', 1)[-1]}"})
                 if path == "/api/user/code":
+                    if method == "GET":
+                        return Result(
+                            200,
+                            {
+                                "ok": 1,
+                                "branch": state.get("uploaded_branch"),
+                                "modules": {"main": state.get("uploaded_code_text")},
+                            },
+                        )
                     return Result(200, {"ok": 1})
                 if path == "/api/game/place-spawn":
                     return Result(200, {"ok": 1})
@@ -4699,6 +4711,66 @@ cli:
         self.assertNotIn("consumedParametersSha256", summary["variants"][1])
         self.assertNotIn("consumedStrategyVariantId", summary["variants"][1])
 
+    def test_active_code_readback_summary_compares_uploaded_main_by_hash(self) -> None:
+        uploaded = "module.exports.loop = function loop() { return 1; };\n"
+
+        matched = harness.private_simulator_active_code_readback_summary(
+            uploaded,
+            {"branch": "default", "modules": {"main": uploaded}},
+            branch="default",
+            http_status=200,
+        )
+        mismatched = harness.private_simulator_active_code_readback_summary(
+            uploaded,
+            {"branch": "default", "modules": {"main": uploaded + "// stale\n"}},
+            branch="default",
+            http_status=200,
+        )
+
+        self.assertEqual(matched["status"], "matched")
+        self.assertTrue(matched["activeCodeMatchesUploaded"])
+        self.assertEqual(matched["uploadedCodeSha256"], matched["activeCodeSha256"])
+        self.assertEqual(mismatched["status"], "mismatch")
+        self.assertFalse(mismatched["activeCodeMatchesUploaded"])
+        self.assertIn(
+            "active private-server code hash verification failed",
+            harness.private_simulator_active_code_readback_error(mismatched) or "",
+        )
+
+    def test_runtime_parameter_trainability_smoke_gate_blocks_missing_consumption(self) -> None:
+        code = "module.exports.loop = function loop() {};"
+        injection = self.uploaded_runtime_parameter_injection()
+        readback = harness.private_simulator_active_code_readback_summary(
+            code,
+            {"modules": {"main": code}},
+            branch="default",
+            http_status=200,
+        )
+        missing = harness.runtime_parameter_consumption_check(injection, None)
+        consumed = harness.runtime_parameter_consumption_check(
+            injection,
+            self.runtime_parameter_consumption_evidence(injection),
+        )
+
+        self.assertIn(
+            "runtime-parameter trainability smoke gate failed",
+            harness.runtime_parameter_trainability_smoke_gate_error(
+                runtime_parameter_injection=injection,
+                runtime_parameter_consumption=missing,
+                ticks_run=1,
+                active_code_readback=readback,
+            )
+            or "",
+        )
+        self.assertIsNone(
+            harness.runtime_parameter_trainability_smoke_gate_error(
+                runtime_parameter_injection=injection,
+                runtime_parameter_consumption=consumed,
+                ticks_run=1,
+                active_code_readback=readback,
+            )
+        )
+
     def test_direct_game_loop_runtime_parameter_consumption_evidence_validates(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         evidence = harness.direct_game_loop_runtime_parameter_consumption_evidence(
@@ -5388,6 +5460,7 @@ cli:
 
             def __init__(self) -> None:
                 self.uploaded_branch: str | None = None
+                self.uploaded_code_text: str | None = None
                 self.runtime_payload: dict[str, object] | None = None
                 self.gametime = 0
                 self.room = "E1S1"
@@ -5459,6 +5532,7 @@ cli:
 
             def build_code_payload(self, cfg: FakeSmokeConfig, code: str) -> dict[str, object]:
                 self.uploaded_branch = str(cfg.branch)
+                self.uploaded_code_text = code
                 prefix = f"var {harness.RUNTIME_PARAMETER_INJECTION_GLOBAL} = "
                 start = code.find(prefix)
                 if start >= 0:
@@ -5519,7 +5593,7 @@ cli:
                 }
 
             def http_json(self, method: str, base_url: str, path: str, *args: object, **kwargs: object) -> Result:
-                _ = method, base_url, args
+                _ = base_url, args
                 if path == "/api/game/room-terrain":
                     return Result(200, {"terrain": [{"room": self.room, "terrain": "0" * 2500}]})
                 if path == "/api/register/submit":
@@ -5527,6 +5601,15 @@ cli:
                 if path == "/api/auth/signin":
                     return Result(200, {"ok": 1, "token": "token"})
                 if path == "/api/user/code":
+                    if method == "GET":
+                        return Result(
+                            200,
+                            {
+                                "ok": 1,
+                                "branch": self.uploaded_branch,
+                                "modules": {"main": self.uploaded_code_text},
+                            },
+                        )
                     return Result(200, {"ok": 1})
                 if path == "/api/game/place-spawn":
                     return Result(200, {"ok": 1})
@@ -5609,6 +5692,8 @@ cli:
         self.assertTrue(result["runtimeParameterInjection"]["runtimeParameterInjection"])
         self.assertTrue(result["runtimeParameterInjection"]["runtimeParameterConsumption"])
         self.assertEqual(result["runtimeParameterInjection"]["runtimeParameterConsumptionStatus"], "consumed")
+        self.assertTrue(result["activeCodeReadback"]["activeCodeMatchesUploaded"])
+        self.assertEqual(result["activeCodeReadback"]["status"], "matched")
         self.assertTrue(result["runtimeParameterConsumption"]["runtimeParameterConsumption"])
         self.assertEqual(result["runtimeParameterConsumption"]["source"], "Memory.rlRuntimePolicyParameters")
         self.assertEqual(result["runtimeParameterConsumption"]["evaluatedParameters"], parameters)

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -4732,9 +4732,15 @@ cli:
             branch="default",
             http_status=200,
         )
-        missing_branch = harness.private_simulator_active_code_readback_summary(
+        branchless_matched = harness.private_simulator_active_code_readback_summary(
             uploaded,
             {"modules": {"main": uploaded}},
+            branch="default",
+            http_status=200,
+        )
+        branchless_mismatched = harness.private_simulator_active_code_readback_summary(
+            uploaded,
+            {"modules": {"main": uploaded + "// stale\n"}},
             branch="default",
             http_status=200,
         )
@@ -4746,12 +4752,58 @@ cli:
         self.assertFalse(mismatched["activeCodeMatchesUploaded"])
         self.assertEqual(branch_mismatched["status"], "branch-mismatch")
         self.assertFalse(branch_mismatched["activeCodeMatchesUploaded"])
-        self.assertEqual(missing_branch["status"], "missing-branch")
-        self.assertFalse(missing_branch["activeCodeMatchesUploaded"])
+        self.assertEqual(branchless_matched["status"], "matched")
+        self.assertTrue(branchless_matched["activeCodeMatchesUploaded"])
+        self.assertNotIn("activeBranch", branchless_matched)
+        self.assertEqual(branchless_mismatched["status"], "mismatch")
+        self.assertFalse(branchless_mismatched["activeCodeMatchesUploaded"])
         self.assertIn(
             "active private-server code hash verification failed",
             harness.private_simulator_active_code_readback_error(mismatched) or "",
         )
+
+    def test_active_code_readback_poll_accepts_branchless_matching_payload(self) -> None:
+        uploaded = "module.exports.loop = function loop() { return 1; };\n"
+
+        class Cfg:
+            server_url = "http://127.0.0.1:21000"
+
+        class Result:
+            status = 200
+            payload = {"ok": 1, "modules": {"main": uploaded}}
+            headers: dict[str, str] = {}
+
+        class FakeSmoke:
+            def __init__(self) -> None:
+                self.http_calls = 0
+
+            def token_headers(self, token: str) -> dict[str, str]:
+                return {"X-Token": token}
+
+            def update_token_from_headers(self, token: str, headers: dict[str, str]) -> str:
+                _ = headers
+                return token
+
+            def http_json(self, *_args: object, **_kwargs: object) -> Result:
+                self.http_calls += 1
+                return Result()
+
+        smoke = FakeSmoke()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            token, readback = harness._poll_private_simulator_active_code_readback(
+                smoke,
+                Cfg(),
+                "token",
+                uploaded,
+                branch="default",
+                output_path=Path(temp_dir) / "active_code_readback.json",
+            )
+
+        self.assertEqual(token, "token")
+        self.assertEqual(smoke.http_calls, 1)
+        self.assertEqual(readback["status"], "matched")
+        self.assertTrue(readback["activeCodeMatchesUploaded"])
+        self.assertNotIn("activeBranch", readback)
 
     def test_active_code_readback_poll_retries_transport_error_with_diagnostics(self) -> None:
         uploaded = "module.exports.loop = function loop() { return 1; };\n"
@@ -5460,6 +5512,99 @@ cli:
 
         self.assertEqual(observed_tick, 42)
         self.assertEqual(tick_entry["tick"], 42)
+
+    def test_runtime_parameter_injection_tick_capture_retries_missing_initial_clock(self) -> None:
+        class Result:
+            def __init__(self, payload: object, headers: dict[str, str] | None = None) -> None:
+                self.payload = payload
+                self.headers = headers or {}
+
+        class FakeSmoke:
+            def __init__(self) -> None:
+                self.overview_calls = 0
+                self.stats_calls = 0
+
+            def token_headers(self, token: str) -> dict[str, str]:
+                return {"X-Token": token}
+
+            def update_token_from_headers(self, token: str, headers: dict[str, str]) -> str:
+                return headers.get("X-Token", token)
+
+            def http_json(self, method: str, base_url: str, path: str, **kwargs: object) -> Result:
+                _ = method, base_url, kwargs
+                if path == "/api/user/overview":
+                    self.overview_calls += 1
+                    return Result(
+                        {"ok": 1, "rooms": ["E1S1"], "gametimes": []},
+                        {"X-Token": f"overview-{self.overview_calls}"},
+                    )
+                if path == "/stats":
+                    self.stats_calls += 1
+                    if self.stats_calls == 1:
+                        return Result({"ok": 1}, {"X-Token": "stats-empty"})
+                    return Result({"gametime": "37"}, {"X-Token": "stats-37"})
+                raise AssertionError(path)
+
+        smoke = FakeSmoke()
+        with mock.patch.object(harness.time, "sleep", return_value=None) as sleep:
+            token, tick = harness._capture_runtime_parameter_injection_tick(
+                argparse.Namespace(server_url="http://127.0.0.1"),
+                smoke,
+                "token",
+                "shardX",
+                {"ok": 1, "rooms": ["E1S1"], "gametimes": []},
+                max_attempts=3,
+            )
+
+        self.assertEqual(token, "stats-37")
+        self.assertEqual(tick, 37)
+        self.assertEqual(smoke.stats_calls, 2)
+        self.assertEqual(smoke.overview_calls, 1)
+        sleep.assert_called_once_with(harness.RUN_TICK_POLL_SECONDS)
+
+    def test_runtime_parameter_injection_tick_capture_fails_after_bounded_missing_clock(self) -> None:
+        class Result:
+            def __init__(self, payload: object) -> None:
+                self.payload = payload
+                self.headers: dict[str, str] = {}
+
+        class FakeSmoke:
+            def __init__(self) -> None:
+                self.overview_calls = 0
+                self.stats_calls = 0
+
+            def token_headers(self, token: str) -> dict[str, str]:
+                return {"X-Token": token}
+
+            def update_token_from_headers(self, token: str, headers: dict[str, str]) -> str:
+                _ = headers
+                return token
+
+            def http_json(self, method: str, base_url: str, path: str, **kwargs: object) -> Result:
+                _ = method, base_url, kwargs
+                if path == "/api/user/overview":
+                    self.overview_calls += 1
+                    return Result({"ok": 1, "rooms": ["E1S1"], "gametimes": []})
+                if path == "/stats":
+                    self.stats_calls += 1
+                    return Result({"ok": 1})
+                raise AssertionError(path)
+
+        smoke = FakeSmoke()
+        with mock.patch.object(harness.time, "sleep", return_value=None) as sleep:
+            with self.assertRaisesRegex(RuntimeError, "failed to capture numeric injection tick"):
+                harness._capture_runtime_parameter_injection_tick(
+                    argparse.Namespace(server_url="http://127.0.0.1"),
+                    smoke,
+                    "token",
+                    "shardX",
+                    {"ok": 1, "rooms": ["E1S1"], "gametimes": []},
+                    max_attempts=2,
+                )
+
+        self.assertEqual(smoke.stats_calls, 2)
+        self.assertEqual(smoke.overview_calls, 1)
+        sleep.assert_called_once_with(harness.RUN_TICK_POLL_SECONDS)
 
     def test_build_variant_metrics_reduces_territory_resources_and_combat(self) -> None:
         tick_log = [

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -4753,6 +4753,70 @@ cli:
             harness.private_simulator_active_code_readback_error(mismatched) or "",
         )
 
+    def test_active_code_readback_poll_retries_transport_error_with_diagnostics(self) -> None:
+        uploaded = "module.exports.loop = function loop() { return 1; };\n"
+        writes: list[harness.JsonObject] = []
+
+        class Cfg:
+            server_url = "http://127.0.0.1:21000"
+
+        class Result:
+            def __init__(self) -> None:
+                self.status = 200
+                self.payload = {"branch": "default", "modules": {"main": uploaded}}
+                self.headers = {"X-Token": "next-token"}
+
+        class FakeSmoke:
+            def __init__(self) -> None:
+                self.http_calls = 0
+                self.update_calls = 0
+
+            def token_headers(self, token: str) -> dict[str, str]:
+                return {"X-Token": token}
+
+            def update_token_from_headers(self, token: str, headers: dict[str, str]) -> str:
+                self.update_calls += 1
+                self.updated_headers = headers
+                return f"{token}-rotated"
+
+            def http_json(self, *_args: object, **_kwargs: object) -> Result:
+                self.http_calls += 1
+                if self.http_calls == 1:
+                    raise TimeoutError("readback timed out")
+                return Result()
+
+        def capture_write(path: Path, payload: harness.JsonObject) -> None:
+            _ = path
+            writes.append(copy.deepcopy(payload))
+
+        smoke = FakeSmoke()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "active_code_readback.json"
+            with mock.patch.object(harness, "write_json_atomic", side_effect=capture_write):
+                with mock.patch.object(harness.time, "sleep", return_value=None) as sleep:
+                    token, readback = harness._poll_private_simulator_active_code_readback(
+                        smoke,
+                        Cfg(),
+                        "token",
+                        uploaded,
+                        branch="default",
+                        output_path=output_path,
+                    )
+
+        self.assertEqual(token, "token-rotated")
+        self.assertEqual(smoke.http_calls, 2)
+        self.assertEqual(smoke.update_calls, 1)
+        sleep.assert_called_once_with(harness.RUN_TICK_POLL_SECONDS)
+        self.assertEqual(len(writes), 2)
+        self.assertEqual(writes[0]["status"], "transport-error")
+        self.assertEqual(writes[0]["attempt"], 1)
+        self.assertEqual(writes[0]["maxAttempts"], harness.ACTIVE_CODE_READBACK_MAX_ATTEMPTS)
+        self.assertEqual(writes[0]["exceptionType"], "TimeoutError")
+        self.assertIn("readback timed out", writes[0]["error"])
+        self.assertNotIn("httpStatus", writes[0])
+        self.assertEqual(readback["status"], "matched")
+        self.assertEqual(readback["attempt"], 2)
+
     def test_runtime_parameter_trainability_smoke_gate_blocks_missing_consumption(self) -> None:
         code = "module.exports.loop = function loop() {};"
         injection = self.uploaded_runtime_parameter_injection()
@@ -4763,16 +4827,46 @@ cli:
             http_status=200,
         )
         missing = harness.runtime_parameter_consumption_check(injection, None)
-        consumed = harness.runtime_parameter_consumption_check(
+        unticked_consumed = harness.runtime_parameter_consumption_check(
             injection,
             self.runtime_parameter_consumption_evidence(injection),
         )
+        consumed_evidence = self.runtime_parameter_consumption_evidence(injection)
+        consumed_evidence["tick"] = 1
+        consumed = harness.runtime_parameter_consumption_check(
+            injection,
+            consumed_evidence,
+        )
+        injection_at_tick = copy.deepcopy(injection)
+        injection_at_tick["tick"] = 1
+        stale_tick_consumption = copy.deepcopy(consumed)
+        stale_tick_consumption["consumedTick"] = 1
 
         self.assertIn(
             "runtime-parameter trainability smoke gate failed",
             harness.runtime_parameter_trainability_smoke_gate_error(
                 runtime_parameter_injection=injection,
                 runtime_parameter_consumption=missing,
+                ticks_run=1,
+                active_code_readback=readback,
+            )
+            or "",
+        )
+        self.assertIn(
+            "missing positive consumedTick",
+            harness.runtime_parameter_trainability_smoke_gate_error(
+                runtime_parameter_injection=injection,
+                runtime_parameter_consumption=unticked_consumed,
+                ticks_run=1,
+                active_code_readback=readback,
+            )
+            or "",
+        )
+        self.assertIn(
+            "did not advance beyond injection tick",
+            harness.runtime_parameter_trainability_smoke_gate_error(
+                runtime_parameter_injection=injection_at_tick,
+                runtime_parameter_consumption=stale_tick_consumption,
                 ticks_run=1,
                 active_code_readback=readback,
             )

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -4837,6 +4837,8 @@ cli:
             injection,
             consumed_evidence,
         )
+        injection_before_consumption_tick = copy.deepcopy(injection)
+        injection_before_consumption_tick["tick"] = 0
         injection_at_tick = copy.deepcopy(injection)
         injection_at_tick["tick"] = 1
         stale_tick_consumption = copy.deepcopy(consumed)
@@ -4863,6 +4865,16 @@ cli:
             or "",
         )
         self.assertIn(
+            "missing numeric injection tick",
+            harness.runtime_parameter_trainability_smoke_gate_error(
+                runtime_parameter_injection=injection,
+                runtime_parameter_consumption=consumed,
+                ticks_run=1,
+                active_code_readback=readback,
+            )
+            or "",
+        )
+        self.assertIn(
             "did not advance beyond injection tick",
             harness.runtime_parameter_trainability_smoke_gate_error(
                 runtime_parameter_injection=injection_at_tick,
@@ -4874,7 +4886,7 @@ cli:
         )
         self.assertIsNone(
             harness.runtime_parameter_trainability_smoke_gate_error(
-                runtime_parameter_injection=injection,
+                runtime_parameter_injection=injection_before_consumption_tick,
                 runtime_parameter_consumption=consumed,
                 ticks_run=1,
                 active_code_readback=readback,
@@ -5809,10 +5821,15 @@ cli:
         self.assertTrue(result["runtimeParameterInjection"]["runtimeParameterInjection"])
         self.assertTrue(result["runtimeParameterInjection"]["runtimeParameterConsumption"])
         self.assertEqual(result["runtimeParameterInjection"]["runtimeParameterConsumptionStatus"], "consumed")
+        self.assertIsInstance(result["runtimeParameterInjection"].get("tick"), int)
         self.assertTrue(result["activeCodeReadback"]["activeCodeMatchesUploaded"])
         self.assertEqual(result["activeCodeReadback"]["status"], "matched")
         self.assertEqual(result["activeCodeReadback"]["attempt"], 2)
         self.assertTrue(result["runtimeParameterConsumption"]["runtimeParameterConsumption"])
+        self.assertGreater(
+            result["runtimeParameterConsumption"]["consumedTick"],
+            result["runtimeParameterInjection"]["tick"],
+        )
         self.assertEqual(result["runtimeParameterConsumption"]["source"], "Memory.rlRuntimePolicyParameters")
         self.assertEqual(result["runtimeParameterConsumption"]["evaluatedParameters"], parameters)
         self.assertEqual(

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -5466,6 +5466,53 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(calls[1]["host_port_start"], 24125)
         self.assertEqual(runs[0]["runId"], "scale-run")
 
+    def test_private_runner_pre_scale_smoke_gate_rejects_unsafe_smoke_run(self) -> None:
+        calls: list[JsonObject] = []
+        variants = [
+            runner.StrategyVariant(
+                id="candidate.scale-env-01",
+                family="test-family",
+                parameters={"knob": 1},
+            )
+        ]
+        config = runner.SimulationConfig(
+            ticks=500,
+            workers=5,
+            repetitions=1,
+            host_port_start=24125,
+            room="E1S1",
+            shard="shardX",
+            branch="activeWorld",
+            code_path=Path("prod/dist/main.js"),
+            map_source_file=Path("maps/map-0b6758af.json"),
+            simulator_out_dir=Path("runtime-artifacts/rl-simulator-test"),
+            scale_environments=5,
+            min_concurrent_environments=5,
+        )
+
+        def fake_run_simulator(**kwargs: Any) -> JsonObject:
+            calls.append(dict(kwargs))
+            return {
+                "type": "screeps-rl-simulator-run",
+                "runId": kwargs["run_id"],
+                "liveEffect": True,
+                "officialMmoWrites": False,
+                "variants": [],
+            }
+
+        with mock.patch.object(runner.simulator_harness, "run_simulator", side_effect=fake_run_simulator):
+            with self.assertRaisesRegex(RuntimeError, "run\\[0\\]\\.liveEffect=true"):
+                runner.execute_simulator_runs(
+                    simulator_runner=runner.simulator_harness.run_simulator,
+                    variants=variants,
+                    config=config,
+                    card={"run_id": "scale-run"},
+                    report_id="scale-run",
+                )
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["run_id"], "scale-run-pre-scale-smoke")
+
     def test_private_runner_pre_scale_smoke_gate_rejects_missing_requested_variant_row(self) -> None:
         code = (
             f'var marker = "{runner.simulator_harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER}";\n'
@@ -5526,6 +5573,42 @@ export const STRATEGY_REGISTRY = [
                             "runtimeParameterConsumption": {
                                 "status": "consumed",
                                 "runtimeParameterConsumption": True,
+                            },
+                        }
+                    ],
+                },
+                "candidate.scale-env-01",
+            )
+
+    def test_private_runner_pre_scale_smoke_gate_rejects_non_positive_consumed_tick(self) -> None:
+        code = (
+            f'var marker = "{runner.simulator_harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER}";\n'
+            "module.exports.loop = function loop() {};"
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "missing numeric consumedTick"):
+            runner.validate_pre_scale_trainability_smoke_gate(
+                {
+                    "type": "screeps-rl-simulator-run",
+                    "runId": "scale-run-pre-scale-smoke",
+                    "liveEffect": False,
+                    "officialMmoWrites": False,
+                    "variants": [
+                        {
+                            "variant_id": "candidate.scale-env-01",
+                            "ok": True,
+                            "tick_log": [{"tick": 1}],
+                            "activeCodeReadback": runner.simulator_harness.private_simulator_active_code_readback_summary(
+                                code,
+                                {"branch": "default", "modules": {"main": code}},
+                                branch="default",
+                                http_status=200,
+                            ),
+                            "runtimeParameterInjection": {"runtimeParameterInjection": True},
+                            "runtimeParameterConsumption": {
+                                "status": "consumed",
+                                "runtimeParameterConsumption": True,
+                                "consumedTick": 0,
                             },
                         }
                     ],

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -5463,6 +5463,38 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(calls[1]["min_concurrent_environments"], 5)
         self.assertEqual(runs[0]["runId"], "scale-run")
 
+    def test_private_runner_pre_scale_smoke_gate_rejects_missing_requested_variant_row(self) -> None:
+        code = (
+            f'var marker = "{runner.simulator_harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER}";\n'
+            "module.exports.loop = function loop() {};"
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "produced no variant result"):
+            runner.validate_pre_scale_trainability_smoke_gate(
+                {
+                    "type": "screeps-rl-simulator-run",
+                    "runId": "scale-run-pre-scale-smoke",
+                    "liveEffect": False,
+                    "officialMmoWrites": False,
+                    "variants": [
+                        {
+                            "variant_id": "unrelated-success",
+                            "ok": True,
+                            "tick_log": [{"tick": 1}],
+                            "activeCodeReadback": runner.simulator_harness.private_simulator_active_code_readback_summary(
+                                code,
+                                {"modules": {"main": code}},
+                                branch="default",
+                                http_status=200,
+                            ),
+                            "runtimeParameterInjection": {"runtimeParameterInjection": True},
+                            "runtimeParameterConsumption": {"runtimeParameterConsumption": True},
+                        }
+                    ],
+                },
+                "candidate.scale-env-01",
+            )
+
     def test_private_runner_pre_scale_smoke_gate_rejects_missing_consumption_before_scale(self) -> None:
         calls: list[JsonObject] = []
         variants = [

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -5390,7 +5390,11 @@ export const STRATEGY_REGISTRY = [
                 "module.exports.loop = function loop() {};",
                 injection,
             )
-            injection = runner.simulator_harness.mark_runtime_parameter_injection_uploaded(injection, code_text=code)
+            injection = runner.simulator_harness.mark_runtime_parameter_injection_uploaded(
+                injection,
+                code_text=code,
+                upload_tick=0,
+            )
             evidence = {
                 "type": runner.simulator_harness.RUNTIME_PARAMETER_CONSUMPTION_TYPE,
                 "consumerMarker": runner.simulator_harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER,
@@ -5609,6 +5613,42 @@ export const STRATEGY_REGISTRY = [
                                 "status": "consumed",
                                 "runtimeParameterConsumption": True,
                                 "consumedTick": 0,
+                            },
+                        }
+                    ],
+                },
+                "candidate.scale-env-01",
+            )
+
+    def test_private_runner_pre_scale_smoke_gate_rejects_missing_injection_tick(self) -> None:
+        code = (
+            f'var marker = "{runner.simulator_harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER}";\n'
+            "module.exports.loop = function loop() {};"
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "missing numeric injection tick"):
+            runner.validate_pre_scale_trainability_smoke_gate(
+                {
+                    "type": "screeps-rl-simulator-run",
+                    "runId": "scale-run-pre-scale-smoke",
+                    "liveEffect": False,
+                    "officialMmoWrites": False,
+                    "variants": [
+                        {
+                            "variant_id": "candidate.scale-env-01",
+                            "ok": True,
+                            "tick_log": [{"tick": 1}],
+                            "activeCodeReadback": runner.simulator_harness.private_simulator_active_code_readback_summary(
+                                code,
+                                {"branch": "default", "modules": {"main": code}},
+                                branch="default",
+                                http_status=200,
+                            ),
+                            "runtimeParameterInjection": {"runtimeParameterInjection": True},
+                            "runtimeParameterConsumption": {
+                                "status": "consumed",
+                                "runtimeParameterConsumption": True,
+                                "consumedTick": 1,
                             },
                         }
                     ],

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -5351,6 +5351,193 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(summary["perRun"][1]["successfulEnvironments"], 2)
         self.assertFalse(summary["perRun"][1]["ok"])
 
+    def test_private_runner_pre_scale_smoke_gate_runs_one_tick_before_scale(self) -> None:
+        calls: list[JsonObject] = []
+        variants = [
+            runner.StrategyVariant(
+                id="candidate.scale-env-01",
+                family="test-family",
+                parameters={"knob": 1},
+            ),
+            runner.StrategyVariant(
+                id="candidate.scale-env-02",
+                family="test-family",
+                parameters={"knob": 1},
+            ),
+        ]
+        config = runner.SimulationConfig(
+            ticks=500,
+            workers=5,
+            repetitions=1,
+            host_port_start=24125,
+            room="E1S1",
+            shard="shardX",
+            branch="activeWorld",
+            code_path=Path("prod/dist/main.js"),
+            map_source_file=Path("maps/map-0b6758af.json"),
+            simulator_out_dir=Path("runtime-artifacts/rl-simulator-test"),
+            scale_environments=5,
+            min_concurrent_environments=5,
+        )
+
+        def smoke_variant_result(variant_id: str, variant_configs: JsonObject) -> JsonObject:
+            injection = runner.simulator_harness.runtime_parameter_injection_for_variant(
+                variant_id,
+                variant_configs[variant_id],
+            )
+            code = runner.simulator_harness.apply_runtime_parameter_injection_to_code(
+                f'var marker = "{runner.simulator_harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER}";\n'
+                "module.exports.loop = function loop() {};",
+                injection,
+            )
+            injection = runner.simulator_harness.mark_runtime_parameter_injection_uploaded(injection, code_text=code)
+            evidence = {
+                "type": runner.simulator_harness.RUNTIME_PARAMETER_CONSUMPTION_TYPE,
+                "consumerMarker": runner.simulator_harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER,
+                "consumerVersion": runner.simulator_harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_VERSION,
+                "runtimeParameterInjection": True,
+                "consumed": True,
+                "strategyVariantId": variant_id,
+                "parameters": copy.deepcopy(injection["parameters"]),
+                "parametersSha256": injection["parametersSha256"],
+                "consumedStrategyVariantId": variant_id,
+                "consumedParametersSha256": injection["parametersSha256"],
+                "liveEffect": False,
+                "officialMmoWrites": False,
+                "officialMmoWritesAllowed": False,
+            }
+            consumption = runner.simulator_harness.runtime_parameter_consumption_check(injection, evidence)
+            return {
+                "variant_id": variant_id,
+                "ok": True,
+                "tick_log": [{"tick": 1}],
+                "activeCodeReadback": runner.simulator_harness.private_simulator_active_code_readback_summary(
+                    code,
+                    {"modules": {"main": code}},
+                    branch="default",
+                    http_status=200,
+                ),
+                "runtimeParameterInjection": runner.simulator_harness.apply_runtime_parameter_consumption_to_injection(
+                    injection,
+                    consumption,
+                ),
+                "runtimeParameterConsumption": consumption,
+            }
+
+        def fake_run_simulator(**kwargs: Any) -> JsonObject:
+            calls.append(dict(kwargs))
+            if str(kwargs["run_id"]).endswith("-pre-scale-smoke"):
+                variant_id = kwargs["variants"][0]
+                return {
+                    "type": "screeps-rl-simulator-run",
+                    "runId": kwargs["run_id"],
+                    "liveEffect": False,
+                    "officialMmoWrites": False,
+                    "variants": [smoke_variant_result(variant_id, kwargs["variant_configs"])],
+                }
+            return {
+                "type": "screeps-rl-simulator-run",
+                "runId": kwargs["run_id"],
+                "liveEffect": False,
+                "officialMmoWrites": False,
+                "variants": [],
+            }
+
+        with mock.patch.object(runner.simulator_harness, "run_simulator", side_effect=fake_run_simulator):
+            runs = runner.execute_simulator_runs(
+                simulator_runner=runner.simulator_harness.run_simulator,
+                variants=variants,
+                config=config,
+                card={"run_id": "scale-run"},
+                report_id="scale-run",
+            )
+
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0]["run_id"], "scale-run-pre-scale-smoke")
+        self.assertEqual(calls[0]["ticks"], 1)
+        self.assertEqual(calls[0]["workers"], 1)
+        self.assertEqual(calls[0]["variants"], ["candidate.scale-env-01"])
+        self.assertEqual(calls[0]["min_concurrent_environments"], 0)
+        self.assertEqual(calls[1]["run_id"], "scale-run")
+        self.assertEqual(calls[1]["variants"], [variant.id for variant in variants])
+        self.assertEqual(calls[1]["min_concurrent_environments"], 5)
+        self.assertEqual(runs[0]["runId"], "scale-run")
+
+    def test_private_runner_pre_scale_smoke_gate_rejects_missing_consumption_before_scale(self) -> None:
+        calls: list[JsonObject] = []
+        variants = [
+            runner.StrategyVariant(
+                id="candidate.scale-env-01",
+                family="test-family",
+                parameters={"knob": 1},
+            )
+        ]
+        config = runner.SimulationConfig(
+            ticks=500,
+            workers=5,
+            repetitions=1,
+            host_port_start=24125,
+            room="E1S1",
+            shard="shardX",
+            branch="activeWorld",
+            code_path=Path("prod/dist/main.js"),
+            map_source_file=Path("maps/map-0b6758af.json"),
+            simulator_out_dir=Path("runtime-artifacts/rl-simulator-test"),
+            scale_environments=5,
+            min_concurrent_environments=5,
+        )
+
+        def fake_run_simulator(**kwargs: Any) -> JsonObject:
+            calls.append(dict(kwargs))
+            variant_id = kwargs["variants"][0]
+            injection = runner.simulator_harness.runtime_parameter_injection_for_variant(
+                variant_id,
+                kwargs["variant_configs"][variant_id],
+            )
+            code = runner.simulator_harness.apply_runtime_parameter_injection_to_code(
+                f'var marker = "{runner.simulator_harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER}";\n'
+                "module.exports.loop = function loop() {};",
+                injection,
+            )
+            injection = runner.simulator_harness.mark_runtime_parameter_injection_uploaded(injection, code_text=code)
+            return {
+                "type": "screeps-rl-simulator-run",
+                "runId": kwargs["run_id"],
+                "liveEffect": False,
+                "officialMmoWrites": False,
+                "variants": [
+                    {
+                        "variant_id": variant_id,
+                        "ok": True,
+                        "tick_log": [{"tick": 1}],
+                        "activeCodeReadback": runner.simulator_harness.private_simulator_active_code_readback_summary(
+                            code,
+                            {"modules": {"main": code}},
+                            branch="default",
+                            http_status=200,
+                        ),
+                        "runtimeParameterInjection": injection,
+                        "runtimeParameterConsumption": runner.simulator_harness.runtime_parameter_consumption_check(
+                            injection,
+                            None,
+                        ),
+                    }
+                ],
+            }
+
+        with mock.patch.object(runner.simulator_harness, "run_simulator", side_effect=fake_run_simulator):
+            with self.assertRaisesRegex(RuntimeError, "did not prove runtime parameter consumption"):
+                runner.execute_simulator_runs(
+                    simulator_runner=runner.simulator_harness.run_simulator,
+                    variants=variants,
+                    config=config,
+                    card={"run_id": "scale-run"},
+                    report_id="scale-run",
+                )
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["run_id"], "scale-run-pre-scale-smoke")
+
     def test_scale_environment_card_expands_variants_and_records_success_threshold(self) -> None:
         expanded_ids = runner.simulator_harness.expand_scale_environment_variants(["baseline", "candidate"], 5)
         start = tick(1, [room("W1N1", energy=100)])

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -5405,6 +5405,7 @@ export const STRATEGY_REGISTRY = [
                 "liveEffect": False,
                 "officialMmoWrites": False,
                 "officialMmoWritesAllowed": False,
+                "tick": 1,
             }
             consumption = runner.simulator_harness.runtime_parameter_consumption_check(injection, evidence)
             return {
@@ -5413,7 +5414,7 @@ export const STRATEGY_REGISTRY = [
                 "tick_log": [{"tick": 1}],
                 "activeCodeReadback": runner.simulator_harness.private_simulator_active_code_readback_summary(
                     code,
-                    {"modules": {"main": code}},
+                    {"branch": "default", "modules": {"main": code}},
                     branch="default",
                     http_status=200,
                 ),
@@ -5458,9 +5459,11 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(calls[0]["workers"], 1)
         self.assertEqual(calls[0]["variants"], ["candidate.scale-env-01"])
         self.assertEqual(calls[0]["min_concurrent_environments"], 0)
+        self.assertEqual(calls[0]["host_port_start"], 24133)
         self.assertEqual(calls[1]["run_id"], "scale-run")
         self.assertEqual(calls[1]["variants"], [variant.id for variant in variants])
         self.assertEqual(calls[1]["min_concurrent_environments"], 5)
+        self.assertEqual(calls[1]["host_port_start"], 24125)
         self.assertEqual(runs[0]["runId"], "scale-run")
 
     def test_private_runner_pre_scale_smoke_gate_rejects_missing_requested_variant_row(self) -> None:
@@ -5483,12 +5486,86 @@ export const STRATEGY_REGISTRY = [
                             "tick_log": [{"tick": 1}],
                             "activeCodeReadback": runner.simulator_harness.private_simulator_active_code_readback_summary(
                                 code,
-                                {"modules": {"main": code}},
+                                {"branch": "default", "modules": {"main": code}},
                                 branch="default",
                                 http_status=200,
                             ),
                             "runtimeParameterInjection": {"runtimeParameterInjection": True},
                             "runtimeParameterConsumption": {"runtimeParameterConsumption": True},
+                        }
+                    ],
+                },
+                "candidate.scale-env-01",
+            )
+
+    def test_private_runner_pre_scale_smoke_gate_rejects_consumption_without_numeric_tick(self) -> None:
+        code = (
+            f'var marker = "{runner.simulator_harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER}";\n'
+            "module.exports.loop = function loop() {};"
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "missing numeric consumedTick"):
+            runner.validate_pre_scale_trainability_smoke_gate(
+                {
+                    "type": "screeps-rl-simulator-run",
+                    "runId": "scale-run-pre-scale-smoke",
+                    "liveEffect": False,
+                    "officialMmoWrites": False,
+                    "variants": [
+                        {
+                            "variant_id": "candidate.scale-env-01",
+                            "ok": True,
+                            "tick_log": [{"tick": 1}],
+                            "activeCodeReadback": runner.simulator_harness.private_simulator_active_code_readback_summary(
+                                code,
+                                {"branch": "default", "modules": {"main": code}},
+                                branch="default",
+                                http_status=200,
+                            ),
+                            "runtimeParameterInjection": {"runtimeParameterInjection": True},
+                            "runtimeParameterConsumption": {
+                                "status": "consumed",
+                                "runtimeParameterConsumption": True,
+                            },
+                        }
+                    ],
+                },
+                "candidate.scale-env-01",
+            )
+
+    def test_private_runner_pre_scale_smoke_gate_rejects_consumption_before_injection_tick(self) -> None:
+        code = (
+            f'var marker = "{runner.simulator_harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER}";\n'
+            "module.exports.loop = function loop() {};"
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "did not advance beyond injection tick"):
+            runner.validate_pre_scale_trainability_smoke_gate(
+                {
+                    "type": "screeps-rl-simulator-run",
+                    "runId": "scale-run-pre-scale-smoke",
+                    "liveEffect": False,
+                    "officialMmoWrites": False,
+                    "variants": [
+                        {
+                            "variant_id": "candidate.scale-env-01",
+                            "ok": True,
+                            "tick_log": [{"tick": 7}],
+                            "activeCodeReadback": runner.simulator_harness.private_simulator_active_code_readback_summary(
+                                code,
+                                {"branch": "default", "modules": {"main": code}},
+                                branch="default",
+                                http_status=200,
+                            ),
+                            "runtimeParameterInjection": {
+                                "runtimeParameterInjection": True,
+                                "tick": 7,
+                            },
+                            "runtimeParameterConsumption": {
+                                "status": "consumed",
+                                "runtimeParameterConsumption": True,
+                                "consumedTick": 7,
+                            },
                         }
                     ],
                 },
@@ -5544,7 +5621,7 @@ export const STRATEGY_REGISTRY = [
                         "tick_log": [{"tick": 1}],
                         "activeCodeReadback": runner.simulator_harness.private_simulator_active_code_readback_summary(
                             code,
-                            {"modules": {"main": code}},
+                            {"branch": "default", "modules": {"main": code}},
                             branch="default",
                             http_status=200,
                         ),


### PR DESCRIPTION
## Summary
- Add an active-code readback hash check for private simulator runtime-parameter smoke runs.
- Require one-tick runtime-parameter consumption evidence before scale training treats runtime-injected candidates as trainable.
- Preserve worker broken-stderr scale-run tolerance with explicit test fixture readback support.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py`
- `python3 -m unittest scripts.test_screeps_rl_simulator_harness scripts.test_screeps_rl_training_runner -v` (270 tests OK)

## Safety
- Offline/private simulator path only.
- No official MMO writes.
- No cloud or paid Tencent execution triggered by this PR.

Refs #1431
Refs #1299
