### PR TITLE
fix(rl): surface stale conclusion backlog gate

### DIFF
--- a/scripts/rl_conclusion_registry.py
+++ b/scripts/rl_conclusion_registry.py
@@ -16,6 +16,9 @@ from typing import Any, Sequence
 SCHEMA_VERSION = 1
 REGISTRY_TYPE = "rl-conclusion-registry"
 CONCLUSION_STATUSES = ("OPEN", "STALE", "ACTIONED", "VALIDATING", "CLOSED", "ESCALATED")
+ACTIONABLE_STALE_SEVERITIES = ("P0", "P1")
+ACTIONABLE_STALE_CONCLUSION_THRESHOLD = 10
+ACTIONABLE_STALE_CONCLUSION_PREVIEW_LIMIT = 10
 
 JsonObject = dict[str, Any]
 
@@ -204,7 +207,75 @@ def summarize_conclusions(
         "staleOrEscalated": status_counts["STALE"] + status_counts["ESCALATED"],
         "countsByStatus": counts_by_status,
         "unknown": unknown_count,
+        "actionableIssueGate": high_priority_stale_issue_gate(records),
     }
+
+
+def high_priority_stale_issue_gate(records: dict[str, JsonObject]) -> JsonObject:
+    stale_by_severity = {severity: 0 for severity in ACTIONABLE_STALE_SEVERITIES}
+    open_by_severity = {severity: 0 for severity in ACTIONABLE_STALE_SEVERITIES}
+    unresolved: list[JsonObject] = []
+
+    for record in records.values():
+        severity = str(record.get("severity", "")).upper()
+        if severity not in ACTIONABLE_STALE_SEVERITIES:
+            continue
+        status = str(record.get("status", "")).upper()
+        if status == "STALE":
+            stale_by_severity[severity] += 1
+            unresolved.append(record)
+        elif status == "OPEN":
+            open_by_severity[severity] += 1
+            unresolved.append(record)
+
+    stale_count = sum(stale_by_severity.values())
+    open_count = sum(open_by_severity.values())
+    threshold_exceeded = stale_count > ACTIONABLE_STALE_CONCLUSION_THRESHOLD
+    highest_priority_ids = [
+        conclusion_id
+        for conclusion_id in (
+            record.get("conclusionId")
+            for record in sorted(unresolved, key=conclusion_gate_priority_key)
+        )
+        if isinstance(conclusion_id, str) and conclusion_id
+    ][:ACTIONABLE_STALE_CONCLUSION_PREVIEW_LIMIT]
+
+    gate: JsonObject = {
+        "name": "p0_p1_stale_conclusion_backlog",
+        "status": "ACTION_REQUIRED" if threshold_exceeded else "OK",
+        "threshold": ACTIONABLE_STALE_CONCLUSION_THRESHOLD,
+        "thresholdExceeded": threshold_exceeded,
+        "staleHighPriorityCount": stale_count,
+        "openHighPriorityCount": open_count,
+        "staleBySeverity": stale_by_severity,
+        "openBySeverity": open_by_severity,
+        "highestPriorityConclusionIds": highest_priority_ids,
+    }
+    if threshold_exceeded:
+        gate["recommendedAction"] = (
+            "create_or_update_aggregate_rl_conclusion_closure_issue_and_project_evidence"
+        )
+        gate["evidence"] = (
+            f"{stale_count} P0/P1 STALE conclusions exceed threshold "
+            f"{ACTIONABLE_STALE_CONCLUSION_THRESHOLD}; steward/checker must route aggregate closure "
+            "or escalation before reporting the backlog as background context."
+        )
+    return gate
+
+
+def conclusion_gate_priority_key(record: JsonObject) -> tuple[int, int, str, str]:
+    severity_order = {"P0": 0, "P1": 1}
+    status_order = {"STALE": 0, "OPEN": 1}
+    severity = str(record.get("severity", "")).upper()
+    status = str(record.get("status", "")).upper()
+    last_seen = str(record.get("lastSeenAt") or record.get("nextVerification") or "")
+    conclusion_id = str(record.get("conclusionId") or "")
+    return (
+        severity_order.get(severity, 99),
+        status_order.get(status, 99),
+        last_seen,
+        conclusion_id,
+    )
 
 
 def merge_registry_file(

--- a/scripts/test_rl_conclusion_registry.py
+++ b/scripts/test_rl_conclusion_registry.py
@@ -173,6 +173,65 @@ class RlConclusionRegistryTest(unittest.TestCase):
         self.assertEqual(merged["summary"]["countsByStatus"]["UNKNOWN"], 1)
         self.assertEqual(merged["summary"]["countsByStatus"]["DEFERRED"], 1)
 
+    def test_summary_surfaces_high_priority_stale_backlog_gate(self) -> None:
+        records = {
+            f"P0-STALE-{index:02d}": {
+                "conclusionId": f"P0-STALE-{index:02d}",
+                "status": "STALE",
+                "severity": "P0",
+                "lastSeenAt": f"2026-05-2{index % 10}T00:00:00Z",
+            }
+            for index in range(11)
+        }
+        records["P1-OPEN"] = {
+            "conclusionId": "P1-OPEN",
+            "status": "OPEN",
+            "severity": "P1",
+            "lastSeenAt": "2026-05-31T00:00:00Z",
+        }
+        records["P2-STALE"] = {
+            "conclusionId": "P2-STALE",
+            "status": "STALE",
+            "severity": "P2",
+            "lastSeenAt": "2026-05-31T00:00:00Z",
+        }
+
+        gate = registry.summarize_conclusions(records)["actionableIssueGate"]
+
+        self.assertEqual(gate["name"], "p0_p1_stale_conclusion_backlog")
+        self.assertEqual(gate["status"], "ACTION_REQUIRED")
+        self.assertTrue(gate["thresholdExceeded"])
+        self.assertEqual(gate["threshold"], 10)
+        self.assertEqual(gate["staleHighPriorityCount"], 11)
+        self.assertEqual(gate["openHighPriorityCount"], 1)
+        self.assertEqual(gate["staleBySeverity"], {"P0": 11, "P1": 0})
+        self.assertEqual(gate["openBySeverity"], {"P0": 0, "P1": 1})
+        self.assertEqual(gate["highestPriorityConclusionIds"][0], "P0-STALE-00")
+        self.assertNotIn("P2-STALE", gate["highestPriorityConclusionIds"])
+        self.assertEqual(
+            gate["recommendedAction"],
+            "create_or_update_aggregate_rl_conclusion_closure_issue_and_project_evidence",
+        )
+        self.assertIn("11 P0/P1 STALE conclusions exceed threshold 10", gate["evidence"])
+
+    def test_summary_gate_ok_when_high_priority_stale_count_within_threshold(self) -> None:
+        records = {
+            f"P1-STALE-{index:02d}": {
+                "conclusionId": f"P1-STALE-{index:02d}",
+                "status": "STALE",
+                "severity": "P1",
+            }
+            for index in range(10)
+        }
+
+        gate = registry.summarize_conclusions(records)["actionableIssueGate"]
+
+        self.assertEqual(gate["status"], "OK")
+        self.assertFalse(gate["thresholdExceeded"])
+        self.assertEqual(gate["staleHighPriorityCount"], 10)
+        self.assertNotIn("recommendedAction", gate)
+        self.assertNotIn("evidence", gate)
+
     def test_normalize_conclusions_rejects_duplicate_conclusion_ids(self) -> None:
         with self.assertRaisesRegex(registry.ConclusionRegistryError, "DUPLICATE-ID"):
             registry.normalize_conclusions(


### PR DESCRIPTION
## Summary
- Adds an actionable high-priority stale-conclusion backlog gate to `summarize_conclusions()` so the steward/checker cannot treat large P0/P1 STALE conclusion counts as background-only context.
- Reports the gate with threshold, severity breakdown, highest-priority conclusion IDs, recommended action, and evidence text when P0/P1 STALE conclusions exceed the threshold.
- Adds focused unit coverage for both ACTION_REQUIRED and OK threshold cases.

Fixes #1529.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/rl_conclusion_registry.py scripts/test_rl_conclusion_registry.py`
- `python3 -m unittest scripts/test_rl_conclusion_registry.py` — 11 tests OK

## Issue closure gate
- [x] #1529: `scripts/rl_conclusion_registry.py` now emits `summary.actionableIssueGate` when P0/P1 stale conclusions exceed the aggregate routing threshold; regression tests cover the stale-backlog and threshold-ok paths.

## Universal task Done gate
- [x] Task type: code/test.
- [x] Expected observable outcome / named deliverable: RL conclusion registry summaries expose a machine-readable gate for stale P0/P1 backlog routing.
- [x] Non-goals / accepted substitutes: no paid Tencent compute, no official MMO writes, no conclusion closure by this PR, no reward/strategy change.
- [x] Verification evidence required before Done: diff check, py_compile, and focused unittest pass on the PR branch.
- [x] Project Evidence / Next action / Blocked by: controller updates #1529 and this PR Project fields with commit/test/check evidence and any review/check blocker.
- [x] Post-merge/deploy/runtime proof: no official deploy required for offline RL registry script/test change; next steward/Loop report should consume the new gate and route closure actions.
- [x] Named deliverable proof: commit `3a28a9f3` adds `actionableIssueGate` plus two tests in `scripts/test_rl_conclusion_registry.py`.
