### PR TITLE
fix: unblock loaded E29N57 builders

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -25437,7 +25437,7 @@ function selectCriticalCpuWorkerTask(creep) {
   if (missingSpawnConstructionSite) {
     return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: missingSpawnConstructionSite.id });
   }
-  const storedProtectedConstructionTask = selectCriticalCpuStoredProtectedConstructionTask(creep);
+  const storedProtectedConstructionTask = selectStoredProtectedSourceContainerConstructionTask(creep);
   if (storedProtectedConstructionTask) {
     return applyMinimumUsefulLoadPolicy(creep, storedProtectedConstructionTask);
   }
@@ -25463,12 +25463,16 @@ function selectCriticalCpuWorkerTask(creep) {
   }
   return null;
 }
-function selectCriticalCpuStoredProtectedConstructionTask(creep) {
-  const constructionSite = selectCriticalCpuStoredProtectedConstructionSite(creep);
+function selectStoredProtectedSourceContainerConstructionTask(creep, constructionSites, constructionReservationContext) {
+  const constructionSite = selectStoredProtectedSourceContainerConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext
+  );
   return constructionSite ? { type: "build", targetId: constructionSite.id } : null;
 }
-function selectCriticalCpuStoredProtectedConstructionEnergyAcquisitionTask(creep) {
-  const constructionSite = selectCriticalCpuStoredProtectedConstructionEnergyAcquisitionSite(creep);
+function selectStoredProtectedSourceContainerConstructionEnergyAcquisitionTask(creep) {
+  const constructionSite = selectStoredProtectedSourceContainerConstructionEnergyAcquisitionSite(creep);
   if (!constructionSite) {
     return null;
   }
@@ -25478,7 +25482,7 @@ function selectCriticalCpuStoredProtectedConstructionEnergyAcquisitionTask(creep
   }
   return candidates.sort(compareBuilderEnergyAcquisitionCandidates)[0].task;
 }
-function selectCriticalCpuStoredProtectedConstructionEnergyAcquisitionSite(creep) {
+function selectStoredProtectedSourceContainerConstructionEnergyAcquisitionSite(creep) {
   const constructionSites = findConstructionSites(creep.room);
   if (constructionSites.length === 0) {
     return null;
@@ -25495,17 +25499,17 @@ function selectCriticalCpuStoredProtectedConstructionEnergyAcquisitionSite(creep
     priorityContext
   );
 }
-function selectCriticalCpuStoredProtectedConstructionSite(creep) {
-  const constructionSites = findConstructionSites(creep.room);
-  if (constructionSites.length === 0) {
+function selectStoredProtectedSourceContainerConstructionSite(creep, constructionSites, constructionReservationContext) {
+  const sites = constructionSites != null ? constructionSites : findConstructionSites(creep.room);
+  if (sites.length === 0) {
     return null;
   }
-  const constructionReservationContext = createConstructionReservationContext(creep.room);
-  const priorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  const reservations = constructionReservationContext != null ? constructionReservationContext : createConstructionReservationContext(creep.room);
+  const priorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, sites);
   return selectUnreservedConstructionSite(
     creep,
-    constructionSites,
-    constructionReservationContext,
+    sites,
+    reservations,
     (site) => canSpendOnStoredProtectedSourceContainerConstruction(creep, site, priorityContext),
     { priorityContext }
   );
@@ -25540,7 +25544,7 @@ function selectCriticalCpuEnergyAcquisitionTask(creep) {
   if (hasCriticalCpuRepairDemand(creep)) {
     return selectWorkerEnergyCriticalAcquisitionTask(creep);
   }
-  return selectCriticalCpuStoredProtectedConstructionEnergyAcquisitionTask(creep);
+  return selectStoredProtectedSourceContainerConstructionEnergyAcquisitionTask(creep);
 }
 function hasCriticalCpuRepairDemand(creep) {
   return selectCriticalOwnedSpawnRepairTarget(creep) !== null || selectEmergencyOwnedRampartRepairTarget(creep) !== null || selectThreatenedBarrierRepairTarget(creep) !== null || selectCriticalInfrastructureRepairTarget(creep) !== null;
@@ -25610,6 +25614,10 @@ function selectHeuristicWorkerTask(creep) {
     }
     let hasPriorityEnergySink = false;
     if (getFreeEnergyCapacity8(creep) > 0) {
+      const storedProtectedConstructionEnergyAcquisitionTask = selectStoredProtectedSourceContainerConstructionEnergyAcquisitionTask(creep);
+      if (storedProtectedConstructionEnergyAcquisitionTask) {
+        return storedProtectedConstructionEnergyAcquisitionTask;
+      }
       const spawnRecoveryEnergySink = selectFillableEnergySink(creep);
       if (spawnRecoveryEnergySink) {
         hasPriorityEnergySink = true;
@@ -25768,6 +25776,14 @@ function selectHeuristicWorkerTask(creep) {
         targetId: threatenedBarrierRepairTarget2.id
       });
     }
+  }
+  const storedProtectedConstructionTask = selectStoredProtectedSourceContainerConstructionTask(
+    creep,
+    constructionSites,
+    constructionReservationContext
+  );
+  if (storedProtectedConstructionTask) {
+    return applyMinimumUsefulLoadPolicy(creep, storedProtectedConstructionTask);
   }
   const bootstrapExtensionConstructionSite = selectBootstrapExtensionConstructionSiteBeforeRefill(
     creep,
@@ -27734,7 +27750,7 @@ function isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext
   return isRoadConstructionSite2(site) && priority === CONSTRUCTION_SITE_IMPACT_PRIORITY.energyStarvedCriticalRoad;
 }
 function canSpendOnStoredProtectedSourceContainerConstruction(creep, site, priorityContext) {
-  return isSourceContainerConstructionSite2(site, priorityContext) && !hasVisibleHostilePresence3(creep.room) && checkEnergyBufferForStoredConstructionSpending(creep.room) && hasMinimumProductiveWorkerCoverageForBoundedConstruction(creep) && !hasSameRoomWorkerAssignedToTask(creep.room, creep, "build");
+  return isSourceContainerConstructionSite2(site, priorityContext) && !hasVisibleHostilePresence3(creep.room) && checkEnergyBufferForStoredConstructionSpending(creep.room) && !hasSameRoomWorkerAssignedToTask(creep.room, creep, "build");
 }
 function isSourceContainerConstructionSite2(site, priorityContext) {
   const priority = getConstructionSiteImpactPriority(site, priorityContext);
@@ -31591,7 +31607,6 @@ var ADJACENT_ACTION_MOVE_RANGE = 1;
 var RANGED_WORK_MOVE_RANGE = 3;
 var EXACT_POSITION_MOVE_RANGE = 0;
 var MIN_HAULER_DROPPED_ENERGY = 25;
-var SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS2 = 2;
 var SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS2 = 300;
 function runWorker(creep) {
   var _a, _b;
@@ -32013,12 +32028,6 @@ function hasSafeStoredEnergyForBoundedConstruction2(creep, selectedTask) {
   }
   const storedEnergy = getRoomStoredEnergyAvailableForConstruction(creep.room);
   if (storedEnergy < CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY) {
-    return false;
-  }
-  const sameRoomWorkers = getRoomOwnedCreeps2(creep.room).filter(
-    (worker) => isProductiveSameRoomWorker2(worker, creep.room)
-  );
-  if (sameRoomWorkers.length < SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS2) {
     return false;
   }
   if (hasOtherSameRoomBuildAssignment(creep)) {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -76,7 +76,6 @@ const ADJACENT_ACTION_MOVE_RANGE = 1;
 const RANGED_WORK_MOVE_RANGE = 3;
 const EXACT_POSITION_MOVE_RANGE = 0;
 const MIN_HAULER_DROPPED_ENERGY = 25;
-const SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS = 2;
 const SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS = 300;
 
 interface WorkerTaskSelectionNullLoopState {
@@ -775,13 +774,6 @@ function hasSafeStoredEnergyForBoundedConstruction(
 
   const storedEnergy = getRoomStoredEnergyAvailableForConstruction(creep.room);
   if (storedEnergy < CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY) {
-    return false;
-  }
-
-  const sameRoomWorkers = getRoomOwnedCreeps(creep.room).filter((worker) =>
-    isProductiveSameRoomWorker(worker, creep.room)
-  );
-  if (sameRoomWorkers.length < SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS) {
     return false;
   }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -392,7 +392,7 @@ function selectCriticalCpuWorkerTask(creep: Creep): CreepTaskMemory | null {
     return applyMinimumUsefulLoadPolicy(creep, { type: 'build', targetId: missingSpawnConstructionSite.id });
   }
 
-  const storedProtectedConstructionTask = selectCriticalCpuStoredProtectedConstructionTask(creep);
+  const storedProtectedConstructionTask = selectStoredProtectedSourceContainerConstructionTask(creep);
   if (storedProtectedConstructionTask) {
     return applyMinimumUsefulLoadPolicy(creep, storedProtectedConstructionTask);
   }
@@ -423,17 +423,23 @@ function selectCriticalCpuWorkerTask(creep: Creep): CreepTaskMemory | null {
   return null;
 }
 
-function selectCriticalCpuStoredProtectedConstructionTask(
-  creep: Creep
+function selectStoredProtectedSourceContainerConstructionTask(
+  creep: Creep,
+  constructionSites?: ConstructionSite[],
+  constructionReservationContext?: ConstructionReservationContext
 ): Extract<CreepTaskMemory, { type: 'build' }> | null {
-  const constructionSite = selectCriticalCpuStoredProtectedConstructionSite(creep);
+  const constructionSite = selectStoredProtectedSourceContainerConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext
+  );
   return constructionSite ? { type: 'build', targetId: constructionSite.id } : null;
 }
 
-function selectCriticalCpuStoredProtectedConstructionEnergyAcquisitionTask(
+function selectStoredProtectedSourceContainerConstructionEnergyAcquisitionTask(
   creep: Creep
 ): BuilderEnergyAcquisitionTask | null {
-  const constructionSite = selectCriticalCpuStoredProtectedConstructionEnergyAcquisitionSite(creep);
+  const constructionSite = selectStoredProtectedSourceContainerConstructionEnergyAcquisitionSite(creep);
   if (!constructionSite) {
     return null;
   }
@@ -446,7 +452,7 @@ function selectCriticalCpuStoredProtectedConstructionEnergyAcquisitionTask(
   return candidates.sort(compareBuilderEnergyAcquisitionCandidates)[0].task;
 }
 
-function selectCriticalCpuStoredProtectedConstructionEnergyAcquisitionSite(
+function selectStoredProtectedSourceContainerConstructionEnergyAcquisitionSite(
   creep: Creep
 ): ConstructionSite | null {
   const constructionSites = findConstructionSites(creep.room);
@@ -468,18 +474,22 @@ function selectCriticalCpuStoredProtectedConstructionEnergyAcquisitionSite(
   );
 }
 
-function selectCriticalCpuStoredProtectedConstructionSite(creep: Creep): ConstructionSite | null {
-  const constructionSites = findConstructionSites(creep.room);
-  if (constructionSites.length === 0) {
+function selectStoredProtectedSourceContainerConstructionSite(
+  creep: Creep,
+  constructionSites?: ConstructionSite[],
+  constructionReservationContext?: ConstructionReservationContext
+): ConstructionSite | null {
+  const sites = constructionSites ?? findConstructionSites(creep.room);
+  if (sites.length === 0) {
     return null;
   }
 
-  const constructionReservationContext = createConstructionReservationContext(creep.room);
-  const priorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  const reservations = constructionReservationContext ?? createConstructionReservationContext(creep.room);
+  const priorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, sites);
   return selectUnreservedConstructionSite(
     creep,
-    constructionSites,
-    constructionReservationContext,
+    sites,
+    reservations,
     (site) => canSpendOnStoredProtectedSourceContainerConstruction(creep, site, priorityContext),
     { priorityContext }
   );
@@ -526,7 +536,7 @@ function selectCriticalCpuEnergyAcquisitionTask(
     return selectWorkerEnergyCriticalAcquisitionTask(creep);
   }
 
-  return selectCriticalCpuStoredProtectedConstructionEnergyAcquisitionTask(creep);
+  return selectStoredProtectedSourceContainerConstructionEnergyAcquisitionTask(creep);
 }
 
 function hasCriticalCpuRepairDemand(creep: Creep): boolean {
@@ -617,6 +627,12 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
 
     let hasPriorityEnergySink = false;
     if (getFreeEnergyCapacity(creep) > 0) {
+      const storedProtectedConstructionEnergyAcquisitionTask =
+        selectStoredProtectedSourceContainerConstructionEnergyAcquisitionTask(creep);
+      if (storedProtectedConstructionEnergyAcquisitionTask) {
+        return storedProtectedConstructionEnergyAcquisitionTask;
+      }
+
       const spawnRecoveryEnergySink = selectFillableEnergySink(creep);
       if (spawnRecoveryEnergySink) {
         hasPriorityEnergySink = true;
@@ -817,6 +833,15 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
         targetId: threatenedBarrierRepairTarget.id as Id<Structure>
       });
     }
+  }
+
+  const storedProtectedConstructionTask = selectStoredProtectedSourceContainerConstructionTask(
+    creep,
+    constructionSites,
+    constructionReservationContext
+  );
+  if (storedProtectedConstructionTask) {
+    return applyMinimumUsefulLoadPolicy(creep, storedProtectedConstructionTask);
   }
 
   const bootstrapExtensionConstructionSite = selectBootstrapExtensionConstructionSiteBeforeRefill(
@@ -3805,7 +3830,6 @@ function canSpendOnStoredProtectedSourceContainerConstruction(
     isSourceContainerConstructionSite(site, priorityContext) &&
     !hasVisibleHostilePresence(creep.room) &&
     checkEnergyBufferForStoredConstructionSpending(creep.room) &&
-    hasMinimumProductiveWorkerCoverageForBoundedConstruction(creep) &&
     !hasSameRoomWorkerAssignedToTask(creep.room, creep, 'build')
   );
 }

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -4718,6 +4718,135 @@ describe('runWorker', () => {
     expect(transfer).not.toHaveBeenCalled();
   });
 
+  it('does not let spawn reservation refill starve the only E29N57 source-container builder', () => {
+    const source = {
+      id: 'source1',
+      pos: { x: 20, y: 20, roomName: 'E29N57' } as RoomPosition
+    } as Source;
+    const site = {
+      id: 'site1',
+      structureType: 'container',
+      progress: 500,
+      progressTotal: 5_000,
+      pos: { x: 20, y: 21, roomName: 'E29N57' } as RoomPosition
+    } as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(250),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      }
+    } as unknown as StructureSpawn;
+    const storedContainer = {
+      id: 'stored-container1',
+      structureType: 'container',
+      pos: { x: 20, y: 22, roomName: 'E29N57' } as RoomPosition,
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 1_333 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) =>
+          resource === undefined || resource === RESOURCE_ENERGY ? 2_000 : 0
+        )
+      }
+    } as unknown as StructureContainer;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N57',
+      energyAvailable: 650,
+      energyCapacityAvailable: 1_800,
+      controller,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [spawn, storedContainer];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          if (type === FIND_SOURCES) {
+            return [source];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const transfer = jest.fn();
+    const creep = {
+      name: 'Builder',
+      memory: { role: 'worker', colony: 'E29N57' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(30),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      build,
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    roomCreeps.push(creep);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      economy: {
+        spawnEnergyReservation: {
+          updatedAt: 123,
+          rooms: {
+            E29N57: {
+              bodyCost: 800,
+              creepName: 'worker-E29N57-124',
+              reservedAt: 123,
+              reservedEnergy: 800,
+              role: 'worker',
+              roomName: 'E29N57',
+              updatedAt: 123
+            }
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Builder: creep },
+      rooms: { E29N57: room },
+      time: 124,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'site1') {
+          return site;
+        }
+
+        if (id === 'spawn1') {
+          return spawn;
+        }
+
+        return id === 'stored-container1' ? storedContainer : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'site1' });
+    expect(creep.memory.workerDispatchDiagnostic?.spawnReservationTask).toBeUndefined();
+    expect(build).toHaveBeenCalledWith(site);
+    expect(transfer).not.toHaveBeenCalled();
+  });
+
   it('keeps E29N57 source-container construction ahead of spawn reservation refill during low-bucket shedding', () => {
     const source = {
       id: 'source1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -12902,6 +12902,110 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'stored-container1' });
   });
 
+  it('refills uncovered E29N57 source-container construction from storage before spawn recovery', () => {
+    const source = makeSource('source1', 20, 20, 'E29N57');
+    const site = {
+      id: 'container-site1',
+      structureType: 'container',
+      progress: 500,
+      progressTotal: 5_000,
+      pos: {
+        ...makeRoomPosition(20, 21, 'E29N57'),
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'stored-container1' ? 1 : 99))
+      }
+    } as unknown as ConstructionSite;
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 50, {
+      pos: makeRoomPosition(20, 19, 'E29N57')
+    });
+    const storedContainer = makeStoredEnergyContainerWithCapacity('stored-container1', 1_333, 2_000, {
+      pos: {
+        ...makeRoomPosition(20, 22, 'E29N57'),
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'spawn1' ? 3 : 1))
+      }
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N57',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 650,
+      energyCapacityAvailable: 1_800,
+      myStructures: [spawn as AnyOwnedStructure],
+      sources: [source],
+      structures: [spawn as unknown as AnyStructure, storedContainer as AnyStructure]
+    });
+    const creep = {
+      name: 'StorageBuilder',
+      memory: { role: 'worker', colony: 'E29N57' },
+      pos: {
+        ...makeRoomPosition(20, 21, 'E29N57'),
+        getRangeTo: jest.fn((target: { id?: string }) => {
+          if (target.id === 'stored-container1') return 1;
+          if (target.id === 'source1') return 1;
+          return 99;
+        })
+      },
+      getActiveBodyparts: jest.fn().mockReturnValue(25),
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ StorageBuilder: creep });
+    setGameObjectsById([site, spawn, storedContainer, source], { rooms: { E29N57: room }, time: 124 });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'stored-container1' });
+  });
+
+  it('assigns the only loaded E29N57 source-container builder despite spawn refill demand', () => {
+    const source = makeSource('source1', 20, 20, 'E29N57');
+    const site = {
+      id: 'container-site1',
+      structureType: 'container',
+      progress: 500,
+      progressTotal: 5_000,
+      pos: makeRoomPosition(20, 21, 'E29N57')
+    } as ConstructionSite;
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 50);
+    const storedContainer = makeStoredEnergyContainerWithCapacity('stored-container1', 1_333, 2_000, {
+      pos: makeRoomPosition(20, 22, 'E29N57')
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N57',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 650,
+      energyCapacityAvailable: 1_800,
+      myStructures: [spawn as AnyOwnedStructure],
+      sources: [source],
+      structures: [storedContainer as AnyStructure]
+    });
+    const creep = {
+      name: 'LoadedBuilder',
+      memory: { role: 'worker', colony: 'E29N57' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(30),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ LoadedBuilder: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'container-site1' });
+  });
+
   it('does not count the current build-assigned worker as uncovered construction coverage', () => {
     const site = { id: 'wall-site1', structureType: 'constructedWall' } as ConstructionSite;
     const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 317, {


### PR DESCRIPTION
## Summary
- unblocks loaded E29N57 workers from remaining stuck in energy logistics while construction sites are uncovered
- prioritizes build assignment from stored energy containers when room energy is already above the reserve threshold
- adds worker task/runner regression coverage and refreshes the generated Screeps bundle

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (103 suites / 2156 tests passed)
- `cd prod && npm run build`

Related to issue #1553.

## Universal task Done gate
- [x] Task type: Bot capability gameplay bugfix for E29N57 construction-deadlock behavior.
- [x] Expected observable outcome / named deliverable: loaded builders choose uncovered construction work when stored energy can satisfy the room reserve, producing commit `1a6409f` on branch `fix/issue-1553-followup`.
- [x] Non-goals / accepted substitutes: no room retarget, no official deploy from this PR, no change to spawn-reserve policy outside the loaded-builder construction gap.
- [x] Verification evidence required before Done: controller ran diff-check, prod typecheck, full Jest run, and prod build successfully in `/root/screeps-worktrees/issue-1553-followup`.
- [x] Project Evidence / Next action / Blocked by: issue #1553 Project fields are updated with the Codex commit/verification evidence and PR-gate next action.
- [x] Post-merge/deploy/runtime proof: issue #1553 remains the runtime acceptance surface for official deploy evidence plus a fresh runtime summary showing E29N57 build progress or decreased pendingBuildProgress.
- [x] Named deliverable proof: `prod/src/tasks/workerTasks.ts`, `prod/src/creeps/workerRunner.ts`, regression tests, and `prod/dist/main.js` changed together in Codex-authored commit `1a6409f`.
