### PR TITLE
territory: align expansion room limit with GCL capacity

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -8359,6 +8359,27 @@ function maxRoomsForRcl(controllerLevel) {
   const rcl = Math.min(8, Math.max(1, Math.floor(controllerLevel)));
   return MAX_ROOM_COUNT_BY_RCL[rcl];
 }
+function getExpansionRoomLimitCapacity({
+  controllerLevel,
+  gclLevel
+}) {
+  const rclRoomLimitCapacity = maxRoomsForRcl(controllerLevel);
+  const gclRoomCapacity = normalizeGclClaimRoomCapacity(gclLevel);
+  if (gclRoomCapacity !== null && gclRoomCapacity > rclRoomLimitCapacity) {
+    return {
+      roomLimitCapacity: gclRoomCapacity,
+      rclRoomLimitCapacity,
+      roomLimitBasis: "gclCapacity",
+      gclRoomCapacity
+    };
+  }
+  return {
+    roomLimitCapacity: rclRoomLimitCapacity,
+    rclRoomLimitCapacity,
+    roomLimitBasis: "rclPolicy",
+    ...gclRoomCapacity !== null ? { gclRoomCapacity } : {}
+  };
+}
 function buildRuntimeExpansionCandidates(colony) {
   var _a2;
   const rooms = (_a2 = getGameRooms3()) != null ? _a2 : {};
@@ -8928,12 +8949,16 @@ function getExpansionPreconditions(input, candidate) {
   }
   const ownedRoomCount = getOwnedRoomCount(input);
   const gclRoomCapacity = getGclClaimRoomCapacity(input);
-  if (gclRoomCapacity !== null && ownedRoomCount >= gclRoomCapacity) {
+  const gclCapacityReached = gclRoomCapacity !== null && ownedRoomCount >= gclRoomCapacity;
+  if (gclCapacityReached) {
     preconditions.push(GCL_LIMIT_PRECONDITION);
   }
-  const maxRoomCount = maxRoomsForRcl(input.controllerLevel);
-  if (ownedRoomCount >= maxRoomCount) {
-    preconditions.push(`limit expansion to ${maxRoomCount} owned rooms for current controller level`);
+  const roomLimitCapacity = getExpansionRoomLimitCapacity({
+    controllerLevel: input.controllerLevel,
+    gclLevel: input.gclLevel
+  }).roomLimitCapacity;
+  if (!gclCapacityReached && ownedRoomCount >= roomLimitCapacity) {
+    preconditions.push(`limit expansion to ${roomLimitCapacity} owned rooms for current controller level`);
   }
   if (typeof input.ticksToDowngrade === "number" && input.ticksToDowngrade <= DOWNGRADE_GUARD_TICKS) {
     preconditions.push("stabilize home controller downgrade timer");
@@ -8969,7 +8994,9 @@ function isScoutOnlyRemoteEnergyBufferLow(input) {
   return input.energyAvailable - TERRITORY_CONTROLLER_BODY_COST < input.energyBufferThreshold;
 }
 function getGclClaimRoomCapacity(input) {
-  const level = input.gclLevel;
+  return normalizeGclClaimRoomCapacity(input.gclLevel);
+}
+function normalizeGclClaimRoomCapacity(level) {
   if (typeof level !== "number" || !Number.isFinite(level) || level <= 0) {
     return null;
   }
@@ -17024,12 +17051,17 @@ function getAutonomousExpansionCapacitySummary(colony) {
     colony.room.name,
     getControllerOwnerUsername8(colony.room.controller)
   );
-  const roomLimitCapacity = maxRoomsForRcl((_a2 = colony.room.controller) == null ? void 0 : _a2.level);
   const gclRoomCapacity = getGclLevel3();
-  const status = gclRoomCapacity !== null && ownedRoomCount >= gclRoomCapacity ? "gclInsufficient" : ownedRoomCount >= roomLimitCapacity ? "roomLimitReached" : "available";
+  const roomLimit = getExpansionRoomLimitCapacity({
+    controllerLevel: (_a2 = colony.room.controller) == null ? void 0 : _a2.level,
+    gclLevel: gclRoomCapacity
+  });
+  const status = gclRoomCapacity !== null && ownedRoomCount >= gclRoomCapacity ? "gclInsufficient" : ownedRoomCount >= roomLimit.roomLimitCapacity ? "roomLimitReached" : "available";
   return {
     ownedRoomCount,
-    roomLimitCapacity,
+    roomLimitCapacity: roomLimit.roomLimitCapacity,
+    rclRoomLimitCapacity: roomLimit.rclRoomLimitCapacity,
+    roomLimitBasis: roomLimit.roomLimitBasis,
     status,
     ...gclRoomCapacity !== null ? { gclRoomCapacity } : {}
   };
@@ -17719,7 +17751,10 @@ function getExpansionCapacitySkipReason(colony) {
   if (gclLevel !== null && ownedRoomCount >= gclLevel) {
     return "gclInsufficient";
   }
-  if (ownedRoomCount >= maxRoomsForRcl((_a2 = colony.room.controller) == null ? void 0 : _a2.level)) {
+  if (ownedRoomCount >= getExpansionRoomLimitCapacity({
+    controllerLevel: (_a2 = colony.room.controller) == null ? void 0 : _a2.level,
+    gclLevel
+  }).roomLimitCapacity) {
     return "roomLimitReached";
   }
   return null;
@@ -39576,6 +39611,8 @@ function buildTerritoryExpansionProgressSummary(colony, survival, territoryExpan
     ownedRoomCount: capacity.ownedRoomCount,
     roomCapacityStatus: capacity.status,
     roomLimitCapacity: capacity.roomLimitCapacity,
+    rclRoomLimitCapacity: capacity.rclRoomLimitCapacity,
+    roomLimitBasis: capacity.roomLimitBasis,
     ...capacity.gclRoomCapacity !== void 0 ? { gclRoomCapacity: capacity.gclRoomCapacity } : {},
     activePipelineStateKey: getAutonomousExpansionPipelineStateKey(colonyName),
     ...activePipeline ? { activePipeline } : {},

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -435,6 +435,8 @@ interface RuntimeTerritoryExpansionProgressSummary {
   ownedRoomCount: number;
   roomCapacityStatus: AutonomousExpansionCapacitySummary['status'];
   roomLimitCapacity: number;
+  rclRoomLimitCapacity: number;
+  roomLimitBasis: AutonomousExpansionCapacitySummary['roomLimitBasis'];
   gclRoomCapacity?: number;
   activePipelineStateKey: string;
   activePipeline?: RuntimeTerritoryExpansionPipelineProgressSummary;
@@ -1662,6 +1664,8 @@ function buildTerritoryExpansionProgressSummary(
     ownedRoomCount: capacity.ownedRoomCount,
     roomCapacityStatus: capacity.status,
     roomLimitCapacity: capacity.roomLimitCapacity,
+    rclRoomLimitCapacity: capacity.rclRoomLimitCapacity,
+    roomLimitBasis: capacity.roomLimitBasis,
     ...(capacity.gclRoomCapacity !== undefined ? { gclRoomCapacity: capacity.gclRoomCapacity } : {}),
     activePipelineStateKey: getAutonomousExpansionPipelineStateKey(colonyName),
     ...(activePipeline ? { activePipeline } : {}),

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -148,6 +148,15 @@ export interface ExpansionScoringInput {
   candidates: ExpansionCandidateInput[];
 }
 
+export type ExpansionRoomLimitBasis = 'rclPolicy' | 'gclCapacity';
+
+export interface ExpansionRoomLimitCapacity {
+  roomLimitCapacity: number;
+  rclRoomLimitCapacity: number;
+  roomLimitBasis: ExpansionRoomLimitBasis;
+  gclRoomCapacity?: number;
+}
+
 export interface ExpansionClaimedRoomInput {
   roomName: string;
   sourceCount?: number;
@@ -441,6 +450,32 @@ export function maxRoomsForRcl(controllerLevel: number | undefined): number {
 
   const rcl = Math.min(8, Math.max(1, Math.floor(controllerLevel)));
   return MAX_ROOM_COUNT_BY_RCL[rcl];
+}
+
+export function getExpansionRoomLimitCapacity({
+  controllerLevel,
+  gclLevel
+}: {
+  controllerLevel: number | undefined;
+  gclLevel?: number | null;
+}): ExpansionRoomLimitCapacity {
+  const rclRoomLimitCapacity = maxRoomsForRcl(controllerLevel);
+  const gclRoomCapacity = normalizeGclClaimRoomCapacity(gclLevel);
+  if (gclRoomCapacity !== null && gclRoomCapacity > rclRoomLimitCapacity) {
+    return {
+      roomLimitCapacity: gclRoomCapacity,
+      rclRoomLimitCapacity,
+      roomLimitBasis: 'gclCapacity',
+      gclRoomCapacity
+    };
+  }
+
+  return {
+    roomLimitCapacity: rclRoomLimitCapacity,
+    rclRoomLimitCapacity,
+    roomLimitBasis: 'rclPolicy',
+    ...(gclRoomCapacity !== null ? { gclRoomCapacity } : {})
+  };
 }
 
 function buildRuntimeExpansionCandidates(colony: ColonySnapshot): ExpansionCandidateInput[] {
@@ -1230,13 +1265,17 @@ function getExpansionPreconditions(
 
   const ownedRoomCount = getOwnedRoomCount(input);
   const gclRoomCapacity = getGclClaimRoomCapacity(input);
-  if (gclRoomCapacity !== null && ownedRoomCount >= gclRoomCapacity) {
+  const gclCapacityReached = gclRoomCapacity !== null && ownedRoomCount >= gclRoomCapacity;
+  if (gclCapacityReached) {
     preconditions.push(GCL_LIMIT_PRECONDITION);
   }
 
-  const maxRoomCount = maxRoomsForRcl(input.controllerLevel);
-  if (ownedRoomCount >= maxRoomCount) {
-    preconditions.push(`limit expansion to ${maxRoomCount} owned rooms for current controller level`);
+  const roomLimitCapacity = getExpansionRoomLimitCapacity({
+    controllerLevel: input.controllerLevel,
+    gclLevel: input.gclLevel
+  }).roomLimitCapacity;
+  if (!gclCapacityReached && ownedRoomCount >= roomLimitCapacity) {
+    preconditions.push(`limit expansion to ${roomLimitCapacity} owned rooms for current controller level`);
   }
 
   if (typeof input.ticksToDowngrade === 'number' && input.ticksToDowngrade <= DOWNGRADE_GUARD_TICKS) {
@@ -1296,7 +1335,10 @@ function isScoutOnlyRemoteEnergyBufferLow(input: ExpansionScoringInput): boolean
 }
 
 function getGclClaimRoomCapacity(input: ExpansionScoringInput): number | null {
-  const level = input.gclLevel;
+  return normalizeGclClaimRoomCapacity(input.gclLevel);
+}
+
+function normalizeGclClaimRoomCapacity(level: number | null | undefined): number | null {
   if (typeof level !== 'number' || !Number.isFinite(level) || level <= 0) {
     return null;
   }

--- a/prod/src/territory/expansionTrigger.ts
+++ b/prod/src/territory/expansionTrigger.ts
@@ -5,9 +5,10 @@ import {
 } from './autoClaim';
 import {
   NEXT_EXPANSION_TARGET_CREATOR,
-  maxRoomsForRcl,
+  getExpansionRoomLimitCapacity,
   type ExpansionCandidateReport,
   type ExpansionCandidateScore,
+  type ExpansionRoomLimitBasis,
   type NextExpansionTargetSelection
 } from './expansionScoring';
 import {
@@ -70,6 +71,8 @@ interface ExpansionProgressBlocker {
 export interface AutonomousExpansionCapacitySummary {
   ownedRoomCount: number;
   roomLimitCapacity: number;
+  rclRoomLimitCapacity: number;
+  roomLimitBasis: ExpansionRoomLimitBasis;
   status: 'available' | 'gclInsufficient' | 'roomLimitReached';
   gclRoomCapacity?: number;
 }
@@ -193,18 +196,23 @@ export function getAutonomousExpansionCapacitySummary(
     colony.room.name,
     getControllerOwnerUsername(colony.room.controller)
   );
-  const roomLimitCapacity = maxRoomsForRcl(colony.room.controller?.level);
   const gclRoomCapacity = getGclLevel();
+  const roomLimit = getExpansionRoomLimitCapacity({
+    controllerLevel: colony.room.controller?.level,
+    gclLevel: gclRoomCapacity
+  });
   const status =
     gclRoomCapacity !== null && ownedRoomCount >= gclRoomCapacity
       ? 'gclInsufficient'
-      : ownedRoomCount >= roomLimitCapacity
+      : ownedRoomCount >= roomLimit.roomLimitCapacity
         ? 'roomLimitReached'
         : 'available';
 
   return {
     ownedRoomCount,
-    roomLimitCapacity,
+    roomLimitCapacity: roomLimit.roomLimitCapacity,
+    rclRoomLimitCapacity: roomLimit.rclRoomLimitCapacity,
+    roomLimitBasis: roomLimit.roomLimitBasis,
     status,
     ...(gclRoomCapacity !== null ? { gclRoomCapacity } : {})
   };
@@ -1252,7 +1260,13 @@ function getExpansionCapacitySkipReason(colony: ColonySnapshot): NextExpansionTa
     return 'gclInsufficient';
   }
 
-  if (ownedRoomCount >= maxRoomsForRcl(colony.room.controller?.level)) {
+  if (
+    ownedRoomCount >=
+    getExpansionRoomLimitCapacity({
+      controllerLevel: colony.room.controller?.level,
+      gclLevel
+    }).roomLimitCapacity
+  ) {
     return 'roomLimitReached';
   }
 

--- a/prod/test/expansionScoring.test.ts
+++ b/prod/test/expansionScoring.test.ts
@@ -2171,6 +2171,94 @@ describe('next expansion scoring', () => {
     expect(belowLimit.next?.preconditions).not.toContain(roomLimitPrecondition);
   });
 
+  it('lets GCL capacity raise the safe expansion room limit above the internal RCL cap', () => {
+    expect(maxRoomsForRcl(4)).toBe(3);
+
+    const atCurrentRoomCount = scoreExpansionCandidates(
+      makeInput([makeCandidate({ roomName: 'W3N1', sourceCount: 2 })], {
+        controllerLevel: 4,
+        ownedRoomCount: 3,
+        gclLevel: 5
+      })
+    );
+    const belowGclCapacity = scoreExpansionCandidates(
+      makeInput([makeCandidate({ roomName: 'W4N1', sourceCount: 2 })], {
+        controllerLevel: 4,
+        ownedRoomCount: 4,
+        gclLevel: 5
+      })
+    );
+    const atGclCapacity = scoreExpansionCandidates(
+      makeInput([makeCandidate({ roomName: 'W5N1', sourceCount: 2 })], {
+        controllerLevel: 4,
+        ownedRoomCount: 5,
+        gclLevel: 5
+      })
+    );
+    const aboveGclCapacity = scoreExpansionCandidates(
+      makeInput([makeCandidate({ roomName: 'W6N1', sourceCount: 2 })], {
+        controllerLevel: 4,
+        ownedRoomCount: 6,
+        gclLevel: 5
+      })
+    );
+    const scoutNeededAtCurrentRoomCount = scoreExpansionCandidates(
+      makeInput([makeCandidate({ roomName: 'W7N1', sourceCount: undefined, visible: false })], {
+        controllerLevel: 4,
+        ownedRoomCount: 3,
+        gclLevel: 5
+      })
+    );
+
+    expect(atCurrentRoomCount.next?.preconditions).not.toContain(
+      'limit expansion to 3 owned rooms for current controller level'
+    );
+    expect(refreshNextExpansionTargetSelection(makeSafeColony({ controllerLevel: 4 }), atCurrentRoomCount, 216))
+      .toMatchObject({
+        status: 'planned',
+        colony: 'W1N1',
+        targetRoom: 'W3N1'
+      });
+    expect(belowGclCapacity.next?.preconditions).not.toContain(
+      'limit expansion to 3 owned rooms for current controller level'
+    );
+    expect(refreshNextExpansionTargetSelection(makeSafeColony({ controllerLevel: 4 }), belowGclCapacity, 217))
+      .toMatchObject({
+        status: 'planned',
+        colony: 'W1N1',
+        targetRoom: 'W4N1'
+      });
+    expect(atGclCapacity.next?.preconditions).toContain('wait for GCL capacity to claim another room');
+    expect(atGclCapacity.next?.preconditions).not.toContain(
+      'limit expansion to 3 owned rooms for current controller level'
+    );
+    expect(refreshNextExpansionTargetSelection(makeSafeColony({ controllerLevel: 4 }), atGclCapacity, 218))
+      .toEqual({
+        status: 'skipped',
+        colony: 'W1N1',
+        reason: 'gclInsufficient'
+      });
+    expect(aboveGclCapacity.next?.preconditions).toContain('wait for GCL capacity to claim another room');
+    expect(aboveGclCapacity.next?.preconditions).not.toContain(
+      'limit expansion to 3 owned rooms for current controller level'
+    );
+    expect(scoutNeededAtCurrentRoomCount.next).toMatchObject({
+      roomName: 'W7N1',
+      evidenceStatus: 'insufficient-evidence',
+      preconditions: []
+    });
+    expect(refreshNextExpansionTargetSelection(
+      makeSafeColony({ controllerLevel: 4 }),
+      scoutNeededAtCurrentRoomCount,
+      219
+    )).toMatchObject({
+      status: 'skipped',
+      colony: 'W1N1',
+      reason: 'insufficientEvidence'
+    });
+    expect(selectExpansionScoutTargets(scoutNeededAtCurrentRoomCount)).toMatchObject([{ roomName: 'W7N1' }]);
+  });
+
   it('does not persist next expansion claim intents when the RCL room limit is reached', () => {
     const colony = makeSafeColony({ controllerLevel: 3 });
     const report = scoreExpansionCandidates(

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -353,6 +353,8 @@ describe('runtime telemetry summaries', () => {
             ownedRoomCount: 1,
             roomCapacityStatus: 'roomLimitReached',
             roomLimitCapacity: 1,
+            rclRoomLimitCapacity: 1,
+            roomLimitBasis: 'rclPolicy',
             activePipelineStateKey: 'pipeline:none',
             controlCounts: {
               active: { claim: 0, reserve: 0, scout: 0 },
@@ -3208,6 +3210,31 @@ describe('runtime telemetry summaries', () => {
     });
   });
 
+  it('reports when GCL capacity raises the room limit above the internal RCL policy', () => {
+    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL, controllerLevel: 4 });
+    const globals = globalThis as unknown as { Game: Partial<Game> };
+    globals.Game.gcl = { level: 5 } as GlobalControlLevel;
+    globals.Game.rooms = {
+      ...globals.Game.rooms,
+      W2N1: makeOwnedRuntimeSummaryRoom('W2N1', 4),
+      W3N1: makeOwnedRuntimeSummaryRoom('W3N1', 3)
+    };
+
+    emitRuntimeSummary([colony], [], [], { persistOccupationRecommendations: false });
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.territoryExpansionProgress).toMatchObject({
+      colony: 'W1N1',
+      ownedRoomCount: 3,
+      roomCapacityStatus: 'available',
+      roomLimitCapacity: 5,
+      rclRoomLimitCapacity: 3,
+      gclRoomCapacity: 5,
+      roomLimitBasis: 'gclCapacity'
+    });
+  });
+
   it('groups creeps by colony before building per-room summaries', () => {
     const firstColony = makeColony({
       time: RUNTIME_SUMMARY_INTERVAL,
@@ -4372,6 +4399,21 @@ function makeWorker(memory: CreepMemory, energy = 0, name?: string): Creep {
     memory,
     store: makeEnergyStore(energy)
   } as unknown as Creep;
+}
+
+function makeOwnedRuntimeSummaryRoom(roomName: string, controllerLevel: number): Room {
+  return {
+    name: roomName,
+    energyAvailable: 300,
+    energyCapacityAvailable: 300,
+    controller: {
+      my: true,
+      owner: { username: 'me' },
+      level: controllerLevel,
+      ticksToDowngrade: 15_000
+    },
+    find: jest.fn().mockReturnValue([])
+  } as unknown as Room;
 }
 
 function makeWorkerBehaviorSample(


### PR DESCRIPTION
## Summary
- Let GCL capacity raise the autonomous expansion room limit above the internal RCL policy cap when it is safely available.
- Preserve the RCL policy cap in telemetry via `rclRoomLimitCapacity` and `roomLimitBasis` so Gameplay Evolution can distinguish GCL-driven expansion from the conservative fallback.
- Add regression coverage for precondition selection, skip reasons, and runtime-summary expansion-capacity telemetry.

## Issue Reference
Refs #1669

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (104 suites, 2267 tests)
- `cd prod && npm run build`
- Controller-side verification completed at 2026-06-05T05:24:43Z after rebuilding `prod/dist/main.js`.

## Universal task Done gate
- [x] Task type: code / Territory-Economy gameplay behavior.
- [x] Expected observable outcome / named deliverable: autonomous expansion gating uses current GCL room capacity when it exceeds the RCL policy cap, while exposing both the effective and RCL-only limits in runtime telemetry.
- [x] Non-goals / accepted substitutes: no forced claim target, no hostile-room bypass, no owner decision, and no official MMO deploy performed by this PR.
- [x] Verification evidence required before Done: TypeScript typecheck, Jest full suite, bundle build, issue-completion gate, prod-ci, bot-review/thread gates, and post-merge deploy acceptance before #1669 is complete.
- [x] Project Evidence / Next action / Blocked by: #1669 is updated to In review with PR #1688, commit df59e360, controller verification evidence, and CodeRabbit/CI merge-gate follow-up.
- [x] Post-merge/deploy/runtime proof: deploy acceptance proof target is runtime summary `roomLimitBasis="gclCapacity"` plus a 4th-room expansion plan under the standard safety gates; #1669 Project Next action names that acceptance check.
- [x] Named deliverable proof: `prod/test/expansionScoring.test.ts` covers GCL-raised limits and `prod/test/runtimeSummary.test.ts` covers the new telemetry fields.
