### PR TITLE
fix(rl): tolerate nonfatal activation evidence warnings

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -5620,7 +5620,7 @@ def build_multi_tier_policy_activation_evidence(
     target_room = activation.get("targetRoom")
     if not isinstance(target_room, str):
         return None
-    evidence_warnings = [_safe_text(error, 240) for error in evidence_errors if str(error).strip()]
+    evidence_warnings = [_safe_text(error, 240) for error in (evidence_errors or ()) if str(error).strip()]
     if evidence_warnings:
         activation["evidenceWarnings"] = evidence_warnings[:5]
     observed = _multi_tier_policy_activation_observed_evidence(tick_log, target_room)

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -5608,7 +5608,7 @@ def build_multi_tier_policy_activation_evidence(
     evidence_errors: Sequence[Any] = (),
     allow_offline_projection: bool = False,
 ) -> JsonObject | None:
-    if run_errors or evidence_errors or len(tick_log) < 2:
+    if run_errors or len(tick_log) < 2:
         return None
     activation = select_multi_tier_policy_activation(
         strategy_variant,
@@ -5620,6 +5620,9 @@ def build_multi_tier_policy_activation_evidence(
     target_room = activation.get("targetRoom")
     if not isinstance(target_room, str):
         return None
+    evidence_warnings = [_safe_text(error, 240) for error in evidence_errors if str(error).strip()]
+    if evidence_warnings:
+        activation["evidenceWarnings"] = evidence_warnings[:5]
     observed = _multi_tier_policy_activation_observed_evidence(tick_log, target_room)
     if observed is not None:
         activation["objectiveSignalObserved"] = True

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -4809,6 +4809,9 @@ def multi_tier_activation_sample_trace(
             if field in activation_metrics:
                 trace_policy_activation[field] = activation_metrics.get(field)
         trace["policyActivation"] = trace_policy_activation
+        evidence_warnings = policy_activation.get("evidenceWarnings")
+        if isinstance(evidence_warnings, list):
+            trace["evidenceWarnings"] = copy.deepcopy(evidence_warnings[:5])
     if projected_evidence is not None:
         trace["projectedEvidence"] = {
             "mode": projected_evidence.get("mode"),
@@ -6214,13 +6217,26 @@ def build_multi_tier_activation_proof(
             "classification": classification,
             "criticality": "P0",
             "evidence": evidence,
-            "action": (
-                "rerun policy-gradient multi-tier validation with an extended simulation horizon"
-                if horizon_too_short
-                else "repair local/private simulator objective activation before paid Tencent validation"
-            ),
+            "action": multi_tier_activation_blocker_action(classification),
         }
     return proof
+
+
+def multi_tier_activation_blocker_action(classification: str) -> str:
+    if classification == "SIMULATION_HORIZON_TOO_SHORT":
+        return "rerun policy-gradient multi-tier validation with an extended simulation horizon"
+    if classification == "SIMULATOR_NO_SUCCESSFUL_SAMPLES":
+        return (
+            "repair local/private simulator reliability so multi-tier activation proof has "
+            "successful samples before paid Tencent validation"
+        )
+    if classification == "SIMULATOR_OBJECTIVE_SIGNAL_NOT_ACTIVATED":
+        return (
+            "repair simulator/bot objective actuation so at least one successful local/private sample "
+            f"exceeds territory score {MULTI_TIER_TERRITORY_ACTIVATION_THRESHOLD} or hostile kills "
+            f"{MULTI_TIER_HOSTILE_KILLS_ACTIVATION_THRESHOLD} before paid Tencent validation"
+        )
+    return "repair multi-tier fixture signal transport before paid Tencent validation"
 
 
 def multi_tier_activation_variant_row(result: JsonObject) -> JsonObject:

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1382,6 +1382,49 @@ cli:
         self.assertTrue(activation["observedEvidence"]["hostileCountReduced"])
         self.assertFalse(activation["observedEvidence"]["fixtureGeneratedRoomState"])
 
+    def test_multi_tier_policy_activation_projects_despite_nonfatal_evidence_warnings(self) -> None:
+        fixture_path = Path("scripts/fixtures/rl/multi-tier-territory-combat-v1.map.json")
+        fixture_summaries = harness._private_map_fixture_room_summaries(fixture_path)
+        tick_log = [
+            {"tick": 1, "rooms": {"E1S1": copy.deepcopy(fixture_summaries["E1S1"])}},
+            {"tick": 2, "rooms": {"E1S1": copy.deepcopy(fixture_summaries["E1S1"])}},
+        ]
+        for tick_entry in tick_log:
+            harness._merge_fixture_room_summaries_into_tick(tick_entry, fixture_summaries)
+        strategy_variant = {
+            "id": "construction-priority.pg.territory-seed.v1",
+            "parameters": {
+                "baseScoreWeight": 1,
+                "territorySignalWeight": 22,
+                "resourceSignalWeight": 3,
+                "killSignalWeight": 5,
+                "riskPenalty": 4,
+            },
+        }
+
+        activation = harness.build_multi_tier_policy_activation_evidence(
+            tick_log,
+            strategy_variant,
+            fixture_summaries,
+            anchor_room="E1S1",
+            evidence_errors=["mongo room evidence failed: no room document returned"],
+            allow_offline_projection=True,
+        )
+        projected_metrics = harness.project_multi_tier_policy_activation_metrics(
+            harness.build_variant_metrics(tick_log),
+            activation,
+        )
+
+        self.assertIsNotNone(activation)
+        assert activation is not None
+        self.assertEqual(activation["objectiveSignalSource"], "offline_shadow_projection")
+        self.assertEqual(activation["evidenceWarnings"], ["mongo room evidence failed: no room document returned"])
+        self.assertEqual(projected_metrics["hostileKills"], 1)
+        self.assertEqual(projected_metrics["policyActivation"]["hostileKillsSource"], "projectedEvidence")
+        self.assertFalse(activation["safety"]["liveEffect"])
+        self.assertFalse(activation["safety"]["officialMmoWrites"])
+        self.assertFalse(activation["safety"]["officialMmoWritesAllowed"])
+
     def test_multi_tier_policy_activation_projects_offline_hostile_engagement_metrics(self) -> None:
         fixture_path = Path("scripts/fixtures/rl/multi-tier-territory-combat-v0.map.json")
         fixture_summaries = harness._private_map_fixture_room_summaries(fixture_path)

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -1425,6 +1425,41 @@ cli:
         self.assertFalse(activation["safety"]["officialMmoWrites"])
         self.assertFalse(activation["safety"]["officialMmoWritesAllowed"])
 
+    def test_multi_tier_policy_activation_projects_with_null_evidence_errors(self) -> None:
+        fixture_path = Path("scripts/fixtures/rl/multi-tier-territory-combat-v1.map.json")
+        fixture_summaries = harness._private_map_fixture_room_summaries(fixture_path)
+        tick_log = [
+            {"tick": 1, "rooms": {"E1S1": copy.deepcopy(fixture_summaries["E1S1"])}},
+            {"tick": 2, "rooms": {"E1S1": copy.deepcopy(fixture_summaries["E1S1"])}},
+        ]
+        for tick_entry in tick_log:
+            harness._merge_fixture_room_summaries_into_tick(tick_entry, fixture_summaries)
+        strategy_variant = {
+            "id": "construction-priority.pg.territory-seed.v1",
+            "parameters": {
+                "baseScoreWeight": 1,
+                "territorySignalWeight": 22,
+                "resourceSignalWeight": 3,
+                "killSignalWeight": 5,
+                "riskPenalty": 4,
+            },
+        }
+
+        activation = harness.build_multi_tier_policy_activation_evidence(
+            tick_log,
+            strategy_variant,
+            fixture_summaries,
+            anchor_room="E1S1",
+            evidence_errors=None,
+            allow_offline_projection=True,
+        )
+
+        self.assertIsNotNone(activation)
+        assert activation is not None
+        self.assertEqual(activation["objectiveSignalSource"], "offline_shadow_projection")
+        self.assertIn("projectedEvidence", activation)
+        self.assertNotIn("evidenceWarnings", activation)
+
     def test_multi_tier_policy_activation_projects_offline_hostile_engagement_metrics(self) -> None:
         fixture_path = Path("scripts/fixtures/rl/multi-tier-territory-combat-v0.map.json")
         fixture_summaries = harness._private_map_fixture_room_summaries(fixture_path)

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -1076,7 +1076,7 @@ class RlTrainingRunnerTest(unittest.TestCase):
             code_commit="b" * 40,
             training_approach="policy_gradient",
             created_at="2026-05-18T10:26:30Z",
-            scenario_id=card_helper.MULTI_TIER_SCENARIO_ID,
+            scenario_id=card_helper.MULTI_TIER_SCENARIO_V0_ID,
             require_multi_tier_scenario=True,
         )
         simulator_results: dict[str, JsonObject] = {}
@@ -1117,6 +1117,7 @@ class RlTrainingRunnerTest(unittest.TestCase):
         self.assertEqual(territory_result["metrics"]["kills"]["ownLosses"], 4)
         self.assertTrue(territory_result["multiTierActivationSamples"][0]["passesActivation"])
         territory_trace = territory_result["multiTierActivationTraces"][0]
+        self.assertEqual(territory_trace["policyActivation"]["objectiveSignalSource"], "offline_shadow_projection")
         self.assertEqual(territory_trace["policyActivation"]["hostileKillsSource"], "projectedEvidence")
         self.assertEqual(
             territory_trace["evidenceWarnings"],

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -1070,6 +1070,62 @@ class RlTrainingRunnerTest(unittest.TestCase):
         self.assertFalse(report["officialMmoWrites"])
         self.assertFalse(report["officialMmoWritesAllowed"])
 
+    def test_multi_tier_activation_projection_tolerates_nonfatal_evidence_warnings(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-training-multitier-nonfatal-evidence-warning",
+            code_commit="b" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-18T10:26:30Z",
+            scenario_id=card_helper.MULTI_TIER_SCENARIO_ID,
+            require_multi_tier_scenario=True,
+        )
+        simulator_results: dict[str, JsonObject] = {}
+        for variant in card["strategy_variants"]:
+            variant_id = variant["id"]
+            result = variant_result(
+                variant_id,
+                [
+                    tick(1, [room("E1S1", spawns=1, creeps=1, rcl=3, energy=300)]),
+                    tick(2, [room("E1S1", spawns=1, creeps=1, rcl=3, energy=300)]),
+                ],
+            )
+            result["metrics"] = {"territoryDelta": 0, "hostileKills": 0, "ownLosses": 4}
+            result["evidenceErrors"] = ["mongo room evidence failed: no room document returned"]
+            simulator_results[variant_id] = result
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="multi-tier-projected-warning",
+                simulator_runner=MockSimulator(simulator_results),
+            )
+
+        proof = report["activationProof"]
+        self.assertEqual(proof["status"], "passed")
+        self.assertTrue(proof["ok"])
+        self.assertIn("construction-priority.pg.territory-seed.v1", proof["passingVariants"])
+        territory_result = next(
+            result
+            for result in report["variantResults"]
+            if result["variantId"] == "construction-priority.pg.territory-seed.v1"
+        )
+        self.assertEqual(territory_result["metrics"]["kills"]["hostileKills"], 1)
+        self.assertEqual(territory_result["metrics"]["kills"]["ownLosses"], 4)
+        self.assertTrue(territory_result["multiTierActivationSamples"][0]["passesActivation"])
+        territory_trace = territory_result["multiTierActivationTraces"][0]
+        self.assertEqual(territory_trace["policyActivation"]["hostileKillsSource"], "projectedEvidence")
+        self.assertEqual(
+            territory_trace["evidenceWarnings"],
+            ["mongo room evidence failed: no room document returned"],
+        )
+        self.assertFalse(report["liveEffect"])
+        self.assertFalse(report["officialMmoWrites"])
+        self.assertFalse(report["officialMmoWritesAllowed"])
+
     def test_multi_tier_activation_projection_reconstructs_metrics_only_runs(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-training-multitier-projected-metrics",


### PR DESCRIPTION
## Summary

- Allow multi-tier activation projection to tolerate nonfatal simulator evidence warnings while preserving the warning in activation traces.
- Keep paid-validation safety intact: outputs remain offline/shadow only and do not write to the official MMO.
- Add focused simulator harness and training runner tests for warning-preserving objective activation.

## Evidence

- Local degraded fallback report: `runtime-artifacts/rl-training/loop-a-degraded-fallback-20260601t2245z.json` classified `SIMULATOR_OBJECTIVE_SIGNAL_NOT_ACTIVATED` after nonfatal Mongo room evidence warnings prevented projected activation from being treated as valid.
- Commit: `9d1ebf0bbfc6017a64b5cc73b8a9d15656658fcb` by `lanyusea's bot <lanyusea@gmail.com>`.

## Verification

- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_simulator_harness.py scripts/test_screeps_rl_training_runner.py`
- `python3 -m unittest scripts.test_screeps_rl_simulator_harness scripts.test_screeps_rl_training_runner -v` — 321 tests OK

## Safety

- No official MMO writes.
- No paid Tencent run launched.
- No secrets printed.
- The patch only changes offline simulator/training activation evidence handling and tests.

## Universal task Done gate

- [x] Task type: code/test repair for RL simulator/training validation.
- [x] Expected observable outcome / named deliverable: nonfatal objective-activation evidence warnings are preserved without suppressing safe offline projected activation.
- [x] Non-goals / accepted substitutes: no paid Tencent validation, no official MMO deployment, no live policy rollout.
- [x] Verification evidence required before Done: controller ran diff check, py_compile, and targeted unittest suite with 321 tests OK.
- [x] Project Evidence / Next action / Blocked by: Project fields are updated by the steward/controller with commit, PR, verification, and next validation action.
- [x] Post-merge/deploy/runtime proof: offline script repair uses PR checks plus a follow-up local fallback report to prove activation classification changes; official deploy is out of scope.
- [x] Named deliverable proof: changed files `scripts/screeps_rl_simulator_harness.py`, `scripts/screeps_rl_training_runner.py`, and corresponding focused tests implement and verify warning-preserving activation evidence.

Related to issue #1566.
