### PR TITLE
fix: pause repeated Tencent room-busy failures

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -5144,7 +5144,7 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 3
-    if controller.final_status == E1S1_REPEAT_GUARD_FINAL_STATUS:
+    if controller.final_status in {E1S1_REPEAT_GUARD_FINAL_STATUS, PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS}:
         print(
             json.dumps(
                 {

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -2793,7 +2793,7 @@ def recent_paid_failure_recurrence_evidence(args: argparse.Namespace, artifact_d
     except OSError:
         return []
     evidence: list[dict[str, Any]] = []
-    for summary_path in summary_paths[:PAID_FAILURE_RECURRENCE_GUARD_RECENT_SUMMARY_LIMIT]:
+    for summary_path in summary_paths:
         try:
             if summary_path.parent.resolve() == current_dir:
                 continue
@@ -2802,6 +2802,8 @@ def recent_paid_failure_recurrence_evidence(args: argparse.Namespace, artifact_d
         item = paid_failure_recurrence_evidence_from_summary(read_json_object(summary_path), summary_path)
         if item is not None:
             evidence.append(item)
+            if len(evidence) >= PAID_FAILURE_RECURRENCE_GUARD_RECENT_SUMMARY_LIMIT:
+                break
     return evidence
 
 

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -93,6 +93,33 @@ E1S1_REPEAT_GUARD_NEXT_ACTION = (
     f"use --scenario-id {MULTI_TIER_SCENARIO_ID} --require-multi-tier-scenario after PR #1204; "
     "do not launch another E1S1-only Tencent batch"
 )
+PAID_FAILURE_RECURRENCE_GUARD_TYPE = "screeps-tencent-batch-rl-paid-failure-recurrence-guard"
+PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS = "skipped_paid_failure_recurrence_launch_guard"
+PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD = 10
+PAID_FAILURE_RECURRENCE_GUARD_RECENT_SUMMARY_LIMIT = 100
+PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE = "simulator_place_spawn_room_busy"
+PAID_FAILURE_RECURRENCE_GUARD_NEXT_ACTIONS = {
+    PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE: (
+        "auto-pause Tencent RL paid compute for repeated place-spawn room busy failures (#1506); "
+        "ship and verify the room-busy root fix tracked by #1501 / PR #1504 before launching another paid rerun"
+    ),
+}
+PAID_FAILURE_SIGNATURE_TEXT_KEYS = frozenset(
+    {
+        "classification",
+        "collectionError",
+        "error",
+        "failureClass",
+        "message",
+        "nextAction",
+        "reason",
+        "stderr_tail",
+        "stderrTail",
+        "stdout_tail",
+        "stdoutTail",
+        "tail",
+    }
+)
 DEFAULT_SIMULATION_MAP_SOURCE_REL = "maps/map-0b6758af.json"
 DEFAULT_SIMULATION_ROOM = "E1S1"
 RUN_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]{2,80}$")
@@ -1054,7 +1081,7 @@ class Controller:
 
     def check_pre_launch_guard(self) -> bool:
         started = time.time()
-        guard = build_e1s1_repeat_launch_guard(
+        guard = build_tencent_batch_launch_guard(
             args=self.args,
             run_id=self.run_id,
             artifact_dir=self.artifact_dir,
@@ -1067,8 +1094,10 @@ class Controller:
             "path": str(guard_path),
             "status": guard["status"],
             "blocked": guard["blocked"],
+            "activeGuard": guard.get("activeGuard"),
             "reason": guard.get("reason"),
             "nextAction": guard.get("nextAction"),
+            "activeSignature": evidence.get("activeSignature"),
             "evidenceCount": evidence["count"],
             "evidenceThreshold": evidence["threshold"],
         }
@@ -1079,12 +1108,18 @@ class Controller:
             path=str(guard_path),
             status=guard["status"],
             blocked=guard["blocked"],
+            activeGuard=guard.get("activeGuard"),
+            activeSignature=evidence.get("activeSignature"),
             evidenceCount=evidence["count"],
             evidenceThreshold=evidence["threshold"],
         )
         if not guard["blocked"]:
             return False
-        self.final_status = E1S1_REPEAT_GUARD_FINAL_STATUS
+        self.final_status = (
+            PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS
+            if guard.get("activeGuard") == "paid_failure_recurrence_guard"
+            else E1S1_REPEAT_GUARD_FINAL_STATUS
+        )
         self.finished_at = utc_now_iso()
         self.write_summary()
         return True
@@ -2561,6 +2596,44 @@ def remote_training_failure_message(
     return "no remote diagnostics collected"
 
 
+def build_tencent_batch_launch_guard(
+    *,
+    args: argparse.Namespace,
+    run_id: str,
+    artifact_dir: Path,
+) -> dict[str, Any]:
+    e1s1_guard = build_e1s1_repeat_launch_guard(
+        args=args,
+        run_id=run_id,
+        artifact_dir=artifact_dir,
+    )
+    recurrence_guard = build_paid_failure_recurrence_launch_guard(
+        args=args,
+        run_id=run_id,
+        artifact_dir=artifact_dir,
+    )
+    guard = copy.deepcopy(e1s1_guard)
+    guard["checks"] = {
+        "e1s1Repeat": e1s1_guard,
+        "paidFailureRecurrence": recurrence_guard,
+    }
+    if recurrence_guard["blocked"]:
+        guard.update(
+            {
+                "status": recurrence_guard["status"],
+                "blocked": True,
+                "reason": recurrence_guard.get("reason"),
+                "nextAction": recurrence_guard.get("nextAction"),
+                "evidence": recurrence_guard["evidence"],
+                "safety": recurrence_guard["safety"],
+                "activeGuard": "paid_failure_recurrence_guard",
+            }
+        )
+        return guard
+    guard["activeGuard"] = "e1s1_repeat_launch_guard" if e1s1_guard["blocked"] else None
+    return guard
+
+
 def build_e1s1_repeat_launch_guard(
     *,
     args: argparse.Namespace,
@@ -2607,6 +2680,83 @@ def build_e1s1_repeat_launch_guard(
     }
 
 
+def build_paid_failure_recurrence_launch_guard(
+    *,
+    args: argparse.Namespace,
+    run_id: str,
+    artifact_dir: Path,
+) -> dict[str, Any]:
+    evidence_runs = recent_paid_failure_recurrence_evidence(args, artifact_dir)
+    signature_counts: dict[str, int] = {}
+    for item in evidence_runs:
+        signature = text_value(item.get("signature"))
+        if signature is None:
+            continue
+        signature_counts[signature] = signature_counts.get(signature, 0) + 1
+    blocked_signature = next(
+        (
+            signature
+            for signature, count in sorted(signature_counts.items())
+            if count >= PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD
+        ),
+        None,
+    )
+    signature_runs = [
+        item for item in evidence_runs if blocked_signature is not None and item.get("signature") == blocked_signature
+    ]
+    active_count = (
+        len(signature_runs)
+        if blocked_signature is not None
+        else max(signature_counts.values(), default=0)
+    )
+    blocked = blocked_signature is not None
+    reason = None
+    if blocked:
+        reason = (
+            f"recent Tencent RL paid-run failures reached {active_count}/"
+            f"{PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD} identical known failure signature "
+            f"{blocked_signature!r}"
+        )
+    return {
+        "type": PAID_FAILURE_RECURRENCE_GUARD_TYPE,
+        "schemaVersion": 1,
+        "runId": run_id,
+        "checkedAt": utc_now_iso(),
+        "status": "blocked" if blocked else "clear",
+        "blocked": blocked,
+        "reason": reason,
+        "nextAction": (
+            PAID_FAILURE_RECURRENCE_GUARD_NEXT_ACTIONS.get(blocked_signature)
+            if blocked_signature is not None
+            else None
+        ),
+        "currentLaunch": {
+            "command": getattr(args, "command", None),
+            "preflightOnly": bool(getattr(args, "preflight_only", False)),
+            "trainingApproach": getattr(args, "training_approach", None),
+            "scenarioId": scenario_id_from_args(args),
+            "workers": getattr(args, "workers", None),
+            "repetitions": getattr(args, "repetitions", None),
+        },
+        "evidence": {
+            "threshold": PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD,
+            "count": active_count,
+            "recentSummaryLimit": PAID_FAILURE_RECURRENCE_GUARD_RECENT_SUMMARY_LIMIT,
+            "activeSignature": blocked_signature,
+            "signatureCounts": signature_counts,
+            "runs": signature_runs if blocked else evidence_runs,
+        },
+        "safety": {
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+            "secretsPrinted": False,
+            "remoteExecutionAttempted": False,
+            "scaleOutAttempted": False,
+        },
+    }
+
+
 def e1s1_repeat_guard_current_launch(args: argparse.Namespace) -> dict[str, Any]:
     scenario_id = scenario_id_from_args(args)
     current_launch = {
@@ -2627,6 +2777,32 @@ def e1s1_repeat_guard_current_launch(args: argparse.Namespace) -> dict[str, Any]
     if is_multi_tier_scenario_id(scenario_id):
         current_launch["fixtureEvidence"] = multi_tier_launch_fixture_evidence(scenario_id)
     return current_launch
+
+
+def recent_paid_failure_recurrence_evidence(args: argparse.Namespace, artifact_dir: Path) -> list[dict[str, Any]]:
+    artifact_root = resolved_artifact_root(args)
+    if not artifact_root.is_dir():
+        return []
+    current_dir = artifact_dir.resolve()
+    try:
+        summary_paths = sorted(
+            artifact_root.glob("*/controller-summary.json"),
+            key=lambda path: (path.stat().st_mtime, path.as_posix()),
+            reverse=True,
+        )
+    except OSError:
+        return []
+    evidence: list[dict[str, Any]] = []
+    for summary_path in summary_paths[:PAID_FAILURE_RECURRENCE_GUARD_RECENT_SUMMARY_LIMIT]:
+        try:
+            if summary_path.parent.resolve() == current_dir:
+                continue
+        except OSError:
+            continue
+        item = paid_failure_recurrence_evidence_from_summary(read_json_object(summary_path), summary_path)
+        if item is not None:
+            evidence.append(item)
+    return evidence
 
 
 def recent_e1s1_dead_tier_evidence(args: argparse.Namespace, artifact_dir: Path) -> list[dict[str, Any]]:
@@ -2703,6 +2879,98 @@ def e1s1_dead_tier_evidence_from_summary(
         "kills": metric["kills"],
         "metricPairCount": metric["metricPairCount"],
     }
+
+
+def paid_failure_recurrence_evidence_from_summary(
+    summary: dict[str, Any] | None,
+    summary_path: Path,
+) -> dict[str, Any] | None:
+    if not paid_failure_recurrence_summary_candidate(summary):
+        return None
+    assert summary is not None
+    signature = paid_failure_signature_from_summary(summary)
+    if signature is None:
+        return None
+    run_id = text_value(summary.get("runId")) or summary_path.parent.name
+    return {
+        "runId": run_id,
+        "summaryPath": str(summary_path),
+        "finishedAt": text_value(summary.get("finishedAt")),
+        "finalStatus": text_value(summary.get("finalStatus")),
+        "signature": signature["signature"],
+        "reason": signature["reason"],
+        "matchedBy": signature["matchedBy"],
+        "diagnosticExcerpt": signature["diagnosticExcerpt"],
+    }
+
+
+def paid_failure_recurrence_summary_candidate(summary: dict[str, Any] | None) -> bool:
+    if not isinstance(summary, dict):
+        return False
+    final_status = text_value(summary.get("finalStatus"))
+    if final_status is None:
+        return False
+    if final_status.startswith(("completed", "preflight", "skipped_")):
+        return False
+    remote_failure = dict_value(path_value(summary, "outputs", "remoteTrainingFailure"))
+    if final_status != "failed" and remote_failure is None:
+        return False
+    execution = dict_value(summary.get("execution"))
+    if execution is None:
+        return remote_failure is not None or final_status == "failed"
+    if execution.get("preflightOnly") is True:
+        return False
+    return bool(
+        remote_failure is not None
+        or execution.get("computeAttempted") is True
+        or execution.get("scaleOutAttempted") is True
+        or execution.get("remoteTrainingAttempted") is True
+    )
+
+
+def paid_failure_signature_from_summary(summary: dict[str, Any]) -> dict[str, str] | None:
+    failure_class = text_value(path_value(summary, "outputs", "remoteTrainingFailure", "failureClass"))
+    if failure_class == PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE:
+        return {
+            "signature": PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            "reason": "place-spawn room busy",
+            "matchedBy": "outputs.remoteTrainingFailure.failureClass",
+            "diagnosticExcerpt": failure_class,
+        }
+    for text in iter_failure_signature_texts(summary):
+        if REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RE.search(text):
+            return {
+                "signature": PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                "reason": "place-spawn room busy",
+                "matchedBy": "controller-summary diagnostic text",
+                "diagnosticExcerpt": diagnostic_tail(text, 600),
+            }
+    return None
+
+
+def iter_failure_signature_texts(raw: Any, *, parent_key: str | None = None, depth: int = 0) -> list[str]:
+    if depth > 10:
+        return []
+    if isinstance(raw, dict):
+        texts: list[str] = []
+        for key, value in raw.items():
+            key_text = str(key)
+            if isinstance(value, str) and key_text in PAID_FAILURE_SIGNATURE_TEXT_KEYS:
+                texts.append(value)
+            elif isinstance(value, str) and key_text.lower().endswith(("tail", "_tail")):
+                texts.append(value)
+            elif isinstance(value, (dict, list)):
+                texts.extend(iter_failure_signature_texts(value, parent_key=key_text, depth=depth + 1))
+        return texts
+    if isinstance(raw, list):
+        texts = []
+        for value in raw:
+            if isinstance(value, (dict, list)):
+                texts.extend(iter_failure_signature_texts(value, parent_key=parent_key, depth=depth + 1))
+            elif isinstance(value, str) and parent_key in PAID_FAILURE_SIGNATURE_TEXT_KEYS:
+                texts.append(value)
+        return texts
+    return []
 
 
 def load_collected_training_report(

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -672,6 +672,38 @@ def write_tencent_failure_summary(
     return summary_path
 
 
+def write_paid_failure_recurrence_skipped_summary(artifact_root: Path, run_id: str) -> Path:
+    run_dir = artifact_root / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    summary = {
+        "type": "screeps-tencent-batch-rl-run",
+        "schemaVersion": 1,
+        "runId": run_id,
+        "startedAt": "2026-05-29T20:00:03Z",
+        "finishedAt": "2026-05-29T20:00:04Z",
+        "partial": False,
+        "finalStatus": runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS,
+        "execution": {
+            "command": "run-single",
+            "mode": "compute",
+            "preflightOnly": False,
+            "computeAttempted": False,
+            "scaleOutAttempted": False,
+            "remoteTrainingAttempted": False,
+        },
+        "outputs": {
+            "launchGuard": {
+                "status": "blocked",
+                "activeGuard": "paid_failure_recurrence_guard",
+                "activeSignature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            }
+        },
+    }
+    summary_path = run_dir / "controller-summary.json"
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+    return summary_path
+
+
 def strip_tencent_guard_location_evidence(summary_path: Path) -> None:
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
     training_report = summary["outputs"]["trainingReport"]
@@ -3637,6 +3669,57 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertFalse(summary["execution"]["computeAttempted"])
         self.assertFalse(summary["execution"]["scaleOutAttempted"])
         self.assertFalse(summary["safety"]["scaleDownAttempted"])
+
+    def test_paid_failure_recurrence_guard_scans_past_newer_skipped_guard_summaries(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            failure_paths = [
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+                for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD)
+            ]
+            skipped_paths = [
+                write_paid_failure_recurrence_skipped_summary(
+                    artifact_root,
+                    f"tencent-pg-skipped-guard-{index}",
+                )
+                for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_RECENT_SUMMARY_LIMIT)
+            ]
+            for index, summary_path in enumerate(failure_paths):
+                timestamp = 1_700_000_000 + index
+                os.utime(summary_path, (timestamp, timestamp))
+            for index, summary_path in enumerate(skipped_paths):
+                timestamp = 1_700_000_100 + index
+                os.utime(summary_path, (timestamp, timestamp))
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                "500",
+                "--workers",
+                "1",
+            ])
+
+            guard = runner.build_paid_failure_recurrence_launch_guard(
+                args=args,
+                run_id="new-run",
+                artifact_dir=artifact_root / "new-run",
+            )
+
+        self.assertTrue(guard["blocked"])
+        self.assertEqual(guard["status"], "blocked")
+        self.assertEqual(guard["evidence"]["activeSignature"], runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE)
+        self.assertEqual(guard["evidence"]["count"], runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD)
+        self.assertEqual(
+            {item["runId"] for item in guard["evidence"]["runs"]},
+            {f"tencent-pg-room-busy-{index}" for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD)},
+        )
 
     def test_no_arg_preflight_defaults_to_multi_tier_policy_gradient_without_repeat_guard(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -589,6 +589,89 @@ def write_tencent_guard_summary(
     return summary_path
 
 
+def write_tencent_failure_summary(
+    artifact_root: Path,
+    run_id: str,
+    *,
+    failure_text: str | None = None,
+    failure_class: str | None = runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+) -> Path:
+    run_dir = artifact_root / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    stderr_tail = failure_text or (
+        "pre-scale private-simulator trainability smoke gate failed: "
+        "place-spawn room busy after 12 attempt(s): "
+        '{"classification": "place_spawn_room_busy"}'
+    )
+    remote_failure: dict[str, object] = {
+        "status": "failed_exit",
+        "retryable": False,
+        "returncode": 2,
+        "artifactDir": str(run_dir / "remote"),
+        "diagnostics": {
+            "training-stderr.log": {
+                "path": str(run_dir / "remote" / "training-stderr.log"),
+                "bytes": len(stderr_tail),
+                "tail": stderr_tail,
+            }
+        },
+    }
+    if failure_class is not None:
+        remote_failure["failureClass"] = failure_class
+    summary = {
+        "type": "screeps-tencent-batch-rl-run",
+        "schemaVersion": 1,
+        "runId": run_id,
+        "startedAt": "2026-05-29T19:45:03Z",
+        "finishedAt": "2026-05-29T19:47:03Z",
+        "partial": False,
+        "finalStatus": "failed",
+        "execution": {
+            "command": "run-single",
+            "mode": "compute",
+            "preflightOnly": False,
+            "computeAttempted": True,
+            "scaleOutAttempted": True,
+            "remoteTrainingAttempted": True,
+            "trainingReportProduced": False,
+            "environmentsRun": 0,
+        },
+        "safety": {
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+            "billingGuardBeforeScale": True,
+            "scaleDownAttempted": True,
+            "secretsPrinted": False,
+        },
+        "outputs": {
+            "error": f"BatchRunError: remote_training failed with exit 2: training-stderr.log: {stderr_tail}",
+            "remoteTrainingFailure": remote_failure,
+        },
+        "steps": [
+            {
+                "name": "remote_training",
+                "ok": False,
+                "returncode": 2,
+                "stdout_tail": "",
+                "stderr_tail": stderr_tail,
+                "detail": {"argv": ["ssh", "worker"]},
+            },
+            {
+                "name": "scale_down",
+                "ok": True,
+                "returncode": 0,
+                "stdout_tail": "{}",
+                "stderr_tail": "",
+                "detail": {"desiredCapacity": 0},
+            },
+        ],
+    }
+    summary_path = run_dir / "controller-summary.json"
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+    return summary_path
+
+
 def strip_tencent_guard_location_evidence(summary_path: Path) -> None:
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
     training_report = summary["outputs"]["trainingReport"]
@@ -640,6 +723,83 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
 
             def scale_up_and_wait(self) -> None:
                 events.append("scale_up")
+
+        controller = FakeController(args=args, run_id=args.run_id, artifact_dir=artifact_dir)
+        with mock.patch.object(runner, "validate_static_inputs", return_value=None):
+            controller.run()
+        guard = json.loads((artifact_dir / "launch_guard.json").read_text(encoding="utf-8"))
+        summary = json.loads((artifact_dir / "controller-summary.json").read_text(encoding="utf-8"))
+        return events, controller, guard, summary
+
+    def run_stubbed_compute(
+        self,
+        args: argparse.Namespace,
+        artifact_dir: Path,
+    ) -> tuple[list[str], runner.Controller, dict[str, object], dict[str, object]]:
+        events: list[str] = []
+
+        class FakeController(runner.Controller):
+            def ensure_map_present(self) -> None:
+                events.append("map")
+
+            def ensure_dist_present(self) -> None:
+                events.append("dist")
+
+            def run_billing_guard(self) -> None:
+                events.append("billing")
+
+            def verify_security_group(self) -> None:
+                events.append("security_group")
+
+            def generate_experiment_card(self) -> None:
+                events.append("experiment_card")
+
+            def scale_up_and_wait(self) -> None:
+                events.append("scale_up")
+                self.scaled_up = True
+                self.instance_id = "ins-test"
+                self.public_ip = "203.0.113.10"
+                self.record_step("scale_up", 100.0, True, desiredCapacity=1)
+
+            def verify_worker_security(self) -> None:
+                events.append("worker_security")
+
+            def bootstrap_worker(self) -> None:
+                events.append("bootstrap")
+
+            def transfer_repo_bundle(self) -> None:
+                events.append("repo_bundle")
+
+            def transfer_secret_env(self) -> None:
+                events.append("secret_env")
+
+            def run_remote_training(self) -> None:
+                events.append("remote_training")
+                self.record_step("remote_training", 101.0, True, reportId=self.run_id)
+
+            def collect_remote_artifacts(self) -> None:
+                events.append("collect_artifacts")
+
+            def verify_remote_training_report(self) -> None:
+                events.append("verify_training_report")
+                self.result["trainingReport"] = {
+                    "path": str(self.artifact_dir / "remote" / "runtime-artifacts" / "rl-training" / f"{self.run_id}.json"),
+                    "reportId": self.run_id,
+                    "liveEffect": False,
+                    "officialMmoWrites": False,
+                    "officialMmoWritesAllowed": False,
+                    "artifactCount": 5,
+                    "scaleValidation": {
+                        "ok": True,
+                        "totalEnvironments": 5,
+                        "successfulEnvironments": 5,
+                        "minimumSuccessfulEnvironments": 4,
+                    },
+                }
+
+            def scale_down(self) -> None:
+                events.append("scale_down")
+                self.record_step("scale_down", 102.0, True, desiredCapacity=0)
 
         controller = FakeController(args=args, run_id=args.run_id, artifact_dir=artifact_dir)
         with mock.patch.object(runner, "validate_static_inputs", return_value=None):
@@ -3378,6 +3538,105 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(guard["currentLaunch"]["fixtureEvidence"]["hostileSpawnCount"], 1)
         self.assertEqual(guard["currentLaunch"]["fixtureEvidence"]["hostileTowerCount"], 1)
         self.assertEqual(guard["evidence"]["count"], 0)
+
+    def test_paid_failure_recurrence_guard_extracts_room_busy_signature_from_summary_text(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            summary_path = write_tencent_failure_summary(
+                artifact_root,
+                "tencent-pg-room-busy",
+                failure_class=None,
+                failure_text=(
+                    "pre-scale private-simulator trainability smoke gate failed: "
+                    "place-spawn room busy after 12 attempt(s): "
+                    '{"classification": "place_spawn_room_busy"}'
+                ),
+            )
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+
+            evidence = runner.paid_failure_recurrence_evidence_from_summary(summary, summary_path)
+
+        assert evidence is not None
+        self.assertEqual(evidence["signature"], runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE)
+        self.assertEqual(evidence["reason"], "place-spawn room busy")
+        self.assertEqual(evidence["matchedBy"], "controller-summary diagnostic text")
+        self.assertIn("place-spawn room busy after 12 attempt", evidence["diagnosticExcerpt"])
+
+    def test_paid_failure_recurrence_guard_allows_dispatch_below_threshold(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD - 1):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                "500",
+                "--workers",
+                "1",
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertFalse(guard["blocked"])
+        self.assertEqual(guard["checks"]["paidFailureRecurrence"]["status"], "clear")
+        self.assertEqual(
+            guard["checks"]["paidFailureRecurrence"]["evidence"]["count"],
+            runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD - 1,
+        )
+        self.assertEqual(controller.final_status, "completed")
+        self.assertEqual(summary["finalStatus"], "completed")
+        self.assertIn("scale_up", events)
+        self.assertTrue(summary["execution"]["scaleOutAttempted"])
+
+    def test_paid_failure_recurrence_guard_blocks_room_busy_threshold_before_compute(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                "500",
+                "--workers",
+                "1",
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertEqual(events, [])
+        self.assertTrue(guard["blocked"])
+        self.assertEqual(guard["activeGuard"], "paid_failure_recurrence_guard")
+        self.assertEqual(guard["status"], "blocked")
+        self.assertEqual(guard["evidence"]["activeSignature"], runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE)
+        self.assertEqual(guard["evidence"]["count"], runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD)
+        self.assertIn("#1506", guard["nextAction"])
+        self.assertIn("#1501", guard["nextAction"])
+        self.assertIn("#1504", guard["nextAction"])
+        self.assertIn("simulator_place_spawn_room_busy", guard["reason"])
+        self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+        self.assertEqual(summary["finalStatus"], runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+        self.assertEqual(summary["outputs"]["launchGuard"]["activeSignature"], runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE)
+        self.assertFalse(summary["execution"]["computeAttempted"])
+        self.assertFalse(summary["execution"]["scaleOutAttempted"])
+        self.assertFalse(summary["safety"]["scaleDownAttempted"])
 
     def test_no_arg_preflight_defaults_to_multi_tier_policy_gradient_without_repeat_guard(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -6015,6 +6015,35 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertFalse(payload["ok"])
         self.assertEqual(payload["status"], "completed_scale_down_failed")
 
+    def test_main_exits_nonzero_when_paid_failure_recurrence_guard_blocks(self) -> None:
+        class FakeController:
+            def __init__(self, args: argparse.Namespace, run_id: str, artifact_dir: Path) -> None:
+                self.args = args
+                self.run_id = run_id
+                self.artifact_dir = artifact_dir
+                self.final_status = "unknown"
+                self.result = {"launchGuard": {"status": "blocked", "activeGuard": "paid_failure_recurrence_guard"}}
+
+            def run(self) -> None:
+                self.final_status = runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS
+
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            mock.patch.object(runner, "Controller", FakeController),
+            mock.patch.object(runner.sys, "stdout", stdout),
+            mock.patch.object(runner.sys, "stderr", stderr),
+        ):
+            exit_code = runner.main(["run-single", "--run-id", "run-test", "--artifact-root", temp_dir])
+
+        self.assertEqual(exit_code, 4)
+        self.assertEqual(stdout.getvalue(), "")
+        payload = json.loads(stderr.getvalue())
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["status"], runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+        self.assertEqual(payload["launchGuard"]["activeGuard"], "paid_failure_recurrence_guard")
+
     def test_bootstrap_worker_uses_configured_worker_user(self) -> None:
         args = controller_args()
         args.worker_user = "custom-worker"


### PR DESCRIPTION
## Summary
- add a recurring-failure launch guard for Tencent RL runs so repeated identical `place-spawn room busy` failures can block paid scale-out before another worker starts
- persist a machine-readable `launch_guard.json` with evidence counts, matched failure signatures, and next action
- cover the guard with deterministic unit tests for below-threshold, threshold-crossed, and non-matching failure histories

## Linked issue
Refs #1506

## Verification
- [x] `git diff --check origin/main...HEAD`
- [x] `PYTHONPYCACHEPREFIX=/tmp/pr1506-pycache python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- [x] `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/test_screeps_tencent_batch_rl_runner.py` (142 tests)

## Issue closure gate
- [x] #1506: PR #1506 provides the code-side auto-pause deliverable and controller verification; #1506 stays open for merge plus a later Loop A/Tencent artifact showing repeated room-busy signatures are blocked before scale-out.

## Universal task Done gate
- [x] Task type: RL flywheel ops/code fix for Tencent paid-compute admission safety.
- [x] Expected observable outcome / named deliverable: a Codex-authored branch commit that detects repeated identical room-busy Tencent failures and emits a launch guard before paid scale-out.
- [x] Non-goals / accepted substitutes: no official MMO writes, no live gameplay behavior change, no Tencent paid validation launched by this PR.
- [x] Verification evidence required before Done: local diff check, Python compile, and Tencent runner unittest evidence listed above; GitHub CI and automated review must pass on this PR head before merge.
- [x] Project Evidence / Next action / Blocked by: PR and #1506 Project fields are updated by the scheduler; next action is PR review/CI, then one later Loop A/Tencent run or preflight artifact confirming the guard behavior before closing #1506.
- [x] Post-merge/deploy/runtime proof: post-merge proof is a Loop A/Tencent artifact where the launch guard records the repeated room-busy signature and prevents an unnecessary scale-out; this PR does not claim that proof yet.
- [x] Named deliverable proof: commit `0f73fb69` by `lanyusea's bot <lanyusea@gmail.com>` changes only `scripts/screeps_tencent_batch_rl_runner.py` and `scripts/test_screeps_tencent_batch_rl_runner.py`.

## Safety
- `liveEffect=false`; this path only affects offline/private Tencent batch runner admission.
- No secrets are printed by the new diagnostics.
- Paid compute remains governed by billing guard, ASG max=1, and no-duplicate-runner checks.
