### PR TITLE
fix: preserve runtime worker evidence in summaries

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -40411,7 +40411,7 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     constructionScoring,
     ...includeOptionalSummary ? summarizeRuntimeBehavior(colonyWorkers, colonyCreeps, tick) : {},
     ...includeStructureSnapshot ? { structures: summarizeStructures(colony, colonyWorkers) } : {},
-    ...includeOptionalSummary ? summarizeWorkerEfficiency(colonyWorkers, tick) : {},
+    ...summarizeOptionalWorkerEfficiency(colonyWorkers, tick, includeOptionalSummary),
     ...includeOptionalSummary ? summarizeRefillTelemetry(colonyWorkers, tick) : {},
     ...summarizeSpawnCriticalRefill(colonyWorkers, tick),
     ...buildControllerSummary(colony.room),
@@ -41504,12 +41504,24 @@ function calculateRoadCoverageRatio(roadCount, pendingRoadSiteCount) {
   }
   return roundRatio6(roadCount, totalKnownRoadWork);
 }
+function summarizeOptionalWorkerEfficiency(workers, tick, includeOptionalSummary) {
+  if (!includeOptionalSummary) {
+    return {
+      workerLoadEfficiency: summarizeUnavailableWorkerLoadEfficiency("optional_summary_suppressed_by_cpu")
+    };
+  }
+  return summarizeWorkerEfficiency(workers, tick);
+}
 function summarizeWorkerEfficiency(workers, tick) {
   const samples = workers.map((worker) => ({ creepName: getCreepName2(worker), sample: worker.memory.workerEfficiency })).filter(
     (entry) => isWorkerEfficiencySample(entry.sample) && isRecentWorkerEfficiencySample(entry.sample, tick)
   ).sort(compareWorkerEfficiencySampleEntries);
   if (samples.length === 0) {
-    return {};
+    return {
+      workerLoadEfficiency: summarizeUnavailableWorkerLoadEfficiency(
+        workers.length === 0 ? "no_worker_creeps" : "recent_worker_efficiency_sample_missing"
+      )
+    };
   }
   const reportedSamples = samples.slice(0, MAX_WORKER_EFFICIENCY_SAMPLES).map(toRuntimeWorkerEfficiencySample);
   const lowLoadReturnSamples = samples.filter((entry) => entry.sample.type === "lowLoadReturn");
@@ -41530,7 +41542,15 @@ function summarizeWorkerEfficiency(workers, tick) {
       samples: reportedSamples,
       ...samples.length > MAX_WORKER_EFFICIENCY_SAMPLES ? { omittedSampleCount: samples.length - MAX_WORKER_EFFICIENCY_SAMPLES } : {}
     },
-    ...workerLoadEfficiency ? { workerLoadEfficiency } : {}
+    workerLoadEfficiency: workerLoadEfficiency != null ? workerLoadEfficiency : summarizeUnavailableWorkerLoadEfficiency("recent_worker_efficiency_sample_missing")
+  };
+}
+function summarizeUnavailableWorkerLoadEfficiency(unavailableReason) {
+  return {
+    sampleCount: 0,
+    tripEnergyMean: null,
+    tripEnergyMin: null,
+    unavailableReason
   };
 }
 function summarizeWorkerLoadEfficiency(samples) {

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -723,10 +723,16 @@ interface RuntimeWorkerEfficiencySummary {
   omittedSampleCount?: number;
 }
 
+type RuntimeWorkerLoadEfficiencyUnavailableReason =
+  | 'no_worker_creeps'
+  | 'optional_summary_suppressed_by_cpu'
+  | 'recent_worker_efficiency_sample_missing';
+
 interface RuntimeWorkerLoadEfficiencySummary {
   sampleCount: number;
-  tripEnergyMean: number;
-  tripEnergyMin: number;
+  tripEnergyMean: number | null;
+  tripEnergyMin: number | null;
+  unavailableReason?: RuntimeWorkerLoadEfficiencyUnavailableReason;
 }
 
 interface RuntimeBehaviorSummary {
@@ -1275,7 +1281,7 @@ function summarizeRoom(
     constructionScoring,
     ...(includeOptionalSummary ? summarizeRuntimeBehavior(colonyWorkers, colonyCreeps, tick) : {}),
     ...(includeStructureSnapshot ? { structures: summarizeStructures(colony, colonyWorkers) } : {}),
-    ...(includeOptionalSummary ? summarizeWorkerEfficiency(colonyWorkers, tick) : {}),
+    ...summarizeOptionalWorkerEfficiency(colonyWorkers, tick, includeOptionalSummary),
     ...(includeOptionalSummary ? summarizeRefillTelemetry(colonyWorkers, tick) : {}),
     ...summarizeSpawnCriticalRefill(colonyWorkers, tick),
     ...buildControllerSummary(colony.room),
@@ -2887,12 +2893,29 @@ function calculateRoadCoverageRatio(roadCount: number, pendingRoadSiteCount: num
   return roundRatio(roadCount, totalKnownRoadWork);
 }
 
+function summarizeOptionalWorkerEfficiency(
+  workers: Creep[],
+  tick: number,
+  includeOptionalSummary: boolean
+): {
+  workerEfficiency?: RuntimeWorkerEfficiencySummary;
+  workerLoadEfficiency: RuntimeWorkerLoadEfficiencySummary;
+} {
+  if (!includeOptionalSummary) {
+    return {
+      workerLoadEfficiency: summarizeUnavailableWorkerLoadEfficiency('optional_summary_suppressed_by_cpu')
+    };
+  }
+
+  return summarizeWorkerEfficiency(workers, tick);
+}
+
 function summarizeWorkerEfficiency(
   workers: Creep[],
   tick: number
 ): {
   workerEfficiency?: RuntimeWorkerEfficiencySummary;
-  workerLoadEfficiency?: RuntimeWorkerLoadEfficiencySummary;
+  workerLoadEfficiency: RuntimeWorkerLoadEfficiencySummary;
 } {
   const samples = workers
     .map((worker) => ({ creepName: getCreepName(worker), sample: worker.memory.workerEfficiency }))
@@ -2903,7 +2926,11 @@ function summarizeWorkerEfficiency(
     .sort(compareWorkerEfficiencySampleEntries);
 
   if (samples.length === 0) {
-    return {};
+    return {
+      workerLoadEfficiency: summarizeUnavailableWorkerLoadEfficiency(
+        workers.length === 0 ? 'no_worker_creeps' : 'recent_worker_efficiency_sample_missing'
+      )
+    };
   }
 
   const reportedSamples = samples.slice(0, MAX_WORKER_EFFICIENCY_SAMPLES).map(toRuntimeWorkerEfficiencySample);
@@ -2928,7 +2955,19 @@ function summarizeWorkerEfficiency(
         ? { omittedSampleCount: samples.length - MAX_WORKER_EFFICIENCY_SAMPLES }
         : {})
     },
-    ...(workerLoadEfficiency ? { workerLoadEfficiency } : {})
+    workerLoadEfficiency:
+      workerLoadEfficiency ?? summarizeUnavailableWorkerLoadEfficiency('recent_worker_efficiency_sample_missing')
+  };
+}
+
+function summarizeUnavailableWorkerLoadEfficiency(
+  unavailableReason: RuntimeWorkerLoadEfficiencyUnavailableReason
+): RuntimeWorkerLoadEfficiencySummary {
+  return {
+    sampleCount: 0,
+    tripEnergyMean: null,
+    tripEnergyMin: null,
+    unavailableReason
   };
 }
 

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -278,6 +278,12 @@ describe('runtime telemetry summaries', () => {
               creepDestroyedCount: 1
             }
           },
+          workerLoadEfficiency: {
+            sampleCount: 0,
+            tripEnergyMean: null,
+            tripEnergyMin: null,
+            unavailableReason: 'recent_worker_efficiency_sample_missing'
+          },
           constructionPriority: {
             candidates: [
               {
@@ -600,6 +606,12 @@ describe('runtime telemetry summaries', () => {
     expect(room.territoryExpansion).toBeUndefined();
     expect(room.behavior).toBeUndefined();
     expect(room.workerEfficiency).toBeUndefined();
+    expect(room.workerLoadEfficiency).toEqual({
+      sampleCount: 0,
+      tripEnergyMean: null,
+      tripEnergyMin: null,
+      unavailableReason: 'optional_summary_suppressed_by_cpu'
+    });
     expect(room.refillDeliveryTicks).toBeUndefined();
     expect(room.refillWorkerUtilization).toBeUndefined();
     expect(room.workerEnergyThroughput).toBeUndefined();
@@ -2736,6 +2748,33 @@ describe('runtime telemetry summaries', () => {
       storedEnergy: 0,
       workerCarriedEnergy: 0,
       harvestedThisTick: 0
+    });
+  });
+
+  it('reports why worker load efficiency has no recent samples', () => {
+    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
+    const worker = makeWorker(
+      {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'build', targetId: 'site-1' as Id<ConstructionSite> }
+      },
+      40,
+      'BuilderWithoutEfficiencySample'
+    );
+
+    emitRuntimeSummary([colony], [worker]);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.taskCounts).toMatchObject({ build: 1 });
+    expect(room.workerAssignmentEvidenceAvailable).toBe(true);
+    expect(room.workerEfficiency).toBeUndefined();
+    expect(room.workerLoadEfficiency).toEqual({
+      sampleCount: 0,
+      tripEnergyMean: null,
+      tripEnergyMin: null,
+      unavailableReason: 'recent_worker_efficiency_sample_missing'
     });
   });
 


### PR DESCRIPTION
## Summary
- Preserves worker-assignment evidence in runtime summaries when task-count visibility exists but numeric load-efficiency samples are unavailable.
- Adds bounded unavailable reasons for worker-load-efficiency output so monitor consumers can distinguish CPU-suppressed/no-sample states from missing creep memory.
- Regenerates `prod/dist/main.js` from the verified source change.

Fixes #1703

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/screeps_runtime_kpi_reducer.py scripts/screeps_runtime_summary_console_capture.py scripts/screeps_rl_metrics_ingestor.py`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`
- Controller verifier log: `/tmp/issue-1703-controller-verify.log` with `CONTROLLER_1703_VERIFY_PASS`.

## Issue closure gate
- [x] #1703: Codex-authored commit `b084f670` updates runtime summary telemetry and tests; controller verifier completed diff-check, py_compile, typecheck, Jest, and build with `CONTROLLER_1703_VERIFY_PASS`.

## Universal task Done gate
- [x] Task type: production telemetry code and generated bundle update.
- [x] Expected observable outcome / named deliverable: Screeps runtime-summary report emits worker-assignment evidence plus bounded worker-load-efficiency unavailable reason for no numeric samples.
- [x] Non-goals / accepted substitutes: direct HTTP monitor fallback creep-memory limits remain a separate capture-surface behavior; this PR repairs bot-emitted runtime-summary semantics.
- [x] Verification evidence required before Done: `/tmp/issue-1703-controller-verify.log` plus commit `b084f670` and regenerated `prod/dist/main.js`.
- [x] Project Evidence / Next action / Blocked by: Project item records verifier evidence; next action is exact-head PR gate; blocker field empty for code completion.
- [x] Post-merge/deploy/runtime proof: bundle build proof is `prod/dist/main.js`; runtime acceptance surface is the next official deploy health capture tied to this PR head.
- [x] Named deliverable proof: `prod/src/telemetry/runtimeSummary.ts`, `prod/test/runtimeSummary.test.ts`, and `prod/dist/main.js` in commit `b084f670`.
