### PR TITLE
fix: reduce low-bucket telemetry churn

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -959,12 +959,6 @@ function getRuntimeCpuBudget(game) {
   const runtimeGame = game != null ? game : getRuntimeGame();
   return buildRuntimeCpuBudget(readRuntimeCpuSample(runtimeGame));
 }
-function isRuntimeCpuBucketCritical(game) {
-  var _a;
-  const runtimeGame = game != null ? game : getRuntimeGame();
-  const bucket = (_a = runtimeGame == null ? void 0 : runtimeGame.cpu) == null ? void 0 : _a.bucket;
-  return typeof bucket === "number" && Number.isFinite(bucket) && bucket <= CRITICAL_CPU_BUCKET_THRESHOLD;
-}
 function isRuntimeCpuBucketLow(game) {
   var _a;
   const runtimeGame = game != null ? game : getRuntimeGame();
@@ -21850,7 +21844,7 @@ var BEHAVIOR_COUNTER_KEYS = [
 var TOP_IDLE_WORKER_COUNT = 3;
 function observeCreepBehaviorTick(creep, tick = getGameTime24()) {
   var _a, _b;
-  if (isRuntimeCpuBucketCritical()) {
+  if (shouldSuppressBehaviorTelemetryForCpuRecovery()) {
     return;
   }
   const telemetry = ensureCreepBehaviorTelemetry(creep);
@@ -21875,7 +21869,7 @@ function observeCreepBehaviorTick(creep, tick = getGameTime24()) {
 }
 function recordCreepBehaviorIdle(creep, tick = getGameTime24()) {
   var _a;
-  if (isRuntimeCpuBucketCritical()) {
+  if (shouldSuppressBehaviorTelemetryForCpuRecovery()) {
     return;
   }
   const telemetry = ensureCreepBehaviorTelemetry(creep);
@@ -21887,7 +21881,7 @@ function recordCreepBehaviorIdle(creep, tick = getGameTime24()) {
 }
 function recordCreepBehaviorMove(creep, tick = getGameTime24()) {
   var _a;
-  if (isRuntimeCpuBucketCritical()) {
+  if (shouldSuppressBehaviorTelemetryForCpuRecovery()) {
     return;
   }
   const telemetry = ensureCreepBehaviorTelemetry(creep);
@@ -21898,7 +21892,7 @@ function recordCreepBehaviorMove(creep, tick = getGameTime24()) {
   telemetry.lastMoveTick = tick;
 }
 function recordCreepBehaviorMoveTask(creep, task) {
-  if (isRuntimeCpuBucketCritical()) {
+  if (shouldSuppressBehaviorTelemetryForCpuRecovery()) {
     return;
   }
   const telemetry = ensureCreepBehaviorTelemetry(creep);
@@ -21915,7 +21909,7 @@ function recordCreepBehaviorMoveTask(creep, task) {
 }
 function recordCreepBehaviorWork(creep, tick = getGameTime24()) {
   var _a;
-  if (isRuntimeCpuBucketCritical()) {
+  if (shouldSuppressBehaviorTelemetryForCpuRecovery()) {
     return;
   }
   const telemetry = ensureCreepBehaviorTelemetry(creep);
@@ -21926,14 +21920,14 @@ function recordCreepBehaviorWork(creep, tick = getGameTime24()) {
   telemetry.lastWorkTick = tick;
 }
 function recordCreepBehaviorRepairTarget(creep, targetId) {
-  if (isRuntimeCpuBucketCritical()) {
+  if (shouldSuppressBehaviorTelemetryForCpuRecovery()) {
     return;
   }
   ensureCreepBehaviorTelemetry(creep).repairTargetId = targetId;
 }
 function recordCreepBehaviorContainerTransfer(creep) {
   var _a;
-  if (isRuntimeCpuBucketCritical()) {
+  if (shouldSuppressBehaviorTelemetryForCpuRecovery()) {
     return;
   }
   const telemetry = ensureCreepBehaviorTelemetry(creep);
@@ -21941,7 +21935,7 @@ function recordCreepBehaviorContainerTransfer(creep) {
 }
 function recordCreepBehaviorSourceContainerWithdrawal(creep, tick = getGameTime24()) {
   var _a;
-  if (isRuntimeCpuBucketCritical()) {
+  if (shouldSuppressBehaviorTelemetryForCpuRecovery()) {
     return;
   }
   const telemetry = ensureCreepBehaviorTelemetry(creep);
@@ -21953,7 +21947,7 @@ function recordCreepBehaviorSourceContainerWithdrawal(creep, tick = getGameTime2
 }
 function recordCreepBehaviorEnergyAcquisition(creep, method) {
   var _a;
-  if (isRuntimeCpuBucketCritical()) {
+  if (shouldSuppressBehaviorTelemetryForCpuRecovery()) {
     return;
   }
   const telemetry = ensureCreepBehaviorTelemetry(creep);
@@ -21981,6 +21975,9 @@ function ensureCreepBehaviorTelemetry(creep) {
     creep.memory.behaviorTelemetry = {};
   }
   return creep.memory.behaviorTelemetry;
+}
+function shouldSuppressBehaviorTelemetryForCpuRecovery() {
+  return isRuntimeCpuBucketLow();
 }
 function recordBuildTargetStuckObservation(telemetry) {
   var _a;

--- a/prod/src/telemetry/behaviorTelemetry.ts
+++ b/prod/src/telemetry/behaviorTelemetry.ts
@@ -1,4 +1,4 @@
-import { isRuntimeCpuBucketCritical } from '../runtime/cpuBudget';
+import { isRuntimeCpuBucketLow } from '../runtime/cpuBudget';
 
 export interface RuntimeCreepBehaviorSummary {
   creepName?: string;
@@ -73,7 +73,7 @@ const BEHAVIOR_COUNTER_KEYS: CreepBehaviorCounterKey[] = [
 const TOP_IDLE_WORKER_COUNT = 3;
 
 export function observeCreepBehaviorTick(creep: Creep, tick: number = getGameTime()): void {
-  if (isRuntimeCpuBucketCritical()) {
+  if (shouldSuppressBehaviorTelemetryForCpuRecovery()) {
     return;
   }
 
@@ -101,7 +101,7 @@ export function observeCreepBehaviorTick(creep: Creep, tick: number = getGameTim
 }
 
 export function recordCreepBehaviorIdle(creep: Creep, tick: number = getGameTime()): void {
-  if (isRuntimeCpuBucketCritical()) {
+  if (shouldSuppressBehaviorTelemetryForCpuRecovery()) {
     return;
   }
 
@@ -115,7 +115,7 @@ export function recordCreepBehaviorIdle(creep: Creep, tick: number = getGameTime
 }
 
 export function recordCreepBehaviorMove(creep: Creep, tick: number = getGameTime()): void {
-  if (isRuntimeCpuBucketCritical()) {
+  if (shouldSuppressBehaviorTelemetryForCpuRecovery()) {
     return;
   }
 
@@ -129,7 +129,7 @@ export function recordCreepBehaviorMove(creep: Creep, tick: number = getGameTime
 }
 
 export function recordCreepBehaviorMoveTask(creep: Creep, task: CreepTaskMemory): void {
-  if (isRuntimeCpuBucketCritical()) {
+  if (shouldSuppressBehaviorTelemetryForCpuRecovery()) {
     return;
   }
 
@@ -148,7 +148,7 @@ export function recordCreepBehaviorMoveTask(creep: Creep, task: CreepTaskMemory)
 }
 
 export function recordCreepBehaviorWork(creep: Creep, tick: number = getGameTime()): void {
-  if (isRuntimeCpuBucketCritical()) {
+  if (shouldSuppressBehaviorTelemetryForCpuRecovery()) {
     return;
   }
 
@@ -162,7 +162,7 @@ export function recordCreepBehaviorWork(creep: Creep, tick: number = getGameTime
 }
 
 export function recordCreepBehaviorRepairTarget(creep: Creep, targetId: string): void {
-  if (isRuntimeCpuBucketCritical()) {
+  if (shouldSuppressBehaviorTelemetryForCpuRecovery()) {
     return;
   }
 
@@ -170,7 +170,7 @@ export function recordCreepBehaviorRepairTarget(creep: Creep, targetId: string):
 }
 
 export function recordCreepBehaviorContainerTransfer(creep: Creep): void {
-  if (isRuntimeCpuBucketCritical()) {
+  if (shouldSuppressBehaviorTelemetryForCpuRecovery()) {
     return;
   }
 
@@ -179,7 +179,7 @@ export function recordCreepBehaviorContainerTransfer(creep: Creep): void {
 }
 
 export function recordCreepBehaviorSourceContainerWithdrawal(creep: Creep, tick: number = getGameTime()): void {
-  if (isRuntimeCpuBucketCritical()) {
+  if (shouldSuppressBehaviorTelemetryForCpuRecovery()) {
     return;
   }
 
@@ -196,7 +196,7 @@ export function recordCreepBehaviorEnergyAcquisition(
   creep: Creep,
   method: RuntimeEnergyAcquisitionMethod
 ): void {
-  if (isRuntimeCpuBucketCritical()) {
+  if (shouldSuppressBehaviorTelemetryForCpuRecovery()) {
     return;
   }
 
@@ -234,6 +234,10 @@ function ensureCreepBehaviorTelemetry(creep: Creep): CreepBehaviorTelemetryMemor
   }
 
   return creep.memory.behaviorTelemetry;
+}
+
+function shouldSuppressBehaviorTelemetryForCpuRecovery(): boolean {
+  return isRuntimeCpuBucketLow();
 }
 
 function recordBuildTargetStuckObservation(telemetry: CreepBehaviorTelemetryMemory): void {

--- a/prod/test/hauler.test.ts
+++ b/prod/test/hauler.test.ts
@@ -1,5 +1,5 @@
 import { runHauler } from '../src/creeps/hauler';
-import { CRITICAL_CPU_BUCKET_THRESHOLD } from '../src/runtime/cpuBudget';
+import { CRITICAL_CPU_BUCKET_THRESHOLD, LOW_CPU_BUCKET_THRESHOLD } from '../src/runtime/cpuBudget';
 
 const OK_CODE = 0 as ScreepsReturnCode;
 const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
@@ -89,6 +89,34 @@ describe('runHauler', () => {
     expect(creep.memory.task).toEqual({ type: 'withdraw', targetId: 'container-rich' });
     expect(creep.withdraw).toHaveBeenCalledWith(richContainer, RESOURCE_ENERGY);
     expect(creep.memory.behaviorTelemetry).toBeUndefined();
+  });
+
+  it('skips behavior telemetry writes during noncritical low-bucket recovery', () => {
+    const assignedContainer = makeStoreStructure('container1', STRUCTURE_CONTAINER, 100, 0);
+    const richContainer = makeStoreStructure('container-rich', STRUCTURE_CONTAINER, 800, 0);
+    const remoteRoom = makeRoom('W2N1', true, [], [], [
+      assignedContainer as unknown as Structure,
+      richContainer as unknown as Structure
+    ]);
+    const creep = makeHauler(remoteRoom, 0);
+    const getUsed = jest.fn().mockReturnValue(21);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: { W2N1: remoteRoom },
+      cpu: {
+        getUsed,
+        limit: 70,
+        bucket: LOW_CPU_BUCKET_THRESHOLD - 1,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) => (id === 'container1' ? assignedContainer : null))
+    };
+
+    runHauler(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'withdraw', targetId: 'container-rich' });
+    expect(creep.withdraw).toHaveBeenCalledWith(richContainer, RESOURCE_ENERGY);
+    expect(creep.memory.behaviorTelemetry).toBeUndefined();
+    expect(getUsed).not.toHaveBeenCalled();
   });
 
   it('withdraws from an overflow-risk container before richer durable storage', () => {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -18,6 +18,7 @@ import {
 } from '../src/colony/survivalMode';
 import { OCCUPIED_CONTROLLER_SIGN_TEXT } from '../src/territory/controllerSigning';
 import { TERRITORY_RESERVATION_RENEWAL_TICKS } from '../src/territory/territoryPlanner';
+import { LOW_CPU_BUCKET_THRESHOLD } from '../src/runtime/cpuBudget';
 import { installVisibleOwnedRcl6ColonyRoomDefault } from './helpers/territoryControlGate';
 
 function withRangeTo<T extends { id: string }>(object: T, rangesByTargetId: Record<string, number>): T {
@@ -2262,6 +2263,37 @@ describe('runWorker', () => {
       lastMoveTick: 11,
       lastObservedTick: 12
     });
+  });
+
+  it('skips worker behavior telemetry writes during noncritical low-bucket recovery', () => {
+    const source = { id: 'source1' } as Source;
+    const creep = {
+      name: 'Worker1',
+      memory: { role: 'worker', task: { type: 'harvest', targetId: 'source1' as Id<Source> } },
+      pos: { x: 10, y: 10, roomName: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room: { name: 'W1N1', find: jest.fn().mockReturnValue([source]) },
+      harvest: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 10,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(21),
+        limit: 70,
+        bucket: LOW_CPU_BUCKET_THRESHOLD - 1,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn().mockReturnValue(source)
+    };
+
+    runWorker(creep);
+
+    expect(creep.harvest).toHaveBeenCalledWith(source);
+    expect(creep.memory.behaviorTelemetry).toBeUndefined();
   });
 
   it('switches a full source-container harvester to controller work', () => {


### PR DESCRIPTION
## Summary
- Suppress nonessential creep behavior telemetry writes whenever the runtime CPU bucket is below the low-bucket threshold, not only at the critical threshold.
- Preserve worker/hauler gameplay actions while avoiding telemetry memory churn during P1 CPU recovery.
- Add worker and hauler regression coverage and rebuild `prod/dist/main.js`.

Refs #1490.

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`

## Universal task Done gate
- [x] Task type: Production CPU-shedding hotfix slice for Screeps runtime telemetry.
- [x] Expected observable outcome / named deliverable: Bot behavior keeps harvesting and hauling while low-bucket creep behavior telemetry writes are skipped.
- [x] Non-goals / accepted substitutes: No deploy, no issue closure, no RL compute, and no Project mutation from Codex in this PR.
- [x] Verification evidence required before Done: Controller reran `git diff --check`, `npm run typecheck`, `npm test -- --runInBand`, and `npm run build` successfully on commit a5d9c076.
- [x] Project Evidence / Next action / Blocked by: Project item will record PR number, commit a5d9c076, verification pass, and runtime acceptance watch on issue 1490; Blocked by field stays empty for the code review gate.
- [x] Post-merge/deploy/runtime proof: Runtime monitor proof target is cpu bucket at or above 1000 or monotonic recovery in `runtime-artifacts/screeps-monitor` with owned rooms alive; issue 1490 carries the runtime acceptance watch.
- [x] Named deliverable proof: Commit a5d9c076 changes `behaviorTelemetry.ts`, `hauler.test.ts`, `workerRunner.test.ts`, and regenerated `dist/main.js`.
