### PR TITLE
fix(rl): activate runtime objective consumption

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -33626,8 +33626,8 @@ function areRoomsAdjacent(left, right) {
   const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
   if (gameMap && typeof gameMap.describeExits === "function") {
     const exits = gameMap.describeExits(left);
-    if (exits && Object.values(exits).includes(right)) {
-      return true;
+    if (exits) {
+      return Object.values(exits).includes(right);
     }
   }
   const leftCoordinates = parseRoomCoordinates3(left);
@@ -33637,7 +33637,7 @@ function areRoomsAdjacent(left, right) {
   }
   const dx = Math.abs(leftCoordinates.x - rightCoordinates.x);
   const dy = Math.abs(leftCoordinates.y - rightCoordinates.y);
-  return dx <= 1 && dy <= 1 && dx + dy > 0;
+  return dx === 1 && dy === 0 || dx === 0 && dy === 1;
 }
 function parseRoomCoordinates3(roomName) {
   const match = /^(E|W)(\d+)(N|S)(\d+)$/.exec(roomName);
@@ -35645,11 +35645,11 @@ function planDefenseSpawnForContext(context) {
       return localDefenseSpawn;
     }
   }
-  const runtimeObjectiveSpawn = planRuntimePolicyObjectiveDefenseSpawn(context);
-  if (runtimeObjectiveSpawn) {
-    return runtimeObjectiveSpawn;
+  const postClaimDefenseSpawn = planPostClaimControllerDefenseSpawn(context);
+  if (postClaimDefenseSpawn) {
+    return postClaimDefenseSpawn;
   }
-  return planPostClaimControllerDefenseSpawn(context);
+  return planRuntimePolicyObjectiveDefenseSpawn(context);
 }
 function planRuntimePolicyObjectiveDefenseSpawn(context) {
   if (context.survival.hostilePresence || context.survival.controllerDowngradeGuard || context.workerCapacity < Math.min(context.workerTarget, LOCAL_SUPPORT_WORKER_FLOOR)) {
@@ -35659,7 +35659,8 @@ function planRuntimePolicyObjectiveDefenseSpawn(context) {
   if (!objectiveTarget || objectiveTarget.hostileCreepCount <= 0) {
     return null;
   }
-  if (countAssignedRoomDefenders(objectiveTarget.targetRoom) >= getDesiredDefenderCount(objectiveTarget.hostileCreepCount)) {
+  const assignedDefenders = countAssignedRoomDefenders(objectiveTarget.targetRoom);
+  if (assignedDefenders >= getDesiredDefenderCount(objectiveTarget.hostileCreepCount)) {
     return null;
   }
   const spawn = context.colony.spawns.find((candidate) => !candidate.spawning);
@@ -35669,7 +35670,7 @@ function planRuntimePolicyObjectiveDefenseSpawn(context) {
   const defenderPlan = planDefenderSpawn({
     roomName: objectiveTarget.targetRoom,
     hostileCreepCount: objectiveTarget.hostileCreepCount,
-    activeDefenderCount: countAssignedRoomDefenders(objectiveTarget.targetRoom),
+    activeDefenderCount: assignedDefenders,
     energyAvailable: getSpawnEnergyBudget(context.colony),
     gameTime: context.gameTime,
     nameSuffix: context.options.nameSuffix

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -33364,6 +33364,435 @@ function isNonEmptyString24(value) {
   return typeof value === "string" && value.length > 0;
 }
 
+// src/strategy/runtimePolicyParameters.ts
+var RUNTIME_POLICY_PARAMETERS_GLOBAL = "__SCREEPS_RL_RUNTIME_POLICY_PARAMETERS__";
+var RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL = "__SCREEPS_RL_RUNTIME_POLICY_PARAMETER_CONSUMPTION__";
+var RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER = "screeps-rl-runtime-policy-parameters-consumer-v1";
+var RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION = "v1";
+var RUNTIME_POLICY_PARAMETER_CONSUMPTION_LOG_PREFIX = "#runtime-parameter-consumption ";
+var MULTI_TIER_EXPANSION_ACTIVATION_MIN_SCORE = 12;
+function applyRuntimePolicyParametersToRegistry(registry) {
+  var _a;
+  const clonedRegistry = registry.map(cloneStrategyRegistryEntry);
+  const payload = readRuntimePolicyParameterPayload();
+  if (!payload) {
+    const evidence2 = buildConsumptionEvidence({ consumed: false, appliedStrategyIds: [] });
+    publishRuntimePolicyParameterConsumptionEvidence(evidence2);
+    return { registry: clonedRegistry, evidence: evidence2 };
+  }
+  const parameters = normalizeRuntimePolicyParameters(payload.parameters);
+  if (!parameters) {
+    const evidence2 = buildConsumptionEvidence({
+      payload,
+      consumed: false,
+      appliedStrategyIds: [],
+      reason: "runtime policy parameter payload did not include a non-empty parameters object"
+    });
+    publishRuntimePolicyParameterConsumptionEvidence(evidence2);
+    return { registry: clonedRegistry, evidence: evidence2 };
+  }
+  const appliedStrategyIds = [];
+  const targetedStrategyIds = new Set(
+    clonedRegistry.filter((entry) => runtimePolicyPayloadTargetsEntry(payload, entry)).map((entry) => entry.id)
+  );
+  const activatesSingleExplicitTarget = targetedStrategyIds.size === 1 && runtimePolicyPayloadExplicitIds(payload).length > 0;
+  const activatedFamily = activatesSingleExplicitTarget ? (_a = clonedRegistry.find((entry) => targetedStrategyIds.has(entry.id))) == null ? void 0 : _a.family : void 0;
+  const patchedRegistry = clonedRegistry.map((entry) => {
+    if (!targetedStrategyIds.has(entry.id)) {
+      if (activatedFamily !== void 0 && entry.family === activatedFamily && entry.rolloutStatus === "incumbent") {
+        return {
+          ...entry,
+          rolloutStatus: "shadow"
+        };
+      }
+      return entry;
+    }
+    appliedStrategyIds.push(entry.id);
+    return {
+      ...entry,
+      ...activatesSingleExplicitTarget ? { rolloutStatus: "incumbent" } : {},
+      defaultValues: {
+        ...entry.defaultValues,
+        ...parameters
+      }
+    };
+  });
+  const matched = appliedStrategyIds.length > 0;
+  const evidence = buildConsumptionEvidence({
+    payload,
+    consumed: false,
+    parameters,
+    appliedStrategyIds,
+    reason: matched ? "runtime policy parameter payload matched registry entries; awaiting tick runtime strategy evaluation" : "runtime policy parameter payload did not match any strategy registry entry"
+  });
+  publishRuntimePolicyParameterConsumptionEvidence(evidence);
+  return { registry: patchedRegistry, evidence };
+}
+function createRuntimePolicyParameterConsumptionRecorder() {
+  const payload = readRuntimePolicyParameterPayload();
+  const parameters = payload ? normalizeRuntimePolicyParameters(payload.parameters) : null;
+  const appliedStrategyIds = /* @__PURE__ */ new Set();
+  return {
+    recordStrategyRuntimeUse(entry) {
+      if (!payload || !parameters) {
+        return;
+      }
+      if (!runtimePolicyPayloadTargetsEntry(payload, entry)) {
+        return;
+      }
+      if (!strategyEntryUsesRuntimeParameters(entry, parameters)) {
+        return;
+      }
+      appliedStrategyIds.add(entry.id);
+    },
+    buildEvidence() {
+      if (!payload) {
+        return buildConsumptionEvidence({ consumed: false, appliedStrategyIds: [] });
+      }
+      if (!parameters) {
+        return buildConsumptionEvidence({
+          payload,
+          consumed: false,
+          appliedStrategyIds: [],
+          reason: "runtime policy parameter payload did not include a non-empty parameters object"
+        });
+      }
+      const observedStrategyIds = [...appliedStrategyIds].sort();
+      const consumed = observedStrategyIds.length > 0;
+      return buildConsumptionEvidence({
+        payload,
+        consumed,
+        parameters,
+        appliedStrategyIds: observedStrategyIds,
+        reason: consumed ? "runtime policy parameter payload was used by tick runtime strategy evaluation" : "runtime policy parameter payload was not used by tick runtime strategy evaluation"
+      });
+    }
+  };
+}
+function persistRuntimePolicyParameterConsumptionEvidence(evidence) {
+  const memory = runtimeMemoryRoot();
+  const persistedEvidence = stickyRuntimePolicyParameterConsumptionEvidence(
+    evidence,
+    memory.rlRuntimePolicyParameters
+  );
+  const tick = runtimeTick();
+  const tickedEvidence = {
+    ...persistedEvidence,
+    tick
+  };
+  memory.rlRuntimePolicyParameters = tickedEvidence;
+  publishRuntimePolicyParameterConsumptionEvidence(tickedEvidence);
+  emitRuntimePolicyParameterConsumptionEvidence(tickedEvidence);
+}
+function selectRuntimePolicyObjectiveActivationTarget(colonyRoomName) {
+  const payload = readRuntimePolicyParameterPayload();
+  if (!payload || !runtimePolicyPayloadTargetsConstructionPriority(payload)) {
+    return null;
+  }
+  const parameters = normalizeRuntimePolicyParameters(payload.parameters);
+  if (!parameters) {
+    return null;
+  }
+  const activationScore = scoreRuntimePolicyObjectiveActivation(parameters);
+  if (activationScore === null || activationScore < MULTI_TIER_EXPANSION_ACTIVATION_MIN_SCORE) {
+    return null;
+  }
+  return selectVisibleAdjacentHostileObjectiveTarget(colonyRoomName, activationScore);
+}
+function readRuntimePolicyParameterPayload() {
+  const lexicalPayload = runtimePolicyParameterPayloadFromValue(readLexicalRuntimePolicyParameterPayload());
+  if (lexicalPayload) {
+    return lexicalPayload;
+  }
+  for (const root of runtimeGlobalRoots()) {
+    const payload = runtimePolicyParameterPayloadFromValue(root[RUNTIME_POLICY_PARAMETERS_GLOBAL]);
+    if (payload) {
+      return payload;
+    }
+  }
+  return null;
+}
+function readLexicalRuntimePolicyParameterPayload() {
+  try {
+    if (typeof __SCREEPS_RL_RUNTIME_POLICY_PARAMETERS__ !== "undefined") {
+      return __SCREEPS_RL_RUNTIME_POLICY_PARAMETERS__;
+    }
+  } catch (_error) {
+    return void 0;
+  }
+  return void 0;
+}
+function runtimePolicyParameterPayloadFromValue(value) {
+  if (isRecord26(value) && value.runtimeParameterInjection === true && value.candidateParameterScope === "runtime_injected") {
+    return value;
+  }
+  return null;
+}
+function normalizeRuntimePolicyParameters(raw) {
+  if (!isRecord26(raw)) {
+    return null;
+  }
+  const parameters = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (typeof value === "number") {
+      if (Number.isFinite(value)) {
+        parameters[key] = value;
+      }
+    } else if (typeof value === "string" || typeof value === "boolean") {
+      parameters[key] = value;
+    }
+  }
+  return Object.keys(parameters).length > 0 ? parameters : null;
+}
+function runtimePolicyPayloadTargetsEntry(payload, entry) {
+  const explicitIds = runtimePolicyPayloadExplicitIds(payload);
+  const family = textOrUndefined(payload.family);
+  if (explicitIds.length > 0) {
+    return explicitIds.includes(entry.id);
+  }
+  return family !== void 0 && entry.family === family;
+}
+function runtimePolicyPayloadExplicitIds(payload) {
+  return [
+    textOrUndefined(payload.strategyVariantId),
+    textOrUndefined(payload.candidatePolicyId),
+    textOrUndefined(payload.sourceStrategyId)
+  ].filter((id) => id !== void 0);
+}
+function runtimePolicyPayloadTargetsConstructionPriority(payload) {
+  const family = textOrUndefined(payload.family);
+  if (family === "construction-priority") {
+    return true;
+  }
+  return runtimePolicyPayloadExplicitIds(payload).some((id) => id.startsWith("construction-priority."));
+}
+function scoreRuntimePolicyObjectiveActivation(parameters) {
+  var _a, _b, _c;
+  const territorySignalWeight = strategyNumber(parameters.territorySignalWeight);
+  if (territorySignalWeight === null) {
+    return null;
+  }
+  const baseScoreWeight = (_a = strategyNumber(parameters.baseScoreWeight)) != null ? _a : 1;
+  const killSignalWeight = (_b = strategyNumber(parameters.killSignalWeight)) != null ? _b : 0;
+  const riskPenalty = (_c = strategyNumber(parameters.riskPenalty)) != null ? _c : 0;
+  return territorySignalWeight * baseScoreWeight + Math.min(killSignalWeight, 8) * 0.25 - riskPenalty * 0.25;
+}
+function selectVisibleAdjacentHostileObjectiveTarget(colonyRoomName, activationScore) {
+  var _a, _b;
+  if (!isNonEmptyString25(colonyRoomName)) {
+    return null;
+  }
+  const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
+  if (!rooms) {
+    return null;
+  }
+  const candidates = [];
+  for (const [roomName, room] of Object.entries(rooms)) {
+    if (!room || roomName === colonyRoomName || !areRoomsAdjacent(colonyRoomName, roomName)) {
+      continue;
+    }
+    const hostileCreepCount = countRoomFind2(room, "FIND_HOSTILE_CREEPS");
+    const hostileStructureCount = countRoomFind2(room, "FIND_HOSTILE_STRUCTURES");
+    if (hostileCreepCount + hostileStructureCount <= 0) {
+      continue;
+    }
+    candidates.push({
+      colony: colonyRoomName,
+      targetRoom: roomName,
+      hostileCreepCount,
+      hostileStructureCount,
+      activationScore
+    });
+  }
+  return (_b = candidates.sort(compareRuntimePolicyObjectiveActivationTargets)[0]) != null ? _b : null;
+}
+function compareRuntimePolicyObjectiveActivationTargets(left, right) {
+  return right.hostileCreepCount - left.hostileCreepCount || right.hostileStructureCount - left.hostileStructureCount || left.targetRoom.localeCompare(right.targetRoom);
+}
+function countRoomFind2(room, globalName) {
+  const findConstant = globalThis[globalName];
+  if (typeof findConstant !== "number" || typeof room.find !== "function") {
+    return 0;
+  }
+  try {
+    const result = room.find(findConstant);
+    return Array.isArray(result) ? result.length : 0;
+  } catch (_error) {
+    return 0;
+  }
+}
+function areRoomsAdjacent(left, right) {
+  var _a;
+  const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
+  if (gameMap && typeof gameMap.describeExits === "function") {
+    const exits = gameMap.describeExits(left);
+    if (exits && Object.values(exits).includes(right)) {
+      return true;
+    }
+  }
+  const leftCoordinates = parseRoomCoordinates3(left);
+  const rightCoordinates = parseRoomCoordinates3(right);
+  if (!leftCoordinates || !rightCoordinates) {
+    return false;
+  }
+  const dx = Math.abs(leftCoordinates.x - rightCoordinates.x);
+  const dy = Math.abs(leftCoordinates.y - rightCoordinates.y);
+  return dx <= 1 && dy <= 1 && dx + dy > 0;
+}
+function parseRoomCoordinates3(roomName) {
+  const match = /^(E|W)(\d+)(N|S)(\d+)$/.exec(roomName);
+  if (!match) {
+    return null;
+  }
+  const horizontal = match[1] === "E" ? Number(match[2]) : -Number(match[2]) - 1;
+  const vertical = match[3] === "S" ? Number(match[4]) : -Number(match[4]) - 1;
+  return Number.isFinite(horizontal) && Number.isFinite(vertical) ? { x: horizontal, y: vertical } : null;
+}
+function strategyNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+function strategyEntryUsesRuntimeParameters(entry, parameters) {
+  for (const [key, value] of Object.entries(parameters)) {
+    if (entry.defaultValues[key] !== value) {
+      return false;
+    }
+  }
+  return true;
+}
+function buildConsumptionEvidence(options) {
+  var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n;
+  const runtimeParameterInjection = ((_a = options.payload) == null ? void 0 : _a.runtimeParameterInjection) === true && ((_b = options.payload) == null ? void 0 : _b.candidateParameterScope) === "runtime_injected";
+  return {
+    type: "screeps-rl-runtime-policy-parameter-consumption",
+    consumerMarker: RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER,
+    consumerVersion: RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION,
+    runtimeParameterInjection,
+    consumed: options.consumed,
+    ...textOrUndefined((_c = options.payload) == null ? void 0 : _c.strategyVariantId) ? { strategyVariantId: textOrUndefined((_d = options.payload) == null ? void 0 : _d.strategyVariantId) } : {},
+    ...textOrUndefined((_e = options.payload) == null ? void 0 : _e.candidatePolicyId) ? { candidatePolicyId: textOrUndefined((_f = options.payload) == null ? void 0 : _f.candidatePolicyId) } : {},
+    ...textOrUndefined((_g = options.payload) == null ? void 0 : _g.family) ? { family: textOrUndefined((_h = options.payload) == null ? void 0 : _h.family) } : {},
+    ...options.parameters ? { parameters: options.parameters } : {},
+    ...textOrUndefined((_i = options.payload) == null ? void 0 : _i.parametersSha256) ? { parametersSha256: textOrUndefined((_j = options.payload) == null ? void 0 : _j.parametersSha256) } : {},
+    ...options.consumed && textOrUndefined((_k = options.payload) == null ? void 0 : _k.strategyVariantId) ? { consumedStrategyVariantId: textOrUndefined((_l = options.payload) == null ? void 0 : _l.strategyVariantId) } : {},
+    ...options.consumed && textOrUndefined((_m = options.payload) == null ? void 0 : _m.parametersSha256) ? { consumedParametersSha256: textOrUndefined((_n = options.payload) == null ? void 0 : _n.parametersSha256) } : {},
+    appliedStrategyIds: [...options.appliedStrategyIds].sort(),
+    ...options.reason ? { reason: options.reason } : {},
+    liveEffect: false,
+    officialMmoWrites: false,
+    officialMmoWritesAllowed: false
+  };
+}
+function publishRuntimePolicyParameterConsumptionEvidence(evidence) {
+  for (const root of runtimeGlobalRoots()) {
+    root[RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL] = evidence;
+  }
+}
+function emitRuntimePolicyParameterConsumptionEvidence(evidence) {
+  if (evidence.runtimeParameterInjection !== true) {
+    return;
+  }
+  try {
+    console.log(`${RUNTIME_POLICY_PARAMETER_CONSUMPTION_LOG_PREFIX}${JSON.stringify(evidence)}`);
+  } catch (_error) {
+  }
+}
+function stickyRuntimePolicyParameterConsumptionEvidence(evidence, previous) {
+  if (evidence.consumed || !shouldCarryRuntimePolicyParameterConsumptionEvidence(evidence, previous)) {
+    return cloneRuntimePolicyParameterConsumptionEvidence(evidence);
+  }
+  return cloneRuntimePolicyParameterConsumptionEvidence(previous);
+}
+function shouldCarryRuntimePolicyParameterConsumptionEvidence(evidence, previous) {
+  if (!previous || previous.consumed !== true) {
+    return false;
+  }
+  if (evidence.runtimeParameterInjection !== true || previous.runtimeParameterInjection !== true) {
+    return false;
+  }
+  if (!evidence.parameters || !previous.parameters) {
+    return false;
+  }
+  if (evidence.consumerMarker !== RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER || previous.consumerMarker !== RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER || evidence.consumerVersion !== RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION || previous.consumerVersion !== RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION) {
+    return false;
+  }
+  const currentHash = textOrUndefined(evidence.parametersSha256);
+  const previousHash = textOrUndefined(previous.parametersSha256);
+  if (!currentHash || currentHash !== previousHash) {
+    return false;
+  }
+  return sameOptionalText(evidence.strategyVariantId, previous.strategyVariantId) && sameOptionalText(evidence.candidatePolicyId, previous.candidatePolicyId) && sameOptionalText(evidence.family, previous.family);
+}
+function cloneRuntimePolicyParameterConsumptionEvidence(evidence) {
+  const cloned = { ...evidence };
+  delete cloned.tick;
+  return {
+    ...cloned,
+    ...evidence.parameters ? { parameters: { ...evidence.parameters } } : {},
+    appliedStrategyIds: [...evidence.appliedStrategyIds]
+  };
+}
+function sameOptionalText(left, right) {
+  return textOrUndefined(left) === textOrUndefined(right);
+}
+function cloneStrategyRegistryEntry(entry) {
+  return {
+    ...entry,
+    defaultValues: { ...entry.defaultValues },
+    evidenceLinks: entry.evidenceLinks.map((link) => ({ ...link })),
+    rollback: {
+      ...entry.rollback,
+      stopConditions: [...entry.rollback.stopConditions]
+    },
+    supportedContext: {
+      ...entry.supportedContext,
+      artifactTypes: [...entry.supportedContext.artifactTypes],
+      ...entry.supportedContext.shards ? { shards: [...entry.supportedContext.shards] } : {},
+      ...entry.supportedContext.rooms ? { rooms: [...entry.supportedContext.rooms] } : {}
+    },
+    knobBounds: entry.knobBounds.map((knob) => ({ ...knob, bounds: { ...knob.bounds } }))
+  };
+}
+function textOrUndefined(value) {
+  return typeof value === "string" && value.length > 0 ? value : void 0;
+}
+function isNonEmptyString25(value) {
+  return typeof value === "string" && value.length > 0;
+}
+function runtimeMemoryRoot() {
+  if (typeof Memory !== "undefined") {
+    return Memory;
+  }
+  const root = globalThis;
+  if (!root.Memory) {
+    root.Memory = {};
+  }
+  return root.Memory;
+}
+function runtimeGlobalRoots() {
+  const roots = [];
+  const root = globalThis;
+  addRuntimeGlobalRoot(roots, globalThis);
+  addRuntimeGlobalRoot(roots, root.global);
+  addRuntimeGlobalRoot(roots, root.self);
+  return roots;
+}
+function addRuntimeGlobalRoot(roots, value) {
+  if (!isRecord26(value) || roots.includes(value)) {
+    return;
+  }
+  roots.push(value);
+}
+function runtimeTick() {
+  var _a, _b;
+  if (typeof Game !== "undefined" && typeof Game.time === "number") {
+    return Game.time;
+  }
+  return (_b = (_a = globalThis.Game) == null ? void 0 : _a.time) != null ? _b : 0;
+}
+function isRecord26(value) {
+  return typeof value === "object" && value !== null;
+}
+
 // src/economy/creepBodyScaling.ts
 var MAX_CREEP_PARTS6 = 50;
 var BODY_PART_COSTS2 = {
@@ -33669,18 +34098,18 @@ function getHaulerDeliveryRoomName(creep) {
     return void 0;
   }
   const localRoomName = (_c = creep.memory.energyHauler) == null ? void 0 : _c.roomName;
-  if (isNonEmptyString25(localRoomName) && (((_d = creep.room) == null ? void 0 : _d.name) === void 0 || creep.room.name === localRoomName || ((_e = creep.memory.task) == null ? void 0 : _e.type) === "transfer")) {
+  if (isNonEmptyString26(localRoomName) && (((_d = creep.room) == null ? void 0 : _d.name) === void 0 || creep.room.name === localRoomName || ((_e = creep.memory.task) == null ? void 0 : _e.type) === "transfer")) {
     return localRoomName;
   }
   const remoteHomeRoom = (_f = creep.memory.remoteHauler) == null ? void 0 : _f.homeRoom;
-  return isNonEmptyString25(remoteHomeRoom) ? remoteHomeRoom : void 0;
+  return isNonEmptyString26(remoteHomeRoom) ? remoteHomeRoom : void 0;
 }
 function getCrossRoomHaulerDeliveryRoomName(creep) {
   if (isCollectingEnergyTask(creep.memory.task)) {
     return void 0;
   }
   const assignment = creep.memory.crossRoomHauler;
-  if (!isNonEmptyString25(assignment == null ? void 0 : assignment.targetRoom)) {
+  if (!isNonEmptyString26(assignment == null ? void 0 : assignment.targetRoom)) {
     return void 0;
   }
   if (assignment.state !== void 0 && assignment.state !== "delivering") {
@@ -33691,7 +34120,7 @@ function getCrossRoomHaulerDeliveryRoomName(creep) {
 function isCollectingEnergyTask(task) {
   return (task == null ? void 0 : task.type) === "harvest" || (task == null ? void 0 : task.type) === "pickup" || (task == null ? void 0 : task.type) === "withdraw";
 }
-function isNonEmptyString25(value) {
+function isNonEmptyString26(value) {
   return typeof value === "string" && value.length > 0;
 }
 function getStoredEnergy21(target) {
@@ -33738,7 +34167,7 @@ var ROUTE_DISTANCE_CACHE_TTL_TICKS = 300;
 function recordPlannedMultiRoomUpgraderSpawn(memory) {
   var _a, _b;
   const sustain = memory.controllerSustain;
-  if (memory.role !== "worker" || (sustain == null ? void 0 : sustain.role) !== "upgrader" || !isNonEmptyString26(sustain.homeRoom) || !isNonEmptyString26(sustain.targetRoom)) {
+  if (memory.role !== "worker" || (sustain == null ? void 0 : sustain.role) !== "upgrader" || !isNonEmptyString27(sustain.homeRoom) || !isNonEmptyString27(sustain.targetRoom)) {
     return;
   }
   const cache = getActiveMultiRoomUpgraderCountCache();
@@ -33830,11 +34259,11 @@ function getVisibleMultiRoomUpgradeCandidates(colony, config, hasStorageSurplus)
 }
 function getVisibleMultiRoomUpgradeCandidate(homeRoom, room, config, activeUpgraderCounts, order, hasStorageSurplus) {
   var _a, _b;
-  if (!isNonEmptyString26(room.name) || room.name === homeRoom || isKnownDeadZoneRoom(room.name)) {
+  if (!isNonEmptyString27(room.name) || room.name === homeRoom || isKnownDeadZoneRoom(room.name)) {
     return null;
   }
   const controller = room.controller;
-  if (!controller || !isNonEmptyString26(controller.id)) {
+  if (!controller || !isNonEmptyString27(controller.id)) {
     return null;
   }
   const controllerState = getEligibleControllerState(controller);
@@ -33891,7 +34320,7 @@ function getPostClaimControllerUpgradeProgression(homeRoom, targetRoom, controll
   return getControllerLevel2(controller) < desiredControllerLevel ? { desiredControllerLevel } : null;
 }
 function isPostClaimControllerUpgradeRecord(record, homeRoom, targetRoom) {
-  return isRecord26(record) && record.colony === homeRoom && record.roomName === targetRoom && isPostClaimControllerUpgradeStatus(record.status);
+  return isRecord27(record) && record.colony === homeRoom && record.roomName === targetRoom && isPostClaimControllerUpgradeStatus(record.status);
 }
 function isPostClaimControllerUpgradeStatus(status) {
   return status === "detected" || status === "spawnSitePending" || status === "spawnSiteBlocked" || status === "spawningWorkers" || status === "ready";
@@ -33941,7 +34370,7 @@ function hasActiveClaimedRoomSpawnConstructionSite(room) {
   }
 }
 function isActiveSpawnConstructionSite(site) {
-  return isRecord26(site) && matchesStructureType24(site.structureType, "STRUCTURE_SPAWN", "spawn") && hasIncompleteConstructionSiteProgress(site);
+  return isRecord27(site) && matchesStructureType24(site.structureType, "STRUCTURE_SPAWN", "spawn") && hasIncompleteConstructionSiteProgress(site);
 }
 function hasIncompleteConstructionSiteProgress(site) {
   const progress = site.progress;
@@ -34003,7 +34432,7 @@ function countActiveMultiRoomUpgradersByHomeRoom(creeps) {
   const countsByHomeRoom = {};
   for (const creep of Object.values(creeps)) {
     const sustain = (_a = creep.memory) == null ? void 0 : _a.controllerSustain;
-    if ((sustain == null ? void 0 : sustain.role) !== "upgrader" || !isNonEmptyString26(sustain.homeRoom) || !isNonEmptyString26(sustain.targetRoom) || !isActiveMultiRoomUpgrader(creep)) {
+    if ((sustain == null ? void 0 : sustain.role) !== "upgrader" || !isNonEmptyString27(sustain.homeRoom) || !isNonEmptyString27(sustain.targetRoom) || !isActiveMultiRoomUpgrader(creep)) {
       continue;
     }
     const countsByTarget = (_b = countsByHomeRoom[sustain.homeRoom]) != null ? _b : {};
@@ -34115,13 +34544,13 @@ function getTerritoryRouteDistanceCache3(gameTime) {
   if (!memory) {
     return void 0;
   }
-  if (!isRecord26(memory.territory)) {
+  if (!isRecord27(memory.territory)) {
     memory.territory = {};
   }
-  if (!isRecord26(memory.territory.routeDistances)) {
+  if (!isRecord27(memory.territory.routeDistances)) {
     memory.territory.routeDistances = {};
   }
-  if (!isRecord26(memory.territory.routeDistancesUpdatedAt)) {
+  if (!isRecord27(memory.territory.routeDistancesUpdatedAt)) {
     memory.territory.routeDistancesUpdatedAt = {};
   }
   const distances = memory.territory.routeDistances;
@@ -34169,7 +34598,7 @@ function isAdjacentRoom(fromRoom, targetRoom) {
     return false;
   }
   const exits = gameMap.describeExits(fromRoom);
-  if (!isRecord26(exits)) {
+  if (!isRecord27(exits)) {
     return false;
   }
   return Object.values(exits).some((roomName) => roomName === targetRoom);
@@ -34183,10 +34612,10 @@ function getGameTime31() {
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
-function isRecord26(value) {
+function isRecord27(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString26(value) {
+function isNonEmptyString27(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -34223,7 +34652,7 @@ function buildControllerManagementPlan(colony, roleCounts, workerTarget, gameTim
   var _a, _b, _c, _d, _e;
   const roomName = colony.room.name;
   const controller = colony.room.controller;
-  if ((controller == null ? void 0 : controller.my) !== true || !isNonEmptyString27(controller.id)) {
+  if ((controller == null ? void 0 : controller.my) !== true || !isNonEmptyString28(controller.id)) {
     return {
       roomName,
       updatedAt: gameTime,
@@ -34546,7 +34975,7 @@ function normalizeDesiredControllerLevel(value) {
 function getControllerTicksToDowngradeField(controller) {
   return typeof controller.ticksToDowngrade === "number" && Number.isFinite(controller.ticksToDowngrade) ? { ticksToDowngrade: controller.ticksToDowngrade } : {};
 }
-function isNonEmptyString27(value) {
+function isNonEmptyString28(value) {
   return typeof value === "string" && value.length > 0;
 }
 function normalizeNonNegativeInteger13(value) {
@@ -35114,7 +35543,7 @@ function selectPostClaimControllerSustainPlan(colony) {
 function getPostClaimControllerSustainRecords(colonyName) {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord27(records)) {
+  if (!isRecord28(records)) {
     return [];
   }
   return Object.values(records).filter(
@@ -35122,7 +35551,7 @@ function getPostClaimControllerSustainRecords(colonyName) {
   ).sort(comparePostClaimControllerSustainRecords);
 }
 function isPostClaimControllerSustainRecord(record, colonyName) {
-  return isRecord27(record) && record.colony === colonyName && record.roomName !== colonyName && isNonEmptyString28(record.roomName) && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
+  return isRecord28(record) && record.colony === colonyName && record.roomName !== colonyName && isNonEmptyString29(record.roomName) && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
 }
 function comparePostClaimControllerSustainRecords(left, right) {
   const leftHasSpawn = hasOperationalSpawnInRoom(left.roomName);
@@ -35216,7 +35645,42 @@ function planDefenseSpawnForContext(context) {
       return localDefenseSpawn;
     }
   }
+  const runtimeObjectiveSpawn = planRuntimePolicyObjectiveDefenseSpawn(context);
+  if (runtimeObjectiveSpawn) {
+    return runtimeObjectiveSpawn;
+  }
   return planPostClaimControllerDefenseSpawn(context);
+}
+function planRuntimePolicyObjectiveDefenseSpawn(context) {
+  if (context.survival.hostilePresence || context.survival.controllerDowngradeGuard || context.workerCapacity < Math.min(context.workerTarget, LOCAL_SUPPORT_WORKER_FLOOR)) {
+    return null;
+  }
+  const objectiveTarget = selectRuntimePolicyObjectiveActivationTarget(context.colony.room.name);
+  if (!objectiveTarget || objectiveTarget.hostileCreepCount <= 0) {
+    return null;
+  }
+  if (countAssignedRoomDefenders(objectiveTarget.targetRoom) >= getDesiredDefenderCount(objectiveTarget.hostileCreepCount)) {
+    return null;
+  }
+  const spawn = context.colony.spawns.find((candidate) => !candidate.spawning);
+  if (!spawn) {
+    return null;
+  }
+  const defenderPlan = planDefenderSpawn({
+    roomName: objectiveTarget.targetRoom,
+    hostileCreepCount: objectiveTarget.hostileCreepCount,
+    activeDefenderCount: countAssignedRoomDefenders(objectiveTarget.targetRoom),
+    energyAvailable: getSpawnEnergyBudget(context.colony),
+    gameTime: context.gameTime,
+    nameSuffix: context.options.nameSuffix
+  });
+  if (!defenderPlan) {
+    return null;
+  }
+  return {
+    spawn,
+    ...defenderPlan
+  };
 }
 function planDefenseSpawnForRoom(colony, activeDefenderCount, gameTime, options) {
   const hostileCount = getRoomHostileCreepCount(colony.room);
@@ -35590,16 +36054,16 @@ function hasExpansionClaimSpawnDemand(colonyName) {
 function hasActiveExpansionClaimPipeline(territory, colonyName) {
   var _a;
   const pipeline = (_a = territory.expansionPipelines) == null ? void 0 : _a[colonyName];
-  return isRecord27(pipeline) && pipeline.status === "active" && pipeline.stage === "claiming" && pipeline.targetRoom !== colonyName;
+  return isRecord28(pipeline) && pipeline.status === "active" && pipeline.stage === "claiming" && pipeline.targetRoom !== colonyName;
 }
 function hasRunnableExpansionClaimIntent(territory, colonyName) {
   return Array.isArray(territory.intents) ? territory.intents.some(
-    (intent) => isRecord27(intent) && intent.colony === colonyName && intent.targetRoom !== colonyName && intent.action === "claim" && (intent.status === "planned" || intent.status === "active") && isExpansionClaimSource(intent.createdBy)
+    (intent) => isRecord28(intent) && intent.colony === colonyName && intent.targetRoom !== colonyName && intent.action === "claim" && (intent.status === "planned" || intent.status === "active") && isExpansionClaimSource(intent.createdBy)
   ) : false;
 }
 function hasRunnableExpansionClaimTarget(territory, colonyName) {
   return Array.isArray(territory.targets) ? territory.targets.some(
-    (target) => isRecord27(target) && target.colony === colonyName && target.roomName !== colonyName && target.enabled !== false && target.action === "claim" && isExpansionClaimSource(target.createdBy)
+    (target) => isRecord28(target) && target.colony === colonyName && target.roomName !== colonyName && target.enabled !== false && target.action === "claim" && isExpansionClaimSource(target.createdBy)
   ) : false;
 }
 function isExpansionClaimSource(source) {
@@ -35930,10 +36394,10 @@ function getStorageBalanceMemory() {
   var _a, _b;
   return (_b = (_a = globalThis.Memory) == null ? void 0 : _a.economy) == null ? void 0 : _b.storageBalance;
 }
-function isRecord27(value) {
+function isRecord28(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString28(value) {
+function isNonEmptyString29(value) {
   return typeof value === "string" && value.length > 0;
 }
 function findRoomObjects27(room, globalName) {
@@ -36298,7 +36762,7 @@ function normalizeRemoteHarvesterMemory2(creep) {
     return null;
   }
   const assignment = creep.memory.remoteHarvester;
-  if (!isRecord28(assignment) || typeof assignment.homeRoom !== "string" || assignment.homeRoom.length === 0 || typeof assignment.targetRoom !== "string" || assignment.targetRoom.length === 0 || assignment.homeRoom === assignment.targetRoom || typeof assignment.sourceId !== "string" || assignment.sourceId.length === 0) {
+  if (!isRecord29(assignment) || typeof assignment.homeRoom !== "string" || assignment.homeRoom.length === 0 || typeof assignment.targetRoom !== "string" || assignment.targetRoom.length === 0 || assignment.homeRoom === assignment.targetRoom || typeof assignment.sourceId !== "string" || assignment.sourceId.length === 0) {
     return null;
   }
   return assignment;
@@ -36350,7 +36814,7 @@ function getEnergyResource23() {
   var _a;
   return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
 }
-function isRecord28(value) {
+function isRecord29(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -36465,12 +36929,12 @@ function groupCreepsByColony(creeps, colonies) {
   const colonyNames = new Set(colonies.map((colony) => colony.room.name));
   for (const creep of creeps) {
     const colonyName = creep.memory.colony;
-    if (isNonEmptyString29(colonyName)) {
+    if (isNonEmptyString30(colonyName)) {
       addCreepToColonyGroup(creepsByColony, colonyName, creep);
       continue;
     }
     const roomName = (_a = creep.room) == null ? void 0 : _a.name;
-    if (creep.memory.role === "worker" && isNonEmptyString29(roomName) && colonyNames.has(roomName) && isRoomLocalWorkerName(creep, roomName)) {
+    if (creep.memory.role === "worker" && isNonEmptyString30(roomName) && colonyNames.has(roomName) && isRoomLocalWorkerName(creep, roomName)) {
       addCreepToColonyGroup(creepsByColony, roomName, creep);
     }
   }
@@ -36485,7 +36949,7 @@ function addCreepToColonyGroup(creepsByColony, colonyName, creep) {
 function isRoomLocalWorkerName(creep, roomName) {
   return typeof creep.name === "string" && creep.name.startsWith(`worker-${roomName}-`);
 }
-function isNonEmptyString29(value) {
+function isNonEmptyString30(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber11(value) {
@@ -36676,7 +37140,7 @@ function getStaleScoutIntelTargetRooms(summary, gameTime) {
   );
 }
 function getUniqueSortedRoomNames(roomNames) {
-  return [...new Set(roomNames.filter(isNonEmptyString29))].sort();
+  return [...new Set(roomNames.filter(isNonEmptyString30))].sort();
 }
 function buildScoutOnlyTargetSummaries(colony, summary) {
   var _a, _b;
@@ -36725,7 +37189,7 @@ function getScoutOnlyExpansionCandidatesByRoom(colonyName) {
   }
   const candidatesByRoom = /* @__PURE__ */ new Map();
   for (const rawCandidate of candidates) {
-    if (!isRecord29(rawCandidate) || rawCandidate.colony !== colonyName || rawCandidate.scoutOnly !== true || !isNonEmptyString29(rawCandidate.roomName)) {
+    if (!isRecord30(rawCandidate) || rawCandidate.colony !== colonyName || rawCandidate.scoutOnly !== true || !isNonEmptyString30(rawCandidate.roomName)) {
       continue;
     }
     candidatesByRoom.set(rawCandidate.roomName, {
@@ -36742,10 +37206,10 @@ function getScoutOnlyExpansionCandidatesByRoom(colonyName) {
   return candidatesByRoom;
 }
 function isPostClaimBootstrapBlockerMemory(value) {
-  return isRecord29(value) && isNonEmptyString29(value.colony) && isNonEmptyString29(value.roomName) && isPostClaimBootstrapStatus2(value.status) && isFiniteNumber11(value.updatedAt) && isFiniteNumber11(value.age) && isFiniteNumber11(value.workerTarget) && isFiniteNumber11(value.spawnCount) && isFiniteNumber11(value.workerCount);
+  return isRecord30(value) && isNonEmptyString30(value.colony) && isNonEmptyString30(value.roomName) && isPostClaimBootstrapStatus2(value.status) && isFiniteNumber11(value.updatedAt) && isFiniteNumber11(value.age) && isFiniteNumber11(value.workerTarget) && isFiniteNumber11(value.spawnCount) && isFiniteNumber11(value.workerCount);
 }
 function isPostClaimBootstrapIgnoredBlockerMemory(value) {
-  if (!isRecord29(value)) {
+  if (!isRecord30(value)) {
     return false;
   }
   const reason = value.reason;
@@ -36933,7 +37397,7 @@ function isRecentWorkerTaskBehaviorSample(sample, tick) {
   return sample.tick <= tick && sample.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL;
 }
 function isWorkerTaskBehaviorSample(value) {
-  return isRecord29(value) && value.type === "workerTaskBehavior" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && isRecord29(value.state) && isRecord29(value.action) && isWorkerTaskBehaviorActionType(value.action.type) && typeof value.action.targetId === "string";
+  return isRecord30(value) && value.type === "workerTaskBehavior" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && isRecord30(value.state) && isRecord30(value.action) && isWorkerTaskBehaviorActionType(value.action.type) && typeof value.action.targetId === "string";
 }
 function isRecentWorkerTaskPolicyShadow(value, tick) {
   if (!isWorkerTaskPolicyShadow(value)) {
@@ -36942,7 +37406,7 @@ function isRecentWorkerTaskPolicyShadow(value, tick) {
   return tick <= 0 || value.tick <= tick && value.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL;
 }
 function isWorkerTaskPolicyShadow(value) {
-  return isRecord29(value) && value.type === "workerTaskPolicyShadow" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && typeof value.matched === "boolean";
+  return isRecord30(value) && value.type === "workerTaskPolicyShadow" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && typeof value.matched === "boolean";
 }
 function shouldBuildStructureSnapshot(tick) {
   return tick > 0 && tick % RUNTIME_SUMMARY_INTERVAL === 0;
@@ -36981,7 +37445,7 @@ function countConstructionSitesByType(constructionSites, globalName, fallback) {
   return constructionSites.filter((site) => isStructureOfType(site, globalName, fallback)).length;
 }
 function countOwnedRamparts(structures) {
-  return structures.filter((structure) => isRecord29(structure) && isObservedOwnedRampart(structure)).length;
+  return structures.filter((structure) => isRecord30(structure) && isObservedOwnedRampart(structure)).length;
 }
 function summarizeContainers(structures) {
   return structures.filter((structure) => isStructureOfType(structure, "STRUCTURE_CONTAINER", "container")).map(toRuntimeContainerSnapshot).filter((summary) => summary !== null).sort((left, right) => left.id.localeCompare(right.id));
@@ -37018,7 +37482,7 @@ function summarizeRepairTargetDistribution(colonyWorkers, roomStructures) {
   return [...repairCounts.entries()].sort(([leftTargetId], [rightTargetId]) => leftTargetId.localeCompare(rightTargetId)).map(([targetId, repairCount]) => toRuntimeRepairTargetSnapshot(targetId, repairCount, structuresById.get(targetId)));
 }
 function toRuntimeRepairTargetSnapshot(targetId, repairCount, structure) {
-  const structureRecord = isRecord29(structure) ? structure : {};
+  const structureRecord = isRecord30(structure) ? structure : {};
   const structureType = typeof structureRecord.structureType === "string" ? structureRecord.structureType : void 0;
   const hits = getFiniteNumber(structureRecord.hits);
   const hitsMax = getFiniteNumber(structureRecord.hitsMax);
@@ -37031,7 +37495,7 @@ function toRuntimeRepairTargetSnapshot(targetId, repairCount, structure) {
   };
 }
 function isStructureOfType(structure, globalName, fallback) {
-  return isRecord29(structure) && matchesStructureType26(structure.structureType, globalName, fallback);
+  return isRecord30(structure) && matchesStructureType26(structure.structureType, globalName, fallback);
 }
 function calculateRoadCoverageRatio(roadCount, pendingRoadSiteCount) {
   const totalKnownRoadWork = roadCount + pendingRoadSiteCount;
@@ -37234,7 +37698,7 @@ function isRecentRefillDeliverySample(sample, tick) {
   return isRefillDeliverySample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - REFILL_DELIVERY_SAMPLE_TTL);
 }
 function isRefillDeliverySample(value) {
-  return isRecord29(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
+  return isRecord30(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
 }
 function roundRatio6(numerator, denominator) {
   if (denominator <= 0) {
@@ -37249,7 +37713,7 @@ function isRecentWorkerEfficiencySample(sample, tick) {
   return sample.tick <= tick && sample.tick > tick - WORKER_EFFICIENCY_SAMPLE_TTL;
 }
 function isWorkerEfficiencySample(value) {
-  if (!isRecord29(value)) {
+  if (!isRecord30(value)) {
     return false;
   }
   return (value.type === "lowLoadReturn" || value.type === "nearbyEnergyChoice") && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && isWorkerEfficiencyTaskType(value.selectedTask) && typeof value.targetId === "string";
@@ -37290,7 +37754,7 @@ function isRecentSpawnCriticalRefillSample(sample, tick) {
   return isSpawnCriticalRefillSample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - SPAWN_CRITICAL_REFILL_SAMPLE_TTL);
 }
 function isSpawnCriticalRefillSample(value) {
-  return isRecord29(value) && value.type === "spawnCriticalRefill" && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.spawnEnergy === "number" && Number.isFinite(value.spawnEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && typeof value.threshold === "number" && Number.isFinite(value.threshold);
+  return isRecord30(value) && value.type === "spawnCriticalRefill" && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.spawnEnergy === "number" && Number.isFinite(value.spawnEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && typeof value.threshold === "number" && Number.isFinite(value.threshold);
 }
 function getCreepName2(creep) {
   const name = creep.name;
@@ -37317,7 +37781,7 @@ function buildControllerSummary(room) {
   return { controller: summary };
 }
 function summarizeControllerSign(sign) {
-  if (!isRecord29(sign)) {
+  if (!isRecord30(sign)) {
     return null;
   }
   const datetime = summarizeControllerSignDatetime(sign.datetime);
@@ -37404,7 +37868,7 @@ function getDirectRoomEnergyStructures2(room) {
   );
 }
 function isRoomEnergyStoreStructure(structure) {
-  if (!isRecord29(structure)) {
+  if (!isRecord30(structure)) {
     return false;
   }
   return matchesStructureType26(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType26(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType26(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType26(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType26(structure.structureType, "STRUCTURE_LINK", "link") || matchesStructureType26(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
@@ -37616,7 +38080,7 @@ function canSpendWorkerEnergyOnAnyConstructionSiteForTelemetry(room, carriedEner
   return constructionSites.some((site) => canSpendWorkerEnergyOnConstructionSiteForTelemetry(room, carriedEnergy, site));
 }
 function canSpendWorkerEnergyOnConstructionSiteForTelemetry(room, carriedEnergy, constructionSite) {
-  if (!isRecord29(constructionSite)) {
+  if (!isRecord30(constructionSite)) {
     return checkEnergyBufferForConstructionSpending(room);
   }
   if (matchesStructureType26(constructionSite.structureType, "STRUCTURE_EXTENSION", "extension")) {
@@ -37740,7 +38204,7 @@ function hasSpawnReservedConstructionEnergy(colony, roomEnergyStructures, energy
   return spawnEnergy > 0 && getRoomEnergyAvailable13(colony) > energyBuffer.threshold;
 }
 function isSpawnEnergyStructure(structure) {
-  return isRecord29(structure) && matchesStructureType26(structure.structureType, "STRUCTURE_SPAWN", "spawn");
+  return isRecord30(structure) && matchesStructureType26(structure.structureType, "STRUCTURE_SPAWN", "spawn");
 }
 function isBuildBlockedByEnergyBuffer(colony, assignedCarriedEnergy) {
   const energyAvailable = getRoomEnergyAvailable13(colony);
@@ -37784,7 +38248,7 @@ function sumPendingBuildProgress(constructionSites) {
   return constructionSites.reduce((total, constructionSite) => total + getPendingBuildProgress(constructionSite), 0);
 }
 function getPendingBuildProgress(constructionSite) {
-  if (!isRecord29(constructionSite)) {
+  if (!isRecord30(constructionSite)) {
     return 0;
   }
   const progress = getFiniteNumber(constructionSite.progress);
@@ -37798,7 +38262,7 @@ function sumRepairBacklogHits(roomStructures) {
   return roomStructures.reduce((total, structure) => total + getRepairBacklogHits(structure), 0);
 }
 function getRepairBacklogHits(structure) {
-  if (!isRecord29(structure) || !isObservableRepairBacklogStructure(structure)) {
+  if (!isRecord30(structure) || !isObservableRepairBacklogStructure(structure)) {
     return 0;
   }
   const hits = getFiniteNumber(structure.hits);
@@ -38060,10 +38524,10 @@ function summarizeRoomEventMetrics(room, refillTargetIds = getSpawnExtensionEner
   let hasResourceEvents = false;
   let hasCombatEvents = false;
   for (const entry of eventLog) {
-    if (!isRecord29(entry) || typeof entry.event !== "number") {
+    if (!isRecord30(entry) || typeof entry.event !== "number") {
       continue;
     }
-    const data = isRecord29(entry.data) ? entry.data : {};
+    const data = isRecord30(entry.data) ? entry.data : {};
     if (entry.event === harvestEvent && isEnergyEventData(data)) {
       resourceEvents.harvestedEnergy += getNumericEventData(data, "amount");
       hasResourceEvents = true;
@@ -38129,7 +38593,7 @@ function getSpawnExtensionEnergyStructureIds(room) {
   return ids;
 }
 function isSpawnExtensionEnergyStructure2(structure) {
-  return isRecord29(structure) && (matchesStructureType26(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType26(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
+  return isRecord30(structure) && (matchesStructureType26(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType26(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
 }
 function getEventTargetId(data) {
   return typeof data.targetId === "string" && data.targetId.length > 0 ? data.targetId : null;
@@ -38138,7 +38602,7 @@ function buildEventObjectId(entry) {
   return typeof entry.objectId === "string" && entry.objectId.length > 0 ? { objectId: entry.objectId } : {};
 }
 function getObjectId13(value) {
-  return isRecord29(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
+  return isRecord30(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
 }
 function findRoomObjects29(room, constantName) {
   const findConstant = getGlobalNumber19(constantName);
@@ -38188,7 +38652,7 @@ function uniqueRoomObjects2(objects) {
   return uniqueObjects;
 }
 function getObjectIdentityKey2(object) {
-  if (!isRecord29(object)) {
+  if (!isRecord30(object)) {
     return null;
   }
   if (typeof object.id === "string" && object.id.length > 0) {
@@ -38203,7 +38667,7 @@ function sumEnergyInStores(objects) {
   return objects.reduce((total, object) => total + getEnergyInStore(object), 0);
 }
 function getEnergyInStore(object) {
-  if (!isRecord29(object) || !isRecord29(object.store)) {
+  if (!isRecord30(object) || !isRecord30(object.store)) {
     return 0;
   }
   const storedEnergy = object.store[getEnergyResource24()];
@@ -38221,7 +38685,7 @@ function normalizeEnergyAmount7(value) {
   return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
 }
 function getEnergyCapacityInStore(object) {
-  if (!isRecord29(object) || !isRecord29(object.store)) {
+  if (!isRecord30(object) || !isRecord30(object.store)) {
     return 0;
   }
   const getCapacity = object.store.getCapacity;
@@ -38240,7 +38704,7 @@ function getEnergyCapacityInStore(object) {
   return typeof capacity === "number" && Number.isFinite(capacity) ? Math.max(0, capacity) : 0;
 }
 function getFreeEnergyCapacityInStore(object) {
-  if (!isRecord29(object) || !isRecord29(object.store)) {
+  if (!isRecord30(object) || !isRecord30(object.store)) {
     return 0;
   }
   const getFreeCapacity = object.store.getFreeCapacity;
@@ -38253,7 +38717,7 @@ function getFreeEnergyCapacityInStore(object) {
 function sumDroppedEnergy2(droppedResources) {
   const energyResource = getEnergyResource24();
   return droppedResources.reduce((total, droppedResource) => {
-    if (!isRecord29(droppedResource) || droppedResource.resourceType !== energyResource) {
+    if (!isRecord30(droppedResource) || droppedResource.resourceType !== energyResource) {
       return total;
     }
     return total + (typeof droppedResource.amount === "number" ? droppedResource.amount : 0);
@@ -38282,7 +38746,7 @@ function getEnergyResource24() {
   const value = globalThis.RESOURCE_ENERGY;
   return typeof value === "string" ? value : "energy";
 }
-function isRecord29(value) {
+function isRecord30(value) {
   return typeof value === "object" && value !== null;
 }
 function buildCpuSummary() {
@@ -40896,10 +41360,10 @@ function getMutableMineralHarvesterMemory(creep) {
   return memory;
 }
 function normalizeMineralHarvesterMemory(value) {
-  if (!isRecord30(value) || !isNonEmptyString30(value.homeRoom) || !isNonEmptyString30(value.mineralId)) {
+  if (!isRecord31(value) || !isNonEmptyString31(value.homeRoom) || !isNonEmptyString31(value.mineralId)) {
     return null;
   }
-  const targetId = isNonEmptyString30(value.targetId) ? value.targetId : void 0;
+  const targetId = isNonEmptyString31(value.targetId) ? value.targetId : void 0;
   if (!targetId) {
     return null;
   }
@@ -40908,7 +41372,7 @@ function normalizeMineralHarvesterMemory(value) {
     mineralId: value.mineralId,
     targetId,
     ...typeof value.mineralAmount === "number" && Number.isFinite(value.mineralAmount) ? { mineralAmount: normalizeNonNegativeInteger19(value.mineralAmount) } : {},
-    ...isNonEmptyString30(value.mineralType) ? { mineralType: value.mineralType } : {}
+    ...isNonEmptyString31(value.mineralType) ? { mineralType: value.mineralType } : {}
   };
 }
 function getAssignedMineral(assignment, room) {
@@ -41035,10 +41499,10 @@ function normalizePositiveInteger2(value) {
   const normalized = Math.floor(value);
   return normalized > 0 ? normalized : null;
 }
-function isRecord30(value) {
+function isRecord31(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString30(value) {
+function isNonEmptyString31(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -41076,11 +41540,11 @@ function refreshTerritoryExecutionTargets(action, options = {}) {
   return { action, targetCount, intentCount };
 }
 function normalizeExecutionTarget(rawTarget, action, colonyFilter) {
-  if (!isRecord31(rawTarget)) {
+  if (!isRecord32(rawTarget)) {
     return null;
   }
   const targetAction = getExecutionTargetAction(rawTarget);
-  if (targetAction !== action || !isNonEmptyString31(rawTarget.colony) || !isNonEmptyString31(rawTarget.roomName) || rawTarget.enabled === false || rawTarget.roomName === rawTarget.colony || isNonEmptyString31(colonyFilter) && rawTarget.colony !== colonyFilter) {
+  if (targetAction !== action || !isNonEmptyString32(rawTarget.colony) || !isNonEmptyString32(rawTarget.roomName) || rawTarget.enabled === false || rawTarget.roomName === rawTarget.colony || isNonEmptyString32(colonyFilter) && rawTarget.colony !== colonyFilter) {
     return null;
   }
   return {
@@ -41099,7 +41563,7 @@ function getExecutionTargetAction(rawTarget) {
   return isTerritoryControlAction4(rawTarget.actionHint) ? rawTarget.actionHint : null;
 }
 function canonicalizeExecutionTarget(rawTarget, target) {
-  if (!isRecord31(rawTarget)) {
+  if (!isRecord32(rawTarget)) {
     return;
   }
   rawTarget.action = target.action;
@@ -41155,10 +41619,10 @@ function isTerritoryControlAction4(action) {
 function isPositiveFiniteNumber3(value) {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
-function isNonEmptyString31(value) {
+function isNonEmptyString32(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isRecord31(value) {
+function isRecord32(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 function getGameTime36() {
@@ -41596,11 +42060,11 @@ function buildAutonomousExpansionScoringInput(colony, report, context, gameTime)
   const ownedRoomNames = getVisibleOwnedRoomNames5(colonyName, colonyOwnerUsername);
   const adjacentRoomNamesByOwnedRoom = getAdjacentRoomNamesByOwnedRoom(ownedRoomNames, context);
   const claimedRooms = buildRuntimeClaimedRoomSynergyEvidence(colony.room, colonyOwnerUsername);
-  const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString32(room.mineralType));
+  const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString33(room.mineralType));
   const seenRooms = /* @__PURE__ */ new Set();
   const candidates = [];
   report.candidates.forEach((candidate, order) => {
-    if (!isNonEmptyString32(candidate.roomName) || seenRooms.has(candidate.roomName)) {
+    if (!isNonEmptyString33(candidate.roomName) || seenRooms.has(candidate.roomName)) {
       return;
     }
     seenRooms.add(candidate.roomName);
@@ -41666,7 +42130,7 @@ function summarizeExpansionController2(controller) {
   return {
     ...typeof controller.my === "boolean" ? { my: controller.my } : {},
     ...ownerUsername ? { ownerUsername } : {},
-    ...isNonEmptyString32(reservationUsername) ? { reservationUsername } : {},
+    ...isNonEmptyString33(reservationUsername) ? { reservationUsername } : {},
     ...typeof ((_b = controller.reservation) == null ? void 0 : _b.ticksToEnd) === "number" ? { reservationTicksToEnd: controller.reservation.ticksToEnd } : {}
   };
 }
@@ -41687,7 +42151,7 @@ function getVisibleOwnedRoomNames5(colonyName, ownerUsername) {
     return ownedRoomNames;
   }
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString32(room.name) && (!ownerUsername || getControllerOwnerUsername10(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString33(room.name) && (!ownerUsername || getControllerOwnerUsername10(room.controller) === ownerUsername)) {
       ownedRoomNames.add(room.name);
     }
   }
@@ -41726,12 +42190,12 @@ function getAdjacentRoomNames7(roomName, gameMap = ((_a) => (_a = globalThis.Gam
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord32(exits)) {
+  if (!isRecord33(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER6.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString32(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString33(exitRoom) ? [exitRoom] : [];
   });
 }
 function hasSufficientAutonomousExpansionClaimRcl(colony) {
@@ -41802,13 +42266,13 @@ function upsertTerritoryTarget4(territoryMemory, target) {
     territoryMemory.targets = [];
   }
   const existingTarget = territoryMemory.targets.find(
-    (rawTarget) => isSameTarget2(rawTarget, target) && isRecord32(rawTarget) && rawTarget.createdBy === target.createdBy
+    (rawTarget) => isSameTarget2(rawTarget, target) && isRecord33(rawTarget) && rawTarget.createdBy === target.createdBy
   );
   if (!existingTarget) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord32(existingTarget)) {
+  if (isRecord33(existingTarget)) {
     existingTarget.action = target.action;
     existingTarget.createdBy = target.createdBy;
     existingTarget.enabled = target.enabled;
@@ -41839,7 +42303,7 @@ function pruneAutonomousExpansionClaimTargets(colony, territoryMemory = getTerri
     if (activeTarget && isSameTarget2(target, activeTarget)) {
       return true;
     }
-    if (isRecord32(target) && isNonEmptyString32(target.roomName) && target.action === "claim") {
+    if (isRecord33(target) && isNonEmptyString33(target.roomName) && target.action === "claim") {
       removedTargetKeys.add(getTargetKey2(target.roomName, "claim"));
     }
     return false;
@@ -41858,7 +42322,7 @@ function pruneOccupationRecommendationTargets(territoryMemory, colony) {
     return;
   }
   territoryMemory.targets = territoryMemory.targets.filter(
-    (target) => !(isRecord32(target) && target.colony === colony && target.createdBy === "occupationRecommendation")
+    (target) => !(isRecord33(target) && target.colony === colony && target.createdBy === "occupationRecommendation")
   );
 }
 function isAutonomousClaimSuppressed(colony, targetRoom, gameTime, intents) {
@@ -41926,7 +42390,7 @@ function isClaimExecutionAssignment(assignment) {
 }
 function getRecommendedExpansionClaimExecutionGate(colony, assignment) {
   var _a;
-  if (!isNonEmptyString32(colony)) {
+  if (!isNonEmptyString33(colony)) {
     return null;
   }
   const territoryMemory = getTerritoryMemoryRecord10();
@@ -42262,7 +42726,7 @@ function hasIdenticalClaimIntentSource(intents, colony, targetRoom, createdBy) {
   );
 }
 function isMatchingRecommendedClaimTarget(target, colony, targetRoom) {
-  return isRecord32(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && isTerritoryAutomationSource5(target.createdBy) && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy);
+  return isRecord33(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && isTerritoryAutomationSource5(target.createdBy) && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy);
 }
 function getMatchingExpansionPlannerClaimRecommendation(colony, assignment) {
   return getExpansionPlannerClaimRecommendations(colony).find(
@@ -42273,7 +42737,7 @@ function recordColonyExpansionClaimVerification(input) {
   var _a;
   const colonyRoom = getVisibleRoom15(input.colony);
   const selection = (_a = colonyRoom == null ? void 0 : colonyRoom.memory) == null ? void 0 : _a.cachedExpansionSelection;
-  if (!isRecord32(selection) || selection.targetRoom !== input.targetRoom) {
+  if (!isRecord33(selection) || selection.targetRoom !== input.targetRoom) {
     return;
   }
   selection.claimExecution = {
@@ -42307,12 +42771,12 @@ function getClaimColony(creep, controller) {
   return (_e = (_d = (_b = creep.memory.colony) != null ? _b : (_a = creep.room) == null ? void 0 : _a.name) != null ? _d : (_c = controller == null ? void 0 : controller.room) == null ? void 0 : _c.name) != null ? _e : "unknown";
 }
 function isForeignOwnedController(controller) {
-  return controller.my !== true && isNonEmptyString32(getControllerOwnerUsername10(controller));
+  return controller.my !== true && isNonEmptyString33(getControllerOwnerUsername10(controller));
 }
 function isForeignReservedController3(controller, colony) {
   var _a, _b;
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
-  if (!isNonEmptyString32(reservationUsername)) {
+  if (!isNonEmptyString33(reservationUsername)) {
     return false;
   }
   return reservationUsername !== getControllerOwnerUsername10((_b = getVisibleRoom15(colony != null ? colony : "")) == null ? void 0 : _b.controller);
@@ -42342,10 +42806,10 @@ function isTerritoryAutomationSource5(source) {
   return source === "occupationRecommendation" || source === "autonomousExpansionClaim" || source === "colonyExpansion" || source === "expansionPlanner" || source === "nextExpansionScoring" || source === "adjacentRoomReservation";
 }
 function isAutonomousExpansionClaimTarget(target, colony) {
-  return isRecord32(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
+  return isRecord33(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
 }
 function isSameTarget2(left, right) {
-  return isRecord32(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord33(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getTargetKey2(roomName, action) {
   return `${roomName}:${action}`;
@@ -42388,17 +42852,17 @@ function isControllerOwned3(controller) {
 function isControllerReserved(controller, colonyOwnerUsername) {
   var _a;
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString32(reservationUsername) && reservationUsername !== colonyOwnerUsername;
+  return isNonEmptyString33(reservationUsername) && reservationUsername !== colonyOwnerUsername;
 }
 function getControllerOwnerUsername10(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString32(username) ? username : void 0;
+  return isNonEmptyString33(username) ? username : void 0;
 }
-function isRecord32(value) {
+function isRecord33(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString32(value) {
+function isNonEmptyString33(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -42562,20 +43026,20 @@ function getControllerStatus2(room, scoutIntel) {
     if (!controller) {
       return "missing";
     }
-    if (controller.my === true || isNonEmptyString33((_a = controller.owner) == null ? void 0 : _a.username)) {
+    if (controller.my === true || isNonEmptyString34((_a = controller.owner) == null ? void 0 : _a.username)) {
       return "owned";
     }
-    if (isNonEmptyString33((_b = controller.reservation) == null ? void 0 : _b.username)) {
+    if (isNonEmptyString34((_b = controller.reservation) == null ? void 0 : _b.username)) {
       return "reserved";
     }
     return "neutral";
   }
   if (scoutIntel == null ? void 0 : scoutIntel.controller) {
     const controller = scoutIntel.controller;
-    if (controller.my === true || isNonEmptyString33(controller.ownerUsername)) {
+    if (controller.my === true || isNonEmptyString34(controller.ownerUsername)) {
       return "owned";
     }
-    if (isNonEmptyString33(controller.reservationUsername)) {
+    if (isNonEmptyString34(controller.reservationUsername)) {
       return "reserved";
     }
     return "neutral";
@@ -42613,12 +43077,12 @@ function getAdjacentRoomNames8(roomName) {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord33(exits)) {
+  if (!isRecord34(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER7.flatMap((direction) => {
     const adjacentRoom = exits[direction];
-    return isNonEmptyString33(adjacentRoom) ? [adjacentRoom] : [];
+    return isNonEmptyString34(adjacentRoom) ? [adjacentRoom] : [];
   });
 }
 function getRoomTerrain14(roomName) {
@@ -42652,10 +43116,10 @@ function getGlobalNumber20(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function isRecord33(value) {
+function isRecord34(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString33(value) {
+function isNonEmptyString34(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -42737,10 +43201,10 @@ function getWritableBootstrapperMemory() {
 function getActivePostClaimBootstrapRecord(roomName) {
   var _a, _b, _c;
   const record = (_c = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps) == null ? void 0 : _c[roomName];
-  return isRecord34(record) && record.roomName === roomName && record.status !== "ready" ? record : null;
+  return isRecord35(record) && record.roomName === roomName && record.status !== "ready" ? record : null;
 }
 function resolveClaimOriginColony(room, previous, activePostClaimRecord) {
-  if (isNonEmptyString34(activePostClaimRecord == null ? void 0 : activePostClaimRecord.colony)) {
+  if (isNonEmptyString35(activePostClaimRecord == null ? void 0 : activePostClaimRecord.colony)) {
     return activePostClaimRecord.colony;
   }
   const plannedClaimOrigin = getPlannedClaimOriginColony(room.name);
@@ -42779,21 +43243,21 @@ function getPlannedClaimOriginColony(roomName) {
     return null;
   }
   const pipelineOrigin = (_c = Object.values((_b = territory.expansionPipelines) != null ? _b : {}).find(
-    (pipeline) => isRecord34(pipeline) && pipeline.targetRoom === roomName && pipeline.status === "active" && isNonEmptyString34(pipeline.colony)
+    (pipeline) => isRecord35(pipeline) && pipeline.targetRoom === roomName && pipeline.status === "active" && isNonEmptyString35(pipeline.colony)
   )) == null ? void 0 : _c.colony;
-  if (isNonEmptyString34(pipelineOrigin)) {
+  if (isNonEmptyString35(pipelineOrigin)) {
     return pipelineOrigin;
   }
   const targetOrigin = Array.isArray(territory.targets) ? (_d = territory.targets.find(
-    (target) => isRecord34(target) && target.roomName === roomName && target.action === "claim" && isNonEmptyString34(target.colony)
+    (target) => isRecord35(target) && target.roomName === roomName && target.action === "claim" && isNonEmptyString35(target.colony)
   )) == null ? void 0 : _d.colony : null;
-  if (isNonEmptyString34(targetOrigin)) {
+  if (isNonEmptyString35(targetOrigin)) {
     return targetOrigin;
   }
   const intentOrigin = Array.isArray(territory.intents) ? (_e = territory.intents.find(
-    (intent) => isRecord34(intent) && intent.targetRoom === roomName && intent.action === "claim" && intent.status !== "completed" && intent.status !== "inactive" && isNonEmptyString34(intent.colony)
+    (intent) => isRecord35(intent) && intent.targetRoom === roomName && intent.action === "claim" && intent.status !== "completed" && intent.status !== "inactive" && isNonEmptyString35(intent.colony)
   )) == null ? void 0 : _e.colony : null;
-  return isNonEmptyString34(intentOrigin) ? intentOrigin : null;
+  return isNonEmptyString35(intentOrigin) ? intentOrigin : null;
 }
 function selectNearestOwnedSpawnRoom(targetRoomName, options = {}) {
   var _a, _b;
@@ -42817,7 +43281,7 @@ function selectNearestOwnedSpawnRoom(targetRoomName, options = {}) {
       Object.values(spawns).map((spawn) => spawn == null ? void 0 : spawn.room).filter(
         (room) => {
           var _a2;
-          return (room == null ? void 0 : room.name) !== targetRoomName && isNonEmptyString34(room == null ? void 0 : room.name) && ((_a2 = room.controller) == null ? void 0 : _a2.my) === true;
+          return (room == null ? void 0 : room.name) !== targetRoomName && isNonEmptyString35(room == null ? void 0 : room.name) && ((_a2 = room.controller) == null ? void 0 : _a2.my) === true;
         }
       ).map((room) => room.name)
     )
@@ -42894,10 +43358,10 @@ function getGameTime38() {
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
 }
-function isRecord34(value) {
+function isRecord35(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString34(value) {
+function isNonEmptyString35(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -43068,7 +43532,7 @@ function assignNextScoutTarget(creep, excludedTargetRoom) {
 }
 function selectNextScoutAssignment(colony, excludedTargetRoom, currentCreepName) {
   var _a, _b;
-  if (!isNonEmptyString35(colony)) {
+  if (!isNonEmptyString36(colony)) {
     return null;
   }
   const gameTime = getGameTime39();
@@ -43081,7 +43545,7 @@ function selectNextScoutIntentAssignment(colony, excludedTargetRoom, currentCree
     return null;
   }
   for (const intent of intents) {
-    if (!isRecord35(intent)) {
+    if (!isRecord36(intent)) {
       continue;
     }
     if (intent.colony === colony && intent.action === "scout" && (intent.status === "planned" || intent.status === "active") && isPendingScoutTarget(colony, intent.targetRoom, excludedTargetRoom, currentCreepName, gameTime)) {
@@ -43101,7 +43565,7 @@ function selectNextScoutAttemptAssignment(colony, excludedTargetRoom, currentCre
     return null;
   }
   for (const attempt of Object.values(attempts)) {
-    if (!isRecord35(attempt)) {
+    if (!isRecord36(attempt)) {
       continue;
     }
     if (attempt.colony === colony && attempt.status === "requested" && isPendingScoutTarget(colony, attempt.roomName, excludedTargetRoom, currentCreepName, gameTime)) {
@@ -43127,7 +43591,7 @@ function selectNextConfiguredScoutAssignment(colony, excludedTargetRoom, current
   return null;
 }
 function isPendingScoutTarget(colony, targetRoom, excludedTargetRoom, currentCreepName, gameTime) {
-  return isNonEmptyString35(targetRoom) && targetRoom !== excludedTargetRoom && !isVisibleRoomKnown2(targetRoom) && !isTerritoryScoutIntelFresh(colony, targetRoom, gameTime) && isTerritoryScoutAssignmentAvailableForCreep(colony, targetRoom, currentCreepName, gameTime);
+  return isNonEmptyString36(targetRoom) && targetRoom !== excludedTargetRoom && !isVisibleRoomKnown2(targetRoom) && !isTerritoryScoutIntelFresh(colony, targetRoom, gameTime) && isTerritoryScoutAssignmentAvailableForCreep(colony, targetRoom, currentCreepName, gameTime);
 }
 function recycleIdleTerritoryScout(creep) {
   const spawn = selectRecycleSpawn(creep.memory.colony);
@@ -43148,7 +43612,7 @@ function recycleIdleTerritoryScout(creep) {
 }
 function selectRecycleSpawn(colony) {
   var _a, _b;
-  if (!isNonEmptyString35(colony)) {
+  if (!isNonEmptyString36(colony)) {
     return null;
   }
   const spawns = (_a = globalThis.Game) == null ? void 0 : _a.spawns;
@@ -43163,7 +43627,7 @@ function selectRecycleSpawn(colony) {
 function moveTowardHomeRoom(creep) {
   var _a;
   const homeRoom = creep.memory.colony;
-  if (!isNonEmptyString35(homeRoom) || ((_a = creep.room) == null ? void 0 : _a.name) === homeRoom || typeof creep.moveTo !== "function") {
+  if (!isNonEmptyString36(homeRoom) || ((_a = creep.room) == null ? void 0 : _a.name) === homeRoom || typeof creep.moveTo !== "function") {
     return;
   }
   const RoomPositionCtor = globalThis.RoomPosition;
@@ -43176,10 +43640,10 @@ function isVisibleRoomKnown2(roomName) {
   var _a, _b;
   return ((_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName]) != null;
 }
-function isNonEmptyString35(value) {
+function isNonEmptyString36(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isRecord35(value) {
+function isRecord36(value) {
   return typeof value === "object" && value !== null;
 }
 function isJestRuntime() {
@@ -43408,17 +43872,17 @@ function getCachedExpansionExecutorSelection(colonyMemory, colonyName) {
   const refreshedAt = colonyMemory.lastExpansionScoreTime;
   const rawSelection = colonyMemory.cachedExpansionSelection;
   const selection = normalizeExpansionExecutorSelection(rawSelection, colonyName);
-  if (!isFiniteNumber12(refreshedAt) || !isRecord36(rawSelection) || !isNonEmptyString36(rawSelection.stateKey) || !selection) {
+  if (!isFiniteNumber12(refreshedAt) || !isRecord37(rawSelection) || !isNonEmptyString37(rawSelection.stateKey) || !selection) {
     return null;
   }
   return { refreshedAt, stateKey: rawSelection.stateKey, selection };
 }
 function normalizeExpansionExecutorSelection(rawSelection, colonyName) {
-  if (!isRecord36(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
+  if (!isRecord37(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
     return null;
   }
   if (rawSelection.status === "planned") {
-    if (!isNonEmptyString36(rawSelection.targetRoom)) {
+    if (!isNonEmptyString37(rawSelection.targetRoom)) {
       return null;
     }
     return {
@@ -43468,7 +43932,7 @@ function hasExpansionExecutorTarget(colony, targetRoom) {
   }
   const targets = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.targets;
   return Array.isArray(targets) ? targets.some(
-    (target) => isRecord36(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
+    (target) => isRecord37(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
   ) : false;
 }
 function getExpansionExecutorCacheStateKey(colony, gameTime = getGameTime40()) {
@@ -43593,12 +44057,12 @@ function countActivePostClaimBootstraps(colonyName, gameTime) {
 function getLatestTerritoryScoutIntelUpdatedAt(colony) {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.scoutIntel;
-  if (!isRecord36(records)) {
+  if (!isRecord37(records)) {
     return 0;
   }
   let latestUpdatedAt = 0;
   for (const record of Object.values(records)) {
-    if (isRecord36(record) && record.colony === colony && isFiniteNumber12(record.updatedAt) && record.updatedAt > latestUpdatedAt) {
+    if (isRecord37(record) && record.colony === colony && isFiniteNumber12(record.updatedAt) && record.updatedAt > latestUpdatedAt) {
       latestUpdatedAt = record.updatedAt;
     }
   }
@@ -43624,10 +44088,10 @@ function getFindConstant11(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function isRecord36(value) {
+function isRecord37(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString36(value) {
+function isNonEmptyString37(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber12(value) {
@@ -43739,7 +44203,7 @@ function reserveRoomForPlannedClaim(creep) {
   };
 }
 function isPlannedClaimAssignment(assignment) {
-  return isNonEmptyString37(assignment == null ? void 0 : assignment.targetRoom) && assignment.action === "claim";
+  return isNonEmptyString38(assignment == null ? void 0 : assignment.targetRoom) && assignment.action === "claim";
 }
 function selectClaimReservationController(creep, assignment) {
   var _a, _b, _c, _d, _e;
@@ -43768,7 +44232,7 @@ function countVisibleOwnedRooms4(colony) {
     return 0;
   }
   const colonyOwnerUsername = getControllerOwnerUsername11(
-    isNonEmptyString37(colony) ? (_b = rooms[colony]) == null ? void 0 : _b.controller : void 0
+    isNonEmptyString38(colony) ? (_b = rooms[colony]) == null ? void 0 : _b.controller : void 0
   );
   let ownedRoomCount = 0;
   for (const room of Object.values(rooms)) {
@@ -43784,10 +44248,10 @@ function canReserveControllerForColony(controller, creep) {
     return true;
   }
   const actorUsername = getActorUsername(creep);
-  return isNonEmptyString37(actorUsername) && reservationUsername === actorUsername;
+  return isNonEmptyString38(actorUsername) && reservationUsername === actorUsername;
 }
 function isControllerOwned4(controller) {
-  return controller.my === true || isNonEmptyString37(getControllerOwnerUsername11(controller));
+  return controller.my === true || isNonEmptyString38(getControllerOwnerUsername11(controller));
 }
 function getActiveClaimPartCount(creep) {
   var _a;
@@ -43804,22 +44268,22 @@ function getActiveClaimPartCount(creep) {
 function getActorUsername(creep) {
   var _a, _b, _c;
   const creepOwner = (_a = creep.owner) == null ? void 0 : _a.username;
-  if (isNonEmptyString37(creepOwner)) {
+  if (isNonEmptyString38(creepOwner)) {
     return creepOwner;
   }
   const colony = creep.memory.colony;
-  const room = isNonEmptyString37(colony) ? (_c = (_b = globalThis.Game) == null ? void 0 : _b.rooms) == null ? void 0 : _c[colony] : void 0;
+  const room = isNonEmptyString38(colony) ? (_c = (_b = globalThis.Game) == null ? void 0 : _b.rooms) == null ? void 0 : _c[colony] : void 0;
   return getControllerOwnerUsername11(room == null ? void 0 : room.controller);
 }
 function getControllerOwnerUsername11(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString37(username) ? username : void 0;
+  return isNonEmptyString38(username) ? username : void 0;
 }
 function getControllerReservationUsername7(controller) {
   var _a;
   const username = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString37(username) ? username : void 0;
+  return isNonEmptyString38(username) ? username : void 0;
 }
 function getClaimBodyPartConstant() {
   var _a;
@@ -43830,7 +44294,7 @@ function getGameTime41() {
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
-function isNonEmptyString37(value) {
+function isNonEmptyString38(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -44065,11 +44529,11 @@ function getReservationControllerState(colonyName, roomName, ownerUsername) {
   if (!controller) {
     return { kind: "missing" };
   }
-  if (controller.my === true || isNonEmptyString38(controller.ownerUsername)) {
+  if (controller.my === true || isNonEmptyString39(controller.ownerUsername)) {
     return { kind: "owned", ...controller.id ? { controllerId: controller.id } : {} };
   }
-  if (isNonEmptyString38(controller.reservationUsername)) {
-    if (isNonEmptyString38(ownerUsername) && controller.reservationUsername === ownerUsername) {
+  if (isNonEmptyString39(controller.reservationUsername)) {
+    if (isNonEmptyString39(ownerUsername) && controller.reservationUsername === ownerUsername) {
       return {
         kind: "ownReserved",
         ...controller.id ? { controllerId: controller.id } : {},
@@ -44083,12 +44547,12 @@ function getReservationControllerState(colonyName, roomName, ownerUsername) {
 function getVisibleControllerReservationState(controller, ownerUsername) {
   var _a;
   const controllerId = controller.id;
-  if (controller.my === true || isNonEmptyString38((_a = controller.owner) == null ? void 0 : _a.username)) {
+  if (controller.my === true || isNonEmptyString39((_a = controller.owner) == null ? void 0 : _a.username)) {
     return { kind: "owned", controllerId };
   }
   const reservation = controller.reservation;
-  if (isNonEmptyString38(reservation == null ? void 0 : reservation.username)) {
-    if (isNonEmptyString38(ownerUsername) && reservation.username === ownerUsername) {
+  if (isNonEmptyString39(reservation == null ? void 0 : reservation.username)) {
+    if (isNonEmptyString39(ownerUsername) && reservation.username === ownerUsername) {
       return {
         kind: "ownReserved",
         controllerId,
@@ -44178,7 +44642,7 @@ function upsertAdjacentRoomReservationTarget(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord37(existingTarget)) {
+  if (isRecord38(existingTarget)) {
     existingTarget.createdBy = ADJACENT_ROOM_RESERVATION_TARGET_CREATOR;
     existingTarget.enabled = target.enabled;
     if (target.controllerId) {
@@ -44211,13 +44675,13 @@ function hasBlockingTerritoryPlan2(colony) {
   );
 }
 function isBlockingTerritoryTarget(target, colony) {
-  return isRecord37(target) && target.colony === colony && target.enabled !== false && target.createdBy !== ADJACENT_ROOM_RESERVATION_TARGET_CREATOR && (target.action === "claim" || target.action === "reserve");
+  return isRecord38(target) && target.colony === colony && target.enabled !== false && target.createdBy !== ADJACENT_ROOM_RESERVATION_TARGET_CREATOR && (target.action === "claim" || target.action === "reserve");
 }
 function isAdjacentRoomReservationTarget(target, colony) {
-  return isRecord37(target) && target.colony === colony && target.action === "reserve" && target.createdBy === ADJACENT_ROOM_RESERVATION_TARGET_CREATOR;
+  return isRecord38(target) && target.colony === colony && target.action === "reserve" && target.createdBy === ADJACENT_ROOM_RESERVATION_TARGET_CREATOR;
 }
 function isSameTarget3(left, right) {
-  return isRecord37(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord38(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getAdjacentRoomNames9(roomName) {
   var _a;
@@ -44226,12 +44690,12 @@ function getAdjacentRoomNames9(roomName) {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord37(exits)) {
+  if (!isRecord38(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER8.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString38(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString39(exitRoom) ? [exitRoom] : [];
   });
 }
 function getPersistedExpansionCandidatePriorities(colony) {
@@ -44242,7 +44706,7 @@ function getPersistedExpansionCandidatePriorities(colony) {
   }
   const priorities = /* @__PURE__ */ new Map();
   for (const [index, rawCandidate] of rawCandidates.entries()) {
-    if (!isRecord37(rawCandidate) || rawCandidate.colony !== colony || !isNonEmptyString38(rawCandidate.roomName) || rawCandidate.evidenceStatus === "unavailable" || priorities.has(rawCandidate.roomName)) {
+    if (!isRecord38(rawCandidate) || rawCandidate.colony !== colony || !isNonEmptyString39(rawCandidate.roomName) || rawCandidate.evidenceStatus === "unavailable" || priorities.has(rawCandidate.roomName)) {
       continue;
     }
     priorities.set(rawCandidate.roomName, {
@@ -44260,7 +44724,7 @@ function countVisibleOwnedRooms5(colonyName, ownerUsername) {
   }
   let ownedRoomCount = 0;
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString38(room.name) && (!ownerUsername || getControllerOwnerUsername12(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString39(room.name) && (!ownerUsername || getControllerOwnerUsername12(room.controller) === ownerUsername)) {
       ownedRoomCount += 1;
     }
   }
@@ -44296,7 +44760,7 @@ function getFindConstant12(name) {
 function getControllerOwnerUsername12(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString38(username) ? username : void 0;
+  return isNonEmptyString39(username) ? username : void 0;
 }
 function compareOptionalNumbers8(left, right) {
   return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
@@ -44332,10 +44796,10 @@ function getGameTime42() {
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
-function isNonEmptyString38(value) {
+function isNonEmptyString39(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isRecord37(value) {
+function isRecord38(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -44426,7 +44890,7 @@ function clearColonyExpansionClaimIntent(colony) {
 function selectColonyExpansionCandidate(colony) {
   const ownerUsername = getControllerOwnerUsername13(colony.room.controller);
   const claimedRooms = buildRuntimeClaimedRoomSynergyEvidence(colony.room, ownerUsername);
-  const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString39(room.mineralType));
+  const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString40(room.mineralType));
   const candidates = getAdjacentRoomNames10(colony.room.name).flatMap((roomName, order) => {
     if (isConfiguredExpansionScoutOnlyTarget(colony.room.name, roomName)) {
       return [];
@@ -44580,11 +45044,11 @@ function getColonyExpansionControllerState(colonyName, roomName, ownerUsername) 
       return { kind: "missing" };
     }
     const controllerId = controller2.id;
-    if (controller2.my === true || isNonEmptyString39((_a = controller2.owner) == null ? void 0 : _a.username)) {
+    if (controller2.my === true || isNonEmptyString40((_a = controller2.owner) == null ? void 0 : _a.username)) {
       return { kind: "owned", controllerId };
     }
     const reservationUsername = (_b = controller2.reservation) == null ? void 0 : _b.username;
-    if (isNonEmptyString39(reservationUsername)) {
+    if (isNonEmptyString40(reservationUsername)) {
       return reservationUsername === ownerUsername ? {
         kind: "ownReserved",
         controllerId,
@@ -44601,10 +45065,10 @@ function getColonyExpansionControllerState(colonyName, roomName, ownerUsername) 
   if (!controller) {
     return { kind: "missing" };
   }
-  if (controller.my === true || isNonEmptyString39(controller.ownerUsername)) {
+  if (controller.my === true || isNonEmptyString40(controller.ownerUsername)) {
     return { kind: "owned", ...controller.id ? { controllerId: controller.id } : {} };
   }
-  if (isNonEmptyString39(controller.reservationUsername)) {
+  if (isNonEmptyString40(controller.reservationUsername)) {
     return controller.reservationUsername === ownerUsername ? {
       kind: "ownReserved",
       ...controller.id ? { controllerId: controller.id } : {},
@@ -44619,7 +45083,7 @@ function hasBlockingClaimIntent(colony, targetRoom) {
     return false;
   }
   if (Array.isArray(territoryMemory.targets) && territoryMemory.targets.some(
-    (target) => isRecord38(target) && target.colony === colony && target.action === "claim" && target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR
+    (target) => isRecord39(target) && target.colony === colony && target.action === "claim" && target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR
   )) {
     return true;
   }
@@ -44665,13 +45129,13 @@ function pruneColonyExpansionClaimTargets(colony, territoryMemory, activeTarget)
   const removedRooms = /* @__PURE__ */ new Set();
   if (Array.isArray(territoryMemory.targets)) {
     territoryMemory.targets = territoryMemory.targets.filter((target) => {
-      if (!isRecord38(target) || target.colony !== colony || target.action !== "claim" || target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR) {
+      if (!isRecord39(target) || target.colony !== colony || target.action !== "claim" || target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR) {
         return true;
       }
       if (activeTarget && isSameTarget4(target, activeTarget)) {
         return true;
       }
-      if (isNonEmptyString39(target.roomName)) {
+      if (isNonEmptyString40(target.roomName)) {
         removedRooms.add(target.roomName);
       }
       return false;
@@ -44688,7 +45152,7 @@ function pruneColonyExpansionClaimTargets(colony, territoryMemory, activeTarget)
 function pruneAdjacentReservationForTarget(colony, targetRoom, territoryMemory) {
   if (Array.isArray(territoryMemory.targets)) {
     territoryMemory.targets = territoryMemory.targets.filter(
-      (target) => !(isRecord38(target) && target.colony === colony && target.roomName === targetRoom && target.action === "reserve" && target.createdBy === "adjacentRoomReservation")
+      (target) => !(isRecord39(target) && target.colony === colony && target.roomName === targetRoom && target.action === "reserve" && target.createdBy === "adjacentRoomReservation")
     );
   }
   const intents = normalizeTerritoryIntents(territoryMemory.intents).filter(
@@ -44705,7 +45169,7 @@ function upsertTerritoryTarget5(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord38(existingTarget)) {
+  if (isRecord39(existingTarget)) {
     existingTarget.createdBy = COLONY_EXPANSION_CLAIM_TARGET_CREATOR;
     existingTarget.enabled = target.enabled;
     if (target.postClaimBootstrapReserveEnergy) {
@@ -44731,7 +45195,7 @@ function upsertTerritoryIntent6(intents, nextIntent) {
   intents.push(nextIntent);
 }
 function isSameTarget4(left, right) {
-  return isRecord38(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord39(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getAdjacentRoomNames10(roomName) {
   var _a;
@@ -44740,12 +45204,12 @@ function getAdjacentRoomNames10(roomName) {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord38(exits)) {
+  if (!isRecord39(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER9.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString39(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString40(exitRoom) ? [exitRoom] : [];
   });
 }
 function getVisibleRoom18(roomName) {
@@ -44764,7 +45228,7 @@ function countVisibleOwnedRooms6(colonyName, ownerUsername) {
   }
   let ownedRoomCount = 0;
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString39(room.name) && (!ownerUsername || getControllerOwnerUsername13(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString40(room.name) && (!ownerUsername || getControllerOwnerUsername13(room.controller) === ownerUsername)) {
       ownedRoomCount += 1;
     }
   }
@@ -44778,17 +45242,17 @@ function getGclLevel7() {
 function hasActivePostClaimBootstrap2(colonyName) {
   var _a;
   const records = (_a = getTerritoryMemoryRecord12()) == null ? void 0 : _a.postClaimBootstraps;
-  if (!isRecord38(records)) {
+  if (!isRecord39(records)) {
     return false;
   }
   return Object.values(records).some(
-    (record) => isRecord38(record) && record.colony === colonyName && record.status !== "ready"
+    (record) => isRecord39(record) && record.colony === colonyName && record.status !== "ready"
   );
 }
 function getControllerOwnerUsername13(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString39(username) ? username : void 0;
+  return isNonEmptyString40(username) ? username : void 0;
 }
 function getTerritoryMemoryRecord12() {
   var _a;
@@ -44809,10 +45273,10 @@ function getGameTime43() {
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
 }
-function isRecord38(value) {
+function isRecord39(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString39(value) {
+function isNonEmptyString40(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -44848,7 +45312,7 @@ function runAssignedReservation(creep, assignment, gate) {
   var _a;
   const colony = creep.memory.colony;
   const gameTime = getGameTime44();
-  if (!isNonEmptyString40(colony) || !isReservationExecutionGateRunnable(gate, gameTime)) {
+  if (!isNonEmptyString41(colony) || !isReservationExecutionGateRunnable(gate, gameTime)) {
     completeReservationAssignment(creep);
     return true;
   }
@@ -44941,7 +45405,7 @@ function selectReservationAssignment(creep) {
     return null;
   }
   const colony = creep.memory.colony;
-  if (!isNonEmptyString40(colony) || !hasReservationEnergyBudget(colony)) {
+  if (!isNonEmptyString41(colony) || !hasReservationEnergyBudget(colony)) {
     return null;
   }
   const territoryMemory = getTerritoryMemoryRecord13();
@@ -45056,7 +45520,7 @@ function getReservationRenewalPriority(selection) {
   return selection.renewalTicksToEnd !== void 0 ? 0 : 1;
 }
 function getReservationExecutionGate(colony, assignment) {
-  if (!isNonEmptyString40(colony)) {
+  if (!isNonEmptyString41(colony)) {
     return null;
   }
   const territoryMemory = getTerritoryMemoryRecord13();
@@ -45170,7 +45634,7 @@ function refreshVisibleReservationMemory(colony, assignment, controller, actorUs
 }
 function getStoredTerritoryReservation2(territoryMemory, colony, targetRoom, controllerId) {
   const reservation = normalizeTerritoryReservation2(
-    isRecord39(territoryMemory.reservations) ? territoryMemory.reservations[getTerritoryReservationMemoryKey2(colony, targetRoom)] : void 0
+    isRecord40(territoryMemory.reservations) ? territoryMemory.reservations[getTerritoryReservationMemoryKey2(colony, targetRoom)] : void 0
   );
   if (!reservation || reservation.colony !== colony || reservation.roomName !== targetRoom || controllerId !== void 0 && reservation.controllerId !== void 0 && reservation.controllerId !== controllerId) {
     return null;
@@ -45178,7 +45642,7 @@ function getStoredTerritoryReservation2(territoryMemory, colony, targetRoom, con
   return reservation;
 }
 function normalizeTerritoryReservations2(rawReservations) {
-  if (!isRecord39(rawReservations)) {
+  if (!isRecord40(rawReservations)) {
     return {};
   }
   const reservations = {};
@@ -45191,10 +45655,10 @@ function normalizeTerritoryReservations2(rawReservations) {
   return reservations;
 }
 function normalizeTerritoryReservation2(rawReservation) {
-  if (!isRecord39(rawReservation)) {
+  if (!isRecord40(rawReservation)) {
     return null;
   }
-  if (!isNonEmptyString40(rawReservation.colony) || !isNonEmptyString40(rawReservation.roomName) || !isFiniteNumber13(rawReservation.ticksToEnd) || !isFiniteNumber13(rawReservation.updatedAt)) {
+  if (!isNonEmptyString41(rawReservation.colony) || !isNonEmptyString41(rawReservation.roomName) || !isFiniteNumber13(rawReservation.ticksToEnd) || !isFiniteNumber13(rawReservation.updatedAt)) {
     return null;
   }
   return {
@@ -45233,7 +45697,7 @@ function getReservationRouteDistance(territoryMemory, colony, targetRoom) {
     return 0;
   }
   const routeKey = `${colony}${TERRITORY_ROUTE_DISTANCE_SEPARATOR5}${targetRoom}`;
-  const cachedDistance = isRecord39(territoryMemory.routeDistances) ? territoryMemory.routeDistances[routeKey] : void 0;
+  const cachedDistance = isRecord40(territoryMemory.routeDistances) ? territoryMemory.routeDistances[routeKey] : void 0;
   if (typeof cachedDistance === "number" || cachedDistance === null) {
     return cachedDistance;
   }
@@ -45328,11 +45792,11 @@ function isMatchingExpansionPlannerReservationIntent(intent, colony, targetRoom,
 }
 function hasMatchingExpansionPlannerReservationTarget(territoryMemory, colony, targetRoom, controllerId) {
   return Array.isArray(territoryMemory.targets) ? territoryMemory.targets.some(
-    (target) => isRecord39(target) && target.colony === colony && target.roomName === targetRoom && target.action === "reserve" && target.createdBy === EXPANSION_PLANNER_TARGET_CREATOR && target.enabled !== false && (!controllerId || !isNonEmptyString40(target.controllerId) || target.controllerId === controllerId)
+    (target) => isRecord40(target) && target.colony === colony && target.roomName === targetRoom && target.action === "reserve" && target.createdBy === EXPANSION_PLANNER_TARGET_CREATOR && target.enabled !== false && (!controllerId || !isNonEmptyString41(target.controllerId) || target.controllerId === controllerId)
   ) : false;
 }
 function isReservationExecutionAssignment(assignment) {
-  return isNonEmptyString40(assignment == null ? void 0 : assignment.targetRoom) && assignment.action === "reserve";
+  return isNonEmptyString41(assignment == null ? void 0 : assignment.targetRoom) && assignment.action === "reserve";
 }
 function isTerritoryIntentSuspensionActive3(intent, gameTime) {
   if (!intent.suspended) {
@@ -45341,19 +45805,19 @@ function isTerritoryIntentSuspensionActive3(intent, gameTime) {
   return gameTime - intent.suspended.updatedAt <= TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS;
 }
 function isControllerOwned5(controller) {
-  return controller.my === true || isNonEmptyString40(getControllerOwnerUsername14(controller));
+  return controller.my === true || isNonEmptyString41(getControllerOwnerUsername14(controller));
 }
 function isControllerOwnedByActor(controller, actorUsername) {
-  return controller.my === true || isNonEmptyString40(actorUsername) && getControllerOwnerUsername14(controller) === actorUsername;
+  return controller.my === true || isNonEmptyString41(actorUsername) && getControllerOwnerUsername14(controller) === actorUsername;
 }
 function isForeignReservedController4(controller, actorUsername) {
   var _a;
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString40(reservationUsername) && reservationUsername !== actorUsername;
+  return isNonEmptyString41(reservationUsername) && reservationUsername !== actorUsername;
 }
 function getOwnReservationTicksToEnd3(controller, actorUsername) {
   const reservation = controller.reservation;
-  if (!isNonEmptyString40(actorUsername) || !isNonEmptyString40(reservation == null ? void 0 : reservation.username) || reservation.username !== actorUsername || !isFiniteNumber13(reservation.ticksToEnd)) {
+  if (!isNonEmptyString41(actorUsername) || !isNonEmptyString41(reservation == null ? void 0 : reservation.username) || reservation.username !== actorUsername || !isFiniteNumber13(reservation.ticksToEnd)) {
     return null;
   }
   return Math.floor(Math.max(0, reservation.ticksToEnd));
@@ -45361,7 +45825,7 @@ function getOwnReservationTicksToEnd3(controller, actorUsername) {
 function getReservationActorUsername(creep, colony) {
   var _a, _b, _c, _d;
   const creepOwner = (_a = creep.owner) == null ? void 0 : _a.username;
-  if (isNonEmptyString40(creepOwner)) {
+  if (isNonEmptyString41(creepOwner)) {
     return creepOwner;
   }
   return getControllerOwnerUsername14((_d = (_c = (_b = globalThis.Game) == null ? void 0 : _b.rooms) == null ? void 0 : _c[colony]) == null ? void 0 : _d.controller);
@@ -45369,7 +45833,7 @@ function getReservationActorUsername(creep, colony) {
 function getControllerOwnerUsername14(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString40(username) ? username : void 0;
+  return isNonEmptyString41(username) ? username : void 0;
 }
 function getActiveClaimPartCount2(creep) {
   var _a;
@@ -45381,7 +45845,7 @@ function getActiveClaimPartCount2(creep) {
   return Array.isArray(creep.body) ? creep.body.filter((part) => isActiveBodyPart7(part, claimPart)).length : 0;
 }
 function isActiveBodyPart7(part, bodyPartType) {
-  if (!isRecord39(part)) {
+  if (!isRecord40(part)) {
     return false;
   }
   return part.type === bodyPartType && typeof part.hits === "number" && part.hits > 0;
@@ -45443,10 +45907,10 @@ function isPositiveFiniteNumber4(value) {
 function isFiniteNumber13(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
-function isNonEmptyString40(value) {
+function isNonEmptyString41(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isRecord39(value) {
+function isRecord40(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -45799,7 +46263,7 @@ function buildMemoryTerritoryState(roomName) {
   const expansionCandidates = [];
   if (Array.isArray(targets)) {
     for (const target of targets) {
-      if (!isRecord40(target) || target.colony !== roomName || typeof target.roomName !== "string") {
+      if (!isRecord41(target) || target.colony !== roomName || typeof target.roomName !== "string") {
         continue;
       }
       const action = normalizeTerritoryAction(target.action);
@@ -45861,12 +46325,12 @@ function countVisibleOwnedRooms7() {
 }
 function countStructuresByType3(structures, globalName, fallback) {
   return structures.filter(
-    (structure) => isRecord40(structure) && matchesStructureType31(structure.structureType, globalName, fallback)
+    (structure) => isRecord41(structure) && matchesStructureType31(structure.structureType, globalName, fallback)
   ).length;
 }
 function estimateRepairBacklogHits(structures) {
   return structures.reduce((total, structure) => {
-    if (!isRecord40(structure)) {
+    if (!isRecord41(structure)) {
       return total;
     }
     const hits = finiteNumberOrNull(structure.hits);
@@ -45882,7 +46346,7 @@ function getStoredEnergy26(room) {
   return getEnergyInStore2(storage);
 }
 function getEnergyInStore2(object) {
-  if (!isRecord40(object) || !isRecord40(object.store)) {
+  if (!isRecord41(object) || !isRecord41(object.store)) {
     return 0;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
@@ -45934,7 +46398,7 @@ function finiteNumberOrZero(value) {
 function finiteNumberOrNull(value) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
-function isRecord40(value) {
+function isRecord41(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -46157,11 +46621,11 @@ function ensureLocalWorkerColonyMemory(colonies, creeps) {
   }
   const colonyNames = new Set(colonies.map((colony) => colony.room.name));
   for (const creep of creeps) {
-    if (creep.memory.role !== "worker" || isNonEmptyString41(creep.memory.colony)) {
+    if (creep.memory.role !== "worker" || isNonEmptyString42(creep.memory.colony)) {
       continue;
     }
     const roomName = (_a = creep.room) == null ? void 0 : _a.name;
-    if (isNonEmptyString41(roomName) && colonyNames.has(roomName) && isRoomLocalWorkerName2(creep, roomName)) {
+    if (isNonEmptyString42(roomName) && colonyNames.has(roomName) && isRoomLocalWorkerName2(creep, roomName)) {
       creep.memory.colony = roomName;
     }
   }
@@ -46169,7 +46633,7 @@ function ensureLocalWorkerColonyMemory(colonies, creeps) {
 function isRoomLocalWorkerName2(creep, roomName) {
   return typeof creep.name === "string" && creep.name.startsWith(`worker-${roomName}-`);
 }
-function isNonEmptyString41(value) {
+function isNonEmptyString42(value) {
   return typeof value === "string" && value.length > 0;
 }
 function orderCreepsForEconomyTaskPriority(creeps) {
@@ -47010,324 +47474,6 @@ function getGameTime45() {
   return typeof Game !== "undefined" && typeof Game.time === "number" ? Game.time : 0;
 }
 
-// src/strategy/runtimePolicyParameters.ts
-var RUNTIME_POLICY_PARAMETERS_GLOBAL = "__SCREEPS_RL_RUNTIME_POLICY_PARAMETERS__";
-var RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL = "__SCREEPS_RL_RUNTIME_POLICY_PARAMETER_CONSUMPTION__";
-var RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER = "screeps-rl-runtime-policy-parameters-consumer-v1";
-var RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION = "v1";
-var RUNTIME_POLICY_PARAMETER_CONSUMPTION_LOG_PREFIX = "#runtime-parameter-consumption ";
-function applyRuntimePolicyParametersToRegistry(registry) {
-  var _a;
-  const clonedRegistry = registry.map(cloneStrategyRegistryEntry);
-  const payload = readRuntimePolicyParameterPayload();
-  if (!payload) {
-    const evidence2 = buildConsumptionEvidence({ consumed: false, appliedStrategyIds: [] });
-    publishRuntimePolicyParameterConsumptionEvidence(evidence2);
-    return { registry: clonedRegistry, evidence: evidence2 };
-  }
-  const parameters = normalizeRuntimePolicyParameters(payload.parameters);
-  if (!parameters) {
-    const evidence2 = buildConsumptionEvidence({
-      payload,
-      consumed: false,
-      appliedStrategyIds: [],
-      reason: "runtime policy parameter payload did not include a non-empty parameters object"
-    });
-    publishRuntimePolicyParameterConsumptionEvidence(evidence2);
-    return { registry: clonedRegistry, evidence: evidence2 };
-  }
-  const appliedStrategyIds = [];
-  const targetedStrategyIds = new Set(
-    clonedRegistry.filter((entry) => runtimePolicyPayloadTargetsEntry(payload, entry)).map((entry) => entry.id)
-  );
-  const activatesSingleExplicitTarget = targetedStrategyIds.size === 1 && runtimePolicyPayloadExplicitIds(payload).length > 0;
-  const activatedFamily = activatesSingleExplicitTarget ? (_a = clonedRegistry.find((entry) => targetedStrategyIds.has(entry.id))) == null ? void 0 : _a.family : void 0;
-  const patchedRegistry = clonedRegistry.map((entry) => {
-    if (!targetedStrategyIds.has(entry.id)) {
-      if (activatedFamily !== void 0 && entry.family === activatedFamily && entry.rolloutStatus === "incumbent") {
-        return {
-          ...entry,
-          rolloutStatus: "shadow"
-        };
-      }
-      return entry;
-    }
-    appliedStrategyIds.push(entry.id);
-    return {
-      ...entry,
-      ...activatesSingleExplicitTarget ? { rolloutStatus: "incumbent" } : {},
-      defaultValues: {
-        ...entry.defaultValues,
-        ...parameters
-      }
-    };
-  });
-  const matched = appliedStrategyIds.length > 0;
-  const evidence = buildConsumptionEvidence({
-    payload,
-    consumed: false,
-    parameters,
-    appliedStrategyIds,
-    reason: matched ? "runtime policy parameter payload matched registry entries; awaiting tick runtime strategy evaluation" : "runtime policy parameter payload did not match any strategy registry entry"
-  });
-  publishRuntimePolicyParameterConsumptionEvidence(evidence);
-  return { registry: patchedRegistry, evidence };
-}
-function createRuntimePolicyParameterConsumptionRecorder() {
-  const payload = readRuntimePolicyParameterPayload();
-  const parameters = payload ? normalizeRuntimePolicyParameters(payload.parameters) : null;
-  const appliedStrategyIds = /* @__PURE__ */ new Set();
-  return {
-    recordStrategyRuntimeUse(entry) {
-      if (!payload || !parameters) {
-        return;
-      }
-      if (!runtimePolicyPayloadTargetsEntry(payload, entry)) {
-        return;
-      }
-      if (!strategyEntryUsesRuntimeParameters(entry, parameters)) {
-        return;
-      }
-      appliedStrategyIds.add(entry.id);
-    },
-    buildEvidence() {
-      if (!payload) {
-        return buildConsumptionEvidence({ consumed: false, appliedStrategyIds: [] });
-      }
-      if (!parameters) {
-        return buildConsumptionEvidence({
-          payload,
-          consumed: false,
-          appliedStrategyIds: [],
-          reason: "runtime policy parameter payload did not include a non-empty parameters object"
-        });
-      }
-      const observedStrategyIds = [...appliedStrategyIds].sort();
-      const consumed = observedStrategyIds.length > 0;
-      return buildConsumptionEvidence({
-        payload,
-        consumed,
-        parameters,
-        appliedStrategyIds: observedStrategyIds,
-        reason: consumed ? "runtime policy parameter payload was used by tick runtime strategy evaluation" : "runtime policy parameter payload was not used by tick runtime strategy evaluation"
-      });
-    }
-  };
-}
-function persistRuntimePolicyParameterConsumptionEvidence(evidence) {
-  const memory = runtimeMemoryRoot();
-  const persistedEvidence = stickyRuntimePolicyParameterConsumptionEvidence(
-    evidence,
-    memory.rlRuntimePolicyParameters
-  );
-  const tick = runtimeTick();
-  const tickedEvidence = {
-    ...persistedEvidence,
-    tick
-  };
-  memory.rlRuntimePolicyParameters = tickedEvidence;
-  publishRuntimePolicyParameterConsumptionEvidence(tickedEvidence);
-  emitRuntimePolicyParameterConsumptionEvidence(tickedEvidence);
-}
-function readRuntimePolicyParameterPayload() {
-  const lexicalPayload = runtimePolicyParameterPayloadFromValue(readLexicalRuntimePolicyParameterPayload());
-  if (lexicalPayload) {
-    return lexicalPayload;
-  }
-  for (const root of runtimeGlobalRoots()) {
-    const payload = runtimePolicyParameterPayloadFromValue(root[RUNTIME_POLICY_PARAMETERS_GLOBAL]);
-    if (payload) {
-      return payload;
-    }
-  }
-  return null;
-}
-function readLexicalRuntimePolicyParameterPayload() {
-  try {
-    if (typeof __SCREEPS_RL_RUNTIME_POLICY_PARAMETERS__ !== "undefined") {
-      return __SCREEPS_RL_RUNTIME_POLICY_PARAMETERS__;
-    }
-  } catch (_error) {
-    return void 0;
-  }
-  return void 0;
-}
-function runtimePolicyParameterPayloadFromValue(value) {
-  if (isRecord41(value) && value.runtimeParameterInjection === true && value.candidateParameterScope === "runtime_injected") {
-    return value;
-  }
-  return null;
-}
-function normalizeRuntimePolicyParameters(raw) {
-  if (!isRecord41(raw)) {
-    return null;
-  }
-  const parameters = {};
-  for (const [key, value] of Object.entries(raw)) {
-    if (typeof value === "number") {
-      if (Number.isFinite(value)) {
-        parameters[key] = value;
-      }
-    } else if (typeof value === "string" || typeof value === "boolean") {
-      parameters[key] = value;
-    }
-  }
-  return Object.keys(parameters).length > 0 ? parameters : null;
-}
-function runtimePolicyPayloadTargetsEntry(payload, entry) {
-  const explicitIds = runtimePolicyPayloadExplicitIds(payload);
-  const family = textOrUndefined(payload.family);
-  if (explicitIds.length > 0) {
-    return explicitIds.includes(entry.id);
-  }
-  return family !== void 0 && entry.family === family;
-}
-function runtimePolicyPayloadExplicitIds(payload) {
-  return [
-    textOrUndefined(payload.strategyVariantId),
-    textOrUndefined(payload.candidatePolicyId),
-    textOrUndefined(payload.sourceStrategyId)
-  ].filter((id) => id !== void 0);
-}
-function strategyEntryUsesRuntimeParameters(entry, parameters) {
-  for (const [key, value] of Object.entries(parameters)) {
-    if (entry.defaultValues[key] !== value) {
-      return false;
-    }
-  }
-  return true;
-}
-function buildConsumptionEvidence(options) {
-  var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n;
-  const runtimeParameterInjection = ((_a = options.payload) == null ? void 0 : _a.runtimeParameterInjection) === true && ((_b = options.payload) == null ? void 0 : _b.candidateParameterScope) === "runtime_injected";
-  return {
-    type: "screeps-rl-runtime-policy-parameter-consumption",
-    consumerMarker: RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER,
-    consumerVersion: RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION,
-    runtimeParameterInjection,
-    consumed: options.consumed,
-    ...textOrUndefined((_c = options.payload) == null ? void 0 : _c.strategyVariantId) ? { strategyVariantId: textOrUndefined((_d = options.payload) == null ? void 0 : _d.strategyVariantId) } : {},
-    ...textOrUndefined((_e = options.payload) == null ? void 0 : _e.candidatePolicyId) ? { candidatePolicyId: textOrUndefined((_f = options.payload) == null ? void 0 : _f.candidatePolicyId) } : {},
-    ...textOrUndefined((_g = options.payload) == null ? void 0 : _g.family) ? { family: textOrUndefined((_h = options.payload) == null ? void 0 : _h.family) } : {},
-    ...options.parameters ? { parameters: options.parameters } : {},
-    ...textOrUndefined((_i = options.payload) == null ? void 0 : _i.parametersSha256) ? { parametersSha256: textOrUndefined((_j = options.payload) == null ? void 0 : _j.parametersSha256) } : {},
-    ...options.consumed && textOrUndefined((_k = options.payload) == null ? void 0 : _k.strategyVariantId) ? { consumedStrategyVariantId: textOrUndefined((_l = options.payload) == null ? void 0 : _l.strategyVariantId) } : {},
-    ...options.consumed && textOrUndefined((_m = options.payload) == null ? void 0 : _m.parametersSha256) ? { consumedParametersSha256: textOrUndefined((_n = options.payload) == null ? void 0 : _n.parametersSha256) } : {},
-    appliedStrategyIds: [...options.appliedStrategyIds].sort(),
-    ...options.reason ? { reason: options.reason } : {},
-    liveEffect: false,
-    officialMmoWrites: false,
-    officialMmoWritesAllowed: false
-  };
-}
-function publishRuntimePolicyParameterConsumptionEvidence(evidence) {
-  for (const root of runtimeGlobalRoots()) {
-    root[RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL] = evidence;
-  }
-}
-function emitRuntimePolicyParameterConsumptionEvidence(evidence) {
-  if (evidence.runtimeParameterInjection !== true) {
-    return;
-  }
-  try {
-    console.log(`${RUNTIME_POLICY_PARAMETER_CONSUMPTION_LOG_PREFIX}${JSON.stringify(evidence)}`);
-  } catch (_error) {
-  }
-}
-function stickyRuntimePolicyParameterConsumptionEvidence(evidence, previous) {
-  if (evidence.consumed || !shouldCarryRuntimePolicyParameterConsumptionEvidence(evidence, previous)) {
-    return cloneRuntimePolicyParameterConsumptionEvidence(evidence);
-  }
-  return cloneRuntimePolicyParameterConsumptionEvidence(previous);
-}
-function shouldCarryRuntimePolicyParameterConsumptionEvidence(evidence, previous) {
-  if (!previous || previous.consumed !== true) {
-    return false;
-  }
-  if (evidence.runtimeParameterInjection !== true || previous.runtimeParameterInjection !== true) {
-    return false;
-  }
-  if (!evidence.parameters || !previous.parameters) {
-    return false;
-  }
-  if (evidence.consumerMarker !== RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER || previous.consumerMarker !== RUNTIME_POLICY_PARAMETERS_CONSUMER_MARKER || evidence.consumerVersion !== RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION || previous.consumerVersion !== RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION) {
-    return false;
-  }
-  const currentHash = textOrUndefined(evidence.parametersSha256);
-  const previousHash = textOrUndefined(previous.parametersSha256);
-  if (!currentHash || currentHash !== previousHash) {
-    return false;
-  }
-  return sameOptionalText(evidence.strategyVariantId, previous.strategyVariantId) && sameOptionalText(evidence.candidatePolicyId, previous.candidatePolicyId) && sameOptionalText(evidence.family, previous.family);
-}
-function cloneRuntimePolicyParameterConsumptionEvidence(evidence) {
-  const cloned = { ...evidence };
-  delete cloned.tick;
-  return {
-    ...cloned,
-    ...evidence.parameters ? { parameters: { ...evidence.parameters } } : {},
-    appliedStrategyIds: [...evidence.appliedStrategyIds]
-  };
-}
-function sameOptionalText(left, right) {
-  return textOrUndefined(left) === textOrUndefined(right);
-}
-function cloneStrategyRegistryEntry(entry) {
-  return {
-    ...entry,
-    defaultValues: { ...entry.defaultValues },
-    evidenceLinks: entry.evidenceLinks.map((link) => ({ ...link })),
-    rollback: {
-      ...entry.rollback,
-      stopConditions: [...entry.rollback.stopConditions]
-    },
-    supportedContext: {
-      ...entry.supportedContext,
-      artifactTypes: [...entry.supportedContext.artifactTypes],
-      ...entry.supportedContext.shards ? { shards: [...entry.supportedContext.shards] } : {},
-      ...entry.supportedContext.rooms ? { rooms: [...entry.supportedContext.rooms] } : {}
-    },
-    knobBounds: entry.knobBounds.map((knob) => ({ ...knob, bounds: { ...knob.bounds } }))
-  };
-}
-function textOrUndefined(value) {
-  return typeof value === "string" && value.length > 0 ? value : void 0;
-}
-function runtimeMemoryRoot() {
-  if (typeof Memory !== "undefined") {
-    return Memory;
-  }
-  const root = globalThis;
-  if (!root.Memory) {
-    root.Memory = {};
-  }
-  return root.Memory;
-}
-function runtimeGlobalRoots() {
-  const roots = [];
-  const root = globalThis;
-  addRuntimeGlobalRoot(roots, globalThis);
-  addRuntimeGlobalRoot(roots, root.global);
-  addRuntimeGlobalRoot(roots, root.self);
-  return roots;
-}
-function addRuntimeGlobalRoot(roots, value) {
-  if (!isRecord41(value) || roots.includes(value)) {
-    return;
-  }
-  roots.push(value);
-}
-function runtimeTick() {
-  var _a, _b;
-  if (typeof Game !== "undefined" && typeof Game.time === "number") {
-    return Game.time;
-  }
-  return (_b = (_a = globalThis.Game) == null ? void 0 : _a.time) != null ? _b : 0;
-}
-function isRecord41(value) {
-  return typeof value === "object" && value !== null;
-}
-
 // src/strategy/shadowEvaluator.ts
 var DEFAULT_VARIANCE_CONFIG = {
   enabled: true,
@@ -47871,7 +48017,7 @@ function normalizeHistoricalReplay(rawReplay) {
   if (!isRecord42(rawReplay)) {
     return null;
   }
-  if (!isNonEmptyString42(rawReplay.replayId) || !isNonEmptyString42(rawReplay.room) || !isFiniteNumber14(rawReplay.startTick) || !isFiniteNumber14(rawReplay.endTick) || !isFiniteNumber14(rawReplay.finalScore) || !isRecord42(rawReplay.kpiHistory)) {
+  if (!isNonEmptyString43(rawReplay.replayId) || !isNonEmptyString43(rawReplay.room) || !isFiniteNumber14(rawReplay.startTick) || !isFiniteNumber14(rawReplay.endTick) || !isFiniteNumber14(rawReplay.finalScore) || !isRecord42(rawReplay.kpiHistory)) {
     return null;
   }
   const kpiHistory = Object.entries(rawReplay.kpiHistory).reduce(
@@ -47899,7 +48045,7 @@ function formatCorrelation(correlation) {
 function isRecord42(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString42(value) {
+function isNonEmptyString43(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber14(value) {

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -1195,12 +1195,12 @@ function planDefenseSpawnForContext(context: SpawnPlanningContext): SpawnRequest
     }
   }
 
-  const runtimeObjectiveSpawn = planRuntimePolicyObjectiveDefenseSpawn(context);
-  if (runtimeObjectiveSpawn) {
-    return runtimeObjectiveSpawn;
+  const postClaimDefenseSpawn = planPostClaimControllerDefenseSpawn(context);
+  if (postClaimDefenseSpawn) {
+    return postClaimDefenseSpawn;
   }
 
-  return planPostClaimControllerDefenseSpawn(context);
+  return planRuntimePolicyObjectiveDefenseSpawn(context);
 }
 
 function planRuntimePolicyObjectiveDefenseSpawn(context: SpawnPlanningContext): SpawnRequest | null {
@@ -1217,10 +1217,8 @@ function planRuntimePolicyObjectiveDefenseSpawn(context: SpawnPlanningContext): 
     return null;
   }
 
-  if (
-    countAssignedRoomDefenders(objectiveTarget.targetRoom) >=
-    getDesiredDefenderCount(objectiveTarget.hostileCreepCount)
-  ) {
+  const assignedDefenders = countAssignedRoomDefenders(objectiveTarget.targetRoom);
+  if (assignedDefenders >= getDesiredDefenderCount(objectiveTarget.hostileCreepCount)) {
     return null;
   }
 
@@ -1232,7 +1230,7 @@ function planRuntimePolicyObjectiveDefenseSpawn(context: SpawnPlanningContext): 
   const defenderPlan = planDefenderSpawn({
     roomName: objectiveTarget.targetRoom,
     hostileCreepCount: objectiveTarget.hostileCreepCount,
-    activeDefenderCount: countAssignedRoomDefenders(objectiveTarget.targetRoom),
+    activeDefenderCount: assignedDefenders,
     energyAvailable: getSpawnEnergyBudget(context.colony),
     gameTime: context.gameTime,
     nameSuffix: context.options.nameSuffix

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -29,6 +29,7 @@ import {
   hasControllerAttackPressure,
   planDefenderSpawn
 } from '../defense/defensePlanner';
+import { selectRuntimePolicyObjectiveActivationTarget } from '../strategy/runtimePolicyParameters';
 import {
   selectDynamicCreepBody,
   type DynamicCreepBodyDemand,
@@ -1194,7 +1195,56 @@ function planDefenseSpawnForContext(context: SpawnPlanningContext): SpawnRequest
     }
   }
 
+  const runtimeObjectiveSpawn = planRuntimePolicyObjectiveDefenseSpawn(context);
+  if (runtimeObjectiveSpawn) {
+    return runtimeObjectiveSpawn;
+  }
+
   return planPostClaimControllerDefenseSpawn(context);
+}
+
+function planRuntimePolicyObjectiveDefenseSpawn(context: SpawnPlanningContext): SpawnRequest | null {
+  if (
+    context.survival.hostilePresence ||
+    context.survival.controllerDowngradeGuard ||
+    context.workerCapacity < Math.min(context.workerTarget, LOCAL_SUPPORT_WORKER_FLOOR)
+  ) {
+    return null;
+  }
+
+  const objectiveTarget = selectRuntimePolicyObjectiveActivationTarget(context.colony.room.name);
+  if (!objectiveTarget || objectiveTarget.hostileCreepCount <= 0) {
+    return null;
+  }
+
+  if (
+    countAssignedRoomDefenders(objectiveTarget.targetRoom) >=
+    getDesiredDefenderCount(objectiveTarget.hostileCreepCount)
+  ) {
+    return null;
+  }
+
+  const spawn = context.colony.spawns.find((candidate) => !candidate.spawning);
+  if (!spawn) {
+    return null;
+  }
+
+  const defenderPlan = planDefenderSpawn({
+    roomName: objectiveTarget.targetRoom,
+    hostileCreepCount: objectiveTarget.hostileCreepCount,
+    activeDefenderCount: countAssignedRoomDefenders(objectiveTarget.targetRoom),
+    energyAvailable: getSpawnEnergyBudget(context.colony),
+    gameTime: context.gameTime,
+    nameSuffix: context.options.nameSuffix
+  });
+  if (!defenderPlan) {
+    return null;
+  }
+
+  return {
+    spawn,
+    ...defenderPlan
+  };
 }
 
 function planDefenseSpawnForRoom(

--- a/prod/src/strategy/runtimePolicyParameters.ts
+++ b/prod/src/strategy/runtimePolicyParameters.ts
@@ -39,6 +39,14 @@ export interface RuntimePolicyParameterConsumptionRecorder {
   buildEvidence: () => RuntimePolicyParameterConsumptionEvidence;
 }
 
+export interface RuntimePolicyObjectiveActivationTarget {
+  colony: string;
+  targetRoom: string;
+  hostileCreepCount: number;
+  hostileStructureCount: number;
+  activationScore: number;
+}
+
 interface RuntimePolicyParameterPayload {
   runtimeParameterInjection?: unknown;
   candidateParameterScope?: unknown;
@@ -53,6 +61,8 @@ interface RuntimePolicyParameterPayload {
 type RuntimeMemory = Partial<Memory> & {
   rlRuntimePolicyParameters?: RuntimePolicyParameterConsumptionEvidence & { tick: number };
 };
+
+const MULTI_TIER_EXPANSION_ACTIVATION_MIN_SCORE = 12;
 
 export function applyRuntimePolicyParametersToRegistry(
   registry: StrategyRegistryEntry[]
@@ -189,6 +199,27 @@ export function persistRuntimePolicyParameterConsumptionEvidence(
   emitRuntimePolicyParameterConsumptionEvidence(tickedEvidence);
 }
 
+export function selectRuntimePolicyObjectiveActivationTarget(
+  colonyRoomName: string
+): RuntimePolicyObjectiveActivationTarget | null {
+  const payload = readRuntimePolicyParameterPayload();
+  if (!payload || !runtimePolicyPayloadTargetsConstructionPriority(payload)) {
+    return null;
+  }
+
+  const parameters = normalizeRuntimePolicyParameters(payload.parameters);
+  if (!parameters) {
+    return null;
+  }
+
+  const activationScore = scoreRuntimePolicyObjectiveActivation(parameters);
+  if (activationScore === null || activationScore < MULTI_TIER_EXPANSION_ACTIVATION_MIN_SCORE) {
+    return null;
+  }
+
+  return selectVisibleAdjacentHostileObjectiveTarget(colonyRoomName, activationScore);
+}
+
 function readRuntimePolicyParameterPayload(): RuntimePolicyParameterPayload | null {
   const lexicalPayload = runtimePolicyParameterPayloadFromValue(readLexicalRuntimePolicyParameterPayload());
   if (lexicalPayload) {
@@ -266,6 +297,126 @@ function runtimePolicyPayloadExplicitIds(payload: RuntimePolicyParameterPayload)
     textOrUndefined(payload.candidatePolicyId),
     textOrUndefined(payload.sourceStrategyId)
   ].filter((id): id is string => id !== undefined);
+}
+
+function runtimePolicyPayloadTargetsConstructionPriority(payload: RuntimePolicyParameterPayload): boolean {
+  const family = textOrUndefined(payload.family);
+  if (family === 'construction-priority') {
+    return true;
+  }
+
+  return runtimePolicyPayloadExplicitIds(payload).some((id) => id.startsWith('construction-priority.'));
+}
+
+function scoreRuntimePolicyObjectiveActivation(parameters: Record<string, StrategyKnobValue>): number | null {
+  const territorySignalWeight = strategyNumber(parameters.territorySignalWeight);
+  if (territorySignalWeight === null) {
+    return null;
+  }
+
+  const baseScoreWeight = strategyNumber(parameters.baseScoreWeight) ?? 1;
+  const killSignalWeight = strategyNumber(parameters.killSignalWeight) ?? 0;
+  const riskPenalty = strategyNumber(parameters.riskPenalty) ?? 0;
+  return territorySignalWeight * baseScoreWeight + Math.min(killSignalWeight, 8) * 0.25 - riskPenalty * 0.25;
+}
+
+function selectVisibleAdjacentHostileObjectiveTarget(
+  colonyRoomName: string,
+  activationScore: number
+): RuntimePolicyObjectiveActivationTarget | null {
+  if (!isNonEmptyString(colonyRoomName)) {
+    return null;
+  }
+
+  const rooms = (globalThis as { Game?: Partial<Pick<Game, 'rooms'>> }).Game?.rooms;
+  if (!rooms) {
+    return null;
+  }
+
+  const candidates: RuntimePolicyObjectiveActivationTarget[] = [];
+  for (const [roomName, room] of Object.entries(rooms)) {
+    if (!room || roomName === colonyRoomName || !areRoomsAdjacent(colonyRoomName, roomName)) {
+      continue;
+    }
+
+    const hostileCreepCount = countRoomFind(room, 'FIND_HOSTILE_CREEPS');
+    const hostileStructureCount = countRoomFind(room, 'FIND_HOSTILE_STRUCTURES');
+    if (hostileCreepCount + hostileStructureCount <= 0) {
+      continue;
+    }
+
+    candidates.push({
+      colony: colonyRoomName,
+      targetRoom: roomName,
+      hostileCreepCount,
+      hostileStructureCount,
+      activationScore
+    });
+  }
+
+  return candidates.sort(compareRuntimePolicyObjectiveActivationTargets)[0] ?? null;
+}
+
+function compareRuntimePolicyObjectiveActivationTargets(
+  left: RuntimePolicyObjectiveActivationTarget,
+  right: RuntimePolicyObjectiveActivationTarget
+): number {
+  return (
+    right.hostileCreepCount - left.hostileCreepCount ||
+    right.hostileStructureCount - left.hostileStructureCount ||
+    left.targetRoom.localeCompare(right.targetRoom)
+  );
+}
+
+function countRoomFind(room: Room, globalName: 'FIND_HOSTILE_CREEPS' | 'FIND_HOSTILE_STRUCTURES'): number {
+  const findConstant = (globalThis as Record<string, unknown>)[globalName];
+  if (typeof findConstant !== 'number' || typeof room.find !== 'function') {
+    return 0;
+  }
+
+  try {
+    const result = room.find(findConstant as FindConstant);
+    return Array.isArray(result) ? result.length : 0;
+  } catch (_error) {
+    return 0;
+  }
+}
+
+function areRoomsAdjacent(left: string, right: string): boolean {
+  const gameMap = (globalThis as { Game?: Partial<Pick<Game, 'map'>> }).Game?.map;
+  if (gameMap && typeof gameMap.describeExits === 'function') {
+    const exits = gameMap.describeExits(left);
+    if (exits && Object.values(exits).includes(right)) {
+      return true;
+    }
+  }
+
+  const leftCoordinates = parseRoomCoordinates(left);
+  const rightCoordinates = parseRoomCoordinates(right);
+  if (!leftCoordinates || !rightCoordinates) {
+    return false;
+  }
+
+  const dx = Math.abs(leftCoordinates.x - rightCoordinates.x);
+  const dy = Math.abs(leftCoordinates.y - rightCoordinates.y);
+  return dx <= 1 && dy <= 1 && dx + dy > 0;
+}
+
+function parseRoomCoordinates(roomName: string): { x: number; y: number } | null {
+  const match = /^(E|W)(\d+)(N|S)(\d+)$/.exec(roomName);
+  if (!match) {
+    return null;
+  }
+
+  const horizontal = match[1] === 'E' ? Number(match[2]) : -Number(match[2]) - 1;
+  const vertical = match[3] === 'S' ? Number(match[4]) : -Number(match[4]) - 1;
+  return Number.isFinite(horizontal) && Number.isFinite(vertical)
+    ? { x: horizontal, y: vertical }
+    : null;
+}
+
+function strategyNumber(value: StrategyKnobValue | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 
 function strategyEntryUsesRuntimeParameters(
@@ -442,6 +593,10 @@ function cloneStrategyRegistryEntry(entry: StrategyRegistryEntry): StrategyRegis
 
 function textOrUndefined(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
 }
 
 function runtimeMemoryRoot(): RuntimeMemory {

--- a/prod/src/strategy/runtimePolicyParameters.ts
+++ b/prod/src/strategy/runtimePolicyParameters.ts
@@ -386,8 +386,8 @@ function areRoomsAdjacent(left: string, right: string): boolean {
   const gameMap = (globalThis as { Game?: Partial<Pick<Game, 'map'>> }).Game?.map;
   if (gameMap && typeof gameMap.describeExits === 'function') {
     const exits = gameMap.describeExits(left);
-    if (exits && Object.values(exits).includes(right)) {
-      return true;
+    if (exits) {
+      return Object.values(exits).includes(right);
     }
   }
 
@@ -399,7 +399,7 @@ function areRoomsAdjacent(left: string, right: string): boolean {
 
   const dx = Math.abs(leftCoordinates.x - rightCoordinates.x);
   const dy = Math.abs(leftCoordinates.y - rightCoordinates.y);
-  return dx <= 1 && dy <= 1 && dx + dy > 0;
+  return (dx === 1 && dy === 0) || (dx === 0 && dy === 1);
 }
 
 function parseRoomCoordinates(roomName: string): { x: number; y: number } | null {

--- a/prod/test/runtimePolicyParameters.test.ts
+++ b/prod/test/runtimePolicyParameters.test.ts
@@ -5,7 +5,8 @@ import {
   RUNTIME_POLICY_PARAMETERS_CONSUMER_VERSION,
   applyRuntimePolicyParametersToRegistry,
   createRuntimePolicyParameterConsumptionRecorder,
-  persistRuntimePolicyParameterConsumptionEvidence
+  persistRuntimePolicyParameterConsumptionEvidence,
+  selectRuntimePolicyObjectiveActivationTarget
 } from '../src/strategy/runtimePolicyParameters';
 import { DEFAULT_STRATEGY_REGISTRY } from '../src/strategy/strategyRegistry';
 
@@ -16,7 +17,52 @@ describe('runtime policy parameters', () => {
     delete (globalThis as Record<string, unknown>).self;
     delete (globalThis as { Memory?: unknown }).Memory;
     delete (globalThis as { Game?: unknown }).Game;
+    delete (globalThis as { FIND_HOSTILE_CREEPS?: number }).FIND_HOSTILE_CREEPS;
+    delete (globalThis as { FIND_HOSTILE_STRUCTURES?: number }).FIND_HOSTILE_STRUCTURES;
   });
+
+  function installRuntimeConstructionPriorityPayload(): void {
+    (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETERS_GLOBAL] = {
+      runtimeParameterInjection: true,
+      candidateParameterScope: 'runtime_injected',
+      strategyVariantId: 'construction-priority.pg.territory-seed.v1',
+      candidatePolicyId: 'construction-priority.pg.territory-seed.v1',
+      sourceStrategyId: 'construction-priority.incumbent.v1',
+      family: 'construction-priority',
+      parameters: {
+        baseScoreWeight: 1,
+        territorySignalWeight: 22,
+        resourceSignalWeight: 3,
+        killSignalWeight: 5,
+        riskPenalty: 4
+      },
+      parametersSha256: 'runtime-objective-sha'
+    };
+  }
+
+  function installHostileFindGlobals(): void {
+    (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 3;
+    (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 4;
+  }
+
+  function makeRuntimeRoom(roomName: string, hostileCreepCount = 0, hostileStructureCount = 0): Room {
+    return {
+      name: roomName,
+      find: jest.fn((type: number) => {
+        if (type === FIND_HOSTILE_CREEPS) {
+          return Array.from({ length: hostileCreepCount }, (_, index) => ({ id: `${roomName}-hostile-${index}` }));
+        }
+
+        if (type === FIND_HOSTILE_STRUCTURES) {
+          return Array.from({ length: hostileStructureCount }, (_, index) => ({
+            id: `${roomName}-structure-${index}`
+          }));
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+  }
 
   it('applies private-simulator payload parameters to matching strategy entries', () => {
     (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETERS_GLOBAL] = {
@@ -266,6 +312,37 @@ describe('runtime policy parameters', () => {
       appliedStrategyIds: [],
       reason: 'runtime policy parameter payload was not used by tick runtime strategy evaluation'
     });
+  });
+
+  it('uses describeExits as authoritative for runtime objective adjacency', () => {
+    installHostileFindGlobals();
+    installRuntimeConstructionPriorityPayload();
+    const describeExits = jest.fn((roomName: string) =>
+      roomName === 'E0N0' ? { 1: 'E0N1', 3: 'E1N0' } : {}
+    );
+    (globalThis as { Game?: Partial<Game> }).Game = {
+      rooms: {
+        E0N0: makeRuntimeRoom('E0N0'),
+        E1N1: makeRuntimeRoom('E1N1', 2, 1)
+      },
+      map: { describeExits } as unknown as GameMap
+    };
+
+    expect(selectRuntimePolicyObjectiveActivationTarget('E0N0')).toBeNull();
+    expect(describeExits).toHaveBeenCalledWith('E0N0');
+  });
+
+  it('does not treat diagonal rooms as adjacent without map exit data', () => {
+    installHostileFindGlobals();
+    installRuntimeConstructionPriorityPayload();
+    (globalThis as { Game?: Partial<Game> }).Game = {
+      rooms: {
+        E0N0: makeRuntimeRoom('E0N0'),
+        E1N1: makeRuntimeRoom('E1N1', 2, 1)
+      }
+    };
+
+    expect(selectRuntimePolicyObjectiveActivationTarget('E0N0')).toBeNull();
   });
 
   it('keeps consumed evidence sticky across ticks for the same injected payload', () => {

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -23,6 +23,7 @@ import {
   TERRITORY_AUTO_CLAIM_REQUIRED_ENERGY,
   TERRITORY_AUTO_CLAIM_RESERVATION_MIN_TICKS
 } from '../src/territory/autoClaim';
+import { RUNTIME_POLICY_PARAMETERS_GLOBAL } from '../src/strategy/runtimePolicyParameters';
 import { installRuntimeCurrentRoom } from './helpers/runtimeRoomConfig';
 
 describe('planSpawn', () => {
@@ -70,6 +71,7 @@ describe('planSpawn', () => {
     };
     delete (globalThis as { FIND_HOSTILE_CREEPS?: number }).FIND_HOSTILE_CREEPS;
     delete (globalThis as { FIND_HOSTILE_STRUCTURES?: number }).FIND_HOSTILE_STRUCTURES;
+    delete (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETERS_GLOBAL];
     delete (globalThis as { Game?: Partial<Game> }).Game;
     delete (globalThis as { Memory?: Partial<Memory> }).Memory;
   });
@@ -243,6 +245,37 @@ describe('planSpawn', () => {
       find: jest.fn((type: number) => {
         if (type === FIND_SOURCES) {
           return Array.from({ length: sourceCount }, (_, index) => ({ id: `${roomName}-source${index}` }));
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+  }
+
+  function installRuntimeConstructionPriorityPayload(parameters: Record<string, number>): void {
+    (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETERS_GLOBAL] = {
+      runtimeParameterInjection: true,
+      candidateParameterScope: 'runtime_injected',
+      strategyVariantId: 'construction-priority.pg.territory-seed.v1',
+      candidatePolicyId: 'construction-priority.pg.territory-seed.v1',
+      sourceStrategyId: 'construction-priority.incumbent.v1',
+      family: 'construction-priority',
+      parameters,
+      parametersSha256: 'runtime-objective-sha'
+    };
+  }
+
+  function makeRuntimeObjectiveHostileRoom(roomName = 'E2S1'): Room {
+    return {
+      name: roomName,
+      controller: { id: `${roomName}-controller`, my: false, owner: { username: 'Invader' } } as StructureController,
+      find: jest.fn((type: number) => {
+        if (type === FIND_HOSTILE_CREEPS) {
+          return [{ id: `${roomName}-hostile-1` }, { id: `${roomName}-hostile-2` }] as Creep[];
+        }
+
+        if (type === FIND_HOSTILE_STRUCTURES) {
+          return [{ id: `${roomName}-spawn`, structureType: STRUCTURE_SPAWN }] as Structure[];
         }
 
         return [];
@@ -2964,6 +2997,76 @@ describe('planSpawn', () => {
         defense: { homeRoom: 'W1N1' }
       }
     });
+  });
+
+  it('spawns a defender toward a visible adjacent hostile room when runtime construction weights activate the objective', () => {
+    installHostileFindGlobals();
+    installRuntimeConstructionPriorityPayload({
+      baseScoreWeight: 1,
+      territorySignalWeight: 22,
+      resourceSignalWeight: 3,
+      killSignalWeight: 5,
+      riskPenalty: 4
+    });
+    const { colony, spawn } = makeColony({
+      roomName: 'E1S1',
+      sourceCount: 2,
+      energyAvailable: 300,
+      energyCapacityAvailable: 300,
+      controller: makeSafeOwnedController(3)
+    });
+    const hostileRoom = makeRuntimeObjectiveHostileRoom('E2S1');
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      rooms: {
+        E1S1: colony.room,
+        E2S1: hostileRoom
+      },
+      map: {
+        describeExits: jest.fn(() => ({ 3: 'E2S1' }))
+      } as unknown as GameMap
+    };
+
+    expect(planSpawn(colony, { worker: 4, sourceHarvester: 2 }, 165)).toEqual({
+      spawn,
+      body: ['tough', 'attack', 'move', 'tough', 'attack', 'move'],
+      name: 'defender-E2S1-165',
+      memory: {
+        role: 'defender',
+        colony: 'E2S1',
+        defense: { homeRoom: 'E2S1' }
+      }
+    });
+  });
+
+  it('does not spawn a runtime objective defender for low-scoring construction weights', () => {
+    installHostileFindGlobals();
+    installRuntimeConstructionPriorityPayload({
+      baseScoreWeight: 1,
+      territorySignalWeight: 2,
+      resourceSignalWeight: 18,
+      killSignalWeight: 3,
+      riskPenalty: 3
+    });
+    const { colony } = makeColony({
+      roomName: 'E1S1',
+      sourceCount: 2,
+      energyAvailable: 300,
+      energyCapacityAvailable: 300,
+      controller: makeSafeOwnedController(3)
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      rooms: {
+        E1S1: colony.room,
+        E2S1: makeRuntimeObjectiveHostileRoom('E2S1')
+      },
+      map: {
+        describeExits: jest.fn(() => ({ 3: 'E2S1' }))
+      } as unknown as GameMap
+    };
+
+    expect(planSpawn(colony, { worker: 4, sourceHarvester: 2 }, 166)).toBeNull();
   });
 
   it('keeps bootstrap recovery ahead of defender spawning while hostiles are visible', () => {

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -3016,6 +3016,9 @@ describe('planSpawn', () => {
       controller: makeSafeOwnedController(3)
     });
     const hostileRoom = makeRuntimeObjectiveHostileRoom('E2S1');
+    const describeExits = jest.fn((roomName: string) =>
+      roomName === colony.room.name ? { 3: 'E2S1' } : {}
+    );
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       creeps: {},
       rooms: {
@@ -3023,7 +3026,7 @@ describe('planSpawn', () => {
         E2S1: hostileRoom
       },
       map: {
-        describeExits: jest.fn(() => ({ 3: 'E2S1' }))
+        describeExits
       } as unknown as GameMap
     };
 
@@ -3037,6 +3040,70 @@ describe('planSpawn', () => {
         defense: { homeRoom: 'E2S1' }
       }
     });
+    expect(describeExits).toHaveBeenCalledWith(colony.room.name);
+  });
+
+  it('keeps post-claim controller defense ahead of runtime objective defenders', () => {
+    installHostileFindGlobals();
+    installRuntimeConstructionPriorityPayload({
+      baseScoreWeight: 1,
+      territorySignalWeight: 22,
+      resourceSignalWeight: 3,
+      killSignalWeight: 5,
+      riskPenalty: 4
+    });
+    const { colony, spawn } = makeColony({
+      roomName: 'E1S1',
+      sourceCount: 2,
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController(4)
+    });
+    const describeExits = jest.fn((roomName: string) =>
+      roomName === colony.room.name ? { 3: 'E2S1' } : {}
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      rooms: {
+        E1S1: colony.room,
+        E2S1: makeRuntimeObjectiveHostileRoom('E2S1'),
+        W2N1: makeTerritoryRoom('W2N1', {
+          id: 'controller2',
+          my: true,
+          level: 1,
+          upgradeBlocked: 20
+        } as StructureController)
+      },
+      spawns: { Spawn1: spawn },
+      map: { describeExits } as unknown as GameMap
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          W2N1: {
+            colony: 'E1S1',
+            roomName: 'W2N1',
+            status: 'ready',
+            claimedAt: 174,
+            updatedAt: 175,
+            workerTarget: 2,
+            controllerId: 'controller2' as Id<StructureController>
+          }
+        }
+      }
+    };
+
+    expect(planSpawn(colony, { worker: 4, sourceHarvester: 2 }, 167)).toEqual({
+      spawn,
+      body: ['tough', 'attack', 'move'],
+      name: 'defender-W2N1-167',
+      memory: {
+        role: 'defender',
+        colony: 'W2N1',
+        defense: { homeRoom: 'W2N1' }
+      }
+    });
+    expect(describeExits).not.toHaveBeenCalled();
   });
 
   it('does not spawn a runtime objective defender for low-scoring construction weights', () => {
@@ -3055,6 +3122,9 @@ describe('planSpawn', () => {
       energyCapacityAvailable: 300,
       controller: makeSafeOwnedController(3)
     });
+    const describeExits = jest.fn((roomName: string) =>
+      roomName === colony.room.name ? { 3: 'E2S1' } : {}
+    );
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       creeps: {},
       rooms: {
@@ -3062,7 +3132,7 @@ describe('planSpawn', () => {
         E2S1: makeRuntimeObjectiveHostileRoom('E2S1')
       },
       map: {
-        describeExits: jest.fn(() => ({ 3: 'E2S1' }))
+        describeExits
       } as unknown as GameMap
     };
 


### PR DESCRIPTION
## Summary
- consumes runtime construction-priority policy weights in spawn planning via objective activation scoring
- directs defender spawning toward visible adjacent hostile rooms when activated so simulator objective signals can exceed the flat territory/kills floor
- adds focused regression coverage and rebuilt `prod/dist/main.js`

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 103 suites / 2057 tests passed
- `cd prod && npm run build`

## Issue closure gate
- [ ] #1299: keep open until a fresh Loop A/Tencent/local validation artifact proves `SIMULATOR_OBJECTIVE_SIGNAL_NOT_ACTIVATED` cleared (territory>2 or hostileKills>0) with runtime parameter consumption evidence.

Refs #1299
Refs #1337
Refs #1032
