### PR TITLE
fix(rl): bound E1 dataset gate source index

### DIFF
--- a/scripts/screeps_rl_dataset_export.py
+++ b/scripts/screeps_rl_dataset_export.py
@@ -43,6 +43,7 @@ DEFAULT_EVAL_RATIO = 0.2
 INCOMPLETE_DERIVED_RUNTIME_SUMMARY_SKIP_REASON = "incomplete_derived_runtime_summary"
 STALE_NON_CURRENT_CONSOLE_CAPTURE_SKIP_REASON = "stale_non_current_room_console_capture"
 STALE_CONSOLE_CAPTURE_SOURCE_AGE_HOURS = 24.0
+SKIPPED_FILE_LOG_LIMIT = 100
 SKIPPED_SAMPLE_LOG_LIMIT = 50
 GENERATED_ARTIFACT_DIRECTORY_NAMES = (
     "rl-datasets",
@@ -194,7 +195,7 @@ def collect_artifact_records(
     binary_file_extensions: Sequence[str] = (),
     use_default_paths: bool = True,
 ) -> ScanResult:
-    input_paths = list(paths) if paths or not use_default_paths else list(DEFAULT_INPUT_PATHS)
+    input_paths = dedupe_input_paths(list(paths) if paths or not use_default_paths else list(DEFAULT_INPUT_PATHS))
     resolved_excluded_roots = resolved_paths(excluded_roots)
     result = ScanResult(input_paths=input_paths)
     max_age_cutoff = (
@@ -245,6 +246,18 @@ def collect_artifact_records(
 
     result.records.sort(key=record_sort_key)
     return result
+
+
+def dedupe_input_paths(paths: Sequence[str]) -> list[str]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for path_text in paths:
+        key = str(resolve_path(Path(path_text).expanduser()))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(path_text)
+    return deduped
 
 
 def iter_directory_files(
@@ -1285,6 +1298,30 @@ def build_skipped_sample_summary(scan: ScanResult) -> JsonObject:
     }
 
 
+def build_skipped_file_summary(scan: ScanResult) -> JsonObject:
+    skipped_files = sorted_skipped_files(scan)
+    return {
+        "skippedFileCount": len(scan.skipped_files),
+        "skippedFileReasons": count_skipped_file_field(scan, "reason"),
+        "skippedFiles": skipped_files[:SKIPPED_FILE_LOG_LIMIT],
+        "skippedFileLogLimit": SKIPPED_FILE_LOG_LIMIT,
+        "skippedFilesTruncated": max(0, len(skipped_files) - SKIPPED_FILE_LOG_LIMIT),
+    }
+
+
+def sorted_skipped_files(scan: ScanResult) -> list[JsonObject]:
+    return sorted(scan.skipped_files, key=lambda item: (str(item.get("path", "")), str(item.get("reason", ""))))
+
+
+def count_skipped_file_field(scan: ScanResult, field_name: str) -> JsonObject:
+    counts: dict[str, int] = {}
+    for skipped_file in scan.skipped_files:
+        value = skipped_file.get(field_name)
+        key = value if isinstance(value, str) and value else "unknown"
+        counts[key] = counts.get(key, 0) + 1
+    return dict(sorted(counts.items(), key=lambda item: (-item[1], item[0])))
+
+
 def sorted_skipped_samples(scan: ScanResult) -> list[JsonObject]:
     return sorted(
         scan.skipped_samples,
@@ -1307,6 +1344,7 @@ def count_skipped_sample_field(scan: ScanResult, field_name: str) -> JsonObject:
 
 
 def build_source_index(scan: ScanResult) -> JsonObject:
+    skipped_file_summary = build_skipped_file_summary(scan)
     skipped_sample_summary = build_skipped_sample_summary(scan)
     return {
         "type": "screeps-rl-source-index",
@@ -1325,7 +1363,7 @@ def build_source_index(scan: ScanResult) -> JsonObject:
             for source in sorted(scan.source_files.values(), key=lambda item: item.source_id)
         ],
         "strategyShadowReports": scan.strategy_shadow_reports,
-        "skippedFiles": sorted(scan.skipped_files, key=lambda item: (item.get("path", ""), item.get("reason", ""))),
+        **skipped_file_summary,
         **skipped_sample_summary,
     }
 

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -7532,6 +7532,9 @@ def append_dataset_metadata(
 
     if raw_type == "screeps-rl-source-index":
         source_files = raw.get("sourceFiles")
+        skipped_file_count = number_or_none(raw.get("skippedFileCount"))
+        if skipped_file_count is None and isinstance(raw.get("skippedFiles"), list):
+            skipped_file_count = len(raw["skippedFiles"])
         metadata["datasets"]["sourceIndexes"].append(
             {
                 **common,
@@ -7540,7 +7543,7 @@ def append_dataset_metadata(
                 "scannedFiles": number_or_none(raw.get("scannedFiles")),
                 "matchedArtifactCount": number_or_none(raw.get("matchedArtifactCount")),
                 "strategyShadowReportCount": number_or_none(raw.get("strategyShadowReportCount")),
-                "skippedFileCount": len(raw.get("skippedFiles")) if isinstance(raw.get("skippedFiles"), list) else None,
+                "skippedFileCount": skipped_file_count,
             }
         )
         return

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -7532,7 +7532,7 @@ def append_dataset_metadata(
 
     if raw_type == "screeps-rl-source-index":
         source_files = raw.get("sourceFiles")
-        skipped_file_count = number_or_none(raw.get("skippedFileCount"))
+        skipped_file_count = non_negative_int_or_none(raw.get("skippedFileCount"))
         if skipped_file_count is None and isinstance(raw.get("skippedFiles"), list):
             skipped_file_count = len(raw["skippedFiles"])
         metadata["datasets"]["sourceIndexes"].append(
@@ -7850,6 +7850,15 @@ def select_number_map(raw: Any) -> JsonObject:
 
 def number_or_none(value: Any) -> int | float | None:
     return value if dataset_export.is_number(value) else None
+
+
+def non_negative_int_or_none(value: Any) -> int | None:
+    number = number_or_none(value)
+    if isinstance(number, int):
+        return number if number >= 0 else None
+    if isinstance(number, float) and number >= 0 and number.is_integer():
+        return int(number)
+    return None
 
 
 def assert_no_secret_leak(payload: JsonObject, secrets: Sequence[str]) -> None:

--- a/scripts/test_screeps_rl_dataset_export.py
+++ b/scripts/test_screeps_rl_dataset_export.py
@@ -258,6 +258,37 @@ class RlDatasetExportTest(unittest.TestCase):
         self.assertEqual(summary["sampleCount"], 1)
         self.assertEqual(summary["runtimeSummaryArtifactCount"], 1)
 
+    def test_duplicate_input_roots_are_scanned_once(self) -> None:
+        payload = {
+            "type": "runtime-summary",
+            "tick": 121,
+            "rooms": [{"roomName": "E29N55", "resources": {"storedEnergy": 250}}],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-summary-console"
+            artifact_root.mkdir()
+            artifact = artifact_root / "runtime-summary-console-20260521T025000Z.log"
+            artifact.write_text(runtime_line(payload), encoding="utf-8")
+            out_dir = root / "datasets"
+
+            summary = exporter.build_dataset(
+                [str(artifact_root), str(artifact_root)],
+                out_dir,
+                run_id="deduped-input-root-run",
+                bot_commit="2" * 40,
+                eval_ratio_value=0,
+                created_at="2026-05-21T03:03:07Z",
+                home_room="E29N55",
+            )
+            source_index = read_json(out_dir / "deduped-input-root-run" / "source_index.json")
+
+        self.assertEqual(summary["sampleCount"], 1)
+        self.assertEqual(summary["runtimeSummaryArtifactCount"], 1)
+        self.assertEqual(source_index["scannedFiles"], 1)
+        self.assertEqual(source_index["inputPaths"], [str(artifact_root)])
+
     def test_stale_non_current_console_capture_sample_is_filtered_with_evidence(self) -> None:
         stale_payload = {
             "type": "runtime-summary",
@@ -427,6 +458,40 @@ class RlDatasetExportTest(unittest.TestCase):
         self.assertEqual(source_index["skippedSamplesTruncated"], 5)
         self.assertEqual(run_manifest["source"]["skippedSampleCount"], skipped_count)
         self.assertEqual(len(run_manifest["source"]["skippedSamples"]), exporter.SKIPPED_SAMPLE_LOG_LIMIT)
+
+    def test_skipped_files_are_summarized_without_full_source_index_log(self) -> None:
+        payload = {
+            "type": "runtime-summary",
+            "tick": 1056600,
+            "rooms": [{"roomName": "E29N55", "resources": {"storedEnergy": 250}}],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact = root / "runtime-summary-console-20260521T025000Z.log"
+            artifact.write_text(runtime_line(payload), encoding="utf-8")
+            skipped_count = exporter.SKIPPED_FILE_LOG_LIMIT + 7
+            for index in range(skipped_count):
+                (root / f"binary-{index:03d}.log").write_bytes(b"\0")
+            out_dir = root / "datasets"
+
+            summary = exporter.build_dataset(
+                [str(root)],
+                out_dir,
+                run_id="bounded-skipped-files-run",
+                bot_commit="4" * 40,
+                eval_ratio_value=0,
+                created_at="2026-05-21T03:03:07Z",
+                home_room="E29N55",
+            )
+            source_index = read_json(out_dir / "bounded-skipped-files-run" / "source_index.json")
+
+        self.assertEqual(summary["sampleCount"], 1)
+        self.assertEqual(summary["skippedFileCount"], skipped_count)
+        self.assertEqual(source_index["skippedFileCount"], skipped_count)
+        self.assertEqual(source_index["skippedFileReasons"], {"binary": skipped_count})
+        self.assertEqual(len(source_index["skippedFiles"]), exporter.SKIPPED_FILE_LOG_LIMIT)
+        self.assertEqual(source_index["skippedFilesTruncated"], 7)
 
     def test_generated_rl_dataset_source_index_directory_is_not_rescanned(self) -> None:
         payload = {

--- a/scripts/test_screeps_rl_dataset_gate.py
+++ b/scripts/test_screeps_rl_dataset_gate.py
@@ -561,6 +561,34 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
         self.assertEqual(report["quality_checks"]["samples_accepted"], 1)
         self.assertEqual(report["quality_checks"]["samples_rejected"], 0)
 
+    def test_run_deduplicates_input_roots_before_gate_evaluation(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-summary-console"
+            artifact_root.mkdir()
+            artifact = artifact_root / "runtime-summary-console-20260521T025000Z.log"
+            home_room = runtime_payload(100)
+            home_room["rooms"][0]["roomName"] = "E29N55"
+            artifact.write_text(runtime_line(home_room), encoding="utf-8")
+
+            report = gate.run_gate(
+                [str(artifact_root), str(artifact_root)],
+                out_dir=root / "gates",
+                gate_id="gate-deduped-input-root",
+                created_at="2026-05-21T03:03:07Z",
+                dataset_out_dir=root / "datasets",
+                skip_shadow_report=True,
+                bot_commit="e" * 40,
+                eval_ratio_value=0,
+                repo_root=Path.cwd(),
+            )
+            source_index = read_json(root / "datasets" / report["dataset"]["runId"] / "source_index.json")
+
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["dataset"]["runtimeSummaryArtifactCount"], 1)
+        self.assertEqual(report["quality_checks"]["samples_total"], 1)
+        self.assertEqual(source_index["scannedFiles"], 1)
+
     def test_home_room_env_var_controls_no_owned_spawns_rejection(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_dataset_gate.py
+++ b/scripts/test_screeps_rl_dataset_gate.py
@@ -571,23 +571,32 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
             home_room["rooms"][0]["roomName"] = "E29N55"
             artifact.write_text(runtime_line(home_room), encoding="utf-8")
 
-            report = gate.run_gate(
-                [str(artifact_root), str(artifact_root)],
-                out_dir=root / "gates",
-                gate_id="gate-deduped-input-root",
-                created_at="2026-05-21T03:03:07Z",
-                dataset_out_dir=root / "datasets",
-                skip_shadow_report=True,
-                bot_commit="e" * 40,
-                eval_ratio_value=0,
-                repo_root=Path.cwd(),
-            )
+            scanned_roots: list[Path] = []
+            real_iter_directory_files = dataset_export.iter_directory_files
+
+            def counting_iter_directory_files(root_path: Path, *args: Any, **kwargs: Any) -> list[Path]:
+                scanned_roots.append(root_path.resolve())
+                return real_iter_directory_files(root_path, *args, **kwargs)
+
+            with mock.patch.object(dataset_export, "iter_directory_files", side_effect=counting_iter_directory_files):
+                report = gate.run_gate(
+                    [str(artifact_root), str(artifact_root)],
+                    out_dir=root / "gates",
+                    gate_id="gate-deduped-input-root",
+                    created_at="2026-05-21T03:03:07Z",
+                    dataset_out_dir=root / "datasets",
+                    skip_shadow_report=True,
+                    bot_commit="e" * 40,
+                    eval_ratio_value=0,
+                    repo_root=Path.cwd(),
+                )
             source_index = read_json(root / "datasets" / report["dataset"]["runId"] / "source_index.json")
 
         self.assertTrue(report["ok"])
         self.assertEqual(report["dataset"]["runtimeSummaryArtifactCount"], 1)
         self.assertEqual(report["quality_checks"]["samples_total"], 1)
         self.assertEqual(source_index["scannedFiles"], 1)
+        self.assertEqual(scanned_roots, [artifact_root.resolve()])
 
     def test_home_room_env_var_controls_no_owned_spawns_rejection(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -240,6 +240,46 @@ class RlSimulatorHarnessTest(unittest.TestCase):
         )
         self.assertEqual([item["workDir"] for item in manifest["privateSmoke"]], [None, "/tmp/screeps-private-smoke"])
 
+    def test_source_index_metadata_rejects_invalid_skipped_file_counts(self) -> None:
+        source = harness.dataset_export.SourceFile(
+            source_id="source-index",
+            path="source_index.json",
+            display_path="source_index.json",
+            size_bytes=100,
+            sha256="0" * 64,
+        )
+        metadata: harness.JsonObject = {
+            "datasets": {
+                "runManifests": [],
+                "scenarioManifests": [],
+                "sourceIndexes": [],
+                "exportSummaries": [],
+            },
+        }
+
+        for line_number, skipped_file_count in enumerate((-1, 2.5, "3"), start=1):
+            harness.append_dataset_metadata(
+                metadata,
+                source,
+                line_number,
+                {
+                    "type": "screeps-rl-source-index",
+                    "skippedFileCount": skipped_file_count,
+                    "skippedFiles": [{"path": "a.log"}, {"path": "b.log"}],
+                },
+            )
+        harness.append_dataset_metadata(
+            metadata,
+            source,
+            4,
+            {"type": "screeps-rl-source-index", "skippedFileCount": 3.0, "skippedFiles": [{"path": "a.log"}]},
+        )
+
+        self.assertEqual(
+            [item["skippedFileCount"] for item in metadata["datasets"]["sourceIndexes"]],
+            [2, 2, 2, 3],
+        )
+
     def test_estimated_worker_rate_records_target_comparison(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary
- Bounds E1 dataset `source_index.json` skipped-file logging instead of materializing every skipped file.
- Keeps aggregate skipped-file counts/reasons/truncation metadata so downstream reports retain provenance.
- Teaches simulator metadata ingestion to read the new `skippedFileCount` field while remaining backward-compatible with older `skippedFiles` lists.

## Related issue
Refs #1534

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_dataset_export.py scripts/screeps_rl_simulator_harness.py scripts/test_screeps_rl_dataset_export.py scripts/test_screeps_rl_dataset_gate.py`
- `python3 -m pytest scripts/test_screeps_rl_dataset_export.py scripts/test_screeps_rl_dataset_gate.py -q` → 36 passed
- Bounded E1 gate run from the PR worktree: `python3 scripts/screeps_rl_dataset_gate.py run --out-dir /tmp/e1-verify-1534-run/gates --gate-id verify-1534 --dataset-out-dir /tmp/e1-verify-1534-run/datasets --sample-limit 200 --skip-shadow-report /root/screeps/runtime-artifacts/runtime-summary-console` → `ok=true`, 200 samples, acceptance rate 1.0, no timeout.
- Source index spot-check: `/tmp/e1-verify-1534-run/datasets/rl-d16f7470e3ec/source_index.json` is 1,673,215 bytes with `skippedFileCount=4625`, `skippedFiles` bounded to 100, `skippedFilesTruncated=4525`.

## Universal task Done gate
- [x] Task type: RL flywheel code fix for recurring E1 gate timeout evidence path.
- [x] Expected observable outcome / named deliverable: bounded source-index skipped-file summary plus backward-compatible metadata ingestion.
- [x] Non-goals / accepted substitutes: no paid Tencent compute, no official MMO writes, no cron schedule changes.
- [x] Verification evidence required before Done: controller verification commands above and bounded local E1 gate run evidence above.
- [x] Project Evidence / Next action / Blocked by: PR and issue Project items updated with commit/test/e1-verify evidence; next action is exact-head CI and automated review gate.
- [x] Post-merge/deploy/runtime proof: next E1 cron run will use the merged bounded source-index path; local PR-branch gate proof is recorded above for the same command surface.
- [x] Named deliverable proof: commit `2d697426` changes `scripts/screeps_rl_dataset_export.py`, `scripts/screeps_rl_simulator_harness.py`, and focused tests only.

## Safety
- Analysis/code path only; no live policy control.
- No secrets printed or touched.
- Paid Tencent validation remains held by the existing recurrence guard.
