### PR TITLE
territory: preserve pressure-aware scout validation

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4454,7 +4454,8 @@ function validateTerritoryScoutIntelForClaim({
   colony,
   targetRoom,
   colonyOwnerUsername,
-  gameTime
+  gameTime,
+  allowForeignReservationPressure = false
 }) {
   const attempt = getTerritoryScoutAttempt(colony, targetRoom);
   const intel = getTerritoryScoutIntel(colony, targetRoom);
@@ -4474,7 +4475,7 @@ function validateTerritoryScoutIntelForClaim({
   if (isNonEmptyString6(controller.ownerUsername)) {
     return { status: "blocked", reason: "controllerOwned", intel };
   }
-  if (isNonEmptyString6(controller.reservationUsername) && controller.reservationUsername !== colonyOwnerUsername) {
+  if (isNonEmptyString6(controller.reservationUsername) && controller.reservationUsername !== colonyOwnerUsername && allowForeignReservationPressure !== true) {
     return { status: "blocked", reason: "controllerReserved", intel };
   }
   if (intel.hostileCreepCount > 0 || intel.hostileStructureCount > 0 || intel.hostileSpawnCount > 0) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -8632,7 +8632,7 @@ function scoreExpansionCandidate(input, candidate) {
   rationale.push(...synergy.rationale);
   const score = calculateExpansionScore(input, candidate, evidenceStatus, synergy.score);
   const reservation = getReservationEvidence(input, candidate.controller);
-  const requiresControllerPressure = (reservation == null ? void 0 : reservation.relation) === "foreign";
+  const requiresControllerPressure = candidate.requiresControllerPressure === true || (reservation == null ? void 0 : reservation.relation) === "foreign";
   const scoredCandidate = {
     roomName: candidate.roomName,
     score,
@@ -17052,7 +17052,8 @@ function refreshScoutingStage(colony, pipeline, gameTime, telemetryEvents, terri
     colony: pipeline.colony,
     targetRoom: pipeline.targetRoom,
     ...colonyOwnerUsername ? { colonyOwnerUsername } : {},
-    gameTime
+    gameTime,
+    allowForeignReservationPressure: pipeline.requiresControllerPressure === true
   });
   const controllerId = (_c = pipeline.controllerId) != null ? _c : (_b = (_a2 = validation.intel) == null ? void 0 : _a2.controller) == null ? void 0 : _b.id;
   recordTerritoryScoutValidation(
@@ -17099,7 +17100,11 @@ function refreshScoutingStage(colony, pipeline, gameTime, telemetryEvents, terri
 }
 function refreshReservingStage(colony, pipeline, gameTime, telemetryEvents, territoryMemory, colonyOwnerUsername) {
   const visibleRoom = getVisibleRoom3(pipeline.targetRoom);
-  const visibleAbort = visibleRoom ? getVisibleTargetAbortReason(visibleRoom, colonyOwnerUsername) : null;
+  const visibleAbort = visibleRoom ? getVisibleTargetAbortReason(
+    visibleRoom,
+    colonyOwnerUsername,
+    pipeline.requiresControllerPressure === true
+  ) : null;
   if (visibleAbort) {
     return abortExpansionPipeline(territoryMemory, pipeline, visibleAbort, gameTime);
   }
@@ -17132,7 +17137,11 @@ function refreshReservingStage(colony, pipeline, gameTime, telemetryEvents, terr
 }
 function refreshClaimingStage(colony, pipeline, gameTime, telemetryEvents, territoryMemory, colonyOwnerUsername) {
   const visibleRoom = getVisibleRoom3(pipeline.targetRoom);
-  const visibleAbort = visibleRoom ? getVisibleTargetAbortReason(visibleRoom, colonyOwnerUsername) : null;
+  const visibleAbort = visibleRoom ? getVisibleTargetAbortReason(
+    visibleRoom,
+    colonyOwnerUsername,
+    pipeline.requiresControllerPressure === true
+  ) : null;
   if (visibleAbort) {
     return abortExpansionPipeline(territoryMemory, pipeline, visibleAbort, gameTime);
   }
@@ -17287,6 +17296,7 @@ function createExpansionPipeline(colony, candidate, config, gameTime) {
     threshold: config.scoreThreshold,
     startedAt: gameTime,
     updatedAt: gameTime,
+    ...candidate.requiresControllerPressure === true ? { requiresControllerPressure: true } : {},
     ...candidate.controllerId ? { controllerId: candidate.controllerId } : {}
   };
 }
@@ -17365,7 +17375,7 @@ function getScoutValidationAbortReason(validation) {
       return "scoutTimedOut";
   }
 }
-function getVisibleTargetAbortReason(room, colonyOwnerUsername) {
+function getVisibleTargetAbortReason(room, colonyOwnerUsername, allowForeignReservationPressure = false) {
   if (hasVisibleHostiles(room)) {
     return "targetHostile";
   }
@@ -17381,7 +17391,7 @@ function getVisibleTargetAbortReason(room, colonyOwnerUsername) {
     return "controllerOwned";
   }
   const reservationUsername = getControllerReservationUsername5(controller);
-  if (reservationUsername && reservationUsername !== colonyOwnerUsername) {
+  if (reservationUsername && reservationUsername !== colonyOwnerUsername && allowForeignReservationPressure !== true) {
     return "controllerReserved";
   }
   return null;
@@ -17411,6 +17421,7 @@ function persistPipelineControlPlan(territoryMemory, pipeline, action, gameTime)
     updatedAt: gameTime,
     createdBy: NEXT_EXPANSION_TARGET_CREATOR,
     ...pipeline.controllerId ? { controllerId: pipeline.controllerId } : {},
+    ...pipeline.requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...postClaimBootstrapReserveEnergy !== void 0 ? { postClaimBootstrapReserveEnergy } : {}
   });
 }
@@ -17506,6 +17517,7 @@ function normalizeExpansionPipeline(rawPipeline, colony) {
     threshold: rawPipeline.threshold,
     startedAt: rawPipeline.startedAt,
     updatedAt: rawPipeline.updatedAt,
+    ...rawPipeline.requiresControllerPressure === true ? { requiresControllerPressure: true } : {},
     ...typeof rawPipeline.controllerId === "string" ? { controllerId: rawPipeline.controllerId } : {},
     ...isFiniteNumber9(rawPipeline.reservationConfirmedAt) ? { reservationConfirmedAt: rawPipeline.reservationConfirmedAt } : {},
     ...isFiniteNumber9(rawPipeline.claimedAt) ? { claimedAt: rawPipeline.claimedAt } : {},
@@ -17526,6 +17538,7 @@ function toAutonomousExpansionPipelineSummary(pipeline) {
     updatedAt: pipeline.updatedAt,
     ...pipeline.claimState ? { claimState: pipeline.claimState } : {},
     ...pipeline.controllerId ? { controllerId: pipeline.controllerId } : {},
+    ...pipeline.requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...pipeline.reservationConfirmedAt !== void 0 ? { reservationConfirmedAt: pipeline.reservationConfirmedAt } : {},
     ...pipeline.claimedAt !== void 0 ? { claimedAt: pipeline.claimedAt } : {}
   };
@@ -44235,6 +44248,7 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, tel
     colony: colonyName,
     targetRoom: candidate.roomName,
     score: candidate.score,
+    ...candidate.requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...candidate.controllerId ? { controllerId: candidate.controllerId } : {}
   };
   if (isPostClaimBootstrapBlockedCandidate(candidate)) {
@@ -44266,7 +44280,7 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, tel
     return { ...visibleControllerEvaluation, reason: "controllerOwned" };
   }
   const colonyOwnerUsername = getControllerOwnerUsername11(colony.room.controller);
-  if (controller && isControllerReserved(controller, colonyOwnerUsername)) {
+  if (controller && isControllerReserved(controller, colonyOwnerUsername) && candidate.requiresControllerPressure !== true) {
     return { ...visibleControllerEvaluation, reason: "controllerReserved" };
   }
   if (isAutonomousExpansionClaimGclInsufficient()) {
@@ -44282,7 +44296,8 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, tel
     colony: colonyName,
     targetRoom: candidate.roomName,
     colonyOwnerUsername: getControllerOwnerUsername11(colony.room.controller),
-    gameTime
+    gameTime,
+    allowForeignReservationPressure: candidate.requiresControllerPressure === true
   });
   const scoutControllerId = getScoutValidationControllerId(scoutValidation);
   const controllerId = (_c = (_b = controller == null ? void 0 : controller.id) != null ? _b : scoutControllerId) != null ? _c : candidate.controllerId;
@@ -44332,6 +44347,7 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, tel
     colony: colonyName,
     targetRoom: candidate.roomName,
     score: candidate.score,
+    ...candidate.requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...typeof controllerId === "string" ? { controllerId } : {}
   };
 }
@@ -44420,7 +44436,8 @@ function toExpansionCandidateInput(candidate, order, colonyName, includeMineralS
     ...typeof candidate.sourceCount === "number" ? { sourceCount: candidate.sourceCount } : {},
     ...mineral ? { mineral } : {},
     ...typeof hostileCreepCount === "number" ? { hostileCreepCount } : {},
-    ...typeof hostileStructureCount === "number" ? { hostileStructureCount } : {}
+    ...typeof hostileStructureCount === "number" ? { hostileStructureCount } : {},
+    ...candidate.requiresControllerPressure === true ? { requiresControllerPressure: true } : {}
   };
 }
 function summarizeScoutedExpansionMineral(mineral) {
@@ -44566,7 +44583,8 @@ function persistAutonomousExpansionClaimIntent(colony, evaluation, gameTime, con
     status: (existingIntent == null ? void 0 : existingIntent.status) === "active" ? "active" : "planned",
     updatedAt: gameTime,
     createdBy: AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR,
-    ...target.controllerId ? { controllerId: target.controllerId } : {}
+    ...target.controllerId ? { controllerId: target.controllerId } : {},
+    ...evaluation.requiresControllerPressure ? { requiresControllerPressure: true } : {}
   });
   syncAutonomousExpansionClaimIntentContext(context, territoryMemory, intents);
 }

--- a/prod/src/territory/claimExecutor.ts
+++ b/prod/src/territory/claimExecutor.ts
@@ -102,6 +102,7 @@ export interface AutonomousExpansionClaimEvaluation {
   reason?: AutonomousExpansionClaimSkipReason;
   targetRoom?: string;
   controllerId?: Id<StructureController>;
+  requiresControllerPressure?: boolean;
   score?: number;
 }
 
@@ -470,6 +471,7 @@ function evaluateAutonomousExpansionClaim(
     colony: colonyName,
     targetRoom: candidate.roomName,
     score: candidate.score,
+    ...(candidate.requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(candidate.controllerId ? { controllerId: candidate.controllerId } : {})
   };
 
@@ -512,7 +514,11 @@ function evaluateAutonomousExpansionClaim(
   }
 
   const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
-  if (controller && isControllerReserved(controller, colonyOwnerUsername)) {
+  if (
+    controller &&
+    isControllerReserved(controller, colonyOwnerUsername) &&
+    candidate.requiresControllerPressure !== true
+  ) {
     return { ...visibleControllerEvaluation, reason: 'controllerReserved' };
   }
 
@@ -532,7 +538,8 @@ function evaluateAutonomousExpansionClaim(
     colony: colonyName,
     targetRoom: candidate.roomName,
     colonyOwnerUsername: getControllerOwnerUsername(colony.room.controller),
-    gameTime
+    gameTime,
+    allowForeignReservationPressure: candidate.requiresControllerPressure === true
   });
   const scoutControllerId = getScoutValidationControllerId(scoutValidation);
   const controllerId = controller?.id ?? scoutControllerId ?? candidate.controllerId;
@@ -587,6 +594,7 @@ function evaluateAutonomousExpansionClaim(
     colony: colonyName,
     targetRoom: candidate.roomName,
     score: candidate.score,
+    ...(candidate.requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(typeof controllerId === 'string' ? { controllerId: controllerId as Id<StructureController> } : {})
   };
 }
@@ -721,7 +729,8 @@ function toExpansionCandidateInput(
     ...(typeof candidate.sourceCount === 'number' ? { sourceCount: candidate.sourceCount } : {}),
     ...(mineral ? { mineral } : {}),
     ...(typeof hostileCreepCount === 'number' ? { hostileCreepCount } : {}),
-    ...(typeof hostileStructureCount === 'number' ? { hostileStructureCount } : {})
+    ...(typeof hostileStructureCount === 'number' ? { hostileStructureCount } : {}),
+    ...(candidate.requiresControllerPressure === true ? { requiresControllerPressure: true } : {})
   };
 }
 
@@ -950,7 +959,8 @@ function persistAutonomousExpansionClaimIntent(
     status: existingIntent?.status === 'active' ? 'active' : 'planned',
     updatedAt: gameTime,
     createdBy: AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR,
-    ...(target.controllerId ? { controllerId: target.controllerId } : {})
+    ...(target.controllerId ? { controllerId: target.controllerId } : {}),
+    ...(evaluation.requiresControllerPressure ? { requiresControllerPressure: true } : {})
   });
   syncAutonomousExpansionClaimIntentContext(context, territoryMemory, intents);
 }

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -173,6 +173,7 @@ export interface ExpansionCandidateInput {
   hostileCreepCount?: number;
   hostileStructureCount?: number;
   hostilePressureDistance?: number;
+  requiresControllerPressure?: boolean;
   scoutOnly?: boolean;
   allowLongRange?: boolean;
 }
@@ -841,7 +842,8 @@ function scoreExpansionCandidate(
 
   const score = calculateExpansionScore(input, candidate, evidenceStatus, synergy.score);
   const reservation = getReservationEvidence(input, candidate.controller);
-  const requiresControllerPressure = reservation?.relation === 'foreign';
+  const requiresControllerPressure =
+    candidate.requiresControllerPressure === true || reservation?.relation === 'foreign';
   const scoredCandidate: ExpansionCandidateScore = {
     roomName: candidate.roomName,
     score,

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -388,7 +388,8 @@ function validateNextExpansionScoutIntel(
     colony: colonyName,
     targetRoom: candidate.roomName,
     colonyOwnerUsername: getControllerOwnerUsername(colony.room.controller),
-    gameTime
+    gameTime,
+    allowForeignReservationPressure: candidate.requiresControllerPressure === true
   });
   recordTerritoryScoutValidation(
     colonyName,

--- a/prod/src/territory/expansionTrigger.ts
+++ b/prod/src/territory/expansionTrigger.ts
@@ -85,6 +85,7 @@ export interface AutonomousExpansionPipelineSummary {
   updatedAt: number;
   claimState?: TerritoryExpansionClaimState;
   controllerId?: Id<StructureController>;
+  requiresControllerPressure?: boolean;
   reservationConfirmedAt?: number;
   claimedAt?: number;
 }
@@ -295,7 +296,8 @@ function refreshScoutingStage(
     colony: pipeline.colony,
     targetRoom: pipeline.targetRoom,
     ...(colonyOwnerUsername ? { colonyOwnerUsername } : {}),
-    gameTime
+    gameTime,
+    allowForeignReservationPressure: pipeline.requiresControllerPressure === true
   });
   const controllerId = pipeline.controllerId ?? validation.intel?.controller?.id;
   recordTerritoryScoutValidation(
@@ -357,7 +359,13 @@ function refreshReservingStage(
   colonyOwnerUsername: string | undefined
 ): NextExpansionTargetSelection {
   const visibleRoom = getVisibleRoom(pipeline.targetRoom);
-  const visibleAbort = visibleRoom ? getVisibleTargetAbortReason(visibleRoom, colonyOwnerUsername) : null;
+  const visibleAbort = visibleRoom
+    ? getVisibleTargetAbortReason(
+        visibleRoom,
+        colonyOwnerUsername,
+        pipeline.requiresControllerPressure === true
+      )
+    : null;
   if (visibleAbort) {
     return abortExpansionPipeline(territoryMemory, pipeline, visibleAbort, gameTime);
   }
@@ -401,7 +409,13 @@ function refreshClaimingStage(
   colonyOwnerUsername: string | undefined
 ): NextExpansionTargetSelection {
   const visibleRoom = getVisibleRoom(pipeline.targetRoom);
-  const visibleAbort = visibleRoom ? getVisibleTargetAbortReason(visibleRoom, colonyOwnerUsername) : null;
+  const visibleAbort = visibleRoom
+    ? getVisibleTargetAbortReason(
+        visibleRoom,
+        colonyOwnerUsername,
+        pipeline.requiresControllerPressure === true
+      )
+    : null;
   if (visibleAbort) {
     return abortExpansionPipeline(territoryMemory, pipeline, visibleAbort, gameTime);
   }
@@ -627,6 +641,7 @@ function createExpansionPipeline(
     threshold: config.scoreThreshold,
     startedAt: gameTime,
     updatedAt: gameTime,
+    ...(candidate.requiresControllerPressure === true ? { requiresControllerPressure: true } : {}),
     ...(candidate.controllerId ? { controllerId: candidate.controllerId } : {})
   };
 }
@@ -743,7 +758,8 @@ function getScoutValidationAbortReason(
 
 function getVisibleTargetAbortReason(
   room: Room,
-  colonyOwnerUsername: string | undefined
+  colonyOwnerUsername: string | undefined,
+  allowForeignReservationPressure = false
 ): TerritoryExpansionAbortReason | null {
   if (hasVisibleHostiles(room)) {
     return 'targetHostile';
@@ -764,7 +780,11 @@ function getVisibleTargetAbortReason(
   }
 
   const reservationUsername = getControllerReservationUsername(controller);
-  if (reservationUsername && reservationUsername !== colonyOwnerUsername) {
+  if (
+    reservationUsername &&
+    reservationUsername !== colonyOwnerUsername &&
+    allowForeignReservationPressure !== true
+  ) {
     return 'controllerReserved';
   }
 
@@ -802,6 +822,7 @@ function persistPipelineControlPlan(
     updatedAt: gameTime,
     createdBy: NEXT_EXPANSION_TARGET_CREATOR,
     ...(pipeline.controllerId ? { controllerId: pipeline.controllerId } : {}),
+    ...(pipeline.requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(postClaimBootstrapReserveEnergy !== undefined ? { postClaimBootstrapReserveEnergy } : {})
   });
 }
@@ -960,6 +981,7 @@ function normalizeExpansionPipeline(
     threshold: rawPipeline.threshold,
     startedAt: rawPipeline.startedAt,
     updatedAt: rawPipeline.updatedAt,
+    ...(rawPipeline.requiresControllerPressure === true ? { requiresControllerPressure: true } : {}),
     ...(typeof rawPipeline.controllerId === 'string'
       ? { controllerId: rawPipeline.controllerId as Id<StructureController> }
       : {}),
@@ -987,6 +1009,7 @@ function toAutonomousExpansionPipelineSummary(
     updatedAt: pipeline.updatedAt,
     ...(pipeline.claimState ? { claimState: pipeline.claimState } : {}),
     ...(pipeline.controllerId ? { controllerId: pipeline.controllerId } : {}),
+    ...(pipeline.requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(pipeline.reservationConfirmedAt !== undefined
       ? { reservationConfirmedAt: pipeline.reservationConfirmedAt }
       : {}),

--- a/prod/src/territory/scoutIntel.ts
+++ b/prod/src/territory/scoutIntel.ts
@@ -133,12 +133,14 @@ export function validateTerritoryScoutIntelForClaim({
   colony,
   targetRoom,
   colonyOwnerUsername,
-  gameTime
+  gameTime,
+  allowForeignReservationPressure = false
 }: {
   colony: string;
   targetRoom: string;
   colonyOwnerUsername?: string;
   gameTime: number;
+  allowForeignReservationPressure?: boolean;
 }): TerritoryScoutValidationResult {
   const attempt = getTerritoryScoutAttempt(colony, targetRoom);
   const intel = getTerritoryScoutIntel(colony, targetRoom);
@@ -168,7 +170,8 @@ export function validateTerritoryScoutIntelForClaim({
 
   if (
     isNonEmptyString(controller.reservationUsername) &&
-    controller.reservationUsername !== colonyOwnerUsername
+    controller.reservationUsername !== colonyOwnerUsername &&
+    allowForeignReservationPressure !== true
   ) {
     return { status: 'blocked', reason: 'controllerReserved', intel };
   }

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -1002,6 +1002,7 @@ declare global {
     startedAt: number;
     updatedAt: number;
     controllerId?: Id<StructureController>;
+    requiresControllerPressure?: boolean;
     reservationConfirmedAt?: number;
     claimedAt?: number;
     completedAt?: number;

--- a/prod/test/claimExecutor.test.ts
+++ b/prod/test/claimExecutor.test.ts
@@ -1234,8 +1234,9 @@ describe('autonomous expansion claim executor', () => {
     });
   });
 
-  it('blocks visible foreign-reserved controllers before autonomous claim planning', () => {
+  it('plans controller-pressure work for visible foreign-reserved controllers', () => {
     const controllerId = 'controller2' as Id<StructureController>;
+    const colony = makeColony({ mineralType: 'O' });
     (Game.rooms as Record<string, Room>).W2N1 = makeTargetRoom('W2N1', {
       controllerId,
       reservationUsername: 'enemy',
@@ -1243,7 +1244,7 @@ describe('autonomous expansion claim executor', () => {
     });
 
     const evaluation = refreshAutonomousExpansionClaimIntent(
-      makeColony(),
+      colony,
       makeReport([
         makeCandidate({
           roomName: 'W2N1',
@@ -1255,13 +1256,33 @@ describe('autonomous expansion claim executor', () => {
     );
 
     expect(evaluation).toMatchObject({
-      status: 'skipped',
+      status: 'planned',
       colony: 'W1N1',
       targetRoom: 'W2N1',
       controllerId,
-      reason: 'controllerReserved'
+      requiresControllerPressure: true
     });
-    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        createdBy: 'autonomousExpansionClaim',
+        controllerId
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 152,
+        createdBy: 'autonomousExpansionClaim',
+        controllerId,
+        requiresControllerPressure: true
+      }
+    ]);
     expect(Memory.territory?.scoutIntel?.['W1N1>W2N1']).toMatchObject({
       colony: 'W1N1',
       roomName: 'W2N1',
@@ -1763,13 +1784,15 @@ function makeCandidate({
   controllerId,
   source = 'adjacent',
   action = 'reserve',
-  sourceCount = 1
+  sourceCount = 1,
+  requiresControllerPressure = false
 }: {
   roomName: string;
   controllerId?: Id<StructureController>;
   source?: OccupationRecommendationScore['source'];
   action?: OccupationRecommendationScore['action'];
   sourceCount?: number | null;
+  requiresControllerPressure?: boolean;
 }): OccupationRecommendationScore {
   return {
     roomName,
@@ -1782,6 +1805,7 @@ function makeCandidate({
     risks: [],
     routeDistance: 1,
     roadDistance: 1,
+    ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(typeof sourceCount === 'number' ? { sourceCount } : {}),
     ...(controllerId ? { controllerId } : {})
   };

--- a/prod/test/expansionScoring.test.ts
+++ b/prod/test/expansionScoring.test.ts
@@ -1235,6 +1235,130 @@ describe('next expansion scoring', () => {
     });
   });
 
+  it('uses fresh source-scarce scout proof to persist a controller-pressure claim target', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        scoutIntel: {
+          'W1N1>W2N1': makeScoutIntel('W2N1', {
+            updatedAt: 800,
+            sourceCount: 1,
+            controller: {
+              id: 'controller-W2N1' as Id<StructureController>,
+              my: false,
+              reservationUsername: 'enemy',
+              reservationTicksToEnd: 3_000
+            }
+          })
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 801,
+      rooms: {
+        W1N1: colony.room
+      }
+    };
+
+    const report = scoreExpansionCandidates(
+      makeInput(
+        [makeUnscoredCandidate('W2N1', 0)],
+        {
+          claimedRooms: [{ roomName: 'W1N1', sourceCount: 1 }]
+        }
+      )
+    );
+
+    expect(report.next).toMatchObject({
+      roomName: 'W2N1',
+      evidenceStatus: 'sufficient',
+      visible: false,
+      sourceCount: 1,
+      requiresControllerPressure: true,
+      reservation: { username: 'enemy', relation: 'foreign', ticksToEnd: 3_000 }
+    });
+    expect(report.next?.rationale).toContain('synergy fills energy source coverage gap');
+    expect(refreshNextExpansionTargetSelection(colony, report, 801)).toEqual({
+      status: 'planned',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      controllerId: 'controller-W2N1',
+      score: report.candidates[0].score
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        createdBy: 'nextExpansionScoring',
+        controllerId: 'controller-W2N1'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 801,
+        createdBy: 'nextExpansionScoring',
+        controllerId: 'controller-W2N1',
+        requiresControllerPressure: true
+      }
+    ]);
+  });
+
+  it('keeps source-scarce controller-pressure candidates blocked when scout proof finds hostiles', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        scoutIntel: {
+          'W1N1>W2N1': makeScoutIntel('W2N1', {
+            updatedAt: 800,
+            sourceCount: 1,
+            hostileCreepCount: 1,
+            controller: {
+              id: 'controller-W2N1' as Id<StructureController>,
+              my: false,
+              reservationUsername: 'enemy',
+              reservationTicksToEnd: 3_000
+            }
+          })
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 801,
+      rooms: {
+        W1N1: colony.room
+      }
+    };
+
+    const report = scoreExpansionCandidates(
+      makeInput(
+        [makeUnscoredCandidate('W2N1', 0)],
+        {
+          claimedRooms: [{ roomName: 'W1N1', sourceCount: 1 }]
+        }
+      )
+    );
+
+    expect(getCandidate(report, 'W2N1')).toMatchObject({
+      roomName: 'W2N1',
+      evidenceStatus: 'unavailable',
+      hostileCreepCount: 1,
+      blockReason: 'targetHostile'
+    });
+    expect(report.next).toBeNull();
+    expect(refreshNextExpansionTargetSelection(colony, report, 801)).toEqual({
+      status: 'skipped',
+      colony: 'W1N1',
+      reason: 'unavailable'
+    });
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.intents).toBeUndefined();
+  });
+
   it('requests a scout refresh instead of claiming from stale second-ring intel', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {

--- a/prod/test/expansionTrigger.test.ts
+++ b/prod/test/expansionTrigger.test.ts
@@ -77,6 +77,82 @@ describe('autonomous expansion trigger pipeline', () => {
     });
   });
 
+  it('passes controller-pressure scout validation through the autonomous pipeline', () => {
+    const gameTime = 40;
+    const controllerId = 'controller2' as Id<StructureController>;
+    const colony = makeColony({
+      storageEnergy: 2_000,
+      rcl: 5,
+      energyAvailable: getExpansionTriggerRequiredEnergy(5),
+      energyCapacityAvailable: 1800
+    });
+    const report = makeReport([
+      makeCandidate({
+        roomName: 'W2N1',
+        evidenceStatus: 'insufficient-evidence',
+        visible: false,
+        controllerId,
+        requiresControllerPressure: true
+      })
+    ]);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        scoutIntel: {
+          'W1N1>W2N1': {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            updatedAt: gameTime - 1,
+            controller: {
+              id: controllerId,
+              my: false,
+              reservationUsername: 'enemy',
+              reservationTicksToEnd: 3_000
+            },
+            sourceIds: ['source1'],
+            sourceCount: 1,
+            hostileCreepCount: 0,
+            hostileStructureCount: 0,
+            hostileSpawnCount: 0
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: gameTime,
+      rooms: {
+        W1N1: colony.room
+      }
+    };
+    setSafeHomeThreat('W1N1', gameTime);
+
+    expect(refreshAutonomousExpansionPipeline(colony, report, gameTime)).toMatchObject({
+      status: 'planned',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      controllerId,
+      score: 900
+    });
+    expect(Memory.territory?.expansionPipelines?.W1N1).toMatchObject({
+      status: 'active',
+      stage: 'reserving',
+      targetRoom: 'W2N1',
+      controllerId,
+      requiresControllerPressure: true
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: gameTime,
+        createdBy: 'nextExpansionScoring',
+        controllerId,
+        requiresControllerPressure: true
+      }
+    ]);
+  });
+
   it('starts a Seasonal RCL3 pipeline when room energy reaches the RCL3 threshold', () => {
     const threshold = getExpansionTriggerRequiredEnergy(3);
     expect(threshold).toBe(800);
@@ -978,13 +1054,15 @@ function makeCandidate({
   score = 900,
   evidenceStatus = 'sufficient',
   visible = true,
-  controllerId = `${roomName}-controller` as Id<StructureController>
+  controllerId = `${roomName}-controller` as Id<StructureController>,
+  requiresControllerPressure = false
 }: {
   roomName: string;
   score?: number;
   evidenceStatus?: ExpansionCandidateScore['evidenceStatus'];
   visible?: boolean;
   controllerId?: Id<StructureController> | null;
+  requiresControllerPressure?: boolean;
 }): ExpansionCandidateScore {
   return {
     roomName,
@@ -997,6 +1075,7 @@ function makeCandidate({
     risks: [],
     adjacentToOwnedRoom: true,
     sourceCount: 2,
+    ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(controllerId ? { controllerId } : {})
   };
 }


### PR DESCRIPTION
## Summary
- Preserves pressure-aware source-scarce expansion candidates during final scout-intel validation when the scorer already marked the candidate as needing controller pressure.
- Keeps default scout validation strict for normal candidates and keeps hostile scout proof blocking the same candidate.
- Adds regression coverage for the foreign-reserved controller-pressure path and rebuilds `prod/dist/main.js`.

Fixes #1647

## Verification
- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand` (all listed suites PASS; controller foreground timed out at 60s while printing Jest output, no Jest/npm child remained afterward)
- [x] `cd prod && npm run build`
- [x] Controller rechecked clean worktree and Codex-authored commit `07adaebe lanyusea's bot <lanyusea@gmail.com> territory: preserve controller-pressure scout validation`

## Universal task Done gate
- [x] Task type: code recovery / Territory-Economy follow-up.
- [x] Expected observable outcome / named deliverable: stale dirty issue #1540 worktree is reconciled into a clean Codex-authored follow-up PR, preserving only the still-valid controller-pressure scout-validation fix.
- [x] Non-goals / accepted substitutes: does not retarget rooms, deploy to official MMO, or change unrelated expansion scoring thresholds.
- [x] Verification evidence required before Done: controller-side `git diff --check`, TypeScript typecheck, Jest run, production bundle build, and exact-head PR checks/review gates before merge.
- [x] Project Evidence / Next action / Blocked by: ProjectV2 field repair is temporarily blocked by GitHub GraphQL quota exhaustion observed during scheduler run; REST issue/PR evidence records the intended state until the next Project repair slice.
- [x] Post-merge/deploy/runtime proof: gameplay-affecting change requires normal post-merge official deploy floor and subsequent runtime observation before any gameplay acceptance issue is closed.
- [x] Named deliverable proof: PR head contains `prod/src/territory/scoutIntel.ts`, `prod/src/territory/expansionScoring.ts`, `prod/test/expansionScoring.test.ts`, and regenerated `prod/dist/main.js`.

## Issue closure gate
- [x] #1647: the stale dirty worktree has been classified as FIX by `/tmp/issue1540-dirty-reconcile-triage.md`, controller-verified, committed by Codex, and routed to this PR for review/merge.
- [x] No closed issue still needs owner action; post-merge deployment/runtime acceptance remains handled by the normal deploy floor rather than by #1647 itself.
