### PR TITLE
Fix RL fixture-owned spawn initialization

### DIFF
--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -5221,7 +5221,7 @@ def _launcher_cli_result_summary(result: JsonObject) -> JsonObject:
     return summary
 
 
-def _self_heal_fixture_place_spawn_room_busy(
+def _adopt_private_fixture_owner(
     smoke: Any,
     compose: list[str],
     cfg: Any,
@@ -5230,11 +5230,13 @@ def _self_heal_fixture_place_spawn_room_busy(
     room: str,
     worker_index: int,
     variant_id: str,
+    phase: str,
+    debug_message: str,
 ) -> JsonObject:
     identity = _private_map_fixture_owner_identity(map_source_file, room)
     if identity is None:
         return {
-            "phase": "place-spawn-room-busy-self-heal",
+            "phase": phase,
             "classification": "skipped",
             "reason": "target room is not an owned private-map fixture room",
         }
@@ -5243,7 +5245,7 @@ def _self_heal_fixture_place_spawn_room_busy(
     target_username = _non_empty_text(getattr(cfg, "username", None))
     if target_username is None:
         summary: JsonObject = {
-            "phase": "place-spawn-room-busy-self-heal",
+            "phase": phase,
             "classification": "skipped",
             "reason": "cfg.username is not set; cannot adopt fixture owner",
             "room": room,
@@ -5256,7 +5258,7 @@ def _self_heal_fixture_place_spawn_room_busy(
     _debug_worker_phase(
         worker_index,
         variant_id,
-        "place-spawn room busy; adopting private fixture owner",
+        debug_message,
         room=room,
         fixtureOwnerId=fixture_owner_id,
         targetUsername=target_username,
@@ -5269,7 +5271,7 @@ def _self_heal_fixture_place_spawn_room_busy(
         "adopt private fixture owner",
     )
     summary: JsonObject = {
-        "phase": "place-spawn-room-busy-self-heal",
+        "phase": phase,
         "classification": "fixture_owner_adopted",
         "room": room,
         "fixtureOwnerId": fixture_owner_id,
@@ -5279,6 +5281,113 @@ def _self_heal_fixture_place_spawn_room_busy(
     if fixture_owner_username is not None:
         summary["fixtureOwnerUsername"] = fixture_owner_username
     return summary
+
+
+def _self_heal_fixture_place_spawn_room_busy(
+    smoke: Any,
+    compose: list[str],
+    cfg: Any,
+    *,
+    map_source_file: Path,
+    room: str,
+    worker_index: int,
+    variant_id: str,
+) -> JsonObject:
+    return _adopt_private_fixture_owner(
+        smoke,
+        compose,
+        cfg,
+        map_source_file=map_source_file,
+        room=room,
+        worker_index=worker_index,
+        variant_id=variant_id,
+        phase="place-spawn-room-busy-self-heal",
+        debug_message="place-spawn room busy; adopting private fixture owner",
+    )
+
+
+def _preinitialize_fixture_owned_room_for_spawn(
+    smoke: Any,
+    compose: list[str],
+    cfg: Any,
+    *,
+    map_source_file: Path,
+    room: str,
+    worker_index: int,
+    variant_id: str,
+) -> JsonObject | None:
+    if _private_map_fixture_owner_identity(map_source_file, room) is None:
+        return None
+    try:
+        adoption = _adopt_private_fixture_owner(
+            smoke,
+            compose,
+            cfg,
+            map_source_file=map_source_file,
+            room=room,
+            worker_index=worker_index,
+            variant_id=variant_id,
+            phase="fixture-owned-room-preinitialization",
+            debug_message="preinitializing fixture-owned room; adopting private fixture owner",
+        )
+    except Exception as exc:  # noqa: BLE001 - preflight adoption is an optimization; preserve retry-guarded place-spawn.
+        _debug_worker_phase(
+            worker_index,
+            variant_id,
+            "fixture-owned room preinitialization failed; falling back to place-spawn",
+            room=room,
+            error=_safe_text(exc, 360),
+        )
+        return None
+    if adoption.get("classification") != "fixture_owner_adopted":
+        return None
+    return {
+        "phase": "place-spawn",
+        "classification": "already_playing",
+        "reason": "private fixture room already has owned anchor state",
+        "skippedPlaceSpawn": True,
+        "fixtureOwnerAdoption": adoption,
+    }
+
+
+def _initialize_spawn_for_private_simulator(
+    smoke: Any,
+    cfg: Any,
+    token: str,
+    *,
+    compose: list[str],
+    map_source_file: Path,
+    room: str,
+    worker_index: int,
+    variant_id: str,
+) -> tuple[str, JsonObject]:
+    preinitialized = _preinitialize_fixture_owned_room_for_spawn(
+        smoke,
+        compose,
+        cfg,
+        map_source_file=map_source_file,
+        room=room,
+        worker_index=worker_index,
+        variant_id=variant_id,
+    )
+    if preinitialized is not None:
+        return token, preinitialized
+    return _place_spawn_with_retry(
+        smoke,
+        cfg,
+        token,
+        worker_index=worker_index,
+        variant_id=variant_id,
+        room_busy_self_healer=lambda attempt, summary: _self_heal_fixture_place_spawn_room_busy(
+            smoke,
+            compose,
+            cfg,
+            map_source_file=map_source_file,
+            room=room,
+            worker_index=worker_index,
+            variant_id=variant_id,
+        ),
+    )
 
 
 def _private_map_fixture_room_summaries(map_source_file: Path) -> dict[str, JsonObject]:
@@ -6645,21 +6754,17 @@ def _run_variant(
             output_path=safe_run_root / "active_code_readback.json",
         )
 
-        token, place_spawn = _place_spawn_with_retry(
+        if compose is None:
+            raise RuntimeError("compose command was not initialized before spawn initialization")
+        token, place_spawn = _initialize_spawn_for_private_simulator(
             smoke,
             cfg,
             token,
+            compose=compose,
+            map_source_file=scenario_map_source_file,
+            room=room,
             worker_index=worker_index,
             variant_id=variant_id,
-            room_busy_self_healer=lambda attempt, summary: _self_heal_fixture_place_spawn_room_busy(
-                smoke,
-                compose,
-                cfg,
-                map_source_file=scenario_map_source_file,
-                room=room,
-                worker_index=worker_index,
-                variant_id=variant_id,
-            ),
         )
 
         initial_state = smoke.http_json(

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -5153,6 +5153,8 @@ def _fixture_owner_adoption_expression(
   const fixtureOwnerRefs = new Set([fixtureOwnerId, fixtureOwnerUsername].filter(value => value).map(String));
   const targetUsername = {json.dumps(target_username)};
   const objectsCollection = storage.db['rooms.objects'];
+  const objectType = object => String((object && (object.type || object.structureType)) || '');
+  const isOwnedAnchorObject = object => ['controller', 'spawn'].includes(objectType(object));
   return storage.db.users.findOne({{username: targetUsername}}).then(user => {{
     if (!user || !user._id) {{
       throw new Error(`smoke user not found: ${{targetUsername}}`);
@@ -5163,15 +5165,26 @@ def _fixture_owner_adoption_expression(
       let adoptedObjects = 0;
       let reboundControllers = 0;
       let reservationUpdates = 0;
+      let rewrittenOwnerReferences = 0;
+      let rewrittenAnchorReferences = 0;
       for (const object of objects || []) {{
         const patch = {{}};
+        const anchorObject = isOwnedAnchorObject(object);
         if (object.user != null && fixtureOwnerRefs.has(String(object.user))) {{
           patch.user = targetUserId;
           adoptedObjects += 1;
+          rewrittenOwnerReferences += 1;
+          if (anchorObject) {{
+            rewrittenAnchorReferences += 1;
+          }}
         }}
         if (object.bindUser != null && fixtureOwnerRefs.has(String(object.bindUser))) {{
           patch.bindUser = targetUserId;
           reboundControllers += 1;
+          rewrittenOwnerReferences += 1;
+          if (objectType(object) === 'controller') {{
+            rewrittenAnchorReferences += 1;
+          }}
         }}
         if (
           object.reservation
@@ -5180,6 +5193,7 @@ def _fixture_owner_adoption_expression(
         ) {{
           patch.reservation = Object.assign({{}}, object.reservation, {{user: targetUserId}});
           reservationUpdates += 1;
+          rewrittenOwnerReferences += 1;
         }}
         if (Object.keys(patch).length > 0 && object._id != null) {{
           updates.push(objectsCollection.update({{_id: object._id}}, {{$set: patch}}));
@@ -5199,6 +5213,8 @@ def _fixture_owner_adoption_expression(
         adoptedObjects,
         reboundControllers,
         reservationUpdates,
+        rewrittenOwnerReferences,
+        rewrittenAnchorReferences,
         activeUser: true,
         roomActivated: true
       }}));
@@ -5218,7 +5234,23 @@ def _launcher_cli_result_summary(result: JsonObject) -> JsonObject:
     response_excerpt = result.get("response_excerpt")
     if isinstance(response_excerpt, str):
         summary["responseExcerpt"] = _safe_text(response_excerpt, 500)
+        try:
+            parsed_response = json.loads(response_excerpt)
+        except json.JSONDecodeError:
+            parsed_response = None
+        if isinstance(parsed_response, dict):
+            summary["responsePayload"] = parsed_response
     return summary
+
+
+def _fixture_owner_adoption_rewritten_anchor_references(adoption: JsonObject) -> int:
+    result = adoption.get("result")
+    if not isinstance(result, dict):
+        return 0
+    payload = result.get("responsePayload")
+    if not isinstance(payload, dict):
+        return 0
+    return _extract_int(payload.get("rewrittenAnchorReferences")) or 0
 
 
 def _adopt_private_fixture_owner(
@@ -5340,6 +5372,8 @@ def _preinitialize_fixture_owned_room_for_spawn(
         )
         return None
     if adoption.get("classification") != "fixture_owner_adopted":
+        return None
+    if _fixture_owner_adoption_rewritten_anchor_references(adoption) <= 0:
         return None
     return {
         "phase": "place-spawn",

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -6375,7 +6375,16 @@ cli:
                 return {
                     "status": 200,
                     "elapsed_seconds": 0.02,
-                    "response_excerpt": '{"ok":true,"adoptedObjects":5,"activeUser":true}',
+                    "response_excerpt": json.dumps(
+                        {
+                            "ok": True,
+                            "adoptedObjects": 5,
+                            "rewrittenOwnerReferences": 5,
+                            "rewrittenAnchorReferences": 2,
+                            "activeUser": True,
+                        },
+                        sort_keys=True,
+                    ),
                 }
 
         smoke = FakeSmoke()
@@ -6423,7 +6432,16 @@ cli:
                 return {
                     "status": 200,
                     "elapsed_seconds": 0.02,
-                    "response_excerpt": '{"ok":true,"adoptedObjects":5,"activeUser":true}',
+                    "response_excerpt": json.dumps(
+                        {
+                            "ok": True,
+                            "adoptedObjects": 5,
+                            "rewrittenOwnerReferences": 5,
+                            "rewrittenAnchorReferences": 2,
+                            "activeUser": True,
+                        },
+                        sort_keys=True,
+                    ),
                 }
 
         smoke = FakeSmoke()
@@ -6448,8 +6466,127 @@ cli:
         self.assertEqual(summary["reason"], "private fixture room already has owned anchor state")
         self.assertEqual(summary["fixtureOwnerAdoption"]["classification"], "fixture_owner_adopted")
         self.assertEqual(summary["fixtureOwnerAdoption"]["targetUsername"], "rl-sim-fixture")
+        self.assertEqual(
+            summary["fixtureOwnerAdoption"]["result"]["responsePayload"]["rewrittenAnchorReferences"],
+            2,
+        )
         self.assertEqual(len(smoke.expressions), 1)
         self.assertIn("fixtureOwnerRefs.has", smoke.expressions[0])
+        self.assertIn("rewrittenAnchorReferences", smoke.expressions[0])
+
+    def test_fixture_owned_anchor_preinitialization_falls_back_without_anchor_rewrite_evidence(self) -> None:
+        class FakeSmoke:
+            def __init__(self) -> None:
+                self.expressions: list[str] = []
+
+            def run_launcher_cli(
+                self,
+                compose: list[str],
+                cfg: argparse.Namespace,
+                expression: str,
+            ) -> dict[str, object]:
+                _ = compose, cfg
+                self.expressions.append(expression)
+                return {
+                    "status": 200,
+                    "elapsed_seconds": 0.02,
+                    "response_excerpt": json.dumps(
+                        {
+                            "ok": True,
+                            "adoptedObjects": 0,
+                            "reboundControllers": 0,
+                            "reservationUpdates": 0,
+                            "rewrittenOwnerReferences": 0,
+                            "rewrittenAnchorReferences": 0,
+                            "activeUser": True,
+                        },
+                        sort_keys=True,
+                    ),
+                }
+
+        smoke = FakeSmoke()
+        cfg = argparse.Namespace(username="rl-sim-fixture")
+        fixture_path = Path("scripts/fixtures/rl/multi-tier-territory-combat-v1.map.json")
+
+        with mock.patch.object(harness, "_debug_worker_phase"):
+            summary = harness._preinitialize_fixture_owned_room_for_spawn(
+                smoke,
+                ["compose"],
+                cfg,
+                map_source_file=fixture_path,
+                room="E1S1",
+                worker_index=0,
+                variant_id="variant-a",
+            )
+
+        self.assertIsNone(summary)
+        self.assertEqual(len(smoke.expressions), 1)
+
+    def test_fixture_owned_anchor_preinitialization_falls_back_for_reservation_only_rewrite(self) -> None:
+        class FakeSmoke:
+            def __init__(self) -> None:
+                self.expressions: list[str] = []
+
+            def run_launcher_cli(
+                self,
+                compose: list[str],
+                cfg: argparse.Namespace,
+                expression: str,
+            ) -> dict[str, object]:
+                _ = compose, cfg
+                self.expressions.append(expression)
+                return {
+                    "status": 200,
+                    "elapsed_seconds": 0.02,
+                    "response_excerpt": json.dumps(
+                        {
+                            "ok": True,
+                            "adoptedObjects": 0,
+                            "reboundControllers": 0,
+                            "reservationUpdates": 1,
+                            "rewrittenOwnerReferences": 1,
+                            "rewrittenAnchorReferences": 0,
+                            "activeUser": True,
+                        },
+                        sort_keys=True,
+                    ),
+                }
+
+        fixture = {
+            "type": harness.PRIVATE_MAP_FIXTURE_TYPE,
+            "owner": {"id": "owner", "username": "rl-owner"},
+            "rooms": [
+                {
+                    "room": "E1S1",
+                    "objects": [
+                        {
+                            "_id": "controller-reserved",
+                            "type": "controller",
+                            "reservation": {"user": "owner"},
+                        }
+                    ],
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture_path = Path(temp_dir) / "map.json"
+            fixture_path.write_text(json.dumps(fixture, sort_keys=True), encoding="utf-8")
+            smoke = FakeSmoke()
+            cfg = argparse.Namespace(username="rl-sim-fixture")
+
+            with mock.patch.object(harness, "_debug_worker_phase"):
+                summary = harness._preinitialize_fixture_owned_room_for_spawn(
+                    smoke,
+                    ["compose"],
+                    cfg,
+                    map_source_file=fixture_path,
+                    room="E1S1",
+                    worker_index=0,
+                    variant_id="variant-a",
+                )
+
+        self.assertIsNone(summary)
+        self.assertEqual(len(smoke.expressions), 1)
 
     def test_fixture_owned_anchor_preinitialization_skips_neutral_rooms(self) -> None:
         class FakeSmoke:
@@ -6529,7 +6666,16 @@ cli:
                 return {
                     "status": 200,
                     "elapsed_seconds": 0.02,
-                    "response_excerpt": '{"ok":true,"adoptedObjects":5,"activeUser":true}',
+                    "response_excerpt": json.dumps(
+                        {
+                            "ok": True,
+                            "adoptedObjects": 5,
+                            "rewrittenOwnerReferences": 5,
+                            "rewrittenAnchorReferences": 2,
+                            "activeUser": True,
+                        },
+                        sort_keys=True,
+                    ),
                 }
 
             def http_json(self, method: str, base_url: str, path: str, *args: object, **kwargs: object) -> object:

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -6407,6 +6407,160 @@ cli:
         self.assertIn("ACTIVE_ROOMS", smoke.expressions[0])
         debug_phase.assert_called_once()
 
+    def test_fixture_owned_anchor_preinitialization_adopts_owner_and_skips_place_spawn(self) -> None:
+        class FakeSmoke:
+            def __init__(self) -> None:
+                self.expressions: list[str] = []
+
+            def run_launcher_cli(
+                self,
+                compose: list[str],
+                cfg: argparse.Namespace,
+                expression: str,
+            ) -> dict[str, object]:
+                _ = compose, cfg
+                self.expressions.append(expression)
+                return {
+                    "status": 200,
+                    "elapsed_seconds": 0.02,
+                    "response_excerpt": '{"ok":true,"adoptedObjects":5,"activeUser":true}',
+                }
+
+        smoke = FakeSmoke()
+        cfg = argparse.Namespace(username="rl-sim-fixture")
+        fixture_path = Path("scripts/fixtures/rl/multi-tier-territory-combat-v1.map.json")
+
+        with mock.patch.object(harness, "_debug_worker_phase"):
+            summary = harness._preinitialize_fixture_owned_room_for_spawn(
+                smoke,
+                ["compose"],
+                cfg,
+                map_source_file=fixture_path,
+                room="E1S1",
+                worker_index=0,
+                variant_id="variant-a",
+            )
+
+        self.assertIsNotNone(summary)
+        assert summary is not None
+        self.assertEqual(summary["classification"], "already_playing")
+        self.assertTrue(summary["skippedPlaceSpawn"])
+        self.assertEqual(summary["reason"], "private fixture room already has owned anchor state")
+        self.assertEqual(summary["fixtureOwnerAdoption"]["classification"], "fixture_owner_adopted")
+        self.assertEqual(summary["fixtureOwnerAdoption"]["targetUsername"], "rl-sim-fixture")
+        self.assertEqual(len(smoke.expressions), 1)
+        self.assertIn("fixtureOwnerRefs.has", smoke.expressions[0])
+
+    def test_fixture_owned_anchor_preinitialization_skips_neutral_rooms(self) -> None:
+        class FakeSmoke:
+            def __init__(self) -> None:
+                self.expressions: list[str] = []
+
+            def run_launcher_cli(
+                self,
+                compose: list[str],
+                cfg: argparse.Namespace,
+                expression: str,
+            ) -> dict[str, object]:
+                _ = compose, cfg
+                self.expressions.append(expression)
+                return {"status": 200}
+
+        smoke = FakeSmoke()
+        cfg = argparse.Namespace(username="rl-sim-fixture")
+        fixture_path = Path("scripts/fixtures/rl/multi-tier-territory-combat-v1.map.json")
+
+        summary = harness._preinitialize_fixture_owned_room_for_spawn(
+            smoke,
+            ["compose"],
+            cfg,
+            map_source_file=fixture_path,
+            room="E2S1",
+            worker_index=0,
+            variant_id="variant-a",
+        )
+
+        self.assertIsNone(summary)
+        self.assertEqual(smoke.expressions, [])
+
+    def test_fixture_owned_anchor_preinitialization_falls_back_on_launcher_error(self) -> None:
+        class FakeSmoke:
+            def run_launcher_cli(
+                self,
+                compose: list[str],
+                cfg: argparse.Namespace,
+                expression: str,
+            ) -> dict[str, object]:
+                _ = compose, cfg, expression
+                raise RuntimeError("temporary launcher CLI failure")
+
+        cfg = argparse.Namespace(username="rl-sim-fixture")
+        fixture_path = Path("scripts/fixtures/rl/multi-tier-territory-combat-v1.map.json")
+
+        with mock.patch.object(harness, "_debug_worker_phase") as debug_phase:
+            summary = harness._preinitialize_fixture_owned_room_for_spawn(
+                FakeSmoke(),
+                ["compose"],
+                cfg,
+                map_source_file=fixture_path,
+                room="E1S1",
+                worker_index=0,
+                variant_id="variant-a",
+            )
+
+        self.assertIsNone(summary)
+        self.assertGreaterEqual(debug_phase.call_count, 2)
+        self.assertEqual(debug_phase.call_args.args[2], "fixture-owned room preinitialization failed; falling back to place-spawn")
+
+    def test_initialize_spawn_skips_place_spawn_for_fixture_owned_anchor(self) -> None:
+        class FakeSmoke:
+            def __init__(self) -> None:
+                self.expressions: list[str] = []
+                self.place_spawn_calls = 0
+
+            def run_launcher_cli(
+                self,
+                compose: list[str],
+                cfg: argparse.Namespace,
+                expression: str,
+            ) -> dict[str, object]:
+                _ = compose, cfg
+                self.expressions.append(expression)
+                return {
+                    "status": 200,
+                    "elapsed_seconds": 0.02,
+                    "response_excerpt": '{"ok":true,"adoptedObjects":5,"activeUser":true}',
+                }
+
+            def http_json(self, method: str, base_url: str, path: str, *args: object, **kwargs: object) -> object:
+                _ = method, base_url, args, kwargs
+                if path == "/api/game/place-spawn":
+                    self.place_spawn_calls += 1
+                raise AssertionError(f"unexpected HTTP call: {path}")
+
+        smoke = FakeSmoke()
+        cfg = argparse.Namespace(username="rl-sim-fixture", server_url="http://127.0.0.1", room="E1S1")
+        fixture_path = Path("scripts/fixtures/rl/multi-tier-territory-combat-v1.map.json")
+
+        with mock.patch.object(harness, "_debug_worker_phase"):
+            token, summary = harness._initialize_spawn_for_private_simulator(
+                smoke,
+                cfg,
+                "initial-token",
+                compose=["compose"],
+                map_source_file=fixture_path,
+                room="E1S1",
+                worker_index=0,
+                variant_id="variant-a",
+            )
+
+        self.assertEqual(token, "initial-token")
+        self.assertEqual(summary["classification"], "already_playing")
+        self.assertTrue(summary["skippedPlaceSpawn"])
+        self.assertEqual(summary["fixtureOwnerAdoption"]["classification"], "fixture_owner_adopted")
+        self.assertEqual(smoke.place_spawn_calls, 0)
+        self.assertEqual(len(smoke.expressions), 1)
+
     def test_fixture_room_busy_self_healer_skips_without_target_username(self) -> None:
         class FakeSmoke:
             def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- preinitialize private simulator fixtures that already contain the target owned anchor room by adopting the fixture owner before spawn setup
- skip `/api/game/place-spawn` only when the adoption result proves a live owned anchor rewrite
- keep the existing bounded `room busy` retry/self-heal path for non-fixture, weak-evidence, reservation-only, or launcher CLI preinitialization error fallback cases

## Evidence
- `python3 -m py_compile scripts/screeps_rl_simulator_harness.py scripts/test_screeps_rl_simulator_harness.py`
- `python3 -m unittest scripts.test_screeps_rl_simulator_harness` (198 tests)
- `python3 -m unittest scripts.test_screeps_tencent_batch_rl_runner` (168 tests)
- `python3 scripts/screeps_rl_simulator_harness.py self-test` (`ok=true`, `liveEffect=false`, `officialMmoWrites=false`)

## Automated review triage
- Gemini line 5333: FIX / critical. The finding was valid: launcher CLI failure during proactive preinitialization could bypass the retry-guarded `place-spawn` path. Resolution in 57e489a catches preinitialization adoption exceptions, logs fallback, returns `None`, and adds `test_fixture_owned_anchor_preinitialization_falls_back_on_launcher_error`.
- CodeRabbit line 5349: FIX / critical. The finding was valid: source-fixture ownership plus a successful CLI call was weaker than live owned-anchor rewrite proof. Resolution in 49b24e4 parses adoption payload counters, requires `rewrittenAnchorReferences > 0` before skipping `place-spawn`, and adds zero-rewrite plus reservation-only fallback tests.

## Universal task Done gate
- [x] Task type: code bugfix for private simulator RL initialization.
- [x] Expected observable outcome / named deliverable: fixture-owned anchor rooms initialize by owner adoption and do not call `/api/game/place-spawn` unless live owned-anchor rewrite evidence is present.
- [x] Non-goals / accepted substitutes: no official MMO writes and no paid Tencent compute in this PR.
- [x] Verification evidence required before Done: py_compile, RL simulator unittest suite, Tencent batch unittest suite, and simulator harness self-test all passed on head commit 49b24e4938ffdfcc40fe7a39fc46a8e181878228 after the CodeRabbit repair.
- [x] Project Evidence / Next action / Blocked by: Project item for PR #1577 is In review; Evidence is repair commits 57e489a and 49b24e4 plus green local checks and automated review triage; Next action is automated review gate plus bounded guarded runtime validation tracked on the linked issue; Blocked by none for this PR slice.
- [x] Post-merge/deploy/runtime proof: this PR provides script and test proof only; runtime proof belongs to the existing guarded validation flow on the linked issue.
- [x] Named deliverable proof: `placeSpawn.classification=already_playing` with `fixtureOwnerAdoption.result.responsePayload.rewrittenAnchorReferences > 0` is asserted by the new unit coverage.

## Safety
- No official MMO writes.
- No paid Tencent compute launched.
- Runtime validation should remain a bounded guarded preflight/single-worker run after duplicate-runner, ASG, and billing checks.

Related to issue #1501.
