### PR TITLE
fix: route CPU bucket critical runtime alerts

### DIFF
--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -60,6 +60,7 @@ WORKER_ASSIGNMENT_GAP_RECOVERY_TICK_TOLERANCE = 0
 RUNTIME_SUMMARY_TICK_METADATA_KEY = "__runtimeSummaryTick"
 RUNTIME_SUMMARY_ARTIFACT_TIMESTAMP_METADATA_KEY = "__runtimeSummaryArtifactTimestamp"
 RUNTIME_SUMMARY_SOURCE_METADATA_KEY = "__runtimeSummarySource"
+RUNTIME_SUMMARY_CPU_METADATA_KEY = "__runtimeSummaryCpu"
 MONITOR_RUNTIME_SUMMARY_SOURCE = "screeps-runtime-monitor"
 ASSIGNED_WORKER_TASK_NAMES = ("harvest", "transfer", "build", "repair", "upgrade")
 BUILD_BLOCKED_REASON_PATHS = (
@@ -110,6 +111,15 @@ ENERGY_BUFFER_UNHEALTHY_REQUIRED_CONSECUTIVE = 2
 ENERGY_BUFFER_UNHEALTHY_ROUTES = [
     {"issue": "#906", "topic": "metric_taxonomy"},
     {"issue": "#907", "topic": "reward_decisions"},
+]
+CPU_BUCKET_LOW_KIND = "cpu_bucket_low"
+CPU_BUCKET_CRITICAL_KIND = "cpu_bucket_critical"
+CPU_BUCKET_LOW_THRESHOLD = 1_000
+CPU_BUCKET_CRITICAL_THRESHOLD = 100
+CPU_BUCKET_ROUTES = [
+    {"issue": "#1490", "topic": "runtime_alert"},
+    {"issue": "#906", "topic": "metric_taxonomy"},
+    {"issue": "#924", "topic": "scorecard_gate"},
 ]
 CONSTRUCTION_DEADLOCK_KIND = "construction_deadlock_ticks"
 CONSTRUCTION_DEADLOCK_P1_TICKS = 100
@@ -276,6 +286,28 @@ TACTICAL_CATEGORY_RULES: dict[str, dict[str, Any]] = {
         "decision": "owner_action_or_codex_hotfix",
         "actions": ["capture_runtime_context", "inspect_resource_state", "start_hotfix_gate"],
     },
+    CPU_BUCKET_CRITICAL_KIND: {
+        "severity": "critical",
+        "decision": "codex_hotfix",
+        "actions": ["capture_runtime_context", "inspect_recent_deploy", "start_hotfix_gate"],
+        "metadata": {
+            "metric": "cpu.bucket",
+            "related_issues": ["#1490", "#906", "#924"],
+            "thresholds": {"P1": CPU_BUCKET_LOW_THRESHOLD, "P0": CPU_BUCKET_CRITICAL_THRESHOLD},
+            "routes_to": CPU_BUCKET_ROUTES,
+        },
+    },
+    CPU_BUCKET_LOW_KIND: {
+        "severity": "high",
+        "decision": "codex_hotfix",
+        "actions": ["capture_runtime_context", "inspect_recent_deploy", "start_hotfix_gate"],
+        "metadata": {
+            "metric": "cpu.bucket",
+            "related_issues": ["#1490", "#906", "#924"],
+            "thresholds": {"P1": CPU_BUCKET_LOW_THRESHOLD, "P0": CPU_BUCKET_CRITICAL_THRESHOLD},
+            "routes_to": CPU_BUCKET_ROUTES,
+        },
+    },
     "energy_buffer_unhealthy": {
         "severity": "high",
         "decision": "metric_taxonomy_and_reward_decision_followup",
@@ -341,6 +373,8 @@ TACTICAL_REASON_CATEGORY_MAP = {
     "runtime_exception": ["runtime_exception"],
     "runtime_deadlock": ["runtime_deadlock"],
     "resource_crisis": ["resource_crisis"],
+    CPU_BUCKET_CRITICAL_KIND: [CPU_BUCKET_CRITICAL_KIND],
+    CPU_BUCKET_LOW_KIND: [CPU_BUCKET_LOW_KIND],
     "energy_buffer_unhealthy": ["energy_buffer_unhealthy"],
     CONSTRUCTION_DEADLOCK_KIND: [CONSTRUCTION_DEADLOCK_KIND],
     "worker_idle_collapse": ["worker_idle_collapse"],
@@ -1217,6 +1251,156 @@ def format_energy_value(value: int | float | None) -> str:
     return str(value)
 
 
+def cpu_bucket_metadata() -> dict[str, Any]:
+    return {
+        "metric": "cpu.bucket",
+        "related_issues": [str(route["issue"]) for route in CPU_BUCKET_ROUTES],
+        "thresholds": {"P1": CPU_BUCKET_LOW_THRESHOLD, "P0": CPU_BUCKET_CRITICAL_THRESHOLD},
+        "routes_to": [dict(route) for route in CPU_BUCKET_ROUTES],
+    }
+
+
+def string_list_values(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str) and item]
+
+
+def runtime_cpu_signal_values(room: dict[str, Any], field: str) -> list[str]:
+    values: list[str] = []
+    for candidate in (
+        nested_value(room, RUNTIME_SUMMARY_CPU_METADATA_KEY, field),
+        nested_value(room, "cpu", field),
+        room.get(field),
+    ):
+        for item in string_list_values(candidate):
+            if item not in values:
+                values.append(item)
+    return values
+
+
+def runtime_cpu_pressure(room: dict[str, Any]) -> str | None:
+    for candidate in (
+        nested_value(room, RUNTIME_SUMMARY_CPU_METADATA_KEY, "pressure"),
+        nested_value(room, "cpu", "pressure"),
+        room.get("pressure"),
+    ):
+        if isinstance(candidate, str) and candidate in {"normal", "degraded", "critical"}:
+            return candidate
+    return None
+
+
+def runtime_cpu_bucket(room: dict[str, Any]) -> int | float | None:
+    return first_number_value(
+        room,
+        ("cpuBucket",),
+        ("cpu", "bucket"),
+        (RUNTIME_SUMMARY_CPU_METADATA_KEY, "bucket"),
+        ("bucket",),
+    )
+
+
+def runtime_cpu_used(room: dict[str, Any]) -> int | float | None:
+    return first_number_value(
+        room,
+        ("cpuUsed",),
+        ("cpu", "used"),
+        (RUNTIME_SUMMARY_CPU_METADATA_KEY, "used"),
+    )
+
+
+def runtime_cpu_limit(room: dict[str, Any]) -> int | float | None:
+    return first_number_value(
+        room,
+        ("cpuLimit",),
+        ("cpu", "limit"),
+        (RUNTIME_SUMMARY_CPU_METADATA_KEY, "limit"),
+    )
+
+
+def runtime_low_bucket_ticks(room: dict[str, Any]) -> int | float | None:
+    return first_number_value(
+        room,
+        ("lowBucketTicks",),
+        ("cpu", "lowBucketTicks"),
+        (RUNTIME_SUMMARY_CPU_METADATA_KEY, "lowBucketTicks"),
+    )
+
+
+def detect_cpu_bucket_kind(runtime_room: dict[str, Any] | None) -> str | None:
+    if not isinstance(runtime_room, dict):
+        return None
+
+    bucket = runtime_cpu_bucket(runtime_room)
+    pressure = runtime_cpu_pressure(runtime_room)
+    alerts = set(runtime_cpu_signal_values(runtime_room, "alerts"))
+    reasons = set(runtime_cpu_signal_values(runtime_room, "reasons"))
+
+    critical_bucket = (
+        pressure == "critical"
+        or "criticalBucket" in reasons
+        or (bucket is not None and bucket <= CPU_BUCKET_CRITICAL_THRESHOLD)
+    )
+    if critical_bucket:
+        return CPU_BUCKET_CRITICAL_KIND
+
+    low_bucket = (
+        "lowBucket" in alerts
+        or "lowBucket" in reasons
+        or (bucket is not None and bucket < CPU_BUCKET_LOW_THRESHOLD)
+    )
+    if low_bucket:
+        return CPU_BUCKET_LOW_KIND
+    return None
+
+
+def build_cpu_bucket_reason(ref: RoomRef, runtime_room: dict[str, Any], kind: str) -> dict[str, Any]:
+    bucket = runtime_cpu_bucket(runtime_room)
+    used = runtime_cpu_used(runtime_room)
+    limit = runtime_cpu_limit(runtime_room)
+    pressure = runtime_cpu_pressure(runtime_room)
+    alerts = runtime_cpu_signal_values(runtime_room, "alerts")
+    reasons = runtime_cpu_signal_values(runtime_room, "reasons")
+    low_bucket_ticks = runtime_low_bucket_ticks(runtime_room)
+    critical = kind == CPU_BUCKET_CRITICAL_KIND
+    threshold = CPU_BUCKET_CRITICAL_THRESHOLD if critical else CPU_BUCKET_LOW_THRESHOLD
+    severity = "critical" if critical else "high"
+    priority = "P0" if critical else "P1"
+    return {
+        "kind": kind,
+        "room": ref.key,
+        "room_name": ref.room,
+        "severity": severity,
+        "priority": priority,
+        "cpuBucket": bucket,
+        "cpu_bucket": bucket,
+        "bucket": bucket,
+        "cpuUsed": used,
+        "cpuLimit": limit,
+        "pressure": pressure,
+        "alerts": alerts,
+        "reasons": reasons,
+        "lowBucketTicks": low_bucket_ticks,
+        "threshold": threshold,
+        "low_bucket_threshold": CPU_BUCKET_LOW_THRESHOLD,
+        "critical_bucket_threshold": CPU_BUCKET_CRITICAL_THRESHOLD,
+        "metadata": cpu_bucket_metadata(),
+        "message": (
+            f"{kind} in {ref.key}: cpu bucket {format_energy_value(bucket)} below "
+            f"{threshold} threshold; pressure={pressure or 'unknown'}, alerts={alerts or []}, "
+            f"reasons={reasons or []}."
+        ),
+        "signature": f"{kind}:{ref.key}",
+    }
+
+
+def detect_cpu_bucket_reason(ref: RoomRef, runtime_room: dict[str, Any] | None) -> dict[str, Any] | None:
+    kind = detect_cpu_bucket_kind(runtime_room)
+    if kind is None or not isinstance(runtime_room, dict):
+        return None
+    return build_cpu_bucket_reason(ref, runtime_room, kind)
+
+
 def build_energy_buffer_unhealthy_reason(
     ref: RoomRef,
     room: dict[str, Any],
@@ -2067,6 +2251,10 @@ def evaluate_room_alert(
     )
     if construction_deadlock_candidate is not None:
         detected.append(construction_deadlock_candidate)
+
+    cpu_bucket_candidate = detect_cpu_bucket_reason(snapshot.ref, runtime_room_summary)
+    if cpu_bucket_candidate is not None:
+        detected.append(cpu_bucket_candidate)
 
     previous_energy_buffer_unhealthy_count = number_value(rule_counts.get(ENERGY_BUFFER_UNHEALTHY_KIND)) or 0
     energy_buffer_unhealthy_candidate = detect_energy_buffer_unhealthy_reason(
@@ -3492,6 +3680,35 @@ def runtime_summary_room_has_worker_idle_fields(room: dict[str, Any]) -> bool:
     )
 
 
+def runtime_summary_payload_has_cpu_fields(payload: dict[str, Any]) -> bool:
+    cpu = payload.get("cpu")
+    if not isinstance(cpu, dict):
+        return False
+    return any(
+        key in cpu
+        for key in (
+            "bucket",
+            "pressure",
+            "alerts",
+            "reasons",
+            "lowBucketTicks",
+            "bucketEmptyTicks",
+        )
+    )
+
+
+def runtime_summary_room_has_cpu_fields(room: dict[str, Any]) -> bool:
+    return any(key in room for key in ("cpuBucket", "cpu", "bucket", "pressure", "alerts", "reasons"))
+
+
+def runtime_summary_room_has_monitor_alert_fields(room: dict[str, Any], payload: dict[str, Any]) -> bool:
+    return (
+        runtime_summary_room_has_worker_idle_fields(room)
+        or runtime_summary_room_has_cpu_fields(room)
+        or runtime_summary_payload_has_cpu_fields(payload)
+    )
+
+
 def parse_runtime_summary_line(line: str) -> dict[str, Any] | None:
     stripped = line.strip()
     if not stripped.startswith(RUNTIME_SUMMARY_PREFIX):
@@ -3571,6 +3788,9 @@ def runtime_summary_room_with_metadata(payload: dict[str, Any], path: Path, room
         result[RUNTIME_SUMMARY_SOURCE_METADATA_KEY] = source
     elif path.name.startswith("runtime-summary-monitor-"):
         result[RUNTIME_SUMMARY_SOURCE_METADATA_KEY] = MONITOR_RUNTIME_SUMMARY_SOURCE
+    cpu = payload.get("cpu")
+    if isinstance(cpu, dict):
+        result[RUNTIME_SUMMARY_CPU_METADATA_KEY] = dict(cpu)
     return result
 
 
@@ -3606,7 +3826,7 @@ def load_latest_runtime_room_summaries(
             rooms = payload_runtime_rooms(payload)
             payload_explicit_shards_by_room = runtime_summary_explicit_shards_by_room(rooms)
             for room in rooms:
-                if not runtime_summary_room_has_worker_idle_fields(room):
+                if not runtime_summary_room_has_monitor_alert_fields(room, payload):
                     continue
                 for ref in refs:
                     if not runtime_summary_room_matches(
@@ -4457,6 +4677,18 @@ def threshold_exceeds_capacity_reason(room: dict[str, Any]) -> dict[str, Any] | 
     }
 
 
+def runtime_summary_room_ref(room: dict[str, Any]) -> RoomRef:
+    room_ref = room.get("room")
+    if isinstance(room_ref, str) and "/" in room_ref:
+        shard, room_name = room_ref.split("/", 1)
+        if shard and room_name:
+            return RoomRef(shard=shard, room=room_name)
+
+    room_name = runtime_summary_room_name(room)
+    shard = runtime_summary_room_shard(room)
+    return RoomRef(shard=shard or "unknown", room=room_name or str(room_ref or "unknown"))
+
+
 def runtime_summary_lookup_keys(room: dict[str, Any]) -> list[str]:
     keys: list[str] = []
     room_ref = room.get("room")
@@ -4551,6 +4783,9 @@ def evaluate_postdeploy_health_gate(summary_payload: dict[str, Any], alert_paylo
             threshold_reason = threshold_exceeds_capacity_reason(room)
             if threshold_reason is not None:
                 reasons.append(threshold_reason)
+            cpu_reason = detect_cpu_bucket_reason(runtime_summary_room_ref(room), room)
+            if cpu_reason is not None:
+                reasons.append(cpu_reason)
             if owner_missing:
                 creeps = 0
                 spawns = 0

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -3830,9 +3830,42 @@ def runtime_cpu_summary_room(ref: RoomRef, cpu: dict[str, Any]) -> dict[str, Any
     used = number_value(cpu.get("used"))
     if used is not None:
         result["cpuUsed"] = used
+    limit = number_value(cpu.get("limit"))
+    if limit is not None:
+        result["cpuLimit"] = limit
     bucket = number_value(cpu.get("bucket"))
     if bucket is not None:
         result["cpuBucket"] = bucket
+    low_bucket_ticks = number_value(cpu.get("lowBucketTicks"))
+    if low_bucket_ticks is not None:
+        result["lowBucketTicks"] = low_bucket_ticks
+    return result
+
+
+def runtime_summary_room_with_cpu_fields(base: dict[str, Any], cpu_room: dict[str, Any]) -> dict[str, Any]:
+    result = dict(base)
+    for field in ("room", "roomName", "shard"):
+        if field not in result and field in cpu_room:
+            result[field] = cpu_room[field]
+    cpu_metadata = as_dict(cpu_room.get(RUNTIME_SUMMARY_CPU_METADATA_KEY))
+    if cpu_metadata:
+        result[RUNTIME_SUMMARY_CPU_METADATA_KEY] = dict(cpu_metadata)
+    nested_cpu = as_dict(cpu_room.get("cpu"))
+    if nested_cpu:
+        result["cpu"] = dict(nested_cpu)
+    for field in (
+        "cpuBucket",
+        "cpuUsed",
+        "cpuLimit",
+        "lowBucketTicks",
+        "bucketEmptyTicks",
+        "bucket",
+        "pressure",
+        "alerts",
+        "reasons",
+    ):
+        if field in cpu_room:
+            result[field] = cpu_room[field]
     return result
 
 
@@ -3852,10 +3885,11 @@ def load_latest_runtime_room_summaries(
         return {}
 
     ambiguous_room_names = ambiguous_runtime_room_names([*refs, *(disambiguation_refs or [])])
-    result: dict[str, dict[str, Any]] = {}
-    result_keys: dict[str, tuple[bool, int, bool, float, int, int, str]] = {}
-    result_freshness_keys: dict[str, tuple[bool, float, int, bool, int, str]] = {}
-    compact_cpu_result_keys: set[str] = set()
+    runtime_result: dict[str, dict[str, Any]] = {}
+    runtime_result_keys: dict[str, tuple[bool, int, bool, float, int, int, str]] = {}
+    runtime_cpu_freshness_keys: dict[str, tuple[bool, float, int, bool, int, str]] = {}
+    cpu_result: dict[str, dict[str, Any]] = {}
+    cpu_freshness_keys: dict[str, tuple[bool, float, int, bool, int, str]] = {}
     for path in paths:
         try:
             lines = path.read_text(encoding="utf-8").splitlines()
@@ -3864,18 +3898,20 @@ def load_latest_runtime_room_summaries(
             continue
 
         for line_index, line in reversed(list(enumerate(lines))):
+            is_cpu_summary_line = line.strip().startswith(RUNTIME_CPU_SUMMARY_PREFIX)
             cpu_payload = parse_runtime_cpu_summary_line(line)
+            if is_cpu_summary_line and cpu_payload is None:
+                warnings.append(f"runtime-summary artifact ignored malformed #cpu-summary {path.name}:{line_index + 1}")
+                continue
             if cpu_payload is not None:
                 cpu = as_dict(cpu_payload.get("cpu"))
                 candidate_freshness_key = runtime_summary_freshness_key(cpu_payload, path, line_index)
                 for ref in refs:
-                    if candidate_freshness_key <= result_freshness_keys.get(ref.key, (False, -1.0, -1, False, -1, "")):
+                    if candidate_freshness_key <= cpu_freshness_keys.get(ref.key, (False, -1.0, -1, False, -1, "")):
                         continue
                     room = runtime_cpu_summary_room(ref, cpu)
-                    result[ref.key] = runtime_summary_room_with_metadata(cpu_payload, path, room)
-                    result_keys[ref.key] = runtime_summary_candidate_key(cpu_payload, path, line_index, room)
-                    result_freshness_keys[ref.key] = candidate_freshness_key
-                    compact_cpu_result_keys.add(ref.key)
+                    cpu_result[ref.key] = runtime_summary_room_with_metadata(cpu_payload, path, room)
+                    cpu_freshness_keys[ref.key] = candidate_freshness_key
                 continue
 
             payload = parse_runtime_summary_line(line)
@@ -3883,6 +3919,7 @@ def load_latest_runtime_room_summaries(
                 continue
             rooms = payload_runtime_rooms(payload)
             payload_explicit_shards_by_room = runtime_summary_explicit_shards_by_room(rooms)
+            candidate_freshness_key = runtime_summary_freshness_key(payload, path, line_index)
             for room in rooms:
                 if not runtime_summary_room_has_monitor_alert_fields(room, payload):
                     continue
@@ -3895,18 +3932,37 @@ def load_latest_runtime_room_summaries(
                     ):
                         continue
                     candidate_key = runtime_summary_candidate_key(payload, path, line_index, room)
-                    candidate_freshness_key = runtime_summary_freshness_key(payload, path, line_index)
-                    if ref.key in compact_cpu_result_keys:
-                        if candidate_freshness_key <= result_freshness_keys.get(ref.key, (False, -1.0, -1, False, -1, "")):
-                            continue
-                    elif candidate_key <= result_keys.get(ref.key, (False, -1, False, -1.0, -1, -1, "")):
+                    candidate_room = runtime_summary_room_with_metadata(payload, path, room)
+                    if runtime_summary_room_has_cpu_fields(room) or runtime_summary_payload_has_cpu_fields(payload):
+                        if candidate_freshness_key > cpu_freshness_keys.get(ref.key, (False, -1.0, -1, False, -1, "")):
+                            cpu_result[ref.key] = candidate_room
+                            cpu_freshness_keys[ref.key] = candidate_freshness_key
+                    if candidate_key <= runtime_result_keys.get(ref.key, (False, -1, False, -1.0, -1, -1, "")):
                         continue
-                    result[ref.key] = runtime_summary_room_with_metadata(payload, path, room)
-                    result_keys[ref.key] = candidate_key
-                    result_freshness_keys[ref.key] = candidate_freshness_key
-                    compact_cpu_result_keys.discard(ref.key)
+                    runtime_result[ref.key] = candidate_room
+                    runtime_result_keys[ref.key] = candidate_key
+                    if runtime_summary_room_has_cpu_fields(room) or runtime_summary_payload_has_cpu_fields(payload):
+                        runtime_cpu_freshness_keys[ref.key] = candidate_freshness_key
                     break
 
+    result: dict[str, dict[str, Any]] = {}
+    for ref in refs:
+        runtime_room = runtime_result.get(ref.key)
+        cpu_room = cpu_result.get(ref.key)
+        if runtime_room is None and cpu_room is None:
+            continue
+        if runtime_room is None:
+            result[ref.key] = dict(cpu_room) if cpu_room is not None else {}
+            continue
+        if cpu_room is None:
+            result[ref.key] = dict(runtime_room)
+            continue
+        cpu_key = cpu_freshness_keys.get(ref.key)
+        runtime_cpu_key = runtime_cpu_freshness_keys.get(ref.key)
+        if cpu_key is not None and (runtime_cpu_key is None or cpu_key > runtime_cpu_key):
+            result[ref.key] = runtime_summary_room_with_cpu_fields(runtime_room, cpu_room)
+        else:
+            result[ref.key] = dict(runtime_room)
     return result
 
 
@@ -4781,10 +4837,11 @@ def load_runtime_summary_artifact_rooms(artifact_path: str) -> dict[str, dict[st
         if payload is None:
             continue
         for room in payload_runtime_rooms(payload):
-            if not runtime_summary_room_has_worker_idle_fields(room):
+            if not runtime_summary_room_has_monitor_alert_fields(room, payload):
                 continue
+            runtime_room = runtime_summary_room_with_metadata(payload, Path(artifact_path), room)
             for key in runtime_summary_lookup_keys(room):
-                result.setdefault(key, room)
+                result.setdefault(key, runtime_room)
         if result:
             return result
 
@@ -4815,6 +4872,8 @@ def enrich_room_summaries_from_runtime_artifact(room_summaries: list[Any], artif
             buffer_health = as_dict(runtime_room.get("energyBufferHealth"))
             if buffer_health:
                 room["energyBufferHealth"] = buffer_health
+        if runtime_summary_room_has_cpu_fields(runtime_room) or as_dict(runtime_room.get(RUNTIME_SUMMARY_CPU_METADATA_KEY)):
+            room.update(runtime_summary_room_with_cpu_fields(room, runtime_room))
 
 
 def evaluate_postdeploy_health_gate(summary_payload: dict[str, Any], alert_payload: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -49,6 +49,7 @@ RAMPART_SAFE_DECAY_HITS_FLOOR = 10_000
 RAMPART_CRITICAL_DAMAGE_DELTA = 5_000
 RAMPART_CRITICAL_DAMAGE_HITS_CEILING = 121_000
 RUNTIME_SUMMARY_PREFIX = "#runtime-summary "
+RUNTIME_CPU_SUMMARY_PREFIX = "#cpu-summary "
 WORKER_IDLE_COLLAPSE_KIND = "worker_idle_collapse"
 WORKER_IDLE_COLLAPSE_TICK_THRESHOLD = 20
 WORKER_IDLE_COLLAPSE_REQUIRED_CONSECUTIVE = 2
@@ -3722,6 +3723,23 @@ def parse_runtime_summary_line(line: str) -> dict[str, Any] | None:
     return None
 
 
+def parse_runtime_cpu_summary_line(line: str) -> dict[str, Any] | None:
+    stripped = line.strip()
+    if not stripped.startswith(RUNTIME_CPU_SUMMARY_PREFIX):
+        return None
+    try:
+        cpu = json.loads(html.unescape(stripped[len(RUNTIME_CPU_SUMMARY_PREFIX) :]))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(cpu, dict):
+        return None
+
+    payload = {"type": "runtime-cpu-summary", "cpu": cpu}
+    if not runtime_summary_payload_has_cpu_fields(payload):
+        return None
+    return payload
+
+
 def payload_runtime_rooms(payload: dict[str, Any]) -> list[dict[str, Any]]:
     rooms = payload.get("rooms")
     if not isinstance(rooms, list):
@@ -3753,6 +3771,19 @@ def runtime_summary_log_paths(runtime_summary_dir: Path) -> list[Path]:
 
 def runtime_summary_payload_tick(payload: dict[str, Any]) -> int | None:
     return tick_number(payload.get("tick"))
+
+
+def runtime_summary_freshness_key(payload: dict[str, Any], path: Path, line_index: int) -> tuple[bool, float, int, bool, int, str]:
+    tick = runtime_summary_payload_tick(payload)
+    timestamp = runtime_summary_artifact_timestamp(path)
+    return (
+        timestamp is not None,
+        timestamp if timestamp is not None else -1.0,
+        line_index,
+        tick is not None,
+        tick if tick is not None else -1,
+        str(path),
+    )
 
 
 def runtime_summary_candidate_key(
@@ -3794,6 +3825,17 @@ def runtime_summary_room_with_metadata(payload: dict[str, Any], path: Path, room
     return result
 
 
+def runtime_cpu_summary_room(ref: RoomRef, cpu: dict[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {"room": ref.key, "roomName": ref.room, "shard": ref.shard}
+    used = number_value(cpu.get("used"))
+    if used is not None:
+        result["cpuUsed"] = used
+    bucket = number_value(cpu.get("bucket"))
+    if bucket is not None:
+        result["cpuBucket"] = bucket
+    return result
+
+
 def load_latest_runtime_room_summaries(
     runtime_summary_dir: Path,
     refs: list[RoomRef],
@@ -3812,6 +3854,8 @@ def load_latest_runtime_room_summaries(
     ambiguous_room_names = ambiguous_runtime_room_names([*refs, *(disambiguation_refs or [])])
     result: dict[str, dict[str, Any]] = {}
     result_keys: dict[str, tuple[bool, int, bool, float, int, int, str]] = {}
+    result_freshness_keys: dict[str, tuple[bool, float, int, bool, int, str]] = {}
+    compact_cpu_result_keys: set[str] = set()
     for path in paths:
         try:
             lines = path.read_text(encoding="utf-8").splitlines()
@@ -3820,6 +3864,20 @@ def load_latest_runtime_room_summaries(
             continue
 
         for line_index, line in reversed(list(enumerate(lines))):
+            cpu_payload = parse_runtime_cpu_summary_line(line)
+            if cpu_payload is not None:
+                cpu = as_dict(cpu_payload.get("cpu"))
+                candidate_freshness_key = runtime_summary_freshness_key(cpu_payload, path, line_index)
+                for ref in refs:
+                    if candidate_freshness_key <= result_freshness_keys.get(ref.key, (False, -1.0, -1, False, -1, "")):
+                        continue
+                    room = runtime_cpu_summary_room(ref, cpu)
+                    result[ref.key] = runtime_summary_room_with_metadata(cpu_payload, path, room)
+                    result_keys[ref.key] = runtime_summary_candidate_key(cpu_payload, path, line_index, room)
+                    result_freshness_keys[ref.key] = candidate_freshness_key
+                    compact_cpu_result_keys.add(ref.key)
+                continue
+
             payload = parse_runtime_summary_line(line)
             if payload is None:
                 continue
@@ -3837,10 +3895,16 @@ def load_latest_runtime_room_summaries(
                     ):
                         continue
                     candidate_key = runtime_summary_candidate_key(payload, path, line_index, room)
-                    if candidate_key <= result_keys.get(ref.key, (False, -1, False, -1.0, -1, -1, "")):
+                    candidate_freshness_key = runtime_summary_freshness_key(payload, path, line_index)
+                    if ref.key in compact_cpu_result_keys:
+                        if candidate_freshness_key <= result_freshness_keys.get(ref.key, (False, -1.0, -1, False, -1, "")):
+                            continue
+                    elif candidate_key <= result_keys.get(ref.key, (False, -1, False, -1.0, -1, -1, "")):
                         continue
                     result[ref.key] = runtime_summary_room_with_metadata(payload, path, room)
                     result_keys[ref.key] = candidate_key
+                    result_freshness_keys[ref.key] = candidate_freshness_key
+                    compact_cpu_result_keys.discard(ref.key)
                     break
 
     return result

--- a/scripts/screeps_runtime_summary_console_capture.py
+++ b/scripts/screeps_runtime_summary_console_capture.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Persist Screeps #runtime-summary console lines into local artifacts."""
+"""Persist Screeps runtime telemetry console lines into local artifacts."""
 
 from __future__ import annotations
 
@@ -21,6 +21,8 @@ import screeps_world_profiles as world_profiles
 
 
 DEFAULT_OUT_DIR = Path("/root/screeps/runtime-artifacts/runtime-summary-console")
+RUNTIME_CPU_SUMMARY_PREFIX = "#cpu-summary "
+RUNTIME_TELEMETRY_PREFIXES = (reducer.RUNTIME_SUMMARY_PREFIX, RUNTIME_CPU_SUMMARY_PREFIX)
 DEFAULT_API_URL = "https://screeps.com"
 DEFAULT_CONSOLE_CHANNELS = ("console",)
 DEFAULT_LIVE_TIMEOUT_SECONDS = 20.0
@@ -107,10 +109,14 @@ def iter_runtime_summary_lines(lines: Iterable[str]) -> Iterable[str]:
             yield normalized
 
 
+def is_runtime_telemetry_line(line: str) -> bool:
+    return any(line.startswith(prefix) for prefix in RUNTIME_TELEMETRY_PREFIXES)
+
+
 def normalize_runtime_summary_line(line: str) -> str | None:
-    if not line.startswith(reducer.RUNTIME_SUMMARY_PREFIX):
+    if not is_runtime_telemetry_line(line):
         line = html.unescape(line)
-    if not line.startswith(reducer.RUNTIME_SUMMARY_PREFIX):
+    if not is_runtime_telemetry_line(line):
         return None
     return line.rstrip("\r\n") + "\n"
 
@@ -488,8 +494,8 @@ class WorldProfileArgumentParser(argparse.ArgumentParser):
 def build_parser() -> argparse.ArgumentParser:
     parser = WorldProfileArgumentParser(
         description=(
-            "Persist only exact-prefix Screeps #runtime-summary console lines into a local artifact "
-            "that the KPI artifact bridge can scan."
+            "Persist only exact-prefix Screeps #runtime-summary and #cpu-summary console lines "
+            "into a local artifact that monitor and KPI tooling can scan."
         ),
     )
     world_profiles.add_world_profile_argument(parser)

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -647,6 +647,301 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(trigger["metadata"]["metric"], "constructionDeadlockTicks")
         self.assertEqual(trigger["metadata"]["thresholds"], {"P0": 500, "P1": 100})
 
+    def test_cpu_bucket_critical_runtime_summary_alerts_health_gate_and_tactical_response(self) -> None:
+        payload = {
+            "type": "runtime-summary",
+            "tick": 1200,
+            "cpu": {
+                "used": 30.14,
+                "limit": 70,
+                "bucket": 4,
+                "pressure": "critical",
+                "alerts": ["lowBucket"],
+                "reasons": ["criticalBucket"],
+                "lowBucketTicks": 4,
+            },
+            "rooms": [{"roomName": "E26S49", "shard": "shardX"}],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_dir = Path(temp_dir)
+            (runtime_dir / "runtime-summary-console-20260529T001418Z.log").write_text(
+                "#runtime-summary " + json.dumps(payload) + "\n",
+                encoding="utf-8",
+            )
+            warnings: list[str] = []
+            runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                runtime_dir,
+                [monitor.RoomRef(shard="shardX", room="E26S49")],
+                warnings,
+            )
+
+        self.assertEqual(warnings, [])
+        runtime_room = runtime_rooms["shardX/E26S49"]
+        self.assertEqual(runtime_room[monitor.RUNTIME_SUMMARY_CPU_METADATA_KEY]["pressure"], "critical")
+
+        snapshot = make_snapshot(
+            {
+                "spawn1": {
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                },
+                "worker-1": {
+                    "type": "creep",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "name": "worker-1",
+                    "x": 23,
+                    "y": 25,
+                },
+            }
+        )
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            snapshot,
+            {"baseline_established": True, "owner": "owner"},
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_room,
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertEqual([reason["kind"] for reason in emitted], [monitor.CPU_BUCKET_CRITICAL_KIND])
+        cpu_reason = emitted[0]
+        self.assertEqual(cpu_reason["priority"], "P0")
+        self.assertEqual(cpu_reason["severity"], "critical")
+        self.assertEqual(cpu_reason["cpuBucket"], 4)
+        self.assertEqual(cpu_reason["pressure"], "critical")
+        self.assertEqual(cpu_reason["alerts"], ["lowBucket"])
+
+        alert_payload = {
+            "ok": True,
+            "mode": "alert",
+            "alert": True,
+            "reasons": emitted,
+            "rooms": ["shardX/E26S49"],
+        }
+        health = monitor.evaluate_postdeploy_health_gate(
+            {
+                "ok": True,
+                "mode": "summary",
+                "room_summaries": [
+                    {
+                        "room": "shardX/E26S49",
+                        "owned_creeps": 1,
+                        "owned_spawns": 1,
+                        "creeps": 1,
+                        "spawns": 1,
+                        "owner": "owner",
+                        "cpuBucket": 4,
+                    }
+                ],
+            },
+            alert_payload,
+        )
+        self.assertFalse(health["ok"])
+        self.assertIn(monitor.CPU_BUCKET_CRITICAL_KIND, [reason["kind"] for reason in health["reasons"]])
+
+        report = monitor.build_tactical_response_report(alert_payload)
+        self.assertTrue(report["emergency"])
+        self.assertEqual(report["severity"], "critical")
+        self.assertEqual(report["priority"], "P0")
+        self.assertEqual(report["categories"], [monitor.CPU_BUCKET_CRITICAL_KIND])
+        self.assertEqual(report["scheduler"]["recommended_output"], "TACTICAL_EMERGENCY_REPORT")
+        trigger = report["triggers"][0]
+        self.assertEqual(trigger["priority"], "P0")
+        self.assertEqual(trigger["metadata"]["metric"], "cpu.bucket")
+        self.assertEqual(trigger["metadata"]["thresholds"], {"P0": 100, "P1": 1000})
+
+    def test_cpu_bucket_low_runtime_summary_alerts_as_p1(self) -> None:
+        snapshot = make_snapshot(
+            {
+                "spawn1": {
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                },
+                "worker-1": {
+                    "type": "creep",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "name": "worker-1",
+                    "x": 23,
+                    "y": 25,
+                },
+            }
+        )
+        runtime_room = {
+            "roomName": "E26S49",
+            monitor.RUNTIME_SUMMARY_CPU_METADATA_KEY: {
+                "bucket": 499,
+                "pressure": "degraded",
+                "alerts": ["lowBucket"],
+                "reasons": ["lowBucket"],
+            },
+        }
+
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            snapshot,
+            {"baseline_established": True, "owner": "owner"},
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_room,
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertEqual([reason["kind"] for reason in emitted], [monitor.CPU_BUCKET_LOW_KIND])
+        self.assertEqual(emitted[0]["priority"], "P1")
+        report = monitor.build_tactical_response_report(
+            {"ok": True, "mode": "alert", "alert": True, "reasons": emitted, "rooms": ["shardX/E26S49"]}
+        )
+        self.assertTrue(report["emergency"])
+        self.assertEqual(report["severity"], "high")
+        self.assertEqual(report["priority"], "P1")
+        self.assertEqual(report["categories"], [monitor.CPU_BUCKET_LOW_KIND])
+
+    def test_cpu_bucket_healthy_or_missing_summary_stays_silent(self) -> None:
+        snapshot = make_snapshot(
+            {
+                "spawn1": {
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                },
+                "worker-1": {
+                    "type": "creep",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "name": "worker-1",
+                    "x": 23,
+                    "y": 25,
+                },
+            }
+        )
+        cases = (
+            {"roomName": "E26S49", monitor.RUNTIME_SUMMARY_CPU_METADATA_KEY: {"bucket": 9000, "pressure": "normal"}},
+            {"roomName": "E26S49"},
+        )
+
+        for runtime_room in cases:
+            with self.subTest(runtime_room=runtime_room):
+                emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+                    snapshot,
+                    {"baseline_established": True, "owner": "owner"},
+                    now=100,
+                    debounce_seconds=300,
+                    runtime_room_summary=runtime_room,
+                )
+                self.assertEqual(suppressed, [])
+                self.assertNotIn(monitor.CPU_BUCKET_CRITICAL_KIND, [reason["kind"] for reason in emitted])
+                self.assertNotIn(monitor.CPU_BUCKET_LOW_KIND, [reason["kind"] for reason in emitted])
+
+        for room_summary in (
+            {
+                "room": "shardX/E26S49",
+                "owned_creeps": 1,
+                "owned_spawns": 1,
+                "creeps": 1,
+                "spawns": 1,
+                "owner": "owner",
+                "cpuBucket": 9000,
+            },
+            {
+                "room": "shardX/E26S49",
+                "owned_creeps": 1,
+                "owned_spawns": 1,
+                "creeps": 1,
+                "spawns": 1,
+                "owner": "owner",
+            },
+        ):
+            with self.subTest(room_summary=room_summary):
+                health = monitor.evaluate_postdeploy_health_gate(
+                    {"ok": True, "mode": "summary", "room_summaries": [room_summary]},
+                    {"ok": True, "mode": "alert", "alert": False, "reasons": []},
+                )
+                self.assertTrue(health["ok"])
+
+    def test_cpu_bucket_alert_does_not_mask_hostile_or_damage_alerts(self) -> None:
+        previous = {
+            "baseline_established": True,
+            "owner": "owner",
+            "structures": {
+                "spawn1": {
+                    "type": "spawn",
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                    "owned": True,
+                    "damageable": True,
+                    "critical": True,
+                }
+            },
+        }
+        snapshot = make_snapshot(
+            {
+                "spawn1": {
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 25,
+                    "y": 25,
+                    "hits": 4900,
+                    "hitsMax": 5000,
+                },
+                "worker-1": {
+                    "type": "creep",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "name": "worker-1",
+                    "x": 23,
+                    "y": 25,
+                },
+                "hostile-1": {
+                    "type": "creep",
+                    "owner": {"username": "Invader"},
+                    "x": 20,
+                    "y": 21,
+                },
+            }
+        )
+        runtime_room = {
+            "roomName": "E26S49",
+            monitor.RUNTIME_SUMMARY_CPU_METADATA_KEY: {
+                "bucket": 4,
+                "pressure": "critical",
+                "alerts": ["lowBucket"],
+                "reasons": ["criticalBucket"],
+            },
+        }
+
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            snapshot,
+            previous,
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_room,
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertEqual(
+            {reason["kind"] for reason in emitted},
+            {"hostile_creep", "structure_damage", monitor.CPU_BUCKET_CRITICAL_KIND},
+        )
+
     def test_clean_no_alert_expansion_bootstrap_without_spawn_stays_silent(self) -> None:
         report = monitor.build_tactical_response_report(EXPANSION_BOOTSTRAP_NO_ALERT_FIXTURE)
 

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -757,6 +757,48 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(trigger["metadata"]["metric"], "cpu.bucket")
         self.assertEqual(trigger["metadata"]["thresholds"], {"P0": 100, "P1": 1000})
 
+    def test_postdeploy_health_gate_enriches_cpu_fields_from_runtime_summary_artifact(self) -> None:
+        payload = {
+            "type": "runtime-summary",
+            "tick": 1200,
+            "cpu": {
+                "used": 30.14,
+                "limit": 70,
+                "bucket": 4,
+                "pressure": "critical",
+                "reasons": ["criticalBucket"],
+            },
+            "rooms": [{"roomName": "E26S49", "shard": "shardX", "workerCount": 1}],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact = Path(temp_dir) / "runtime-summary-monitor-20260529T001418Z.log"
+            artifact.write_text("#runtime-summary " + json.dumps(payload) + "\n", encoding="utf-8")
+
+            health = monitor.evaluate_postdeploy_health_gate(
+                {
+                    "ok": True,
+                    "mode": "summary",
+                    "room_summaries": [
+                        {
+                            "room": "shardX/E26S49",
+                            "owned_creeps": 1,
+                            "owned_spawns": 1,
+                            "creeps": 1,
+                            "spawns": 1,
+                            "owner": "owner",
+                        }
+                    ],
+                    "runtime_summary_artifact": str(artifact),
+                },
+                {"ok": True, "mode": "alert", "alert": False, "reasons": [], "rooms": ["shardX/E26S49"]},
+            )
+
+        self.assertFalse(health["ok"])
+        cpu_reason = next(reason for reason in health["reasons"] if reason["kind"] == monitor.CPU_BUCKET_CRITICAL_KIND)
+        self.assertEqual(cpu_reason["cpuBucket"], 4)
+        self.assertEqual(cpu_reason["pressure"], "critical")
+
     def test_compact_cpu_summary_alerts_health_gate_and_tactical_response(self) -> None:
         old_room_payload = {
             "type": "runtime-summary",
@@ -800,7 +842,10 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(warnings, [])
         runtime_room = runtime_rooms["shardX/E26S49"]
         self.assertEqual(runtime_room["room"], "shardX/E26S49")
+        self.assertEqual(runtime_room["workerCount"], 3)
+        self.assertEqual(runtime_room["taskCounts"]["harvest"], 2)
         self.assertEqual(runtime_room["cpuBucket"], 0)
+        self.assertEqual(runtime_room["cpuLimit"], 70)
         self.assertEqual(runtime_room[monitor.RUNTIME_SUMMARY_CPU_METADATA_KEY]["pressure"], "critical")
         self.assertEqual(runtime_room[monitor.RUNTIME_SUMMARY_CPU_METADATA_KEY]["reasons"], ["criticalBucket"])
 
@@ -874,6 +919,51 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(report["priority"], "P0")
         self.assertEqual(report["categories"], [monitor.CPU_BUCKET_CRITICAL_KIND])
 
+    def test_fresh_runtime_summary_cpu_fields_override_stale_compact_cpu_summary(self) -> None:
+        compact_cpu_payload = {
+            "used": 30.14,
+            "limit": 70,
+            "bucket": 0,
+            "pressure": "critical",
+            "reasons": ["criticalBucket"],
+        }
+        runtime_payload = {
+            "type": "runtime-summary",
+            "tick": 1200,
+            "cpu": {"used": 6.5, "limit": 70, "bucket": 9000, "pressure": "normal"},
+            "rooms": [
+                {
+                    "roomName": "E26S49",
+                    "shard": "shardX",
+                    "workerCount": 3,
+                    "taskCounts": {"harvest": 2, "transfer": 1, "build": 0, "repair": 0, "upgrade": 0, "none": 0},
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_dir = Path(temp_dir)
+            (runtime_dir / "runtime-summary-console-20260529T001000Z.log").write_text(
+                "#cpu-summary " + json.dumps(compact_cpu_payload) + "\n",
+                encoding="utf-8",
+            )
+            (runtime_dir / "runtime-summary-console-20260529T001418Z.log").write_text(
+                "#runtime-summary " + json.dumps(runtime_payload) + "\n",
+                encoding="utf-8",
+            )
+            warnings: list[str] = []
+            runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                runtime_dir,
+                [monitor.RoomRef(shard="shardX", room="E26S49")],
+                warnings,
+            )
+
+        self.assertEqual(warnings, [])
+        runtime_room = runtime_rooms["shardX/E26S49"]
+        self.assertEqual(runtime_room["workerCount"], 3)
+        self.assertEqual(runtime_room[monitor.RUNTIME_SUMMARY_CPU_METADATA_KEY]["bucket"], 9000)
+        self.assertIsNone(monitor.detect_cpu_bucket_reason(monitor.RoomRef(shard="shardX", room="E26S49"), runtime_room))
+
     def test_compact_cpu_summary_healthy_malformed_or_missing_stays_silent(self) -> None:
         snapshot = make_snapshot(
             {
@@ -897,12 +987,16 @@ class TacticalResponseBridgeTest(unittest.TestCase):
             }
         )
         cases = (
-            ("healthy", "#cpu-summary " + json.dumps({"used": 6.5, "bucket": 9000, "pressure": "normal"}) + "\n"),
-            ("malformed", "#cpu-summary {bad json\n"),
-            ("missing", ""),
+            (
+                "healthy",
+                "#cpu-summary " + json.dumps({"used": 6.5, "bucket": 9000, "pressure": "normal"}) + "\n",
+                False,
+            ),
+            ("malformed", "#cpu-summary {bad json\n", True),
+            ("missing", "", False),
         )
 
-        for name, content in cases:
+        for name, content, expects_warning in cases:
             with self.subTest(name=name):
                 with tempfile.TemporaryDirectory() as temp_dir:
                     runtime_dir = Path(temp_dir)
@@ -918,7 +1012,10 @@ class TacticalResponseBridgeTest(unittest.TestCase):
                         warnings,
                     )
 
-                self.assertEqual(warnings, [])
+                if expects_warning:
+                    self.assertTrue(any("#cpu-summary" in warning for warning in warnings), warnings)
+                else:
+                    self.assertEqual(warnings, [])
                 runtime_room = runtime_rooms.get("shardX/E26S49")
                 if name == "healthy":
                     self.assertIsNotNone(runtime_room)

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -757,6 +757,188 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(trigger["metadata"]["metric"], "cpu.bucket")
         self.assertEqual(trigger["metadata"]["thresholds"], {"P0": 100, "P1": 1000})
 
+    def test_compact_cpu_summary_alerts_health_gate_and_tactical_response(self) -> None:
+        old_room_payload = {
+            "type": "runtime-summary",
+            "tick": 1190,
+            "rooms": [
+                {
+                    "roomName": "E26S49",
+                    "shard": "shardX",
+                    "workerCount": 3,
+                    "taskCounts": {"harvest": 2, "transfer": 1, "build": 0, "repair": 0, "upgrade": 0, "none": 0},
+                }
+            ],
+        }
+        compact_cpu_payload = {
+            "used": 30.14,
+            "limit": 70,
+            "bucket": 0,
+            "pressure": "critical",
+            "alerts": ["lowBucket"],
+            "reasons": ["criticalBucket"],
+            "lowBucketTicks": 4,
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_dir = Path(temp_dir)
+            (runtime_dir / "runtime-summary-console-20260529T001000Z.log").write_text(
+                "#runtime-summary " + json.dumps(old_room_payload) + "\n",
+                encoding="utf-8",
+            )
+            (runtime_dir / "runtime-summary-console-20260529T001418Z.log").write_text(
+                "#cpu-summary " + json.dumps(compact_cpu_payload) + "\n",
+                encoding="utf-8",
+            )
+            warnings: list[str] = []
+            runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                runtime_dir,
+                [monitor.RoomRef(shard="shardX", room="E26S49")],
+                warnings,
+            )
+
+        self.assertEqual(warnings, [])
+        runtime_room = runtime_rooms["shardX/E26S49"]
+        self.assertEqual(runtime_room["room"], "shardX/E26S49")
+        self.assertEqual(runtime_room["cpuBucket"], 0)
+        self.assertEqual(runtime_room[monitor.RUNTIME_SUMMARY_CPU_METADATA_KEY]["pressure"], "critical")
+        self.assertEqual(runtime_room[monitor.RUNTIME_SUMMARY_CPU_METADATA_KEY]["reasons"], ["criticalBucket"])
+
+        snapshot = make_snapshot(
+            {
+                "spawn1": {
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                },
+                "worker-1": {
+                    "type": "creep",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "name": "worker-1",
+                    "x": 23,
+                    "y": 25,
+                },
+            }
+        )
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            snapshot,
+            {"baseline_established": True, "owner": "owner"},
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_room,
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertEqual([reason["kind"] for reason in emitted], [monitor.CPU_BUCKET_CRITICAL_KIND])
+        self.assertEqual(emitted[0]["priority"], "P0")
+        self.assertEqual(emitted[0]["severity"], "critical")
+        self.assertEqual(emitted[0]["cpuBucket"], 0)
+
+        alert_payload = {
+            "ok": True,
+            "mode": "alert",
+            "alert": True,
+            "reasons": emitted,
+            "rooms": ["shardX/E26S49"],
+        }
+        health = monitor.evaluate_postdeploy_health_gate(
+            {
+                "ok": True,
+                "mode": "summary",
+                "room_summaries": [
+                    {
+                        "room": "shardX/E26S49",
+                        "owned_creeps": 1,
+                        "owned_spawns": 1,
+                        "creeps": 1,
+                        "spawns": 1,
+                        "owner": "owner",
+                    }
+                ],
+            },
+            alert_payload,
+        )
+
+        self.assertFalse(health["ok"])
+        active_alert = next(reason for reason in health["reasons"] if reason["kind"] == "postdeploy_active_alert")
+        self.assertEqual(active_alert["source"]["kind"], monitor.CPU_BUCKET_CRITICAL_KIND)
+
+        report = monitor.build_tactical_response_report(alert_payload)
+        self.assertTrue(report["emergency"])
+        self.assertEqual(report["severity"], "critical")
+        self.assertEqual(report["priority"], "P0")
+        self.assertEqual(report["categories"], [monitor.CPU_BUCKET_CRITICAL_KIND])
+
+    def test_compact_cpu_summary_healthy_malformed_or_missing_stays_silent(self) -> None:
+        snapshot = make_snapshot(
+            {
+                "spawn1": {
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                },
+                "worker-1": {
+                    "type": "creep",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "name": "worker-1",
+                    "x": 23,
+                    "y": 25,
+                },
+            }
+        )
+        cases = (
+            ("healthy", "#cpu-summary " + json.dumps({"used": 6.5, "bucket": 9000, "pressure": "normal"}) + "\n"),
+            ("malformed", "#cpu-summary {bad json\n"),
+            ("missing", ""),
+        )
+
+        for name, content in cases:
+            with self.subTest(name=name):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    runtime_dir = Path(temp_dir)
+                    if content:
+                        (runtime_dir / "runtime-summary-console-20260529T001418Z.log").write_text(
+                            content,
+                            encoding="utf-8",
+                        )
+                    warnings: list[str] = []
+                    runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                        runtime_dir,
+                        [monitor.RoomRef(shard="shardX", room="E26S49")],
+                        warnings,
+                    )
+
+                self.assertEqual(warnings, [])
+                runtime_room = runtime_rooms.get("shardX/E26S49")
+                if name == "healthy":
+                    self.assertIsNotNone(runtime_room)
+                    assert runtime_room is not None
+                    self.assertEqual(runtime_room[monitor.RUNTIME_SUMMARY_CPU_METADATA_KEY]["bucket"], 9000)
+                else:
+                    self.assertIsNone(runtime_room)
+
+                emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+                    snapshot,
+                    {"baseline_established": True, "owner": "owner"},
+                    now=100,
+                    debounce_seconds=300,
+                    runtime_room_summary=runtime_room,
+                )
+
+                self.assertEqual(suppressed, [])
+                self.assertNotIn(monitor.CPU_BUCKET_CRITICAL_KIND, [reason["kind"] for reason in emitted])
+                self.assertNotIn(monitor.CPU_BUCKET_LOW_KIND, [reason["kind"] for reason in emitted])
+
     def test_cpu_bucket_low_runtime_summary_alerts_as_p1(self) -> None:
         snapshot = make_snapshot(
             {

--- a/scripts/test_screeps_runtime_summary_console_capture.py
+++ b/scripts/test_screeps_runtime_summary_console_capture.py
@@ -55,13 +55,18 @@ class FakeWebsocketsModule:
 
 
 class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
-    def test_filters_only_exact_runtime_summary_lines(self) -> None:
+    def test_filters_only_exact_runtime_telemetry_lines(self) -> None:
         lines = [
             "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":1}\n",
+            "#cpu-summary {\"used\":6.5,\"bucket\":9000,\"pressure\":\"normal\"}\n",
             "noise #runtime-summary {\"type\":\"runtime-summary\",\"tick\":2}\n",
+            "noise #cpu-summary {\"bucket\":0}\n",
             "\"#runtime-summary {\\\"type\\\":\\\"runtime-summary\\\",\\\"tick\\\":3}\"\n",
+            "\"#cpu-summary {\\\"bucket\\\":0}\"\n",
             " #runtime-summary {\"type\":\"runtime-summary\",\"tick\":4}\n",
+            " #cpu-summary {\"bucket\":0}\n",
             "#runtime-summary {bad json}\n",
+            "#cpu-summary {bad json}\n",
             "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":5}",
         ]
 
@@ -71,10 +76,45 @@ class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
             accepted,
             [
                 "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":1}\n",
+                "#cpu-summary {\"used\":6.5,\"bucket\":9000,\"pressure\":\"normal\"}\n",
                 "#runtime-summary {bad json}\n",
+                "#cpu-summary {bad json}\n",
                 "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":5}\n",
             ],
         )
+
+    def test_persists_compact_cpu_summary_lines_to_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            input_path = root / "console.log"
+            out_dir = root / "runtime-artifacts" / "runtime-summary-console"
+            input_path.write_text(
+                "noise before\n"
+                "#cpu-summary {\"used\":30.14,\"limit\":70,\"bucket\":0,\"pressure\":\"critical\"}\n"
+                "noise #cpu-summary {\"bucket\":9999}\n"
+                "#cpu-summary {bad json}\n"
+                " #cpu-summary {\"bucket\":10}\n",
+                encoding="utf-8",
+            )
+
+            result = capture.persist_runtime_summary_artifact(
+                input_paths=[str(input_path)],
+                out_dir=out_dir,
+                artifact_name="capture.log",
+            )
+
+            self.assertEqual(result.input_paths, [str(input_path)])
+            self.assertEqual(result.input_line_count, 5)
+            self.assertEqual(result.persisted_line_count, 2)
+            self.assertEqual(result.skipped_line_count, 3)
+            self.assertEqual(result.output_path, out_dir / "capture.log")
+            self.assertEqual(
+                result.output_path.read_text(encoding="utf-8").splitlines(),
+                [
+                    "#cpu-summary {\"used\":30.14,\"limit\":70,\"bucket\":0,\"pressure\":\"critical\"}",
+                    "#cpu-summary {bad json}",
+                ],
+            )
 
     def test_persists_matching_console_lines_to_artifact(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -288,6 +328,7 @@ class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
                             "messages": {
                                 "log": [
                                     "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":101}",
+                                    "#cpu-summary {\"used\":30.14,\"limit\":70,\"bucket\":0,\"pressure\":\"critical\"}",
                                     "noise #runtime-summary {\"type\":\"runtime-summary\",\"tick\":999}",
                                 ],
                                 "results": [
@@ -331,14 +372,15 @@ class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
             )
 
             self.assertEqual(result.input_paths, ["live-official-console"])
-            self.assertEqual(result.input_line_count, 5)
-            self.assertEqual(result.persisted_line_count, 3)
+            self.assertEqual(result.input_line_count, 6)
+            self.assertEqual(result.persisted_line_count, 4)
             self.assertEqual(result.skipped_line_count, 2)
             self.assertEqual(result.output_path, out_dir / "live.log")
             self.assertEqual(
                 result.output_path.read_text(encoding="utf-8").splitlines(),
                 [
                     "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":101}",
+                    "#cpu-summary {\"used\":30.14,\"limit\":70,\"bucket\":0,\"pressure\":\"critical\"}",
                     "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":102}",
                     "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":103}",
                 ],


### PR DESCRIPTION
## Summary
- routes runtime-summary CPU bucket `lowBucket` / critical pressure into the runtime monitor alert reasons
- propagates CPU bucket alert reasons through postdeploy health-gate and tactical-response classification
- adds focused coverage for critical, low, healthy/missing, and mixed hostile/damage + CPU alert cases

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py`
- `python3 -m unittest scripts/test_screeps_runtime_monitor_tactical_response.py`
- `python3 scripts/screeps-runtime-monitor.py self-test`

Refs #1490

## Universal task Done gate

- [x] Task type: runtime-monitor code.
- [x] Expected observable outcome / named deliverable: CPU bucket low/critical runtime-summary evidence emits monitor alert reasons plus health-gate and tactical-response classifications.
- [x] Non-goals / accepted substitutes: no official MMO write, deploy, Tencent compute, SSH, cron edit, or gameplay behavior change.
- [x] Verification evidence required before Done: diff-check, py_compile, focused unittest 73 tests, and monitor self-test 39 tests pass on commit b896eb3b.
- [x] Project Evidence / Next action / Blocked by: #1490 and PR #1491 Project items set In review with Evidence and Next action; PR gates are represented in Project text fields.
- [x] Post-merge/deploy/runtime proof: runtime monitor self-test proves alert, health-gate, and tactical-response outputs for CPU bucket cases on this branch.
- [x] Named deliverable proof: `scripts/screeps-runtime-monitor.py` now emits `cpu_bucket_critical` and `cpu_bucket_low`; `scripts/test_screeps_runtime_monitor_tactical_response.py` asserts P0/P1 routing and no false alert for healthy or absent CPU data.

## Safety
- No official MMO writes, deploys, Tencent compute, SSH, or cron changes.
- Monitor/alert routing only; no gameplay behavior change.
