### PR TITLE
fix: surface worker-carried energy in runtime summaries

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -37732,6 +37732,7 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     energyCapacity: colony.energyCapacityAvailable,
     energyBufferHealth: getRoomEnergyBufferHealth(colony.room),
     workerCount: colonyWorkers.length,
+    workerCarriedEnergy: resources.workerCarriedEnergy,
     workerAssignmentEvidenceAvailable: true,
     workerAssignmentEvidence,
     ...summarizeWorkerAssignmentBlockedRoomFields(resources.productiveEnergy),

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -274,6 +274,7 @@ interface RuntimeRoomSummary {
   cpuBucket?: number;
   energyBufferHealth: EnergyBufferHealth;
   workerCount: number;
+  workerCarriedEnergy: number;
   workerAssignmentEvidenceAvailable: true;
   workerAssignmentEvidence: RuntimeWorkerAssignmentEvidenceSummary;
   workerAssignmentBlockedDetail?: RuntimeWorkerAssignmentBlockedDetail;
@@ -964,6 +965,7 @@ function summarizeRoom(
     energyCapacity: colony.energyCapacityAvailable,
     energyBufferHealth: getRoomEnergyBufferHealth(colony.room),
     workerCount: colonyWorkers.length,
+    workerCarriedEnergy: resources.workerCarriedEnergy,
     workerAssignmentEvidenceAvailable: true,
     workerAssignmentEvidence,
     ...summarizeWorkerAssignmentBlockedRoomFields(resources.productiveEnergy),

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -104,6 +104,7 @@ describe('runtime telemetry summaries', () => {
             healthy: true
           },
           workerCount: 2,
+          workerCarriedEnergy: 60,
           workerAssignmentEvidenceAvailable: true,
           workerAssignmentEvidence: {
             source: 'runtime-summary',
@@ -1584,6 +1585,7 @@ describe('runtime telemetry summaries', () => {
 
     const payload = parseLoggedSummary();
     const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.workerCarriedEnergy).toBe(45);
     expect((room.resources as Record<string, unknown>).workerCarriedEnergy).toBe(45);
   });
 
@@ -1602,6 +1604,7 @@ describe('runtime telemetry summaries', () => {
 
     const payload = parseLoggedSummary();
     const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.workerCarriedEnergy).toBe(40);
     expect((room.resources as Record<string, unknown>).workerCarriedEnergy).toBe(40);
   });
 
@@ -1696,6 +1699,7 @@ describe('runtime telemetry summaries', () => {
 
     const payload = parseLoggedSummary();
     const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.workerCarriedEnergy).toBe(0);
     expect(room.resources).toMatchObject({
       storedEnergy: 0,
       workerCarriedEnergy: 0,

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -4612,6 +4612,7 @@ def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
     ]
     behavior_totals = behavior_pathing_totals(snapshot.info)
     assignment_blocked_fields = worker_assignment_blocked_fields(snapshot, metrics)
+    worker_carried_energy = sum(store_energy(obj) for obj in owned_creeps)
     productive_energy = {
         "pendingBuildProgress": metrics.pending_build_progress,
         "buildCarriedEnergy": metrics.build_carried_energy,
@@ -4643,6 +4644,7 @@ def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
         "cpuBucket": metrics.cpu_bucket,
         "rclLevel": metrics.rcl_level,
         "storedEnergy": metrics.stored_energy,
+        "workerCarriedEnergy": worker_carried_energy,
         "controller": metrics.controller_summary,
         "structures": {
             "extensionCount": metrics.extension_count,
@@ -4650,7 +4652,7 @@ def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
         },
         "resources": {
             "storedEnergy": metrics.stored_energy,
-            "workerCarriedEnergy": sum(store_energy(obj) for obj in owned_creeps),
+            "workerCarriedEnergy": worker_carried_energy,
             "droppedEnergy": sum(number_value(obj.get("amount")) or 0 for obj in dropped_energy),
             "sourceCount": len(sources),
             "productiveEnergy": productive_energy,

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -2375,6 +2375,7 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         )
         self.assertEqual(payload["rooms"][0]["rclLevel"], 3)
         self.assertEqual(payload["rooms"][0]["storedEnergy"], 355)
+        self.assertEqual(payload["rooms"][0]["workerCarriedEnergy"], 61)
         self.assertEqual(payload["rooms"][0]["resources"]["storedEnergy"], 355)
         self.assertEqual(payload["rooms"][0]["resources"]["workerCarriedEnergy"], 61)
         self.assertEqual(payload["rooms"][0]["resources"]["sourceCount"], 1)
@@ -2648,6 +2649,7 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
             room["taskCounts"],
             {"harvest": 0, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0, "none": 0},
         )
+        self.assertEqual(room["workerCarriedEnergy"], 48)
         self.assertEqual(room["resources"]["workerCarriedEnergy"], 48)
         self.assertEqual(room["constructionDeadlockTicks"], 0)
         self.assertNotIn("buildBlockedReason", room)


### PR DESCRIPTION
## Summary
- Refs #1517.
- Surface `workerCarriedEnergy` at the top level of runtime room summaries emitted by both in-game telemetry and the external runtime monitor.
- Keep the existing nested `resources.workerCarriedEnergy` contract intact.
- Regenerate `prod/dist/main.js` from the TypeScript source.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py`
- `python3 -m unittest scripts.test_screeps_runtime_monitor_tactical_response -q` (79 tests OK; command exited 0)
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (103 suites / 2110 tests passed)
- `cd prod && npm run build`

## Universal task Done gate
- [x] Task type: P1 RL data-quality telemetry code fix.
- [x] Expected observable outcome / named deliverable: runtime room-summary payloads expose top-level `workerCarriedEnergy` for RL data-quality gates while preserving the nested resources field.
- [x] Non-goals / accepted substitutes: no reward tuning, no paid Tencent run, no issue closure from PR creation alone, and no learned-policy official-MMO rollout.
- [x] Verification evidence required before Done: controller ran diff-check, py_compile, focused runtime monitor unittest, prod typecheck, full Jest, and prod build successfully on commit `1c323fd9`.
- [x] Project Evidence / Next action / Blocked by: PR and #1517 Project items should remain In review/In progress; next action is exact-head CI/review gate, then merge/deploy/observe fresh runtime-summary-console output.
- [x] Post-merge/deploy/runtime proof: runtime-summary-console proof is tracked by #1517/#879; this PR deliverable supplies the telemetry mirror in source, monitor, tests, and regenerated bundle without starting paid compute or official-MMO learned-policy writes.
- [x] Named deliverable proof: changed files are `prod/src/telemetry/runtimeSummary.ts`, `prod/test/runtimeSummary.test.ts`, `prod/dist/main.js`, `scripts/screeps-runtime-monitor.py`, and `scripts/test_screeps_runtime_monitor_tactical_response.py`.

## Safety
This only adds/mirrors telemetry fields. It does not start paid compute, does not print secrets, and does not permit official MMO learned-policy writes.

