### PR TITLE
cpu: strengthen degraded recovery shedding

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1062,7 +1062,7 @@ function hasLowBucketRecoveryPressure(sample) {
   if (sample.bucket === void 0 || sample.bucket < LOW_CPU_BUCKET_THRESHOLD) {
     return false;
   }
-  return sample.bucket < LOW_CPU_BUCKET_THRESHOLD + getCpuBucketRecoveryHeadroom(sample.limit);
+  return sample.bucket <= LOW_CPU_BUCKET_THRESHOLD + getCpuBucketRecoveryHeadroom(sample.limit);
 }
 function getCpuBucketRecoveryHeadroom(limit) {
   if (limit !== void 0 && limit > 0) {

--- a/prod/src/runtime/cpuBudget.ts
+++ b/prod/src/runtime/cpuBudget.ts
@@ -234,7 +234,7 @@ function hasLowBucketRecoveryPressure(sample: RuntimeCpuSample): boolean {
     return false;
   }
 
-  return sample.bucket < LOW_CPU_BUCKET_THRESHOLD + getCpuBucketRecoveryHeadroom(sample.limit);
+  return sample.bucket <= LOW_CPU_BUCKET_THRESHOLD + getCpuBucketRecoveryHeadroom(sample.limit);
 }
 
 function getCpuBucketRecoveryHeadroom(limit: number | undefined): number {

--- a/prod/test/cpuBudget.test.ts
+++ b/prod/test/cpuBudget.test.ts
@@ -160,7 +160,7 @@ describe('runtime CPU budget policy', () => {
     expect(shouldShedNonessentialCpuWork(budget)).toBe(true);
   });
 
-  it('keeps optional work paused through the observed post-alert recovery band', () => {
+  it('keeps optional work paused through the observed post-alert recovery boundary', () => {
     const recoveryBudget = buildRuntimeCpuBudget({
       tick: 1760015,
       used: 12,
@@ -168,11 +168,18 @@ describe('runtime CPU budget policy', () => {
       bucket: 1_142,
       tickLimit: 500
     });
-    const recoveredBudget = buildRuntimeCpuBudget({
+    const boundaryBudget = buildRuntimeCpuBudget({
       tick: 1760016,
       used: 12,
       limit: 70,
       bucket: 1_210,
+      tickLimit: 500
+    });
+    const recoveredBudget = buildRuntimeCpuBudget({
+      tick: 1760017,
+      used: 12,
+      limit: 70,
+      bucket: 1_211,
       tickLimit: 500
     });
 
@@ -186,6 +193,16 @@ describe('runtime CPU budget policy', () => {
     expect(shouldRunOptionalCpuWork(recoveryBudget, 'economy-global-optional')).toBe(false);
     expect(shouldRunOptionalCpuRoomWork(recoveryBudget, 'E29N55')).toBe(false);
     expect(shouldShedNonessentialCpuWork(recoveryBudget)).toBe(true);
+    expect(boundaryBudget).toMatchObject({
+      pressure: 'degraded',
+      degraded: true,
+      critical: false,
+      lowCpuLimit: false,
+      reasons: ['lowBucketRecovery']
+    });
+    expect(shouldRunOptionalCpuWork(boundaryBudget, 'economy-global-optional')).toBe(false);
+    expect(shouldRunOptionalCpuRoomWork(boundaryBudget, 'E29N55')).toBe(false);
+    expect(shouldShedNonessentialCpuWork(boundaryBudget)).toBe(true);
     expect(recoveredBudget).toMatchObject({
       pressure: 'normal',
       degraded: false,


### PR DESCRIPTION
## Summary
- Strengthens the CPU degraded-recovery boundary so optional work remains shed while the bucket is still recovering.
- Adds regression coverage for keeping degraded recovery active at the postdeploy failure bucket range.
- Rebuilds `prod/dist/main.js` from the source change.

## Evidence
- Fresh CPU-bearing console evidence before this fix showed `usedOverLimit` at bucket 1210 and `lowBucketRecovery` at buckets 1118/1132 after deploy run 26933538761.
- Controller-side verification before commit:
  - `git diff --check` PASS
  - `cd prod && npm run typecheck` PASS
  - `cd prod && npm test -- --runInBand` PASS (104 suites, 2238 tests)
  - `cd prod && npm run build` PASS
- Commit: `14897783d219b33871d3b081cdec30779fa0a42c`

## Universal task Done gate
- [x] Task type: P0 runtime CPU-safety code change associated with issue #1490.
- [x] Expected observable outcome / named deliverable: CPU degraded-recovery policy keeps optional work shed through the observed low-bucket recovery range.
- [x] Non-goals / accepted substitutes: Issue #1490 closure and #1656 release are separate acceptance lanes tied to live deploy evidence.
- [x] Verification evidence required before Done: controller `git diff --check`, prod typecheck, Jest 104 suites 2238 tests, prod build, PR checks, automated review, official deploy evidence, CPU-bearing console acceptance.
- [x] Project Evidence / Next action / Blocked by: PR #1658 and issue #1490 project items record commit 14897783, verification evidence, review gate, deploy gate, and CPU acceptance criteria.
- [x] Post-merge/deploy/runtime proof: Done requires merge commit, official deploy run evidence, and fresh CPU console acceptance with zero `usedOverLimit` and zero `lowBucketRecovery` recurrence.
- [x] Named deliverable proof: Commit 14897783 updates `prod/src/runtime/cpuBudget.ts`, `prod/test/cpuBudget.test.ts`, and rebuilt `prod/dist/main.js`.

## Gate / rollout notes
- Related to issue #1490. Closure waits for merge, official deploy to shardX/E29N55, and fresh CPU-bearing console acceptance with zero `usedOverLimit`/`lowBucketRecovery` recurrence.
- Issue #1656 release sequencing waits for #1490 CPU acceptance.
