### PR TITLE
fix: classify E29N57 rampart decay alerts

### DIFF
--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -2071,7 +2071,8 @@ def is_expected_safe_rampart_decay_reason(
     delta = number_from_reason(reason, "delta")
     if current_hits is None or delta is None:
         return False
-    if delta >= RAMPART_CRITICAL_DAMAGE_DELTA:
+    # Long monitor gaps can accumulate normal decay above the raw damage delta threshold.
+    if delta >= RAMPART_CRITICAL_DAMAGE_DELTA and current_hits <= RAMPART_CRITICAL_DAMAGE_HITS_CEILING:
         return False
 
     return (

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -1642,6 +1642,79 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertFalse(report["emergency"])
         self.assertTrue(report["silent"])
 
+    def test_high_health_rampart_decay_after_monitor_gap_is_suppressed(self) -> None:
+        previous_tick = 1_613_249
+        current_tick = 1_615_205
+        current_hits = 2_414_601
+        delta = 5_700
+        previous = {
+            "baseline_established": True,
+            "tick": previous_tick,
+            "structures": {
+                "spawn1": {
+                    "type": "spawn",
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                    "owned": True,
+                    "damageable": True,
+                    "critical": True,
+                },
+                "rampart1": {
+                    "type": "rampart",
+                    "x": 35,
+                    "y": 27,
+                    "hits": current_hits + delta,
+                    "hitsMax": 10_000_000,
+                    "owned": True,
+                    "damageable": True,
+                    "critical": False,
+                },
+            },
+        }
+        snapshot = make_snapshot(
+            {
+                "spawn1": {
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                },
+                "rampart1": {
+                    "type": "rampart",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 35,
+                    "y": 27,
+                    "hits": current_hits,
+                    "hitsMax": 10_000_000,
+                },
+            },
+            tick=current_tick,
+        )
+
+        expected_decay = monitor.expected_rampart_decay_delta(previous, current_tick)
+        self.assertGreater(delta, monitor.RAMPART_CRITICAL_DAMAGE_DELTA)
+        self.assertGreater(current_hits, monitor.RAMPART_CRITICAL_DAMAGE_HITS_CEILING)
+        self.assertLessEqual(delta, expected_decay)
+
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            snapshot,
+            previous,
+            now=100,
+            debounce_seconds=300,
+        )
+
+        self.assertEqual(emitted, [])
+        self.assertEqual(len(suppressed), 1)
+        self.assertEqual(suppressed[0]["delta"], delta)
+        self.assertEqual(suppressed[0]["expected_decay_delta"], expected_decay)
+        self.assertEqual(suppressed[0]["suppression_reason"], "expected_rampart_decay")
+
     def test_unknown_or_non_advancing_rampart_decay_ticks_do_not_suppress_damage(self) -> None:
         decay = monitor.RAMPART_DECAY_HITS_PER_EVENT
         safe_floor = monitor.RAMPART_SAFE_DECAY_HITS_FLOOR


### PR DESCRIPTION
## Summary
- Refines runtime-monitor rampart alert suppression so high-health rampart hit decreases accumulated over a long monitor gap can be classified as expected decay instead of actionable damage.
- Adds a focused regression test for the E29N57-style monitor gap case where the decay delta exceeds the raw critical-damage delta but remains within expected rampart decay.

Related to issue 1550.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py`
- `python3 -m pytest scripts/test_screeps_runtime_monitor_tactical_response.py -q` (80 passed, 19 subtests passed)

## Universal task Done gate
- [x] Task type: code/test.
- [x] Expected observable outcome / named deliverable: E29N57 high-health rampart decay after a long monitor gap is classified as expected decay rather than an emergency damage alert when the loss is within expected decay.
- [x] Non-goals / accepted substitutes: scope excludes production bot repair-planning changes and does not close runtime monitoring until a later fresh alert/summary proves the incident is quiet.
- [x] Verification evidence required before Done: focused runtime-monitor tactical pytest, py_compile, and diff whitespace check listed above.
- [x] Project Evidence / Next action / Blocked by: scheduler will update Project fields with PR head SHA, checks/review gates, and post-merge runtime-alert acceptance requirement.
- [x] Post-merge/deploy/runtime proof: scripts-only monitor classification change; official MMO deploy is N/A. Acceptance is the next runtime-alert/direct-health bundle showing no false-positive rampart emergency for this condition.
- [x] Named deliverable proof: `scripts/screeps-runtime-monitor.py` and `scripts/test_screeps_runtime_monitor_tactical_response.py` implement and exercise the decay classification rule.
