### PR TITLE
fix: detect Seasonal FIND_SCORES items

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -25957,6 +25957,7 @@ function getGameTick2() {
 // src/season/scoreCollection.ts
 var SCORE_COLLECTOR_ROLE = "scoreCollector";
 var SCORE_FIND_CONSTANT_GLOBALS = [
+  "FIND_SCORES",
   "FIND_SCORE",
   "FIND_SCORE_ITEMS",
   "FIND_SCORE_OBJECTS",

--- a/prod/src/season/scoreCollection.ts
+++ b/prod/src/season/scoreCollection.ts
@@ -1,6 +1,7 @@
 import { getRuntimeFeatureGates } from '../runtime/featureGates';
 
 type ScoreFindConstantGlobal =
+  | 'FIND_SCORES'
   | 'FIND_SCORE'
   | 'FIND_SCORE_ITEMS'
   | 'FIND_SCORE_OBJECTS'
@@ -47,6 +48,7 @@ type RoomPositionConstructor = new (x: number, y: number, roomName: string) => R
 export const SCORE_COLLECTOR_ROLE = 'scoreCollector';
 
 const SCORE_FIND_CONSTANT_GLOBALS: ScoreFindConstantGlobal[] = [
+  'FIND_SCORES',
   'FIND_SCORE',
   'FIND_SCORE_ITEMS',
   'FIND_SCORE_OBJECTS',

--- a/prod/test/scoreCollection.test.ts
+++ b/prod/test/scoreCollection.test.ts
@@ -9,6 +9,7 @@ describe('season scoreCollector swarm', () => {
   beforeEach(() => {
     (globalThis as unknown as { ERR_NO_PATH: number }).ERR_NO_PATH = -2;
     (globalThis as unknown as { FIND_SCORE: number }).FIND_SCORE = 42;
+    delete (globalThis as unknown as { FIND_SCORES?: number }).FIND_SCORES;
     (globalThis as unknown as { RoomPosition: new (x: number, y: number, roomName: string) => RoomPosition })
       .RoomPosition = class {
         public constructor(
@@ -150,6 +151,42 @@ describe('season scoreCollector swarm', () => {
       state: 'collecting',
       visibleScoreCount: 1,
       assignedScoreTargetId: 'score1'
+    });
+  });
+
+  it('detects documented Seasonal FIND_SCORES constant without singular aliases', () => {
+    delete (globalThis as unknown as { FIND_SCORE?: number }).FIND_SCORE;
+    (globalThis as unknown as { FIND_SCORES: number }).FIND_SCORES = 10031;
+    const score = makeScoreItem('scorePlural1', 'W1N1');
+    const roomFind = jest.fn((type: number) =>
+      type === (globalThis as unknown as { FIND_SCORES: number }).FIND_SCORES ? [score] : []
+    );
+    const room = {
+      name: 'W1N1',
+      find: roomFind
+    } as unknown as Room;
+    const moveTo = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'ScoreCollectorPlural',
+      memory: makeScoreCollectorMemory('W1N1', 'W2N1', 100),
+      room,
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'scorePlural1' ? 2 : 50))
+      },
+      moveTo
+    } as unknown as Creep;
+    setGameCreeps({ ScoreCollectorPlural: creep });
+    setGameObjectsById([score]);
+
+    runScoreCollector(creep);
+
+    expect(roomFind).toHaveBeenCalledWith(10031);
+    expect(creep.memory.task).toEqual({ type: 'collectScore', targetId: 'scorePlural1' });
+    expect(moveTo).toHaveBeenCalledWith(score, { range: 0 });
+    expect(creep.memory.seasonScoreCollector).toMatchObject({
+      state: 'collecting',
+      visibleScoreCount: 1,
+      assignedScoreTargetId: 'scorePlural1'
     });
   });
 


### PR DESCRIPTION
## Summary

Addresses the live Seasonal scoreCollector detection gap found during issue 1685 validation: Season 10 exposes the documented room find constant as plural `FIND_SCORES`, while the implementation only probed singular/alternate aliases.

Changes:
- Add `FIND_SCORES` to score item discovery before compatibility aliases.
- Add regression coverage where only `FIND_SCORES = 10031` exists and no singular `FIND_SCORE` alias is available.
- Rebuild `prod/dist/main.js`.

## Live evidence

Owner report: `scoreCollector-E9S27-E9S29-69002` in `shardSeason/E9S29` ignored a visible Score.

Captured artifact:
`runtime-artifacts/seasonal/score-triage/20260605T161024Z-scoreCollector-E9S27-E9S29-69002.json`

Observed:
- Tick 69449: E9S29 Score `6a22f204a9c1f8043f2d44bc` at `(18,24)`, score `1014`, decayTime `72271`.
- Collector at `(24,23)`, `[MOVE]`, fatigue `0`, targetRoom `E9S29`.
- Collector memory had `seasonScoreCollection.blockedReason=no_visible_score`, `visibleCount=0`.
- docs-season API documents `FIND_SCORES = 10031` and `room.find(FIND_SCORES)`.

## Verification

- [x] `npm test -- --runInBand scoreCollection.test.ts`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test -- --runInBand`
- [x] `git diff --check HEAD~1..HEAD`

## Universal task Done gate

- [x] Task type: code bugfix for Seasonal score item discovery.
- [x] Expected observable outcome / named deliverable: `scoreCollector` detects documented `FIND_SCORES` Score objects and issues exact-tile movement.
- [x] Non-goals / accepted substitutes: no pickup, withdraw, transfer, or store-based score mechanic change.
- [x] Verification evidence required before Done: focused Jest, typecheck, build, full Jest, and diff-check all pass.
- [x] Project Evidence / Next action / Blocked by: Project fields were refreshed with evidence and routed follow-up state.
- [x] Post-merge/deploy/runtime proof: local code gate is complete; live proof is tracked on issue 1685.
- [x] Named deliverable proof: regression test covers plural `FIND_SCORES` without singular aliases; bundle contains `FIND_SCORES`.

Related to issue 1685.
