### PR TITLE
fix: shed optional work after CPU over-limit samples

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1029,7 +1029,7 @@ function shouldRunOptionalCpuWork(budget, key, interval = DEGRADED_OPTIONAL_WORK
   if (!budget.degraded) {
     return true;
   }
-  if (budget.critical || hasLowBucketPressure(budget)) {
+  if (budget.critical || hasLowBucketPressure(budget) || hasUsedOverLimitPressure(budget)) {
     return false;
   }
   return isCadenceTick(budget.tick, key, interval);
@@ -1038,7 +1038,7 @@ function shouldRunOptionalCpuRoomWork(budget, roomName, interval = DEGRADED_ROOM
   if (!budget.degraded) {
     return true;
   }
-  if (budget.critical || hasLowBucketPressure(budget)) {
+  if (budget.critical || hasLowBucketPressure(budget) || hasUsedOverLimitPressure(budget)) {
     return false;
   }
   return isCadenceTick(budget.tick, roomName, interval);
@@ -1047,10 +1047,13 @@ function shouldThrottleRuntimeSummaryCadence(budget) {
   return budget.degraded;
 }
 function shouldShedNonessentialCpuWork(budget) {
-  return budget.critical || hasLowBucketPressure(budget);
+  return budget.critical || hasLowBucketPressure(budget) || hasUsedOverLimitPressure(budget);
 }
 function hasLowBucketPressure(budget) {
   return budget.reasons.includes("lowBucket") || budget.reasons.includes("criticalBucket");
+}
+function hasUsedOverLimitPressure(budget) {
+  return budget.reasons.includes("usedOverLimit");
 }
 function updateRuntimeCpuTelemetryState(sample) {
   resetRuntimeCpuTelemetryStateForTick(sample.tick);

--- a/prod/src/runtime/cpuBudget.ts
+++ b/prod/src/runtime/cpuBudget.ts
@@ -174,7 +174,7 @@ export function shouldRunOptionalCpuWork(
     return true;
   }
 
-  if (budget.critical || hasLowBucketPressure(budget)) {
+  if (budget.critical || hasLowBucketPressure(budget) || hasUsedOverLimitPressure(budget)) {
     return false;
   }
 
@@ -190,7 +190,7 @@ export function shouldRunOptionalCpuRoomWork(
     return true;
   }
 
-  if (budget.critical || hasLowBucketPressure(budget)) {
+  if (budget.critical || hasLowBucketPressure(budget) || hasUsedOverLimitPressure(budget)) {
     return false;
   }
 
@@ -202,7 +202,7 @@ export function shouldThrottleRuntimeSummaryCadence(budget: RuntimeCpuBudget): b
 }
 
 export function shouldShedNonessentialCpuWork(budget: RuntimeCpuBudget): boolean {
-  return budget.critical || hasLowBucketPressure(budget);
+  return budget.critical || hasLowBucketPressure(budget) || hasUsedOverLimitPressure(budget);
 }
 
 export function resetRuntimeCpuTelemetryForTesting(): void {
@@ -215,6 +215,10 @@ export function resetRuntimeCpuTelemetryForTesting(): void {
 
 export function hasLowBucketPressure(budget: RuntimeCpuBudget): boolean {
   return budget.reasons.includes('lowBucket') || budget.reasons.includes('criticalBucket');
+}
+
+function hasUsedOverLimitPressure(budget: RuntimeCpuBudget): boolean {
+  return budget.reasons.includes('usedOverLimit');
 }
 
 function updateRuntimeCpuTelemetryState(sample: RuntimeCpuSample): RuntimeCpuTelemetryState {

--- a/prod/test/cpuBudget.test.ts
+++ b/prod/test/cpuBudget.test.ts
@@ -139,6 +139,27 @@ describe('runtime CPU budget policy', () => {
     ).toBe(true);
   });
 
+  it('sheds optional work once the current tick exceeds its CPU limit', () => {
+    const budget = buildRuntimeCpuBudget({
+      tick: 222,
+      used: 71,
+      limit: 70,
+      bucket: 9_000,
+      tickLimit: 500
+    });
+
+    expect(budget).toMatchObject({
+      pressure: 'degraded',
+      degraded: true,
+      critical: false,
+      lowCpuLimit: false,
+      reasons: ['usedOverLimit']
+    });
+    expect(shouldRunOptionalCpuWork(budget, 'economy-global-optional')).toBe(false);
+    expect(shouldRunOptionalCpuRoomWork(budget, 'E29N55')).toBe(false);
+    expect(shouldShedNonessentialCpuWork(budget)).toBe(true);
+  });
+
   it('refreshes CPU used samples during the same game tick', () => {
     const getUsed = jest.fn().mockReturnValueOnce(21).mockReturnValueOnce(71);
     (globalThis as unknown as { Game: Partial<Game> }).Game = {

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -248,6 +248,33 @@ describe('runEconomy', () => {
     expect(shouldRunCreepForCpuBudget(creep('scout'), lowBucketBudget, probedRooms)).toBe(false);
   });
 
+  it('sheds nonessential creep roles after the current tick exceeds its CPU limit', () => {
+    const overLimitBudget = buildRuntimeCpuBudget({
+      tick: 127,
+      used: 71,
+      limit: 70,
+      bucket: 9_000,
+      tickLimit: 500
+    });
+    const room = {
+      name: 'W1N1',
+      controller: { my: true, ticksToDowngrade: CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS + 1 } as StructureController
+    } as Room;
+    const creep = (role: string, memory: Partial<CreepMemory> = {}): Creep =>
+      ({ memory: { role, ...memory }, room }) as unknown as Creep;
+    const probedRooms = new Set<string>();
+
+    expect(shouldRunCreepForCpuBudget(creep('worker'), overLimitBudget, probedRooms)).toBe(true);
+    expect(shouldRunCreepForCpuBudget(creep('sourceHarvester'), overLimitBudget, probedRooms)).toBe(true);
+    expect(shouldRunCreepForCpuBudget(creep('hauler'), overLimitBudget, probedRooms)).toBe(true);
+    expect(shouldRunCreepForCpuBudget(creep('crossRoomHauler'), overLimitBudget, probedRooms)).toBe(true);
+    expect(shouldRunCreepForCpuBudget(creep('upgrader'), overLimitBudget, probedRooms)).toBe(false);
+    expect(shouldRunCreepForCpuBudget(creep('remoteHarvester'), overLimitBudget, probedRooms)).toBe(false);
+    expect(shouldRunCreepForCpuBudget(creep('mineralHarvester'), overLimitBudget, probedRooms)).toBe(false);
+    expect(shouldRunCreepForCpuBudget(creep('claimer'), overLimitBudget, probedRooms)).toBe(false);
+    expect(shouldRunCreepForCpuBudget(creep('scout'), overLimitBudget, probedRooms)).toBe(false);
+  });
+
   it('spawns a worker request for an owned colony below target workers', () => {
     const room = { name: 'W1N1', energyAvailable: 300, energyCapacityAvailable: 300 } as Room;
     const spawn = {

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -567,6 +567,62 @@ describe('runtime telemetry summaries', () => {
     expect(onStrategyRegistryRuntimeUse).not.toHaveBeenCalled();
   });
 
+  it('omits optional room telemetry after the current tick exceeds its CPU limit', () => {
+    const worker = makeWorker(
+      {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'harvest', targetId: 'source1' as Id<Source> },
+        behaviorTelemetry: {
+          idleTicks: 1,
+          moveTicks: 0,
+          workTicks: 0,
+          stuckTicks: 0,
+          containerTransfers: 0,
+          sourceContainerWithdrawals: 0,
+          pathLength: 0,
+          lastObservedTick: RUNTIME_SUMMARY_INTERVAL * 5
+        },
+        workerEfficiency: {
+          type: 'nearbyEnergyChoice',
+          tick: RUNTIME_SUMMARY_INTERVAL * 5,
+          carriedEnergy: 5,
+          freeCapacity: 45,
+          selectedTask: 'pickup',
+          targetId: 'drop-1',
+          energy: 50,
+          range: 1
+        }
+      },
+      5,
+      'Worker1'
+    );
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL * 5,
+      creeps: [worker]
+    });
+    const onStrategyRegistryRuntimeUse = jest.fn();
+    (Game as Partial<Game>).cpu = {
+      getUsed: jest.fn().mockReturnValue(71),
+      limit: 70,
+      bucket: 9_000,
+      tickLimit: 500
+    } as unknown as CPU;
+
+    emitRuntimeSummary([colony], [worker], [], {
+      strategyRegistry: DEFAULT_STRATEGY_REGISTRY,
+      onStrategyRegistryRuntimeUse
+    });
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.constructionPriority).toEqual({ candidates: [], nextPrimary: null });
+    expect(room.territoryExpansion).toBeUndefined();
+    expect(room.behavior).toBeUndefined();
+    expect(room.workerEfficiency).toBeUndefined();
+    expect(onStrategyRegistryRuntimeUse).not.toHaveBeenCalled();
+  });
+
   it('reports per-creep behavior counters and resets emitted counters', () => {
     const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
     const worker = makeWorker(
@@ -3659,6 +3715,13 @@ describe('runtime telemetry summaries', () => {
       bucket: 43,
       tickLimit: 63
     });
+    const overLimitBudget = buildRuntimeCpuBudget({
+      tick: RUNTIME_SUMMARY_INTERVAL,
+      used: 71,
+      limit: 70,
+      bucket: 9_000,
+      tickLimit: 500
+    });
     const spawnEvent: RuntimeTelemetryEvent = {
       type: 'spawn',
       roomName: 'W1N1',
@@ -3697,6 +3760,9 @@ describe('runtime telemetry summaries', () => {
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [spawnEvent], criticalBucketBudget)).toBe(false);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [safeModeEvent], criticalBucketBudget)).toBe(true);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [damageOnlyDefenseEvent], criticalBucketBudget)).toBe(true);
+    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [spawnEvent], overLimitBudget)).toBe(false);
+    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL * 5, [spawnEvent], overLimitBudget)).toBe(true);
+    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [safeModeEvent], overLimitBudget)).toBe(true);
   });
 
   it('reports construction-priority runtime use from runtime summary scoring', () => {


### PR DESCRIPTION
## Related issue

- Related to #1490 (runtime acceptance stays on the issue until sustained post-deploy CPU proof is observed).

## Summary

- Treat `usedOverLimit` CPU samples as immediate degraded-pressure input for optional-work shedding.
- Stop optional global/room work, nonessential creep roles, and optional runtime-summary payloads after the current tick has already exceeded the CPU limit.
- Preserve survival/economy-critical creep roles and existing critical/low-bucket behavior.
- Regenerate `prod/dist/main.js` from the build.

## Verification

- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (104 suites / 2222 tests)
- `cd prod && npm run build`
- final `git diff --check`

## Universal task Done gate

- [x] Task type: production runtime CPU mitigation.
- [x] Expected observable outcome / named deliverable: optional Screeps work sheds immediately after over-limit CPU samples while critical survival/economy roles continue.
- [x] Non-goals / accepted substitutes: no owner action, no deploy from this PR branch, no paid compute, and no GitHub Project mutation by Codex.
- [x] Verification evidence required before Done: controller verification above passed on commit `e1154ec9`.
- [x] Project Evidence / Next action / Blocked by: controller will update #1490/PR Project fields with commit, checks, PR gate, deploy, and runtime CPU acceptance evidence.
- [x] Post-merge/deploy/runtime proof: acceptance artifacts are official deploy evidence plus runtime-alert/summary windows showing sustained CPU bucket above the P1 threshold.
- [x] Named deliverable proof: commit `e1154ec9` modifies `prod/src/runtime/cpuBudget.ts`, focused tests, and generated `prod/dist/main.js`.

## Notes

- No secrets touched or printed.
- Codex authored the implementation and commit: `e1154ec9 lanyusea's bot <lanyusea@gmail.com> fix: shed optional work after CPU over-limit samples`.