### PR TITLE
telemetry: expose construction suppression and idle reasons

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -38951,7 +38951,7 @@ function selectWorkerIdleReason(worker, cpuBudget) {
   if (!memory) {
     return "room_snapshot_missing_creep_memory";
   }
-  if (memory.task) {
+  if (getWorkerTaskType(worker)) {
     return null;
   }
   if (hasObservableWorkerBody(worker) && !hasAnyActiveWorkerBodyPart(worker)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -38660,6 +38660,7 @@ var MAX_WORKER_EFFICIENCY_REASON_SAMPLES = 5;
 var MAX_REFILL_DELIVERY_SAMPLES = 5;
 var MAX_SPAWN_CRITICAL_REFILL_SAMPLES = 5;
 var MAX_WORKER_ASSIGNMENT_BLOCKED_WORKERS = 12;
+var MAX_WORKER_IDLE_REASON_WORKERS = 8;
 var MAX_TERRITORY_INTENT_SUMMARIES = 5;
 var WORKER_EFFICIENCY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 var WORKER_BEHAVIOR_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
@@ -38838,9 +38839,10 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
   const assignedTaskCount = countAssignedWorkerTasks(colonyWorkers);
   const workerAssignmentEvidence = summarizeWorkerAssignmentEvidence(
     tick,
-    colonyWorkers.length,
+    colonyWorkers,
     assignedTaskCount,
-    resourcesWithoutActivity.productiveEnergy.assignedWorkerCount
+    resourcesWithoutActivity.productiveEnergy.assignedWorkerCount,
+    cpuBudget
   );
   const constructionDeadlockTicks = getRoomConstructionDeadlockTicks(colony.room);
   const survival = summarizeSurvival(colony, roleCounts);
@@ -38903,15 +38905,82 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     ...buildPostClaimBootstrapSummary(colony.room.name)
   };
 }
-function summarizeWorkerAssignmentEvidence(tick, workerCount, assignedTaskCount, productiveAssignmentCount) {
+function summarizeWorkerAssignmentEvidence(tick, workers, assignedTaskCount, productiveAssignmentCount, cpuBudget) {
+  const idleSummary = summarizeWorkerIdleReasons(workers, cpuBudget);
   return {
     source: "runtime-summary",
     available: true,
     tick,
-    workerCount,
+    workerCount: workers.length,
     assignedTaskCount,
-    productiveAssignmentCount
+    productiveAssignmentCount,
+    unassignedWorkerCount: idleSummary.unassignedWorkerCount,
+    idleReasonCounts: idleSummary.reasonCounts,
+    ...idleSummary.workers.length > 0 ? { idleWorkers: idleSummary.workers } : {}
   };
+}
+function summarizeWorkerIdleReasons(workers, cpuBudget) {
+  const reasonCounts = createEmptyWorkerIdleReasonCounts();
+  const idleWorkers = [];
+  let unassignedWorkerCount = 0;
+  for (const worker of workers) {
+    const reason = selectWorkerIdleReason(worker, cpuBudget);
+    if (!reason) {
+      continue;
+    }
+    unassignedWorkerCount += 1;
+    reasonCounts[reason] += 1;
+    if (idleWorkers.length < MAX_WORKER_IDLE_REASON_WORKERS) {
+      idleWorkers.push(formatWorkerIdleReasonDetail(worker, reason));
+    }
+  }
+  idleWorkers.sort(compareWorkerIdleReasonDetails);
+  return { unassignedWorkerCount, reasonCounts, workers: idleWorkers };
+}
+function createEmptyWorkerIdleReasonCounts() {
+  return {
+    cpu_shed_assignment_skipped: 0,
+    no_task_available: 0,
+    role_body_unavailable: 0,
+    room_snapshot_missing_creep_memory: 0,
+    task_assignment_not_observed: 0
+  };
+}
+function selectWorkerIdleReason(worker, cpuBudget) {
+  const memory = worker.memory;
+  if (!memory) {
+    return "room_snapshot_missing_creep_memory";
+  }
+  if (memory.task) {
+    return null;
+  }
+  if (hasObservableWorkerBody(worker) && !hasAnyActiveWorkerBodyPart(worker)) {
+    return "role_body_unavailable";
+  }
+  const diagnostic = getCurrentWorkerDispatchDiagnostic(worker);
+  if ((diagnostic == null ? void 0 : diagnostic.reason) === "no_selected_task_idle") {
+    return "no_task_available";
+  }
+  if (shouldShedNonessentialCpuWork(cpuBudget) && diagnostic === null) {
+    return "cpu_shed_assignment_skipped";
+  }
+  return "task_assignment_not_observed";
+}
+function formatWorkerIdleReasonDetail(worker, reason) {
+  const diagnostic = getCurrentWorkerDispatchDiagnostic(worker);
+  return {
+    ...getWorkerName(worker) ? { name: getWorkerName(worker) } : {},
+    reason,
+    carriedEnergy: getEnergyInStore(worker),
+    freeCapacity: getFreeEnergyCapacityInStore(worker),
+    ...diagnostic ? { dispatchReason: diagnostic.reason, dispatchTick: diagnostic.tick } : {},
+    ...(diagnostic == null ? void 0 : diagnostic.selectedTask) ? { dispatchSelectedTask: diagnostic.selectedTask } : {},
+    ...(diagnostic == null ? void 0 : diagnostic.assignedTask) ? { dispatchAssignedTask: diagnostic.assignedTask } : {}
+  };
+}
+function compareWorkerIdleReasonDetails(left, right) {
+  var _a2, _b;
+  return left.reason.localeCompare(right.reason) || right.carriedEnergy - left.carriedEnergy || ((_a2 = left.name) != null ? _a2 : "").localeCompare((_b = right.name) != null ? _b : "");
 }
 function emptyConstructionPrioritySummary() {
   return {
@@ -38974,6 +39043,14 @@ function summarizeConstructionActivity(productiveEnergy, constructionPriority, e
       state: "candidate_suppressed",
       accepted: true,
       reason: selectConstructionActivitySuppressedReason(productiveEnergy, cpuBudget)
+    };
+  }
+  if (productiveEnergy.constructionSiteCount > 0 && productiveEnergy.pendingBuildProgress <= 0) {
+    return {
+      ...common,
+      state: "no_viable_candidate",
+      accepted: false,
+      reason: "construction_site_progress_unavailable"
     };
   }
   if (productiveEnergy.constructionSiteCount > 0 || productiveEnergy.pendingBuildProgress > 0) {
@@ -40329,8 +40406,11 @@ function summarizeProductiveEnergy(colony, colonyWorkers, constructionSites, roo
 }
 function selectBuildBlockedReason(colony, colonyWorkers, productiveAssignments, pendingBuildProgress, constructionSiteCount, events) {
   var _a2;
-  if (constructionSiteCount <= 0 || pendingBuildProgress <= 0) {
+  if (constructionSiteCount <= 0) {
     return "no_construction_sites";
+  }
+  if (pendingBuildProgress <= 0) {
+    return "construction_site_progress_unavailable";
   }
   if (((_a2 = events == null ? void 0 : events.builtProgress) != null ? _a2 : 0) > 0 || productiveAssignments.buildCarriedEnergy > 0) {
     return void 0;
@@ -40546,6 +40626,15 @@ function hasConstructionEnergyAcquisitionTask(creep) {
 }
 function isConstructionCapableWorker(creep) {
   return hasActiveBodyPart(creep, "WORK", "work") && getEnergyCapacityInStore(creep) > 0;
+}
+function hasObservableWorkerBody(creep) {
+  if (typeof creep.getActiveBodyparts === "function") {
+    return true;
+  }
+  return Array.isArray(creep.body);
+}
+function hasAnyActiveWorkerBodyPart(creep) {
+  return hasActiveBodyPart(creep, "WORK", "work") || hasActiveBodyPart(creep, "CARRY", "carry") || hasActiveBodyPart(creep, "MOVE", "move");
 }
 function hasActiveBodyPart(creep, globalName, fallback) {
   var _a2, _b;

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -1329,7 +1329,7 @@ function selectWorkerIdleReason(
     return 'room_snapshot_missing_creep_memory';
   }
 
-  if (memory.task) {
+  if (getWorkerTaskType(worker)) {
     return null;
   }
 

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -105,6 +105,7 @@ const MAX_WORKER_EFFICIENCY_REASON_SAMPLES = 5;
 const MAX_REFILL_DELIVERY_SAMPLES = 5;
 const MAX_SPAWN_CRITICAL_REFILL_SAMPLES = 5;
 const MAX_WORKER_ASSIGNMENT_BLOCKED_WORKERS = 12;
+const MAX_WORKER_IDLE_REASON_WORKERS = 8;
 const MAX_TERRITORY_INTENT_SUMMARIES = 5;
 const WORKER_EFFICIENCY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 const WORKER_BEHAVIOR_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
@@ -120,6 +121,7 @@ const DEFAULT_EXTENSION_ENERGY_CAPACITY = 50;
 type WorkerTaskType = (typeof WORKER_TASK_TYPES)[number];
 type ProductiveWorkerTaskType = (typeof PRODUCTIVE_WORKER_TASK_TYPES)[number];
 type RuntimeBuildBlockedReason =
+  | 'construction_site_progress_unavailable'
   | 'energy_buffer_blocked'
   | 'no_construction_sites'
   | 'worker_assignment_gap';
@@ -136,7 +138,15 @@ type RuntimeConstructionActivityReason =
   | 'spawn_reserving_energy'
   | 'worker_assignment_gap'
   | 'scored_candidate_available'
+  | 'construction_site_progress_unavailable'
   | 'no_viable_candidate';
+type RuntimeWorkerIdleReason =
+  | 'cpu_shed_assignment_skipped'
+  | 'no_task_available'
+  | 'role_body_unavailable'
+  | 'room_snapshot_missing_creep_memory'
+  | 'task_assignment_not_observed';
+type RuntimeWorkerIdleReasonCounts = Record<RuntimeWorkerIdleReason, number>;
 type RuntimeWorkerAssignmentBlockedDetail =
   | 'energy_buffer_below_threshold'
   | 'energy_buffer_spend_margin'
@@ -610,6 +620,9 @@ interface RuntimeWorkerAssignmentEvidenceSummary {
   workerCount: number;
   assignedTaskCount: number;
   productiveAssignmentCount: number;
+  unassignedWorkerCount: number;
+  idleReasonCounts: RuntimeWorkerIdleReasonCounts;
+  idleWorkers?: RuntimeWorkerIdleWorkerDetail[];
 }
 
 interface RuntimeConstructionActivitySummary {
@@ -635,6 +648,17 @@ interface RuntimeConstructionActivityCandidateSummary {
   score: number;
   urgency: ConstructionPriorityUrgency;
   policyAction?: ConstructionPriorityPolicyAction;
+}
+
+interface RuntimeWorkerIdleWorkerDetail {
+  name?: string;
+  reason: RuntimeWorkerIdleReason;
+  carriedEnergy: number;
+  freeCapacity: number;
+  dispatchReason?: WorkerDispatchDiagnosticReason;
+  dispatchSelectedTask?: string;
+  dispatchAssignedTask?: string;
+  dispatchTick?: number;
 }
 
 interface RuntimeWorkerAssignmentBlockedWorkerDetail {
@@ -1166,9 +1190,10 @@ function summarizeRoom(
   const assignedTaskCount = countAssignedWorkerTasks(colonyWorkers);
   const workerAssignmentEvidence = summarizeWorkerAssignmentEvidence(
     tick,
-    colonyWorkers.length,
+    colonyWorkers,
     assignedTaskCount,
-    resourcesWithoutActivity.productiveEnergy.assignedWorkerCount
+    resourcesWithoutActivity.productiveEnergy.assignedWorkerCount,
+    cpuBudget
   );
   const constructionDeadlockTicks = getRoomConstructionDeadlockTicks(colony.room);
   const survival = summarizeSurvival(colony, roleCounts);
@@ -1237,18 +1262,118 @@ function summarizeRoom(
 
 function summarizeWorkerAssignmentEvidence(
   tick: number,
-  workerCount: number,
+  workers: Creep[],
   assignedTaskCount: number,
-  productiveAssignmentCount: number
+  productiveAssignmentCount: number,
+  cpuBudget: RuntimeCpuBudget
 ): RuntimeWorkerAssignmentEvidenceSummary {
+  const idleSummary = summarizeWorkerIdleReasons(workers, cpuBudget);
   return {
     source: 'runtime-summary',
     available: true,
     tick,
-    workerCount,
+    workerCount: workers.length,
     assignedTaskCount,
-    productiveAssignmentCount
+    productiveAssignmentCount,
+    unassignedWorkerCount: idleSummary.unassignedWorkerCount,
+    idleReasonCounts: idleSummary.reasonCounts,
+    ...(idleSummary.workers.length > 0 ? { idleWorkers: idleSummary.workers } : {})
   };
+}
+
+function summarizeWorkerIdleReasons(
+  workers: Creep[],
+  cpuBudget: RuntimeCpuBudget
+): {
+  unassignedWorkerCount: number;
+  reasonCounts: RuntimeWorkerIdleReasonCounts;
+  workers: RuntimeWorkerIdleWorkerDetail[];
+} {
+  const reasonCounts = createEmptyWorkerIdleReasonCounts();
+  const idleWorkers: RuntimeWorkerIdleWorkerDetail[] = [];
+  let unassignedWorkerCount = 0;
+
+  for (const worker of workers) {
+    const reason = selectWorkerIdleReason(worker, cpuBudget);
+    if (!reason) {
+      continue;
+    }
+
+    unassignedWorkerCount += 1;
+    reasonCounts[reason] += 1;
+    if (idleWorkers.length < MAX_WORKER_IDLE_REASON_WORKERS) {
+      idleWorkers.push(formatWorkerIdleReasonDetail(worker, reason));
+    }
+  }
+
+  idleWorkers.sort(compareWorkerIdleReasonDetails);
+  return { unassignedWorkerCount, reasonCounts, workers: idleWorkers };
+}
+
+function createEmptyWorkerIdleReasonCounts(): RuntimeWorkerIdleReasonCounts {
+  return {
+    cpu_shed_assignment_skipped: 0,
+    no_task_available: 0,
+    role_body_unavailable: 0,
+    room_snapshot_missing_creep_memory: 0,
+    task_assignment_not_observed: 0
+  };
+}
+
+function selectWorkerIdleReason(
+  worker: Creep,
+  cpuBudget: RuntimeCpuBudget
+): RuntimeWorkerIdleReason | null {
+  const memory = worker.memory;
+  if (!memory) {
+    return 'room_snapshot_missing_creep_memory';
+  }
+
+  if (memory.task) {
+    return null;
+  }
+
+  if (hasObservableWorkerBody(worker) && !hasAnyActiveWorkerBodyPart(worker)) {
+    return 'role_body_unavailable';
+  }
+
+  const diagnostic = getCurrentWorkerDispatchDiagnostic(worker);
+  if (diagnostic?.reason === 'no_selected_task_idle') {
+    return 'no_task_available';
+  }
+
+  if (shouldShedNonessentialCpuWork(cpuBudget) && diagnostic === null) {
+    return 'cpu_shed_assignment_skipped';
+  }
+
+  return 'task_assignment_not_observed';
+}
+
+function formatWorkerIdleReasonDetail(
+  worker: Creep,
+  reason: RuntimeWorkerIdleReason
+): RuntimeWorkerIdleWorkerDetail {
+  const diagnostic = getCurrentWorkerDispatchDiagnostic(worker);
+  return {
+    ...(getWorkerName(worker) ? { name: getWorkerName(worker) } : {}),
+    reason,
+    carriedEnergy: getEnergyInStore(worker),
+    freeCapacity: getFreeEnergyCapacityInStore(worker),
+    ...(diagnostic ? { dispatchReason: diagnostic.reason, dispatchTick: diagnostic.tick } : {}),
+    ...(diagnostic?.selectedTask ? { dispatchSelectedTask: diagnostic.selectedTask } : {}),
+    ...(diagnostic?.assignedTask ? { dispatchAssignedTask: diagnostic.assignedTask } : {})
+  };
+}
+
+function compareWorkerIdleReasonDetails(
+  left: RuntimeWorkerIdleWorkerDetail,
+  right: RuntimeWorkerIdleWorkerDetail
+): number {
+  return (
+    left.reason.localeCompare(right.reason) ||
+    (right.carriedEnergy - left.carriedEnergy) ||
+    (left.name ?? '').localeCompare(right.name ?? '')
+  );
 }
 
 function emptyConstructionPrioritySummary(): RuntimeConstructionPrioritySummary {
@@ -1333,6 +1458,15 @@ function summarizeConstructionActivity(
       state: 'candidate_suppressed',
       accepted: true,
       reason: selectConstructionActivitySuppressedReason(productiveEnergy, cpuBudget)
+    };
+  }
+
+  if (productiveEnergy.constructionSiteCount > 0 && productiveEnergy.pendingBuildProgress <= 0) {
+    return {
+      ...common,
+      state: 'no_viable_candidate',
+      accepted: false,
+      reason: 'construction_site_progress_unavailable'
     };
   }
 
@@ -3404,8 +3538,12 @@ function selectBuildBlockedReason(
   constructionSiteCount: number,
   events: RuntimeResourceEventSummary | undefined
 ): RuntimeBuildBlockedReason | undefined {
-  if (constructionSiteCount <= 0 || pendingBuildProgress <= 0) {
+  if (constructionSiteCount <= 0) {
     return 'no_construction_sites';
+  }
+
+  if (pendingBuildProgress <= 0) {
+    return 'construction_site_progress_unavailable';
   }
 
   if ((events?.builtProgress ?? 0) > 0 || productiveAssignments.buildCarriedEnergy > 0) {
@@ -3736,9 +3874,25 @@ function isConstructionCapableWorker(creep: Creep): boolean {
   return hasActiveBodyPart(creep, 'WORK', 'work') && getEnergyCapacityInStore(creep) > 0;
 }
 
+function hasObservableWorkerBody(creep: Creep): boolean {
+  if (typeof creep.getActiveBodyparts === 'function') {
+    return true;
+  }
+
+  return Array.isArray((creep as Creep & { body?: Array<{ type?: BodyPartConstant; hits?: number }> }).body);
+}
+
+function hasAnyActiveWorkerBodyPart(creep: Creep): boolean {
+  return (
+    hasActiveBodyPart(creep, 'WORK', 'work') ||
+    hasActiveBodyPart(creep, 'CARRY', 'carry') ||
+    hasActiveBodyPart(creep, 'MOVE', 'move')
+  );
+}
+
 function hasActiveBodyPart(
   creep: Creep,
-  globalName: 'WORK',
+  globalName: 'WORK' | 'CARRY' | 'MOVE',
   fallback: BodyPartConstant
 ): boolean {
   const bodyPart = ((globalThis as Partial<Record<typeof globalName, BodyPartConstant>>)[globalName] ??

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -114,7 +114,22 @@ describe('runtime telemetry summaries', () => {
             tick: RUNTIME_SUMMARY_INTERVAL,
             workerCount: 2,
             assignedTaskCount: 1,
-            productiveAssignmentCount: 0
+            productiveAssignmentCount: 0,
+            unassignedWorkerCount: 1,
+            idleReasonCounts: {
+              cpu_shed_assignment_skipped: 0,
+              no_task_available: 0,
+              role_body_unavailable: 0,
+              room_snapshot_missing_creep_memory: 0,
+              task_assignment_not_observed: 1
+            },
+            idleWorkers: [
+              {
+                reason: 'task_assignment_not_observed',
+                carriedEnergy: 20,
+                freeCapacity: 0
+              }
+            ]
           },
           spawnStatus: [
             {
@@ -1702,6 +1717,39 @@ describe('runtime telemetry summaries', () => {
     expect(productiveEnergy.constructionActivity).toEqual(room.constructionActivity);
   });
 
+  it('distinguishes visible construction sites without pending progress from absent construction sites', () => {
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      includeEventLog: false,
+      constructionSites: [
+        {
+          id: 'opaque-extension-site',
+          structureType: TEST_GLOBALS.STRUCTURE_EXTENSION
+        }
+      ]
+    });
+
+    emitRuntimeSummary([colony], []);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    const productiveEnergy = (room.resources as Record<string, Record<string, unknown>>).productiveEnergy;
+    expect(productiveEnergy.buildBlockedReason).toBe('construction_site_progress_unavailable');
+    expect(room.constructionActivity).toMatchObject({
+      source: 'runtime-summary',
+      state: 'no_viable_candidate',
+      accepted: false,
+      reason: 'construction_site_progress_unavailable',
+      constructionSiteCount: 1,
+      pendingBuildProgress: 0,
+      buildCarriedEnergy: 0,
+      buildProgress: 0,
+      workerAssignmentEvidenceAvailable: true,
+      buildBlockedReason: 'construction_site_progress_unavailable'
+    });
+    expect(productiveEnergy.constructionActivity).toEqual(room.constructionActivity);
+  });
+
   it('marks construction activity as candidate suppressed when a scored candidate has no site yet', () => {
     const colony = makeColony({
       time: RUNTIME_SUMMARY_INTERVAL,
@@ -1826,10 +1874,155 @@ describe('runtime telemetry summaries', () => {
       tick: RUNTIME_SUMMARY_INTERVAL,
       workerCount: 1,
       assignedTaskCount: 0,
-      productiveAssignmentCount: 0
+      productiveAssignmentCount: 0,
+      unassignedWorkerCount: 1,
+      idleReasonCounts: {
+        cpu_shed_assignment_skipped: 0,
+        no_task_available: 0,
+        role_body_unavailable: 0,
+        room_snapshot_missing_creep_memory: 0,
+        task_assignment_not_observed: 1
+      },
+      idleWorkers: [
+        {
+          name: 'worker-E29N55-idle',
+          reason: 'task_assignment_not_observed',
+          carriedEnergy: 0,
+          freeCapacity: 0
+        }
+      ]
     });
     expect(productiveEnergy.workerAssignmentEvidenceAvailable).toBe(true);
     expect(productiveEnergy.buildBlockedReason).toBe('worker_assignment_gap');
+  });
+
+  it('reports no-task idle reasons from current worker dispatch diagnostics', () => {
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      includeEventLog: false
+    });
+    const idleWorker = makeWorker(
+      {
+        role: 'worker',
+        colony: 'W1N1',
+        workerDispatchDiagnostic: {
+          tick: RUNTIME_SUMMARY_INTERVAL,
+          reason: 'no_selected_task_idle',
+          carriedEnergy: 50,
+          freeCapacity: 0
+        }
+      },
+      50,
+      'NoTaskWorker'
+    );
+
+    emitRuntimeSummary([colony], [idleWorker]);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.workerAssignmentEvidence).toMatchObject({
+      workerCount: 1,
+      assignedTaskCount: 0,
+      unassignedWorkerCount: 1,
+      idleReasonCounts: {
+        cpu_shed_assignment_skipped: 0,
+        no_task_available: 1,
+        role_body_unavailable: 0,
+        room_snapshot_missing_creep_memory: 0,
+        task_assignment_not_observed: 0
+      },
+      idleWorkers: [
+        {
+          name: 'NoTaskWorker',
+          reason: 'no_task_available',
+          carriedEnergy: 50,
+          freeCapacity: 0,
+          dispatchReason: 'no_selected_task_idle',
+          dispatchTick: RUNTIME_SUMMARY_INTERVAL
+        }
+      ]
+    });
+  });
+
+  it('reports role or body unavailable when an unassigned worker has no active body parts', () => {
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      includeEventLog: false
+    });
+    const bodylessWorker = {
+      name: 'BodylessWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      body: [],
+      store: makeEnergyStore(0, 50)
+    } as unknown as Creep;
+
+    emitRuntimeSummary([colony], [bodylessWorker]);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.workerAssignmentEvidence).toMatchObject({
+      workerCount: 1,
+      assignedTaskCount: 0,
+      unassignedWorkerCount: 1,
+      idleReasonCounts: {
+        cpu_shed_assignment_skipped: 0,
+        no_task_available: 0,
+        role_body_unavailable: 1,
+        room_snapshot_missing_creep_memory: 0,
+        task_assignment_not_observed: 0
+      },
+      idleWorkers: [
+        {
+          name: 'BodylessWorker',
+          reason: 'role_body_unavailable',
+          carriedEnergy: 0,
+          freeCapacity: 50
+        }
+      ]
+    });
+  });
+
+  it('reports CPU-shed idle workers when assignment was skipped without current dispatch evidence', () => {
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL * 5,
+      includeEventLog: false
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game.cpu = {
+      getUsed: jest.fn().mockReturnValue(1),
+      limit: 100,
+      bucket: 500,
+      tickLimit: 500
+    } as unknown as CPU;
+    const idleWorker = makeWorker({ role: 'worker', colony: 'W1N1' }, 0, 'CpuSkippedWorker');
+
+    emitRuntimeSummary([colony], [idleWorker]);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.workerAssignmentEvidence).toMatchObject({
+      workerCount: 1,
+      assignedTaskCount: 0,
+      unassignedWorkerCount: 1,
+      idleReasonCounts: {
+        cpu_shed_assignment_skipped: 1,
+        no_task_available: 0,
+        role_body_unavailable: 0,
+        room_snapshot_missing_creep_memory: 0,
+        task_assignment_not_observed: 0
+      },
+      idleWorkers: [
+        {
+          name: 'CpuSkippedWorker',
+          reason: 'cpu_shed_assignment_skipped',
+          carriedEnergy: 0,
+          freeCapacity: 0
+        }
+      ]
+    });
+    expect(room.constructionActivity).toMatchObject({
+      cpuPressure: 'degraded',
+      cpuReasons: ['lowBucket']
+    });
   });
 
   it('counts non-display worker task assignments as assigned runtime evidence', () => {

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -1896,6 +1896,60 @@ describe('runtime telemetry summaries', () => {
     expect(productiveEnergy.buildBlockedReason).toBe('worker_assignment_gap');
   });
 
+  it('counts malformed stale worker task memory as unassigned idle evidence', () => {
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      roomName: 'E29N55',
+      includeEventLog: false,
+      constructionSites: [
+        { id: 'extension-site', structureType: TEST_GLOBALS.STRUCTURE_EXTENSION, progress: 0, progressTotal: 50 }
+      ]
+    });
+    const malformedTaskWorker = makeWorker(
+      {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { targetId: 'stale-construction-site' } as unknown as CreepMemory['task']
+      },
+      0,
+      'worker-E29N55-malformed-task'
+    );
+
+    emitRuntimeSummary([colony], [malformedTaskWorker]);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.taskCounts).toMatchObject({
+      build: 0,
+      harvest: 0,
+      none: 1,
+      repair: 0,
+      transfer: 0,
+      upgrade: 0
+    });
+    expect(room.workerAssignmentEvidence).toMatchObject({
+      workerCount: 1,
+      assignedTaskCount: 0,
+      productiveAssignmentCount: 0,
+      unassignedWorkerCount: 1,
+      idleReasonCounts: {
+        cpu_shed_assignment_skipped: 0,
+        no_task_available: 0,
+        role_body_unavailable: 0,
+        room_snapshot_missing_creep_memory: 0,
+        task_assignment_not_observed: 1
+      },
+      idleWorkers: [
+        {
+          name: 'worker-E29N55-malformed-task',
+          reason: 'task_assignment_not_observed',
+          carriedEnergy: 0,
+          freeCapacity: 0
+        }
+      ]
+    });
+  });
+
   it('reports no-task idle reasons from current worker dispatch diagnostics', () => {
     const colony = makeColony({
       time: RUNTIME_SUMMARY_INTERVAL,


### PR DESCRIPTION
## Summary
- Adds additive runtime-summary fields that explain construction candidate suppression and worker idle/no-task reasons instead of leaving `taskCounts.none` as an opaque count.
- Aggregates stable worker idle reason counts and examples from current dispatch diagnostics, construction-site state, CPU shedding, energy-buffer/spawn-reservation gates, and body/task availability.
- Extends focused runtime-summary Jest coverage and regenerates `prod/dist/main.js` from the production build.

Fixes #1644

## Verification
- [x] Controller: `git diff --check`
- [x] Controller: `cd prod && npm run typecheck`
- [x] Controller: `cd prod && npm test -- --runInBand` — 104 suites / 2236 tests passed
- [x] Controller: `cd prod && npm run build`
- [x] Commit-only Codex recovery created real linked-worktree commit `96601404bc16b476e200189a7c66422c08f8bc47` with author/committer `lanyusea's bot <lanyusea@gmail.com>` after rejecting the synthetic `.git-local` commit as completion evidence.

## Universal task Done gate
- [x] Task type: code / telemetry instrumentation for RL feedback and gameplay-runtime diagnosis.
- [x] Expected observable outcome / named deliverable: runtime summaries expose machine-readable construction suppression and worker idle/no-task reason telemetry for #1644.
- [x] Non-goals / accepted substitutes: does not tune construction thresholds, deploy an RL policy, retarget rooms, or change expansion candidate selection.
- [x] Verification evidence required before Done: controller `git diff --check`, TypeScript typecheck, full Jest run, production build, exact-head PR checks, automated review gate, and scheduler merge gate evidence.
- [x] Project Evidence / Next action / Blocked by: #1644 Project item is moved to In review with commit/test evidence; no owner-side blocker exists.
- [x] Post-merge/deploy/runtime proof: deploy floor will ship the merged bundle to official MMO, then fresh runtime-summary captures must show the new reason fields before runtime acceptance is counted.
- [x] Named deliverable proof: PR head changes `prod/src/telemetry/runtimeSummary.ts`, `prod/test/runtimeSummary.test.ts`, and generated `prod/dist/main.js`.

## Issue closure gate
- [x] #1644: Codex-authored commit `96601404bc16b476e200189a7c66422c08f8bc47` adds the requested construction suppression and worker idle/no-task reason telemetry, focused tests, and regenerated bundle; controller verification passed (`diff-check`, typecheck, Jest, build).
- [x] No owner action is required; any future runtime tuning from these new fields should use a new smallest atomic issue with fresh post-deploy telemetry evidence.
