### PR TITLE
fix: bound E1 dataset gate source-index evaluation

### DIFF
--- a/scripts/screeps_rl_dataset_export.py
+++ b/scripts/screeps_rl_dataset_export.py
@@ -44,6 +44,11 @@ INCOMPLETE_DERIVED_RUNTIME_SUMMARY_SKIP_REASON = "incomplete_derived_runtime_sum
 STALE_NON_CURRENT_CONSOLE_CAPTURE_SKIP_REASON = "stale_non_current_room_console_capture"
 STALE_CONSOLE_CAPTURE_SOURCE_AGE_HOURS = 24.0
 SKIPPED_SAMPLE_LOG_LIMIT = 50
+GENERATED_ARTIFACT_DIRECTORY_NAMES = (
+    "rl-datasets",
+    "rl-dataset-gates",
+    "rl-control-loop",
+)
 DERIVED_RUNTIME_SOURCE_MARKERS = ("screeps-runtime-monitor", "screeps-runtime-monitor-json")
 DERIVED_RUNTIME_BASENAME_PREFIXES = ("postdeploy-observation", "runtime-summary-monitor", "latest-summary-output")
 CONSOLE_CAPTURE_SOURCE_MARKER = "runtime-summary-console"
@@ -883,7 +888,12 @@ def build_dataset(
     resolved_bot_commit = bot_commit or git_commit(repo)
     resolved_out_dir = out_dir.expanduser()
     resolved_home_room = home_room or configured_home_room()
-    scan = collect_artifact_records(paths, max_file_bytes=max_file_bytes, excluded_roots=[resolved_out_dir])
+    scan = collect_artifact_records(
+        paths,
+        max_file_bytes=max_file_bytes,
+        excluded_roots=[resolved_out_dir],
+        excluded_directory_names=GENERATED_ARTIFACT_DIRECTORY_NAMES,
+    )
     filter_incomplete_derived_runtime_records(scan)
     filter_stale_non_current_console_capture_records(scan, home_room=resolved_home_room, created_at=created_at)
     rows = build_tick_rows(scan.records, resolved_bot_commit, sample_limit, eval_ratio_value, split_seed)
@@ -1297,6 +1307,7 @@ def count_skipped_sample_field(scan: ScanResult, field_name: str) -> JsonObject:
 
 
 def build_source_index(scan: ScanResult) -> JsonObject:
+    skipped_sample_summary = build_skipped_sample_summary(scan)
     return {
         "type": "screeps-rl-source-index",
         "schemaVersion": SCHEMA_VERSION,
@@ -1315,7 +1326,7 @@ def build_source_index(scan: ScanResult) -> JsonObject:
         ],
         "strategyShadowReports": scan.strategy_shadow_reports,
         "skippedFiles": sorted(scan.skipped_files, key=lambda item: (item.get("path", ""), item.get("reason", ""))),
-        "skippedSamples": sorted_skipped_samples(scan),
+        **skipped_sample_summary,
     }
 
 

--- a/scripts/screeps_strategy_shadow_report.py
+++ b/scripts/screeps_strategy_shadow_report.py
@@ -139,11 +139,12 @@ def build_strategy_shadow_report(
     resolved_bot_commit = bot_commit or dataset_export.git_commit(repo)
     resolved_generated_at = generated_at or utc_now_iso()
 
-    scan_kwargs = {}
+    excluded_directory_names = list(dataset_export.GENERATED_ARTIFACT_DIRECTORY_NAMES)
+    scan_kwargs = {"excluded_directory_names": excluded_directory_names}
     if fast:
+        excluded_directory_names.extend(FAST_EXCLUDED_DIRECTORY_NAMES)
         scan_kwargs.update(
             max_age_hours=max_age_hours,
-            excluded_directory_names=FAST_EXCLUDED_DIRECTORY_NAMES,
             binary_file_extensions=FAST_BINARY_FILE_EXTENSIONS,
         )
 

--- a/scripts/test_screeps_rl_dataset_export.py
+++ b/scripts/test_screeps_rl_dataset_export.py
@@ -382,6 +382,106 @@ class RlDatasetExportTest(unittest.TestCase):
         self.assertEqual(summary["skippedSampleCount"], 0)
         self.assertEqual(rows[0]["observation"]["roomName"], "E29N55")
 
+    def test_stale_skipped_samples_are_summarized_without_full_source_index_log(self) -> None:
+        current_payload = {
+            "type": "runtime-summary",
+            "tick": 1056600,
+            "rooms": [{"roomName": "E29N55", "resources": {"storedEnergy": 250}}],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            for index in range(exporter.SKIPPED_SAMPLE_LOG_LIMIT + 5):
+                stale_payload = {
+                    "type": "runtime-summary",
+                    "tick": 786180 + index,
+                    "rooms": [{"roomName": f"E26S{index % 10}", "resources": {"storedEnergy": 0}}],
+                }
+                stale_artifact = root / f"runtime-summary-console-20260510T1735{index % 60:02d}Z-{index}.log"
+                stale_artifact.write_text(runtime_line(stale_payload), encoding="utf-8")
+
+            current_artifact = root / "runtime-summary-console-20260521T025000Z.log"
+            current_artifact.write_text(runtime_line(current_payload), encoding="utf-8")
+            out_dir = root / "datasets"
+
+            summary = exporter.build_dataset(
+                [str(root)],
+                out_dir,
+                run_id="bounded-skipped-source-index-run",
+                bot_commit="3" * 40,
+                sample_limit=1,
+                eval_ratio_value=0,
+                created_at="2026-05-21T03:03:07Z",
+                home_room="E29N55",
+            )
+            rows = read_ndjson(out_dir / "bounded-skipped-source-index-run" / "ticks.ndjson")
+            source_index = read_json(out_dir / "bounded-skipped-source-index-run" / "source_index.json")
+            run_manifest = read_json(out_dir / "bounded-skipped-source-index-run" / "run_manifest.json")
+
+        skipped_count = exporter.SKIPPED_SAMPLE_LOG_LIMIT + 5
+        self.assertEqual(summary["sampleCount"], 1)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["observation"]["roomName"], "E29N55")
+        self.assertEqual(source_index["skippedSampleCount"], skipped_count)
+        self.assertEqual(len(source_index["skippedSamples"]), exporter.SKIPPED_SAMPLE_LOG_LIMIT)
+        self.assertEqual(source_index["skippedSamplesTruncated"], 5)
+        self.assertEqual(run_manifest["source"]["skippedSampleCount"], skipped_count)
+        self.assertEqual(len(run_manifest["source"]["skippedSamples"]), exporter.SKIPPED_SAMPLE_LOG_LIMIT)
+
+    def test_generated_rl_dataset_source_index_directory_is_not_rescanned(self) -> None:
+        payload = {
+            "type": "runtime-summary",
+            "tick": 1056600,
+            "rooms": [{"roomName": "E29N55", "resources": {"storedEnergy": 250}}],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            generated_dataset_dir = artifact_root / "rl-datasets" / "old-run"
+            generated_dataset_dir.mkdir(parents=True)
+            generated_source_index = generated_dataset_dir / "source_index.json"
+            generated_source_index.write_text(
+                json.dumps(
+                    {
+                        "type": "screeps-rl-source-index",
+                        "skippedSamples": [
+                            {
+                                "reason": exporter.STALE_NON_CURRENT_CONSOLE_CAPTURE_SKIP_REASON,
+                                "path": f"runtime-summary-console-20260510T0000{index:02d}Z.log",
+                                "roomName": "E26S49",
+                            }
+                            for index in range(60)
+                        ],
+                    },
+                    sort_keys=True,
+                ),
+                encoding="utf-8",
+            )
+            runtime_artifact = artifact_root / "runtime-summary-console-20260521T025000Z.log"
+            runtime_artifact.write_text(runtime_line(payload), encoding="utf-8")
+            out_dir = artifact_root / "rl-datasets-new"
+            original_scan_file = exporter.scan_file
+            scanned_paths: list[Path] = []
+
+            def tracking_scan_file(path: Path, *args: object, **kwargs: object) -> None:
+                scanned_paths.append(path)
+                original_scan_file(path, *args, **kwargs)
+
+            with mock.patch.object(exporter, "scan_file", side_effect=tracking_scan_file):
+                summary = exporter.build_dataset(
+                    [str(artifact_root)],
+                    out_dir,
+                    run_id="skip-generated-source-index-run",
+                    bot_commit="4" * 40,
+                    eval_ratio_value=0,
+                    created_at="2026-05-21T03:03:07Z",
+                    home_room="E29N55",
+                )
+
+        self.assertEqual(summary["sampleCount"], 1)
+        self.assertNotIn(generated_source_index, scanned_paths)
+
     def test_incomplete_postdeploy_monitor_summary_json_is_filtered_from_samples(self) -> None:
         monitor_payload = {
             "ok": True,

--- a/scripts/test_screeps_rl_dataset_gate.py
+++ b/scripts/test_screeps_rl_dataset_gate.py
@@ -404,6 +404,55 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
         self.assertEqual(quality["acceptance_rate"], 1.0)
         self.assertEqual(saved_report["dataset"]["skippedSamples"][0]["roomName"], "E26S48")
 
+    def test_run_bounds_large_stale_non_current_tail_before_quality_evaluation(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            stale_count = dataset_export.SKIPPED_SAMPLE_LOG_LIMIT + 5
+            for index in range(stale_count):
+                stale_room = runtime_payload(786180 + index, stored_energy=0)
+                room = stale_room["rooms"][0]
+                room["roomName"] = f"E26S{index % 10}"
+                room["workerCount"] = 0
+                room["spawnStatus"] = []
+                room["taskCounts"] = {"harvest": 0, "upgrade": 0, "none": 0}
+                room["energyAvailable"] = 0
+                room["resources"]["workerCarriedEnergy"] = 0
+                stale_artifact = root / f"runtime-summary-console-20260510T1735{index % 60:02d}Z-{index}.log"
+                stale_artifact.write_text(runtime_line(stale_room), encoding="utf-8")
+
+            current_artifact = root / "runtime-summary-console-20260521T025000Z.log"
+            current_room = runtime_payload(1056600, stored_energy=250)
+            current_room["rooms"][0]["roomName"] = "E29N55"
+            current_artifact.write_text(runtime_line(current_room), encoding="utf-8")
+
+            with mock.patch.dict(gate.os.environ, {"SCREEPS_HOME_ROOM": "E29N55"}, clear=False):
+                report = gate.run_gate(
+                    [str(root)],
+                    out_dir=root / "gates",
+                    gate_id="gate-bounded-stale-tail",
+                    created_at="2026-05-21T03:03:07Z",
+                    dataset_out_dir=root / "datasets",
+                    sample_limit=1,
+                    min_samples=1,
+                    skip_shadow_report=True,
+                    bot_commit="a" * 40,
+                    eval_ratio_value=0,
+                    repo_root=Path.cwd(),
+                )
+
+            source_index = read_json(root / "datasets" / report["dataset"]["runId"] / "source_index.json")
+
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["dataset"]["sampleCount"], 1)
+        self.assertEqual(report["dataset"]["skippedSampleCount"], stale_count)
+        self.assertEqual(len(report["dataset"]["skippedSamples"]), dataset_export.SKIPPED_SAMPLE_LOG_LIMIT)
+        self.assertEqual(report["dataset"]["skippedSamplesTruncated"], 5)
+        self.assertEqual(source_index["skippedSampleCount"], stale_count)
+        self.assertEqual(len(source_index["skippedSamples"]), dataset_export.SKIPPED_SAMPLE_LOG_LIMIT)
+        self.assertEqual(report["quality_checks"]["samples_total"], 1)
+        self.assertEqual(report["quality_checks"]["samples_accepted"], 1)
+        self.assertEqual(report["quality_checks"]["samples_rejected"], 0)
+
     def test_run_rejects_malformed_created_at_before_stale_age_logic(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_strategy_shadow_report.py
+++ b/scripts/test_screeps_strategy_shadow_report.py
@@ -201,6 +201,54 @@ class StrategyShadowReportTest(unittest.TestCase):
         self.assertIn("kpiSummary", report)
         self.assertNotIn("#runtime-summary", json.dumps(report, sort_keys=True))
 
+    def test_generated_rl_dataset_source_index_directory_is_not_scanned(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            generated_dataset_dir = artifact_root / "rl-datasets" / "old-run"
+            generated_dataset_dir.mkdir(parents=True)
+            generated_source_index = generated_dataset_dir / "source_index.json"
+            generated_source_index.write_text(
+                json.dumps(
+                    {
+                        "type": "screeps-rl-source-index",
+                        "skippedSamples": [
+                            {"reason": "stale_non_current_room_console_capture", "roomName": "E26S49"}
+                            for _ in range(60)
+                        ],
+                    },
+                    sort_keys=True,
+                ),
+                encoding="utf-8",
+            )
+            runtime_artifact = artifact_root / "runtime.log"
+            runtime_artifact.write_text(runtime_line(replay_payload()), encoding="utf-8")
+            out_dir = root / "strategy-shadow"
+            original_scan_file = dataset_export.scan_file
+            scanned_paths: list[Path] = []
+
+            def tracking_scan_file(path: Path, *args: object, **kwargs: object) -> None:
+                scanned_paths.append(path)
+                original_scan_file(path, *args, **kwargs)
+
+            with mock.patch.object(dataset_export, "scan_file", side_effect=tracking_scan_file):
+                with mock.patch.object(
+                    shadow_report,
+                    "run_shadow_evaluator",
+                    return_value={"enabled": True, "artifactCount": 1, "modelReports": []},
+                ):
+                    summary = shadow_report.build_strategy_shadow_report(
+                        [str(artifact_root)],
+                        out_dir,
+                        report_id="shadow-skip-generated-source-index",
+                        generated_at="2026-05-01T00:00:00Z",
+                        bot_commit="a" * 40,
+                        repo_root=REPO_ROOT,
+                    )
+
+        self.assertTrue(summary["ok"])
+        self.assertNotIn(generated_source_index, scanned_paths)
+
     def test_bounds_diff_samples_and_redacts_configured_secret_values(self) -> None:
         secret = "supersecret123456"
         payloads = [replay_payload(200, secret), replay_payload(201, secret), replay_payload(202, secret)]


### PR DESCRIPTION
## Summary
- Bounds E1 dataset/export/shadow source-index handling so large stale/skipped source_index.json inputs honor small sample limits.
- Adds regression coverage for stale source-index entries across dataset export, gate, and shadow report paths.

Fixes #1510.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_dataset_gate.py scripts/test_screeps_rl_dataset_gate.py scripts/screeps_rl_dataset_export.py scripts/test_screeps_rl_dataset_export.py scripts/screeps_strategy_shadow_report.py scripts/test_screeps_strategy_shadow_report.py`
- `python3 -m unittest scripts/test_screeps_rl_dataset_gate.py scripts/test_screeps_rl_dataset_export.py scripts/test_screeps_strategy_shadow_report.py`

## Issue closure gate
- [x] #1510: source-index evaluation is bounded by current sample/gate selection and focused tests pass for the stale/skipped large-index regression.

## Universal task Done gate
- [x] Task type: code/test.
- [x] Expected observable outcome / named deliverable: E1 dataset gate can evaluate current datasets with large stale/skipped source indexes while honoring small sample limits.
- [x] Non-goals / accepted substitutes: no Tencent paid compute launch, no GitHub Project mutation by Codex, no official MMO deployment change.
- [x] Verification evidence required before Done: diff check, py_compile, and focused unittest suite pass in the branch worktree.
- [x] Project Evidence / Next action / Blocked by: controller updates Project Evidence and Next action for issue #1510 and this PR in the scheduler run; Blocked by records live review/check gates when present.
- [x] Post-merge/deploy/runtime proof: no official MMO deploy is required because the changed files are RL/offline scripts and tests; next Loop A E1 gate run supplies runtime flywheel proof.
- [x] Named deliverable proof: branch commit `db74a4a5` plus the focused test commands above demonstrate the named E1 source-index bound.
