### PR TITLE
fix(rl): expose simulator consumption smoke evidence

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -110,6 +110,9 @@ RUNTIME_PARAMETER_CONSUMPTION_EVIDENCE_SOURCES = (
     "redis.Memory.rlRuntimePolicyParameters",
     "mongo.Memory.rlRuntimePolicyParameters",
 )
+RUNTIME_PARAMETER_CONSUMPTION_FAST_EVIDENCE_SOURCES = (
+    RUNTIME_PARAMETER_CONSUMPTION_EVIDENCE_SOURCES[0],
+)
 ACTIVE_CODE_READBACK_TYPE = "screeps-rl-private-simulator-active-code-readback"
 ACTIVE_CODE_READBACK_MAX_ATTEMPTS = 5
 MONGO_CONSOLE_RUNTIME_PARAMETER_OUTPUT_LIMIT = 200000
@@ -1618,6 +1621,8 @@ def collect_runtime_parameter_consumption_evidence(
     cfg: Any,
     token: str | None,
     injection: JsonObject | None = None,
+    *,
+    fast_only: bool = False,
 ) -> tuple[JsonObject | None, list[str]]:
     errors: list[str] = []
     collectors = [
@@ -1632,6 +1637,8 @@ def collect_runtime_parameter_consumption_evidence(
     ]
     invalid_evidence: JsonObject | None = None
     for source, collector in collectors:
+        if fast_only and source not in RUNTIME_PARAMETER_CONSUMPTION_FAST_EVIDENCE_SOURCES:
+            continue
         try:
             evidence = collector(smoke, compose, cfg, token, injection)
         except Exception as exc:  # noqa: BLE001 - missing evidence blocks eligibility but should not fail the run
@@ -1676,6 +1683,7 @@ def collect_runtime_parameter_consumption_evidence_with_retries(
             cfg,
             token,
             injection,
+            fast_only=attempt > 1,
         )
         if evidence is not None:
             validation_error = (
@@ -1683,7 +1691,7 @@ def collect_runtime_parameter_consumption_evidence_with_retries(
                 if injection is not None
                 else None
             )
-            if validation_error is None or attempt == attempts:
+            if validation_error is None:
                 return evidence, errors + [f"attempt {attempt}: {error}" for error in attempt_errors]
             errors.extend(f"attempt {attempt}: {error}" for error in attempt_errors)
             errors.append(f"attempt {attempt}: runtime parameter consumption evidence invalid: {validation_error}")
@@ -1694,9 +1702,15 @@ def collect_runtime_parameter_consumption_evidence_with_retries(
         if attempt < attempts:
             time.sleep(retry_seconds)
     checked_sources = ", ".join(RUNTIME_PARAMETER_CONSUMPTION_EVIDENCE_SOURCES)
+    retry_sources = ", ".join(RUNTIME_PARAMETER_CONSUMPTION_FAST_EVIDENCE_SOURCES)
+    checked_detail = (
+        f"checked {checked_sources} on first attempt and retried {retry_sources}"
+        if attempts > 1
+        else f"checked {checked_sources}"
+    )
     errors.append(
         f"no runtime parameter consumption evidence after {attempts} probe attempt(s); "
-        f"checked {checked_sources}"
+        f"{checked_detail}"
     )
     return None, errors
 

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -83,6 +83,8 @@ RUN_HTTP_PORT_STEP = 2
 RUN_PORT_SCAN_ATTEMPTS = 2048
 RUN_TICK_TIMEOUT_SECONDS = 300
 RUN_TICK_POLL_SECONDS = 0.20
+RUN_RUNTIME_PARAMETER_CONSUMPTION_PROBE_ATTEMPTS = 3
+RUN_RUNTIME_PARAMETER_CONSUMPTION_PROBE_RETRY_SECONDS = 1.0
 RUN_WORKER_PREFIX = "rl-sim-worker"
 RUN_BROKEN_PIPE_MAX_RETRIES = 1
 RUN_BROKEN_PIPE_RETRY_BACKOFF_SECONDS = 2.0
@@ -101,6 +103,13 @@ RUNTIME_PARAMETER_INJECTION_CONSUMER_VERSION = "v1"
 RUNTIME_PARAMETER_CONSUMPTION_LOG_PREFIX = "#runtime-parameter-consumption "
 RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE = "private_simulator_game_loop_runtime_parameters"
 RUNTIME_PARAMETER_CONSUMPTION_CANDIDATE_MAX_DEPTH = 8
+RUNTIME_PARAMETER_CONSUMPTION_EVIDENCE_SOURCES = (
+    "Memory.rlRuntimePolicyParameters",
+    "console.runtimePolicyParameterConsumption",
+    "mongo.console.runtimePolicyParameterConsumption",
+    "redis.Memory.rlRuntimePolicyParameters",
+    "mongo.Memory.rlRuntimePolicyParameters",
+)
 ACTIVE_CODE_READBACK_TYPE = "screeps-rl-private-simulator-active-code-readback"
 ACTIVE_CODE_READBACK_MAX_ATTEMPTS = 5
 MONGO_CONSOLE_RUNTIME_PARAMETER_OUTPUT_LIMIT = 200000
@@ -1139,8 +1148,24 @@ def runtime_parameter_trainability_smoke_gate_error(
         return None
     status = text_or_none(runtime_parameter_consumption.get("status")) or "missing"
     reason = text_or_none(runtime_parameter_consumption.get("reason")) or (
-        "one-tick simulator smoke did not expose consumed runtime policy parameter evidence"
+        "simulator smoke did not expose consumed runtime policy parameter evidence"
     )
+    diagnostics: list[str] = []
+    direct_status = text_or_none(runtime_parameter_consumption.get("directRuntimeEvaluationStatus"))
+    if direct_status is not None:
+        diagnostics.append(f"directRuntimeEvaluationStatus={direct_status}")
+    direct_reason = text_or_none(runtime_parameter_consumption.get("directRuntimeEvaluationReason"))
+    if direct_reason is not None:
+        diagnostics.append(f"directRuntimeEvaluationReason={direct_reason}")
+    if active_code_readback is not None:
+        readback_status = text_or_none(active_code_readback.get("status"))
+        active_code_matches = active_code_readback.get("activeCodeMatchesUploaded")
+        diagnostics.append(f"activeCodeReadbackStatus={readback_status or 'unknown'}")
+        if isinstance(active_code_matches, bool):
+            diagnostics.append(f"activeCodeMatchesUploaded={str(active_code_matches).lower()}")
+    diagnostics.append(f"ticksRun={ticks_run}")
+    if diagnostics:
+        reason = f"{reason}; " + "; ".join(diagnostics)
     return f"runtime-parameter trainability smoke gate failed: status={status}: {reason}"
 
 
@@ -1596,14 +1621,14 @@ def collect_runtime_parameter_consumption_evidence(
 ) -> tuple[JsonObject | None, list[str]]:
     errors: list[str] = []
     collectors = [
-        ("Memory.rlRuntimePolicyParameters", _collect_http_runtime_parameter_consumption_evidence),
-        ("console.runtimePolicyParameterConsumption", _collect_console_runtime_parameter_consumption_evidence),
+        (RUNTIME_PARAMETER_CONSUMPTION_EVIDENCE_SOURCES[0], _collect_http_runtime_parameter_consumption_evidence),
+        (RUNTIME_PARAMETER_CONSUMPTION_EVIDENCE_SOURCES[1], _collect_console_runtime_parameter_consumption_evidence),
         (
-            "mongo.console.runtimePolicyParameterConsumption",
+            RUNTIME_PARAMETER_CONSUMPTION_EVIDENCE_SOURCES[2],
             _collect_mongo_console_runtime_parameter_consumption_evidence,
         ),
-        ("redis.Memory.rlRuntimePolicyParameters", _collect_redis_runtime_parameter_consumption_evidence),
-        ("mongo.Memory.rlRuntimePolicyParameters", _collect_mongo_runtime_parameter_consumption_evidence),
+        (RUNTIME_PARAMETER_CONSUMPTION_EVIDENCE_SOURCES[3], _collect_redis_runtime_parameter_consumption_evidence),
+        (RUNTIME_PARAMETER_CONSUMPTION_EVIDENCE_SOURCES[4], _collect_mongo_runtime_parameter_consumption_evidence),
     ]
     invalid_evidence: JsonObject | None = None
     for source, collector in collectors:
@@ -1628,6 +1653,51 @@ def collect_runtime_parameter_consumption_evidence(
             return evidence, errors
     if invalid_evidence is not None:
         return invalid_evidence, errors
+    return None, errors
+
+
+def collect_runtime_parameter_consumption_evidence_with_retries(
+    smoke: Any,
+    compose: Sequence[str] | None,
+    cfg: Any,
+    token: str | None,
+    injection: JsonObject | None = None,
+    *,
+    max_attempts: int = RUN_RUNTIME_PARAMETER_CONSUMPTION_PROBE_ATTEMPTS,
+    retry_seconds: float = RUN_RUNTIME_PARAMETER_CONSUMPTION_PROBE_RETRY_SECONDS,
+) -> tuple[JsonObject | None, list[str]]:
+    """Collect runtime-parameter consumption evidence with a bounded post-tick retry window."""
+    attempts = max(1, max_attempts)
+    errors: list[str] = []
+    for attempt in range(1, attempts + 1):
+        evidence, attempt_errors = collect_runtime_parameter_consumption_evidence(
+            smoke,
+            compose,
+            cfg,
+            token,
+            injection,
+        )
+        if evidence is not None:
+            validation_error = (
+                runtime_parameter_consumption_validation_error(injection, evidence)
+                if injection is not None
+                else None
+            )
+            if validation_error is None or attempt == attempts:
+                return evidence, errors + [f"attempt {attempt}: {error}" for error in attempt_errors]
+            errors.extend(f"attempt {attempt}: {error}" for error in attempt_errors)
+            errors.append(f"attempt {attempt}: runtime parameter consumption evidence invalid: {validation_error}")
+            if attempt < attempts:
+                time.sleep(retry_seconds)
+            continue
+        errors.extend(f"attempt {attempt}: {error}" for error in attempt_errors)
+        if attempt < attempts:
+            time.sleep(retry_seconds)
+    checked_sources = ", ".join(RUNTIME_PARAMETER_CONSUMPTION_EVIDENCE_SOURCES)
+    errors.append(
+        f"no runtime parameter consumption evidence after {attempts} probe attempt(s); "
+        f"checked {checked_sources}"
+    )
     return None, errors
 
 
@@ -5736,7 +5806,7 @@ def _run_variant(
             except Exception as exc:  # noqa: BLE001 - HTTP evidence may still be sufficient
                 evidence_errors.append(f"mongo room evidence failed: {_safe_text(exc, 360)}")
         if runtime_parameter_injection.get("status") == "injected":
-            consumption_evidence, consumption_errors = collect_runtime_parameter_consumption_evidence(
+            consumption_evidence, consumption_errors = collect_runtime_parameter_consumption_evidence_with_retries(
                 smoke,
                 compose,
                 cfg,

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -37,6 +37,7 @@ DEFAULT_RESOURCE_NORMALIZER = 1000.0
 DEFAULT_RUN_REPETITIONS = 1
 DEFAULT_STEAM_KEY_ENV_FILE = screeps_secret_env.DEFAULT_LOCAL_SECRET_ENV_FILE
 STEAM_KEY_ENV_FILE_ENV = "SCREEPS_RL_STEAM_KEY_ENV_FILE"
+PRE_SCALE_TRAINABILITY_SMOKE_TICKS = 2
 DEFAULT_POLICY_UPDATE_LEARNING_RATE = 0.25
 RANK_WEIGHTED_FINITE_DIFFERENCE_ALGORITHM = "rank_weighted_finite_difference_v1"
 TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM = "reinforce_v1"
@@ -1034,7 +1035,7 @@ def maybe_run_pre_scale_trainability_smoke_gate(
         effective_workers,
     )
     smoke_run = simulator_runner(
-        ticks=1,
+        ticks=PRE_SCALE_TRAINABILITY_SMOKE_TICKS,
         workers=1,
         variants=[smoke_variant.id],
         out_dir=config.simulator_out_dir,

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -3102,6 +3102,98 @@ cli:
         self.assertEqual(calls, 2)
         sleep.assert_called_once_with(0.25)
 
+    def test_runtime_parameter_consumption_collection_retries_fail_closed_on_invalid_evidence(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        stale = self.runtime_parameter_consumption_evidence(injection)
+        stale["parameters"] = {
+            **stale["parameters"],
+            "territorySignalWeight": stale["parameters"]["territorySignalWeight"] + 1,
+        }
+        fast_only_attempts: list[bool] = []
+
+        def fake_collect(*args: object, **kwargs: object) -> tuple[dict[str, object] | None, list[str]]:
+            _ = args
+            fast_only_attempts.append(bool(kwargs.get("fast_only")))
+            return stale, ["stale runtime parameter evidence"]
+
+        with mock.patch.object(
+            harness,
+            "collect_runtime_parameter_consumption_evidence",
+            side_effect=fake_collect,
+        ):
+            with mock.patch.object(harness.time, "sleep", return_value=None):
+                extracted, errors = harness.collect_runtime_parameter_consumption_evidence_with_retries(
+                    object(),
+                    ["compose"],
+                    object(),
+                    "token",
+                    injection,
+                    max_attempts=2,
+                    retry_seconds=0.25,
+                )
+
+        self.assertIsNone(extracted)
+        self.assertEqual(fast_only_attempts, [False, True])
+        self.assertIn("attempt 1: stale runtime parameter evidence", errors)
+        self.assertIn("attempt 2: stale runtime parameter evidence", errors)
+        self.assertTrue(
+            any(
+                "runtime parameter consumption evidence invalid: runtime policy parameter evidence parameters disagreed"
+                in error
+                for error in errors
+            )
+        )
+        self.assertIn("no runtime parameter consumption evidence after 2 probe attempt(s)", errors[-1])
+
+    def test_runtime_parameter_consumption_collection_retries_only_fast_sources(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+
+        with (
+            mock.patch.object(
+                harness,
+                "_collect_http_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ) as http_collect,
+            mock.patch.object(
+                harness,
+                "_collect_console_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ) as console_collect,
+            mock.patch.object(
+                harness,
+                "_collect_mongo_console_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ) as mongo_console_collect,
+            mock.patch.object(
+                harness,
+                "_collect_redis_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ) as redis_collect,
+            mock.patch.object(
+                harness,
+                "_collect_mongo_runtime_parameter_consumption_evidence",
+                return_value=None,
+            ) as mongo_collect,
+            mock.patch.object(harness.time, "sleep", return_value=None),
+        ):
+            extracted, errors = harness.collect_runtime_parameter_consumption_evidence_with_retries(
+                object(),
+                ["compose"],
+                object(),
+                "token",
+                injection,
+                max_attempts=2,
+                retry_seconds=0.25,
+            )
+
+        self.assertIsNone(extracted)
+        self.assertEqual(http_collect.call_count, 2)
+        self.assertEqual(console_collect.call_count, 1)
+        self.assertEqual(mongo_console_collect.call_count, 1)
+        self.assertEqual(redis_collect.call_count, 1)
+        self.assertEqual(mongo_collect.call_count, 1)
+        self.assertIn("retried Memory.rlRuntimePolicyParameters", errors[-1])
+
     def test_runtime_parameter_consumption_collection_retry_diagnostic_lists_sources(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
 

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -3068,6 +3068,64 @@ cli:
         self.assertEqual(extracted, expected)
         self.assertEqual(errors, [])
 
+    def test_runtime_parameter_consumption_collection_retries_after_tick_race(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+        evidence = self.runtime_parameter_consumption_evidence(injection)
+        calls = 0
+
+        def fake_collect(*args: object, **kwargs: object) -> tuple[dict[str, object] | None, list[str]]:
+            _ = args, kwargs
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return None, []
+            return evidence, []
+
+        with mock.patch.object(
+            harness,
+            "collect_runtime_parameter_consumption_evidence",
+            side_effect=fake_collect,
+        ):
+            with mock.patch.object(harness.time, "sleep", return_value=None) as sleep:
+                extracted, errors = harness.collect_runtime_parameter_consumption_evidence_with_retries(
+                    object(),
+                    ["compose"],
+                    object(),
+                    "token",
+                    injection,
+                    max_attempts=3,
+                    retry_seconds=0.25,
+                )
+
+        self.assertIs(extracted, evidence)
+        self.assertEqual(errors, [])
+        self.assertEqual(calls, 2)
+        sleep.assert_called_once_with(0.25)
+
+    def test_runtime_parameter_consumption_collection_retry_diagnostic_lists_sources(self) -> None:
+        injection = self.uploaded_runtime_parameter_injection()
+
+        with mock.patch.object(
+            harness,
+            "collect_runtime_parameter_consumption_evidence",
+            return_value=(None, []),
+        ):
+            with mock.patch.object(harness.time, "sleep", return_value=None):
+                extracted, errors = harness.collect_runtime_parameter_consumption_evidence_with_retries(
+                    object(),
+                    ["compose"],
+                    object(),
+                    "token",
+                    injection,
+                    max_attempts=2,
+                    retry_seconds=0.25,
+                )
+
+        self.assertIsNone(extracted)
+        self.assertIn("no runtime parameter consumption evidence after 2 probe attempt(s)", errors[-1])
+        self.assertIn("Memory.rlRuntimePolicyParameters", errors[-1])
+        self.assertIn("mongo.Memory.rlRuntimePolicyParameters", errors[-1])
+
     def test_runtime_parameter_consumption_collection_accepts_mongo_console_tick_evidence(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         evidence = self.runtime_parameter_consumption_evidence(injection)

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -5351,7 +5351,7 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(summary["perRun"][1]["successfulEnvironments"], 2)
         self.assertFalse(summary["perRun"][1]["ok"])
 
-    def test_private_runner_pre_scale_smoke_gate_runs_one_tick_before_scale(self) -> None:
+    def test_private_runner_pre_scale_smoke_gate_runs_probe_ticks_before_scale(self) -> None:
         calls: list[JsonObject] = []
         variants = [
             runner.StrategyVariant(
@@ -5459,7 +5459,7 @@ export const STRATEGY_REGISTRY = [
 
         self.assertEqual(len(calls), 2)
         self.assertEqual(calls[0]["run_id"], "scale-run-pre-scale-smoke")
-        self.assertEqual(calls[0]["ticks"], 1)
+        self.assertEqual(calls[0]["ticks"], runner.PRE_SCALE_TRAINABILITY_SMOKE_TICKS)
         self.assertEqual(calls[0]["workers"], 1)
         self.assertEqual(calls[0]["variants"], ["candidate.scale-env-01"])
         self.assertEqual(calls[0]["min_concurrent_environments"], 0)


### PR DESCRIPTION
## Summary
- Add simulator-side runtime-policy consumption evidence fallback from runtime memory when private-server console output is missing.
- Carry the fallback through the pre-scale trainability smoke so the #1436 guard can distinguish real missing consumption from absent console transport.
- Add regression tests for the smoke-gate path and training report propagation.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py`
- `python3 -m unittest scripts.test_screeps_rl_simulator_harness scripts.test_screeps_rl_training_runner -v` (282 tests OK)

## Safety / rollout
- No official MMO writes.
- No Tencent paid compute was launched by this PR.
- Post-merge validation remains required: one guarded smoke on current main must prove `runtimeParameterConsumption=true` and `consumedVariantCount>0` with `officialMmoWrites=false` before broader #1032/#1337 scale work resumes.

Related to issue #1431, #1299, #879, #1032, and #1337.
