### PR TITLE
gameplay: unblock construction under spawn reserve

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -25753,6 +25753,17 @@ function selectHeuristicWorkerTask(creep) {
   }
   const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
   const constructionReservationContext = constructionSites.length > 0 ? createConstructionReservationContext(creep.room) : createEmptyConstructionReservationContext();
+  let cachedShouldYieldSpawnReservationToConstructionBacklog;
+  const getShouldYieldSpawnReservationToConstructionBacklog = () => {
+    if (cachedShouldYieldSpawnReservationToConstructionBacklog === void 0) {
+      cachedShouldYieldSpawnReservationToConstructionBacklog = shouldYieldSpawnReservationToConstructionBacklog(
+        creep,
+        constructionSites,
+        constructionReservationContext
+      );
+    }
+    return cachedShouldYieldSpawnReservationToConstructionBacklog;
+  };
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
   const ownedSpawnCount = getOwnedSpawnCount(creep.room);
   const hasMissingSpawnRecoveryConstructionSite = ownedSpawnCount === 0 && constructionSites.some(isSpawnConstructionSite);
@@ -25806,7 +25817,8 @@ function selectHeuristicWorkerTask(creep) {
       creep,
       spawnOrExtensionEnergySink,
       constructionSites,
-      constructionReservationContext
+      constructionReservationContext,
+      getShouldYieldSpawnReservationToConstructionBacklog
     );
     if (productiveTaskBeforeIdleRefill) {
       return applyMinimumUsefulLoadPolicy(creep, productiveTaskBeforeIdleRefill);
@@ -25947,7 +25959,7 @@ function selectHeuristicWorkerTask(creep) {
   if (uncoveredRoutineRampartMaintenanceTask) {
     return applyMinimumUsefulLoadPolicy(creep, uncoveredRoutineRampartMaintenanceTask);
   }
-  if (shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) && !shouldYieldSpawnReservationToConstructionBacklog(creep, constructionSites, constructionReservationContext)) {
+  if (shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) && !getShouldYieldSpawnReservationToConstructionBacklog()) {
     return null;
   }
   const controllerSustainBarrierMaintenanceTask = selectControllerSustainBarrierMaintenanceTask(
@@ -26056,7 +26068,7 @@ function selectHeuristicWorkerTask(creep) {
   if (energySurplusStorageTask) {
     return energySurplusStorageTask;
   }
-  if (shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) && !shouldYieldSpawnReservationToConstructionBacklog(creep, constructionSites, constructionReservationContext)) {
+  if (shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) && !getShouldYieldSpawnReservationToConstructionBacklog()) {
     return null;
   }
   if (controllerSigningTask && !bootstrapNonCriticalWorkSuppressed) {
@@ -28153,16 +28165,14 @@ function selectReadyFollowUpProductiveEnergySinkTask(creep, capacityConstruction
   );
   return criticalRoadConstructionSite ? { type: "build", targetId: criticalRoadConstructionSite.id } : null;
 }
-function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(creep, spawnOrExtensionEnergySink, constructionSites, constructionReservationContext) {
+function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(creep, spawnOrExtensionEnergySink, constructionSites, constructionReservationContext, getShouldYieldSpawnReservationToConstructionBacklog) {
   const deferForHealthyBuffer = shouldDeferIdleSpawnExtensionRefillForHealthyBuffer(
     creep,
     spawnOrExtensionEnergySink
   );
   const deferForBoundedConstruction = !deferForHealthyBuffer && shouldDeferIdleSpawnExtensionRefillForBoundedConstruction(
-    creep,
     spawnOrExtensionEnergySink,
-    constructionSites,
-    constructionReservationContext
+    getShouldYieldSpawnReservationToConstructionBacklog
   );
   if (!deferForHealthyBuffer && !deferForBoundedConstruction) {
     return null;
@@ -28187,8 +28197,8 @@ function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(creep, spawnOr
 function shouldDeferIdleSpawnExtensionRefillForHealthyBuffer(creep, spawnOrExtensionEnergySink) {
   return spawnOrExtensionEnergySink !== null && !hasActiveSpawningSpawn(creep.room) && hasHealthyRoomEnergyBuffer(creep.room);
 }
-function shouldDeferIdleSpawnExtensionRefillForBoundedConstruction(creep, spawnOrExtensionEnergySink, constructionSites, constructionReservationContext) {
-  return spawnOrExtensionEnergySink !== null && shouldYieldSpawnReservationToConstructionBacklog(creep, constructionSites, constructionReservationContext);
+function shouldDeferIdleSpawnExtensionRefillForBoundedConstruction(spawnOrExtensionEnergySink, getShouldYieldSpawnReservationToConstructionBacklog) {
+  return spawnOrExtensionEnergySink !== null && getShouldYieldSpawnReservationToConstructionBacklog();
 }
 function shouldYieldSpawnReservationToConstructionBacklog(creep, constructionSites, constructionReservationContext) {
   if (getUsedEnergy2(creep) <= 0 || getActiveWorkParts2(creep) <= 0 || constructionSites.length === 0 || hasEmergencySpawnExtensionRefillDemand(creep)) {
@@ -28197,10 +28207,18 @@ function shouldYieldSpawnReservationToConstructionBacklog(creep, constructionSit
   if (!hasMinimumProductiveWorkerCoverageForBoundedConstruction(creep)) {
     return false;
   }
-  if (hasSameRoomWorkerAssignedToTask(creep.room, creep, "build")) {
+  if (hasOtherSameRoomBuildCoverageWorker(creep)) {
     return false;
   }
   return hasSpendableConstructionBacklogFromSites(creep, constructionSites, constructionReservationContext);
+}
+function hasOtherSameRoomBuildCoverageWorker(creep) {
+  return getSameRoomLoadedWorkers(creep).some(
+    (worker) => {
+      var _a, _b;
+      return !isSameCreep(worker, creep) && ((_b = (_a = worker.memory) == null ? void 0 : _a.task) == null ? void 0 : _b.type) === "build" && getActiveWorkParts2(worker) > 0;
+    }
+  );
 }
 function hasMinimumProductiveWorkerCoverageForBoundedConstruction(creep) {
   return getRoomOwnedCreeps(creep.room).filter((worker) => isProductiveSameRoomWorker(worker, creep.room)).length >= SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -25370,7 +25370,6 @@ var MAX_HARVEST_PATH_OPS = 2e3;
 var LOW_LOAD_YIELD_SWITCH_MIN_IMPROVEMENT_RATIO = 1.1;
 var LOW_LOAD_YIELD_SWITCH_MIN_ABSOLUTE_GAIN = 0.25;
 var SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS = 2;
-var SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS = 300;
 var nearTermSpawnExtensionRefillReserveCache = null;
 var interRoomLiveTransferCandidateCache = null;
 var interRoomHaulReservationCache = null;
@@ -25948,7 +25947,7 @@ function selectHeuristicWorkerTask(creep) {
   if (uncoveredRoutineRampartMaintenanceTask) {
     return applyMinimumUsefulLoadPolicy(creep, uncoveredRoutineRampartMaintenanceTask);
   }
-  if (shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep)) {
+  if (shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) && !shouldYieldSpawnReservationToConstructionBacklog(creep, constructionSites, constructionReservationContext)) {
     return null;
   }
   const controllerSustainBarrierMaintenanceTask = selectControllerSustainBarrierMaintenanceTask(
@@ -26057,7 +26056,7 @@ function selectHeuristicWorkerTask(creep) {
   if (energySurplusStorageTask) {
     return energySurplusStorageTask;
   }
-  if (shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep)) {
+  if (shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) && !shouldYieldSpawnReservationToConstructionBacklog(creep, constructionSites, constructionReservationContext)) {
     return null;
   }
   if (controllerSigningTask && !bootstrapNonCriticalWorkSuppressed) {
@@ -26580,6 +26579,9 @@ function hasSpendableConstructionBacklog(creep) {
     return false;
   }
   const constructionReservationContext = createConstructionReservationContext(creep.room);
+  return hasSpendableConstructionBacklogFromSites(creep, constructionSites, constructionReservationContext);
+}
+function hasSpendableConstructionBacklogFromSites(creep, constructionSites, constructionReservationContext) {
   const priorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
   return constructionSites.some(
     (site) => site.my !== false && hasUnreservedConstructionProgress(creep, site, constructionReservationContext) && canSpendCreepEnergyOnConstructionSite(creep, site, priorityContext)
@@ -28159,7 +28161,8 @@ function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(creep, spawnOr
   const deferForBoundedConstruction = !deferForHealthyBuffer && shouldDeferIdleSpawnExtensionRefillForBoundedConstruction(
     creep,
     spawnOrExtensionEnergySink,
-    constructionSites
+    constructionSites,
+    constructionReservationContext
   );
   if (!deferForHealthyBuffer && !deferForBoundedConstruction) {
     return null;
@@ -28184,11 +28187,11 @@ function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(creep, spawnOr
 function shouldDeferIdleSpawnExtensionRefillForHealthyBuffer(creep, spawnOrExtensionEnergySink) {
   return spawnOrExtensionEnergySink !== null && !hasActiveSpawningSpawn(creep.room) && hasHealthyRoomEnergyBuffer(creep.room);
 }
-function shouldDeferIdleSpawnExtensionRefillForBoundedConstruction(creep, spawnOrExtensionEnergySink, constructionSites) {
-  return spawnOrExtensionEnergySink !== null && !hasActiveSpawningSpawn(creep.room) && constructionSites.length > 0 && hasSafeStoredEnergyForBoundedConstruction(creep);
+function shouldDeferIdleSpawnExtensionRefillForBoundedConstruction(creep, spawnOrExtensionEnergySink, constructionSites, constructionReservationContext) {
+  return spawnOrExtensionEnergySink !== null && shouldYieldSpawnReservationToConstructionBacklog(creep, constructionSites, constructionReservationContext);
 }
-function hasSafeStoredEnergyForBoundedConstruction(creep) {
-  if (!checkEnergyBufferForStoredConstructionSpending(creep.room)) {
+function shouldYieldSpawnReservationToConstructionBacklog(creep, constructionSites, constructionReservationContext) {
+  if (getUsedEnergy2(creep) <= 0 || getActiveWorkParts2(creep) <= 0 || constructionSites.length === 0 || hasEmergencySpawnExtensionRefillDemand(creep)) {
     return false;
   }
   if (!hasMinimumProductiveWorkerCoverageForBoundedConstruction(creep)) {
@@ -28197,7 +28200,7 @@ function hasSafeStoredEnergyForBoundedConstruction(creep) {
   if (hasSameRoomWorkerAssignedToTask(creep.room, creep, "build")) {
     return false;
   }
-  return getRoomStoredEnergyAvailableForConstruction(creep.room) >= SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS;
+  return hasSpendableConstructionBacklogFromSites(creep, constructionSites, constructionReservationContext);
 }
 function hasMinimumProductiveWorkerCoverageForBoundedConstruction(creep) {
   return getRoomOwnedCreeps(creep.room).filter((worker) => isProductiveSameRoomWorker(worker, creep.room)).length >= SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS;
@@ -31629,7 +31632,7 @@ var RANGED_WORK_MOVE_RANGE = 3;
 var EXACT_POSITION_MOVE_RANGE = 0;
 var MIN_HAULER_DROPPED_ENERGY = 25;
 var SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS2 = 2;
-var SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS2 = 300;
+var SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS = 300;
 function runWorker(creep) {
   var _a, _b;
   if (runControllerSustainMovement(creep)) {
@@ -32040,9 +32043,9 @@ function selectSpawnEnergyReservationRefillTask(creep, currentTask, selectedTask
   return targetId.length > 0 ? { type: "transfer", targetId } : null;
 }
 function shouldDeferSpawnReservationRefillForProductiveWork(creep, selectedTask) {
-  return ((selectedTask == null ? void 0 : selectedTask.type) === "build" || (selectedTask == null ? void 0 : selectedTask.type) === "repair") && !hasActiveSpawningSpawn2(creep.room) && (hasHealthyRoomEnergyBuffer2(creep.room) || hasSafeStoredEnergyForBoundedConstruction2(creep, selectedTask));
+  return ((selectedTask == null ? void 0 : selectedTask.type) === "build" || (selectedTask == null ? void 0 : selectedTask.type) === "repair") && !hasActiveSpawningSpawn2(creep.room) && (hasHealthyRoomEnergyBuffer2(creep.room) || hasSafeStoredEnergyForBoundedConstruction(creep, selectedTask));
 }
-function hasSafeStoredEnergyForBoundedConstruction2(creep, selectedTask) {
+function hasSafeStoredEnergyForBoundedConstruction(creep, selectedTask) {
   if ((selectedTask == null ? void 0 : selectedTask.type) !== "build") {
     return false;
   }
@@ -32057,7 +32060,7 @@ function hasSafeStoredEnergyForBoundedConstruction2(creep, selectedTask) {
   if (hasOtherSameRoomBuildAssignment(creep)) {
     return false;
   }
-  return storedEnergy >= SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS2;
+  return storedEnergy >= SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS;
 }
 function hasOtherSameRoomBuildAssignment(creep) {
   return getRoomOwnedCreeps2(creep.room).some((worker) => {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -42,7 +42,6 @@ import {
   checkEnergyBufferForStoredConstructionSpending,
   getEffectiveRoomEnergyBufferThreshold,
   getConstructionSpendingEnergyThreshold,
-  getRoomStoredEnergyAvailableForConstruction,
   getStorageEnergyAvailableForWithdrawal,
   getStorageEnergyReserveThreshold,
   hasMinimumWorkerSpawnEnergyForConstruction,
@@ -154,7 +153,6 @@ const MAX_HARVEST_PATH_OPS = 2_000;
 const LOW_LOAD_YIELD_SWITCH_MIN_IMPROVEMENT_RATIO = 1.1;
 const LOW_LOAD_YIELD_SWITCH_MIN_ABSOLUTE_GAIN = 0.25;
 const SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS = 2;
-const SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS = 300;
 
 type RepairableWorkerStructure =
   | StructureRoad
@@ -1035,7 +1033,10 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     return applyMinimumUsefulLoadPolicy(creep, uncoveredRoutineRampartMaintenanceTask);
   }
 
-  if (shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep)) {
+  if (
+    shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) &&
+    !shouldYieldSpawnReservationToConstructionBacklog(creep, constructionSites, constructionReservationContext)
+  ) {
     return null;
   }
 
@@ -1175,7 +1176,10 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     return energySurplusStorageTask;
   }
 
-  if (shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep)) {
+  if (
+    shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) &&
+    !shouldYieldSpawnReservationToConstructionBacklog(creep, constructionSites, constructionReservationContext)
+  ) {
     return null;
   }
 
@@ -2027,6 +2031,14 @@ function hasSpendableConstructionBacklog(creep: Creep): boolean {
   }
 
   const constructionReservationContext = createConstructionReservationContext(creep.room);
+  return hasSpendableConstructionBacklogFromSites(creep, constructionSites, constructionReservationContext);
+}
+
+function hasSpendableConstructionBacklogFromSites(
+  creep: Creep,
+  constructionSites: ConstructionSite[],
+  constructionReservationContext: ConstructionReservationContext
+): boolean {
   const priorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
   return constructionSites.some(
     (site) =>
@@ -4505,7 +4517,8 @@ function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(
     shouldDeferIdleSpawnExtensionRefillForBoundedConstruction(
       creep,
       spawnOrExtensionEnergySink,
-      constructionSites
+      constructionSites,
+      constructionReservationContext
     );
 
   if (!deferForHealthyBuffer && !deferForBoundedConstruction) {
@@ -4546,18 +4559,26 @@ function shouldDeferIdleSpawnExtensionRefillForHealthyBuffer(
 function shouldDeferIdleSpawnExtensionRefillForBoundedConstruction(
   creep: Creep,
   spawnOrExtensionEnergySink: StructureSpawn | StructureExtension | null,
-  constructionSites: ConstructionSite[]
+  constructionSites: ConstructionSite[],
+  constructionReservationContext: ConstructionReservationContext
 ): boolean {
   return (
     spawnOrExtensionEnergySink !== null &&
-    !hasActiveSpawningSpawn(creep.room) &&
-    constructionSites.length > 0 &&
-    hasSafeStoredEnergyForBoundedConstruction(creep)
+    shouldYieldSpawnReservationToConstructionBacklog(creep, constructionSites, constructionReservationContext)
   );
 }
 
-function hasSafeStoredEnergyForBoundedConstruction(creep: Creep): boolean {
-  if (!checkEnergyBufferForStoredConstructionSpending(creep.room)) {
+function shouldYieldSpawnReservationToConstructionBacklog(
+  creep: Creep,
+  constructionSites: ConstructionSite[],
+  constructionReservationContext: ConstructionReservationContext
+): boolean {
+  if (
+    getUsedEnergy(creep) <= 0 ||
+    getActiveWorkParts(creep) <= 0 ||
+    constructionSites.length === 0 ||
+    hasEmergencySpawnExtensionRefillDemand(creep)
+  ) {
     return false;
   }
 
@@ -4569,10 +4590,7 @@ function hasSafeStoredEnergyForBoundedConstruction(creep: Creep): boolean {
     return false;
   }
 
-  return (
-    getRoomStoredEnergyAvailableForConstruction(creep.room) >=
-    SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS
-  );
+  return hasSpendableConstructionBacklogFromSites(creep, constructionSites, constructionReservationContext);
 }
 
 function hasMinimumProductiveWorkerCoverageForBoundedConstruction(creep: Creep): boolean {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -804,6 +804,18 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     constructionSites.length > 0
       ? createConstructionReservationContext(creep.room)
       : createEmptyConstructionReservationContext();
+  let cachedShouldYieldSpawnReservationToConstructionBacklog: boolean | undefined;
+  const getShouldYieldSpawnReservationToConstructionBacklog = (): boolean => {
+    if (cachedShouldYieldSpawnReservationToConstructionBacklog === undefined) {
+      cachedShouldYieldSpawnReservationToConstructionBacklog = shouldYieldSpawnReservationToConstructionBacklog(
+        creep,
+        constructionSites,
+        constructionReservationContext
+      );
+    }
+
+    return cachedShouldYieldSpawnReservationToConstructionBacklog;
+  };
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
   const ownedSpawnCount = getOwnedSpawnCount(creep.room);
   const hasMissingSpawnRecoveryConstructionSite =
@@ -869,7 +881,8 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
       creep,
       spawnOrExtensionEnergySink,
       constructionSites,
-      constructionReservationContext
+      constructionReservationContext,
+      getShouldYieldSpawnReservationToConstructionBacklog
     );
     if (productiveTaskBeforeIdleRefill) {
       return applyMinimumUsefulLoadPolicy(creep, productiveTaskBeforeIdleRefill);
@@ -1035,7 +1048,7 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
 
   if (
     shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) &&
-    !shouldYieldSpawnReservationToConstructionBacklog(creep, constructionSites, constructionReservationContext)
+    !getShouldYieldSpawnReservationToConstructionBacklog()
   ) {
     return null;
   }
@@ -1178,7 +1191,7 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
 
   if (
     shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) &&
-    !shouldYieldSpawnReservationToConstructionBacklog(creep, constructionSites, constructionReservationContext)
+    !getShouldYieldSpawnReservationToConstructionBacklog()
   ) {
     return null;
   }
@@ -4506,7 +4519,8 @@ function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(
   creep: Creep,
   spawnOrExtensionEnergySink: StructureSpawn | StructureExtension | null,
   constructionSites: ConstructionSite[],
-  constructionReservationContext: ConstructionReservationContext
+  constructionReservationContext: ConstructionReservationContext,
+  getShouldYieldSpawnReservationToConstructionBacklog: () => boolean
 ): ProductiveEnergySinkTask | null {
   const deferForHealthyBuffer = shouldDeferIdleSpawnExtensionRefillForHealthyBuffer(
     creep,
@@ -4515,10 +4529,8 @@ function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(
   const deferForBoundedConstruction =
     !deferForHealthyBuffer &&
     shouldDeferIdleSpawnExtensionRefillForBoundedConstruction(
-      creep,
       spawnOrExtensionEnergySink,
-      constructionSites,
-      constructionReservationContext
+      getShouldYieldSpawnReservationToConstructionBacklog
     );
 
   if (!deferForHealthyBuffer && !deferForBoundedConstruction) {
@@ -4557,14 +4569,12 @@ function shouldDeferIdleSpawnExtensionRefillForHealthyBuffer(
 }
 
 function shouldDeferIdleSpawnExtensionRefillForBoundedConstruction(
-  creep: Creep,
   spawnOrExtensionEnergySink: StructureSpawn | StructureExtension | null,
-  constructionSites: ConstructionSite[],
-  constructionReservationContext: ConstructionReservationContext
+  getShouldYieldSpawnReservationToConstructionBacklog: () => boolean
 ): boolean {
   return (
     spawnOrExtensionEnergySink !== null &&
-    shouldYieldSpawnReservationToConstructionBacklog(creep, constructionSites, constructionReservationContext)
+    getShouldYieldSpawnReservationToConstructionBacklog()
   );
 }
 
@@ -4586,11 +4596,20 @@ function shouldYieldSpawnReservationToConstructionBacklog(
     return false;
   }
 
-  if (hasSameRoomWorkerAssignedToTask(creep.room, creep, 'build')) {
+  if (hasOtherSameRoomBuildCoverageWorker(creep)) {
     return false;
   }
 
   return hasSpendableConstructionBacklogFromSites(creep, constructionSites, constructionReservationContext);
+}
+
+function hasOtherSameRoomBuildCoverageWorker(creep: Creep): boolean {
+  return getSameRoomLoadedWorkers(creep).some(
+    (worker) =>
+      !isSameCreep(worker, creep) &&
+      worker.memory?.task?.type === 'build' &&
+      getActiveWorkParts(worker) > 0
+  );
 }
 
 function hasMinimumProductiveWorkerCoverageForBoundedConstruction(creep: Creep): boolean {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -7806,6 +7806,86 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
   });
 
+  it('keeps safe construction available while active spawn completion reserve still needs refill energy', () => {
+    const spawningSpawn = makeEnergySinkWithEnergy('spawn-busy', 'spawn' as StructureConstant, 300, 0, {
+      spawning: { remainingTime: 10 }
+    });
+    const refillExtension = makeEnergySinkWithEnergy('extension-low', 'extension' as StructureConstant, 0, 50);
+    const roadSite = { id: 'road-site1', my: true, structureType: 'road' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [roadSite],
+      controller,
+      energyAvailable: 500,
+      energyCapacityAvailable: 550,
+      myStructures: [spawningSpawn as AnyOwnedStructure, refillExtension as AnyOwnedStructure]
+    });
+    const reserveWorker = makeRefillReserveWorker(room, 'ReserveA', 50, 1);
+    const creep = makeRefillReserveWorker(room, 'Builder', 50, 9);
+    setGameCreeps({ ReserveA: reserveWorker, Builder: creep });
+
+    expect(estimateNearTermSpawnExtensionRefillReserve(room)).toBe(550);
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
+  });
+
+  it('keeps safe construction available when full spawn energy is still reserved for near-term spawn completion', () => {
+    const spawningSpawn = makeEnergySinkWithEnergy('spawn-busy', 'spawn' as StructureConstant, 300, 0, {
+      spawning: { remainingTime: 10 }
+    });
+    const fullExtension = makeEnergySinkWithEnergy('extension-full', 'extension' as StructureConstant, 50, 0);
+    const roadSite = { id: 'road-site1', my: true, structureType: 'road' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [roadSite],
+      controller,
+      energyAvailable: 550,
+      energyCapacityAvailable: 550,
+      myStructures: [spawningSpawn as AnyOwnedStructure, fullExtension as AnyOwnedStructure]
+    });
+    const reserveWorker = makeRefillReserveWorker(room, 'ReserveA', 50, 1);
+    const creep = makeRefillReserveWorker(room, 'Builder', 50, 9);
+    setGameCreeps({ ReserveA: reserveWorker, Builder: creep });
+
+    expect(estimateNearTermSpawnExtensionRefillReserve(room)).toBe(550);
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
+  });
+
+  it('keeps emergency spawn refill ahead of construction during active spawn completion reserve', () => {
+    const criticalSpawningSpawn = makeEnergySinkWithEnergy('spawn-critical', 'spawn' as StructureConstant, 100, 50, {
+      spawning: { remainingTime: 10 }
+    });
+    const roadSite = { id: 'road-site1', my: true, structureType: 'road' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [roadSite],
+      controller,
+      energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+      energyCapacityAvailable: 550,
+      myStructures: [criticalSpawningSpawn as AnyOwnedStructure]
+    });
+    const reserveWorker = makeRefillReserveWorker(room, 'ReserveA', 50, 1);
+    const creep = makeRefillReserveWorker(room, 'Builder', 50, 9);
+    setGameCreeps({ ReserveA: reserveWorker, Builder: creep });
+
+    expect(estimateNearTermSpawnExtensionRefillReserve(room)).toBe(550);
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-critical' });
+  });
+
   it('keeps emergency spawn refill before surplus spending while a near-term reserve is active', () => {
     const spawningSpawn = {
       id: 'spawn1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -7698,6 +7698,102 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toBeNull();
   });
 
+  it('reuses the construction-yield decision across idle-refill and spawn-reserve guards', () => {
+    const refillExtension = makeEnergySinkWithEnergy('extension-low', 'extension' as StructureConstant, 0, 50);
+    const spawnSite = {
+      id: 'spawn-site1',
+      my: true,
+      pos: makeRoomPosition(30, 30),
+      structureType: 'spawn'
+    } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [spawnSite],
+      controller,
+      energyAvailable: 250,
+      energyCapacityAvailable: 550,
+      myStructures: [refillExtension as AnyOwnedStructure]
+    });
+    const getActiveBodyparts = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'ReserveBuilder',
+      memory: { role: 'worker' },
+      getActiveBodyparts,
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'spawn-site1' ? 99 : 1)) },
+      room
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { ReserveBuilder: creep },
+      time: 800
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      economy: {
+        spawnEnergyReservation: {
+          updatedAt: 800,
+          rooms: {
+            W1N1: {
+              bodyCost: 550,
+              creepName: 'NextWorker',
+              reservedAt: 800,
+              reservedEnergy: 550,
+              role: 'worker',
+              roomName: 'W1N1',
+              updatedAt: 800
+            }
+          }
+        }
+      }
+    };
+
+    expect(estimateNearTermSpawnExtensionRefillReserve(room)).toBe(300);
+    expect(selectWorkerTask(creep)).toBeNull();
+    expect(getActiveBodyparts.mock.calls.filter(([part]) => part === 'work')).toHaveLength(1);
+  });
+
+  it.each([
+    ['no carried energy', 0, 1],
+    ['no active WORK', 50, 0]
+  ] as const)('keeps construction available when an assigned builder has %s', (_label, assignedEnergy, activeWorkParts) => {
+    const spawningSpawn = makeEnergySinkWithEnergy('spawn-busy', 'spawn' as StructureConstant, 300, 0, {
+      spawning: { remainingTime: 10 }
+    });
+    const refillExtension = makeEnergySinkWithEnergy('extension-low', 'extension' as StructureConstant, 0, 50);
+    const roadSite = { id: 'road-site1', my: true, structureType: 'road' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [roadSite],
+      controller,
+      energyAvailable: 500,
+      energyCapacityAvailable: 550,
+      myStructures: [spawningSpawn as AnyOwnedStructure, refillExtension as AnyOwnedStructure]
+    });
+    const reserveWorker = makeRefillReserveWorker(room, 'ReserveA', 50, 1);
+    const assignedBuilder = {
+      name: 'AssignedBuilder',
+      memory: { role: 'worker', task: { type: 'build', targetId: 'road-site1' } },
+      getActiveBodyparts: jest.fn().mockReturnValue(activeWorkParts),
+      store: { getUsedCapacity: jest.fn().mockReturnValue(assignedEnergy) },
+      pos: { getRangeTo: jest.fn().mockReturnValue(2) },
+      room
+    } as unknown as Creep;
+    const creep = makeRefillReserveWorker(room, 'Builder', 50, 9);
+    setGameCreeps({ ReserveA: reserveWorker, AssignedBuilder: assignedBuilder, Builder: creep });
+
+    expect(estimateNearTermSpawnExtensionRefillReserve(room)).toBe(550);
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
+  });
+
   it('keeps construction available when other workers cover near-term refill reserve', () => {
     const busyFullSpawn = {
       id: 'spawn-busy',


### PR DESCRIPTION
## Summary

- Implements the #1606 behavior repair for over-conservative `spawn_reserving_energy` construction routing.
- Lets construction and upgrade work proceed when usable room energy is available while preserving emergency spawn-reserve behavior.
- Adds focused worker-task regression tests and refreshes the Screeps bundle artifact.

Related issue: #1606

## Verification

Controller-side verification on the reconciled worktree:

```text
git diff --check
cd prod && npm run typecheck
cd prod && npm test -- --runInBand  # 103 suites / 2170 tests passed
cd prod && npm run build            # dist/main.js rebuilt
```

Commit evidence:

```text
3a10cd0a lanyusea's bot <lanyusea@gmail.com> gameplay: unblock construction under spawn reserve
```

## Universal task Done gate

- [x] Task type: production behavior code PR for the Screeps bot.
- [x] Expected observable outcome / named deliverable: branch `fix/issue-1606-spawn-reserving-build` carries commit `3a10cd0a` with worker-task routing logic and regression tests for construction under spawn reserve.
- [x] Non-goals / accepted substitutes: no paid Tencent compute, no direct RL reward tuning, no owner action, and no scope outside the worker-task construction or upgrade routing path.
- [x] Verification evidence required before Done: `git diff --check`, `npm run typecheck`, `npm test -- --runInBand`, and `npm run build` passed on the reconciled tree.
- [x] Project Evidence / Next action / Blocked by: issue and PR Project fields name the PR gate, controller verification, and runtime acceptance criterion; Blocked by field empty because no autonomous blocker exists.
- [x] Post-merge/deploy/runtime proof: related issue #1606 owns the fresh-runtime acceptance criterion: E29N55 or E29N57 shows construction or upgrade work with non-increasing construction deadlock ticks in a new observation window.
- [x] Named deliverable proof: commit `3a10cd0a` changes `prod/src/tasks/workerTasks.ts`, `prod/test/workerTasks.test.ts`, and `prod/dist/main.js`.
