### PR TITLE
fix: unblock E29N57 postdeploy construction

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -25401,7 +25401,7 @@ function selectCriticalCpuWorkerTask(creep) {
     return selectCriticalCpuEnergyAcquisitionTask(creep);
   }
   const controller = creep.room.controller;
-  if (controller && shouldGuardControllerDowngradeForWorkerLoad(creep, controller) && canUpgradeController(controller)) {
+  if (controller && shouldGuardControllerDowngradeForWorkerLoad(creep, controller, { allowConstructionBacklogYield: false }) && canUpgradeController(controller)) {
     return { type: "upgrade", targetId: controller.id };
   }
   const criticalSpawnRepairTarget = selectCriticalOwnedSpawnRepairTarget(creep);
@@ -25538,7 +25538,7 @@ function selectCriticalCpuEnergyAcquisitionTask(creep) {
     return selectWorkerEnergyCriticalAcquisitionTask(creep);
   }
   const controller = creep.room.controller;
-  if (controller && shouldGuardControllerDowngradeForWorkerLoad(creep, controller) && canUpgradeController(controller)) {
+  if (controller && shouldGuardControllerDowngradeForWorkerLoad(creep, controller, { allowConstructionBacklogYield: false }) && canUpgradeController(controller)) {
     return selectWorkerEnergyCriticalAcquisitionTask(creep);
   }
   if (hasCriticalCpuRepairDemand(creep)) {
@@ -26529,11 +26529,12 @@ function isWorkerRefillBoundOrReservableForSpawnExtensionDelivery(worker, spawnE
   const task = (_a = worker.memory) == null ? void 0 : _a.task;
   return task == null || (task == null ? void 0 : task.type) === "transfer" && task.targetId !== void 0 && spawnExtensionEnergyStructureIds.has(String(task.targetId));
 }
-function shouldGuardControllerDowngradeForWorkerLoad(creep, controller) {
+function shouldGuardControllerDowngradeForWorkerLoad(creep, controller, options = {}) {
+  var _a;
   if (!shouldGuardControllerDowngrade2(controller)) {
     return false;
   }
-  if (shouldYieldControllerDowngradeGuardToConstructionBacklog(creep, controller)) {
+  if (((_a = options.allowConstructionBacklogYield) != null ? _a : true) && shouldYieldControllerDowngradeGuardToConstructionBacklog(creep, controller)) {
     return false;
   }
   return !getLowLoadWorkerEnergyContext(creep) || isControllerDowngradeImminentForLowLoadReturn(controller);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -26542,7 +26542,13 @@ function isControllerDowngradeImminentForLowLoadReturn(controller) {
   return (controller == null ? void 0 : controller.my) === true && typeof controller.ticksToDowngrade === "number" && controller.ticksToDowngrade < LOW_LOAD_CONTROLLER_DOWNGRADE_IMMINENT_TICKS;
 }
 function shouldYieldControllerDowngradeGuardToConstructionBacklog(creep, controller) {
-  return (controller == null ? void 0 : controller.my) === true && controller.level === 2 && !isControllerDowngradeImminentForLowLoadReturn(controller) && getUsedEnergy2(creep) > 0 && getActiveWorkParts2(creep) > 0 && hasOtherLoadedWorkerUpgradingController(creep, controller) && !hasSameRoomWorkerAssignedToTask(creep.room, creep, "build") && hasSpendableConstructionBacklog(creep);
+  if ((controller == null ? void 0 : controller.my) !== true || isControllerDowngradeImminentForLowLoadReturn(controller) || getUsedEnergy2(creep) <= 0 || getActiveWorkParts2(creep) <= 0 || hasSameRoomWorkerAssignedToTask(creep.room, creep, "build") || !hasSpendableConstructionBacklog(creep)) {
+    return false;
+  }
+  if (controller.level === 2) {
+    return hasOtherLoadedWorkerUpgradingController(creep, controller);
+  }
+  return controller.level >= 3 && hasHealthyRoomEnergyBuffer(creep.room) && hasMinimumProductiveWorkerCoverageForBoundedConstruction(creep);
 }
 function hasOtherLoadedWorkerUpgradingController(creep, controller) {
   return getSameRoomLoadedWorkers(creep).some(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1957,15 +1957,25 @@ function shouldYieldControllerDowngradeGuardToConstructionBacklog(
   creep: Creep,
   controller: StructureController | undefined
 ): boolean {
+  if (
+    controller?.my !== true ||
+    isControllerDowngradeImminentForLowLoadReturn(controller) ||
+    getUsedEnergy(creep) <= 0 ||
+    getActiveWorkParts(creep) <= 0 ||
+    hasSameRoomWorkerAssignedToTask(creep.room, creep, 'build') ||
+    !hasSpendableConstructionBacklog(creep)
+  ) {
+    return false;
+  }
+
+  if (controller.level === 2) {
+    return hasOtherLoadedWorkerUpgradingController(creep, controller);
+  }
+
   return (
-    controller?.my === true &&
-    controller.level === 2 &&
-    !isControllerDowngradeImminentForLowLoadReturn(controller) &&
-    getUsedEnergy(creep) > 0 &&
-    getActiveWorkParts(creep) > 0 &&
-    hasOtherLoadedWorkerUpgradingController(creep, controller) &&
-    !hasSameRoomWorkerAssignedToTask(creep.room, creep, 'build') &&
-    hasSpendableConstructionBacklog(creep)
+    controller.level >= 3 &&
+    hasHealthyRoomEnergyBuffer(creep.room) &&
+    hasMinimumProductiveWorkerCoverageForBoundedConstruction(creep)
   );
 }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -307,6 +307,10 @@ interface SourceContainerWithdrawalContext {
   sources: Source[];
 }
 
+interface ControllerDowngradeGuardOptions {
+  allowConstructionBacklogYield?: boolean;
+}
+
 let nearTermSpawnExtensionRefillReserveCache: NearTermSpawnExtensionRefillReserveCache | null = null;
 let interRoomLiveTransferCandidateCache: LiveTransferCandidateCache | null = null;
 let interRoomHaulReservationCache: InterRoomHaulReservationCache | null = null;
@@ -348,7 +352,7 @@ function selectCriticalCpuWorkerTask(creep: Creep): CreepTaskMemory | null {
   const controller = creep.room.controller;
   if (
     controller &&
-    shouldGuardControllerDowngradeForWorkerLoad(creep, controller) &&
+    shouldGuardControllerDowngradeForWorkerLoad(creep, controller, { allowConstructionBacklogYield: false }) &&
     canUpgradeController(controller)
   ) {
     return { type: 'upgrade', targetId: controller.id };
@@ -526,7 +530,7 @@ function selectCriticalCpuEnergyAcquisitionTask(
   const controller = creep.room.controller;
   if (
     controller &&
-    shouldGuardControllerDowngradeForWorkerLoad(creep, controller) &&
+    shouldGuardControllerDowngradeForWorkerLoad(creep, controller, { allowConstructionBacklogYield: false }) &&
     canUpgradeController(controller)
   ) {
     return selectWorkerEnergyCriticalAcquisitionTask(creep);
@@ -1930,13 +1934,17 @@ function isWorkerRefillBoundOrReservableForSpawnExtensionDelivery(
 
 function shouldGuardControllerDowngradeForWorkerLoad(
   creep: Creep,
-  controller: StructureController | undefined
+  controller: StructureController | undefined,
+  options: ControllerDowngradeGuardOptions = {}
 ): boolean {
   if (!shouldGuardControllerDowngrade(controller)) {
     return false;
   }
 
-  if (shouldYieldControllerDowngradeGuardToConstructionBacklog(creep, controller)) {
+  if (
+    (options.allowConstructionBacklogYield ?? true) &&
+    shouldYieldControllerDowngradeGuardToConstructionBacklog(creep, controller)
+  ) {
     return false;
   }
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -4847,6 +4847,155 @@ describe('runWorker', () => {
     expect(transfer).not.toHaveBeenCalled();
   });
 
+  it('assigns a post-deploy E29N57 builder while a stale spawn reserve signal is present', () => {
+    const source = {
+      id: 'source1',
+      pos: { x: 20, y: 20, roomName: 'E29N57' } as RoomPosition
+    } as Source;
+    const site = {
+      id: 'site1',
+      structureType: 'container',
+      progress: 10,
+      progressTotal: 4_500,
+      pos: { x: 20, y: 21, roomName: 'E29N57' } as RoomPosition
+    } as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 250 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+      }
+    } as unknown as StructureSpawn;
+    const storedContainer = {
+      id: 'stored-container1',
+      structureType: 'container',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 1_090 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) =>
+          resource === undefined || resource === RESOURCE_ENERGY ? 2_000 : 0
+        )
+      }
+    } as unknown as StructureContainer;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: 4_359
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N57',
+      energyAvailable: 1_045,
+      energyCapacityAvailable: 1_800,
+      controller,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [spawn, storedContainer];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          if (type === FIND_SOURCES) {
+            return [source];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const transfer = jest.fn();
+    const upgradeController = jest.fn();
+    const creep = {
+      name: 'LoadedBuilder',
+      memory: { role: 'worker', colony: 'E29N57' },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 30 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 70 : 0))
+      },
+      room,
+      build,
+      transfer,
+      upgradeController,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const recoveryWorker = {
+      name: 'RecoveryWorker',
+      memory: { role: 'worker', colony: 'E29N57', task: { type: 'harvest', targetId: 'source1' as Id<Source> } },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, recoveryWorker);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      economy: {
+        spawnEnergyReservation: {
+          updatedAt: 1_663_670,
+          rooms: {
+            E29N57: {
+              bodyCost: 1_800,
+              creepName: 'worker-E29N57-next',
+              reservedAt: 1_663_670,
+              reservedEnergy: 1_800,
+              role: 'worker',
+              roomName: 'E29N57',
+              updatedAt: 1_663_670
+            }
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { LoadedBuilder: creep, RecoveryWorker: recoveryWorker },
+      rooms: { E29N57: room },
+      time: 1_663_671,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'site1') {
+          return site;
+        }
+
+        if (id === 'controller1') {
+          return controller;
+        }
+
+        if (id === 'spawn1') {
+          return spawn;
+        }
+
+        return id === 'stored-container1' ? storedContainer : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'site1' });
+    expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+      baseSelectedTask: 'build',
+      selectedTask: 'build',
+      assignedTask: 'build'
+    });
+    expect(creep.memory.workerDispatchDiagnostic?.spawnReservationTask).toBeUndefined();
+    expect(build).toHaveBeenCalledWith(site);
+    expect(transfer).not.toHaveBeenCalled();
+    expect(upgradeController).not.toHaveBeenCalled();
+  });
+
   it('keeps E29N57 source-container construction ahead of spawn reservation refill during low-bucket shedding', () => {
     const source = {
       id: 'source1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -12720,6 +12720,79 @@ describe('selectWorkerTask', () => {
     expect(selectedTask).toEqual({ type: 'build', targetId: 'wall-site1' });
   });
 
+  it('keeps RCL3 construction yield above the downgrade guard when CPU is healthy', () => {
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0);
+    const site = { id: 'wall-site1', structureType: 'constructedWall' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [site],
+      controller,
+      energyAvailable: 909,
+      energyCapacityAvailable: 1_800,
+      myStructures: [fullSpawn as AnyOwnedStructure]
+    });
+    const builder = {
+      name: 'BuilderCandidate',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room
+    } as unknown as Creep;
+    const idleWorker = {
+      name: 'IdleWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ BuilderCandidate: builder, IdleWorker: idleWorker });
+
+    expect(selectWorkerTask(builder)).toEqual({ type: 'build', targetId: 'wall-site1' });
+  });
+
+  it('keeps the downgrade guard upgrading under low-bucket shedding when construction yield would idle', () => {
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0);
+    const site = { id: 'wall-site1', structureType: 'constructedWall' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [site],
+      controller,
+      energyAvailable: 909,
+      energyCapacityAvailable: 1_800,
+      myStructures: [fullSpawn as AnyOwnedStructure]
+    });
+    const builder = {
+      name: 'LowBucketBuilder',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room
+    } as unknown as Creep;
+    const idleWorker = {
+      name: 'IdleWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ LowBucketBuilder: builder, IdleWorker: idleWorker });
+    setCpuBucket(948);
+
+    expect(selectWorkerTask(builder)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
   it('reserves a loaded worker for container construction when container surplus protects recovery energy', () => {
     const site = {
       id: 'source-container-site1',


### PR DESCRIPTION
## Summary
- Allow loaded workers in healthy RCL3+ rooms to yield controller-upgrade guard work to a spendable construction backlog when other productive coverage and room energy buffer are present.
- Add a regression test for the postdeploy E29N57 deadlock shape where a stale spawn reservation signal coexisted with carried worker energy and a container construction site.
- Rebuild `prod/dist/main.js` from the verified source.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (103 suites, 2157 tests)
- `cd prod && npm run build`

Related to issue 1590.

## Universal task Done gate
- [x] Task type: Production gameplay bugfix for E29N57 construction assignment.
- [x] Expected observable outcome / named deliverable: loaded E29N57 workers can select the container construction site instead of remaining stuck on controller-upgrade/spawn-reservation fallback when the room has healthy worker coverage and energy buffer.
- [x] Non-goals / accepted substitutes: no change to low-RCL emergency controller-sustain behavior, no owner-side action, no Tencent/paid compute, and no official MMO writes from this PR branch.
- [x] Verification evidence required before Done: controller verification passed with diff-check, typecheck, full Jest, and build on commit ae5522545a6cfe1d92f618dec95ba63111f00caa.
- [x] Project Evidence / Next action / Blocked by: issue 1590 Project item is updated by the scheduler to In review with this PR head, verification evidence, and review/deploy gate handoff.
- [x] Post-merge/deploy/runtime proof: issue 1590 remains the runtime proof lane for official deploy evidence plus fresh E29N57 runtime-summary construction-progress evidence before issue closure.
- [x] Named deliverable proof: `prod/test/workerRunner.test.ts` includes the E29N57 stale-reservation loaded-builder regression, and `prod/src/tasks/workerTasks.ts` contains the guarded RCL3+ construction-yield path.
