### PR TITLE
fix: retain repair work under critical CPU guard

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -31370,7 +31370,7 @@ function getCriticalCpuTaskRetentionDecision(creep, task) {
   return { retain: false };
 }
 function shouldRetainCriticalCpuRepairTask(creep) {
-  return getUsedTransferEnergy(creep) > 0 && !isSpawnEnergyCritical(creep.room) && !isControllerDowngradeGuardActive2(creep.room);
+  return getUsedTransferEnergy(creep) > 0 && !assessWorkerEnergyCriticalState(creep).active && !isControllerDowngradeGuardActive2(creep.room);
 }
 function getCriticalCpuTransferRetentionDecision(creep, task) {
   if (getUsedTransferEnergy(creep) <= 0) {
@@ -31405,10 +31405,6 @@ function shouldDeferSpawnReservationRefillForProductiveWork(creep, selectedTask)
 function hasHealthyRoomEnergyBuffer2(room) {
   const energyAvailable = getRoomEnergyAvailable12(room);
   return energyAvailable !== null && energyAvailable >= getEffectiveRoomEnergyBufferThreshold(room);
-}
-function isSpawnEnergyCritical(room) {
-  const energyAvailable = getRoomEnergyAvailable12(room);
-  return energyAvailable !== null && energyAvailable < CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD;
 }
 function isControllerDowngradeGuardActive2(room) {
   const controller = room.controller;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -31364,7 +31364,13 @@ function getCriticalCpuTaskRetentionDecision(creep, task) {
   if (isTerritoryControlTask2(task)) {
     return getCriticalCpuTerritoryControlRetentionDecision(creep, task);
   }
+  if (task.type === "repair") {
+    return { retain: shouldRetainCriticalCpuRepairTask(creep) };
+  }
   return { retain: false };
+}
+function shouldRetainCriticalCpuRepairTask(creep) {
+  return getUsedTransferEnergy(creep) > 0 && !isSpawnEnergyCritical(creep.room) && !isControllerDowngradeGuardActive2(creep.room);
 }
 function getCriticalCpuTransferRetentionDecision(creep, task) {
   if (getUsedTransferEnergy(creep) <= 0) {
@@ -31399,6 +31405,14 @@ function shouldDeferSpawnReservationRefillForProductiveWork(creep, selectedTask)
 function hasHealthyRoomEnergyBuffer2(room) {
   const energyAvailable = getRoomEnergyAvailable12(room);
   return energyAvailable !== null && energyAvailable >= getEffectiveRoomEnergyBufferThreshold(room);
+}
+function isSpawnEnergyCritical(room) {
+  const energyAvailable = getRoomEnergyAvailable12(room);
+  return energyAvailable !== null && energyAvailable < CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD;
+}
+function isControllerDowngradeGuardActive2(room) {
+  const controller = room.controller;
+  return (controller == null ? void 0 : controller.my) === true && typeof controller.ticksToDowngrade === "number" && controller.ticksToDowngrade <= CONTROLLER_DOWNGRADE_GUARD_TICKS;
 }
 function hasActiveSpawningSpawn2(room) {
   if (typeof FIND_MY_STRUCTURES !== "number" || typeof (room == null ? void 0 : room.find) !== "function") {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -31173,6 +31173,11 @@ function runWorker(creep) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptForWorkerEnergyCriticalTask(currentTask, energyCriticalTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
+  } else if (shouldPreemptRepairTaskForCriticalCpuRepairPreemption(
+    currentTask,
+    criticalCpuTaskRetention.repairPreemptionTask
+  )) {
+    taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptControllerSigningForRecovery(currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptForControllerSigning(creep, currentTask, selectedTask)) {
@@ -31365,12 +31370,90 @@ function getCriticalCpuTaskRetentionDecision(creep, task) {
     return getCriticalCpuTerritoryControlRetentionDecision(creep, task);
   }
   if (task.type === "repair") {
-    return { retain: shouldRetainCriticalCpuRepairTask(creep) };
+    return getCriticalCpuRepairRetentionDecision(creep, task);
   }
   return { retain: false };
 }
+function getCriticalCpuRepairRetentionDecision(creep, task) {
+  if (!shouldRetainCriticalCpuRepairTask(creep)) {
+    return { retain: false };
+  }
+  const preemptionTarget = selectCriticalCpuRepairPreemptionTarget(creep);
+  if (preemptionTarget !== null && String(preemptionTarget.id) !== String(task.targetId)) {
+    const repairPreemptionTask = {
+      type: "repair",
+      targetId: preemptionTarget.id
+    };
+    return {
+      retain: false,
+      repairPreemptionTask,
+      selectionContext: createSingleTaskSelectionContext(repairPreemptionTask)
+    };
+  }
+  return { retain: true };
+}
+function createSingleTaskSelectionContext(task) {
+  return {
+    baseSelectedTask: task,
+    energyCriticalTask: null,
+    selectedTask: task,
+    spawnReservationRefillTask: null
+  };
+}
 function shouldRetainCriticalCpuRepairTask(creep) {
   return getUsedTransferEnergy(creep) > 0 && !assessWorkerEnergyCriticalState(creep).active && !isControllerDowngradeGuardActive2(creep.room) && !shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep);
+}
+function shouldPreemptRepairTaskForCriticalCpuRepairPreemption(task, repairPreemptionTask) {
+  return task.type === "repair" && repairPreemptionTask !== void 0 && !isSameTask2(task, repairPreemptionTask);
+}
+function selectCriticalCpuRepairPreemptionTarget(creep) {
+  var _a, _b;
+  const visibleStructures = findVisibleStructuresForCriticalCpuRepairPreemption(creep.room);
+  const criticalSpawnRepairTarget = visibleStructures.filter(isCriticalCpuOwnedSpawnRepairTarget).sort(compareCriticalCpuRepairPreemptionTargets)[0];
+  if (criticalSpawnRepairTarget) {
+    return criticalSpawnRepairTarget;
+  }
+  const emergencyRampartRepairTarget = visibleStructures.filter(isCriticalCpuEmergencyOwnedRampartRepairTarget).sort(compareCriticalCpuRepairPreemptionTargets)[0];
+  if (emergencyRampartRepairTarget) {
+    return emergencyRampartRepairTarget;
+  }
+  if (((_a = creep.room.controller) == null ? void 0 : _a.my) !== true || !isColonyRoomThreatened(creep.room.name)) {
+    return null;
+  }
+  return (_b = visibleStructures.filter(isCriticalCpuThreatenedBarrierRepairTarget).sort(compareCriticalCpuRepairPreemptionTargets)[0]) != null ? _b : null;
+}
+function findVisibleStructuresForCriticalCpuRepairPreemption(room) {
+  const findStructures = globalThis.FIND_STRUCTURES;
+  if (typeof findStructures !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  const structures = room.find(findStructures);
+  return Array.isArray(structures) ? structures : [];
+}
+function isCriticalCpuOwnedSpawnRepairTarget(structure) {
+  return isCriticalCpuRepairStructureType(structure, "STRUCTURE_SPAWN", "spawn") && structure.my === true && !isWorkerRepairTargetComplete(structure) && getCriticalCpuRepairHitsRatio(structure) <= CRITICAL_SPAWN_REPAIR_HITS_RATIO;
+}
+function isCriticalCpuEmergencyOwnedRampartRepairTarget(structure) {
+  return isCriticalCpuOwnedRampart(structure) && !isWorkerRepairTargetComplete(structure) && structure.hits <= EMERGENCY_RAMPART_REPAIR_HITS_CEILING;
+}
+function isCriticalCpuThreatenedBarrierRepairTarget(structure) {
+  return isCriticalCpuBarrierRepairTarget(structure) && !isWorkerRepairTargetComplete(structure);
+}
+function isCriticalCpuBarrierRepairTarget(structure) {
+  return isCriticalCpuOwnedRampart(structure) || isCriticalCpuRepairStructureType(structure, "STRUCTURE_WALL", "constructedWall");
+}
+function isCriticalCpuOwnedRampart(structure) {
+  return isCriticalCpuRepairStructureType(structure, "STRUCTURE_RAMPART", "rampart") && structure.my === true;
+}
+function compareCriticalCpuRepairPreemptionTargets(left, right) {
+  return getCriticalCpuRepairHitsRatio(left) - getCriticalCpuRepairHitsRatio(right) || left.hits - right.hits || String(left.id).localeCompare(String(right.id));
+}
+function getCriticalCpuRepairHitsRatio(structure) {
+  return structure.hitsMax > 0 ? structure.hits / structure.hitsMax : 1;
+}
+function isCriticalCpuRepairStructureType(structure, globalConstantName, fallback) {
+  const globalConstant = globalThis[globalConstantName];
+  return structure.structureType === (globalConstant != null ? globalConstant : fallback);
 }
 function getCriticalCpuTransferRetentionDecision(creep, task) {
   if (getUsedTransferEnergy(creep) <= 0) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -31370,7 +31370,7 @@ function getCriticalCpuTaskRetentionDecision(creep, task) {
   return { retain: false };
 }
 function shouldRetainCriticalCpuRepairTask(creep) {
-  return getUsedTransferEnergy(creep) > 0 && !assessWorkerEnergyCriticalState(creep).active && !isControllerDowngradeGuardActive2(creep.room);
+  return getUsedTransferEnergy(creep) > 0 && !assessWorkerEnergyCriticalState(creep).active && !isControllerDowngradeGuardActive2(creep.room) && !shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep);
 }
 function getCriticalCpuTransferRetentionDecision(creep, task) {
   if (getUsedTransferEnergy(creep) <= 0) {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -406,7 +406,8 @@ function shouldRetainCriticalCpuRepairTask(creep: Creep): boolean {
   return (
     getUsedTransferEnergy(creep) > 0 &&
     !assessWorkerEnergyCriticalState(creep).active &&
-    !isControllerDowngradeGuardActive(creep.room)
+    !isControllerDowngradeGuardActive(creep.room) &&
+    !shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep)
   );
 }
 

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -1,6 +1,8 @@
 import {
   CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD,
+  CRITICAL_SPAWN_REPAIR_HITS_RATIO,
   CONTROLLER_DOWNGRADE_GUARD_TICKS,
+  EMERGENCY_RAMPART_REPAIR_HITS_CEILING,
   MINIMUM_USEFUL_LOAD_RATIO,
   selectWorkerPreHarvestTask,
   isUpgraderBoostActive,
@@ -47,6 +49,7 @@ import {
   type RuntimeEnergyAcquisitionMethod
 } from '../telemetry/behaviorTelemetry';
 import { getRuntimeCpuBudget } from '../runtime/cpuBudget';
+import { isColonyRoomThreatened } from '../defense/colonyThreats';
 
 type TransferSinkStructureConstantGlobal =
   | 'STRUCTURE_EXTENSION'
@@ -93,6 +96,7 @@ interface WorkerTaskSelectionContext {
 
 interface CriticalCpuTaskRetentionDecision {
   retain: boolean;
+  repairPreemptionTask?: Extract<CreepTaskMemory, { type: 'repair' }>;
   retainedTask?: CreepTaskMemory;
   selectionContext?: WorkerTaskSelectionContext;
 }
@@ -138,6 +142,13 @@ export function runWorker(creep: Creep): void {
   } else if (shouldPreemptForVisibleTerritoryControllerTask(currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptForWorkerEnergyCriticalTask(currentTask, energyCriticalTask)) {
+    taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
+  } else if (
+    shouldPreemptRepairTaskForCriticalCpuRepairPreemption(
+      currentTask,
+      criticalCpuTaskRetention.repairPreemptionTask
+    )
+  ) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptControllerSigningForRecovery(currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
@@ -396,10 +407,43 @@ function getCriticalCpuTaskRetentionDecision(
   }
 
   if (task.type === 'repair') {
-    return { retain: shouldRetainCriticalCpuRepairTask(creep) };
+    return getCriticalCpuRepairRetentionDecision(creep, task);
   }
 
   return { retain: false };
+}
+
+function getCriticalCpuRepairRetentionDecision(
+  creep: Creep,
+  task: Extract<CreepTaskMemory, { type: 'repair' }>
+): CriticalCpuTaskRetentionDecision {
+  if (!shouldRetainCriticalCpuRepairTask(creep)) {
+    return { retain: false };
+  }
+
+  const preemptionTarget = selectCriticalCpuRepairPreemptionTarget(creep);
+  if (preemptionTarget !== null && String(preemptionTarget.id) !== String(task.targetId)) {
+    const repairPreemptionTask: Extract<CreepTaskMemory, { type: 'repair' }> = {
+      type: 'repair',
+      targetId: preemptionTarget.id as Id<Structure>
+    };
+    return {
+      retain: false,
+      repairPreemptionTask,
+      selectionContext: createSingleTaskSelectionContext(repairPreemptionTask)
+    };
+  }
+
+  return { retain: true };
+}
+
+function createSingleTaskSelectionContext(task: CreepTaskMemory): WorkerTaskSelectionContext {
+  return {
+    baseSelectedTask: task,
+    energyCriticalTask: null,
+    selectedTask: task,
+    spawnReservationRefillTask: null
+  };
 }
 
 function shouldRetainCriticalCpuRepairTask(creep: Creep): boolean {
@@ -409,6 +453,114 @@ function shouldRetainCriticalCpuRepairTask(creep: Creep): boolean {
     !isControllerDowngradeGuardActive(creep.room) &&
     !shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep)
   );
+}
+
+function shouldPreemptRepairTaskForCriticalCpuRepairPreemption(
+  task: CreepTaskMemory,
+  repairPreemptionTask: Extract<CreepTaskMemory, { type: 'repair' }> | undefined
+): boolean {
+  return (
+    task.type === 'repair' &&
+    repairPreemptionTask !== undefined &&
+    !isSameTask(task, repairPreemptionTask)
+  );
+}
+
+function selectCriticalCpuRepairPreemptionTarget(creep: Creep): Structure | null {
+  const visibleStructures = findVisibleStructuresForCriticalCpuRepairPreemption(creep.room);
+  const criticalSpawnRepairTarget = visibleStructures
+    .filter(isCriticalCpuOwnedSpawnRepairTarget)
+    .sort(compareCriticalCpuRepairPreemptionTargets)[0];
+  if (criticalSpawnRepairTarget) {
+    return criticalSpawnRepairTarget;
+  }
+
+  const emergencyRampartRepairTarget = visibleStructures
+    .filter(isCriticalCpuEmergencyOwnedRampartRepairTarget)
+    .sort(compareCriticalCpuRepairPreemptionTargets)[0];
+  if (emergencyRampartRepairTarget) {
+    return emergencyRampartRepairTarget;
+  }
+
+  if (creep.room.controller?.my !== true || !isColonyRoomThreatened(creep.room.name)) {
+    return null;
+  }
+
+  return (
+    visibleStructures
+      .filter(isCriticalCpuThreatenedBarrierRepairTarget)
+      .sort(compareCriticalCpuRepairPreemptionTargets)[0] ?? null
+  );
+}
+
+function findVisibleStructuresForCriticalCpuRepairPreemption(room: Room): AnyStructure[] {
+  const findStructures = (globalThis as unknown as { FIND_STRUCTURES?: number }).FIND_STRUCTURES;
+  if (typeof findStructures !== 'number' || typeof room.find !== 'function') {
+    return [];
+  }
+
+  const structures = (room as Room & { find: (type: number) => unknown[] }).find(findStructures);
+  return Array.isArray(structures) ? (structures as AnyStructure[]) : [];
+}
+
+function isCriticalCpuOwnedSpawnRepairTarget(structure: AnyStructure): structure is StructureSpawn {
+  return (
+    isCriticalCpuRepairStructureType(structure, 'STRUCTURE_SPAWN', 'spawn') &&
+    (structure as Partial<StructureSpawn>).my === true &&
+    !isWorkerRepairTargetComplete(structure) &&
+    getCriticalCpuRepairHitsRatio(structure) <= CRITICAL_SPAWN_REPAIR_HITS_RATIO
+  );
+}
+
+function isCriticalCpuEmergencyOwnedRampartRepairTarget(structure: AnyStructure): structure is StructureRampart {
+  return (
+    isCriticalCpuOwnedRampart(structure) &&
+    !isWorkerRepairTargetComplete(structure) &&
+    structure.hits <= EMERGENCY_RAMPART_REPAIR_HITS_CEILING
+  );
+}
+
+function isCriticalCpuThreatenedBarrierRepairTarget(
+  structure: AnyStructure
+): structure is StructureRampart | StructureWall {
+  return isCriticalCpuBarrierRepairTarget(structure) && !isWorkerRepairTargetComplete(structure);
+}
+
+function isCriticalCpuBarrierRepairTarget(structure: AnyStructure): structure is StructureRampart | StructureWall {
+  return (
+    isCriticalCpuOwnedRampart(structure) ||
+    isCriticalCpuRepairStructureType(structure, 'STRUCTURE_WALL', 'constructedWall')
+  );
+}
+
+function isCriticalCpuOwnedRampart(structure: AnyStructure): structure is StructureRampart {
+  return (
+    isCriticalCpuRepairStructureType(structure, 'STRUCTURE_RAMPART', 'rampart') &&
+    (structure as Partial<StructureRampart>).my === true
+  );
+}
+
+function compareCriticalCpuRepairPreemptionTargets(left: Structure, right: Structure): number {
+  return (
+    getCriticalCpuRepairHitsRatio(left) - getCriticalCpuRepairHitsRatio(right) ||
+    left.hits - right.hits ||
+    String(left.id).localeCompare(String(right.id))
+  );
+}
+
+function getCriticalCpuRepairHitsRatio(structure: Structure): number {
+  return structure.hitsMax > 0 ? structure.hits / structure.hitsMax : 1;
+}
+
+function isCriticalCpuRepairStructureType(
+  structure: AnyStructure,
+  globalConstantName: 'STRUCTURE_RAMPART' | 'STRUCTURE_SPAWN' | 'STRUCTURE_WALL',
+  fallback: StructureConstant
+): boolean {
+  const globalConstant = (globalThis as unknown as Record<string, StructureConstant | undefined>)[
+    globalConstantName
+  ];
+  return structure.structureType === (globalConstant ?? fallback);
 }
 
 function getCriticalCpuTransferRetentionDecision(

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -11,6 +11,7 @@ import {
   shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill
 } from '../tasks/workerTasks';
 import {
+  assessWorkerEnergyCriticalState,
   selectWorkerEnergyCriticalTask,
   shouldPreemptForWorkerEnergyCriticalTask
 } from './workerTaskPolicy';
@@ -404,7 +405,7 @@ function getCriticalCpuTaskRetentionDecision(
 function shouldRetainCriticalCpuRepairTask(creep: Creep): boolean {
   return (
     getUsedTransferEnergy(creep) > 0 &&
-    !isSpawnEnergyCritical(creep.room) &&
+    !assessWorkerEnergyCriticalState(creep).active &&
     !isControllerDowngradeGuardActive(creep.room)
   );
 }
@@ -473,11 +474,6 @@ function shouldDeferSpawnReservationRefillForProductiveWork(
 function hasHealthyRoomEnergyBuffer(room: Room): boolean {
   const energyAvailable = getRoomEnergyAvailable(room);
   return energyAvailable !== null && energyAvailable >= getEffectiveRoomEnergyBufferThreshold(room);
-}
-
-function isSpawnEnergyCritical(room: Room): boolean {
-  const energyAvailable = getRoomEnergyAvailable(room);
-  return energyAvailable !== null && energyAvailable < CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD;
 }
 
 function isControllerDowngradeGuardActive(room: Room): boolean {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -394,7 +394,19 @@ function getCriticalCpuTaskRetentionDecision(
     return getCriticalCpuTerritoryControlRetentionDecision(creep, task);
   }
 
+  if (task.type === 'repair') {
+    return { retain: shouldRetainCriticalCpuRepairTask(creep) };
+  }
+
   return { retain: false };
+}
+
+function shouldRetainCriticalCpuRepairTask(creep: Creep): boolean {
+  return (
+    getUsedTransferEnergy(creep) > 0 &&
+    !isSpawnEnergyCritical(creep.room) &&
+    !isControllerDowngradeGuardActive(creep.room)
+  );
 }
 
 function getCriticalCpuTransferRetentionDecision(
@@ -461,6 +473,20 @@ function shouldDeferSpawnReservationRefillForProductiveWork(
 function hasHealthyRoomEnergyBuffer(room: Room): boolean {
   const energyAvailable = getRoomEnergyAvailable(room);
   return energyAvailable !== null && energyAvailable >= getEffectiveRoomEnergyBufferThreshold(room);
+}
+
+function isSpawnEnergyCritical(room: Room): boolean {
+  const energyAvailable = getRoomEnergyAvailable(room);
+  return energyAvailable !== null && energyAvailable < CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD;
+}
+
+function isControllerDowngradeGuardActive(room: Room): boolean {
+  const controller = room.controller;
+  return (
+    controller?.my === true &&
+    typeof controller.ticksToDowngrade === 'number' &&
+    controller.ticksToDowngrade <= CONTROLLER_DOWNGRADE_GUARD_TICKS
+  );
 }
 
 function hasActiveSpawningSpawn(room: Room): boolean {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -184,9 +184,63 @@ describe('runWorker', () => {
 
     runWorker(creep);
 
-    expect(room.find).not.toHaveBeenCalled();
+    expect((room.find as jest.Mock).mock.calls.some(([type]) => type === FIND_CONSTRUCTION_SITES)).toBe(false);
     expect(creep.memory.task).toEqual({ type: 'repair', targetId: 'road1' });
     expect(repair).toHaveBeenCalledWith(road);
+  });
+
+  it('pauses retained critical CPU repair when this worker must reserve energy for near-term spawn refill', () => {
+    const busyFullSpawn = {
+      id: 'spawn-busy',
+      structureType: 'spawn',
+      spawning: { remainingTime: 10 },
+      store: { getFreeCapacity: jest.fn().mockReturnValue(0) }
+    } as unknown as StructureSpawn;
+    const road = { id: 'road1', structureType: 'road', hits: 1_000, hitsMax: 5_000 } as StructureRoad;
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 300,
+      energyCapacityAvailable: 300,
+      controller: {
+        my: true,
+        ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 100
+      } as StructureController,
+      find: jest.fn((type: number) => (type === FIND_MY_STRUCTURES ? [busyFullSpawn] : []))
+    } as unknown as Room;
+    const repair = jest.fn().mockReturnValue(0);
+    const getObjectById = jest.fn().mockReturnValue(road);
+    const creep = {
+      name: 'RepairWorker',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'repair', targetId: 'road1' as Id<Structure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      repair,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { RepairWorker: creep },
+      time: 125,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(21),
+        limit: 70,
+        bucket: 62,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toBeUndefined();
+    expect(getObjectById).not.toHaveBeenCalled();
+    expect(repair).not.toHaveBeenCalled();
   });
 
   it('does not retain critical CPU repair work when the controller downgrade guard is active', () => {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1,5 +1,9 @@
 import { runWorker } from '../src/creeps/workerRunner';
 import {
+  WORKER_ENERGY_CRITICAL_SPAWN_EXIT_THRESHOLD,
+  WORKER_ENERGY_CRITICAL_STORAGE_EXIT_MARGIN
+} from '../src/creeps/workerTaskPolicy';
+import {
   CONTROLLER_DOWNGRADE_GUARD_TICKS,
   CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD,
   IDLE_RAMPART_REPAIR_HITS_CEILING,
@@ -234,6 +238,143 @@ describe('runWorker', () => {
 
     expect(creep.memory.task).toEqual({ type: 'upgrade', targetId: 'controller1' });
     expect(upgradeController).toHaveBeenCalledWith(controller);
+    expect(repair).not.toHaveBeenCalled();
+  });
+
+  it('preempts retained critical CPU repair while spawn-critical hysteresis is active', () => {
+    const source = { id: 'source1', energy: 300 } as Source;
+    const road = { id: 'road1', structureType: 'road', hits: 1_000, hitsMax: 5_000 } as StructureRoad;
+    const room = {
+      name: 'W1N1',
+      energyAvailable: WORKER_ENERGY_CRITICAL_SPAWN_EXIT_THRESHOLD - 1,
+      find: jest.fn((type: number) => (type === FIND_SOURCES ? [source] : []))
+    } as unknown as Room;
+    const harvest = jest.fn().mockReturnValue(0);
+    const repair = jest.fn();
+    const creep = {
+      name: 'RepairWorker',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'repair', targetId: 'road1' as Id<Structure> },
+        workerEnergyCriticalPolicy: {
+          type: 'workerEnergyCriticalPolicy',
+          schemaVersion: 1,
+          active: true,
+          reason: 'spawn',
+          enteredAt: 700,
+          updatedAt: 700,
+          spawnEnergy: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+          spawnEnterThreshold: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD,
+          spawnExitThreshold: WORKER_ENERGY_CRITICAL_SPAWN_EXIT_THRESHOLD
+        }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(25),
+        getFreeCapacity: jest.fn().mockReturnValue(25)
+      },
+      room,
+      harvest,
+      repair,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { RepairWorker: creep },
+      time: 701,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(21),
+        limit: 70,
+        bucket: 62,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) => (id === 'source1' ? source : road)) as unknown as Game['getObjectById']
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(creep.memory.workerEnergyCriticalPolicy).toMatchObject({
+      active: true,
+      reason: 'spawn',
+      spawnEnergy: WORKER_ENERGY_CRITICAL_SPAWN_EXIT_THRESHOLD - 1
+    });
+    expect(harvest).toHaveBeenCalledWith(source);
+    expect(repair).not.toHaveBeenCalled();
+  });
+
+  it('preempts retained critical CPU repair while storage-critical hysteresis is active', () => {
+    const road = { id: 'road1', structureType: 'road', hits: 1_000, hitsMax: 5_000 } as StructureRoad;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(500 + WORKER_ENERGY_CRITICAL_STORAGE_EXIT_MARGIN - 1),
+        getFreeCapacity: jest.fn().mockReturnValue(1_000)
+      }
+    } as unknown as StructureStorage;
+    const room = {
+      name: 'W1N1',
+      energyAvailable: WORKER_ENERGY_CRITICAL_SPAWN_EXIT_THRESHOLD,
+      controller: {
+        my: true,
+        level: 3,
+        ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 100
+      } as StructureController,
+      storage,
+      find: jest.fn((type: number) => (type === FIND_STRUCTURES ? [storage] : []))
+    } as unknown as Room;
+    const repair = jest.fn();
+    const transfer = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'RepairWorker',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'repair', targetId: 'road1' as Id<Structure> },
+        workerEnergyCriticalPolicy: {
+          type: 'workerEnergyCriticalPolicy',
+          schemaVersion: 1,
+          active: true,
+          reason: 'storage',
+          enteredAt: 700,
+          updatedAt: 700,
+          storageEnergy: 499,
+          storageEnterThreshold: 500,
+          storageExitThreshold: 500 + WORKER_ENERGY_CRITICAL_STORAGE_EXIT_MARGIN
+        }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      repair,
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { RepairWorker: creep },
+      time: 701,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(21),
+        limit: 70,
+        bucket: 62,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) =>
+        id === 'storage1' ? storage : road
+      ) as unknown as Game['getObjectById']
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'storage1' });
+    expect(creep.memory.workerEnergyCriticalPolicy).toMatchObject({
+      active: true,
+      reason: 'storage',
+      storageEnergy: 500 + WORKER_ENERGY_CRITICAL_STORAGE_EXIT_MARGIN - 1
+    });
+    expect(transfer).toHaveBeenCalledWith(storage, RESOURCE_ENERGY);
     expect(repair).not.toHaveBeenCalled();
   });
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -189,6 +189,69 @@ describe('runWorker', () => {
     expect(repair).toHaveBeenCalledWith(road);
   });
 
+  it('preempts retained critical CPU routine repair when an emergency rampart repair appears', () => {
+    const road = { id: 'road1', structureType: 'road', hits: 1_000, hitsMax: 5_000 } as StructureRoad;
+    const rampart = {
+      id: 'rampart1',
+      structureType: 'rampart',
+      my: true,
+      hits: 1_000,
+      hitsMax: 100_000
+    } as StructureRampart;
+    const room = {
+      name: 'W1N1',
+      energyAvailable: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD + 100,
+      energyCapacityAvailable: 550,
+      controller: {
+        my: true,
+        level: 3,
+        ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 100
+      } as StructureController,
+      find: jest.fn((type: number) => {
+        if (type === FIND_STRUCTURES) {
+          return [road, rampart];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const repair = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'RepairWorker',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'repair', targetId: 'road1' as Id<Structure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      repair,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { RepairWorker: creep },
+      time: 126,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(21),
+        limit: 70,
+        bucket: 62,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) =>
+        id === 'rampart1' ? rampart : id === 'road1' ? road : null
+      ) as unknown as Game['getObjectById']
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'repair', targetId: 'rampart1' });
+    expect(repair).toHaveBeenCalledWith(rampart);
+    expect(repair).not.toHaveBeenCalledWith(road);
+  });
+
   it('pauses retained critical CPU repair when this worker must reserve energy for near-term spawn refill', () => {
     const busyFullSpawn = {
       id: 'spawn-busy',

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -140,6 +140,103 @@ describe('runWorker', () => {
     expect(harvest).toHaveBeenCalledWith(source);
   });
 
+  it('keeps an executable assigned repair under critical CPU bucket without full task reselection', () => {
+    const road = { id: 'road1', structureType: 'road', hits: 1_000, hitsMax: 5_000 } as StructureRoad;
+    const room = {
+      name: 'W1N1',
+      energyAvailable: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD + 100,
+      controller: {
+        my: true,
+        ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 100
+      } as StructureController,
+      find: jest.fn().mockReturnValue([{ id: 'extension-site1' }])
+    } as unknown as Room;
+    const repair = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'RepairWorker',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'repair', targetId: 'road1' as Id<Structure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      repair,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { RepairWorker: creep },
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(21),
+        limit: 70,
+        bucket: 62,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) => (id === 'road1' ? road : null)) as unknown as Game['getObjectById']
+    };
+
+    runWorker(creep);
+
+    expect(room.find).not.toHaveBeenCalled();
+    expect(creep.memory.task).toEqual({ type: 'repair', targetId: 'road1' });
+    expect(repair).toHaveBeenCalledWith(road);
+  });
+
+  it('does not retain critical CPU repair work when the controller downgrade guard is active', () => {
+    const road = { id: 'road1', structureType: 'road', hits: 1_000, hitsMax: 5_000 } as StructureRoad;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS
+    } as StructureController;
+    const room = {
+      name: 'W1N1',
+      energyAvailable: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD + 100,
+      controller,
+      find: jest.fn().mockReturnValue([])
+    } as unknown as Room;
+    const repair = jest.fn();
+    const upgradeController = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'RepairWorker',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'repair', targetId: 'road1' as Id<Structure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      repair,
+      upgradeController,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { RepairWorker: creep },
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(21),
+        limit: 70,
+        bucket: 62,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) =>
+        id === 'controller1' ? controller : id === 'road1' ? road : null
+      ) as unknown as Game['getObjectById']
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'upgrade', targetId: 'controller1' });
+    expect(upgradeController).toHaveBeenCalledWith(controller);
+    expect(repair).not.toHaveBeenCalled();
+  });
+
   it.each(['claim', 'reserve'] as const)(
     'drops a retained visible %s task under critical CPU when the home room fails the territory gate',
     (action) => {


### PR DESCRIPTION
## Summary
- Retain already-executable repair tasks during critical CPU bucket mode when spawn-energy and controller-downgrade safety gates are clear.
- Preserve the emergency full-selection path for spawn refill and controller downgrade guard cases.
- Add focused worker-runner coverage and rebuild `prod/dist/main.js`.

Related issue: #1490.

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` — 103 suites / 2092 tests passed
- `npm run build`

## Universal task Done gate
- [x] Task type: P0 runtime hotfix PR for CPU-bucket recurrence issue 1490.
- [x] Expected observable outcome / named deliverable: workers avoid CPU-heavy full task reselection for safe retained repair tasks under critical bucket while emergency spawn/controller gates still preempt repairs.
- [x] Non-goals / accepted substitutes: no learned-policy rollout, no owner action, and no issue-closing keyword in this PR body.
- [x] Verification evidence required before Done: controller verification passed with `git diff --check`, typecheck, Jest runInBand, and build on commit `54eef182`.
- [x] Project Evidence / Next action / Blocked by: issue 1490 Project item is updated; PR Project item will be added with exact-head CI/CodeRabbit/deploy gates tracked before merge.
- [x] Post-merge/deploy/runtime proof: official deploy evidence for the merge commit plus a CPU-bearing runtime monitor artifact showing bucket recovery/no `lowBucket` are the named acceptance proof for issue 1490.
- [x] Named deliverable proof: `prod/src/creeps/workerRunner.ts`, `prod/test/workerRunner.test.ts`, and regenerated `prod/dist/main.js` in Codex-authored commit `54eef182`.
