### PR TITLE
fix: shed idle harvest fallback under low CPU bucket

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -32100,7 +32100,7 @@ function fallbackToEnergyOnNullSelectionLoop(creep, selectedTask) {
     delete creep.memory.workerTaskSelectionNullLoop;
     return selectedTask;
   }
-  if (getRuntimeCpuBudget().critical) {
+  if (shouldShedNonessentialCpuWork(getRuntimeCpuBudget())) {
     return null;
   }
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -53,7 +53,7 @@ import {
   recordCreepBehaviorWork,
   type RuntimeEnergyAcquisitionMethod
 } from '../telemetry/behaviorTelemetry';
-import { getRuntimeCpuBudget, isRuntimeCpuBucketLow } from '../runtime/cpuBudget';
+import { getRuntimeCpuBudget, isRuntimeCpuBucketLow, shouldShedNonessentialCpuWork } from '../runtime/cpuBudget';
 import { isColonyRoomThreatened } from '../defense/colonyThreats';
 
 type TransferSinkStructureConstantGlobal =
@@ -864,7 +864,7 @@ function fallbackToEnergyOnNullSelectionLoop(
     return selectedTask;
   }
 
-  if (getRuntimeCpuBudget().critical) {
+  if (shouldShedNonessentialCpuWork(getRuntimeCpuBudget())) {
     return null;
   }
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1013,6 +1013,58 @@ describe('runWorker', () => {
     expect(harvest).not.toHaveBeenCalled();
   });
 
+  it('does not use the idle fallback to start noncritical harvest during low-bucket recovery', () => {
+    const source = { id: 'source1', energy: 300 } as Source;
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 800,
+      energyCapacityAvailable: 800,
+      controller: {
+        my: true,
+        level: 4,
+        ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+      } as StructureController,
+      find: jest.fn((type: number) => (type === FIND_SOURCES ? [source] : []))
+    } as unknown as Room;
+    const harvest = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'Worker1',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        workerTaskSelectionNullLoop: {
+          lastNullSelectionTick: 899,
+          nullSelectionCount: 10,
+          fallbackAttempts: 0,
+          idleStartTick: 890
+        }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room,
+      harvest,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Worker1: creep },
+      time: 900,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(18),
+        limit: 70,
+        bucket: 961,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) => (id === 'source1' ? source : null)) as unknown as Game['getObjectById']
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toBeUndefined();
+    expect(harvest).not.toHaveBeenCalled();
+  });
+
   it('moves to collect a score target at exact range without pickup', () => {
     const score = makeScoreTarget('score1');
     const pickup = jest.fn();


### PR DESCRIPTION
## Summary
- suppresses the idle worker fallback harvest when the runtime CPU budget is in low-bucket shed mode, not only when it is critical
- adds regression coverage for a bucket-961 recovery tick so idle fallback work does not start nonessential harvest CPU spend
- rebuilds `prod/dist/main.js`

Related to issue #1490.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 103 suites / 2163 tests passed
- `cd prod && npm run build`

## Universal task Done gate
- [x] Task type: Production code CPU-safety follow-up.
- [x] Expected observable outcome / named deliverable: Low-bucket mode suppresses idle fallback harvest and avoids nonessential worker CPU spend while recovery is active.
- [x] Non-goals / accepted substitutes: No learned-policy activation, no Tencent paid compute, no strategic behavior rewrite.
- [x] Verification evidence required before Done: Controller verification passed with diff-check, typecheck, full Jest, and build in `/root/screeps-worktrees/issue-1490-cpu-bucket-followup/prod`.
- [x] Project Evidence / Next action / Blocked by: Steward records PR, commit, verification, and review-gate state on the PR/issue Project items.
- [x] Post-merge/deploy/runtime proof: Runtime acceptance is issue 1490's CPU-bearing console evidence surface.
- [x] Named deliverable proof: Codex-authored commit `4640fd6c` changes `workerRunner` low-bucket fallback behavior and adds a bucket-961 regression test.

## Safety
- No secrets printed.
- `prod/node_modules` was untracked verification infrastructure and is not part of the commit.
