### PR TITLE
fix: shed low-bucket nonessential telemetry

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -31521,7 +31521,7 @@ function runWorker(creep) {
   executeAssignedTask(creep, selectedTask);
 }
 function recordWorkerDispatchDiagnostic(creep, context) {
-  if (isRuntimeCpuBucketCritical()) {
+  if (isRuntimeCpuBucketLow()) {
     return;
   }
   const memory = creep.memory;
@@ -37748,7 +37748,7 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   creepsByColony != null ? creepsByColony : creepsByColony = groupCreepsByColony(creeps, colonies);
   const reportedEvents = events.slice(0, MAX_REPORTED_EVENTS);
   const persistOccupationRecommendations = options.persistOccupationRecommendations !== false;
-  const includeOptionalSummary = !cpuBudget.lowCpuLimit && !cpuBudget.critical;
+  const includeOptionalSummary = !cpuBudget.lowCpuLimit && !shouldShedNonessentialCpuWork(cpuBudget);
   const rooms = colonies.map(
     (colony) => {
       var _a, _b;
@@ -37776,8 +37776,14 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   return summary;
 }
 function shouldEmitRuntimeSummary(tick, events, cpuBudget = getRuntimeCpuBudget()) {
-  if (cpuBudget.critical) {
-    return hasCriticalRuntimeSummaryEvent(events);
+  if (shouldShedNonessentialCpuWork(cpuBudget)) {
+    if (hasCriticalRuntimeSummaryEvent(events)) {
+      return true;
+    }
+    if (cpuBudget.critical) {
+      return false;
+    }
+    return tick > 0 && tick % DEGRADED_RUNTIME_SUMMARY_INTERVAL === 0;
   }
   if (events.length > 0) {
     return true;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -50,7 +50,7 @@ import {
   recordCreepBehaviorWork,
   type RuntimeEnergyAcquisitionMethod
 } from '../telemetry/behaviorTelemetry';
-import { getRuntimeCpuBudget, isRuntimeCpuBucketCritical } from '../runtime/cpuBudget';
+import { getRuntimeCpuBudget, isRuntimeCpuBucketLow } from '../runtime/cpuBudget';
 import { isColonyRoomThreatened } from '../defense/colonyThreats';
 
 type TransferSinkStructureConstantGlobal =
@@ -217,7 +217,7 @@ function recordWorkerDispatchDiagnostic(
   creep: Creep,
   context: WorkerDispatchDiagnosticContext
 ): void {
-  if (isRuntimeCpuBucketCritical()) {
+  if (isRuntimeCpuBucketLow()) {
     return;
   }
 

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -66,6 +66,7 @@ import {
 import {
   buildRuntimeCpuTelemetrySummary,
   getRuntimeCpuBudget,
+  shouldShedNonessentialCpuWork,
   shouldThrottleRuntimeSummaryCadence,
   type RuntimeCpuAlert,
   type RuntimeCpuPressure,
@@ -809,7 +810,7 @@ export function emitRuntimeSummary(
   creepsByColony ??= groupCreepsByColony(creeps, colonies);
   const reportedEvents = events.slice(0, MAX_REPORTED_EVENTS);
   const persistOccupationRecommendations = options.persistOccupationRecommendations !== false;
-  const includeOptionalSummary = !cpuBudget.lowCpuLimit && !cpuBudget.critical;
+  const includeOptionalSummary = !cpuBudget.lowCpuLimit && !shouldShedNonessentialCpuWork(cpuBudget);
   const rooms = colonies.map((colony) =>
     summarizeRoom(
       colony,
@@ -840,8 +841,16 @@ export function shouldEmitRuntimeSummary(
   events: RuntimeTelemetryEvent[],
   cpuBudget = getRuntimeCpuBudget()
 ): boolean {
-  if (cpuBudget.critical) {
-    return hasCriticalRuntimeSummaryEvent(events);
+  if (shouldShedNonessentialCpuWork(cpuBudget)) {
+    if (hasCriticalRuntimeSummaryEvent(events)) {
+      return true;
+    }
+
+    if (cpuBudget.critical) {
+      return false;
+    }
+
+    return tick > 0 && tick % DEGRADED_RUNTIME_SUMMARY_INTERVAL === 0;
   }
 
   if (events.length > 0) {

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -437,6 +437,63 @@ describe('runtime telemetry summaries', () => {
     expect(payload.events).toEqual([damageOnlyDefenseEvent]);
   });
 
+  it('omits optional room telemetry from degraded-cadence summaries during low-bucket recovery', () => {
+    const worker = makeWorker(
+      {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'harvest', targetId: 'source1' as Id<Source> },
+        behaviorTelemetry: {
+          idleTicks: 1,
+          moveTicks: 0,
+          workTicks: 0,
+          stuckTicks: 0,
+          containerTransfers: 0,
+          sourceContainerWithdrawals: 0,
+          pathLength: 0,
+          lastObservedTick: RUNTIME_SUMMARY_INTERVAL * 5
+        },
+        workerEfficiency: {
+          type: 'nearbyEnergyChoice',
+          tick: RUNTIME_SUMMARY_INTERVAL * 5,
+          carriedEnergy: 5,
+          freeCapacity: 45,
+          selectedTask: 'pickup',
+          targetId: 'drop-1',
+          energy: 50,
+          range: 1
+        }
+      },
+      5,
+      'Worker1'
+    );
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL * 5,
+      creeps: [worker]
+    });
+    const onStrategyRegistryRuntimeUse = jest.fn();
+    (Game as Partial<Game>).cpu = {
+      getUsed: jest.fn().mockReturnValue(18),
+      limit: 70,
+      bucket: 500,
+      tickLimit: 500
+    } as unknown as CPU;
+
+    emitRuntimeSummary([colony], [worker], [], {
+      strategyRegistry: DEFAULT_STRATEGY_REGISTRY,
+      onStrategyRegistryRuntimeUse
+    });
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.constructionPriority).toEqual({ candidates: [], nextPrimary: null });
+    expect(room.territoryExpansion).toBeUndefined();
+    expect(room.behavior).toBeUndefined();
+    expect(room.workerEfficiency).toBeUndefined();
+    expect(room.refillTelemetry).toBeUndefined();
+    expect(onStrategyRegistryRuntimeUse).not.toHaveBeenCalled();
+  });
+
   it('reports per-creep behavior counters and resets emitted counters', () => {
     const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
     const worker = makeWorker(
@@ -2963,7 +3020,7 @@ describe('runtime telemetry summaries', () => {
     expect(Memory.territory?.intents).toBeUndefined();
   });
 
-  it('keeps E29N56 scout-only evidence out of reserve recommendations when CPU blocks conversion', () => {
+  it('omits E29N56 scout-only expansion evidence while low-bucket telemetry shedding is active', () => {
     const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL * 5, roomName: 'E29N55' });
     const room = colony.room as Room & { find: jest.Mock; energyAvailable: number; energyCapacityAvailable: number };
     const controller = room.controller as StructureController & { level: number; ticksToDowngrade: number };
@@ -3041,18 +3098,9 @@ describe('runtime telemetry summaries', () => {
 
     const payload = parseLoggedSummary();
     const [summaryRoom] = payload.rooms as Array<Record<string, unknown>>;
-    const territoryExpansion = summaryRoom.territoryExpansion as Record<string, unknown>;
-    const expansionCandidate = (territoryExpansion.candidates as Array<Record<string, unknown>>).find(
-      (candidate) => candidate.roomName === 'E29N56'
-    );
     const recommendation = summaryRoom.territoryRecommendation as Record<string, unknown>;
 
-    expect(expansionCandidate).toMatchObject({
-      roomName: 'E29N56',
-      evidenceStatus: 'sufficient',
-      scoutOnly: true,
-      blockReason: 'cpuBucketLow'
-    });
+    expect(summaryRoom.territoryExpansion).toBeUndefined();
     expect(recommendation).toMatchObject({
       candidates: [],
       next: null,
@@ -3125,7 +3173,9 @@ describe('runtime telemetry summaries', () => {
 
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [], lowBucketBudget)).toBe(false);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL * 5, [], lowBucketBudget)).toBe(true);
-    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [spawnEvent], lowBucketBudget)).toBe(true);
+    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [spawnEvent], lowBucketBudget)).toBe(false);
+    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL * 5, [spawnEvent], lowBucketBudget)).toBe(true);
+    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [safeModeEvent], lowBucketBudget)).toBe(true);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL * 5, [], criticalBucketBudget)).toBe(false);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [spawnEvent], criticalBucketBudget)).toBe(false);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [safeModeEvent], criticalBucketBudget)).toBe(true);

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -462,6 +462,21 @@ describe('runtime telemetry summaries', () => {
           targetId: 'drop-1',
           energy: 50,
           range: 1
+        },
+        refillTelemetry: {
+          recentDeliveries: [
+            {
+              tick: RUNTIME_SUMMARY_INTERVAL * 5,
+              targetId: 'spawn1',
+              deliveryTicks: 4,
+              activeTicks: 3,
+              idleOrOtherTaskTicks: 1,
+              energyDelivered: 20
+            }
+          ],
+          refillActiveTicks: 3,
+          idleOrOtherTaskTicks: 1,
+          lastUpdatedAt: RUNTIME_SUMMARY_INTERVAL * 5
         }
       },
       5,
@@ -490,7 +505,9 @@ describe('runtime telemetry summaries', () => {
     expect(room.territoryExpansion).toBeUndefined();
     expect(room.behavior).toBeUndefined();
     expect(room.workerEfficiency).toBeUndefined();
-    expect(room.refillTelemetry).toBeUndefined();
+    expect(room.refillDeliveryTicks).toBeUndefined();
+    expect(room.refillWorkerUtilization).toBeUndefined();
+    expect(room.workerEnergyThroughput).toBeUndefined();
     expect(onStrategyRegistryRuntimeUse).not.toHaveBeenCalled();
   });
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -145,6 +145,44 @@ describe('runWorker', () => {
     expect(harvest).toHaveBeenCalledWith(source);
   });
 
+  it('suppresses worker dispatch diagnostics during low-bucket recovery', () => {
+    const source = { id: 'source1', energy: 300 } as Source;
+    const room = {
+      name: 'W1N1',
+      find: jest.fn().mockReturnValue([source])
+    } as unknown as Room;
+    const creep = {
+      name: 'Worker1',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'harvest', targetId: 'source1' as Id<Source> }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room,
+      harvest: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 124,
+      creeps: { Worker1: creep },
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(18),
+        limit: 70,
+        bucket: 500,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) => (id === 'source1' ? source : null)) as unknown as Game['getObjectById']
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.workerDispatchDiagnostic).toBeUndefined();
+  });
+
   it('keeps an executable assigned repair under critical CPU bucket without full task reselection', () => {
     const road = { id: 'road1', structureType: 'road', hits: 1_000, hitsMax: 5_000 } as StructureRoad;
     const room = {


### PR DESCRIPTION
## Summary
- Reduce nonessential runtime-summary payload work during low-bucket recovery.
- Suppress worker dispatch diagnostics across the full low-bucket range.
- Add focused Jest coverage and keep `prod/dist/main.js` synchronized.

Related issues: #1536 and #1490.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`

## Universal task Done gate
- [x] Task type: production code bugfix for CPU-low runtime relief.
- [x] Expected observable outcome / named deliverable: Codex-authored commit `61d7aa8e` reduces optional runtime-summary and worker-diagnostic CPU work during low-bucket pressure.
- [x] Non-goals / accepted substitutes: No Tencent compute, official deploy, Project mutation by Codex, or automatic issue closure in this PR.
- [x] Verification evidence required before Done: `git diff --check`, `npm run typecheck`, `npm test -- --runInBand`, and `npm run build` passed from `/root/screeps-worktrees/issue-1536-cpu-low-relief` at 2026-05-31T23:50Z.
- [x] Project Evidence / Next action / Blocked by: Controller records PR and issue Project fields with commit `61d7aa8e`, verification commands, review gate, and runtime acceptance criterion.
- [x] Post-merge/deploy/runtime proof: Runtime acceptance criterion is CPU bucket at or above 1000 in fresh CPU-bearing console captures for #1536/#1490; this PR supplies code and test proof.
- [x] Named deliverable proof: Commit `61d7aa8e` changes exactly `prod/src/telemetry/runtimeSummary.ts`, `prod/src/creeps/workerRunner.ts`, `prod/test/runtimeSummary.test.ts`, `prod/test/workerRunner.test.ts`, and `prod/dist/main.js`.
