### PR TITLE
fix(rl): preserve mixed conclusion registry records

### DIFF
--- a/scripts/rl_conclusion_registry.py
+++ b/scripts/rl_conclusion_registry.py
@@ -16,6 +16,17 @@ from typing import Any, Sequence
 
 SCHEMA_VERSION = 1
 REGISTRY_TYPE = "rl-conclusion-registry"
+REGISTRY_METADATA_KEYS = frozenset(
+    (
+        "schemaVersion",
+        "registryType",
+        "type",
+        "lastUpdatedAt",
+        "updatedAt",
+        "updatedBy",
+        "summary",
+    )
+)
 CONCLUSION_STATUSES = ("OPEN", "STALE", "ACTIONED", "VALIDATING", "CLOSED", "ESCALATED")
 ACTIONABLE_STALE_SEVERITIES = ("P0", "P1")
 ACTIONABLE_STALE_STATUSES = ("OPEN", "STALE")
@@ -99,6 +110,10 @@ def merge_normalized_record_maps(sources: Sequence[dict[str, JsonObject]]) -> di
     return records
 
 
+def is_metadata_only_registry_payload(value: JsonObject) -> bool:
+    return bool(value) and all(key in REGISTRY_METADATA_KEYS for key in value)
+
+
 def normalize_conclusions(value: Any) -> dict[str, JsonObject]:
     if value is None:
         return {}
@@ -117,6 +132,8 @@ def normalize_conclusions(value: Any) -> dict[str, JsonObject]:
         ]
         if registry_sources:
             return merge_normalized_record_maps(registry_sources)
+        if is_metadata_only_registry_payload(value):
+            return {}
 
     items: list[tuple[str | None, Any]]
     if isinstance(value, dict):

--- a/scripts/rl_conclusion_registry.py
+++ b/scripts/rl_conclusion_registry.py
@@ -89,11 +89,34 @@ def load_registry(path: Path) -> JsonObject:
     return parsed
 
 
+def merge_normalized_record_maps(sources: Sequence[dict[str, JsonObject]]) -> dict[str, JsonObject]:
+    records: dict[str, JsonObject] = {}
+    for source in sources:
+        for conclusion_id, record in source.items():
+            if conclusion_id in records:
+                raise ConclusionRegistryError(f"duplicate conclusionId {conclusion_id!r} in conclusions payload")
+            records[conclusion_id] = record
+    return records
+
+
 def normalize_conclusions(value: Any) -> dict[str, JsonObject]:
     if value is None:
         return {}
-    if isinstance(value, dict) and "conclusions" in value and "conclusionId" not in value:
-        return normalize_conclusions(value.get("conclusions"))
+    if isinstance(value, dict):
+        if isinstance(value.get("conclusionId"), str):
+            conclusion_id = value["conclusionId"]
+            if not conclusion_id:
+                raise ConclusionRegistryError("each conclusion record must have a non-empty conclusionId")
+            record = dict(value)
+            return {conclusion_id: record}
+
+        registry_sources = [
+            normalize_conclusions(value[key])
+            for key in ("conclusions", "entries")
+            if key in value
+        ]
+        if registry_sources:
+            return merge_normalized_record_maps(registry_sources)
 
     items: list[tuple[str | None, Any]]
     if isinstance(value, dict):
@@ -125,6 +148,7 @@ def merge_registry_payload(
     owner_cron: str,
     updated_at: str,
     updated_by: str | None = None,
+    prune_omitted_owner_records: bool = True,
 ) -> JsonObject:
     if not owner_cron:
         raise ConclusionRegistryError("owner_cron must be non-empty")
@@ -132,14 +156,17 @@ def merge_registry_payload(
         raise ConclusionRegistryError("updated_at must be non-empty")
 
     existing_payload = existing or {}
-    existing_records = normalize_conclusions(existing_payload.get("conclusions"))
+    existing_records = normalize_conclusions(existing_payload)
     incoming_records = normalize_conclusions(producer_conclusions)
 
-    merged = {
-        conclusion_id: record
-        for conclusion_id, record in existing_records.items()
-        if conclusion_id in incoming_records or record.get("ownerCron") != owner_cron
-    }
+    if prune_omitted_owner_records:
+        merged = {
+            conclusion_id: record
+            for conclusion_id, record in existing_records.items()
+            if conclusion_id in incoming_records or record.get("ownerCron") != owner_cron
+        }
+    else:
+        merged = dict(existing_records)
     new_count = 0
     closed_this_window = 0
     for conclusion_id, incoming in incoming_records.items():
@@ -495,6 +522,7 @@ def merge_registry_file(
     owner_cron: str,
     updated_at: str,
     updated_by: str | None = None,
+    prune_omitted_owner_records: bool = True,
 ) -> JsonObject:
     with locked_registry(path):
         merged = merge_registry_payload(
@@ -503,6 +531,7 @@ def merge_registry_file(
             owner_cron=owner_cron,
             updated_at=updated_at,
             updated_by=updated_by,
+            prune_omitted_owner_records=prune_omitted_owner_records,
         )
         write_json_atomic(path, merged)
     return merged

--- a/scripts/test_rl_conclusion_registry.py
+++ b/scripts/test_rl_conclusion_registry.py
@@ -459,6 +459,45 @@ class RlConclusionRegistryTest(unittest.TestCase):
         self.assertEqual(list(single_record), ["TOP-LEVEL-SINGLE"])
         self.assertEqual(single_record["TOP-LEVEL-SINGLE"]["status"], "VALIDATING")
 
+    def test_merge_registry_file_accepts_metadata_only_existing_registry(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "conclusion-registry.json"
+            path.write_text(
+                registry.canonical_json(
+                    {
+                        "schemaVersion": 1,
+                        "registryType": "rl-conclusion-registry",
+                        "lastUpdatedAt": "2026-05-31T00:00:00Z",
+                        "updatedBy": "bootstrap",
+                        "summary": {"total": 0},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            merged = registry.merge_registry_file(
+                path,
+                [
+                    {
+                        "conclusionId": "E1-GATE-STATUS",
+                        "status": "OPEN",
+                        "statement": "Metadata-only registry can receive its first conclusion.",
+                    },
+                ],
+                owner_cron="d6cff532edd4",
+                updated_at="2026-06-01T00:00:00Z",
+            )
+            saved = read_json(path)
+
+        self.assertEqual(saved, merged)
+        self.assertEqual(saved["schemaVersion"], 1)
+        self.assertEqual(saved["registryType"], "rl-conclusion-registry")
+        self.assertEqual(list(saved["conclusions"]), ["E1-GATE-STATUS"])
+        self.assertNotIn("summary", saved["conclusions"])
+        self.assertEqual(saved["conclusions"]["E1-GATE-STATUS"]["ownerCron"], "d6cff532edd4")
+        self.assertEqual(saved["summary"]["total"], 1)
+        self.assertEqual(saved["summary"]["new"], 1)
+
     def test_loop_b_append_update_preserves_existing_entries_shape_records(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             path = Path(temp_dir) / "conclusion-registry.json"

--- a/scripts/test_rl_conclusion_registry.py
+++ b/scripts/test_rl_conclusion_registry.py
@@ -402,6 +402,158 @@ class RlConclusionRegistryTest(unittest.TestCase):
                 }
             )
 
+        with self.assertRaisesRegex(registry.ConclusionRegistryError, "DUPLICATE-ID"):
+            registry.normalize_conclusions(
+                {
+                    "schemaVersion": 1,
+                    "registryType": "rl-conclusion-registry",
+                    "conclusions": {
+                        "DUPLICATE-ID": {"conclusionId": "DUPLICATE-ID", "status": "OPEN"},
+                    },
+                    "entries": [
+                        {"conclusionId": "DUPLICATE-ID", "status": "CLOSED"},
+                    ],
+                }
+            )
+
+    def test_normalize_conclusions_accepts_mixed_registry_shapes(self) -> None:
+        records = registry.normalize_conclusions(
+            {
+                "schemaVersion": 1,
+                "type": "screeps-rl-conclusion-registry",
+                "conclusions": {
+                    "CANONICAL-DICT": {
+                        "conclusionId": "CANONICAL-DICT",
+                        "status": "ACTIONED",
+                    },
+                },
+                "entries": [
+                    {
+                        "conclusionId": "LEGACY-ENTRY-LIST",
+                        "status": "OPEN",
+                    },
+                    {
+                        "conclusionId": "LEGACY-ENTRY-STALE",
+                        "status": "STALE",
+                    },
+                ],
+            }
+        )
+
+        self.assertEqual(
+            sorted(records),
+            ["CANONICAL-DICT", "LEGACY-ENTRY-LIST", "LEGACY-ENTRY-STALE"],
+        )
+        self.assertEqual(records["CANONICAL-DICT"]["status"], "ACTIONED")
+        self.assertEqual(records["LEGACY-ENTRY-LIST"]["status"], "OPEN")
+        self.assertEqual(records["LEGACY-ENTRY-STALE"]["status"], "STALE")
+
+        single_record = registry.normalize_conclusions(
+            {
+                "conclusionId": "TOP-LEVEL-SINGLE",
+                "status": "VALIDATING",
+                "statement": "Single producer conclusion payload.",
+            }
+        )
+
+        self.assertEqual(list(single_record), ["TOP-LEVEL-SINGLE"])
+        self.assertEqual(single_record["TOP-LEVEL-SINGLE"]["status"], "VALIDATING")
+
+    def test_loop_b_append_update_preserves_existing_entries_shape_records(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "conclusion-registry.json"
+            path.write_text(
+                registry.canonical_json(
+                    {
+                        "schemaVersion": 1,
+                        "type": "screeps-rl-conclusion-registry",
+                        "updatedAt": "2026-06-01T02:00:00Z",
+                        "entries": [
+                            {
+                                "conclusionId": "LOOP-B-OLDER-OPEN",
+                                "ownerCron": "01609968392a",
+                                "status": "OPEN",
+                                "severity": "P0",
+                                "statement": "Older Loop B conclusion must remain visible.",
+                            },
+                            {
+                                "conclusionId": "LOOP-B-ACTIONED",
+                                "ownerCron": "01609968392a",
+                                "status": "ACTIONED",
+                                "severity": "P1",
+                                "statement": "Loop B action remains in follow-up.",
+                            },
+                            {
+                                "conclusionId": "STEWARD-STALE",
+                                "ownerCron": "aed8362e4501",
+                                "status": "STALE",
+                                "severity": "P0",
+                                "statement": "Steward stale backlog item must remain visible.",
+                            },
+                            {
+                                "conclusionId": "E1-VALIDATING",
+                                "ownerCron": "d6cff532edd4",
+                                "status": "VALIDATING",
+                                "severity": "P1",
+                                "statement": "E1 validation must remain visible.",
+                            },
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            merged = registry.merge_registry_file(
+                path,
+                {
+                    "conclusionId": "LOOP-B-NEW-UNPROVEN",
+                    "status": "OPEN",
+                    "severity": "P0",
+                    "statement": "New Loop B report remains unproven.",
+                },
+                owner_cron="01609968392a",
+                updated_at="2026-06-01T02:59:07Z",
+                updated_by="01609968392a",
+                prune_omitted_owner_records=False,
+            )
+            saved = read_json(path)
+
+        self.assertEqual(saved, merged)
+        conclusions = saved["conclusions"]
+        self.assertEqual(
+            sorted(conclusions),
+            [
+                "E1-VALIDATING",
+                "LOOP-B-ACTIONED",
+                "LOOP-B-NEW-UNPROVEN",
+                "LOOP-B-OLDER-OPEN",
+                "STEWARD-STALE",
+            ],
+        )
+        self.assertEqual(conclusions["LOOP-B-OLDER-OPEN"]["ownerCron"], "01609968392a")
+        self.assertEqual(conclusions["LOOP-B-ACTIONED"]["status"], "ACTIONED")
+        self.assertEqual(conclusions["STEWARD-STALE"]["ownerCron"], "aed8362e4501")
+        self.assertEqual(conclusions["E1-VALIDATING"]["status"], "VALIDATING")
+        self.assertEqual(conclusions["LOOP-B-NEW-UNPROVEN"]["ownerCron"], "01609968392a")
+        self.assertEqual(conclusions["LOOP-B-NEW-UNPROVEN"]["lastSeenAt"], "2026-06-01T02:59:07Z")
+        self.assertEqual(merged["summary"]["total"], 5)
+        self.assertEqual(merged["summary"]["new"], 1)
+        self.assertEqual(merged["summary"]["open"], 2)
+        self.assertEqual(merged["summary"]["actioned"], 1)
+        self.assertEqual(merged["summary"]["validating"], 1)
+        self.assertEqual(merged["summary"]["staleOrEscalated"], 1)
+        self.assertEqual(
+            merged["summary"]["countsByStatus"],
+            {
+                "ACTIONED": 1,
+                "CLOSED": 0,
+                "ESCALATED": 0,
+                "OPEN": 2,
+                "STALE": 1,
+                "VALIDATING": 1,
+            },
+        )
+
     @unittest.skipIf(os.name == "nt", "POSIX file mode preservation test")
     def test_merge_registry_file_preserves_existing_permissions(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- Preserve RL conclusion-registry records when a producer writes canonical `conclusions` while the existing registry still uses legacy `entries`.
- Add regression coverage for mixed registry shapes, duplicate IDs across shapes, top-level single-record payloads, and append/update behavior that keeps older Loop B/steward/E1 records visible.

Related to issue #1543.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/rl_conclusion_registry.py scripts/test_rl_conclusion_registry.py`
- `python3 -m unittest scripts/test_rl_conclusion_registry.py` — 15 tests OK

## Universal task Done gate
- [x] Task type: code/test bugfix for RL conclusion-registry preservation.
- [x] Expected observable outcome / named deliverable: mixed `entries` + `conclusions` registry payloads normalize and merge without dropping existing conclusion records.
- [x] Non-goals / accepted substitutes: no runtime deploy, no Tencent paid compute, no cron changes, no official MMO writes.
- [x] Verification evidence required before Done: controller ran diff-check, py_compile, and registry unittest; CI will re-run repo gates on this PR head.
- [x] Project Evidence / Next action / Blocked by: REST checkpoint comment records PR head `fc2d3d7e` and GraphQL reset time for ProjectV2 field sync.
- [x] Post-merge/deploy/runtime proof: post-merge main should run the same registry unit test and then the next Loop A/B producer should preserve legacy registry entries.
- [x] Named deliverable proof: commit `fc2d3d7e` changes only `scripts/rl_conclusion_registry.py` and `scripts/test_rl_conclusion_registry.py`.

## Safety
No secrets, no paid compute, and no official Screeps API writes are involved.