### PR TITLE
fix: suppress recovery telemetry under low CPU bucket

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -48248,14 +48248,20 @@ var Kernel = class {
     this.dependencies.initializeMemory();
     this.dependencies.cleanupDeadCreepMemory();
     const defenseEvents = this.dependencies.runDefense();
-    const forwardedEvents = selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime45());
+    const cpuBudget = getRuntimeCpuBudget();
+    const forwardedEvents = selectForwardedDefenseEvents(
+      defenseEvents,
+      this.lastForwardedDefenseEventTick,
+      getGameTime45(),
+      cpuBudget
+    );
     return hasKernelRunOptions(options) ? this.dependencies.runEconomy(forwardedEvents, options) : this.dependencies.runEconomy(forwardedEvents);
   }
 };
 function hasKernelRunOptions(options) {
   return options.strategyRegistry !== void 0 || options.runtimeStrategyConstructionEnabled !== void 0 || options.onStrategyRegistryRuntimeUse !== void 0;
 }
-function selectForwardedDefenseEvents(events, lastForwardedDefenseEventTick, tick) {
+function selectForwardedDefenseEvents(events, lastForwardedDefenseEventTick, tick, cpuBudget) {
   const forwardedEvents = [];
   pruneStaleForwardedDefenseEvents(lastForwardedDefenseEventTick, tick);
   const prioritizedEvents = events.map((event, index) => ({ event, index })).sort(
@@ -48264,7 +48270,7 @@ function selectForwardedDefenseEvents(events, lastForwardedDefenseEventTick, tic
   for (const { event } of prioritizedEvents) {
     if (event.type !== "defense") {
       forwardedEvents.push(event);
-    } else if (shouldForwardDefenseEvent(event, lastForwardedDefenseEventTick, tick)) {
+    } else if (shouldForwardDefenseEvent(event, lastForwardedDefenseEventTick, tick, cpuBudget)) {
       forwardedEvents.push(event);
     }
     if (forwardedEvents.length >= MAX_FORWARDED_DEFENSE_EVENTS_PER_TICK) {
@@ -48273,7 +48279,10 @@ function selectForwardedDefenseEvents(events, lastForwardedDefenseEventTick, tic
   }
   return forwardedEvents;
 }
-function shouldForwardDefenseEvent(event, lastForwardedDefenseEventTick, tick) {
+function shouldForwardDefenseEvent(event, lastForwardedDefenseEventTick, tick, cpuBudget) {
+  if (shouldSuppressRecoveryDefenseTelemetry(event, cpuBudget)) {
+    return false;
+  }
   if (event.action === "safeMode") {
     return true;
   }
@@ -48284,6 +48293,15 @@ function shouldForwardDefenseEvent(event, lastForwardedDefenseEventTick, tick) {
   }
   lastForwardedDefenseEventTick.set(key, tick);
   return true;
+}
+function shouldSuppressRecoveryDefenseTelemetry(event, cpuBudget) {
+  if (!hasLowBucketPressure2(cpuBudget) || event.hostileCreepCount > 0 || event.hostileStructureCount > 0) {
+    return false;
+  }
+  return event.action === "towerRepair" || event.action === "towerHeal";
+}
+function hasLowBucketPressure2(cpuBudget) {
+  return cpuBudget.reasons.includes("lowBucket") || cpuBudget.reasons.includes("criticalBucket");
 }
 function pruneStaleForwardedDefenseEvents(lastForwardedDefenseEventTick, tick) {
   for (const [key, lastForwardedTick] of lastForwardedDefenseEventTick) {

--- a/prod/src/kernel/Kernel.ts
+++ b/prod/src/kernel/Kernel.ts
@@ -4,6 +4,7 @@ import { runEconomy } from '../economy/economyLoop';
 import { RUNTIME_SUMMARY_INTERVAL, type RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
 import type { RuntimeSummary } from '../telemetry/runtimeSummary';
 import type { StrategyRegistryEntry } from '../strategy/strategyRegistry';
+import { getRuntimeCpuBudget, type RuntimeCpuBudget } from '../runtime/cpuBudget';
 
 const MAX_FORWARDED_DEFENSE_EVENTS_PER_TICK = 5;
 const DEFENSE_EVENT_FORWARDING_TTL_TICKS = RUNTIME_SUMMARY_INTERVAL;
@@ -40,7 +41,13 @@ export class Kernel {
     this.dependencies.initializeMemory();
     this.dependencies.cleanupDeadCreepMemory();
     const defenseEvents = this.dependencies.runDefense();
-    const forwardedEvents = selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime());
+    const cpuBudget = getRuntimeCpuBudget();
+    const forwardedEvents = selectForwardedDefenseEvents(
+      defenseEvents,
+      this.lastForwardedDefenseEventTick,
+      getGameTime(),
+      cpuBudget
+    );
     return hasKernelRunOptions(options)
       ? this.dependencies.runEconomy(forwardedEvents, options)
       : this.dependencies.runEconomy(forwardedEvents);
@@ -58,7 +65,8 @@ function hasKernelRunOptions(options: KernelRunOptions): boolean {
 function selectForwardedDefenseEvents(
   events: RuntimeTelemetryEvent[],
   lastForwardedDefenseEventTick: Map<string, number>,
-  tick: number
+  tick: number,
+  cpuBudget: RuntimeCpuBudget
 ): RuntimeTelemetryEvent[] {
   const forwardedEvents: RuntimeTelemetryEvent[] = [];
   pruneStaleForwardedDefenseEvents(lastForwardedDefenseEventTick, tick);
@@ -72,7 +80,7 @@ function selectForwardedDefenseEvents(
   for (const { event } of prioritizedEvents) {
     if (event.type !== 'defense') {
       forwardedEvents.push(event);
-    } else if (shouldForwardDefenseEvent(event, lastForwardedDefenseEventTick, tick)) {
+    } else if (shouldForwardDefenseEvent(event, lastForwardedDefenseEventTick, tick, cpuBudget)) {
       forwardedEvents.push(event);
     }
 
@@ -87,8 +95,13 @@ function selectForwardedDefenseEvents(
 function shouldForwardDefenseEvent(
   event: Extract<RuntimeTelemetryEvent, { type: 'defense' }>,
   lastForwardedDefenseEventTick: Map<string, number>,
-  tick: number
+  tick: number,
+  cpuBudget: RuntimeCpuBudget
 ): boolean {
+  if (shouldSuppressRecoveryDefenseTelemetry(event, cpuBudget)) {
+    return false;
+  }
+
   if (event.action === 'safeMode') {
     return true;
   }
@@ -105,6 +118,21 @@ function shouldForwardDefenseEvent(
 
   lastForwardedDefenseEventTick.set(key, tick);
   return true;
+}
+
+function shouldSuppressRecoveryDefenseTelemetry(
+  event: Extract<RuntimeTelemetryEvent, { type: 'defense' }>,
+  cpuBudget: RuntimeCpuBudget
+): boolean {
+  if (!hasLowBucketPressure(cpuBudget) || event.hostileCreepCount > 0 || event.hostileStructureCount > 0) {
+    return false;
+  }
+
+  return event.action === 'towerRepair' || event.action === 'towerHeal';
+}
+
+function hasLowBucketPressure(cpuBudget: RuntimeCpuBudget): boolean {
+  return cpuBudget.reasons.includes('lowBucket') || cpuBudget.reasons.includes('criticalBucket');
 }
 
 function pruneStaleForwardedDefenseEvents(

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -172,6 +172,27 @@ describe('runEconomy', () => {
     expect(shouldRunCreepForCpuBudget(creep('scout'), criticalBudget)).toBe(false);
   });
 
+  it('keeps creep execution active during noncritical low-bucket recovery', () => {
+    const lowBucketBudget = buildRuntimeCpuBudget({
+      tick: 126,
+      used: 65,
+      limit: 70,
+      bucket: 101,
+      tickLimit: 500
+    });
+    const room = {
+      name: 'W1N1',
+      controller: { my: true, ticksToDowngrade: CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS + 1 } as StructureController
+    } as Room;
+    const creep = (role: string, memory: Partial<CreepMemory> = {}): Creep =>
+      ({ memory: { role, ...memory }, room }) as unknown as Creep;
+
+    expect(shouldRunCreepForCpuBudget(creep('worker'), lowBucketBudget)).toBe(true);
+    expect(shouldRunCreepForCpuBudget(creep('upgrader'), lowBucketBudget)).toBe(true);
+    expect(shouldRunCreepForCpuBudget(creep('claimer'), lowBucketBudget)).toBe(true);
+    expect(shouldRunCreepForCpuBudget(creep('scout'), lowBucketBudget)).toBe(true);
+  });
+
   it('spawns a worker request for an owned colony below target workers', () => {
     const room = { name: 'W1N1', energyAvailable: 300, energyCapacityAvailable: 300 } as Room;
     const spawn = {

--- a/prod/test/kernel.test.ts
+++ b/prod/test/kernel.test.ts
@@ -148,6 +148,82 @@ describe('Kernel', () => {
     expect(runEconomy).toHaveBeenNthCalledWith(2, [safeModeEvent]);
   });
 
+  it('suppresses recovery defense telemetry during low-bucket recovery while still running economy', () => {
+    const towerRepairEvent = makeDefenseEvent({
+      action: 'towerRepair',
+      reason: 'criticalStructureDamaged',
+      hostileCreepCount: 0,
+      hostileStructureCount: 0,
+      damagedCriticalStructureCount: 12,
+      structureId: 'tower1',
+      targetId: 'rampart1'
+    });
+    const runDefense = jest.fn().mockReturnValue([towerRepairEvent]);
+    const runEconomy = jest.fn();
+    const kernel = new Kernel({
+      initializeMemory: jest.fn(),
+      cleanupDeadCreepMemory: jest.fn(),
+      runDefense,
+      runEconomy
+    });
+
+    setGameTime(501, { used: 65, limit: 70, bucket: 101, tickLimit: 500 });
+    kernel.run();
+
+    expect(runDefense).toHaveBeenCalledTimes(1);
+    expect(runEconomy).toHaveBeenCalledWith([]);
+  });
+
+  it('forwards recovery defense telemetry when CPU bucket is healthy', () => {
+    const towerRepairEvent = makeDefenseEvent({
+      action: 'towerRepair',
+      reason: 'criticalStructureDamaged',
+      hostileCreepCount: 0,
+      hostileStructureCount: 0,
+      damagedCriticalStructureCount: 12,
+      structureId: 'tower1',
+      targetId: 'rampart1'
+    });
+    const runEconomy = jest.fn();
+    const kernel = new Kernel({
+      initializeMemory: jest.fn(),
+      cleanupDeadCreepMemory: jest.fn(),
+      runDefense: jest.fn().mockReturnValue([towerRepairEvent]),
+      runEconomy
+    });
+
+    setGameTime(601, { used: 12, limit: 70, bucket: 9_000, tickLimit: 500 });
+    kernel.run();
+
+    expect(runEconomy).toHaveBeenCalledWith([towerRepairEvent]);
+  });
+
+  it('keeps critical defense telemetry during low-bucket recovery', () => {
+    const safeModeEvent = makeDefenseEvent({
+      action: 'safeMode',
+      reason: 'safeModeEarlyRoomThreat',
+      targetId: 'controller1'
+    });
+    const towerAttackEvent = makeDefenseEvent({
+      action: 'towerAttack',
+      reason: 'hostileVisible',
+      hostileCreepCount: 1,
+      targetId: 'hostile1'
+    });
+    const runEconomy = jest.fn();
+    const kernel = new Kernel({
+      initializeMemory: jest.fn(),
+      cleanupDeadCreepMemory: jest.fn(),
+      runDefense: jest.fn().mockReturnValue([towerAttackEvent, safeModeEvent]),
+      runEconomy
+    });
+
+    setGameTime(701, { used: 65, limit: 70, bucket: 101, tickLimit: 500 });
+    kernel.run();
+
+    expect(runEconomy).toHaveBeenCalledWith([safeModeEvent, towerAttackEvent]);
+  });
+
   it('forwards strategy runtime-use options to the economy loop', () => {
     const runEconomy = jest.fn();
     const onStrategyRegistryRuntimeUse = jest.fn();
@@ -195,6 +271,19 @@ function makeDefenseEvent(
   };
 }
 
-function setGameTime(time: number): void {
-  (globalThis as unknown as { Game: Partial<Game> }).Game = { time };
+function setGameTime(
+  time: number,
+  cpu?: { used: number; limit: number; bucket: number; tickLimit: number }
+): void {
+  const game: Partial<Game> = { time };
+  if (cpu) {
+    game.cpu = {
+      getUsed: jest.fn().mockReturnValue(cpu.used),
+      limit: cpu.limit,
+      bucket: cpu.bucket,
+      tickLimit: cpu.tickLimit
+    } as unknown as CPU;
+  }
+
+  (globalThis as unknown as { Game: Partial<Game> }).Game = game;
 }

--- a/prod/test/kernel.test.ts
+++ b/prod/test/kernel.test.ts
@@ -174,6 +174,30 @@ describe('Kernel', () => {
     expect(runEconomy).toHaveBeenCalledWith([]);
   });
 
+  it('forwards recovery defense telemetry during low-bucket recovery when hostiles are present', () => {
+    const towerRepairEvent = makeDefenseEvent({
+      action: 'towerRepair',
+      reason: 'criticalStructureDamaged',
+      hostileCreepCount: 1,
+      hostileStructureCount: 0,
+      damagedCriticalStructureCount: 12,
+      structureId: 'tower1',
+      targetId: 'rampart1'
+    });
+    const runEconomy = jest.fn();
+    const kernel = new Kernel({
+      initializeMemory: jest.fn(),
+      cleanupDeadCreepMemory: jest.fn(),
+      runDefense: jest.fn().mockReturnValue([towerRepairEvent]),
+      runEconomy
+    });
+
+    setGameTime(551, { used: 65, limit: 70, bucket: 101, tickLimit: 500 });
+    kernel.run();
+
+    expect(runEconomy).toHaveBeenCalledWith([towerRepairEvent]);
+  });
+
   it('forwards recovery defense telemetry when CPU bucket is healthy', () => {
     const towerRepairEvent = makeDefenseEvent({
       action: 'towerRepair',


### PR DESCRIPTION
## Summary
- Suppress noncritical tower repair/heal defense telemetry while the CPU bucket is under low-bucket pressure and no hostiles are visible.
- Preserve economy/creep execution during noncritical low-bucket recovery.
- Add regression coverage for low-bucket telemetry suppression, critical defense forwarding, and creep-execution behavior.

Refs #1536

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (103 suites / 2119 tests passed)
- `cd prod && npm run build`

## Safety
- No paid Tencent compute.
- No official MMO writes from this branch.
- CPU guard keeps safeMode/towerAttack telemetry and all noncritical creep execution intact.

## Universal task Done gate
- [x] Task type: P1 runtime reliability code hotfix for official MMO CPU-bucket recurrence.
- [x] Expected observable outcome / named deliverable: Codex-authored PR with Kernel low-bucket telemetry suppression, tests, and synchronized bundled artifact.
- [x] Non-goals / accepted substitutes: No paid Tencent compute; no official MMO writes; no passive-mode shutdown of survival/economy behavior.
- [x] Verification evidence required before Done: controller ran diff-check, TypeScript check, full Jest suite 103/103 suites and 2119/2119 tests, and production bundle build on commit 5aa1f4a1.
- [x] Project Evidence / Next action / Blocked by: issue 1536 Project item records In progress recovery lane; PR Project item records review gate and exact commit evidence; runtime acceptance continues through issue 1536.
- [x] Post-merge/deploy/runtime proof: deterministic PR proof is commit 5aa1f4a1 plus verified build artifact; runtime monitor archive scheduler-check-20260531T051130Z is the triggering baseline for issue 1536 acceptance tracking.
- [x] Named deliverable proof: changed files are prod/src/kernel/Kernel.ts, prod/test/economyLoop.test.ts, prod/test/kernel.test.ts, and prod/dist/main.js with Codex author lanyusea's bot.
