### PR TITLE
fix: preserve Tencent recurrence recovery evidence

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -3597,7 +3597,19 @@ def paid_failure_post_fix_validation_attempts(
         )
         if item is not None and paid_failure_post_fix_attempt_consumes_validation_slot(item):
             attempts.append(item)
+    attempts.sort(key=paid_failure_post_fix_validation_attempt_order_key, reverse=True)
     return attempts
+
+
+def paid_failure_post_fix_validation_attempt_order_key(
+    attempt: dict[str, Any],
+) -> tuple[bool, float, str]:
+    epoch = paid_failure_summary_item_epoch(attempt)
+    return (
+        epoch is not None,
+        epoch if epoch is not None else 0.0,
+        text_value(attempt.get("summaryPath")) or "",
+    )
 
 
 def paid_failure_post_fix_validation_attempt_from_summary(

--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -3278,14 +3278,30 @@ def paid_failure_post_fix_validation_recovery_eligibility(
         result["reason"] = "a post-fix validation already completed"
         return result
     if recovery_class is None:
+        recovery_attempt_count = sum(
+            1 for attempt in prior_attempts if attempt.get("recoveryAttempt") is True
+        )
+        if recovery_attempt_count > 0:
+            result["reason"] = (
+                "post-fix validation recovery was already attempted"
+                if recovery_attempt_count == 1
+                else f"post-fix validation recovery was already attempted {recovery_attempt_count} times"
+            )
+            latest_recovery = next(
+                (attempt for attempt in prior_attempts if attempt.get("recoveryAttempt") is True),
+                None,
+            )
+            partial_progress = dict_value(
+                latest_recovery.get("partialSimulatorProgress") if latest_recovery else None
+            )
+            if partial_progress is not None:
+                result["latestRecoveryPartialSimulatorProgress"] = partial_progress
+            return result
         if len(prior_attempts) not in (1, 2):
             result["reason"] = (
                 "recovery requires one prior consumed post-fix validation attempt, or one timed-out "
                 "recovery attempt after a no-compute admission failure"
             )
-            return result
-        if any(attempt.get("recoveryAttempt") is True for attempt in prior_attempts):
-            result["reason"] = "post-fix validation recovery was already attempted"
             return result
         if paid_failure_post_fix_attempt_reached_compute_or_training(prior_attempt):
             result["reason"] = (
@@ -3628,6 +3644,13 @@ def paid_failure_post_fix_validation_attempt_from_summary(
     environments_run = scale_gates.non_negative_int(execution.get("environmentsRun"))
     remote_failure = dict_value(path_value(summary, "outputs", "remoteTrainingFailure"))
     remote_failure_class = text_value(remote_failure.get("failureClass")) if remote_failure else None
+    partial_progress = (
+        paid_failure_post_fix_partial_simulator_progress_summary(
+            dict_value(remote_failure.get("partialSimulatorProgress"))
+        )
+        if remote_failure
+        else None
+    )
     training_report = dict_value(path_value(summary, "outputs", "trainingReport"))
     execution_timeouts = dict_value(inputs.get("executionTimeouts")) or {}
     planned_batch_scale = dict_value(inputs.get("plannedBatchScale"))
@@ -3669,10 +3692,58 @@ def paid_failure_post_fix_validation_attempt_from_summary(
         "environmentsRun": environments_run,
         "remoteTrainingFailurePresent": remote_failure is not None,
         "remoteTrainingFailureClass": remote_failure_class,
+        "partialSimulatorProgress": partial_progress,
         "validationPlan": validation_plan,
     }
     attempt["validationSlotConsumed"] = paid_failure_post_fix_attempt_consumes_validation_slot(attempt)
     return attempt
+
+
+def paid_failure_post_fix_partial_simulator_progress_summary(
+    progress: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if progress is None:
+        return None
+    summary: dict[str, Any] = {}
+    for key in (
+        "runSummaryCount",
+        "completedEnvironmentRows",
+        "successfulEnvironmentRows",
+        "failedEnvironmentRows",
+        "ticksRun",
+    ):
+        value = scale_gates.non_negative_int(progress.get(key))
+        if value is not None:
+            summary[key] = value
+    wall_clock_seconds = numeric_value(progress.get("wallClockSeconds"))
+    if wall_clock_seconds is not None:
+        summary["wallClockSeconds"] = round(wall_clock_seconds, 3)
+
+    notable_runs: list[dict[str, Any]] = []
+    run_summaries = progress.get("runSummaries")
+    if isinstance(run_summaries, list):
+        for run_summary in run_summaries:
+            run = dict_value(run_summary)
+            if run is None:
+                continue
+            failed = scale_gates.non_negative_int(run.get("failed")) or 0
+            if run.get("ok") is True and failed == 0:
+                continue
+            notable_runs.append(
+                {
+                    "runId": text_value(run.get("runId")),
+                    "ok": run.get("ok") is True,
+                    "totalEnvironments": scale_gates.non_negative_int(run.get("totalEnvironments")),
+                    "successful": scale_gates.non_negative_int(run.get("successful")),
+                    "failed": failed,
+                    "ticksRun": scale_gates.non_negative_int(run.get("ticksRun")),
+                }
+            )
+            if len(notable_runs) >= 5:
+                break
+    if notable_runs:
+        summary["notableRunSummaries"] = notable_runs
+    return summary or None
 
 
 def paid_failure_post_fix_execution_context_complete(
@@ -3836,6 +3907,13 @@ def paid_failure_recurrence_next_action(
                 "validation signature; only launch a recovery with that signature"
             )
         run_id = text_value(prior.get("runId")) or "the prior post-fix validation"
+        recovery_reason = text_value(recovery.get("reason"))
+        if recovery_reason is not None:
+            return (
+                f"{base}; post-fix validation was already attempted in {run_id} without a completed report; "
+                f"{recovery_reason}; inspect collected partial diagnostics and do not launch another "
+                "paid rerun until a new bounded validation plan is selected"
+            )
         return (
             f"{base}; post-fix validation was already attempted in {run_id} without a completed report, "
             "so inspect that run and ship a local code/diagnostic fix before any further paid rerun"

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -4714,6 +4714,110 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertIn("recovery was already attempted", recovery["reason"])
         self.assertFalse(summary["execution"]["computeAttempted"])
 
+    def test_paid_failure_recurrence_guard_explains_repeated_timeout_recovery_with_partial_progress(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            write_post_fix_validation_pre_scale_admission_failure_summary(
+                artifact_root,
+                "tencent-postfix-room-busy-v1",
+            )
+            write_post_fix_validation_recovery_remote_timeout_summary(
+                artifact_root,
+                "postfix-room-busy-validation-timeout",
+            )
+            latest_recovery_path = write_post_fix_validation_recovery_remote_timeout_summary(
+                artifact_root,
+                "postfix-validation-run-timeout-2",
+            )
+            latest_recovery = json.loads(latest_recovery_path.read_text(encoding="utf-8"))
+            latest_recovery["finishedAt"] = "2026-06-02T00:16:27Z"
+            latest_recovery["execution"]["environmentsRun"] = 20
+            latest_recovery["outputs"]["remoteTrainingFailure"]["partialSimulatorProgress"] = {
+                "runSummaryCount": 4,
+                "completedEnvironmentRows": 20,
+                "successfulEnvironmentRows": 19,
+                "failedEnvironmentRows": 1,
+                "ticksRun": 38000,
+                "wallClockSeconds": 2941.509,
+                "runSummaries": [
+                    {
+                        "runId": "postfix-validation-run-timeout-2-r04",
+                        "ok": False,
+                        "totalEnvironments": 5,
+                        "successful": 4,
+                        "failed": 1,
+                        "ticksRun": 8000,
+                    }
+                ],
+            }
+            latest_recovery_path.write_text(json.dumps(latest_recovery), encoding="utf-8")
+            touched_time = latest_recovery_path.stat().st_mtime + 10
+            os.utime(latest_recovery_path, (touched_time, touched_time))
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                str(runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS),
+                "--workers",
+                "5",
+                "--scale-environments",
+                "5",
+                "--repetitions",
+                "20",
+                "--training-timeout-seconds",
+                "7200",
+                "--postfix-validation-signature",
+                runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertEqual(events, [])
+        self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+        self.assertTrue(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
+        self.assertEqual(guard["postFixValidation"]["priorAttemptCount"], 3)
+        prior_attempt = guard["postFixValidation"]["priorAttempt"]
+        self.assertEqual(prior_attempt["runId"], "postfix-validation-run-timeout-2")
+        self.assertEqual(prior_attempt["partialSimulatorProgress"]["successfulEnvironmentRows"], 19)
+        self.assertEqual(prior_attempt["partialSimulatorProgress"]["failedEnvironmentRows"], 1)
+        self.assertEqual(
+            prior_attempt["partialSimulatorProgress"]["notableRunSummaries"][0]["runId"],
+            "postfix-validation-run-timeout-2-r04",
+        )
+        recovery = guard["postFixValidation"]["recoveryEligibility"]
+        self.assertFalse(recovery["eligible"])
+        self.assertIn("already attempted 2 times", recovery["reason"])
+        self.assertEqual(
+            recovery["latestRecoveryPartialSimulatorProgress"]["completedEnvironmentRows"],
+            20,
+        )
+        self.assertIn("already attempted 2 times", guard["nextAction"])
+        self.assertIn("new bounded validation plan", guard["nextAction"])
+        self.assertFalse(summary["execution"]["computeAttempted"])
+
     def test_paid_failure_recurrence_guard_explains_timeout_recovery_when_signature_missing(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             artifact_root = Path(temp_dir) / "batch-runs"

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -4586,6 +4586,9 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             pre_scale_attempt = json.loads(pre_scale_attempt_path.read_text(encoding="utf-8"))
             timeout_attempt = json.loads(timeout_attempt_path.read_text(encoding="utf-8"))
             self.assertGreater(timeout_attempt["finishedAt"], pre_scale_attempt["finishedAt"])
+            same_mtime = 1_779_999_999
+            os.utime(pre_scale_attempt_path, (same_mtime, same_mtime))
+            os.utime(timeout_attempt_path, (same_mtime, same_mtime))
             args = runner.parse_cli_args([
                 "run-single",
                 "--run-id",
@@ -4725,11 +4728,11 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             )
             write_post_fix_validation_recovery_remote_timeout_summary(
                 artifact_root,
-                "postfix-room-busy-validation-timeout",
+                "z-postfix-room-busy-validation-timeout",
             )
             latest_recovery_path = write_post_fix_validation_recovery_remote_timeout_summary(
                 artifact_root,
-                "postfix-validation-run-timeout-2",
+                "a-postfix-validation-run-timeout-2",
             )
             latest_recovery = json.loads(latest_recovery_path.read_text(encoding="utf-8"))
             latest_recovery["finishedAt"] = "2026-06-02T00:16:27Z"
@@ -4743,7 +4746,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 "wallClockSeconds": 2941.509,
                 "runSummaries": [
                     {
-                        "runId": "postfix-validation-run-timeout-2-r04",
+                        "runId": "a-postfix-validation-run-timeout-2-r04",
                         "ok": False,
                         "totalEnvironments": 5,
                         "successful": 4,
@@ -4753,8 +4756,9 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 ],
             }
             latest_recovery_path.write_text(json.dumps(latest_recovery), encoding="utf-8")
-            touched_time = latest_recovery_path.stat().st_mtime + 10
-            os.utime(latest_recovery_path, (touched_time, touched_time))
+            same_mtime = 1_779_999_999
+            for summary_path in artifact_root.glob("*/controller-summary.json"):
+                os.utime(summary_path, (same_mtime, same_mtime))
             args = runner.parse_cli_args([
                 "run-single",
                 "--run-id",
@@ -4800,12 +4804,12 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
         self.assertEqual(guard["postFixValidation"]["priorAttemptCount"], 3)
         prior_attempt = guard["postFixValidation"]["priorAttempt"]
-        self.assertEqual(prior_attempt["runId"], "postfix-validation-run-timeout-2")
+        self.assertEqual(prior_attempt["runId"], "a-postfix-validation-run-timeout-2")
         self.assertEqual(prior_attempt["partialSimulatorProgress"]["successfulEnvironmentRows"], 19)
         self.assertEqual(prior_attempt["partialSimulatorProgress"]["failedEnvironmentRows"], 1)
         self.assertEqual(
             prior_attempt["partialSimulatorProgress"]["notableRunSummaries"][0]["runId"],
-            "postfix-validation-run-timeout-2-r04",
+            "a-postfix-validation-run-timeout-2-r04",
         )
         recovery = guard["postFixValidation"]["recoveryEligibility"]
         self.assertFalse(recovery["eligible"])


### PR DESCRIPTION
## Summary
- Classifies the Tencent room-busy recurrence guard evidence as historical rather than fresh post-fix room-busy failure.
- Preserves bounded `partialSimulatorProgress` from consumed post-fix validation recoveries so the next ledger exposes the actual timeout shape.
- Adds regression coverage for repeated recovery attempts with partial simulator progress and no paid compute attempt.

Fixes #1706

## Verification
- `python3 -m unittest scripts.test_screeps_tencent_batch_rl_runner`
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `git diff --check`
- Controller verifier log: `/tmp/issue-1706-controller-verify.log` with `CONTROLLER_1706_VERIFY_PASS`.

## Safety / follow-up
- No paid Tencent compute was launched, no ASG desired capacity changed, and the recurrence/billing guard remains active.
- Follow-up issue 1710 tracks the newly identified private-server HTTP readiness timeout lane.

## Issue closure gate
- [x] #1706: Codex-authored commit `b748f977` classifies the room-busy recurrence as historical, preserves partial simulator progress evidence, adds regression coverage, and controller verification passed with `CONTROLLER_1706_VERIFY_PASS`.

## Universal task Done gate
- [x] Task type: RL Tencent guard classification code and regression tests.
- [x] Expected observable outcome / named deliverable: Tencent batch admission summaries include partial simulator progress for consumed post-fix recoveries and explain repeated recovery attempts.
- [x] Non-goals / accepted substitutes: no paid compute, no ASG scaling, and no recurrence-guard bypass occurs in this PR.
- [x] Verification evidence required before Done: `/tmp/issue-1706-controller-verify.log` plus commit `b748f977` and `/tmp/issue-1706-codex-result.md`.
- [x] Project Evidence / Next action / Blocked by: Project item records held classification; next action is follow-up issue 1710 for HTTP readiness; blocker field names paid guard safety.
- [x] Post-merge/deploy/runtime proof: deterministic runner tests prove no-paid guard reporting behavior; next ledger execution will surface preserved partial simulator progress from merged code.
- [x] Named deliverable proof: `scripts/screeps_tencent_batch_rl_runner.py` and `scripts/test_screeps_tencent_batch_rl_runner.py` in commit `b748f977`.
