### PR TITLE
fix(rl): add Grafana metrics contract

### DIFF
--- a/docs/ops/grafana/README.md
+++ b/docs/ops/grafana/README.md
@@ -1,0 +1,63 @@
+# Screeps RL Grafana Contract
+
+This directory is the durable local Grafana contract for the RL flywheel metrics surface. It is separate from the Python dashboard-equivalent on `127.0.0.1:8765`.
+
+## Files
+
+| Path | Purpose |
+| --- | --- |
+| `screeps-rl-gameplay-metrics.json` | Starter Grafana dashboard for the SQLite RL metrics store. |
+| `provisioning/datasources/screeps-rl-sqlite.yaml` | Grafana datasource provisioning for `runtime-artifacts/rl-metrics/rl_metrics.sqlite` through the `frser-sqlite-datasource` plugin. |
+| `provisioning/dashboards/screeps-rl-dashboards.yaml` | Grafana dashboard provisioning for the tracked dashboard JSON. |
+
+The datasource UID is `screeps-rl-metrics-sqlite`; the dashboard UID is `screeps-rl-gameplay-metrics`.
+
+## Local Run
+
+Print the Docker command without starting Grafana:
+
+```bash
+npm run rl-grafana:print-command
+```
+
+Run actual Grafana on `127.0.0.1:3000`:
+
+```bash
+npm run rl-grafana:run
+```
+
+The default image is `grafana/grafana-oss:11.5.2`; pass `-- --image <image>` to the npm command if the operator intentionally validates a different Grafana image.
+
+The runner mounts:
+
+- `docs/ops/grafana/provisioning` at `/etc/grafana/provisioning`;
+- `docs/ops/grafana` at `/var/lib/grafana/dashboards/screeps`;
+- `runtime-artifacts/rl-metrics` at `/var/lib/grafana/rl-metrics`.
+
+The container installs the `frser-sqlite-datasource` plugin through `GF_INSTALL_PLUGINS`. The host database file must exist before starting the container:
+
+```text
+runtime-artifacts/rl-metrics/rl_metrics.sqlite
+```
+
+Dashboard path after startup:
+
+```text
+http://127.0.0.1:3000/d/screeps-rl-gameplay-metrics/screeps-rl-gameplay-metrics
+```
+
+## Validation
+
+Validate provisioning and dashboard JSON without requiring a running Grafana service:
+
+```bash
+npm run rl-grafana:validate:provisioning
+```
+
+Run the full contract check against local Grafana:
+
+```bash
+npm run rl-grafana:validate
+```
+
+If Grafana is absent, the full validator reports `NOT_RUNNING` instead of `PASS`. That result is intentional: static provisioning correctness is not actual Grafana service evidence.

--- a/docs/ops/grafana/provisioning/dashboards/screeps-rl-dashboards.yaml
+++ b/docs/ops/grafana/provisioning/dashboards/screeps-rl-dashboards.yaml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+providers:
+  - name: screeps-rl-dashboards
+    orgId: 1
+    folder: Screeps RL
+    folderUid: screeps-rl
+    type: file
+    disableDeletion: false
+    allowUiUpdates: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards/screeps
+      foldersFromFilesStructure: false

--- a/docs/ops/grafana/provisioning/datasources/screeps-rl-sqlite.yaml
+++ b/docs/ops/grafana/provisioning/datasources/screeps-rl-sqlite.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Screeps RL Metrics SQLite
+    uid: screeps-rl-metrics-sqlite
+    type: frser-sqlite-datasource
+    access: proxy
+    orgId: 1
+    isDefault: true
+    editable: false
+    jsonData:
+      path: /var/lib/grafana/rl-metrics/rl_metrics.sqlite

--- a/docs/ops/grafana/screeps-rl-gameplay-metrics.json
+++ b/docs/ops/grafana/screeps-rl-gameplay-metrics.json
@@ -446,6 +446,42 @@
       ],
       "title": "Worker Load Efficiency Distribution",
       "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "screeps-rl-metrics-sqlite"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 13,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "format": "table",
+          "queryText": "SELECT created_at, decision_key, status, rationale, source_artifact FROM metric_iteration_decisions ORDER BY created_at DESC LIMIT 100;",
+          "rawQuery": true,
+          "refId": "A"
+        },
+        {
+          "format": "table",
+          "queryText": "SELECT observed_at, metric_name, value, source_artifact FROM metric_observations WHERE metric_name = 'source.rl_metrics_refresh.completed' ORDER BY observed_at DESC LIMIT 20;",
+          "rawQuery": true,
+          "refId": "B"
+        }
+      ],
+      "title": "#879 Decision And Refresh Evidence",
+      "type": "table"
     }
   ],
   "refresh": "5m",

--- a/docs/ops/rl-live-dashboard-runbook.md
+++ b/docs/ops/rl-live-dashboard-runbook.md
@@ -1,10 +1,69 @@
 # RL Live Dashboard Runbook
 
-Status: issue #1237 live observability surface for the #879 RL evidence loop. This supersedes the one-time #1184 local foundation without reopening it.
+Status: issue #1474 real-Grafana contract for the #879 RL evidence loop. This supersedes the one-time #1184 local foundation and the closed #1237/#1381/#1388/#1464 chain without reopening those issues.
 
-This repository keeps the Grafana JSON dashboard in `docs/ops/grafana/`, but the owner-facing operational surface is the dependency-light local live service. The canonical roadmap surface is GitHub Pages at https://lanyusea.github.io/screeps/; the static HTML artifact is supporting evidence, not a Discord roadmap attachment. Neither path requires a Grafana SQLite plugin, external network access, or secrets.
+This runbook has two explicitly separate surfaces:
 
-## Operator Commands
+- Actual Grafana: a Grafana service on `127.0.0.1:3000`, provisioned from `docs/ops/grafana/`, using the `frser-sqlite-datasource` plugin against `runtime-artifacts/rl-metrics/rl_metrics.sqlite`. This is the #1474 selected self-actionable contract.
+- Python dashboard-equivalent: the dependency-light local live service on `127.0.0.1:8765`. It remains a fallback/supporting surface and does not satisfy actual Grafana acceptance by itself.
+
+The canonical roadmap surface is GitHub Pages at https://lanyusea.github.io/screeps/; the static HTML artifact is supporting evidence, not a Discord roadmap attachment.
+
+## Actual Grafana Operator Commands
+
+Provisioning files:
+
+```text
+docs/ops/grafana/provisioning/datasources/screeps-rl-sqlite.yaml
+docs/ops/grafana/provisioning/dashboards/screeps-rl-dashboards.yaml
+docs/ops/grafana/screeps-rl-gameplay-metrics.json
+```
+
+The Grafana SQLite datasource plugin is required:
+
+```text
+frser-sqlite-datasource
+```
+
+Print the Docker command without starting a container:
+
+```bash
+npm run rl-grafana:print-command
+```
+
+Run actual Grafana locally:
+
+```bash
+npm run rl-grafana:run
+```
+
+Default Grafana URL:
+
+```text
+http://127.0.0.1:3000/
+```
+
+Dashboard path:
+
+```text
+http://127.0.0.1:3000/d/screeps-rl-gameplay-metrics/screeps-rl-gameplay-metrics
+```
+
+Validate tracked provisioning and dashboard JSON without requiring Docker/Grafana:
+
+```bash
+npm run rl-grafana:validate:provisioning
+```
+
+Validate the live Grafana service, datasource, and dashboard reachability:
+
+```bash
+npm run rl-grafana:validate
+```
+
+When no Grafana service is listening, the full validator reports `NOT_RUNNING`; that is not a passing acceptance result. Actual Grafana acceptance requires `npm run rl-grafana:validate` to report `PASS` against a service on `127.0.0.1:3000`.
+
+## Python Dashboard-Equivalent Operator Commands
 
 Metrics database:
 
@@ -90,7 +149,7 @@ Trigger a local refresh through the running service only after starting it with 
 curl -fsS -X POST http://127.0.0.1:8765/refresh
 ```
 
-## Dashboard Coverage
+## Python Dashboard-Equivalent Coverage
 
 The live page and `/api/summary` cover:
 
@@ -134,10 +193,32 @@ runtime-artifacts/rl-dashboard.html
 
 Use this static command when refreshing local RL evidence for the GitHub Pages roadmap. Do not schedule or attach a Discord roadmap update for this artifact.
 
+## Actual Grafana Coverage And #879 Evidence
 
-## #1381 Closure Gate
+The actual Grafana dashboard is provisioned from `docs/ops/grafana/screeps-rl-gameplay-metrics.json` and is grounded in the SQLite tables created by `scripts/screeps_rl_metrics_ingestor.py`. Its starter panels cover:
 
-Issue #1381 is a false-completion repair for closed #1184/#1237/#1350. Do **not** close it on a code merge, a runbook update, `npm run rl-metrics-refresh`, static HTML generation, or SQLite file existence alone. Closure requires all of the following live evidence in #879/#1381 Project Evidence:
+| Area | SQLite table/query source |
+| --- | --- |
+| Runtime metric history and refresh proof | `metric_observations`, including `source.rl_metrics_refresh.completed`. |
+| Room economy, construction, pathing, and worker efficiency | `runtime_room_metrics`. |
+| Gameplay findings | `gameplay_behavior_findings`. |
+| Coverage gaps | `metric_coverage_gaps`. |
+| E1 dataset gates | `rl_dataset_gate_metrics`. |
+| Loop A training execution | `rl_training_execution_metrics`. |
+| Loop B policy advantage | `rl_policy_advantage_metrics`. |
+| #879 iteration decisions | `metric_iteration_decisions`. |
+
+#879 evidence is honest only when it states which surface was checked:
+
+- Python fallback evidence: `http://127.0.0.1:8765/`, `/api/summary`, `/healthz`, and `npm run rl-dashboard-live:acceptance`.
+- Actual Grafana evidence: `http://127.0.0.1:3000/`, the dashboard path, `frser-sqlite-datasource` provisioning, `runtime-artifacts/rl-metrics/rl_metrics.sqlite` datasource path, and `npm run rl-grafana:validate` `PASS`.
+
+A Python dashboard-equivalent health or acceptance PASS must not be described as actual Grafana service/panel evidence.
+
+
+## Historical #1381 Closure Gate
+
+Issue #1381 was a false-completion repair for closed #1184/#1237/#1350. Keep this as a historical guardrail only; #1474 work must not reopen #1381 or the closed predecessor chain. Do **not** close it on a code merge, a runbook update, `npm run rl-metrics-refresh`, static HTML generation, or SQLite file existence alone. Closure required all of the following live evidence in #879/#1381 Project Evidence:
 
 1. A running dashboard process/listener at the owner-facing URL (`http://127.0.0.1:8765/` by default).
 2. `npm run rl-dashboard-live:health` output showing `/healthz` with `ok=true`.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
     "rl-dashboard-live": "python3 scripts/screeps_rl_live_dashboard.py serve --refresh-on-start --auto-refresh-seconds 300",
     "rl-dashboard-live:health": "python3 scripts/screeps_rl_live_dashboard.py healthcheck",
     "rl-dashboard-live:acceptance": "python3 scripts/screeps_rl_live_dashboard.py acceptance",
+    "rl-grafana:print-command": "python3 scripts/screeps_rl_grafana.py docker-command",
+    "rl-grafana:run": "python3 scripts/screeps_rl_grafana.py run",
+    "rl-grafana:validate": "python3 scripts/screeps_rl_grafana.py validate",
+    "rl-grafana:validate:provisioning": "python3 scripts/screeps_rl_grafana.py validate --provisioning-only",
     "rl-metrics-refresh": "python3 scripts/screeps_rl_live_dashboard.py refresh"
   },
   "devDependencies": {

--- a/scripts/screeps_rl_grafana.py
+++ b/scripts/screeps_rl_grafana.py
@@ -1,0 +1,551 @@
+#!/usr/bin/env python3
+"""Validate and run the local Grafana surface for Screeps RL metrics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+DATASOURCE_UID = "screeps-rl-metrics-sqlite"
+DATASOURCE_TYPE = "frser-sqlite-datasource"
+DATASOURCE_NAME = "Screeps RL Metrics SQLite"
+DASHBOARD_UID = "screeps-rl-gameplay-metrics"
+DASHBOARD_TITLE = "Screeps RL Gameplay Metrics"
+DASHBOARD_SLUG = "screeps-rl-gameplay-metrics"
+DEFAULT_GRAFANA_URL = "http://127.0.0.1:3000"
+DEFAULT_GRAFANA_IMAGE = "grafana/grafana-oss:11.5.2"
+DEFAULT_GRAFANA_PLUGIN = DATASOURCE_TYPE
+DEFAULT_CONTAINER_NAME = "screeps-rl-grafana"
+CONTAINER_DB_PATH = "/var/lib/grafana/rl-metrics/rl_metrics.sqlite"
+CONTAINER_DASHBOARD_PATH = "/var/lib/grafana/dashboards/screeps"
+CONTAINER_PROVISIONING_PATH = "/etc/grafana/provisioning"
+
+REQUIRED_QUERY_COVERAGE = {
+    "metric observation history": "FROM metric_observations",
+    "runtime room metrics": "FROM runtime_room_metrics",
+    "gameplay behavior findings": "FROM gameplay_behavior_findings",
+    "metric coverage gaps": "FROM metric_coverage_gaps",
+    "E1 dataset gate metrics": "FROM rl_dataset_gate_metrics",
+    "Loop A training execution metrics": "FROM rl_training_execution_metrics",
+    "Loop B policy advantage metrics": "FROM rl_policy_advantage_metrics",
+    "#879 iteration decisions": "FROM metric_iteration_decisions",
+    "metrics refresh proof": "source.rl_metrics_refresh.completed",
+}
+
+
+JsonObject = dict[str, Any]
+
+
+def default_repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def grafana_root(repo_root: Path) -> Path:
+    return repo_root / "docs" / "ops" / "grafana"
+
+
+def datasource_file(repo_root: Path) -> Path:
+    return grafana_root(repo_root) / "provisioning" / "datasources" / "screeps-rl-sqlite.yaml"
+
+
+def dashboard_provider_file(repo_root: Path) -> Path:
+    return grafana_root(repo_root) / "provisioning" / "dashboards" / "screeps-rl-dashboards.yaml"
+
+
+def dashboard_file(repo_root: Path) -> Path:
+    return grafana_root(repo_root) / "screeps-rl-gameplay-metrics.json"
+
+
+def default_db_path(repo_root: Path) -> Path:
+    return repo_root / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite"
+
+
+def check_result(name: str, status: str, details: str) -> JsonObject:
+    return {"name": name, "status": status, "details": details}
+
+
+def append_check(report: JsonObject, name: str, ok: bool, details: str) -> None:
+    status = "PASS" if ok else "FAIL"
+    report["checks"].append(check_result(name, status, details))
+    if not ok:
+        report["errors"].append(f"{name}: {details}")
+
+
+def read_json(path: Path) -> JsonObject:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def iter_panels(panels: Any) -> list[JsonObject]:
+    result: list[JsonObject] = []
+    if not isinstance(panels, list):
+        return result
+    for panel in panels:
+        if not isinstance(panel, dict):
+            continue
+        result.append(panel)
+        result.extend(iter_panels(panel.get("panels")))
+    return result
+
+
+def panel_queries(panels: list[JsonObject]) -> list[str]:
+    queries: list[str] = []
+    for panel in panels:
+        targets = panel.get("targets", [])
+        if not isinstance(targets, list):
+            continue
+        for target in targets:
+            if not isinstance(target, dict):
+                continue
+            query_text = target.get("queryText")
+            if isinstance(query_text, str):
+                queries.append(query_text)
+    return queries
+
+
+def validate_dashboard_payload(dashboard: JsonObject, path: Path) -> JsonObject:
+    report: JsonObject = {"status": "PASS", "checks": [], "errors": [], "warnings": []}
+
+    append_check(report, "dashboard uid", dashboard.get("uid") == DASHBOARD_UID, f"{path} uid must be {DASHBOARD_UID}")
+    append_check(
+        report,
+        "dashboard title",
+        dashboard.get("title") == DASHBOARD_TITLE,
+        f"{path} title must be {DASHBOARD_TITLE}",
+    )
+
+    panels = iter_panels(dashboard.get("panels"))
+    append_check(report, "dashboard panels", len(panels) > 0, f"{path} must define at least one panel")
+
+    panel_ids = [panel.get("id") for panel in panels if isinstance(panel.get("id"), int)]
+    append_check(
+        report,
+        "dashboard panel ids",
+        len(panel_ids) == len(set(panel_ids)) == len(panels),
+        "every panel must have a unique integer id",
+    )
+
+    datasource_errors = []
+    for panel in panels:
+        datasource = panel.get("datasource")
+        if not isinstance(datasource, dict):
+            datasource_errors.append(f"panel {panel.get('id')} has no datasource object")
+            continue
+        if datasource.get("uid") != DATASOURCE_UID or datasource.get("type") != DATASOURCE_TYPE:
+            datasource_errors.append(f"panel {panel.get('id')} does not use {DATASOURCE_UID}/{DATASOURCE_TYPE}")
+    append_check(
+        report,
+        "dashboard datasource binding",
+        not datasource_errors,
+        "; ".join(datasource_errors) if datasource_errors else "all panels use the provisioned SQLite datasource",
+    )
+
+    queries = "\n".join(panel_queries(panels))
+    for name, required_fragment in REQUIRED_QUERY_COVERAGE.items():
+        append_check(
+            report,
+            f"dashboard query coverage: {name}",
+            required_fragment in queries,
+            f"dashboard queries must include {required_fragment}",
+        )
+
+    report["panelCount"] = len(panels)
+    report["queryCount"] = len(panel_queries(panels))
+    report["status"] = "FAIL" if report["errors"] else "PASS"
+    return report
+
+
+def validate_static(repo_root: Path) -> JsonObject:
+    repo_root = repo_root.resolve()
+    report: JsonObject = {
+        "status": "PASS",
+        "repoRoot": str(repo_root),
+        "grafanaUrl": DEFAULT_GRAFANA_URL,
+        "datasourceUid": DATASOURCE_UID,
+        "datasourceType": DATASOURCE_TYPE,
+        "dashboardUid": DASHBOARD_UID,
+        "checks": [],
+        "errors": [],
+        "warnings": [],
+    }
+
+    datasource_path = datasource_file(repo_root)
+    dashboard_provider_path = dashboard_provider_file(repo_root)
+    dashboard_path = dashboard_file(repo_root)
+    db_path = default_db_path(repo_root)
+
+    for name, path in (
+        ("datasource provisioning file", datasource_path),
+        ("dashboard provisioning file", dashboard_provider_path),
+        ("dashboard JSON file", dashboard_path),
+    ):
+        append_check(report, name, path.is_file(), f"{path} must exist")
+
+    if datasource_path.is_file():
+        datasource_text = datasource_path.read_text(encoding="utf-8")
+        datasource_requirements = {
+            "apiVersion: 1": "Grafana provisioning API version",
+            "datasources:": "datasource list",
+            f"name: {DATASOURCE_NAME}": "datasource display name",
+            f"uid: {DATASOURCE_UID}": "stable datasource UID",
+            f"type: {DATASOURCE_TYPE}": "SQLite datasource plugin id",
+            "access: proxy": "server-side datasource access",
+            "isDefault: true": "default local datasource",
+            "editable: false": "tracked provisioning is authoritative",
+            f"path: {CONTAINER_DB_PATH}": "container-visible SQLite path",
+        }
+        for required_text, description in datasource_requirements.items():
+            append_check(
+                report,
+                f"datasource provisioning: {description}",
+                required_text in datasource_text,
+                f"{datasource_path} must include {required_text}",
+            )
+        secret_markers = ("secureJsonData", "password:", "token:", "basicAuthUser", "basicAuthPassword")
+        append_check(
+            report,
+            "datasource provisioning has no secrets",
+            not any(marker in datasource_text for marker in secret_markers),
+            f"{datasource_path} must not contain credentials",
+        )
+
+    if dashboard_provider_path.is_file():
+        provider_text = dashboard_provider_path.read_text(encoding="utf-8")
+        provider_requirements = {
+            "apiVersion: 1": "Grafana provisioning API version",
+            "providers:": "dashboard provider list",
+            "name: screeps-rl-dashboards": "dashboard provider name",
+            "folder: Screeps RL": "dashboard folder",
+            "type: file": "file-backed dashboard provider",
+            f"path: {CONTAINER_DASHBOARD_PATH}": "container-visible dashboard path",
+            "allowUiUpdates: false": "tracked dashboard JSON is authoritative",
+        }
+        for required_text, description in provider_requirements.items():
+            append_check(
+                report,
+                f"dashboard provisioning: {description}",
+                required_text in provider_text,
+                f"{dashboard_provider_path} must include {required_text}",
+            )
+
+    if dashboard_path.is_file():
+        try:
+            dashboard = read_json(dashboard_path)
+            dashboard_report = validate_dashboard_payload(dashboard, dashboard_path)
+            report["checks"].extend(dashboard_report["checks"])
+            report["errors"].extend(dashboard_report["errors"])
+            report["warnings"].extend(dashboard_report["warnings"])
+            report["panelCount"] = dashboard_report["panelCount"]
+            report["queryCount"] = dashboard_report["queryCount"]
+        except (OSError, ValueError, json.JSONDecodeError) as error:
+            append_check(report, "dashboard JSON parses", False, str(error))
+
+    if db_path.is_file():
+        report["metricsDb"] = {"status": "PRESENT", "path": str(db_path)}
+    else:
+        report["metricsDb"] = {"status": "MISSING", "path": str(db_path)}
+        report["warnings"].append(
+            f"{db_path} is not present in this worktree; start Grafana only where the runtime metrics DB exists"
+        )
+
+    report["dashboardPath"] = f"/d/{DASHBOARD_UID}/{DASHBOARD_SLUG}"
+    report["status"] = "FAIL" if report["errors"] else "PASS"
+    return report
+
+
+def fetch_json(url: str, timeout: float) -> tuple[int, JsonObject]:
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError(f"{url} did not return a JSON object")
+        return response.status, payload
+
+
+def fetch_status(url: str, timeout: float) -> int:
+    request = urllib.request.Request(url, headers={"Accept": "text/html,application/json"})
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return int(response.status)
+
+
+def live_url(base_url: str, path: str) -> str:
+    return urllib.parse.urljoin(base_url.rstrip("/") + "/", path.lstrip("/"))
+
+
+def validate_live(base_url: str = DEFAULT_GRAFANA_URL, timeout: float = 2.0) -> JsonObject:
+    report: JsonObject = {
+        "status": "PASS",
+        "grafanaUrl": base_url,
+        "dashboardPath": f"/d/{DASHBOARD_UID}/{DASHBOARD_SLUG}",
+        "checks": [],
+        "errors": [],
+        "warnings": [],
+    }
+
+    try:
+        health_status, health_payload = fetch_json(live_url(base_url, "/api/health"), timeout)
+    except urllib.error.HTTPError as error:
+        append_check(report, "grafana health", False, f"/api/health returned HTTP {error.code}")
+        report["status"] = "FAIL"
+        return report
+    except (ConnectionError, TimeoutError, OSError, urllib.error.URLError) as error:
+        report["status"] = "NOT_RUNNING"
+        report["checks"].append(check_result("grafana health", "NOT_RUNNING", str(error)))
+        report["errors"].append(f"Grafana is not reachable at {base_url}: {error}")
+        return report
+    except (ValueError, json.JSONDecodeError) as error:
+        append_check(report, "grafana health JSON", False, str(error))
+        report["status"] = "FAIL"
+        return report
+
+    append_check(report, "grafana health", health_status == 200, f"/api/health returned HTTP {health_status}")
+    report["health"] = health_payload
+
+    datasource_endpoint = live_url(base_url, f"/api/datasources/uid/{DATASOURCE_UID}")
+    try:
+        datasource_status, datasource_payload = fetch_json(datasource_endpoint, timeout)
+        append_check(
+            report,
+            "grafana datasource reachability",
+            datasource_status == 200
+            and datasource_payload.get("uid") == DATASOURCE_UID
+            and datasource_payload.get("type") == DATASOURCE_TYPE,
+            f"{datasource_endpoint} must return {DATASOURCE_UID}/{DATASOURCE_TYPE}",
+        )
+    except urllib.error.HTTPError as error:
+        append_check(report, "grafana datasource reachability", False, f"{datasource_endpoint} returned HTTP {error.code}")
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        append_check(report, "grafana datasource reachability", False, str(error))
+
+    dashboard_api_endpoint = live_url(base_url, f"/api/dashboards/uid/{DASHBOARD_UID}")
+    try:
+        dashboard_status, dashboard_payload = fetch_json(dashboard_api_endpoint, timeout)
+        dashboard = dashboard_payload.get("dashboard")
+        dashboard_ok = (
+            dashboard_status == 200
+            and isinstance(dashboard, dict)
+            and dashboard.get("uid") == DASHBOARD_UID
+            and dashboard.get("title") == DASHBOARD_TITLE
+        )
+        append_check(
+            report,
+            "grafana dashboard API reachability",
+            dashboard_ok,
+            f"{dashboard_api_endpoint} must return dashboard {DASHBOARD_UID}",
+        )
+    except urllib.error.HTTPError as error:
+        append_check(report, "grafana dashboard API reachability", False, f"{dashboard_api_endpoint} returned HTTP {error.code}")
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        append_check(report, "grafana dashboard API reachability", False, str(error))
+
+    dashboard_page = live_url(base_url, f"/d/{DASHBOARD_UID}/{DASHBOARD_SLUG}")
+    try:
+        page_status = fetch_status(dashboard_page, timeout)
+        append_check(
+            report,
+            "grafana dashboard page reachability",
+            page_status == 200,
+            f"{dashboard_page} returned HTTP {page_status}",
+        )
+    except urllib.error.HTTPError as error:
+        append_check(report, "grafana dashboard page reachability", False, f"{dashboard_page} returned HTTP {error.code}")
+    except OSError as error:
+        append_check(report, "grafana dashboard page reachability", False, str(error))
+
+    report["status"] = "FAIL" if report["errors"] else "PASS"
+    return report
+
+
+def build_docker_command(
+    repo_root: Path,
+    db_path: Path,
+    host: str,
+    port: int,
+    image: str,
+    plugin: str,
+    container_name: str,
+) -> list[str]:
+    repo_root = repo_root.resolve()
+    db_path = db_path.resolve()
+    return [
+        "docker",
+        "run",
+        "--rm",
+        "--name",
+        container_name,
+        "-p",
+        f"{host}:{port}:3000",
+        "-e",
+        f"GF_INSTALL_PLUGINS={plugin}",
+        "-e",
+        f"GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS={plugin}",
+        "-e",
+        "GF_AUTH_ANONYMOUS_ENABLED=true",
+        "-e",
+        "GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer",
+        "-e",
+        "GF_AUTH_DISABLE_LOGIN_FORM=true",
+        "-e",
+        "GF_AUTH_BASIC_ENABLED=false",
+        "-e",
+        "GF_SECURITY_ADMIN_USER=admin",
+        "-e",
+        "GF_SECURITY_ADMIN_PASSWORD=local-dev-only",
+        "-v",
+        f"{grafana_root(repo_root) / 'provisioning'}:{CONTAINER_PROVISIONING_PATH}:ro",
+        "-v",
+        f"{grafana_root(repo_root)}:{CONTAINER_DASHBOARD_PATH}:ro",
+        "-v",
+        f"{db_path.parent}:/var/lib/grafana/rl-metrics:ro",
+        image,
+    ]
+
+
+def render_command(command: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in command)
+
+
+def print_report(report: JsonObject, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return
+    print(f"status: {report['status']}")
+    for check in report.get("checks", []):
+        print(f"{check['status']}: {check['name']} - {check['details']}")
+    for warning in report.get("warnings", []):
+        print(f"WARNING: {warning}")
+    for error in report.get("errors", []):
+        print(f"ERROR: {error}")
+
+
+def exit_code_for_report(report: JsonObject) -> int:
+    if report["status"] == "PASS":
+        return 0
+    if report["status"] == "NOT_RUNNING":
+        return 2
+    return 1
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    repo_root = args.repo_root.resolve()
+    static_report = validate_static(repo_root)
+    if args.provisioning_only or static_report["status"] != "PASS":
+        print_report(static_report, args.json)
+        return exit_code_for_report(static_report)
+
+    live_report = validate_live(args.url, timeout=args.timeout)
+    combined: JsonObject = {
+        "status": live_report["status"],
+        "repoRoot": str(repo_root),
+        "static": static_report,
+        "live": live_report,
+        "checks": static_report["checks"] + live_report["checks"],
+        "warnings": static_report["warnings"] + live_report["warnings"],
+        "errors": static_report["errors"] + live_report["errors"],
+    }
+    if live_report["status"] == "PASS":
+        combined["status"] = "PASS"
+    elif live_report["status"] == "NOT_RUNNING":
+        combined["status"] = "NOT_RUNNING"
+    else:
+        combined["status"] = "FAIL"
+    print_report(combined, args.json)
+    return exit_code_for_report(combined)
+
+
+def cmd_docker_command(args: argparse.Namespace) -> int:
+    command = build_docker_command(
+        repo_root=args.repo_root,
+        db_path=args.db_path,
+        host=args.host,
+        port=args.port,
+        image=args.image,
+        plugin=args.plugin,
+        container_name=args.container_name,
+    )
+    print(render_command(command))
+    return 0
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    repo_root = args.repo_root.resolve()
+    db_path = args.db_path.resolve()
+    static_report = validate_static(repo_root)
+    if static_report["status"] != "PASS":
+        print_report(static_report, args.json)
+        return exit_code_for_report(static_report)
+    if not db_path.is_file():
+        print(f"ERROR: metrics DB is missing: {db_path}", file=sys.stderr)
+        print("Run npm run rl-metrics-refresh in an environment with runtime artifacts before starting Grafana.", file=sys.stderr)
+        return 2
+    command = build_docker_command(
+        repo_root=repo_root,
+        db_path=db_path,
+        host=args.host,
+        port=args.port,
+        image=args.image,
+        plugin=args.plugin,
+        container_name=args.container_name,
+    )
+    if args.print_only:
+        print(render_command(command))
+        return 0
+    return subprocess.run(command, check=False).returncode
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run or validate the Screeps RL Grafana contract.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate_parser = subparsers.add_parser("validate", help="Validate static provisioning and optionally live Grafana.")
+    validate_parser.add_argument("--repo-root", type=Path, default=default_repo_root())
+    validate_parser.add_argument("--url", default=DEFAULT_GRAFANA_URL)
+    validate_parser.add_argument("--timeout", type=float, default=2.0)
+    validate_parser.add_argument("--provisioning-only", action="store_true")
+    validate_parser.add_argument("--json", action="store_true")
+    validate_parser.set_defaults(func=cmd_validate)
+
+    docker_parser = subparsers.add_parser("docker-command", help="Print the Docker command for local Grafana.")
+    docker_parser.add_argument("--repo-root", type=Path, default=default_repo_root())
+    docker_parser.add_argument("--db-path", type=Path, default=default_db_path(default_repo_root()))
+    docker_parser.add_argument("--host", default="127.0.0.1")
+    docker_parser.add_argument("--port", type=int, default=3000)
+    docker_parser.add_argument("--image", default=DEFAULT_GRAFANA_IMAGE)
+    docker_parser.add_argument("--plugin", default=DEFAULT_GRAFANA_PLUGIN)
+    docker_parser.add_argument("--container-name", default=DEFAULT_CONTAINER_NAME)
+    docker_parser.set_defaults(func=cmd_docker_command)
+
+    run_parser = subparsers.add_parser("run", help="Run Grafana in Docker for the local RL metrics DB.")
+    run_parser.add_argument("--repo-root", type=Path, default=default_repo_root())
+    run_parser.add_argument("--db-path", type=Path, default=default_db_path(default_repo_root()))
+    run_parser.add_argument("--host", default="127.0.0.1")
+    run_parser.add_argument("--port", type=int, default=3000)
+    run_parser.add_argument("--image", default=DEFAULT_GRAFANA_IMAGE)
+    run_parser.add_argument("--plugin", default=DEFAULT_GRAFANA_PLUGIN)
+    run_parser.add_argument("--container-name", default=DEFAULT_CONTAINER_NAME)
+    run_parser.add_argument("--print-only", action="store_true")
+    run_parser.add_argument("--json", action="store_true")
+    run_parser.set_defaults(func=cmd_run)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/screeps_rl_grafana.py
+++ b/scripts/screeps_rl_grafana.py
@@ -324,7 +324,15 @@ def validate_live(base_url: str = DEFAULT_GRAFANA_URL, timeout: float = 2.0) -> 
             f"{datasource_endpoint} must return {DATASOURCE_UID}/{DATASOURCE_TYPE}",
         )
     except urllib.error.HTTPError as error:
-        append_check(report, "grafana datasource reachability", False, f"{datasource_endpoint} returned HTTP {error.code}")
+        if error.code in (401, 403):
+            details = (
+                f"{datasource_endpoint} returned HTTP {error.code}; anonymous Viewer access cannot read "
+                "datasource metadata, so static provisioning validation is authoritative for the datasource contract"
+            )
+            report["checks"].append(check_result("grafana datasource reachability", "SKIP", details))
+            report["warnings"].append(details)
+        else:
+            append_check(report, "grafana datasource reachability", False, f"{datasource_endpoint} returned HTTP {error.code}")
     except (OSError, ValueError, json.JSONDecodeError) as error:
         append_check(report, "grafana datasource reachability", False, str(error))
 

--- a/scripts/screeps_rl_grafana.py
+++ b/scripts/screeps_rl_grafana.py
@@ -28,6 +28,7 @@ DEFAULT_CONTAINER_NAME = "screeps-rl-grafana"
 CONTAINER_DB_PATH = "/var/lib/grafana/rl-metrics/rl_metrics.sqlite"
 CONTAINER_DASHBOARD_PATH = "/var/lib/grafana/dashboards/screeps"
 CONTAINER_PROVISIONING_PATH = "/etc/grafana/provisioning"
+LOCAL_GRAFANA_HOSTS = {"127.0.0.1", "localhost", "::1"}
 
 REQUIRED_QUERY_COVERAGE = {
     "metric observation history": "FROM metric_observations",
@@ -43,6 +44,31 @@ REQUIRED_QUERY_COVERAGE = {
 
 
 JsonObject = dict[str, Any]
+
+
+class HostBindingError(ValueError):
+    """Raised when Grafana would be exposed beyond loopback by default."""
+
+
+def validate_host_binding(host: str, allow_nonlocal: bool) -> None:
+    if allow_nonlocal or host in LOCAL_GRAFANA_HOSTS:
+        return
+    allowed_hosts = ", ".join(sorted(LOCAL_GRAFANA_HOSTS))
+    raise HostBindingError(
+        f"refusing non-local host binding {host!r} without --allow-nonlocal; "
+        f"allowed local hosts: {allowed_hosts}"
+    )
+
+
+def docker_port_binding(host: str, port: int) -> str:
+    if ":" in host and not host.startswith("["):
+        return f"[{host}]:{port}:3000"
+    return f"{host}:{port}:3000"
+
+
+def host_binding_error(error: HostBindingError) -> int:
+    print(f"ERROR: {error}", file=sys.stderr)
+    return 2
 
 
 def default_repo_root() -> Path:
@@ -383,7 +409,9 @@ def build_docker_command(
     image: str,
     plugin: str,
     container_name: str,
+    allow_nonlocal: bool = False,
 ) -> list[str]:
+    validate_host_binding(host, allow_nonlocal)
     repo_root = repo_root.resolve()
     db_path = db_path.resolve()
     return [
@@ -393,7 +421,7 @@ def build_docker_command(
         "--name",
         container_name,
         "-p",
-        f"{host}:{port}:3000",
+        docker_port_binding(host, port),
         "-e",
         f"GF_INSTALL_PLUGINS={plugin}",
         "-e",
@@ -415,7 +443,7 @@ def build_docker_command(
         "-v",
         f"{grafana_root(repo_root)}:{CONTAINER_DASHBOARD_PATH}:ro",
         "-v",
-        f"{db_path.parent}:/var/lib/grafana/rl-metrics:ro",
+        f"{db_path}:{CONTAINER_DB_PATH}:ro",
         image,
     ]
 
@@ -473,20 +501,29 @@ def cmd_validate(args: argparse.Namespace) -> int:
 
 
 def cmd_docker_command(args: argparse.Namespace) -> int:
-    command = build_docker_command(
-        repo_root=args.repo_root,
-        db_path=args.db_path,
-        host=args.host,
-        port=args.port,
-        image=args.image,
-        plugin=args.plugin,
-        container_name=args.container_name,
-    )
+    try:
+        command = build_docker_command(
+            repo_root=args.repo_root,
+            db_path=args.db_path,
+            host=args.host,
+            port=args.port,
+            image=args.image,
+            plugin=args.plugin,
+            container_name=args.container_name,
+            allow_nonlocal=args.allow_nonlocal,
+        )
+    except HostBindingError as error:
+        return host_binding_error(error)
     print(render_command(command))
     return 0
 
 
 def cmd_run(args: argparse.Namespace) -> int:
+    try:
+        validate_host_binding(args.host, args.allow_nonlocal)
+    except HostBindingError as error:
+        return host_binding_error(error)
+
     repo_root = args.repo_root.resolve()
     db_path = args.db_path.resolve()
     static_report = validate_static(repo_root)
@@ -505,6 +542,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         image=args.image,
         plugin=args.plugin,
         container_name=args.container_name,
+        allow_nonlocal=args.allow_nonlocal,
     )
     if args.print_only:
         print(render_command(command))
@@ -532,6 +570,7 @@ def build_parser() -> argparse.ArgumentParser:
     docker_parser.add_argument("--image", default=DEFAULT_GRAFANA_IMAGE)
     docker_parser.add_argument("--plugin", default=DEFAULT_GRAFANA_PLUGIN)
     docker_parser.add_argument("--container-name", default=DEFAULT_CONTAINER_NAME)
+    docker_parser.add_argument("--allow-nonlocal", action="store_true")
     docker_parser.set_defaults(func=cmd_docker_command)
 
     run_parser = subparsers.add_parser("run", help="Run Grafana in Docker for the local RL metrics DB.")
@@ -544,6 +583,7 @@ def build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--container-name", default=DEFAULT_CONTAINER_NAME)
     run_parser.add_argument("--print-only", action="store_true")
     run_parser.add_argument("--json", action="store_true")
+    run_parser.add_argument("--allow-nonlocal", action="store_true")
     run_parser.set_defaults(func=cmd_run)
 
     return parser

--- a/scripts/test_screeps_rl_grafana.py
+++ b/scripts/test_screeps_rl_grafana.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 
 import copy
+import io
 import json
 import sys
 import urllib.error
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
 
@@ -99,9 +101,67 @@ class ScreepsRlGrafanaContractTest(unittest.TestCase):
         self.assertIn(f"GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS={grafana.DATASOURCE_TYPE}", command)
         self.assertIn(f"{grafana.grafana_root(REPO_ROOT) / 'provisioning'}:{grafana.CONTAINER_PROVISIONING_PATH}:ro", command)
         self.assertIn(f"{grafana.grafana_root(REPO_ROOT)}:{grafana.CONTAINER_DASHBOARD_PATH}:ro", command)
-        self.assertIn(f"{db_path.parent.resolve()}:/var/lib/grafana/rl-metrics:ro", command)
+        self.assertIn(f"{db_path.resolve()}:{grafana.CONTAINER_DB_PATH}:ro", command)
+        self.assertNotIn(f"{db_path.parent.resolve()}:/var/lib/grafana/rl-metrics:ro", command)
         self.assertIn("grafana/grafana-oss:test", command)
         self.assertNotIn("0.0.0.0:3000:3000", command_text)
+
+    def test_docker_command_mounts_custom_db_file_to_provisioned_container_path(self) -> None:
+        db_path = Path("/tmp/custom-rl-metrics.sqlite")
+
+        command = grafana.build_docker_command(
+            repo_root=REPO_ROOT,
+            db_path=db_path,
+            host="127.0.0.1",
+            port=3000,
+            image="grafana/grafana-oss:test",
+            plugin=grafana.DATASOURCE_TYPE,
+            container_name="screeps-rl-grafana-test",
+        )
+
+        self.assertIn(f"{db_path.resolve()}:{grafana.CONTAINER_DB_PATH}:ro", command)
+        self.assertNotIn(f"{db_path.parent.resolve()}:/var/lib/grafana/rl-metrics:ro", command)
+
+    def test_docker_command_rejects_nonlocal_host_without_override(self) -> None:
+        stderr = io.StringIO()
+
+        with redirect_stderr(stderr):
+            exit_code = grafana.main(["docker-command", "--host", "0.0.0.0"])
+
+        self.assertEqual(exit_code, 2)
+        self.assertIn("refusing non-local host binding", stderr.getvalue())
+        self.assertIn("--allow-nonlocal", stderr.getvalue())
+
+    def test_run_rejects_nonlocal_host_before_starting_container(self) -> None:
+        stderr = io.StringIO()
+
+        with redirect_stderr(stderr):
+            exit_code = grafana.main(["run", "--host", "0.0.0.0", "--print-only"])
+
+        self.assertEqual(exit_code, 2)
+        self.assertIn("refusing non-local host binding", stderr.getvalue())
+
+    def test_docker_command_allows_explicit_nonlocal_override(self) -> None:
+        stdout = io.StringIO()
+
+        with redirect_stdout(stdout):
+            exit_code = grafana.main(["docker-command", "--host", "0.0.0.0", "--allow-nonlocal"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("0.0.0.0:3000:3000", stdout.getvalue())
+
+    def test_docker_command_formats_ipv6_loopback_binding(self) -> None:
+        command = grafana.build_docker_command(
+            repo_root=REPO_ROOT,
+            db_path=REPO_ROOT / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite",
+            host="::1",
+            port=3000,
+            image="grafana/grafana-oss:test",
+            plugin=grafana.DATASOURCE_TYPE,
+            container_name="screeps-rl-grafana-test",
+        )
+
+        self.assertIn("[::1]:3000:3000", command)
 
 
 if __name__ == "__main__":

--- a/scripts/test_screeps_rl_grafana.py
+++ b/scripts/test_screeps_rl_grafana.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 import copy
 import json
 import sys
+import urllib.error
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -54,6 +56,29 @@ class ScreepsRlGrafanaContractTest(unittest.TestCase):
 
         self.assertEqual(report["status"], "NOT_RUNNING")
         self.assertEqual(report["checks"][0]["status"], "NOT_RUNNING")
+
+    def test_live_validator_tolerates_datasource_api_forbidden_for_anonymous_viewer(self) -> None:
+        def fake_fetch_json(url: str, timeout: float) -> tuple[int, grafana.JsonObject]:
+            if url.endswith("/api/health"):
+                return 200, {"database": "ok", "version": "test"}
+            if url.endswith(f"/api/datasources/uid/{grafana.DATASOURCE_UID}"):
+                raise urllib.error.HTTPError(url, 403, "Forbidden", hdrs=None, fp=None)
+            if url.endswith(f"/api/dashboards/uid/{grafana.DASHBOARD_UID}"):
+                return 200, {"dashboard": {"uid": grafana.DASHBOARD_UID, "title": grafana.DASHBOARD_TITLE}}
+            raise AssertionError(f"unexpected JSON fetch: {url}")
+
+        with patch.object(grafana, "fetch_json", side_effect=fake_fetch_json), patch.object(
+            grafana, "fetch_status", return_value=200
+        ):
+            report = grafana.validate_live("http://grafana.test", timeout=0.1)
+
+        datasource_check = next(
+            check for check in report["checks"] if check["name"] == "grafana datasource reachability"
+        )
+        self.assertEqual(report["status"], "PASS")
+        self.assertEqual(datasource_check["status"], "SKIP")
+        self.assertIn("anonymous Viewer", datasource_check["details"])
+        self.assertTrue(any("static provisioning validation is authoritative" in warning for warning in report["warnings"]))
 
     def test_docker_command_mounts_provisioning_dashboard_and_metrics_db(self) -> None:
         db_path = REPO_ROOT / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite"

--- a/scripts/test_screeps_rl_grafana.py
+++ b/scripts/test_screeps_rl_grafana.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import copy
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import screeps_rl_grafana as grafana
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class ScreepsRlGrafanaContractTest(unittest.TestCase):
+    def test_static_repository_contract_passes_without_running_grafana(self) -> None:
+        report = grafana.validate_static(REPO_ROOT)
+
+        self.assertEqual(report["status"], "PASS")
+        self.assertEqual(report["datasourceUid"], grafana.DATASOURCE_UID)
+        self.assertEqual(report["datasourceType"], grafana.DATASOURCE_TYPE)
+        self.assertGreaterEqual(report["panelCount"], 13)
+        self.assertEqual(report["metricsDb"]["status"], "MISSING")
+        coverage_checks = {
+            check["name"]: check["status"]
+            for check in report["checks"]
+            if check["name"].startswith("dashboard query coverage:")
+        }
+        for coverage_name in grafana.REQUIRED_QUERY_COVERAGE:
+            self.assertEqual(coverage_checks[f"dashboard query coverage: {coverage_name}"], "PASS")
+
+    def test_dashboard_contract_rejects_missing_iteration_decision_query(self) -> None:
+        dashboard_path = grafana.dashboard_file(REPO_ROOT)
+        dashboard = json.loads(dashboard_path.read_text(encoding="utf-8"))
+        broken_dashboard = copy.deepcopy(dashboard)
+        broken_dashboard["panels"] = [
+            panel for panel in broken_dashboard["panels"] if panel.get("id") != 13
+        ]
+
+        report = grafana.validate_dashboard_payload(broken_dashboard, dashboard_path)
+
+        self.assertEqual(report["status"], "FAIL")
+        self.assertIn(
+            "#879 iteration decisions",
+            "\n".join(error for error in report["errors"]),
+        )
+
+    def test_live_validator_reports_not_running_instead_of_pass(self) -> None:
+        report = grafana.validate_live("http://127.0.0.1:9", timeout=0.1)
+
+        self.assertEqual(report["status"], "NOT_RUNNING")
+        self.assertEqual(report["checks"][0]["status"], "NOT_RUNNING")
+
+    def test_docker_command_mounts_provisioning_dashboard_and_metrics_db(self) -> None:
+        db_path = REPO_ROOT / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite"
+
+        command = grafana.build_docker_command(
+            repo_root=REPO_ROOT,
+            db_path=db_path,
+            host="127.0.0.1",
+            port=3000,
+            image="grafana/grafana-oss:test",
+            plugin=grafana.DATASOURCE_TYPE,
+            container_name="screeps-rl-grafana-test",
+        )
+        command_text = " ".join(command)
+
+        self.assertIn("127.0.0.1:3000:3000", command)
+        self.assertIn(f"GF_INSTALL_PLUGINS={grafana.DATASOURCE_TYPE}", command)
+        self.assertIn(f"GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS={grafana.DATASOURCE_TYPE}", command)
+        self.assertIn(f"{grafana.grafana_root(REPO_ROOT) / 'provisioning'}:{grafana.CONTAINER_PROVISIONING_PATH}:ro", command)
+        self.assertIn(f"{grafana.grafana_root(REPO_ROOT)}:{grafana.CONTAINER_DASHBOARD_PATH}:ro", command)
+        self.assertIn(f"{db_path.parent.resolve()}:/var/lib/grafana/rl-metrics:ro", command)
+        self.assertIn("grafana/grafana-oss:test", command)
+        self.assertNotIn("0.0.0.0:3000:3000", command_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a tracked Grafana provisioning contract for the Screeps RL SQLite metrics store
- add a Grafana dashboard JSON with coverage for metric observations, runtime-room metrics, behavior findings, coverage gaps, E1, Loop A, Loop B, and #879 metric iteration decisions
- add a local validator/runner script plus tests and npm entrypoints so the actual Grafana path can be verified separately from the Python dashboard-equivalent

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_grafana.py scripts/test_screeps_rl_grafana.py`
- `python3 -m unittest scripts/test_screeps_rl_grafana.py`
- `python3 scripts/screeps_rl_grafana.py validate --provisioning-only --json` → PASS; panelCount=13, queryCount=21, metricsDb=MISSING in the worktree as expected

## Issue / Project notes
Refs #1474.
Refs #879.
Refs #1191.

Related to issue 1474: this PR does not complete the issue by itself; the issue acceptance criteria require either live actual-Grafana evidence or explicit owner acceptance of the Python dashboard-equivalent. This PR creates the durable actual-Grafana contract and validation surface needed for that next proof.

## Safety
- local-only Grafana/Docker runner; no official MMO writes
- no secrets in datasource provisioning; datasource path points to the local SQLite metrics artifact

