### PR TITLE
fix: reduce critical CPU runtime churn

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -24805,19 +24805,9 @@ var cpuTelemetryState = {
   bucketEmptyTicks: 0,
   overLimitTicks: 0
 };
-var runtimeCpuBudgetCache = null;
 function getRuntimeCpuBudget(game) {
   const runtimeGame = game != null ? game : getRuntimeGame();
-  const tick = normalizeTick(runtimeGame == null ? void 0 : runtimeGame.time);
-  const shouldUseCache = game === void 0 && runtimeGame !== void 0 && tick > 0;
-  if (shouldUseCache && (runtimeCpuBudgetCache == null ? void 0 : runtimeCpuBudgetCache.game) === runtimeGame && runtimeCpuBudgetCache.tick === tick) {
-    return runtimeCpuBudgetCache.budget;
-  }
-  const budget = buildRuntimeCpuBudget(readRuntimeCpuSample(runtimeGame));
-  if (shouldUseCache) {
-    runtimeCpuBudgetCache = { game: runtimeGame, tick: budget.tick, budget };
-  }
-  return budget;
+  return buildRuntimeCpuBudget(readRuntimeCpuSample(runtimeGame));
 }
 function buildRuntimeCpuBudget(sample) {
   const reasons = [];
@@ -46794,6 +46784,7 @@ var LOW_ROOM_ENERGY_TASK_PRIORITY_RATIO = 0.5;
 function runEconomy(preludeTelemetryEvents = [], options = {}) {
   var _a, _b, _c, _d;
   const featureGates = getRuntimeFeatureGates();
+  const shouldRunOptionalGlobalWork = () => shouldRunOptionalCpuWork(getRuntimeCpuBudget(), "economy-global-optional");
   const cpuBudget = getRuntimeCpuBudget();
   const runOptionalGlobalWork = shouldRunOptionalCpuWork(cpuBudget, "economy-global-optional");
   const creeps = Object.values(Game.creeps);
@@ -46822,7 +46813,8 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
   const postClaimBootstrapFocusRoomName = selectPostClaimBootstrapFocusRoomName(colonies);
   const controllerUpgradeTargetRooms = getControllerUpgradeTargetRooms2(colonies);
   for (const colony of colonies) {
-    const runOptionalRoomWork = shouldRunOptionalCpuRoomWork(cpuBudget, colony.room.name);
+    let roomCpuBudget = getRuntimeCpuBudget();
+    let runOptionalRoomWork = shouldRunOptionalCpuRoomWork(roomCpuBudget, colony.room.name);
     recordSourceWorkloads(colony.room, creeps, Game.time);
     let roleCounts = getPlannedOrCurrentRoleCounts(creeps, colony.room.name, plannedRoleCountsByRoom);
     plannedRoleCountsByRoom.set(colony.room.name, roleCounts);
@@ -46846,7 +46838,7 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
       telemetryEvents,
       { focusRoomName: postClaimBootstrapFocusRoomName }
     );
-    if (shouldRunConstructionPlanning(cpuBudget, runOptionalRoomWork, survivalAssessment)) {
+    if (shouldRunConstructionPlanning(roomCpuBudget, runOptionalRoomWork, survivalAssessment)) {
       refreshPostClaimDefenseConstruction(colony, { focusRoomName: postClaimBootstrapFocusRoomName });
     }
     const constructionOptions = {
@@ -46856,7 +46848,7 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
       runtimeStrategyConstructionEnabled: options.runtimeStrategyConstructionEnabled,
       onStrategyRegistryRuntimeUse: options.onStrategyRegistryRuntimeUse
     };
-    if (shouldRunConstructionPlanning(cpuBudget, runOptionalRoomWork, survivalAssessment)) {
+    if (shouldRunConstructionPlanning(roomCpuBudget, runOptionalRoomWork, survivalAssessment)) {
       if (postClaimBootstrapRefresh.deferred === true) {
         planDeferredClaimedRoomCapacityConstruction(colony, constructionOptions);
       } else {
@@ -46865,13 +46857,13 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
         });
       }
     }
-    if (survivalAssessment.mode === "TERRITORY_READY" && shouldRunTerritoryPlanning(cpuBudget, runOptionalRoomWork)) {
+    if (survivalAssessment.mode === "TERRITORY_READY" && shouldRunTerritoryPlanning(roomCpuBudget, runOptionalRoomWork)) {
       refreshRemoteMiningSetup(colony, Game.time, { focusRoomName: postClaimBootstrapFocusRoomName });
     }
-    if (shouldRunTerritoryPlanning(cpuBudget, runOptionalRoomWork)) {
+    if (shouldRunTerritoryPlanning(roomCpuBudget, runOptionalRoomWork)) {
       refreshExecutableTerritoryRecommendation(colony, creeps, survivalAssessment.territoryReady, telemetryEvents);
     }
-    if (survivalAssessment.territoryReady && shouldRunTerritoryPlanning(cpuBudget, runOptionalRoomWork)) {
+    if (survivalAssessment.territoryReady && shouldRunTerritoryPlanning(roomCpuBudget, runOptionalRoomWork)) {
       refreshClaimExecutionTargets({ colony: colony.room.name, gameTime: Game.time });
       refreshReserveExecutionTargets({ colony: colony.room.name, gameTime: Game.time });
     }
@@ -46944,6 +46936,8 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
       }
     }
     transferEnergy(colony.room);
+    roomCpuBudget = getRuntimeCpuBudget();
+    runOptionalRoomWork = shouldRunOptionalCpuRoomWork(roomCpuBudget, colony.room.name);
     if (runOptionalRoomWork) {
       manageStorage(colony.room);
       refreshRoomEnergySurplusState(colony.room);
@@ -46956,11 +46950,11 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
       recordStrategyRecommendationTelemetry(colony, creeps, telemetryEvents);
     }
   }
-  if (runOptionalGlobalWork) {
+  if (shouldRunOptionalGlobalWork()) {
     ensureRemoteSourceContainersForAssignedHarvesters(creeps);
   }
   attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom);
-  if (runOptionalGlobalWork) {
+  if (shouldRunOptionalGlobalWork()) {
     attemptMineralHarvesterSpawns(colonies, creeps, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom);
   }
   refreshSpawnEnergyReservationStates(colonies);
@@ -48479,7 +48473,6 @@ var strategyRegistryState = {
 var recentKpiWindows = {};
 var baselineKpiWindows = {};
 function loop() {
-  const cpuBudget = getRuntimeCpuBudget();
   const runtimePolicyParameters = applyRuntimePolicyParametersToRegistry(strategyRegistryState.entries);
   const hasPatchedRuntimeStrategies = runtimePolicyParameters.evidence.appliedStrategyIds.length > 0;
   const runtimePolicyParameterPlanningEnabled = runtimePolicyParameters.evidence.runtimeParameterInjection === true && hasPatchedRuntimeStrategies;
@@ -48503,7 +48496,7 @@ function loop() {
   } finally {
     persistRuntimePolicyParameterConsumptionEvidence(runtimePolicyParameterConsumption.buildEvidence());
   }
-  if (!cpuBudget.degraded) {
+  if (!getRuntimeCpuBudget().degraded) {
     strategyRegistryState.entries = runStrategyRolloutMonitoring(summary, strategyRegistryState.entries);
   }
 }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -24805,8 +24805,19 @@ var cpuTelemetryState = {
   bucketEmptyTicks: 0,
   overLimitTicks: 0
 };
-function getRuntimeCpuBudget(game = getRuntimeGame()) {
-  return buildRuntimeCpuBudget(readRuntimeCpuSample(game));
+var runtimeCpuBudgetCache = null;
+function getRuntimeCpuBudget(game) {
+  const runtimeGame = game != null ? game : getRuntimeGame();
+  const tick = normalizeTick(runtimeGame == null ? void 0 : runtimeGame.time);
+  const shouldUseCache = game === void 0 && runtimeGame !== void 0 && tick > 0;
+  if (shouldUseCache && (runtimeCpuBudgetCache == null ? void 0 : runtimeCpuBudgetCache.game) === runtimeGame && runtimeCpuBudgetCache.tick === tick) {
+    return runtimeCpuBudgetCache.budget;
+  }
+  const budget = buildRuntimeCpuBudget(readRuntimeCpuSample(runtimeGame));
+  if (shouldUseCache) {
+    runtimeCpuBudgetCache = { game: runtimeGame, tick: budget.tick, budget };
+  }
+  return budget;
 }
 function buildRuntimeCpuBudget(sample) {
   const reasons = [];
@@ -31348,7 +31359,7 @@ function shouldRetainAssignedTaskUnderCriticalCpu(creep, task) {
     return false;
   }
   if (isEnergyAcquisitionTask2(task)) {
-    return getFreeTransferEnergyCapacity(creep) > 0;
+    return getFreeTransferEnergyCapacity(creep) > 0 && getUsedTransferEnergy(creep) <= 0;
   }
   if (task.type === "transfer" || isEnergySpendingTask(task)) {
     return getUsedTransferEnergy(creep) > 0;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -24887,7 +24887,7 @@ function shouldRunOptionalCpuRoomWork(budget, roomName, interval = DEGRADED_ROOM
   return isCadenceTick(budget.tick, roomName, interval);
 }
 function shouldThrottleRuntimeSummaryCadence(budget) {
-  return budget.lowCpuLimit;
+  return budget.degraded;
 }
 function updateRuntimeCpuTelemetryState(sample) {
   resetRuntimeCpuTelemetryStateForTick(sample.tick);
@@ -31155,6 +31155,10 @@ function runWorker(creep) {
   }
   observeCreepBehaviorTick(creep);
   const currentTask = creep.memory.task;
+  if (shouldRetainAssignedTaskUnderCriticalCpu(creep, currentTask)) {
+    executeAssignedTask(creep, null);
+    return;
+  }
   const baseSelectedTask = selectWorkerTaskForRunner(creep);
   const energyCriticalTask = selectWorkerEnergyCriticalTask(creep, currentTask, baseSelectedTask);
   const spawnReservationRefillTask = selectSpawnEnergyReservationRefillTask(
@@ -31338,6 +31342,18 @@ function getGameTick4() {
 function selectWorkerTaskForRunner(creep) {
   const selectedTask = selectWorkerTask(creep);
   return fallbackToEnergyOnNullSelectionLoop(creep, selectedTask);
+}
+function shouldRetainAssignedTaskUnderCriticalCpu(creep, task) {
+  if (!getRuntimeCpuBudget().critical || !task || !canExecuteTask(creep, task)) {
+    return false;
+  }
+  if (isEnergyAcquisitionTask2(task)) {
+    return getFreeTransferEnergyCapacity(creep) > 0;
+  }
+  if (task.type === "transfer" || isEnergySpendingTask(task)) {
+    return getUsedTransferEnergy(creep) > 0;
+  }
+  return task.type === "signController" || isTerritoryControlTask2(task);
 }
 function selectSpawnEnergyReservationRefillTask(creep, currentTask, selectedTask) {
   if (shouldDeferSpawnReservationRefillForProductiveWork(creep, selectedTask)) {
@@ -37239,7 +37255,7 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   }
   const reportedEvents = events.slice(0, MAX_REPORTED_EVENTS);
   const persistOccupationRecommendations = options.persistOccupationRecommendations !== false;
-  const includeOptionalSummary = !shouldThrottleRuntimeSummaryCadence(cpuBudget) && !cpuBudget.critical;
+  const includeOptionalSummary = !cpuBudget.lowCpuLimit && !cpuBudget.critical;
   const rooms = colonies.map(
     (colony) => {
       var _a, _b;
@@ -37335,13 +37351,9 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
   const tick = getGameTime32();
   const colonyWorkers = colonyCreeps.filter((creep) => creep.memory.role === "worker");
   const roleCounts = countCreepsByRole(colonyCreeps, colony.room.name);
-  const territoryExpansion = buildRuntimeExpansionCandidateReport(colony);
-  const territoryRecommendation = buildRuntimeOccupationRecommendationReport(
-    colony,
-    colonyWorkers,
-    territoryExpansion
-  );
-  if (persistOccupationRecommendations) {
+  const territoryExpansion = includeOptionalSummary ? buildRuntimeExpansionCandidateReport(colony) : void 0;
+  const territoryRecommendation = territoryExpansion ? buildRuntimeOccupationRecommendationReport(colony, colonyWorkers, territoryExpansion) : emptyTerritoryRecommendationReport();
+  if (persistOccupationRecommendations && includeOptionalSummary) {
     persistOccupationRecommendationFollowUpIntent(territoryRecommendation, tick);
   }
   const resources = summarizeResources(colony, colonyWorkers, colonyCreeps, eventMetrics.resources);
@@ -37382,8 +37394,8 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
       onStrategyRegistryRuntimeUse
     ) : emptyConstructionPrioritySummary(),
     survival: summarizeSurvival(colony, roleCounts),
-    territoryRecommendation: includeOptionalSummary ? territoryRecommendation : emptyTerritoryRecommendationReport(),
-    ...includeOptionalSummary && territoryExpansion.candidates.length > 0 ? { territoryExpansion } : {},
+    territoryRecommendation,
+    ...territoryExpansion && territoryExpansion.candidates.length > 0 ? { territoryExpansion } : {},
     ...includeOptionalSummary ? buildTerritoryIntentSummary(colony.room.name, roleCounts) : {},
     ...includeOptionalSummary ? buildTerritoryExecutionHintSummary(colony.room.name) : {},
     ...includeOptionalSummary ? buildTerritoryScoutSummary(colony, roleCounts) : {},

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -31361,7 +31361,10 @@ function getCriticalCpuTaskRetentionDecision(creep, task) {
   if (task.type === "transfer") {
     return getCriticalCpuTransferRetentionDecision(creep, task);
   }
-  return { retain: isTerritoryControlTask2(task) };
+  if (isTerritoryControlTask2(task)) {
+    return getCriticalCpuTerritoryControlRetentionDecision(creep, task);
+  }
+  return { retain: false };
 }
 function getCriticalCpuTransferRetentionDecision(creep, task) {
   if (getUsedTransferEnergy(creep) <= 0) {
@@ -31370,6 +31373,10 @@ function getCriticalCpuTransferRetentionDecision(creep, task) {
   const selectionContext = selectWorkerTaskContext(creep, task);
   const shouldPreempt = shouldPreemptForWorkerEnergyCriticalTask(task, selectionContext.energyCriticalTask) || shouldPreemptTransferTaskForControllerDowngradeGuard(creep, task, selectionContext.selectedTask) || shouldPreemptTransferTaskForBetterEnergySink(creep, task, selectionContext.selectedTask);
   return { retain: !shouldPreempt, selectionContext };
+}
+function getCriticalCpuTerritoryControlRetentionDecision(creep, task) {
+  const selectionContext = selectWorkerTaskContext(creep, task);
+  return { retain: isSameOptionalTask(task, selectionContext.selectedTask), selectionContext };
 }
 function selectSpawnEnergyReservationRefillTask(creep, currentTask, selectedTask) {
   if (shouldDeferSpawnReservationRefillForProductiveWork(creep, selectedTask)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -31364,7 +31364,7 @@ function shouldRetainAssignedTaskUnderCriticalCpu(creep, task) {
   if (task.type === "transfer" || isEnergySpendingTask(task)) {
     return getUsedTransferEnergy(creep) > 0;
   }
-  return task.type === "signController" || isTerritoryControlTask2(task);
+  return isTerritoryControlTask2(task);
 }
 function selectSpawnEnergyReservationRefillTask(creep, currentTask, selectedTask) {
   if (shouldDeferSpawnReservationRefillForProductiveWork(creep, selectedTask)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -31361,7 +31361,7 @@ function shouldRetainAssignedTaskUnderCriticalCpu(creep, task) {
   if (isEnergyAcquisitionTask2(task)) {
     return getFreeTransferEnergyCapacity(creep) > 0 && getUsedTransferEnergy(creep) <= 0;
   }
-  if (task.type === "transfer" || isEnergySpendingTask(task)) {
+  if (task.type === "transfer") {
     return getUsedTransferEnergy(creep) > 0;
   }
   return isTerritoryControlTask2(task);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -31166,18 +31166,13 @@ function runWorker(creep) {
   }
   observeCreepBehaviorTick(creep);
   const currentTask = creep.memory.task;
-  if (shouldRetainAssignedTaskUnderCriticalCpu(creep, currentTask)) {
+  const criticalCpuTaskRetention = getCriticalCpuTaskRetentionDecision(creep, currentTask);
+  if (criticalCpuTaskRetention.retain) {
     executeAssignedTask(creep, null);
     return;
   }
-  const baseSelectedTask = selectWorkerTaskForRunner(creep);
-  const energyCriticalTask = selectWorkerEnergyCriticalTask(creep, currentTask, baseSelectedTask);
-  const spawnReservationRefillTask = selectSpawnEnergyReservationRefillTask(
-    creep,
-    currentTask,
-    energyCriticalTask != null ? energyCriticalTask : baseSelectedTask
-  );
-  const selectedTask = (_a = spawnReservationRefillTask != null ? spawnReservationRefillTask : energyCriticalTask) != null ? _a : baseSelectedTask;
+  const selectionContext = (_a = criticalCpuTaskRetention.selectionContext) != null ? _a : selectWorkerTaskContext(creep, currentTask);
+  const { baseSelectedTask, energyCriticalTask, selectedTask, spawnReservationRefillTask } = selectionContext;
   let taskAssignedThisTick = false;
   if (!currentTask) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask) !== null;
@@ -31354,17 +31349,37 @@ function selectWorkerTaskForRunner(creep) {
   const selectedTask = selectWorkerTask(creep);
   return fallbackToEnergyOnNullSelectionLoop(creep, selectedTask);
 }
-function shouldRetainAssignedTaskUnderCriticalCpu(creep, task) {
+function selectWorkerTaskContext(creep, currentTask) {
+  var _a;
+  const baseSelectedTask = selectWorkerTaskForRunner(creep);
+  const energyCriticalTask = selectWorkerEnergyCriticalTask(creep, currentTask, baseSelectedTask);
+  const spawnReservationRefillTask = selectSpawnEnergyReservationRefillTask(
+    creep,
+    currentTask,
+    energyCriticalTask != null ? energyCriticalTask : baseSelectedTask
+  );
+  const selectedTask = (_a = spawnReservationRefillTask != null ? spawnReservationRefillTask : energyCriticalTask) != null ? _a : baseSelectedTask;
+  return { baseSelectedTask, energyCriticalTask, selectedTask, spawnReservationRefillTask };
+}
+function getCriticalCpuTaskRetentionDecision(creep, task) {
   if (!getRuntimeCpuBudget().critical || !task || !canExecuteTask(creep, task)) {
-    return false;
+    return { retain: false };
   }
   if (isEnergyAcquisitionTask2(task)) {
-    return getFreeTransferEnergyCapacity(creep) > 0 && getUsedTransferEnergy(creep) <= 0;
+    return { retain: getFreeTransferEnergyCapacity(creep) > 0 && getUsedTransferEnergy(creep) <= 0 };
   }
   if (task.type === "transfer") {
-    return getUsedTransferEnergy(creep) > 0;
+    return getCriticalCpuTransferRetentionDecision(creep, task);
   }
-  return isTerritoryControlTask2(task);
+  return { retain: isTerritoryControlTask2(task) };
+}
+function getCriticalCpuTransferRetentionDecision(creep, task) {
+  if (getUsedTransferEnergy(creep) <= 0) {
+    return { retain: false };
+  }
+  const selectionContext = selectWorkerTaskContext(creep, task);
+  const shouldPreempt = shouldPreemptForWorkerEnergyCriticalTask(task, selectionContext.energyCriticalTask) || shouldPreemptTransferTaskForControllerDowngradeGuard(creep, task, selectionContext.selectedTask) || shouldPreemptTransferTaskForBetterEnergySink(creep, task, selectionContext.selectedTask);
+  return { retain: !shouldPreempt, selectionContext };
 }
 function selectSpawnEnergyReservationRefillTask(creep, currentTask, selectedTask) {
   if (shouldDeferSpawnReservationRefillForProductiveWork(creep, selectedTask)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -31147,7 +31147,7 @@ var RANGED_WORK_MOVE_RANGE = 3;
 var EXACT_POSITION_MOVE_RANGE = 0;
 var MIN_HAULER_DROPPED_ENERGY = 25;
 function runWorker(creep) {
-  var _a;
+  var _a, _b;
   if (runControllerSustainMovement(creep)) {
     return;
   }
@@ -31158,10 +31158,10 @@ function runWorker(creep) {
   const currentTask = creep.memory.task;
   const criticalCpuTaskRetention = getCriticalCpuTaskRetentionDecision(creep, currentTask);
   if (criticalCpuTaskRetention.retain) {
-    executeAssignedTask(creep, null);
+    executeAssignedTask(creep, (_a = criticalCpuTaskRetention.retainedTask) != null ? _a : null);
     return;
   }
-  const selectionContext = (_a = criticalCpuTaskRetention.selectionContext) != null ? _a : selectWorkerTaskContext(creep, currentTask);
+  const selectionContext = (_b = criticalCpuTaskRetention.selectionContext) != null ? _b : selectWorkerTaskContext(creep, currentTask);
   const { baseSelectedTask, energyCriticalTask, selectedTask, spawnReservationRefillTask } = selectionContext;
   let taskAssignedThisTick = false;
   if (!currentTask) {
@@ -31376,7 +31376,8 @@ function getCriticalCpuTransferRetentionDecision(creep, task) {
 }
 function getCriticalCpuTerritoryControlRetentionDecision(creep, task) {
   const selectionContext = selectWorkerTaskContext(creep, task);
-  return { retain: isSameOptionalTask(task, selectionContext.selectedTask), selectionContext };
+  const retain = isSameOptionalTask(task, selectionContext.selectedTask);
+  return { retain, ...retain ? { retainedTask: task } : {}, selectionContext };
 }
 function selectSpawnEnergyReservationRefillTask(creep, currentTask, selectedTask) {
   if (shouldDeferSpawnReservationRefillForProductiveWork(creep, selectedTask)) {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -361,7 +361,7 @@ function shouldRetainAssignedTaskUnderCriticalCpu(
     return getFreeTransferEnergyCapacity(creep) > 0 && getUsedTransferEnergy(creep) <= 0;
   }
 
-  if (task.type === 'transfer' || isEnergySpendingTask(task)) {
+  if (task.type === 'transfer') {
     return getUsedTransferEnergy(creep) > 0;
   }
 

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -45,6 +45,7 @@ import {
   recordCreepBehaviorWork,
   type RuntimeEnergyAcquisitionMethod
 } from '../telemetry/behaviorTelemetry';
+import { getRuntimeCpuBudget } from '../runtime/cpuBudget';
 
 type TransferSinkStructureConstantGlobal =
   | 'STRUCTURE_EXTENSION'
@@ -102,6 +103,11 @@ export function runWorker(creep: Creep): void {
   observeCreepBehaviorTick(creep);
 
   const currentTask = creep.memory.task;
+  if (shouldRetainAssignedTaskUnderCriticalCpu(creep, currentTask)) {
+    executeAssignedTask(creep, null);
+    return;
+  }
+
   const baseSelectedTask = selectWorkerTaskForRunner(creep);
   const energyCriticalTask = selectWorkerEnergyCriticalTask(creep, currentTask, baseSelectedTask);
   const spawnReservationRefillTask = selectSpawnEnergyReservationRefillTask(
@@ -341,6 +347,25 @@ function getGameTick(): number {
 function selectWorkerTaskForRunner(creep: Creep): CreepTaskMemory | null {
   const selectedTask = selectWorkerTask(creep);
   return fallbackToEnergyOnNullSelectionLoop(creep, selectedTask);
+}
+
+function shouldRetainAssignedTaskUnderCriticalCpu(
+  creep: Creep,
+  task: CreepTaskMemory | null | undefined
+): task is CreepTaskMemory {
+  if (!getRuntimeCpuBudget().critical || !task || !canExecuteTask(creep, task)) {
+    return false;
+  }
+
+  if (isEnergyAcquisitionTask(task)) {
+    return getFreeTransferEnergyCapacity(creep) > 0;
+  }
+
+  if (task.type === 'transfer' || isEnergySpendingTask(task)) {
+    return getUsedTransferEnergy(creep) > 0;
+  }
+
+  return task.type === 'signController' || isTerritoryControlTask(task);
 }
 
 function selectSpawnEnergyReservationRefillTask(

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -83,6 +83,18 @@ interface TaskExecutionResult {
   sourceContainerWithdrawal?: boolean;
 }
 
+interface WorkerTaskSelectionContext {
+  baseSelectedTask: CreepTaskMemory | null;
+  energyCriticalTask: CreepTaskMemory | null;
+  selectedTask: CreepTaskMemory | null;
+  spawnReservationRefillTask: CreepTaskMemory | null;
+}
+
+interface CriticalCpuTaskRetentionDecision {
+  retain: boolean;
+  selectionContext?: WorkerTaskSelectionContext;
+}
+
 type ScoreTaskTarget = RoomObject & _HasId;
 type WorkerTaskTarget =
   | Source
@@ -103,19 +115,16 @@ export function runWorker(creep: Creep): void {
   observeCreepBehaviorTick(creep);
 
   const currentTask = creep.memory.task;
-  if (shouldRetainAssignedTaskUnderCriticalCpu(creep, currentTask)) {
+  const criticalCpuTaskRetention = getCriticalCpuTaskRetentionDecision(creep, currentTask);
+  if (criticalCpuTaskRetention.retain) {
     executeAssignedTask(creep, null);
     return;
   }
 
-  const baseSelectedTask = selectWorkerTaskForRunner(creep);
-  const energyCriticalTask = selectWorkerEnergyCriticalTask(creep, currentTask, baseSelectedTask);
-  const spawnReservationRefillTask = selectSpawnEnergyReservationRefillTask(
-    creep,
-    currentTask,
-    energyCriticalTask ?? baseSelectedTask
-  );
-  const selectedTask = spawnReservationRefillTask ?? energyCriticalTask ?? baseSelectedTask;
+  const selectionContext =
+    criticalCpuTaskRetention.selectionContext ?? selectWorkerTaskContext(creep, currentTask);
+  const { baseSelectedTask, energyCriticalTask, selectedTask, spawnReservationRefillTask } =
+    selectionContext;
   let taskAssignedThisTick = false;
 
   if (!currentTask) {
@@ -349,23 +358,54 @@ function selectWorkerTaskForRunner(creep: Creep): CreepTaskMemory | null {
   return fallbackToEnergyOnNullSelectionLoop(creep, selectedTask);
 }
 
-function shouldRetainAssignedTaskUnderCriticalCpu(
+function selectWorkerTaskContext(
+  creep: Creep,
+  currentTask: CreepTaskMemory | null | undefined
+): WorkerTaskSelectionContext {
+  const baseSelectedTask = selectWorkerTaskForRunner(creep);
+  const energyCriticalTask = selectWorkerEnergyCriticalTask(creep, currentTask, baseSelectedTask);
+  const spawnReservationRefillTask = selectSpawnEnergyReservationRefillTask(
+    creep,
+    currentTask,
+    energyCriticalTask ?? baseSelectedTask
+  );
+  const selectedTask = spawnReservationRefillTask ?? energyCriticalTask ?? baseSelectedTask;
+  return { baseSelectedTask, energyCriticalTask, selectedTask, spawnReservationRefillTask };
+}
+
+function getCriticalCpuTaskRetentionDecision(
   creep: Creep,
   task: CreepTaskMemory | null | undefined
-): task is CreepTaskMemory {
+): CriticalCpuTaskRetentionDecision {
   if (!getRuntimeCpuBudget().critical || !task || !canExecuteTask(creep, task)) {
-    return false;
+    return { retain: false };
   }
 
   if (isEnergyAcquisitionTask(task)) {
-    return getFreeTransferEnergyCapacity(creep) > 0 && getUsedTransferEnergy(creep) <= 0;
+    return { retain: getFreeTransferEnergyCapacity(creep) > 0 && getUsedTransferEnergy(creep) <= 0 };
   }
 
   if (task.type === 'transfer') {
-    return getUsedTransferEnergy(creep) > 0;
+    return getCriticalCpuTransferRetentionDecision(creep, task);
   }
 
-  return isTerritoryControlTask(task);
+  return { retain: isTerritoryControlTask(task) };
+}
+
+function getCriticalCpuTransferRetentionDecision(
+  creep: Creep,
+  task: Extract<CreepTaskMemory, { type: 'transfer' }>
+): CriticalCpuTaskRetentionDecision {
+  if (getUsedTransferEnergy(creep) <= 0) {
+    return { retain: false };
+  }
+
+  const selectionContext = selectWorkerTaskContext(creep, task);
+  const shouldPreempt =
+    shouldPreemptForWorkerEnergyCriticalTask(task, selectionContext.energyCriticalTask) ||
+    shouldPreemptTransferTaskForControllerDowngradeGuard(creep, task, selectionContext.selectedTask) ||
+    shouldPreemptTransferTaskForBetterEnergySink(creep, task, selectionContext.selectedTask);
+  return { retain: !shouldPreempt, selectionContext };
 }
 
 function selectSpawnEnergyReservationRefillTask(

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -389,7 +389,11 @@ function getCriticalCpuTaskRetentionDecision(
     return getCriticalCpuTransferRetentionDecision(creep, task);
   }
 
-  return { retain: isTerritoryControlTask(task) };
+  if (isTerritoryControlTask(task)) {
+    return getCriticalCpuTerritoryControlRetentionDecision(creep, task);
+  }
+
+  return { retain: false };
 }
 
 function getCriticalCpuTransferRetentionDecision(
@@ -406,6 +410,14 @@ function getCriticalCpuTransferRetentionDecision(
     shouldPreemptTransferTaskForControllerDowngradeGuard(creep, task, selectionContext.selectedTask) ||
     shouldPreemptTransferTaskForBetterEnergySink(creep, task, selectionContext.selectedTask);
   return { retain: !shouldPreempt, selectionContext };
+}
+
+function getCriticalCpuTerritoryControlRetentionDecision(
+  creep: Creep,
+  task: Extract<CreepTaskMemory, { type: 'claim' | 'reserve' }>
+): CriticalCpuTaskRetentionDecision {
+  const selectionContext = selectWorkerTaskContext(creep, task);
+  return { retain: isSameOptionalTask(task, selectionContext.selectedTask), selectionContext };
 }
 
 function selectSpawnEnergyReservationRefillTask(

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -358,7 +358,7 @@ function shouldRetainAssignedTaskUnderCriticalCpu(
   }
 
   if (isEnergyAcquisitionTask(task)) {
-    return getFreeTransferEnergyCapacity(creep) > 0;
+    return getFreeTransferEnergyCapacity(creep) > 0 && getUsedTransferEnergy(creep) <= 0;
   }
 
   if (task.type === 'transfer' || isEnergySpendingTask(task)) {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -92,6 +92,7 @@ interface WorkerTaskSelectionContext {
 
 interface CriticalCpuTaskRetentionDecision {
   retain: boolean;
+  retainedTask?: CreepTaskMemory;
   selectionContext?: WorkerTaskSelectionContext;
 }
 
@@ -117,7 +118,7 @@ export function runWorker(creep: Creep): void {
   const currentTask = creep.memory.task;
   const criticalCpuTaskRetention = getCriticalCpuTaskRetentionDecision(creep, currentTask);
   if (criticalCpuTaskRetention.retain) {
-    executeAssignedTask(creep, null);
+    executeAssignedTask(creep, criticalCpuTaskRetention.retainedTask ?? null);
     return;
   }
 
@@ -417,7 +418,8 @@ function getCriticalCpuTerritoryControlRetentionDecision(
   task: Extract<CreepTaskMemory, { type: 'claim' | 'reserve' }>
 ): CriticalCpuTaskRetentionDecision {
   const selectionContext = selectWorkerTaskContext(creep, task);
-  return { retain: isSameOptionalTask(task, selectionContext.selectedTask), selectionContext };
+  const retain = isSameOptionalTask(task, selectionContext.selectedTask);
+  return { retain, ...(retain ? { retainedTask: task } : {}), selectionContext };
 }
 
 function selectSpawnEnergyReservationRefillTask(

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -365,7 +365,7 @@ function shouldRetainAssignedTaskUnderCriticalCpu(
     return getUsedTransferEnergy(creep) > 0;
   }
 
-  return task.type === 'signController' || isTerritoryControlTask(task);
+  return isTerritoryControlTask(task);
 }
 
 function selectSpawnEnergyReservationRefillTask(

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -161,6 +161,8 @@ export function runEconomy(
   options: EconomyRuntimeOptions = {}
 ): RuntimeSummary | undefined {
   const featureGates = getRuntimeFeatureGates();
+  const shouldRunOptionalGlobalWork = (): boolean =>
+    shouldRunOptionalCpuWork(getRuntimeCpuBudget(), 'economy-global-optional');
   const cpuBudget = getRuntimeCpuBudget();
   const runOptionalGlobalWork = shouldRunOptionalCpuWork(cpuBudget, 'economy-global-optional');
   const creeps = Object.values(Game.creeps);
@@ -195,7 +197,8 @@ export function runEconomy(
   const controllerUpgradeTargetRooms = getControllerUpgradeTargetRooms(colonies);
 
   for (const colony of colonies) {
-    const runOptionalRoomWork = shouldRunOptionalCpuRoomWork(cpuBudget, colony.room.name);
+    let roomCpuBudget = getRuntimeCpuBudget();
+    let runOptionalRoomWork = shouldRunOptionalCpuRoomWork(roomCpuBudget, colony.room.name);
     recordSourceWorkloads(colony.room, creeps, Game.time);
     let roleCounts = getPlannedOrCurrentRoleCounts(creeps, colony.room.name, plannedRoleCountsByRoom);
     plannedRoleCountsByRoom.set(colony.room.name, roleCounts);
@@ -222,7 +225,7 @@ export function runEconomy(
       telemetryEvents,
       { focusRoomName: postClaimBootstrapFocusRoomName }
     );
-    if (shouldRunConstructionPlanning(cpuBudget, runOptionalRoomWork, survivalAssessment)) {
+    if (shouldRunConstructionPlanning(roomCpuBudget, runOptionalRoomWork, survivalAssessment)) {
       refreshPostClaimDefenseConstruction(colony, { focusRoomName: postClaimBootstrapFocusRoomName });
     }
     const constructionOptions = {
@@ -232,7 +235,7 @@ export function runEconomy(
       runtimeStrategyConstructionEnabled: options.runtimeStrategyConstructionEnabled,
       onStrategyRegistryRuntimeUse: options.onStrategyRegistryRuntimeUse
     };
-    if (shouldRunConstructionPlanning(cpuBudget, runOptionalRoomWork, survivalAssessment)) {
+    if (shouldRunConstructionPlanning(roomCpuBudget, runOptionalRoomWork, survivalAssessment)) {
       if (postClaimBootstrapRefresh.deferred === true) {
         planDeferredClaimedRoomCapacityConstruction(colony, constructionOptions);
       } else {
@@ -241,13 +244,13 @@ export function runEconomy(
         });
       }
     }
-    if (survivalAssessment.mode === 'TERRITORY_READY' && shouldRunTerritoryPlanning(cpuBudget, runOptionalRoomWork)) {
+    if (survivalAssessment.mode === 'TERRITORY_READY' && shouldRunTerritoryPlanning(roomCpuBudget, runOptionalRoomWork)) {
       refreshRemoteMiningSetup(colony, Game.time, { focusRoomName: postClaimBootstrapFocusRoomName });
     }
-    if (shouldRunTerritoryPlanning(cpuBudget, runOptionalRoomWork)) {
+    if (shouldRunTerritoryPlanning(roomCpuBudget, runOptionalRoomWork)) {
       refreshExecutableTerritoryRecommendation(colony, creeps, survivalAssessment.territoryReady, telemetryEvents);
     }
-    if (survivalAssessment.territoryReady && shouldRunTerritoryPlanning(cpuBudget, runOptionalRoomWork)) {
+    if (survivalAssessment.territoryReady && shouldRunTerritoryPlanning(roomCpuBudget, runOptionalRoomWork)) {
       refreshClaimExecutionTargets({ colony: colony.room.name, gameTime: Game.time });
       refreshReserveExecutionTargets({ colony: colony.room.name, gameTime: Game.time });
     }
@@ -330,6 +333,8 @@ export function runEconomy(
     }
 
     transferLinkEnergy(colony.room);
+    roomCpuBudget = getRuntimeCpuBudget();
+    runOptionalRoomWork = shouldRunOptionalCpuRoomWork(roomCpuBudget, colony.room.name);
     if (runOptionalRoomWork) {
       manageStorage(colony.room);
       refreshRoomEnergySurplusState(colony.room);
@@ -343,11 +348,11 @@ export function runEconomy(
     }
   }
 
-  if (runOptionalGlobalWork) {
+  if (shouldRunOptionalGlobalWork()) {
     ensureRemoteSourceContainersForAssignedHarvesters(creeps);
   }
   attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom);
-  if (runOptionalGlobalWork) {
+  if (shouldRunOptionalGlobalWork()) {
     attemptMineralHarvesterSpawns(colonies, creeps, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom);
   }
   refreshSpawnEnergyReservationStates(colonies);

--- a/prod/src/main.ts
+++ b/prod/src/main.ts
@@ -45,7 +45,6 @@ const recentKpiWindows: KpiWindowHistory = {};
 const baselineKpiWindows: KpiWindowHistory = {};
 
 export function loop(): void {
-  const cpuBudget = getRuntimeCpuBudget();
   const runtimePolicyParameters = applyRuntimePolicyParametersToRegistry(strategyRegistryState.entries);
   const hasPatchedRuntimeStrategies = runtimePolicyParameters.evidence.appliedStrategyIds.length > 0;
   const runtimePolicyParameterPlanningEnabled =
@@ -74,7 +73,7 @@ export function loop(): void {
   } finally {
     persistRuntimePolicyParameterConsumptionEvidence(runtimePolicyParameterConsumption.buildEvidence());
   }
-  if (!cpuBudget.degraded) {
+  if (!getRuntimeCpuBudget().degraded) {
     strategyRegistryState.entries = runStrategyRolloutMonitoring(summary, strategyRegistryState.entries);
   }
 }

--- a/prod/src/runtime/cpuBudget.ts
+++ b/prod/src/runtime/cpuBudget.ts
@@ -53,6 +53,12 @@ interface RuntimeCpuTelemetryState {
   overLimitTicks: number;
 }
 
+interface RuntimeCpuBudgetCache {
+  game: RuntimeGameLike;
+  tick: number;
+  budget: RuntimeCpuBudget;
+}
+
 export const LOW_CPU_ACCOUNT_LIMIT = 20;
 export const LOW_CPU_BUCKET_THRESHOLD = 1_000;
 export const CRITICAL_CPU_BUCKET_THRESHOLD = 100;
@@ -66,9 +72,25 @@ let cpuTelemetryState: RuntimeCpuTelemetryState = {
   bucketEmptyTicks: 0,
   overLimitTicks: 0
 };
+let runtimeCpuBudgetCache: RuntimeCpuBudgetCache | null = null;
 
-export function getRuntimeCpuBudget(game: RuntimeGameLike | undefined = getRuntimeGame()): RuntimeCpuBudget {
-  return buildRuntimeCpuBudget(readRuntimeCpuSample(game));
+export function getRuntimeCpuBudget(game?: RuntimeGameLike): RuntimeCpuBudget {
+  const runtimeGame = game ?? getRuntimeGame();
+  const tick = normalizeTick(runtimeGame?.time);
+  const shouldUseCache = game === undefined && runtimeGame !== undefined && tick > 0;
+  if (
+    shouldUseCache &&
+    runtimeCpuBudgetCache?.game === runtimeGame &&
+    runtimeCpuBudgetCache.tick === tick
+  ) {
+    return runtimeCpuBudgetCache.budget;
+  }
+
+  const budget = buildRuntimeCpuBudget(readRuntimeCpuSample(runtimeGame));
+  if (shouldUseCache) {
+    runtimeCpuBudgetCache = { game: runtimeGame, tick: budget.tick, budget };
+  }
+  return budget;
 }
 
 export function buildRuntimeCpuBudget(sample: RuntimeCpuSample): RuntimeCpuBudget {
@@ -194,6 +216,7 @@ export function resetRuntimeCpuTelemetryForTesting(): void {
     bucketEmptyTicks: 0,
     overLimitTicks: 0
   };
+  runtimeCpuBudgetCache = null;
 }
 
 function updateRuntimeCpuTelemetryState(sample: RuntimeCpuSample): RuntimeCpuTelemetryState {

--- a/prod/src/runtime/cpuBudget.ts
+++ b/prod/src/runtime/cpuBudget.ts
@@ -53,12 +53,6 @@ interface RuntimeCpuTelemetryState {
   overLimitTicks: number;
 }
 
-interface RuntimeCpuBudgetCache {
-  game: RuntimeGameLike;
-  tick: number;
-  budget: RuntimeCpuBudget;
-}
-
 export const LOW_CPU_ACCOUNT_LIMIT = 20;
 export const LOW_CPU_BUCKET_THRESHOLD = 1_000;
 export const CRITICAL_CPU_BUCKET_THRESHOLD = 100;
@@ -72,25 +66,10 @@ let cpuTelemetryState: RuntimeCpuTelemetryState = {
   bucketEmptyTicks: 0,
   overLimitTicks: 0
 };
-let runtimeCpuBudgetCache: RuntimeCpuBudgetCache | null = null;
 
 export function getRuntimeCpuBudget(game?: RuntimeGameLike): RuntimeCpuBudget {
   const runtimeGame = game ?? getRuntimeGame();
-  const tick = normalizeTick(runtimeGame?.time);
-  const shouldUseCache = game === undefined && runtimeGame !== undefined && tick > 0;
-  if (
-    shouldUseCache &&
-    runtimeCpuBudgetCache?.game === runtimeGame &&
-    runtimeCpuBudgetCache.tick === tick
-  ) {
-    return runtimeCpuBudgetCache.budget;
-  }
-
-  const budget = buildRuntimeCpuBudget(readRuntimeCpuSample(runtimeGame));
-  if (shouldUseCache) {
-    runtimeCpuBudgetCache = { game: runtimeGame, tick: budget.tick, budget };
-  }
-  return budget;
+  return buildRuntimeCpuBudget(readRuntimeCpuSample(runtimeGame));
 }
 
 export function buildRuntimeCpuBudget(sample: RuntimeCpuSample): RuntimeCpuBudget {
@@ -216,7 +195,6 @@ export function resetRuntimeCpuTelemetryForTesting(): void {
     bucketEmptyTicks: 0,
     overLimitTicks: 0
   };
-  runtimeCpuBudgetCache = null;
 }
 
 function updateRuntimeCpuTelemetryState(sample: RuntimeCpuSample): RuntimeCpuTelemetryState {

--- a/prod/src/runtime/cpuBudget.ts
+++ b/prod/src/runtime/cpuBudget.ts
@@ -185,7 +185,7 @@ export function shouldRunOptionalCpuRoomWork(
 }
 
 export function shouldThrottleRuntimeSummaryCadence(budget: RuntimeCpuBudget): boolean {
-  return budget.lowCpuLimit;
+  return budget.degraded;
 }
 
 export function resetRuntimeCpuTelemetryForTesting(): void {

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -805,7 +805,7 @@ export function emitRuntimeSummary(
 
   const reportedEvents = events.slice(0, MAX_REPORTED_EVENTS);
   const persistOccupationRecommendations = options.persistOccupationRecommendations !== false;
-  const includeOptionalSummary = !shouldThrottleRuntimeSummaryCadence(cpuBudget) && !cpuBudget.critical;
+  const includeOptionalSummary = !cpuBudget.lowCpuLimit && !cpuBudget.critical;
   const rooms = colonies.map((colony) =>
     summarizeRoom(
       colony,
@@ -940,13 +940,11 @@ function summarizeRoom(
   const tick = getGameTime();
   const colonyWorkers = colonyCreeps.filter((creep) => creep.memory.role === 'worker');
   const roleCounts = countCreepsByRole(colonyCreeps, colony.room.name);
-  const territoryExpansion = buildRuntimeExpansionCandidateReport(colony);
-  const territoryRecommendation = buildRuntimeOccupationRecommendationReport(
-    colony,
-    colonyWorkers,
-    territoryExpansion
-  );
-  if (persistOccupationRecommendations) {
+  const territoryExpansion = includeOptionalSummary ? buildRuntimeExpansionCandidateReport(colony) : undefined;
+  const territoryRecommendation = territoryExpansion
+    ? buildRuntimeOccupationRecommendationReport(colony, colonyWorkers, territoryExpansion)
+    : emptyTerritoryRecommendationReport();
+  if (persistOccupationRecommendations && includeOptionalSummary) {
     persistOccupationRecommendationFollowUpIntent(territoryRecommendation, tick);
   }
   const resources = summarizeResources(colony, colonyWorkers, colonyCreeps, eventMetrics.resources);
@@ -990,8 +988,8 @@ function summarizeRoom(
         )
       : emptyConstructionPrioritySummary(),
     survival: summarizeSurvival(colony, roleCounts),
-    territoryRecommendation: includeOptionalSummary ? territoryRecommendation : emptyTerritoryRecommendationReport(),
-    ...(includeOptionalSummary && territoryExpansion.candidates.length > 0 ? { territoryExpansion } : {}),
+    territoryRecommendation,
+    ...(territoryExpansion && territoryExpansion.candidates.length > 0 ? { territoryExpansion } : {}),
     ...(includeOptionalSummary ? buildTerritoryIntentSummary(colony.room.name, roleCounts) : {}),
     ...(includeOptionalSummary ? buildTerritoryExecutionHintSummary(colony.room.name) : {}),
     ...(includeOptionalSummary ? buildTerritoryScoutSummary(colony, roleCounts) : {}),

--- a/prod/test/cpuBudget.test.ts
+++ b/prod/test/cpuBudget.test.ts
@@ -84,14 +84,14 @@ describe('runtime CPU budget policy', () => {
     expect(shouldThrottleRuntimeSummaryCadence(budget)).toBe(true);
   });
 
-  it('reuses the runtime CPU budget sample during the same game tick', () => {
-    const getUsed = jest.fn().mockReturnValue(21);
+  it('refreshes CPU used samples during the same game tick', () => {
+    const getUsed = jest.fn().mockReturnValueOnce(21).mockReturnValueOnce(71);
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       time: 123,
       cpu: {
         getUsed,
         limit: 70,
-        bucket: 43,
+        bucket: 9_000,
         tickLimit: 500
       } as unknown as CPU
     };
@@ -99,13 +99,18 @@ describe('runtime CPU budget policy', () => {
     const first = getRuntimeCpuBudget();
     const second = getRuntimeCpuBudget();
 
-    expect(second).toBe(first);
-    expect(getUsed).toHaveBeenCalledTimes(1);
+    expect(first).toMatchObject({
+      tick: 123,
+      pressure: 'normal',
+      reasons: []
+    });
     expect(second).toMatchObject({
       tick: 123,
-      pressure: 'critical',
-      reasons: ['criticalBucket']
+      pressure: 'degraded',
+      reasons: ['usedOverLimit'],
+      sample: expect.objectContaining({ used: 71 })
     });
+    expect(getUsed).toHaveBeenCalledTimes(2);
   });
 
   it('alerts on repeated empty bucket and sustained used-over-limit samples', () => {

--- a/prod/test/cpuBudget.test.ts
+++ b/prod/test/cpuBudget.test.ts
@@ -2,7 +2,8 @@ import {
   buildRuntimeCpuBudget,
   buildRuntimeCpuTelemetrySummary,
   resetRuntimeCpuTelemetryForTesting,
-  shouldRunOptionalCpuRoomWork
+  shouldRunOptionalCpuRoomWork,
+  shouldThrottleRuntimeSummaryCadence
 } from '../src/runtime/cpuBudget';
 
 describe('runtime CPU budget policy', () => {
@@ -61,6 +62,25 @@ describe('runtime CPU budget policy', () => {
       reasons: ['lowCpuLimit']
     });
     expect(decisions.filter(Boolean)).toHaveLength(1);
+  });
+
+  it('throttles runtime-summary cadence for low bucket pressure on otherwise healthy CPU accounts', () => {
+    const budget = buildRuntimeCpuBudget({
+      tick: 42,
+      used: 21,
+      limit: 70,
+      bucket: 43,
+      tickLimit: 500
+    });
+
+    expect(budget).toMatchObject({
+      pressure: 'critical',
+      degraded: true,
+      critical: true,
+      lowCpuLimit: false,
+      reasons: ['criticalBucket']
+    });
+    expect(shouldThrottleRuntimeSummaryCadence(budget)).toBe(true);
   });
 
   it('alerts on repeated empty bucket and sustained used-over-limit samples', () => {

--- a/prod/test/cpuBudget.test.ts
+++ b/prod/test/cpuBudget.test.ts
@@ -1,6 +1,7 @@
 import {
   buildRuntimeCpuBudget,
   buildRuntimeCpuTelemetrySummary,
+  getRuntimeCpuBudget,
   resetRuntimeCpuTelemetryForTesting,
   shouldRunOptionalCpuRoomWork,
   shouldThrottleRuntimeSummaryCadence
@@ -81,6 +82,30 @@ describe('runtime CPU budget policy', () => {
       reasons: ['criticalBucket']
     });
     expect(shouldThrottleRuntimeSummaryCadence(budget)).toBe(true);
+  });
+
+  it('reuses the runtime CPU budget sample during the same game tick', () => {
+    const getUsed = jest.fn().mockReturnValue(21);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 123,
+      cpu: {
+        getUsed,
+        limit: 70,
+        bucket: 43,
+        tickLimit: 500
+      } as unknown as CPU
+    };
+
+    const first = getRuntimeCpuBudget();
+    const second = getRuntimeCpuBudget();
+
+    expect(second).toBe(first);
+    expect(getUsed).toHaveBeenCalledTimes(1);
+    expect(second).toMatchObject({
+      tick: 123,
+      pressure: 'critical',
+      reasons: ['criticalBucket']
+    });
   });
 
   it('alerts on repeated empty bucket and sustained used-over-limit samples', () => {

--- a/prod/test/mainRuntimePolicyParameters.test.ts
+++ b/prod/test/mainRuntimePolicyParameters.test.ts
@@ -20,6 +20,7 @@ describe('main runtime policy parameter consumption', () => {
     logSpy.mockRestore();
     jest.resetModules();
     jest.dontMock('../src/kernel/Kernel');
+    jest.dontMock('../src/rl/kpiRolloutMonitor');
     jest.dontMock('../src/strategy/runtimePolicyParameters');
     delete (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETERS_GLOBAL];
     delete (globalThis as Record<string, unknown>)[RUNTIME_POLICY_PARAMETER_CONSUMPTION_GLOBAL];
@@ -265,6 +266,47 @@ describe('main runtime policy parameter consumption', () => {
         consumedParametersSha256: 'flagless-runtime-use-sha'
       })
     );
+  });
+
+  it('uses a post-kernel CPU sample for the rollout monitoring gate', () => {
+    installScreepsGlobals();
+    const getUsed = jest.fn().mockReturnValueOnce(1).mockReturnValue(71);
+    (globalThis as unknown as { Game: Partial<Game> }).Game.cpu = {
+      getUsed,
+      limit: 70,
+      bucket: 9_000,
+      tickLimit: 500
+    } as unknown as CPU;
+    const run = jest.fn((_options: KernelRunOptions = {}) => {
+      getUsed();
+      return makeRuntimeSummary();
+    });
+    const checkKpiRegression = jest.fn(() => ({
+      regression: false,
+      regressedFamilies: [],
+      details: '',
+      metrics: {}
+    }));
+    jest.doMock('../src/rl/kpiRolloutMonitor', () => {
+      const actual = jest.requireActual<typeof import('../src/rl/kpiRolloutMonitor')>(
+        '../src/rl/kpiRolloutMonitor'
+      );
+      return {
+        ...actual,
+        checkKpiRegression
+      };
+    });
+    mockKernel(run);
+    let main: typeof import('../src/main') | undefined;
+    jest.isolateModules(() => {
+      main = jest.requireActual<typeof import('../src/main')>('../src/main');
+    });
+
+    main?.loop();
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(getUsed).toHaveBeenCalledTimes(2);
+    expect(checkKpiRegression).not.toHaveBeenCalled();
   });
 });
 

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -8,7 +8,7 @@ import {
   shouldEmitRuntimeSummary,
   type RuntimeTelemetryEvent
 } from '../src/telemetry/runtimeSummary';
-import { resetRuntimeCpuTelemetryForTesting } from '../src/runtime/cpuBudget';
+import { buildRuntimeCpuBudget, resetRuntimeCpuTelemetryForTesting } from '../src/runtime/cpuBudget';
 import { recordCreepBehaviorIdle } from '../src/telemetry/behaviorTelemetry';
 import { CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD } from '../src/tasks/workerTasks';
 import { OCCUPIED_CONTROLLER_SIGN_TEXT } from '../src/territory/controllerSigning';
@@ -2918,7 +2918,7 @@ describe('runtime telemetry summaries', () => {
   });
 
   it('keeps E29N56 scout-only evidence out of reserve recommendations when CPU blocks conversion', () => {
-    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL, roomName: 'E29N55' });
+    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL * 5, roomName: 'E29N55' });
     const room = colony.room as Room & { find: jest.Mock; energyAvailable: number; energyCapacityAvailable: number };
     const controller = room.controller as StructureController & { level: number; ticksToDowngrade: number };
     const spawn = colony.spawns[0] as StructureSpawn & { my?: boolean; isActive?: jest.Mock };
@@ -3031,6 +3031,28 @@ describe('runtime telemetry summaries', () => {
         }
       ])
     ).toBe(true);
+  });
+
+  it('uses degraded cadence for low CPU bucket pressure without suppressing event summaries', () => {
+    const criticalBucketBudget = buildRuntimeCpuBudget({
+      tick: RUNTIME_SUMMARY_INTERVAL,
+      used: 21,
+      limit: 70,
+      bucket: 43,
+      tickLimit: 500
+    });
+    const spawnEvent: RuntimeTelemetryEvent = {
+      type: 'spawn',
+      roomName: 'W1N1',
+      spawnName: 'Spawn1',
+      creepName: 'worker-W1N1-1',
+      role: 'worker',
+      result: 0 as ScreepsReturnCode
+    };
+
+    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [], criticalBucketBudget)).toBe(false);
+    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL * 5, [], criticalBucketBudget)).toBe(true);
+    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [spawnEvent], criticalBucketBudget)).toBe(true);
   });
 
   it('reports construction-priority runtime use from runtime summary scoring', () => {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -140,6 +140,64 @@ describe('runWorker', () => {
     expect(harvest).toHaveBeenCalledWith(source);
   });
 
+  it('preempts loaded critical CPU harvest for emergency spawn refill', () => {
+    const source = { id: 'source1', energy: 300 } as Source;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(300) }
+    } as unknown as StructureSpawn;
+    const room = {
+      name: 'W1N1',
+      energyAvailable: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+      find: jest.fn(
+        (type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          return type === FIND_SOURCES ? [source] : [];
+        }
+      )
+    } as unknown as Room;
+    const harvest = jest.fn();
+    const transfer = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'Worker1',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'harvest', targetId: 'source1' as Id<Source> }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(30),
+        getFreeCapacity: jest.fn().mockReturnValue(20)
+      },
+      room,
+      harvest,
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Worker1: creep },
+      time: 124,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(21),
+        limit: 70,
+        bucket: 43,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) => (id === 'spawn1' ? spawn : source)) as unknown as Game['getObjectById']
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(transfer).toHaveBeenCalledWith(spawn, RESOURCE_ENERGY);
+    expect(harvest).not.toHaveBeenCalled();
+  });
+
   it('moves to collect a score target at exact range without pickup', () => {
     const score = makeScoreTarget('score1');
     const pickup = jest.fn();

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -198,6 +198,92 @@ describe('runWorker', () => {
     expect(harvest).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      taskName: 'build',
+      task: { type: 'build', targetId: 'site1' as Id<ConstructionSite> },
+      target: { id: 'site1', structureType: 'road' } as ConstructionSite,
+      action: 'build'
+    },
+    {
+      taskName: 'repair',
+      task: { type: 'repair', targetId: 'road1' as Id<Structure> },
+      target: { id: 'road1', structureType: 'road', hits: 100, hitsMax: 5_000 } as StructureRoad,
+      action: 'repair'
+    },
+    {
+      taskName: 'upgrade',
+      task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> },
+      target: {
+        id: 'controller1',
+        my: true,
+        level: 2,
+        ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+      } as StructureController,
+      action: 'upgradeController'
+    }
+  ])('preempts loaded critical CPU $taskName for emergency spawn refill', ({ task, target, action }) => {
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD - 1),
+        getFreeCapacity: jest.fn().mockReturnValue(101)
+      }
+    } as unknown as StructureSpawn;
+    const taskAction = jest.fn().mockReturnValue(0);
+    const transfer = jest.fn().mockReturnValue(0);
+    const room = {
+      name: 'W1N1',
+      energyAvailable: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+      energyCapacityAvailable: 550,
+      controller: task.type === 'upgrade' ? target : undefined,
+      find: jest.fn((type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return task.type === 'build' ? [target] : [];
+        }
+        return [];
+      })
+    } as unknown as Room;
+    const creep = {
+      name: 'Worker1',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      transfer,
+      [action]: taskAction,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Worker1: creep },
+      time: 126,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(21),
+        limit: 70,
+        bucket: 43,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) => (id === 'spawn1' ? spawn : target)) as unknown as Game['getObjectById']
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(transfer).toHaveBeenCalledWith(spawn, RESOURCE_ENERGY);
+    expect(taskAction).not.toHaveBeenCalled();
+  });
+
   it('moves to collect a score target at exact range without pickup', () => {
     const score = makeScoreTarget('score1');
     const pickup = jest.fn();

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -5195,6 +5195,64 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
+  it('preempts retained tower transfer work for emergency spawn refill under critical CPU', () => {
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(300) }
+    } as unknown as StructureSpawn;
+    const tower = {
+      id: 'tower1',
+      structureType: 'tower',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(300) }
+    } as unknown as StructureTower;
+    const creep = {
+      name: 'Worker1',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'transfer', targetId: 'tower1' as Id<AnyStoreStructure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: {
+        name: 'W1N1',
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: StructureSpawn | StructureTower) => boolean }) => {
+            if (type !== FIND_MY_STRUCTURES) {
+              return [];
+            }
+
+            const structures = [spawn, tower];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+        )
+      },
+      transfer: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Worker1: creep },
+      time: 780,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(21),
+        limit: 70,
+        bucket: 43,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) => (id === 'tower1' ? tower : spawn))
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(creep.transfer).toHaveBeenCalledWith(spawn, 'energy');
+    expect(creep.transfer).not.toHaveBeenCalledWith(tower, 'energy');
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
   it('reselects and executes a same-priority transfer when the current sink is full', () => {
     const fullExtension = {
       id: 'extension-full',

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -140,6 +140,78 @@ describe('runWorker', () => {
     expect(harvest).toHaveBeenCalledWith(source);
   });
 
+  it.each(['claim', 'reserve'] as const)(
+    'drops a retained visible %s task under critical CPU when the home room fails the territory gate',
+    (action) => {
+      const controller = { id: 'controller2', my: false } as StructureController;
+      const homeRoom = {
+        name: 'W1N1',
+        controller: { id: 'controller1', my: true, level: 4, owner: { username: 'me' } },
+        find: jest.fn().mockReturnValue([])
+      } as unknown as Room;
+      const targetRoom = {
+        name: 'W2N1',
+        controller,
+        find: jest.fn().mockReturnValue([])
+      } as unknown as Room;
+      const claimController = jest.fn().mockReturnValue(0);
+      const reserveController = jest.fn().mockReturnValue(0);
+      const attackController = jest.fn().mockReturnValue(0);
+      const creep = {
+        name: 'Worker1',
+        owner: { username: 'me' },
+        memory: {
+          role: 'worker',
+          colony: 'W1N1',
+          territory: { targetRoom: 'W2N1', action },
+          task: { type: action, targetId: 'controller2' as Id<StructureController> }
+        },
+        getActiveBodyparts: jest.fn().mockReturnValue(1),
+        store: {
+          getUsedCapacity: jest.fn().mockReturnValue(0),
+          getFreeCapacity: jest.fn().mockReturnValue(0)
+        },
+        room: targetRoom,
+        claimController,
+        reserveController,
+        attackController,
+        moveTo: jest.fn()
+      } as unknown as Creep;
+      (globalThis as unknown as { Game: Partial<Game> }).Game = {
+        creeps: { Worker1: creep },
+        rooms: { W1N1: homeRoom, W2N1: targetRoom },
+        time: 127,
+        cpu: {
+          getUsed: jest.fn().mockReturnValue(21),
+          limit: 70,
+          bucket: 43,
+          tickLimit: 500
+        } as unknown as CPU,
+        getObjectById: jest.fn((id: string) =>
+          id === 'controller2' ? controller : null
+        ) as unknown as Game['getObjectById']
+      };
+
+      runWorker(creep);
+
+      expect(creep.memory.task).toBeUndefined();
+      expect(creep.memory.territory).toBeUndefined();
+      expect(claimController).not.toHaveBeenCalled();
+      expect(reserveController).not.toHaveBeenCalled();
+      expect(attackController).not.toHaveBeenCalled();
+      expect(Memory.territory?.intents).toEqual([
+        {
+          colony: 'W1N1',
+          targetRoom: 'W2N1',
+          action,
+          status: 'suppressed',
+          updatedAt: 127,
+          reason: 'controllerLevel'
+        }
+      ]);
+    }
+  );
+
   it('preempts loaded critical CPU harvest for emergency spawn refill', () => {
     const source = { id: 'source1', energy: 300 } as Source;
     const spawn = {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -100,6 +100,46 @@ describe('runWorker', () => {
     expect(creep.memory.task).toEqual({ type: 'harvest', targetId: 'source1' });
   });
 
+  it('keeps an executable assigned harvest under critical CPU bucket without full task reselection', () => {
+    const source = { id: 'source1', energy: 300 } as Source;
+    const room = {
+      name: 'W1N1',
+      find: jest.fn().mockReturnValue([{ id: 'source2' }])
+    } as unknown as Room;
+    const harvest = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'Worker1',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'harvest', targetId: 'source1' as Id<Source> }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room,
+      harvest,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Worker1: creep },
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(21),
+        limit: 70,
+        bucket: 43,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) => (id === 'source1' ? source : null)) as unknown as Game['getObjectById']
+    };
+
+    runWorker(creep);
+
+    expect(room.find).not.toHaveBeenCalled();
+    expect(creep.memory.task).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(harvest).toHaveBeenCalledWith(source);
+  });
+
   it('moves to collect a score target at exact range without pickup', () => {
     const score = makeScoreTarget('score1');
     const pickup = jest.fn();

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -693,6 +693,67 @@ describe('runWorker', () => {
     expect(creep.signController).not.toHaveBeenCalled();
   });
 
+  it('preempts an assigned controller sign for recovery under critical CPU bucket', () => {
+    const source = { id: 'source1', energy: 300 } as Source;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getUsedCapacity: jest.fn().mockReturnValue(190), getFreeCapacity: jest.fn().mockReturnValue(110) }
+    } as unknown as StructureSpawn;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1,
+      sign: { username: 'enemy', text: 'not ours', time: 10, datetime: '2026-05-08T00:00:00.000Z' }
+    } as unknown as StructureController;
+    const room = {
+      name: 'E29N55',
+      energyAvailable: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+      energyCapacityAvailable: 550,
+      controller,
+      find: jest.fn((type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+        if (type === FIND_SOURCES) {
+          return [source];
+        }
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn as unknown as AnyOwnedStructure];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+        return [];
+      })
+    } as unknown as Room;
+    const creep = {
+      name: 'Worker1',
+      memory: { role: 'worker', colony: 'E29N55', task: { type: 'signController', targetId: 'controller1' as Id<StructureController> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room,
+      harvest: jest.fn().mockReturnValue(0),
+      signController: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Worker1: creep },
+      time: 125,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(21),
+        limit: 70,
+        bucket: 43,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) => (id === 'source1' ? source : controller))
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(creep.harvest).toHaveBeenCalledWith(source);
+    expect(creep.signController).not.toHaveBeenCalled();
+  });
+
   it('does not assign owned controller signing while hostiles are visible', () => {
     const controller = {
       id: 'controller1',

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -199,6 +199,7 @@ describe('runWorker', () => {
       expect(claimController).not.toHaveBeenCalled();
       expect(reserveController).not.toHaveBeenCalled();
       expect(attackController).not.toHaveBeenCalled();
+      expect(creep.moveTo).not.toHaveBeenCalled();
       expect(Memory.territory?.intents).toEqual([
         {
           colony: 'W1N1',
@@ -209,6 +210,64 @@ describe('runWorker', () => {
           reason: 'controllerLevel'
         }
       ]);
+    }
+  );
+
+  it.each(['claim', 'reserve'] as const)(
+    'preserves a retained %s task under critical CPU when target lookup is temporarily unavailable',
+    (action) => {
+      const controller = { id: 'controller2', my: false } as StructureController;
+      const room = {
+        name: 'W2N1',
+        controller,
+        find: jest.fn().mockReturnValue([])
+      } as unknown as Room;
+      const claimController = jest.fn();
+      const reserveController = jest.fn();
+      const attackController = jest.fn();
+      const moveTo = jest.fn();
+      const creep = {
+        name: 'Worker1',
+        owner: { username: 'me' },
+        memory: {
+          role: 'worker',
+          colony: 'W1N1',
+          territory: { targetRoom: 'W2N1', action },
+          task: { type: action, targetId: 'controller2' as Id<StructureController> }
+        },
+        getActiveBodyparts: jest.fn().mockReturnValue(1),
+        store: {
+          getUsedCapacity: jest.fn().mockReturnValue(0),
+          getFreeCapacity: jest.fn().mockReturnValue(0)
+        },
+        room,
+        claimController,
+        reserveController,
+        attackController,
+        moveTo
+      } as unknown as Creep;
+      const getObjectById = jest.fn().mockReturnValue(null);
+      (globalThis as unknown as { Game: Partial<Game> }).Game = {
+        creeps: { Worker1: creep },
+        rooms: { W2N1: room },
+        time: 128,
+        cpu: {
+          getUsed: jest.fn().mockReturnValue(21),
+          limit: 70,
+          bucket: 43,
+          tickLimit: 500
+        } as unknown as CPU,
+        getObjectById
+      };
+
+      runWorker(creep);
+
+      expect(getObjectById).toHaveBeenCalledWith('controller2');
+      expect(creep.memory.task).toEqual({ type: action, targetId: 'controller2' });
+      expect(claimController).not.toHaveBeenCalled();
+      expect(reserveController).not.toHaveBeenCalled();
+      expect(attackController).not.toHaveBeenCalled();
+      expect(moveTo).not.toHaveBeenCalled();
     }
   );
 


### PR DESCRIPTION
## Summary
- Retain executable assigned worker tasks under critical CPU bucket pressure to avoid per-tick reselection churn.
- Treat low-bucket/degraded pressure as a runtime-summary cadence throttle while still emitting event summaries.
- Suppress optional territory expansion/recommendation persistence during critical CPU summaries and rebuild `prod/dist/main.js`.

## Test Plan
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm test -- --runInBand` — 103 suites / 2078 tests passed
- [x] `npm run build`

Related to issue 1490.

## Universal task Done gate
- [x] Task type: production code hotfix with tests and rebuilt Screeps bundle.
- [x] Expected observable outcome / named deliverable: critical CPU ticks spend less work on optional summary/reselection paths while preserving event telemetry and executable assigned worker work.
- [x] Non-goals / accepted substitutes: no official MMO deploy or runtime acceptance is claimed by this PR body; issue 1490 remains open for deploy/runtime evidence.
- [x] Verification evidence required before Done: local typecheck, Jest, build, PR checks, review-thread resolution, official deploy evidence, and fresh runtime CPU bucket observation on issue 1490.
- [x] Project Evidence / Next action / Blocked by: issue 1490 is In progress at PR creation; controller will move issue/PR to In review with this PR number, exact head, tests, and review/deploy next action.
- [x] Post-merge/deploy/runtime proof: issue 1490 carries runtime proof target of deployed commit plus fresh monitor evidence showing CPU recovery and no lowBucket alert.
- [x] Named deliverable proof: commit `d47b3d5a` changes `prod/src/runtime/cpuBudget.ts`, `prod/src/creeps/workerRunner.ts`, `prod/src/telemetry/runtimeSummary.ts`, tests, and rebuilt `prod/dist/main.js`.
