### PR TITLE
fix: recover consumed room-busy validation admission

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -99,6 +99,7 @@ PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD = 10
 PAID_FAILURE_RECURRENCE_GUARD_RECENT_SUMMARY_LIMIT = 100
 PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE = "simulator_place_spawn_room_busy"
 PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_ALLOWED_STATUS = "post_fix_validation_allowed"
+PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS = "post_fix_validation_recovery_allowed"
 PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_REQUIRED_STATUS = "blocked_post_fix_validation_required"
 PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS = "blocked_post_fix_validation_consumed"
 PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_SUPERSEDED_STATUS = "blocked_post_fix_validation_superseded"
@@ -2764,6 +2765,9 @@ def build_paid_failure_recurrence_launch_guard(
         elif validation.get("status") == "allowed":
             blocked = False
             status = PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_ALLOWED_STATUS
+        elif validation.get("status") == "recovery_allowed":
+            blocked = False
+            status = PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS
         elif validation.get("status") == "available":
             status = PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_REQUIRED_STATUS
         elif validation.get("status") == "consumed":
@@ -2779,6 +2783,8 @@ def build_paid_failure_recurrence_launch_guard(
             reason += "; a completed post-fix validation is superseded by newer matching failures"
         elif validation.get("status") == "allowed":
             reason += "; allowing one explicit post-fix validation attempt"
+        elif validation.get("status") == "recovery_allowed":
+            reason += "; allowing one explicit recovery validation after a pre-scale no-compute admission failure"
         elif validation.get("status") == "consumed":
             reason += "; a post-fix validation attempt already ran without completing successfully"
     next_action = None
@@ -2800,6 +2806,7 @@ def build_paid_failure_recurrence_launch_guard(
             "scenarioId": scenario_id_from_args(args),
             "workers": getattr(args, "workers", None),
             "repetitions": getattr(args, "repetitions", None),
+            "policyGradientTrustSampleRequest": policy_gradient_trust_sample_request(args),
             "allowedPaidFailureRecurrenceValidations": sorted(
                 paid_failure_recurrence_validation_requests(args)
             ),
@@ -2890,7 +2897,8 @@ def paid_failure_post_fix_validation_state(
 ) -> dict[str, Any]:
     requested_signatures = paid_failure_recurrence_validation_requests(args)
     fix_status = paid_failure_recurrence_known_fix_status(signature)
-    prior_attempt = latest_paid_failure_post_fix_validation_attempt(args, artifact_dir, signature)
+    prior_attempts = paid_failure_post_fix_validation_attempts(args, artifact_dir, signature)
+    prior_attempt = prior_attempts[0] if prior_attempts else None
     state: dict[str, Any] = {
         "signature": signature,
         "status": "unavailable",
@@ -2900,8 +2908,18 @@ def paid_failure_post_fix_validation_state(
         "priorAttempt": prior_attempt,
     }
     if prior_attempt is not None:
+        state["priorAttemptCount"] = len(prior_attempts)
+        recovery = paid_failure_post_fix_validation_recovery_eligibility(
+            args=args,
+            signature=signature,
+            prior_attempts=prior_attempts,
+            fix_status=fix_status,
+        )
+        state["recoveryEligibility"] = recovery
         if text_value(prior_attempt.get("outcome")) == "completed":
             state["status"] = "validated"
+        elif recovery["eligible"] is True:
+            state["status"] = "recovery_allowed"
         else:
             state["status"] = "consumed"
         return state
@@ -2911,6 +2929,61 @@ def paid_failure_post_fix_validation_state(
     if signature in requested_signatures:
         state["status"] = "unverified"
     return state
+
+
+def paid_failure_post_fix_validation_recovery_eligibility(
+    *,
+    args: argparse.Namespace,
+    signature: str,
+    prior_attempts: list[dict[str, Any]],
+    fix_status: dict[str, Any],
+) -> dict[str, Any]:
+    trust_sample_request = policy_gradient_trust_sample_request(args)
+    requested = signature in paid_failure_recurrence_validation_requests(args)
+    result: dict[str, Any] = {
+        "eligible": False,
+        "reason": None,
+        "requiresExplicitValidationSignature": True,
+        "requested": requested,
+        "policyGradientTrustSampleRequest": trust_sample_request,
+    }
+    if signature != PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE:
+        result["reason"] = "recovery is only defined for simulator_place_spawn_room_busy"
+        return result
+    if fix_status.get("present") is not True:
+        result["reason"] = "registered room-busy fix is not verified in the current checkout"
+        return result
+    if not requested:
+        result["reason"] = "explicit post-fix validation signature was not requested"
+        return result
+    if len(prior_attempts) != 1:
+        result["reason"] = "recovery requires exactly one prior consumed post-fix validation attempt"
+        return result
+    prior_attempt = prior_attempts[0]
+    if any(text_value(attempt.get("outcome")) == "completed" for attempt in prior_attempts):
+        result["reason"] = "a post-fix validation already completed"
+        return result
+    if any(attempt.get("recoveryAttempt") is True for attempt in prior_attempts):
+        result["reason"] = "post-fix validation recovery was already attempted"
+        return result
+    if any(paid_failure_post_fix_attempt_reached_compute_or_training(attempt) for attempt in prior_attempts):
+        result["reason"] = "a prior post-fix validation reached compute, scale, remote training, environments, or a report"
+        return result
+    if not paid_failure_post_fix_attempt_is_pre_scale_no_compute_admission_failure(prior_attempt):
+        result["reason"] = "prior post-fix validation was not a pre-scale no-compute admission failure"
+        return result
+    if not isinstance(trust_sample_request, dict):
+        result["reason"] = "policy-gradient trust sample request metadata is absent"
+        return result
+    if trust_sample_request.get("meetsTrustSampleTarget") is not True:
+        result["reason"] = "policy-gradient requested samples are below the trust gate target"
+        return result
+    result["eligible"] = True
+    result["reason"] = (
+        "one recovery validation is allowed after a consumed pre-scale no-compute admission failure"
+    )
+    result["priorAttemptRunId"] = text_value(prior_attempt.get("runId"))
+    return result
 
 
 def paid_failure_post_fix_validation_state_with_recurrence_evidence(
@@ -3032,9 +3105,18 @@ def latest_paid_failure_post_fix_validation_attempt(
     artifact_dir: Path,
     signature: str,
 ) -> dict[str, Any] | None:
+    attempts = paid_failure_post_fix_validation_attempts(args, artifact_dir, signature)
+    return attempts[0] if attempts else None
+
+
+def paid_failure_post_fix_validation_attempts(
+    args: argparse.Namespace,
+    artifact_dir: Path,
+    signature: str,
+) -> list[dict[str, Any]]:
     artifact_root = resolved_artifact_root(args)
     if not artifact_root.is_dir():
-        return None
+        return []
     current_dir = artifact_dir.resolve()
     try:
         summary_paths = sorted(
@@ -3043,7 +3125,8 @@ def latest_paid_failure_post_fix_validation_attempt(
             reverse=True,
         )
     except OSError:
-        return None
+        return []
+    attempts: list[dict[str, Any]] = []
     for summary_path in summary_paths:
         try:
             if summary_path.parent.resolve() == current_dir:
@@ -3056,8 +3139,8 @@ def latest_paid_failure_post_fix_validation_attempt(
             signature,
         )
         if item is not None:
-            return item
-    return None
+            attempts.append(item)
+    return attempts
 
 
 def paid_failure_post_fix_validation_attempt_from_summary(
@@ -3078,10 +3161,12 @@ def paid_failure_post_fix_validation_attempt_from_summary(
         return None
     validation_status = text_value(validation.get("status"))
     guard_status = text_value(guard.get("status"))
-    if (
-        validation_status != "allowed"
-        and guard_status != PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_ALLOWED_STATUS
-    ):
+    allowed_validation_statuses = {"allowed", "recovery_allowed"}
+    allowed_guard_statuses = {
+        PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_ALLOWED_STATUS,
+        PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS,
+    }
+    if validation_status not in allowed_validation_statuses and guard_status not in allowed_guard_statuses:
         return None
     final_status = text_value(summary.get("finalStatus"))
     run_id = text_value(summary.get("runId")) or summary_path.parent.name
@@ -3090,6 +3175,11 @@ def paid_failure_post_fix_validation_attempt_from_summary(
         failure = paid_failure_signature_from_summary(summary)
         if failure is not None:
             failure_signature = failure["signature"]
+    execution = dict_value(summary.get("execution")) or {}
+    environments_run = scale_gates.non_negative_int(execution.get("environmentsRun"))
+    remote_failure = dict_value(path_value(summary, "outputs", "remoteTrainingFailure"))
+    remote_failure_class = text_value(remote_failure.get("failureClass")) if remote_failure else None
+    training_report = dict_value(path_value(summary, "outputs", "trainingReport"))
     return {
         "runId": run_id,
         "summaryPath": str(summary_path),
@@ -3100,7 +3190,44 @@ def paid_failure_post_fix_validation_attempt_from_summary(
         "guardStatus": guard_status,
         "outcome": "completed" if isinstance(final_status, str) and final_status.startswith("completed") else "not_completed",
         "failureSignature": failure_signature,
+        "recoveryAttempt": validation_status == "recovery_allowed"
+        or guard_status == PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS,
+        "computeAttempted": execution.get("computeAttempted") is True,
+        "scaleOutAttempted": execution.get("scaleOutAttempted") is True,
+        "remoteTrainingAttempted": execution.get("remoteTrainingAttempted") is True,
+        "trainingReportProduced": execution.get("trainingReportProduced") is True,
+        "trainingReportPresent": training_report is not None,
+        "environmentsRun": environments_run,
+        "remoteTrainingFailureClass": remote_failure_class,
     }
+
+
+def paid_failure_post_fix_attempt_reached_compute_or_training(attempt: dict[str, Any]) -> bool:
+    environments_run = attempt.get("environmentsRun")
+    return bool(
+        attempt.get("computeAttempted") is True
+        or attempt.get("scaleOutAttempted") is True
+        or attempt.get("remoteTrainingAttempted") is True
+        or attempt.get("trainingReportProduced") is True
+        or attempt.get("trainingReportPresent") is True
+        or (isinstance(environments_run, int) and environments_run > 0)
+    )
+
+
+def paid_failure_post_fix_attempt_is_pre_scale_no_compute_admission_failure(
+    attempt: dict[str, Any],
+) -> bool:
+    final_status = text_value(attempt.get("finalStatus"))
+    environments_run = attempt.get("environmentsRun")
+    no_environments = environments_run in (None, 0)
+    return bool(
+        final_status == "failed"
+        and text_value(attempt.get("outcome")) == "not_completed"
+        and not paid_failure_post_fix_attempt_reached_compute_or_training(attempt)
+        and no_environments
+        and attempt.get("failureSignature") is None
+        and attempt.get("remoteTrainingFailureClass") is None
+    )
 
 
 def paid_failure_recurrence_next_action(
@@ -3125,6 +3252,14 @@ def paid_failure_recurrence_next_action(
         return (
             f"{base}; run exactly one bounded post-fix validation for {issue} / {pr}; "
             "if simulator_place_spawn_room_busy recurs, keep the paid recurrence guard active"
+        )
+    if status == "recovery_allowed":
+        prior = dict_value(validation.get("priorAttempt")) or {}
+        run_id = text_value(prior.get("runId")) or "the prior post-fix validation"
+        return (
+            f"{base}; one recovery validation is allowed because {run_id} failed before scale, "
+            "compute, remote training, environments, or a training report; if simulator_place_spawn_room_busy "
+            "recurs or compute starts and fails, keep the paid recurrence guard active"
         )
     if status == "available":
         return (

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -104,6 +104,13 @@ PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_REQUIRED_STATUS = "blocked_post_fix_
 PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS = "blocked_post_fix_validation_consumed"
 PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_SUPERSEDED_STATUS = "blocked_post_fix_validation_superseded"
 PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATED_STATUS = "clear_post_fix_validated"
+PAID_FAILURE_POST_FIX_NO_COMPUTE_REQUIRED_EXECUTION_FIELDS = (
+    "computeAttempted",
+    "scaleOutAttempted",
+    "remoteTrainingAttempted",
+    "trainingReportProduced",
+    "environmentsRun",
+)
 PAID_FAILURE_RECURRENCE_KNOWN_FIXES = {
     PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE: {
         "issue": "#1501",
@@ -3176,7 +3183,7 @@ def paid_failure_post_fix_validation_attempt_from_summary(
         if failure is not None:
             failure_signature = failure["signature"]
     execution_context = dict_value(summary.get("execution"))
-    execution_context_present = execution_context is not None
+    execution_context_present = paid_failure_post_fix_execution_context_complete(execution_context)
     execution = execution_context or {}
     environments_run = scale_gates.non_negative_int(execution.get("environmentsRun"))
     remote_failure = dict_value(path_value(summary, "outputs", "remoteTrainingFailure"))
@@ -3203,6 +3210,22 @@ def paid_failure_post_fix_validation_attempt_from_summary(
         "environmentsRun": environments_run,
         "remoteTrainingFailureClass": remote_failure_class,
     }
+
+
+def paid_failure_post_fix_execution_context_complete(
+    execution_context: dict[str, Any] | None,
+) -> bool:
+    if execution_context is None:
+        return False
+    if not all(
+        field in execution_context
+        for field in PAID_FAILURE_POST_FIX_NO_COMPUTE_REQUIRED_EXECUTION_FIELDS
+    ):
+        return False
+    bool_fields = PAID_FAILURE_POST_FIX_NO_COMPUTE_REQUIRED_EXECUTION_FIELDS[:-1]
+    if not all(isinstance(execution_context.get(field), bool) for field in bool_fields):
+        return False
+    return scale_gates.non_negative_int(execution_context.get("environmentsRun")) is not None
 
 
 def paid_failure_post_fix_attempt_reached_compute_or_training(attempt: dict[str, Any]) -> bool:

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -3175,7 +3175,9 @@ def paid_failure_post_fix_validation_attempt_from_summary(
         failure = paid_failure_signature_from_summary(summary)
         if failure is not None:
             failure_signature = failure["signature"]
-    execution = dict_value(summary.get("execution")) or {}
+    execution_context = dict_value(summary.get("execution"))
+    execution_context_present = execution_context is not None
+    execution = execution_context or {}
     environments_run = scale_gates.non_negative_int(execution.get("environmentsRun"))
     remote_failure = dict_value(path_value(summary, "outputs", "remoteTrainingFailure"))
     remote_failure_class = text_value(remote_failure.get("failureClass")) if remote_failure else None
@@ -3192,6 +3194,7 @@ def paid_failure_post_fix_validation_attempt_from_summary(
         "failureSignature": failure_signature,
         "recoveryAttempt": validation_status == "recovery_allowed"
         or guard_status == PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS,
+        "executionContextPresent": execution_context_present,
         "computeAttempted": execution.get("computeAttempted") is True,
         "scaleOutAttempted": execution.get("scaleOutAttempted") is True,
         "remoteTrainingAttempted": execution.get("remoteTrainingAttempted") is True,
@@ -3223,6 +3226,7 @@ def paid_failure_post_fix_attempt_is_pre_scale_no_compute_admission_failure(
     return bool(
         final_status == "failed"
         and text_value(attempt.get("outcome")) == "not_completed"
+        and attempt.get("executionContextPresent") is True
         and not paid_failure_post_fix_attempt_reached_compute_or_training(attempt)
         and no_environments
         and attempt.get("failureSignature") is None

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -4019,6 +4019,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             guard["postFixValidation"]["priorAttempt"]["runId"],
             "tencent-postfix-room-busy-v1",
         )
+        self.assertTrue(guard["postFixValidation"]["priorAttempt"]["executionContextPresent"])
         self.assertFalse(guard["postFixValidation"]["priorAttempt"]["computeAttempted"])
         self.assertFalse(guard["postFixValidation"]["priorAttempt"]["scaleOutAttempted"])
         self.assertFalse(guard["postFixValidation"]["priorAttempt"]["remoteTrainingAttempted"])
@@ -4033,6 +4034,68 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(summary["outputs"]["launchGuard"]["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS)
         self.assertEqual(summary["outputs"]["launchGuard"]["postFixValidation"]["status"], "recovery_allowed")
         self.assertTrue(summary["execution"]["computeAttempted"])
+
+    def test_paid_failure_recurrence_guard_blocks_recovery_without_prior_execution_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            prior_attempt_path = write_post_fix_validation_pre_scale_admission_failure_summary(
+                artifact_root,
+                "tencent-postfix-room-busy-v1",
+            )
+            prior_summary = json.loads(prior_attempt_path.read_text(encoding="utf-8"))
+            prior_summary.pop("execution")
+            prior_attempt_path.write_text(json.dumps(prior_summary), encoding="utf-8")
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                "500",
+                "--workers",
+                "5",
+                "--scale-environments",
+                "5",
+                "--repetitions",
+                "5",
+                "--allow-paid-failure-recurrence-validation",
+                runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertEqual(events, [])
+        self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+        self.assertTrue(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
+        self.assertEqual(guard["postFixValidation"]["status"], "consumed")
+        self.assertFalse(guard["postFixValidation"]["priorAttempt"]["executionContextPresent"])
+        self.assertFalse(guard["postFixValidation"]["recoveryEligibility"]["eligible"])
+        self.assertIn(
+            "not a pre-scale no-compute admission failure",
+            guard["postFixValidation"]["recoveryEligibility"]["reason"],
+        )
+        self.assertFalse(summary["execution"]["computeAttempted"])
 
     def test_paid_failure_recurrence_guard_blocks_recovery_without_explicit_signature(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -763,6 +763,62 @@ def write_post_fix_validation_summary(
     return summary_path
 
 
+def write_post_fix_validation_pre_scale_admission_failure_summary(
+    artifact_root: Path,
+    run_id: str,
+    *,
+    guard_status: str = runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_ALLOWED_STATUS,
+    validation_status: str = "allowed",
+) -> Path:
+    run_dir = artifact_root / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    summary = {
+        "type": "screeps-tencent-batch-rl-run",
+        "schemaVersion": 1,
+        "runId": run_id,
+        "startedAt": "2026-05-29T23:59:27Z",
+        "finishedAt": "2026-05-29T23:59:28Z",
+        "partial": False,
+        "finalStatus": "failed",
+        "execution": {
+            "command": "run-single",
+            "mode": "compute",
+            "preflightOnly": False,
+            "computeAttempted": False,
+            "scaleOutAttempted": False,
+            "remoteTrainingAttempted": False,
+            "trainingReportProduced": False,
+            "environmentsRun": 0,
+        },
+        "outputs": {
+            "error": (
+                "CardValidationError: policy-gradient requestedSamplesPerCandidate=1 "
+                "< target 20"
+            ),
+            "launchGuard": {
+                "status": guard_status,
+                "blocked": False,
+                "activeSignature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                "postFixValidation": {
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "status": validation_status,
+                    "requested": True,
+                    "knownFix": {
+                        "issue": "#1501",
+                        "pullRequest": "#1504",
+                        "mergeCommit": "95f960b2",
+                        "present": True,
+                    },
+                    "priorAttempt": None,
+                },
+            },
+        },
+    }
+    summary_path = run_dir / "controller-summary.json"
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+    return summary_path
+
+
 def set_summary_finished_at(summary_path: Path, finished_at: str) -> None:
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
     summary["finishedAt"] = finished_at
@@ -3902,7 +3958,250 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
         self.assertEqual(guard["postFixValidation"]["status"], "consumed")
         self.assertEqual(guard["postFixValidation"]["priorAttempt"]["runId"], "tencent-pg-post-fix-failed")
+        self.assertFalse(guard["postFixValidation"]["recoveryEligibility"]["eligible"])
+        self.assertIn("reached compute", guard["postFixValidation"]["recoveryEligibility"]["reason"])
         self.assertIn("already attempted", guard["nextAction"])
+        self.assertFalse(summary["execution"]["computeAttempted"])
+
+    def test_paid_failure_recurrence_guard_allows_recovery_after_pre_scale_admission_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            write_post_fix_validation_pre_scale_admission_failure_summary(
+                artifact_root,
+                "tencent-postfix-room-busy-v1",
+            )
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                "500",
+                "--workers",
+                "5",
+                "--scale-environments",
+                "5",
+                "--repetitions",
+                "5",
+                "--allow-paid-failure-recurrence-validation",
+                runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertIn("scale_up", events)
+        self.assertIn("remote_training", events)
+        self.assertFalse(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS)
+        self.assertEqual(guard["postFixValidation"]["status"], "recovery_allowed")
+        self.assertTrue(guard["postFixValidation"]["recoveryEligibility"]["eligible"])
+        self.assertEqual(
+            guard["postFixValidation"]["priorAttempt"]["runId"],
+            "tencent-postfix-room-busy-v1",
+        )
+        self.assertFalse(guard["postFixValidation"]["priorAttempt"]["computeAttempted"])
+        self.assertFalse(guard["postFixValidation"]["priorAttempt"]["scaleOutAttempted"])
+        self.assertFalse(guard["postFixValidation"]["priorAttempt"]["remoteTrainingAttempted"])
+        self.assertFalse(guard["postFixValidation"]["priorAttempt"]["trainingReportProduced"])
+        self.assertEqual(guard["postFixValidation"]["priorAttempt"]["environmentsRun"], 0)
+        self.assertEqual(
+            guard["currentLaunch"]["policyGradientTrustSampleRequest"]["requestedSamplesPerCandidate"],
+            25,
+        )
+        self.assertTrue(guard["currentLaunch"]["policyGradientTrustSampleRequest"]["meetsTrustSampleTarget"])
+        self.assertEqual(controller.final_status, "completed")
+        self.assertEqual(summary["outputs"]["launchGuard"]["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS)
+        self.assertEqual(summary["outputs"]["launchGuard"]["postFixValidation"]["status"], "recovery_allowed")
+        self.assertTrue(summary["execution"]["computeAttempted"])
+
+    def test_paid_failure_recurrence_guard_blocks_recovery_without_explicit_signature(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            write_post_fix_validation_pre_scale_admission_failure_summary(
+                artifact_root,
+                "tencent-postfix-room-busy-v1",
+            )
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                "500",
+                "--workers",
+                "5",
+                "--scale-environments",
+                "5",
+                "--repetitions",
+                "5",
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertEqual(events, [])
+        self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+        self.assertTrue(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
+        self.assertEqual(guard["postFixValidation"]["status"], "consumed")
+        self.assertFalse(guard["postFixValidation"]["recoveryEligibility"]["eligible"])
+        self.assertIn("explicit post-fix validation signature", guard["postFixValidation"]["recoveryEligibility"]["reason"])
+        self.assertFalse(summary["execution"]["computeAttempted"])
+
+    def test_paid_failure_recurrence_guard_blocks_recovery_below_trust_sample_target(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            write_post_fix_validation_pre_scale_admission_failure_summary(
+                artifact_root,
+                "tencent-postfix-room-busy-v1",
+            )
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                "500",
+                "--workers",
+                "1",
+                "--repetitions",
+                "1",
+                "--allow-paid-failure-recurrence-validation",
+                runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertEqual(events, [])
+        self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+        self.assertTrue(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
+        self.assertEqual(guard["postFixValidation"]["status"], "consumed")
+        self.assertFalse(guard["postFixValidation"]["recoveryEligibility"]["eligible"])
+        self.assertIn("below the trust gate target", guard["postFixValidation"]["recoveryEligibility"]["reason"])
+        self.assertEqual(
+            guard["postFixValidation"]["recoveryEligibility"]["policyGradientTrustSampleRequest"][
+                "requestedSamplesPerCandidate"
+            ],
+            1,
+        )
+        self.assertFalse(summary["execution"]["computeAttempted"])
+
+    def test_paid_failure_recurrence_guard_blocks_second_recovery_attempt(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            write_post_fix_validation_pre_scale_admission_failure_summary(
+                artifact_root,
+                "tencent-postfix-room-busy-recovery",
+                guard_status=runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS,
+                validation_status="recovery_allowed",
+            )
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                "500",
+                "--workers",
+                "5",
+                "--scale-environments",
+                "5",
+                "--repetitions",
+                "5",
+                "--allow-paid-failure-recurrence-validation",
+                runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertEqual(events, [])
+        self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+        self.assertTrue(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
+        self.assertEqual(guard["postFixValidation"]["status"], "consumed")
+        self.assertTrue(guard["postFixValidation"]["priorAttempt"]["recoveryAttempt"])
+        self.assertFalse(guard["postFixValidation"]["recoveryEligibility"]["eligible"])
+        self.assertIn("recovery was already attempted", guard["postFixValidation"]["recoveryEligibility"]["reason"])
         self.assertFalse(summary["execution"]["computeAttempted"])
 
     def test_paid_failure_recurrence_guard_blocks_second_validation_past_recent_summary_limit(self) -> None:

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -4097,6 +4097,85 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         )
         self.assertFalse(summary["execution"]["computeAttempted"])
 
+    def test_paid_failure_recurrence_guard_blocks_recovery_with_incomplete_prior_execution_metadata(self) -> None:
+        cases: list[tuple[str, str | None]] = [("empty execution", None)]
+        cases.extend(
+            (f"missing {field}", field)
+            for field in runner.PAID_FAILURE_POST_FIX_NO_COMPUTE_REQUIRED_EXECUTION_FIELDS
+        )
+
+        for case_name, missing_field in cases:
+            with self.subTest(case=case_name):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    artifact_root = Path(temp_dir) / "batch-runs"
+                    for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                        write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+                    prior_attempt_path = write_post_fix_validation_pre_scale_admission_failure_summary(
+                        artifact_root,
+                        "tencent-postfix-room-busy-v1",
+                    )
+                    prior_summary = json.loads(prior_attempt_path.read_text(encoding="utf-8"))
+                    if missing_field is None:
+                        prior_summary["execution"] = {}
+                    else:
+                        execution = prior_summary["execution"]
+                        self.assertIsInstance(execution, dict)
+                        execution.pop(missing_field, None)
+                    prior_attempt_path.write_text(json.dumps(prior_summary), encoding="utf-8")
+                    args = runner.parse_cli_args([
+                        "run-single",
+                        "--run-id",
+                        "new-run",
+                        "--artifact-root",
+                        str(artifact_root),
+                        "--training-approach",
+                        "policy_gradient",
+                        "--scenario-id",
+                        runner.MULTI_TIER_SCENARIO_ID,
+                        "--ticks",
+                        "500",
+                        "--workers",
+                        "5",
+                        "--scale-environments",
+                        "5",
+                        "--repetitions",
+                        "5",
+                        "--allow-paid-failure-recurrence-validation",
+                        runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    ])
+                    artifact_dir = artifact_root / "new-run"
+
+                    with mock.patch.object(
+                        runner,
+                        "paid_failure_recurrence_known_fix_status",
+                        return_value={
+                            "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                            "issue": "#1501",
+                            "pullRequest": "#1504",
+                            "mergeCommit": "95f960b2",
+                            "present": True,
+                            "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                        },
+                    ):
+                        events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+                self.assertEqual(events, [])
+                self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+                self.assertTrue(guard["blocked"])
+                self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
+                self.assertNotEqual(
+                    guard["status"],
+                    runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS,
+                )
+                self.assertEqual(guard["postFixValidation"]["status"], "consumed")
+                self.assertFalse(guard["postFixValidation"]["priorAttempt"]["executionContextPresent"])
+                self.assertFalse(guard["postFixValidation"]["recoveryEligibility"]["eligible"])
+                self.assertIn(
+                    "not a pre-scale no-compute admission failure",
+                    guard["postFixValidation"]["recoveryEligibility"]["reason"],
+                )
+                self.assertFalse(summary["execution"]["computeAttempted"])
+
     def test_paid_failure_recurrence_guard_blocks_recovery_without_explicit_signature(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             artifact_root = Path(temp_dir) / "batch-runs"


### PR DESCRIPTION
## Summary

- Adds a trust-compatible recovery path for the Tencent paid-failure recurrence guard when a prior post-fix validation admission was consumed by a pre-scale/no-compute failure.
- Requires the retry to be explicit for `simulator_place_spawn_room_busy` and to meet the policy-gradient trust sample floor before allowing one additional validation.
- Preserves the hard guard by rejecting low-sample retries, missing explicit signatures, and any second recovery attempt.

## Verification

- `git diff --check`
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts/test_screeps_tencent_batch_rl_runner.py -v` — 154 tests OK

## Issue linkage

Related to issue 1501.

The issue stays open until a later Tencent validation produces landing evidence: room-busy failures = 0, `environmentsRun > 0`, `trainingReportProduced = true`, runtime-parameter consumption, and ASG scale-down proof.

## Universal task Done gate

- [x] Task type: code/test guard recovery for RL Tencent batch validation admission.
- [x] Expected observable outcome / named deliverable: one bounded recovery admission is available only for a no-compute pre-scale consumed validation, with tests for allowed and rejected paths.
- [x] Non-goals / accepted substitutes: this PR does not launch paid compute and leaves external Tencent validation under issue 1501.
- [x] Verification evidence required before Done: controller verification passed `git diff --check`, `py_compile`, and 154-runner unittests.
- [x] Project Evidence / Next action / Blocked by: Project fields cite PR 1512, commit 5629cb7e, controller verification, and the external validation criterion for issue 1501.
- [x] Post-merge/deploy/runtime proof: external Tencent proof for issue 1501 is defined in the issue and Project; this code PR supplies source and test recovery.
- [x] Named deliverable proof: commit `5629cb7e` changes only `scripts/screeps_tencent_batch_rl_runner.py` and `scripts/test_screeps_tencent_batch_rl_runner.py`.
