### PR TITLE
fix: shed optional work under empty CPU bucket

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -21016,6 +21016,12 @@ function getRuntimeCpuBudget(game) {
   const runtimeGame = game != null ? game : getRuntimeGame();
   return buildRuntimeCpuBudget(readRuntimeCpuSample(runtimeGame));
 }
+function isRuntimeCpuBucketCritical(game) {
+  var _a;
+  const runtimeGame = game != null ? game : getRuntimeGame();
+  const bucket = (_a = runtimeGame == null ? void 0 : runtimeGame.cpu) == null ? void 0 : _a.bucket;
+  return typeof bucket === "number" && Number.isFinite(bucket) && bucket <= CRITICAL_CPU_BUCKET_THRESHOLD;
+}
 function buildRuntimeCpuBudget(sample) {
   const reasons = [];
   const lowCpuLimit = sample.limit !== void 0 && sample.limit <= LOW_CPU_ACCOUNT_LIMIT;
@@ -21598,6 +21604,9 @@ var BEHAVIOR_COUNTER_KEYS = [
 var TOP_IDLE_WORKER_COUNT = 3;
 function observeCreepBehaviorTick(creep, tick = getGameTime24()) {
   var _a, _b;
+  if (isRuntimeCpuBucketCritical()) {
+    return;
+  }
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastObservedTick === tick) {
     return;
@@ -21618,6 +21627,9 @@ function observeCreepBehaviorTick(creep, tick = getGameTime24()) {
 }
 function recordCreepBehaviorIdle(creep, tick = getGameTime24()) {
   var _a;
+  if (isRuntimeCpuBucketCritical()) {
+    return;
+  }
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastIdleTick === tick) {
     return;
@@ -21627,6 +21639,9 @@ function recordCreepBehaviorIdle(creep, tick = getGameTime24()) {
 }
 function recordCreepBehaviorMove(creep, tick = getGameTime24()) {
   var _a;
+  if (isRuntimeCpuBucketCritical()) {
+    return;
+  }
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastMoveTick === tick) {
     return;
@@ -21636,6 +21651,9 @@ function recordCreepBehaviorMove(creep, tick = getGameTime24()) {
 }
 function recordCreepBehaviorWork(creep, tick = getGameTime24()) {
   var _a;
+  if (isRuntimeCpuBucketCritical()) {
+    return;
+  }
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastWorkTick === tick) {
     return;
@@ -21644,15 +21662,24 @@ function recordCreepBehaviorWork(creep, tick = getGameTime24()) {
   telemetry.lastWorkTick = tick;
 }
 function recordCreepBehaviorRepairTarget(creep, targetId) {
+  if (isRuntimeCpuBucketCritical()) {
+    return;
+  }
   ensureCreepBehaviorTelemetry(creep).repairTargetId = targetId;
 }
 function recordCreepBehaviorContainerTransfer(creep) {
   var _a;
+  if (isRuntimeCpuBucketCritical()) {
+    return;
+  }
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   telemetry.containerTransfers = ((_a = telemetry.containerTransfers) != null ? _a : 0) + 1;
 }
 function recordCreepBehaviorSourceContainerWithdrawal(creep, tick = getGameTime24()) {
   var _a;
+  if (isRuntimeCpuBucketCritical()) {
+    return;
+  }
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastSourceContainerWithdrawalTick === tick) {
     return;
@@ -21662,6 +21689,9 @@ function recordCreepBehaviorSourceContainerWithdrawal(creep, tick = getGameTime2
 }
 function recordCreepBehaviorEnergyAcquisition(creep, method) {
   var _a;
+  if (isRuntimeCpuBucketCritical()) {
+    return;
+  }
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   const key = getEnergyAcquisitionCounterKey(method);
   telemetry[key] = ((_a = telemetry[key]) != null ? _a : 0) + 1;
@@ -31359,6 +31389,9 @@ function runWorker(creep) {
   executeAssignedTask(creep, selectedTask);
 }
 function recordWorkerDispatchDiagnostic(creep, context) {
+  if (isRuntimeCpuBucketCritical()) {
+    return;
+  }
   const memory = creep.memory;
   if (!memory) {
     return;
@@ -47219,7 +47252,11 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
   }
   refreshSpawnEnergyReservationStates(colonies);
   refreshSpawnEnergyBufferStates(colonies, reservedSpawnEnergyByRoom);
+  const creepCpuBudget = getRuntimeCpuBudget();
   for (const creep of orderCreepsForEconomyTaskPriority(creeps)) {
+    if (!shouldRunCreepForCpuBudget(creep, creepCpuBudget)) {
+      continue;
+    }
     if (featureGates.labManagement && shouldYieldCreepToLabManager(creep, Game.time)) {
       continue;
     }
@@ -47281,6 +47318,38 @@ function orderCreepsForEconomyTaskPriority(creeps) {
   })).sort(
     (left, right) => left.priority - right.priority || left.index - right.index
   ).map((entry) => entry.creep);
+}
+function shouldRunCreepForCpuBudget(creep, cpuBudget) {
+  if (!cpuBudget.critical) {
+    return true;
+  }
+  const role = creep.memory.role;
+  if (role === "worker") {
+    return shouldRunWorkerForCriticalCpu(creep);
+  }
+  if (role === UPGRADER_ROLE) {
+    return isDowngradeGuardControllerCreep(creep);
+  }
+  if (role === SOURCE_HARVESTER_ROLE || role === HAULER_ROLE || role === CROSS_ROOM_HAULER_ROLE) {
+    return true;
+  }
+  return false;
+}
+function shouldRunWorkerForCriticalCpu(creep) {
+  const sustain = creep.memory.controllerSustain;
+  if ((sustain == null ? void 0 : sustain.role) === "upgrader") {
+    return isDowngradeGuardControllerCreep(creep);
+  }
+  return creep.memory.territory === void 0;
+}
+function isDowngradeGuardControllerCreep(creep) {
+  var _a, _b;
+  if (((_a = creep.memory.controllerUpgrade) == null ? void 0 : _a.priority) === "downgradeGuard") {
+    return true;
+  }
+  const controller = (_b = creep.room) == null ? void 0 : _b.controller;
+  const ticksToDowngrade = normalizeOptionalNonNegativeInteger3(controller == null ? void 0 : controller.ticksToDowngrade);
+  return (controller == null ? void 0 : controller.my) === true && ticksToDowngrade !== void 0 && ticksToDowngrade <= CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS;
 }
 function getEconomyCreepTaskPriority(creep) {
   if (!isLowRoomEnergyForWorkerTaskPriority(creep.room)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -47320,10 +47320,11 @@ function orderCreepsForEconomyTaskPriority(creeps) {
   ).map((entry) => entry.creep);
 }
 function shouldRunCreepForCpuBudget(creep, cpuBudget) {
+  var _a;
   if (!cpuBudget.critical) {
     return true;
   }
-  const role = creep.memory.role;
+  const role = (_a = creep.memory) == null ? void 0 : _a.role;
   if (role === "worker") {
     return shouldRunWorkerForCriticalCpu(creep);
   }
@@ -47336,18 +47337,19 @@ function shouldRunCreepForCpuBudget(creep, cpuBudget) {
   return false;
 }
 function shouldRunWorkerForCriticalCpu(creep) {
-  const sustain = creep.memory.controllerSustain;
-  if ((sustain == null ? void 0 : sustain.role) === "upgrader") {
-    return isDowngradeGuardControllerCreep(creep);
-  }
-  return creep.memory.territory === void 0;
-}
-function isDowngradeGuardControllerCreep(creep) {
   var _a, _b;
-  if (((_a = creep.memory.controllerUpgrade) == null ? void 0 : _a.priority) === "downgradeGuard") {
+  const sustain = (_a = creep.memory) == null ? void 0 : _a.controllerSustain;
+  if ((sustain == null ? void 0 : sustain.role) === "upgrader") {
     return true;
   }
-  const controller = (_b = creep.room) == null ? void 0 : _b.controller;
+  return ((_b = creep.memory) == null ? void 0 : _b.territory) === void 0;
+}
+function isDowngradeGuardControllerCreep(creep) {
+  var _a, _b, _c;
+  if (((_b = (_a = creep.memory) == null ? void 0 : _a.controllerUpgrade) == null ? void 0 : _b.priority) === "downgradeGuard") {
+    return true;
+  }
+  const controller = (_c = creep.room) == null ? void 0 : _c.controller;
   const ticksToDowngrade = normalizeOptionalNonNegativeInteger3(controller == null ? void 0 : controller.ticksToDowngrade);
   return (controller == null ? void 0 : controller.my) === true && ticksToDowngrade !== void 0 && ticksToDowngrade <= CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS;
 }

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -48,7 +48,7 @@ import {
   recordCreepBehaviorWork,
   type RuntimeEnergyAcquisitionMethod
 } from '../telemetry/behaviorTelemetry';
-import { getRuntimeCpuBudget } from '../runtime/cpuBudget';
+import { getRuntimeCpuBudget, isRuntimeCpuBucketCritical } from '../runtime/cpuBudget';
 import { isColonyRoomThreatened } from '../defense/colonyThreats';
 
 type TransferSinkStructureConstantGlobal =
@@ -213,6 +213,10 @@ function recordWorkerDispatchDiagnostic(
   creep: Creep,
   context: WorkerDispatchDiagnosticContext
 ): void {
+  if (isRuntimeCpuBucketCritical()) {
+    return;
+  }
+
   const memory = creep.memory;
   if (!memory) {
     return;

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -12,7 +12,11 @@ import {
 } from '../construction/claimed-room-planner';
 import { countCreepsByRole, getWorkerCapacity, type RoleCounts } from '../creeps/roleCounts';
 import { runWorker } from '../creeps/workerRunner';
-import { runUpgraderCreep, UPGRADER_ROLE } from '../creeps/upgraderRunner';
+import {
+  CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS,
+  runUpgraderCreep,
+  UPGRADER_ROLE
+} from '../creeps/upgraderRunner';
 import { SOURCE_HARVESTER_ROLE, runSourceHarvester } from '../creeps/sourceHarvester';
 import { HAULER_ROLE, runHauler } from '../creeps/hauler';
 import { REMOTE_HARVESTER_ROLE, runRemoteHarvester } from '../creeps/remoteHarvester';
@@ -358,7 +362,12 @@ export function runEconomy(
   refreshSpawnEnergyReservationStates(colonies);
   refreshSpawnEnergyBufferStates(colonies, reservedSpawnEnergyByRoom);
 
+  const creepCpuBudget = getRuntimeCpuBudget();
   for (const creep of orderCreepsForEconomyTaskPriority(creeps)) {
+    if (!shouldRunCreepForCpuBudget(creep, creepCpuBudget)) {
+      continue;
+    }
+
     if (featureGates.labManagement && shouldYieldCreepToLabManager(creep, Game.time)) {
       continue;
     }
@@ -432,6 +441,50 @@ export function orderCreepsForEconomyTaskPriority(creeps: Creep[]): Creep[] {
         left.index - right.index
     )
     .map((entry) => entry.creep);
+}
+
+export function shouldRunCreepForCpuBudget(creep: Creep, cpuBudget: RuntimeCpuBudget): boolean {
+  if (!cpuBudget.critical) {
+    return true;
+  }
+
+  const role = creep.memory.role;
+  if (role === 'worker') {
+    return shouldRunWorkerForCriticalCpu(creep);
+  }
+
+  if (role === UPGRADER_ROLE) {
+    return isDowngradeGuardControllerCreep(creep);
+  }
+
+  if (role === SOURCE_HARVESTER_ROLE || role === HAULER_ROLE || role === CROSS_ROOM_HAULER_ROLE) {
+    return true;
+  }
+
+  return false;
+}
+
+function shouldRunWorkerForCriticalCpu(creep: Creep): boolean {
+  const sustain = creep.memory.controllerSustain;
+  if (sustain?.role === 'upgrader') {
+    return isDowngradeGuardControllerCreep(creep);
+  }
+
+  return creep.memory.territory === undefined;
+}
+
+function isDowngradeGuardControllerCreep(creep: Creep): boolean {
+  if (creep.memory.controllerUpgrade?.priority === 'downgradeGuard') {
+    return true;
+  }
+
+  const controller = creep.room?.controller;
+  const ticksToDowngrade = normalizeOptionalNonNegativeInteger(controller?.ticksToDowngrade);
+  return (
+    controller?.my === true &&
+    ticksToDowngrade !== undefined &&
+    ticksToDowngrade <= CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS
+  );
 }
 
 function getEconomyCreepTaskPriority(creep: Creep): number {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -448,7 +448,7 @@ export function shouldRunCreepForCpuBudget(creep: Creep, cpuBudget: RuntimeCpuBu
     return true;
   }
 
-  const role = creep.memory.role;
+  const role = creep.memory?.role;
   if (role === 'worker') {
     return shouldRunWorkerForCriticalCpu(creep);
   }
@@ -465,16 +465,16 @@ export function shouldRunCreepForCpuBudget(creep: Creep, cpuBudget: RuntimeCpuBu
 }
 
 function shouldRunWorkerForCriticalCpu(creep: Creep): boolean {
-  const sustain = creep.memory.controllerSustain;
+  const sustain = creep.memory?.controllerSustain;
   if (sustain?.role === 'upgrader') {
-    return isDowngradeGuardControllerCreep(creep);
+    return true;
   }
 
-  return creep.memory.territory === undefined;
+  return creep.memory?.territory === undefined;
 }
 
 function isDowngradeGuardControllerCreep(creep: Creep): boolean {
-  if (creep.memory.controllerUpgrade?.priority === 'downgradeGuard') {
+  if (creep.memory?.controllerUpgrade?.priority === 'downgradeGuard') {
     return true;
   }
 

--- a/prod/src/runtime/cpuBudget.ts
+++ b/prod/src/runtime/cpuBudget.ts
@@ -72,6 +72,12 @@ export function getRuntimeCpuBudget(game?: RuntimeGameLike): RuntimeCpuBudget {
   return buildRuntimeCpuBudget(readRuntimeCpuSample(runtimeGame));
 }
 
+export function isRuntimeCpuBucketCritical(game?: RuntimeGameLike): boolean {
+  const runtimeGame = game ?? getRuntimeGame();
+  const bucket = runtimeGame?.cpu?.bucket;
+  return typeof bucket === 'number' && Number.isFinite(bucket) && bucket <= CRITICAL_CPU_BUCKET_THRESHOLD;
+}
+
 export function buildRuntimeCpuBudget(sample: RuntimeCpuSample): RuntimeCpuBudget {
   const reasons: RuntimeCpuPressureReason[] = [];
   const lowCpuLimit = sample.limit !== undefined && sample.limit <= LOW_CPU_ACCOUNT_LIMIT;

--- a/prod/src/telemetry/behaviorTelemetry.ts
+++ b/prod/src/telemetry/behaviorTelemetry.ts
@@ -1,3 +1,5 @@
+import { isRuntimeCpuBucketCritical } from '../runtime/cpuBudget';
+
 export interface RuntimeCreepBehaviorSummary {
   creepName?: string;
   idleTicks: number;
@@ -71,6 +73,10 @@ const BEHAVIOR_COUNTER_KEYS: CreepBehaviorCounterKey[] = [
 const TOP_IDLE_WORKER_COUNT = 3;
 
 export function observeCreepBehaviorTick(creep: Creep, tick: number = getGameTime()): void {
+  if (isRuntimeCpuBucketCritical()) {
+    return;
+  }
+
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastObservedTick === tick) {
     return;
@@ -93,6 +99,10 @@ export function observeCreepBehaviorTick(creep: Creep, tick: number = getGameTim
 }
 
 export function recordCreepBehaviorIdle(creep: Creep, tick: number = getGameTime()): void {
+  if (isRuntimeCpuBucketCritical()) {
+    return;
+  }
+
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastIdleTick === tick) {
     return;
@@ -103,6 +113,10 @@ export function recordCreepBehaviorIdle(creep: Creep, tick: number = getGameTime
 }
 
 export function recordCreepBehaviorMove(creep: Creep, tick: number = getGameTime()): void {
+  if (isRuntimeCpuBucketCritical()) {
+    return;
+  }
+
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastMoveTick === tick) {
     return;
@@ -113,6 +127,10 @@ export function recordCreepBehaviorMove(creep: Creep, tick: number = getGameTime
 }
 
 export function recordCreepBehaviorWork(creep: Creep, tick: number = getGameTime()): void {
+  if (isRuntimeCpuBucketCritical()) {
+    return;
+  }
+
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastWorkTick === tick) {
     return;
@@ -123,15 +141,27 @@ export function recordCreepBehaviorWork(creep: Creep, tick: number = getGameTime
 }
 
 export function recordCreepBehaviorRepairTarget(creep: Creep, targetId: string): void {
+  if (isRuntimeCpuBucketCritical()) {
+    return;
+  }
+
   ensureCreepBehaviorTelemetry(creep).repairTargetId = targetId;
 }
 
 export function recordCreepBehaviorContainerTransfer(creep: Creep): void {
+  if (isRuntimeCpuBucketCritical()) {
+    return;
+  }
+
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   telemetry.containerTransfers = (telemetry.containerTransfers ?? 0) + 1;
 }
 
 export function recordCreepBehaviorSourceContainerWithdrawal(creep: Creep, tick: number = getGameTime()): void {
+  if (isRuntimeCpuBucketCritical()) {
+    return;
+  }
+
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastSourceContainerWithdrawalTick === tick) {
     return;
@@ -145,6 +175,10 @@ export function recordCreepBehaviorEnergyAcquisition(
   creep: Creep,
   method: RuntimeEnergyAcquisitionMethod
 ): void {
+  if (isRuntimeCpuBucketCritical()) {
+    return;
+  }
+
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   const key = getEnergyAcquisitionCounterKey(method);
   telemetry[key] = (telemetry[key] ?? 0) + 1;

--- a/prod/test/cpuBudget.test.ts
+++ b/prod/test/cpuBudget.test.ts
@@ -2,6 +2,7 @@ import {
   buildRuntimeCpuBudget,
   buildRuntimeCpuTelemetrySummary,
   getRuntimeCpuBudget,
+  isRuntimeCpuBucketCritical,
   resetRuntimeCpuTelemetryForTesting,
   shouldRunOptionalCpuWork,
   shouldRunOptionalCpuRoomWork,
@@ -151,6 +152,23 @@ describe('runtime CPU budget policy', () => {
       sample: expect.objectContaining({ used: 71 })
     });
     expect(getUsed).toHaveBeenCalledTimes(2);
+  });
+
+  it('detects critical bucket pressure without sampling CPU used', () => {
+    const getUsed = jest.fn().mockReturnValue(21);
+
+    expect(
+      isRuntimeCpuBucketCritical({
+        time: 124,
+        cpu: {
+          getUsed,
+          limit: 70,
+          bucket: 1,
+          tickLimit: 500
+        }
+      })
+    ).toBe(true);
+    expect(getUsed).not.toHaveBeenCalled();
   });
 
   it('alerts on repeated empty bucket and sustained used-over-limit samples', () => {

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -1,8 +1,10 @@
 import {
   compareSpawnSourceRouteDistances,
   orderCreepsForEconomyTaskPriority,
-  runEconomy
+  runEconomy,
+  shouldRunCreepForCpuBudget
 } from '../src/economy/economyLoop';
+import { buildRuntimeCpuBudget } from '../src/runtime/cpuBudget';
 import { SPAWN_ENERGY_RESERVATION_IDLE_RELEASE_TICKS } from '../src/economy/spawnEnergyReservation';
 import { MIN_SPAWN_ENERGY_BUFFER } from '../src/spawn/spawnConfig';
 import { CONTROLLER_DOWNGRADE_GUARD_TICKS } from '../src/tasks/workerTasks';
@@ -102,6 +104,71 @@ describe('runEconomy', () => {
       'Second',
       'Third'
     ]);
+  });
+
+  it('sheds optional creep roles under critical CPU bucket pressure', () => {
+    const criticalBudget = buildRuntimeCpuBudget({
+      tick: 125,
+      used: 21,
+      limit: 70,
+      bucket: 1,
+      tickLimit: 500
+    });
+    const stableRoom = {
+      name: 'W1N1',
+      controller: { my: true, ticksToDowngrade: 10_000 } as StructureController
+    } as Room;
+    const downgradeRoom = {
+      name: 'W1N1',
+      controller: { my: true, ticksToDowngrade: 1_000 } as StructureController
+    } as Room;
+    const creep = (
+      role: string,
+      memory: Partial<CreepMemory> = {},
+      room: Room = stableRoom
+    ): Creep => ({ memory: { role, ...memory }, room }) as unknown as Creep;
+
+    expect(shouldRunCreepForCpuBudget(creep('worker'), criticalBudget)).toBe(true);
+    expect(
+      shouldRunCreepForCpuBudget(
+        creep('worker', { spawnSupport: { originRoom: 'W1N1', targetRoom: 'W2N1' } }),
+        criticalBudget
+      )
+    ).toBe(true);
+    expect(shouldRunCreepForCpuBudget(creep('sourceHarvester'), criticalBudget)).toBe(true);
+    expect(shouldRunCreepForCpuBudget(creep('hauler'), criticalBudget)).toBe(true);
+    expect(shouldRunCreepForCpuBudget(creep('crossRoomHauler'), criticalBudget)).toBe(true);
+    expect(
+      shouldRunCreepForCpuBudget(
+        creep('upgrader', {
+          controllerUpgrade: {
+            roomName: 'W1N1',
+            controllerId: 'controller1' as Id<StructureController>,
+            priority: 'downgradeGuard'
+          }
+        }),
+        criticalBudget
+      )
+    ).toBe(true);
+    expect(shouldRunCreepForCpuBudget(creep('upgrader', {}, downgradeRoom), criticalBudget)).toBe(true);
+
+    expect(shouldRunCreepForCpuBudget(creep('upgrader'), criticalBudget)).toBe(false);
+    expect(
+      shouldRunCreepForCpuBudget(
+        creep('worker', { controllerSustain: { homeRoom: 'W1N1', targetRoom: 'W2N1', role: 'upgrader' } }),
+        criticalBudget
+      )
+    ).toBe(false);
+    expect(
+      shouldRunCreepForCpuBudget(
+        creep('worker', { territory: { targetRoom: 'W2N1', action: 'reserve' } }),
+        criticalBudget
+      )
+    ).toBe(false);
+    expect(shouldRunCreepForCpuBudget(creep('remoteHarvester'), criticalBudget)).toBe(false);
+    expect(shouldRunCreepForCpuBudget(creep('mineralHarvester'), criticalBudget)).toBe(false);
+    expect(shouldRunCreepForCpuBudget(creep('claimer'), criticalBudget)).toBe(false);
+    expect(shouldRunCreepForCpuBudget(creep('scout'), criticalBudget)).toBe(false);
   });
 
   it('spawns a worker request for an owned colony below target workers', () => {

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -5,6 +5,7 @@ import {
   shouldRunCreepForCpuBudget
 } from '../src/economy/economyLoop';
 import { buildRuntimeCpuBudget } from '../src/runtime/cpuBudget';
+import { CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS } from '../src/creeps/upgraderRunner';
 import { SPAWN_ENERGY_RESERVATION_IDLE_RELEASE_TICKS } from '../src/economy/spawnEnergyReservation';
 import { MIN_SPAWN_ENERGY_BUFFER } from '../src/spawn/spawnConfig';
 import { CONTROLLER_DOWNGRADE_GUARD_TICKS } from '../src/tasks/workerTasks';
@@ -116,11 +117,11 @@ describe('runEconomy', () => {
     });
     const stableRoom = {
       name: 'W1N1',
-      controller: { my: true, ticksToDowngrade: 10_000 } as StructureController
+      controller: { my: true, ticksToDowngrade: CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS + 1 } as StructureController
     } as Room;
     const downgradeRoom = {
       name: 'W1N1',
-      controller: { my: true, ticksToDowngrade: 1_000 } as StructureController
+      controller: { my: true, ticksToDowngrade: CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS } as StructureController
     } as Room;
     const creep = (
       role: string,
@@ -151,14 +152,14 @@ describe('runEconomy', () => {
       )
     ).toBe(true);
     expect(shouldRunCreepForCpuBudget(creep('upgrader', {}, downgradeRoom), criticalBudget)).toBe(true);
+    expect(shouldRunCreepForCpuBudget(creep('upgrader', {}, stableRoom), criticalBudget)).toBe(false);
 
-    expect(shouldRunCreepForCpuBudget(creep('upgrader'), criticalBudget)).toBe(false);
     expect(
       shouldRunCreepForCpuBudget(
         creep('worker', { controllerSustain: { homeRoom: 'W1N1', targetRoom: 'W2N1', role: 'upgrader' } }),
         criticalBudget
       )
-    ).toBe(false);
+    ).toBe(true);
     expect(
       shouldRunCreepForCpuBudget(
         creep('worker', { territory: { targetRoom: 'W2N1', action: 'reserve' } }),

--- a/prod/test/hauler.test.ts
+++ b/prod/test/hauler.test.ts
@@ -64,6 +64,32 @@ describe('runHauler', () => {
     expect(creep.memory.behaviorTelemetry).toMatchObject({ energyAcquisitionWithdrawn: 1 });
   });
 
+  it('skips behavior telemetry writes under critical CPU bucket pressure', () => {
+    const assignedContainer = makeStoreStructure('container1', STRUCTURE_CONTAINER, 100, 0);
+    const richContainer = makeStoreStructure('container-rich', STRUCTURE_CONTAINER, 800, 0);
+    const remoteRoom = makeRoom('W2N1', true, [], [], [
+      assignedContainer as unknown as Structure,
+      richContainer as unknown as Structure
+    ]);
+    const creep = makeHauler(remoteRoom, 0);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: { W2N1: remoteRoom },
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(21),
+        limit: 70,
+        bucket: 1,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) => (id === 'container1' ? assignedContainer : null))
+    };
+
+    runHauler(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'withdraw', targetId: 'container-rich' });
+    expect(creep.withdraw).toHaveBeenCalledWith(richContainer, RESOURCE_ENERGY);
+    expect(creep.memory.behaviorTelemetry).toBeUndefined();
+  });
+
   it('withdraws from an overflow-risk container before richer durable storage', () => {
     const assignedContainer = makeStoreStructure('container1', STRUCTURE_CONTAINER, 100, 1_900, 2_000);
     const overflowContainer = makeStoreStructure('container-overflow', STRUCTURE_CONTAINER, 1_700, 300, 2_000);

--- a/prod/test/hauler.test.ts
+++ b/prod/test/hauler.test.ts
@@ -1,4 +1,5 @@
 import { runHauler } from '../src/creeps/hauler';
+import { CRITICAL_CPU_BUCKET_THRESHOLD } from '../src/runtime/cpuBudget';
 
 const OK_CODE = 0 as ScreepsReturnCode;
 const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
@@ -77,7 +78,7 @@ describe('runHauler', () => {
       cpu: {
         getUsed: jest.fn().mockReturnValue(21),
         limit: 70,
-        bucket: 1,
+        bucket: CRITICAL_CPU_BUCKET_THRESHOLD,
         tickLimit: 500
       } as unknown as CPU,
       getObjectById: jest.fn((id: string) => (id === 'container1' ? assignedContainer : null))


### PR DESCRIPTION
## Summary
- Implement CPU budget-aware fallback behavior for optional worker work when bucket recovery is active.
- Reduce unsafe optional-task overhead and keep critical defense/harvest tasks available under low-bucket pressure.

## Issue
- Fixes #1490

## Verification
- npm run typecheck
- npm test -- --runInBand --testPathPattern='cpuBudget|economyLoop|hauler'
- npm run build

## Universal task Done gate
- [x] Task type: P0 runtime-safety bugfix for CPU-bucket recurrence in official MMO bot execution.
- [x] Expected observable outcome / named deliverable: critical CPU-bucket execution keeps spawn/source/hauler/controller-sustain work available while shedding optional territory/mineral/scout work; bundled Screeps artifact is synchronized.
- [x] Non-goals / accepted substitutes: RL/Tencent paid validation and official MMO deployment are outside this CPU-gate code slice; release-floor issue #63 handles deploy evidence for gameplay-affecting main commits.
- [x] Verification evidence required before Done: `git diff --check`; `cd prod && npm run typecheck`; `cd prod && npm test -- --runInBand` (103 suites, 2108 tests); `cd prod && npm run build`; review-fix commit `ba003f90`.
- [x] Project Evidence / Next action / Blocked by: #1490 and PR #1514 Project items carry commit/test/review-gate evidence and exact next gate for CodeRabbit/Gemini/prod-ci review completion.
- [x] Post-merge/deploy/runtime proof: deployment-floor issue #63 owns official MMO upload evidence; CPU-bearing runtime summary/alert evidence is the operational proof surface for the merged fix.
- [x] Named deliverable proof: commit `ba003f90` updates `prod/src/economy/economyLoop.ts`, focused tests, and `prod/dist/main.js` to preserve sustain upgraders and optional-chaining CPU-gate reads under critical bucket pressure.

## Issue closure gate
- [x] #1490: code fix and review-fix evidence are in commit `ba003f90`; controller verification passed `git diff --check`, full prod typecheck, full Jest (`103 passed`, `2108 passed`), and production build, satisfying the CPU-bucket recurrence deliverable.
