### PR TITLE
rl: enforce trust sample requests

### DIFF
--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -960,6 +960,16 @@ def build_card(
         policy_gradient = policy_gradient_block(registry_path or DEFAULT_STRATEGY_REGISTRY_PATH)
         card["policy_gradient"] = policy_gradient
         card["strategy_variants"] = policy_gradient_strategy_variants(policy_gradient)
+        trust_samples = validate_policy_gradient(policy_gradient)
+        sample_plan = policy_gradient_trust_sample_plan(
+            repetitions=positive_int(card["simulation"]["repetitions"]),
+            scale_environments=positive_int(
+                first_present(card["simulation"], ("scale_environments", "scaleEnvironments"))
+            ),
+            variant_count=len(card["strategy_variants"]),
+            required_samples_per_candidate=trust_samples,
+        )
+        card["simulation"]["repetitions"] = sample_plan["requiredRepetitions"]
     if loop_a_card_supply:
         card["card_supply"] = loop_a_card_supply_block(
             dataset_run_id=dataset_run_id,
@@ -1355,7 +1365,11 @@ def validate_card(raw: Any) -> None:
     if policy_gradient is not None:
         policy_gradient_trust_samples = validate_policy_gradient(policy_gradient)
     if training_approach == "policy_gradient":
-        validate_policy_gradient_simulation(simulation, policy_gradient_trust_samples)
+        validate_policy_gradient_simulation(
+            simulation,
+            policy_gradient_trust_samples,
+            variant_count=len(strategy_variants) if isinstance(strategy_variants, list) else 0,
+        )
         validate_policy_gradient_strategy_variants(policy_gradient, strategy_variants)
 
 
@@ -2619,7 +2633,12 @@ def validate_simulation(raw: Any) -> None:
             raise CardValidationError(f"simulation.{field} must be a non-empty string")
 
 
-def validate_policy_gradient_simulation(raw: Any, required_samples_per_candidate: int | None = None) -> None:
+def validate_policy_gradient_simulation(
+    raw: Any,
+    required_samples_per_candidate: int | None = None,
+    *,
+    variant_count: int = 1,
+) -> None:
     if not isinstance(raw, dict):
         raise CardValidationError("simulation must be a JSON object")
     ticks = positive_int(raw.get("ticks"))
@@ -2637,13 +2656,60 @@ def validate_policy_gradient_simulation(raw: Any, required_samples_per_candidate
     workers = positive_int(raw.get("workers"))
     if workers is None or (worker_floor is not None and workers < worker_floor):
         raise CardValidationError(POLICY_GRADIENT_WORKER_CONCURRENCY_ERROR)
-    requested_samples = repetitions * scale_environments if repetitions is not None else None
-    if requested_samples is None or requested_samples < required_samples:
+    sample_plan = policy_gradient_trust_sample_plan(
+        repetitions=repetitions,
+        scale_environments=scale_environments,
+        variant_count=variant_count,
+        required_samples_per_candidate=required_samples,
+    )
+    if sample_plan["minimumSamplesPerCandidate"] < required_samples:
         raise CardValidationError(
             "policy_gradient cards require "
             f"requested samples per candidate >= {required_samples} to satisfy gradient_trust_gate "
-            "(simulation.repetitions * simulation.scale_environments)"
+            "(per-candidate expanded simulator rows * simulation.repetitions); "
+            f"planned minimum is {sample_plan['minimumSamplesPerCandidate']} with "
+            f"{sample_plan['variantCount']} variant(s), {sample_plan['expandedRowCount']} expanded row(s), "
+            f"and {sample_plan['repetitions']} repetition(s); "
+            f"requires simulation.repetitions >= {sample_plan['requiredRepetitions']}"
         )
+
+
+def policy_gradient_trust_sample_plan(
+    *,
+    repetitions: int | None,
+    scale_environments: int | None,
+    variant_count: int,
+    required_samples_per_candidate: int,
+) -> JsonObject:
+    """Plan the minimum return samples each candidate receives after row expansion."""
+    safe_variant_count = max(1, variant_count)
+    safe_repetitions = repetitions if repetitions is not None and repetitions > 0 else 0
+    safe_scale_environments = scale_environments if scale_environments is not None and scale_environments > 0 else None
+    row_count = max(safe_scale_environments or safe_variant_count, safe_variant_count)
+    rows_by_candidate = [0 for _index in range(safe_variant_count)]
+    for row_index in range(row_count):
+        rows_by_candidate[row_index % safe_variant_count] += 1
+    samples_by_candidate = [row_count_for_candidate * safe_repetitions for row_count_for_candidate in rows_by_candidate]
+    min_rows_per_candidate = min(rows_by_candidate) if rows_by_candidate else 0
+    required_repetitions = (
+        math.ceil(required_samples_per_candidate / min_rows_per_candidate)
+        if min_rows_per_candidate > 0
+        else required_samples_per_candidate
+    )
+    return {
+        "variantCount": safe_variant_count,
+        "repetitions": safe_repetitions,
+        "scaleEnvironments": safe_scale_environments,
+        "expandedRowCount": row_count,
+        "rowsPerCandidate": rows_by_candidate,
+        "minimumRowsPerCandidate": min_rows_per_candidate,
+        "samplesPerCandidate": samples_by_candidate,
+        "minimumSamplesPerCandidate": min(samples_by_candidate) if samples_by_candidate else 0,
+        "requiredSamplesPerCandidate": required_samples_per_candidate,
+        "requiredRepetitions": max(safe_repetitions, required_repetitions),
+        "minimumTotalSamples": required_samples_per_candidate * safe_variant_count,
+        "requestedTotalSamples": sum(samples_by_candidate),
+    }
 
 
 def policy_gradient_simulation_scale_environments(raw: JsonObject) -> int:

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -20,6 +20,7 @@ from typing import Any, Callable, Mapping, Sequence, TextIO
 
 from screeps_rl_experiment_card import (
     POLICY_GRADIENT_MIN_SIMULATION_TICKS,
+    policy_gradient_trust_sample_plan,
     scenario_supports_multi_tier_policy_comparison,
     validate_scenario_metadata,
 )
@@ -366,6 +367,38 @@ def validate_experiment_card(card: JsonObject) -> None:
     if training_approach == "policy_gradient" and (ticks is None or ticks < POLICY_GRADIENT_MIN_SIMULATION_TICKS):
         raise TrainingCardError(
             f"policy_gradient cards require simulation.ticks >= {POLICY_GRADIENT_MIN_SIMULATION_TICKS}"
+        )
+    if training_approach == "policy_gradient":
+        validate_policy_gradient_scale_sample_plan(card, simulation, raw_variants)
+
+
+def validate_policy_gradient_scale_sample_plan(
+    card: JsonObject,
+    simulation: JsonObject,
+    raw_variants: Sequence[Any],
+) -> None:
+    scale_environments = positive_int_value(first_present(simulation, ("scale_environments", "scaleEnvironments")))
+    if scale_environments is None:
+        return
+    repetitions = positive_int_value(simulation.get("repetitions")) or DEFAULT_RUN_REPETITIONS
+    policy_gradient = card.get("policy_gradient", card.get("policyGradient"))
+    required_samples = DEFAULT_GRADIENT_TRUST_MIN_SAMPLES_PER_CANDIDATE
+    if isinstance(policy_gradient, dict):
+        required_samples = int(policy_update_gradient_stability_config(policy_gradient)["minimumSamplesPerCandidate"])
+    sample_plan = policy_gradient_trust_sample_plan(
+        repetitions=repetitions,
+        scale_environments=scale_environments,
+        variant_count=len(raw_variants),
+        required_samples_per_candidate=required_samples,
+    )
+    if sample_plan["minimumSamplesPerCandidate"] < required_samples:
+        raise TrainingCardError(
+            "policy_gradient scale validation requires "
+            f"requested samples per candidate >= {required_samples}; "
+            f"planned minimum is {sample_plan['minimumSamplesPerCandidate']} with "
+            f"{sample_plan['variantCount']} variant(s), {sample_plan['expandedRowCount']} expanded row(s), "
+            f"and {sample_plan['repetitions']} repetition(s); "
+            f"requires simulation.repetitions >= {sample_plan['requiredRepetitions']}"
         )
 
 

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -864,7 +864,7 @@ class RlExperimentCardTest(unittest.TestCase):
         runner.validate_experiment_card(generated)
         config = runner.simulation_config_from_card(generated)
         self.assertEqual(config.workers, 2)
-        self.assertEqual(config.repetitions, 10)
+        self.assertEqual(config.repetitions, 20)
         self.assertEqual(config.ticks, card_helper.POLICY_GRADIENT_MIN_SIMULATION_TICKS)
         self.assertEqual(config.scale_environments, 2)
         self.assertEqual(config.min_concurrent_environments, 2)
@@ -2727,6 +2727,29 @@ class RlExperimentCardTest(unittest.TestCase):
         self.assertGreaterEqual(config.ticks, card_helper.POLICY_GRADIENT_MIN_SIMULATION_TICKS)
         self.assertGreaterEqual(config.repetitions, 20)
 
+    def test_policy_gradient_card_generation_floors_scaled_four_variant_sample_plan(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-scaled-four-variants",
+            code_commit="1" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-17T00:25:00Z",
+            simulation_repetitions=10,
+            simulation_workers=2,
+            simulation_scale_environments=2,
+            simulation_min_concurrent_environments=2,
+        )
+        config = runner.simulation_config_from_card(card)
+        plan = card_helper.policy_gradient_trust_sample_plan(
+            repetitions=config.repetitions,
+            scale_environments=config.scale_environments,
+            variant_count=len(card["strategy_variants"]),
+            required_samples_per_candidate=20,
+        )
+
+        self.assertEqual(len(card["strategy_variants"]), 4)
+        self.assertEqual(config.repetitions, 20)
+        self.assertGreaterEqual(plan["minimumSamplesPerCandidate"], 20)
+
     def test_non_policy_gradient_card_preserves_requested_short_horizon(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-bandit-short-horizon",
@@ -2773,12 +2796,46 @@ class RlExperimentCardTest(unittest.TestCase):
             training_approach="policy_gradient",
             created_at="2026-05-17T00:25:00Z",
         )
-        card["simulation"]["workers"] = 5
-        card["simulation"]["repetitions"] = 4
-        card["simulation"]["scale_environments"] = 5
-        card["simulation"]["min_concurrent_environments"] = 5
+        card["simulation"]["workers"] = 10
+        card["simulation"]["repetitions"] = 10
+        card["simulation"]["scale_environments"] = 10
+        card["simulation"]["min_concurrent_environments"] = 10
 
         card_helper.validate_card(card)
+
+    def test_validate_rejects_policy_gradient_total_scale_budget_that_under_samples_four_variants(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-total-scale-under-samples",
+            code_commit="1" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-17T00:25:00Z",
+            simulation_repetitions=10,
+            simulation_workers=2,
+            simulation_scale_environments=2,
+            simulation_min_concurrent_environments=2,
+        )
+        card["simulation"]["repetitions"] = 10
+
+        with self.assertRaisesRegex(
+            card_helper.CardValidationError,
+            "requested samples per candidate >= 20",
+        ):
+            card_helper.validate_card(card)
+
+    def test_policy_gradient_sample_plan_counts_expanded_rows_per_variant(self) -> None:
+        plan = card_helper.policy_gradient_trust_sample_plan(
+            repetitions=10,
+            scale_environments=2,
+            variant_count=4,
+            required_samples_per_candidate=20,
+        )
+
+        self.assertEqual(plan["expandedRowCount"], 4)
+        self.assertEqual(plan["rowsPerCandidate"], [1, 1, 1, 1])
+        self.assertEqual(plan["samplesPerCandidate"], [10, 10, 10, 10])
+        self.assertEqual(plan["minimumSamplesPerCandidate"], 10)
+        self.assertEqual(plan["requiredRepetitions"], 20)
+        self.assertEqual(plan["minimumTotalSamples"], 80)
 
     def test_validate_rejects_policy_gradient_scale_environments_above_workers(self) -> None:
         card = card_helper.build_card(
@@ -3058,7 +3115,7 @@ class RlExperimentCardTest(unittest.TestCase):
         runner.validate_experiment_card(generated)
         config = runner.simulation_config_from_card(generated)
         self.assertEqual(config.workers, 5)
-        self.assertEqual(config.repetitions, 4)
+        self.assertEqual(config.repetitions, 20)
         self.assertEqual(config.scale_environments, 5)
         self.assertIsNone(config.min_concurrent_environments)
 

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -523,6 +523,25 @@ class RlTrainingRunnerTest(unittest.TestCase):
         ):
             runner.validate_experiment_card(card)
 
+    def test_experiment_card_validation_rejects_scaled_policy_gradient_under_sample_plan(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-training-policy-gradient-under-sampled-scale",
+            code_commit="a" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-18T10:19:45Z",
+            simulation_repetitions=10,
+            simulation_workers=2,
+            simulation_scale_environments=2,
+            simulation_min_concurrent_environments=2,
+        )
+        card["simulation"]["repetitions"] = 10
+
+        with self.assertRaisesRegex(
+            runner.TrainingCardError,
+            "planned minimum is 10 .*requires simulation\\.repetitions >= 20",
+        ):
+            runner.validate_experiment_card(card)
+
     def test_experiment_card_validation_rejects_inconsistent_scenario_suitability(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-training-scenario-invalid",
@@ -2920,6 +2939,7 @@ export const STRATEGY_REGISTRY = [
             update["gradientEstimation"]["schemeIdentity"]["estimator"],
             runner.POLICY_GRADIENT_LEXICOGRAPHIC_REINFORCE_ESTIMATOR,
         )
+
         self.assertEqual(
             update["gradientEstimation"]["schemeIdentity"]["gradientReward"],
             runner.POLICY_GRADIENT_LEXICOGRAPHIC_PER_TIER_REWARD,
@@ -2965,6 +2985,59 @@ export const STRATEGY_REGISTRY = [
         self.assertFalse(update["promotionGate"]["officialMmoWritesAllowed"])
         self.assertTrue(update["nextCandidatePolicy"]["trustedGradientUpdate"])
         self.assertFalse(update["nextCandidatePolicy"]["liveEffect"])
+
+    def test_gradient_stability_records_insufficient_samples_for_four_candidate_validation_plan(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-four-candidate-samples",
+            code_commit="1" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-05-17T00:25:00Z",
+            simulation_repetitions=10,
+            simulation_workers=2,
+            simulation_scale_environments=2,
+            simulation_min_concurrent_environments=2,
+        )
+        policy_gradient = card["policy_gradient"]
+        parameter_space = runner.policy_update_parameter_space(policy_gradient)
+        candidates: list[JsonObject] = []
+        samples: list[JsonObject] = []
+        for candidate in policy_gradient["candidate_parameter_vectors"]:
+            row = {
+                "candidatePolicyId": candidate["candidatePolicyId"],
+                "strategyVariantId": candidate["strategyVariantId"],
+                "parameters": candidate["parameters"],
+                "returnSampleCount": 10,
+            }
+            candidates.append(row)
+            for _index in range(10):
+                samples.append(
+                    {
+                        "candidatePolicyId": candidate["candidatePolicyId"],
+                        "strategyVariantId": candidate["strategyVariantId"],
+                        "parameters": candidate["parameters"],
+                        "returnTuple": [1, 0, 0, 0],
+                    }
+                )
+
+        stability = runner.policy_update_gradient_stability_gate(
+            policy_gradient=policy_gradient,
+            parameter_space=parameter_space,
+            candidates=candidates,
+            samples=samples,
+            anchor_parameters=candidates[0]["parameters"],
+            return_baseline=[1, 0, 0, 0],
+            gradient={},
+            selected_reward_tier_by_parameter={},
+        )
+
+        self.assertEqual(stability["classification"], "insufficient_sample_high_variance")
+        self.assertEqual(stability["minimumSamplesPerCandidate"], 20)
+        self.assertEqual(stability["minimumTotalSamples"], 80)
+        self.assertEqual(stability["totalReturnSampleCount"], 40)
+        self.assertEqual(set(stability["sampleCountByCandidate"].values()), {10})
+        self.assertEqual(len(stability["insufficientCandidates"]), 4)
+        self.assertIn("fewer Monte Carlo return samples per candidate", stability["reason"])
+        self.assertFalse(stability["trustedGradientUpdate"])
 
     def test_reinforce_gradient_stability_trusts_same_scheme_previous_gradient(self) -> None:
         policy_gradient = reinforce_stability_policy_gradient()


### PR DESCRIPTION
## Summary
- Enforces/validates policy-gradient trust-sample planning so 4-variant validation-scale cards cannot silently produce only 10 return samples per candidate when the trust gate requires 20.
- Adds deterministic metadata for requested/required samples and focused regression coverage for both card validation and training-runner stability reporting.
- Keeps the path offline/private/shadow only; no Tencent paid compute, ASG, official MMO writes, deploys, or live policy control.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_training_runner.py scripts/screeps_rl_experiment_card.py scripts/test_screeps_rl_training_runner.py scripts/test_screeps_rl_experiment_card.py`
- `python3 -m unittest scripts/test_screeps_rl_training_runner.py scripts/test_screeps_rl_experiment_card.py` — 216 tests OK

## Safety
- No secrets printed.
- No paid Tencent run launched.
- No official MMO writes or policy rollout.
- Follow-up validation remains gated by Project/PR review and #1337 evidence.

Related to #1337, #879, #1032, #1582.

## Universal task Done gate
- [x] Task type: RL flywheel code/test change for offline trust-sample planning.
- [x] Expected observable outcome / named deliverable: guarded card/runner behavior that surfaces when a validation-scale card undersamples policy-gradient candidates against the configured trust threshold.
- [x] Non-goals / accepted substitutes: no Tencent paid compute, no official MMO deploy, no learned-policy rollout, no reward-model scalar authorization work from #1582 in this PR.
- [x] Verification evidence required before Done: local diff-check, py_compile, and unittest suite results recorded above for the exact changed files.
- [x] Project Evidence / Next action / Blocked by: #1337/#879/#1032 Project fields identify commit/PR evidence and the separate guarded validation artifact required before #1337 closure.
- [x] Post-merge/deploy/runtime proof: #1337 stays open for the next guarded local validation report proving return samples per candidate meet the trust gate; this PR does not claim official deploy/runtime proof.
- [x] Named deliverable proof: source and tests implement the trust-sample planning/validation contract in `scripts/screeps_rl_experiment_card.py` and `scripts/screeps_rl_training_runner.py`.
