### PR TITLE
fix: allow guarded timeout recovery validation

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -1916,7 +1916,7 @@ def default_run_id(command: str = "run-single") -> str:
 
 
 def canonical_json(value: Any) -> str:
-    return json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+    return json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True, allow_nan=False) + "\n"
 
 
 def tail_text(raw: str | None, limit: int = 3000) -> str:
@@ -2546,6 +2546,7 @@ def remote_training_partial_simulator_progress(artifact_dir: Path, run_id: str |
         if ticks_run is None:
             ticks_run = scale_gates.non_negative_int(payload.get("totalTicks")) or 0
         wall_clock_seconds = numeric_value(payload.get("wallClockSeconds")) or 0.0
+        completed_environment_rows = successful + failed
         summary = {
             "runId": text_value(payload.get("runId")) or path.parent.name,
             "summaryPath": str(path),
@@ -2557,7 +2558,7 @@ def remote_training_partial_simulator_progress(artifact_dir: Path, run_id: str |
             "wallClockSeconds": round(wall_clock_seconds, 3),
         }
         summaries.append(summary)
-        totals["completedEnvironmentRows"] += total_environments
+        totals["completedEnvironmentRows"] += completed_environment_rows
         totals["successfulEnvironmentRows"] += successful
         totals["failedEnvironmentRows"] += failed
         totals["ticksRun"] += ticks_run
@@ -3985,12 +3986,14 @@ def numeric_value(value: Any) -> float | None:
     if isinstance(value, bool):
         return None
     if isinstance(value, (int, float)):
-        return float(value)
+        parsed = float(value)
+        return parsed if math.isfinite(parsed) else None
     if isinstance(value, str):
         try:
-            return float(value)
+            parsed = float(value)
         except ValueError:
             return None
+        return parsed if math.isfinite(parsed) else None
     return None
 
 

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -1738,12 +1738,14 @@ if [ ! -s report-extract.json ] && [ -s training-summary.json ]; then
   cp training-summary.json report-extract.json
 fi
 simulator_diagnostics=()
-for simulator_run_id in "$RUN_ID" "$RUN_ID-pre-scale-smoke"; do
-  for simulator_file in run_summary.json resource_guard_failure.json setup_failure.json run_failure.json owned_room_scorecard.json; do
-    if [ -f "simulator-artifacts/$simulator_run_id/$simulator_file" ]; then
-      simulator_diagnostics+=("simulator-artifacts/$simulator_run_id/$simulator_file")
-    fi
-  done
+for simulator_dir in "simulator-artifacts/$RUN_ID" "simulator-artifacts/$RUN_ID-pre-scale-smoke" "simulator-artifacts/$RUN_ID"-r*; do
+  if [ -d "$simulator_dir" ]; then
+    for simulator_file in run_summary.json resource_guard_failure.json setup_failure.json run_failure.json owned_room_scorecard.json; do
+      if [ -f "$simulator_dir/$simulator_file" ]; then
+        simulator_diagnostics+=("$simulator_dir/$simulator_file")
+      fi
+    done
+  fi
 done
 tar -czf remote-artifacts.tar.gz \
   experiment_card.json card-validation.json training-summary.json training-stderr.log report-extract.json \
@@ -2199,6 +2201,10 @@ def controller_execution_summary(
     remote_training_attempted = "remote_training" in step_names
     compute_attempted = scale_out_attempted or remote_training_attempted or training_report_produced
     environments_run = training_environments_run(training_report_data)
+    if environments_run == 0:
+        partial_environments = remote_training_partial_environment_count(result)
+        if partial_environments is not None:
+            environments_run = partial_environments
     preflight_only = bool(getattr(args, "preflight_only", False))
     return {
         "command": getattr(args, "command", None),
@@ -2213,6 +2219,15 @@ def controller_execution_summary(
         "artifactCount": training_report_data.get("artifactCount"),
         "environmentsRun": environments_run,
     }
+
+
+def remote_training_partial_environment_count(result: dict[str, Any]) -> int | None:
+    remote_failure = dict_value(result.get("remoteTrainingFailure"))
+    progress = dict_value(remote_failure.get("partialSimulatorProgress")) if remote_failure is not None else None
+    if progress is None:
+        return None
+    count = scale_gates.non_negative_int(progress.get("completedEnvironmentRows"))
+    return count if count is not None and count > 0 else None
 
 
 def controller_batch_scale_summary(
@@ -2415,6 +2430,30 @@ def remote_training_diagnostic_files(run_id: str | None = None) -> tuple[str, ..
     return tuple(files)
 
 
+def remote_training_available_diagnostic_files(artifact_dir: Path, run_id: str | None = None) -> tuple[str, ...]:
+    files = list(remote_training_diagnostic_files(run_id))
+    seen = set(files)
+    if not isinstance(run_id, str) or RUN_ID_RE.match(run_id) is None:
+        return tuple(files)
+    simulator_root = artifact_dir / "remote" / "simulator-artifacts"
+    try:
+        run_dirs = sorted(
+            path
+            for path in simulator_root.glob(f"{run_id}-r*")
+            if path.is_dir()
+        )
+    except OSError:
+        return tuple(files)
+    for run_dir in run_dirs:
+        for filename in REMOTE_SIMULATOR_DIAGNOSTIC_FILES:
+            rel = f"simulator-artifacts/{run_dir.name}/{filename}"
+            if rel in seen:
+                continue
+            files.append(rel)
+            seen.add(rel)
+    return tuple(files)
+
+
 def remote_training_failure_diagnostics(
     artifact_dir: Path,
     returncode: int,
@@ -2426,7 +2465,7 @@ def remote_training_failure_diagnostics(
 ) -> dict[str, Any]:
     remote_dir = artifact_dir / "remote"
     files: dict[str, dict[str, Any]] = {}
-    for filename in remote_training_diagnostic_files(run_id):
+    for filename in remote_training_available_diagnostic_files(artifact_dir, run_id):
         path = remote_dir / filename
         entry: dict[str, Any] = {"path": str(path)}
         try:
@@ -2460,9 +2499,80 @@ def remote_training_failure_diagnostics(
     resource_guard = remote_training_resource_guard_summary(artifact_dir, run_id)
     if resource_guard is not None:
         payload["resourceGuard"] = resource_guard
+    partial_progress = remote_training_partial_simulator_progress(artifact_dir, run_id)
+    if partial_progress is not None:
+        payload["partialSimulatorProgress"] = partial_progress
     if collection_error:
         payload["collectionError"] = diagnostic_tail(collection_error)
     return payload
+
+
+def remote_training_partial_simulator_progress(artifact_dir: Path, run_id: str | None) -> dict[str, Any] | None:
+    if not isinstance(run_id, str) or RUN_ID_RE.match(run_id) is None:
+        return None
+    simulator_root = artifact_dir / "remote" / "simulator-artifacts"
+    try:
+        run_dirs = [simulator_root / run_id]
+        run_dirs.extend(
+            path
+            for path in simulator_root.glob(f"{run_id}-r*")
+            if path.is_dir()
+        )
+        run_summary_paths = sorted(path / "run_summary.json" for path in run_dirs if path.is_dir())
+    except OSError:
+        return None
+    summaries: list[dict[str, Any]] = []
+    totals = {
+        "completedEnvironmentRows": 0,
+        "successfulEnvironmentRows": 0,
+        "failedEnvironmentRows": 0,
+        "ticksRun": 0,
+        "wallClockSeconds": 0.0,
+    }
+    for path in run_summary_paths:
+        payload = read_diagnostic_json_object(path)
+        if payload is None:
+            continue
+        variants = payload.get("variants")
+        variant_count = len(variants) if isinstance(variants, list) else None
+        total_environments = scale_gates.non_negative_int(payload.get("total_environments"))
+        if total_environments is None:
+            total_environments = scale_gates.non_negative_int(payload.get("totalEnvironments"))
+        if total_environments is None:
+            total_environments = variant_count or 0
+        successful = scale_gates.non_negative_int(payload.get("successful")) or 0
+        failed = scale_gates.non_negative_int(payload.get("failed")) or 0
+        ticks_run = scale_gates.non_negative_int(payload.get("total_ticks"))
+        if ticks_run is None:
+            ticks_run = scale_gates.non_negative_int(payload.get("totalTicks")) or 0
+        wall_clock_seconds = numeric_value(payload.get("wallClockSeconds")) or 0.0
+        summary = {
+            "runId": text_value(payload.get("runId")) or path.parent.name,
+            "summaryPath": str(path),
+            "ok": payload.get("ok") is True,
+            "totalEnvironments": total_environments,
+            "successful": successful,
+            "failed": failed,
+            "ticksRun": ticks_run,
+            "wallClockSeconds": round(wall_clock_seconds, 3),
+        }
+        summaries.append(summary)
+        totals["completedEnvironmentRows"] += total_environments
+        totals["successfulEnvironmentRows"] += successful
+        totals["failedEnvironmentRows"] += failed
+        totals["ticksRun"] += ticks_run
+        totals["wallClockSeconds"] += wall_clock_seconds
+    if not summaries:
+        return None
+    return {
+        "runSummaryCount": len(summaries),
+        "completedEnvironmentRows": totals["completedEnvironmentRows"],
+        "successfulEnvironmentRows": totals["successfulEnvironmentRows"],
+        "failedEnvironmentRows": totals["failedEnvironmentRows"],
+        "ticksRun": totals["ticksRun"],
+        "wallClockSeconds": round(totals["wallClockSeconds"], 3),
+        "runSummaries": summaries[:10],
+    }
 
 
 def classify_remote_training_failure(
@@ -2964,20 +3074,27 @@ def paid_failure_post_fix_validation_recovery_eligibility(
     if not requested:
         result["reason"] = "explicit post-fix validation signature was not requested"
         return result
-    if len(prior_attempts) != 1:
-        result["reason"] = "recovery requires exactly one prior consumed post-fix validation attempt"
-        return result
     prior_attempt = prior_attempts[0]
     if any(text_value(attempt.get("outcome")) == "completed" for attempt in prior_attempts):
         result["reason"] = "a post-fix validation already completed"
         return result
-    if any(attempt.get("recoveryAttempt") is True for attempt in prior_attempts):
-        result["reason"] = "post-fix validation recovery was already attempted"
-        return result
-    if any(paid_failure_post_fix_attempt_reached_compute_or_training(attempt) for attempt in prior_attempts):
-        result["reason"] = "a prior post-fix validation reached compute, scale, remote training, environments, or a report"
-        return result
-    if not paid_failure_post_fix_attempt_is_pre_scale_no_compute_admission_failure(prior_attempt):
+    recovery_class = paid_failure_post_fix_validation_recovery_class_for_attempts(prior_attempts)
+    if recovery_class is None:
+        if len(prior_attempts) not in (1, 2):
+            result["reason"] = (
+                "recovery requires one prior consumed post-fix validation attempt, or one timed-out "
+                "recovery attempt after a no-compute admission failure"
+            )
+            return result
+        if any(attempt.get("recoveryAttempt") is True for attempt in prior_attempts):
+            result["reason"] = "post-fix validation recovery was already attempted"
+            return result
+        if paid_failure_post_fix_attempt_reached_compute_or_training(prior_attempt):
+            result["reason"] = (
+                "a prior post-fix validation reached compute, scale, remote training, environments, "
+                "or a report without a recoverable timeout classification"
+            )
+            return result
         result["reason"] = "prior post-fix validation was not a pre-scale no-compute admission failure"
         return result
     if not isinstance(trust_sample_request, dict):
@@ -2987,11 +3104,73 @@ def paid_failure_post_fix_validation_recovery_eligibility(
         result["reason"] = "policy-gradient requested samples are below the trust gate target"
         return result
     result["eligible"] = True
-    result["reason"] = (
-        "one recovery validation is allowed after a consumed pre-scale no-compute admission failure"
-    )
+    result["recoveryClass"] = recovery_class
+    if recovery_class in {"remote_training_timeout", "remote_training_timeout_after_recovery"}:
+        result["reason"] = (
+            "one recovery validation is allowed after a consumed remote-training timeout "
+            "without a completed report"
+        )
+        if recovery_class == "remote_training_timeout_after_recovery":
+            recovery_attempt = next(
+                (attempt for attempt in prior_attempts if attempt.get("recoveryAttempt") is True),
+                prior_attempt,
+            )
+            result["priorRecoveryAttemptRunId"] = text_value(recovery_attempt.get("runId"))
+            result["priorAttemptRunId"] = text_value(recovery_attempt.get("runId"))
+            return result
+    else:
+        result["reason"] = (
+            "one recovery validation is allowed after a consumed pre-scale no-compute admission failure"
+        )
     result["priorAttemptRunId"] = text_value(prior_attempt.get("runId"))
     return result
+
+
+def paid_failure_post_fix_validation_recovery_class_for_attempts(
+    prior_attempts: list[dict[str, Any]],
+) -> str | None:
+    if len(prior_attempts) == 1:
+        attempt = prior_attempts[0]
+        if attempt.get("recoveryAttempt") is True:
+            return None
+        return paid_failure_post_fix_validation_recovery_class(attempt)
+    if len(prior_attempts) != 2:
+        return None
+    recovery_attempts = [attempt for attempt in prior_attempts if attempt.get("recoveryAttempt") is True]
+    admission_attempts = [attempt for attempt in prior_attempts if attempt.get("recoveryAttempt") is not True]
+    if len(recovery_attempts) != 1 or len(admission_attempts) != 1:
+        return None
+    if not paid_failure_post_fix_attempt_is_pre_scale_no_compute_admission_failure(admission_attempts[0]):
+        return None
+    if not paid_failure_post_fix_attempt_is_remote_training_timeout_without_report(recovery_attempts[0]):
+        return None
+    return "remote_training_timeout_after_recovery"
+
+
+def paid_failure_post_fix_validation_recovery_class(attempt: dict[str, Any]) -> str | None:
+    if paid_failure_post_fix_attempt_is_pre_scale_no_compute_admission_failure(attempt):
+        return "pre_scale_no_compute_admission_failure"
+    if paid_failure_post_fix_attempt_is_remote_training_timeout_without_report(attempt):
+        return "remote_training_timeout"
+    return None
+
+
+def paid_failure_post_fix_attempt_is_remote_training_timeout_without_report(
+    attempt: dict[str, Any],
+) -> bool:
+    return bool(
+        text_value(attempt.get("finalStatus")) == "failed"
+        and text_value(attempt.get("outcome")) == "not_completed"
+        and attempt.get("executionContextPresent") is True
+        and attempt.get("computeAttempted") is True
+        and attempt.get("scaleOutAttempted") is True
+        and attempt.get("remoteTrainingAttempted") is True
+        and attempt.get("trainingReportProduced") is not True
+        and attempt.get("trainingReportPresent") is not True
+        and attempt.get("remoteTrainingFailurePresent") is True
+        and text_value(attempt.get("remoteTrainingFailureClass")) == "remote_training_timeout"
+        and attempt.get("failureSignature") is None
+    )
 
 
 def paid_failure_post_fix_validation_state_with_recurrence_evidence(
@@ -3323,7 +3502,21 @@ def paid_failure_recurrence_next_action(
         )
     if status == "recovery_allowed":
         prior = dict_value(validation.get("priorAttempt")) or {}
-        run_id = text_value(prior.get("runId")) or "the prior post-fix validation"
+        recovery = dict_value(validation.get("recoveryEligibility")) or {}
+        run_id = (
+            text_value(recovery.get("priorRecoveryAttemptRunId"))
+            or text_value(prior.get("runId"))
+            or "the prior post-fix validation"
+        )
+        if text_value(recovery.get("recoveryClass")) in {
+            "remote_training_timeout",
+            "remote_training_timeout_after_recovery",
+        }:
+            return (
+                f"{base}; one recovery validation is allowed because {run_id} timed out in remote "
+                "training without a completed report; rerun only with an explicitly sized timeout "
+                "or a smaller validation slice, and keep the guard active if room-busy recurs"
+            )
         return (
             f"{base}; one recovery validation is allowed because {run_id} failed before scale, "
             "compute, remote training, environments, or a training report; if simulator_place_spawn_room_busy "
@@ -5654,6 +5847,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--allow-paid-failure-recurrence-validation",
+        "--postfix-validation-signature",
+        dest="allow_paid_failure_recurrence_validation",
         action="append",
         choices=tuple(PAID_FAILURE_RECURRENCE_KNOWN_FIXES),
         default=None,

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -6221,6 +6221,79 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(progress["ticksRun"], 19600)
         self.assertEqual(progress["wallClockSeconds"], 1330.75)
 
+    def test_remote_training_partial_progress_counts_terminal_rows_not_planned_total(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_dir = root / "remote" / "simulator-artifacts" / "run-test"
+            run_dir.mkdir(parents=True)
+            (run_dir / "run_summary.json").write_text(
+                json.dumps({
+                    "runId": "run-test",
+                    "ok": False,
+                    "successful": 2,
+                    "failed": 1,
+                    "total_environments": 5,
+                    "total_ticks": 1234,
+                    "wallClockSeconds": 12.3456,
+                    "variants": [{}, {}, {}, {}, {}],
+                }),
+                encoding="utf-8",
+            )
+
+            progress = runner.remote_training_partial_simulator_progress(root, "run-test")
+
+        self.assertIsNotNone(progress)
+        assert progress is not None
+        self.assertEqual(progress["completedEnvironmentRows"], 3)
+        self.assertEqual(progress["successfulEnvironmentRows"], 2)
+        self.assertEqual(progress["failedEnvironmentRows"], 1)
+        self.assertEqual(progress["runSummaries"][0]["totalEnvironments"], 5)
+        self.assertEqual(progress["runSummaries"][0]["wallClockSeconds"], 12.346)
+
+        execution = runner.controller_execution_summary(
+            controller_args(),
+            steps=[],
+            result={"remoteTrainingFailure": {"partialSimulatorProgress": progress}},
+            scaled_up=False,
+            instance_id=None,
+        )
+        self.assertEqual(execution["environmentsRun"], 3)
+
+    def test_remote_training_partial_progress_normalizes_non_finite_wall_clock_seconds(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            simulator_root = root / "remote" / "simulator-artifacts"
+            for run_id, seconds in (("run-test-r01", float("nan")), ("run-test-r02", float("inf"))):
+                run_dir = simulator_root / run_id
+                run_dir.mkdir(parents=True)
+                (run_dir / "run_summary.json").write_text(
+                    json.dumps({
+                        "runId": run_id,
+                        "ok": True,
+                        "successful": 1,
+                        "failed": 0,
+                        "total_environments": 1,
+                        "total_ticks": 100,
+                        "wallClockSeconds": seconds,
+                    }),
+                    encoding="utf-8",
+                )
+
+            progress = runner.remote_training_partial_simulator_progress(root, "run-test")
+
+        self.assertIsNotNone(progress)
+        assert progress is not None
+        self.assertEqual(progress["wallClockSeconds"], 0.0)
+        self.assertEqual([summary["wallClockSeconds"] for summary in progress["runSummaries"]], [0.0, 0.0])
+        self.assertEqual(progress["completedEnvironmentRows"], 2)
+        encoded = runner.canonical_json({"partialSimulatorProgress": progress})
+        self.assertNotIn("NaN", encoded)
+        self.assertNotIn("Infinity", encoded)
+
+    def test_canonical_json_rejects_non_finite_numbers(self) -> None:
+        with self.assertRaises(ValueError):
+            runner.canonical_json({"wallClockSeconds": float("nan")})
+
     def test_controller_execution_summary_uses_partial_timeout_progress_when_no_report(self) -> None:
         args = controller_args()
         result = {

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -876,6 +876,8 @@ def write_post_fix_validation_remote_timeout_summary(artifact_root: Path, run_id
         failure_class="remote_training_timeout",
     )
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary["startedAt"] = "2026-05-30T00:00:03Z"
+    summary["finishedAt"] = "2026-05-30T00:02:03Z"
     timeout_tail = "validation heartbeat: environmentsStarted=5 environmentsCompleted=0"
     remote_failure = summary["outputs"]["remoteTrainingFailure"]
     remote_failure["returncode"] = runner.PROCESS_TIMEOUT_RETURN_CODE
@@ -4276,14 +4278,17 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             artifact_root = Path(temp_dir) / "batch-runs"
             for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
                 write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
-            write_post_fix_validation_pre_scale_admission_failure_summary(
+            pre_scale_attempt_path = write_post_fix_validation_pre_scale_admission_failure_summary(
                 artifact_root,
                 "tencent-postfix-room-busy-v1",
             )
-            write_post_fix_validation_recovery_remote_timeout_summary(
+            timeout_attempt_path = write_post_fix_validation_recovery_remote_timeout_summary(
                 artifact_root,
                 "postfix-room-busy-validation-timeout",
             )
+            pre_scale_attempt = json.loads(pre_scale_attempt_path.read_text(encoding="utf-8"))
+            timeout_attempt = json.loads(timeout_attempt_path.read_text(encoding="utf-8"))
+            self.assertGreater(timeout_attempt["finishedAt"], pre_scale_attempt["finishedAt"])
             args = runner.parse_cli_args([
                 "run-single",
                 "--run-id",

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -868,6 +868,40 @@ def write_post_fix_validation_in_progress_summary(artifact_root: Path, run_id: s
     return summary_path
 
 
+def write_post_fix_validation_remote_timeout_summary(artifact_root: Path, run_id: str) -> Path:
+    summary_path = write_post_fix_validation_summary(
+        artifact_root,
+        run_id,
+        final_status="failed",
+        failure_class="remote_training_timeout",
+    )
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    timeout_tail = "validation heartbeat: environmentsStarted=5 environmentsCompleted=0"
+    remote_failure = summary["outputs"]["remoteTrainingFailure"]
+    remote_failure["returncode"] = runner.PROCESS_TIMEOUT_RETURN_CODE
+    remote_failure["controllerTimedOut"] = True
+    remote_failure["diagnostics"]["training-stderr.log"]["tail"] = timeout_tail
+    remote_failure["diagnostics"]["training-stderr.log"]["bytes"] = len(timeout_tail)
+    summary["outputs"]["error"] = (
+        "BatchRunError: remote_training failed with exit 124: "
+        "training-stderr.log: validation heartbeat"
+    )
+    summary["steps"][0]["returncode"] = runner.PROCESS_TIMEOUT_RETURN_CODE
+    summary["steps"][0]["stderr_tail"] = timeout_tail
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+    return summary_path
+
+
+def write_post_fix_validation_recovery_remote_timeout_summary(artifact_root: Path, run_id: str) -> Path:
+    summary_path = write_post_fix_validation_remote_timeout_summary(artifact_root, run_id)
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    launch_guard = summary["outputs"]["launchGuard"]
+    launch_guard["status"] = runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS
+    launch_guard["postFixValidation"]["status"] = "recovery_allowed"
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+    return summary_path
+
+
 def write_invalid_run_id_validation_admission_failure_summary(artifact_root: Path, run_id: str) -> Path:
     summary_path = write_post_fix_validation_pre_scale_admission_failure_summary(
         artifact_root,
@@ -4176,6 +4210,128 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(summary["outputs"]["launchGuard"]["postFixValidation"]["status"], "recovery_allowed")
         self.assertTrue(summary["execution"]["computeAttempted"])
 
+    def test_paid_failure_recurrence_guard_allows_explicit_recovery_after_remote_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            write_post_fix_validation_remote_timeout_summary(
+                artifact_root,
+                "postfix-room-busy-validation-timeout",
+            )
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                "500",
+                "--workers",
+                "5",
+                "--scale-environments",
+                "5",
+                "--repetitions",
+                "5",
+                "--postfix-validation-signature",
+                runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertIn("scale_up", events)
+        self.assertIn("remote_training", events)
+        self.assertFalse(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS)
+        recovery = guard["postFixValidation"]["recoveryEligibility"]
+        self.assertTrue(recovery["eligible"])
+        self.assertEqual(recovery["recoveryClass"], "remote_training_timeout")
+        self.assertEqual(
+            guard["postFixValidation"]["priorAttempt"]["remoteTrainingFailureClass"],
+            "remote_training_timeout",
+        )
+        self.assertIn("explicitly sized timeout", guard["nextAction"])
+        self.assertEqual(controller.final_status, "completed")
+        self.assertEqual(summary["outputs"]["launchGuard"]["postFixValidation"]["status"], "recovery_allowed")
+
+    def test_paid_failure_recurrence_guard_allows_timeout_fix_after_timed_out_recovery(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            write_post_fix_validation_pre_scale_admission_failure_summary(
+                artifact_root,
+                "tencent-postfix-room-busy-v1",
+            )
+            write_post_fix_validation_recovery_remote_timeout_summary(
+                artifact_root,
+                "postfix-room-busy-validation-timeout",
+            )
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                "500",
+                "--workers",
+                "5",
+                "--scale-environments",
+                "5",
+                "--repetitions",
+                "5",
+                "--postfix-validation-signature",
+                runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertIn("scale_up", events)
+        self.assertFalse(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS)
+        recovery = guard["postFixValidation"]["recoveryEligibility"]
+        self.assertTrue(recovery["eligible"])
+        self.assertEqual(recovery["recoveryClass"], "remote_training_timeout_after_recovery")
+        self.assertEqual(recovery["priorRecoveryAttemptRunId"], "postfix-room-busy-validation-timeout")
+        self.assertIn("explicitly sized timeout", guard["nextAction"])
+        self.assertEqual(controller.final_status, "completed")
+        self.assertEqual(summary["outputs"]["launchGuard"]["postFixValidation"]["status"], "recovery_allowed")
+
     def test_paid_failure_recurrence_guard_ignores_preflight_only_recovery_admission(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             artifact_root = Path(temp_dir) / "batch-runs"
@@ -6017,6 +6173,76 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertNotIn("tail-secret", stderr["tail"])
         self.assertNotIn("old failure marker", stderr["tail"])
 
+    def test_remote_training_failure_diagnostics_summarizes_repetition_progress(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            remote = root / "remote"
+            remote.mkdir()
+            for filename in runner.REMOTE_TRAINING_DIAGNOSTIC_FILES:
+                (remote / filename).write_text("", encoding="utf-8")
+            simulator_root = remote / "simulator-artifacts"
+            for run_id, successful, failed, ticks, seconds in (
+                ("run-test-r01", 5, 0, 10000, 640.25),
+                ("run-test-r02", 4, 1, 9600, 690.5),
+            ):
+                run_dir = simulator_root / run_id
+                run_dir.mkdir(parents=True)
+                (run_dir / "run_summary.json").write_text(
+                    json.dumps({
+                        "runId": run_id,
+                        "ok": failed == 0,
+                        "successful": successful,
+                        "failed": failed,
+                        "total_environments": successful + failed,
+                        "total_ticks": ticks,
+                        "wallClockSeconds": seconds,
+                        "variants": [{} for _ in range(successful + failed)],
+                    }),
+                    encoding="utf-8",
+                )
+
+            diagnostics = runner.remote_training_failure_diagnostics(
+                root,
+                runner.PROCESS_TIMEOUT_RETURN_CODE,
+                run_id="run-test",
+                controller_timed_out=True,
+            )
+
+        self.assertEqual(diagnostics["failureClass"], "remote_training_timeout")
+        self.assertIn(
+            "simulator-artifacts/run-test-r01/run_summary.json",
+            diagnostics["diagnostics"],
+        )
+        progress = diagnostics["partialSimulatorProgress"]
+        self.assertEqual(progress["runSummaryCount"], 2)
+        self.assertEqual(progress["completedEnvironmentRows"], 10)
+        self.assertEqual(progress["successfulEnvironmentRows"], 9)
+        self.assertEqual(progress["failedEnvironmentRows"], 1)
+        self.assertEqual(progress["ticksRun"], 19600)
+        self.assertEqual(progress["wallClockSeconds"], 1330.75)
+
+    def test_controller_execution_summary_uses_partial_timeout_progress_when_no_report(self) -> None:
+        args = controller_args()
+        result = {
+            "remoteTrainingFailure": {
+                "failureClass": "remote_training_timeout",
+                "partialSimulatorProgress": {
+                    "completedEnvironmentRows": 10,
+                },
+            }
+        }
+
+        execution = runner.controller_execution_summary(
+            args,
+            steps=[],
+            result=result,
+            scaled_up=False,
+            instance_id=None,
+        )
+
+        self.assertEqual(execution["environmentsRun"], 10)
+        self.assertFalse(execution["trainingReportProduced"])
+
     def test_collect_remote_artifacts_tolerates_missing_partial_diagnostics(self) -> None:
         args = controller_args()
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -6050,7 +6276,10 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             "for simulator_file in run_summary.json resource_guard_failure.json setup_failure.json run_failure.json owned_room_scorecard.json",
             scripts[0],
         )
-        self.assertIn('for simulator_run_id in "$RUN_ID" "$RUN_ID-pre-scale-smoke"', scripts[0])
+        self.assertIn(
+            'for simulator_dir in "simulator-artifacts/$RUN_ID" "simulator-artifacts/$RUN_ID-pre-scale-smoke" "simulator-artifacts/$RUN_ID"-r*',
+            scripts[0],
+        )
 
     def test_generate_experiment_card_passes_multi_tier_scenario_request(self) -> None:
         args = controller_args()


### PR DESCRIPTION
## Summary
- Allows the guarded timeout-recovery validation path to proceed when the prior consumed attempt was only a preflight/no-compute guard result.
- Keeps duplicate paid-compute protections intact while distinguishing non-consuming preflight evidence from real paid validation attempts.
- Adds focused runner tests for the recovery-admission behavior.

Related to issue 1501.

## Verification
- `git diff --check origin/main...HEAD`
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts.test_screeps_tencent_batch_rl_runner -q` (165 tests)

## Universal task Done gate
- [x] Task type: code/test.
- [x] Expected observable outcome / named deliverable: timeout-recovery validation admission treats preflight-only no-compute evidence as non-consuming while preserving real paid-attempt accounting.
- [x] Non-goals / accepted substitutes: scope excludes paid Tencent launch, official MMO runtime changes, and validation-issue closure before later compute evidence.
- [x] Verification evidence required before Done: focused runner unittest, py_compile, and diff whitespace check listed above.
- [x] Project Evidence / Next action / Blocked by: scheduler updated Project fields with head SHA, check/review gate, and validation next action.
- [x] Post-merge/deploy/runtime proof: scripts-only runner change; official MMO deploy is N/A. Acceptance surface is the next guarded validation evidence on the merged code.
- [x] Named deliverable proof: code/test diff in `scripts/screeps_tencent_batch_rl_runner.py` and `scripts/test_screeps_tencent_batch_rl_runner.py` implements and exercises the admission rule.
