### PR TITLE
fix(rl): activate objective defender priority

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35185,7 +35185,7 @@ function getSpawnQueueRolePriorityRank(priority) {
   }
 }
 function getDefenseSpawnQueuePriority(context) {
-  return context.survival.hostilePresence || hasOwnedRoomHostilePresence() || hasControllerAttackPressure(context.colony.room.controller) || selectPostClaimControllerDefensePlan(context.colony) ? "critical" : "normal";
+  return context.survival.hostilePresence || hasOwnedRoomHostilePresence() || hasControllerAttackPressure(context.colony.room.controller) || selectPostClaimControllerDefensePlan(context.colony) || hasRuntimePolicyObjectiveDefenseSpawnDemand(context) ? "critical" : "normal";
 }
 function getLocalSourceMiningSpawnQueuePriority(context) {
   return hasLocalSourceHarvesterShortfall(context) ? "critical" : "high";
@@ -35682,6 +35682,13 @@ function planRuntimePolicyObjectiveDefenseSpawn(context) {
     spawn,
     ...defenderPlan
   };
+}
+function hasRuntimePolicyObjectiveDefenseSpawnDemand(context) {
+  if (context.survival.hostilePresence || context.survival.controllerDowngradeGuard || context.workerCapacity < Math.min(context.workerTarget, LOCAL_SUPPORT_WORKER_FLOOR)) {
+    return false;
+  }
+  const objectiveTarget = selectRuntimePolicyObjectiveActivationTarget(context.colony.room.name);
+  return objectiveTarget !== null && objectiveTarget.hostileCreepCount > 0 && countAssignedRoomDefenders(objectiveTarget.targetRoom) < getDesiredDefenderCount(objectiveTarget.hostileCreepCount);
 }
 function planDefenseSpawnForRoom(colony, activeDefenderCount, gameTime, options) {
   const hostileCount = getRoomHostileCreepCount(colony.room);

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -475,7 +475,8 @@ function getDefenseSpawnQueuePriority(context: SpawnPlanningContext): SpawnQueue
   return context.survival.hostilePresence ||
     hasOwnedRoomHostilePresence() ||
     hasControllerAttackPressure(context.colony.room.controller) ||
-    selectPostClaimControllerDefensePlan(context.colony)
+    selectPostClaimControllerDefensePlan(context.colony) ||
+    hasRuntimePolicyObjectiveDefenseSpawnDemand(context)
     ? 'critical'
     : 'normal';
 }
@@ -1243,6 +1244,23 @@ function planRuntimePolicyObjectiveDefenseSpawn(context: SpawnPlanningContext): 
     spawn,
     ...defenderPlan
   };
+}
+
+function hasRuntimePolicyObjectiveDefenseSpawnDemand(context: SpawnPlanningContext): boolean {
+  if (
+    context.survival.hostilePresence ||
+    context.survival.controllerDowngradeGuard ||
+    context.workerCapacity < Math.min(context.workerTarget, LOCAL_SUPPORT_WORKER_FLOOR)
+  ) {
+    return false;
+  }
+
+  const objectiveTarget = selectRuntimePolicyObjectiveActivationTarget(context.colony.room.name);
+  return (
+    objectiveTarget !== null &&
+    objectiveTarget.hostileCreepCount > 0 &&
+    countAssignedRoomDefenders(objectiveTarget.targetRoom) < getDesiredDefenderCount(objectiveTarget.hostileCreepCount)
+  );
 }
 
 function planDefenseSpawnForRoom(

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -3044,6 +3044,39 @@ describe('planSpawn', () => {
   });
 
   it('prioritizes a runtime objective defender before source mining once local workers are stable', () => {
+    const sourcePositions = [
+      { x: 10, y: 20, roomName: 'E1S1' } as RoomPosition,
+      { x: 40, y: 28, roomName: 'E1S1' } as RoomPosition
+    ];
+    const sourceContainers = [
+      makeRemoteContainer('container0', 0, 10, 21, 'E1S1') as unknown as AnyStructure,
+      makeRemoteContainer('container1', 0, 40, 29, 'E1S1') as unknown as AnyStructure
+    ];
+    const { colony, spawn } = makeColony({
+      roomName: 'E1S1',
+      sourceCount: 2,
+      energyAvailable: 600,
+      energyCapacityAvailable: 600,
+      controller: makeSafeOwnedController(3),
+      sourcePositions,
+      structures: sourceContainers
+    });
+
+    expect(planSpawn(colony, { worker: 3, sourceHarvester: 0 }, 167)).toEqual({
+      spawn,
+      body: ['work', 'work', 'work', 'work', 'work', 'carry', 'move'],
+      name: 'sourceHarvester-E1S1-source0-167',
+      memory: {
+        role: 'sourceHarvester',
+        colony: 'E1S1',
+        sourceHarvester: {
+          roomName: 'E1S1',
+          sourceId: 'source0',
+          containerId: 'container0'
+        }
+      }
+    });
+
     installHostileFindGlobals();
     installRuntimeConstructionPriorityPayload({
       baseScoreWeight: 1,
@@ -3051,17 +3084,6 @@ describe('planSpawn', () => {
       resourceSignalWeight: 3,
       killSignalWeight: 5,
       riskPenalty: 4
-    });
-    const { colony, spawn } = makeColony({
-      roomName: 'E1S1',
-      sourceCount: 2,
-      energyAvailable: 300,
-      energyCapacityAvailable: 300,
-      controller: makeSafeOwnedController(3),
-      sourcePositions: [
-        { x: 10, y: 20, roomName: 'E1S1' } as RoomPosition,
-        { x: 40, y: 28, roomName: 'E1S1' } as RoomPosition
-      ]
     });
     const hostileRoom = makeRuntimeObjectiveHostileRoom('E2S1');
     const describeExits = jest.fn((roomName: string) =>

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -3043,6 +3043,53 @@ describe('planSpawn', () => {
     expect(describeExits).toHaveBeenCalledWith(colony.room.name);
   });
 
+  it('prioritizes a runtime objective defender before source mining once local workers are stable', () => {
+    installHostileFindGlobals();
+    installRuntimeConstructionPriorityPayload({
+      baseScoreWeight: 1,
+      territorySignalWeight: 22,
+      resourceSignalWeight: 3,
+      killSignalWeight: 5,
+      riskPenalty: 4
+    });
+    const { colony, spawn } = makeColony({
+      roomName: 'E1S1',
+      sourceCount: 2,
+      energyAvailable: 300,
+      energyCapacityAvailable: 300,
+      controller: makeSafeOwnedController(3),
+      sourcePositions: [
+        { x: 10, y: 20, roomName: 'E1S1' } as RoomPosition,
+        { x: 40, y: 28, roomName: 'E1S1' } as RoomPosition
+      ]
+    });
+    const hostileRoom = makeRuntimeObjectiveHostileRoom('E2S1');
+    const describeExits = jest.fn((roomName: string) =>
+      roomName === colony.room.name ? { 3: 'E2S1' } : {}
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      rooms: {
+        E1S1: colony.room,
+        E2S1: hostileRoom
+      },
+      map: {
+        describeExits
+      } as unknown as GameMap
+    };
+
+    expect(planSpawn(colony, { worker: 3, sourceHarvester: 0 }, 168)).toEqual({
+      spawn,
+      body: ['tough', 'attack', 'move', 'tough', 'attack', 'move'],
+      name: 'defender-E2S1-168',
+      memory: {
+        role: 'defender',
+        colony: 'E2S1',
+        defense: { homeRoom: 'E2S1' }
+      }
+    });
+  });
+
   it('keeps post-claim controller defense ahead of runtime objective defenders', () => {
     installHostileFindGlobals();
     installRuntimeConstructionPriorityPayload({

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -755,6 +755,71 @@ class RlTrainingRunnerTest(unittest.TestCase):
         self.assertEqual(proof["bestObserved"]["territoryScore"], 3.0)
         self.assertEqual(proof["blocker"]["classification"], "SIMULATOR_OBJECTIVE_SIGNAL_NOT_ACTIVATED")
 
+    def test_multi_tier_activation_proof_blocks_post_1448_smoke_without_combat_activation(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-training-multitier-post-1448-blocked",
+            code_commit="b" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-18T10:24:30Z",
+            scenario_id=card_helper.MULTI_TIER_SCENARIO_ID,
+            require_multi_tier_scenario=True,
+        )
+        proof = runner.build_multi_tier_activation_proof(
+            results=[
+                {
+                    "variantId": "construction-priority.pg.territory-seed.v1",
+                    "sampleCount": 1,
+                    "metrics": {
+                        "territory": {"delta": 2},
+                        "kills": {"hostileKills": 0},
+                        "objectiveSignal": {
+                            "initialObservedRoomCount": 2,
+                            "finalObservedRoomCount": 2,
+                            "initialHostileCreeps": 2,
+                            "finalHostileCreeps": 2,
+                            "initialHostileStructures": 1,
+                            "finalHostileStructures": 1,
+                            "initialObjectiveSignalPresent": True,
+                            "finalObjectiveSignalPresent": True,
+                        },
+                    },
+                    "multiTierActivationTraces": [
+                        {
+                            "sampleIndex": 0,
+                            "ticksRun": 500,
+                            "policyActivationPresent": True,
+                            "policyActivation": {
+                                "executionAction": "engage-hostiles",
+                                "objectiveSignalSource": "tick_log",
+                                "targetRoom": "E2S1",
+                            },
+                        }
+                    ],
+                }
+            ],
+            scenario=card["scenario"],
+            kpi_summary={},
+        )
+
+        self.assertIsNotNone(proof)
+        if proof is None:
+            self.fail("expected multi-tier activation proof")
+        self.assertEqual(proof["status"], "blocked")
+        self.assertEqual(proof["criteria"]["territoryScoreMustExceed"], 2)
+        self.assertEqual(proof["criteria"]["hostileKillsMustExceed"], 0)
+        self.assertTrue(proof["transport"]["objectiveSignalObserved"])
+        self.assertEqual(proof["bestObserved"]["territoryScore"], 2.0)
+        self.assertEqual(proof["bestObserved"]["hostileKills"], 0.0)
+        self.assertEqual(proof["blocker"]["classification"], "SIMULATOR_OBJECTIVE_SIGNAL_NOT_ACTIVATED")
+        sample = proof["variants"][0]["activationSamples"][0]
+        self.assertTrue(sample["objectiveSignalObserved"])
+        self.assertFalse(sample["activationScorePasses"])
+        self.assertFalse(sample["passesActivation"])
+        trace = proof["variants"][0]["activationTraces"][0]
+        self.assertEqual(trace["ticksRun"], 500)
+        self.assertEqual(trace["policyActivation"]["executionAction"], "engage-hostiles")
+        self.assertEqual(trace["policyActivation"]["targetRoom"], "E2S1")
+
     def test_multi_tier_activation_proof_reports_missing_samples_separately(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-training-multitier-no-samples",


### PR DESCRIPTION
## Summary
- Prioritize runtime-policy objective defender spawns as critical once local workers are stable, so source-mining recovery does not starve the multi-tier territory/combat objective activation path.
- Add a spawn-planner regression covering the post-local-worker-stability objective-defender priority.
- Add a training-runner activation-proof regression for the post-#1448 smoke shape where objective transport is present but territory/combat activation remains blocked.
- Regenerate `prod/dist/main.js` via `npm run build`.

## Verification
Controller-side verification completed on commit `85e7f67e`:
- `git diff --check`
- `python3 -m unittest scripts.test_screeps_rl_training_runner.RlTrainingRunnerTest.test_multi_tier_activation_proof_blocks_post_1448_smoke_without_combat_activation scripts.test_screeps_rl_training_runner.RlTrainingRunnerTest.test_multi_tier_activation_proof_rejects_stitched_sample_average scripts.test_screeps_rl_training_runner.RlTrainingRunnerTest.test_multi_tier_activation_proof_passes_when_variant_has_hostile_kill_signal`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (103 suites / 2061 tests passed)
- `cd prod && npm run build`

## Issue linkage
Related to issue 1450, issue 879, issue 1032, and issue 1337.

Issue 1450 remains open until the scheduler attaches post-merge guarded-smoke objective-activation evidence (`territoryScore > 2` or `hostileKills > 0`).

## Post-merge validation gate
After merge, run exactly one guarded Tencent/private smoke from the merged `main`; keep `officialMmoWrites=false` / `liveEffect=false`; require activation proof with `territoryScore > 2` or `hostileKills > 0` before starting validation-scale.