### PR TITLE
fix(rl): extend objective activation smoke windows

### DIFF
--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -69,7 +69,7 @@ DEFAULT_SIMULATION_WORKERS = 1
 MULTI_TIER_ANCHOR_ROOM = "E1S1"
 MULTI_TIER_ADJACENT_ROOM = "E2S1"
 MULTI_TIER_ACTIVE_IMPLEMENTATION_STATUS = "active_fixture_validated"
-POLICY_GRADIENT_MIN_SIMULATION_TICKS = 500
+POLICY_GRADIENT_MIN_SIMULATION_TICKS = 2000
 POLICY_GRADIENT_SIMULATION_TICKS = POLICY_GRADIENT_MIN_SIMULATION_TICKS
 POLICY_GRADIENT_TRUST_MIN_SAMPLES_PER_CANDIDATE = 20
 POLICY_GRADIENT_SIMULATION_REPETITIONS = POLICY_GRADIENT_TRUST_MIN_SAMPLES_PER_CANDIDATE
@@ -2605,7 +2605,8 @@ def build_parser() -> argparse.ArgumentParser:
         "--ticks",
         type=positive_int_arg,
         help=(
-            "Simulation ticks to request. Defaults to 50, or 500 for policy_gradient cards."
+            f"Simulation ticks to request. Defaults to 50, or {POLICY_GRADIENT_MIN_SIMULATION_TICKS} "
+            "for policy_gradient cards."
         ),
     )
     parser.add_argument(
@@ -2653,7 +2654,7 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Write a standalone Loop A local-fallback experiment_card.json from an accepted "
             "dataset gate. Implies policy_gradient card supply and defaults to 5 workers, "
-            "20 repetitions, and 500 ticks."
+            f"20 repetitions, and {POLICY_GRADIENT_MIN_SIMULATION_TICKS} ticks."
         ),
     )
     parser.add_argument(

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence, TextIO
 
 from screeps_rl_experiment_card import (
+    POLICY_GRADIENT_MIN_SIMULATION_TICKS,
     scenario_supports_multi_tier_policy_comparison,
     validate_scenario_metadata,
 )
@@ -299,6 +300,7 @@ def parse_yaml_card(text: str, path: Path) -> Any:
 def validate_experiment_card(card: JsonObject) -> None:
     if card.get("status") != "shadow":
         raise TrainingCardError("status must be shadow")
+    training_approach = card.get("training_approach", card.get("trainingApproach"))
 
     safety = card.get("safety")
     if not isinstance(safety, dict):
@@ -337,7 +339,8 @@ def validate_experiment_card(card: JsonObject) -> None:
         raise TrainingCardError("experiment card must define at least one strategy variant")
 
     simulation = raw_mapping(card.get("simulation", card.get("simulator", {})), "simulation")
-    if "ticks" in simulation and positive_int_value(simulation["ticks"]) is None:
+    ticks = positive_int_value(simulation["ticks"]) if "ticks" in simulation else None
+    if "ticks" in simulation and ticks is None:
         raise TrainingCardError("simulation.ticks must be a positive integer")
     if "workers" in simulation and positive_int_value(simulation["workers"]) is None:
         raise TrainingCardError("simulation.workers must be a positive integer")
@@ -355,6 +358,10 @@ def validate_experiment_card(card: JsonObject) -> None:
         and positive_int_value(simulation.get("host_port_start", simulation.get("hostPortStart"))) is None
     ):
         raise TrainingCardError("simulation.host_port_start must be a positive integer")
+    if training_approach == "policy_gradient" and (ticks is None or ticks < POLICY_GRADIENT_MIN_SIMULATION_TICKS):
+        raise TrainingCardError(
+            f"policy_gradient cards require simulation.ticks >= {POLICY_GRADIENT_MIN_SIMULATION_TICKS}"
+        )
 
 
 def validate_card_supply(card: JsonObject) -> None:
@@ -5921,7 +5928,9 @@ def build_multi_tier_activation_proof(
         return None
     rows = [multi_tier_activation_variant_row(result) for result in results]
     usable_rows = [row for row in rows if (int_or_none(row.get("sampleCount")) or 0) > 0]
-    passed_rows = [row for row in usable_rows if row["passesActivation"]]
+    audit_ticks = int_or_none(audit.get("ticks")) if isinstance(audit, dict) else None
+    horizon_too_short = audit_ticks is not None and audit_ticks < POLICY_GRADIENT_MIN_SIMULATION_TICKS
+    passed_rows = [] if horizon_too_short else [row for row in usable_rows if row["passesActivation"]]
     transport_observed = any(row["objectiveSignalObserved"] for row in rows)
     status = "passed" if passed_rows else "blocked"
     proof: JsonObject = {
@@ -5936,6 +5945,7 @@ def build_multi_tier_activation_proof(
             "activationScoreOperator": "or",
             "territoryScoreMustExceed": MULTI_TIER_TERRITORY_ACTIVATION_THRESHOLD,
             "hostileKillsMustExceed": MULTI_TIER_HOSTILE_KILLS_ACTIVATION_THRESHOLD,
+            "minimumSimulationTicks": POLICY_GRADIENT_MIN_SIMULATION_TICKS,
             "requiredForPaidTencentValidation": True,
         },
         "fixtureEvidence": multi_tier_fixture_evidence(scenario),
@@ -5955,7 +5965,13 @@ def build_multi_tier_activation_proof(
     if passed_rows:
         proof["passingVariants"] = [row["variantId"] for row in passed_rows]
     else:
-        if not usable_rows:
+        if horizon_too_short:
+            classification = "SIMULATION_HORIZON_TOO_SHORT"
+            evidence = (
+                f"multi-tier activation proof requires at least {POLICY_GRADIENT_MIN_SIMULATION_TICKS} ticks "
+                f"per simulator environment; observed {audit_ticks}"
+            )
+        elif not usable_rows:
             classification = "SIMULATOR_NO_SUCCESSFUL_SAMPLES"
             evidence = "no successful simulator samples were available for multi-tier activation proof"
         elif transport_observed:
@@ -5972,7 +5988,11 @@ def build_multi_tier_activation_proof(
             "classification": classification,
             "criticality": "P0",
             "evidence": evidence,
-            "action": "repair local/private simulator objective activation before paid Tencent validation",
+            "action": (
+                "rerun policy-gradient multi-tier validation with an extended simulation horizon"
+                if horizon_too_short
+                else "repair local/private simulator objective activation before paid Tencent validation"
+            ),
         }
     return proof
 

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -37,6 +37,7 @@ from screeps_rl_experiment_card import (
     MULTI_TIER_ACTIVE_IMPLEMENTATION_STATUS,
     MULTI_TIER_SCENARIO_ID,
     MULTI_TIER_SIMULATION_MAP_SOURCE_REL,
+    POLICY_GRADIENT_MIN_SIMULATION_TICKS,
     SCENARIO_IDS,
     multi_tier_scenario_fixture_summary,
     scenario_supports_multi_tier_policy_comparison,
@@ -61,7 +62,6 @@ TENCENT_S3_2XLARGE16_MAX_VALIDATION_ENVIRONMENTS = 6
 TENCENT_S3_2XLARGE16_MEMORY_PER_ENVIRONMENT_MIB = 2300
 TENCENT_S3_2XLARGE16_HOST_RESERVE_MIB = 1536
 SCALE_PROOF_SUCCESS_RATE = 0.8
-POLICY_GRADIENT_MIN_SIMULATION_TICKS = 500
 POLICY_GRADIENT_TRUST_MIN_SAMPLES_PER_CANDIDATE = 20
 POLICY_GRADIENT_DEFAULT_VALIDATION_WORKERS = 5
 REWARD_TIER_ORDER = ("reliability", "territory", "resources", "kills")
@@ -2515,8 +2515,8 @@ def build_e1s1_repeat_launch_guard(
     reason = None
     if blocked:
         reason = (
-            "recent completed 500-tick Tencent E1S1 single-room no-hostile runs "
-            "show territory=2 and kills=0 for every reported variant"
+            f"recent completed >= {POLICY_GRADIENT_MIN_SIMULATION_TICKS}-tick Tencent E1S1 "
+            "single-room no-hostile runs show territory=2 and kills=0 for every reported variant"
         )
     return {
         "type": E1S1_REPEAT_GUARD_TYPE,
@@ -4651,7 +4651,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--known-hosts-path", default=str(DEFAULT_KNOWN_HOSTS))
     parser.add_argument("--dataset-run-id", default="rl-3d29e8b9397d")
     parser.add_argument("--training-approach", default="bandit", choices=("bandit", "evolutionary", "policy_gradient"))
-    parser.add_argument("--ticks", type=int, default=50, help="Simulator ticks; policy_gradient runs are floored to 500.")
+    parser.add_argument(
+        "--ticks",
+        type=int,
+        default=50,
+        help=f"Simulator ticks; policy_gradient runs are floored to {POLICY_GRADIENT_MIN_SIMULATION_TICKS}.",
+    )
     parser.add_argument("--workers", type=int, default=1)
     parser.add_argument(
         "--scale-environments",

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -123,7 +123,7 @@ class RlExperimentCardTest(unittest.TestCase):
         learnable_names = [item["name"] for item in policy_gradient["learnable_parameters"]]
 
         self.assertEqual(card["training_approach"], "policy_gradient")
-        self.assertEqual(config.ticks, 500)
+        self.assertEqual(config.ticks, card_helper.POLICY_GRADIENT_MIN_SIMULATION_TICKS)
         self.assertEqual(config.repetitions, 20)
         self.assertFalse(card["liveEffect"])
         self.assertFalse(card["officialMmoWrites"])
@@ -359,7 +359,7 @@ class RlExperimentCardTest(unittest.TestCase):
         supply = card["card_supply"]
         self.assertEqual(card["status"], "shadow")
         self.assertEqual(card["training_approach"], "policy_gradient")
-        self.assertEqual(config.ticks, 500)
+        self.assertEqual(config.ticks, card_helper.POLICY_GRADIENT_MIN_SIMULATION_TICKS)
         self.assertEqual(config.workers, 5)
         self.assertEqual(config.repetitions, 20)
         self.assertEqual(supply["state"], "available")
@@ -589,7 +589,7 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(generated["dataset_run_id"], "rl-accepted-newer")
         self.assertEqual(generated["training_approach"], "policy_gradient")
         self.assertEqual(generated["status"], "shadow")
-        self.assertEqual(generated["simulation"]["ticks"], 500)
+        self.assertEqual(generated["simulation"]["ticks"], card_helper.POLICY_GRADIENT_MIN_SIMULATION_TICKS)
         self.assertEqual(generated["simulation"]["workers"], 5)
         self.assertEqual(generated["simulation"]["repetitions"], 20)
         self.assertEqual(generated["scenario"]["scenario_id"], card_helper.MULTI_TIER_SCENARIO_ID)
@@ -684,7 +684,7 @@ class RlExperimentCardTest(unittest.TestCase):
         config = runner.simulation_config_from_card(generated)
         self.assertEqual(config.workers, 5)
         self.assertEqual(config.repetitions, 20)
-        self.assertEqual(config.ticks, 500)
+        self.assertEqual(config.ticks, card_helper.POLICY_GRADIENT_MIN_SIMULATION_TICKS)
 
         supply = generated["card_supply"]
         self.assertEqual(generated["status"], "shadow")
@@ -2489,8 +2489,20 @@ class RlExperimentCardTest(unittest.TestCase):
         )
         config = runner.simulation_config_from_card(card)
 
-        self.assertGreaterEqual(config.ticks, 500)
+        self.assertGreaterEqual(config.ticks, card_helper.POLICY_GRADIENT_MIN_SIMULATION_TICKS)
         self.assertGreaterEqual(config.repetitions, 20)
+
+    def test_non_policy_gradient_card_preserves_requested_short_horizon(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-bandit-short-horizon",
+            code_commit="1" * 40,
+            training_approach="bandit",
+            created_at="2026-05-17T00:25:00Z",
+            simulation_ticks=125,
+        )
+        config = runner.simulation_config_from_card(card)
+
+        self.assertEqual(config.ticks, 125)
 
     def test_validate_rejects_policy_gradient_below_long_horizon_floor(self) -> None:
         card = card_helper.build_card(
@@ -2499,9 +2511,12 @@ class RlExperimentCardTest(unittest.TestCase):
             training_approach="policy_gradient",
             created_at="2026-05-17T00:25:00Z",
         )
-        card["simulation"]["ticks"] = 499
+        card["simulation"]["ticks"] = card_helper.POLICY_GRADIENT_MIN_SIMULATION_TICKS - 1
 
-        with self.assertRaisesRegex(card_helper.CardValidationError, "simulation\\.ticks >= 500"):
+        with self.assertRaisesRegex(
+            card_helper.CardValidationError,
+            f"simulation\\.ticks >= {card_helper.POLICY_GRADIENT_MIN_SIMULATION_TICKS}",
+        ):
             card_helper.validate_card(card)
 
     def test_validate_rejects_policy_gradient_below_trust_sample_budget(self) -> None:
@@ -2710,7 +2725,7 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         runner.validate_experiment_card(generated)
         config = runner.simulation_config_from_card(generated)
-        self.assertEqual(config.ticks, 500)
+        self.assertEqual(config.ticks, card_helper.POLICY_GRADIENT_MIN_SIMULATION_TICKS)
         self.assertEqual(config.repetitions, 20)
         self.assertEqual(generated["training_approach"], "policy_gradient")
         self.assertEqual(generated["policy_gradient"]["target_family"], "construction-priority")

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -511,7 +511,7 @@ class RlTrainingRunnerTest(unittest.TestCase):
             training_approach="policy_gradient",
             created_at="2026-05-18T10:19:30Z",
         )
-        card["simulation"]["ticks"] = 500
+        card["simulation"]["ticks"] = runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS - 1
 
         with self.assertRaisesRegex(
             runner.TrainingCardError,
@@ -936,7 +936,7 @@ class RlTrainingRunnerTest(unittest.TestCase):
             ],
             scenario=card["scenario"],
             kpi_summary={},
-            audit={"ticks": 500},
+            audit={"ticks": runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS - 1},
         )
 
         self.assertIsNotNone(proof)

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -504,6 +504,21 @@ class RlTrainingRunnerTest(unittest.TestCase):
         with self.assertRaisesRegex(runner.TrainingCardError, "scenario metadata is required"):
             runner.validate_experiment_card(card)
 
+    def test_experiment_card_validation_rejects_policy_gradient_below_activation_floor(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-training-policy-gradient-short-horizon",
+            code_commit="a" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-18T10:19:30Z",
+        )
+        card["simulation"]["ticks"] = 500
+
+        with self.assertRaisesRegex(
+            runner.TrainingCardError,
+            f"simulation\\.ticks >= {runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS}",
+        ):
+            runner.validate_experiment_card(card)
+
     def test_experiment_card_validation_rejects_inconsistent_scenario_suitability(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-training-scenario-invalid",
@@ -888,6 +903,50 @@ class RlTrainingRunnerTest(unittest.TestCase):
         self.assertTrue(proof["ok"])
         self.assertEqual(proof["passingVariants"], [variant_ids[0]])
         self.assertNotIn("blocker", proof)
+
+    def test_multi_tier_activation_proof_blocks_short_audit_horizon(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-training-multitier-short-audit",
+            code_commit="b" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-18T10:22:30Z",
+            scenario_id=card_helper.MULTI_TIER_SCENARIO_ID,
+            require_multi_tier_scenario=True,
+        )
+        proof = runner.build_multi_tier_activation_proof(
+            results=[
+                {
+                    "variantId": "candidate",
+                    "sampleCount": 1,
+                    "metrics": {
+                        "territory": {"delta": 3},
+                        "kills": {"hostileKills": 1},
+                        "objectiveSignal": {
+                            "initialObservedRoomCount": 2,
+                            "finalObservedRoomCount": 2,
+                            "initialHostileCreeps": 2,
+                            "finalHostileCreeps": 1,
+                            "initialHostileStructures": 1,
+                            "finalHostileStructures": 1,
+                            "initialObjectiveSignalPresent": True,
+                            "finalObjectiveSignalPresent": True,
+                        },
+                    },
+                }
+            ],
+            scenario=card["scenario"],
+            kpi_summary={},
+            audit={"ticks": 500},
+        )
+
+        self.assertIsNotNone(proof)
+        if proof is None:
+            self.fail("expected multi-tier activation proof")
+        self.assertEqual(proof["status"], "blocked")
+        self.assertFalse(proof["ok"])
+        self.assertEqual(proof["blocker"]["classification"], "SIMULATION_HORIZON_TOO_SHORT")
+        self.assertEqual(proof["criteria"]["minimumSimulationTicks"], runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS)
+        self.assertNotIn("passingVariants", proof)
 
     def test_multi_tier_activation_proof_derives_kills_from_observed_hostile_reduction(self) -> None:
         card = card_helper.build_card(
@@ -1993,7 +2052,7 @@ export const STRATEGY_REGISTRY = [
         self.assertFalse(report["policyUpdate"]["promotionGate"]["loopAPromotionEligible"])
         self.assertFalse(report["policyUpdate"]["promotionGate"]["loopBPromotionEligible"])
         self.assertNotIn("policyUpdateArtifactPath", report)
-        self.assertEqual(simulator.calls[0]["ticks"], 500)
+        self.assertEqual(simulator.calls[0]["ticks"], runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS)
         self.assertEqual(simulator.calls[0]["variants"], variant_ids)
         self.assertEqual(
             simulator.calls[0]["variant_configs"]["construction-priority.pg.territory-seed.v1"]["parameters"],

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -482,7 +482,7 @@ def write_tencent_guard_summary(
     run_id: str,
     *,
     scenario_id: str = runner.DEFAULT_SCENARIO_ID,
-    ticks: int = 500,
+    ticks: int = runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS,
     final_status: str = "completed",
     territory_kills: tuple[tuple[float, float], ...] = ((2, 0), (2, 0)),
     room: str = "E1S1",
@@ -3035,7 +3035,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                             "officialMmoWrites": False,
                             "officialMmoWritesAllowed": False,
                             "artifactCount": 25,
-                            "simulation": {"ticks": 500},
+                            "simulation": {"ticks": runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS},
                             "scaleValidation": {
                                 "ok": True,
                                 "targetEnvironments": 5,
@@ -3107,7 +3107,10 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(summary["execution"]["artifactCount"], 25)
         self.assertEqual(summary["execution"]["environmentsRun"], 25)
         self.assertEqual(summary["batchScale"]["environmentRows"], 25)
-        self.assertEqual(summary["batchScale"]["simulatorTicks"], 12500)
+        self.assertEqual(
+            summary["batchScale"]["simulatorTicks"],
+            25 * runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS,
+        )
         self.assertEqual(training_report["artifactCount"], 25)
         self.assertEqual(training_report["policyUpdateIterations"], 0)
         self.assertIsNone(training_report["policyUpdateArtifactPath"])
@@ -3144,6 +3147,27 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertFalse(guard["safety"]["scaleOutAttempted"])
         self.assertEqual({item["territory"] for item in guard["evidence"]["runs"]}, {2})
         self.assertEqual({item["kills"] for item in guard["evidence"]["runs"]}, {0})
+
+    def test_e1s1_repeat_launch_guard_ignores_legacy_500_tick_policy_gradient_smokes(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for run_id in ("tencent-pg-legacy-1", "tencent-pg-legacy-2", "tencent-pg-legacy-3"):
+                write_tencent_guard_summary(artifact_root, run_id, ticks=500)
+            args = controller_args()
+            args.artifact_root = artifact_root
+            args.training_approach = "policy_gradient"
+            args.ticks = 500
+
+            guard = runner.build_e1s1_repeat_launch_guard(
+                args=args,
+                run_id="new-run",
+                artifact_dir=artifact_root / "new-run",
+            )
+
+        self.assertFalse(guard["blocked"])
+        self.assertEqual(guard["status"], "clear")
+        self.assertEqual(guard["evidence"]["count"], 0)
+        self.assertEqual(guard["currentLaunch"]["effectiveTicks"], runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS)
 
     def test_e1s1_repeat_launch_guard_scans_past_recent_irrelevant_summaries(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -3316,6 +3340,13 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(args.repetitions, 4)
         self.assertEqual(runner.policy_gradient_samples_per_candidate(args), 20)
         self.assertEqual(runner.effective_training_ticks(args), runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS)
+
+    def test_effective_training_ticks_preserves_non_policy_gradient_request(self) -> None:
+        args = controller_args()
+        args.training_approach = "bandit"
+        args.ticks = 125
+
+        self.assertEqual(runner.effective_training_ticks(args), 125)
 
     def test_preflight_command_uses_preflight_run_id_prefix(self) -> None:
         args = runner.parse_cli_args(["preflight"])
@@ -3772,7 +3803,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(card["card_supply"]["type"], "screeps-rl-loop-a-card-supply")
         self.assertEqual(card["card_supply"]["consumer"], "loop-a-policy-gradient")
         self.assertTrue(card["card_supply"]["available_for_training"])
-        self.assertEqual(card["simulation"]["ticks"], 500)
+        self.assertEqual(card["simulation"]["ticks"], runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS)
         self.assertEqual(card["simulation"]["workers"], 5)
         self.assertEqual(card["simulation"]["repetitions"], 5)
         self.assertFalse(card["officialMmoWrites"])
@@ -3780,7 +3811,10 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(controller.result["experimentCard"]["trainingApproach"], "policy_gradient")
         self.assertEqual(controller.result["experimentCard"]["cardSupply"]["state"], "available")
         self.assertEqual(spec["experimentCard"]["cardSupply"]["state"], "available")
-        self.assertEqual(spec["scaleProof"]["remoteRunnerContract"]["cardSimulationFields"]["ticks"], 500)
+        self.assertEqual(
+            spec["scaleProof"]["remoteRunnerContract"]["cardSimulationFields"]["ticks"],
+            runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS,
+        )
 
     def test_run_remote_training_collects_diagnostics_on_exit_two(self) -> None:
         args = controller_args()
@@ -5288,7 +5322,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                             "officialMmoWrites": False,
                             "officialMmoWritesAllowed": False,
                             "artifactCount": 23,
-                            "simulation": {"ticks": 500},
+                            "simulation": {"ticks": runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS},
                             "scaleValidation": {
                                 "ok": False,
                                 "targetEnvironments": 5,


### PR DESCRIPTION
## Summary
- Extends objective-activation smoke configuration so the RL training runner and Tencent runner can request/record longer activation windows for the territory/combat objective proof.
- Persists the activation-window metadata into experiment cards and generated runtime artifacts so post-run triage can distinguish true objective failure from too-short smoke horizons.
- Adds focused regression coverage for experiment-card defaults, training-runner propagation, and Tencent batch runner command/artifact handling.

## Verification
- `python3 -m py_compile scripts/screeps_rl_experiment_card.py scripts/screeps_rl_training_runner.py scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_rl_experiment_card.py scripts/test_screeps_rl_training_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `git diff --check`
- `python3 -m unittest scripts.test_screeps_rl_experiment_card scripts.test_screeps_rl_training_runner scripts.test_screeps_tencent_batch_rl_runner` (327 tests OK)

## Safety
- Offline/RL runner scripts only; no official MMO runtime writes.
- Further paid Tencent compute remains gated by the active #1233/#1337/#879 validation cadence and should not be duplicated while a batch run is active.

Refs #1450, #879, #1032, #1337, #1299, #1233.
