### PR TITLE
fix: fail fast on RL room-busy validation timeouts

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -207,6 +207,11 @@ REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RE = re.compile(
     r"(?:place-spawn room busy after \d+ attempt\(s\)|\bplace_spawn_room_busy\b|room-busy placement lock)",
     re.IGNORECASE,
 )
+REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RETRY_RE = re.compile(
+    r"place-spawn room busy;\s*retrying\b",
+    re.IGNORECASE,
+)
+REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RETRY_THRESHOLD = 2
 REMOTE_NETWORK_RE = re.compile(
     r"(?:connection refused|request canceled|too many requests|toomanyrequests|network .*timed? out|"
     r"net/http|Client\.Timeout)",
@@ -2479,6 +2484,8 @@ def classify_remote_training_failure(
         return "simulator_resource_guard_rejected"
     if REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RE.search(diagnostic_text):
         return "simulator_place_spawn_room_busy"
+    if controller_timed_out and simulator_place_spawn_room_busy_retry_loop(diagnostic_text):
+        return "simulator_place_spawn_room_busy"
     if process_failure_class in {"network_unreachable", "host_key_self_healing_failed", "host_key_mismatch"}:
         return process_failure_class
     simulator_setup_text = "\n".join(
@@ -2512,6 +2519,11 @@ def classify_remote_training_failure(
     return "remote_process_failed"
 
 
+def simulator_place_spawn_room_busy_retry_loop(text: str) -> bool:
+    retry_count = len(REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RETRY_RE.findall(text))
+    return retry_count >= REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RETRY_THRESHOLD
+
+
 def remote_training_failure_next_action(failure_class: str) -> str | None:
     if failure_class == "simulator_setup_retryable":
         return (
@@ -2527,7 +2539,8 @@ def remote_training_failure_next_action(failure_class: str) -> str | None:
         )
     if failure_class == "simulator_place_spawn_room_busy":
         return (
-            "inspect private-simulator reset/import room state and place-spawn diagnostics; "
+            "inspect private-simulator reset/import room state and place-spawn diagnostics, "
+            "then ship a local code/diagnostic fix; "
             "do not rerun paid validation unchanged until the room-busy placement lock is explained"
         )
     return None
@@ -3339,7 +3352,7 @@ def paid_failure_recurrence_next_action(
         run_id = text_value(prior.get("runId")) or "the prior post-fix validation"
         return (
             f"{base}; post-fix validation was already attempted in {run_id} without a completed report, "
-            "so inspect that run before any further paid rerun"
+            "so inspect that run and ship a local code/diagnostic fix before any further paid rerun"
         )
     if status == "superseded":
         prior = dict_value(validation.get("priorAttempt")) or {}
@@ -3499,7 +3512,10 @@ def paid_failure_signature_from_summary(summary: dict[str, Any]) -> dict[str, st
             "diagnosticExcerpt": failure_class,
         }
     for text in iter_failure_signature_texts(summary):
-        if REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RE.search(text):
+        if (
+            REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RE.search(text)
+            or simulator_place_spawn_room_busy_retry_loop(text)
+        ):
             return {
                 "signature": PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
                 "reason": "place-spawn room busy",

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -3777,6 +3777,31 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(evidence["matchedBy"], "controller-summary diagnostic text")
         self.assertIn("place-spawn room busy after 12 attempt", evidence["diagnosticExcerpt"])
 
+    def test_paid_failure_recurrence_guard_extracts_room_busy_signature_from_retry_loop(self) -> None:
+        retry_log = "\n".join(
+            [
+                'phase="place-spawn room busy; retrying" attempt="1" maxAttempts="12" retrySeconds="1.0"',
+                'phase="place-spawn room busy; retrying" attempt="1" maxAttempts="12" retrySeconds="1.0"',
+            ]
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            summary_path = write_tencent_failure_summary(
+                artifact_root,
+                "postfix-room-busy-validation",
+                failure_class="remote_training_timeout",
+                failure_text=retry_log,
+            )
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+
+            evidence = runner.paid_failure_recurrence_evidence_from_summary(summary, summary_path)
+
+        assert evidence is not None
+        self.assertEqual(evidence["signature"], runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE)
+        self.assertEqual(evidence["reason"], "place-spawn room busy")
+        self.assertEqual(evidence["matchedBy"], "controller-summary diagnostic text")
+        self.assertIn("place-spawn room busy; retrying", evidence["diagnosticExcerpt"])
+
     def test_paid_failure_recurrence_guard_allows_dispatch_below_threshold(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             artifact_root = Path(temp_dir) / "batch-runs"
@@ -5512,6 +5537,61 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             "validation heartbeat",
             failure["diagnostics"]["training-stderr.log"]["tail"],
         )
+
+    def test_run_remote_training_classifies_timeout_room_busy_retry_loop(self) -> None:
+        args = controller_args()
+        args.training_timeout_seconds = 3600
+        retry_log = "\n".join(
+            [
+                (
+                    "2026-05-30T21:18:41Z rl-sim-worker[0] variant=baseline "
+                    'phase="place-spawn room busy; retrying" '
+                    'attempt="1" maxAttempts="12" retrySeconds="1.0"'
+                ),
+                (
+                    "2026-05-30T21:21:31Z rl-sim-worker[2] variant=baseline "
+                    'phase="place-spawn room busy; retrying" '
+                    'attempt="1" maxAttempts="12" retrySeconds="1.0"'
+                ),
+            ]
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=root)
+
+            def fake_ssh_cmd(
+                _name: str,
+                _remote_command: str,
+                **_kwargs: object,
+            ) -> subprocess.CompletedProcess[str]:
+                return runner.timeout_completed_process(
+                    ["ssh"],
+                    subprocess.TimeoutExpired(["ssh"], 3600, output=b"", stderr=retry_log.encode()),
+                )
+
+            def fake_collect_remote_artifacts() -> None:
+                remote = root / "remote"
+                remote.mkdir(parents=True)
+                (remote / "training-stderr.log").write_text(f"{retry_log}\n", encoding="utf-8")
+                (remote / "training-summary.json").write_text("", encoding="utf-8")
+                (remote / "card-validation.json").write_text('{"ok": true}\n', encoding="utf-8")
+                (remote / "report-extract.json").write_text("", encoding="utf-8")
+
+            with (
+                mock.patch.object(controller, "ssh_cmd", side_effect=fake_ssh_cmd),
+                mock.patch.object(controller, "collect_remote_artifacts", side_effect=fake_collect_remote_artifacts),
+            ):
+                with self.assertRaisesRegex(runner.BatchRunError, "place-spawn room busy; retrying"):
+                    controller.run_remote_training()
+
+            failure = controller.result["remoteTrainingFailure"]
+
+        self.assertEqual(failure["returncode"], runner.PROCESS_TIMEOUT_RETURN_CODE)
+        self.assertEqual(failure["failureClass"], "simulator_place_spawn_room_busy")
+        self.assertTrue(failure["controllerTimedOut"])
+        self.assertFalse(failure["retryable"])
+        self.assertIn("local code/diagnostic fix", failure["nextAction"])
+        self.assertIn("do not rerun paid validation unchanged", failure["nextAction"])
 
     def test_run_remote_training_does_not_classify_remote_exit_124_as_controller_timeout(self) -> None:
         args = controller_args()


### PR DESCRIPTION
## Summary

- Classify remote training timeouts that contain repeated `place-spawn room busy; retrying` simulator logs as `simulator_place_spawn_room_busy` instead of generic `remote_training_timeout`.
- Surface a safer next action that requires a local code/diagnostic fix before another paid validation run.
- Extend paid-failure recurrence evidence extraction so retry-loop text keeps the room-busy guard active.

Related to issue 1501.

## Verification

- `git diff --check`
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts/test_screeps_tencent_batch_rl_runner.py` — 161 tests passed.

## Universal task Done gate

- [x] Task type: code diagnostic hardening for RL batch validation.
- [x] Expected observable outcome / named deliverable: room-busy validation timeout classification changes from generic timeout to `simulator_place_spawn_room_busy` with recurrence evidence.
- [x] Non-goals / accepted substitutes: no paid Tencent run, no external workflow dispatch, and no live-game behavior change in this PR.
- [x] Verification evidence required before Done: diff-check, py_compile, and full Tencent batch runner unittest evidence listed above.
- [x] Project Evidence / Next action / Blocked by: Project issue 1501 records commit, test evidence, and paid-rerun hold state after PR creation.
- [x] Post-merge/deploy/runtime proof: scripts-only change; post-merge proof is main-branch script test success plus the next preflight classifying the consumed validation as room-busy.
- [x] Named deliverable proof: batch-runner classification code and tests in this PR are the named deliverable; no dashboard or deployed service is introduced.
