### PR TITLE
fix: unblock expansion after completed claims

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -17263,11 +17263,14 @@ function getTerritoryTargetRoomName(target) {
   return isRecord18(target) && isNonEmptyString17(target.roomName) ? target.roomName : null;
 }
 function isSatisfiedClaimTarget(territoryMemory, colony, targetRoom, colonyOwnerUsername) {
-  return isVisibleRoomOwnedByColonyOwner(targetRoom, colonyOwnerUsername) || isPostClaimBootstrapSatisfied(territoryMemory, colony, targetRoom);
+  const visibleRoom = getVisibleRoom3(targetRoom);
+  if (isRoomOwnedByColonyOwner(visibleRoom, colonyOwnerUsername)) {
+    return true;
+  }
+  return !visibleRoom && isPostClaimBootstrapSatisfied(territoryMemory, colony, targetRoom);
 }
-function isVisibleRoomOwnedByColonyOwner(roomName, colonyOwnerUsername) {
-  var _a;
-  const controller = (_a = getVisibleRoom3(roomName)) == null ? void 0 : _a.controller;
+function isRoomOwnedByColonyOwner(room, colonyOwnerUsername) {
+  const controller = room == null ? void 0 : room.controller;
   return (controller == null ? void 0 : controller.my) === true || isNonEmptyString17(colonyOwnerUsername) && getControllerOwnerUsername7(controller) === colonyOwnerUsername;
 }
 function isPostClaimBootstrapSatisfied(territoryMemory, colony, targetRoom) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -16573,6 +16573,8 @@ function refreshAutonomousExpansionPipeline(colony, report, gameTime = getGameTi
       reason: "unavailable"
     };
   }
+  const colonyOwnerUsername = getControllerOwnerUsername7(colony.room.controller);
+  pruneSatisfiedClaimPlans(territoryMemory, colonyName, colonyOwnerUsername);
   const activePipeline = getActiveExpansionPipeline(territoryMemory, colonyName);
   if (!isAutonomousTerritoryControlAllowedForColony(colony)) {
     if (activePipeline) {
@@ -16597,10 +16599,12 @@ function refreshAutonomousExpansionPipeline(colony, report, gameTime = getGameTi
   const trigger = selectExpansionTriggerCandidate(colony, report, territoryMemory, gameTime);
   if (!trigger) {
     prunePipelinePlans(territoryMemory, colonyName);
+    const skip = getTriggerSkip(colony, report, territoryMemory, gameTime);
     return {
       status: "skipped",
       colony: colonyName,
-      reason: getTriggerSkipReason(colony, report, territoryMemory, gameTime)
+      reason: skip.reason,
+      ...skip.reasonDetail ? { reasonDetail: skip.reasonDetail } : {}
     };
   }
   const pipeline = createExpansionPipeline(colonyName, trigger.candidate, trigger.config, gameTime);
@@ -16833,7 +16837,11 @@ function selectExpansionTriggerCandidate(colony, report, territoryMemory, gameTi
   if (!isExpansionTriggerReady(colony, gameTime, config)) {
     return null;
   }
-  if (hasBlockingExpansionInProgress(territoryMemory, colony.room.name)) {
+  if (getBlockingExpansionInProgress(
+    territoryMemory,
+    colony.room.name,
+    getControllerOwnerUsername7(colony.room.controller)
+  )) {
     return null;
   }
   const candidate = findExpansionTriggerCandidate(colony, report, territoryMemory, config);
@@ -16852,38 +16860,43 @@ function findExpansionTriggerCandidate(colony, report, territoryMemory, config) 
     })
   )) != null ? _a : null;
 }
-function getTriggerSkipReason(colony, report, territoryMemory, gameTime) {
+function getTriggerSkip(colony, report, territoryMemory, gameTime) {
   if (report.candidates.length === 0) {
-    return "noCandidate";
+    return { reason: "noCandidate" };
   }
   if (report.candidates.some((candidate) => candidate.preconditions.includes(GCL_LIMIT_PRECONDITION2))) {
-    return "gclInsufficient";
+    return { reason: "gclInsufficient" };
   }
   if (report.candidates.some(
     (candidate) => candidate.preconditions.some((precondition) => precondition.startsWith(ROOM_LIMIT_PRECONDITION_PREFIX2))
   )) {
-    return "roomLimitReached";
+    return { reason: "roomLimitReached" };
   }
   const config = getExpansionTriggerConfig();
   if (!isExpansionHomeStable(colony, gameTime, config)) {
-    return "unmetPreconditions";
+    return { reason: "unmetPreconditions" };
   }
-  if (hasBlockingExpansionInProgress(territoryMemory, colony.room.name)) {
-    return "unmetPreconditions";
+  const blocker = getBlockingExpansionInProgress(
+    territoryMemory,
+    colony.room.name,
+    getControllerOwnerUsername7(colony.room.controller)
+  );
+  if (blocker) {
+    return { reason: "unmetPreconditions", reasonDetail: blocker.reasonDetail };
   }
   if (!isExpansionTriggerReady(colony, gameTime, config) && findExpansionTriggerCandidate(colony, report, territoryMemory, config)) {
-    return "unmetPreconditions";
+    return { reason: "unmetPreconditions" };
   }
   if (report.candidates.some((candidate) => candidate.evidenceStatus === "insufficient-evidence")) {
-    return "insufficientEvidence";
+    return { reason: "insufficientEvidence" };
   }
   if (report.candidates.some((candidate) => candidate.preconditions.length > 0)) {
-    return "unmetPreconditions";
+    return { reason: "unmetPreconditions" };
   }
   if (!isExpansionTriggerReady(colony, gameTime, config)) {
-    return "unmetPreconditions";
+    return { reason: "unmetPreconditions" };
   }
-  return "unavailable";
+  return { reason: "unavailable" };
 }
 function getPreControlGateSkipReason(report) {
   if (report.candidates.length === 0) {
@@ -17170,27 +17183,97 @@ function getMaxRoomEnergyCapacityForRcl(controllerLevel) {
   const rcl = Math.max(0, Math.min(8, Math.floor(controllerLevel)));
   return (_a = MAX_ROOM_ENERGY_CAPACITY_BY_RCL[rcl]) != null ? _a : null;
 }
-function hasBlockingExpansionInProgress(territoryMemory, colony) {
+function getBlockingExpansionInProgress(territoryMemory, colony, colonyOwnerUsername) {
   const pipelines = getExpansionPipelinesRecord(territoryMemory);
-  if (Object.values(pipelines).some((pipeline) => pipeline.colony === colony && pipeline.status === "active")) {
-    return true;
+  const activePipeline = Object.values(pipelines).find(
+    (pipeline) => pipeline.colony === colony && pipeline.status === "active"
+  );
+  if (activePipeline) {
+    return { reasonDetail: "activeExpansionPipeline", targetRoom: activePipeline.targetRoom };
   }
-  if (getActivePostClaimBootstrapBlockers(colony).length > 0) {
-    return true;
+  const activeBootstrapBlocker = getActivePostClaimBootstrapBlockers(colony)[0];
+  if (activeBootstrapBlocker) {
+    return { reasonDetail: "activePostClaimBootstrap", targetRoom: activeBootstrapBlocker.roomName };
   }
   const targets = Array.isArray(territoryMemory.targets) ? territoryMemory.targets : [];
-  if (targets.some((target) => isBlockingExpansionTarget2(target, colony))) {
-    return true;
-  }
-  return normalizeTerritoryIntents(territoryMemory.intents).some(
-    (intent) => isBlockingExpansionIntent(intent, colony)
+  const blockingTarget = targets.find(
+    (target) => isBlockingExpansionTarget2(target, colony, territoryMemory, colonyOwnerUsername)
   );
+  if (blockingTarget) {
+    const targetRoom = getTerritoryTargetRoomName(blockingTarget);
+    return {
+      reasonDetail: "activeClaimTarget",
+      ...targetRoom ? { targetRoom } : {}
+    };
+  }
+  const blockingIntent = normalizeTerritoryIntents(territoryMemory.intents).find(
+    (intent) => isBlockingExpansionIntent(intent, colony, territoryMemory, colonyOwnerUsername)
+  );
+  if (blockingIntent) {
+    return { reasonDetail: "activeClaimIntent", targetRoom: blockingIntent.targetRoom };
+  }
+  return null;
 }
-function isBlockingExpansionTarget2(target, colony) {
+function pruneSatisfiedClaimPlans(territoryMemory, colony, colonyOwnerUsername) {
+  pruneSatisfiedClaimTargets(territoryMemory, colony, colonyOwnerUsername);
+  pruneSatisfiedClaimIntents(territoryMemory, colony, colonyOwnerUsername);
+}
+function pruneSatisfiedClaimTargets(territoryMemory, colony, colonyOwnerUsername) {
+  if (!Array.isArray(territoryMemory.targets)) {
+    return;
+  }
+  const targets = territoryMemory.targets;
+  territoryMemory.targets = targets.filter((target) => {
+    const targetRoom = getTerritoryTargetRoomName(target);
+    return !isClaimTargetInProgress(target, colony) || !targetRoom || !isSatisfiedClaimTarget(territoryMemory, colony, targetRoom, colonyOwnerUsername);
+  });
+}
+function pruneSatisfiedClaimIntents(territoryMemory, colony, colonyOwnerUsername) {
+  const rawIntents = territoryMemory.intents;
+  const intents = normalizeTerritoryIntents(rawIntents);
+  if (intents.length === 0) {
+    if (Array.isArray(rawIntents) && rawIntents.length > 0) {
+      delete territoryMemory.intents;
+    }
+    return;
+  }
+  const nextIntents = intents.filter(
+    (intent) => !isClaimIntentInProgress(intent, colony) || !isSatisfiedClaimTarget(territoryMemory, colony, intent.targetRoom, colonyOwnerUsername)
+  );
+  if (nextIntents.length > 0) {
+    territoryMemory.intents = nextIntents;
+  } else {
+    delete territoryMemory.intents;
+  }
+}
+function isBlockingExpansionTarget2(target, colony, territoryMemory, colonyOwnerUsername) {
+  const targetRoom = getTerritoryTargetRoomName(target);
+  return isClaimTargetInProgress(target, colony) && !!targetRoom && !isSatisfiedClaimTarget(territoryMemory, colony, targetRoom, colonyOwnerUsername);
+}
+function isClaimTargetInProgress(target, colony) {
   return isRecord18(target) && target.colony === colony && target.enabled !== false && target.action === "claim";
 }
-function isBlockingExpansionIntent(intent, colony) {
+function isBlockingExpansionIntent(intent, colony, territoryMemory, colonyOwnerUsername) {
+  return isClaimIntentInProgress(intent, colony) && !isSatisfiedClaimTarget(territoryMemory, colony, intent.targetRoom, colonyOwnerUsername);
+}
+function isClaimIntentInProgress(intent, colony) {
   return intent.colony === colony && intent.action === "claim" && (intent.status === "planned" || intent.status === "active");
+}
+function getTerritoryTargetRoomName(target) {
+  return isRecord18(target) && isNonEmptyString17(target.roomName) ? target.roomName : null;
+}
+function isSatisfiedClaimTarget(territoryMemory, colony, targetRoom, colonyOwnerUsername) {
+  return isVisibleRoomOwnedByColonyOwner(targetRoom, colonyOwnerUsername) || isPostClaimBootstrapSatisfied(territoryMemory, colony, targetRoom);
+}
+function isVisibleRoomOwnedByColonyOwner(roomName, colonyOwnerUsername) {
+  var _a;
+  const controller = (_a = getVisibleRoom3(roomName)) == null ? void 0 : _a.controller;
+  return (controller == null ? void 0 : controller.my) === true || isNonEmptyString17(colonyOwnerUsername) && getControllerOwnerUsername7(controller) === colonyOwnerUsername;
+}
+function isPostClaimBootstrapSatisfied(territoryMemory, colony, targetRoom) {
+  var _a;
+  const record = (_a = territoryMemory.postClaimBootstraps) == null ? void 0 : _a[targetRoom];
+  return isRecord18(record) && record.colony === colony && record.roomName === targetRoom && (record.status === "ready" || record.status === "completed");
 }
 function getExpansionCapacitySkipReason(colony) {
   var _a;
@@ -45150,14 +45233,19 @@ function normalizeExpansionExecutorSelection(rawSelection, colonyName) {
   if (!reason) {
     return null;
   }
+  const reasonDetail = normalizeExpansionExecutorSkipReasonDetail(rawSelection.reasonDetail);
   return {
     status: "skipped",
     colony: colonyName,
-    reason
+    reason,
+    ...reasonDetail ? { reasonDetail } : {}
   };
 }
 function normalizeExpansionExecutorSkipReason(reason) {
   return reason === "noCandidate" || reason === "gclInsufficient" || reason === "roomLimitReached" || reason === "unmetPreconditions" || reason === "insufficientEvidence" || reason === "unavailable" ? reason : void 0;
+}
+function normalizeExpansionExecutorSkipReasonDetail(reasonDetail) {
+  return reasonDetail === "activeExpansionPipeline" || reasonDetail === "activePostClaimBootstrap" || reasonDetail === "activeClaimTarget" || reasonDetail === "activeClaimIntent" ? reasonDetail : void 0;
 }
 function isExpansionExecutorCacheReusable(cachedSelection, colony, gameTime, stateKey) {
   if (hasActiveAutonomousExpansionPipeline(colony.room.name)) {
@@ -45204,6 +45292,7 @@ function getExpansionExecutorCacheStateKey(colony, gameTime = getGameTime40()) {
     countActiveExpansionExecutorSpawns(colony),
     getExpansionExecutorVisibleHostileState(colony.room),
     getExpansionExecutorThreatState(colony.room.name, gameTime),
+    getExpansionExecutorClaimPlanState(colony.room.name),
     countActivePostClaimBootstraps(colony.room.name, gameTime),
     getAutonomousExpansionPipelineStateKey(colony.room.name),
     getLatestTerritoryScoutIntelUpdatedAt(colony.room.name)
@@ -45306,6 +45395,17 @@ function getGclLevel5() {
 }
 function countActivePostClaimBootstraps(colonyName, gameTime) {
   return getActivePostClaimBootstrapBlockers(colonyName, gameTime).length;
+}
+function getExpansionExecutorClaimPlanState(colonyName) {
+  var _a;
+  const territory = (_a = globalThis.Memory) == null ? void 0 : _a.territory;
+  const targets = Array.isArray(territory == null ? void 0 : territory.targets) ? territory.targets.filter(
+    (target) => isRecord37(target) && target.colony === colonyName && target.enabled !== false && target.action === "claim" && isNonEmptyString37(target.roomName)
+  ).map((target) => target.roomName) : [];
+  const intents = Array.isArray(territory == null ? void 0 : territory.intents) ? territory.intents.filter(
+    (intent) => isRecord37(intent) && intent.colony === colonyName && intent.action === "claim" && (intent.status === "planned" || intent.status === "active") && isNonEmptyString37(intent.targetRoom)
+  ).map((intent) => intent.targetRoom) : [];
+  return [...targets, ...intents].sort().join(",");
 }
 function getLatestTerritoryScoutIntelUpdatedAt(colony) {
   var _a, _b;

--- a/prod/src/territory/expansionExecutor.ts
+++ b/prod/src/territory/expansionExecutor.ts
@@ -177,11 +177,13 @@ function normalizeExpansionExecutorSelection(
   if (!reason) {
     return null;
   }
+  const reasonDetail = normalizeExpansionExecutorSkipReasonDetail(rawSelection.reasonDetail);
 
   return {
     status: 'skipped',
     colony: colonyName,
-    reason
+    reason,
+    ...(reasonDetail ? { reasonDetail } : {})
   };
 }
 
@@ -195,6 +197,17 @@ function normalizeExpansionExecutorSkipReason(
     reason === 'insufficientEvidence' ||
     reason === 'unavailable'
     ? reason
+    : undefined;
+}
+
+function normalizeExpansionExecutorSkipReasonDetail(
+  reasonDetail: unknown
+): NextExpansionTargetSelection['reasonDetail'] | undefined {
+  return reasonDetail === 'activeExpansionPipeline' ||
+    reasonDetail === 'activePostClaimBootstrap' ||
+    reasonDetail === 'activeClaimTarget' ||
+    reasonDetail === 'activeClaimIntent'
+    ? reasonDetail
     : undefined;
 }
 
@@ -273,6 +286,7 @@ function getExpansionExecutorCacheStateKey(colony: ColonySnapshot, gameTime = ge
     countActiveExpansionExecutorSpawns(colony),
     getExpansionExecutorVisibleHostileState(colony.room),
     getExpansionExecutorThreatState(colony.room.name, gameTime),
+    getExpansionExecutorClaimPlanState(colony.room.name),
     countActivePostClaimBootstraps(colony.room.name, gameTime),
     getAutonomousExpansionPipelineStateKey(colony.room.name),
     getLatestTerritoryScoutIntelUpdatedAt(colony.room.name)
@@ -403,6 +417,36 @@ function getGclLevel(): number | null {
 
 function countActivePostClaimBootstraps(colonyName: string, gameTime: number): number {
   return getActivePostClaimBootstrapBlockers(colonyName, gameTime).length;
+}
+
+function getExpansionExecutorClaimPlanState(colonyName: string): string {
+  const territory = (globalThis as { Memory?: Partial<Memory> }).Memory?.territory;
+  const targets = Array.isArray(territory?.targets)
+    ? territory.targets
+        .filter(
+          (target) =>
+            isRecord(target) &&
+            target.colony === colonyName &&
+            target.enabled !== false &&
+            target.action === 'claim' &&
+            isNonEmptyString(target.roomName)
+        )
+        .map((target) => target.roomName as string)
+    : [];
+  const intents = Array.isArray(territory?.intents)
+    ? territory.intents
+        .filter(
+          (intent) =>
+            isRecord(intent) &&
+            intent.colony === colonyName &&
+            intent.action === 'claim' &&
+            (intent.status === 'planned' || intent.status === 'active') &&
+            isNonEmptyString(intent.targetRoom)
+        )
+        .map((intent) => intent.targetRoom as string)
+    : [];
+
+  return [...targets, ...intents].sort().join(',');
 }
 
 function getLatestTerritoryScoutIntelUpdatedAt(colony: string): number {

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -208,11 +208,17 @@ export type NextExpansionTargetSelectionReason =
   | 'unmetPreconditions'
   | 'insufficientEvidence'
   | 'unavailable';
+export type NextExpansionTargetSelectionReasonDetail =
+  | 'activeExpansionPipeline'
+  | 'activePostClaimBootstrap'
+  | 'activeClaimTarget'
+  | 'activeClaimIntent';
 
 export interface NextExpansionTargetSelection {
   status: NextExpansionTargetSelectionStatus;
   colony: string;
   reason?: NextExpansionTargetSelectionReason;
+  reasonDetail?: NextExpansionTargetSelectionReasonDetail;
   targetRoom?: string;
   controllerId?: Id<StructureController>;
   score?: number;

--- a/prod/src/territory/expansionTrigger.ts
+++ b/prod/src/territory/expansionTrigger.ts
@@ -56,6 +56,16 @@ interface ExpansionTriggerCandidate {
   config: ExpansionTriggerConfig;
 }
 
+interface ExpansionTriggerSkip {
+  reason: NextExpansionTargetSelection['reason'];
+  reasonDetail?: NextExpansionTargetSelection['reasonDetail'];
+}
+
+interface ExpansionProgressBlocker {
+  reasonDetail: NonNullable<NextExpansionTargetSelection['reasonDetail']>;
+  targetRoom?: string;
+}
+
 export function refreshAutonomousExpansionPipeline(
   colony: ColonySnapshot,
   report: ExpansionCandidateReport,
@@ -72,6 +82,8 @@ export function refreshAutonomousExpansionPipeline(
     };
   }
 
+  const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
+  pruneSatisfiedClaimPlans(territoryMemory, colonyName, colonyOwnerUsername);
   const activePipeline = getActiveExpansionPipeline(territoryMemory, colonyName);
   if (!isAutonomousTerritoryControlAllowedForColony(colony)) {
     if (activePipeline) {
@@ -99,10 +111,12 @@ export function refreshAutonomousExpansionPipeline(
   const trigger = selectExpansionTriggerCandidate(colony, report, territoryMemory, gameTime);
   if (!trigger) {
     prunePipelinePlans(territoryMemory, colonyName);
+    const skip = getTriggerSkip(colony, report, territoryMemory, gameTime);
     return {
       status: 'skipped',
       colony: colonyName,
-      reason: getTriggerSkipReason(colony, report, territoryMemory, gameTime)
+      reason: skip.reason,
+      ...(skip.reasonDetail ? { reasonDetail: skip.reasonDetail } : {})
     };
   }
 
@@ -416,7 +430,13 @@ function selectExpansionTriggerCandidate(
     return null;
   }
 
-  if (hasBlockingExpansionInProgress(territoryMemory, colony.room.name)) {
+  if (
+    getBlockingExpansionInProgress(
+      territoryMemory,
+      colony.room.name,
+      getControllerOwnerUsername(colony.room.controller)
+    )
+  ) {
     return null;
   }
 
@@ -449,18 +469,18 @@ function findExpansionTriggerCandidate(
   ) ?? null;
 }
 
-function getTriggerSkipReason(
+function getTriggerSkip(
   colony: ColonySnapshot,
   report: ExpansionCandidateReport,
   territoryMemory: TerritoryMemory,
   gameTime: number
-): NextExpansionTargetSelection['reason'] {
+): ExpansionTriggerSkip {
   if (report.candidates.length === 0) {
-    return 'noCandidate';
+    return { reason: 'noCandidate' };
   }
 
   if (report.candidates.some((candidate) => candidate.preconditions.includes(GCL_LIMIT_PRECONDITION))) {
-    return 'gclInsufficient';
+    return { reason: 'gclInsufficient' };
   }
 
   if (
@@ -468,38 +488,43 @@ function getTriggerSkipReason(
       candidate.preconditions.some((precondition) => precondition.startsWith(ROOM_LIMIT_PRECONDITION_PREFIX))
     )
   ) {
-    return 'roomLimitReached';
+    return { reason: 'roomLimitReached' };
   }
 
   const config = getExpansionTriggerConfig();
   if (!isExpansionHomeStable(colony, gameTime, config)) {
-    return 'unmetPreconditions';
+    return { reason: 'unmetPreconditions' };
   }
 
-  if (hasBlockingExpansionInProgress(territoryMemory, colony.room.name)) {
-    return 'unmetPreconditions';
+  const blocker = getBlockingExpansionInProgress(
+    territoryMemory,
+    colony.room.name,
+    getControllerOwnerUsername(colony.room.controller)
+  );
+  if (blocker) {
+    return { reason: 'unmetPreconditions', reasonDetail: blocker.reasonDetail };
   }
 
   if (
     !isExpansionTriggerReady(colony, gameTime, config) &&
     findExpansionTriggerCandidate(colony, report, territoryMemory, config)
   ) {
-    return 'unmetPreconditions';
+    return { reason: 'unmetPreconditions' };
   }
 
   if (report.candidates.some((candidate) => candidate.evidenceStatus === 'insufficient-evidence')) {
-    return 'insufficientEvidence';
+    return { reason: 'insufficientEvidence' };
   }
 
   if (report.candidates.some((candidate) => candidate.preconditions.length > 0)) {
-    return 'unmetPreconditions';
+    return { reason: 'unmetPreconditions' };
   }
 
   if (!isExpansionTriggerReady(colony, gameTime, config)) {
-    return 'unmetPreconditions';
+    return { reason: 'unmetPreconditions' };
   }
 
-  return 'unavailable';
+  return { reason: 'unavailable' };
 }
 
 function getPreControlGateSkipReason(report: ExpansionCandidateReport): NextExpansionTargetSelection['reason'] {
@@ -939,27 +964,116 @@ function getMaxRoomEnergyCapacityForRcl(controllerLevel: number | undefined): nu
   return MAX_ROOM_ENERGY_CAPACITY_BY_RCL[rcl] ?? null;
 }
 
-function hasBlockingExpansionInProgress(territoryMemory: TerritoryMemory, colony: string): boolean {
+function getBlockingExpansionInProgress(
+  territoryMemory: TerritoryMemory,
+  colony: string,
+  colonyOwnerUsername: string | undefined
+): ExpansionProgressBlocker | null {
   const pipelines = getExpansionPipelinesRecord(territoryMemory);
-  if (Object.values(pipelines).some((pipeline) => pipeline.colony === colony && pipeline.status === 'active')) {
-    return true;
+  const activePipeline = Object.values(pipelines).find(
+    (pipeline) => pipeline.colony === colony && pipeline.status === 'active'
+  );
+  if (activePipeline) {
+    return { reasonDetail: 'activeExpansionPipeline', targetRoom: activePipeline.targetRoom };
   }
 
-  if (getActivePostClaimBootstrapBlockers(colony).length > 0) {
-    return true;
+  const activeBootstrapBlocker = getActivePostClaimBootstrapBlockers(colony)[0];
+  if (activeBootstrapBlocker) {
+    return { reasonDetail: 'activePostClaimBootstrap', targetRoom: activeBootstrapBlocker.roomName };
   }
 
   const targets = Array.isArray(territoryMemory.targets) ? territoryMemory.targets : [];
-  if (targets.some((target) => isBlockingExpansionTarget(target, colony))) {
-    return true;
+  const blockingTarget = targets.find((target) =>
+    isBlockingExpansionTarget(target, colony, territoryMemory, colonyOwnerUsername)
+  );
+  if (blockingTarget) {
+    const targetRoom = getTerritoryTargetRoomName(blockingTarget);
+    return {
+      reasonDetail: 'activeClaimTarget',
+      ...(targetRoom ? { targetRoom } : {})
+    };
   }
 
-  return normalizeTerritoryIntents(territoryMemory.intents).some((intent) =>
-    isBlockingExpansionIntent(intent, colony)
+  const blockingIntent = normalizeTerritoryIntents(territoryMemory.intents).find((intent) =>
+    isBlockingExpansionIntent(intent, colony, territoryMemory, colonyOwnerUsername)
+  );
+  if (blockingIntent) {
+    return { reasonDetail: 'activeClaimIntent', targetRoom: blockingIntent.targetRoom };
+  }
+
+  return null;
+}
+
+function pruneSatisfiedClaimPlans(
+  territoryMemory: TerritoryMemory,
+  colony: string,
+  colonyOwnerUsername: string | undefined
+): void {
+  pruneSatisfiedClaimTargets(territoryMemory, colony, colonyOwnerUsername);
+  pruneSatisfiedClaimIntents(territoryMemory, colony, colonyOwnerUsername);
+}
+
+function pruneSatisfiedClaimTargets(
+  territoryMemory: TerritoryMemory,
+  colony: string,
+  colonyOwnerUsername: string | undefined
+): void {
+  if (!Array.isArray(territoryMemory.targets)) {
+    return;
+  }
+
+  const targets = territoryMemory.targets;
+  territoryMemory.targets = targets.filter((target) => {
+    const targetRoom = getTerritoryTargetRoomName(target);
+    return (
+      !isClaimTargetInProgress(target, colony) ||
+      !targetRoom ||
+      !isSatisfiedClaimTarget(territoryMemory, colony, targetRoom, colonyOwnerUsername)
+    );
+  });
+}
+
+function pruneSatisfiedClaimIntents(
+  territoryMemory: TerritoryMemory,
+  colony: string,
+  colonyOwnerUsername: string | undefined
+): void {
+  const rawIntents = territoryMemory.intents;
+  const intents = normalizeTerritoryIntents(rawIntents);
+  if (intents.length === 0) {
+    if (Array.isArray(rawIntents) && rawIntents.length > 0) {
+      delete territoryMemory.intents;
+    }
+    return;
+  }
+
+  const nextIntents = intents.filter(
+    (intent) =>
+      !isClaimIntentInProgress(intent, colony) ||
+      !isSatisfiedClaimTarget(territoryMemory, colony, intent.targetRoom, colonyOwnerUsername)
+  );
+  if (nextIntents.length > 0) {
+    territoryMemory.intents = nextIntents;
+  } else {
+    delete territoryMemory.intents;
+  }
+}
+
+function isBlockingExpansionTarget(
+  target: unknown,
+  colony: string,
+  territoryMemory: TerritoryMemory,
+  colonyOwnerUsername: string | undefined
+): boolean {
+  const targetRoom = getTerritoryTargetRoomName(target);
+  return (
+    isClaimTargetInProgress(target, colony) &&
+    !!targetRoom &&
+    !isSatisfiedClaimTarget(territoryMemory, colony, targetRoom, colonyOwnerUsername)
   );
 }
 
-function isBlockingExpansionTarget(target: unknown, colony: string): boolean {
+function isClaimTargetInProgress(target: unknown, colony: string): boolean {
   return (
     isRecord(target) &&
     target.colony === colony &&
@@ -968,11 +1082,61 @@ function isBlockingExpansionTarget(target: unknown, colony: string): boolean {
   );
 }
 
-function isBlockingExpansionIntent(intent: TerritoryIntentMemory, colony: string): boolean {
+function isBlockingExpansionIntent(
+  intent: TerritoryIntentMemory,
+  colony: string,
+  territoryMemory: TerritoryMemory,
+  colonyOwnerUsername: string | undefined
+): boolean {
+  return (
+    isClaimIntentInProgress(intent, colony) &&
+    !isSatisfiedClaimTarget(territoryMemory, colony, intent.targetRoom, colonyOwnerUsername)
+  );
+}
+
+function isClaimIntentInProgress(intent: TerritoryIntentMemory, colony: string): boolean {
   return (
     intent.colony === colony &&
     intent.action === 'claim' &&
     (intent.status === 'planned' || intent.status === 'active')
+  );
+}
+
+function getTerritoryTargetRoomName(target: unknown): string | null {
+  return isRecord(target) && isNonEmptyString(target.roomName) ? target.roomName : null;
+}
+
+function isSatisfiedClaimTarget(
+  territoryMemory: TerritoryMemory,
+  colony: string,
+  targetRoom: string,
+  colonyOwnerUsername: string | undefined
+): boolean {
+  return (
+    isVisibleRoomOwnedByColonyOwner(targetRoom, colonyOwnerUsername) ||
+    isPostClaimBootstrapSatisfied(territoryMemory, colony, targetRoom)
+  );
+}
+
+function isVisibleRoomOwnedByColonyOwner(roomName: string, colonyOwnerUsername: string | undefined): boolean {
+  const controller = getVisibleRoom(roomName)?.controller;
+  return (
+    controller?.my === true ||
+    (isNonEmptyString(colonyOwnerUsername) && getControllerOwnerUsername(controller) === colonyOwnerUsername)
+  );
+}
+
+function isPostClaimBootstrapSatisfied(
+  territoryMemory: TerritoryMemory,
+  colony: string,
+  targetRoom: string
+): boolean {
+  const record = territoryMemory.postClaimBootstraps?.[targetRoom] as unknown;
+  return (
+    isRecord(record) &&
+    record.colony === colony &&
+    record.roomName === targetRoom &&
+    (record.status === 'ready' || record.status === 'completed')
   );
 }
 

--- a/prod/src/territory/expansionTrigger.ts
+++ b/prod/src/territory/expansionTrigger.ts
@@ -1112,14 +1112,16 @@ function isSatisfiedClaimTarget(
   targetRoom: string,
   colonyOwnerUsername: string | undefined
 ): boolean {
-  return (
-    isVisibleRoomOwnedByColonyOwner(targetRoom, colonyOwnerUsername) ||
-    isPostClaimBootstrapSatisfied(territoryMemory, colony, targetRoom)
-  );
+  const visibleRoom = getVisibleRoom(targetRoom);
+  if (isRoomOwnedByColonyOwner(visibleRoom, colonyOwnerUsername)) {
+    return true;
+  }
+
+  return !visibleRoom && isPostClaimBootstrapSatisfied(territoryMemory, colony, targetRoom);
 }
 
-function isVisibleRoomOwnedByColonyOwner(roomName: string, colonyOwnerUsername: string | undefined): boolean {
-  const controller = getVisibleRoom(roomName)?.controller;
+function isRoomOwnedByColonyOwner(room: Room | undefined, colonyOwnerUsername: string | undefined): boolean {
+  const controller = room?.controller;
   return (
     controller?.my === true ||
     (isNonEmptyString(colonyOwnerUsername) && getControllerOwnerUsername(controller) === colonyOwnerUsername)

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -741,6 +741,11 @@ declare global {
     | 'unmetPreconditions'
     | 'insufficientEvidence'
     | 'unavailable';
+  type RoomExpansionSelectionReasonDetail =
+    | 'activeExpansionPipeline'
+    | 'activePostClaimBootstrap'
+    | 'activeClaimTarget'
+    | 'activeClaimIntent';
 
   interface RoomMemory {
     lastExpansionScoreTime?: number;
@@ -779,6 +784,7 @@ declare global {
     status: RoomExpansionSelectionStatus;
     colony: string;
     reason?: RoomExpansionSelectionReason;
+    reasonDetail?: RoomExpansionSelectionReasonDetail;
     targetRoom?: string;
     controllerId?: Id<StructureController>;
     score?: number;

--- a/prod/test/expansionTrigger.test.ts
+++ b/prod/test/expansionTrigger.test.ts
@@ -536,7 +536,8 @@ describe('autonomous expansion trigger pipeline', () => {
     expect(refreshAutonomousExpansionPipeline(colony, report, 50)).toEqual({
       status: 'skipped',
       colony: 'W1N1',
-      reason: 'unmetPreconditions'
+      reason: 'unmetPreconditions',
+      reasonDetail: 'activeClaimTarget'
     });
     expect(Memory.territory?.expansionPipelines?.W1N1).toBeUndefined();
 
@@ -558,7 +559,108 @@ describe('autonomous expansion trigger pipeline', () => {
     expect(refreshAutonomousExpansionPipeline(colony, report, 50)).toEqual({
       status: 'skipped',
       colony: 'W1N1',
-      reason: 'unmetPreconditions'
+      reason: 'unmetPreconditions',
+      reasonDetail: 'activeClaimIntent'
+    });
+    expect(Memory.territory?.expansionPipelines?.W1N1).toBeUndefined();
+  });
+
+  it('self-heals completed E29N56 and E29N57 claim intents before the next E29N55 expansion', () => {
+    const gameTime = 1_708_611;
+    const colony = makeColony({ roomName: 'E29N55', storageEnergy: 2_000, rcl: 6 });
+    const report = makeReport([
+      makeCandidate({ roomName: 'E29N58', controllerId: 'controller-e29n58' as Id<StructureController> })
+    ]);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        expansionPipelines: {},
+        intents: [
+          {
+            colony: 'E29N55',
+            targetRoom: 'E29N56',
+            action: 'claim',
+            status: 'active',
+            updatedAt: 1_218_191
+          },
+          {
+            colony: 'E29N55',
+            targetRoom: 'E29N57',
+            action: 'claim',
+            status: 'active',
+            updatedAt: 1_218_674
+          }
+        ],
+        postClaimBootstraps: {
+          E29N56: makePostClaimBootstrap('E29N55', 'E29N56', 'ready'),
+          E29N57: makePostClaimBootstrap('E29N55', 'E29N57', 'completed')
+        } as unknown as Record<string, TerritoryPostClaimBootstrapMemory>
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: gameTime,
+      gcl: { level: 5 } as GlobalControlLevel,
+      rooms: {
+        E29N55: colony.room,
+        E29N56: makeTargetRoom('E29N56', 'controller-e29n56' as Id<StructureController>, { my: true }),
+        E29N57: makeTargetRoom('E29N57', 'controller-e29n57' as Id<StructureController>, { my: true }),
+        E29N58: makeTargetRoom('E29N58', 'controller-e29n58' as Id<StructureController>)
+      }
+    };
+    setSafeHomeThreat('E29N55', gameTime);
+
+    expect(refreshAutonomousExpansionPipeline(colony, report, gameTime)).toMatchObject({
+      status: 'planned',
+      colony: 'E29N55',
+      targetRoom: 'E29N58',
+      controllerId: 'controller-e29n58'
+    });
+    expect(Memory.territory?.intents).toEqual([
+      expect.objectContaining({
+        colony: 'E29N55',
+        targetRoom: 'E29N58',
+        action: 'reserve',
+        status: 'planned'
+      })
+    ]);
+    expect(Memory.territory?.intents?.some((intent) => intent.targetRoom === 'E29N56')).toBe(false);
+    expect(Memory.territory?.intents?.some((intent) => intent.targetRoom === 'E29N57')).toBe(false);
+    expect(Memory.territory?.expansionPipelines?.E29N55).toMatchObject({
+      status: 'active',
+      stage: 'reserving',
+      targetRoom: 'E29N58'
+    });
+  });
+
+  it('reports active post-claim bootstrap blockers separately from generic unmet preconditions', () => {
+    const colony = makeColony({ storageEnergy: 2_000 });
+    const report = makeReport([
+      makeCandidate({ roomName: 'W2N1', controllerId: 'controller2' as Id<StructureController> })
+    ]);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          W3N1: makePostClaimBootstrap('W1N1', 'W3N1', 'detected')
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 52,
+      gcl: { level: 5 } as GlobalControlLevel,
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeTargetRoom('W2N1', 'controller2' as Id<StructureController>),
+        W3N1: makeTargetRoom('W3N1', 'controller3' as Id<StructureController>, { my: true })
+      },
+      spawns: {},
+      creeps: {}
+    };
+    setSafeHomeThreat('W1N1', 52);
+
+    expect(refreshAutonomousExpansionPipeline(colony, report, 52)).toEqual({
+      status: 'skipped',
+      colony: 'W1N1',
+      reason: 'unmetPreconditions',
+      reasonDetail: 'activePostClaimBootstrap'
     });
     expect(Memory.territory?.expansionPipelines?.W1N1).toBeUndefined();
   });
@@ -702,12 +804,14 @@ function makeCandidate({
 }
 
 function makeColony({
+  roomName = 'W1N1',
   storageEnergy = 0,
   rcl = 6,
   ticksToDowngrade = 10_000,
   energyAvailable = 1_300,
   energyCapacityAvailable = 1_300
 }: {
+  roomName?: string;
   storageEnergy?: number;
   rcl?: number;
   ticksToDowngrade?: number;
@@ -715,7 +819,7 @@ function makeColony({
   energyCapacityAvailable?: number;
 } = {}): ColonySnapshot {
   const room = {
-    name: 'W1N1',
+    name: roomName,
     energyAvailable,
     energyCapacityAvailable,
     storage: makeStorage(storageEnergy),
@@ -727,7 +831,7 @@ function makeColony({
       ticksToDowngrade
     } as StructureController,
     memory: {},
-    find: jest.fn((findType: number) => (findType === FIND_SOURCES ? makeSources('W1N1', 2) : []))
+    find: jest.fn((findType: number) => (findType === FIND_SOURCES ? makeSources(roomName, 2) : []))
   } as unknown as Room & { memory: RoomMemory };
 
   return {
@@ -744,20 +848,26 @@ function makeTargetRoom(
   controllerId: Id<StructureController>,
   {
     hostileCreepCount = 0,
-    sourceCount = 2
+    sourceCount = 2,
+    my = false,
+    ownerUsername
   }: {
     hostileCreepCount?: number;
     sourceCount?: number;
+    my?: boolean;
+    ownerUsername?: string;
   } = {}
 ): Room {
   const sources = makeSources(roomName, sourceCount);
   const hostiles = Array.from({ length: hostileCreepCount }, (_value, index) => ({ id: `hostile-${index}` }));
+  const owner = ownerUsername ?? (my ? 'me' : undefined);
   return {
     name: roomName,
     controller: {
       id: controllerId,
-      my: false,
-      pos: makePosition(25, 25, roomName)
+      my,
+      pos: makePosition(25, 25, roomName),
+      ...(owner ? { owner: { username: owner } } : {})
     } as StructureController,
     find: jest.fn((findType: number) => {
       if (findType === FIND_SOURCES) {
@@ -770,6 +880,21 @@ function makeTargetRoom(
       return [];
     })
   } as unknown as Room;
+}
+
+function makePostClaimBootstrap(
+  colony: string,
+  roomName: string,
+  status: TerritoryPostClaimBootstrapStatus | 'completed'
+): TerritoryPostClaimBootstrapMemory {
+  return {
+    colony,
+    roomName,
+    status,
+    claimedAt: 1_200_000,
+    updatedAt: 1_200_000,
+    workerTarget: 2
+  } as TerritoryPostClaimBootstrapMemory;
 }
 
 function makeStorage(energy: number): StructureStorage {

--- a/prod/test/expansionTrigger.test.ts
+++ b/prod/test/expansionTrigger.test.ts
@@ -517,7 +517,8 @@ describe('autonomous expansion trigger pipeline', () => {
       time: 50,
       rooms: {
         W1N1: colony.room,
-        W2N1: makeTargetRoom('W2N1', 'controller2' as Id<StructureController>)
+        W2N1: makeTargetRoom('W2N1', 'controller2' as Id<StructureController>),
+        W3N1: makeTargetRoom('W3N1', 'controller3' as Id<StructureController>)
       }
     };
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
@@ -629,6 +630,56 @@ describe('autonomous expansion trigger pipeline', () => {
       stage: 'reserving',
       targetRoom: 'E29N58'
     });
+  });
+
+  it('keeps visible unowned ready-bootstrap recovery claims blocking expansion', () => {
+    const gameTime = 1_708_612;
+    const colony = makeColony({ roomName: 'E29N55', storageEnergy: 2_000, rcl: 6 });
+    const report = makeReport([
+      makeCandidate({ roomName: 'E29N58', controllerId: 'controller-e29n58' as Id<StructureController> })
+    ]);
+    const recoveryTarget = {
+      colony: 'E29N55',
+      roomName: 'E29N56',
+      action: 'claim' as const
+    };
+    const recoveryIntent = {
+      colony: 'E29N55',
+      targetRoom: 'E29N56',
+      action: 'claim' as const,
+      status: 'active' as const,
+      updatedAt: 1_218_191
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        expansionPipelines: {},
+        targets: [recoveryTarget],
+        intents: [recoveryIntent],
+        postClaimBootstraps: {
+          E29N56: makePostClaimBootstrap('E29N55', 'E29N56', 'ready')
+        } as unknown as Record<string, TerritoryPostClaimBootstrapMemory>
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: gameTime,
+      gcl: { level: 5 } as GlobalControlLevel,
+      rooms: {
+        E29N55: colony.room,
+        E29N56: makeTargetRoom('E29N56', 'controller-e29n56' as Id<StructureController>),
+        E29N58: makeTargetRoom('E29N58', 'controller-e29n58' as Id<StructureController>)
+      }
+    };
+    setSafeHomeThreat('E29N55', gameTime);
+
+    expect(refreshAutonomousExpansionPipeline(colony, report, gameTime)).toEqual({
+      status: 'skipped',
+      colony: 'E29N55',
+      reason: 'unmetPreconditions',
+      reasonDetail: 'activeClaimTarget'
+    });
+    expect(Memory.territory?.targets).toEqual([recoveryTarget]);
+    expect(Memory.territory?.intents).toEqual([recoveryIntent]);
+    expect(Memory.territory?.expansionPipelines?.E29N55).toBeUndefined();
   });
 
   it('reports active post-claim bootstrap blockers separately from generic unmet preconditions', () => {


### PR DESCRIPTION
## Summary

- Clears/satisfies completed `claim` intents for already-owned/post-claim-ready rooms so E29N55 is not permanently blocked by completed E29N56/E29N57 claims.
- Adds expansion skip `reasonDetail` plumbing/cache state so `unmetPreconditions` can identify active pipeline/bootstrap/claim-target/claim-intent blockers.
- Preserves recovery claims for visible unowned rooms even when a stale ready/completed post-claim bootstrap record exists.
- Adds regression tests for stale completed claims, visible-unowned recovery claims, genuine active claim blockers, and active post-claim bootstrap blocker evidence.

## Verification

- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand`
- [x] `cd prod && npm run build`
- [x] `git diff --check`

Controller-side verification after the review-fix commit: full suite passed (`103` suites, `2182` tests).

## Review-fix evidence

- [x] `chatgpt-codex-connector` thread `PRRT_kwDOSMSsO86GiWZ6`: classified `FIX`, critical; fixed by commit `f67225e673a704bbed29eafa08b50785e3b6b5d3`.
- [x] Visible unowned rooms with ready/completed bootstrap records now remain unsatisfied and keep recovery claim targets/intents blocking expansion.

## Universal task Done gate

- [x] Task type: code bugfix for live official-MMO territory expansion blocker.
- [x] Expected observable outcome / named deliverable: completed E29N56/E29N57 claim intents no longer keep E29N55 expansion stuck on generic `unmetPreconditions`; expansion skip detail names the real blocker.
- [x] Non-goals / accepted substitutes: this PR preserves safety and no-proactive-attack gates; it does not force-claim a specific foreign-reserved candidate.
- [x] Verification evidence required before Done: typecheck, full Jest, build, PR checks/review gate, official MMO deploy evidence, and runtime observation of E29N55 expansion blocker state.
- [x] Project Evidence / Next action / Blocked by: controller recorded Project item status `In review`, PR URL, commit `f67225e673a704bbed29eafa08b50785e3b6b5d3`, and verification PASS evidence.
- [x] Post-merge/deploy/runtime proof: PR-local proof is typecheck/full Jest/build; issue 1624 owns the official-deploy/runtime live-effect gate.
- [x] Named deliverable proof: committed code/test/build artifact at `f67225e673a704bbed29eafa08b50785e3b6b5d3` implements the stale-claim unblocker, lost-room recovery guard, and reason-detail surface.

## Links

Related to issue 1624.
Related to issue 1527.
Related to issue 1540.
