### PR TITLE
seasonal: support reserve-first remote mining

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35725,10 +35725,7 @@ function getRemoteSourceAssignmentsInRoom(homeRoom, room) {
   });
 }
 function getRemoteSourceRoomRecords(homeRoom) {
-  return uniqueRemoteSourceRoomRecords([
-    ...getRemoteMiningRecords(homeRoom),
-    ...getRemoteBootstrapRecords(homeRoom)
-  ]).sort(compareRemoteSourceRoomRecords);
+  return uniqueRemoteSourceRoomRecords(getRemoteMiningRecords(homeRoom)).sort(compareRemoteSourceRoomRecords);
 }
 function getRemoteMiningRecords(homeRoom) {
   var _a2, _b;
@@ -35739,50 +35736,24 @@ function getRemoteMiningRecords(homeRoom) {
   return Object.values(records).filter((record) => isRemoteMiningRecord(record, homeRoom)).map((record) => ({
     colony: record.colony,
     roomName: record.roomName,
-    order: record.updatedAt,
-    source: "remoteMining"
+    order: record.updatedAt
   }));
 }
 function isRemoteMiningRecord(record, homeRoom) {
   return isRecord24(record) && record.colony === homeRoom && isNonEmptyString24(record.roomName) && record.roomName !== homeRoom && (record.status === "containerPending" || record.status === "containerReady" || record.status === "active");
 }
-function getRemoteBootstrapRecords(homeRoom) {
-  var _a2, _b;
-  const records = (_b = (_a2 = globalThis.Memory) == null ? void 0 : _a2.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord24(records)) {
-    return [];
-  }
-  return Object.values(records).filter((record) => isRemoteBootstrapRecord(record, homeRoom)).sort(compareRemoteBootstrapRecords).map((record) => ({
-    colony: record.colony,
-    roomName: record.roomName,
-    order: record.claimedAt,
-    source: "postClaimBootstrap"
-  }));
-}
-function isRemoteBootstrapRecord(record, homeRoom) {
-  return isRecord24(record) && record.colony === homeRoom && isNonEmptyString24(record.roomName) && record.roomName !== homeRoom && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
-}
-function compareRemoteBootstrapRecords(left, right) {
-  return left.claimedAt - right.claimedAt || left.roomName.localeCompare(right.roomName);
-}
 function uniqueRemoteSourceRoomRecords(records) {
   const byRoom = /* @__PURE__ */ new Map();
   for (const record of records) {
     const existing = byRoom.get(record.roomName);
-    if (!existing || compareRemoteSourceRoomRecordSource(record, existing) < 0) {
+    if (!existing || compareRemoteSourceRoomRecords(record, existing) < 0) {
       byRoom.set(record.roomName, record);
     }
   }
   return [...byRoom.values()];
 }
 function compareRemoteSourceRoomRecords(left, right) {
-  return left.order - right.order || compareRemoteSourceRoomRecordSource(left, right) || left.roomName.localeCompare(right.roomName);
-}
-function compareRemoteSourceRoomRecordSource(left, right) {
-  return getRemoteSourceRoomRecordSourceRank(left.source) - getRemoteSourceRoomRecordSourceRank(right.source);
-}
-function getRemoteSourceRoomRecordSourceRank(source) {
-  return source === "postClaimBootstrap" ? 0 : 1;
+  return left.order - right.order || left.roomName.localeCompare(right.roomName);
 }
 function compareRemoteSourceAssignments(left, right) {
   return left.targetRoom.localeCompare(right.targetRoom) || String(left.sourceId).localeCompare(String(right.sourceId));

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35592,6 +35592,7 @@ var ERR_NOT_ENOUGH_RESOURCES_CODE3 = -6;
 var ERR_NOT_IN_RANGE_CODE7 = -9;
 var DEFAULT_REMOTE_ROOM_DISTANCE = 1;
 var CRITICAL_ROAD_MOVE_COST = 1;
+var REMOTE_SOURCE_DROPPED_ENERGY_RANGE = 1;
 function selectRemoteHarvesterAssignment(homeRoom) {
   var _a2;
   return (_a2 = getRemoteSourceAssignments(homeRoom).find(
@@ -35626,7 +35627,7 @@ function isRemoteOperationSuspended(homeRoom, targetRoom) {
   return hasSafeRouteAvoidingDeadZones(homeRoom, targetRoom) === false;
 }
 function runRemoteHarvester(creep) {
-  var _a2, _b, _c, _d, _e;
+  var _a2, _b, _c, _d, _e, _f;
   const assignment = normalizeRemoteHarvesterMemory((_a2 = creep.memory) == null ? void 0 : _a2.remoteHarvester);
   if (!assignment) {
     return;
@@ -35648,18 +35649,26 @@ function runRemoteHarvester(creep) {
   }
   const source = getAssignedSource3(assignment);
   const container = getAssignedContainer2(assignment);
-  if (!container) {
-    delete creep.memory.task;
-    if (getCarriedEnergy5(creep) > 0) {
+  if (!source) {
+    if (!container && getCarriedEnergy5(creep) > 0) {
+      delete creep.memory.task;
       (_d = creep.drop) == null ? void 0 : _d.call(creep, getEnergyResource19());
       return;
     }
-  }
-  if (!source) {
     if (container) {
       moveTo3(creep, container, assignment);
     }
     return;
+  }
+  if (!container) {
+    delete creep.memory.task;
+    if (getCarriedEnergy5(creep) > 0) {
+      if (buildAssignedSourceContainerSite(creep, source, assignment)) {
+        return;
+      }
+      (_e = creep.drop) == null ? void 0 : _e.call(creep, getEnergyResource19());
+      return;
+    }
   }
   if (!isInRangeTo2(creep, source, 1)) {
     moveTo3(creep, container != null ? container : source, assignment);
@@ -35675,7 +35684,7 @@ function runRemoteHarvester(creep) {
     transferToContainer(creep, container, assignment);
     return;
   }
-  const result = (_e = creep.harvest) == null ? void 0 : _e.call(creep, source);
+  const result = (_f = creep.harvest) == null ? void 0 : _f.call(creep, source);
   if (container && (result === getErrFullCode2() || result === getErrNotEnoughResourcesCode2()) && getCarriedEnergy5(creep) > 0) {
     transferToContainer(creep, container, assignment);
   }
@@ -35716,6 +35725,7 @@ function getRemoteSourceAssignmentsInRoom(homeRoom, room) {
   return room.find(FIND_SOURCES).map((source) => {
     const container = findSourceContainer(room, source);
     const containerEnergy = container ? getStoredEnergy19(container) : 0;
+    const droppedEnergy = container ? 0 : getDroppedEnergyNearSource(room, source);
     const containerCapacity = container ? getStoreEnergyCapacity(container) : null;
     const containerFillRatio = container ? getContainerEnergyFillRatio(container, containerEnergy) : null;
     return {
@@ -35724,11 +35734,28 @@ function getRemoteSourceAssignmentsInRoom(homeRoom, room) {
       sourceId: source.id,
       ...container ? { containerId: container.id } : {},
       ...containerCapacity === null ? {} : { containerCapacity },
-      containerEnergy,
+      containerEnergy: container ? containerEnergy : droppedEnergy,
       ...containerFillRatio === null ? {} : { containerFillRatio },
       routeDistance: estimateRemoteRoomDistance(homeRoom, room.name)
     };
   });
+}
+function findDroppedEnergyNearSource(room, source) {
+  if (typeof FIND_DROPPED_RESOURCES !== "number" || typeof (room == null ? void 0 : room.find) !== "function") {
+    return [];
+  }
+  const sourcePosition = getRoomObjectPosition(source);
+  if (!sourcePosition) {
+    return [];
+  }
+  const droppedResources = room.find(FIND_DROPPED_RESOURCES);
+  if (!Array.isArray(droppedResources)) {
+    return [];
+  }
+  return droppedResources.filter(isDroppedEnergy2).filter((resource) => {
+    const resourcePosition = getRoomObjectPosition(resource);
+    return resourcePosition !== null && (typeof resourcePosition.roomName !== "string" || typeof sourcePosition.roomName !== "string" || resourcePosition.roomName === sourcePosition.roomName) && getRangeBetweenPositions2(sourcePosition, resourcePosition) <= REMOTE_SOURCE_DROPPED_ENERGY_RANGE;
+  }).sort(compareDroppedEnergyForPickup);
 }
 function getRemoteSourceRoomRecords(homeRoom) {
   return uniqueRemoteSourceRoomRecords(getRemoteMiningRecords(homeRoom)).sort(compareRemoteSourceRoomRecords);
@@ -35849,6 +35876,24 @@ function transferToContainer(creep, container, assignment) {
     moveTo3(creep, container, assignment);
   }
 }
+function buildAssignedSourceContainerSite(creep, source, assignment) {
+  if (typeof creep.build !== "function") {
+    return false;
+  }
+  const site = creep.room ? findSourceContainerConstructionSite(creep.room, source) : null;
+  if (!site) {
+    return false;
+  }
+  creep.memory.task = {
+    type: "build",
+    targetId: site.id
+  };
+  const result = creep.build(site);
+  if (result === getErrNotInRangeCode3()) {
+    moveTo3(creep, site, assignment);
+  }
+  return true;
+}
 function moveTo3(creep, target, assignment) {
   var _a2;
   (_a2 = creep.moveTo) == null ? void 0 : _a2.call(creep, target, getRemoteMoveOpts(assignment));
@@ -35923,6 +35968,15 @@ function getStoredEnergy19(target) {
   }
   const storedEnergy = store == null ? void 0 : store[getEnergyResource19()];
   return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
+}
+function getDroppedEnergyNearSource(room, source) {
+  return findDroppedEnergyNearSource(room, source).reduce((total, resource) => total + resource.amount, 0);
+}
+function isDroppedEnergy2(resource) {
+  return resource.resourceType === getEnergyResource19() && resource.amount > 0;
+}
+function compareDroppedEnergyForPickup(left, right) {
+  return right.amount - left.amount || String(left.id).localeCompare(String(right.id));
 }
 function getEnergyResource19() {
   var _a2;
@@ -36050,10 +36104,7 @@ function selectRemoteHaulerAssignment(homeRoom) {
   if (!hasRemoteHaulerDeliveryDemand(homeRoom)) {
     return null;
   }
-  return (_a2 = getRemoteSourceAssignments(homeRoom).filter(hasRemoteContainerAssignment).filter((assignment) => assignment.containerEnergy > REMOTE_HAULER_DISPATCH_ENERGY_THRESHOLD).filter((assignment) => countRemoteHaulersForContainer(assignment) < MAX_REMOTE_HAULERS_PER_CONTAINER).sort(compareRemoteHaulerAssignments)[0]) != null ? _a2 : null;
-}
-function hasRemoteContainerAssignment(assignment) {
-  return isNonEmptyString25(assignment.containerId);
+  return (_a2 = getRemoteSourceAssignments(homeRoom).filter((assignment) => assignment.containerEnergy > REMOTE_HAULER_DISPATCH_ENERGY_THRESHOLD).filter((assignment) => countRemoteHaulersForAssignment(assignment) < MAX_REMOTE_HAULERS_PER_CONTAINER).sort(compareRemoteHaulerAssignments)[0]) != null ? _a2 : null;
 }
 function hasRemoteHaulerDeliveryDemand(homeRoom) {
   const room = getVisibleRoom11(homeRoom);
@@ -36293,15 +36344,17 @@ function collectRemoteEnergy(creep, assignment) {
   const assignedContainer = getAssignedContainer3(assignment);
   if (((_a2 = creep.room) == null ? void 0 : _a2.name) !== assignment.targetRoom) {
     delete creep.memory.task;
-    moveTowardRoom4(creep, assignment.targetRoom, assignedContainer);
+    moveTowardRoom4(creep, assignment.targetRoom, assignedContainer != null ? assignedContainer : getAssignedSource4(assignment), assignment);
+    return;
+  }
+  if (!assignedContainer) {
+    collectRemoteDroppedEnergy(creep, assignment);
     return;
   }
   const source = selectRemoteHaulerEnergySource(creep, assignedContainer);
   if (!source) {
     delete creep.memory.task;
-    if (assignedContainer) {
-      moveTo4(creep, assignedContainer);
-    }
+    moveTo4(creep, assignedContainer);
     return;
   }
   const task = {
@@ -36357,11 +36410,11 @@ function getRemoteHaulerAssignmentFillRatio(assignment) {
   const capacity = assignment.containerCapacity;
   return typeof capacity === "number" && Number.isFinite(capacity) && capacity > 0 ? Math.max(0, Math.min(1, assignment.containerEnergy / capacity)) : null;
 }
-function countRemoteHaulersForContainer(assignment) {
+function countRemoteHaulersForAssignment(assignment) {
   return getRemoteOperationCreeps2(assignment.homeRoom, assignment.targetRoom).filter(
     (creep) => {
-      var _a2, _b, _c, _d;
-      return ((_a2 = creep.memory) == null ? void 0 : _a2.role) === HAULER_ROLE && canSatisfyRemoteCreepCapacity2(creep) && ((_b = creep.memory.remoteHauler) == null ? void 0 : _b.homeRoom) === assignment.homeRoom && ((_c = creep.memory.remoteHauler) == null ? void 0 : _c.targetRoom) === assignment.targetRoom && String((_d = creep.memory.remoteHauler) == null ? void 0 : _d.containerId) === String(assignment.containerId);
+      var _a2, _b, _c, _d, _e;
+      return ((_a2 = creep.memory) == null ? void 0 : _a2.role) === HAULER_ROLE && canSatisfyRemoteCreepCapacity2(creep) && ((_b = creep.memory.remoteHauler) == null ? void 0 : _b.homeRoom) === assignment.homeRoom && ((_c = creep.memory.remoteHauler) == null ? void 0 : _c.targetRoom) === assignment.targetRoom && (isNonEmptyString25(assignment.containerId) ? String((_d = creep.memory.remoteHauler) == null ? void 0 : _d.containerId) === String(assignment.containerId) : String((_e = creep.memory.remoteHauler) == null ? void 0 : _e.sourceId) === String(assignment.sourceId));
     }
   ).length;
 }
@@ -36372,15 +36425,60 @@ function normalizeRemoteHaulerMemory(value) {
   if (!isRecord25(value)) {
     return null;
   }
-  return isNonEmptyString25(value.homeRoom) && isNonEmptyString25(value.targetRoom) && isNonEmptyString25(value.sourceId) && isNonEmptyString25(value.containerId) ? {
+  return isNonEmptyString25(value.homeRoom) && isNonEmptyString25(value.targetRoom) && isNonEmptyString25(value.sourceId) && (value.containerId == null || isNonEmptyString25(value.containerId)) ? {
     homeRoom: value.homeRoom,
     targetRoom: value.targetRoom,
     sourceId: value.sourceId,
-    containerId: value.containerId
+    ...isNonEmptyString25(value.containerId) ? { containerId: value.containerId } : {}
   } : null;
 }
 function getAssignedContainer3(assignment) {
-  return getObjectById4(assignment.containerId);
+  return isNonEmptyString25(assignment.containerId) ? getObjectById4(assignment.containerId) : null;
+}
+function getAssignedSource4(assignment) {
+  var _a2;
+  const source = getObjectById4(assignment.sourceId);
+  if (source) {
+    return source;
+  }
+  const room = getVisibleRoom11(assignment.targetRoom);
+  if (!room || typeof FIND_SOURCES !== "number" || typeof room.find !== "function") {
+    return null;
+  }
+  return (_a2 = room.find(FIND_SOURCES).find((candidate) => String(candidate.id) === String(assignment.sourceId))) != null ? _a2 : null;
+}
+function collectRemoteDroppedEnergy(creep, assignment) {
+  var _a2;
+  const source = getAssignedSource4(assignment);
+  if (!source) {
+    delete creep.memory.task;
+    moveTowardRoom4(creep, assignment.targetRoom, void 0, assignment);
+    return;
+  }
+  const droppedEnergy = selectDroppedEnergyNearSource(creep.room, source, creep);
+  if (!droppedEnergy) {
+    delete creep.memory.task;
+    moveTo4(creep, source);
+    return;
+  }
+  const task = {
+    type: "pickup",
+    targetId: droppedEnergy.id
+  };
+  creep.memory.task = task;
+  const result = (_a2 = creep.pickup) == null ? void 0 : _a2.call(creep, droppedEnergy);
+  if (result === OK_CODE14) {
+    recordCreepBehaviorEnergyAcquisition(creep, "pickedUp");
+  }
+  if (result === getErrNotInRangeCode4()) {
+    moveTo4(creep, droppedEnergy);
+  }
+}
+function selectDroppedEnergyNearSource(room, source, creep) {
+  var _a2;
+  return (_a2 = findDroppedEnergyNearSource(room, source).sort(
+    (left, right) => right.amount - left.amount || getRangeToRoomObject6(creep, left) - getRangeToRoomObject6(creep, right) || String(left.id).localeCompare(String(right.id))
+  )[0]) != null ? _a2 : null;
 }
 function selectRemoteHaulerEnergySource(creep, assignedContainer) {
   var _a2;
@@ -39038,6 +39136,7 @@ function selectPostClaimControllerDefensePlan(colony) {
   return null;
 }
 function planRemoteEconomySpawn(context) {
+  var _a2;
   if (context.options.workersOnly || context.survival.mode !== "TERRITORY_READY" || context.workerCapacity < context.workerTarget || context.colony.energyAvailable < context.colony.energyCapacityAvailable) {
     return null;
   }
@@ -39091,7 +39190,7 @@ function planRemoteEconomySpawn(context) {
     spawn,
     body,
     name: appendSpawnNameSuffix(
-      `${HAULER_ROLE}-${context.colony.room.name}-${remoteHaulerAssignment.targetRoom}-${remoteHaulerAssignment.containerId}-${context.gameTime}`,
+      `${HAULER_ROLE}-${context.colony.room.name}-${remoteHaulerAssignment.targetRoom}-${(_a2 = remoteHaulerAssignment.containerId) != null ? _a2 : remoteHaulerAssignment.sourceId}-${context.gameTime}`,
       context.options
     ),
     memory: {
@@ -40115,10 +40214,10 @@ function hasDroppedEnergyDecayingAtSource(room, source) {
   const droppedResources = (_a2 = findRoomObjects28(room, "FIND_DROPPED_RESOURCES")) != null ? _a2 : [];
   return droppedResources.some((resource) => {
     const resourcePosition = getRoomObjectPosition(resource);
-    return resourcePosition !== null && isDroppedEnergy2(resource) && isSameRoomPosition(resourcePosition, room.name) && getRangeBetweenPositions2(sourcePosition, resourcePosition) <= 1;
+    return resourcePosition !== null && isDroppedEnergy3(resource) && isSameRoomPosition(resourcePosition, room.name) && getRangeBetweenPositions2(sourcePosition, resourcePosition) <= 1;
   });
 }
-function isDroppedEnergy2(resource) {
+function isDroppedEnergy3(resource) {
   const amount = resource.amount;
   const ticksToDecay = resource.ticksToDecay;
   return resource.resourceType === getEnergyResource23() && typeof amount === "number" && Number.isFinite(amount) && amount > 0 && (typeof ticksToDecay !== "number" || ticksToDecay > 0);

--- a/prod/src/creeps/hauler.ts
+++ b/prod/src/creeps/hauler.ts
@@ -12,10 +12,10 @@ import { selectSeasonScoreCollectionTask } from '../season/scoreCollection';
 import { recordCreepBehaviorEnergyAcquisition } from '../telemetry/behaviorTelemetry';
 import {
   getRemoteSourceAssignments,
+  findDroppedEnergyNearSource,
   moveTowardRoom,
   REMOTE_CREEP_REPLACEMENT_TICKS,
   shouldRetreatFromRemote,
-  type RemoteContainerAssignment,
   type RemoteSourceAssignment
 } from './remoteHarvester';
 import { buildRemoteHaulerBody } from '../spawn/bodyBuilder';
@@ -72,22 +72,17 @@ const SCORE_COLLECTOR_FALLBACK_ROOM_KEYS: SeasonScoreCollectorRoomKey[] = [
 
 export { buildRemoteHaulerBody };
 
-export function selectRemoteHaulerAssignment(homeRoom: string): RemoteContainerAssignment | null {
+export function selectRemoteHaulerAssignment(homeRoom: string): RemoteSourceAssignment | null {
   if (!hasRemoteHaulerDeliveryDemand(homeRoom)) {
     return null;
   }
 
   return (
     getRemoteSourceAssignments(homeRoom)
-      .filter(hasRemoteContainerAssignment)
       .filter((assignment) => assignment.containerEnergy > REMOTE_HAULER_DISPATCH_ENERGY_THRESHOLD)
-      .filter((assignment) => countRemoteHaulersForContainer(assignment) < MAX_REMOTE_HAULERS_PER_CONTAINER)
+      .filter((assignment) => countRemoteHaulersForAssignment(assignment) < MAX_REMOTE_HAULERS_PER_CONTAINER)
       .sort(compareRemoteHaulerAssignments)[0] ?? null
   );
-}
-
-function hasRemoteContainerAssignment(assignment: RemoteSourceAssignment): assignment is RemoteContainerAssignment {
-  return isNonEmptyString(assignment.containerId);
 }
 
 function hasRemoteHaulerDeliveryDemand(homeRoom: string): boolean {
@@ -393,16 +388,19 @@ function collectRemoteEnergy(creep: Creep, assignment: CreepRemoteHaulerMemory):
   const assignedContainer = getAssignedContainer(assignment);
   if (creep.room?.name !== assignment.targetRoom) {
     delete creep.memory.task;
-    moveTowardRoom(creep, assignment.targetRoom, assignedContainer);
+    moveTowardRoom(creep, assignment.targetRoom, assignedContainer ?? getAssignedSource(assignment), assignment);
+    return;
+  }
+
+  if (!assignedContainer) {
+    collectRemoteDroppedEnergy(creep, assignment);
     return;
   }
 
   const source = selectRemoteHaulerEnergySource(creep, assignedContainer);
   if (!source) {
     delete creep.memory.task;
-    if (assignedContainer) {
-      moveTo(creep, assignedContainer);
-    }
+    moveTo(creep, assignedContainer);
     return;
   }
 
@@ -478,14 +476,16 @@ function getRemoteHaulerAssignmentFillRatio(assignment: RemoteSourceAssignment):
     : null;
 }
 
-function countRemoteHaulersForContainer(assignment: RemoteSourceAssignment): number {
+function countRemoteHaulersForAssignment(assignment: RemoteSourceAssignment): number {
   return getRemoteOperationCreeps(assignment.homeRoom, assignment.targetRoom).filter(
     (creep) =>
       creep.memory?.role === HAULER_ROLE &&
       canSatisfyRemoteCreepCapacity(creep) &&
       creep.memory.remoteHauler?.homeRoom === assignment.homeRoom &&
       creep.memory.remoteHauler?.targetRoom === assignment.targetRoom &&
-      String(creep.memory.remoteHauler?.containerId) === String(assignment.containerId)
+      (isNonEmptyString(assignment.containerId)
+        ? String(creep.memory.remoteHauler?.containerId) === String(assignment.containerId)
+        : String(creep.memory.remoteHauler?.sourceId) === String(assignment.sourceId))
   ).length;
 }
 
@@ -501,18 +501,79 @@ function normalizeRemoteHaulerMemory(value: unknown): CreepRemoteHaulerMemory | 
   return isNonEmptyString(value.homeRoom) &&
     isNonEmptyString(value.targetRoom) &&
     isNonEmptyString(value.sourceId) &&
-    isNonEmptyString(value.containerId)
+    (value.containerId == null || isNonEmptyString(value.containerId))
     ? {
         homeRoom: value.homeRoom,
         targetRoom: value.targetRoom,
         sourceId: value.sourceId as Id<Source>,
-        containerId: value.containerId as Id<StructureContainer>
+        ...(isNonEmptyString(value.containerId) ? { containerId: value.containerId as Id<StructureContainer> } : {})
       }
     : null;
 }
 
 function getAssignedContainer(assignment: CreepRemoteHaulerMemory): StructureContainer | null {
-  return getObjectById<StructureContainer>(assignment.containerId);
+  return isNonEmptyString(assignment.containerId) ? getObjectById<StructureContainer>(assignment.containerId) : null;
+}
+
+function getAssignedSource(assignment: CreepRemoteHaulerMemory): Source | null {
+  const source = getObjectById<Source>(assignment.sourceId);
+  if (source) {
+    return source;
+  }
+
+  const room = getVisibleRoom(assignment.targetRoom);
+  if (!room || typeof FIND_SOURCES !== 'number' || typeof room.find !== 'function') {
+    return null;
+  }
+
+  return (
+    (room.find(FIND_SOURCES) as Source[]).find((candidate) => String(candidate.id) === String(assignment.sourceId)) ??
+    null
+  );
+}
+
+function collectRemoteDroppedEnergy(creep: Creep, assignment: CreepRemoteHaulerMemory): void {
+  const source = getAssignedSource(assignment);
+  if (!source) {
+    delete creep.memory.task;
+    moveTowardRoom(creep, assignment.targetRoom, undefined, assignment);
+    return;
+  }
+
+  const droppedEnergy = selectDroppedEnergyNearSource(creep.room, source, creep);
+  if (!droppedEnergy) {
+    delete creep.memory.task;
+    moveTo(creep, source);
+    return;
+  }
+
+  const task: Extract<CreepTaskMemory, { type: 'pickup' }> = {
+    type: 'pickup',
+    targetId: droppedEnergy.id
+  };
+  creep.memory.task = task;
+  const result = creep.pickup?.(droppedEnergy);
+  if (result === OK_CODE) {
+    recordCreepBehaviorEnergyAcquisition(creep, 'pickedUp');
+  }
+  if (result === getErrNotInRangeCode()) {
+    moveTo(creep, droppedEnergy);
+  }
+}
+
+function selectDroppedEnergyNearSource(
+  room: Room | undefined,
+  source: Source,
+  creep: Creep
+): Resource<ResourceConstant> | null {
+  return (
+    findDroppedEnergyNearSource(room, source).sort(
+      (left, right) =>
+        right.amount - left.amount ||
+        getRangeToRoomObject(creep, left) - getRangeToRoomObject(creep, right) ||
+        String(left.id).localeCompare(String(right.id))
+    )[0] ?? null
+  );
 }
 
 function selectRemoteHaulerEnergySource(

--- a/prod/src/creeps/remoteHarvester.ts
+++ b/prod/src/creeps/remoteHarvester.ts
@@ -4,7 +4,12 @@ import {
   isCriticalRoadLogisticsWork
 } from '../construction/criticalRoads';
 import { getContainerEnergyFillRatio, getStoreEnergyCapacity } from '../economy/containerEnergy';
-import { findSourceContainer } from '../economy/sourceContainers';
+import {
+  findSourceContainer,
+  findSourceContainerConstructionSite,
+  getRangeBetweenPositions,
+  getRoomObjectPosition
+} from '../economy/sourceContainers';
 import { buildRemoteHarvesterBody } from '../spawn/bodyBuilder';
 
 export const REMOTE_HARVESTER_ROLE = 'remoteHarvester';
@@ -17,6 +22,7 @@ const ERR_NOT_ENOUGH_RESOURCES_CODE = -6 as ScreepsReturnCode;
 const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
 const DEFAULT_REMOTE_ROOM_DISTANCE = 1;
 const CRITICAL_ROAD_MOVE_COST = 1;
+const REMOTE_SOURCE_DROPPED_ENERGY_RANGE = 1;
 
 export interface RemoteSourceAssignment {
   homeRoom: string;
@@ -113,19 +119,29 @@ export function runRemoteHarvester(creep: Creep): void {
 
   const source = getAssignedSource(assignment);
   const container = getAssignedContainer(assignment);
-  if (!container) {
-    delete creep.memory.task;
-    if (getCarriedEnergy(creep) > 0) {
+  if (!source) {
+    if (!container && getCarriedEnergy(creep) > 0) {
+      delete creep.memory.task;
       creep.drop?.(getEnergyResource());
       return;
     }
-  }
 
-  if (!source) {
     if (container) {
       moveTo(creep, container, assignment);
     }
     return;
+  }
+
+  if (!container) {
+    delete creep.memory.task;
+    if (getCarriedEnergy(creep) > 0) {
+      if (buildAssignedSourceContainerSite(creep, source, assignment)) {
+        return;
+      }
+
+      creep.drop?.(getEnergyResource());
+      return;
+    }
   }
 
   if (!isInRangeTo(creep, source, 1)) {
@@ -208,6 +224,7 @@ function getRemoteSourceAssignmentsInRoom(homeRoom: string, room: Room): RemoteS
     .map((source) => {
       const container = findSourceContainer(room, source);
       const containerEnergy = container ? getStoredEnergy(container) : 0;
+      const droppedEnergy = container ? 0 : getDroppedEnergyNearSource(room, source);
       const containerCapacity = container ? getStoreEnergyCapacity(container) : null;
       const containerFillRatio = container ? getContainerEnergyFillRatio(container, containerEnergy) : null;
       return {
@@ -216,11 +233,41 @@ function getRemoteSourceAssignmentsInRoom(homeRoom: string, room: Room): RemoteS
         sourceId: source.id,
         ...(container ? { containerId: container.id } : {}),
         ...(containerCapacity === null ? {} : { containerCapacity }),
-        containerEnergy,
+        containerEnergy: container ? containerEnergy : droppedEnergy,
         ...(containerFillRatio === null ? {} : { containerFillRatio }),
         routeDistance: estimateRemoteRoomDistance(homeRoom, room.name)
       };
     });
+}
+
+export function findDroppedEnergyNearSource(room: Room | undefined, source: Source): Resource<ResourceConstant>[] {
+  if (typeof FIND_DROPPED_RESOURCES !== 'number' || typeof room?.find !== 'function') {
+    return [];
+  }
+
+  const sourcePosition = getRoomObjectPosition(source);
+  if (!sourcePosition) {
+    return [];
+  }
+
+  const droppedResources = room.find(FIND_DROPPED_RESOURCES) as Resource<ResourceConstant>[];
+  if (!Array.isArray(droppedResources)) {
+    return [];
+  }
+
+  return droppedResources
+    .filter(isDroppedEnergy)
+    .filter((resource) => {
+      const resourcePosition = getRoomObjectPosition(resource);
+      return (
+        resourcePosition !== null &&
+        (typeof resourcePosition.roomName !== 'string' ||
+          typeof sourcePosition.roomName !== 'string' ||
+          resourcePosition.roomName === sourcePosition.roomName) &&
+        getRangeBetweenPositions(sourcePosition, resourcePosition) <= REMOTE_SOURCE_DROPPED_ENERGY_RANGE
+      );
+    })
+    .sort(compareDroppedEnergyForPickup);
 }
 
 function getRemoteSourceRoomRecords(homeRoom: string): RemoteSourceRoomRecord[] {
@@ -399,6 +446,31 @@ function transferToContainer(
   }
 }
 
+function buildAssignedSourceContainerSite(
+  creep: Creep,
+  source: Source,
+  assignment: CreepRemoteHarvesterMemory
+): boolean {
+  if (typeof creep.build !== 'function') {
+    return false;
+  }
+
+  const site = creep.room ? findSourceContainerConstructionSite(creep.room, source) : null;
+  if (!site) {
+    return false;
+  }
+
+  creep.memory.task = {
+    type: 'build',
+    targetId: site.id as Id<ConstructionSite>
+  };
+  const result = creep.build(site);
+  if (result === getErrNotInRangeCode()) {
+    moveTo(creep, site, assignment);
+  }
+  return true;
+}
+
 function moveTo(
   creep: Creep,
   target: RoomObject | RoomPosition,
@@ -495,6 +567,21 @@ function getStoredEnergy(target: unknown): number {
 
   const storedEnergy = store?.[getEnergyResource()];
   return typeof storedEnergy === 'number' && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
+}
+
+function getDroppedEnergyNearSource(room: Room, source: Source): number {
+  return findDroppedEnergyNearSource(room, source).reduce((total, resource) => total + resource.amount, 0);
+}
+
+function isDroppedEnergy(resource: Resource<ResourceConstant>): boolean {
+  return resource.resourceType === getEnergyResource() && resource.amount > 0;
+}
+
+function compareDroppedEnergyForPickup(
+  left: Resource<ResourceConstant>,
+  right: Resource<ResourceConstant>
+): number {
+  return right.amount - left.amount || String(left.id).localeCompare(String(right.id));
 }
 
 function getEnergyResource(): ResourceConstant {

--- a/prod/src/creeps/remoteHarvester.ts
+++ b/prod/src/creeps/remoteHarvester.ts
@@ -37,7 +37,6 @@ interface RemoteSourceRoomRecord {
   colony: string;
   roomName: string;
   order: number;
-  source: 'remoteMining' | 'postClaimBootstrap';
 }
 
 export { buildRemoteHarvesterBody };
@@ -225,10 +224,7 @@ function getRemoteSourceAssignmentsInRoom(homeRoom: string, room: Room): RemoteS
 }
 
 function getRemoteSourceRoomRecords(homeRoom: string): RemoteSourceRoomRecord[] {
-  return uniqueRemoteSourceRoomRecords([
-    ...getRemoteMiningRecords(homeRoom),
-    ...getRemoteBootstrapRecords(homeRoom)
-  ]).sort(compareRemoteSourceRoomRecords);
+  return uniqueRemoteSourceRoomRecords(getRemoteMiningRecords(homeRoom)).sort(compareRemoteSourceRoomRecords);
 }
 
 function getRemoteMiningRecords(homeRoom: string): RemoteSourceRoomRecord[] {
@@ -242,8 +238,7 @@ function getRemoteMiningRecords(homeRoom: string): RemoteSourceRoomRecord[] {
     .map((record): RemoteSourceRoomRecord => ({
       colony: record.colony,
       roomName: record.roomName,
-      order: record.updatedAt,
-      source: 'remoteMining'
+      order: record.updatedAt
     }));
 }
 
@@ -257,49 +252,11 @@ function isRemoteMiningRecord(record: unknown, homeRoom: string): record is Terr
   );
 }
 
-function getRemoteBootstrapRecords(homeRoom: string): RemoteSourceRoomRecord[] {
-  const records = (globalThis as { Memory?: Partial<Memory> }).Memory?.territory?.postClaimBootstraps;
-  if (!isRecord(records)) {
-    return [];
-  }
-
-  return Object.values(records)
-    .filter((record): record is TerritoryPostClaimBootstrapMemory => isRemoteBootstrapRecord(record, homeRoom))
-    .sort(compareRemoteBootstrapRecords)
-    .map((record): RemoteSourceRoomRecord => ({
-      colony: record.colony,
-      roomName: record.roomName,
-      order: record.claimedAt,
-      source: 'postClaimBootstrap'
-    }));
-}
-
-function isRemoteBootstrapRecord(record: unknown, homeRoom: string): record is TerritoryPostClaimBootstrapMemory {
-  return (
-    isRecord(record) &&
-    record.colony === homeRoom &&
-    isNonEmptyString(record.roomName) &&
-    record.roomName !== homeRoom &&
-    (record.status === 'detected' ||
-      record.status === 'spawnSitePending' ||
-      record.status === 'spawnSiteBlocked' ||
-      record.status === 'spawningWorkers' ||
-      record.status === 'ready')
-  );
-}
-
-function compareRemoteBootstrapRecords(
-  left: TerritoryPostClaimBootstrapMemory,
-  right: TerritoryPostClaimBootstrapMemory
-): number {
-  return left.claimedAt - right.claimedAt || left.roomName.localeCompare(right.roomName);
-}
-
 function uniqueRemoteSourceRoomRecords(records: RemoteSourceRoomRecord[]): RemoteSourceRoomRecord[] {
   const byRoom = new Map<string, RemoteSourceRoomRecord>();
   for (const record of records) {
     const existing = byRoom.get(record.roomName);
-    if (!existing || compareRemoteSourceRoomRecordSource(record, existing) < 0) {
+    if (!existing || compareRemoteSourceRoomRecords(record, existing) < 0) {
       byRoom.set(record.roomName, record);
     }
   }
@@ -308,19 +265,7 @@ function uniqueRemoteSourceRoomRecords(records: RemoteSourceRoomRecord[]): Remot
 }
 
 function compareRemoteSourceRoomRecords(left: RemoteSourceRoomRecord, right: RemoteSourceRoomRecord): number {
-  return (
-    left.order - right.order ||
-    compareRemoteSourceRoomRecordSource(left, right) ||
-    left.roomName.localeCompare(right.roomName)
-  );
-}
-
-function compareRemoteSourceRoomRecordSource(left: RemoteSourceRoomRecord, right: RemoteSourceRoomRecord): number {
-  return getRemoteSourceRoomRecordSourceRank(left.source) - getRemoteSourceRoomRecordSourceRank(right.source);
-}
-
-function getRemoteSourceRoomRecordSourceRank(source: RemoteSourceRoomRecord['source']): number {
-  return source === 'postClaimBootstrap' ? 0 : 1;
+  return left.order - right.order || left.roomName.localeCompare(right.roomName);
 }
 
 function compareRemoteSourceAssignments(left: RemoteSourceAssignment, right: RemoteSourceAssignment): number {

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -1436,7 +1436,7 @@ function planRemoteEconomySpawn(context: SpawnPlanningContext): SpawnRequest | n
     spawn,
     body,
     name: appendSpawnNameSuffix(
-      `${HAULER_ROLE}-${context.colony.room.name}-${remoteHaulerAssignment.targetRoom}-${remoteHaulerAssignment.containerId}-${context.gameTime}`,
+      `${HAULER_ROLE}-${context.colony.room.name}-${remoteHaulerAssignment.targetRoom}-${remoteHaulerAssignment.containerId ?? remoteHaulerAssignment.sourceId}-${context.gameTime}`,
       context.options
     ),
     memory: {

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -218,7 +218,7 @@ declare global {
     homeRoom: string;
     targetRoom: string;
     sourceId: Id<Source>;
-    containerId: Id<StructureContainer>;
+    containerId?: Id<StructureContainer>;
   }
 
   interface CreepEnergyHaulerMemory {

--- a/prod/test/hauler.test.ts
+++ b/prod/test/hauler.test.ts
@@ -10,6 +10,8 @@ describe('runHauler', () => {
     (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 1;
     (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 2;
     (globalThis as unknown as { FIND_STRUCTURES: number }).FIND_STRUCTURES = 3;
+    (globalThis as unknown as { FIND_DROPPED_RESOURCES: number }).FIND_DROPPED_RESOURCES = 4;
+    (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 5;
     (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
     (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
     (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
@@ -46,6 +48,25 @@ describe('runHauler', () => {
     expect(creep.memory.task).toEqual({ type: 'withdraw', targetId: 'container1' });
     expect(creep.withdraw).toHaveBeenCalledWith(container, RESOURCE_ENERGY);
     expect(creep.moveTo).toHaveBeenCalledWith(container, { reusePath: 20, ignoreRoads: false });
+  });
+
+  it('picks up dropped energy near the assigned remote source without a container', () => {
+    const source = makeSource('source1', 10, 10);
+    const droppedEnergy = makeDroppedEnergy('drop1', 700, 10, 10);
+    const remoteRoom = makeRoom('W2N1', true, [], [], [], [droppedEnergy], [source]);
+    const creep = makeHauler(remoteRoom, 0, null);
+    creep.pickup = jest.fn().mockReturnValue(ERR_NOT_IN_RANGE_CODE);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: { W2N1: remoteRoom },
+      getObjectById: jest.fn((id: string) => (id === 'source1' ? source : null))
+    };
+
+    runHauler(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'pickup', targetId: 'drop1' });
+    expect(creep.pickup).toHaveBeenCalledWith(droppedEnergy);
+    expect(creep.moveTo).toHaveBeenCalledWith(droppedEnergy, { reusePath: 20, ignoreRoads: false });
+    expect(creep.withdraw).not.toHaveBeenCalled();
   });
 
   it('withdraws from the richest visible remote container or storage source', () => {
@@ -174,6 +195,21 @@ describe('runHauler', () => {
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       rooms: { W1N1: homeRoom },
       getObjectById: jest.fn((id: string) => (id === 'spawn1' ? spawn : id === 'storage1' ? storage : null))
+    };
+
+    runHauler(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(creep.transfer).toHaveBeenCalledWith(spawn, RESOURCE_ENERGY);
+  });
+
+  it('delivers carried remote energy without a container assignment', () => {
+    const spawn = makeStoreStructure('spawn1', STRUCTURE_SPAWN, 100, 200);
+    const homeRoom = makeRoom('W1N1', true, [spawn], []);
+    const creep = makeHauler(homeRoom, 100, null);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: { W1N1: homeRoom },
+      getObjectById: jest.fn((id: string) => (id === 'spawn1' ? spawn : null))
     };
 
     runHauler(creep);
@@ -364,7 +400,11 @@ describe('runHauler', () => {
   });
 });
 
-function makeHauler(room: Room, carriedEnergy: number): Creep {
+function makeHauler(
+  room: Room,
+  carriedEnergy: number,
+  containerId: Id<StructureContainer> | null = 'container1' as Id<StructureContainer>
+): Creep {
   return {
     memory: {
       role: 'hauler',
@@ -373,15 +413,17 @@ function makeHauler(room: Room, carriedEnergy: number): Creep {
         homeRoom: 'W1N1',
         targetRoom: 'W2N1',
         sourceId: 'source1' as Id<Source>,
-        containerId: 'container1' as Id<StructureContainer>
+        ...(containerId === null ? {} : { containerId })
       }
     },
+    pos: makeRoomPosition(10, 11, room.name),
     room,
     store: {
       getUsedCapacity: jest.fn((resource: ResourceConstant) => (resource === RESOURCE_ENERGY ? carriedEnergy : 0))
     },
     withdraw: jest.fn().mockReturnValue(OK_CODE),
     transfer: jest.fn().mockReturnValue(OK_CODE),
+    pickup: jest.fn().mockReturnValue(OK_CODE),
     moveTo: jest.fn()
   } as unknown as Creep;
 }
@@ -416,7 +458,9 @@ function makeRoom(
   owned: boolean,
   structures: AnyOwnedStructure[],
   hostiles: Creep[],
-  roomStructures: Structure[] = []
+  roomStructures: Structure[] = [],
+  droppedResources: Resource<ResourceConstant>[] = [],
+  sources: Source[] = []
 ): Room {
   return {
     name: roomName,
@@ -434,9 +478,39 @@ function makeRoom(
         return roomStructures;
       }
 
+      if (type === FIND_DROPPED_RESOURCES) {
+        return droppedResources;
+      }
+
+      if (type === FIND_SOURCES) {
+        return sources;
+      }
+
       return [];
     })
   } as unknown as Room;
+}
+
+function makeSource(id: string, x: number, y: number, roomName = 'W2N1'): Source {
+  return {
+    id,
+    pos: makeRoomPosition(x, y, roomName)
+  } as unknown as Source;
+}
+
+function makeDroppedEnergy(
+  id: string,
+  amount: number,
+  x: number,
+  y: number,
+  roomName = 'W2N1'
+): Resource<ResourceConstant> {
+  return {
+    id,
+    amount,
+    resourceType: RESOURCE_ENERGY,
+    pos: makeRoomPosition(x, y, roomName)
+  } as unknown as Resource<ResourceConstant>;
 }
 
 function makeScoreItem(id: string, x: number, y: number, roomName = 'W1N1'): RoomObject & { id: string; score: number; scoreType: string } {

--- a/prod/test/remoteHarvester.test.ts
+++ b/prod/test/remoteHarvester.test.ts
@@ -1,4 +1,4 @@
-import { runRemoteHarvester } from '../src/creeps/remoteHarvester';
+import { getRemoteSourceAssignments, runRemoteHarvester } from '../src/creeps/remoteHarvester';
 
 const OK_CODE = 0 as ScreepsReturnCode;
 
@@ -33,6 +33,29 @@ describe('runRemoteHarvester', () => {
 
     expect(creep.transfer).toHaveBeenCalledWith(container, RESOURCE_ENERGY);
     expect(creep.harvest).not.toHaveBeenCalled();
+  });
+
+  it('does not select remote assignments directly from post-claim bootstrap memory', () => {
+    const remoteRoom = makeRoom('W2N1', false, [], undefined, { sources: [makeSource('source1')] });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: { W2N1: remoteRoom }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          W2N1: {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            status: 'spawnSitePending',
+            claimedAt: 500,
+            updatedAt: 501,
+            workerTarget: 1
+          }
+        }
+      }
+    };
+
+    expect(getRemoteSourceAssignments('W1N1')).toEqual([]);
   });
 
   it('retreats home when the assigned remote room is hostile owned', () => {

--- a/prod/test/remoteHarvester.test.ts
+++ b/prod/test/remoteHarvester.test.ts
@@ -5,7 +5,9 @@ const OK_CODE = 0 as ScreepsReturnCode;
 describe('runRemoteHarvester', () => {
   beforeEach(() => {
     (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 1;
+    (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 2;
     (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+    (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
     (globalThis as unknown as { ERR_NOT_IN_RANGE: ScreepsReturnCode }).ERR_NOT_IN_RANGE = -9 as ScreepsReturnCode;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
   });
@@ -100,6 +102,32 @@ describe('runRemoteHarvester', () => {
     expect(creep.harvest).toHaveBeenCalledWith(source);
     expect(creep.transfer).not.toHaveBeenCalled();
     expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
+  it('builds an adjacent source container site before dropping carried remote energy', () => {
+    const source = makeSource('source1');
+    const containerSite = makeContainerConstructionSite('container-site1', { x: 10, y: 11, roomName: 'W2N1' });
+    const remoteRoom = makeRoom('W2N1', true, [], undefined, {
+      sources: [source],
+      constructionSites: [containerSite]
+    });
+    const creep = makeRemoteHarvester(remoteRoom, {
+      usedEnergy: 50,
+      freeEnergy: 0,
+      range: 1,
+      containerId: null
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: { W2N1: remoteRoom },
+      getObjectById: jest.fn((id: string) => (id === source.id ? source : null))
+    };
+
+    runRemoteHarvester(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'container-site1' });
+    expect(creep.build).toHaveBeenCalledWith(containerSite);
+    expect(creep.drop).not.toHaveBeenCalled();
+    expect(creep.harvest).not.toHaveBeenCalled();
   });
 
   it('harvests in neutral assigned remote rooms', () => {
@@ -256,6 +284,8 @@ function makeRemoteHarvester(
     },
     harvest: jest.fn().mockReturnValue(OK_CODE),
     transfer: jest.fn().mockReturnValue(OK_CODE),
+    build: jest.fn().mockReturnValue(OK_CODE),
+    drop: jest.fn().mockReturnValue(OK_CODE),
     moveTo: jest.fn()
   } as unknown as Creep;
 }
@@ -317,4 +347,15 @@ function makeContainer(id: string): StructureContainer {
       getUsedCapacity: jest.fn().mockReturnValue(0)
     }
   } as unknown as StructureContainer;
+}
+
+function makeContainerConstructionSite(
+  id: string,
+  pos: { x: number; y: number; roomName: string }
+): ConstructionSite {
+  return {
+    id,
+    structureType: 'container',
+    pos
+  } as unknown as ConstructionSite;
 }

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -446,6 +446,48 @@ describe('planSpawn', () => {
     };
   }
 
+  function makeRemoteMiningMemory(
+    targetRoom = 'W2N1',
+    {
+      colony = 'W1N1',
+      sourceId = `${targetRoom}-source0`,
+      containerId = `${targetRoom}-container0`,
+      status = containerId === null ? 'containerPending' : 'containerReady',
+      containerBuilt = containerId !== null,
+      containerSitePending = containerId === null,
+      energyAvailable = 0,
+      energyFlowing = false
+    }: {
+      colony?: string;
+      sourceId?: string;
+      containerId?: string | null;
+      status?: TerritoryRemoteMiningStatus;
+      containerBuilt?: boolean;
+      containerSitePending?: boolean;
+      energyAvailable?: number;
+      energyFlowing?: boolean;
+    } = {}
+  ): TerritoryRemoteMiningRoomMemory {
+    return {
+      colony,
+      roomName: targetRoom,
+      status,
+      updatedAt: 501,
+      sources: {
+        [sourceId]: {
+          sourceId,
+          ...(containerId === null ? {} : { containerId }),
+          containerBuilt,
+          containerSitePending,
+          harvesterAssigned: false,
+          haulerAssigned: false,
+          energyAvailable,
+          energyFlowing
+        }
+      }
+    };
+  }
+
   function makePostClaimSustainUpgrader(targetRoom = 'W2N1', homeRoom = 'W1N1'): Creep {
     return {
       memory: {
@@ -2318,7 +2360,9 @@ describe('planSpawn', () => {
     };
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       territory: {
-        postClaimBootstraps: { W2N1: makeSatisfiedPostClaimRemoteMemory() }
+        remoteMining: {
+          'W1N1:W2N1': makeRemoteMiningMemory()
+        }
       }
     };
 
@@ -2560,7 +2604,13 @@ describe('planSpawn', () => {
     };
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       territory: {
-        postClaimBootstraps: { W2N1: makeSatisfiedPostClaimRemoteMemory() }
+        remoteMining: {
+          'W1N1:W2N1': makeRemoteMiningMemory('W2N1', {
+            containerId: null,
+            containerBuilt: false,
+            containerSitePending: true
+          })
+        }
       }
     };
 
@@ -2615,6 +2665,15 @@ describe('planSpawn', () => {
             colony: 'E17S59',
             controllerId: 'controller-e17s58' as Id<StructureController>
           }
+        },
+        remoteMining: {
+          'E17S59:E17S58': makeRemoteMiningMemory('E17S58', {
+            colony: 'E17S59',
+            sourceId: 'e17s58-source-a',
+            containerId: null,
+            containerBuilt: false,
+            containerSitePending: true
+          })
         },
         scoutIntel: {
           'E17S59>E18S59': makeFreshScoutIntel('E17S59', 'E18S59', 814),
@@ -2675,6 +2734,15 @@ describe('planSpawn', () => {
             controllerId: 'controller-e18s59' as Id<StructureController>
           }
         },
+        remoteMining: {
+          'E17S59:E18S59': makeRemoteMiningMemory('E18S59', {
+            colony: 'E17S59',
+            sourceId: 'e18s59-source-a',
+            containerId: null,
+            containerBuilt: false,
+            containerSitePending: true
+          })
+        },
         scoutIntel: {
           'E17S59>E18S59': makeFreshScoutIntel('E17S59', 'E18S59', 837),
           'E17S59>E17S60': makeFreshScoutIntel('E17S59', 'E17S60', 837)
@@ -2698,12 +2766,12 @@ describe('planSpawn', () => {
     });
   });
 
-  it('spawns a remote harvester for a reserve-only room while an owner hold suppresses claiming', () => {
+  it('spawns a remote harvester for a reserve-only room without claim intent pressure', () => {
     const { colony, spawn } = makeColony({
       roomName: 'E9S27',
-      energyAvailable: 650,
-      energyCapacityAvailable: 650,
-      controller: makeSafeOwnedController(6)
+      energyAvailable: 1300,
+      energyCapacityAvailable: 1300,
+      controller: makeSafeOwnedController(4)
     });
     const source = makeRemoteSource('e9s28-source-a', 10, 10, 'E9S28');
     const remoteRoom = makeRemoteEconomyRoom({
@@ -2726,21 +2794,9 @@ describe('planSpawn', () => {
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       territory: {
         targets: [
-          { colony: 'E9S27', roomName: 'E9S28', action: 'claim' },
           { colony: 'E9S27', roomName: 'E9S28', action: 'reserve' }
         ],
         intents: [
-          {
-            colony: 'E9S27',
-            targetRoom: 'E9S28',
-            action: 'claim',
-            status: 'suppressed',
-            updatedAt: 1_000,
-            suspended: {
-              reason: 'owner_reserve_only',
-              updatedAt: 1_000
-            } as unknown as TerritoryIntentSuspensionMemory
-          },
           {
             colony: 'E9S27',
             targetRoom: 'E9S28',
@@ -2812,7 +2868,9 @@ describe('planSpawn', () => {
     };
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       territory: {
-        postClaimBootstraps: { W2N1: makeSatisfiedPostClaimRemoteMemory() }
+        remoteMining: {
+          'W1N1:W2N1': makeRemoteMiningMemory()
+        }
       }
     };
 
@@ -2871,7 +2929,9 @@ describe('planSpawn', () => {
     };
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       territory: {
-        postClaimBootstraps: { W2N1: makeSatisfiedPostClaimRemoteMemory() }
+        remoteMining: {
+          'W1N1:W2N1': makeRemoteMiningMemory()
+        }
       }
     };
 
@@ -2894,7 +2954,9 @@ describe('planSpawn', () => {
     };
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       territory: {
-        postClaimBootstraps: { W2N1: makeSatisfiedPostClaimRemoteMemory() },
+        remoteMining: {
+          'W1N1:W2N1': makeRemoteMiningMemory()
+        },
         intents: [
           {
             colony: 'W1N1',
@@ -2932,7 +2994,9 @@ describe('planSpawn', () => {
     };
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       territory: {
-        postClaimBootstraps: { W2N1: makeSatisfiedPostClaimRemoteMemory() }
+        remoteMining: {
+          'W1N1:W2N1': makeRemoteMiningMemory()
+        }
       }
     };
 

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -58,6 +58,7 @@ describe('planSpawn', () => {
     (globalThis as unknown as { FIND_MY_CONSTRUCTION_SITES: number }).FIND_MY_CONSTRUCTION_SITES = 2;
     (globalThis as unknown as { FIND_STRUCTURES: number }).FIND_STRUCTURES = 5;
     (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 6;
+    (globalThis as unknown as { FIND_DROPPED_RESOURCES: number }).FIND_DROPPED_RESOURCES = 7;
     (globalThis as unknown as { FIND_MY_CREEPS: number }).FIND_MY_CREEPS = 10;
     (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
     (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
@@ -378,6 +379,21 @@ describe('planSpawn', () => {
     } as unknown as StructureContainer;
   }
 
+  function makeDroppedEnergy(
+    id: string,
+    amount: number,
+    x = 10,
+    y = 10,
+    roomName = 'W2N1'
+  ): Resource<ResourceConstant> {
+    return {
+      id,
+      amount,
+      resourceType: RESOURCE_ENERGY,
+      pos: makeRoomPosition(x, y, roomName)
+    } as unknown as Resource<ResourceConstant>;
+  }
+
   function makeEnergyHaulingStructure(
     id: string,
     structureType: StructureConstant,
@@ -406,12 +422,14 @@ describe('planSpawn', () => {
     roomName = 'W2N1',
     source = makeRemoteSource(`${roomName}-source0`, 10, 10, roomName),
     container = makeRemoteContainer(`${roomName}-container0`, 0, 10, 11, roomName),
-    controller = { id: `${roomName}-controller`, my: true, level: 1 } as StructureController
+    controller = { id: `${roomName}-controller`, my: true, level: 1 } as StructureController,
+    droppedResources = []
   }: {
     roomName?: string;
     source?: Source;
     container?: StructureContainer | null;
     controller?: StructureController;
+    droppedResources?: Resource<ResourceConstant>[];
   } = {}): Room {
     return {
       name: roomName,
@@ -427,6 +445,10 @@ describe('planSpawn', () => {
 
         if (type === FIND_MY_CREEPS) {
           return findMockCreepsInRoom(roomName);
+        }
+
+        if (type === FIND_DROPPED_RESOURCES) {
+          return droppedResources;
         }
 
         return [];
@@ -511,7 +533,7 @@ describe('planSpawn', () => {
     };
   }
 
-  function makeRemoteHarvester(sourceId = 'W2N1-source0', containerId = 'W2N1-container0'): Creep {
+  function makeRemoteHarvester(sourceId = 'W2N1-source0', containerId: string | null = 'W2N1-container0'): Creep {
     return {
       memory: {
         role: 'remoteHarvester',
@@ -520,7 +542,24 @@ describe('planSpawn', () => {
           homeRoom: 'W1N1',
           targetRoom: 'W2N1',
           sourceId: sourceId as Id<Source>,
-          containerId: containerId as Id<StructureContainer>
+          ...(containerId === null ? {} : { containerId: containerId as Id<StructureContainer> })
+        }
+      },
+      room: { name: 'W2N1' } as Room,
+      ticksToLive: 1_000
+    } as Creep;
+  }
+
+  function makeRemoteHauler(sourceId = 'W2N1-source0', containerId: string | null = 'W2N1-container0'): Creep {
+    return {
+      memory: {
+        role: 'hauler',
+        colony: 'W1N1',
+        remoteHauler: {
+          homeRoom: 'W1N1',
+          targetRoom: 'W2N1',
+          sourceId: sourceId as Id<Source>,
+          ...(containerId === null ? {} : { containerId: containerId as Id<StructureContainer> })
         }
       },
       room: { name: 'W2N1' } as Room,
@@ -2906,6 +2945,86 @@ describe('planSpawn', () => {
         }
       }
     });
+  });
+
+  it('dispatches one remote hauler for dropped energy near a pending remote source without a container', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController(),
+      ownedStructures: [makeRemoteHaulerStorageSink('storage1')]
+    });
+    const source = makeRemoteSource('W2N1-source0');
+    const lowDroppedEnergyRoom = makeRemoteEconomyRoom({
+      source,
+      container: null,
+      droppedResources: [makeDroppedEnergy('drop-low', 500)]
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 510,
+      rooms: { W1N1: colony.room, W2N1: lowDroppedEnergyRoom },
+      spawns: { Spawn1: spawn },
+      creeps: {
+        RemoteHarvester: makeRemoteHarvester('W2N1-source0', null)
+      },
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        remoteMining: {
+          'W1N1:W2N1': makeRemoteMiningMemory('W2N1', {
+            containerId: null,
+            containerBuilt: false,
+            containerSitePending: true
+          })
+        }
+      }
+    };
+
+    expect(planSpawn(colony, { worker: 4 }, 511)).toBeNull();
+
+    const highDroppedEnergyRoom = makeRemoteEconomyRoom({
+      source,
+      container: null,
+      droppedResources: [makeDroppedEnergy('drop-high', 700)]
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 511,
+      rooms: { W1N1: colony.room, W2N1: highDroppedEnergyRoom },
+      spawns: { Spawn1: spawn },
+      creeps: {
+        RemoteHarvester: makeRemoteHarvester('W2N1-source0', null)
+      },
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+
+    expect(planSpawn(colony, { worker: 4 }, 512)).toEqual({
+      spawn,
+      body: ['carry', 'move', 'carry', 'move', 'carry', 'move', 'carry', 'move', 'carry', 'move', 'carry', 'move'],
+      name: 'hauler-W1N1-W2N1-W2N1-source0-512',
+      memory: {
+        role: 'hauler',
+        colony: 'W1N1',
+        remoteHauler: {
+          homeRoom: 'W1N1',
+          targetRoom: 'W2N1',
+          sourceId: 'W2N1-source0'
+        }
+      }
+    });
+
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 512,
+      rooms: { W1N1: colony.room, W2N1: highDroppedEnergyRoom },
+      spawns: { Spawn1: spawn },
+      creeps: {
+        RemoteHarvester: makeRemoteHarvester('W2N1-source0', null),
+        RemoteHauler: makeRemoteHauler('W2N1-source0', null)
+      },
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+
+    expect(planSpawn(colony, { worker: 4 }, 513)).toBeNull();
   });
 
   it('waits on remote haulers when the home colony has no known delivery demand', () => {


### PR DESCRIPTION
## Summary
- Adds first-class reserve-first remote mining behavior for safe reserved Seasonal rooms without requiring fake `postClaimBootstraps` state.
- Adds the live E9S28 no-container recovery path: pending remote sources with enough loose dropped energy can dispatch one remote hauler by source, and no-container remote haulers pick up source-adjacent dropped energy before delivering home.
- Reduces future pending-container waste by having no-container remote harvesters build adjacent source-container construction sites before falling back to dropping energy.
- Preserves container-based remote hauling, hostile/foreign-controller safety holds, local delivery-demand gates, and no proactive player attack behavior.
- Regenerates the Screeps bundle through `npm run build`.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand hauler.test.ts remoteHarvester.test.ts spawnPlanner.test.ts` → `3 passed / 203 tests passed`
- `cd prod && npm run build`
- `cd prod && npm test -- --runInBand` → `105 passed / 2316 tests passed`

Related to issue 1700. Runtime/live-effect acceptance remains tracked on the issue until Seasonal deploy and observation evidence exist.

## Issue linkage / runtime acceptance note
- Related to issue 1700: this PR implements the code slice and keeps runtime acceptance on the issue until Seasonal deploy/live proof is collected.

## Universal task Done gate
- [x] Task type: Seasonal World gameplay production-code feature/fix.
- [x] Expected observable outcome / named deliverable: safe reserved adjacent rooms can become remote-mining targets without claim intent or fake post-claim bootstrap records, and pre-container remote source drops are recoverable before containers finish.
- [x] Non-goals / accepted substitutes: no paid Tencent compute, no learned-policy rollout, no official MMO write from this PR, and no proactive player attack behavior.
- [x] Verification evidence required before Done: `git diff --check`, prod typecheck, targeted Jest `3 passed / 203 tests`, full Jest `105 passed / 2316 tests`, and prod build passed from the controller on commit `f6bf2c62`.
- [x] Project Evidence / Next action / Blocked by: Project fields were refreshed with PR #1718, commit `f6bf2c62`, live E9S28 artifacts, and next controller gate/deploy routing; no blocker text is set.
- [x] Post-merge/deploy/runtime proof: implementation proof is the local test/build suite above; live Seasonal observation remains tracked on issue 1700 before the tracking item is marked Done.
- [x] Named deliverable proof: commit `f6bf2c62` changes `prod/src/creeps/remoteHarvester.ts`, `prod/src/creeps/hauler.ts`, `prod/src/spawn/spawnPlanner.ts`, `prod/src/types.d.ts`, focused tests, and regenerated `prod/dist/main.js`.