### PR TITLE
fix: use container surplus for bounded construction

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3701,6 +3701,25 @@ function getStorageEnergyAvailableForWithdrawal(room, storage = getRoomStorage(r
   }
   return Math.max(0, storedEnergy - getStorageEnergyReserve(room));
 }
+function getRoomStoredEnergyAvailableForConstruction(room) {
+  var _a;
+  if (((_a = room.controller) == null ? void 0 : _a.my) !== true) {
+    return 0;
+  }
+  return findRoomStructures(room).reduce((total, structure) => {
+    const storedEnergy = getStoredEnergy(structure);
+    if (storedEnergy <= 0) {
+      return total;
+    }
+    if (matchesStructureType3(structure.structureType, "STRUCTURE_STORAGE", "storage")) {
+      return total + getStorageEnergyAvailableForWithdrawal(room, structure, storedEnergy);
+    }
+    if (matchesStructureType3(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType3(structure.structureType, "STRUCTURE_TERMINAL", "terminal")) {
+      return total + storedEnergy;
+    }
+    return total;
+  }, 0);
+}
 function getRoomEnergyBufferHealth(room) {
   const observation = getRoomSpawnExtensionEnergyObservation(room);
   const currentEnergy = observation.currentEnergy;
@@ -25340,7 +25359,7 @@ var MAX_HARVEST_PATH_OPS = 2e3;
 var LOW_LOAD_YIELD_SWITCH_MIN_IMPROVEMENT_RATIO = 1.1;
 var LOW_LOAD_YIELD_SWITCH_MIN_ABSOLUTE_GAIN = 0.25;
 var SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS = 2;
-var SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORAGE_SURPLUS = 300;
+var SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS = 300;
 var nearTermSpawnExtensionRefillReserveCache = null;
 var interRoomLiveTransferCandidateCache = null;
 var interRoomHaulReservationCache = null;
@@ -28077,7 +28096,7 @@ function hasSafeStoredEnergyForBoundedConstruction(creep) {
   if (hasSameRoomWorkerAssignedToTask(creep.room, creep, "build")) {
     return false;
   }
-  return getStorageEnergyAvailableForWithdrawal(creep.room) >= SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORAGE_SURPLUS;
+  return getRoomStoredEnergyAvailableForConstruction(creep.room) >= SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS;
 }
 function hasHealthyRoomEnergyBuffer(room) {
   const energyAvailable = getRoomEnergyAvailable10(room);
@@ -31506,7 +31525,7 @@ var RANGED_WORK_MOVE_RANGE = 3;
 var EXACT_POSITION_MOVE_RANGE = 0;
 var MIN_HAULER_DROPPED_ENERGY = 25;
 var SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS2 = 2;
-var SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORAGE_SURPLUS2 = 300;
+var SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS2 = 300;
 function runWorker(creep) {
   var _a, _b;
   if (runControllerSustainMovement(creep)) {
@@ -31934,7 +31953,7 @@ function hasSafeStoredEnergyForBoundedConstruction2(creep, selectedTask) {
   if (hasOtherSameRoomBuildAssignment(creep)) {
     return false;
   }
-  return getStorageEnergyAvailableForWithdrawal(creep.room) >= SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORAGE_SURPLUS2;
+  return getRoomStoredEnergyAvailableForConstruction(creep.room) >= SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS2;
 }
 function hasOtherSameRoomBuildAssignment(creep) {
   return getRoomOwnedCreeps2(creep.room).some((worker) => {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -23,7 +23,7 @@ import { canCreepPressureTerritoryController } from '../territory/territoryPlann
 import {
   getConstructionSpendingEnergyThreshold,
   getEffectiveRoomEnergyBufferThreshold,
-  getStorageEnergyAvailableForWithdrawal
+  getRoomStoredEnergyAvailableForConstruction
 } from '../economy/energyBuffer';
 import { getSpawnEnergyWithdrawalAmount, isSpawnEnergySource } from '../economy/spawnEnergyBuffer';
 import {
@@ -75,7 +75,7 @@ const RANGED_WORK_MOVE_RANGE = 3;
 const EXACT_POSITION_MOVE_RANGE = 0;
 const MIN_HAULER_DROPPED_ENERGY = 25;
 const SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS = 2;
-const SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORAGE_SURPLUS = 300;
+const SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS = 300;
 
 interface WorkerTaskSelectionNullLoopState {
   lastNullSelectionTick: number;
@@ -786,8 +786,8 @@ function hasSafeStoredEnergyForBoundedConstruction(
   }
 
   return (
-    getStorageEnergyAvailableForWithdrawal(creep.room) >=
-    SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORAGE_SURPLUS
+    getRoomStoredEnergyAvailableForConstruction(creep.room) >=
+    SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS
   );
 }
 

--- a/prod/src/economy/energyBuffer.ts
+++ b/prod/src/economy/energyBuffer.ts
@@ -30,7 +30,12 @@ export interface StorageWithdrawalOptions {
   allowBelowReserve?: boolean;
 }
 
-type StructureConstantGlobal = 'STRUCTURE_EXTENSION' | 'STRUCTURE_SPAWN' | 'STRUCTURE_STORAGE';
+type StructureConstantGlobal =
+  | 'STRUCTURE_CONTAINER'
+  | 'STRUCTURE_EXTENSION'
+  | 'STRUCTURE_SPAWN'
+  | 'STRUCTURE_STORAGE'
+  | 'STRUCTURE_TERMINAL';
 type FindConstantGlobal = 'FIND_MY_STRUCTURES' | 'FIND_STRUCTURES';
 
 interface EnergyObservation {
@@ -188,6 +193,35 @@ export function getStorageEnergyAvailableForWithdrawal(
   }
 
   return Math.max(0, storedEnergy - getStorageEnergyReserve(room));
+}
+
+export function getRoomStoredEnergyAvailableForConstruction(room: Room): number {
+  if (room.controller?.my !== true) {
+    return 0;
+  }
+
+  return findRoomStructures(room).reduce<number>((total, structure) => {
+    const storedEnergy = getStoredEnergy(structure);
+    if (storedEnergy <= 0) {
+      return total;
+    }
+
+    if (matchesStructureType(structure.structureType, 'STRUCTURE_STORAGE', 'storage')) {
+      return (
+        total +
+        getStorageEnergyAvailableForWithdrawal(room, structure as StructureStorage, storedEnergy)
+      );
+    }
+
+    if (
+      matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container') ||
+      matchesStructureType(structure.structureType, 'STRUCTURE_TERMINAL', 'terminal')
+    ) {
+      return total + storedEnergy;
+    }
+
+    return total;
+  }, 0);
 }
 
 export function getRoomEnergyBufferHealth(room: Room): EnergyBufferHealth {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -41,6 +41,7 @@ import {
   checkEnergyBufferForExtensionConstruction,
   getEffectiveRoomEnergyBufferThreshold,
   getConstructionSpendingEnergyThreshold,
+  getRoomStoredEnergyAvailableForConstruction,
   getStorageEnergyAvailableForWithdrawal,
   getStorageEnergyReserveThreshold,
   hasMinimumWorkerSpawnEnergyForConstruction,
@@ -152,7 +153,7 @@ const MAX_HARVEST_PATH_OPS = 2_000;
 const LOW_LOAD_YIELD_SWITCH_MIN_IMPROVEMENT_RATIO = 1.1;
 const LOW_LOAD_YIELD_SWITCH_MIN_ABSOLUTE_GAIN = 0.25;
 const SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS = 2;
-const SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORAGE_SURPLUS = 300;
+const SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS = 300;
 
 type RepairableWorkerStructure =
   | StructureRoad
@@ -4415,8 +4416,8 @@ function hasSafeStoredEnergyForBoundedConstruction(creep: Creep): boolean {
   }
 
   return (
-    getStorageEnergyAvailableForWithdrawal(creep.room) >=
-    SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORAGE_SURPLUS
+    getRoomStoredEnergyAvailableForConstruction(creep.room) >=
+    SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS
   );
 }
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -4462,6 +4462,134 @@ describe('runWorker', () => {
     expect(transfer).not.toHaveBeenCalled();
   });
 
+  it('keeps bounded container construction ahead of spawn reservation refill when container surplus protects recovery energy', () => {
+    const site = {
+      id: 'site1',
+      structureType: 'container',
+      progress: 0,
+      progressTotal: 4_500
+    } as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(250),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      }
+    } as unknown as StructureSpawn;
+    const storedContainer = {
+      id: 'stored-container1',
+      structureType: 'container',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 1_485 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) =>
+          resource === undefined || resource === RESOURCE_ENERGY ? 2_000 : 0
+        )
+      }
+    } as unknown as StructureContainer;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N57',
+      energyAvailable: 650,
+      energyCapacityAvailable: 1_800,
+      controller,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [spawn, storedContainer];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const transfer = jest.fn();
+    const creep = {
+      name: 'Builder',
+      memory: { role: 'worker', colony: 'E29N57' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      build,
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const reserveWorker = {
+      name: 'ReserveWorker',
+      memory: { role: 'worker', colony: 'E29N57' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, reserveWorker);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      economy: {
+        spawnEnergyReservation: {
+          updatedAt: 123,
+          rooms: {
+            E29N57: {
+              bodyCost: 800,
+              creepName: 'worker-E29N57-124',
+              reservedAt: 123,
+              reservedEnergy: 800,
+              role: 'worker',
+              roomName: 'E29N57',
+              updatedAt: 123
+            }
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Builder: creep, ReserveWorker: reserveWorker },
+      rooms: { E29N57: room },
+      time: 124,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'site1') {
+          return site;
+        }
+
+        if (id === 'spawn1') {
+          return spawn;
+        }
+
+        return id === 'stored-container1' ? storedContainer : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'site1' });
+    expect(creep.memory.workerDispatchDiagnostic?.spawnReservationTask).toBeUndefined();
+    expect(build).toHaveBeenCalledWith(site);
+    expect(transfer).not.toHaveBeenCalled();
+  });
+
   it('keeps spawn reservation refill protected when the room has only one worker', () => {
     const site = {
       id: 'site1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -12720,6 +12720,47 @@ describe('selectWorkerTask', () => {
     expect(selectedTask).toEqual({ type: 'build', targetId: 'wall-site1' });
   });
 
+  it('reserves a loaded worker for container construction when container surplus protects recovery energy', () => {
+    const site = {
+      id: 'source-container-site1',
+      structureType: 'container',
+      progress: 0,
+      progressTotal: 4_500
+    } as ConstructionSite;
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 50);
+    const storedContainer = makeStoredEnergyContainerWithCapacity('stored-container1', 1_485, 2_000);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N57',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 650,
+      energyCapacityAvailable: 1_800,
+      myStructures: [spawn as AnyOwnedStructure],
+      structures: [storedContainer as AnyStructure]
+    });
+    const builder = {
+      name: 'BuilderCandidate',
+      memory: { role: 'worker', colony: 'E29N57' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    const idleWorker = {
+      name: 'IdleWorker',
+      memory: { role: 'worker', colony: 'E29N57' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ BuilderCandidate: builder, IdleWorker: idleWorker });
+
+    expect(selectWorkerTask(builder)).toEqual({ type: 'build', targetId: 'source-container-site1' });
+  });
+
   it('does not count the current build-assigned worker as uncovered construction coverage', () => {
     const site = { id: 'wall-site1', structureType: 'constructedWall' } as ConstructionSite;
     const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 317, {


### PR DESCRIPTION
## Summary

- Allows remote/secondary rooms with safe stored energy to spend energy on construction instead of remaining blocked behind spawn-reservation behavior.
- Keeps emergency spawn and critical refill safeguards intact.
- Adds focused coverage for the E29N57-style room state and synchronizes the Screeps bundle artifact.

## Evidence

- Fresh runtime summary tick 1642008: E29N57 alive with `storedEnergy=1485`, `pendingBuildProgress=4500`, `buildCarriedEnergy=0`, and `taskCounts.build=0` after PR #1556 deployed.
- Commit: `c561b0f28896fecba06642d79e1ad74e831ac2f2` by `lanyusea's bot <lanyusea@gmail.com>`.

## Verification

- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 103 suites / 2146 tests passed
- `cd prod && npm run build`

## Safety

- No official MMO deploy performed by this PR.
- Generated `prod/dist/main.js` was updated through the build command.
- Emergency/no-creep spawn recovery and core energy safeguards remain in scope for the test gate.

## Universal task Done gate

- [x] Task type: production code/test repair for a practical gameplay bottleneck.
- [x] Expected observable outcome / named deliverable: E29N57-style stored-energy construction backlog can receive build work when spawn safety allows it.
- [x] Non-goals / accepted substitutes: no official MMO deploy in this PR, no expansion dispatch, no learned-policy rollout.
- [x] Verification evidence required before Done: controller ran diff check, prod typecheck, full Jest, and build; all passed.
- [x] Project Evidence / Next action / Blocked by: Project fields are updated by the steward/controller with commit, PR, verification, and post-merge acceptance action.
- [x] Post-merge/deploy/runtime proof: post-merge official deploy plus runtime summary must show E29N57 build activity or construction progress before issue closure.
- [x] Named deliverable proof: changed `prod/src/economy/energyBuffer.ts`, worker task/runner logic, focused tests, and rebuilt `prod/dist/main.js` implement the construction-energy unblock.

Related to issue #1553.
