### PR TITLE
fix(rl): keep live dashboard summary responsive

### DIFF
--- a/docs/ops/rl-live-dashboard-runbook.md
+++ b/docs/ops/rl-live-dashboard-runbook.md
@@ -82,7 +82,7 @@ python3 scripts/screeps_rl_live_dashboard.py serve \
   --auto-refresh-seconds 300
 ```
 
-The live server precomputes and caches generated `/api/summary` and HTML summary data, invalidates that cache after each refresh, and bounds newest-artifact evidence scans. The default summary inspects the newest 25 files per targeted source group and exposes truncation metadata in `artifactEvidenceScan` plus `tencentBatch.truncated`, so capped scans are visible instead of silent. The standard local service therefore keeps health checks and summary reads fast while still refreshing SQLite on start and every 300 seconds while running.
+The live server precomputes and caches generated `/api/summary` and HTML summary data, preserves the last usable summary while a refresh is in progress, keeps the primed summary after a successful refresh, and invalidates the cache when refresh data changes without a usable primed summary. The default summary inspects the newest 25 files per targeted source group and exposes truncation metadata in `artifactEvidenceScan` plus `tencentBatch.truncated`, so capped scans are visible instead of silent. The standard local service therefore keeps health checks and summary reads fast while still refreshing SQLite on start and every 300 seconds while running.
 
 Trigger a local refresh through the running service only after starting it with `--enable-refresh-endpoint`:
 

--- a/docs/ops/rl-live-dashboard-runbook.md
+++ b/docs/ops/rl-live-dashboard-runbook.md
@@ -82,7 +82,7 @@ python3 scripts/screeps_rl_live_dashboard.py serve \
   --auto-refresh-seconds 300
 ```
 
-The live server precomputes and caches generated `/api/summary` and HTML summary data, preserves the last usable summary while a refresh is in progress, keeps the primed summary after a successful refresh, and invalidates the cache when refresh data changes without a usable primed summary. The default summary inspects the newest 25 files per targeted source group and exposes truncation metadata in `artifactEvidenceScan` plus `tencentBatch.truncated`, so capped scans are visible instead of silent. The standard local service therefore keeps health checks and summary reads fast while still refreshing SQLite on start and every 300 seconds while running.
+The live server precomputes and caches generated `/api/summary` and HTML summary data, preserves the last usable summary only while a refresh is in progress, rebuilds a fresh primed summary from the refreshed SQLite/artifacts after each successful refresh, and invalidates stale or in-progress cache data if that post-refresh rebuild fails. The default summary inspects the newest 25 files per targeted source group and exposes truncation metadata in `artifactEvidenceScan` plus `tencentBatch.truncated`, so capped scans are visible instead of silent. The standard local service therefore keeps health checks and summary reads fast while still refreshing SQLite on start and every 300 seconds while running.
 
 Trigger a local refresh through the running service only after starting it with `--enable-refresh-endpoint`:
 

--- a/scripts/screeps_rl_live_dashboard.py
+++ b/scripts/screeps_rl_live_dashboard.py
@@ -218,6 +218,7 @@ class LiveDashboardHTTPServer(ThreadingHTTPServer):
         self.summary_cache_dashboard_url: str | None = None
         self.summary_cache_until = 0.0
         self.summary_cache_generation = 0
+        self.active_refresh_token: str | None = None
         self.refresh_state: JsonObject = {
             "mode": "auto" if config.auto_refresh_seconds > 0 else "manual",
             "autoRefreshSeconds": config.auto_refresh_seconds if config.auto_refresh_seconds > 0 else None,
@@ -250,6 +251,8 @@ class LiveDashboardHTTPServer(ThreadingHTTPServer):
                 self.refresh_state.get("activeRefreshStartedAt") if keep_in_progress else None
             )
             self.refresh_state["activeRefreshReason"] = active_reason if keep_in_progress else None
+            if not keep_in_progress:
+                self.active_refresh_token = None
             self.refresh_state["lastRefreshAt"] = timestamp
             self.refresh_state["lastRefreshOk"] = refresh_succeeded(refresh)
             self.refresh_state["lastRefresh"] = dashboard_json_safe(refresh, self.config.repo_root)
@@ -264,11 +267,14 @@ class LiveDashboardHTTPServer(ThreadingHTTPServer):
         with self.refresh_state_lock:
             return dict(self.refresh_state)
 
-    def finish_refresh_progress(self, *, preserve_summary: bool = False) -> None:
+    def finish_refresh_progress(self, *, refresh_token: str, preserve_summary: bool = False) -> None:
         with self.refresh_state_lock:
+            if getattr(self, "active_refresh_token", None) != refresh_token:
+                return
             self.refresh_state["refreshInProgress"] = False
             self.refresh_state["activeRefreshStartedAt"] = None
             self.refresh_state["activeRefreshReason"] = None
+            self.active_refresh_token = None
             refresh = dict(self.refresh_state)
         if preserve_summary:
             self.refresh_cached_summary_state(refresh)
@@ -277,6 +283,7 @@ class LiveDashboardHTTPServer(ThreadingHTTPServer):
 
     def mark_refresh_started(self, reason: str) -> str:
         timestamp = utc_now_iso()
+        refresh_token = f"{timestamp}:{time.monotonic_ns()}"
         with self.refresh_state_lock:
             previous_refresh_ok = self.refresh_state.get("lastRefreshOk") is True and bool(
                 self.refresh_state.get("lastRefreshAt")
@@ -284,12 +291,13 @@ class LiveDashboardHTTPServer(ThreadingHTTPServer):
             self.refresh_state["refreshInProgress"] = True
             self.refresh_state["activeRefreshStartedAt"] = timestamp
             self.refresh_state["activeRefreshReason"] = reason
+            self.active_refresh_token = refresh_token
         self.invalidate_summary_cache(preserve_existing=previous_refresh_ok)
-        return timestamp
+        return refresh_token
 
     def run_refresh_cycle(self, reason: str) -> JsonObject:
         with self.refresh_lock:
-            self.mark_refresh_started(reason)
+            refresh_token = self.mark_refresh_started(reason)
             try:
                 refresh = refresh_metrics(
                     self.config.db_path,
@@ -309,9 +317,9 @@ class LiveDashboardHTTPServer(ThreadingHTTPServer):
                 self.prime_summary_cache()
                 summary_primed = True
             except Exception:
-                self.invalidate_summary_cache()
+                summary_primed = False
             finally:
-                self.finish_refresh_progress(preserve_summary=summary_primed)
+                self.finish_refresh_progress(refresh_token=refresh_token, preserve_summary=summary_primed)
         return refresh
 
     def start_background_refresh(self, reason: str) -> threading.Thread:

--- a/scripts/screeps_rl_live_dashboard.py
+++ b/scripts/screeps_rl_live_dashboard.py
@@ -264,12 +264,16 @@ class LiveDashboardHTTPServer(ThreadingHTTPServer):
         with self.refresh_state_lock:
             return dict(self.refresh_state)
 
-    def finish_refresh_progress(self) -> None:
+    def finish_refresh_progress(self, *, preserve_summary: bool = False) -> None:
         with self.refresh_state_lock:
             self.refresh_state["refreshInProgress"] = False
             self.refresh_state["activeRefreshStartedAt"] = None
             self.refresh_state["activeRefreshReason"] = None
-        self.invalidate_summary_cache()
+            refresh = dict(self.refresh_state)
+        if preserve_summary:
+            self.refresh_cached_summary_state(refresh)
+        else:
+            self.invalidate_summary_cache()
 
     def mark_refresh_started(self, reason: str) -> str:
         timestamp = utc_now_iso()
@@ -300,12 +304,14 @@ class LiveDashboardHTTPServer(ThreadingHTTPServer):
                 active_reason=f"{reason} summary",
             )
         if refresh_succeeded(refresh):
+            summary_primed = False
             try:
                 self.prime_summary_cache()
+                summary_primed = True
             except Exception:
                 self.invalidate_summary_cache()
             finally:
-                self.finish_refresh_progress()
+                self.finish_refresh_progress(preserve_summary=summary_primed)
         return refresh
 
     def start_background_refresh(self, reason: str) -> threading.Thread:
@@ -349,6 +355,15 @@ class LiveDashboardHTTPServer(ThreadingHTTPServer):
                 self.summary_cache = None
                 self.summary_cache_dashboard_url = None
                 self.summary_cache_until = 0.0
+            self.summary_cache_generation += 1
+
+    def refresh_cached_summary_state(self, refresh: JsonObject) -> None:
+        with self.summary_lock:
+            if self.summary_cache is None:
+                return
+            self.summary_cache = summary_with_refresh(self.summary_cache, refresh)
+            cache_ttl = max(0.0, float(self.config.summary_cache_seconds))
+            self.summary_cache_until = time.monotonic() + cache_ttl if cache_ttl > 0 else 0.0
             self.summary_cache_generation += 1
 
     def prime_summary_cache(self) -> JsonObject:

--- a/scripts/screeps_rl_live_dashboard.py
+++ b/scripts/screeps_rl_live_dashboard.py
@@ -375,7 +375,11 @@ class LiveDashboardHTTPServer(ThreadingHTTPServer):
             self.summary_cache_generation += 1
 
     def prime_summary_cache(self) -> JsonObject:
-        return self.summary_snapshot(self.dashboard_url(), allow_refresh_placeholder=False)
+        return self.summary_snapshot(
+            self.dashboard_url(),
+            allow_refresh_placeholder=False,
+            force_rebuild_cache=True,
+        )
 
     def cached_summary_for_refresh(self, dashboard_url: str, refresh: JsonObject) -> JsonObject | None:
         with self.summary_lock:
@@ -386,7 +390,13 @@ class LiveDashboardHTTPServer(ThreadingHTTPServer):
                 return None
             return summary_with_refresh(cached, refresh)
 
-    def summary_snapshot(self, dashboard_url: str, *, allow_refresh_placeholder: bool = True) -> JsonObject:
+    def summary_snapshot(
+        self,
+        dashboard_url: str,
+        *,
+        allow_refresh_placeholder: bool = True,
+        force_rebuild_cache: bool = False,
+    ) -> JsonObject:
         refresh = self.refresh_snapshot()
         if allow_refresh_placeholder and refresh.get("refreshInProgress"):
             cached = self.cached_summary_for_refresh(dashboard_url, refresh)
@@ -397,7 +407,8 @@ class LiveDashboardHTTPServer(ThreadingHTTPServer):
         current_monotonic = time.monotonic()
         with self.summary_lock:
             if (
-                not refresh.get("refreshInProgress")
+                not force_rebuild_cache
+                and not refresh.get("refreshInProgress")
                 and cache_ttl > 0
                 and self.summary_cache is not None
                 and self.summary_cache_dashboard_url == dashboard_url
@@ -432,7 +443,8 @@ class LiveDashboardHTTPServer(ThreadingHTTPServer):
         current_monotonic = time.monotonic()
         with self.summary_lock:
             if (
-                cache_ttl > 0
+                not force_rebuild_cache
+                and cache_ttl > 0
                 and self.summary_cache is not None
                 and self.summary_cache_dashboard_url == dashboard_url
                 and current_monotonic < self.summary_cache_until

--- a/scripts/test_screeps_rl_live_dashboard.py
+++ b/scripts/test_screeps_rl_live_dashboard.py
@@ -1973,11 +1973,38 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
                 summary_cache_seconds=60,
             )
             server = make_unbound_live_server(config)
+            dashboard_url = server.dashboard_url()
+            stale_refresh = dict(server.refresh_state)
+            stale_refresh["lastRefreshAt"] = "2026-05-18T10:00:00Z"
+            stale_refresh["lastRefreshOk"] = True
+            stale_refresh["lastRefresh"] = {"ok": True, "files_scanned": 1}
+            server.refresh_state.update(stale_refresh)
+            with server.summary_lock:
+                server.summary_cache = {
+                    "type": "screeps-rl-live-dashboard",
+                    "generatedAt": "stale-cached-summary",
+                    "dashboardUrl": dashboard_url,
+                    "health": {"ok": True, "status": "ok", "failures": []},
+                    "db": {
+                        "exists": True,
+                        "schemaReady": True,
+                        "tables": {"metric_observations": 1},
+                        "latestObservedAt": "2026-05-18T10:00:00Z",
+                    },
+                    "refresh": stale_refresh,
+                    "e1Gate": {"status": "OK"},
+                    "loopA": {"environment": {}, "training": {}},
+                    "loopB": {"policy": {}, "scorecard": {"status": "OK"}},
+                    "tencentBatch": {"hasData": True},
+                    "projectGates": [{"issue": "#1233", "status": "OK"}],
+                }
+                server.summary_cache_dashboard_url = dashboard_url
+                server.summary_cache_until = time.monotonic() + 60
             live.refresh_metrics = successful_refresh_metrics
             live.build_live_summary = cached_build_live_summary
             try:
                 refresh = server.run_refresh_cycle("manual")
-                summary = server.summary_snapshot(server.dashboard_url())
+                summary = server.summary_snapshot(dashboard_url)
             finally:
                 live.refresh_metrics = original_refresh_metrics
                 live.build_live_summary = original_build_live_summary
@@ -1985,6 +2012,7 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
         self.assertTrue(refresh["ok"])
         self.assertEqual(len(build_calls), 1)
         self.assertEqual(summary["generatedAt"], "primed-call-1")
+        self.assertNotEqual(summary["generatedAt"], "stale-cached-summary")
         self.assertFalse(summary["refresh"]["refreshInProgress"])
         self.assertIsNone(summary["refresh"]["activeRefreshReason"])
         self.assertTrue(summary["refresh"]["lastRefreshOk"])

--- a/scripts/test_screeps_rl_live_dashboard.py
+++ b/scripts/test_screeps_rl_live_dashboard.py
@@ -256,6 +256,7 @@ def make_unbound_live_server(
     server.summary_cache_dashboard_url = None
     server.summary_cache_until = 0.0
     server.summary_cache_generation = 0
+    server.active_refresh_token = None
     server.refresh_state = {
         "mode": "auto" if config.auto_refresh_seconds > 0 else "manual",
         "autoRefreshSeconds": config.auto_refresh_seconds if config.auto_refresh_seconds > 0 else None,
@@ -1901,6 +1902,31 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
         self.assertFalse(first["refresh"]["refreshInProgress"])
         self.assertFalse(second["refresh"]["refreshInProgress"])
 
+    def test_finish_refresh_progress_ignores_stale_refresh_token(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            artifact_root = repo_root / "runtime-artifacts"
+            db_path = repo_root / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite"
+            config = live.LiveDashboardConfig(repo_root=repo_root, artifact_root=artifact_root, db_path=db_path)
+            server = make_unbound_live_server(config)
+
+            first_token = server.mark_refresh_started("auto")
+            second_token = server.mark_refresh_started("manual")
+            second_started_at = server.refresh_snapshot()["activeRefreshStartedAt"]
+
+            server.finish_refresh_progress(refresh_token=first_token)
+            stale_finish = server.refresh_snapshot()
+            server.finish_refresh_progress(refresh_token=second_token)
+            final_finish = server.refresh_snapshot()
+
+        self.assertNotEqual(first_token, second_token)
+        self.assertTrue(stale_finish["refreshInProgress"])
+        self.assertEqual(stale_finish["activeRefreshStartedAt"], second_started_at)
+        self.assertEqual(stale_finish["activeRefreshReason"], "manual")
+        self.assertFalse(final_finish["refreshInProgress"])
+        self.assertIsNone(final_finish["activeRefreshStartedAt"])
+        self.assertIsNone(final_finish["activeRefreshReason"])
+
     def test_successful_refresh_keeps_primed_summary_cache_after_finishing(self) -> None:
         original_refresh_metrics = live.refresh_metrics
         original_build_live_summary = live.build_live_summary
@@ -1963,6 +1989,72 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
         self.assertIsNone(summary["refresh"]["activeRefreshReason"])
         self.assertTrue(summary["refresh"]["lastRefreshOk"])
         self.assertEqual(summary["refresh"]["lastRefresh"]["files_scanned"], 7)
+
+    def test_failed_summary_priming_clears_refresh_progress_and_stale_cache(self) -> None:
+        original_refresh_metrics = live.refresh_metrics
+        original_build_live_summary = live.build_live_summary
+        primed_refreshes: list[JsonObject] = []
+
+        def successful_refresh_metrics(
+            db_path: Path,
+            artifact_root: Path,
+            paths: Any = None,
+            **_kwargs: Any,
+        ) -> JsonObject:
+            return {"ok": True, "files_scanned": 7}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            artifact_root = repo_root / "runtime-artifacts"
+            db_path = repo_root / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite"
+            config = live.LiveDashboardConfig(
+                repo_root=repo_root,
+                artifact_root=artifact_root,
+                db_path=db_path,
+                summary_cache_seconds=60,
+            )
+            server = make_unbound_live_server(config)
+
+            def failing_build_live_summary(*_args: Any, **kwargs: Any) -> JsonObject:
+                refresh = dict(kwargs.get("refresh") or {})
+                primed_refreshes.append(refresh)
+                with server.summary_lock:
+                    server.summary_cache = {
+                        "type": "screeps-rl-live-dashboard",
+                        "generatedAt": "stale-in-progress",
+                        "dashboardUrl": kwargs.get("dashboard_url"),
+                        "health": {"ok": True, "status": "ok", "failures": []},
+                        "db": {
+                            "exists": True,
+                            "schemaReady": True,
+                            "tables": {"metric_observations": 1},
+                            "latestObservedAt": "2026-05-18T10:09:00Z",
+                        },
+                        "refresh": refresh,
+                    }
+                    server.summary_cache_dashboard_url = str(kwargs.get("dashboard_url"))
+                    server.summary_cache_until = time.monotonic() + 60
+                raise RuntimeError("summary priming failed")
+
+            live.refresh_metrics = successful_refresh_metrics
+            live.build_live_summary = failing_build_live_summary
+            try:
+                refresh = server.run_refresh_cycle("manual")
+                snapshot = server.refresh_snapshot()
+                with server.summary_lock:
+                    cached_summary = server.summary_cache
+            finally:
+                live.refresh_metrics = original_refresh_metrics
+                live.build_live_summary = original_build_live_summary
+
+        self.assertTrue(refresh["ok"])
+        self.assertEqual(len(primed_refreshes), 1)
+        self.assertTrue(primed_refreshes[0]["refreshInProgress"])
+        self.assertEqual(primed_refreshes[0]["activeRefreshReason"], "manual summary")
+        self.assertFalse(snapshot["refreshInProgress"])
+        self.assertIsNone(snapshot["activeRefreshStartedAt"])
+        self.assertIsNone(snapshot["activeRefreshReason"])
+        self.assertIsNone(cached_summary)
 
     def test_live_acceptance_passes_running_service(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_live_dashboard.py
+++ b/scripts/test_screeps_rl_live_dashboard.py
@@ -238,6 +238,41 @@ def wait_for_json_url(url: str, timeout_seconds: float = 5.0) -> JsonObject:
             time.sleep(0.05)
 
 
+def make_unbound_live_server(
+    config: live.LiveDashboardConfig,
+    server_address: tuple[str, int] = ("127.0.0.1", 8765),
+) -> live.LiveDashboardHTTPServer:
+    server = live.LiveDashboardHTTPServer.__new__(live.LiveDashboardHTTPServer)
+    server.config = config
+    server.server_address = server_address
+    server.refresh_lock = threading.Lock()
+    server.refresh_state_lock = threading.Lock()
+    server.summary_lock = threading.Lock()
+    server.background_refresh_threads_lock = threading.Lock()
+    server.background_refresh_threads = []
+    server.refresh_stop = threading.Event()
+    server.refresh_thread = None
+    server.summary_cache = None
+    server.summary_cache_dashboard_url = None
+    server.summary_cache_until = 0.0
+    server.summary_cache_generation = 0
+    server.refresh_state = {
+        "mode": "auto" if config.auto_refresh_seconds > 0 else "manual",
+        "autoRefreshSeconds": config.auto_refresh_seconds if config.auto_refresh_seconds > 0 else None,
+        "initialRefreshRequired": config.initial_refresh_required,
+        "refreshInProgress": False,
+        "activeRefreshStartedAt": None,
+        "activeRefreshReason": None,
+        "lastRefreshAt": None,
+        "lastRefreshOk": None,
+        "lastRefresh": None,
+        "nextRefreshAt": live.utc_iso_after(config.auto_refresh_seconds)
+        if config.auto_refresh_seconds > 0
+        else None,
+    }
+    return server
+
+
 class ScreepsRlLiveDashboardTest(unittest.TestCase):
     def test_tencent_active_run_within_declared_timeout_uses_utc_age(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -1865,6 +1900,69 @@ class ScreepsRlLiveDashboardTest(unittest.TestCase):
         self.assertTrue(first["refresh"]["lastRefreshOk"])
         self.assertFalse(first["refresh"]["refreshInProgress"])
         self.assertFalse(second["refresh"]["refreshInProgress"])
+
+    def test_successful_refresh_keeps_primed_summary_cache_after_finishing(self) -> None:
+        original_refresh_metrics = live.refresh_metrics
+        original_build_live_summary = live.build_live_summary
+        build_calls: list[JsonObject] = []
+
+        def successful_refresh_metrics(
+            db_path: Path,
+            artifact_root: Path,
+            paths: Any = None,
+            **_kwargs: Any,
+        ) -> JsonObject:
+            return {"ok": True, "files_scanned": 7}
+
+        def cached_build_live_summary(*_args: Any, **kwargs: Any) -> JsonObject:
+            refresh = dict(kwargs.get("refresh") or {})
+            build_calls.append(refresh)
+            return {
+                "type": "screeps-rl-live-dashboard",
+                "generatedAt": f"primed-call-{len(build_calls)}",
+                "dashboardUrl": kwargs.get("dashboard_url"),
+                "health": {"ok": True, "status": "ok", "failures": []},
+                "db": {
+                    "exists": True,
+                    "schemaReady": True,
+                    "tables": {"metric_observations": 1},
+                    "latestObservedAt": "2026-05-18T10:09:00Z",
+                },
+                "refresh": refresh,
+                "e1Gate": {"status": "OK"},
+                "loopA": {"environment": {}, "training": {}},
+                "loopB": {"policy": {}, "scorecard": {"status": "OK"}},
+                "tencentBatch": {"hasData": True},
+                "projectGates": [{"issue": "#1233", "status": "OK"}],
+            }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            artifact_root = repo_root / "runtime-artifacts"
+            db_path = repo_root / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite"
+            config = live.LiveDashboardConfig(
+                repo_root=repo_root,
+                artifact_root=artifact_root,
+                db_path=db_path,
+                summary_cache_seconds=60,
+            )
+            server = make_unbound_live_server(config)
+            live.refresh_metrics = successful_refresh_metrics
+            live.build_live_summary = cached_build_live_summary
+            try:
+                refresh = server.run_refresh_cycle("manual")
+                summary = server.summary_snapshot(server.dashboard_url())
+            finally:
+                live.refresh_metrics = original_refresh_metrics
+                live.build_live_summary = original_build_live_summary
+
+        self.assertTrue(refresh["ok"])
+        self.assertEqual(len(build_calls), 1)
+        self.assertEqual(summary["generatedAt"], "primed-call-1")
+        self.assertFalse(summary["refresh"]["refreshInProgress"])
+        self.assertIsNone(summary["refresh"]["activeRefreshReason"])
+        self.assertTrue(summary["refresh"]["lastRefreshOk"])
+        self.assertEqual(summary["refresh"]["lastRefresh"]["files_scanned"], 7)
 
     def test_live_acceptance_passes_running_service(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- keep the live dashboard's primed `/api/summary` cache available after successful refresh completion
- add regression coverage proving a successful refresh does not discard the warm summary payload
- preserve fast owner-facing dashboard reads while refresh state transitions from in-progress to complete

## Verification
- `python3 -m unittest scripts.test_screeps_rl_live_dashboard.ScreepsRlLiveDashboardTest.test_summary_and_healthz_read_sqlite_under_refresh_lock scripts.test_screeps_rl_live_dashboard.ScreepsRlLiveDashboardTest.test_summary_endpoint_uses_cache_until_refresh_invalidates_it scripts.test_screeps_rl_live_dashboard.ScreepsRlLiveDashboardTest.test_successful_refresh_does_not_cache_in_progress_summary scripts.test_screeps_rl_live_dashboard.ScreepsRlLiveDashboardTest.test_successful_refresh_keeps_primed_summary_cache_after_finishing scripts.test_screeps_rl_live_dashboard.ScreepsRlLiveDashboardTest.test_live_acceptance_passes_running_service scripts.test_screeps_rl_live_dashboard.ScreepsRlLiveDashboardTest.test_health_and_acceptance_stay_ok_during_auto_refresh_with_cached_summary`
- `python3 -m py_compile scripts/screeps_rl_live_dashboard.py scripts/screeps_rl_dashboard.py scripts/screeps_rl_metrics_ingestor.py`
- `git diff --check`

## Safety
- Observability/dashboard-only change; no official MMO writes and no learned-policy rollout.
- Existing canonical dashboard process was not killed during investigation.

Related to issue #1464. Controller must run post-merge live-dashboard acceptance before closing the issue.