### PR TITLE
fix: reduce low-bucket tower recovery work

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -942,6 +942,196 @@ function normalizeEnergyAmount(value) {
   return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
 }
 
+// src/runtime/cpuBudget.ts
+var LOW_CPU_ACCOUNT_LIMIT = 20;
+var LOW_CPU_BUCKET_THRESHOLD = 1e3;
+var CRITICAL_CPU_BUCKET_THRESHOLD = 100;
+var DEGRADED_OPTIONAL_WORK_INTERVAL = 5;
+var DEGRADED_ROOM_OPTIONAL_WORK_INTERVAL = 3;
+var REPEATED_BUCKET_EMPTY_TICKS = 2;
+var SUSTAINED_OVER_LIMIT_TICKS = 2;
+var cpuTelemetryState = {
+  lowBucketTicks: 0,
+  bucketEmptyTicks: 0,
+  overLimitTicks: 0
+};
+function getRuntimeCpuBudget(game) {
+  const runtimeGame = game != null ? game : getRuntimeGame();
+  return buildRuntimeCpuBudget(readRuntimeCpuSample(runtimeGame));
+}
+function isRuntimeCpuBucketCritical(game) {
+  var _a;
+  const runtimeGame = game != null ? game : getRuntimeGame();
+  const bucket = (_a = runtimeGame == null ? void 0 : runtimeGame.cpu) == null ? void 0 : _a.bucket;
+  return typeof bucket === "number" && Number.isFinite(bucket) && bucket <= CRITICAL_CPU_BUCKET_THRESHOLD;
+}
+function isRuntimeCpuBucketLow(game) {
+  var _a;
+  const runtimeGame = game != null ? game : getRuntimeGame();
+  const bucket = (_a = runtimeGame == null ? void 0 : runtimeGame.cpu) == null ? void 0 : _a.bucket;
+  return typeof bucket === "number" && Number.isFinite(bucket) && bucket < LOW_CPU_BUCKET_THRESHOLD;
+}
+function buildRuntimeCpuBudget(sample) {
+  const reasons = [];
+  const lowCpuLimit = sample.limit !== void 0 && sample.limit <= LOW_CPU_ACCOUNT_LIMIT;
+  if (lowCpuLimit) {
+    reasons.push("lowCpuLimit");
+  }
+  const criticalBucket = sample.bucket !== void 0 && sample.bucket <= CRITICAL_CPU_BUCKET_THRESHOLD;
+  if (criticalBucket) {
+    reasons.push("criticalBucket");
+  } else if (sample.bucket !== void 0 && sample.bucket < LOW_CPU_BUCKET_THRESHOLD) {
+    reasons.push("lowBucket");
+  }
+  if (sample.used !== void 0 && sample.limit !== void 0 && sample.limit > 0 && sample.used > sample.limit) {
+    reasons.push("usedOverLimit");
+  }
+  const critical = criticalBucket;
+  const degraded = critical || reasons.length > 0;
+  return {
+    tick: sample.tick,
+    sample,
+    pressure: critical ? "critical" : degraded ? "degraded" : "normal",
+    degraded,
+    critical,
+    lowCpuLimit,
+    reasons
+  };
+}
+function readRuntimeCpuSample(game = getRuntimeGame()) {
+  const cpu = game == null ? void 0 : game.cpu;
+  return {
+    tick: normalizeTick(game == null ? void 0 : game.time),
+    ...optionalFiniteNumber("used", readCpuUsed(cpu)),
+    ...optionalFiniteNumber("limit", cpu == null ? void 0 : cpu.limit),
+    ...optionalFiniteNumber("bucket", cpu == null ? void 0 : cpu.bucket),
+    ...optionalFiniteNumber("tickLimit", cpu == null ? void 0 : cpu.tickLimit)
+  };
+}
+function buildRuntimeCpuTelemetrySummary(sample = readRuntimeCpuSample()) {
+  if (sample.used === void 0 && sample.limit === void 0 && sample.bucket === void 0 && sample.tickLimit === void 0) {
+    resetRuntimeCpuTelemetryStateForTick(sample.tick);
+    clearRuntimeCpuTelemetryCounters();
+    return null;
+  }
+  const budget = buildRuntimeCpuBudget(sample);
+  const state = updateRuntimeCpuTelemetryState(sample);
+  const alerts = buildRuntimeCpuAlerts(sample, state);
+  return {
+    tick: sample.tick,
+    ...sample.used !== void 0 ? { used: sample.used } : {},
+    ...sample.limit !== void 0 ? { limit: sample.limit } : {},
+    ...sample.tickLimit !== void 0 ? { tickLimit: sample.tickLimit } : {},
+    ...sample.bucket !== void 0 ? { bucket: sample.bucket } : {},
+    pressure: budget.pressure,
+    ...budget.reasons.length > 0 ? { reasons: budget.reasons } : {},
+    ...alerts.length > 0 ? { alerts } : {},
+    ...state.lowBucketTicks > 0 ? { lowBucketTicks: state.lowBucketTicks } : {},
+    ...state.bucketEmptyTicks > 0 ? { bucketEmptyTicks: state.bucketEmptyTicks } : {},
+    ...state.overLimitTicks > 0 ? { overLimitTicks: state.overLimitTicks } : {}
+  };
+}
+function shouldRunOptionalCpuWork(budget, key, interval = DEGRADED_OPTIONAL_WORK_INTERVAL) {
+  if (!budget.degraded) {
+    return true;
+  }
+  if (budget.critical || hasLowBucketPressure(budget)) {
+    return false;
+  }
+  return isCadenceTick(budget.tick, key, interval);
+}
+function shouldRunOptionalCpuRoomWork(budget, roomName, interval = DEGRADED_ROOM_OPTIONAL_WORK_INTERVAL) {
+  if (!budget.degraded) {
+    return true;
+  }
+  if (budget.critical || hasLowBucketPressure(budget)) {
+    return false;
+  }
+  return isCadenceTick(budget.tick, roomName, interval);
+}
+function shouldThrottleRuntimeSummaryCadence(budget) {
+  return budget.degraded;
+}
+function shouldShedNonessentialCpuWork(budget) {
+  return budget.critical || hasLowBucketPressure(budget);
+}
+function hasLowBucketPressure(budget) {
+  return budget.reasons.includes("lowBucket") || budget.reasons.includes("criticalBucket");
+}
+function updateRuntimeCpuTelemetryState(sample) {
+  resetRuntimeCpuTelemetryStateForTick(sample.tick);
+  const lowBucket = sample.bucket !== void 0 && sample.bucket < LOW_CPU_BUCKET_THRESHOLD;
+  const bucketEmpty = sample.bucket !== void 0 && sample.bucket <= 0;
+  const overLimit = sample.used !== void 0 && sample.limit !== void 0 && sample.limit > 0 && sample.used > sample.limit;
+  cpuTelemetryState.lowBucketTicks = lowBucket ? cpuTelemetryState.lowBucketTicks + 1 : 0;
+  cpuTelemetryState.bucketEmptyTicks = bucketEmpty ? cpuTelemetryState.bucketEmptyTicks + 1 : 0;
+  cpuTelemetryState.overLimitTicks = overLimit ? cpuTelemetryState.overLimitTicks + 1 : 0;
+  return cpuTelemetryState;
+}
+function resetRuntimeCpuTelemetryStateForTick(tick) {
+  const lastTick = cpuTelemetryState.lastTick;
+  if (lastTick !== void 0 && tick > 0 && lastTick > 0 && tick !== lastTick + 1) {
+    clearRuntimeCpuTelemetryCounters();
+  }
+  if (lastTick !== void 0 && tick > 0 && lastTick > tick) {
+    clearRuntimeCpuTelemetryCounters();
+  }
+  cpuTelemetryState.lastTick = tick;
+}
+function clearRuntimeCpuTelemetryCounters() {
+  cpuTelemetryState.lowBucketTicks = 0;
+  cpuTelemetryState.bucketEmptyTicks = 0;
+  cpuTelemetryState.overLimitTicks = 0;
+}
+function buildRuntimeCpuAlerts(sample, state) {
+  const alerts = [];
+  if (state.bucketEmptyTicks >= REPEATED_BUCKET_EMPTY_TICKS) {
+    alerts.push("bucketEmptyRepeated");
+  }
+  if (sample.bucket !== void 0 && sample.bucket < LOW_CPU_BUCKET_THRESHOLD) {
+    alerts.push("lowBucket");
+  }
+  if (state.overLimitTicks >= SUSTAINED_OVER_LIMIT_TICKS) {
+    alerts.push("sustainedUsedOverLimit");
+  }
+  return alerts;
+}
+function isCadenceTick(tick, key, interval) {
+  const normalizedInterval = Math.max(1, Math.floor(interval));
+  if (tick <= 0) {
+    return false;
+  }
+  return (tick + stableHash(key)) % normalizedInterval === 0;
+}
+function stableHash(value) {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = hash * 31 + value.charCodeAt(index) >>> 0;
+  }
+  return hash;
+}
+function readCpuUsed(cpu) {
+  const getUsed = cpu == null ? void 0 : cpu.getUsed;
+  if (typeof getUsed !== "function") {
+    return void 0;
+  }
+  try {
+    const used = getUsed.call(cpu);
+    return typeof used === "number" && Number.isFinite(used) ? used : void 0;
+  } catch {
+    return void 0;
+  }
+}
+function optionalFiniteNumber(key, value) {
+  return typeof value === "number" && Number.isFinite(value) ? { [key]: value } : {};
+}
+function normalizeTick(value) {
+  return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+function getRuntimeGame() {
+  return globalThis.Game;
+}
+
 // src/defense/defenseTelemetry.ts
 var MAX_RECORDED_DEFENSE_ACTIONS = 20;
 var CRITICAL_STRUCTURE_DAMAGE_RATIO = 0.85;
@@ -2070,7 +2260,8 @@ var TOWER_RECOVERY_ENERGY_RESERVE = 250;
 var OK_CODE2 = 0;
 function runTowersWithResult(room, options = {}) {
   var _a;
-  const context = buildDefenseTelemetryContext(room);
+  const allowRecoveryActions = options.allowRecoveryActions !== false;
+  const context = allowRecoveryActions ? buildDefenseTelemetryContext(room) : buildTowerAttackOnlyTelemetryContext(room);
   const events = [];
   const result = {
     events,
@@ -2082,12 +2273,23 @@ function runTowersWithResult(room, options = {}) {
     if (runTowerAttack(tower, context, result, (_a = options.priorityTargetGroups) != null ? _a : [])) {
       continue;
     }
+    if (!allowRecoveryActions) {
+      continue;
+    }
     if (runTowerHeal(tower, context, result)) {
       continue;
     }
     runTowerRepair(tower, context, result);
   }
   return result;
+}
+function buildTowerAttackOnlyTelemetryContext(room) {
+  return {
+    room,
+    hostileCreeps: findHostileCreeps(room),
+    hostileStructures: findHostileStructures(room),
+    damagedCriticalStructures: []
+  };
 }
 function runTowerHeal(tower, context, result) {
   if (!canSpendTowerEnergyOnRecovery(tower) || typeof tower.heal !== "function") {
@@ -2113,11 +2315,14 @@ function runTowerHeal(tower, context, result) {
   return healResult === OK_CODE2;
 }
 function runTowerAttack(tower, context, result, priorityTargetGroups) {
-  var _a;
   if (typeof tower.attack !== "function") {
     return false;
   }
-  const target = (_a = selectPriorityTowerAttackTarget(tower, priorityTargetGroups)) != null ? _a : selectTowerAttackTarget(tower, context.hostileCreeps, context.hostileStructures, {
+  const priorityTarget = selectPriorityTowerAttackTarget(tower, priorityTargetGroups);
+  if (!priorityTarget && context.hostileCreeps.length === 0 && context.hostileStructures.length === 0) {
+    return false;
+  }
+  const target = priorityTarget != null ? priorityTarget : selectTowerAttackTarget(tower, context.hostileCreeps, context.hostileStructures, {
     controller: context.room.controller,
     protectedStructures: findOwnedStructures(context.room)
   });
@@ -2297,20 +2502,27 @@ var MAX_RECORDED_DEFENSE_ACTIONS2 = 20;
 var ERR_NOT_IN_RANGE_CODE = -9;
 function runDefense() {
   const telemetryEvents = [];
+  const shedNonessentialCpuWork = isRuntimeCpuBucketLow();
   refreshVisibleDeadZoneMemory();
   const colonies = getOwnedColonies();
   const contexts = colonies.map(createDefenseContext);
   recordColonyThreats(contexts.map(buildThreatObservation));
   const towerPriorityTargetGroups = buildTowerPriorityTargetGroups(contexts);
   for (const context of contexts) {
-    runColonyDefense(context, telemetryEvents, towerPriorityTargetGroups);
+    runColonyDefense(
+      context,
+      telemetryEvents,
+      towerPriorityTargetGroups,
+      shouldAllowPassiveTowerRecovery(context, shedNonessentialCpuWork)
+    );
   }
   runDefenders(Object.values(Game.creeps), telemetryEvents);
   return telemetryEvents;
 }
-function runColonyDefense(context, telemetryEvents, towerPriorityTargetGroups) {
+function runColonyDefense(context, telemetryEvents, towerPriorityTargetGroups, allowPassiveTowerRecovery) {
   const towerDefenseResult = runTowersWithResult(context.colony.room, {
-    priorityTargetGroups: towerPriorityTargetGroups
+    priorityTargetGroups: towerPriorityTargetGroups,
+    allowRecoveryActions: allowPassiveTowerRecovery
   });
   telemetryEvents.push(...towerDefenseResult.events);
   const safeModeResult = runSafeModeWithResult(context.colony.room);
@@ -2322,6 +2534,12 @@ function runColonyDefense(context, telemetryEvents, towerPriorityTargetGroups) {
     return;
   }
   recordWorkerFallbackIfNeeded(context, telemetryEvents);
+}
+function shouldAllowPassiveTowerRecovery(context, shedNonessentialCpuWork) {
+  if (!shedNonessentialCpuWork) {
+    return true;
+  }
+  return context.hostileCreeps.length > 0 || context.hostileStructures.length > 0 || context.damagedCriticalStructures.length > 0;
 }
 function recordWorkerFallbackIfNeeded(context, telemetryEvents) {
   if (!hasDefensePressure({
@@ -21090,190 +21308,6 @@ function isPositiveFiniteNumber2(value) {
 }
 function isRecord19(value) {
   return typeof value === "object" && value !== null;
-}
-
-// src/runtime/cpuBudget.ts
-var LOW_CPU_ACCOUNT_LIMIT = 20;
-var LOW_CPU_BUCKET_THRESHOLD = 1e3;
-var CRITICAL_CPU_BUCKET_THRESHOLD = 100;
-var DEGRADED_OPTIONAL_WORK_INTERVAL = 5;
-var DEGRADED_ROOM_OPTIONAL_WORK_INTERVAL = 3;
-var REPEATED_BUCKET_EMPTY_TICKS = 2;
-var SUSTAINED_OVER_LIMIT_TICKS = 2;
-var cpuTelemetryState = {
-  lowBucketTicks: 0,
-  bucketEmptyTicks: 0,
-  overLimitTicks: 0
-};
-function getRuntimeCpuBudget(game) {
-  const runtimeGame = game != null ? game : getRuntimeGame();
-  return buildRuntimeCpuBudget(readRuntimeCpuSample(runtimeGame));
-}
-function isRuntimeCpuBucketCritical(game) {
-  var _a;
-  const runtimeGame = game != null ? game : getRuntimeGame();
-  const bucket = (_a = runtimeGame == null ? void 0 : runtimeGame.cpu) == null ? void 0 : _a.bucket;
-  return typeof bucket === "number" && Number.isFinite(bucket) && bucket <= CRITICAL_CPU_BUCKET_THRESHOLD;
-}
-function buildRuntimeCpuBudget(sample) {
-  const reasons = [];
-  const lowCpuLimit = sample.limit !== void 0 && sample.limit <= LOW_CPU_ACCOUNT_LIMIT;
-  if (lowCpuLimit) {
-    reasons.push("lowCpuLimit");
-  }
-  const criticalBucket = sample.bucket !== void 0 && sample.bucket <= CRITICAL_CPU_BUCKET_THRESHOLD;
-  if (criticalBucket) {
-    reasons.push("criticalBucket");
-  } else if (sample.bucket !== void 0 && sample.bucket < LOW_CPU_BUCKET_THRESHOLD) {
-    reasons.push("lowBucket");
-  }
-  if (sample.used !== void 0 && sample.limit !== void 0 && sample.limit > 0 && sample.used > sample.limit) {
-    reasons.push("usedOverLimit");
-  }
-  const critical = criticalBucket;
-  const degraded = critical || reasons.length > 0;
-  return {
-    tick: sample.tick,
-    sample,
-    pressure: critical ? "critical" : degraded ? "degraded" : "normal",
-    degraded,
-    critical,
-    lowCpuLimit,
-    reasons
-  };
-}
-function readRuntimeCpuSample(game = getRuntimeGame()) {
-  const cpu = game == null ? void 0 : game.cpu;
-  return {
-    tick: normalizeTick(game == null ? void 0 : game.time),
-    ...optionalFiniteNumber("used", readCpuUsed(cpu)),
-    ...optionalFiniteNumber("limit", cpu == null ? void 0 : cpu.limit),
-    ...optionalFiniteNumber("bucket", cpu == null ? void 0 : cpu.bucket),
-    ...optionalFiniteNumber("tickLimit", cpu == null ? void 0 : cpu.tickLimit)
-  };
-}
-function buildRuntimeCpuTelemetrySummary(sample = readRuntimeCpuSample()) {
-  if (sample.used === void 0 && sample.limit === void 0 && sample.bucket === void 0 && sample.tickLimit === void 0) {
-    resetRuntimeCpuTelemetryStateForTick(sample.tick);
-    clearRuntimeCpuTelemetryCounters();
-    return null;
-  }
-  const budget = buildRuntimeCpuBudget(sample);
-  const state = updateRuntimeCpuTelemetryState(sample);
-  const alerts = buildRuntimeCpuAlerts(sample, state);
-  return {
-    tick: sample.tick,
-    ...sample.used !== void 0 ? { used: sample.used } : {},
-    ...sample.limit !== void 0 ? { limit: sample.limit } : {},
-    ...sample.tickLimit !== void 0 ? { tickLimit: sample.tickLimit } : {},
-    ...sample.bucket !== void 0 ? { bucket: sample.bucket } : {},
-    pressure: budget.pressure,
-    ...budget.reasons.length > 0 ? { reasons: budget.reasons } : {},
-    ...alerts.length > 0 ? { alerts } : {},
-    ...state.lowBucketTicks > 0 ? { lowBucketTicks: state.lowBucketTicks } : {},
-    ...state.bucketEmptyTicks > 0 ? { bucketEmptyTicks: state.bucketEmptyTicks } : {},
-    ...state.overLimitTicks > 0 ? { overLimitTicks: state.overLimitTicks } : {}
-  };
-}
-function shouldRunOptionalCpuWork(budget, key, interval = DEGRADED_OPTIONAL_WORK_INTERVAL) {
-  if (!budget.degraded) {
-    return true;
-  }
-  if (budget.critical || hasLowBucketPressure(budget)) {
-    return false;
-  }
-  return isCadenceTick(budget.tick, key, interval);
-}
-function shouldRunOptionalCpuRoomWork(budget, roomName, interval = DEGRADED_ROOM_OPTIONAL_WORK_INTERVAL) {
-  if (!budget.degraded) {
-    return true;
-  }
-  if (budget.critical || hasLowBucketPressure(budget)) {
-    return false;
-  }
-  return isCadenceTick(budget.tick, roomName, interval);
-}
-function shouldThrottleRuntimeSummaryCadence(budget) {
-  return budget.degraded;
-}
-function shouldShedNonessentialCpuWork(budget) {
-  return budget.critical || hasLowBucketPressure(budget);
-}
-function hasLowBucketPressure(budget) {
-  return budget.reasons.includes("lowBucket") || budget.reasons.includes("criticalBucket");
-}
-function updateRuntimeCpuTelemetryState(sample) {
-  resetRuntimeCpuTelemetryStateForTick(sample.tick);
-  const lowBucket = sample.bucket !== void 0 && sample.bucket < LOW_CPU_BUCKET_THRESHOLD;
-  const bucketEmpty = sample.bucket !== void 0 && sample.bucket <= 0;
-  const overLimit = sample.used !== void 0 && sample.limit !== void 0 && sample.limit > 0 && sample.used > sample.limit;
-  cpuTelemetryState.lowBucketTicks = lowBucket ? cpuTelemetryState.lowBucketTicks + 1 : 0;
-  cpuTelemetryState.bucketEmptyTicks = bucketEmpty ? cpuTelemetryState.bucketEmptyTicks + 1 : 0;
-  cpuTelemetryState.overLimitTicks = overLimit ? cpuTelemetryState.overLimitTicks + 1 : 0;
-  return cpuTelemetryState;
-}
-function resetRuntimeCpuTelemetryStateForTick(tick) {
-  const lastTick = cpuTelemetryState.lastTick;
-  if (lastTick !== void 0 && tick > 0 && lastTick > 0 && tick !== lastTick + 1) {
-    clearRuntimeCpuTelemetryCounters();
-  }
-  if (lastTick !== void 0 && tick > 0 && lastTick > tick) {
-    clearRuntimeCpuTelemetryCounters();
-  }
-  cpuTelemetryState.lastTick = tick;
-}
-function clearRuntimeCpuTelemetryCounters() {
-  cpuTelemetryState.lowBucketTicks = 0;
-  cpuTelemetryState.bucketEmptyTicks = 0;
-  cpuTelemetryState.overLimitTicks = 0;
-}
-function buildRuntimeCpuAlerts(sample, state) {
-  const alerts = [];
-  if (state.bucketEmptyTicks >= REPEATED_BUCKET_EMPTY_TICKS) {
-    alerts.push("bucketEmptyRepeated");
-  }
-  if (sample.bucket !== void 0 && sample.bucket < LOW_CPU_BUCKET_THRESHOLD) {
-    alerts.push("lowBucket");
-  }
-  if (state.overLimitTicks >= SUSTAINED_OVER_LIMIT_TICKS) {
-    alerts.push("sustainedUsedOverLimit");
-  }
-  return alerts;
-}
-function isCadenceTick(tick, key, interval) {
-  const normalizedInterval = Math.max(1, Math.floor(interval));
-  if (tick <= 0) {
-    return false;
-  }
-  return (tick + stableHash(key)) % normalizedInterval === 0;
-}
-function stableHash(value) {
-  let hash = 0;
-  for (let index = 0; index < value.length; index += 1) {
-    hash = hash * 31 + value.charCodeAt(index) >>> 0;
-  }
-  return hash;
-}
-function readCpuUsed(cpu) {
-  const getUsed = cpu == null ? void 0 : cpu.getUsed;
-  if (typeof getUsed !== "function") {
-    return void 0;
-  }
-  try {
-    const used = getUsed.call(cpu);
-    return typeof used === "number" && Number.isFinite(used) ? used : void 0;
-  } catch {
-    return void 0;
-  }
-}
-function optionalFiniteNumber(key, value) {
-  return typeof value === "number" && Number.isFinite(value) ? { [key]: value } : {};
-}
-function normalizeTick(value) {
-  return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
-}
-function getRuntimeGame() {
-  return globalThis.Game;
 }
 
 // src/creeps/upgraderRunner.ts

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2318,10 +2318,10 @@ function runTowerAttack(tower, context, result, priorityTargetGroups) {
   if (typeof tower.attack !== "function") {
     return false;
   }
-  const priorityTarget = selectPriorityTowerAttackTarget(tower, priorityTargetGroups);
-  if (!priorityTarget && context.hostileCreeps.length === 0 && context.hostileStructures.length === 0) {
+  if (context.hostileCreeps.length === 0 && context.hostileStructures.length === 0) {
     return false;
   }
+  const priorityTarget = selectPriorityTowerAttackTarget(tower, priorityTargetGroups);
   const target = priorityTarget != null ? priorityTarget : selectTowerAttackTarget(tower, context.hostileCreeps, context.hostileStructures, {
     controller: context.room.controller,
     protectedStructures: findOwnedStructures(context.room)

--- a/prod/src/defense/defenseLoop.ts
+++ b/prod/src/defense/defenseLoop.ts
@@ -1,4 +1,5 @@
 import { getOwnedColonies, type ColonySnapshot } from '../colony/colonyRegistry';
+import { isRuntimeCpuBucketLow } from '../runtime/cpuBudget';
 import type { RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
 import { isDamagedStructure } from './defenseTelemetry';
 import {
@@ -53,6 +54,7 @@ interface DefenseActionInput {
 
 export function runDefense(): RuntimeTelemetryEvent[] {
   const telemetryEvents: RuntimeTelemetryEvent[] = [];
+  const shedNonessentialCpuWork = isRuntimeCpuBucketLow();
   refreshVisibleDeadZoneMemory();
   const colonies = getOwnedColonies();
   const contexts = colonies.map(createDefenseContext);
@@ -60,7 +62,12 @@ export function runDefense(): RuntimeTelemetryEvent[] {
   const towerPriorityTargetGroups = buildTowerPriorityTargetGroups(contexts);
 
   for (const context of contexts) {
-    runColonyDefense(context, telemetryEvents, towerPriorityTargetGroups);
+    runColonyDefense(
+      context,
+      telemetryEvents,
+      towerPriorityTargetGroups,
+      shouldAllowPassiveTowerRecovery(context, shedNonessentialCpuWork)
+    );
   }
 
   runDefenders(Object.values(Game.creeps), telemetryEvents);
@@ -71,10 +78,12 @@ export function runDefense(): RuntimeTelemetryEvent[] {
 function runColonyDefense(
   context: DefenseContext,
   telemetryEvents: RuntimeTelemetryEvent[],
-  towerPriorityTargetGroups: TowerPriorityTargetGroup[]
+  towerPriorityTargetGroups: TowerPriorityTargetGroup[],
+  allowPassiveTowerRecovery: boolean
 ): void {
   const towerDefenseResult = runTowersWithResult(context.colony.room, {
-    priorityTargetGroups: towerPriorityTargetGroups
+    priorityTargetGroups: towerPriorityTargetGroups,
+    allowRecoveryActions: allowPassiveTowerRecovery
   });
   telemetryEvents.push(...towerDefenseResult.events);
   const safeModeResult = runSafeModeWithResult(context.colony.room);
@@ -89,6 +98,18 @@ function runColonyDefense(
   }
 
   recordWorkerFallbackIfNeeded(context, telemetryEvents);
+}
+
+function shouldAllowPassiveTowerRecovery(context: DefenseContext, shedNonessentialCpuWork: boolean): boolean {
+  if (!shedNonessentialCpuWork) {
+    return true;
+  }
+
+  return (
+    context.hostileCreeps.length > 0 ||
+    context.hostileStructures.length > 0 ||
+    context.damagedCriticalStructures.length > 0
+  );
 }
 
 function recordWorkerFallbackIfNeeded(

--- a/prod/src/defense/towerManager.ts
+++ b/prod/src/defense/towerManager.ts
@@ -2,6 +2,8 @@ import type { RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
 import {
   buildDefenseTelemetryContext,
   compareObjectIds,
+  findHostileCreeps,
+  findHostileStructures,
   findMyCreeps,
   findOwnedStructures,
   getEnergyResource,
@@ -27,6 +29,7 @@ export interface TowerPriorityTargetGroup {
 
 export interface TowerRunOptions {
   priorityTargetGroups?: TowerPriorityTargetGroup[];
+  allowRecoveryActions?: boolean;
 }
 
 export const TOWER_RECOVERY_ENERGY_RESERVE = 250;
@@ -38,7 +41,10 @@ export function runTowers(room: Room, options: TowerRunOptions = {}): RuntimeTel
 }
 
 export function runTowersWithResult(room: Room, options: TowerRunOptions = {}): TowerRunResult {
-  const context = buildDefenseTelemetryContext(room);
+  const allowRecoveryActions = options.allowRecoveryActions !== false;
+  const context = allowRecoveryActions
+    ? buildDefenseTelemetryContext(room)
+    : buildTowerAttackOnlyTelemetryContext(room);
   const events: RuntimeTelemetryEvent[] = [];
   const result: TowerRunResult = {
     events,
@@ -52,6 +58,10 @@ export function runTowersWithResult(room: Room, options: TowerRunOptions = {}): 
       continue;
     }
 
+    if (!allowRecoveryActions) {
+      continue;
+    }
+
     if (runTowerHeal(tower, context, result)) {
       continue;
     }
@@ -60,6 +70,15 @@ export function runTowersWithResult(room: Room, options: TowerRunOptions = {}): 
   }
 
   return result;
+}
+
+function buildTowerAttackOnlyTelemetryContext(room: Room): DefenseTelemetryContext {
+  return {
+    room,
+    hostileCreeps: findHostileCreeps(room),
+    hostileStructures: findHostileStructures(room),
+    damagedCriticalStructures: []
+  };
 }
 
 function runTowerHeal(
@@ -102,8 +121,13 @@ function runTowerAttack(
     return false;
   }
 
+  const priorityTarget = selectPriorityTowerAttackTarget(tower, priorityTargetGroups);
+  if (!priorityTarget && context.hostileCreeps.length === 0 && context.hostileStructures.length === 0) {
+    return false;
+  }
+
   const target =
-    selectPriorityTowerAttackTarget(tower, priorityTargetGroups) ??
+    priorityTarget ??
     selectTowerAttackTarget(tower, context.hostileCreeps, context.hostileStructures, {
       controller: context.room.controller,
       protectedStructures: findOwnedStructures(context.room)

--- a/prod/src/defense/towerManager.ts
+++ b/prod/src/defense/towerManager.ts
@@ -121,11 +121,11 @@ function runTowerAttack(
     return false;
   }
 
-  const priorityTarget = selectPriorityTowerAttackTarget(tower, priorityTargetGroups);
-  if (!priorityTarget && context.hostileCreeps.length === 0 && context.hostileStructures.length === 0) {
+  if (context.hostileCreeps.length === 0 && context.hostileStructures.length === 0) {
     return false;
   }
 
+  const priorityTarget = selectPriorityTowerAttackTarget(tower, priorityTargetGroups);
   const target =
     priorityTarget ??
     selectTowerAttackTarget(tower, context.hostileCreeps, context.hostileStructures, {

--- a/prod/src/runtime/cpuBudget.ts
+++ b/prod/src/runtime/cpuBudget.ts
@@ -78,6 +78,12 @@ export function isRuntimeCpuBucketCritical(game?: RuntimeGameLike): boolean {
   return typeof bucket === 'number' && Number.isFinite(bucket) && bucket <= CRITICAL_CPU_BUCKET_THRESHOLD;
 }
 
+export function isRuntimeCpuBucketLow(game?: RuntimeGameLike): boolean {
+  const runtimeGame = game ?? getRuntimeGame();
+  const bucket = runtimeGame?.cpu?.bucket;
+  return typeof bucket === 'number' && Number.isFinite(bucket) && bucket < LOW_CPU_BUCKET_THRESHOLD;
+}
+
 export function buildRuntimeCpuBudget(sample: RuntimeCpuSample): RuntimeCpuBudget {
   const reasons: RuntimeCpuPressureReason[] = [];
   const lowCpuLimit = sample.limit !== undefined && sample.limit <= LOW_CPU_ACCOUNT_LIMIT;

--- a/prod/test/cpuBudget.test.ts
+++ b/prod/test/cpuBudget.test.ts
@@ -3,6 +3,7 @@ import {
   buildRuntimeCpuTelemetrySummary,
   getRuntimeCpuBudget,
   isRuntimeCpuBucketCritical,
+  isRuntimeCpuBucketLow,
   resetRuntimeCpuTelemetryForTesting,
   shouldRunOptionalCpuWork,
   shouldRunOptionalCpuRoomWork,
@@ -181,6 +182,34 @@ describe('runtime CPU budget policy', () => {
         }
       })
     ).toBe(true);
+    expect(getUsed).not.toHaveBeenCalled();
+  });
+
+  it('detects low bucket pressure without sampling CPU used', () => {
+    const getUsed = jest.fn().mockReturnValue(21);
+
+    expect(
+      isRuntimeCpuBucketLow({
+        time: 125,
+        cpu: {
+          getUsed,
+          limit: 70,
+          bucket: 999,
+          tickLimit: 500
+        }
+      })
+    ).toBe(true);
+    expect(
+      isRuntimeCpuBucketLow({
+        time: 126,
+        cpu: {
+          getUsed,
+          limit: 70,
+          bucket: 1_000,
+          tickLimit: 500
+        }
+      })
+    ).toBe(false);
     expect(getUsed).not.toHaveBeenCalled();
   });
 

--- a/prod/test/defense.test.ts
+++ b/prod/test/defense.test.ts
@@ -290,6 +290,27 @@ describe('automatic room defense response', () => {
     expect(tower.attack).not.toHaveBeenCalled();
     expect(controller.activateSafeMode).not.toHaveBeenCalled();
   });
+
+  it('skips per-tower priority scans when no local hostile targets are visible', () => {
+    const remoteRoom = { name: 'W2N1' } as Room;
+    const remoteHostile = makeHostile('remote-hostile');
+    (remoteHostile as unknown as { room: Room }).room = remoteRoom;
+    const leftTower = makeTower('tower-left', { energy: 500, x: 10, y: 25 });
+    const rightTower = makeTower('tower-right', { energy: 500, x: 40, y: 25 });
+    const room = makeRoom({ structures: [leftTower, rightTower] });
+    attachRoom([leftTower, rightTower], room);
+
+    const events = runTowers(room, {
+      allowRecoveryActions: false,
+      priorityTargetGroups: [{ hostileCreeps: [remoteHostile], hostileStructures: [] }]
+    });
+
+    const findCalls = (room.find as jest.Mock).mock.calls as Array<[number]>;
+    expect(events).toEqual([]);
+    expect(leftTower.attack).not.toHaveBeenCalled();
+    expect(rightTower.attack).not.toHaveBeenCalled();
+    expect(findCalls.filter(([type]) => type === TEST_GLOBALS.FIND_MY_STRUCTURES)).toHaveLength(1);
+  });
 });
 
 function installSpawnPlanningRoom({

--- a/prod/test/defenseLoop.test.ts
+++ b/prod/test/defenseLoop.test.ts
@@ -13,7 +13,8 @@ const TEST_GLOBALS = {
   FIND_MY_CREEPS: 104,
   RESOURCE_ENERGY: 'energy',
   STRUCTURE_SPAWN: 'spawn',
-  STRUCTURE_TOWER: 'tower'
+  STRUCTURE_TOWER: 'tower',
+  STRUCTURE_RAMPART: 'rampart'
 } as const;
 
 describe('runDefense', () => {
@@ -210,6 +211,48 @@ describe('runDefense', () => {
       hostileStructureCount: 0,
       damagedCriticalStructureCount: 1
     });
+  });
+
+  it('sheds passive rampart tower recovery during low-bucket recovery without hostiles', () => {
+    const rampart = makeRampart('rampart-low', 200_000, 300_000);
+    const roomFixture = makeOwnedRoom({ extraStructures: [rampart] });
+    const tower = makeTower(roomFixture.room, {
+      id: 'tower1',
+      repair: jest.fn().mockReturnValue(OK_CODE),
+      energy: 500
+    });
+    roomFixture.setTowers([tower]);
+    setCpu({ used: 10, limit: 70, bucket: 942, tickLimit: 500 });
+
+    const events = runDefense();
+
+    expect(tower.repair).not.toHaveBeenCalled();
+    expect(events).toEqual([]);
+  });
+
+  it('keeps damaged spawn tower recovery during low-bucket recovery', () => {
+    const roomFixture = makeOwnedRoom({
+      spawnHits: 2_000,
+      spawnHitsMax: 5_000
+    });
+    const tower = makeTower(roomFixture.room, {
+      id: 'tower1',
+      repair: jest.fn().mockReturnValue(OK_CODE),
+      energy: 500
+    });
+    roomFixture.setTowers([tower]);
+    setCpu({ used: 10, limit: 70, bucket: 942, tickLimit: 500 });
+
+    const events = runDefense();
+
+    expect(tower.repair).toHaveBeenCalledWith(roomFixture.spawn);
+    expect(events).toMatchObject([
+      {
+        type: 'defense',
+        action: 'towerRepair',
+        targetId: 'spawn1'
+      }
+    ]);
   });
 
   it('falls back to local hostiles when attacked sibling room targets are out of tower range', () => {
@@ -759,6 +802,7 @@ function makeOwnedRoom({
   hostiles = [],
   hostileStructures = [],
   includeSpawn = true,
+  extraStructures = [],
   spawnHits = 5_000,
   spawnHitsMax = 5_000
 }: {
@@ -766,11 +810,12 @@ function makeOwnedRoom({
   hostiles?: Creep[];
   hostileStructures?: Structure[];
   includeSpawn?: boolean;
+  extraStructures?: Structure[];
   spawnHits?: number;
   spawnHitsMax?: number;
 } = {}): OwnedRoomFixture {
   let towers: StructureTower[] = [];
-  const room = makeRoom({ controller, hostiles, hostileStructures, getTowers: () => towers });
+  const room = makeRoom({ controller, hostiles, hostileStructures, getTowers: () => towers, extraStructures });
   const spawn = includeSpawn
     ? ({
         id: 'spawn1',
@@ -805,7 +850,8 @@ function makeRoom({
   hostiles = [],
   hostileStructures = [],
   myCreeps = [],
-  getTowers = () => []
+  getTowers = () => [],
+  extraStructures = []
 }: {
   roomName?: string;
   controller: StructureController;
@@ -813,6 +859,7 @@ function makeRoom({
   hostileStructures?: Structure[];
   myCreeps?: Creep[];
   getTowers?: () => StructureTower[];
+  extraStructures?: Structure[];
 }): Room {
   const room = {
     name: roomName,
@@ -830,7 +877,7 @@ function makeRoom({
 
       if (type === TEST_GLOBALS.FIND_MY_STRUCTURES) {
         const spawns = Object.values((globalThis as unknown as { Game?: Partial<Game> }).Game?.spawns ?? {});
-        return [...spawns, ...getTowers()];
+        return [...spawns, ...getTowers(), ...extraStructures];
       }
 
       if (type === TEST_GLOBALS.FIND_MY_CREEPS) {
@@ -850,6 +897,15 @@ function makeRoom({
   }
 
   return room;
+}
+
+function setCpu(cpu: { used: number; limit: number; bucket: number; tickLimit: number }): void {
+  (globalThis as unknown as { Game: Partial<Game> }).Game.cpu = {
+    getUsed: jest.fn().mockReturnValue(cpu.used),
+    limit: cpu.limit,
+    bucket: cpu.bucket,
+    tickLimit: cpu.tickLimit
+  } as unknown as CPU;
 }
 
 function makeController({
@@ -935,6 +991,17 @@ function makeHostileStructure(
     structureType,
     pos: makePosition(x, y, roomName)
   } as unknown as Structure;
+}
+
+function makeRampart(id: string, hits: number, hitsMax: number): StructureRampart {
+  return {
+    id,
+    structureType: TEST_GLOBALS.STRUCTURE_RAMPART,
+    my: true,
+    hits,
+    hitsMax,
+    pos: makePosition()
+  } as unknown as StructureRampart;
 }
 
 function makePosition(x = 25, y = 25, roomName = 'W1N1'): RoomPosition {


### PR DESCRIPTION
## Summary
- Adds a low-bucket CPU guard that sheds passive/non-critical tower recovery work while preserving hostile response and critical owned-structure recovery.
- Exposes a `isRuntimeCpuBucketLow` helper and adds focused tests for low-bucket tower repair behavior plus helper boundaries.
- Rebuilds `prod/dist/main.js` from the verified source changes.

Related: #1536

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (103 suites / 2135 tests)
- `cd prod && npm run build`

## Universal task Done gate
- [x] Task type: code/test/build.
- [x] Expected observable outcome / named deliverable: low-bucket runtime skips passive rampart tower recovery while retaining hostile-response and critical spawn repair behavior.
- [x] Non-goals / accepted substitutes: no official MMO deploy, no Tencent compute, and no runtime alert issue completion in this PR.
- [x] Verification evidence required before Done: controller verification passed with `git diff --check`, prod typecheck, Jest, and build on commit `09576c559c7f59a7cf290fd1443cc4dd0bc3ddab`.
- [x] Project Evidence / Next action / Blocked by: scheduler updates issue/PR Project fields with head SHA, verification, CodeRabbit/CI gate, and runtime acceptance action.
- [x] Post-merge/deploy/runtime proof: issue #1536 remains the acceptance tracker for runtime-alert/runtime-summary captures showing CPU bucket sustained above 1000 for 200+ ticks, or the next relief slice if it stays below threshold.
- [x] Named deliverable proof: commit `09576c559c7f59a7cf290fd1443cc4dd0bc3ddab` changes tower recovery CPU shedding, source helper, tests, and bundled `prod/dist/main.js`.
