### PR TITLE
rl: bound E1 console capture export window

### DIFF
--- a/scripts/screeps_rl_dataset_export.py
+++ b/scripts/screeps_rl_dataset_export.py
@@ -37,6 +37,7 @@ CONSOLE_CAPTURE_INPUT_PATHS = (
     "/root/screeps/runtime-artifacts/runtime-summary-console",
     "runtime-artifacts/runtime-summary-console",
 )
+CONSOLE_CAPTURE_MAX_AGE_HOURS = 24.0
 DEFAULT_OUT_DIR = Path("runtime-artifacts/rl-datasets")
 DEFAULT_MAX_FILE_BYTES = 5 * 1024 * 1024
 DEFAULT_SAMPLE_LIMIT = 200
@@ -124,6 +125,16 @@ def eval_ratio(value: str) -> float:
     return parsed
 
 
+def positive_float(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be a number") from error
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a finite positive number")
+    return parsed
+
+
 def display_path(path: Path | str) -> str:
     text = str(path)
     try:
@@ -191,7 +202,7 @@ def collect_artifact_records(
     paths: Sequence[str],
     max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
     excluded_roots: Sequence[Path | str] = (),
-    max_age_hours: int | None = None,
+    max_age_hours: float | None = None,
     excluded_directory_names: Sequence[str] = (),
     binary_file_extensions: Sequence[str] = (),
     use_default_paths: bool = True,
@@ -897,6 +908,7 @@ def build_dataset(
     repo_root: Path | None = None,
     created_at: str | None = None,
     home_room: str | None = None,
+    source_max_age_hours: float | None = None,
 ) -> JsonObject:
     repo = repo_root or Path.cwd()
     resolved_bot_commit = bot_commit or git_commit(repo)
@@ -906,6 +918,7 @@ def build_dataset(
         paths,
         max_file_bytes=max_file_bytes,
         excluded_roots=[resolved_out_dir],
+        max_age_hours=source_max_age_hours,
         excluded_directory_names=GENERATED_ARTIFACT_DIRECTORY_NAMES,
     )
     filter_incomplete_derived_runtime_records(scan)
@@ -927,7 +940,7 @@ def build_dataset(
 
     runtime_lines = runtime_lines_from_records(scan.records)
     kpi_windows = reducer.reduce_runtime_kpis(runtime_lines)
-    source_index = build_source_index(scan)
+    source_index = build_source_index(scan, source_max_age_hours=source_max_age_hours)
     split_counts = count_splits(rows)
     scenario_manifest = build_scenario_manifest(resolved_run_id, scan, resolved_bot_commit)
     episodes = build_episodes(resolved_run_id, rows, kpi_windows)
@@ -940,6 +953,7 @@ def build_dataset(
         split_seed=split_seed,
         eval_ratio_value=eval_ratio_value,
         files=files,
+        source_max_age_hours=source_max_age_hours,
     )
     dataset_card = render_dataset_card(resolved_run_id, run_manifest, episodes)
 
@@ -974,6 +988,8 @@ def build_dataset(
         "runtimeSummaryArtifactCount": len(scan.records),
         "strategyShadowReportCount": len(scan.strategy_shadow_reports),
         "skippedFileCount": len(scan.skipped_files),
+        "skippedFileReasons": count_skipped_file_field(scan, "reason"),
+        **optional_source_max_age(source_max_age_hours),
         **build_skipped_sample_summary(scan),
         "splitCounts": split_counts,
         "files": files,
@@ -1346,13 +1362,20 @@ def count_skipped_sample_field(scan: ScanResult, field_name: str) -> JsonObject:
     return dict(sorted(counts.items(), key=lambda item: (-item[1], item[0])))
 
 
-def build_source_index(scan: ScanResult) -> JsonObject:
+def optional_source_max_age(source_max_age_hours: float | None) -> JsonObject:
+    if source_max_age_hours is None:
+        return {}
+    return {"sourceMaxAgeHours": source_max_age_hours}
+
+
+def build_source_index(scan: ScanResult, *, source_max_age_hours: float | None = None) -> JsonObject:
     skipped_file_summary = build_skipped_file_summary(scan)
     skipped_sample_summary = build_skipped_sample_summary(scan)
     return {
         "type": "screeps-rl-source-index",
         "schemaVersion": SCHEMA_VERSION,
         "inputPaths": redacted_input_paths(scan.input_paths),
+        **optional_source_max_age(source_max_age_hours),
         "scannedFiles": scan.scanned_files,
         "matchedArtifactCount": len(scan.records),
         "strategyShadowReportCount": len(scan.strategy_shadow_reports),
@@ -1435,6 +1458,7 @@ def build_run_manifest(
     split_seed: str,
     eval_ratio_value: float,
     files: JsonObject,
+    source_max_age_hours: float | None = None,
 ) -> JsonObject:
     action_surfaces = sorted(
         {
@@ -1462,11 +1486,13 @@ def build_run_manifest(
         "botCommit": bot_commit,
         "source": {
             "inputPaths": redacted_input_paths(scan.input_paths),
+            **optional_source_max_age(source_max_age_hours),
             "scannedFiles": scan.scanned_files,
             "sourceArtifactCount": len(scan.source_files),
             "matchedArtifactCount": len(scan.records),
             "strategyShadowReportCount": len(scan.strategy_shadow_reports),
             "skippedFileCount": len(scan.skipped_files),
+            "skippedFileReasons": count_skipped_file_field(scan, "reason"),
             **build_skipped_sample_summary(scan),
         },
         "strategy": {
@@ -1710,6 +1736,15 @@ def build_parser() -> argparse.ArgumentParser:
         default="screeps-rl-v1",
         help="Seed string for deterministic train/eval assignment.",
     )
+    parser.add_argument(
+        "--source-max-age-hours",
+        type=positive_float,
+        default=None,
+        help=(
+            "Skip source files older than this many hours by mtime. "
+            f"Default: {CONSOLE_CAPTURE_MAX_AGE_HOURS:g} in --console-capture-only mode, otherwise unbounded."
+        ),
+    )
     return parser
 
 
@@ -1724,6 +1759,9 @@ def resolve_cli_input_paths(args: argparse.Namespace, stderr: TextIO = sys.stder
 def main(argv: list[str] | None = None, stdout: TextIO = sys.stdout, stderr: TextIO = sys.stderr) -> int:
     args = build_parser().parse_args(argv)
     input_paths = resolve_cli_input_paths(args, stderr)
+    source_max_age_hours = args.source_max_age_hours
+    if args.console_capture_only and source_max_age_hours is None:
+        source_max_age_hours = CONSOLE_CAPTURE_MAX_AGE_HOURS
     summary = build_dataset(
         input_paths,
         args.out_dir,
@@ -1733,6 +1771,7 @@ def main(argv: list[str] | None = None, stdout: TextIO = sys.stdout, stderr: Tex
         sample_limit=args.sample_limit,
         eval_ratio_value=args.eval_ratio,
         split_seed=args.split_seed,
+        source_max_age_hours=source_max_age_hours,
     )
     stdout.write(json.dumps(summary, indent=2, sort_keys=True))
     stdout.write("\n")

--- a/scripts/screeps_rl_dataset_gate.py
+++ b/scripts/screeps_rl_dataset_gate.py
@@ -754,6 +754,10 @@ def dataset_source_diagnostics(
     runtime_summary_count = dataset_summary.get("runtimeSummaryArtifactCount")
     skipped_sample_count = dataset_summary.get("skippedSampleCount")
     skipped_sample_reasons = dataset_summary.get("skippedSampleReasons")
+    skipped_file_reasons = source.get("skippedFileReasons")
+    if not isinstance(skipped_file_reasons, dict):
+        skipped_file_reasons = dataset_summary.get("skippedFileReasons")
+    source_max_age_hours = source.get("sourceMaxAgeHours", dataset_summary.get("sourceMaxAgeHours"))
 
     if sample_count >= min_samples:
         return {
@@ -762,7 +766,17 @@ def dataset_source_diagnostics(
             "inputPaths": input_paths,
         }
 
-    if source_artifact_count == 0:
+    if (
+        source_artifact_count == 0
+        and isinstance(skipped_file_reasons, dict)
+        and int(skipped_file_reasons.get("older_than_max_age", 0)) > 0
+    ):
+        classification = "no_recent_source_artifacts_within_max_age"
+        recommended_action = (
+            "Refresh runtime-summary-console captures or increase the console-capture source window; "
+            f"all scanned source files were older than the configured {source_max_age_hours}h max age."
+        )
+    elif source_artifact_count == 0:
         classification = "no_source_artifacts_scanned"
         recommended_action = (
             "Point the full E1 gate at runtime-summary source artifacts, such as "
@@ -790,9 +804,11 @@ def dataset_source_diagnostics(
         "recommendedAction": recommended_action,
         "inputPaths": input_paths,
         "scannedFiles": source.get("scannedFiles"),
+        "sourceMaxAgeHours": source_max_age_hours,
         "sourceArtifactCount": source_artifact_count,
         "runtimeSummaryArtifactCount": runtime_summary_count,
         "skippedFileCount": source.get("skippedFileCount"),
+        "skippedFileReasons": skipped_file_reasons,
         "skippedSampleCount": skipped_sample_count,
         "skippedSampleReasons": skipped_sample_reasons,
     }

--- a/scripts/screeps_rl_dataset_gate.py
+++ b/scripts/screeps_rl_dataset_gate.py
@@ -741,6 +741,16 @@ def official_mmo_control_forbidden(value: Any) -> bool:
     return value is False or (isinstance(value, str) and value.startswith("forbidden"))
 
 
+def source_max_age_window_text(source_max_age_hours: Any) -> str:
+    if (
+        isinstance(source_max_age_hours, (int, float))
+        and not isinstance(source_max_age_hours, bool)
+        and math.isfinite(float(source_max_age_hours))
+    ):
+        return f"configured {source_max_age_hours:g}h max age"
+    return "configured max-age window"
+
+
 def dataset_source_diagnostics(
     dataset_summary: JsonObject,
     run_manifest: JsonObject,
@@ -774,7 +784,7 @@ def dataset_source_diagnostics(
         classification = "no_recent_source_artifacts_within_max_age"
         recommended_action = (
             "Refresh runtime-summary-console captures or increase the console-capture source window; "
-            f"all scanned source files were older than the configured {source_max_age_hours}h max age."
+            f"all scanned source files were older than the {source_max_age_window_text(source_max_age_hours)}."
         )
     elif source_artifact_count == 0:
         classification = "no_source_artifacts_scanned"

--- a/scripts/test_screeps_rl_dataset_export.py
+++ b/scripts/test_screeps_rl_dataset_export.py
@@ -267,6 +267,61 @@ class RlDatasetExportTest(unittest.TestCase):
         self.assertEqual(summary["sampleCount"], 1)
         self.assertEqual(summary["runtimeSummaryArtifactCount"], 1)
 
+    def test_console_capture_only_defaults_to_recent_source_window(self) -> None:
+        old_payload = {
+            "type": "runtime-summary",
+            "tick": 119,
+            "rooms": [{"roomName": "E26S49", "resources": {"storedEnergy": 10}}],
+        }
+        current_payload = {
+            "type": "runtime-summary",
+            "tick": 120,
+            "rooms": [{"roomName": "E29N55", "resources": {"storedEnergy": 250}}],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            console_root = root / "runtime-summary-console"
+            console_root.mkdir()
+            old_artifact = console_root / "runtime-summary-console-20260510T173515Z.log"
+            current_artifact = console_root / "runtime-summary-console-20260603T150458Z.log"
+            old_artifact.write_text(runtime_line(old_payload), encoding="utf-8")
+            current_artifact.write_text(runtime_line(current_payload), encoding="utf-8")
+            os.utime(old_artifact, (0, 0))
+            out_dir = root / "datasets"
+            stdout = io.StringIO()
+
+            with mock.patch.object(exporter, "CONSOLE_CAPTURE_INPUT_PATHS", (str(console_root),)):
+                exit_code = exporter.main(
+                    [
+                        "--console-capture-only",
+                        "--out-dir",
+                        str(out_dir),
+                        "--run-id",
+                        "recent-console-capture-run",
+                        "--bot-commit",
+                        "1" * 40,
+                    ],
+                    stdout=stdout,
+                    stderr=io.StringIO(),
+                )
+
+            summary = json.loads(stdout.getvalue())
+            rows = read_ndjson(out_dir / "recent-console-capture-run" / "ticks.ndjson")
+            source_index = read_json(out_dir / "recent-console-capture-run" / "source_index.json")
+            run_manifest = read_json(out_dir / "recent-console-capture-run" / "run_manifest.json")
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(summary["sampleCount"], 1)
+        self.assertEqual(summary["runtimeSummaryArtifactCount"], 1)
+        self.assertEqual(summary["skippedFileReasons"], {"older_than_max_age": 1})
+        self.assertEqual(summary["sourceMaxAgeHours"], exporter.CONSOLE_CAPTURE_MAX_AGE_HOURS)
+        self.assertEqual(rows[0]["observation"]["roomName"], "E29N55")
+        self.assertEqual(source_index["sourceMaxAgeHours"], exporter.CONSOLE_CAPTURE_MAX_AGE_HOURS)
+        self.assertEqual(source_index["skippedFileReasons"], {"older_than_max_age": 1})
+        self.assertEqual(run_manifest["source"]["sourceMaxAgeHours"], exporter.CONSOLE_CAPTURE_MAX_AGE_HOURS)
+        self.assertEqual(run_manifest["source"]["skippedFileReasons"], {"older_than_max_age": 1})
+
     def test_duplicate_input_roots_are_scanned_once(self) -> None:
         payload = {
             "type": "runtime-summary",

--- a/scripts/test_screeps_rl_dataset_gate.py
+++ b/scripts/test_screeps_rl_dataset_gate.py
@@ -379,6 +379,31 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
         self.assertEqual(diagnostics["sourceMaxAgeHours"], dataset_export.CONSOLE_CAPTURE_MAX_AGE_HOURS)
         self.assertEqual(diagnostics["skippedFileReasons"], {"older_than_max_age": 12})
         self.assertIn("Refresh runtime-summary-console captures", diagnostics["recommendedAction"])
+        self.assertIn("configured 24h max age", diagnostics["recommendedAction"])
+
+    def test_stale_only_source_window_uses_fallback_when_max_age_missing(self) -> None:
+        diagnostics = gate.dataset_source_diagnostics(
+            {
+                "sampleCount": 0,
+                "sourceArtifactCount": 0,
+                "runtimeSummaryArtifactCount": 0,
+                "skippedFileReasons": {"older_than_max_age": 3},
+            },
+            {
+                "source": {
+                    "inputPaths": ["runtime-artifacts/runtime-summary-console"],
+                    "skippedFileReasons": {"older_than_max_age": 3},
+                },
+            },
+            sample_count=0,
+            min_samples=1,
+        )
+
+        self.assertEqual(diagnostics["status"], "blocked")
+        self.assertEqual(diagnostics["classification"], "no_recent_source_artifacts_within_max_age")
+        self.assertIsNone(diagnostics["sourceMaxAgeHours"])
+        self.assertIn("configured max-age window", diagnostics["recommendedAction"])
+        self.assertNotIn("Noneh", diagnostics["recommendedAction"])
 
     def test_run_rejects_dead_room_dataset_samples(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_dataset_gate.py
+++ b/scripts/test_screeps_rl_dataset_gate.py
@@ -317,6 +317,69 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
             "no_runtime_summary_artifacts",
         )
 
+    def test_stale_only_source_window_reports_recent_capture_blocker(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_dir = root / "datasets" / "stale-only-run"
+            run_dir.mkdir(parents=True)
+            file_paths = {
+                "runDir": run_dir,
+                "scenarioManifest": run_dir / "scenario_manifest.json",
+                "runManifest": run_dir / "run_manifest.json",
+                "sourceIndex": run_dir / "source_index.json",
+                "ticks": run_dir / "ticks.ndjson",
+                "kpiWindows": run_dir / "kpi_windows.json",
+                "episodes": run_dir / "episodes.json",
+                "datasetCard": run_dir / "dataset_card.md",
+            }
+            for key, path in file_paths.items():
+                if key == "runDir":
+                    continue
+                path.write_text("{}\n", encoding="utf-8")
+
+            dataset_summary = {
+                "ok": True,
+                "runId": "stale-only-run",
+                "sampleCount": 0,
+                "sourceArtifactCount": 0,
+                "runtimeSummaryArtifactCount": 0,
+                "skippedFileCount": 12,
+                "skippedFileReasons": {"older_than_max_age": 12},
+                "skippedSampleCount": 0,
+                "skippedSampleReasons": {},
+                "splitCounts": {},
+            }
+            run_manifest = {
+                "type": dataset_export.RUN_MANIFEST_TYPE,
+                "source": {
+                    "inputPaths": ["runtime-artifacts/runtime-summary-console"],
+                    "sourceMaxAgeHours": dataset_export.CONSOLE_CAPTURE_MAX_AGE_HOURS,
+                    "scannedFiles": 0,
+                    "sourceArtifactCount": 0,
+                    "matchedArtifactCount": 0,
+                    "skippedFileCount": 12,
+                    "skippedFileReasons": {"older_than_max_age": 12},
+                },
+                "strategy": {"liveEffect": False},
+                "safety": {"officialMmoControl": "forbidden until offline gates pass"},
+            }
+
+            readiness = gate.evaluate_dataset_readiness(
+                dataset_summary,
+                file_paths,
+                run_manifest,
+                ticks_count=0,
+                min_samples=1,
+            )
+
+        diagnostics = readiness["diagnostics"]
+        self.assertEqual(readiness["status"], "fail")
+        self.assertEqual(diagnostics["status"], "blocked")
+        self.assertEqual(diagnostics["classification"], "no_recent_source_artifacts_within_max_age")
+        self.assertEqual(diagnostics["sourceMaxAgeHours"], dataset_export.CONSOLE_CAPTURE_MAX_AGE_HOURS)
+        self.assertEqual(diagnostics["skippedFileReasons"], {"older_than_max_age": 12})
+        self.assertIn("Refresh runtime-summary-console captures", diagnostics["recommendedAction"])
+
     def test_run_rejects_dead_room_dataset_samples(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary

- Adds a bounded source-age window for `--console-capture-only` dataset exports so the E1 no-agent shadow-eval cron scans recent runtime-summary-console captures instead of every historical capture.
- Propagates `sourceMaxAgeHours` and skipped-file reason summaries into dataset/source manifests so empty recent windows degrade into an actionable diagnostic.
- Adds export and dataset-gate tests for the recent-window behavior and stale-only diagnostic path.

Fixes #1639

## Verification

- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_dataset_export.py scripts/screeps_rl_dataset_gate.py scripts/test_screeps_rl_dataset_export.py scripts/test_screeps_rl_dataset_gate.py`
- `python3 -m unittest scripts.test_screeps_rl_dataset_export scripts.test_screeps_rl_dataset_gate -v` — 41 tests OK
- Controller cron-equivalent export proof from this branch: `--console-capture-only --sample-limit 100 --eval-ratio 0.50` completed in 2.256s within the 100s E1 timeout, `sampleCount=100`, `splitCounts={"train":45,"eval":55}`, `runtimeSummaryArtifactCount=81`, `sourceMaxAgeHours=24.0`, `skippedFileReasons={"older_than_max_age":5821,...}`, readiness `status=pass`.
- Safety proof: offline dataset/export only; no official MMO writes; no live API writes.

## Issue closure gate

- [x] #1639: bounded recent-source export and stale-window diagnostics address the E1 `export_timeout`; controller proof completed the cron-equivalent export in 2.256s under the 100s timeout and readiness returned pass.

## Universal task Done gate

- [x] Task type: RL flywheel bug fix for script-only dataset export and readiness diagnostics.
- [x] Expected observable outcome / named deliverable: E1 shadow-eval bounded gate export completes from recent console captures within the cron timeout or reports an actionable stale-source diagnostic artifact.
- [x] Non-goals / accepted substitutes: no Tencent compute, no official MMO writes, no cron schedule changes, and no live Screeps API writes.
- [x] Verification evidence required before Done: diff check, py_compile, 41 focused unittests, and cron-equivalent export/readiness proof all pass from the issue worktree.
- [x] Project Evidence / Next action / Blocked by: Project fields identify this PR plus commit `e523a4ec`; Next action is exact-head checks and automated review; Blocked by field is empty.
- [x] Post-merge/deploy/runtime proof: cron-equivalent local run produced `sampleCount=100`, `eval=55`, `sourceMaxAgeHours=24.0`, and readiness pass in 2.256s.
- [x] Named deliverable proof: the changed exporter/gate scripts expose the bounded recent-source behavior and actionable `no_recent_source_artifacts_within_max_age` diagnostic covered by focused tests.
