### PR TITLE
fix(gameplay): suppress stale owned-room scout recommendations

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -18031,6 +18031,15 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime, optio
           0,
           routeDistanceLookupContext
         ),
+        ...getVisibleOwnedRoomAdjacentReserveCandidates(
+          colonyName,
+          colonyOwnerUsername,
+          territoryMemory,
+          intents,
+          gameTime,
+          !hasBlockingConfiguredTarget,
+          routeDistanceLookupContext
+        ),
         ...getAdjacentFollowUpReserveCandidates(
           colonyName,
           colonyOwnerUsername,
@@ -18988,6 +18997,33 @@ function getActiveCoveredConfiguredReserveTargets(colonyName, colonyOwnerUsernam
     return [{ target, order }];
   });
 }
+function getVisibleOwnedRoomAdjacentReserveCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, includeScoutCandidates, routeDistanceLookupContext) {
+  return getVisibleOwnedAdjacentScoutOriginRooms(colonyName, routeDistanceLookupContext).flatMap(
+    (originRoomName, index) => getAdjacentReserveCandidates(
+      colonyName,
+      originRoomName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      includeScoutCandidates,
+      "ownedAdjacent",
+      (index + 1) * EXIT_DIRECTION_ORDER5.length,
+      routeDistanceLookupContext
+    ).filter((candidate) => candidate.intentAction === "scout")
+  );
+}
+function getVisibleOwnedAdjacentScoutOriginRooms(colonyName, routeDistanceLookupContext) {
+  return getVisibleOwnedRoomNames4(colonyName).filter((roomName) => roomName !== colonyName).sort(
+    (left, right) => {
+      var _a, _b;
+      return compareOptionalNumbers5(
+        (_a = getKnownRouteLength2(colonyName, left, routeDistanceLookupContext)) != null ? _a : void 0,
+        (_b = getKnownRouteLength2(colonyName, right, routeDistanceLookupContext)) != null ? _b : void 0
+      ) || left.localeCompare(right);
+    }
+  );
+}
 function getSatisfiedConfiguredClaimTargets(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, routeDistanceLookupContext) {
   return getSatisfiedConfiguredTargets(
     colonyName,
@@ -19586,7 +19622,10 @@ function getTerritoryCandidateSourcePriority(source) {
   if (source === "satisfiedReserveAdjacent") {
     return 3;
   }
-  return source === "activeReserveAdjacent" ? 4 : 5;
+  if (source === "activeReserveAdjacent") {
+    return 4;
+  }
+  return source === "adjacent" ? 5 : 6;
 }
 function buildTerritoryFollowUp(source, originRoom) {
   const originAction = getTerritoryFollowUpOriginAction2(source);
@@ -46365,6 +46404,9 @@ function buildMemoryTerritoryState(roomName) {
       if (!action) {
         continue;
       }
+      if (isVisibleOwnedByColonyAccount(target.roomName, roomName)) {
+        continue;
+      }
       const candidate = {
         roomName: target.roomName,
         action
@@ -46378,7 +46420,7 @@ function buildMemoryTerritoryState(roomName) {
   }
   const roomMemory = (_d = (_c = (_b = globalThis.Game) == null ? void 0 : _b.rooms) == null ? void 0 : _c[roomName]) == null ? void 0 : _d.memory;
   const cachedExpansionSelection = roomMemory == null ? void 0 : roomMemory.cachedExpansionSelection;
-  if ((cachedExpansionSelection == null ? void 0 : cachedExpansionSelection.status) === "planned" && cachedExpansionSelection.colony === roomName && cachedExpansionSelection.targetRoom) {
+  if ((cachedExpansionSelection == null ? void 0 : cachedExpansionSelection.status) === "planned" && cachedExpansionSelection.colony === roomName && cachedExpansionSelection.targetRoom && !isVisibleOwnedByColonyAccount(cachedExpansionSelection.targetRoom, roomName)) {
     expansionCandidates.push({
       roomName: cachedExpansionSelection.targetRoom,
       action: "claim",
@@ -46417,6 +46459,25 @@ function countVisibleOwnedRooms7() {
     var _a2;
     return ((_a2 = room == null ? void 0 : room.controller) == null ? void 0 : _a2.my) === true;
   }).length;
+}
+function isVisibleOwnedByColonyAccount(targetRoomName, colonyRoomName) {
+  var _a, _b, _c;
+  const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
+  const targetController = (_b = rooms == null ? void 0 : rooms[targetRoomName]) == null ? void 0 : _b.controller;
+  if (!targetController) {
+    return false;
+  }
+  if (targetController.my === true) {
+    return true;
+  }
+  const colonyOwnerUsername = getControllerOwnerUsername15((_c = rooms == null ? void 0 : rooms[colonyRoomName]) == null ? void 0 : _c.controller);
+  const targetOwnerUsername = getControllerOwnerUsername15(targetController);
+  return typeof colonyOwnerUsername === "string" && colonyOwnerUsername.length > 0 && targetOwnerUsername === colonyOwnerUsername;
+}
+function getControllerOwnerUsername15(controller) {
+  var _a;
+  const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
+  return typeof username === "string" && username.length > 0 ? username : null;
 }
 function countStructuresByType3(structures, globalName, fallback) {
   return structures.filter(

--- a/prod/src/strategy/strategyRecommender.ts
+++ b/prod/src/strategy/strategyRecommender.ts
@@ -359,6 +359,9 @@ function buildMemoryTerritoryState(roomName: string): StrategyRecommendationTerr
       if (!action) {
         continue;
       }
+      if (isVisibleOwnedByColonyAccount(target.roomName, roomName)) {
+        continue;
+      }
       const candidate = {
         roomName: target.roomName,
         action
@@ -376,7 +379,8 @@ function buildMemoryTerritoryState(roomName: string): StrategyRecommendationTerr
   if (
     cachedExpansionSelection?.status === 'planned' &&
     cachedExpansionSelection.colony === roomName &&
-    cachedExpansionSelection.targetRoom
+    cachedExpansionSelection.targetRoom &&
+    !isVisibleOwnedByColonyAccount(cachedExpansionSelection.targetRoom, roomName)
   ) {
     expansionCandidates.push({
       roomName: cachedExpansionSelection.targetRoom,
@@ -418,6 +422,32 @@ function countVisibleOwnedRooms(): number {
     return 0;
   }
   return Object.values(rooms).filter((room) => room?.controller?.my === true).length;
+}
+
+function isVisibleOwnedByColonyAccount(targetRoomName: string, colonyRoomName: string): boolean {
+  const rooms = (globalThis as { Game?: Partial<Game> }).Game?.rooms;
+  const targetController = rooms?.[targetRoomName]?.controller;
+  if (!targetController) {
+    return false;
+  }
+
+  if (targetController.my === true) {
+    return true;
+  }
+
+  const colonyOwnerUsername = getControllerOwnerUsername(rooms?.[colonyRoomName]?.controller);
+  const targetOwnerUsername = getControllerOwnerUsername(targetController);
+  return (
+    typeof colonyOwnerUsername === 'string' &&
+    colonyOwnerUsername.length > 0 &&
+    targetOwnerUsername === colonyOwnerUsername
+  );
+}
+
+function getControllerOwnerUsername(controller: StructureController | undefined): string | null {
+  const username = (controller as (StructureController & { owner?: { username?: string } }) | undefined)?.owner
+    ?.username;
+  return typeof username === 'string' && username.length > 0 ? username : null;
 }
 
 function countStructuresByType(structures: unknown[], globalName: string, fallback: string): number {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -186,6 +186,7 @@ type TerritoryCandidateSource =
   | 'satisfiedClaimAdjacent'
   | 'satisfiedReserveAdjacent'
   | 'activeReserveAdjacent'
+  | 'ownedAdjacent'
   | 'adjacent';
 
 interface ScoredTerritoryTarget extends SelectedTerritoryTarget {
@@ -1552,6 +1553,15 @@ function selectTerritoryTarget(
           !hasBlockingConfiguredTarget,
           'adjacent',
           0,
+          routeDistanceLookupContext
+        ),
+        ...getVisibleOwnedRoomAdjacentReserveCandidates(
+          colonyName,
+          colonyOwnerUsername,
+          territoryMemory,
+          intents,
+          gameTime,
+          !hasBlockingConfiguredTarget,
           routeDistanceLookupContext
         ),
         ...getAdjacentFollowUpReserveCandidates(
@@ -3148,6 +3158,47 @@ function getActiveCoveredConfiguredReserveTargets(
   });
 }
 
+function getVisibleOwnedRoomAdjacentReserveCandidates(
+  colonyName: string,
+  colonyOwnerUsername: string | null,
+  territoryMemory: Record<string, unknown> | null,
+  intents: TerritoryIntentMemory[],
+  gameTime: number,
+  includeScoutCandidates: boolean,
+  routeDistanceLookupContext: RouteDistanceLookupContext
+): ScoredTerritoryTarget[] {
+  return getVisibleOwnedAdjacentScoutOriginRooms(colonyName, routeDistanceLookupContext).flatMap(
+    (originRoomName, index) =>
+      getAdjacentReserveCandidates(
+        colonyName,
+        originRoomName,
+        colonyOwnerUsername,
+        territoryMemory,
+        intents,
+        gameTime,
+        includeScoutCandidates,
+        'ownedAdjacent',
+        (index + 1) * EXIT_DIRECTION_ORDER.length,
+        routeDistanceLookupContext
+      ).filter((candidate) => candidate.intentAction === 'scout')
+  );
+}
+
+function getVisibleOwnedAdjacentScoutOriginRooms(
+  colonyName: string,
+  routeDistanceLookupContext: RouteDistanceLookupContext
+): string[] {
+  return getVisibleOwnedRoomNames(colonyName)
+    .filter((roomName) => roomName !== colonyName)
+    .sort(
+      (left, right) =>
+        compareOptionalNumbers(
+          getKnownRouteLength(colonyName, left, routeDistanceLookupContext) ?? undefined,
+          getKnownRouteLength(colonyName, right, routeDistanceLookupContext) ?? undefined
+        ) || left.localeCompare(right)
+    );
+}
+
 function getSatisfiedConfiguredClaimTargets(
   colonyName: string,
   colonyOwnerUsername: string | null,
@@ -4147,7 +4198,11 @@ function getTerritoryCandidateSourcePriority(source: TerritoryCandidateSource): 
     return 3;
   }
 
-  return source === 'activeReserveAdjacent' ? 4 : 5;
+  if (source === 'activeReserveAdjacent') {
+    return 4;
+  }
+
+  return source === 'adjacent' ? 5 : 6;
 }
 
 function buildTerritoryFollowUp(

--- a/prod/test/strategyRecommender.test.ts
+++ b/prod/test/strategyRecommender.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildStrategyRecommendationRoomState,
   generateStrategyRecommendations,
   rejectUncertain,
   type StrategyRecommendation,
@@ -6,6 +7,11 @@ import {
 } from '../src/strategy/strategyRecommender';
 
 describe('strategy recommender', () => {
+  afterEach(() => {
+    delete (globalThis as { Game?: Partial<Game> }).Game;
+    delete (globalThis as { Memory?: Partial<Memory> }).Memory;
+  });
+
   it('filters recommendations below the default confidence threshold', () => {
     const recommendations = rejectUncertain([
       makeRecommendation({ confidence: 0.69, reasoning: 'below threshold' }),
@@ -119,6 +125,39 @@ describe('strategy recommender', () => {
         defensePosture: 'passive'
       })
     );
+  });
+
+  it('does not recommend visible owned rooms from stale territory memory as remote or expansion targets', () => {
+    const colony = makeRecommendationColony('W1N1');
+    (globalThis as unknown as { Game: Partial<Game> & { rooms: Record<string, Room> } }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W1N2: {
+          name: 'W1N2',
+          controller: { my: true, owner: { username: 'me' } } as StructureController
+        } as Room,
+        W2N1: {
+          name: 'W2N1',
+          controller: { my: false, owner: { username: 'me' } } as StructureController
+        } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' },
+          { colony: 'W1N1', roomName: 'W2N1', action: 'claim' }
+        ]
+      }
+    };
+
+    const state = buildStrategyRecommendationRoomState(colony, []);
+    const recommendations = generateStrategyRecommendations(state);
+
+    expect(state.territory?.remoteTargets).toEqual([]);
+    expect(state.territory?.expansionCandidates).toEqual([]);
+    expect(recommendations.some((recommendation) => recommendation.remoteTarget)).toBe(false);
+    expect(recommendations.some((recommendation) => recommendation.expansionCandidate)).toBe(false);
   });
 
   it.each([2, 3, 4])(
@@ -239,5 +278,25 @@ function makeStableHighRclRoom(): StrategyRecommendationRoomState {
         { roomName: 'W2N1', action: 'claim', score: 880, routeDistance: 1, sourceCount: 2, evidenceStatus: 'sufficient' }
       ]
     }
+  };
+}
+
+function makeRecommendationColony(roomName: string) {
+  const room = {
+    name: roomName,
+    controller: {
+      my: true,
+      owner: { username: 'me' },
+      level: 5,
+      ticksToDowngrade: 20_000
+    } as StructureController,
+    find: jest.fn(() => [])
+  } as unknown as Room;
+
+  return {
+    room,
+    spawns: [],
+    energyAvailable: 1300,
+    energyCapacityAvailable: 1300
   };
 }

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -639,6 +639,76 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('scouts missing visibility adjacent to current owned rooms without reserve or claim control', () => {
+    const colony = makeSafeColony({
+      roomName: 'E29N55',
+      controller: { my: true, owner: { username: 'me' }, level: 5, ticksToDowngrade: 20_000 } as StructureController,
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300
+    });
+    const describeExits = jest.fn((roomName: string) => {
+      if (roomName === 'E29N55') {
+        return { '1': 'E29N54' };
+      }
+      if (roomName === 'E29N57') {
+        return { '3': 'E30N57' };
+      }
+      return {};
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        E29N55: colony.room,
+        E29N57: {
+          name: 'E29N57',
+          controller: { my: true, owner: { username: 'me' }, level: 4 } as StructureController
+        } as Room
+      },
+      map: { describeExits } as unknown as GameMap
+    };
+
+    expect(
+      planTerritoryIntent(
+        colony,
+        { worker: 4, claimer: 0, claimersByTargetRoom: {} },
+        3,
+        527,
+        { scoutOnly: true, scoutOnlyTargetRooms: ['E29N54'] }
+      )
+    ).toEqual({
+      colony: 'E29N55',
+      targetRoom: 'E29N54',
+      action: 'scout'
+    });
+
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+
+    expect(
+      planTerritoryIntent(
+        colony,
+        { worker: 4, claimer: 0, claimersByTargetRoom: {} },
+        3,
+        528,
+        { scoutOnly: true, scoutOnlyTargetRooms: ['E30N57'] }
+      )
+    ).toEqual({
+      colony: 'E29N55',
+      targetRoom: 'E30N57',
+      action: 'scout'
+    });
+    expect(describeExits).toHaveBeenCalledWith('E29N55');
+    expect(describeExits).toHaveBeenCalledWith('E29N57');
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'E29N55',
+        targetRoom: 'E30N57',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: 528
+      }
+    ]);
+  });
+
   it('suppresses duplicate scout spawns for targets already covered by a healthy scout', () => {
     const roleCounts = { worker: 4, scout: 1, scoutsByTargetRoom: { E28N54: 1 } };
 


### PR DESCRIPTION
## Summary
- Suppresses stale territory/scout recommendations for rooms already owned or already covered by healthy scouts.
- Adds completion-aware multi-room bootstrap tests for the E29N56/E29N57 follow-up lane.
- Rebuilds `prod/dist/main.js` from the verified TypeScript sources.

## Test plan
- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand` (103 suites, 2066 tests passed)
- [x] `cd prod && npm run build`

## Runtime / deploy note
Fresh scheduler health check before PR creation: `/tmp/screeps-runtime-scheduler-20260528T095851Z/summary.json`, `/tmp/screeps-runtime-scheduler-20260528T095851Z/alert.json`, and `/tmp/screeps-runtime-scheduler-20260528T095851Z/health-gate.json` showed E29N55/E29N57/E29N56 each with one owned spawn, owned creeps present, hostiles=0, `alert=false`, and health gate OK.

Related to issue #1318. Post-merge official deploy + observation should decide final issue closure; this PR intentionally does not auto-close the validation lane.
