### PR TITLE
fix: self-heal simulator room-busy placement

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -5075,6 +5075,154 @@ def _fixture_room_objects(room_payload: JsonObject, room_name: str) -> list[Json
     return objects
 
 
+def _private_map_fixture_owner_identity(map_source_file: Path, room_name: str) -> JsonObject | None:
+    """Return the private-fixture placeholder owner for a room that imports owned state."""
+    rooms = _private_map_fixture_rooms(map_source_file)
+    room_payload = rooms.get(room_name)
+    if not isinstance(room_payload, dict):
+        return None
+    try:
+        raw = json.loads(map_source_file.expanduser().read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    owner = raw.get("owner") if isinstance(raw, dict) and isinstance(raw.get("owner"), dict) else {}
+    owner_id = text_or_none(owner.get("id")) if isinstance(owner, dict) else None
+    owner_username = text_or_none(owner.get("username")) if isinstance(owner, dict) else None
+    if owner_id is None:
+        return None
+    objects = _fixture_room_objects(room_payload, room_name)
+    if not any(_object_is_owned(item, owner_id, owner_username) for item in objects):
+        return None
+    identity: JsonObject = {"id": owner_id}
+    if owner_username is not None:
+        identity["username"] = owner_username
+    return identity
+
+
+def _fixture_owner_adoption_expression(room_name: str, fixture_owner_id: str, target_username: str) -> str:
+    """Build a launcher CLI expression that maps imported fixture owner ids to the smoke user."""
+    return f"""\
+(() => {{
+  const roomName = {json.dumps(room_name)};
+  const fixtureOwnerId = {json.dumps(fixture_owner_id)};
+  const targetUsername = {json.dumps(target_username)};
+  const objectsCollection = storage.db['rooms.objects'];
+  return storage.db.users.findOne({{username: targetUsername}}).then(user => {{
+    if (!user || !user._id) {{
+      throw new Error(`smoke user not found: ${{targetUsername}}`);
+    }}
+    const targetUserId = String(user._id);
+    return objectsCollection.find({{room: roomName}}).then(objects => {{
+      const updates = [];
+      let adoptedObjects = 0;
+      let reboundControllers = 0;
+      let reservationUpdates = 0;
+      for (const object of objects || []) {{
+        const patch = {{}};
+        if (object.user != null && String(object.user) === fixtureOwnerId) {{
+          patch.user = targetUserId;
+          adoptedObjects += 1;
+        }}
+        if (object.bindUser != null && String(object.bindUser) === fixtureOwnerId) {{
+          patch.bindUser = targetUserId;
+          reboundControllers += 1;
+        }}
+        if (
+          object.reservation
+          && object.reservation.user != null
+          && String(object.reservation.user) === fixtureOwnerId
+        ) {{
+          patch.reservation = Object.assign({{}}, object.reservation, {{user: targetUserId}});
+          reservationUpdates += 1;
+        }}
+        if (Object.keys(patch).length > 0 && object._id != null) {{
+          updates.push(objectsCollection.update({{_id: object._id}}, {{$set: patch}}));
+        }}
+      }}
+      updates.push(storage.db.users.update({{_id: user._id}}, {{$set: {{active: 10000}}}}));
+      updates.push(storage.db.rooms.update({{_id: roomName}}, {{$set: {{invaderGoal: 1000000}}}}));
+      if (storage.env && storage.env.keys && storage.env.keys.ACTIVE_ROOMS && storage.env.sadd) {{
+        updates.push(storage.env.sadd(storage.env.keys.ACTIVE_ROOMS, roomName));
+      }}
+      return Promise.all(updates).then(() => JSON.stringify({{
+        ok: true,
+        room: roomName,
+        fixtureOwnerId,
+        targetUsername,
+        adoptedObjects,
+        reboundControllers,
+        reservationUpdates,
+        activeUser: true,
+        roomActivated: true
+      }}));
+    }});
+  }});
+}})()
+"""
+
+
+def _launcher_cli_result_summary(result: JsonObject) -> JsonObject:
+    summary: JsonObject = {
+        "status": _extract_int(result.get("status")),
+    }
+    elapsed_seconds = result.get("elapsed_seconds")
+    if isinstance(elapsed_seconds, (int, float)):
+        summary["elapsedSeconds"] = elapsed_seconds
+    response_excerpt = result.get("response_excerpt")
+    if isinstance(response_excerpt, str):
+        summary["responseExcerpt"] = _safe_text(response_excerpt, 500)
+    return summary
+
+
+def _self_heal_fixture_place_spawn_room_busy(
+    smoke: Any,
+    compose: list[str],
+    cfg: Any,
+    *,
+    map_source_file: Path,
+    room: str,
+    worker_index: int,
+    variant_id: str,
+) -> JsonObject:
+    identity = _private_map_fixture_owner_identity(map_source_file, room)
+    if identity is None:
+        return {
+            "phase": "place-spawn-room-busy-self-heal",
+            "classification": "skipped",
+            "reason": "target room is not an owned private-map fixture room",
+        }
+    fixture_owner_id = str(identity["id"])
+    target_username = str(getattr(cfg, "username", ""))
+    expression = _fixture_owner_adoption_expression(room, fixture_owner_id, target_username)
+    _debug_worker_phase(
+        worker_index,
+        variant_id,
+        "place-spawn room busy; adopting private fixture owner",
+        room=room,
+        fixtureOwnerId=fixture_owner_id,
+        targetUsername=target_username,
+    )
+    result = _require_launcher_cli_success(
+        smoke,
+        compose,
+        cfg,
+        expression,
+        "adopt private fixture owner",
+    )
+    summary: JsonObject = {
+        "phase": "place-spawn-room-busy-self-heal",
+        "classification": "fixture_owner_adopted",
+        "room": room,
+        "fixtureOwnerId": fixture_owner_id,
+        "targetUsername": target_username,
+        "result": _launcher_cli_result_summary(result),
+    }
+    fixture_owner_username = text_or_none(identity.get("username"))
+    if fixture_owner_username is not None:
+        summary["fixtureOwnerUsername"] = fixture_owner_username
+    return summary
+
+
 def _private_map_fixture_room_summaries(map_source_file: Path) -> dict[str, JsonObject]:
     """Build sanitized room summaries for scenario fixture rooms missing from private APIs."""
     rooms = _private_map_fixture_rooms(map_source_file)
@@ -5991,6 +6139,15 @@ def _place_spawn_retry_attempt_summaries(attempts: Sequence[JsonObject]) -> list
     return [copy.deepcopy(attempt) for attempt in attempts]
 
 
+def _place_spawn_self_healing_summaries(attempts: Sequence[JsonObject]) -> list[JsonObject]:
+    summaries: list[JsonObject] = []
+    for attempt in attempts:
+        self_healing = attempt.get("selfHealing")
+        if isinstance(self_healing, dict):
+            summaries.append(copy.deepcopy(self_healing))
+    return summaries
+
+
 def _place_spawn_with_retry(
     smoke: Any,
     cfg: Any,
@@ -6000,8 +6157,10 @@ def _place_spawn_with_retry(
     variant_id: str,
     max_attempts: int = RUN_PLACE_SPAWN_MAX_ATTEMPTS,
     retry_seconds: float = RUN_PLACE_SPAWN_RETRY_SECONDS,
+    room_busy_self_healer: Any | None = None,
 ) -> tuple[str, JsonObject]:
     attempts: list[JsonObject] = []
+    room_busy_self_heal_attempted = False
     for attempt in range(1, max_attempts + 1):
         place = smoke.http_json(
             "POST",
@@ -6022,8 +6181,26 @@ def _place_spawn_with_retry(
                     "maxAttempts": max_attempts,
                     "recovered": True,
                 }
+                self_healing = _place_spawn_self_healing_summaries(attempts)
+                if self_healing:
+                    summary["retry"]["selfHealing"] = {
+                        "attempts": self_healing,
+                        "recovered": True,
+                    }
             return token, summary
         if classification == "room_busy":
+            if room_busy_self_healer is not None and not room_busy_self_heal_attempted:
+                room_busy_self_heal_attempted = True
+                try:
+                    healing = room_busy_self_healer(attempt, summary)
+                except Exception as exc:  # noqa: BLE001 - preserve room-busy classification if recovery itself fails.
+                    healing = {
+                        "phase": "place-spawn-room-busy-self-heal",
+                        "classification": "self_heal_failed",
+                        "error": _safe_text(exc, 360),
+                    }
+                if isinstance(healing, dict):
+                    summary["selfHealing"] = copy.deepcopy(healing)
             if attempt < max_attempts:
                 _debug_worker_phase(
                     worker_index,
@@ -6046,6 +6223,12 @@ def _place_spawn_with_retry(
                     "until the room-busy placement lock is explained"
                 ),
             }
+            self_healing = _place_spawn_self_healing_summaries(attempts)
+            if self_healing:
+                detail["selfHealing"] = {
+                    "attempts": self_healing,
+                    "recovered": False,
+                }
             raise PlaceSpawnRoomBusyError(detail)
         raise RuntimeError(
             "place-spawn API rejected with unexpected payload: "
@@ -6407,6 +6590,15 @@ def _run_variant(
             token,
             worker_index=worker_index,
             variant_id=variant_id,
+            room_busy_self_healer=lambda attempt, summary: _self_heal_fixture_place_spawn_room_busy(
+                smoke,
+                compose,
+                cfg,
+                map_source_file=scenario_map_source_file,
+                room=room,
+                worker_index=worker_index,
+                variant_id=variant_id,
+            ),
         )
 
         initial_state = smoke.http_json(

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -5072,6 +5072,12 @@ def _fixture_room_objects(room_payload: JsonObject, room_name: str) -> list[Json
                 normalized.setdefault("type", normalized.get("structureType"))
             normalized.setdefault("room", room_name)
             objects.append(normalized)
+    controller = room_payload.get("controller")
+    if isinstance(controller, dict):
+        normalized = dict(controller)
+        normalized.setdefault("type", "controller")
+        normalized.setdefault("room", room_name)
+        objects.append(normalized)
     return objects
 
 

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -5075,6 +5075,39 @@ def _fixture_room_objects(room_payload: JsonObject, room_name: str) -> list[Json
     return objects
 
 
+def _fixture_owner_reference_matches(
+    value: Any,
+    owner_id: str | None,
+    owner_username: str | None,
+) -> bool:
+    if isinstance(value, str):
+        observed = value
+    elif isinstance(value, (int, float)):
+        observed = str(value)
+    else:
+        return False
+    if not observed:
+        return False
+    return bool((owner_id and observed == owner_id) or (owner_username and observed == owner_username))
+
+
+def _fixture_room_object_matches_owner(
+    item: JsonObject,
+    owner_id: str | None,
+    owner_username: str | None,
+) -> bool:
+    if _object_is_owned(item, owner_id, owner_username):
+        return True
+    if _object_type(item) != "controller":
+        return False
+    if _fixture_owner_reference_matches(item.get("bindUser"), owner_id, owner_username):
+        return True
+    reservation = item.get("reservation")
+    if isinstance(reservation, dict):
+        return _fixture_owner_reference_matches(reservation.get("user"), owner_id, owner_username)
+    return False
+
+
 def _private_map_fixture_owner_identity(map_source_file: Path, room_name: str) -> JsonObject | None:
     """Return the private-fixture placeholder owner for a room that imports owned state."""
     rooms = _private_map_fixture_rooms(map_source_file)
@@ -5091,7 +5124,7 @@ def _private_map_fixture_owner_identity(map_source_file: Path, room_name: str) -
     if owner_id is None:
         return None
     objects = _fixture_room_objects(room_payload, room_name)
-    if not any(_object_is_owned(item, owner_id, owner_username) for item in objects):
+    if not any(_fixture_room_object_matches_owner(item, owner_id, owner_username) for item in objects):
         return None
     identity: JsonObject = {"id": owner_id}
     if owner_username is not None:
@@ -5099,12 +5132,19 @@ def _private_map_fixture_owner_identity(map_source_file: Path, room_name: str) -
     return identity
 
 
-def _fixture_owner_adoption_expression(room_name: str, fixture_owner_id: str, target_username: str) -> str:
+def _fixture_owner_adoption_expression(
+    room_name: str,
+    fixture_owner_id: str,
+    fixture_owner_username: str | None,
+    target_username: str,
+) -> str:
     """Build a launcher CLI expression that maps imported fixture owner ids to the smoke user."""
     return f"""\
 (() => {{
   const roomName = {json.dumps(room_name)};
   const fixtureOwnerId = {json.dumps(fixture_owner_id)};
+  const fixtureOwnerUsername = {json.dumps(fixture_owner_username)};
+  const fixtureOwnerRefs = new Set([fixtureOwnerId, fixtureOwnerUsername].filter(value => value).map(String));
   const targetUsername = {json.dumps(target_username)};
   const objectsCollection = storage.db['rooms.objects'];
   return storage.db.users.findOne({{username: targetUsername}}).then(user => {{
@@ -5119,18 +5159,18 @@ def _fixture_owner_adoption_expression(room_name: str, fixture_owner_id: str, ta
       let reservationUpdates = 0;
       for (const object of objects || []) {{
         const patch = {{}};
-        if (object.user != null && String(object.user) === fixtureOwnerId) {{
+        if (object.user != null && fixtureOwnerRefs.has(String(object.user))) {{
           patch.user = targetUserId;
           adoptedObjects += 1;
         }}
-        if (object.bindUser != null && String(object.bindUser) === fixtureOwnerId) {{
+        if (object.bindUser != null && fixtureOwnerRefs.has(String(object.bindUser))) {{
           patch.bindUser = targetUserId;
           reboundControllers += 1;
         }}
         if (
           object.reservation
           && object.reservation.user != null
-          && String(object.reservation.user) === fixtureOwnerId
+          && fixtureOwnerRefs.has(String(object.reservation.user))
         ) {{
           patch.reservation = Object.assign({{}}, object.reservation, {{user: targetUserId}});
           reservationUpdates += 1;
@@ -5148,6 +5188,7 @@ def _fixture_owner_adoption_expression(room_name: str, fixture_owner_id: str, ta
         ok: true,
         room: roomName,
         fixtureOwnerId,
+        fixtureOwnerUsername,
         targetUsername,
         adoptedObjects,
         reboundControllers,
@@ -5192,8 +5233,20 @@ def _self_heal_fixture_place_spawn_room_busy(
             "reason": "target room is not an owned private-map fixture room",
         }
     fixture_owner_id = str(identity["id"])
-    target_username = str(getattr(cfg, "username", ""))
-    expression = _fixture_owner_adoption_expression(room, fixture_owner_id, target_username)
+    fixture_owner_username = text_or_none(identity.get("username"))
+    target_username = _non_empty_text(getattr(cfg, "username", None))
+    if target_username is None:
+        summary: JsonObject = {
+            "phase": "place-spawn-room-busy-self-heal",
+            "classification": "skipped",
+            "reason": "cfg.username is not set; cannot adopt fixture owner",
+            "room": room,
+            "fixtureOwnerId": fixture_owner_id,
+        }
+        if fixture_owner_username is not None:
+            summary["fixtureOwnerUsername"] = fixture_owner_username
+        return summary
+    expression = _fixture_owner_adoption_expression(room, fixture_owner_id, fixture_owner_username, target_username)
     _debug_worker_phase(
         worker_index,
         variant_id,
@@ -5217,7 +5270,6 @@ def _self_heal_fixture_place_spawn_room_busy(
         "targetUsername": target_username,
         "result": _launcher_cli_result_summary(result),
     }
-    fixture_owner_username = text_or_none(identity.get("username"))
     if fixture_owner_username is not None:
         summary["fixtureOwnerUsername"] = fixture_owner_username
     return summary

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -6149,6 +6149,133 @@ cli:
             "room_busy",
         )
 
+    def test_private_fixture_owner_identity_detects_imported_owned_anchor(self) -> None:
+        fixture_path = Path("scripts/fixtures/rl/multi-tier-territory-combat-v1.map.json")
+
+        identity = harness._private_map_fixture_owner_identity(fixture_path, "E1S1")
+
+        self.assertEqual(identity, {"id": "owner", "username": "rl-owner"})
+        self.assertIsNone(harness._private_map_fixture_owner_identity(fixture_path, "E2S1"))
+
+    def test_fixture_room_busy_self_healer_adopts_fixture_owner_to_smoke_user(self) -> None:
+        class FakeSmoke:
+            def __init__(self) -> None:
+                self.expressions: list[str] = []
+
+            def run_launcher_cli(
+                self,
+                compose: list[str],
+                cfg: argparse.Namespace,
+                expression: str,
+            ) -> dict[str, object]:
+                _ = compose, cfg
+                self.expressions.append(expression)
+                return {
+                    "status": 200,
+                    "elapsed_seconds": 0.02,
+                    "response_excerpt": '{"ok":true,"adoptedObjects":5,"activeUser":true}',
+                }
+
+        smoke = FakeSmoke()
+        cfg = argparse.Namespace(username="rl-sim-fixture")
+        fixture_path = Path("scripts/fixtures/rl/multi-tier-territory-combat-v1.map.json")
+
+        with mock.patch.object(harness, "_debug_worker_phase") as debug_phase:
+            summary = harness._self_heal_fixture_place_spawn_room_busy(
+                smoke,
+                ["compose"],
+                cfg,
+                map_source_file=fixture_path,
+                room="E1S1",
+                worker_index=0,
+                variant_id="variant-a",
+            )
+
+        self.assertEqual(summary["classification"], "fixture_owner_adopted")
+        self.assertEqual(summary["fixtureOwnerId"], "owner")
+        self.assertEqual(summary["fixtureOwnerUsername"], "rl-owner")
+        self.assertEqual(summary["targetUsername"], "rl-sim-fixture")
+        self.assertEqual(summary["result"]["status"], 200)
+        self.assertEqual(len(smoke.expressions), 1)
+        self.assertIn("storage.db.users.findOne", smoke.expressions[0])
+        self.assertIn('"owner"', smoke.expressions[0])
+        self.assertIn('"rl-sim-fixture"', smoke.expressions[0])
+        self.assertIn("ACTIVE_ROOMS", smoke.expressions[0])
+        debug_phase.assert_called_once()
+
+    def test_place_spawn_retry_runs_room_busy_self_healing_before_retry(self) -> None:
+        class Result:
+            def __init__(self, payload: object, token: str) -> None:
+                self.status = 200
+                self.payload = payload
+                self.headers = {"X-Token": token}
+
+        class FakeSmoke:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def build_spawn_payload(self, cfg: argparse.Namespace) -> dict[str, object]:
+                return {"room": cfg.room, "name": "Spawn1", "x": 20, "y": 20}
+
+            def token_headers(self, token: str) -> dict[str, str]:
+                return {"X-Token": token}
+
+            def update_token_from_headers(self, token: str, headers: dict[str, str]) -> str:
+                return headers.get("X-Token", token)
+
+            def http_json(self, method: str, base_url: str, path: str, *args: object, **kwargs: object) -> Result:
+                _ = method, base_url, path, args, kwargs
+                self.calls += 1
+                if self.calls == 1:
+                    return Result({"error": "room busy"}, "busy-token")
+                return Result({"error": "already playing"}, "adopted-token")
+
+        healing_calls: list[tuple[int, dict[str, object]]] = []
+
+        def heal(attempt: int, summary: dict[str, object]) -> dict[str, object]:
+            healing_calls.append((attempt, copy.deepcopy(summary)))
+            return {
+                "phase": "place-spawn-room-busy-self-heal",
+                "classification": "fixture_owner_adopted",
+                "room": "E1S1",
+            }
+
+        smoke = FakeSmoke()
+        cfg = argparse.Namespace(server_url="http://127.0.0.1", room="E1S1")
+
+        with (
+            mock.patch.object(harness.time, "sleep", return_value=None) as sleep,
+            mock.patch.object(harness, "_debug_worker_phase"),
+        ):
+            token, summary = harness._place_spawn_with_retry(
+                smoke,
+                cfg,
+                "initial-token",
+                worker_index=0,
+                variant_id="variant-a",
+                max_attempts=3,
+                retry_seconds=0.25,
+                room_busy_self_healer=heal,
+            )
+
+        self.assertEqual(token, "adopted-token")
+        self.assertEqual(smoke.calls, 2)
+        self.assertEqual(len(healing_calls), 1)
+        self.assertEqual(healing_calls[0][0], 1)
+        self.assertEqual(healing_calls[0][1]["classification"], "room_busy")
+        sleep.assert_called_once_with(0.25)
+        self.assertEqual(summary["classification"], "already_playing")
+        self.assertTrue(summary["retry"]["recovered"])
+        self.assertTrue(summary["retry"]["selfHealing"]["recovered"])
+        self.assertEqual(
+            summary["retry"]["selfHealing"]["attempts"][0]["classification"],
+            "fixture_owner_adopted",
+        )
+        self.assertEqual(
+            summary["retry"]["attempts"][0]["selfHealing"]["classification"],
+            "fixture_owner_adopted",
+        )
+
     def test_place_spawn_retry_recovers_from_room_busy(self) -> None:
         class Result:
             def __init__(self, payload: object, token: str) -> None:

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -6202,6 +6202,45 @@ cli:
             )
             self.assertIsNone(harness._private_map_fixture_owner_identity(fixture_path, "E3S1"))
 
+    def test_private_fixture_owner_identity_detects_top_level_controller_ownership(self) -> None:
+        fixture = {
+            "type": harness.PRIVATE_MAP_FIXTURE_TYPE,
+            "owner": {"id": "owner", "username": "rl-owner"},
+            "rooms": {
+                "E1S1": {
+                    "controller": {
+                        "_id": "controller-bind",
+                        "bindUser": "rl-owner",
+                    },
+                },
+                "E2S1": {
+                    "controller": {
+                        "_id": "controller-reserved",
+                        "reservation": {"user": "owner"},
+                    },
+                },
+                "E3S1": {
+                    "controller": {
+                        "_id": "controller-neutral",
+                        "level": 1,
+                    },
+                },
+            },
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture_path = Path(temp_dir) / "map.json"
+            fixture_path.write_text(json.dumps(fixture, sort_keys=True), encoding="utf-8")
+
+            self.assertEqual(
+                harness._private_map_fixture_owner_identity(fixture_path, "E1S1"),
+                {"id": "owner", "username": "rl-owner"},
+            )
+            self.assertEqual(
+                harness._private_map_fixture_owner_identity(fixture_path, "E2S1"),
+                {"id": "owner", "username": "rl-owner"},
+            )
+            self.assertIsNone(harness._private_map_fixture_owner_identity(fixture_path, "E3S1"))
+
     def test_fixture_room_busy_self_healer_adopts_fixture_owner_to_smoke_user(self) -> None:
         class FakeSmoke:
             def __init__(self) -> None:

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -6157,6 +6157,51 @@ cli:
         self.assertEqual(identity, {"id": "owner", "username": "rl-owner"})
         self.assertIsNone(harness._private_map_fixture_owner_identity(fixture_path, "E2S1"))
 
+    def test_private_fixture_owner_identity_detects_controller_binding_and_reservation(self) -> None:
+        fixture = {
+            "type": harness.PRIVATE_MAP_FIXTURE_TYPE,
+            "owner": {"id": "owner", "username": "rl-owner"},
+            "rooms": [
+                {
+                    "room": "E1S1",
+                    "objects": [
+                        {
+                            "_id": "controller-bind",
+                            "type": "controller",
+                            "bindUser": "rl-owner",
+                        }
+                    ],
+                },
+                {
+                    "room": "E2S1",
+                    "objects": [
+                        {
+                            "_id": "controller-reserved",
+                            "type": "controller",
+                            "reservation": {"user": "owner"},
+                        }
+                    ],
+                },
+                {
+                    "room": "E3S1",
+                    "objects": [{"_id": "controller-neutral", "type": "controller"}],
+                },
+            ],
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture_path = Path(temp_dir) / "map.json"
+            fixture_path.write_text(json.dumps(fixture, sort_keys=True), encoding="utf-8")
+
+            self.assertEqual(
+                harness._private_map_fixture_owner_identity(fixture_path, "E1S1"),
+                {"id": "owner", "username": "rl-owner"},
+            )
+            self.assertEqual(
+                harness._private_map_fixture_owner_identity(fixture_path, "E2S1"),
+                {"id": "owner", "username": "rl-owner"},
+            )
+            self.assertIsNone(harness._private_map_fixture_owner_identity(fixture_path, "E3S1"))
+
     def test_fixture_room_busy_self_healer_adopts_fixture_owner_to_smoke_user(self) -> None:
         class FakeSmoke:
             def __init__(self) -> None:
@@ -6199,9 +6244,48 @@ cli:
         self.assertEqual(len(smoke.expressions), 1)
         self.assertIn("storage.db.users.findOne", smoke.expressions[0])
         self.assertIn('"owner"', smoke.expressions[0])
+        self.assertIn('"rl-owner"', smoke.expressions[0])
         self.assertIn('"rl-sim-fixture"', smoke.expressions[0])
+        self.assertIn("fixtureOwnerRefs.has", smoke.expressions[0])
         self.assertIn("ACTIVE_ROOMS", smoke.expressions[0])
         debug_phase.assert_called_once()
+
+    def test_fixture_room_busy_self_healer_skips_without_target_username(self) -> None:
+        class FakeSmoke:
+            def __init__(self) -> None:
+                self.expressions: list[str] = []
+
+            def run_launcher_cli(
+                self,
+                compose: list[str],
+                cfg: argparse.Namespace,
+                expression: str,
+            ) -> dict[str, object]:
+                _ = compose, cfg
+                self.expressions.append(expression)
+                return {"status": 200}
+
+        fixture_path = Path("scripts/fixtures/rl/multi-tier-territory-combat-v1.map.json")
+        for cfg in (argparse.Namespace(username=""), argparse.Namespace()):
+            with self.subTest(cfg=cfg):
+                smoke = FakeSmoke()
+                with mock.patch.object(harness, "_debug_worker_phase") as debug_phase:
+                    summary = harness._self_heal_fixture_place_spawn_room_busy(
+                        smoke,
+                        ["compose"],
+                        cfg,
+                        map_source_file=fixture_path,
+                        room="E1S1",
+                        worker_index=0,
+                        variant_id="variant-a",
+                    )
+
+                self.assertEqual(summary["classification"], "skipped")
+                self.assertEqual(summary["reason"], "cfg.username is not set; cannot adopt fixture owner")
+                self.assertEqual(summary["fixtureOwnerId"], "owner")
+                self.assertEqual(summary["fixtureOwnerUsername"], "rl-owner")
+                self.assertEqual(smoke.expressions, [])
+                debug_phase.assert_not_called()
 
     def test_place_spawn_retry_runs_room_busy_self_healing_before_retry(self) -> None:
         class Result:


### PR DESCRIPTION
## Summary
- add a private-simulator room-busy self-heal path for imported fixture owner state before retrying spawn placement
- adopt the fixture owner objects/controllers/reservations to the registered smoke user through the launcher CLI when the target fixture room is already owned
- keep bounded retry diagnostics and surface self-heal evidence in `placeSpawn.retry.selfHealing`

## Linked issue
Refs #1501

## Verification
- [x] `git diff --check`
- [x] `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/test_screeps_rl_simulator_harness.py`
- [x] `python3 -m unittest scripts/test_screeps_rl_simulator_harness.py` (186 tests)

## Issue closure gate
- [x] #1501: PR #1504 provides the code-side self-heal deliverable and controller verification; #1501 stays open for the named post-merge guarded Tencent/private-simulator validation before issue completion.

## Universal task Done gate
- [x] Task type: RL flywheel code fix for the private simulator/Tencent pre-scale trainability smoke path.
- [x] Expected observable outcome / named deliverable: a Codex-authored branch commit that self-heals private-map fixture ownership when `place-spawn` reports `room busy`, then retries within the existing bounded placement budget.
- [x] Non-goals / accepted substitutes: no official MMO writes, no live gameplay behavior change, no Tencent paid validation launched by this PR.
- [x] Verification evidence required before Done: local diff check, Python compile, and simulator harness unittest evidence listed above; GitHub CI and automated review must pass on this PR head before merge.
- [x] Project Evidence / Next action / Blocked by: PR and #1501 Project fields are updated by the scheduler; next action is PR review/CI, then one guarded post-merge validation run before closing #1501.
- [x] Post-merge/deploy/runtime proof: post-merge proof is a guarded Tencent/private-simulator run that no longer fails with `place-spawn room busy`; this PR does not claim that proof yet.
- [x] Named deliverable proof: commit `6026fb57` by `lanyusea's bot <lanyusea@gmail.com>` changes only `scripts/screeps_rl_simulator_harness.py` and `scripts/test_screeps_rl_simulator_harness.py`.

## Safety
- `liveEffect=false`; this path only affects offline/private simulator harness execution.
- No secrets are printed by the new diagnostics.
- Paid compute remains held until the PR merges and the scheduler performs the separate ASG/billing/no-runner gate.

