### PR TITLE
fix: allow guarded post-fix room-busy validation

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -98,6 +98,18 @@ PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS = "skipped_paid_failure_recurrence_la
 PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD = 10
 PAID_FAILURE_RECURRENCE_GUARD_RECENT_SUMMARY_LIMIT = 100
 PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE = "simulator_place_spawn_room_busy"
+PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_ALLOWED_STATUS = "post_fix_validation_allowed"
+PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_REQUIRED_STATUS = "blocked_post_fix_validation_required"
+PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS = "blocked_post_fix_validation_consumed"
+PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATED_STATUS = "clear_post_fix_validated"
+PAID_FAILURE_RECURRENCE_KNOWN_FIXES = {
+    PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE: {
+        "issue": "#1501",
+        "pullRequest": "#1504",
+        "mergeCommit": "95f960b2",
+        "description": "simulator room-busy self-heal/root fix",
+    },
+}
 PAID_FAILURE_RECURRENCE_GUARD_NEXT_ACTIONS = {
     PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE: (
         "auto-pause Tencent RL paid compute for repeated place-spawn room busy failures (#1506); "
@@ -1101,6 +1113,8 @@ class Controller:
             "evidenceCount": evidence["count"],
             "evidenceThreshold": evidence["threshold"],
         }
+        if isinstance(guard.get("postFixValidation"), dict):
+            self.result["launchGuard"]["postFixValidation"] = guard["postFixValidation"]
         self.record_step(
             "e1s1_repeat_launch_guard",
             started,
@@ -2629,6 +2643,23 @@ def build_tencent_batch_launch_guard(
                 "activeGuard": "paid_failure_recurrence_guard",
             }
         )
+        if isinstance(recurrence_guard.get("postFixValidation"), dict):
+            guard["postFixValidation"] = recurrence_guard["postFixValidation"]
+        return guard
+    if not e1s1_guard["blocked"] and recurrence_guard["status"] != "clear":
+        guard.update(
+            {
+                "status": recurrence_guard["status"],
+                "blocked": False,
+                "reason": recurrence_guard.get("reason"),
+                "nextAction": recurrence_guard.get("nextAction"),
+                "evidence": recurrence_guard["evidence"],
+                "safety": recurrence_guard["safety"],
+                "activeGuard": None,
+            }
+        )
+        if isinstance(recurrence_guard.get("postFixValidation"), dict):
+            guard["postFixValidation"] = recurrence_guard["postFixValidation"]
         return guard
     guard["activeGuard"] = "e1s1_repeat_launch_guard" if e1s1_guard["blocked"] else None
     return guard
@@ -2709,27 +2740,49 @@ def build_paid_failure_recurrence_launch_guard(
         if blocked_signature is not None
         else max(signature_counts.values(), default=0)
     )
+    validation: dict[str, Any] | None = None
     blocked = blocked_signature is not None
+    status = "blocked" if blocked else "clear"
     reason = None
     if blocked:
+        validation = paid_failure_post_fix_validation_state(
+            args=args,
+            artifact_dir=artifact_dir,
+            signature=blocked_signature,
+        )
+        if validation.get("status") == "validated":
+            blocked = False
+            status = PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATED_STATUS
+        elif validation.get("status") == "allowed":
+            blocked = False
+            status = PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_ALLOWED_STATUS
+        elif validation.get("status") == "available":
+            status = PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_REQUIRED_STATUS
+        elif validation.get("status") == "consumed":
+            status = PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS
         reason = (
             f"recent Tencent RL paid-run failures reached {active_count}/"
             f"{PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD} identical known failure signature "
             f"{blocked_signature!r}"
         )
+        if validation.get("status") == "validated":
+            reason += "; a later post-fix validation completed, so older recurrence evidence is reset"
+        elif validation.get("status") == "allowed":
+            reason += "; allowing one explicit post-fix validation attempt"
+        elif validation.get("status") == "consumed":
+            reason += "; a post-fix validation attempt already ran without completing successfully"
+    next_action = None
+    if blocked_signature is not None:
+        next_action = paid_failure_recurrence_next_action(blocked_signature, validation)
     return {
         "type": PAID_FAILURE_RECURRENCE_GUARD_TYPE,
         "schemaVersion": 1,
         "runId": run_id,
         "checkedAt": utc_now_iso(),
-        "status": "blocked" if blocked else "clear",
+        "status": status,
         "blocked": blocked,
         "reason": reason,
-        "nextAction": (
-            PAID_FAILURE_RECURRENCE_GUARD_NEXT_ACTIONS.get(blocked_signature)
-            if blocked_signature is not None
-            else None
-        ),
+        "nextAction": next_action,
         "currentLaunch": {
             "command": getattr(args, "command", None),
             "preflightOnly": bool(getattr(args, "preflight_only", False)),
@@ -2737,6 +2790,9 @@ def build_paid_failure_recurrence_launch_guard(
             "scenarioId": scenario_id_from_args(args),
             "workers": getattr(args, "workers", None),
             "repetitions": getattr(args, "repetitions", None),
+            "allowedPaidFailureRecurrenceValidations": sorted(
+                paid_failure_recurrence_validation_requests(args)
+            ),
         },
         "evidence": {
             "threshold": PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD,
@@ -2744,8 +2800,9 @@ def build_paid_failure_recurrence_launch_guard(
             "recentSummaryLimit": PAID_FAILURE_RECURRENCE_GUARD_RECENT_SUMMARY_LIMIT,
             "activeSignature": blocked_signature,
             "signatureCounts": signature_counts,
-            "runs": signature_runs if blocked else evidence_runs,
+            "runs": signature_runs if blocked_signature is not None else evidence_runs,
         },
+        "postFixValidation": validation,
         "safety": {
             "liveEffect": False,
             "officialMmoWrites": False,
@@ -2805,6 +2862,213 @@ def recent_paid_failure_recurrence_evidence(args: argparse.Namespace, artifact_d
             if len(evidence) >= PAID_FAILURE_RECURRENCE_GUARD_RECENT_SUMMARY_LIMIT:
                 break
     return evidence
+
+
+def paid_failure_recurrence_validation_requests(args: argparse.Namespace) -> set[str]:
+    raw = getattr(args, "allow_paid_failure_recurrence_validation", None)
+    if raw is None:
+        return set()
+    values = raw if isinstance(raw, list) else [raw]
+    return {value for value in (text_value(item) for item in values) if value is not None}
+
+
+def paid_failure_post_fix_validation_state(
+    *,
+    args: argparse.Namespace,
+    artifact_dir: Path,
+    signature: str,
+) -> dict[str, Any]:
+    requested_signatures = paid_failure_recurrence_validation_requests(args)
+    fix_status = paid_failure_recurrence_known_fix_status(signature)
+    prior_attempt = latest_paid_failure_post_fix_validation_attempt(args, artifact_dir, signature)
+    state: dict[str, Any] = {
+        "signature": signature,
+        "status": "unavailable",
+        "requested": signature in requested_signatures,
+        "requestedSignatures": sorted(requested_signatures),
+        "knownFix": fix_status,
+        "priorAttempt": prior_attempt,
+    }
+    if prior_attempt is not None:
+        if text_value(prior_attempt.get("outcome")) == "completed":
+            state["status"] = "validated"
+        else:
+            state["status"] = "consumed"
+        return state
+    if fix_status.get("present") is True:
+        state["status"] = "allowed" if signature in requested_signatures else "available"
+        return state
+    if signature in requested_signatures:
+        state["status"] = "unverified"
+    return state
+
+
+def paid_failure_recurrence_known_fix_status(signature: str) -> dict[str, Any]:
+    fix = PAID_FAILURE_RECURRENCE_KNOWN_FIXES.get(signature)
+    if fix is None:
+        return {
+            "signature": signature,
+            "present": False,
+            "reason": "no known post-fix validation reset is registered for this signature",
+        }
+    merge_commit = str(fix["mergeCommit"])
+    present = git_ref_is_ancestor_of_head(merge_commit)
+    if present is True:
+        evidence = f"merge commit {merge_commit} is reachable from HEAD"
+    elif present is False:
+        evidence = f"merge commit {merge_commit} is not reachable from HEAD"
+    else:
+        evidence = f"could not verify whether merge commit {merge_commit} is reachable from HEAD"
+    return {
+        **fix,
+        "signature": signature,
+        "present": present,
+        "evidence": evidence,
+    }
+
+
+def git_ref_is_ancestor_of_head(ref: str) -> bool | None:
+    try:
+        cp = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", ref, "HEAD"],
+            cwd=str(REPO_ROOT),
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if cp.returncode == 0:
+        return True
+    if cp.returncode == 1:
+        return False
+    return None
+
+
+def latest_paid_failure_post_fix_validation_attempt(
+    args: argparse.Namespace,
+    artifact_dir: Path,
+    signature: str,
+) -> dict[str, Any] | None:
+    artifact_root = resolved_artifact_root(args)
+    if not artifact_root.is_dir():
+        return None
+    current_dir = artifact_dir.resolve()
+    try:
+        summary_paths = sorted(
+            artifact_root.glob("*/controller-summary.json"),
+            key=lambda path: (path.stat().st_mtime, path.as_posix()),
+            reverse=True,
+        )
+    except OSError:
+        return None
+    scanned = 0
+    for summary_path in summary_paths:
+        try:
+            if summary_path.parent.resolve() == current_dir:
+                continue
+        except OSError:
+            continue
+        scanned += 1
+        item = paid_failure_post_fix_validation_attempt_from_summary(
+            read_json_object(summary_path),
+            summary_path,
+            signature,
+        )
+        if item is not None:
+            return item
+        if scanned >= PAID_FAILURE_RECURRENCE_GUARD_RECENT_SUMMARY_LIMIT:
+            break
+    return None
+
+
+def paid_failure_post_fix_validation_attempt_from_summary(
+    summary: dict[str, Any] | None,
+    summary_path: Path,
+    signature: str,
+) -> dict[str, Any] | None:
+    if not isinstance(summary, dict):
+        return None
+    guard = dict_value(path_value(summary, "outputs", "launchGuard"))
+    if guard is None:
+        return None
+    validation = dict_value(guard.get("postFixValidation"))
+    if validation is None:
+        return None
+    validation_signature = text_value(validation.get("signature")) or text_value(guard.get("activeSignature"))
+    if validation_signature != signature:
+        return None
+    validation_status = text_value(validation.get("status"))
+    guard_status = text_value(guard.get("status"))
+    if (
+        validation_status != "allowed"
+        and guard_status != PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_ALLOWED_STATUS
+    ):
+        return None
+    final_status = text_value(summary.get("finalStatus"))
+    run_id = text_value(summary.get("runId")) or summary_path.parent.name
+    failure_signature = None
+    if paid_failure_recurrence_summary_candidate(summary):
+        failure = paid_failure_signature_from_summary(summary)
+        if failure is not None:
+            failure_signature = failure["signature"]
+    return {
+        "runId": run_id,
+        "summaryPath": str(summary_path),
+        "finishedAt": text_value(summary.get("finishedAt")),
+        "finalStatus": final_status,
+        "signature": signature,
+        "status": validation_status,
+        "guardStatus": guard_status,
+        "outcome": "completed" if isinstance(final_status, str) and final_status.startswith("completed") else "not_completed",
+        "failureSignature": failure_signature,
+    }
+
+
+def paid_failure_recurrence_next_action(
+    signature: str,
+    validation: dict[str, Any] | None,
+) -> str | None:
+    if signature != PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE:
+        return PAID_FAILURE_RECURRENCE_GUARD_NEXT_ACTIONS.get(signature)
+    base = "auto-pause Tencent RL paid compute for repeated place-spawn room busy failures (#1506)"
+    if validation is None:
+        return PAID_FAILURE_RECURRENCE_GUARD_NEXT_ACTIONS.get(signature)
+    status = text_value(validation.get("status"))
+    known_fix = dict_value(validation.get("knownFix")) or {}
+    merge_commit = text_value(known_fix.get("mergeCommit")) or "the room-busy fix"
+    issue = text_value(known_fix.get("issue")) or "#1501"
+    pr = text_value(known_fix.get("pullRequest")) or "#1504"
+    if status == "validated":
+        prior = dict_value(validation.get("priorAttempt")) or {}
+        run_id = text_value(prior.get("runId")) or "the prior post-fix validation"
+        return f"{base}; post-fix validation {run_id} completed, so older room-busy recurrence evidence is reset"
+    if status == "allowed":
+        return (
+            f"{base}; run exactly one bounded post-fix validation for {issue} / {pr}; "
+            "if simulator_place_spawn_room_busy recurs, keep the paid recurrence guard active"
+        )
+    if status == "available":
+        return (
+            f"{base}; {issue} / {pr} fix {merge_commit} is present, so launch exactly one guarded "
+            "post-fix validation with --allow-paid-failure-recurrence-validation "
+            f"{PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE}; if the same signature recurs, keep compute paused"
+        )
+    if status == "consumed":
+        prior = dict_value(validation.get("priorAttempt")) or {}
+        run_id = text_value(prior.get("runId")) or "the prior post-fix validation"
+        return (
+            f"{base}; post-fix validation was already attempted in {run_id} without a completed report, "
+            "so inspect that run before any further paid rerun"
+        )
+    if status == "unverified":
+        evidence = text_value(known_fix.get("evidence")) or f"could not verify {issue} / {pr}"
+        return (
+            f"{base}; post-fix validation was requested but the current checkout is not verified safe "
+            f"({evidence}); verify the fix before paid compute"
+        )
+    return PAID_FAILURE_RECURRENCE_GUARD_NEXT_ACTIONS.get(signature)
 
 
 def recent_e1s1_dead_tier_evidence(args: argparse.Namespace, artifact_dir: Path) -> list[dict[str, Any]]:
@@ -5091,6 +5355,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--require-multi-tier-scenario",
         action="store_true",
         help="Reject Tencent policy comparison cards unless the scenario has territory and combat signals.",
+    )
+    parser.add_argument(
+        "--allow-paid-failure-recurrence-validation",
+        action="append",
+        choices=tuple(PAID_FAILURE_RECURRENCE_KNOWN_FIXES),
+        default=None,
+        help=(
+            "Allow one guarded post-fix validation for a known paid-failure recurrence signature after "
+            "the registered fix is present in the current checkout."
+        ),
     )
     parser.add_argument("--variant", action="append", help="Strategy variant id; repeat to override generated card variants.")
     parser.add_argument("--artifact-root", type=Path, default=DEFAULT_ARTIFACT_ROOT)

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -101,6 +101,7 @@ PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE = "simulator_place_spawn_room_busy"
 PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_ALLOWED_STATUS = "post_fix_validation_allowed"
 PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_REQUIRED_STATUS = "blocked_post_fix_validation_required"
 PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS = "blocked_post_fix_validation_consumed"
+PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_SUPERSEDED_STATUS = "blocked_post_fix_validation_superseded"
 PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATED_STATUS = "clear_post_fix_validated"
 PAID_FAILURE_RECURRENCE_KNOWN_FIXES = {
     PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE: {
@@ -2751,8 +2752,15 @@ def build_paid_failure_recurrence_launch_guard(
             signature=blocked_signature,
         )
         if validation.get("status") == "validated":
-            blocked = False
-            status = PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATED_STATUS
+            validation = paid_failure_post_fix_validation_state_with_recurrence_evidence(
+                validation,
+                signature_runs,
+            )
+            if validation.get("status") == "validated":
+                blocked = False
+                status = PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATED_STATUS
+            else:
+                status = PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_SUPERSEDED_STATUS
         elif validation.get("status") == "allowed":
             blocked = False
             status = PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_ALLOWED_STATUS
@@ -2767,6 +2775,8 @@ def build_paid_failure_recurrence_launch_guard(
         )
         if validation.get("status") == "validated":
             reason += "; a later post-fix validation completed, so older recurrence evidence is reset"
+        elif validation.get("status") == "superseded":
+            reason += "; a completed post-fix validation is superseded by newer matching failures"
         elif validation.get("status") == "allowed":
             reason += "; allowing one explicit post-fix validation attempt"
         elif validation.get("status") == "consumed":
@@ -2901,6 +2911,77 @@ def paid_failure_post_fix_validation_state(
     if signature in requested_signatures:
         state["status"] = "unverified"
     return state
+
+
+def paid_failure_post_fix_validation_state_with_recurrence_evidence(
+    validation: dict[str, Any],
+    signature_runs: list[dict[str, Any]],
+) -> dict[str, Any]:
+    state = copy.deepcopy(validation)
+    prior_attempt = dict_value(state.get("priorAttempt"))
+    validation_epoch = paid_failure_summary_item_epoch(prior_attempt)
+    post_validation_runs: list[dict[str, Any]] = []
+    reset_runs: list[dict[str, Any]] = []
+    unknown_order_runs: list[dict[str, Any]] = []
+    for item in signature_runs:
+        item_epoch = paid_failure_summary_item_epoch(item)
+        if validation_epoch is None or item_epoch is None:
+            unknown_order_runs.append(item)
+        elif item_epoch > validation_epoch:
+            post_validation_runs.append(item)
+        else:
+            reset_runs.append(item)
+    post_validation_count = len(post_validation_runs)
+    unknown_order_count = len(unknown_order_runs)
+    reset_applies = (
+        validation_epoch is not None
+        and unknown_order_count == 0
+        and post_validation_count < PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD
+    )
+    state["recurrenceEvidence"] = {
+        "threshold": PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD,
+        "thresholdEvidenceCount": len(signature_runs),
+        "validationFinishedAt": text_value(prior_attempt.get("finishedAt")) if prior_attempt else None,
+        "validationSummaryPath": text_value(prior_attempt.get("summaryPath")) if prior_attempt else None,
+        "postValidationFailureCount": post_validation_count,
+        "resetFailureCount": len(reset_runs),
+        "unknownOrderFailureCount": unknown_order_count,
+        "resetApplies": reset_applies,
+        "postValidationRuns": paid_failure_recurrence_evidence_refs(post_validation_runs),
+        "unknownOrderRuns": paid_failure_recurrence_evidence_refs(unknown_order_runs),
+    }
+    if not reset_applies:
+        state["status"] = "superseded"
+    return state
+
+
+def paid_failure_summary_item_epoch(item: dict[str, Any] | None) -> float | None:
+    if item is None:
+        return None
+    epoch = parse_iso_epoch(item.get("finishedAt"))
+    if epoch is not None:
+        return epoch
+    summary_path = text_value(item.get("summaryPath"))
+    if summary_path is None:
+        return None
+    try:
+        return Path(summary_path).stat().st_mtime
+    except OSError:
+        return None
+
+
+def paid_failure_recurrence_evidence_refs(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    refs: list[dict[str, Any]] = []
+    for item in items:
+        refs.append(
+            {
+                "runId": text_value(item.get("runId")),
+                "finishedAt": text_value(item.get("finishedAt")),
+                "summaryPath": text_value(item.get("summaryPath")),
+                "finalStatus": text_value(item.get("finalStatus")),
+            }
+        )
+    return refs
 
 
 def paid_failure_recurrence_known_fix_status(signature: str) -> dict[str, Any]:
@@ -3061,6 +3142,22 @@ def paid_failure_recurrence_next_action(
         return (
             f"{base}; post-fix validation was already attempted in {run_id} without a completed report, "
             "so inspect that run before any further paid rerun"
+        )
+    if status == "superseded":
+        prior = dict_value(validation.get("priorAttempt")) or {}
+        run_id = text_value(prior.get("runId")) or "the prior post-fix validation"
+        evidence = dict_value(validation.get("recurrenceEvidence")) or {}
+        count = evidence.get("postValidationFailureCount")
+        threshold = evidence.get("threshold") or PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD
+        unknown_count = evidence.get("unknownOrderFailureCount")
+        if not isinstance(count, int) or count < PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD:
+            return (
+                f"{base}; post-fix validation {run_id} completed, but {unknown_count} matching failures "
+                "could not be ordered relative to it, so keep paid compute paused and inspect those runs"
+            )
+        return (
+            f"{base}; post-fix validation {run_id} completed, but {count}/{threshold} newer matching "
+            "failures reached the recurrence threshold, so keep paid compute paused and inspect those runs"
         )
     if status == "unverified":
         evidence = text_value(known_fix.get("evidence")) or f"could not verify {issue} / {pr}"

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -3044,14 +3044,12 @@ def latest_paid_failure_post_fix_validation_attempt(
         )
     except OSError:
         return None
-    scanned = 0
     for summary_path in summary_paths:
         try:
             if summary_path.parent.resolve() == current_dir:
                 continue
         except OSError:
             continue
-        scanned += 1
         item = paid_failure_post_fix_validation_attempt_from_summary(
             read_json_object(summary_path),
             summary_path,
@@ -3059,8 +3057,6 @@ def latest_paid_failure_post_fix_validation_attempt(
         )
         if item is not None:
             return item
-        if scanned >= PAID_FAILURE_RECURRENCE_GUARD_RECENT_SUMMARY_LIMIT:
-            break
     return None
 
 

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -763,6 +763,12 @@ def write_post_fix_validation_summary(
     return summary_path
 
 
+def set_summary_finished_at(summary_path: Path, finished_at: str) -> None:
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary["finishedAt"] = finished_at
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+
+
 def strip_tencent_guard_location_evidence(summary_path: Path) -> None:
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
     training_report = summary["outputs"]["trainingReport"]
@@ -3898,6 +3904,110 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(guard["postFixValidation"]["priorAttempt"]["runId"], "tencent-pg-post-fix-failed")
         self.assertIn("already attempted", guard["nextAction"])
         self.assertFalse(summary["execution"]["computeAttempted"])
+
+    def test_paid_failure_recurrence_guard_completed_validation_resets_older_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            write_post_fix_validation_summary(
+                artifact_root,
+                "tencent-pg-post-fix-completed",
+                final_status="completed",
+            )
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                "500",
+                "--workers",
+                "1",
+            ])
+
+            guard = runner.build_paid_failure_recurrence_launch_guard(
+                args=args,
+                run_id="new-run",
+                artifact_dir=artifact_root / "new-run",
+            )
+
+        self.assertFalse(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATED_STATUS)
+        self.assertEqual(guard["postFixValidation"]["status"], "validated")
+        recurrence_evidence = guard["postFixValidation"]["recurrenceEvidence"]
+        self.assertTrue(recurrence_evidence["resetApplies"])
+        self.assertEqual(recurrence_evidence["resetFailureCount"], runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD)
+        self.assertEqual(recurrence_evidence["postValidationFailureCount"], 0)
+        self.assertEqual(recurrence_evidence["unknownOrderFailureCount"], 0)
+        self.assertIn("older room-busy recurrence evidence is reset", guard["nextAction"])
+
+    def test_paid_failure_recurrence_guard_reblocks_after_completed_validation_recurrence(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-old-room-busy-{index}")
+            write_post_fix_validation_summary(
+                artifact_root,
+                "tencent-pg-post-fix-completed",
+                final_status="completed",
+            )
+            new_run_ids = {
+                f"tencent-pg-new-room-busy-{index}"
+                for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD)
+            }
+            for index, run_id in enumerate(sorted(new_run_ids)):
+                summary_path = write_tencent_failure_summary(artifact_root, run_id)
+                set_summary_finished_at(summary_path, f"2026-05-29T22:{index:02d}:03Z")
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                "500",
+                "--workers",
+                "1",
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertEqual(events, [])
+        self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+        self.assertTrue(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_SUPERSEDED_STATUS)
+        self.assertEqual(guard["postFixValidation"]["status"], "superseded")
+        recurrence_evidence = guard["postFixValidation"]["recurrenceEvidence"]
+        self.assertFalse(recurrence_evidence["resetApplies"])
+        self.assertEqual(
+            recurrence_evidence["postValidationFailureCount"],
+            runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD,
+        )
+        self.assertEqual(recurrence_evidence["resetFailureCount"], runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD)
+        self.assertEqual(
+            {item["runId"] for item in recurrence_evidence["postValidationRuns"]},
+            new_run_ids,
+        )
+        self.assertIn("newer matching failures", guard["nextAction"])
+        self.assertEqual(summary["finalStatus"], runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+        self.assertFalse(summary["execution"]["computeAttempted"])
+        summary_validation = summary["outputs"]["launchGuard"]["postFixValidation"]
+        self.assertEqual(summary_validation["status"], "superseded")
+        self.assertEqual(
+            summary_validation["recurrenceEvidence"]["postValidationFailureCount"],
+            runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD,
+        )
 
     def test_paid_failure_recurrence_guard_scans_past_newer_skipped_guard_summaries(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -3905,6 +3905,75 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertIn("already attempted", guard["nextAction"])
         self.assertFalse(summary["execution"]["computeAttempted"])
 
+    def test_paid_failure_recurrence_guard_blocks_second_validation_past_recent_summary_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            old_paths = [
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+                for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD)
+            ]
+            prior_attempt_path = write_post_fix_validation_summary(
+                artifact_root,
+                "tencent-pg-post-fix-failed",
+                final_status="failed",
+                failure_class=runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            )
+            newer_paths = [
+                write_paid_failure_recurrence_skipped_summary(
+                    artifact_root,
+                    f"tencent-pg-newer-skipped-{index}",
+                )
+                for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_RECENT_SUMMARY_LIMIT)
+            ]
+            for index, summary_path in enumerate(old_paths):
+                timestamp = 1_700_000_000 + index
+                os.utime(summary_path, (timestamp, timestamp))
+            os.utime(prior_attempt_path, (1_700_000_050, 1_700_000_050))
+            for index, summary_path in enumerate(newer_paths):
+                timestamp = 1_700_000_100 + index
+                os.utime(summary_path, (timestamp, timestamp))
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                "500",
+                "--workers",
+                "1",
+                "--allow-paid-failure-recurrence-validation",
+                runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertEqual(events, [])
+        self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+        self.assertTrue(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
+        self.assertEqual(guard["postFixValidation"]["status"], "consumed")
+        self.assertEqual(guard["postFixValidation"]["priorAttempt"]["runId"], "tencent-pg-post-fix-failed")
+        self.assertIn("already attempted", guard["nextAction"])
+        self.assertFalse(summary["execution"]["computeAttempted"])
+
     def test_paid_failure_recurrence_guard_completed_validation_resets_older_failures(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             artifact_root = Path(temp_dir) / "batch-runs"

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -93,6 +93,7 @@ def controller_args() -> argparse.Namespace:
         training_approach="bandit",
         training_timeout_seconds=1,
         transfer_timeout_seconds=1,
+        allow_paid_failure_recurrence_validation=None,
         variant=None,
         worker_user="screeps-batch",
         workers=1,
@@ -700,6 +701,64 @@ def write_paid_failure_recurrence_skipped_summary(artifact_root: Path, run_id: s
         },
     }
     summary_path = run_dir / "controller-summary.json"
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+    return summary_path
+
+
+def write_post_fix_validation_summary(
+    artifact_root: Path,
+    run_id: str,
+    *,
+    final_status: str = "completed",
+    failure_class: str | None = None,
+) -> Path:
+    if final_status == "completed":
+        run_dir = artifact_root / run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+        summary = {
+            "type": "screeps-tencent-batch-rl-run",
+            "schemaVersion": 1,
+            "runId": run_id,
+            "startedAt": "2026-05-29T21:00:03Z",
+            "finishedAt": "2026-05-29T21:04:03Z",
+            "partial": False,
+            "finalStatus": "completed",
+            "execution": {
+                "command": "run-single",
+                "mode": "compute",
+                "preflightOnly": False,
+                "computeAttempted": True,
+                "scaleOutAttempted": True,
+                "remoteTrainingAttempted": True,
+                "trainingReportProduced": True,
+            },
+            "outputs": {},
+        }
+        summary_path = run_dir / "controller-summary.json"
+    else:
+        summary_path = write_tencent_failure_summary(
+            artifact_root,
+            run_id,
+            failure_class=failure_class,
+        )
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary.setdefault("outputs", {})["launchGuard"] = {
+        "status": runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_ALLOWED_STATUS,
+        "blocked": False,
+        "activeSignature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+        "postFixValidation": {
+            "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            "status": "allowed",
+            "requested": True,
+            "knownFix": {
+                "issue": "#1501",
+                "pullRequest": "#1504",
+                "mergeCommit": "95f960b2",
+                "present": True,
+            },
+            "priorAttempt": None,
+        },
+    }
     summary_path.write_text(json.dumps(summary), encoding="utf-8")
     return summary_path
 
@@ -3651,7 +3710,19 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             ])
             artifact_dir = artifact_root / "new-run"
 
-            events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": False,
+                    "evidence": "merge commit 95f960b2 is not reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
 
         self.assertEqual(events, [])
         self.assertTrue(guard["blocked"])
@@ -3669,6 +3740,164 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertFalse(summary["execution"]["computeAttempted"])
         self.assertFalse(summary["execution"]["scaleOutAttempted"])
         self.assertFalse(summary["safety"]["scaleDownAttempted"])
+
+    def test_paid_failure_recurrence_guard_gives_post_fix_validation_action_when_fix_present(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                "500",
+                "--workers",
+                "1",
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertEqual(events, [])
+        self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+        self.assertTrue(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_REQUIRED_STATUS)
+        self.assertEqual(guard["postFixValidation"]["status"], "available")
+        self.assertTrue(guard["postFixValidation"]["knownFix"]["present"])
+        self.assertIn("--allow-paid-failure-recurrence-validation", guard["nextAction"])
+        self.assertIn(runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE, guard["nextAction"])
+        self.assertNotIn("ship and verify", guard["nextAction"])
+        self.assertEqual(
+            summary["outputs"]["launchGuard"]["postFixValidation"]["status"],
+            "available",
+        )
+        self.assertFalse(summary["execution"]["computeAttempted"])
+
+    def test_paid_failure_recurrence_guard_allows_explicit_post_fix_validation_once(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                "500",
+                "--workers",
+                "1",
+                "--allow-paid-failure-recurrence-validation",
+                runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertIn("scale_up", events)
+        self.assertIn("remote_training", events)
+        self.assertFalse(guard["blocked"])
+        self.assertIsNone(guard["activeGuard"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_ALLOWED_STATUS)
+        self.assertEqual(guard["postFixValidation"]["status"], "allowed")
+        self.assertTrue(guard["postFixValidation"]["requested"])
+        self.assertIn("exactly one", guard["nextAction"])
+        self.assertEqual(controller.final_status, "completed")
+        self.assertEqual(summary["finalStatus"], "completed")
+        self.assertTrue(summary["execution"]["computeAttempted"])
+        self.assertEqual(
+            summary["outputs"]["launchGuard"]["postFixValidation"]["status"],
+            "allowed",
+        )
+
+    def test_paid_failure_recurrence_guard_blocks_second_post_fix_validation_attempt(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            write_post_fix_validation_summary(
+                artifact_root,
+                "tencent-pg-post-fix-failed",
+                final_status="failed",
+                failure_class=runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            )
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                "500",
+                "--workers",
+                "1",
+                "--allow-paid-failure-recurrence-validation",
+                runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertEqual(events, [])
+        self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+        self.assertTrue(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
+        self.assertEqual(guard["postFixValidation"]["status"], "consumed")
+        self.assertEqual(guard["postFixValidation"]["priorAttempt"]["runId"], "tencent-pg-post-fix-failed")
+        self.assertIn("already attempted", guard["nextAction"])
+        self.assertFalse(summary["execution"]["computeAttempted"])
 
     def test_paid_failure_recurrence_guard_scans_past_newer_skipped_guard_summaries(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -3706,11 +3935,23 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 "1",
             ])
 
-            guard = runner.build_paid_failure_recurrence_launch_guard(
-                args=args,
-                run_id="new-run",
-                artifact_dir=artifact_root / "new-run",
-            )
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": False,
+                    "evidence": "merge commit 95f960b2 is not reachable from HEAD",
+                },
+            ):
+                guard = runner.build_paid_failure_recurrence_launch_guard(
+                    args=args,
+                    run_id="new-run",
+                    artifact_dir=artifact_root / "new-run",
+                )
 
         self.assertTrue(guard["blocked"])
         self.assertEqual(guard["status"], "blocked")


### PR DESCRIPTION
## Summary

- Adds a registered post-repair validation path for the repeated Tencent RL `simulator_place_spawn_room_busy` paid-failure guard once the #1501 / #1504 repair is present in `HEAD`.
- Adds `--allow-paid-failure-recurrence-validation simulator_place_spawn_room_busy` so exactly one bounded validation can pass the recurrence guard, while subsequent non-completed attempts are consumed and keep compute paused.
- Review-fix commit `a4a9671e9a7f59e4b6ddd1aa4954d865c788922f` keeps the guard blocking if matching failures recur after a completed post-repair validation.
- Records post-repair validation state in launch-guard/controller-summary artifacts and expands unit coverage for available/allowed/consumed/validated/superseded states.

Related to #1501, #1506, #879, #1032, #1337.

## Verification

- `git diff --check`
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts/test_screeps_tencent_batch_rl_runner.py -v` (149 tests OK)

## Safety

- No official MMO writes.
- No Tencent scale-out or paid compute was launched by this PR.
- The runner still requires the explicit signature flag for the one validation pass and records consumed/non-completed attempts.

## Universal task Done gate

- [x] Task type: code/test RL runner guard update.
- [x] Expected observable outcome / named deliverable: Tencent RL paid-failure recurrence guard can distinguish registered room-busy repair available, one allowed validation, consumed failed validation, completed validation reset, and superseded validation when newer failures recur.
- [x] Non-goals / accepted substitutes: no automatic paid rerun, no official MMO behavior change, no reward-policy change.
- [x] Verification evidence required before Done: local `git diff --check`, Python compile, and 149-runner-test unittest pass recorded above; PR CI and automated review recorded on the PR before merge.
- [x] Project Evidence / Next action / Blocked by: #1501/#879/#1032/#1337 remain the validation owners; Project fields updated by the steward with this PR URL, commits, and exact next guarded validation action.
- [x] Post-merge/deploy/runtime proof: no official deploy required for this script-only guard; the required runtime proof is the subsequent single guarded Tencent/private-sim validation artifact linked back to #1501/#1032.
- [x] Named deliverable proof: commits `c176ce0c87331bcbd97a04e5778bc8a23784ddba` and `a4a9671e9a7f59e4b6ddd1aa4954d865c788922f` add the flag, artifact state, recurrence re-blocking, and recurrence-guard tests.
