### PR TITLE
fix: handle RL simulator room-busy setup blockers

### DIFF
--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -1517,6 +1517,8 @@ def simulator_place_spawn_room_busy_rows(simulator_runs: Sequence[JsonObject]) -
         for variant_index, variant in enumerate(variants):
             if not isinstance(variant, dict):
                 continue
+            if variant.get("ok") is True:
+                continue
             if not variant_has_place_spawn_room_busy(variant):
                 continue
             evidence: JsonObject = {

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -48,6 +48,7 @@ POLICY_UPDATE_ALGORITHM = RANK_WEIGHTED_FINITE_DIFFERENCE_ALGORITHM
 DEFAULT_POLICY_UPDATE_ALGORITHM = TRUE_GRADIENT_POLICY_UPDATE_ALGORITHM
 METADATA_ONLY_POLICY_UPDATE_SKIP_REASON = "candidate_parameters_metadata_only"
 RUNTIME_PARAMETER_INJECTION_INCOMPLETE_SKIP_REASON = "runtime_parameter_injection_missing_or_incomplete"
+SIMULATOR_SETUP_PLACE_SPAWN_ROOM_BUSY_SKIP_REASON = "simulator_setup_place_spawn_room_busy"
 POLICY_UPDATE_ARTIFACT_DIR = "policy-candidates"
 CANDIDATE_SCORECARD_ARTIFACT_DIR = "candidate-scorecards"
 MULTI_CANDIDATE_SCORECARD_SET_TYPE = "screeps-rl-multi-candidate-scorecard-set"
@@ -1476,6 +1477,118 @@ def build_scale_validation_summary(
     }
 
 
+def simulator_setup_policy_update_blocker(
+    simulator_runs: Sequence[JsonObject],
+    scale_validation: JsonObject | None,
+) -> JsonObject | None:
+    """Return setup-failure evidence that must block policy updates for degraded simulator runs."""
+    if not isinstance(scale_validation, dict) or scale_validation.get("ok") is not False:
+        return None
+    room_busy_rows = simulator_place_spawn_room_busy_rows(simulator_runs)
+    if not room_busy_rows:
+        return None
+    return {
+        "classification": SIMULATOR_SETUP_PLACE_SPAWN_ROOM_BUSY_SKIP_REASON,
+        "reason": (
+            "simulator scale validation failed because at least one environment hit persistent "
+            "place-spawn room-busy setup; setup failures are not policy reward evidence"
+        ),
+        "failedEnvironmentCount": scale_validation.get("failedEnvironments"),
+        "successfulEnvironmentCount": scale_validation.get("successfulEnvironments"),
+        "totalEnvironmentCount": scale_validation.get("totalEnvironments"),
+        "minimumSuccessfulEnvironments": scale_validation.get("minimumSuccessfulEnvironments"),
+        "evidence": room_busy_rows[:10],
+        "evidenceCount": len(room_busy_rows),
+        "nextAction": (
+            "repair simulator spawn allocation/setup before emitting a policy update from this training slice"
+        ),
+    }
+
+
+def simulator_place_spawn_room_busy_rows(simulator_runs: Sequence[JsonObject]) -> list[JsonObject]:
+    rows: list[JsonObject] = []
+    for run_index, run in enumerate(simulator_runs):
+        if not isinstance(run, dict):
+            continue
+        run_id = text_or_none(run.get("runId")) or f"run[{run_index}]"
+        variants = run.get("variants")
+        if not isinstance(variants, list):
+            continue
+        for variant_index, variant in enumerate(variants):
+            if not isinstance(variant, dict):
+                continue
+            if not variant_has_place_spawn_room_busy(variant):
+                continue
+            evidence: JsonObject = {
+                "runId": run_id,
+                "runIndex": run_index,
+                "variantIndex": variant_index,
+                "variantId": text_or_none(variant.get("variant_id", variant.get("variantId"))),
+                "ok": variant.get("ok") is True,
+                "ticksRun": number_or_none(variant.get("ticks_run", variant.get("ticksRun"))),
+                "error": text_or_none(variant.get("error")),
+            }
+            place_spawn = variant.get("placeSpawn")
+            if isinstance(place_spawn, dict):
+                evidence["placeSpawn"] = {
+                    "classification": text_or_none(place_spawn.get("classification")),
+                    "phase": text_or_none(place_spawn.get("phase")),
+                    "maxAttempts": int_or_none(place_spawn.get("maxAttempts")),
+                }
+            rows.append(evidence)
+    return rows
+
+
+def variant_has_place_spawn_room_busy(variant: JsonObject) -> bool:
+    place_spawn = variant.get("placeSpawn")
+    if isinstance(place_spawn, dict):
+        classification = text_or_none(place_spawn.get("classification"))
+        if classification in {"place_spawn_room_busy", "room_busy"}:
+            return True
+    texts: list[str] = []
+    for key in ("error", "diagnostic", "reason"):
+        value = text_or_none(variant.get(key))
+        if value is not None:
+            texts.append(value)
+    errors = variant.get("errors")
+    if isinstance(errors, list):
+        texts.extend(str(error) for error in errors if error is not None)
+    combined = "\n".join(texts).lower()
+    return "place-spawn room busy" in combined or "place_spawn_room_busy" in combined
+
+
+def build_simulator_setup_blocked_policy_update(
+    *,
+    policy_gradient: JsonObject,
+    blocker: JsonObject,
+) -> JsonObject:
+    algorithm = policy_update_algorithm(policy_gradient)
+    target_family = text_or_none(policy_gradient.get("target_family", policy_gradient.get("targetFamily"))) or "unknown"
+    runtime_injected = not policy_gradient_candidate_parameters_metadata_only(policy_gradient)
+    parameter_evidence: JsonObject = {
+        "candidateParameterScope": "runtime_injected" if runtime_injected else "metadata_only",
+        "runtimeParameterInjection": runtime_injected,
+        "runtimeParameterConsumption": False,
+        "runtimeParameterConsumptionStatus": "blocked_by_simulator_setup",
+        "policyUpdateEligible": False,
+        "reason": blocker["reason"],
+        "setupFailureClassification": blocker["classification"],
+        "simulatorSetupBlocker": copy.deepcopy(blocker),
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+        "safety": safety_metadata(),
+    }
+    return {
+        **build_policy_update_base(algorithm=algorithm, target_family=target_family),
+        "skippedReason": SIMULATOR_SETUP_PLACE_SPAWN_ROOM_BUSY_SKIP_REASON,
+        "candidateCount": policy_gradient_candidate_vector_count(policy_gradient),
+        "parameterEvidence": parameter_evidence,
+        "simulatorSetupBlocker": copy.deepcopy(blocker),
+        "promotionGate": policy_update_promotion_gate(parameter_evidence, policy_update_generated=False),
+    }
+
+
 def scale_validation_environment_id(variant: JsonObject) -> str:
     """Return a stable per-run environment id for scale-proof row counting."""
     for key in ("environmentId", "envId", "environment", "slot"):
@@ -1928,12 +2041,19 @@ def build_training_report(
         report["runtimeParameterInjection"] = runtime_parameter_injection
     if policy_gradient is not None:
         report["policyGradient"] = policy_gradient
-        policy_update = build_policy_update(
-            policy_gradient=policy_gradient,
-            results=results,
-            report_id=report_id,
-            generated_at=generated_at,
-        )
+        setup_blocker = simulator_setup_policy_update_blocker(simulator_runs, scale_validation)
+        if setup_blocker is not None:
+            policy_update = build_simulator_setup_blocked_policy_update(
+                policy_gradient=policy_gradient,
+                blocker=setup_blocker,
+            )
+        else:
+            policy_update = build_policy_update(
+                policy_gradient=policy_gradient,
+                results=results,
+                report_id=report_id,
+                generated_at=generated_at,
+            )
         report["policyUpdateIterations"] = int(policy_update.get("iterations", 0))
         policy_update_algorithm_name = text_or_none(policy_update.get("algorithm"))
         report["policyUpdateAlgorithm"] = policy_update_algorithm_name

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -7314,6 +7314,86 @@ export const STRATEGY_REGISTRY = [
         )
         self.assertFalse(update["promotionGate"]["policyUpdateGenerated"])
 
+    def test_successful_room_busy_diagnostic_rows_do_not_block_policy_update_artifact(self) -> None:
+        def stale_room_busy_success(result: JsonObject) -> JsonObject:
+            result = copy.deepcopy(result)
+            result.update(
+                {
+                    "error": "recovered after previous place-spawn room busy: place_spawn_room_busy",
+                    "diagnostic": "last setup retry was place_spawn_room_busy but rollout recovered",
+                    "placeSpawn": {
+                        "phase": "place-spawn",
+                        "classification": "place_spawn_room_busy",
+                        "maxAttempts": 12,
+                    },
+                }
+            )
+            return result
+
+        def unrelated_failure(variant_id: str) -> JsonObject:
+            result = variant_result(variant_id, [])
+            result.update(
+                {
+                    "ok": False,
+                    "ticks_run": 0,
+                    "error": "simulator timeout before scoring",
+                }
+            )
+            return result
+
+        class SequentialSimulator:
+            def __init__(self, runs: list[dict[str, JsonObject]]) -> None:
+                self.runs = runs
+                self.calls: list[JsonObject] = []
+
+            def __call__(self, **kwargs: Any) -> JsonObject:
+                self.calls.append(dict(kwargs))
+                if len(self.calls) > len(self.runs):
+                    raise AssertionError("sequential simulator exhausted")
+                return MockSimulator(
+                    self.runs[len(self.calls) - 1],
+                    inject_runtime_parameters=True,
+                )(**kwargs)
+
+        card = gradient_momentum_training_card()
+        card["simulation"]["repetitions"] = 20
+        card["simulation"]["workers"] = 1
+        card["simulation"]["scale_environments"] = 2
+        card["simulation"]["min_concurrent_environments"] = 2
+        successful_run = gradient_momentum_simulator_results(candidate_rooms=2)
+        stale_diagnostic_run = {
+            "variant-a": stale_room_busy_success(successful_run["variant-a"]),
+            "variant-b": unrelated_failure("variant-b"),
+        }
+        simulator = SequentialSimulator([successful_run for _index in range(19)] + [stale_diagnostic_run])
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                out_dir,
+                report_id="successful-room-busy-diagnostic-does-not-block-policy-update",
+                simulator_runner=simulator,
+            )
+            artifact_path_exists = Path(report["policyUpdateArtifactPath"]).exists()
+
+        self.assertEqual(len(simulator.calls), 20)
+        self.assertFalse(report["scaleValidation"]["ok"])
+        self.assertEqual(report["scaleValidation"]["failedEnvironments"], 1)
+        update = report["policyUpdate"]
+        self.assertNotEqual(
+            update.get("skippedReason"),
+            runner.SIMULATOR_SETUP_PLACE_SPAWN_ROOM_BUSY_SKIP_REASON,
+        )
+        self.assertNotIn("simulatorSetupBlocker", update)
+        self.assertEqual(update["iterations"], 1)
+        self.assertIn("nextCandidatePolicy", update)
+        self.assertIn("policyUpdateArtifactPath", report)
+        self.assertTrue(artifact_path_exists)
+
     def test_unsafe_simulator_flags_fail_before_report_is_persisted(self) -> None:
         start = tick(1, [room("W1N1", energy=100)])
         baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200)])])

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -7234,6 +7234,86 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(report["scaleValidation"]["targetEnvironments"], 5)
         self.assertEqual(report["scaleValidation"]["totalEnvironments"], len(variant_ids))
 
+    def test_room_busy_scale_failure_blocks_policy_update_artifact(self) -> None:
+        def room_busy_result(variant_id: str) -> JsonObject:
+            result = variant_result(variant_id, [])
+            result.update(
+                {
+                    "ok": False,
+                    "ticks_run": 0,
+                    "error": "place-spawn room busy after 12 attempt(s): place_spawn_room_busy",
+                    "placeSpawn": {
+                        "phase": "place-spawn",
+                        "classification": "place_spawn_room_busy",
+                        "maxAttempts": 12,
+                    },
+                }
+            )
+            return result
+
+        class SequentialSimulator:
+            def __init__(self, runs: list[dict[str, JsonObject]]) -> None:
+                self.runs = runs
+                self.calls: list[JsonObject] = []
+
+            def __call__(self, **kwargs: Any) -> JsonObject:
+                self.calls.append(dict(kwargs))
+                if len(self.calls) > len(self.runs):
+                    raise AssertionError("sequential simulator exhausted")
+                return MockSimulator(
+                    self.runs[len(self.calls) - 1],
+                    inject_runtime_parameters=True,
+                )(**kwargs)
+
+        card = gradient_momentum_training_card()
+        card["simulation"]["repetitions"] = 20
+        card["simulation"]["workers"] = 1
+        card["simulation"]["scale_environments"] = 2
+        card["simulation"]["min_concurrent_environments"] = 2
+        successful_run = gradient_momentum_simulator_results(candidate_rooms=2)
+        degraded_run = {
+            "variant-a": successful_run["variant-a"],
+            "variant-b": room_busy_result("variant-b"),
+        }
+        simulator = SequentialSimulator([successful_run for _index in range(19)] + [degraded_run])
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            write_json(card_path, card)
+            report = runner.run_training_experiment(
+                card_path,
+                out_dir,
+                report_id="room-busy-scale-blocks-policy-update",
+                simulator_runner=simulator,
+            )
+
+        self.assertEqual(len(simulator.calls), 20)
+        self.assertFalse(report["scaleValidation"]["ok"])
+        self.assertEqual(report["scaleValidation"]["failedEnvironments"], 1)
+        update = report["policyUpdate"]
+        self.assertEqual(
+            update["skippedReason"],
+            runner.SIMULATOR_SETUP_PLACE_SPAWN_ROOM_BUSY_SKIP_REASON,
+        )
+        self.assertEqual(update["iterations"], 0)
+        self.assertNotIn("nextCandidatePolicy", update)
+        self.assertNotIn("policyUpdateArtifactPath", report)
+        self.assertFalse(report["trueGradient"])
+        self.assertFalse(report["trustedGradientUpdate"])
+        blocker = update["simulatorSetupBlocker"]
+        self.assertEqual(blocker["classification"], runner.SIMULATOR_SETUP_PLACE_SPAWN_ROOM_BUSY_SKIP_REASON)
+        self.assertEqual(blocker["evidenceCount"], 1)
+        self.assertEqual(blocker["evidence"][0]["variantId"], "variant-b")
+        self.assertEqual(blocker["evidence"][0]["placeSpawn"]["classification"], "place_spawn_room_busy")
+        self.assertFalse(update["parameterEvidence"]["policyUpdateEligible"])
+        self.assertEqual(
+            update["parameterEvidence"]["runtimeParameterConsumptionStatus"],
+            "blocked_by_simulator_setup",
+        )
+        self.assertFalse(update["promotionGate"]["policyUpdateGenerated"])
+
     def test_unsafe_simulator_flags_fail_before_report_is_persisted(self) -> None:
         start = tick(1, [room("W1N1", energy=100)])
         baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200)])])


### PR DESCRIPTION
Fixes #1628

## Summary
- Detect simulator place-spawn room-busy setup failures in RL training reports.
- Block policy-update artifact generation when scale validation is degraded by room-busy setup failures.
- Surface explicit simulator setup blocker evidence so Loop A/Loop B can route the anomaly to capability construction instead of treating it as a candidate-policy update.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_training_runner.py`
- `PYTHONPATH=scripts python3 -m unittest scripts.test_screeps_rl_training_runner.RlTrainingRunnerTest.test_room_busy_scale_failure_blocks_policy_update_artifact`
- `PYTHONPATH=scripts python3 -m unittest scripts.test_screeps_rl_training_runner` (147 tests)

## Issue closure gate
- [x] #1628: The runner now records `simulatorSetupBlocker` evidence and uses `simulator_setup_place_spawn_room_busy` to skip policy update generation when room-busy setup failures make the training slice invalid; controller verification passed diff-check, py_compile, focused regression, and full runner unittest.

## Universal task Done gate
- [x] Task type: RL simulator/training-runner bug fix for issue #1628.
- [x] Expected observable outcome / named deliverable: `scripts/screeps_rl_training_runner.py` emits explicit room-busy setup blocker evidence and avoids false policy-update artifacts for degraded simulator setup slices.
- [x] Non-goals / accepted substitutes: No official MMO writes, no learned-policy live rollout, no Tencent paid batch launch, and no production TypeScript changes.
- [x] Verification evidence required before Done: controller ran git diff check, Python compile checks, focused room-busy regression, and full `scripts.test_screeps_rl_training_runner` unittest suite successfully.
- [x] Project Evidence / Next action / Blocked by: Project fields for #1628 and this PR record the verified commit, PR checks/review gate, and exact next merge action.
- [x] Post-merge/deploy/runtime proof: The RL training execution ledger is the runtime proof surface for this offline runner fix; a room-busy invalid slice reports `simulator_setup_place_spawn_room_busy` and omits policy-update artifacts by construction.
- [x] Named deliverable proof: Commit `fae822f9` (`rl: fix simulator room-busy spawn allocation`) changes only `scripts/screeps_rl_training_runner.py` and `scripts/test_screeps_rl_training_runner.py` with the focused regression test.