### PR TITLE
rl: gate Tencent timeout recovery sizing

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -3085,7 +3085,8 @@ def paid_failure_post_fix_timeout_recovery_sizing(
         and prior_simulator_ticks is not None
         and current_simulator_ticks < prior_simulator_ticks
     )
-    smaller_validation_slice = smaller_environment_rows or smaller_simulator_ticks
+    # plannedBatchScale.simulatorTicks is total simulator work, not per-environment ticks.
+    smaller_validation_slice = smaller_simulator_ticks
     return {
         "priorAttemptRunId": text_value(prior_attempt.get("runId")) if prior_attempt is not None else None,
         "priorTrainingTimeoutSeconds": prior_training_timeout,

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -366,6 +366,7 @@ CLI_EXPLICIT_OPTION_DESTS = {
     "--workers": "workers",
     "--scale-environments": "scale_environments",
     "--repetitions": "repetitions",
+    "--training-timeout-seconds": "training_timeout_seconds",
 }
 PREFLIGHT_MODE_OPTION_DESTS = frozenset((
     "training_approach",
@@ -2916,6 +2917,7 @@ def build_paid_failure_recurrence_launch_guard(
     next_action = None
     if blocked_signature is not None:
         next_action = paid_failure_recurrence_next_action(blocked_signature, validation)
+    current_validation_plan = paid_failure_current_validation_plan(args)
     return {
         "type": PAID_FAILURE_RECURRENCE_GUARD_TYPE,
         "schemaVersion": 1,
@@ -2932,6 +2934,9 @@ def build_paid_failure_recurrence_launch_guard(
             "scenarioId": scenario_id_from_args(args),
             "workers": getattr(args, "workers", None),
             "repetitions": getattr(args, "repetitions", None),
+            "trainingTimeoutSeconds": current_validation_plan["trainingTimeoutSeconds"],
+            "plannedBatchScale": current_validation_plan["plannedBatchScale"],
+            "validationPlan": current_validation_plan,
             "policyGradientTrustSampleRequest": policy_gradient_trust_sample_request(args),
             "allowedPaidFailureRecurrenceValidations": sorted(
                 paid_failure_recurrence_validation_requests(args)
@@ -3013,6 +3018,90 @@ def paid_failure_recurrence_validation_requests(args: argparse.Namespace) -> set
         return set()
     values = raw if isinstance(raw, list) else [raw]
     return {value for value in (text_value(item) for item in values) if value is not None}
+
+
+def paid_failure_current_validation_plan(args: argparse.Namespace) -> dict[str, Any]:
+    explicit_options = set(getattr(args, "explicit_cli_options", ()))
+    planned_scale = planned_batch_scale_from_args(args)
+    training_timeout = max(0, int(getattr(args, "training_timeout_seconds", 0) or 0))
+    return {
+        "workers": getattr(args, "workers", None),
+        "scaleEnvironments": resolve_scale_environment_count(args),
+        "repetitions": getattr(args, "repetitions", None),
+        "requestedTicks": getattr(args, "ticks", None),
+        "effectiveTicks": effective_training_ticks(args),
+        "trainingTimeoutSeconds": training_timeout,
+        "plannedBatchScale": planned_scale,
+        "explicitTrainingTimeout": "training_timeout_seconds" in explicit_options,
+        "explicitValidationSlice": bool(
+            explicit_options.intersection({"workers", "scale_environments", "repetitions", "ticks"})
+        ),
+    }
+
+
+def paid_failure_post_fix_timeout_recovery_sizing(
+    args: argparse.Namespace,
+    prior_attempts: list[dict[str, Any]],
+) -> dict[str, Any]:
+    current_plan = paid_failure_current_validation_plan(args)
+    prior_attempt = next(
+        (
+            attempt
+            for attempt in prior_attempts
+            if paid_failure_post_fix_attempt_is_remote_training_timeout_without_report(attempt)
+        ),
+        None,
+    )
+    prior_plan = dict_value(prior_attempt.get("validationPlan")) if prior_attempt is not None else None
+    prior_plan = prior_plan or {}
+    current_training_timeout = scale_gates.non_negative_int(current_plan.get("trainingTimeoutSeconds"))
+    prior_training_timeout = scale_gates.non_negative_int(prior_plan.get("trainingTimeoutSeconds"))
+    current_environment_rows = scale_gates.non_negative_int(
+        path_value(current_plan, "plannedBatchScale", "environmentRows")
+    )
+    prior_environment_rows = scale_gates.non_negative_int(
+        path_value(prior_plan, "plannedBatchScale", "environmentRows")
+    )
+    current_simulator_ticks = scale_gates.non_negative_int(
+        path_value(current_plan, "plannedBatchScale", "simulatorTicks")
+    )
+    prior_simulator_ticks = scale_gates.non_negative_int(
+        path_value(prior_plan, "plannedBatchScale", "simulatorTicks")
+    )
+    explicit_training_timeout = current_plan.get("explicitTrainingTimeout") is True
+    timeout_increased = bool(
+        explicit_training_timeout
+        and current_training_timeout is not None
+        and prior_training_timeout is not None
+        and current_training_timeout > prior_training_timeout
+    )
+    smaller_environment_rows = bool(
+        current_environment_rows is not None
+        and prior_environment_rows is not None
+        and current_environment_rows < prior_environment_rows
+    )
+    smaller_simulator_ticks = bool(
+        current_simulator_ticks is not None
+        and prior_simulator_ticks is not None
+        and current_simulator_ticks < prior_simulator_ticks
+    )
+    smaller_validation_slice = smaller_environment_rows or smaller_simulator_ticks
+    return {
+        "priorAttemptRunId": text_value(prior_attempt.get("runId")) if prior_attempt is not None else None,
+        "priorTrainingTimeoutSeconds": prior_training_timeout,
+        "currentTrainingTimeoutSeconds": current_training_timeout,
+        "explicitTrainingTimeout": explicit_training_timeout,
+        "timeoutIncreased": timeout_increased,
+        "priorEnvironmentRows": prior_environment_rows,
+        "currentEnvironmentRows": current_environment_rows,
+        "smallerEnvironmentRows": smaller_environment_rows,
+        "priorSimulatorTicks": prior_simulator_ticks,
+        "currentSimulatorTicks": current_simulator_ticks,
+        "smallerSimulatorTicks": smaller_simulator_ticks,
+        "smallerValidationSlice": smaller_validation_slice,
+        "acceptable": timeout_increased or smaller_validation_slice,
+        "requiredChange": "explicitly_larger_training_timeout_or_smaller_validation_slice",
+    }
 
 
 def paid_failure_post_fix_validation_state(
@@ -3117,12 +3206,27 @@ def paid_failure_post_fix_validation_recovery_eligibility(
     if trust_sample_request.get("meetsTrustSampleTarget") is not True:
         result["reason"] = "policy-gradient requested samples are below the trust gate target"
         return result
+    if recovery_class in {"remote_training_timeout", "remote_training_timeout_after_recovery"}:
+        paid_failure_post_fix_validation_recovery_metadata(
+            result,
+            recovery_class,
+            prior_attempts,
+        )
+        timeout_sizing = paid_failure_post_fix_timeout_recovery_sizing(args, prior_attempts)
+        result["timeoutRecoverySizing"] = timeout_sizing
+        if timeout_sizing.get("acceptable") is not True:
+            result["reason"] = (
+                "remote-training timeout recovery requires an explicitly larger "
+                "--training-timeout-seconds or a smaller validation slice than the latest timed-out attempt"
+            )
+            return result
     result["eligible"] = True
-    paid_failure_post_fix_validation_recovery_metadata(
-        result,
-        recovery_class,
-        prior_attempts,
-    )
+    if "recoveryClass" not in result:
+        paid_failure_post_fix_validation_recovery_metadata(
+            result,
+            recovery_class,
+            prior_attempts,
+        )
     if recovery_class in {"remote_training_timeout", "remote_training_timeout_after_recovery"}:
         result["reason"] = (
             "one recovery validation is allowed after a consumed remote-training timeout "
@@ -3158,13 +3262,19 @@ def paid_failure_post_fix_validation_recovery_metadata(
 def paid_failure_post_fix_validation_recovery_class_for_attempts(
     prior_attempts: list[dict[str, Any]],
 ) -> str | None:
-    if len(prior_attempts) == 1:
-        attempt = prior_attempts[0]
-        if attempt.get("recoveryAttempt") is True:
-            return None
-        return paid_failure_post_fix_validation_recovery_class(attempt)
-    if len(prior_attempts) != 2:
+    if not prior_attempts:
         return None
+    latest_attempt = prior_attempts[0]
+    if paid_failure_post_fix_attempt_is_remote_training_timeout_without_report(latest_attempt):
+        return (
+            "remote_training_timeout_after_recovery"
+            if latest_attempt.get("recoveryAttempt") is True
+            else "remote_training_timeout"
+        )
+    if len(prior_attempts) == 1:
+        if latest_attempt.get("recoveryAttempt") is True:
+            return None
+        return paid_failure_post_fix_validation_recovery_class(latest_attempt)
     recovery_attempts = [attempt for attempt in prior_attempts if attempt.get("recoveryAttempt") is True]
     admission_attempts = [attempt for attempt in prior_attempts if attempt.get("recoveryAttempt") is not True]
     if len(recovery_attempts) != 1 or len(admission_attempts) != 1:
@@ -3404,6 +3514,21 @@ def paid_failure_post_fix_validation_attempt_from_summary(
     remote_failure = dict_value(path_value(summary, "outputs", "remoteTrainingFailure"))
     remote_failure_class = text_value(remote_failure.get("failureClass")) if remote_failure else None
     training_report = dict_value(path_value(summary, "outputs", "trainingReport"))
+    execution_timeouts = dict_value(inputs.get("executionTimeouts")) or {}
+    planned_batch_scale = dict_value(inputs.get("plannedBatchScale"))
+    policy_gradient_request = dict_value(inputs.get("policyGradientTrustSampleRequest"))
+    validation_plan = {
+        "workers": scale_gates.non_negative_int(inputs.get("workers")),
+        "repetitions": scale_gates.non_negative_int(inputs.get("repetitions")),
+        "requestedTicks": scale_gates.non_negative_int(inputs.get("ticks")),
+        "trainingTimeoutSeconds": scale_gates.non_negative_int(
+            execution_timeouts.get("trainingTimeoutSeconds")
+        ),
+        "plannedBatchScale": copy.deepcopy(planned_batch_scale) if planned_batch_scale is not None else None,
+        "policyGradientTrustSampleRequest": copy.deepcopy(policy_gradient_request)
+        if policy_gradient_request is not None
+        else None,
+    }
     attempt = {
         "runId": run_id,
         "summaryPath": str(summary_path),
@@ -3429,6 +3554,7 @@ def paid_failure_post_fix_validation_attempt_from_summary(
         "environmentsRun": environments_run,
         "remoteTrainingFailurePresent": remote_failure is not None,
         "remoteTrainingFailureClass": remote_failure_class,
+        "validationPlan": validation_plan,
     }
     attempt["validationSlotConsumed"] = paid_failure_post_fix_attempt_consumes_validation_slot(attempt)
     return attempt
@@ -3543,7 +3669,7 @@ def paid_failure_recurrence_next_action(
         }:
             return (
                 f"{base}; one recovery validation is allowed because {run_id} timed out in remote "
-                "training without a completed report; rerun only with an explicitly sized timeout "
+                "training without a completed report; rerun only with an explicitly larger timeout "
                 "or a smaller validation slice, and keep the guard active if room-busy recurs"
             )
         return (
@@ -3568,11 +3694,20 @@ def paid_failure_recurrence_next_action(
                 or text_value(prior.get("runId"))
                 or "the prior post-fix validation"
             )
+            if recovery.get("requested") is True:
+                reason = text_value(recovery.get("reason")) or (
+                    "the requested recovery did not change the timeout or validation slice"
+                )
+                return (
+                    f"{base}; {run_id} timed out in remote training without a completed report; "
+                    f"{reason}; inspect collected partial diagnostics, then only launch a recovery "
+                    "with an explicitly larger timeout or a smaller validation slice"
+                )
             return (
                 f"{base}; {run_id} timed out in remote training without a completed report, "
                 "but this launch did not request the explicit post-fix validation signature; "
                 "inspect collected partial diagnostics, then only launch a recovery with that "
-                "signature plus an explicitly sized timeout or a smaller validation slice"
+                "signature plus an explicitly larger timeout or a smaller validation slice"
             )
         if recovery_class == "pre_scale_no_compute_admission_failure":
             run_id = (

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -3267,24 +3267,32 @@ def paid_failure_post_fix_validation_recovery_class_for_attempts(
         return None
     latest_attempt = prior_attempts[0]
     if paid_failure_post_fix_attempt_is_remote_training_timeout_without_report(latest_attempt):
-        return (
-            "remote_training_timeout_after_recovery"
-            if latest_attempt.get("recoveryAttempt") is True
-            else "remote_training_timeout"
-        )
+        if latest_attempt.get("recoveryAttempt") is True:
+            if paid_failure_post_fix_attempts_prove_pre_scale_timeout_recovery(prior_attempts):
+                return "remote_training_timeout_after_recovery"
+            return None
+        return "remote_training_timeout"
     if len(prior_attempts) == 1:
         if latest_attempt.get("recoveryAttempt") is True:
             return None
         return paid_failure_post_fix_validation_recovery_class(latest_attempt)
+    if paid_failure_post_fix_attempts_prove_pre_scale_timeout_recovery(prior_attempts):
+        return "remote_training_timeout_after_recovery"
+    return None
+
+
+def paid_failure_post_fix_attempts_prove_pre_scale_timeout_recovery(
+    prior_attempts: list[dict[str, Any]],
+) -> bool:
     recovery_attempts = [attempt for attempt in prior_attempts if attempt.get("recoveryAttempt") is True]
     admission_attempts = [attempt for attempt in prior_attempts if attempt.get("recoveryAttempt") is not True]
     if len(recovery_attempts) != 1 or len(admission_attempts) != 1:
-        return None
+        return False
     if not paid_failure_post_fix_attempt_is_pre_scale_no_compute_admission_failure(admission_attempts[0]):
-        return None
+        return False
     if not paid_failure_post_fix_attempt_is_remote_training_timeout_without_report(recovery_attempts[0]):
-        return None
-    return "remote_training_timeout_after_recovery"
+        return False
+    return True
 
 
 def paid_failure_post_fix_validation_recovery_class(attempt: dict[str, Any]) -> str | None:

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -3265,6 +3265,10 @@ def paid_failure_post_fix_validation_recovery_class_for_attempts(
 ) -> str | None:
     if not prior_attempts:
         return None
+    if paid_failure_post_fix_attempts_include_timeout_recovery(prior_attempts):
+        if paid_failure_post_fix_attempts_prove_pre_scale_timeout_recovery(prior_attempts):
+            return "remote_training_timeout_after_recovery"
+        return None
     latest_attempt = prior_attempts[0]
     if paid_failure_post_fix_attempt_is_remote_training_timeout_without_report(latest_attempt):
         if latest_attempt.get("recoveryAttempt") is True:
@@ -3279,6 +3283,14 @@ def paid_failure_post_fix_validation_recovery_class_for_attempts(
     if paid_failure_post_fix_attempts_prove_pre_scale_timeout_recovery(prior_attempts):
         return "remote_training_timeout_after_recovery"
     return None
+
+
+def paid_failure_post_fix_attempts_include_timeout_recovery(prior_attempts: list[dict[str, Any]]) -> bool:
+    return any(
+        attempt.get("recoveryAttempt") is True
+        and paid_failure_post_fix_attempt_is_remote_training_timeout_without_report(attempt)
+        for attempt in prior_attempts
+    )
 
 
 def paid_failure_post_fix_attempts_prove_pre_scale_timeout_recovery(

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -4552,6 +4552,11 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertIn("scale_up", events)
         self.assertFalse(guard["blocked"])
         self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS)
+        self.assertEqual(guard["postFixValidation"]["priorAttemptCount"], 2)
+        self.assertEqual(
+            guard["postFixValidation"]["priorAttempt"]["runId"],
+            "postfix-room-busy-validation-timeout",
+        )
         recovery = guard["postFixValidation"]["recoveryEligibility"]
         self.assertTrue(recovery["eligible"])
         self.assertEqual(recovery["recoveryClass"], "remote_training_timeout_after_recovery")
@@ -4560,6 +4565,78 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertIn("remote-training timeout", guard["reason"])
         self.assertEqual(controller.final_status, "completed")
         self.assertEqual(summary["outputs"]["launchGuard"]["postFixValidation"]["status"], "recovery_allowed")
+
+    def test_paid_failure_recurrence_guard_blocks_third_timeout_recovery_after_paid_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            write_post_fix_validation_remote_timeout_summary(
+                artifact_root,
+                "postfix-room-busy-validation-timeout",
+                workers=5,
+                repetitions=20,
+                ticks=runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS,
+                training_timeout_seconds=3600,
+            )
+            write_post_fix_validation_recovery_remote_timeout_summary(
+                artifact_root,
+                "postfix-room-busy-validation-timeout-recovery",
+            )
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                str(runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS),
+                "--workers",
+                "5",
+                "--scale-environments",
+                "5",
+                "--repetitions",
+                "20",
+                "--training-timeout-seconds",
+                "7200",
+                "--postfix-validation-signature",
+                runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertEqual(events, [])
+        self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+        self.assertTrue(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
+        self.assertEqual(guard["postFixValidation"]["status"], "consumed")
+        self.assertEqual(guard["postFixValidation"]["priorAttemptCount"], 2)
+        prior_attempt = guard["postFixValidation"]["priorAttempt"]
+        self.assertEqual(prior_attempt["runId"], "postfix-room-busy-validation-timeout-recovery")
+        self.assertTrue(prior_attempt["recoveryAttempt"])
+        self.assertEqual(prior_attempt["remoteTrainingFailureClass"], "remote_training_timeout")
+        recovery = guard["postFixValidation"]["recoveryEligibility"]
+        self.assertFalse(recovery["eligible"])
+        self.assertNotIn("recoveryClass", recovery)
+        self.assertIn("recovery was already attempted", recovery["reason"])
+        self.assertFalse(summary["execution"]["computeAttempted"])
 
     def test_paid_failure_recurrence_guard_explains_timeout_recovery_when_signature_missing(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -4496,6 +4496,75 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(controller.final_status, "completed")
         self.assertEqual(summary["outputs"]["launchGuard"]["postFixValidation"]["status"], "recovery_allowed")
 
+    def test_paid_failure_recurrence_guard_allows_smaller_validation_slice_recovery(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            write_post_fix_validation_remote_timeout_summary(
+                artifact_root,
+                "postfix-room-busy-validation-timeout",
+                workers=5,
+                repetitions=20,
+                ticks=runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS,
+                training_timeout_seconds=3600,
+            )
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                str(runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS),
+                "--workers",
+                "5",
+                "--scale-environments",
+                "2",
+                "--repetitions",
+                "20",
+                "--training-timeout-seconds",
+                "3600",
+                "--postfix-validation-signature",
+                runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertIn("scale_up", events)
+        self.assertIn("remote_training", events)
+        self.assertFalse(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS)
+        recovery = guard["postFixValidation"]["recoveryEligibility"]
+        self.assertTrue(recovery["eligible"])
+        sizing = recovery["timeoutRecoverySizing"]
+        self.assertFalse(sizing["timeoutIncreased"])
+        self.assertTrue(sizing["smallerValidationSlice"])
+        self.assertEqual(sizing["priorTrainingTimeoutSeconds"], 3600)
+        self.assertEqual(sizing["currentTrainingTimeoutSeconds"], 3600)
+        self.assertEqual(sizing["priorEnvironmentRows"], 100)
+        self.assertEqual(sizing["currentEnvironmentRows"], 40)
+        self.assertTrue(sizing["smallerEnvironmentRows"])
+        self.assertEqual(controller.final_status, "completed")
+        self.assertEqual(summary["outputs"]["launchGuard"]["postFixValidation"]["status"], "recovery_allowed")
+
     def test_paid_failure_recurrence_guard_allows_timeout_fix_after_timed_out_recovery(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             artifact_root = Path(temp_dir) / "batch-runs"

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -4384,6 +4384,51 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertIn("smaller validation slice", guard["nextAction"])
         self.assertFalse(summary["execution"]["computeAttempted"])
 
+    def test_paid_failure_timeout_recovery_sizing_blocks_row_shrink_with_larger_tick_work(self) -> None:
+        args = argparse.Namespace(
+            explicit_cli_options={"scale_environments", "repetitions", "ticks"},
+            repetitions=1,
+            scale_environments=99,
+            ticks=10000,
+            training_approach="policy_gradient",
+            training_timeout_seconds=3600,
+            workers=99,
+        )
+        prior_attempt = {
+            "runId": "prior-timeout",
+            "finalStatus": "failed",
+            "outcome": "not_completed",
+            "executionContextPresent": True,
+            "computeAttempted": True,
+            "scaleOutAttempted": True,
+            "remoteTrainingAttempted": True,
+            "trainingReportProduced": False,
+            "trainingReportPresent": False,
+            "remoteTrainingFailurePresent": True,
+            "remoteTrainingFailureClass": "remote_training_timeout",
+            "failureSignature": None,
+            "validationPlan": {
+                "trainingTimeoutSeconds": 3600,
+                "plannedBatchScale": runner.scale_gates.build_batch_scale_summary(
+                    environment_rows=100,
+                    simulator_ticks=100 * 500,
+                    basis="requested_inputs",
+                ),
+            },
+        }
+
+        sizing = runner.paid_failure_post_fix_timeout_recovery_sizing(args, [prior_attempt])
+
+        self.assertEqual(sizing["priorEnvironmentRows"], 100)
+        self.assertEqual(sizing["currentEnvironmentRows"], 99)
+        self.assertTrue(sizing["smallerEnvironmentRows"])
+        self.assertEqual(sizing["priorSimulatorTicks"], 100 * 500)
+        self.assertEqual(sizing["currentSimulatorTicks"], 99 * 10000)
+        self.assertFalse(sizing["smallerSimulatorTicks"])
+        self.assertFalse(sizing["smallerValidationSlice"])
+        self.assertFalse(sizing["timeoutIncreased"])
+        self.assertFalse(sizing["acceptable"])
+
     def test_paid_failure_recurrence_guard_allows_timeout_recovery_with_larger_timeout(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             artifact_root = Path(temp_dir) / "batch-runs"

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -868,7 +868,15 @@ def write_post_fix_validation_in_progress_summary(artifact_root: Path, run_id: s
     return summary_path
 
 
-def write_post_fix_validation_remote_timeout_summary(artifact_root: Path, run_id: str) -> Path:
+def write_post_fix_validation_remote_timeout_summary(
+    artifact_root: Path,
+    run_id: str,
+    *,
+    workers: int = 5,
+    repetitions: int = 20,
+    ticks: int = runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS,
+    training_timeout_seconds: int = 3600,
+) -> Path:
     summary_path = write_post_fix_validation_summary(
         artifact_root,
         run_id,
@@ -878,6 +886,40 @@ def write_post_fix_validation_remote_timeout_summary(artifact_root: Path, run_id
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
     summary["startedAt"] = "2026-05-30T00:00:03Z"
     summary["finishedAt"] = "2026-05-30T00:02:03Z"
+    environment_rows = workers * repetitions
+    effective_ticks = max(ticks, runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS)
+    summary["inputs"] = {
+        "command": "run-single",
+        "executionMode": "compute",
+        "preflightOnly": False,
+        "trainingApproach": "policy_gradient",
+        "workers": workers,
+        "repetitions": repetitions,
+        "ticks": ticks,
+        "executionTimeouts": {
+            "bootstrapTimeoutSeconds": 1800,
+            "scaleDownTimeoutSeconds": 600,
+            "scaleTimeoutSeconds": 900,
+            "trainingTimeoutSeconds": training_timeout_seconds,
+            "transferTimeoutSeconds": 1200,
+            "totalSeconds": 4500 + training_timeout_seconds,
+        },
+        "plannedBatchScale": runner.scale_gates.build_batch_scale_summary(
+            environment_rows=environment_rows,
+            simulator_ticks=environment_rows * effective_ticks,
+            basis="requested_inputs",
+        ),
+        "policyGradientTrustSampleRequest": {
+            "targetSamplesPerCandidate": runner.POLICY_GRADIENT_TRUST_MIN_SAMPLES_PER_CANDIDATE,
+            "requestedSamplesPerCandidate": environment_rows,
+            "scaleEnvironmentsPerRepetition": workers,
+            "repetitions": repetitions,
+            "meetsTrustSampleTarget": (
+                environment_rows >= runner.POLICY_GRADIENT_TRUST_MIN_SAMPLES_PER_CANDIDATE
+            ),
+            "reason": "requested samples meet the policy-gradient trust gate target",
+        },
+    }
     timeout_tail = "validation heartbeat: environmentsStarted=5 environmentsCompleted=0"
     remote_failure = summary["outputs"]["remoteTrainingFailure"]
     remote_failure["returncode"] = runner.PROCESS_TIMEOUT_RETURN_CODE
@@ -4269,7 +4311,143 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             guard["postFixValidation"]["priorAttempt"]["remoteTrainingFailureClass"],
             "remote_training_timeout",
         )
-        self.assertIn("explicitly sized timeout", guard["nextAction"])
+        self.assertIn("explicitly larger timeout", guard["nextAction"])
+        self.assertEqual(controller.final_status, "completed")
+        self.assertEqual(summary["outputs"]["launchGuard"]["postFixValidation"]["status"], "recovery_allowed")
+
+    def test_paid_failure_recurrence_guard_blocks_timeout_recovery_without_timeout_or_slice_change(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            write_post_fix_validation_remote_timeout_summary(
+                artifact_root,
+                "postfix-room-busy-validation-timeout",
+                workers=5,
+                repetitions=20,
+                ticks=runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS,
+                training_timeout_seconds=3600,
+            )
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                str(runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS),
+                "--workers",
+                "5",
+                "--scale-environments",
+                "5",
+                "--repetitions",
+                "20",
+                "--postfix-validation-signature",
+                runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertEqual(events, [])
+        self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+        self.assertTrue(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
+        recovery = guard["postFixValidation"]["recoveryEligibility"]
+        self.assertFalse(recovery["eligible"])
+        self.assertEqual(recovery["recoveryClass"], "remote_training_timeout")
+        self.assertIn("explicitly larger --training-timeout-seconds", recovery["reason"])
+        sizing = recovery["timeoutRecoverySizing"]
+        self.assertEqual(sizing["priorEnvironmentRows"], 100)
+        self.assertEqual(sizing["currentEnvironmentRows"], 100)
+        self.assertEqual(sizing["priorTrainingTimeoutSeconds"], 3600)
+        self.assertEqual(sizing["currentTrainingTimeoutSeconds"], 3600)
+        self.assertFalse(sizing["timeoutIncreased"])
+        self.assertFalse(sizing["smallerValidationSlice"])
+        self.assertIn("explicitly larger timeout", guard["nextAction"])
+        self.assertIn("smaller validation slice", guard["nextAction"])
+        self.assertFalse(summary["execution"]["computeAttempted"])
+
+    def test_paid_failure_recurrence_guard_allows_timeout_recovery_with_larger_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            write_post_fix_validation_remote_timeout_summary(
+                artifact_root,
+                "postfix-room-busy-validation-timeout",
+                workers=5,
+                repetitions=20,
+                ticks=runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS,
+                training_timeout_seconds=3600,
+            )
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                str(runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS),
+                "--workers",
+                "5",
+                "--scale-environments",
+                "5",
+                "--repetitions",
+                "20",
+                "--training-timeout-seconds",
+                "7200",
+                "--postfix-validation-signature",
+                runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertIn("scale_up", events)
+        self.assertIn("remote_training", events)
+        self.assertFalse(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS)
+        recovery = guard["postFixValidation"]["recoveryEligibility"]
+        self.assertTrue(recovery["eligible"])
+        sizing = recovery["timeoutRecoverySizing"]
+        self.assertTrue(sizing["explicitTrainingTimeout"])
+        self.assertTrue(sizing["timeoutIncreased"])
+        self.assertFalse(sizing["smallerValidationSlice"])
+        self.assertEqual(sizing["priorTrainingTimeoutSeconds"], 3600)
+        self.assertEqual(sizing["currentTrainingTimeoutSeconds"], 7200)
         self.assertEqual(controller.final_status, "completed")
         self.assertEqual(summary["outputs"]["launchGuard"]["postFixValidation"]["status"], "recovery_allowed")
 
@@ -4333,7 +4511,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertTrue(recovery["eligible"])
         self.assertEqual(recovery["recoveryClass"], "remote_training_timeout_after_recovery")
         self.assertEqual(recovery["priorRecoveryAttemptRunId"], "postfix-room-busy-validation-timeout")
-        self.assertIn("explicitly sized timeout", guard["nextAction"])
+        self.assertIn("explicitly larger timeout", guard["nextAction"])
         self.assertIn("remote-training timeout", guard["reason"])
         self.assertEqual(controller.final_status, "completed")
         self.assertEqual(summary["outputs"]["launchGuard"]["postFixValidation"]["status"], "recovery_allowed")
@@ -4396,7 +4574,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(recovery["priorRecoveryAttemptRunId"], "postfix-room-busy-validation-timeout")
         self.assertIn("explicit post-fix validation signature", recovery["reason"])
         self.assertIn("explicit post-fix validation signature", guard["nextAction"])
-        self.assertIn("explicitly sized timeout", guard["nextAction"])
+        self.assertIn("explicitly larger timeout", guard["nextAction"])
         self.assertIn("smaller validation slice", guard["nextAction"])
         self.assertFalse(summary["execution"]["computeAttempted"])
 

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -4571,7 +4571,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             artifact_root = Path(temp_dir) / "batch-runs"
             for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
                 write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
-            write_post_fix_validation_remote_timeout_summary(
+            timeout_attempt_path = write_post_fix_validation_remote_timeout_summary(
                 artifact_root,
                 "postfix-room-busy-validation-timeout",
                 workers=5,
@@ -4579,10 +4579,12 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 ticks=runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS,
                 training_timeout_seconds=3600,
             )
-            write_post_fix_validation_recovery_remote_timeout_summary(
+            recovery_attempt_path = write_post_fix_validation_recovery_remote_timeout_summary(
                 artifact_root,
                 "postfix-room-busy-validation-timeout-recovery",
             )
+            touched_time = recovery_attempt_path.stat().st_mtime + 10
+            os.utime(timeout_attempt_path, (touched_time, touched_time))
             args = runner.parse_cli_args([
                 "run-single",
                 "--run-id",
@@ -4629,8 +4631,8 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(guard["postFixValidation"]["status"], "consumed")
         self.assertEqual(guard["postFixValidation"]["priorAttemptCount"], 2)
         prior_attempt = guard["postFixValidation"]["priorAttempt"]
-        self.assertEqual(prior_attempt["runId"], "postfix-room-busy-validation-timeout-recovery")
-        self.assertTrue(prior_attempt["recoveryAttempt"])
+        self.assertEqual(prior_attempt["runId"], "postfix-room-busy-validation-timeout")
+        self.assertFalse(prior_attempt["recoveryAttempt"])
         self.assertEqual(prior_attempt["remoteTrainingFailureClass"], "remote_training_timeout")
         recovery = guard["postFixValidation"]["recoveryEligibility"]
         self.assertFalse(recovery["eligible"])


### PR DESCRIPTION
## Summary

- Implements the #1596 Tencent post-fix validation recovery sizing changes before any new paid rerun.
- Adds an explicit larger training timeout, a smaller validation slice, recovery eligibility checks, total-workload shrink enforcement, and a hard stop for repeated timeout recoveries.
- Extends Tencent batch-runner tests for timeout recovery behavior, row-shrink-with-larger-tick-work rejection, and third paid-recovery prevention.

Related issue: #1596

## Verification

Controller-side verification on the reconciled worktree:

```text
git diff --check
python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py
python3 -m unittest scripts/test_screeps_tencent_batch_rl_runner.py  # 173 tests passed after review-fix commit 3c39e0e3
```

Commit evidence:

```text
374a1c1c lanyusea's bot <lanyusea@gmail.com> rl: gate Tencent timeout recovery sizing
3db1021c lanyusea's bot <lanyusea@gmail.com> rl: require Tencent timeout recovery workload shrink
3c39e0e3 lanyusea's bot <lanyusea@gmail.com> rl: prevent repeated Tencent timeout recoveries
```

Review triage evidence:

```text
Thread PRRT_kwDOSMSsO86GUq-H classified FIX in /tmp/pr1610-review-triage.md; fixed by commit 3db1021c and resolved.
Thread PRRT_kwDOSMSsO86GUy-B classified FIX in /tmp/pr1610-review-triage-PRRT_kwDOSMSsO86GUy-B.md; fixed by commit 3c39e0e3.
```

## Universal task Done gate

- [x] Task type: RL flywheel operations code PR for Tencent validation safety.
- [x] Expected observable outcome / named deliverable: branch `fix/issue-1596-tencent-timeout` carries commits `374a1c1c`, `3db1021c`, and `3c39e0e3` with bounded timeout sizing, validation-slice sizing, workload-shrink enforcement, repeated-recovery prevention, and recovery-eligibility tests.
- [x] Non-goals / accepted substitutes: no paid Tencent compute dispatch, no cloud resource mutation, no owner action, and no scope outside the batch-runner timeout recovery path.
- [x] Verification evidence required before Done: `git diff --check`, Python compile checks, and `python3 -m unittest scripts/test_screeps_tencent_batch_rl_runner.py` passed with 173 tests on the reconciled tree.
- [x] Project Evidence / Next action / Blocked by: issue and PR Project fields name the PR gate, controller verification, review-fix triage, and guarded validation path; Blocked by field records the review-window gate.
- [x] Post-merge/deploy/runtime proof: related issue #1596 owns the guarded rerun criterion: a future preflight or validation attempt uses the smaller validation slice, larger timeout, and one-recovery limit without immediately consuming the paid-failure guard.
- [x] Named deliverable proof: commits `374a1c1c`, `3db1021c`, and `3c39e0e3` change `scripts/screeps_tencent_batch_rl_runner.py` and `scripts/test_screeps_tencent_batch_rl_runner.py`.
