### PR TITLE
gameplay: prioritize active rampart repair

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -29016,10 +29016,13 @@ function selectRoutineRampartMaintenanceRepairTarget(creep) {
   return selectAvailableRoutineRepairTarget(creep, computeRoutineRampartMaintenanceRepairTargets(creep.room));
 }
 function selectActiveRampartRepairEnergyAcquisitionTask(creep) {
-  if (getFreeEnergyCapacity8(creep) <= 0 || !selectActiveOwnedRampartRepairTarget(creep)) {
+  if (getFreeEnergyCapacity8(creep) <= 0 || hasVisibleConstructionSites(creep.room) || !selectActiveOwnedRampartRepairTarget(creep)) {
     return null;
   }
   return selectWorkerEnergyCriticalAcquisitionTask(creep);
+}
+function hasVisibleConstructionSites(room) {
+  return typeof FIND_CONSTRUCTION_SITES === "number" && room.find(FIND_CONSTRUCTION_SITES).length > 0;
 }
 function selectActiveOwnedRampartRepairTarget(creep) {
   var _a;
@@ -29272,7 +29275,8 @@ function isEmergencyOwnedRampartRepairTarget(structure) {
   return matchesStructureType18(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure) && !isWorkerRepairTargetComplete(structure) && structure.hits <= EMERGENCY_RAMPART_REPAIR_HITS_CEILING;
 }
 function isActiveOwnedRampartRepairTarget(structure) {
-  return matchesStructureType18(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure) && !isWorkerRepairTargetComplete(structure) && structure.hits <= Math.min(structure.hitsMax, ACTIVE_RAMPART_REPAIR_HITS_CEILING);
+  const repairCeiling = Math.min(structure.hitsMax, ACTIVE_RAMPART_REPAIR_HITS_CEILING);
+  return matchesStructureType18(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure) && structure.hits < repairCeiling;
 }
 function isOwnedSpawnRepairTarget(structure) {
   return isSpawnRepairTarget(structure) && structure.my === true;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -24968,6 +24968,7 @@ var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
 var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 var CRITICAL_SPAWN_REPAIR_HITS_RATIO = 0.25;
 var EMERGENCY_RAMPART_REPAIR_HITS_CEILING = 1e4;
+var ACTIVE_RAMPART_REPAIR_HITS_CEILING = 12e4;
 var IDLE_RAMPART_REPAIR_HITS_CEILING2 = 15e4;
 var TOWER_REFILL_ENERGY_FLOOR = 500;
 var CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
@@ -25135,6 +25136,10 @@ function selectHeuristicWorkerTask(creep) {
       const constructionBacklogEnergyAcquisitionTask = selectConstructionBacklogEnergyAcquisitionTask(creep);
       if (constructionBacklogEnergyAcquisitionTask) {
         return constructionBacklogEnergyAcquisitionTask;
+      }
+      const activeRampartRepairEnergyAcquisitionTask = selectActiveRampartRepairEnergyAcquisitionTask(creep);
+      if (activeRampartRepairEnergyAcquisitionTask) {
+        return activeRampartRepairEnergyAcquisitionTask;
       }
       const nearbyWorkerEnergyAcquisitionTask = selectNearbyWorkerEnergyAcquisitionTask(creep);
       if (nearbyWorkerEnergyAcquisitionTask) {
@@ -25388,6 +25393,13 @@ function selectHeuristicWorkerTask(creep) {
     return applyMinimumUsefulLoadPolicy(creep, {
       type: "repair",
       targetId: threatenedBarrierRepairTarget.id
+    });
+  }
+  const activeRampartRepairTarget = constructionSites.length === 0 ? selectActiveOwnedRampartRepairTarget(creep) : null;
+  if (activeRampartRepairTarget) {
+    return applyMinimumUsefulLoadPolicy(creep, {
+      type: "repair",
+      targetId: activeRampartRepairTarget.id
     });
   }
   const uncoveredRoutineRampartMaintenanceTask = selectUncoveredRoutineRampartMaintenanceTask(
@@ -29003,6 +29015,27 @@ function selectRoutineBarrierMaintenanceRepairTarget(creep) {
 function selectRoutineRampartMaintenanceRepairTarget(creep) {
   return selectAvailableRoutineRepairTarget(creep, computeRoutineRampartMaintenanceRepairTargets(creep.room));
 }
+function selectActiveRampartRepairEnergyAcquisitionTask(creep) {
+  if (getFreeEnergyCapacity8(creep) <= 0 || !selectActiveOwnedRampartRepairTarget(creep)) {
+    return null;
+  }
+  return selectWorkerEnergyCriticalAcquisitionTask(creep);
+}
+function selectActiveOwnedRampartRepairTarget(creep) {
+  var _a;
+  if (((_a = creep.room.controller) == null ? void 0 : _a.my) !== true || hasVisibleHostilePresence3(creep.room) || !hasActiveRampartRepairEnergyReserve(creep.room)) {
+    return null;
+  }
+  const repairTargets = findVisibleRoomStructures(creep.room).filter(isActiveOwnedRampartRepairTarget).filter((structure) => hasActiveRampartRepairAssignmentCapacity(creep, structure));
+  if (repairTargets.length === 0) {
+    return null;
+  }
+  return repairTargets.sort(compareRepairTargets)[0];
+}
+function hasActiveRampartRepairEnergyReserve(room) {
+  const energyAvailable = getRoomEnergyAvailable10(room);
+  return energyAvailable === null || energyAvailable >= CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD;
+}
 function getRoutineBarrierMaintenanceRepairTargets(room) {
   const gameTick = getGameTick3();
   const roomName = getRoomName6(room);
@@ -29181,6 +29214,9 @@ function isRoutineRepairTargetWithinOpportunisticRange(creep, structure) {
 function hasRoutineRepairAssignmentCapacity(creep, structure) {
   return isUrgentBarrierRepairTarget(structure) || isWorkerAssignedToRepairTarget(creep, structure) || !hasOtherWorkerAssignedToRepairTarget(creep, structure);
 }
+function hasActiveRampartRepairAssignmentCapacity(creep, structure) {
+  return isWorkerAssignedToRepairTarget(creep, structure) || !hasOtherLoadedWorkerAssignedToRepairTarget(creep, structure);
+}
 function isUrgentBarrierRepairTarget(structure) {
   return isWorkerBarrierRepairStructure(structure) && structure.hits < Math.min(structure.hitsMax, BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING);
 }
@@ -29189,6 +29225,14 @@ function hasOtherWorkerAssignedToRepairTarget(creep, structure) {
     (worker) => {
       var _a;
       return !isSameCreep(worker, creep) && ((_a = worker.memory) == null ? void 0 : _a.role) === "worker" && isWorkerAssignedToRepairTarget(worker, structure);
+    }
+  );
+}
+function hasOtherLoadedWorkerAssignedToRepairTarget(creep, structure) {
+  return getRoomOwnedCreeps(creep.room).some(
+    (worker) => {
+      var _a;
+      return !isSameCreep(worker, creep) && ((_a = worker.memory) == null ? void 0 : _a.role) === "worker" && getUsedEnergy2(worker) > 0 && isWorkerAssignedToRepairTarget(worker, structure);
     }
   );
 }
@@ -29226,6 +29270,9 @@ function isCriticalOwnedSpawnRepairTarget(structure) {
 }
 function isEmergencyOwnedRampartRepairTarget(structure) {
   return matchesStructureType18(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure) && !isWorkerRepairTargetComplete(structure) && structure.hits <= EMERGENCY_RAMPART_REPAIR_HITS_CEILING;
+}
+function isActiveOwnedRampartRepairTarget(structure) {
+  return matchesStructureType18(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure) && !isWorkerRepairTargetComplete(structure) && structure.hits <= Math.min(structure.hitsMax, ACTIVE_RAMPART_REPAIR_HITS_CEILING);
 }
 function isOwnedSpawnRepairTarget(structure) {
   return isSpawnRepairTarget(structure) && structure.my === true;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -29235,7 +29235,7 @@ function hasOtherLoadedWorkerAssignedToRepairTarget(creep, structure) {
   return getRoomOwnedCreeps(creep.room).some(
     (worker) => {
       var _a;
-      return !isSameCreep(worker, creep) && ((_a = worker.memory) == null ? void 0 : _a.role) === "worker" && getUsedEnergy2(worker) > 0 && isWorkerAssignedToRepairTarget(worker, structure);
+      return !isSameCreep(worker, creep) && ((_a = worker.memory) == null ? void 0 : _a.role) === "worker" && getUsedEnergy2(worker) > 0 && getActiveWorkParts2(worker) > 0 && isWorkerAssignedToRepairTarget(worker, structure);
     }
   );
 }

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -85,6 +85,7 @@ export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
 export const CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 export const CRITICAL_SPAWN_REPAIR_HITS_RATIO = 0.25;
 export const EMERGENCY_RAMPART_REPAIR_HITS_CEILING = 10_000;
+export const ACTIVE_RAMPART_REPAIR_HITS_CEILING = 120_000;
 // Keep routine barrier maintenance above the monitor's critical rampart damage band.
 export const IDLE_RAMPART_REPAIR_HITS_CEILING = 150_000;
 export const TOWER_REFILL_ENERGY_FLOOR = 500;
@@ -429,6 +430,11 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
         return constructionBacklogEnergyAcquisitionTask;
       }
 
+      const activeRampartRepairEnergyAcquisitionTask = selectActiveRampartRepairEnergyAcquisitionTask(creep);
+      if (activeRampartRepairEnergyAcquisitionTask) {
+        return activeRampartRepairEnergyAcquisitionTask;
+      }
+
       const nearbyWorkerEnergyAcquisitionTask = selectNearbyWorkerEnergyAcquisitionTask(creep);
       if (nearbyWorkerEnergyAcquisitionTask) {
         return nearbyWorkerEnergyAcquisitionTask;
@@ -737,6 +743,15 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     return applyMinimumUsefulLoadPolicy(creep, {
       type: 'repair',
       targetId: threatenedBarrierRepairTarget.id as Id<Structure>
+    });
+  }
+
+  const activeRampartRepairTarget =
+    constructionSites.length === 0 ? selectActiveOwnedRampartRepairTarget(creep) : null;
+  if (activeRampartRepairTarget) {
+    return applyMinimumUsefulLoadPolicy(creep, {
+      type: 'repair',
+      targetId: activeRampartRepairTarget.id as Id<Structure>
     });
   }
 
@@ -6463,6 +6478,40 @@ function selectRoutineRampartMaintenanceRepairTarget(creep: Creep): StructureRam
   return selectAvailableRoutineRepairTarget(creep, computeRoutineRampartMaintenanceRepairTargets(creep.room));
 }
 
+function selectActiveRampartRepairEnergyAcquisitionTask(
+  creep: Creep
+): Extract<CreepTaskMemory, { type: 'harvest' | 'pickup' | 'withdraw' }> | null {
+  if (getFreeEnergyCapacity(creep) <= 0 || !selectActiveOwnedRampartRepairTarget(creep)) {
+    return null;
+  }
+
+  return selectWorkerEnergyCriticalAcquisitionTask(creep);
+}
+
+function selectActiveOwnedRampartRepairTarget(creep: Creep): StructureRampart | null {
+  if (
+    creep.room.controller?.my !== true ||
+    hasVisibleHostilePresence(creep.room) ||
+    !hasActiveRampartRepairEnergyReserve(creep.room)
+  ) {
+    return null;
+  }
+
+  const repairTargets = findVisibleRoomStructures(creep.room)
+    .filter(isActiveOwnedRampartRepairTarget)
+    .filter((structure) => hasActiveRampartRepairAssignmentCapacity(creep, structure));
+  if (repairTargets.length === 0) {
+    return null;
+  }
+
+  return repairTargets.sort(compareRepairTargets)[0];
+}
+
+function hasActiveRampartRepairEnergyReserve(room: Room): boolean {
+  const energyAvailable = getRoomEnergyAvailable(room);
+  return energyAvailable === null || energyAvailable >= CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD;
+}
+
 function getRoutineBarrierMaintenanceRepairTargets(room: Room): Array<StructureRampart | StructureWall> {
   const gameTick = getGameTick();
   const roomName = getRoomName(room);
@@ -6768,6 +6817,13 @@ function hasRoutineRepairAssignmentCapacity(creep: Creep, structure: RepairableW
   );
 }
 
+function hasActiveRampartRepairAssignmentCapacity(creep: Creep, structure: StructureRampart): boolean {
+  return (
+    isWorkerAssignedToRepairTarget(creep, structure) ||
+    !hasOtherLoadedWorkerAssignedToRepairTarget(creep, structure)
+  );
+}
+
 function isUrgentBarrierRepairTarget(structure: RepairableWorkerStructure): boolean {
   return (
     isWorkerBarrierRepairStructure(structure) &&
@@ -6780,6 +6836,16 @@ function hasOtherWorkerAssignedToRepairTarget(creep: Creep, structure: Repairabl
     (worker) =>
       !isSameCreep(worker, creep) &&
       worker.memory?.role === 'worker' &&
+      isWorkerAssignedToRepairTarget(worker, structure)
+  );
+}
+
+function hasOtherLoadedWorkerAssignedToRepairTarget(creep: Creep, structure: RepairableWorkerStructure): boolean {
+  return getRoomOwnedCreeps(creep.room).some(
+    (worker) =>
+      !isSameCreep(worker, creep) &&
+      worker.memory?.role === 'worker' &&
+      getUsedEnergy(worker) > 0 &&
       isWorkerAssignedToRepairTarget(worker, structure)
   );
 }
@@ -6855,6 +6921,15 @@ function isEmergencyOwnedRampartRepairTarget(structure: AnyStructure): structure
     isOwnedRampart(structure) &&
     !isWorkerRepairTargetComplete(structure) &&
     structure.hits <= EMERGENCY_RAMPART_REPAIR_HITS_CEILING
+  );
+}
+
+function isActiveOwnedRampartRepairTarget(structure: AnyStructure): structure is StructureRampart {
+  return (
+    matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart') &&
+    isOwnedRampart(structure) &&
+    !isWorkerRepairTargetComplete(structure) &&
+    structure.hits <= Math.min(structure.hitsMax, ACTIVE_RAMPART_REPAIR_HITS_CEILING)
   );
 }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -6478,14 +6478,22 @@ function selectRoutineRampartMaintenanceRepairTarget(creep: Creep): StructureRam
   return selectAvailableRoutineRepairTarget(creep, computeRoutineRampartMaintenanceRepairTargets(creep.room));
 }
 
-function selectActiveRampartRepairEnergyAcquisitionTask(
+export function selectActiveRampartRepairEnergyAcquisitionTask(
   creep: Creep
 ): Extract<CreepTaskMemory, { type: 'harvest' | 'pickup' | 'withdraw' }> | null {
-  if (getFreeEnergyCapacity(creep) <= 0 || !selectActiveOwnedRampartRepairTarget(creep)) {
+  if (
+    getFreeEnergyCapacity(creep) <= 0 ||
+    hasVisibleConstructionSites(creep.room) ||
+    !selectActiveOwnedRampartRepairTarget(creep)
+  ) {
     return null;
   }
 
   return selectWorkerEnergyCriticalAcquisitionTask(creep);
+}
+
+function hasVisibleConstructionSites(room: Room): boolean {
+  return typeof FIND_CONSTRUCTION_SITES === 'number' && room.find(FIND_CONSTRUCTION_SITES).length > 0;
 }
 
 function selectActiveOwnedRampartRepairTarget(creep: Creep): StructureRampart | null {
@@ -6925,11 +6933,11 @@ function isEmergencyOwnedRampartRepairTarget(structure: AnyStructure): structure
 }
 
 function isActiveOwnedRampartRepairTarget(structure: AnyStructure): structure is StructureRampart {
+  const repairCeiling = Math.min(structure.hitsMax, ACTIVE_RAMPART_REPAIR_HITS_CEILING);
   return (
     matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart') &&
     isOwnedRampart(structure) &&
-    !isWorkerRepairTargetComplete(structure) &&
-    structure.hits <= Math.min(structure.hitsMax, ACTIVE_RAMPART_REPAIR_HITS_CEILING)
+    structure.hits < repairCeiling
   );
 }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -6854,6 +6854,7 @@ function hasOtherLoadedWorkerAssignedToRepairTarget(creep: Creep, structure: Rep
       !isSameCreep(worker, creep) &&
       worker.memory?.role === 'worker' &&
       getUsedEnergy(worker) > 0 &&
+      getActiveWorkParts(worker) > 0 &&
       isWorkerAssignedToRepairTarget(worker, structure)
   );
 }

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -14599,6 +14599,7 @@ describe('selectWorkerTask', () => {
 
     expect(estimateNearTermSpawnExtensionRefillReserve(room)).toBe(550);
     expect(selectWorkerTask(creep)).toBeNull();
+    expect(repairer.getActiveBodyparts).toHaveBeenCalledWith('work');
   });
 
   it('ignores active rampart repair coverage from a loaded worker without active WORK parts', () => {
@@ -14650,6 +14651,7 @@ describe('selectWorkerTask', () => {
 
     expect(estimateNearTermSpawnExtensionRefillReserve(room)).toBe(550);
     expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'rampart-active-decay' });
+    expect(disabledRepairer.getActiveBodyparts).toHaveBeenCalledWith('work');
   });
 
   it.each([

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -14580,6 +14580,7 @@ describe('selectWorkerTask', () => {
     });
     const repairer = {
       name: 'Repairer',
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
       memory: {
         role: 'worker',
         colony: 'E29N55',
@@ -14598,6 +14599,57 @@ describe('selectWorkerTask', () => {
 
     expect(estimateNearTermSpawnExtensionRefillReserve(room)).toBe(550);
     expect(selectWorkerTask(creep)).toBeNull();
+  });
+
+  it('ignores active rampart repair coverage from a loaded worker without active WORK parts', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const busyFullSpawn = {
+      id: 'spawn-busy',
+      structureType: 'spawn',
+      spawning: { remainingTime: 10 },
+      store: { getFreeCapacity: jest.fn().mockReturnValue(0) }
+    } as unknown as StructureSpawn;
+    const rampart = makeStructure(
+      'rampart-active-decay',
+      'rampart' as StructureConstant,
+      119_801,
+      300_000_000,
+      { my: true }
+    );
+    const room = makeWorkerTaskRoom({
+      name: 'E29N55',
+      controller,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      myStructures: [busyFullSpawn as AnyOwnedStructure],
+      structures: [rampart]
+    });
+    const disabledRepairer = {
+      name: 'DisabledRepairer',
+      getActiveBodyparts: jest.fn().mockReturnValue(0),
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'repair', targetId: 'rampart-active-decay' as Id<Structure> }
+      },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    const creep = {
+      name: 'ReplacementRepairer',
+      memory: { role: 'worker', colony: 'E29N55' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ DisabledRepairer: disabledRepairer, ReplacementRepairer: creep });
+
+    expect(estimateNearTermSpawnExtensionRefillReserve(room)).toBe(550);
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'rampart-active-decay' });
   });
 
   it.each([

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -24,6 +24,7 @@ import {
   canSpendWorkerEnergyOnConstructionSite,
   canUpgradeController,
   isUpgraderBoostActive,
+  selectActiveRampartRepairEnergyAcquisitionTask,
   selectWorkerEnergyCriticalAcquisitionTask,
   isWorkerRepairTargetComplete,
   selectWorkerTask,
@@ -14378,6 +14379,86 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'e29n56-rampart-alert-buffer' });
+  });
+
+  it('does not acquire active rampart repair energy while construction sites remain', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const extensionSite = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
+    const source = makeSource('source1', 20, 20);
+    const rampart = makeStructure(
+      'rampart-active-alert',
+      'rampart' as StructureConstant,
+      ACTIVE_RAMPART_REPAIR_HITS_CEILING - 1,
+      300_000,
+      { my: true }
+    );
+    const creep = {
+      name: 'EmptyRepairer',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room: makeWorkerTaskRoom({
+        constructionSites: [extensionSite],
+        controller,
+        energyAvailable: 550,
+        energyCapacityAvailable: 550,
+        sources: [source],
+        structures: [rampart]
+      })
+    } as unknown as Creep;
+
+    expect(selectActiveRampartRepairEnergyAcquisitionTask(creep)).toBeNull();
+  });
+
+  it('repairs bootstrap-gated active ramparts before controller boost work', () => {
+    const structures: AnyStructure[] = [];
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      progress: 40_727,
+      progressTotal: 45_000,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N55',
+      controller,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      structures
+    });
+    const activeSpawn = makeStructure('spawn1', 'spawn' as StructureConstant, 5_000, 5_000, {
+      my: true,
+      pos: makeRoomPosition(17, 24, 'E29N55')
+    });
+    const rampart = makeStructure(
+      'rampart-bootstrap-active-alert',
+      'rampart' as StructureConstant,
+      80_000,
+      300_000,
+      { my: true, room }
+    );
+    structures.push(activeSpawn, rampart);
+    const creep = {
+      name: 'BootstrapBoostWorker',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        controllerUpgrade: { roomName: 'E29N55', controllerId: 'controller1' }
+      },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+
+    expect(isWorkerRepairTargetComplete(rampart)).toBe(true);
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'rampart-bootstrap-active-alert' });
   });
 
   it('repairs E29N55 active-decay ramparts before controller upgrade pressure', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1,5 +1,6 @@
 import {
   CONTROLLER_DOWNGRADE_GUARD_TICKS,
+  ACTIVE_RAMPART_REPAIR_HITS_CEILING,
   CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD,
   CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO,
   CRITICAL_SPAWN_REPAIR_HITS_RATIO,
@@ -14890,6 +14891,42 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('repairs repeated active-alert rampart damage before controller boost below the construction floor', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      progress: 40_727,
+      progressTotal: 45_000,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const rampart = makeStructure(
+      'e29n56-repeated-alert-rampart',
+      'rampart' as StructureConstant,
+      ACTIVE_RAMPART_REPAIR_HITS_CEILING - 2_199,
+      300_000,
+      { my: true }
+    );
+    const creep = {
+      name: 'E29N56BoostWorker',
+      memory: {
+        role: 'worker',
+        colony: 'E29N56',
+        controllerUpgrade: { roomName: 'E29N56', controllerId: 'controller1' }
+      },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        name: 'E29N56',
+        controller,
+        energyAvailable: 299,
+        energyCapacityAvailable: 550,
+        structures: [rampart]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'e29n56-repeated-alert-rampart' });
   });
 
   it('prioritizes barrier repair in threatened rooms before ordinary repair work', () => {


### PR DESCRIPTION
## Summary
- adds an active safe-rampart repair band for owned rooms below 120k hits when no hostiles are visible
- lets workers acquire energy for that active rampart path before ordinary refill/upgrade choices
- adds a regression for the E29N56 repeated-alert condition that was still losing rampart hits below the active band

## Verification
- `git diff --check`
- `npm run typecheck` from `prod/`
- `npm test -- --runInBand` from `prod/` (103 suites / 2067 tests)
- `npm run build` from `prod/`

## Safety
- No official MMO writes in this PR.
- Runtime validation still requires merge + deploy + fresh monitor evidence before the incident issue can be closed.
- Related to #1487.

## Universal task Done gate
- [x] Task type: code.
- [x] Expected observable outcome / named deliverable: workers in a safe owned room prioritize an active rampart below 120k hits over controller boost/upgrade when the repeated-alert condition is present.
- [x] Non-goals / accepted substitutes: no official MMO write, no runtime deploy, and no issue closure in this PR.
- [x] Verification evidence required before Done: controller-side `git diff --check`, prod typecheck, full Jest, and prod build all passed before PR creation.
- [x] Project Evidence / Next action / Blocked by: issue #1487 Project fields point at this PR and require CI, CodeRabbit, merge, deploy, and post-deploy monitor evidence.
- [x] Post-merge/deploy/runtime proof: runtime proof is outside this code PR; the required later evidence is a deployed build plus fresh E29N56 monitor showing alert clearance or rampart recovery.
- [x] Named deliverable proof: `prod/src/tasks/workerTasks.ts`, `prod/test/workerTasks.test.ts`, and regenerated `prod/dist/main.js` include the active rampart repair path and focused regression.
