### PR TITLE
rl: add stale conclusion action plan

### DIFF
--- a/scripts/rl_conclusion_registry.py
+++ b/scripts/rl_conclusion_registry.py
@@ -8,6 +8,7 @@ import json
 import os
 import stat
 import tempfile
+from collections import Counter
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Sequence
@@ -17,8 +18,12 @@ SCHEMA_VERSION = 1
 REGISTRY_TYPE = "rl-conclusion-registry"
 CONCLUSION_STATUSES = ("OPEN", "STALE", "ACTIONED", "VALIDATING", "CLOSED", "ESCALATED")
 ACTIONABLE_STALE_SEVERITIES = ("P0", "P1")
+ACTIONABLE_STALE_STATUSES = ("OPEN", "STALE")
 ACTIONABLE_STALE_CONCLUSION_THRESHOLD = 10
 ACTIONABLE_STALE_CONCLUSION_PREVIEW_LIMIT = 10
+STALE_CONCLUSION_AGGREGATE_ROUTING_ISSUE = "#1543"
+STALE_CONCLUSION_AGGREGATE_ROUTING_ISSUE_NUMBER = 1543
+MIN_STALE_CONCLUSION_TRIAGE_DECISIONS_PER_STEWARD_CYCLE = 3
 
 JsonObject = dict[str, Any]
 
@@ -208,6 +213,7 @@ def summarize_conclusions(
         "countsByStatus": counts_by_status,
         "unknown": unknown_count,
         "actionableIssueGate": high_priority_stale_issue_gate(records),
+        "staleConclusionActionPlan": build_stale_conclusion_action_plan(records),
     }
 
 
@@ -243,6 +249,12 @@ def high_priority_stale_issue_gate(records: dict[str, JsonObject]) -> JsonObject
     gate: JsonObject = {
         "name": "p0_p1_stale_conclusion_backlog",
         "status": "ACTION_REQUIRED" if threshold_exceeded else "OK",
+        "aggregateRoutingIssue": STALE_CONCLUSION_AGGREGATE_ROUTING_ISSUE,
+        "aggregateRoutingIssueNumber": STALE_CONCLUSION_AGGREGATE_ROUTING_ISSUE_NUMBER,
+        "minimumStaleTransitionsPerStewardCycle": (
+            MIN_STALE_CONCLUSION_TRIAGE_DECISIONS_PER_STEWARD_CYCLE
+        ),
+        "requiredStaleTransition": "STALE -> ACTIONED/CLOSED",
         "threshold": ACTIONABLE_STALE_CONCLUSION_THRESHOLD,
         "thresholdExceeded": threshold_exceeded,
         "staleHighPriorityCount": stale_count,
@@ -261,6 +273,204 @@ def high_priority_stale_issue_gate(records: dict[str, JsonObject]) -> JsonObject
             "or escalation before reporting the backlog as background context."
         )
     return gate
+
+
+def build_stale_conclusion_action_plan(
+    registry_or_conclusions: Any,
+    *,
+    aggregate_issue: str = STALE_CONCLUSION_AGGREGATE_ROUTING_ISSUE,
+    aggregate_issue_number: int = STALE_CONCLUSION_AGGREGATE_ROUTING_ISSUE_NUMBER,
+    minimum_stale_transitions_per_cycle: int = (
+        MIN_STALE_CONCLUSION_TRIAGE_DECISIONS_PER_STEWARD_CYCLE
+    ),
+    preview_limit: int = ACTIONABLE_STALE_CONCLUSION_PREVIEW_LIMIT,
+) -> JsonObject:
+    """Build a deterministic steward plan for P0/P1 OPEN or STALE conclusions."""
+    if minimum_stale_transitions_per_cycle < 0:
+        raise ConclusionRegistryError("minimum_stale_transitions_per_cycle must be non-negative")
+    if preview_limit < 0:
+        raise ConclusionRegistryError("preview_limit must be non-negative")
+
+    records = normalize_conclusions(registry_or_conclusions)
+    candidates = sorted(
+        (record for record in records.values() if is_stale_action_plan_candidate(record)),
+        key=stale_action_plan_priority_key,
+    )
+
+    counts_by_status = {
+        status: sum(1 for record in candidates if conclusion_status(record) == status)
+        for status in ACTIONABLE_STALE_STATUSES
+    }
+    counts_by_severity = {
+        severity: sum(1 for record in candidates if conclusion_severity(record) == severity)
+        for severity in ACTIONABLE_STALE_SEVERITIES
+    }
+    counts_by_category = dict(
+        sorted(Counter(conclusion_category(record) for record in candidates).items())
+    )
+
+    grouped_records: dict[str, list[JsonObject]] = {
+        "likelySupersededOrStale": [],
+        "currentActionableBlockers": [],
+    }
+    for record in candidates:
+        action_record = stale_action_plan_record(record)
+        group_name = str(action_record["triageGroup"])
+        grouped_records[group_name].append(action_record)
+
+    stale_count = counts_by_status["STALE"]
+    target_transitions = min(stale_count, minimum_stale_transitions_per_cycle)
+
+    return {
+        "name": "p0_p1_open_stale_conclusion_action_plan",
+        "aggregateRoutingIssue": aggregate_issue,
+        "aggregateRoutingIssueNumber": aggregate_issue_number,
+        "candidateFilter": {
+            "statuses": list(ACTIONABLE_STALE_STATUSES),
+            "severities": list(ACTIONABLE_STALE_SEVERITIES),
+        },
+        "totalActionableCount": len(candidates),
+        "staleDecisionBacklogCount": stale_count,
+        "countsByStatus": counts_by_status,
+        "countsBySeverity": counts_by_severity,
+        "countsByCategory": counts_by_category,
+        "highestPriorityConclusionIds": [
+            conclusion_id
+            for conclusion_id in (record.get("conclusionId") for record in candidates)
+            if isinstance(conclusion_id, str) and conclusion_id
+        ][:preview_limit],
+        "groups": grouped_records,
+        "recommendedNextAction": {
+            "action": "triage_stale_conclusions_via_aggregate_routing_issue",
+            "routingIssue": aggregate_issue,
+            "routingIssueNumber": aggregate_issue_number,
+            "minimumStaleTransitionsPerStewardCycle": minimum_stale_transitions_per_cycle,
+            "requiredStaleTransition": "STALE -> ACTIONED/CLOSED",
+            "targetStaleTransitionsThisCycle": target_transitions,
+        },
+    }
+
+
+def is_stale_action_plan_candidate(record: JsonObject) -> bool:
+    return (
+        conclusion_severity(record) in ACTIONABLE_STALE_SEVERITIES
+        and conclusion_status(record) in ACTIONABLE_STALE_STATUSES
+    )
+
+
+def stale_action_plan_record(record: JsonObject) -> JsonObject:
+    status = conclusion_status(record)
+    severity = conclusion_severity(record)
+    category = conclusion_category(record)
+    flags = stale_action_plan_evidence_flags(record)
+    superseded = "statement_superseded" in flags or "category_superseded" in flags
+    likely_stale = superseded or "status_stale" in flags or "category_stale" in flags
+    group = "likelySupersededOrStale" if likely_stale else "currentActionableBlockers"
+    if superseded:
+        disposition = "CLOSE_IF_SUPERSEDED"
+    elif likely_stale:
+        disposition = "TRIAGE_STALE_TO_ACTIONED_OR_CLOSED"
+    elif "required_landing_evidence_present" in flags or "next_verification_present" in flags:
+        disposition = "ROUTE_CURRENT_BLOCKER_FOR_EVIDENCE"
+    else:
+        disposition = "VERIFY_AND_ROUTE_CURRENT_BLOCKER"
+
+    action_record: JsonObject = {
+        "conclusionId": str(record.get("conclusionId") or ""),
+        "status": status,
+        "severity": severity,
+        "category": category,
+        "triageGroup": group,
+        "recommendedDisposition": disposition,
+        "evidenceFlags": flags,
+    }
+    for field in ("lastSeenAt", "requiredLandingEvidence", "nextVerification"):
+        value = record.get(field)
+        if has_evidence_value(value):
+            action_record[field] = value
+    linked_issues = normalize_linked_issues(record.get("linkedIssues"))
+    if linked_issues:
+        action_record["linkedIssues"] = linked_issues
+    return action_record
+
+
+def stale_action_plan_evidence_flags(record: JsonObject) -> list[str]:
+    flags: list[str] = []
+    status = conclusion_status(record)
+    statement = str(record.get("statement") or "")
+    category = conclusion_category(record)
+    category_upper = category.upper()
+    if status == "STALE":
+        flags.append("status_stale")
+    if "SUPERSEDED" in statement.upper():
+        flags.append("statement_superseded")
+    if "SUPERSEDED" in category_upper or "OBSOLETE" in category_upper or "DEPRECATED" in category_upper:
+        flags.append("category_superseded")
+    if "STALE" in category_upper:
+        flags.append("category_stale")
+    if normalize_linked_issues(record.get("linkedIssues")):
+        flags.append("linked_issue_present")
+    if has_evidence_value(record.get("requiredLandingEvidence")):
+        flags.append("required_landing_evidence_present")
+    if has_evidence_value(record.get("nextVerification")):
+        flags.append("next_verification_present")
+    return flags
+
+
+def stale_action_plan_priority_key(record: JsonObject) -> tuple[int, int, str, str, str]:
+    severity_order = {"P0": 0, "P1": 1}
+    status_order = {"STALE": 0, "OPEN": 1}
+    return (
+        severity_order.get(conclusion_severity(record), 99),
+        status_order.get(conclusion_status(record), 99),
+        str(record.get("lastSeenAt") or record.get("nextVerification") or ""),
+        conclusion_category(record),
+        str(record.get("conclusionId") or ""),
+    )
+
+
+def conclusion_status(record: JsonObject) -> str:
+    return str(record.get("status", "UNKNOWN")).upper()
+
+
+def conclusion_severity(record: JsonObject) -> str:
+    return str(record.get("severity", "")).upper()
+
+
+def conclusion_category(record: JsonObject) -> str:
+    category = record.get("category")
+    if not isinstance(category, str) or not category.strip():
+        return "UNCATEGORIZED"
+    return category.strip()
+
+
+def has_evidence_value(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, tuple, dict)):
+        return bool(value)
+    return True
+
+
+def normalize_linked_issues(value: Any) -> list[str]:
+    if not has_evidence_value(value):
+        return []
+    if isinstance(value, list):
+        values = value
+    else:
+        values = [value]
+    normalized = [stable_text_value(item) for item in values if has_evidence_value(item)]
+    return sorted(dict.fromkeys(item for item in normalized if item))
+
+
+def stable_text_value(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    return json.dumps(value, ensure_ascii=True, sort_keys=True)
 
 
 def conclusion_gate_priority_key(record: JsonObject) -> tuple[int, int, str, str]:

--- a/scripts/test_rl_conclusion_registry.py
+++ b/scripts/test_rl_conclusion_registry.py
@@ -212,6 +212,10 @@ class RlConclusionRegistryTest(unittest.TestCase):
             gate["recommendedAction"],
             "create_or_update_aggregate_rl_conclusion_closure_issue_and_project_evidence",
         )
+        self.assertEqual(gate["aggregateRoutingIssue"], "#1543")
+        self.assertEqual(gate["aggregateRoutingIssueNumber"], 1543)
+        self.assertEqual(gate["minimumStaleTransitionsPerStewardCycle"], 3)
+        self.assertEqual(gate["requiredStaleTransition"], "STALE -> ACTIONED/CLOSED")
         self.assertIn("11 P0/P1 STALE conclusions exceed threshold 10", gate["evidence"])
 
     def test_summary_gate_ok_when_high_priority_stale_count_within_threshold(self) -> None:
@@ -231,6 +235,155 @@ class RlConclusionRegistryTest(unittest.TestCase):
         self.assertEqual(gate["staleHighPriorityCount"], 10)
         self.assertNotIn("recommendedAction", gate)
         self.assertNotIn("evidence", gate)
+
+    def test_action_plan_handles_object_registry_and_routes_issue_1543(self) -> None:
+        payload = {
+            "schemaVersion": 1,
+            "registryType": "rl-conclusion-registry",
+            "conclusions": {
+                "P1-CURRENT-BLOCKER": {
+                    "conclusionId": "P1-CURRENT-BLOCKER",
+                    "status": "OPEN",
+                    "severity": "P1",
+                    "category": "runtime-evidence",
+                    "linkedIssues": [1542, "#1540"],
+                    "requiredLandingEvidence": {"pr": "#1500"},
+                    "nextVerification": "rerun steward after merge evidence lands",
+                    "lastSeenAt": "2026-05-31T00:00:00Z",
+                    "statement": "Runtime policy still needs landing evidence.",
+                },
+                "P0-SUPERSEDED": {
+                    "conclusionId": "P0-SUPERSEDED",
+                    "status": "STALE",
+                    "severity": "P0",
+                    "category": "policy-stale",
+                    "lastSeenAt": "2026-05-25T00:00:00Z",
+                    "statement": "SUPERSEDED by the current rollout path.",
+                },
+                "P2-IGNORED": {
+                    "conclusionId": "P2-IGNORED",
+                    "status": "STALE",
+                    "severity": "P2",
+                    "category": "policy-stale",
+                },
+                "P0-CLOSED-IGNORED": {
+                    "conclusionId": "P0-CLOSED-IGNORED",
+                    "status": "CLOSED",
+                    "severity": "P0",
+                    "category": "runtime-evidence",
+                },
+            },
+        }
+
+        plan = registry.build_stale_conclusion_action_plan(payload)
+
+        self.assertEqual(plan["aggregateRoutingIssue"], "#1543")
+        self.assertEqual(plan["aggregateRoutingIssueNumber"], 1543)
+        self.assertEqual(plan["candidateFilter"], {"statuses": ["OPEN", "STALE"], "severities": ["P0", "P1"]})
+        self.assertEqual(plan["totalActionableCount"], 2)
+        self.assertEqual(plan["staleDecisionBacklogCount"], 1)
+        self.assertEqual(plan["countsByStatus"], {"OPEN": 1, "STALE": 1})
+        self.assertEqual(plan["countsBySeverity"], {"P0": 1, "P1": 1})
+        self.assertEqual(plan["countsByCategory"], {"policy-stale": 1, "runtime-evidence": 1})
+        self.assertEqual(plan["highestPriorityConclusionIds"], ["P0-SUPERSEDED", "P1-CURRENT-BLOCKER"])
+        self.assertEqual(
+            plan["recommendedNextAction"],
+            {
+                "action": "triage_stale_conclusions_via_aggregate_routing_issue",
+                "routingIssue": "#1543",
+                "routingIssueNumber": 1543,
+                "minimumStaleTransitionsPerStewardCycle": 3,
+                "requiredStaleTransition": "STALE -> ACTIONED/CLOSED",
+                "targetStaleTransitionsThisCycle": 1,
+            },
+        )
+
+        stale_records = plan["groups"]["likelySupersededOrStale"]
+        self.assertEqual([item["conclusionId"] for item in stale_records], ["P0-SUPERSEDED"])
+        self.assertEqual(stale_records[0]["recommendedDisposition"], "CLOSE_IF_SUPERSEDED")
+        self.assertEqual(
+            stale_records[0]["evidenceFlags"],
+            ["status_stale", "statement_superseded", "category_stale"],
+        )
+
+        current_records = plan["groups"]["currentActionableBlockers"]
+        self.assertEqual([item["conclusionId"] for item in current_records], ["P1-CURRENT-BLOCKER"])
+        self.assertEqual(current_records[0]["recommendedDisposition"], "ROUTE_CURRENT_BLOCKER_FOR_EVIDENCE")
+        self.assertEqual(
+            current_records[0]["evidenceFlags"],
+            [
+                "linked_issue_present",
+                "required_landing_evidence_present",
+                "next_verification_present",
+            ],
+        )
+        self.assertEqual(current_records[0]["linkedIssues"], ["#1540", "1542"])
+        self.assertEqual(
+            registry.summarize_conclusions(registry.normalize_conclusions(payload))["staleConclusionActionPlan"],
+            plan,
+        )
+
+    def test_action_plan_handles_legacy_list_registry_and_orders_deterministically(self) -> None:
+        payload = {
+            "schemaVersion": 1,
+            "registryType": "rl-conclusion-registry",
+            "conclusions": [
+                {
+                    "conclusionId": "P1-STALE-OLDER",
+                    "status": "STALE",
+                    "severity": "P1",
+                    "category": "runtime-evidence",
+                    "lastSeenAt": "2026-05-01T00:00:00Z",
+                },
+                {
+                    "conclusionId": "P0-OPEN",
+                    "status": "OPEN",
+                    "severity": "P0",
+                    "category": "runtime-evidence",
+                    "lastSeenAt": "2026-05-01T00:00:00Z",
+                },
+                {
+                    "conclusionId": "P0-STALE-NEWER",
+                    "status": "STALE",
+                    "severity": "P0",
+                    "category": "runtime-evidence",
+                    "lastSeenAt": "2026-05-03T00:00:00Z",
+                },
+                {
+                    "conclusionId": "P0-STALE-OLDER",
+                    "status": "STALE",
+                    "severity": "P0",
+                    "category": "runtime-evidence",
+                    "lastSeenAt": "2026-05-02T00:00:00Z",
+                },
+                {
+                    "conclusionId": "P1-ACTIONED-IGNORED",
+                    "status": "ACTIONED",
+                    "severity": "P1",
+                    "category": "runtime-evidence",
+                },
+            ],
+        }
+
+        plan = registry.build_stale_conclusion_action_plan(payload, preview_limit=3)
+
+        self.assertEqual(plan["totalActionableCount"], 4)
+        self.assertEqual(plan["staleDecisionBacklogCount"], 3)
+        self.assertEqual(plan["countsByStatus"], {"OPEN": 1, "STALE": 3})
+        self.assertEqual(plan["countsBySeverity"], {"P0": 3, "P1": 1})
+        self.assertEqual(
+            plan["highestPriorityConclusionIds"],
+            ["P0-STALE-OLDER", "P0-STALE-NEWER", "P0-OPEN"],
+        )
+        self.assertEqual(plan["recommendedNextAction"]["targetStaleTransitionsThisCycle"], 3)
+        self.assertEqual(
+            [item["conclusionId"] for item in plan["groups"]["likelySupersededOrStale"]],
+            ["P0-STALE-OLDER", "P0-STALE-NEWER", "P1-STALE-OLDER"],
+        )
+        self.assertEqual(
+            [item["conclusionId"] for item in plan["groups"]["currentActionableBlockers"]],
+            ["P0-OPEN"],
+        )
 
     def test_normalize_conclusions_rejects_duplicate_conclusion_ids(self) -> None:
         with self.assertRaisesRegex(registry.ConclusionRegistryError, "DUPLICATE-ID"):


### PR DESCRIPTION
## Summary
- Adds deterministic stale-conclusion action-plan helpers to the RL conclusion registry utilities.
- Groups P0/P1 OPEN/STALE conclusions into current actionable blockers versus likely superseded/stale triage candidates.
- Adds focused unit coverage for dict/list registry shapes, counts, ordering, routing metadata, and grouping behavior.

## Verification
- `python3 -m py_compile scripts/rl_conclusion_registry.py scripts/test_rl_conclusion_registry.py`
- `python3 scripts/test_rl_conclusion_registry.py` (13 tests OK)
- `git diff --check`

## Universal task Done gate
- [x] Task type: code + test helper for RL conclusion backlog routing automation.
- [x] Expected observable outcome / named deliverable: `build_stale_conclusion_action_plan` data contract in `scripts/rl_conclusion_registry.py` with focused registry tests.
- [x] Non-goals / accepted substitutes: no live runtime registry mutation, no paid compute, no official MMO deployment.
- [x] Verification evidence required before Done: py_compile, focused registry tests, and diff-check listed above.
- [x] Project Evidence / Next action / Blocked by: issue 1543 Project item records Codex commit/PR evidence and remains the aggregate steward-routing lane.
- [x] Post-merge/deploy/runtime proof: no official-runtime deploy needed; proof is the helper contract available on main for the next steward/scheduler cycle.
- [x] Named deliverable proof: commit `b3806e66` changes only `scripts/rl_conclusion_registry.py` and `scripts/test_rl_conclusion_registry.py`.

Refs #1543.
