### PR TITLE
monitor: capture bounded creep task evidence

### DIFF
--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import base64
+import binascii
 import errno
+import gzip
 import html
 import json
 import math
@@ -25,6 +28,7 @@ import tempfile
 import time
 import urllib.parse
 import urllib.request
+import zlib
 from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -5214,6 +5218,16 @@ def decode_user_memory_data(payload: Any) -> dict[str, Any] | None:
     stripped = data.strip()
     if not stripped or stripped == "null":
         return {}
+    if stripped.startswith("gz:"):
+        encoded = stripped[3:].strip()
+        if not encoded:
+            return None
+        try:
+            stripped = gzip.decompress(base64.b64decode(encoded, validate=True)).decode("utf-8").strip()
+        except (binascii.Error, EOFError, OSError, UnicodeDecodeError, zlib.error):
+            return None
+        if not stripped or stripped == "null":
+            return {}
     try:
         decoded = json.loads(stripped)
     except json.JSONDecodeError:

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -5162,6 +5162,21 @@ def safe_assignment_string(value: Any) -> str | None:
     return redacted[: MAX_CREEP_MEMORY_ASSIGNMENT_STRING_LENGTH - 3] + "..."
 
 
+def user_memory_api_error(payload: Any, secrets: list[str] | None = None) -> str | None:
+    if not isinstance(payload, dict):
+        return None
+    ok = payload.get("ok")
+    if ok not in (0, False):
+        return None
+    status = "ok=false" if ok is False else "ok=0"
+    for key in ("error", "message", "err"):
+        detail = string_value(payload.get(key))
+        if detail is not None:
+            redacted = redact_secrets(detail, secrets or [])
+            return f"user memory API returned {status}: {short_text(redacted, 120)}"
+    return f"user memory API returned {status}"
+
+
 def decode_user_memory_data(payload: Any) -> dict[str, Any] | None:
     if not isinstance(payload, dict):
         return None
@@ -5207,6 +5222,9 @@ def fetch_creep_memory_map_for_shard(ctx: RuntimeContext, shard: str) -> dict[st
     for params, path_requested in requests:
         try:
             payload = get_json(ctx.base_http, ctx.token, "/api/user/memory", params)
+            api_error = user_memory_api_error(payload, [ctx.token])
+            if api_error is not None:
+                raise RuntimeError(api_error)
         except Exception as exc:  # noqa: BLE001 - caller reports one sanitized warning per shard
             last_error = exc
             continue

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -69,6 +69,11 @@ def alert_collection_timeout_budget_seconds(
     )
 
 
+def creep_memory_collection_timeout_budget_seconds(shard_count: int = 1) -> float:
+    shards = max(1, int(shard_count))
+    return shards * CREEP_MEMORY_COLLECTION_TIMEOUT_SECONDS_PER_SHARD
+
+
 DEFAULT_ALERT_TIMEOUT_SECONDS = alert_collection_timeout_budget_seconds()
 ALERT_TIMEOUT_POLL_SECONDS = 0.02
 ALERT_TIMEOUT_TERMINATE_GRACE_SECONDS = 1.0
@@ -992,15 +997,23 @@ def discover_owned_rooms(ctx: RuntimeContext, forced_room: RoomRef | None) -> tu
     return [fallback], overview, warnings, [fallback]
 
 
-def alert_collection_room_count(ctx: RuntimeContext, room_arg: str | None) -> int:
+def alert_collection_room_and_shard_count(ctx: RuntimeContext, room_arg: str | None) -> tuple[int, int]:
     forced_room = parse_room_arg(room_arg, ctx.default_shard)
     if forced_room:
-        return 1
+        return 1, 1
     try:
         overview = get_json(ctx.base_http, ctx.token, "/api/user/overview")
     except Exception:  # noqa: BLE001 - default timeout must still exist when discovery is unavailable
-        return 1
-    return max(1, len(overview_room_refs(overview)))
+        return 1, 1
+    refs = overview_room_refs(overview)
+    if not refs:
+        return 1, 1
+    return len(refs), max(1, len({ref.shard for ref in refs}))
+
+
+def alert_collection_room_count(ctx: RuntimeContext, room_arg: str | None) -> int:
+    room_count, _shard_count = alert_collection_room_and_shard_count(ctx, room_arg)
+    return room_count
 
 
 def terrain_cache_path(cache_dir: Path, ref: RoomRef) -> Path:
@@ -5268,11 +5281,19 @@ def fetch_creep_memories_by_shard(
     ctx: RuntimeContext,
     refs: list[RoomRef],
     warnings: list[str],
+    *,
+    timeout_budget_seconds_per_shard: float = CREEP_MEMORY_COLLECTION_TIMEOUT_SECONDS_PER_SHARD,
+    request_timeout_seconds: float = CREEP_MEMORY_REQUEST_TIMEOUT_SECONDS,
 ) -> dict[str, dict[str, Any]]:
     result: dict[str, dict[str, Any]] = {}
     for shard in sorted({ref.shard for ref in refs}):
         try:
-            result[shard] = fetch_creep_memory_map_for_shard(ctx, shard)
+            result[shard] = fetch_creep_memory_map_for_shard(
+                ctx,
+                shard,
+                timeout_budget_seconds=timeout_budget_seconds_per_shard,
+                request_timeout_seconds=request_timeout_seconds,
+            )
         except Exception as exc:  # noqa: BLE001 - runtime summary can still explain missing creep memory
             warnings.append(
                 f"{shard} creep memory unavailable: {short_text(redact_secrets(str(exc), [ctx.token]), 140)}"
@@ -6479,12 +6500,12 @@ def alert_timeout_seconds_from_args(args: argparse.Namespace) -> float:
         return float(configured_timeout)
 
     ctx = context_from_env(getattr(args, "world_profile", None))
-    room_count = alert_collection_room_count(ctx, getattr(args, "room", None))
+    room_count, shard_count = alert_collection_room_and_shard_count(ctx, getattr(args, "room", None))
     return alert_collection_timeout_budget_seconds(
         collection_attempts=ctx.collection_attempts,
         collection_retry_delay_seconds=ctx.collection_retry_delay_seconds,
         room_count=room_count,
-    )
+    ) + creep_memory_collection_timeout_budget_seconds(shard_count)
 
 
 def run_parsed_command(args: argparse.Namespace) -> int:
@@ -6928,8 +6949,8 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help=(
             "Wall-clock timeout for the alert command before emitting diagnostic JSON "
-            "(default: auto budget from monitored rooms and collection retry settings, "
-            "or SCREEPS_ALERT_TIMEOUT_SECONDS)."
+            "(default: auto budget from monitored rooms, collection retry settings, and "
+            "bounded creep-memory evidence, or SCREEPS_ALERT_TIMEOUT_SECONDS)."
         ),
     )
     alert.add_argument(

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -43,6 +43,8 @@ DEFAULT_DEBOUNCE_SECONDS = 300
 DEFAULT_COLLECTION_ATTEMPTS = 3
 DEFAULT_COLLECTION_RETRY_DELAY_SECONDS = 5
 ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS = 25.0
+CREEP_MEMORY_REQUEST_TIMEOUT_SECONDS = 2.0
+CREEP_MEMORY_COLLECTION_TIMEOUT_SECONDS_PER_SHARD = 5.0
 ALERT_COLLECTION_DISCOVERY_REQUEST_COUNT = 2
 ALERT_COLLECTION_INITIAL_ROOM_REQUEST_COUNT = 1
 ALERT_COLLECTION_FALLBACK_REQUEST_COUNT_PER_ATTEMPT = 2
@@ -876,7 +878,14 @@ def context_from_env(world_profile: str | None = None) -> RuntimeContext:
     )
 
 
-def get_json(base_http: str, token: str, path: str, params: dict[str, Any] | None = None) -> Any:
+def get_json(
+    base_http: str,
+    token: str,
+    path: str,
+    params: dict[str, Any] | None = None,
+    *,
+    timeout_seconds: float = ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS,
+) -> Any:
     url = base_http + path
     if params:
         url += "?" + urllib.parse.urlencode(params)
@@ -887,7 +896,7 @@ def get_json(base_http: str, token: str, path: str, params: dict[str, Any] | Non
             "User-Agent": "screeps-runtime-monitor/1.0",
         },
     )
-    with urllib.request.urlopen(request, timeout=ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS) as response:
+    with urllib.request.urlopen(request, timeout=max(0.001, float(timeout_seconds))) as response:
         return json.load(response)
 
 
@@ -5211,17 +5220,36 @@ def user_memory_creep_map(payload: Any, path_requested: bool) -> dict[str, Any] 
     return None
 
 
-def fetch_creep_memory_map_for_shard(ctx: RuntimeContext, shard: str) -> dict[str, Any]:
+def fetch_creep_memory_map_for_shard(
+    ctx: RuntimeContext,
+    shard: str,
+    *,
+    timeout_budget_seconds: float = CREEP_MEMORY_COLLECTION_TIMEOUT_SECONDS_PER_SHARD,
+    request_timeout_seconds: float = CREEP_MEMORY_REQUEST_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
     requests = (
         ({"path": "creeps", "shard": shard}, True),
         ({"path": "creeps"}, True),
         ({"shard": shard}, False),
         ({}, False),
     )
+    timeout_budget = max(0.0, float(timeout_budget_seconds))
+    request_timeout_cap = max(0.001, float(request_timeout_seconds))
+    deadline = time.monotonic() + timeout_budget
     last_error: Exception | None = None
     for params, path_requested in requests:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            last_error = TimeoutError(f"creep memory fetch timed out after {timeout_budget:g}s")
+            break
         try:
-            payload = get_json(ctx.base_http, ctx.token, "/api/user/memory", params)
+            payload = get_json(
+                ctx.base_http,
+                ctx.token,
+                "/api/user/memory",
+                params,
+                timeout_seconds=min(request_timeout_cap, remaining),
+            )
             api_error = user_memory_api_error(payload, [ctx.token])
             if api_error is not None:
                 raise RuntimeError(api_error)

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -108,7 +108,11 @@ RUNTIME_SUMMARY_CAPTURE_HISTORY_METADATA_KEY = "__runtimeSummaryCaptureHistory"
 RUNTIME_SUMMARY_SOURCE_METADATA_KEY = "__runtimeSummarySource"
 RUNTIME_SUMMARY_CPU_METADATA_KEY = "__runtimeSummaryCpu"
 MONITOR_RUNTIME_SUMMARY_SOURCE = "screeps-runtime-monitor"
-ASSIGNED_WORKER_TASK_NAMES = ("harvest", "transfer", "build", "repair", "upgrade")
+ASSIGNED_WORKER_TASK_NAMES = ("harvest", "pickup", "withdraw", "transfer", "build", "repair", "upgrade")
+WORKER_TASK_COUNT_NAMES = ("harvest", "transfer", "build", "repair", "upgrade")
+MAX_CREEP_MEMORY_ASSIGNMENT_EVIDENCE_PER_ROOM = 12
+MAX_CREEP_MEMORY_ASSIGNMENT_STRING_LENGTH = 96
+MAX_WORKER_ASSIGNMENT_BLOCKED_WORKERS = 12
 BUILD_BLOCKED_REASON_PATHS = (
     ("buildBlockedReason",),
     ("resources", "productiveEnergy", "buildBlockedReason"),
@@ -160,6 +164,29 @@ WORKER_ASSIGNMENT_BLOCKED_WORKER_NUMBER_FIELDS = (
     "carriedEnergy",
     "dispatchTick",
     "freeCapacity",
+)
+SAFE_CREEP_MEMORY_ASSIGNMENT_STRING_FIELDS = ("role", "colony")
+SAFE_CREEP_TASK_STRING_FIELDS = (
+    "type",
+    "targetId",
+    "sourceId",
+    "resourceType",
+    "constructionSiteId",
+    "controllerId",
+)
+SAFE_WORKER_DISPATCH_DIAGNOSTIC_STRING_FIELDS = (
+    "reason",
+    "currentTargetId",
+    "selectedTask",
+    "selectedTargetId",
+    "baseSelectedTask",
+    "baseSelectedTargetId",
+    "energyCriticalTask",
+    "energyCriticalTargetId",
+    "spawnReservationTask",
+    "spawnReservationTargetId",
+    "assignedTask",
+    "assignedTargetId",
 )
 ENERGY_BUFFER_UNHEALTHY_KIND = "energy_buffer_unhealthy"
 ENERGY_BUFFER_UNHEALTHY_REQUIRED_CONSECUTIVE = 2
@@ -672,6 +699,7 @@ class RoomSummaryMetrics:
     owned_creep_objects: list[dict[str, Any]]
     task_counts: dict[str, int]
     worker_assignment_evidence_available: bool
+    worker_assignment_evidence: dict[str, Any]
     worker_assignment_evidence_unavailable_reason: str | None
     construction_sites: list[dict[str, Any]]
     pending_build_progress: int | float
@@ -1096,6 +1124,7 @@ def collect_snapshots(ctx: RuntimeContext, room_arg: str | None) -> tuple[list[R
     refs, overview, warnings, overview_refs = discover_owned_rooms(ctx, forced_room)
     configured_owner, configured_owner_id = user_identity(ctx, warnings)
     configured_owner = configured_owner or overview_username(overview)
+    creep_memories_by_shard = fetch_creep_memories_by_shard(ctx, refs, warnings)
     snapshots: list[RoomSnapshot] = []
 
     for ref in refs:
@@ -1115,6 +1144,12 @@ def collect_snapshots(ctx: RuntimeContext, room_arg: str | None) -> tuple[list[R
                     event = fetch_room_event_http(ctx, ref)
                 objects = normalize_objects(event.get("objects"))
                 owner = infer_owner(objects, configured_owner, configured_owner_id)
+                objects = attach_safe_creep_memory_to_owned_creeps(
+                    objects,
+                    creep_memories_by_shard.get(ref.shard, {}),
+                    owner,
+                    configured_owner_id,
+                )
                 tick = event.get("gameTime") or event.get("time") or gametime_from_overview(overview, ref.shard)
                 snapshots.append(
                     RoomSnapshot(
@@ -4349,6 +4384,7 @@ def room_summary(snapshot: RoomSnapshot, image: str | None = None) -> dict[str, 
         "expected_owner_id": snapshot.expected_owner_id,
         "taskCounts": metrics.task_counts,
         "workerAssignmentEvidenceAvailable": metrics.worker_assignment_evidence_available,
+        "workerAssignmentEvidence": metrics.worker_assignment_evidence,
         **assignment_evidence_unavailable_fields,
         "pendingBuildProgress": metrics.pending_build_progress,
         "buildCarriedEnergy": metrics.build_carried_energy,
@@ -5095,7 +5131,8 @@ def worker_load_efficiency(
 
 
 def worker_task_counts(owned_creeps: list[dict[str, Any]]) -> dict[str, int]:
-    counts = {"harvest": 0, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0, "none": 0}
+    counts = {task_name: 0 for task_name in WORKER_TASK_COUNT_NAMES}
+    counts["none"] = 0
     for creep in owned_creeps:
         if not is_worker_creep(creep):
             continue
@@ -5111,6 +5148,167 @@ def string_value(value: Any) -> str | None:
     if isinstance(value, str) and value:
         return value
     return None
+
+
+def safe_assignment_string(value: Any) -> str | None:
+    text = string_value(value)
+    if text is None:
+        return None
+    redacted = redact_secrets(text, [])
+    if len(redacted) <= MAX_CREEP_MEMORY_ASSIGNMENT_STRING_LENGTH:
+        return redacted
+    if MAX_CREEP_MEMORY_ASSIGNMENT_STRING_LENGTH <= 3:
+        return redacted[:MAX_CREEP_MEMORY_ASSIGNMENT_STRING_LENGTH]
+    return redacted[: MAX_CREEP_MEMORY_ASSIGNMENT_STRING_LENGTH - 3] + "..."
+
+
+def decode_user_memory_data(payload: Any) -> dict[str, Any] | None:
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("ok") in (0, False):
+        return None
+    data = payload.get("data")
+    if data is None:
+        return payload
+    if isinstance(data, dict):
+        return data
+    if not isinstance(data, str):
+        return None
+    stripped = data.strip()
+    if not stripped or stripped == "null":
+        return {}
+    try:
+        decoded = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+    return decoded if isinstance(decoded, dict) else None
+
+
+def user_memory_creep_map(payload: Any, path_requested: bool) -> dict[str, Any] | None:
+    decoded = decode_user_memory_data(payload)
+    if decoded is None:
+        return None
+    creeps = decoded.get("creeps")
+    if isinstance(creeps, dict):
+        return creeps
+    if path_requested:
+        return decoded
+    return None
+
+
+def fetch_creep_memory_map_for_shard(ctx: RuntimeContext, shard: str) -> dict[str, Any]:
+    requests = (
+        ({"path": "creeps", "shard": shard}, True),
+        ({"path": "creeps"}, True),
+        ({"shard": shard}, False),
+        ({}, False),
+    )
+    last_error: Exception | None = None
+    for params, path_requested in requests:
+        try:
+            payload = get_json(ctx.base_http, ctx.token, "/api/user/memory", params)
+        except Exception as exc:  # noqa: BLE001 - caller reports one sanitized warning per shard
+            last_error = exc
+            continue
+        creep_map = user_memory_creep_map(payload, path_requested)
+        if creep_map is not None:
+            return creep_map
+    if last_error is not None:
+        raise last_error
+    return {}
+
+
+def fetch_creep_memories_by_shard(
+    ctx: RuntimeContext,
+    refs: list[RoomRef],
+    warnings: list[str],
+) -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    for shard in sorted({ref.shard for ref in refs}):
+        try:
+            result[shard] = fetch_creep_memory_map_for_shard(ctx, shard)
+        except Exception as exc:  # noqa: BLE001 - runtime summary can still explain missing creep memory
+            warnings.append(
+                f"{shard} creep memory unavailable: {short_text(redact_secrets(str(exc), [ctx.token]), 140)}"
+            )
+            result[shard] = {}
+    return result
+
+
+def sanitize_task_memory(value: Any) -> dict[str, Any] | str | None:
+    if isinstance(value, str):
+        return safe_assignment_string(value)
+    if not isinstance(value, dict):
+        return None
+    result: dict[str, Any] = {}
+    for key in SAFE_CREEP_TASK_STRING_FIELDS:
+        field_value = safe_assignment_string(value.get(key))
+        if field_value is not None:
+            result[key] = field_value
+    return result or None
+
+
+def sanitize_worker_dispatch_diagnostic_memory(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    result: dict[str, Any] = {}
+    for key in SAFE_WORKER_DISPATCH_DIAGNOSTIC_STRING_FIELDS:
+        field_value = safe_assignment_string(value.get(key))
+        if field_value is not None:
+            result[key] = field_value
+    tick = number_value(value.get("tick"))
+    if tick is not None:
+        result["tick"] = tick
+    return result or None
+
+
+def sanitize_creep_assignment_memory(value: Any) -> dict[str, Any]:
+    memory = as_dict(value)
+    result: dict[str, Any] = {}
+    for key in SAFE_CREEP_MEMORY_ASSIGNMENT_STRING_FIELDS:
+        field_value = safe_assignment_string(memory.get(key))
+        if field_value is not None:
+            result[key] = field_value
+    task = sanitize_task_memory(memory.get("task"))
+    if task is not None:
+        result["task"] = task
+    diagnostic = sanitize_worker_dispatch_diagnostic_memory(memory.get("workerDispatchDiagnostic"))
+    if diagnostic is not None:
+        result["workerDispatchDiagnostic"] = diagnostic
+    return result
+
+
+def attach_safe_creep_memory_to_owned_creeps(
+    objects: dict[str, dict[str, Any]],
+    creep_memories: dict[str, Any],
+    owner_username: str | None,
+    owner_id: str | None = None,
+) -> dict[str, dict[str, Any]]:
+    if not creep_memories:
+        return objects
+
+    result: dict[str, dict[str, Any]] = {}
+    changed = False
+    for object_id, obj in objects.items():
+        if not isinstance(obj, dict) or obj.get("type") != "creep":
+            result[object_id] = obj
+            continue
+        name = string_value(obj.get("name"))
+        if name is None or not is_owned_object(obj, owner_username, owner_id):
+            result[object_id] = obj
+            continue
+        safe_memory = sanitize_creep_assignment_memory(creep_memories.get(name))
+        if not safe_memory:
+            result[object_id] = obj
+            continue
+        merged = dict(as_dict(obj.get("memory")))
+        merged.update(safe_memory)
+        updated = dict(obj)
+        updated["memory"] = merged
+        result[object_id] = updated
+        changed = True
+
+    return result if changed else objects
 
 
 def explicit_worker_assignment_blocked_detail(source: dict[str, Any]) -> str | None:
@@ -5132,7 +5330,7 @@ def sanitized_worker_assignment_blocked_worker(value: Any) -> dict[str, Any] | N
 
     result: dict[str, Any] = {}
     for key in WORKER_ASSIGNMENT_BLOCKED_WORKER_STRING_FIELDS:
-        field_value = string_value(value.get(key))
+        field_value = safe_assignment_string(value.get(key))
         if field_value is not None:
             result[key] = field_value
     for key in WORKER_ASSIGNMENT_BLOCKED_WORKER_NUMBER_FIELDS:
@@ -5154,7 +5352,10 @@ def explicit_worker_assignment_blocked_workers(source: dict[str, Any]) -> list[d
             continue
         workers = [
             worker
-            for worker in (sanitized_worker_assignment_blocked_worker(item) for item in value)
+            for worker in (
+                sanitized_worker_assignment_blocked_worker(item)
+                for item in value[:MAX_WORKER_ASSIGNMENT_BLOCKED_WORKERS]
+            )
             if worker is not None
         ]
         return workers
@@ -5185,6 +5386,81 @@ def creep_task_type(creep: dict[str, Any]) -> str | None:
         if task_type is not None:
             return task_type
     return None
+
+
+def worker_assignment_task_is_productive(task_type: str | None) -> bool:
+    return task_type is not None and task_type.strip().lower() in ASSIGNED_WORKER_TASK_NAMES
+
+
+def creep_task_field(creep: dict[str, Any], key: str) -> str | None:
+    task = creep_memory(creep).get("task")
+    if not isinstance(task, dict):
+        return None
+    return safe_assignment_string(task.get(key))
+
+
+def creep_assignment_evidence_candidate(creep: dict[str, Any]) -> bool:
+    return creep_has_assignment_evidence(creep) or creep_name_looks_like_worker(creep)
+
+
+def worker_assignment_creep_evidence(creep: dict[str, Any], snapshot_tick: int | str | None) -> dict[str, Any]:
+    task_type = creep_task_type(creep)
+    memory = creep_memory(creep)
+    role = creep_role(creep)
+    task_target_id = creep_task_field(creep, "targetId")
+    task_source_id = creep_task_field(creep, "sourceId")
+    task_construction_site_id = creep_task_field(creep, "constructionSiteId")
+    evidence: dict[str, Any] = {
+        **({"name": creep_name(creep)} if creep_name(creep) else {}),
+        "memoryAvailable": bool(memory),
+        **({"role": safe_assignment_string(role)} if role else {}),
+        **({"task": safe_assignment_string(task_type)} if task_type else {}),
+        **({"taskTargetId": task_target_id} if task_target_id else {}),
+        **({"taskSourceId": task_source_id} if task_source_id else {}),
+        **({"taskConstructionSiteId": task_construction_site_id} if task_construction_site_id else {}),
+        "carriedEnergy": carried_energy(creep),
+        "freeCapacity": creep_free_energy_capacity(creep),
+    }
+    evidence.update(worker_dispatch_diagnostic_fields(creep, snapshot_tick))
+    return evidence
+
+
+def worker_assignment_evidence_summary(
+    owned_creeps: list[dict[str, Any]],
+    tick: int | str | None,
+    assignment_evidence_available: bool,
+    unavailable_reason: str | None,
+) -> dict[str, Any]:
+    workers = [creep for creep in owned_creeps if is_worker_creep(creep)]
+    assigned_task_count = sum(1 for worker in workers if creep_task_type(worker) is not None)
+    productive_assignment_count = sum(
+        1 for worker in workers if worker_assignment_task_is_productive(creep_task_type(worker))
+    )
+    candidates = sorted(
+        [creep for creep in owned_creeps if creep_assignment_evidence_candidate(creep)],
+        key=lambda creep: (creep_name(creep) or "", creep_task_type(creep) or ""),
+    )
+    samples = [
+        worker_assignment_creep_evidence(creep, tick)
+        for creep in candidates[:MAX_CREEP_MEMORY_ASSIGNMENT_EVIDENCE_PER_ROOM]
+    ]
+    evidence: dict[str, Any] = {
+        "source": MONITOR_RUNTIME_SUMMARY_SOURCE,
+        "available": assignment_evidence_available,
+        **({"unavailableReason": unavailable_reason} if unavailable_reason is not None else {}),
+        **({"tick": tick} if isinstance(tick, int) else {}),
+        "visibleCreepCount": len(owned_creeps),
+        "workerCount": len(workers),
+        "assignedTaskCount": assigned_task_count,
+        "productiveAssignmentCount": productive_assignment_count,
+        "unassignedWorkerCount": max(0, len(workers) - assigned_task_count),
+        "sampleLimit": MAX_CREEP_MEMORY_ASSIGNMENT_EVIDENCE_PER_ROOM,
+        "sampleCount": len(samples),
+        "sampleTruncated": len(candidates) > MAX_CREEP_MEMORY_ASSIGNMENT_EVIDENCE_PER_ROOM,
+    }
+    if samples:
+        evidence["creepSamples"] = samples
+    return evidence
 
 
 def creep_free_energy_capacity(creep: dict[str, Any]) -> int | float:
@@ -5303,21 +5579,27 @@ def worker_dispatch_diagnostic_fields(
     ):
         return {}
 
-    return {
-        **({"dispatchReason": diagnostic.get("reason")} if string_value(diagnostic.get("reason")) else {}),
-        **({"dispatchTick": diagnostic_tick} if diagnostic_tick is not None else {}),
-        **({"dispatchCurrentTargetId": diagnostic.get("currentTargetId")} if string_value(diagnostic.get("currentTargetId")) else {}),
-        **({"dispatchSelectedTask": diagnostic.get("selectedTask")} if string_value(diagnostic.get("selectedTask")) else {}),
-        **({"dispatchSelectedTargetId": diagnostic.get("selectedTargetId")} if string_value(diagnostic.get("selectedTargetId")) else {}),
-        **({"dispatchBaseSelectedTask": diagnostic.get("baseSelectedTask")} if string_value(diagnostic.get("baseSelectedTask")) else {}),
-        **({"dispatchBaseSelectedTargetId": diagnostic.get("baseSelectedTargetId")} if string_value(diagnostic.get("baseSelectedTargetId")) else {}),
-        **({"dispatchEnergyCriticalTask": diagnostic.get("energyCriticalTask")} if string_value(diagnostic.get("energyCriticalTask")) else {}),
-        **({"dispatchEnergyCriticalTargetId": diagnostic.get("energyCriticalTargetId")} if string_value(diagnostic.get("energyCriticalTargetId")) else {}),
-        **({"dispatchSpawnReservationTask": diagnostic.get("spawnReservationTask")} if string_value(diagnostic.get("spawnReservationTask")) else {}),
-        **({"dispatchSpawnReservationTargetId": diagnostic.get("spawnReservationTargetId")} if string_value(diagnostic.get("spawnReservationTargetId")) else {}),
-        **({"dispatchAssignedTask": diagnostic.get("assignedTask")} if string_value(diagnostic.get("assignedTask")) else {}),
-        **({"dispatchAssignedTargetId": diagnostic.get("assignedTargetId")} if string_value(diagnostic.get("assignedTargetId")) else {}),
-    }
+    result: dict[str, Any] = {}
+    for source_key, target_key in (
+        ("reason", "dispatchReason"),
+        ("currentTargetId", "dispatchCurrentTargetId"),
+        ("selectedTask", "dispatchSelectedTask"),
+        ("selectedTargetId", "dispatchSelectedTargetId"),
+        ("baseSelectedTask", "dispatchBaseSelectedTask"),
+        ("baseSelectedTargetId", "dispatchBaseSelectedTargetId"),
+        ("energyCriticalTask", "dispatchEnergyCriticalTask"),
+        ("energyCriticalTargetId", "dispatchEnergyCriticalTargetId"),
+        ("spawnReservationTask", "dispatchSpawnReservationTask"),
+        ("spawnReservationTargetId", "dispatchSpawnReservationTargetId"),
+        ("assignedTask", "dispatchAssignedTask"),
+        ("assignedTargetId", "dispatchAssignedTargetId"),
+    ):
+        field_value = safe_assignment_string(diagnostic.get(source_key))
+        if field_value is not None:
+            result[target_key] = field_value
+    if diagnostic_tick is not None:
+        result["dispatchTick"] = diagnostic_tick
+    return result
 
 
 def worker_assignment_blocked_workers_from_creeps(
@@ -5326,7 +5608,10 @@ def worker_assignment_blocked_workers_from_creeps(
 ) -> list[dict[str, Any]]:
     workers = [creep for creep in metrics.owned_creep_objects if is_worker_creep(creep)]
     result: list[dict[str, Any]] = []
-    for worker in sorted(workers, key=lambda creep: (creep_task_type(creep) or "", creep_name(creep) or "")):
+    for worker in sorted(
+        workers,
+        key=lambda creep: (creep_task_type(creep) or "", creep_name(creep) or ""),
+    )[:MAX_WORKER_ASSIGNMENT_BLOCKED_WORKERS]:
         worker_summary: dict[str, Any] = {
             **({"name": creep_name(worker)} if creep_name(worker) else {}),
             **({"task": creep_task_type(worker)} if creep_task_type(worker) else {}),
@@ -5647,6 +5932,12 @@ def compute_room_summary_metrics(snapshot: RoomSnapshot) -> RoomSummaryMetrics:
         owned_creep_objects,
         assignment_evidence_available,
     )
+    assignment_evidence = worker_assignment_evidence_summary(
+        owned_creep_objects,
+        snapshot.tick,
+        assignment_evidence_available,
+        assignment_evidence_unavailable_reason,
+    )
     pending_build_progress = sum(construction_site_pending_progress(site) for site in construction_sites)
     extension_pending_build_progress = sum(
         construction_site_pending_progress(site) for site in extension_construction_sites
@@ -5666,6 +5957,7 @@ def compute_room_summary_metrics(snapshot: RoomSnapshot) -> RoomSummaryMetrics:
         owned_creep_objects=owned_creep_objects,
         task_counts=task_counts,
         worker_assignment_evidence_available=assignment_evidence_available,
+        worker_assignment_evidence=assignment_evidence,
         worker_assignment_evidence_unavailable_reason=assignment_evidence_unavailable_reason,
         construction_sites=construction_sites,
         pending_build_progress=pending_build_progress,
@@ -5751,6 +6043,8 @@ def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
     construction_activity = construction_activity_summary(snapshot, metrics, assignment_blocked_fields)
     worker_carried_energy = sum(store_energy(obj) for obj in owned_creeps)
     productive_energy = {
+        "assignedWorkerCount": metrics.worker_assignment_evidence.get("assignedTaskCount", 0),
+        "productiveAssignmentCount": metrics.worker_assignment_evidence.get("productiveAssignmentCount", 0),
         "pendingBuildProgress": metrics.pending_build_progress,
         "buildCarriedEnergy": metrics.build_carried_energy,
         "constructionDeadlockTicks": metrics.construction_deadlock_ticks,
@@ -5769,6 +6063,7 @@ def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
         "shard": snapshot.ref.shard,
         "taskCounts": metrics.task_counts,
         "workerAssignmentEvidenceAvailable": metrics.worker_assignment_evidence_available,
+        "workerAssignmentEvidence": metrics.worker_assignment_evidence,
         **assignment_evidence_unavailable_fields,
         "pendingBuildProgress": metrics.pending_build_progress,
         "buildCarriedEnergy": metrics.build_carried_energy,

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -3386,9 +3386,12 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
                     _token: str,
                     path: str,
                     params: dict[str, object] | None = None,
+                    *,
+                    timeout_seconds: float = monitor.ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS,
                 ) -> object:
                     self.assertEqual(path, "/api/user/memory")
                     calls.append(dict(params or {}))
+                    self.assertEqual(timeout_seconds, monitor.CREEP_MEMORY_REQUEST_TIMEOUT_SECONDS)
                     return {"ok": ok_value, "error": "auth failed token=secret-token"}
 
                 with mock.patch.object(monitor, "get_json", side_effect=fake_get_json):
@@ -3400,6 +3403,61 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
                 self.assertIn(f"shardX creep memory unavailable: user memory API returned {expected_status}", warnings[0])
                 self.assertIn("auth failed", warnings[0])
                 self.assertNotIn("secret-token", warnings[0])
+
+    def test_fetch_creep_memories_uses_dedicated_timeout_budget(self) -> None:
+        ref = monitor.RoomRef(shard="shardX", room="E29N55")
+        ctx = monitor.RuntimeContext(
+            base_http="https://screeps.com",
+            token="secret-token",
+            default_shard="shardX",
+            default_room="E29N55",
+            owner=None,
+            owner_id=None,
+            state_file=Path("/tmp/state.json"),
+            cache_dir=Path("/tmp/cache"),
+            debounce_seconds=300,
+            collection_attempts=1,
+            collection_retry_delay_seconds=0,
+        )
+        warnings: list[str] = []
+        calls: list[dict[str, object]] = []
+        timeouts: list[float] = []
+        monotonic_values = iter([100.0, 100.0, 102.25, 104.75, 105.25])
+
+        def fake_monotonic() -> float:
+            return next(monotonic_values)
+
+        def fake_get_json(
+            _base_http: str,
+            _token: str,
+            path: str,
+            params: dict[str, object] | None = None,
+            *,
+            timeout_seconds: float = monitor.ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS,
+        ) -> object:
+            self.assertEqual(path, "/api/user/memory")
+            calls.append(dict(params or {}))
+            timeouts.append(timeout_seconds)
+            raise TimeoutError("slow user memory")
+
+        with mock.patch.object(monitor.time, "monotonic", side_effect=fake_monotonic):
+            with mock.patch.object(monitor, "get_json", side_effect=fake_get_json):
+                memories = monitor.fetch_creep_memories_by_shard(ctx, [ref], warnings)
+
+        self.assertEqual(memories, {"shardX": {}})
+        self.assertEqual(
+            calls,
+            [
+                {"path": "creeps", "shard": "shardX"},
+                {"path": "creeps"},
+                {"shard": "shardX"},
+            ],
+        )
+        self.assertEqual(timeouts[:2], [monitor.CREEP_MEMORY_REQUEST_TIMEOUT_SECONDS] * 2)
+        self.assertAlmostEqual(timeouts[2], 0.25)
+        self.assertTrue(all(timeout < monitor.ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS for timeout in timeouts))
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("shardX creep memory unavailable: creep memory fetch timed out after 5s", warnings[0])
 
     def test_collect_snapshots_merges_redacted_creep_memory_assignment_evidence(self) -> None:
         ref = monitor.RoomRef(shard="shardX", room="E29N55")
@@ -3448,9 +3506,17 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
                 },
             }
 
-        def fake_get_json(_base_http: str, _token: str, path: str, params: dict[str, object] | None = None) -> object:
+        def fake_get_json(
+            _base_http: str,
+            _token: str,
+            path: str,
+            params: dict[str, object] | None = None,
+            *,
+            timeout_seconds: float = monitor.ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS,
+        ) -> object:
             self.assertEqual(path, "/api/user/memory")
             self.assertEqual(params, {"path": "creeps", "shard": "shardX"})
+            self.assertEqual(timeout_seconds, monitor.CREEP_MEMORY_REQUEST_TIMEOUT_SECONDS)
             return {
                 "ok": 1,
                 "data": json.dumps(

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -298,6 +298,13 @@ def make_worker_assignment_gap_metrics() -> monitor.RoomSummaryMetrics:
         owned_creep_objects=[],
         task_counts={"harvest": 0, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0},
         worker_assignment_evidence_available=True,
+        worker_assignment_evidence={
+            "source": "runtime-summary",
+            "available": True,
+            "workerCount": 0,
+            "assignedTaskCount": 0,
+            "productiveAssignmentCount": 0,
+        },
         worker_assignment_evidence_unavailable_reason=None,
         construction_sites=[{"type": "constructionSite"}],
         pending_build_progress=50,
@@ -3346,6 +3353,197 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         )
         self.assertIsNone(reason)
         self.assertEqual(next_state, 0)
+
+    def test_collect_snapshots_merges_redacted_creep_memory_assignment_evidence(self) -> None:
+        ref = monitor.RoomRef(shard="shardX", room="E29N55")
+        ctx = monitor.RuntimeContext(
+            base_http="https://screeps.com",
+            token="secret-token",
+            default_shard="shardX",
+            default_room="E29N55",
+            owner=None,
+            owner_id=None,
+            state_file=Path("/tmp/state.json"),
+            cache_dir=Path("/tmp/cache"),
+            debounce_seconds=300,
+            collection_attempts=1,
+            collection_retry_delay_seconds=0,
+        )
+
+        async def fake_fetch_room_event(_ctx: monitor.RuntimeContext, _ref: monitor.RoomRef) -> dict[str, object]:
+            return {
+                "gameTime": 1839622,
+                "objects": {
+                    "spawn-1": {
+                        "_id": "spawn-1",
+                        "type": "spawn",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                    },
+                    "site-1": {
+                        "_id": "site-1",
+                        "type": "constructionSite",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "structureType": "extension",
+                        "progress": 0,
+                        "progressTotal": 50,
+                    },
+                    "worker-1": {
+                        "_id": "worker-1",
+                        "type": "creep",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "name": "WorkerBuild",
+                        "body": [{"type": "work", "hits": 100}, {"type": "carry", "hits": 100}],
+                        "store": {"energy": 25, "capacity": 50},
+                    },
+                },
+            }
+
+        def fake_get_json(_base_http: str, _token: str, path: str, params: dict[str, object] | None = None) -> object:
+            self.assertEqual(path, "/api/user/memory")
+            self.assertEqual(params, {"path": "creeps", "shard": "shardX"})
+            return {
+                "ok": 1,
+                "data": json.dumps(
+                    {
+                        "WorkerBuild": {
+                            "role": "worker",
+                            "task": {"type": "build", "targetId": "token=abcdef123456"},
+                            "workerDispatchDiagnostic": {
+                                "tick": 1839622,
+                                "reason": "selected_build",
+                                "assignedTask": "build",
+                                "assignedTargetId": "site-1",
+                            },
+                            "secretNotes": "do-not-emit",
+                        }
+                    }
+                ),
+            }
+
+        with mock.patch.object(monitor, "discover_owned_rooms", return_value=([ref], {"username": "lanyusea"}, [], [ref])):
+            with mock.patch.object(monitor, "user_identity", return_value=("lanyusea", "user-1")):
+                with mock.patch.object(monitor, "fetch_terrain", return_value="0" * monitor.TERRAIN_CELLS):
+                    with mock.patch.object(monitor, "fetch_room_event", side_effect=fake_fetch_room_event):
+                        with mock.patch.object(monitor, "get_json", side_effect=fake_get_json):
+                            snapshots, warnings, overview_refs = monitor.collect_snapshots(ctx, None)
+
+        self.assertEqual(warnings, [])
+        self.assertEqual(overview_refs, [ref])
+        payload = monitor.runtime_summary_payload_from_snapshots(snapshots)
+        room = payload["rooms"][0]
+        productive_energy = room["resources"]["productiveEnergy"]
+        evidence = room["workerAssignmentEvidence"]
+
+        self.assertTrue(room["workerAssignmentEvidenceAvailable"])
+        self.assertTrue(productive_energy["workerAssignmentEvidenceAvailable"])
+        self.assertEqual(room["taskCounts"]["build"], 1)
+        self.assertEqual(evidence["productiveAssignmentCount"], 1)
+        self.assertEqual(productive_energy["productiveAssignmentCount"], 1)
+        self.assertEqual(evidence["creepSamples"][0]["name"], "WorkerBuild")
+        self.assertEqual(evidence["creepSamples"][0]["role"], "worker")
+        self.assertEqual(evidence["creepSamples"][0]["task"], "build")
+        self.assertEqual(evidence["creepSamples"][0]["dispatchAssignedTask"], "build")
+        rendered = json.dumps(evidence, sort_keys=True)
+        self.assertNotIn("secretNotes", rendered)
+        self.assertNotIn("abcdef123456", rendered)
+
+    def test_runtime_summary_payload_marks_partial_creep_memory_samples(self) -> None:
+        objects = monitor.normalize_objects(
+            {
+                "worker-1": {
+                    "_id": "worker-1",
+                    "type": "creep",
+                    "my": True,
+                    "owner": {"username": "lanyusea"},
+                    "name": "WorkerBuild",
+                    "store": {"energy": 25, "capacity": 50},
+                },
+                "worker-2": {
+                    "_id": "worker-2",
+                    "type": "creep",
+                    "my": True,
+                    "owner": {"username": "lanyusea"},
+                    "name": "WorkerMissing",
+                    "store": {"energy": 0, "capacity": 50},
+                },
+            }
+        )
+        objects = monitor.attach_safe_creep_memory_to_owned_creeps(
+            objects,
+            {"WorkerBuild": {"role": "worker", "task": {"type": "build", "targetId": "site-1"}}},
+            "lanyusea",
+        )
+        snapshot = monitor.RoomSnapshot(
+            ref=monitor.RoomRef(shard="shardX", room="E29N55"),
+            terrain="0" * monitor.TERRAIN_CELLS,
+            objects=objects,
+            tick=1839623,
+            owner="lanyusea",
+            info={},
+        )
+
+        payload = monitor.runtime_summary_payload_from_snapshots([snapshot])
+        evidence = payload["rooms"][0]["workerAssignmentEvidence"]
+        samples = {sample["name"]: sample for sample in evidence["creepSamples"]}
+
+        self.assertTrue(payload["rooms"][0]["workerAssignmentEvidenceAvailable"])
+        self.assertEqual(payload["rooms"][0]["taskCounts"]["build"], 1)
+        self.assertEqual(evidence["visibleCreepCount"], 2)
+        self.assertEqual(evidence["workerCount"], 1)
+        self.assertTrue(samples["WorkerBuild"]["memoryAvailable"])
+        self.assertFalse(samples["WorkerMissing"]["memoryAvailable"])
+        self.assertNotIn("workerAssignmentEvidenceUnavailableReason", payload["rooms"][0])
+
+    def test_worker_assignment_evidence_caps_and_redacts_creep_samples(self) -> None:
+        objects: dict[str, dict[str, object]] = {}
+        creep_memory: dict[str, dict[str, object]] = {}
+        for index in range(monitor.MAX_CREEP_MEMORY_ASSIGNMENT_EVIDENCE_PER_ROOM + 3):
+            name = f"Worker{index:02d}"
+            objects[f"worker-{index}"] = {
+                "_id": f"worker-{index}",
+                "type": "creep",
+                "my": True,
+                "owner": {"username": "lanyusea"},
+                "name": name,
+                "store": {"energy": index, "capacity": 50},
+            }
+            creep_memory[name] = {
+                "role": "worker",
+                "task": {
+                    "type": "upgrade",
+                    "targetId": "controller-1-" + ("x" * 200),
+                },
+                "password": "do-not-emit",
+            }
+        normalized = monitor.attach_safe_creep_memory_to_owned_creeps(
+            monitor.normalize_objects(objects),
+            creep_memory,
+            "lanyusea",
+        )
+        snapshot = monitor.RoomSnapshot(
+            ref=monitor.RoomRef(shard="shardX", room="E29N55"),
+            terrain="0" * monitor.TERRAIN_CELLS,
+            objects=normalized,
+            tick=1839624,
+            owner="lanyusea",
+            info={},
+        )
+
+        evidence = monitor.runtime_summary_payload_from_snapshots([snapshot])["rooms"][0]["workerAssignmentEvidence"]
+        rendered = json.dumps(evidence, sort_keys=True)
+
+        self.assertEqual(evidence["sampleLimit"], monitor.MAX_CREEP_MEMORY_ASSIGNMENT_EVIDENCE_PER_ROOM)
+        self.assertEqual(len(evidence["creepSamples"]), monitor.MAX_CREEP_MEMORY_ASSIGNMENT_EVIDENCE_PER_ROOM)
+        self.assertTrue(evidence["sampleTruncated"])
+        self.assertNotIn("password", rendered)
+        self.assertNotIn("do-not-emit", rendered)
+        self.assertLessEqual(
+            max(len(sample["taskTargetId"]) for sample in evidence["creepSamples"]),
+            monitor.MAX_CREEP_MEMORY_ASSIGNMENT_STRING_LENGTH,
+        )
 
     def test_runtime_summary_payload_ignores_non_worker_assignment_evidence(self) -> None:
         snapshot = monitor.RoomSnapshot(

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-import importlib.util
+import base64
 import copy
 import errno
+import gzip
+import importlib.util
 import io
 import json
 import sys
@@ -3439,6 +3441,108 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
                 self.assertIn(f"shardX creep memory unavailable: user memory API returned {expected_status}", warnings[0])
                 self.assertIn("auth failed", warnings[0])
                 self.assertNotIn("secret-token", warnings[0])
+
+    def test_fetch_creep_memory_map_decodes_gzipped_user_memory_payload(self) -> None:
+        ctx = monitor.RuntimeContext(
+            base_http="https://screeps.com",
+            token="secret-token",
+            default_shard="shardX",
+            default_room="E29N55",
+            owner=None,
+            owner_id=None,
+            state_file=Path("/tmp/state.json"),
+            cache_dir=Path("/tmp/cache"),
+            debounce_seconds=300,
+            collection_attempts=1,
+            collection_retry_delay_seconds=0,
+        )
+        creep_memory = {
+            "WorkerBuild": {
+                "role": "worker",
+                "task": {"type": "build", "targetId": "site-1"},
+            }
+        }
+        encoded = base64.b64encode(
+            gzip.compress(json.dumps(creep_memory, sort_keys=True).encode("utf-8"))
+        ).decode("ascii")
+        calls: list[dict[str, object]] = []
+
+        def fake_get_json(
+            _base_http: str,
+            _token: str,
+            path: str,
+            params: dict[str, object] | None = None,
+            *,
+            timeout_seconds: float = monitor.ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS,
+        ) -> object:
+            self.assertEqual(path, "/api/user/memory")
+            calls.append(dict(params or {}))
+            self.assertEqual(timeout_seconds, monitor.CREEP_MEMORY_REQUEST_TIMEOUT_SECONDS)
+            return {"ok": 1, "data": "gz:" + encoded}
+
+        with mock.patch.object(monitor, "get_json", side_effect=fake_get_json):
+            memories = monitor.fetch_creep_memory_map_for_shard(ctx, "shardX")
+
+        self.assertEqual(calls, [{"path": "creeps", "shard": "shardX"}])
+        self.assertEqual(memories, creep_memory)
+
+    def test_fetch_creep_memories_treats_malformed_gzipped_user_memory_as_non_decodable(self) -> None:
+        ref = monitor.RoomRef(shard="shardX", room="E29N55")
+        ctx = monitor.RuntimeContext(
+            base_http="https://screeps.com",
+            token="secret-token",
+            default_shard="shardX",
+            default_room="E29N55",
+            owner=None,
+            owner_id=None,
+            state_file=Path("/tmp/state.json"),
+            cache_dir=Path("/tmp/cache"),
+            debounce_seconds=300,
+            collection_attempts=1,
+            collection_retry_delay_seconds=0,
+        )
+        malformed_payloads = [
+            ("invalid-base64", "gz:not-base64-token=secret-token"),
+            (
+                "invalid-gzip",
+                "gz:" + base64.b64encode(b"not gzip token=secret-token").decode("ascii"),
+            ),
+            (
+                "invalid-json",
+                "gz:" + base64.b64encode(gzip.compress(b'{"WorkerBuild":')).decode("ascii"),
+            ),
+        ]
+        expected_calls = [
+            {"path": "creeps", "shard": "shardX"},
+            {"path": "creeps"},
+            {"shard": "shardX"},
+            {},
+        ]
+
+        for case, data in malformed_payloads:
+            with self.subTest(case=case):
+                warnings: list[str] = []
+                calls: list[dict[str, object]] = []
+
+                def fake_get_json(
+                    _base_http: str,
+                    _token: str,
+                    path: str,
+                    params: dict[str, object] | None = None,
+                    *,
+                    timeout_seconds: float = monitor.ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS,
+                ) -> object:
+                    self.assertEqual(path, "/api/user/memory")
+                    calls.append(dict(params or {}))
+                    self.assertEqual(timeout_seconds, monitor.CREEP_MEMORY_REQUEST_TIMEOUT_SECONDS)
+                    return {"ok": 1, "data": data}
+
+                with mock.patch.object(monitor, "get_json", side_effect=fake_get_json):
+                    memories = monitor.fetch_creep_memories_by_shard(ctx, [ref], warnings)
+
+                self.assertEqual(memories, {"shardX": {}})
+                self.assertEqual(calls, expected_calls)
+                self.assertEqual(warnings, [])
 
     def test_fetch_creep_memories_uses_dedicated_timeout_budget(self) -> None:
         ref = monitor.RoomRef(shard="shardX", room="E29N55")

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -357,6 +357,10 @@ class WorldProfileDefaultsTest(unittest.TestCase):
         self.assertEqual(Path(alert_args.runtime_summary_dir), monitor.DEFAULT_RUNTIME_SUMMARY_OUT_DIR)
         self.assertEqual(monitor.alert_collection_timeout_budget_seconds(), expected_alert_timeout)
         self.assertEqual(monitor.DEFAULT_ALERT_TIMEOUT_SECONDS, expected_alert_timeout)
+        self.assertLess(
+            monitor.CREEP_MEMORY_COLLECTION_TIMEOUT_SECONDS_PER_SHARD,
+            monitor.ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS,
+        )
         self.assertIsNone(alert_args.alert_timeout_seconds)
         self.assertLess(monitor.DEFAULT_ALERT_TIMEOUT_SECONDS, 15 * 60)
         self.assertEqual(ctx.base_http, monitor.DEFAULT_API_URL)
@@ -413,13 +417,45 @@ class WorldProfileDefaultsTest(unittest.TestCase):
                     rc = monitor.run_parsed_command(alert_args)
 
         self.assertEqual(rc, 0)
-        self.assertAlmostEqual(
-            run_alert.call_args.args[1],
-            monitor.alert_collection_timeout_budget_seconds(
-                collection_attempts=4,
-                collection_retry_delay_seconds=7.5,
-                room_count=2,
-            ),
+        alert_collection_budget = monitor.alert_collection_timeout_budget_seconds(
+            collection_attempts=4,
+            collection_retry_delay_seconds=7.5,
+            room_count=2,
+        )
+        memory_evidence_budget = monitor.creep_memory_collection_timeout_budget_seconds(shard_count=1)
+        self.assertAlmostEqual(run_alert.call_args.args[1], alert_collection_budget + memory_evidence_budget)
+
+    def test_alert_timeout_default_adds_bounded_creep_memory_budget_per_shard(self) -> None:
+        overview = {
+            "shards": {
+                "shardSeason": {"rooms": ["E1N1"]},
+                "shardX": {"rooms": ["E2N2"]},
+            }
+        }
+        with mock.patch.dict(monitor.os.environ, {"SCREEPS_AUTH_TOKEN": "token"}, clear=True):
+            alert_args = monitor.build_parser().parse_args(["alert"])
+            with mock.patch.object(monitor, "get_json", return_value=overview):
+                with mock.patch.object(monitor, "run_alert_with_process_timeout", return_value=0) as run_alert:
+                    rc = monitor.run_parsed_command(alert_args)
+
+        alert_collection_budget = monitor.alert_collection_timeout_budget_seconds(room_count=2)
+        memory_evidence_budget = monitor.creep_memory_collection_timeout_budget_seconds(shard_count=2)
+
+        self.assertEqual(rc, 0)
+        self.assertAlmostEqual(run_alert.call_args.args[1], alert_collection_budget + memory_evidence_budget)
+        self.assertEqual(memory_evidence_budget, 2 * monitor.CREEP_MEMORY_COLLECTION_TIMEOUT_SECONDS_PER_SHARD)
+        self.assertEqual(
+            alert_collection_budget,
+            (
+                monitor.ALERT_COLLECTION_DISCOVERY_REQUEST_COUNT
+                + 2
+                * (
+                    monitor.ALERT_COLLECTION_INITIAL_ROOM_REQUEST_COUNT
+                    + monitor.DEFAULT_COLLECTION_ATTEMPTS * monitor.ALERT_COLLECTION_FALLBACK_REQUEST_COUNT_PER_ATTEMPT
+                )
+            )
+            * monitor.ROOM_SNAPSHOT_REQUEST_TIMEOUT_SECONDS
+            + 2 * (monitor.DEFAULT_COLLECTION_ATTEMPTS - 1) * monitor.DEFAULT_COLLECTION_RETRY_DELAY_SECONDS,
         )
 
     def test_positive_float_arg_rejects_non_finite_values(self) -> None:

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -3354,6 +3354,53 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         self.assertIsNone(reason)
         self.assertEqual(next_state, 0)
 
+    def test_fetch_creep_memories_reports_user_memory_api_errors(self) -> None:
+        ref = monitor.RoomRef(shard="shardX", room="E29N55")
+        ctx = monitor.RuntimeContext(
+            base_http="https://screeps.com",
+            token="secret-token",
+            default_shard="shardX",
+            default_room="E29N55",
+            owner=None,
+            owner_id=None,
+            state_file=Path("/tmp/state.json"),
+            cache_dir=Path("/tmp/cache"),
+            debounce_seconds=300,
+            collection_attempts=1,
+            collection_retry_delay_seconds=0,
+        )
+        expected_calls = [
+            {"path": "creeps", "shard": "shardX"},
+            {"path": "creeps"},
+            {"shard": "shardX"},
+            {},
+        ]
+
+        for ok_value, expected_status in ((False, "ok=false"), (0, "ok=0")):
+            with self.subTest(ok=ok_value):
+                warnings: list[str] = []
+                calls: list[dict[str, object]] = []
+
+                def fake_get_json(
+                    _base_http: str,
+                    _token: str,
+                    path: str,
+                    params: dict[str, object] | None = None,
+                ) -> object:
+                    self.assertEqual(path, "/api/user/memory")
+                    calls.append(dict(params or {}))
+                    return {"ok": ok_value, "error": "auth failed token=secret-token"}
+
+                with mock.patch.object(monitor, "get_json", side_effect=fake_get_json):
+                    memories = monitor.fetch_creep_memories_by_shard(ctx, [ref], warnings)
+
+                self.assertEqual(memories, {"shardX": {}})
+                self.assertEqual(calls, expected_calls)
+                self.assertEqual(len(warnings), 1)
+                self.assertIn(f"shardX creep memory unavailable: user memory API returned {expected_status}", warnings[0])
+                self.assertIn("auth failed", warnings[0])
+                self.assertNotIn("secret-token", warnings[0])
+
     def test_collect_snapshots_merges_redacted_creep_memory_assignment_evidence(self) -> None:
         ref = monitor.RoomRef(shard="shardX", room="E29N55")
         ctx = monitor.RuntimeContext(


### PR DESCRIPTION
## Summary
- Adds bounded/redacted creep task-memory evidence to runtime summaries so worker assignment/task counts can be populated instead of reporting only `room_snapshot_missing_creep_memory`.
- Caps and truncates per-room samples to avoid memory/log bloat and secret leakage.
- Adds regression coverage for present memory, missing/partial memory, cap/truncation, and redaction behavior.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py`
- `python3 -m pytest scripts/test_screeps_runtime_monitor_tactical_response.py -q` → `108 passed, 28 subtests passed`

Fixes #1717

## Issue closure gate
- [x] #1717: Runtime summary worker-assignment evidence now includes bounded/redacted creep memory samples with deterministic tests for availability, missing/partial data, cap/truncation, and redaction behavior.

## Universal task Done gate
- [x] Task type: Runtime monitor / RL-flywheel instrumentation bugfix.
- [x] Expected observable outcome / named deliverable: runtime summary payloads expose bounded `workerAssignmentEvidence` so task counts and worker assignment analysis are no longer blind when creep memory is available.
- [x] Non-goals / accepted substitutes: no reward-weight change, no learned-policy rollout, no paid Tencent compute, no official MMO write, and no full Memory dump.
- [x] Verification evidence required before Done: `git diff --check`, `py_compile`, and targeted pytest `108 passed / 28 subtests passed` all passed from the controller on commit `c6e80800`.
- [x] Project Evidence / Next action / Blocked by: Project item moves to In review for this PR; next controller action is exact-head CI/CodeRabbit/thread gate and post-merge runtime-summary artifact capture; Blocked by is empty unless review gates find a blocker.
- [x] Post-merge/deploy/runtime proof: capture a fresh runtime-summary-console or monitor artifact showing `workerAssignmentEvidenceAvailable=true` or a precise non-blank blocker for current owned rooms.
- [x] Named deliverable proof: commit `c6e80800` changes `scripts/screeps-runtime-monitor.py` and `scripts/test_screeps_runtime_monitor_tactical_response.py`.
