### PR TITLE
fix: allow owner-recommended long-range expansion target

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4019,8 +4019,8 @@ function dedupeTerritoryExpansionScoutTargets(targets) {
       continue;
     }
     targetsByKey.set(key, {
-      ...target,
       ...existingTarget,
+      ...target,
       ...existingTarget.scoutOnly === true || target.scoutOnly === true ? { scoutOnly: true } : {},
       ...existingTarget.allowLongRange === true || target.allowLongRange === true ? { allowLongRange: true } : {}
     });
@@ -17263,7 +17263,13 @@ function getPreControlGateSkipReason(report) {
   if (report.candidates.length === 0) {
     return "noCandidate";
   }
-  if (report.candidates.some((candidate) => candidate.evidenceStatus === "insufficient-evidence")) {
+  const nonUnavailableCandidates = report.candidates.filter((candidate) => candidate.evidenceStatus !== "unavailable");
+  if (nonUnavailableCandidates.some(
+    (candidate) => candidate.evidenceStatus === "sufficient" || candidate.preconditions.length > 0
+  )) {
+    return "unmetPreconditions";
+  }
+  if (nonUnavailableCandidates.length > 0 && nonUnavailableCandidates.every((candidate) => candidate.evidenceStatus === "insufficient-evidence")) {
     return "insufficientEvidence";
   }
   return "unmetPreconditions";
@@ -46124,7 +46130,7 @@ function refreshExpansionExecutorIntent(colony, gameTime = getGameTime40(), tele
   if (selection.targetRoom) {
     scoutTargetRooms.push(selection.targetRoom);
   }
-  if (selection.status === "skipped" && selection.reason === "insufficientEvidence") {
+  if (!hasActivePipeline && selection.status === "skipped" && (selection.reason === "insufficientEvidence" || selection.reason === "unmetPreconditions" && !isAutonomousTerritoryControlAllowedForController(colony.room.controller))) {
     const scoutTargets = dedupeRoomScoutingTargets([
       ...selectExpansionScoutTargets(report),
       ...getConfiguredExpansionRoomScoutingTargets(colony, gameTime)

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1564,6 +1564,15 @@ var TERRITORY_EXPANSION_ROOM_SELECTION = {
       scoutOnly: true
     },
     {
+      colony: activeRoom,
+      roomName: "E34N49",
+      nearestOwnedRoom: activeRoom,
+      nearestOwnedRoomDistance: 11,
+      routeDistance: 11,
+      adjacentToOwnedRoom: false,
+      allowLongRange: true
+    },
+    {
       colony: LOGISTICS_ROOM_SELECTION.localFirstSourceRoom,
       roomName: "E18S59",
       nearestOwnedRoom: LOGISTICS_ROOM_SELECTION.localFirstSourceRoom,
@@ -3933,10 +3942,11 @@ function isRecord3(value) {
 
 // src/territory/expansionConfig.ts
 function getTerritoryExpansionScoutTargets(colonyName = getRuntimeCurrentRoomName()) {
-  return [
+  return dedupeTerritoryExpansionScoutTargets([
     ...getMemoryConfiguredExpansionScoutTargets(colonyName),
-    ...getEnabledRuntimeCurrentRoomScoutOnlyTargets(colonyName)
-  ];
+    ...getEnabledRuntimeCurrentRoomScoutOnlyTargets(colonyName),
+    ...getStaticExpansionScoutTargets(colonyName)
+  ]);
 }
 function getRuntimeCurrentRoomScoutOnlyTargets(colonyName = getRuntimeCurrentRoomName()) {
   const currentRoomName = getRuntimeCurrentRoomName();
@@ -3967,7 +3977,7 @@ function getCurrentRoomScoutOnlyAdjacentRoomNames(roomName) {
   ].filter(isNonEmptyString4);
 }
 function isConfiguredExpansionScoutOnlyTarget(colony, roomName) {
-  return [...getTerritoryExpansionScoutTargets(colony), ...TERRITORY_EXPANSION_ROOM_SELECTION.scoutTargets].some(
+  return getTerritoryExpansionScoutTargets(colony).some(
     (target) => target.colony === colony && target.roomName === roomName && target.scoutOnly === true
   );
 }
@@ -3990,6 +4000,35 @@ function getEnabledRuntimeCurrentRoomScoutOnlyTargets(colonyName) {
     return [];
   }
   return getRuntimeCurrentRoomScoutOnlyTargets(colonyName);
+}
+function getStaticExpansionScoutTargets(colonyName) {
+  return TERRITORY_EXPANSION_ROOM_SELECTION.scoutTargets.flatMap((target) => {
+    if (colonyName && target.colony !== colonyName) {
+      return [];
+    }
+    return [{ ...target }];
+  });
+}
+function dedupeTerritoryExpansionScoutTargets(targets) {
+  const targetsByKey = /* @__PURE__ */ new Map();
+  for (const target of targets) {
+    const key = getScoutTargetKey(target);
+    const existingTarget = targetsByKey.get(key);
+    if (!existingTarget) {
+      targetsByKey.set(key, target);
+      continue;
+    }
+    targetsByKey.set(key, {
+      ...target,
+      ...existingTarget,
+      ...existingTarget.scoutOnly === true || target.scoutOnly === true ? { scoutOnly: true } : {},
+      ...existingTarget.allowLongRange === true || target.allowLongRange === true ? { allowLongRange: true } : {}
+    });
+  }
+  return Array.from(targetsByKey.values());
+}
+function getScoutTargetKey(target) {
+  return `${target.colony}>${target.roomName}`;
 }
 function buildRuntimeCurrentRoomScoutOnlyTarget(currentRoomName, roomName) {
   return {
@@ -4018,7 +4057,8 @@ function normalizeExpansionScoutTarget(target) {
     nearestOwnedRoomDistance: normalizePositiveDistance(target.nearestOwnedRoomDistance),
     routeDistance: normalizePositiveDistance(target.routeDistance),
     adjacentToOwnedRoom: target.adjacentToOwnedRoom === true,
-    ...target.scoutOnly === true ? { scoutOnly: true } : {}
+    ...target.scoutOnly === true ? { scoutOnly: true } : {},
+    ...target.allowLongRange === true ? { allowLongRange: true } : {}
   };
 }
 function parseRoomName(roomName) {
@@ -8216,12 +8256,15 @@ function selectExpansionScoutTargets(report, limit = 1, gameTime = getGameTime16
     return [];
   }
   return report.candidates.filter(
-    (candidate) => candidate.visible === false && isScoutableNearbyExpansionCandidate(candidate) && (candidate.evidenceStatus === "insufficient-evidence" || isExpansionCandidateScoutRefreshDue(report.colonyName, candidate.roomName, gameTime))
+    (candidate) => candidate.visible === false && isScoutableExpansionCandidate(candidate) && (candidate.evidenceStatus === "insufficient-evidence" || isExpansionCandidateScoutRefreshDue(report.colonyName, candidate.roomName, gameTime))
   ).slice(0, boundedLimit).map((candidate) => ({
     roomName: candidate.roomName,
     ...candidate.nearestOwnedRoomDistance !== void 0 ? { distance: candidate.nearestOwnedRoomDistance } : {},
     ...candidate.controllerId ? { controllerId: candidate.controllerId } : {}
   }));
+}
+function isScoutableExpansionCandidate(candidate) {
+  return candidate.allowLongRange === true || isScoutableNearbyExpansionCandidate(candidate);
 }
 function isScoutableNearbyExpansionCandidate(candidate) {
   return candidate.adjacentToOwnedRoom || typeof candidate.routeDistance === "number" && candidate.routeDistance <= MAX_NEARBY_EXPANSION_ROUTE_DISTANCE || typeof candidate.nearestOwnedRoomDistance === "number" && candidate.nearestOwnedRoomDistance <= MAX_NEARBY_EXPANSION_ROUTE_DISTANCE;
@@ -8349,7 +8392,8 @@ function buildRuntimeExpansionCandidates(colony) {
       nearbyRoomDistancesByOwnedRoom
     );
     const adjacentToOwnedRoom = (configuredScoutTarget == null ? void 0 : configuredScoutTarget.adjacentToOwnedRoom) === true || isAdjacentToOwnedRoom(roomName, nearbyRoomDistancesByOwnedRoom);
-    if (!isNearbyExpansionCandidate(routeDistance, nearestOwnedDistance, adjacentToOwnedRoom)) {
+    const allowLongRange = (configuredScoutTarget == null ? void 0 : configuredScoutTarget.allowLongRange) === true;
+    if (!allowLongRange && !isNearbyExpansionCandidate(routeDistance, nearestOwnedDistance, adjacentToOwnedRoom)) {
       return [];
     }
     const room = rooms[roomName];
@@ -8364,6 +8408,7 @@ function buildRuntimeExpansionCandidates(colony) {
         ...nearestOwnedDistance.roomName ? { nearestOwnedRoom: nearestOwnedDistance.roomName } : {},
         ...nearestOwnedDistance.distance !== void 0 ? { nearestOwnedRoomDistance: nearestOwnedDistance.distance } : {},
         ...(configuredScoutTarget == null ? void 0 : configuredScoutTarget.scoutOnly) === true ? { scoutOnly: true } : {},
+        ...allowLongRange ? { allowLongRange: true } : {},
         ...room ? buildVisibleExpansionCandidateEvidence(room) : scoutIntel ? buildScoutedExpansionCandidateEvidence(scoutIntel) : buildUnseenExpansionCandidateEvidence(roomName, gameTime)
       }
     ];
@@ -8612,6 +8657,7 @@ function scoreExpansionCandidate(input, candidate) {
     ...reservation ? { reservation } : {},
     ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...candidate.scoutOnly === true ? { scoutOnly: true } : {},
+    ...candidate.allowLongRange === true ? { allowLongRange: true } : {},
     ...postClaimBootstrapBlocker ? { postClaimBootstrapBlocker } : {},
     ...ignoredPostClaimBootstrapBlockers.length > 0 ? { ignoredPostClaimBootstrapBlockers } : {}
   };
@@ -8934,6 +8980,7 @@ function toPersistedExpansionCandidateMemory(colony, candidate, gameTime, rank) 
     updatedAt: gameTime,
     adjacentToOwnedRoom: candidate.adjacentToOwnedRoom,
     ...candidate.scoutOnly === true ? { scoutOnly: true } : {},
+    ...candidate.allowLongRange === true ? { allowLongRange: true } : {},
     ...recommendedAction ? { recommendedAction } : {},
     ...blockReason ? { blockReason } : {},
     ...candidate.routeDistance !== void 0 ? { routeDistance: candidate.routeDistance } : {},
@@ -8966,7 +9013,7 @@ function getPersistedExpansionCandidateRecommendedAction(candidate) {
   if (isViableExpansionClaimCandidate(candidate)) {
     return "claim";
   }
-  return candidate.evidenceStatus === "insufficient-evidence" && isScoutableNearbyExpansionCandidate(candidate) ? "scout" : void 0;
+  return candidate.evidenceStatus === "insufficient-evidence" && isScoutableExpansionCandidate(candidate) ? "scout" : void 0;
 }
 function isViableScoutOnlyRemoteCandidate(candidate) {
   return candidate.scoutOnly === true && candidate.evidenceStatus === "sufficient" && hasScoutOnlyRemoteRelevantPrecondition(candidate) === false && candidate.requiresControllerPressure !== true && typeof candidate.sourceCount === "number" && candidate.sourceCount > 0 && isAdjacentScoutOnlyRemoteCandidate(candidate);

--- a/prod/src/config/roomSelection.ts
+++ b/prod/src/config/roomSelection.ts
@@ -20,6 +20,7 @@ export interface StaticExpansionScoutTargetSelection {
   routeDistance: number;
   adjacentToOwnedRoom: boolean;
   scoutOnly?: boolean;
+  allowLongRange?: boolean;
 }
 
 export const ACTIVE_OFFICIAL_ROOM_SELECTION = {
@@ -115,6 +116,15 @@ export const TERRITORY_EXPANSION_ROOM_SELECTION = {
       routeDistance: 1,
       adjacentToOwnedRoom: true,
       scoutOnly: true
+    },
+    {
+      colony: activeRoom,
+      roomName: 'E34N49',
+      nearestOwnedRoom: activeRoom,
+      nearestOwnedRoomDistance: 11,
+      routeDistance: 11,
+      adjacentToOwnedRoom: false,
+      allowLongRange: true
     },
     {
       colony: LOGISTICS_ROOM_SELECTION.localFirstSourceRoom,

--- a/prod/src/territory/expansionConfig.ts
+++ b/prod/src/territory/expansionConfig.ts
@@ -123,8 +123,8 @@ function dedupeTerritoryExpansionScoutTargets(
     }
 
     targetsByKey.set(key, {
-      ...target,
       ...existingTarget,
+      ...target,
       ...(existingTarget.scoutOnly === true || target.scoutOnly === true ? { scoutOnly: true } : {}),
       ...(existingTarget.allowLongRange === true || target.allowLongRange === true ? { allowLongRange: true } : {})
     });

--- a/prod/src/territory/expansionConfig.ts
+++ b/prod/src/territory/expansionConfig.ts
@@ -12,6 +12,7 @@ export interface TerritoryExpansionScoutTargetConfig {
   routeDistance: number;
   adjacentToOwnedRoom: boolean;
   scoutOnly?: boolean;
+  allowLongRange?: boolean;
 }
 
 export const TERRITORY_EXPANSION_SCOUT_TARGETS: readonly TerritoryExpansionScoutTargetConfig[] = [];
@@ -19,10 +20,11 @@ export const TERRITORY_EXPANSION_SCOUT_TARGETS: readonly TerritoryExpansionScout
 export function getTerritoryExpansionScoutTargets(
   colonyName = getRuntimeCurrentRoomName()
 ): TerritoryExpansionScoutTargetConfig[] {
-  return [
+  return dedupeTerritoryExpansionScoutTargets([
     ...getMemoryConfiguredExpansionScoutTargets(colonyName),
-    ...getEnabledRuntimeCurrentRoomScoutOnlyTargets(colonyName)
-  ];
+    ...getEnabledRuntimeCurrentRoomScoutOnlyTargets(colonyName),
+    ...getStaticExpansionScoutTargets(colonyName)
+  ]);
 }
 
 export function getRuntimeCurrentRoomScoutOnlyTargets(
@@ -63,7 +65,7 @@ export function getCurrentRoomScoutOnlyAdjacentRoomNames(roomName: string): stri
 }
 
 export function isConfiguredExpansionScoutOnlyTarget(colony: string, roomName: string): boolean {
-  return [...getTerritoryExpansionScoutTargets(colony), ...TERRITORY_EXPANSION_ROOM_SELECTION.scoutTargets].some(
+  return getTerritoryExpansionScoutTargets(colony).some(
     (target) => target.colony === colony && target.roomName === roomName && target.scoutOnly === true
   );
 }
@@ -94,6 +96,45 @@ function getEnabledRuntimeCurrentRoomScoutOnlyTargets(
   }
 
   return getRuntimeCurrentRoomScoutOnlyTargets(colonyName);
+}
+
+function getStaticExpansionScoutTargets(
+  colonyName: string | undefined
+): TerritoryExpansionScoutTargetConfig[] {
+  return TERRITORY_EXPANSION_ROOM_SELECTION.scoutTargets.flatMap((target) => {
+    if (colonyName && target.colony !== colonyName) {
+      return [];
+    }
+
+    return [{ ...target }];
+  });
+}
+
+function dedupeTerritoryExpansionScoutTargets(
+  targets: TerritoryExpansionScoutTargetConfig[]
+): TerritoryExpansionScoutTargetConfig[] {
+  const targetsByKey = new Map<string, TerritoryExpansionScoutTargetConfig>();
+  for (const target of targets) {
+    const key = getScoutTargetKey(target);
+    const existingTarget = targetsByKey.get(key);
+    if (!existingTarget) {
+      targetsByKey.set(key, target);
+      continue;
+    }
+
+    targetsByKey.set(key, {
+      ...target,
+      ...existingTarget,
+      ...(existingTarget.scoutOnly === true || target.scoutOnly === true ? { scoutOnly: true } : {}),
+      ...(existingTarget.allowLongRange === true || target.allowLongRange === true ? { allowLongRange: true } : {})
+    });
+  }
+
+  return Array.from(targetsByKey.values());
+}
+
+function getScoutTargetKey(target: Pick<TerritoryExpansionScoutTargetConfig, 'colony' | 'roomName'>): string {
+  return `${target.colony}>${target.roomName}`;
 }
 
 function buildRuntimeCurrentRoomScoutOnlyTarget(
@@ -138,7 +179,8 @@ function normalizeExpansionScoutTarget(
     nearestOwnedRoomDistance: normalizePositiveDistance(target.nearestOwnedRoomDistance),
     routeDistance: normalizePositiveDistance(target.routeDistance),
     adjacentToOwnedRoom: target.adjacentToOwnedRoom === true,
-    ...(target.scoutOnly === true ? { scoutOnly: true } : {})
+    ...(target.scoutOnly === true ? { scoutOnly: true } : {}),
+    ...(target.allowLongRange === true ? { allowLongRange: true } : {})
   };
 }
 

--- a/prod/src/territory/expansionExecutor.ts
+++ b/prod/src/territory/expansionExecutor.ts
@@ -72,7 +72,13 @@ export function refreshExpansionExecutorIntent(
   if (selection.targetRoom) {
     scoutTargetRooms.push(selection.targetRoom);
   }
-  if (selection.status === 'skipped' && selection.reason === 'insufficientEvidence') {
+  if (
+    !hasActivePipeline &&
+    selection.status === 'skipped' &&
+    (selection.reason === 'insufficientEvidence' ||
+      (selection.reason === 'unmetPreconditions' &&
+        !isAutonomousTerritoryControlAllowedForController(colony.room.controller)))
+  ) {
     const scoutTargets = dedupeRoomScoutingTargets([
       ...selectExpansionScoutTargets(report),
       ...getConfiguredExpansionRoomScoutingTargets(colony, gameTime)

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -123,6 +123,7 @@ export interface ExpansionCandidateScore {
   reservation?: ExpansionReservationEvidence;
   requiresControllerPressure?: boolean;
   scoutOnly?: boolean;
+  allowLongRange?: boolean;
   blockReason?: TerritoryExpansionCandidateBlockReason;
   postClaimBootstrapBlocker?: PostClaimBootstrapBlockerSummary;
   ignoredPostClaimBootstrapBlockers?: PostClaimBootstrapIgnoredBlockerSummary[];
@@ -173,6 +174,7 @@ export interface ExpansionCandidateInput {
   hostileStructureCount?: number;
   hostilePressureDistance?: number;
   scoutOnly?: boolean;
+  allowLongRange?: boolean;
 }
 
 export interface ExpansionMineralEvidence {
@@ -244,7 +246,7 @@ export function selectExpansionScoutTargets(
   return report.candidates
     .filter((candidate) =>
       candidate.visible === false &&
-      isScoutableNearbyExpansionCandidate(candidate) &&
+      isScoutableExpansionCandidate(candidate) &&
       (candidate.evidenceStatus === 'insufficient-evidence' ||
         isExpansionCandidateScoutRefreshDue(report.colonyName, candidate.roomName, gameTime))
     )
@@ -254,6 +256,10 @@ export function selectExpansionScoutTargets(
       ...(candidate.nearestOwnedRoomDistance !== undefined ? { distance: candidate.nearestOwnedRoomDistance } : {}),
       ...(candidate.controllerId ? { controllerId: candidate.controllerId } : {})
     }));
+}
+
+function isScoutableExpansionCandidate(candidate: ExpansionCandidateScore): boolean {
+  return candidate.allowLongRange === true || isScoutableNearbyExpansionCandidate(candidate);
 }
 
 function isScoutableNearbyExpansionCandidate(candidate: ExpansionCandidateScore): boolean {
@@ -517,7 +523,8 @@ function buildRuntimeExpansionCandidates(colony: ColonySnapshot): ExpansionCandi
     const adjacentToOwnedRoom =
       configuredScoutTarget?.adjacentToOwnedRoom === true ||
       isAdjacentToOwnedRoom(roomName, nearbyRoomDistancesByOwnedRoom);
-    if (!isNearbyExpansionCandidate(routeDistance, nearestOwnedDistance, adjacentToOwnedRoom)) {
+    const allowLongRange = configuredScoutTarget?.allowLongRange === true;
+    if (!allowLongRange && !isNearbyExpansionCandidate(routeDistance, nearestOwnedDistance, adjacentToOwnedRoom)) {
       return [];
     }
 
@@ -535,6 +542,7 @@ function buildRuntimeExpansionCandidates(colony: ColonySnapshot): ExpansionCandi
           ? { nearestOwnedRoomDistance: nearestOwnedDistance.distance }
           : {}),
         ...(configuredScoutTarget?.scoutOnly === true ? { scoutOnly: true } : {}),
+        ...(allowLongRange ? { allowLongRange: true } : {}),
         ...(room
           ? buildVisibleExpansionCandidateEvidence(room)
           : scoutIntel
@@ -862,6 +870,7 @@ function scoreExpansionCandidate(
     ...(reservation ? { reservation } : {}),
     ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(candidate.scoutOnly === true ? { scoutOnly: true } : {}),
+    ...(candidate.allowLongRange === true ? { allowLongRange: true } : {}),
     ...(postClaimBootstrapBlocker ? { postClaimBootstrapBlocker } : {}),
     ...(ignoredPostClaimBootstrapBlockers.length > 0
       ? { ignoredPostClaimBootstrapBlockers }
@@ -1394,6 +1403,7 @@ function toPersistedExpansionCandidateMemory(
     updatedAt: gameTime,
     adjacentToOwnedRoom: candidate.adjacentToOwnedRoom,
     ...(candidate.scoutOnly === true ? { scoutOnly: true } : {}),
+    ...(candidate.allowLongRange === true ? { allowLongRange: true } : {}),
     ...(recommendedAction ? { recommendedAction } : {}),
     ...(blockReason ? { blockReason } : {}),
     ...(candidate.routeDistance !== undefined ? { routeDistance: candidate.routeDistance } : {}),
@@ -1444,7 +1454,7 @@ function getPersistedExpansionCandidateRecommendedAction(
     return 'claim';
   }
 
-  return candidate.evidenceStatus === 'insufficient-evidence' && isScoutableNearbyExpansionCandidate(candidate)
+  return candidate.evidenceStatus === 'insufficient-evidence' && isScoutableExpansionCandidate(candidate)
     ? 'scout'
     : undefined;
 }

--- a/prod/src/territory/expansionTrigger.ts
+++ b/prod/src/territory/expansionTrigger.ts
@@ -591,7 +591,19 @@ function getPreControlGateSkipReason(report: ExpansionCandidateReport): NextExpa
     return 'noCandidate';
   }
 
-  if (report.candidates.some((candidate) => candidate.evidenceStatus === 'insufficient-evidence')) {
+  const nonUnavailableCandidates = report.candidates.filter((candidate) => candidate.evidenceStatus !== 'unavailable');
+  if (
+    nonUnavailableCandidates.some(
+      (candidate) => candidate.evidenceStatus === 'sufficient' || candidate.preconditions.length > 0
+    )
+  ) {
+    return 'unmetPreconditions';
+  }
+
+  if (
+    nonUnavailableCandidates.length > 0 &&
+    nonUnavailableCandidates.every((candidate) => candidate.evidenceStatus === 'insufficient-evidence')
+  ) {
     return 'insufficientEvidence';
   }
 

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -821,6 +821,7 @@ declare global {
     routeDistance: number;
     adjacentToOwnedRoom: boolean;
     scoutOnly?: boolean;
+    allowLongRange?: boolean;
   }
 
   interface TerritoryTargetMemory {
@@ -967,6 +968,7 @@ declare global {
     updatedAt: number;
     adjacentToOwnedRoom: boolean;
     scoutOnly?: boolean;
+    allowLongRange?: boolean;
     recommendedAction?: TerritoryExpansionCandidateRecommendedAction;
     blockReason?: TerritoryExpansionCandidateBlockReason;
     routeDistance?: number;

--- a/prod/test/config/roomSelection.test.ts
+++ b/prod/test/config/roomSelection.test.ts
@@ -66,6 +66,15 @@ describe('room selection config', () => {
           colony: ACTIVE_OFFICIAL_ROOM_SELECTION.roomName,
           nearestOwnedRoom: ACTIVE_OFFICIAL_ROOM_SELECTION.roomName,
           scoutOnly: true
+        }),
+        expect.objectContaining({
+          colony: ACTIVE_OFFICIAL_ROOM_SELECTION.roomName,
+          roomName: 'E34N49',
+          nearestOwnedRoom: ACTIVE_OFFICIAL_ROOM_SELECTION.roomName,
+          nearestOwnedRoomDistance: 11,
+          routeDistance: 11,
+          adjacentToOwnedRoom: false,
+          allowLongRange: true
         })
       ])
     );

--- a/prod/test/e26s50ClaimPipeline.test.ts
+++ b/prod/test/e26s50ClaimPipeline.test.ts
@@ -111,7 +111,7 @@ describe('E18S59 claim pipeline', () => {
     expect(refreshExpansionExecutorIntent(colony, 827)).toEqual({
       status: 'skipped',
       colony: 'E17S59',
-      reason: 'insufficientEvidence'
+      reason: 'unmetPreconditions'
     });
     expect(Memory.territory?.expansionCandidates?.find((candidate) => candidate.roomName === 'E18S59')).toMatchObject({
       colony: 'E17S59',

--- a/prod/test/e26s50ClaimPipeline.test.ts
+++ b/prod/test/e26s50ClaimPipeline.test.ts
@@ -113,7 +113,8 @@ describe('E18S59 claim pipeline', () => {
       colony: 'E17S59',
       reason: 'unmetPreconditions'
     });
-    expect(Memory.territory?.expansionCandidates?.find((candidate) => candidate.roomName === 'E18S59')).toMatchObject({
+    const e18s59Candidate = Memory.territory?.expansionCandidates?.find((candidate) => candidate.roomName === 'E18S59');
+    expect(e18s59Candidate).toMatchObject({
       colony: 'E17S59',
       roomName: 'E18S59',
       evidenceStatus: 'sufficient',
@@ -122,7 +123,7 @@ describe('E18S59 claim pipeline', () => {
       nearestOwnedRoomDistance: 1,
       routeDistance: 1
     });
-    expect(Memory.territory?.expansionCandidates?.[0]).not.toHaveProperty('preconditions');
+    expect(e18s59Candidate).not.toHaveProperty('preconditions');
     expect(Memory.territory?.targets).toBeUndefined();
   });
 

--- a/prod/test/e26s50ClaimPipeline.test.ts
+++ b/prod/test/e26s50ClaimPipeline.test.ts
@@ -111,9 +111,9 @@ describe('E18S59 claim pipeline', () => {
     expect(refreshExpansionExecutorIntent(colony, 827)).toEqual({
       status: 'skipped',
       colony: 'E17S59',
-      reason: 'unmetPreconditions'
+      reason: 'insufficientEvidence'
     });
-    expect(Memory.territory?.expansionCandidates?.[0]).toMatchObject({
+    expect(Memory.territory?.expansionCandidates?.find((candidate) => candidate.roomName === 'E18S59')).toMatchObject({
       colony: 'E17S59',
       roomName: 'E18S59',
       evidenceStatus: 'sufficient',

--- a/prod/test/expansionExecutor.test.ts
+++ b/prod/test/expansionExecutor.test.ts
@@ -534,10 +534,17 @@ describe('expansion executor', () => {
           action: 'scout',
           status: 'planned',
           updatedAt: 968_900
+        },
+        {
+          colony: 'E29N55',
+          targetRoom: 'E34N49',
+          action: 'scout',
+          status: 'planned',
+          updatedAt: 968_900
         }
       ])
     );
-    expect(Memory.territory?.intents).toHaveLength(2);
+    expect(Memory.territory?.intents).toHaveLength(3);
     expect(Memory.territory?.expansionPipelines).toEqual({});
     expect(Memory.territory?.expansionCandidates).toEqual(
       expect.arrayContaining([

--- a/prod/test/expansionExecutor.test.ts
+++ b/prod/test/expansionExecutor.test.ts
@@ -513,7 +513,7 @@ describe('expansion executor', () => {
     expect(refreshExpansionExecutorIntent(colony, 968_900)).toEqual({
       status: 'skipped',
       colony: 'E29N55',
-      reason: 'insufficientEvidence'
+      reason: 'unmetPreconditions'
     });
     expect(Memory.territory?.targets).toBeUndefined();
     expect(

--- a/prod/test/expansionPlanner.test.ts
+++ b/prod/test/expansionPlanner.test.ts
@@ -762,6 +762,13 @@ describe('expansion planner', () => {
         controllerId: 'controller-E30N55',
         sourceCount: 2,
         terrainType: 'unknown'
+      },
+      {
+        colony: 'E29N55',
+        roomName: 'E34N49',
+        status: 'requested',
+        updatedAt: 968_900,
+        distance: 11
       }
     ]);
     expect(Memory.territory?.targets).toBeUndefined();

--- a/prod/test/expansionTrigger.test.ts
+++ b/prod/test/expansionTrigger.test.ts
@@ -87,7 +87,13 @@ describe('autonomous expansion trigger pipeline', () => {
       energyCapacityAvailable: 800
     });
     const report = makeReport([
-      makeCandidate({ roomName: 'W2N1', controllerId: 'controller2' as Id<StructureController> })
+      makeCandidate({ roomName: 'W2N1', controllerId: 'controller2' as Id<StructureController> }),
+      makeCandidate({
+        roomName: 'W3N1',
+        evidenceStatus: 'insufficient-evidence',
+        visible: false,
+        controllerId: null
+      })
     ]);
     const targetRoom = makeTargetRoom('W2N1', 'controller2' as Id<StructureController>);
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
@@ -199,7 +205,13 @@ describe('autonomous expansion trigger pipeline', () => {
       energyCapacityAvailable: 1800
     });
     const report = makeReport([
-      makeCandidate({ roomName: 'W2N1', controllerId: 'controller2' as Id<StructureController> })
+      makeCandidate({ roomName: 'W2N1', controllerId: 'controller2' as Id<StructureController> }),
+      makeCandidate({
+        roomName: 'W3N1',
+        evidenceStatus: 'insufficient-evidence',
+        visible: false,
+        controllerId: null
+      })
     ]);
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       time: 9,

--- a/prod/test/roomScouting.test.ts
+++ b/prod/test/roomScouting.test.ts
@@ -248,13 +248,15 @@ describe('room scouting', () => {
     expect(result.records).toEqual([
       makeRequestedScoutRecord('E29N54', 968_800),
       makeRequestedScoutRecord('E28N55', 968_800),
-      makeRequestedScoutRecord('E30N55', 968_800)
+      makeRequestedScoutRecord('E30N55', 968_800),
+      makeRequestedScoutRecord('E34N49', 968_800, 11)
     ]);
     expect(Memory.territory?.targets).toBeUndefined();
     expect(Memory.territory?.intents).toEqual([
       makeScoutIntent('E29N54', 968_800),
       makeScoutIntent('E28N55', 968_800),
-      makeScoutIntent('E30N55', 968_800)
+      makeScoutIntent('E30N55', 968_800),
+      makeScoutIntent('E34N49', 968_800)
     ]);
   });
 
@@ -280,14 +282,16 @@ describe('room scouting', () => {
       makeRequestedScoutRecord('E29N56', 968_801),
       makeRequestedScoutRecord('E29N54', 968_801),
       makeRequestedScoutRecord('E28N55', 968_801),
-      makeRequestedScoutRecord('E30N55', 968_801)
+      makeRequestedScoutRecord('E30N55', 968_801),
+      makeRequestedScoutRecord('E34N49', 968_801, 11)
     ]);
     expect(Memory.territory?.targets).toBeUndefined();
     expect(Memory.territory?.intents).toEqual([
       makeScoutIntent('E29N56', 968_801),
       makeScoutIntent('E29N54', 968_801),
       makeScoutIntent('E28N55', 968_801),
-      makeScoutIntent('E30N55', 968_801)
+      makeScoutIntent('E30N55', 968_801),
+      makeScoutIntent('E34N49', 968_801)
     ]);
   });
 });
@@ -379,13 +383,13 @@ function makeSpawn(name: string, room: Room): StructureSpawn {
   } as StructureSpawn;
 }
 
-function makeRequestedScoutRecord(roomName: string, updatedAt: number) {
+function makeRequestedScoutRecord(roomName: string, updatedAt: number, distance = 1) {
   return {
     colony: 'E29N55',
     roomName,
     status: 'requested',
     updatedAt,
-    distance: 1
+    distance
   };
 }
 

--- a/prod/test/territory/expansionConfig.test.ts
+++ b/prod/test/territory/expansionConfig.test.ts
@@ -161,9 +161,10 @@ describe('territory expansion config', () => {
             colony: 'E29N55',
             roomName: 'E34N49',
             nearestOwnedRoom: 'E29N55',
-            nearestOwnedRoomDistance: 11,
-            routeDistance: 11,
-            adjacentToOwnedRoom: false
+            nearestOwnedRoomDistance: 99,
+            routeDistance: 99,
+            adjacentToOwnedRoom: true,
+            allowLongRange: true
           },
           {
             colony: 'E29N55',
@@ -172,7 +173,8 @@ describe('territory expansion config', () => {
             nearestOwnedRoomDistance: 1,
             routeDistance: 1,
             adjacentToOwnedRoom: true,
-            scoutOnly: true
+            scoutOnly: true,
+            allowLongRange: true
           }
         ]
       }
@@ -191,7 +193,18 @@ describe('territory expansion config', () => {
         allowLongRange: true
       }
     ]);
-    expect(targets.filter((target) => target.roomName === 'E29N54')).toHaveLength(1);
+    expect(targets.filter((target) => target.roomName === 'E29N54')).toEqual([
+      {
+        colony: 'E29N55',
+        roomName: 'E29N54',
+        nearestOwnedRoom: 'E29N55',
+        nearestOwnedRoomDistance: 1,
+        routeDistance: 1,
+        adjacentToOwnedRoom: true,
+        scoutOnly: true,
+        allowLongRange: true
+      }
+    ]);
   });
 });
 

--- a/prod/test/territory/expansionConfig.test.ts
+++ b/prod/test/territory/expansionConfig.test.ts
@@ -75,6 +75,22 @@ describe('territory expansion config', () => {
     expect(getTerritoryExpansionScoutTargets('W8N3')).toEqual([]);
   });
 
+  it('includes the static owner-recommended E34N49 long-range target for E29N55', () => {
+    expect(getTerritoryExpansionScoutTargets('E29N55')).toEqual(
+      expect.arrayContaining([
+        {
+          colony: 'E29N55',
+          roomName: 'E34N49',
+          nearestOwnedRoom: 'E29N55',
+          nearestOwnedRoomDistance: 11,
+          routeDistance: 11,
+          adjacentToOwnedRoom: false,
+          allowLongRange: true
+        }
+      ])
+    );
+  });
+
   it('merges explicit Memory scout targets with runtime current-room scout-only targets', () => {
     const room = makeOwnedRoom('E29N55');
     (globalThis as { Game: Partial<Game> }).Game = {
@@ -112,8 +128,70 @@ describe('territory expansion config', () => {
         routeDistance: 2,
         adjacentToOwnedRoom: false
       },
-      ...makeE29N55ScoutOnlyTargets()
+      ...makeE29N55ScoutOnlyTargets(),
+      {
+        colony: 'E29N55',
+        roomName: 'E34N49',
+        nearestOwnedRoom: 'E29N55',
+        nearestOwnedRoomDistance: 11,
+        routeDistance: 11,
+        adjacentToOwnedRoom: false,
+        allowLongRange: true
+      }
     ]);
+  });
+
+  it('dedupes memory, runtime, and static scout targets while preserving long-range capability', () => {
+    const room = makeOwnedRoom('E29N55');
+    (globalThis as { Game: Partial<Game> }).Game = {
+      rooms: {
+        E29N55: room
+      },
+      spawns: {
+        Spawn1: makeSpawn('Spawn1', room)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      runtime: {
+        currentRoomName: 'E29N55'
+      },
+      territory: {
+        expansionScoutTargets: [
+          {
+            colony: 'E29N55',
+            roomName: 'E34N49',
+            nearestOwnedRoom: 'E29N55',
+            nearestOwnedRoomDistance: 11,
+            routeDistance: 11,
+            adjacentToOwnedRoom: false
+          },
+          {
+            colony: 'E29N55',
+            roomName: 'E29N54',
+            nearestOwnedRoom: 'E29N55',
+            nearestOwnedRoomDistance: 1,
+            routeDistance: 1,
+            adjacentToOwnedRoom: true,
+            scoutOnly: true
+          }
+        ]
+      }
+    };
+
+    const targets = getTerritoryExpansionScoutTargets('E29N55');
+
+    expect(targets.filter((target) => target.roomName === 'E34N49')).toEqual([
+      {
+        colony: 'E29N55',
+        roomName: 'E34N49',
+        nearestOwnedRoom: 'E29N55',
+        nearestOwnedRoomDistance: 11,
+        routeDistance: 11,
+        adjacentToOwnedRoom: false,
+        allowLongRange: true
+      }
+    ]);
+    expect(targets.filter((target) => target.roomName === 'E29N54')).toHaveLength(1);
   });
 });
 

--- a/prod/test/territory/expansionScoring.test.ts
+++ b/prod/test/territory/expansionScoring.test.ts
@@ -116,6 +116,104 @@ describe('configured territory expansion scoring', () => {
 
     expect(report.candidates.map((candidate) => candidate.roomName)).not.toContain('E17S60');
   });
+
+  it('includes configured E34N49 for E29N55 despite long-range route distance', () => {
+    const colony = makeColony('E29N55');
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 1746986,
+      rooms: {
+        E29N55: colony.room
+      },
+      map: makeMap()
+    };
+
+    const report = buildRuntimeExpansionCandidateReport(colony);
+    const candidate = getCandidate(report, 'E34N49');
+
+    expect(candidate).toMatchObject({
+      roomName: 'E34N49',
+      visible: false,
+      evidenceStatus: 'insufficient-evidence',
+      adjacentToOwnedRoom: false,
+      nearestOwnedRoom: 'E29N55',
+      nearestOwnedRoomDistance: 11,
+      routeDistance: 11,
+      allowLongRange: true,
+      risks: expect.arrayContaining([
+        'controller evidence missing until scout',
+        'source count evidence missing until scout',
+        'hostile evidence missing until scout'
+      ])
+    });
+    expect(selectExpansionScoutTargets(report, 10, 1746986)).toEqual(
+      expect.arrayContaining([expect.objectContaining({ roomName: 'E34N49', distance: 11 })])
+    );
+  });
+
+  it('keeps unconfigured far runtime rooms excluded by the nearby expansion filter', () => {
+    const colony = makeColony('E29N55');
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 1746986,
+      rooms: {
+        E29N55: colony.room,
+        E40N40: makeNeutralRoom('E40N40')
+      },
+      map: makeMap()
+    };
+
+    const report = buildRuntimeExpansionCandidateReport(colony);
+
+    expect(report.candidates.map((candidate) => candidate.roomName)).not.toContain('E40N40');
+  });
+
+  it.each([
+    [
+      'foreign-owned controller',
+      {
+        controller: {
+          id: 'controller-E34N49' as Id<StructureController>,
+          my: false,
+          ownerUsername: 'enemy'
+        }
+      },
+      ['enemy-owned controller cannot be claimed safely']
+    ],
+    [
+      'hostile presence',
+      {
+        hostileCreepCount: 1
+      },
+      ['hostile presence scouted']
+    ]
+  ])('keeps configured E34N49 unavailable with %s scout intel', (_caseName, intelOverrides, expectedRisks) => {
+    const colony = makeColony('E29N55');
+    Memory.territory = {
+      ...(Memory.territory ?? {}),
+      scoutIntel: {
+        'E29N55>E34N49': makeScoutIntel('E29N55', 'E34N49', intelOverrides)
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 1746986,
+      rooms: {
+        E29N55: colony.room
+      },
+      map: makeMap()
+    };
+
+    const report = buildRuntimeExpansionCandidateReport(colony);
+    const candidate = getCandidate(report, 'E34N49');
+
+    expect(candidate).toMatchObject({
+      roomName: 'E34N49',
+      evidenceStatus: 'unavailable',
+      allowLongRange: true,
+      risks: expect.arrayContaining(expectedRisks)
+    });
+    expect(selectExpansionScoutTargets(report, 10, 1746986).map((target) => target.roomName)).not.toContain(
+      'E34N49'
+    );
+  });
 });
 
 function makeColony(roomName: string): ColonySnapshot {
@@ -151,10 +249,88 @@ function makeOwnedRoom(roomName: string): Room {
   } as unknown as Room;
 }
 
+function makeNeutralRoom(roomName: string): Room {
+  return {
+    name: roomName,
+    controller: {
+      id: `controller-${roomName}` as Id<StructureController>,
+      my: false,
+      pos: { x: 25, y: 25, roomName } as RoomPosition
+    } as StructureController,
+    find: jest.fn((findType: number): unknown[] => {
+      if (findType === FIND_SOURCES) {
+        return [
+          { id: `${roomName}-source-a`, pos: { x: 10, y: 20, roomName } },
+          { id: `${roomName}-source-b`, pos: { x: 35, y: 40, roomName } }
+        ];
+      }
+      return [];
+    })
+  } as unknown as Room;
+}
+
 function makeTerrain(mask: number): RoomTerrain {
   return {
     get: jest.fn(() => mask)
   } as unknown as RoomTerrain;
+}
+
+function makeMap(): GameMap {
+  return {
+    describeExits: jest.fn(() => ({})),
+    getRoomTerrain: jest.fn(() => makeTerrain(0)),
+    getRoomLinearDistance: jest.fn((fromRoom: string, targetRoom: string) =>
+      getTestRouteDistance(fromRoom, targetRoom)
+    ),
+    findRoute: jest.fn((fromRoom: string, targetRoom: string) =>
+      Array.from({ length: getTestRouteDistance(fromRoom, targetRoom) }, (_value, index) => ({
+        exit: 1,
+        room: `${targetRoom}-${index}`
+      }))
+    )
+  } as unknown as GameMap;
+}
+
+function getTestRouteDistance(fromRoom: string, targetRoom: string): number {
+  if (fromRoom === targetRoom) {
+    return 0;
+  }
+
+  if (targetRoom === 'E34N49') {
+    return 11;
+  }
+
+  if (targetRoom === 'E40N40') {
+    return 30;
+  }
+
+  return 1;
+}
+
+function makeScoutIntel(
+  colony: string,
+  roomName: string,
+  overrides: Partial<TerritoryScoutIntelMemory> = {}
+): TerritoryScoutIntelMemory {
+  return {
+    colony,
+    roomName,
+    updatedAt: 1746986,
+    controller: {
+      id: `controller-${roomName}` as Id<StructureController>,
+      my: false
+    },
+    sourceIds: [`${roomName}-source-a`, `${roomName}-source-b`],
+    sourceCount: 2,
+    sourceAccessPoints: 8,
+    controllerSourceRange: 23,
+    terrain: { walkableRatio: 0.9, swampRatio: 0.04, wallRatio: 0.1 },
+    mineral: { id: `${roomName}-mineral`, mineralType: 'U' },
+    hostileCreepCount: 0,
+    hostileStructureCount: 0,
+    hostileSpawnCount: 0,
+    ...overrides
+  };
 }
 
 function getCandidate(

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1068,7 +1068,7 @@ describe('planTerritoryIntent', () => {
     );
 
     expect(plan?.action).toBe('scout');
-    expect(plan?.targetRoom).toBe('E29N56');
+    expect(plan?.targetRoom).toBe('E29N54');
     expect(Memory.territory?.targets).toBeUndefined();
     expect(
       (Memory.territory?.intents ?? []).filter((intent) => intent.action === 'claim' || intent.action === 'reserve')
@@ -1076,14 +1076,13 @@ describe('planTerritoryIntent', () => {
     expect(Memory.territory?.intents).toEqual([
       {
         colony: 'E29N55',
-        targetRoom: 'E29N56',
+        targetRoom: 'E29N54',
         action: 'scout',
         status: 'planned',
-        updatedAt: gameTime,
-        blockReason: 'controllerLevelLow'
+        updatedAt: gameTime
       }
     ]);
-    expect(Memory.territory?.expansionCandidates?.[0]).toMatchObject({
+    expect(getPersistedExpansionCandidate('E29N56')).toMatchObject({
       colony: 'E29N55',
       roomName: 'E29N56',
       scoutOnly: true,
@@ -1162,10 +1161,25 @@ describe('planTerritoryIntent', () => {
 
     const plan = planTerritoryIntent(colony, { worker: 4, claimer: 0, claimersByTargetRoom: {} }, 4, gameTime);
 
-    expect(plan).toBeNull();
+    expect(plan).toEqual({
+      colony: 'E29N55',
+      targetRoom: 'E29N54',
+      action: 'scout'
+    });
     expect(Memory.territory?.targets).toBeUndefined();
-    expect(Memory.territory?.intents).toBeUndefined();
-    expect(Memory.territory?.expansionCandidates?.[0]).toMatchObject({
+    expect(
+      (Memory.territory?.intents ?? []).filter((intent) => intent.action === 'claim' || intent.action === 'reserve')
+    ).toEqual([]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'E29N55',
+        targetRoom: 'E29N54',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: gameTime
+      }
+    ]);
+    expect(getPersistedExpansionCandidate('E29N56')).toMatchObject({
       colony: 'E29N55',
       roomName: 'E29N56',
       scoutOnly: true,
@@ -8336,6 +8350,10 @@ function makeExpansionCandidateMemory(
     recommendedAction: 'scout',
     ...overrides
   };
+}
+
+function getPersistedExpansionCandidate(roomName: string): TerritoryExpansionCandidateMemory | undefined {
+  return Memory.territory?.expansionCandidates?.find((candidate) => candidate.roomName === roomName);
 }
 
 function makeScoutIntel(


### PR DESCRIPTION
## Summary
- Adds a bounded `allowLongRange` expansion target path for explicit configured/owner-recommended rooms while keeping unconfigured runtime rooms inside the existing nearby filter.
- Adds E34N49 as the current owner-recommended E29N55 network expansion candidate with distance 11, non-adjacent metadata, and normal scout/claim safety gates.
- Wires static configured expansion targets through scouting/scoring with dedupe, and persists the long-range flag into candidate memory/telemetry evidence.

Related to issue #1540.

## Verification
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm test -- --runInBand test/territory/expansionScoring.test.ts test/territory/expansionConfig.test.ts test/roomScouting.test.ts test/expansionExecutor.test.ts test/territoryPlanner.test.ts` — 207 tests passed
- [x] `npm test -- --runInBand` — 104 suites / 2228 tests passed
- [x] `npm run build`
- [x] `python3 scripts/screeps-runtime-monitor.py self-test` — 42 tests passed

## Universal task Done gate
- [x] Task type: code
- [x] Expected observable outcome / named deliverable: the official E29N55 network can scout and score the explicit owner-recommended long-range E34N49 candidate instead of being limited to distance-2 rooms.
- [x] Non-goals / accepted substitutes: this PR does not widen blind map search; only explicit configured long-range targets bypass the nearby filter, and all controller/hostile/GCL/RCL/CPU/energy/bootstrap gates remain active.
- [x] Verification evidence required before Done: local typecheck, targeted Jest, full Jest, build, monitor self-test, PR checks, automated review triage, merge gate, official deploy evidence, and live runtime evidence showing E34N49 selected/scouted/planned or a machine-readable blocker.
- [x] Project Evidence / Next action / Blocked by: Project issue #1540 has owner directive evidence and live E34N49 API evidence; next action is PR review, merge-gate verification, official deploy, and live evidence capture; blockers are clear.
- [x] Post-merge/deploy/runtime proof: local verification succeeded in this branch; official deploy plus live Memory/runtime evidence are the required proof before moving issue status to Done.
- [x] Named deliverable proof: source, tests, and generated bundle prove the bounded long-range candidate path; live proof will be recorded in Project Evidence before Done.
