### PR TITLE
fix: harden Tencent pre-scale docker pulls

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -158,7 +158,8 @@ RUN_COMPOSE_PULL_PROGRESS_OUTPUT_RE = re.compile(
 )
 RUN_COMPOSE_SETUP_TERMINAL_OUTPUT_RE = re.compile(
     r"(?:manifest (?:for .* )?not found|manifest unknown|pull access denied|repository .* does not exist|"
-    r"unauthorized|authentication required|denied: requested access|no matching manifest|invalid reference format)",
+    r"unauthorized|authentication required|denied: requested access|no matching manifest|invalid reference format|"
+    r"no space left on device|disk quota exceeded|read-only file system)",
     re.IGNORECASE,
 )
 HARNESS_EXCLUDED_DIRECTORY_NAMES = ("node_modules", ".git", "__pycache__")

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -88,7 +88,7 @@ RUN_RUNTIME_PARAMETER_CONSUMPTION_PROBE_RETRY_SECONDS = 1.0
 RUN_WORKER_PREFIX = "rl-sim-worker"
 RUN_BROKEN_PIPE_MAX_RETRIES = 1
 RUN_BROKEN_PIPE_RETRY_BACKOFF_SECONDS = 2.0
-RUN_COMPOSE_SETUP_MAX_ATTEMPTS = 2
+RUN_COMPOSE_SETUP_MAX_ATTEMPTS = 4
 RUN_COMPOSE_SETUP_RETRY_BACKOFF_SECONDS = 2.0
 RUN_ID_PREFIX = "rl-sim-run"
 RUN_ID_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]+$")
@@ -150,6 +150,15 @@ RUN_COMPOSE_SETUP_RETRYABLE_OUTPUT_RE = re.compile(
     r"connection reset|connection refused|temporary failure|network .*timed? out|"
     r"net/http|Client\.Timeout|request canceled|too many requests|toomanyrequests|"
     r"error pulling image|failed to (?:copy|extract|pull|fetch))",
+    re.IGNORECASE,
+)
+RUN_COMPOSE_PULL_PROGRESS_OUTPUT_RE = re.compile(
+    r"(?:Pulling fs layer|Download(?:ing| complete)|Verifying Checksum|Extracting|Waiting|Pull complete|\bPulling\b)",
+    re.IGNORECASE,
+)
+RUN_COMPOSE_SETUP_TERMINAL_OUTPUT_RE = re.compile(
+    r"(?:manifest (?:for .* )?not found|manifest unknown|pull access denied|repository .* does not exist|"
+    r"unauthorized|authentication required|denied: requested access|no matching manifest|invalid reference format)",
     re.IGNORECASE,
 )
 HARNESS_EXCLUDED_DIRECTORY_NAMES = ("node_modules", ".git", "__pycache__")
@@ -4457,7 +4466,12 @@ def _is_retryable_compose_setup_failure(result: Any) -> bool:
     if returncode is None and "exceptionType" not in result:
         return False
     output = _compose_setup_output_text(result)
-    return bool(RUN_COMPOSE_SETUP_RETRYABLE_OUTPUT_RE.search(output))
+    if RUN_COMPOSE_SETUP_TERMINAL_OUTPUT_RE.search(output):
+        return False
+    return bool(
+        RUN_COMPOSE_SETUP_RETRYABLE_OUTPUT_RE.search(output)
+        or RUN_COMPOSE_PULL_PROGRESS_OUTPUT_RE.search(output)
+    )
 
 
 def _run_compose_setup_command_with_retry(

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -134,6 +134,15 @@ REMOTE_SIMULATOR_SETUP_RETRYABLE_RE = re.compile(
     r"connection reset|temporary failure|error pulling image|failed to (?:copy|extract|pull|fetch))",
     re.IGNORECASE,
 )
+REMOTE_SIMULATOR_PULL_PROGRESS_RE = re.compile(
+    r"(?:Pulling fs layer|Download(?:ing| complete)|Verifying Checksum|Extracting|Waiting|Pull complete|\bPulling\b)",
+    re.IGNORECASE,
+)
+REMOTE_SIMULATOR_SETUP_TERMINAL_RE = re.compile(
+    r"(?:manifest (?:for .* )?not found|manifest unknown|pull access denied|repository .* does not exist|"
+    r"unauthorized|authentication required|denied: requested access|no matching manifest|invalid reference format)",
+    re.IGNORECASE,
+)
 REMOTE_SIMULATOR_SETUP_CONTEXT_RE = re.compile(
     r"(?:retryable setup failure|docker compose (?:pull|up)|screeps-rl-simulator-setup-failure|"
     r"setup_failure|error pulling image|failed to (?:copy|extract|pull|fetch))",
@@ -1657,10 +1666,12 @@ if [ ! -s report-extract.json ] && [ -s training-summary.json ]; then
   cp training-summary.json report-extract.json
 fi
 simulator_diagnostics=()
-for simulator_file in run_summary.json resource_guard_failure.json setup_failure.json run_failure.json owned_room_scorecard.json; do
-  if [ -f "simulator-artifacts/$RUN_ID/$simulator_file" ]; then
-    simulator_diagnostics+=("simulator-artifacts/$RUN_ID/$simulator_file")
-  fi
+for simulator_run_id in "$RUN_ID" "$RUN_ID-pre-scale-smoke"; do
+  for simulator_file in run_summary.json resource_guard_failure.json setup_failure.json run_failure.json owned_room_scorecard.json; do
+    if [ -f "simulator-artifacts/$simulator_run_id/$simulator_file" ]; then
+      simulator_diagnostics+=("simulator-artifacts/$simulator_run_id/$simulator_file")
+    fi
+  done
 done
 tar -czf remote-artifacts.tar.gz \
   experiment_card.json card-validation.json training-summary.json training-stderr.log report-extract.json \
@@ -2293,7 +2304,12 @@ def remote_training_report_path(artifact_dir: Path, run_id: str) -> Path:
 def remote_training_diagnostic_files(run_id: str | None = None) -> tuple[str, ...]:
     files = list(REMOTE_TRAINING_DIAGNOSTIC_FILES)
     if isinstance(run_id, str) and RUN_ID_RE.match(run_id):
-        files.extend(f"simulator-artifacts/{run_id}/{filename}" for filename in REMOTE_SIMULATOR_DIAGNOSTIC_FILES)
+        diagnostic_run_ids = (run_id, f"{run_id}-pre-scale-smoke")
+        files.extend(
+            f"simulator-artifacts/{diagnostic_run_id}/{filename}"
+            for diagnostic_run_id in diagnostic_run_ids
+            for filename in REMOTE_SIMULATOR_DIAGNOSTIC_FILES
+        )
     return tuple(files)
 
 
@@ -2370,9 +2386,11 @@ def classify_remote_training_failure(
     )
     if (
         REMOTE_SIMULATOR_SETUP_CONTEXT_RE.search(simulator_setup_text)
+        and not REMOTE_SIMULATOR_SETUP_TERMINAL_RE.search(simulator_setup_text)
         and (
             REMOTE_SIMULATOR_SETUP_RETRYABLE_RE.search(simulator_setup_text)
             or REMOTE_NETWORK_RE.search(simulator_setup_text)
+            or REMOTE_SIMULATOR_PULL_PROGRESS_RE.search(simulator_setup_text)
         )
     ):
         return "simulator_setup_retryable"

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -140,7 +140,8 @@ REMOTE_SIMULATOR_PULL_PROGRESS_RE = re.compile(
 )
 REMOTE_SIMULATOR_SETUP_TERMINAL_RE = re.compile(
     r"(?:manifest (?:for .* )?not found|manifest unknown|pull access denied|repository .* does not exist|"
-    r"unauthorized|authentication required|denied: requested access|no matching manifest|invalid reference format)",
+    r"unauthorized|authentication required|denied: requested access|no matching manifest|invalid reference format|"
+    r"no space left on device|disk quota exceeded|read-only file system)",
     re.IGNORECASE,
 )
 REMOTE_SIMULATOR_SETUP_CONTEXT_RE = re.compile(

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -6175,6 +6175,54 @@ cli:
         self.assertEqual(len(smoke.commands), harness.RUN_COMPOSE_SETUP_MAX_ATTEMPTS)
         self.assertEqual(sleep.call_count, harness.RUN_COMPOSE_SETUP_MAX_ATTEMPTS - 1)
 
+    def test_compose_setup_progress_with_disk_failure_is_not_retryable(self) -> None:
+        for message in ("no space left on device", "disk quota exceeded", "read-only file system"):
+            with self.subTest(message=message):
+                result = {
+                    "returncode": 2,
+                    "elapsed_seconds": 65.0,
+                    "output_excerpt": f"screeps Pulling\n3892befd2c3f Pulling fs layer\n{message}",
+                }
+
+                self.assertFalse(harness._is_retryable_compose_setup_failure(result))
+
+        class FakeSmoke:
+            def __init__(self) -> None:
+                self.commands: list[list[str]] = []
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout
+                self.commands.append(command)
+                return {
+                    "returncode": 2,
+                    "elapsed_seconds": 65.0,
+                    "output_excerpt": (
+                        "screeps Pulling\n"
+                        "3892befd2c3f Pulling fs layer\n"
+                        "failed to register layer: no space left on device"
+                    ),
+                }
+
+        smoke = FakeSmoke()
+        with mock.patch.object(harness.time, "sleep", return_value=None) as sleep:
+            with self.assertRaisesRegex(RuntimeError, "docker compose pull failed"):
+                harness._run_compose_setup_command_with_retry(
+                    smoke,
+                    object(),
+                    ["compose", "pull"],
+                    "docker compose pull",
+                    timeout=123,
+                )
+
+        self.assertEqual(smoke.commands, [["compose", "pull"]])
+        sleep.assert_not_called()
+
     def test_compose_setup_retry_recovers_transient_run_command_exception(self) -> None:
         class FakeSmoke:
             def __init__(self) -> None:

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -6089,6 +6089,92 @@ cli:
         self.assertTrue(result["setupRetry"]["recovered"])
         self.assertEqual(len(result["setupRetry"]["attempts"]), 2)
 
+    def test_compose_setup_retry_recovers_interrupted_pull_progress(self) -> None:
+        class FakeSmoke:
+            def __init__(self) -> None:
+                self.commands: list[list[str]] = []
+                self.results = [
+                    {
+                        "returncode": 2,
+                        "elapsed_seconds": 64.967,
+                        "output_excerpt": (
+                            " mongo Pulling \n"
+                            " screeps Pulling \n"
+                            " redis Pulling \n"
+                            " 3892befd2c3f Pulling fs layer \n"
+                            " 32ab8bed435e Download complete \n"
+                            " 3892befd2c3f Downloading"
+                        ),
+                    },
+                    {"returncode": 0, "elapsed_seconds": 0.2, "output_excerpt": ""},
+                ]
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout
+                self.commands.append(command)
+                return self.results.pop(0)
+
+            def require_success(self, result: dict[str, object]) -> dict[str, object]:
+                if result.get("returncode") != 0:
+                    raise AssertionError("failed setup attempts must be classified before require_success")
+                return result
+
+        smoke = FakeSmoke()
+        with mock.patch.object(harness.time, "sleep", return_value=None) as sleep:
+            result = harness._run_compose_setup_command_with_retry(
+                smoke,
+                object(),
+                ["compose", "pull"],
+                "docker compose pull",
+                timeout=123,
+            )
+
+        self.assertEqual(smoke.commands, [["compose", "pull"], ["compose", "pull"]])
+        sleep.assert_called_once_with(harness.RUN_COMPOSE_SETUP_RETRY_BACKOFF_SECONDS)
+        self.assertEqual(result["returncode"], 0)
+        self.assertTrue(result["setupRetry"]["recovered"])
+        self.assertTrue(result["setupRetry"]["attempts"][0]["retryable"])
+
+    def test_compose_setup_progress_failure_stays_retryable_after_bounded_attempts(self) -> None:
+        class FakeSmoke:
+            def __init__(self) -> None:
+                self.commands: list[list[str]] = []
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: object,
+                *,
+                timeout: int,
+            ) -> dict[str, object]:
+                _ = cfg, timeout
+                self.commands.append(command)
+                return {
+                    "returncode": 2,
+                    "elapsed_seconds": 65.0,
+                    "output_excerpt": "screeps Pulling\n3892befd2c3f Pulling fs layer\n3892befd2c3f Downloading",
+                }
+
+        smoke = FakeSmoke()
+        with mock.patch.object(harness.time, "sleep", return_value=None) as sleep:
+            with self.assertRaisesRegex(RuntimeError, "retryable_setup_failure"):
+                harness._run_compose_setup_command_with_retry(
+                    smoke,
+                    object(),
+                    ["compose", "pull"],
+                    "docker compose pull",
+                    timeout=123,
+                )
+
+        self.assertEqual(len(smoke.commands), harness.RUN_COMPOSE_SETUP_MAX_ATTEMPTS)
+        self.assertEqual(sleep.call_count, harness.RUN_COMPOSE_SETUP_MAX_ATTEMPTS - 1)
+
     def test_compose_setup_retry_recovers_transient_run_command_exception(self) -> None:
         class FakeSmoke:
             def __init__(self) -> None:
@@ -6185,7 +6271,7 @@ cli:
                 return {
                     "returncode": 1,
                     "elapsed_seconds": 0.1,
-                    "output_excerpt": "manifest for screeps/private-server:missing not found",
+                    "output_excerpt": "screeps Pulling\nmanifest for screeps/private-server:missing not found",
                 }
 
         smoke = FakeSmoke()

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -4069,6 +4069,26 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertFalse(failure["retryable"])
         self.assertNotIn("nextAction", failure)
 
+    def test_setup_context_terminal_disk_error_is_not_retryable_setup_failure(self) -> None:
+        for message in ("no space left on device", "disk quota exceeded", "read-only file system"):
+            with self.subTest(message=message):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    root = Path(temp_dir)
+                    remote = root / "remote"
+                    remote.mkdir()
+                    (remote / "training-stderr.log").write_text(
+                        "pre-scale private-simulator trainability smoke gate failed: "
+                        "docker compose pull failed: screeps Pulling\n"
+                        f"3892befd2c3f Pulling fs layer\n{message}\n",
+                        encoding="utf-8",
+                    )
+
+                    failure = runner.remote_training_failure_diagnostics(root, 2, run_id="run-test")
+
+                self.assertEqual(failure["failureClass"], "remote_process_failed")
+                self.assertFalse(failure["retryable"])
+                self.assertNotIn("nextAction", failure)
+
     def test_generic_network_api_diagnostic_does_not_get_docker_setup_guidance(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -4002,6 +4002,73 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertTrue(failure["retryable"])
         self.assertIn("Docker image pull/setup", failure["nextAction"])
 
+    def test_setup_context_interrupted_pull_progress_is_retryable_setup_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            remote = root / "remote"
+            remote.mkdir()
+            (remote / "training-stderr.log").write_text(
+                "pre-scale private-simulator trainability smoke gate failed: "
+                "docker compose pull failed: {'ok': True, 'payload': "
+                "'{\"attempts\": [{\"attempt\": 1, \"elapsedSeconds\": 64.967, "
+                "\"outputExcerpt\": \" mongo Pulling \\\\n screeps Pulling \\\\n redis Pulling \\\\n "
+                "3892befd2c3f Pulling fs layer \\\\n 32ab8bed435e Download complete \\\\n "
+                "3892befd2c3f Downloading\"}]}' }\n",
+                encoding="utf-8",
+            )
+
+            failure = runner.remote_training_failure_diagnostics(root, 2, run_id="run-test")
+
+        self.assertEqual(failure["failureClass"], "simulator_setup_retryable")
+        self.assertTrue(failure["retryable"])
+        self.assertIn("Docker image pull/setup", failure["nextAction"])
+
+    def test_pre_scale_smoke_setup_artifact_is_collected_as_retryable_setup_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            setup_dir = root / "remote" / "simulator-artifacts" / "run-test-pre-scale-smoke"
+            setup_dir.mkdir(parents=True)
+            (setup_dir / "setup_failure.json").write_text(
+                json.dumps(
+                    {
+                        "type": "screeps-rl-simulator-setup-failure",
+                        "phase": "run-variants",
+                        "error": (
+                            "docker compose pull failed after 4 attempt(s): "
+                            "retryable_setup_failure: screeps Pulling; 3892befd2c3f Downloading"
+                        ),
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            failure = runner.remote_training_failure_diagnostics(root, 2, run_id="run-test")
+
+        self.assertEqual(failure["failureClass"], "simulator_setup_retryable")
+        self.assertTrue(failure["retryable"])
+        self.assertIn(
+            "simulator-artifacts/run-test-pre-scale-smoke/setup_failure.json",
+            failure["diagnostics"],
+        )
+
+    def test_setup_context_terminal_pull_error_is_not_retryable_setup_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            remote = root / "remote"
+            remote.mkdir()
+            (remote / "training-stderr.log").write_text(
+                "pre-scale private-simulator trainability smoke gate failed: "
+                "docker compose pull failed: screeps Pulling\n"
+                "manifest for screeps/private-server:missing not found\n",
+                encoding="utf-8",
+            )
+
+            failure = runner.remote_training_failure_diagnostics(root, 2, run_id="run-test")
+
+        self.assertEqual(failure["failureClass"], "remote_process_failed")
+        self.assertFalse(failure["retryable"])
+        self.assertNotIn("nextAction", failure)
+
     def test_generic_network_api_diagnostic_does_not_get_docker_setup_guidance(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -4123,6 +4190,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             "for simulator_file in run_summary.json resource_guard_failure.json setup_failure.json run_failure.json owned_room_scorecard.json",
             scripts[0],
         )
+        self.assertIn('for simulator_run_id in "$RUN_ID" "$RUN_ID-pre-scale-smoke"', scripts[0])
 
     def test_generate_experiment_card_passes_multi_tier_scenario_request(self) -> None:
         args = controller_args()


### PR DESCRIPTION
## Summary
- Harden the private-simulator pre-scale Docker setup path so transient/first-boot compose pull/up failures are retried and reported with setup/pull diagnostics instead of being mistaken for RL objective evidence.
- Preserve scheduler safety classification for terminal setup failures before any trusted environment rows are produced.
- Add focused regression coverage for the simulator harness and Tencent batch runner paths.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_tencent_batch_rl_runner.py` — 296 tests OK

## Issue closure gate
- [x] #1459: Commit `70009419` adds the verified pre-scale Docker setup hardening and tests; controller-side diff-check, py_compile, and focused unittest verification passed without launching paid Tencent compute.

Fixes #1459
