### PR TITLE
telemetry: count recovery worker assignments as productive

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -38671,6 +38671,7 @@ var OBSERVED_RAMPART_REPAIR_HITS_CEILING = 15e4;
 var TERRITORY_EXPANSION_PROGRESS_CPU_BUCKET_FLOOR = 500;
 var WORKER_TASK_TYPES = ["harvest", "transfer", "build", "repair", "upgrade"];
 var PRODUCTIVE_WORKER_TASK_TYPES = ["build", "repair", "upgrade"];
+var PRODUCTIVE_WORKER_ASSIGNMENT_TASK_TYPES = ["harvest", "pickup", "withdraw", "transfer", "build", "repair", "upgrade"];
 var DEFAULT_EXTENSION_ENERGY_CAPACITY = 50;
 var runtimeCpuSummaryEmissionState = {};
 var cachedRefillTargetIdsByRoom = /* @__PURE__ */ new Map();
@@ -38838,11 +38839,12 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
   const resourcesWithoutActivity = summarizeResources(colony, colonyWorkers, colonyCreeps, eventMetrics.resources);
   const taskCounts = countWorkerTasks(colonyWorkers);
   const assignedTaskCount = countAssignedWorkerTasks(colonyWorkers);
+  const productiveAssignmentCount = countProductiveWorkerAssignments(colonyWorkers);
   const workerAssignmentEvidence = summarizeWorkerAssignmentEvidence(
     tick,
     colonyWorkers,
     assignedTaskCount,
-    resourcesWithoutActivity.productiveEnergy.assignedWorkerCount,
+    productiveAssignmentCount,
     cpuBudget
   );
   const constructionDeadlockTicks = getRoomConstructionDeadlockTicks(colony.room);
@@ -38998,6 +39000,15 @@ function emptyTerritoryRecommendationReport() {
 }
 function countAssignedWorkerTasks(workers) {
   return workers.reduce((assignedCount, worker) => assignedCount + (getWorkerTaskType(worker) ? 1 : 0), 0);
+}
+function countProductiveWorkerAssignments(workers) {
+  return workers.reduce(
+    (assignedCount, worker) => assignedCount + (isProductiveWorkerAssignmentTaskType(getWorkerTaskType(worker)) ? 1 : 0),
+    0
+  );
+}
+function isProductiveWorkerAssignmentTaskType(taskType) {
+  return PRODUCTIVE_WORKER_ASSIGNMENT_TASK_TYPES.includes(taskType);
 }
 function summarizeWorkerAssignmentBlockedRoomFields(productiveEnergy) {
   return {

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -116,10 +116,12 @@ const TERRITORY_EXPANSION_PROGRESS_CPU_BUCKET_FLOOR = 500;
 
 const WORKER_TASK_TYPES = ['harvest', 'transfer', 'build', 'repair', 'upgrade'] as const;
 const PRODUCTIVE_WORKER_TASK_TYPES = ['build', 'repair', 'upgrade'] as const;
+const PRODUCTIVE_WORKER_ASSIGNMENT_TASK_TYPES = ['harvest', 'pickup', 'withdraw', 'transfer', 'build', 'repair', 'upgrade'] as const;
 const DEFAULT_EXTENSION_ENERGY_CAPACITY = 50;
 
 type WorkerTaskType = (typeof WORKER_TASK_TYPES)[number];
 type ProductiveWorkerTaskType = (typeof PRODUCTIVE_WORKER_TASK_TYPES)[number];
+type ProductiveWorkerAssignmentTaskType = (typeof PRODUCTIVE_WORKER_ASSIGNMENT_TASK_TYPES)[number];
 type RuntimeBuildBlockedReason =
   | 'construction_site_progress_unavailable'
   | 'energy_buffer_blocked'
@@ -1188,11 +1190,12 @@ function summarizeRoom(
   const resourcesWithoutActivity = summarizeResources(colony, colonyWorkers, colonyCreeps, eventMetrics.resources);
   const taskCounts = countWorkerTasks(colonyWorkers);
   const assignedTaskCount = countAssignedWorkerTasks(colonyWorkers);
+  const productiveAssignmentCount = countProductiveWorkerAssignments(colonyWorkers);
   const workerAssignmentEvidence = summarizeWorkerAssignmentEvidence(
     tick,
     colonyWorkers,
     assignedTaskCount,
-    resourcesWithoutActivity.productiveEnergy.assignedWorkerCount,
+    productiveAssignmentCount,
     cpuBudget
   );
   const constructionDeadlockTicks = getRoomConstructionDeadlockTicks(colony.room);
@@ -1393,6 +1396,20 @@ function emptyTerritoryRecommendationReport(): OccupationRecommendationReport {
 
 function countAssignedWorkerTasks(workers: Creep[]): number {
   return workers.reduce((assignedCount, worker) => assignedCount + (getWorkerTaskType(worker) ? 1 : 0), 0);
+}
+
+function countProductiveWorkerAssignments(workers: Creep[]): number {
+  return workers.reduce(
+    (assignedCount, worker) =>
+      assignedCount + (isProductiveWorkerAssignmentTaskType(getWorkerTaskType(worker)) ? 1 : 0),
+    0
+  );
+}
+
+function isProductiveWorkerAssignmentTaskType(
+  taskType: string | undefined
+): taskType is ProductiveWorkerAssignmentTaskType {
+  return PRODUCTIVE_WORKER_ASSIGNMENT_TASK_TYPES.includes(taskType as ProductiveWorkerAssignmentTaskType);
 }
 
 function summarizeWorkerAssignmentBlockedRoomFields(

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -114,7 +114,7 @@ describe('runtime telemetry summaries', () => {
             tick: RUNTIME_SUMMARY_INTERVAL,
             workerCount: 2,
             assignedTaskCount: 1,
-            productiveAssignmentCount: 0,
+            productiveAssignmentCount: 1,
             unassignedWorkerCount: 1,
             idleReasonCounts: {
               cpu_shed_assignment_skipped: 0,
@@ -2079,7 +2079,7 @@ describe('runtime telemetry summaries', () => {
     });
   });
 
-  it('counts non-display worker task assignments as assigned runtime evidence', () => {
+  it('counts non-display energy acquisition assignments as productive runtime evidence', () => {
     const colony = makeColony({
       time: RUNTIME_SUMMARY_INTERVAL,
       includeEventLog: false
@@ -2125,7 +2125,7 @@ describe('runtime telemetry summaries', () => {
     expect(room.workerAssignmentEvidence).toMatchObject({
       workerCount: 3,
       assignedTaskCount: 3,
-      productiveAssignmentCount: 0
+      productiveAssignmentCount: 2
     });
   });
 
@@ -2220,6 +2220,85 @@ describe('runtime telemetry summaries', () => {
     expect(room.constructionActivity).toEqual(
       (room.resources as Record<string, Record<string, unknown>>).productiveEnergy.constructionActivity
     );
+  });
+
+  it('counts recovery assignments as productive while preserving the spawn reservation construction blocker', () => {
+    const spawn = {
+      id: 'spawn1',
+      name: 'Spawn1',
+      structureType: TEST_GLOBALS.STRUCTURE_SPAWN,
+      store: makeEnergyStore(300, 300)
+    };
+    const makeCapableWorker = (memory: CreepMemory, energy: number, name: string): Creep =>
+      ({
+        name,
+        memory,
+        store: makeEnergyStore(energy, 50),
+        getActiveBodyparts: jest.fn().mockReturnValue(1)
+      }) as unknown as Creep;
+    const workers = [
+      makeCapableWorker(
+        { role: 'worker', colony: 'W1N1', task: { type: 'transfer', targetId: 'spawn1' as Id<AnyStoreStructure> } },
+        50,
+        'Refiller'
+      ),
+      makeCapableWorker(
+        { role: 'worker', colony: 'W1N1', task: { type: 'withdraw', targetId: 'container1' as Id<AnyStoreStructure> } },
+        0,
+        'Withdrawer'
+      ),
+      makeCapableWorker(
+        { role: 'worker', colony: 'W1N1', task: { type: 'pickup', targetId: 'drop1' as Id<Resource<ResourceConstant>> } },
+        0,
+        'Picker'
+      ),
+      makeCapableWorker(
+        { role: 'worker', colony: 'W1N1', task: { type: 'harvest', targetId: 'source1' as Id<Source> } },
+        0,
+        'Harvester'
+      )
+    ];
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      includeEventLog: false,
+      structures: [spawn],
+      creeps: workers,
+      constructionSites: [
+        { id: 'extension-site', structureType: TEST_GLOBALS.STRUCTURE_EXTENSION, progress: 0, progressTotal: 50 }
+      ]
+    });
+    (colony.room as Room & { energyAvailable: number; energyCapacityAvailable: number }).energyAvailable = 300;
+    colony.energyAvailable = 300;
+
+    emitRuntimeSummary([colony], workers);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.taskCounts).toMatchObject({
+      build: 0,
+      harvest: 1,
+      none: 2,
+      repair: 0,
+      transfer: 1,
+      upgrade: 0
+    });
+    expect(room.workerAssignmentEvidence).toMatchObject({
+      workerCount: 4,
+      assignedTaskCount: 4,
+      productiveAssignmentCount: 4,
+      unassignedWorkerCount: 0
+    });
+    expect((room.resources as Record<string, Record<string, unknown>>).productiveEnergy).toMatchObject({
+      assignedWorkerCount: 0,
+      assignedCarriedEnergy: 0,
+      buildBlockedReason: 'worker_assignment_gap',
+      workerAssignmentBlockedDetail: 'spawn_reserving_energy',
+      constructionActivity: {
+        state: 'candidate_suppressed',
+        accepted: true,
+        reason: 'spawn_reserving_energy'
+      }
+    });
   });
 
   it('reports per-worker build and repair rejection reasons for construction assignment gaps', () => {
@@ -2363,7 +2442,7 @@ describe('runtime telemetry summaries', () => {
     expect(room.workerAssignmentEvidence).toMatchObject({
       workerCount: 1,
       assignedTaskCount: 1,
-      productiveAssignmentCount: 0
+      productiveAssignmentCount: 1
     });
     expect((room.resources as Record<string, Record<string, unknown>>).productiveEnergy.buildBlockedReason).toBeUndefined();
   });


### PR DESCRIPTION
## Summary
- Counts worker recovery assignments (`harvest`, `pickup`, `withdraw`, `transfer`) as productive worker-assignment evidence in runtime summaries.
- Keeps construction-blocker semantics separate so spawn-reserved energy can still suppress build activity correctly.
- Rebuilds `prod/dist/main.js` from the verified source.

Related to issue #1661.

## Verification
- [x] `git diff --check`
- [x] From `prod/`: `npm run typecheck && npm test -- --runInBand && npm run build && sha256sum dist/main.js && wc -c dist/main.js`
- [x] Verification result: 104 Jest suites and 2241 tests passed; bundle SHA-256 `42eb9f07c9dc9d46019b8761d919e331136876d46ad43bb6afe615073c2b6921`; bundle size `2133280` bytes.

## Universal task Done gate
- [x] Task type: code.
- [x] Expected observable outcome / named deliverable: Runtime summaries report recovery-task worker assignments as productive assignment evidence while retaining the existing construction blocker details.
- [x] Non-goals / accepted substitutes: No live RL policy change, no room-limit change, no seasonal score-path change, and no direct official deploy in this branch.
- [x] Verification evidence required before Done: `git diff --check`, TypeScript typecheck, full Jest in-band suite, and production bundle rebuild all pass on commit `b47b1a3e`.
- [x] Project Evidence / Next action / Blocked by: Project fields will name PR review and exact-head CI as the merge gate for issue 1661.
- [x] Post-merge/deploy/runtime proof: Issue 1661 acceptance uses fresh runtime-summary console evidence showing productive assignment counts from the deployed bundle.
- [x] Named deliverable proof: `prod/src/telemetry/runtimeSummary.ts`, `prod/test/runtimeSummary.test.ts`, and regenerated `prod/dist/main.js` implement and verify the telemetry contract.
