### PR TITLE
fix(rl): harden Tencent pre-scale smoke

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -88,6 +88,8 @@ RUN_RUNTIME_PARAMETER_CONSUMPTION_PROBE_RETRY_SECONDS = 1.0
 RUN_WORKER_PREFIX = "rl-sim-worker"
 RUN_BROKEN_PIPE_MAX_RETRIES = 1
 RUN_BROKEN_PIPE_RETRY_BACKOFF_SECONDS = 2.0
+RUN_COMPOSE_SETUP_MAX_ATTEMPTS = 2
+RUN_COMPOSE_SETUP_RETRY_BACKOFF_SECONDS = 2.0
 RUN_ID_PREFIX = "rl-sim-run"
 RUN_ID_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 RUN_RESOURCE_GUARD_ALLOW_UNSAFE_ENV = "SCREEPS_RL_SIM_ALLOW_UNSAFE_SCALE"
@@ -143,6 +145,13 @@ PRIVATE_MAP_FIXTURE_TYPE = "screeps-rl-private-map-fixture"
 _WORKER_PHASE_DEBUG_DISABLED = False
 SCALE_ENVIRONMENT_VARIANT_RE = re.compile(r"^(?P<base>.+)\.scale-env-(?P<index>\d{2,})$")
 ROOM_NAME_RE = re.compile(r"^(?P<horizontal>[WE])(?P<x>\d+)(?P<vertical>[NS])(?P<y>\d+)$")
+RUN_COMPOSE_SETUP_RETRYABLE_OUTPUT_RE = re.compile(
+    r"(?:unexpected EOF|context deadline exceeded|i/o timeout|TLS handshake timeout|"
+    r"connection reset|connection refused|temporary failure|network .*timed? out|"
+    r"net/http|Client\.Timeout|request canceled|too many requests|toomanyrequests|"
+    r"error pulling image|failed to (?:copy|extract|pull|fetch))",
+    re.IGNORECASE,
+)
 HARNESS_EXCLUDED_DIRECTORY_NAMES = ("node_modules", ".git", "__pycache__")
 HARNESS_BINARY_FILE_EXTENSIONS = (
     ".bmp",
@@ -4407,6 +4416,72 @@ def _require_command_success(smoke: Any, result: Any, phase: str) -> JsonObject:
     return result
 
 
+def _compose_setup_attempt_summary(result: Any, attempt: int) -> JsonObject:
+    if not isinstance(result, dict):
+        return {
+            "attempt": attempt,
+            "returncode": None,
+            "elapsedSeconds": None,
+            "outputExcerpt": _safe_text(result, 500),
+            "retryable": False,
+        }
+    return {
+        "attempt": attempt,
+        "returncode": _coerce_int(result.get("returncode")),
+        "elapsedSeconds": result.get("elapsed_seconds"),
+        "outputExcerpt": _safe_text(result.get("output_excerpt", ""), 500),
+        "retryable": _is_retryable_compose_setup_failure(result),
+    }
+
+
+def _is_retryable_compose_setup_failure(result: Any) -> bool:
+    if not isinstance(result, dict):
+        return False
+    if result.get("returncode") in (None, 0):
+        return False
+    output = str(result.get("output_excerpt", ""))
+    return bool(RUN_COMPOSE_SETUP_RETRYABLE_OUTPUT_RE.search(output))
+
+
+def _run_compose_setup_command_with_retry(
+    smoke: Any,
+    cfg: Any,
+    command: list[str],
+    phase: str,
+    *,
+    timeout: int,
+) -> JsonObject:
+    attempts: list[JsonObject] = []
+    for attempt in range(1, RUN_COMPOSE_SETUP_MAX_ATTEMPTS + 1):
+        result = smoke.run_command(command, cfg, timeout=timeout)
+        attempts.append(_compose_setup_attempt_summary(result, attempt))
+        if isinstance(result, dict) and result.get("returncode") in (None, 0):
+            checked = _require_command_success(smoke, result, phase)
+            if len(attempts) > 1:
+                checked["setupRetry"] = {
+                    "attempts": attempts,
+                    "maxAttempts": RUN_COMPOSE_SETUP_MAX_ATTEMPTS,
+                    "recovered": True,
+                }
+            return checked
+        if attempt < RUN_COMPOSE_SETUP_MAX_ATTEMPTS and _is_retryable_compose_setup_failure(result):
+            time.sleep(RUN_COMPOSE_SETUP_RETRY_BACKOFF_SECONDS)
+            continue
+        detail = {
+            "phase": phase,
+            "attempts": attempts,
+            "maxAttempts": RUN_COMPOSE_SETUP_MAX_ATTEMPTS,
+        }
+        if attempts[-1].get("retryable") is True:
+            detail["classification"] = "retryable_setup_failure"
+            detail["nextAction"] = "rerun the bounded simulator validation after Docker image pull/setup flakiness settles"
+            raise RuntimeError(
+                f"{phase} failed after {attempt} attempt(s): {_safe_redact_smoke_payload(detail)}"
+            )
+        raise RuntimeError(f"{phase} failed: {_safe_redact_smoke_payload(detail)}")
+    raise RuntimeError(f"{phase} failed without a command attempt")
+
+
 def _install_simulator_repair_mod(smoke: Any, cfg: Any) -> Path:
     """Install local launcher compatibility fixes into this worker's generated mod dir."""
     mod_path = cfg.work_dir / "mods" / SIMULATOR_REPAIR_MOD_FILENAME
@@ -5924,11 +5999,29 @@ def _run_variant(
             returncode=down_result.get("returncode"),
             elapsed_seconds=down_result.get("elapsed_seconds"),
         )
-        _debug_worker_phase(worker_index, variant_id, "before docker compose up", command="up -d")
-        up_result = _require_command_success(
+        _debug_worker_phase(worker_index, variant_id, "before docker compose pull", command="pull")
+        pull_result = _run_compose_setup_command_with_retry(
             smoke,
-            smoke.run_command([*compose, "up", "-d"], cfg, timeout=RUN_CONTAINER_UP_TIMEOUT_SECONDS),
+            cfg,
+            [*compose, "pull"],
+            "docker compose pull",
+            timeout=RUN_CONTAINER_UP_TIMEOUT_SECONDS,
+        )
+        _debug_worker_phase(
+            worker_index,
+            variant_id,
+            "after docker compose pull",
+            returncode=pull_result.get("returncode"),
+            elapsed_seconds=pull_result.get("elapsed_seconds"),
+            setupRetry=pull_result.get("setupRetry"),
+        )
+        _debug_worker_phase(worker_index, variant_id, "before docker compose up", command="up -d")
+        up_result = _run_compose_setup_command_with_retry(
+            smoke,
+            cfg,
+            [*compose, "up", "-d"],
             "docker compose up",
+            timeout=RUN_CONTAINER_UP_TIMEOUT_SECONDS,
         )
         _debug_worker_phase(
             worker_index,

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -4416,6 +4416,14 @@ def _require_command_success(smoke: Any, result: Any, phase: str) -> JsonObject:
     return result
 
 
+def _compose_setup_output_text(result: dict[str, Any]) -> str:
+    return "\n".join(
+        str(part)
+        for part in (result.get("output_excerpt"), result.get("stdout"), result.get("stderr"))
+        if part
+    )
+
+
 def _compose_setup_attempt_summary(result: Any, attempt: int) -> JsonObject:
     if not isinstance(result, dict):
         return {
@@ -4425,21 +4433,28 @@ def _compose_setup_attempt_summary(result: Any, attempt: int) -> JsonObject:
             "outputExcerpt": _safe_text(result, 500),
             "retryable": False,
         }
-    return {
+    summary: JsonObject = {
         "attempt": attempt,
         "returncode": _coerce_int(result.get("returncode")),
         "elapsedSeconds": result.get("elapsed_seconds"),
-        "outputExcerpt": _safe_text(result.get("output_excerpt", ""), 500),
+        "outputExcerpt": _safe_text(_compose_setup_output_text(result), 500),
         "retryable": _is_retryable_compose_setup_failure(result),
     }
+    exception_type = result.get("exceptionType")
+    if isinstance(exception_type, str) and exception_type:
+        summary["exceptionType"] = exception_type
+    return summary
 
 
 def _is_retryable_compose_setup_failure(result: Any) -> bool:
     if not isinstance(result, dict):
         return False
-    if result.get("returncode") in (None, 0):
+    returncode = result.get("returncode")
+    if returncode == 0:
         return False
-    output = str(result.get("output_excerpt", ""))
+    if returncode is None and "exceptionType" not in result:
+        return False
+    output = _compose_setup_output_text(result)
     return bool(RUN_COMPOSE_SETUP_RETRYABLE_OUTPUT_RE.search(output))
 
 
@@ -4453,9 +4468,16 @@ def _run_compose_setup_command_with_retry(
 ) -> JsonObject:
     attempts: list[JsonObject] = []
     for attempt in range(1, RUN_COMPOSE_SETUP_MAX_ATTEMPTS + 1):
-        result = smoke.run_command(command, cfg, timeout=timeout)
+        try:
+            result = smoke.run_command(command, cfg, timeout=timeout)
+        except Exception as error:  # noqa: BLE001 - compose setup exceptions still need retry classification.
+            result = {
+                "returncode": None,
+                "output_excerpt": f"{type(error).__name__}: {_safe_text(error, 500)}",
+                "exceptionType": type(error).__name__,
+            }
         attempts.append(_compose_setup_attempt_summary(result, attempt))
-        if isinstance(result, dict) and result.get("returncode") in (None, 0):
+        if isinstance(result, dict) and result.get("returncode") in (None, 0) and "exceptionType" not in result:
             checked = _require_command_success(smoke, result, phase)
             if len(attempts) > 1:
                 checked["setupRetry"] = {
@@ -6029,6 +6051,7 @@ def _run_variant(
             "after docker compose up",
             returncode=up_result.get("returncode"),
             elapsed_seconds=up_result.get("elapsed_seconds"),
+            setupRetry=up_result.get("setupRetry"),
         )
         _wait_for_http_with_smoke(cfg, smoke, timeout_seconds=RUN_CONTAINER_UP_TIMEOUT_SECONDS)
         _require_launcher_cli_success(smoke, compose, cfg, "system.resetAllData()", "reset simulator data")

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -4452,6 +4452,8 @@ def _is_retryable_compose_setup_failure(result: Any) -> bool:
     returncode = result.get("returncode")
     if returncode == 0:
         return False
+    if result.get("exceptionType") in {"TimeoutExpired", "TimeoutError"}:
+        return True
     if returncode is None and "exceptionType" not in result:
         return False
     output = _compose_setup_output_text(result)

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -56,6 +56,10 @@ DEFAULT_WORKER_USER = "screeps-batch"
 DEFAULT_REMOTE_BASE = "/opt/screeps-batch/jobs"
 DEFAULT_ARTIFACT_ROOT = Path("runtime-artifacts/tencent-cloud/batch-runs")
 MAX_SCALE_PROOF_WORKERS = 16
+TENCENT_VALIDATION_INSTANCE_TYPE = "S3.2XLARGE16"
+TENCENT_S3_2XLARGE16_MAX_VALIDATION_ENVIRONMENTS = 6
+TENCENT_S3_2XLARGE16_MEMORY_PER_ENVIRONMENT_MIB = 2300
+TENCENT_S3_2XLARGE16_HOST_RESERVE_MIB = 1536
 SCALE_PROOF_SUCCESS_RATE = 0.8
 POLICY_GRADIENT_MIN_SIMULATION_TICKS = 500
 POLICY_GRADIENT_TRUST_MIN_SAMPLES_PER_CANDIDATE = 20
@@ -123,6 +127,13 @@ SSH_NETWORK_UNREACHABLE_RE = re.compile(
 REMOTE_RESOURCE_GUARD_RE = re.compile(
     r"(?:resource guard rejected simulator scale run|screeps-rl-simulator-resource-guard-failure|"
     r'"phase"\s*:\s*"resource-guard")',
+    re.IGNORECASE,
+)
+REMOTE_SIMULATOR_SETUP_RETRYABLE_RE = re.compile(
+    r"(?:retryable setup failure|unexpected EOF|context deadline exceeded|i/o timeout|TLS handshake timeout|"
+    r"connection reset|connection refused|temporary failure|network .*timed? out|"
+    r"net/http|Client\.Timeout|request canceled|too many requests|toomanyrequests|"
+    r"error pulling image|failed to (?:copy|extract|pull|fetch))",
     re.IGNORECASE,
 )
 SECRET_KEY_CANDIDATE_PATTERN = r"[A-Za-z_][A-Za-z0-9_-]{0,80}"
@@ -2308,11 +2319,14 @@ def remote_training_failure_diagnostics(
     payload: dict[str, Any] = {
         "status": "failed_exit",
         "failureClass": failure_class,
-        "retryable": failure_class in {"network_unreachable"},
+        "retryable": failure_class in {"network_unreachable", "simulator_setup_retryable"},
         "returncode": returncode,
         "artifactDir": str(remote_dir),
         "diagnostics": files,
     }
+    next_action = remote_training_failure_next_action(failure_class)
+    if next_action is not None:
+        payload["nextAction"] = next_action
     resource_guard = remote_training_resource_guard_summary(artifact_dir, run_id)
     if resource_guard is not None:
         payload["resourceGuard"] = resource_guard
@@ -2332,11 +2346,24 @@ def classify_remote_training_failure(
     )
     if REMOTE_RESOURCE_GUARD_RE.search(diagnostic_text):
         return "simulator_resource_guard_rejected"
+    if REMOTE_SIMULATOR_SETUP_RETRYABLE_RE.search(diagnostic_text):
+        return "simulator_setup_retryable"
     if process_failure_class in {"network_unreachable", "host_key_self_healing_failed", "host_key_mismatch"}:
         return process_failure_class
     if returncode == 255:
         return "ssh_transport_failed"
     return "remote_process_failed"
+
+
+def remote_training_failure_next_action(failure_class: str) -> str | None:
+    if failure_class == "simulator_setup_retryable":
+        return (
+            "rerun the same bounded validation after Docker image pull/setup flakiness settles; "
+            "inspect simulator setup diagnostics if the retry repeats"
+        )
+    if failure_class == "network_unreachable":
+        return "rerun after the worker SSH/network path is reachable"
+    return None
 
 
 def remote_training_resource_guard_summary(artifact_dir: Path, run_id: str | None) -> dict[str, Any] | None:
@@ -4376,6 +4403,7 @@ def validate_static_inputs(args: argparse.Namespace, run_id: str) -> None:
             raise BatchRunError(f"scale environments must be between 1 and {MAX_SCALE_PROOF_WORKERS}")
         if args.workers < scale_environments:
             raise BatchRunError("workers must be at least scale environments for concurrent scale proof")
+    validate_tencent_s3_validation_scale_cap(args, scale_environments)
     if args.repetitions < 1 or args.ticks < 1:
         raise BatchRunError("ticks and repetitions must be positive")
     scenario_id = scenario_id_from_args(args)
@@ -4392,6 +4420,31 @@ def validate_static_inputs(args: argparse.Namespace, run_id: str) -> None:
         multi_tier_launch_fixture_evidence()
     if not args.controller_ip.endswith("/32"):
         raise BatchRunError("controller IP must be a /32 CIDR")
+
+
+def validate_tencent_s3_validation_scale_cap(args: argparse.Namespace, scale_environments: int | None) -> None:
+    requested_workers = int(getattr(args, "workers", 0) or 0)
+    requested_environments = max(requested_workers, scale_environments or 0)
+    cap = TENCENT_S3_2XLARGE16_MAX_VALIDATION_ENVIRONMENTS
+    if requested_environments <= cap:
+        return
+    requested_required_mib = (
+        TENCENT_S3_2XLARGE16_HOST_RESERVE_MIB
+        + requested_environments * TENCENT_S3_2XLARGE16_MEMORY_PER_ENVIRONMENT_MIB
+    )
+    cap_required_mib = (
+        TENCENT_S3_2XLARGE16_HOST_RESERVE_MIB
+        + cap * TENCENT_S3_2XLARGE16_MEMORY_PER_ENVIRONMENT_MIB
+    )
+    raise BatchRunError(
+        f"{TENCENT_VALIDATION_INSTANCE_TYPE} validation cap exceeded: "
+        f"workers={requested_workers} scaleEnvironments={scale_environments} "
+        f"requires about {requested_required_mib} MiB memory/swap by the simulator resource guard, "
+        f"but this Tencent 8 vCPU / 16 GiB validation worker is capped at {cap} concurrent "
+        f"simulator environment(s) ({cap_required_mib} MiB estimate). "
+        f"Next action: rerun with --workers {cap} --scale-environments {cap}, "
+        "or move the ASG to a larger memory instance before requesting more environments."
+    )
 
 
 def policy_gradient_samples_per_candidate(args: argparse.Namespace) -> int:

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -131,9 +131,17 @@ REMOTE_RESOURCE_GUARD_RE = re.compile(
 )
 REMOTE_SIMULATOR_SETUP_RETRYABLE_RE = re.compile(
     r"(?:retryable setup failure|unexpected EOF|context deadline exceeded|i/o timeout|TLS handshake timeout|"
-    r"connection reset|connection refused|temporary failure|network .*timed? out|"
-    r"net/http|Client\.Timeout|request canceled|too many requests|toomanyrequests|"
-    r"error pulling image|failed to (?:copy|extract|pull|fetch))",
+    r"connection reset|temporary failure|error pulling image|failed to (?:copy|extract|pull|fetch))",
+    re.IGNORECASE,
+)
+REMOTE_SIMULATOR_SETUP_CONTEXT_RE = re.compile(
+    r"(?:retryable setup failure|docker compose (?:pull|up)|screeps-rl-simulator-setup-failure|"
+    r"setup_failure|error pulling image|failed to (?:copy|extract|pull|fetch))",
+    re.IGNORECASE,
+)
+REMOTE_NETWORK_RE = re.compile(
+    r"(?:connection refused|request canceled|too many requests|toomanyrequests|network .*timed? out|"
+    r"net/http|Client\.Timeout)",
     re.IGNORECASE,
 )
 SECRET_KEY_CANDIDATE_PATTERN = r"[A-Za-z_][A-Za-z0-9_-]{0,80}"
@@ -2346,10 +2354,30 @@ def classify_remote_training_failure(
     )
     if REMOTE_RESOURCE_GUARD_RE.search(diagnostic_text):
         return "simulator_resource_guard_rejected"
-    if REMOTE_SIMULATOR_SETUP_RETRYABLE_RE.search(diagnostic_text):
-        return "simulator_setup_retryable"
     if process_failure_class in {"network_unreachable", "host_key_self_healing_failed", "host_key_mismatch"}:
         return process_failure_class
+    simulator_setup_text = "\n".join(
+        tail
+        for filename, entry in files.items()
+        for tail in [entry.get("tail")]
+        if isinstance(tail, str)
+        and (
+            filename.endswith("setup_failure.json")
+            or filename.endswith("run_summary.json")
+            or filename.endswith("run_failure.json")
+            or REMOTE_SIMULATOR_SETUP_CONTEXT_RE.search(tail)
+        )
+    )
+    if (
+        REMOTE_SIMULATOR_SETUP_CONTEXT_RE.search(simulator_setup_text)
+        and (
+            REMOTE_SIMULATOR_SETUP_RETRYABLE_RE.search(simulator_setup_text)
+            or REMOTE_NETWORK_RE.search(simulator_setup_text)
+        )
+    ):
+        return "simulator_setup_retryable"
+    if returncode == 255 and REMOTE_NETWORK_RE.search(diagnostic_text):
+        return "network_unreachable"
     if returncode == 255:
         return "ssh_transport_failed"
     return "remote_process_failed"
@@ -4442,8 +4470,8 @@ def validate_tencent_s3_validation_scale_cap(args: argparse.Namespace, scale_env
         f"requires about {requested_required_mib} MiB memory/swap by the simulator resource guard, "
         f"but this Tencent 8 vCPU / 16 GiB validation worker is capped at {cap} concurrent "
         f"simulator environment(s) ({cap_required_mib} MiB estimate). "
-        f"Next action: rerun with --workers {cap} --scale-environments {cap}, "
-        "or move the ASG to a larger memory instance before requesting more environments."
+        f"Next action: rerun with --workers {cap} --scale-environments {cap}. "
+        f"This runner currently enforces the {TENCENT_VALIDATION_INSTANCE_TYPE} validation cap."
     )
 
 

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -6044,6 +6044,85 @@ cli:
         self.assertEqual(result["error"], "stop before side effects")
         self.assertIsNone(result["launcherRepairMod"])
 
+    def test_compose_setup_retry_recovers_transient_image_pull_failure(self) -> None:
+        class FakeSmoke:
+            def __init__(self) -> None:
+                self.commands: list[list[str]] = []
+                self.results = [
+                    {
+                        "returncode": 1,
+                        "elapsed_seconds": 0.4,
+                        "output_excerpt": "failed to pull layer: unexpected EOF",
+                    },
+                    {"returncode": 0, "elapsed_seconds": 0.2, "output_excerpt": ""},
+                ]
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout
+                self.commands.append(command)
+                return self.results.pop(0)
+
+            def require_success(self, result: dict[str, object]) -> dict[str, object]:
+                if result.get("returncode") != 0:
+                    raise AssertionError("failed setup attempts must be classified before require_success")
+                return result
+
+        smoke = FakeSmoke()
+        with mock.patch.object(harness.time, "sleep", return_value=None) as sleep:
+            result = harness._run_compose_setup_command_with_retry(
+                smoke,
+                object(),
+                ["compose", "pull"],
+                "docker compose pull",
+                timeout=123,
+            )
+
+        self.assertEqual(smoke.commands, [["compose", "pull"], ["compose", "pull"]])
+        sleep.assert_called_once_with(harness.RUN_COMPOSE_SETUP_RETRY_BACKOFF_SECONDS)
+        self.assertEqual(result["returncode"], 0)
+        self.assertTrue(result["setupRetry"]["recovered"])
+        self.assertEqual(len(result["setupRetry"]["attempts"]), 2)
+
+    def test_compose_setup_retry_does_not_retry_non_transient_pull_failure(self) -> None:
+        class FakeSmoke:
+            def __init__(self) -> None:
+                self.commands: list[list[str]] = []
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout
+                self.commands.append(command)
+                return {
+                    "returncode": 1,
+                    "elapsed_seconds": 0.1,
+                    "output_excerpt": "manifest for screeps/private-server:missing not found",
+                }
+
+        smoke = FakeSmoke()
+        with mock.patch.object(harness.time, "sleep", return_value=None) as sleep:
+            with self.assertRaisesRegex(RuntimeError, "docker compose pull failed"):
+                harness._run_compose_setup_command_with_retry(
+                    smoke,
+                    object(),
+                    ["compose", "pull"],
+                    "docker compose pull",
+                    timeout=123,
+                )
+
+        self.assertEqual(smoke.commands, [["compose", "pull"]])
+        sleep.assert_not_called()
+
     def test_run_variant_active_world_alias_uploads_executable_branch_for_runtime_consumption(self) -> None:
         variant_id = "construction-priority.pg.territory-seed.v1"
         parameters = {

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -6089,6 +6089,45 @@ cli:
         self.assertTrue(result["setupRetry"]["recovered"])
         self.assertEqual(len(result["setupRetry"]["attempts"]), 2)
 
+    def test_compose_setup_retry_recovers_transient_run_command_exception(self) -> None:
+        class FakeSmoke:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+            ) -> dict[str, object]:
+                _ = command, cfg, timeout
+                self.calls += 1
+                if self.calls == 1:
+                    raise TimeoutError("context deadline exceeded while pulling image")
+                return {"returncode": 0, "elapsed_seconds": 0.2, "output_excerpt": ""}
+
+            def require_success(self, result: dict[str, object]) -> dict[str, object]:
+                if result.get("returncode") != 0:
+                    raise AssertionError("only the recovered setup result should be required to succeed")
+                return result
+
+        smoke = FakeSmoke()
+        with mock.patch.object(harness.time, "sleep", return_value=None) as sleep:
+            result = harness._run_compose_setup_command_with_retry(
+                smoke,
+                object(),
+                ["compose", "pull"],
+                "docker compose pull",
+                timeout=123,
+            )
+
+        self.assertEqual(smoke.calls, 2)
+        sleep.assert_called_once_with(harness.RUN_COMPOSE_SETUP_RETRY_BACKOFF_SECONDS)
+        self.assertTrue(result["setupRetry"]["recovered"])
+        self.assertEqual(result["setupRetry"]["attempts"][0]["exceptionType"], "TimeoutError")
+        self.assertTrue(result["setupRetry"]["attempts"][0]["retryable"])
+
     def test_compose_setup_retry_does_not_retry_non_transient_pull_failure(self) -> None:
         class FakeSmoke:
             def __init__(self) -> None:
@@ -6122,6 +6161,93 @@ cli:
 
         self.assertEqual(smoke.commands, [["compose", "pull"]])
         sleep.assert_not_called()
+
+    def test_run_variant_logs_recovered_up_retry_evidence(self) -> None:
+        class FakeSmokeConfig:
+            def __init__(self, **kwargs: object) -> None:
+                for key, value in kwargs.items():
+                    setattr(self, key, value)
+
+            @property
+            def map_path(self) -> Path:
+                return self.work_dir / "maps" / "map-0b6758af.json"
+
+        class FakeSmoke:
+            SmokeConfig = FakeSmokeConfig
+
+            def __init__(self) -> None:
+                self.up_attempts = 0
+
+            def required_env_errors(self, cfg: FakeSmokeConfig) -> list[str]:
+                return []
+
+            def assert_safe_work_dir(self, work_dir: Path) -> None:
+                return None
+
+            def preflight_host_ports(self, cfg: FakeSmokeConfig) -> dict[str, object]:
+                return {"checks": [{"available": True}]}
+
+            def find_compose_command(self) -> list[str]:
+                return ["compose"]
+
+            def prepare_work_dir(self, cfg: FakeSmokeConfig) -> None:
+                return None
+
+            def write_generated_text(self, work_dir: Path, path: Path, text: str) -> None:
+                return None
+
+            def prepare_map(self, cfg: FakeSmokeConfig) -> None:
+                return None
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: FakeSmokeConfig,
+                *,
+                timeout: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout
+                if command[-2:] == ["up", "-d"]:
+                    self.up_attempts += 1
+                    if self.up_attempts == 1:
+                        return {
+                            "returncode": 1,
+                            "elapsed_seconds": 0.4,
+                            "output_excerpt": "failed to pull layer: unexpected EOF",
+                        }
+                return {"returncode": 0, "elapsed_seconds": 0.2, "output_excerpt": ""}
+
+        stderr = io.StringIO()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            code_path = root / "main.js"
+            map_path = root / "map.json"
+            code_path.write_text("module.exports.loop = function() {};", encoding="utf-8")
+            map_path.write_text("{\"ok\": true}", encoding="utf-8")
+
+            with (
+                mock.patch("screeps_rl_simulator_harness._load_private_smoke_module", return_value=FakeSmoke()),
+                mock.patch.object(harness.time, "sleep", return_value=None),
+                mock.patch("screeps_rl_simulator_harness._wait_for_http_with_smoke", side_effect=RuntimeError("stop after up debug")),
+                mock.patch("sys.stderr", stderr),
+            ):
+                result = harness._run_variant(
+                    0,
+                    "baseline",
+                    run_id="up-retry-log",
+                    ticks=1,
+                    room="E1S1",
+                    shard="shardX",
+                    branch="activeWorld",
+                    code_path=code_path,
+                    map_source_file=map_path,
+                    out_dir=root / "out",
+                )
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["error"], "stop after up debug")
+        self.assertIn('phase="after docker compose up"', stderr.getvalue())
+        self.assertIn("setupRetry=", stderr.getvalue())
 
     def test_run_variant_active_world_alias_uploads_executable_branch_for_runtime_consumption(self) -> None:
         variant_id = "construction-priority.pg.territory-seed.v1"

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -6128,6 +6128,46 @@ cli:
         self.assertEqual(result["setupRetry"]["attempts"][0]["exceptionType"], "TimeoutError")
         self.assertTrue(result["setupRetry"]["attempts"][0]["retryable"])
 
+    def test_compose_setup_retry_recovers_plain_timeout_expired_exception(self) -> None:
+        class FakeSmoke:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout
+                self.calls += 1
+                if self.calls == 1:
+                    raise subprocess.TimeoutExpired(command, 900)
+                return {"returncode": 0, "elapsed_seconds": 0.2, "output_excerpt": ""}
+
+            def require_success(self, result: dict[str, object]) -> dict[str, object]:
+                if result.get("returncode") != 0:
+                    raise AssertionError("only the recovered setup result should be required to succeed")
+                return result
+
+        smoke = FakeSmoke()
+        with mock.patch.object(harness.time, "sleep", return_value=None) as sleep:
+            result = harness._run_compose_setup_command_with_retry(
+                smoke,
+                object(),
+                ["compose", "pull"],
+                "docker compose pull",
+                timeout=123,
+            )
+
+        attempts = result["setupRetry"]["attempts"]
+        self.assertEqual(smoke.calls, 2)
+        sleep.assert_called_once_with(harness.RUN_COMPOSE_SETUP_RETRY_BACKOFF_SECONDS)
+        self.assertEqual(attempts[0]["exceptionType"], "TimeoutExpired")
+        self.assertIn("timed out after 900 seconds", attempts[0]["outputExcerpt"])
+        self.assertTrue(attempts[0]["retryable"])
+
     def test_compose_setup_retry_does_not_retry_non_transient_pull_failure(self) -> None:
         class FakeSmoke:
             def __init__(self) -> None:

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -3630,6 +3630,34 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             args.require_multi_tier_scenario = True
             runner.validate_static_inputs(args, "run-test")
 
+    def test_static_validation_rejects_s3_validation_scale_above_resource_guard_cap(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            args = controller_args()
+            args.tccli = str(root / "tccli")
+            args.billing_guard = str(root / "billing-guard.py")
+            args.ssh_key = str(root / "id_ed25519")
+            args.secret_env = str(root / ".env")
+            args.workers = 16
+            args.scale_environments = 16
+            for path in (args.tccli, args.billing_guard, args.ssh_key, args.secret_env):
+                write_text(Path(path))
+
+            with self.assertRaisesRegex(
+                runner.BatchRunError,
+                r"S3\.2XLARGE16 validation cap exceeded.*38336 MiB.*--workers 6 --scale-environments 6",
+            ):
+                runner.validate_static_inputs(args, "run-test")
+
+            args.workers = runner.TENCENT_S3_2XLARGE16_MAX_VALIDATION_ENVIRONMENTS
+            args.scale_environments = runner.TENCENT_S3_2XLARGE16_MAX_VALIDATION_ENVIRONMENTS
+            runner.validate_static_inputs(args, "run-test")
+
+            args.workers = runner.TENCENT_S3_2XLARGE16_MAX_VALIDATION_ENVIRONMENTS + 1
+            args.scale_environments = None
+            with self.assertRaisesRegex(runner.BatchRunError, "validation cap exceeded"):
+                runner.validate_static_inputs(args, "run-test")
+
     def test_policy_gradient_cli_defaults_to_multi_tier_required_scenario(self) -> None:
         args = runner.build_parser().parse_args([
             "preflight",
@@ -3916,6 +3944,60 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             "simulator-artifacts/run-test/resource_guard_failure.json",
             failure["diagnostics"],
         )
+
+    def test_run_remote_training_classifies_retryable_simulator_setup_failure(self) -> None:
+        args = controller_args()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=root)
+
+            def fake_ssh_cmd(
+                _name: str,
+                _remote_command: str,
+                **_kwargs: object,
+            ) -> subprocess.CompletedProcess[str]:
+                return subprocess.CompletedProcess(["ssh"], 2, "", "")
+
+            def fake_collect_remote_artifacts() -> None:
+                remote = root / "remote"
+                remote.mkdir(parents=True)
+                (remote / "training-stderr.log").write_text(
+                    "pre-scale private-simulator trainability smoke gate failed: "
+                    "docker compose up failed after 2 attempt(s): retryable setup failure: unexpected EOF\n",
+                    encoding="utf-8",
+                )
+                (remote / "training-summary.json").write_text("", encoding="utf-8")
+                (remote / "card-validation.json").write_text('{"ok": true}\n', encoding="utf-8")
+                (remote / "report-extract.json").write_text("", encoding="utf-8")
+
+            with (
+                mock.patch.object(controller, "ssh_cmd", side_effect=fake_ssh_cmd),
+                mock.patch.object(controller, "collect_remote_artifacts", side_effect=fake_collect_remote_artifacts),
+            ):
+                with self.assertRaisesRegex(runner.BatchRunError, "docker compose up failed"):
+                    controller.run_remote_training()
+
+            failure = controller.result["remoteTrainingFailure"]
+
+        self.assertEqual(failure["failureClass"], "simulator_setup_retryable")
+        self.assertTrue(failure["retryable"])
+        self.assertIn("rerun", failure["nextAction"])
+
+    def test_runtime_parameter_smoke_failure_remains_non_retryable_remote_process_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            remote = root / "remote"
+            remote.mkdir()
+            (remote / "training-stderr.log").write_text(
+                "pre-scale private-simulator trainability smoke gate did not prove runtime parameter consumption: missing\n",
+                encoding="utf-8",
+            )
+
+            failure = runner.remote_training_failure_diagnostics(root, 2, run_id="run-test")
+
+        self.assertEqual(failure["failureClass"], "remote_process_failed")
+        self.assertFalse(failure["retryable"])
+        self.assertNotIn("nextAction", failure)
 
     def test_diagnostic_redaction_covers_common_secret_formats(self) -> None:
         raw = (

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -3646,8 +3646,10 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             with self.assertRaisesRegex(
                 runner.BatchRunError,
                 r"S3\.2XLARGE16 validation cap exceeded.*38336 MiB.*--workers 6 --scale-environments 6",
-            ):
+            ) as raised:
                 runner.validate_static_inputs(args, "run-test")
+            self.assertIn("currently enforces the S3.2XLARGE16 validation cap", str(raised.exception))
+            self.assertNotIn("larger memory instance", str(raised.exception))
 
             args.workers = runner.TENCENT_S3_2XLARGE16_MAX_VALIDATION_ENVIRONMENTS
             args.scale_environments = runner.TENCENT_S3_2XLARGE16_MAX_VALIDATION_ENVIRONMENTS
@@ -3982,6 +3984,39 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(failure["failureClass"], "simulator_setup_retryable")
         self.assertTrue(failure["retryable"])
         self.assertIn("rerun", failure["nextAction"])
+
+    def test_setup_context_network_timeout_keeps_docker_setup_guidance(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            remote = root / "remote"
+            remote.mkdir()
+            (remote / "training-stderr.log").write_text(
+                "pre-scale private-simulator trainability smoke gate failed: "
+                "docker compose pull failed after 2 attempt(s): Client.Timeout exceeded\n",
+                encoding="utf-8",
+            )
+
+            failure = runner.remote_training_failure_diagnostics(root, 2, run_id="run-test")
+
+        self.assertEqual(failure["failureClass"], "simulator_setup_retryable")
+        self.assertTrue(failure["retryable"])
+        self.assertIn("Docker image pull/setup", failure["nextAction"])
+
+    def test_generic_network_api_diagnostic_does_not_get_docker_setup_guidance(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            remote = root / "remote"
+            remote.mkdir()
+            (remote / "training-stderr.log").write_text(
+                "Tencent API request canceled: too many requests while polling batch status\n",
+                encoding="utf-8",
+            )
+
+            failure = runner.remote_training_failure_diagnostics(root, 2, run_id="run-test")
+
+        self.assertEqual(failure["failureClass"], "remote_process_failed")
+        self.assertFalse(failure["retryable"])
+        self.assertNotIn("nextAction", failure)
 
     def test_runtime_parameter_smoke_failure_remains_non_retryable_remote_process_failure(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- Hardens Tencent batch pre-scale simulator smoke handling after zero-environment validation failures.
- Adds runner/harness coverage for robust smoke-failure classification and prevents paid scale validation from proceeding without a valid pre-scale smoke.
- Addresses the exact-head CodeRabbit timeout finding by retrying `TimeoutExpired`/`TimeoutError` setup exceptions; classifies the tuple-form `endswith` comment as `ADVISORY_ONLY` under the critical-only policy.

## Verification
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_tencent_batch_rl_runner.py` — 291 tests OK on 2026-05-26T22:06Z.
- `python3 scripts/check_issue_completion_gate.py --repo lanyusea/screeps --pr 1460` — PASS after commit-message amend and PR body update.

## CodeRabbit triage
- `3307106952`: `FIX` — valid critical operational bug; fixed in `d08f23cc4af65fa8af90b540f350622f444eaf9f`.
- `3307106962`: `ADVISORY_ONLY` — tuple-form `endswith` is non-critical style cleanup; no code churn.
- Full local triage artifact: `/tmp/pr1460-codex-triage.md` on the controller.

## Issue closure gate
- [x] #1459: Codex-authored commits `3145c51f3f3108bb58a343c6e3fdc303fb109fc2`, `828c3bca23526cae7d7e069260f2d4ef87866edd`, and `d08f23cc4af65fa8af90b540f350622f444eaf9f` implement and review-harden the Tencent pre-scale smoke fix. Controller verification above passed on current head `d08f23cc4af65fa8af90b540f350622f444eaf9f`.

Fixes #1459

