### PR TITLE
construction: cover E29N56 first tower priority

### DIFF
--- a/prod/test/claimedRoomPlanner.test.ts
+++ b/prod/test/claimedRoomPlanner.test.ts
@@ -202,6 +202,63 @@ describe('claimed room construction planner', () => {
     expect(room.createConstructionSite).toHaveBeenCalledWith(16, 23, STRUCTURE_EXTENSION);
   });
 
+  it('plans the first E29N56 tower at RCL4 with pending extension and storage work', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        claimedRoomBootstrapper: {
+          rooms: {
+            E29N56: {
+              roomName: 'E29N56',
+              owned: true,
+              claimedAt: 1_837_000,
+              updatedAt: 1_837_614
+            }
+          }
+        }
+      }
+    };
+    const pendingExtension = makeConstructionSite(
+      'extension-pending',
+      TEST_GLOBALS.STRUCTURE_EXTENSION,
+      16,
+      23,
+      'E29N56'
+    );
+    const pendingStorage = makeConstructionSite(
+      'storage-pending',
+      TEST_GLOBALS.STRUCTURE_STORAGE,
+      17,
+      23,
+      'E29N56'
+    );
+    const { room, colony } = makeColony({
+      roomName: 'E29N56',
+      controllerLevel: 4,
+      energyAvailable: 1_050,
+      energyCapacityAvailable: 1_050,
+      spawnPosition: { x: 17, y: 24 },
+      structures: makeExtensions(15, 'E29N56'),
+      constructionSites: [pendingExtension, pendingStorage],
+      sources: []
+    });
+
+    const result = planClaimedRoomConstruction(colony);
+
+    expect(result.yielded).toBe(false);
+    expect(result.placements[0]).toMatchObject({
+      priority: 'tower',
+      roomName: 'E29N56',
+      structureType: TEST_GLOBALS.STRUCTURE_TOWER,
+      result: OK_CODE,
+      energyReserved: 50
+    });
+    expect(result.energyAvailable - result.energyReserved).toBeGreaterThanOrEqual(500);
+    expect(room.createConstructionSite.mock.calls.filter(([, , structureType]) => structureType === STRUCTURE_TOWER))
+      .toHaveLength(1);
+    expect(room.createConstructionSite).not.toHaveBeenCalledWith(expect.any(Number), expect.any(Number), STRUCTURE_EXTENSION);
+    expect(room.createConstructionSite).not.toHaveBeenCalledWith(expect.any(Number), expect.any(Number), STRUCTURE_STORAGE);
+  });
+
   it('seeds a deferred RCL2 claimed room extension when spawn coverage already exists', () => {
     const { room, colony } = makeColony({
       roomName: 'E29N57',


### PR DESCRIPTION
## Summary
- Adds regression coverage that E29N56 RCL4 construction planning selects the first tower before pending extension/storage follow-up work.
- Documents the current production planner behavior without altering runtime source in this slice.

Related to issue 1528.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand claimedRoomPlanner.test.ts`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`

## Universal task Done gate
- [x] Task type: production test coverage for E29N56 tower-priority gameplay behavior.
- [x] Expected observable outcome / named deliverable: `prod/test/claimedRoomPlanner.test.ts` covers first E29N56 tower selection at RCL4 while extension/storage work already exists.
- [x] Non-goals / accepted substitutes: no runtime source rewrite in this slice because the existing planner already selects the tower; runtime construction/deploy proof remains tracked by issue 1528.
- [x] Verification evidence required before Done: controller ran diff-check, TypeScript typecheck, focused claimed-room planner Jest, full Jest, and bundle build successfully on commit `6a8aa177a36e5ac1696f6f947e5c0cdefefdd646`.
- [x] Project Evidence / Next action / Blocked by: issue 1528 and this PR are in Project `screeps`; Evidence records Codex commit plus controller verification; Next action is exact-head CI/review gate, then deploy/runtime tower observation under issue 1528; Blocked by is exact-head PR gate.
- [x] Post-merge/deploy/runtime proof: post-merge deploy lane must verify official MMO build containing the planner coverage and runtime E29N56 tower site/structure observation before issue 1528 is marked Done.
- [x] Named deliverable proof: `prod/test/claimedRoomPlanner.test.ts` test `plans the first E29N56 tower at RCL4 with queued extension and storage work` passes in focused and full Jest runs.
