### PR TITLE
fix(rl): surface full E1 gate report failures

### DIFF
--- a/scripts/screeps_rl_dataset_gate.py
+++ b/scripts/screeps_rl_dataset_gate.py
@@ -741,6 +741,63 @@ def official_mmo_control_forbidden(value: Any) -> bool:
     return value is False or (isinstance(value, str) and value.startswith("forbidden"))
 
 
+def dataset_source_diagnostics(
+    dataset_summary: JsonObject,
+    run_manifest: JsonObject,
+    *,
+    sample_count: int,
+    min_samples: int,
+) -> JsonObject:
+    source = run_manifest.get("source") if isinstance(run_manifest.get("source"), dict) else {}
+    input_paths = source.get("inputPaths") if isinstance(source.get("inputPaths"), list) else []
+    source_artifact_count = dataset_summary.get("sourceArtifactCount")
+    runtime_summary_count = dataset_summary.get("runtimeSummaryArtifactCount")
+    skipped_sample_count = dataset_summary.get("skippedSampleCount")
+    skipped_sample_reasons = dataset_summary.get("skippedSampleReasons")
+
+    if sample_count >= min_samples:
+        return {
+            "status": "pass",
+            "classification": "sample_floor_satisfied",
+            "inputPaths": input_paths,
+        }
+
+    if source_artifact_count == 0:
+        classification = "no_source_artifacts_scanned"
+        recommended_action = (
+            "Point the full E1 gate at runtime-summary source artifacts, such as "
+            "runtime-artifacts/runtime-summary-console, instead of an empty or generated gate-data directory."
+        )
+    elif runtime_summary_count == 0:
+        classification = "no_runtime_summary_artifacts"
+        recommended_action = (
+            "Use the same runtime-summary console source window that feeds the passing E1-lite gate; "
+            "generated gate-data and dataset directories are outputs, not full-gate input evidence."
+        )
+    elif isinstance(skipped_sample_count, int) and skipped_sample_count > 0 and sample_count == 0:
+        classification = "all_runtime_samples_filtered"
+        recommended_action = (
+            "Refresh or narrow the runtime-summary source window so the full gate has current samples "
+            "for the configured home room."
+        )
+    else:
+        classification = "insufficient_runtime_samples"
+        recommended_action = "Collect more current runtime-summary samples before treating the full E1 gate as fresh."
+
+    return {
+        "status": "blocked",
+        "classification": classification,
+        "recommendedAction": recommended_action,
+        "inputPaths": input_paths,
+        "scannedFiles": source.get("scannedFiles"),
+        "sourceArtifactCount": source_artifact_count,
+        "runtimeSummaryArtifactCount": runtime_summary_count,
+        "skippedFileCount": source.get("skippedFileCount"),
+        "skippedSampleCount": skipped_sample_count,
+        "skippedSampleReasons": skipped_sample_reasons,
+    }
+
+
 def evaluate_dataset_readiness(
     dataset_summary: JsonObject,
     file_paths: dict[str, Path],
@@ -750,6 +807,17 @@ def evaluate_dataset_readiness(
     min_samples: int,
 ) -> JsonObject:
     sample_count = int(dataset_summary.get("sampleCount", 0)) if isinstance(dataset_summary.get("sampleCount"), int) else 0
+    runtime_summary_count = (
+        int(dataset_summary.get("runtimeSummaryArtifactCount", 0))
+        if isinstance(dataset_summary.get("runtimeSummaryArtifactCount"), int)
+        else 0
+    )
+    diagnostics = dataset_source_diagnostics(
+        dataset_summary,
+        run_manifest,
+        sample_count=sample_count,
+        min_samples=min_samples,
+    )
     files_to_check = ("scenarioManifest", "runManifest", "sourceIndex", "ticks", "kpiWindows", "episodes", "datasetCard")
     checks: list[JsonObject] = [
         pass_fail_check(
@@ -765,6 +833,17 @@ def evaluate_dataset_readiness(
             actual=run_manifest.get("type"),
         ),
     ]
+    if sample_count < min_samples:
+        checks.append(
+            pass_fail_check(
+                "runtime_summary_artifacts_present",
+                runtime_summary_count > 0,
+                actual=runtime_summary_count,
+                required=">0",
+                classification=diagnostics.get("classification"),
+                recommendedAction=diagnostics.get("recommendedAction"),
+            )
+        )
     for key in files_to_check:
         checks.append(
             pass_fail_check(
@@ -797,6 +876,7 @@ def evaluate_dataset_readiness(
         "splitCounts": dataset_summary.get("splitCounts"),
         "runId": dataset_summary.get("runId"),
         "runDir": dataset_export.display_path(file_paths["runDir"]),
+        "diagnostics": diagnostics,
     }
 
 
@@ -1607,6 +1687,129 @@ def write_output(payload: JsonObject, output: Path | None, stdout: TextIO) -> No
     write_json_atomic(output, payload)
 
 
+def cli_failure_created_at(args: argparse.Namespace) -> str:
+    created_at = getattr(args, "created_at", None)
+    if isinstance(created_at, str) and parse_iso_utc_timestamp(created_at) is not None:
+        return created_at
+    return utc_now_iso()
+
+
+def cli_failure_gate_id(args: argparse.Namespace, repo: Path, created_at: str) -> str:
+    gate_id = getattr(args, "gate_id", None)
+    if isinstance(gate_id, str) and gate_id:
+        validate_gate_id(gate_id)
+        return gate_id
+    bot_commit = getattr(args, "bot_commit", None) or dataset_export.git_commit(repo)
+    return default_gate_id(
+        created_at=created_at,
+        input_paths=getattr(args, "paths", []),
+        candidate_config=getattr(args, "candidate_config", None),
+        baseline_kpi=getattr(args, "baseline_kpi", None),
+        current_kpi=getattr(args, "current_kpi", None),
+        bot_commit=bot_commit,
+    )
+
+
+def build_cli_failure_report(
+    args: argparse.Namespace,
+    error: Exception,
+    *,
+    repo: Path,
+    created_at: str,
+    gate_id: str,
+    gate_dir: Path,
+) -> JsonObject:
+    report_path = gate_dir / "gate_report.json"
+    summary_path = gate_dir / "gate_summary.json"
+    redacted_error = dataset_export.redact_text(str(error))
+    bot_commit = getattr(args, "bot_commit", None) or dataset_export.git_commit(repo)
+    input_paths = [
+        dataset_export.display_path(path)
+        for path in resolve_input_paths(getattr(args, "paths", []), repo)
+    ]
+    failure = {
+        "status": "fail",
+        "stage": "full_gate_execution",
+        "errorClass": error.__class__.__name__,
+        "error": redacted_error,
+        "recommendedAction": (
+            "Inspect this executionFailure block and rerun the full E1 gate after correcting the input "
+            "or configuration error. The CLI persists this report before returning non-zero so the "
+            "control loop does not treat the gate directory as silently empty."
+        ),
+    }
+    blocking_reason = {
+        "gate": "execution",
+        "name": "full_gate_execution",
+        "status": "fail",
+        "errorClass": failure["errorClass"],
+        "error": redacted_error,
+    }
+    return {
+        "ok": False,
+        "type": REPORT_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "gateId": gate_id,
+        "createdAt": created_at,
+        "owningIssue": "#409",
+        "mode": "candidate" if getattr(args, "candidate_config", None) is not None else "current-bot-behavior",
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+        "safety": safety_metadata(),
+        "input": {
+            "paths": input_paths,
+            "candidateConfig": dataset_export.display_path(getattr(args, "candidate_config", None))
+            if getattr(args, "candidate_config", None) is not None
+            else None,
+            "baselineKpi": dataset_export.display_path(getattr(args, "baseline_kpi", None))
+            if getattr(args, "baseline_kpi", None) is not None
+            else None,
+            "currentKpi": dataset_export.display_path(getattr(args, "current_kpi", None))
+            if getattr(args, "current_kpi", None) is not None
+            else None,
+            "botCommit": bot_commit,
+        },
+        "datasetGate": {
+            "status": "fail",
+            "checks": [
+                pass_fail_check(
+                    "gate_execution_completed",
+                    False,
+                    errorClass=failure["errorClass"],
+                    error=redacted_error,
+                )
+            ],
+        },
+        "executionFailure": failure,
+        "blockingReasons": [blocking_reason],
+        "outputs": {
+            "gateDir": dataset_export.display_path(gate_dir),
+            "reportPath": dataset_export.display_path(report_path),
+            "summaryPath": dataset_export.display_path(summary_path),
+        },
+        "reportPath": dataset_export.display_path(report_path),
+    }
+
+
+def persist_cli_failure_report(args: argparse.Namespace, error: Exception, stderr: TextIO) -> None:
+    if getattr(args, "command", None) != "run":
+        return
+    try:
+        repo = (getattr(args, "repo_root", None) or Path.cwd()).expanduser().resolve()
+        created_at = cli_failure_created_at(args)
+        gate_id = cli_failure_gate_id(args, repo, created_at)
+        out_dir = resolve_path_against_repo(getattr(args, "out_dir", DEFAULT_OUT_DIR), repo)
+        gate_dir = out_dir / gate_id
+        gate_dir.mkdir(parents=True, exist_ok=True)
+        report = build_cli_failure_report(args, error, repo=repo, created_at=created_at, gate_id=gate_id, gate_dir=gate_dir)
+        write_json_atomic(gate_dir / "gate_report.json", report)
+        write_json_atomic(gate_dir / "gate_summary.json", build_summary(report))
+        stderr.write(f"failure report: {dataset_export.display_path(gate_dir / 'gate_report.json')}\n")
+    except Exception as report_error:  # noqa: BLE001 - best-effort diagnostics must not hide the original error
+        stderr.write(f"warning: could not write failure report: {dataset_export.redact_text(str(report_error))}\n")
+
+
 def main(argv: list[str] | None = None, stdout: TextIO = sys.stdout, stderr: TextIO = sys.stderr) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -1653,9 +1856,11 @@ def main(argv: list[str] | None = None, stdout: TextIO = sys.stdout, stderr: Tex
 
         parser.error(f"unsupported command: {args.command}")
     except (DatasetGateError, conclusion_registry.ConclusionRegistryError) as error:
+        persist_cli_failure_report(args, error, stderr)
         stderr.write(f"error: {error}\n")
         return 2
     except (RuntimeError, OSError, mmo_validator.ValidationConfigError) as error:
+        persist_cli_failure_report(args, error, stderr)
         stderr.write(f"error: {dataset_export.redact_text(str(error))}\n")
         return 2
 

--- a/scripts/screeps_rl_dataset_gate.py
+++ b/scripts/screeps_rl_dataset_gate.py
@@ -1792,6 +1792,52 @@ def build_cli_failure_report(
     }
 
 
+def build_post_report_failure(error: Exception) -> JsonObject:
+    redacted_error = dataset_export.redact_text(str(error))
+    return {
+        "status": "fail",
+        "stage": "post_report_persistence",
+        "errorClass": error.__class__.__name__,
+        "error": redacted_error,
+        "recommendedAction": (
+            "The gate report was already written and has been preserved. Inspect this postReportFailure "
+            "block, correct the post-report persistence error, and rerun the full E1 gate if registry "
+            "or wrapper evidence must be refreshed."
+        ),
+    }
+
+
+def preserve_completed_gate_artifacts(report_path: Path, summary_path: Path, error: Exception, stderr: TextIO) -> bool:
+    if not report_path.exists() and not summary_path.exists():
+        return False
+
+    post_report_failure = build_post_report_failure(error)
+    preserved_paths: list[Path] = []
+    report: JsonObject | None = None
+
+    if report_path.exists():
+        report = load_json(report_path)
+        report["postReportFailure"] = post_report_failure
+        write_json_atomic(report_path, report)
+        preserved_paths.append(report_path)
+
+    if summary_path.exists():
+        summary = load_json(summary_path)
+    elif report is not None:
+        summary = build_summary(report)
+    else:
+        summary = None
+
+    if summary is not None:
+        summary["postReportFailure"] = post_report_failure
+        write_json_atomic(summary_path, summary)
+        preserved_paths.append(summary_path)
+
+    displayed_paths = ", ".join(dataset_export.display_path(path) for path in preserved_paths)
+    stderr.write(f"preserved completed gate artifacts after post-report failure: {displayed_paths}\n")
+    return True
+
+
 def persist_cli_failure_report(args: argparse.Namespace, error: Exception, stderr: TextIO) -> None:
     if getattr(args, "command", None) != "run":
         return
@@ -1802,10 +1848,14 @@ def persist_cli_failure_report(args: argparse.Namespace, error: Exception, stder
         out_dir = resolve_path_against_repo(getattr(args, "out_dir", DEFAULT_OUT_DIR), repo)
         gate_dir = out_dir / gate_id
         gate_dir.mkdir(parents=True, exist_ok=True)
+        report_path = gate_dir / "gate_report.json"
+        summary_path = gate_dir / "gate_summary.json"
+        if preserve_completed_gate_artifacts(report_path, summary_path, error, stderr):
+            return
         report = build_cli_failure_report(args, error, repo=repo, created_at=created_at, gate_id=gate_id, gate_dir=gate_dir)
-        write_json_atomic(gate_dir / "gate_report.json", report)
-        write_json_atomic(gate_dir / "gate_summary.json", build_summary(report))
-        stderr.write(f"failure report: {dataset_export.display_path(gate_dir / 'gate_report.json')}\n")
+        write_json_atomic(report_path, report)
+        write_json_atomic(summary_path, build_summary(report))
+        stderr.write(f"failure report: {dataset_export.display_path(report_path)}\n")
     except Exception as report_error:  # noqa: BLE001 - best-effort diagnostics must not hide the original error
         stderr.write(f"warning: could not write failure report: {dataset_export.redact_text(str(report_error))}\n")
 

--- a/scripts/test_screeps_rl_dataset_gate.py
+++ b/scripts/test_screeps_rl_dataset_gate.py
@@ -712,6 +712,64 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
         self.assertIn("simulated full gate dataset failure", report["executionFailure"]["error"])
         self.assertEqual(report["datasetGate"]["status"], "fail")
         self.assertEqual(summary["blockingReasons"][0]["gate"], "execution")
+        self.assertNotIn("postReportFailure", report)
+
+    def test_cli_preserves_completed_gate_artifacts_when_post_report_registry_update_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            control_loop = artifact_root / "rl-control-loop"
+            registry_path = control_loop / "conclusion-registry.json"
+            registry_path.parent.mkdir(parents=True, exist_ok=True)
+            registry_path.write_text("{not valid json", encoding="utf-8")
+            artifact = root / "runtime.log"
+            artifact.write_text(runtime_line(runtime_payload(100)), encoding="utf-8")
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+
+            exit_code = gate.main(
+                [
+                    "run",
+                    str(artifact),
+                    "--out-dir",
+                    str(control_loop / "gate-data"),
+                    "--gate-id",
+                    "gate-registry-crash",
+                    "--created-at",
+                    "2026-05-23T00:00:00Z",
+                    "--dataset-out-dir",
+                    str(artifact_root / "rl-datasets"),
+                    "--skip-shadow-report",
+                    "--bot-commit",
+                    "c" * 40,
+                    "--eval-ratio",
+                    "0",
+                    "--repo-root",
+                    str(root),
+                ],
+                stdout=stdout,
+                stderr=stderr,
+            )
+
+            report_path = control_loop / "gate-data" / "gate-registry-crash" / "gate_report.json"
+            summary_path = control_loop / "gate-data" / "gate-registry-crash" / "gate_summary.json"
+            report = read_json(report_path)
+            summary = read_json(summary_path)
+
+        self.assertEqual(exit_code, 2)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("preserved completed gate artifacts", stderr.getvalue())
+        self.assertIn("not valid JSON", stderr.getvalue())
+        self.assertNotIn("failure report:", stderr.getvalue())
+        self.assertNotIn("executionFailure", report)
+        self.assertIn("dataset", report)
+        self.assertIn("quality_checks", report)
+        self.assertEqual(summary["datasetRunId"], report["dataset"]["runId"])
+        self.assertEqual(summary["sampleCount"], report["datasetGate"]["sampleCount"])
+        self.assertEqual(report["postReportFailure"]["stage"], "post_report_persistence")
+        self.assertEqual(report["postReportFailure"]["errorClass"], "ConclusionRegistryError")
+        self.assertIn("not valid JSON", report["postReportFailure"]["error"])
+        self.assertEqual(summary["postReportFailure"], report["postReportFailure"])
 
     def test_gate_data_out_dir_merges_e1_conclusions_without_dropping_loop_b_records(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_dataset_gate.py
+++ b/scripts/test_screeps_rl_dataset_gate.py
@@ -278,6 +278,45 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
             self.assertEqual(baseline_metrics[metric]["target"], expected_value)
         self.assertFalse(rollout_decision_exists)
 
+    def test_empty_full_gate_input_reports_actionable_source_diagnostics(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            generated_gate_data = root / "runtime-artifacts" / "rl-control-loop" / "gate-data" / "rl-empty"
+            generated_gate_data.mkdir(parents=True)
+            write_json(generated_gate_data / "gate_summary.json", {"type": "not-a-runtime-summary"})
+
+            report = gate.run_gate(
+                [str(generated_gate_data)],
+                out_dir=root / "gates",
+                gate_id="gate-empty-input",
+                created_at="2026-05-31T02:19:40Z",
+                dataset_out_dir=root / "datasets",
+                skip_shadow_report=True,
+                bot_commit="a" * 40,
+                eval_ratio_value=0,
+                repo_root=root,
+            )
+            saved_report = read_json(root / "gates" / "gate-empty-input" / "gate_report.json")
+
+        self.assertFalse(report["ok"])
+        self.assertFalse(saved_report["ok"])
+        self.assertEqual(report["datasetGate"]["sampleCount"], 0)
+        diagnostics = report["datasetGate"]["diagnostics"]
+        self.assertEqual(diagnostics["status"], "blocked")
+        self.assertEqual(diagnostics["classification"], "no_runtime_summary_artifacts")
+        self.assertIn("runtime-summary console", diagnostics["recommendedAction"])
+        self.assertEqual(diagnostics["runtimeSummaryArtifactCount"], 0)
+        failed_checks = {
+            check["name"]: check
+            for check in report["datasetGate"]["checks"]
+            if check["status"] == "fail"
+        }
+        self.assertIn("minimum_samples", failed_checks)
+        self.assertEqual(
+            failed_checks["runtime_summary_artifacts_present"]["classification"],
+            "no_runtime_summary_artifacts",
+        )
+
     def test_run_rejects_dead_room_dataset_samples(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -624,6 +663,55 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
         self.assertEqual(report["quality_checks"]["home_room"], "W1N1")
         self.assertEqual(report["quality_checks"]["samples_rejected"], 1)
         self.assertIn("no_owned_spawns", report["quality_checks"]["rejection_reasons"])
+
+    def test_cli_persists_failure_report_when_full_gate_errors_before_report_write(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact = root / "runtime.log"
+            artifact.write_text(runtime_line(runtime_payload(100)), encoding="utf-8")
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+
+            with mock.patch.object(
+                gate.dataset_export,
+                "build_dataset",
+                side_effect=RuntimeError("simulated full gate dataset failure"),
+            ):
+                exit_code = gate.main(
+                    [
+                        "run",
+                        str(artifact),
+                        "--out-dir",
+                        str(root / "gates"),
+                        "--gate-id",
+                        "gate-dataset-crash",
+                        "--dataset-out-dir",
+                        str(root / "datasets"),
+                        "--skip-shadow-report",
+                        "--bot-commit",
+                        "b" * 40,
+                        "--eval-ratio",
+                        "0",
+                    ],
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+
+            report_path = root / "gates" / "gate-dataset-crash" / "gate_report.json"
+            summary_path = root / "gates" / "gate-dataset-crash" / "gate_summary.json"
+            report = read_json(report_path)
+            summary = read_json(summary_path)
+
+        self.assertEqual(exit_code, 2)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("failure report:", stderr.getvalue())
+        self.assertIn("simulated full gate dataset failure", stderr.getvalue())
+        self.assertFalse(report["ok"])
+        self.assertEqual(report["executionFailure"]["stage"], "full_gate_execution")
+        self.assertEqual(report["executionFailure"]["errorClass"], "RuntimeError")
+        self.assertIn("simulated full gate dataset failure", report["executionFailure"]["error"])
+        self.assertEqual(report["datasetGate"]["status"], "fail")
+        self.assertEqual(summary["blockingReasons"][0]["gate"], "execution")
 
     def test_gate_data_out_dir_merges_e1_conclusions_without_dropping_loop_b_records(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

- Surface full E1 dataset-gate execution failures as persisted `gate_report.json` / `gate_summary.json` artifacts instead of leaving an empty gate directory.
- Add dataset diagnostics for zero runtime-summary artifacts so lite/full gate drift becomes actionable.
- Add regression tests for both no-runtime-summary diagnostics and pre-report execution failure persistence.

## Evidence

- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_dataset_gate.py scripts/test_screeps_rl_dataset_gate.py`
- `python3 -m unittest scripts.test_screeps_rl_dataset_gate -v` — 19 tests OK

Related issue: 1569.

## Universal task Done gate

- [x] Task type: code.
- [x] Expected observable outcome / named deliverable: full E1 gate failures now produce machine-readable failure reports and summaries with actionable diagnostics.
- [x] Non-goals / accepted substitutes: no paid Tencent compute, no official MMO writes, and no production bot deploy from this scripts-only change.
- [x] Verification evidence required before Done: diff-check, Python compile, and `scripts.test_screeps_rl_dataset_gate` all passed locally before PR creation.
- [x] Project Evidence / Next action / Blocked by: issue 1569 Project item records Codex commit `457f646`, local verification, and the post-merge Loop A consumption action.
- [x] Post-merge/deploy/runtime proof: official deploy is not applicable; Loop A full-gate execution on main will consume the new persisted failure-report surface.
- [x] Named deliverable proof: commit `457f646` changes `scripts/screeps_rl_dataset_gate.py` and `scripts/test_screeps_rl_dataset_gate.py` only.
