### PR TITLE
fix: shed nonessential work under critical CPU

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -37753,7 +37753,7 @@ function hasCriticalRuntimeSummaryEvent(events) {
     if (event.type !== "defense") {
       return false;
     }
-    return event.action === "safeMode" || event.hostileCreepCount > 0 || event.hostileStructureCount > 0;
+    return event.action === "safeMode" || event.hostileCreepCount > 0 || event.hostileStructureCount > 0 || event.damagedCriticalStructureCount > 0;
   });
 }
 function resetCachedRefillTelemetryIfTickRewound(tick) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -47536,7 +47536,7 @@ function getWorkerCriticalCpuProbeRoomName(creep) {
   return typeof roomName === "string" && roomName.length > 0 ? roomName : null;
 }
 function shouldRunCriticalCpuColonyPlanning(colony, roleCounts) {
-  if (getWorkerCapacity(roleCounts) <= 0) {
+  if (roleCounts.worker <= 0 || getWorkerCapacity(roleCounts) <= 0) {
     return true;
   }
   if (isControllerDowngradeGuardController(colony.room.controller)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -47274,12 +47274,18 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
     let runOptionalRoomWork = shouldRunOptionalCpuRoomWork(roomCpuBudget, colony.room.name);
     let roleCounts = getPlannedOrCurrentRoleCounts(creeps, colony.room.name, plannedRoleCountsByRoom);
     plannedRoleCountsByRoom.set(colony.room.name, roleCounts);
-    if (criticalCpu && !shouldRunCriticalCpuColonyPlanning(colony, roleCounts)) {
-      continue;
+    let survivalAssessment;
+    if (criticalCpu) {
+      survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
+      if (!shouldRunCriticalCpuColonyPlanning(colony, roleCounts, survivalAssessment)) {
+        continue;
+      }
     }
     recordSourceWorkloads(colony.room, creeps, Game.time);
-    const workerTarget = getWorkerTarget(colony, roleCounts);
-    const survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
+    if (survivalAssessment === void 0) {
+      survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
+    }
+    const workerTarget = survivalAssessment.workerTarget;
     recordColonySurvivalAssessment(colony.room.name, survivalAssessment, Game.time);
     persistColonyStageAssessment(colony, survivalAssessment, Game.time);
     refreshControllerManagement(
@@ -47535,8 +47541,11 @@ function getWorkerCriticalCpuProbeRoomName(creep) {
   const roomName = (_c = (_a = creep.room) == null ? void 0 : _a.name) != null ? _c : (_b = creep.memory) == null ? void 0 : _b.colony;
   return typeof roomName === "string" && roomName.length > 0 ? roomName : null;
 }
-function shouldRunCriticalCpuColonyPlanning(colony, roleCounts) {
+function shouldRunCriticalCpuColonyPlanning(colony, roleCounts, survivalAssessment) {
   if (roleCounts.worker <= 0 || getWorkerCapacity(roleCounts) <= 0) {
+    return true;
+  }
+  if (roleCounts.worker < survivalAssessment.survivalWorkerFloor || survivalAssessment.workerCapacity < survivalAssessment.survivalWorkerFloor) {
     return true;
   }
   if (isControllerDowngradeGuardController(colony.room.controller)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -37680,10 +37680,11 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   const cpuBudget = getRuntimeCpuBudget();
   const emitsSummary = shouldEmitRuntimeSummary(tick, events, cpuBudget);
   const shouldRefreshRuntimeTelemetry = !shouldThrottleRuntimeSummaryCadence(cpuBudget) || emitsSummary;
-  const creepsByColony = groupCreepsByColony(creeps, colonies);
+  let creepsByColony;
   let refillTargetIdsByRoom = cachedRefillTargetIdsByRoom;
   let eventMetricsByRoom = cachedEventMetricsByRoom;
   if (emitsSummary) {
+    creepsByColony = groupCreepsByColony(creeps, colonies);
     refillTargetIdsByRoom = buildRefillTargetIdsByRoom(colonies);
     eventMetricsByRoom = buildRoomEventMetricsByRoom(colonies, refillTargetIdsByRoom);
     cachedRefillTargetIdsByRoom = refillTargetIdsByRoom;
@@ -37691,6 +37692,7 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
     cachedEventMetricsTick = tick;
   }
   if (shouldRefreshRuntimeTelemetry) {
+    creepsByColony != null ? creepsByColony : creepsByColony = groupCreepsByColony(creeps, colonies);
     refreshRefillTelemetry(
       colonies,
       creepsByColony,
@@ -37706,6 +37708,7 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   if (!emitsSummary) {
     return void 0;
   }
+  creepsByColony != null ? creepsByColony : creepsByColony = groupCreepsByColony(creeps, colonies);
   const reportedEvents = events.slice(0, MAX_REPORTED_EVENTS);
   const persistOccupationRecommendations = options.persistOccupationRecommendations !== false;
   const includeOptionalSummary = !cpuBudget.lowCpuLimit && !cpuBudget.critical;
@@ -37736,11 +37739,22 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   return summary;
 }
 function shouldEmitRuntimeSummary(tick, events, cpuBudget = getRuntimeCpuBudget()) {
+  if (cpuBudget.critical) {
+    return hasCriticalRuntimeSummaryEvent(events);
+  }
   if (events.length > 0) {
     return true;
   }
   const interval = shouldThrottleRuntimeSummaryCadence(cpuBudget) ? DEGRADED_RUNTIME_SUMMARY_INTERVAL : RUNTIME_SUMMARY_INTERVAL;
   return tick > 0 && tick % interval === 0;
+}
+function hasCriticalRuntimeSummaryEvent(events) {
+  return events.some((event) => {
+    if (event.type !== "defense") {
+      return false;
+    }
+    return event.action === "safeMode" || event.hostileCreepCount > 0 || event.hostileStructureCount > 0;
+  });
 }
 function resetCachedRefillTelemetryIfTickRewound(tick) {
   if (cachedEventMetricsTick === void 0 || tick >= cachedEventMetricsTick) {
@@ -47222,8 +47236,9 @@ var LOW_ROOM_ENERGY_TASK_PRIORITY_RATIO = 0.5;
 function runEconomy(preludeTelemetryEvents = [], options = {}) {
   var _a, _b, _c, _d;
   const featureGates = getRuntimeFeatureGates();
-  const shouldRunOptionalGlobalWork = () => shouldRunOptionalCpuWork(getRuntimeCpuBudget(), "economy-global-optional");
   const cpuBudget = getRuntimeCpuBudget();
+  const criticalCpu = cpuBudget.critical;
+  const shouldRunOptionalGlobalWork = () => shouldRunOptionalCpuWork(getRuntimeCpuBudget(), "economy-global-optional");
   const runOptionalGlobalWork = shouldRunOptionalCpuWork(cpuBudget, "economy-global-optional");
   const creeps = Object.values(Game.creeps);
   if (runOptionalGlobalWork) {
@@ -47237,25 +47252,32 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
   }
   const ownedColonies = getOwnedColonies();
   ensureLocalWorkerColonyMemory(ownedColonies, creeps);
-  refreshSpawnEnergyReservationStates(ownedColonies);
+  if (!criticalCpu) {
+    refreshSpawnEnergyReservationStates(ownedColonies);
+  }
   const initialRoleCountsByRoom = new Map(
     ownedColonies.map((colony) => [colony.room.name, countCreepsByRole(creeps, colony.room.name)])
   );
-  const colonies = orderColoniesForSpawnPlanning(ownedColonies, initialRoleCountsByRoom);
+  const colonies = criticalCpu ? ownedColonies : orderColoniesForSpawnPlanning(ownedColonies, initialRoleCountsByRoom);
   const telemetryEvents = [...preludeTelemetryEvents];
   const usedSpawnsByRoom = /* @__PURE__ */ new Map();
   const reservedSpawnEnergyByRoom = /* @__PURE__ */ new Map();
   const plannedRoleCountsByRoom = new Map(initialRoleCountsByRoom);
   clearColonySurvivalAssessmentCache();
-  refreshClaimedRoomBootstrapperOwnership(telemetryEvents);
-  const postClaimBootstrapFocusRoomName = selectPostClaimBootstrapFocusRoomName(colonies);
-  const controllerUpgradeTargetRooms = getControllerUpgradeTargetRooms2(colonies);
+  if (!criticalCpu) {
+    refreshClaimedRoomBootstrapperOwnership(telemetryEvents);
+  }
+  const postClaimBootstrapFocusRoomName = criticalCpu ? null : selectPostClaimBootstrapFocusRoomName(colonies);
+  const controllerUpgradeTargetRooms = criticalCpu ? void 0 : getControllerUpgradeTargetRooms2(colonies);
   for (const colony of colonies) {
     let roomCpuBudget = getRuntimeCpuBudget();
     let runOptionalRoomWork = shouldRunOptionalCpuRoomWork(roomCpuBudget, colony.room.name);
-    recordSourceWorkloads(colony.room, creeps, Game.time);
     let roleCounts = getPlannedOrCurrentRoleCounts(creeps, colony.room.name, plannedRoleCountsByRoom);
     plannedRoleCountsByRoom.set(colony.room.name, roleCounts);
+    if (criticalCpu && !shouldRunCriticalCpuColonyPlanning(colony, roleCounts)) {
+      continue;
+    }
+    recordSourceWorkloads(colony.room, creeps, Game.time);
     const workerTarget = getWorkerTarget(colony, roleCounts);
     const survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
     recordColonySurvivalAssessment(colony.room.name, survivalAssessment, Game.time);
@@ -47388,15 +47410,19 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
       recordStrategyRecommendationTelemetry(colony, creeps, telemetryEvents);
     }
   }
-  if (shouldRunOptionalGlobalWork()) {
+  if (!criticalCpu && shouldRunOptionalGlobalWork()) {
     ensureRemoteSourceContainersForAssignedHarvesters(creeps);
   }
-  attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom);
-  if (shouldRunOptionalGlobalWork()) {
+  if (!criticalCpu) {
+    attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom);
+  }
+  if (!criticalCpu && shouldRunOptionalGlobalWork()) {
     attemptMineralHarvesterSpawns(colonies, creeps, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom);
   }
-  refreshSpawnEnergyReservationStates(colonies);
-  refreshSpawnEnergyBufferStates(colonies, reservedSpawnEnergyByRoom);
+  if (!criticalCpu) {
+    refreshSpawnEnergyReservationStates(colonies);
+    refreshSpawnEnergyBufferStates(colonies, reservedSpawnEnergyByRoom);
+  }
   const creepCpuBudget = getRuntimeCpuBudget();
   const criticalCpuIdleWorkerProbeRooms = /* @__PURE__ */ new Set();
   for (const creep of orderCreepsForEconomyTaskPriority(creeps)) {
@@ -47509,12 +47535,24 @@ function getWorkerCriticalCpuProbeRoomName(creep) {
   const roomName = (_c = (_a = creep.room) == null ? void 0 : _a.name) != null ? _c : (_b = creep.memory) == null ? void 0 : _b.colony;
   return typeof roomName === "string" && roomName.length > 0 ? roomName : null;
 }
+function shouldRunCriticalCpuColonyPlanning(colony, roleCounts) {
+  if (getWorkerCapacity(roleCounts) <= 0) {
+    return true;
+  }
+  if (isControllerDowngradeGuardController(colony.room.controller)) {
+    return true;
+  }
+  return isColonyRoomThreatened(colony.room.name, Game.time);
+}
 function isDowngradeGuardControllerCreep(creep) {
   var _a, _b, _c;
   if (((_b = (_a = creep.memory) == null ? void 0 : _a.controllerUpgrade) == null ? void 0 : _b.priority) === "downgradeGuard") {
     return true;
   }
   const controller = (_c = creep.room) == null ? void 0 : _c.controller;
+  return isControllerDowngradeGuardController(controller);
+}
+function isControllerDowngradeGuardController(controller) {
   const ticksToDowngrade = normalizeOptionalNonNegativeInteger3(controller == null ? void 0 : controller.ticksToDowngrade);
   return (controller == null ? void 0 : controller.my) === true && ticksToDowngrade !== void 0 && ticksToDowngrade <= CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS;
 }

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -213,13 +213,19 @@ export function runEconomy(
     let runOptionalRoomWork = shouldRunOptionalCpuRoomWork(roomCpuBudget, colony.room.name);
     let roleCounts = getPlannedOrCurrentRoleCounts(creeps, colony.room.name, plannedRoleCountsByRoom);
     plannedRoleCountsByRoom.set(colony.room.name, roleCounts);
-    if (criticalCpu && !shouldRunCriticalCpuColonyPlanning(colony, roleCounts)) {
-      continue;
+    let survivalAssessment: ReturnType<typeof assessColonySnapshotSurvival> | undefined;
+    if (criticalCpu) {
+      survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
+      if (!shouldRunCriticalCpuColonyPlanning(colony, roleCounts, survivalAssessment)) {
+        continue;
+      }
     }
 
     recordSourceWorkloads(colony.room, creeps, Game.time);
-    const workerTarget = getWorkerTarget(colony, roleCounts);
-    const survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
+    if (survivalAssessment === undefined) {
+      survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
+    }
+    const workerTarget = survivalAssessment.workerTarget;
     recordColonySurvivalAssessment(colony.room.name, survivalAssessment, Game.time);
     persistColonyStageAssessment(colony, survivalAssessment, Game.time);
     refreshControllerManagement(
@@ -524,8 +530,19 @@ function getWorkerCriticalCpuProbeRoomName(creep: Creep): string | null {
   return typeof roomName === 'string' && roomName.length > 0 ? roomName : null;
 }
 
-function shouldRunCriticalCpuColonyPlanning(colony: ColonySnapshot, roleCounts: RoleCounts): boolean {
+function shouldRunCriticalCpuColonyPlanning(
+  colony: ColonySnapshot,
+  roleCounts: RoleCounts,
+  survivalAssessment: ReturnType<typeof assessColonySnapshotSurvival>
+): boolean {
   if (roleCounts.worker <= 0 || getWorkerCapacity(roleCounts) <= 0) {
+    return true;
+  }
+
+  if (
+    roleCounts.worker < survivalAssessment.survivalWorkerFloor ||
+    survivalAssessment.workerCapacity < survivalAssessment.survivalWorkerFloor
+  ) {
     return true;
   }
 

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -43,6 +43,7 @@ import {
   shouldRunOptionalCpuWork,
   type RuntimeCpuBudget
 } from '../runtime/cpuBudget';
+import { isColonyRoomThreatened } from '../defense/colonyThreats';
 import { recordSourceWorkloads } from './sourceWorkload';
 import {
   ensureRemoteSourceContainersForAssignedHarvesters
@@ -165,9 +166,10 @@ export function runEconomy(
   options: EconomyRuntimeOptions = {}
 ): RuntimeSummary | undefined {
   const featureGates = getRuntimeFeatureGates();
+  const cpuBudget = getRuntimeCpuBudget();
+  const criticalCpu = cpuBudget.critical;
   const shouldRunOptionalGlobalWork = (): boolean =>
     shouldRunOptionalCpuWork(getRuntimeCpuBudget(), 'economy-global-optional');
-  const cpuBudget = getRuntimeCpuBudget();
   const runOptionalGlobalWork = shouldRunOptionalCpuWork(cpuBudget, 'economy-global-optional');
   const creeps = Object.values(Game.creeps);
   if (runOptionalGlobalWork) {
@@ -186,26 +188,36 @@ export function runEconomy(
   }
   const ownedColonies = getOwnedColonies();
   ensureLocalWorkerColonyMemory(ownedColonies, creeps);
-  refreshSpawnEnergyReservationStates(ownedColonies);
+  if (!criticalCpu) {
+    refreshSpawnEnergyReservationStates(ownedColonies);
+  }
   const initialRoleCountsByRoom = new Map(
     ownedColonies.map((colony) => [colony.room.name, countCreepsByRole(creeps, colony.room.name)] as const)
   );
-  const colonies = orderColoniesForSpawnPlanning(ownedColonies, initialRoleCountsByRoom);
+  const colonies = criticalCpu
+    ? ownedColonies
+    : orderColoniesForSpawnPlanning(ownedColonies, initialRoleCountsByRoom);
   const telemetryEvents: RuntimeTelemetryEvent[] = [...preludeTelemetryEvents];
   const usedSpawnsByRoom = new Map<string, Set<StructureSpawn>>();
   const reservedSpawnEnergyByRoom = new Map<string, number>();
   const plannedRoleCountsByRoom = new Map<string, RoleCounts>(initialRoleCountsByRoom);
   clearColonySurvivalAssessmentCache();
-  refreshClaimedRoomBootstrapperOwnership(telemetryEvents);
-  const postClaimBootstrapFocusRoomName = selectPostClaimBootstrapFocusRoomName(colonies);
-  const controllerUpgradeTargetRooms = getControllerUpgradeTargetRooms(colonies);
+  if (!criticalCpu) {
+    refreshClaimedRoomBootstrapperOwnership(telemetryEvents);
+  }
+  const postClaimBootstrapFocusRoomName = criticalCpu ? null : selectPostClaimBootstrapFocusRoomName(colonies);
+  const controllerUpgradeTargetRooms = criticalCpu ? undefined : getControllerUpgradeTargetRooms(colonies);
 
   for (const colony of colonies) {
     let roomCpuBudget = getRuntimeCpuBudget();
     let runOptionalRoomWork = shouldRunOptionalCpuRoomWork(roomCpuBudget, colony.room.name);
-    recordSourceWorkloads(colony.room, creeps, Game.time);
     let roleCounts = getPlannedOrCurrentRoleCounts(creeps, colony.room.name, plannedRoleCountsByRoom);
     plannedRoleCountsByRoom.set(colony.room.name, roleCounts);
+    if (criticalCpu && !shouldRunCriticalCpuColonyPlanning(colony, roleCounts)) {
+      continue;
+    }
+
+    recordSourceWorkloads(colony.room, creeps, Game.time);
     const workerTarget = getWorkerTarget(colony, roleCounts);
     const survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
     recordColonySurvivalAssessment(colony.room.name, survivalAssessment, Game.time);
@@ -352,15 +364,19 @@ export function runEconomy(
     }
   }
 
-  if (shouldRunOptionalGlobalWork()) {
+  if (!criticalCpu && shouldRunOptionalGlobalWork()) {
     ensureRemoteSourceContainersForAssignedHarvesters(creeps);
   }
-  attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom);
-  if (shouldRunOptionalGlobalWork()) {
+  if (!criticalCpu) {
+    attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom);
+  }
+  if (!criticalCpu && shouldRunOptionalGlobalWork()) {
     attemptMineralHarvesterSpawns(colonies, creeps, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom);
   }
-  refreshSpawnEnergyReservationStates(colonies);
-  refreshSpawnEnergyBufferStates(colonies, reservedSpawnEnergyByRoom);
+  if (!criticalCpu) {
+    refreshSpawnEnergyReservationStates(colonies);
+    refreshSpawnEnergyBufferStates(colonies, reservedSpawnEnergyByRoom);
+  }
 
   const creepCpuBudget = getRuntimeCpuBudget();
   const criticalCpuIdleWorkerProbeRooms = new Set<string>();
@@ -508,12 +524,28 @@ function getWorkerCriticalCpuProbeRoomName(creep: Creep): string | null {
   return typeof roomName === 'string' && roomName.length > 0 ? roomName : null;
 }
 
+function shouldRunCriticalCpuColonyPlanning(colony: ColonySnapshot, roleCounts: RoleCounts): boolean {
+  if (getWorkerCapacity(roleCounts) <= 0) {
+    return true;
+  }
+
+  if (isControllerDowngradeGuardController(colony.room.controller)) {
+    return true;
+  }
+
+  return isColonyRoomThreatened(colony.room.name, Game.time);
+}
+
 function isDowngradeGuardControllerCreep(creep: Creep): boolean {
   if (creep.memory?.controllerUpgrade?.priority === 'downgradeGuard') {
     return true;
   }
 
   const controller = creep.room?.controller;
+  return isControllerDowngradeGuardController(controller);
+}
+
+function isControllerDowngradeGuardController(controller: StructureController | undefined): boolean {
   const ticksToDowngrade = normalizeOptionalNonNegativeInteger(controller?.ticksToDowngrade);
   return (
     controller?.my === true &&
@@ -1467,7 +1499,7 @@ function buildAffordableCrossRoomHaulerBody(
 function getSpawnPlanningOptions(
   successfulSpawnCount: number,
   hasPendingTerritoryFollowUp: boolean,
-  controllerUpgradeTargetRooms: readonly string[] | null
+  controllerUpgradeTargetRooms: readonly string[] | null | undefined
 ): SpawnPlanningOptions {
   const allowTerritoryFollowUp = successfulSpawnCount > 0 || hasPendingTerritoryFollowUp;
   if (successfulSpawnCount === 0) {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -525,7 +525,7 @@ function getWorkerCriticalCpuProbeRoomName(creep: Creep): string | null {
 }
 
 function shouldRunCriticalCpuColonyPlanning(colony: ColonySnapshot, roleCounts: RoleCounts): boolean {
-  if (getWorkerCapacity(roleCounts) <= 0) {
+  if (roleCounts.worker <= 0 || getWorkerCapacity(roleCounts) <= 0) {
     return true;
   }
 

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -863,7 +863,8 @@ function hasCriticalRuntimeSummaryEvent(events: RuntimeTelemetryEvent[]): boolea
     return (
       event.action === 'safeMode' ||
       event.hostileCreepCount > 0 ||
-      event.hostileStructureCount > 0
+      event.hostileStructureCount > 0 ||
+      event.damagedCriticalStructureCount > 0
     );
   });
 }

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -774,11 +774,12 @@ export function emitRuntimeSummary(
   const cpuBudget = getRuntimeCpuBudget();
   const emitsSummary = shouldEmitRuntimeSummary(tick, events, cpuBudget);
   const shouldRefreshRuntimeTelemetry = !shouldThrottleRuntimeSummaryCadence(cpuBudget) || emitsSummary;
-  const creepsByColony = groupCreepsByColony(creeps, colonies);
+  let creepsByColony: Map<string, Creep[]> | undefined;
   let refillTargetIdsByRoom = cachedRefillTargetIdsByRoom;
   let eventMetricsByRoom = cachedEventMetricsByRoom;
 
   if (emitsSummary) {
+    creepsByColony = groupCreepsByColony(creeps, colonies);
     refillTargetIdsByRoom = buildRefillTargetIdsByRoom(colonies);
     eventMetricsByRoom = buildRoomEventMetricsByRoom(colonies, refillTargetIdsByRoom);
     cachedRefillTargetIdsByRoom = refillTargetIdsByRoom;
@@ -787,6 +788,7 @@ export function emitRuntimeSummary(
   }
 
   if (shouldRefreshRuntimeTelemetry) {
+    creepsByColony ??= groupCreepsByColony(creeps, colonies);
     refreshRefillTelemetry(
       colonies,
       creepsByColony,
@@ -804,6 +806,7 @@ export function emitRuntimeSummary(
     return undefined;
   }
 
+  creepsByColony ??= groupCreepsByColony(creeps, colonies);
   const reportedEvents = events.slice(0, MAX_REPORTED_EVENTS);
   const persistOccupationRecommendations = options.persistOccupationRecommendations !== false;
   const includeOptionalSummary = !cpuBudget.lowCpuLimit && !cpuBudget.critical;
@@ -837,6 +840,10 @@ export function shouldEmitRuntimeSummary(
   events: RuntimeTelemetryEvent[],
   cpuBudget = getRuntimeCpuBudget()
 ): boolean {
+  if (cpuBudget.critical) {
+    return hasCriticalRuntimeSummaryEvent(events);
+  }
+
   if (events.length > 0) {
     return true;
   }
@@ -845,6 +852,20 @@ export function shouldEmitRuntimeSummary(
     ? DEGRADED_RUNTIME_SUMMARY_INTERVAL
     : RUNTIME_SUMMARY_INTERVAL;
   return tick > 0 && tick % interval === 0;
+}
+
+function hasCriticalRuntimeSummaryEvent(events: RuntimeTelemetryEvent[]): boolean {
+  return events.some((event) => {
+    if (event.type !== 'defense') {
+      return false;
+    }
+
+    return (
+      event.action === 'safeMode' ||
+      event.hostileCreepCount > 0 ||
+      event.hostileStructureCount > 0
+    );
+  });
 }
 
 export function resetRuntimeCpuSummaryEmissionForTesting(): void {

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -338,6 +338,58 @@ describe('runEconomy', () => {
     expect(room.find).not.toHaveBeenCalled();
   });
 
+  it('keeps worker recovery planning under critical CPU when only source harvesters remain', () => {
+    const findSources = (globalThis as Record<string, unknown>).FIND_SOURCES;
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 300,
+      energyCapacityAvailable: 800,
+      controller: {
+        my: true,
+        level: 3,
+        ticksToDowngrade: CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS + 1
+      } as StructureController,
+      find: jest.fn((type: FindConstant) => (type === findSources ? [{} as Source] : []))
+    } as unknown as Room;
+    const spawn = {
+      name: 'Spawn1',
+      room,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const sourceHarvester = {
+      name: 'SourceHarvester1',
+      ticksToLive: 1000,
+      memory: {
+        role: 'sourceHarvester',
+        colony: 'W1N1',
+        sourceHarvester: {
+          roomName: 'W1N1',
+          sourceId: 'source1' as Id<Source>
+        }
+      },
+      room
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 128,
+      rooms: { W1N1: room },
+      spawns: { Spawn1: spawn },
+      creeps: { SourceHarvester1: sourceHarvester },
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(12),
+        limit: 70,
+        bucket: 1,
+        tickLimit: 21
+      } as unknown as CPU
+    };
+
+    runEconomy();
+
+    expect(spawn.spawnCreep).toHaveBeenCalledWith(['work', 'carry', 'move'], 'worker-W1N1-128', {
+      memory: { role: 'worker', colony: 'W1N1' }
+    });
+  });
+
   it('spawns an emergency bootstrap worker without requiring the energy buffer', () => {
     const room = {
       name: 'W1N1',

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -292,6 +292,52 @@ describe('runEconomy', () => {
     });
   });
 
+  it('skips stable colony planning while the CPU bucket is critical', () => {
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 800,
+      energyCapacityAvailable: 800,
+      controller: {
+        my: true,
+        level: 3,
+        ticksToDowngrade: CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS + 1
+      } as StructureController,
+      find: jest.fn(() => [])
+    } as unknown as Room;
+    const spawn = {
+      name: 'Spawn1',
+      room,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const worker = {
+      name: 'Worker1',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'reserve' }
+      },
+      room
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 127,
+      rooms: { W1N1: room },
+      spawns: { Spawn1: spawn },
+      creeps: { Worker1: worker },
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(12),
+        limit: 70,
+        bucket: 1,
+        tickLimit: 21
+      } as unknown as CPU
+    };
+
+    runEconomy();
+
+    expect(spawn.spawnCreep).not.toHaveBeenCalled();
+    expect(room.find).not.toHaveBeenCalled();
+  });
+
   it('spawns an emergency bootstrap worker without requiring the energy buffer', () => {
     const room = {
       name: 'W1N1',

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -310,8 +310,57 @@ describe('runEconomy', () => {
       spawning: null,
       spawnCreep: jest.fn().mockReturnValue(OK_CODE)
     } as unknown as StructureSpawn;
+    const makeWorker = (name: string): Creep => ({
+      name,
+      memory: {
+        role: 'worker',
+        colony: 'W1N1'
+      },
+      room
+    }) as unknown as Creep;
+    const worker1 = makeWorker('Worker1');
+    const worker2 = makeWorker('Worker2');
+    const worker3 = makeWorker('Worker3');
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 127,
+      rooms: { W1N1: room },
+      spawns: { Spawn1: spawn },
+      creeps: { Worker1: worker1, Worker2: worker2, Worker3: worker3 },
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(12),
+        limit: 70,
+        bucket: 1,
+        tickLimit: 21
+      } as unknown as CPU
+    };
+
+    runEconomy();
+
+    expect(spawn.spawnCreep).not.toHaveBeenCalled();
+  });
+
+  it('keeps local worker floor recovery planning under critical CPU when one counted worker remains', () => {
+    const findSources = (globalThis as Record<string, unknown>).FIND_SOURCES;
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 300,
+      energyCapacityAvailable: 800,
+      controller: {
+        my: true,
+        level: 3,
+        ticksToDowngrade: CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS + 1
+      } as StructureController,
+      find: jest.fn((type: FindConstant) => (type === findSources ? [{} as Source] : []))
+    } as unknown as Room;
+    const spawn = {
+      name: 'Spawn1',
+      room,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
     const worker = {
       name: 'Worker1',
+      ticksToLive: 1000,
       memory: {
         role: 'worker',
         colony: 'W1N1',
@@ -320,7 +369,7 @@ describe('runEconomy', () => {
       room
     } as unknown as Creep;
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
-      time: 127,
+      time: 129,
       rooms: { W1N1: room },
       spawns: { Spawn1: spawn },
       creeps: { Worker1: worker },
@@ -334,8 +383,9 @@ describe('runEconomy', () => {
 
     runEconomy();
 
-    expect(spawn.spawnCreep).not.toHaveBeenCalled();
-    expect(room.find).not.toHaveBeenCalled();
+    expect(spawn.spawnCreep).toHaveBeenCalledWith(['work', 'carry', 'move'], 'worker-W1N1-129', {
+      memory: { role: 'worker', colony: 'W1N1' }
+    });
   });
 
   it('keeps worker recovery planning under critical CPU when only source harvesters remain', () => {

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -412,6 +412,31 @@ describe('runtime telemetry summaries', () => {
     expect((message as string).startsWith(RUNTIME_CPU_SUMMARY_PREFIX)).toBe(true);
   });
 
+  it('emits damage-only critical defense summaries while the CPU bucket is critical', () => {
+    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
+    const damageOnlyDefenseEvent: RuntimeTelemetryEvent = {
+      type: 'defense',
+      action: 'workerFallback',
+      roomName: 'W1N1',
+      reason: 'workerEmergencyFallback',
+      hostileCreepCount: 0,
+      hostileStructureCount: 0,
+      damagedCriticalStructureCount: 1,
+      tick: RUNTIME_SUMMARY_INTERVAL
+    };
+    (Game as Partial<Game>).cpu = {
+      getUsed: jest.fn().mockReturnValue(24),
+      limit: 70,
+      bucket: 43,
+      tickLimit: 63
+    } as unknown as CPU;
+
+    emitRuntimeSummary([colony], [], [damageOnlyDefenseEvent]);
+
+    const payload = parseLoggedSummary();
+    expect(payload.events).toEqual([damageOnlyDefenseEvent]);
+  });
+
   it('reports per-creep behavior counters and resets emitted counters', () => {
     const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
     const worker = makeWorker(
@@ -3087,6 +3112,16 @@ describe('runtime telemetry summaries', () => {
       damagedCriticalStructureCount: 0,
       tick: RUNTIME_SUMMARY_INTERVAL
     };
+    const damageOnlyDefenseEvent: RuntimeTelemetryEvent = {
+      type: 'defense',
+      action: 'workerFallback',
+      roomName: 'W1N1',
+      reason: 'workerEmergencyFallback',
+      hostileCreepCount: 0,
+      hostileStructureCount: 0,
+      damagedCriticalStructureCount: 1,
+      tick: RUNTIME_SUMMARY_INTERVAL
+    };
 
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [], lowBucketBudget)).toBe(false);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL * 5, [], lowBucketBudget)).toBe(true);
@@ -3094,6 +3129,7 @@ describe('runtime telemetry summaries', () => {
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL * 5, [], criticalBucketBudget)).toBe(false);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [spawnEvent], criticalBucketBudget)).toBe(false);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [safeModeEvent], criticalBucketBudget)).toBe(true);
+    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [damageOnlyDefenseEvent], criticalBucketBudget)).toBe(true);
   });
 
   it('reports construction-priority runtime use from runtime summary scoring', () => {

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -395,6 +395,23 @@ describe('runtime telemetry summaries', () => {
     expect(logSpy).not.toHaveBeenCalled();
   });
 
+  it('suppresses full cadence summaries while the CPU bucket is critical', () => {
+    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL * 5 });
+    (Game as Partial<Game>).cpu = {
+      getUsed: jest.fn().mockReturnValue(24),
+      limit: 70,
+      bucket: 43,
+      tickLimit: 63
+    } as unknown as CPU;
+
+    emitRuntimeSummary([colony], []);
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const [message] = logSpy.mock.calls[0];
+    expect(typeof message).toBe('string');
+    expect((message as string).startsWith(RUNTIME_CPU_SUMMARY_PREFIX)).toBe(true);
+  });
+
   it('reports per-creep behavior counters and resets emitted counters', () => {
     const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
     const worker = makeWorker(
@@ -3037,13 +3054,20 @@ describe('runtime telemetry summaries', () => {
     ).toBe(true);
   });
 
-  it('uses degraded cadence for low CPU bucket pressure without suppressing event summaries', () => {
+  it('uses degraded cadence for low bucket pressure and suppresses noncritical summaries at critical bucket', () => {
+    const lowBucketBudget = buildRuntimeCpuBudget({
+      tick: RUNTIME_SUMMARY_INTERVAL,
+      used: 21,
+      limit: 70,
+      bucket: 500,
+      tickLimit: 500
+    });
     const criticalBucketBudget = buildRuntimeCpuBudget({
       tick: RUNTIME_SUMMARY_INTERVAL,
       used: 21,
       limit: 70,
       bucket: 43,
-      tickLimit: 500
+      tickLimit: 63
     });
     const spawnEvent: RuntimeTelemetryEvent = {
       type: 'spawn',
@@ -3053,10 +3077,23 @@ describe('runtime telemetry summaries', () => {
       role: 'worker',
       result: 0 as ScreepsReturnCode
     };
+    const safeModeEvent: RuntimeTelemetryEvent = {
+      type: 'defense',
+      action: 'safeMode',
+      roomName: 'W1N1',
+      reason: 'safeModeEarlyRoomThreat',
+      hostileCreepCount: 2,
+      hostileStructureCount: 0,
+      damagedCriticalStructureCount: 0,
+      tick: RUNTIME_SUMMARY_INTERVAL
+    };
 
-    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [], criticalBucketBudget)).toBe(false);
-    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL * 5, [], criticalBucketBudget)).toBe(true);
-    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [spawnEvent], criticalBucketBudget)).toBe(true);
+    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [], lowBucketBudget)).toBe(false);
+    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL * 5, [], lowBucketBudget)).toBe(true);
+    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [spawnEvent], lowBucketBudget)).toBe(true);
+    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL * 5, [], criticalBucketBudget)).toBe(false);
+    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [spawnEvent], criticalBucketBudget)).toBe(false);
+    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [safeModeEvent], criticalBucketBudget)).toBe(true);
   });
 
   it('reports construction-priority runtime use from runtime summary scoring', () => {


### PR DESCRIPTION
## Summary
- shed nonessential economy-room planning work while the CPU bucket is critical or emergency-only
- skip runtime summary event-log scans under the same critical CPU state while preserving room/resource snapshot fields
- add regression coverage for critical-CPU economy planning and runtime-summary event omission; rebuild `prod/dist/main.js`

Refs #1536.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 103 suites / 2123 tests passed
- `cd prod && npm run build`

## Universal task Done gate
- [x] Task type: production code CPU-safety follow-up.
- [x] Expected observable outcome / named deliverable: under critical CPU, the economy/runtime summary path avoids nonessential scans/event-log work while preserving survival-relevant behavior and required telemetry shape.
- [x] Non-goals / accepted substitutes: no runtime issue closure in this PR; #1536 remains the acceptance tracker for official MMO CPU-bearing observation.
- [x] Verification evidence required before Done: controller ran diff-check, typecheck, full Jest, and build on commit `254fa686`.
- [x] Project Evidence / Next action / Blocked by: PR and #1536 Project fields will record commit `254fa686`, controller verification, and exact-head review/CI/deploy gate.
- [x] Post-merge/deploy/runtime proof: #1536 retains runtime acceptance tracking for deployed CPU bucket recovery evidence.
- [x] Named deliverable proof: `prod/src/economy/economyLoop.ts`, `prod/src/telemetry/runtimeSummary.ts`, their Jest tests, and `prod/dist/main.js` contain the CPU shedding implementation, tests, and bundle.

## Safety
- No secrets printed.
- No official MMO writes in this PR.
- Runtime acceptance remains gated on post-deploy monitor evidence through #1536.
