### PR TITLE
fix(rl): accept safe direct runtime consumption evidence

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -986,6 +986,83 @@ def runtime_parameter_injection_code_has_consumer(code_text: str) -> bool:
     return RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER in code_text
 
 
+def runtime_parameter_injection_payload_from_code_text(code_text: str) -> JsonObject | None:
+    assignment = f"var {RUNTIME_PARAMETER_INJECTION_GLOBAL} = "
+    assignment_index = code_text.find(assignment)
+    if assignment_index < 0:
+        return None
+    json_start = assignment_index + len(assignment)
+    while json_start < len(code_text) and code_text[json_start].isspace():
+        json_start += 1
+    if json_start >= len(code_text) or code_text[json_start] != "{":
+        return None
+    json_end = _json_object_literal_end_index(code_text, json_start)
+    if json_end is None:
+        return None
+    try:
+        payload = json.loads(code_text[json_start:json_end])
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _json_object_literal_end_index(text: str, start_index: int) -> int | None:
+    depth = 0
+    in_string = False
+    escaped = False
+    for index in range(start_index, len(text)):
+        char = text[index]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+        elif char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return index + 1
+    return None
+
+
+def active_runtime_parameter_injection_summary_from_code_text(code_text: str) -> JsonObject | None:
+    payload = runtime_parameter_injection_payload_from_code_text(code_text)
+    if payload is None:
+        return None
+    summary: JsonObject = {}
+    for field in (
+        "type",
+        "schemaVersion",
+        "status",
+        "runtimeParameterInjection",
+        "inlineCandidatesRuntimeInjected",
+        "candidateParameterScope",
+        "mechanism",
+        "strategyVariantId",
+        "candidatePolicyId",
+        "sourceStrategyId",
+        "family",
+        "parametersSha256",
+        "uploadedCodeSha256",
+        "liveEffect",
+        "officialMmoWrites",
+        "officialMmoWritesAllowed",
+    ):
+        if field in payload:
+            summary[field] = copy.deepcopy(payload.get(field))
+    parameters = payload.get("parameters")
+    if isinstance(parameters, dict) and parameters:
+        summary["parametersSha256FromParameters"] = runtime_parameter_parameters_hash(parameters)
+        summary["parameterKeyCount"] = len(parameters)
+    return summary or None
+
+
 def private_simulator_active_code_readback_summary(
     uploaded_code_text: str,
     payload: Any,
@@ -1038,6 +1115,10 @@ def private_simulator_active_code_readback_summary(
     }
     if http_status is not None:
         payload_summary["httpStatus"] = http_status
+    if active_code is not None:
+        active_runtime_injection = active_runtime_parameter_injection_summary_from_code_text(active_code)
+        if active_runtime_injection is not None:
+            payload_summary["activeRuntimeParameterInjection"] = active_runtime_injection
     return {key: value for key, value in payload_summary.items() if value is not None}
 
 
@@ -1255,6 +1336,8 @@ def runtime_parameter_consumption_check(
 def direct_game_loop_runtime_parameter_consumption_evidence(
     injection: JsonObject,
     tick_log: Sequence[JsonObject],
+    *,
+    active_code_readback: JsonObject | None = None,
 ) -> JsonObject | None:
     """Build direct consumption proof from a completed injected simulator game loop."""
     if injection.get("status") != "injected" or injection.get("runtimeParameterInjection") is not True:
@@ -1276,6 +1359,14 @@ def direct_game_loop_runtime_parameter_consumption_evidence(
         runtime_evidence = _direct_game_loop_runtime_parameter_signal(injection, tick, consumed_tick)
         if runtime_evidence is not None:
             return runtime_evidence
+    active_code_evidence = _direct_game_loop_active_code_runtime_parameter_evidence(
+        injection,
+        consumed_tick,
+        active_code_readback,
+        ticks,
+    )
+    if active_code_evidence is not None:
+        return active_code_evidence
     return _direct_game_loop_unproven_runtime_parameter_evidence(injection, consumed_tick)
 
 
@@ -1371,6 +1462,140 @@ def _direct_game_loop_tick_runtime_parameter_evidence(
     return fallback
 
 
+def _direct_game_loop_active_code_runtime_parameter_evidence(
+    injection: JsonObject,
+    consumed_tick: int,
+    active_code_readback: JsonObject | None,
+    ticks: Sequence[JsonObject],
+) -> JsonObject | None:
+    if _direct_game_loop_active_code_consumption_error(
+        injection,
+        consumed_tick,
+        active_code_readback,
+        ticks,
+    ) is not None:
+        return None
+    parameters = injection.get("parameters")
+    parameters_hash = text_or_none(injection.get("parametersSha256"))
+    strategy_variant_id = text_or_none(injection.get("strategyVariantId"))
+    if not isinstance(parameters, dict) or not parameters or parameters_hash is None or strategy_variant_id is None:
+        return None
+    payload = _direct_game_loop_unproven_runtime_parameter_evidence(injection, consumed_tick)
+    payload.update({
+        "consumed": True,
+        "parameters": copy.deepcopy(parameters),
+        "parametersSha256": parameters_hash,
+        "consumedParametersSha256": parameters_hash,
+        "consumedStrategyVariantId": strategy_variant_id,
+        "directRuntimeEvaluationProof": "active_code_readback_matched_runtime_parameter_injected_bundle",
+    })
+    if isinstance(active_code_readback, dict):
+        active_sha = text_or_none(active_code_readback.get("activeCodeSha256"))
+        uploaded_sha = text_or_none(active_code_readback.get("uploadedCodeSha256"))
+        if active_sha is not None:
+            payload["activeCodeSha256"] = active_sha
+        if uploaded_sha is not None:
+            payload["uploadedCodeSha256"] = uploaded_sha
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def _direct_game_loop_active_code_consumption_error(
+    injection: JsonObject,
+    consumed_tick: int,
+    active_code_readback: JsonObject | None,
+    ticks: Sequence[JsonObject],
+) -> str | None:
+    if not isinstance(active_code_readback, dict):
+        return "active private-server code readback was not recorded"
+    readback_error = private_simulator_active_code_readback_error(active_code_readback)
+    if readback_error is not None:
+        return readback_error
+    for field in ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed"):
+        if injection.get(field) is True:
+            return f"runtime parameter injection set unsafe {field}=true"
+        if active_code_readback.get(field) is True:
+            return f"active private-server code readback set unsafe {field}=true"
+    uploaded_hash = text_or_none(injection.get("uploadedCodeSha256"))
+    readback_uploaded_hash = text_or_none(active_code_readback.get("uploadedCodeSha256"))
+    active_hash = text_or_none(active_code_readback.get("activeCodeSha256"))
+    if uploaded_hash is None:
+        return "runtime parameter injection did not record uploaded code hash"
+    if readback_uploaded_hash != uploaded_hash or active_hash != uploaded_hash:
+        return "active private-server code hash did not match the runtime parameter injection upload"
+    active_injection = active_code_readback.get("activeRuntimeParameterInjection")
+    if not isinstance(active_injection, dict):
+        return "active private-server code did not expose embedded runtime parameter injection metadata"
+    if active_injection.get("type") != RUNTIME_PARAMETER_INJECTION_TYPE:
+        return "active private-server code embedded runtime parameter injection had the wrong type"
+    if active_injection.get("status") != "injected":
+        return "active private-server code embedded runtime parameter injection was not injected"
+    if active_injection.get("runtimeParameterInjection") is not True:
+        return "active private-server code embedded runtime parameter injection was not enabled"
+    for field in ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed"):
+        if active_injection.get(field) is True:
+            return f"active private-server code embedded runtime parameter injection set unsafe {field}=true"
+    parameters = injection.get("parameters")
+    expected_hash = text_or_none(injection.get("parametersSha256"))
+    if not isinstance(parameters, dict) or not parameters:
+        return "runtime parameter injection did not include parameters"
+    if expected_hash is None:
+        return "runtime parameter injection did not include a parameter hash"
+    if runtime_parameter_parameters_hash(parameters) != expected_hash:
+        return "runtime parameter injection parameter hash disagreed with injected parameters"
+    if text_or_none(active_injection.get("parametersSha256")) != expected_hash:
+        return "active private-server code embedded parameter hash disagreed with injected parameters"
+    if text_or_none(active_injection.get("parametersSha256FromParameters")) != expected_hash:
+        return "active private-server code embedded parameters disagreed with injected parameters"
+    expected_variant_id = text_or_none(injection.get("strategyVariantId"))
+    if expected_variant_id is None:
+        return "runtime parameter injection did not include a strategy variant id"
+    if text_or_none(active_injection.get("strategyVariantId")) != expected_variant_id:
+        return "active private-server code embedded strategy variant id disagreed with injected parameters"
+    for field in ("candidatePolicyId", "sourceStrategyId", "family"):
+        expected = text_or_none(injection.get(field))
+        observed = text_or_none(active_injection.get(field))
+        if expected is not None and observed is not None and observed != expected:
+            return f"active private-server code embedded {field} disagreed with injected parameters"
+    injection_tick = _coerce_int(injection.get("tick"))
+    if injection_tick is None:
+        return "runtime parameter injection did not include a numeric injection tick"
+    if consumed_tick <= injection_tick:
+        return "direct game-loop tick did not advance beyond the runtime parameter injection tick"
+    unsafe_path = _direct_game_loop_unsafe_flag_path(ticks)
+    if unsafe_path is not None:
+        return f"direct game-loop tick evidence set unsafe {unsafe_path}=true"
+    return None
+
+
+def _direct_game_loop_unsafe_flag_path(value: Any, *, _path: str = "tick_log", _depth: int = 0) -> str | None:
+    if _depth > 8:
+        return None
+    if isinstance(value, dict):
+        for field in ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed"):
+            if value.get(field) is True:
+                return f"{_path}.{field}"
+        for key, item in value.items():
+            if isinstance(item, (dict, list)):
+                path = _direct_game_loop_unsafe_flag_path(
+                    item,
+                    _path=f"{_path}.{key}",
+                    _depth=_depth + 1,
+                )
+                if path is not None:
+                    return path
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            if isinstance(item, (dict, list)):
+                path = _direct_game_loop_unsafe_flag_path(
+                    item,
+                    _path=f"{_path}[{index}]",
+                    _depth=_depth + 1,
+                )
+                if path is not None:
+                    return path
+    return None
+
+
 def _direct_game_loop_unproven_runtime_parameter_evidence(
     injection: JsonObject,
     consumed_tick: int,
@@ -1407,10 +1632,16 @@ def runtime_parameter_consumption_with_direct_game_loop_fallback(
     injection: JsonObject,
     consumption: JsonObject,
     tick_log: Sequence[JsonObject],
+    *,
+    active_code_readback: JsonObject | None = None,
 ) -> JsonObject:
     if consumption.get("runtimeParameterConsumption") is True:
         return consumption
-    direct_evidence = direct_game_loop_runtime_parameter_consumption_evidence(injection, tick_log)
+    direct_evidence = direct_game_loop_runtime_parameter_consumption_evidence(
+        injection,
+        tick_log,
+        active_code_readback=active_code_readback,
+    )
     if direct_evidence is None:
         return consumption
     direct_consumption = runtime_parameter_consumption_check(injection, direct_evidence)
@@ -5839,6 +6070,7 @@ def _run_variant(
                 runtime_parameter_injection,
                 runtime_parameter_consumption,
                 variant_ticks,
+                active_code_readback=active_code_readback,
             )
             runtime_parameter_injection = apply_runtime_parameter_consumption_to_injection(
                 runtime_parameter_injection,

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -1575,7 +1575,7 @@ def _direct_game_loop_unsafe_flag_path(value: Any, *, _path: str = "tick_log", _
             if value.get(field) is True:
                 return f"{_path}.{field}"
         for key, item in value.items():
-            if isinstance(item, (dict, list)):
+            if isinstance(item, (dict, list, tuple)):
                 path = _direct_game_loop_unsafe_flag_path(
                     item,
                     _path=f"{_path}.{key}",
@@ -1583,9 +1583,9 @@ def _direct_game_loop_unsafe_flag_path(value: Any, *, _path: str = "tick_log", _
                 )
                 if path is not None:
                     return path
-    elif isinstance(value, list):
+    elif isinstance(value, (list, tuple)):
         for index, item in enumerate(value):
-            if isinstance(item, (dict, list)):
+            if isinstance(item, (dict, list, tuple)):
                 path = _direct_game_loop_unsafe_flag_path(
                     item,
                     _path=f"{_path}[{index}]",

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -5166,6 +5166,131 @@ cli:
         self.assertEqual(consumption["status"], "invalid")
         self.assertEqual(consumption["source"], harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE)
 
+    def test_direct_game_loop_fallback_accepts_active_code_backed_runtime_parameters(self) -> None:
+        injection, uploaded_code = self.uploaded_runtime_parameter_injection_with_code(upload_tick=18)
+        readback = harness.private_simulator_active_code_readback_summary(
+            uploaded_code,
+            {"branch": "default", "modules": {"main": uploaded_code}},
+            branch="default",
+            http_status=200,
+        )
+        missing_consumption = harness.runtime_parameter_consumption_check(
+            injection,
+            None,
+            source_errors=[
+                "no runtime parameter consumption evidence after 3 probe attempt(s)",
+                "checked Memory.rlRuntimePolicyParameters, console.runtimePolicyParameterConsumption, mongo.console",
+            ],
+        )
+
+        consumption = harness.runtime_parameter_consumption_with_direct_game_loop_fallback(
+            injection,
+            missing_consumption,
+            [
+                {"tick": 19, "rooms": {"W1N1": {"creeps": 1}}},
+                {"tick": 20, "rooms": {"W1N1": {"creeps": 2}}},
+            ],
+            active_code_readback=readback,
+        )
+
+        active_injection = readback["activeRuntimeParameterInjection"]
+        self.assertEqual(active_injection["strategyVariantId"], injection["strategyVariantId"])
+        self.assertEqual(active_injection["parametersSha256"], injection["parametersSha256"])
+        self.assertEqual(active_injection["parametersSha256FromParameters"], injection["parametersSha256"])
+        self.assertEqual(consumption["status"], "consumed")
+        self.assertTrue(consumption["runtimeParameterConsumption"])
+        self.assertEqual(consumption["source"], harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE)
+        self.assertEqual(consumption["consumedTick"], 20)
+        self.assertEqual(consumption["evaluatedParameters"], injection["parameters"])
+        self.assertEqual(consumption["consumedParametersSha256"], injection["parametersSha256"])
+        self.assertEqual(consumption["consumedStrategyVariantId"], injection["strategyVariantId"])
+        self.assertEqual(consumption["fallbackRuntimeParameterConsumptionStatus"], "missing")
+        self.assertFalse(consumption["officialMmoWrites"])
+        self.assertIsNone(
+            harness.runtime_parameter_trainability_smoke_gate_error(
+                runtime_parameter_injection=harness.apply_runtime_parameter_consumption_to_injection(
+                    injection,
+                    consumption,
+                ),
+                runtime_parameter_consumption=consumption,
+                ticks_run=2,
+                active_code_readback=readback,
+            )
+        )
+
+    def test_direct_game_loop_active_code_path_fails_closed_for_invalid_proof_inputs(self) -> None:
+        injection, uploaded_code = self.uploaded_runtime_parameter_injection_with_code(upload_tick=18)
+        readback = harness.private_simulator_active_code_readback_summary(
+            uploaded_code,
+            {"branch": "default", "modules": {"main": uploaded_code}},
+            branch="default",
+            http_status=200,
+        )
+
+        cases = []
+        missing_parameters = copy.deepcopy(injection)
+        missing_parameters.pop("parameters", None)
+        cases.append(("missing_parameters", missing_parameters, readback, [{"tick": 20, "rooms": {"W1N1": {}}}]))
+        mismatched_hash = copy.deepcopy(injection)
+        mismatched_hash["parametersSha256"] = "0" * 64
+        cases.append(("mismatched_hash", mismatched_hash, readback, [{"tick": 20, "rooms": {"W1N1": {}}}]))
+        wrong_variant = copy.deepcopy(injection)
+        wrong_variant["strategyVariantId"] = "construction-priority.pg.wrong-seed.v1"
+        cases.append(("wrong_variant", wrong_variant, readback, [{"tick": 20, "rooms": {"W1N1": {}}}]))
+        unsafe_injection = copy.deepcopy(injection)
+        unsafe_injection["officialMmoWritesAllowed"] = True
+        cases.append(("unsafe_injection", unsafe_injection, readback, [{"tick": 20, "rooms": {"W1N1": {}}}]))
+        unsafe_readback = copy.deepcopy(readback)
+        unsafe_readback["liveEffect"] = True
+        cases.append(("unsafe_readback", injection, unsafe_readback, [{"tick": 20, "rooms": {"W1N1": {}}}]))
+        unsafe_tick = [{"tick": 20, "officialMmoWritesAllowed": True, "rooms": {"W1N1": {}}}]
+        cases.append(("unsafe_tick", injection, readback, unsafe_tick))
+
+        for name, candidate_injection, candidate_readback, tick_log in cases:
+            with self.subTest(name=name):
+                missing = harness.runtime_parameter_consumption_check(candidate_injection, None)
+                consumption = harness.runtime_parameter_consumption_with_direct_game_loop_fallback(
+                    candidate_injection,
+                    missing,
+                    tick_log,
+                    active_code_readback=candidate_readback,
+                )
+
+                self.assertFalse(consumption["runtimeParameterConsumption"])
+                self.assertNotEqual(
+                    consumption.get("source"),
+                    harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE,
+                )
+
+    def test_direct_game_loop_active_code_path_preserves_explicit_false_consumed_signal(self) -> None:
+        injection, uploaded_code = self.uploaded_runtime_parameter_injection_with_code(upload_tick=18)
+        readback = harness.private_simulator_active_code_readback_summary(
+            uploaded_code,
+            {"branch": "default", "modules": {"main": uploaded_code}},
+            branch="default",
+            http_status=200,
+        )
+        missing = harness.runtime_parameter_consumption_check(injection, None)
+
+        consumption = harness.runtime_parameter_consumption_with_direct_game_loop_fallback(
+            injection,
+            missing,
+            [
+                {
+                    "tick": 20,
+                    "runtimeParameterConsumption": False,
+                    "consumedParametersSha256": injection["parametersSha256"],
+                    "consumedStrategyVariantId": injection["strategyVariantId"],
+                }
+            ],
+            active_code_readback=readback,
+        )
+
+        self.assertFalse(consumption["runtimeParameterConsumption"])
+        self.assertEqual(consumption["status"], "missing")
+        self.assertEqual(consumption["directRuntimeEvaluationStatus"], "invalid")
+        self.assertIn("did not mark the payload consumed", consumption["directRuntimeEvaluationReason"])
+
     def test_direct_game_loop_runtime_parameter_consumption_skips_non_numeric_trailing_ticks(self) -> None:
         injection = self.uploaded_runtime_parameter_injection()
         evidence = harness.direct_game_loop_runtime_parameter_consumption_evidence(
@@ -5296,7 +5421,11 @@ cli:
         self.assertEqual(consumption["directRuntimeEvaluationStatus"], "invalid")
         self.assertIn("did not mark the payload consumed", consumption["directRuntimeEvaluationReason"])
 
-    def uploaded_runtime_parameter_injection(self) -> harness.JsonObject:
+    def uploaded_runtime_parameter_injection_with_code(
+        self,
+        *,
+        upload_tick: int | None = None,
+    ) -> tuple[harness.JsonObject, str]:
         base_code = (
             '"use strict";\n'
             f'var runtimePolicyConsumer = "{harness.RUNTIME_PARAMETER_INJECTION_CONSUMER_MARKER}";\n'
@@ -5316,7 +5445,16 @@ cli:
         }
         injection = harness.runtime_parameter_injection_for_variant(variant["id"], variant)
         upload = harness.apply_runtime_parameter_injection_to_code(base_code, injection)
-        return harness.mark_runtime_parameter_injection_uploaded(injection, code_text=upload)
+        uploaded = harness.mark_runtime_parameter_injection_uploaded(
+            injection,
+            code_text=upload,
+            upload_tick=upload_tick,
+        )
+        return uploaded, upload
+
+    def uploaded_runtime_parameter_injection(self) -> harness.JsonObject:
+        uploaded, _upload = self.uploaded_runtime_parameter_injection_with_code()
+        return uploaded
 
     def runtime_parameter_consumption_evidence(self, injection: harness.JsonObject) -> harness.JsonObject:
         return {

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -5262,6 +5262,36 @@ cli:
                     harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE,
                 )
 
+    def test_direct_game_loop_active_code_path_fails_closed_for_tuple_wrapped_unsafe_flags(self) -> None:
+        injection, uploaded_code = self.uploaded_runtime_parameter_injection_with_code(upload_tick=18)
+        readback = harness.private_simulator_active_code_readback_summary(
+            uploaded_code,
+            {"branch": "default", "modules": {"main": uploaded_code}},
+            branch="default",
+            http_status=200,
+        )
+        missing = harness.runtime_parameter_consumption_check(injection, None)
+
+        consumption = harness.runtime_parameter_consumption_with_direct_game_loop_fallback(
+            injection,
+            missing,
+            [
+                {"tick": 19, "rooms": {"W1N1": {"creeps": 1}}},
+                {
+                    "tick": 20,
+                    "rooms": {"W1N1": ({"officialMmoWritesAllowed": True},)},
+                },
+            ],
+            active_code_readback=readback,
+        )
+
+        self.assertFalse(consumption["runtimeParameterConsumption"])
+        self.assertNotEqual(
+            consumption.get("source"),
+            harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE,
+        )
+        self.assertEqual(consumption["directRuntimeEvaluationStatus"], "invalid")
+
     def test_direct_game_loop_active_code_path_preserves_explicit_false_consumed_signal(self) -> None:
         injection, uploaded_code = self.uploaded_runtime_parameter_injection_with_code(upload_tick=18)
         readback = harness.private_simulator_active_code_readback_summary(

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -222,6 +222,7 @@ class MockSimulator:
         include_runtime_consumption_evidence: bool = True,
         include_runtime_consumption_parameters: bool = True,
         include_direct_game_loop_consumption_evidence: bool = False,
+        include_active_code_direct_consumption_evidence: bool = False,
         evaluated_parameters_by_variant: dict[str, JsonObject] | None = None,
         js_runtime_numeric_canonicalization: bool = False,
     ) -> None:
@@ -231,6 +232,7 @@ class MockSimulator:
         self.include_runtime_consumption_evidence = include_runtime_consumption_evidence
         self.include_runtime_consumption_parameters = include_runtime_consumption_parameters
         self.include_direct_game_loop_consumption_evidence = include_direct_game_loop_consumption_evidence
+        self.include_active_code_direct_consumption_evidence = include_active_code_direct_consumption_evidence
         self.evaluated_parameters_by_variant = evaluated_parameters_by_variant or {}
         self.js_runtime_numeric_canonicalization = js_runtime_numeric_canonicalization
         self.calls: list[JsonObject] = []
@@ -263,10 +265,33 @@ class MockSimulator:
                     injection,
                 )
                 self.last_uploaded_code_by_variant[variant_id] = code_text
+                upload_tick = None
+                if self.include_active_code_direct_consumption_evidence:
+                    tick_log = result.get("tick_log")
+                    if isinstance(tick_log, list):
+                        numeric_ticks = [
+                            tick_entry.get("tick")
+                            for tick_entry in tick_log
+                            if isinstance(tick_entry, dict)
+                            and isinstance(tick_entry.get("tick"), int)
+                            and not isinstance(tick_entry.get("tick"), bool)
+                        ]
+                        if numeric_ticks:
+                            upload_tick = min(numeric_ticks) - 1
                 result["runtimeParameterInjection"] = runner.simulator_harness.mark_runtime_parameter_injection_uploaded(
                     injection,
                     code_text=code_text,
+                    upload_tick=upload_tick,
                 )
+                if self.include_active_code_direct_consumption_evidence:
+                    result["activeCodeReadback"] = (
+                        runner.simulator_harness.private_simulator_active_code_readback_summary(
+                            code_text,
+                            {"branch": "default", "modules": {"main": code_text}},
+                            branch="default",
+                            http_status=200,
+                        )
+                    )
                 if variant_id in self.evaluated_parameters_by_variant:
                     evaluated_parameters = copy.deepcopy(self.evaluated_parameters_by_variant[variant_id])
                 else:
@@ -330,17 +355,28 @@ class MockSimulator:
                         result["runtimeParameterInjection"],
                         consumption_evidence,
                     )
-                elif self.include_direct_game_loop_consumption_evidence:
+                elif (
+                    self.include_direct_game_loop_consumption_evidence
+                    or self.include_active_code_direct_consumption_evidence
+                ):
                     runtime_consumption = runner.simulator_harness.runtime_parameter_consumption_check(
                         result["runtimeParameterInjection"],
                         None,
                     )
-                if runtime_consumption is not None and self.include_direct_game_loop_consumption_evidence:
+                if runtime_consumption is not None and (
+                    self.include_direct_game_loop_consumption_evidence
+                    or self.include_active_code_direct_consumption_evidence
+                ):
                     runtime_consumption = (
                         runner.simulator_harness.runtime_parameter_consumption_with_direct_game_loop_fallback(
                             result["runtimeParameterInjection"],
                             runtime_consumption,
                             tick_log if isinstance(tick_log, list) else [],
+                            active_code_readback=(
+                                result.get("activeCodeReadback")
+                                if self.include_active_code_direct_consumption_evidence
+                                else None
+                            ),
                         )
                     )
                 if runtime_consumption is not None:
@@ -4788,6 +4824,77 @@ export const STRATEGY_REGISTRY = [
         )
         self.assertFalse(report["officialMmoWrites"])
         self.assertFalse(report["policyUpdate"]["officialMmoWrites"])
+
+    def test_active_code_direct_consumption_reaches_training_report(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-active-code-direct-consumption",
+            code_commit="f" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-26T03:10:00Z",
+            simulation_ticks=100,
+            simulation_repetitions=1,
+        )
+        variant_ids = [variant["id"] for variant in card["strategy_variants"]]
+        start = tick(1, [room("W1N1", energy=100)])
+        simulator_results = {
+            variant_id: variant_result(variant_id, [start, tick(2, [room("W1N1", energy=200)])])
+            for variant_id in variant_ids
+        }
+        simulator = MockSimulator(
+            simulator_results,
+            inject_runtime_parameters=True,
+            include_runtime_consumption_evidence=False,
+            include_active_code_direct_consumption_evidence=True,
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="policy-gradient-active-code-direct-consumption",
+                generated_at="2026-05-26T03:11:00Z",
+                simulator_runner=simulator,
+            )
+
+        self.assertTrue(report["runtimeParameterInjection"]["runtimeParameterInjection"])
+        self.assertTrue(report["runtimeParameterInjection"]["runtimeParameterConsumption"])
+        self.assertEqual(report["runtimeParameterInjection"]["runtimeParameterConsumptionStatus"], "consumed")
+        self.assertEqual(report["runtimeParameterInjection"]["consumedVariantCount"], len(variant_ids))
+        self.assertTrue(report["policyGradient"]["runner_support"]["runtime_parameter_consumption"])
+        self.assertTrue(report["candidateScorecard"]["runtimeParameterConsumption"])
+        self.assertGreater(report["candidateScorecard"]["consumedVariantCount"], 0)
+        self.assertTrue(
+            all(
+                row["runtimeParameterConsumption"]
+                for row in report["runtimeParameterInjection"]["variants"]
+            )
+        )
+        self.assertTrue(
+            all(
+                row["runtimeParameterConsumptionSource"]
+                == runner.simulator_harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE
+                for row in report["runtimeParameterInjection"]["variants"]
+            )
+        )
+        self.assertTrue(
+            all(
+                result["runtimeParameterConsumption"]["source"]
+                == runner.simulator_harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE
+                for result in simulator.last_variants
+            )
+        )
+        self.assertTrue(
+            all(
+                result["activeCodeReadback"]["activeRuntimeParameterInjection"]["parametersSha256"]
+                == result["runtimeParameterInjection"]["parametersSha256"]
+                for result in simulator.last_variants
+            )
+        )
+        self.assertFalse(report["officialMmoWrites"])
+        self.assertFalse(report["policyUpdate"]["officialMmoWritesAllowed"])
 
     def test_runtime_injected_metadata_ranking_materializes_reinforce_update_without_consumption_probe(self) -> None:
         card = card_helper.build_card(

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -284,11 +284,17 @@ class MockSimulator:
                     upload_tick=upload_tick,
                 )
                 if self.include_active_code_direct_consumption_evidence:
+                    requested_branch = kwargs.get("branch")
+                    readback_branch = runner.simulator_harness.normalize_private_server_code_branch(
+                        requested_branch
+                        if isinstance(requested_branch, str)
+                        else runner.simulator_harness.DEFAULT_ACTIVE_WORLD_BRANCH
+                    )
                     result["activeCodeReadback"] = (
                         runner.simulator_harness.private_simulator_active_code_readback_summary(
                             code_text,
-                            {"branch": "default", "modules": {"main": code_text}},
-                            branch="default",
+                            {"branch": readback_branch, "modules": {"main": code_text}},
+                            branch=readback_branch,
                             http_status=200,
                         )
                     )
@@ -4834,6 +4840,7 @@ export const STRATEGY_REGISTRY = [
             simulation_ticks=100,
             simulation_repetitions=1,
         )
+        card["simulation"]["branch"] = "active-code-direct-consumption-test"
         variant_ids = [variant["id"] for variant in card["strategy_variants"]]
         start = tick(1, [room("W1N1", energy=100)])
         simulator_results = {
@@ -4858,6 +4865,7 @@ export const STRATEGY_REGISTRY = [
                 generated_at="2026-05-26T03:11:00Z",
                 simulator_runner=simulator,
             )
+            scorecard_payload = read_json(Path(report["scorecardArtifactPath"]))
 
         self.assertTrue(report["runtimeParameterInjection"]["runtimeParameterInjection"])
         self.assertTrue(report["runtimeParameterInjection"]["runtimeParameterConsumption"])
@@ -4866,6 +4874,22 @@ export const STRATEGY_REGISTRY = [
         self.assertTrue(report["policyGradient"]["runner_support"]["runtime_parameter_consumption"])
         self.assertTrue(report["candidateScorecard"]["runtimeParameterConsumption"])
         self.assertGreater(report["candidateScorecard"]["consumedVariantCount"], 0)
+        readback_branch = runner.simulator_harness.normalize_private_server_code_branch(
+            card["simulation"]["branch"]
+        )
+        self.assertEqual(simulator.calls[0]["branch"], card["simulation"]["branch"])
+        self.assertTrue(
+            all(
+                result["activeCodeReadback"]["branch"] == readback_branch
+                and result["activeCodeReadback"]["activeBranch"] == readback_branch
+                for result in simulator.last_variants
+            )
+        )
+        self.assertTrue(scorecard_payload["overallGate"]["runtimeCandidateGate"]["runtimeParameterConsumption"])
+        self.assertEqual(
+            scorecard_payload["overallGate"]["runtimeCandidateGate"]["runtimeParameterConsumptionSource"],
+            runner.simulator_harness.RUNTIME_PARAMETER_DIRECT_GAME_LOOP_CONSUMPTION_SOURCE,
+        )
         self.assertTrue(
             all(
                 row["runtimeParameterConsumption"]


### PR DESCRIPTION
## Summary

Follow-up for the post-merge issue 1431 smoke failure after PR #1441. The Tencent guarded smoke `tencent-pg-20260526t022006z` matched active code and executed two ticks, but direct runtime evaluation stayed invalid because the direct evidence did not mark the payload consumed.

This patch accepts direct game-loop runtime consumption only when it is backed by active private-server code readback of the exact injected bundle and matching runtime-parameter metadata. It keeps missing/mismatched/unsafe evidence fail-closed and carries the consumed direct evidence into the training runner report/scorecard rollups so `runtimeParameterConsumption=true` and `consumedVariantCount>0` can be produced by the next guarded smoke.

Related to issue 1431.

## Verification

Controller-side verification from `/root/screeps-worktrees/1431-postmerge-smoke-direct-consumption`:

- [x] `git diff --check`
- [x] `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py`
- [x] `python3 -m unittest scripts.test_screeps_rl_simulator_harness scripts.test_screeps_rl_training_runner -v` — 288 tests OK

## Post-merge validation hold

The linked issue should remain open after this PR merges. After merge, run exactly one guarded post-fix smoke and require machine-readable `runtimeParameterConsumption=true` plus `consumedVariantCount>0` with `officialMmoWrites=false` before resuming paid scale/Tencent validation.
