### PR TITLE
fix: spawn Seasonal reserve controller creeps

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -19336,7 +19336,7 @@ function getPersistedTerritoryIntentCandidates(colony, colonyName, colonyOwnerUs
       colony,
       targetRoom: intent.targetRoom,
       territoryMemory
-    }) || !isVisibleTerritoryIntentActionable(intent.targetRoom, intent.action, intent.controllerId, colonyOwnerUsername)) {
+    }) || isTerritoryControlAction3(intent.action) && isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(colonyName, intent.targetRoom) || !isVisibleTerritoryIntentActionable(intent.targetRoom, intent.action, intent.controllerId, colonyOwnerUsername)) {
       return [];
     }
     const intentKey = `${intent.targetRoom}:${intent.action}`;
@@ -20129,7 +20129,7 @@ function getScoutOnlyRemoteConversionBlockReason(colony, candidate, recommendati
   if (isCpuBucketBelowScoutOnlyRemoteFloor()) {
     return "cpuBucketLow";
   }
-  if (!isScoutOnlyRemoteEnergyBufferReady(colony)) {
+  if (candidate.source !== "occupationIntent" && !isScoutOnlyRemoteEnergyBufferReady(colony)) {
     return "energyBufferLow";
   }
   return null;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -19653,8 +19653,12 @@ function getAdjacentReserveCandidates(colonyName, originRoomName, colonyOwnerUse
     if (roomName === colonyName || existingTargetRooms.has(roomName) || isKnownDeadZoneRoom(roomName) || isTerritoryTargetSuppressed(target, intents, gameTime) || isTerritoryRoomSuspendedForColony(intents, colonyName, roomName, gameTime) || isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(intents, colonyName, roomName, "reserve", gameTime)) {
       return [];
     }
+    const controlExcluded = isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(colonyName, roomName);
     const candidateState = getAdjacentReserveCandidateState(roomName, colonyOwnerUsername);
     if (candidateState === "safe") {
+      if (controlExcluded) {
+        return [];
+      }
       const candidate = scoreTerritoryCandidate(
         {
           target,
@@ -20071,6 +20075,12 @@ function isSafeAdjacentControllerProgressCandidate(candidate, recommendation, in
 function getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts, blockReason = null) {
   if (isAutoClaimApprovedTerritoryCandidate(candidate)) {
     return candidate.intentAction;
+  }
+  if (candidate.source === "occupationIntent" && candidate.intentAction === "scout" && isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(
+    candidate.target.colony,
+    candidate.target.roomName
+  )) {
+    return "scout";
   }
   if (blockReason !== null && isConfiguredScoutOnlyRemoteConversionTarget(candidate)) {
     return "scout";

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -2849,8 +2849,13 @@ function getAdjacentReserveCandidates(
       return [];
     }
 
+    const controlExcluded = isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(colonyName, roomName);
     const candidateState = getAdjacentReserveCandidateState(roomName, colonyOwnerUsername);
     if (candidateState === 'safe') {
+      if (controlExcluded) {
+        return [];
+      }
+
       const candidate = scoreTerritoryCandidate(
         {
           target,
@@ -3500,6 +3505,17 @@ function getRecommendedTerritoryIntentAction(
 ): TerritoryIntentAction {
   if (isAutoClaimApprovedTerritoryCandidate(candidate)) {
     return candidate.intentAction;
+  }
+
+  if (
+    candidate.source === 'occupationIntent' &&
+    candidate.intentAction === 'scout' &&
+    isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(
+      candidate.target.colony,
+      candidate.target.roomName
+    )
+  ) {
+    return 'scout';
   }
 
   if (blockReason !== null && isConfiguredScoutOnlyRemoteConversionTarget(candidate)) {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -44,7 +44,10 @@ import {
   isClaimPlanBlockedByHigherPriorityColony,
   pruneLowerPriorityDuplicateClaimPlans
 } from './multiRoomTerritory';
-import { isConfiguredExpansionScoutOnlyTarget } from './expansionConfig';
+import {
+  isConfiguredExpansionScoutOnlyTarget,
+  isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl
+} from './expansionConfig';
 import {
   AUTONOMOUS_TERRITORY_CONTROL_SUPPRESSION_REASON,
   isAutonomousTerritoryControlAllowedForColony,
@@ -2311,6 +2314,8 @@ function getPersistedTerritoryIntentCandidates(
           targetRoom: intent.targetRoom,
           territoryMemory
         })) ||
+      (isTerritoryControlAction(intent.action) &&
+        isConfiguredExpansionScoutOnlyTargetExcludedFromTerritoryControl(colonyName, intent.targetRoom)) ||
       !isVisibleTerritoryIntentActionable(intent.targetRoom, intent.action, intent.controllerId, colonyOwnerUsername)
     ) {
       return [];
@@ -3601,7 +3606,10 @@ function getScoutOnlyRemoteConversionBlockReason(
     return 'cpuBucketLow';
   }
 
-  if (!isScoutOnlyRemoteEnergyBufferReady(colony)) {
+  if (
+    candidate.source !== 'occupationIntent' &&
+    !isScoutOnlyRemoteEnergyBufferReady(colony)
+  ) {
     return 'energyBufferLow';
   }
 

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -3536,6 +3536,157 @@ describe('planSpawn', () => {
     ]);
   });
 
+  it('spawns a Seasonal RCL3 reserver when a reserve intent duplicates a stale scout intent', () => {
+    (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 11;
+    (globalThis as unknown as { STRUCTURE_RAMPART: StructureConstant }).STRUCTURE_RAMPART = 'rampart';
+    (globalThis as unknown as { STRUCTURE_WALL: StructureConstant }).STRUCTURE_WALL = 'constructedWall';
+    const controllerId = '6a1c3660d05a7c237d18c27d' as Id<StructureController>;
+    const { colony, spawn } = makeColony({
+      roomName: 'E9S27',
+      sourceCount: 2,
+      energyAvailable: 800,
+      energyCapacityAvailable: 800,
+      controller: {
+        id: 'controller-E9S27' as Id<StructureController>,
+        my: true,
+        level: 3,
+        ticksToDowngrade: 10_000,
+        owner: { username: 'player' },
+        pos: { x: 25, y: 25, roomName: 'E9S27' } as RoomPosition
+      } as StructureController,
+      ownedStructures: [
+        {
+          id: 'spawn1',
+          structureType: 'spawn',
+          my: true,
+          pos: { x: 17, y: 24, roomName: 'E9S27' }
+        } as AnyOwnedStructure,
+        {
+          id: 'spawn-rampart',
+          structureType: 'rampart',
+          my: true,
+          pos: { x: 17, y: 24, roomName: 'E9S27' }
+        } as AnyOwnedStructure,
+        {
+          id: 'tower1',
+          structureType: 'tower',
+          my: true,
+          pos: { x: 20, y: 20, roomName: 'E9S27' }
+        } as AnyOwnedStructure
+      ],
+      structures: [
+        {
+          id: 'spawn-wall-a',
+          structureType: 'constructedWall',
+          pos: { x: 16, y: 23, roomName: 'E9S27' }
+        } as AnyStructure,
+        {
+          id: 'spawn-wall-b',
+          structureType: 'constructedWall',
+          pos: { x: 18, y: 23, roomName: 'E9S27' }
+        } as AnyStructure,
+        {
+          id: 'spawn-wall-c',
+          structureType: 'constructedWall',
+          pos: { x: 16, y: 25, roomName: 'E9S27' }
+        } as AnyStructure,
+        {
+          id: 'spawn-wall-d',
+          structureType: 'constructedWall',
+          pos: { x: 18, y: 25, roomName: 'E9S27' }
+        } as AnyStructure
+      ]
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      rooms: {
+        E9S27: {
+          colonyStage: { mode: 'TERRITORY_READY', updatedAt: 52_397 },
+          cachedExpansionSelection: {
+            colony: 'E9S27',
+            targetRoom: 'E9S28',
+            status: 'planned',
+            reason: 'gclInsufficient'
+          }
+        }
+      },
+      territory: {
+        intents: [
+          {
+            colony: 'E9S27',
+            targetRoom: 'E9S28',
+            action: 'reserve',
+            status: 'planned',
+            updatedAt: 52_272,
+            createdBy: 'occupationRecommendation',
+            controllerId
+          },
+          {
+            colony: 'E9S27',
+            targetRoom: 'E9S28',
+            action: 'scout',
+            status: 'planned',
+            updatedAt: 52_397,
+            controllerId
+          }
+        ],
+        expansionCandidates: [
+          {
+            colony: 'E9S27',
+            roomName: 'E9S28',
+            rank: 1,
+            score: 1_200,
+            evidenceStatus: 'sufficient',
+            visible: true,
+            updatedAt: 52_397,
+            adjacentToOwnedRoom: true,
+            scoutOnly: true,
+            recommendedAction: 'reserve',
+            routeDistance: 1,
+            controllerId,
+            sourceCount: 2,
+            hostileCreepCount: 0,
+            hostileStructureCount: 0
+          }
+        ]
+      },
+      runtime: { currentRoomName: 'E9S27' }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 52_398,
+      shard: { name: 'shardSeason', type: 'normal' } as Game['shard'],
+      cpu: { bucket: 10_000 } as Game['cpu'],
+      gcl: { level: 1 } as Game['gcl'],
+      map: {
+        describeExits: jest.fn((roomName: string) => (roomName === 'E9S27' ? { '3': 'E9S28' } : {})),
+        findRoute: jest.fn(() => [{ exit: 3, room: 'E9S28' }])
+      } as unknown as GameMap,
+      rooms: {
+        E9S27: colony.room,
+        E9S28: makeTerritoryRoom(
+          'E9S28',
+          { id: controllerId, my: false } as StructureController,
+          2
+        )
+      },
+      creeps: {}
+    };
+
+    expect(planSpawn(colony, { worker: 4, sourceHarvester: 1, claimer: 0, claimersByTargetRoom: {} }, 52_398)).toEqual({
+      spawn,
+      body: ['claim', 'move'],
+      name: 'claimer-E9S27-E9S28-52398',
+      memory: {
+        role: 'claimer',
+        colony: 'E9S27',
+        territory: {
+          targetRoom: 'E9S28',
+          action: 'reserve',
+          controllerId
+        }
+      }
+    });
+  });
+
   it('plans a claimer-role claimer for a claim-ready configured reserve target', () => {
     const { colony, spawn } = makeColony({
       energyAvailable: 650,

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -353,6 +353,60 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('does not promote an explicit scout-only persisted scout intent into reserve control', () => {
+    const colony = makeSafeColony({
+      controller: { my: true, owner: { username: 'me' }, level: 6, ticksToDowngrade: 10_000 } as StructureController,
+      energyAvailable: 1_800,
+      energyCapacityAvailable: 1_800
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        expansionScoutTargets: [
+          {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            nearestOwnedRoom: 'W1N1',
+            nearestOwnedRoomDistance: 1,
+            routeDistance: 1,
+            adjacentToOwnedRoom: true,
+            scoutOnly: true
+          }
+        ],
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'scout',
+            status: 'planned',
+            updatedAt: 509,
+            controllerId: 'controller2' as Id<StructureController>
+          }
+        ]
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1', {
+          controller: { id: 'controller2' as Id<StructureController>, my: false } as StructureController,
+          sourceCount: 2
+        })
+      },
+      map: {
+        describeExits: jest.fn(() => ({ '3': 'W2N1' })),
+        findRoute: jest.fn(() => [{ exit: 3, room: 'W2N1' }])
+      } as unknown as GameMap
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, scout: 0, claimer: 0, claimersByTargetRoom: {} }, 3, 510)
+    ).toBeNull();
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(
+      (Memory.territory?.intents ?? []).filter((intent) => intent.action === 'claim' || intent.action === 'reserve')
+    ).toEqual([]);
+  });
+
   it('holds configured territory execution while an E29N55-like RCL3 room has no tower', () => {
     const globals = globalThis as unknown as {
       FIND_STRUCTURES: number;


### PR DESCRIPTION
## Summary
- Allow persisted `occupationRecommendation` reserve intents for Seasonal runtime-current-room scout-only adjacent targets to remain spawn-eligible instead of being downgraded by the scout-only conversion energy-buffer hold.
- Keep explicit/static scout-only holds excluded from persisted control intent selection, and keep stale scout intents from those rooms from promoting into reserve control.
- Preserve CPU, home-alert, controller-pressure, hostile/foreign-controller, RCL, GCL, and persistent-world gates.
- Add a live-shaped E9S27/E9S28 spawn planner regression covering duplicate reserve+scout intents for the same safe room and expecting a `claimer` memory assignment with `territory.action = 'reserve'`; add coverage that explicit scout-only persisted scout intents do not promote into reserve.

## Linked work
Related to issue 1671

## Verification
- `git diff --check` passed.
- `npm run typecheck` passed (`tsc --noEmit`).
- `npm test -- --runInBand` passed: 104 suites, 2267 tests.
- `npm run build` passed and regenerated `prod/dist/main.js` through esbuild (`dist/main.js 2.1mb`).

## Universal task Done gate

- [x] Task type: bugfix.
- [x] Expected observable outcome / named deliverable: Seasonal E9S27 RCL3 with an E9S28 reserve intent plans a territory controller creep for reserve instead of noop or scout-only work.
- [x] Non-goals / accepted substitutes: No proactive attack behavior; no weakening of hostile/foreign-controller safety, CPU/home-alert guards, explicit scout-only operator holds, persistent-world gates, or controller/RCL/GCL semantics.
- [x] Verification evidence required before Done: `git diff --check`; `npm run typecheck`; `npm test -- --runInBand` with 104 suites and 2267 tests passing; `npm run build` regenerating `prod/dist/main.js`.
- [x] Project Evidence / Next action / Blocked by: issue #1671 and PR #1686 Project items are `In review`; Evidence lists PR #1686, head `27ddd0ad`, local verification, and the explicit scout-only review fix; Next action is PR gate then live proof; Blocked by empty.
- [x] Post-merge/deploy/runtime proof: Deferred to issue #1671 live-proof workflow by task request; this PR supplies code, regression, verification, and bundle artifact.
- [x] Named deliverable proof: PR #1686 at `27ddd0ad` includes the spawnPlanner regression proving E9S27/E9S28 reserve intent returns `claimer` memory with `territory.action = 'reserve'` and preserved controller id, plus the territoryPlanner regression preserving explicit scout-only operator holds.

## Live follow-up
Live deploy/effect proof remains on issue #1671 after merge.