### PR TITLE
fix: explain Tencent timeout recovery guard

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -2903,7 +2903,14 @@ def build_paid_failure_recurrence_launch_guard(
         elif validation.get("status") == "allowed":
             reason += "; allowing one explicit post-fix validation attempt"
         elif validation.get("status") == "recovery_allowed":
-            reason += "; allowing one explicit recovery validation after a pre-scale no-compute admission failure"
+            recovery = dict_value(validation.get("recoveryEligibility")) or {}
+            if text_value(recovery.get("recoveryClass")) in {
+                "remote_training_timeout",
+                "remote_training_timeout_after_recovery",
+            }:
+                reason += "; allowing one explicit recovery validation after a remote-training timeout without a completed report"
+            else:
+                reason += "; allowing one explicit recovery validation after a pre-scale no-compute admission failure"
         elif validation.get("status") == "consumed":
             reason += "; a post-fix validation attempt already ran without completing successfully"
     next_action = None
@@ -3072,14 +3079,20 @@ def paid_failure_post_fix_validation_recovery_eligibility(
     if fix_status.get("present") is not True:
         result["reason"] = "registered room-busy fix is not verified in the current checkout"
         return result
+    recovery_class = paid_failure_post_fix_validation_recovery_class_for_attempts(prior_attempts)
     if not requested:
+        if recovery_class is not None:
+            paid_failure_post_fix_validation_recovery_metadata(
+                result,
+                recovery_class,
+                prior_attempts,
+            )
         result["reason"] = "explicit post-fix validation signature was not requested"
         return result
     prior_attempt = prior_attempts[0]
     if any(text_value(attempt.get("outcome")) == "completed" for attempt in prior_attempts):
         result["reason"] = "a post-fix validation already completed"
         return result
-    recovery_class = paid_failure_post_fix_validation_recovery_class_for_attempts(prior_attempts)
     if recovery_class is None:
         if len(prior_attempts) not in (1, 2):
             result["reason"] = (
@@ -3105,26 +3118,41 @@ def paid_failure_post_fix_validation_recovery_eligibility(
         result["reason"] = "policy-gradient requested samples are below the trust gate target"
         return result
     result["eligible"] = True
-    result["recoveryClass"] = recovery_class
+    paid_failure_post_fix_validation_recovery_metadata(
+        result,
+        recovery_class,
+        prior_attempts,
+    )
     if recovery_class in {"remote_training_timeout", "remote_training_timeout_after_recovery"}:
         result["reason"] = (
             "one recovery validation is allowed after a consumed remote-training timeout "
             "without a completed report"
         )
         if recovery_class == "remote_training_timeout_after_recovery":
-            recovery_attempt = next(
-                (attempt for attempt in prior_attempts if attempt.get("recoveryAttempt") is True),
-                prior_attempt,
-            )
-            result["priorRecoveryAttemptRunId"] = text_value(recovery_attempt.get("runId"))
-            result["priorAttemptRunId"] = text_value(recovery_attempt.get("runId"))
             return result
     else:
         result["reason"] = (
             "one recovery validation is allowed after a consumed pre-scale no-compute admission failure"
         )
-    result["priorAttemptRunId"] = text_value(prior_attempt.get("runId"))
     return result
+
+
+def paid_failure_post_fix_validation_recovery_metadata(
+    result: dict[str, Any],
+    recovery_class: str,
+    prior_attempts: list[dict[str, Any]],
+) -> None:
+    result["recoveryClass"] = recovery_class
+    prior_attempt = prior_attempts[0]
+    if recovery_class == "remote_training_timeout_after_recovery":
+        recovery_attempt = next(
+            (attempt for attempt in prior_attempts if attempt.get("recoveryAttempt") is True),
+            prior_attempt,
+        )
+        result["priorRecoveryAttemptRunId"] = text_value(recovery_attempt.get("runId"))
+        result["priorAttemptRunId"] = text_value(recovery_attempt.get("runId"))
+        return
+    result["priorAttemptRunId"] = text_value(prior_attempt.get("runId"))
 
 
 def paid_failure_post_fix_validation_recovery_class_for_attempts(
@@ -3531,6 +3559,32 @@ def paid_failure_recurrence_next_action(
         )
     if status == "consumed":
         prior = dict_value(validation.get("priorAttempt")) or {}
+        recovery = dict_value(validation.get("recoveryEligibility")) or {}
+        recovery_class = text_value(recovery.get("recoveryClass"))
+        if recovery_class in {"remote_training_timeout", "remote_training_timeout_after_recovery"}:
+            run_id = (
+                text_value(recovery.get("priorRecoveryAttemptRunId"))
+                or text_value(recovery.get("priorAttemptRunId"))
+                or text_value(prior.get("runId"))
+                or "the prior post-fix validation"
+            )
+            return (
+                f"{base}; {run_id} timed out in remote training without a completed report, "
+                "but this launch did not request the explicit post-fix validation signature; "
+                "inspect collected partial diagnostics, then only launch a recovery with that "
+                "signature plus an explicitly sized timeout or a smaller validation slice"
+            )
+        if recovery_class == "pre_scale_no_compute_admission_failure":
+            run_id = (
+                text_value(recovery.get("priorAttemptRunId"))
+                or text_value(prior.get("runId"))
+                or "the prior post-fix validation"
+            )
+            return (
+                f"{base}; {run_id} failed before scale, compute, remote training, environments, "
+                "or a training report, but this launch did not request the explicit post-fix "
+                "validation signature; only launch a recovery with that signature"
+            )
         run_id = text_value(prior.get("runId")) or "the prior post-fix validation"
         return (
             f"{base}; post-fix validation was already attempted in {run_id} without a completed report, "

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -4334,8 +4334,71 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(recovery["recoveryClass"], "remote_training_timeout_after_recovery")
         self.assertEqual(recovery["priorRecoveryAttemptRunId"], "postfix-room-busy-validation-timeout")
         self.assertIn("explicitly sized timeout", guard["nextAction"])
+        self.assertIn("remote-training timeout", guard["reason"])
         self.assertEqual(controller.final_status, "completed")
         self.assertEqual(summary["outputs"]["launchGuard"]["postFixValidation"]["status"], "recovery_allowed")
+
+    def test_paid_failure_recurrence_guard_explains_timeout_recovery_when_signature_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            write_post_fix_validation_pre_scale_admission_failure_summary(
+                artifact_root,
+                "tencent-postfix-room-busy-v1",
+            )
+            write_post_fix_validation_recovery_remote_timeout_summary(
+                artifact_root,
+                "postfix-room-busy-validation-timeout",
+            )
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                "500",
+                "--workers",
+                "5",
+                "--scale-environments",
+                "5",
+                "--repetitions",
+                "5",
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertEqual(events, [])
+        self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+        self.assertTrue(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
+        recovery = guard["postFixValidation"]["recoveryEligibility"]
+        self.assertFalse(recovery["eligible"])
+        self.assertEqual(recovery["recoveryClass"], "remote_training_timeout_after_recovery")
+        self.assertEqual(recovery["priorRecoveryAttemptRunId"], "postfix-room-busy-validation-timeout")
+        self.assertIn("explicit post-fix validation signature", recovery["reason"])
+        self.assertIn("explicit post-fix validation signature", guard["nextAction"])
+        self.assertIn("explicitly sized timeout", guard["nextAction"])
+        self.assertIn("smaller validation slice", guard["nextAction"])
+        self.assertFalse(summary["execution"]["computeAttempted"])
 
     def test_paid_failure_recurrence_guard_ignores_preflight_only_recovery_admission(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

- Preserve remote-training timeout recovery metadata even when the explicit post-fix validation signature is missing, so the guard can explain why paid compute stays held.
- Differentiate timed-out remote-training recovery from pre-scale no-compute admission failures in launch-guard reason and next-action text.
- Add focused unit coverage for the consumed post-fix timeout-recovery path.

Fixes #1596

## Verification

Controller-side verification from `/root/screeps-worktrees/issue-1596-room-busy-validation-timeout`:

- `git -c filter.lfs.required=false -c filter.lfs.clean= -c filter.lfs.smudge= -c filter.lfs.process= diff --check` — PASS
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py` — PASS
- Focused unittest for 4 runner/guard tests — PASS
- `python3 -m unittest scripts.test_screeps_tencent_batch_rl_runner` — PASS (`169` tests)
- `git merge-base --is-ancestor origin/main HEAD` — PASS

## Issue closure gate

- [x] #1596: Codex-authored commit `9424baba` implements the local/offline guard diagnostic fix, adds focused tests, and keeps Tencent paid `run-single` held unless an explicit post-fix validation signature is requested with an appropriately sized timeout or smaller validation slice. No paid compute, ASG scale, deploy, or official MMO write occurred.

## Universal task Done gate

- [x] Task type: RL flywheel runner/guard code fix.
- [x] Expected observable outcome / named deliverable: launch guard explains the consumed remote-training-timeout recovery class and its exact safe next action instead of generic room-busy guard prose.
- [x] Non-goals / accepted substitutes: no Tencent paid compute, no ASG scale-out, no official MMO deploy/write, no learned-policy rollout.
- [x] Verification evidence required before Done: diff-check, py_compile, focused runner tests, full runner unittest, and merge-base checks all passed on commit `9424baba`.
- [x] Project Evidence / Next action / Blocked by: #1596 and this PR Project items identify commit `9424baba`, verification, and review gate.
- [x] Post-merge/deploy/runtime proof: merged code plus exact-head CI/review gate is the named deliverable proof for this local guard diagnostic; paid validation remains controlled by the explicit signature guard.
- [x] Named deliverable proof: `scripts/screeps_tencent_batch_rl_runner.py` and `scripts/test_screeps_tencent_batch_rl_runner.py` are committed by `lanyusea's bot <lanyusea@gmail.com>`.

## Safety

No secrets printed. No Tencent paid compute or ASG mutation. No official MMO writes. Codex did not mutate GitHub/Project or push; controller handled orchestration after verification.