### PR TITLE
rl: enforce role-scoped policy lane metadata

### DIFF
--- a/docs/ops/rl-act-loop-feedback.md
+++ b/docs/ops/rl-act-loop-feedback.md
@@ -44,7 +44,7 @@ Each plan emits:
 - `feedbackIngestion`: current state for finding -> decision -> card -> training -> scorecard -> rollout feedback.
 - `decision`, `status`, and `blockingReasons`: fields that the SQLite/Grafana ingestion path can count through `metric_iteration_decisions`.
 
-Policy-family routing follows `docs/ops/rl-policy-family-flywheel.md`: no new cron lanes, flexible `policyFamily` / `topAgent` / `rolePolicy` fields, and fallback only from known `parameterSurface` names such as `construction-priority -> top.construction`.
+Policy-family routing follows `docs/ops/rl-policy-family-flywheel.md`: no new cron lanes, flexible `policyFamily` / `topAgent` / `rolePolicy` / `trainingRole` fields, and fallback only from known `parameterSurface` names such as `construction-priority -> top.construction` or `worker-task -> role.worker-task`.
 
 Allowed classifications:
 
@@ -83,8 +83,11 @@ The fixture `scripts/fixtures/rl/act-loop-mixed-unproven-policy-advantage.json` 
 
 - `nextScenarioDelta.targetScenarioId = "multi-tier-territory-combat-v0"`
 - `nextPolicyDelta.parameterSurface = "construction-priority"` with bounded weights
+- `nextPolicyDelta.policyFamily = "top.construction"`; this is high-level canary evidence and not role-policy completion evidence
 - `nextExperimentCardDelta.trainingApproach = "policy_gradient"`
 - no `nextRewardDecision`, because the evidence does not justify reward tuning yet
+
+Issue #1583 can produce bounded `top.construction` canary evidence. Issue #1585 requires separate `role.worker-task`, `role.source-harvester`, and `role.defender-micro` lane metadata and scorecards before any role-policy completion claim.
 
 ## Verification
 

--- a/docs/ops/rl-domain-roadmap.md
+++ b/docs/ops/rl-domain-roadmap.md
@@ -67,7 +67,7 @@ Current lane identities include:
 
 Smoke-scale evidence cannot close scale-first training work. The current `5 workers x 5 repetitions x 500 ticks = 25 env rows / 12,500 simulator ticks` shape is smoke-only; validation requires >=200 env rows and >=200k ticks, and the scale/cadence atomic issues own the minimum acceptable 8c16g utilization ladder.
 
-Policy-family-aware execution starts with `top.construction` as the existing `construction-priority` bridge and `role.worker-task` as the first lower-level surface. These labels are routing metadata only; reward, scorecard, canary, rollout, and feedback gates remain unchanged.
+Policy-family-aware execution starts with `top.construction` as the existing `construction-priority` bridge and `role.worker-task`, `role.source-harvester`, and `role.defender-micro` as the first role-scoped surfaces. These labels are routing metadata only; reward, scorecard, canary, rollout, and feedback gates remain unchanged. Evidence from #1583's bounded `top.construction` canary is not role-policy completion evidence for #1585.
 
 ## Current issue map
 
@@ -125,7 +125,7 @@ Accepted input classes:
 A tick sample must expose:
 
 - observation: tick, room, shard, energy, workers/tasks, spawn state, controller, resources, combat, CPU, reliability, monitor counters;
-- action labels: high-level offline labels such as `construction-priority` and `expansion-remote-candidate`, always `liveEffect: false`;
+- action labels: high-level offline labels such as `construction-priority` and `expansion-remote-candidate`, plus future role-scoped labels that preserve `policyFamily`, `rolePolicy`, and `trainingRole`; always `liveEffect: false`;
 - reward components: reliability, territory, resources, kills; scalar reward remains `null` until an experiment card explicitly preserves this order.
 
 Generated datasets stay local derived artifacts by default:

--- a/docs/ops/rl-policy-family-flywheel.md
+++ b/docs/ops/rl-policy-family-flywheel.md
@@ -38,6 +38,7 @@ Top-level policy families:
 Role and lower-level policy families:
 
 - `role.worker-task`
+- `role.source-harvester`
 - `role.tower-action`
 - `role.hauler-routing`
 - `role.builder-repair`
@@ -52,8 +53,9 @@ Role and lower-level policy families:
 The first durable slice is plumbing, not a behavior rollout.
 
 - `top.construction` bridges the existing `construction-priority` candidate stream into the top-level hierarchy.
-- `role.worker-task` is the first low-level policy surface for later dataset, training, scorecard, and canary work.
+- `role.worker-task`, `role.source-harvester`, and `role.defender-micro` are the initial role-policy lanes for later dataset, training, scorecard, and canary work.
 - `role.tower-action` is recognized as a route fallback for tower-action policy-surface findings, but it does not authorize live tower behavior changes.
+- Top-level `construction-priority` or `top.construction` canary evidence remains high-level policy evidence only. It must not be counted as role-policy completion for worker-task, source-harvester, or defender-micro lanes.
 
 When explicit route fields are absent, the only initial fallback mappings are:
 
@@ -61,6 +63,10 @@ When explicit route fields are absent, the only initial fallback mappings are:
 | --- | --- |
 | `construction-priority` | `top.construction` |
 | `worker-task` | `role.worker-task` |
+| `source-harvester` | `role.source-harvester` |
+| `harvester` | `role.source-harvester` |
+| `defender-micro` | `role.defender-micro` |
+| `defender` | `role.defender-micro` |
 | `tower-action` | `role.tower-action` |
 
 All other parameter surfaces keep the existing `parameterSurface` behavior without inventing a policy-family route.

--- a/scripts/fixtures/rl/act-loop-mixed-unproven-policy-advantage.json
+++ b/scripts/fixtures/rl/act-loop-mixed-unproven-policy-advantage.json
@@ -5,6 +5,8 @@
   "onlineUtilityStatus": "MIXED",
   "candidateId": "construction-priority.pg.territory-seed.v1",
   "incumbentId": "construction-priority.incumbent.v1",
+  "policyFamily": "top.construction",
+  "metaPolicyReason": "Top-level construction-priority Loop B canary evidence; not role-policy completion evidence.",
   "datasetRunId": "rl-loop-b-sample-000001",
   "evidenceWindow": "2026-05-19T12:00:00Z..2026-05-19T20:00:00Z",
   "scenarioEvidence": {

--- a/scripts/fixtures/rl/role-policy-scorecards/README.md
+++ b/scripts/fixtures/rl/role-policy-scorecards/README.md
@@ -1,0 +1,15 @@
+# Role-Policy Scorecard Fixtures
+
+These deterministic fixtures lock the issue #1585 output contract for the first
+role-scoped RL policy lanes. They are offline/private/shadow evidence shape
+fixtures only: no live compute was run, `liveEffect` is `false`, and
+`officialMmoWrites` is `false`.
+
+Each JSON file represents one rejected candidate-vs-baseline scorecard lane:
+
+- `role.worker-task.scorecard.json`
+- `role.source-harvester.scorecard.json`
+- `role.defender-micro.scorecard.json`
+
+Top-level `construction-priority` or `top.construction` canary evidence must not
+be counted as satisfying these role-policy fixtures.

--- a/scripts/fixtures/rl/role-policy-scorecards/role.defender-micro.scorecard.json
+++ b/scripts/fixtures/rl/role-policy-scorecards/role.defender-micro.scorecard.json
@@ -1,0 +1,54 @@
+{
+  "type": "screeps-rl-evaluation-scorecard",
+  "schemaVersion": 1,
+  "runId": "rl-scorecard-role-defender-micro-fixture",
+  "timestamp": "2026-06-01T00:00:00Z",
+  "fixtureOnly": true,
+  "noLiveComputeRun": true,
+  "liveEffect": false,
+  "officialMmoWrites": false,
+  "officialMmoWritesAllowed": false,
+  "rolePolicyMetadata": {
+    "candidate": {
+      "policyFamily": "role.defender-micro",
+      "rolePolicy": "defender-micro",
+      "trainingRole": "defender"
+    },
+    "baseline": {
+      "policyFamily": "role.defender-micro",
+      "rolePolicy": "defender-micro",
+      "trainingRole": "defender"
+    },
+    "rolePolicyFamilies": [
+      "role.defender-micro"
+    ],
+    "liveEffect": false,
+    "officialMmoWrites": false,
+    "officialMmoWritesAllowed": false
+  },
+  "candidate": {
+    "id": "role.defender-micro.shadow-candidate.v1",
+    "policyFamily": "role.defender-micro",
+    "rolePolicy": "defender-micro",
+    "trainingRole": "defender",
+    "runtimeParameterInjection": {
+      "status": "missing",
+      "runtimeParameterInjection": false,
+      "policyUpdateEligible": false,
+      "reason": "fixture has no runtime parameter injection evidence"
+    }
+  },
+  "baseline": {
+    "id": "role.defender-micro.heuristic-baseline.v1",
+    "policyFamily": "role.defender-micro",
+    "rolePolicy": "defender-micro",
+    "trainingRole": "defender"
+  },
+  "overallGate": {
+    "status": "HOLD",
+    "rationale": "deterministic role-policy fixture only; no live compute was run",
+    "requiredActions": [
+      "Collect offline/private/shadow defender-micro evidence before any role-policy completion claim."
+    ]
+  }
+}

--- a/scripts/fixtures/rl/role-policy-scorecards/role.source-harvester.scorecard.json
+++ b/scripts/fixtures/rl/role-policy-scorecards/role.source-harvester.scorecard.json
@@ -1,0 +1,54 @@
+{
+  "type": "screeps-rl-evaluation-scorecard",
+  "schemaVersion": 1,
+  "runId": "rl-scorecard-role-source-harvester-fixture",
+  "timestamp": "2026-06-01T00:00:00Z",
+  "fixtureOnly": true,
+  "noLiveComputeRun": true,
+  "liveEffect": false,
+  "officialMmoWrites": false,
+  "officialMmoWritesAllowed": false,
+  "rolePolicyMetadata": {
+    "candidate": {
+      "policyFamily": "role.source-harvester",
+      "rolePolicy": "source-harvester",
+      "trainingRole": "source-harvester"
+    },
+    "baseline": {
+      "policyFamily": "role.source-harvester",
+      "rolePolicy": "source-harvester",
+      "trainingRole": "source-harvester"
+    },
+    "rolePolicyFamilies": [
+      "role.source-harvester"
+    ],
+    "liveEffect": false,
+    "officialMmoWrites": false,
+    "officialMmoWritesAllowed": false
+  },
+  "candidate": {
+    "id": "role.source-harvester.shadow-candidate.v1",
+    "policyFamily": "role.source-harvester",
+    "rolePolicy": "source-harvester",
+    "trainingRole": "source-harvester",
+    "runtimeParameterInjection": {
+      "status": "missing",
+      "runtimeParameterInjection": false,
+      "policyUpdateEligible": false,
+      "reason": "fixture has no runtime parameter injection evidence"
+    }
+  },
+  "baseline": {
+    "id": "role.source-harvester.heuristic-baseline.v1",
+    "policyFamily": "role.source-harvester",
+    "rolePolicy": "source-harvester",
+    "trainingRole": "source-harvester"
+  },
+  "overallGate": {
+    "status": "HOLD",
+    "rationale": "deterministic role-policy fixture only; no live compute was run",
+    "requiredActions": [
+      "Collect offline/private/shadow source-harvester evidence before any role-policy completion claim."
+    ]
+  }
+}

--- a/scripts/fixtures/rl/role-policy-scorecards/role.worker-task.scorecard.json
+++ b/scripts/fixtures/rl/role-policy-scorecards/role.worker-task.scorecard.json
@@ -1,0 +1,54 @@
+{
+  "type": "screeps-rl-evaluation-scorecard",
+  "schemaVersion": 1,
+  "runId": "rl-scorecard-role-worker-task-fixture",
+  "timestamp": "2026-06-01T00:00:00Z",
+  "fixtureOnly": true,
+  "noLiveComputeRun": true,
+  "liveEffect": false,
+  "officialMmoWrites": false,
+  "officialMmoWritesAllowed": false,
+  "rolePolicyMetadata": {
+    "candidate": {
+      "policyFamily": "role.worker-task",
+      "rolePolicy": "worker-task",
+      "trainingRole": "worker"
+    },
+    "baseline": {
+      "policyFamily": "role.worker-task",
+      "rolePolicy": "worker-task",
+      "trainingRole": "worker"
+    },
+    "rolePolicyFamilies": [
+      "role.worker-task"
+    ],
+    "liveEffect": false,
+    "officialMmoWrites": false,
+    "officialMmoWritesAllowed": false
+  },
+  "candidate": {
+    "id": "role.worker-task.shadow-candidate.v1",
+    "policyFamily": "role.worker-task",
+    "rolePolicy": "worker-task",
+    "trainingRole": "worker",
+    "runtimeParameterInjection": {
+      "status": "missing",
+      "runtimeParameterInjection": false,
+      "policyUpdateEligible": false,
+      "reason": "fixture has no runtime parameter injection evidence"
+    }
+  },
+  "baseline": {
+    "id": "role.worker-task.heuristic-baseline.v1",
+    "policyFamily": "role.worker-task",
+    "rolePolicy": "worker-task",
+    "trainingRole": "worker"
+  },
+  "overallGate": {
+    "status": "HOLD",
+    "rationale": "deterministic role-policy fixture only; no live compute was run",
+    "requiredActions": [
+      "Collect offline/private/shadow candidate-vs-baseline evidence before any role-policy completion claim."
+    ]
+  }
+}

--- a/scripts/screeps_rl_act_loop_planner.py
+++ b/scripts/screeps_rl_act_loop_planner.py
@@ -13,6 +13,8 @@ import tempfile
 from pathlib import Path
 from typing import Any, Sequence, TextIO
 
+import screeps_rl_role_policy_lanes as role_policy_lanes
+
 
 PLAN_TYPE = "screeps-rl-act-loop-plan"
 BATCH_TYPE = "screeps-rl-act-loop-plan-batch"
@@ -48,7 +50,7 @@ POLICY_SURFACE_NAME_ALIASES = (
     "targetFamily",
     "target_family",
 )
-POLICY_ROUTE_FIELDS = ("policyFamily", "topAgent", "rolePolicy", "level")
+POLICY_ROUTE_FIELDS = ("policyFamily", "topAgent", "rolePolicy", "trainingRole", "level")
 POLICY_ROUTE_ALIASES: dict[str, tuple[str, ...]] = {
     "policyFamily": (
         "policyFamily",
@@ -58,11 +60,17 @@ POLICY_ROUTE_ALIASES: dict[str, tuple[str, ...]] = {
     ),
     "topAgent": ("topAgent", "top_agent"),
     "rolePolicy": ("rolePolicy", "role_policy"),
+    "trainingRole": ("trainingRole", "training_role"),
     "level": ("level",),
 }
 POLICY_FAMILY_FALLBACKS = {
     "constructionpriority": "top.construction",
     "workertask": "role.worker-task",
+    "worker": "role.worker-task",
+    "sourceharvester": "role.source-harvester",
+    "harvester": "role.source-harvester",
+    "defendermicro": "role.defender-micro",
+    "defender": "role.defender-micro",
     "toweraction": "role.tower-action",
 }
 
@@ -623,13 +631,22 @@ def explicit_policy_route(raw: JsonObject) -> JsonObject:
 def infer_policy_route(raw: JsonObject) -> JsonObject:
     route = explicit_policy_route(raw)
     if "policyFamily" in route:
-        return route
+        return complete_policy_route(route)
     surface = explicit_policy_surface(raw)
     if not surface:
-        return route
+        return complete_policy_route(route)
     policy_family = POLICY_FAMILY_FALLBACKS.get(normalize_key(surface))
     if policy_family:
         route["policyFamily"] = policy_family
+    return complete_policy_route(route)
+
+
+def complete_policy_route(route: JsonObject) -> JsonObject:
+    completed = role_policy_lanes.complete_lane_metadata(route)
+    if completed:
+        merged = dict(route)
+        merged.update(completed)
+        return merged
     return route
 
 
@@ -1113,6 +1130,7 @@ def build_plan(raw: JsonObject, *, source_artifact: str | None = None) -> JsonOb
         "nextScenarioDelta": scenario_delta,
         "nextPolicyDelta": policy_delta,
         "nextExperimentCardDelta": card_delta,
+        "rolePolicyLanes": role_policy_lanes.role_policy_contract(),
         "feedbackIngestion": build_feedback_state(
             raw,
             finding=finding,

--- a/scripts/screeps_rl_dataset_export.py
+++ b/scripts/screeps_rl_dataset_export.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any, Iterable, Sequence, TextIO
 
 import screeps_runtime_kpi_reducer as reducer
+import screeps_rl_role_policy_lanes as role_policy_lanes
 import screeps_world_profiles as world_profiles
 
 
@@ -1105,6 +1106,7 @@ def build_action_labels(room: JsonObject) -> list[JsonObject]:
                     "surface": "construction-priority",
                     "sourceDecisionField": "constructionPriority.nextPrimary",
                     "registryFamily": "construction-priority",
+                    "policyFamily": "top.construction",
                     "rolloutStatus": "offline-shadow-label",
                     "label": redact_text(candidate["buildItem"]),
                     "room": redact_text(candidate.get("room")) if isinstance(candidate.get("room"), str) else room.get("roomName"),
@@ -1127,6 +1129,7 @@ def build_action_labels(room: JsonObject) -> list[JsonObject]:
                     "surface": "expansion-remote-candidate",
                     "sourceDecisionField": "territoryRecommendation.next",
                     "registryFamily": "expansion-remote-candidate",
+                    "policyFamily": "top.remote-expansion",
                     "rolloutStatus": "offline-shadow-label",
                     "label": action,
                     "targetRoom": redact_text(candidate["roomName"]),
@@ -1441,6 +1444,17 @@ def build_run_manifest(
             if isinstance(label, dict) and isinstance(label.get("surface"), str)
         }
     )
+    action_labels = [
+        label
+        for row in rows
+        for label in row.get("actionLabels", [])
+        if isinstance(label, dict)
+    ]
+    role_policy_lanes.validate_role_policy_collection(
+        action_labels,
+        context="run_manifest.actionLabels",
+    )
+    role_policy_summary = role_policy_lanes.summarize_role_policy_collection(action_labels)
     return {
         "type": RUN_MANIFEST_TYPE,
         "schemaVersion": SCHEMA_VERSION,
@@ -1462,6 +1476,8 @@ def build_run_manifest(
             "shadowReports": scan.strategy_shadow_reports,
             "liveEffect": False,
         },
+        "rolePolicyLanes": role_policy_lanes.role_policy_contract(),
+        "rolePolicyMetadata": role_policy_summary,
         "split": {
             "method": "sha256-threshold",
             "seed": split_seed,

--- a/scripts/screeps_rl_experiment_card.py
+++ b/scripts/screeps_rl_experiment_card.py
@@ -16,6 +16,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Sequence, TextIO
 
+import screeps_rl_role_policy_lanes as role_policy_lanes
+
 
 TRAINING_APPROACHES = ("bandit", "evolutionary", "policy_gradient")
 DATASET_RUN_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
@@ -114,6 +116,7 @@ E1_GATE_FRESHNESS_HOURS = 36.0
 JsonObject = dict[str, Any]
 
 CONSTRUCTION_PRIORITY_FAMILY = "construction-priority"
+TOP_CONSTRUCTION_POLICY_FAMILY = "top.construction"
 CONSTRUCTION_PRIORITY_REGISTRY_IDS = (
     "construction-priority.incumbent.v1",
     "construction-priority.territory-shadow.v1",
@@ -970,7 +973,9 @@ def build_card(
         "officialMmoWrites": False,
         "officialMmoWritesAllowed": False,
         "ood_rejection": True,
+        "policyFamily": TOP_CONSTRUCTION_POLICY_FAMILY,
         "reward_model": reward_model(scalar_weighted_sum_authorized=scalar_weighted_sum_authorized),
+        "role_policy_lanes": role_policy_lanes.role_policy_contract(),
         "scenario": scenario,
         "safety": safety_block(),
         "simulation": simulation_block(
@@ -1097,6 +1102,7 @@ def policy_gradient_block(registry_path: Path) -> JsonObject:
     return {
         "type": "construction-priority-policy-gradient-card",
         "target_family": CONSTRUCTION_PRIORITY_FAMILY,
+        "policyFamily": TOP_CONSTRUCTION_POLICY_FAMILY,
         "candidate_policy_id_field": "candidatePolicyId",
         "source_registry": repo_relative(registry_path),
         "owning_issues": ["#1032", "#879", "#924"],
@@ -1161,6 +1167,8 @@ def policy_gradient_strategy_variants(policy_gradient: JsonObject) -> list[JsonO
                 "candidatePolicyId": candidate.get("candidatePolicyId"),
                 "sourceStrategyId": candidate.get("sourceStrategyId"),
                 "family": candidate.get("family"),
+                "policyFamily": candidate.get("policyFamily"),
+                "rolePolicy": candidate.get("rolePolicy"),
                 "rolloutStatus": candidate.get("rolloutStatus"),
                 "title": candidate.get("title"),
                 "trainingRole": "policy_gradient_candidate",
@@ -1250,6 +1258,7 @@ def policy_gradient_candidate(
         "strategyVariantId": candidate_policy_id,
         "sourceStrategyId": source_strategy_id,
         "family": CONSTRUCTION_PRIORITY_FAMILY,
+        "policyFamily": TOP_CONSTRUCTION_POLICY_FAMILY,
         "rolloutStatus": rollout_status,
         "title": title,
         "parameters": parameter_vector,
@@ -1388,8 +1397,9 @@ def validate_card(raw: Any) -> None:
     validate_card_supply(raw)
     validate_source_gate(raw)
     validate_scenario(raw)
+    validate_role_policy_lane_contract(raw)
     strategy_variants = first_present(raw, ("strategy_variants", "strategyVariants", "variants"))
-    validate_strategy_variants(strategy_variants)
+    validate_strategy_variants(strategy_variants, parent=raw)
     simulation = first_present(raw, ("simulation", "simulator"))
     validate_simulation(simulation)
     policy_gradient = first_present(raw, ("policy_gradient", "policyGradient"))
@@ -1453,6 +1463,16 @@ def validate_card_supply(card: JsonObject) -> None:
         validate_created_at(consumed_at)
         if not isinstance(raw.get("consumed_by_report_id"), str) or not raw.get("consumed_by_report_id"):
             raise CardValidationError("consumed Loop A card supply requires consumed_by_report_id")
+
+
+def validate_role_policy_lane_contract(card: JsonObject) -> None:
+    contract = first_present(card, ("role_policy_lanes", "rolePolicyLanes", "policyLaneContract"))
+    if contract is None:
+        return
+    try:
+        role_policy_lanes.validate_lane_contract(contract, "role_policy_lanes")
+    except role_policy_lanes.RolePolicyLaneError as error:
+        raise CardValidationError(str(error)) from error
 
 
 def validate_source_gate(card: JsonObject) -> None:
@@ -2463,19 +2483,33 @@ def validate_scalar_weighted_sum_authorization(
         raise CardValidationError("reward_model.scalar_weighted_sum weights must preserve lexicographic dominance")
 
 
-def validate_strategy_variants(raw: Any) -> None:
+def validate_strategy_variants(raw: Any, *, parent: JsonObject | None = None) -> None:
     if not isinstance(raw, list) or len(raw) == 0:
         raise CardValidationError("strategy_variants must contain at least one registry id or inline variant")
+    inline_variants: list[JsonObject] = []
     for index, item in enumerate(raw):
         if isinstance(item, str):
             validate_strategy_id(item, f"strategy_variants[{index}]")
             continue
         if not isinstance(item, dict):
             raise CardValidationError(f"strategy_variants[{index}] must be a string or JSON object")
+        inline_variants.append(item)
         variant_id = item.get("id")
         if not isinstance(variant_id, str) or not variant_id:
             raise CardValidationError(f"strategy_variants[{index}].id must be a non-empty string")
         validate_strategy_id(variant_id, f"strategy_variants[{index}].id")
+        try:
+            role_policy_lanes.validate_role_policy_metadata(item, f"strategy_variants[{index}]")
+        except role_policy_lanes.RolePolicyLaneError as error:
+            raise CardValidationError(str(error)) from error
+    try:
+        role_policy_lanes.validate_role_policy_collection(
+            inline_variants,
+            context="strategy_variants",
+            parent=parent,
+        )
+    except role_policy_lanes.RolePolicyLaneError as error:
+        raise CardValidationError(str(error)) from error
 
 
 def validate_strategy_id(value: str, label: str) -> None:
@@ -2513,6 +2547,14 @@ def validate_policy_gradient(raw: Any) -> int:
         if candidate_policy_id in candidate_ids:
             raise CardValidationError(f"duplicate policy_gradient candidatePolicyId: {candidate_policy_id}")
         candidate_ids.add(candidate_policy_id)
+    try:
+        role_policy_lanes.validate_role_policy_collection(
+            candidates,
+            context="policy_gradient.candidate_parameter_vectors",
+            parent=raw,
+        )
+    except role_policy_lanes.RolePolicyLaneError as error:
+        raise CardValidationError(str(error)) from error
 
     required_samples_per_candidate = validate_policy_gradient_update(first_present(raw, ("policy_update", "policyUpdate")))
 
@@ -2667,6 +2709,10 @@ def validate_policy_gradient_candidate(raw: Any, index: int) -> None:
     validate_strategy_id(raw["sourceStrategyId"], f"policy_gradient.candidate_parameter_vectors[{index}].sourceStrategyId")
     if raw["family"] != CONSTRUCTION_PRIORITY_FAMILY:
         raise CardValidationError(f"policy_gradient.candidate_parameter_vectors[{index}].family must be construction-priority")
+    try:
+        role_policy_lanes.validate_role_policy_metadata(raw, f"policy_gradient.candidate_parameter_vectors[{index}]")
+    except role_policy_lanes.RolePolicyLaneError as error:
+        raise CardValidationError(str(error)) from error
     parameters = raw.get("parameters")
     if not isinstance(parameters, dict):
         raise CardValidationError(f"policy_gradient.candidate_parameter_vectors[{index}].parameters must be an object")

--- a/scripts/screeps_rl_role_policy_lanes.py
+++ b/scripts/screeps_rl_role_policy_lanes.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Shared role-scoped RL policy lane contract for offline/shadow artifacts."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Sequence
+
+
+SCHEMA_VERSION = 1
+CONTRACT_TYPE = "screeps-rl-role-policy-lane-contract"
+LANE_DEFINITION_TYPE = "screeps-rl-role-policy-lane-definition"
+ROLE_POLICY_FAMILY_PREFIX = "role."
+MIXED_ROLE_REASON_FIELDS = (
+    "mixedRolePolicyReason",
+    "mixed_role_policy_reason",
+    "metaPolicyReason",
+    "meta_policy_reason",
+    "topLevelMetaPolicyReason",
+    "top_level_meta_policy_reason",
+    "policyAggregationReason",
+    "policy_aggregation_reason",
+)
+
+JsonObject = dict[str, Any]
+
+
+class RolePolicyLaneError(ValueError):
+    """Raised when a role-policy lane artifact loses required metadata."""
+
+
+ROLE_POLICY_LANES: tuple[JsonObject, ...] = (
+    {
+        "type": LANE_DEFINITION_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "laneId": "role.worker-task",
+        "policyFamily": "role.worker-task",
+        "rolePolicy": "worker-task",
+        "trainingRole": "worker",
+        "scope": "worker task and target selection: harvest, transfer, build, repair, upgrade",
+        "baseline": {
+            "strategyVariantId": "role.worker-task.heuristic-baseline.v1",
+            "candidatePolicyId": "role.worker-task.heuristic-baseline.v1",
+            "policyFamily": "role.worker-task",
+            "rolePolicy": "worker-task",
+            "trainingRole": "worker",
+            "rolloutStatus": "incumbent",
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+        },
+        "candidate": {
+            "strategyVariantId": "role.worker-task.shadow-candidate.v1",
+            "candidatePolicyId": "role.worker-task.shadow-candidate.v1",
+            "policyFamily": "role.worker-task",
+            "rolePolicy": "worker-task",
+            "trainingRole": "worker",
+            "rolloutStatus": "shadow",
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+        },
+    },
+    {
+        "type": LANE_DEFINITION_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "laneId": "role.source-harvester",
+        "policyFamily": "role.source-harvester",
+        "rolePolicy": "source-harvester",
+        "trainingRole": "source-harvester",
+        "scope": (
+            "source assignment, harvest positioning, container/link interaction, "
+            "and bounded remote-harvest constraints"
+        ),
+        "baseline": {
+            "strategyVariantId": "role.source-harvester.heuristic-baseline.v1",
+            "candidatePolicyId": "role.source-harvester.heuristic-baseline.v1",
+            "policyFamily": "role.source-harvester",
+            "rolePolicy": "source-harvester",
+            "trainingRole": "source-harvester",
+            "rolloutStatus": "incumbent",
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+        },
+        "candidate": {
+            "strategyVariantId": "role.source-harvester.shadow-candidate.v1",
+            "candidatePolicyId": "role.source-harvester.shadow-candidate.v1",
+            "policyFamily": "role.source-harvester",
+            "rolePolicy": "source-harvester",
+            "trainingRole": "source-harvester",
+            "rolloutStatus": "shadow",
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+        },
+    },
+    {
+        "type": LANE_DEFINITION_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "laneId": "role.defender-micro",
+        "policyFamily": "role.defender-micro",
+        "rolePolicy": "defender-micro",
+        "trainingRole": "defender",
+        "scope": (
+            "defender and tower-adjacent tactical response: target selection, "
+            "engage, retreat, and guard behaviors"
+        ),
+        "baseline": {
+            "strategyVariantId": "role.defender-micro.heuristic-baseline.v1",
+            "candidatePolicyId": "role.defender-micro.heuristic-baseline.v1",
+            "policyFamily": "role.defender-micro",
+            "rolePolicy": "defender-micro",
+            "trainingRole": "defender",
+            "rolloutStatus": "incumbent",
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+        },
+        "candidate": {
+            "strategyVariantId": "role.defender-micro.shadow-candidate.v1",
+            "candidatePolicyId": "role.defender-micro.shadow-candidate.v1",
+            "policyFamily": "role.defender-micro",
+            "rolePolicy": "defender-micro",
+            "trainingRole": "defender",
+            "rolloutStatus": "shadow",
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+        },
+    },
+)
+
+
+def role_policy_lane_definitions() -> list[JsonObject]:
+    return [copy.deepcopy(lane) for lane in ROLE_POLICY_LANES]
+
+
+def role_policy_contract(*, owning_issue: str = "#1585") -> JsonObject:
+    return {
+        "type": CONTRACT_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "owningIssue": owning_issue,
+        "initialLanes": role_policy_lane_definitions(),
+        "requiredMetadata": ["policyFamily", "rolePolicy", "trainingRole"],
+        "mixedRolePolicyFamiliesRequireReason": True,
+        "acceptedMixedRoleReasonFields": list(MIXED_ROLE_REASON_FIELDS),
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+        "notes": (
+            "Top-level construction-priority canary evidence is policyFamily=top.construction; "
+            "it is not role-policy completion evidence unless a separate role.* lane scorecard exists."
+        ),
+    }
+
+
+def known_lane_by_policy_family() -> dict[str, JsonObject]:
+    return {str(lane["policyFamily"]): lane for lane in ROLE_POLICY_LANES}
+
+
+def is_role_policy_family(value: Any) -> bool:
+    return isinstance(value, str) and value.startswith(ROLE_POLICY_FAMILY_PREFIX)
+
+
+def text_or_none(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def first_mapping(raw: JsonObject, keys: Sequence[str]) -> JsonObject | None:
+    for key in keys:
+        value = raw.get(key)
+        if isinstance(value, dict):
+            return value
+    return None
+
+
+def explicit_mixed_role_policy_reason(raw: JsonObject | None) -> str | None:
+    if not isinstance(raw, dict):
+        return None
+    for field in MIXED_ROLE_REASON_FIELDS:
+        value = text_or_none(raw.get(field))
+        if value is not None:
+            return value
+    for container_key in ("policyLaneContract", "rolePolicyLaneContract", "policyRouting"):
+        nested = first_mapping(raw, (container_key,))
+        if nested is None:
+            continue
+        nested_reason = explicit_mixed_role_policy_reason(nested)
+        if nested_reason is not None:
+            return nested_reason
+    return None
+
+
+def lane_metadata(raw: Any) -> JsonObject:
+    if not isinstance(raw, dict):
+        return {}
+    metadata: JsonObject = {}
+    policy_family = text_or_none(raw.get("policyFamily")) or text_or_none(raw.get("policy_family"))
+    role_policy = text_or_none(raw.get("rolePolicy")) or text_or_none(raw.get("role_policy"))
+    training_role = text_or_none(raw.get("trainingRole")) or text_or_none(raw.get("training_role"))
+    if policy_family is not None:
+        metadata["policyFamily"] = policy_family
+    if role_policy is not None:
+        metadata["rolePolicy"] = role_policy
+    if training_role is not None:
+        metadata["trainingRole"] = training_role
+    return metadata
+
+
+def lane_defaults(policy_family: str) -> JsonObject | None:
+    lane = known_lane_by_policy_family().get(policy_family)
+    if lane is None:
+        return None
+    return {
+        "policyFamily": lane["policyFamily"],
+        "rolePolicy": lane["rolePolicy"],
+        "trainingRole": lane["trainingRole"],
+    }
+
+
+def complete_lane_metadata(raw: JsonObject) -> JsonObject:
+    metadata = lane_metadata(raw)
+    policy_family = text_or_none(metadata.get("policyFamily"))
+    defaults = lane_defaults(policy_family) if policy_family else None
+    if defaults is not None:
+        completed = dict(defaults)
+        completed.update(metadata)
+        return completed
+    return metadata
+
+
+def validate_role_policy_metadata(raw: Any, context: str) -> None:
+    metadata = lane_metadata(raw)
+    policy_family = text_or_none(metadata.get("policyFamily"))
+    role_policy = text_or_none(metadata.get("rolePolicy"))
+    training_role = text_or_none(metadata.get("trainingRole"))
+    if not policy_family:
+        if role_policy or training_role:
+            raise RolePolicyLaneError(f"{context} has rolePolicy/trainingRole but omits policyFamily")
+        return
+    if not is_role_policy_family(policy_family):
+        return
+    if not role_policy:
+        raise RolePolicyLaneError(f"{context} policyFamily={policy_family} requires rolePolicy")
+    if not training_role:
+        raise RolePolicyLaneError(f"{context} policyFamily={policy_family} requires trainingRole")
+    defaults = lane_defaults(policy_family)
+    if defaults is None:
+        return
+    if role_policy != defaults["rolePolicy"]:
+        raise RolePolicyLaneError(
+            f"{context} rolePolicy={role_policy} does not match {policy_family} lane "
+            f"rolePolicy={defaults['rolePolicy']}"
+        )
+    if training_role != defaults["trainingRole"]:
+        raise RolePolicyLaneError(
+            f"{context} trainingRole={training_role} does not match {policy_family} lane "
+            f"trainingRole={defaults['trainingRole']}"
+        )
+
+
+def validate_lane_contract(raw: Any, context: str = "role_policy_lanes") -> None:
+    if not isinstance(raw, dict):
+        raise RolePolicyLaneError(f"{context} must be a JSON object")
+    lanes = raw.get("initialLanes")
+    if not isinstance(lanes, list) or not lanes:
+        raise RolePolicyLaneError(f"{context}.initialLanes must contain role lane definitions")
+    seen: set[str] = set()
+    for index, lane in enumerate(lanes):
+        if not isinstance(lane, dict):
+            raise RolePolicyLaneError(f"{context}.initialLanes[{index}] must be a JSON object")
+        validate_role_policy_metadata(lane, f"{context}.initialLanes[{index}]")
+        policy_family = text_or_none(lane.get("policyFamily"))
+        if policy_family is None:
+            raise RolePolicyLaneError(f"{context}.initialLanes[{index}].policyFamily is required")
+        if policy_family in seen:
+            raise RolePolicyLaneError(f"{context}.initialLanes contains duplicate policyFamily={policy_family}")
+        seen.add(policy_family)
+        for endpoint in ("baseline", "candidate"):
+            value = lane.get(endpoint)
+            if not isinstance(value, dict):
+                raise RolePolicyLaneError(f"{context}.initialLanes[{index}].{endpoint} must be a JSON object")
+            validate_role_policy_metadata(value, f"{context}.initialLanes[{index}].{endpoint}")
+            for unsafe_field in ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed"):
+                if value.get(unsafe_field) is True:
+                    raise RolePolicyLaneError(
+                        f"{context}.initialLanes[{index}].{endpoint}.{unsafe_field} must be false"
+                    )
+    required = set(known_lane_by_policy_family())
+    missing = sorted(required - seen)
+    if missing:
+        raise RolePolicyLaneError(f"{context}.initialLanes missing required role lanes: {', '.join(missing)}")
+
+
+def validate_role_policy_collection(
+    items: Sequence[Any],
+    *,
+    context: str,
+    parent: JsonObject | None = None,
+) -> list[str]:
+    role_families: set[str] = set()
+    for index, item in enumerate(items):
+        item_context = f"{context}[{index}]"
+        validate_role_policy_metadata(item, item_context)
+        metadata = lane_metadata(item)
+        policy_family = text_or_none(metadata.get("policyFamily"))
+        if is_role_policy_family(policy_family):
+            role_families.add(policy_family)
+    if len(role_families) > 1 and explicit_mixed_role_policy_reason(parent) is None:
+        raise RolePolicyLaneError(
+            f"{context} combines multiple role policy families without an explicit meta-policy reason: "
+            f"{', '.join(sorted(role_families))}"
+        )
+    return sorted(role_families)
+
+
+def summarize_role_policy_collection(items: Sequence[Any], *, parent: JsonObject | None = None) -> JsonObject:
+    role_families = []
+    role_policies = []
+    training_roles = []
+    for item in items:
+        metadata = lane_metadata(item)
+        policy_family = text_or_none(metadata.get("policyFamily"))
+        role_policy = text_or_none(metadata.get("rolePolicy"))
+        training_role = text_or_none(metadata.get("trainingRole"))
+        if is_role_policy_family(policy_family):
+            role_families.append(policy_family)
+            if role_policy is not None:
+                role_policies.append(role_policy)
+            if training_role is not None:
+                training_roles.append(training_role)
+    return {
+        "rolePolicyFamilies": sorted(set(role_families)),
+        "rolePolicies": sorted(set(role_policies)),
+        "trainingRoles": sorted(set(training_roles)),
+        "mixedRolePolicyReason": explicit_mixed_role_policy_reason(parent),
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+    }

--- a/scripts/screeps_rl_scorecard.py
+++ b/scripts/screeps_rl_scorecard.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import hashlib
 import html
 import json
@@ -16,6 +17,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Sequence, TextIO
+
+import screeps_rl_role_policy_lanes as role_policy_lanes
 
 
 SCHEMA_VERSION = 1
@@ -699,6 +702,8 @@ def collect_artifact_bundle(
     identifiers: list[str] = []
     commits: list[str] = []
     runtime_injection_evidence: list[JsonObject] = []
+    policy_metadata_rows: list[JsonObject] = []
+    mixed_role_policy_reasons: list[str] = []
 
     while queue:
         path = queue.pop(0).resolve()
@@ -727,6 +732,12 @@ def collect_artifact_bundle(
                 runtime_injection_evidence.extend(extract_runtime_parameter_injection_evidence(payload, source))
                 identifiers.extend(extract_identifiers(payload, role))
                 commits.extend(extract_commits(payload, role))
+                policy_metadata = role_policy_lanes.lane_metadata(payload)
+                if policy_metadata:
+                    policy_metadata_rows.append({"source": source, **policy_metadata})
+                mixed_reason = role_policy_lanes.explicit_mixed_role_policy_reason(payload)
+                if mixed_reason is not None:
+                    mixed_role_policy_reasons.append(mixed_reason)
                 for referenced in collect_referenced_paths(payload, path.parent, repo_root):
                     if referenced not in seen_files and referenced not in queue:
                         queue.append(referenced)
@@ -743,13 +754,38 @@ def collect_artifact_bundle(
     metrics = accumulator.summarize()
     resolved_id = explicit_id or first_text(identifiers) or default_bundle_id(root, metrics)
     resolved_commit = explicit_commit or first_text(commits)
+    validate_bundle_policy_metadata(policy_metadata_rows, role)
+    policy_metadata = first_policy_metadata(policy_metadata_rows)
     return {
         "id": resolved_id,
         "commit": resolved_commit,
         "artifacts": artifacts,
         "metrics": metrics,
         "runtimeParameterInjection": summarize_runtime_parameter_injection(runtime_injection_evidence),
+        "policyMetadata": policy_metadata,
+        "policyFamily": policy_metadata.get("policyFamily"),
+        "rolePolicy": policy_metadata.get("rolePolicy"),
+        "trainingRole": policy_metadata.get("trainingRole"),
+        "mixedRolePolicyReason": first_text(mixed_role_policy_reasons),
     }
+
+
+def validate_bundle_policy_metadata(rows: Sequence[JsonObject], role: str) -> None:
+    try:
+        role_policy_lanes.validate_role_policy_collection(
+            rows,
+            context=f"{role}.policyMetadata",
+        )
+    except role_policy_lanes.RolePolicyLaneError as error:
+        raise ScorecardError(str(error)) from error
+
+
+def first_policy_metadata(rows: Sequence[JsonObject]) -> JsonObject:
+    for row in rows:
+        metadata = role_policy_lanes.lane_metadata(row)
+        if metadata:
+            return metadata
+    return {}
 
 
 def first_text(values: Sequence[str]) -> str | None:
@@ -1865,6 +1901,7 @@ def build_scorecard(
         explicit_id=baseline_id,
         explicit_commit=baseline_commit,
     )
+    validate_scorecard_policy_metadata(candidate, baseline)
     resolved_run_id = run_id or default_scorecard_run_id(created, candidate, baseline)
     dimensions = {
         key: compare_dimension(spec, candidate, baseline)
@@ -1876,7 +1913,17 @@ def build_scorecard(
         "schemaVersion": SCHEMA_VERSION,
         "runId": resolved_run_id,
         "timestamp": created,
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+        "safety": {
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+            "allowedUse": "offline/private/shadow candidate-vs-baseline scorecard evidence only",
+        },
         "scorecardContract": overall_gate["scorecardContract"],
+        "rolePolicyMetadata": scorecard_role_policy_metadata(candidate, baseline),
         "candidate": public_bundle(candidate),
         "baseline": public_bundle(baseline),
         "dimensions": dimensions,
@@ -1885,11 +1932,69 @@ def build_scorecard(
     }
 
 
+def validate_scorecard_policy_metadata(candidate: JsonObject, baseline: JsonObject) -> None:
+    candidate_metadata = candidate.get("policyMetadata") if isinstance(candidate.get("policyMetadata"), dict) else {}
+    baseline_metadata = baseline.get("policyMetadata") if isinstance(baseline.get("policyMetadata"), dict) else {}
+    parent = {
+        "mixedRolePolicyReason": candidate.get("mixedRolePolicyReason") or baseline.get("mixedRolePolicyReason")
+    }
+    try:
+        role_policy_lanes.validate_role_policy_collection(
+            [candidate_metadata, baseline_metadata],
+            context="scorecard.policyMetadata",
+            parent=parent,
+        )
+    except role_policy_lanes.RolePolicyLaneError as error:
+        raise ScorecardError(str(error)) from error
+
+    candidate_family = candidate_metadata.get("policyFamily")
+    baseline_family = baseline_metadata.get("policyFamily")
+    if role_policy_lanes.is_role_policy_family(candidate_family) and not role_policy_lanes.is_role_policy_family(baseline_family):
+        raise ScorecardError("role-scoped candidate scorecard baseline omits role policyFamily")
+    if role_policy_lanes.is_role_policy_family(baseline_family) and not role_policy_lanes.is_role_policy_family(candidate_family):
+        raise ScorecardError("role-scoped baseline scorecard candidate omits role policyFamily")
+    if (
+        role_policy_lanes.is_role_policy_family(candidate_family)
+        and role_policy_lanes.is_role_policy_family(baseline_family)
+        and candidate_family != baseline_family
+        and role_policy_lanes.explicit_mixed_role_policy_reason(parent) is None
+    ):
+        raise ScorecardError(
+            "candidate and baseline role policyFamily differ without explicit meta-policy reason: "
+            f"{candidate_family} vs {baseline_family}"
+        )
+
+
+def scorecard_role_policy_metadata(candidate: JsonObject, baseline: JsonObject) -> JsonObject:
+    return {
+        "candidate": copy_metadata(candidate),
+        "baseline": copy_metadata(baseline),
+        "rolePolicyFamilies": sorted(
+            {
+                family
+                for family in (candidate.get("policyFamily"), baseline.get("policyFamily"))
+                if role_policy_lanes.is_role_policy_family(family)
+            }
+        ),
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+    }
+
+
+def copy_metadata(bundle: JsonObject) -> JsonObject:
+    metadata = bundle.get("policyMetadata")
+    return copy.deepcopy(metadata) if isinstance(metadata, dict) else {}
+
+
 def public_bundle(bundle: JsonObject) -> JsonObject:
     return {
         "id": bundle.get("id"),
         "commit": bundle.get("commit"),
         "artifacts": bundle.get("artifacts", []),
+        "policyFamily": bundle.get("policyFamily"),
+        "rolePolicy": bundle.get("rolePolicy"),
+        "trainingRole": bundle.get("trainingRole"),
         "runtimeParameterInjection": bundle.get("runtimeParameterInjection"),
     }
 

--- a/scripts/screeps_rl_scorecard.py
+++ b/scripts/screeps_rl_scorecard.py
@@ -754,7 +754,12 @@ def collect_artifact_bundle(
     metrics = accumulator.summarize()
     resolved_id = explicit_id or first_text(identifiers) or default_bundle_id(root, metrics)
     resolved_commit = explicit_commit or first_text(commits)
-    validate_bundle_policy_metadata(policy_metadata_rows, role)
+    mixed_role_policy_reason = first_text(mixed_role_policy_reasons)
+    validate_bundle_policy_metadata(
+        policy_metadata_rows,
+        role,
+        mixed_role_policy_reason=mixed_role_policy_reason,
+    )
     policy_metadata = first_policy_metadata(policy_metadata_rows)
     return {
         "id": resolved_id,
@@ -766,15 +771,22 @@ def collect_artifact_bundle(
         "policyFamily": policy_metadata.get("policyFamily"),
         "rolePolicy": policy_metadata.get("rolePolicy"),
         "trainingRole": policy_metadata.get("trainingRole"),
-        "mixedRolePolicyReason": first_text(mixed_role_policy_reasons),
+        "mixedRolePolicyReason": mixed_role_policy_reason,
     }
 
 
-def validate_bundle_policy_metadata(rows: Sequence[JsonObject], role: str) -> None:
+def validate_bundle_policy_metadata(
+    rows: Sequence[JsonObject],
+    role: str,
+    *,
+    mixed_role_policy_reason: str | None = None,
+) -> None:
+    parent = {"mixedRolePolicyReason": mixed_role_policy_reason} if mixed_role_policy_reason is not None else None
     try:
         role_policy_lanes.validate_role_policy_collection(
             rows,
             context=f"{role}.policyMetadata",
+            parent=parent,
         )
     except role_policy_lanes.RolePolicyLaneError as error:
         raise ScorecardError(str(error)) from error

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -29,6 +29,7 @@ import screeps_secret_env
 import screeps_rl_simulator_harness as simulator_harness
 import screeps_rl_scale_gates as scale_gates
 import screeps_rl_scorecard as scorecard_helper
+import screeps_rl_role_policy_lanes as role_policy_lanes
 
 
 SCHEMA_VERSION = 1
@@ -130,6 +131,7 @@ class StrategyVariant:
     candidate_policy_id: str | None = None
     family: str | None = None
     policy_family: str | None = None
+    role_policy: str | None = None
     parameter_evidence: JsonObject | None = None
     rollout_status: str | None = None
     source_strategy_id: str | None = None
@@ -149,6 +151,8 @@ class StrategyVariant:
             payload["family"] = self.family
         if self.policy_family:
             payload["policyFamily"] = self.policy_family
+        if self.role_policy:
+            payload["rolePolicy"] = self.role_policy
         if self.parameter_evidence is not None:
             payload["parameterEvidence"] = copy.deepcopy(self.parameter_evidence)
         if self.rollout_status:
@@ -342,11 +346,20 @@ def validate_experiment_card(card: JsonObject) -> None:
         raise TrainingCardError("reward_model.scalar_weighted_sum_authorized must be false unless explicitly authorized")
 
     validate_card_supply(card)
+    validate_role_policy_lane_contract(card)
     validate_scenario_metadata(card, error_cls=TrainingCardError, require_presence=True)
 
     raw_variants = raw_variant_definitions(card)
     if not isinstance(raw_variants, list) or len(raw_variants) == 0:
         raise TrainingCardError("experiment card must define at least one strategy variant")
+    try:
+        role_policy_lanes.validate_role_policy_collection(
+            [item for item in raw_variants if isinstance(item, dict)],
+            context="strategy_variants",
+            parent=card,
+        )
+    except role_policy_lanes.RolePolicyLaneError as error:
+        raise TrainingCardError(str(error)) from error
 
     simulation = raw_mapping(card.get("simulation", card.get("simulator", {})), "simulation")
     ticks = positive_int_value(simulation["ticks"]) if "ticks" in simulation else None
@@ -523,6 +536,16 @@ def validate_card_supply(card: JsonObject) -> None:
             raise TrainingCardError("consumed Loop A card supply requires consumed_by_report_id")
 
 
+def validate_role_policy_lane_contract(card: JsonObject) -> None:
+    contract = first_present(card, ("role_policy_lanes", "rolePolicyLanes", "policyLaneContract"))
+    if contract is None:
+        return
+    try:
+        role_policy_lanes.validate_lane_contract(contract, "role_policy_lanes")
+    except role_policy_lanes.RolePolicyLaneError as error:
+        raise TrainingCardError(str(error)) from error
+
+
 def raw_variant_definitions(card: JsonObject) -> Any:
     for key in ("strategy_variants", "strategyVariants", "variants"):
         if key in card:
@@ -563,7 +586,24 @@ def load_strategy_variants(card: JsonObject, registry_path: Path | None = None) 
             raise TrainingCardError(f"duplicate strategy variant id: {variant.id}")
         seen.add(variant.id)
         variants.append(variant)
+    validate_role_policy_variants(variants, context="strategy_variants", parent=card)
     return variants
+
+
+def validate_role_policy_variants(
+    variants: Sequence[StrategyVariant],
+    *,
+    context: str,
+    parent: JsonObject | None = None,
+) -> None:
+    try:
+        role_policy_lanes.validate_role_policy_collection(
+            [variant.to_json() for variant in variants],
+            context=context,
+            parent=parent,
+        )
+    except role_policy_lanes.RolePolicyLaneError as error:
+        raise TrainingCardError(str(error)) from error
 
 
 def apply_policy_gradient_candidate_vectors_to_variants(
@@ -644,6 +684,11 @@ def policy_gradient_candidate_vector_variant(
             or text_or_none(candidate.get("policy_family"))
             or variant.policy_family
         ),
+        role_policy=(
+            text_or_none(candidate.get("rolePolicy"))
+            or text_or_none(candidate.get("role_policy"))
+            or variant.role_policy
+        ),
         parameter_evidence=copy.deepcopy(parameter_evidence)
         if parameter_evidence is not None
         else copy.deepcopy(variant.parameter_evidence),
@@ -697,6 +742,7 @@ def expand_scale_environment_strategy_variants(
                 candidate_policy_id=base.candidate_policy_id,
                 family=base.family,
                 policy_family=base.policy_family,
+                role_policy=base.role_policy,
                 parameter_evidence=copy.deepcopy(base.parameter_evidence),
                 rollout_status=base.rollout_status,
                 source_strategy_id=base.source_strategy_id,
@@ -739,6 +785,11 @@ def normalize_variant(raw: Any, registry: dict[str, StrategyVariant]) -> Strateg
         or text_or_none(raw.get("policy_family"))
         or (registry_variant.policy_family if registry_variant else None)
     )
+    role_policy = (
+        text_or_none(raw.get("rolePolicy"))
+        or text_or_none(raw.get("role_policy"))
+        or (registry_variant.role_policy if registry_variant else None)
+    )
     parameter_evidence = first_mapping(raw, ("parameterEvidence", "parameter_evidence"))
     rollout_status = (
         text_or_none(raw.get("rolloutStatus"))
@@ -746,18 +797,35 @@ def normalize_variant(raw: Any, registry: dict[str, StrategyVariant]) -> Strateg
         or (registry_variant.rollout_status if registry_variant else None)
     )
     title = text_or_none(raw.get("title")) or (registry_variant.title if registry_variant else None)
+    training_role = (
+        text_or_none(raw.get("trainingRole"))
+        or text_or_none(raw.get("training_role"))
+        or (registry_variant.training_role if registry_variant else None)
+    )
+    try:
+        role_policy_lanes.validate_role_policy_metadata(
+            {
+                "policyFamily": policy_family,
+                "rolePolicy": role_policy,
+                "trainingRole": training_role,
+            },
+            f"strategy variant {variant_id}",
+        )
+    except role_policy_lanes.RolePolicyLaneError as error:
+        raise TrainingCardError(str(error)) from error
     return StrategyVariant(
         id=variant_id,
         parameters=dict(sorted(parameters.items())),
         candidate_policy_id=candidate_policy_id,
         family=family,
         policy_family=policy_family,
+        role_policy=role_policy,
         parameter_evidence=copy.deepcopy(parameter_evidence) if parameter_evidence is not None else None,
         rollout_status=rollout_status,
         source_strategy_id=source_strategy_id,
         source=source,
         title=title,
-        training_role=text_or_none(raw.get("trainingRole")) or text_or_none(raw.get("training_role")),
+        training_role=training_role,
     )
 
 
@@ -782,8 +850,10 @@ def load_strategy_registry(path: Path) -> dict[str, StrategyVariant]:
             parameters=parameters,
             family=regex_group(r"\bfamily:\s*['\"]([^'\"]+)['\"]", block),
             policy_family=regex_group(r"\bpolicyFamily:\s*['\"]([^'\"]+)['\"]", block),
+            role_policy=regex_group(r"\brolePolicy:\s*['\"]([^'\"]+)['\"]", block),
             rollout_status=regex_group(r"\brolloutStatus:\s*['\"]([^'\"]+)['\"]", block),
             title=regex_group(r"\btitle:\s*['\"]([^'\"]+)['\"]", block),
+            training_role=regex_group(r"\btrainingRole:\s*['\"]([^'\"]+)['\"]", block),
             source="registry",
         )
     return registry
@@ -1064,8 +1134,10 @@ def run_training_experiment(
     card = load_experiment_card(card_path)
     variants = load_strategy_variants(card, registry_path=registry_path)
     variants = apply_policy_gradient_candidate_vectors_to_variants(card, variants)
+    validate_role_policy_variants(variants, context="policy_gradient.candidate_parameter_vectors", parent=card)
     config = simulation_config_from_card(card)
     variants = expand_scale_environment_strategy_variants(variants, config.scale_environments)
+    validate_role_policy_variants(variants, context="expanded_strategy_variants", parent=card)
     reward_options = reward_options_from_card(card)
     resolved_report_id = report_id or default_report_id(card, variants, config)
     validate_report_id(resolved_report_id)
@@ -1444,7 +1516,7 @@ def build_report_runtime_parameter_injection_summary(
                 "parametersSha256": injection.get("parametersSha256"),
                 "reason": injection.get("reason"),
             }
-            for field in ("candidatePolicyId", "sourceStrategyId", "family"):
+            for field in ("candidatePolicyId", "sourceStrategyId", "family", "policyFamily", "rolePolicy", "trainingRole"):
                 value = injection.get(field)
                 if value is None:
                     value = result.get(field)
@@ -1853,6 +1925,14 @@ def build_training_report(
         report["policyUpdate"] = policy_update
     if scalar_weighted_reward is not None:
         report["conclusionRegistryUpdate"] = scalar_weighted_reward_conclusion_registry_update(report)
+    role_policy_summary = role_policy_lanes.summarize_role_policy_collection(results, parent=card)
+    report["rolePolicies"] = role_policy_summary["rolePolicies"]
+    report["trainingRoles"] = role_policy_summary["trainingRoles"]
+    report["rolePolicyMetadata"] = role_policy_summary
+    report["rolePolicyLanes"] = copy.deepcopy(
+        first_present(card, ("role_policy_lanes", "rolePolicyLanes", "policyLaneContract"))
+        or role_policy_lanes.role_policy_contract()
+    )
     return report
 
 
@@ -4391,6 +4471,8 @@ def build_candidate_scorecard_readiness_for_pair(
     baseline_rank: int | None,
 ) -> JsonObject:
     report_runtime_parameter_injection = report.get("runtimeParameterInjection")
+    candidate_metadata = role_policy_metadata_for_variant(report, candidate_id)
+    baseline_metadata = role_policy_metadata_for_variant(report, baseline_id)
     scorecard_id = candidate_scorecard_id(report, candidate_id, baseline_id)
     runtime_parameter_injection = candidate_scorecard_runtime_parameter_injection(report, candidate_id)
     runtime_ready = scorecard_runtime_injection_ready(runtime_parameter_injection)
@@ -4444,6 +4526,11 @@ def build_candidate_scorecard_readiness_for_pair(
         "candidateRank": candidate_rank,
         "baselineRank": baseline_rank,
         "comparisonKey": f"{candidate_id}::vs::{baseline_id}",
+        "policyFamily": candidate_metadata.get("policyFamily"),
+        "rolePolicy": candidate_metadata.get("rolePolicy"),
+        "trainingRole": candidate_metadata.get("trainingRole"),
+        "candidatePolicyMetadata": candidate_metadata,
+        "baselinePolicyMetadata": baseline_metadata,
         "runtimeParameterInjection": runtime_ready,
         "runtimeParameterConsumption": runtime_consumed,
         "injectedVariantCount": injected_count,
@@ -4779,6 +4866,16 @@ def variant_result_by_id(report: JsonObject, variant_id: str) -> JsonObject | No
     return None
 
 
+def role_policy_metadata_for_variant(report: JsonObject, variant_id: str) -> JsonObject:
+    result = variant_result_by_id(report, variant_id)
+    if isinstance(result, dict):
+        return role_policy_lanes.lane_metadata(result)
+    for variant in report.get("strategyVariants", []):
+        if isinstance(variant, dict) and text_or_none(variant.get("id")) == variant_id:
+            return role_policy_lanes.lane_metadata(variant)
+    return {}
+
+
 def scorecard_projection_payload(
     report: JsonObject,
     *,
@@ -4788,6 +4885,7 @@ def scorecard_projection_payload(
     runtime_parameter_injection: Any,
 ) -> JsonObject:
     variant_id = text_or_none(result.get("variantId")) or "unknown"
+    lane_metadata = role_policy_lanes.lane_metadata(result)
     payload: JsonObject = {
         "type": REPORT_TYPE,
         "schemaVersion": SCHEMA_VERSION,
@@ -4798,6 +4896,9 @@ def scorecard_projection_payload(
         "baselineId": variant_id if role == "baseline" else peer_variant_id,
         "strategyVariantId": variant_id,
         "peerStrategyVariantId": peer_variant_id,
+        "policyFamily": lane_metadata.get("policyFamily"),
+        "rolePolicy": lane_metadata.get("rolePolicy"),
+        "trainingRole": lane_metadata.get("trainingRole"),
         "artifactCount": result.get("sampleCount", 1),
         "metricsByCategory": scorecard_metrics_by_category(result),
         "liveEffect": False,
@@ -5067,6 +5168,8 @@ def summarize_variant(
         summary["scalarWeightedReward"] = copy.deepcopy(scalar_reward)
     if variant.policy_family:
         summary["policyFamily"] = variant.policy_family
+    if variant.role_policy:
+        summary["rolePolicy"] = variant.role_policy
     if variant.candidate_policy_id:
         summary["candidatePolicyId"] = variant.candidate_policy_id
     if variant.source_strategy_id:
@@ -6373,6 +6476,10 @@ def rank_variant_results(results: Sequence[JsonObject]) -> list[JsonObject]:
         )
         if isinstance(result.get("policyFamily"), str):
             ranking[-1]["policyFamily"] = result["policyFamily"]
+        if isinstance(result.get("rolePolicy"), str):
+            ranking[-1]["rolePolicy"] = result["rolePolicy"]
+        if isinstance(result.get("trainingRole"), str):
+            ranking[-1]["trainingRole"] = result["trainingRole"]
     return ranking
 
 
@@ -6469,6 +6576,9 @@ def build_shadow_compatible_model_reports(
         reports.append(
             {
                 "family": "rl-training",
+                "policyFamily": item.get("policyFamily"),
+                "rolePolicy": item.get("rolePolicy"),
+                "trainingRole": item.get("trainingRole"),
                 "incumbentStrategyId": incumbent,
                 "candidateStrategyId": variant_id,
                 "rankingDiffCount": 1 if incumbent_rank is not None and item["rank"] != incumbent_rank else 0,
@@ -6821,8 +6931,12 @@ def summarize_card(
         "codeCommit": card.get("code_commit", card.get("codeCommit")),
         "trainingApproach": card.get("training_approach", card.get("trainingApproach")),
         "status": card.get("status", "shadow"),
+        "policyFamily": card.get("policyFamily", card.get("policy_family")),
         "safety": card.get("safety"),
     }
+    contract = first_present(card, ("role_policy_lanes", "rolePolicyLanes", "policyLaneContract"))
+    if isinstance(contract, dict):
+        summary["rolePolicyLanes"] = copy.deepcopy(contract)
     policy_gradient = policy_gradient_metadata_from_card(
         card,
         runtime_parameter_injection=runtime_parameter_injection,
@@ -7392,6 +7506,9 @@ def build_generation_summary(report: JsonObject) -> JsonObject:
         "scorecardArtifactPath": report.get("scorecardArtifactPath"),
         "candidateScorecard": copy.deepcopy(report.get("candidateScorecard")),
         "candidateScorecards": copy.deepcopy(report.get("candidateScorecards")),
+        "rolePolicies": copy.deepcopy(report.get("rolePolicies", [])),
+        "trainingRoles": copy.deepcopy(report.get("trainingRoles", [])),
+        "rolePolicyMetadata": copy.deepcopy(report.get("rolePolicyMetadata")),
         "scalarWeightedReward": copy.deepcopy(report.get("scalarWeightedReward")),
         "conclusionRegistryUpdate": copy.deepcopy(report.get("conclusionRegistryUpdate")),
         "warnings": report["warnings"],

--- a/scripts/test_screeps_rl_act_loop_planner.py
+++ b/scripts/test_screeps_rl_act_loop_planner.py
@@ -38,6 +38,7 @@ class ScreepsRlActLoopPlannerTest(unittest.TestCase):
 
         policy_delta = plan["nextPolicyDelta"]
         self.assertEqual(policy_delta["parameterSurface"], "construction-priority")
+        self.assertEqual(policy_delta["policyFamily"], "top.construction")
         self.assertEqual(policy_delta["boundsStatus"], "present")
         self.assertEqual(
             [item["name"] for item in policy_delta["bounds"]],
@@ -51,7 +52,12 @@ class ScreepsRlActLoopPlannerTest(unittest.TestCase):
         self.assertEqual(card_delta["datasetRunId"], "rl-loop-b-sample-000001")
         self.assertEqual(card_delta["status"], "shadow")
         self.assertEqual(card_delta["deltas"]["policy"]["parameterSurface"], "construction-priority")
+        self.assertEqual(card_delta["deltas"]["policy"]["policyFamily"], "top.construction")
         self.assertFalse(card_delta["safety"]["liveEffect"])
+        self.assertEqual(
+            [lane["policyFamily"] for lane in plan["rolePolicyLanes"]["initialLanes"]],
+            ["role.worker-task", "role.source-harvester", "role.defender-micro"],
+        )
 
         feedback = plan["feedbackIngestion"]
         self.assertEqual(feedback["finding"]["state"], "observed")
@@ -91,6 +97,34 @@ class ScreepsRlActLoopPlannerTest(unittest.TestCase):
         self.assertEqual(plan["finding"]["classification"], "policy_parameterization_gap")
         self.assertIsNone(plan["nextScenarioDelta"])
         self.assertEqual(plan["nextPolicyDelta"]["parameterSurface"], "construction-priority")
+
+    def test_role_policy_surface_fallback_preserves_route_metadata(self) -> None:
+        plan = planner.build_plan(
+            {
+                "title": "Worker task selection needs role-scoped bounds",
+                "classification": "policy_parameterization_gap",
+                "parameterSurface": {
+                    "name": "worker-task",
+                    "bounds": [
+                        {
+                            "name": "repairPriority",
+                            "min": 0,
+                            "max": 10,
+                            "step": 1,
+                        }
+                    ],
+                },
+            }
+        )
+
+        policy_delta = plan["nextPolicyDelta"]
+        self.assertEqual(policy_delta["policyFamily"], "role.worker-task")
+        self.assertEqual(policy_delta["rolePolicy"], "worker-task")
+        self.assertEqual(policy_delta["trainingRole"], "worker")
+        self.assertEqual(
+            plan["nextExperimentCardDelta"]["deltas"]["policy"]["policyFamily"],
+            "role.worker-task",
+        )
 
     def test_unknown_source_scenario_uses_registered_default_target(self) -> None:
         plan = planner.build_plan(

--- a/scripts/test_screeps_rl_dataset_export.py
+++ b/scripts/test_screeps_rl_dataset_export.py
@@ -125,6 +125,10 @@ class RlDatasetExportTest(unittest.TestCase):
             [label["surface"] for label in row["actionLabels"]],
             ["construction-priority", "expansion-remote-candidate"],
         )
+        self.assertEqual(
+            [label["policyFamily"] for label in row["actionLabels"]],
+            ["top.construction", "top.remote-expansion"],
+        )
         self.assertEqual(row["observation"]["resources"]["harvestedThisTick"], 80)
         self.assertEqual(row["reward"]["components"]["resources"]["harvestedThisTick"], 80)
         self.assertEqual(row["reward"]["components"]["resources"]["harvestedEnergy"], 80)
@@ -133,6 +137,11 @@ class RlDatasetExportTest(unittest.TestCase):
             "expansion-remote-candidate",
         ])
         self.assertFalse(run_manifest["strategy"]["liveEffect"])
+        self.assertEqual(
+            [lane["policyFamily"] for lane in run_manifest["rolePolicyLanes"]["initialLanes"]],
+            ["role.worker-task", "role.source-harvester", "role.defender-micro"],
+        )
+        self.assertEqual(run_manifest["rolePolicyMetadata"]["rolePolicyFamilies"], [])
         self.assertEqual(kpi_windows["input"]["runtimeSummaryCount"], 1)
         self.assertEqual(kpi_windows["resources"]["totals"]["latest"]["storedEnergy"], 420)
         self.assertEqual(kpi_windows["resources"]["totals"]["latest"]["harvestedThisTick"], 80)

--- a/scripts/test_screeps_rl_experiment_card.py
+++ b/scripts/test_screeps_rl_experiment_card.py
@@ -13,6 +13,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
 import screeps_rl_experiment_card as card_helper
+import screeps_rl_role_policy_lanes as role_policy_lanes
 import screeps_rl_simulator_harness as harness
 import screeps_rl_training_runner as runner
 
@@ -100,6 +101,63 @@ class RlExperimentCardTest(unittest.TestCase):
             card["scenario"]["suitability"]["classification"],
             "not_suitable_for_territory_combat_differentiation",
         )
+        self.assertEqual(card["policyFamily"], "top.construction")
+        role_policy_lanes.validate_lane_contract(card["role_policy_lanes"])
+        self.assertEqual(
+            [lane["policyFamily"] for lane in card["role_policy_lanes"]["initialLanes"]],
+            ["role.worker-task", "role.source-harvester", "role.defender-micro"],
+        )
+
+    def test_role_scoped_strategy_variant_requires_lane_metadata(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-role-policy-missing",
+            code_commit="b" * 40,
+            training_approach="bandit",
+            created_at="2026-05-16T10:09:35Z",
+        )
+        card["strategy_variants"] = [
+            {
+                "id": "role.worker-task.shadow-candidate.v1",
+                "policyFamily": "role.worker-task",
+                "rolloutStatus": "shadow",
+                "parameters": {},
+            }
+        ]
+
+        with self.assertRaisesRegex(card_helper.CardValidationError, "requires rolePolicy"):
+            card_helper.validate_card(card)
+
+    def test_mixed_role_scoped_strategy_variants_require_meta_policy_reason(self) -> None:
+        card = card_helper.build_card(
+            dataset_run_id="rl-role-policy-mixed",
+            code_commit="c" * 40,
+            training_approach="bandit",
+            created_at="2026-05-16T10:09:35Z",
+        )
+        card["strategy_variants"] = [
+            {
+                "id": "role.worker-task.shadow-candidate.v1",
+                "policyFamily": "role.worker-task",
+                "rolePolicy": "worker-task",
+                "trainingRole": "worker",
+                "rolloutStatus": "shadow",
+                "parameters": {},
+            },
+            {
+                "id": "role.defender-micro.shadow-candidate.v1",
+                "policyFamily": "role.defender-micro",
+                "rolePolicy": "defender-micro",
+                "trainingRole": "defender",
+                "rolloutStatus": "shadow",
+                "parameters": {},
+            },
+        ]
+
+        with self.assertRaisesRegex(card_helper.CardValidationError, "multiple role policy families"):
+            card_helper.validate_card(card)
+
+        card["metaPolicyReason"] = "explicit meta-policy lane comparison fixture"
+        card_helper.validate_card(card)
 
     def test_policy_gradient_construction_priority_card_is_runner_valid(self) -> None:
         card = card_helper.build_card(

--- a/scripts/test_screeps_rl_role_policy_lanes.py
+++ b/scripts/test_screeps_rl_role_policy_lanes.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import screeps_rl_role_policy_lanes as lanes
+
+
+FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "rl" / "role-policy-scorecards"
+
+
+class ScreepsRlRolePolicyLanesTest(unittest.TestCase):
+    def test_contract_defines_safe_baseline_and_candidate_per_initial_lane(self) -> None:
+        contract = lanes.role_policy_contract()
+
+        lanes.validate_lane_contract(contract)
+        by_family = {lane["policyFamily"]: lane for lane in contract["initialLanes"]}
+        self.assertEqual(
+            set(by_family),
+            {"role.worker-task", "role.source-harvester", "role.defender-micro"},
+        )
+        for lane in by_family.values():
+            for endpoint in ("baseline", "candidate"):
+                payload = lane[endpoint]
+                self.assertEqual(payload["policyFamily"], lane["policyFamily"])
+                self.assertEqual(payload["rolePolicy"], lane["rolePolicy"])
+                self.assertEqual(payload["trainingRole"], lane["trainingRole"])
+                self.assertFalse(payload["liveEffect"])
+                self.assertFalse(payload["officialMmoWrites"])
+                self.assertFalse(payload["officialMmoWritesAllowed"])
+
+    def test_role_policy_scorecard_fixtures_cover_each_lane_and_are_shadow_only(self) -> None:
+        fixtures = sorted(FIXTURE_ROOT.glob("role.*.scorecard.json"))
+        self.assertEqual(len(fixtures), 3)
+
+        observed: set[str] = set()
+        for path in fixtures:
+            with self.subTest(path=path.name):
+                payload = json.loads(path.read_text(encoding="utf-8"))
+                self.assertEqual(payload["type"], "screeps-rl-evaluation-scorecard")
+                self.assertTrue(payload["fixtureOnly"])
+                self.assertTrue(payload["noLiveComputeRun"])
+                self.assertFalse(payload["liveEffect"])
+                self.assertFalse(payload["officialMmoWrites"])
+                self.assertFalse(payload["officialMmoWritesAllowed"])
+
+                metadata = payload["rolePolicyMetadata"]
+                candidate = metadata["candidate"]
+                baseline = metadata["baseline"]
+                lanes.validate_role_policy_collection(
+                    [candidate, baseline],
+                    context=f"{path.name}.rolePolicyMetadata",
+                )
+                self.assertEqual(candidate, baseline)
+                self.assertEqual(metadata["rolePolicyFamilies"], [candidate["policyFamily"]])
+                observed.add(candidate["policyFamily"])
+
+        self.assertEqual(
+            observed,
+            {"role.worker-task", "role.source-harvester", "role.defender-micro"},
+        )
+
+    def test_mixed_role_policy_families_require_explicit_meta_policy_reason(self) -> None:
+        worker = {
+            "policyFamily": "role.worker-task",
+            "rolePolicy": "worker-task",
+            "trainingRole": "worker",
+        }
+        defender = {
+            "policyFamily": "role.defender-micro",
+            "rolePolicy": "defender-micro",
+            "trainingRole": "defender",
+        }
+
+        with self.assertRaisesRegex(lanes.RolePolicyLaneError, "multiple role policy families"):
+            lanes.validate_role_policy_collection([worker, defender], context="test")
+
+        families = lanes.validate_role_policy_collection(
+            [worker, defender],
+            context="test",
+            parent={"metaPolicyReason": "explicit meta-policy comparison fixture"},
+        )
+        self.assertEqual(families, ["role.defender-micro", "role.worker-task"])
+
+    def test_role_scoped_metadata_requires_policy_family_role_policy_and_training_role(self) -> None:
+        with self.assertRaisesRegex(lanes.RolePolicyLaneError, "omits policyFamily"):
+            lanes.validate_role_policy_metadata(
+                {"rolePolicy": "worker-task", "trainingRole": "worker"},
+                "candidate",
+            )
+
+        with self.assertRaisesRegex(lanes.RolePolicyLaneError, "requires rolePolicy"):
+            lanes.validate_role_policy_metadata(
+                {"policyFamily": "role.worker-task", "trainingRole": "worker"},
+                "candidate",
+            )
+
+        with self.assertRaisesRegex(lanes.RolePolicyLaneError, "requires trainingRole"):
+            lanes.validate_role_policy_metadata(
+                {"policyFamily": "role.worker-task", "rolePolicy": "worker-task"},
+                "candidate",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -1722,6 +1722,8 @@ export const STRATEGY_REGISTRY = [
         card = base_card()
         card["strategy_variants"][0]["policyFamily"] = "top.construction"
         card["strategy_variants"][1]["policy_family"] = "role.worker-task"
+        card["strategy_variants"][1]["role_policy"] = "worker-task"
+        card["strategy_variants"][1]["training_role"] = "worker"
         start = tick(1, [room("W1N1", energy=100)])
         baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=300, harvested=100)])])
         candidate = variant_result("candidate", [start, tick(2, [room("W1N1", energy=900, harvested=100)])])
@@ -1742,12 +1744,71 @@ export const STRATEGY_REGISTRY = [
         ranking_by_id = {item["variantId"]: item for item in report["ranking"]}
         self.assertEqual(strategy_by_id["baseline"]["policyFamily"], "top.construction")
         self.assertEqual(strategy_by_id["candidate"]["policyFamily"], "role.worker-task")
+        self.assertEqual(strategy_by_id["candidate"]["rolePolicy"], "worker-task")
+        self.assertEqual(strategy_by_id["candidate"]["trainingRole"], "worker")
         self.assertEqual(result_by_id["baseline"]["policyFamily"], "top.construction")
         self.assertEqual(result_by_id["candidate"]["policyFamily"], "role.worker-task")
+        self.assertEqual(result_by_id["candidate"]["rolePolicy"], "worker-task")
+        self.assertEqual(result_by_id["candidate"]["trainingRole"], "worker")
         self.assertEqual(ranking_by_id["baseline"]["policyFamily"], "top.construction")
         self.assertEqual(ranking_by_id["candidate"]["policyFamily"], "role.worker-task")
+        self.assertEqual(ranking_by_id["candidate"]["rolePolicy"], "worker-task")
+        self.assertEqual(ranking_by_id["candidate"]["trainingRole"], "worker")
         self.assertEqual(report["policyFamilies"], ["role.worker-task", "top.construction"])
+        self.assertEqual(report["rolePolicies"], ["worker-task"])
+        self.assertEqual(report["trainingRoles"], ["worker"])
         self.assertEqual(report["modelFamilies"], ["test-family"])
+
+    def test_multiple_role_policy_families_require_meta_policy_reason(self) -> None:
+        card = base_card(["worker", "defender"])
+        card["strategy_variants"][0].update(
+            {
+                "policyFamily": "role.worker-task",
+                "rolePolicy": "worker-task",
+                "trainingRole": "worker",
+            }
+        )
+        card["strategy_variants"][1].update(
+            {
+                "policyFamily": "role.defender-micro",
+                "rolePolicy": "defender-micro",
+                "trainingRole": "defender",
+            }
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            write_json(card_path, card)
+            with self.assertRaisesRegex(runner.TrainingCardError, "multiple role policy families"):
+                runner.run_training_experiment(
+                    card_path,
+                    root / "reports",
+                    report_id="mixed-role-policy",
+                    simulator_runner=MockSimulator(
+                        {
+                            "worker": variant_result("worker", [tick(1, [room("W1N1")])]),
+                            "defender": variant_result("defender", [tick(1, [room("W1N1")])]),
+                        }
+                    ),
+                )
+
+            card["metaPolicyReason"] = "explicit meta-policy training fixture"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="mixed-role-policy-with-reason",
+                simulator_runner=MockSimulator(
+                    {
+                        "worker": variant_result("worker", [tick(1, [room("W1N1")])]),
+                        "defender": variant_result("defender", [tick(1, [room("W1N1")])]),
+                    }
+                ),
+            )
+
+        self.assertEqual(report["rolePolicies"], ["defender-micro", "worker-task"])
+        self.assertEqual(report["rolePolicyMetadata"]["mixedRolePolicyReason"], "explicit meta-policy training fixture")
 
     def test_equal_reward_tuple_does_not_count_as_top_change(self) -> None:
         start = tick(1, [room("W1N1", energy=100)])

--- a/scripts/tests/test_rl_scorecard.py
+++ b/scripts/tests/test_rl_scorecard.py
@@ -321,6 +321,55 @@ def test_scorecard_rejects_mixed_role_families_without_meta_reason(tmp_path: Pat
         raise AssertionError("mixed role policy families should fail scorecard validation")
 
 
+def test_scorecard_accepts_mixed_role_bundle_with_meta_reason(tmp_path: Path) -> None:
+    baseline_gate = write_bundle(tmp_path / "baseline", candidate=False)
+    candidate_gate = write_bundle(tmp_path / "candidate", candidate=True)
+    reason = "explicit meta-policy scorecard bundle for cross-role comparison"
+    write_role_policy_metadata(
+        baseline_gate.parent,
+        policy_family="role.worker-task",
+        role_policy="worker-task",
+        training_role="worker",
+    )
+    write_role_policy_metadata(
+        candidate_gate.parent,
+        policy_family="role.worker-task",
+        role_policy="worker-task",
+        training_role="worker",
+    )
+    write_json(
+        candidate_gate.parent / "zz-defender-policy-metadata.json",
+        {
+            "type": "screeps-rl-role-policy-scorecard-source",
+            "policyFamily": "role.defender-micro",
+            "rolePolicy": "defender-micro",
+            "trainingRole": "defender",
+            "metaPolicyReason": reason,
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+        },
+    )
+
+    candidate_bundle = scorecard.collect_artifact_bundle(
+        candidate_gate.parent,
+        role="candidate",
+        repo_root=tmp_path,
+    )
+    report = scorecard.build_scorecard(
+        candidate_path=candidate_gate.parent,
+        baseline_path=baseline_gate.parent,
+        repo_root=tmp_path,
+        timestamp="2026-05-11T00:00:00Z",
+        run_id="scorecard-role-mixed-with-reason",
+    )
+
+    assert candidate_bundle["mixedRolePolicyReason"] == reason
+    assert report["overallGate"]["status"] == "PASS"
+    assert report["candidate"]["policyFamily"] == "role.worker-task"
+    assert report["baseline"]["policyFamily"] == "role.worker-task"
+
+
 def test_scorecard_holds_when_runtime_consumption_evidence_is_omitted(tmp_path: Path) -> None:
     baseline = write_bundle(tmp_path / "baseline", candidate=False)
     candidate = write_bundle(tmp_path / "candidate", candidate=True)

--- a/scripts/tests/test_rl_scorecard.py
+++ b/scripts/tests/test_rl_scorecard.py
@@ -175,6 +175,21 @@ def write_bundle(root: Path, *, candidate: bool, safety_regression: bool = False
     return gate_path
 
 
+def write_role_policy_metadata(root: Path, *, policy_family: str, role_policy: str | None, training_role: str | None) -> None:
+    payload: JsonObject = {
+        "type": "screeps-rl-role-policy-scorecard-source",
+        "policyFamily": policy_family,
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+    }
+    if role_policy is not None:
+        payload["rolePolicy"] = role_policy
+    if training_role is not None:
+        payload["trainingRole"] = training_role
+    write_json(root / "policy-metadata.json", payload)
+
+
 def test_scorecard_passes_when_candidate_improves_without_regression(tmp_path: Path) -> None:
     baseline = write_bundle(tmp_path / "baseline", candidate=False)
     candidate = write_bundle(tmp_path / "candidate", candidate=True)
@@ -205,6 +220,105 @@ def test_scorecard_passes_when_candidate_improves_without_regression(tmp_path: P
     assert report["dimensions"]["creep_efficiency"]["status"] == "improved"
     assert report["dimensions"]["combat"]["status"] == "neutral"
     assert report["overallGate"]["monotonic"]["improvedNonSafetyDimension"] is True
+    assert report["liveEffect"] is False
+    assert report["officialMmoWrites"] is False
+
+
+def test_scorecard_preserves_role_policy_metadata(tmp_path: Path) -> None:
+    baseline_gate = write_bundle(tmp_path / "baseline", candidate=False)
+    candidate_gate = write_bundle(tmp_path / "candidate", candidate=True)
+    write_role_policy_metadata(
+        baseline_gate.parent,
+        policy_family="role.worker-task",
+        role_policy="worker-task",
+        training_role="worker",
+    )
+    write_role_policy_metadata(
+        candidate_gate.parent,
+        policy_family="role.worker-task",
+        role_policy="worker-task",
+        training_role="worker",
+    )
+
+    report = scorecard.build_scorecard(
+        candidate_path=candidate_gate.parent,
+        baseline_path=baseline_gate.parent,
+        repo_root=tmp_path,
+        timestamp="2026-05-11T00:00:00Z",
+        run_id="scorecard-role-worker",
+    )
+
+    assert report["rolePolicyMetadata"]["rolePolicyFamilies"] == ["role.worker-task"]
+    assert report["candidate"]["policyFamily"] == "role.worker-task"
+    assert report["candidate"]["rolePolicy"] == "worker-task"
+    assert report["candidate"]["trainingRole"] == "worker"
+    assert report["baseline"]["policyFamily"] == "role.worker-task"
+    assert report["liveEffect"] is False
+    assert report["officialMmoWrites"] is False
+
+
+def test_role_scoped_scorecard_rejects_missing_role_family(tmp_path: Path) -> None:
+    baseline_gate = write_bundle(tmp_path / "baseline", candidate=False)
+    candidate_gate = write_bundle(tmp_path / "candidate", candidate=True)
+    write_json(
+        candidate_gate.parent / "policy-metadata.json",
+        {
+            "type": "screeps-rl-role-policy-scorecard-source",
+            "rolePolicy": "worker-task",
+            "trainingRole": "worker",
+            "liveEffect": False,
+            "officialMmoWrites": False,
+        },
+    )
+    write_role_policy_metadata(
+        baseline_gate.parent,
+        policy_family="role.worker-task",
+        role_policy="worker-task",
+        training_role="worker",
+    )
+
+    try:
+        scorecard.build_scorecard(
+            candidate_path=candidate_gate.parent,
+            baseline_path=baseline_gate.parent,
+            repo_root=tmp_path,
+            timestamp="2026-05-11T00:00:00Z",
+            run_id="scorecard-role-missing-family",
+        )
+    except scorecard.ScorecardError as error:
+        assert "omits policyFamily" in str(error)
+    else:
+        raise AssertionError("missing role policyFamily should fail scorecard validation")
+
+
+def test_scorecard_rejects_mixed_role_families_without_meta_reason(tmp_path: Path) -> None:
+    baseline_gate = write_bundle(tmp_path / "baseline", candidate=False)
+    candidate_gate = write_bundle(tmp_path / "candidate", candidate=True)
+    write_role_policy_metadata(
+        candidate_gate.parent,
+        policy_family="role.worker-task",
+        role_policy="worker-task",
+        training_role="worker",
+    )
+    write_role_policy_metadata(
+        baseline_gate.parent,
+        policy_family="role.defender-micro",
+        role_policy="defender-micro",
+        training_role="defender",
+    )
+
+    try:
+        scorecard.build_scorecard(
+            candidate_path=candidate_gate.parent,
+            baseline_path=baseline_gate.parent,
+            repo_root=tmp_path,
+            timestamp="2026-05-11T00:00:00Z",
+            run_id="scorecard-role-mixed",
+        )
+    except scorecard.ScorecardError as error:
+        assert "multiple role policy families" in str(error) or "role policyFamily differ" in str(error)
+    else:
+        raise AssertionError("mixed role policy families should fail scorecard validation")
 
 
 def test_scorecard_holds_when_runtime_consumption_evidence_is_omitted(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Refs #1585.

This PR adds a machine-readable role-policy lane contract for the RL flywheel so top-level construction-priority evidence cannot be miscounted as role-scoped policy completion. It defines initial `role.worker-task`, `role.source-harvester`, and `role.defender-micro` lanes, preserves `policyFamily` / `rolePolicy` / `trainingRole` metadata across dataset, experiment card, training runner, scorecard, and Loop B/Act-loop surfaces, and adds deterministic shadow-only scorecard fixtures for each lane.

No Tencent paid compute, official MMO writes, or production runtime bundle changes are included.

## Verification

- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_act_loop_planner.py scripts/screeps_rl_dataset_export.py scripts/screeps_rl_experiment_card.py scripts/screeps_rl_scorecard.py scripts/screeps_rl_training_runner.py scripts/screeps_rl_role_policy_lanes.py scripts/test_screeps_rl_act_loop_planner.py scripts/test_screeps_rl_dataset_export.py scripts/test_screeps_rl_experiment_card.py scripts/test_screeps_rl_training_runner.py scripts/test_screeps_rl_role_policy_lanes.py scripts/tests/test_rl_scorecard.py`
- `python3 -m unittest scripts/test_screeps_rl_role_policy_lanes.py scripts/test_screeps_rl_act_loop_planner.py scripts/test_screeps_rl_dataset_export.py scripts/test_screeps_rl_experiment_card.py scripts/test_screeps_rl_training_runner.py scripts/tests/test_rl_scorecard.py` — 278 tests passed

## Universal task Done gate

- [x] Task type: RL flywheel scripts/docs/test implementation, not official runtime deployment.
- [x] Expected observable outcome / named deliverable: role-policy lane contract plus shadow-only scorecard fixtures enforce `policyFamily`, `rolePolicy`, and `trainingRole` for worker-task, source-harvester, and defender-micro lanes.
- [x] Non-goals / accepted substitutes: no Tencent paid compute, no official MMO writes, no learned-policy rollout, and no `prod/dist/main.js` change in this slice.
- [x] Verification evidence required before Done: local `git diff --check`, Python compile checks, and targeted unittest suite passed; GitHub exact-head checks provide the PR gate.
- [x] Project Evidence / Next action / Blocked by: #1585 Project item will point at this PR, exact head `43032612af87fe891f1c5db028050aba7767d177`, local verification above, and PR review/check gates as the next action.
- [x] Post-merge/deploy/runtime proof: no deploy required because only docs/scripts/fixtures/tests changed; post-merge proof is main containing the role-policy lane contract and CI passing on the merge commit.
- [x] Named deliverable proof: committed files include `scripts/screeps_rl_role_policy_lanes.py`, `scripts/test_screeps_rl_role_policy_lanes.py`, and `scripts/fixtures/rl/role-policy-scorecards/` for the three role lanes.
