### PR TITLE
fix: pause optional CPU work during low-bucket recovery

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -21080,7 +21080,7 @@ function shouldRunOptionalCpuWork(budget, key, interval = DEGRADED_OPTIONAL_WORK
   if (!budget.degraded) {
     return true;
   }
-  if (budget.critical) {
+  if (budget.critical || hasLowBucketPressure(budget)) {
     return false;
   }
   return isCadenceTick(budget.tick, key, interval);
@@ -21089,13 +21089,16 @@ function shouldRunOptionalCpuRoomWork(budget, roomName, interval = DEGRADED_ROOM
   if (!budget.degraded) {
     return true;
   }
-  if (budget.critical) {
+  if (budget.critical || hasLowBucketPressure(budget)) {
     return false;
   }
   return isCadenceTick(budget.tick, roomName, interval);
 }
 function shouldThrottleRuntimeSummaryCadence(budget) {
   return budget.degraded;
+}
+function hasLowBucketPressure(budget) {
+  return budget.reasons.includes("lowBucket") || budget.reasons.includes("criticalBucket");
 }
 function updateRuntimeCpuTelemetryState(sample) {
   resetRuntimeCpuTelemetryStateForTick(sample.tick);

--- a/prod/src/runtime/cpuBudget.ts
+++ b/prod/src/runtime/cpuBudget.ts
@@ -162,7 +162,7 @@ export function shouldRunOptionalCpuWork(
     return true;
   }
 
-  if (budget.critical) {
+  if (budget.critical || hasLowBucketPressure(budget)) {
     return false;
   }
 
@@ -178,7 +178,7 @@ export function shouldRunOptionalCpuRoomWork(
     return true;
   }
 
-  if (budget.critical) {
+  if (budget.critical || hasLowBucketPressure(budget)) {
     return false;
   }
 
@@ -195,6 +195,10 @@ export function resetRuntimeCpuTelemetryForTesting(): void {
     bucketEmptyTicks: 0,
     overLimitTicks: 0
   };
+}
+
+function hasLowBucketPressure(budget: RuntimeCpuBudget): boolean {
+  return budget.reasons.includes('lowBucket') || budget.reasons.includes('criticalBucket');
 }
 
 function updateRuntimeCpuTelemetryState(sample: RuntimeCpuSample): RuntimeCpuTelemetryState {

--- a/prod/test/cpuBudget.test.ts
+++ b/prod/test/cpuBudget.test.ts
@@ -3,6 +3,7 @@ import {
   buildRuntimeCpuTelemetrySummary,
   getRuntimeCpuBudget,
   resetRuntimeCpuTelemetryForTesting,
+  shouldRunOptionalCpuWork,
   shouldRunOptionalCpuRoomWork,
   shouldThrottleRuntimeSummaryCadence
 } from '../src/runtime/cpuBudget';
@@ -82,6 +83,45 @@ describe('runtime CPU budget policy', () => {
       reasons: ['criticalBucket']
     });
     expect(shouldThrottleRuntimeSummaryCadence(budget)).toBe(true);
+  });
+
+  it('keeps optional work paused throughout low-bucket recovery on otherwise healthy CPU accounts', () => {
+    const decisions = [1, 2, 3, 4, 5, 6].map((tick) => {
+      const budget = buildRuntimeCpuBudget({
+        tick,
+        used: 18,
+        limit: 70,
+        bucket: 500,
+        tickLimit: 500
+      });
+
+      return {
+        global: shouldRunOptionalCpuWork(budget, 'economy-global-optional'),
+        room: shouldRunOptionalCpuRoomWork(budget, 'E29N55')
+      };
+    });
+
+    expect(
+      buildRuntimeCpuBudget({
+        tick: 1,
+        used: 18,
+        limit: 70,
+        bucket: 500,
+        tickLimit: 500
+      })
+    ).toMatchObject({
+      pressure: 'degraded',
+      degraded: true,
+      critical: false,
+      lowCpuLimit: false,
+      reasons: ['lowBucket']
+    });
+    expect(decisions).toEqual(
+      expect.arrayContaining([
+        { global: false, room: false }
+      ])
+    );
+    expect(decisions.every((decision) => decision.global === false && decision.room === false)).toBe(true);
   });
 
   it('refreshes CPU used samples during the same game tick', () => {


### PR DESCRIPTION
## Summary

- Keeps global and per-room optional CPU work paused while the runtime CPU budget is in low-bucket recovery, even when current tick CPU usage/limit looks otherwise healthy.
- Adds a regression test for the low-bucket degraded-but-not-critical case so optional work stays off across recovery ticks.
- Rebuilds `prod/dist/main.js` from the updated source.

## Verification

Controller verification after reconciling current `origin/main`:

- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` — 103 suites / 2105 tests passed
- `npm run build`

## Issue linkage

Related to issue 1490.

The issue stays open until official MMO post-deploy runtime evidence shows the CPU bucket recurrence cleared and no survival/build regressions appear.

## Runtime / deployment note

This changes official-runtime `prod/` code and generated bundle output. If merged, the deployment floor must run the official MMO deploy workflow for `main` and collect post-deploy runtime-summary/runtime-alert/CPU-bearing evidence before marking the runtime incident accepted.

## Universal task Done gate

- [x] Task type: production code/test hotfix for runtime CPU safety.
- [x] Expected observable outcome / named deliverable: optional CPU work remains paused during low-bucket recovery until bucket pressure clears.
- [x] Non-goals / accepted substitutes: this PR keeps issue 1490 open for runtime acceptance and makes no runtime-acceptance claim without post-deploy monitor proof.
- [x] Verification evidence required before Done: controller verification passed `git diff --check`, `npm run typecheck`, `npm test -- --runInBand`, and `npm run build`.
- [x] Project Evidence / Next action / Blocked by: Project fields must cite this PR, commit `d89e87a6`, the full verification bundle, and post-merge official deploy + CPU-bearing acceptance as the next action.
- [x] Post-merge/deploy/runtime proof: external acceptance criterion is official MMO deploy plus fresh runtime alert/summary proof that CPU bucket is no longer critical; this PR deliverable is the verified source/test hotfix.
- [x] Named deliverable proof: commit `d89e87a6` changes `prod/src/runtime/cpuBudget.ts`, `prod/test/cpuBudget.test.ts`, and regenerated `prod/dist/main.js`.

