### PR TITLE
cpu: preserve construction planning under CPU overrun

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1068,6 +1068,12 @@ function shouldThrottleRuntimeSummaryCadence(budget) {
 function shouldShedNonessentialCpuWork(budget) {
   return budget.critical || hasLowBucketPressure(budget) || hasUsedOverLimitPressure(budget);
 }
+function shouldRunConstructionCpuWork(budget) {
+  if (!budget.degraded) {
+    return true;
+  }
+  return !budget.lowCpuLimit && !budget.critical && !hasLowBucketPressure(budget);
+}
 function hasLowBucketPressure(budget) {
   return budget.reasons.includes("lowBucketRecovery") || budget.reasons.includes("lowBucket") || budget.reasons.includes("criticalBucket");
 }
@@ -40236,6 +40242,7 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   const reportedEvents = events.slice(0, MAX_REPORTED_EVENTS);
   const persistOccupationRecommendations = options.persistOccupationRecommendations !== false;
   const includeOptionalSummary = !cpuBudget.lowCpuLimit && !shouldShedNonessentialCpuWork(cpuBudget);
+  const includeConstructionScoring = shouldRunConstructionCpuWork(cpuBudget);
   const rooms = colonies.map(
     (colony) => {
       var _a2, _b;
@@ -40248,6 +40255,7 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
         options.strategyRegistry,
         options.onStrategyRegistryRuntimeUse,
         includeOptionalSummary,
+        includeConstructionScoring,
         cpuBudget
       );
     }
@@ -40345,7 +40353,7 @@ function buildRoomEventMetricsByRoom(colonies, refillTargetIdsByRoom) {
   }
   return eventMetricsByRoom;
 }
-function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, eventMetrics, includeStructureSnapshot, strategyRegistry, onStrategyRegistryRuntimeUse, includeOptionalSummary, cpuBudget) {
+function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, eventMetrics, includeStructureSnapshot, strategyRegistry, onStrategyRegistryRuntimeUse, includeOptionalSummary, includeConstructionScoring, cpuBudget) {
   const tick = getGameTime33();
   const colonyWorkers = colonyCreeps.filter((creep) => creep.memory.role === "worker");
   const roleCounts = countCreepsByRole(colonyCreeps, colony.room.name);
@@ -40373,7 +40381,7 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     territoryExpansion,
     tick
   );
-  const constructionPriorityEvaluation = includeOptionalSummary ? summarizeConstructionPriority(
+  const constructionPriorityEvaluation = includeConstructionScoring ? summarizeConstructionPriority(
     colony,
     colonyWorkers,
     strategyRegistry,
@@ -50620,6 +50628,15 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
     if (shedNonessentialCpuWork) {
       survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
       if (!shouldRunShedCpuColonyPlanning(colony, roleCounts, survivalAssessment)) {
+        if (shouldRunConstructionCpuWork(roomCpuBudget)) {
+          runClaimedRoomConstructionForCpuBudget(
+            colony,
+            creeps,
+            options,
+            postClaimBootstrapFocusRoomName,
+            false
+          );
+        }
         continue;
       }
     }
@@ -50647,23 +50664,13 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
       { focusRoomName: postClaimBootstrapFocusRoomName }
     );
     if (shouldRunConstructionPlanning(roomCpuBudget, runOptionalRoomWork, survivalAssessment)) {
-      refreshPostClaimDefenseConstruction(colony, { focusRoomName: postClaimBootstrapFocusRoomName });
-    }
-    const constructionOptions = {
-      respectRoomEnergyBuffer: true,
-      creeps,
-      strategyRegistry: options.strategyRegistry,
-      runtimeStrategyConstructionEnabled: options.runtimeStrategyConstructionEnabled,
-      onStrategyRegistryRuntimeUse: options.onStrategyRegistryRuntimeUse
-    };
-    if (shouldRunConstructionPlanning(roomCpuBudget, runOptionalRoomWork, survivalAssessment)) {
-      if (postClaimBootstrapRefresh.deferred === true) {
-        planDeferredClaimedRoomCapacityConstruction(colony, constructionOptions);
-      } else {
-        planClaimedRoomConstruction(colony, {
-          ...constructionOptions
-        });
-      }
+      runClaimedRoomConstructionForCpuBudget(
+        colony,
+        creeps,
+        options,
+        postClaimBootstrapFocusRoomName,
+        postClaimBootstrapRefresh.deferred === true
+      );
     }
     if (survivalAssessment.mode === "TERRITORY_READY" && shouldRunTerritoryPlanning(roomCpuBudget, runOptionalRoomWork)) {
       refreshRemoteMiningSetup(colony, Game.time, { focusRoomName: postClaimBootstrapFocusRoomName });
@@ -50895,6 +50902,21 @@ function shouldRunShedCpuColonyPlanning(colony, roleCounts, survivalAssessment) 
   }
   return isColonyRoomThreatened(colony.room.name, Game.time);
 }
+function runClaimedRoomConstructionForCpuBudget(colony, creeps, options, postClaimBootstrapFocusRoomName, deferred) {
+  refreshPostClaimDefenseConstruction(colony, { focusRoomName: postClaimBootstrapFocusRoomName });
+  const constructionOptions = {
+    respectRoomEnergyBuffer: true,
+    creeps,
+    strategyRegistry: options.strategyRegistry,
+    runtimeStrategyConstructionEnabled: options.runtimeStrategyConstructionEnabled,
+    onStrategyRegistryRuntimeUse: options.onStrategyRegistryRuntimeUse
+  };
+  if (deferred) {
+    planDeferredClaimedRoomCapacityConstruction(colony, constructionOptions);
+    return;
+  }
+  planClaimedRoomConstruction(colony, constructionOptions);
+}
 function isDowngradeGuardControllerCreep(creep) {
   var _a2, _b, _c;
   if (((_b = (_a2 = creep.memory) == null ? void 0 : _a2.controllerUpgrade) == null ? void 0 : _b.priority) === "downgradeGuard") {
@@ -50983,6 +51005,9 @@ function shouldRunConstructionPlanning(cpuBudget, runOptionalRoomWork, survivalA
   }
   if (cpuBudget.critical) {
     return false;
+  }
+  if (shouldRunConstructionCpuWork(cpuBudget)) {
+    return true;
   }
   return runOptionalRoomWork || survivalAssessment.mode === "BOOTSTRAP" || survivalAssessment.mode === "DEFENSE" || survivalAssessment.hostilePresence || survivalAssessment.controllerDowngradeGuard;
 }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -50617,7 +50617,8 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
   if (!shedNonessentialCpuWork) {
     refreshClaimedRoomBootstrapperOwnership(telemetryEvents);
   }
-  const postClaimBootstrapFocusRoomName = shedNonessentialCpuWork ? null : selectPostClaimBootstrapFocusRoomName(colonies);
+  const runConstructionCpuWork = shouldRunConstructionCpuWork(cpuBudget);
+  const postClaimBootstrapFocusRoomName = shedNonessentialCpuWork && !runConstructionCpuWork ? null : selectPostClaimBootstrapFocusRoomName(colonies);
   const controllerUpgradeTargetRooms = shedNonessentialCpuWork ? void 0 : getControllerUpgradeTargetRooms2(colonies);
   for (const colony of colonies) {
     let roomCpuBudget = getRuntimeCpuBudget();
@@ -50629,12 +50630,19 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
       survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
       if (!shouldRunShedCpuColonyPlanning(colony, roleCounts, survivalAssessment)) {
         if (shouldRunConstructionCpuWork(roomCpuBudget)) {
+          const postClaimBootstrapRefresh2 = refreshPostClaimBootstrap(
+            colony,
+            roleCounts,
+            Game.time,
+            telemetryEvents,
+            { focusRoomName: postClaimBootstrapFocusRoomName }
+          );
           runClaimedRoomConstructionForCpuBudget(
             colony,
             creeps,
             options,
             postClaimBootstrapFocusRoomName,
-            false
+            postClaimBootstrapRefresh2.deferred === true
           );
         }
         continue;

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -39,6 +39,7 @@ import type { StrategyRegistryEntry } from '../strategy/strategyRegistry';
 import { getRuntimeFeatureGates, type RuntimeFeatureGates } from '../runtime/featureGates';
 import {
   getRuntimeCpuBudget,
+  shouldRunConstructionCpuWork,
   shouldRunOptionalCpuRoomWork,
   shouldRunOptionalCpuWork,
   shouldShedNonessentialCpuWork,
@@ -217,6 +218,15 @@ export function runEconomy(
     if (shedNonessentialCpuWork) {
       survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
       if (!shouldRunShedCpuColonyPlanning(colony, roleCounts, survivalAssessment)) {
+        if (shouldRunConstructionCpuWork(roomCpuBudget)) {
+          runClaimedRoomConstructionForCpuBudget(
+            colony,
+            creeps,
+            options,
+            postClaimBootstrapFocusRoomName,
+            false
+          );
+        }
         continue;
       }
     }
@@ -248,23 +258,13 @@ export function runEconomy(
       { focusRoomName: postClaimBootstrapFocusRoomName }
     );
     if (shouldRunConstructionPlanning(roomCpuBudget, runOptionalRoomWork, survivalAssessment)) {
-      refreshPostClaimDefenseConstruction(colony, { focusRoomName: postClaimBootstrapFocusRoomName });
-    }
-    const constructionOptions = {
-      respectRoomEnergyBuffer: true,
-      creeps,
-      strategyRegistry: options.strategyRegistry,
-      runtimeStrategyConstructionEnabled: options.runtimeStrategyConstructionEnabled,
-      onStrategyRegistryRuntimeUse: options.onStrategyRegistryRuntimeUse
-    };
-    if (shouldRunConstructionPlanning(roomCpuBudget, runOptionalRoomWork, survivalAssessment)) {
-      if (postClaimBootstrapRefresh.deferred === true) {
-        planDeferredClaimedRoomCapacityConstruction(colony, constructionOptions);
-      } else {
-        planClaimedRoomConstruction(colony, {
-          ...constructionOptions
-        });
-      }
+      runClaimedRoomConstructionForCpuBudget(
+        colony,
+        creeps,
+        options,
+        postClaimBootstrapFocusRoomName,
+        postClaimBootstrapRefresh.deferred === true
+      );
     }
     if (survivalAssessment.mode === 'TERRITORY_READY' && shouldRunTerritoryPlanning(roomCpuBudget, runOptionalRoomWork)) {
       refreshRemoteMiningSetup(colony, Game.time, { focusRoomName: postClaimBootstrapFocusRoomName });
@@ -553,6 +553,30 @@ function shouldRunShedCpuColonyPlanning(
   return isColonyRoomThreatened(colony.room.name, Game.time);
 }
 
+function runClaimedRoomConstructionForCpuBudget(
+  colony: ColonySnapshot,
+  creeps: Creep[],
+  options: EconomyRuntimeOptions,
+  postClaimBootstrapFocusRoomName: string | null,
+  deferred: boolean
+): void {
+  refreshPostClaimDefenseConstruction(colony, { focusRoomName: postClaimBootstrapFocusRoomName });
+  const constructionOptions = {
+    respectRoomEnergyBuffer: true,
+    creeps,
+    strategyRegistry: options.strategyRegistry,
+    runtimeStrategyConstructionEnabled: options.runtimeStrategyConstructionEnabled,
+    onStrategyRegistryRuntimeUse: options.onStrategyRegistryRuntimeUse
+  };
+
+  if (deferred) {
+    planDeferredClaimedRoomCapacityConstruction(colony, constructionOptions);
+    return;
+  }
+
+  planClaimedRoomConstruction(colony, constructionOptions);
+}
+
 function isDowngradeGuardControllerCreep(creep: Creep): boolean {
   if (creep.memory?.controllerUpgrade?.priority === 'downgradeGuard') {
     return true;
@@ -675,6 +699,10 @@ function shouldRunConstructionPlanning(
 
   if (cpuBudget.critical) {
     return false;
+  }
+
+  if (shouldRunConstructionCpuWork(cpuBudget)) {
+    return true;
   }
 
   return (

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -206,7 +206,10 @@ export function runEconomy(
   if (!shedNonessentialCpuWork) {
     refreshClaimedRoomBootstrapperOwnership(telemetryEvents);
   }
-  const postClaimBootstrapFocusRoomName = shedNonessentialCpuWork ? null : selectPostClaimBootstrapFocusRoomName(colonies);
+  const runConstructionCpuWork = shouldRunConstructionCpuWork(cpuBudget);
+  const postClaimBootstrapFocusRoomName = shedNonessentialCpuWork && !runConstructionCpuWork
+    ? null
+    : selectPostClaimBootstrapFocusRoomName(colonies);
   const controllerUpgradeTargetRooms = shedNonessentialCpuWork ? undefined : getControllerUpgradeTargetRooms(colonies);
 
   for (const colony of colonies) {
@@ -219,12 +222,19 @@ export function runEconomy(
       survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
       if (!shouldRunShedCpuColonyPlanning(colony, roleCounts, survivalAssessment)) {
         if (shouldRunConstructionCpuWork(roomCpuBudget)) {
+          const postClaimBootstrapRefresh = refreshPostClaimBootstrap(
+            colony,
+            roleCounts,
+            Game.time,
+            telemetryEvents,
+            { focusRoomName: postClaimBootstrapFocusRoomName }
+          );
           runClaimedRoomConstructionForCpuBudget(
             colony,
             creeps,
             options,
             postClaimBootstrapFocusRoomName,
-            false
+            postClaimBootstrapRefresh.deferred === true
           );
         }
         continue;

--- a/prod/src/runtime/cpuBudget.ts
+++ b/prod/src/runtime/cpuBudget.ts
@@ -209,6 +209,14 @@ export function shouldShedNonessentialCpuWork(budget: RuntimeCpuBudget): boolean
   return budget.critical || hasLowBucketPressure(budget) || hasUsedOverLimitPressure(budget);
 }
 
+export function shouldRunConstructionCpuWork(budget: RuntimeCpuBudget): boolean {
+  if (!budget.degraded) {
+    return true;
+  }
+
+  return !budget.lowCpuLimit && !budget.critical && !hasLowBucketPressure(budget);
+}
+
 export function resetRuntimeCpuTelemetryForTesting(): void {
   cpuTelemetryState = {
     lowBucketTicks: 0,

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -84,6 +84,7 @@ import {
 import {
   buildRuntimeCpuTelemetrySummary,
   getRuntimeCpuBudget,
+  shouldRunConstructionCpuWork,
   shouldShedNonessentialCpuWork,
   shouldThrottleRuntimeSummaryCadence,
   type RuntimeCpuAlert,
@@ -1051,6 +1052,7 @@ export function emitRuntimeSummary(
   const reportedEvents = events.slice(0, MAX_REPORTED_EVENTS);
   const persistOccupationRecommendations = options.persistOccupationRecommendations !== false;
   const includeOptionalSummary = !cpuBudget.lowCpuLimit && !shouldShedNonessentialCpuWork(cpuBudget);
+  const includeConstructionScoring = shouldRunConstructionCpuWork(cpuBudget);
   const rooms = colonies.map((colony) =>
     summarizeRoom(
       colony,
@@ -1061,6 +1063,7 @@ export function emitRuntimeSummary(
       options.strategyRegistry,
       options.onStrategyRegistryRuntimeUse,
       includeOptionalSummary,
+      includeConstructionScoring,
       cpuBudget
     )
   );
@@ -1209,6 +1212,7 @@ function summarizeRoom(
   strategyRegistry: StrategyRegistryEntry[] | undefined,
   onStrategyRegistryRuntimeUse: ((entry: StrategyRegistryEntry) => void) | undefined,
   includeOptionalSummary: boolean,
+  includeConstructionScoring: boolean,
   cpuBudget: RuntimeCpuBudget
 ): RuntimeRoomSummary {
   const tick = getGameTime();
@@ -1240,7 +1244,7 @@ function summarizeRoom(
     territoryExpansion,
     tick
   );
-  const constructionPriorityEvaluation = includeOptionalSummary
+  const constructionPriorityEvaluation = includeConstructionScoring
     ? summarizeConstructionPriority(
         colony,
         colonyWorkers,

--- a/prod/test/cpuBudget.test.ts
+++ b/prod/test/cpuBudget.test.ts
@@ -5,6 +5,7 @@ import {
   isRuntimeCpuBucketCritical,
   isRuntimeCpuBucketLow,
   resetRuntimeCpuTelemetryForTesting,
+  shouldRunConstructionCpuWork,
   shouldRunOptionalCpuWork,
   shouldRunOptionalCpuRoomWork,
   shouldShedNonessentialCpuWork,
@@ -158,6 +159,7 @@ describe('runtime CPU budget policy', () => {
     expect(shouldRunOptionalCpuWork(budget, 'economy-global-optional')).toBe(false);
     expect(shouldRunOptionalCpuRoomWork(budget, 'E29N55')).toBe(false);
     expect(shouldShedNonessentialCpuWork(budget)).toBe(true);
+    expect(shouldRunConstructionCpuWork(budget)).toBe(false);
   });
 
   it('keeps optional work paused through the observed postdeploy recovery buckets', () => {
@@ -194,6 +196,7 @@ describe('runtime CPU budget policy', () => {
       expect(shouldRunOptionalCpuWork(budget, 'economy-global-optional')).toBe(false);
       expect(shouldRunOptionalCpuRoomWork(budget, 'E29N55')).toBe(false);
       expect(shouldShedNonessentialCpuWork(budget)).toBe(true);
+      expect(shouldRunConstructionCpuWork(budget)).toBe(false);
     }
   });
 
@@ -290,7 +293,7 @@ describe('runtime CPU budget policy', () => {
     });
   });
 
-  it('sheds optional work once the current tick exceeds its CPU limit', () => {
+  it('sheds optional work but preserves construction work once the current tick exceeds its CPU limit', () => {
     const budget = buildRuntimeCpuBudget({
       tick: 222,
       used: 71,
@@ -309,6 +312,7 @@ describe('runtime CPU budget policy', () => {
     expect(shouldRunOptionalCpuWork(budget, 'economy-global-optional')).toBe(false);
     expect(shouldRunOptionalCpuRoomWork(budget, 'E29N55')).toBe(false);
     expect(shouldShedNonessentialCpuWork(budget)).toBe(true);
+    expect(shouldRunConstructionCpuWork(budget)).toBe(true);
   });
 
   it('refreshes CPU used samples during the same game tick', () => {

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -3747,6 +3747,135 @@ describe('runEconomy', () => {
     });
   });
 
+  it('keeps post-claim spawn construction focused during used-over-limit CPU shedding', () => {
+    (globalThis as unknown as {
+      FIND_MY_CONSTRUCTION_SITES: number;
+      FIND_SOURCES: number;
+      FIND_HOSTILE_CREEPS: number;
+      FIND_HOSTILE_STRUCTURES: number;
+      LOOK_STRUCTURES: LOOK_STRUCTURES;
+      LOOK_CONSTRUCTION_SITES: LOOK_CONSTRUCTION_SITES;
+      STRUCTURE_SPAWN: StructureConstant;
+      TERRAIN_MASK_WALL: number;
+      Memory: Partial<Memory>;
+    }).FIND_MY_CONSTRUCTION_SITES = 2;
+    (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
+    (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 6;
+    (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 7;
+    (globalThis as unknown as { LOOK_STRUCTURES: LOOK_STRUCTURES }).LOOK_STRUCTURES = 'structure';
+    (globalThis as unknown as { LOOK_CONSTRUCTION_SITES: LOOK_CONSTRUCTION_SITES }).LOOK_CONSTRUCTION_SITES =
+      'constructionSite';
+    (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
+    (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          W2N1: {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            status: 'detected',
+            claimedAt: 400,
+            updatedAt: 400,
+            workerTarget: 2,
+            controllerId: 'controller2' as Id<StructureController>
+          },
+          W3N1: {
+            colony: 'W1N1',
+            roomName: 'W3N1',
+            status: 'detected',
+            claimedAt: 401,
+            updatedAt: 401,
+            workerTarget: 2,
+            controllerId: 'controller3' as Id<StructureController>
+          }
+        }
+      }
+    };
+
+    const makePostClaimRoom = (roomName: string, controllerId: Id<StructureController>): Room => {
+      const constructionSites: ConstructionSite[] = [];
+      return {
+        name: roomName,
+        energyAvailable: 0,
+        energyCapacityAvailable: 0,
+        controller: {
+          id: controllerId,
+          my: true,
+          level: 1,
+          ticksToDowngrade: CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS + 1,
+          pos: { x: 25, y: 25, roomName }
+        } as StructureController,
+        find: jest.fn((type: number) => {
+          if (type === FIND_SOURCES) {
+            return [{ id: `${roomName}-source1`, pos: { x: 21, y: 21, roomName } } as Source];
+          }
+
+          if (type === FIND_MY_CONSTRUCTION_SITES) {
+            return constructionSites;
+          }
+
+          return [];
+        }),
+        lookForAtArea: jest.fn().mockReturnValue([]),
+        createConstructionSite: jest.fn((x: number, y: number, structureType: StructureConstant) => {
+          constructionSites.push({
+            id: `${roomName}-site-${x}-${y}`,
+            structureType,
+            pos: { x, y, roomName }
+          } as ConstructionSite);
+          return OK_CODE;
+        })
+      } as unknown as Room;
+    };
+    const olderRoom = makePostClaimRoom('W2N1', 'controller2' as Id<StructureController>);
+    const newerRoom = makePostClaimRoom('W3N1', 'controller3' as Id<StructureController>);
+    const makeShedWorker = (room: Room, index: number): Creep =>
+      ({
+        name: `worker-${room.name}-${index}`,
+        memory: {
+          role: 'worker',
+          colony: room.name,
+          territory: { targetRoom: `${room.name}-remote`, action: 'reserve' }
+        },
+        room
+      }) as unknown as Creep;
+    const creeps: Record<string, Creep> = {};
+    for (const room of [olderRoom, newerRoom]) {
+      for (let index = 0; index < 3; index += 1) {
+        const worker = makeShedWorker(room, index);
+        creeps[worker.name] = worker;
+      }
+    }
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 404,
+      rooms: { W3N1: newerRoom, W2N1: olderRoom },
+      spawns: {},
+      creeps,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(71),
+        limit: 70,
+        bucket: 9_000,
+        tickLimit: 500
+      } as unknown as CPU,
+      map: {
+        getRoomTerrain: jest.fn().mockReturnValue({ get: jest.fn().mockReturnValue(0) })
+      } as unknown as GameMap
+    };
+
+    runEconomy();
+
+    expect(olderRoom.createConstructionSite).toHaveBeenCalledWith(23, 23, STRUCTURE_SPAWN);
+    expect(newerRoom.createConstructionSite).not.toHaveBeenCalled();
+    expect(Memory.territory?.postClaimBootstraps?.W2N1).toMatchObject({
+      status: 'spawnSitePending',
+      updatedAt: 404
+    });
+    expect(Memory.territory?.postClaimBootstraps?.W3N1).toMatchObject({
+      status: 'detected',
+      updatedAt: 401
+    });
+  });
+
   it('seeds RCL2 extensions in a deferred post-claim room that already has a spawn', () => {
     (globalThis as unknown as {
       FIND_SOURCES: number;

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -1955,6 +1955,85 @@ describe('runEconomy', () => {
     expect(worker.memory.task).toEqual({ type: 'build', targetId: 'site-24-24' });
   });
 
+  it('preserves construction planning after the current tick exceeds its CPU limit with a healthy bucket', () => {
+    (globalThis as unknown as {
+      FIND_MY_STRUCTURES: number;
+      FIND_MY_CONSTRUCTION_SITES: number;
+      FIND_CONSTRUCTION_SITES: number;
+      RESOURCE_ENERGY: ResourceConstant;
+      STRUCTURE_EXTENSION: StructureConstant;
+      TERRAIN_MASK_WALL: number;
+      LOOK_STRUCTURES: LOOK_STRUCTURES;
+      LOOK_CONSTRUCTION_SITES: LOOK_CONSTRUCTION_SITES;
+    }).FIND_MY_STRUCTURES = 1;
+    (globalThis as unknown as { FIND_MY_CONSTRUCTION_SITES: number }).FIND_MY_CONSTRUCTION_SITES = 2;
+    (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 3;
+    (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+    (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
+    (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+    (globalThis as unknown as { LOOK_STRUCTURES: LOOK_STRUCTURES }).LOOK_STRUCTURES = 'structure';
+    (globalThis as unknown as { LOOK_CONSTRUCTION_SITES: LOOK_CONSTRUCTION_SITES }).LOOK_CONSTRUCTION_SITES =
+      'constructionSite';
+
+    const constructionSites: ConstructionSite[] = [];
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 800,
+      energyCapacityAvailable: 800,
+      controller: {
+        my: true,
+        level: 2,
+        id: 'controller1',
+        ticksToDowngrade: CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS + 1
+      } as StructureController,
+      find: jest.fn((type: number) => (type === 3 ? constructionSites : [])),
+      lookForAt: jest.fn(() => {
+        throw new Error('extension planner should use cached occupancy instead of per-candidate lookups');
+      }),
+      lookForAtArea: jest.fn().mockReturnValue([]),
+      createConstructionSite: jest.fn((x: number, y: number, structureType: StructureConstant) => {
+        constructionSites.push({
+          id: `site-${x}-${y}`,
+          structureType,
+          pos: { x, y, roomName: 'W1N1' } as RoomPosition
+        } as ConstructionSite);
+        return OK_CODE;
+      })
+    } as unknown as Room;
+    const spawn = {
+      name: 'Spawn1',
+      room,
+      pos: { x: 25, y: 25, roomName: 'W1N1' },
+      spawning: null,
+      spawnCreep: jest.fn()
+    } as unknown as StructureSpawn;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 253,
+      rooms: { W1N1: room },
+      spawns: { Spawn1: spawn },
+      creeps: {
+        Worker1: makeEconomyWorker(room),
+        Worker2: makeEconomyWorker(room),
+        Worker3: makeEconomyWorker(room),
+        Worker4: makeEconomyWorker(room),
+        Worker5: makeEconomyWorker(room)
+      },
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(71),
+        limit: 70,
+        bucket: 9_000,
+        tickLimit: 500
+      } as unknown as CPU,
+      map: {
+        getRoomTerrain: jest.fn().mockReturnValue({ get: jest.fn().mockReturnValue(0) })
+      } as unknown as Game['map']
+    };
+
+    runEconomy();
+
+    expect(room.createConstructionSite).toHaveBeenCalledWith(24, 24, STRUCTURE_EXTENSION);
+  });
+
   it('preempts an existing RCL2 upgrade task for newly planned extension construction', () => {
     (globalThis as unknown as {
       FIND_MY_STRUCTURES: number;

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -699,11 +699,28 @@ describe('runtime telemetry summaries', () => {
 
     const payload = parseLoggedSummary();
     const [room] = payload.rooms as Array<Record<string, unknown>>;
-    expect(room.constructionPriority).toEqual({ candidates: [], nextPrimary: null });
+    expect(room.constructionPriority).toMatchObject({
+      nextPrimary: {
+        buildItem: 'build rampart defense',
+        room: 'W1N1',
+        urgency: 'critical'
+      }
+    });
+    expect(room.constructionScoring).toEqual({
+      source: 'runtime-summary',
+      loopRan: true,
+      skipped: false,
+      rawCandidateCount: 4,
+      viableCandidateCount: 4,
+      suppressedCandidateCount: 3,
+      dominantSuppressionReason: 'lower_ranked_candidate',
+      acceptedCandidateCount: 1,
+      sitePlacementAttempted: false
+    });
     expect(room.territoryExpansion).toBeUndefined();
     expect(room.behavior).toBeUndefined();
     expect(room.workerEfficiency).toBeUndefined();
-    expect(onStrategyRegistryRuntimeUse).not.toHaveBeenCalled();
+    expect(onStrategyRegistryRuntimeUse).toHaveBeenCalledTimes(1);
   });
 
   it('reports per-creep behavior counters and resets emitted counters', () => {


### PR DESCRIPTION
## Summary
- Preserve construction planning/scoring during single-tick CPU overrun when bucket headroom is healthy.
- Keep optional/nonessential CPU shedding intact for low-bucket, low-limit, and critical CPU states.
- Add regression coverage for CPU-budget policy, economy construction planning, runtime summary construction scoring, and regenerated Screeps bundle.

Refs #1490

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 105 suites / 2305 tests passed
- `cd prod && npm run build`

## Universal task Done gate
- [x] Task type: P0 runtime reliability / bot capability code change for CPU-budget construction planning.
- [x] Expected observable outcome / named deliverable: construction planning and runtime-summary construction scoring still run during `usedOverLimit` ticks when bucket headroom is healthy, while low-bucket/critical/low-limit CPU states continue shedding nonessential work.
- [x] Non-goals / accepted substitutes: this PR does not claim official-MMO CPU recovery closure; issue #1490 keeps its runtime acceptance gate.
- [x] Verification evidence required before Done: controller verification passed `git diff --check`, `npm run typecheck`, `npm test -- --runInBand`, and `npm run build` on commit `1a447fd42653446c2d749ef28cc93c4c4e5bff58`.
- [x] Project Evidence / Next action / Blocked by: Project `screeps` for #1490 and this PR records the commit, verification, and review/deploy gate as the next action.
- [x] Post-merge/deploy/runtime proof: postdeploy CPU/runtime observation remains tracked by open issue #1490; this PR supplies the code/test/build gate needed before deployment.
- [x] Named deliverable proof: `shouldRunConstructionCpuWork` plus economy/runtime-summary call sites and regression tests prove the named CPU-overrun construction-planning behavior.
