### PR TITLE
fix(rl): preserve Tencent worker known_hosts entries

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -871,6 +871,31 @@ class Controller:
                 host_key_count=len(current_lines),
             )
 
+        find_result = self.find_worker_known_host()
+        if not find_result.ok:
+            return find_result
+        if find_result.status == "existing_known_host_entry":
+            host_key_count = max(find_result.host_key_count, 1)
+            self.record_step(
+                "prepare_worker_known_host",
+                started,
+                True,
+                None,
+                publicIp=self.public_ip,
+                knownHostsFile=str(known_hosts),
+                status="existing_known_host_keyscan_unavailable",
+                retryable=False,
+                keyscanStatus=scan_result.status,
+                keyscanRetryable=scan_result.retryable,
+                hostKeyCount=host_key_count,
+            )
+            self.mark_worker_known_host_prepared()
+            return KnownHostPrepareResult(
+                True,
+                "existing_known_host_keyscan_unavailable",
+                host_key_count=host_key_count,
+            )
+
         if not self.clear_worker_known_host():
             return KnownHostPrepareResult(
                 False,
@@ -933,6 +958,74 @@ class Controller:
             return KnownHostPrepareResult(True, status)
         reason = tail_text(sanitize_known_hosts_cleanup_text(cp.stderr or cp.stdout)) or scan_result.reason
         return KnownHostPrepareResult(False, status, retryable=retryable, reason=reason)
+
+    def find_worker_known_host(self) -> KnownHostPrepareResult:
+        if not self.public_ip:
+            return KnownHostPrepareResult(True, "skipped_no_public_ip")
+        known_hosts = self.known_hosts_path
+        cmd = ["ssh-keygen", "-F", self.public_ip, "-f", str(known_hosts)]
+        started = time.time()
+        try:
+            known_hosts.parent.mkdir(parents=True, exist_ok=True)
+            known_hosts.touch(exist_ok=True)
+            cp = subprocess.run(
+                cmd,
+                text=True,
+                capture_output=True,
+                cwd=str(REPO_ROOT),
+                timeout=KNOWN_HOSTS_CLEANUP_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as error:
+            stdout_raw = getattr(error, "stdout", None)
+            if stdout_raw is None:
+                stdout_raw = getattr(error, "output", None)
+            stderr_raw = getattr(error, "stderr", None)
+            stdout = decode_subprocess_text(stdout_raw)
+            stderr = decode_subprocess_text(stderr_raw)
+            stderr = "\n".join(part for part in (f"{type(error).__name__}: {error}", stderr) if part)
+            cp = subprocess.CompletedProcess(cmd, 124, stdout, stderr)
+        except OSError as error:
+            cp = subprocess.CompletedProcess(cmd, 127, "", f"{type(error).__name__}: {error}")
+
+        host_key_count = len(
+            HOST_KEY_BLOB_RE.findall("\n".join(part for part in (cp.stdout, cp.stderr) if part))
+        )
+        if cp.returncode == 0:
+            status = "existing_known_host_entry"
+        elif cp.returncode == 1:
+            status = "missing_known_host_entry"
+        else:
+            status = "host_key_unverified_existing_entry_blocked"
+        ok = cp.returncode in {0, 1}
+        self.record_step(
+            "find_worker_known_host",
+            started,
+            ok,
+            sanitized_known_hosts_completed_process(cp),
+            argv=redacted_argv(cmd),
+            publicIp=self.public_ip,
+            knownHostsFile=str(known_hosts),
+            status=status,
+            retryable=False,
+            hostKeyCount=host_key_count,
+        )
+        if ok:
+            return KnownHostPrepareResult(
+                True,
+                status,
+                host_key_count=max(host_key_count, 1) if cp.returncode == 0 else 0,
+            )
+        reason = tail_text(sanitize_known_hosts_cleanup_text(cp.stderr or cp.stdout)) or (
+            f"ssh-keygen -F exited {cp.returncode} while checking existing known_hosts entry"
+        )
+        return KnownHostPrepareResult(
+            False,
+            status,
+            retryable=False,
+            reason=reason,
+            host_key_count=host_key_count,
+        )
 
     def install_worker_known_host(self, scanned_lines: Sequence[str], *, had_plain_entry: bool) -> KnownHostPrepareResult:
         known_hosts = self.known_hosts_path

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -7175,6 +7175,63 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(controller.steps[-1].detail["hostKeyCount"], 1)
         self.assertIn("203.0.113.10", controller.known_hosts_prepared_public_ips)
 
+    def test_prepare_worker_known_host_preserves_hashed_existing_entry_when_keyscan_unavailable(self) -> None:
+        hashed_key = "|1|salt|hash ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIhashed"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args = controller_args()
+            args.known_hosts_path = str(Path(temp_dir) / "known_hosts")
+            known_hosts = Path(args.known_hosts_path)
+            known_hosts.write_text(hashed_key + "\n", encoding="utf-8")
+            controller = runner.Controller(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
+            controller.public_ip = "203.0.113.10"
+            keyscan_calls = 0
+            find_calls = 0
+
+            def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                nonlocal keyscan_calls, find_calls
+                if cmd[0] == "ssh-keyscan":
+                    keyscan_calls += 1
+                    return subprocess.CompletedProcess(cmd, 1, "", "")
+                if cmd[:2] == ["ssh-keygen", "-F"]:
+                    find_calls += 1
+                    stdout = f"# Host 203.0.113.10 found: line 1\n{hashed_key}\n"
+                    return subprocess.CompletedProcess(cmd, 0, stdout, "")
+                if cmd[:2] == ["ssh-keygen", "-R"]:
+                    raise AssertionError("hashed existing known_hosts entry should not be removed before strict SSH")
+                if cmd[0] == "ssh":
+                    raise AssertionError("accept-new SSH should not run for an existing known_hosts entry")
+                raise AssertionError(cmd)
+
+            with (
+                mock.patch.object(runner.subprocess, "run", side_effect=fake_run),
+                mock.patch.object(runner.time, "sleep", return_value=None) as sleep,
+            ):
+                result = controller.prepare_worker_known_host()
+
+            self.assertTrue(result.ok)
+            self.assertEqual(result.status, "existing_known_host_keyscan_unavailable")
+            self.assertEqual(known_hosts.read_text(encoding="utf-8"), hashed_key + "\n")
+
+        self.assertEqual(keyscan_calls, 3)
+        self.assertEqual(find_calls, 1)
+        sleep.assert_has_calls([mock.call(2.0), mock.call(5.0)])
+        self.assertEqual(
+            [step.name for step in controller.steps],
+            [
+                "scan_worker_host_key",
+                "scan_worker_host_key",
+                "scan_worker_host_key",
+                "find_worker_known_host",
+                "prepare_worker_known_host",
+            ],
+        )
+        self.assertEqual(controller.steps[3].detail["status"], "existing_known_host_entry")
+        self.assertIn("[REDACTED_HOST_KEY]", controller.steps[3].stdout_tail or "")
+        self.assertNotIn("AAAAC3NzaC1lZDI1NTE5AAAAIhashed", controller.steps[3].stdout_tail or "")
+        self.assertEqual(controller.steps[-1].detail["status"], "existing_known_host_keyscan_unavailable")
+        self.assertEqual(controller.steps[-1].detail["hostKeyCount"], 1)
+        self.assertIn("203.0.113.10", controller.known_hosts_prepared_public_ips)
+
     def test_ssh_cmd_preserves_existing_entry_then_self_heals_strict_mismatch(self) -> None:
         stale_key = "203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIstale"
         current_key = "203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIcurrent"
@@ -7260,10 +7317,15 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             controller = runner.Controller(args=args, run_id="run-test", artifact_dir=Path(temp_dir))
             controller.public_ip = "203.0.113.10"
             commands: list[list[str]] = []
+            find_calls = 0
 
             def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                nonlocal find_calls
                 commands.append(cmd)
                 if cmd[0] == "ssh-keyscan":
+                    return subprocess.CompletedProcess(cmd, 1, "", "")
+                if cmd[:2] == ["ssh-keygen", "-F"]:
+                    find_calls += 1
                     return subprocess.CompletedProcess(cmd, 1, "", "")
                 if cmd[0] == "ssh-keygen":
                     known_hosts.write_text("", encoding="utf-8")
@@ -7286,12 +7348,14 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             self.assertEqual(result.status, "accepted_new_known_host")
 
         sleep.assert_has_calls([mock.call(2.0), mock.call(5.0)])
+        self.assertEqual(find_calls, 1)
         self.assertEqual(
             [step.name for step in controller.steps],
             [
                 "scan_worker_host_key",
                 "scan_worker_host_key",
                 "scan_worker_host_key",
+                "find_worker_known_host",
                 "clear_worker_known_host",
                 "accept_new_worker_known_host",
             ],


### PR DESCRIPTION
## Linked issues

Intentional PR-body closing linkage:
- None.

Related / non-closing linkage:
- Refs #1681.

## Domain / Kind

- Domain: RL flywheel
- Kind: ops

## Summary

- Preserve an existing Tencent worker known_hosts entry when ssh-keyscan is temporarily unavailable, so the next paid-validation preflight can keep strict SSH safety instead of deleting a usable cached key first.
- Add `ssh-keygen -F` detection and step evidence for existing entries.
- Cover the hashed-entry preservation path and the accept-new fallback path with unit tests.

## Verification

- [x] Local check: `git diff --check HEAD^..HEAD` PASS.
- [x] Local check: `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py` PASS.
- [x] Local check: `python3 -m unittest scripts/test_screeps_tencent_batch_rl_runner.py` PASS (176 tests).
- [x] GitHub Project issue/PR fields are current (`Status`, `Evidence`, `Next action`; plus `Blocked by` when blocked): #1681 and PR #1698 are `In review` with Evidence/Next action/Blocked by set.
- [ ] Automated review has no blocking findings and review threads are resolved/outdated/non-blocking.
- [x] QA gate: controller verification above; no paid Tencent run or ASG mutation performed.
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate

- [x] Task type: ops code hardening for RL Tencent batch preflight.
- [x] Expected observable outcome / named deliverable: worker known_hosts self-healing preserves an existing cached host key when keyscan is unavailable, with redacted step evidence and tests.
- [x] Non-goals / accepted substitutes: no paid Tencent validation run, no ASG capacity change, no recurrence-guard reset, and no official MMO behavior change in this PR.
- [x] Verification evidence required before Done: controller checks listed above plus GitHub CI and automated review gate before merge.
- [x] Project Evidence / Next action / Blocked by: PR opened from commit `2c130a5d`; Project fields will be updated immediately after PR creation.
- [x] Post-merge/deploy/runtime proof: not applicable; this is a preflight/SSH safety hardening slice. The next paid validation remains separately gated by #1233 and the recurrence guard.
- [x] Named deliverable proof: `scripts/screeps_tencent_batch_rl_runner.py` now checks `ssh-keygen -F`; unit tests assert existing hashed entries are preserved and not removed before strict SSH.

## Issue closure gate

No issue is linked with a closing keyword. #1681 should close only after merge plus Project Done reconciliation.

## Runtime / deployment impact

- [x] No gameplay/runtime/deployment impact.
- [ ] Gameplay/runtime/deployment impact; Deployment Floor evidence or HELD blocker is recorded.

## Notes

- Review/merge gates: wait at least 15 minutes after PR creation, require green checks, inspect CodeRabbit/Gemini/review threads, and keep linked issue/PR Project state current until merged or explicitly closed.

