### PR TITLE
fix: propagate RL reward decision provenance

### DIFF
--- a/scripts/screeps_rl_control_loop_ledgers.py
+++ b/scripts/screeps_rl_control_loop_ledgers.py
@@ -880,6 +880,28 @@ def load_reward_decision_record(path: Path) -> JsonObject | None:
     return record
 
 
+def reward_decision_record_matches_candidate(
+    record: JsonObject,
+    *,
+    scorecard_id: str | None,
+    candidate_policy_id: str | None,
+) -> bool:
+    candidate = candidate_policy_text(candidate_policy_id)
+    if candidate is None:
+        return False
+    record_candidate = candidate_policy_text(
+        record.get("candidatePolicyId"),
+        as_dict(record.get("validationEvidence")).get("candidatePolicyId"),
+    )
+    if record_candidate != candidate:
+        return False
+    record_scorecard_id = first_text_value(
+        record.get("scorecardId"),
+        as_dict(record.get("validationEvidence")).get("scorecardId"),
+    )
+    return scorecard_ids_match(scorecard_id, record_scorecard_id)
+
+
 def find_existing_scorecard_reward_decision(
     *,
     artifact_root: Path,
@@ -895,7 +917,15 @@ def find_existing_scorecard_reward_decision(
         expected_id = reward_decision_id_for_scorecard(scorecard_id, candidate)
         expected_path = reward_decision_path(artifact_root, expected_id)
         expected_record = load_reward_decision_record(expected_path)
-        if expected_record is not None and text_value(expected_record.get("rewardDecisionId")) == expected_id:
+        if (
+            expected_record is not None
+            and text_value(expected_record.get("rewardDecisionId")) == expected_id
+            and reward_decision_record_matches_candidate(
+                expected_record,
+                scorecard_id=scorecard_id,
+                candidate_policy_id=candidate,
+            )
+        ):
             return expected_id, repo_display_path(expected_path, repo_root)
 
     matches: list[tuple[datetime, str, str, Path]] = []
@@ -906,17 +936,11 @@ def find_existing_scorecard_reward_decision(
         record = load_reward_decision_record(path)
         if record is None:
             continue
-        record_candidate = candidate_policy_text(
-            record.get("candidatePolicyId"),
-            as_dict(record.get("validationEvidence")).get("candidatePolicyId"),
-        )
-        if record_candidate != candidate:
-            continue
-        record_scorecard_id = first_text_value(
-            record.get("scorecardId"),
-            as_dict(record.get("validationEvidence")).get("scorecardId"),
-        )
-        if not scorecard_ids_match(scorecard_id, record_scorecard_id):
+        if not reward_decision_record_matches_candidate(
+            record,
+            scorecard_id=scorecard_id,
+            candidate_policy_id=candidate,
+        ):
             continue
         reward_decision_id = text_value(record.get("rewardDecisionId"))
         if reward_decision_id is None:
@@ -932,6 +956,47 @@ def find_existing_scorecard_reward_decision(
     return reward_decision_id, repo_display_path(path, repo_root)
 
 
+def matching_carried_reward_decision_link(
+    *,
+    previous_policy: JsonObject | None,
+    training_payload: JsonObject | None,
+    scorecard_id: str | None,
+    candidate_policy_id: str | None,
+    artifact_root: Path,
+    repo_root: Path,
+) -> tuple[str | None, str | None]:
+    reward_decision_id = existing_reward_decision_id(previous_policy, training_payload)
+    if reward_decision_id is None:
+        return None, None
+
+    path_candidates = [
+        reward_decision_existing_path(
+            reward_decision_id=reward_decision_id,
+            existing_path=existing_reward_decision_artifact_path(previous_policy, training_payload),
+            artifact_root=artifact_root,
+            repo_root=repo_root,
+        ),
+        reward_decision_path(artifact_root, reward_decision_id),
+    ]
+    seen: set[str] = set()
+    for path in path_candidates:
+        path_key = path.as_posix()
+        if path_key in seen:
+            continue
+        seen.add(path_key)
+        record = load_reward_decision_record(path)
+        if record is None or text_value(record.get("rewardDecisionId")) != reward_decision_id:
+            continue
+        if not reward_decision_record_matches_candidate(
+            record,
+            scorecard_id=scorecard_id,
+            candidate_policy_id=candidate_policy_id,
+        ):
+            continue
+        return reward_decision_id, repo_display_path(path, repo_root)
+    return None, None
+
+
 def resolve_reward_decision_link(
     *,
     previous_policy: JsonObject | None,
@@ -941,18 +1006,21 @@ def resolve_reward_decision_link(
     artifact_root: Path,
     repo_root: Path,
 ) -> tuple[str | None, str | None]:
-    reward_decision_id = existing_reward_decision_id(previous_policy, training_payload)
-    reward_decision_artifact_path = existing_reward_decision_artifact_path(previous_policy, training_payload)
-    if reward_decision_id is not None:
-        if reward_decision_artifact_path is None:
-            path = reward_decision_path(artifact_root, reward_decision_id)
-            if path.exists():
-                reward_decision_artifact_path = repo_display_path(path, repo_root)
-        return reward_decision_id, reward_decision_artifact_path
+    scorecard_id = text_value(as_dict(scorecard).get("scorecardId"))
+    carried_id, carried_path = matching_carried_reward_decision_link(
+        previous_policy=previous_policy,
+        training_payload=training_payload,
+        scorecard_id=scorecard_id,
+        candidate_policy_id=candidate_policy_id,
+        artifact_root=artifact_root,
+        repo_root=repo_root,
+    )
+    if carried_id is not None:
+        return carried_id, carried_path
     return find_existing_scorecard_reward_decision(
         artifact_root=artifact_root,
         repo_root=repo_root,
-        scorecard_id=text_value(as_dict(scorecard).get("scorecardId")),
+        scorecard_id=scorecard_id,
         candidate_policy_id=candidate_policy_id,
     )
 

--- a/scripts/screeps_rl_control_loop_ledgers.py
+++ b/scripts/screeps_rl_control_loop_ledgers.py
@@ -815,6 +815,19 @@ def existing_reward_decision_id(previous_policy: JsonObject | None, training_pay
     )
 
 
+def existing_reward_decision_artifact_path(
+    previous_policy: JsonObject | None,
+    training_payload: JsonObject | None,
+) -> str | None:
+    payload = as_dict(training_payload)
+    return first_text_value(
+        as_dict(previous_policy).get("rewardDecisionArtifactPath"),
+        payload.get("rewardDecisionArtifactPath"),
+        as_dict(payload.get("trainingArtifacts")).get("rewardDecisionArtifactPath"),
+        as_dict(payload.get("metricsFields")).get("rewardDecisionArtifactPath"),
+    )
+
+
 def reward_decision_id_for_scorecard(scorecard_id: str, candidate_policy_id: str) -> str:
     digest = hashlib.sha1(f"{scorecard_id}\n{candidate_policy_id}".encode("utf-8")).hexdigest()[:12]
     return f"RD-AUTO-{digest}"
@@ -835,6 +848,113 @@ def reward_decision_existing_path(
         path = Path(existing_path)
         return path if path.is_absolute() else repo_root / path
     return reward_decision_path(artifact_root, reward_decision_id)
+
+
+def scorecard_ids_match(candidate_scorecard_id: str | None, record_scorecard_id: str | None) -> bool:
+    if candidate_scorecard_id is None:
+        return True
+    if record_scorecard_id is None:
+        return False
+    return (
+        candidate_scorecard_id == record_scorecard_id
+        or candidate_scorecard_id in record_scorecard_id
+        or record_scorecard_id in candidate_scorecard_id
+    )
+
+
+def reward_decision_record_timestamp(path: Path, record: JsonObject) -> datetime:
+    for key in ("updatedAt", "createdAt", "decidedAt", "generatedAt"):
+        parsed = static_dashboard.parse_iso_datetime(record.get(key))
+        if parsed is not None:
+            return parsed
+    return static_dashboard.artifact_timestamp(path, record)
+
+
+def load_reward_decision_record(path: Path) -> JsonObject | None:
+    record = load_json(path)
+    if record is None:
+        return None
+    reward_decision_id = text_value(record.get("rewardDecisionId"))
+    if reward_decision_id is None:
+        return None
+    return record
+
+
+def find_existing_scorecard_reward_decision(
+    *,
+    artifact_root: Path,
+    repo_root: Path,
+    scorecard_id: str | None,
+    candidate_policy_id: str | None,
+) -> tuple[str | None, str | None]:
+    candidate = candidate_policy_text(candidate_policy_id)
+    if candidate is None:
+        return None, None
+
+    if scorecard_id is not None:
+        expected_id = reward_decision_id_for_scorecard(scorecard_id, candidate)
+        expected_path = reward_decision_path(artifact_root, expected_id)
+        expected_record = load_reward_decision_record(expected_path)
+        if expected_record is not None and text_value(expected_record.get("rewardDecisionId")) == expected_id:
+            return expected_id, repo_display_path(expected_path, repo_root)
+
+    matches: list[tuple[datetime, str, str, Path]] = []
+    decision_root = artifact_root / "rl-control-loop" / "reward-decisions"
+    if not decision_root.is_dir():
+        return None, None
+    for path in sorted(decision_root.glob("*.json")):
+        record = load_reward_decision_record(path)
+        if record is None:
+            continue
+        record_candidate = candidate_policy_text(
+            record.get("candidatePolicyId"),
+            as_dict(record.get("validationEvidence")).get("candidatePolicyId"),
+        )
+        if record_candidate != candidate:
+            continue
+        record_scorecard_id = first_text_value(
+            record.get("scorecardId"),
+            as_dict(record.get("validationEvidence")).get("scorecardId"),
+        )
+        if not scorecard_ids_match(scorecard_id, record_scorecard_id):
+            continue
+        reward_decision_id = text_value(record.get("rewardDecisionId"))
+        if reward_decision_id is None:
+            continue
+        matches.append((reward_decision_record_timestamp(path, record), reward_decision_id, path.as_posix(), path))
+    if not matches:
+        return None, None
+    if scorecard_id is None:
+        unique_ids = {reward_decision_id for _timestamp, reward_decision_id, _path_key, _path in matches}
+        if len(unique_ids) != 1:
+            return None, None
+    _timestamp, reward_decision_id, _path_key, path = max(matches)
+    return reward_decision_id, repo_display_path(path, repo_root)
+
+
+def resolve_reward_decision_link(
+    *,
+    previous_policy: JsonObject | None,
+    training_payload: JsonObject | None,
+    scorecard: JsonObject | None,
+    candidate_policy_id: str | None,
+    artifact_root: Path,
+    repo_root: Path,
+) -> tuple[str | None, str | None]:
+    reward_decision_id = existing_reward_decision_id(previous_policy, training_payload)
+    reward_decision_artifact_path = existing_reward_decision_artifact_path(previous_policy, training_payload)
+    if reward_decision_id is not None:
+        if reward_decision_artifact_path is None:
+            path = reward_decision_path(artifact_root, reward_decision_id)
+            if path.exists():
+                reward_decision_artifact_path = repo_display_path(path, repo_root)
+        return reward_decision_id, reward_decision_artifact_path
+    return find_existing_scorecard_reward_decision(
+        artifact_root=artifact_root,
+        repo_root=repo_root,
+        scorecard_id=text_value(as_dict(scorecard).get("scorecardId")),
+        candidate_policy_id=candidate_policy_id,
+    )
 
 
 def scorecard_reward_decision_type(training: JsonObject) -> str:
@@ -1102,10 +1222,15 @@ def emit_scorecard_reward_decision_if_missing(
     online_utility_status: str,
     current_policy_advantage_path: Path | None,
 ) -> tuple[str | None, str | None]:
-    existing = existing_reward_decision_id(previous_policy, training_payload)
-    existing_path = first_text_value(as_dict(previous_policy).get("rewardDecisionArtifactPath"))
-
     scorecard_id = text_value(scorecard.get("scorecardId"))
+    existing, existing_path = resolve_reward_decision_link(
+        previous_policy=previous_policy,
+        training_payload=training_payload,
+        scorecard=scorecard,
+        candidate_policy_id=candidate_policy_id,
+        artifact_root=artifact_root,
+        repo_root=repo_root,
+    )
     if scorecard_id is None or candidate_policy_text(candidate_policy_id) is None:
         if existing is not None:
             return existing, existing_path
@@ -1237,7 +1362,13 @@ def training_online_deployment_blocker(training: JsonObject) -> str | None:
     return None
 
 
-def training_anomalies(dashboard: JsonObject, previous: JsonObject | None, repo_root: Path) -> list[JsonObject]:
+def training_anomalies(
+    dashboard: JsonObject,
+    previous: JsonObject | None,
+    repo_root: Path,
+    *,
+    reward_decision_id: str | None = None,
+) -> list[JsonObject]:
     training = as_dict(dashboard.get("training"))
     gate = as_dict(dashboard.get("gate"))
     anomalies: list[JsonObject] = []
@@ -1270,7 +1401,11 @@ def training_anomalies(dashboard: JsonObject, previous: JsonObject | None, repo_
             }
         )
     for item in as_list((previous or {}).get("anomalies")):
-        if isinstance(item, dict) and item.get("code") not in {anomaly["code"] for anomaly in anomalies}:
+        if not isinstance(item, dict):
+            continue
+        if reward_decision_id is not None and item.get("code") == "REWARD_DECISION_ID_NULL":
+            continue
+        if item.get("code") not in {anomaly["code"] for anomaly in anomalies}:
             anomalies.append(item)
     return anomalies[:12]
 
@@ -1308,10 +1443,12 @@ def build_training_ledger(
     training = as_dict(summary.get("training"))
     gate = as_dict(summary.get("gate"))
     simulator = as_dict(summary.get("simulator"))
+    previous_policy = latest_artifact_payload(summary, "policyAdvantage", repo_root)
     status = training_status(training)
     did_run = training_did_run(training)
     iteration = as_dict((previous or {}).get("iterationExecution"))
     environment = as_dict((previous or {}).get("environmentExecution"))
+    training_artifacts = as_dict((previous or {}).get("trainingArtifacts"))
     metrics_fields = as_dict((previous or {}).get("metricsFields"))
     git = git_metadata(repo_root)
     episodes = int_value(training.get("episodes")) or int_value(iteration.get("episodesRun")) or 0
@@ -1319,8 +1456,27 @@ def build_training_ledger(
     ticks_run = int_value(iteration.get("simulatorTicksRun")) or int_value(simulator.get("ticksRun")) or 0
     env_completed = int_value(environment.get("completed")) or int_value(simulator.get("succeeded")) or 0
     env_failed = int_value(environment.get("failed")) or int_value(simulator.get("failed")) or 0
-    anomalies = training_anomalies(summary, previous, repo_root)
     previous_environment = as_dict((previous or {}).get("environmentExecution"))
+    policy_update = as_dict((previous or {}).get("policyUpdate"))
+    next_candidate_policy = as_dict(policy_update.get("nextCandidatePolicy"))
+    candidate_policy_ids = as_list(training_artifacts.get("candidatePolicyIds"))
+    scorecard = selected_scorecard_evidence(previous, previous_policy, repo_root)
+    candidate_policy_id = candidate_policy_text(
+        metrics_fields.get("candidatePolicyId"),
+        (previous or {}).get("policyUpdateCandidatePolicyId"),
+        next_candidate_policy.get("candidatePolicyId"),
+        candidate_policy_ids[-1] if candidate_policy_ids else None,
+        scorecard.get("scorecardCandidatePolicyId"),
+    )
+    reward_decision_id, reward_decision_artifact_path = resolve_reward_decision_link(
+        previous_policy=previous_policy,
+        training_payload=previous,
+        scorecard=scorecard,
+        candidate_policy_id=candidate_policy_id,
+        artifact_root=artifact_root,
+        repo_root=repo_root,
+    )
+    anomalies = training_anomalies(summary, previous, repo_root, reward_decision_id=reward_decision_id)
 
     return {
         "type": TRAINING_LEDGER_TYPE,
@@ -1330,6 +1486,8 @@ def build_training_ledger(
         "sourceIssue": None,
         "historicalContextIssues": HISTORICAL_CONTEXT_ISSUES,
         **git,
+        "rewardDecisionId": reward_decision_id,
+        "rewardDecisionArtifactPath": reward_decision_artifact_path,
         "status": status,
         "trainingDidRun": did_run,
         "e1Gate": {
@@ -1371,12 +1529,13 @@ def build_training_ledger(
             "policyUpdateNote": iteration.get("policyUpdateNote") or "bounded artifact producer did not launch training",
         },
         "trainingArtifacts": {
-            "experimentCard": as_dict((previous or {}).get("trainingArtifacts")).get("experimentCard"),
-            "experimentCardPath": as_dict((previous or {}).get("trainingArtifacts")).get("experimentCardPath"),
-            "simulatorRunIds": as_dict((previous or {}).get("trainingArtifacts")).get("simulatorRunIds", []),
-            "trainingReportIds": as_dict((previous or {}).get("trainingArtifacts")).get("trainingReportIds", []),
-            "candidatePolicyIds": as_dict((previous or {}).get("trainingArtifacts")).get("candidatePolicyIds", []),
-            "rewardDecisionId": as_dict((previous or {}).get("trainingArtifacts")).get("rewardDecisionId"),
+            "experimentCard": training_artifacts.get("experimentCard"),
+            "experimentCardPath": training_artifacts.get("experimentCardPath"),
+            "simulatorRunIds": training_artifacts.get("simulatorRunIds", []),
+            "trainingReportIds": training_artifacts.get("trainingReportIds", []),
+            "candidatePolicyIds": training_artifacts.get("candidatePolicyIds", []),
+            "rewardDecisionId": reward_decision_id,
+            "rewardDecisionArtifactPath": reward_decision_artifact_path,
             "latestTrainingLedger": latest_artifact_path(summary, "trainingLedger", repo_root),
         },
         "anomalies": anomalies,
@@ -1394,7 +1553,7 @@ def build_training_ledger(
             "policyUpdateIterations": metrics_fields.get("policyUpdateIterations", policy_updates),
             "trainingReportIds": metrics_fields.get("trainingReportIds", []),
             "candidatePolicyId": metrics_fields.get("candidatePolicyId"),
-            "rewardDecisionId": metrics_fields.get("rewardDecisionId"),
+            "rewardDecisionId": reward_decision_id,
             "anomalyCategories": [item.get("code") for item in anomalies],
         },
         "githubComment": "skipped_no_atomic_issue",

--- a/scripts/test_screeps_rl_control_loop_ledgers.py
+++ b/scripts/test_screeps_rl_control_loop_ledgers.py
@@ -568,6 +568,64 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
         self.assertNotIn("REWARD_DECISION_ID_NULL", anomaly_codes)
         self.assertIn("E1_GATE_STALE", anomaly_codes)
 
+    def test_training_ledger_rejects_stale_policy_reward_decision_for_new_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root, report_id = write_root_local2w_training_report_artifacts(root, trusted_gradient_update=True)
+            report_path = artifact_root / "rl-training" / f"{report_id}.json"
+            report_payload = read_json(report_path)
+            report_payload["anomalies"] = [{"severity": "P1", "code": "REWARD_DECISION_ID_NULL"}]
+            write_json(report_path, report_payload)
+
+            stale_reward_decision_id, stale_reward_decision_path = write_legacy_scorecard_reward_decision(
+                root,
+                artifact_root,
+                scorecard_id="rl-scorecard-old-candidate",
+                candidate_policy_id="old-candidate-policy",
+            )
+            write_json(
+                artifact_root / "rl-control-loop" / "20260604T000001Z-policy-advantage.json",
+                {
+                    "type": ledgers.POLICY_ADVANTAGE_TYPE,
+                    "createdAt": "2026-06-04T00:00:01Z",
+                    "candidatePolicyId": "old-candidate-policy",
+                    "baselinePolicyId": "incumbent",
+                    "onlineUtilityStatus": "UNPROVEN",
+                    "rewardDecisionId": stale_reward_decision_id,
+                    "rewardDecisionArtifactPath": stale_reward_decision_path,
+                    "scorecardId": "rl-scorecard-old-candidate",
+                    "metrics": {},
+                },
+            )
+            output = root / "out" / "training-ledger.json"
+
+            exit_code = ledgers.main(
+                [
+                    "training-ledger",
+                    "--repo-root",
+                    str(root),
+                    "--artifact-root",
+                    str(artifact_root),
+                    "--output",
+                    str(output),
+                    "--created-at",
+                    "2026-06-05T00:00:03Z",
+                    "--max-files-per-root",
+                    "4",
+                ],
+                stdout=io.StringIO(),
+                stderr=io.StringIO(),
+            )
+            payload = read_json(output)
+
+        anomaly_codes = {item["code"] for item in payload["anomalies"]}
+        self.assertEqual(exit_code, 0)
+        self.assertIsNone(payload["rewardDecisionId"])
+        self.assertIsNone(payload["rewardDecisionArtifactPath"])
+        self.assertIsNone(payload["trainingArtifacts"]["rewardDecisionId"])
+        self.assertIsNone(payload["metricsFields"]["rewardDecisionId"])
+        self.assertIn("REWARD_DECISION_ID_NULL", anomaly_codes)
+
     def test_policy_advantage_output_is_bounded_and_artifact_first(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_control_loop_ledgers.py
+++ b/scripts/test_screeps_rl_control_loop_ledgers.py
@@ -272,6 +272,42 @@ def write_root_local2w_training_report_artifacts(
     return artifact_root, LOCAL2W_REPORT_ID
 
 
+def local2w_next_policy_id() -> str:
+    return f"{LOCAL2W_REPORT_ID}.next-policy"
+
+
+def local2w_scorecard_id() -> str:
+    return f"rl-scorecard-{LOCAL2W_REPORT_ID}-187e0c0e1786"
+
+
+def write_legacy_scorecard_reward_decision(
+    root: Path,
+    artifact_root: Path,
+    *,
+    scorecard_id: str,
+    candidate_policy_id: str,
+) -> tuple[str, str]:
+    legacy_scorecard_id = (
+        f"{scorecard_id} (selected best), also rl-scorecard-...-7f7682d0397f, "
+        "rl-scorecard-...-ed14bbc41bea (3 total)"
+    )
+    reward_decision_id = ledgers.reward_decision_id_for_scorecard(legacy_scorecard_id, candidate_policy_id)
+    path = artifact_root / "rl-control-loop" / "reward-decisions" / f"{reward_decision_id}.json"
+    write_json(
+        path,
+        {
+            "type": ledgers.REWARD_DECISION_RECORD_TYPE,
+            "schemaVersion": ledgers.SCHEMA_VERSION,
+            "rewardDecisionId": reward_decision_id,
+            "scorecardId": legacy_scorecard_id,
+            "candidatePolicyId": candidate_policy_id,
+            "createdAt": "2026-06-05T00:00:00Z",
+            "updatedAt": "2026-06-05T00:00:00Z",
+        },
+    )
+    return reward_decision_id, path.relative_to(root).as_posix()
+
+
 class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
     def test_training_ledger_writes_artifact_when_stdout_is_closed(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -439,6 +475,99 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
         self.assertNotIn("TRAINING_LEDGER_MISSING", anomaly_codes)
         self.assertNotIn("activeRunner PID 1012127", payload["nextTrainingCapabilityAction"])
 
+    def test_training_ledger_propagates_existing_reward_decision_and_clears_null_anomaly(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root, report_id = write_root_local2w_training_report_artifacts(root, trusted_gradient_update=True)
+            candidate_policy_id = local2w_next_policy_id()
+            scorecard_id = local2w_scorecard_id()
+            reward_decision_id, reward_decision_path = write_legacy_scorecard_reward_decision(
+                root,
+                artifact_root,
+                scorecard_id=scorecard_id,
+                candidate_policy_id=candidate_policy_id,
+            )
+            write_json(
+                artifact_root / "rl-control-loop" / "20260605T000001Z-policy-advantage.json",
+                {
+                    "type": ledgers.POLICY_ADVANTAGE_TYPE,
+                    "createdAt": "2026-06-05T00:00:01Z",
+                    "candidatePolicyId": candidate_policy_id,
+                    "baselinePolicyId": "incumbent",
+                    "onlineUtilityStatus": "UNPROVEN",
+                    "rewardDecisionId": None,
+                    "rewardDecisionArtifactPath": None,
+                    "scorecardId": scorecard_id,
+                    "metrics": {},
+                },
+            )
+            write_json(
+                artifact_root / "rl-control-loop" / "20260605T000002Z-training-ledger.json",
+                {
+                    "type": ledgers.TRAINING_LEDGER_TYPE,
+                    "createdAt": "2026-06-05T00:00:02Z",
+                    "status": "RUN_VALIDATED",
+                    "trainingDidRun": True,
+                    "environmentExecution": {"started": 80, "completed": 80, "failed": 0, "successRate": 1.0},
+                    "iterationExecution": {
+                        "simulatorTicksRequested": 160000,
+                        "simulatorTicksRun": 160000,
+                        "episodesRun": 80,
+                        "candidateEvaluationIterations": 1,
+                        "policyUpdateIterations": 1,
+                    },
+                    "trainingArtifacts": {
+                        "trainingReportIds": [report_id],
+                        "candidatePolicyIds": [candidate_policy_id],
+                        "rewardDecisionId": None,
+                        "rewardDecisionArtifactPath": None,
+                    },
+                    "metricsFields": {
+                        "envCompleted": 80,
+                        "ticksRun": 160000,
+                        "episodes": 80,
+                        "policyUpdateIterations": 1,
+                        "trainingReportIds": [report_id],
+                        "candidatePolicyId": candidate_policy_id,
+                        "rewardDecisionId": None,
+                    },
+                    "anomalies": [
+                        {"severity": "P1", "code": "REWARD_DECISION_ID_NULL"},
+                        {"severity": "P2", "code": "E1_GATE_STALE"},
+                    ],
+                },
+            )
+            output = root / "out" / "training-ledger.json"
+
+            exit_code = ledgers.main(
+                [
+                    "training-ledger",
+                    "--repo-root",
+                    str(root),
+                    "--artifact-root",
+                    str(artifact_root),
+                    "--output",
+                    str(output),
+                    "--created-at",
+                    "2026-06-05T00:00:03Z",
+                    "--max-files-per-root",
+                    "4",
+                ],
+                stdout=io.StringIO(),
+                stderr=io.StringIO(),
+            )
+            payload = read_json(output)
+
+        anomaly_codes = {item["code"] for item in payload["anomalies"]}
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["rewardDecisionId"], reward_decision_id)
+        self.assertEqual(payload["rewardDecisionArtifactPath"], reward_decision_path)
+        self.assertEqual(payload["trainingArtifacts"]["rewardDecisionId"], reward_decision_id)
+        self.assertEqual(payload["trainingArtifacts"]["rewardDecisionArtifactPath"], reward_decision_path)
+        self.assertEqual(payload["metricsFields"]["rewardDecisionId"], reward_decision_id)
+        self.assertNotIn("REWARD_DECISION_ID_NULL", anomaly_codes)
+        self.assertIn("E1_GATE_STALE", anomaly_codes)
+
     def test_policy_advantage_output_is_bounded_and_artifact_first(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -549,6 +678,57 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
         self.assertEqual(payload["deployabilityStatus"], "BLOCKED")
         self.assertEqual(payload["metrics"]["territory"]["advantage"], "BLOCKED_NO_COMPUTE")
         self.assertEqual(payload["regressions"][0]["metric"], "territory")
+
+    def test_policy_advantage_consumes_existing_legacy_scorecard_reward_decision(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root, _report_id = write_root_local2w_training_report_artifacts(root, trusted_gradient_update=True)
+            candidate_policy_id = local2w_next_policy_id()
+            scorecard_id = local2w_scorecard_id()
+            reward_decision_id, reward_decision_path = write_legacy_scorecard_reward_decision(
+                root,
+                artifact_root,
+                scorecard_id=scorecard_id,
+                candidate_policy_id=candidate_policy_id,
+            )
+            write_json(
+                artifact_root / "rl-control-loop" / "20260605T000001Z-policy-advantage.json",
+                {
+                    "type": ledgers.POLICY_ADVANTAGE_TYPE,
+                    "createdAt": "2026-06-05T00:00:01Z",
+                    "candidatePolicyId": candidate_policy_id,
+                    "baselinePolicyId": "incumbent",
+                    "onlineUtilityStatus": "UNPROVEN",
+                    "rewardDecisionId": None,
+                    "rewardDecisionArtifactPath": None,
+                    "scorecardId": scorecard_id,
+                    "metrics": {},
+                },
+            )
+            output = root / "out" / "policy-advantage.json"
+
+            exit_code = ledgers.main(
+                [
+                    "policy-advantage",
+                    "--repo-root",
+                    str(root),
+                    "--artifact-root",
+                    str(artifact_root),
+                    "--output",
+                    str(output),
+                    "--created-at",
+                    "2026-06-05T00:00:02Z",
+                    "--max-files-per-root",
+                    "4",
+                ],
+                stdout=io.StringIO(),
+                stderr=io.StringIO(),
+            )
+            payload = read_json(output)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["rewardDecisionId"], reward_decision_id)
+        self.assertEqual(payload["rewardDecisionArtifactPath"], reward_decision_path)
 
     def test_policy_advantage_emits_reward_decision_for_trusted_selected_scorecard(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- Adds reward-decision provenance propagation from existing scorecard/reward artifacts into RL training and policy-advantage ledgers.
- Preserves explicit reward-decision fields when already present and suppresses stale `REWARD_DECISION_ID_NULL` anomalies once a matching decision is found.
- Adds regression coverage for training ledger and legacy scorecard consumption paths.

Fixes #1705

## Verification
- `python3 -m unittest scripts.test_screeps_rl_control_loop_ledgers`
- `python3 -m unittest scripts.test_validate_rl_reward_decisions`
- `python3 -m py_compile scripts/screeps_rl_control_loop_ledgers.py scripts/test_screeps_rl_control_loop_ledgers.py`
- `git diff --check`
- Controller verifier log: `/tmp/issue-1705-controller-verify.log` with `CONTROLLER_1705_VERIFY_PASS`.

## Issue closure gate
- [x] #1705: Codex-authored commit `9685c42a` propagates rewardDecisionId provenance and adds regression tests; controller verifier completed both unittest targets, py_compile, and diff-check with `CONTROLLER_1705_VERIFY_PASS`.

## Universal task Done gate
- [x] Task type: RL control-loop artifact producer code and tests.
- [x] Expected observable outcome / named deliverable: training and policy-advantage ledgers carry matching rewardDecisionId and rewardDecisionArtifactPath from existing reward-decision artifacts.
- [x] Non-goals / accepted substitutes: no paid Tencent compute, candidate promotion, or live policy rollout occurs in this PR.
- [x] Verification evidence required before Done: `/tmp/issue-1705-controller-verify.log` plus commit `9685c42a` test additions.
- [x] Project Evidence / Next action / Blocked by: Project item records verifier evidence; next action is exact-head PR gate; blocker field empty for code completion.
- [x] Post-merge/deploy/runtime proof: deterministic ledger unit tests prove artifact provenance propagation; next scheduler ledger run will emit refreshed artifacts from merged code.
- [x] Named deliverable proof: `scripts/screeps_rl_control_loop_ledgers.py` and `scripts/test_screeps_rl_control_loop_ledgers.py` in commit `9685c42a`.
