### PR TITLE
monitor: alert on persistent worker deadlocks

### DIFF
--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -60,8 +60,13 @@ WORKER_ASSIGNMENT_GAP_REQUIRED_TICKS = 100
 WORKER_ASSIGNMENT_GAP_RECOVERY_TICK_TOLERANCE = 0
 WORKER_ASSIGNMENT_STALL_KIND = "worker_assignment_stall"
 WORKER_ASSIGNMENT_STALL_REQUIRED_TICKS = 100
+WORKER_ASSIGNMENT_STALL_REQUIRED_CONSECUTIVE_CAPTURES = 4
+RUNTIME_SUMMARY_CAPTURE_HISTORY_LIMIT = 12
 RUNTIME_SUMMARY_TICK_METADATA_KEY = "__runtimeSummaryTick"
 RUNTIME_SUMMARY_ARTIFACT_TIMESTAMP_METADATA_KEY = "__runtimeSummaryArtifactTimestamp"
+RUNTIME_SUMMARY_ARTIFACT_PATH_METADATA_KEY = "__runtimeSummaryArtifactPath"
+RUNTIME_SUMMARY_ARTIFACT_LINE_METADATA_KEY = "__runtimeSummaryArtifactLine"
+RUNTIME_SUMMARY_CAPTURE_HISTORY_METADATA_KEY = "__runtimeSummaryCaptureHistory"
 RUNTIME_SUMMARY_SOURCE_METADATA_KEY = "__runtimeSummarySource"
 RUNTIME_SUMMARY_CPU_METADATA_KEY = "__runtimeSummaryCpu"
 MONITOR_RUNTIME_SUMMARY_SOURCE = "screeps-runtime-monitor"
@@ -142,6 +147,8 @@ CONSTRUCTION_DEADLOCK_ROUTES = [
     {"issue": "#1025", "topic": "construction_deadlock_ticks"},
 ]
 WORKER_ASSIGNMENT_STALL_ROUTES = [
+    {"issue": "#1580", "topic": "worker_deadlock_alert"},
+    {"issue": "#1553", "topic": "e29n57_worker_deadlock"},
     {"issue": "#1573", "topic": "worker_deadlock_alert"},
     {"issue": "#906", "topic": "gameplay_behavior_metric"},
 ]
@@ -283,8 +290,11 @@ TACTICAL_CATEGORY_RULES: dict[str, dict[str, Any]] = {
         "actions": ["capture_runtime_context", "inspect_resource_state", "open_incident_issue"],
         "metadata": {
             "metric": "workerAssignmentEvidence.productiveAssignmentCount",
-            "related_issues": ["#1573", "#906"],
-            "thresholds": {"P2": WORKER_ASSIGNMENT_STALL_REQUIRED_TICKS},
+            "related_issues": ["#1580", "#1553", "#1573", "#906"],
+            "thresholds": {
+                "P2_ticks": WORKER_ASSIGNMENT_STALL_REQUIRED_TICKS,
+                "P2_consecutive_captures": WORKER_ASSIGNMENT_STALL_REQUIRED_CONSECUTIVE_CAPTURES,
+            },
             "routes_to": WORKER_ASSIGNMENT_STALL_ROUTES,
         },
     },
@@ -1275,7 +1285,10 @@ def worker_assignment_stall_metadata() -> dict[str, Any]:
     return {
         "metric": "workerAssignmentEvidence.productiveAssignmentCount",
         "related_issues": [str(route["issue"]) for route in WORKER_ASSIGNMENT_STALL_ROUTES],
-        "thresholds": {"P2": WORKER_ASSIGNMENT_STALL_REQUIRED_TICKS},
+        "thresholds": {
+            "P2_ticks": WORKER_ASSIGNMENT_STALL_REQUIRED_TICKS,
+            "P2_consecutive_captures": WORKER_ASSIGNMENT_STALL_REQUIRED_CONSECUTIVE_CAPTURES,
+        },
         "routes_to": [dict(route) for route in WORKER_ASSIGNMENT_STALL_ROUTES],
     }
 
@@ -2061,7 +2074,7 @@ def detect_worker_assignment_gap_sustained_reason(
     return None, state
 
 
-def worker_assignment_stall_evidence(
+def worker_assignment_deadlock_evidence(
     runtime_room: dict[str, Any] | None,
     metrics: RoomSummaryMetrics,
 ) -> dict[str, Any] | None:
@@ -2078,30 +2091,35 @@ def worker_assignment_stall_evidence(
     if productive_assignment_count != 0:
         return None
 
+    worker_count = first_number_value(
+        runtime_room,
+        ("workerCount",),
+        ("workerAssignmentEvidence", "workerCount"),
+        ("resources", "productiveEnergy", "workerCount"),
+        ("productiveEnergy", "workerCount"),
+    )
+    if worker_count is not None and worker_count <= 0:
+        return None
+
     construction_site_count = runtime_construction_site_count(runtime_room)
     if construction_site_count is None:
         construction_site_count = len(metrics.construction_sites)
     pending_build_progress = runtime_pending_build_progress(runtime_room)
     if pending_build_progress is None:
         pending_build_progress = metrics.pending_build_progress
-    if construction_site_count <= 0 and pending_build_progress <= 0:
-        return None
 
     build_count = runtime_task_count(runtime_room, "build")
     if build_count is None:
         build_count = metrics.task_counts.get("build")
-    if build_count is not None and build_count > 0:
-        return None
 
     runtime_gap_blocked_reason = runtime_build_blocked_reason(runtime_room)
-    if runtime_gap_blocked_reason == WORKER_ASSIGNMENT_GAP_BLOCKED_REASON:
-        return None
     build_blocked_reason = runtime_gap_blocked_reason or metrics.build_blocked_reason
 
     task_counts = dict(as_dict(runtime_room.get("taskCounts"))) or dict(metrics.task_counts)
     evidence = {
         "workerAssignmentBlockedDetail": blocked_detail,
         "productiveAssignmentCount": productive_assignment_count,
+        "workerCount": worker_count,
         "build": build_count,
         "task_counts": task_counts,
         "constructionSiteCount": construction_site_count,
@@ -2114,9 +2132,115 @@ def worker_assignment_stall_evidence(
     if blocked_workers:
         evidence["workerAssignmentBlockedWorkers"] = blocked_workers
     artifact_timestamp = runtime_room.get(RUNTIME_SUMMARY_ARTIFACT_TIMESTAMP_METADATA_KEY)
-    if isinstance(artifact_timestamp, str) and artifact_timestamp:
+    if isinstance(artifact_timestamp, (int, float, str)) and artifact_timestamp:
         evidence["runtimeSummaryArtifactTimestamp"] = artifact_timestamp
+    artifact_path = runtime_room.get(RUNTIME_SUMMARY_ARTIFACT_PATH_METADATA_KEY)
+    if isinstance(artifact_path, str) and artifact_path:
+        evidence["runtimeSummaryArtifactPath"] = artifact_path
+    artifact_line = number_value(runtime_room.get(RUNTIME_SUMMARY_ARTIFACT_LINE_METADATA_KEY))
+    if artifact_line is not None:
+        evidence["runtimeSummaryArtifactLine"] = int(artifact_line)
     return evidence
+
+
+def worker_assignment_stall_evidence(
+    runtime_room: dict[str, Any] | None,
+    metrics: RoomSummaryMetrics,
+) -> dict[str, Any] | None:
+    evidence = worker_assignment_deadlock_evidence(runtime_room, metrics)
+    if evidence is None:
+        return None
+
+    if evidence["constructionSiteCount"] <= 0 and evidence["pendingBuildProgress"] <= 0:
+        return None
+    build_count = evidence.get("build")
+    if build_count is not None and build_count > 0:
+        return None
+    if runtime_build_blocked_reason(runtime_room) == WORKER_ASSIGNMENT_GAP_BLOCKED_REASON:
+        return None
+    return evidence
+
+
+def runtime_summary_capture_history(runtime_room: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(runtime_room, dict):
+        return []
+    value = runtime_room.get(RUNTIME_SUMMARY_CAPTURE_HISTORY_METADATA_KEY)
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def worker_assignment_deadlock_capture_matches(capture: dict[str, Any]) -> bool:
+    if not runtime_worker_assignment_evidence_available(capture):
+        return False
+    if runtime_productive_assignment_count(capture) != 0:
+        return False
+    if runtime_worker_assignment_blocked_detail(capture) is None:
+        return False
+    worker_count = first_number_value(capture, ("workerCount",), ("workerAssignmentEvidence", "workerCount"))
+    return worker_count is None or worker_count > 0
+
+
+def worker_assignment_deadlock_consecutive_captures(
+    runtime_room: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    captures = runtime_summary_capture_history(runtime_room)
+    if not captures:
+        return []
+    consecutive: list[dict[str, Any]] = []
+    for capture in captures:
+        if not worker_assignment_deadlock_capture_matches(capture):
+            break
+        consecutive.append(capture)
+    return consecutive
+
+
+def worker_assignment_capture_state(captures: list[dict[str, Any]], current_tick_value: Any) -> dict[str, int]:
+    current_tick = tick_number(captures[0].get("runtimeSummaryTick")) if captures else None
+    start_tick = tick_number(captures[-1].get("runtimeSummaryTick")) if captures else None
+    if current_tick is None:
+        current_tick = tick_number(current_tick_value)
+    if start_tick is None:
+        start_tick = current_tick
+    if current_tick is None:
+        current_tick = start_tick if start_tick is not None else 0
+    if start_tick is None:
+        start_tick = current_tick
+    return {
+        "start_tick": start_tick,
+        "last_tick": current_tick,
+        "consecutive_ticks": max(0, current_tick - start_tick),
+    }
+
+
+def worker_assignment_capture_paths(captures: list[dict[str, Any]]) -> list[str]:
+    paths: list[str] = []
+    for capture in captures:
+        path = capture.get("path")
+        if isinstance(path, str) and path and path not in paths:
+            paths.append(path)
+    return paths
+
+
+def worker_assignment_capture_window_evidence(
+    runtime_room: dict[str, Any] | None,
+    metrics: RoomSummaryMetrics,
+) -> tuple[dict[str, Any], dict[str, int]] | None:
+    captures = worker_assignment_deadlock_consecutive_captures(runtime_room)
+    if len(captures) < WORKER_ASSIGNMENT_STALL_REQUIRED_CONSECUTIVE_CAPTURES:
+        return None
+
+    evidence = worker_assignment_deadlock_evidence(runtime_room, metrics)
+    if evidence is None:
+        evidence = worker_assignment_deadlock_evidence(captures[0], metrics)
+    if evidence is None:
+        return None
+
+    evidence["consecutiveCaptures"] = len(captures)
+    evidence["thresholdCaptures"] = WORKER_ASSIGNMENT_STALL_REQUIRED_CONSECUTIVE_CAPTURES
+    evidence["runtimeSummaryCaptures"] = captures
+    evidence["runtimeSummaryCapturePaths"] = worker_assignment_capture_paths(captures)
+    return evidence, worker_assignment_capture_state(captures, evidence.get("runtimeSummaryTick"))
 
 
 def build_worker_assignment_stall_reason(
@@ -2125,6 +2249,14 @@ def build_worker_assignment_stall_reason(
     state: dict[str, int],
 ) -> dict[str, Any]:
     blocked_detail = evidence["workerAssignmentBlockedDetail"]
+    consecutive_captures = number_value(evidence.get("consecutiveCaptures"))
+    if consecutive_captures is not None:
+        duration = (
+            f"across {format_energy_value(consecutive_captures)} consecutive runtime-summary captures "
+            f"(threshold>{WORKER_ASSIGNMENT_STALL_REQUIRED_CONSECUTIVE_CAPTURES - 1})."
+        )
+    else:
+        duration = f"for {state['consecutive_ticks']} ticks."
     return {
         "kind": WORKER_ASSIGNMENT_STALL_KIND,
         "room": ref.key,
@@ -2138,12 +2270,17 @@ def build_worker_assignment_stall_reason(
         "start_tick": state["start_tick"],
         "current_tick": state["last_tick"],
         "consecutive_ticks": state["consecutive_ticks"],
+        "next_action": (
+            "Codex triage: inspect worker dispatch and spawn energy reservation for the affected room; "
+            "verify productiveAssignmentCount recovers above 0 in fresh runtime-summary captures."
+        ),
+        "owner_ping": False,
         "metadata": worker_assignment_stall_metadata(),
         "message": (
             f"{WORKER_ASSIGNMENT_STALL_KIND} in {ref.key}: "
             f"productiveAssignmentCount=0, workerAssignmentBlockedDetail={blocked_detail}, "
             f"pendingBuildProgress={format_energy_value(evidence.get('pendingBuildProgress'))} "
-            f"for {state['consecutive_ticks']} ticks."
+            f"{duration}"
         ),
         "signature": f"{WORKER_ASSIGNMENT_STALL_KIND}:{ref.key}",
     }
@@ -2156,6 +2293,11 @@ def detect_worker_assignment_stall_reason(
     previous_rule_state: Any,
     current_tick_value: Any,
 ) -> tuple[dict[str, Any] | None, dict[str, int] | int]:
+    capture_window = worker_assignment_capture_window_evidence(runtime_room, metrics)
+    if capture_window is not None:
+        evidence, state = capture_window
+        return build_worker_assignment_stall_reason(ref, evidence, state), state
+
     evidence = worker_assignment_stall_evidence(runtime_room, metrics)
     if evidence is None:
         return None, 0
@@ -2400,9 +2542,14 @@ def evaluate_room_alert(
         detected.append(extension_count_zero_candidate)
 
     previous_worker_assignment_stall_state = rule_counts.get(WORKER_ASSIGNMENT_STALL_KIND)
+    owned_room_for_worker_alerts = bool(
+        current_owned_spawns > 0
+        or current_owned_creeps > 0
+        or (expected_owner is not None and snapshot.owner == expected_owner)
+    )
     worker_assignment_stall_candidate, worker_assignment_stall_state = detect_worker_assignment_stall_reason(
         snapshot.ref,
-        runtime_room_summary,
+        runtime_room_summary if owned_room_for_worker_alerts else None,
         current_metrics,
         previous_worker_assignment_stall_state,
         snapshot.tick,
@@ -3888,6 +4035,9 @@ def runtime_summary_room_has_monitor_alert_fields(room: dict[str, Any], payload:
         runtime_summary_room_has_worker_idle_fields(room)
         or runtime_summary_room_has_cpu_fields(room)
         or runtime_summary_payload_has_cpu_fields(payload)
+        or runtime_productive_assignment_count(room) is not None
+        or runtime_worker_assignment_blocked_detail(room) is not None
+        or bool(runtime_worker_assignment_blocked_workers(room))
     )
 
 
@@ -3987,7 +4137,12 @@ def runtime_summary_candidate_key(
     )
 
 
-def runtime_summary_room_with_metadata(payload: dict[str, Any], path: Path, room: dict[str, Any]) -> dict[str, Any]:
+def runtime_summary_room_with_metadata(
+    payload: dict[str, Any],
+    path: Path,
+    room: dict[str, Any],
+    line_index: int | None = None,
+) -> dict[str, Any]:
     result = dict(room)
     tick = runtime_summary_payload_tick(payload)
     if tick is not None:
@@ -3995,6 +4150,9 @@ def runtime_summary_room_with_metadata(payload: dict[str, Any], path: Path, room
     timestamp = runtime_summary_artifact_timestamp(path)
     if timestamp is not None:
         result[RUNTIME_SUMMARY_ARTIFACT_TIMESTAMP_METADATA_KEY] = timestamp
+    result[RUNTIME_SUMMARY_ARTIFACT_PATH_METADATA_KEY] = str(path)
+    if line_index is not None:
+        result[RUNTIME_SUMMARY_ARTIFACT_LINE_METADATA_KEY] = line_index + 1
     source = payload.get("source")
     if isinstance(source, str) and source:
         result[RUNTIME_SUMMARY_SOURCE_METADATA_KEY] = source
@@ -4050,6 +4208,90 @@ def runtime_summary_room_with_cpu_fields(base: dict[str, Any], cpu_room: dict[st
     return result
 
 
+def runtime_summary_capture_history_entry(room: dict[str, Any]) -> dict[str, Any]:
+    entry: dict[str, Any] = {}
+    for source_key, target_key in (
+        ("room", "room"),
+        ("roomName", "roomName"),
+        ("shard", "shard"),
+        (RUNTIME_SUMMARY_SOURCE_METADATA_KEY, "source"),
+        (RUNTIME_SUMMARY_ARTIFACT_PATH_METADATA_KEY, "path"),
+    ):
+        value = room.get(source_key)
+        if isinstance(value, str) and value:
+            entry[target_key] = value
+
+    tick = runtime_summary_room_tick(room)
+    if tick is not None:
+        entry["runtimeSummaryTick"] = tick
+    timestamp = room.get(RUNTIME_SUMMARY_ARTIFACT_TIMESTAMP_METADATA_KEY)
+    if isinstance(timestamp, (int, float, str)):
+        entry["runtimeSummaryArtifactTimestamp"] = timestamp
+    line_number = number_value(room.get(RUNTIME_SUMMARY_ARTIFACT_LINE_METADATA_KEY))
+    if line_number is not None:
+        entry["line"] = int(line_number)
+
+    productive_assignment_count = runtime_productive_assignment_count(room)
+    if productive_assignment_count is not None:
+        entry["productiveAssignmentCount"] = productive_assignment_count
+    blocked_detail = runtime_worker_assignment_blocked_detail(room)
+    if blocked_detail is not None:
+        entry["workerAssignmentBlockedDetail"] = blocked_detail
+    blocked_workers = runtime_worker_assignment_blocked_workers(room)
+    if blocked_workers:
+        entry["workerAssignmentBlockedWorkers"] = blocked_workers
+    worker_count = first_number_value(room, ("workerCount",), ("workerAssignmentEvidence", "workerCount"))
+    if worker_count is not None:
+        entry["workerCount"] = worker_count
+
+    task_counts = as_dict(room.get("taskCounts"))
+    if task_counts:
+        entry["taskCounts"] = dict(task_counts)
+    build_count = runtime_task_count(room, "build")
+    if build_count is not None:
+        entry["build"] = build_count
+    construction_site_count = runtime_construction_site_count(room)
+    if construction_site_count is not None:
+        entry["constructionSiteCount"] = construction_site_count
+    pending_build_progress = runtime_pending_build_progress(room)
+    if pending_build_progress is not None:
+        entry["pendingBuildProgress"] = pending_build_progress
+    build_blocked_reason = runtime_build_blocked_reason(room)
+    if build_blocked_reason is not None:
+        entry["buildBlockedReason"] = build_blocked_reason
+
+    return entry
+
+
+def runtime_summary_capture_history_key(entry: dict[str, Any]) -> tuple[bool, int, bool, float, int, str]:
+    tick = tick_number(entry.get("runtimeSummaryTick"))
+    timestamp = number_value(entry.get("runtimeSummaryArtifactTimestamp"))
+    line_number = number_value(entry.get("line"))
+    path = entry.get("path")
+    return (
+        tick is not None,
+        tick if tick is not None else -1,
+        timestamp is not None,
+        timestamp if timestamp is not None else -1.0,
+        int(line_number) if line_number is not None else -1,
+        path if isinstance(path, str) else "",
+    )
+
+
+def attach_runtime_summary_capture_history(
+    room: dict[str, Any],
+    history: list[dict[str, Any]],
+) -> dict[str, Any]:
+    result = dict(room)
+    if history:
+        result[RUNTIME_SUMMARY_CAPTURE_HISTORY_METADATA_KEY] = sorted(
+            history,
+            key=runtime_summary_capture_history_key,
+            reverse=True,
+        )[:RUNTIME_SUMMARY_CAPTURE_HISTORY_LIMIT]
+    return result
+
+
 def load_latest_runtime_room_summaries(
     runtime_summary_dir: Path,
     refs: list[RoomRef],
@@ -4071,6 +4313,7 @@ def load_latest_runtime_room_summaries(
     runtime_cpu_freshness_keys: dict[str, tuple[bool, float, int, bool, int, str]] = {}
     cpu_result: dict[str, dict[str, Any]] = {}
     cpu_freshness_keys: dict[str, tuple[bool, float, int, bool, int, str]] = {}
+    capture_history: dict[str, list[dict[str, Any]]] = {}
     for path in paths:
         try:
             lines = path.read_text(encoding="utf-8").splitlines()
@@ -4091,7 +4334,7 @@ def load_latest_runtime_room_summaries(
                     if candidate_freshness_key <= cpu_freshness_keys.get(ref.key, (False, -1.0, -1, False, -1, "")):
                         continue
                     room = runtime_cpu_summary_room(ref, cpu)
-                    cpu_result[ref.key] = runtime_summary_room_with_metadata(cpu_payload, path, room)
+                    cpu_result[ref.key] = runtime_summary_room_with_metadata(cpu_payload, path, room, line_index)
                     cpu_freshness_keys[ref.key] = candidate_freshness_key
                 continue
 
@@ -4113,7 +4356,8 @@ def load_latest_runtime_room_summaries(
                     ):
                         continue
                     candidate_key = runtime_summary_candidate_key(payload, path, line_index, room)
-                    candidate_room = runtime_summary_room_with_metadata(payload, path, room)
+                    candidate_room = runtime_summary_room_with_metadata(payload, path, room, line_index)
+                    capture_history.setdefault(ref.key, []).append(runtime_summary_capture_history_entry(candidate_room))
                     if runtime_summary_room_has_cpu_fields(room) or runtime_summary_payload_has_cpu_fields(payload):
                         if candidate_freshness_key > cpu_freshness_keys.get(ref.key, (False, -1.0, -1, False, -1, "")):
                             cpu_result[ref.key] = candidate_room
@@ -4130,20 +4374,24 @@ def load_latest_runtime_room_summaries(
     for ref in refs:
         runtime_room = runtime_result.get(ref.key)
         cpu_room = cpu_result.get(ref.key)
+        history = capture_history.get(ref.key, [])
         if runtime_room is None and cpu_room is None:
             continue
         if runtime_room is None:
-            result[ref.key] = dict(cpu_room) if cpu_room is not None else {}
+            result[ref.key] = attach_runtime_summary_capture_history(dict(cpu_room) if cpu_room is not None else {}, history)
             continue
         if cpu_room is None:
-            result[ref.key] = dict(runtime_room)
+            result[ref.key] = attach_runtime_summary_capture_history(runtime_room, history)
             continue
         cpu_key = cpu_freshness_keys.get(ref.key)
         runtime_cpu_key = runtime_cpu_freshness_keys.get(ref.key)
         if cpu_key is not None and (runtime_cpu_key is None or cpu_key > runtime_cpu_key):
-            result[ref.key] = runtime_summary_room_with_cpu_fields(runtime_room, cpu_room)
+            result[ref.key] = attach_runtime_summary_capture_history(
+                runtime_summary_room_with_cpu_fields(runtime_room, cpu_room),
+                history,
+            )
         else:
-            result[ref.key] = dict(runtime_room)
+            result[ref.key] = attach_runtime_summary_capture_history(runtime_room, history)
     return result
 
 

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -2230,9 +2230,9 @@ def worker_assignment_capture_window_evidence(
     if len(captures) < WORKER_ASSIGNMENT_STALL_REQUIRED_CONSECUTIVE_CAPTURES:
         return None
 
-    evidence = worker_assignment_deadlock_evidence(runtime_room, metrics)
+    evidence = worker_assignment_stall_evidence(runtime_room, metrics)
     if evidence is None:
-        evidence = worker_assignment_deadlock_evidence(captures[0], metrics)
+        evidence = worker_assignment_stall_evidence(captures[0], metrics)
     if evidence is None:
         return None
 
@@ -4240,7 +4240,13 @@ def runtime_summary_capture_history_entry(room: dict[str, Any]) -> dict[str, Any
     blocked_workers = runtime_worker_assignment_blocked_workers(room)
     if blocked_workers:
         entry["workerAssignmentBlockedWorkers"] = blocked_workers
-    worker_count = first_number_value(room, ("workerCount",), ("workerAssignmentEvidence", "workerCount"))
+    worker_count = first_number_value(
+        room,
+        ("workerCount",),
+        ("workerAssignmentEvidence", "workerCount"),
+        ("resources", "productiveEnergy", "workerCount"),
+        ("productiveEnergy", "workerCount"),
+    )
     if worker_count is not None:
         entry["workerCount"] = worker_count
 

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -2222,12 +2222,25 @@ def worker_assignment_capture_paths(captures: list[dict[str, Any]]) -> list[str]
     return paths
 
 
+def worker_assignment_capture_window_is_fresh(captures: list[dict[str, Any]], current_tick_value: Any) -> bool:
+    if not captures:
+        return False
+    current_tick = tick_number(current_tick_value)
+    latest_capture_tick = tick_number(captures[0].get("runtimeSummaryTick"))
+    if current_tick is None or latest_capture_tick is None:
+        return False
+    return latest_capture_tick >= current_tick
+
+
 def worker_assignment_capture_window_evidence(
     runtime_room: dict[str, Any] | None,
     metrics: RoomSummaryMetrics,
+    current_tick_value: Any,
 ) -> tuple[dict[str, Any], dict[str, int]] | None:
     captures = worker_assignment_deadlock_consecutive_captures(runtime_room)
     if len(captures) < WORKER_ASSIGNMENT_STALL_REQUIRED_CONSECUTIVE_CAPTURES:
+        return None
+    if not worker_assignment_capture_window_is_fresh(captures, current_tick_value):
         return None
 
     evidence = worker_assignment_stall_evidence(runtime_room, metrics)
@@ -2293,7 +2306,7 @@ def detect_worker_assignment_stall_reason(
     previous_rule_state: Any,
     current_tick_value: Any,
 ) -> tuple[dict[str, Any] | None, dict[str, int] | int]:
-    capture_window = worker_assignment_capture_window_evidence(runtime_room, metrics)
+    capture_window = worker_assignment_capture_window_evidence(runtime_room, metrics, current_tick_value)
     if capture_window is not None:
         evidence, state = capture_window
         return build_worker_assignment_stall_reason(ref, evidence, state), state

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -3771,6 +3771,54 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         self.assertIn("#1580", report["triggers"][0]["metadata"]["related_issues"])
         self.assertIn("#1553", report["triggers"][0]["metadata"]["related_issues"])
 
+    def test_worker_deadlock_console_capture_window_requires_fresh_latest_capture(self) -> None:
+        room = "E29N57"
+        ticks = [1630662, 1630668, 1630675, 1630685]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_dir = Path(temp_dir)
+            for index, tick in enumerate(ticks, start=1):
+                (runtime_dir / f"runtime-summary-console-20260601T00000{index}Z.log").write_text(
+                    "#runtime-summary "
+                    + json.dumps(
+                        worker_deadlock_runtime_summary_payload(
+                            room,
+                            tick,
+                            productive_assignment_count=0,
+                            blocked_detail="spawn_reserving_energy",
+                        )
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+            (runtime_dir / "runtime-summary-console-20260601T000100Z.log").write_text(
+                "#cpu-summary " + json.dumps({"used": 4.2, "limit": 70, "bucket": 9000, "pressure": "normal"}) + "\n",
+                encoding="utf-8",
+            )
+
+            warnings: list[str] = []
+            runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                runtime_dir,
+                [monitor.RoomRef(shard="shardX", room=room)],
+                warnings,
+            )
+
+        self.assertEqual(warnings, [])
+        runtime_room = runtime_rooms[f"shardX/{room}"]
+        self.assertEqual(
+            runtime_room[monitor.RUNTIME_SUMMARY_CAPTURE_HISTORY_METADATA_KEY][0]["runtimeSummaryTick"],
+            ticks[-1],
+        )
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            make_owned_worker_room_snapshot(room, ticks[-1] + 25),
+            {"baseline_established": True, "owner": "lanyusea"},
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_room,
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertNotIn(monitor.WORKER_ASSIGNMENT_STALL_KIND, [reason["kind"] for reason in emitted])
+
     def test_worker_deadlock_console_capture_without_build_backlog_stays_silent(self) -> None:
         room = "E29N57"
         ticks = [1630662, 1630668, 1630675, 1630685]
@@ -3915,6 +3963,51 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
 
         self.assertEqual(suppressed, [])
         self.assertNotIn(monitor.WORKER_ASSIGNMENT_STALL_KIND, [reason["kind"] for reason in emitted])
+
+    def test_worker_deadlock_console_capture_prefers_top_level_worker_count(self) -> None:
+        room = "E29N57"
+        ticks = [1630662, 1630668, 1630675, 1630685]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_dir = Path(temp_dir)
+            for index, tick in enumerate(ticks, start=1):
+                payload = worker_deadlock_runtime_summary_payload(
+                    room,
+                    tick,
+                    productive_assignment_count=0,
+                    blocked_detail="spawn_reserving_energy",
+                )
+                room_summary = payload["rooms"][0]
+                room_summary["workerAssignmentEvidence"].pop("workerCount", None)
+                room_summary["resources"]["productiveEnergy"]["workerCount"] = 0
+                (runtime_dir / f"runtime-summary-console-20260601T00000{index}Z.log").write_text(
+                    "#runtime-summary " + json.dumps(payload) + "\n",
+                    encoding="utf-8",
+                )
+
+            warnings: list[str] = []
+            runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                runtime_dir,
+                [monitor.RoomRef(shard="shardX", room=room)],
+                warnings,
+            )
+
+        self.assertEqual(warnings, [])
+        runtime_room = runtime_rooms[f"shardX/{room}"]
+        self.assertEqual(
+            runtime_room[monitor.RUNTIME_SUMMARY_CAPTURE_HISTORY_METADATA_KEY][0]["workerCount"],
+            2,
+        )
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            make_owned_worker_room_snapshot(room, ticks[-1]),
+            {"baseline_established": True, "owner": "lanyusea"},
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_room,
+        )
+
+        self.assertEqual(suppressed, [])
+        stall_reason = next(reason for reason in emitted if reason["kind"] == monitor.WORKER_ASSIGNMENT_STALL_KIND)
+        self.assertEqual(stall_reason["workerCount"], 2)
 
     def test_worker_deadlock_console_capture_transient_window_stays_silent(self) -> None:
         room = "E29N57"

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -200,6 +200,85 @@ def make_snapshot(objects: dict[str, dict[str, object]], tick: int | str | None 
     )
 
 
+def make_owned_worker_room_snapshot(room: str, tick: int) -> monitor.RoomSnapshot:
+    return monitor.RoomSnapshot(
+        ref=monitor.RoomRef("shardX", room),
+        terrain="0" * monitor.TERRAIN_CELLS,
+        objects=monitor.normalize_objects(
+            {
+                "spawn1": {
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "lanyusea"},
+                    "x": 17,
+                    "y": 24,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                },
+                "worker1": {
+                    "type": "creep",
+                    "my": True,
+                    "owner": {"username": "lanyusea"},
+                    "name": "WorkerA",
+                    "memory": {"role": "worker"},
+                },
+                "site1": {
+                    "type": "constructionSite",
+                    "my": True,
+                    "owner": {"username": "lanyusea"},
+                    "structureType": "extension",
+                    "progress": 0,
+                    "progressTotal": 4500,
+                    "x": 19,
+                    "y": 24,
+                },
+            }
+        ),
+        tick=tick,
+        owner="lanyusea",
+        info={"energyAvailable": 1650},
+        expected_owner="lanyusea",
+    )
+
+
+def worker_deadlock_runtime_summary_payload(
+    room: str,
+    tick: int,
+    productive_assignment_count: int,
+    blocked_detail: str | None,
+) -> dict[str, object]:
+    worker_assignment_evidence = {
+        "source": "runtime-summary",
+        "available": True,
+        "tick": tick,
+        "workerCount": 2,
+        "assignedTaskCount": productive_assignment_count,
+        "productiveAssignmentCount": productive_assignment_count,
+    }
+    productive_energy: dict[str, object] = {
+        "constructionSiteCount": 1,
+        "pendingBuildProgress": 4500,
+        "productiveAssignmentCount": productive_assignment_count,
+    }
+    room_summary: dict[str, object] = {
+        "roomName": room,
+        "shard": "shardX",
+        "workerAssignmentEvidenceAvailable": True,
+        "workerAssignmentEvidence": worker_assignment_evidence,
+        "workerCount": 2,
+        "taskCounts": {"harvest": 0, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0, "none": 2},
+        "constructionSiteCount": 1,
+        "pendingBuildProgress": 4500,
+        "productiveAssignmentCount": productive_assignment_count,
+        "resources": {"productiveEnergy": productive_energy},
+    }
+    if blocked_detail is not None:
+        room_summary["workerAssignmentBlockedDetail"] = blocked_detail
+        room_summary["workerAssignmentBlockedWorkers"] = [{"name": "WorkerA", "task": "build", "carriedEnergy": 0}]
+        productive_energy["workerAssignmentBlockedDetail"] = blocked_detail
+    return {"type": "runtime-summary", "tick": tick, "rooms": [room_summary]}
+
+
 def make_worker_assignment_gap_metrics() -> monitor.RoomSummaryMetrics:
     return monitor.RoomSummaryMetrics(
         structures=[],
@@ -3616,6 +3695,118 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         self.assertEqual(report["categories"], [monitor.WORKER_ASSIGNMENT_STALL_KIND])
         self.assertEqual(report["triggers"][0]["reason_kind"], monitor.WORKER_ASSIGNMENT_STALL_KIND)
         self.assertIn("#1573", report["triggers"][0]["metadata"]["related_issues"])
+
+    def test_persistent_worker_deadlock_console_captures_alert_after_four_captures(self) -> None:
+        room = "E29N57"
+        ticks = [1630662, 1630668, 1630675, 1630685]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_dir = Path(temp_dir)
+            paths: list[Path] = []
+            for index, tick in enumerate(ticks, start=1):
+                path = runtime_dir / f"runtime-summary-console-20260601T00000{index}Z.log"
+                path.write_text(
+                    "#runtime-summary "
+                    + json.dumps(
+                        worker_deadlock_runtime_summary_payload(
+                            room,
+                            tick,
+                            productive_assignment_count=0,
+                            blocked_detail="spawn_reserving_energy",
+                        )
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+                paths.append(path)
+
+            warnings: list[str] = []
+            runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                runtime_dir,
+                [monitor.RoomRef(shard="shardX", room=room)],
+                warnings,
+            )
+
+        self.assertEqual(warnings, [])
+        runtime_room = runtime_rooms[f"shardX/{room}"]
+        self.assertEqual(runtime_room[monitor.RUNTIME_SUMMARY_TICK_METADATA_KEY], ticks[-1])
+        self.assertEqual(
+            len(runtime_room[monitor.RUNTIME_SUMMARY_CAPTURE_HISTORY_METADATA_KEY]),
+            monitor.WORKER_ASSIGNMENT_STALL_REQUIRED_CONSECUTIVE_CAPTURES,
+        )
+
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            make_owned_worker_room_snapshot(room, ticks[-1]),
+            {"baseline_established": True, "owner": "lanyusea"},
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_room,
+        )
+
+        self.assertEqual(suppressed, [])
+        stall_reason = next(reason for reason in emitted if reason["kind"] == monitor.WORKER_ASSIGNMENT_STALL_KIND)
+        self.assertEqual(stall_reason["room"], f"shardX/{room}")
+        self.assertEqual(stall_reason["workerAssignmentBlockedDetail"], "spawn_reserving_energy")
+        self.assertEqual(stall_reason["productiveAssignmentCount"], 0)
+        self.assertEqual(stall_reason["consecutiveCaptures"], 4)
+        self.assertEqual(stall_reason["thresholdCaptures"], 4)
+        self.assertEqual(stall_reason["runtimeSummaryTick"], ticks[-1])
+        self.assertEqual(stall_reason["runtimeSummaryCaptures"][0]["runtimeSummaryTick"], ticks[-1])
+        self.assertEqual(set(stall_reason["runtimeSummaryCapturePaths"]), {str(path) for path in paths})
+        self.assertIn("Codex triage", stall_reason["next_action"])
+        self.assertIs(stall_reason["owner_ping"], False)
+
+        report = monitor.build_tactical_response_report(
+            {"ok": True, "mode": "alert", "alert": True, "reasons": [stall_reason], "rooms": [f"shardX/{room}"]}
+        )
+        self.assertEqual(report["priority"], "P2")
+        self.assertIn("#1580", report["triggers"][0]["metadata"]["related_issues"])
+        self.assertIn("#1553", report["triggers"][0]["metadata"]["related_issues"])
+
+    def test_worker_deadlock_console_capture_transient_window_stays_silent(self) -> None:
+        room = "E29N57"
+        captures = [
+            (1630662, 0, "spawn_reserving_energy"),
+            (1630668, 0, "spawn_reserving_energy"),
+            (1630675, 1, None),
+            (1630680, 0, "spawn_reserving_energy"),
+            (1630685, 0, "spawn_reserving_energy"),
+            (1630690, 0, "spawn_reserving_energy"),
+        ]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_dir = Path(temp_dir)
+            for index, (tick, productive_count, blocked_detail) in enumerate(captures, start=1):
+                (runtime_dir / f"runtime-summary-console-20260601T00000{index}Z.log").write_text(
+                    "#runtime-summary "
+                    + json.dumps(
+                        worker_deadlock_runtime_summary_payload(
+                            room,
+                            tick,
+                            productive_assignment_count=productive_count,
+                            blocked_detail=blocked_detail,
+                        )
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+
+            warnings: list[str] = []
+            runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                runtime_dir,
+                [monitor.RoomRef(shard="shardX", room=room)],
+                warnings,
+            )
+
+        self.assertEqual(warnings, [])
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            make_owned_worker_room_snapshot(room, captures[-1][0]),
+            {"baseline_established": True, "owner": "lanyusea"},
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_rooms[f"shardX/{room}"],
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertNotIn(monitor.WORKER_ASSIGNMENT_STALL_KIND, [reason["kind"] for reason in emitted])
 
     def test_productive_assignment_stall_stale_runtime_summary_does_not_age(self) -> None:
         runtime_room = {

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -247,6 +247,15 @@ def worker_deadlock_runtime_summary_payload(
     productive_assignment_count: int,
     blocked_detail: str | None,
 ) -> dict[str, object]:
+    productive_task_count = max(0, min(2, productive_assignment_count))
+    task_counts = {
+        "harvest": 0,
+        "transfer": 0,
+        "build": productive_task_count,
+        "repair": 0,
+        "upgrade": 0,
+        "none": max(0, 2 - productive_task_count),
+    }
     worker_assignment_evidence = {
         "source": "runtime-summary",
         "available": True,
@@ -266,7 +275,7 @@ def worker_deadlock_runtime_summary_payload(
         "workerAssignmentEvidenceAvailable": True,
         "workerAssignmentEvidence": worker_assignment_evidence,
         "workerCount": 2,
-        "taskCounts": {"harvest": 0, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0, "none": 2},
+        "taskCounts": task_counts,
         "constructionSiteCount": 1,
         "pendingBuildProgress": 4500,
         "productiveAssignmentCount": productive_assignment_count,
@@ -3761,6 +3770,151 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         self.assertEqual(report["priority"], "P2")
         self.assertIn("#1580", report["triggers"][0]["metadata"]["related_issues"])
         self.assertIn("#1553", report["triggers"][0]["metadata"]["related_issues"])
+
+    def test_worker_deadlock_console_capture_without_build_backlog_stays_silent(self) -> None:
+        room = "E29N57"
+        ticks = [1630662, 1630668, 1630675, 1630685]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_dir = Path(temp_dir)
+            for index, tick in enumerate(ticks, start=1):
+                payload = worker_deadlock_runtime_summary_payload(
+                    room,
+                    tick,
+                    productive_assignment_count=0,
+                    blocked_detail="spawn_reserving_energy",
+                )
+                room_summary = payload["rooms"][0]
+                productive_energy = room_summary["resources"]["productiveEnergy"]
+                room_summary["constructionSiteCount"] = 0
+                room_summary["pendingBuildProgress"] = 0
+                productive_energy["constructionSiteCount"] = 0
+                productive_energy["pendingBuildProgress"] = 0
+                (runtime_dir / f"runtime-summary-console-20260601T00000{index}Z.log").write_text(
+                    "#runtime-summary " + json.dumps(payload) + "\n",
+                    encoding="utf-8",
+                )
+
+            warnings: list[str] = []
+            runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                runtime_dir,
+                [monitor.RoomRef(shard="shardX", room=room)],
+                warnings,
+            )
+
+        self.assertEqual(warnings, [])
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            make_owned_worker_room_snapshot(room, ticks[-1]),
+            {"baseline_established": True, "owner": "lanyusea"},
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_rooms[f"shardX/{room}"],
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertNotIn(monitor.WORKER_ASSIGNMENT_STALL_KIND, [reason["kind"] for reason in emitted])
+
+    def test_worker_deadlock_console_capture_gap_window_stays_silent(self) -> None:
+        room = "E29N57"
+        ticks = [1630662, 1630668, 1630675, 1630685]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_dir = Path(temp_dir)
+            for index, tick in enumerate(ticks, start=1):
+                payload = worker_deadlock_runtime_summary_payload(
+                    room,
+                    tick,
+                    productive_assignment_count=0,
+                    blocked_detail="spawn_reserving_energy",
+                )
+                room_summary = payload["rooms"][0]
+                productive_energy = room_summary["resources"]["productiveEnergy"]
+                room_summary["buildBlockedReason"] = monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON
+                productive_energy["buildBlockedReason"] = monitor.WORKER_ASSIGNMENT_GAP_BLOCKED_REASON
+                (runtime_dir / f"runtime-summary-console-20260601T00000{index}Z.log").write_text(
+                    "#runtime-summary " + json.dumps(payload) + "\n",
+                    encoding="utf-8",
+                )
+
+            warnings: list[str] = []
+            runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                runtime_dir,
+                [monitor.RoomRef(shard="shardX", room=room)],
+                warnings,
+            )
+
+        self.assertEqual(warnings, [])
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            make_owned_worker_room_snapshot(room, ticks[-1]),
+            {"baseline_established": True, "owner": "lanyusea"},
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_rooms[f"shardX/{room}"],
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertNotIn(monitor.WORKER_ASSIGNMENT_STALL_KIND, [reason["kind"] for reason in emitted])
+
+    def test_worker_deadlock_console_capture_nested_zero_worker_count_stays_silent(self) -> None:
+        room = "E29N57"
+        ticks = [1630662, 1630668, 1630675, 1630685]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_dir = Path(temp_dir)
+            for index, tick in enumerate(ticks, start=1):
+                payload = {
+                    "type": "runtime-summary",
+                    "tick": tick,
+                    "rooms": [
+                        {
+                            "roomName": room,
+                            "shard": "shardX",
+                            "workerAssignmentEvidenceAvailable": True,
+                            "taskCounts": {
+                                "harvest": 0,
+                                "transfer": 0,
+                                "build": 0,
+                                "repair": 0,
+                                "upgrade": 0,
+                                "none": 0,
+                            },
+                            "resources": {
+                                "productiveEnergy": {
+                                    "workerCount": 0,
+                                    "constructionSiteCount": 1,
+                                    "pendingBuildProgress": 4500,
+                                    "productiveAssignmentCount": 0,
+                                    "workerAssignmentBlockedDetail": "spawn_reserving_energy",
+                                }
+                            },
+                        }
+                    ],
+                }
+                (runtime_dir / f"runtime-summary-console-20260601T00000{index}Z.log").write_text(
+                    "#runtime-summary " + json.dumps(payload) + "\n",
+                    encoding="utf-8",
+                )
+
+            warnings: list[str] = []
+            runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                runtime_dir,
+                [monitor.RoomRef(shard="shardX", room=room)],
+                warnings,
+            )
+
+        self.assertEqual(warnings, [])
+        runtime_room = runtime_rooms[f"shardX/{room}"]
+        self.assertEqual(
+            runtime_room[monitor.RUNTIME_SUMMARY_CAPTURE_HISTORY_METADATA_KEY][0]["workerCount"],
+            0,
+        )
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            make_owned_worker_room_snapshot(room, ticks[-1]),
+            {"baseline_established": True, "owner": "lanyusea"},
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_room,
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertNotIn(monitor.WORKER_ASSIGNMENT_STALL_KIND, [reason["kind"] for reason in emitted])
 
     def test_worker_deadlock_console_capture_transient_window_stays_silent(self) -> None:
         room = "E29N57"


### PR DESCRIPTION
## Summary
- Adds a persistent worker-deadlock detector to `scripts/screeps-runtime-monitor.py` so repeated zero-productive-assignment / blocked-worker evidence becomes a runtime alert instead of remaining only in Gameplay Evolution prose.
- Adds focused tactical-response tests for worker-deadlock alert routing and action guidance.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py`
- `python3 -m pytest scripts/test_screeps_runtime_monitor_tactical_response.py -q` — 85 passed, 22 subtests passed

## Issue closure gate
- [x] #1580: Persistent worker-deadlock captures are converted into monitor alert/tactical-response behavior with focused test coverage; verified by the commands above at commit `4175c8106235263917987313d355a4a709531b40`.

Fixes #1580

## Universal task Done gate
- [x] Task type: Runtime monitor / KPI recurrence-prevention code change.
- [x] Expected observable outcome / named deliverable: `scripts/screeps-runtime-monitor.py` emits worker-deadlock alerts from persisted assignment-blocker evidence; named deliverable is commit `4175c8106235263917987313d355a4a709531b40`.
- [x] Non-goals / accepted substitutes: This PR does not change official MMO bot behavior or deploy runtime code; it only improves monitor alerting and tactical-response routing.
- [x] Verification evidence required before Done: `git diff --check`, Python compilation, and focused tactical-response pytest all pass for the changed monitor files.
- [x] Project Evidence / Next action / Blocked by: Issue #1580 and this PR will be set to In review with commit `4175c8106235263917987313d355a4a709531b40`, verification results, and review/CI gate as the next controller action.
- [x] Post-merge/deploy/runtime proof: No official MMO deploy is required for this monitor-only change; post-merge proof is prod-ci success plus the next runtime-alert cron using the updated monitor script.
- [x] Named deliverable proof: `scripts/screeps-runtime-monitor.py` and `scripts/test_screeps_runtime_monitor_tactical_response.py` changed in commit `4175c8106235263917987313d355a4a709531b40`.
