### PR TITLE
fix(rl): keep transient room-busy retries out of recurrence guard

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -207,11 +207,6 @@ REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RE = re.compile(
     r"(?:place-spawn room busy after \d+ attempt\(s\)|\bplace_spawn_room_busy\b|room-busy placement lock)",
     re.IGNORECASE,
 )
-REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RETRY_RE = re.compile(
-    r"place-spawn room busy;\s*retrying\b",
-    re.IGNORECASE,
-)
-REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RETRY_THRESHOLD = 2
 REMOTE_NETWORK_RE = re.compile(
     r"(?:connection refused|request canceled|too many requests|toomanyrequests|network .*timed? out|"
     r"net/http|Client\.Timeout)",
@@ -2484,8 +2479,6 @@ def classify_remote_training_failure(
         return "simulator_resource_guard_rejected"
     if REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RE.search(diagnostic_text):
         return "simulator_place_spawn_room_busy"
-    if controller_timed_out and simulator_place_spawn_room_busy_retry_loop(diagnostic_text):
-        return "simulator_place_spawn_room_busy"
     if process_failure_class in {"network_unreachable", "host_key_self_healing_failed", "host_key_mismatch"}:
         return process_failure_class
     simulator_setup_text = "\n".join(
@@ -2517,11 +2510,6 @@ def classify_remote_training_failure(
     if returncode == 255:
         return "ssh_transport_failed"
     return "remote_process_failed"
-
-
-def simulator_place_spawn_room_busy_retry_loop(text: str) -> bool:
-    retry_count = len(REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RETRY_RE.findall(text))
-    return retry_count >= REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RETRY_THRESHOLD
 
 
 def remote_training_failure_next_action(failure_class: str) -> str | None:
@@ -3512,10 +3500,7 @@ def paid_failure_signature_from_summary(summary: dict[str, Any]) -> dict[str, st
             "diagnosticExcerpt": failure_class,
         }
     for text in iter_failure_signature_texts(summary):
-        if (
-            REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RE.search(text)
-            or simulator_place_spawn_room_busy_retry_loop(text)
-        ):
+        if REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RE.search(text):
             return {
                 "signature": PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
                 "reason": "place-spawn room busy",

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -3777,7 +3777,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(evidence["matchedBy"], "controller-summary diagnostic text")
         self.assertIn("place-spawn room busy after 12 attempt", evidence["diagnosticExcerpt"])
 
-    def test_paid_failure_recurrence_guard_extracts_room_busy_signature_from_retry_loop(self) -> None:
+    def test_paid_failure_recurrence_guard_ignores_nonterminal_room_busy_retry_telemetry(self) -> None:
         retry_log = "\n".join(
             [
                 'phase="place-spawn room busy; retrying" attempt="1" maxAttempts="12" retrySeconds="1.0"',
@@ -3796,11 +3796,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
 
             evidence = runner.paid_failure_recurrence_evidence_from_summary(summary, summary_path)
 
-        assert evidence is not None
-        self.assertEqual(evidence["signature"], runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE)
-        self.assertEqual(evidence["reason"], "place-spawn room busy")
-        self.assertEqual(evidence["matchedBy"], "controller-summary diagnostic text")
-        self.assertIn("place-spawn room busy; retrying", evidence["diagnosticExcerpt"])
+        self.assertIsNone(evidence)
 
     def test_paid_failure_recurrence_guard_allows_dispatch_below_threshold(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -5538,7 +5534,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             failure["diagnostics"]["training-stderr.log"]["tail"],
         )
 
-    def test_run_remote_training_classifies_timeout_room_busy_retry_loop(self) -> None:
+    def test_run_remote_training_keeps_timeout_for_nonterminal_room_busy_retry_telemetry(self) -> None:
         args = controller_args()
         args.training_timeout_seconds = 3600
         retry_log = "\n".join(
@@ -5587,11 +5583,10 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             failure = controller.result["remoteTrainingFailure"]
 
         self.assertEqual(failure["returncode"], runner.PROCESS_TIMEOUT_RETURN_CODE)
-        self.assertEqual(failure["failureClass"], "simulator_place_spawn_room_busy")
+        self.assertEqual(failure["failureClass"], "remote_training_timeout")
         self.assertTrue(failure["controllerTimedOut"])
         self.assertFalse(failure["retryable"])
-        self.assertIn("local code/diagnostic fix", failure["nextAction"])
-        self.assertIn("do not rerun paid validation unchanged", failure["nextAction"])
+        self.assertIn("smaller chunks", failure["nextAction"])
 
     def test_run_remote_training_does_not_classify_remote_exit_124_as_controller_timeout(self) -> None:
         args = controller_args()


### PR DESCRIPTION
## Summary
- keeps transient `place-spawn room busy; retrying` telemetry out of the paid-failure recurrence guard
- preserves terminal room-busy failures (`place-spawn room busy after N attempts`) as the guarded recurrence signature
- updates runner tests so controller timeouts with only retry telemetry remain `remote_training_timeout`

## Verification
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `git diff --check`
- `python3 -m pytest scripts/test_screeps_tencent_batch_rl_runner.py -q` — 161 passed, 97 subtests passed

Related to issue 1501.

## Universal task Done gate
- [x] Task type: RL runner recurrence-guard classification fix.
- [x] Expected observable outcome / named deliverable: transient retry telemetry no longer consumes the room-busy recurrence guard while terminal room-busy evidence still maps to `simulator_place_spawn_room_busy`.
- [x] Non-goals / accepted substitutes: no Tencent paid compute launch, no official MMO deploy, no reward/policy decision changes.
- [x] Verification evidence required before Done: py_compile, diff-check, and targeted pytest suite passing on the PR head.
- [x] Project Evidence / Next action / Blocked by: controller updates issue 1501 and this PR Project items with head SHA, verification, and exact review-gate next action.
- [x] Post-merge/deploy/runtime proof: scripts-only classification change; post-merge proof is a guarded validation/preflight run that shows retry-only telemetry does not consume the paid-failure guard.
- [x] Named deliverable proof: commit `391bff31` changes only `scripts/screeps_tencent_batch_rl_runner.py` and `scripts/test_screeps_tencent_batch_rl_runner.py`.
