### PR TITLE
docs: sync cron registry to DeepSeek model switch

### DIFF
--- a/docs/ops/cron-and-route-registry.md
+++ b/docs/ops/cron-and-route-registry.md
@@ -71,21 +71,21 @@ Repeat policy values:
 | Job | ID | Schedule | Delivery | Provider | Model | Workdir | Repeat | Criticality | Purpose |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Screeps autonomous continuation worker | `f66ed36d7be0` | `8,28,48 * * * *` | `discord:#task-queue` | `openai-codex` | `gpt-5.5` | `/root/screeps` | `high-horizon` | P0 | Dispatcher/reconciler for safe work lanes. |
-| Screeps P0 agent operations monitor | `75cedbb77150` | `7,37 * * * *` | `discord:1497820688843800776` | `minimax-cn` | `MiniMax-M2.7` | `-` | `forever` | P0 | Autonomous-system health monitor, registry-drift detector, and consolidated Tencent Cloud cost guard. |
+| Screeps P0 agent operations monitor | `75cedbb77150` | `7,37 * * * *` | `discord:1497820688843800776` | `deepseek` | `deepseek-v4-flash` | `-` | `forever` | P0 | Autonomous-system health monitor, registry-drift detector, and consolidated Tencent Cloud cost guard. |
 | Screeps runtime room alert text check | `1df5ef0c3835` | `1,16,31,46 * * * *` | `discord:1497588512436785284` | `openai-codex` | `gpt-5.5` | `-` | `forever` | P0 | Runtime alert/tactical response for all owned rooms; no-alert runs return exactly `[SILENT]`. |
-| Screeps owner-decision escalation fanout | `bbc7f783075e` | `3,13,23,33,43,53 * * * *` | `discord:1497586175580311654` | `minimax-cn` | `MiniMax-M2.7` | `-` | `high-horizon` | P0 | Mirrors fresh unresolved owner-action decisions to the canonical decisions route. |
-| Screeps runtime room summary images | `befcbb7b2d60` | `58 * * * *` | `discord:1497588267057680385` | `minimax-cn` | `MiniMax-M2.7` | `-` | `high-horizon` | P1 | Runtime summary report/images for all owned rooms. |
-| Screeps console capture (live energy telemetry) | `7ee147327ba6` | `*/30 * * * *` | `local` | `minimax-cn` | `MiniMax-M2.7` | `-` | `forever` | P1 | Local bounded console/energy telemetry collector. |
-| Screeps dev-log fanout reporter | `d3bf35c278d5` | `25,55 * * * *` | `discord:#dev-log` | `minimax-cn` | `MiniMax-M2.7` | `-` | `forever` | P1 | Dev log fanout from live repo/cron state. |
-| Screeps research-notes fanout reporter | `3c0d20aa2e45` | `10,40 * * * *` | `discord:#research-notes` | `minimax-cn` | `MiniMax-M2.7` | `-` | `forever` | P1 | Research/RL progress fanout. |
-| Screeps 6h development report | `dfcaf65d7ea7` | `47 */6 * * *` | `discord:1497587260835758222:1497833662241181746` | `minimax-cn` | `MiniMax-M2.7` | `-` | `high-horizon` | P1 | Threaded 6h health/progress report. |
-| Screeps Gameplay Evolution Review | `c7b3dda8f1ac` | `0 */8 * * *` | `discord:#task-queue` | `minimax-cn` | `MiniMax-M2.7` | `-` | `high-horizon` | P1 | 8h strategy review for current target `E29N55`. |
-| Screeps Gameplay Evolution Review decisions archive | `dc1c46787f2e` | `15 */8 * * *` | `discord:1497586175580311654` | `minimax-cn` | `MiniMax-M2.7` | `-` | `high-horizon` | P1 | Archive accepted strategy decisions/current strategy. |
+| Screeps owner-decision escalation fanout | `bbc7f783075e` | `3,13,23,33,43,53 * * * *` | `discord:1497586175580311654` | `deepseek` | `deepseek-v4-flash` | `-` | `high-horizon` | P0 | Mirrors fresh unresolved owner-action decisions to the canonical decisions route. |
+| Screeps runtime room summary images | `befcbb7b2d60` | `58 * * * *` | `discord:1497588267057680385` | `deepseek` | `deepseek-v4-flash` | `-` | `high-horizon` | P1 | Runtime summary report/images for all owned rooms. |
+| Screeps console capture (live energy telemetry) | `7ee147327ba6` | `*/30 * * * *` | `local` | `deepseek` | `deepseek-v4-flash` | `-` | `forever` | P1 | Local bounded console/energy telemetry collector. |
+| Screeps dev-log fanout reporter | `d3bf35c278d5` | `25,55 * * * *` | `discord:#dev-log` | `deepseek` | `deepseek-v4-flash` | `-` | `forever` | P1 | Dev log fanout from live repo/cron state. |
+| Screeps research-notes fanout reporter | `3c0d20aa2e45` | `10,40 * * * *` | `discord:#research-notes` | `deepseek` | `deepseek-v4-flash` | `-` | `forever` | P1 | Research/RL progress fanout. |
+| Screeps 6h development report | `dfcaf65d7ea7` | `47 */6 * * *` | `discord:1497587260835758222:1497833662241181746` | `deepseek` | `deepseek-v4-flash` | `-` | `high-horizon` | P1 | Threaded 6h health/progress report. |
+| Screeps Gameplay Evolution Review | `c7b3dda8f1ac` | `0 */8 * * *` | `discord:#task-queue` | `deepseek` | `deepseek-v4-flash` | `-` | `high-horizon` | P1 | 8h strategy review for current target `E29N55`. |
+| Screeps Gameplay Evolution Review decisions archive | `dc1c46787f2e` | `15 */8 * * *` | `discord:1497586175580311654` | `deepseek` | `deepseek-v4-flash` | `-` | `high-horizon` | P1 | Archive accepted strategy decisions/current strategy. |
 | Screeps RL flywheel steward | `aed8362e4501` | `17 * * * *` | `discord:#task-queue` | `openai-codex` | `gpt-5.5` | `/root/screeps` | `high-horizon` | P1 | RL flywheel stewardship and issue/Project reconciliation. |
-| Screeps RL shadow-eval pipeline | `d6cff532edd4` | `5 * * * *` | `discord:#task-queue` | `minimax-cn` | `MiniMax-M2.7` | `/root/screeps` | `high-horizon` | P1 | Shadow-eval ledger producer for RL candidate/baseline evidence. |
-| Screeps RL training execution ledger | `5c869e7d8a1d` | `14,44 * * * *` | `discord:#task-queue` | `minimax-cn` | `MiniMax-M2.7` | `-` | `high-horizon` | P1 | Training execution ledger for offline/private RL campaigns; owns Tencent RL utilization control through its preflight instead of a standalone cron. |
-| Screeps RL policy online advantage ledger | `01609968392a` | `27,57 * * * *` | `discord:#task-queue` | `minimax-cn` | `MiniMax-M2.7` | `/root/screeps` | `high-horizon` | P1 | Online advantage ledger comparing candidate policy signals against baseline. |
-| Hermes state daily backup | `bf68a3951853` | `0 4 * * *` | `local` | `minimax-cn` | `MiniMax-M2.7` | `-` | `forever` | Support | Daily private Hermes-state backup. |
+| Screeps RL shadow-eval bounded gate | `d6cff532edd4` | `5 * * * *` | `discord:#task-queue` | `deepseek` | `deepseek-v4-flash` | `-` | `high-horizon` | P1 | Shadow-eval ledger producer for RL candidate/baseline evidence. |
+| Screeps RL training execution ledger | `5c869e7d8a1d` | `14,44 * * * *` | `discord:#task-queue` | `deepseek` | `deepseek-v4-flash` | `-` | `high-horizon` | P1 | Training execution ledger for offline/private RL campaigns; owns Tencent RL utilization control through its preflight instead of a standalone cron. |
+| Screeps RL policy online advantage ledger | `01609968392a` | `27,57 * * * *` | `discord:#task-queue` | `deepseek` | `deepseek-v4-flash` | `/root/screeps` | `high-horizon` | P1 | Online advantage ledger comparing candidate policy signals against baseline. |
+| Hermes state daily backup | `bf68a3951853` | `0 4 * * *` | `local` | `deepseek` | `deepseek-v4-flash` | `-` | `forever` | Support | Daily private Hermes-state backup. |
 
 ## Transient and retired cron jobs
 

--- a/scripts/test_check_cron_registry.py
+++ b/scripts/test_check_cron_registry.py
@@ -45,13 +45,13 @@ class CronRegistryCompareTests(unittest.TestCase):
         live = {
             "recurring-job": live_recurring_job(),
             "one-shot-migration": {
-                "name": "MiniMax one-shot migration",
+                "name": "DeepSeek one-shot migration",
                 "enabled": True,
                 "state": "scheduled",
                 "schedule": "at 2026-05-23 12:00",
                 "deliver": "local",
-                "provider": "minimax-cn",
-                "model": "MiniMax-M2.7",
+                "provider": "deepseek",
+                "model": "deepseek-v4-flash",
                 "repeat": {"times": 1, "completed": 0},
             },
         }
@@ -70,13 +70,13 @@ class CronRegistryCompareTests(unittest.TestCase):
         live = {
             "recurring-job": live_recurring_job(),
             "one-shot-repeat-string": {
-                "name": "MiniMax one-shot migration",
+                "name": "DeepSeek one-shot migration",
                 "enabled": True,
                 "state": "scheduled",
                 "schedule": "at 2026-05-23 12:00",
                 "deliver": "local",
-                "provider": "minimax-cn",
-                "model": "MiniMax-M2.7",
+                "provider": "deepseek",
+                "model": "deepseek-v4-flash",
                 "repeat": "1/1",
             },
         }


### PR DESCRIPTION
## Summary
- Syncs the Screeps cron/route registry to the owner-requested DeepSeek migration for 13 non-Codex recurring cron jobs.
- Updates the registry entry for `d6cff532edd4` to match the live renamed `Screeps RL shadow-eval bounded gate` job and its no-workdir configuration.
- Updates the cron registry unit-test fixtures so one-shot migration examples no longer carry the retired MiniMax provider/model names.

## Linked issue
- None pre-existing. Related to the owner-requested operational DeepSeek cron migration in Discord.

## Roadmap category
- Agent OS / cron operations hygiene.

## Universal task Done gate
- [x] Task type: docs/test/ops registry sync.
- [x] Expected observable outcome / named deliverable: live cron registry checker passes strict mode against the current scheduler after the model switch.
- [x] Non-goals / accepted substitutes: no production Screeps bot code change; no Codex-owned `prod/` implementation change.
- [x] Verification evidence required before Done: `python3 scripts/check_cron_registry.py --strict`; `python3 -m unittest scripts/test_check_cron_registry.py`; `git diff --check`.
- [x] Project Evidence / Next action / Blocked by: PR is the evidence surface; next action is normal PR review/merge gate; no owner blocker.
- [x] Post-merge/deploy/runtime proof: N/A for docs/test registry sync; live runtime proof is the scheduler metadata and strict registry check.
- [x] Named deliverable proof: strict registry checker reports 16 expected recurring jobs, 16 live jobs, 0 missing, 0 unexpected, 0 one-shot ignored, 0 mismatches.

## Test plan
- [x] `python3 scripts/check_cron_registry.py --strict`
- [x] `python3 -m unittest scripts/test_check_cron_registry.py`
- [x] `git diff --check`
