### PR TITLE
fix: default policy gradient batch to scenario v1

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -364,6 +364,9 @@ class Controller:
     final_status: str = "unknown"
     result: dict[str, Any] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        apply_policy_gradient_scenario_defaults(self.args)
+
     @property
     def tccLI(self) -> Path:  # keep misspelling out of external API; internal property only
         return Path(self.args.tccli)
@@ -415,6 +418,7 @@ class Controller:
         report_safety = training_report if isinstance(training_report, dict) else {}
         execution = controller_execution_summary(self.args, self.steps, self.result, self.scaled_up, self.instance_id)
         batch_scale = controller_batch_scale_summary(self.args, self.steps, self.result)
+        scenario_id = scenario_id_from_args(self.args)
         payload = {
             "type": "screeps-tencent-batch-rl-run",
             "schemaVersion": 1,
@@ -455,8 +459,8 @@ class Controller:
                 "workers": self.args.workers,
                 "repetitions": self.args.repetitions,
                 "trainingApproach": self.args.training_approach,
-                "scenarioId": getattr(self.args, "scenario_id", DEFAULT_SCENARIO_ID),
-                "requireMultiTierScenario": getattr(self.args, "require_multi_tier_scenario", False),
+                "scenarioId": scenario_id,
+                "requireMultiTierScenario": require_multi_tier_scenario_from_args(self.args, scenario_id),
                 "policyGradientTrustSampleRequest": policy_gradient_trust_sample_request(self.args),
                 "plannedBatchScale": planned_batch_scale_from_args(self.args),
                 "executionTimeouts": controller_timeout_summary(self.args),
@@ -4324,7 +4328,27 @@ def minimum_successful_environments(environment_count: int) -> int:
 
 
 def scenario_id_from_args(args: argparse.Namespace) -> str:
+    if policy_gradient_default_scenario_applies(args):
+        return MULTI_TIER_SCENARIO_ID
     return getattr(args, "scenario_id", None) or DEFAULT_SCENARIO_ID
+
+
+def scenario_id_explicitly_requested(args: argparse.Namespace) -> bool:
+    return "scenario_id" in set(getattr(args, "explicit_cli_options", ()))
+
+
+def policy_gradient_default_scenario_applies(args: argparse.Namespace) -> bool:
+    return (
+        getattr(args, "training_approach", None) == "policy_gradient"
+        and not scenario_id_explicitly_requested(args)
+    )
+
+
+def apply_policy_gradient_scenario_defaults(args: argparse.Namespace) -> None:
+    if not policy_gradient_default_scenario_applies(args):
+        return
+    args.scenario_id = MULTI_TIER_SCENARIO_ID
+    args.require_multi_tier_scenario = True
 
 
 def require_multi_tier_scenario_from_args(args: argparse.Namespace, scenario_id: str | None = None) -> bool:
@@ -4403,6 +4427,7 @@ def build_scale_proof_spec(
     experiment_card: dict[str, Any],
 ) -> dict[str, Any]:
     scenario_id = scenario_id_from_args(args)
+    require_multi_tier_scenario = require_multi_tier_scenario_from_args(args, scenario_id)
     fixture_evidence = (
         multi_tier_launch_fixture_evidence(scenario_id)
         if is_multi_tier_scenario_id(scenario_id)
@@ -4447,6 +4472,7 @@ def build_scale_proof_spec(
                 "trainingRunner": "scripts/screeps_rl_training_runner.py",
                 "simulatorHarness": "scripts/screeps_rl_simulator_harness.py",
                 "cardSimulationFields": card_simulation_fields,
+                "requireMultiTierScenario": require_multi_tier_scenario,
                 "policyGradientTrustSampleRequest": policy_gradient_trust_sample_request(args),
             },
         },
@@ -4534,6 +4560,7 @@ def scale_proof_failure_summary(raw: dict[str, Any], *, minimum: int) -> str:
 
 
 def validate_static_inputs(args: argparse.Namespace, run_id: str) -> None:
+    apply_policy_gradient_scenario_defaults(args)
     if not RUN_ID_RE.fullmatch(run_id):
         raise BatchRunError("run id must be lowercase and contain only letters, numbers, dot, underscore, hyphen")
     for path_label, path_text in {
@@ -4663,6 +4690,7 @@ def apply_cli_scenario_defaults(args: argparse.Namespace) -> argparse.Namespace:
             args.scenario_id = DEFAULT_SCENARIO_ID
     elif args.scenario_id == MULTI_TIER_SCENARIO_ID:
         args.require_multi_tier_scenario = True
+    apply_policy_gradient_scenario_defaults(args)
     apply_policy_gradient_validation_sample_defaults(args)
     return args
 

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -668,6 +668,27 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             },
         )
 
+    def test_controller_summary_resolves_policy_gradient_legacy_default_to_scenario_v1(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args = controller_args()
+            args.training_approach = "policy_gradient"
+            args.scenario_id = runner.MULTI_TIER_SCENARIO_IDS[0]
+            controller = runner.Controller(
+                args=args,
+                run_id="tencent-pg-20260529t093003z",
+                artifact_dir=Path(temp_dir) / "run",
+            )
+
+            controller.write_summary(partial=True)
+
+            summary = json.loads((controller.artifact_dir / "controller-summary.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(args.scenario_id, runner.MULTI_TIER_SCENARIO_ID)
+        self.assertTrue(args.require_multi_tier_scenario)
+        self.assertEqual(summary["inputs"]["trainingApproach"], "policy_gradient")
+        self.assertEqual(summary["inputs"]["scenarioId"], runner.MULTI_TIER_SCENARIO_ID)
+        self.assertTrue(summary["inputs"]["requireMultiTierScenario"])
+
     def test_run_cp_records_timeout_as_failed_step(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             controller = runner.Controller(args=controller_args(), run_id="run-test", artifact_dir=Path(temp_dir))
@@ -3197,6 +3218,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             args.artifact_root = artifact_root
             args.training_approach = "policy_gradient"
             args.ticks = 500
+            args.explicit_cli_options = {"scenario_id"}
 
             guard = runner.build_e1s1_repeat_launch_guard(
                 args=args,
@@ -3221,6 +3243,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             args.artifact_root = artifact_root
             args.training_approach = "policy_gradient"
             args.ticks = 500
+            args.explicit_cli_options = {"scenario_id"}
 
             guard = runner.build_e1s1_repeat_launch_guard(
                 args=args,
@@ -3253,6 +3276,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             args.artifact_root = artifact_root
             args.training_approach = "policy_gradient"
             args.ticks = 500
+            args.explicit_cli_options = {"scenario_id"}
 
             guard = runner.build_e1s1_repeat_launch_guard(
                 args=args,
@@ -3276,6 +3300,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             args.artifact_root = artifact_root
             args.training_approach = "policy_gradient"
             args.ticks = 500
+            args.explicit_cli_options = {"scenario_id"}
 
             guard = runner.build_e1s1_repeat_launch_guard(
                 args=args,
@@ -3301,6 +3326,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             args.artifact_root = artifact_root
             args.training_approach = "policy_gradient"
             args.ticks = 500
+            args.explicit_cli_options = {"scenario_id"}
 
             guard = runner.build_e1s1_repeat_launch_guard(
                 args=args,
@@ -3550,6 +3576,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             args.preflight_only = True
             args.training_approach = "policy_gradient"
             args.ticks = 500
+            args.explicit_cli_options = {"scenario_id"}
             artifact_dir = artifact_root / "new-run"
             controller = FakeController(args=args, run_id="new-run", artifact_dir=artifact_dir)
 
@@ -3720,6 +3747,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             runner.validate_static_inputs(args, "run-test")
 
             args.training_approach = "policy_gradient"
+            args.explicit_cli_options = {"scenario_id"}
             args.scenario_id = runner.DEFAULT_SCENARIO_ID
             args.require_multi_tier_scenario = False
             with self.assertRaisesRegex(runner.BatchRunError, "policy_gradient Tencent proof requires"):
@@ -3778,7 +3806,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(args.workers, 5)
         self.assertEqual(args.repetitions, 4)
 
-    def test_policy_gradient_explicit_v0_does_not_enter_required_multi_tier_path(self) -> None:
+    def test_policy_gradient_legacy_v0_default_resolves_to_active_multi_tier_scenario(self) -> None:
         args = controller_args()
         args.training_approach = "policy_gradient"
         args.scenario_id = runner.MULTI_TIER_SCENARIO_IDS[0]
@@ -3786,8 +3814,29 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
 
         runner.apply_cli_scenario_defaults(args)
 
-        self.assertEqual(args.scenario_id, runner.MULTI_TIER_SCENARIO_IDS[0])
-        self.assertFalse(args.require_multi_tier_scenario)
+        self.assertEqual(args.scenario_id, runner.MULTI_TIER_SCENARIO_ID)
+        self.assertEqual(runner.scenario_id_from_args(args), runner.MULTI_TIER_SCENARIO_ID)
+        self.assertTrue(runner.require_multi_tier_scenario_from_args(args))
+
+    def test_policy_gradient_explicit_v0_cli_request_is_rejected_by_static_guard(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            args = runner.parse_cli_args([
+                "preflight",
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_IDS[0],
+            ])
+            args.tccli = str(root / "tccli")
+            args.billing_guard = str(root / "billing-guard.py")
+            args.ssh_key = str(root / "id_ed25519")
+            args.secret_env = str(root / ".env")
+            for path in (args.tccli, args.billing_guard, args.ssh_key, args.secret_env):
+                write_text(Path(path))
+
+            with self.assertRaisesRegex(runner.BatchRunError, "policy_gradient Tencent proof requires"):
+                runner.validate_static_inputs(args, "run-test")
 
     def test_policy_gradient_validation_defaults_tolerate_unset_workers_and_repetitions(self) -> None:
         args = runner.build_parser().parse_args([
@@ -3854,22 +3903,16 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 observed_cmds.append(cmd)
                 if name == "generate_experiment_card":
                     output = Path(cmd[cmd.index("--output") + 1])
-                    payload = generated_experiment_card()
-                    payload["training_approach"] = "policy_gradient"
-                    if "--loop-a-policy-gradient-supply" in cmd:
-                        payload["card_supply"] = {
-                            "type": "screeps-rl-loop-a-card-supply",
-                            "consumer": "loop-a-policy-gradient",
-                            "state": "available",
-                            "available_for_training": True,
-                            "dataset_run_id": payload["dataset_run_id"],
-                            "training_approach": payload["training_approach"],
-                            "created_at": payload["created_at"],
-                            "status_field": "status",
-                            "safety_status": "shadow",
-                            "consumed_at": None,
-                            "consumed_by_report_id": None,
-                        }
+                    requested_scenario_id = cmd[cmd.index("--scenario-id") + 1]
+                    payload = card_helper.build_card(
+                        dataset_run_id="dataset-test",
+                        code_commit="a" * 40,
+                        training_approach="policy_gradient",
+                        created_at="2026-05-18T10:18:00Z",
+                        loop_a_card_supply="--loop-a-policy-gradient-supply" in cmd,
+                        scenario_id=requested_scenario_id,
+                        require_multi_tier_scenario="--require-multi-tier-scenario" in cmd,
+                    )
                     payload["simulation"]["ticks"] = 100
                     payload["simulation"]["workers"] = 1
                     payload["simulation"]["repetitions"] = 1
@@ -3882,11 +3925,16 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             card = json.loads((root / "experiment_card.json").read_text(encoding="utf-8"))
             spec = json.loads((root / "scale_proof_spec.json").read_text(encoding="utf-8"))
 
+        generate_cmd = observed_cmds[0]
+        self.assertEqual(generate_cmd[generate_cmd.index("--scenario-id") + 1], runner.MULTI_TIER_SCENARIO_ID)
+        self.assertIn("--require-multi-tier-scenario", generate_cmd)
         self.assertEqual(card["training_approach"], "policy_gradient")
-        self.assertIn("--loop-a-policy-gradient-supply", observed_cmds[0])
+        self.assertIn("--loop-a-policy-gradient-supply", generate_cmd)
         self.assertEqual(card["card_supply"]["type"], "screeps-rl-loop-a-card-supply")
         self.assertEqual(card["card_supply"]["consumer"], "loop-a-policy-gradient")
         self.assertTrue(card["card_supply"]["available_for_training"])
+        self.assertEqual(card["scenario"]["scenario_id"], runner.MULTI_TIER_SCENARIO_ID)
+        self.assertEqual(card["simulation"]["map_source_file"], runner.MULTI_TIER_SIMULATION_MAP_SOURCE_REL)
         self.assertEqual(card["simulation"]["ticks"], runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS)
         self.assertEqual(card["simulation"]["workers"], 5)
         self.assertEqual(card["simulation"]["repetitions"], 5)
@@ -3895,6 +3943,12 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(controller.result["experimentCard"]["trainingApproach"], "policy_gradient")
         self.assertEqual(controller.result["experimentCard"]["cardSupply"]["state"], "available")
         self.assertEqual(spec["experimentCard"]["cardSupply"]["state"], "available")
+        self.assertEqual(spec["experimentCard"]["scenario"]["scenario_id"], runner.MULTI_TIER_SCENARIO_ID)
+        self.assertTrue(spec["scaleProof"]["remoteRunnerContract"]["requireMultiTierScenario"])
+        self.assertEqual(
+            spec["scaleProof"]["remoteRunnerContract"]["cardSimulationFields"]["scenario_id"],
+            runner.MULTI_TIER_SCENARIO_ID,
+        )
         self.assertEqual(
             spec["scaleProof"]["remoteRunnerContract"]["cardSimulationFields"]["ticks"],
             runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS,
@@ -4478,6 +4532,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(card["simulation"]["map_source_file"], runner.MULTI_TIER_SIMULATION_MAP_SOURCE_REL)
         self.assertEqual(card["scenario"]["evidence"]["map_source_file"], runner.MULTI_TIER_SIMULATION_MAP_SOURCE_REL)
         self.assertEqual(spec["experimentCard"]["scenario"]["scenario_id"], runner.MULTI_TIER_SCENARIO_ID)
+        self.assertTrue(spec["scaleProof"]["remoteRunnerContract"]["requireMultiTierScenario"])
         self.assertEqual(
             spec["scaleProof"]["remoteRunnerContract"]["cardSimulationFields"]["map_source_file"],
             runner.MULTI_TIER_SIMULATION_MAP_SOURCE_REL,

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -31,6 +31,17 @@ READY_RUNTIME_SCORECARD_PATH = (
 )
 
 
+def legacy_multi_tier_scenario_id() -> str:
+    legacy_ids = tuple(
+        scenario_id
+        for scenario_id in runner.MULTI_TIER_SCENARIO_IDS
+        if scenario_id != runner.MULTI_TIER_SCENARIO_ID
+    )
+    if len(legacy_ids) != 1:
+        raise AssertionError("expected exactly one legacy multi-tier scenario ID")
+    return legacy_ids[0]
+
+
 def ready_runtime_pair_scorecard_path(scorecard_id: str, candidate_id: str, baseline_id: str) -> str:
     return (
         "runtime-artifacts/rl-training/candidate-scorecards/run-test/"
@@ -672,7 +683,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             args = controller_args()
             args.training_approach = "policy_gradient"
-            args.scenario_id = runner.MULTI_TIER_SCENARIO_IDS[0]
+            args.scenario_id = legacy_multi_tier_scenario_id()
             controller = runner.Controller(
                 args=args,
                 run_id="tencent-pg-20260529t093003z",
@@ -3753,7 +3764,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             with self.assertRaisesRegex(runner.BatchRunError, "policy_gradient Tencent proof requires"):
                 runner.validate_static_inputs(args, "run-test")
 
-            args.scenario_id = runner.MULTI_TIER_SCENARIO_IDS[0]
+            args.scenario_id = legacy_multi_tier_scenario_id()
             args.require_multi_tier_scenario = False
             with self.assertRaisesRegex(runner.BatchRunError, "policy_gradient Tencent proof requires"):
                 runner.validate_static_inputs(args, "run-test")
@@ -3809,7 +3820,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
     def test_policy_gradient_legacy_v0_default_resolves_to_active_multi_tier_scenario(self) -> None:
         args = controller_args()
         args.training_approach = "policy_gradient"
-        args.scenario_id = runner.MULTI_TIER_SCENARIO_IDS[0]
+        args.scenario_id = legacy_multi_tier_scenario_id()
         args.require_multi_tier_scenario = False
 
         runner.apply_cli_scenario_defaults(args)
@@ -3826,7 +3837,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 "--training-approach",
                 "policy_gradient",
                 "--scenario-id",
-                runner.MULTI_TIER_SCENARIO_IDS[0],
+                legacy_multi_tier_scenario_id(),
             ])
             args.tccli = str(root / "tccli")
             args.billing_guard = str(root / "billing-guard.py")


### PR DESCRIPTION
## Summary
- Default Tencent policy-gradient batch runs without an explicit scenario to the active `multi-tier-territory-combat-v1` scenario.
- Automatically set the multi-tier requirement for those defaulted policy-gradient runs and propagate it into controller summaries / scale-proof specs.
- Preserve the explicit incompatible v0/default scenario guard so unsafe policy-gradient requests still fail before compute.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py scripts/screeps_rl_experiment_card.py`
- `python3 -m unittest scripts/test_screeps_tencent_batch_rl_runner.py` (137 tests OK)

## Safety
- No paid Tencent compute was launched by this PR.
- No official MMO writes.
- The post-merge validation action remains a guarded batch/preflight lane.

Fixes #1497

## Issue closure gate
- [x] #1497: Codex-authored commit `e680d521454cffca0fb06225c32e5f0242824d00` makes policy-gradient default dispatch resolve to scenario v1, adds focused regression coverage, and passed controller verification listed above.

## Universal task Done gate
- [x] Task type: P0 RL flywheel code fix for Tencent batch policy-gradient dispatch.
- [x] Expected observable outcome / named deliverable: PR #1498 makes default policy-gradient Tencent batch experiment cards and scale-proof specs use multi-tier-territory-combat-v1 while preserving explicit incompatible v0 rejection.
- [x] Non-goals / accepted substitutes: No paid Tencent compute, no official MMO writes, no reward-weight changes, no broad runner refactor.
- [x] Verification evidence required before Done: git diff --check; py_compile for runner and tests; python3 -m unittest scripts/test_screeps_tencent_batch_rl_runner.py with 137 tests OK; prod-ci green on head e680d521454cffca0fb06225c32e5f0242824d00.
- [x] Project Evidence / Next action / Blocked by: Issue #1497 item and PR #1498 item are in Project screeps with Status In review, P0, RL flywheel, code, evidence e680d521 and next gate action; no external owner blocker.
- [x] Post-merge/deploy/runtime proof: Merge PR #1498, fast-forward main, then record guarded scenario-v1 batch preflight or validation artifact in #1497 and #879 before compute-scale continuation.
- [x] Named deliverable proof: PR #1498 diff changes scenario resolution and tests in scripts/screeps_tencent_batch_rl_runner.py plus scripts/test_screeps_tencent_batch_rl_runner.py; controller run proved generated card/spec v1 propagation and explicit v0 rejection.
