### PR TITLE
economy: prioritize near-full construction backlog

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -33124,7 +33124,12 @@ function selectWorkerTaskContext(creep, currentTask) {
     effectiveEnergyCriticalTask != null ? effectiveEnergyCriticalTask : baseSelectedTask
   );
   const selectedTask = (_a2 = spawnReservationRefillTask != null ? spawnReservationRefillTask : effectiveEnergyCriticalTask) != null ? _a2 : baseSelectedTask;
-  return { baseSelectedTask, energyCriticalTask, selectedTask, spawnReservationRefillTask };
+  return {
+    baseSelectedTask,
+    energyCriticalTask: effectiveEnergyCriticalTask,
+    selectedTask,
+    spawnReservationRefillTask
+  };
 }
 function getCriticalCpuTaskRetentionDecision(creep, task) {
   if (!getRuntimeCpuBudget().critical || !task || !canExecuteTask(creep, task)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -27083,6 +27083,15 @@ function selectHeuristicWorkerTask(creep) {
   if (capacityConstructionSite) {
     return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: capacityConstructionSite.id });
   }
+  const nearFullConstructionBacklogTask = selectNearFullConstructionBacklogTaskBeforeCriticalRepair(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    getShouldYieldSpawnReservationToConstructionBacklog
+  );
+  if (nearFullConstructionBacklogTask) {
+    return applyMinimumUsefulLoadPolicy(creep, nearFullConstructionBacklogTask);
+  }
   const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
   if (criticalRepairTarget) {
     return applyMinimumUsefulLoadPolicy(creep, {
@@ -29337,6 +29346,20 @@ function selectReadyFollowUpProductiveEnergySinkTask(creep, capacityConstruction
   );
   return criticalRoadConstructionSite ? { type: "build", targetId: criticalRoadConstructionSite.id } : null;
 }
+function selectNearFullConstructionBacklogTaskBeforeCriticalRepair(creep, constructionSites, constructionReservationContext, getShouldYieldSpawnReservationToConstructionBacklog) {
+  if (!isRoomEnergyFullOrCoveredByCarriedEnergy(creep.room, getUsedEnergy2(creep)) || !getShouldYieldSpawnReservationToConstructionBacklog() || shouldUpgradeForRcl3DefenseUnlock(creep, creep.room.controller)) {
+    return null;
+  }
+  const constructionPriorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  const constructionSite = selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    () => true,
+    { priorityContext: constructionPriorityContext }
+  );
+  return constructionSite ? { type: "build", targetId: constructionSite.id } : null;
+}
 function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(creep, spawnOrExtensionEnergySink, constructionSites, constructionReservationContext, getShouldYieldSpawnReservationToConstructionBacklog) {
   const deferForHealthyBuffer = shouldDeferIdleSpawnExtensionRefillForHealthyBuffer(
     creep,
@@ -29398,6 +29421,14 @@ function hasMinimumProductiveWorkerCoverageForBoundedConstruction(creep) {
 function hasHealthyRoomEnergyBuffer(room) {
   const energyAvailable = getRoomEnergyAvailable10(room);
   return energyAvailable !== null && energyAvailable >= getEffectiveRoomEnergyBufferThreshold(room);
+}
+function isRoomEnergyFullOrCoveredByCarriedEnergy(room, carriedEnergy) {
+  const energyAvailable = getRoomEnergyAvailable10(room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable7(room);
+  if (carriedEnergy <= 0 || energyAvailable === null || energyCapacityAvailable === null || energyCapacityAvailable <= 0) {
+    return false;
+  }
+  return Math.max(0, energyCapacityAvailable - energyAvailable) <= carriedEnergy;
 }
 function hasActiveSpawningSpawn(room) {
   return findSpawnExtensionEnergyStructures(room).some(
@@ -32873,6 +32904,8 @@ function runWorker(creep) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForSpawnReservationRefill(currentTask, spawnReservationRefillTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
+  } else if (shouldPreemptEnergyAcquisitionTaskForNearFullConstruction(creep, currentTask, selectedTask)) {
+    taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptTaskForUrgentRepair(currentTask, selectedTask)) {
@@ -33045,12 +33078,17 @@ function selectWorkerTaskContext(creep, currentTask) {
   var _a2;
   const baseSelectedTask = selectWorkerTaskForRunner(creep);
   const energyCriticalTask = selectWorkerEnergyCriticalTask(creep, currentTask, baseSelectedTask);
+  const effectiveEnergyCriticalTask = shouldYieldStorageCriticalAcquisitionToNearFullConstruction(
+    creep,
+    energyCriticalTask,
+    baseSelectedTask
+  ) ? null : energyCriticalTask;
   const spawnReservationRefillTask = selectSpawnEnergyReservationRefillTask(
     creep,
     currentTask,
-    energyCriticalTask != null ? energyCriticalTask : baseSelectedTask
+    effectiveEnergyCriticalTask != null ? effectiveEnergyCriticalTask : baseSelectedTask
   );
-  const selectedTask = (_a2 = spawnReservationRefillTask != null ? spawnReservationRefillTask : energyCriticalTask) != null ? _a2 : baseSelectedTask;
+  const selectedTask = (_a2 = spawnReservationRefillTask != null ? spawnReservationRefillTask : effectiveEnergyCriticalTask) != null ? _a2 : baseSelectedTask;
   return { baseSelectedTask, energyCriticalTask, selectedTask, spawnReservationRefillTask };
 }
 function getCriticalCpuTaskRetentionDecision(creep, task) {
@@ -33501,6 +33539,10 @@ function getRoomEnergyAvailable12(room) {
   const energyAvailable = room.energyAvailable;
   return typeof energyAvailable === "number" && Number.isFinite(energyAvailable) ? Math.max(0, energyAvailable) : null;
 }
+function getRoomEnergyCapacityAvailable8(room) {
+  const energyCapacityAvailable = room.energyCapacityAvailable;
+  return typeof energyCapacityAvailable === "number" && Number.isFinite(energyCapacityAvailable) ? Math.max(0, energyCapacityAvailable) : null;
+}
 function getCarriedEnergy4(creep) {
   return getStoredEnergy17(creep);
 }
@@ -33750,6 +33792,9 @@ function shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, task, selecte
 }
 function shouldPreemptEnergyAcquisitionTaskForSpawnReservationRefill(task, spawnReservationRefillTask) {
   return isEnergyAcquisitionTask2(task) && (spawnReservationRefillTask == null ? void 0 : spawnReservationRefillTask.type) === "transfer" && !isSameTask2(task, spawnReservationRefillTask);
+}
+function shouldPreemptEnergyAcquisitionTaskForNearFullConstruction(creep, task, selectedTask) {
+  return isEnergyAcquisitionTask2(task) && selectedTask !== null && !isSameTask2(task, selectedTask) && shouldYieldStorageCriticalAcquisitionToNearFullConstruction(creep, task, selectedTask);
 }
 function shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, task, selectedTask) {
   var _a2;
@@ -34031,14 +34076,38 @@ function isCapacityEnablingConstructionSite2(target) {
   if (typeof structureType !== "string") {
     return false;
   }
-  return matchesCapacityConstructionStructureType(structureType, "STRUCTURE_SPAWN", "spawn") || matchesCapacityConstructionStructureType(structureType, "STRUCTURE_EXTENSION", "extension");
+  return matchesConstructionStructureType(structureType, "STRUCTURE_SPAWN", "spawn") || matchesConstructionStructureType(structureType, "STRUCTURE_EXTENSION", "extension");
+}
+function shouldYieldStorageCriticalAcquisitionToNearFullConstruction(creep, acquisitionTask, selectedTask) {
+  var _a2, _b;
+  if (acquisitionTask === null || !isEnergyAcquisitionTask2(acquisitionTask) || (selectedTask == null ? void 0 : selectedTask.type) !== "build" || ((_b = (_a2 = creep.memory) == null ? void 0 : _a2.workerEnergyCriticalPolicy) == null ? void 0 : _b.reason) !== "storage") {
+    return false;
+  }
+  const carriedEnergy = getUsedTransferEnergy(creep);
+  const constructionSite = getTaskTarget(selectedTask);
+  return carriedEnergy > 0 && isRoomEnergyFullOrCoveredByCarriedEnergy2(creep.room, carriedEnergy) && isCriticalConstructionSite(constructionSite) && canSpendWorkerEnergyOnConstructionSite(creep, constructionSite);
+}
+function isCriticalConstructionSite(target) {
+  const structureType = target == null ? void 0 : target.structureType;
+  if (typeof structureType !== "string") {
+    return false;
+  }
+  return matchesConstructionStructureType(structureType, "STRUCTURE_SPAWN", "spawn") || matchesConstructionStructureType(structureType, "STRUCTURE_EXTENSION", "extension") || matchesConstructionStructureType(structureType, "STRUCTURE_TOWER", "tower") || matchesConstructionStructureType(structureType, "STRUCTURE_CONTAINER", "container") || matchesConstructionStructureType(structureType, "STRUCTURE_ROAD", "road");
+}
+function isRoomEnergyFullOrCoveredByCarriedEnergy2(room, carriedEnergy) {
+  const energyAvailable = getRoomEnergyAvailable12(room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable8(room);
+  if (carriedEnergy <= 0 || energyAvailable === null || energyCapacityAvailable === null || energyCapacityAvailable <= 0) {
+    return false;
+  }
+  return Math.max(0, energyCapacityAvailable - energyAvailable) <= carriedEnergy;
 }
 function isSpawnConstructionTaskTarget(target) {
   const structureType = target == null ? void 0 : target.structureType;
   if (typeof structureType !== "string") {
     return false;
   }
-  return matchesCapacityConstructionStructureType(structureType, "STRUCTURE_SPAWN", "spawn");
+  return matchesConstructionStructureType(structureType, "STRUCTURE_SPAWN", "spawn");
 }
 function getFreeTransferEnergyCapacity(target) {
   var _a2;
@@ -34157,7 +34226,7 @@ function matchesTransferSinkStructureType(actual, globalName, fallback) {
   const constants = globalThis;
   return actual === ((_a2 = constants[globalName]) != null ? _a2 : fallback);
 }
-function matchesCapacityConstructionStructureType(actual, globalName, fallback) {
+function matchesConstructionStructureType(actual, globalName, fallback) {
   var _a2;
   const constants = globalThis;
   return actual === ((_a2 = constants[globalName]) != null ? _a2 : fallback);

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -431,7 +431,12 @@ function selectWorkerTaskContext(
     effectiveEnergyCriticalTask ?? baseSelectedTask
   );
   const selectedTask = spawnReservationRefillTask ?? effectiveEnergyCriticalTask ?? baseSelectedTask;
-  return { baseSelectedTask, energyCriticalTask, selectedTask, spawnReservationRefillTask };
+  return {
+    baseSelectedTask,
+    energyCriticalTask: effectiveEnergyCriticalTask,
+    selectedTask,
+    spawnReservationRefillTask
+  };
 }
 
 function getCriticalCpuTaskRetentionDecision(

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -63,7 +63,12 @@ type TransferSinkStructureConstantGlobal =
   | 'STRUCTURE_LINK'
   | 'STRUCTURE_SPAWN'
   | 'STRUCTURE_TOWER';
-type CapacityConstructionStructureConstantGlobal = 'STRUCTURE_SPAWN' | 'STRUCTURE_EXTENSION';
+type ConstructionStructureConstantGlobal =
+  | 'STRUCTURE_SPAWN'
+  | 'STRUCTURE_EXTENSION'
+  | 'STRUCTURE_TOWER'
+  | 'STRUCTURE_CONTAINER'
+  | 'STRUCTURE_ROAD';
 
 const MAX_IMMEDIATE_RESELECT_EXECUTIONS = 1;
 const WORKER_NULL_LOOP_TICK_WINDOW = 10;
@@ -179,6 +184,8 @@ export function runWorker(creep: Creep): void {
   } else if (shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForSpawnReservationRefill(currentTask, spawnReservationRefillTask)) {
+    taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
+  } else if (shouldPreemptEnergyAcquisitionTaskForNearFullConstruction(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
@@ -411,12 +418,19 @@ function selectWorkerTaskContext(
 ): WorkerTaskSelectionContext {
   const baseSelectedTask = selectWorkerTaskForRunner(creep);
   const energyCriticalTask = selectWorkerEnergyCriticalTask(creep, currentTask, baseSelectedTask);
+  const effectiveEnergyCriticalTask = shouldYieldStorageCriticalAcquisitionToNearFullConstruction(
+    creep,
+    energyCriticalTask,
+    baseSelectedTask
+  )
+    ? null
+    : energyCriticalTask;
   const spawnReservationRefillTask = selectSpawnEnergyReservationRefillTask(
     creep,
     currentTask,
-    energyCriticalTask ?? baseSelectedTask
+    effectiveEnergyCriticalTask ?? baseSelectedTask
   );
-  const selectedTask = spawnReservationRefillTask ?? energyCriticalTask ?? baseSelectedTask;
+  const selectedTask = spawnReservationRefillTask ?? effectiveEnergyCriticalTask ?? baseSelectedTask;
   return { baseSelectedTask, energyCriticalTask, selectedTask, spawnReservationRefillTask };
 }
 
@@ -1165,6 +1179,13 @@ function getRoomEnergyAvailable(room: Room): number | null {
     : null;
 }
 
+function getRoomEnergyCapacityAvailable(room: Room): number | null {
+  const energyCapacityAvailable = (room as Room & { energyCapacityAvailable?: unknown }).energyCapacityAvailable;
+  return typeof energyCapacityAvailable === 'number' && Number.isFinite(energyCapacityAvailable)
+    ? Math.max(0, energyCapacityAvailable)
+    : null;
+}
+
 function getCarriedEnergy(creep: Creep): number {
   return getStoredEnergy(creep);
 }
@@ -1539,6 +1560,19 @@ function shouldPreemptEnergyAcquisitionTaskForSpawnReservationRefill(
     isEnergyAcquisitionTask(task) &&
     spawnReservationRefillTask?.type === 'transfer' &&
     !isSameTask(task, spawnReservationRefillTask)
+  );
+}
+
+function shouldPreemptEnergyAcquisitionTaskForNearFullConstruction(
+  creep: Creep,
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  return (
+    isEnergyAcquisitionTask(task) &&
+    selectedTask !== null &&
+    !isSameTask(task, selectedTask) &&
+    shouldYieldStorageCriticalAcquisitionToNearFullConstruction(creep, task, selectedTask)
   );
 }
 
@@ -1989,9 +2023,63 @@ function isCapacityEnablingConstructionSite(target: unknown): target is Construc
   }
 
   return (
-    matchesCapacityConstructionStructureType(structureType, 'STRUCTURE_SPAWN', 'spawn') ||
-    matchesCapacityConstructionStructureType(structureType, 'STRUCTURE_EXTENSION', 'extension')
+    matchesConstructionStructureType(structureType, 'STRUCTURE_SPAWN', 'spawn') ||
+    matchesConstructionStructureType(structureType, 'STRUCTURE_EXTENSION', 'extension')
   );
+}
+
+function shouldYieldStorageCriticalAcquisitionToNearFullConstruction(
+  creep: Creep,
+  acquisitionTask: CreepTaskMemory | null,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  if (
+    acquisitionTask === null ||
+    !isEnergyAcquisitionTask(acquisitionTask) ||
+    selectedTask?.type !== 'build' ||
+    creep.memory?.workerEnergyCriticalPolicy?.reason !== 'storage'
+  ) {
+    return false;
+  }
+
+  const carriedEnergy = getUsedTransferEnergy(creep);
+  const constructionSite = getTaskTarget(selectedTask);
+  return (
+    carriedEnergy > 0 &&
+    isRoomEnergyFullOrCoveredByCarriedEnergy(creep.room, carriedEnergy) &&
+    isCriticalConstructionSite(constructionSite) &&
+    canSpendWorkerEnergyOnConstructionSite(creep, constructionSite)
+  );
+}
+
+function isCriticalConstructionSite(target: unknown): target is ConstructionSite {
+  const structureType = (target as { structureType?: unknown } | null)?.structureType;
+  if (typeof structureType !== 'string') {
+    return false;
+  }
+
+  return (
+    matchesConstructionStructureType(structureType, 'STRUCTURE_SPAWN', 'spawn') ||
+    matchesConstructionStructureType(structureType, 'STRUCTURE_EXTENSION', 'extension') ||
+    matchesConstructionStructureType(structureType, 'STRUCTURE_TOWER', 'tower') ||
+    matchesConstructionStructureType(structureType, 'STRUCTURE_CONTAINER', 'container') ||
+    matchesConstructionStructureType(structureType, 'STRUCTURE_ROAD', 'road')
+  );
+}
+
+function isRoomEnergyFullOrCoveredByCarriedEnergy(room: Room, carriedEnergy: number): boolean {
+  const energyAvailable = getRoomEnergyAvailable(room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(room);
+  if (
+    carriedEnergy <= 0 ||
+    energyAvailable === null ||
+    energyCapacityAvailable === null ||
+    energyCapacityAvailable <= 0
+  ) {
+    return false;
+  }
+
+  return Math.max(0, energyCapacityAvailable - energyAvailable) <= carriedEnergy;
 }
 
 function isSpawnConstructionTaskTarget(target: unknown): target is ConstructionSite {
@@ -2000,7 +2088,7 @@ function isSpawnConstructionTaskTarget(target: unknown): target is ConstructionS
     return false;
   }
 
-  return matchesCapacityConstructionStructureType(structureType, 'STRUCTURE_SPAWN', 'spawn');
+  return matchesConstructionStructureType(structureType, 'STRUCTURE_SPAWN', 'spawn');
 }
 
 function getFreeTransferEnergyCapacity(target: unknown): number {
@@ -2161,12 +2249,12 @@ function matchesTransferSinkStructureType(
   return actual === (constants[globalName] ?? fallback);
 }
 
-function matchesCapacityConstructionStructureType(
+function matchesConstructionStructureType(
   actual: string,
-  globalName: CapacityConstructionStructureConstantGlobal,
+  globalName: ConstructionStructureConstantGlobal,
   fallback: string
 ): boolean {
-  const constants = globalThis as unknown as Partial<Record<CapacityConstructionStructureConstantGlobal, string>>;
+  const constants = globalThis as unknown as Partial<Record<ConstructionStructureConstantGlobal, string>>;
   return actual === (constants[globalName] ?? fallback);
 }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1027,6 +1027,16 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     return applyMinimumUsefulLoadPolicy(creep, { type: 'build', targetId: capacityConstructionSite.id });
   }
 
+  const nearFullConstructionBacklogTask = selectNearFullConstructionBacklogTaskBeforeCriticalRepair(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    getShouldYieldSpawnReservationToConstructionBacklog
+  );
+  if (nearFullConstructionBacklogTask) {
+    return applyMinimumUsefulLoadPolicy(creep, nearFullConstructionBacklogTask);
+  }
+
   const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
   if (criticalRepairTarget) {
     return applyMinimumUsefulLoadPolicy(creep, {
@@ -4566,6 +4576,31 @@ function selectReadyFollowUpProductiveEnergySinkTask(
   return criticalRoadConstructionSite ? { type: 'build', targetId: criticalRoadConstructionSite.id } : null;
 }
 
+function selectNearFullConstructionBacklogTaskBeforeCriticalRepair(
+  creep: Creep,
+  constructionSites: ConstructionSite[],
+  constructionReservationContext: ConstructionReservationContext,
+  getShouldYieldSpawnReservationToConstructionBacklog: () => boolean
+): Extract<CreepTaskMemory, { type: 'build' }> | null {
+  if (
+    !isRoomEnergyFullOrCoveredByCarriedEnergy(creep.room, getUsedEnergy(creep)) ||
+    !getShouldYieldSpawnReservationToConstructionBacklog() ||
+    shouldUpgradeForRcl3DefenseUnlock(creep, creep.room.controller)
+  ) {
+    return null;
+  }
+
+  const constructionPriorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  const constructionSite = selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    () => true,
+    { priorityContext: constructionPriorityContext }
+  );
+  return constructionSite ? { type: 'build', targetId: constructionSite.id } : null;
+}
+
 function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(
   creep: Creep,
   spawnOrExtensionEnergySink: StructureSpawn | StructureExtension | null,
@@ -4673,6 +4708,21 @@ function hasMinimumProductiveWorkerCoverageForBoundedConstruction(creep: Creep):
 function hasHealthyRoomEnergyBuffer(room: Room): boolean {
   const energyAvailable = getRoomEnergyAvailable(room);
   return energyAvailable !== null && energyAvailable >= getEffectiveRoomEnergyBufferThreshold(room);
+}
+
+function isRoomEnergyFullOrCoveredByCarriedEnergy(room: Room, carriedEnergy: number): boolean {
+  const energyAvailable = getRoomEnergyAvailable(room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(room);
+  if (
+    carriedEnergy <= 0 ||
+    energyAvailable === null ||
+    energyCapacityAvailable === null ||
+    energyCapacityAvailable <= 0
+  ) {
+    return false;
+  }
+
+  return Math.max(0, energyCapacityAvailable - energyAvailable) <= carriedEnergy;
 }
 
 function hasActiveSpawningSpawn(room: Room): boolean {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1,8 +1,10 @@
 import { runWorker } from '../src/creeps/workerRunner';
+import * as workerTaskPolicy from '../src/creeps/workerTaskPolicy';
 import {
   WORKER_ENERGY_CRITICAL_SPAWN_EXIT_THRESHOLD,
   WORKER_ENERGY_CRITICAL_STORAGE_EXIT_MARGIN
 } from '../src/creeps/workerTaskPolicy';
+import * as workerTasks from '../src/tasks/workerTasks';
 import {
   CONTROLLER_DOWNGRADE_GUARD_TICKS,
   CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD,
@@ -5794,14 +5796,128 @@ describe('runWorker', () => {
       currentTask: 'withdraw',
       currentTargetId: 'energy-container1',
       baseSelectedTask: 'build',
-      energyCriticalTask: 'withdraw',
-      energyCriticalTargetId: 'energy-container1',
       selectedTask: 'build',
       assignedTask: 'build'
     });
+    expect(creep.memory.workerDispatchDiagnostic?.energyCriticalTask).toBeUndefined();
+    expect(creep.memory.workerDispatchDiagnostic?.energyCriticalTargetId).toBeUndefined();
     expect(build).toHaveBeenCalledWith(site);
     expect(withdraw).not.toHaveBeenCalled();
     expect(repair).not.toHaveBeenCalled();
+  });
+
+  it('keeps an existing near-full build assignment when storage-critical acquisition yields', () => {
+    const site = {
+      id: 'container-site1',
+      my: true,
+      structureType: 'container',
+      progress: 3_900,
+      progressTotal: 4_500,
+      pos: { x: 20, y: 21, roomName: 'E29N55' } as RoomPosition
+    } as ConstructionSite;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 600 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(10_000)
+      }
+    } as unknown as StructureStorage;
+    const acquisitionContainer = {
+      id: 'energy-container1',
+      structureType: 'container',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 1_000 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(1_000)
+      }
+    } as unknown as StructureContainer;
+    const room = {
+      name: 'E29N55',
+      energyAvailable: 2_250,
+      energyCapacityAvailable: 2_300,
+      storage,
+      find: jest.fn((type: number) => {
+        if (type === FIND_STRUCTURES) {
+          return [storage, acquisitionContainer];
+        }
+
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const withdraw = jest.fn();
+    const selectedBuildTask = { type: 'build', targetId: 'container-site1' as Id<ConstructionSite> } as const;
+    const yieldedAcquisitionTask = {
+      type: 'withdraw',
+      targetId: 'energy-container1' as Id<AnyStoreStructure>
+    } as const;
+    const creep = {
+      name: 'NearFullBuilder',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: selectedBuildTask,
+        workerEnergyCriticalPolicy: {
+          type: 'workerEnergyCriticalPolicy',
+          schemaVersion: 1,
+          active: true,
+          reason: 'storage',
+          enteredAt: 1_812_850,
+          updatedAt: 1_812_851,
+          storageEnergy: 600,
+          storageEnterThreshold: 1_000,
+          storageExitThreshold: 1_250
+        }
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 98 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 2 : 0))
+      },
+      room,
+      build,
+      withdraw,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(selectedBuildTask);
+    const selectWorkerEnergyCriticalTask = jest
+      .spyOn(workerTaskPolicy, 'selectWorkerEnergyCriticalTask')
+      .mockReturnValue(yieldedAcquisitionTask);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { NearFullBuilder: creep },
+      rooms: { E29N55: room },
+      time: 1_812_851,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'container-site1') {
+          return site;
+        }
+
+        return id === 'energy-container1' ? acquisitionContainer : null;
+      })
+    };
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual(selectedBuildTask);
+      expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+        currentTask: 'build',
+        currentTargetId: 'container-site1',
+        baseSelectedTask: 'build',
+        selectedTask: 'build',
+        assignedTask: 'build'
+      });
+      expect(creep.memory.workerDispatchDiagnostic?.energyCriticalTask).toBeUndefined();
+      expect(creep.memory.workerDispatchDiagnostic?.energyCriticalTargetId).toBeUndefined();
+      expect(build).toHaveBeenCalledWith(site);
+      expect(withdraw).not.toHaveBeenCalled();
+    } finally {
+      selectWorkerTask.mockRestore();
+      selectWorkerEnergyCriticalTask.mockRestore();
+    }
   });
 
   it('preempts a stale E29N57 spawn reservation transfer when stored energy can cover construction', () => {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -5638,6 +5638,172 @@ describe('runWorker', () => {
     expect(upgradeController).not.toHaveBeenCalled();
   });
 
+  it('preempts a near-full E29N55 storage-critical withdraw for container construction under a spawn reserve signal', () => {
+    const site = {
+      id: 'container-site1',
+      my: true,
+      structureType: 'container',
+      progress: 3_900,
+      progressTotal: 4_500,
+      pos: { x: 20, y: 21, roomName: 'E29N55' } as RoomPosition
+    } as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 300 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      }
+    } as unknown as StructureSpawn;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 600 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(10_000)
+      }
+    } as unknown as StructureStorage;
+    const acquisitionContainer = {
+      id: 'energy-container1',
+      structureType: 'container',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 1_000 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(1_000)
+      }
+    } as unknown as StructureContainer;
+    const damagedContainer = {
+      id: 'damaged-container1',
+      structureType: 'container',
+      hits: 500,
+      hitsMax: 2_000
+    } as StructureContainer;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 6,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 3_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N55',
+      energyAvailable: 2_250,
+      energyCapacityAvailable: 2_300,
+      controller,
+      storage,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn, storage] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [spawn, storage, acquisitionContainer, damagedContainer];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const withdraw = jest.fn();
+    const repair = jest.fn();
+    const creep = {
+      name: 'NearFullBuilder',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'withdraw', targetId: 'energy-container1' as Id<AnyStoreStructure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 98 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 2 : 0))
+      },
+      room,
+      build,
+      withdraw,
+      repair,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const recoveryWorker = {
+      name: 'RecoveryWorker',
+      memory: { role: 'worker', colony: 'E29N55' },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, recoveryWorker);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      economy: {
+        spawnEnergyReservation: {
+          updatedAt: 1_812_850,
+          rooms: {
+            E29N55: {
+              bodyCost: 2_300,
+              creepName: 'worker-E29N55-next',
+              reservedAt: 1_812_850,
+              reservedEnergy: 2_300,
+              role: 'worker',
+              roomName: 'E29N55',
+              updatedAt: 1_812_850
+            }
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { NearFullBuilder: creep, RecoveryWorker: recoveryWorker },
+      rooms: { E29N55: room },
+      time: 1_812_851,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'container-site1') {
+          return site;
+        }
+
+        if (id === 'spawn1') {
+          return spawn;
+        }
+
+        if (id === 'storage1') {
+          return storage;
+        }
+
+        if (id === 'damaged-container1') {
+          return damagedContainer;
+        }
+
+        return id === 'energy-container1' ? acquisitionContainer : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'container-site1' });
+    expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+      currentTask: 'withdraw',
+      currentTargetId: 'energy-container1',
+      baseSelectedTask: 'build',
+      energyCriticalTask: 'withdraw',
+      energyCriticalTargetId: 'energy-container1',
+      selectedTask: 'build',
+      assignedTask: 'build'
+    });
+    expect(build).toHaveBeenCalledWith(site);
+    expect(withdraw).not.toHaveBeenCalled();
+    expect(repair).not.toHaveBeenCalled();
+  });
+
   it('preempts a stale E29N57 spawn reservation transfer when stored energy can cover construction', () => {
     const site = {
       id: 'road-site1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -13124,6 +13124,71 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(builder)).toEqual({ type: 'build', targetId: 'wall-site1' });
   });
 
+  it('keeps near-full E29N55 construction ahead of critical container repair under a spawn reserve signal', () => {
+    const site = {
+      id: 'container-site1',
+      my: true,
+      structureType: 'container',
+      progress: 3_900,
+      progressTotal: 4_500
+    } as ConstructionSite;
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0);
+    const damagedContainer = makeStructure('damaged-container', 'container' as StructureConstant, 500, 2_000);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 6,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 3_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N55',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 2_250,
+      energyCapacityAvailable: 2_300,
+      myStructures: [fullSpawn as AnyOwnedStructure],
+      structures: [damagedContainer]
+    });
+    const builder = {
+      name: 'NearFullBuilder',
+      memory: { role: 'worker', colony: 'E29N55' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(98),
+        getFreeCapacity: jest.fn().mockReturnValue(2)
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({
+      NearFullBuilder: builder,
+      RecoveryWorker: {
+        name: 'RecoveryWorker',
+        memory: { role: 'worker', colony: 'E29N55' },
+        store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+        room
+      } as unknown as Creep
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      economy: {
+        spawnEnergyReservation: {
+          updatedAt: 1_812_850,
+          rooms: {
+            E29N55: {
+              bodyCost: 2_300,
+              creepName: 'worker-E29N55-next',
+              reservedAt: 1_812_850,
+              reservedEnergy: 2_300,
+              role: 'worker',
+              roomName: 'E29N55',
+              updatedAt: 1_812_850
+            }
+          }
+        }
+      }
+    };
+
+    expect(selectWorkerTask(builder)).toEqual({ type: 'build', targetId: 'container-site1' });
+  });
+
   it('reserves a loaded worker for construction when healthy energy and idle workers leave build coverage empty', () => {
     const site = { id: 'wall-site1', structureType: 'constructedWall' } as ConstructionSite;
     const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 317, {


### PR DESCRIPTION
## Summary

- Recovered the postdeploy #1678 follow-up worktree and rebased it onto current `origin/main` (`e5091384`).
- Lets near-full rooms spend carried worker energy on critical construction backlog instead of continuing storage-critical/spawn-reserve energy acquisition when room energy is already full or covered by carried energy.
- Extends construction priority coverage and tests for the E29N55 build-starvation acceptance case.

Refs #1678.

## Verification

- `git diff --check` PASS
- `git diff --check HEAD^ HEAD` PASS
- `npm run typecheck` PASS
- `npm test -- --runInBand` PASS (105 suites, 2,279 tests)
- `npm run build` PASS; `prod/dist/main.js` regenerated

## Universal task Done gate

- [x] Task type: production code bugfix with tests and regenerated Screeps bundle.
- [x] Expected observable outcome / named deliverable: commit `b88812fb` prioritizes near-full critical construction backlog for #1678.
- [x] Non-goals / accepted substitutes: no learned-policy rollout, no official MMO write from this PR, no Seasonal behavior change.
- [x] Verification evidence required before Done: controller and Codex verification commands listed above passed on the PR branch.
- [x] Project Evidence / Next action / Blocked by: Project #1678 records active PR gate evidence and the runtime acceptance target; controller keeps #1678 open for runtime proof.
- [x] Post-merge/deploy/runtime proof: named runtime proof is a later postdeploy runtime-summary capture showing E29N55 `taskCounts.build > 0` or construction backlog movement under #1678.
- [x] Named deliverable proof: `prod/src/creeps/workerRunner.ts`, `prod/src/tasks/workerTasks.ts`, focused Jest tests, and `prod/dist/main.js` are included in the Codex-authored commit.
