### PR TITLE
rl: suppress fresh full E1 stale anomaly

### DIFF
--- a/scripts/screeps_rl_control_loop_ledgers.py
+++ b/scripts/screeps_rl_control_loop_ledgers.py
@@ -29,6 +29,8 @@ DEFAULT_ARTIFACT_ROOT = Path("runtime-artifacts")
 DEFAULT_CONTROL_LOOP_DIR = Path("runtime-artifacts/rl-control-loop")
 DEFAULT_MAX_FILES_PER_ROOT = 25
 DEFAULT_STDOUT_BYTES = 4096
+E1_FULL_GATE_MIN_SAMPLE_COUNT = 200
+E1_GATE_STALE_FRESHNESS_SECONDS = 86400
 HISTORICAL_CONTEXT_ISSUES = [879, 893, 1589]
 REWARD_DECISION_SOURCE_ISSUE = 1690
 REWARD_DECISION_RELATED_ISSUES = [907, 924]
@@ -1415,6 +1417,36 @@ def training_did_run(training: JsonObject) -> bool:
     return bool(training.get("hasComputeEvidence") is True or training.get("trainingDidRun") is True)
 
 
+def utc_datetime_value(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        parsed = static_dashboard.parse_iso_datetime(value)
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def selected_gate_resolves_e1_stale_anomaly(dashboard: JsonObject) -> bool:
+    gate = as_dict(dashboard.get("gate"))
+    if not gate:
+        return False
+    status = (text_value(gate.get("status")) or "").lower()
+    if status not in {"pass", "passed", "ok"}:
+        return False
+    sample_count = int_value(gate.get("sampleCount"))
+    if sample_count is None or sample_count < E1_FULL_GATE_MIN_SAMPLE_COUNT:
+        return False
+    generated_at = utc_datetime_value(dashboard.get("generatedAt"))
+    gate_timestamp = utc_datetime_value(gate.get("timestamp"))
+    if generated_at is None or gate_timestamp is None:
+        return False
+    age_seconds = (generated_at - gate_timestamp).total_seconds()
+    return 0 <= age_seconds <= E1_GATE_STALE_FRESHNESS_SECONDS
+
+
 def training_report_ids_from_training(training: JsonObject) -> list[str]:
     return unique_text_values(as_list(as_dict(training.get("identity")).get("report")))
 
@@ -1440,6 +1472,7 @@ def training_anomalies(
     training = as_dict(dashboard.get("training"))
     gate = as_dict(dashboard.get("gate"))
     anomalies: list[JsonObject] = []
+    stale_e1_gate_resolved = selected_gate_resolves_e1_stale_anomaly(dashboard)
     if not gate:
         anomalies.append(
             {
@@ -1472,6 +1505,8 @@ def training_anomalies(
         if not isinstance(item, dict):
             continue
         if reward_decision_id is not None and item.get("code") == "REWARD_DECISION_ID_NULL":
+            continue
+        if stale_e1_gate_resolved and item.get("code") == "E1_GATE_STALE":
             continue
         if item.get("code") not in {anomaly["code"] for anomaly in anomalies}:
             anomalies.append(item)

--- a/scripts/test_screeps_rl_control_loop_ledgers.py
+++ b/scripts/test_screeps_rl_control_loop_ledgers.py
@@ -568,6 +568,96 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
         self.assertNotIn("REWARD_DECISION_ID_NULL", anomaly_codes)
         self.assertIn("E1_GATE_STALE", anomaly_codes)
 
+    def test_training_ledger_clears_stale_e1_anomaly_when_selected_full_gate_is_fresh(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            output = root / "out" / "training-ledger.json"
+            write_json(
+                artifact_root / "rl-dataset-gates" / "e1-gate-20260605T191602Z" / "gate_report.json",
+                {
+                    "type": "screeps-rl-dataset-evaluation-gate",
+                    "createdAt": "2026-06-05T19:16:02Z",
+                    "ok": True,
+                    "gateId": "e1-gate-20260605T191602Z",
+                    "dataset": {"runId": "rl-fresh-full-e1", "sampleCount": 200},
+                    "datasetGate": {"status": "pass", "sampleCount": 200},
+                    "quality_checks": {"status": "pass", "samples_accepted": 200, "samples_rejected": 0},
+                    "blockingReasons": [],
+                },
+            )
+            write_json(
+                artifact_root / "rl-control-loop" / "20260605T223000Z-training-ledger.json",
+                {
+                    "type": ledgers.TRAINING_LEDGER_TYPE,
+                    "createdAt": "2026-06-05T22:30:00Z",
+                    "status": "RUN_VALIDATED",
+                    "trainingDidRun": True,
+                    "e1Gate": {
+                        "gateId": "e1-gate-20260603T045100Z",
+                        "ok": True,
+                        "datasetRunId": "rl-stale-full-e1",
+                        "sampleCount": 200,
+                    },
+                    "environmentExecution": {"started": 80, "completed": 80, "failed": 0, "successRate": 1.0},
+                    "iterationExecution": {
+                        "simulatorTicksRequested": 160000,
+                        "simulatorTicksRun": 160000,
+                        "episodesRun": 80,
+                        "candidateEvaluationIterations": 1,
+                        "policyUpdateIterations": 1,
+                    },
+                    "trainingArtifacts": {
+                        "trainingReportIds": ["training-report-current"],
+                        "candidatePolicyIds": ["candidate-current"],
+                    },
+                    "metricsFields": {
+                        "envCompleted": 80,
+                        "ticksRun": 160000,
+                        "episodes": 80,
+                        "policyUpdateIterations": 1,
+                        "trainingReportIds": ["training-report-current"],
+                        "candidatePolicyId": "candidate-current",
+                    },
+                    "anomalies": [
+                        {
+                            "severity": "P2",
+                            "code": "E1_GATE_STALE",
+                            "evidence": "latest full E1 gate is e1-gate-20260603T045100Z",
+                            "evidencePaths": [
+                                "runtime-artifacts/rl-dataset-gates/e1-gate-20260603T045100Z/gate_report.json",
+                            ],
+                        },
+                    ],
+                },
+            )
+
+            exit_code = ledgers.main(
+                [
+                    "training-ledger",
+                    "--repo-root",
+                    str(root),
+                    "--artifact-root",
+                    str(artifact_root),
+                    "--output",
+                    str(output),
+                    "--created-at",
+                    "2026-06-05T22:31:00Z",
+                    "--max-files-per-root",
+                    "8",
+                ],
+                stdout=io.StringIO(),
+                stderr=io.StringIO(),
+            )
+            payload = read_json(output)
+
+        anomaly_codes = {item["code"] for item in payload["anomalies"]}
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["e1Gate"]["gateId"], "e1-gate-20260605T191602Z")
+        self.assertTrue(payload["e1Gate"]["ok"])
+        self.assertEqual(payload["e1Gate"]["sampleCount"], 200)
+        self.assertNotIn("E1_GATE_STALE", anomaly_codes)
+
     def test_training_ledger_rejects_stale_policy_reward_decision_for_new_candidate(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary
- Suppress a carried-forward `E1_GATE_STALE` anomaly when the selected E1 gate is a fresh full pass.
- Add deterministic regression coverage for the mixed-state case where a stale anomaly candidate exists but `e1Gate` now points at `e1-gate-20260605T191602Z`.
- Keep the change offline/script-only: no paid Tencent compute, no reward tuning, and no official MMO writes.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_control_loop_ledgers.py scripts/test_screeps_rl_control_loop_ledgers.py`
- `python3 -m pytest scripts/test_screeps_rl_control_loop_ledgers.py -q` → `16 passed in 0.34s`
- Fresh no-paid ledger artifact: `runtime-artifacts/rl-control-loop/post-pr1714-training-ledger-20260605T225807Z.json` reports `status=RUN_VALIDATED`, `e1Gate.gateId=e1-gate-20260605T191602Z`, `sampleCount=200`, and `anomalyCodes=[TENCENT_BATCH_BLOCKED, LOCAL_TRAINING_COMPLETED_NO_ACTIVE_RUNNER]` with no `E1_GATE_STALE`.

Fixes #1714

## Issue closure gate
- [x] #1714: Fresh full E1 gate `e1-gate-20260605T191602Z` now suppresses stale carried-forward `E1_GATE_STALE` anomalies; regression coverage and a fresh no-paid ledger artifact prove the false anomaly is absent.

## Universal task Done gate
- [x] Task type: RL flywheel control-loop bugfix for the Loop A training-ledger producer.
- [x] Expected observable outcome / named deliverable: `runtime-artifacts/rl-control-loop/post-pr1714-training-ledger-20260605T225807Z.json` shows the fresh E1 gate selected with no `E1_GATE_STALE` anomaly.
- [x] Non-goals / accepted substitutes: no paid Tencent run, no reward-weight change, no learned-policy rollout, and no official MMO write were performed.
- [x] Verification evidence required before Done: `git diff --check`, `py_compile`, focused pytest `16 passed`, and the fresh no-paid ledger artifact listed above.
- [x] Project Evidence / Next action / Blocked by: Project item moves to In review for PR review using commit `b87a2d88`; next controller action is exact-head CI/CodeRabbit/thread gate; Blocked by is empty.
- [x] Post-merge/deploy/runtime proof: This script-only RL ledger fix uses the generated no-paid ledger artifact as proof; scheduled Loop A ledger execution on main provides the follow-up artifact signal, and official MMO deployment is not part of this task.
- [x] Named deliverable proof: Commit `b87a2d88` modifies `scripts/screeps_rl_control_loop_ledgers.py` and `scripts/test_screeps_rl_control_loop_ledgers.py` only, with the regression test covering the stale-anomaly suppression path.
