### PR TITLE
fix(rl): add lexicographic gradient estimator

### DIFF
--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -77,6 +77,11 @@ GRADIENT_MOMENTUM_EVIDENCE_TYPE = "screeps-rl-gradient-momentum-evidence"
 POLICY_GRADIENT_SCALAR_ESTIMATOR = "scalar_weighted_sum_score_function_reinforce_v1"
 POLICY_GRADIENT_SCALAR_REWARD = "scalar_weighted_sum"
 POLICY_GRADIENT_SCALAR_WEIGHTED_SUM_USE = "gradient_estimation_only_non_promotional"
+POLICY_GRADIENT_LEXICOGRAPHIC_REINFORCE_ESTIMATOR = "lexicographic_per_tier_score_function_reinforce_v1"
+POLICY_GRADIENT_LEXICOGRAPHIC_PER_TIER_REWARD = "lexicographic_per_tier"
+POLICY_GRADIENT_LEXICOGRAPHIC_TIER_BASELINE = "anchor_candidate_mean_return"
+POLICY_GRADIENT_LEXICOGRAPHIC_TIER_SELECTION = "first_nonzero_reward_tier_by_parameter"
+POLICY_GRADIENT_LEXICOGRAPHIC_PAIRWISE_ADVANTAGE_SCALE = 0.5
 POLICY_GRADIENT_LEXICOGRAPHIC_REWARD = "lexicographic"
 # Cap the estimator reward scale used by the update gradient; promotion remains
 # lexicographic-gated.
@@ -2069,33 +2074,17 @@ def build_reinforce_policy_update(
     learning_rate = policy_update_learning_rate(policy_gradient)
     bounded_integer_step = policy_update_uses_bounded_integer_step(policy_gradient)
     anchor_parameters = anchor["parameters"]
-    gradient_by_tier: JsonObject = {}
-    selected_reward_tier_by_parameter: JsonObject = {}
-
-    for name, spec in parameter_space.items():
-        anchor_value = float(anchor_parameters[name])
-        span = max(float(spec["max"]) - float(spec["min"]), 1.0)
-        tier_gradients: dict[str, float | int] = {}
-        for tier_index, tier in enumerate(REWARD_TIERS):
-            raw_gradient = 0.0
-            for sample in samples:
-                row = sample["candidate"]
-                normalized_delta = (float(row["parameters"][name]) - anchor_value) / span
-                advantage = float(sample["returnTuple"][tier_index]) - float(return_baseline[tier_index])
-                raw_gradient += advantage * normalized_delta
-            tier_gradients[tier] = round_policy_number(raw_gradient / len(samples))
-        selected_tier, selected_gradient = first_nonzero_tier_gradient(tier_gradients)
-        selected_reward_tier_by_parameter[name] = selected_tier
-        gradient_by_tier[name] = tier_gradients
-        del selected_gradient
-
-    gradient_estimation = policy_update_scalar_weighted_gradient_estimation(
+    anchor_return_baseline = policy_update_candidate_return_baseline(anchor)
+    gradient_estimation = policy_update_lexicographic_reinforce_gradient_estimation(
         policy_gradient=policy_gradient,
         parameter_space=parameter_space,
         samples=samples,
         anchor_parameters=anchor_parameters,
+        anchor_return_baseline=anchor_return_baseline,
     )
     raw_gradient = gradient_estimation["gradient"]
+    gradient_by_tier = gradient_estimation["gradientByRewardTier"]
+    selected_reward_tier_by_parameter = gradient_estimation["selectedRewardTierByParameter"]
     gradient_momentum = policy_update_gradient_momentum_evidence(
         policy_gradient=policy_gradient,
         raw_gradient=raw_gradient,
@@ -2141,6 +2130,10 @@ def build_reinforce_policy_update(
         gradient_momentum=gradient_momentum,
     )
     parameter_evidence = policy_update_runtime_injection_ready_parameter_evidence(policy_gradient, candidates)
+    gradient_stability = policy_update_gradient_stability_with_parameter_evidence(
+        gradient_stability,
+        parameter_evidence,
+    )
     if parameter_evidence.get("policyUpdateEligible") is not True:
         return {
             **base,
@@ -2241,8 +2234,8 @@ def build_reinforce_policy_update(
         "parameterEvidence": {
             "derivation": (
                 "deterministic REINFORCE score-function estimate from offline simulator Monte Carlo "
-                "reward-tuple returns, using scalar weighted-sum rewards for gradient estimation only "
-                "and preserving lexicographic ranking/promotion gates"
+                "reward-tuple returns, selecting the first lexicographic reward tier with per-parameter "
+                "evidence and preserving lexicographic ranking/promotion gates"
             ),
             "targetFamily": target_family,
             "learnableKnobs": list(parameter_space),
@@ -2282,7 +2275,7 @@ def build_reinforce_policy_update(
         "iterations": 1,
         "policyUpdateAlgorithm": TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM,
         "trueGradient": True,
-        "policyGradientEstimator": POLICY_GRADIENT_SCALAR_ESTIMATOR,
+        "policyGradientEstimator": POLICY_GRADIENT_LEXICOGRAPHIC_REINFORCE_ESTIMATOR,
         "gradientStable": gradient_stability["gradientStable"],
         "trustedGradientUpdate": trusted_gradient_update,
         "highVariance": gradient_stability["highVariance"],
@@ -2401,6 +2394,24 @@ def policy_update_scalar_gradient_scheme_identity(weight_evidence: JsonObject) -
     }
 
 
+def policy_update_lexicographic_reinforce_gradient_scheme_identity() -> JsonObject:
+    return {
+        "type": GRADIENT_ESTIMATION_SCHEME_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "estimator": POLICY_GRADIENT_LEXICOGRAPHIC_REINFORCE_ESTIMATOR,
+        "gradientReward": POLICY_GRADIENT_LEXICOGRAPHIC_PER_TIER_REWARD,
+        "gradientUse": "policy_gradient_estimation_only",
+        "scalarWeightedSumUse": "not_used",
+        "rankingRewardModel": POLICY_GRADIENT_LEXICOGRAPHIC_REWARD,
+        "rewardComponentOrder": list(REWARD_TIERS),
+        "tierBaseline": POLICY_GRADIENT_LEXICOGRAPHIC_TIER_BASELINE,
+        "tierSelection": POLICY_GRADIENT_LEXICOGRAPHIC_TIER_SELECTION,
+        "advantageScale": POLICY_GRADIENT_LEXICOGRAPHIC_PAIRWISE_ADVANTAGE_SCALE,
+        "lexicographicRankingPreserved": True,
+        "scalarWeightedSumAuthorized": False,
+    }
+
+
 def policy_update_lexicographic_gradient_scheme_identity() -> JsonObject:
     return {
         "type": GRADIENT_ESTIMATION_SCHEME_TYPE,
@@ -2428,6 +2439,9 @@ GRADIENT_SCHEME_COMPARISON_IDENTITY_FIELDS = (
     "scalarWeightedSumUse",
     "rankingRewardModel",
     "rewardComponentOrder",
+    "tierBaseline",
+    "tierSelection",
+    "advantageScale",
     "lexicographicRankingPreserved",
     "scalarWeightedSumAuthorized",
     "normalizedWeightsByRewardTier",
@@ -2481,6 +2495,9 @@ def policy_update_gradient_scheme_identity_from_evidence(raw: Any) -> JsonObject
         ("normalizationCap", "normalizationCap"),
         ("normalizationFactor", "normalizationFactor"),
         ("scalarRewardScaleFactor", "scalarRewardScaleFactor"),
+        ("tierBaseline", "tierBaseline"),
+        ("tierSelection", "tierSelection"),
+        ("advantageScale", "advantageScale"),
     ):
         if source_key in raw:
             identity[dest_key] = copy.deepcopy(raw[source_key])
@@ -2636,6 +2653,166 @@ def mean_policy_return_tuple(return_tuples: Sequence[Sequence[Any]]) -> list[flo
         return [0 for _tier in REWARD_TIERS]
     columns = list(zip(*return_tuples))
     return [round_policy_number(statistics.fmean(float(value) for value in column)) for column in columns]
+
+
+def policy_update_candidate_return_baseline(row: JsonObject) -> list[float | int]:
+    mean_return = policy_return_tuple_from_sequence(row.get("meanReturn"))
+    if mean_return is not None:
+        return mean_return
+    raw_samples = row.get("returnSamples")
+    if isinstance(raw_samples, list):
+        samples = [
+            sample
+            for raw_sample in raw_samples
+            for sample in [policy_return_tuple_from_sequence(raw_sample)]
+            if sample is not None
+        ]
+        if samples:
+            return mean_policy_return_tuple(samples)
+    reward_tuple = policy_return_tuple_from_sequence(row.get("rewardTuple"))
+    if reward_tuple is not None:
+        return reward_tuple
+    return [0 for _tier in REWARD_TIERS]
+
+
+def policy_update_lexicographic_reinforce_gradient_estimation(
+    *,
+    policy_gradient: JsonObject,
+    parameter_space: dict[str, JsonObject],
+    samples: Sequence[JsonObject],
+    anchor_parameters: JsonObject,
+    anchor_return_baseline: Sequence[float | int],
+) -> JsonObject:
+    del policy_gradient
+    scheme_identity = policy_update_lexicographic_reinforce_gradient_scheme_identity()
+    scheme_key = policy_update_gradient_scheme_key(scheme_identity)
+    gradient: JsonObject = {}
+    cap_normalized_gradient: JsonObject = {}
+    gradient_by_tier: JsonObject = {}
+    raw_gradient_by_tier: JsonObject = {}
+    tier_evidence_by_parameter: JsonObject = {}
+    selected_reward_tier_by_parameter: JsonObject = {}
+    direction_by_parameter: JsonObject = {}
+
+    for name, spec in parameter_space.items():
+        span = max(float(spec["max"]) - float(spec["min"]), 1.0)
+        anchor_value = float(anchor_parameters[name])
+        tier_raw_gradients: JsonObject = {}
+        tier_rounded_gradients: JsonObject = {}
+        tier_evidence: JsonObject = {}
+        for tier_index, tier in enumerate(REWARD_TIERS):
+            raw_gradient = 0.0
+            contribution_sum = 0.0
+            positive_count = 0
+            negative_count = 0
+            zero_count = 0
+            baseline_value = (
+                float(anchor_return_baseline[tier_index])
+                if tier_index < len(anchor_return_baseline)
+                else 0.0
+            )
+            for sample in samples:
+                row = sample["candidate"]
+                normalized_delta = (float(row["parameters"][name]) - anchor_value) / span
+                return_tuple = sample["returnTuple"]
+                tier_return = float(return_tuple[tier_index]) if tier_index < len(return_tuple) else 0.0
+                advantage = tier_return - baseline_value
+                advantage *= POLICY_GRADIENT_LEXICOGRAPHIC_PAIRWISE_ADVANTAGE_SCALE
+                contribution = advantage * normalized_delta
+                raw_gradient += contribution
+                contribution_sum += contribution
+                if contribution > 1e-12:
+                    positive_count += 1
+                elif contribution < -1e-12:
+                    negative_count += 1
+                else:
+                    zero_count += 1
+            estimate = raw_gradient / len(samples) if samples else 0.0
+            rounded_estimate = round_policy_number(estimate)
+            nonzero_count = positive_count + negative_count
+            dominant_count = max(positive_count, negative_count)
+            dominant_ratio = 1.0 if nonzero_count == 0 else dominant_count / nonzero_count
+            tier_raw_gradients[tier] = estimate
+            tier_rounded_gradients[tier] = rounded_estimate
+            tier_evidence[tier] = {
+                "rewardTier": tier,
+                "gradient": rounded_estimate,
+                "rawGradient": estimate,
+                "anchorReturnBaseline": round_policy_number(baseline_value),
+                "contributionSum": round_policy_number(contribution_sum),
+                "positiveContributionCount": positive_count,
+                "negativeContributionCount": negative_count,
+                "zeroContributionCount": zero_count,
+                "nonZeroContributionCount": nonzero_count,
+                "dominantDirectionRatio": round_policy_number(dominant_ratio),
+            }
+
+        selected_tier, selected_gradient = first_nonzero_tier_gradient(tier_raw_gradients)
+        selected_reward_tier_by_parameter[name] = selected_tier
+        gradient[name] = selected_gradient
+        cap_normalized_gradient[name] = round_policy_number(selected_gradient)
+        gradient_by_tier[name] = tier_rounded_gradients
+        raw_gradient_by_tier[name] = tier_raw_gradients
+        tier_evidence_by_parameter[name] = tier_evidence
+        selected_evidence = (
+            copy.deepcopy(tier_evidence[selected_tier])
+            if selected_tier is not None
+            else {
+                "rewardTier": None,
+                "gradient": 0,
+                "rawGradient": 0,
+                "anchorReturnBaseline": None,
+                "contributionSum": 0,
+                "positiveContributionCount": 0,
+                "negativeContributionCount": 0,
+                "zeroContributionCount": len(samples),
+                "nonZeroContributionCount": 0,
+                "dominantDirectionRatio": 1,
+            }
+        )
+        selected_evidence.update(
+            {
+                "gradientReward": POLICY_GRADIENT_LEXICOGRAPHIC_PER_TIER_REWARD,
+                "selectedRewardTier": selected_tier,
+                "gradientByRewardTier": copy.deepcopy(tier_rounded_gradients),
+                "rawGradientByRewardTier": copy.deepcopy(tier_raw_gradients),
+            }
+        )
+        direction_by_parameter[name] = selected_evidence
+
+    return {
+        "type": GRADIENT_ESTIMATION_EVIDENCE_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "estimator": POLICY_GRADIENT_LEXICOGRAPHIC_REINFORCE_ESTIMATOR,
+        "gradientReward": POLICY_GRADIENT_LEXICOGRAPHIC_PER_TIER_REWARD,
+        "gradientUse": "policy_gradient_estimation_only",
+        "scalarWeightedSumUse": "not_used",
+        "rankingRewardModel": POLICY_GRADIENT_LEXICOGRAPHIC_REWARD,
+        "rewardComponentOrder": list(REWARD_TIERS),
+        "tierBaseline": POLICY_GRADIENT_LEXICOGRAPHIC_TIER_BASELINE,
+        "tierSelection": POLICY_GRADIENT_LEXICOGRAPHIC_TIER_SELECTION,
+        "advantageScale": POLICY_GRADIENT_LEXICOGRAPHIC_PAIRWISE_ADVANTAGE_SCALE,
+        "lexicographicRankingPreserved": True,
+        "scalarWeightedSumAuthorized": False,
+        "schemeIdentity": scheme_identity,
+        "schemeKey": scheme_key,
+        "comparisonKey": policy_update_gradient_scheme_comparison_key(scheme_identity),
+        "trustedComparisonKey": policy_update_gradient_scheme_comparison_key(scheme_identity),
+        "returnBaseline": [round_policy_number(float(value)) for value in anchor_return_baseline],
+        "returnBaselineType": POLICY_GRADIENT_LEXICOGRAPHIC_TIER_BASELINE,
+        "gradient": gradient,
+        "capNormalizedGradient": cap_normalized_gradient,
+        "gradientByRewardTier": gradient_by_tier,
+        "rawGradientByRewardTier": raw_gradient_by_tier,
+        "tierEvidenceByParameter": tier_evidence_by_parameter,
+        "selectedRewardTierByParameter": selected_reward_tier_by_parameter,
+        "sampleCount": len(samples),
+        "directionByParameter": direction_by_parameter,
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+        "safety": safety_metadata(),
+    }
 
 
 def policy_update_scalar_weighted_gradient_estimation(
@@ -3040,7 +3217,7 @@ def policy_update_gradient_stability_gate(
         classification = "conflicting_direction_high_variance"
         convergence_label = "high_variance_not_convergence"
         reason = (
-            "true-gradient estimate has opposing per-sample update directions for scalar weighted-sum rewards"
+            "true-gradient estimate has opposing per-sample update directions for selected lexicographic reward tiers"
         )
     elif conflicting_momentum_parameters:
         classification = "momentum_conflict_high_variance"
@@ -3095,6 +3272,39 @@ def policy_update_gradient_stability_gate(
             payload["gradientSchemeIdentity"] = copy.deepcopy(scheme_identity)
     if isinstance(gradient_momentum, dict):
         payload["gradientMomentum"] = copy.deepcopy(gradient_momentum)
+    return payload
+
+
+def policy_update_gradient_stability_with_parameter_evidence(
+    gradient_stability: JsonObject,
+    parameter_evidence: JsonObject,
+) -> JsonObject:
+    if (
+        gradient_stability.get("trustedUpdate") is not True
+        or parameter_evidence.get("eligibilityMode") != "runtime_injected_metadata_scorecard_ranking"
+        or parameter_evidence.get("runtimeParameterConsumption") is True
+    ):
+        return gradient_stability
+
+    payload = copy.deepcopy(gradient_stability)
+    reason = (
+        "runtime-injected candidate metadata produced an offline scorecard ranking, but the private simulator "
+        "did not expose runtime parameter consumption evidence, so the gradient remains offline/shadow-only "
+        "and untrusted"
+    )
+    payload.update(
+        {
+            "status": "untrusted",
+            "classification": "runtime_parameter_consumption_missing",
+            "convergenceLabel": "runtime_parameter_consumption_missing",
+            "convergenceStatus": "not_converged_high_variance",
+            "gradientStable": False,
+            "trustedUpdate": False,
+            "trustedGradientUpdate": False,
+            "highVariance": True,
+            "reason": reason,
+        }
+    )
     return payload
 
 

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -2747,7 +2747,12 @@ def policy_update_lexicographic_reinforce_gradient_estimation(
                 "dominantDirectionRatio": round_policy_number(dominant_ratio),
             }
 
-        selected_tier, selected_gradient = first_nonzero_tier_gradient(tier_raw_gradients)
+        selected_tier, selected_rounded_gradient = first_nonzero_tier_gradient(tier_rounded_gradients)
+        selected_gradient = (
+            tier_raw_gradients.get(selected_tier, selected_rounded_gradient)
+            if selected_tier is not None
+            else 0
+        )
         selected_reward_tier_by_parameter[name] = selected_tier
         gradient[name] = selected_gradient
         cap_normalized_gradient[name] = round_policy_number(selected_gradient)

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -3436,12 +3436,13 @@ export const STRATEGY_REGISTRY = [
         self.assertFalse(update["officialMmoWrites"])
         self.assertFalse(update["officialMmoWritesAllowed"])
 
-    def test_reinforce_policy_update_uses_unrounded_lexicographic_gradient_for_parameter_delta(self) -> None:
+    def test_reinforce_policy_update_does_not_move_on_rounded_zero_lexicographic_gradient(self) -> None:
         policy_gradient = {
             "targetFamily": "test-family",
             "policyUpdate": {
                 "algorithm": runner.TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM,
                 "learning_rate": 1,
+                "bounded_integer_step": True,
                 "gradient_reward_weights": {
                     "reliability": 1,
                     "territory": 1,
@@ -3457,7 +3458,7 @@ export const STRATEGY_REGISTRY = [
                 "policy_update_reward_use": "eligible_with_evaluated_runtime_parameters",
                 "runtime_parameter_consumption_status": "consumed",
             },
-            "learnableParameters": [{"name": "tinySignalWeight", "min": 0, "max": 10_000_000}],
+            "learnableParameters": [{"name": "tinySignalWeight", "min": 0, "max": 10_000_000, "step": 1}],
             "candidateParameterVectors": [
                 {
                     "candidatePolicyId": "candidate-a",
@@ -3495,24 +3496,26 @@ export const STRATEGY_REGISTRY = [
             generated_at="2026-05-22T00:05:00Z",
         )
 
-        raw_gradient = float(update["rawGradient"]["tinySignalWeight"])
-        self.assertEqual(update["iterations"], 1)
-        self.assertGreater(raw_gradient, 0)
-        self.assertLess(raw_gradient, 0.0000005)
-        self.assertEqual(runner.round_policy_number(raw_gradient), 0)
+        raw_tier_gradient = float(
+            update["gradientEstimation"]["rawGradientByRewardTier"]["tinySignalWeight"]["reliability"]
+        )
+        self.assertEqual(update["iterations"], 0)
+        self.assertEqual(update["skippedReason"], "bounded_update_no_parameter_change")
+        self.assertTrue(update["boundedIntegerStep"])
+        self.assertGreater(raw_tier_gradient, 0)
+        self.assertLess(raw_tier_gradient, 0.0000005)
+        self.assertEqual(runner.round_policy_number(raw_tier_gradient), 0)
+        self.assertEqual(update["gradientEstimation"]["selectedRewardTierByParameter"], {"tinySignalWeight": None})
+        self.assertEqual(update["rawGradient"], {"tinySignalWeight": 0})
         self.assertEqual(update["gradientEstimation"]["capNormalizedGradient"], {"tinySignalWeight": 0})
         self.assertEqual(update["gradientEstimation"]["directionByParameter"]["tinySignalWeight"]["gradient"], 0)
         self.assertEqual(update["gradient"], update["gradientMomentum"]["rawEmaGradient"])
         self.assertEqual(update["gradientMomentum"]["emaGradient"], {"tinySignalWeight": 0})
         self.assertEqual(update["gradientMomentum"]["directionByParameter"]["tinySignalWeight"]["emaGradient"], 0)
-        self.assertGreater(float(update["gradient"]["tinySignalWeight"]), 0)
-        self.assertGreater(float(update["gradientMomentum"]["rawEmaGradient"]["tinySignalWeight"]), 0)
-        self.assertEqual(update["parameterDelta"], {"tinySignalWeight": 2.5})
-        self.assertEqual(update["updatedParameters"], {"tinySignalWeight": 2.5})
-        self.assertEqual(
-            update["nextCandidatePolicy"]["parameterEvidence"]["parameterDelta"],
-            {"tinySignalWeight": 2.5},
-        )
+        self.assertEqual(update["gradient"], {"tinySignalWeight": 0})
+        self.assertNotIn("parameterDelta", update)
+        self.assertNotIn("updatedParameters", update)
+        self.assertNotIn("nextCandidatePolicy", update)
 
     def test_gradient_momentum_config_prefers_raw_ema_round_trip_state(self) -> None:
         raw_previous = 0.00000025

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -90,6 +90,10 @@ def scalar_gradient_scheme_identity(policy_gradient: JsonObject | None = None) -
     )
 
 
+def lexicographic_reinforce_gradient_scheme_identity() -> JsonObject:
+    return runner.policy_update_lexicographic_reinforce_gradient_scheme_identity()
+
+
 def base_card(variant_ids: list[str] | None = None) -> JsonObject:
     ids = variant_ids or ["baseline", "candidate"]
     return {
@@ -2844,18 +2848,24 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(stability["sampleCountByCandidate"], {"variant-a": 20, "variant-b": 20})
         self.assertEqual(stability["classification"], "stable")
         self.assertEqual(stability["convergenceLabel"], "trusted_gradient_update")
-        self.assertEqual(update["policyGradientEstimator"], runner.POLICY_GRADIENT_SCALAR_ESTIMATOR)
-        self.assertEqual(update["gradientEstimation"]["gradientReward"], "scalar_weighted_sum")
-        self.assertEqual(update["gradientEstimation"]["scalarWeightedSumUse"], "gradient_estimation_only_non_promotional")
+        self.assertEqual(
+            update["policyGradientEstimator"],
+            runner.POLICY_GRADIENT_LEXICOGRAPHIC_REINFORCE_ESTIMATOR,
+        )
+        self.assertEqual(
+            update["gradientEstimation"]["gradientReward"],
+            runner.POLICY_GRADIENT_LEXICOGRAPHIC_PER_TIER_REWARD,
+        )
+        self.assertEqual(update["gradientEstimation"]["scalarWeightedSumUse"], "not_used")
         self.assertTrue(update["gradientEstimation"]["lexicographicRankingPreserved"])
         self.assertFalse(update["gradientEstimation"]["scalarWeightedSumAuthorized"])
         self.assertEqual(
             update["gradientEstimation"]["schemeIdentity"]["estimator"],
-            runner.POLICY_GRADIENT_SCALAR_ESTIMATOR,
+            runner.POLICY_GRADIENT_LEXICOGRAPHIC_REINFORCE_ESTIMATOR,
         )
         self.assertEqual(
             update["gradientEstimation"]["schemeIdentity"]["gradientReward"],
-            "scalar_weighted_sum",
+            runner.POLICY_GRADIENT_LEXICOGRAPHIC_PER_TIER_REWARD,
         )
         self.assertEqual(
             update["gradientEstimation"]["schemeKey"],
@@ -2873,19 +2883,21 @@ export const STRATEGY_REGISTRY = [
             update["nextCandidatePolicy"]["gradientEstimationSchemeKey"],
             update["gradientEstimation"]["schemeKey"],
         )
-        self.assertEqual(update["gradientEstimation"]["sourceMaxComponentWeight"], 1000000000)
-        self.assertEqual(update["gradientEstimation"]["normalizationCap"], 10000)
-        self.assertEqual(update["gradientEstimation"]["normalizationFactor"], 10000)
-        self.assertEqual(update["gradientEstimation"]["scalarRewardScaleFactor"], 0.00001)
+        self.assertNotIn("sourceMaxComponentWeight", update["gradientEstimation"])
+        self.assertNotIn("scalarRewardScaleFactor", update["gradientEstimation"])
+        self.assertEqual(
+            update["gradientEstimation"]["selectedRewardTierByParameter"],
+            {"territorySignalWeight": "reliability"},
+        )
         self.assertEqual(update["gradient"], update["gradientMomentum"]["rawEmaGradient"])
         self.assertEqual(
             runner.round_policy_number(update["gradient"]["territorySignalWeight"]),
             update["gradientMomentum"]["emaGradient"]["territorySignalWeight"],
         )
-        self.assertAlmostEqual(float(update["gradient"]["territorySignalWeight"]), 1666.666667, places=6)
-        self.assertEqual(update["parameterDelta"], {"territorySignalWeight": 24})
-        self.assertEqual(update["updatedParameters"], {"territorySignalWeight": 30})
-        self.assertEqual(update["gradientEstimation"]["capNormalizedGradient"], {"territorySignalWeight": 1666.666667})
+        self.assertAlmostEqual(float(update["gradient"]["territorySignalWeight"]), 0.016667, places=6)
+        self.assertEqual(update["parameterDelta"], {"territorySignalWeight": 0.5})
+        self.assertEqual(update["updatedParameters"], {"territorySignalWeight": 6.5})
+        self.assertEqual(update["gradientEstimation"]["capNormalizedGradient"], {"territorySignalWeight": 0.016667})
         self.assertEqual(
             runner.round_policy_number(update["gradientEstimation"]["gradient"]["territorySignalWeight"]),
             update["gradientEstimation"]["capNormalizedGradient"]["territorySignalWeight"],
@@ -2902,7 +2914,7 @@ export const STRATEGY_REGISTRY = [
         policy_gradient["policyUpdate"]["gradient_momentum"] = {
             "ema_decay": 0.8,
             "previous_ema_gradient": {"territorySignalWeight": 0.25},
-            "previous_gradient_estimation_scheme": scalar_gradient_scheme_identity(policy_gradient),
+            "previous_gradient_estimation_scheme": lexicographic_reinforce_gradient_scheme_identity(),
         }
 
         update = runner.build_policy_update(
@@ -2986,14 +2998,7 @@ export const STRATEGY_REGISTRY = [
             runner.policy_update_gradient_scheme_comparison_key(different_estimator),
         )
 
-    def test_reinforce_gradient_stability_trusts_scaled_equivalent_previous_scheme(self) -> None:
-        previous_policy_gradient = reinforce_stability_policy_gradient()
-        previous_policy_gradient["policyUpdate"]["gradient_reward_weights"] = {
-            "reliability": 100,
-            "territory": 50,
-            "resources": 25,
-            "kills": 10,
-        }
+    def test_reinforce_gradient_stability_trusts_weight_changes_under_lexicographic_scheme(self) -> None:
         policy_gradient = reinforce_stability_policy_gradient()
         policy_gradient["policyUpdate"]["gradient_reward_weights"] = {
             "reliability": 200,
@@ -3004,7 +3009,7 @@ export const STRATEGY_REGISTRY = [
         policy_gradient["policyUpdate"]["gradient_momentum"] = {
             "ema_decay": 0.8,
             "previous_ema_gradient": {"territorySignalWeight": 0.25},
-            "previous_gradient_estimation_scheme": scalar_gradient_scheme_identity(previous_policy_gradient),
+            "previous_gradient_estimation_scheme": lexicographic_reinforce_gradient_scheme_identity(),
         }
 
         update = runner.build_policy_update(
@@ -3181,7 +3186,7 @@ export const STRATEGY_REGISTRY = [
         self.assertGreater(direction["contributionSum"], 0)
         self.assertEqual(direction["contributionSum"], direction["capNormalizedContributionSum"])
 
-    def test_reinforce_policy_update_preserves_large_source_weight_scale(self) -> None:
+    def test_reinforce_policy_update_ignores_scalar_weight_scale_for_active_gradient(self) -> None:
         policy_gradient = {
             "targetFamily": "test-family",
             "policyUpdate": {
@@ -3241,16 +3246,197 @@ export const STRATEGY_REGISTRY = [
         )
 
         self.assertEqual(update["iterations"], 1)
-        self.assertEqual(update["gradientEstimation"]["scalarRewardScaleFactor"], 0.00000001)
-        self.assertEqual(update["gradient"], {"territorySignalWeight": 12500000})
-        self.assertEqual(update["parameterDelta"], {"territorySignalWeight": 1})
-        self.assertEqual(update["updatedParameters"], {"territorySignalWeight": 2})
+        self.assertEqual(
+            update["gradientEstimation"]["estimator"],
+            runner.POLICY_GRADIENT_LEXICOGRAPHIC_REINFORCE_ESTIMATOR,
+        )
+        self.assertNotIn("scalarRewardScaleFactor", update["gradientEstimation"])
+        self.assertEqual(update["gradient"], {"territorySignalWeight": 0.125})
+        self.assertEqual(update["parameterDelta"], {"territorySignalWeight": 0.025})
+        self.assertEqual(update["updatedParameters"], {"territorySignalWeight": 1.025})
         self.assertEqual(
             update["nextCandidatePolicy"]["parameterEvidence"]["parameterDelta"],
-            {"territorySignalWeight": 1},
+            {"territorySignalWeight": 0.025},
         )
 
-    def test_reinforce_policy_update_uses_unrounded_scalar_gradient_for_parameter_delta(self) -> None:
+    def test_reinforce_lexicographic_gradient_estimator_does_not_let_reliability_weight_mask_lower_tiers(self) -> None:
+        policy_gradient = {
+            "targetFamily": "test-family",
+            "policyUpdate": {
+                "algorithm": runner.TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM,
+                "learning_rate": 0.1,
+                "gradient_reward_weights": {
+                    "reliability": 1_000_000_000_000.0,
+                    "territory": 1_000_000.0,
+                    "resources": 1_000.0,
+                    "kills": 1.0,
+                },
+                "gradient_stability_gate": {"minimum_samples_per_candidate": 1},
+            },
+            "runner_support": {
+                "runtime_parameter_injection": True,
+                "inline_candidates_runtime_injected": True,
+                "candidate_parameter_scope": "runtime_injected",
+                "simulator_variant_transport": "variant_ids_with_runtime_injected_parameters",
+                "policy_update_reward_use": "eligible_with_evaluated_runtime_parameters",
+                "runtime_parameter_consumption_status": "consumed",
+            },
+            "learnableParameters": [
+                {"name": "reliabilitySignalWeight", "min": 0, "max": 2},
+                {"name": "territorySignalWeight", "min": 0, "max": 2},
+                {"name": "resourceSignalWeight", "min": 0, "max": 2},
+                {"name": "combatSignalWeight", "min": 0, "max": 2},
+            ],
+            "candidateParameterVectors": [
+                {
+                    "candidatePolicyId": "candidate-anchor",
+                    "strategyVariantId": "variant-anchor",
+                    "rolloutStatus": "incumbent",
+                    "parameters": {
+                        "reliabilitySignalWeight": 0,
+                        "territorySignalWeight": 0,
+                        "resourceSignalWeight": 0,
+                        "combatSignalWeight": 0,
+                    },
+                },
+                {
+                    "candidatePolicyId": "candidate-reliability",
+                    "strategyVariantId": "variant-reliability",
+                    "rolloutStatus": "shadow",
+                    "parameters": {
+                        "reliabilitySignalWeight": 1,
+                        "territorySignalWeight": 0,
+                        "resourceSignalWeight": 0,
+                        "combatSignalWeight": 0,
+                    },
+                },
+                {
+                    "candidatePolicyId": "candidate-territory",
+                    "strategyVariantId": "variant-territory",
+                    "rolloutStatus": "shadow",
+                    "parameters": {
+                        "reliabilitySignalWeight": 0,
+                        "territorySignalWeight": 1,
+                        "resourceSignalWeight": 0,
+                        "combatSignalWeight": 0,
+                    },
+                },
+                {
+                    "candidatePolicyId": "candidate-resources",
+                    "strategyVariantId": "variant-resources",
+                    "rolloutStatus": "shadow",
+                    "parameters": {
+                        "reliabilitySignalWeight": 0,
+                        "territorySignalWeight": 0,
+                        "resourceSignalWeight": 1,
+                        "combatSignalWeight": 0,
+                    },
+                },
+                {
+                    "candidatePolicyId": "candidate-kills",
+                    "strategyVariantId": "variant-kills",
+                    "rolloutStatus": "shadow",
+                    "parameters": {
+                        "reliabilitySignalWeight": 0,
+                        "territorySignalWeight": 0,
+                        "resourceSignalWeight": 0,
+                        "combatSignalWeight": 1,
+                    },
+                },
+            ],
+        }
+        results = [
+            {
+                "variantId": "variant-anchor",
+                "sampleCount": 1,
+                "reward": {"tuple": [1, 0, 0, 0]},
+                "evaluatedParameters": {
+                    "reliabilitySignalWeight": 0,
+                    "territorySignalWeight": 0,
+                    "resourceSignalWeight": 0,
+                    "combatSignalWeight": 0,
+                },
+            },
+            {
+                "variantId": "variant-reliability",
+                "sampleCount": 1,
+                "reward": {"tuple": [2, 0, 0, 0]},
+                "evaluatedParameters": {
+                    "reliabilitySignalWeight": 1,
+                    "territorySignalWeight": 0,
+                    "resourceSignalWeight": 0,
+                    "combatSignalWeight": 0,
+                },
+            },
+            {
+                "variantId": "variant-territory",
+                "sampleCount": 1,
+                "reward": {"tuple": [1, 5, 0, 0]},
+                "evaluatedParameters": {
+                    "reliabilitySignalWeight": 0,
+                    "territorySignalWeight": 1,
+                    "resourceSignalWeight": 0,
+                    "combatSignalWeight": 0,
+                },
+            },
+            {
+                "variantId": "variant-resources",
+                "sampleCount": 1,
+                "reward": {"tuple": [1, 0, 7, 0]},
+                "evaluatedParameters": {
+                    "reliabilitySignalWeight": 0,
+                    "territorySignalWeight": 0,
+                    "resourceSignalWeight": 1,
+                    "combatSignalWeight": 0,
+                },
+            },
+            {
+                "variantId": "variant-kills",
+                "sampleCount": 1,
+                "reward": {"tuple": [1, 0, 0, 11]},
+                "evaluatedParameters": {
+                    "reliabilitySignalWeight": 0,
+                    "territorySignalWeight": 0,
+                    "resourceSignalWeight": 0,
+                    "combatSignalWeight": 1,
+                },
+            },
+        ]
+
+        update = runner.build_policy_update(
+            policy_gradient=policy_gradient,
+            results=results,
+            report_id="policy-gradient-lexicographic-tier-selection",
+            generated_at="2026-05-22T00:02:00Z",
+        )
+
+        selected = update["gradientEstimation"]["selectedRewardTierByParameter"]
+        per_tier = update["gradientEstimation"]["gradientByRewardTier"]
+        self.assertEqual(update["iterations"], 1)
+        self.assertEqual(update["policyGradientEstimator"], runner.POLICY_GRADIENT_LEXICOGRAPHIC_REINFORCE_ESTIMATOR)
+        self.assertNotEqual(update["policyGradientEstimator"], runner.POLICY_GRADIENT_SCALAR_ESTIMATOR)
+        self.assertEqual(
+            selected,
+            {
+                "reliabilitySignalWeight": "reliability",
+                "territorySignalWeight": "territory",
+                "resourceSignalWeight": "resources",
+                "combatSignalWeight": "kills",
+            },
+        )
+        self.assertEqual(per_tier["territorySignalWeight"]["reliability"], 0)
+        self.assertGreater(per_tier["territorySignalWeight"]["territory"], 0)
+        self.assertEqual(per_tier["resourceSignalWeight"]["reliability"], 0)
+        self.assertGreater(per_tier["resourceSignalWeight"]["resources"], 0)
+        self.assertEqual(per_tier["combatSignalWeight"]["reliability"], 0)
+        self.assertGreater(per_tier["combatSignalWeight"]["kills"], 0)
+        self.assertFalse(update["gradientEstimation"]["scalarWeightedSumAuthorized"])
+        self.assertEqual(update["gradientEstimation"]["scalarWeightedSumUse"], "not_used")
+        self.assertFalse(update["liveEffect"])
+        self.assertFalse(update["officialMmoWrites"])
+        self.assertFalse(update["officialMmoWritesAllowed"])
+
+    def test_reinforce_policy_update_uses_unrounded_lexicographic_gradient_for_parameter_delta(self) -> None:
         policy_gradient = {
             "targetFamily": "test-family",
             "policyUpdate": {
@@ -3364,11 +3550,9 @@ export const STRATEGY_REGISTRY = [
         self.assertFalse(update["gradientStable"])
         self.assertFalse(update["trustedGradientUpdate"])
         self.assertTrue(update["highVariance"])
-        self.assertEqual(update["gradientEstimation"]["normalizationFactor"], 10000)
-        self.assertEqual(update["gradientEstimation"]["scalarRewardScaleFactor"], 0.00001)
-        self.assertEqual(update["gradientEstimation"]["capNormalizedGradient"], {"territorySignalWeight": 1666.666667})
-        self.assertEqual(update["parameterDelta"], {"territorySignalWeight": 24})
-        self.assertEqual(update["updatedParameters"], {"territorySignalWeight": 30})
+        self.assertEqual(update["gradientEstimation"]["capNormalizedGradient"], {"territorySignalWeight": 0.016667})
+        self.assertEqual(update["parameterDelta"], {"territorySignalWeight": 0.5})
+        self.assertEqual(update["updatedParameters"], {"territorySignalWeight": 6.5})
         self.assertGreater(abs(float(update["gradient"]["territorySignalWeight"])), 0)
         self.assertEqual(stability["classification"], "insufficient_sample_high_variance")
         self.assertEqual(stability["convergenceLabel"], "sample_only_not_convergence")
@@ -3452,7 +3636,7 @@ export const STRATEGY_REGISTRY = [
         policy_gradient["policyUpdate"]["gradient_momentum"] = {
             "ema_decay": 0.8,
             "previous_ema_gradient": {"territorySignalWeight": 0.25},
-            "previous_gradient_estimation_scheme": scalar_gradient_scheme_identity(policy_gradient),
+            "previous_gradient_estimation_scheme": lexicographic_reinforce_gradient_scheme_identity(),
         }
         update = runner.build_policy_update(
             policy_gradient=policy_gradient,
@@ -4281,7 +4465,10 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(report["gradientTrustGateReason"], report["gradientStability"]["reason"])
         self.assertEqual(report["highVarianceReason"], report["gradientStability"]["reason"])
         self.assertEqual(report["gradientTrustGateClassification"], "insufficient_sample_high_variance")
-        self.assertEqual(report["gradientEstimation"]["gradientReward"], "scalar_weighted_sum")
+        self.assertEqual(
+            report["gradientEstimation"]["gradientReward"],
+            runner.POLICY_GRADIENT_LEXICOGRAPHIC_PER_TIER_REWARD,
+        )
         self.assertIsInstance(report["gradientEstimation"]["schemeIdentity"], dict)
         self.assertEqual(report["gradientEstimationSchemeKey"], report["gradientEstimation"]["schemeKey"])
         self.assertEqual(report["gradientComparisonKey"], report["gradientEstimation"]["comparisonKey"])
@@ -4292,7 +4479,10 @@ export const STRATEGY_REGISTRY = [
         )
         self.assertEqual(report["gradientMomentum"]["type"], runner.GRADIENT_MOMENTUM_EVIDENCE_TYPE)
         self.assertFalse(persisted["trustedGradientUpdate"])
-        self.assertEqual(persisted["gradientEstimation"]["estimator"], runner.POLICY_GRADIENT_SCALAR_ESTIMATOR)
+        self.assertEqual(
+            persisted["gradientEstimation"]["estimator"],
+            runner.POLICY_GRADIENT_LEXICOGRAPHIC_REINFORCE_ESTIMATOR,
+        )
         self.assertEqual(persisted["gradientEstimationSchemeKey"], report["gradientEstimation"]["schemeKey"])
         self.assertIsNotNone(report["policyUpdateCandidatePolicyId"])
         self.assertIn("policyUpdateArtifactPath", report)


### PR DESCRIPTION
## Summary
- Replaces the scalar weighted-sum policy-gradient estimator with a lexicographic/per-tier estimator so reliability cannot mask territory/resource/combat signals.
- Adds focused coverage for per-tier advantage ordering and regression handling in the RL training runner tests.

## Linked issue
Related to issue 1482.

## Roadmap category
- Domain: RL flywheel
- Kind: code
- Priority: P0

## Verification
- `git diff --check` — PASS
- `python3 -m py_compile scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_training_runner.py` — PASS
- `python3 -m unittest scripts/test_screeps_rl_training_runner.py` — PASS (129 tests)

## Safety
- Offline/private RL training framework only.
- No official MMO writes, no deploy, no live policy rollout.
- Further paid validation remains held until the active Tencent run is digested and this estimator fix lands.
