### PR TITLE
fix(agent-os): align p0 monitor registry provider

### DIFF
--- a/docs/ops/cron-and-route-registry.md
+++ b/docs/ops/cron-and-route-registry.md
@@ -71,7 +71,7 @@ Repeat policy values:
 | Job | ID | Schedule | Delivery | Provider | Model | Workdir | Repeat | Criticality | Purpose |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Screeps autonomous continuation worker | `f66ed36d7be0` | `8,28,48 * * * *` | `discord:#task-queue` | `openai-codex` | `gpt-5.5` | `/root/screeps` | `high-horizon` | P0 | Dispatcher/reconciler for safe work lanes. |
-| Screeps P0 agent operations monitor | `75cedbb77150` | `7,37 * * * *` | `discord:1497820688843800776` | `openai-codex` | `gpt-5.5` | `-` | `forever` | P0 | Autonomous-system health monitor, registry-drift detector, and consolidated Tencent Cloud cost guard. |
+| Screeps P0 agent operations monitor | `75cedbb77150` | `7,37 * * * *` | `discord:1497820688843800776` | `minimax-cn` | `MiniMax-M2.7` | `-` | `forever` | P0 | Autonomous-system health monitor, registry-drift detector, and consolidated Tencent Cloud cost guard. |
 | Screeps runtime room alert text check | `1df5ef0c3835` | `1,16,31,46 * * * *` | `discord:1497588512436785284` | `openai-codex` | `gpt-5.5` | `-` | `forever` | P0 | Runtime alert/tactical response for all owned rooms; no-alert runs return exactly `[SILENT]`. |
 | Screeps owner-decision escalation fanout | `bbc7f783075e` | `3,13,23,33,43,53 * * * *` | `discord:1497586175580311654` | `minimax-cn` | `MiniMax-M2.7` | `-` | `high-horizon` | P0 | Mirrors fresh unresolved owner-action decisions to the canonical decisions route. |
 | Screeps runtime room summary images | `befcbb7b2d60` | `58 * * * *` | `discord:1497588267057680385` | `minimax-cn` | `MiniMax-M2.7` | `-` | `high-horizon` | P1 | Runtime summary report/images for all owned rooms. |


### PR DESCRIPTION
## Summary
- Align the expected cron registry row for the P0 operations monitor (`75cedbb77150`) with the live MiniMax provider/model restored during #1479 triage.
- Preserve the recurring job table, one-shot ignore semantics, schedule, delivery target, workdir, and repeat policy.

## Linked issue
Related to issue 1479.

## Roadmap category
- Domain: Agent OS
- Kind: ops/docs
- Priority: P0

## Verification
- `python3 scripts/check_cron_registry.py --strict` — PASS (16 expected recurring jobs, 1 ignored one-shot, 0 mismatches)
- `python3 -m unittest scripts/test_check_cron_registry.py` — PASS
- `git diff --check` — PASS

## Notes
This PR is a registry-alignment step for issue 1479 only. Issue 1479 should remain open until the post-restore P0 monitor acceptance hold completes with consecutive successful scheduled runs and registry PASS evidence.
