### PR TITLE
fix: limit idle worker probes during critical CPU

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -47398,8 +47398,9 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
   refreshSpawnEnergyReservationStates(colonies);
   refreshSpawnEnergyBufferStates(colonies, reservedSpawnEnergyByRoom);
   const creepCpuBudget = getRuntimeCpuBudget();
+  const criticalCpuIdleWorkerProbeRooms = /* @__PURE__ */ new Set();
   for (const creep of orderCreepsForEconomyTaskPriority(creeps)) {
-    if (!shouldRunCreepForCpuBudget(creep, creepCpuBudget)) {
+    if (!shouldRunCreepForCpuBudget(creep, creepCpuBudget, criticalCpuIdleWorkerProbeRooms)) {
       continue;
     }
     if (featureGates.labManagement && shouldYieldCreepToLabManager(creep, Game.time)) {
@@ -47464,14 +47465,14 @@ function orderCreepsForEconomyTaskPriority(creeps) {
     (left, right) => left.priority - right.priority || left.index - right.index
   ).map((entry) => entry.creep);
 }
-function shouldRunCreepForCpuBudget(creep, cpuBudget) {
+function shouldRunCreepForCpuBudget(creep, cpuBudget, criticalCpuIdleWorkerProbeRooms) {
   var _a;
   if (!cpuBudget.critical) {
     return true;
   }
   const role = (_a = creep.memory) == null ? void 0 : _a.role;
   if (role === "worker") {
-    return shouldRunWorkerForCriticalCpu(creep);
+    return shouldRunWorkerForCriticalCpu(creep, criticalCpuIdleWorkerProbeRooms);
   }
   if (role === UPGRADER_ROLE) {
     return isDowngradeGuardControllerCreep(creep);
@@ -47481,13 +47482,32 @@ function shouldRunCreepForCpuBudget(creep, cpuBudget) {
   }
   return false;
 }
-function shouldRunWorkerForCriticalCpu(creep) {
-  var _a, _b;
+function shouldRunWorkerForCriticalCpu(creep, criticalCpuIdleWorkerProbeRooms) {
+  var _a, _b, _c, _d;
   const sustain = (_a = creep.memory) == null ? void 0 : _a.controllerSustain;
   if ((sustain == null ? void 0 : sustain.role) === "upgrader") {
     return true;
   }
-  return ((_b = creep.memory) == null ? void 0 : _b.territory) === void 0;
+  if (((_b = creep.memory) == null ? void 0 : _b.territory) !== void 0) {
+    return false;
+  }
+  if (((_c = creep.memory) == null ? void 0 : _c.spawnSupport) !== void 0 || ((_d = creep.memory) == null ? void 0 : _d.task) != null || criticalCpuIdleWorkerProbeRooms === void 0) {
+    return true;
+  }
+  const roomName = getWorkerCriticalCpuProbeRoomName(creep);
+  if (roomName === null) {
+    return true;
+  }
+  if (criticalCpuIdleWorkerProbeRooms.has(roomName)) {
+    return false;
+  }
+  criticalCpuIdleWorkerProbeRooms.add(roomName);
+  return true;
+}
+function getWorkerCriticalCpuProbeRoomName(creep) {
+  var _a, _b, _c;
+  const roomName = (_c = (_a = creep.room) == null ? void 0 : _a.name) != null ? _c : (_b = creep.memory) == null ? void 0 : _b.colony;
+  return typeof roomName === "string" && roomName.length > 0 ? roomName : null;
 }
 function isDowngradeGuardControllerCreep(creep) {
   var _a, _b, _c;

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -363,8 +363,9 @@ export function runEconomy(
   refreshSpawnEnergyBufferStates(colonies, reservedSpawnEnergyByRoom);
 
   const creepCpuBudget = getRuntimeCpuBudget();
+  const criticalCpuIdleWorkerProbeRooms = new Set<string>();
   for (const creep of orderCreepsForEconomyTaskPriority(creeps)) {
-    if (!shouldRunCreepForCpuBudget(creep, creepCpuBudget)) {
+    if (!shouldRunCreepForCpuBudget(creep, creepCpuBudget, criticalCpuIdleWorkerProbeRooms)) {
       continue;
     }
 
@@ -443,14 +444,18 @@ export function orderCreepsForEconomyTaskPriority(creeps: Creep[]): Creep[] {
     .map((entry) => entry.creep);
 }
 
-export function shouldRunCreepForCpuBudget(creep: Creep, cpuBudget: RuntimeCpuBudget): boolean {
+export function shouldRunCreepForCpuBudget(
+  creep: Creep,
+  cpuBudget: RuntimeCpuBudget,
+  criticalCpuIdleWorkerProbeRooms?: Set<string>
+): boolean {
   if (!cpuBudget.critical) {
     return true;
   }
 
   const role = creep.memory?.role;
   if (role === 'worker') {
-    return shouldRunWorkerForCriticalCpu(creep);
+    return shouldRunWorkerForCriticalCpu(creep, criticalCpuIdleWorkerProbeRooms);
   }
 
   if (role === UPGRADER_ROLE) {
@@ -464,13 +469,43 @@ export function shouldRunCreepForCpuBudget(creep: Creep, cpuBudget: RuntimeCpuBu
   return false;
 }
 
-function shouldRunWorkerForCriticalCpu(creep: Creep): boolean {
+function shouldRunWorkerForCriticalCpu(
+  creep: Creep,
+  criticalCpuIdleWorkerProbeRooms: Set<string> | undefined
+): boolean {
   const sustain = creep.memory?.controllerSustain;
   if (sustain?.role === 'upgrader') {
     return true;
   }
 
-  return creep.memory?.territory === undefined;
+  if (creep.memory?.territory !== undefined) {
+    return false;
+  }
+
+  if (
+    creep.memory?.spawnSupport !== undefined ||
+    creep.memory?.task != null ||
+    criticalCpuIdleWorkerProbeRooms === undefined
+  ) {
+    return true;
+  }
+
+  const roomName = getWorkerCriticalCpuProbeRoomName(creep);
+  if (roomName === null) {
+    return true;
+  }
+
+  if (criticalCpuIdleWorkerProbeRooms.has(roomName)) {
+    return false;
+  }
+
+  criticalCpuIdleWorkerProbeRooms.add(roomName);
+  return true;
+}
+
+function getWorkerCriticalCpuProbeRoomName(creep: Creep): string | null {
+  const roomName = creep.room?.name ?? creep.memory?.colony;
+  return typeof roomName === 'string' && roomName.length > 0 ? roomName : null;
 }
 
 function isDowngradeGuardControllerCreep(creep: Creep): boolean {

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -172,6 +172,48 @@ describe('runEconomy', () => {
     expect(shouldRunCreepForCpuBudget(creep('scout'), criticalBudget)).toBe(false);
   });
 
+  it('limits unassigned local worker task probes per room under critical CPU bucket pressure', () => {
+    const criticalBudget = buildRuntimeCpuBudget({
+      tick: 126,
+      used: 21,
+      limit: 70,
+      bucket: 1,
+      tickLimit: 500
+    });
+    const roomA = {
+      name: 'W1N1',
+      controller: { my: true, ticksToDowngrade: CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS + 1 } as StructureController
+    } as Room;
+    const roomB = {
+      name: 'W2N1',
+      controller: { my: true, ticksToDowngrade: CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS + 1 } as StructureController
+    } as Room;
+    const creep = (
+      name: string,
+      memory: Partial<CreepMemory> = {},
+      room: Room = roomA
+    ): Creep => ({ name, memory: { role: 'worker', colony: room.name, ...memory }, room }) as unknown as Creep;
+    const probedRooms = new Set<string>();
+
+    expect(
+      shouldRunCreepForCpuBudget(
+        creep('assigned', { task: { type: 'transfer', targetId: 'spawn1' as Id<AnyStoreStructure> } }),
+        criticalBudget,
+        probedRooms
+      )
+    ).toBe(true);
+    expect(shouldRunCreepForCpuBudget(creep('first-idle'), criticalBudget, probedRooms)).toBe(true);
+    expect(shouldRunCreepForCpuBudget(creep('second-idle'), criticalBudget, probedRooms)).toBe(false);
+    expect(shouldRunCreepForCpuBudget(creep('other-room-idle', {}, roomB), criticalBudget, probedRooms)).toBe(true);
+    expect(
+      shouldRunCreepForCpuBudget(
+        creep('spawn-support', { spawnSupport: { originRoom: 'W1N1', targetRoom: 'W3N1' } }),
+        criticalBudget,
+        probedRooms
+      )
+    ).toBe(true);
+  });
+
   it('keeps creep execution active during noncritical low-bucket recovery', () => {
     const lowBucketBudget = buildRuntimeCpuBudget({
       tick: 126,


### PR DESCRIPTION
## Summary
- limit critical-CPU idle-worker probes to at most one unassigned local worker per room per tick
- keep assigned workers, spawn-support workers, and downgrade-sustain upgraders runnable under critical CPU
- add unit coverage for per-room idle-worker probe limiting and rebuild `prod/dist/main.js`

Refs #1536.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 103 suites / 2121 tests passed
- `cd prod && npm run build`

## Universal task Done gate
- [x] Task type: production code CPU-safety follow-up.
- [x] Expected observable outcome / named deliverable: critical-CPU economy loop runs only a bounded idle-worker probe set while preserving assigned work and controller sustain behavior.
- [x] Non-goals / accepted substitutes: no runtime issue closure in this PR; #1536 remains the acceptance tracker for official MMO CPU observation.
- [x] Verification evidence required before Done: controller ran diff-check, typecheck, full Jest, and build on commit `f17190d6`.
- [x] Project Evidence / Next action / Blocked by: PR and #1536 Project fields will record commit `f17190d6`, controller verification, and exact-head review/CI gate.
- [x] Post-merge/deploy/runtime proof: #1536 retains runtime acceptance tracking for deployed CPU bucket recovery evidence.
- [x] Named deliverable proof: `prod/src/economy/economyLoop.ts`, `prod/test/economyLoop.test.ts`, and `prod/dist/main.js` contain the bounded probe implementation, tests, and bundle.

## Safety
- No secrets printed.
- No official MMO writes in this PR.
- Runtime acceptance remains gated on post-deploy monitor evidence through #1536.
