### PR TITLE
runtime-monitor: bound alert timeout diagnostics

### DIFF
--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -43,6 +43,8 @@ DEFAULT_COLLECTION_RETRY_DELAY_SECONDS = 5
 DEFAULT_ALERT_TIMEOUT_SECONDS = 20.0
 ALERT_TIMEOUT_POLL_SECONDS = 0.02
 ALERT_TIMEOUT_TERMINATE_GRACE_SECONDS = 1.0
+DEFERRED_STATE_WRITE_ENV = "SCREEPS_MONITOR_DEFER_STATE_WRITE"
+DEFERRED_STATE_TARGET_ENV = "SCREEPS_MONITOR_DEFER_STATE_TARGET"
 DEFAULT_SHARD = world_profiles.PERSISTENT_DEFAULTS.shard
 DEFAULT_ROOM = world_profiles.PERSISTENT_DEFAULTS.room
 WORLD_PROFILE_ENV = world_profiles.WORLD_PROFILE_ENV
@@ -3835,7 +3837,23 @@ def load_state(path: Path) -> dict[str, Any]:
         return {}
 
 
+def state_paths_match(left: Path, right: Path) -> bool:
+    try:
+        return left.expanduser().resolve(strict=False) == right.expanduser().resolve(strict=False)
+    except OSError:
+        return str(left.expanduser()) == str(right.expanduser())
+
+
+def state_write_path(path: Path) -> Path:
+    deferred_path = os.environ.get(DEFERRED_STATE_WRITE_ENV)
+    deferred_target = os.environ.get(DEFERRED_STATE_TARGET_ENV)
+    if deferred_path and deferred_target and state_paths_match(path, Path(deferred_target)):
+        return Path(deferred_path).expanduser()
+    return path
+
+
 def save_state(path: Path, state: dict[str, Any]) -> None:
+    path = state_write_path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = json.dumps(state, indent=2, sort_keys=True)
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=str(path.parent), delete=False) as handle:
@@ -5898,7 +5916,7 @@ def signal_child_tree(pid: int, signum: int) -> None:
             os.killpg(pid, signum)
             return
         except ProcessLookupError:
-            return
+            pass
         except OSError:
             pass
     try:
@@ -5917,7 +5935,7 @@ def terminate_timed_out_child(pid: int) -> None:
     wait_for_child_exit(pid, ALERT_TIMEOUT_TERMINATE_GRACE_SECONDS)
 
 
-def run_alert_child(args: argparse.Namespace, output_path: Path) -> None:
+def run_alert_child(args: argparse.Namespace, output_path: Path, deferred_state_path: Path, state_file: Path) -> None:
     rc = 1
     try:
         if hasattr(os, "setsid"):
@@ -5925,6 +5943,8 @@ def run_alert_child(args: argparse.Namespace, output_path: Path) -> None:
                 os.setsid()
             except OSError:
                 pass
+        os.environ[DEFERRED_STATE_WRITE_ENV] = str(deferred_state_path)
+        os.environ[DEFERRED_STATE_TARGET_ENV] = str(state_file)
 
         with output_path.open("w", encoding="utf-8") as child_stdout:
             try:
@@ -5942,6 +5962,13 @@ def run_alert_child(args: argparse.Namespace, output_path: Path) -> None:
             child_stdout.flush()
     finally:
         os._exit(normalized_exit_code(rc))
+
+
+def promote_deferred_state(deferred_state_path: Path, state_file: Path) -> None:
+    if not deferred_state_path.exists():
+        return
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    os.replace(deferred_state_path, state_file)
 
 
 def read_text_lossy(path: Path) -> str:
@@ -5991,14 +6018,22 @@ def run_alert_with_process_timeout(args: argparse.Namespace, timeout_seconds: fl
     output_fd, output_name = tempfile.mkstemp(prefix="screeps-alert-stdout-", suffix=".json")
     os.close(output_fd)
     output_path = Path(output_name)
+    deferred_state_fd, deferred_state_name = tempfile.mkstemp(prefix="screeps-alert-state-", suffix=".json")
+    os.close(deferred_state_fd)
+    deferred_state_path = Path(deferred_state_name)
     try:
+        deferred_state_path.unlink()
+    except FileNotFoundError:
+        pass
+    try:
+        state_file = context_from_env(args.world_profile).state_file
         try:
             pid = os.fork()
         except OSError:
             return run_alert_with_signal_timeout(args, timeout_seconds)
 
         if pid == 0:
-            run_alert_child(args, output_path)
+            run_alert_child(args, output_path, deferred_state_path, state_file)
 
         rc = wait_for_child_exit(pid, timeout_seconds)
         if rc is None:
@@ -6007,6 +6042,8 @@ def run_alert_with_process_timeout(args: argparse.Namespace, timeout_seconds: fl
 
         output = read_text_lossy(output_path)
         assert_complete_json_output("alert", rc, output)
+        if rc == 0:
+            promote_deferred_state(deferred_state_path, state_file)
         sys.stdout.write(output)
         if not output.endswith("\n"):
             sys.stdout.write("\n")
@@ -6014,6 +6051,10 @@ def run_alert_with_process_timeout(args: argparse.Namespace, timeout_seconds: fl
     finally:
         try:
             output_path.unlink()
+        except FileNotFoundError:
+            pass
+        try:
+            deferred_state_path.unlink()
         except FileNotFoundError:
             pass
 

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -42,7 +42,29 @@ DEFAULT_DEBOUNCE_SECONDS = 300
 DEFAULT_COLLECTION_ATTEMPTS = 3
 DEFAULT_COLLECTION_RETRY_DELAY_SECONDS = 5
 ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS = 25.0
-DEFAULT_ALERT_TIMEOUT_SECONDS = 60.0
+ALERT_COLLECTION_DISCOVERY_REQUEST_COUNT = 2
+ALERT_COLLECTION_INITIAL_ROOM_REQUEST_COUNT = 1
+ALERT_COLLECTION_FALLBACK_REQUEST_COUNT_PER_ATTEMPT = 2
+
+
+def alert_collection_timeout_budget_seconds(
+    collection_attempts: int = DEFAULT_COLLECTION_ATTEMPTS,
+    collection_retry_delay_seconds: float = DEFAULT_COLLECTION_RETRY_DELAY_SECONDS,
+) -> float:
+    attempts = max(1, int(collection_attempts))
+    retry_delay_seconds = max(0.0, float(collection_retry_delay_seconds))
+    request_count = (
+        ALERT_COLLECTION_DISCOVERY_REQUEST_COUNT
+        + ALERT_COLLECTION_INITIAL_ROOM_REQUEST_COUNT
+        + (attempts * ALERT_COLLECTION_FALLBACK_REQUEST_COUNT_PER_ATTEMPT)
+    )
+    return (
+        request_count * ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS
+        + max(0, attempts - 1) * retry_delay_seconds
+    )
+
+
+DEFAULT_ALERT_TIMEOUT_SECONDS = alert_collection_timeout_budget_seconds()
 ALERT_TIMEOUT_POLL_SECONDS = 0.02
 ALERT_TIMEOUT_TERMINATE_GRACE_SECONDS = 1.0
 DEFERRED_STATE_WRITE_ENV = "SCREEPS_MONITOR_DEFER_STATE_WRITE"

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import errno
 import html
 import json
 import os
@@ -5968,7 +5969,34 @@ def promote_deferred_state(deferred_state_path: Path, state_file: Path) -> None:
     if not deferred_state_path.exists():
         return
     state_file.parent.mkdir(parents=True, exist_ok=True)
-    os.replace(deferred_state_path, state_file)
+    try:
+        os.replace(deferred_state_path, state_file)
+        return
+    except OSError as exc:
+        if exc.errno != errno.EXDEV:
+            raise
+
+    temp_fd: int | None = None
+    temp_path: Path | None = None
+    try:
+        temp_fd, temp_name = tempfile.mkstemp(prefix=f".{state_file.name}.", suffix=".tmp", dir=str(state_file.parent))
+        temp_path = Path(temp_name)
+        with deferred_state_path.open("rb") as source, os.fdopen(temp_fd, "wb") as target:
+            temp_fd = None
+            shutil.copyfileobj(source, target)
+        os.replace(temp_path, state_file)
+        deferred_state_path.unlink()
+    finally:
+        if temp_fd is not None:
+            try:
+                os.close(temp_fd)
+            except OSError:
+                pass
+        if temp_path is not None:
+            try:
+                temp_path.unlink()
+            except FileNotFoundError:
+                pass
 
 
 def read_text_lossy(path: Path) -> str:

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -41,7 +41,8 @@ DEFAULT_RUNTIME_SUMMARY_OUT_DIR = Path("/root/screeps/runtime-artifacts/runtime-
 DEFAULT_DEBOUNCE_SECONDS = 300
 DEFAULT_COLLECTION_ATTEMPTS = 3
 DEFAULT_COLLECTION_RETRY_DELAY_SECONDS = 5
-DEFAULT_ALERT_TIMEOUT_SECONDS = 20.0
+ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS = 25.0
+DEFAULT_ALERT_TIMEOUT_SECONDS = 60.0
 ALERT_TIMEOUT_POLL_SECONDS = 0.02
 ALERT_TIMEOUT_TERMINATE_GRACE_SECONDS = 1.0
 DEFERRED_STATE_WRITE_ENV = "SCREEPS_MONITOR_DEFER_STATE_WRITE"
@@ -833,7 +834,7 @@ def get_json(base_http: str, token: str, path: str, params: dict[str, Any] | Non
             "User-Agent": "screeps-runtime-monitor/1.0",
         },
     )
-    with urllib.request.urlopen(request, timeout=25) as response:
+    with urllib.request.urlopen(request, timeout=ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS) as response:
         return json.load(response)
 
 
@@ -1010,11 +1011,11 @@ async def fetch_room_event(ctx: RuntimeContext, ref: RoomRef) -> dict[str, Any]:
         raise RuntimeError("Python package 'websockets' is required") from exc
 
     uri = ctx.base_ws + "/socket/websocket"
-    async with websockets.connect(uri, open_timeout=25) as websocket:
+    async with websockets.connect(uri, open_timeout=ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS) as websocket:
         await websocket.send("auth " + ctx.token)
         authenticated = False
         for _ in range(30):
-            message = await asyncio.wait_for(websocket.recv(), timeout=25)
+            message = await asyncio.wait_for(websocket.recv(), timeout=ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS)
             if isinstance(message, bytes):
                 message = message.decode()
             if isinstance(message, str) and message.startswith("auth "):
@@ -1026,7 +1027,7 @@ async def fetch_room_event(ctx: RuntimeContext, ref: RoomRef) -> dict[str, Any]:
         channel = f"room:{ref.shard}/{ref.room}"
         await websocket.send(f"subscribe {channel}")
         for _ in range(60):
-            message = await asyncio.wait_for(websocket.recv(), timeout=25)
+            message = await asyncio.wait_for(websocket.recv(), timeout=ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS)
             if isinstance(message, bytes):
                 message = message.decode()
             if not isinstance(message, str) or not message.startswith("["):

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -14,6 +14,7 @@ import asyncio
 import errno
 import html
 import json
+import math
 import os
 import re
 import shutil
@@ -50,17 +51,19 @@ ALERT_COLLECTION_FALLBACK_REQUEST_COUNT_PER_ATTEMPT = 2
 def alert_collection_timeout_budget_seconds(
     collection_attempts: int = DEFAULT_COLLECTION_ATTEMPTS,
     collection_retry_delay_seconds: float = DEFAULT_COLLECTION_RETRY_DELAY_SECONDS,
+    room_count: int = 1,
 ) -> float:
     attempts = max(1, int(collection_attempts))
+    rooms = max(1, int(room_count))
     retry_delay_seconds = max(0.0, float(collection_retry_delay_seconds))
-    request_count = (
-        ALERT_COLLECTION_DISCOVERY_REQUEST_COUNT
-        + ALERT_COLLECTION_INITIAL_ROOM_REQUEST_COUNT
-        + (attempts * ALERT_COLLECTION_FALLBACK_REQUEST_COUNT_PER_ATTEMPT)
+    per_room_request_count = (
+        ALERT_COLLECTION_INITIAL_ROOM_REQUEST_COUNT
+        + attempts * ALERT_COLLECTION_FALLBACK_REQUEST_COUNT_PER_ATTEMPT
     )
+    request_count = ALERT_COLLECTION_DISCOVERY_REQUEST_COUNT + rooms * per_room_request_count
     return (
         request_count * ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS
-        + max(0, attempts - 1) * retry_delay_seconds
+        + rooms * max(0, attempts - 1) * retry_delay_seconds
     )
 
 
@@ -814,7 +817,7 @@ def positive_float_arg(value: str) -> float:
         parsed = float(value)
     except ValueError as exc:
         raise argparse.ArgumentTypeError(f"expected a positive number, got {value!r}") from exc
-    if parsed <= 0:
+    if not math.isfinite(parsed) or parsed <= 0:
         raise argparse.ArgumentTypeError(f"expected a positive number, got {value!r}")
     return parsed
 
@@ -952,6 +955,17 @@ def discover_owned_rooms(ctx: RuntimeContext, forced_room: RoomRef | None) -> tu
     return [fallback], overview, warnings, [fallback]
 
 
+def alert_collection_room_count(ctx: RuntimeContext, room_arg: str | None) -> int:
+    forced_room = parse_room_arg(room_arg, ctx.default_shard)
+    if forced_room:
+        return 1
+    try:
+        overview = get_json(ctx.base_http, ctx.token, "/api/user/overview")
+    except Exception:  # noqa: BLE001 - default timeout must still exist when discovery is unavailable
+        return 1
+    return max(1, len(overview_room_refs(overview)))
+
+
 def terrain_cache_path(cache_dir: Path, ref: RoomRef) -> Path:
     return cache_dir / f"{ref.file_fragment}.json"
 
@@ -1033,11 +1047,19 @@ async def fetch_room_event(ctx: RuntimeContext, ref: RoomRef) -> dict[str, Any]:
         raise RuntimeError("Python package 'websockets' is required") from exc
 
     uri = ctx.base_ws + "/socket/websocket"
+    deadline = time.monotonic() + ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS
+
+    def remaining_websocket_timeout() -> float:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(f"room snapshot websocket timed out for {ref.key}")
+        return remaining
+
     async with websockets.connect(uri, open_timeout=ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS) as websocket:
         await websocket.send("auth " + ctx.token)
         authenticated = False
         for _ in range(30):
-            message = await asyncio.wait_for(websocket.recv(), timeout=ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS)
+            message = await asyncio.wait_for(websocket.recv(), timeout=remaining_websocket_timeout())
             if isinstance(message, bytes):
                 message = message.decode()
             if isinstance(message, str) and message.startswith("auth "):
@@ -1049,7 +1071,7 @@ async def fetch_room_event(ctx: RuntimeContext, ref: RoomRef) -> dict[str, Any]:
         channel = f"room:{ref.shard}/{ref.room}"
         await websocket.send(f"subscribe {channel}")
         for _ in range(60):
-            message = await asyncio.wait_for(websocket.recv(), timeout=ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS)
+            message = await asyncio.wait_for(websocket.recv(), timeout=remaining_websocket_timeout())
             if isinstance(message, bytes):
                 message = message.decode()
             if not isinstance(message, str) or not message.startswith("["):
@@ -6110,11 +6132,25 @@ def run_alert_with_process_timeout(args: argparse.Namespace, timeout_seconds: fl
             pass
 
 
+def alert_timeout_seconds_from_args(args: argparse.Namespace) -> float:
+    configured_timeout = getattr(args, "alert_timeout_seconds", None)
+    if configured_timeout is not None:
+        return float(configured_timeout)
+
+    ctx = context_from_env(getattr(args, "world_profile", None))
+    room_count = alert_collection_room_count(ctx, getattr(args, "room", None))
+    return alert_collection_timeout_budget_seconds(
+        collection_attempts=ctx.collection_attempts,
+        collection_retry_delay_seconds=ctx.collection_retry_delay_seconds,
+        room_count=room_count,
+    )
+
+
 def run_parsed_command(args: argparse.Namespace) -> int:
     if getattr(args, "command", None) != "alert":
         return int(args.func(args))
 
-    timeout_seconds = float(getattr(args, "alert_timeout_seconds", DEFAULT_ALERT_TIMEOUT_SECONDS))
+    timeout_seconds = alert_timeout_seconds_from_args(args)
     return run_alert_with_process_timeout(args, timeout_seconds)
 
 
@@ -6492,8 +6528,12 @@ def apply_world_profile_defaults(args: argparse.Namespace) -> argparse.Namespace
         args.runtime_summary_out_dir = str(profile.runtime_summary_out_dir)
     if hasattr(args, "runtime_summary_dir") and getattr(args, "runtime_summary_dir") is None:
         args.runtime_summary_dir = env_default("SCREEPS_RUNTIME_SUMMARY_DIR", str(profile.runtime_summary_out_dir))
-    if hasattr(args, "alert_timeout_seconds") and getattr(args, "alert_timeout_seconds") is None:
-        raw_timeout = env_default("SCREEPS_ALERT_TIMEOUT_SECONDS", str(DEFAULT_ALERT_TIMEOUT_SECONDS))
+    if (
+        hasattr(args, "alert_timeout_seconds")
+        and getattr(args, "alert_timeout_seconds") is None
+        and "SCREEPS_ALERT_TIMEOUT_SECONDS" in os.environ
+    ):
+        raw_timeout = os.environ["SCREEPS_ALERT_TIMEOUT_SECONDS"]
         try:
             args.alert_timeout_seconds = positive_float_arg(raw_timeout)
         except argparse.ArgumentTypeError as exc:
@@ -6547,7 +6587,8 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help=(
             "Wall-clock timeout for the alert command before emitting diagnostic JSON "
-            f"(default: {DEFAULT_ALERT_TIMEOUT_SECONDS:g}s or SCREEPS_ALERT_TIMEOUT_SECONDS)."
+            "(default: auto budget from monitored rooms and collection retry settings, "
+            "or SCREEPS_ALERT_TIMEOUT_SECONDS)."
         ),
     )
     alert.add_argument(

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -16,6 +16,7 @@ import json
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -39,6 +40,9 @@ DEFAULT_RUNTIME_SUMMARY_OUT_DIR = Path("/root/screeps/runtime-artifacts/runtime-
 DEFAULT_DEBOUNCE_SECONDS = 300
 DEFAULT_COLLECTION_ATTEMPTS = 3
 DEFAULT_COLLECTION_RETRY_DELAY_SECONDS = 5
+DEFAULT_ALERT_TIMEOUT_SECONDS = 20.0
+ALERT_TIMEOUT_POLL_SECONDS = 0.02
+ALERT_TIMEOUT_TERMINATE_GRACE_SECONDS = 1.0
 DEFAULT_SHARD = world_profiles.PERSISTENT_DEFAULTS.shard
 DEFAULT_ROOM = world_profiles.PERSISTENT_DEFAULTS.room
 WORLD_PROFILE_ENV = world_profiles.WORLD_PROFILE_ENV
@@ -777,6 +781,16 @@ def parse_room_arg(value: str | None, default_shard: str) -> RoomRef | None:
 
 def env_default(name: str, default: str) -> str:
     return os.environ[name] if name in os.environ else default
+
+
+def positive_float_arg(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected a positive number, got {value!r}") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"expected a positive number, got {value!r}")
+    return parsed
 
 
 def context_from_env(world_profile: str | None = None) -> RuntimeContext:
@@ -5831,6 +5845,228 @@ def print_json(payload: dict[str, Any], secrets: list[str]) -> None:
     sys.stdout.write("\n")
 
 
+class MonitorCommandTimeout(TimeoutError):
+    def __init__(self, command: str, timeout_seconds: float) -> None:
+        self.command = command
+        self.timeout_seconds = timeout_seconds
+        super().__init__(f"{command} command exceeded {timeout_seconds:g}s timeout")
+
+
+class MonitorCommandChildFailure(RuntimeError):
+    def __init__(self, command: str, exit_code: int, detail: str) -> None:
+        self.command = command
+        self.exit_code = exit_code
+        self.detail = detail
+        super().__init__(f"{command} command failed in supervised child: {detail}")
+
+
+def normalized_exit_code(value: int) -> int:
+    if value < 0:
+        return 1
+    if value > 255:
+        return 1
+    return value
+
+
+def child_exit_code_from_status(status: int) -> int:
+    if os.WIFEXITED(status):
+        return os.WEXITSTATUS(status)
+    if os.WIFSIGNALED(status):
+        return 128 + os.WTERMSIG(status)
+    return 1
+
+
+def wait_for_child_exit(pid: int, timeout_seconds: float) -> int | None:
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        try:
+            waited_pid, status = os.waitpid(pid, os.WNOHANG)
+        except ChildProcessError:
+            return 1
+        if waited_pid == pid:
+            return child_exit_code_from_status(status)
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return None
+        time.sleep(min(ALERT_TIMEOUT_POLL_SECONDS, remaining))
+
+
+def signal_child_tree(pid: int, signum: int) -> None:
+    if hasattr(os, "killpg"):
+        try:
+            os.killpg(pid, signum)
+            return
+        except ProcessLookupError:
+            return
+        except OSError:
+            pass
+    try:
+        os.kill(pid, signum)
+    except ProcessLookupError:
+        return
+    except OSError:
+        return
+
+
+def terminate_timed_out_child(pid: int) -> None:
+    signal_child_tree(pid, signal.SIGTERM)
+    if wait_for_child_exit(pid, ALERT_TIMEOUT_TERMINATE_GRACE_SECONDS) is not None:
+        return
+    signal_child_tree(pid, signal.SIGKILL)
+    wait_for_child_exit(pid, ALERT_TIMEOUT_TERMINATE_GRACE_SECONDS)
+
+
+def run_alert_child(args: argparse.Namespace, output_path: Path) -> None:
+    rc = 1
+    try:
+        if hasattr(os, "setsid"):
+            try:
+                os.setsid()
+            except OSError:
+                pass
+
+        with output_path.open("w", encoding="utf-8") as child_stdout:
+            try:
+                os.dup2(child_stdout.fileno(), 1)
+            except OSError:
+                pass
+            sys.stdout = child_stdout
+            try:
+                rc = int(args.func(args))
+            except Exception as exc:  # noqa: BLE001 - child must return scheduler-readable JSON
+                token = os.environ.get("SCREEPS_AUTH_TOKEN", "")
+                payload = command_failure_payload(args, exc, token)
+                print_json(payload, [token])
+                rc = 1
+            child_stdout.flush()
+    finally:
+        os._exit(normalized_exit_code(rc))
+
+
+def read_text_lossy(path: Path) -> str:
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        return handle.read()
+
+
+def assert_complete_json_output(command: str, exit_code: int, output: str) -> None:
+    if not output.strip():
+        raise MonitorCommandChildFailure(command, exit_code, "no JSON was written to stdout")
+    try:
+        json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise MonitorCommandChildFailure(command, exit_code, "stdout was not complete JSON") from exc
+
+
+def run_alert_with_signal_timeout(args: argparse.Namespace, timeout_seconds: float) -> int:
+    if not hasattr(signal, "SIGALRM") or not hasattr(signal, "setitimer"):
+        return int(args.func(args))
+
+    previous_handler = signal.getsignal(signal.SIGALRM)
+    previous_timer = signal.getitimer(signal.ITIMER_REAL)
+
+    def raise_timeout(_signum: int, _frame: Any) -> None:
+        raise MonitorCommandTimeout("alert", timeout_seconds)
+
+    signal.signal(signal.SIGALRM, raise_timeout)
+    signal.setitimer(signal.ITIMER_REAL, timeout_seconds)
+    try:
+        return int(args.func(args))
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous_handler)
+        if previous_timer[0] > 0:
+            signal.setitimer(signal.ITIMER_REAL, previous_timer[0], previous_timer[1])
+
+
+def run_alert_with_process_timeout(args: argparse.Namespace, timeout_seconds: float) -> int:
+    if not hasattr(os, "fork"):
+        return run_alert_with_signal_timeout(args, timeout_seconds)
+
+    try:
+        sys.stdout.flush()
+    except Exception:
+        pass
+
+    output_fd, output_name = tempfile.mkstemp(prefix="screeps-alert-stdout-", suffix=".json")
+    os.close(output_fd)
+    output_path = Path(output_name)
+    try:
+        try:
+            pid = os.fork()
+        except OSError:
+            return run_alert_with_signal_timeout(args, timeout_seconds)
+
+        if pid == 0:
+            run_alert_child(args, output_path)
+
+        rc = wait_for_child_exit(pid, timeout_seconds)
+        if rc is None:
+            terminate_timed_out_child(pid)
+            raise MonitorCommandTimeout("alert", timeout_seconds)
+
+        output = read_text_lossy(output_path)
+        assert_complete_json_output("alert", rc, output)
+        sys.stdout.write(output)
+        if not output.endswith("\n"):
+            sys.stdout.write("\n")
+        return rc
+    finally:
+        try:
+            output_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def run_parsed_command(args: argparse.Namespace) -> int:
+    if getattr(args, "command", None) != "alert":
+        return int(args.func(args))
+
+    timeout_seconds = float(getattr(args, "alert_timeout_seconds", DEFAULT_ALERT_TIMEOUT_SECONDS))
+    return run_alert_with_process_timeout(args, timeout_seconds)
+
+
+def command_failure_payload(args: argparse.Namespace, exc: Exception, token: str) -> dict[str, Any]:
+    mode = str(getattr(args, "command", "unknown"))
+    diagnostic: dict[str, Any] = {"kind": "command_failed"}
+    if isinstance(exc, MonitorCommandTimeout):
+        diagnostic = {
+            "kind": "command_timeout",
+            "command": exc.command,
+            "timeout_seconds": exc.timeout_seconds,
+        }
+    elif isinstance(exc, MonitorCommandChildFailure):
+        diagnostic = {
+            "kind": "command_child_failed",
+            "command": exc.command,
+            "exit_code": exc.exit_code,
+            "detail": exc.detail,
+        }
+
+    payload: dict[str, Any] = {
+        "ok": False,
+        "mode": mode,
+        "error": redact_secrets(str(exc), [token]),
+        "diagnostic": diagnostic,
+    }
+    if mode == "alert":
+        payload.update(
+            {
+                "alert": False,
+                "reasons": [],
+                "images": [],
+                "rooms": [],
+                "summary": {},
+                "room_summaries": [],
+                "suppressed": False,
+                "suppressed_count": 0,
+                "suppressed_reasons": [],
+                "warnings": [],
+            }
+        )
+    return payload
+
+
 def load_json_file(path: str) -> dict[str, Any]:
     with open(path, "r", encoding="utf-8") as handle:
         value = json.load(handle)
@@ -6164,6 +6400,12 @@ def apply_world_profile_defaults(args: argparse.Namespace) -> argparse.Namespace
         args.runtime_summary_out_dir = str(profile.runtime_summary_out_dir)
     if hasattr(args, "runtime_summary_dir") and getattr(args, "runtime_summary_dir") is None:
         args.runtime_summary_dir = env_default("SCREEPS_RUNTIME_SUMMARY_DIR", str(profile.runtime_summary_out_dir))
+    if hasattr(args, "alert_timeout_seconds") and getattr(args, "alert_timeout_seconds") is None:
+        raw_timeout = env_default("SCREEPS_ALERT_TIMEOUT_SECONDS", str(DEFAULT_ALERT_TIMEOUT_SECONDS))
+        try:
+            args.alert_timeout_seconds = positive_float_arg(raw_timeout)
+        except argparse.ArgumentTypeError as exc:
+            raise ValueError(f"invalid SCREEPS_ALERT_TIMEOUT_SECONDS: {exc}") from exc
     return args
 
 
@@ -6207,6 +6449,15 @@ def build_parser() -> argparse.ArgumentParser:
     alert = subcommands.add_parser("alert", help="evaluate alert rules and render alert PNGs when needed")
     add_live_options(alert)
     alert.add_argument("--force-alert-image", action="store_true", help="render alert-style image even when no alert is emitted")
+    alert.add_argument(
+        "--alert-timeout-seconds",
+        type=positive_float_arg,
+        default=None,
+        help=(
+            "Wall-clock timeout for the alert command before emitting diagnostic JSON "
+            f"(default: {DEFAULT_ALERT_TIMEOUT_SECONDS:g}s or SCREEPS_ALERT_TIMEOUT_SECONDS)."
+        ),
+    )
     alert.add_argument(
         "--runtime-summary-dir",
         default=None,
@@ -7640,14 +7891,10 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     try:
-        return int(args.func(args))
+        return run_parsed_command(args)
     except Exception as exc:  # noqa: BLE001 - cron-facing JSON failure without stack or secrets
         token = os.environ.get("SCREEPS_AUTH_TOKEN", "")
-        payload = {
-            "ok": False,
-            "mode": getattr(args, "command", "unknown"),
-            "error": redact_secrets(str(exc), [token]),
-        }
+        payload = command_failure_payload(args, exc, token)
         print_json(payload, [token])
         return 1
 

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import importlib.util
 import copy
+import io
 import json
 import sys
 import tempfile
@@ -333,6 +334,7 @@ class WorldProfileDefaultsTest(unittest.TestCase):
         self.assertEqual(alert_args.world_profile, "persistent")
         self.assertEqual(Path(alert_args.out_dir), monitor.DEFAULT_OUT_DIR)
         self.assertEqual(Path(alert_args.runtime_summary_dir), monitor.DEFAULT_RUNTIME_SUMMARY_OUT_DIR)
+        self.assertEqual(alert_args.alert_timeout_seconds, monitor.DEFAULT_ALERT_TIMEOUT_SECONDS)
         self.assertEqual(ctx.base_http, monitor.DEFAULT_API_URL)
         self.assertEqual(ctx.default_shard, monitor.DEFAULT_SHARD)
         self.assertEqual(ctx.default_room, monitor.DEFAULT_ROOM)
@@ -444,6 +446,72 @@ class WorldProfileDefaultsTest(unittest.TestCase):
                 monitor.RoomRef(shard="shardX", room="E29N55"),
             ],
         )
+
+
+class AlertCommandFailurePayloadTest(unittest.TestCase):
+    def test_alert_timeout_returns_structured_diagnostic_json(self) -> None:
+        def stalled_alert(_args: object) -> int:
+            monitor.time.sleep(1)
+            return 0
+
+        with mock.patch.dict(monitor.os.environ, {"SCREEPS_AUTH_TOKEN": "abcdef123456"}, clear=True):
+            with mock.patch.object(monitor, "command_alert", new=stalled_alert):
+                with mock.patch("sys.stdout", new_callable=io.StringIO) as stdout:
+                    rc = monitor.main(["alert", "--alert-timeout-seconds", "0.01"])
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(rc, 1)
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["mode"], "alert")
+        self.assertFalse(payload["alert"])
+        self.assertEqual(payload["reasons"], [])
+        self.assertEqual(payload["rooms"], [])
+        self.assertEqual(payload["diagnostic"]["kind"], "command_timeout")
+        self.assertEqual(payload["diagnostic"]["command"], "alert")
+        self.assertAlmostEqual(payload["diagnostic"]["timeout_seconds"], 0.01)
+        self.assertNotIn("abcdef123456", stdout.getvalue())
+
+    def test_alert_timeout_returns_json_when_child_blocks_in_subprocess(self) -> None:
+        def stalled_alert(_args: object) -> int:
+            monitor.subprocess.run(
+                [sys.executable, "-c", "import time; time.sleep(5)"],
+                check=True,
+            )
+            return 0
+
+        with mock.patch.dict(monitor.os.environ, {"SCREEPS_AUTH_TOKEN": "abcdef123456"}, clear=True):
+            with mock.patch.object(monitor, "command_alert", new=stalled_alert):
+                with mock.patch("sys.stdout", new_callable=io.StringIO) as stdout:
+                    rc = monitor.main(["alert", "--alert-timeout-seconds", "0.01"])
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(rc, 1)
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["mode"], "alert")
+        self.assertFalse(payload["alert"])
+        self.assertEqual(payload["diagnostic"]["kind"], "command_timeout")
+        self.assertEqual(payload["diagnostic"]["command"], "alert")
+        self.assertNotIn("abcdef123456", stdout.getvalue())
+
+    def test_alert_exception_returns_alert_shaped_failure_json(self) -> None:
+        def failing_alert(_args: object) -> int:
+            raise RuntimeError("capture failed with token=abcdef123456")
+
+        with mock.patch.dict(monitor.os.environ, {"SCREEPS_AUTH_TOKEN": "abcdef123456"}, clear=True):
+            with mock.patch.object(monitor, "command_alert", new=failing_alert):
+                with mock.patch("sys.stdout", new_callable=io.StringIO) as stdout:
+                    rc = monitor.main(["alert"])
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(rc, 1)
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["mode"], "alert")
+        self.assertFalse(payload["alert"])
+        self.assertEqual(payload["reasons"], [])
+        self.assertEqual(payload["room_summaries"], [])
+        self.assertEqual(payload["diagnostic"], {"kind": "command_failed"})
+        self.assertIn("capture failed", payload["error"])
+        self.assertNotIn("abcdef123456", payload["error"])
 
 
 class TacticalResponseBridgeTest(unittest.TestCase):

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -449,6 +449,16 @@ class WorldProfileDefaultsTest(unittest.TestCase):
 
 
 class AlertCommandFailurePayloadTest(unittest.TestCase):
+    def test_signal_child_tree_falls_back_to_process_signal_when_process_group_missing(self) -> None:
+        if not hasattr(monitor.os, "killpg"):
+            self.skipTest("os.killpg is unavailable")
+
+        with mock.patch.object(monitor.os, "killpg", side_effect=ProcessLookupError):
+            with mock.patch.object(monitor.os, "kill") as kill:
+                monitor.signal_child_tree(1234, monitor.signal.SIGTERM)
+
+        kill.assert_called_once_with(1234, monitor.signal.SIGTERM)
+
     def test_alert_timeout_returns_structured_diagnostic_json(self) -> None:
         def stalled_alert(_args: object) -> int:
             monitor.time.sleep(1)
@@ -492,6 +502,65 @@ class AlertCommandFailurePayloadTest(unittest.TestCase):
         self.assertEqual(payload["diagnostic"]["kind"], "command_timeout")
         self.assertEqual(payload["diagnostic"]["command"], "alert")
         self.assertNotIn("abcdef123456", stdout.getvalue())
+
+    def test_alert_timeout_does_not_promote_deferred_child_state(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            state_path = Path(temp_dir) / "state.json"
+            existing_state = {"existing": True}
+            state_path.write_text(json.dumps(existing_state), encoding="utf-8")
+
+            def stalled_alert(_args: object) -> int:
+                monitor.save_state(state_path, {"rooms": {"shardX/E1N1": {"alerts": {"hostile": 123}}}})
+                monitor.time.sleep(1)
+                return 0
+
+            with mock.patch.dict(
+                monitor.os.environ,
+                {"SCREEPS_AUTH_TOKEN": "abcdef123456", "SCREEPS_MONITOR_STATE_FILE": str(state_path)},
+                clear=True,
+            ):
+                with mock.patch.object(monitor, "command_alert", new=stalled_alert):
+                    with mock.patch("sys.stdout", new_callable=io.StringIO) as stdout:
+                        rc = monitor.main(["alert", "--alert-timeout-seconds", "0.01"])
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(rc, 1)
+            self.assertEqual(payload["diagnostic"]["kind"], "command_timeout")
+            self.assertEqual(json.loads(state_path.read_text(encoding="utf-8")), existing_state)
+
+    def test_alert_success_promotes_deferred_child_state_after_complete_json(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            state_path = Path(temp_dir) / "state.json"
+            saved_state = {"version": 1, "rooms": {"shardX/E1N1": {"alerts": {"hostile": 123}}}}
+
+            def successful_alert(_args: object) -> int:
+                monitor.save_state(state_path, saved_state)
+                monitor.print_json(
+                    {
+                        "ok": True,
+                        "mode": "alert",
+                        "alert": False,
+                        "reasons": [],
+                        "rooms": [],
+                        "state_file": str(state_path),
+                    },
+                    ["abcdef123456"],
+                )
+                return 0
+
+            with mock.patch.dict(
+                monitor.os.environ,
+                {"SCREEPS_AUTH_TOKEN": "abcdef123456", "SCREEPS_MONITOR_STATE_FILE": str(state_path)},
+                clear=True,
+            ):
+                with mock.patch.object(monitor, "command_alert", new=successful_alert):
+                    with mock.patch("sys.stdout", new_callable=io.StringIO) as stdout:
+                        rc = monitor.main(["alert", "--alert-timeout-seconds", "1"])
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(rc, 0)
+            self.assertTrue(payload["ok"])
+            self.assertEqual(json.loads(state_path.read_text(encoding="utf-8")), saved_state)
 
     def test_alert_exception_returns_alert_shaped_failure_json(self) -> None:
         def failing_alert(_args: object) -> int:

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -336,6 +336,10 @@ class WorldProfileDefaultsTest(unittest.TestCase):
         self.assertEqual(Path(alert_args.out_dir), monitor.DEFAULT_OUT_DIR)
         self.assertEqual(Path(alert_args.runtime_summary_dir), monitor.DEFAULT_RUNTIME_SUMMARY_OUT_DIR)
         self.assertEqual(alert_args.alert_timeout_seconds, monitor.DEFAULT_ALERT_TIMEOUT_SECONDS)
+        self.assertGreater(
+            monitor.DEFAULT_ALERT_TIMEOUT_SECONDS,
+            monitor.ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS * 2,
+        )
         self.assertEqual(ctx.base_http, monitor.DEFAULT_API_URL)
         self.assertEqual(ctx.default_shard, monitor.DEFAULT_SHARD)
         self.assertEqual(ctx.default_room, monitor.DEFAULT_ROOM)

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -8,6 +8,7 @@ import io
 import json
 import sys
 import tempfile
+import types
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -349,7 +350,7 @@ class WorldProfileDefaultsTest(unittest.TestCase):
         self.assertEqual(Path(alert_args.runtime_summary_dir), monitor.DEFAULT_RUNTIME_SUMMARY_OUT_DIR)
         self.assertEqual(monitor.alert_collection_timeout_budget_seconds(), expected_alert_timeout)
         self.assertEqual(monitor.DEFAULT_ALERT_TIMEOUT_SECONDS, expected_alert_timeout)
-        self.assertEqual(alert_args.alert_timeout_seconds, expected_alert_timeout)
+        self.assertIsNone(alert_args.alert_timeout_seconds)
         self.assertLess(monitor.DEFAULT_ALERT_TIMEOUT_SECONDS, 15 * 60)
         self.assertEqual(ctx.base_http, monitor.DEFAULT_API_URL)
         self.assertEqual(ctx.default_shard, monitor.DEFAULT_SHARD)
@@ -366,6 +367,59 @@ class WorldProfileDefaultsTest(unittest.TestCase):
             alert_args = monitor.build_parser().parse_args(["alert"])
 
         self.assertEqual(alert_args.alert_timeout_seconds, 12.5)
+
+    def test_alert_timeout_budget_scales_across_rooms_and_retry_delay(self) -> None:
+        self.assertAlmostEqual(
+            monitor.alert_collection_timeout_budget_seconds(
+                collection_attempts=4,
+                collection_retry_delay_seconds=7.5,
+                room_count=3,
+            ),
+            (
+                (
+                    monitor.ALERT_COLLECTION_DISCOVERY_REQUEST_COUNT
+                    + 3
+                    * (
+                        monitor.ALERT_COLLECTION_INITIAL_ROOM_REQUEST_COUNT
+                        + 4 * monitor.ALERT_COLLECTION_FALLBACK_REQUEST_COUNT_PER_ATTEMPT
+                    )
+                )
+                * monitor.ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS
+                + 3 * (4 - 1) * 7.5
+            ),
+        )
+
+    def test_alert_timeout_default_uses_collection_env_and_room_count(self) -> None:
+        overview = {"shards": {"shardX": {"rooms": ["E1N1", "E2N2"]}}}
+        with mock.patch.dict(
+            monitor.os.environ,
+            {
+                "SCREEPS_AUTH_TOKEN": "token",
+                "SCREEPS_MONITOR_COLLECTION_ATTEMPTS": "4",
+                "SCREEPS_MONITOR_COLLECTION_RETRY_DELAY_SECONDS": "7.5",
+            },
+            clear=True,
+        ):
+            alert_args = monitor.build_parser().parse_args(["alert"])
+            with mock.patch.object(monitor, "get_json", return_value=overview):
+                with mock.patch.object(monitor, "run_alert_with_process_timeout", return_value=0) as run_alert:
+                    rc = monitor.run_parsed_command(alert_args)
+
+        self.assertEqual(rc, 0)
+        self.assertAlmostEqual(
+            run_alert.call_args.args[1],
+            monitor.alert_collection_timeout_budget_seconds(
+                collection_attempts=4,
+                collection_retry_delay_seconds=7.5,
+                room_count=2,
+            ),
+        )
+
+    def test_positive_float_arg_rejects_non_finite_values(self) -> None:
+        for value in ("nan", "inf", "-inf", "1e309"):
+            with self.subTest(value=value):
+                with self.assertRaises(monitor.argparse.ArgumentTypeError):
+                    monitor.positive_float_arg(value)
 
     def test_seasonal_profile_isolates_monitor_defaults(self) -> None:
         with mock.patch.dict(monitor.os.environ, {"SCREEPS_AUTH_TOKEN": "token"}, clear=True):
@@ -474,6 +528,74 @@ class WorldProfileDefaultsTest(unittest.TestCase):
         )
 
 
+class OsWithoutFork:
+    def __init__(self, wrapped: object) -> None:
+        self._wrapped = wrapped
+
+    def __getattr__(self, name: str) -> object:
+        if name == "fork":
+            raise AttributeError(name)
+        return getattr(self._wrapped, name)
+
+
+class AlertCollectionTimeoutTest(unittest.TestCase):
+    def test_fetch_room_event_uses_one_websocket_deadline_across_recv_loops(self) -> None:
+        messages = [
+            "auth ok",
+            ['room:shardX/E1N1', {"objects": [], "gameTime": 123}],
+        ]
+        wait_for_timeouts: list[float] = []
+
+        class FakeWebSocket:
+            async def send(self, _message: str) -> None:
+                return None
+
+            async def recv(self) -> object:
+                return json.dumps(messages.pop(0)) if isinstance(messages[0], list) else messages.pop(0)
+
+        class FakeConnection:
+            async def __aenter__(self) -> FakeWebSocket:
+                return FakeWebSocket()
+
+            async def __aexit__(self, _exc_type: object, _exc: object, _traceback: object) -> None:
+                return None
+
+        async def fake_wait_for(awaitable: object, timeout: float) -> object:
+            wait_for_timeouts.append(timeout)
+            return await awaitable
+
+        real_monotonic = monitor.time.monotonic
+        script_times = iter([100.0, 100.0, 110.0])
+
+        def fake_monotonic() -> float:
+            if Path(sys._getframe(1).f_code.co_filename) == MODULE_PATH:
+                return next(script_times)
+            return real_monotonic()
+
+        fake_websockets = types.SimpleNamespace(connect=lambda _uri, open_timeout: FakeConnection())
+        ctx = monitor.RuntimeContext(
+            base_http="https://screeps.com",
+            token="token",
+            default_shard="shardX",
+            default_room="E1N1",
+            owner=None,
+            owner_id=None,
+            state_file=Path("/tmp/state.json"),
+            cache_dir=Path("/tmp/cache"),
+            debounce_seconds=300,
+            collection_attempts=1,
+            collection_retry_delay_seconds=0,
+        )
+
+        with mock.patch.dict(sys.modules, {"websockets": fake_websockets}):
+            with mock.patch.object(monitor.time, "monotonic", new=fake_monotonic):
+                with mock.patch.object(monitor.asyncio, "wait_for", new=fake_wait_for):
+                    event = monitor.asyncio.run(monitor.fetch_room_event(ctx, monitor.RoomRef("shardX", "E1N1")))
+
+        self.assertEqual(event["objects"], [])
+        self.assertEqual(wait_for_timeouts, [monitor.ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS, 15.0])
+
+
 class AlertCommandFailurePayloadTest(unittest.TestCase):
     def test_signal_child_tree_falls_back_to_process_signal_when_process_group_missing(self) -> None:
         if not hasattr(monitor.os, "killpg"):
@@ -525,6 +647,30 @@ class AlertCommandFailurePayloadTest(unittest.TestCase):
         self.assertFalse(payload["ok"])
         self.assertEqual(payload["mode"], "alert")
         self.assertFalse(payload["alert"])
+        self.assertEqual(payload["diagnostic"]["kind"], "command_timeout")
+        self.assertEqual(payload["diagnostic"]["command"], "alert")
+        self.assertNotIn("abcdef123456", stdout.getvalue())
+
+    def test_alert_signal_timeout_returns_json_when_child_blocks_in_subprocess(self) -> None:
+        def stalled_alert(_args: object) -> int:
+            monitor.subprocess.run(
+                [sys.executable, "-c", "import time; time.sleep(5)"],
+                check=True,
+            )
+            return 0
+
+        with mock.patch.object(monitor, "os", new=OsWithoutFork(monitor.os)):
+            with mock.patch.dict(monitor.os.environ, {"SCREEPS_AUTH_TOKEN": "abcdef123456"}, clear=True):
+                with mock.patch.object(monitor, "command_alert", new=stalled_alert):
+                    with mock.patch("sys.stdout", new_callable=io.StringIO) as stdout:
+                        rc = monitor.main(["alert", "--alert-timeout-seconds", "0.01"])
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(rc, 1)
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["mode"], "alert")
+        self.assertFalse(payload["alert"])
+        self.assertEqual(payload["rooms"], [])
         self.assertEqual(payload["diagnostic"]["kind"], "command_timeout")
         self.assertEqual(payload["diagnostic"]["command"], "alert")
         self.assertNotIn("abcdef123456", stdout.getvalue())
@@ -624,6 +770,7 @@ class AlertCommandFailurePayloadTest(unittest.TestCase):
         self.assertEqual(payload["mode"], "alert")
         self.assertFalse(payload["alert"])
         self.assertEqual(payload["reasons"], [])
+        self.assertEqual(payload["rooms"], [])
         self.assertEqual(payload["room_summaries"], [])
         self.assertEqual(payload["diagnostic"], {"kind": "command_failed"})
         self.assertIn("capture failed", payload["error"])

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import importlib.util
 import copy
+import errno
 import io
 import json
 import sys
@@ -527,6 +528,27 @@ class AlertCommandFailurePayloadTest(unittest.TestCase):
             self.assertEqual(rc, 1)
             self.assertEqual(payload["diagnostic"]["kind"], "command_timeout")
             self.assertEqual(json.loads(state_path.read_text(encoding="utf-8")), existing_state)
+
+    def test_promote_deferred_state_handles_cross_device_replace(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_root = Path(temp_dir)
+            deferred_state_path = temp_root / "deferred-state.json"
+            state_path = temp_root / "monitor-state" / "state.json"
+            saved_state = {"version": 1, "rooms": {"shardX/E1N1": {"alerts": {"hostile": 123}}}}
+            deferred_state_path.write_text(json.dumps(saved_state), encoding="utf-8")
+
+            original_replace = monitor.os.replace
+
+            def replace_with_cross_device_once(src: str | Path, dst: str | Path) -> None:
+                if Path(src) == deferred_state_path and Path(dst) == state_path:
+                    raise OSError(errno.EXDEV, "Invalid cross-device link")
+                original_replace(src, dst)
+
+            with mock.patch.object(monitor.os, "replace", side_effect=replace_with_cross_device_once):
+                monitor.promote_deferred_state(deferred_state_path, state_path)
+
+            self.assertEqual(json.loads(state_path.read_text(encoding="utf-8")), saved_state)
+            self.assertFalse(deferred_state_path.exists())
 
     def test_alert_success_promotes_deferred_child_state_after_complete_json(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -329,22 +329,43 @@ class WorldProfileDefaultsTest(unittest.TestCase):
             alert_args = monitor.build_parser().parse_args(["alert"])
             ctx = monitor.context_from_env(summary_args.world_profile)
 
+        expected_alert_timeout = (
+            (
+                monitor.ALERT_COLLECTION_DISCOVERY_REQUEST_COUNT
+                + monitor.ALERT_COLLECTION_INITIAL_ROOM_REQUEST_COUNT
+                + (
+                    monitor.DEFAULT_COLLECTION_ATTEMPTS
+                    * monitor.ALERT_COLLECTION_FALLBACK_REQUEST_COUNT_PER_ATTEMPT
+                )
+            )
+            * monitor.ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS
+            + (monitor.DEFAULT_COLLECTION_ATTEMPTS - 1) * monitor.DEFAULT_COLLECTION_RETRY_DELAY_SECONDS
+        )
         self.assertEqual(summary_args.world_profile, "persistent")
         self.assertEqual(Path(summary_args.out_dir), monitor.DEFAULT_OUT_DIR)
         self.assertEqual(Path(summary_args.runtime_summary_out_dir), monitor.DEFAULT_RUNTIME_SUMMARY_OUT_DIR)
         self.assertEqual(alert_args.world_profile, "persistent")
         self.assertEqual(Path(alert_args.out_dir), monitor.DEFAULT_OUT_DIR)
         self.assertEqual(Path(alert_args.runtime_summary_dir), monitor.DEFAULT_RUNTIME_SUMMARY_OUT_DIR)
-        self.assertEqual(alert_args.alert_timeout_seconds, monitor.DEFAULT_ALERT_TIMEOUT_SECONDS)
-        self.assertGreater(
-            monitor.DEFAULT_ALERT_TIMEOUT_SECONDS,
-            monitor.ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS * 2,
-        )
+        self.assertEqual(monitor.alert_collection_timeout_budget_seconds(), expected_alert_timeout)
+        self.assertEqual(monitor.DEFAULT_ALERT_TIMEOUT_SECONDS, expected_alert_timeout)
+        self.assertEqual(alert_args.alert_timeout_seconds, expected_alert_timeout)
+        self.assertLess(monitor.DEFAULT_ALERT_TIMEOUT_SECONDS, 15 * 60)
         self.assertEqual(ctx.base_http, monitor.DEFAULT_API_URL)
         self.assertEqual(ctx.default_shard, monitor.DEFAULT_SHARD)
         self.assertEqual(ctx.default_room, monitor.DEFAULT_ROOM)
         self.assertEqual(ctx.state_file, monitor.DEFAULT_STATE_FILE)
         self.assertEqual(ctx.cache_dir, monitor.DEFAULT_CACHE_DIR)
+
+    def test_alert_timeout_env_override_preserved(self) -> None:
+        with mock.patch.dict(
+            monitor.os.environ,
+            {"SCREEPS_AUTH_TOKEN": "token", "SCREEPS_ALERT_TIMEOUT_SECONDS": "12.5"},
+            clear=True,
+        ):
+            alert_args = monitor.build_parser().parse_args(["alert"])
+
+        self.assertEqual(alert_args.alert_timeout_seconds, 12.5)
 
     def test_seasonal_profile_isolates_monitor_defaults(self) -> None:
         with mock.patch.dict(monitor.os.environ, {"SCREEPS_AUTH_TOKEN": "token"}, clear=True):


### PR DESCRIPTION
## Summary

Refs #1652.

- Bound the runtime monitor `alert` subcommand with process-level timeout handling so a hung alert run emits complete structured JSON instead of leaving a zero-byte artifact.
- Preserve alert-shaped failure payloads (`ok=false`, `alert=false`, empty rooms/reasons, timeout diagnostics) with secret redaction.
- Add regression coverage for timeout and failure payload behavior.

## Evidence

- Codex continuation commit: `897ab5c17fab runtime-monitor: bound alert command timeout diagnostics`.
- Controller verification from `/root/screeps-worktrees/issue-1652-runtime-alert-timeout`:
  - `git diff --check HEAD~1..HEAD`
  - `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py`
  - `python3 -m unittest scripts.test_screeps_runtime_monitor_tactical_response -q` — 95 tests passed
  - `python3 scripts/screeps-runtime-monitor.py self-test` — rc=0 / 42 self-tests passed
  - live timeout smoke: `timeout 10s python3 scripts/screeps-runtime-monitor.py alert --alert-timeout-seconds 0.1 > /tmp/issue1652-alert-timeout-fixed.json` returned rc=1 but wrote valid JSON with `diagnostic.kind=command_timeout`, `mode=alert`, `alert=false`, `rooms=[]`.

## Safety

- No official MMO writes, no paid compute, no deploy, no GitHub Project mutation from the Codex lane.
- The branch only changes the runtime-monitor script and its focused tests.
- Issue #1652 should remain open until post-merge scheduled runtime-alert evidence proves the zero-byte/hang recurrence is gone.

## Universal task Done gate

- [x] Task type: runtime-monitor bugfix PR.
- [x] Expected observable outcome / named deliverable: Codex-authored branch that makes alert timeout failures write complete diagnostic JSON instead of zero-byte artifacts.
- [x] Non-goals / accepted substitutes: no official deploy, no Screeps MMO write, no paid compute, no owner-side action, no issue closure before scheduled proof.
- [x] Verification evidence required before Done: controller ran diff-check, py_compile, focused unittest, monitor self-test, and a live timeout JSON smoke on commit 897ab5c17fab.
- [x] Project Evidence / Next action / Blocked by: issue #1652 and this PR Project fields record commit/tests and review-gate action.
- [x] Post-merge/deploy/runtime proof: scheduled runtime-alert job must later produce non-empty alert JSON or `[SILENT]` without timeout/zero-byte artifacts.
- [x] Named deliverable proof: commit 897ab5c17fab contains the alert timeout wrapper, alert-shaped failure payload, and regression tests.
