### PR TITLE
monitor: suppress safe rampart decay jitter

### DIFF
--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -44,6 +44,7 @@ DEFAULT_ROOM = world_profiles.PERSISTENT_DEFAULTS.room
 WORLD_PROFILE_ENV = world_profiles.WORLD_PROFILE_ENV
 RAMPART_DECAY_HITS_PER_EVENT = 300
 RAMPART_DECAY_EVENT_TICKS = 100
+RAMPART_DECAY_SUPPRESSION_TOLERANCE_EVENTS = 1
 RAMPART_DECAY_RECENT_HOSTILE_TICKS = RAMPART_DECAY_EVENT_TICKS
 RAMPART_SAFE_DECAY_HITS_FLOOR = 10_000
 RAMPART_CRITICAL_DAMAGE_DELTA = 5_000
@@ -2346,6 +2347,13 @@ def expected_rampart_decay_delta(previous_room_state: dict[str, Any], current_ti
     return decay_events * RAMPART_DECAY_HITS_PER_EVENT
 
 
+def safe_rampart_decay_suppression_delta(previous_room_state: dict[str, Any], current_tick_value: Any) -> int:
+    expected_delta = expected_rampart_decay_delta(previous_room_state, current_tick_value)
+    if expected_delta <= 0:
+        return 0
+    return expected_delta + RAMPART_DECAY_SUPPRESSION_TOLERANCE_EVENTS * RAMPART_DECAY_HITS_PER_EVENT
+
+
 def previous_room_state_has_recent_visible_hostiles(
     previous_room_state: dict[str, Any], current_tick_value: Any
 ) -> bool:
@@ -2397,7 +2405,7 @@ def is_expected_safe_rampart_decay_reason(
 
     return (
         current_hits > RAMPART_SAFE_DECAY_HITS_FLOOR
-        and 0 < delta <= expected_rampart_decay_delta(previous_room_state, current_tick_value)
+        and 0 < delta <= safe_rampart_decay_suppression_delta(previous_room_state, current_tick_value)
     )
 
 
@@ -2635,6 +2643,7 @@ def evaluate_room_alert(
             suppressed_reason = dict(reason)
             suppressed_reason["suppression_reason"] = "expected_rampart_decay"
             suppressed_reason["expected_decay_delta"] = expected_rampart_decay_delta(previous_room_state, snapshot.tick)
+            suppressed_reason["allowed_decay_delta"] = safe_rampart_decay_suppression_delta(previous_room_state, snapshot.tick)
             suppressed_reason["safe_hits_floor"] = RAMPART_SAFE_DECAY_HITS_FLOOR
             suppressed.append(suppressed_reason)
             continue

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -1803,6 +1803,83 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(suppressed[0]["expected_decay_delta"], expected_decay)
         self.assertEqual(suppressed[0]["suppression_reason"], "expected_rampart_decay")
 
+    def test_high_health_rampart_decay_with_one_event_tick_jitter_is_suppressed(self) -> None:
+        previous_tick = 1_684_407
+        current_tick = 1_684_807
+        current_hits = 2_203_221
+        delta = 1_500
+        previous = {
+            "baseline_established": True,
+            "tick": previous_tick,
+            "visible_hostile_creeps": 0,
+            "structures": {
+                "spawn1": {
+                    "type": "spawn",
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                    "owned": True,
+                    "damageable": True,
+                    "critical": True,
+                },
+                "rampart1": {
+                    "type": "rampart",
+                    "x": 35,
+                    "y": 26,
+                    "hits": current_hits + delta,
+                    "hitsMax": 10_000_000,
+                    "owned": True,
+                    "damageable": True,
+                    "critical": False,
+                },
+            },
+        }
+        snapshot = make_snapshot(
+            {
+                "spawn1": {
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                },
+                "rampart1": {
+                    "type": "rampart",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 35,
+                    "y": 26,
+                    "hits": current_hits,
+                    "hitsMax": 10_000_000,
+                },
+            },
+            tick=current_tick,
+        )
+
+        expected_decay = monitor.expected_rampart_decay_delta(previous, current_tick)
+        allowed_decay = monitor.safe_rampart_decay_suppression_delta(previous, current_tick)
+        self.assertEqual(expected_decay, 1_200)
+        self.assertEqual(delta, expected_decay + monitor.RAMPART_DECAY_HITS_PER_EVENT)
+        self.assertEqual(allowed_decay, delta)
+        self.assertGreater(current_hits, monitor.RAMPART_CRITICAL_DAMAGE_HITS_CEILING)
+
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            snapshot,
+            previous,
+            now=100,
+            debounce_seconds=300,
+        )
+
+        self.assertEqual(emitted, [])
+        self.assertEqual(len(suppressed), 1)
+        self.assertEqual(suppressed[0]["delta"], delta)
+        self.assertEqual(suppressed[0]["expected_decay_delta"], expected_decay)
+        self.assertEqual(suppressed[0]["allowed_decay_delta"], allowed_decay)
+        self.assertEqual(suppressed[0]["suppression_reason"], "expected_rampart_decay")
+
     def test_unknown_or_non_advancing_rampart_decay_ticks_do_not_suppress_damage(self) -> None:
         decay = monitor.RAMPART_DECAY_HITS_PER_EVENT
         safe_floor = monitor.RAMPART_SAFE_DECAY_HITS_FLOOR


### PR DESCRIPTION
## Summary

- Implements the #1607 runtime-monitor triage outcome for high-hit rampart decay noise.
- Suppresses safe rampart decay jitter when rooms are alive, no hostiles are present, and rampart hit deltas match the safe decay profile.
- Adds a regression test for one-event tick jitter in high-health rampart decay evidence.

Related issue: #1607

## Verification

Controller-side verification on the reconciled worktree:

```text
git diff --check
python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py
python3 -m unittest scripts/test_screeps_runtime_monitor_tactical_response.py  # 91 tests passed
```

Commit evidence:

```text
b5c2bbb9 lanyusea's bot <lanyusea@gmail.com> monitor: suppress safe rampart decay jitter
```

## Universal task Done gate

- [x] Task type: runtime monitor code PR for Screeps tactical-alert classification.
- [x] Expected observable outcome / named deliverable: branch `fix/issue-1607-rampart-alert` carries commit `b5c2bbb9` with safe rampart decay suppression logic and tactical-response regression coverage.
- [x] Non-goals / accepted substitutes: no production bot repair-priority change, no owner action, no paid compute, and no scope outside monitor classification for safe rampart decay evidence.
- [x] Verification evidence required before Done: `git diff --check`, Python compile checks, and `python3 -m unittest scripts/test_screeps_runtime_monitor_tactical_response.py` passed on the reconciled tree.
- [x] Project Evidence / Next action / Blocked by: issue and PR Project fields name the PR gate, controller verification, and runtime alert acceptance criterion; Blocked by field empty because no autonomous blocker exists.
- [x] Post-merge/deploy/runtime proof: related issue #1607 owns the fresh-monitor acceptance criterion: high-health safe rampart decay no longer emits structure-damage alert noise while hostile or unsafe damage remains alertable.
- [x] Named deliverable proof: commit `b5c2bbb9` changes `scripts/screeps-runtime-monitor.py` and `scripts/test_screeps_runtime_monitor_tactical_response.py`.
