### PR TITLE
rl: record worker transport reward decision hold

### DIFF
--- a/docs/ops/examples/rl-reward-decisions/RD-V3-006-workerTransportEfficiency.json
+++ b/docs/ops/examples/rl-reward-decisions/RD-V3-006-workerTransportEfficiency.json
@@ -1,0 +1,139 @@
+{
+  "rewardDecisionId": "RD-V3-006-workerTransportEfficiency",
+  "title": "Proposal: worker transport efficiency telemetry hold",
+  "state": "proposed",
+  "linkedGitHubIssue": "https://github.com/lanyusea/screeps/issues/1555",
+  "linkedMetricEvidence": [
+    "https://github.com/lanyusea/screeps/issues/906",
+    "https://github.com/lanyusea/screeps/issues/907",
+    "https://github.com/lanyusea/screeps/issues/924",
+    "2026-06-01 Gameplay Evolution Review: workers were observed running transfer tasks with carriedEnergy around 0-6 and freeCapacity around 94.",
+    "archive:/root/.hermes/cron/output/c7b3dda8f1ac/2026-06-02_01-21-18.md: E29N56 reported 2 low-load returns at 9/100 and 16/100 with reason noReachableEnergy and mean tripEnergy 12.5; E29N57 reported spawn-reservation/build-deadlock behavior rather than direct low-load transport evidence."
+  ],
+  "linkedDashboardPanels": [
+    "runtime summary: workerEfficiency.lowLoadReturnCount",
+    "runtime summary: workerEfficiency.avoidableLowLoadReturnCount",
+    "runtime summary: workerEfficiency.tripEnergyMean",
+    "runtime summary: workerEfficiency.tripEnergyMin",
+    "runtime summary: workerEfficiency.lowLoadReturnReasons",
+    "planned telemetry: low-load transport reason distribution and noReachableEnergy counter",
+    "planned #924-compatible candidate-vs-baseline logistics scorecard"
+  ],
+  "problemStatement": "Runtime and gameplay review evidence shows workers sometimes returning or transferring with very low energy loads, including 0-6/100 transfer-task observations and E29N56 returns at 9/100 and 16/100. These micro-hauls can waste movement, CPU, and worker ticks when energy is reachable and the room is not in emergency recovery. The current concrete E29N56 samples are tagged noReachableEnergy, and the E29N57 evidence is dominated by spawn-reservation/build-deadlock behavior, so the evidence is not yet sufficient to start a reward experiment without better telemetry attribution.",
+  "hypothesis": "A future offline/shadow worker_transport_efficiency penalty for avoidable low-load micro-hauls should increase useful delivered energy per trip and reduce wasteful transfer/upgrade travel, but only when telemetry proves the low-load trip was avoidable. The penalty must exclude emergency spawn/refill recovery, controller downgrade protection, hostile retreat, genuine energy starvation, noReachableEnergy cases, and other higher-priority reliability or territory gates.",
+  "currentRewardCoverage": "Runtime telemetry already exposes lowLoadReturnCount, avoidableLowLoadReturnCount, lowLoadReturnReasons, carriedEnergy/freeCapacity samples, and trip energy summaries. The existing worker-efficiency RL reward remains generic work_ticks/total_ticks plus delivered-energy, idle, range, and risk terms. No accepted reward component currently targets worker_transport_efficiency micro-hauls, and the available evidence lacks a durable per-trip join across source energy reachability, target saturation, task intent, path distance, room buffer state, spawn reservation state, delivered energy, CPU, and stuck/pathing outcome.",
+  "proposedChangeType": "add_component_pending_telemetry",
+  "component": "worker_transport_efficiency",
+  "direction": "lower_is_better for avoidable low-load returns; candidate penalty only after telemetry proves carriedEnergy / capacity is below 0.20 on a non-emergency trip with reachable energy and no higher-priority exception",
+  "expectedBehaviorChange": "After telemetry is sufficient and a separate offline/shadow experiment is approved, candidate policies should rank below baseline when they repeatedly choose avoidable low-load transfer or upgrade trips, and should rank above comparable policies when they deliver fuller loads without delaying emergency refill, construction unblock, controller safety, or room survival. This decision does not authorize training, live reward defaults, or official MMO learned-policy writes.",
+  "decisionDisposition": "hold_for_telemetry",
+  "telemetryGate": {
+    "requiredBeforeRewardExperiment": true,
+    "sourceIssue": "https://github.com/lanyusea/screeps/issues/1554",
+    "requiredEvidence": [
+      "per-room lowLoadReturnCount, avoidableLowLoadReturnCount, and lowLoadReturnReasons over repeated windows",
+      "trip load factor with carriedEnergy, freeCapacity, and capacity at the dispatch and delivery points",
+      "source or nearby energy reachability at the acquisition decision",
+      "transfer or upgrade target type and saturation state",
+      "room energy buffer, spawn reservation active/idle state, and controller downgrade pressure",
+      "deliveredEnergyPerTrip and useful work ticks",
+      "path distance, stuck ticks, pathFindingFailures, and CPU bucket impact"
+    ],
+    "reason": "The 9/100 and 16/100 E29N56 samples are currently tagged noReachableEnergy, which can be a valid starvation exception rather than an avoidable transport inefficiency."
+  },
+  "riskAndRegressions": [
+    "A naive low-load penalty can punish correct noReachableEnergy or energy-starvation behavior.",
+    "Waiting for fuller loads can delay urgent spawn, extension, tower, or controller refill.",
+    "The penalty can mask a dispatch bug, such as spawn reservation blocking builders, by treating a cause as a reward symptom.",
+    "Longer acquisition trips can increase path CPU, stuck ticks, or hostile exposure.",
+    "Micro-haul evidence from one room/window can overfit a reward component before a repeated baseline exists."
+  ],
+  "validationWindows": [
+    {
+      "name": "telemetry_readiness_gate",
+      "minimumDurationHours": 8,
+      "requiredEvidence": [
+        "repeated low-load transport windows from at least two runtime captures or a single continuous 8-hour capture",
+        "reason distribution separates noReachableEnergy, emergency refill, controller safety, hostile retreat, source starvation, and avoidable micro-haul cases",
+        "source or nearby energy reachability and target saturation are present for qualifying samples",
+        "spawn reservation active/idle state and construction-deadlock context are present so dispatch deadlocks are not mislabeled as reward inefficiency",
+        "deliveredEnergyPerTrip or equivalent useful energy delivery metric is present",
+        "liveEffect:false",
+        "officialMmoWrites:false",
+        "officialMmoWritesAllowed:false"
+      ]
+    },
+    {
+      "name": "historical_shadow_reward_replay",
+      "minimumDurationHours": 8,
+      "requiredEvidence": [
+        "only after telemetry_readiness_gate passes",
+        "candidate predicate excludes noReachableEnergy and emergency/survival exceptions",
+        "avoidable low-load return count and return load factor versus baseline",
+        "delivered energy per trip versus baseline",
+        "spawn/refill latency, controller downgrade safety, construction progress, CPU bucket, stuck ticks, and reliability non-regression",
+        "liveEffect:false",
+        "officialMmoWrites:false"
+      ]
+    },
+    {
+      "name": "candidate_vs_baseline_scorecard",
+      "minimumDurationHours": 8,
+      "requiredEvidence": [
+        "#924-compatible scorecard artifact comparing the transport-efficiency candidate against the incumbent baseline",
+        "qualifying avoidable low-load micro-haul count decreases versus baseline",
+        "mean delivered energy per trip or return load factor improves versus baseline",
+        "territory, resource throughput, spawn/refill safety, CPU, and reliability do not regress",
+        "officialMmoWritesAllowed:false"
+      ]
+    }
+  ],
+  "acceptanceCriteria": [
+    "This record is accepted only as a proposed decision and telemetry hold; it is not approval for a reward experiment.",
+    "Issue #1554 or an equivalent metric artifact first proves repeated avoidable low-load micro-hauls, not only noReachableEnergy or emergency exceptions.",
+    "The candidate predicate is limited to non-emergency trips where carriedEnergy / capacity is below 0.20, reachable energy existed at the acquisition decision, target saturation does not explain the small load, and no higher-priority reliability or territory gate applies.",
+    "A future generated #924-compatible candidate-vs-baseline scorecard artifact shows avoidable low-load returns decrease and deliveredEnergyPerTrip or returnLoadFactor improves versus baseline.",
+    "Spawn/refill latency, controller downgrade safety, construction progress, CPU bucket, stuck/pathing metrics, reliability, territory, and resource metrics do not regress versus baseline.",
+    "All validation artifacts preserve liveEffect:false, officialMmoWrites:false, officialMmoWritesAllowed:false, and all live-control safety flags false."
+  ],
+  "rollbackCriteria": [
+    "Reject the reward experiment if telemetry shows most low-load returns are noReachableEnergy, emergency refill, controller safety, hostile retreat, or genuine starvation exceptions.",
+    "Reject or reduce the penalty if spawn, extension, tower, or controller refill latency regresses versus baseline.",
+    "Reject or gate the penalty if delivered energy per trip improves only by increasing path CPU, stuck ticks, pathFindingFailures, or hostile exposure.",
+    "Reject the candidate if the #924-compatible scorecard shows reliability, territory, resource, construction progress, or CPU regression not explicitly accepted by owner review.",
+    "Reject if the implementation enables any official MMO learned-policy write, live control surface, Memory write, RawMemory write, creep intent, spawn intent, construction intent, or market intent.",
+    "Owner rejects, suspends, or supersedes the decision."
+  ],
+  "safety": {
+    "liveEffect": false,
+    "officialMmoWrites": false,
+    "officialMmoWritesAllowed": false,
+    "memoryWritesAllowed": false,
+    "rawMemoryWritesAllowed": false,
+    "rawCreepIntentControl": false,
+    "spawnIntentControl": false,
+    "constructionIntentControl": false,
+    "marketIntentControl": false
+  },
+  "stewardDecision": {
+    "state": "hold_for_telemetry",
+    "decidedBy": null,
+    "decidedAt": null,
+    "notes": "Proposal only. The available evidence is enough to register issue #1555 as a reward-decision candidate, but not enough to start a reward experiment. Require #1554 or equivalent telemetry to prove avoidable low-load micro-hauls before any offline/shadow reward candidate is trained or scorecarded."
+  },
+  "ownerDecision": {
+    "state": "not_requested",
+    "decidedBy": null,
+    "decidedAt": null,
+    "notes": "No accepted reward change, no reward experiment approval, and no live official MMO authority."
+  },
+  "linkedPRs": [],
+  "linkedTrainingRuns": [],
+  "linkedPolicyEvaluations": [
+    "archive:/root/.hermes/cron/output/c7b3dda8f1ac/2026-06-02_01-21-18.md",
+    "pending: #1554 telemetry readiness evidence",
+    "pending: future #924-compatible candidate-vs-baseline logistics scorecard if telemetry gate passes"
+  ],
+  "createdAt": "2026-06-02T00:00:00Z",
+  "updatedAt": "2026-06-02T00:00:00Z"
+}

--- a/docs/ops/examples/rl-reward-decisions/README.md
+++ b/docs/ops/examples/rl-reward-decisions/README.md
@@ -17,3 +17,4 @@ Current examples:
 - `RD-0003-stuck-actionless-creeps.json`
 - `RD-V3-004-constructionNeglectPenalty.json`
 - `RD-V3-005-onlineReliabilityRollbackPenalty.json`
+- `RD-V3-006-workerTransportEfficiency.json`

--- a/docs/ops/rl-reward-decision-log.md
+++ b/docs/ops/rl-reward-decision-log.md
@@ -72,6 +72,7 @@ The JSON template is `docs/ops/templates/rl-reward-decision.template.json`.
 | `RD-0003-stuck-actionless-creeps` | `proposed` | stuck/actionless creeps | needs metric evidence; not accepted | #907, #906 |
 | `RD-V3-004-constructionNeglectPenalty` | `proposed` | `build=0` with construction backlog | needs offline/shadow replay plus future #924-compatible scorecard artifact; not accepted | #1024, #907, #906, #924 |
 | `RD-V3-005-onlineReliabilityRollbackPenalty` | `proposed` | online/shadow reliability rollback over threshold | candidate admission/#924 scorecard gate proposal only; not accepted | #1558, #907, #924, #1536, #1548 |
+| `RD-V3-006-workerTransportEfficiency` | `proposed` | low-load worker transport micro-hauls | hold for #1554 telemetry; no reward experiment accepted | #1555, #907, #906, #924 |
 | `RD-0005-expansion-without-spawn` | `proposed` | claim/expansion room with 0 spawns after grace window | needs metric evidence; not accepted | #907, #906 |
 | `RD-0006-metric-and-reliability-gates` | `proposed` | CPU, reliability, or missing metrics | needs metric evidence; not accepted | #907, #906 |
 
@@ -135,6 +136,23 @@ The JSON template is `docs/ops/templates/rl-reward-decision.template.json`.
 - Post-gate experiment plan: after #1536, #1548, and Tencent recurrence gates clear, create an offline/shadow experiment card comparing the incumbent baseline against these candidate families or successor family IDs, with `rollbackThresholdPct`, baseline/candidate reliability, reliability delta, #924 scorecard status, CPU/room safety, territory, resources, and kills recorded before any reward-shaping or scenario-weighting variant.
 - Safety flags: `liveEffect:false`, `officialMmoWrites:false`, and `officialMmoWritesAllowed:false`; this decision does not authorize learned-policy live writes or paid Tencent validation.
 - Acceptance status: not accepted; proposal only.
+
+### RD-V3-006-workerTransportEfficiency
+
+- State: `proposed`
+- Linked issue: https://github.com/lanyusea/screeps/issues/1555
+- Change-control reference: https://github.com/lanyusea/screeps/issues/907
+- Linked metric taxonomy: https://github.com/lanyusea/screeps/issues/906
+- Linked scorecard gate: https://github.com/lanyusea/screeps/issues/924
+- Telemetry prerequisite: issue #1554 or an equivalent artifact must first prove repeated avoidable low-load micro-hauls.
+- Evidence: the 2026-06-01 Gameplay Evolution Review observed transfer-task workers around 0-6/100 carried energy. The 2026-06-02 review archive `/root/.hermes/cron/output/c7b3dda8f1ac/2026-06-02_01-21-18.md` reported E29N56 low-load returns at 9/100 and 16/100 with reason `noReachableEnergy`, while E29N57 evidence was dominated by spawn-reservation/build-deadlock behavior.
+- Problem: low-load worker transport can waste travel, CPU, and worker ticks when the trip was avoidable, but current samples may be legitimate no-reachable-energy or dispatch-deadlock symptoms.
+- Possible Act choice: after telemetry proves avoidable cases, add a shadow/offline `worker_transport_efficiency` penalty for non-emergency trips below 20% carry load only when reachable energy existed and no higher-priority reliability, territory, controller-safety, or refill exception applies.
+- Decision: hold for telemetry. The evidence is sufficient for a #1555 reward-decision record, but insufficient for a reward experiment.
+- Validation metric: #1554/equivalent telemetry must expose low-load reason distribution, carried/free capacity, source reachability, target saturation, room buffer, spawn-reservation state, delivered energy per trip, CPU, and stuck/pathing impact. A later #924-compatible scorecard must show fewer avoidable low-load returns and higher delivered energy per trip or return load factor without regressions.
+- Rollback/rejection criteria: reject if most low-load returns are `noReachableEnergy`, emergency refill, controller safety, hostile retreat, or starvation exceptions; if spawn/refill latency, controller safety, construction progress, CPU, stuck/pathing, reliability, territory, or resources regress; or if any live official MMO learned-policy write/control surface is enabled.
+- Safety flags: `liveEffect:false`, `officialMmoWrites:false`, and `officialMmoWritesAllowed:false`; this decision does not authorize training, reward defaults, or learned-policy live writes.
+- Acceptance status: not accepted; proposal and telemetry hold only.
 
 ### RD-0005-expansion-without-spawn
 

--- a/docs/ops/rl-reward-decision-registry.md
+++ b/docs/ops/rl-reward-decision-registry.md
@@ -8,7 +8,7 @@ Canonical PDCA Act-loop registry for RL reward components, weights, penalties, v
 - **Previous reward-decision issue:** #907, closed after PR #961 merged
 - **Historical context:** #879 (quarantined; not an active reward-decision container or progress proxy)
 - **Machine-readable schema:** `docs/ops/rl-reward-schema.yaml` (v1, #967)
-- **Last updated:** 2026-06-01
+- **Last updated:** 2026-06-02
 
 ## Purpose
 
@@ -80,6 +80,8 @@ Source for the first three pending records: Gameplay Evolution Review output `20
 Source for `RD-V3-004-constructionNeglectPenalty`: issue #1024 and Gameplay Evolution Review 2026-05-14 08:07, following the #907 change-control framework and #924 as the source scorecard contract. A future generated #924-compatible scorecard artifact is still required for #1024 acceptance.
 
 Source for `RD-V3-005-onlineReliabilityRollbackPenalty`: issue #1558 and the 2026-05-31 Loop B policy online advantage rollback evidence. The artifact path is `runtime-artifacts/rl-control-loop/20260531T194800Z-policy-advantage.json`; newer policy advantage reports may reference the same rollback window. Runtime console ticks 1623386-1623404 disabled `construction-priority.territory-shadow.v1` and `expansion-remote.territory-shadow.v1` after reliability dropped about 17.0-18.4% versus the configured 10.0% rollback threshold. The first implementation recommendation is #924 candidate admission/scorecard gating only. Reward shaping and scenario weighting remain future shadow-only follow-ups.
+
+Source for `RD-V3-006-workerTransportEfficiency`: issue #1555, the 2026-06-01 Gameplay Evolution Review low-load transport observation, and the 2026-06-02 Gameplay Evolution Review archive `/root/.hermes/cron/output/c7b3dda8f1ac/2026-06-02_01-21-18.md`. The observed evidence includes transfer-task workers around 0-6/100 carried energy, E29N56 low-load returns at 9/100 and 16/100 with `noReachableEnergy`, and E29N57 spawn-reservation/build-deadlock context. This is enough to register a decision, but not enough to start a reward experiment; #1554 or equivalent telemetry must first separate avoidable micro-hauls from valid starvation, emergency, or dispatch-deadlock cases.
 
 ### RD-V3-001-workerLoadEfficiency
 
@@ -156,6 +158,21 @@ Source for `RD-V3-005-onlineReliabilityRollbackPenalty`: issue #1558 and the 202
 | `rollback_conditions` | Owner-independent rejection if reliability drop exceeds threshold; if #924 reliability fields or windows are missing; if candidate gains are bought with reliability, CPU, room survival, spawn survival, loop exception, telemetry freshness, territory, or resource regression; if reward shaping/scenario weighting is implemented before admission gating; if paid Tencent compute is required while #1536/#1548/Tencent recurrence gates are blocked; or if any live learned-policy write/control surface is enabled. |
 | `implementation_tracking` | Issue #1558; previous reward-decision container #907; candidate-vs-baseline scorecard contract #924; Tencent/compute blockers #1536 and #1548; decision JSON `docs/ops/examples/rl-reward-decisions/RD-V3-005-onlineReliabilityRollbackPenalty.json`; post-gate experiment card TBD after compute gates clear. |
 
+### RD-V3-006-workerTransportEfficiency
+
+| Field | Value |
+| --- | --- |
+| `decision_id` | `RD-V3-006-workerTransportEfficiency` |
+| `component_id` | `worker-transport-efficiency` |
+| `status` | `PROPOSED` |
+| `source` | Issue #1555; Gameplay Evolution Review 2026-06-01 low-load transfer-task observations; Gameplay Evolution Review 2026-06-02 01:21 archive `c7b3dda8f1ac`. |
+| `hypothesis` | A future offline/shadow `worker_transport_efficiency` penalty for avoidable low-load micro-hauls should increase useful delivered energy per trip and reduce wasted transfer/upgrade travel, but only when telemetry proves the low-load trip was avoidable and no emergency, starvation, controller-safety, hostile, or higher-priority gate applies. |
+| `current_metric_coverage` | Partial and insufficient for a reward experiment. Runtime summaries expose `workerEfficiency.lowLoadReturnCount`, `avoidableLowLoadReturnCount`, `lowLoadReturnReasons`, carried/free capacity samples, and trip energy summaries. The available E29N56 samples are tagged `noReachableEnergy`, and E29N57 evidence points at spawn-reservation/build-deadlock behavior. Validation still needs a per-trip join across source energy reachability, target saturation, task intent, path distance, room buffer state, spawn reservation state, delivered energy, CPU, and stuck/pathing outcome. |
+| `required_code_changes` | No reward implementation yet. First close the #1554 telemetry gap or produce an equivalent artifact that separates avoidable low-load micro-hauls from valid no-reachable-energy, emergency refill, controller-safety, hostile-retreat, and starvation cases. If that gate passes, add only an offline/shadow reward candidate with `liveEffect=false`, `officialMmoWrites=false`, and `officialMmoWritesAllowed=false`. |
+| `validation_criteria` | Telemetry readiness requires repeated low-load transport windows over at least 8 hours, reason distribution, carried/free capacity and capacity load factor, source reachability, target saturation, room buffer, spawn-reservation active/idle state, deliveredEnergyPerTrip or returnLoadFactor, CPU bucket, and stuck/pathing evidence. A later #924-compatible scorecard must show avoidable low-load return count decreases and deliveredEnergyPerTrip or returnLoadFactor improves versus baseline, with no regression to spawn/refill latency, controller safety, construction progress, CPU, reliability, territory, or resources. |
+| `rollback_conditions` | Reject if telemetry shows most low-load returns are `noReachableEnergy`, emergency refill, controller safety, hostile retreat, or genuine starvation exceptions; if fuller-load behavior delays urgent refill or controller safety; if it improves load factor by increasing path CPU, stuck ticks, pathFindingFailures, or hostile exposure; if #924 scorecard dimensions regress; or if any live learned-policy write/control surface is enabled. |
+| `implementation_tracking` | Issue #1555; previous reward-decision container #907; metric taxonomy link #906; candidate-vs-baseline scorecard contract #924; telemetry prerequisite #1554 or equivalent artifact; decision JSON `docs/ops/examples/rl-reward-decisions/RD-V3-006-workerTransportEfficiency.json`. Steward disposition: hold for telemetry, no reward experiment accepted. |
+
 ## Registered Components
 
 These are registry entries from v2 or this v3 Act container. `PROPOSED` entries are not accepted reward defaults.
@@ -167,6 +184,7 @@ These are registry entries from v2 or this v3 Act container. `PROPOSED` entries 
 | `stuck-penalty` | `RD-V3-003-verifyStuckPenalty` | penalty | `-0.02` per stuck tick candidate from v2 | reliability | `PROPOSED` | Pending v3 verification and possible implementation. |
 | `construction-neglect-penalty` | `RD-V3-004-constructionNeglectPenalty` | penalty | proportional to `constructionSiteCount`, coefficient TBD | resources | `PROPOSED` | Pending offline/shadow replay and future #924-compatible scorecard artifact; no live writes. |
 | `online-reliability-rollback-penalty` | `RD-V3-005-onlineReliabilityRollbackPenalty` | gate | fail closed above configured rollback threshold, currently 10.0% reliability drop | reliability | `PROPOSED` | Candidate admission/#924 scorecard gate proposal only; reward shaping and scenario weighting deferred to future shadow-only decisions; no paid Tencent while gates are blocked; no live writes. |
+| `worker-transport-efficiency` | `RD-V3-006-workerTransportEfficiency` | penalty | TBD; hold for telemetry | logistics | `PROPOSED` | Telemetry hold only; #1554/equivalent evidence required before any offline/shadow reward experiment; no live writes. |
 | `territory-expansion-reward` | TBD | reward | TBD | territory | `PROPOSED` | Placeholder from v2 linked to #958; outside the 2026-05-12 pending Act batch. |
 
 ## Integration Points
@@ -188,6 +206,8 @@ These are registry entries from v2 or this v3 Act container. `PROPOSED` entries 
 - #1024 - P1 construction-neglect reward decision for `build=0` with construction sites
 - #1536 - Tencent recurrence gate blocker
 - #1548 - Tencent validation/compute gate blocker
+- #1554 - Telemetry prerequisite for low-load transport attribution and deadlock reason coverage
+- #1555 - P1 worker transport efficiency reward decision
 - #1558 - P0 reliability rollback reward decision
 - #958 - Expansion initiation gap and territory reward placeholder
 - #959 - RL reward decision registry v2 issue

--- a/docs/ops/rl-reward-registry.yaml
+++ b/docs/ops/rl-reward-registry.yaml
@@ -7,7 +7,7 @@ schema:
   replaces:
     - "https://github.com/lanyusea/screeps/issues/907"
   created_date: "2026-05-13"
-  updated_date: "2026-05-16"
+  updated_date: "2026-06-02"
   status: "active"
   canonical_path: "docs/ops/rl-reward-registry.yaml"
 
@@ -230,6 +230,68 @@ entries:
       marketIntentControl: false
     decision_record: "docs/ops/examples/rl-reward-decisions/RD-V3-004-constructionNeglectPenalty.json"
     notes: "This proposed registry entry does not authorize live reward defaults or official MMO writes."
+
+  - id: "RRD-2026-06-02-1555"
+    component_name: "workerTransportEfficiency"
+    version: "v1"
+    change_type: "add"
+    component_kind: "penalty"
+    priority: "P1"
+    status: "proposed"
+    candidate_weight: null
+    candidate_formula: "pending telemetry; possible negative reward for avoidable low-load transport trips below 20% carry load"
+    candidate_predicate:
+      carried_load_ratio_lt: 0.20
+      task_kind_in:
+        - "transfer"
+        - "upgrade"
+      reachable_energy_at_acquisition: true
+      target_saturation_explains_low_load: false
+      no_reachable_energy_reason: false
+      emergency_refill_or_controller_safety: false
+      hostile_or_survival_exception: false
+    evidence:
+      - "Issue #1555: 2026-06-01 Gameplay Evolution Review observed transfer-task workers around 0-6/100 carried energy."
+      - "2026-06-02 Gameplay Evolution Review archive c7b3dda8f1ac: E29N56 reported low-load returns at 9/100 and 16/100 with reason noReachableEnergy and mean tripEnergy 12.5."
+      - "2026-06-02 Gameplay Evolution Review archive c7b3dda8f1ac: E29N57 evidence was dominated by spawn-reservation/build-deadlock behavior, so the reward signal must not mask dispatch bugs."
+    hypothesis: >
+      Penalizing avoidable low-load worker transport micro-hauls should improve
+      useful delivered energy per trip and reduce wasted movement/CPU after
+      higher-priority reliability, territory, emergency refill, controller
+      safety, and starvation exceptions are excluded.
+    validation_criteria:
+      - "Hold for #1554 telemetry or an equivalent artifact before any reward experiment."
+      - "Telemetry shows repeated avoidable low-load transport windows over at least 8 hours, not only noReachableEnergy, emergency, hostile, controller-safety, or genuine starvation exceptions."
+      - "Qualifying samples include carriedEnergy, freeCapacity, capacity/loadFactor, task kind, source energy reachability, target saturation, room buffer state, spawn-reservation active/idle state, deliveredEnergyPerTrip or returnLoadFactor, CPU bucket, stuck ticks, and pathFindingFailures."
+      - "A future #924-compatible candidate-vs-baseline scorecard shows avoidable low-load return count decreases and deliveredEnergyPerTrip or returnLoadFactor improves versus baseline."
+      - "Spawn/refill latency, controller downgrade safety, construction progress, CPU bucket, stuck/pathing metrics, reliability, territory, and resource metrics do not regress versus baseline."
+      - "Validation artifacts preserve liveEffect=false, officialMmoWrites=false, and officialMmoWritesAllowed=false."
+    rollback_condition:
+      - "Reject if most low-load returns are noReachableEnergy, emergency refill, controller safety, hostile retreat, or genuine starvation exceptions."
+      - "Reject or reduce if urgent refill, controller safety, construction progress, reliability, territory, resources, CPU, stuck/pathing, or hostile exposure regress versus baseline."
+      - "Reject if a dispatch deadlock such as idle spawn reservation is mislabeled as transport inefficiency."
+      - "Reject if any official MMO learned-policy write, Memory/RawMemory write, creep intent, spawn intent, construction intent, market intent, or other live control surface is enabled."
+    linked_github_issue: "https://github.com/lanyusea/screeps/issues/1555"
+    related_github_issues:
+      - "https://github.com/lanyusea/screeps/issues/907"
+      - "https://github.com/lanyusea/screeps/issues/906"
+      - "https://github.com/lanyusea/screeps/issues/924"
+      - "https://github.com/lanyusea/screeps/issues/1554"
+    proposed_by: "Issue #1555; Gameplay Evolution Review 2026-06-01 and 2026-06-02; RL Steward intake"
+    created_date: "2026-06-02"
+    scope: "telemetry hold; offline/shadow reward decision only; no learned-policy live official MMO control"
+    safety:
+      liveEffect: false
+      officialMmoWrites: false
+      officialMmoWritesAllowed: false
+      memoryWritesAllowed: false
+      rawMemoryWritesAllowed: false
+      rawCreepIntentControl: false
+      spawnIntentControl: false
+      constructionIntentControl: false
+      marketIntentControl: false
+    decision_record: "docs/ops/examples/rl-reward-decisions/RD-V3-006-workerTransportEfficiency.json"
+    notes: "HOLD_FOR_TELEMETRY. This proposed registry entry is not approval for training, reward defaults, or official MMO writes."
 
   - id: "RRD-2026-05-13-003"
     component_name: "lowLoadHarvestPenalty"

--- a/docs/ops/rl-reward-schema.yaml
+++ b/docs/ops/rl-reward-schema.yaml
@@ -5,9 +5,9 @@
 # Human-readable registry: docs/ops/rl-reward-decision-registry.md
 
 schema: 1
-source_issues: [967, 1024]
+source_issues: [967, 1024, 1555]
 historical_context_issues: [879]
-last_updated: "2026-05-16"
+last_updated: "2026-06-02"
 
 # Reward components are additive: total_reward = sum(component_reward * weight)
 components:
@@ -33,6 +33,42 @@ components:
     rollback:
       worker_count_lt: 3
       energy_buffer_unhealthy_consecutive: 2
+
+  # RD-V3-006 / #1555: Hold low-load worker transport penalty for telemetry
+  - component_id: worker-transport-efficiency
+    decision_id: RD-V3-006-workerTransportEfficiency
+    type: penalty
+    category: logistics
+    status: PROPOSED
+    candidate_weight: null
+    hypothesis: >
+      Penalizing avoidable low-load worker transport micro-hauls could improve
+      useful delivered energy per trip, but only after telemetry distinguishes
+      avoidable transfer/upgrade trips from noReachableEnergy, emergency,
+      controller-safety, hostile, starvation, and dispatch-deadlock exceptions.
+    predicate:
+      carried_load_ratio_lt: 0.20
+      reachable_energy_at_acquisition: true
+      target_saturation_explains_low_load: false
+      no_reachable_energy_reason: false
+      emergency_refill_or_controller_safety: false
+    validation:
+      status: HOLD_FOR_TELEMETRY
+      telemetry_issue: 1554
+      metric: deliveredEnergyPerTrip_or_returnLoadFactor
+      avoidable_low_load_return_count_decreases: true
+      minimum_duration_hours: 8
+      scorecard: "#924-compatible candidate-vs-baseline"
+      safety_flags:
+        liveEffect: false
+        officialMmoWrites: false
+        officialMmoWritesAllowed: false
+    rollback:
+      no_reachable_energy_majority: true
+      emergency_or_starvation_false_positive: true
+      spawn_refill_regression: true
+      controller_safety_regression: true
+      cpu_or_stuck_pathing_regression: true
 
   # RD-V3-002: Positive reward for >=1 build task when backlog exists
   - component_id: build-allocation-minimum

--- a/docs/ops/rl-reward-schema.yaml
+++ b/docs/ops/rl-reward-schema.yaml
@@ -48,10 +48,14 @@ components:
       controller-safety, hostile, starvation, and dispatch-deadlock exceptions.
     predicate:
       carried_load_ratio_lt: 0.20
+      task_kind_in:
+        - transfer
+        - upgrade
       reachable_energy_at_acquisition: true
       target_saturation_explains_low_load: false
       no_reachable_energy_reason: false
       emergency_refill_or_controller_safety: false
+      hostile_or_survival_exception: false
     validation:
       status: HOLD_FOR_TELEMETRY
       telemetry_issue: 1554


### PR DESCRIPTION
## Summary
- adds `RD-V3-006-workerTransportEfficiency` as a proposed RL reward-decision record for issue #1555
- records the disposition as a telemetry hold: no reward experiment, no reward default, no paid compute, and no official MMO learned-policy writes are authorized
- links the decision to #906/#907/#924 and the telemetry prerequisite #1554

Fixes #1555.

## Verification
- `git diff --check`
- `python3 scripts/validate_rl_reward_decisions.py docs/ops/examples/rl-reward-decisions` → `validated 6 RL reward decision JSON file(s)`
- `python3 -m pytest scripts/test_validate_rl_reward_decisions.py -q` → `4 passed`

## Issue closure gate
- [x] #1555: `RD-V3-006-workerTransportEfficiency` exists in the decision JSON, log, registry markdown, registry YAML, and schema YAML; the record explicitly chooses telemetry hold and preserves all live-control safety flags as false.

## Universal task Done gate
- [x] Task type: RL reward decision/change-control documentation and registry artifact.
- [x] Expected observable outcome / named deliverable: `docs/ops/examples/rl-reward-decisions/RD-V3-006-workerTransportEfficiency.json` plus matching registry/log/schema entries.
- [x] Non-goals / accepted substitutes: no reward-weight implementation, no training launch, no paid Tencent run, and no official MMO learned-policy control.
- [x] Verification evidence required before Done: validator passes on all reward decision JSON files, targeted pytest passes, and diff check is clean.
- [x] Project Evidence / Next action / Blocked by: Project item #1555 is updated by the scheduler with this PR/head evidence and telemetry-hold disposition.
- [x] Post-merge/deploy/runtime proof: PR merge SHA plus Project Done is the proof surface; official MMO deploy/runtime proof is irrelevant for a docs/ops-only reward-decision record.
- [x] Named deliverable proof: `RD-V3-006-workerTransportEfficiency.json` records `decisionDisposition=hold_for_telemetry`, `officialMmoWritesAllowed=false`, and #1554 as the telemetry gate.
