### PR TITLE
fix: preserve CPU alerts across null monitor summaries

### DIFF
--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -3684,6 +3684,9 @@ def runtime_summary_room_has_worker_idle_fields(room: dict[str, Any]) -> bool:
 def runtime_summary_payload_has_cpu_fields(payload: dict[str, Any]) -> bool:
     return (
         runtime_cpu_bucket(payload) is not None
+        or runtime_cpu_used(payload) is not None
+        or runtime_cpu_limit(payload) is not None
+        or runtime_low_bucket_ticks(payload) is not None
         or runtime_cpu_pressure(payload) is not None
         or bool(runtime_cpu_signal_values(payload, "alerts"))
         or bool(runtime_cpu_signal_values(payload, "reasons"))
@@ -3693,6 +3696,9 @@ def runtime_summary_payload_has_cpu_fields(payload: dict[str, Any]) -> bool:
 def runtime_summary_room_has_cpu_fields(room: dict[str, Any]) -> bool:
     return (
         runtime_cpu_bucket(room) is not None
+        or runtime_cpu_used(room) is not None
+        or runtime_cpu_limit(room) is not None
+        or runtime_low_bucket_ticks(room) is not None
         or runtime_cpu_pressure(room) is not None
         or bool(runtime_cpu_signal_values(room, "alerts"))
         or bool(runtime_cpu_signal_values(room, "reasons"))

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -3682,24 +3682,21 @@ def runtime_summary_room_has_worker_idle_fields(room: dict[str, Any]) -> bool:
 
 
 def runtime_summary_payload_has_cpu_fields(payload: dict[str, Any]) -> bool:
-    cpu = payload.get("cpu")
-    if not isinstance(cpu, dict):
-        return False
-    return any(
-        key in cpu
-        for key in (
-            "bucket",
-            "pressure",
-            "alerts",
-            "reasons",
-            "lowBucketTicks",
-            "bucketEmptyTicks",
-        )
+    return (
+        runtime_cpu_bucket(payload) is not None
+        or runtime_cpu_pressure(payload) is not None
+        or bool(runtime_cpu_signal_values(payload, "alerts"))
+        or bool(runtime_cpu_signal_values(payload, "reasons"))
     )
 
 
 def runtime_summary_room_has_cpu_fields(room: dict[str, Any]) -> bool:
-    return any(key in room for key in ("cpuBucket", "cpu", "bucket", "pressure", "alerts", "reasons"))
+    return (
+        runtime_cpu_bucket(room) is not None
+        or runtime_cpu_pressure(room) is not None
+        or bool(runtime_cpu_signal_values(room, "alerts"))
+        or bool(runtime_cpu_signal_values(room, "reasons"))
+    )
 
 
 def runtime_summary_room_has_monitor_alert_fields(room: dict[str, Any], payload: dict[str, Any]) -> bool:
@@ -3820,7 +3817,7 @@ def runtime_summary_room_with_metadata(payload: dict[str, Any], path: Path, room
     elif path.name.startswith("runtime-summary-monitor-"):
         result[RUNTIME_SUMMARY_SOURCE_METADATA_KEY] = MONITOR_RUNTIME_SUMMARY_SOURCE
     cpu = payload.get("cpu")
-    if isinstance(cpu, dict):
+    if isinstance(cpu, dict) and runtime_summary_payload_has_cpu_fields(payload):
         result[RUNTIME_SUMMARY_CPU_METADATA_KEY] = dict(cpu)
     return result
 

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -1147,6 +1147,53 @@ class TacticalResponseBridgeTest(unittest.TestCase):
                 self.assertNotIn(monitor.CPU_BUCKET_CRITICAL_KIND, [reason["kind"] for reason in emitted])
                 self.assertNotIn(monitor.CPU_BUCKET_LOW_KIND, [reason["kind"] for reason in emitted])
 
+    def test_compact_cpu_summary_usage_only_and_low_bucket_ticks_are_preserved(self) -> None:
+        cases = (
+            (
+                "used and limit only",
+                {"used": 6.5, "limit": 70},
+                {"cpuUsed": 6.5, "cpuLimit": 70},
+                {"used": 6.5, "limit": 70},
+            ),
+            (
+                "low bucket ticks only",
+                {"lowBucketTicks": 4},
+                {"lowBucketTicks": 4},
+                {"lowBucketTicks": 4},
+            ),
+        )
+
+        for name, compact_cpu_payload, expected_room_fields, expected_cpu_fields in cases:
+            with self.subTest(name=name):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    runtime_dir = Path(temp_dir)
+                    (runtime_dir / "runtime-summary-console-20260529T001418Z.log").write_text(
+                        "#cpu-summary " + json.dumps(compact_cpu_payload) + "\n",
+                        encoding="utf-8",
+                    )
+                    warnings: list[str] = []
+                    runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                        runtime_dir,
+                        [monitor.RoomRef(shard="shardX", room="E26S49")],
+                        warnings,
+                    )
+
+                self.assertEqual(warnings, [])
+                runtime_room = runtime_rooms.get("shardX/E26S49")
+                self.assertIsNotNone(runtime_room)
+                assert runtime_room is not None
+                for field, expected in expected_room_fields.items():
+                    self.assertEqual(runtime_room[field], expected)
+                cpu_metadata = runtime_room[monitor.RUNTIME_SUMMARY_CPU_METADATA_KEY]
+                for field, expected in expected_cpu_fields.items():
+                    self.assertEqual(cpu_metadata[field], expected)
+                self.assertIsNone(
+                    monitor.detect_cpu_bucket_reason(
+                        monitor.RoomRef(shard="shardX", room="E26S49"),
+                        runtime_room,
+                    )
+                )
+
     def test_cpu_bucket_low_runtime_summary_alerts_as_p1(self) -> None:
         snapshot = make_snapshot(
             {

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -964,6 +964,117 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(runtime_room[monitor.RUNTIME_SUMMARY_CPU_METADATA_KEY]["bucket"], 9000)
         self.assertIsNone(monitor.detect_cpu_bucket_reason(monitor.RoomRef(shard="shardX", room="E26S49"), runtime_room))
 
+    def test_newer_null_monitor_cpu_does_not_mask_persisted_cpu_alerts(self) -> None:
+        cases = (
+            (
+                "top-level runtime-summary cpu",
+                "#runtime-summary "
+                + json.dumps(
+                    {
+                        "type": "runtime-summary",
+                        "tick": 1200,
+                        "cpu": {
+                            "used": 29.42,
+                            "limit": 70,
+                            "bucket": 15,
+                            "pressure": "critical",
+                            "alerts": ["lowBucket"],
+                            "reasons": ["criticalBucket"],
+                            "lowBucketTicks": 1,
+                        },
+                        "rooms": [{"roomName": "E26S49", "shard": "shardX", "workerCount": 1}],
+                    }
+                )
+                + "\n",
+            ),
+            (
+                "room-level runtime-summary cpu",
+                "#runtime-summary "
+                + json.dumps(
+                    {
+                        "type": "runtime-summary",
+                        "tick": 1200,
+                        "rooms": [
+                            {
+                                "roomName": "E26S49",
+                                "shard": "shardX",
+                                "workerCount": 1,
+                                "cpuUsed": 29.42,
+                                "cpuBucket": 15,
+                            }
+                        ],
+                    }
+                )
+                + "\n",
+            ),
+            (
+                "compact cpu-summary",
+                "#cpu-summary "
+                + json.dumps(
+                    {
+                        "used": 29.42,
+                        "limit": 70,
+                        "bucket": 15,
+                        "pressure": "critical",
+                        "alerts": ["lowBucket"],
+                        "reasons": ["criticalBucket"],
+                        "lowBucketTicks": 1,
+                    }
+                )
+                + "\n",
+            ),
+        )
+        null_monitor_payload = {
+            "type": "runtime-summary",
+            "source": monitor.MONITOR_RUNTIME_SUMMARY_SOURCE,
+            "tick": 1205,
+            "cpu": {"used": None, "bucket": None},
+            "rooms": [
+                {
+                    "roomName": "E26S49",
+                    "shard": "shardX",
+                    "workerCount": 3,
+                    "taskCounts": {"harvest": 2, "transfer": 1, "build": 0, "repair": 0, "upgrade": 0, "none": 0},
+                    "cpuUsed": None,
+                    "cpuBucket": None,
+                }
+            ],
+        }
+
+        for name, persisted_cpu_line in cases:
+            with self.subTest(name=name):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    runtime_dir = Path(temp_dir)
+                    (runtime_dir / "runtime-summary-console-20260529T043738Z.log").write_text(
+                        persisted_cpu_line,
+                        encoding="utf-8",
+                    )
+                    (runtime_dir / "runtime-summary-monitor-20260529T045325Z.log").write_text(
+                        "#runtime-summary " + json.dumps(null_monitor_payload) + "\n",
+                        encoding="utf-8",
+                    )
+                    warnings: list[str] = []
+                    runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                        runtime_dir,
+                        [monitor.RoomRef(shard="shardX", room="E26S49")],
+                        warnings,
+                    )
+
+                self.assertEqual(warnings, [])
+                runtime_room = runtime_rooms["shardX/E26S49"]
+                self.assertEqual(runtime_room["workerCount"], 3)
+                self.assertEqual(runtime_room["taskCounts"]["harvest"], 2)
+
+                reason = monitor.detect_cpu_bucket_reason(
+                    monitor.RoomRef(shard="shardX", room="E26S49"),
+                    runtime_room,
+                )
+
+                self.assertIsNotNone(reason)
+                assert reason is not None
+                self.assertEqual(reason["kind"], monitor.CPU_BUCKET_CRITICAL_KIND)
+                self.assertEqual(reason["cpuBucket"], 15)
+
     def test_compact_cpu_summary_healthy_malformed_or_missing_stays_silent(self) -> None:
         snapshot = make_snapshot(
             {


### PR DESCRIPTION
## Summary
- Preserve prior CPU-bearing runtime-summary evidence when the newest monitor-generated summary has null CPU fields.
- Add regression coverage for top-level runtime CPU, room-level CPU, and compact `#cpu-summary` artifacts followed by a null monitor summary.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py`
- `python3 scripts/test_screeps_runtime_monitor_tactical_response.py` (79 tests OK)
- `python3 scripts/screeps-runtime-monitor.py self-test` (39 tests OK)

## Universal task Done gate
- [x] Task type: P0 runtime monitor bugfix follow-up.
- [x] Expected observable outcome / named deliverable: CPU-critical evidence from persisted runtime summaries is preserved when a newer monitor summary has null CPU fields, so alert classification can still use the CPU-bearing artifact.
- [x] Non-goals / accepted substitutes: official MMO bot behavior, deploy workflow changes, Tencent compute, RL reward changes, and gameplay planner edits are out of scope.
- [x] Verification evidence required before Done: local `git diff --check`, `py_compile`, tactical-response suite 79 OK, and monitor self-test 39 OK on commits `08e7284e` and review-fix `bcc41917`.
- [x] Project Evidence / Next action / Blocked by: Project items for issue #1490 and PR #1492 record In review state, commits `08e7284e` and review-fix `bcc41917`, verification evidence, and review-gate handoff.
- [x] Post-merge/deploy/runtime proof: issue #1490 owns fresh CPU-bearing runtime observation for production acceptance; this PR supplies the deterministic parser/alert regression proof.
- [x] Named deliverable proof: `test_newer_null_monitor_cpu_does_not_mask_persisted_cpu_alerts` covers top-level runtime CPU, room-level CPU, and compact `#cpu-summary` inputs and expects `CPU_BUCKET_CRITICAL_KIND` with bucket `15`.

## Issue link
Related to issue #1490. The validation issue stays open until fresh CPU-bearing runtime evidence proves alert routing or sustained bucket recovery.

## Safety
- Runtime monitor/scripts only; no official MMO upload, no deploy, no Tencent/paid compute.
- No secrets printed or changed.



## Review-fix update
- `bcc41917` accepts persisted CPU summaries with usage-only telemetry and keeps newer null monitor summaries from suppressing CPU alert recovery.
- Controller verification after the review-fix: `git diff --check`; `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py`; `python3 -m unittest scripts/test_screeps_runtime_monitor_tactical_response.py` (79 tests OK).
