### PR TITLE
fix: align cron registry with minimax failover providers

### DIFF
--- a/docs/ops/cron-and-route-registry.md
+++ b/docs/ops/cron-and-route-registry.md
@@ -79,12 +79,12 @@ Repeat policy values:
 | Screeps dev-log fanout reporter | `d3bf35c278d5` | `25,55 * * * *` | `discord:#dev-log` | `minimax-cn` | `MiniMax-M2.7` | `-` | `forever` | P1 | Dev log fanout from live repo/cron state. |
 | Screeps research-notes fanout reporter | `3c0d20aa2e45` | `10,40 * * * *` | `discord:#research-notes` | `minimax-cn` | `MiniMax-M2.7` | `-` | `forever` | P1 | Research/RL progress fanout. |
 | Screeps 6h development report | `dfcaf65d7ea7` | `47 */6 * * *` | `discord:1497587260835758222:1497833662241181746` | `minimax-cn` | `MiniMax-M2.7` | `-` | `high-horizon` | P1 | Threaded 6h health/progress report. |
-| Screeps Gameplay Evolution Review | `c7b3dda8f1ac` | `0 */8 * * *` | `discord:#task-queue` | `openai-codex` | `gpt-5.5` | `-` | `high-horizon` | P1 | 8h strategy review for current target `E29N55`. |
+| Screeps Gameplay Evolution Review | `c7b3dda8f1ac` | `0 */8 * * *` | `discord:#task-queue` | `minimax-cn` | `MiniMax-M2.7` | `-` | `high-horizon` | P1 | 8h strategy review for current target `E29N55`. |
 | Screeps Gameplay Evolution Review decisions archive | `dc1c46787f2e` | `15 */8 * * *` | `discord:1497586175580311654` | `minimax-cn` | `MiniMax-M2.7` | `-` | `high-horizon` | P1 | Archive accepted strategy decisions/current strategy. |
 | Screeps RL flywheel steward | `aed8362e4501` | `17 * * * *` | `discord:#task-queue` | `openai-codex` | `gpt-5.5` | `/root/screeps` | `high-horizon` | P1 | RL flywheel stewardship and issue/Project reconciliation. |
-| Screeps RL shadow-eval pipeline | `d6cff532edd4` | `5 * * * *` | `discord:#task-queue` | `deepseek` | `deepseek-v4-pro` | `/root/screeps` | `high-horizon` | P1 | Shadow-eval ledger producer for RL candidate/baseline evidence. |
-| Screeps RL training execution ledger | `5c869e7d8a1d` | `14,44 * * * *` | `discord:#task-queue` | `deepseek` | `deepseek-v4-pro` | `-` | `high-horizon` | P1 | Training execution ledger for offline/private RL campaigns; owns Tencent RL utilization control through its preflight instead of a standalone cron. |
-| Screeps RL policy online advantage ledger | `01609968392a` | `27,57 * * * *` | `discord:#task-queue` | `deepseek` | `deepseek-v4-pro` | `/root/screeps` | `high-horizon` | P1 | Online advantage ledger comparing candidate policy signals against baseline. |
+| Screeps RL shadow-eval pipeline | `d6cff532edd4` | `5 * * * *` | `discord:#task-queue` | `minimax-cn` | `MiniMax-M2.7` | `/root/screeps` | `high-horizon` | P1 | Shadow-eval ledger producer for RL candidate/baseline evidence. |
+| Screeps RL training execution ledger | `5c869e7d8a1d` | `14,44 * * * *` | `discord:#task-queue` | `minimax-cn` | `MiniMax-M2.7` | `-` | `high-horizon` | P1 | Training execution ledger for offline/private RL campaigns; owns Tencent RL utilization control through its preflight instead of a standalone cron. |
+| Screeps RL policy online advantage ledger | `01609968392a` | `27,57 * * * *` | `discord:#task-queue` | `minimax-cn` | `MiniMax-M2.7` | `/root/screeps` | `high-horizon` | P1 | Online advantage ledger comparing candidate policy signals against baseline. |
 | Hermes state daily backup | `bf68a3951853` | `0 4 * * *` | `local` | `minimax-cn` | `MiniMax-M2.7` | `-` | `forever` | Support | Daily private Hermes-state backup. |
 
 ## Transient and retired cron jobs


### PR DESCRIPTION
## Summary
- Aligns `docs/ops/cron-and-route-registry.md` with the intentional MiniMax failover provider/model now running for the Gameplay Evolution and RL ledger jobs.
- Leaves live Hermes cron config untouched; this PR updates the repository source of truth only.

Fixes #1521.

## Verification
- `python3 -m py_compile scripts/check_cron_registry.py`
- `python3 scripts/check_cron_registry.py --strict`
- `git diff --check`

## Issue closure gate
- [x] #1521: fresh Gameplay/RL cron outputs exist under MiniMax failover and the strict registry check reports PASS with 0 mismatches after this source-of-truth update.

## Universal task Done gate
- [x] Task type: docs/process.
- [x] Expected observable outcome / named deliverable: cron registry strict check passes against the live repaired MiniMax failover jobs.
- [x] Non-goals / accepted substitutes: no live cron mutation, no secret changes, no new scheduled jobs, no production bot behavior change.
- [x] Verification evidence required before Done: py_compile for the checker, strict registry check PASS with 0 mismatches, and diff check pass.
- [x] Project Evidence / Next action / Blocked by: controller updates issue #1521 and this PR Project fields with exact head and review/check gate state.
- [x] Post-merge/deploy/runtime proof: no official MMO deploy is required because only registry documentation changes; subsequent scheduler pre-run registry checks provide the runtime proof.
- [x] Named deliverable proof: `docs/ops/cron-and-route-registry.md` lists `minimax-cn` / `MiniMax-M2.7` for `c7b3dda8f1ac`, `d6cff532edd4`, `5c869e7d8a1d`, and `01609968392a`.
