### PR TITLE
fix: release surplus energy for blocked builders

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -31946,7 +31946,12 @@ function hasSafeStoredEnergyForBoundedConstruction2(creep, selectedTask) {
   if ((selectedTask == null ? void 0 : selectedTask.type) !== "build") {
     return false;
   }
-  if (!checkEnergyBufferForStoredConstructionSpending(creep.room)) {
+  const energyAvailable = getRoomEnergyAvailable12(creep.room);
+  if (energyAvailable === null || energyAvailable < MINIMUM_WORKER_SPAWN_ENERGY) {
+    return false;
+  }
+  const storedEnergy = getRoomStoredEnergyAvailableForConstruction(creep.room);
+  if (storedEnergy < CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY) {
     return false;
   }
   const sameRoomWorkers = getRoomOwnedCreeps2(creep.room).filter(
@@ -31958,7 +31963,7 @@ function hasSafeStoredEnergyForBoundedConstruction2(creep, selectedTask) {
   if (hasOtherSameRoomBuildAssignment(creep)) {
     return false;
   }
-  return getRoomStoredEnergyAvailableForConstruction(creep.room) >= SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS2;
+  return storedEnergy >= SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS2;
 }
 function hasOtherSameRoomBuildAssignment(creep) {
   return getRoomOwnedCreeps2(creep.room).some((worker) => {
@@ -39016,7 +39021,8 @@ function selectWorkerAssignmentBlockedDetail(colony, colonyWorkers, roomEnergySt
     return "no_valid_body";
   }
   const energyBuffer = getRoomEnergyBufferHealth(colony.room);
-  if ((!energyBuffer.healthy || energyBuffer.currentEnergy < energyBuffer.threshold) && !checkEnergyBufferForStoredConstructionSpending(colony.room)) {
+  const allowsStoredConstructionSpending = checkEnergyBufferForStoredConstructionSpending(colony.room);
+  if ((!energyBuffer.healthy || energyBuffer.currentEnergy < energyBuffer.threshold) && !allowsStoredConstructionSpending) {
     return "energy_buffer_below_threshold";
   }
   if (hasCarriedEnergyWorkerBlockedByConstructionEnergyMargin(colony.room, colonyWorkers, constructionSites)) {
@@ -39025,7 +39031,7 @@ function selectWorkerAssignmentBlockedDetail(colony, colonyWorkers, roomEnergySt
   if (colonyWorkers.every((worker) => getFreeEnergyCapacityInStore(worker) <= 0)) {
     return "room_capacity_full";
   }
-  if (hasSpawnReservedConstructionEnergy(colony, roomEnergyStructures, energyBuffer)) {
+  if (!allowsStoredConstructionSpending && hasSpawnReservedConstructionEnergy(colony, roomEnergyStructures, energyBuffer)) {
     return "spawn_reserving_energy";
   }
   return "unknown";

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3653,6 +3653,13 @@ function checkEnergyBufferForConstructionSpending(room) {
   }
   return observation.currentEnergy >= getConstructionSpendingEnergyThreshold(room);
 }
+function checkEnergyBufferForStoredConstructionSpending(room) {
+  const observation = getRoomSpawnExtensionEnergyObservation(room);
+  if (!observation.known) {
+    return false;
+  }
+  return observation.currentEnergy >= MINIMUM_WORKER_SPAWN_ENERGY && getRoomStoredEnergyAvailableForConstruction(room) >= CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY;
+}
 function checkEnergyBufferForCapacityEnablingConstruction(room, amount) {
   if (checkEnergyBufferForSpending(room, amount)) {
     return true;
@@ -27631,7 +27638,7 @@ function canSpendWorkerEnergyOnConstructionSite(creep, site) {
 }
 function canSpendCreepEnergyOnConstructionSite(creep, site, priorityContext) {
   const carriedEnergy = getUsedEnergy2(creep);
-  return carriedEnergy > 0 && isMissingSpawnRecoveryConstructionSite(creep.room, site) || carriedEnergy > 0 && checkEnergyBufferForConstructionSpending(creep.room) || carriedEnergy > 0 && isExtensionConstructionSite(site) && checkEnergyBufferForExtensionConstruction(creep.room, carriedEnergy) || carriedEnergy > 0 && !isExtensionConstructionSite(site) && isCapacityEnablingConstructionSite(site, priorityContext) && checkEnergyBufferForCapacityEnablingConstruction(creep.room, carriedEnergy) || carriedEnergy > 0 && canCompleteConstructionSiteWithCarriedEnergy(creep, site) || carriedEnergy > 0 && isLowWorkerThroughputRecoveryConstructionAllowed(creep, site) || carriedEnergy > 0 && hasMinimumWorkerSpawnEnergyForConstruction(creep.room) && isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext);
+  return carriedEnergy > 0 && isMissingSpawnRecoveryConstructionSite(creep.room, site) || carriedEnergy > 0 && checkEnergyBufferForConstructionSpending(creep.room) || carriedEnergy > 0 && checkEnergyBufferForStoredConstructionSpending(creep.room) || carriedEnergy > 0 && isExtensionConstructionSite(site) && checkEnergyBufferForExtensionConstruction(creep.room, carriedEnergy) || carriedEnergy > 0 && !isExtensionConstructionSite(site) && isCapacityEnablingConstructionSite(site, priorityContext) && checkEnergyBufferForCapacityEnablingConstruction(creep.room, carriedEnergy) || carriedEnergy > 0 && canCompleteConstructionSiteWithCarriedEnergy(creep, site) || carriedEnergy > 0 && isLowWorkerThroughputRecoveryConstructionAllowed(creep, site) || carriedEnergy > 0 && hasMinimumWorkerSpawnEnergyForConstruction(creep.room) && isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext);
 }
 function isLowWorkerThroughputRecoveryConstructionAllowed(creep, site) {
   return site.my !== false && hasLowWorkerThroughputRecoveryPressure(creep);
@@ -28083,8 +28090,7 @@ function shouldDeferIdleSpawnExtensionRefillForBoundedConstruction(creep, spawnO
   return spawnOrExtensionEnergySink !== null && !hasActiveSpawningSpawn(creep.room) && constructionSites.length > 0 && hasSafeStoredEnergyForBoundedConstruction(creep);
 }
 function hasSafeStoredEnergyForBoundedConstruction(creep) {
-  const energyAvailable = getRoomEnergyAvailable10(creep.room);
-  if (energyAvailable === null || energyAvailable < getConstructionSpendingEnergyThreshold(creep.room)) {
+  if (!checkEnergyBufferForStoredConstructionSpending(creep.room)) {
     return false;
   }
   const sameRoomWorkers = getRoomOwnedCreeps(creep.room).filter(
@@ -31940,8 +31946,7 @@ function hasSafeStoredEnergyForBoundedConstruction2(creep, selectedTask) {
   if ((selectedTask == null ? void 0 : selectedTask.type) !== "build") {
     return false;
   }
-  const energyAvailable = getRoomEnergyAvailable12(creep.room);
-  if (energyAvailable === null || energyAvailable < getConstructionSpendingEnergyThreshold(creep.room)) {
+  if (!checkEnergyBufferForStoredConstructionSpending(creep.room)) {
     return false;
   }
   const sameRoomWorkers = getRoomOwnedCreeps2(creep.room).filter(
@@ -39011,7 +39016,7 @@ function selectWorkerAssignmentBlockedDetail(colony, colonyWorkers, roomEnergySt
     return "no_valid_body";
   }
   const energyBuffer = getRoomEnergyBufferHealth(colony.room);
-  if (!energyBuffer.healthy || energyBuffer.currentEnergy < energyBuffer.threshold) {
+  if ((!energyBuffer.healthy || energyBuffer.currentEnergy < energyBuffer.threshold) && !checkEnergyBufferForStoredConstructionSpending(colony.room)) {
     return "energy_buffer_below_threshold";
   }
   if (hasCarriedEnergyWorkerBlockedByConstructionEnergyMargin(colony.room, colonyWorkers, constructionSites)) {
@@ -39107,6 +39112,9 @@ function canSpendWorkerEnergyOnAnyConstructionSiteForTelemetry(room, carriedEner
   return constructionSites.some((site) => canSpendWorkerEnergyOnConstructionSiteForTelemetry(room, carriedEnergy, site));
 }
 function canSpendWorkerEnergyOnConstructionSiteForTelemetry(room, carriedEnergy, constructionSite) {
+  if (checkEnergyBufferForStoredConstructionSpending(room)) {
+    return true;
+  }
   if (!isRecord30(constructionSite)) {
     return checkEnergyBufferForConstructionSpending(room);
   }
@@ -39237,6 +39245,9 @@ function isBuildBlockedByEnergyBuffer(colony, assignedCarriedEnergy) {
   const energyAvailable = getRoomEnergyAvailable13(colony);
   if (energyAvailable <= 0) {
     return true;
+  }
+  if (checkEnergyBufferForStoredConstructionSpending(colony.room)) {
+    return false;
   }
   const buffer = getRoomEnergyBufferHealth(colony.room);
   return buffer.healthy === false && buffer.currentEnergy < buffer.threshold && assignedCarriedEnergy <= 0;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -21,6 +21,7 @@ import {
 import { runUpgrader } from './upgraderRunner';
 import { canCreepPressureTerritoryController } from '../territory/territoryPlanner';
 import {
+  checkEnergyBufferForStoredConstructionSpending,
   getConstructionSpendingEnergyThreshold,
   getEffectiveRoomEnergyBufferThreshold,
   getRoomStoredEnergyAvailableForConstruction
@@ -766,11 +767,7 @@ function hasSafeStoredEnergyForBoundedConstruction(
     return false;
   }
 
-  const energyAvailable = getRoomEnergyAvailable(creep.room);
-  if (
-    energyAvailable === null ||
-    energyAvailable < getConstructionSpendingEnergyThreshold(creep.room)
-  ) {
+  if (!checkEnergyBufferForStoredConstructionSpending(creep.room)) {
     return false;
   }
 

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -21,10 +21,11 @@ import {
 import { runUpgrader } from './upgraderRunner';
 import { canCreepPressureTerritoryController } from '../territory/territoryPlanner';
 import {
-  checkEnergyBufferForStoredConstructionSpending,
+  CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY,
   getConstructionSpendingEnergyThreshold,
   getEffectiveRoomEnergyBufferThreshold,
-  getRoomStoredEnergyAvailableForConstruction
+  getRoomStoredEnergyAvailableForConstruction,
+  MINIMUM_WORKER_SPAWN_ENERGY
 } from '../economy/energyBuffer';
 import { getSpawnEnergyWithdrawalAmount, isSpawnEnergySource } from '../economy/spawnEnergyBuffer';
 import {
@@ -767,7 +768,13 @@ function hasSafeStoredEnergyForBoundedConstruction(
     return false;
   }
 
-  if (!checkEnergyBufferForStoredConstructionSpending(creep.room)) {
+  const energyAvailable = getRoomEnergyAvailable(creep.room);
+  if (energyAvailable === null || energyAvailable < MINIMUM_WORKER_SPAWN_ENERGY) {
+    return false;
+  }
+
+  const storedEnergy = getRoomStoredEnergyAvailableForConstruction(creep.room);
+  if (storedEnergy < CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY) {
     return false;
   }
 
@@ -782,10 +789,7 @@ function hasSafeStoredEnergyForBoundedConstruction(
     return false;
   }
 
-  return (
-    getRoomStoredEnergyAvailableForConstruction(creep.room) >=
-    SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS
-  );
+  return storedEnergy >= SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS;
 }
 
 function hasOtherSameRoomBuildAssignment(creep: Creep): boolean {

--- a/prod/src/economy/energyBuffer.ts
+++ b/prod/src/economy/energyBuffer.ts
@@ -114,6 +114,18 @@ export function checkEnergyBufferForConstructionSpending(room: Room): boolean {
   return observation.currentEnergy >= getConstructionSpendingEnergyThreshold(room);
 }
 
+export function checkEnergyBufferForStoredConstructionSpending(room: Room): boolean {
+  const observation = getRoomSpawnExtensionEnergyObservation(room);
+  if (!observation.known) {
+    return false;
+  }
+
+  return (
+    observation.currentEnergy >= MINIMUM_WORKER_SPAWN_ENERGY &&
+    getRoomStoredEnergyAvailableForConstruction(room) >= CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY
+  );
+}
+
 export function checkEnergyBufferForCapacityEnablingConstruction(room: Room, amount: number): boolean {
   if (checkEnergyBufferForSpending(room, amount)) {
     return true;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -39,6 +39,7 @@ import {
   checkEnergyBufferForCapacityEnablingConstruction,
   checkEnergyBufferForConstructionSpending,
   checkEnergyBufferForExtensionConstruction,
+  checkEnergyBufferForStoredConstructionSpending,
   getEffectiveRoomEnergyBufferThreshold,
   getConstructionSpendingEnergyThreshold,
   getRoomStoredEnergyAvailableForConstruction,
@@ -3649,6 +3650,7 @@ function canSpendCreepEnergyOnConstructionSite(
   return (
     (carriedEnergy > 0 && isMissingSpawnRecoveryConstructionSite(creep.room, site)) ||
     (carriedEnergy > 0 && checkEnergyBufferForConstructionSpending(creep.room)) ||
+    (carriedEnergy > 0 && checkEnergyBufferForStoredConstructionSpending(creep.room)) ||
     (carriedEnergy > 0 &&
       isExtensionConstructionSite(site) &&
       checkEnergyBufferForExtensionConstruction(creep.room, carriedEnergy)) ||
@@ -4396,11 +4398,7 @@ function shouldDeferIdleSpawnExtensionRefillForBoundedConstruction(
 }
 
 function hasSafeStoredEnergyForBoundedConstruction(creep: Creep): boolean {
-  const energyAvailable = getRoomEnergyAvailable(creep.room);
-  if (
-    energyAvailable === null ||
-    energyAvailable < getConstructionSpendingEnergyThreshold(creep.room)
-  ) {
+  if (!checkEnergyBufferForStoredConstructionSpending(creep.room)) {
     return false;
   }
 

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -45,6 +45,7 @@ import {
   checkEnergyBufferForCapacityEnablingConstruction,
   checkEnergyBufferForConstructionSpending,
   checkEnergyBufferForExtensionConstruction,
+  checkEnergyBufferForStoredConstructionSpending,
   getRoomEnergyBufferHealth,
   type EnergyBufferHealth
 } from '../economy/energyBuffer';
@@ -2551,7 +2552,10 @@ function selectWorkerAssignmentBlockedDetail(
   }
 
   const energyBuffer = getRoomEnergyBufferHealth(colony.room);
-  if (!energyBuffer.healthy || energyBuffer.currentEnergy < energyBuffer.threshold) {
+  if (
+    (!energyBuffer.healthy || energyBuffer.currentEnergy < energyBuffer.threshold) &&
+    !checkEnergyBufferForStoredConstructionSpending(colony.room)
+  ) {
     return 'energy_buffer_below_threshold';
   }
 
@@ -2705,6 +2709,10 @@ function canSpendWorkerEnergyOnConstructionSiteForTelemetry(
   carriedEnergy: number,
   constructionSite: unknown
 ): boolean {
+  if (checkEnergyBufferForStoredConstructionSpending(room)) {
+    return true;
+  }
+
   if (!isRecord(constructionSite)) {
     return checkEnergyBufferForConstructionSpending(room);
   }
@@ -2884,6 +2892,10 @@ function isBuildBlockedByEnergyBuffer(colony: ColonySnapshot, assignedCarriedEne
   const energyAvailable = getRoomEnergyAvailable(colony);
   if (energyAvailable <= 0) {
     return true;
+  }
+
+  if (checkEnergyBufferForStoredConstructionSpending(colony.room)) {
+    return false;
   }
 
   const buffer = getRoomEnergyBufferHealth(colony.room);

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -2552,9 +2552,10 @@ function selectWorkerAssignmentBlockedDetail(
   }
 
   const energyBuffer = getRoomEnergyBufferHealth(colony.room);
+  const allowsStoredConstructionSpending = checkEnergyBufferForStoredConstructionSpending(colony.room);
   if (
     (!energyBuffer.healthy || energyBuffer.currentEnergy < energyBuffer.threshold) &&
-    !checkEnergyBufferForStoredConstructionSpending(colony.room)
+    !allowsStoredConstructionSpending
   ) {
     return 'energy_buffer_below_threshold';
   }
@@ -2567,7 +2568,10 @@ function selectWorkerAssignmentBlockedDetail(
     return 'room_capacity_full';
   }
 
-  if (hasSpawnReservedConstructionEnergy(colony, roomEnergyStructures, energyBuffer)) {
+  if (
+    !allowsStoredConstructionSpending &&
+    hasSpawnReservedConstructionEnergy(colony, roomEnergyStructures, energyBuffer)
+  ) {
     return 'spawn_reserving_energy';
   }
 

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -1325,6 +1325,55 @@ describe('runtime telemetry summaries', () => {
     );
   });
 
+  it('does not report an energy-buffer construction block when E29N57 has stored energy for build work', () => {
+    const spawn = {
+      id: 'spawn1',
+      name: 'Spawn1',
+      structureType: TEST_GLOBALS.STRUCTURE_SPAWN,
+      store: makeEnergyStore(250, 300)
+    };
+    const storedContainer = {
+      id: 'stored-container1',
+      structureType: TEST_GLOBALS.STRUCTURE_CONTAINER,
+      store: makeEnergyStore(2_069, 2_000)
+    };
+    const worker = {
+      name: 'StoredEnergyBuilder',
+      memory: { role: 'worker', colony: 'E29N57' },
+      store: makeEnergyStore(30, 50),
+      getActiveBodyparts: jest.fn().mockReturnValue(1)
+    } as unknown as Creep;
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      roomName: 'E29N57',
+      includeEventLog: false,
+      structures: [spawn, storedContainer],
+      creeps: [worker],
+      constructionSites: [
+        { id: 'container-site', structureType: TEST_GLOBALS.STRUCTURE_CONTAINER, progress: 500, progressTotal: 5_000 }
+      ]
+    });
+    (colony.room as Room & { energyAvailable: number; energyCapacityAvailable: number }).energyAvailable = 250;
+    (colony.room as Room & { energyAvailable: number; energyCapacityAvailable: number }).energyCapacityAvailable = 1_800;
+    (colony.room.controller as StructureController).level = 5;
+    colony.energyAvailable = 250;
+    colony.energyCapacityAvailable = 1_800;
+
+    emitRuntimeSummary([colony], [worker]);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    const productiveEnergy = (room.resources as Record<string, Record<string, unknown>>).productiveEnergy;
+    expect(productiveEnergy.buildBlockedReason).toBe('worker_assignment_gap');
+    expect(productiveEnergy.workerAssignmentBlockedDetail).toBe('unknown');
+    const [blockedWorker] = productiveEnergy.workerAssignmentBlockedWorkers as Array<Record<string, unknown>>;
+    expect(blockedWorker).toMatchObject({
+      name: 'StoredEnergyBuilder',
+      buildBlockedReason: 'build_blocked_unknown'
+    });
+    expect(blockedWorker).not.toHaveProperty('constructionEnergyGate');
+  });
+
   it('marks zero assigned worker tasks as authoritative runtime evidence', () => {
     const colony = makeColony({
       time: RUNTIME_SUMMARY_INTERVAL,

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -1325,17 +1325,27 @@ describe('runtime telemetry summaries', () => {
     );
   });
 
-  it('does not report an energy-buffer construction block when E29N57 has stored energy for build work', () => {
+  it('does not report an energy-buffer or spawn-reservation construction block when E29N57 has stored energy for build work', () => {
     const spawn = {
       id: 'spawn1',
       name: 'Spawn1',
       structureType: TEST_GLOBALS.STRUCTURE_SPAWN,
-      store: makeEnergyStore(250, 300)
+      store: makeEnergyStore(300, 300)
     };
+    const extensions = Array.from({ length: 30 }, (_, index) => ({
+      id: `extension${index + 1}`,
+      structureType: TEST_GLOBALS.STRUCTURE_EXTENSION,
+      store: makeEnergyStore(index < 11 ? 50 : 0, 50)
+    }));
     const storedContainer = {
       id: 'stored-container1',
       structureType: TEST_GLOBALS.STRUCTURE_CONTAINER,
-      store: makeEnergyStore(2_069, 2_000)
+      store: makeEnergyStore(2_000, 2_000)
+    };
+    const storage = {
+      id: 'storage1',
+      structureType: TEST_GLOBALS.STRUCTURE_STORAGE,
+      store: makeEnergyStore(69, 10_000)
     };
     const worker = {
       name: 'StoredEnergyBuilder',
@@ -1347,16 +1357,16 @@ describe('runtime telemetry summaries', () => {
       time: RUNTIME_SUMMARY_INTERVAL,
       roomName: 'E29N57',
       includeEventLog: false,
-      structures: [spawn, storedContainer],
+      structures: [spawn, ...extensions, storedContainer, storage],
       creeps: [worker],
       constructionSites: [
         { id: 'container-site', structureType: TEST_GLOBALS.STRUCTURE_CONTAINER, progress: 500, progressTotal: 5_000 }
       ]
     });
-    (colony.room as Room & { energyAvailable: number; energyCapacityAvailable: number }).energyAvailable = 250;
+    (colony.room as Room & { energyAvailable: number; energyCapacityAvailable: number }).energyAvailable = 850;
     (colony.room as Room & { energyAvailable: number; energyCapacityAvailable: number }).energyCapacityAvailable = 1_800;
     (colony.room.controller as StructureController).level = 5;
-    colony.energyAvailable = 250;
+    colony.energyAvailable = 850;
     colony.energyCapacityAvailable = 1_800;
 
     emitRuntimeSummary([colony], [worker]);

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -4590,6 +4590,134 @@ describe('runWorker', () => {
     expect(transfer).not.toHaveBeenCalled();
   });
 
+  it('keeps E29N57 container construction ahead of spawn reservation refill below the general construction floor when stored energy protects recovery', () => {
+    const site = {
+      id: 'site1',
+      structureType: 'container',
+      progress: 500,
+      progressTotal: 5_000
+    } as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(250),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      }
+    } as unknown as StructureSpawn;
+    const storedContainer = {
+      id: 'stored-container1',
+      structureType: 'container',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 2_069 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) =>
+          resource === undefined || resource === RESOURCE_ENERGY ? 2_000 : 0
+        )
+      }
+    } as unknown as StructureContainer;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N57',
+      energyAvailable: 250,
+      energyCapacityAvailable: 1_800,
+      controller,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [spawn, storedContainer];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const transfer = jest.fn();
+    const creep = {
+      name: 'Builder',
+      memory: { role: 'worker', colony: 'E29N57' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(30),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      build,
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const reserveWorker = {
+      name: 'ReserveWorker',
+      memory: { role: 'worker', colony: 'E29N57' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, reserveWorker);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      economy: {
+        spawnEnergyReservation: {
+          updatedAt: 123,
+          rooms: {
+            E29N57: {
+              bodyCost: 800,
+              creepName: 'worker-E29N57-124',
+              reservedAt: 123,
+              reservedEnergy: 800,
+              role: 'worker',
+              roomName: 'E29N57',
+              updatedAt: 123
+            }
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Builder: creep, ReserveWorker: reserveWorker },
+      rooms: { E29N57: room },
+      time: 124,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'site1') {
+          return site;
+        }
+
+        if (id === 'spawn1') {
+          return spawn;
+        }
+
+        return id === 'stored-container1' ? storedContainer : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'site1' });
+    expect(creep.memory.workerDispatchDiagnostic?.spawnReservationTask).toBeUndefined();
+    expect(build).toHaveBeenCalledWith(site);
+    expect(transfer).not.toHaveBeenCalled();
+  });
+
   it('keeps spawn reservation refill protected when the room has only one worker', () => {
     const site = {
       id: 'site1',

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -4610,7 +4610,7 @@ describe('runWorker', () => {
       id: 'stored-container1',
       structureType: 'container',
       store: {
-        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 2_069 : 0)),
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 1_900 : 0)),
         getCapacity: jest.fn((resource?: ResourceConstant) =>
           resource === undefined || resource === RESOURCE_ENERGY ? 2_000 : 0
         )

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -12761,6 +12761,44 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(builder)).toEqual({ type: 'build', targetId: 'source-container-site1' });
   });
 
+  it('spends carried energy on E29N57 container construction below the general floor when stored surplus protects recovery', () => {
+    const site = {
+      id: 'container-site1',
+      structureType: 'container',
+      progress: 500,
+      progressTotal: 5_000
+    } as ConstructionSite;
+    const fullSpawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 0);
+    const storedContainer = makeStoredEnergyContainerWithCapacity('stored-container1', 2_069, 2_000);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N57',
+      constructionSites: [site],
+      controller,
+      energyAvailable: MINIMUM_WORKER_SPAWN_ENERGY + 50,
+      energyCapacityAvailable: 1_800,
+      myStructures: [fullSpawn as AnyOwnedStructure],
+      structures: [storedContainer as AnyStructure]
+    });
+    const creep = {
+      name: 'StoredEnergyBuilder',
+      memory: { role: 'worker', colony: 'E29N57' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(30),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room
+    } as unknown as Creep;
+
+    expect(canSpendWorkerEnergyOnConstructionSite(creep, site)).toBe(true);
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'container-site1' });
+  });
+
   it('does not count the current build-assigned worker as uncovered construction coverage', () => {
     const site = { id: 'wall-site1', structureType: 'constructedWall' } as ConstructionSite;
     const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 317, {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -12769,7 +12769,7 @@ describe('selectWorkerTask', () => {
       progressTotal: 5_000
     } as ConstructionSite;
     const fullSpawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 0);
-    const storedContainer = makeStoredEnergyContainerWithCapacity('stored-container1', 2_069, 2_000);
+    const storedContainer = makeStoredEnergyContainerWithCapacity('stored-container1', 2_000, 2_000);
     const controller = {
       id: 'controller1',
       my: true,


### PR DESCRIPTION
## Summary
- Releases surplus room energy for build/repair work when spawn-reservation is blocking productive workers.
- Surfaces worker-surplus telemetry in runtime summaries.
- Adds regression coverage for worker assignment, task selection, runtime-summary evidence, and review-fix coverage for legal Screeps store fixtures.

## Review-fix triage
- CodeRabbit workerRunner duplicate stored-energy scan: FIX — cached/reused storedEnergy to avoid repeated room-structure scans on the same execution path.
- CodeRabbit runtimeSummary contradictory `spawn_reserving_energy` after stored-energy override: FIX — stored-energy override now suppresses spawn-reservation detail.
- CodeRabbit impossible over-capacity test fixtures: FIX — fixtures now model legal store capacities while preserving surplus-energy coverage.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 103 suites / 2149 tests passed
- `cd prod && npm run build`

## Universal task Done gate
- [x] Task type: production bot code + tests.
- [x] Expected observable outcome / named deliverable: E29N57-style rooms with available surplus energy can assign productive build/repair work instead of remaining stuck behind spawn energy reservation.
- [x] Non-goals / accepted substitutes: no expansion, deploy, or learned-policy change in this PR; runtime acceptance remains tracked separately.
- [x] Verification evidence required before Done: controller verification passed with diff-check, typecheck, Jest, and build on review-fix commit `ee753a6e`.
- [x] Project Evidence / Next action / Blocked by: PR and issue Project items record review-fix commit `ee753a6e`, controller verification, and current exact-head review state.
- [x] Post-merge/deploy/runtime proof: official MMO deploy plus runtime-summary evidence should show `taskCounts.build > 0`, decreasing `pendingBuildProgress`, or productive assignment in the affected room.
- [x] Named deliverable proof: commits `a732198f` and `ee753a6e` change the worker/task/energy-buffer path and update `prod/dist/main.js` from the verified build.

## Issue linkage
Related to issue 1553. This PR intentionally leaves runtime acceptance open for post-deploy observation before the issue is completed.