### PR TITLE
rl: persist gradient momentum evidence for policy updates

### DIFF
--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -1184,8 +1184,10 @@ def run_training_experiment(
         mark_candidate_scorecard_materialization_failed(report, error)
     state_artifact_path = policy_gradient_momentum_state_artifact_path_for_report(report, report_path.parent)
     previous_state_artifact_bytes = None
-    if state_artifact_path is not None and state_artifact_path.exists():
+    previous_state_artifact_existed = state_artifact_path is not None and state_artifact_path.exists()
+    if previous_state_artifact_existed:
         try:
+            assert state_artifact_path is not None
             previous_state_artifact_bytes = state_artifact_path.read_bytes()
         except OSError as error:
             warning = (
@@ -1211,6 +1213,7 @@ def run_training_experiment(
             rollback_policy_gradient_momentum_state_artifact(
                 materialized_state_artifact_path,
                 previous_state_artifact_bytes,
+                previous_artifact_existed=previous_state_artifact_existed,
             )
         raise
     report["reportPath"] = dataset_export.display_path(report_path)
@@ -7962,8 +7965,15 @@ def write_json_atomic(path: Path, payload: Any) -> None:
             pass
 
 
-def rollback_policy_gradient_momentum_state_artifact(path: Path, previous_bytes: bytes | None) -> None:
+def rollback_policy_gradient_momentum_state_artifact(
+    path: Path,
+    previous_bytes: bytes | None,
+    *,
+    previous_artifact_existed: bool = False,
+) -> None:
     if previous_bytes is None:
+        if previous_artifact_existed:
+            return
         try:
             path.unlink()
         except FileNotFoundError:

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -1182,9 +1182,26 @@ def run_training_experiment(
         materialize_candidate_scorecard_artifact(report, report_path.parent, report_secret_values)
     except scorecard_helper.ScorecardError as error:
         mark_candidate_scorecard_materialization_failed(report, error)
-    materialize_policy_gradient_momentum_state(report, report_path.parent, report_path, report_secret_values)
-    assert_no_secret_leak(report, report_secret_values)
-    write_json_atomic(report_path, report)
+    state_artifact_path = policy_gradient_momentum_state_artifact_path_for_report(report, report_path.parent)
+    previous_state_artifact_bytes = None
+    if state_artifact_path is not None and state_artifact_path.exists():
+        previous_state_artifact_bytes = state_artifact_path.read_bytes()
+    materialized_state_artifact_path = materialize_policy_gradient_momentum_state(
+        report,
+        report_path.parent,
+        report_path,
+        report_secret_values,
+    )
+    try:
+        assert_no_secret_leak(report, report_secret_values)
+        write_json_atomic(report_path, report)
+    except Exception:
+        if materialized_state_artifact_path is not None:
+            rollback_policy_gradient_momentum_state_artifact(
+                materialized_state_artifact_path,
+                previous_state_artifact_bytes,
+            )
+        raise
     report["reportPath"] = dataset_export.display_path(report_path)
     if stdout is not None:
         stdout.write(canonical_json(build_generation_summary(report)))
@@ -3461,8 +3478,11 @@ def load_policy_gradient_momentum_state(policy_gradient: JsonObject | None, out_
         state_reference["previousStateArtifactLoadError"] = "gradient momentum state artifact was not a JSON object"
         return state_reference
     state_payload_hash = policy_update_gradient_momentum_state_payload_hash(raw_payload)
-    stored_payload_hash = text_or_none(raw_payload.get("statePayloadHash"))
-    if stored_payload_hash is not None and stored_payload_hash != state_payload_hash:
+    stored_payload_hash = raw_payload.get("statePayloadHash")
+    if not isinstance(stored_payload_hash, str) or not stored_payload_hash:
+        state_reference["previousStateArtifactLoadError"] = "gradient momentum state payload hash was missing or invalid"
+        return state_reference
+    if stored_payload_hash != state_payload_hash:
         state_reference["previousStateArtifactLoadError"] = "gradient momentum state payload hash did not match artifact contents"
         return state_reference
 
@@ -4534,20 +4554,20 @@ def materialize_policy_gradient_momentum_state(
     out_dir: Path,
     report_path: Path,
     secret_values: Sequence[str] = (),
-) -> None:
+) -> Path | None:
     if report.get("trueGradient") is not True:
-        return
+        return None
     update = report.get("policyUpdate")
     policy_gradient = report.get("policyGradient")
     if not isinstance(update, dict) or not isinstance(policy_gradient, dict):
-        return
+        return None
     momentum = update.get("gradientMomentum")
     if not isinstance(momentum, dict):
-        return
+        return None
     state_identity = policy_update_gradient_momentum_state_identity(policy_gradient)
     state_path = policy_update_gradient_momentum_state_path(policy_gradient, out_dir)
     if state_identity is None or state_path is None:
-        return
+        return None
 
     state_key = policy_update_gradient_momentum_state_key(state_identity)
     state_artifact_path = dataset_export.display_path(state_path)
@@ -4621,6 +4641,7 @@ def materialize_policy_gradient_momentum_state(
             "stateMaterialized": True,
         },
     )
+    return state_path
 
 
 def update_gradient_momentum_report_metadata(report: JsonObject, metadata: JsonObject) -> None:
@@ -4635,6 +4656,18 @@ def update_gradient_momentum_report_metadata(report: JsonObject, metadata: JsonO
         parameter_evidence = next_candidate_policy.get("parameterEvidence")
         if isinstance(parameter_evidence, dict):
             parameter_evidence["gradientMomentum"] = copy.deepcopy(update["gradientMomentum"])
+
+
+def policy_gradient_momentum_state_artifact_path_for_report(report: JsonObject, out_dir: Path) -> Path | None:
+    if report.get("trueGradient") is not True:
+        return None
+    update = report.get("policyUpdate")
+    policy_gradient = report.get("policyGradient")
+    if not isinstance(update, dict) or not isinstance(policy_gradient, dict):
+        return None
+    if not isinstance(update.get("gradientMomentum"), dict):
+        return None
+    return policy_update_gradient_momentum_state_path(policy_gradient, out_dir)
 
 
 def materialize_candidate_scorecard_artifact(
@@ -7857,6 +7890,34 @@ def write_json_atomic(path: Path, payload: Any) -> None:
         with os.fdopen(temp_fd, "w", encoding="utf-8") as handle:
             temp_fd = -1
             handle.write(canonical_json(payload))
+        os.replace(temp_path, path)
+    finally:
+        if temp_fd != -1:
+            try:
+                os.close(temp_fd)
+            except OSError:
+                pass
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def rollback_policy_gradient_momentum_state_artifact(path: Path, previous_bytes: bytes | None) -> None:
+    if previous_bytes is None:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        return
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".rollback.tmp", dir=str(path.parent))
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(temp_fd, "wb") as handle:
+            temp_fd = -1
+            handle.write(previous_bytes)
         os.replace(temp_path, path)
     finally:
         if temp_fd != -1:

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -76,6 +76,9 @@ DEFAULT_GRADIENT_EMA_DECAY = 0.8
 GRADIENT_ESTIMATION_EVIDENCE_TYPE = "screeps-rl-gradient-estimation-evidence"
 GRADIENT_ESTIMATION_SCHEME_TYPE = "screeps-rl-gradient-estimation-scheme"
 GRADIENT_MOMENTUM_EVIDENCE_TYPE = "screeps-rl-gradient-momentum-evidence"
+GRADIENT_MOMENTUM_STATE_TYPE = "screeps-rl-gradient-momentum-state"
+GRADIENT_MOMENTUM_STATE_IDENTITY_TYPE = "screeps-rl-gradient-momentum-state-identity"
+GRADIENT_MOMENTUM_STATE_ARTIFACT_DIR = "gradient-momentum"
 POLICY_GRADIENT_SCALAR_ESTIMATOR = "scalar_weighted_sum_score_function_reinforce_v1"
 POLICY_GRADIENT_SCALAR_REWARD = "scalar_weighted_sum"
 POLICY_GRADIENT_SCALAR_WEIGHTED_SUM_USE = "gradient_estimation_only_non_promotional"
@@ -1142,6 +1145,11 @@ def run_training_experiment(
     resolved_report_id = report_id or default_report_id(card, variants, config)
     validate_report_id(resolved_report_id)
     ensure_steam_key_for_training(simulator_runner=simulator_runner, env_file=steam_key_env_file)
+    resolved_out_dir = out_dir.expanduser()
+    previous_gradient_momentum_state = load_policy_gradient_momentum_state(
+        policy_gradient_metadata_from_card(card),
+        resolved_out_dir,
+    )
 
     simulator_runs = execute_simulator_runs(
         simulator_runner=simulator_runner,
@@ -1160,10 +1168,11 @@ def run_training_experiment(
         reward_options=reward_options,
         report_id=resolved_report_id,
         generated_at=generated_at or utc_now_iso(),
+        previous_gradient_momentum_state=previous_gradient_momentum_state,
     )
     report_secret_values = dataset_export.configured_secret_values() + [os.environ.get("STEAM_KEY", "")]
     assert_no_secret_leak(report, report_secret_values)
-    report_path = out_dir.expanduser() / f"{resolved_report_id}.json"
+    report_path = resolved_out_dir / f"{resolved_report_id}.json"
     policy_artifacts = materialize_policy_update_artifacts(report, report_path.parent)
     for _artifact_path, artifact_payload in policy_artifacts:
         assert_no_secret_leak(artifact_payload, report_secret_values)
@@ -1173,6 +1182,7 @@ def run_training_experiment(
         materialize_candidate_scorecard_artifact(report, report_path.parent, report_secret_values)
     except scorecard_helper.ScorecardError as error:
         mark_candidate_scorecard_materialization_failed(report, error)
+    materialize_policy_gradient_momentum_state(report, report_path.parent, report_path)
     assert_no_secret_leak(report, report_secret_values)
     write_json_atomic(report_path, report)
     report["reportPath"] = dataset_export.display_path(report_path)
@@ -1734,6 +1744,7 @@ def build_training_report(
     reward_options: JsonObject,
     report_id: str,
     generated_at: str,
+    previous_gradient_momentum_state: JsonObject | None = None,
 ) -> JsonObject:
     per_variant_runs = collect_variant_runs(simulator_runs, [variant.id for variant in variants])
     scenario = scenario_metadata_from_card(card)
@@ -1774,6 +1785,11 @@ def build_training_report(
         else None
     )
     policy_gradient = policy_gradient_metadata_from_card(card, runtime_parameter_injection=runtime_parameter_injection)
+    if policy_gradient is not None and isinstance(previous_gradient_momentum_state, dict):
+        policy_gradient = policy_gradient_with_loaded_gradient_momentum_state(
+            policy_gradient,
+            previous_gradient_momentum_state,
+        )
     if (
         policy_gradient is not None
         and scenario is not None
@@ -3349,6 +3365,175 @@ def policy_update_scalar_reward(return_tuple: Sequence[Any], weights: JsonObject
     return total
 
 
+def policy_update_expected_true_gradient_scheme_identity(policy_gradient: JsonObject) -> JsonObject | None:
+    if policy_update_algorithm(policy_gradient) != TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM:
+        return None
+    if policy_gradient_scalar_weighted_sum_authorized(policy_gradient):
+        reward_model = first_mapping(policy_gradient, ("reward_model", "rewardModel"))
+        return policy_update_scalar_gradient_scheme_identity(
+            policy_update_scalar_reward_weight_evidence(policy_gradient),
+            scalar_weighted_sum_authorized=True,
+            scalar_weighted_sum_use=scalar_weighted_sum_use(reward_model),
+        )
+    return policy_update_lexicographic_reinforce_gradient_scheme_identity()
+
+
+def policy_update_gradient_momentum_state_identity(policy_gradient: JsonObject) -> JsonObject | None:
+    scheme_identity = policy_update_expected_true_gradient_scheme_identity(policy_gradient)
+    if scheme_identity is None:
+        return None
+    target_family = text_or_none(policy_gradient.get("target_family", policy_gradient.get("targetFamily"))) or "unknown"
+    return {
+        "type": GRADIENT_MOMENTUM_STATE_IDENTITY_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "targetFamily": target_family,
+        "policyUpdateAlgorithm": TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM,
+        "gradientComparisonKey": policy_update_gradient_scheme_comparison_key(scheme_identity),
+        "gradientSchemeIdentity": policy_update_gradient_scheme_comparison_identity(scheme_identity),
+        "learnableParameters": copy.deepcopy(policy_update_parameter_space(policy_gradient)),
+    }
+
+
+def policy_update_gradient_momentum_state_key(identity: JsonObject) -> str:
+    return canonical_hash(identity)
+
+
+def policy_update_gradient_momentum_state_path(policy_gradient: JsonObject, out_dir: Path) -> Path | None:
+    identity = policy_update_gradient_momentum_state_identity(policy_gradient)
+    if identity is None:
+        return None
+    target_family = safe_artifact_stem(text_or_none(identity.get("targetFamily")) or "unknown")[:80]
+    state_key = policy_update_gradient_momentum_state_key(identity)
+    return out_dir / GRADIENT_MOMENTUM_STATE_ARTIFACT_DIR / f"{target_family}-{state_key[:16]}.json"
+
+
+def policy_update_gradient_momentum_state_reference(policy_gradient: JsonObject, out_dir: Path) -> JsonObject | None:
+    identity = policy_update_gradient_momentum_state_identity(policy_gradient)
+    if identity is None:
+        return None
+    state_path = policy_update_gradient_momentum_state_path(policy_gradient, out_dir)
+    if state_path is None:
+        return None
+    return {
+        "type": GRADIENT_MOMENTUM_STATE_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "stateIdentity": identity,
+        "stateKey": policy_update_gradient_momentum_state_key(identity),
+        "stateArtifactPath": dataset_export.display_path(state_path),
+        "previousStateArtifactPresent": state_path.exists(),
+        "previousStateArtifactLoaded": False,
+        "previousGradientPresent": False,
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+        "safety": safety_metadata(),
+    }
+
+
+def policy_update_gradient_momentum_from_state_payload(raw: Any) -> JsonObject | None:
+    if not isinstance(raw, dict):
+        return None
+    if text_or_none(raw.get("type")) == GRADIENT_MOMENTUM_EVIDENCE_TYPE:
+        return copy.deepcopy(raw)
+    momentum = first_mapping(raw, ("gradientMomentum", "gradient_momentum", "momentum"))
+    return copy.deepcopy(momentum) if momentum is not None else None
+
+
+def load_policy_gradient_momentum_state(policy_gradient: JsonObject | None, out_dir: Path) -> JsonObject | None:
+    if not isinstance(policy_gradient, dict):
+        return None
+    state_reference = policy_update_gradient_momentum_state_reference(policy_gradient, out_dir)
+    state_path = policy_update_gradient_momentum_state_path(policy_gradient, out_dir)
+    if state_reference is None or state_path is None or not state_path.exists():
+        return state_reference
+
+    try:
+        state_bytes = state_path.read_bytes()
+        raw_payload = json.loads(state_bytes.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        state_reference["previousStateArtifactLoadError"] = dataset_export.redact_text(str(error))
+        return state_reference
+    if not isinstance(raw_payload, dict):
+        state_reference["previousStateArtifactLoadError"] = "gradient momentum state artifact was not a JSON object"
+        return state_reference
+
+    stored_identity = first_mapping(raw_payload, ("stateIdentity", "gradientMomentumStateIdentity"))
+    stored_key = text_or_none(raw_payload.get("stateKey"))
+    expected_key = text_or_none(state_reference.get("stateKey"))
+    if stored_identity is not None:
+        stored_key = policy_update_gradient_momentum_state_key(stored_identity)
+    if stored_key is not None and expected_key is not None and stored_key != expected_key:
+        state_reference["previousStateArtifactLoadError"] = "gradient momentum state identity did not match current policy-gradient comparison"
+        return state_reference
+
+    gradient_momentum = policy_update_gradient_momentum_from_state_payload(raw_payload)
+    if gradient_momentum is None:
+        state_reference["previousStateArtifactLoadError"] = "gradient momentum state artifact did not contain momentum evidence"
+        return state_reference
+
+    previous_gradient = first_present(gradient_momentum, ("rawEmaGradient", "emaGradient"))
+    previous_gradient_present = isinstance(previous_gradient, dict) and bool(previous_gradient)
+    state_reference.update(
+        {
+            "previousStateArtifactLoaded": True,
+            "previousGradientPresent": previous_gradient_present,
+            "previousGradientSourcePath": dataset_export.display_path(state_path),
+            "previousGradientSourceSha256": hashlib.sha256(state_bytes).hexdigest(),
+            "previousGradientSourceReportId": text_or_none(
+                first_non_null_present(raw_payload, ("sourceReportId", "reportId"))
+            ),
+            "previousGradientSourceGeneratedAt": text_or_none(
+                first_non_null_present(raw_payload, ("sourceReportGeneratedAt", "generatedAt"))
+            ),
+            "previousTrustedGradientUpdate": raw_payload.get("sourceTrustedGradientUpdate"),
+            "previousGradientTrustGateClassification": text_or_none(
+                raw_payload.get("sourceGradientTrustGateClassification")
+            ),
+            "gradientMomentum": gradient_momentum,
+        }
+    )
+    return state_reference
+
+
+def policy_update_gradient_momentum_state_reference_config(state_reference: JsonObject) -> JsonObject:
+    payload: JsonObject = {}
+    for key in (
+        "stateArtifactPath",
+        "stateKey",
+        "stateIdentity",
+        "previousStateArtifactPresent",
+        "previousStateArtifactLoaded",
+        "previousGradientSourcePath",
+        "previousGradientSourceSha256",
+        "previousGradientSourceReportId",
+        "previousGradientSourceGeneratedAt",
+        "previousTrustedGradientUpdate",
+        "previousGradientTrustGateClassification",
+    ):
+        if key in state_reference:
+            payload[key] = copy.deepcopy(state_reference[key])
+    return payload
+
+
+def policy_gradient_with_loaded_gradient_momentum_state(
+    policy_gradient: JsonObject,
+    state_reference: JsonObject,
+) -> JsonObject:
+    payload = copy.deepcopy(policy_gradient)
+    update_config = first_mapping(payload, ("policyUpdate", "policy_update"))
+    if update_config is None:
+        update_config = {}
+        payload["policyUpdate"] = update_config
+    existing_momentum = first_mapping(update_config, ("gradientMomentum", "gradient_momentum"))
+    loaded_momentum = first_mapping(state_reference, ("gradientMomentum",))
+    momentum_config = copy.deepcopy(loaded_momentum) if loaded_momentum is not None else {}
+    if existing_momentum is not None:
+        momentum_config.update(copy.deepcopy(existing_momentum))
+    momentum_config.update(policy_update_gradient_momentum_state_reference_config(state_reference))
+    update_config["gradientMomentum"] = momentum_config
+    return payload
+
+
 def policy_update_gradient_momentum_evidence(
     *,
     policy_gradient: JsonObject,
@@ -3396,6 +3581,7 @@ def policy_update_gradient_momentum_evidence(
     raw_ema_gradient: JsonObject = {}
     conflicting_parameters: list[str] = []
     direction_by_parameter: JsonObject = {}
+    raw_vs_momentum_direction_by_parameter: JsonObject = {}
     for name, value in raw_gradient.items():
         raw_value = float(value)
         previous_present = name in previous_gradient
@@ -3427,12 +3613,29 @@ def policy_update_gradient_momentum_evidence(
             "emaDirection": ema_sign,
             "momentumConsistent": momentum_consistent,
         }
+        raw_vs_momentum_direction_by_parameter[name] = {
+            "rawGradient": round_policy_number(raw_value),
+            "momentumAdjustedGradient": rounded_ema_value,
+            "rawDirection": raw_sign,
+            "momentumAdjustedDirection": ema_sign,
+            "directionChanged": raw_sign != ema_sign,
+        }
 
+    previous_gradient_present = bool(previous_gradient)
+    previous_gradient_used = any(
+        isinstance(evidence, dict) and evidence.get("previousGradientPresent") is True
+        for evidence in direction_by_parameter.values()
+    )
     payload: JsonObject = {
         "type": GRADIENT_MOMENTUM_EVIDENCE_TYPE,
         "schemaVersion": SCHEMA_VERSION,
         "emaDecay": decay,
-        "previousGradientPresent": bool(previous_gradient),
+        "emaPreviousWeight": round_policy_number(decay),
+        "emaCurrentWeight": round_policy_number(1.0 - decay),
+        "smoothingFactor": round_policy_number(1.0 - decay),
+        "previousGradientPresent": previous_gradient_present,
+        "previousGradientUsed": previous_gradient_used,
+        "momentumApplied": previous_gradient_used,
         "configuredPreviousGradientPresent": configured_previous_gradient_present,
         "gradientSchemeCompatible": gradient_scheme_compatible,
         "gradientSchemeComparisonStatus": scheme_status,
@@ -3446,6 +3649,10 @@ def policy_update_gradient_momentum_evidence(
         "momentumConsistent": not conflicting_parameters,
         "conflictingParameters": conflicting_parameters,
         "directionByParameter": direction_by_parameter,
+        "rawVsMomentumAdjustedDirectionByParameter": raw_vs_momentum_direction_by_parameter,
+        "updateGradientSource": "raw_ema_gradient",
+        "trustGateEvidenceSource": "momentum_adjusted_gradient" if previous_gradient_used else "raw_gradient",
+        "trustGateMomentumEvidenceUsed": previous_gradient_used,
         "liveEffect": False,
         "officialMmoWrites": False,
         "officialMmoWritesAllowed": False,
@@ -3455,6 +3662,41 @@ def policy_update_gradient_momentum_evidence(
         payload["gradientSchemeIdentity"] = current_scheme_identity
     if isinstance(previous_scheme_identity, dict):
         payload["previousGradientSchemeIdentity"] = copy.deepcopy(previous_scheme_identity)
+    state_artifact_path = text_or_none(config.get("stateArtifactPath"))
+    state_key = text_or_none(config.get("stateKey"))
+    state_identity = first_mapping(config, ("stateIdentity",))
+    state_payload: JsonObject = {
+        "type": GRADIENT_MOMENTUM_STATE_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "stateArtifactPath": state_artifact_path,
+        "stateKey": state_key,
+        "previousStateArtifactPresent": config.get("previousStateArtifactPresent") is True,
+        "previousStateArtifactLoaded": config.get("previousStateArtifactLoaded") is True,
+        "previousGradientSourcePath": text_or_none(config.get("previousGradientSourcePath")),
+        "previousGradientSourceSha256": text_or_none(config.get("previousGradientSourceSha256")),
+        "previousGradientSourceReportId": text_or_none(config.get("previousGradientSourceReportId")),
+        "previousGradientSourceGeneratedAt": text_or_none(config.get("previousGradientSourceGeneratedAt")),
+        "previousTrustedGradientUpdate": config.get("previousTrustedGradientUpdate"),
+        "previousGradientTrustGateClassification": text_or_none(
+            config.get("previousGradientTrustGateClassification")
+        ),
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+        "safety": safety_metadata(),
+    }
+    if state_identity is not None:
+        state_payload["stateIdentity"] = copy.deepcopy(state_identity)
+    if state_artifact_path is not None:
+        payload["stateArtifactPath"] = state_artifact_path
+    if state_key is not None:
+        payload["stateKey"] = state_key
+    for key, value in state_payload.items():
+        if key in {"type", "schemaVersion", "liveEffect", "officialMmoWrites", "officialMmoWritesAllowed", "safety"}:
+            continue
+        if value is not None:
+            payload[key] = copy.deepcopy(value)
+    payload["state"] = state_payload
     return payload
 
 
@@ -3462,6 +3704,7 @@ def policy_update_gradient_momentum_config(policy_gradient: JsonObject) -> JsonO
     configs = policy_update_gradient_state_config_candidates(policy_gradient)
     decay = DEFAULT_GRADIENT_EMA_DECAY
     previous_gradient: JsonObject = {}
+    state_config: JsonObject = {}
     for raw in configs:
         raw_decay = first_present(
             raw,
@@ -3492,6 +3735,21 @@ def policy_update_gradient_momentum_config(policy_gradient: JsonObject) -> JsonO
                 parsed_value = number_or_none(value)
                 if isinstance(name, str) and parsed_value is not None and math.isfinite(float(parsed_value)):
                     previous_gradient[name] = float(parsed_value)
+        for key in (
+            "stateArtifactPath",
+            "stateKey",
+            "stateIdentity",
+            "previousStateArtifactPresent",
+            "previousStateArtifactLoaded",
+            "previousGradientSourcePath",
+            "previousGradientSourceSha256",
+            "previousGradientSourceReportId",
+            "previousGradientSourceGeneratedAt",
+            "previousTrustedGradientUpdate",
+            "previousGradientTrustGateClassification",
+        ):
+            if key in raw:
+                state_config[key] = copy.deepcopy(raw[key])
 
     previous_scheme = policy_update_previous_gradient_scheme_config(policy_gradient)
     return {
@@ -3500,6 +3758,7 @@ def policy_update_gradient_momentum_config(policy_gradient: JsonObject) -> JsonO
         "previousGradientSchemeIdentity": previous_scheme["previousGradientSchemeIdentity"],
         "previousGradientSchemeKey": previous_scheme["previousGradientSchemeKey"],
         "previousGradientComparisonKey": previous_scheme["previousGradientComparisonKey"],
+        **state_config,
     }
 
 
@@ -3571,6 +3830,16 @@ def policy_update_gradient_stability_gate(
         if isinstance(gradient_momentum, dict) and isinstance(gradient_momentum.get("conflictingParameters"), list)
         else []
     )
+    trust_gate_momentum_evidence_used = (
+        gradient_momentum.get("trustGateMomentumEvidenceUsed") is True
+        if isinstance(gradient_momentum, dict)
+        else False
+    )
+    trust_gate_evidence_source = (
+        text_or_none(gradient_momentum.get("trustGateEvidenceSource"))
+        if isinstance(gradient_momentum, dict)
+        else "raw_gradient"
+    ) or "raw_gradient"
 
     direction_consistent = not conflicting_parameters
     gradient_stable = sample_size_sufficient and direction_consistent and momentum_consistent and gradient_scheme_comparable
@@ -3624,6 +3893,13 @@ def policy_update_gradient_stability_gate(
         "momentumConsistent": momentum_consistent,
         "gradientSchemeComparable": gradient_scheme_comparable,
         "gradientSchemeComparisonStatus": gradient_scheme_status,
+        "trustGateEvidenceSource": trust_gate_evidence_source,
+        "trustGateMomentumEvidenceUsed": trust_gate_momentum_evidence_used,
+        "trustGateEvidence": {
+            "directionConsistencySource": "raw_gradient_estimation_contribution_directions",
+            "momentumEvidenceSource": trust_gate_evidence_source,
+            "momentumEvidenceUsed": trust_gate_momentum_evidence_used,
+        },
         "minimumSamplesPerCandidate": min_samples_per_candidate,
         "minimumTotalSamples": minimum_total_samples,
         "totalReturnSampleCount": total_sample_count,
@@ -4231,6 +4507,113 @@ def materialize_policy_update_artifacts(report: JsonObject, out_dir: Path) -> li
     update["artifactPath"] = display_path
     report["policyUpdateArtifactPath"] = display_path
     return [(artifact_path, artifact)]
+
+
+def materialize_policy_gradient_momentum_state(report: JsonObject, out_dir: Path, report_path: Path) -> None:
+    if report.get("trueGradient") is not True:
+        return
+    update = report.get("policyUpdate")
+    policy_gradient = report.get("policyGradient")
+    if not isinstance(update, dict) or not isinstance(policy_gradient, dict):
+        return
+    momentum = update.get("gradientMomentum")
+    if not isinstance(momentum, dict):
+        return
+    state_identity = policy_update_gradient_momentum_state_identity(policy_gradient)
+    state_path = policy_update_gradient_momentum_state_path(policy_gradient, out_dir)
+    if state_identity is None or state_path is None:
+        return
+
+    state_key = policy_update_gradient_momentum_state_key(state_identity)
+    state_artifact_path = dataset_export.display_path(state_path)
+    state_metadata: JsonObject = {
+        "stateArtifactPath": state_artifact_path,
+        "stateKey": state_key,
+        "stateIdentity": copy.deepcopy(state_identity),
+        "stateMaterialized": True,
+    }
+    update_gradient_momentum_report_metadata(report, state_metadata)
+    momentum = update["gradientMomentum"]
+
+    state_payload = copy.deepcopy(momentum)
+    state_payload.update(
+        {
+            "stateArtifactType": GRADIENT_MOMENTUM_STATE_TYPE,
+            "stateArtifactPath": state_artifact_path,
+            "stateKey": state_key,
+            "stateIdentity": copy.deepcopy(state_identity),
+            "sourceReportId": report.get("reportId"),
+            "sourceReportGeneratedAt": report.get("generatedAt"),
+            "sourceReportPath": dataset_export.display_path(report_path),
+            "sourcePolicyUpdateAlgorithm": report.get("policyUpdateAlgorithm"),
+            "sourceTrustedGradientUpdate": report.get("trustedGradientUpdate"),
+            "sourceGradientStable": report.get("gradientStable"),
+            "sourceHighVariance": report.get("highVariance"),
+            "sourceGradientTrustGateClassification": report.get("gradientTrustGateClassification"),
+            "sourceGradientTrustGateReason": report.get("gradientTrustGateReason"),
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+            "safety": safety_metadata(),
+        }
+    )
+    state_payload["statePayloadHash"] = canonical_hash(
+        {
+            key: value
+            for key, value in state_payload.items()
+            if key != "statePayloadHash"
+        }
+    )
+    write_json_atomic(state_path, state_payload)
+
+    state_summary = {
+        "type": GRADIENT_MOMENTUM_STATE_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "stateArtifactPath": state_artifact_path,
+        "stateKey": state_key,
+        "stateIdentity": copy.deepcopy(state_identity),
+        "statePayloadHash": state_payload["statePayloadHash"],
+        "stateMaterialized": True,
+        "sourceReportId": report.get("reportId"),
+        "sourceReportGeneratedAt": report.get("generatedAt"),
+        "previousGradientPresent": momentum.get("previousGradientPresent") is True,
+        "previousGradientUsed": momentum.get("previousGradientUsed") is True,
+        "previousGradientSourcePath": momentum.get("previousGradientSourcePath"),
+        "previousGradientSourceSha256": momentum.get("previousGradientSourceSha256"),
+        "previousGradientSourceReportId": momentum.get("previousGradientSourceReportId"),
+        "emaDecay": momentum.get("emaDecay"),
+        "smoothingFactor": momentum.get("smoothingFactor"),
+        "trustGateEvidenceSource": momentum.get("trustGateEvidenceSource"),
+        "trustedGradientUpdate": report.get("trustedGradientUpdate"),
+        "gradientStable": report.get("gradientStable"),
+        "highVariance": report.get("highVariance"),
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+        "safety": safety_metadata(),
+    }
+    report["gradientMomentumState"] = state_summary
+    update_gradient_momentum_report_metadata(
+        report,
+        {
+            "statePayloadHash": state_payload["statePayloadHash"],
+            "stateMaterialized": True,
+        },
+    )
+
+
+def update_gradient_momentum_report_metadata(report: JsonObject, metadata: JsonObject) -> None:
+    update = report.get("policyUpdate")
+    if not isinstance(update, dict) or not isinstance(update.get("gradientMomentum"), dict):
+        return
+    update["gradientMomentum"].update(copy.deepcopy(metadata))
+    report["gradientMomentum"] = copy.deepcopy(update["gradientMomentum"])
+    next_candidate_policy = update.get("nextCandidatePolicy")
+    if isinstance(next_candidate_policy, dict):
+        next_candidate_policy["gradientMomentum"] = copy.deepcopy(update["gradientMomentum"])
+        parameter_evidence = next_candidate_policy.get("parameterEvidence")
+        if isinstance(parameter_evidence, dict):
+            parameter_evidence["gradientMomentum"] = copy.deepcopy(update["gradientMomentum"])
 
 
 def materialize_candidate_scorecard_artifact(
@@ -7500,6 +7883,7 @@ def build_generation_summary(report: JsonObject) -> JsonObject:
         "highVarianceReason": report.get("highVarianceReason"),
         "gradientEstimation": copy.deepcopy(report.get("gradientEstimation")),
         "gradientMomentum": copy.deepcopy(report.get("gradientMomentum")),
+        "gradientMomentumState": copy.deepcopy(report.get("gradientMomentumState")),
         "gradientStability": copy.deepcopy(report.get("gradientStability")),
         "runtimeParameterInjection": copy.deepcopy(report.get("runtimeParameterInjection")),
         "scorecardId": report.get("scorecardId"),

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -1182,7 +1182,7 @@ def run_training_experiment(
         materialize_candidate_scorecard_artifact(report, report_path.parent, report_secret_values)
     except scorecard_helper.ScorecardError as error:
         mark_candidate_scorecard_materialization_failed(report, error)
-    materialize_policy_gradient_momentum_state(report, report_path.parent, report_path)
+    materialize_policy_gradient_momentum_state(report, report_path.parent, report_path, report_secret_values)
     assert_no_secret_leak(report, report_secret_values)
     write_json_atomic(report_path, report)
     report["reportPath"] = dataset_export.display_path(report_path)
@@ -3407,6 +3407,10 @@ def policy_update_gradient_momentum_state_path(policy_gradient: JsonObject, out_
     return out_dir / GRADIENT_MOMENTUM_STATE_ARTIFACT_DIR / f"{target_family}-{state_key[:16]}.json"
 
 
+def policy_update_gradient_momentum_state_payload_hash(payload: JsonObject) -> str:
+    return canonical_hash({key: value for key, value in payload.items() if key != "statePayloadHash"})
+
+
 def policy_update_gradient_momentum_state_reference(policy_gradient: JsonObject, out_dir: Path) -> JsonObject | None:
     identity = policy_update_gradient_momentum_state_identity(policy_gradient)
     if identity is None:
@@ -3456,6 +3460,11 @@ def load_policy_gradient_momentum_state(policy_gradient: JsonObject | None, out_
     if not isinstance(raw_payload, dict):
         state_reference["previousStateArtifactLoadError"] = "gradient momentum state artifact was not a JSON object"
         return state_reference
+    state_payload_hash = policy_update_gradient_momentum_state_payload_hash(raw_payload)
+    stored_payload_hash = text_or_none(raw_payload.get("statePayloadHash"))
+    if stored_payload_hash is not None and stored_payload_hash != state_payload_hash:
+        state_reference["previousStateArtifactLoadError"] = "gradient momentum state payload hash did not match artifact contents"
+        return state_reference
 
     stored_identity = first_mapping(raw_payload, ("stateIdentity", "gradientMomentumStateIdentity"))
     stored_key = text_or_none(raw_payload.get("stateKey"))
@@ -3478,7 +3487,7 @@ def load_policy_gradient_momentum_state(policy_gradient: JsonObject | None, out_
             "previousStateArtifactLoaded": True,
             "previousGradientPresent": previous_gradient_present,
             "previousGradientSourcePath": dataset_export.display_path(state_path),
-            "previousGradientSourceSha256": hashlib.sha256(state_bytes).hexdigest(),
+            "previousGradientSourceSha256": state_payload_hash,
             "previousGradientSourceReportId": text_or_none(
                 first_non_null_present(raw_payload, ("sourceReportId", "reportId"))
             ),
@@ -3503,6 +3512,7 @@ def policy_update_gradient_momentum_state_reference_config(state_reference: Json
         "stateIdentity",
         "previousStateArtifactPresent",
         "previousStateArtifactLoaded",
+        "previousStateArtifactLoadError",
         "previousGradientSourcePath",
         "previousGradientSourceSha256",
         "previousGradientSourceReportId",
@@ -3526,9 +3536,17 @@ def policy_gradient_with_loaded_gradient_momentum_state(
         payload["policyUpdate"] = update_config
     existing_momentum = first_mapping(update_config, ("gradientMomentum", "gradient_momentum"))
     loaded_momentum = first_mapping(state_reference, ("gradientMomentum",))
-    momentum_config = copy.deepcopy(loaded_momentum) if loaded_momentum is not None else {}
+    decay_fields = ("ema_decay", "emaDecay", "momentum", "momentumDecay", "gradient_ema_decay", "gradientEmaDecay")
+    configured_decay = first_non_null_present(update_config, decay_fields)
     if existing_momentum is not None:
-        momentum_config.update(copy.deepcopy(existing_momentum))
+        nested_decay = first_non_null_present(existing_momentum, decay_fields)
+        if nested_decay is not None:
+            configured_decay = nested_decay
+    momentum_config = copy.deepcopy(existing_momentum) if existing_momentum is not None else {}
+    if loaded_momentum is not None:
+        momentum_config.update(copy.deepcopy(loaded_momentum))
+    if configured_decay is not None:
+        momentum_config["emaDecay"] = copy.deepcopy(configured_decay)
     momentum_config.update(policy_update_gradient_momentum_state_reference_config(state_reference))
     update_config["gradientMomentum"] = momentum_config
     return payload
@@ -3672,6 +3690,7 @@ def policy_update_gradient_momentum_evidence(
         "stateKey": state_key,
         "previousStateArtifactPresent": config.get("previousStateArtifactPresent") is True,
         "previousStateArtifactLoaded": config.get("previousStateArtifactLoaded") is True,
+        "previousStateArtifactLoadError": text_or_none(config.get("previousStateArtifactLoadError")),
         "previousGradientSourcePath": text_or_none(config.get("previousGradientSourcePath")),
         "previousGradientSourceSha256": text_or_none(config.get("previousGradientSourceSha256")),
         "previousGradientSourceReportId": text_or_none(config.get("previousGradientSourceReportId")),
@@ -3741,6 +3760,7 @@ def policy_update_gradient_momentum_config(policy_gradient: JsonObject) -> JsonO
             "stateIdentity",
             "previousStateArtifactPresent",
             "previousStateArtifactLoaded",
+            "previousStateArtifactLoadError",
             "previousGradientSourcePath",
             "previousGradientSourceSha256",
             "previousGradientSourceReportId",
@@ -4509,7 +4529,12 @@ def materialize_policy_update_artifacts(report: JsonObject, out_dir: Path) -> li
     return [(artifact_path, artifact)]
 
 
-def materialize_policy_gradient_momentum_state(report: JsonObject, out_dir: Path, report_path: Path) -> None:
+def materialize_policy_gradient_momentum_state(
+    report: JsonObject,
+    out_dir: Path,
+    report_path: Path,
+    secret_values: Sequence[str] = (),
+) -> None:
     if report.get("trueGradient") is not True:
         return
     update = report.get("policyUpdate")
@@ -4557,13 +4582,8 @@ def materialize_policy_gradient_momentum_state(report: JsonObject, out_dir: Path
             "safety": safety_metadata(),
         }
     )
-    state_payload["statePayloadHash"] = canonical_hash(
-        {
-            key: value
-            for key, value in state_payload.items()
-            if key != "statePayloadHash"
-        }
-    )
+    state_payload["statePayloadHash"] = policy_update_gradient_momentum_state_payload_hash(state_payload)
+    assert_no_secret_leak(state_payload, secret_values)
     write_json_atomic(state_path, state_payload)
 
     state_summary = {
@@ -4581,6 +4601,7 @@ def materialize_policy_gradient_momentum_state(report: JsonObject, out_dir: Path
         "previousGradientSourcePath": momentum.get("previousGradientSourcePath"),
         "previousGradientSourceSha256": momentum.get("previousGradientSourceSha256"),
         "previousGradientSourceReportId": momentum.get("previousGradientSourceReportId"),
+        "previousStateArtifactLoadError": momentum.get("previousStateArtifactLoadError"),
         "emaDecay": momentum.get("emaDecay"),
         "smoothingFactor": momentum.get("smoothingFactor"),
         "trustGateEvidenceSource": momentum.get("trustGateEvidenceSource"),

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -1185,7 +1185,18 @@ def run_training_experiment(
     state_artifact_path = policy_gradient_momentum_state_artifact_path_for_report(report, report_path.parent)
     previous_state_artifact_bytes = None
     if state_artifact_path is not None and state_artifact_path.exists():
-        previous_state_artifact_bytes = state_artifact_path.read_bytes()
+        try:
+            previous_state_artifact_bytes = state_artifact_path.read_bytes()
+        except OSError as error:
+            warning = (
+                "previous gradient momentum state artifact snapshot skipped: "
+                f"{dataset_export.redact_text(str(error))}"
+            )
+            warnings = report.get("warnings")
+            if isinstance(warnings, list):
+                warnings.append(warning)
+            else:
+                report["warnings"] = [warning]
     materialized_state_artifact_path = materialize_policy_gradient_momentum_state(
         report,
         report_path.parent,
@@ -3460,6 +3471,49 @@ def policy_update_gradient_momentum_from_state_payload(raw: Any) -> JsonObject |
     return copy.deepcopy(momentum) if momentum is not None else None
 
 
+def resolve_policy_gradient_momentum_source_report_path(raw_path: str, out_dir: Path) -> Path:
+    source_path = Path(raw_path).expanduser()
+    if source_path.is_absolute():
+        return source_path
+
+    candidates = [source_path, out_dir / source_path, out_dir / source_path.name]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return source_path
+
+
+def policy_gradient_momentum_state_source_report_load_error(raw_payload: JsonObject, out_dir: Path) -> str | None:
+    source_report_path_text = text_or_none(raw_payload.get("sourceReportPath"))
+    if source_report_path_text is None:
+        return "gradient momentum state source report path was missing or invalid"
+
+    source_report_id = text_or_none(first_non_null_present(raw_payload, ("sourceReportId", "reportId")))
+    source_report_generated_at = text_or_none(
+        first_non_null_present(raw_payload, ("sourceReportGeneratedAt", "generatedAt"))
+    )
+    if source_report_id is None or source_report_generated_at is None:
+        return "gradient momentum state source report identity was missing or invalid"
+
+    source_report_path = resolve_policy_gradient_momentum_source_report_path(source_report_path_text, out_dir)
+    if not source_report_path.exists():
+        return "gradient momentum state source report was missing"
+
+    try:
+        source_report = json.loads(source_report_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        return f"gradient momentum state source report could not be read: {dataset_export.redact_text(str(error))}"
+    if not isinstance(source_report, dict):
+        return "gradient momentum state source report was not a JSON object"
+
+    if (
+        text_or_none(source_report.get("reportId")) != source_report_id
+        or text_or_none(source_report.get("generatedAt")) != source_report_generated_at
+    ):
+        return "gradient momentum state source report identity did not match state artifact"
+    return None
+
+
 def load_policy_gradient_momentum_state(policy_gradient: JsonObject | None, out_dir: Path) -> JsonObject | None:
     if not isinstance(policy_gradient, dict):
         return None
@@ -3493,6 +3547,11 @@ def load_policy_gradient_momentum_state(policy_gradient: JsonObject | None, out_
         stored_key = policy_update_gradient_momentum_state_key(stored_identity)
     if stored_key is not None and expected_key is not None and stored_key != expected_key:
         state_reference["previousStateArtifactLoadError"] = "gradient momentum state identity did not match current policy-gradient comparison"
+        return state_reference
+
+    source_report_load_error = policy_gradient_momentum_state_source_report_load_error(raw_payload, out_dir)
+    if source_report_load_error is not None:
+        state_reference["previousStateArtifactLoadError"] = source_report_load_error
         return state_reference
 
     gradient_momentum = policy_update_gradient_momentum_from_state_payload(raw_payload)

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -3446,6 +3446,138 @@ export const STRATEGY_REGISTRY = [
             self.assertFalse(failed_report_path.exists())
             self.assertEqual(read_json(state_path), first_state)
 
+    def test_gradient_momentum_state_snapshot_read_error_does_not_abort_report(self) -> None:
+        card = gradient_momentum_training_card()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            write_json(card_path, card)
+            first_report = runner.run_training_experiment(
+                card_path,
+                out_dir,
+                report_id="gradient-momentum-snapshot-source",
+                generated_at="2026-06-02T01:05:30Z",
+                simulator_runner=MockSimulator(
+                    gradient_momentum_simulator_results(),
+                    inject_runtime_parameters=True,
+                ),
+            )
+            state_path = Path(first_report["gradientMomentumState"]["stateArtifactPath"])
+            state_read_count = 0
+            original_read_bytes = Path.read_bytes
+
+            def fail_late_state_snapshot(path: Path) -> bytes:
+                nonlocal state_read_count
+                if path == state_path:
+                    state_read_count += 1
+                    if state_read_count == 2:
+                        raise OSError("simulated late state snapshot failure")
+                return original_read_bytes(path)
+
+            with mock.patch.object(Path, "read_bytes", fail_late_state_snapshot):
+                report = runner.run_training_experiment(
+                    card_path,
+                    out_dir,
+                    report_id="gradient-momentum-snapshot-continues",
+                    generated_at="2026-06-02T01:05:45Z",
+                    simulator_runner=MockSimulator(
+                        gradient_momentum_simulator_results(),
+                        inject_runtime_parameters=True,
+                    ),
+                )
+
+            persisted = read_json(out_dir / "gradient-momentum-snapshot-continues.json")
+
+        self.assertEqual(state_read_count, 2)
+        self.assertTrue(report["gradientMomentum"]["previousStateArtifactLoaded"])
+        self.assertTrue(persisted["gradientMomentum"]["previousStateArtifactLoaded"])
+        self.assertTrue(
+            any("simulated late state snapshot failure" in warning for warning in persisted["warnings"])
+        )
+
+    def test_gradient_momentum_state_requires_source_report_path(self) -> None:
+        card = gradient_momentum_training_card()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                out_dir,
+                report_id="gradient-momentum-source-report-path",
+                generated_at="2026-06-02T01:06:00Z",
+                simulator_runner=MockSimulator(
+                    gradient_momentum_simulator_results(),
+                    inject_runtime_parameters=True,
+                ),
+            )
+            state_path = Path(report["gradientMomentumState"]["stateArtifactPath"])
+            valid_state = read_json(state_path)
+
+            cases = (
+                ("missing_path", None, "source report path"),
+                ("missing_file", str(out_dir / "missing-source-report.json"), "source report was missing"),
+            )
+            for case_name, source_report_path, expected_error in cases:
+                with self.subTest(case_name=case_name):
+                    state = copy.deepcopy(valid_state)
+                    if source_report_path is None:
+                        state.pop("sourceReportPath", None)
+                    else:
+                        state["sourceReportPath"] = source_report_path
+                    state["statePayloadHash"] = runner.policy_update_gradient_momentum_state_payload_hash(state)
+                    write_json(state_path, state)
+
+                    loaded = runner.load_policy_gradient_momentum_state(
+                        runner.policy_gradient_metadata_from_card(card),
+                        out_dir,
+                    )
+
+                    self.assertIsNotNone(loaded)
+                    assert loaded is not None
+                    self.assertTrue(loaded["previousStateArtifactPresent"])
+                    self.assertFalse(loaded["previousStateArtifactLoaded"])
+                    self.assertIn(expected_error, loaded["previousStateArtifactLoadError"])
+
+    def test_gradient_momentum_state_requires_source_report_identity_match(self) -> None:
+        card = gradient_momentum_training_card()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            report_path = out_dir / "gradient-momentum-source-report-identity.json"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                out_dir,
+                report_id="gradient-momentum-source-report-identity",
+                generated_at="2026-06-02T01:06:30Z",
+                simulator_runner=MockSimulator(
+                    gradient_momentum_simulator_results(),
+                    inject_runtime_parameters=True,
+                ),
+            )
+            state_path = Path(report["gradientMomentumState"]["stateArtifactPath"])
+            persisted_report = read_json(report_path)
+            persisted_report["generatedAt"] = "2026-06-02T01:06:31Z"
+            write_json(report_path, persisted_report)
+
+            loaded = runner.load_policy_gradient_momentum_state(
+                runner.policy_gradient_metadata_from_card(card),
+                out_dir,
+            )
+
+        self.assertIsNotNone(loaded)
+        assert loaded is not None
+        self.assertTrue(loaded["previousStateArtifactPresent"])
+        self.assertFalse(loaded["previousStateArtifactLoaded"])
+        self.assertIn("source report identity did not match", loaded["previousStateArtifactLoadError"])
+
     def test_gradient_momentum_state_requires_payload_hash(self) -> None:
         card = gradient_momentum_training_card()
 

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -85,6 +85,8 @@ def reinforce_stability_results(candidate_returns: list[list[int | float]]) -> l
 
 def gradient_momentum_training_card() -> JsonObject:
     card = base_card(["variant-a", "variant-b"])
+    card["training_approach"] = "policy_gradient"
+    card["simulation"]["ticks"] = runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS
     card["policy_gradient"] = reinforce_stability_policy_gradient()
     return card
 
@@ -104,6 +106,32 @@ def gradient_momentum_simulator_results(*, candidate_rooms: int = 2) -> dict[str
             [start, tick(2, candidate_final_rooms)],
         ),
     }
+
+
+def gradient_momentum_metric_simulator_results(candidate_territory_delta: int | float) -> dict[str, JsonObject]:
+    results = gradient_momentum_simulator_results(candidate_rooms=1)
+    results["variant-a"]["metrics"] = {"territoryDelta": 1, "resourceDelta": 0, "combatDelta": 0}
+    results["variant-b"]["metrics"] = {
+        "territoryDelta": candidate_territory_delta,
+        "resourceDelta": 0,
+        "combatDelta": 0,
+    }
+    return results
+
+
+def sequential_gradient_momentum_simulator(candidate_territory_deltas: list[int | float]):
+    deltas = list(candidate_territory_deltas)
+    index = 0
+
+    def simulator(**kwargs: Any) -> JsonObject:
+        nonlocal index
+        if index >= len(deltas):
+            raise AssertionError("sequential gradient momentum simulator exhausted")
+        results = gradient_momentum_metric_simulator_results(deltas[index])
+        index += 1
+        return MockSimulator(results, inject_runtime_parameters=True)(**kwargs)
+
+    return simulator
 
 
 def scalar_gradient_scheme_identity(policy_gradient: JsonObject | None = None) -> JsonObject:
@@ -3241,7 +3269,7 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(second_momentum["trustGateEvidenceSource"], "momentum_adjusted_gradient")
         self.assertEqual(second_momentum["previousGradientSourceReportId"], "gradient-momentum-first")
         self.assertEqual(second_momentum["previousGradientSourcePath"], first_momentum["stateArtifactPath"])
-        self.assertIsInstance(second_momentum["previousGradientSourceSha256"], str)
+        self.assertEqual(second_momentum["previousGradientSourceSha256"], first_state["statePayloadHash"])
         self.assertEqual(second_momentum["smoothingFactor"], 0.2)
         self.assertFalse(second_report["trustedGradientUpdate"])
         self.assertTrue(second_report["highVariance"])
@@ -3252,6 +3280,86 @@ export const STRATEGY_REGISTRY = [
         self.assertFalse(second_persisted["officialMmoWrites"])
         self.assertFalse(second_persisted["officialMmoWritesAllowed"])
         self.assertFalse(second_persisted["gradientMomentumState"]["officialMmoWritesAllowed"])
+
+    def test_gradient_momentum_state_load_error_survives_artifact_overwrite(self) -> None:
+        card = gradient_momentum_training_card()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            write_json(card_path, card)
+            state_path = runner.policy_update_gradient_momentum_state_path(
+                runner.policy_gradient_metadata_from_card(card),
+                out_dir,
+            )
+            self.assertIsNotNone(state_path)
+            assert state_path is not None
+            state_path.parent.mkdir(parents=True, exist_ok=True)
+            state_path.write_text("{not-json", encoding="utf-8")
+
+            report = runner.run_training_experiment(
+                card_path,
+                out_dir,
+                report_id="gradient-momentum-corrupt-state",
+                generated_at="2026-06-02T01:02:00Z",
+                simulator_runner=MockSimulator(
+                    gradient_momentum_simulator_results(),
+                    inject_runtime_parameters=True,
+                ),
+            )
+            persisted = read_json(out_dir / "gradient-momentum-corrupt-state.json")
+
+        momentum = report["gradientMomentum"]
+        self.assertTrue(momentum["previousStateArtifactPresent"])
+        self.assertFalse(momentum["previousStateArtifactLoaded"])
+        self.assertIn("Expecting property name", momentum["previousStateArtifactLoadError"])
+        self.assertEqual(
+            persisted["gradientMomentum"]["previousStateArtifactLoadError"],
+            momentum["previousStateArtifactLoadError"],
+        )
+        self.assertEqual(
+            persisted["gradientMomentumState"]["previousStateArtifactLoadError"],
+            momentum["previousStateArtifactLoadError"],
+        )
+
+    def test_gradient_momentum_state_secret_scan_blocks_state_write(self) -> None:
+        secret = "momentum-secret-token-123456"
+        policy_gradient = reinforce_stability_policy_gradient()
+        report: JsonObject = {
+            "trueGradient": True,
+            "reportId": "gradient-momentum-secret-state",
+            "generatedAt": "2026-06-02T01:03:00Z",
+            "policyGradient": policy_gradient,
+            "policyUpdateAlgorithm": runner.TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM,
+            "trustedGradientUpdate": False,
+            "gradientStable": False,
+            "highVariance": True,
+            "policyUpdate": {
+                "gradientMomentum": {
+                    "type": runner.GRADIENT_MOMENTUM_EVIDENCE_TYPE,
+                    "schemaVersion": runner.SCHEMA_VERSION,
+                    "rawEmaGradient": {"territorySignalWeight": 1.0},
+                    "emaGradient": {"territorySignalWeight": 1.0},
+                    "secretNote": secret,
+                }
+            },
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            state_path = runner.policy_update_gradient_momentum_state_path(policy_gradient, root)
+            self.assertIsNotNone(state_path)
+            assert state_path is not None
+            with self.assertRaisesRegex(RuntimeError, "configured secret"):
+                runner.materialize_policy_gradient_momentum_state(
+                    report,
+                    root,
+                    root / "gradient-momentum-secret-state.json",
+                    [secret],
+                )
+
+            self.assertFalse(state_path.exists())
 
     def test_policy_gradient_scheme_comparison_key_uses_effective_scalar_weights(self) -> None:
         def scheme_for_weights(weights: JsonObject) -> JsonObject:
@@ -4025,31 +4133,38 @@ export const STRATEGY_REGISTRY = [
         self.assertFalse(update["gradientStability"]["officialMmoWritesAllowed"])
 
     def test_reinforce_gradient_conflict_remains_untrusted_with_loaded_momentum(self) -> None:
-        first_update = runner.build_policy_update(
-            policy_gradient=reinforce_stability_policy_gradient(),
-            results=reinforce_stability_results([[2, 0, 0, 0] for _index in range(20)]),
-            report_id="policy-gradient-momentum-state-source",
-            generated_at="2026-06-02T01:10:00Z",
-        )
-        policy_gradient = reinforce_stability_policy_gradient()
-        policy_gradient["policyUpdate"]["gradientMomentum"] = {
-            **copy.deepcopy(first_update["gradientMomentum"]),
-            "stateArtifactPath": "runtime-artifacts/rl-training/gradient-momentum/test-family-state.json",
-            "stateKey": "test-state-key",
-            "previousStateArtifactPresent": True,
-            "previousStateArtifactLoaded": True,
-            "previousGradientSourcePath": "runtime-artifacts/rl-training/gradient-momentum/test-family-state.json",
-            "previousGradientSourceSha256": "a" * 64,
-            "previousGradientSourceReportId": "policy-gradient-momentum-state-source",
-        }
-        oscillating_returns = [[2, 0, 0, 0] for _index in range(11)] + [[0, 0, 0, 0] for _index in range(9)]
+        oscillating_territory_deltas = [2 for _index in range(11)] + [0 for _index in range(9)]
+        card = gradient_momentum_training_card()
+        card["simulation"]["repetitions"] = len(oscillating_territory_deltas)
 
-        update = runner.build_policy_update(
-            policy_gradient=policy_gradient,
-            results=reinforce_stability_results(oscillating_returns),
-            report_id="policy-gradient-loaded-momentum-conflict",
-            generated_at="2026-06-02T01:11:00Z",
-        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            write_json(card_path, card)
+            first_report = runner.run_training_experiment(
+                card_path,
+                out_dir,
+                report_id="policy-gradient-momentum-state-source",
+                generated_at="2026-06-02T01:10:00Z",
+                simulator_runner=sequential_gradient_momentum_simulator([2 for _index in range(20)]),
+            )
+            first_raw_ema = first_report["gradientMomentum"]["rawEmaGradient"]["territorySignalWeight"]
+
+            second_card = copy.deepcopy(card)
+            second_card["policy_gradient"]["policyUpdate"]["gradientMomentum"] = {
+                "rawEmaGradient": {"territorySignalWeight": -999.0},
+                "emaGradient": {"territorySignalWeight": -999.0},
+                "previousGradientSourceReportId": "inline-fake-source",
+            }
+            write_json(card_path, second_card)
+            update = runner.run_training_experiment(
+                card_path,
+                out_dir,
+                report_id="policy-gradient-loaded-momentum-conflict",
+                generated_at="2026-06-02T01:11:00Z",
+                simulator_runner=sequential_gradient_momentum_simulator(oscillating_territory_deltas),
+            )["policyUpdate"]
 
         stability = update["gradientStability"]
         momentum = update["gradientMomentum"]
@@ -4057,6 +4172,10 @@ export const STRATEGY_REGISTRY = [
         self.assertTrue(momentum["previousGradientUsed"])
         self.assertEqual(momentum["trustGateEvidenceSource"], "momentum_adjusted_gradient")
         self.assertEqual(momentum["previousGradientSourceReportId"], "policy-gradient-momentum-state-source")
+        self.assertEqual(
+            momentum["directionByParameter"]["territorySignalWeight"]["previousEmaGradient"],
+            runner.round_policy_number(first_raw_ema),
+        )
         self.assertEqual(stability["classification"], "conflicting_direction_high_variance")
         self.assertFalse(stability["directionConsistent"])
         self.assertFalse(update["trustedGradientUpdate"])

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -3232,6 +3232,63 @@ export const STRATEGY_REGISTRY = [
             )
             first_state_path = Path(first_report["gradientMomentumState"]["stateArtifactPath"])
             first_state = read_json(first_state_path)
+            competing_policy_gradient = copy.deepcopy(card["policy_gradient"])
+            competing_policy_gradient["rewardModel"] = card_helper.reward_model(
+                scalar_weighted_sum_authorized=True
+            )
+            competing_state_path = runner.policy_update_gradient_momentum_state_path(
+                competing_policy_gradient,
+                out_dir,
+            )
+            self.assertIsNotNone(competing_state_path)
+            assert competing_state_path is not None
+            self.assertNotEqual(competing_state_path, first_state_path)
+            competing_state_identity = runner.policy_update_gradient_momentum_state_identity(
+                competing_policy_gradient
+            )
+            self.assertIsNotNone(competing_state_identity)
+            assert competing_state_identity is not None
+            competing_scheme_identity = competing_state_identity["gradientSchemeIdentity"]
+            competing_momentum = copy.deepcopy(first_report["gradientMomentum"])
+            competing_momentum.update(
+                {
+                    "gradientSchemeIdentity": copy.deepcopy(competing_scheme_identity),
+                    "gradientSchemeKey": runner.policy_update_gradient_scheme_key(competing_scheme_identity),
+                    "gradientComparisonKey": competing_state_identity["gradientComparisonKey"],
+                }
+            )
+            competing_report: JsonObject = {
+                "trueGradient": True,
+                "reportId": "gradient-momentum-competing-scalar",
+                "generatedAt": "2026-06-02T01:00:30Z",
+                "policyGradient": competing_policy_gradient,
+                "policyUpdateAlgorithm": runner.TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM,
+                "trustedGradientUpdate": False,
+                "gradientStable": False,
+                "highVariance": True,
+                "policyUpdate": {
+                    "gradientMomentum": competing_momentum,
+                },
+            }
+            materialized_competing_state_path = runner.materialize_policy_gradient_momentum_state(
+                competing_report,
+                out_dir,
+                out_dir / "gradient-momentum-competing-scalar.json",
+            )
+            self.assertEqual(materialized_competing_state_path, competing_state_path)
+            competing_state = read_json(competing_state_path)
+            self.assertNotEqual(
+                competing_state["stateIdentity"]["gradientComparisonKey"],
+                first_state["stateIdentity"]["gradientComparisonKey"],
+            )
+            self.assertNotEqual(
+                competing_state["gradientComparisonKey"],
+                first_state["gradientComparisonKey"],
+            )
+            self.assertNotEqual(
+                competing_state["stateIdentity"]["gradientSchemeIdentity"],
+                first_state["stateIdentity"]["gradientSchemeIdentity"],
+            )
 
             second_report = runner.run_training_experiment(
                 card_path,
@@ -3241,6 +3298,8 @@ export const STRATEGY_REGISTRY = [
                 simulator_runner=second_simulator,
             )
             second_persisted = read_json(out_dir / "gradient-momentum-second.json")
+            competing_state_still_present = competing_state_path.exists()
+            competing_state_after_second = read_json(competing_state_path)
 
         first_momentum = first_report["gradientMomentum"]
         second_momentum = second_report["gradientMomentum"]
@@ -3270,6 +3329,21 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(second_momentum["previousGradientSourceReportId"], "gradient-momentum-first")
         self.assertEqual(second_momentum["previousGradientSourcePath"], first_momentum["stateArtifactPath"])
         self.assertEqual(second_momentum["previousGradientSourceSha256"], first_state["statePayloadHash"])
+        self.assertTrue(competing_state_still_present)
+        self.assertEqual(competing_state_after_second, competing_state)
+        self.assertEqual(competing_state["sourceReportId"], "gradient-momentum-competing-scalar")
+        self.assertNotEqual(
+            second_momentum["previousGradientSourceReportId"],
+            competing_state["sourceReportId"],
+        )
+        self.assertNotEqual(
+            second_momentum["previousGradientSourcePath"],
+            competing_state["stateArtifactPath"],
+        )
+        self.assertNotEqual(
+            second_momentum["previousGradientSourceSha256"],
+            competing_state["statePayloadHash"],
+        )
         self.assertEqual(second_momentum["smoothingFactor"], 0.2)
         self.assertFalse(second_report["trustedGradientUpdate"])
         self.assertTrue(second_report["highVariance"])
@@ -3309,6 +3383,7 @@ export const STRATEGY_REGISTRY = [
                 ),
             )
             persisted = read_json(out_dir / "gradient-momentum-corrupt-state.json")
+            rewritten_state = read_json(Path(report["gradientMomentumState"]["stateArtifactPath"]))
 
         momentum = report["gradientMomentum"]
         self.assertTrue(momentum["previousStateArtifactPresent"])
@@ -3322,6 +3397,99 @@ export const STRATEGY_REGISTRY = [
             persisted["gradientMomentumState"]["previousStateArtifactLoadError"],
             momentum["previousStateArtifactLoadError"],
         )
+        self.assertEqual(
+            rewritten_state["previousStateArtifactLoadError"],
+            momentum["previousStateArtifactLoadError"],
+        )
+
+    def test_gradient_momentum_state_rolls_back_when_report_write_fails(self) -> None:
+        card = gradient_momentum_training_card()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            write_json(card_path, card)
+            first_report = runner.run_training_experiment(
+                card_path,
+                out_dir,
+                report_id="gradient-momentum-rollback-first",
+                generated_at="2026-06-02T01:04:00Z",
+                simulator_runner=MockSimulator(
+                    gradient_momentum_simulator_results(),
+                    inject_runtime_parameters=True,
+                ),
+            )
+            state_path = Path(first_report["gradientMomentumState"]["stateArtifactPath"])
+            first_state = read_json(state_path)
+            failed_report_path = out_dir / "gradient-momentum-rollback-failed.json"
+            original_write_json_atomic = runner.write_json_atomic
+
+            def fail_final_report_write(path: Path, payload: Any) -> None:
+                if path == failed_report_path:
+                    raise OSError("simulated report write failure")
+                original_write_json_atomic(path, payload)
+
+            with mock.patch.object(runner, "write_json_atomic", fail_final_report_write):
+                with self.assertRaisesRegex(OSError, "simulated report write failure"):
+                    runner.run_training_experiment(
+                        card_path,
+                        out_dir,
+                        report_id="gradient-momentum-rollback-failed",
+                        generated_at="2026-06-02T01:05:00Z",
+                        simulator_runner=MockSimulator(
+                            gradient_momentum_simulator_results(),
+                            inject_runtime_parameters=True,
+                        ),
+                    )
+
+            self.assertFalse(failed_report_path.exists())
+            self.assertEqual(read_json(state_path), first_state)
+
+    def test_gradient_momentum_state_requires_payload_hash(self) -> None:
+        card = gradient_momentum_training_card()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                out_dir,
+                report_id="gradient-momentum-hash-source",
+                generated_at="2026-06-02T01:06:00Z",
+                simulator_runner=MockSimulator(
+                    gradient_momentum_simulator_results(),
+                    inject_runtime_parameters=True,
+                ),
+            )
+            state_path = Path(report["gradientMomentumState"]["stateArtifactPath"])
+            valid_state = read_json(state_path)
+
+            for case_name, replacement_hash in (
+                ("missing", None),
+                ("empty", ""),
+                ("non_string", 123),
+            ):
+                with self.subTest(case_name=case_name):
+                    corrupt_state = copy.deepcopy(valid_state)
+                    if replacement_hash is None:
+                        corrupt_state.pop("statePayloadHash", None)
+                    else:
+                        corrupt_state["statePayloadHash"] = replacement_hash
+                    write_json(state_path, corrupt_state)
+
+                    loaded = runner.load_policy_gradient_momentum_state(
+                        runner.policy_gradient_metadata_from_card(card),
+                        out_dir,
+                    )
+
+                    self.assertIsNotNone(loaded)
+                    assert loaded is not None
+                    self.assertTrue(loaded["previousStateArtifactPresent"])
+                    self.assertFalse(loaded["previousStateArtifactLoaded"])
+                    self.assertIn("payload hash", loaded["previousStateArtifactLoadError"])
 
     def test_gradient_momentum_state_secret_scan_blocks_state_write(self) -> None:
         secret = "momentum-secret-token-123456"

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -3497,6 +3497,64 @@ export const STRATEGY_REGISTRY = [
             any("simulated late state snapshot failure" in warning for warning in persisted["warnings"])
         )
 
+    def test_gradient_momentum_state_snapshot_read_error_does_not_delete_state_on_report_failure(self) -> None:
+        card = gradient_momentum_training_card()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            write_json(card_path, card)
+            first_report = runner.run_training_experiment(
+                card_path,
+                out_dir,
+                report_id="gradient-momentum-snapshot-rollback-source",
+                generated_at="2026-06-02T01:06:00Z",
+                simulator_runner=MockSimulator(
+                    gradient_momentum_simulator_results(),
+                    inject_runtime_parameters=True,
+                ),
+            )
+            state_path = Path(first_report["gradientMomentumState"]["stateArtifactPath"])
+            failed_report_path = out_dir / "gradient-momentum-snapshot-rollback-failed.json"
+            state_read_count = 0
+            original_read_bytes = Path.read_bytes
+            original_write_json_atomic = runner.write_json_atomic
+
+            def fail_late_state_snapshot(path: Path) -> bytes:
+                nonlocal state_read_count
+                if path == state_path:
+                    state_read_count += 1
+                    if state_read_count == 2:
+                        raise OSError("simulated late state snapshot failure")
+                return original_read_bytes(path)
+
+            def fail_final_report_write(path: Path, payload: Any) -> None:
+                if path == failed_report_path:
+                    raise OSError("simulated report write failure")
+                original_write_json_atomic(path, payload)
+
+            with (
+                mock.patch.object(Path, "read_bytes", fail_late_state_snapshot),
+                mock.patch.object(runner, "write_json_atomic", fail_final_report_write),
+            ):
+                with self.assertRaisesRegex(OSError, "simulated report write failure"):
+                    runner.run_training_experiment(
+                        card_path,
+                        out_dir,
+                        report_id="gradient-momentum-snapshot-rollback-failed",
+                        generated_at="2026-06-02T01:06:30Z",
+                        simulator_runner=MockSimulator(
+                            gradient_momentum_simulator_results(),
+                            inject_runtime_parameters=True,
+                        ),
+                    )
+
+            self.assertEqual(state_read_count, 2)
+            self.assertFalse(failed_report_path.exists())
+            self.assertTrue(state_path.exists())
+            self.assertEqual(read_json(state_path)["stateArtifactType"], runner.GRADIENT_MOMENTUM_STATE_TYPE)
+
     def test_gradient_momentum_state_requires_source_report_path(self) -> None:
         card = gradient_momentum_training_card()
 

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -83,6 +83,29 @@ def reinforce_stability_results(candidate_returns: list[list[int | float]]) -> l
     ]
 
 
+def gradient_momentum_training_card() -> JsonObject:
+    card = base_card(["variant-a", "variant-b"])
+    card["policy_gradient"] = reinforce_stability_policy_gradient()
+    return card
+
+
+def gradient_momentum_simulator_results(*, candidate_rooms: int = 2) -> dict[str, JsonObject]:
+    start = tick(1, [room("W1N1", energy=100)])
+    candidate_final_rooms = [room("W1N1", energy=150)]
+    if candidate_rooms >= 2:
+        candidate_final_rooms.append(room("W1N2", energy=100))
+    return {
+        "variant-a": variant_result(
+            "variant-a",
+            [start, tick(2, [room("W1N1", energy=100)])],
+        ),
+        "variant-b": variant_result(
+            "variant-b",
+            [start, tick(2, candidate_final_rooms)],
+        ),
+    }
+
+
 def scalar_gradient_scheme_identity(policy_gradient: JsonObject | None = None) -> JsonObject:
     policy_gradient = policy_gradient or reinforce_stability_policy_gradient()
     return runner.policy_update_scalar_gradient_scheme_identity(
@@ -3156,6 +3179,80 @@ export const STRATEGY_REGISTRY = [
         self.assertTrue(update["promotionGate"]["loopAPromotionEligible"])
         self.assertTrue(update["promotionGate"]["loopBPromotionEligible"])
 
+    def test_gradient_momentum_state_persists_and_loads_same_comparison(self) -> None:
+        card = gradient_momentum_training_card()
+        first_simulator = MockSimulator(
+            gradient_momentum_simulator_results(),
+            inject_runtime_parameters=True,
+        )
+        second_simulator = MockSimulator(
+            gradient_momentum_simulator_results(),
+            inject_runtime_parameters=True,
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            write_json(card_path, card)
+            first_report = runner.run_training_experiment(
+                card_path,
+                out_dir,
+                report_id="gradient-momentum-first",
+                generated_at="2026-06-02T01:00:00Z",
+                simulator_runner=first_simulator,
+            )
+            first_state_path = Path(first_report["gradientMomentumState"]["stateArtifactPath"])
+            first_state = read_json(first_state_path)
+
+            second_report = runner.run_training_experiment(
+                card_path,
+                out_dir,
+                report_id="gradient-momentum-second",
+                generated_at="2026-06-02T01:01:00Z",
+                simulator_runner=second_simulator,
+            )
+            second_persisted = read_json(out_dir / "gradient-momentum-second.json")
+
+        first_momentum = first_report["gradientMomentum"]
+        second_momentum = second_report["gradientMomentum"]
+        self.assertEqual(first_report["policyUpdateIterations"], 1)
+        self.assertTrue(first_report["trueGradient"])
+        self.assertFalse(first_momentum["previousGradientPresent"])
+        self.assertFalse(first_momentum["previousGradientUsed"])
+        self.assertFalse(first_momentum["previousStateArtifactPresent"])
+        self.assertFalse(first_momentum["previousStateArtifactLoaded"])
+        self.assertEqual(first_momentum["trustGateEvidenceSource"], "raw_gradient")
+        self.assertFalse(first_report["trustedGradientUpdate"])
+        self.assertTrue(first_report["highVariance"])
+        self.assertEqual(first_state["sourceReportId"], "gradient-momentum-first")
+        self.assertEqual(first_state["stateArtifactType"], runner.GRADIENT_MOMENTUM_STATE_TYPE)
+        self.assertFalse(first_state["liveEffect"])
+        self.assertFalse(first_state["officialMmoWrites"])
+        self.assertFalse(first_state["officialMmoWritesAllowed"])
+
+        self.assertEqual(second_report["policyUpdateIterations"], 1)
+        self.assertTrue(second_report["trueGradient"])
+        self.assertTrue(second_momentum["previousGradientPresent"])
+        self.assertTrue(second_momentum["previousGradientUsed"])
+        self.assertTrue(second_momentum["previousStateArtifactPresent"])
+        self.assertTrue(second_momentum["previousStateArtifactLoaded"])
+        self.assertEqual(second_momentum["gradientSchemeComparisonStatus"], "same_scheme")
+        self.assertEqual(second_momentum["trustGateEvidenceSource"], "momentum_adjusted_gradient")
+        self.assertEqual(second_momentum["previousGradientSourceReportId"], "gradient-momentum-first")
+        self.assertEqual(second_momentum["previousGradientSourcePath"], first_momentum["stateArtifactPath"])
+        self.assertIsInstance(second_momentum["previousGradientSourceSha256"], str)
+        self.assertEqual(second_momentum["smoothingFactor"], 0.2)
+        self.assertFalse(second_report["trustedGradientUpdate"])
+        self.assertTrue(second_report["highVariance"])
+        self.assertEqual(second_report["gradientStability"]["trustGateEvidenceSource"], "momentum_adjusted_gradient")
+        self.assertTrue(second_report["gradientStability"]["trustGateMomentumEvidenceUsed"])
+        self.assertEqual(second_persisted["gradientMomentumState"]["sourceReportId"], "gradient-momentum-second")
+        self.assertFalse(second_persisted["liveEffect"])
+        self.assertFalse(second_persisted["officialMmoWrites"])
+        self.assertFalse(second_persisted["officialMmoWritesAllowed"])
+        self.assertFalse(second_persisted["gradientMomentumState"]["officialMmoWritesAllowed"])
+
     def test_policy_gradient_scheme_comparison_key_uses_effective_scalar_weights(self) -> None:
         def scheme_for_weights(weights: JsonObject) -> JsonObject:
             policy_gradient = reinforce_stability_policy_gradient()
@@ -3926,6 +4023,48 @@ export const STRATEGY_REGISTRY = [
         self.assertTrue(update["promotionGate"]["runtimeParameterConsumption"])
         self.assertFalse(update["promotionGate"]["liveEffect"])
         self.assertFalse(update["gradientStability"]["officialMmoWritesAllowed"])
+
+    def test_reinforce_gradient_conflict_remains_untrusted_with_loaded_momentum(self) -> None:
+        first_update = runner.build_policy_update(
+            policy_gradient=reinforce_stability_policy_gradient(),
+            results=reinforce_stability_results([[2, 0, 0, 0] for _index in range(20)]),
+            report_id="policy-gradient-momentum-state-source",
+            generated_at="2026-06-02T01:10:00Z",
+        )
+        policy_gradient = reinforce_stability_policy_gradient()
+        policy_gradient["policyUpdate"]["gradientMomentum"] = {
+            **copy.deepcopy(first_update["gradientMomentum"]),
+            "stateArtifactPath": "runtime-artifacts/rl-training/gradient-momentum/test-family-state.json",
+            "stateKey": "test-state-key",
+            "previousStateArtifactPresent": True,
+            "previousStateArtifactLoaded": True,
+            "previousGradientSourcePath": "runtime-artifacts/rl-training/gradient-momentum/test-family-state.json",
+            "previousGradientSourceSha256": "a" * 64,
+            "previousGradientSourceReportId": "policy-gradient-momentum-state-source",
+        }
+        oscillating_returns = [[2, 0, 0, 0] for _index in range(11)] + [[0, 0, 0, 0] for _index in range(9)]
+
+        update = runner.build_policy_update(
+            policy_gradient=policy_gradient,
+            results=reinforce_stability_results(oscillating_returns),
+            report_id="policy-gradient-loaded-momentum-conflict",
+            generated_at="2026-06-02T01:11:00Z",
+        )
+
+        stability = update["gradientStability"]
+        momentum = update["gradientMomentum"]
+        self.assertTrue(momentum["previousGradientPresent"])
+        self.assertTrue(momentum["previousGradientUsed"])
+        self.assertEqual(momentum["trustGateEvidenceSource"], "momentum_adjusted_gradient")
+        self.assertEqual(momentum["previousGradientSourceReportId"], "policy-gradient-momentum-state-source")
+        self.assertEqual(stability["classification"], "conflicting_direction_high_variance")
+        self.assertFalse(stability["directionConsistent"])
+        self.assertFalse(update["trustedGradientUpdate"])
+        self.assertTrue(update["highVariance"])
+        self.assertFalse(update["promotionGate"]["loopAPromotionEligible"])
+        self.assertFalse(update["promotionGate"]["loopBPromotionEligible"])
+        self.assertFalse(update["officialMmoWritesAllowed"])
+        self.assertFalse(momentum["officialMmoWritesAllowed"])
 
     def test_reinforce_too_few_return_samples_marks_update_untrusted(self) -> None:
         update = runner.build_policy_update(


### PR DESCRIPTION
## Summary
- Persists policy-gradient momentum state artifacts keyed by gradient comparison identity so later runs can load same-scheme previous-gradient evidence.
- Adds auditable `previousGradientPresent`, `previousGradientUsed`, state path/hash, and trust-gate evidence-source metadata while preserving offline-only safety flags.
- Keeps high-variance/conflicting-gradient candidates untrusted; momentum evidence improves traceability, not promotion laxity.

Fixes #1355

## Verification
- `git diff --check -- scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_training_runner.py`
- `python3 -m py_compile scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_training_runner.py`
- `python3 -m unittest scripts/test_screeps_rl_training_runner.py` — 138 tests OK
- `git merge-base --is-ancestor origin/main HEAD`

## Issue closure gate
- [x] #1355: Commit `21a53d381d6206ebe9d7ac0788aca427ed734ba3` adds persisted gradient-momentum state loading/materialization plus focused tests proving same-comparison reload and conservative untrusted classification for conflicting gradients.

## Universal task Done gate
- [x] Task type: code.
- [x] Expected observable outcome / named deliverable: Gradient momentum state is materialized under the training output directory and reused by later same-comparison training reports with explicit state identity/path/hash metadata.
- [x] Non-goals / accepted substitutes: No live MMO policy control, no Tencent paid compute launch, no cron change, and no reward-weight decision change in this slice.
- [x] Verification evidence required before Done: The three verification commands above pass from the PR worktree and the branch is based on current `origin/main`.
- [x] Project Evidence / Next action / Blocked by: Project items for #1355 and this PR record commit `21a53d38`, verification commands, and the review/merge gate as the next action; no owner action is required.
- [x] Post-merge/deploy/runtime proof: Script-only offline RL training runner change; proof surface is merged main containing commit `21a53d38` plus successful issue-completion/prod-ci checks, with no official Screeps deploy required.
- [x] Named deliverable proof: Tests `test_gradient_momentum_state_persists_and_loads_same_comparison` and `test_reinforce_gradient_conflict_remains_untrusted_with_loaded_momentum` prove persisted state reuse and conservative safety behavior.

## Safety
- `liveEffect=false`, `officialMmoWrites=false`, and `officialMmoWritesAllowed=false` remain asserted in state/momentum artifacts and tests.
- No secrets, runtime artifacts, `prod/node_modules`, or generated local caches are committed.
