### PR TITLE
fix: classify Tencent HTTP readiness timeouts

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -208,6 +208,12 @@ REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RE = re.compile(
     r"(?:place-spawn room busy after \d+ attempt\(s\)|\bplace_spawn_room_busy\b|room-busy placement lock)",
     re.IGNORECASE,
 )
+REMOTE_PRIVATE_SERVER_HTTP_READINESS_TIMEOUT_RE = re.compile(
+    r"(?:private[- ]server did not become HTTP[- ]ready after \d+s|"
+    r"private[- ]server HTTP[- ]readiness (?:timeout|timed out)|"
+    r"HTTP[- ]readiness timeout)",
+    re.IGNORECASE,
+)
 REMOTE_NETWORK_RE = re.compile(
     r"(?:connection refused|request canceled|too many requests|toomanyrequests|network .*timed? out|"
     r"net/http|Client\.Timeout)",
@@ -2578,6 +2584,17 @@ def remote_training_failure_diagnostics(
         process_failure_class=process_failure_class,
         controller_timed_out=controller_timed_out,
     )
+    partial_progress = remote_training_partial_simulator_progress(artifact_dir, run_id)
+    timeout_reason = None
+    if failure_class == "remote_training_timeout":
+        timeout_reason = remote_training_failure_timeout_reason(
+            files,
+            controller_timed_out=controller_timed_out,
+        )
+    if timeout_reason is None:
+        timeout_reason = partial_simulator_progress_timeout_reason(partial_progress)
+    if timeout_reason is not None and failure_class in {"remote_process_failed", "remote_training_timeout"}:
+        failure_class = "remote_training_timeout"
     payload: dict[str, Any] = {
         "status": "failed_exit",
         "failureClass": failure_class,
@@ -2586,15 +2603,16 @@ def remote_training_failure_diagnostics(
         "artifactDir": str(remote_dir),
         "diagnostics": files,
     }
+    if timeout_reason is not None and failure_class == "remote_training_timeout":
+        payload["timeoutReason"] = timeout_reason
     if controller_timed_out:
         payload["controllerTimedOut"] = True
-    next_action = remote_training_failure_next_action(failure_class)
+    next_action = remote_training_failure_next_action(failure_class, timeout_reason)
     if next_action is not None:
         payload["nextAction"] = next_action
     resource_guard = remote_training_resource_guard_summary(artifact_dir, run_id)
     if resource_guard is not None:
         payload["resourceGuard"] = resource_guard
-    partial_progress = remote_training_partial_simulator_progress(artifact_dir, run_id)
     if partial_progress is not None:
         payload["partialSimulatorProgress"] = partial_progress
     if collection_error:
@@ -2652,6 +2670,9 @@ def remote_training_partial_simulator_progress(artifact_dir: Path, run_id: str |
             "ticksRun": ticks_run,
             "wallClockSeconds": round(wall_clock_seconds, 3),
         }
+        failure = simulator_run_summary_failure_summary(payload)
+        if failure is not None:
+            summary["failure"] = failure
         summaries.append(summary)
         totals["completedEnvironmentRows"] += completed_environment_rows
         totals["successfulEnvironmentRows"] += successful
@@ -2671,6 +2692,66 @@ def remote_training_partial_simulator_progress(artifact_dir: Path, run_id: str |
     }
 
 
+def simulator_run_summary_failure_summary(payload: dict[str, Any]) -> dict[str, Any] | None:
+    ok = payload.get("ok") is True
+    failed = scale_gates.non_negative_int(payload.get("failed")) or 0
+    if ok and failed == 0:
+        return None
+    texts = simulator_run_summary_failure_texts(payload)
+    diagnostic_text = "\n".join(texts)
+    timeout_reason = remote_training_timeout_reason_from_text(diagnostic_text)
+    if timeout_reason == "private_server_http_readiness":
+        return {
+            "classification": "private_server_http_readiness_timeout",
+            "timeoutReason": timeout_reason,
+            "diagnosticExcerpt": diagnostic_tail(diagnostic_text, 600),
+        }
+    failure_class = text_value(payload.get("failureClass"))
+    if failure_class is not None:
+        return {
+            "classification": failure_class,
+            "diagnosticExcerpt": diagnostic_tail(diagnostic_text or failure_class, 600),
+        }
+    if REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RE.search(diagnostic_text):
+        return {
+            "classification": PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            "diagnosticExcerpt": diagnostic_tail(diagnostic_text, 600),
+        }
+    if diagnostic_text:
+        return {
+            "classification": "simulator_run_failed",
+            "diagnosticExcerpt": diagnostic_tail(diagnostic_text, 600),
+        }
+    return None
+
+
+def simulator_run_summary_failure_texts(payload: dict[str, Any]) -> list[str]:
+    texts: list[str] = []
+
+    def add_text(value: Any) -> None:
+        if isinstance(value, str) and value:
+            texts.append(value)
+
+    add_text(payload.get("failureClass"))
+    add_text(payload.get("error"))
+    errors = payload.get("errors")
+    if isinstance(errors, list):
+        for error in errors:
+            add_text(error)
+    variants = payload.get("variants")
+    if isinstance(variants, list):
+        for variant in variants:
+            if not isinstance(variant, dict):
+                continue
+            add_text(variant.get("failureClass"))
+            add_text(variant.get("error"))
+            variant_errors = variant.get("errors")
+            if isinstance(variant_errors, list):
+                for error in variant_errors:
+                    add_text(error)
+    return texts
+
+
 def classify_remote_training_failure(
     files: Mapping[str, dict[str, Any]],
     *,
@@ -2678,15 +2759,15 @@ def classify_remote_training_failure(
     process_failure_class: str | None = None,
     controller_timed_out: bool = False,
 ) -> str:
-    diagnostic_text = "\n".join(
-        tail for entry in files.values() for tail in [entry.get("tail")] if isinstance(tail, str)
-    )
+    diagnostic_text = remote_training_diagnostic_text(files)
     if REMOTE_RESOURCE_GUARD_RE.search(diagnostic_text):
         return "simulator_resource_guard_rejected"
     if REMOTE_SIMULATOR_PLACE_SPAWN_ROOM_BUSY_RE.search(diagnostic_text):
         return "simulator_place_spawn_room_busy"
     if process_failure_class in {"network_unreachable", "host_key_self_healing_failed", "host_key_mismatch"}:
         return process_failure_class
+    if remote_training_timeout_reason_from_text(diagnostic_text) is not None:
+        return "remote_training_timeout"
     simulator_setup_text = "\n".join(
         tail
         for filename, entry in files.items()
@@ -2718,7 +2799,30 @@ def classify_remote_training_failure(
     return "remote_process_failed"
 
 
-def remote_training_failure_next_action(failure_class: str) -> str | None:
+def remote_training_diagnostic_text(files: Mapping[str, dict[str, Any]]) -> str:
+    return "\n".join(
+        tail for entry in files.values() for tail in [entry.get("tail")] if isinstance(tail, str)
+    )
+
+
+def remote_training_timeout_reason_from_text(text: str) -> str | None:
+    if REMOTE_PRIVATE_SERVER_HTTP_READINESS_TIMEOUT_RE.search(text):
+        return "private_server_http_readiness"
+    return None
+
+
+def remote_training_failure_timeout_reason(
+    files: Mapping[str, dict[str, Any]],
+    *,
+    controller_timed_out: bool = False,
+) -> str | None:
+    reason = remote_training_timeout_reason_from_text(remote_training_diagnostic_text(files))
+    if reason is not None:
+        return reason
+    return "controller_timeout" if controller_timed_out else None
+
+
+def remote_training_failure_next_action(failure_class: str, timeout_reason: str | None = None) -> str | None:
     if failure_class == "simulator_setup_retryable":
         return (
             "rerun the same bounded validation after Docker image pull/setup flakiness settles; "
@@ -2727,6 +2831,11 @@ def remote_training_failure_next_action(failure_class: str) -> str | None:
     if failure_class == "network_unreachable":
         return "rerun after the worker SSH/network path is reachable"
     if failure_class == "remote_training_timeout":
+        if timeout_reason == "private_server_http_readiness":
+            return (
+                "inspect failed simulator private-server HTTP readiness diagnostics, then rerun "
+                "validation in smaller chunks or with an explicitly sized training timeout"
+            )
         return (
             "inspect collected partial diagnostics, then rerun validation in smaller chunks "
             "or with an explicitly sized training timeout"
@@ -3296,6 +3405,11 @@ def paid_failure_post_fix_validation_recovery_eligibility(
             )
             if partial_progress is not None:
                 result["latestRecoveryPartialSimulatorProgress"] = partial_progress
+            timeout_reason = text_value(
+                latest_recovery.get("remoteTrainingTimeoutReason") if latest_recovery else None
+            )
+            if timeout_reason is not None:
+                result["latestRecoveryTimeoutReason"] = timeout_reason
             return result
         if len(prior_attempts) not in (1, 2):
             result["reason"] = (
@@ -3655,13 +3769,21 @@ def paid_failure_post_fix_validation_attempt_from_summary(
         preflight_only = inputs.get("preflightOnly") is True
     environments_run = scale_gates.non_negative_int(execution.get("environmentsRun"))
     remote_failure = dict_value(path_value(summary, "outputs", "remoteTrainingFailure"))
-    remote_failure_class = text_value(remote_failure.get("failureClass")) if remote_failure else None
-    partial_progress = (
-        paid_failure_post_fix_partial_simulator_progress_summary(
-            dict_value(remote_failure.get("partialSimulatorProgress"))
-        )
-        if remote_failure
-        else None
+    raw_partial_progress = (
+        dict_value(remote_failure.get("partialSimulatorProgress")) if remote_failure is not None else None
+    )
+    artifact_partial_progress = remote_training_partial_simulator_progress(summary_path.parent, run_id)
+    partial_progress = paid_failure_post_fix_partial_simulator_progress_summary(
+        artifact_partial_progress or raw_partial_progress
+    )
+    remote_timeout_reason = paid_failure_post_fix_remote_training_timeout_reason(
+        summary,
+        remote_failure,
+        artifact_partial_progress or raw_partial_progress,
+    )
+    remote_failure_class = paid_failure_post_fix_remote_training_failure_class(
+        remote_failure,
+        remote_timeout_reason,
     )
     training_report = dict_value(path_value(summary, "outputs", "trainingReport"))
     execution_timeouts = dict_value(inputs.get("executionTimeouts")) or {}
@@ -3704,11 +3826,70 @@ def paid_failure_post_fix_validation_attempt_from_summary(
         "environmentsRun": environments_run,
         "remoteTrainingFailurePresent": remote_failure is not None,
         "remoteTrainingFailureClass": remote_failure_class,
+        "remoteTrainingTimeoutReason": remote_timeout_reason,
         "partialSimulatorProgress": partial_progress,
         "validationPlan": validation_plan,
     }
     attempt["validationSlotConsumed"] = paid_failure_post_fix_attempt_consumes_validation_slot(attempt)
     return attempt
+
+
+def paid_failure_post_fix_remote_training_timeout_reason(
+    summary: dict[str, Any],
+    remote_failure: dict[str, Any] | None,
+    partial_progress: dict[str, Any] | None,
+) -> str | None:
+    if remote_failure is not None:
+        timeout_reason = text_value(remote_failure.get("timeoutReason"))
+        if timeout_reason is not None:
+            return timeout_reason
+        for text in iter_failure_signature_texts(remote_failure):
+            reason = remote_training_timeout_reason_from_text(text)
+            if reason is not None:
+                return reason
+    reason = partial_simulator_progress_timeout_reason(partial_progress)
+    if reason is not None:
+        return reason
+    for text in iter_failure_signature_texts(summary):
+        reason = remote_training_timeout_reason_from_text(text)
+        if reason is not None:
+            return reason
+    return None
+
+
+def paid_failure_post_fix_remote_training_failure_class(
+    remote_failure: dict[str, Any] | None,
+    timeout_reason: str | None,
+) -> str | None:
+    failure_class = text_value(remote_failure.get("failureClass")) if remote_failure is not None else None
+    if timeout_reason is not None and failure_class in {None, "remote_process_failed"}:
+        return "remote_training_timeout"
+    return failure_class
+
+
+def partial_simulator_progress_timeout_reason(progress: dict[str, Any] | None) -> str | None:
+    if progress is None:
+        return None
+    run_summaries = progress.get("runSummaries")
+    if not isinstance(run_summaries, list):
+        return None
+    for run_summary in run_summaries:
+        run = dict_value(run_summary)
+        if run is None:
+            continue
+        failure = dict_value(run.get("failure"))
+        if failure is not None:
+            timeout_reason = text_value(failure.get("timeoutReason"))
+            if timeout_reason is not None:
+                return timeout_reason
+            if text_value(failure.get("classification")) == "private_server_http_readiness_timeout":
+                return "private_server_http_readiness"
+            excerpt = text_value(failure.get("diagnosticExcerpt"))
+            if excerpt is not None:
+                reason = remote_training_timeout_reason_from_text(excerpt)
+                if reason is not None:
+                    return reason
+    return None
 
 
 def paid_failure_post_fix_partial_simulator_progress_summary(
@@ -3741,16 +3922,18 @@ def paid_failure_post_fix_partial_simulator_progress_summary(
             failed = scale_gates.non_negative_int(run.get("failed")) or 0
             if run.get("ok") is True and failed == 0:
                 continue
-            notable_runs.append(
-                {
-                    "runId": text_value(run.get("runId")),
-                    "ok": run.get("ok") is True,
-                    "totalEnvironments": scale_gates.non_negative_int(run.get("totalEnvironments")),
-                    "successful": scale_gates.non_negative_int(run.get("successful")),
-                    "failed": failed,
-                    "ticksRun": scale_gates.non_negative_int(run.get("ticksRun")),
-                }
-            )
+            notable_run: dict[str, Any] = {
+                "runId": text_value(run.get("runId")),
+                "ok": run.get("ok") is True,
+                "totalEnvironments": scale_gates.non_negative_int(run.get("totalEnvironments")),
+                "successful": scale_gates.non_negative_int(run.get("successful")),
+                "failed": failed,
+                "ticksRun": scale_gates.non_negative_int(run.get("ticksRun")),
+            }
+            failure = dict_value(run.get("failure"))
+            if failure is not None:
+                notable_run["failure"] = copy.deepcopy(failure)
+            notable_runs.append(notable_run)
             if len(notable_runs) >= 5:
                 break
     if notable_runs:

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -951,6 +951,58 @@ def write_post_fix_validation_recovery_remote_timeout_summary(artifact_root: Pat
     return summary_path
 
 
+def write_post_fix_validation_readiness_timeout_summary(
+    artifact_root: Path,
+    run_id: str,
+    *,
+    recovery_attempt: bool = False,
+) -> Path:
+    summary_path = write_post_fix_validation_remote_timeout_summary(artifact_root, run_id)
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    remote_failure = summary["outputs"]["remoteTrainingFailure"]
+    remote_failure["failureClass"] = "remote_process_failed"
+    remote_failure["returncode"] = 2
+    remote_failure.pop("controllerTimedOut", None)
+    remote_failure["diagnostics"]["training-stderr.log"]["tail"] = (
+        "remote training failed after partial simulator progress; inspect simulator run summaries"
+    )
+    summary["outputs"]["error"] = "BatchRunError: remote_training failed with exit 2"
+    summary["steps"][0]["returncode"] = 2
+    summary["steps"][0]["stderr_tail"] = remote_failure["diagnostics"]["training-stderr.log"]["tail"]
+    summary["execution"]["environmentsRun"] = 20
+    if recovery_attempt:
+        launch_guard = summary["outputs"]["launchGuard"]
+        launch_guard["status"] = runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_RECOVERY_ALLOWED_STATUS
+        launch_guard["postFixValidation"]["status"] = "recovery_allowed"
+    simulator_run = summary_path.parent / "remote" / "simulator-artifacts" / f"{run_id}-r04"
+    simulator_run.mkdir(parents=True)
+    readiness_error = "private server did not become HTTP-ready after 900s: <urlopen error [Errno 111] Connection refused>"
+    (simulator_run / "run_summary.json").write_text(
+        json.dumps(
+            {
+                "runId": f"{run_id}-r04",
+                "ok": False,
+                "successful": 4,
+                "failed": 1,
+                "total_environments": 5,
+                "total_ticks": 8000,
+                "wallClockSeconds": 913.193,
+                "error": readiness_error,
+                "variants": [
+                    {
+                        "ok": False,
+                        "error": readiness_error,
+                        "errors": [readiness_error],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    summary_path.write_text(json.dumps(summary), encoding="utf-8")
+    return summary_path
+
+
 def write_invalid_run_id_validation_admission_failure_summary(artifact_root: Path, run_id: str) -> Path:
     summary_path = write_post_fix_validation_pre_scale_admission_failure_summary(
         artifact_root,
@@ -4822,6 +4874,93 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertIn("new bounded validation plan", guard["nextAction"])
         self.assertFalse(summary["execution"]["computeAttempted"])
 
+    def test_paid_failure_recurrence_guard_classifies_readiness_timeout_recovery_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            write_post_fix_validation_pre_scale_admission_failure_summary(
+                artifact_root,
+                "tencent-postfix-room-busy-v1",
+            )
+            write_post_fix_validation_recovery_remote_timeout_summary(
+                artifact_root,
+                "postfix-room-busy-validation-timeout",
+            )
+            latest_recovery_path = write_post_fix_validation_readiness_timeout_summary(
+                artifact_root,
+                "postfix-validation-run-readiness-timeout",
+                recovery_attempt=True,
+            )
+            touched_time = latest_recovery_path.stat().st_mtime + 10
+            os.utime(latest_recovery_path, (touched_time, touched_time))
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                str(runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS),
+                "--workers",
+                "5",
+                "--scale-environments",
+                "5",
+                "--repetitions",
+                "20",
+                "--training-timeout-seconds",
+                "7200",
+                "--postfix-validation-signature",
+                runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+
+        self.assertEqual(events, [])
+        self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+        self.assertTrue(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
+        self.assertEqual(guard["postFixValidation"]["priorAttemptCount"], 3)
+        prior_attempt = guard["postFixValidation"]["priorAttempt"]
+        self.assertEqual(prior_attempt["runId"], "postfix-validation-run-readiness-timeout")
+        self.assertEqual(prior_attempt["remoteTrainingFailureClass"], "remote_training_timeout")
+        self.assertEqual(prior_attempt["remoteTrainingTimeoutReason"], "private_server_http_readiness")
+        progress = prior_attempt["partialSimulatorProgress"]
+        self.assertEqual(progress["completedEnvironmentRows"], 5)
+        self.assertEqual(progress["successfulEnvironmentRows"], 4)
+        self.assertEqual(progress["failedEnvironmentRows"], 1)
+        notable = progress["notableRunSummaries"][0]
+        self.assertEqual(notable["runId"], "postfix-validation-run-readiness-timeout-r04")
+        self.assertEqual(notable["failure"]["classification"], "private_server_http_readiness_timeout")
+        self.assertEqual(notable["failure"]["timeoutReason"], "private_server_http_readiness")
+        recovery = guard["postFixValidation"]["recoveryEligibility"]
+        self.assertFalse(recovery["eligible"])
+        self.assertEqual(recovery["latestRecoveryTimeoutReason"], "private_server_http_readiness")
+        self.assertEqual(
+            recovery["latestRecoveryPartialSimulatorProgress"]["notableRunSummaries"][0]["failure"]["classification"],
+            "private_server_http_readiness_timeout",
+        )
+        self.assertIn("already attempted 2 times", recovery["reason"])
+        self.assertIn("new bounded validation plan", guard["nextAction"])
+        self.assertFalse(summary["execution"]["computeAttempted"])
+
     def test_paid_failure_recurrence_guard_explains_timeout_recovery_when_signature_missing(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             artifact_root = Path(temp_dir) / "batch-runs"
@@ -6340,6 +6479,52 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertFalse(failure["retryable"])
         self.assertNotIn("controllerTimedOut", failure)
         self.assertNotIn("nextAction", failure)
+
+    def test_remote_training_diagnostics_classifies_private_server_http_readiness_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            remote = root / "remote"
+            simulator_run = remote / "simulator-artifacts" / "run-test-r04"
+            simulator_run.mkdir(parents=True)
+            readiness_error = (
+                "private server did not become HTTP-ready after 900s: "
+                "<urlopen error [Errno 111] Connection refused>"
+            )
+            (remote / "training-stderr.log").write_text(
+                "remote training failed after partial simulator progress\n",
+                encoding="utf-8",
+            )
+            (simulator_run / "run_summary.json").write_text(
+                json.dumps(
+                    {
+                        "runId": "run-test-r04",
+                        "ok": False,
+                        "successful": 4,
+                        "failed": 1,
+                        "total_environments": 5,
+                        "total_ticks": 8000,
+                        "wallClockSeconds": 913.193,
+                        "error": readiness_error,
+                        "variants": [{"ok": False, "errors": [readiness_error]}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            failure = runner.remote_training_failure_diagnostics(root, 2, run_id="run-test")
+
+        self.assertEqual(failure["failureClass"], "remote_training_timeout")
+        self.assertEqual(failure["timeoutReason"], "private_server_http_readiness")
+        self.assertFalse(failure["retryable"])
+        self.assertNotIn("controllerTimedOut", failure)
+        self.assertIn("HTTP readiness", failure["nextAction"])
+        progress = failure["partialSimulatorProgress"]
+        self.assertEqual(progress["completedEnvironmentRows"], 5)
+        self.assertEqual(progress["successfulEnvironmentRows"], 4)
+        self.assertEqual(progress["failedEnvironmentRows"], 1)
+        failed_run = progress["runSummaries"][0]
+        self.assertEqual(failed_run["failure"]["classification"], "private_server_http_readiness_timeout")
+        self.assertEqual(failed_run["failure"]["timeoutReason"], "private_server_http_readiness")
 
     def test_run_remote_training_classifies_ssh_server_timeout(self) -> None:
         args = controller_args()


### PR DESCRIPTION
## Summary
- Classifies Tencent private-server HTTP readiness timeouts separately from historical `simulator_place_spawn_room_busy` recurrence.
- Adds no-paid deterministic tests for consumed recovery evidence with partial simulator progress and readiness-timeout diagnostics.
- Keeps paid compute guarded: this PR does not bypass the recurrence guard, does not scale Tencent, and does not authorize a paid rerun.

Fixes #1710

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts/test_screeps_tencent_batch_rl_runner.py` (179 tests)

## Runtime / safety evidence
- Safe preflight-only artifact before this PR: `/root/screeps/runtime-artifacts/tencent-cloud/batch-runs/postmerge-1711-preflight-20260605t215816z/controller-summary.json`
- That preflight stopped at `skipped_paid_failure_recurrence_launch_guard` with `computeAttempted=false` and `scaleOutAttempted=false`, while preserving partial simulator progress: 19/20 successful environment rows and the remaining failure as private-server HTTP readiness timeout.
- No live-game writes, deploys, paid Tencent compute, or ASG scale-out were performed.

## Universal task Done gate
- [x] Task type: code.
- [x] Expected observable outcome / named deliverable: Tencent runner classifies private-server HTTP readiness timeouts and exposes no-paid recovery diagnostics.
- [x] Non-goals / accepted substitutes: paid cloud execution and official MMO deployment are excluded for this script diagnostic slice.
- [x] Verification evidence required before Done: head `507891e914e1301df6072b674a4f2d9c7be21aba` passed diff-check, py_compile, and 179 runner unit tests.
- [x] Project Evidence / Next action / Blocked by: #1710 and PR #1713 Project items record head `507891e9`, local verification, no-paid safety, and review handoff.
- [x] Post-merge/deploy/runtime proof: script-only change uses the preflight artifact `postmerge-1711-preflight-20260605t215816z` as runtime-shape evidence; no official MMO deploy is part of this deliverable.
- [x] Named deliverable proof: changed files `scripts/screeps_tencent_batch_rl_runner.py` and `scripts/test_screeps_tencent_batch_rl_runner.py` implement and test the readiness-timeout diagnostic.

## Issue closure gate
- [x] #1710: PR head `507891e9` delivers the exact Tencent HTTP readiness timeout diagnostic, no-paid safety evidence, and deterministic test coverage for the issue contract.

## Merge gate handoff
Repository PR checks, automated review, review-thread query, Project refresh, and elapsed-review gates still apply before merge; this section records the handoff and does not claim those future gates have passed.
