### PR TITLE
runtime: shed construction after CPU over-limit

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -948,6 +948,7 @@ var LOW_CPU_BUCKET_THRESHOLD = 1e3;
 var CRITICAL_CPU_BUCKET_THRESHOLD = 100;
 var DEGRADED_OPTIONAL_WORK_INTERVAL = 5;
 var DEGRADED_ROOM_OPTIONAL_WORK_INTERVAL = 3;
+var CPU_BUCKET_RECOVERY_HEADROOM_MULTIPLIER = 2;
 var REPEATED_BUCKET_EMPTY_TICKS = 2;
 var SUSTAINED_OVER_LIMIT_TICKS = 2;
 var cpuTelemetryState = {
@@ -1065,7 +1066,7 @@ function hasLowBucketRecoveryPressure(sample) {
 }
 function getCpuBucketRecoveryHeadroom(limit) {
   if (limit !== void 0 && limit > 0) {
-    return Math.ceil(limit);
+    return Math.ceil(limit * CPU_BUCKET_RECOVERY_HEADROOM_MULTIPLIER);
   }
   return LOW_CPU_ACCOUNT_LIMIT;
 }

--- a/prod/src/runtime/cpuBudget.ts
+++ b/prod/src/runtime/cpuBudget.ts
@@ -59,6 +59,7 @@ export const LOW_CPU_BUCKET_THRESHOLD = 1_000;
 export const CRITICAL_CPU_BUCKET_THRESHOLD = 100;
 export const DEGRADED_OPTIONAL_WORK_INTERVAL = 5;
 export const DEGRADED_ROOM_OPTIONAL_WORK_INTERVAL = 3;
+const CPU_BUCKET_RECOVERY_HEADROOM_MULTIPLIER = 2;
 const REPEATED_BUCKET_EMPTY_TICKS = 2;
 const SUSTAINED_OVER_LIMIT_TICKS = 2;
 
@@ -238,7 +239,7 @@ function hasLowBucketRecoveryPressure(sample: RuntimeCpuSample): boolean {
 
 function getCpuBucketRecoveryHeadroom(limit: number | undefined): number {
   if (limit !== undefined && limit > 0) {
-    return Math.ceil(limit);
+    return Math.ceil(limit * CPU_BUCKET_RECOVERY_HEADROOM_MULTIPLIER);
   }
 
   return LOW_CPU_ACCOUNT_LIMIT;

--- a/prod/test/cpuBudget.test.ts
+++ b/prod/test/cpuBudget.test.ts
@@ -160,6 +160,39 @@ describe('runtime CPU budget policy', () => {
     expect(shouldShedNonessentialCpuWork(budget)).toBe(true);
   });
 
+  it('keeps optional work paused through the observed post-alert recovery band', () => {
+    const recoveryBudget = buildRuntimeCpuBudget({
+      tick: 1760015,
+      used: 12,
+      limit: 70,
+      bucket: 1_076,
+      tickLimit: 500
+    });
+    const recoveredBudget = buildRuntimeCpuBudget({
+      tick: 1760016,
+      used: 12,
+      limit: 70,
+      bucket: 1_140,
+      tickLimit: 500
+    });
+
+    expect(recoveryBudget).toMatchObject({
+      pressure: 'degraded',
+      degraded: true,
+      critical: false,
+      lowCpuLimit: false,
+      reasons: ['lowBucketRecovery']
+    });
+    expect(shouldRunOptionalCpuWork(recoveryBudget, 'economy-global-optional')).toBe(false);
+    expect(shouldRunOptionalCpuRoomWork(recoveryBudget, 'E29N55')).toBe(false);
+    expect(shouldShedNonessentialCpuWork(recoveryBudget)).toBe(true);
+    expect(recoveredBudget).toMatchObject({
+      pressure: 'normal',
+      degraded: false,
+      reasons: []
+    });
+  });
+
   it('sheds optional work once the current tick exceeds its CPU limit', () => {
     const budget = buildRuntimeCpuBudget({
       tick: 222,


### PR DESCRIPTION
## Summary

Refs #1490.

- Extend CPU bucket recovery headroom so optional work remains shed for a wider recovery band above the low-bucket threshold.
- Add regression coverage for the degraded recovery-band behavior.
- Rebuild the Screeps bundle so `prod/dist/main.js` matches the source change.

## Evidence

- Codex implementation commit: `99b53fd7 runtime: shed construction after CPU over-limit`.
- Controller verification from `/root/screeps-worktrees/issue-1490-cpu-followup`:
  - `git diff --check`
  - `cd prod && npm run typecheck`
  - `cd prod && npm test -- --runInBand` — 104 suites / 2238 tests passed
  - `cd prod && npm run build`
- Runtime context: latest CPU-bearing console artifact `runtime-artifacts/runtime-summary-console/runtime-summary-console-20260603T232908Z.log` showed degraded recovery around bucket `1015-1070` plus one `usedOverLimit` sample at tick `1760015`; fresh read-only monitor artifact `runtime-artifacts/screeps-monitor/rl-steward-check-20260604T0014Z.pSTywF/` showed rooms alive/healthy while direct monitor CPU fields were null.

## Safety

- No deploy, official MMO write, GitHub Project mutation, or issue closure is part of this branch.
- The branch only changes CPU-budget logic, focused tests, and the generated bundle.

## Universal task Done gate

- [x] Task type: production-code runtime CPU-pressure mitigation PR.
- [x] Expected observable outcome / named deliverable: Codex-authored branch that widens optional-work shedding during CPU bucket recovery and keeps the generated Screeps bundle synchronized.
- [x] Non-goals / accepted substitutes: no official deploy, no issue closure, no reward-policy change, no paid Tencent run, no owner-side action.
- [x] Verification evidence required before Done: controller ran diff-check, typecheck, full Jest, and build successfully on commit 99b53fd7.
- [x] Project Evidence / Next action / Blocked by: PR enters review for issue 1490; Project fields record commit/tests and review-gate action.
- [x] Post-merge/deploy/runtime proof: issue 1490 requires official deploy plus CPU-bearing console observation with bucket above 1000 and no lowBucket recurrence.
- [x] Named deliverable proof: commit 99b53fd7 contains the CPU-budget source change, regression test, and rebuilt `prod/dist/main.js`.
