### PR TITLE
fix: preempt stale spawn refill for construction

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -31628,6 +31628,7 @@ var ADJACENT_ACTION_MOVE_RANGE = 1;
 var RANGED_WORK_MOVE_RANGE = 3;
 var EXACT_POSITION_MOVE_RANGE = 0;
 var MIN_HAULER_DROPPED_ENERGY = 25;
+var SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS2 = 2;
 var SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS2 = 300;
 function runWorker(creep) {
   var _a, _b;
@@ -31686,6 +31687,8 @@ function runWorker(creep) {
   } else if (shouldPreemptLowLoadReturnTaskForEnergyAcquisition(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptTransferTaskForControllerDowngradeGuard(creep, currentTask, selectedTask)) {
+    taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
+  } else if (shouldPreemptTransferTaskForConstructionBacklog(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptTransferTaskForBetterEnergySink(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
@@ -32649,6 +32652,29 @@ function shouldPreemptTransferTaskForControllerDowngradeGuard(creep, task, selec
     return false;
   }
   return isDowngradeGuardUpgradeTask(creep, selectedTask);
+}
+function shouldPreemptTransferTaskForConstructionBacklog(creep, task, selectedTask) {
+  if (task.type !== "transfer" || (selectedTask == null ? void 0 : selectedTask.type) !== "build" || isSameTask2(task, selectedTask)) {
+    return false;
+  }
+  if (getUsedTransferEnergy(creep) <= 0 || !hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep)) {
+    return false;
+  }
+  const currentTarget = getTaskTarget(task);
+  if (!isNonCriticalSpawnExtensionTransferTarget(currentTarget)) {
+    return false;
+  }
+  if (!shouldDeferSpawnReservationRefillForProductiveWork(creep, selectedTask)) {
+    return false;
+  }
+  const constructionSite = getTaskTarget(selectedTask);
+  return Boolean(constructionSite && canSpendWorkerEnergyOnConstructionSite(creep, constructionSite));
+}
+function hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep) {
+  return getRoomOwnedCreeps2(creep.room).filter((worker) => isProductiveSameRoomWorker2(worker, creep.room)).length >= SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS2;
+}
+function isNonCriticalSpawnExtensionTransferTarget(target) {
+  return getTransferSinkPriority(target) === 2;
 }
 function shouldPreemptSpendingTaskForControllerPressure(creep, task, selectedTask) {
   var _a;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -76,6 +76,7 @@ const ADJACENT_ACTION_MOVE_RANGE = 1;
 const RANGED_WORK_MOVE_RANGE = 3;
 const EXACT_POSITION_MOVE_RANGE = 0;
 const MIN_HAULER_DROPPED_ENERGY = 25;
+const SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS = 2;
 const SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS = 300;
 
 interface WorkerTaskSelectionNullLoopState {
@@ -181,6 +182,8 @@ export function runWorker(creep: Creep): void {
   } else if (shouldPreemptLowLoadReturnTaskForEnergyAcquisition(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptTransferTaskForControllerDowngradeGuard(creep, currentTask, selectedTask)) {
+    taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
+  } else if (shouldPreemptTransferTaskForConstructionBacklog(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptTransferTaskForBetterEnergySink(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
@@ -1701,6 +1704,43 @@ function shouldPreemptTransferTaskForControllerDowngradeGuard(
   }
 
   return isDowngradeGuardUpgradeTask(creep, selectedTask);
+}
+
+function shouldPreemptTransferTaskForConstructionBacklog(
+  creep: Creep,
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  if (task.type !== 'transfer' || selectedTask?.type !== 'build' || isSameTask(task, selectedTask)) {
+    return false;
+  }
+
+  if (getUsedTransferEnergy(creep) <= 0 || !hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep)) {
+    return false;
+  }
+
+  const currentTarget = getTaskTarget(task);
+  if (!isNonCriticalSpawnExtensionTransferTarget(currentTarget)) {
+    return false;
+  }
+
+  if (!shouldDeferSpawnReservationRefillForProductiveWork(creep, selectedTask)) {
+    return false;
+  }
+
+  const constructionSite = getTaskTarget(selectedTask) as ConstructionSite | null;
+  return Boolean(constructionSite && canSpendWorkerEnergyOnConstructionSite(creep, constructionSite));
+}
+
+function hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep: Creep): boolean {
+  return (
+    getRoomOwnedCreeps(creep.room).filter((worker) => isProductiveSameRoomWorker(worker, creep.room)).length >=
+    SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS
+  );
+}
+
+function isNonCriticalSpawnExtensionTransferTarget(target: unknown): boolean {
+  return getTransferSinkPriority(target) === 2;
 }
 
 function shouldPreemptSpendingTaskForControllerPressure(

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -5048,6 +5048,144 @@ describe('runWorker', () => {
     expect(upgradeController).not.toHaveBeenCalled();
   });
 
+  it('preempts a stale E29N57 spawn reservation transfer when stored energy can cover construction', () => {
+    const site = {
+      id: 'road-site1',
+      structureType: 'road',
+      progress: 935,
+      progressTotal: 5_000,
+      pos: { x: 22, y: 21, roomName: 'E29N57' } as RoomPosition
+    } as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 250 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+      }
+    } as unknown as StructureSpawn;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 1_332 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(10_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N57',
+      energyAvailable: 650,
+      energyCapacityAvailable: 1_800,
+      controller,
+      storage,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn, storage] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [spawn, storage];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const transfer = jest.fn();
+    const creep = {
+      name: 'LoadedBuilder',
+      memory: {
+        role: 'worker',
+        colony: 'E29N57',
+        task: { type: 'transfer', targetId: 'spawn1' as Id<AnyStoreStructure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 68 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 32 : 0))
+      },
+      room,
+      build,
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const recoveryWorker = {
+      name: 'RecoveryWorker',
+      memory: { role: 'worker', colony: 'E29N57' },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, recoveryWorker);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      economy: {
+        spawnEnergyReservation: {
+          updatedAt: 1_676_999,
+          rooms: {
+            E29N57: {
+              bodyCost: 1_800,
+              creepName: 'worker-E29N57-next',
+              reservedAt: 1_676_999,
+              reservedEnergy: 1_800,
+              role: 'worker',
+              roomName: 'E29N57',
+              updatedAt: 1_676_999
+            }
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { LoadedBuilder: creep, RecoveryWorker: recoveryWorker },
+      rooms: { E29N57: room },
+      time: 1_677_000,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        if (id === 'spawn1') {
+          return spawn;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'road-site1' });
+    expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+      currentTask: 'transfer',
+      baseSelectedTask: 'build',
+      selectedTask: 'build',
+      assignedTask: 'build'
+    });
+    expect(creep.memory.workerDispatchDiagnostic?.spawnReservationTask).toBeUndefined();
+    expect(build).toHaveBeenCalledWith(site);
+    expect(transfer).not.toHaveBeenCalled();
+  });
+
   it('keeps E29N57 source-container construction ahead of spawn reservation refill during low-bucket shedding', () => {
     const source = {
       id: 'source1',
@@ -5442,6 +5580,127 @@ describe('runWorker', () => {
       time: 124,
       getObjectById: jest.fn((id: string) => {
         if (id === 'site1') {
+          return site;
+        }
+
+        if (id === 'spawn1') {
+          return spawn;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(transfer).toHaveBeenCalledWith(spawn, 'energy');
+    expect(build).not.toHaveBeenCalled();
+  });
+
+  it('keeps an assigned spawn reservation transfer when E29N57 has only one productive worker', () => {
+    const site = {
+      id: 'road-site1',
+      structureType: 'road',
+      progress: 935,
+      progressTotal: 5_000
+    } as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(250),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      }
+    } as unknown as StructureSpawn;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(1_332),
+        getFreeCapacity: jest.fn().mockReturnValue(10_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N57',
+      energyAvailable: 650,
+      energyCapacityAvailable: 1_800,
+      controller,
+      storage,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn, storage] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [spawn, storage];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn();
+    const transfer = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'OnlyWorker',
+      memory: {
+        role: 'worker',
+        colony: 'E29N57',
+        task: { type: 'transfer', targetId: 'spawn1' as Id<AnyStoreStructure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(68),
+        getFreeCapacity: jest.fn().mockReturnValue(32)
+      },
+      room,
+      build,
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    roomCreeps.push(creep);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      economy: {
+        spawnEnergyReservation: {
+          updatedAt: 1_676_999,
+          rooms: {
+            E29N57: {
+              bodyCost: 1_800,
+              creepName: 'worker-E29N57-next',
+              reservedAt: 1_676_999,
+              reservedEnergy: 1_800,
+              role: 'worker',
+              roomName: 'E29N57',
+              updatedAt: 1_676_999
+            }
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { OnlyWorker: creep },
+      rooms: { E29N57: room },
+      time: 1_677_000,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
           return site;
         }
 


### PR DESCRIPTION
## Summary
- Adds a spawn-reservation preemption path so a loaded worker can switch from non-critical spawn/extension refill to selected construction when the room has productive-worker coverage and surplus energy.
- Adds E29N57 recurrence tests for the construction-preemption path and for the single-productive-worker safety hold.
- Rebuilds the Screeps bundle artifact.

## Verification
- Controller-side `git diff --check` from `/root/screeps-worktrees/e29n57-construction-stall-1603` passed.
- Controller-side `npm run typecheck` from `prod/` passed.
- Controller-side `npm test -- --runInBand` from `prod/` passed: 103 suites / 2167 tests.
- Controller-side `npm run build` from `prod/` passed at 2026-06-02T00:55:52Z.

## Universal task Done gate
- [x] Task type: code bugfix for Territory/Economy worker dispatch behavior.
- [x] Expected observable outcome / named deliverable: loaded E29N57 workers can leave stale non-critical spawn refill and perform construction when selected build work is safe under spawn-reservation coverage rules.
- [x] Non-goals / accepted substitutes: no owner action, no RL reward change, no reopened #1553/#1590 window, and no deployment in this PR.
- [x] Verification evidence required before Done: local diff-check, typecheck, Jest, and bundle build listed above; runtime acceptance remains represented by issue #1603 without a closing keyword.
- [x] Project Evidence / Next action / Blocked by: issue #1603 and this PR are Project-tracked with current implementation/verification evidence and a merge/review-gate next action.
- [x] Post-merge/deploy/runtime proof: issue #1603 remains the runtime validation tracker; the required MMO proof is a fresh runtime-summary capture showing E29N57 `taskCounts.build > 0`, `buildCarriedEnergy > 0`, or `pendingBuildProgress < 4065`.
- [x] Named deliverable proof: commit `2d167db45a52dda7cdf98351ba2b669363a0c57a` modifies `workerRunner.ts`, `workerRunner.test.ts`, and `dist/main.js`.

## Issue linkage
Related to issue #1603. This PR intentionally avoids a closing keyword because #1603 includes deployment/runtime acceptance criteria.
