### PR TITLE
economy: restore construction task assignment

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -28505,7 +28505,14 @@ function canSpendWorkerEnergyOnConstructionSite(creep, site) {
 }
 function canSpendCreepEnergyOnConstructionSite(creep, site, priorityContext) {
   const carriedEnergy = getUsedEnergy2(creep);
-  return carriedEnergy > 0 && isMissingSpawnRecoveryConstructionSite(creep.room, site) || carriedEnergy > 0 && checkEnergyBufferForConstructionSpending(creep.room) || carriedEnergy > 0 && checkEnergyBufferForStoredConstructionSpending(creep.room) || carriedEnergy > 0 && isExtensionConstructionSite(site) && checkEnergyBufferForExtensionConstruction(creep.room, carriedEnergy) || carriedEnergy > 0 && !isExtensionConstructionSite(site) && isCapacityEnablingConstructionSite(site, priorityContext) && checkEnergyBufferForCapacityEnablingConstruction(creep.room, carriedEnergy) || carriedEnergy > 0 && canCompleteConstructionSiteWithCarriedEnergy(creep, site) || carriedEnergy > 0 && isLowWorkerThroughputRecoveryConstructionAllowed(creep, site) || carriedEnergy > 0 && hasMinimumWorkerSpawnEnergyForConstruction(creep.room) && isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext);
+  return carriedEnergy > 0 && isMissingSpawnRecoveryConstructionSite(creep.room, site) || carriedEnergy > 0 && checkEnergyBufferForConstructionSpending(creep.room) || carriedEnergy > 0 && checkEnergyBufferForStoredConstructionSpending(creep.room) || carriedEnergy > 0 && canSpendCarriedSurplusOnBoundedConstruction(creep, site) || carriedEnergy > 0 && isExtensionConstructionSite(site) && checkEnergyBufferForExtensionConstruction(creep.room, carriedEnergy) || carriedEnergy > 0 && !isExtensionConstructionSite(site) && isCapacityEnablingConstructionSite(site, priorityContext) && checkEnergyBufferForCapacityEnablingConstruction(creep.room, carriedEnergy) || carriedEnergy > 0 && canCompleteConstructionSiteWithCarriedEnergy(creep, site) || carriedEnergy > 0 && isLowWorkerThroughputRecoveryConstructionAllowed(creep, site) || carriedEnergy > 0 && hasMinimumWorkerSpawnEnergyForConstruction(creep.room) && isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext);
+}
+function canSpendCarriedSurplusOnBoundedConstruction(creep, site) {
+  const room = creep.room;
+  const controller = room.controller;
+  const survivalAssessment = getWorkerColonySurvivalAssessment(creep);
+  const roomEnergy = getRoomEnergyAvailable10(room);
+  return site.my !== false && (controller == null ? void 0 : controller.my) === true && roomEnergy !== null && roomEnergy >= MINIMUM_WORKER_SPAWN_ENERGY && !hasVisibleHostilePresence3(room) && !suppressesBootstrapNonCriticalWork(survivalAssessment) && !suppressesTerritoryWork(survivalAssessment) && !shouldGuardControllerDowngrade2(controller) && getActiveWorkParts2(creep) > 0 && hasMinimumProductiveWorkerCoverageForBoundedConstruction(creep) && !hasOtherSameRoomBuildCoverageWorker(creep);
 }
 function isLowWorkerThroughputRecoveryConstructionAllowed(creep, site) {
   return site.my !== false && hasLowWorkerThroughputRecoveryPressure(creep);

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -3840,6 +3840,7 @@ function canSpendCreepEnergyOnConstructionSite(
     (carriedEnergy > 0 && isMissingSpawnRecoveryConstructionSite(creep.room, site)) ||
     (carriedEnergy > 0 && checkEnergyBufferForConstructionSpending(creep.room)) ||
     (carriedEnergy > 0 && checkEnergyBufferForStoredConstructionSpending(creep.room)) ||
+    (carriedEnergy > 0 && canSpendCarriedSurplusOnBoundedConstruction(creep, site)) ||
     (carriedEnergy > 0 &&
       isExtensionConstructionSite(site) &&
       checkEnergyBufferForExtensionConstruction(creep.room, carriedEnergy)) ||
@@ -3852,6 +3853,26 @@ function canSpendCreepEnergyOnConstructionSite(
     (carriedEnergy > 0 &&
       hasMinimumWorkerSpawnEnergyForConstruction(creep.room) &&
       isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext))
+  );
+}
+
+function canSpendCarriedSurplusOnBoundedConstruction(creep: Creep, site: ConstructionSite): boolean {
+  const room = creep.room;
+  const controller = room.controller;
+  const survivalAssessment = getWorkerColonySurvivalAssessment(creep);
+  const roomEnergy = getRoomEnergyAvailable(room);
+  return (
+    site.my !== false &&
+    controller?.my === true &&
+    roomEnergy !== null &&
+    roomEnergy >= MINIMUM_WORKER_SPAWN_ENERGY &&
+    !hasVisibleHostilePresence(room) &&
+    !suppressesBootstrapNonCriticalWork(survivalAssessment) &&
+    !suppressesTerritoryWork(survivalAssessment) &&
+    !shouldGuardControllerDowngrade(controller) &&
+    getActiveWorkParts(creep) > 0 &&
+    hasMinimumProductiveWorkerCoverageForBoundedConstruction(creep) &&
+    !hasOtherSameRoomBuildCoverageWorker(creep)
   );
 }
 

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -13078,6 +13078,52 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'wall-site1' });
   });
 
+  it('keeps one loaded E29N55 builder on construction below the generic spawn buffer when workers carry surplus energy', () => {
+    const site = {
+      id: 'wall-site1',
+      structureType: 'constructedWall',
+      progress: 0,
+      progressTotal: 5_000
+    } as ConstructionSite;
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 6,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 3_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N55',
+      constructionSites: [site],
+      controller,
+      energyAvailable: MINIMUM_WORKER_SPAWN_ENERGY + 50,
+      energyCapacityAvailable: 2_300,
+      myStructures: [fullSpawn as AnyOwnedStructure]
+    });
+    const builder = {
+      name: 'BuilderCandidate',
+      memory: { role: 'worker', colony: 'E29N55' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({
+      BuilderCandidate: builder,
+      LoadedWorkerA: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }),
+      LoadedWorkerB: makeLoadedWorker(room, { type: 'transfer', targetId: 'spawn-full' as Id<AnyStoreStructure> }),
+      EmptyWorker: {
+        name: 'EmptyWorker',
+        memory: { role: 'worker', colony: 'E29N55' },
+        store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+        room
+      } as unknown as Creep
+    });
+
+    expect(selectWorkerTask(builder)).toEqual({ type: 'build', targetId: 'wall-site1' });
+  });
+
   it('reserves a loaded worker for construction when healthy energy and idle workers leave build coverage empty', () => {
     const site = { id: 'wall-site1', structureType: 'constructedWall' } as ConstructionSite;
     const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 317, {


### PR DESCRIPTION
## Summary
- Add a bounded carried-energy construction escape hatch so one safe, loaded worker can take construction when the room is alive and the generic spawn buffer would otherwise suppress all build work.
- Guard the escape hatch with owned-room, no-hostile, no-survival-suppression, downgrade-safety, worker-spawn energy floor, work-part coverage, and no-existing-build-coverage checks.
- Add focused worker task coverage and rebuild the Screeps bundle.

## Issue Reference
Refs #1678

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (104 suites, 2266 tests)
- `cd prod && npm run build`
- Branch fast-forwarded to `origin/main` `48e7c902` before the final verification and Codex-authored commit `07eaa088`.

## Universal task Done gate
- [x] Task type: production Screeps worker-task bugfix.
- [x] Expected observable outcome / named deliverable: worker task selection can assign one bounded construction worker for safe owned-room construction backlog while preserving emergency and controller-safety gates.
- [x] Non-goals / accepted substitutes: no official MMO deploy, no RL policy change, no runtime monitor schema expansion, no Project automation rewrite.
- [x] Verification evidence required before Done: whitespace diff check passed; TypeScript typecheck passed; Jest passed 104 suites and 2266 tests; production bundle build passed; commit 07eaa088 contains the code and bundle diff.
- [x] Project Evidence / Next action / Blocked by: #1678 Project In progress records commit 07eaa088, verification evidence, PR gate action, and code-slice gate value cleared.
- [x] Post-merge/deploy/runtime proof: #1678 owns runtime-summary acceptance capture for build task assignment or backlog movement; this PR provides the verified prod-code prerequisite.
- [x] Named deliverable proof: commit 07eaa088 changes `prod/src/tasks/workerTasks.ts`, `prod/test/workerTasks.test.ts`, and `prod/dist/main.js` with the bounded construction assignment rule and focused test.

## Safety
- Construction spending remains disallowed during visible hostile pressure, survival suppression, territory-work suppression, controller downgrade guard, insufficient worker-spawn energy, lack of productive workers, or existing loaded build coverage.
- No credentials, official deploy, or Project mutations are included in the code commit.