### PR TITLE
fix: allow safe construction energy use

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -27994,11 +27994,16 @@ function selectReadyFollowUpProductiveEnergySinkTask(creep, capacityConstruction
   return criticalRoadConstructionSite ? { type: "build", targetId: criticalRoadConstructionSite.id } : null;
 }
 function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(creep, spawnOrExtensionEnergySink, constructionSites, constructionReservationContext) {
-  if (!shouldDeferIdleSpawnExtensionRefillForProductiveWork(
+  const deferForHealthyBuffer = shouldDeferIdleSpawnExtensionRefillForHealthyBuffer(
+    creep,
+    spawnOrExtensionEnergySink
+  );
+  const deferForBoundedConstruction = !deferForHealthyBuffer && shouldDeferIdleSpawnExtensionRefillForBoundedConstruction(
     creep,
     spawnOrExtensionEnergySink,
     constructionSites
-  )) {
+  );
+  if (!deferForHealthyBuffer && !deferForBoundedConstruction) {
     return null;
   }
   const constructionPriorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
@@ -28012,11 +28017,17 @@ function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(creep, spawnOr
   if (constructionSite) {
     return { type: "build", targetId: constructionSite.id };
   }
+  if (!deferForHealthyBuffer) {
+    return null;
+  }
   const repairTarget = selectRepairTarget(creep);
   return repairTarget ? { type: "repair", targetId: repairTarget.id } : null;
 }
-function shouldDeferIdleSpawnExtensionRefillForProductiveWork(creep, spawnOrExtensionEnergySink, constructionSites) {
-  return spawnOrExtensionEnergySink !== null && !hasActiveSpawningSpawn(creep.room) && (hasHealthyRoomEnergyBuffer(creep.room) || constructionSites.length > 0 && hasSafeStoredEnergyForBoundedConstruction(creep));
+function shouldDeferIdleSpawnExtensionRefillForHealthyBuffer(creep, spawnOrExtensionEnergySink) {
+  return spawnOrExtensionEnergySink !== null && !hasActiveSpawningSpawn(creep.room) && hasHealthyRoomEnergyBuffer(creep.room);
+}
+function shouldDeferIdleSpawnExtensionRefillForBoundedConstruction(creep, spawnOrExtensionEnergySink, constructionSites) {
+  return spawnOrExtensionEnergySink !== null && !hasActiveSpawningSpawn(creep.room) && constructionSites.length > 0 && hasSafeStoredEnergyForBoundedConstruction(creep);
 }
 function hasSafeStoredEnergyForBoundedConstruction(creep) {
   const energyAvailable = getRoomEnergyAvailable10(creep.room);
@@ -31844,7 +31855,9 @@ function hasSafeStoredEnergyForBoundedConstruction2(creep, selectedTask) {
   if (energyAvailable === null || energyAvailable < getConstructionSpendingEnergyThreshold(creep.room)) {
     return false;
   }
-  const sameRoomWorkers = getRoomOwnedCreeps2(creep.room).filter((worker) => isSameRoomWorker2(worker, creep.room));
+  const sameRoomWorkers = getRoomOwnedCreeps2(creep.room).filter(
+    (worker) => isProductiveSameRoomWorker(worker, creep.room)
+  );
   if (sameRoomWorkers.length < SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS2) {
     return false;
   }
@@ -31856,7 +31869,7 @@ function hasSafeStoredEnergyForBoundedConstruction2(creep, selectedTask) {
 function hasOtherSameRoomBuildAssignment(creep) {
   return getRoomOwnedCreeps2(creep.room).some((worker) => {
     var _a, _b;
-    if (isSameCreep2(worker, creep) || !isSameRoomWorker2(worker, creep.room)) {
+    if (isSameCreep2(worker, creep) || !isProductiveSameRoomWorker(worker, creep.room)) {
       return false;
     }
     return ((_b = (_a = worker.memory) == null ? void 0 : _a.task) == null ? void 0 : _b.type) === "build";
@@ -32527,7 +32540,7 @@ function isCurrentTransferTargetCoveredByOtherLoadedWorkers(creep, task, target)
   }
   let reservedEnergy = 0;
   for (const worker of creep.room.find(FIND_MY_CREEPS)) {
-    if (isSameCreep2(worker, creep) || !isSameRoomWorkerWithEnergy2(worker, creep.room)) {
+    if (isSameCreep2(worker, creep) || !isProductiveSameRoomWorkerWithEnergy(worker, creep.room)) {
       continue;
     }
     const workerTask = (_a = worker.memory) == null ? void 0 : _a.task;
@@ -32582,9 +32595,35 @@ function isSameRoomWorkerWithEnergy2(creep, room) {
   var _a;
   return ((_a = creep.memory) == null ? void 0 : _a.role) === "worker" && isInRoom2(creep, room) && getUsedTransferEnergy(creep) > 0;
 }
+function isProductiveSameRoomWorkerWithEnergy(creep, room) {
+  return isSameRoomWorkerWithEnergy2(creep, room) && !willBypassNormalWorkerTaskSelectionThisTick(creep);
+}
+function isProductiveSameRoomWorker(creep, room) {
+  return isSameRoomWorker2(creep, room) && !willBypassNormalWorkerTaskSelectionThisTick(creep);
+}
 function isSameRoomWorker2(creep, room) {
   var _a;
   return ((_a = creep.memory) == null ? void 0 : _a.role) === "worker" && isInRoom2(creep, room);
+}
+function willBypassNormalWorkerTaskSelectionThisTick(creep) {
+  return willRunControllerSustainMovementBeforeNormalTaskSelection(creep) || willRunSpawnSupportMovementBeforeNormalTaskSelection(creep);
+}
+function willRunControllerSustainMovementBeforeNormalTaskSelection(creep) {
+  var _a, _b;
+  const sustain = (_a = creep.memory) == null ? void 0 : _a.controllerSustain;
+  if (!isControllerSustainMemory(sustain)) {
+    return false;
+  }
+  const roomName = (_b = creep.room) == null ? void 0 : _b.name;
+  if (roomName !== sustain.targetRoom) {
+    return true;
+  }
+  return sustain.role === "hauler" && getCarriedEnergy4(creep) <= 0;
+}
+function willRunSpawnSupportMovementBeforeNormalTaskSelection(creep) {
+  var _a, _b;
+  const support = (_a = creep.memory) == null ? void 0 : _a.spawnSupport;
+  return isSpawnSupportMemory(support) && ((_b = creep.room) == null ? void 0 : _b.name) !== support.targetRoom;
 }
 function isInRoom2(creep, room) {
   var _a;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -28034,7 +28034,9 @@ function hasSafeStoredEnergyForBoundedConstruction(creep) {
   if (energyAvailable === null || energyAvailable < getConstructionSpendingEnergyThreshold(creep.room)) {
     return false;
   }
-  const sameRoomWorkers = getRoomOwnedCreeps(creep.room).filter((worker) => isSameRoomWorker(worker, creep.room));
+  const sameRoomWorkers = getRoomOwnedCreeps(creep.room).filter(
+    (worker) => isProductiveSameRoomWorker(worker, creep.room)
+  );
   if (sameRoomWorkers.length < SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS) {
     return false;
   }
@@ -30082,6 +30084,40 @@ function isSameRoomWorker(creep, room) {
   var _a;
   return ((_a = creep.memory) == null ? void 0 : _a.role) === "worker" && isInRoom(creep, room);
 }
+function isProductiveSameRoomWorker(creep, room) {
+  return isSameRoomWorker(creep, room) && !willBypassNormalWorkerTaskSelectionThisTick(creep);
+}
+function willBypassNormalWorkerTaskSelectionThisTick(creep) {
+  return willRunControllerSustainMovementBeforeNormalTaskSelection(creep) || willRunSpawnSupportMovementBeforeNormalTaskSelection(creep);
+}
+function willRunControllerSustainMovementBeforeNormalTaskSelection(creep) {
+  var _a, _b;
+  const sustain = (_a = creep.memory) == null ? void 0 : _a.controllerSustain;
+  if (!isControllerSustainMemory(sustain)) {
+    return false;
+  }
+  const roomName = (_b = creep.room) == null ? void 0 : _b.name;
+  if (roomName !== sustain.targetRoom) {
+    return true;
+  }
+  return sustain.role === "hauler" && getUsedEnergy2(creep) <= 0;
+}
+function willRunSpawnSupportMovementBeforeNormalTaskSelection(creep) {
+  var _a, _b;
+  const support = (_a = creep.memory) == null ? void 0 : _a.spawnSupport;
+  return isSpawnSupportMemory(support) && ((_b = creep.room) == null ? void 0 : _b.name) !== support.targetRoom;
+}
+function isControllerSustainMemory(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const memory = value;
+  return typeof memory.homeRoom === "string" && memory.homeRoom.length > 0 && typeof memory.targetRoom === "string" && memory.targetRoom.length > 0 && (memory.role === "upgrader" || memory.role === "hauler");
+}
+function isSpawnSupportMemory(value) {
+  const support = value;
+  return typeof value === "object" && value !== null && typeof support.originRoom === "string" && typeof support.targetRoom === "string" && support.originRoom.length > 0 && support.targetRoom.length > 0;
+}
 function isSource2ControllerLaneTask(creep, topology) {
   var _a;
   const task = (_a = creep.memory) == null ? void 0 : _a.task;
@@ -31856,7 +31892,7 @@ function hasSafeStoredEnergyForBoundedConstruction2(creep, selectedTask) {
     return false;
   }
   const sameRoomWorkers = getRoomOwnedCreeps2(creep.room).filter(
-    (worker) => isProductiveSameRoomWorker(worker, creep.room)
+    (worker) => isProductiveSameRoomWorker2(worker, creep.room)
   );
   if (sameRoomWorkers.length < SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS2) {
     return false;
@@ -31869,7 +31905,7 @@ function hasSafeStoredEnergyForBoundedConstruction2(creep, selectedTask) {
 function hasOtherSameRoomBuildAssignment(creep) {
   return getRoomOwnedCreeps2(creep.room).some((worker) => {
     var _a, _b;
-    if (isSameCreep2(worker, creep) || !isProductiveSameRoomWorker(worker, creep.room)) {
+    if (isSameCreep2(worker, creep) || !isProductiveSameRoomWorker2(worker, creep.room)) {
       return false;
     }
     return ((_b = (_a = worker.memory) == null ? void 0 : _a.task) == null ? void 0 : _b.type) === "build";
@@ -31962,7 +31998,7 @@ function getWorkerTaskSelectionNullLoopState(creep, gameTime) {
 function runControllerSustainMovement(creep) {
   var _a;
   const sustain = creep.memory.controllerSustain;
-  if (!isControllerSustainMemory(sustain)) {
+  if (!isControllerSustainMemory2(sustain)) {
     return false;
   }
   const roomName = (_a = creep.room) == null ? void 0 : _a.name;
@@ -32002,7 +32038,7 @@ function selectControllerSustainDestinationRoom(creep, sustain, roomName) {
 function runSpawnSupportMovement(creep) {
   var _a;
   const support = creep.memory.spawnSupport;
-  if (!isSpawnSupportMemory(support)) {
+  if (!isSpawnSupportMemory2(support)) {
     return false;
   }
   if (((_a = creep.room) == null ? void 0 : _a.name) === support.targetRoom) {
@@ -32012,7 +32048,7 @@ function runSpawnSupportMovement(creep) {
   moveTowardRoom3(creep, support.targetRoom);
   return true;
 }
-function isSpawnSupportMemory(value) {
+function isSpawnSupportMemory2(value) {
   const support = value;
   return typeof value === "object" && value !== null && typeof support.originRoom === "string" && typeof support.targetRoom === "string" && support.originRoom.length > 0 && support.targetRoom.length > 0;
 }
@@ -32161,7 +32197,7 @@ function findVisibleAssignedDurableEnergyDropoff(creep, task) {
     (structure) => isDurableEnergyDropoff(structure) && String(structure.id) === targetId
   )) != null ? _a : null;
 }
-function isControllerSustainMemory(value) {
+function isControllerSustainMemory2(value) {
   if (typeof value !== "object" || value === null) {
     return false;
   }
@@ -32596,22 +32632,22 @@ function isSameRoomWorkerWithEnergy2(creep, room) {
   return ((_a = creep.memory) == null ? void 0 : _a.role) === "worker" && isInRoom2(creep, room) && getUsedTransferEnergy(creep) > 0;
 }
 function isProductiveSameRoomWorkerWithEnergy(creep, room) {
-  return isSameRoomWorkerWithEnergy2(creep, room) && !willBypassNormalWorkerTaskSelectionThisTick(creep);
+  return isSameRoomWorkerWithEnergy2(creep, room) && !willBypassNormalWorkerTaskSelectionThisTick2(creep);
 }
-function isProductiveSameRoomWorker(creep, room) {
-  return isSameRoomWorker2(creep, room) && !willBypassNormalWorkerTaskSelectionThisTick(creep);
+function isProductiveSameRoomWorker2(creep, room) {
+  return isSameRoomWorker2(creep, room) && !willBypassNormalWorkerTaskSelectionThisTick2(creep);
 }
 function isSameRoomWorker2(creep, room) {
   var _a;
   return ((_a = creep.memory) == null ? void 0 : _a.role) === "worker" && isInRoom2(creep, room);
 }
-function willBypassNormalWorkerTaskSelectionThisTick(creep) {
-  return willRunControllerSustainMovementBeforeNormalTaskSelection(creep) || willRunSpawnSupportMovementBeforeNormalTaskSelection(creep);
+function willBypassNormalWorkerTaskSelectionThisTick2(creep) {
+  return willRunControllerSustainMovementBeforeNormalTaskSelection2(creep) || willRunSpawnSupportMovementBeforeNormalTaskSelection2(creep);
 }
-function willRunControllerSustainMovementBeforeNormalTaskSelection(creep) {
+function willRunControllerSustainMovementBeforeNormalTaskSelection2(creep) {
   var _a, _b;
   const sustain = (_a = creep.memory) == null ? void 0 : _a.controllerSustain;
-  if (!isControllerSustainMemory(sustain)) {
+  if (!isControllerSustainMemory2(sustain)) {
     return false;
   }
   const roomName = (_b = creep.room) == null ? void 0 : _b.name;
@@ -32620,10 +32656,10 @@ function willRunControllerSustainMovementBeforeNormalTaskSelection(creep) {
   }
   return sustain.role === "hauler" && getCarriedEnergy4(creep) <= 0;
 }
-function willRunSpawnSupportMovementBeforeNormalTaskSelection(creep) {
+function willRunSpawnSupportMovementBeforeNormalTaskSelection2(creep) {
   var _a, _b;
   const support = (_a = creep.memory) == null ? void 0 : _a.spawnSupport;
-  return isSpawnSupportMemory(support) && ((_b = creep.room) == null ? void 0 : _b.name) !== support.targetRoom;
+  return isSpawnSupportMemory2(support) && ((_b = creep.room) == null ? void 0 : _b.name) !== support.targetRoom;
 }
 function isInRoom2(creep, room) {
   var _a;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -25302,6 +25302,8 @@ var HARVEST_SOURCE_CONTAINER_RANGE = 0;
 var MAX_HARVEST_PATH_OPS = 2e3;
 var LOW_LOAD_YIELD_SWITCH_MIN_IMPROVEMENT_RATIO = 1.1;
 var LOW_LOAD_YIELD_SWITCH_MIN_ABSOLUTE_GAIN = 0.25;
+var SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS = 2;
+var SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORAGE_SURPLUS = 300;
 var nearTermSpawnExtensionRefillReserveCache = null;
 var interRoomLiveTransferCandidateCache = null;
 var interRoomHaulReservationCache = null;
@@ -27989,7 +27991,11 @@ function selectReadyFollowUpProductiveEnergySinkTask(creep, capacityConstruction
   return criticalRoadConstructionSite ? { type: "build", targetId: criticalRoadConstructionSite.id } : null;
 }
 function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(creep, spawnOrExtensionEnergySink, constructionSites, constructionReservationContext) {
-  if (!shouldDeferIdleSpawnExtensionRefillForProductiveWork(creep, spawnOrExtensionEnergySink)) {
+  if (!shouldDeferIdleSpawnExtensionRefillForProductiveWork(
+    creep,
+    spawnOrExtensionEnergySink,
+    constructionSites
+  )) {
     return null;
   }
   const constructionPriorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
@@ -28006,8 +28012,22 @@ function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(creep, spawnOr
   const repairTarget = selectRepairTarget(creep);
   return repairTarget ? { type: "repair", targetId: repairTarget.id } : null;
 }
-function shouldDeferIdleSpawnExtensionRefillForProductiveWork(creep, spawnOrExtensionEnergySink) {
-  return spawnOrExtensionEnergySink !== null && hasHealthyRoomEnergyBuffer(creep.room) && !hasActiveSpawningSpawn(creep.room);
+function shouldDeferIdleSpawnExtensionRefillForProductiveWork(creep, spawnOrExtensionEnergySink, constructionSites) {
+  return spawnOrExtensionEnergySink !== null && !hasActiveSpawningSpawn(creep.room) && (hasHealthyRoomEnergyBuffer(creep.room) || constructionSites.length > 0 && hasSafeStoredEnergyForBoundedConstruction(creep));
+}
+function hasSafeStoredEnergyForBoundedConstruction(creep) {
+  const energyAvailable = getRoomEnergyAvailable10(creep.room);
+  if (energyAvailable === null || energyAvailable < getConstructionSpendingEnergyThreshold(creep.room)) {
+    return false;
+  }
+  const sameRoomWorkers = getRoomOwnedCreeps(creep.room).filter((worker) => isSameRoomWorker(worker, creep.room));
+  if (sameRoomWorkers.length < SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS) {
+    return false;
+  }
+  if (hasSameRoomWorkerAssignedToTask(creep.room, creep, "build")) {
+    return false;
+  }
+  return getStorageEnergyAvailableForWithdrawal(creep.room) >= SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORAGE_SURPLUS;
 }
 function hasHealthyRoomEnergyBuffer(room) {
   const energyAvailable = getRoomEnergyAvailable10(room);
@@ -31401,6 +31421,8 @@ var ADJACENT_ACTION_MOVE_RANGE = 1;
 var RANGED_WORK_MOVE_RANGE = 3;
 var EXACT_POSITION_MOVE_RANGE = 0;
 var MIN_HAULER_DROPPED_ENERGY = 25;
+var SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS2 = 2;
+var SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORAGE_SURPLUS2 = 300;
 function runWorker(creep) {
   var _a, _b;
   if (runControllerSustainMovement(creep)) {
@@ -31809,7 +31831,33 @@ function selectSpawnEnergyReservationRefillTask(creep, currentTask, selectedTask
   return targetId.length > 0 ? { type: "transfer", targetId } : null;
 }
 function shouldDeferSpawnReservationRefillForProductiveWork(creep, selectedTask) {
-  return ((selectedTask == null ? void 0 : selectedTask.type) === "build" || (selectedTask == null ? void 0 : selectedTask.type) === "repair") && hasHealthyRoomEnergyBuffer2(creep.room) && !hasActiveSpawningSpawn2(creep.room);
+  return ((selectedTask == null ? void 0 : selectedTask.type) === "build" || (selectedTask == null ? void 0 : selectedTask.type) === "repair") && !hasActiveSpawningSpawn2(creep.room) && (hasHealthyRoomEnergyBuffer2(creep.room) || hasSafeStoredEnergyForBoundedConstruction2(creep, selectedTask));
+}
+function hasSafeStoredEnergyForBoundedConstruction2(creep, selectedTask) {
+  if ((selectedTask == null ? void 0 : selectedTask.type) !== "build") {
+    return false;
+  }
+  const energyAvailable = getRoomEnergyAvailable12(creep.room);
+  if (energyAvailable === null || energyAvailable < getConstructionSpendingEnergyThreshold(creep.room)) {
+    return false;
+  }
+  const sameRoomWorkers = getRoomOwnedCreeps2(creep.room).filter((worker) => isSameRoomWorker2(worker, creep.room));
+  if (sameRoomWorkers.length < SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS2) {
+    return false;
+  }
+  if (hasOtherSameRoomBuildAssignment(creep)) {
+    return false;
+  }
+  return getStorageEnergyAvailableForWithdrawal(creep.room) >= SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORAGE_SURPLUS2;
+}
+function hasOtherSameRoomBuildAssignment(creep) {
+  return getRoomOwnedCreeps2(creep.room).some((worker) => {
+    var _a, _b;
+    if (isSameCreep2(worker, creep) || !isSameRoomWorker2(worker, creep.room)) {
+      return false;
+    }
+    return ((_b = (_a = worker.memory) == null ? void 0 : _a.task) == null ? void 0 : _b.type) === "build";
+  });
 }
 function hasHealthyRoomEnergyBuffer2(room) {
   const energyAvailable = getRoomEnergyAvailable12(room);
@@ -32530,6 +32578,10 @@ function getUsedTransferEnergy(creep) {
 function isSameRoomWorkerWithEnergy2(creep, room) {
   var _a;
   return ((_a = creep.memory) == null ? void 0 : _a.role) === "worker" && isInRoom2(creep, room) && getUsedTransferEnergy(creep) > 0;
+}
+function isSameRoomWorker2(creep, room) {
+  var _a;
+  return ((_a = creep.memory) == null ? void 0 : _a.role) === "worker" && isInRoom2(creep, room);
 }
 function isInRoom2(creep, room) {
   var _a;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -774,7 +774,9 @@ function hasSafeStoredEnergyForBoundedConstruction(
     return false;
   }
 
-  const sameRoomWorkers = getRoomOwnedCreeps(creep.room).filter((worker) => isSameRoomWorker(worker, creep.room));
+  const sameRoomWorkers = getRoomOwnedCreeps(creep.room).filter((worker) =>
+    isProductiveSameRoomWorker(worker, creep.room)
+  );
   if (sameRoomWorkers.length < SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS) {
     return false;
   }
@@ -791,7 +793,7 @@ function hasSafeStoredEnergyForBoundedConstruction(
 
 function hasOtherSameRoomBuildAssignment(creep: Creep): boolean {
   return getRoomOwnedCreeps(creep.room).some((worker) => {
-    if (isSameCreep(worker, creep) || !isSameRoomWorker(worker, creep.room)) {
+    if (isSameCreep(worker, creep) || !isProductiveSameRoomWorker(worker, creep.room)) {
       return false;
     }
 
@@ -1836,7 +1838,7 @@ function isCurrentTransferTargetCoveredByOtherLoadedWorkers(
 
   let reservedEnergy = 0;
   for (const worker of creep.room.find(FIND_MY_CREEPS)) {
-    if (isSameCreep(worker, creep) || !isSameRoomWorkerWithEnergy(worker, creep.room)) {
+    if (isSameCreep(worker, creep) || !isProductiveSameRoomWorkerWithEnergy(worker, creep.room)) {
       continue;
     }
 
@@ -1906,8 +1908,42 @@ function isSameRoomWorkerWithEnergy(creep: Creep, room: Room): boolean {
   return creep.memory?.role === 'worker' && isInRoom(creep, room) && getUsedTransferEnergy(creep) > 0;
 }
 
+function isProductiveSameRoomWorkerWithEnergy(creep: Creep, room: Room): boolean {
+  return isSameRoomWorkerWithEnergy(creep, room) && !willBypassNormalWorkerTaskSelectionThisTick(creep);
+}
+
+function isProductiveSameRoomWorker(creep: Creep, room: Room): boolean {
+  return isSameRoomWorker(creep, room) && !willBypassNormalWorkerTaskSelectionThisTick(creep);
+}
+
 function isSameRoomWorker(creep: Creep, room: Room): boolean {
   return creep.memory?.role === 'worker' && isInRoom(creep, room);
+}
+
+function willBypassNormalWorkerTaskSelectionThisTick(creep: Creep): boolean {
+  return (
+    willRunControllerSustainMovementBeforeNormalTaskSelection(creep) ||
+    willRunSpawnSupportMovementBeforeNormalTaskSelection(creep)
+  );
+}
+
+function willRunControllerSustainMovementBeforeNormalTaskSelection(creep: Creep): boolean {
+  const sustain = creep.memory?.controllerSustain;
+  if (!isControllerSustainMemory(sustain)) {
+    return false;
+  }
+
+  const roomName = creep.room?.name;
+  if (roomName !== sustain.targetRoom) {
+    return true;
+  }
+
+  return sustain.role === 'hauler' && getCarriedEnergy(creep) <= 0;
+}
+
+function willRunSpawnSupportMovementBeforeNormalTaskSelection(creep: Creep): boolean {
+  const support = creep.memory?.spawnSupport;
+  return isSpawnSupportMemory(support) && creep.room?.name !== support.targetRoom;
 }
 
 function isInRoom(creep: Creep, room: Room): boolean {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -22,7 +22,8 @@ import { runUpgrader } from './upgraderRunner';
 import { canCreepPressureTerritoryController } from '../territory/territoryPlanner';
 import {
   getConstructionSpendingEnergyThreshold,
-  getEffectiveRoomEnergyBufferThreshold
+  getEffectiveRoomEnergyBufferThreshold,
+  getStorageEnergyAvailableForWithdrawal
 } from '../economy/energyBuffer';
 import { getSpawnEnergyWithdrawalAmount, isSpawnEnergySource } from '../economy/spawnEnergyBuffer';
 import {
@@ -73,6 +74,8 @@ const ADJACENT_ACTION_MOVE_RANGE = 1;
 const RANGED_WORK_MOVE_RANGE = 3;
 const EXACT_POSITION_MOVE_RANGE = 0;
 const MIN_HAULER_DROPPED_ENERGY = 25;
+const SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS = 2;
+const SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORAGE_SURPLUS = 300;
 
 interface WorkerTaskSelectionNullLoopState {
   lastNullSelectionTick: number;
@@ -749,9 +752,51 @@ function shouldDeferSpawnReservationRefillForProductiveWork(
 ): boolean {
   return (
     (selectedTask?.type === 'build' || selectedTask?.type === 'repair') &&
-    hasHealthyRoomEnergyBuffer(creep.room) &&
-    !hasActiveSpawningSpawn(creep.room)
+    !hasActiveSpawningSpawn(creep.room) &&
+    (hasHealthyRoomEnergyBuffer(creep.room) ||
+      hasSafeStoredEnergyForBoundedConstruction(creep, selectedTask))
   );
+}
+
+function hasSafeStoredEnergyForBoundedConstruction(
+  creep: Creep,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  if (selectedTask?.type !== 'build') {
+    return false;
+  }
+
+  const energyAvailable = getRoomEnergyAvailable(creep.room);
+  if (
+    energyAvailable === null ||
+    energyAvailable < getConstructionSpendingEnergyThreshold(creep.room)
+  ) {
+    return false;
+  }
+
+  const sameRoomWorkers = getRoomOwnedCreeps(creep.room).filter((worker) => isSameRoomWorker(worker, creep.room));
+  if (sameRoomWorkers.length < SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS) {
+    return false;
+  }
+
+  if (hasOtherSameRoomBuildAssignment(creep)) {
+    return false;
+  }
+
+  return (
+    getStorageEnergyAvailableForWithdrawal(creep.room) >=
+    SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORAGE_SURPLUS
+  );
+}
+
+function hasOtherSameRoomBuildAssignment(creep: Creep): boolean {
+  return getRoomOwnedCreeps(creep.room).some((worker) => {
+    if (isSameCreep(worker, creep) || !isSameRoomWorker(worker, creep.room)) {
+      return false;
+    }
+
+    return worker.memory?.task?.type === 'build';
+  });
 }
 
 function hasHealthyRoomEnergyBuffer(room: Room): boolean {
@@ -1859,6 +1904,10 @@ function getUsedTransferEnergy(creep: Creep): number {
 
 function isSameRoomWorkerWithEnergy(creep: Creep, room: Room): boolean {
   return creep.memory?.role === 'worker' && isInRoom(creep, room) && getUsedTransferEnergy(creep) > 0;
+}
+
+function isSameRoomWorker(creep: Creep, room: Room): boolean {
+  return creep.memory?.role === 'worker' && isInRoom(creep, room);
 }
 
 function isInRoom(creep: Creep, room: Room): boolean {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -4403,7 +4403,9 @@ function hasSafeStoredEnergyForBoundedConstruction(creep: Creep): boolean {
     return false;
   }
 
-  const sameRoomWorkers = getRoomOwnedCreeps(creep.room).filter((worker) => isSameRoomWorker(worker, creep.room));
+  const sameRoomWorkers = getRoomOwnedCreeps(creep.room).filter((worker) =>
+    isProductiveSameRoomWorker(worker, creep.room)
+  );
   if (sameRoomWorkers.length < SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS) {
     return false;
   }
@@ -7738,6 +7740,63 @@ function hasOtherSource2ControllerLaneWorker(creep: Creep, topology: Source2Cont
 
 function isSameRoomWorker(creep: Creep, room: Room): boolean {
   return creep.memory?.role === 'worker' && isInRoom(creep, room);
+}
+
+function isProductiveSameRoomWorker(creep: Creep, room: Room): boolean {
+  return isSameRoomWorker(creep, room) && !willBypassNormalWorkerTaskSelectionThisTick(creep);
+}
+
+function willBypassNormalWorkerTaskSelectionThisTick(creep: Creep): boolean {
+  return (
+    willRunControllerSustainMovementBeforeNormalTaskSelection(creep) ||
+    willRunSpawnSupportMovementBeforeNormalTaskSelection(creep)
+  );
+}
+
+function willRunControllerSustainMovementBeforeNormalTaskSelection(creep: Creep): boolean {
+  const sustain = creep.memory?.controllerSustain;
+  if (!isControllerSustainMemory(sustain)) {
+    return false;
+  }
+
+  const roomName = creep.room?.name;
+  if (roomName !== sustain.targetRoom) {
+    return true;
+  }
+
+  return sustain.role === 'hauler' && getUsedEnergy(creep) <= 0;
+}
+
+function willRunSpawnSupportMovementBeforeNormalTaskSelection(creep: Creep): boolean {
+  const support = creep.memory?.spawnSupport;
+  return isSpawnSupportMemory(support) && creep.room?.name !== support.targetRoom;
+}
+
+function isControllerSustainMemory(value: unknown): value is CreepControllerSustainMemory {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const memory = value as Partial<CreepControllerSustainMemory>;
+  return (
+    typeof memory.homeRoom === 'string' &&
+    memory.homeRoom.length > 0 &&
+    typeof memory.targetRoom === 'string' &&
+    memory.targetRoom.length > 0 &&
+    (memory.role === 'upgrader' || memory.role === 'hauler')
+  );
+}
+
+function isSpawnSupportMemory(value: unknown): value is CreepSpawnSupportMemory {
+  const support = value as Partial<CreepSpawnSupportMemory>;
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof support.originRoom === 'string' &&
+    typeof support.targetRoom === 'string' &&
+    support.originRoom.length > 0 &&
+    support.targetRoom.length > 0
+  );
 }
 
 function isSource2ControllerLaneTask(creep: Creep, topology: Source2ControllerLaneTopology): boolean {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -4334,13 +4334,19 @@ function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(
   constructionSites: ConstructionSite[],
   constructionReservationContext: ConstructionReservationContext
 ): ProductiveEnergySinkTask | null {
-  if (
-    !shouldDeferIdleSpawnExtensionRefillForProductiveWork(
+  const deferForHealthyBuffer = shouldDeferIdleSpawnExtensionRefillForHealthyBuffer(
+    creep,
+    spawnOrExtensionEnergySink
+  );
+  const deferForBoundedConstruction =
+    !deferForHealthyBuffer &&
+    shouldDeferIdleSpawnExtensionRefillForBoundedConstruction(
       creep,
       spawnOrExtensionEnergySink,
       constructionSites
-    )
-  ) {
+    );
+
+  if (!deferForHealthyBuffer && !deferForBoundedConstruction) {
     return null;
   }
 
@@ -4356,11 +4362,26 @@ function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(
     return { type: 'build', targetId: constructionSite.id };
   }
 
+  if (!deferForHealthyBuffer) {
+    return null;
+  }
+
   const repairTarget = selectRepairTarget(creep);
   return repairTarget ? { type: 'repair', targetId: repairTarget.id as Id<Structure> } : null;
 }
 
-function shouldDeferIdleSpawnExtensionRefillForProductiveWork(
+function shouldDeferIdleSpawnExtensionRefillForHealthyBuffer(
+  creep: Creep,
+  spawnOrExtensionEnergySink: StructureSpawn | StructureExtension | null
+): boolean {
+  return (
+    spawnOrExtensionEnergySink !== null &&
+    !hasActiveSpawningSpawn(creep.room) &&
+    hasHealthyRoomEnergyBuffer(creep.room)
+  );
+}
+
+function shouldDeferIdleSpawnExtensionRefillForBoundedConstruction(
   creep: Creep,
   spawnOrExtensionEnergySink: StructureSpawn | StructureExtension | null,
   constructionSites: ConstructionSite[]
@@ -4368,8 +4389,8 @@ function shouldDeferIdleSpawnExtensionRefillForProductiveWork(
   return (
     spawnOrExtensionEnergySink !== null &&
     !hasActiveSpawningSpawn(creep.room) &&
-    (hasHealthyRoomEnergyBuffer(creep.room) ||
-      (constructionSites.length > 0 && hasSafeStoredEnergyForBoundedConstruction(creep)))
+    constructionSites.length > 0 &&
+    hasSafeStoredEnergyForBoundedConstruction(creep)
   );
 }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -151,6 +151,8 @@ const HARVEST_SOURCE_CONTAINER_RANGE = 0;
 const MAX_HARVEST_PATH_OPS = 2_000;
 const LOW_LOAD_YIELD_SWITCH_MIN_IMPROVEMENT_RATIO = 1.1;
 const LOW_LOAD_YIELD_SWITCH_MIN_ABSOLUTE_GAIN = 0.25;
+const SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS = 2;
+const SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORAGE_SURPLUS = 300;
 
 type RepairableWorkerStructure =
   | StructureRoad
@@ -4332,7 +4334,13 @@ function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(
   constructionSites: ConstructionSite[],
   constructionReservationContext: ConstructionReservationContext
 ): ProductiveEnergySinkTask | null {
-  if (!shouldDeferIdleSpawnExtensionRefillForProductiveWork(creep, spawnOrExtensionEnergySink)) {
+  if (
+    !shouldDeferIdleSpawnExtensionRefillForProductiveWork(
+      creep,
+      spawnOrExtensionEnergySink,
+      constructionSites
+    )
+  ) {
     return null;
   }
 
@@ -4354,12 +4362,38 @@ function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(
 
 function shouldDeferIdleSpawnExtensionRefillForProductiveWork(
   creep: Creep,
-  spawnOrExtensionEnergySink: StructureSpawn | StructureExtension | null
+  spawnOrExtensionEnergySink: StructureSpawn | StructureExtension | null,
+  constructionSites: ConstructionSite[]
 ): boolean {
   return (
     spawnOrExtensionEnergySink !== null &&
-    hasHealthyRoomEnergyBuffer(creep.room) &&
-    !hasActiveSpawningSpawn(creep.room)
+    !hasActiveSpawningSpawn(creep.room) &&
+    (hasHealthyRoomEnergyBuffer(creep.room) ||
+      (constructionSites.length > 0 && hasSafeStoredEnergyForBoundedConstruction(creep)))
+  );
+}
+
+function hasSafeStoredEnergyForBoundedConstruction(creep: Creep): boolean {
+  const energyAvailable = getRoomEnergyAvailable(creep.room);
+  if (
+    energyAvailable === null ||
+    energyAvailable < getConstructionSpendingEnergyThreshold(creep.room)
+  ) {
+    return false;
+  }
+
+  const sameRoomWorkers = getRoomOwnedCreeps(creep.room).filter((worker) => isSameRoomWorker(worker, creep.room));
+  if (sameRoomWorkers.length < SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS) {
+    return false;
+  }
+
+  if (hasSameRoomWorkerAssignedToTask(creep.room, creep, 'build')) {
+    return false;
+  }
+
+  return (
+    getStorageEnergyAvailableForWithdrawal(creep.room) >=
+    SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORAGE_SURPLUS
   );
 }
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -4297,6 +4297,242 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
+  it('keeps bounded construction ahead of spawn reservation refill when storage surplus protects recovery energy', () => {
+    const site = {
+      id: 'site1',
+      structureType: 'container',
+      progress: 0,
+      progressTotal: 5_000
+    } as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(250),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      }
+    } as unknown as StructureSpawn;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(1_673),
+        getFreeCapacity: jest.fn().mockReturnValue(10_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 650,
+      energyCapacityAvailable: 1_800,
+      controller,
+      storage,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn, storage] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [spawn, storage];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const transfer = jest.fn();
+    const creep = {
+      name: 'Builder',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      build,
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const reserveWorker = {
+      name: 'ReserveWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, reserveWorker);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      economy: {
+        spawnEnergyReservation: {
+          updatedAt: 123,
+          rooms: {
+            W1N1: {
+              bodyCost: 800,
+              creepName: 'worker-W1N1-124',
+              reservedAt: 123,
+              reservedEnergy: 800,
+              role: 'worker',
+              roomName: 'W1N1',
+              updatedAt: 123
+            }
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Builder: creep, ReserveWorker: reserveWorker },
+      rooms: { W1N1: room },
+      time: 124,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'site1') {
+          return site;
+        }
+
+        return id === 'spawn1' ? spawn : storage;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'site1' });
+    expect(creep.memory.workerDispatchDiagnostic?.spawnReservationTask).toBeUndefined();
+    expect(build).toHaveBeenCalledWith(site);
+    expect(transfer).not.toHaveBeenCalled();
+  });
+
+  it('keeps spawn reservation refill protected when the room has only one worker', () => {
+    const site = {
+      id: 'site1',
+      structureType: 'container',
+      progress: 0,
+      progressTotal: 5_000
+    } as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(250),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      }
+    } as unknown as StructureSpawn;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(1_673),
+        getFreeCapacity: jest.fn().mockReturnValue(10_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 650,
+      energyCapacityAvailable: 1_800,
+      controller,
+      storage,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn, storage] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [spawn, storage];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn();
+    const transfer = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'OnlyWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      build,
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    roomCreeps.push(creep);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      economy: {
+        spawnEnergyReservation: {
+          updatedAt: 123,
+          rooms: {
+            W1N1: {
+              bodyCost: 800,
+              creepName: 'worker-W1N1-124',
+              reservedAt: 123,
+              reservedEnergy: 800,
+              role: 'worker',
+              roomName: 'W1N1',
+              updatedAt: 123
+            }
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { OnlyWorker: creep },
+      rooms: { W1N1: room },
+      time: 124,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'site1') {
+          return site;
+        }
+
+        return id === 'spawn1' ? spawn : storage;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(transfer).toHaveBeenCalledWith(spawn, 'energy');
+    expect(build).not.toHaveBeenCalled();
+  });
+
   it('preempts construction for an assigned visible reserve target before spawn refill pressure', () => {
     const spawn = {
       id: 'spawn1',

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -4408,7 +4408,11 @@ describe('runWorker', () => {
           return site;
         }
 
-        return id === 'spawn1' ? spawn : storage;
+        if (id === 'spawn1') {
+          return spawn;
+        }
+
+        return id === 'storage1' ? storage : null;
       })
     };
 
@@ -4522,7 +4526,11 @@ describe('runWorker', () => {
           return site;
         }
 
-        return id === 'spawn1' ? spawn : storage;
+        if (id === 'spawn1') {
+          return spawn;
+        }
+
+        return id === 'storage1' ? storage : null;
       })
     };
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -4541,6 +4541,136 @@ describe('runWorker', () => {
     expect(build).not.toHaveBeenCalled();
   });
 
+  it('does not count outbound spawn-support workers as spawn reservation recovery coverage', () => {
+    const site = {
+      id: 'site1',
+      structureType: 'container',
+      progress: 0,
+      progressTotal: 5_000
+    } as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(250),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      }
+    } as unknown as StructureSpawn;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(1_673),
+        getFreeCapacity: jest.fn().mockReturnValue(10_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 650,
+      energyCapacityAvailable: 1_800,
+      controller,
+      storage,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn, storage] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [spawn, storage];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn();
+    const transfer = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'LocalBuilder',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      build,
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const outboundSupportWorker = {
+      name: 'OutboundSupport',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        spawnSupport: { originRoom: 'W1N1', targetRoom: 'W2N1' }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, outboundSupportWorker);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      economy: {
+        spawnEnergyReservation: {
+          updatedAt: 123,
+          rooms: {
+            W1N1: {
+              bodyCost: 800,
+              creepName: 'worker-W1N1-124',
+              reservedAt: 123,
+              reservedEnergy: 800,
+              role: 'worker',
+              roomName: 'W1N1',
+              updatedAt: 123
+            }
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { LocalBuilder: creep, OutboundSupport: outboundSupportWorker },
+      rooms: { W1N1: room },
+      time: 124,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'site1') {
+          return site;
+        }
+
+        if (id === 'spawn1') {
+          return spawn;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(transfer).toHaveBeenCalledWith(spawn, 'energy');
+    expect(build).not.toHaveBeenCalled();
+  });
+
   it('preempts construction for an assigned visible reserve target before spawn refill pressure', () => {
     const spawn = {
       id: 'spawn1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -12238,6 +12238,53 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'road-worn' });
   });
 
+  it('keeps idle spawn refill before repairs when bounded construction has no selectable site', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const storage = makeEnergySinkWithEnergy(
+      'storage1',
+      'storage' as StructureConstant,
+      1_200,
+      10_000
+    ) as unknown as StructureStorage;
+    const spentSite = {
+      id: 'spent-site1',
+      structureType: 'road',
+      progress: 100,
+      progressTotal: 100
+    } as ConstructionSite;
+    const road = makeStructure('road-worn', 'road' as StructureConstant, 4_000, 5_000);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [spentSite],
+      controller,
+      energyAvailable: 300,
+      energyCapacityAvailable: 1_800,
+      myStructures: [spawn as AnyOwnedStructure, storage as unknown as AnyOwnedStructure],
+      structures: [road, storage as unknown as AnyStructure]
+    }) as Room & { storage: StructureStorage };
+    room.storage = storage;
+    const creep = {
+      name: 'BoundedBuilder',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    const reserveWorker = {
+      name: 'ReserveWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ BoundedBuilder: creep, ReserveWorker: reserveWorker });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+  });
+
   it('builds follow-up-ready capacity construction before fallback territory upgrading', () => {
     const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
     const controller = {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -12285,6 +12285,64 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
   });
 
+  it.each([
+    [
+      'outbound spawn-support worker',
+      { spawnSupport: { originRoom: 'W1N1', targetRoom: 'W2N1' } }
+    ],
+    [
+      'in-transit controller-sustain worker',
+      { controllerSustain: { homeRoom: 'W1N1', targetRoom: 'W2N1', role: 'hauler' } }
+    ]
+  ] as Array<[string, Partial<CreepMemory>]>)(
+    'keeps idle spawn refill before bounded construction when only an %s appears to cover recovery',
+    (_workerKind, assignmentMemory) => {
+      const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+      const storage = makeEnergySinkWithEnergy(
+        'storage1',
+        'storage' as StructureConstant,
+        1_200,
+        10_000
+      ) as unknown as StructureStorage;
+      const site = {
+        id: 'road-site1',
+        structureType: 'road',
+        progress: 0,
+        progressTotal: 5_000
+      } as ConstructionSite;
+      const controller = {
+        id: 'controller1',
+        my: true,
+        level: 5,
+        ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+      } as StructureController;
+      const room = makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller,
+        energyAvailable: 300,
+        energyCapacityAvailable: 1_800,
+        myStructures: [spawn as AnyOwnedStructure, storage as unknown as AnyOwnedStructure],
+        structures: [storage as unknown as AnyStructure]
+      }) as Room & { storage: StructureStorage };
+      room.storage = storage;
+      const creep = {
+        name: 'LocalBuilder',
+        memory: { role: 'worker', colony: 'W1N1' },
+        store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+        room
+      } as unknown as Creep;
+      const apparentCoverageWorker = {
+        name: 'ApparentCoverage',
+        memory: { role: 'worker', colony: 'W1N1', ...assignmentMemory },
+        store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+        room
+      } as unknown as Creep;
+      setGameCreeps({ LocalBuilder: creep, ApparentCoverage: apparentCoverageWorker });
+
+      expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    }
+  );
+
   it('builds follow-up-ready capacity construction before fallback territory upgrading', () => {
     const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
     const controller = {


### PR DESCRIPTION
## Summary
- Allows workers to spend bounded construction energy while preserving emergency spawn/recovery reserves.
- Adds build-assignment telemetry/guard coverage for the E29N57 container deadlock pattern.
- Rebuilds `prod/dist/main.js` from the verified source changes.

Related to issue 1553.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (103 suites / 2128 tests)
- `cd prod && npm run build`

## Universal task Done gate
- [x] Task type: code/test/build.
- [x] Expected observable outcome / named deliverable: healthy rooms can assign/build construction work from safe excess energy while emergency worker/spawn recovery remains protected.
- [x] Non-goals / accepted substitutes: scope excludes official MMO deploy, runtime issue closure, and reward/metric taxonomy follow-ups now tracked separately in issues 1554 and 1555.
- [x] Verification evidence required before Done: controller verification listed above plus Codex commit `c1a01718` by `lanyusea's bot <lanyusea@gmail.com>`.
- [x] Project Evidence / Next action / Blocked by: issue 1553 Project fields cite commit/test evidence and PR review/deploy/runtime acceptance as the next controller gate.
- [x] Post-merge/deploy/runtime proof: issue 1553 remains the runtime-acceptance surface; proof requires later official deploy plus runtime summary showing `buildCarriedEnergy > 0` or `taskCounts.build > 0` within the observation window.
- [x] Named deliverable proof: `prod/src/creeps/workerRunner.ts`, `prod/src/tasks/workerTasks.ts`, `prod/test/workerRunner.test.ts`, and `prod/dist/main.js` contain the focused construction-energy guard and coverage.
