### PR TITLE
fix: classify simulator place-spawn room busy

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -85,6 +85,8 @@ RUN_TICK_TIMEOUT_SECONDS = 300
 RUN_TICK_POLL_SECONDS = 0.20
 RUN_RUNTIME_PARAMETER_CONSUMPTION_PROBE_ATTEMPTS = 3
 RUN_RUNTIME_PARAMETER_CONSUMPTION_PROBE_RETRY_SECONDS = 1.0
+RUN_PLACE_SPAWN_MAX_ATTEMPTS = 12
+RUN_PLACE_SPAWN_RETRY_SECONDS = 1.0
 RUN_WORKER_PREFIX = "rl-sim-worker"
 RUN_BROKEN_PIPE_MAX_RETRIES = 1
 RUN_BROKEN_PIPE_RETRY_BACKOFF_SECONDS = 2.0
@@ -5924,6 +5926,123 @@ def _safe_redact_smoke_payload(payload: Any) -> JsonObject:
     return {"ok": True, "payload": dataset_export.redact_text(json.dumps(payload, sort_keys=True, ensure_ascii=True))[:2000]}
 
 
+def _json_text_payload(value: Any) -> Any:
+    if not isinstance(value, str):
+        return None
+    try:
+        return json.loads(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _place_spawn_error_text(payload: Any) -> str:
+    if isinstance(payload, dict):
+        for key in ("error", "message"):
+            value = payload.get(key)
+            if isinstance(value, str):
+                return value
+        nested = payload.get("payload")
+        nested_payload = _json_text_payload(nested)
+        if nested_payload is not None:
+            return _place_spawn_error_text(nested_payload)
+        if isinstance(nested, str):
+            return nested
+    if isinstance(payload, str):
+        nested_payload = _json_text_payload(payload)
+        if nested_payload is not None:
+            return _place_spawn_error_text(nested_payload)
+        return payload
+    return ""
+
+
+def _place_spawn_response_kind(result: Any) -> str:
+    payload = getattr(result, "payload", None)
+    status = _extract_int(getattr(result, "status", None))
+    error = _place_spawn_error_text(payload).lower()
+    if "already playing" in error:
+        return "already_playing"
+    if "room busy" in error:
+        return "room_busy"
+    if (status is None or status == 200) and isinstance(payload, dict) and payload.get("ok") in (1, True):
+        return "ok"
+    return "rejected"
+
+
+def _place_spawn_attempt_summary(result: Any, attempt: int, classification: str) -> JsonObject:
+    return {
+        "attempt": attempt,
+        "status": _extract_int(getattr(result, "status", None)),
+        "classification": classification,
+        "response": _safe_redact_smoke_payload(getattr(result, "payload", None)),
+    }
+
+
+def _place_spawn_with_retry(
+    smoke: Any,
+    cfg: Any,
+    token: str,
+    *,
+    worker_index: int,
+    variant_id: str,
+    max_attempts: int = RUN_PLACE_SPAWN_MAX_ATTEMPTS,
+    retry_seconds: float = RUN_PLACE_SPAWN_RETRY_SECONDS,
+) -> tuple[str, JsonObject]:
+    attempts: list[JsonObject] = []
+    for attempt in range(1, max_attempts + 1):
+        place = smoke.http_json(
+            "POST",
+            cfg.server_url,
+            "/api/game/place-spawn",
+            smoke.build_spawn_payload(cfg),
+            headers=smoke.token_headers(token),
+            timeout=RUN_PHASE_TIMEOUT_SECONDS,
+        )
+        token = smoke.update_token_from_headers(token, getattr(place, "headers", {}))
+        classification = _place_spawn_response_kind(place)
+        summary = _place_spawn_attempt_summary(place, attempt, classification)
+        attempts.append(summary)
+        if classification in {"ok", "already_playing"}:
+            if len(attempts) > 1:
+                summary["retry"] = {
+                    "attempts": attempts,
+                    "maxAttempts": max_attempts,
+                    "recovered": True,
+                }
+            return token, summary
+        if classification == "room_busy":
+            if attempt < max_attempts:
+                _debug_worker_phase(
+                    worker_index,
+                    variant_id,
+                    "place-spawn room busy; retrying",
+                    attempt=attempt,
+                    maxAttempts=max_attempts,
+                    retrySeconds=retry_seconds,
+                )
+                time.sleep(retry_seconds)
+                continue
+            detail = {
+                "phase": "place-spawn",
+                "classification": "place_spawn_room_busy",
+                "attempts": attempts,
+                "maxAttempts": max_attempts,
+                "retrySeconds": retry_seconds,
+                "nextAction": (
+                    "inspect private-simulator reset/import room state; do not rerun paid validation unchanged "
+                    "until the room-busy placement lock is explained"
+                ),
+            }
+            raise RuntimeError(
+                f"place-spawn room busy after {max_attempts} attempt(s): "
+                f"{_safe_redact_smoke_payload(detail)}"
+            )
+        raise RuntimeError(
+            "place-spawn API rejected with unexpected payload: "
+            f"{_safe_redact_smoke_payload(getattr(place, 'payload', None))}"
+        )
+    raise RuntimeError("place-spawn failed without an API attempt")
+
+
 def _fetch_room_overviews(
     cfg: Any,
     smoke: Any,
@@ -6064,6 +6183,7 @@ def _run_variant(
     compose: list[str] | None = None
     uploaded_code_text: str | None = None
     active_code_readback: JsonObject | None = None
+    place_spawn: JsonObject | None = None
     try:
         smoke = _load_private_smoke_module()
         summarize_prepared_map = _is_default_map_source_file(map_source_file)
@@ -6270,18 +6390,13 @@ def _run_variant(
             output_path=safe_run_root / "active_code_readback.json",
         )
 
-        place = smoke.http_json(
-            "POST",
-            cfg.server_url,
-            "/api/game/place-spawn",
-            smoke.build_spawn_payload(cfg),
-            headers=smoke.token_headers(token),
-            timeout=RUN_PHASE_TIMEOUT_SECONDS,
+        token, place_spawn = _place_spawn_with_retry(
+            smoke,
+            cfg,
+            token,
+            worker_index=worker_index,
+            variant_id=variant_id,
         )
-        if not isinstance(place.payload, dict) or not (place.payload.get("ok") == 1):
-            place_payload = _safe_redact_smoke_payload(place.payload)
-            if "already playing" not in str(place.payload.get("error", "")).lower():
-                raise RuntimeError(f"place-spawn API rejected with unexpected payload: {place_payload}")
 
         initial_state = smoke.http_json(
             "GET",
@@ -6430,6 +6545,7 @@ def _run_variant(
         "branch": api_branch,
         "requestedBranch": branch,
         "terrainReady": terrain_ready,
+        "placeSpawn": place_spawn,
         "mongoRoomEvidence": mongo_room_evidence,
         "scenarioFixture": build_scenario_fixture_objective_summary(fixture_room_summaries),
         "launcherRepairMod": str(repair_mod_path) if repair_mod_path is not None else None,

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -5926,6 +5926,16 @@ def _safe_redact_smoke_payload(payload: Any) -> JsonObject:
     return {"ok": True, "payload": dataset_export.redact_text(json.dumps(payload, sort_keys=True, ensure_ascii=True))[:2000]}
 
 
+class PlaceSpawnRoomBusyError(RuntimeError):
+    def __init__(self, detail: JsonObject) -> None:
+        self.detail = copy.deepcopy(detail)
+        max_attempts = detail.get("maxAttempts")
+        super().__init__(
+            f"place-spawn room busy after {max_attempts} attempt(s): "
+            f"{_safe_redact_smoke_payload(self.detail)}"
+        )
+
+
 def _json_text_payload(value: Any) -> Any:
     if not isinstance(value, str):
         return None
@@ -6028,7 +6038,7 @@ def _place_spawn_with_retry(
             detail = {
                 "phase": "place-spawn",
                 "classification": "place_spawn_room_busy",
-                "attempts": attempts,
+                "attempts": _place_spawn_retry_attempt_summaries(attempts),
                 "maxAttempts": max_attempts,
                 "retrySeconds": retry_seconds,
                 "nextAction": (
@@ -6036,10 +6046,7 @@ def _place_spawn_with_retry(
                     "until the room-busy placement lock is explained"
                 ),
             }
-            raise RuntimeError(
-                f"place-spawn room busy after {max_attempts} attempt(s): "
-                f"{_safe_redact_smoke_payload(detail)}"
-            )
+            raise PlaceSpawnRoomBusyError(detail)
         raise RuntimeError(
             "place-spawn API rejected with unexpected payload: "
             f"{_safe_redact_smoke_payload(getattr(place, 'payload', None))}"
@@ -6486,6 +6493,8 @@ def _run_variant(
             if smoke_gate_error is not None:
                 errors.append(smoke_gate_error)
     except Exception as exc:  # noqa: BLE001 - collect the failure into a safe result
+        if isinstance(exc, PlaceSpawnRoomBusyError):
+            place_spawn = copy.deepcopy(exc.detail)
         errors.append(_safe_text(exc, 480))
         runtime_parameter_injection = mark_runtime_parameter_injection_failed(runtime_parameter_injection, exc)
     finally:

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -5977,6 +5977,10 @@ def _place_spawn_attempt_summary(result: Any, attempt: int, classification: str)
     }
 
 
+def _place_spawn_retry_attempt_summaries(attempts: Sequence[JsonObject]) -> list[JsonObject]:
+    return [copy.deepcopy(attempt) for attempt in attempts]
+
+
 def _place_spawn_with_retry(
     smoke: Any,
     cfg: Any,
@@ -6004,7 +6008,7 @@ def _place_spawn_with_retry(
         if classification in {"ok", "already_playing"}:
             if len(attempts) > 1:
                 summary["retry"] = {
-                    "attempts": attempts,
+                    "attempts": _place_spawn_retry_attempt_summaries(attempts),
                     "maxAttempts": max_attempts,
                     "recovered": True,
                 }

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -155,6 +155,10 @@ REMOTE_SIMULATOR_SETUP_CONTEXT_RE = re.compile(
     r"setup_failure|error pulling image|failed to (?:copy|extract|pull|fetch))",
     re.IGNORECASE,
 )
+REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RE = re.compile(
+    r"(?:place-spawn room busy|place_spawn_room_busy|room-busy placement lock)",
+    re.IGNORECASE,
+)
 REMOTE_NETWORK_RE = re.compile(
     r"(?:connection refused|request canceled|too many requests|toomanyrequests|network .*timed? out|"
     r"net/http|Client\.Timeout)",
@@ -2415,6 +2419,8 @@ def classify_remote_training_failure(
     )
     if REMOTE_RESOURCE_GUARD_RE.search(diagnostic_text):
         return "simulator_resource_guard_rejected"
+    if REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RE.search(diagnostic_text):
+        return "simulator_place_spawn_room_busy"
     if process_failure_class in {"network_unreachable", "host_key_self_healing_failed", "host_key_mismatch"}:
         return process_failure_class
     simulator_setup_text = "\n".join(
@@ -2460,6 +2466,11 @@ def remote_training_failure_next_action(failure_class: str) -> str | None:
         return (
             "inspect collected partial diagnostics, then rerun validation in smaller chunks "
             "or with an explicitly sized training timeout"
+        )
+    if failure_class == "simulator_place_spawn_room_busy":
+        return (
+            "inspect private-simulator reset/import room state and place-spawn diagnostics; "
+            "do not rerun paid validation unchanged until the room-busy placement lock is explained"
         )
     return None
 

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -156,7 +156,7 @@ REMOTE_SIMULATOR_SETUP_CONTEXT_RE = re.compile(
     re.IGNORECASE,
 )
 REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RE = re.compile(
-    r"(?:place-spawn room busy|place_spawn_room_busy|room-busy placement lock)",
+    r"(?:place-spawn room busy after \d+ attempt\(s\)|\bplace_spawn_room_busy\b|room-busy placement lock)",
     re.IGNORECASE,
 )
 REMOTE_NETWORK_RE = re.compile(

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -6159,6 +6159,7 @@ cli:
         class FakeSmoke:
             def __init__(self) -> None:
                 self.calls = 0
+                self.seen_headers: list[dict[str, str]] = []
 
             def build_spawn_payload(self, cfg: argparse.Namespace) -> dict[str, object]:
                 return {"room": cfg.room, "name": "Spawn1", "x": 20, "y": 20}
@@ -6170,7 +6171,9 @@ cli:
                 return headers.get("X-Token", token)
 
             def http_json(self, method: str, base_url: str, path: str, *args: object, **kwargs: object) -> Result:
-                _ = method, base_url, path, args, kwargs
+                _ = method, base_url, path, args
+                headers = kwargs.get("headers")
+                self.seen_headers.append(dict(headers) if isinstance(headers, dict) else {})
                 self.calls += 1
                 if self.calls == 1:
                     return Result({"error": "room busy"}, "busy-token")
@@ -6195,6 +6198,8 @@ cli:
 
         self.assertEqual(token, "placed-token")
         self.assertEqual(smoke.calls, 2)
+        self.assertEqual(smoke.seen_headers[0].get("X-Token"), "initial-token")
+        self.assertEqual(smoke.seen_headers[1].get("X-Token"), "busy-token")
         sleep.assert_called_once_with(0.25)
         debug_phase.assert_called_once()
         self.assertEqual(summary["classification"], "ok")
@@ -6257,6 +6262,12 @@ cli:
                 )
 
         self.assertIn("do not rerun paid validation unchanged", str(caught.exception))
+        self.assertIsInstance(caught.exception, harness.PlaceSpawnRoomBusyError)
+        self.assertEqual(caught.exception.detail["classification"], "place_spawn_room_busy")
+        self.assertEqual(caught.exception.detail["maxAttempts"], 3)
+        self.assertEqual(len(caught.exception.detail["attempts"]), 3)
+        self.assertEqual(caught.exception.detail["attempts"][0]["classification"], "room_busy")
+        self.assertIn("do not rerun paid validation unchanged", caught.exception.detail["nextAction"])
         self.assertEqual(smoke.calls, 3)
         self.assertEqual(sleep.call_count, 2)
 
@@ -6540,6 +6551,155 @@ cli:
         self.assertFalse(result["ok"])
         self.assertEqual(result["error"], "stop before side effects")
         self.assertIsNone(result["launcherRepairMod"])
+
+    def test_run_variant_records_persistent_place_spawn_room_busy_detail(self) -> None:
+        class FakeSmokeConfig:
+            def __init__(self, **kwargs: object) -> None:
+                for key, value in kwargs.items():
+                    setattr(self, key, value)
+
+            @property
+            def config_path(self) -> Path:
+                return self.work_dir / "config.yml"
+
+            @property
+            def map_path(self) -> Path:
+                return self.work_dir / "maps" / "map-0b6758af.json"
+
+        class Result:
+            def __init__(self, status: int, payload: object, headers: dict[str, str] | None = None) -> None:
+                self.status = status
+                self.payload = payload
+                self.headers = headers or {}
+
+        class FakeSmoke:
+            SmokeConfig = FakeSmokeConfig
+            DEFAULT_MAP_URL = ""
+
+            def __init__(self) -> None:
+                self.place_spawn_calls = 0
+
+            def required_env_errors(self, cfg: FakeSmokeConfig) -> list[str]:
+                _ = cfg
+                return []
+
+            def assert_safe_work_dir(self, work_dir: Path) -> None:
+                _ = work_dir
+
+            def preflight_host_ports(self, cfg: FakeSmokeConfig) -> dict[str, object]:
+                _ = cfg
+                return {"checks": [{"available": True}]}
+
+            def find_compose_command(self) -> list[str]:
+                return ["compose"]
+
+            def prepare_work_dir(self, cfg: FakeSmokeConfig) -> None:
+                _ = cfg
+
+            def build_launcher_config(self, cfg: FakeSmokeConfig) -> str:
+                _ = cfg
+                return "serverConfig:\n  shardName: shardX\n  mapFile: /screeps/maps/map-0b6758af.json\n"
+
+            def write_generated_text(self, work_dir: Path, path: Path, text: str) -> None:
+                _ = work_dir, path, text
+
+            def prepare_map(self, cfg: FakeSmokeConfig) -> None:
+                _ = cfg
+
+            def run_command(
+                self,
+                command: list[str],
+                cfg: FakeSmokeConfig,
+                *,
+                timeout: int,
+                output_limit: int | None = None,
+            ) -> dict[str, object]:
+                _ = command, cfg, timeout, output_limit
+                return {"returncode": 0, "elapsed_seconds": 0.0, "output_excerpt": ""}
+
+            def run_launcher_cli(self, compose: list[str], cfg: FakeSmokeConfig, expression: str) -> dict[str, object]:
+                _ = compose, cfg, expression
+                return {"status": 200, "response_excerpt": "undefined\n"}
+
+            def wait_for_http(self, cfg: FakeSmokeConfig, timeout: int) -> dict[str, object]:
+                _ = cfg, timeout
+                return {"ok": True}
+
+            def token_headers(self, token: str | None) -> dict[str, str]:
+                return {"X-Token": token or ""}
+
+            def update_token_from_headers(self, token: str, headers: dict[str, str]) -> str:
+                return headers.get("X-Token", token)
+
+            def build_register_payload(self, cfg: FakeSmokeConfig) -> dict[str, object]:
+                return {"username": cfg.username, "email": cfg.email, "password": cfg.password}
+
+            def build_signin_payload(self, cfg: FakeSmokeConfig) -> dict[str, object]:
+                return {"email": cfg.email, "password": cfg.password}
+
+            def build_code_payload(self, cfg: FakeSmokeConfig, code: str) -> dict[str, object]:
+                return {"branch": cfg.branch, "modules": {"main": code}}
+
+            def build_spawn_payload(self, cfg: FakeSmokeConfig) -> dict[str, object]:
+                return {"room": cfg.room, "name": cfg.spawn_name, "x": cfg.spawn_x, "y": cfg.spawn_y}
+
+            def api_dict_succeeded(self, result: Result) -> bool:
+                return isinstance(result.payload, dict) and result.payload.get("ok") in (1, True)
+
+            def upload_code_succeeded(self, result: Result) -> bool:
+                return self.api_dict_succeeded(result)
+
+            def http_json(self, method: str, base_url: str, path: str, *args: object, **kwargs: object) -> Result:
+                _ = method, base_url, args, kwargs
+                if path == "/api/register/submit":
+                    return Result(200, {"ok": 1})
+                if path == "/api/auth/signin":
+                    return Result(200, {"ok": 1, "token": "signin-token"})
+                if path == "/api/user/code":
+                    return Result(200, {"ok": 1})
+                if path == "/api/game/place-spawn":
+                    self.place_spawn_calls += 1
+                    return Result(200, {"error": "room busy"}, {"X-Token": f"busy-{self.place_spawn_calls}"})
+                raise AssertionError(path)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            code_path = root / "main.js"
+            map_path = root / "map.json"
+            code_path.write_text("module.exports.loop = function() {};", encoding="utf-8")
+            map_path.write_text("{\"ok\": true}", encoding="utf-8")
+            fake_smoke = FakeSmoke()
+
+            with (
+                mock.patch("screeps_rl_simulator_harness._load_private_smoke_module", return_value=fake_smoke),
+                mock.patch("screeps_rl_simulator_harness._wait_for_terrain_ready", return_value={"ok": True}),
+                mock.patch(
+                    "screeps_rl_simulator_harness._poll_private_simulator_active_code_readback",
+                    return_value=("readback-token", {"status": "matched"}),
+                ),
+                mock.patch("screeps_rl_simulator_harness._private_map_fixture_room_summaries", return_value={}),
+                mock.patch.object(harness.time, "sleep", return_value=None),
+            ):
+                result = harness._run_variant(
+                    0,
+                    "baseline",
+                    run_id="place-spawn-busy-detail",
+                    ticks=1,
+                    room="E1S1",
+                    shard="shardX",
+                    branch="activeWorld",
+                    code_path=code_path,
+                    map_source_file=map_path,
+                    out_dir=root / "out",
+                )
+
+        self.assertFalse(result["ok"])
+        self.assertIn("place-spawn room busy after", result["error"])
+        self.assertEqual(fake_smoke.place_spawn_calls, harness.RUN_PLACE_SPAWN_MAX_ATTEMPTS)
+        self.assertEqual(result["placeSpawn"]["classification"], "place_spawn_room_busy")
+        self.assertEqual(result["placeSpawn"]["maxAttempts"], harness.RUN_PLACE_SPAWN_MAX_ATTEMPTS)
+        self.assertEqual(len(result["placeSpawn"]["attempts"]), harness.RUN_PLACE_SPAWN_MAX_ATTEMPTS)
+        self.assertIn("do not rerun paid validation unchanged", result["placeSpawn"]["nextAction"])
 
     def test_compose_setup_retry_recovers_transient_image_pull_failure(self) -> None:
         class FakeSmoke:

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -6211,11 +6211,16 @@ cli:
         serializable_summary = {"placeSpawn": summary}
         encoded = json.dumps(serializable_summary, sort_keys=True)
         self.assertIn('"recovered": true', encoded)
-        harness.assert_no_secret_leak(serializable_summary, [])
+        self.assertNotIn("busy-token", encoded)
+        self.assertNotIn("placed-token", encoded)
+        harness.assert_no_secret_leak(serializable_summary, ["busy-token", "placed-token"])
         with tempfile.TemporaryDirectory() as temp_dir:
             output_path = Path(temp_dir) / "summary.json"
             harness.write_json_atomic(output_path, serializable_summary)
             written = read_json(output_path)
+        written_text = json.dumps(written, sort_keys=True)
+        self.assertNotIn("busy-token", written_text)
+        self.assertNotIn("placed-token", written_text)
         self.assertEqual(written["placeSpawn"]["retry"]["attempts"][1]["classification"], "ok")
 
     def test_place_spawn_retry_reports_persistent_room_busy_with_no_rerun_guidance(self) -> None:
@@ -6700,6 +6705,13 @@ cli:
         self.assertEqual(result["placeSpawn"]["maxAttempts"], harness.RUN_PLACE_SPAWN_MAX_ATTEMPTS)
         self.assertEqual(len(result["placeSpawn"]["attempts"]), harness.RUN_PLACE_SPAWN_MAX_ATTEMPTS)
         self.assertIn("do not rerun paid validation unchanged", result["placeSpawn"]["nextAction"])
+        busy_tokens = [f"busy-{attempt}" for attempt in range(1, harness.RUN_PLACE_SPAWN_MAX_ATTEMPTS + 1)]
+        result_text = json.dumps(result, sort_keys=True)
+        place_spawn_text = json.dumps(result["placeSpawn"], sort_keys=True)
+        for token in busy_tokens:
+            self.assertNotIn(token, result_text)
+            self.assertNotIn(token, place_spawn_text)
+        harness.assert_no_secret_leak(result["placeSpawn"], busy_tokens)
 
     def test_compose_setup_retry_recovers_transient_image_pull_failure(self) -> None:
         class FakeSmoke:

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -6200,6 +6200,18 @@ cli:
         self.assertEqual(summary["classification"], "ok")
         self.assertTrue(summary["retry"]["recovered"])
         self.assertEqual(summary["retry"]["attempts"][0]["classification"], "room_busy")
+        self.assertEqual(summary["retry"]["attempts"][1]["classification"], "ok")
+        self.assertNotIn("retry", summary["retry"]["attempts"][1])
+
+        serializable_summary = {"placeSpawn": summary}
+        encoded = json.dumps(serializable_summary, sort_keys=True)
+        self.assertIn('"recovered": true', encoded)
+        harness.assert_no_secret_leak(serializable_summary, [])
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "summary.json"
+            harness.write_json_atomic(output_path, serializable_summary)
+            written = read_json(output_path)
+        self.assertEqual(written["placeSpawn"]["retry"]["attempts"][1]["classification"], "ok")
 
     def test_place_spawn_retry_reports_persistent_room_busy_with_no_rerun_guidance(self) -> None:
         class Result:

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -6129,6 +6129,125 @@ cli:
         self.assertFalse(harness._merge_mongo_room_summary_into_tick(tick_entry, mongo_summary))
         self.assertEqual(harness._mongo_room_summary_error(mongo_summary), "could not parse mongosh summary")
 
+    def test_place_spawn_parser_recognizes_room_busy_payload_shapes(self) -> None:
+        class Result:
+            def __init__(self, payload: object) -> None:
+                self.status = 200
+                self.payload = payload
+
+        self.assertEqual(harness._place_spawn_response_kind(Result({"ok": 1})), "ok")
+        self.assertEqual(
+            harness._place_spawn_response_kind(Result({"error": "already playing"})),
+            "already_playing",
+        )
+        self.assertEqual(
+            harness._place_spawn_response_kind(Result({"error": "room busy"})),
+            "room_busy",
+        )
+        self.assertEqual(
+            harness._place_spawn_response_kind(Result({"ok": True, "payload": '{"error": "room busy"}'})),
+            "room_busy",
+        )
+
+    def test_place_spawn_retry_recovers_from_room_busy(self) -> None:
+        class Result:
+            def __init__(self, payload: object, token: str) -> None:
+                self.status = 200
+                self.payload = payload
+                self.headers = {"X-Token": token}
+
+        class FakeSmoke:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def build_spawn_payload(self, cfg: argparse.Namespace) -> dict[str, object]:
+                return {"room": cfg.room, "name": "Spawn1", "x": 20, "y": 20}
+
+            def token_headers(self, token: str) -> dict[str, str]:
+                return {"X-Token": token}
+
+            def update_token_from_headers(self, token: str, headers: dict[str, str]) -> str:
+                return headers.get("X-Token", token)
+
+            def http_json(self, method: str, base_url: str, path: str, *args: object, **kwargs: object) -> Result:
+                _ = method, base_url, path, args, kwargs
+                self.calls += 1
+                if self.calls == 1:
+                    return Result({"error": "room busy"}, "busy-token")
+                return Result({"ok": 1}, "placed-token")
+
+        smoke = FakeSmoke()
+        cfg = argparse.Namespace(server_url="http://127.0.0.1", room="E1S1")
+
+        with (
+            mock.patch.object(harness.time, "sleep", return_value=None) as sleep,
+            mock.patch.object(harness, "_debug_worker_phase") as debug_phase,
+        ):
+            token, summary = harness._place_spawn_with_retry(
+                smoke,
+                cfg,
+                "initial-token",
+                worker_index=0,
+                variant_id="variant-a",
+                max_attempts=3,
+                retry_seconds=0.25,
+            )
+
+        self.assertEqual(token, "placed-token")
+        self.assertEqual(smoke.calls, 2)
+        sleep.assert_called_once_with(0.25)
+        debug_phase.assert_called_once()
+        self.assertEqual(summary["classification"], "ok")
+        self.assertTrue(summary["retry"]["recovered"])
+        self.assertEqual(summary["retry"]["attempts"][0]["classification"], "room_busy")
+
+    def test_place_spawn_retry_reports_persistent_room_busy_with_no_rerun_guidance(self) -> None:
+        class Result:
+            status = 200
+            payload = {"error": "room busy"}
+            headers: dict[str, str] = {}
+
+        class FakeSmoke:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def build_spawn_payload(self, cfg: argparse.Namespace) -> dict[str, object]:
+                return {"room": cfg.room, "name": "Spawn1", "x": 20, "y": 20}
+
+            def token_headers(self, token: str) -> dict[str, str]:
+                return {"X-Token": token}
+
+            def update_token_from_headers(self, token: str, headers: dict[str, str]) -> str:
+                _ = headers
+                return token
+
+            def http_json(self, method: str, base_url: str, path: str, *args: object, **kwargs: object) -> Result:
+                _ = method, base_url, path, args, kwargs
+                self.calls += 1
+                return Result()
+
+        smoke = FakeSmoke()
+        cfg = argparse.Namespace(server_url="http://127.0.0.1", room="E1S1")
+
+        with (
+            mock.patch.object(harness.time, "sleep", return_value=None) as sleep,
+            mock.patch.object(harness, "_debug_worker_phase"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "place-spawn room busy after 3 attempt") as caught:
+                harness._place_spawn_with_retry(
+                    smoke,
+                    cfg,
+                    "token",
+                    worker_index=0,
+                    variant_id="variant-a",
+                    max_attempts=3,
+                    retry_seconds=0.25,
+                )
+
+        self.assertIn("do not rerun paid validation unchanged", str(caught.exception))
+        self.assertEqual(smoke.calls, 3)
+        self.assertEqual(sleep.call_count, 2)
+
     def test_run_one_tick_uses_stats_gametime_when_private_overview_has_no_shard_clock(self) -> None:
         class Result:
             def __init__(self, payload: object) -> None:

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -4423,6 +4423,23 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertFalse(failure["retryable"])
         self.assertIn("do not rerun paid validation unchanged", failure["nextAction"])
 
+    def test_recovered_place_spawn_room_busy_retry_log_does_not_override_later_retryable_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            remote = root / "remote"
+            remote.mkdir()
+            (remote / "training-stderr.log").write_text(
+                "place-spawn room busy; retrying attempt=1 maxAttempts=12 retrySeconds=30\n"
+                "Client.Timeout exceeded while polling batch status\n",
+                encoding="utf-8",
+            )
+
+            failure = runner.remote_training_failure_diagnostics(root, 255, run_id="run-test")
+
+        self.assertEqual(failure["failureClass"], "network_unreachable")
+        self.assertTrue(failure["retryable"])
+        self.assertIn("worker SSH/network", failure["nextAction"])
+
     def test_diagnostic_redaction_covers_common_secret_formats(self) -> None:
         raw = (
             "STEAM_KEY=steam-secret\n"

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -4405,6 +4405,24 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertFalse(failure["retryable"])
         self.assertNotIn("nextAction", failure)
 
+    def test_place_spawn_room_busy_smoke_failure_gets_specific_non_retryable_guidance(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            remote = root / "remote"
+            remote.mkdir()
+            (remote / "training-stderr.log").write_text(
+                "pre-scale private-simulator trainability smoke gate failed: "
+                "place-spawn room busy after 12 attempt(s): "
+                '{"classification": "place_spawn_room_busy"}\n',
+                encoding="utf-8",
+            )
+
+            failure = runner.remote_training_failure_diagnostics(root, 2, run_id="run-test")
+
+        self.assertEqual(failure["failureClass"], "simulator_place_spawn_room_busy")
+        self.assertFalse(failure["retryable"])
+        self.assertIn("do not rerun paid validation unchanged", failure["nextAction"])
+
     def test_diagnostic_redaction_covers_common_secret_formats(self) -> None:
         raw = (
             "STEAM_KEY=steam-secret\n"


### PR DESCRIPTION
## Summary
- Add classified retry handling for private-server `place-spawn` room-busy responses in the RL simulator harness.
- Persist redacted place-spawn attempt diagnostics in variant summaries.
- Classify repeated room-busy pre-scale failures in the Tencent runner as a specific non-retryable simulator setup blocker with no-duplicate-paid-run guidance.

## Test Plan
- [x] `git diff --check`
- [x] `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_tencent_batch_rl_runner.py`
- [x] `python3 -m unittest scripts.test_screeps_rl_simulator_harness.RlSimulatorHarnessTest.test_place_spawn_parser_recognizes_room_busy_payload_shapes scripts.test_screeps_rl_simulator_harness.RlSimulatorHarnessTest.test_place_spawn_retry_recovers_from_room_busy scripts.test_screeps_rl_simulator_harness.RlSimulatorHarnessTest.test_place_spawn_retry_reports_persistent_room_busy_with_no_rerun_guidance scripts.test_screeps_tencent_batch_rl_runner.TencentBatchRlRunnerTest.test_place_spawn_room_busy_smoke_failure_gets_specific_non_retryable_guidance`

Related to issue 1501.

## Universal task Done gate
- [x] Task type: scripts-side RL training capability hotfix with targeted tests.
- [x] Expected observable outcome / named deliverable: private-server room-busy placement locks are retried briefly, then reported as `simulator_place_spawn_room_busy` with actionable diagnostics instead of silent duplicate paid validation.
- [x] Non-goals / accepted substitutes: no new Tencent paid validation run is launched by this PR; issue 1501 remains open for post-merge validation evidence.
- [x] Verification evidence required before Done: local syntax checks, targeted unittest coverage, PR checks, review-thread resolution, and a post-merge RL pre-scale attempt recorded on issue 1501.
- [x] Project Evidence / Next action / Blocked by: issue 1501 is In progress at PR creation; controller will move issue/PR to In review with this PR number, exact head, tests, and review/validation next action.
- [x] Post-merge/deploy/runtime proof: issue 1501 carries runtime proof target of a guarded post-merge pre-scale run that either succeeds past place-spawn or records the classified room-busy diagnostic.
- [x] Named deliverable proof: commit `399c0b4c` changes `scripts/screeps_rl_simulator_harness.py`, `scripts/screeps_tencent_batch_rl_runner.py`, and targeted tests.
