### PR TITLE
rl: guard scalar reward activation

### DIFF
--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -28,6 +28,8 @@ STRATEGY_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
 DRY_RUN_DATASET_RUN_ID = "rl-dry-run-000000000000"
 SAFETY_FALSE_FIELDS = ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed")
 SAFETY_TRUE_FIELDS = ("ood_rejection", "conservative_actions_only")
+SCALAR_WEIGHTED_SUM_USE = "offline_private_shadow_policy_gradient_comparison"
+SCALAR_WEIGHTED_SUM_COMPONENT_ORDER = ["reliability", "territory", "resources", "kills", "activation"]
 SCENARIO_METADATA_TYPE = "screeps-rl-training-scenario"
 DEFAULT_SCENARIO_ID = "e1s1-single-room-no-hostile"
 MULTI_TIER_SCENARIO_V0_ID = "multi-tier-territory-combat-v0"
@@ -223,8 +225,8 @@ def validate_created_at(created_at: str) -> None:
         raise CardValidationError("created_at must be an ISO UTC timestamp like 2026-05-03T00:00:00.000000Z")
 
 
-def reward_model() -> JsonObject:
-    return {
+def reward_model(*, scalar_weighted_sum_authorized: bool = False) -> JsonObject:
+    model: JsonObject = {
         "component_order": ["reliability", "territory", "resources", "kills"],
         "component_weights": {
             "alpha_reliability": 1000000000,
@@ -233,9 +235,30 @@ def reward_model() -> JsonObject:
             "delta_kills": 1,
         },
         "formula": "R = alpha*R_reliability + beta*R_territory + gamma*R_resources + delta*R_kills; alpha >> beta >> gamma >> delta",
-        "scalar_weighted_sum_authorized": False,
+        "scalar_weighted_sum_authorized": scalar_weighted_sum_authorized,
+        "scalar_weighted_sum_use": SCALAR_WEIGHTED_SUM_USE if scalar_weighted_sum_authorized else "not_used",
         "type": "lexicographic",
     }
+    if scalar_weighted_sum_authorized:
+        model["scalar_weighted_sum"] = {
+            "authorized": True,
+            "use": SCALAR_WEIGHTED_SUM_USE,
+            "component_order": list(SCALAR_WEIGHTED_SUM_COMPONENT_ORDER),
+            "component_weights": {
+                "alpha_reliability": 1000000000,
+                "beta_territory": 1000000,
+                "gamma_resources": 1000,
+                "delta_kills": 1,
+                "epsilon_activation": 1,
+            },
+            "activation_score_source": (
+                "multiTierActivationTraces.policyActivation.activationScore; "
+                "missing activation scores are treated as zero"
+            ),
+            "ranking_reward_model": "lexicographic",
+            "promotion_use": "blocked_until_trusted_samples_and_loop_b_advantage_gate",
+        }
+    return model
 
 
 def safety_block() -> JsonObject:
@@ -874,6 +897,7 @@ def build_card(
     source_gate: JsonObject | None = None,
     scenario_id: str = DEFAULT_SCENARIO_ID,
     require_multi_tier_scenario: bool = False,
+    scalar_weighted_sum_authorized: bool = False,
 ) -> JsonObject:
     validate_dataset_run_id(dataset_run_id)
     validate_code_commit(code_commit)
@@ -882,6 +906,8 @@ def build_card(
         raise CardValidationError(f"training_approach must be one of: {', '.join(TRAINING_APPROACHES)}")
     if loop_a_card_supply and training_approach != "policy_gradient":
         raise CardValidationError("Loop A card supply requires training_approach=policy_gradient")
+    if scalar_weighted_sum_authorized and training_approach != "policy_gradient":
+        raise CardValidationError("scalar weighted reward authorization requires training_approach=policy_gradient")
 
     default_ticks = POLICY_GRADIENT_SIMULATION_TICKS if training_approach == "policy_gradient" else DEFAULT_SIMULATION_TICKS
     default_repetitions = (
@@ -922,6 +948,10 @@ def build_card(
         raise CardValidationError(
             "multi-tier policy comparisons require a scenario with adjacent-room territory and hostile combat signals"
         )
+    if scalar_weighted_sum_authorized and not scenario_supports_multi_tier_policy_comparison(scenario):
+        raise CardValidationError(
+            "scalar weighted reward authorization requires the active multi-tier territory/combat scenario"
+        )
     simulation_map_source_file = scenario_simulation_map_source_file(scenario_id)
 
     commit_prefix = code_commit[:12].lower()
@@ -940,7 +970,7 @@ def build_card(
         "officialMmoWrites": False,
         "officialMmoWritesAllowed": False,
         "ood_rejection": True,
-        "reward_model": reward_model(),
+        "reward_model": reward_model(scalar_weighted_sum_authorized=scalar_weighted_sum_authorized),
         "scenario": scenario,
         "safety": safety_block(),
         "simulation": simulation_block(
@@ -1350,7 +1380,11 @@ def validate_card(raw: Any) -> None:
         raise CardValidationError(f"card_id must be {expected}")
 
     validate_safety(raw)
-    validate_reward_model(raw.get("reward_model"))
+    validate_reward_model(
+        raw.get("reward_model"),
+        training_approach=training_approach,
+        scenario=raw.get("scenario"),
+    )
     validate_card_supply(raw)
     validate_source_gate(raw)
     validate_scenario(raw)
@@ -2341,7 +2375,12 @@ def validate_safety(raw: JsonObject) -> None:
             raise CardValidationError(f"{field} must be true when present")
 
 
-def validate_reward_model(raw: Any) -> None:
+def validate_reward_model(
+    raw: Any,
+    *,
+    training_approach: str | None = None,
+    scenario: Any = None,
+) -> None:
     if not isinstance(raw, dict):
         raise CardValidationError("reward_model must be a JSON object")
     if raw.get("type") != "lexicographic":
@@ -2362,8 +2401,66 @@ def validate_reward_model(raw: Any) -> None:
         > weights["delta_kills"]
     ):
         raise CardValidationError("reward_model weights must be strictly lexicographic")
-    if raw.get("scalar_weighted_sum_authorized") is not False:
-        raise CardValidationError("reward_model.scalar_weighted_sum_authorized must be false")
+    scalar_authorized = first_present(
+        raw,
+        ("scalar_weighted_sum_authorized", "scalarWeightedSumAuthorized"),
+    )
+    if scalar_authorized is False:
+        scalar_use = first_present(raw, ("scalar_weighted_sum_use", "scalarWeightedSumUse"))
+        if scalar_use not in (None, "not_used"):
+            raise CardValidationError("reward_model.scalar_weighted_sum_use must be not_used unless authorized")
+        return
+    if scalar_authorized is not True:
+        raise CardValidationError("reward_model.scalar_weighted_sum_authorized must be false unless explicitly authorized")
+    validate_scalar_weighted_sum_authorization(raw, training_approach=training_approach, scenario=scenario)
+
+
+def validate_scalar_weighted_sum_authorization(
+    raw: JsonObject,
+    *,
+    training_approach: str | None,
+    scenario: Any,
+) -> None:
+    if training_approach != "policy_gradient":
+        raise CardValidationError("reward_model.scalar_weighted_sum_authorized requires training_approach=policy_gradient")
+    if not scenario_supports_multi_tier_policy_comparison(scenario):
+        raise CardValidationError("reward_model.scalar_weighted_sum_authorized requires active multi-tier scenario evidence")
+    scalar_use = first_present(raw, ("scalar_weighted_sum_use", "scalarWeightedSumUse"))
+    if scalar_use != SCALAR_WEIGHTED_SUM_USE:
+        raise CardValidationError(f"reward_model.scalar_weighted_sum_use must be {SCALAR_WEIGHTED_SUM_USE}")
+    config = first_present(raw, ("scalar_weighted_sum", "scalarWeightedSum"))
+    if not isinstance(config, dict):
+        raise CardValidationError("reward_model.scalar_weighted_sum must be a JSON object when authorized")
+    if first_present(config, ("authorized", "scalar_weighted_sum_authorized", "scalarWeightedSumAuthorized")) is not True:
+        raise CardValidationError("reward_model.scalar_weighted_sum.authorized must be true when authorized")
+    if first_present(config, ("use", "scalar_weighted_sum_use", "scalarWeightedSumUse")) != SCALAR_WEIGHTED_SUM_USE:
+        raise CardValidationError(f"reward_model.scalar_weighted_sum.use must be {SCALAR_WEIGHTED_SUM_USE}")
+    if first_present(config, ("component_order", "componentOrder")) != SCALAR_WEIGHTED_SUM_COMPONENT_ORDER:
+        raise CardValidationError(
+            "reward_model.scalar_weighted_sum.component_order must preserve reliability, territory, resources, kills, activation"
+        )
+    weights = first_present(config, ("component_weights", "componentWeights"))
+    if not isinstance(weights, dict):
+        raise CardValidationError("reward_model.scalar_weighted_sum.component_weights must be a JSON object")
+    required_weights = (
+        "alpha_reliability",
+        "beta_territory",
+        "gamma_resources",
+        "delta_kills",
+        "epsilon_activation",
+    )
+    for field in required_weights:
+        value = weights.get(field)
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            raise CardValidationError(f"reward_model.scalar_weighted_sum.component_weights.{field} must be a positive integer")
+    if not (
+        weights["alpha_reliability"]
+        > weights["beta_territory"]
+        > weights["gamma_resources"]
+        > weights["delta_kills"]
+        >= weights["epsilon_activation"]
+    ):
+        raise CardValidationError("reward_model.scalar_weighted_sum weights must preserve lexicographic dominance")
 
 
 def validate_strategy_variants(raw: Any) -> None:
@@ -2842,6 +2939,12 @@ def resolve_cli_scenario_request(args: argparse.Namespace) -> tuple[str, bool]:
         if scenario_id not in MULTI_TIER_SCENARIO_IDS:
             raise CardValidationError("Loop A policy-gradient proof requires the multi-tier territory/combat scenario")
         return scenario_id, True
+    if args.authorize_scalar_weighted_reward:
+        if scenario_id is None:
+            return MULTI_TIER_SCENARIO_ID, True
+        if scenario_id not in MULTI_TIER_SCENARIO_IDS:
+            raise CardValidationError("scalar weighted reward authorization requires the multi-tier territory/combat scenario")
+        return scenario_id, True
     return scenario_id or DEFAULT_SCENARIO_ID, require_multi_tier
 
 
@@ -2930,6 +3033,14 @@ def build_parser() -> argparse.ArgumentParser:
         "--require-multi-tier-scenario",
         action="store_true",
         help="Reject cards whose scenario lacks adjacent-room territory and hostile combat signals.",
+    )
+    parser.add_argument(
+        "--authorize-scalar-weighted-reward",
+        action="store_true",
+        help=(
+            "Authorize scalar weighted reward aggregation for offline/private/shadow policy-gradient "
+            "comparison only. Requires the active multi-tier territory/combat scenario."
+        ),
     )
     parser.add_argument(
         "--dry-run",
@@ -3156,6 +3267,7 @@ def main(
             source_gate=source_gate,
             scenario_id=scenario_id,
             require_multi_tier_scenario=require_multi_tier_scenario,
+            scalar_weighted_sum_authorized=args.authorize_scalar_weighted_reward,
         )
         if args.loop_a_local_fallback:
             output_path = args.output or repo / DEFAULT_LOOP_A_LOCAL_FALLBACK_CARD_PATH.relative_to(REPO_ROOT)

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -78,6 +78,7 @@ GRADIENT_MOMENTUM_EVIDENCE_TYPE = "screeps-rl-gradient-momentum-evidence"
 POLICY_GRADIENT_SCALAR_ESTIMATOR = "scalar_weighted_sum_score_function_reinforce_v1"
 POLICY_GRADIENT_SCALAR_REWARD = "scalar_weighted_sum"
 POLICY_GRADIENT_SCALAR_WEIGHTED_SUM_USE = "gradient_estimation_only_non_promotional"
+SCALAR_WEIGHTED_SUM_AUTHORIZED_USE = "offline_private_shadow_policy_gradient_comparison"
 POLICY_GRADIENT_LEXICOGRAPHIC_REINFORCE_ESTIMATOR = "lexicographic_per_tier_score_function_reinforce_v1"
 POLICY_GRADIENT_LEXICOGRAPHIC_PER_TIER_REWARD = "lexicographic_per_tier"
 POLICY_GRADIENT_LEXICOGRAPHIC_TIER_BASELINE = "anchor_candidate_mean_return"
@@ -94,6 +95,7 @@ DEFAULT_POLICY_GRADIENT_SCALAR_COMPONENT_WEIGHTS = {
     "kills": 1.0,
 }
 REWARD_TIERS = ("reliability", "territory", "resources", "kills")
+SCALAR_WEIGHTED_REWARD_TIERS = (*REWARD_TIERS, "activation")
 MULTI_TIER_ACTIVATION_PROOF_TYPE = "screeps-rl-multi-tier-activation-proof"
 MULTI_TIER_ACTIVATION_AUDIT_TYPE = "screeps-rl-multi-tier-activation-audit"
 MULTI_TIER_ACTIVATION_IMPLEMENTATION = "multi-tier-policy-activation-proof-v2"
@@ -334,8 +336,10 @@ def validate_experiment_card(card: JsonObject) -> None:
         "scalar_weighted_sum_authorized",
         reward_model.get("scalarWeightedSumAuthorized"),
     )
-    if scalar_authorized is not False:
-        raise TrainingCardError("reward_model.scalar_weighted_sum_authorized must be false")
+    if scalar_authorized is True:
+        validate_scalar_weighted_reward_authorization(card, reward_model, training_approach)
+    elif scalar_authorized is not False:
+        raise TrainingCardError("reward_model.scalar_weighted_sum_authorized must be false unless explicitly authorized")
 
     validate_card_supply(card)
     validate_scenario_metadata(card, error_cls=TrainingCardError, require_presence=True)
@@ -370,6 +374,77 @@ def validate_experiment_card(card: JsonObject) -> None:
         )
     if training_approach == "policy_gradient":
         validate_policy_gradient_scale_sample_plan(card, simulation, raw_variants)
+
+
+def validate_scalar_weighted_reward_authorization(
+    card: JsonObject,
+    reward_model: JsonObject,
+    training_approach: Any,
+) -> None:
+    if training_approach != "policy_gradient":
+        raise TrainingCardError("reward_model.scalar_weighted_sum_authorized requires training_approach=policy_gradient")
+    if not card_scenario_supports_multi_tier_policy_comparison(card):
+        raise TrainingCardError("reward_model.scalar_weighted_sum_authorized requires active multi-tier scenario evidence")
+    scalar_use = first_present(reward_model, ("scalar_weighted_sum_use", "scalarWeightedSumUse"))
+    if scalar_use != SCALAR_WEIGHTED_SUM_AUTHORIZED_USE:
+        raise TrainingCardError(f"reward_model.scalar_weighted_sum_use must be {SCALAR_WEIGHTED_SUM_AUTHORIZED_USE}")
+    config = first_mapping(reward_model, ("scalar_weighted_sum", "scalarWeightedSum"))
+    if config is None:
+        raise TrainingCardError("reward_model.scalar_weighted_sum must be present when scalar reward is authorized")
+    if first_present(config, ("authorized", "scalar_weighted_sum_authorized", "scalarWeightedSumAuthorized")) is not True:
+        raise TrainingCardError("reward_model.scalar_weighted_sum.authorized must be true when authorized")
+    if first_present(config, ("use", "scalar_weighted_sum_use", "scalarWeightedSumUse")) != SCALAR_WEIGHTED_SUM_AUTHORIZED_USE:
+        raise TrainingCardError(f"reward_model.scalar_weighted_sum.use must be {SCALAR_WEIGHTED_SUM_AUTHORIZED_USE}")
+    if first_present(config, ("component_order", "componentOrder")) != list(SCALAR_WEIGHTED_REWARD_TIERS):
+        raise TrainingCardError(
+            "reward_model.scalar_weighted_sum.component_order must preserve reliability, territory, resources, kills, activation"
+        )
+    weights = first_mapping(config, ("component_weights", "componentWeights"))
+    if weights is None:
+        raise TrainingCardError("reward_model.scalar_weighted_sum.component_weights must be present")
+    required_weights = (
+        "alpha_reliability",
+        "beta_territory",
+        "gamma_resources",
+        "delta_kills",
+        "epsilon_activation",
+    )
+    for field in required_weights:
+        value = weights.get(field)
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            raise TrainingCardError(
+                f"reward_model.scalar_weighted_sum.component_weights.{field} must be a positive integer"
+            )
+    if not (
+        weights["alpha_reliability"]
+        > weights["beta_territory"]
+        > weights["gamma_resources"]
+        > weights["delta_kills"]
+        >= weights["epsilon_activation"]
+    ):
+        raise TrainingCardError("reward_model.scalar_weighted_sum weights must preserve lexicographic dominance")
+
+
+def card_scenario_supports_multi_tier_policy_comparison(card: JsonObject) -> bool:
+    scenario = card.get("scenario", card.get("trainingScenario"))
+    if not isinstance(scenario, dict):
+        return False
+    capabilities = scenario.get("capabilities")
+    suitability = scenario.get("suitability")
+    evidence = scenario.get("evidence")
+    if not isinstance(capabilities, dict) or not isinstance(suitability, dict) or not isinstance(evidence, dict):
+        return False
+    hostile_fixture = text_or_none(first_present(evidence, ("hostile_fixture", "hostileFixture")))
+    return (
+        capabilities.get("multi_room_capable") is True
+        and capabilities.get("adjacent_room_territory_signal") is True
+        and capabilities.get("hostile_combat_signal") is True
+        and capabilities.get("multi_tier_policy_comparison") is True
+        and suitability.get("multi_tier_policy_comparison") is True
+        and suitability.get("territory_combat_differentiation") is True
+        and first_present(evidence, ("implementation_status", "implementationStatus")) == "active_fixture_validated"
+        and bool(hostile_fixture)
+    )
 
 
 def validate_policy_gradient_scale_sample_plan(
@@ -905,6 +980,26 @@ def text_or_none(value: Any) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
+def scalar_weighted_sum_authorized(raw: Any) -> bool:
+    if not isinstance(raw, dict):
+        return False
+    return first_present(raw, ("scalar_weighted_sum_authorized", "scalarWeightedSumAuthorized")) is True
+
+
+def scalar_weighted_sum_use(raw: Any) -> str:
+    if not isinstance(raw, dict):
+        return "not_used"
+    return (
+        text_or_none(first_present(raw, ("scalar_weighted_sum_use", "scalarWeightedSumUse")))
+        or "not_used"
+    )
+
+
+def policy_gradient_scalar_weighted_sum_authorized(policy_gradient: JsonObject) -> bool:
+    reward_model = first_mapping(policy_gradient, ("reward_model", "rewardModel"))
+    return scalar_weighted_sum_authorized(reward_model)
+
+
 def runtime_parameter_transport_without_consumption_status(value: Any) -> bool:
     return text_or_none(value) in RUNTIME_PARAMETER_TRANSPORT_WITHOUT_CONSUMPTION_STATUSES
 
@@ -921,14 +1016,23 @@ def reward_options_from_card(card: JsonObject) -> JsonObject:
     normalizers = reward_model.get("normalizers")
     if not isinstance(normalizers, dict):
         normalizers = {}
-    return {
+    scalar_authorized = scalar_weighted_sum_authorized(reward_model)
+    options: JsonObject = {
         "componentOrder": list(REWARD_TIERS),
         "weights": weights,
         "resourceNormalizer": positive_float_value(
             reward_model.get("resource_normalizer", reward_model.get("resourceNormalizer", normalizers.get("resources")))
         )
         or DEFAULT_RESOURCE_NORMALIZER,
+        "scalarWeightedSumAuthorized": scalar_authorized,
+        "scalarWeightedSumUse": scalar_weighted_sum_use(reward_model) if scalar_authorized else "not_used",
     }
+    if scalar_authorized:
+        options["scalarWeightEvidence"] = policy_update_scalar_reward_weight_evidence({"rewardModel": reward_model})
+        scalar_config = first_mapping(reward_model, ("scalar_weighted_sum", "scalarWeightedSum"))
+        if scalar_config is not None:
+            options["scalarWeightedSum"] = copy.deepcopy(scalar_config)
+    return options
 
 
 def positive_float_value(value: Any) -> float | None:
@@ -1606,6 +1710,7 @@ def build_training_report(
         warnings.append(
             "experiment card scenario is classified as not suitable for multi-tier territory/combat policy comparison"
         )
+    scalar_weighted_reward = build_scalar_weighted_reward_report(scored_results, reward_options)
 
     report = {
         "type": REPORT_TYPE,
@@ -1637,18 +1742,7 @@ def build_training_report(
                 "mapSourceFile": str(config.map_source_file),
             },
         },
-        "rewardModel": {
-            "type": "lexicographic",
-            "componentOrder": list(REWARD_TIERS),
-            "resourceNormalizer": reward_options["resourceNormalizer"],
-            "formula": (
-                "compare (successful simulator run share, roomsGained - roomsLost, "
-                "(storedEnergyDelta + collectedEnergy) / resourceNormalizer, "
-                "hostileKills - ownLosses) lexicographically"
-            ),
-            "scalarWeightedSumAuthorized": False,
-            "expansionSurvival": "claimed rooms count as held only with at least one spawn and one owned creep at end",
-        },
+        "rewardModel": build_report_reward_model(reward_options),
         "strategyVariants": [variant.to_json() for variant in variants],
         "candidateStrategyIds": [variant.id for variant in variants],
         "incumbentStrategyIds": incumbent_ids,
@@ -1685,6 +1779,8 @@ def build_training_report(
         "kpiSummary": build_kpi_summary(scored_results),
         "warnings": warnings,
     }
+    if scalar_weighted_reward is not None:
+        report["scalarWeightedReward"] = scalar_weighted_reward
     if scenario is not None:
         report["scenario"] = scenario
         activation_proof = build_multi_tier_activation_proof(
@@ -1755,7 +1851,115 @@ def build_training_report(
         if isinstance(gradient_momentum, dict):
             report["gradientMomentum"] = copy.deepcopy(gradient_momentum)
         report["policyUpdate"] = policy_update
+    if scalar_weighted_reward is not None:
+        report["conclusionRegistryUpdate"] = scalar_weighted_reward_conclusion_registry_update(report)
     return report
+
+
+def build_report_reward_model(reward_options: JsonObject) -> JsonObject:
+    payload: JsonObject = {
+        "type": "lexicographic",
+        "componentOrder": list(REWARD_TIERS),
+        "resourceNormalizer": reward_options["resourceNormalizer"],
+        "formula": (
+            "compare (successful simulator run share, roomsGained - roomsLost, "
+            "(storedEnergyDelta + collectedEnergy) / resourceNormalizer, "
+            "hostileKills - ownLosses) lexicographically"
+        ),
+        "scalarWeightedSumAuthorized": reward_options.get("scalarWeightedSumAuthorized") is True,
+        "scalarWeightedSumUse": reward_options.get("scalarWeightedSumUse") or "not_used",
+        "expansionSurvival": "claimed rooms count as held only with at least one spawn and one owned creep at end",
+    }
+    if reward_options.get("scalarWeightedSumAuthorized") is True:
+        payload["scalarWeightedSum"] = {
+            "authorized": True,
+            "use": reward_options.get("scalarWeightedSumUse") or SCALAR_WEIGHTED_SUM_AUTHORIZED_USE,
+            "rankingRewardModel": POLICY_GRADIENT_LEXICOGRAPHIC_REWARD,
+            "componentOrder": list(SCALAR_WEIGHTED_REWARD_TIERS),
+            "weightEvidence": copy.deepcopy(reward_options.get("scalarWeightEvidence")),
+            "activationScoreSource": (
+                "multiTierActivationTraces.policyActivation.activationScore; missing activation scores are zero"
+            ),
+            "promotionUse": "blocked_until_trusted_samples_and_loop_b_advantage_gate",
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+            "safety": safety_metadata(),
+        }
+    return payload
+
+
+def build_scalar_weighted_reward_report(
+    results: Sequence[JsonObject],
+    reward_options: JsonObject,
+) -> JsonObject | None:
+    if reward_options.get("scalarWeightedSumAuthorized") is not True:
+        return None
+    variant_rewards = []
+    for result in results:
+        reward = result.get("reward") if isinstance(result.get("reward"), dict) else {}
+        scalar_reward = reward.get("scalarWeightedSum") if isinstance(reward, dict) else None
+        if not isinstance(scalar_reward, dict):
+            continue
+        variant_rewards.append({
+            "variantId": result.get("variantId"),
+            "rolloutStatus": result.get("rolloutStatus"),
+            "rewardTuple": copy.deepcopy(reward.get("tuple")),
+            "scalarReward": scalar_reward.get("scalarReward"),
+            "activationScore": scalar_reward.get("activationScore"),
+            "componentValuesByRewardTier": copy.deepcopy(scalar_reward.get("componentValuesByRewardTier")),
+            "weightedComponentsByRewardTier": copy.deepcopy(scalar_reward.get("weightedComponentsByRewardTier")),
+            "sampleCount": scalar_reward.get("sampleCount"),
+        })
+    return {
+        "type": "screeps-rl-scalar-weighted-reward-activation-report",
+        "schemaVersion": SCHEMA_VERSION,
+        "authorized": True,
+        "use": reward_options.get("scalarWeightedSumUse") or SCALAR_WEIGHTED_SUM_AUTHORIZED_USE,
+        "rankingRewardModel": POLICY_GRADIENT_LEXICOGRAPHIC_REWARD,
+        "componentOrder": list(SCALAR_WEIGHTED_REWARD_TIERS),
+        "weightEvidence": copy.deepcopy(reward_options.get("scalarWeightEvidence")),
+        "variantRewards": variant_rewards,
+        "promotionBlockedUntil": [
+            "issue_1337_trusted_samples_per_candidate",
+            "loop_b_policy_advantage_gate",
+        ],
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+        "safety": safety_metadata(),
+    }
+
+
+def scalar_weighted_reward_conclusion_registry_update(report: JsonObject) -> JsonObject:
+    promotion_gate = report.get("policyUpdatePromotionGate")
+    return {
+        "type": "screeps-rl-conclusion-registry-update",
+        "schemaVersion": SCHEMA_VERSION,
+        "sourceIssue": "#1582",
+        "registryPath": "runtime-artifacts/rl-control-loop/conclusion-registry.json",
+        "status": "blocked",
+        "classification": "scalar_weighted_reward_activation_shadow_only",
+        "newConclusionIds": ["ISSUE-1582-SCALAR-WEIGHTED-REWARD-ACTIVATION"],
+        "appendedToExisting": [],
+        "loopA": {
+            "promotionEligible": False,
+            "missingPrerequisites": ["issue_1337_trusted_samples_per_candidate", "loop_b_policy_advantage_gate"],
+        },
+        "loopB": {
+            "promotionEligible": False,
+            "missingPrerequisites": ["loop_b_policy_advantage_gate"],
+        },
+        "promotionGate": copy.deepcopy(promotion_gate) if isinstance(promotion_gate, dict) else None,
+        "reason": (
+            "scalar weighted reward activation is authorized only for offline/private/shadow comparison; "
+            "promotion remains blocked until trusted sample evidence and Loop B advantage gates pass"
+        ),
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+        "safety": safety_metadata(),
+    }
 
 
 def training_simulator_ticks(simulator_runs: Sequence[JsonObject]) -> int:
@@ -2108,16 +2312,25 @@ def build_reinforce_policy_update(
     bounded_integer_step = policy_update_uses_bounded_integer_step(policy_gradient)
     anchor_parameters = anchor["parameters"]
     anchor_return_baseline = policy_update_candidate_return_baseline(anchor)
-    gradient_estimation = policy_update_lexicographic_reinforce_gradient_estimation(
-        policy_gradient=policy_gradient,
-        parameter_space=parameter_space,
-        samples=samples,
-        anchor_parameters=anchor_parameters,
-        anchor_return_baseline=anchor_return_baseline,
-    )
+    scalar_weighted_authorized = policy_gradient_scalar_weighted_sum_authorized(policy_gradient)
+    if scalar_weighted_authorized:
+        gradient_estimation = policy_update_scalar_weighted_gradient_estimation(
+            policy_gradient=policy_gradient,
+            parameter_space=parameter_space,
+            samples=samples,
+            anchor_parameters=anchor_parameters,
+        )
+    else:
+        gradient_estimation = policy_update_lexicographic_reinforce_gradient_estimation(
+            policy_gradient=policy_gradient,
+            parameter_space=parameter_space,
+            samples=samples,
+            anchor_parameters=anchor_parameters,
+            anchor_return_baseline=anchor_return_baseline,
+        )
     raw_gradient = gradient_estimation["gradient"]
-    gradient_by_tier = gradient_estimation["gradientByRewardTier"]
-    selected_reward_tier_by_parameter = gradient_estimation["selectedRewardTierByParameter"]
+    gradient_by_tier = gradient_estimation.get("gradientByRewardTier", {})
+    selected_reward_tier_by_parameter = gradient_estimation.get("selectedRewardTierByParameter", {})
     gradient_momentum = policy_update_gradient_momentum_evidence(
         policy_gradient=policy_gradient,
         raw_gradient=raw_gradient,
@@ -2266,7 +2479,10 @@ def build_reinforce_policy_update(
         "promotionGate": copy.deepcopy(promotion_gate),
         "parameterEvidence": {
             "derivation": (
-                "deterministic REINFORCE score-function estimate from offline simulator Monte Carlo "
+                "deterministic REINFORCE score-function estimate from authorized scalar weighted "
+                "offline/private/shadow reward returns, preserving lexicographic ranking and promotion gates"
+                if scalar_weighted_authorized
+                else "deterministic REINFORCE score-function estimate from offline simulator Monte Carlo "
                 "reward-tuple returns, selecting the first lexicographic reward tier with per-parameter "
                 "evidence and preserving lexicographic ranking/promotion gates"
             ),
@@ -2287,6 +2503,7 @@ def build_reinforce_policy_update(
             "candidateCount": len(candidates),
             "policyUpdateAlgorithm": TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM,
             "trueGradient": True,
+            "scalarWeightedSumAuthorized": scalar_weighted_authorized,
             "gradientStable": gradient_stability["gradientStable"],
             "trustedGradientUpdate": trusted_gradient_update,
             "highVariance": gradient_stability["highVariance"],
@@ -2308,7 +2525,13 @@ def build_reinforce_policy_update(
         "iterations": 1,
         "policyUpdateAlgorithm": TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM,
         "trueGradient": True,
-        "policyGradientEstimator": POLICY_GRADIENT_LEXICOGRAPHIC_REINFORCE_ESTIMATOR,
+        "policyGradientEstimator": (
+            POLICY_GRADIENT_SCALAR_ESTIMATOR
+            if scalar_weighted_authorized
+            else POLICY_GRADIENT_LEXICOGRAPHIC_REINFORCE_ESTIMATOR
+        ),
+        "scalarWeightedSumAuthorized": scalar_weighted_authorized,
+        "scalarWeightedSumUse": gradient_estimation.get("scalarWeightedSumUse"),
         "gradientStable": gradient_stability["gradientStable"],
         "trustedGradientUpdate": trusted_gradient_update,
         "highVariance": gradient_stability["highVariance"],
@@ -2366,10 +2589,17 @@ def policy_update_return_sample_rows(candidates: Sequence[JsonObject]) -> list[J
         raw_samples = row.get("returnSamples")
         if not isinstance(raw_samples, list):
             continue
-        for return_tuple in raw_samples:
+        raw_scalar_samples = row.get("scalarReturnSamples")
+        scalar_samples = raw_scalar_samples if isinstance(raw_scalar_samples, list) else []
+        for sample_index, return_tuple in enumerate(raw_samples):
             if not isinstance(return_tuple, list):
                 continue
-            samples.append({"candidate": row, "returnTuple": return_tuple})
+            sample = {"candidate": row, "returnTuple": return_tuple}
+            if sample_index < len(scalar_samples):
+                scalar_value = number_or_none(scalar_samples[sample_index])
+                if scalar_value is not None:
+                    sample["scalarReturn"] = round_policy_number(float(scalar_value))
+            samples.append(sample)
     return samples
 
 
@@ -2408,18 +2638,23 @@ def first_nonzero_tier_gradient(tier_gradients: JsonObject) -> tuple[str | None,
     return None, 0
 
 
-def policy_update_scalar_gradient_scheme_identity(weight_evidence: JsonObject) -> JsonObject:
+def policy_update_scalar_gradient_scheme_identity(
+    weight_evidence: JsonObject,
+    *,
+    scalar_weighted_sum_authorized: bool = False,
+    scalar_weighted_sum_use: str = POLICY_GRADIENT_SCALAR_WEIGHTED_SUM_USE,
+) -> JsonObject:
     return {
         "type": GRADIENT_ESTIMATION_SCHEME_TYPE,
         "schemaVersion": SCHEMA_VERSION,
         "estimator": POLICY_GRADIENT_SCALAR_ESTIMATOR,
         "gradientReward": POLICY_GRADIENT_SCALAR_REWARD,
         "gradientUse": "policy_gradient_estimation_only",
-        "scalarWeightedSumUse": POLICY_GRADIENT_SCALAR_WEIGHTED_SUM_USE,
+        "scalarWeightedSumUse": scalar_weighted_sum_use,
         "rankingRewardModel": POLICY_GRADIENT_LEXICOGRAPHIC_REWARD,
-        "rewardComponentOrder": list(REWARD_TIERS),
+        "rewardComponentOrder": list(SCALAR_WEIGHTED_REWARD_TIERS),
         "lexicographicRankingPreserved": True,
-        "scalarWeightedSumAuthorized": False,
+        "scalarWeightedSumAuthorized": scalar_weighted_sum_authorized,
         "normalizedWeightsByRewardTier": copy.deepcopy(weight_evidence["normalizedWeightsByRewardTier"]),
         "normalizationCap": weight_evidence["normalizationCap"],
         "normalizationFactor": weight_evidence["normalizationFactor"],
@@ -2861,10 +3096,25 @@ def policy_update_scalar_weighted_gradient_estimation(
     anchor_parameters: JsonObject,
 ) -> JsonObject:
     weight_evidence = policy_update_scalar_reward_weight_evidence(policy_gradient)
-    scheme_identity = policy_update_scalar_gradient_scheme_identity(weight_evidence)
+    scalar_authorized = policy_gradient_scalar_weighted_sum_authorized(policy_gradient)
+    scalar_use = (
+        scalar_weighted_sum_use(first_mapping(policy_gradient, ("reward_model", "rewardModel")))
+        if scalar_authorized
+        else POLICY_GRADIENT_SCALAR_WEIGHTED_SUM_USE
+    )
+    scheme_identity = policy_update_scalar_gradient_scheme_identity(
+        weight_evidence,
+        scalar_weighted_sum_authorized=scalar_authorized,
+        scalar_weighted_sum_use=scalar_use,
+    )
     scheme_key = policy_update_gradient_scheme_key(scheme_identity)
     weights = weight_evidence["normalizedWeightsByRewardTier"]
-    scalar_returns = [policy_update_scalar_reward(sample["returnTuple"], weights) for sample in samples]
+    scalar_returns = [
+        float(scalar_return)
+        if (scalar_return := number_or_none(sample.get("scalarReturn"))) is not None
+        else policy_update_scalar_reward(sample["returnTuple"], weights)
+        for sample in samples
+    ]
     scalar_baseline = statistics.fmean(scalar_returns) if scalar_returns else 0.0
     gradient: JsonObject = {}
     cap_normalized_gradient: JsonObject = {}
@@ -2915,11 +3165,11 @@ def policy_update_scalar_weighted_gradient_estimation(
         "estimator": POLICY_GRADIENT_SCALAR_ESTIMATOR,
         "gradientReward": POLICY_GRADIENT_SCALAR_REWARD,
         "gradientUse": "policy_gradient_estimation_only",
-        "scalarWeightedSumUse": POLICY_GRADIENT_SCALAR_WEIGHTED_SUM_USE,
+        "scalarWeightedSumUse": scalar_use,
         "rankingRewardModel": POLICY_GRADIENT_LEXICOGRAPHIC_REWARD,
-        "rewardComponentOrder": list(REWARD_TIERS),
+        "rewardComponentOrder": list(SCALAR_WEIGHTED_REWARD_TIERS),
         "lexicographicRankingPreserved": True,
-        "scalarWeightedSumAuthorized": False,
+        "scalarWeightedSumAuthorized": scalar_authorized,
         "schemeIdentity": scheme_identity,
         "schemeKey": scheme_key,
         "comparisonKey": policy_update_gradient_scheme_comparison_key(scheme_identity),
@@ -2930,6 +3180,7 @@ def policy_update_scalar_weighted_gradient_estimation(
         "normalizationCap": weight_evidence["normalizationCap"],
         "normalizationFactor": weight_evidence["normalizationFactor"],
         "scalarRewardScaleFactor": weight_evidence["scalarRewardScaleFactor"],
+        "scalarReturns": [round_policy_number(value) for value in scalar_returns],
         "gradient": gradient,
         "capNormalizedGradient": cap_normalized_gradient,
         "scalarReturnBaseline": round_policy_number(scalar_baseline),
@@ -2951,6 +3202,11 @@ def policy_update_scalar_reward_weight_evidence(policy_gradient: JsonObject) -> 
             component_weights = first_mapping(reward_model, ("component_weights", "componentWeights"))
             if component_weights is not None:
                 source_weights.update(policy_update_component_weights_by_tier(component_weights))
+            scalar_config = first_mapping(reward_model, ("scalar_weighted_sum", "scalarWeightedSum"))
+            if scalar_config is not None:
+                scalar_component_weights = first_mapping(scalar_config, ("component_weights", "componentWeights"))
+                if scalar_component_weights is not None:
+                    source_weights.update(policy_update_component_weights_by_tier(scalar_component_weights))
         component_weights = first_mapping(
             raw,
             (
@@ -2969,12 +3225,13 @@ def policy_update_scalar_reward_weight_evidence(policy_gradient: JsonObject) -> 
         DEFAULT_POLICY_GRADIENT_SCALAR_WEIGHT_NORMALIZATION_CAP,
     )
     scalar_reward_scale_factor = normalization_factor / max_source_weight
+    weight_tiers = [tier for tier in SCALAR_WEIGHTED_REWARD_TIERS if tier in source_weights]
     normalized = {
         tier: source_weights[tier] / normalization_factor
-        for tier in REWARD_TIERS
+        for tier in weight_tiers
     }
     return {
-        "sourceComponentWeights": {tier: round_policy_number(source_weights[tier]) for tier in REWARD_TIERS},
+        "sourceComponentWeights": {tier: round_policy_number(source_weights[tier]) for tier in weight_tiers},
         "normalizedWeightsByRewardTier": normalized,
         "sourceMaxComponentWeight": round_policy_number(max_source_weight),
         "normalizationCap": round_policy_number(
@@ -2991,6 +3248,7 @@ def policy_update_component_weights_by_tier(raw: JsonObject) -> dict[str, float]
         "territory": ("territory", "beta_territory", "betaTerritory", "territoryWeight"),
         "resources": ("resources", "gamma_resources", "gammaResources", "resourcesWeight"),
         "kills": ("kills", "delta_kills", "deltaKills", "killsWeight"),
+        "activation": ("activation", "epsilon_activation", "epsilonActivation", "activationWeight"),
     }
     weights: dict[str, float] = {}
     for tier, names in aliases.items():
@@ -3004,7 +3262,7 @@ def policy_update_component_weights_by_tier(raw: JsonObject) -> dict[str, float]
 
 def policy_update_scalar_reward(return_tuple: Sequence[Any], weights: JsonObject) -> float:
     total = 0.0
-    for index, tier in enumerate(REWARD_TIERS):
+    for index, tier in enumerate(SCALAR_WEIGHTED_REWARD_TIERS):
         if index >= len(return_tuple):
             continue
         total += float(return_tuple[index]) * float(weights.get(tier, 0))
@@ -3551,21 +3809,28 @@ def policy_update_candidate_rows(
         if parameters is None:
             continue
         return_samples = policy_update_return_samples(scored_summaries)
-        rows.append(
-            {
-                "candidatePolicyId": candidate_policy_id,
-                "strategyVariantId": candidate_match_id,
-                "sourceStrategyId": text_or_none(candidate.get("sourceStrategyId")),
-                "rolloutStatus": text_or_none(candidate.get("rolloutStatus")),
-                "parameters": parameters,
-                "rewardTuple": aggregate_policy_reward_tuple(scored_summaries),
-                "sampleCount": sum(policy_reward_tuple_sample_weight(summary) for summary in scored_summaries),
-                "returnSamples": return_samples,
-                "returnSampleCount": len(return_samples),
-                "meanReturn": mean_policy_return_tuple(return_samples),
-                "resultVariantIds": [summary["variantId"] for summary in scored_summaries if isinstance(summary.get("variantId"), str)],
-            }
-        )
+        row = {
+            "candidatePolicyId": candidate_policy_id,
+            "strategyVariantId": candidate_match_id,
+            "sourceStrategyId": text_or_none(candidate.get("sourceStrategyId")),
+            "rolloutStatus": text_or_none(candidate.get("rolloutStatus")),
+            "parameters": parameters,
+            "rewardTuple": aggregate_policy_reward_tuple(scored_summaries),
+            "sampleCount": sum(policy_reward_tuple_sample_weight(summary) for summary in scored_summaries),
+            "returnSamples": return_samples,
+            "returnSampleCount": len(return_samples),
+            "meanReturn": mean_policy_return_tuple(return_samples),
+            "resultVariantIds": [
+                summary["variantId"] for summary in scored_summaries if isinstance(summary.get("variantId"), str)
+            ],
+        }
+        scalar_return_samples = policy_update_scalar_return_samples(scored_summaries)
+        if scalar_return_samples:
+            row["scalarReturnSamples"] = scalar_return_samples
+            row["scalarReward"] = round_policy_number(
+                statistics.fmean(float(value) for value in scalar_return_samples)
+            )
+        rows.append(row)
     return rows
 
 
@@ -3644,6 +3909,32 @@ def policy_update_return_samples(summaries: Sequence[JsonObject]) -> list[list[f
             sample = policy_return_tuple_from_sequence(reward_tuple)
             if sample is not None:
                 samples.append(sample)
+    return samples
+
+
+def policy_update_scalar_return_samples(summaries: Sequence[JsonObject]) -> list[float | int]:
+    samples: list[float | int] = []
+    for summary in summaries:
+        reward = summary.get("reward") if isinstance(summary.get("reward"), dict) else {}
+        scalar_reward = reward.get("scalarWeightedSum") if isinstance(reward, dict) else None
+        if not isinstance(scalar_reward, dict):
+            continue
+        raw_samples = scalar_reward.get("scalarReturnSamples")
+        added_samples = False
+        if isinstance(raw_samples, list):
+            for raw_sample in raw_samples:
+                value = number_or_none(raw_sample)
+                if value is not None:
+                    samples.append(round_policy_number(float(value)))
+                    added_samples = True
+        if added_samples:
+            continue
+        value = number_or_none(scalar_reward.get("scalarReward"))
+        if value is None:
+            continue
+        weight = policy_reward_tuple_sample_weight(summary)
+        for _index in range(max(0, weight)):
+            samples.append(round_policy_number(float(value)))
     return samples
 
 
@@ -3830,6 +4121,8 @@ def policy_update_candidate_summary(row: JsonObject) -> JsonObject:
         "sourceStrategyId": row.get("sourceStrategyId"),
         "rolloutStatus": row.get("rolloutStatus"),
         "rewardTuple": row.get("rewardTuple"),
+        "scalarReward": row.get("scalarReward"),
+        "scalarReturnSamples": copy.deepcopy(row.get("scalarReturnSamples")),
         "sampleCount": row.get("sampleCount"),
         "parameters": copy.deepcopy(row.get("parameters")),
         "resultVariantIds": copy.deepcopy(row.get("resultVariantIds")),
@@ -4730,6 +5023,16 @@ def summarize_variant(
         for index, run in enumerate(successful_runs)
     ]
     runtime_parameter_injection = summarize_variant_runtime_parameter_injection(variant, runs)
+    reward_sample_values = reward_samples(run_metrics_by_attempt)
+    reward_sample_stddev_values = reward_sample_stddev(run_metrics_by_attempt)
+    scalar_reward = build_scalar_weighted_reward_summary(
+        reward_tuple=reward_tuple,
+        reward_samples=reward_sample_values,
+        activation_samples=activation_samples,
+        activation_traces=activation_traces,
+        metrics_by_attempt=run_metrics_by_attempt,
+        reward_options=reward_options,
+    )
     summary: JsonObject = {
         "variantId": variant.id,
         "family": variant.family,
@@ -4742,8 +5045,8 @@ def summarize_variant(
             "type": "lexicographic",
             "componentOrder": list(REWARD_TIERS),
             "tuple": reward_tuple,
-            "samples": reward_samples(run_metrics_by_attempt),
-            "sampleStdDev": reward_sample_stddev(run_metrics_by_attempt),
+            "samples": reward_sample_values,
+            "sampleStdDev": reward_sample_stddev_values,
         },
         "metrics": metrics,
         "multiTierActivationSamples": activation_samples,
@@ -4759,6 +5062,9 @@ def summarize_variant(
             for run in runs
         ],
     }
+    if scalar_reward is not None:
+        summary["reward"]["scalarWeightedSum"] = scalar_reward
+        summary["scalarWeightedReward"] = copy.deepcopy(scalar_reward)
     if variant.policy_family:
         summary["policyFamily"] = variant.policy_family
     if variant.candidate_policy_id:
@@ -4773,6 +5079,127 @@ def summarize_variant(
     if variant.training_role:
         summary["trainingRole"] = variant.training_role
     return summary
+
+
+def build_scalar_weighted_reward_summary(
+    *,
+    reward_tuple: Sequence[Any],
+    reward_samples: Sequence[Sequence[Any]],
+    activation_samples: Sequence[JsonObject],
+    activation_traces: Sequence[JsonObject],
+    metrics_by_attempt: Sequence[JsonObject | None],
+    reward_options: JsonObject,
+) -> JsonObject | None:
+    if reward_options.get("scalarWeightedSumAuthorized") is not True:
+        return None
+    weight_evidence = reward_options.get("scalarWeightEvidence")
+    if not isinstance(weight_evidence, dict):
+        return None
+    weights = weight_evidence.get("normalizedWeightsByRewardTier")
+    if not isinstance(weights, dict):
+        return None
+
+    activation_by_attempt: list[JsonObject | None] = []
+    trace_by_sample_index: dict[int, JsonObject] = {}
+    for trace in activation_traces:
+        sample_index = int_or_none(trace.get("sampleIndex")) if isinstance(trace, dict) else None
+        if sample_index is not None:
+            trace_by_sample_index[sample_index] = trace
+    successful_index = 0
+    for metrics in metrics_by_attempt:
+        if metrics is None:
+            activation_by_attempt.append(None)
+            continue
+        activation_by_attempt.append(
+            activation_samples[successful_index] if successful_index < len(activation_samples) else None
+        )
+        successful_index += 1
+
+    activation_scores: list[float | int] = []
+    scalar_samples: list[float | int] = []
+    sample_components: list[JsonObject] = []
+    for sample_index, raw_sample in enumerate(reward_samples):
+        reward_sample = policy_return_tuple_from_sequence(list(raw_sample))
+        if reward_sample is None:
+            reward_sample = [0 for _tier in REWARD_TIERS]
+        activation_sample = (
+            activation_by_attempt[sample_index] if sample_index < len(activation_by_attempt) else None
+        )
+        trace = trace_by_sample_index.get(sample_index)
+        activation_score = scalar_activation_score(activation_sample, trace)
+        activation_scores.append(round_policy_number(activation_score))
+        components = scalar_reward_component_values(reward_sample, activation_score)
+        weighted = scalar_weighted_components(components, weights)
+        scalar_value = round_policy_number(sum(float(value) for value in weighted.values()))
+        scalar_samples.append(scalar_value)
+        sample_components.append({
+            "sampleIndex": sample_index,
+            "componentValuesByRewardTier": components,
+            "weightedComponentsByRewardTier": weighted,
+            "scalarReward": scalar_value,
+        })
+
+    aggregate_components = scalar_reward_component_values(
+        policy_return_tuple_from_sequence(list(reward_tuple)) or [0 for _tier in REWARD_TIERS],
+        statistics.fmean(float(value) for value in activation_scores) if activation_scores else 0.0,
+    )
+    aggregate_weighted = scalar_weighted_components(aggregate_components, weights)
+    scalar_reward = round_policy_number(sum(float(value) for value in aggregate_weighted.values()))
+    return {
+        "type": POLICY_GRADIENT_SCALAR_REWARD,
+        "authorized": True,
+        "use": reward_options.get("scalarWeightedSumUse") or SCALAR_WEIGHTED_SUM_AUTHORIZED_USE,
+        "rankingRewardModel": POLICY_GRADIENT_LEXICOGRAPHIC_REWARD,
+        "componentOrder": list(SCALAR_WEIGHTED_REWARD_TIERS),
+        "componentValuesByRewardTier": aggregate_components,
+        "sourceComponentWeights": copy.deepcopy(weight_evidence.get("sourceComponentWeights")),
+        "normalizedWeightsByRewardTier": copy.deepcopy(weights),
+        "weightedComponentsByRewardTier": aggregate_weighted,
+        "scalarReward": scalar_reward,
+        "scalarReturnSamples": scalar_samples,
+        "activationScore": aggregate_components["activation"],
+        "activationScoreSamples": activation_scores,
+        "sampleComponents": sample_components,
+        "sampleCount": len(scalar_samples),
+        "promotionUse": "blocked_until_trusted_samples_and_loop_b_advantage_gate",
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+        "safety": safety_metadata(),
+    }
+
+
+def scalar_activation_score(sample: JsonObject | None, trace: JsonObject | None) -> float:
+    if isinstance(trace, dict):
+        policy_activation = trace.get("policyActivation")
+        if isinstance(policy_activation, dict):
+            score = number_or_none(policy_activation.get("activationScore"))
+            if score is not None:
+                return float(score)
+    if isinstance(sample, dict):
+        score = number_or_none(sample.get("activationScore"))
+        if score is not None:
+            return float(score)
+    return 0.0
+
+
+def scalar_reward_component_values(
+    reward_tuple: Sequence[Any],
+    activation_score: float | int,
+) -> JsonObject:
+    components: JsonObject = {}
+    for index, tier in enumerate(REWARD_TIERS):
+        value = number_or_none(reward_tuple[index]) if index < len(reward_tuple) else None
+        components[tier] = round_policy_number(float(value) if value is not None else 0.0)
+    components["activation"] = round_policy_number(float(activation_score))
+    return components
+
+
+def scalar_weighted_components(components: JsonObject, weights: JsonObject) -> JsonObject:
+    return {
+        tier: round_policy_number(float(components.get(tier, 0)) * float(weights.get(tier, 0)))
+        for tier in SCALAR_WEIGHTED_REWARD_TIERS
+    }
 
 
 def multi_tier_activation_sample_trace(
@@ -6699,6 +7126,15 @@ def policy_update_promotion_gate(
         )
 
     runtime_consumed_promotion_eligible = policy_update_generated and runtime_consumed and trusted_gradient_update
+    scalar_authorized = parameter_evidence.get("scalarWeightedSumAuthorized") is True
+    if scalar_authorized and runtime_consumed_promotion_eligible:
+        status = "blocked_loop_b_advantage_gate_pending"
+        missing_prerequisites = ["loop_b_policy_advantage_gate"]
+        reason = (
+            "scalar weighted reward is authorized only for offline/private/shadow comparison; "
+            "Loop A/Loop B promotion remains blocked until the Loop B advantage gate passes"
+        )
+        runtime_consumed_promotion_eligible = False
     payload: JsonObject = {
         "type": POLICY_UPDATE_PROMOTION_GATE_TYPE,
         "schemaVersion": SCHEMA_VERSION,
@@ -6724,6 +7160,10 @@ def policy_update_promotion_gate(
         "officialMmoWritesAllowed": False,
         "safety": safety_metadata(),
     }
+    if scalar_authorized:
+        payload["scalarWeightedSumAuthorized"] = True
+        payload["scalarWeightedSumUse"] = parameter_evidence.get("scalarWeightedSumUse")
+        payload["loopBAdvantageGate"] = parameter_evidence.get("loopBAdvantageGate") or "required_before_promotion"
     if gradient_gate_present:
         payload["gradientStable"] = gradient_stability.get("gradientStable") is True
         payload["trustedGradientUpdate"] = trusted_gradient_update
@@ -6794,6 +7234,7 @@ def policy_update_runtime_injection_ready_parameter_evidence(
         or first_present(support, ("runtime_parameter_consumption", "runtimeParameterConsumption")) is True
     )
     runtime_metadata_fallback = policy_gradient_allows_runtime_metadata_policy_update(policy_gradient)
+    scalar_authorized = policy_gradient_scalar_weighted_sum_authorized(policy_gradient)
     candidate_count_ready = len(candidates) >= policy_gradient_candidate_vector_count(policy_gradient)
     eligible = (
         scope == "runtime_injected"
@@ -6818,6 +7259,12 @@ def policy_update_runtime_injection_ready_parameter_evidence(
             else "blocked_until_runtime_parameter_evidence"
         ),
     }
+    if scalar_authorized:
+        payload["scalarWeightedSumAuthorized"] = True
+        payload["scalarWeightedSumUse"] = scalar_weighted_sum_use(
+            first_mapping(policy_gradient, ("reward_model", "rewardModel"))
+        )
+        payload["loopBAdvantageGate"] = "required_before_promotion"
     if consumption_status is not None:
         payload["runtimeParameterConsumptionStatus"] = consumption_status
     if eligible:
@@ -6945,6 +7392,8 @@ def build_generation_summary(report: JsonObject) -> JsonObject:
         "scorecardArtifactPath": report.get("scorecardArtifactPath"),
         "candidateScorecard": copy.deepcopy(report.get("candidateScorecard")),
         "candidateScorecards": copy.deepcopy(report.get("candidateScorecards")),
+        "scalarWeightedReward": copy.deepcopy(report.get("scalarWeightedReward")),
+        "conclusionRegistryUpdate": copy.deepcopy(report.get("conclusionRegistryUpdate")),
         "warnings": report["warnings"],
     }
     if "scaleValidation" in report:

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -5100,18 +5100,18 @@ def build_scalar_weighted_reward_summary(
         return None
 
     activation_by_attempt: list[JsonObject | None] = []
-    trace_by_sample_index: dict[int, JsonObject] = {}
-    for trace in activation_traces:
-        sample_index = int_or_none(trace.get("sampleIndex")) if isinstance(trace, dict) else None
-        if sample_index is not None:
-            trace_by_sample_index[sample_index] = trace
+    trace_by_attempt: list[JsonObject | None] = []
     successful_index = 0
     for metrics in metrics_by_attempt:
         if metrics is None:
             activation_by_attempt.append(None)
+            trace_by_attempt.append(None)
             continue
         activation_by_attempt.append(
             activation_samples[successful_index] if successful_index < len(activation_samples) else None
+        )
+        trace_by_attempt.append(
+            activation_traces[successful_index] if successful_index < len(activation_traces) else None
         )
         successful_index += 1
 
@@ -5125,7 +5125,7 @@ def build_scalar_weighted_reward_summary(
         activation_sample = (
             activation_by_attempt[sample_index] if sample_index < len(activation_by_attempt) else None
         )
-        trace = trace_by_sample_index.get(sample_index)
+        trace = trace_by_attempt[sample_index] if sample_index < len(trace_by_attempt) else None
         activation_score = scalar_activation_score(activation_sample, trace)
         activation_scores.append(round_policy_number(activation_score))
         components = scalar_reward_component_values(reward_sample, activation_score)

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -221,6 +221,52 @@ class RlExperimentCardTest(unittest.TestCase):
             self.assertFalse(card["safety"][field])
             self.assertFalse(scenario["safety"][field])
 
+    def test_scalar_weighted_reward_authorization_is_policy_gradient_shadow_only(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-policy-gradient-scalar-000001",
+            code_commit="c" * 40,
+            training_approach="policy_gradient",
+            created_at="2026-06-01T16:20:00Z",
+            scenario_id=card_helper.MULTI_TIER_SCENARIO_ID,
+            scalar_weighted_sum_authorized=True,
+        )
+
+        card_helper.validate_card(card)
+        runner.validate_experiment_card(card)
+
+        reward_model = card["reward_model"]
+        scalar = reward_model["scalar_weighted_sum"]
+        self.assertTrue(reward_model["scalar_weighted_sum_authorized"])
+        self.assertEqual(reward_model["scalar_weighted_sum_use"], card_helper.SCALAR_WEIGHTED_SUM_USE)
+        self.assertEqual(
+            scalar["component_order"],
+            ["reliability", "territory", "resources", "kills", "activation"],
+        )
+        self.assertEqual(scalar["component_weights"]["epsilon_activation"], 1)
+        self.assertEqual(scalar["ranking_reward_model"], "lexicographic")
+        self.assertFalse(card["liveEffect"])
+        self.assertFalse(card["officialMmoWrites"])
+        self.assertFalse(card["officialMmoWritesAllowed"])
+        self.assertFalse(card["safety"]["liveEffect"])
+        self.assertFalse(card["safety"]["officialMmoWrites"])
+        self.assertFalse(card["safety"]["officialMmoWritesAllowed"])
+        self.assertTrue(card["safety"]["ood_rejection"])
+        self.assertTrue(card["safety"]["conservative_actions_only"])
+
+    def test_scalar_weighted_reward_authorization_rejects_non_policy_gradient(self) -> None:
+        with self.assertRaisesRegex(
+            card_helper.CardValidationError,
+            "requires training_approach=policy_gradient",
+        ):
+            card_helper.build_card(
+                dataset_run_id="rl-bandit-scalar-000001",
+                code_commit="c" * 40,
+                training_approach="bandit",
+                created_at="2026-06-01T16:21:00Z",
+                scenario_id=card_helper.MULTI_TIER_SCENARIO_ID,
+                scalar_weighted_sum_authorized=True,
+            )
+
     def test_multi_tier_v0_scenario_remains_selectable_for_compatibility(self) -> None:
         card = card_helper.build_card(
             dataset_run_id="rl-policy-gradient-multitier-v0",

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -3279,6 +3279,98 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(estimation["gradient"], estimation["capNormalizedGradient"])
         self.assertGreater(estimation["directionByParameter"]["combatSignalWeight"]["positiveContributionCount"], 0)
 
+    def test_authorized_scalar_policy_update_uses_scalar_samples_and_blocks_promotion(self) -> None:
+        policy_gradient = reinforce_stability_policy_gradient()
+        policy_gradient["rewardModel"] = card_helper.reward_model(scalar_weighted_sum_authorized=True)
+        results = reinforce_stability_results([[1, 0, 0, 0] for _index in range(20)])
+        for result in results:
+            scalar_value = 100 if result["variantId"] == "variant-a" else 101
+            result["reward"]["scalarWeightedSum"] = {
+                "scalarReward": scalar_value,
+                "scalarReturnSamples": [scalar_value for _index in range(result["sampleCount"])],
+            }
+
+        update = runner.build_policy_update(
+            policy_gradient=policy_gradient,
+            results=results,
+            report_id="policy-gradient-authorized-scalar",
+            generated_at="2026-06-01T16:25:00Z",
+        )
+
+        self.assertEqual(update["iterations"], 1)
+        self.assertEqual(update["policyGradientEstimator"], runner.POLICY_GRADIENT_SCALAR_ESTIMATOR)
+        self.assertTrue(update["scalarWeightedSumAuthorized"])
+        self.assertTrue(update["gradientEstimation"]["scalarWeightedSumAuthorized"])
+        self.assertEqual(
+            update["gradientEstimation"]["scalarWeightedSumUse"],
+            runner.SCALAR_WEIGHTED_SUM_AUTHORIZED_USE,
+        )
+        self.assertIn("activation", update["gradientEstimation"]["normalizedWeightsByRewardTier"])
+        self.assertGreater(update["gradientEstimation"]["scalarReturns"][-1], update["gradientEstimation"]["scalarReturns"][0])
+        self.assertEqual(update["promotionGate"]["status"], "blocked_loop_b_advantage_gate_pending")
+        self.assertFalse(update["promotionGate"]["loopAPromotionEligible"])
+        self.assertFalse(update["promotionGate"]["loopBPromotionEligible"])
+        self.assertEqual(update["promotionGate"]["loopBAdvantageGate"], "required_before_promotion")
+        self.assertFalse(update["promotionGate"]["liveEffect"])
+        self.assertFalse(update["promotionGate"]["officialMmoWrites"])
+
+    def test_authorized_scalar_training_report_surfaces_activation_reward_components(self) -> None:
+        card = base_card(["baseline", "candidate"])
+        card["training_approach"] = "policy_gradient"
+        card["reward_model"] = card_helper.reward_model(scalar_weighted_sum_authorized=True)
+        card["scenario"] = card_helper.scenario_metadata_block(scenario_id=card_helper.MULTI_TIER_SCENARIO_ID)
+        card["simulation"]["room"] = "E1S1"
+        card["simulation"]["map_source_file"] = str(card_helper.MULTI_TIER_SIMULATION_MAP_SOURCE_FILE)
+        config = runner.simulation_config_from_card(card)
+        variants = [
+            runner.StrategyVariant(id="baseline", family="test-family", parameters={}, rollout_status="incumbent"),
+            runner.StrategyVariant(id="candidate", family="test-family", parameters={}, rollout_status="shadow"),
+        ]
+        start = tick(1, [room("E1S1", energy=100)])
+        end = tick(2, [room("E1S1", energy=100)])
+        baseline_run = variant_result("baseline", [start, end])
+        candidate_run = variant_result("candidate", [start, end])
+        candidate_run["policyActivation"] = {
+            "type": "screeps-rl-multi-tier-policy-activation",
+            "policyAction": "test-activation",
+            "executionAction": "test-activation",
+            "objectiveSignalSource": "offline_shadow_projection",
+            "activationScore": 22.25,
+            "threshold": 10,
+            "reason": "deterministic scalar reward activation test",
+        }
+
+        report = runner.build_training_report(
+            card=card,
+            card_path=Path("card.json"),
+            variants=variants,
+            config=config,
+            simulator_runs=[
+                {
+                    "type": "screeps-rl-simulator-run",
+                    "runId": "scalar-activation-report",
+                    "liveEffect": False,
+                    "officialMmoWrites": False,
+                    "officialMmoWritesAllowed": False,
+                    "variants": [baseline_run, candidate_run],
+                }
+            ],
+            reward_options=runner.reward_options_from_card(card),
+            report_id="scalar-activation-report",
+            generated_at="2026-06-01T16:26:00Z",
+        )
+
+        candidate = next(item for item in report["variantResults"] if item["variantId"] == "candidate")
+        scalar = candidate["reward"]["scalarWeightedSum"]
+        self.assertTrue(report["rewardModel"]["scalarWeightedSumAuthorized"])
+        self.assertEqual(report["rewardModel"]["scalarWeightedSumUse"], runner.SCALAR_WEIGHTED_SUM_AUTHORIZED_USE)
+        self.assertEqual(scalar["activationScore"], 22.25)
+        self.assertGreater(scalar["weightedComponentsByRewardTier"]["activation"], 0)
+        self.assertEqual(report["scalarWeightedReward"]["variantRewards"][1]["activationScore"], 22.25)
+        self.assertEqual(report["conclusionRegistryUpdate"]["sourceIssue"], "#1582")
+        self.assertFalse(report["scalarWeightedReward"]["liveEffect"])
+        self.assertFalse(report["officialMmoWrites"])
+
     def test_policy_gradient_scalar_estimator_preserves_large_source_weight_scale(self) -> None:
         policy_gradient = {
             "policyUpdate": {

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -3371,6 +3371,52 @@ export const STRATEGY_REGISTRY = [
         self.assertFalse(report["scalarWeightedReward"]["liveEffect"])
         self.assertFalse(report["officialMmoWrites"])
 
+    def test_scalar_activation_trace_stays_on_original_attempt_after_failure(self) -> None:
+        card = base_card(["candidate"])
+        card["reward_model"] = card_helper.reward_model(scalar_weighted_sum_authorized=True)
+        variant = runner.StrategyVariant(
+            id="candidate",
+            family="test-family",
+            parameters={},
+            rollout_status="shadow",
+        )
+        failed_run = variant_result("candidate", [])
+        failed_run["variant_run_id"] = "run-candidate-failed"
+        failed_run["ok"] = False
+        failed_run["error"] = "simulator failed before activation evidence"
+        successful_run = variant_result(
+            "candidate",
+            [
+                tick(1, [room("E1S1", energy=100)]),
+                tick(2, [room("E1S1", energy=100)]),
+            ],
+        )
+        successful_run["variant_run_id"] = "run-candidate-success"
+        successful_run["policyActivation"] = {
+            "type": "screeps-rl-multi-tier-policy-activation",
+            "policyAction": "test-activation",
+            "executionAction": "test-activation",
+            "objectiveSignalSource": "offline_shadow_projection",
+            "activationScore": 22.25,
+            "threshold": 10,
+            "reason": "deterministic scalar reward activation test",
+        }
+
+        result = runner.summarize_variant(
+            variant,
+            [failed_run, successful_run],
+            runner.reward_options_from_card(card),
+        )
+
+        scalar = result["reward"]["scalarWeightedSum"]
+        self.assertEqual(result["reward"]["samples"][0], [0, None, None, None])
+        self.assertEqual([trace["sampleIndex"] for trace in result["multiTierActivationTraces"]], [0])
+        self.assertEqual(scalar["activationScoreSamples"], [0, 22.25])
+        self.assertEqual(
+            [row["componentValuesByRewardTier"]["activation"] for row in scalar["sampleComponents"]],
+            [0, 22.25],
+        )
+
     def test_policy_gradient_scalar_estimator_preserves_large_source_weight_scale(self) -> None:
         policy_gradient = {
             "policyUpdate": {


### PR DESCRIPTION
## Summary
- Adds an explicit guarded scalar weighted reward authorization path for offline/private/shadow policy-gradient experiment cards.
- Surfaces scalar weighted activation components in Loop A training reports and policy-update evidence while preserving lexicographic ranking and safety flags.
- Fixes automated review finding `PRRT_kwDOSMSsO86GLYWI`: scalar activation traces now stay aligned to original simulator attempt indexes, so failed attempts cannot inherit later successful activation credit.
- Adds deterministic tests for authorization, default rejection, scalar estimator use, report fields, promotion-gate behavior, and failed-attempt trace alignment.

## Verification
- `git diff --check origin/main...HEAD` — PASS
- `python3 -m py_compile scripts/screeps_rl_experiment_card.py scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_experiment_card.py scripts/test_screeps_rl_training_runner.py` — PASS
- `python3 -m pytest -q scripts/test_screeps_rl_experiment_card.py scripts/test_screeps_rl_training_runner.py` — PASS: 221 passed, 41 subtests passed
- `python3 scripts/screeps_rl_experiment_card.py self-test` — PASS
- `python3 -m pytest -q scripts/tests/test_rl_scorecard.py` — PASS: 26 passed
- Dry-run scalar authorization card generation + validation — PASS; `liveEffect=false`, `officialMmoWrites=false`, `scalar_weighted_sum_authorized=true`, `multi_tier_policy_comparison_suitable=true`

## Review triage
- `PRRT_kwDOSMSsO86GLYWI` classified `FIX`.
- Criticality: invalid scalar activation trace alignment could corrupt authorized policy-gradient reward samples.
- Action: commit `806ffdcf24c404d15c74bcf9c7aca4c7038ead1d` expands activation traces into original-attempt alignment and adds regression coverage.

## Safety
- No official MMO writes.
- No Tencent paid compute.
- No production bot bundle changes.
- Scalar weighted reward evidence is limited to offline/private/shadow gradient estimation; Loop B advantage evidence remains the promotion requirement.

## Universal task Done gate
- [x] Task type: code / RL flywheel scripts.
- [x] Expected observable outcome / named deliverable: `--authorize-scalar-weighted-reward` produces a policy-gradient shadow card whose runner reports scalar weighted activation reward evidence with attempt-aligned activation traces.
- [x] Non-goals / accepted substitutes: no official MMO control, no Tencent batch launch, no role-scoped worker/harvester/defender policy claim.
- [x] Verification evidence required before Done: py_compile, targeted Python tests, scorecard regression tests, self-test, review-fix regression, and dry-run card validation all passed on commit `806ffdcf`.
- [x] Project Evidence / Next action / Blocked by: #1582 and PR #1586 Project items are updated by the controller with current head, review-fix, and verification evidence.
- [x] Post-merge/deploy/runtime proof: scripts-only offline/shadow change; no deploy artifact or live runtime effect is part of this PR contract.
- [x] Named deliverable proof: tests assert scalar authorization, activation-score propagation, conclusion-registry source issue `#1582`, safety flags, Loop B advantage promotion requirement, and failed-attempt activation-trace alignment.

## Issue closure gate
- [x] #1582: Commits `3100ce92` and `806ffdcf` implement guarded scalar weighted reward activation, report evidence, policy-update scalar estimator, review-fix trace alignment, and tests required by the issue.
- [x] No closing issue relies on official deployment, Tencent compute, owner action, or role-scoped policy proof for this PR's code contract; #1583 and #1585 remain separate tracked lanes.

Fixes #1582
Related to issue #1583
Related to issue #1585
