### PR TITLE
fix: ignore preflight-only room-busy validation attempts

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -3145,7 +3145,7 @@ def paid_failure_post_fix_validation_attempts(
             summary_path,
             signature,
         )
-        if item is not None:
+        if item is not None and paid_failure_post_fix_attempt_consumes_validation_slot(item):
             attempts.append(item)
     return attempts
 
@@ -3185,11 +3185,17 @@ def paid_failure_post_fix_validation_attempt_from_summary(
     execution_context = dict_value(summary.get("execution"))
     execution_context_present = paid_failure_post_fix_execution_context_complete(execution_context)
     execution = execution_context or {}
+    inputs = dict_value(summary.get("inputs")) or {}
+    command = text_value(execution.get("command")) or text_value(inputs.get("command"))
+    mode = text_value(execution.get("mode")) or text_value(inputs.get("executionMode"))
+    preflight_only = execution.get("preflightOnly")
+    if not isinstance(preflight_only, bool):
+        preflight_only = inputs.get("preflightOnly") is True
     environments_run = scale_gates.non_negative_int(execution.get("environmentsRun"))
     remote_failure = dict_value(path_value(summary, "outputs", "remoteTrainingFailure"))
     remote_failure_class = text_value(remote_failure.get("failureClass")) if remote_failure else None
     training_report = dict_value(path_value(summary, "outputs", "trainingReport"))
-    return {
+    attempt = {
         "runId": run_id,
         "summaryPath": str(summary_path),
         "finishedAt": text_value(summary.get("finishedAt")),
@@ -3201,6 +3207,10 @@ def paid_failure_post_fix_validation_attempt_from_summary(
         "failureSignature": failure_signature,
         "recoveryAttempt": validation_status == "recovery_allowed"
         or guard_status == PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS,
+        "command": command,
+        "mode": mode,
+        "preflightOnly": preflight_only,
+        "runIdValid": RUN_ID_RE.fullmatch(run_id) is not None,
         "executionContextPresent": execution_context_present,
         "computeAttempted": execution.get("computeAttempted") is True,
         "scaleOutAttempted": execution.get("scaleOutAttempted") is True,
@@ -3208,8 +3218,11 @@ def paid_failure_post_fix_validation_attempt_from_summary(
         "trainingReportProduced": execution.get("trainingReportProduced") is True,
         "trainingReportPresent": training_report is not None,
         "environmentsRun": environments_run,
+        "remoteTrainingFailurePresent": remote_failure is not None,
         "remoteTrainingFailureClass": remote_failure_class,
     }
+    attempt["validationSlotConsumed"] = paid_failure_post_fix_attempt_consumes_validation_slot(attempt)
+    return attempt
 
 
 def paid_failure_post_fix_execution_context_complete(
@@ -3236,7 +3249,31 @@ def paid_failure_post_fix_attempt_reached_compute_or_training(attempt: dict[str,
         or attempt.get("remoteTrainingAttempted") is True
         or attempt.get("trainingReportProduced") is True
         or attempt.get("trainingReportPresent") is True
+        or attempt.get("remoteTrainingFailurePresent") is True
         or (isinstance(environments_run, int) and environments_run > 0)
+    )
+
+
+def paid_failure_post_fix_attempt_consumes_validation_slot(attempt: dict[str, Any]) -> bool:
+    run_id = text_value(attempt.get("runId"))
+    if run_id is None or RUN_ID_RE.fullmatch(run_id) is None:
+        return False
+    final_status = text_value(attempt.get("finalStatus"))
+    if final_status is None or final_status.startswith(("preflight", "skipped_")):
+        return False
+    if attempt.get("preflightOnly") is True:
+        return False
+    if text_value(attempt.get("command")) == "preflight":
+        return False
+    if text_value(attempt.get("mode")) == "preflight":
+        return False
+    if paid_failure_post_fix_attempt_reached_compute_or_training(attempt):
+        return True
+    return bool(
+        final_status == "failed"
+        and text_value(attempt.get("command")) == "run-single"
+        and text_value(attempt.get("mode")) == "compute"
+        and attempt.get("executionContextPresent") is True
     )
 
 

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -3269,12 +3269,15 @@ def paid_failure_post_fix_attempt_consumes_validation_slot(attempt: dict[str, An
         return False
     if paid_failure_post_fix_attempt_reached_compute_or_training(attempt):
         return True
-    return bool(
-        final_status == "failed"
-        and text_value(attempt.get("command")) == "run-single"
-        and text_value(attempt.get("mode")) == "compute"
-        and attempt.get("executionContextPresent") is True
-    )
+    if final_status != "failed":
+        return False
+    command = text_value(attempt.get("command"))
+    mode = text_value(attempt.get("mode"))
+    if command is not None and command != "run-single":
+        return False
+    if mode is not None and mode != "compute":
+        return False
+    return True
 
 
 def paid_failure_post_fix_attempt_is_pre_scale_no_compute_admission_failure(

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -3269,15 +3269,15 @@ def paid_failure_post_fix_attempt_consumes_validation_slot(attempt: dict[str, An
         return False
     if paid_failure_post_fix_attempt_reached_compute_or_training(attempt):
         return True
-    if final_status != "failed":
-        return False
     command = text_value(attempt.get("command"))
     mode = text_value(attempt.get("mode"))
     if command is not None and command != "run-single":
         return False
     if mode is not None and mode != "compute":
         return False
-    return True
+    if final_status == "unknown" and command == "run-single" and mode == "compute":
+        return True
+    return final_status == "failed"
 
 
 def paid_failure_post_fix_attempt_is_pre_scale_no_compute_admission_failure(

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -854,6 +854,20 @@ def write_post_fix_validation_preflight_admission_summary(
     return summary_path
 
 
+def write_post_fix_validation_in_progress_summary(artifact_root: Path, run_id: str) -> Path:
+    summary_path = write_post_fix_validation_pre_scale_admission_failure_summary(
+        artifact_root,
+        run_id,
+    )
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary["finishedAt"] = None
+    summary["partial"] = True
+    summary["finalStatus"] = "unknown"
+    summary["outputs"].pop("error", None)
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+    return summary_path
+
+
 def write_invalid_run_id_validation_admission_failure_summary(artifact_root: Path, run_id: str) -> Path:
     summary_path = write_post_fix_validation_pre_scale_admission_failure_summary(
         artifact_root,
@@ -4009,6 +4023,64 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertFalse(guard["postFixValidation"]["recoveryEligibility"]["eligible"])
         self.assertIn("reached compute", guard["postFixValidation"]["recoveryEligibility"]["reason"])
         self.assertIn("already attempted", guard["nextAction"])
+        self.assertFalse(summary["execution"]["computeAttempted"])
+
+    def test_paid_failure_recurrence_guard_blocks_second_post_fix_validation_while_prior_unknown(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            write_post_fix_validation_in_progress_summary(
+                artifact_root,
+                "tencent-pg-post-fix-running",
+            )
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                "500",
+                "--workers",
+                "1",
+                "--allow-paid-failure-recurrence-validation",
+                runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertEqual(events, [])
+        self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+        self.assertTrue(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
+        self.assertEqual(guard["postFixValidation"]["status"], "consumed")
+        prior_attempt = guard["postFixValidation"]["priorAttempt"]
+        self.assertEqual(prior_attempt["runId"], "tencent-pg-post-fix-running")
+        self.assertEqual(prior_attempt["finalStatus"], "unknown")
+        self.assertTrue(prior_attempt["validationSlotConsumed"])
+        self.assertFalse(guard["postFixValidation"]["recoveryEligibility"]["eligible"])
+        self.assertIn(
+            "not a pre-scale no-compute admission failure",
+            guard["postFixValidation"]["recoveryEligibility"]["reason"],
+        )
         self.assertFalse(summary["execution"]["computeAttempted"])
 
     def test_paid_failure_recurrence_guard_allows_recovery_after_pre_scale_admission_failure(self) -> None:

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -819,6 +819,54 @@ def write_post_fix_validation_pre_scale_admission_failure_summary(
     return summary_path
 
 
+def write_post_fix_validation_preflight_admission_summary(
+    artifact_root: Path,
+    run_id: str,
+    *,
+    guard_status: str = runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS,
+    validation_status: str = "recovery_allowed",
+) -> Path:
+    summary_path = write_post_fix_validation_pre_scale_admission_failure_summary(
+        artifact_root,
+        run_id,
+        guard_status=guard_status,
+        validation_status=validation_status,
+    )
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary["finalStatus"] = "preflight_ok"
+    summary["execution"] = {
+        "command": "preflight",
+        "mode": "preflight",
+        "preflightOnly": True,
+        "computeAttempted": False,
+        "scaleOutAttempted": False,
+        "remoteTrainingAttempted": False,
+        "trainingReportProduced": False,
+        "environmentsRun": 0,
+    }
+    summary["inputs"] = {
+        "command": "preflight",
+        "executionMode": "preflight",
+        "preflightOnly": True,
+    }
+    summary["outputs"].pop("error", None)
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+    return summary_path
+
+
+def write_invalid_run_id_validation_admission_failure_summary(artifact_root: Path, run_id: str) -> Path:
+    summary_path = write_post_fix_validation_pre_scale_admission_failure_summary(
+        artifact_root,
+        run_id,
+    )
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary["outputs"]["error"] = (
+        "BatchRunError: run id must be lowercase and contain only letters, numbers, dot, underscore, hyphen"
+    )
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+    return summary_path
+
+
 def set_summary_finished_at(summary_path: Path, finished_at: str) -> None:
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
     summary["finishedAt"] = finished_at
@@ -4035,7 +4083,63 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(summary["outputs"]["launchGuard"]["postFixValidation"]["status"], "recovery_allowed")
         self.assertTrue(summary["execution"]["computeAttempted"])
 
-    def test_paid_failure_recurrence_guard_blocks_recovery_without_prior_execution_metadata(self) -> None:
+    def test_paid_failure_recurrence_guard_ignores_preflight_only_recovery_admission(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            write_post_fix_validation_preflight_admission_summary(
+                artifact_root,
+                "cron-postfix-room-busy-recovery-preflight-20260530t063756z",
+            )
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                "500",
+                "--workers",
+                "5",
+                "--scale-environments",
+                "5",
+                "--repetitions",
+                "5",
+                "--allow-paid-failure-recurrence-validation",
+                runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertIn("scale_up", events)
+        self.assertIn("remote_training", events)
+        self.assertFalse(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_ALLOWED_STATUS)
+        self.assertEqual(guard["postFixValidation"]["status"], "allowed")
+        self.assertIsNone(guard["postFixValidation"]["priorAttempt"])
+        self.assertNotIn("priorAttemptCount", guard["postFixValidation"])
+        self.assertEqual(controller.final_status, "completed")
+        self.assertTrue(summary["execution"]["computeAttempted"])
+
+    def test_paid_failure_recurrence_guard_ignores_prior_without_execution_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             artifact_root = Path(temp_dir) / "batch-runs"
             for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
@@ -4084,20 +4188,16 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             ):
                 events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
 
-        self.assertEqual(events, [])
-        self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
-        self.assertTrue(guard["blocked"])
-        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
-        self.assertEqual(guard["postFixValidation"]["status"], "consumed")
-        self.assertFalse(guard["postFixValidation"]["priorAttempt"]["executionContextPresent"])
-        self.assertFalse(guard["postFixValidation"]["recoveryEligibility"]["eligible"])
-        self.assertIn(
-            "not a pre-scale no-compute admission failure",
-            guard["postFixValidation"]["recoveryEligibility"]["reason"],
-        )
-        self.assertFalse(summary["execution"]["computeAttempted"])
+        self.assertIn("scale_up", events)
+        self.assertIn("remote_training", events)
+        self.assertEqual(controller.final_status, "completed")
+        self.assertFalse(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_ALLOWED_STATUS)
+        self.assertEqual(guard["postFixValidation"]["status"], "allowed")
+        self.assertIsNone(guard["postFixValidation"]["priorAttempt"])
+        self.assertTrue(summary["execution"]["computeAttempted"])
 
-    def test_paid_failure_recurrence_guard_blocks_recovery_with_incomplete_prior_execution_metadata(self) -> None:
+    def test_paid_failure_recurrence_guard_ignores_recovery_with_incomplete_prior_execution_metadata(self) -> None:
         cases: list[tuple[str, str | None]] = [("empty execution", None)]
         cases.extend(
             (f"missing {field}", field)
@@ -4159,22 +4259,18 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                     ):
                         events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
 
-                self.assertEqual(events, [])
-                self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
-                self.assertTrue(guard["blocked"])
-                self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
+                self.assertIn("scale_up", events)
+                self.assertIn("remote_training", events)
+                self.assertEqual(controller.final_status, "completed")
+                self.assertFalse(guard["blocked"])
+                self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_ALLOWED_STATUS)
                 self.assertNotEqual(
                     guard["status"],
                     runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS,
                 )
-                self.assertEqual(guard["postFixValidation"]["status"], "consumed")
-                self.assertFalse(guard["postFixValidation"]["priorAttempt"]["executionContextPresent"])
-                self.assertFalse(guard["postFixValidation"]["recoveryEligibility"]["eligible"])
-                self.assertIn(
-                    "not a pre-scale no-compute admission failure",
-                    guard["postFixValidation"]["recoveryEligibility"]["reason"],
-                )
-                self.assertFalse(summary["execution"]["computeAttempted"])
+                self.assertEqual(guard["postFixValidation"]["status"], "allowed")
+                self.assertIsNone(guard["postFixValidation"]["priorAttempt"])
+                self.assertTrue(summary["execution"]["computeAttempted"])
 
     def test_paid_failure_recurrence_guard_blocks_recovery_without_explicit_signature(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -4293,12 +4389,17 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             artifact_root = Path(temp_dir) / "batch-runs"
             for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
                 write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
-            write_post_fix_validation_pre_scale_admission_failure_summary(
+            prior_attempt_path = write_post_fix_validation_summary(
                 artifact_root,
                 "tencent-postfix-room-busy-recovery",
-                guard_status=runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS,
-                validation_status="recovery_allowed",
+                final_status="failed",
+                failure_class=runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
             )
+            prior_summary = json.loads(prior_attempt_path.read_text(encoding="utf-8"))
+            prior_launch_guard = prior_summary["outputs"]["launchGuard"]
+            prior_launch_guard["status"] = runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS
+            prior_launch_guard["postFixValidation"]["status"] = "recovery_allowed"
+            prior_attempt_path.write_text(json.dumps(prior_summary), encoding="utf-8")
             args = runner.parse_cli_args([
                 "run-single",
                 "--run-id",
@@ -4342,9 +4443,65 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
         self.assertEqual(guard["postFixValidation"]["status"], "consumed")
         self.assertTrue(guard["postFixValidation"]["priorAttempt"]["recoveryAttempt"])
+        self.assertTrue(guard["postFixValidation"]["priorAttempt"]["computeAttempted"])
         self.assertFalse(guard["postFixValidation"]["recoveryEligibility"]["eligible"])
         self.assertIn("recovery was already attempted", guard["postFixValidation"]["recoveryEligibility"]["reason"])
         self.assertFalse(summary["execution"]["computeAttempted"])
+
+    def test_paid_failure_recurrence_guard_ignores_invalid_run_id_admission_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            write_invalid_run_id_validation_admission_failure_summary(
+                artifact_root,
+                "cron-postfix-room-busy-recovery-preflight-20260530T063739Z",
+            )
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                "500",
+                "--workers",
+                "5",
+                "--scale-environments",
+                "5",
+                "--repetitions",
+                "5",
+                "--allow-paid-failure-recurrence-validation",
+                runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertIn("scale_up", events)
+        self.assertIn("remote_training", events)
+        self.assertFalse(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_ALLOWED_STATUS)
+        self.assertEqual(guard["postFixValidation"]["status"], "allowed")
+        self.assertIsNone(guard["postFixValidation"]["priorAttempt"])
+        self.assertEqual(controller.final_status, "completed")
+        self.assertTrue(summary["execution"]["computeAttempted"])
 
     def test_paid_failure_recurrence_guard_blocks_second_validation_past_recent_summary_limit(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -4139,7 +4139,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(controller.final_status, "completed")
         self.assertTrue(summary["execution"]["computeAttempted"])
 
-    def test_paid_failure_recurrence_guard_ignores_prior_without_execution_metadata(self) -> None:
+    def test_paid_failure_recurrence_guard_blocks_legacy_run_single_failure_without_execution_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             artifact_root = Path(temp_dir) / "batch-runs"
             for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
@@ -4188,16 +4188,23 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             ):
                 events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
 
-        self.assertIn("scale_up", events)
-        self.assertIn("remote_training", events)
-        self.assertEqual(controller.final_status, "completed")
-        self.assertFalse(guard["blocked"])
-        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_ALLOWED_STATUS)
-        self.assertEqual(guard["postFixValidation"]["status"], "allowed")
-        self.assertIsNone(guard["postFixValidation"]["priorAttempt"])
-        self.assertTrue(summary["execution"]["computeAttempted"])
+        self.assertEqual(events, [])
+        self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+        self.assertTrue(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
+        self.assertEqual(guard["postFixValidation"]["status"], "consumed")
+        prior_attempt = guard["postFixValidation"]["priorAttempt"]
+        self.assertEqual(prior_attempt["runId"], "tencent-postfix-room-busy-v1")
+        self.assertFalse(prior_attempt["executionContextPresent"])
+        self.assertTrue(prior_attempt["validationSlotConsumed"])
+        self.assertFalse(guard["postFixValidation"]["recoveryEligibility"]["eligible"])
+        self.assertIn(
+            "not a pre-scale no-compute admission failure",
+            guard["postFixValidation"]["recoveryEligibility"]["reason"],
+        )
+        self.assertFalse(summary["execution"]["computeAttempted"])
 
-    def test_paid_failure_recurrence_guard_ignores_recovery_with_incomplete_prior_execution_metadata(self) -> None:
+    def test_paid_failure_recurrence_guard_blocks_recovery_with_incomplete_prior_execution_metadata(self) -> None:
         cases: list[tuple[str, str | None]] = [("empty execution", None)]
         cases.extend(
             (f"missing {field}", field)
@@ -4259,18 +4266,25 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                     ):
                         events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
 
-                self.assertIn("scale_up", events)
-                self.assertIn("remote_training", events)
-                self.assertEqual(controller.final_status, "completed")
-                self.assertFalse(guard["blocked"])
-                self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_ALLOWED_STATUS)
+                self.assertEqual(events, [])
+                self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+                self.assertTrue(guard["blocked"])
+                self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
                 self.assertNotEqual(
                     guard["status"],
                     runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS,
                 )
-                self.assertEqual(guard["postFixValidation"]["status"], "allowed")
-                self.assertIsNone(guard["postFixValidation"]["priorAttempt"])
-                self.assertTrue(summary["execution"]["computeAttempted"])
+                self.assertEqual(guard["postFixValidation"]["status"], "consumed")
+                prior_attempt = guard["postFixValidation"]["priorAttempt"]
+                self.assertEqual(prior_attempt["runId"], "tencent-postfix-room-busy-v1")
+                self.assertFalse(prior_attempt["executionContextPresent"])
+                self.assertTrue(prior_attempt["validationSlotConsumed"])
+                self.assertFalse(guard["postFixValidation"]["recoveryEligibility"]["eligible"])
+                self.assertIn(
+                    "not a pre-scale no-compute admission failure",
+                    guard["postFixValidation"]["recoveryEligibility"]["reason"],
+                )
+                self.assertFalse(summary["execution"]["computeAttempted"])
 
     def test_paid_failure_recurrence_guard_blocks_recovery_without_explicit_signature(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- Refs #1501.
- Treat preflight-only recovery/admission artifacts as non-consuming for the paid-failure recurrence post-fix validation slot.
- Ignore invalid run-id recovery attempts for slot consumption so a real `run-single` compute validation can still proceed after the room-busy fix.
- Preserve the recurrence guard for actual compute/training attempts and remote training failures.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts.test_screeps_tencent_batch_rl_runner -q` (158 tests OK)

## Universal task Done gate
- [x] Task type: P0 RL flywheel runner guard-accounting code fix.
- [x] Expected observable outcome / named deliverable: preflight-only or invalid-run-id room-busy recovery artifacts no longer consume the single post-fix validation slot; real compute validation can be admitted by the guard.
- [x] Non-goals / accepted substitutes: no paid Tencent scale-out, no issue closure, no official-MMO learned-policy rollout, and no change to the recurrence guard for real compute/training attempts.
- [x] Verification evidence required before Done: controller ran diff-check, py_compile, and the focused Tencent runner unittest file successfully on commit `85cb2af8`.
- [x] Project Evidence / Next action / Blocked by: PR and #1501 Project items should stay In review/In progress; next action is exact-head CI/review gate, then post-merge guarded validation from current main.
- [x] Post-merge/deploy/runtime proof: guarded room-busy validation proof is tracked by #1501/#879; this PR deliverable supplies the guard-accounting code and focused tests without starting paid compute or official-MMO writes.
- [x] Named deliverable proof: changed files are `scripts/screeps_tencent_batch_rl_runner.py` and `scripts/test_screeps_tencent_batch_rl_runner.py`; test coverage includes preflight-only admission, invalid run id, and actual compute/failure slot-consumption behavior.

## Safety
All changes are runner/controller-side validation accounting. The PR does not start paid compute, does not print secrets, and does not permit official MMO writes.

