### PR TITLE
fix: isolate rl grafana tests from local metrics db

### DIFF
--- a/scripts/test_screeps_rl_grafana.py
+++ b/scripts/test_screeps_rl_grafana.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 import copy
 import io
 import json
+import shutil
 import subprocess
 import sys
 import tempfile
 import urllib.error
 import unittest
-from contextlib import redirect_stderr, redirect_stdout
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
 
@@ -20,6 +21,18 @@ import screeps_rl_grafana as grafana
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@contextmanager
+def isolated_static_repo(*, with_metrics_db: bool = False):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        repo_root = Path(temp_dir)
+        shutil.copytree(grafana.grafana_root(REPO_ROOT), grafana.grafana_root(repo_root))
+        if with_metrics_db:
+            db_path = grafana.default_db_path(repo_root)
+            db_path.parent.mkdir(parents=True)
+            db_path.write_bytes(b"static validator only checks that this file exists\n")
+        yield repo_root
 
 
 def grafana_docker_command(db_path: Path | None = None) -> list[str]:
@@ -99,7 +112,8 @@ def grafana_inspect_payload(
 
 class ScreepsRlGrafanaContractTest(unittest.TestCase):
     def test_static_repository_contract_passes_without_running_grafana(self) -> None:
-        report = grafana.validate_static(REPO_ROOT)
+        with isolated_static_repo() as repo_root:
+            report = grafana.validate_static(repo_root)
 
         self.assertEqual(report["status"], "PASS")
         self.assertEqual(report["datasourceUid"], grafana.DATASOURCE_UID)
@@ -117,6 +131,14 @@ class ScreepsRlGrafanaContractTest(unittest.TestCase):
             check for check in report["checks"] if check["name"] == "dashboard frser SQLite target contract"
         )
         self.assertEqual(target_contract_check["status"], "PASS")
+
+    def test_static_repository_contract_passes_with_local_metrics_db_present(self) -> None:
+        with isolated_static_repo(with_metrics_db=True) as repo_root:
+            report = grafana.validate_static(repo_root)
+
+        self.assertEqual(report["status"], "PASS")
+        self.assertEqual(report["metricsDb"]["status"], "PRESENT")
+        self.assertEqual(report["metricsDb"]["path"], str(grafana.default_db_path(repo_root.resolve())))
 
     def test_dashboard_contract_rejects_missing_iteration_decision_query(self) -> None:
         dashboard_path = grafana.dashboard_file(REPO_ROOT)


### PR DESCRIPTION
## Summary
- isolate the RL Grafana static-contract unit test from ignored local runtime artifacts
- add a regression test proving validate_static remains PASS when runtime-artifacts/rl-metrics/rl_metrics.sqlite exists under the checked repo root
- keep production Grafana validation behavior unchanged

Related to issue #1539.

## Verification
- git diff --check HEAD~1..HEAD
- python3 -m py_compile scripts/screeps_rl_grafana.py scripts/test_screeps_rl_grafana.py
- python3 -m unittest scripts.test_screeps_rl_grafana
- simulated runtime-artifacts/rl-metrics/rl_metrics.sqlite, reran python3 -m unittest scripts.test_screeps_rl_grafana, then removed the simulated artifact
- npm run -s rl-grafana:validate:provisioning -- --json

## Universal task Done gate
- [x] Task type: P0 RL flywheel test/hotfix for merged PR #1541 post-merge main-worktree verification.
- [x] Expected observable outcome / named deliverable: deterministic scripts.test_screeps_rl_grafana results whether a local ignored RL metrics SQLite file exists or not.
- [x] Non-goals / accepted substitutes: no production Grafana runtime behavior change; no official MMO deploy needed for a test-only hotfix.
- [x] Verification evidence required before Done: diff-check, py_compile, unittest without local DB, unittest with simulated local DB, and rl-grafana provisioning validation all PASS on commit 47b9b314.
- [x] Project Evidence / Next action / Blocked by: PR and #1539 Project items record commit 47b9b314, verification commands, and review-gate next action; no external blocker.
- [x] Post-merge/deploy/runtime proof: main-worktree acceptance criterion is the same unittest/provisioning bundle passing from /root/screeps with the real ignored metrics DB present; deploy is not applicable for this test-only change.
- [x] Named deliverable proof: scripts/test_screeps_rl_grafana.py now creates isolated temporary repo fixtures for missing-present metrics DB cases and includes the PRESENT regression assertion.
