### PR TITLE
economy: preempt safe tower refills for construction backlog

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -26718,16 +26718,6 @@ function selectCriticalCpuWorkerTask(creep) {
   if (storedProtectedConstructionTask) {
     return applyMinimumUsefulLoadPolicy(creep, storedProtectedConstructionTask);
   }
-  const constructionSites = findConstructionSites(creep.room);
-  const constructionReservationContext = constructionSites.length > 0 ? createConstructionReservationContext(creep.room) : createEmptyConstructionReservationContext();
-  const boundedConstructionBacklogTask = selectBoundedConstructionBacklogTaskBeforeNonCriticalRefill(
-    creep,
-    constructionSites,
-    constructionReservationContext
-  );
-  if (boundedConstructionBacklogTask) {
-    return applyMinimumUsefulLoadPolicy(creep, boundedConstructionBacklogTask);
-  }
   if (spawnOrExtensionEnergySink) {
     return {
       type: "transfer",
@@ -26735,6 +26725,17 @@ function selectCriticalCpuWorkerTask(creep) {
     };
   }
   const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
+  const constructionSites = findConstructionSites(creep.room);
+  const constructionReservationContext = constructionSites.length > 0 ? createConstructionReservationContext(creep.room) : createEmptyConstructionReservationContext();
+  const boundedConstructionBacklogTask = priorityTowerEnergySink ? selectBoundedConstructionBacklogTaskBeforeNonCriticalRefill(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    priorityTowerEnergySink
+  ) : null;
+  if (boundedConstructionBacklogTask) {
+    return applyMinimumUsefulLoadPolicy(creep, boundedConstructionBacklogTask);
+  }
   if (priorityTowerEnergySink) {
     return applyMinimumUsefulLoadPolicy(creep, {
       type: "transfer",
@@ -29539,11 +29540,11 @@ function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(creep, spawnOr
   const repairTarget = selectRepairTarget(creep);
   return repairTarget ? { type: "repair", targetId: repairTarget.id } : null;
 }
-function selectBoundedConstructionBacklogTaskBeforeNonCriticalRefill(creep, constructionSites, constructionReservationContext, deferredRefillSink = null) {
+function selectBoundedConstructionBacklogTaskBeforeNonCriticalRefill(creep, constructionSites, constructionReservationContext, deferredRefillSink) {
   if (hasVisibleHostilePresence3(creep.room)) {
     return null;
   }
-  if (deferredRefillSink !== null && !isNonCriticalRefillSinkForConstructionBacklog(creep, deferredRefillSink)) {
+  if (!isNonCriticalRefillSinkForConstructionBacklog(creep, deferredRefillSink)) {
     return null;
   }
   if (!shouldYieldSpawnReservationToConstructionBacklog(creep, constructionSites, constructionReservationContext)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -26718,6 +26718,16 @@ function selectCriticalCpuWorkerTask(creep) {
   if (storedProtectedConstructionTask) {
     return applyMinimumUsefulLoadPolicy(creep, storedProtectedConstructionTask);
   }
+  const constructionSites = findConstructionSites(creep.room);
+  const constructionReservationContext = constructionSites.length > 0 ? createConstructionReservationContext(creep.room) : createEmptyConstructionReservationContext();
+  const boundedConstructionBacklogTask = selectBoundedConstructionBacklogTaskBeforeNonCriticalRefill(
+    creep,
+    constructionSites,
+    constructionReservationContext
+  );
+  if (boundedConstructionBacklogTask) {
+    return applyMinimumUsefulLoadPolicy(creep, boundedConstructionBacklogTask);
+  }
   if (spawnOrExtensionEnergySink) {
     return {
       type: "transfer",
@@ -27048,6 +27058,7 @@ function selectHeuristicWorkerTask(creep) {
     return cachedShouldYieldSpawnReservationToConstructionBacklog;
   };
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
+  const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
   const ownedSpawnCount = getOwnedSpawnCount(creep.room);
   const hasMissingSpawnRecoveryConstructionSite = ownedSpawnCount === 0 && constructionSites.some(isSpawnConstructionSite);
   const canPrioritizeEmergencyWorkBeforeBootstrapSpawnRecovery = !hasMissingSpawnRecoveryConstructionSite && (!bootstrapNonCriticalWorkSuppressed || (ownedSpawnCount != null ? ownedSpawnCount : 0) > 0);
@@ -27105,6 +27116,15 @@ function selectHeuristicWorkerTask(creep) {
     );
     if (productiveTaskBeforeIdleRefill) {
       return applyMinimumUsefulLoadPolicy(creep, productiveTaskBeforeIdleRefill);
+    }
+    const boundedConstructionTaskBeforeTowerRefill = priorityTowerEnergySink ? selectBoundedConstructionBacklogTaskBeforeNonCriticalRefill(
+      creep,
+      constructionSites,
+      constructionReservationContext,
+      priorityTowerEnergySink
+    ) : null;
+    if (boundedConstructionTaskBeforeTowerRefill) {
+      return applyMinimumUsefulLoadPolicy(creep, boundedConstructionTaskBeforeTowerRefill);
     }
   }
   if (spawnOrExtensionEnergySink && canPrioritizeEmergencyWorkBeforeBootstrapSpawnRecovery) {
@@ -27178,7 +27198,6 @@ function selectHeuristicWorkerTask(creep) {
       return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: capacityConstructionSite.id });
     }
   }
-  const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
   if (priorityTowerEnergySink) {
     return applyMinimumUsefulLoadPolicy(creep, {
       type: "transfer",
@@ -29519,6 +29538,29 @@ function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(creep, spawnOr
   }
   const repairTarget = selectRepairTarget(creep);
   return repairTarget ? { type: "repair", targetId: repairTarget.id } : null;
+}
+function selectBoundedConstructionBacklogTaskBeforeNonCriticalRefill(creep, constructionSites, constructionReservationContext, deferredRefillSink = null) {
+  if (hasVisibleHostilePresence3(creep.room)) {
+    return null;
+  }
+  if (deferredRefillSink !== null && !isNonCriticalRefillSinkForConstructionBacklog(creep, deferredRefillSink)) {
+    return null;
+  }
+  if (!shouldYieldSpawnReservationToConstructionBacklog(creep, constructionSites, constructionReservationContext)) {
+    return null;
+  }
+  const priorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  const constructionSite = selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    (site) => site.my !== false && canSpendCreepEnergyOnConstructionSite(creep, site, priorityContext),
+    { priorityContext }
+  );
+  return constructionSite ? { type: "build", targetId: constructionSite.id } : null;
+}
+function isNonCriticalRefillSinkForConstructionBacklog(creep, sink) {
+  return isTowerEnergySink(sink) && !hasVisibleHostilePresence3(creep.room);
 }
 function shouldDeferIdleSpawnExtensionRefillForHealthyBuffer(creep, spawnOrExtensionEnergySink) {
   return spawnOrExtensionEnergySink !== null && !hasActiveSpawningSpawn(creep.room) && hasHealthyRoomEnergyBuffer(creep.room);
@@ -34068,7 +34110,7 @@ function shouldPreemptTransferTaskForConstructionBacklog(creep, task, selectedTa
     return false;
   }
   const currentTarget = getTaskTarget(task);
-  if (!isNonCriticalSpawnExtensionTransferTarget(currentTarget)) {
+  if (!isNonCriticalSpawnExtensionTransferTarget(currentTarget) && !isNonCriticalTowerRefillTransferTarget(creep, currentTarget)) {
     return false;
   }
   if (!shouldDeferSpawnReservationRefillForProductiveWork(creep, selectedTask)) {
@@ -34082,6 +34124,9 @@ function hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep) {
 }
 function isNonCriticalSpawnExtensionTransferTarget(target) {
   return getTransferSinkPriority(target) === 2;
+}
+function isNonCriticalTowerRefillTransferTarget(creep, target) {
+  return getTransferSinkPriority(target) === 1 && !isRoomThreatened(creep);
 }
 function shouldPreemptSpendingTaskForControllerPressure(creep, task, selectedTask) {
   var _a2;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -1810,7 +1810,10 @@ function shouldPreemptTransferTaskForConstructionBacklog(
   }
 
   const currentTarget = getTaskTarget(task);
-  if (!isNonCriticalSpawnExtensionTransferTarget(currentTarget)) {
+  if (
+    !isNonCriticalSpawnExtensionTransferTarget(currentTarget) &&
+    !isNonCriticalTowerRefillTransferTarget(creep, currentTarget)
+  ) {
     return false;
   }
 
@@ -1831,6 +1834,10 @@ function hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep: Creep
 
 function isNonCriticalSpawnExtensionTransferTarget(target: unknown): boolean {
   return getTransferSinkPriority(target) === 2;
+}
+
+function isNonCriticalTowerRefillTransferTarget(creep: Creep, target: unknown): boolean {
+  return getTransferSinkPriority(target) === 1 && !isRoomThreatened(creep);
 }
 
 function shouldPreemptSpendingTaskForControllerPressure(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -399,6 +399,20 @@ function selectCriticalCpuWorkerTask(creep: Creep): CreepTaskMemory | null {
     return applyMinimumUsefulLoadPolicy(creep, storedProtectedConstructionTask);
   }
 
+  const constructionSites = findConstructionSites(creep.room);
+  const constructionReservationContext =
+    constructionSites.length > 0
+      ? createConstructionReservationContext(creep.room)
+      : createEmptyConstructionReservationContext();
+  const boundedConstructionBacklogTask = selectBoundedConstructionBacklogTaskBeforeNonCriticalRefill(
+    creep,
+    constructionSites,
+    constructionReservationContext
+  );
+  if (boundedConstructionBacklogTask) {
+    return applyMinimumUsefulLoadPolicy(creep, boundedConstructionBacklogTask);
+  }
+
   if (spawnOrExtensionEnergySink) {
     return {
       type: 'transfer',
@@ -831,6 +845,7 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     return cachedShouldYieldSpawnReservationToConstructionBacklog;
   };
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
+  const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
   const ownedSpawnCount = getOwnedSpawnCount(creep.room);
   const hasMissingSpawnRecoveryConstructionSite =
     ownedSpawnCount === 0 && constructionSites.some(isSpawnConstructionSite);
@@ -900,6 +915,18 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     );
     if (productiveTaskBeforeIdleRefill) {
       return applyMinimumUsefulLoadPolicy(creep, productiveTaskBeforeIdleRefill);
+    }
+
+    const boundedConstructionTaskBeforeTowerRefill = priorityTowerEnergySink
+      ? selectBoundedConstructionBacklogTaskBeforeNonCriticalRefill(
+        creep,
+        constructionSites,
+        constructionReservationContext,
+        priorityTowerEnergySink
+      )
+      : null;
+    if (boundedConstructionTaskBeforeTowerRefill) {
+      return applyMinimumUsefulLoadPolicy(creep, boundedConstructionTaskBeforeTowerRefill);
     }
   }
 
@@ -986,7 +1013,6 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     }
   }
 
-  const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
   if (priorityTowerEnergySink) {
     return applyMinimumUsefulLoadPolicy(creep, {
       type: 'transfer',
@@ -4641,6 +4667,39 @@ function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(
 
   const repairTarget = selectRepairTarget(creep);
   return repairTarget ? { type: 'repair', targetId: repairTarget.id as Id<Structure> } : null;
+}
+
+function selectBoundedConstructionBacklogTaskBeforeNonCriticalRefill(
+  creep: Creep,
+  constructionSites: ConstructionSite[],
+  constructionReservationContext: ConstructionReservationContext,
+  deferredRefillSink: FillableEnergySink | null = null
+): Extract<CreepTaskMemory, { type: 'build' }> | null {
+  if (hasVisibleHostilePresence(creep.room)) {
+    return null;
+  }
+
+  if (deferredRefillSink !== null && !isNonCriticalRefillSinkForConstructionBacklog(creep, deferredRefillSink)) {
+    return null;
+  }
+
+  if (!shouldYieldSpawnReservationToConstructionBacklog(creep, constructionSites, constructionReservationContext)) {
+    return null;
+  }
+
+  const priorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  const constructionSite = selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    (site) => site.my !== false && canSpendCreepEnergyOnConstructionSite(creep, site, priorityContext),
+    { priorityContext }
+  );
+  return constructionSite ? { type: 'build', targetId: constructionSite.id } : null;
+}
+
+function isNonCriticalRefillSinkForConstructionBacklog(creep: Creep, sink: FillableEnergySink): boolean {
+  return isTowerEnergySink(sink) && !hasVisibleHostilePresence(creep.room);
 }
 
 function shouldDeferIdleSpawnExtensionRefillForHealthyBuffer(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -399,20 +399,6 @@ function selectCriticalCpuWorkerTask(creep: Creep): CreepTaskMemory | null {
     return applyMinimumUsefulLoadPolicy(creep, storedProtectedConstructionTask);
   }
 
-  const constructionSites = findConstructionSites(creep.room);
-  const constructionReservationContext =
-    constructionSites.length > 0
-      ? createConstructionReservationContext(creep.room)
-      : createEmptyConstructionReservationContext();
-  const boundedConstructionBacklogTask = selectBoundedConstructionBacklogTaskBeforeNonCriticalRefill(
-    creep,
-    constructionSites,
-    constructionReservationContext
-  );
-  if (boundedConstructionBacklogTask) {
-    return applyMinimumUsefulLoadPolicy(creep, boundedConstructionBacklogTask);
-  }
-
   if (spawnOrExtensionEnergySink) {
     return {
       type: 'transfer',
@@ -421,6 +407,23 @@ function selectCriticalCpuWorkerTask(creep: Creep): CreepTaskMemory | null {
   }
 
   const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
+  const constructionSites = findConstructionSites(creep.room);
+  const constructionReservationContext =
+    constructionSites.length > 0
+      ? createConstructionReservationContext(creep.room)
+      : createEmptyConstructionReservationContext();
+  const boundedConstructionBacklogTask = priorityTowerEnergySink
+    ? selectBoundedConstructionBacklogTaskBeforeNonCriticalRefill(
+      creep,
+      constructionSites,
+      constructionReservationContext,
+      priorityTowerEnergySink
+    )
+    : null;
+  if (boundedConstructionBacklogTask) {
+    return applyMinimumUsefulLoadPolicy(creep, boundedConstructionBacklogTask);
+  }
+
   if (priorityTowerEnergySink) {
     return applyMinimumUsefulLoadPolicy(creep, {
       type: 'transfer',
@@ -4673,13 +4676,13 @@ function selectBoundedConstructionBacklogTaskBeforeNonCriticalRefill(
   creep: Creep,
   constructionSites: ConstructionSite[],
   constructionReservationContext: ConstructionReservationContext,
-  deferredRefillSink: FillableEnergySink | null = null
+  deferredRefillSink: FillableEnergySink
 ): Extract<CreepTaskMemory, { type: 'build' }> | null {
   if (hasVisibleHostilePresence(creep.room)) {
     return null;
   }
 
-  if (deferredRefillSink !== null && !isNonCriticalRefillSinkForConstructionBacklog(creep, deferredRefillSink)) {
+  if (!isNonCriticalRefillSinkForConstructionBacklog(creep, deferredRefillSink)) {
     return null;
   }
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -6058,6 +6058,241 @@ describe('runWorker', () => {
     expect(transfer).not.toHaveBeenCalled();
   });
 
+  it('preempts an E29N55 tower refill transfer for construction backlog while CPU shedding', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 935,
+      progressTotal: 5_000,
+      pos: { x: 22, y: 21, roomName: 'E29N55' } as RoomPosition
+    } as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 300 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      }
+    } as unknown as StructureSpawn;
+    const tower = {
+      id: 'tower1',
+      structureType: 'tower',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 250 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 750 : 0))
+      }
+    } as unknown as StructureTower;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 6,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N55',
+      energyAvailable: 2_300,
+      energyCapacityAvailable: 2_300,
+      controller,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn, tower] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [spawn, tower];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          if (type === FIND_HOSTILE_CREEPS) {
+            return [];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const transfer = jest.fn();
+    const creep = {
+      name: 'LoadedBuilder',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'transfer', targetId: 'tower1' as Id<AnyStoreStructure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      },
+      room,
+      build,
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const recoveryWorker = {
+      name: 'RecoveryWorker',
+      memory: { role: 'worker', colony: 'E29N55' },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, recoveryWorker);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { LoadedBuilder: creep, RecoveryWorker: recoveryWorker },
+      rooms: { E29N55: room },
+      time: 1_815_736,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(101),
+        limit: 70,
+        bucket: 1_844,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        if (id === 'tower1') {
+          return tower;
+        }
+
+        return id === 'spawn1' ? spawn : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'road-site1' });
+    expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+      currentTask: 'transfer',
+      baseSelectedTask: 'build',
+      selectedTask: 'build',
+      assignedTask: 'build'
+    });
+    expect(build).toHaveBeenCalledWith(site);
+    expect(transfer).not.toHaveBeenCalled();
+  });
+
+  it('keeps tower refill ahead of construction backlog while hostiles are visible', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 935,
+      progressTotal: 5_000
+    } as ConstructionSite;
+    const tower = {
+      id: 'tower1',
+      structureType: 'tower',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 250 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 750 : 0))
+      }
+    } as unknown as StructureTower;
+    const hostile = { id: 'hostile1' } as Creep;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 6,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N55',
+      energyAvailable: 2_300,
+      energyCapacityAvailable: 2_300,
+      controller,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES) {
+            const structures = [tower] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          if (type === FIND_HOSTILE_CREEPS) {
+            return [hostile];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn();
+    const transfer = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'LoadedWorker',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'transfer', targetId: 'tower1' as Id<AnyStoreStructure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      },
+      room,
+      build,
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const recoveryWorker = {
+      name: 'RecoveryWorker',
+      memory: { role: 'worker', colony: 'E29N55' },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, recoveryWorker);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { LoadedWorker: creep, RecoveryWorker: recoveryWorker },
+      rooms: { E29N55: room },
+      time: 1_815_737,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(101),
+        limit: 70,
+        bucket: 1_844,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        return id === 'tower1' ? tower : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'tower1' });
+    expect(transfer).toHaveBeenCalledWith(tower, RESOURCE_ENERGY);
+    expect(build).not.toHaveBeenCalled();
+  });
+
   it('keeps E29N57 source-container construction ahead of spawn reservation refill during low-bucket shedding', () => {
     const source = {
       id: 'source1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -12413,6 +12413,54 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
   });
 
+  it('keeps critical CPU infrastructure repair ahead of construction when no safe refill is deferred', () => {
+    const site = {
+      id: 'wall-site1',
+      my: true,
+      structureType: 'constructedWall',
+      progress: 0,
+      progressTotal: 5_000
+    } as ConstructionSite;
+    const criticalContainer = makeStructure(
+      'container-critical',
+      'container' as StructureConstant,
+      500,
+      2_000
+    );
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [site],
+      controller,
+      energyAvailable: 800,
+      energyCapacityAvailable: 800,
+      structures: [criticalContainer]
+    });
+    const creep = {
+      name: 'CriticalCpuWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room
+    } as unknown as Creep;
+    const reserveWorker = {
+      name: 'ReserveWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ CriticalCpuWorker: creep, ReserveWorker: reserveWorker });
+    setCpuBucket(43);
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'container-critical' });
+  });
+
   it('uses the survival buffer multiplier before selecting construction spending', () => {
     const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0);
     const site = { id: 'road-site1', structureType: 'road' } as ConstructionSite;


### PR DESCRIPTION
## Summary
- preempt non-critical tower refill transfer tasks for construction backlog when the room is not threatened
- add bounded construction-backlog selection before safe tower refill under CPU shedding
- add regression tests for safe tower preemption and hostile-visible tower protection

Refs #1678

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`

## Universal task Done gate
- [x] Task type: code bugfix for Screeps worker task selection under #1678.
- [x] Expected observable outcome / named deliverable: PR #1692 provides the worker-task code path and regression tests that let safe tower refill yield to visible construction backlog when the room is not threatened.
- [x] Non-goals / accepted substitutes: No direct official MMO write, no issue auto-closure, and no learned-policy/live RL rollout in this code slice.
- [x] Verification evidence required before Done: controller verified `git diff --check`, `npm run typecheck`, Jest 105 suites / 2287 tests, and `npm run build` on head `b1cd9e8334dce5ecdf032ff219c2b987bdcb2e49`.
- [x] Project Evidence / Next action / Blocked by: #1678 and PR #1692 Project items are `In review`; Evidence names commit `b1cd9e83`; Next action names PR gate, official deploy, and runtime observation.
- [x] Post-merge/deploy/runtime proof: #1678 owns deploy observation evidence; success criterion is runtime summary with positive `taskCounts.build` or `buildCarriedEnergy` while construction backlog exists.
- [x] Named deliverable proof: commit `b1cd9e83` changes `prod/src/creeps/workerRunner.ts`, `prod/src/tasks/workerTasks.ts`, `prod/test/workerRunner.test.ts`, and synced `prod/dist/main.js`.

## Safety
- No secrets printed or changed.
- No official MMO writes are performed by this PR itself; deployment remains gated by the official workflow and postdeploy observation.
