### PR TITLE
fix(rl): accept fresh full gate cards

### DIFF
--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -2139,7 +2139,9 @@ def is_canonical_e1_current_gate_data_report(payload: JsonObject, path: Path | N
         return False
     if not gate_report_path_matches_payload(payload, path):
         return False
-    return gate_data_current_report_source(payload, path)
+    if gate_data_current_report_source(payload, path):
+        return True
+    return is_fully_accepted_e1_current_gate(payload)
 
 
 def gate_data_current_report_source(payload: JsonObject, path: Path | None = None) -> bool:

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -1569,6 +1569,73 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertEqual(summary["source_gate"]["gate_id"], gate_id)
         self.assertEqual(summary["source_gate"]["dataset_run_id"], dataset_run_id)
 
+    def test_loop_a_local_fallback_accepts_fresh_hash_dataset_gate_when_complete(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runtime_root = root / "runtime-artifacts"
+            gate_id = "rl-gate-065c36f76111"
+            dataset_run_id = "rl-57c9b9540796"
+            gate_path = runtime_root / "rl-dataset-gates" / gate_id / "gate_report.json"
+            output_path = runtime_root / "rl-experiment-cards" / "experiment_card.json"
+            gate_path.parent.mkdir(parents=True)
+            gate_path.write_text(
+                json.dumps(
+                    {
+                        "type": card_helper.SOURCE_GATE_TYPE,
+                        "ok": True,
+                        "gateId": gate_id,
+                        "createdAt": "2026-06-01T07:55:24Z",
+                        "mode": "current-bot-behavior",
+                        "dataset": {"ok": True, "runId": dataset_run_id, "sampleCount": 200},
+                        "datasetGate": {"status": "pass", "sampleCount": 200},
+                        "quality_checks": {
+                            "status": "pass",
+                            "samples_accepted": 200,
+                            "samples_rejected": 0,
+                            "acceptance_rate": 1.0,
+                        },
+                        "shadowEvaluation": {"status": "pass", "ok": True},
+                        "blockingReasons": [],
+                        "outputs": {"gateDir": f"runtime-artifacts/rl-dataset-gates/{gate_id}"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            selected = card_helper.select_accepted_dataset_gate(
+                runtime_root,
+                reference_time="2026-06-01T08:00:00Z",
+                max_age_hours=card_helper.E1_GATE_FRESHNESS_HOURS,
+            )
+            stdout = io.StringIO()
+            with mock.patch.object(card_helper, "utc_now_iso", return_value="2026-06-01T08:00:00Z"):
+                exit_code = card_helper.main(
+                    [
+                        "--loop-a-local-fallback",
+                        "--source-gate-id",
+                        gate_id,
+                        "--dataset-gate-root",
+                        str(runtime_root),
+                        "--code-commit",
+                        "8" * 40,
+                        "--created-at",
+                        "2026-06-01T08:00:00Z",
+                        "--output",
+                        str(output_path),
+                    ],
+                    stdout=stdout,
+                    stderr=io.StringIO(),
+                    repo_root=REPO_ROOT,
+                )
+            summary = json.loads(stdout.getvalue())
+
+        self.assertEqual(selected["gate_id"], gate_id)
+        self.assertEqual(selected["dataset_run_id"], dataset_run_id)
+        self.assertTrue(selected["gate_report_path"].endswith(f"rl-dataset-gates/{gate_id}/gate_report.json"))
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(summary["source_gate"]["gate_id"], gate_id)
+        self.assertEqual(summary["source_gate"]["dataset_run_id"], dataset_run_id)
+
     def test_fresh_dataset_gate_selection_requires_reference_time(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             runtime_root = Path(temp_dir) / "runtime-artifacts"


### PR DESCRIPTION
## Summary
- Accept fresh full E1 `rl-gate-*` reports under `runtime-artifacts/rl-dataset-gates` when generating Loop A local-fallback experiment cards.
- Add a regression test for the fresh full hash-gate layout that #1571 surfaced.
- Preserve RL safety: this changes offline card selection only; no Tencent paid compute, no ASG scale-out, no official MMO writes.

## Related work
Refs #1571.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_experiment_card.py scripts/test_screeps_rl_experiment_card.py`
- `python3 -m unittest scripts.test_screeps_rl_experiment_card.RlExperimentCardTest.test_loop_a_local_fallback_accepts_fresh_hash_dataset_gate_when_complete -v`
- `python3 -m unittest scripts.test_screeps_rl_experiment_card -v` (81 tests OK)
- `python3 scripts/screeps_rl_experiment_card.py --loop-a-local-fallback --source-gate-id rl-gate-065c36f76111 --dataset-gate-root /root/screeps/runtime-artifacts/rl-dataset-gates --output /tmp/issue-1571-loop-a-fresh-card-controller.json`
- `python3 /tmp/issue-1571-projection-smoke.py`

## Universal task Done gate
- [x] Task type: RL flywheel code/test repair for issue #1571 fresh-gate Loop A card generation.
- [x] Expected observable outcome / named deliverable: fresh full E1 gate `rl-gate-065c36f76111` can generate a shadow Loop A local-fallback card, and the bounded projection smoke demonstrates non-identical candidate reward tuples.
- [x] Non-goals / accepted substitutes: no Tencent paid compute, no ASG scale-out, no `run-single`, no official MMO write path, and no learned policy rollout.
- [x] Verification evidence required before Done: the controller verification commands listed above pass on commit `c2ff4207dd290d5623381bcb2c6fd53fdd9289e1`.
- [x] Project Evidence / Next action / Blocked by: Project fields for #1571/#879/#1032 record the durable triage artifacts under `runtime-artifacts/rl-control-loop/issue-1571-candidate-differentiation-20260601T1021Z/` and the next Loop A/B consumption requirement.
- [x] Post-merge/deploy/runtime proof: no official deploy is required for this scripts-only RL repair; the post-merge proof is a later Loop A/B artifact from current main showing differentiated candidate rankings from the fresh gate.
- [x] Named deliverable proof: `runtime-artifacts/rl-control-loop/issue-1571-candidate-differentiation-20260601T1021Z/index.json` records the triage artifact, generated card, projection smoke script, smoke report, and safety status.