### PR TITLE
rl: add degraded Loop A fallback card profile

### DIFF
--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -511,10 +511,12 @@ def simulation_block(
     ticks: int = DEFAULT_SIMULATION_TICKS,
     workers: int = DEFAULT_SIMULATION_WORKERS,
     repetitions: int = DEFAULT_SIMULATION_REPETITIONS,
+    scale_environments: int | None = None,
+    min_concurrent_environments: int | None = None,
     room: str = "E1S1",
     map_source_file: Path = DEFAULT_SIMULATION_MAP_SOURCE_FILE,
 ) -> JsonObject:
-    return {
+    block = {
         "branch": "$activeWorld",
         "code_path": str(DEFAULT_SIMULATION_CODE_PATH),
         "map_source_file": str(map_source_file),
@@ -525,6 +527,11 @@ def simulation_block(
         "ticks": ticks,
         "workers": workers,
     }
+    if scale_environments is not None:
+        block["scale_environments"] = scale_environments
+    if min_concurrent_environments is not None:
+        block["min_concurrent_environments"] = min_concurrent_environments
+    return block
 
 
 def scenario_metadata_block(*, scenario_id: str = DEFAULT_SCENARIO_ID) -> JsonObject:
@@ -856,6 +863,8 @@ def build_card(
     simulation_ticks: int | None = None,
     simulation_repetitions: int | None = None,
     simulation_workers: int | None = None,
+    simulation_scale_environments: int | None = None,
+    simulation_min_concurrent_environments: int | None = None,
     registry_path: Path | None = None,
     loop_a_card_supply: bool = False,
     source_gate: JsonObject | None = None,
@@ -886,9 +895,22 @@ def build_card(
         simulation_workers if simulation_workers is not None else default_workers,
         "simulation.workers",
     )
+    scale_environments = (
+        require_positive_int(simulation_scale_environments, "simulation.scale_environments")
+        if simulation_scale_environments is not None
+        else None
+    )
+    min_concurrent_environments = (
+        require_positive_int(simulation_min_concurrent_environments, "simulation.min_concurrent_environments")
+        if simulation_min_concurrent_environments is not None
+        else None
+    )
     if training_approach == "policy_gradient":
         ticks = max(ticks, POLICY_GRADIENT_MIN_SIMULATION_TICKS)
-        repetitions = max(repetitions, POLICY_GRADIENT_SIMULATION_REPETITIONS)
+        if scale_environments is None:
+            repetitions = max(repetitions, POLICY_GRADIENT_SIMULATION_REPETITIONS)
+        else:
+            repetitions = max(repetitions, math.ceil(POLICY_GRADIENT_SIMULATION_REPETITIONS / scale_environments))
     scenario = scenario_metadata_block(scenario_id=scenario_id)
     if require_multi_tier_scenario and not scenario_supports_multi_tier_policy_comparison(scenario):
         raise CardValidationError(
@@ -919,6 +941,8 @@ def build_card(
             ticks=ticks,
             workers=workers,
             repetitions=repetitions,
+            scale_environments=scale_environments,
+            min_concurrent_environments=min_concurrent_environments,
             room=scenario_anchor_room(scenario_id),
             map_source_file=simulation_map_source_file,
         ),
@@ -2552,6 +2576,13 @@ def validate_simulation(raw: Any) -> None:
     for field in ("ticks", "workers", "repetitions"):
         if positive_int(raw.get(field)) is None:
             raise CardValidationError(f"simulation.{field} must be a positive integer")
+    for field, aliases in (
+        ("scale_environments", ("scale_environments", "scaleEnvironments")),
+        ("min_concurrent_environments", ("min_concurrent_environments", "minConcurrentEnvironments")),
+    ):
+        value = first_present(raw, aliases)
+        if value is not None and positive_int(value) is None:
+            raise CardValidationError(f"simulation.{field} must be a positive integer")
     host_port_start = first_present(raw, ("host_port_start", "hostPortStart"))
     if host_port_start is not None and positive_int(host_port_start) is None:
         raise CardValidationError("simulation.host_port_start must be a positive integer")
@@ -2688,8 +2719,15 @@ def positive_int_arg(raw: str) -> int:
     return value
 
 
-def loop_a_local_fallback_value(value: int | None, *, default: int, maximum: int, label: str) -> int:
-    resolved = default if value is None else max(value, default)
+def loop_a_local_fallback_value(
+    value: int | None,
+    *,
+    default: int,
+    maximum: int,
+    label: str,
+    allow_below_default: bool = False,
+) -> int:
+    resolved = default if value is None else (value if allow_below_default else max(value, default))
     if resolved > maximum:
         raise CardValidationError(f"Loop A local fallback {label} must be <= {maximum}")
     return resolved
@@ -2766,6 +2804,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="Simulator worker count to request. Defaults to 1.",
     )
     parser.add_argument(
+        "--scale-environments",
+        type=positive_int_arg,
+        help=(
+            "Policy-gradient scale environments used for sample-budget validation. "
+            "Defaults to the worker count for degraded Loop A local fallback cards."
+        ),
+    )
+    parser.add_argument(
+        "--min-concurrent-environments",
+        type=positive_int_arg,
+        help="Minimum concurrent simulator environments requested by the training runner.",
+    )
+    parser.add_argument(
         "--scenario-id",
         choices=SCENARIO_IDS,
         default=None,
@@ -2800,6 +2851,14 @@ def build_parser() -> argparse.ArgumentParser:
             "Write a standalone Loop A local-fallback experiment_card.json from an accepted "
             "dataset gate. Implies policy_gradient card supply and defaults to 5 workers, "
             f"20 repetitions, and {POLICY_GRADIENT_MIN_SIMULATION_TICKS} ticks."
+        ),
+    )
+    parser.add_argument(
+        "--degraded-local-fallback-profile",
+        action="store_true",
+        help=(
+            "Allow explicit lower worker/repetition counts for a shadow-only Loop A local-fallback "
+            "card when scale environments still satisfy the policy-gradient sample budget."
         ),
     )
     parser.add_argument(
@@ -2880,6 +2939,8 @@ def main(
             raise CardValidationError("--loop-a-local-fallback writes a standalone experiment_card.json; use --output")
         if args.loop_a_local_fallback and args.dry_run:
             raise CardValidationError("--loop-a-local-fallback requires an accepted dataset gate")
+        if args.degraded_local_fallback_profile and not args.loop_a_local_fallback:
+            raise CardValidationError("--degraded-local-fallback-profile requires --loop-a-local-fallback")
 
         if args.select_loop_a_card:
             if args.validate or args.loop_a_local_fallback:
@@ -2951,7 +3012,10 @@ def main(
         simulation_ticks = args.ticks
         simulation_repetitions = args.repetitions
         simulation_workers = args.workers
+        simulation_scale_environments = args.scale_environments
+        simulation_min_concurrent_environments = args.min_concurrent_environments
         if args.loop_a_local_fallback:
+            degraded_local_fallback_profile = bool(args.degraded_local_fallback_profile)
             simulation_ticks = loop_a_local_fallback_value(
                 args.ticks,
                 default=LOOP_A_LOCAL_FALLBACK_TICKS,
@@ -2963,13 +3027,20 @@ def main(
                 default=LOOP_A_LOCAL_FALLBACK_REPETITIONS,
                 maximum=LOOP_A_LOCAL_FALLBACK_REPETITIONS,
                 label="repetitions",
+                allow_below_default=degraded_local_fallback_profile,
             )
             simulation_workers = loop_a_local_fallback_value(
                 args.workers,
                 default=LOOP_A_LOCAL_FALLBACK_WORKERS,
                 maximum=LOOP_A_LOCAL_FALLBACK_WORKERS,
                 label="workers",
+                allow_below_default=degraded_local_fallback_profile,
             )
+            if degraded_local_fallback_profile:
+                if simulation_scale_environments is None:
+                    simulation_scale_environments = simulation_workers
+                if simulation_min_concurrent_environments is None:
+                    simulation_min_concurrent_environments = simulation_scale_environments
         scenario_id, require_multi_tier_scenario = resolve_cli_scenario_request(args)
         card = build_card(
             dataset_run_id=dataset_run_id,
@@ -2979,6 +3050,8 @@ def main(
             simulation_ticks=simulation_ticks,
             simulation_repetitions=simulation_repetitions,
             simulation_workers=simulation_workers,
+            simulation_scale_environments=simulation_scale_environments,
+            simulation_min_concurrent_environments=simulation_min_concurrent_environments,
             loop_a_card_supply=loop_a_card_supply,
             source_gate=source_gate,
             scenario_id=scenario_id,

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -97,6 +97,10 @@ POLICY_GRADIENT_SIMULATION_REPETITIONS = POLICY_GRADIENT_TRUST_MIN_SAMPLES_PER_C
 POLICY_GRADIENT_UPDATE_ALGORITHM = "reinforce_v1"
 POLICY_GRADIENT_UPDATE_LEARNING_RATE = 1
 POLICY_GRADIENT_UPDATE_ESTIMATOR = "score_function_reinforce_v1"
+POLICY_GRADIENT_WORKER_CONCURRENCY_ERROR = (
+    "policy_gradient cards require simulation.workers >= simulation.min_concurrent_environments "
+    "(or simulation.scale_environments when min_concurrent_environments is omitted)"
+)
 LOOP_A_LOCAL_FALLBACK_TICKS = POLICY_GRADIENT_MIN_SIMULATION_TICKS
 LOOP_A_LOCAL_FALLBACK_MAX_TICKS = 5000
 LOOP_A_LOCAL_FALLBACK_REPETITIONS = POLICY_GRADIENT_SIMULATION_REPETITIONS
@@ -906,6 +910,8 @@ def build_card(
         else None
     )
     if training_approach == "policy_gradient":
+        if simulation_workers is None and scale_environments is not None:
+            workers = max(workers, scale_environments)
         ticks = max(ticks, POLICY_GRADIENT_MIN_SIMULATION_TICKS)
         if scale_environments is None:
             repetitions = max(repetitions, POLICY_GRADIENT_SIMULATION_REPETITIONS)
@@ -2622,6 +2628,13 @@ def validate_policy_gradient_simulation(raw: Any, required_samples_per_candidate
     required_samples = required_samples_per_candidate or POLICY_GRADIENT_TRUST_MIN_SAMPLES_PER_CANDIDATE
     repetitions = positive_int(raw.get("repetitions"))
     scale_environments = policy_gradient_simulation_scale_environments(raw)
+    min_concurrent_environments = positive_int(
+        first_present(raw, ("min_concurrent_environments", "minConcurrentEnvironments"))
+    )
+    worker_floor = policy_gradient_worker_concurrency_floor(scale_environments, min_concurrent_environments)
+    workers = positive_int(raw.get("workers"))
+    if workers is None or (worker_floor is not None and workers < worker_floor):
+        raise CardValidationError(POLICY_GRADIENT_WORKER_CONCURRENCY_ERROR)
     requested_samples = repetitions * scale_environments if repetitions is not None else None
     if requested_samples is None or requested_samples < required_samples:
         raise CardValidationError(
@@ -2639,6 +2652,13 @@ def policy_gradient_simulation_scale_environments(raw: JsonObject) -> int:
     if scale_environments is None:
         raise CardValidationError("simulation.scale_environments must be a positive integer")
     return scale_environments
+
+
+def policy_gradient_worker_concurrency_floor(
+    scale_environments: int | None,
+    min_concurrent_environments: int | None,
+) -> int | None:
+    return min_concurrent_environments if min_concurrent_environments is not None else scale_environments
 
 
 def positive_int(value: Any) -> int | None:

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -2583,6 +2583,18 @@ def validate_simulation(raw: Any) -> None:
         value = first_present(raw, aliases)
         if value is not None and positive_int(value) is None:
             raise CardValidationError(f"simulation.{field} must be a positive integer")
+    scale_environments = positive_int(first_present(raw, ("scale_environments", "scaleEnvironments")))
+    min_concurrent_environments = positive_int(
+        first_present(raw, ("min_concurrent_environments", "minConcurrentEnvironments"))
+    )
+    if (
+        scale_environments is not None
+        and min_concurrent_environments is not None
+        and min_concurrent_environments > scale_environments
+    ):
+        raise CardValidationError(
+            "simulation.min_concurrent_environments must be <= simulation.scale_environments"
+        )
     host_port_start = first_present(raw, ("host_port_start", "hostPortStart"))
     if host_port_start is not None and positive_int(host_port_start) is None:
         raise CardValidationError("simulation.host_port_start must be a positive integer")

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -2713,6 +2713,33 @@ class RlExperimentCardTest(unittest.TestCase):
 
         card_helper.validate_card(card)
 
+    def test_validate_rejects_simulation_min_concurrent_above_scale_environments(self) -> None:
+        for index, (scale_field, min_field) in enumerate((
+            ("scale_environments", "min_concurrent_environments"),
+            ("scaleEnvironments", "minConcurrentEnvironments"),
+        ), start=1):
+            with self.subTest(scale_field=scale_field, min_field=min_field):
+                card = card_helper.build_card(
+                    dataset_run_id=f"rl-simulation-concurrency-{index}",
+                    code_commit="1" * 40,
+                    training_approach="policy_gradient",
+                    created_at="2026-05-17T00:25:00Z",
+                    simulation_scale_environments=2,
+                    simulation_min_concurrent_environments=2,
+                )
+                simulation = card.pop("simulation")
+                simulation[scale_field] = simulation.pop("scale_environments")
+                simulation[min_field] = 10
+                if min_field != "min_concurrent_environments":
+                    simulation.pop("min_concurrent_environments")
+                card["simulation"] = simulation
+
+                with self.assertRaisesRegex(
+                    card_helper.CardValidationError,
+                    "min_concurrent_environments must be <= simulation\\.scale_environments",
+                ):
+                    card_helper.validate_card(card)
+
     def test_validate_rejects_policy_gradient_below_target_trust_sample_budget(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-policy-gradient-high-target",

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -2713,6 +2713,41 @@ class RlExperimentCardTest(unittest.TestCase):
 
         card_helper.validate_card(card)
 
+    def test_validate_rejects_policy_gradient_scale_environments_above_workers(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-scale-workers",
+            code_commit="1" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-17T00:25:00Z",
+            simulation_repetitions=1,
+            simulation_scale_environments=5,
+        )
+        card["simulation"]["workers"] = 1
+
+        with self.assertRaisesRegex(card_helper.CardValidationError, "simulation\\.workers >="):
+            card_helper.validate_card(card)
+
+    def test_validate_rejects_policy_gradient_min_concurrent_above_workers_without_scale(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-min-workers",
+            code_commit="1" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-17T00:25:00Z",
+        )
+        card["simulation"]["min_concurrent_environments"] = 5
+
+        with self.assertRaisesRegex(card_helper.CardValidationError, "simulation\\.workers >="):
+            card_helper.validate_card(card)
+
+        with self.assertRaisesRegex(card_helper.CardValidationError, "simulation\\.workers >="):
+            card_helper.build_card(
+                dataset_run_id="rl-policy-gradient-generated-min-workers",
+                code_commit="1" * 40,
+                training_approach="policy_gradient",
+                created_at="2026-05-17T00:25:00Z",
+                simulation_min_concurrent_environments=5,
+            )
+
     def test_validate_rejects_simulation_min_concurrent_above_scale_environments(self) -> None:
         for index, (scale_field, min_field) in enumerate((
             ("scale_environments", "min_concurrent_environments"),
@@ -2924,6 +2959,41 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(config.repetitions, 20)
         self.assertEqual(generated["training_approach"], "policy_gradient")
         self.assertEqual(generated["policy_gradient"]["target_family"], "construction-priority")
+
+    def test_cli_policy_gradient_scale_environments_defaults_workers(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "card.json"
+            exit_code = card_helper.main(
+                [
+                    "--dataset-run-id",
+                    "rl-policy-gradient-cli-scale",
+                    "--code-commit",
+                    "3" * 40,
+                    "--training-approach",
+                    "policy_gradient",
+                    "--created-at",
+                    "2026-05-17T00:25:00Z",
+                    "--repetitions",
+                    "1",
+                    "--scale-environments",
+                    "5",
+                    "--output",
+                    str(output_path),
+                ],
+                stdout=io.StringIO(),
+                stderr=io.StringIO(),
+                repo_root=REPO_ROOT,
+            )
+            generated = json.loads(output_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, 0)
+        card_helper.validate_card(generated)
+        runner.validate_experiment_card(generated)
+        config = runner.simulation_config_from_card(generated)
+        self.assertEqual(config.workers, 5)
+        self.assertEqual(config.repetitions, 4)
+        self.assertEqual(config.scale_environments, 5)
+        self.assertIsNone(config.min_concurrent_environments)
 
 
 if __name__ == "__main__":

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -795,6 +795,87 @@ class RlExperimentCardTest(unittest.TestCase):
             with self.assertRaises(card_helper.CardValidationError):
                 card_helper.validate_card(nested_live_regression)
 
+    def test_cli_writes_degraded_loop_a_local_fallback_resource_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runtime_root = root / "runtime-artifacts"
+            gate_id = "rl-gate-e40f73af6f71"
+            dataset_run_id = "rl-b3d6e3a2af75"
+            gate_path = runtime_root / "rl-control-loop" / "gate-data" / gate_id / "gate_report.json"
+            output_path = runtime_root / "rl-experiment-cards" / "experiment_card.json"
+            gate_path.parent.mkdir(parents=True)
+            gate_path.write_text(
+                json.dumps(
+                    {
+                        "type": card_helper.SOURCE_GATE_TYPE,
+                        "ok": True,
+                        "gateId": gate_id,
+                        "createdAt": "2026-05-30T18:08:37Z",
+                        "dataset": {"ok": True, "runId": dataset_run_id, "sampleCount": 200},
+                        "datasetGate": {"status": "pass", "sampleCount": 200},
+                        "quality_checks": {
+                            "status": "pass",
+                            "samples_accepted": 200,
+                            "samples_rejected": 0,
+                            "acceptance_rate": 1.0,
+                        },
+                        "shadowEvaluation": {"status": "pass", "ok": True},
+                        "blockingReasons": [],
+                        "outputs": {"gateDir": f"runtime-artifacts/rl-control-loop/gate-data/{gate_id}"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            stdout = io.StringIO()
+
+            exit_code = card_helper.main(
+                [
+                    "--loop-a-local-fallback",
+                    "--degraded-local-fallback-profile",
+                    "--source-gate-id",
+                    gate_id,
+                    "--dataset-gate-root",
+                    str(runtime_root),
+                    "--code-commit",
+                    "7" * 40,
+                    "--created-at",
+                    "2026-05-31T21:06:00Z",
+                    "--ticks",
+                    "2000",
+                    "--repetitions",
+                    "10",
+                    "--workers",
+                    "2",
+                    "--output",
+                    str(output_path),
+                ],
+                stdout=stdout,
+                stderr=io.StringIO(),
+                repo_root=REPO_ROOT,
+            )
+            summary = json.loads(stdout.getvalue())
+            generated = json.loads(output_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(summary["loop_a_local_fallback"])
+        self.assertEqual(summary["source_gate"]["gate_id"], gate_id)
+        self.assertEqual(summary["source_gate"]["dataset_run_id"], dataset_run_id)
+        card_helper.validate_card(generated)
+        runner.validate_experiment_card(generated)
+        config = runner.simulation_config_from_card(generated)
+        self.assertEqual(config.workers, 2)
+        self.assertEqual(config.repetitions, 10)
+        self.assertEqual(config.ticks, card_helper.POLICY_GRADIENT_MIN_SIMULATION_TICKS)
+        self.assertEqual(config.scale_environments, 2)
+        self.assertEqual(config.min_concurrent_environments, 2)
+        self.assertEqual(generated["dataset_run_id"], dataset_run_id)
+        self.assertEqual(generated["source_gate"]["gate_id"], gate_id)
+        self.assertEqual(generated["training_approach"], "policy_gradient")
+        self.assertEqual(generated["simulation"]["scale_environments"], 2)
+        self.assertEqual(generated["simulation"]["min_concurrent_environments"], 2)
+        self.assertEqual(generated["card_supply"]["state"], "available")
+        self.assertTrue(generated["card_supply"]["available_for_training"])
+
     def test_loop_a_local_fallback_rejects_explicit_single_room_scenario(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary
- Adds a degraded Loop A local-fallback profile for RL experiment-card generation while preserving the existing default heavy fallback profile.
- Adds optional `scale_environments` / `min_concurrent_environments` simulation metadata and validation for card compatibility with policy-gradient sample-budget checks.
- Adds a focused unit test that generates and validates the 2-worker / 10-repetition / 2000-tick local fallback card shape from the latest accepted E1 gate.

Related issue: 1559.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_experiment_card.py scripts/test_screeps_rl_experiment_card.py`
- `python3 -m unittest scripts.test_screeps_rl_experiment_card -q` (76 tests)

## Safety
- No Tencent paid compute launched.
- No official MMO writes or deploys.
- Runtime card promotion remains a controller/Loop A artifact operation, not a tracked repository file change.

## Universal task Done gate
- [x] Task type: RL flywheel script/test change for local fallback card generation.
- [x] Expected observable outcome / named deliverable: branch commit `5c74610e` adds degraded local fallback card generator support and focused tests for a 2-worker, 10-repetition, 2000-tick profile.
- [x] Non-goals / accepted substitutes: no Tencent paid compute, no official MMO write, no live simulator/training execution; this PR is generator support plus validation coverage.
- [x] Verification evidence required before Done: controller verification passed with `git diff --check`, Python bytecode compilation, and the experiment-card unittest module with 76 passing tests.
- [x] Project Evidence / Next action / Blocked by: issue/PR Project entries are refreshed by the controller with this head SHA, verification evidence, and the review/CI gate.
- [x] Post-merge/deploy/runtime proof: scripts-only change has no official MMO deploy requirement; issue 1559 acceptance uses controller-generated card/resource-fit evidence before issue closure.
- [x] Named deliverable proof: generated-card evidence was recorded in `/tmp/issue1559-light-card-evidence.md` by the implementation lane and is referenced in controller handoff evidence.
