### PR TITLE
fix: add expansion stagnation guard

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -16628,6 +16628,30 @@ function getAutonomousExpansionPipelineStateKey(colony) {
     pipeline.updatedAt
   ].join(":");
 }
+function getAutonomousExpansionPipelineSummary(colony) {
+  const territoryMemory = getTerritoryMemoryRecord7();
+  const pipeline = territoryMemory ? getActiveExpansionPipeline(territoryMemory, colony) : null;
+  if (!pipeline) {
+    return null;
+  }
+  return toAutonomousExpansionPipelineSummary(pipeline);
+}
+function getAutonomousExpansionCapacitySummary(colony) {
+  var _a;
+  const ownedRoomCount = countVisibleOwnedRooms2(
+    colony.room.name,
+    getControllerOwnerUsername7(colony.room.controller)
+  );
+  const roomLimitCapacity = maxRoomsForRcl((_a = colony.room.controller) == null ? void 0 : _a.level);
+  const gclRoomCapacity = getGclLevel3();
+  const status = gclRoomCapacity !== null && ownedRoomCount >= gclRoomCapacity ? "gclInsufficient" : ownedRoomCount >= roomLimitCapacity ? "roomLimitReached" : "available";
+  return {
+    ownedRoomCount,
+    roomLimitCapacity,
+    status,
+    ...gclRoomCapacity !== null ? { gclRoomCapacity } : {}
+  };
+}
 function recordExpansionPipelineClaimState({
   colony,
   targetRoom,
@@ -17124,6 +17148,22 @@ function normalizeExpansionPipeline(rawPipeline, colony) {
     ...isFiniteNumber9(rawPipeline.completedAt) ? { completedAt: rawPipeline.completedAt } : {},
     ...isExpansionAbortReason(rawPipeline.abortReason) ? { abortReason: rawPipeline.abortReason } : {},
     ...isFiniteNumber9(rawPipeline.abortedAt) ? { abortedAt: rawPipeline.abortedAt } : {}
+  };
+}
+function toAutonomousExpansionPipelineSummary(pipeline) {
+  return {
+    colony: pipeline.colony,
+    targetRoom: pipeline.targetRoom,
+    status: pipeline.status,
+    stage: pipeline.stage,
+    score: pipeline.score,
+    threshold: pipeline.threshold,
+    startedAt: pipeline.startedAt,
+    updatedAt: pipeline.updatedAt,
+    ...pipeline.claimState ? { claimState: pipeline.claimState } : {},
+    ...pipeline.controllerId ? { controllerId: pipeline.controllerId } : {},
+    ...pipeline.reservationConfirmedAt !== void 0 ? { reservationConfirmedAt: pipeline.reservationConfirmedAt } : {},
+    ...pipeline.claimedAt !== void 0 ? { claimedAt: pipeline.claimedAt } : {}
   };
 }
 function getPipelineConfig(pipeline) {
@@ -38179,6 +38219,7 @@ var WORKER_BEHAVIOR_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 var REFILL_DELIVERY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 var SPAWN_CRITICAL_REFILL_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 var OBSERVED_RAMPART_REPAIR_HITS_CEILING = 15e4;
+var TERRITORY_EXPANSION_PROGRESS_CPU_BUCKET_FLOOR = 500;
 var WORKER_TASK_TYPES = ["harvest", "transfer", "build", "repair", "upgrade"];
 var PRODUCTIVE_WORKER_TASK_TYPES = ["build", "repair", "upgrade"];
 var DEFAULT_EXTENSION_ENERGY_CAPACITY = 50;
@@ -38354,6 +38395,13 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     resources.productiveEnergy.assignedWorkerCount
   );
   const constructionDeadlockTicks = getRoomConstructionDeadlockTicks(colony.room);
+  const survival = summarizeSurvival(colony, roleCounts);
+  const territoryExpansionProgress = buildTerritoryExpansionProgressSummary(
+    colony,
+    survival,
+    territoryExpansion,
+    tick
+  );
   return {
     roomName: colony.room.name,
     energyAvailable: colony.energyAvailable,
@@ -38382,8 +38430,9 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
       strategyRegistry,
       onStrategyRegistryRuntimeUse
     ) : emptyConstructionPrioritySummary(),
-    survival: summarizeSurvival(colony, roleCounts),
+    survival,
     territoryRecommendation,
+    territoryExpansionProgress,
     ...territoryExpansion && territoryExpansion.candidates.length > 0 ? { territoryExpansion } : {},
     ...includeOptionalSummary ? buildTerritoryIntentSummary(colony.room.name, roleCounts) : {},
     ...includeOptionalSummary ? buildTerritoryExecutionHintSummary(colony.room.name) : {},
@@ -38444,6 +38493,400 @@ function buildTerritoryIntentSummary(colonyName, roleCounts) {
 function buildTerritoryExecutionHintSummary(colonyName) {
   const territoryExecutionHints = getActiveTerritoryFollowUpExecutionHints(colonyName);
   return territoryExecutionHints.length > 0 ? { territoryExecutionHints } : {};
+}
+function buildTerritoryExpansionProgressSummary(colony, survival, territoryExpansion, tick) {
+  const colonyName = colony.room.name;
+  const capacity = getAutonomousExpansionCapacitySummary(colony);
+  const activePipeline = getAutonomousExpansionPipelineSummary(colonyName);
+  const cachedSelection = getCachedExpansionSelectionSummary(colony);
+  const controlCounts = getTerritoryExpansionControlCounts(colonyName);
+  const topCandidate = getTopExpansionProgressCandidate(colonyName, territoryExpansion);
+  const activePostClaimBootstrap = getActivePostClaimBootstrapProgressSummary(colonyName, tick);
+  const blocker = selectTerritoryExpansionBlocker({
+    activePipeline,
+    capacity,
+    cachedSelection,
+    topCandidate,
+    activePostClaimBootstrap,
+    survival,
+    territoryExpansion,
+    colony
+  });
+  const lastProgressAt = maxFiniteNumber([
+    activePipeline == null ? void 0 : activePipeline.updatedAt,
+    cachedSelection == null ? void 0 : cachedSelection.refreshedAt,
+    topCandidate == null ? void 0 : topCandidate.updatedAt,
+    activePostClaimBootstrap == null ? void 0 : activePostClaimBootstrap.updatedAt,
+    controlCounts.latestIntentUpdatedAt
+  ]);
+  return {
+    colony: colonyName,
+    source: "runtime-summary",
+    updatedAt: tick,
+    territoryCapable: survival.mode === "TERRITORY_READY",
+    blocker: blocker.blocker,
+    blockerSource: blocker.source,
+    ownedRoomCount: capacity.ownedRoomCount,
+    roomCapacityStatus: capacity.status,
+    roomLimitCapacity: capacity.roomLimitCapacity,
+    ...capacity.gclRoomCapacity !== void 0 ? { gclRoomCapacity: capacity.gclRoomCapacity } : {},
+    activePipelineStateKey: getAutonomousExpansionPipelineStateKey(colonyName),
+    ...activePipeline ? { activePipeline } : {},
+    ...cachedSelection ? { cachedSelection } : {},
+    controlCounts: controlCounts.counts,
+    ...topCandidate ? { topCandidate } : {},
+    ...activePostClaimBootstrap ? { activePostClaimBootstrap } : {},
+    ...lastProgressAt !== void 0 ? { lastProgressAt } : {},
+    ...blocker.targetRoom ? { targetRoom: blocker.targetRoom } : {},
+    ...blocker.reason ? { reason: blocker.reason } : {},
+    ...blocker.reasonDetail ? { reasonDetail: blocker.reasonDetail } : {}
+  };
+}
+function selectTerritoryExpansionBlocker({
+  activePipeline,
+  capacity,
+  cachedSelection,
+  topCandidate,
+  activePostClaimBootstrap,
+  survival,
+  territoryExpansion,
+  colony
+}) {
+  var _a;
+  if (activePipeline) {
+    return {
+      blocker: "activeExpansionPipeline",
+      source: "activePipeline",
+      targetRoom: activePipeline.targetRoom
+    };
+  }
+  if (capacity.status !== "available") {
+    return { blocker: capacity.status, source: "capacity" };
+  }
+  if (activePostClaimBootstrap) {
+    return {
+      blocker: "activePostClaimBootstrap",
+      source: "postClaimBootstrap",
+      targetRoom: activePostClaimBootstrap.roomName
+    };
+  }
+  if ((cachedSelection == null ? void 0 : cachedSelection.status) === "planned") {
+    return {
+      blocker: "none",
+      source: "selection",
+      targetRoom: cachedSelection.targetRoom
+    };
+  }
+  if (cachedSelection == null ? void 0 : cachedSelection.reasonDetail) {
+    return {
+      blocker: getTerritoryExpansionBlockerForReasonDetail(cachedSelection.reasonDetail),
+      source: "selection",
+      reason: cachedSelection.reason,
+      reasonDetail: cachedSelection.reasonDetail,
+      targetRoom: cachedSelection.targetRoom
+    };
+  }
+  if (topCandidate == null ? void 0 : topCandidate.blocker) {
+    return {
+      blocker: topCandidate.blocker,
+      source: "candidate",
+      targetRoom: topCandidate.roomName
+    };
+  }
+  if (cachedSelection == null ? void 0 : cachedSelection.reason) {
+    return {
+      blocker: getTerritoryExpansionBlockerForSelectionReason(cachedSelection.reason),
+      source: "selection",
+      reason: cachedSelection.reason,
+      targetRoom: cachedSelection.targetRoom
+    };
+  }
+  const survivalBlocker = getTerritoryExpansionBlockerForSurvival(survival);
+  if (survivalBlocker) {
+    return { blocker: survivalBlocker, source: "survival" };
+  }
+  const cpuBucket = getCpuBucket2();
+  if (cpuBucket !== void 0 && cpuBucket < TERRITORY_EXPANSION_PROGRESS_CPU_BUCKET_FLOOR) {
+    return { blocker: "cpuBucketLow", source: "cpu" };
+  }
+  if (territoryExpansion) {
+    return {
+      blocker: territoryExpansion.candidates.length === 0 ? "noCandidate" : "unavailable",
+      source: "candidate",
+      ...((_a = territoryExpansion.next) == null ? void 0 : _a.roomName) ? { targetRoom: territoryExpansion.next.roomName } : {}
+    };
+  }
+  if (topCandidate) {
+    return { blocker: "unavailable", source: "candidate", targetRoom: topCandidate.roomName };
+  }
+  const hasNoPersistentTerritoryEvidence = !cachedSelection && !hasAnyTerritoryExpansionProgressMemory(colony.room.name);
+  return {
+    blocker: hasNoPersistentTerritoryEvidence ? "monitorEvidenceMissing" : "unavailable",
+    source: "monitor"
+  };
+}
+function getCachedExpansionSelectionSummary(colony) {
+  const memory = getRoomMemoryRecord(colony);
+  const rawSelection = memory == null ? void 0 : memory.cachedExpansionSelection;
+  if (!isRecord30(rawSelection) || !isRoomExpansionSelectionStatus(rawSelection.status)) {
+    return null;
+  }
+  const refreshedAt = isFiniteNumber11(memory == null ? void 0 : memory.lastExpansionScoreTime) ? memory.lastExpansionScoreTime : void 0;
+  return {
+    status: rawSelection.status,
+    ...refreshedAt !== void 0 ? { refreshedAt } : {},
+    ...isNonEmptyString30(rawSelection.stateKey) ? { stateKey: rawSelection.stateKey } : {},
+    ...isNonEmptyString30(rawSelection.targetRoom) ? { targetRoom: rawSelection.targetRoom } : {},
+    ...isRoomExpansionSelectionReason(rawSelection.reason) ? { reason: rawSelection.reason } : {},
+    ...isRoomExpansionSelectionReasonDetail(rawSelection.reasonDetail) ? { reasonDetail: rawSelection.reasonDetail } : {},
+    ...isFiniteNumber11(rawSelection.score) ? { score: rawSelection.score } : {}
+  };
+}
+function getTerritoryExpansionControlCounts(colonyName) {
+  const counts = {
+    active: emptyTerritoryActionCounts(),
+    planned: emptyTerritoryActionCounts(),
+    targets: { claim: 0, reserve: 0 }
+  };
+  let latestIntentUpdatedAt;
+  const territory = getTerritoryMemoryRecord9();
+  if (!territory) {
+    return { counts };
+  }
+  for (const target of Array.isArray(territory.targets) ? territory.targets : []) {
+    if (!isRecord30(target) || target.colony !== colonyName || target.enabled === false) {
+      continue;
+    }
+    if (target.action === "claim" || target.action === "reserve") {
+      counts.targets[target.action] += 1;
+    }
+  }
+  for (const intent of normalizeTerritoryIntents(territory.intents)) {
+    if (intent.colony !== colonyName) {
+      continue;
+    }
+    if (intent.status === "active") {
+      counts.active[intent.action] += 1;
+    } else if (intent.status === "planned") {
+      counts.planned[intent.action] += 1;
+    }
+    if ((intent.status === "active" || intent.status === "planned") && (latestIntentUpdatedAt === void 0 || intent.updatedAt > latestIntentUpdatedAt)) {
+      latestIntentUpdatedAt = intent.updatedAt;
+    }
+  }
+  return {
+    counts,
+    ...latestIntentUpdatedAt !== void 0 ? { latestIntentUpdatedAt } : {}
+  };
+}
+function emptyTerritoryActionCounts() {
+  return { claim: 0, reserve: 0, scout: 0 };
+}
+function getTopExpansionProgressCandidate(colonyName, territoryExpansion) {
+  var _a;
+  const scoredCandidate = (_a = territoryExpansion == null ? void 0 : territoryExpansion.next) != null ? _a : territoryExpansion == null ? void 0 : territoryExpansion.candidates[0];
+  if (scoredCandidate) {
+    return toExpansionProgressCandidate({
+      roomName: scoredCandidate.roomName,
+      evidenceStatus: scoredCandidate.evidenceStatus,
+      score: scoredCandidate.score,
+      blockReason: scoredCandidate.blockReason,
+      routeDistance: scoredCandidate.routeDistance,
+      nearestOwnedRoom: scoredCandidate.nearestOwnedRoom,
+      nearestOwnedRoomDistance: scoredCandidate.nearestOwnedRoomDistance,
+      sourceCount: scoredCandidate.sourceCount,
+      hostileCreepCount: scoredCandidate.hostileCreepCount,
+      hostileStructureCount: scoredCandidate.hostileStructureCount,
+      requiresControllerPressure: scoredCandidate.requiresControllerPressure
+    });
+  }
+  const persistedCandidate = getPersistedTopExpansionCandidate(colonyName);
+  return persistedCandidate ? toExpansionProgressCandidate(persistedCandidate) : null;
+}
+function toExpansionProgressCandidate(candidate) {
+  const blocker = getTerritoryExpansionBlockerForCandidate(candidate);
+  return {
+    roomName: candidate.roomName,
+    ...isExpansionCandidateEvidenceStatus2(candidate.evidenceStatus) ? { evidenceStatus: candidate.evidenceStatus } : {},
+    ...isFiniteNumber11(candidate.score) ? { score: candidate.score } : {},
+    ...isExpansionCandidateRecommendedAction2(candidate.recommendedAction) ? { recommendedAction: candidate.recommendedAction } : {},
+    ...isExpansionCandidateBlockReason2(candidate.blockReason) ? { blockReason: candidate.blockReason } : {},
+    ...blocker ? { blocker } : {},
+    ...isFiniteNumber11(candidate.updatedAt) ? { updatedAt: candidate.updatedAt } : {},
+    ...isFiniteNumber11(candidate.routeDistance) ? { routeDistance: candidate.routeDistance } : {},
+    ...isNonEmptyString30(candidate.nearestOwnedRoom) ? { nearestOwnedRoom: candidate.nearestOwnedRoom } : {},
+    ...isFiniteNumber11(candidate.nearestOwnedRoomDistance) ? { nearestOwnedRoomDistance: candidate.nearestOwnedRoomDistance } : {},
+    ...isFiniteNumber11(candidate.sourceCount) ? { sourceCount: candidate.sourceCount } : {},
+    ...isFiniteNumber11(candidate.hostileCreepCount) ? { hostileCreepCount: candidate.hostileCreepCount } : {},
+    ...isFiniteNumber11(candidate.hostileStructureCount) ? { hostileStructureCount: candidate.hostileStructureCount } : {},
+    ...candidate.requiresControllerPressure === true ? { requiresControllerPressure: true } : {}
+  };
+}
+function getPersistedTopExpansionCandidate(colonyName) {
+  var _a, _b;
+  const candidates = (_a = getTerritoryMemoryRecord9()) == null ? void 0 : _a.expansionCandidates;
+  if (!Array.isArray(candidates)) {
+    return null;
+  }
+  const colonyCandidates = candidates.filter(
+    (candidate) => isRecord30(candidate) && candidate.colony === colonyName && isNonEmptyString30(candidate.roomName)
+  ).sort(comparePersistedExpansionCandidates);
+  return (_b = colonyCandidates[0]) != null ? _b : null;
+}
+function comparePersistedExpansionCandidates(left, right) {
+  var _a, _b;
+  const leftRank = isFiniteNumber11(left.rank) ? left.rank : Number.MAX_SAFE_INTEGER;
+  const rightRank = isFiniteNumber11(right.rank) ? right.rank : Number.MAX_SAFE_INTEGER;
+  if (leftRank !== rightRank) {
+    return leftRank - rightRank;
+  }
+  return ((_a = right.score) != null ? _a : 0) - ((_b = left.score) != null ? _b : 0);
+}
+function getActivePostClaimBootstrapProgressSummary(colonyName, tick) {
+  const blocker = getActivePostClaimBootstrapBlockers(colonyName, tick)[0];
+  return blocker ? toRuntimeTerritoryExpansionPostClaimBootstrapProgress(blocker) : null;
+}
+function toRuntimeTerritoryExpansionPostClaimBootstrapProgress(blocker) {
+  return {
+    colony: blocker.colony,
+    roomName: blocker.roomName,
+    status: blocker.status,
+    updatedAt: blocker.updatedAt,
+    age: blocker.age,
+    workerTarget: blocker.workerTarget,
+    ...blocker.workerCount !== void 0 ? { workerCount: blocker.workerCount } : {},
+    spawnCount: blocker.spawnCount
+  };
+}
+function getTerritoryExpansionBlockerForReasonDetail(reasonDetail) {
+  switch (reasonDetail) {
+    case "activeExpansionPipeline":
+      return "activeExpansionPipeline";
+    case "activePostClaimBootstrap":
+      return "activePostClaimBootstrap";
+    case "activeClaimTarget":
+      return "activeClaimTarget";
+    case "activeClaimIntent":
+      return "activeClaimIntent";
+  }
+}
+function getTerritoryExpansionBlockerForSelectionReason(reason) {
+  switch (reason) {
+    case "gclInsufficient":
+      return "gclInsufficient";
+    case "roomLimitReached":
+      return "roomLimitReached";
+    case "insufficientEvidence":
+      return "insufficientEvidence";
+    case "noCandidate":
+      return "noCandidate";
+    case "unavailable":
+      return "unavailable";
+    case "unmetPreconditions":
+    default:
+      return "unavailable";
+  }
+}
+function getTerritoryExpansionBlockerForCandidate(candidate) {
+  var _a, _b;
+  if (isExpansionCandidateBlockReason2(candidate.blockReason)) {
+    return normalizeTerritoryExpansionCandidateBlocker(candidate.blockReason);
+  }
+  if (candidate.requiresControllerPressure === true) {
+    return "controllerReserved";
+  }
+  if (((_a = candidate.hostileCreepCount) != null ? _a : 0) > 0 || ((_b = candidate.hostileStructureCount) != null ? _b : 0) > 0) {
+    return "targetHostile";
+  }
+  if (candidate.evidenceStatus === "insufficient-evidence") {
+    return "insufficientEvidence";
+  }
+  if (candidate.evidenceStatus === "unavailable") {
+    return "unavailable";
+  }
+  return void 0;
+}
+function normalizeTerritoryExpansionCandidateBlocker(blockReason) {
+  switch (blockReason) {
+    case "routeUnavailable":
+      return "deadZoneRoute";
+    case "targetUnavailable":
+      return "targetUnavailable";
+    default:
+      return blockReason;
+  }
+}
+function getTerritoryExpansionBlockerForSurvival(survival) {
+  var _a;
+  const reasons = (_a = survival.suppressionReasons) != null ? _a : [];
+  if (reasons.includes("defense")) {
+    return "hostilePresence";
+  }
+  if (reasons.includes("defenseFloor")) {
+    return "homeDefenseGate";
+  }
+  if (reasons.includes("territoryEnergyCapacity")) {
+    return "energyCapacityLow";
+  }
+  if (reasons.includes("controllerLevel")) {
+    return "controllerLevelLow";
+  }
+  if (reasons.includes("controllerDowngradeGuard")) {
+    return "homeDowngradeGuard";
+  }
+  if (reasons.includes("bootstrapWorkerFloor") || reasons.includes("bootstrapRecovery") || reasons.includes("spawnEnergyCritical") || reasons.includes("localWorkerRecovery")) {
+    return "bootstrapGate";
+  }
+  return null;
+}
+function hasAnyTerritoryExpansionProgressMemory(colonyName) {
+  var _a, _b;
+  const territory = getTerritoryMemoryRecord9();
+  if (!territory) {
+    return false;
+  }
+  return Object.values((_a = territory.expansionPipelines) != null ? _a : {}).some(
+    (pipeline) => isRecord30(pipeline) && pipeline.colony === colonyName
+  ) || ((_b = territory.expansionCandidates) != null ? _b : []).some(
+    (candidate) => isRecord30(candidate) && candidate.colony === colonyName
+  ) || normalizeTerritoryIntents(territory.intents).some((intent) => intent.colony === colonyName);
+}
+function getRoomMemoryRecord(colony) {
+  var _a, _b;
+  const roomWithMemory = colony.room;
+  return (_b = (_a = colony.memory) != null ? _a : roomWithMemory.memory) != null ? _b : null;
+}
+function getTerritoryMemoryRecord9() {
+  var _a;
+  const territory = (_a = globalThis.Memory) == null ? void 0 : _a.territory;
+  return isRecord30(territory) ? territory : null;
+}
+function getCpuBucket2() {
+  var _a, _b;
+  const bucket = (_b = (_a = globalThis.Game) == null ? void 0 : _a.cpu) == null ? void 0 : _b.bucket;
+  return isFiniteNumber11(bucket) ? bucket : void 0;
+}
+function maxFiniteNumber(values) {
+  let max;
+  for (const value of values) {
+    if (!isFiniteNumber11(value)) {
+      continue;
+    }
+    max = max === void 0 ? value : Math.max(max, value);
+  }
+  return max;
+}
+function isRoomExpansionSelectionStatus(value) {
+  return value === "planned" || value === "skipped";
+}
+function isRoomExpansionSelectionReason(value) {
+  return value === "noCandidate" || value === "gclInsufficient" || value === "roomLimitReached" || value === "unmetPreconditions" || value === "insufficientEvidence" || value === "unavailable";
+}
+function isRoomExpansionSelectionReasonDetail(value) {
+  return value === "activeExpansionPipeline" || value === "activePostClaimBootstrap" || value === "activeClaimTarget" || value === "activeClaimIntent";
+}
+function isExpansionCandidateEvidenceStatus2(value) {
+  return value === "sufficient" || value === "insufficient-evidence" || value === "unavailable";
 }
 function buildTerritoryScoutSummary(colony, roleCounts) {
   const colonyName = colony.room.name;
@@ -42853,7 +43296,7 @@ var TERRITORY_AUTOMATION_SOURCES = /* @__PURE__ */ new Set([
 ]);
 function refreshTerritoryExecutionTargets(action, options = {}) {
   var _a;
-  const territoryMemory = getTerritoryMemoryRecord9();
+  const territoryMemory = getTerritoryMemoryRecord10();
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return { action, targetCount: 0, intentCount: 0 };
   }
@@ -42939,7 +43382,7 @@ function refreshExecutionIntent(intents, target, gameTime) {
   });
   return true;
 }
-function getTerritoryMemoryRecord9() {
+function getTerritoryMemoryRecord10() {
   const memory = globalThis.Memory;
   if (!(memory == null ? void 0 : memory.territory) || typeof memory.territory !== "object" || Array.isArray(memory.territory)) {
     return null;
@@ -43185,7 +43628,7 @@ function isAutonomousExpansionClaimGclInsufficient() {
 function getAutonomousExpansionClaimTickContext(gameTime) {
   var _a;
   const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
-  const territoryMemory = getTerritoryMemoryRecord10();
+  const territoryMemory = getTerritoryMemoryRecord11();
   const rawIntents = territoryMemory == null ? void 0 : territoryMemory.intents;
   if (autonomousExpansionClaimTickContext && autonomousExpansionClaimTickContext.gameTime === gameTime && autonomousExpansionClaimTickContext.gameMap === gameMap) {
     if (autonomousExpansionClaimTickContext.territoryMemory !== territoryMemory || autonomousExpansionClaimTickContext.rawIntents !== rawIntents) {
@@ -43627,7 +44070,7 @@ function upsertTerritoryIntent5(intents, nextIntent) {
   }
   intents.push(nextIntent);
 }
-function pruneAutonomousExpansionClaimTargets(colony, territoryMemory = getTerritoryMemoryRecord10(), activeTarget, context) {
+function pruneAutonomousExpansionClaimTargets(colony, territoryMemory = getTerritoryMemoryRecord11(), activeTarget, context) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return;
   }
@@ -43729,7 +44172,7 @@ function getRecommendedExpansionClaimExecutionGate(colony, assignment) {
   if (!isNonEmptyString33(colony)) {
     return null;
   }
-  const territoryMemory = getTerritoryMemoryRecord10();
+  const territoryMemory = getTerritoryMemoryRecord11();
   if (!territoryMemory) {
     return null;
   }
@@ -44159,7 +44602,7 @@ function getGameTime37() {
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
-function getTerritoryMemoryRecord10() {
+function getTerritoryMemoryRecord11() {
   var _a;
   return (_a = globalThis.Memory) == null ? void 0 : _a.territory;
 }
@@ -45736,7 +46179,7 @@ function selectAdjacentRoomReservationPlan(colony, options = {}) {
   };
 }
 function clearAdjacentRoomReservationIntent(colony) {
-  const territoryMemory = getTerritoryMemoryRecord11();
+  const territoryMemory = getTerritoryMemoryRecord12();
   if (!territoryMemory) {
     return;
   }
@@ -46016,7 +46459,7 @@ function upsertAdjacentRoomReservationIntent(intents, nextIntent) {
   intents.push(nextIntent);
 }
 function hasBlockingTerritoryPlan2(colony) {
-  const territoryMemory = getTerritoryMemoryRecord11();
+  const territoryMemory = getTerritoryMemoryRecord12();
   if (!territoryMemory) {
     return false;
   }
@@ -46053,7 +46496,7 @@ function getAdjacentRoomNames9(roomName) {
 }
 function getPersistedExpansionCandidatePriorities(colony) {
   var _a;
-  const rawCandidates = (_a = getTerritoryMemoryRecord11()) == null ? void 0 : _a.expansionCandidates;
+  const rawCandidates = (_a = getTerritoryMemoryRecord12()) == null ? void 0 : _a.expansionCandidates;
   if (!Array.isArray(rawCandidates)) {
     return /* @__PURE__ */ new Map();
   }
@@ -46130,7 +46573,7 @@ function compareOptionalNumbersDescending2(left, right) {
   }
   return right - left;
 }
-function getTerritoryMemoryRecord11() {
+function getTerritoryMemoryRecord12() {
   var _a;
   return (_a = globalThis.Memory) == null ? void 0 : _a.territory;
 }
@@ -46234,7 +46677,7 @@ function refreshColonyExpansionIntent(colony, assessment, gameTime = getGameTime
   };
 }
 function clearColonyExpansionClaimIntent(colony) {
-  const territoryMemory = getTerritoryMemoryRecord12();
+  const territoryMemory = getTerritoryMemoryRecord13();
   if (!territoryMemory) {
     return;
   }
@@ -46431,7 +46874,7 @@ function getColonyExpansionControllerState(colonyName, roomName, ownerUsername) 
   return { kind: "neutral", ...controller.id ? { controllerId: controller.id } : {} };
 }
 function hasBlockingClaimIntent(colony, targetRoom) {
-  const territoryMemory = getTerritoryMemoryRecord12();
+  const territoryMemory = getTerritoryMemoryRecord13();
   if (!territoryMemory) {
     return false;
   }
@@ -46594,7 +47037,7 @@ function getGclLevel7() {
 }
 function hasActivePostClaimBootstrap2(colonyName) {
   var _a;
-  const records = (_a = getTerritoryMemoryRecord12()) == null ? void 0 : _a.postClaimBootstraps;
+  const records = (_a = getTerritoryMemoryRecord13()) == null ? void 0 : _a.postClaimBootstraps;
   if (!isRecord39(records)) {
     return false;
   }
@@ -46607,7 +47050,7 @@ function getControllerOwnerUsername13(controller) {
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
   return isNonEmptyString40(username) ? username : void 0;
 }
-function getTerritoryMemoryRecord12() {
+function getTerritoryMemoryRecord13() {
   var _a;
   return (_a = globalThis.Memory) == null ? void 0 : _a.territory;
 }
@@ -46761,7 +47204,7 @@ function selectReservationAssignment(creep) {
   if (!isNonEmptyString41(colony) || !hasReservationEnergyBudget(colony)) {
     return null;
   }
-  const territoryMemory = getTerritoryMemoryRecord13();
+  const territoryMemory = getTerritoryMemoryRecord14();
   const recommendations = getExpansionPlannerReservationRecommendations(colony);
   if (!territoryMemory || recommendations.length === 0) {
     return null;
@@ -46876,7 +47319,7 @@ function getReservationExecutionGate(colony, assignment) {
   if (!isNonEmptyString41(colony)) {
     return null;
   }
-  const territoryMemory = getTerritoryMemoryRecord13();
+  const territoryMemory = getTerritoryMemoryRecord14();
   if (!territoryMemory) {
     return null;
   }
@@ -46908,7 +47351,7 @@ function isReservationExecutionGateRunnable(gate, gameTime) {
 }
 function getMatchingReservationIntent(colony, targetRoom, controllerId, allowUnscopedIntent = false) {
   var _a;
-  const territoryMemory = getTerritoryMemoryRecord13();
+  const territoryMemory = getTerritoryMemoryRecord14();
   if (!territoryMemory) {
     return null;
   }
@@ -47217,7 +47660,7 @@ function getEstimatedTerritoryReservationTicksToEnd2(reservation, gameTime) {
 function completeReservationAssignment(creep) {
   delete creep.memory.territory;
 }
-function getTerritoryMemoryRecord13() {
+function getTerritoryMemoryRecord14() {
   var _a;
   return (_a = globalThis.Memory) == null ? void 0 : _a.territory;
 }

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -22,6 +22,13 @@ import {
   type ExpansionCandidateReport
 } from '../territory/expansionScoring';
 import {
+  getAutonomousExpansionCapacitySummary,
+  getAutonomousExpansionPipelineStateKey,
+  getAutonomousExpansionPipelineSummary,
+  type AutonomousExpansionCapacitySummary,
+  type AutonomousExpansionPipelineSummary
+} from '../territory/expansionTrigger';
+import {
   HEURISTIC_WORKER_TASK_POLICY_ID,
   WORKER_TASK_BC_ACTION_TYPES,
   isWorkerTaskBehaviorActionType,
@@ -33,7 +40,13 @@ import {
   getTerritoryIntentProgressSummaries,
   type TerritoryIntentProgressSummary
 } from '../territory/territoryPlanner';
-import { getPostClaimBootstrapSummary, type PostClaimBootstrapSummary } from '../territory/postClaimBootstrap';
+import { normalizeTerritoryIntents } from '../territory/territoryMemoryUtils';
+import {
+  getActivePostClaimBootstrapBlockers,
+  getPostClaimBootstrapSummary,
+  type PostClaimBootstrapSummary,
+  type PostClaimBootstrapBlockerSummary
+} from '../territory/postClaimBootstrap';
 import {
   TERRITORY_SCOUT_VALIDATION_TIMEOUT_TICKS,
   getTerritoryScoutSummary
@@ -95,6 +108,7 @@ const WORKER_BEHAVIOR_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 const REFILL_DELIVERY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 const SPAWN_CRITICAL_REFILL_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 const OBSERVED_RAMPART_REPAIR_HITS_CEILING = 150_000;
+const TERRITORY_EXPANSION_PROGRESS_CPU_BUCKET_FLOOR = 500;
 
 const WORKER_TASK_TYPES = ['harvest', 'transfer', 'build', 'repair', 'upgrade'] as const;
 const PRODUCTIVE_WORKER_TASK_TYPES = ['build', 'repair', 'upgrade'] as const;
@@ -299,6 +313,7 @@ interface RuntimeRoomSummary {
   constructionPriority: RuntimeConstructionPrioritySummary;
   survival: RuntimeSurvivalSummary;
   territoryRecommendation: OccupationRecommendationReport;
+  territoryExpansionProgress: RuntimeTerritoryExpansionProgressSummary;
   territoryExpansion?: ExpansionCandidateReport;
   territoryIntents?: TerritoryIntentProgressSummary[];
   omittedTerritoryIntentCount?: number;
@@ -345,6 +360,109 @@ interface RuntimeTerritoryScoutOnlyTargetSummary {
   hostileCreepCount?: number;
   hostileStructureCount?: number;
   hostileSpawnCount?: number;
+}
+
+type RuntimeTerritoryExpansionBlocker =
+  | 'none'
+  | 'activeExpansionPipeline'
+  | 'activeClaimIntent'
+  | 'activeClaimTarget'
+  | 'activePostClaimBootstrap'
+  | 'postClaimBootstrapActive'
+  | 'roomLimitReached'
+  | 'gclInsufficient'
+  | 'insufficientEvidence'
+  | 'controllerReserved'
+  | 'controllerOwned'
+  | 'controllerMissing'
+  | 'sourcesMissing'
+  | 'controllerRangeMissing'
+  | 'terrainMissing'
+  | 'targetHostile'
+  | 'targetUnavailable'
+  | 'hostilePresence'
+  | 'deadZoneRoute'
+  | 'noCandidate'
+  | 'unavailable'
+  | 'monitorEvidenceMissing'
+  | 'cpuBucketLow'
+  | 'energyCapacityLow'
+  | 'energyBufferLow'
+  | 'homeAlertActive'
+  | 'controllerLevelLow'
+  | 'homeDowngradeGuard'
+  | 'bootstrapGate'
+  | 'homeDefenseGate';
+
+interface RuntimeTerritoryExpansionProgressSummary {
+  colony: string;
+  source: 'runtime-summary';
+  updatedAt: number;
+  territoryCapable: boolean;
+  blocker: RuntimeTerritoryExpansionBlocker;
+  blockerSource: 'activePipeline' | 'capacity' | 'selection' | 'candidate' | 'postClaimBootstrap' | 'survival' | 'cpu' | 'monitor';
+  ownedRoomCount: number;
+  roomCapacityStatus: AutonomousExpansionCapacitySummary['status'];
+  roomLimitCapacity: number;
+  gclRoomCapacity?: number;
+  activePipelineStateKey: string;
+  activePipeline?: RuntimeTerritoryExpansionPipelineProgressSummary;
+  cachedSelection?: RuntimeTerritoryExpansionCachedSelectionSummary;
+  controlCounts: RuntimeTerritoryExpansionControlCounts;
+  topCandidate?: RuntimeTerritoryExpansionCandidateProgressSummary;
+  activePostClaimBootstrap?: RuntimeTerritoryExpansionPostClaimBootstrapProgressSummary;
+  lastProgressAt?: number;
+  targetRoom?: string;
+  reason?: RoomExpansionSelectionReason;
+  reasonDetail?: RoomExpansionSelectionReasonDetail;
+}
+
+type RuntimeTerritoryActionCounts = Record<TerritoryIntentAction, number>;
+
+interface RuntimeTerritoryExpansionControlCounts {
+  active: RuntimeTerritoryActionCounts;
+  planned: RuntimeTerritoryActionCounts;
+  targets: Record<TerritoryControlAction, number>;
+}
+
+type RuntimeTerritoryExpansionPipelineProgressSummary = AutonomousExpansionPipelineSummary;
+
+interface RuntimeTerritoryExpansionCachedSelectionSummary {
+  status: RoomExpansionSelectionStatus;
+  refreshedAt?: number;
+  stateKey?: string;
+  targetRoom?: string;
+  reason?: RoomExpansionSelectionReason;
+  reasonDetail?: RoomExpansionSelectionReasonDetail;
+  score?: number;
+}
+
+interface RuntimeTerritoryExpansionCandidateProgressSummary {
+  roomName: string;
+  evidenceStatus?: TerritoryExpansionCandidateEvidenceStatus;
+  score?: number;
+  recommendedAction?: TerritoryExpansionCandidateRecommendedAction;
+  blockReason?: TerritoryExpansionCandidateBlockReason;
+  blocker?: RuntimeTerritoryExpansionBlocker;
+  updatedAt?: number;
+  routeDistance?: number;
+  nearestOwnedRoom?: string;
+  nearestOwnedRoomDistance?: number;
+  sourceCount?: number;
+  hostileCreepCount?: number;
+  hostileStructureCount?: number;
+  requiresControllerPressure?: boolean;
+}
+
+interface RuntimeTerritoryExpansionPostClaimBootstrapProgressSummary {
+  colony: string;
+  roomName: string;
+  status: TerritoryPostClaimBootstrapStatus;
+  updatedAt: number;
+  age: number;
+  workerTarget: number;
+  workerCount?: number;
+  spawnCount: number;
 }
 
 interface RuntimeControllerSummary {
@@ -991,6 +1109,13 @@ function summarizeRoom(
     resources.productiveEnergy.assignedWorkerCount
   );
   const constructionDeadlockTicks = getRoomConstructionDeadlockTicks(colony.room);
+  const survival = summarizeSurvival(colony, roleCounts);
+  const territoryExpansionProgress = buildTerritoryExpansionProgressSummary(
+    colony,
+    survival,
+    territoryExpansion,
+    tick
+  );
 
   return {
     roomName: colony.room.name,
@@ -1022,8 +1147,9 @@ function summarizeRoom(
           onStrategyRegistryRuntimeUse
         )
       : emptyConstructionPrioritySummary(),
-    survival: summarizeSurvival(colony, roleCounts),
+    survival,
     territoryRecommendation,
+    territoryExpansionProgress,
     ...(territoryExpansion && territoryExpansion.candidates.length > 0 ? { territoryExpansion } : {}),
     ...(includeOptionalSummary ? buildTerritoryIntentSummary(colony.room.name, roleCounts) : {}),
     ...(includeOptionalSummary ? buildTerritoryExecutionHintSummary(colony.room.name) : {}),
@@ -1117,6 +1243,545 @@ function buildTerritoryExecutionHintSummary(
 ): { territoryExecutionHints?: TerritoryExecutionHintMemory[] } {
   const territoryExecutionHints = getActiveTerritoryFollowUpExecutionHints(colonyName);
   return territoryExecutionHints.length > 0 ? { territoryExecutionHints } : {};
+}
+
+interface RuntimeTerritoryExpansionControlCountSummary {
+  counts: RuntimeTerritoryExpansionControlCounts;
+  latestIntentUpdatedAt?: number;
+}
+
+interface RuntimeTerritoryExpansionBlockerEvidence {
+  blocker: RuntimeTerritoryExpansionBlocker;
+  source: RuntimeTerritoryExpansionProgressSummary['blockerSource'];
+  targetRoom?: string;
+  reason?: RoomExpansionSelectionReason;
+  reasonDetail?: RoomExpansionSelectionReasonDetail;
+}
+
+function buildTerritoryExpansionProgressSummary(
+  colony: ColonySnapshot,
+  survival: RuntimeSurvivalSummary,
+  territoryExpansion: ExpansionCandidateReport | undefined,
+  tick: number
+): RuntimeTerritoryExpansionProgressSummary {
+  const colonyName = colony.room.name;
+  const capacity = getAutonomousExpansionCapacitySummary(colony);
+  const activePipeline = getAutonomousExpansionPipelineSummary(colonyName);
+  const cachedSelection = getCachedExpansionSelectionSummary(colony);
+  const controlCounts = getTerritoryExpansionControlCounts(colonyName);
+  const topCandidate = getTopExpansionProgressCandidate(colonyName, territoryExpansion);
+  const activePostClaimBootstrap = getActivePostClaimBootstrapProgressSummary(colonyName, tick);
+  const blocker = selectTerritoryExpansionBlocker({
+    activePipeline,
+    capacity,
+    cachedSelection,
+    topCandidate,
+    activePostClaimBootstrap,
+    survival,
+    territoryExpansion,
+    colony
+  });
+  const lastProgressAt = maxFiniteNumber([
+    activePipeline?.updatedAt,
+    cachedSelection?.refreshedAt,
+    topCandidate?.updatedAt,
+    activePostClaimBootstrap?.updatedAt,
+    controlCounts.latestIntentUpdatedAt
+  ]);
+
+  return {
+    colony: colonyName,
+    source: 'runtime-summary',
+    updatedAt: tick,
+    territoryCapable: survival.mode === 'TERRITORY_READY',
+    blocker: blocker.blocker,
+    blockerSource: blocker.source,
+    ownedRoomCount: capacity.ownedRoomCount,
+    roomCapacityStatus: capacity.status,
+    roomLimitCapacity: capacity.roomLimitCapacity,
+    ...(capacity.gclRoomCapacity !== undefined ? { gclRoomCapacity: capacity.gclRoomCapacity } : {}),
+    activePipelineStateKey: getAutonomousExpansionPipelineStateKey(colonyName),
+    ...(activePipeline ? { activePipeline } : {}),
+    ...(cachedSelection ? { cachedSelection } : {}),
+    controlCounts: controlCounts.counts,
+    ...(topCandidate ? { topCandidate } : {}),
+    ...(activePostClaimBootstrap ? { activePostClaimBootstrap } : {}),
+    ...(lastProgressAt !== undefined ? { lastProgressAt } : {}),
+    ...(blocker.targetRoom ? { targetRoom: blocker.targetRoom } : {}),
+    ...(blocker.reason ? { reason: blocker.reason } : {}),
+    ...(blocker.reasonDetail ? { reasonDetail: blocker.reasonDetail } : {})
+  };
+}
+
+function selectTerritoryExpansionBlocker({
+  activePipeline,
+  capacity,
+  cachedSelection,
+  topCandidate,
+  activePostClaimBootstrap,
+  survival,
+  territoryExpansion,
+  colony
+}: {
+  activePipeline: AutonomousExpansionPipelineSummary | null;
+  capacity: AutonomousExpansionCapacitySummary;
+  cachedSelection: RuntimeTerritoryExpansionCachedSelectionSummary | null;
+  topCandidate: RuntimeTerritoryExpansionCandidateProgressSummary | null;
+  activePostClaimBootstrap: RuntimeTerritoryExpansionPostClaimBootstrapProgressSummary | null;
+  survival: RuntimeSurvivalSummary;
+  territoryExpansion: ExpansionCandidateReport | undefined;
+  colony: ColonySnapshot;
+}): RuntimeTerritoryExpansionBlockerEvidence {
+  if (activePipeline) {
+    return {
+      blocker: 'activeExpansionPipeline',
+      source: 'activePipeline',
+      targetRoom: activePipeline.targetRoom
+    };
+  }
+
+  if (capacity.status !== 'available') {
+    return { blocker: capacity.status, source: 'capacity' };
+  }
+
+  if (activePostClaimBootstrap) {
+    return {
+      blocker: 'activePostClaimBootstrap',
+      source: 'postClaimBootstrap',
+      targetRoom: activePostClaimBootstrap.roomName
+    };
+  }
+
+  if (cachedSelection?.status === 'planned') {
+    return {
+      blocker: 'none',
+      source: 'selection',
+      targetRoom: cachedSelection.targetRoom
+    };
+  }
+
+  if (cachedSelection?.reasonDetail) {
+    return {
+      blocker: getTerritoryExpansionBlockerForReasonDetail(cachedSelection.reasonDetail),
+      source: 'selection',
+      reason: cachedSelection.reason,
+      reasonDetail: cachedSelection.reasonDetail,
+      targetRoom: cachedSelection.targetRoom
+    };
+  }
+
+  if (topCandidate?.blocker) {
+    return {
+      blocker: topCandidate.blocker,
+      source: 'candidate',
+      targetRoom: topCandidate.roomName
+    };
+  }
+
+  if (cachedSelection?.reason) {
+    return {
+      blocker: getTerritoryExpansionBlockerForSelectionReason(cachedSelection.reason),
+      source: 'selection',
+      reason: cachedSelection.reason,
+      targetRoom: cachedSelection.targetRoom
+    };
+  }
+
+  const survivalBlocker = getTerritoryExpansionBlockerForSurvival(survival);
+  if (survivalBlocker) {
+    return { blocker: survivalBlocker, source: 'survival' };
+  }
+
+  const cpuBucket = getCpuBucket();
+  if (
+    cpuBucket !== undefined &&
+    cpuBucket < TERRITORY_EXPANSION_PROGRESS_CPU_BUCKET_FLOOR
+  ) {
+    return { blocker: 'cpuBucketLow', source: 'cpu' };
+  }
+
+  if (territoryExpansion) {
+    return {
+      blocker: territoryExpansion.candidates.length === 0 ? 'noCandidate' : 'unavailable',
+      source: 'candidate',
+      ...(territoryExpansion.next?.roomName ? { targetRoom: territoryExpansion.next.roomName } : {})
+    };
+  }
+
+  if (topCandidate) {
+    return { blocker: 'unavailable', source: 'candidate', targetRoom: topCandidate.roomName };
+  }
+
+  const hasNoPersistentTerritoryEvidence =
+    !cachedSelection &&
+    !hasAnyTerritoryExpansionProgressMemory(colony.room.name);
+  return {
+    blocker: hasNoPersistentTerritoryEvidence ? 'monitorEvidenceMissing' : 'unavailable',
+    source: 'monitor'
+  };
+}
+
+function getCachedExpansionSelectionSummary(
+  colony: ColonySnapshot
+): RuntimeTerritoryExpansionCachedSelectionSummary | null {
+  const memory = getRoomMemoryRecord(colony);
+  const rawSelection = memory?.cachedExpansionSelection;
+  if (!isRecord(rawSelection) || !isRoomExpansionSelectionStatus(rawSelection.status)) {
+    return null;
+  }
+
+  const refreshedAt = isFiniteNumber(memory?.lastExpansionScoreTime)
+    ? memory.lastExpansionScoreTime
+    : undefined;
+  return {
+    status: rawSelection.status,
+    ...(refreshedAt !== undefined ? { refreshedAt } : {}),
+    ...(isNonEmptyString(rawSelection.stateKey) ? { stateKey: rawSelection.stateKey } : {}),
+    ...(isNonEmptyString(rawSelection.targetRoom) ? { targetRoom: rawSelection.targetRoom } : {}),
+    ...(isRoomExpansionSelectionReason(rawSelection.reason) ? { reason: rawSelection.reason } : {}),
+    ...(isRoomExpansionSelectionReasonDetail(rawSelection.reasonDetail)
+      ? { reasonDetail: rawSelection.reasonDetail }
+      : {}),
+    ...(isFiniteNumber(rawSelection.score) ? { score: rawSelection.score } : {})
+  };
+}
+
+function getTerritoryExpansionControlCounts(
+  colonyName: string
+): RuntimeTerritoryExpansionControlCountSummary {
+  const counts: RuntimeTerritoryExpansionControlCounts = {
+    active: emptyTerritoryActionCounts(),
+    planned: emptyTerritoryActionCounts(),
+    targets: { claim: 0, reserve: 0 }
+  };
+  let latestIntentUpdatedAt: number | undefined;
+  const territory = getTerritoryMemoryRecord();
+  if (!territory) {
+    return { counts };
+  }
+
+  for (const target of Array.isArray(territory.targets) ? territory.targets : []) {
+    if (!isRecord(target) || target.colony !== colonyName || target.enabled === false) {
+      continue;
+    }
+    if (target.action === 'claim' || target.action === 'reserve') {
+      counts.targets[target.action] += 1;
+    }
+  }
+
+  for (const intent of normalizeTerritoryIntents(territory.intents)) {
+    if (intent.colony !== colonyName) {
+      continue;
+    }
+    if (intent.status === 'active') {
+      counts.active[intent.action] += 1;
+    } else if (intent.status === 'planned') {
+      counts.planned[intent.action] += 1;
+    }
+    if (
+      (intent.status === 'active' || intent.status === 'planned') &&
+      (latestIntentUpdatedAt === undefined || intent.updatedAt > latestIntentUpdatedAt)
+    ) {
+      latestIntentUpdatedAt = intent.updatedAt;
+    }
+  }
+
+  return {
+    counts,
+    ...(latestIntentUpdatedAt !== undefined ? { latestIntentUpdatedAt } : {})
+  };
+}
+
+function emptyTerritoryActionCounts(): RuntimeTerritoryActionCounts {
+  return { claim: 0, reserve: 0, scout: 0 };
+}
+
+function getTopExpansionProgressCandidate(
+  colonyName: string,
+  territoryExpansion: ExpansionCandidateReport | undefined
+): RuntimeTerritoryExpansionCandidateProgressSummary | null {
+  const scoredCandidate = territoryExpansion?.next ?? territoryExpansion?.candidates[0];
+  if (scoredCandidate) {
+    return toExpansionProgressCandidate({
+      roomName: scoredCandidate.roomName,
+      evidenceStatus: scoredCandidate.evidenceStatus,
+      score: scoredCandidate.score,
+      blockReason: scoredCandidate.blockReason,
+      routeDistance: scoredCandidate.routeDistance,
+      nearestOwnedRoom: scoredCandidate.nearestOwnedRoom,
+      nearestOwnedRoomDistance: scoredCandidate.nearestOwnedRoomDistance,
+      sourceCount: scoredCandidate.sourceCount,
+      hostileCreepCount: scoredCandidate.hostileCreepCount,
+      hostileStructureCount: scoredCandidate.hostileStructureCount,
+      requiresControllerPressure: scoredCandidate.requiresControllerPressure
+    });
+  }
+
+  const persistedCandidate = getPersistedTopExpansionCandidate(colonyName);
+  return persistedCandidate ? toExpansionProgressCandidate(persistedCandidate) : null;
+}
+
+function toExpansionProgressCandidate(
+  candidate: Partial<TerritoryExpansionCandidateMemory> & { roomName: string }
+): RuntimeTerritoryExpansionCandidateProgressSummary {
+  const blocker = getTerritoryExpansionBlockerForCandidate(candidate);
+  return {
+    roomName: candidate.roomName,
+    ...(isExpansionCandidateEvidenceStatus(candidate.evidenceStatus)
+      ? { evidenceStatus: candidate.evidenceStatus }
+      : {}),
+    ...(isFiniteNumber(candidate.score) ? { score: candidate.score } : {}),
+    ...(isExpansionCandidateRecommendedAction(candidate.recommendedAction)
+      ? { recommendedAction: candidate.recommendedAction }
+      : {}),
+    ...(isExpansionCandidateBlockReason(candidate.blockReason) ? { blockReason: candidate.blockReason } : {}),
+    ...(blocker ? { blocker } : {}),
+    ...(isFiniteNumber(candidate.updatedAt) ? { updatedAt: candidate.updatedAt } : {}),
+    ...(isFiniteNumber(candidate.routeDistance) ? { routeDistance: candidate.routeDistance } : {}),
+    ...(isNonEmptyString(candidate.nearestOwnedRoom) ? { nearestOwnedRoom: candidate.nearestOwnedRoom } : {}),
+    ...(isFiniteNumber(candidate.nearestOwnedRoomDistance)
+      ? { nearestOwnedRoomDistance: candidate.nearestOwnedRoomDistance }
+      : {}),
+    ...(isFiniteNumber(candidate.sourceCount) ? { sourceCount: candidate.sourceCount } : {}),
+    ...(isFiniteNumber(candidate.hostileCreepCount) ? { hostileCreepCount: candidate.hostileCreepCount } : {}),
+    ...(isFiniteNumber(candidate.hostileStructureCount)
+      ? { hostileStructureCount: candidate.hostileStructureCount }
+      : {}),
+    ...(candidate.requiresControllerPressure === true ? { requiresControllerPressure: true } : {})
+  };
+}
+
+function getPersistedTopExpansionCandidate(colonyName: string): TerritoryExpansionCandidateMemory | null {
+  const candidates = getTerritoryMemoryRecord()?.expansionCandidates;
+  if (!Array.isArray(candidates)) {
+    return null;
+  }
+
+  const colonyCandidates = candidates
+    .filter(
+      (candidate): candidate is TerritoryExpansionCandidateMemory =>
+        isRecord(candidate) &&
+        candidate.colony === colonyName &&
+        isNonEmptyString(candidate.roomName)
+    )
+    .sort(comparePersistedExpansionCandidates);
+  return colonyCandidates[0] ?? null;
+}
+
+function comparePersistedExpansionCandidates(
+  left: TerritoryExpansionCandidateMemory,
+  right: TerritoryExpansionCandidateMemory
+): number {
+  const leftRank = isFiniteNumber(left.rank) ? left.rank : Number.MAX_SAFE_INTEGER;
+  const rightRank = isFiniteNumber(right.rank) ? right.rank : Number.MAX_SAFE_INTEGER;
+  if (leftRank !== rightRank) {
+    return leftRank - rightRank;
+  }
+
+  return (right.score ?? 0) - (left.score ?? 0);
+}
+
+function getActivePostClaimBootstrapProgressSummary(
+  colonyName: string,
+  tick: number
+): RuntimeTerritoryExpansionPostClaimBootstrapProgressSummary | null {
+  const blocker = getActivePostClaimBootstrapBlockers(colonyName, tick)[0];
+  return blocker ? toRuntimeTerritoryExpansionPostClaimBootstrapProgress(blocker) : null;
+}
+
+function toRuntimeTerritoryExpansionPostClaimBootstrapProgress(
+  blocker: PostClaimBootstrapBlockerSummary
+): RuntimeTerritoryExpansionPostClaimBootstrapProgressSummary {
+  return {
+    colony: blocker.colony,
+    roomName: blocker.roomName,
+    status: blocker.status,
+    updatedAt: blocker.updatedAt,
+    age: blocker.age,
+    workerTarget: blocker.workerTarget,
+    ...(blocker.workerCount !== undefined ? { workerCount: blocker.workerCount } : {}),
+    spawnCount: blocker.spawnCount
+  };
+}
+
+function getTerritoryExpansionBlockerForReasonDetail(
+  reasonDetail: RoomExpansionSelectionReasonDetail
+): RuntimeTerritoryExpansionBlocker {
+  switch (reasonDetail) {
+    case 'activeExpansionPipeline':
+      return 'activeExpansionPipeline';
+    case 'activePostClaimBootstrap':
+      return 'activePostClaimBootstrap';
+    case 'activeClaimTarget':
+      return 'activeClaimTarget';
+    case 'activeClaimIntent':
+      return 'activeClaimIntent';
+  }
+}
+
+function getTerritoryExpansionBlockerForSelectionReason(
+  reason: RoomExpansionSelectionReason
+): RuntimeTerritoryExpansionBlocker {
+  switch (reason) {
+    case 'gclInsufficient':
+      return 'gclInsufficient';
+    case 'roomLimitReached':
+      return 'roomLimitReached';
+    case 'insufficientEvidence':
+      return 'insufficientEvidence';
+    case 'noCandidate':
+      return 'noCandidate';
+    case 'unavailable':
+      return 'unavailable';
+    case 'unmetPreconditions':
+    default:
+      return 'unavailable';
+  }
+}
+
+function getTerritoryExpansionBlockerForCandidate(
+  candidate: Partial<TerritoryExpansionCandidateMemory>
+): RuntimeTerritoryExpansionBlocker | undefined {
+  if (isExpansionCandidateBlockReason(candidate.blockReason)) {
+    return normalizeTerritoryExpansionCandidateBlocker(candidate.blockReason);
+  }
+
+  if (candidate.requiresControllerPressure === true) {
+    return 'controllerReserved';
+  }
+
+  if ((candidate.hostileCreepCount ?? 0) > 0 || (candidate.hostileStructureCount ?? 0) > 0) {
+    return 'targetHostile';
+  }
+
+  if (candidate.evidenceStatus === 'insufficient-evidence') {
+    return 'insufficientEvidence';
+  }
+
+  if (candidate.evidenceStatus === 'unavailable') {
+    return 'unavailable';
+  }
+
+  return undefined;
+}
+
+function normalizeTerritoryExpansionCandidateBlocker(
+  blockReason: TerritoryExpansionCandidateBlockReason
+): RuntimeTerritoryExpansionBlocker {
+  switch (blockReason) {
+    case 'routeUnavailable':
+      return 'deadZoneRoute';
+    case 'targetUnavailable':
+      return 'targetUnavailable';
+    default:
+      return blockReason;
+  }
+}
+
+function getTerritoryExpansionBlockerForSurvival(
+  survival: RuntimeSurvivalSummary
+): RuntimeTerritoryExpansionBlocker | null {
+  const reasons = survival.suppressionReasons ?? [];
+  if (reasons.includes('defense')) {
+    return 'hostilePresence';
+  }
+  if (reasons.includes('defenseFloor')) {
+    return 'homeDefenseGate';
+  }
+  if (reasons.includes('territoryEnergyCapacity')) {
+    return 'energyCapacityLow';
+  }
+  if (reasons.includes('controllerLevel')) {
+    return 'controllerLevelLow';
+  }
+  if (reasons.includes('controllerDowngradeGuard')) {
+    return 'homeDowngradeGuard';
+  }
+  if (
+    reasons.includes('bootstrapWorkerFloor') ||
+    reasons.includes('bootstrapRecovery') ||
+    reasons.includes('spawnEnergyCritical') ||
+    reasons.includes('localWorkerRecovery')
+  ) {
+    return 'bootstrapGate';
+  }
+
+  return null;
+}
+
+function hasAnyTerritoryExpansionProgressMemory(colonyName: string): boolean {
+  const territory = getTerritoryMemoryRecord();
+  if (!territory) {
+    return false;
+  }
+
+  return (
+    Object.values(territory.expansionPipelines ?? {}).some(
+      (pipeline) => isRecord(pipeline) && pipeline.colony === colonyName
+    ) ||
+    (territory.expansionCandidates ?? []).some(
+      (candidate) => isRecord(candidate) && candidate.colony === colonyName
+    ) ||
+    normalizeTerritoryIntents(territory.intents).some((intent) => intent.colony === colonyName)
+  );
+}
+
+function getRoomMemoryRecord(colony: ColonySnapshot): RoomMemory | null {
+  const roomWithMemory = colony.room as Room & { memory?: RoomMemory };
+  return colony.memory ?? roomWithMemory.memory ?? null;
+}
+
+function getTerritoryMemoryRecord(): TerritoryMemory | null {
+  const territory = (globalThis as { Memory?: Partial<Memory> }).Memory?.territory;
+  return isRecord(territory) ? (territory as TerritoryMemory) : null;
+}
+
+function getCpuBucket(): number | undefined {
+  const bucket = (globalThis as { Game?: Partial<Game> }).Game?.cpu?.bucket;
+  return isFiniteNumber(bucket) ? bucket : undefined;
+}
+
+function maxFiniteNumber(values: Array<number | undefined>): number | undefined {
+  let max: number | undefined;
+  for (const value of values) {
+    if (!isFiniteNumber(value)) {
+      continue;
+    }
+    max = max === undefined ? value : Math.max(max, value);
+  }
+  return max;
+}
+
+function isRoomExpansionSelectionStatus(value: unknown): value is RoomExpansionSelectionStatus {
+  return value === 'planned' || value === 'skipped';
+}
+
+function isRoomExpansionSelectionReason(value: unknown): value is RoomExpansionSelectionReason {
+  return (
+    value === 'noCandidate' ||
+    value === 'gclInsufficient' ||
+    value === 'roomLimitReached' ||
+    value === 'unmetPreconditions' ||
+    value === 'insufficientEvidence' ||
+    value === 'unavailable'
+  );
+}
+
+function isRoomExpansionSelectionReasonDetail(
+  value: unknown
+): value is RoomExpansionSelectionReasonDetail {
+  return (
+    value === 'activeExpansionPipeline' ||
+    value === 'activePostClaimBootstrap' ||
+    value === 'activeClaimTarget' ||
+    value === 'activeClaimIntent'
+  );
+}
+
+function isExpansionCandidateEvidenceStatus(
+  value: unknown
+): value is TerritoryExpansionCandidateEvidenceStatus {
+  return value === 'sufficient' || value === 'insufficient-evidence' || value === 'unavailable';
 }
 
 function buildTerritoryScoutSummary(

--- a/prod/src/territory/expansionTrigger.ts
+++ b/prod/src/territory/expansionTrigger.ts
@@ -66,6 +66,28 @@ interface ExpansionProgressBlocker {
   targetRoom?: string;
 }
 
+export interface AutonomousExpansionCapacitySummary {
+  ownedRoomCount: number;
+  roomLimitCapacity: number;
+  status: 'available' | 'gclInsufficient' | 'roomLimitReached';
+  gclRoomCapacity?: number;
+}
+
+export interface AutonomousExpansionPipelineSummary {
+  colony: string;
+  targetRoom: string;
+  status: TerritoryExpansionPipelineStatus;
+  stage: TerritoryExpansionPipelineStage;
+  score: number;
+  threshold: number;
+  startedAt: number;
+  updatedAt: number;
+  claimState?: TerritoryExpansionClaimState;
+  controllerId?: Id<StructureController>;
+  reservationConfirmedAt?: number;
+  claimedAt?: number;
+}
+
 export function refreshAutonomousExpansionPipeline(
   colony: ColonySnapshot,
   report: ExpansionCandidateReport,
@@ -148,6 +170,42 @@ export function getAutonomousExpansionPipelineStateKey(colony: string): string {
     pipeline.claimState ?? 'none',
     pipeline.updatedAt
   ].join(':');
+}
+
+export function getAutonomousExpansionPipelineSummary(
+  colony: string
+): AutonomousExpansionPipelineSummary | null {
+  const territoryMemory = getTerritoryMemoryRecord();
+  const pipeline = territoryMemory ? getActiveExpansionPipeline(territoryMemory, colony) : null;
+  if (!pipeline) {
+    return null;
+  }
+
+  return toAutonomousExpansionPipelineSummary(pipeline);
+}
+
+export function getAutonomousExpansionCapacitySummary(
+  colony: ColonySnapshot
+): AutonomousExpansionCapacitySummary {
+  const ownedRoomCount = countVisibleOwnedRooms(
+    colony.room.name,
+    getControllerOwnerUsername(colony.room.controller)
+  );
+  const roomLimitCapacity = maxRoomsForRcl(colony.room.controller?.level);
+  const gclRoomCapacity = getGclLevel();
+  const status =
+    gclRoomCapacity !== null && ownedRoomCount >= gclRoomCapacity
+      ? 'gclInsufficient'
+      : ownedRoomCount >= roomLimitCapacity
+        ? 'roomLimitReached'
+        : 'available';
+
+  return {
+    ownedRoomCount,
+    roomLimitCapacity,
+    status,
+    ...(gclRoomCapacity !== null ? { gclRoomCapacity } : {})
+  };
 }
 
 export function recordExpansionPipelineClaimState({
@@ -884,6 +942,27 @@ function normalizeExpansionPipeline(
     ...(isFiniteNumber(rawPipeline.completedAt) ? { completedAt: rawPipeline.completedAt } : {}),
     ...(isExpansionAbortReason(rawPipeline.abortReason) ? { abortReason: rawPipeline.abortReason } : {}),
     ...(isFiniteNumber(rawPipeline.abortedAt) ? { abortedAt: rawPipeline.abortedAt } : {})
+  };
+}
+
+function toAutonomousExpansionPipelineSummary(
+  pipeline: TerritoryExpansionPipelineMemory
+): AutonomousExpansionPipelineSummary {
+  return {
+    colony: pipeline.colony,
+    targetRoom: pipeline.targetRoom,
+    status: pipeline.status,
+    stage: pipeline.stage,
+    score: pipeline.score,
+    threshold: pipeline.threshold,
+    startedAt: pipeline.startedAt,
+    updatedAt: pipeline.updatedAt,
+    ...(pipeline.claimState ? { claimState: pipeline.claimState } : {}),
+    ...(pipeline.controllerId ? { controllerId: pipeline.controllerId } : {}),
+    ...(pipeline.reservationConfirmedAt !== undefined
+      ? { reservationConfirmedAt: pipeline.reservationConfirmedAt }
+      : {}),
+    ...(pipeline.claimedAt !== undefined ? { claimedAt: pipeline.claimedAt } : {})
   };
 }
 

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -292,6 +292,23 @@ describe('runtime telemetry summaries', () => {
               repairHitsCeiling: 25_000
             }
           },
+          territoryExpansionProgress: {
+            colony: 'W1N1',
+            source: 'runtime-summary',
+            updatedAt: RUNTIME_SUMMARY_INTERVAL,
+            territoryCapable: false,
+            blocker: 'roomLimitReached',
+            blockerSource: 'capacity',
+            ownedRoomCount: 1,
+            roomCapacityStatus: 'roomLimitReached',
+            roomLimitCapacity: 1,
+            activePipelineStateKey: 'pipeline:none',
+            controlCounts: {
+              active: { claim: 0, reserve: 0, scout: 0 },
+              planned: { claim: 0, reserve: 0, scout: 0 },
+              targets: { claim: 0, reserve: 0 }
+            }
+          },
           territoryRecommendation: {
             candidates: [],
             next: null,
@@ -2402,6 +2419,64 @@ describe('runtime telemetry summaries', () => {
     expect(room.territoryExecutionHints).toEqual([executionHint]);
   });
 
+  it('emits compact active expansion pipeline progress for monitor alerts', () => {
+    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        expansionPipelines: {
+          W1N1: {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            status: 'active',
+            stage: 'claiming',
+            claimState: 'scouted',
+            score: 900,
+            threshold: 700,
+            startedAt: RUNTIME_SUMMARY_INTERVAL - 50,
+            updatedAt: RUNTIME_SUMMARY_INTERVAL - 1,
+            controllerId: 'controller2' as Id<StructureController>
+          }
+        },
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'planned',
+            updatedAt: RUNTIME_SUMMARY_INTERVAL - 1,
+            createdBy: 'nextExpansionScoring'
+          }
+        ]
+      }
+    };
+
+    emitRuntimeSummary([colony], [], [], { persistOccupationRecommendations: false });
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.territoryExpansionProgress).toMatchObject({
+      colony: 'W1N1',
+      blocker: 'activeExpansionPipeline',
+      blockerSource: 'activePipeline',
+      targetRoom: 'W2N1',
+      lastProgressAt: RUNTIME_SUMMARY_INTERVAL - 1,
+      activePipelineStateKey: expect.stringContaining('pipeline:active:claiming:W2N1'),
+      activePipeline: {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        status: 'active',
+        stage: 'claiming',
+        claimState: 'scouted',
+        updatedAt: RUNTIME_SUMMARY_INTERVAL - 1
+      },
+      controlCounts: {
+        active: { claim: 0, reserve: 0, scout: 0 },
+        planned: { claim: 1, reserve: 0, scout: 0 },
+        targets: { claim: 0, reserve: 0 }
+      }
+    });
+  });
+
   it('groups creeps by colony before building per-room summaries', () => {
     const firstColony = makeColony({
       time: RUNTIME_SUMMARY_INTERVAL,
@@ -3180,6 +3255,20 @@ describe('runtime telemetry summaries', () => {
     const recommendation = summaryRoom.territoryRecommendation as Record<string, unknown>;
 
     expect(summaryRoom.territoryExpansion).toBeUndefined();
+    expect(summaryRoom.territoryExpansionProgress).toMatchObject({
+      colony: 'E29N55',
+      source: 'runtime-summary',
+      blocker: 'cpuBucketLow',
+      blockerSource: 'cpu',
+      ownedRoomCount: 1,
+      roomCapacityStatus: 'available',
+      activePipelineStateKey: 'pipeline:none',
+      controlCounts: {
+        active: { claim: 0, reserve: 0, scout: 0 },
+        planned: { claim: 0, reserve: 0, scout: 0 },
+        targets: { claim: 0, reserve: 0 }
+      }
+    });
     expect(recommendation).toMatchObject({
       candidates: [],
       next: null,

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -147,6 +147,45 @@ CONSTRUCTION_DEADLOCK_ROUTES = [
     {"issue": "#906", "topic": "gameplay_behavior_metric"},
     {"issue": "#1025", "topic": "construction_deadlock_ticks"},
 ]
+TERRITORY_EXPANSION_STAGNATION_KIND = "territory_expansion_stagnation"
+TERRITORY_EXPANSION_STAGNATION_TICKS = 5_000
+TERRITORY_EXPANSION_STAGNATION_ROUTES = [
+    {"issue": "#1632", "topic": "expansion_stagnation_guard"},
+    {"issue": "#1624", "topic": "stale_claim_intent_regression"},
+    {"issue": "#1527", "topic": "territory_expansion_monitoring"},
+    {"issue": "#1540", "topic": "runtime_alert_routing"},
+]
+TERRITORY_EXPANSION_NON_ALERT_BLOCKERS = {
+    "activeExpansionPipeline",
+    "activePostClaimBootstrap",
+    "postClaimBootstrapActive",
+    "gclInsufficient",
+    "roomLimitReached",
+    "targetHostile",
+    "hostilePresence",
+    "controllerReserved",
+    "controllerOwned",
+    "deadZoneRoute",
+    "routeUnavailable",
+    "noCandidate",
+    "cpuBucketLow",
+    "energyCapacityLow",
+    "energyBufferLow",
+    "homeAlertActive",
+    "controllerLevelLow",
+    "homeDowngradeGuard",
+    "bootstrapGate",
+    "homeDefenseGate",
+}
+TERRITORY_EXPANSION_STALE_ALERT_BLOCKERS = {
+    "none",
+    "monitorEvidenceMissing",
+    "unavailable",
+    "targetUnavailable",
+    "insufficientEvidence",
+    "activeClaimIntent",
+    "activeClaimTarget",
+}
 WORKER_ASSIGNMENT_STALL_ROUTES = [
     {"issue": "#1580", "topic": "worker_deadlock_alert"},
     {"issue": "#1553", "topic": "e29n57_worker_deadlock"},
@@ -366,6 +405,17 @@ TACTICAL_CATEGORY_RULES: dict[str, dict[str, Any]] = {
             "routes_to": CONSTRUCTION_DEADLOCK_ROUTES,
         },
     },
+    TERRITORY_EXPANSION_STAGNATION_KIND: {
+        "severity": "critical",
+        "decision": "codex_hotfix",
+        "actions": ["capture_runtime_context", "inspect_runtime_deadlock", "start_hotfix_gate"],
+        "metadata": {
+            "metric": "territoryExpansionProgress",
+            "related_issues": [str(route["issue"]) for route in TERRITORY_EXPANSION_STAGNATION_ROUTES],
+            "thresholds": {"P0_ticks": TERRITORY_EXPANSION_STAGNATION_TICKS},
+            "routes_to": TERRITORY_EXPANSION_STAGNATION_ROUTES,
+        },
+    },
     "worker_idle_collapse": {
         "severity": "high",
         "decision": "codex_hotfix_or_owner_action",
@@ -416,6 +466,7 @@ TACTICAL_REASON_CATEGORY_MAP = {
     CPU_BUCKET_LOW_KIND: [CPU_BUCKET_LOW_KIND],
     "energy_buffer_unhealthy": ["energy_buffer_unhealthy"],
     CONSTRUCTION_DEADLOCK_KIND: [CONSTRUCTION_DEADLOCK_KIND],
+    TERRITORY_EXPANSION_STAGNATION_KIND: [TERRITORY_EXPANSION_STAGNATION_KIND],
     "worker_idle_collapse": ["worker_idle_collapse"],
     "private_smoke_failed_phase": ["private_smoke_failure"],
     "private_smoke_runtime_failure": ["private_smoke_failure"],
@@ -1282,6 +1333,15 @@ def construction_deadlock_metadata() -> dict[str, Any]:
     }
 
 
+def territory_expansion_stagnation_metadata() -> dict[str, Any]:
+    return {
+        "metric": "territoryExpansionProgress",
+        "related_issues": [str(route["issue"]) for route in TERRITORY_EXPANSION_STAGNATION_ROUTES],
+        "thresholds": {"P0_ticks": TERRITORY_EXPANSION_STAGNATION_TICKS},
+        "routes_to": [dict(route) for route in TERRITORY_EXPANSION_STAGNATION_ROUTES],
+    }
+
+
 def worker_assignment_stall_metadata() -> dict[str, Any]:
     return {
         "metric": "workerAssignmentEvidence.productiveAssignmentCount",
@@ -1621,6 +1681,295 @@ def detect_construction_deadlock_reason(
         return None
 
     return build_construction_deadlock_reason(ref, runtime_room, metrics, deadlock_ticks)
+
+
+def runtime_territory_expansion_progress(room: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(room, dict):
+        return {}
+    progress = as_dict(room.get("territoryExpansionProgress"))
+    if progress:
+        return progress
+    return as_dict(room.get("territory_expansion_progress"))
+
+
+def territory_expansion_progress_tick(
+    progress: dict[str, Any],
+    runtime_room: dict[str, Any] | None,
+    current_tick_value: Any,
+) -> int | None:
+    for value in (
+        progress.get("updatedAt"),
+        runtime_summary_room_tick(runtime_room or {}),
+        current_tick_value,
+    ):
+        tick = tick_number(value)
+        if tick is not None:
+            return tick
+    return None
+
+
+def territory_expansion_progress_last_tick(progress: dict[str, Any]) -> int | None:
+    for key in ("lastProgressAt", "last_progress_at"):
+        tick = tick_number(progress.get(key))
+        if tick is not None:
+            return tick
+    active_pipeline = as_dict(progress.get("activePipeline"))
+    pipeline_tick = tick_number(active_pipeline.get("updatedAt"))
+    if pipeline_tick is not None:
+        return pipeline_tick
+    cached_selection = as_dict(progress.get("cachedSelection"))
+    return tick_number(cached_selection.get("refreshedAt"))
+
+
+def territory_expansion_blocker(progress: dict[str, Any]) -> str:
+    blocker = progress.get("blocker")
+    return blocker if isinstance(blocker, str) and blocker else "monitorEvidenceMissing"
+
+
+def territory_expansion_target(progress: dict[str, Any]) -> str | None:
+    for source in (
+        progress,
+        as_dict(progress.get("activePipeline")),
+        as_dict(progress.get("cachedSelection")),
+        as_dict(progress.get("topCandidate")),
+        as_dict(progress.get("activePostClaimBootstrap")),
+    ):
+        for key in ("targetRoom", "roomName"):
+            value = source.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return None
+
+
+def territory_expansion_capacity_available(progress: dict[str, Any]) -> bool:
+    status = progress.get("roomCapacityStatus")
+    if isinstance(status, str) and status:
+        return status == "available"
+    owned = number_value(progress.get("ownedRoomCount"))
+    gcl_capacity = number_value(progress.get("gclRoomCapacity"))
+    room_capacity = number_value(progress.get("roomLimitCapacity"))
+    if gcl_capacity is not None and owned is not None and owned >= gcl_capacity:
+        return False
+    if room_capacity is not None and owned is not None and owned >= room_capacity:
+        return False
+    return True
+
+
+def territory_expansion_has_active_pipeline(progress: dict[str, Any]) -> bool:
+    if as_dict(progress.get("activePipeline")):
+        return True
+    return territory_expansion_blocker(progress) == "activeExpansionPipeline"
+
+
+def territory_expansion_progress_is_actionable(
+    progress: dict[str, Any],
+    current_tick: int | None,
+) -> tuple[bool, str]:
+    if progress.get("territoryCapable") is not True:
+        return False, "territory_not_capable"
+    if not territory_expansion_capacity_available(progress):
+        return False, "capacity_blocked"
+    if territory_expansion_has_active_pipeline(progress):
+        return False, "active_pipeline"
+
+    blocker = territory_expansion_blocker(progress)
+    if blocker in TERRITORY_EXPANSION_NON_ALERT_BLOCKERS:
+        return False, blocker
+    if blocker not in TERRITORY_EXPANSION_STALE_ALERT_BLOCKERS:
+        return False, blocker
+
+    if current_tick is None:
+        return blocker in {"monitorEvidenceMissing", "unavailable", "targetUnavailable"}, blocker
+
+    last_progress_tick = territory_expansion_progress_last_tick(progress)
+    if last_progress_tick is not None and current_tick >= last_progress_tick:
+        stale_ticks = current_tick - last_progress_tick
+        if stale_ticks < TERRITORY_EXPANSION_STAGNATION_TICKS:
+            return False, "progress_fresh"
+        return True, blocker
+
+    return True, blocker
+
+
+def territory_expansion_stagnation_previous_state(value: Any) -> dict[str, int]:
+    state = as_dict(value)
+    start_tick = tick_number(state.get("start_tick"))
+    last_tick = tick_number(state.get("last_tick"))
+    if start_tick is None or last_tick is None:
+        return {"start_tick": 0, "last_tick": 0, "consecutive_ticks": 0}
+    consecutive_ticks = number_value(state.get("consecutive_ticks"))
+    return {
+        "start_tick": start_tick,
+        "last_tick": last_tick,
+        "consecutive_ticks": int(consecutive_ticks) if consecutive_ticks is not None else max(0, last_tick - start_tick),
+    }
+
+
+def territory_expansion_stagnation_next_state(previous_state: dict[str, int], current_tick: int) -> dict[str, int]:
+    if previous_state["start_tick"] <= 0 or current_tick < previous_state["last_tick"]:
+        return {"start_tick": current_tick, "last_tick": current_tick, "consecutive_ticks": 0}
+    start_tick = previous_state["start_tick"]
+    return {
+        "start_tick": start_tick,
+        "last_tick": current_tick,
+        "consecutive_ticks": max(0, current_tick - start_tick),
+    }
+
+
+def territory_expansion_progress_evidence(
+    progress: dict[str, Any],
+    runtime_room: dict[str, Any] | None,
+    current_tick: int | None,
+    blocker: str,
+    state: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    top_candidate = as_dict(progress.get("topCandidate"))
+    active_pipeline = as_dict(progress.get("activePipeline"))
+    cached_selection = as_dict(progress.get("cachedSelection"))
+    active_bootstrap = as_dict(progress.get("activePostClaimBootstrap"))
+    evidence: dict[str, Any] = {
+        "colony": progress.get("colony"),
+        "ownedRoomCount": progress.get("ownedRoomCount"),
+        "gclRoomCapacity": progress.get("gclRoomCapacity"),
+        "roomLimitCapacity": progress.get("roomLimitCapacity"),
+        "roomCapacityStatus": progress.get("roomCapacityStatus"),
+        "territoryCapable": progress.get("territoryCapable"),
+        "blocker": blocker,
+        "blockerSource": progress.get("blockerSource"),
+        "targetRoom": territory_expansion_target(progress),
+        "runtimeSummaryTick": current_tick,
+        "lastProgressAt": territory_expansion_progress_last_tick(progress),
+        "activePipelineStateKey": progress.get("activePipelineStateKey"),
+        "controlCounts": as_dict(progress.get("controlCounts")),
+    }
+    if top_candidate:
+        evidence["topCandidate"] = {
+            key: top_candidate.get(key)
+            for key in (
+                "roomName",
+                "score",
+                "evidenceStatus",
+                "recommendedAction",
+                "blockReason",
+                "blocker",
+                "updatedAt",
+                "hostileCreepCount",
+                "hostileStructureCount",
+                "requiresControllerPressure",
+            )
+            if key in top_candidate
+        }
+    if active_pipeline:
+        evidence["activePipeline"] = {
+            key: active_pipeline.get(key)
+            for key in ("targetRoom", "status", "stage", "claimState", "updatedAt", "startedAt")
+            if key in active_pipeline
+        }
+    if cached_selection:
+        evidence["cachedSelection"] = {
+            key: cached_selection.get(key)
+            for key in ("status", "targetRoom", "reason", "reasonDetail", "refreshedAt", "stateKey")
+            if key in cached_selection
+        }
+    if active_bootstrap:
+        evidence["activePostClaimBootstrap"] = {
+            key: active_bootstrap.get(key)
+            for key in ("roomName", "status", "updatedAt", "age", "workerTarget", "workerCount", "spawnCount")
+            if key in active_bootstrap
+        }
+    if state is not None:
+        evidence["startTick"] = state["start_tick"]
+        evidence["consecutiveTicks"] = state["consecutive_ticks"]
+    path = runtime_room.get(RUNTIME_SUMMARY_ARTIFACT_PATH_METADATA_KEY) if isinstance(runtime_room, dict) else None
+    if isinstance(path, str) and path:
+        evidence["runtimeSummaryPath"] = path
+    line = number_value(runtime_room.get(RUNTIME_SUMMARY_ARTIFACT_LINE_METADATA_KEY)) if isinstance(runtime_room, dict) else None
+    if line is not None:
+        evidence["runtimeSummaryLine"] = int(line)
+    return evidence
+
+
+def build_territory_expansion_stagnation_reason(
+    ref: RoomRef,
+    progress: dict[str, Any],
+    runtime_room: dict[str, Any] | None,
+    current_tick: int | None,
+    blocker: str,
+    state: dict[str, int],
+) -> dict[str, Any]:
+    last_progress_tick = territory_expansion_progress_last_tick(progress)
+    stale_ticks = (
+        current_tick - last_progress_tick
+        if current_tick is not None and last_progress_tick is not None and current_tick >= last_progress_tick
+        else state["consecutive_ticks"]
+    )
+    evidence = territory_expansion_progress_evidence(progress, runtime_room, current_tick, blocker, state)
+    target_room = evidence.get("targetRoom")
+    return {
+        "kind": TERRITORY_EXPANSION_STAGNATION_KIND,
+        "room": ref.key,
+        "shard": ref.shard,
+        "room_name": ref.room,
+        "colony": evidence.get("colony") or ref.room,
+        "severity": "critical",
+        "priority": "P0",
+        "blocker": blocker,
+        "targetRoom": target_room,
+        "ownedRoomCount": evidence.get("ownedRoomCount"),
+        "runtimeSummaryTick": current_tick,
+        "lastProgressAt": last_progress_tick,
+        "staleTicks": stale_ticks,
+        "threshold": TERRITORY_EXPANSION_STAGNATION_TICKS,
+        "evidence": evidence,
+        "metadata": territory_expansion_stagnation_metadata(),
+        "message": (
+            f"{TERRITORY_EXPANSION_STAGNATION_KIND} in {ref.key}: "
+            f"blocker={blocker}, target={target_room or 'unknown'}, "
+            f"ownedRoomCount={format_energy_value(evidence.get('ownedRoomCount'))}, "
+            f"staleTicks={format_energy_value(stale_ticks)}."
+        ),
+        "signature": f"{TERRITORY_EXPANSION_STAGNATION_KIND}:{ref.key}:{blocker}:{target_room or 'unknown'}",
+    }
+
+
+def detect_territory_expansion_stagnation_reason(
+    ref: RoomRef,
+    runtime_room: dict[str, Any] | None,
+    previous_rule_state: Any,
+    current_tick_value: Any,
+) -> tuple[dict[str, Any] | None, dict[str, int] | int]:
+    progress = runtime_territory_expansion_progress(runtime_room)
+    if not progress:
+        return None, 0
+
+    current_tick = territory_expansion_progress_tick(progress, runtime_room, current_tick_value)
+    actionable, blocker = territory_expansion_progress_is_actionable(progress, current_tick)
+    if not actionable:
+        return None, 0
+
+    if current_tick is None:
+        return None, territory_expansion_stagnation_previous_state(previous_rule_state)
+
+    last_progress_tick = territory_expansion_progress_last_tick(progress)
+    if (
+        last_progress_tick is not None
+        and current_tick >= last_progress_tick
+        and current_tick - last_progress_tick >= TERRITORY_EXPANSION_STAGNATION_TICKS
+    ):
+        state = {
+            "start_tick": last_progress_tick,
+            "last_tick": current_tick,
+            "consecutive_ticks": current_tick - last_progress_tick,
+        }
+        return build_territory_expansion_stagnation_reason(ref, progress, runtime_room, current_tick, blocker, state), state
+
+    state = territory_expansion_stagnation_next_state(
+        territory_expansion_stagnation_previous_state(previous_rule_state),
+        current_tick,
+    )
+    if state["consecutive_ticks"] >= TERRITORY_EXPANSION_STAGNATION_TICKS:
+        return build_territory_expansion_stagnation_reason(ref, progress, runtime_room, current_tick, blocker, state), state
+    return None, state
 
 
 def build_worker_idle_collapse_reason(
@@ -2598,6 +2947,17 @@ def evaluate_room_alert(
     )
     if construction_deadlock_candidate is not None:
         detected.append(construction_deadlock_candidate)
+
+    previous_territory_expansion_stagnation_state = rule_counts.get(TERRITORY_EXPANSION_STAGNATION_KIND)
+    territory_expansion_stagnation_candidate, territory_expansion_stagnation_state = detect_territory_expansion_stagnation_reason(
+        snapshot.ref,
+        runtime_room_summary,
+        previous_territory_expansion_stagnation_state,
+        snapshot.tick,
+    )
+    rule_counts[TERRITORY_EXPANSION_STAGNATION_KIND] = territory_expansion_stagnation_state
+    if territory_expansion_stagnation_candidate is not None:
+        detected.append(territory_expansion_stagnation_candidate)
 
     cpu_bucket_candidate = detect_cpu_bucket_reason(snapshot.ref, runtime_room_summary)
     if cpu_bucket_candidate is not None:
@@ -4060,6 +4420,7 @@ def runtime_summary_room_has_monitor_alert_fields(room: dict[str, Any], payload:
         or runtime_productive_assignment_count(room) is not None
         or runtime_worker_assignment_blocked_detail(room) is not None
         or bool(runtime_worker_assignment_blocked_workers(room))
+        or bool(runtime_territory_expansion_progress(room))
     )
 
 
@@ -4271,6 +4632,24 @@ def runtime_summary_capture_history_entry(room: dict[str, Any]) -> dict[str, Any
     )
     if worker_count is not None:
         entry["workerCount"] = worker_count
+
+    territory_progress = runtime_territory_expansion_progress(room)
+    if territory_progress:
+        entry["territoryExpansionProgress"] = {
+            key: territory_progress.get(key)
+            for key in (
+                "colony",
+                "territoryCapable",
+                "blocker",
+                "blockerSource",
+                "targetRoom",
+                "ownedRoomCount",
+                "roomCapacityStatus",
+                "lastProgressAt",
+                "updatedAt",
+            )
+            if key in territory_progress
+        }
 
     task_counts = as_dict(room.get("taskCounts"))
     if task_counts:
@@ -5652,6 +6031,67 @@ def command_self_test(_args: argparse.Namespace) -> int:
                 info={},
             )
 
+        def make_owned_snapshot(self, tick: int = 1) -> RoomSnapshot:
+            return RoomSnapshot(
+                ref=RoomRef("shardTest", "E1N1"),
+                terrain="0" * TERRAIN_CELLS,
+                objects=normalize_objects(
+                    {
+                        "spawn1": {
+                            "type": "spawn",
+                            "my": True,
+                            "owner": {"username": "owner"},
+                            "x": 25,
+                            "y": 25,
+                            "hits": 5000,
+                            "hitsMax": 5000,
+                        },
+                        "extension1": {
+                            "type": "extension",
+                            "my": True,
+                            "owner": {"username": "owner"},
+                            "x": 26,
+                            "y": 25,
+                            "hits": 1000,
+                            "hitsMax": 1000,
+                        },
+                        "ctrl": {
+                            "type": "controller",
+                            "my": True,
+                            "owner": {"username": "owner"},
+                            "level": 6,
+                            "x": 5,
+                            "y": 36,
+                        },
+                    }
+                ),
+                tick=tick,
+                owner="owner",
+                info={},
+            )
+
+        def make_territory_progress(self, **overrides: Any) -> dict[str, Any]:
+            progress = {
+                "colony": "E1N1",
+                "source": "runtime-summary",
+                "updatedAt": 1000,
+                "territoryCapable": True,
+                "blocker": "monitorEvidenceMissing",
+                "blockerSource": "monitor",
+                "ownedRoomCount": 2,
+                "roomCapacityStatus": "available",
+                "roomLimitCapacity": 5,
+                "gclRoomCapacity": 6,
+                "activePipelineStateKey": "pipeline:none",
+                "controlCounts": {
+                    "active": {"claim": 0, "reserve": 0, "scout": 0},
+                    "planned": {"claim": 0, "reserve": 0, "scout": 0},
+                    "targets": {"claim": 0, "reserve": 0},
+                },
+            }
+            progress.update(overrides)
+            return progress
+
         def test_first_run_baseline_no_alert(self) -> None:
             snapshot = self.make_snapshot(
                 {
@@ -6140,6 +6580,116 @@ def command_self_test(_args: argparse.Namespace) -> int:
             report = build_tactical_response_report({"ok": True, "mode": "alert", "alert": True, "reasons": [reason]})
             self.assertEqual(report["severity"], "critical")
             self.assertEqual(report["categories"], [CONSTRUCTION_DEADLOCK_KIND])
+
+        def test_territory_expansion_stagnation_alert_serializes_and_routes(self) -> None:
+            first_snapshot = self.make_owned_snapshot(tick=1000)
+            second_snapshot = self.make_owned_snapshot(tick=1000 + TERRITORY_EXPANSION_STAGNATION_TICKS)
+            first_runtime = {"roomName": "E1N1", "territoryExpansionProgress": self.make_territory_progress(updatedAt=1000)}
+            second_runtime = {
+                "roomName": "E1N1",
+                "territoryExpansionProgress": self.make_territory_progress(
+                    updatedAt=1000 + TERRITORY_EXPANSION_STAGNATION_TICKS,
+                    targetRoom="E2N1",
+                    topCandidate={
+                        "roomName": "E2N1",
+                        "evidenceStatus": "sufficient",
+                        "score": 820,
+                        "updatedAt": 1000,
+                    },
+                ),
+            }
+
+            first_emitted, first_suppressed, first_state = evaluate_room_alert(
+                first_snapshot,
+                {"baseline_established": True, "owner": "owner"},
+                now=100,
+                debounce_seconds=300,
+                runtime_room_summary=first_runtime,
+            )
+            self.assertEqual(first_emitted, [])
+            self.assertEqual(first_suppressed, [])
+
+            second_emitted, second_suppressed, _second_state = evaluate_room_alert(
+                second_snapshot,
+                first_state,
+                now=200,
+                debounce_seconds=300,
+                runtime_room_summary=second_runtime,
+            )
+            self.assertEqual(second_suppressed, [])
+            reason = next(reason for reason in second_emitted if reason["kind"] == TERRITORY_EXPANSION_STAGNATION_KIND)
+            self.assertEqual(reason["priority"], "P0")
+            self.assertEqual(reason["blocker"], "monitorEvidenceMissing")
+            self.assertEqual(reason["targetRoom"], "E2N1")
+            self.assertEqual(reason["metadata"]["related_issues"], ["#1632", "#1624", "#1527", "#1540"])
+            json.dumps(reason)
+
+            tactical = build_tactical_response_report({"ok": True, "mode": "alert", "alert": True, "reasons": [reason]})
+            self.assertEqual(tactical["severity"], "critical")
+            self.assertEqual(tactical["priority"], "P0")
+            self.assertEqual(tactical["categories"], [TERRITORY_EXPANSION_STAGNATION_KIND])
+            self.assertEqual(
+                tactical["triggers"][0]["metadata"]["routes_to"][0],
+                {"issue": "#1632", "topic": "expansion_stagnation_guard"},
+            )
+
+            health = evaluate_postdeploy_health_gate(
+                {"ok": True, "room_summaries": [{"room": "E1N1", "owner": "owner", "owned_creeps": 1, "owned_spawns": 1}]},
+                {"ok": True, "mode": "alert", "alert": True, "reasons": [reason]},
+            )
+            self.assertFalse(health["ok"])
+            self.assertIn("postdeploy_active_alert", [item["kind"] for item in health["reasons"]])
+
+        def test_territory_expansion_active_pipeline_suppresses_stagnation_alert(self) -> None:
+            snapshot = self.make_owned_snapshot(tick=10_000)
+            runtime_room = {
+                "roomName": "E1N1",
+                "territoryExpansionProgress": self.make_territory_progress(
+                    updatedAt=10_000,
+                    blocker="activeExpansionPipeline",
+                    blockerSource="activePipeline",
+                    targetRoom="E2N1",
+                    activePipeline={"targetRoom": "E2N1", "status": "active", "stage": "claiming", "updatedAt": 1},
+                ),
+            }
+
+            emitted, suppressed, next_state = evaluate_room_alert(
+                snapshot,
+                {"baseline_established": True, "owner": "owner"},
+                now=100,
+                debounce_seconds=300,
+                runtime_room_summary=runtime_room,
+            )
+
+            self.assertEqual(emitted, [])
+            self.assertEqual(suppressed, [])
+            self.assertEqual(next_state["rule_counts"][TERRITORY_EXPANSION_STAGNATION_KIND], 0)
+
+        def test_territory_expansion_legitimate_blockers_do_not_create_p0_alerts(self) -> None:
+            snapshot = self.make_owned_snapshot(tick=10_000)
+            blockers = [
+                ("gclInsufficient", {"roomCapacityStatus": "gclInsufficient", "ownedRoomCount": 6, "gclRoomCapacity": 6}),
+                ("roomLimitReached", {"roomCapacityStatus": "roomLimitReached", "ownedRoomCount": 5, "roomLimitCapacity": 5}),
+                ("targetHostile", {"targetRoom": "E2N1", "topCandidate": {"roomName": "E2N1", "blocker": "targetHostile"}}),
+                (
+                    "controllerReserved",
+                    {"targetRoom": "E2N1", "topCandidate": {"roomName": "E2N1", "blocker": "controllerReserved"}},
+                ),
+                ("noCandidate", {"blockerSource": "selection"}),
+            ]
+            for blocker, extra in blockers:
+                with self.subTest(blocker=blocker):
+                    progress = self.make_territory_progress(updatedAt=10_000, blocker=blocker, **extra)
+                    self.assertEqual(territory_expansion_blocker(progress), blocker)
+                    emitted, suppressed, _next_state = evaluate_room_alert(
+                        snapshot,
+                        {"baseline_established": True, "owner": "owner"},
+                        now=100,
+                        debounce_seconds=300,
+                        runtime_room_summary={"roomName": "E1N1", "territoryExpansionProgress": progress},
+                    )
+                    self.assertEqual([reason["kind"] for reason in emitted], [])
+                    self.assertEqual(suppressed, [])
 
         def test_worker_idle_collapse_alerts_on_second_consecutive_detection(self) -> None:
             snapshot = self.make_snapshot(


### PR DESCRIPTION
## Summary

- Adds always-on `territoryExpansionProgress` runtime-summary telemetry so monitor-consumed artifacts can answer why a colony is not moving to the next room even when rich optional summaries are throttled.
- Adds runtime-monitor `territory_expansion_stagnation` detection/tactical routing with exact blocker metadata and related issue routes.
- Preserves no-spam behavior for legitimate blockers such as active pipeline, GCL/room limit, hostile/foreign target, no candidate, or scout/monitor evidence still pending.
- Adds Jest and monitor self-test coverage for recurrence prevention.

## Verification

- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand` (`103` suites, `2185` tests)
- [x] `cd prod && npm run build`
- [x] `python3 scripts/screeps-runtime-monitor.py self-test` (`42` tests)

Controller-side verification was run after the stuck Codex implementation process was killed and before commit-only recovery. Commit `aeefdcb897620b0aeb2331b53a3b35d715734234` is Codex-authored.

## Universal task Done gate

- [x] Task type: code + monitor guardrail for live official-MMO territory expansion recurrence prevention.
- [x] Expected observable outcome / named deliverable: monitor-consumed runtime state carries `territoryExpansionProgress`, and sustained territory-capable no-progress states emit `territory_expansion_stagnation` with exact blocker metadata.
- [x] Non-goals / accepted substitutes: this PR does not force-claim a specific target, bypass GCL/RCL/defense/no-proactive-attack gates, or auto-close the post-deploy acceptance issue.
- [x] Verification evidence required before Done: typecheck, full Jest, build, monitor self-test, PR checks/review gate, official MMO deploy, and post-deploy proof that the monitor reports active expansion progress or one explicit non-spam blocker.
- [x] Project Evidence / Next action / Blocked by: controller added issue 1632 to Project `screeps` as P0 In progress and will update PR/issue Project fields with this PR, checks, review, deploy, and post-deploy evidence.
- [x] Post-merge/deploy/runtime proof: PR-local proof is full verification above; issue 1632 owns the official deploy and live post-deploy expansion-state acceptance gate.
- [x] Named deliverable proof: committed changes add the runtime summary territory progress surface, monitor alert/tactical routing, and regression tests/self-tests required to prevent silent multi-day expansion stalls.

## Links

Related to issue 1632.
Related to issue 1624.
Related to issue 1527.
Related to issue 1540.
