### PR TITLE
fix: make rl grafana durable

### DIFF
--- a/docs/ops/grafana/README.md
+++ b/docs/ops/grafana/README.md
@@ -12,6 +12,8 @@ This directory is the durable local Grafana contract for the RL flywheel metrics
 
 The datasource UID is `screeps-rl-metrics-sqlite`; the dashboard UID is `screeps-rl-gameplay-metrics`.
 
+Dashboard targets must keep the frser SQLite fields `rawQueryText`, `queryType`, and, for time-series panels, `timeColumns: ["time"]`; the validator fails when those tracked fields drift.
+
 ## Local Run
 
 Print the Docker command without starting Grafana:
@@ -20,11 +22,13 @@ Print the Docker command without starting Grafana:
 npm run rl-grafana:print-command
 ```
 
-Run actual Grafana on `127.0.0.1:3000`:
+Start or restore actual Grafana on `127.0.0.1:3000`:
 
 ```bash
 npm run rl-grafana:run
 ```
+
+The runner is durable by default: it creates a detached Docker container named `screeps-rl-grafana` with `--restart unless-stopped`, or starts the existing named container and refreshes its restart policy. The port binding remains loopback-only unless an operator explicitly passes the non-local override.
 
 The default image is `grafana/grafana-oss:11.5.2`; pass `-- --image <image>` to the npm command if the operator intentionally validates a different Grafana image.
 
@@ -32,7 +36,7 @@ The runner mounts:
 
 - `docs/ops/grafana/provisioning` at `/etc/grafana/provisioning`;
 - `docs/ops/grafana` at `/var/lib/grafana/dashboards/screeps`;
-- `runtime-artifacts/rl-metrics` at `/var/lib/grafana/rl-metrics`.
+- `runtime-artifacts/rl-metrics/rl_metrics.sqlite` at `/var/lib/grafana/rl-metrics/rl_metrics.sqlite`.
 
 The container installs the `frser-sqlite-datasource` plugin through `GF_INSTALL_PLUGINS`. The host database file must exist before starting the container:
 

--- a/docs/ops/grafana/screeps-rl-gameplay-metrics.json
+++ b/docs/ops/grafana/screeps-rl-gameplay-metrics.json
@@ -39,7 +39,9 @@
           "format": "table",
           "queryText": "SELECT observed_at, tick, room_name, metric_name, value, source_artifact FROM metric_observations WHERE metric_name IN ('survival.owned_rooms','survival.owned_spawns','survival.claimed_room_without_spawn_age_ticks') ORDER BY observed_at DESC LIMIT 200;",
           "rawQuery": true,
-          "refId": "A"
+          "refId": "A",
+          "rawQueryText": "SELECT observed_at, tick, room_name, metric_name, value, source_artifact FROM metric_observations WHERE metric_name IN ('survival.owned_rooms','survival.owned_spawns','survival.claimed_room_without_spawn_age_ticks') ORDER BY observed_at DESC LIMIT 200;",
+          "queryType": "table"
         }
       ],
       "title": "Survival And Ownership",
@@ -79,7 +81,12 @@
           "format": "time_series",
           "queryText": "SELECT observed_at AS time, room_name || ':' || metric_name AS metric, value FROM metric_observations WHERE metric_name IN ('economy.energy_available','economy.stored_energy','economy.worker_carried_energy') ORDER BY observed_at;",
           "rawQuery": true,
-          "refId": "A"
+          "refId": "A",
+          "rawQueryText": "SELECT observed_at AS time, room_name || ':' || metric_name AS metric, value FROM metric_observations WHERE metric_name IN ('economy.energy_available','economy.stored_energy','economy.worker_carried_energy') ORDER BY observed_at;",
+          "queryType": "time series",
+          "timeColumns": [
+            "time"
+          ]
         }
       ],
       "title": "Resource Economy",
@@ -109,13 +116,17 @@
           "format": "table",
           "queryText": "SELECT observed_at, tick, room_name, metric_name, value, source_artifact FROM metric_observations WHERE metric_name IN ('construction.backlog_progress','construction.build_task_count','construction.built_progress','construction.build_carried_energy') ORDER BY observed_at DESC LIMIT 200;",
           "rawQuery": true,
-          "refId": "A"
+          "refId": "A",
+          "rawQueryText": "SELECT observed_at, tick, room_name, metric_name, value, source_artifact FROM metric_observations WHERE metric_name IN ('construction.backlog_progress','construction.build_task_count','construction.built_progress','construction.build_carried_energy') ORDER BY observed_at DESC LIMIT 200;",
+          "queryType": "table"
         },
         {
           "format": "table",
           "queryText": "SELECT first_seen_at, severity, room_name, finding_key, evidence_json, recommendation FROM gameplay_behavior_findings WHERE category = 'stalled-construction' ORDER BY first_seen_at DESC LIMIT 50;",
           "rawQuery": true,
-          "refId": "B"
+          "refId": "B",
+          "rawQueryText": "SELECT first_seen_at, severity, room_name, finding_key, evidence_json, recommendation FROM gameplay_behavior_findings WHERE category = 'stalled-construction' ORDER BY first_seen_at DESC LIMIT 50;",
+          "queryType": "table"
         }
       ],
       "title": "Construction And Infrastructure",
@@ -145,13 +156,17 @@
           "format": "table",
           "queryText": "SELECT observed_at, tick, room_name, metric_name, value, evidence_json FROM metric_observations WHERE metric_name IN ('creep.worker_count','creep.low_load_return_count','creep.return_load_factor','creep.idle_count','creep.stuck_ticks','behavior.upgrade_dominance_ratio') ORDER BY observed_at DESC LIMIT 250;",
           "rawQuery": true,
-          "refId": "A"
+          "refId": "A",
+          "rawQueryText": "SELECT observed_at, tick, room_name, metric_name, value, evidence_json FROM metric_observations WHERE metric_name IN ('creep.worker_count','creep.low_load_return_count','creep.return_load_factor','creep.idle_count','creep.stuck_ticks','behavior.upgrade_dominance_ratio') ORDER BY observed_at DESC LIMIT 250;",
+          "queryType": "table"
         },
         {
           "format": "table",
           "queryText": "SELECT first_seen_at, severity, category, room_name, evidence_json, recommendation FROM gameplay_behavior_findings WHERE category IN ('low-load-return','stuck-actionless','upgrade-dominant-backlog') ORDER BY first_seen_at DESC LIMIT 100;",
           "rawQuery": true,
-          "refId": "B"
+          "refId": "B",
+          "rawQueryText": "SELECT first_seen_at, severity, category, room_name, evidence_json, recommendation FROM gameplay_behavior_findings WHERE category IN ('low-load-return','stuck-actionless','upgrade-dominant-backlog') ORDER BY first_seen_at DESC LIMIT 100;",
+          "queryType": "table"
         }
       ],
       "title": "Creep Efficiency, Stuck, And Load Factor",
@@ -181,13 +196,17 @@
           "format": "table",
           "queryText": "SELECT observed_at, tick, room_name, metric_name, value, source_artifact FROM metric_observations WHERE metric_name IN ('defense.hostile_creep_count','defense.tower_count','defense.rampart_count','construction.defense_backlog') ORDER BY observed_at DESC LIMIT 200;",
           "rawQuery": true,
-          "refId": "A"
+          "refId": "A",
+          "rawQueryText": "SELECT observed_at, tick, room_name, metric_name, value, source_artifact FROM metric_observations WHERE metric_name IN ('defense.hostile_creep_count','defense.tower_count','defense.rampart_count','construction.defense_backlog') ORDER BY observed_at DESC LIMIT 200;",
+          "queryType": "table"
         },
         {
           "format": "table",
           "queryText": "SELECT first_seen_at, severity, room_name, evidence_json, recommendation FROM gameplay_behavior_findings WHERE category = 'missing-late-defense-construction' ORDER BY first_seen_at DESC LIMIT 50;",
           "rawQuery": true,
-          "refId": "B"
+          "refId": "B",
+          "rawQueryText": "SELECT first_seen_at, severity, room_name, evidence_json, recommendation FROM gameplay_behavior_findings WHERE category = 'missing-late-defense-construction' ORDER BY first_seen_at DESC LIMIT 50;",
+          "queryType": "table"
         }
       ],
       "title": "Defense Readiness",
@@ -217,13 +236,17 @@
           "format": "table",
           "queryText": "SELECT observed_at, tick, metric_name, value, source_artifact FROM metric_observations WHERE metric_name IN ('cpu.bucket','cpu.used','reliability.loop_exception_count','reliability.telemetry_silence_ticks') ORDER BY observed_at DESC LIMIT 200;",
           "rawQuery": true,
-          "refId": "A"
+          "refId": "A",
+          "rawQueryText": "SELECT observed_at, tick, metric_name, value, source_artifact FROM metric_observations WHERE metric_name IN ('cpu.bucket','cpu.used','reliability.loop_exception_count','reliability.telemetry_silence_ticks') ORDER BY observed_at DESC LIMIT 200;",
+          "queryType": "table"
         },
         {
           "format": "table",
           "queryText": "SELECT first_seen_at, severity, finding_key, evidence_json, recommendation FROM gameplay_behavior_findings WHERE category = 'runtime-reliability' ORDER BY first_seen_at DESC LIMIT 50;",
           "rawQuery": true,
-          "refId": "B"
+          "refId": "B",
+          "rawQueryText": "SELECT first_seen_at, severity, finding_key, evidence_json, recommendation FROM gameplay_behavior_findings WHERE category = 'runtime-reliability' ORDER BY first_seen_at DESC LIMIT 50;",
+          "queryType": "table"
         }
       ],
       "title": "CPU And Reliability",
@@ -253,19 +276,25 @@
           "format": "table",
           "queryText": "SELECT observed_at, gate_id, status, metric_name, value, source_artifact FROM rl_dataset_gate_metrics ORDER BY observed_at DESC LIMIT 100;",
           "rawQuery": true,
-          "refId": "A"
+          "refId": "A",
+          "rawQueryText": "SELECT observed_at, gate_id, status, metric_name, value, source_artifact FROM rl_dataset_gate_metrics ORDER BY observed_at DESC LIMIT 100;",
+          "queryType": "table"
         },
         {
           "format": "table",
           "queryText": "SELECT observed_at, report_id, variant_id, metric_name, value, source_artifact FROM rl_training_execution_metrics ORDER BY observed_at DESC LIMIT 150;",
           "rawQuery": true,
-          "refId": "B"
+          "refId": "B",
+          "rawQueryText": "SELECT observed_at, report_id, variant_id, metric_name, value, source_artifact FROM rl_training_execution_metrics ORDER BY observed_at DESC LIMIT 150;",
+          "queryType": "table"
         },
         {
           "format": "table",
           "queryText": "SELECT observed_at, report_id, candidate_id, incumbent_id, metric_name, value, directionality FROM rl_policy_advantage_metrics ORDER BY observed_at DESC LIMIT 150;",
           "rawQuery": true,
-          "refId": "C"
+          "refId": "C",
+          "rawQueryText": "SELECT observed_at, report_id, candidate_id, incumbent_id, metric_name, value, directionality FROM rl_policy_advantage_metrics ORDER BY observed_at DESC LIMIT 150;",
+          "queryType": "table"
         }
       ],
       "title": "RL Dataset, Training, And Policy Metrics",
@@ -295,13 +324,17 @@
           "format": "table",
           "queryText": "SELECT observed_at, severity, metric_name, category, room_name, tick, gap_type, message, source_artifact FROM metric_coverage_gaps ORDER BY observed_at DESC LIMIT 250;",
           "rawQuery": true,
-          "refId": "A"
+          "refId": "A",
+          "rawQueryText": "SELECT observed_at, severity, metric_name, category, room_name, tick, gap_type, message, source_artifact FROM metric_coverage_gaps ORDER BY observed_at DESC LIMIT 250;",
+          "queryType": "table"
         },
         {
           "format": "table",
           "queryText": "SELECT metric_name, severity, COUNT(*) AS gap_count FROM metric_coverage_gaps GROUP BY metric_name, severity ORDER BY gap_count DESC, metric_name LIMIT 100;",
           "rawQuery": true,
-          "refId": "B"
+          "refId": "B",
+          "rawQueryText": "SELECT metric_name, severity, COUNT(*) AS gap_count FROM metric_coverage_gaps GROUP BY metric_name, severity ORDER BY gap_count DESC, metric_name LIMIT 100;",
+          "queryType": "table"
         }
       ],
       "title": "Metric Coverage Gaps",
@@ -331,7 +364,9 @@
           "format": "table",
           "queryText": "SELECT COALESCE(build_blocked_reason, 'missing') AS buildBlockedReason, COUNT(*) AS sample_count FROM runtime_room_metrics GROUP BY COALESCE(build_blocked_reason, 'missing') ORDER BY sample_count DESC;",
           "rawQuery": true,
-          "refId": "A"
+          "refId": "A",
+          "rawQueryText": "SELECT COALESCE(build_blocked_reason, 'missing') AS buildBlockedReason, COUNT(*) AS sample_count FROM runtime_room_metrics GROUP BY COALESCE(build_blocked_reason, 'missing') ORDER BY sample_count DESC;",
+          "queryType": "table"
         }
       ],
       "title": "Build Blocked Reason Distribution",
@@ -371,7 +406,12 @@
           "format": "time_series",
           "queryText": "SELECT observed_at AS time, room_name || ':extensions' AS metric, extension_count AS value FROM runtime_room_metrics WHERE extension_count IS NOT NULL UNION ALL SELECT observed_at AS time, room_name || ':extensionCapacity' AS metric, extension_capacity_contribution AS value FROM runtime_room_metrics WHERE extension_capacity_contribution IS NOT NULL ORDER BY time;",
           "rawQuery": true,
-          "refId": "A"
+          "refId": "A",
+          "rawQueryText": "SELECT observed_at AS time, room_name || ':extensions' AS metric, extension_count AS value FROM runtime_room_metrics WHERE extension_count IS NOT NULL UNION ALL SELECT observed_at AS time, room_name || ':extensionCapacity' AS metric, extension_capacity_contribution AS value FROM runtime_room_metrics WHERE extension_capacity_contribution IS NOT NULL ORDER BY time;",
+          "queryType": "time series",
+          "timeColumns": [
+            "time"
+          ]
         }
       ],
       "title": "Extension Count Trend",
@@ -411,7 +451,12 @@
           "format": "time_series",
           "queryText": "SELECT observed_at AS time, room_name || ':pathFindingFailures' AS metric, path_finding_failures AS value FROM runtime_room_metrics WHERE path_finding_failures IS NOT NULL UNION ALL SELECT observed_at AS time, room_name || ':destinationBlocked' AS metric, destination_blocked AS value FROM runtime_room_metrics WHERE destination_blocked IS NOT NULL ORDER BY time;",
           "rawQuery": true,
-          "refId": "A"
+          "refId": "A",
+          "rawQueryText": "SELECT observed_at AS time, room_name || ':pathFindingFailures' AS metric, path_finding_failures AS value FROM runtime_room_metrics WHERE path_finding_failures IS NOT NULL UNION ALL SELECT observed_at AS time, room_name || ':destinationBlocked' AS metric, destination_blocked AS value FROM runtime_room_metrics WHERE destination_blocked IS NOT NULL ORDER BY time;",
+          "queryType": "time series",
+          "timeColumns": [
+            "time"
+          ]
         }
       ],
       "title": "Path Finding Failures Rate",
@@ -441,7 +486,9 @@
           "format": "table",
           "queryText": "SELECT observed_at, tick, room_name, worker_load_trip_energy_mean AS tripEnergyMean, worker_load_trip_energy_min AS tripEnergyMin, source_artifact FROM runtime_room_metrics WHERE worker_load_trip_energy_mean IS NOT NULL OR worker_load_trip_energy_min IS NOT NULL ORDER BY observed_at DESC LIMIT 250;",
           "rawQuery": true,
-          "refId": "A"
+          "refId": "A",
+          "rawQueryText": "SELECT observed_at, tick, room_name, worker_load_trip_energy_mean AS tripEnergyMean, worker_load_trip_energy_min AS tripEnergyMin, source_artifact FROM runtime_room_metrics WHERE worker_load_trip_energy_mean IS NOT NULL OR worker_load_trip_energy_min IS NOT NULL ORDER BY observed_at DESC LIMIT 250;",
+          "queryType": "table"
         }
       ],
       "title": "Worker Load Efficiency Distribution",
@@ -471,13 +518,17 @@
           "format": "table",
           "queryText": "SELECT created_at, decision_key, status, rationale, source_artifact FROM metric_iteration_decisions ORDER BY created_at DESC LIMIT 100;",
           "rawQuery": true,
-          "refId": "A"
+          "refId": "A",
+          "rawQueryText": "SELECT created_at, decision_key, status, rationale, source_artifact FROM metric_iteration_decisions ORDER BY created_at DESC LIMIT 100;",
+          "queryType": "table"
         },
         {
           "format": "table",
           "queryText": "SELECT observed_at, metric_name, value, source_artifact FROM metric_observations WHERE metric_name = 'source.rl_metrics_refresh.completed' ORDER BY observed_at DESC LIMIT 20;",
           "rawQuery": true,
-          "refId": "B"
+          "refId": "B",
+          "rawQueryText": "SELECT observed_at, metric_name, value, source_artifact FROM metric_observations WHERE metric_name = 'source.rl_metrics_refresh.completed' ORDER BY observed_at DESC LIMIT 20;",
+          "queryType": "table"
         }
       ],
       "title": "#879 Decision And Refresh Evidence",

--- a/docs/ops/rl-live-dashboard-runbook.md
+++ b/docs/ops/rl-live-dashboard-runbook.md
@@ -19,6 +19,8 @@ docs/ops/grafana/provisioning/dashboards/screeps-rl-dashboards.yaml
 docs/ops/grafana/screeps-rl-gameplay-metrics.json
 ```
 
+The tracked dashboard JSON includes the frser SQLite target metadata required for rendered panels: `rawQueryText` mirrors `queryText`, every target declares `queryType`, and time-series targets declare `timeColumns: ["time"]`.
+
 The Grafana SQLite datasource plugin is required:
 
 ```text
@@ -31,11 +33,13 @@ Print the Docker command without starting a container:
 npm run rl-grafana:print-command
 ```
 
-Run actual Grafana locally:
+Start or restore actual Grafana locally:
 
 ```bash
 npm run rl-grafana:run
 ```
+
+This command is the durable local supervisor path. It uses a detached Docker container named `screeps-rl-grafana` with Docker restart policy `unless-stopped`; rerunning it starts the existing named container if it is present but stopped. The exposed port remains bound to `127.0.0.1` by default and must not be changed to a non-local address without explicit owner approval.
 
 Default Grafana URL:
 

--- a/scripts/screeps_rl_grafana.py
+++ b/scripts/screeps_rl_grafana.py
@@ -25,10 +25,15 @@ DEFAULT_GRAFANA_URL = "http://127.0.0.1:3000"
 DEFAULT_GRAFANA_IMAGE = "grafana/grafana-oss:11.5.2"
 DEFAULT_GRAFANA_PLUGIN = DATASOURCE_TYPE
 DEFAULT_CONTAINER_NAME = "screeps-rl-grafana"
+DEFAULT_DOCKER_RESTART_POLICY = "unless-stopped"
 CONTAINER_DB_PATH = "/var/lib/grafana/rl-metrics/rl_metrics.sqlite"
 CONTAINER_DASHBOARD_PATH = "/var/lib/grafana/dashboards/screeps"
 CONTAINER_PROVISIONING_PATH = "/etc/grafana/provisioning"
 LOCAL_GRAFANA_HOSTS = {"127.0.0.1", "localhost", "::1"}
+TIME_SERIES_FORMAT = "time_series"
+TIME_SERIES_QUERY_TYPE = "time series"
+TABLE_QUERY_TYPE = "table"
+TIME_SERIES_TIME_COLUMNS = ["time"]
 
 REQUIRED_QUERY_COVERAGE = {
     "metric observation history": "FROM metric_observations",
@@ -140,6 +145,36 @@ def panel_queries(panels: list[JsonObject]) -> list[str]:
     return queries
 
 
+def is_time_series_target(panel: JsonObject, target: JsonObject) -> bool:
+    return panel.get("type") == "timeseries" or target.get("format") == TIME_SERIES_FORMAT
+
+
+def validate_dashboard_targets(panels: list[JsonObject]) -> list[str]:
+    errors: list[str] = []
+    for panel in panels:
+        targets = panel.get("targets", [])
+        if not isinstance(targets, list):
+            errors.append(f"panel {panel.get('id')} targets must be a list")
+            continue
+        for index, target in enumerate(targets):
+            if not isinstance(target, dict):
+                errors.append(f"panel {panel.get('id')} target {index} must be an object")
+                continue
+            target_label = f"panel {panel.get('id')} target {target.get('refId', index)}"
+            query_text = target.get("queryText")
+            if not isinstance(query_text, str) or not query_text.strip():
+                errors.append(f"{target_label} must define non-empty queryText")
+                continue
+            if target.get("rawQueryText") != query_text:
+                errors.append(f"{target_label} rawQueryText must exactly match queryText")
+            expected_query_type = TIME_SERIES_QUERY_TYPE if is_time_series_target(panel, target) else TABLE_QUERY_TYPE
+            if target.get("queryType") != expected_query_type:
+                errors.append(f"{target_label} queryType must be {expected_query_type!r}")
+            if expected_query_type == TIME_SERIES_QUERY_TYPE and target.get("timeColumns") != TIME_SERIES_TIME_COLUMNS:
+                errors.append(f"{target_label} timeColumns must be {TIME_SERIES_TIME_COLUMNS!r}")
+    return errors
+
+
 def validate_dashboard_payload(dashboard: JsonObject, path: Path) -> JsonObject:
     report: JsonObject = {"status": "PASS", "checks": [], "errors": [], "warnings": []}
 
@@ -175,6 +210,16 @@ def validate_dashboard_payload(dashboard: JsonObject, path: Path) -> JsonObject:
         "dashboard datasource binding",
         not datasource_errors,
         "; ".join(datasource_errors) if datasource_errors else "all panels use the provisioned SQLite datasource",
+    )
+
+    target_errors = validate_dashboard_targets(panels)
+    append_check(
+        report,
+        "dashboard frser SQLite target contract",
+        not target_errors,
+        "; ".join(target_errors)
+        if target_errors
+        else "all targets preserve rawQueryText, queryType, and timeColumns where required",
     )
 
     queries = "\n".join(panel_queries(panels))
@@ -410,14 +455,15 @@ def build_docker_command(
     plugin: str,
     container_name: str,
     allow_nonlocal: bool = False,
+    detach: bool = True,
+    restart_policy: str | None = DEFAULT_DOCKER_RESTART_POLICY,
 ) -> list[str]:
     validate_host_binding(host, allow_nonlocal)
     repo_root = repo_root.resolve()
     db_path = db_path.resolve()
-    return [
+    command = [
         "docker",
         "run",
-        "--rm",
         "--name",
         container_name,
         "-p",
@@ -446,6 +492,11 @@ def build_docker_command(
         f"{db_path}:{CONTAINER_DB_PATH}:ro",
         image,
     ]
+    if detach:
+        command[2:2] = ["-d"]
+    if restart_policy:
+        command[2:2] = ["--restart", restart_policy]
+    return command
 
 
 def render_command(command: list[str]) -> str:
@@ -471,6 +522,27 @@ def exit_code_for_report(report: JsonObject) -> int:
     if report["status"] == "NOT_RUNNING":
         return 2
     return 1
+
+
+def ensure_durable_container(command: list[str], container_name: str, restart_policy: str) -> int:
+    inspect = subprocess.run(
+        ["docker", "inspect", "--format", "{{.State.Running}}", container_name],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if inspect.returncode != 0:
+        return subprocess.run(command, check=False).returncode
+
+    update = subprocess.run(["docker", "update", "--restart", restart_policy, container_name], check=False)
+    if update.returncode != 0:
+        return update.returncode
+
+    if inspect.stdout.strip().lower() == "true":
+        print(f"{container_name} already running with restart policy {restart_policy}")
+        return 0
+
+    return subprocess.run(["docker", "start", container_name], check=False).returncode
 
 
 def cmd_validate(args: argparse.Namespace) -> int:
@@ -547,7 +619,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     if args.print_only:
         print(render_command(command))
         return 0
-    return subprocess.run(command, check=False).returncode
+    return ensure_durable_container(command, args.container_name, DEFAULT_DOCKER_RESTART_POLICY)
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/scripts/screeps_rl_grafana.py
+++ b/scripts/screeps_rl_grafana.py
@@ -503,6 +503,164 @@ def render_command(command: list[str]) -> str:
     return " ".join(shlex.quote(part) for part in command)
 
 
+def parse_docker_port_binding(binding: str) -> tuple[str, tuple[str, str]]:
+    if binding.startswith("["):
+        host_end = binding.find("]")
+        if host_end <= 0 or len(binding) <= host_end + 1 or binding[host_end + 1] != ":":
+            raise ValueError(f"invalid Docker port binding: {binding}")
+        host = binding[1:host_end]
+        host_port, container_port = binding[host_end + 2:].split(":", 1)
+    else:
+        host, host_port, container_port = binding.rsplit(":", 2)
+    return f"{container_port}/tcp", (host, host_port)
+
+
+def parse_docker_volume(volume: str) -> tuple[str, tuple[str, bool]]:
+    source, destination, *options = volume.split(":")
+    option_flags = {flag.strip() for option in options for flag in option.split(",")}
+    return destination, (source, "ro" in option_flags)
+
+
+def parse_docker_env(env: str) -> tuple[str, str] | None:
+    key, separator, value = env.partition("=")
+    if not separator:
+        return None
+    return key, value
+
+
+def expected_container_contract(command: list[str]) -> JsonObject:
+    ports: dict[str, list[tuple[str, str]]] = {}
+    mounts: dict[str, tuple[str, bool]] = {}
+    env: dict[str, str] = {}
+    image: str | None = None
+    index = 2 if command[:2] == ["docker", "run"] else 0
+    while index < len(command):
+        argument = command[index]
+        if argument in ("-p", "--publish"):
+            port_key, port_binding = parse_docker_port_binding(command[index + 1])
+            ports.setdefault(port_key, []).append(port_binding)
+            index += 2
+            continue
+        if argument in ("-v", "--volume"):
+            destination, mount = parse_docker_volume(command[index + 1])
+            mounts[destination] = mount
+            index += 2
+            continue
+        if argument in ("-e", "--env"):
+            parsed_env = parse_docker_env(command[index + 1])
+            if parsed_env:
+                key, value = parsed_env
+                env[key] = value
+            index += 2
+            continue
+        if argument in ("--name", "--restart"):
+            index += 2
+            continue
+        if argument in ("-d", "--detach"):
+            index += 1
+            continue
+        if argument.startswith("-"):
+            index += 1
+            continue
+        image = argument
+        break
+    return {
+        "ports": {key: sorted(values) for key, values in ports.items()},
+        "mounts": mounts,
+        "env": env,
+        "image": image,
+    }
+
+
+def actual_container_contract(container: JsonObject) -> JsonObject:
+    host_config = container.get("HostConfig", {})
+    if not isinstance(host_config, dict):
+        host_config = {}
+    config = container.get("Config", {})
+    if not isinstance(config, dict):
+        config = {}
+
+    ports: dict[str, list[tuple[str, str]]] = {}
+    port_bindings = host_config.get("PortBindings", {})
+    if isinstance(port_bindings, dict):
+        for port_key, bindings in port_bindings.items():
+            if not isinstance(port_key, str) or not isinstance(bindings, list):
+                continue
+            parsed_bindings: list[tuple[str, str]] = []
+            for binding in bindings:
+                if not isinstance(binding, dict):
+                    continue
+                parsed_bindings.append((str(binding.get("HostIp", "")), str(binding.get("HostPort", ""))))
+            ports[port_key] = sorted(parsed_bindings)
+
+    mounts: dict[str, tuple[str, bool]] = {}
+    mount_entries = container.get("Mounts", [])
+    if isinstance(mount_entries, list):
+        for mount in mount_entries:
+            if not isinstance(mount, dict):
+                continue
+            source = mount.get("Source")
+            destination = mount.get("Destination")
+            if not isinstance(source, str) or not isinstance(destination, str):
+                continue
+            mode = mount.get("Mode", "")
+            mode_flags = {part.strip() for part in str(mode).split(",")}
+            read_only = mount.get("RW") is False or "ro" in mode_flags
+            mounts[destination] = (source, read_only)
+    if not mounts:
+        binds = host_config.get("Binds", [])
+        if isinstance(binds, list):
+            for bind in binds:
+                if not isinstance(bind, str):
+                    continue
+                destination, mount = parse_docker_volume(bind)
+                mounts[destination] = mount
+
+    env: dict[str, str] = {}
+    env_entries = config.get("Env", [])
+    if isinstance(env_entries, list):
+        for entry in env_entries:
+            if not isinstance(entry, str):
+                continue
+            parsed_env = parse_docker_env(entry)
+            if parsed_env:
+                key, value = parsed_env
+                env[key] = value
+
+    return {
+        "ports": ports,
+        "mounts": mounts,
+        "env": env,
+        "image": config.get("Image") if isinstance(config.get("Image"), str) else None,
+    }
+
+
+def container_reuse_mismatches(command: list[str], container: JsonObject) -> list[str]:
+    expected = expected_container_contract(command)
+    actual = actual_container_contract(container)
+    mismatches: list[str] = []
+
+    if expected["image"] and actual["image"] != expected["image"]:
+        mismatches.append("image")
+
+    if actual["ports"].keys() != expected["ports"].keys():
+        mismatches.append("port set")
+    else:
+        for port_key, expected_bindings in expected["ports"].items():
+            if actual["ports"].get(port_key) != expected_bindings:
+                mismatches.append(f"port binding {port_key}")
+
+    for destination, expected_mount in expected["mounts"].items():
+        if actual["mounts"].get(destination) != expected_mount:
+            mismatches.append(f"mount {destination}")
+
+    for key, expected_value in expected["env"].items():
+        if actual["env"].get(key) != expected_value:
+            mismatches.append(f"env {key}")
+
+    return mismatches
+
+
 def print_report(report: JsonObject, as_json: bool) -> None:
     if as_json:
         print(json.dumps(report, indent=2, sort_keys=True))
@@ -526,7 +684,7 @@ def exit_code_for_report(report: JsonObject) -> int:
 
 def ensure_durable_container(command: list[str], container_name: str, restart_policy: str) -> int:
     inspect = subprocess.run(
-        ["docker", "inspect", "--format", "{{.State.Running}}", container_name],
+        ["docker", "inspect", container_name],
         check=False,
         capture_output=True,
         text=True,
@@ -534,11 +692,34 @@ def ensure_durable_container(command: list[str], container_name: str, restart_po
     if inspect.returncode != 0:
         return subprocess.run(command, check=False).returncode
 
+    try:
+        inspected = json.loads(inspect.stdout)
+    except json.JSONDecodeError as error:
+        print(f"ERROR: docker inspect returned invalid JSON for {container_name}: {error}", file=sys.stderr)
+        return 1
+    if not isinstance(inspected, list) or not inspected or not isinstance(inspected[0], dict):
+        print(f"ERROR: docker inspect returned an invalid container payload for {container_name}", file=sys.stderr)
+        return 1
+
+    container = inspected[0]
+    mismatches = container_reuse_mismatches(command, container)
+    if mismatches:
+        print(
+            f"{container_name} exists with stale Docker settings ({', '.join(mismatches)}); recreating",
+            file=sys.stderr,
+        )
+        remove = subprocess.run(["docker", "rm", "-f", container_name], check=False)
+        if remove.returncode != 0:
+            return remove.returncode
+        return subprocess.run(command, check=False).returncode
+
     update = subprocess.run(["docker", "update", "--restart", restart_policy, container_name], check=False)
     if update.returncode != 0:
         return update.returncode
 
-    if inspect.stdout.strip().lower() == "true":
+    state = container.get("State", {})
+    running = isinstance(state, dict) and state.get("Running") is True
+    if running:
         print(f"{container_name} already running with restart policy {restart_policy}")
         return 0
 

--- a/scripts/test_screeps_rl_grafana.py
+++ b/scripts/test_screeps_rl_grafana.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 import copy
 import io
 import json
+import subprocess
 import sys
+import tempfile
 import urllib.error
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
@@ -36,6 +38,10 @@ class ScreepsRlGrafanaContractTest(unittest.TestCase):
         }
         for coverage_name in grafana.REQUIRED_QUERY_COVERAGE:
             self.assertEqual(coverage_checks[f"dashboard query coverage: {coverage_name}"], "PASS")
+        target_contract_check = next(
+            check for check in report["checks"] if check["name"] == "dashboard frser SQLite target contract"
+        )
+        self.assertEqual(target_contract_check["status"], "PASS")
 
     def test_dashboard_contract_rejects_missing_iteration_decision_query(self) -> None:
         dashboard_path = grafana.dashboard_file(REPO_ROOT)
@@ -52,6 +58,23 @@ class ScreepsRlGrafanaContractTest(unittest.TestCase):
             "#879 iteration decisions",
             "\n".join(error for error in report["errors"]),
         )
+
+    def test_dashboard_contract_rejects_missing_frser_sqlite_target_fields(self) -> None:
+        dashboard_path = grafana.dashboard_file(REPO_ROOT)
+        dashboard = json.loads(dashboard_path.read_text(encoding="utf-8"))
+        broken_dashboard = copy.deepcopy(dashboard)
+        target = broken_dashboard["panels"][1]["targets"][0]
+        target.pop("rawQueryText", None)
+        target.pop("queryType", None)
+        target.pop("timeColumns", None)
+
+        report = grafana.validate_dashboard_payload(broken_dashboard, dashboard_path)
+
+        self.assertEqual(report["status"], "FAIL")
+        errors = "\n".join(error for error in report["errors"])
+        self.assertIn("rawQueryText", errors)
+        self.assertIn("queryType", errors)
+        self.assertIn("timeColumns", errors)
 
     def test_live_validator_reports_not_running_instead_of_pass(self) -> None:
         report = grafana.validate_live("http://127.0.0.1:9", timeout=0.1)
@@ -96,6 +119,9 @@ class ScreepsRlGrafanaContractTest(unittest.TestCase):
         )
         command_text = " ".join(command)
 
+        self.assertIn("-d", command)
+        self.assertIn("--restart", command)
+        self.assertIn(grafana.DEFAULT_DOCKER_RESTART_POLICY, command)
         self.assertIn("127.0.0.1:3000:3000", command)
         self.assertIn(f"GF_INSTALL_PLUGINS={grafana.DATASOURCE_TYPE}", command)
         self.assertIn(f"GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS={grafana.DATASOURCE_TYPE}", command)
@@ -104,6 +130,7 @@ class ScreepsRlGrafanaContractTest(unittest.TestCase):
         self.assertIn(f"{db_path.resolve()}:{grafana.CONTAINER_DB_PATH}:ro", command)
         self.assertNotIn(f"{db_path.parent.resolve()}:/var/lib/grafana/rl-metrics:ro", command)
         self.assertIn("grafana/grafana-oss:test", command)
+        self.assertNotIn("--rm", command)
         self.assertNotIn("0.0.0.0:3000:3000", command_text)
 
     def test_docker_command_mounts_custom_db_file_to_provisioned_container_path(self) -> None:
@@ -162,6 +189,52 @@ class ScreepsRlGrafanaContractTest(unittest.TestCase):
         )
 
         self.assertIn("[::1]:3000:3000", command)
+
+    def test_ensure_durable_container_creates_missing_container(self) -> None:
+        command = ["docker", "run", "-d", "--restart", "unless-stopped", "--name", "test"]
+
+        with patch.object(grafana.subprocess, "run") as run:
+            run.side_effect = [
+                subprocess.CompletedProcess(["docker", "inspect"], 1, stdout="", stderr="missing"),
+                subprocess.CompletedProcess(command, 0, stdout="container-id\n", stderr=""),
+            ]
+            exit_code = grafana.ensure_durable_container(command, "test", "unless-stopped")
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(run.call_args_list[0].args[0][:3], ["docker", "inspect", "--format"])
+        self.assertEqual(run.call_args_list[1].args[0], command)
+
+    def test_ensure_durable_container_starts_existing_container_with_restart_policy(self) -> None:
+        command = ["docker", "run", "-d", "--restart", "unless-stopped", "--name", "test"]
+
+        with patch.object(grafana.subprocess, "run") as run:
+            run.side_effect = [
+                subprocess.CompletedProcess(["docker", "inspect"], 0, stdout="false\n", stderr=""),
+                subprocess.CompletedProcess(["docker", "update"], 0, stdout="test\n", stderr=""),
+                subprocess.CompletedProcess(["docker", "start"], 0, stdout="test\n", stderr=""),
+            ]
+            exit_code = grafana.ensure_durable_container(command, "test", "unless-stopped")
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(run.call_args_list[1].args[0], ["docker", "update", "--restart", "unless-stopped", "test"])
+        self.assertEqual(run.call_args_list[2].args[0], ["docker", "start", "test"])
+
+    def test_run_uses_durable_container_command(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".sqlite") as db_file:
+            with patch.object(grafana.subprocess, "run") as run:
+                run.side_effect = [
+                    subprocess.CompletedProcess(["docker", "inspect"], 1, stdout="", stderr="missing"),
+                    subprocess.CompletedProcess(["docker", "run"], 0, stdout="container-id\n", stderr=""),
+                ]
+                exit_code = grafana.main(["run", "--db-path", db_file.name])
+
+        self.assertEqual(exit_code, 0)
+        docker_run = run.call_args_list[1].args[0]
+        self.assertIn("-d", docker_run)
+        self.assertIn("--restart", docker_run)
+        self.assertIn(grafana.DEFAULT_DOCKER_RESTART_POLICY, docker_run)
+        self.assertIn("127.0.0.1:3000:3000", docker_run)
+        self.assertNotIn("--rm", docker_run)
 
 
 if __name__ == "__main__":

--- a/scripts/test_screeps_rl_grafana.py
+++ b/scripts/test_screeps_rl_grafana.py
@@ -22,6 +22,81 @@ import screeps_rl_grafana as grafana
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
+def grafana_docker_command(db_path: Path | None = None) -> list[str]:
+    return grafana.build_docker_command(
+        repo_root=REPO_ROOT,
+        db_path=db_path or REPO_ROOT / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite",
+        host="127.0.0.1",
+        port=3000,
+        image="grafana/grafana-oss:test",
+        plugin=grafana.DATASOURCE_TYPE,
+        container_name="test",
+    )
+
+
+def grafana_inspect_payload(
+    *,
+    running: bool,
+    host_ip: str = "127.0.0.1",
+    host_port: str = "3000",
+    db_path: Path | None = None,
+    db_source: str | None = None,
+    image: str = "grafana/grafana-oss:test",
+    plugin: str = grafana.DATASOURCE_TYPE,
+) -> str:
+    metrics_db = (db_path or REPO_ROOT / "runtime-artifacts" / "rl-metrics" / "rl_metrics.sqlite").resolve()
+    return json.dumps(
+        [
+            {
+                "State": {"Running": running},
+                "HostConfig": {
+                    "PortBindings": {
+                        "3000/tcp": [
+                            {
+                                "HostIp": host_ip,
+                                "HostPort": host_port,
+                            }
+                        ]
+                    }
+                },
+                "Config": {
+                    "Image": image,
+                    "Env": [
+                        f"GF_INSTALL_PLUGINS={plugin}",
+                        f"GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS={plugin}",
+                        "GF_AUTH_ANONYMOUS_ENABLED=true",
+                        "GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer",
+                        "GF_AUTH_DISABLE_LOGIN_FORM=true",
+                        "GF_AUTH_BASIC_ENABLED=false",
+                        "GF_SECURITY_ADMIN_USER=admin",
+                        "GF_SECURITY_ADMIN_PASSWORD=local-dev-only",
+                    ],
+                },
+                "Mounts": [
+                    {
+                        "Source": str((grafana.grafana_root(REPO_ROOT) / "provisioning").resolve()),
+                        "Destination": grafana.CONTAINER_PROVISIONING_PATH,
+                        "Mode": "ro",
+                        "RW": False,
+                    },
+                    {
+                        "Source": str(grafana.grafana_root(REPO_ROOT).resolve()),
+                        "Destination": grafana.CONTAINER_DASHBOARD_PATH,
+                        "Mode": "ro",
+                        "RW": False,
+                    },
+                    {
+                        "Source": db_source or str(metrics_db),
+                        "Destination": grafana.CONTAINER_DB_PATH,
+                        "Mode": "ro",
+                        "RW": False,
+                    },
+                ],
+            }
+        ]
+    )
+
+
 class ScreepsRlGrafanaContractTest(unittest.TestCase):
     def test_static_repository_contract_passes_without_running_grafana(self) -> None:
         report = grafana.validate_static(REPO_ROOT)
@@ -191,7 +266,7 @@ class ScreepsRlGrafanaContractTest(unittest.TestCase):
         self.assertIn("[::1]:3000:3000", command)
 
     def test_ensure_durable_container_creates_missing_container(self) -> None:
-        command = ["docker", "run", "-d", "--restart", "unless-stopped", "--name", "test"]
+        command = grafana_docker_command()
 
         with patch.object(grafana.subprocess, "run") as run:
             run.side_effect = [
@@ -201,15 +276,20 @@ class ScreepsRlGrafanaContractTest(unittest.TestCase):
             exit_code = grafana.ensure_durable_container(command, "test", "unless-stopped")
 
         self.assertEqual(exit_code, 0)
-        self.assertEqual(run.call_args_list[0].args[0][:3], ["docker", "inspect", "--format"])
+        self.assertEqual(run.call_args_list[0].args[0], ["docker", "inspect", "test"])
         self.assertEqual(run.call_args_list[1].args[0], command)
 
     def test_ensure_durable_container_starts_existing_container_with_restart_policy(self) -> None:
-        command = ["docker", "run", "-d", "--restart", "unless-stopped", "--name", "test"]
+        command = grafana_docker_command()
 
         with patch.object(grafana.subprocess, "run") as run:
             run.side_effect = [
-                subprocess.CompletedProcess(["docker", "inspect"], 0, stdout="false\n", stderr=""),
+                subprocess.CompletedProcess(
+                    ["docker", "inspect"],
+                    0,
+                    stdout=grafana_inspect_payload(running=False),
+                    stderr="",
+                ),
                 subprocess.CompletedProcess(["docker", "update"], 0, stdout="test\n", stderr=""),
                 subprocess.CompletedProcess(["docker", "start"], 0, stdout="test\n", stderr=""),
             ]
@@ -218,6 +298,52 @@ class ScreepsRlGrafanaContractTest(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertEqual(run.call_args_list[1].args[0], ["docker", "update", "--restart", "unless-stopped", "test"])
         self.assertEqual(run.call_args_list[2].args[0], ["docker", "start", "test"])
+
+    def test_ensure_durable_container_recreates_existing_container_with_public_binding(self) -> None:
+        command = grafana_docker_command()
+        stderr = io.StringIO()
+
+        with redirect_stderr(stderr), patch.object(grafana.subprocess, "run") as run:
+            run.side_effect = [
+                subprocess.CompletedProcess(
+                    ["docker", "inspect"],
+                    0,
+                    stdout=grafana_inspect_payload(running=True, host_ip="0.0.0.0"),
+                    stderr="",
+                ),
+                subprocess.CompletedProcess(["docker", "rm", "-f", "test"], 0, stdout="test\n", stderr=""),
+                subprocess.CompletedProcess(command, 0, stdout="container-id\n", stderr=""),
+            ]
+            exit_code = grafana.ensure_durable_container(command, "test", "unless-stopped")
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("stale Docker settings", stderr.getvalue())
+        self.assertEqual(run.call_count, 3)
+        self.assertEqual(run.call_args_list[1].args[0], ["docker", "rm", "-f", "test"])
+        self.assertEqual(run.call_args_list[2].args[0], command)
+
+    def test_ensure_durable_container_recreates_existing_container_with_stale_db_mount(self) -> None:
+        command = grafana_docker_command()
+        stderr = io.StringIO()
+
+        with redirect_stderr(stderr), patch.object(grafana.subprocess, "run") as run:
+            run.side_effect = [
+                subprocess.CompletedProcess(
+                    ["docker", "inspect"],
+                    0,
+                    stdout=grafana_inspect_payload(running=False, db_source="/tmp/stale-rl-metrics.sqlite"),
+                    stderr="",
+                ),
+                subprocess.CompletedProcess(["docker", "rm", "-f", "test"], 0, stdout="test\n", stderr=""),
+                subprocess.CompletedProcess(command, 0, stdout="container-id\n", stderr=""),
+            ]
+            exit_code = grafana.ensure_durable_container(command, "test", "unless-stopped")
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("stale Docker settings", stderr.getvalue())
+        self.assertEqual(run.call_count, 3)
+        self.assertEqual(run.call_args_list[1].args[0], ["docker", "rm", "-f", "test"])
+        self.assertEqual(run.call_args_list[2].args[0], command)
 
     def test_run_uses_durable_container_command(self) -> None:
         with tempfile.NamedTemporaryFile(suffix=".sqlite") as db_file:


### PR DESCRIPTION
## Summary
- make `npm run rl-grafana:run` create/restore a detached loopback-only Docker container with `--restart unless-stopped`
- add static validation for frser SQLite target metadata (`rawQueryText`, `queryType`, and time-series `timeColumns`)
- persist the dashboard target metadata and document the durable local run path

Related to issue #1539.

## Verification
- `python3 -m py_compile scripts/screeps_rl_grafana.py scripts/test_screeps_rl_grafana.py`
- `python3 -m unittest scripts.test_screeps_rl_grafana`
- `npm run -s rl-grafana:validate:provisioning -- --json`
- `npm run -s rl-grafana:run -- --db-path /root/screeps/runtime-artifacts/rl-metrics/rl_metrics.sqlite`
- `npm run -s rl-grafana:validate -- --json --timeout 5`
- `docker inspect screeps-rl-grafana --format 'RestartPolicy={{.HostConfig.RestartPolicy.Name}} Ports={{json .HostConfig.PortBindings}} Running={{.State.Running}}'`
- live dashboard API target-contract check: 21 targets, status PASS

## Universal task Done gate
- [x] Task type: P0 RL flywheel infrastructure durability repair.
- [x] Expected observable outcome / named deliverable: durable local RL Grafana runner plus dashboard target-contract validator and tracked dashboard metadata.
- [x] Non-goals / accepted substitutes: no public exposure, no cron scheduling, no production Screeps bot behavior change under `prod/`.
- [x] Verification evidence required before Done: controller ran Python compile/unit tests, provisioning validation, live run, live validation, Docker restart-policy inspection, and live dashboard API target-contract check.
- [x] Project Evidence / Next action / Blocked by: Project item for issue #1539 was updated by the controller with Codex dispatch evidence and next action; no owner action is required for this PR.
- [x] Post-merge/deploy/runtime proof: branch runtime proof recorded from loopback Grafana on `127.0.0.1:3000` with Docker restart policy `unless-stopped` and `npm run -s rl-grafana:validate -- --json --timeout 5` PASS.
- [x] Named deliverable proof: commit `1fca9822` changes `scripts/screeps_rl_grafana.py`, `scripts/test_screeps_rl_grafana.py`, and `docs/ops/grafana/screeps-rl-gameplay-metrics.json` for the durable runner and target contract.
