### PR TITLE
runtime: add CPU bucket recovery headroom shedding

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -976,6 +976,8 @@ function buildRuntimeCpuBudget(sample) {
     reasons.push("criticalBucket");
   } else if (sample.bucket !== void 0 && sample.bucket < LOW_CPU_BUCKET_THRESHOLD) {
     reasons.push("lowBucket");
+  } else if (hasLowBucketRecoveryPressure(sample)) {
+    reasons.push("lowBucketRecovery");
   }
   if (sample.used !== void 0 && sample.limit !== void 0 && sample.limit > 0 && sample.used > sample.limit) {
     reasons.push("usedOverLimit");
@@ -1050,10 +1052,22 @@ function shouldShedNonessentialCpuWork(budget) {
   return budget.critical || hasLowBucketPressure(budget) || hasUsedOverLimitPressure(budget);
 }
 function hasLowBucketPressure(budget) {
-  return budget.reasons.includes("lowBucket") || budget.reasons.includes("criticalBucket");
+  return budget.reasons.includes("lowBucketRecovery") || budget.reasons.includes("lowBucket") || budget.reasons.includes("criticalBucket");
 }
 function hasUsedOverLimitPressure(budget) {
   return budget.reasons.includes("usedOverLimit");
+}
+function hasLowBucketRecoveryPressure(sample) {
+  if (sample.bucket === void 0 || sample.bucket < LOW_CPU_BUCKET_THRESHOLD) {
+    return false;
+  }
+  return sample.bucket < LOW_CPU_BUCKET_THRESHOLD + getCpuBucketRecoveryHeadroom(sample.limit);
+}
+function getCpuBucketRecoveryHeadroom(limit) {
+  if (limit !== void 0 && limit > 0) {
+    return Math.ceil(limit);
+  }
+  return LOW_CPU_ACCOUNT_LIMIT;
 }
 function updateRuntimeCpuTelemetryState(sample) {
   resetRuntimeCpuTelemetryStateForTick(sample.tick);
@@ -49911,7 +49925,7 @@ function shouldSuppressRecoveryDefenseTelemetry(event, cpuBudget) {
   return event.action === "towerRepair" || event.action === "towerHeal";
 }
 function hasLowBucketPressure2(cpuBudget) {
-  return cpuBudget.reasons.includes("lowBucket") || cpuBudget.reasons.includes("criticalBucket");
+  return cpuBudget.reasons.includes("lowBucketRecovery") || cpuBudget.reasons.includes("lowBucket") || cpuBudget.reasons.includes("criticalBucket");
 }
 function pruneStaleForwardedDefenseEvents(lastForwardedDefenseEventTick, tick) {
   for (const [key, lastForwardedTick] of lastForwardedDefenseEventTick) {

--- a/prod/src/kernel/Kernel.ts
+++ b/prod/src/kernel/Kernel.ts
@@ -132,7 +132,11 @@ function shouldSuppressRecoveryDefenseTelemetry(
 }
 
 function hasLowBucketPressure(cpuBudget: RuntimeCpuBudget): boolean {
-  return cpuBudget.reasons.includes('lowBucket') || cpuBudget.reasons.includes('criticalBucket');
+  return (
+    cpuBudget.reasons.includes('lowBucketRecovery') ||
+    cpuBudget.reasons.includes('lowBucket') ||
+    cpuBudget.reasons.includes('criticalBucket')
+  );
 }
 
 function pruneStaleForwardedDefenseEvents(

--- a/prod/src/runtime/cpuBudget.ts
+++ b/prod/src/runtime/cpuBudget.ts
@@ -1,6 +1,7 @@
 export type RuntimeCpuPressure = 'normal' | 'degraded' | 'critical';
 export type RuntimeCpuPressureReason =
   | 'lowCpuLimit'
+  | 'lowBucketRecovery'
   | 'lowBucket'
   | 'criticalBucket'
   | 'usedOverLimit';
@@ -96,6 +97,8 @@ export function buildRuntimeCpuBudget(sample: RuntimeCpuSample): RuntimeCpuBudge
     reasons.push('criticalBucket');
   } else if (sample.bucket !== undefined && sample.bucket < LOW_CPU_BUCKET_THRESHOLD) {
     reasons.push('lowBucket');
+  } else if (hasLowBucketRecoveryPressure(sample)) {
+    reasons.push('lowBucketRecovery');
   }
 
   if (
@@ -214,11 +217,31 @@ export function resetRuntimeCpuTelemetryForTesting(): void {
 }
 
 export function hasLowBucketPressure(budget: RuntimeCpuBudget): boolean {
-  return budget.reasons.includes('lowBucket') || budget.reasons.includes('criticalBucket');
+  return (
+    budget.reasons.includes('lowBucketRecovery') ||
+    budget.reasons.includes('lowBucket') ||
+    budget.reasons.includes('criticalBucket')
+  );
 }
 
 function hasUsedOverLimitPressure(budget: RuntimeCpuBudget): boolean {
   return budget.reasons.includes('usedOverLimit');
+}
+
+function hasLowBucketRecoveryPressure(sample: RuntimeCpuSample): boolean {
+  if (sample.bucket === undefined || sample.bucket < LOW_CPU_BUCKET_THRESHOLD) {
+    return false;
+  }
+
+  return sample.bucket < LOW_CPU_BUCKET_THRESHOLD + getCpuBucketRecoveryHeadroom(sample.limit);
+}
+
+function getCpuBucketRecoveryHeadroom(limit: number | undefined): number {
+  if (limit !== undefined && limit > 0) {
+    return Math.ceil(limit);
+  }
+
+  return LOW_CPU_ACCOUNT_LIMIT;
 }
 
 function updateRuntimeCpuTelemetryState(sample: RuntimeCpuSample): RuntimeCpuTelemetryState {

--- a/prod/test/cpuBudget.test.ts
+++ b/prod/test/cpuBudget.test.ts
@@ -139,6 +139,27 @@ describe('runtime CPU budget policy', () => {
     ).toBe(true);
   });
 
+  it('sheds optional work before the bucket reaches the low-bucket alert floor', () => {
+    const budget = buildRuntimeCpuBudget({
+      tick: 1749171,
+      used: 10,
+      limit: 70,
+      bucket: 1_007,
+      tickLimit: 500
+    });
+
+    expect(budget).toMatchObject({
+      pressure: 'degraded',
+      degraded: true,
+      critical: false,
+      lowCpuLimit: false,
+      reasons: ['lowBucketRecovery']
+    });
+    expect(shouldRunOptionalCpuWork(budget, 'economy-global-optional')).toBe(false);
+    expect(shouldRunOptionalCpuRoomWork(budget, 'E29N55')).toBe(false);
+    expect(shouldShedNonessentialCpuWork(budget)).toBe(true);
+  });
+
   it('sheds optional work once the current tick exceeds its CPU limit', () => {
     const budget = buildRuntimeCpuBudget({
       tick: 222,


### PR DESCRIPTION
## Summary

Adds a CPU bucket recovery headroom band so optional work stays shed while the bucket is only slightly above the low-bucket alert floor. This targets the runtime CPU recurrence described in #1490 without changing official MMO write behavior from RL artifacts.

Related to #1490.

## Verification

Controller verification before the Codex-authored recovery commit:
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (104 suites, 2229 tests)
- `cd prod && npm run build`

Codex recovery commit:
- `9249f797 runtime: add CPU bucket recovery headroom shedding`

## Safety

- No secrets printed or changed.
- No paid Tencent compute, deploy, cron, or GitHub Project mutation was performed by Codex.
- Runtime behavior change is limited to CPU-pressure gating and generated bundle sync.

## Universal task Done gate

- [x] Task type: runtime CPU reliability hotfix.
- [x] Expected observable outcome / named deliverable: CPU budget marks the low-bucket recovery band as degraded and suppresses optional work before the alert floor is crossed.
- [x] Non-goals / accepted substitutes: no RL policy rollout, no paid compute, no deploy command, no scheduler change.
- [x] Verification evidence required before Done: diff-check, typecheck, Jest, build, PR checks, automated review gate, and CPU-bearing runtime-summary observation.
- [x] Project Evidence / Next action / Blocked by: issue 1490 and this PR carry commit 9249f797 plus controller verification; next action is PR review gate then deploy/observe CPU-bearing telemetry.
- [x] Post-merge/deploy/runtime proof: CPU-bearing runtime-summary console evidence must show the recovery band behavior and no critical bucket recurrence before issue Done.
- [x] Named deliverable proof: commit 9249f797 changes cpuBudget, Kernel CPU suppression checks, focused CPU budget test, and regenerated Screeps bundle.
