### PR TITLE
fix: add E29N55 RCL6 storage construction

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -15106,6 +15106,7 @@ function isFiniteNumber6(value) {
 // src/construction/claimed-room-planner.ts
 var DEFAULT_REQUIRE_ENERGY_OR_CREEPS = true;
 var DEFAULT_CLAIMED_ROOM_ROAD_SITES_PER_TICK = 1;
+var CLAIMED_ROOM_STORAGE_CONSTRUCTION_MIN_RCL = 6;
 function planClaimedRoomConstruction(colony, options = {}) {
   if (!isClaimedRoomConstructionActive(colony.room)) {
     return createEmptyClaimedRoomConstructionResult(colony, "inactive");
@@ -15168,7 +15169,7 @@ function buildClaimedRoomConstructionOptions(colony, options) {
   return {
     ...options,
     includePostClaimRamparts: (_a = options.includePostClaimRamparts) != null ? _a : postClaimRoom,
-    includeStorage: (_b = options.includeStorage) != null ? _b : postClaimRoom,
+    includeStorage: (_b = options.includeStorage) != null ? _b : shouldIncludeClaimedRoomStorageConstruction(colony.room, postClaimRoom),
     postClaimPriorityOrder: (_c = options.postClaimPriorityOrder) != null ? _c : postClaimRoom,
     respectRoomEnergyBuffer: (_d = options.respectRoomEnergyBuffer) != null ? _d : true,
     maxContainerSitesPerTick: (_e = options.maxContainerSitesPerTick) != null ? _e : Math.max(1, sourceCount),
@@ -15178,6 +15179,9 @@ function buildClaimedRoomConstructionOptions(colony, options) {
       ...options.roadOptions
     }
   };
+}
+function shouldIncludeClaimedRoomStorageConstruction(room, postClaimRoom) {
+  return postClaimRoom || getOwnedRoomRcl7(room) >= CLAIMED_ROOM_STORAGE_CONSTRUCTION_MIN_RCL;
 }
 function countAssignedBuilderCreeps(roomName) {
   var _a;

--- a/prod/src/construction/claimed-room-planner.ts
+++ b/prod/src/construction/claimed-room-planner.ts
@@ -30,6 +30,7 @@ export interface ClaimedRoomConstructionPlannerResult extends ConstructionPlanne
 
 const DEFAULT_REQUIRE_ENERGY_OR_CREEPS = true;
 const DEFAULT_CLAIMED_ROOM_ROAD_SITES_PER_TICK = 1;
+const CLAIMED_ROOM_STORAGE_CONSTRUCTION_MIN_RCL = 6;
 
 export function runClaimedRoomConstructionPlanner(
   options: ClaimedRoomConstructionPlannerOptions = {}
@@ -134,7 +135,7 @@ function buildClaimedRoomConstructionOptions(
   return {
     ...options,
     includePostClaimRamparts: options.includePostClaimRamparts ?? postClaimRoom,
-    includeStorage: options.includeStorage ?? postClaimRoom,
+    includeStorage: options.includeStorage ?? shouldIncludeClaimedRoomStorageConstruction(colony.room, postClaimRoom),
     postClaimPriorityOrder: options.postClaimPriorityOrder ?? postClaimRoom,
     respectRoomEnergyBuffer: options.respectRoomEnergyBuffer ?? true,
     maxContainerSitesPerTick: options.maxContainerSitesPerTick ?? Math.max(1, sourceCount),
@@ -144,6 +145,10 @@ function buildClaimedRoomConstructionOptions(
       ...options.roadOptions
     }
   };
+}
+
+function shouldIncludeClaimedRoomStorageConstruction(room: Room, postClaimRoom: boolean): boolean {
+  return postClaimRoom || getOwnedRoomRcl(room) >= CLAIMED_ROOM_STORAGE_CONSTRUCTION_MIN_RCL;
 }
 
 function countAssignedBuilderCreeps(roomName: string): number {

--- a/prod/test/claimedRoomPlanner.test.ts
+++ b/prod/test/claimedRoomPlanner.test.ts
@@ -108,6 +108,78 @@ describe('claimed room construction planner', () => {
     expect(room.createConstructionSite).toHaveBeenCalledWith(33, 21, STRUCTURE_EXTENSION);
   });
 
+  it('requests E29N55 RCL6 storage construction when no storage or storage site exists', () => {
+    const { room, colony } = makeColony({
+      roomName: 'E29N55',
+      controllerLevel: 6,
+      energyAvailable: 7_750,
+      energyCapacityAvailable: 2_300,
+      spawnPosition: { x: 17, y: 24 },
+      structures: makeMatureRcl6Infrastructure('E29N55'),
+      sources: []
+    });
+
+    const result = planClaimedRoomConstruction(colony);
+
+    expect(result.yielded).toBe(false);
+    expect(result.placements).toContainEqual(
+      expect.objectContaining({
+        priority: 'storage',
+        roomName: 'E29N55',
+        structureType: TEST_GLOBALS.STRUCTURE_STORAGE,
+        result: OK_CODE,
+        energyReserved: 50
+      })
+    );
+    expect(
+      room.createConstructionSite.mock.calls.filter(([, , structureType]) => structureType === STRUCTURE_STORAGE)
+    ).toHaveLength(1);
+  });
+
+  it('does not request duplicate RCL6 storage construction when storage already exists', () => {
+    const { room, colony } = makeColony({
+      roomName: 'E29N55',
+      controllerLevel: 6,
+      energyAvailable: 7_750,
+      energyCapacityAvailable: 2_300,
+      spawnPosition: { x: 17, y: 24 },
+      structures: [
+        ...makeMatureRcl6Infrastructure('E29N55'),
+        makeStructure('storage-existing', TEST_GLOBALS.STRUCTURE_STORAGE, 17, 23, 'E29N55')
+      ],
+      sources: []
+    });
+
+    const result = planClaimedRoomConstruction(colony);
+
+    expect(result.placements.some((placement) => placement.priority === 'storage')).toBe(false);
+    expect(
+      room.createConstructionSite.mock.calls.filter(([, , structureType]) => structureType === STRUCTURE_STORAGE)
+    ).toHaveLength(0);
+  });
+
+  it('does not request duplicate RCL6 storage construction when a storage site already exists', () => {
+    const { room, colony } = makeColony({
+      roomName: 'E29N55',
+      controllerLevel: 6,
+      energyAvailable: 7_750,
+      energyCapacityAvailable: 2_300,
+      spawnPosition: { x: 17, y: 24 },
+      structures: makeMatureRcl6Infrastructure('E29N55'),
+      constructionSites: [
+        makeConstructionSite('storage-pending', TEST_GLOBALS.STRUCTURE_STORAGE, 17, 23, 'E29N55')
+      ],
+      sources: []
+    });
+
+    const result = planClaimedRoomConstruction(colony);
+
+    expect(result.placements.some((placement) => placement.priority === 'storage')).toBe(false);
+    expect(
+      room.createConstructionSite.mock.calls.filter(([, , structureType]) => structureType === STRUCTURE_STORAGE)
+    ).toHaveLength(0);
+  });
+
   it('seeds an E29N56 RCL2 first extension site below the energy reserve without reserving energy', () => {
     const { room, colony } = makeColony({
       roomName: 'E29N56',
@@ -539,6 +611,46 @@ function makeExtensions(count: number, roomName = 'W2N1'): Structure[] {
   return Array.from({ length: count }, (_, index) =>
     makeStructure(`extension-${index}`, TEST_GLOBALS.STRUCTURE_EXTENSION, 35 + index, 35, roomName)
   );
+}
+
+function makeMatureRcl6Infrastructure(roomName = 'W2N1'): Structure[] {
+  const extensions = Array.from({ length: 40 }, (_unused, index) =>
+    makeStructure(
+      `extension-${index}`,
+      TEST_GLOBALS.STRUCTURE_EXTENSION,
+      30 + (index % 8),
+      30 + Math.floor(index / 8),
+      roomName
+    )
+  );
+  const containers = Array.from({ length: 5 }, (_unused, index) =>
+    makeStructure(`container-${index}`, TEST_GLOBALS.STRUCTURE_CONTAINER, 22 + index, 22, roomName)
+  );
+  const towers = [
+    makeStructure('tower-1', TEST_GLOBALS.STRUCTURE_TOWER, 20, 24, roomName),
+    makeStructure('tower-2', TEST_GLOBALS.STRUCTURE_TOWER, 20, 25, roomName)
+  ];
+  const coveredDefenseAnchors = [
+    makeStructure('spawn-rampart', TEST_GLOBALS.STRUCTURE_RAMPART, 17, 24, roomName),
+    makeStructure('tower-1-rampart', TEST_GLOBALS.STRUCTURE_RAMPART, 20, 24, roomName),
+    makeStructure('tower-2-rampart', TEST_GLOBALS.STRUCTURE_RAMPART, 20, 25, roomName),
+    makeStructure('controller-rampart', TEST_GLOBALS.STRUCTURE_RAMPART, 24, 24, roomName),
+    ...containers.map((container, index) =>
+      makeStructure(
+        `container-${index}-rampart`,
+        TEST_GLOBALS.STRUCTURE_RAMPART,
+        container.pos.x,
+        container.pos.y,
+        roomName
+      )
+    ),
+    makeStructure('spawn-wall-nw', TEST_GLOBALS.STRUCTURE_WALL, 16, 23, roomName),
+    makeStructure('spawn-wall-ne', TEST_GLOBALS.STRUCTURE_WALL, 18, 23, roomName),
+    makeStructure('spawn-wall-sw', TEST_GLOBALS.STRUCTURE_WALL, 16, 25, roomName),
+    makeStructure('spawn-wall-se', TEST_GLOBALS.STRUCTURE_WALL, 18, 25, roomName)
+  ];
+
+  return [...extensions, ...containers, ...towers, ...coveredDefenseAnchors];
 }
 
 function makeSource(id: string, x: number, y: number, roomName = 'W2N1'): Source {


### PR DESCRIPTION
## Summary

- Enable the claimed-room construction planner to request storage once an owned room reaches RCL6, even after the post-claim phase has ended.
- Add focused E29N55 coverage for storage placement and duplicate existing/pending storage suppression.
- Regenerate `prod/dist/main.js` from the verified source.

Refs #1599

## Verification

Controller-side verification from `/root/screeps-worktrees/issue-1599-e29n55-storage`:

- `git diff --check` — PASS
- `cd prod && npm run typecheck` — PASS
- `cd prod && npm test -- --runInBand` — PASS (`103` suites, `2162` tests)
- `cd prod && npm run build` — PASS

## Universal task Done gate

- [x] Task type: Screeps production code fix PR, issue kept open for runtime acceptance.
- [x] Expected observable outcome / named deliverable: E29N55 RCL6 receives an automatic storage construction site when no storage or storage site exists.
- [x] Non-goals / accepted substitutes: no official MMO deploy in this PR step, no paid compute, no issue auto-closure, no learned-policy rollout.
- [x] Verification evidence required before Done: `git diff --check`, `npm run typecheck`, `npm test -- --runInBand`, and `npm run build` all passed on commit `fa77b177`.
- [x] Project Evidence / Next action / Blocked by: controller will update PR and #1599 Project fields with commit `fa77b177`, verification results, review gate, and runtime acceptance metric.
- [x] Post-merge/deploy/runtime proof: #1599 stays open for postdeploy runtime acceptance; acceptance metric is E29N55 storage construction site creation or storage presence in a fresh runtime summary after deploy.
- [x] Named deliverable proof: `prod/src/construction/claimed-room-planner.ts`, `prod/test/claimedRoomPlanner.test.ts`, and regenerated `prod/dist/main.js` are committed by `lanyusea's bot <lanyusea@gmail.com>`.

## Safety

No secrets printed. No official MMO writes. No Tencent paid compute. Codex did not mutate GitHub/Project or push; controller handles orchestration.