### PR TITLE
fix: enable Seasonal RCL3 adjacent control

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4114,7 +4114,7 @@ function getCurrentRoomScoutOnlyAdjacentRoomNames(roomName) {
 }
 function isConfiguredExpansionScoutOnlyTarget(colony, roomName) {
   return getTerritoryExpansionScoutTargets(colony).some(
-    (target) => target.colony === colony && target.roomName === roomName && target.scoutOnly === true
+    (target) => isScoutOnlyTargetForColonyRoom(target, colony, roomName)
   );
 }
 function isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(colony, roomName) {
@@ -4122,7 +4122,15 @@ function isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(colony
 }
 function isSeasonalRuntimeCurrentRoomAdjacentScoutOnlyTargetTerritoryControlEligible(colony, roomName) {
   const currentRoomName = getRuntimeCurrentRoomName();
-  return isSeasonalRuntimeWorld() && currentRoomName === colony && isRuntimeCurrentRoomScoutTargetsEnabled(colony) && getCurrentRoomScoutOnlyAdjacentRoomNames(currentRoomName).includes(roomName) && isAutonomousTerritoryControlAllowedForColonyName(colony);
+  return isSeasonalRuntimeWorld() && currentRoomName === colony && isRuntimeCurrentRoomScoutTargetsEnabled(colony) && !isExplicitConfiguredExpansionScoutOnlyTarget(colony, roomName) && getCurrentRoomScoutOnlyAdjacentRoomNames(currentRoomName).includes(roomName) && isAutonomousTerritoryControlAllowedForColonyName(colony);
+}
+function isExplicitConfiguredExpansionScoutOnlyTarget(colony, roomName) {
+  return [...getMemoryConfiguredExpansionScoutTargets(colony), ...getStaticExpansionScoutTargets(colony)].some(
+    (target) => isScoutOnlyTargetForColonyRoom(target, colony, roomName)
+  );
+}
+function isScoutOnlyTargetForColonyRoom(target, colony, roomName) {
+  return target.colony === colony && target.roomName === roomName && target.scoutOnly === true;
 }
 function getMemoryConfiguredExpansionScoutTargets(colonyName) {
   var _a2, _b;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3955,164 +3955,6 @@ function isRecord3(value) {
   return typeof value === "object" && value !== null;
 }
 
-// src/territory/expansionConfig.ts
-function getTerritoryExpansionScoutTargets(colonyName = getRuntimeCurrentRoomName()) {
-  return dedupeTerritoryExpansionScoutTargets([
-    ...getMemoryConfiguredExpansionScoutTargets(colonyName),
-    ...getEnabledRuntimeCurrentRoomScoutOnlyTargets(colonyName),
-    ...getStaticExpansionScoutTargets(colonyName)
-  ]);
-}
-function getRuntimeCurrentRoomScoutOnlyTargets(colonyName = getRuntimeCurrentRoomName()) {
-  const currentRoomName = getRuntimeCurrentRoomName();
-  if (!currentRoomName || colonyName !== currentRoomName) {
-    return [];
-  }
-  if (currentRoomName === ACTIVE_OFFICIAL_PASSIVE_SCOUT_TARGET_SELECTION.colony) {
-    const officialTarget = { ...ACTIVE_OFFICIAL_PASSIVE_SCOUT_TARGET_SELECTION };
-    return [
-      officialTarget,
-      ...getCurrentRoomScoutOnlyAdjacentRoomNames(currentRoomName).filter((roomName) => roomName !== officialTarget.roomName).map((roomName) => buildRuntimeCurrentRoomScoutOnlyTarget(currentRoomName, roomName))
-    ];
-  }
-  return getCurrentRoomScoutOnlyAdjacentRoomNames(currentRoomName).map(
-    (roomName) => buildRuntimeCurrentRoomScoutOnlyTarget(currentRoomName, roomName)
-  );
-}
-function getCurrentRoomScoutOnlyAdjacentRoomNames(roomName) {
-  const parsed = parseRoomName(roomName);
-  if (!parsed) {
-    return [];
-  }
-  return [
-    formatRoomName(parsed.x, parsed.y - 1),
-    formatRoomName(parsed.x, parsed.y + 1),
-    formatRoomName(parsed.x - 1, parsed.y),
-    formatRoomName(parsed.x + 1, parsed.y)
-  ].filter(isNonEmptyString4);
-}
-function isConfiguredExpansionScoutOnlyTarget(colony, roomName) {
-  return getTerritoryExpansionScoutTargets(colony).some(
-    (target) => target.colony === colony && target.roomName === roomName && target.scoutOnly === true
-  );
-}
-function getMemoryConfiguredExpansionScoutTargets(colonyName) {
-  var _a2, _b;
-  const targets = (_b = (_a2 = globalThis.Memory) == null ? void 0 : _a2.territory) == null ? void 0 : _b.expansionScoutTargets;
-  if (!Array.isArray(targets)) {
-    return [];
-  }
-  return targets.flatMap((target) => {
-    const normalized = normalizeExpansionScoutTarget(target);
-    if (!normalized || colonyName && normalized.colony !== colonyName) {
-      return [];
-    }
-    return [normalized];
-  });
-}
-function getEnabledRuntimeCurrentRoomScoutOnlyTargets(colonyName) {
-  if (!colonyName || !isRuntimeCurrentRoomScoutTargetsEnabled(colonyName)) {
-    return [];
-  }
-  return getRuntimeCurrentRoomScoutOnlyTargets(colonyName);
-}
-function getStaticExpansionScoutTargets(colonyName) {
-  return TERRITORY_EXPANSION_ROOM_SELECTION.scoutTargets.flatMap((target) => {
-    if (colonyName && target.colony !== colonyName) {
-      return [];
-    }
-    return [{ ...target }];
-  });
-}
-function dedupeTerritoryExpansionScoutTargets(targets) {
-  const targetsByKey = /* @__PURE__ */ new Map();
-  for (const target of targets) {
-    const key = getScoutTargetKey(target);
-    const existingTarget = targetsByKey.get(key);
-    if (!existingTarget) {
-      targetsByKey.set(key, target);
-      continue;
-    }
-    targetsByKey.set(key, {
-      ...existingTarget,
-      ...target,
-      ...existingTarget.scoutOnly === true || target.scoutOnly === true ? { scoutOnly: true } : {},
-      ...existingTarget.allowLongRange === true || target.allowLongRange === true ? { allowLongRange: true } : {}
-    });
-  }
-  return Array.from(targetsByKey.values());
-}
-function getScoutTargetKey(target) {
-  return `${target.colony}>${target.roomName}`;
-}
-function buildRuntimeCurrentRoomScoutOnlyTarget(currentRoomName, roomName) {
-  return {
-    colony: currentRoomName,
-    roomName,
-    nearestOwnedRoom: currentRoomName,
-    nearestOwnedRoomDistance: 1,
-    routeDistance: 1,
-    adjacentToOwnedRoom: true,
-    scoutOnly: true
-  };
-}
-function isRuntimeCurrentRoomScoutTargetsEnabled(colonyName) {
-  var _a2, _b;
-  const memory = globalThis.Memory;
-  return ((_a2 = memory == null ? void 0 : memory.territory) == null ? void 0 : _a2.runtimeCurrentRoomScoutTargetsEnabled) === true || ((_b = memory == null ? void 0 : memory.runtime) == null ? void 0 : _b.currentRoomName) === colonyName;
-}
-function normalizeExpansionScoutTarget(target) {
-  if (!target || !isNonEmptyString4(target.colony) || !isNonEmptyString4(target.roomName) || !isNonEmptyString4(target.nearestOwnedRoom)) {
-    return null;
-  }
-  return {
-    colony: target.colony,
-    roomName: target.roomName,
-    nearestOwnedRoom: target.nearestOwnedRoom,
-    nearestOwnedRoomDistance: normalizePositiveDistance(target.nearestOwnedRoomDistance),
-    routeDistance: normalizePositiveDistance(target.routeDistance),
-    adjacentToOwnedRoom: target.adjacentToOwnedRoom === true,
-    ...target.scoutOnly === true ? { scoutOnly: true } : {},
-    ...target.allowLongRange === true ? { allowLongRange: true } : {}
-  };
-}
-function parseRoomName(roomName) {
-  const match = /^(E|W)(\d+)(N|S)(\d+)$/.exec(roomName);
-  if (!match) {
-    return null;
-  }
-  return {
-    x: parseAxisCoordinate(match[1], Number.parseInt(match[2], 10)),
-    y: parseAxisCoordinate(match[3], Number.parseInt(match[4], 10))
-  };
-}
-function parseAxisCoordinate(direction, coordinate) {
-  return direction === "E" || direction === "S" ? coordinate : -coordinate - 1;
-}
-function formatRoomName(x, y) {
-  const horizontal = formatAxisCoordinate("E", "W", x);
-  const vertical = formatAxisCoordinate("S", "N", y);
-  if (!horizontal || !vertical) {
-    return null;
-  }
-  return `${horizontal.direction}${horizontal.coordinate}${vertical.direction}${vertical.coordinate}`;
-}
-function formatAxisCoordinate(positiveDirection, negativeDirection, coordinate) {
-  if (!Number.isFinite(coordinate)) {
-    return null;
-  }
-  if (coordinate >= 0) {
-    return { direction: positiveDirection, coordinate };
-  }
-  return { direction: negativeDirection, coordinate: -coordinate - 1 };
-}
-function normalizePositiveDistance(value) {
-  return typeof value === "number" && Number.isFinite(value) ? Math.max(1, Math.floor(value)) : 1;
-}
-function isNonEmptyString4(value) {
-  return typeof value === "string" && value.length > 0;
-}
-
 // src/runtime/featureGates.ts
 function getRuntimeFeatureGates(game = getRuntimeGame2()) {
   var _a2, _b;
@@ -4232,6 +4074,171 @@ function isAutonomousTerritoryControlAllowedForColonyName(colonyName) {
 }
 function getAutonomousTerritoryControlMinRcl() {
   return isSeasonalRuntimeWorld() ? SEASONAL_AUTONOMOUS_TERRITORY_CONTROL_MIN_RCL : AUTONOMOUS_TERRITORY_CONTROL_MIN_RCL;
+}
+
+// src/territory/expansionConfig.ts
+function getTerritoryExpansionScoutTargets(colonyName = getRuntimeCurrentRoomName()) {
+  return dedupeTerritoryExpansionScoutTargets([
+    ...getMemoryConfiguredExpansionScoutTargets(colonyName),
+    ...getEnabledRuntimeCurrentRoomScoutOnlyTargets(colonyName),
+    ...getStaticExpansionScoutTargets(colonyName)
+  ]);
+}
+function getRuntimeCurrentRoomScoutOnlyTargets(colonyName = getRuntimeCurrentRoomName()) {
+  const currentRoomName = getRuntimeCurrentRoomName();
+  if (!currentRoomName || colonyName !== currentRoomName) {
+    return [];
+  }
+  if (currentRoomName === ACTIVE_OFFICIAL_PASSIVE_SCOUT_TARGET_SELECTION.colony) {
+    const officialTarget = { ...ACTIVE_OFFICIAL_PASSIVE_SCOUT_TARGET_SELECTION };
+    return [
+      officialTarget,
+      ...getCurrentRoomScoutOnlyAdjacentRoomNames(currentRoomName).filter((roomName) => roomName !== officialTarget.roomName).map((roomName) => buildRuntimeCurrentRoomScoutOnlyTarget(currentRoomName, roomName))
+    ];
+  }
+  return getCurrentRoomScoutOnlyAdjacentRoomNames(currentRoomName).map(
+    (roomName) => buildRuntimeCurrentRoomScoutOnlyTarget(currentRoomName, roomName)
+  );
+}
+function getCurrentRoomScoutOnlyAdjacentRoomNames(roomName) {
+  const parsed = parseRoomName(roomName);
+  if (!parsed) {
+    return [];
+  }
+  return [
+    formatRoomName(parsed.x, parsed.y - 1),
+    formatRoomName(parsed.x, parsed.y + 1),
+    formatRoomName(parsed.x - 1, parsed.y),
+    formatRoomName(parsed.x + 1, parsed.y)
+  ].filter(isNonEmptyString4);
+}
+function isConfiguredExpansionScoutOnlyTarget(colony, roomName) {
+  return getTerritoryExpansionScoutTargets(colony).some(
+    (target) => target.colony === colony && target.roomName === roomName && target.scoutOnly === true
+  );
+}
+function isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(colony, roomName) {
+  return isConfiguredExpansionScoutOnlyTarget(colony, roomName) && !isSeasonalRuntimeCurrentRoomAdjacentScoutOnlyTargetTerritoryControlEligible(colony, roomName);
+}
+function isSeasonalRuntimeCurrentRoomAdjacentScoutOnlyTargetTerritoryControlEligible(colony, roomName) {
+  const currentRoomName = getRuntimeCurrentRoomName();
+  return isSeasonalRuntimeWorld() && currentRoomName === colony && isRuntimeCurrentRoomScoutTargetsEnabled(colony) && getCurrentRoomScoutOnlyAdjacentRoomNames(currentRoomName).includes(roomName) && isAutonomousTerritoryControlAllowedForColonyName(colony);
+}
+function getMemoryConfiguredExpansionScoutTargets(colonyName) {
+  var _a2, _b;
+  const targets = (_b = (_a2 = globalThis.Memory) == null ? void 0 : _a2.territory) == null ? void 0 : _b.expansionScoutTargets;
+  if (!Array.isArray(targets)) {
+    return [];
+  }
+  return targets.flatMap((target) => {
+    const normalized = normalizeExpansionScoutTarget(target);
+    if (!normalized || colonyName && normalized.colony !== colonyName) {
+      return [];
+    }
+    return [normalized];
+  });
+}
+function getEnabledRuntimeCurrentRoomScoutOnlyTargets(colonyName) {
+  if (!colonyName || !isRuntimeCurrentRoomScoutTargetsEnabled(colonyName)) {
+    return [];
+  }
+  return getRuntimeCurrentRoomScoutOnlyTargets(colonyName);
+}
+function getStaticExpansionScoutTargets(colonyName) {
+  return TERRITORY_EXPANSION_ROOM_SELECTION.scoutTargets.flatMap((target) => {
+    if (colonyName && target.colony !== colonyName) {
+      return [];
+    }
+    return [{ ...target }];
+  });
+}
+function dedupeTerritoryExpansionScoutTargets(targets) {
+  const targetsByKey = /* @__PURE__ */ new Map();
+  for (const target of targets) {
+    const key = getScoutTargetKey(target);
+    const existingTarget = targetsByKey.get(key);
+    if (!existingTarget) {
+      targetsByKey.set(key, target);
+      continue;
+    }
+    targetsByKey.set(key, {
+      ...existingTarget,
+      ...target,
+      ...existingTarget.scoutOnly === true || target.scoutOnly === true ? { scoutOnly: true } : {},
+      ...existingTarget.allowLongRange === true || target.allowLongRange === true ? { allowLongRange: true } : {}
+    });
+  }
+  return Array.from(targetsByKey.values());
+}
+function getScoutTargetKey(target) {
+  return `${target.colony}>${target.roomName}`;
+}
+function buildRuntimeCurrentRoomScoutOnlyTarget(currentRoomName, roomName) {
+  return {
+    colony: currentRoomName,
+    roomName,
+    nearestOwnedRoom: currentRoomName,
+    nearestOwnedRoomDistance: 1,
+    routeDistance: 1,
+    adjacentToOwnedRoom: true,
+    scoutOnly: true
+  };
+}
+function isRuntimeCurrentRoomScoutTargetsEnabled(colonyName) {
+  var _a2, _b;
+  const memory = globalThis.Memory;
+  return ((_a2 = memory == null ? void 0 : memory.territory) == null ? void 0 : _a2.runtimeCurrentRoomScoutTargetsEnabled) === true || ((_b = memory == null ? void 0 : memory.runtime) == null ? void 0 : _b.currentRoomName) === colonyName;
+}
+function normalizeExpansionScoutTarget(target) {
+  if (!target || !isNonEmptyString4(target.colony) || !isNonEmptyString4(target.roomName) || !isNonEmptyString4(target.nearestOwnedRoom)) {
+    return null;
+  }
+  return {
+    colony: target.colony,
+    roomName: target.roomName,
+    nearestOwnedRoom: target.nearestOwnedRoom,
+    nearestOwnedRoomDistance: normalizePositiveDistance(target.nearestOwnedRoomDistance),
+    routeDistance: normalizePositiveDistance(target.routeDistance),
+    adjacentToOwnedRoom: target.adjacentToOwnedRoom === true,
+    ...target.scoutOnly === true ? { scoutOnly: true } : {},
+    ...target.allowLongRange === true ? { allowLongRange: true } : {}
+  };
+}
+function parseRoomName(roomName) {
+  const match = /^(E|W)(\d+)(N|S)(\d+)$/.exec(roomName);
+  if (!match) {
+    return null;
+  }
+  return {
+    x: parseAxisCoordinate(match[1], Number.parseInt(match[2], 10)),
+    y: parseAxisCoordinate(match[3], Number.parseInt(match[4], 10))
+  };
+}
+function parseAxisCoordinate(direction, coordinate) {
+  return direction === "E" || direction === "S" ? coordinate : -coordinate - 1;
+}
+function formatRoomName(x, y) {
+  const horizontal = formatAxisCoordinate("E", "W", x);
+  const vertical = formatAxisCoordinate("S", "N", y);
+  if (!horizontal || !vertical) {
+    return null;
+  }
+  return `${horizontal.direction}${horizontal.coordinate}${vertical.direction}${vertical.coordinate}`;
+}
+function formatAxisCoordinate(positiveDirection, negativeDirection, coordinate) {
+  if (!Number.isFinite(coordinate)) {
+    return null;
+  }
+  if (coordinate >= 0) {
+    return { direction: positiveDirection, coordinate };
+  }
+  return { direction: negativeDirection, coordinate: -coordinate - 1 };
+}
+function normalizePositiveDistance(value) {
+  return typeof value === "number" && Number.isFinite(value) ? Math.max(1, Math.floor(value)) : 1;
+}
+function isNonEmptyString4(value) {
+  return typeof value === "string" && value.length > 0;
 }
 
 // src/territory/autoClaim.ts
@@ -8250,7 +8257,8 @@ var SYNERGY_DUAL_SOURCE_DUPLICATE_PENALTY = 80;
 var FOREIGN_RESERVATION_CONTROLLER_PRESSURE_RISK = "foreign reservation requires controller pressure";
 var ROOM_LIMIT_PRECONDITION_PREFIX = "limit expansion to ";
 var GCL_LIMIT_PRECONDITION = "wait for GCL capacity to claim another room";
-var SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION = `reach controller level ${AUTONOMOUS_TERRITORY_CONTROL_MIN_RCL} before scout-only remote conversion`;
+var SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION_PREFIX = "reach controller level ";
+var SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION_SUFFIX = " before scout-only remote conversion";
 var SCOUT_ONLY_REMOTE_ENERGY_BUFFER_PRECONDITION = "preserve home energy buffer before scout-only remote conversion";
 var SCOUT_ONLY_REMOTE_CPU_BUCKET_PRECONDITION = "wait for CPU bucket before scout-only remote conversion";
 var SCOUT_ONLY_REMOTE_HOME_ALERT_PRECONDITION = "clear home alert before scout-only remote conversion";
@@ -8897,8 +8905,9 @@ function getExpansionPreconditions(input, candidate) {
   if (((_a2 = input.controllerLevel) != null ? _a2 : 0) < MIN_CONTROLLER_LEVEL) {
     preconditions.push("reach controller level 2 before expansion");
   }
-  if ((candidate == null ? void 0 : candidate.scoutOnly) === true && ((_b = input.controllerLevel) != null ? _b : 0) < AUTONOMOUS_TERRITORY_CONTROL_MIN_RCL) {
-    preconditions.push(SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION);
+  const scoutOnlyRemoteMinRcl = getAutonomousTerritoryControlMinRcl();
+  if ((candidate == null ? void 0 : candidate.scoutOnly) === true && ((_b = input.controllerLevel) != null ? _b : 0) < scoutOnlyRemoteMinRcl) {
+    preconditions.push(getScoutOnlyRemoteMinRclPrecondition(scoutOnlyRemoteMinRcl));
   }
   if ((candidate == null ? void 0 : candidate.scoutOnly) === true && input.homeAlertActive === true) {
     preconditions.push(SCOUT_ONLY_REMOTE_HOME_ALERT_PRECONDITION);
@@ -8928,6 +8937,9 @@ function getExpansionPreconditions(input, candidate) {
     preconditions.push(SEASONAL_IMMATURE_EXPANSION_PRECONDITION);
   }
   return preconditions;
+}
+function getScoutOnlyRemoteMinRclPrecondition(minRcl = getAutonomousTerritoryControlMinRcl()) {
+  return `${SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION_PREFIX}${minRcl}${SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION_SUFFIX}`;
 }
 function hasActivePostClaimBootstrapBlocker(input) {
   return getActivePostClaimBootstrapBlocker(input) !== null;
@@ -9048,7 +9060,7 @@ function getPersistedExpansionCandidateBlockReason(candidate, recommendedAction)
   if (recommendedAction === "claim" || recommendedAction === "reserve") {
     return void 0;
   }
-  if (hasExpansionPrecondition(candidate, SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION)) {
+  if (candidate.preconditions.some(isScoutOnlyRemoteMinRclPrecondition)) {
     return "controllerLevelLow";
   }
   if (hasExpansionPrecondition(candidate, "reach controller level 2 before expansion")) {
@@ -9124,6 +9136,9 @@ function getPersistedExpansionCandidateBlockReason(candidate, recommendedAction)
 }
 function hasExpansionPrecondition(candidate, precondition) {
   return candidate.preconditions.includes(precondition);
+}
+function isScoutOnlyRemoteMinRclPrecondition(precondition) {
+  return precondition.startsWith(SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION_PREFIX) && precondition.endsWith(SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION_SUFFIX);
 }
 function pruneNextExpansionTargets(colony, activeTarget, territoryMemory = getTerritoryMemoryRecord3()) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
@@ -10595,7 +10610,7 @@ function toRuntimeExpansionPlannerCandidate(colony, room, distance, order, colon
   };
 }
 function isRuntimeExpansionPlannerControlRoomSkipped(colonyName, roomName, ownedRoomNames) {
-  return roomName === colonyName || ownedRoomNames.has(roomName) || isConfiguredExpansionScoutOnlyTarget(colonyName, roomName);
+  return roomName === colonyName || ownedRoomNames.has(roomName) || isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(colonyName, roomName);
 }
 function compareExpansionPlannerCandidates(left, right) {
   return right.score - left.score || right.sourceCount - left.sourceCount || left.distance - right.distance || getExpansionPlannerCandidateAdjacencyBonus(right) - getExpansionPlannerCandidateAdjacencyBonus(left) || left.order - right.order || left.roomName.localeCompare(right.roomName);
@@ -15847,7 +15862,7 @@ function buildRuntimeOccupationCandidates(colony, colonyWorkers, expansionReport
     order
   );
   for (const roomName of getAdjacentRoomNames4(colonyName)) {
-    if (isConfiguredExpansionScoutOnlyTarget(colonyName, roomName)) {
+    if (isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(colonyName, roomName)) {
       continue;
     }
     const cachedRouteDistance = getCachedRouteDistance(colonyName, roomName);
@@ -17236,7 +17251,10 @@ function selectExpansionTriggerCandidate(colony, report, territoryMemory, gameTi
 function findExpansionTriggerCandidate(colony, report, territoryMemory, config) {
   var _a2;
   return (_a2 = report.candidates.find(
-    (scoredCandidate) => scoredCandidate.evidenceStatus !== "unavailable" && !isConfiguredExpansionScoutOnlyTarget(colony.room.name, scoredCandidate.roomName) && scoredCandidate.score >= config.scoreThreshold && scoredCandidate.preconditions.length === 0 && !isClaimPlanBlockedByHigherPriorityColony({
+    (scoredCandidate) => scoredCandidate.evidenceStatus !== "unavailable" && !isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(
+      colony.room.name,
+      scoredCandidate.roomName
+    ) && scoredCandidate.score >= config.scoreThreshold && scoredCandidate.preconditions.length === 0 && !isClaimPlanBlockedByHigherPriorityColony({
       colony,
       targetRoom: scoredCandidate.roomName,
       ...scoredCandidate.routeDistance !== void 0 ? { routeDistance: scoredCandidate.routeDistance } : {},
@@ -44331,7 +44349,7 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, tel
     buildAutonomousExpansionScoringInput(colony, report, context, gameTime)
   );
   const adjacentCandidates = getRankedAdjacentExpansionCandidates(expansionReport).filter(
-    (scoredCandidate) => !isConfiguredExpansionScoutOnlyTarget(colonyName, scoredCandidate.roomName)
+    (scoredCandidate) => !isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(colonyName, scoredCandidate.roomName)
   );
   const candidate = (_a2 = adjacentCandidates.find(
     (scoredCandidate) => !hasBlockingClaimIntentForRoom(scoredCandidate.roomName, context.territoryIntents)
@@ -46805,7 +46823,7 @@ function selectAdjacentRoomReservationPlan(colony, options = {}) {
   const ownerUsername = getControllerOwnerUsername13(colony.room.controller);
   const expansionPriorities = getPersistedExpansionCandidatePriorities(colonyName);
   const candidates = getAdjacentRoomNames9(colonyName).flatMap(
-    (roomName, order) => isConfiguredExpansionScoutOnlyTarget(colonyName, roomName) ? [] : buildReservationCandidate(
+    (roomName, order) => isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(colonyName, roomName) ? [] : buildReservationCandidate(
       colony.room,
       roomName,
       order,
@@ -47362,7 +47380,7 @@ function selectColonyExpansionCandidate(colony) {
   const claimedRooms = buildRuntimeClaimedRoomSynergyEvidence(colony.room, ownerUsername);
   const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString40(room.mineralType));
   const candidates = getAdjacentRoomNames10(colony.room.name).flatMap((roomName, order) => {
-    if (isConfiguredExpansionScoutOnlyTarget(colony.room.name, roomName)) {
+    if (isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(colony.room.name, roomName)) {
       return [];
     }
     const room = getVisibleRoom18(roomName);

--- a/prod/src/territory/claimExecutor.ts
+++ b/prod/src/territory/claimExecutor.ts
@@ -1,6 +1,6 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
 import { recordClaimedRoomBootstrapStage } from '../colony/colonyStage';
-import { isConfiguredExpansionScoutOnlyTarget } from './expansionConfig';
+import { isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl } from './expansionConfig';
 import {
   TERRITORY_CONTROLLER_BODY_COST,
   TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS
@@ -446,7 +446,8 @@ function evaluateAutonomousExpansionClaim(
     buildAutonomousExpansionScoringInput(colony, report, context, gameTime)
   );
   const adjacentCandidates = getRankedAdjacentExpansionCandidates(expansionReport).filter(
-    (scoredCandidate) => !isConfiguredExpansionScoutOnlyTarget(colonyName, scoredCandidate.roomName)
+    (scoredCandidate) =>
+      !isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(colonyName, scoredCandidate.roomName)
   );
   const candidate =
     adjacentCandidates.find(

--- a/prod/src/territory/colonyExpansionPlanner.ts
+++ b/prod/src/territory/colonyExpansionPlanner.ts
@@ -1,6 +1,6 @@
 import type { ColonyStageAssessment } from '../colony/colonyStage';
 import type { ColonySnapshot } from '../colony/colonyRegistry';
-import { isConfiguredExpansionScoutOnlyTarget } from './expansionConfig';
+import { isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl } from './expansionConfig';
 import {
   CLAIM_SCORE_RESERVED_PENALTY,
   scoreClaimTarget,
@@ -176,7 +176,7 @@ function selectColonyExpansionCandidate(colony: ColonySnapshot): ColonyExpansion
   const claimedRooms = buildRuntimeClaimedRoomSynergyEvidence(colony.room, ownerUsername);
   const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString(room.mineralType));
   const candidates = getAdjacentRoomNames(colony.room.name).flatMap((roomName, order) => {
-    if (isConfiguredExpansionScoutOnlyTarget(colony.room.name, roomName)) {
+    if (isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(colony.room.name, roomName)) {
       return [];
     }
 

--- a/prod/src/territory/expansionConfig.ts
+++ b/prod/src/territory/expansionConfig.ts
@@ -67,8 +67,8 @@ export function getCurrentRoomScoutOnlyAdjacentRoomNames(roomName: string): stri
 }
 
 export function isConfiguredExpansionScoutOnlyTarget(colony: string, roomName: string): boolean {
-  return getTerritoryExpansionScoutTargets(colony).some(
-    (target) => target.colony === colony && target.roomName === roomName && target.scoutOnly === true
+  return getTerritoryExpansionScoutTargets(colony).some((target) =>
+    isScoutOnlyTargetForColonyRoom(target, colony, roomName)
   );
 }
 
@@ -91,9 +91,24 @@ export function isSeasonalRuntimeCurrentRoomAdjacentScoutOnlyTargetTerritoryCont
     isSeasonalRuntimeWorld() &&
     currentRoomName === colony &&
     isRuntimeCurrentRoomScoutTargetsEnabled(colony) &&
+    !isExplicitConfiguredExpansionScoutOnlyTarget(colony, roomName) &&
     getCurrentRoomScoutOnlyAdjacentRoomNames(currentRoomName).includes(roomName) &&
     isAutonomousTerritoryControlAllowedForColonyName(colony)
   );
+}
+
+function isExplicitConfiguredExpansionScoutOnlyTarget(colony: string, roomName: string): boolean {
+  return [...getMemoryConfiguredExpansionScoutTargets(colony), ...getStaticExpansionScoutTargets(colony)].some(
+    (target) => isScoutOnlyTargetForColonyRoom(target, colony, roomName)
+  );
+}
+
+function isScoutOnlyTargetForColonyRoom(
+  target: TerritoryExpansionScoutTargetConfig,
+  colony: string,
+  roomName: string
+): boolean {
+  return target.colony === colony && target.roomName === roomName && target.scoutOnly === true;
 }
 
 function getMemoryConfiguredExpansionScoutTargets(

--- a/prod/src/territory/expansionConfig.ts
+++ b/prod/src/territory/expansionConfig.ts
@@ -1,8 +1,10 @@
 import { getRuntimeCurrentRoomName } from '../config/runtimeRooms';
+import { isSeasonalRuntimeWorld } from '../runtime/seasonalPolicy';
 import {
   ACTIVE_OFFICIAL_PASSIVE_SCOUT_TARGET_SELECTION,
   TERRITORY_EXPANSION_ROOM_SELECTION
 } from '../config/roomSelection';
+import { isAutonomousTerritoryControlAllowedForColonyName } from './controlGate';
 
 export interface TerritoryExpansionScoutTargetConfig {
   colony: string;
@@ -67,6 +69,30 @@ export function getCurrentRoomScoutOnlyAdjacentRoomNames(roomName: string): stri
 export function isConfiguredExpansionScoutOnlyTarget(colony: string, roomName: string): boolean {
   return getTerritoryExpansionScoutTargets(colony).some(
     (target) => target.colony === colony && target.roomName === roomName && target.scoutOnly === true
+  );
+}
+
+export function isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(
+  colony: string,
+  roomName: string
+): boolean {
+  return (
+    isConfiguredExpansionScoutOnlyTarget(colony, roomName) &&
+    !isSeasonalRuntimeCurrentRoomAdjacentScoutOnlyTargetTerritoryControlEligible(colony, roomName)
+  );
+}
+
+export function isSeasonalRuntimeCurrentRoomAdjacentScoutOnlyTargetTerritoryControlEligible(
+  colony: string,
+  roomName: string
+): boolean {
+  const currentRoomName = getRuntimeCurrentRoomName();
+  return (
+    isSeasonalRuntimeWorld() &&
+    currentRoomName === colony &&
+    isRuntimeCurrentRoomScoutTargetsEnabled(colony) &&
+    getCurrentRoomScoutOnlyAdjacentRoomNames(currentRoomName).includes(roomName) &&
+    isAutonomousTerritoryControlAllowedForColonyName(colony)
   );
 }
 

--- a/prod/src/territory/expansionPlanner.ts
+++ b/prod/src/territory/expansionPlanner.ts
@@ -1,5 +1,5 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
-import { isConfiguredExpansionScoutOnlyTarget } from './expansionConfig';
+import { isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl } from './expansionConfig';
 import { getTerritoryAutoClaimRequiredEnergy } from './autoClaim';
 import { maxRoomsForRcl } from './expansionScoring';
 import { normalizeTerritoryIntents } from './territoryMemoryUtils';
@@ -1674,7 +1674,7 @@ function isRuntimeExpansionPlannerControlRoomSkipped(
   return (
     roomName === colonyName ||
     ownedRoomNames.has(roomName) ||
-    isConfiguredExpansionScoutOnlyTarget(colonyName, roomName)
+    isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(colonyName, roomName)
   );
 }
 

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -20,7 +20,7 @@ import {
   getTerritoryExpansionScoutTargets,
   type TerritoryExpansionScoutTargetConfig
 } from './expansionConfig';
-import { AUTONOMOUS_TERRITORY_CONTROL_MIN_RCL } from './controlGate';
+import { getAutonomousTerritoryControlMinRcl } from './controlGate';
 import { normalizeTerritoryIntents } from './territoryMemoryUtils';
 import { pruneLowerPriorityDuplicateClaimPlans } from './multiRoomTerritory';
 import {
@@ -68,8 +68,8 @@ const SYNERGY_DUAL_SOURCE_DUPLICATE_PENALTY = 80;
 const FOREIGN_RESERVATION_CONTROLLER_PRESSURE_RISK = 'foreign reservation requires controller pressure';
 const ROOM_LIMIT_PRECONDITION_PREFIX = 'limit expansion to ';
 const GCL_LIMIT_PRECONDITION = 'wait for GCL capacity to claim another room';
-const SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION =
-  `reach controller level ${AUTONOMOUS_TERRITORY_CONTROL_MIN_RCL} before scout-only remote conversion`;
+const SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION_PREFIX = 'reach controller level ';
+const SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION_SUFFIX = ' before scout-only remote conversion';
 const SCOUT_ONLY_REMOTE_ENERGY_BUFFER_PRECONDITION =
   'preserve home energy buffer before scout-only remote conversion';
 const SCOUT_ONLY_REMOTE_CPU_BUCKET_PRECONDITION =
@@ -1208,11 +1208,12 @@ function getExpansionPreconditions(
     preconditions.push('reach controller level 2 before expansion');
   }
 
+  const scoutOnlyRemoteMinRcl = getAutonomousTerritoryControlMinRcl();
   if (
     candidate?.scoutOnly === true &&
-    (input.controllerLevel ?? 0) < AUTONOMOUS_TERRITORY_CONTROL_MIN_RCL
+    (input.controllerLevel ?? 0) < scoutOnlyRemoteMinRcl
   ) {
-    preconditions.push(SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION);
+    preconditions.push(getScoutOnlyRemoteMinRclPrecondition(scoutOnlyRemoteMinRcl));
   }
 
   if (candidate?.scoutOnly === true && input.homeAlertActive === true) {
@@ -1254,6 +1255,10 @@ function getExpansionPreconditions(
   }
 
   return preconditions;
+}
+
+function getScoutOnlyRemoteMinRclPrecondition(minRcl = getAutonomousTerritoryControlMinRcl()): string {
+  return `${SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION_PREFIX}${minRcl}${SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION_SUFFIX}`;
 }
 
 function hasActivePostClaimBootstrapBlocker(input: ExpansionScoringInput): boolean {
@@ -1501,7 +1506,7 @@ function getPersistedExpansionCandidateBlockReason(
     return undefined;
   }
 
-  if (hasExpansionPrecondition(candidate, SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION)) {
+  if (candidate.preconditions.some(isScoutOnlyRemoteMinRclPrecondition)) {
     return 'controllerLevelLow';
   }
 
@@ -1602,6 +1607,13 @@ function getPersistedExpansionCandidateBlockReason(
 
 function hasExpansionPrecondition(candidate: ExpansionCandidateScore, precondition: string): boolean {
   return candidate.preconditions.includes(precondition);
+}
+
+function isScoutOnlyRemoteMinRclPrecondition(precondition: string): boolean {
+  return (
+    precondition.startsWith(SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION_PREFIX) &&
+    precondition.endsWith(SCOUT_ONLY_REMOTE_MIN_RCL_PRECONDITION_SUFFIX)
+  );
 }
 
 function persistNextExpansionTarget(

--- a/prod/src/territory/expansionTrigger.ts
+++ b/prod/src/territory/expansionTrigger.ts
@@ -28,8 +28,8 @@ import {
   recordPostClaimBootstrapClaimSuccess
 } from './postClaimBootstrap';
 import {
-  getTerritoryExpansionScoutTargets,
-  isConfiguredExpansionScoutOnlyTarget
+  isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl,
+  getTerritoryExpansionScoutTargets
 } from './expansionConfig';
 import { TERRITORY_CONTROLLER_BODY_COST } from '../spawn/bodyTemplates';
 import {
@@ -526,7 +526,10 @@ function findExpansionTriggerCandidate(
   return report.candidates.find(
     (scoredCandidate) =>
       scoredCandidate.evidenceStatus !== 'unavailable' &&
-      !isConfiguredExpansionScoutOnlyTarget(colony.room.name, scoredCandidate.roomName) &&
+      !isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(
+        colony.room.name,
+        scoredCandidate.roomName
+      ) &&
       scoredCandidate.score >= config.scoreThreshold &&
       scoredCandidate.preconditions.length === 0 &&
       !isClaimPlanBlockedByHigherPriorityColony({

--- a/prod/src/territory/occupationRecommendation.ts
+++ b/prod/src/territory/occupationRecommendation.ts
@@ -1,5 +1,5 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
-import { isConfiguredExpansionScoutOnlyTarget } from './expansionConfig';
+import { isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl } from './expansionConfig';
 import type { ExpansionCandidateReport, ExpansionCandidateScore } from './expansionScoring';
 import { normalizeTerritoryFollowUp, normalizeTerritoryIntents } from './territoryMemoryUtils';
 
@@ -481,7 +481,7 @@ function buildRuntimeOccupationCandidates(
   );
 
   for (const roomName of getAdjacentRoomNames(colonyName)) {
-    if (isConfiguredExpansionScoutOnlyTarget(colonyName, roomName)) {
+    if (isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(colonyName, roomName)) {
       continue;
     }
 

--- a/prod/src/territory/reservationPlanner.ts
+++ b/prod/src/territory/reservationPlanner.ts
@@ -5,7 +5,7 @@ import {
   scoreClaimTarget,
   type ClaimScore
 } from './claimScoring';
-import { isConfiguredExpansionScoutOnlyTarget } from './expansionConfig';
+import { isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl } from './expansionConfig';
 import { maxRoomsForRcl } from './expansionScoring';
 import { normalizeTerritoryIntents } from './territoryMemoryUtils';
 import { isAutonomousTerritoryControlAllowedForController } from './controlGate';
@@ -126,7 +126,7 @@ export function selectAdjacentRoomReservationPlan(
   const ownerUsername = getControllerOwnerUsername(colony.room.controller);
   const expansionPriorities = getPersistedExpansionCandidatePriorities(colonyName);
   const candidates = getAdjacentRoomNames(colonyName).flatMap((roomName, order) =>
-    isConfiguredExpansionScoutOnlyTarget(colonyName, roomName)
+    isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(colonyName, roomName)
       ? []
       : buildReservationCandidate(
           colony.room,

--- a/prod/test/expansionPlanner.test.ts
+++ b/prod/test/expansionPlanner.test.ts
@@ -542,6 +542,140 @@ describe('expansion planner', () => {
     });
   });
 
+  it('creates Seasonal RCL3 claim intents for live runtime adjacent scout-only evidence', () => {
+    const { colony } = makeColony({
+      roomName: 'E9S27',
+      controllerLevel: 3,
+      energyAvailable: 800,
+      energyCapacityAvailable: 800
+    });
+    installRuntimeCurrentRoom('E9S27');
+    installGame(colony, {
+      gclLevel: 2,
+      shard: { name: 'shardSeason', type: 'normal' },
+      exits: { E9S27: { '5': 'E9S28' } },
+      rooms: {
+        E9S28: makeExpansionRoom('E9S28')
+      }
+    });
+
+    expect(refreshExpansionPlannerIntent(colony, 1_671)).toMatchObject({
+      status: 'planned',
+      colony: 'E9S27',
+      targetRoom: 'E9S28',
+      action: 'claim',
+      controllerId: 'controller-E9S28'
+    });
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 1_672)).toEqual({
+      colony: 'E9S27',
+      targetRoom: 'E9S28',
+      action: 'claim',
+      createdBy: 'expansionPlanner',
+      controllerId: 'controller-E9S28'
+    });
+  });
+
+  it('reserves Seasonal RCL3 runtime adjacent scout-only evidence when GCL blocks claim', () => {
+    const { colony } = makeColony({
+      roomName: 'E9S27',
+      controllerLevel: 3,
+      energyAvailable: 800,
+      energyCapacityAvailable: 800
+    });
+    installRuntimeCurrentRoom('E9S27');
+    installGame(colony, {
+      gclLevel: 1,
+      shard: { name: 'shardSeason', type: 'normal' },
+      exits: { E9S27: { '5': 'E9S28' } },
+      rooms: {
+        E9S28: makeExpansionRoom('E9S28')
+      }
+    });
+
+    expect(refreshExpansionPlannerIntent(colony, 1_673)).toMatchObject({
+      status: 'planned',
+      colony: 'E9S27',
+      targetRoom: 'E9S28',
+      action: 'reserve',
+      controllerId: 'controller-E9S28'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'E9S27',
+        roomName: 'E9S28',
+        action: 'reserve',
+        createdBy: 'expansionPlanner',
+        controllerId: 'controller-E9S28'
+      }
+    ]);
+  });
+
+  it('reserves Seasonal RCL3 runtime adjacent scout-only evidence while an owned expansion is below RCL3', () => {
+    const { colony } = makeColony({
+      roomName: 'E9S27',
+      controllerLevel: 3,
+      energyAvailable: 800,
+      energyCapacityAvailable: 800
+    });
+    installRuntimeCurrentRoom('E9S27');
+    installGame(colony, {
+      gclLevel: 3,
+      shard: { name: 'shardSeason', type: 'normal' },
+      exits: { E9S27: { '1': 'E9S26', '5': 'E9S28' } },
+      rooms: {
+        E9S26: makeOwnedExpansionRoom('E9S26', 2),
+        E9S28: makeExpansionRoom('E9S28')
+      }
+    });
+
+    expect(refreshExpansionPlannerIntent(colony, 1_676)).toMatchObject({
+      status: 'planned',
+      colony: 'E9S27',
+      targetRoom: 'E9S28',
+      action: 'reserve',
+      controllerId: 'controller-E9S28'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'E9S27',
+        roomName: 'E9S28',
+        action: 'reserve',
+        createdBy: 'expansionPlanner',
+        controllerId: 'controller-E9S28'
+      }
+    ]);
+  });
+
+  it('keeps persistent RCL3 runtime scout-only adjacency out of claim and reserve planning', () => {
+    const { colony } = makeColony({
+      roomName: 'E9S27',
+      controllerLevel: 3,
+      energyAvailable: 800,
+      energyCapacityAvailable: 800
+    });
+    installRuntimeCurrentRoom('E9S27');
+    installGame(colony, {
+      gclLevel: 2,
+      exits: { E9S27: { '5': 'E9S28' } },
+      rooms: {
+        E9S28: makeExpansionRoom('E9S28')
+      }
+    });
+
+    expect(refreshExpansionPlannerIntent(colony, 1_674)).toEqual({
+      status: 'skipped',
+      colony: 'E9S27',
+      reason: 'noCandidate',
+      candidates: []
+    });
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 1_675);
+    expect(plan?.action).toBe('scout');
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(
+      (Memory.territory?.intents ?? []).filter((intent) => intent.action === 'claim' || intent.action === 'reserve')
+    ).toEqual([]);
+  });
+
   it('reserves instead of starting a second Seasonal claim while an owned expansion is below RCL3', () => {
     const { colony } = makeColony({
       controllerLevel: 3,

--- a/prod/test/expansionScoring.test.ts
+++ b/prod/test/expansionScoring.test.ts
@@ -409,6 +409,50 @@ describe('next expansion scoring', () => {
     expect(Memory.territory?.targets).toBeUndefined();
   });
 
+  it('promotes sufficient Seasonal RCL3 runtime adjacent scout-only evidence without a stale RCL5 hold', () => {
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      shard: { name: 'shardSeason', type: 'normal' } as Game['shard']
+    };
+    const report = scoreExpansionCandidates(
+      makeInput(
+        [
+          makeCandidate({
+            roomName: 'E9S28',
+            scoutOnly: true,
+            controllerId: 'controller-E9S28' as Id<StructureController>,
+            sourceCount: 2,
+            sourceAccessPoints: 8,
+            mineral: { mineralType: 'O' }
+          })
+        ],
+        {
+          colonyName: 'E9S27',
+          controllerLevel: 3,
+          energyAvailable: 800,
+          energyCapacityAvailable: 800,
+          gclLevel: 2
+        }
+      )
+    );
+
+    expect(getCandidate(report, 'E9S28').preconditions).not.toContain(
+      'reach controller level 5 before scout-only remote conversion'
+    );
+
+    persistExpansionCandidateScores('E9S27', report, 1_671);
+
+    expect(getExpansionCandidateMemory()[0]).toMatchObject({
+      colony: 'E9S27',
+      roomName: 'E9S28',
+      evidenceStatus: 'sufficient',
+      scoutOnly: true,
+      recommendedAction: 'reserve',
+      visible: true,
+      updatedAt: 1_671
+    });
+    expect(getExpansionCandidateMemory()[0]).not.toHaveProperty('blockReason');
+  });
+
   it('holds sufficient E29N56 scout-only evidence below RCL5 with a controller-level block reason', () => {
     const report = scoreExpansionCandidates(
       makeInput(

--- a/prod/test/reservationPlanner.test.ts
+++ b/prod/test/reservationPlanner.test.ts
@@ -73,6 +73,43 @@ describe('adjacent room reservation planner', () => {
     ]);
   });
 
+  it('reserves Seasonal RCL3 runtime adjacent scout-only evidence when GCL blocks claiming', () => {
+    const { colony } = makeColony({
+      roomName: 'E9S27',
+      energyAvailable: 800,
+      energyCapacityAvailable: 800,
+      controller: makeOwnedController('E9S27', 3)
+    });
+    Memory.runtime = { currentRoomName: 'E9S27' };
+    installGame(colony, {
+      gclLevel: 1,
+      shard: { name: 'shardSeason', type: 'normal' },
+      rooms: {
+        E9S28: makeReservationRoom('E9S28', { sourceCount: 2 })
+      },
+      exits: { E9S27: { '5': 'E9S28' } }
+    });
+
+    const evaluation = refreshAdjacentRoomReservationIntent(colony, 1_671);
+
+    expect(evaluation).toMatchObject({
+      status: 'planned',
+      colony: 'E9S27',
+      claimBlocker: 'gclInsufficient',
+      targetRoom: 'E9S28',
+      controllerId: 'controller-E9S28'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'E9S27',
+        roomName: 'E9S28',
+        action: 'reserve',
+        createdBy: ADJACENT_ROOM_RESERVATION_TARGET_CREATOR,
+        controllerId: 'controller-E9S28'
+      }
+    ]);
+  });
+
   it('prefers an unscouted adjacent room before low-priority scouted rooms', () => {
     const { colony } = makeColony({ energyAvailable: 650, energyCapacityAvailable: 650 });
     installGame(colony, {
@@ -437,10 +474,12 @@ function installGame(
   colony: ColonySnapshot,
   {
     gclLevel,
+    shard,
     rooms,
     exits
   }: {
     gclLevel: number;
+    shard?: { name: string; type: string };
     rooms: Record<string, Room>;
     exits: Record<string, Partial<Record<'1' | '3' | '5' | '7', string>>>;
   }
@@ -448,6 +487,7 @@ function installGame(
   (globalThis as unknown as { Game: Partial<Game> }).Game = {
     time: 100,
     gcl: { level: gclLevel, progress: 0, progressTotal: 0 } as GlobalControlLevel,
+    ...(shard ? { shard: shard as Game['shard'] } : {}),
     rooms: { [colony.room.name]: colony.room, ...rooms },
     spawns: {},
     creeps: {},
@@ -503,11 +543,11 @@ function makeReservationRoom(
   } as unknown as Room;
 }
 
-function makeOwnedController(roomName: string): StructureController {
+function makeOwnedController(roomName: string, level = 6): StructureController {
   return {
     id: `controller-${roomName}` as Id<StructureController>,
     my: true,
-    level: 6,
+    level,
     ticksToDowngrade: 10_000,
     owner: { username: 'me' }
   } as StructureController;

--- a/prod/test/territory/expansionConfig.test.ts
+++ b/prod/test/territory/expansionConfig.test.ts
@@ -1,7 +1,8 @@
 import {
   getCurrentRoomScoutOnlyAdjacentRoomNames,
   getRuntimeCurrentRoomScoutOnlyTargets,
-  getTerritoryExpansionScoutTargets
+  getTerritoryExpansionScoutTargets,
+  isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl
 } from '../../src/territory/expansionConfig';
 
 describe('territory expansion config', () => {
@@ -206,12 +207,88 @@ describe('territory expansion config', () => {
       }
     ]);
   });
+
+  it('allows Seasonal RCL3 runtime-current-room adjacent scout-only targets through territory control gates', () => {
+    (globalThis as { Game: Partial<Game> }).Game = {
+      shard: { name: 'shardSeason', type: 'normal' } as Game['shard'],
+      rooms: {
+        E9S27: makeOwnedRoom('E9S27', 3)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      runtime: {
+        currentRoomName: 'E9S27'
+      }
+    };
+
+    expect(isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl('E9S27', 'E9S28')).toBe(false);
+  });
+
+  it('keeps persistent runtime scout-only targets excluded from territory control before the Seasonal RCL3 gate', () => {
+    (globalThis as { Game: Partial<Game> }).Game = {
+      shard: { name: 'shardSeason', type: 'normal' } as Game['shard'],
+      rooms: {
+        E9S27: makeOwnedRoom('E9S27', 2)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      runtime: {
+        currentRoomName: 'E9S27'
+      }
+    };
+
+    expect(isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl('E9S27', 'E9S28')).toBe(true);
+  });
+
+  it('keeps non-season runtime scout-only targets excluded from territory control at RCL3', () => {
+    (globalThis as { Game: Partial<Game> }).Game = {
+      rooms: {
+        E9S27: makeOwnedRoom('E9S27', 3)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      runtime: {
+        currentRoomName: 'E9S27'
+      }
+    };
+
+    expect(isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl('E9S27', 'E9S28')).toBe(true);
+  });
+
+  it('keeps non-adjacent memory scout-only targets excluded from Seasonal territory control', () => {
+    (globalThis as { Game: Partial<Game> }).Game = {
+      shard: { name: 'shardSeason', type: 'normal' } as Game['shard'],
+      rooms: {
+        E9S27: makeOwnedRoom('E9S27', 3)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      runtime: {
+        currentRoomName: 'E9S27'
+      },
+      territory: {
+        expansionScoutTargets: [
+          {
+            colony: 'E9S27',
+            roomName: 'E11S27',
+            nearestOwnedRoom: 'E9S27',
+            nearestOwnedRoomDistance: 2,
+            routeDistance: 2,
+            adjacentToOwnedRoom: false,
+            scoutOnly: true
+          }
+        ]
+      }
+    };
+
+    expect(isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl('E9S27', 'E11S27')).toBe(true);
+  });
 });
 
-function makeOwnedRoom(roomName: string): Room {
+function makeOwnedRoom(roomName: string, level = 8): Room {
   return {
     name: roomName,
-    controller: { my: true }
+    controller: { my: true, level }
   } as Room;
 }
 

--- a/prod/test/territory/expansionConfig.test.ts
+++ b/prod/test/territory/expansionConfig.test.ts
@@ -224,6 +224,35 @@ describe('territory expansion config', () => {
     expect(isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl('E9S27', 'E9S28')).toBe(false);
   });
 
+  it('keeps explicit adjacent memory scout-only targets excluded from Seasonal RCL3 territory control', () => {
+    (globalThis as { Game: Partial<Game> }).Game = {
+      shard: { name: 'shardSeason', type: 'normal' } as Game['shard'],
+      rooms: {
+        E9S27: makeOwnedRoom('E9S27', 3)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      runtime: {
+        currentRoomName: 'E9S27'
+      },
+      territory: {
+        expansionScoutTargets: [
+          {
+            colony: 'E9S27',
+            roomName: 'E9S28',
+            nearestOwnedRoom: 'E9S27',
+            nearestOwnedRoomDistance: 1,
+            routeDistance: 1,
+            adjacentToOwnedRoom: true,
+            scoutOnly: true
+          }
+        ]
+      }
+    };
+
+    expect(isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl('E9S27', 'E9S28')).toBe(true);
+  });
+
   it('keeps persistent runtime scout-only targets excluded from territory control before the Seasonal RCL3 gate', () => {
     (globalThis as { Game: Partial<Game> }).Game = {
       shard: { name: 'shardSeason', type: 'normal' } as Game['shard'],


### PR DESCRIPTION
## Summary
- Lets Seasonal runtime-current-room adjacent scout-only targets graduate into territory-control planning at the existing Seasonal RCL3 gate.
- Routes claim/reserve candidate filters through a new explicit territory-control exclusion helper, preserving persistent and explicit memory/static scout-only holds.
- Updates scout-only expansion scoring to use the active world min-RCL so Seasonal RCL3 no longer records stale RCL5 remote-conversion holds.

## Linked work
- Related to issue 1671.

## Verification
- RED check: applied the new test-only patch to fresh `origin/main` in `/root/screeps-worktrees/issue-1671-redcheck`; focused Jest exited `1` with failures for stale RCL5 precondition, missing Seasonal RCL3 claim/reserve plans, and reservation skipped despite GCL claim blocker.
- Review-fix regression: explicit adjacent `Memory.territory.expansionScoutTargets` `scoutOnly: true` remains excluded from Seasonal RCL3 territory control.
- `git diff --check` — pass.
- `npm run typecheck` — pass.
- `npm test -- --runInBand` — pass, 104 suites / 2251 tests.
- `npm run build` — pass, regenerated `prod/dist/main.js` via build.

## Universal task Done gate
- [x] Task type: code bugfix PR for Seasonal territory/expansion behavior.
- [x] Expected observable outcome / named deliverable: Seasonal E9S27 RCL3 generated adjacent safe rooms can produce claim plans when capacity permits and reserve plans when claim is constrained; persistent and explicit scout-only holds remain gated.
- [x] Non-goals / accepted substitutes: no live deploy in this PR; no persistent MMO behavior loosening; no proactive attack behavior; no manual edit of generated bundle.
- [x] Verification evidence required before Done: RED focused failure on fresh main plus typecheck, full Jest, build, and PR review gates.
- [x] Project Evidence / Next action / Blocked by: issue 1671 Project item is In progress with audit evidence; next action is PR review, merge gate, Seasonal deploy, and live-effect gate; CodeRabbit review availability is recorded in Project blocker text.
- [x] Post-merge/deploy/runtime proof: N/A for this non-closing code PR; live-effect proof is collected on the owning Seasonal issue acceptance path.
- [x] Named deliverable proof: N/A; deliverable is the committed code, tests, and regenerated bundle.

## Issue closure gate
- [x] No issue closure is requested in this PR body or commit message; issue 1671 stays available for post-merge Seasonal live-effect evidence.
