### PR TITLE
fix: recover blocked E29N57 builders

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -21776,8 +21776,10 @@ function observeCreepBehaviorTick(creep, tick = getGameTime24()) {
     const stepDistance = getStepDistance(telemetry.lastPosition, currentPosition);
     if (stepDistance > 0) {
       telemetry.pathLength = ((_a = telemetry.pathLength) != null ? _a : 0) + stepDistance;
+      clearBuildTargetStuckObservation(telemetry);
     } else {
       telemetry.stuckTicks = ((_b = telemetry.stuckTicks) != null ? _b : 0) + 1;
+      recordBuildTargetStuckObservation(telemetry);
     }
   }
   if (currentPosition) {
@@ -21808,6 +21810,22 @@ function recordCreepBehaviorMove(creep, tick = getGameTime24()) {
   }
   telemetry.moveTicks = ((_a = telemetry.moveTicks) != null ? _a : 0) + 1;
   telemetry.lastMoveTick = tick;
+}
+function recordCreepBehaviorMoveTask(creep, task) {
+  if (isRuntimeCpuBucketCritical()) {
+    return;
+  }
+  const telemetry = ensureCreepBehaviorTelemetry(creep);
+  if (task.type !== "build") {
+    delete telemetry.lastMoveBuildTargetId;
+    clearBuildTargetStuckObservation(telemetry);
+    return;
+  }
+  const targetId = String(task.targetId);
+  if (telemetry.lastMoveBuildTargetId !== targetId) {
+    clearBuildTargetStuckObservation(telemetry);
+  }
+  telemetry.lastMoveBuildTargetId = targetId;
 }
 function recordCreepBehaviorWork(creep, tick = getGameTime24()) {
   var _a;
@@ -21877,6 +21895,20 @@ function ensureCreepBehaviorTelemetry(creep) {
     creep.memory.behaviorTelemetry = {};
   }
   return creep.memory.behaviorTelemetry;
+}
+function recordBuildTargetStuckObservation(telemetry) {
+  var _a;
+  const targetId = telemetry.lastMoveBuildTargetId;
+  if (!targetId) {
+    clearBuildTargetStuckObservation(telemetry);
+    return;
+  }
+  telemetry.buildTargetStuckTicks = telemetry.buildTargetStuckTargetId === targetId ? ((_a = telemetry.buildTargetStuckTicks) != null ? _a : 0) + 1 : 1;
+  telemetry.buildTargetStuckTargetId = targetId;
+}
+function clearBuildTargetStuckObservation(telemetry) {
+  delete telemetry.buildTargetStuckTicks;
+  delete telemetry.buildTargetStuckTargetId;
 }
 function toRuntimeCreepBehaviorSummary(creep) {
   const telemetry = creep.memory.behaviorTelemetry;
@@ -32209,6 +32241,7 @@ function runControllerSustainMovement(creep) {
     const energyTask = selectControllerSustainHaulerEnergyTask(creep);
     if (energyTask) {
       clearEnergyDropoffOptimizationMemory(creep);
+      clearBuildTargetStuckTelemetry(creep);
       creep.memory.task = energyTask;
       executeAssignedTask(creep, energyTask);
       return true;
@@ -32250,6 +32283,7 @@ function isSpawnSupportMemory2(value) {
 function clearAssignedTask(creep) {
   delete creep.memory.task;
   clearEnergyDropoffOptimizationMemory(creep);
+  clearBuildTargetStuckTelemetry(creep);
 }
 function moveTowardRoom3(creep, roomName) {
   if (typeof creep.moveTo !== "function") {
@@ -32447,6 +32481,7 @@ function executeAssignedTask(creep, selectedTask, immediateReselectExecutions = 
   if (execution.result === ERR_NOT_IN_RANGE_CODE6) {
     moveToAssignedTaskTarget(creep, task, target);
     recordCreepBehaviorMove(creep);
+    recordCreepBehaviorMoveTask(creep, task);
   }
 }
 function shouldImmediatelyReselectAfterTaskResult(task, result) {
@@ -32462,9 +32497,11 @@ function assignSelectedTask(creep, selectedTask, previousTask) {
   if (!selectedTask || previousTask && isSameTask2(previousTask, selectedTask)) {
     delete creep.memory.task;
     clearEnergyDropoffOptimizationMemory(creep);
+    clearBuildTargetStuckTelemetry(creep);
     return null;
   }
   clearEnergyDropoffOptimizationMemory(creep);
+  clearBuildTargetStuckTelemetry(creep);
   creep.memory.task = selectedTask;
   return selectedTask;
 }
@@ -33182,6 +33219,9 @@ function recordTaskBehavior(creep, task, execution) {
     recordCreepBehaviorMove(creep);
   } else if (execution.action === "work") {
     recordCreepBehaviorWork(creep);
+    if (task.type === "build") {
+      clearBuildTargetStuckTelemetry(creep);
+    }
   } else if (execution.result !== ERR_NOT_IN_RANGE_CODE6) {
     recordCreepBehaviorIdle(creep);
   }
@@ -33230,13 +33270,22 @@ function suppressCurrentBuildTargetIfWorkerIsStuck(creep) {
     return;
   }
   const telemetry = creep.memory.behaviorTelemetry;
-  if (((_a = telemetry == null ? void 0 : telemetry.stuckTicks) != null ? _a : 0) < BUILD_TARGET_STUCK_TICKS || ((_b = telemetry == null ? void 0 : telemetry.workTicks) != null ? _b : 0) > 0) {
+  if (((_a = telemetry == null ? void 0 : telemetry.buildTargetStuckTicks) != null ? _a : 0) < BUILD_TARGET_STUCK_TICKS || (telemetry == null ? void 0 : telemetry.buildTargetStuckTargetId) !== String(task.targetId) || ((_b = telemetry == null ? void 0 : telemetry.workTicks) != null ? _b : 0) > 0) {
     return;
   }
   suppressBuildTarget(creep, task, "stuck");
   if (telemetry) {
-    telemetry.stuckTicks = 0;
+    clearBuildTargetStuckTelemetry(creep);
   }
+}
+function clearBuildTargetStuckTelemetry(creep) {
+  const telemetry = creep.memory.behaviorTelemetry;
+  if (!telemetry) {
+    return;
+  }
+  delete telemetry.buildTargetStuckTicks;
+  delete telemetry.buildTargetStuckTargetId;
+  delete telemetry.lastMoveBuildTargetId;
 }
 function suppressBuildTarget(creep, task, reason) {
   const tick = getGameTick4();

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -27497,7 +27497,7 @@ function selectConstructionSite(creep, constructionSites, predicate = () => true
     ...options.priorityContext
   };
   const candidates = constructionSites.filter(
-    (site) => predicate(site) && canSpendCreepEnergyOnConstructionSite(creep, site, priorityContext) && (!options.requireReasonableRange || isConstructionSiteWithinReasonableRange(creep, site, DEFAULT_REASONABLE_CONSTRUCTION_SITE_RANGE))
+    (site) => predicate(site) && !isConstructionSiteSuppressedForWorker(creep, site) && canSpendCreepEnergyOnConstructionSite(creep, site, priorityContext) && (!options.requireReasonableRange || isConstructionSiteWithinReasonableRange(creep, site, DEFAULT_REASONABLE_CONSTRUCTION_SITE_RANGE))
   );
   if (candidates.length === 0) {
     return null;
@@ -27522,6 +27522,19 @@ function selectConstructionSite(creep, constructionSites, predicate = () => true
     return (_a = position.findClosestByRange(candidatesByStableId)) != null ? _a : candidatesByStableId[0];
   }
   return topImpactCandidates.sort(compareConstructionSiteId)[0];
+}
+function isConstructionSiteSuppressedForWorker(creep, site) {
+  var _a;
+  const blockedBuildTarget = (_a = creep.memory) == null ? void 0 : _a.blockedBuildTarget;
+  if (!blockedBuildTarget) {
+    return false;
+  }
+  const tick = getGameTick3();
+  if (tick !== null && blockedBuildTarget.until <= tick) {
+    delete creep.memory.blockedBuildTarget;
+    return false;
+  }
+  return String(blockedBuildTarget.targetId) === String(site.id);
 }
 function selectUnreservedConstructionSite(creep, constructionSites, constructionReservationContext, predicate = () => true, options = {}) {
   return selectConstructionSite(
@@ -31642,12 +31655,15 @@ var WORKER_STANDBY_IDLE_TIMEOUT_TICKS = 8;
 var WORKER_NULL_LOOP_FALLBACK_ATTEMPTS = 2;
 var OK_CODE11 = 0;
 var ERR_NOT_ENOUGH_RESOURCES_CODE2 = -6;
+var ERR_NO_PATH_CODE6 = -2;
 var ERR_INVALID_TARGET_CODE3 = -7;
 var ERR_FULL_CODE5 = -8;
 var ERR_NOT_IN_RANGE_CODE6 = -9;
 var ADJACENT_ACTION_MOVE_RANGE = 1;
 var RANGED_WORK_MOVE_RANGE = 3;
 var EXACT_POSITION_MOVE_RANGE = 0;
+var BUILD_TARGET_STUCK_TICKS = 2;
+var BUILD_TARGET_SUPPRESSION_TICKS = 15;
 var MIN_HAULER_DROPPED_ENERGY = 25;
 var SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS2 = 2;
 var SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS = 300;
@@ -31660,6 +31676,7 @@ function runWorker(creep) {
     return;
   }
   observeCreepBehaviorTick(creep);
+  suppressCurrentBuildTargetIfWorkerIsStuck(creep);
   const currentTask = creep.memory.task;
   const criticalCpuTaskRetention = getCriticalCpuTaskRetentionDecision(creep, currentTask);
   if (criticalCpuTaskRetention.retain) {
@@ -33179,8 +33196,14 @@ function recordTaskBehavior(creep, task, execution) {
   }
 }
 function moveToAssignedTaskTarget(creep, task, target) {
+  const result = creep.moveTo(target, getAssignedTaskMoveOptions(task));
+  if (task.type === "build" && result === getErrNoPathCode()) {
+    suppressBuildTarget(creep, task, "noPath");
+  }
+}
+function getAssignedTaskMoveOptions(task) {
   const range = getAssignedTaskMoveRange(task);
-  creep.moveTo(target, { range });
+  return task.type === "build" ? { range, ignoreCreeps: true } : { range };
 }
 function getAssignedTaskMoveRange(task) {
   switch (task.type) {
@@ -33199,6 +33222,35 @@ function getAssignedTaskMoveRange(task) {
     case "collectScore":
       return EXACT_POSITION_MOVE_RANGE;
   }
+}
+function suppressCurrentBuildTargetIfWorkerIsStuck(creep) {
+  var _a, _b;
+  const task = creep.memory.task;
+  if ((task == null ? void 0 : task.type) !== "build") {
+    return;
+  }
+  const telemetry = creep.memory.behaviorTelemetry;
+  if (((_a = telemetry == null ? void 0 : telemetry.stuckTicks) != null ? _a : 0) < BUILD_TARGET_STUCK_TICKS || ((_b = telemetry == null ? void 0 : telemetry.workTicks) != null ? _b : 0) > 0) {
+    return;
+  }
+  suppressBuildTarget(creep, task, "stuck");
+  if (telemetry) {
+    telemetry.stuckTicks = 0;
+  }
+}
+function suppressBuildTarget(creep, task, reason) {
+  const tick = getGameTick4();
+  creep.memory.blockedBuildTarget = {
+    targetId: String(task.targetId),
+    blockedAt: tick,
+    until: tick + BUILD_TARGET_SUPPRESSION_TICKS,
+    reason
+  };
+  delete creep.memory.task;
+}
+function getErrNoPathCode() {
+  const errNoPath = globalThis.ERR_NO_PATH;
+  return typeof errNoPath === "number" ? errNoPath : ERR_NO_PATH_CODE6;
 }
 function isContainerStructure3(target) {
   const structureType = target == null ? void 0 : target.structureType;
@@ -35311,7 +35363,7 @@ var MOVE_PART_COST = 50;
 var MAX_CREEP_PARTS7 = 50;
 var MAX_REMOTE_UPGRADER_PATTERN_COUNT = 4;
 var MAX_CONTROLLER_LEVEL4 = 8;
-var ERR_NO_PATH_CODE6 = -2;
+var ERR_NO_PATH_CODE7 = -2;
 var TERRITORY_ROUTE_DISTANCE_SEPARATOR4 = ">";
 var ROUTE_DISTANCE_CACHE_TTL_TICKS = 300;
 function recordPlannedMultiRoomUpgraderSpawn(memory) {
@@ -35755,7 +35807,7 @@ function isAdjacentRoom(fromRoom, targetRoom) {
 }
 function getNoPathResultCode7() {
   const noPathCode = globalThis.ERR_NO_PATH;
-  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE6;
+  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE7;
 }
 function getGameTime31() {
   var _a;
@@ -44276,7 +44328,7 @@ function isNonEmptyString34(value) {
 }
 
 // src/territory/claimedRoomBootstrapper.ts
-var ERR_NO_PATH_CODE7 = -2;
+var ERR_NO_PATH_CODE8 = -2;
 function refreshClaimedRoomBootstrapperOwnership(telemetryEvents = []) {
   var _a, _b;
   const game = globalThis.Game;
@@ -44481,7 +44533,7 @@ function getRoomRouteDistance(fromRoom, toRoom) {
     if (Array.isArray(route)) {
       return route.length;
     }
-    if (route === ERR_NO_PATH_CODE7) {
+    if (route === ERR_NO_PATH_CODE8) {
       return Number.POSITIVE_INFINITY;
     }
   }
@@ -47578,7 +47630,7 @@ function isRecord41(value) {
 
 // src/economy/economyLoop.ts
 var ERR_BUSY_CODE = -4;
-var ERR_NO_PATH_CODE8 = -2;
+var ERR_NO_PATH_CODE9 = -2;
 var OK_CODE20 = 0;
 var BOOTSTRAP_WORKER_BUFFER_BYPASS_MIN_ENERGY = 300;
 var LOW_ROOM_ENERGY_TASK_PRIORITY_RATIO = 0.5;
@@ -48297,7 +48349,7 @@ function getCrossRoomSpawnRouteDistance(sourceRoomName, targetRoomName) {
     if (Array.isArray(route)) {
       return route.length;
     }
-    if (route === ERR_NO_PATH_CODE8) {
+    if (route === ERR_NO_PATH_CODE9) {
       return Number.POSITIVE_INFINITY;
     }
   }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -33264,13 +33264,13 @@ function getAssignedTaskMoveRange(task) {
   }
 }
 function suppressCurrentBuildTargetIfWorkerIsStuck(creep) {
-  var _a, _b;
+  var _a;
   const task = creep.memory.task;
   if ((task == null ? void 0 : task.type) !== "build") {
     return;
   }
   const telemetry = creep.memory.behaviorTelemetry;
-  if (((_a = telemetry == null ? void 0 : telemetry.buildTargetStuckTicks) != null ? _a : 0) < BUILD_TARGET_STUCK_TICKS || (telemetry == null ? void 0 : telemetry.buildTargetStuckTargetId) !== String(task.targetId) || ((_b = telemetry == null ? void 0 : telemetry.workTicks) != null ? _b : 0) > 0) {
+  if (((_a = telemetry == null ? void 0 : telemetry.buildTargetStuckTicks) != null ? _a : 0) < BUILD_TARGET_STUCK_TICKS || (telemetry == null ? void 0 : telemetry.buildTargetStuckTargetId) !== String(task.targetId)) {
     return;
   }
   suppressBuildTarget(creep, task, "stuck");

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -48,6 +48,7 @@ import {
   recordCreepBehaviorEnergyAcquisition,
   recordCreepBehaviorIdle,
   recordCreepBehaviorMove,
+  recordCreepBehaviorMoveTask,
   recordCreepBehaviorRepairTarget,
   recordCreepBehaviorSourceContainerWithdrawal,
   recordCreepBehaviorWork,
@@ -950,6 +951,7 @@ function runControllerSustainMovement(creep: Creep): boolean {
     const energyTask = selectControllerSustainHaulerEnergyTask(creep);
     if (energyTask) {
       clearEnergyDropoffOptimizationMemory(creep);
+      clearBuildTargetStuckTelemetry(creep);
       creep.memory.task = energyTask;
       executeAssignedTask(creep, energyTask);
       return true;
@@ -1015,6 +1017,7 @@ function isSpawnSupportMemory(value: unknown): value is CreepSpawnSupportMemory 
 function clearAssignedTask(creep: Creep): void {
   delete creep.memory.task;
   clearEnergyDropoffOptimizationMemory(creep);
+  clearBuildTargetStuckTelemetry(creep);
 }
 
 function moveTowardRoom(creep: Creep, roomName: string): void {
@@ -1308,6 +1311,7 @@ function executeAssignedTask(
   if (execution.result === ERR_NOT_IN_RANGE_CODE) {
     moveToAssignedTaskTarget(creep, task, target as RoomObject);
     recordCreepBehaviorMove(creep);
+    recordCreepBehaviorMoveTask(creep, task);
   }
 }
 
@@ -1331,10 +1335,12 @@ function assignSelectedTask(
   if (!selectedTask || (previousTask && isSameTask(previousTask, selectedTask))) {
     delete creep.memory.task;
     clearEnergyDropoffOptimizationMemory(creep);
+    clearBuildTargetStuckTelemetry(creep);
     return null;
   }
 
   clearEnergyDropoffOptimizationMemory(creep);
+  clearBuildTargetStuckTelemetry(creep);
   creep.memory.task = selectedTask;
   return selectedTask;
 }
@@ -2424,6 +2430,9 @@ function recordTaskBehavior(
     recordCreepBehaviorMove(creep);
   } else if (execution.action === 'work') {
     recordCreepBehaviorWork(creep);
+    if (task.type === 'build') {
+      clearBuildTargetStuckTelemetry(creep);
+    }
   } else if (execution.result !== ERR_NOT_IN_RANGE_CODE) {
     recordCreepBehaviorIdle(creep);
   }
@@ -2479,14 +2488,29 @@ function suppressCurrentBuildTargetIfWorkerIsStuck(creep: Creep): void {
   }
 
   const telemetry = creep.memory.behaviorTelemetry;
-  if ((telemetry?.stuckTicks ?? 0) < BUILD_TARGET_STUCK_TICKS || (telemetry?.workTicks ?? 0) > 0) {
+  if (
+    (telemetry?.buildTargetStuckTicks ?? 0) < BUILD_TARGET_STUCK_TICKS ||
+    telemetry?.buildTargetStuckTargetId !== String(task.targetId) ||
+    (telemetry?.workTicks ?? 0) > 0
+  ) {
     return;
   }
 
   suppressBuildTarget(creep, task, 'stuck');
   if (telemetry) {
-    telemetry.stuckTicks = 0;
+    clearBuildTargetStuckTelemetry(creep);
   }
+}
+
+function clearBuildTargetStuckTelemetry(creep: Creep): void {
+  const telemetry = creep.memory.behaviorTelemetry;
+  if (!telemetry) {
+    return;
+  }
+
+  delete telemetry.buildTargetStuckTicks;
+  delete telemetry.buildTargetStuckTargetId;
+  delete telemetry.lastMoveBuildTargetId;
 }
 
 function suppressBuildTarget(

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -2490,8 +2490,7 @@ function suppressCurrentBuildTargetIfWorkerIsStuck(creep: Creep): void {
   const telemetry = creep.memory.behaviorTelemetry;
   if (
     (telemetry?.buildTargetStuckTicks ?? 0) < BUILD_TARGET_STUCK_TICKS ||
-    telemetry?.buildTargetStuckTargetId !== String(task.targetId) ||
-    (telemetry?.workTicks ?? 0) > 0
+    telemetry?.buildTargetStuckTargetId !== String(task.targetId)
   ) {
     return;
   }

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -69,12 +69,15 @@ const WORKER_STANDBY_IDLE_TIMEOUT_TICKS = 8;
 const WORKER_NULL_LOOP_FALLBACK_ATTEMPTS = 2;
 const OK_CODE = 0 as ScreepsReturnCode;
 const ERR_NOT_ENOUGH_RESOURCES_CODE = -6 as ScreepsReturnCode;
+const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
 const ERR_INVALID_TARGET_CODE = -7 as ScreepsReturnCode;
 const ERR_FULL_CODE = -8 as ScreepsReturnCode;
 const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
 const ADJACENT_ACTION_MOVE_RANGE = 1;
 const RANGED_WORK_MOVE_RANGE = 3;
 const EXACT_POSITION_MOVE_RANGE = 0;
+const BUILD_TARGET_STUCK_TICKS = 2;
+const BUILD_TARGET_SUPPRESSION_TICKS = 15;
 const MIN_HAULER_DROPPED_ENERGY = 25;
 const SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_WORKERS = 2;
 const SPAWN_RESERVATION_PRODUCTIVE_WORK_MIN_STORED_SURPLUS = 300;
@@ -126,6 +129,7 @@ export function runWorker(creep: Creep): void {
     return;
   }
   observeCreepBehaviorTick(creep);
+  suppressCurrentBuildTargetIfWorkerIsStuck(creep);
 
   const currentTask = creep.memory.task;
   const criticalCpuTaskRetention = getCriticalCpuTaskRetentionDecision(creep, currentTask);
@@ -2438,8 +2442,15 @@ function recordTaskBehavior(
 }
 
 function moveToAssignedTaskTarget(creep: Creep, task: CreepTaskMemory, target: RoomObject): void {
+  const result = creep.moveTo(target, getAssignedTaskMoveOptions(task));
+  if (task.type === 'build' && result === getErrNoPathCode()) {
+    suppressBuildTarget(creep, task, 'noPath');
+  }
+}
+
+function getAssignedTaskMoveOptions(task: CreepTaskMemory): MoveToOpts {
   const range = getAssignedTaskMoveRange(task);
-  creep.moveTo(target, { range });
+  return task.type === 'build' ? { range, ignoreCreeps: true } : { range };
 }
 
 function getAssignedTaskMoveRange(task: CreepTaskMemory): number {
@@ -2459,6 +2470,43 @@ function getAssignedTaskMoveRange(task: CreepTaskMemory): number {
     case 'collectScore':
       return EXACT_POSITION_MOVE_RANGE;
   }
+}
+
+function suppressCurrentBuildTargetIfWorkerIsStuck(creep: Creep): void {
+  const task = creep.memory.task;
+  if (task?.type !== 'build') {
+    return;
+  }
+
+  const telemetry = creep.memory.behaviorTelemetry;
+  if ((telemetry?.stuckTicks ?? 0) < BUILD_TARGET_STUCK_TICKS || (telemetry?.workTicks ?? 0) > 0) {
+    return;
+  }
+
+  suppressBuildTarget(creep, task, 'stuck');
+  if (telemetry) {
+    telemetry.stuckTicks = 0;
+  }
+}
+
+function suppressBuildTarget(
+  creep: Creep,
+  task: Extract<CreepTaskMemory, { type: 'build' }>,
+  reason: WorkerBlockedBuildTargetMemory['reason']
+): void {
+  const tick = getGameTick();
+  creep.memory.blockedBuildTarget = {
+    targetId: String(task.targetId),
+    blockedAt: tick,
+    until: tick + BUILD_TARGET_SUPPRESSION_TICKS,
+    reason
+  };
+  delete creep.memory.task;
+}
+
+function getErrNoPathCode(): ScreepsReturnCode {
+  const errNoPath = (globalThis as unknown as { ERR_NO_PATH?: ScreepsReturnCode }).ERR_NO_PATH;
+  return typeof errNoPath === 'number' ? errNoPath : ERR_NO_PATH_CODE;
 }
 
 function isContainerStructure(target: unknown): boolean {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -3430,6 +3430,7 @@ function selectConstructionSite(
   const candidates = constructionSites.filter(
     (site) =>
       predicate(site) &&
+      !isConstructionSiteSuppressedForWorker(creep, site) &&
       canSpendCreepEnergyOnConstructionSite(creep, site, priorityContext) &&
       (!options.requireReasonableRange ||
         isConstructionSiteWithinReasonableRange(creep, site, DEFAULT_REASONABLE_CONSTRUCTION_SITE_RANGE))
@@ -3467,6 +3468,21 @@ function selectConstructionSite(
   }
 
   return topImpactCandidates.sort(compareConstructionSiteId)[0];
+}
+
+function isConstructionSiteSuppressedForWorker(creep: Creep, site: ConstructionSite): boolean {
+  const blockedBuildTarget = creep.memory?.blockedBuildTarget;
+  if (!blockedBuildTarget) {
+    return false;
+  }
+
+  const tick = getGameTick();
+  if (tick !== null && blockedBuildTarget.until <= tick) {
+    delete creep.memory.blockedBuildTarget;
+    return false;
+  }
+
+  return String(blockedBuildTarget.targetId) === String(site.id);
 }
 
 function selectUnreservedConstructionSite(

--- a/prod/src/telemetry/behaviorTelemetry.ts
+++ b/prod/src/telemetry/behaviorTelemetry.ts
@@ -87,8 +87,10 @@ export function observeCreepBehaviorTick(creep: Creep, tick: number = getGameTim
     const stepDistance = getStepDistance(telemetry.lastPosition, currentPosition);
     if (stepDistance > 0) {
       telemetry.pathLength = (telemetry.pathLength ?? 0) + stepDistance;
+      clearBuildTargetStuckObservation(telemetry);
     } else {
       telemetry.stuckTicks = (telemetry.stuckTicks ?? 0) + 1;
+      recordBuildTargetStuckObservation(telemetry);
     }
   }
 
@@ -124,6 +126,25 @@ export function recordCreepBehaviorMove(creep: Creep, tick: number = getGameTime
 
   telemetry.moveTicks = (telemetry.moveTicks ?? 0) + 1;
   telemetry.lastMoveTick = tick;
+}
+
+export function recordCreepBehaviorMoveTask(creep: Creep, task: CreepTaskMemory): void {
+  if (isRuntimeCpuBucketCritical()) {
+    return;
+  }
+
+  const telemetry = ensureCreepBehaviorTelemetry(creep);
+  if (task.type !== 'build') {
+    delete telemetry.lastMoveBuildTargetId;
+    clearBuildTargetStuckObservation(telemetry);
+    return;
+  }
+
+  const targetId = String(task.targetId);
+  if (telemetry.lastMoveBuildTargetId !== targetId) {
+    clearBuildTargetStuckObservation(telemetry);
+  }
+  telemetry.lastMoveBuildTargetId = targetId;
 }
 
 export function recordCreepBehaviorWork(creep: Creep, tick: number = getGameTime()): void {
@@ -213,6 +234,23 @@ function ensureCreepBehaviorTelemetry(creep: Creep): CreepBehaviorTelemetryMemor
   }
 
   return creep.memory.behaviorTelemetry;
+}
+
+function recordBuildTargetStuckObservation(telemetry: CreepBehaviorTelemetryMemory): void {
+  const targetId = telemetry.lastMoveBuildTargetId;
+  if (!targetId) {
+    clearBuildTargetStuckObservation(telemetry);
+    return;
+  }
+
+  telemetry.buildTargetStuckTicks =
+    telemetry.buildTargetStuckTargetId === targetId ? (telemetry.buildTargetStuckTicks ?? 0) + 1 : 1;
+  telemetry.buildTargetStuckTargetId = targetId;
+}
+
+function clearBuildTargetStuckObservation(telemetry: CreepBehaviorTelemetryMemory): void {
+  delete telemetry.buildTargetStuckTicks;
+  delete telemetry.buildTargetStuckTargetId;
 }
 
 function toRuntimeCreepBehaviorSummary(creep: Creep): RuntimeCreepBehaviorSummary | null {

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -61,6 +61,7 @@ declare global {
     workerDispatchDiagnostic?: WorkerDispatchDiagnosticMemory;
     energyDropoffOptimization?: WorkerEnergyDropoffOptimizationMemory;
     behaviorTelemetry?: CreepBehaviorTelemetryMemory;
+    blockedBuildTarget?: WorkerBlockedBuildTargetMemory;
     crossRoomHauler?: CreepCrossRoomHaulerMemory;
     spawnSupport?: CreepSpawnSupportMemory;
     mineralHarvester?: CreepMineralHarvesterMemory;
@@ -1329,6 +1330,13 @@ declare global {
     lastObservedTick?: number;
     lastIdleTick?: number;
     lastSourceContainerWithdrawalTick?: number;
+  }
+
+  interface WorkerBlockedBuildTargetMemory {
+    targetId: string;
+    blockedAt: number;
+    until: number;
+    reason: 'stuck' | 'noPath';
   }
 
   type CreepTaskMemory =

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -1324,6 +1324,9 @@ declare global {
     energyAcquisitionPickedUp?: number;
     energyAcquisitionWithdrawn?: number;
     pathLength?: number;
+    buildTargetStuckTicks?: number;
+    buildTargetStuckTargetId?: string;
+    lastMoveBuildTargetId?: string;
     lastPosition?: CreepBehaviorPositionMemory;
     lastMoveTick?: number;
     lastWorkTick?: number;

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -2887,6 +2887,55 @@ describe('runWorker', () => {
     expect(creep.memory.behaviorTelemetry?.buildTargetStuckTargetId).toBeUndefined();
   });
 
+  it('suppresses a blocked build target after earlier work on a different site', () => {
+    const build = jest.fn();
+    const moveTo = jest.fn();
+    const getObjectById = jest.fn();
+    const creep = {
+      memory: {
+        task: { type: 'build', targetId: 'site2' as Id<ConstructionSite> },
+        behaviorTelemetry: {
+          stuckTicks: 2,
+          workTicks: 1,
+          buildTargetStuckTicks: 2,
+          buildTargetStuckTargetId: 'site2',
+          lastMoveBuildTargetId: 'site2'
+        }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: { find: jest.fn().mockReturnValue([]) },
+      build,
+      moveTo
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById,
+      time: 200
+    };
+
+    runWorker(creep);
+
+    expect(getObjectById).not.toHaveBeenCalledWith('site2');
+    expect(build).not.toHaveBeenCalled();
+    expect(moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.task).toBeUndefined();
+    expect(creep.memory.blockedBuildTarget).toEqual({
+      targetId: 'site2',
+      blockedAt: 200,
+      until: 215,
+      reason: 'stuck'
+    });
+    expect(creep.memory.behaviorTelemetry).toMatchObject({
+      stuckTicks: 2,
+      workTicks: 1
+    });
+    expect(creep.memory.behaviorTelemetry?.buildTargetStuckTicks).toBeUndefined();
+    expect(creep.memory.behaviorTelemetry?.buildTargetStuckTargetId).toBeUndefined();
+    expect(creep.memory.behaviorTelemetry?.lastMoveBuildTargetId).toBeUndefined();
+  });
+
   it('repairs an existing repair target and moves when not in range', () => {
     const road = { id: 'road1', hits: 1_000, hitsMax: 5_000 } as StructureRoad;
     const repair = jest.fn().mockReturnValue(-9);

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -2712,7 +2712,80 @@ describe('runWorker', () => {
 
     expect(getObjectById).toHaveBeenCalledWith('site1');
     expect(build).toHaveBeenCalledWith(site);
-    expect(moveTo).toHaveBeenCalledWith(site, { range: 3 });
+    expect(moveTo).toHaveBeenCalledWith(site, { range: 3, ignoreCreeps: true });
+  });
+
+  it('suppresses an existing build target when movement cannot find a path', () => {
+    const site = { id: 'site1' } as ConstructionSite;
+    const build = jest.fn().mockReturnValue(-9);
+    const moveTo = jest.fn().mockReturnValue(-2);
+    const getObjectById = jest.fn().mockReturnValue(site);
+    const creep = {
+      memory: { task: { type: 'build', targetId: 'site1' as Id<ConstructionSite> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room: { find: jest.fn().mockReturnValue([]) },
+      build,
+      moveTo
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById,
+      time: 200
+    };
+
+    runWorker(creep);
+
+    expect(build).toHaveBeenCalledWith(site);
+    expect(moveTo).toHaveBeenCalledWith(site, { range: 3, ignoreCreeps: true });
+    expect(creep.memory.task).toBeUndefined();
+    expect(creep.memory.blockedBuildTarget).toEqual({
+      targetId: 'site1',
+      blockedAt: 200,
+      until: 215,
+      reason: 'noPath'
+    });
+  });
+
+  it('suppresses a no-work stuck build task before retaining it', () => {
+    const build = jest.fn();
+    const moveTo = jest.fn();
+    const getObjectById = jest.fn();
+    const creep = {
+      memory: {
+        task: { type: 'build', targetId: 'site1' as Id<ConstructionSite> },
+        behaviorTelemetry: {
+          stuckTicks: 2,
+          workTicks: 0
+        }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: { find: jest.fn().mockReturnValue([]) },
+      build,
+      moveTo
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById,
+      time: 200
+    };
+
+    runWorker(creep);
+
+    expect(getObjectById).not.toHaveBeenCalledWith('site1');
+    expect(build).not.toHaveBeenCalled();
+    expect(moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.task).toBeUndefined();
+    expect(creep.memory.blockedBuildTarget).toEqual({
+      targetId: 'site1',
+      blockedAt: 200,
+      until: 215,
+      reason: 'stuck'
+    });
+    expect(creep.memory.behaviorTelemetry?.stuckTicks).toBe(0);
   });
 
   it('repairs an existing repair target and moves when not in range', () => {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -2748,6 +2748,51 @@ describe('runWorker', () => {
     });
   });
 
+  it('clears build-target stuck telemetry after successful build work', () => {
+    const site = { id: 'site1' } as ConstructionSite;
+    const build = jest.fn().mockReturnValue(0);
+    const moveTo = jest.fn();
+    const getObjectById = jest.fn().mockReturnValue(site);
+    const creep = {
+      memory: {
+        task: { type: 'build', targetId: 'site1' as Id<ConstructionSite> },
+        behaviorTelemetry: {
+          stuckTicks: 1,
+          workTicks: 0,
+          buildTargetStuckTicks: 1,
+          buildTargetStuckTargetId: 'site1',
+          lastMoveBuildTargetId: 'site1'
+        }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: { find: jest.fn().mockReturnValue([]) },
+      build,
+      moveTo
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById,
+      time: 200
+    };
+
+    runWorker(creep);
+
+    expect(getObjectById).toHaveBeenCalledWith('site1');
+    expect(build).toHaveBeenCalledWith(site);
+    expect(moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'site1' });
+    expect(creep.memory.blockedBuildTarget).toBeUndefined();
+    expect(creep.memory.behaviorTelemetry).toMatchObject({
+      stuckTicks: 1,
+      workTicks: 1
+    });
+    expect(creep.memory.behaviorTelemetry?.buildTargetStuckTicks).toBeUndefined();
+    expect(creep.memory.behaviorTelemetry?.buildTargetStuckTargetId).toBeUndefined();
+    expect(creep.memory.behaviorTelemetry?.lastMoveBuildTargetId).toBeUndefined();
+  });
+
   it('suppresses a no-work stuck build task before retaining it', () => {
     const build = jest.fn();
     const moveTo = jest.fn();
@@ -2757,7 +2802,10 @@ describe('runWorker', () => {
         task: { type: 'build', targetId: 'site1' as Id<ConstructionSite> },
         behaviorTelemetry: {
           stuckTicks: 2,
-          workTicks: 0
+          workTicks: 0,
+          buildTargetStuckTicks: 2,
+          buildTargetStuckTargetId: 'site1',
+          lastMoveBuildTargetId: 'site1'
         }
       },
       store: {
@@ -2785,7 +2833,58 @@ describe('runWorker', () => {
       until: 215,
       reason: 'stuck'
     });
-    expect(creep.memory.behaviorTelemetry?.stuckTicks).toBe(0);
+    expect(creep.memory.behaviorTelemetry).toMatchObject({
+      stuckTicks: 2,
+      workTicks: 0
+    });
+    expect(creep.memory.behaviorTelemetry?.buildTargetStuckTicks).toBeUndefined();
+    expect(creep.memory.behaviorTelemetry?.buildTargetStuckTargetId).toBeUndefined();
+    expect(creep.memory.behaviorTelemetry?.lastMoveBuildTargetId).toBeUndefined();
+  });
+
+  it('does not suppress a new build target with stale stuck telemetry from a previous target', () => {
+    const site = { id: 'site2' } as ConstructionSite;
+    const build = jest.fn().mockReturnValue(ERR_NOT_IN_RANGE);
+    const moveTo = jest.fn();
+    const getObjectById = jest.fn().mockReturnValue(site);
+    const creep = {
+      memory: {
+        task: { type: 'build', targetId: 'site2' as Id<ConstructionSite> },
+        behaviorTelemetry: {
+          stuckTicks: 2,
+          workTicks: 0,
+          buildTargetStuckTicks: 2,
+          buildTargetStuckTargetId: 'site1',
+          lastMoveBuildTargetId: 'site1'
+        }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: { find: jest.fn().mockReturnValue([]) },
+      build,
+      moveTo
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById,
+      time: 200
+    };
+
+    runWorker(creep);
+
+    expect(getObjectById).toHaveBeenCalledWith('site2');
+    expect(build).toHaveBeenCalledWith(site);
+    expect(moveTo).toHaveBeenCalledWith(site, { range: 3, ignoreCreeps: true });
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'site2' });
+    expect(creep.memory.blockedBuildTarget).toBeUndefined();
+    expect(creep.memory.behaviorTelemetry).toMatchObject({
+      stuckTicks: 2,
+      workTicks: 0,
+      lastMoveBuildTargetId: 'site2'
+    });
+    expect(creep.memory.behaviorTelemetry?.buildTargetStuckTicks).toBeUndefined();
+    expect(creep.memory.behaviorTelemetry?.buildTargetStuckTargetId).toBeUndefined();
   });
 
   it('repairs an existing repair target and moves when not in range', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1423,6 +1423,64 @@ describe('selectWorkerTask', () => {
     expect(creep.memory.constructionPreBuffer).toBeUndefined();
   });
 
+  it('skips a temporarily blocked construction site for a loaded builder', () => {
+    const blockedSite = {
+      id: 'blocked-site',
+      my: true,
+      structureType: 'extension',
+      progress: 0,
+      progressTotal: 3_000,
+      pos: makeRoomPosition(20, 20)
+    } as ConstructionSite;
+    const openSite = {
+      id: 'open-site',
+      my: true,
+      structureType: 'extension',
+      progress: 0,
+      progressTotal: 3_000,
+      pos: makeRoomPosition(21, 20)
+    } as ConstructionSite;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [blockedSite, openSite],
+      energyAvailable: 650,
+      energyCapacityAvailable: 800
+    });
+    const creep = {
+      name: 'BlockedBuilder',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        blockedBuildTarget: {
+          targetId: 'blocked-site',
+          blockedAt: 100,
+          until: 130,
+          reason: 'stuck'
+        }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0),
+        getCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => {
+          const ranges: Record<string, number> = {
+            'blocked-site': 1,
+            'open-site': 2
+          };
+          return ranges[String(target.id)] ?? 99;
+        })
+      },
+      room
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { BlockedBuilder: creep },
+      time: 115
+    };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'open-site' });
+  });
+
   it('lets spare loaded workers finish construction below the general spend floor', () => {
     const constructionSite = {
       id: 'extension-site',


### PR DESCRIPTION
Fixes #1612

## Summary
- Adds short-lived per-creep build-target suppression when a builder records no-path movement or repeated no-work stuck telemetry on the same construction target.
- Lets loaded builders skip a suppressed construction site and select an alternate reachable build target.
- Uses `ignoreCreeps: true` for build-task movement to reduce transient destination congestion at construction sites.

## Verification
- Controller reconciled branch onto `origin/main` `3722e6c33a12` before verification.
- `git diff --check` — PASS.
- `npm run typecheck` from `prod/` — PASS.
- `npm test -- --runInBand` from `prod/` — PASS: 103 suites, 2176 tests.
- `npm run build` from `prod/` — PASS.
- Final `git diff --check` — PASS.

## Issue closure gate
- [x] #1612: commit `a83cf7997c02e9381e121bf0b951d4c30e2d7ab0` adds deterministic builder build-target suppression plus worker-task tests for alternate construction-site selection, with full controller verification recorded above.

## Universal task Done gate
- [x] Task type: P1 Territory/Economy production-code bugfix.
- [x] Expected observable outcome / named deliverable: loaded E29N57 builders stop repeatedly reselecting the same path-failing construction target and can choose another eligible construction site.
- [x] Non-goals / accepted substitutes: no RL reward tuning, no Tencent compute, no room retargeting, and no construction-priority rewrite.
- [x] Verification evidence required before Done: `git diff --check`, `npm run typecheck`, `npm test -- --runInBand`, `npm run build`, and final `git diff --check` all passed in the controller worktree.
- [x] Project Evidence / Next action / Blocked by: #1612 and this PR Project items are set to In review with commit `a83cf7997c02e9381e121bf0b951d4c30e2d7ab0`, the verification commands above, and exact review-gate next action.
- [x] Post-merge/deploy/runtime proof: runtime proof contract is E29N57 builder `workTicks` or build progress without repeated same-site `destinationBlocked=1` in fresh runtime-summary artifacts.
- [x] Named deliverable proof: `prod/src/creeps/workerRunner.ts`, `prod/src/tasks/workerTasks.ts`, `prod/src/types.d.ts`, `prod/test/workerRunner.test.ts`, `prod/test/workerTasks.test.ts`, and regenerated `prod/dist/main.js` are changed in commit `a83cf7997c02e9381e121bf0b951d4c30e2d7ab0`.
