### PR TITLE
fix(rl): record Tencent validation training timeouts

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -104,6 +104,7 @@ KNOWN_HOSTS_CLEANUP_TIMEOUT_SECONDS = 30
 KNOWN_HOSTS_KEYSCAN_TIMEOUT_SECONDS = 15
 KNOWN_HOSTS_KEYSCAN_RETRY_DELAYS_SECONDS = (2.0, 5.0)
 PROCESS_TIMEOUT_RETURN_CODE = 124
+CONTROLLER_TIMEOUT_ATTR = "_screeps_controller_timed_out"
 SSH_HOST_KEY_TYPES = ("ed25519", "ecdsa", "rsa")
 HOST_KEY_ALGORITHM_RE = (
     r"(?:ssh-rsa(?:-cert-v01@openssh\.com)?|"
@@ -491,7 +492,10 @@ class Controller:
         except OSError as error:
             cp = subprocess.CompletedProcess(list(cmd), 127, "", f"{type(error).__name__}: {error}")
         ok = cp.returncode == 0
-        self.record_step(name, started, ok, cp, argv=redacted_argv(cmd))
+        detail: dict[str, Any] = {"argv": redacted_argv(cmd)}
+        if completed_process_controller_timed_out(cp):
+            detail["controllerTimedOut"] = True
+        self.record_step(name, started, ok, cp, **detail)
         if check and not ok:
             raise BatchRunError(f"{name} failed with exit {cp.returncode}: {tail_text(cp.stderr or cp.stdout)}")
         return cp
@@ -1642,6 +1646,7 @@ PY
             cp.returncode,
             run_id=self.run_id,
             process_failure_class=classify_ssh_process_failure(cp),
+            controller_timed_out=completed_process_controller_timed_out(cp),
             collection_error=collection_error,
         )
         self.result["remoteTrainingFailure"] = diagnostics
@@ -1939,12 +1944,18 @@ def timeout_completed_process(
         else "TimeoutExpired: command timed out"
     )
     stderr = "\n".join(part for part in (message, decode_subprocess_text(stderr_raw)) if part)
-    return subprocess.CompletedProcess(
+    cp = subprocess.CompletedProcess(
         list(cmd),
         PROCESS_TIMEOUT_RETURN_CODE,
         decode_subprocess_text(stdout_raw),
         stderr,
     )
+    setattr(cp, CONTROLLER_TIMEOUT_ATTR, True)
+    return cp
+
+
+def completed_process_controller_timed_out(cp: subprocess.CompletedProcess[str]) -> bool:
+    return getattr(cp, CONTROLLER_TIMEOUT_ATTR, False) is True
 
 
 def sanitize_known_hosts_cleanup_text(raw: str | bytes | None) -> str:
@@ -2338,6 +2349,7 @@ def remote_training_failure_diagnostics(
     *,
     run_id: str | None = None,
     process_failure_class: str | None = None,
+    controller_timed_out: bool = False,
     collection_error: str | None = None,
 ) -> dict[str, Any]:
     remote_dir = artifact_dir / "remote"
@@ -2358,6 +2370,7 @@ def remote_training_failure_diagnostics(
         files,
         returncode=returncode,
         process_failure_class=process_failure_class,
+        controller_timed_out=controller_timed_out,
     )
     payload: dict[str, Any] = {
         "status": "failed_exit",
@@ -2367,6 +2380,8 @@ def remote_training_failure_diagnostics(
         "artifactDir": str(remote_dir),
         "diagnostics": files,
     }
+    if controller_timed_out:
+        payload["controllerTimedOut"] = True
     next_action = remote_training_failure_next_action(failure_class)
     if next_action is not None:
         payload["nextAction"] = next_action
@@ -2383,6 +2398,7 @@ def classify_remote_training_failure(
     *,
     returncode: int,
     process_failure_class: str | None = None,
+    controller_timed_out: bool = False,
 ) -> str:
     diagnostic_text = "\n".join(
         tail for entry in files.values() for tail in [entry.get("tail")] if isinstance(tail, str)
@@ -2413,7 +2429,7 @@ def classify_remote_training_failure(
         )
     ):
         return "simulator_setup_retryable"
-    if returncode == PROCESS_TIMEOUT_RETURN_CODE:
+    if controller_timed_out:
         return "remote_training_timeout"
     if returncode == 255 and REMOTE_NETWORK_RE.search(diagnostic_text):
         return "network_unreachable"

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -103,6 +103,7 @@ SSH_CONNECT_OPTIONS = (
 KNOWN_HOSTS_CLEANUP_TIMEOUT_SECONDS = 30
 KNOWN_HOSTS_KEYSCAN_TIMEOUT_SECONDS = 15
 KNOWN_HOSTS_KEYSCAN_RETRY_DELAYS_SECONDS = (2.0, 5.0)
+PROCESS_TIMEOUT_RETURN_CODE = 124
 SSH_HOST_KEY_TYPES = ("ed25519", "ecdsa", "rsa")
 HOST_KEY_ALGORITHM_RE = (
     r"(?:ssh-rsa(?:-cert-v01@openssh\.com)?|"
@@ -474,16 +475,21 @@ class Controller:
         env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
         started = time.time()
-        cp = subprocess.run(
-            list(cmd),
-            text=True,
-            input=input_text,
-            capture_output=True,
-            cwd=str(cwd or REPO_ROOT),
-            timeout=timeout,
-            env=env,
-            check=False,
-        )
+        try:
+            cp = subprocess.run(
+                list(cmd),
+                text=True,
+                input=input_text,
+                capture_output=True,
+                cwd=str(cwd or REPO_ROOT),
+                timeout=timeout,
+                env=env,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as error:
+            cp = timeout_completed_process(cmd, error)
+        except OSError as error:
+            cp = subprocess.CompletedProcess(list(cmd), 127, "", f"{type(error).__name__}: {error}")
         ok = cp.returncode == 0
         self.record_step(name, started, ok, cp, argv=redacted_argv(cmd))
         if check and not ok:
@@ -1917,6 +1923,30 @@ def decode_subprocess_text(raw: str | bytes | None) -> str:
     return raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else raw
 
 
+def timeout_completed_process(
+    cmd: Sequence[str],
+    error: subprocess.TimeoutExpired,
+) -> subprocess.CompletedProcess[str]:
+    stdout_raw = getattr(error, "stdout", None)
+    if stdout_raw is None:
+        stdout_raw = getattr(error, "output", None)
+    stderr_raw = getattr(error, "stderr", None)
+    timeout_value = getattr(error, "timeout", None)
+    timeout_text = f"{timeout_value:g}" if isinstance(timeout_value, (int, float)) else str(timeout_value or "")
+    message = (
+        f"TimeoutExpired: command timed out after {timeout_text} seconds"
+        if timeout_text
+        else "TimeoutExpired: command timed out"
+    )
+    stderr = "\n".join(part for part in (message, decode_subprocess_text(stderr_raw)) if part)
+    return subprocess.CompletedProcess(
+        list(cmd),
+        PROCESS_TIMEOUT_RETURN_CODE,
+        decode_subprocess_text(stdout_raw),
+        stderr,
+    )
+
+
 def sanitize_known_hosts_cleanup_text(raw: str | bytes | None) -> str:
     if not raw:
         return ""
@@ -2383,6 +2413,8 @@ def classify_remote_training_failure(
         )
     ):
         return "simulator_setup_retryable"
+    if returncode == PROCESS_TIMEOUT_RETURN_CODE:
+        return "remote_training_timeout"
     if returncode == 255 and REMOTE_NETWORK_RE.search(diagnostic_text):
         return "network_unreachable"
     if returncode == 255:
@@ -2398,6 +2430,11 @@ def remote_training_failure_next_action(failure_class: str) -> str | None:
         )
     if failure_class == "network_unreachable":
         return "rerun after the worker SSH/network path is reachable"
+    if failure_class == "remote_training_timeout":
+        return (
+            "inspect collected partial diagnostics, then rerun validation in smaller chunks "
+            "or with an explicitly sized training timeout"
+        )
     return None
 
 

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -668,6 +668,36 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             },
         )
 
+    def test_run_cp_records_timeout_as_failed_step(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            controller = runner.Controller(args=controller_args(), run_id="run-test", artifact_dir=Path(temp_dir))
+            timeout_error = subprocess.TimeoutExpired(
+                ["ssh", "worker"],
+                7,
+                output=b"partial stdout",
+                stderr=b"partial stderr",
+            )
+
+            with mock.patch("subprocess.run", side_effect=timeout_error):
+                cp = controller.run_cp("remote_training", ["ssh", "worker"], check=False, timeout=7)
+
+            summary = json.loads((controller.artifact_dir / "controller-summary.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(cp.returncode, runner.PROCESS_TIMEOUT_RETURN_CODE)
+        self.assertEqual(cp.stdout, "partial stdout")
+        self.assertIn("TimeoutExpired: command timed out after 7 seconds", cp.stderr)
+        self.assertIn("partial stderr", cp.stderr)
+        self.assertTrue(summary["partial"])
+        self.assertTrue(summary["execution"]["remoteTrainingAttempted"])
+        self.assertFalse(summary["execution"]["trainingReportProduced"])
+        self.assertEqual(summary["execution"]["environmentsRun"], 0)
+        step = summary["steps"][0]
+        self.assertEqual(step["name"], "remote_training")
+        self.assertFalse(step["ok"])
+        self.assertEqual(step["returncode"], runner.PROCESS_TIMEOUT_RETURN_CODE)
+        self.assertIn("TimeoutExpired: command timed out after 7 seconds", step["stderr_tail"])
+        self.assertNotIn("['ssh', 'worker']", step["stderr_tail"])
+
     def test_security_group_guard_accepts_single_controller_ssh_rule(self) -> None:
         ingress = [
             {"Action": "ACCEPT", "Protocol": "TCP", "Port": "22", "CidrBlock": CONTROLLER_IP},
@@ -3894,6 +3924,58 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             self.assertIn("simulator argument rejected", stderr["tail"])
             self.assertIn("STEAM_KEY=[REDACTED]", stderr["tail"])
             self.assertNotIn("secret-value", stderr["tail"])
+
+    def test_run_remote_training_classifies_timeout_and_collects_partial_diagnostics(self) -> None:
+        args = controller_args()
+        args.training_timeout_seconds = 3600
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=root)
+            calls: list[tuple[str, dict[str, object]]] = []
+
+            def fake_ssh_cmd(
+                name: str,
+                _remote_command: str,
+                **kwargs: object,
+            ) -> subprocess.CompletedProcess[str]:
+                calls.append((name, kwargs))
+                return subprocess.CompletedProcess(
+                    ["ssh"],
+                    runner.PROCESS_TIMEOUT_RETURN_CODE,
+                    "",
+                    "TimeoutExpired: command timed out after 3600 seconds\n",
+                )
+
+            def fake_collect_remote_artifacts() -> None:
+                remote = root / "remote"
+                remote.mkdir(parents=True)
+                (remote / "training-stderr.log").write_text(
+                    "validation heartbeat: environmentsStarted=0 environmentsCompleted=0\n",
+                    encoding="utf-8",
+                )
+                (remote / "training-summary.json").write_text("", encoding="utf-8")
+                (remote / "card-validation.json").write_text('{"ok": true}\n', encoding="utf-8")
+                (remote / "report-extract.json").write_text("", encoding="utf-8")
+
+            with (
+                mock.patch.object(controller, "ssh_cmd", side_effect=fake_ssh_cmd),
+                mock.patch.object(controller, "collect_remote_artifacts", side_effect=fake_collect_remote_artifacts),
+            ):
+                with self.assertRaisesRegex(runner.BatchRunError, "validation heartbeat"):
+                    controller.run_remote_training()
+
+            failure = controller.result["remoteTrainingFailure"]
+
+        self.assertEqual(calls[0][0], "remote_training")
+        self.assertEqual(calls[0][1]["timeout"], 3600)
+        self.assertEqual(failure["returncode"], runner.PROCESS_TIMEOUT_RETURN_CODE)
+        self.assertEqual(failure["failureClass"], "remote_training_timeout")
+        self.assertFalse(failure["retryable"])
+        self.assertIn("smaller chunks", failure["nextAction"])
+        self.assertIn(
+            "validation heartbeat",
+            failure["diagnostics"]["training-stderr.log"]["tail"],
+        )
 
     def test_run_remote_training_classifies_ssh_server_timeout(self) -> None:
         args = controller_args()

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -697,6 +697,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(step["returncode"], runner.PROCESS_TIMEOUT_RETURN_CODE)
         self.assertIn("TimeoutExpired: command timed out after 7 seconds", step["stderr_tail"])
         self.assertNotIn("['ssh', 'worker']", step["stderr_tail"])
+        self.assertTrue(step["detail"]["controllerTimedOut"])
 
     def test_security_group_guard_accepts_single_controller_ssh_rule(self) -> None:
         ingress = [
@@ -3939,11 +3940,14 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 **kwargs: object,
             ) -> subprocess.CompletedProcess[str]:
                 calls.append((name, kwargs))
-                return subprocess.CompletedProcess(
+                return runner.timeout_completed_process(
                     ["ssh"],
-                    runner.PROCESS_TIMEOUT_RETURN_CODE,
-                    "",
-                    "TimeoutExpired: command timed out after 3600 seconds\n",
+                    subprocess.TimeoutExpired(
+                        ["ssh"],
+                        3600,
+                        output=b"",
+                        stderr=b"validation heartbeat: environmentsStarted=0 environmentsCompleted=0\n",
+                    ),
                 )
 
             def fake_collect_remote_artifacts() -> None:
@@ -3970,12 +3974,58 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(calls[0][1]["timeout"], 3600)
         self.assertEqual(failure["returncode"], runner.PROCESS_TIMEOUT_RETURN_CODE)
         self.assertEqual(failure["failureClass"], "remote_training_timeout")
+        self.assertTrue(failure["controllerTimedOut"])
         self.assertFalse(failure["retryable"])
         self.assertIn("smaller chunks", failure["nextAction"])
         self.assertIn(
             "validation heartbeat",
             failure["diagnostics"]["training-stderr.log"]["tail"],
         )
+
+    def test_run_remote_training_does_not_classify_remote_exit_124_as_controller_timeout(self) -> None:
+        args = controller_args()
+        args.training_timeout_seconds = 3600
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=root)
+
+            def fake_ssh_cmd(
+                _name: str,
+                _remote_command: str,
+                **_kwargs: object,
+            ) -> subprocess.CompletedProcess[str]:
+                return subprocess.CompletedProcess(
+                    ["ssh"],
+                    runner.PROCESS_TIMEOUT_RETURN_CODE,
+                    "",
+                    "remote command exited 124\n",
+                )
+
+            def fake_collect_remote_artifacts() -> None:
+                remote = root / "remote"
+                remote.mkdir(parents=True)
+                (remote / "training-stderr.log").write_text(
+                    "remote process exited with status 124\n",
+                    encoding="utf-8",
+                )
+                (remote / "training-summary.json").write_text("", encoding="utf-8")
+                (remote / "card-validation.json").write_text('{"ok": true}\n', encoding="utf-8")
+                (remote / "report-extract.json").write_text("", encoding="utf-8")
+
+            with (
+                mock.patch.object(controller, "ssh_cmd", side_effect=fake_ssh_cmd),
+                mock.patch.object(controller, "collect_remote_artifacts", side_effect=fake_collect_remote_artifacts),
+            ):
+                with self.assertRaisesRegex(runner.BatchRunError, "remote process exited with status 124"):
+                    controller.run_remote_training()
+
+            failure = controller.result["remoteTrainingFailure"]
+
+        self.assertEqual(failure["returncode"], runner.PROCESS_TIMEOUT_RETURN_CODE)
+        self.assertEqual(failure["failureClass"], "remote_process_failed")
+        self.assertFalse(failure["retryable"])
+        self.assertNotIn("controllerTimedOut", failure)
+        self.assertNotIn("nextAction", failure)
 
     def test_run_remote_training_classifies_ssh_server_timeout(self) -> None:
         args = controller_args()


### PR DESCRIPTION
## Summary
- records controller-side remote training timeouts as failed steps instead of letting `TimeoutExpired` bypass runner accounting
- classifies remote training timeouts with explicit diagnostics/next-action guidance
- adds regression tests for timeout accounting and partial diagnostic collection

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts.test_screeps_tencent_batch_rl_runner` (133 tests)

## Safety
- No Tencent compute launched.
- No official MMO writes.
- Related to #1337, #1032, #1233, #1299, #879.

## Universal task Done gate
- [x] Task type: code.
- [x] Expected observable outcome / named deliverable: Tencent remote-training SSH or subprocess timeouts are recorded as failed training steps with return code 124 and diagnostic artifacts instead of bypassing accounting.
- [x] Non-goals / accepted substitutes: no Tencent batch launch, no official MMO write, no learned-policy rollout, and no issue closure in this PR.
- [x] Verification evidence required before Done: `git diff --check`, Python compile, and `python3 -m unittest scripts.test_screeps_tencent_batch_rl_runner` passed with 133 tests.
- [x] Project Evidence / Next action / Blocked by: PR #1488 carries the code change for issue #1337; issue and PR Project fields identify CI and CodeRabbit gates as the current merge criteria.
- [x] Post-merge/deploy/runtime proof: script accounting change validated locally; official deploy and Tencent compute are outside this deliverable.
- [x] Named deliverable proof: `scripts/screeps_tencent_batch_rl_runner.py` catches remote training timeout paths, and `scripts/test_screeps_tencent_batch_rl_runner.py` covers timeout accounting plus partial diagnostics.
