### PR TITLE
feat: collect seasonal score items

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1654,12 +1654,12 @@ function isHostileNearProtectedStructure(hostile, structures) {
 }
 function compareRange(origin, left, right) {
   var _a;
-  const getRangeTo2 = (_a = origin.pos) == null ? void 0 : _a.getRangeTo;
-  if (typeof getRangeTo2 !== "function") {
+  const getRangeTo3 = (_a = origin.pos) == null ? void 0 : _a.getRangeTo;
+  if (typeof getRangeTo3 !== "function") {
     return 0;
   }
-  const leftRange = left.pos ? getRangeTo2.call(origin.pos, left.pos) : Infinity;
-  const rightRange = right.pos ? getRangeTo2.call(origin.pos, right.pos) : Infinity;
+  const leftRange = left.pos ? getRangeTo3.call(origin.pos, left.pos) : Infinity;
+  const rightRange = right.pos ? getRangeTo3.call(origin.pos, right.pos) : Infinity;
   return leftRange - rightRange;
 }
 function getRangeBetweenPositions(left, right) {
@@ -2226,12 +2226,12 @@ function isTargetInTowerRoom(origin, target) {
 }
 function compareRange2(origin, left, right) {
   var _a;
-  const getRangeTo2 = (_a = origin.pos) == null ? void 0 : _a.getRangeTo;
-  if (typeof getRangeTo2 !== "function") {
+  const getRangeTo3 = (_a = origin.pos) == null ? void 0 : _a.getRangeTo;
+  if (typeof getRangeTo3 !== "function") {
     return 0;
   }
-  const leftRange = left.pos ? getRangeTo2.call(origin.pos, left.pos) : Infinity;
-  const rightRange = right.pos ? getRangeTo2.call(origin.pos, right.pos) : Infinity;
+  const leftRange = left.pos ? getRangeTo3.call(origin.pos, left.pos) : Infinity;
+  const rightRange = right.pos ? getRangeTo3.call(origin.pos, right.pos) : Infinity;
   return leftRange - rightRange;
 }
 function isWoundedCreep(creep) {
@@ -24378,11 +24378,11 @@ function isNearRoomObject4(left, right, range) {
 }
 function compareRangeToCreep(creep, left, right) {
   var _a;
-  const getRangeTo2 = (_a = creep.pos) == null ? void 0 : _a.getRangeTo;
-  if (typeof getRangeTo2 !== "function") {
+  const getRangeTo3 = (_a = creep.pos) == null ? void 0 : _a.getRangeTo;
+  if (typeof getRangeTo3 !== "function") {
     return 0;
   }
-  return normalizeRange(getRangeTo2.call(creep.pos, left)) - normalizeRange(getRangeTo2.call(creep.pos, right));
+  return normalizeRange(getRangeTo3.call(creep.pos, left)) - normalizeRange(getRangeTo3.call(creep.pos, right));
 }
 function normalizeRange(range) {
   return typeof range === "number" && Number.isFinite(range) ? range : Number.POSITIVE_INFINITY;
@@ -24963,6 +24963,146 @@ function getRuntimeGame() {
   return globalThis.Game;
 }
 
+// src/runtime/featureGates.ts
+function getRuntimeFeatureGates(game = getRuntimeGame2()) {
+  var _a, _b;
+  const shardName = normalizeString((_a = game == null ? void 0 : game.shard) == null ? void 0 : _a.name);
+  const shardType = normalizeString((_b = game == null ? void 0 : game.shard) == null ? void 0 : _b.type);
+  const isSeasonal = shardName === "shardSeason" || /season/i.test(shardType != null ? shardType : "");
+  const enabledInPersistent = !isSeasonal;
+  return {
+    cpu: buildCpuMetadata(game == null ? void 0 : game.cpu),
+    isSeasonal,
+    ...shardName ? { shardName } : {},
+    ...shardType ? { shardType } : {},
+    world: isSeasonal ? "seasonal" : "persistent",
+    marketTrading: enabledInPersistent,
+    terminalEnergyTransfers: enabledInPersistent,
+    labManagement: enabledInPersistent
+  };
+}
+function getRuntimeGame2() {
+  return globalThis.Game;
+}
+function buildCpuMetadata(cpu) {
+  return {
+    ...optionalFiniteNumber2("limit", cpu == null ? void 0 : cpu.limit),
+    ...optionalFiniteNumber2("bucket", cpu == null ? void 0 : cpu.bucket),
+    ...optionalFiniteNumber2("tickLimit", cpu == null ? void 0 : cpu.tickLimit)
+  };
+}
+function optionalFiniteNumber2(key, value) {
+  return typeof value === "number" && Number.isFinite(value) ? { [key]: value } : {};
+}
+function normalizeString(value) {
+  return typeof value === "string" && value.length > 0 ? value : void 0;
+}
+
+// src/season/scoreCollection.ts
+var SCORE_FIND_CONSTANT_GLOBALS = [
+  "FIND_SCORE",
+  "FIND_SCORE_ITEMS",
+  "FIND_SCORE_OBJECTS",
+  "FIND_SEASON_SCORE",
+  "FIND_SEASON_SCORE_ITEMS"
+];
+var SCORE_FALLBACK_ROOM_KEYS = [
+  "score",
+  "scores",
+  "scoreItems",
+  "scoreObjects",
+  "seasonScore",
+  "seasonScoreItems"
+];
+function selectSeasonScoreCollectionTask(creep) {
+  var _a;
+  if (!getRuntimeFeatureGates().isSeasonal || ((_a = creep.memory) == null ? void 0 : _a.role) !== "worker") {
+    return null;
+  }
+  const scoreItem = selectBestVisibleScoreItem(creep);
+  return scoreItem ? { type: "collectScore", targetId: scoreItem.id } : null;
+}
+function selectBestVisibleScoreItem(creep) {
+  var _a;
+  const room = creep.room;
+  if (!room) {
+    return null;
+  }
+  return (_a = findVisibleScoreItems(room).sort((left, right) => compareScoreItems(creep, left, right))[0]) != null ? _a : null;
+}
+function findVisibleScoreItems(room) {
+  const candidates = [
+    ...findScoreItemsByFindConstants(room),
+    ...findScoreItemsByFallbackRoomKeys(room)
+  ];
+  const unique = /* @__PURE__ */ new Map();
+  for (const candidate of candidates) {
+    unique.set(String(candidate.id), candidate);
+  }
+  return [...unique.values()];
+}
+function findScoreItemsByFindConstants(room) {
+  const roomFind = room.find;
+  if (typeof roomFind !== "function") {
+    return [];
+  }
+  return getScoreFindConstants().flatMap((findConstant) => safeRoomFind(room, roomFind, findConstant)).filter(isVisibleScoreItem);
+}
+function getScoreFindConstants() {
+  const globals = globalThis;
+  const constants = SCORE_FIND_CONSTANT_GLOBALS.map((name) => globals[name]).filter((value) => typeof value === "number" && Number.isFinite(value));
+  return [...new Set(constants)];
+}
+function safeRoomFind(room, roomFind, findConstant) {
+  try {
+    const result = roomFind.call(room, findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return [];
+  }
+}
+function findScoreItemsByFallbackRoomKeys(room) {
+  const roomRecord = room;
+  return SCORE_FALLBACK_ROOM_KEYS.flatMap((key) => toScoreItemCandidates(roomRecord[key])).filter(isVisibleScoreItem);
+}
+function toScoreItemCandidates(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value === "object" && value !== null) {
+    return Object.values(value);
+  }
+  return [];
+}
+function isVisibleScoreItem(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const candidate = value;
+  return typeof candidate.id === "string" && candidate.id.length > 0 && isRoomPositionLike(candidate.pos) && (hasScoreMarker(candidate) || !hasKnownNonScoreRoomObjectMarker(candidate));
+}
+function isRoomPositionLike(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const position = value;
+  return typeof position.x === "number" && typeof position.y === "number" && typeof position.roomName === "string";
+}
+function hasScoreMarker(candidate) {
+  return candidate.type === "score" || candidate.type === "scoreItem" || candidate.objectType === "score" || candidate.objectType === "scoreItem" || candidate.scoreType === "score" || candidate.scoreType === "scoreItem" || typeof candidate.score === "number" || typeof candidate.points === "number";
+}
+function hasKnownNonScoreRoomObjectMarker(candidate) {
+  return typeof candidate.resourceType === "string" || typeof candidate.structureType === "string" || Array.isArray(candidate.body) || typeof candidate.energyCapacity === "number" || typeof candidate.mineralType === "string" || typeof candidate.progressTotal === "number";
+}
+function compareScoreItems(creep, left, right) {
+  return getRangeTo(creep, left) - getRangeTo(creep, right) || String(left.id).localeCompare(String(right.id));
+}
+function getRangeTo(creep, target) {
+  var _a, _b;
+  const range = (_b = (_a = creep.pos) == null ? void 0 : _a.getRangeTo) == null ? void 0 : _b.call(_a, target);
+  return typeof range === "number" && Number.isFinite(range) ? range : Number.MAX_SAFE_INTEGER;
+}
+
 // src/tasks/workerTasks.ts
 var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
 var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
@@ -25183,6 +25323,10 @@ function selectHeuristicWorkerTask(creep) {
       if (linkEnergyAcquisitionTask) {
         return linkEnergyAcquisitionTask;
       }
+    }
+    const seasonScoreCollectionTask2 = selectSeasonScoreCollectionTask(creep);
+    if (seasonScoreCollectionTask2) {
+      return seasonScoreCollectionTask2;
     }
     const source = selectHarvestSource(creep);
     if (source) {
@@ -25506,6 +25650,10 @@ function selectHeuristicWorkerTask(creep) {
   const interRoomEnergyHaulTask = selectInterRoomEnergyHaulingTask(creep, carriedEnergy);
   if (interRoomEnergyHaulTask) {
     return interRoomEnergyHaulTask;
+  }
+  const seasonScoreCollectionTask = selectSeasonScoreCollectionTask(creep);
+  if (seasonScoreCollectionTask) {
+    return seasonScoreCollectionTask;
   }
   if ((controller == null ? void 0 : controller.my) && canUpgradeController(controller)) {
     return applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id });
@@ -31035,6 +31183,10 @@ function runWorker(creep) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
+  } else if (shouldPreemptEnergyAcquisitionTaskForSeasonScore(currentTask, selectedTask)) {
+    taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
+  } else if (shouldPreemptSeasonScoreTask(currentTask, selectedTask)) {
+    taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptTaskForUpgraderBoost(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForNearbyEnergyChoice(creep, currentTask, selectedTask)) {
@@ -31581,6 +31733,8 @@ function canExecuteTask(creep, task) {
       return typeof creep.signController === "function";
     case "upgrade":
       return typeof creep.upgradeController === "function";
+    case "collectScore":
+      return typeof creep.moveTo === "function";
   }
 }
 function assignNextTask(creep) {
@@ -31595,6 +31749,9 @@ function shouldReplaceTask(creep, task) {
     return false;
   }
   if (task.type === "signController") {
+    return false;
+  }
+  if (task.type === "collectScore") {
     return false;
   }
   if (!((_a = creep.store) == null ? void 0 : _a.getUsedCapacity) || !((_b = creep.store) == null ? void 0 : _b.getFreeCapacity)) {
@@ -31679,6 +31836,12 @@ function shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, task, 
     return shouldPreemptLowLoadEnergyAcquisitionForReturn(creep, selectedTask);
   }
   return isUrgentEnergySpendingTask(selectedTask) || isDowngradeGuardUpgradeTask(creep, selectedTask);
+}
+function shouldPreemptEnergyAcquisitionTaskForSeasonScore(task, selectedTask) {
+  return isEnergyAcquisitionTask2(task) && (selectedTask == null ? void 0 : selectedTask.type) === "collectScore" && !isSameTask2(task, selectedTask);
+}
+function shouldPreemptSeasonScoreTask(task, selectedTask) {
+  return task.type === "collectScore" && selectedTask !== null && !isSameTask2(task, selectedTask);
 }
 function shouldPreemptLowLoadEnergyAcquisitionForReturn(creep, selectedTask) {
   var _a;
@@ -32048,7 +32211,15 @@ function executeTask(creep, task, target) {
       );
     case "upgrade":
       return toTaskExecutionResult(runUpgrader(creep, target), "work");
+    case "collectScore":
+      return executeCollectScoreTask(creep, target);
   }
+}
+function executeCollectScoreTask(creep, target) {
+  if (!isInRangeToRoomObject(creep, target, EXACT_POSITION_MOVE_RANGE)) {
+    return { result: ERR_NOT_IN_RANGE_CODE6 };
+  }
+  return { result: OK_CODE11 };
 }
 function getSafeWithdrawEnergyAmount(creep, target, requestedAmount, task) {
   if (!task.constructionSiteId || !isSpawnEnergySource(target)) {
@@ -32225,6 +32396,8 @@ function getAssignedTaskMoveRange(task) {
     case "reserve":
     case "signController":
       return ADJACENT_ACTION_MOVE_RANGE;
+    case "collectScore":
+      return EXACT_POSITION_MOVE_RANGE;
   }
 }
 function isContainerStructure3(target) {
@@ -39015,41 +39188,6 @@ function getGameTime32() {
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.time) != null ? _b : 0;
 }
 
-// src/runtime/featureGates.ts
-function getRuntimeFeatureGates(game = getRuntimeGame2()) {
-  var _a, _b;
-  const shardName = normalizeString((_a = game == null ? void 0 : game.shard) == null ? void 0 : _a.name);
-  const shardType = normalizeString((_b = game == null ? void 0 : game.shard) == null ? void 0 : _b.type);
-  const isSeasonal = shardName === "shardSeason" || /season/i.test(shardType != null ? shardType : "");
-  const enabledInPersistent = !isSeasonal;
-  return {
-    cpu: buildCpuMetadata(game == null ? void 0 : game.cpu),
-    isSeasonal,
-    ...shardName ? { shardName } : {},
-    ...shardType ? { shardType } : {},
-    world: isSeasonal ? "seasonal" : "persistent",
-    marketTrading: enabledInPersistent,
-    terminalEnergyTransfers: enabledInPersistent,
-    labManagement: enabledInPersistent
-  };
-}
-function getRuntimeGame2() {
-  return globalThis.Game;
-}
-function buildCpuMetadata(cpu) {
-  return {
-    ...optionalFiniteNumber2("limit", cpu == null ? void 0 : cpu.limit),
-    ...optionalFiniteNumber2("bucket", cpu == null ? void 0 : cpu.bucket),
-    ...optionalFiniteNumber2("tickLimit", cpu == null ? void 0 : cpu.tickLimit)
-  };
-}
-function optionalFiniteNumber2(key, value) {
-  return typeof value === "number" && Number.isFinite(value) ? { [key]: value } : {};
-}
-function normalizeString(value) {
-  return typeof value === "string" && value.length > 0 ? value : void 0;
-}
-
 // src/economy/sourceWorkload.ts
 var HARVEST_ENERGY_PER_WORK_PART3 = 2;
 var DEFAULT_SOURCE_ENERGY_CAPACITY3 = 3e3;
@@ -39470,12 +39608,12 @@ function compareDemandTargets(left, right) {
 }
 function compareOptionalRange(worker, left, right) {
   var _a;
-  const getRangeTo2 = (_a = worker.pos) == null ? void 0 : _a.getRangeTo;
-  if (typeof getRangeTo2 !== "function") {
+  const getRangeTo3 = (_a = worker.pos) == null ? void 0 : _a.getRangeTo;
+  if (typeof getRangeTo3 !== "function") {
     return 0;
   }
-  const leftRange = getRangeTo2.call(worker.pos, left);
-  const rightRange = getRangeTo2.call(worker.pos, right);
+  const leftRange = getRangeTo3.call(worker.pos, left);
+  const rightRange = getRangeTo3.call(worker.pos, right);
   return normalizeRange2(leftRange) - normalizeRange2(rightRange);
 }
 function normalizeRange2(range) {
@@ -40106,7 +40244,7 @@ function executeBoostPlan(plan, options) {
       ...plan.lab ? { labId: getObjectId16(plan.lab) } : {}
     };
   }
-  const range = getRangeTo(plan.creep, plan.lab);
+  const range = getRangeTo2(plan.creep, plan.lab);
   if (range !== null && range > 1) {
     markCreepBoostState(plan.creep, "moving", plan);
     if (!options.dryRun && typeof plan.creep.moveTo === "function") {
@@ -40469,13 +40607,13 @@ function getBoostPlanStatusRank(plan) {
   }
   return plan.reason === "resourceUnavailable" ? 1 : 2;
 }
-function getRangeTo(creep, target) {
+function getRangeTo2(creep, target) {
   var _a;
-  const getRangeTo2 = (_a = creep.pos) == null ? void 0 : _a.getRangeTo;
-  if (typeof getRangeTo2 !== "function") {
+  const getRangeTo3 = (_a = creep.pos) == null ? void 0 : _a.getRangeTo;
+  if (typeof getRangeTo3 !== "function") {
     return null;
   }
-  const range = getRangeTo2.call(creep.pos, target);
+  const range = getRangeTo3.call(creep.pos, target);
   return typeof range === "number" && Number.isFinite(range) ? range : null;
 }
 function findRoomObjects30(room, globalConstantName) {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -82,6 +82,16 @@ interface TaskExecutionResult {
   sourceContainerWithdrawal?: boolean;
 }
 
+type ScoreTaskTarget = RoomObject & _HasId;
+type WorkerTaskTarget =
+  | Source
+  | Resource<ResourceConstant>
+  | AnyStoreStructure
+  | ConstructionSite
+  | StructureController
+  | Structure
+  | ScoreTaskTarget;
+
 export function runWorker(creep: Creep): void {
   if (runControllerSustainMovement(creep)) {
     return;
@@ -121,6 +131,10 @@ export function runWorker(creep: Creep): void {
   } else if (shouldPreemptEnergyAcquisitionTaskForSpawnReservationRefill(currentTask, spawnReservationRefillTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, currentTask, selectedTask)) {
+    taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
+  } else if (shouldPreemptEnergyAcquisitionTaskForSeasonScore(currentTask, selectedTask)) {
+    taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
+  } else if (shouldPreemptSeasonScoreTask(currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptTaskForUpgraderBoost(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
@@ -807,7 +821,7 @@ function executeAssignedTask(
     return;
   }
 
-  let target = Game.getObjectById(task.targetId);
+  let target = Game.getObjectById(task.targetId) as WorkerTaskTarget | null;
   if (!target) {
     if (selectedTask && isSameTask(task, selectedTask)) {
       recordCreepBehaviorIdle(creep);
@@ -820,7 +834,7 @@ function executeAssignedTask(
       return;
     }
 
-    target = Game.getObjectById(task.targetId);
+    target = Game.getObjectById(task.targetId) as WorkerTaskTarget | null;
     if (!target) {
       recordCreepBehaviorIdle(creep);
       return;
@@ -834,7 +848,7 @@ function executeAssignedTask(
       return;
     }
 
-    target = Game.getObjectById(task.targetId);
+    target = Game.getObjectById(task.targetId) as WorkerTaskTarget | null;
     if (!target || shouldReplaceTarget(creep, task, target)) {
       recordCreepBehaviorIdle(creep);
       return;
@@ -912,6 +926,8 @@ function canExecuteTask(creep: Creep, task: CreepTaskMemory): boolean {
       return typeof creep.signController === 'function';
     case 'upgrade':
       return typeof creep.upgradeController === 'function';
+    case 'collectScore':
+      return typeof creep.moveTo === 'function';
   }
 }
 
@@ -927,6 +943,10 @@ function shouldReplaceTask(creep: Creep, task: CreepTaskMemory): boolean {
   }
 
   if (task.type === 'signController') {
+    return false;
+  }
+
+  if (task.type === 'collectScore') {
     return false;
   }
 
@@ -1085,6 +1105,20 @@ function shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(
   }
 
   return isUrgentEnergySpendingTask(selectedTask) || isDowngradeGuardUpgradeTask(creep, selectedTask);
+}
+
+function shouldPreemptEnergyAcquisitionTaskForSeasonScore(
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  return isEnergyAcquisitionTask(task) && selectedTask?.type === 'collectScore' && !isSameTask(task, selectedTask);
+}
+
+function shouldPreemptSeasonScoreTask(
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  return task.type === 'collectScore' && selectedTask !== null && !isSameTask(task, selectedTask);
 }
 
 function shouldPreemptLowLoadEnergyAcquisitionForReturn(
@@ -1546,7 +1580,7 @@ function matchesCapacityConstructionStructureType(
 function shouldReplaceTarget(
   creep: Creep,
   task: CreepTaskMemory,
-  target: Source | Resource<ResourceConstant> | AnyStoreStructure | ConstructionSite | StructureController | Structure
+  target: WorkerTaskTarget
 ): boolean {
   if (task.type === 'harvest' && isDepletedHarvestSource(target)) {
     return !(isSourceContainerAssignedHarvestTask(task) && findVisibleHarvestSourceContainer(creep, target));
@@ -1579,7 +1613,7 @@ function isDepletedHarvestSource(target: unknown): target is Source {
 function executeTask(
   creep: Creep,
   task: CreepTaskMemory,
-  target: Source | Resource<ResourceConstant> | AnyStoreStructure | ConstructionSite | StructureController | Structure
+  target: WorkerTaskTarget
 ): TaskExecutionResult {
   switch (task.type) {
     case 'harvest':
@@ -1639,7 +1673,17 @@ function executeTask(
       );
     case 'upgrade':
       return toTaskExecutionResult(runUpgrader(creep, target as StructureController), 'work');
+    case 'collectScore':
+      return executeCollectScoreTask(creep, target as RoomObject);
   }
+}
+
+function executeCollectScoreTask(creep: Creep, target: RoomObject): TaskExecutionResult {
+  if (!isInRangeToRoomObject(creep, target, EXACT_POSITION_MOVE_RANGE)) {
+    return { result: ERR_NOT_IN_RANGE_CODE };
+  }
+
+  return { result: OK_CODE };
 }
 
 function getSafeWithdrawEnergyAmount(
@@ -1897,6 +1941,8 @@ function getAssignedTaskMoveRange(task: CreepTaskMemory): number {
     case 'reserve':
     case 'signController':
       return ADJACENT_ACTION_MOVE_RANGE;
+    case 'collectScore':
+      return EXACT_POSITION_MOVE_RANGE;
   }
 }
 

--- a/prod/src/season/scoreCollection.ts
+++ b/prod/src/season/scoreCollection.ts
@@ -1,0 +1,172 @@
+import { getRuntimeFeatureGates } from '../runtime/featureGates';
+
+type ScoreFindConstantGlobal =
+  | 'FIND_SCORE'
+  | 'FIND_SCORE_ITEMS'
+  | 'FIND_SCORE_OBJECTS'
+  | 'FIND_SEASON_SCORE'
+  | 'FIND_SEASON_SCORE_ITEMS';
+
+type SeasonScoreRoomKey =
+  | 'score'
+  | 'scores'
+  | 'scoreItems'
+  | 'scoreObjects'
+  | 'seasonScore'
+  | 'seasonScoreItems';
+
+interface SeasonScoreItem extends RoomObject {
+  id: Id<SeasonScoreItem>;
+}
+
+const SCORE_FIND_CONSTANT_GLOBALS: ScoreFindConstantGlobal[] = [
+  'FIND_SCORE',
+  'FIND_SCORE_ITEMS',
+  'FIND_SCORE_OBJECTS',
+  'FIND_SEASON_SCORE',
+  'FIND_SEASON_SCORE_ITEMS'
+];
+const SCORE_FALLBACK_ROOM_KEYS: SeasonScoreRoomKey[] = [
+  'score',
+  'scores',
+  'scoreItems',
+  'scoreObjects',
+  'seasonScore',
+  'seasonScoreItems'
+];
+
+export function selectSeasonScoreCollectionTask(
+  creep: Creep
+): Extract<CreepTaskMemory, { type: 'collectScore' }> | null {
+  if (!getRuntimeFeatureGates().isSeasonal || creep.memory?.role !== 'worker') {
+    return null;
+  }
+
+  const scoreItem = selectBestVisibleScoreItem(creep);
+  return scoreItem ? { type: 'collectScore', targetId: scoreItem.id } : null;
+}
+
+function selectBestVisibleScoreItem(creep: Creep): SeasonScoreItem | null {
+  const room = creep.room;
+  if (!room) {
+    return null;
+  }
+
+  return findVisibleScoreItems(room).sort((left, right) => compareScoreItems(creep, left, right))[0] ?? null;
+}
+
+function findVisibleScoreItems(room: Room): SeasonScoreItem[] {
+  const candidates = [
+    ...findScoreItemsByFindConstants(room),
+    ...findScoreItemsByFallbackRoomKeys(room)
+  ];
+  const unique = new Map<string, SeasonScoreItem>();
+
+  for (const candidate of candidates) {
+    unique.set(String(candidate.id), candidate);
+  }
+
+  return [...unique.values()];
+}
+
+function findScoreItemsByFindConstants(room: Room): SeasonScoreItem[] {
+  const roomFind = (room as Room & { find?: (type: number) => unknown }).find;
+  if (typeof roomFind !== 'function') {
+    return [];
+  }
+
+  return getScoreFindConstants()
+    .flatMap((findConstant) => safeRoomFind(room, roomFind, findConstant))
+    .filter(isVisibleScoreItem);
+}
+
+function getScoreFindConstants(): number[] {
+  const globals = globalThis as unknown as Partial<Record<ScoreFindConstantGlobal, unknown>>;
+  const constants = SCORE_FIND_CONSTANT_GLOBALS
+    .map((name) => globals[name])
+    .filter((value): value is number => typeof value === 'number' && Number.isFinite(value));
+
+  return [...new Set(constants)];
+}
+
+function safeRoomFind(room: Room, roomFind: (type: number) => unknown, findConstant: number): unknown[] {
+  try {
+    const result = roomFind.call(room, findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return [];
+  }
+}
+
+function findScoreItemsByFallbackRoomKeys(room: Room): SeasonScoreItem[] {
+  const roomRecord = room as unknown as Partial<Record<SeasonScoreRoomKey, unknown>>;
+  return SCORE_FALLBACK_ROOM_KEYS.flatMap((key) => toScoreItemCandidates(roomRecord[key])).filter(isVisibleScoreItem);
+}
+
+function toScoreItemCandidates(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    return Object.values(value);
+  }
+
+  return [];
+}
+
+function isVisibleScoreItem(value: unknown): value is SeasonScoreItem {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<SeasonScoreItem> & Record<string, unknown>;
+  return (
+    typeof candidate.id === 'string' &&
+    candidate.id.length > 0 &&
+    isRoomPositionLike(candidate.pos) &&
+    (hasScoreMarker(candidate) || !hasKnownNonScoreRoomObjectMarker(candidate))
+  );
+}
+
+function isRoomPositionLike(value: unknown): value is RoomPosition {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const position = value as Partial<RoomPosition>;
+  return typeof position.x === 'number' && typeof position.y === 'number' && typeof position.roomName === 'string';
+}
+
+function hasScoreMarker(candidate: Record<string, unknown>): boolean {
+  return (
+    candidate.type === 'score' ||
+    candidate.type === 'scoreItem' ||
+    candidate.objectType === 'score' ||
+    candidate.objectType === 'scoreItem' ||
+    candidate.scoreType === 'score' ||
+    candidate.scoreType === 'scoreItem' ||
+    typeof candidate.score === 'number' ||
+    typeof candidate.points === 'number'
+  );
+}
+
+function hasKnownNonScoreRoomObjectMarker(candidate: Record<string, unknown>): boolean {
+  return (
+    typeof candidate.resourceType === 'string' ||
+    typeof candidate.structureType === 'string' ||
+    Array.isArray(candidate.body) ||
+    typeof candidate.energyCapacity === 'number' ||
+    typeof candidate.mineralType === 'string' ||
+    typeof candidate.progressTotal === 'number'
+  );
+}
+
+function compareScoreItems(creep: Creep, left: SeasonScoreItem, right: SeasonScoreItem): number {
+  return getRangeTo(creep, left) - getRangeTo(creep, right) || String(left.id).localeCompare(String(right.id));
+}
+
+function getRangeTo(creep: Creep, target: RoomObject): number {
+  const range = creep.pos?.getRangeTo?.(target);
+  return typeof range === 'number' && Number.isFinite(range) ? range : Number.MAX_SAFE_INTEGER;
+}

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -79,6 +79,7 @@ import { SOURCE_HARVESTER_ROLE } from '../creeps/sourceHarvester';
 import { recordWorkerTaskBehaviorTrace } from '../rl/workerTaskBehavior';
 import { selectWorkerTaskWithBcFallback } from '../rl/workerTaskPolicy';
 import { getRuntimeCpuBudget } from '../runtime/cpuBudget';
+import { selectSeasonScoreCollectionTask } from '../season/scoreCollection';
 
 // Low-downgrade safety floor: enough buffer for worker travel/recovery without treating healthy controllers as urgent.
 export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
@@ -488,6 +489,11 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
       }
     }
 
+    const seasonScoreCollectionTask = selectSeasonScoreCollectionTask(creep);
+    if (seasonScoreCollectionTask) {
+      return seasonScoreCollectionTask;
+    }
+
     const source = selectHarvestSource(creep);
     if (source) {
       return createHarvestTaskForSource(creep, source);
@@ -887,6 +893,11 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
   const interRoomEnergyHaulTask = selectInterRoomEnergyHaulingTask(creep, carriedEnergy);
   if (interRoomEnergyHaulTask) {
     return interRoomEnergyHaulTask;
+  }
+
+  const seasonScoreCollectionTask = selectSeasonScoreCollectionTask(creep);
+  if (seasonScoreCollectionTask) {
+    return seasonScoreCollectionTask;
   }
 
   if (controller?.my && canUpgradeController(controller)) {

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -1341,5 +1341,6 @@ declare global {
     | { type: 'claim'; targetId: Id<StructureController> }
     | { type: 'reserve'; targetId: Id<StructureController> }
     | { type: 'signController'; targetId: Id<StructureController> }
-    | { type: 'upgrade'; targetId: Id<StructureController> };
+    | { type: 'upgrade'; targetId: Id<StructureController> }
+    | { type: 'collectScore'; targetId: Id<_HasId> };
 }

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -24,6 +24,15 @@ function withRangeTo<T extends { id: string }>(object: T, rangesByTargetId: Reco
   };
 }
 
+function makeScoreTarget(id: string): RoomObject & { id: string; score: number; scoreType: string } {
+  return {
+    id,
+    pos: { x: 12, y: 10, roomName: 'W1N1' } as RoomPosition,
+    score: 100,
+    scoreType: 'score'
+  } as unknown as RoomObject & { id: string; score: number; scoreType: string };
+}
+
 function makeControllerSigningMemory(
   roomName: string,
   controllerId: Id<StructureController>,
@@ -61,6 +70,7 @@ describe('runWorker', () => {
     (globalThis as unknown as { FIND_STRUCTURES: number }).FIND_STRUCTURES = 5;
     (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 6;
     (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 7;
+    delete (globalThis as unknown as { FIND_SCORE?: number }).FIND_SCORE;
     (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
     (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
     (globalThis as unknown as { STRUCTURE_LINK: StructureConstant }).STRUCTURE_LINK = 'link';
@@ -88,6 +98,119 @@ describe('runWorker', () => {
     runWorker(creep);
 
     expect(creep.memory.task).toEqual({ type: 'harvest', targetId: 'source1' });
+  });
+
+  it('moves to collect a score target at exact range without pickup', () => {
+    const score = makeScoreTarget('score1');
+    const pickup = jest.fn();
+    const moveTo = jest.fn();
+    const room = {
+      name: 'W1N1',
+      find: jest.fn().mockReturnValue([])
+    } as unknown as Room;
+    const creep = {
+      name: 'ScoreWorker',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'collectScore', targetId: 'score1' } as unknown as CreepTaskMemory
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'score1' ? 1 : 99)) },
+      room,
+      moveTo,
+      pickup
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { ScoreWorker: creep },
+      shard: { name: 'shardSeason' } as Game['shard'],
+      getObjectById: jest.fn((id: string) => (id === 'score1' ? score : null)) as unknown as Game['getObjectById']
+    };
+
+    runWorker(creep);
+
+    expect(moveTo).toHaveBeenCalledWith(score, { range: 0 });
+    expect(pickup).not.toHaveBeenCalled();
+  });
+
+  it('preempts assigned score collection for emergency spawn refill', () => {
+    (globalThis as unknown as { FIND_SCORE: number }).FIND_SCORE = 42;
+    const score = makeScoreTarget('score1');
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(300)
+      }
+    } as unknown as StructureSpawn;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 0,
+      energyCapacityAvailable: 300,
+      controller,
+      find: jest.fn((type: number, options?: { filter?: (structure: AnyOwnedStructure | Creep) => boolean }) => {
+        const findScore = (globalThis as unknown as { FIND_SCORE?: number }).FIND_SCORE;
+        if (typeof findScore === 'number' && type === findScore) {
+          return [score];
+        }
+
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn as unknown as AnyOwnedStructure];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return [];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const transfer = jest.fn().mockReturnValue(0);
+    const moveTo = jest.fn();
+    const creep = {
+      name: 'RefillWorker',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'collectScore', targetId: 'score1' } as unknown as CreepTaskMemory
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) =>
+          target.id === 'score1' ? 5 : target.id === 'spawn1' ? 1 : 99
+        )
+      },
+      room,
+      transfer,
+      moveTo
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { RefillWorker: creep },
+      shard: { name: 'shardSeason' } as Game['shard'],
+      getObjectById: jest.fn((id: string) =>
+        id === 'score1' ? score : id === 'spawn1' ? spawn : null
+      ) as unknown as Game['getObjectById']
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(transfer).toHaveBeenCalledWith(spawn, RESOURCE_ENERGY);
+    expect(moveTo).not.toHaveBeenCalledWith(score, { range: 0 });
   });
 
   it('withdraws construction-buffer spawn energy for an idle builder', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -276,6 +276,36 @@ function makeSource(id: string, x: number, y: number, energyOrRoomName: number |
   } as unknown as Source;
 }
 
+function makeScoreItem(id: string, x: number, y: number, roomName = 'W1N1'): RoomObject & { id: string; score: number; scoreType: string } {
+  return {
+    id,
+    pos: makeRoomPosition(x, y, roomName),
+    score: 100,
+    scoreType: 'score'
+  } as unknown as RoomObject & { id: string; score: number; scoreType: string };
+}
+
+function withVisibleScoreItems(room: Room, scoreItems: Array<RoomObject & { id: string }>): Room {
+  const baseFind = room.find as jest.Mock;
+  (room as unknown as { find: jest.Mock }).find = jest.fn((type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+    const findScore = (globalThis as unknown as { FIND_SCORE?: number }).FIND_SCORE;
+    if (typeof findScore === 'number' && type === findScore) {
+      return scoreItems;
+    }
+
+    return baseFind(type, options);
+  });
+  return room;
+}
+
+function setRuntimeShard(name: string): void {
+  const globalScope = globalThis as unknown as { Game?: Partial<Game> };
+  globalScope.Game = {
+    ...(globalScope.Game ?? {}),
+    shard: { name } as Game['shard']
+  };
+}
+
 function makePreHarvestSource(
   id: string,
   x: number,
@@ -512,6 +542,11 @@ describe('selectWorkerTask', () => {
     (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 7;
     (globalThis as unknown as { FIND_TOMBSTONES: number }).FIND_TOMBSTONES = 8;
     (globalThis as unknown as { FIND_RUINS: number }).FIND_RUINS = 9;
+    delete (globalThis as unknown as { FIND_SCORE?: number }).FIND_SCORE;
+    delete (globalThis as unknown as { FIND_SCORE_ITEMS?: number }).FIND_SCORE_ITEMS;
+    delete (globalThis as unknown as { FIND_SCORE_OBJECTS?: number }).FIND_SCORE_OBJECTS;
+    delete (globalThis as unknown as { FIND_SEASON_SCORE?: number }).FIND_SEASON_SCORE;
+    delete (globalThis as unknown as { FIND_SEASON_SCORE_ITEMS?: number }).FIND_SEASON_SCORE_ITEMS;
     (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
     (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
     (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
@@ -544,6 +579,81 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+  });
+
+  it('selects visible season score collection on Seasonal World when recovery work is absent', () => {
+    (globalThis as unknown as { FIND_SCORE: number }).FIND_SCORE = 42;
+    const score = makeScoreItem('score1', 12, 10);
+    const room = withVisibleScoreItems(makeWorkerTaskRoom(), [score]);
+    const creep = {
+      name: 'ScoreWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'score1' ? 2 : 99)) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ ScoreWorker: creep });
+    setRuntimeShard('shardSeason');
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'collectScore', targetId: 'score1' });
+  });
+
+  it('ignores visible score globals on persistent worlds and continues normal work', () => {
+    (globalThis as unknown as { FIND_SCORE: number }).FIND_SCORE = 42;
+    const source = makeSource('source1', 11, 10);
+    const score = makeScoreItem('score1', 12, 10);
+    const room = withVisibleScoreItems(makeWorkerTaskRoom({ sources: [source] }), [score]);
+    const creep = {
+      name: 'PersistentWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo: jest.fn().mockReturnValue(1) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ PersistentWorker: creep });
+    setRuntimeShard('shard3');
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+  });
+
+  it('keeps emergency spawn refill ahead of visible season score collection', () => {
+    (globalThis as unknown as { FIND_SCORE: number }).FIND_SCORE = 42;
+    const score = makeScoreItem('score1', 12, 10);
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const room = withVisibleScoreItems(
+      makeWorkerTaskRoom({
+        controller: {
+          id: 'controller1',
+          my: true,
+          level: 3,
+          ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+        } as StructureController,
+        energyAvailable: 0,
+        energyCapacityAvailable: 300,
+        myStructures: [spawn as AnyOwnedStructure]
+      }),
+      [score]
+    );
+    const creep = {
+      name: 'RefillWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      pos: { getRangeTo: jest.fn().mockReturnValue(1) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ RefillWorker: creep });
+    setRuntimeShard('shardSeason');
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
   });
 
   it('prefers a source that can fill the worker over a closer low-energy source', () => {


### PR DESCRIPTION
## Summary
- Add a Seasonal-only worker task for visible Score items so workers move onto Score positions and collect points opportunistically.
- Reuse existing worker task selection/runner machinery instead of adding a separate seasonal strategy layer.
- Keep hard safety priorities ahead of Score collection and preempt assigned score tasks when emergency refill / energy-critical / controller / territory work appears.
- Detect Score objects defensively via dynamic `FIND_SCORE`-style global constants with fallback room keys so regular-world typings stay compatible.

## Test Plan
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`
- `git diff --check origin/main...HEAD`

## Universal task Done gate
- [x] Task type: code.
- [x] Expected observable outcome / named deliverable: Seasonal-world workers opportunistically move onto visible Score items using existing worker task machinery.
- [x] Non-goals / accepted substitutes: No standalone seasonal strategy rewrite; no live Seasonal deploy in this PR.
- [x] Verification evidence required before Done: Controller ran typecheck, full Jest, build, and diff-check on head `990f9315`; CI validates the same PR head.
- [x] Project Evidence / Next action / Blocked by: Issue #1494 and PR #1496 Project items are In review with Evidence and Next action set; Blocked by has no active value.
- [x] Post-merge/deploy/runtime proof: N/A for live deploy; this is an offline code path PR with build artifact synchronization.
- [x] Named deliverable proof: N/A; expected outcome is code behavior covered by worker task and runner tests, not a named surface, URL, route, dashboard, or report.

## Issue closure gate
- [x] #1494: Seasonal score worker path implemented in PR #1496 with tests, build evidence, and synchronized bundle output.
- [x] No closed issue still needs runtime/process proof, owner action, successor work, partial-fix completion, or any other blocker.

Fixes #1494
