### PR TITLE
fix: recover idle territory claimers

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -49536,14 +49536,83 @@ function isRecord40(value) {
 }
 
 // src/creeps/claimerRunner.ts
+var ERR_NOT_IN_RANGE_CODE14 = -9;
 function runClaimer(creep, telemetryEvents = []) {
   if (runExpansionExecutorClaimer(creep, telemetryEvents)) {
+    recoverIdleNoTerritoryClaimer(creep);
     return;
   }
   if (runReservationExecutor(creep)) {
+    recoverIdleNoTerritoryClaimer(creep);
     return;
   }
   runTerritoryControllerCreep(creep, telemetryEvents);
+  recoverIdleNoTerritoryClaimer(creep);
+}
+function recoverIdleNoTerritoryClaimer(creep) {
+  if (creep.memory.role !== "claimer" || hasValidTerritoryAssignment(creep.memory.territory)) {
+    return;
+  }
+  if (creep.memory.territory !== void 0) {
+    delete creep.memory.territory;
+  }
+  if (runReservationExecutor(creep) && hasValidTerritoryAssignment(creep.memory.territory)) {
+    return;
+  }
+  recycleIdleClaimer(creep);
+}
+function recycleIdleClaimer(creep) {
+  const spawn = selectRecycleSpawn2(creep.memory.colony);
+  clearMoveMemory(creep);
+  if (spawn) {
+    if (typeof spawn.recycleCreep === "function") {
+      const result = spawn.recycleCreep(creep);
+      if (result === ERR_NOT_IN_RANGE_CODE14 && typeof creep.moveTo === "function") {
+        creep.moveTo(spawn);
+      }
+      return;
+    }
+    if (typeof creep.moveTo === "function") {
+      creep.moveTo(spawn);
+    }
+    return;
+  }
+  moveTowardHomeRoom2(creep);
+}
+function selectRecycleSpawn2(colony) {
+  var _a2, _b;
+  if (!isNonEmptyString43(colony)) {
+    return null;
+  }
+  const spawns = (_a2 = globalThis.Game) == null ? void 0 : _a2.spawns;
+  if (!spawns) {
+    return null;
+  }
+  return (_b = Object.values(spawns).find((spawn) => {
+    var _a3;
+    return spawn.my !== false && ((_a3 = spawn.room) == null ? void 0 : _a3.name) === colony;
+  })) != null ? _b : null;
+}
+function moveTowardHomeRoom2(creep) {
+  var _a2;
+  const homeRoom = creep.memory.colony;
+  if (!isNonEmptyString43(homeRoom) || ((_a2 = creep.room) == null ? void 0 : _a2.name) === homeRoom || typeof creep.moveTo !== "function") {
+    return;
+  }
+  const RoomPositionCtor = globalThis.RoomPosition;
+  if (typeof RoomPositionCtor !== "function") {
+    return;
+  }
+  creep.moveTo(new RoomPositionCtor(25, 25, homeRoom));
+}
+function clearMoveMemory(creep) {
+  delete creep.memory._move;
+}
+function hasValidTerritoryAssignment(assignment) {
+  return isNonEmptyString43(assignment == null ? void 0 : assignment.targetRoom) && (assignment.action === "claim" || assignment.action === "reserve" || assignment.action === "scout");
+}
+function isNonEmptyString43(value) {
+  return typeof value === "string" && value.length > 0;
 }
 
 // src/territory/reserveExecutor.ts
@@ -50290,11 +50359,11 @@ function ensureLocalWorkerColonyMemory(colonies, creeps) {
   }
   const colonyNames = new Set(colonies.map((colony) => colony.room.name));
   for (const creep of creeps) {
-    if (creep.memory.role !== "worker" || isNonEmptyString43(creep.memory.colony)) {
+    if (creep.memory.role !== "worker" || isNonEmptyString44(creep.memory.colony)) {
       continue;
     }
     const roomName = (_a2 = creep.room) == null ? void 0 : _a2.name;
-    if (isNonEmptyString43(roomName) && colonyNames.has(roomName) && isRoomLocalWorkerName2(creep, roomName)) {
+    if (isNonEmptyString44(roomName) && colonyNames.has(roomName) && isRoomLocalWorkerName2(creep, roomName)) {
       creep.memory.colony = roomName;
     }
   }
@@ -50302,7 +50371,7 @@ function ensureLocalWorkerColonyMemory(colonies, creeps) {
 function isRoomLocalWorkerName2(creep, roomName) {
   return typeof creep.name === "string" && creep.name.startsWith(`worker-${roomName}-`);
 }
-function isNonEmptyString43(value) {
+function isNonEmptyString44(value) {
   return typeof value === "string" && value.length > 0;
 }
 function orderCreepsForEconomyTaskPriority(creeps) {
@@ -51772,7 +51841,7 @@ function normalizeHistoricalReplay(rawReplay) {
   if (!isRecord42(rawReplay)) {
     return null;
   }
-  if (!isNonEmptyString44(rawReplay.replayId) || !isNonEmptyString44(rawReplay.room) || !isFiniteNumber15(rawReplay.startTick) || !isFiniteNumber15(rawReplay.endTick) || !isFiniteNumber15(rawReplay.finalScore) || !isRecord42(rawReplay.kpiHistory)) {
+  if (!isNonEmptyString45(rawReplay.replayId) || !isNonEmptyString45(rawReplay.room) || !isFiniteNumber15(rawReplay.startTick) || !isFiniteNumber15(rawReplay.endTick) || !isFiniteNumber15(rawReplay.finalScore) || !isRecord42(rawReplay.kpiHistory)) {
     return null;
   }
   const kpiHistory = Object.entries(rawReplay.kpiHistory).reduce(
@@ -51800,7 +51869,7 @@ function formatCorrelation(correlation) {
 function isRecord42(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString44(value) {
+function isNonEmptyString45(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber15(value) {

--- a/prod/src/creeps/claimerRunner.ts
+++ b/prod/src/creeps/claimerRunner.ts
@@ -3,14 +3,100 @@ import { runExpansionExecutorClaimer } from '../territory/expansionExecutor';
 import { runReservationExecutor } from '../territory/reservationExecutor';
 import type { RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
 
+const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
+
+type RoomPositionConstructor = new (x: number, y: number, roomName: string) => RoomPosition;
+
 export function runClaimer(creep: Creep, telemetryEvents: RuntimeTelemetryEvent[] = []): void {
   if (runExpansionExecutorClaimer(creep, telemetryEvents)) {
+    recoverIdleNoTerritoryClaimer(creep);
     return;
   }
 
   if (runReservationExecutor(creep)) {
+    recoverIdleNoTerritoryClaimer(creep);
     return;
   }
 
   runTerritoryControllerCreep(creep, telemetryEvents);
+  recoverIdleNoTerritoryClaimer(creep);
+}
+
+function recoverIdleNoTerritoryClaimer(creep: Creep): void {
+  if (creep.memory.role !== 'claimer' || hasValidTerritoryAssignment(creep.memory.territory)) {
+    return;
+  }
+
+  if (creep.memory.territory !== undefined) {
+    delete creep.memory.territory;
+  }
+
+  if (runReservationExecutor(creep) && hasValidTerritoryAssignment(creep.memory.territory)) {
+    return;
+  }
+
+  recycleIdleClaimer(creep);
+}
+
+function recycleIdleClaimer(creep: Creep): void {
+  const spawn = selectRecycleSpawn(creep.memory.colony);
+  clearMoveMemory(creep);
+  if (spawn) {
+    if (typeof spawn.recycleCreep === 'function') {
+      const result = spawn.recycleCreep(creep);
+      if (result === ERR_NOT_IN_RANGE_CODE && typeof creep.moveTo === 'function') {
+        creep.moveTo(spawn);
+      }
+      return;
+    }
+
+    if (typeof creep.moveTo === 'function') {
+      creep.moveTo(spawn);
+    }
+    return;
+  }
+
+  moveTowardHomeRoom(creep);
+}
+
+function selectRecycleSpawn(colony: string | undefined): StructureSpawn | null {
+  if (!isNonEmptyString(colony)) {
+    return null;
+  }
+
+  const spawns = (globalThis as { Game?: Partial<Pick<Game, 'spawns'>> }).Game?.spawns;
+  if (!spawns) {
+    return null;
+  }
+
+  return Object.values(spawns).find((spawn) => spawn.my !== false && spawn.room?.name === colony) ?? null;
+}
+
+function moveTowardHomeRoom(creep: Creep): void {
+  const homeRoom = creep.memory.colony;
+  if (!isNonEmptyString(homeRoom) || creep.room?.name === homeRoom || typeof creep.moveTo !== 'function') {
+    return;
+  }
+
+  const RoomPositionCtor = (globalThis as { RoomPosition?: RoomPositionConstructor }).RoomPosition;
+  if (typeof RoomPositionCtor !== 'function') {
+    return;
+  }
+
+  creep.moveTo(new RoomPositionCtor(25, 25, homeRoom));
+}
+
+function clearMoveMemory(creep: Creep): void {
+  delete (creep.memory as CreepMemory & { _move?: unknown })._move;
+}
+
+function hasValidTerritoryAssignment(assignment: CreepTerritoryMemory | undefined): assignment is CreepTerritoryMemory {
+  return (
+    isNonEmptyString(assignment?.targetRoom) &&
+    (assignment.action === 'claim' || assignment.action === 'reserve' || assignment.action === 'scout')
+  );
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
 }

--- a/prod/test/claimerRunner.test.ts
+++ b/prod/test/claimerRunner.test.ts
@@ -54,6 +54,179 @@ describe('runClaimer', () => {
     expect(creep.reserveController).not.toHaveBeenCalled();
   });
 
+  it('routes an idle no-territory claimer with stale movement memory home for recycling', () => {
+    const recycleCreep = jest.fn().mockReturnValue(-9);
+    const spawn = {
+      name: 'Spawn1',
+      my: true,
+      room: { name: 'E9S27' },
+      recycleCreep
+    } as unknown as StructureSpawn;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 65_008,
+      rooms: {
+        E9S27: { name: 'E9S27' } as Room,
+        E9S28: { name: 'E9S28' } as Room
+      },
+      spawns: { Spawn1: spawn },
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+
+    const memory = {
+      role: 'claimer',
+      colony: 'E9S27',
+      _move: { dest: { x: 25, y: 25, room: 'E8S28' } }
+    } as CreepMemory & { _move?: unknown };
+    const creep = {
+      name: 'claimer-E9S27-E8S28-64695',
+      memory,
+      room: { name: 'E9S28' },
+      fatigue: 0,
+      body: [
+        { type: 'claim', hits: 100 },
+        { type: 'move', hits: 100 }
+      ],
+      getActiveBodyparts: jest.fn((part: BodyPartConstant) => (part === 'claim' ? 1 : 0)),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runClaimer(creep);
+
+    expect(recycleCreep).toHaveBeenCalledWith(creep);
+    expect(creep.moveTo).toHaveBeenCalledWith(spawn);
+    expect(memory._move).toBeUndefined();
+    expect(creep.memory.territory).toBeUndefined();
+  });
+
+  it('reuses a runnable reservation assignment before recycling an unassigned claimer', () => {
+    const controller = { id: 'controller2', my: false } as StructureController;
+    const recycleCreep = jest.fn();
+    const spawn = {
+      name: 'Spawn1',
+      my: true,
+      room: { name: 'W1N1' },
+      recycleCreep
+    } as unknown as StructureSpawn;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 601,
+      rooms: {
+        W1N1: {
+          name: 'W1N1',
+          energyAvailable: 650,
+          energyCapacityAvailable: 650,
+          controller: { my: true, owner: { username: 'me' }, level: 6 } as StructureController
+        } as Room,
+        W2N1: {
+          name: 'W2N1',
+          controller,
+          find: jest.fn().mockReturnValue([])
+        } as unknown as Room
+      },
+      spawns: { Spawn1: spawn },
+      getObjectById: jest.fn().mockReturnValue(controller)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            action: 'reserve',
+            createdBy: 'expansionPlanner',
+            controllerId: 'controller2' as Id<StructureController>
+          }
+        ]
+      }
+    };
+    const creep = {
+      name: 'Claimer1',
+      memory: { role: 'claimer', colony: 'W1N1' },
+      room: { name: 'W1N1' },
+      body: [
+        { type: 'claim', hits: 100 },
+        { type: 'move', hits: 100 }
+      ],
+      getActiveBodyparts: jest.fn((part: BodyPartConstant) => (part === 'claim' ? 1 : 0)),
+      reserveController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runClaimer(creep);
+
+    expect(creep.memory.territory).toEqual({
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      controllerId: 'controller2'
+    });
+    expect(creep.moveTo).toHaveBeenCalledWith(controller);
+    expect(creep.reserveController).not.toHaveBeenCalled();
+    expect(recycleCreep).not.toHaveBeenCalled();
+  });
+
+  it('keeps active reservation claimers on the controller path instead of recycling them as idle', () => {
+    const controller = { id: 'controller2', my: false } as StructureController;
+    const recycleCreep = jest.fn();
+    const spawn = {
+      name: 'Spawn1',
+      my: true,
+      room: { name: 'W1N1' },
+      recycleCreep
+    } as unknown as StructureSpawn;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 602,
+      rooms: {
+        W2N1: {
+          name: 'W2N1',
+          controller,
+          find: jest.fn().mockReturnValue([])
+        } as unknown as Room
+      },
+      spawns: { Spawn1: spawn },
+      getObjectById: jest.fn().mockReturnValue(controller)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'reserve',
+            status: 'active',
+            updatedAt: 601,
+            controllerId: 'controller2' as Id<StructureController>
+          }
+        ]
+      }
+    };
+    const creep = {
+      name: 'Claimer1',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'reserve', controllerId: 'controller2' as Id<StructureController> }
+      },
+      room: { name: 'W2N1', controller },
+      body: [
+        { type: 'claim', hits: 100 },
+        { type: 'move', hits: 100 }
+      ],
+      getActiveBodyparts: jest.fn((part: BodyPartConstant) => (part === 'claim' ? 1 : 0)),
+      reserveController: jest.fn().mockReturnValue(-9),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runClaimer(creep);
+
+    expect(creep.reserveController).toHaveBeenCalledWith(controller);
+    expect(creep.moveTo).toHaveBeenCalledWith(controller);
+    expect(recycleCreep).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toEqual({
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      controllerId: 'controller2'
+    });
+  });
+
   it('routes recommended expansion claimers toward the visible target controller', () => {
     const colonyRoom = makeColonyRoom();
     const controller = { id: 'controller1', my: false } as StructureController;
@@ -225,7 +398,7 @@ describe('runClaimer', () => {
 
     expect(creep.claimController).toHaveBeenCalledWith(controller);
     expect(creep.signController).toHaveBeenCalledWith(controller, OCCUPIED_CONTROLLER_SIGN_TEXT);
-    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.moveTo).toHaveBeenCalledWith({ x: 25, y: 25, roomName: 'W1N1' });
     expect(creep.memory.territory).toBeUndefined();
     expect(Memory.territory?.targets).toEqual([]);
     expect(Memory.territory?.intents).toEqual([]);
@@ -393,7 +566,7 @@ describe('runClaimer', () => {
 
       expect(creep.claimController).not.toHaveBeenCalled();
       expect(creep.signController).not.toHaveBeenCalled();
-      expect(creep.moveTo).not.toHaveBeenCalled();
+      expect(creep.moveTo).toHaveBeenCalledWith({ x: 25, y: 25, roomName: 'W1N1' });
       expect(creep.memory.territory).toBeUndefined();
       expect(Memory.territory?.targets).toEqual([]);
       expect(Memory.territory?.intents).toEqual([]);


### PR DESCRIPTION
## Summary

Refs #1696

- Adds a final idle recovery path after the existing claimer expansion, reservation, and territory executors run.
- Leaves active claim/reserve/scout assignments on the existing executor paths, then only treats claimers without a valid territory assignment as recoverable idle claimers.
- Gives unassigned claimers one more chance to reuse a runnable reservation assignment, then clears stale movement memory and routes them to an owned home-room spawn for recycling, with safe fallbacks when Screeps APIs are absent in tests.
- Adds focused `runClaimer` coverage for the Seasonal E9S27/E9S28-style no-territory stale `_move` case, reservation reuse, and active reservation non-recycling.

## Verification

- `npm run typecheck` passed.
- `npm test -- --runInBand` passed: 105 suites, 2291 tests.
- `npm run build` passed and regenerated `prod/dist/main.js`.
- `git diff --check` passed.

## Universal task Done gate

- [x] Task type: code behavior bugfix.
- [x] Expected observable outcome / named deliverable: stranded Seasonal territory claimers that lose/shed `memory.territory` after suppressed or completed territory intents no longer sit idle; they either pick up a runnable reservation assignment or head home for spawn recycling.
- [x] Non-goals / accepted substitutes: no broad territory planner rewrite, no source/worker role behavior changes, no deploy or live acceptance claim in this PR.
- [x] Verification evidence required before Done: commit `d32d0258932adba3e5b2f9498254b418f4ca6db1`; `npm run typecheck`; `npm test -- --runInBand`; `npm run build`; `git diff --check`.
- [x] Project Evidence / Next action / Blocked by: Project `screeps` issue #1696 and PR #1697 are `In review`; Evidence records PR URL, commit SHA, and verification commands; Next action names review, merge eligibility, deploy, and live acceptance collection; Blocked by is empty.
- [x] Post-merge/deploy/runtime proof: deploy/live acceptance collection is deferred to the post-PR release gate for #1696; no live acceptance is asserted by this code PR.
- [x] Named deliverable proof: code and tests in `prod/src/creeps/claimerRunner.ts`, `prod/test/claimerRunner.test.ts`, and generated `prod/dist/main.js` in this PR.

## Postdeploy Follow-Up

Postdeploy/live acceptance is pending follow-up for issue #1696 after merge and shardSeason deploy; the acceptance target is evidence that affected no-territory claimers move/recycle or receive a new assignment instead of idling.