### PR TITLE
chore(roadmap): refresh Pages artifacts

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -483,7 +483,7 @@ main {
           <p><strong>Project</strong> · Long-running Screeps: World AI and autonomous operations project.</p>
           <p><strong>Links</strong> · <a href="https://github.com/lanyusea/screeps">https://github.com/lanyusea/screeps</a></p>
         </div>
-        <p class="published"><strong>PUBLISHED</strong> · 2026-06-06T04:13:41+08:00</p>
+        <p class="published"><strong>PUBLISHED</strong> · 2026-06-07T03:47:20+08:00</p>
       </div>
       <div class="hero-art">
         <div class="brand-logo-frame"><img class="brand-logo" src="assets/screeps-community-logo.png" alt="Screeps community logo"></div>
@@ -510,19 +510,19 @@ main {
               <line x1="70.0" y1="190.0" x2="500.0" y2="190.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="195.0" text-anchor="end" fill="#8b6d55" font-size="15">0</text><line x1="70.0" y1="107.0" x2="500.0" y2="107.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="112.0" text-anchor="end" fill="#8b6d55" font-size="15">10</text><line x1="70.0" y1="24.0" x2="500.0" y2="24.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="29.0" text-anchor="end" fill="#8b6d55" font-size="15">20</text>
               <line x1="70.0" y1="24.0" x2="70.0" y2="190.0" stroke="#cdbba7" stroke-width="1.5"/>
               <line x1="70.0" y1="190.0" x2="500.0" y2="190.0" stroke="#cdbba7" stroke-width="1.5"/>
-              <polyline fill="none" stroke="#9f6a3a" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" points="428.3,165.1 500.0,165.1"/><circle cx="428.3" cy="165.1" r="4" fill="#9f6a3a"/><text x="428.3" y="154.1" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">3</text><circle cx="500.0" cy="165.1" r="4" fill="#9f6a3a"/><text x="500.0" y="154.1" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">3</text><polyline fill="none" stroke="#77716a" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" points="428.3,65.5 500.0,65.5"/><circle cx="428.3" cy="65.5" r="4" fill="#77716a"/><text x="428.3" y="54.5" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">15</text><circle cx="500.0" cy="65.5" r="4" fill="#77716a"/><text x="500.0" y="54.5" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">15</text><polyline fill="none" stroke="#c8945a" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6 6" points="428.3,190.0 500.0,190.0"/><circle cx="428.3" cy="190.0" r="4" fill="#c8945a"/><text x="428.3" y="156.0" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">0</text><circle cx="500.0" cy="190.0" r="4" fill="#c8945a"/><text x="500.0" y="156.0" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">0</text>
+              <polyline fill="none" stroke="#9f6a3a" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" points="356.7,165.1 428.3,165.1 500.0,165.1"/><circle cx="356.7" cy="165.1" r="4" fill="#9f6a3a"/><text x="356.7" y="154.1" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">3</text><circle cx="428.3" cy="165.1" r="4" fill="#9f6a3a"/><text x="428.3" y="154.1" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">3</text><circle cx="500.0" cy="165.1" r="4" fill="#9f6a3a"/><text x="500.0" y="154.1" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">3</text><polyline fill="none" stroke="#77716a" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" points="356.7,65.5 428.3,65.5 500.0,65.5"/><circle cx="356.7" cy="65.5" r="4" fill="#77716a"/><text x="356.7" y="54.5" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">15</text><circle cx="428.3" cy="65.5" r="4" fill="#77716a"/><text x="428.3" y="54.5" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">15</text><circle cx="500.0" cy="65.5" r="4" fill="#77716a"/><text x="500.0" y="54.5" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">15</text><polyline fill="none" stroke="#c8945a" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6 6" points="356.7,190.0 428.3,190.0 500.0,190.0"/><circle cx="356.7" cy="190.0" r="4" fill="#c8945a"/><text x="356.7" y="156.0" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">0</text><circle cx="428.3" cy="190.0" r="4" fill="#c8945a"/><text x="428.3" y="156.0" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">0</text><circle cx="500.0" cy="190.0" r="4" fill="#c8945a"/><text x="500.0" y="156.0" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">0</text>
 
-              <text x="70.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">5/31</text>
-<text x="141.7" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/1</text>
-<text x="213.3" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/2</text>
-<text x="285.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/3</text>
-<text x="356.7" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/4</text>
-<text x="428.3" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/5</text>
-<text x="500.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/6</text>
+              <text x="70.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/1</text>
+<text x="141.7" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/2</text>
+<text x="213.3" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/3</text>
+<text x="285.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/4</text>
+<text x="356.7" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/5</text>
+<text x="428.3" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/6</text>
+<text x="500.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/7</text>
               <line x1="8" y1="250" x2="30" y2="250" stroke="#9f6a3a" stroke-width="3"/><text x="38" y="255" fill="#4f443a" font-size="14">Owned rooms</text><line x1="172" y1="250" x2="194" y2="250" stroke="#77716a" stroke-width="3"/><text x="202" y="255" fill="#4f443a" font-size="14">RCL</text><line x1="314" y1="250" x2="336" y2="250" stroke="#c8945a" stroke-width="3" stroke-dasharray="6 6"/><text x="344" y="255" fill="#4f443a" font-size="14">Room gain</text>
             </svg>
 
-            <p class="chart-footer">History collecting (2/7 days observed; insufficient for a complete 7d trend); missing buckets stay blank.</p>
+            <p class="chart-footer">History collecting (3/7 days observed; insufficient for a complete 7d trend); missing buckets stay blank.</p>
           </article>
 
 
@@ -537,22 +537,22 @@ main {
 
             <svg class="chart-svg" role="img" aria-label="Resources 7 day trend" viewBox="0 0 560 260">
               <text x="70.0" y="12" fill="#9a5d25" font-size="14" font-weight="900">energy</text>
-              <line x1="70.0" y1="190.0" x2="500.0" y2="190.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="195.0" text-anchor="end" fill="#8b6d55" font-size="15">0</text><line x1="70.0" y1="107.0" x2="500.0" y2="107.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="112.0" text-anchor="end" fill="#8b6d55" font-size="15">4500</text><line x1="70.0" y1="24.0" x2="500.0" y2="24.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="29.0" text-anchor="end" fill="#8b6d55" font-size="15">9000</text>
+              <line x1="70.0" y1="190.0" x2="500.0" y2="190.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="195.0" text-anchor="end" fill="#8b6d55" font-size="15">0</text><line x1="70.0" y1="107.0" x2="500.0" y2="107.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="112.0" text-anchor="end" fill="#8b6d55" font-size="15">10000</text><line x1="70.0" y1="24.0" x2="500.0" y2="24.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="29.0" text-anchor="end" fill="#8b6d55" font-size="15">20000</text>
               <line x1="70.0" y1="24.0" x2="70.0" y2="190.0" stroke="#cdbba7" stroke-width="1.5"/>
               <line x1="70.0" y1="190.0" x2="500.0" y2="190.0" stroke="#cdbba7" stroke-width="1.5"/>
-              <polyline fill="none" stroke="#25211c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" points="428.3,64.0 500.0,36.8"/><circle cx="428.3" cy="64.0" r="4" fill="#25211c"/><text x="428.3" y="53.0" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">6834</text><circle cx="500.0" cy="36.8" r="4" fill="#25211c"/><text x="500.0" y="25.8" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">8307</text><polyline fill="none" stroke="#c8945a" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6 6" points="428.3,164.1 500.0,171.6"/><circle cx="428.3" cy="164.1" r="4" fill="#c8945a"/><text x="428.3" y="153.1" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">1404</text><circle cx="500.0" cy="171.6" r="4" fill="#c8945a"/><text x="500.0" y="160.6" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">996</text>
+              <polyline fill="none" stroke="#25211c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" points="356.7,133.3 428.3,121.1 500.0,100.1"/><circle cx="356.7" cy="133.3" r="4" fill="#25211c"/><text x="356.7" y="122.3" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">6834</text><circle cx="428.3" cy="121.1" r="4" fill="#25211c"/><text x="428.3" y="110.1" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">8307</text><circle cx="500.0" cy="100.1" r="4" fill="#25211c"/><text x="500.0" y="89.1" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">10835</text><polyline fill="none" stroke="#c8945a" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6 6" points="356.7,178.3 428.3,181.7 500.0,176.5"/><circle cx="356.7" cy="178.3" r="4" fill="#c8945a"/><text x="356.7" y="167.3" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">1404</text><circle cx="428.3" cy="181.7" r="4" fill="#c8945a"/><text x="428.3" y="170.7" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">996</text><circle cx="500.0" cy="176.5" r="4" fill="#c8945a"/><text x="500.0" y="165.5" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">1626</text>
 
-              <text x="70.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">5/31</text>
-<text x="141.7" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/1</text>
-<text x="213.3" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/2</text>
-<text x="285.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/3</text>
-<text x="356.7" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/4</text>
-<text x="428.3" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/5</text>
-<text x="500.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/6</text>
+              <text x="70.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/1</text>
+<text x="141.7" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/2</text>
+<text x="213.3" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/3</text>
+<text x="285.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/4</text>
+<text x="356.7" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/5</text>
+<text x="428.3" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/6</text>
+<text x="500.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/7</text>
               <line x1="8" y1="250" x2="30" y2="250" stroke="#25211c" stroke-width="3"/><text x="38" y="255" fill="#4f443a" font-size="14">Stored energy</text><line x1="172" y1="250" x2="194" y2="250" stroke="#66605a" stroke-width="3"/><text x="202" y="255" fill="#4f443a" font-size="14">Harvest delta</text><line x1="336" y1="250" x2="358" y2="250" stroke="#c8945a" stroke-width="3" stroke-dasharray="6 6"/><text x="366" y="255" fill="#4f443a" font-size="14">Worker carried</text>
             </svg>
 
-            <p class="chart-footer">History collecting (2/7 days observed; insufficient for a complete 7d trend); missing buckets stay blank.</p>
+            <p class="chart-footer">History collecting (3/7 days observed; insufficient for a complete 7d trend); missing buckets stay blank.</p>
           </article>
 
 
@@ -570,19 +570,19 @@ main {
               <line x1="70.0" y1="190.0" x2="500.0" y2="190.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="195.0" text-anchor="end" fill="#8b6d55" font-size="15">0</text><line x1="70.0" y1="107.0" x2="500.0" y2="107.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="112.0" text-anchor="end" fill="#8b6d55" font-size="15">0.5</text><line x1="70.0" y1="24.0" x2="500.0" y2="24.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="29.0" text-anchor="end" fill="#8b6d55" font-size="15">1</text>
               <line x1="70.0" y1="24.0" x2="70.0" y2="190.0" stroke="#cdbba7" stroke-width="1.5"/>
               <line x1="70.0" y1="190.0" x2="500.0" y2="190.0" stroke="#cdbba7" stroke-width="1.5"/>
-              <polyline fill="none" stroke="#77716a" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" points="428.3,190.0 500.0,190.0"/><circle cx="428.3" cy="190.0" r="4" fill="#77716a"/><text x="428.3" y="169.0" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">0</text><circle cx="500.0" cy="190.0" r="4" fill="#77716a"/><text x="500.0" y="169.0" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">0</text>
+              <polyline fill="none" stroke="#77716a" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" points="356.7,190.0 428.3,190.0 500.0,190.0"/><circle cx="356.7" cy="190.0" r="4" fill="#77716a"/><text x="356.7" y="169.0" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">0</text><circle cx="428.3" cy="190.0" r="4" fill="#77716a"/><text x="428.3" y="169.0" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">0</text><circle cx="500.0" cy="190.0" r="4" fill="#77716a"/><text x="500.0" y="169.0" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">0</text>
 
-              <text x="70.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">5/31</text>
-<text x="141.7" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/1</text>
-<text x="213.3" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/2</text>
-<text x="285.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/3</text>
-<text x="356.7" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/4</text>
-<text x="428.3" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/5</text>
-<text x="500.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/6</text>
+              <text x="70.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/1</text>
+<text x="141.7" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/2</text>
+<text x="213.3" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/3</text>
+<text x="285.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/4</text>
+<text x="356.7" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/5</text>
+<text x="428.3" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/6</text>
+<text x="500.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/7</text>
               <line x1="8" y1="250" x2="30" y2="250" stroke="#25211c" stroke-width="3"/><text x="38" y="255" fill="#4f443a" font-size="14">Enemy kills</text><line x1="172" y1="250" x2="194" y2="250" stroke="#77716a" stroke-width="3"/><text x="202" y="255" fill="#4f443a" font-size="14">Hostiles seen</text><line x1="336" y1="250" x2="358" y2="250" stroke="#c8945a" stroke-width="3" stroke-dasharray="6 6"/><text x="366" y="255" fill="#4f443a" font-size="14">Own loss</text>
             </svg>
 
-            <p class="chart-footer">History collecting (2/7 days observed; insufficient for a complete 7d trend); missing buckets stay blank.</p>
+            <p class="chart-footer">History collecting (3/7 days observed; insufficient for a complete 7d trend); missing buckets stay blank.</p>
           </article>
 
         </div>
@@ -621,17 +621,17 @@ main {
           </a>
 
 
-          <a class="roadmap-card" href="https://github.com/lanyusea/screeps/issues/1703">
+          <a class="roadmap-card" href="https://github.com/lanyusea/screeps/issues/1726">
             <h3>Runtime monitor</h3>
             <div class="roadmap-table">
               <span class="roadmap-label">Goal</span><span>Turn live Screeps telemetry into reliable KPI, alert, and report evidence.</span>
-              <span class="roadmap-label">Next</span><span>Current: #1703 In review - P0: Populate creep-memory worker evidence in runtime summaries</span>
+              <span class="roadmap-label">Next</span><span>Current: #1726 Ready - 2026-06-06T05:00Z fresh postmerge monitor: alert=false health ok at ti...</span>
             </div>
             <div class="progress-row">
-              <span class="progress-value">98%</span>
-              <span class="progress-track"><span class="progress-fill" style="width: 98%"></span></span>
+              <span class="progress-value">99%</span>
+              <span class="progress-track"><span class="progress-fill" style="width: 99%"></span></span>
             </div>
-            <div class="roadmap-status">93 Project items · 2 active · 91 done</div>
+            <div class="roadmap-status">94 Project items · 1 active · 93 done</div>
           </a>
 
 
@@ -663,17 +663,17 @@ main {
           </a>
 
 
-          <a class="roadmap-card" href="https://github.com/lanyusea/screeps/issues/1528">
+          <a class="roadmap-card" href="https://github.com/lanyusea/screeps/issues/977">
             <h3>Combat</h3>
             <div class="roadmap-table">
               <span class="roadmap-label">Goal</span><span>Protect survival, hostile response, and defense/combat readiness.</span>
-              <span class="roadmap-label">Next</span><span>Current: #1528 Backlog - 2026-05-31T16:55Z state-audit repair: issue has blocked label and is...</span>
+              <span class="roadmap-label">Next</span><span>No active item; latest tracked: #977 Done - Post-closure 2026-05-12T23:25Z: live alert=false,...</span>
             </div>
             <div class="progress-row">
-              <span class="progress-value">98%</span>
-              <span class="progress-track"><span class="progress-fill" style="width: 98%"></span></span>
+              <span class="progress-value">100%</span>
+              <span class="progress-track"><span class="progress-fill" style="width: 100%"></span></span>
             </div>
-            <div class="roadmap-status">47 Project items · 1 active · 46 done</div>
+            <div class="roadmap-status">47 Project items · 0 active · 47 done</div>
           </a>
 
 
@@ -681,13 +681,13 @@ main {
             <h3>Territory/Economy</h3>
             <div class="roadmap-table">
               <span class="roadmap-label">Goal</span><span>Advance expansion, controller pressure, worker efficiency, and resource throughput.</span>
-              <span class="roadmap-label">Next</span><span>Current: #1490 In progress - 2026-06-05 02:04 +08 CPU acceptance remains open: latest runtime...</span>
+              <span class="roadmap-label">Next</span><span>Current: #1490 In progress - 2026-06-06T05:28Z: CPU still degraded; console tick 1849538 buck...</span>
             </div>
             <div class="progress-row">
-              <span class="progress-value">99%</span>
-              <span class="progress-track"><span class="progress-fill" style="width: 99%"></span></span>
+              <span class="progress-value">98%</span>
+              <span class="progress-track"><span class="progress-fill" style="width: 98%"></span></span>
             </div>
-            <div class="roadmap-status">292 Project items · 4 active · 288 done</div>
+            <div class="roadmap-status">304 Project items · 5 active · 299 done</div>
           </a>
 
 
@@ -709,13 +709,13 @@ main {
             <h3>RL flywheel</h3>
             <div class="roadmap-table">
               <span class="roadmap-label">Goal</span><span>Drive offline/simulator/data/training/validation work for safe strategy self-evolution.</span>
-              <span class="roadmap-label">Next</span><span>Current: #1032 In progress - 2026-06-05T16:36Z: #1698 known_hosts hardening merged; Loop A lo...</span>
+              <span class="roadmap-label">Next</span><span>Current: #1032 In progress - 2026-06-06T17:00Z: stuck local runner PID 3701954 was terminated...</span>
             </div>
             <div class="progress-row">
-              <span class="progress-value">97%</span>
-              <span class="progress-track"><span class="progress-fill" style="width: 97%"></span></span>
+              <span class="progress-value">98%</span>
+              <span class="progress-track"><span class="progress-fill" style="width: 98%"></span></span>
             </div>
-            <div class="roadmap-status">400 Project items · 12 active · 388 done</div>
+            <div class="roadmap-status">413 Project items · 9 active · 404 done</div>
           </a>
 
         </div>
@@ -767,20 +767,13 @@ main {
           <article class="kanban-column">
             <div class="column-heading">
               <h3>Runtime monitor</h3>
-              <span class="column-count">2</span>
+              <span class="column-count">1</span>
             </div>
 
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/1703">
-              <span class="kanban-priority">P0</span>
-              <h4>#1703 P0: Populate creep-memory worker evidence in runtime summaries</h4>
-              <p>In review · Runtime monitor · 2026-06-05T19:55:06Z P0: Populate creep-memory worker evidence in runtime summa...</p>
-            </a>
-
-
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/pull/1708">
-              <span class="kanban-priority">P0</span>
-              <h4>#1708 fix: preserve runtime worker evidence in summaries</h4>
-              <p>In review · Runtime monitor · PR #1708 opened at b084f670; issue body gate passed; controller verification PA...</p>
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/1726">
+              <span class="kanban-priority">P1</span>
+              <h4>#1726 Runtime alert: E29N55 rampart damage unsuppressed at 35,29</h4>
+              <p>Ready · Runtime monitor · 2026-06-06T05:00Z fresh postmerge monitor: alert=false health ok at tick 1849304; p...</p>
             </a>
 
           </article>
@@ -807,15 +800,9 @@ main {
           <article class="kanban-column">
             <div class="column-heading">
               <h3>Combat</h3>
-              <span class="column-count">1</span>
+              <span class="column-count">0</span>
             </div>
-
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/1528">
-              <span class="kanban-priority">P1</span>
-              <h4>#1528 P1: Build first E29N56 tower after RCL4 unlock</h4>
-              <p>Backlog · Combat · 2026-05-31T16:55Z state-audit repair: issue has blocked label and is not executable until...</p>
-            </a>
-
+            <div class="kanban-empty">No Live cards</div>
           </article>
 
 
@@ -828,28 +815,28 @@ main {
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/1490">
               <span class="kanban-priority">P0</span>
               <h4>#1490 P0: CPU bucket critical recurrence after #1433 in official MMO...</h4>
-              <p>In progress · Territory/Economy · 2026-06-05 02:04 +08 CPU acceptance remains open: latest runtime-summary-co...</p>
+              <p>In progress · Territory/Economy · 2026-06-06T05:28Z: CPU still degraded; console tick 1849538 bucket=1845 use...</p>
             </a>
 
 
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/1700">
-              <span class="kanban-priority">P1</span>
-              <h4>#1700 P1: Seasonal E9S28 reserve-first remote mining and road bootstrap</h4>
-              <p>In progress · Territory/Economy · 2026-06-05T18:49Z PR #1702 code is live: official deploy run 27033591689 fo...</p>
-            </a>
-
-
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/1707">
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/1715">
               <span class="kanban-priority">P0</span>
-              <h4>#1707 P0: Verify and repair cross-room construction execution gate af...</h4>
-              <p>Ready · Territory/Economy · Created from Gameplay Review CLOSED_LOOP_FAILED lines 362-374/430-436; fresh cons...</p>
+              <h4>#1715 P0: Fix cross-room construction assignment suppression under wo...</h4>
+              <p>In progress · Territory/Economy · 2026-06-06T19:46Z: #1743 deployed but postdeploy acceptance still failed; r...</p>
             </a>
 
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/1664">
               <span class="kanban-priority">P1</span>
               <h4>#1664 P1: E29N56 energy buffer recovery follow-up after CPU fix</h4>
-              <p>Ready · Territory/Economy · 2026-06-05T18:55Z fresh postdeploy console/runtime alert evidence improved: E29N5...</p>
+              <p>In progress · Territory/Economy · 2026-06-05 21:10Z validation refreshed. Latest console runtime-summary-cons...</p>
+            </a>
+
+
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/1738">
+              <span class="kanban-priority">P1</span>
+              <h4>#1738 P1: Recover energy buffer collapse and construction unblock aft...</h4>
+              <p>In progress · Territory/Economy · 2026-06-06T19:46Z: fresh console shows E29N55 buffer 783 and E29N57 1437; b...</p>
             </a>
 
           </article>
@@ -873,28 +860,28 @@ main {
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/1032">
               <span class="kanban-priority">P0</span>
               <h4>#1032 P0: Scale-first offline/private RL training campaign</h4>
-              <p>In progress · RL flywheel · 2026-06-05T16:36Z: #1698 known_hosts hardening merged; Loop A local training comp...</p>
+              <p>In progress · RL flywheel · 2026-06-06T17:00Z: stuck local runner PID 3701954 was terminated after diagnostic...</p>
             </a>
 
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/1233">
               <span class="kanban-priority">P0</span>
               <h4>#1233 P0: Restore RL steward autonomous compute dispatch cadence</h4>
-              <p>In progress · RL flywheel · 2026-06-05T16:36Z: #1698/#1681 known_hosts hardening merged; latest tencent-pg-20...</p>
+              <p>In progress · RL flywheel · 2026-06-06T14:42Z: latest Tencent summaries through tencent-pg-20260606t144004z a...</p>
             </a>
 
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/1543">
               <span class="kanban-priority">P0</span>
               <h4>#1543 P0: Recover clobbered RL conclusion registry and stale-conclusi...</h4>
-              <p>In progress · RL flywheel · 2026-06-05T16:22Z conclusion registry parsed: total 17, OPEN=1 ACTIONED=3 VALIDAT...</p>
+              <p>In progress · RL flywheel · 2026-06-05T22:33Z conclusion-registry.json updated artifact-first: total 17, CLOS...</p>
             </a>
 
 
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/1566">
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/1583">
               <span class="kanban-priority">P0</span>
-              <h4>#1566 P0: Repair RL multi-tier objective activation proof before paid...</h4>
-              <p>In progress · RL flywheel · 2026-06-05T16:15Z Loop A completed local trusted gradient but rewardDecisionId re...</p>
+              <h4>#1583 P0: Land first bounded RL live canary from fresh-gate candidate</h4>
+              <p>In progress · RL flywheel · 2026-06-05T22:30Z: rewardDecisionId now present in manual Loop A artifact (RD-AUT...</p>
             </a>
 
           </article>
@@ -903,9 +890,15 @@ main {
           <article class="kanban-column">
             <div class="column-heading">
               <h3>Docs/process</h3>
-              <span class="column-count">0</span>
+              <span class="column-count">1</span>
             </div>
-            <div class="kanban-empty">No Live cards</div>
+
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/pull/1728">
+              <span class="kanban-priority">P2</span>
+              <h4>#1728 chore(roadmap): refresh Pages artifacts</h4>
+              <p>In review · Docs/process · 2026-06-06T18:04Z live audit repaired stale evidence: PR #1728 head b5dce126 is BE...</p>
+            </a>
+
           </article>
 
         </div>
@@ -917,23 +910,23 @@ main {
         <div class="process-grid">
 
           <article class="process-card">
-            <p class="process-value">1007</p>
+            <p class="process-value">1028</p>
             <p class="process-label">Commits</p>
             <p class="process-detail">git rev-list --count HEAD</p>
           </article>
 
 
           <article class="process-card">
-            <p class="process-value">823</p>
+            <p class="process-value">835</p>
             <p class="process-label">Issues</p>
             <p class="process-detail">23 open</p>
           </article>
 
 
           <article class="process-card">
-            <p class="process-value">888</p>
+            <p class="process-value">909</p>
             <p class="process-label">PRs</p>
-            <p class="process-detail">868 merged</p>
+            <p class="process-detail">889 merged</p>
           </article>
 
 
@@ -989,7 +982,7 @@ main {
       </section>
 
     </main>
-    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-06-05T20:13:41Z</footer>
+    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-06-06T19:47:20Z</footer>
   </div>
 </body>
 </html>

--- a/docs/roadmap-data.json
+++ b/docs/roadmap-data.json
@@ -3,116 +3,161 @@
     "logo": "assets/screeps-community-logo.png"
   },
   "format": "roadmap-portrait-kpi-kanban-v5",
-  "generatedAt": "2026-06-05T20:13:41Z",
-  "generatedAtCst": "2026-06-06T04:13:41+08:00",
+  "generatedAt": "2026-06-06T19:47:20Z",
+  "generatedAtCst": "2026-06-07T03:47:20+08:00",
   "github": {
     "fetchErrors": [],
     "fetched": true,
     "issues": [
       {
-        "createdAt": "2026-06-05T20:10:42Z",
+        "createdAt": "2026-06-06T17:36:17Z",
         "domain": "RL flywheel",
-        "domainSource": "heuristic",
-        "kind": "bug",
-        "labels": [
-          "kind:bug",
-          "priority:p1",
-          "roadmap",
-          "roadmap:rl-flywheel"
-        ],
-        "milestone": "P1: RL strategy flywheel gate",
-        "number": 1710,
-        "priority": "P1",
-        "state": "OPEN",
-        "status": "Ready",
-        "title": "P1: Repair Tencent post-fix validation private-server HTTP readiness timeout",
-        "type": "Issue",
-        "updatedAt": "2026-06-05T20:10:42Z",
-        "url": "https://github.com/lanyusea/screeps/issues/1710"
-      },
-      {
-        "createdAt": "2026-06-05T20:01:05Z",
-        "domain": "Territory/Economy",
-        "domainSource": "heuristic",
-        "kind": "bug",
-        "labels": [
-          "kind:bug",
-          "priority:p0",
-          "roadmap",
-          "roadmap:territory-economy"
-        ],
-        "milestone": "P1: Territory/Economy gameplay gate",
-        "number": 1707,
-        "priority": "P0",
-        "state": "OPEN",
-        "status": "Ready",
-        "title": "P0: Verify and repair cross-room construction execution gate after failed acceptance",
-        "type": "Issue",
-        "updatedAt": "2026-06-05T20:01:05Z",
-        "url": "https://github.com/lanyusea/screeps/issues/1707"
-      },
-      {
-        "createdAt": "2026-06-05T19:39:41Z",
-        "domain": "RL flywheel",
-        "domainSource": "heuristic",
-        "kind": "bug",
-        "labels": [
-          "kind:bug",
-          "priority:p1",
-          "roadmap",
-          "roadmap:rl-flywheel"
-        ],
-        "milestone": "P1: RL strategy flywheel gate",
-        "number": 1706,
-        "priority": "P1",
-        "state": "OPEN",
-        "status": "Ready",
-        "title": "P1: Validate Tencent room-busy recurrence guard after prior fix",
-        "type": "Issue",
-        "updatedAt": "2026-06-05T19:53:20Z",
-        "url": "https://github.com/lanyusea/screeps/issues/1706"
-      },
-      {
-        "createdAt": "2026-06-05T19:39:38Z",
-        "domain": "Change-control",
-        "domainSource": "heuristic",
-        "kind": "code",
-        "labels": [
-          "kind:code",
-          "priority:p1",
-          "roadmap",
-          "roadmap:rl-flywheel"
-        ],
-        "milestone": "P1: RL strategy flywheel gate",
-        "number": 1705,
-        "priority": "P1",
-        "state": "OPEN",
-        "status": "Ready",
-        "title": "P1: Propagate rewardDecisionId into RL policy advantage artifacts",
-        "type": "Issue",
-        "updatedAt": "2026-06-05T19:56:19Z",
-        "url": "https://github.com/lanyusea/screeps/issues/1705"
-      },
-      {
-        "createdAt": "2026-06-05T17:40:50Z",
-        "domain": "Territory/Economy",
         "domainSource": "heuristic",
         "kind": "ops",
         "labels": [
           "kind:ops",
+          "priority:p1",
+          "roadmap",
+          "roadmap:rl-flywheel"
+        ],
+        "milestone": "P1: RL strategy flywheel gate",
+        "number": 1742,
+        "priority": "P1",
+        "state": "OPEN",
+        "status": "Ready",
+        "title": "P1: Diagnose local RL training runner exit without report after futex hang",
+        "type": "Issue",
+        "updatedAt": "2026-06-06T17:36:17Z",
+        "url": "https://github.com/lanyusea/screeps/issues/1742"
+      },
+      {
+        "createdAt": "2026-06-06T16:20:14Z",
+        "domain": "RL flywheel",
+        "domainSource": "heuristic",
+        "kind": "ops",
+        "labels": [
+          "kind:ops",
+          "priority:p2",
+          "roadmap",
+          "roadmap:rl-flywheel"
+        ],
+        "milestone": "P1: RL strategy flywheel gate",
+        "number": 1739,
+        "priority": "P2",
+        "state": "OPEN",
+        "status": "Ready",
+        "title": "P2: Diagnose RL training runner swap exhaustion",
+        "type": "Issue",
+        "updatedAt": "2026-06-06T17:01:21Z",
+        "url": "https://github.com/lanyusea/screeps/issues/1739"
+      },
+      {
+        "createdAt": "2026-06-06T16:20:11Z",
+        "domain": "Territory/Economy",
+        "domainSource": "heuristic",
+        "kind": "bug",
+        "labels": [
+          "blocked",
+          "kind:bug",
+          "priority:p1",
+          "roadmap",
+          "roadmap:territory-economy"
+        ],
+        "milestone": "P1: Territory/Economy gameplay gate",
+        "number": 1738,
+        "priority": "P1",
+        "state": "OPEN",
+        "status": "Backlog",
+        "title": "P1: Recover energy buffer collapse and construction unblock after Loop B alert",
+        "type": "Issue",
+        "updatedAt": "2026-06-06T19:26:53Z",
+        "url": "https://github.com/lanyusea/screeps/issues/1738"
+      },
+      {
+        "createdAt": "2026-06-06T09:17:38Z",
+        "domain": "RL flywheel",
+        "domainSource": "heuristic",
+        "kind": "bug",
+        "labels": [
+          "blocked",
+          "kind:bug",
           "priority:p0",
           "roadmap",
-          "roadmap:phase-c-telemetry"
+          "roadmap:seasonal-world",
+          "seasonal-smoke"
         ],
-        "milestone": "Phase C: Runtime telemetry / monitor gate",
-        "number": 1703,
+        "milestone": "Seasonal World: smoke readiness gate",
+        "number": 1731,
+        "priority": "P0",
+        "state": "OPEN",
+        "status": "Backlog",
+        "title": "P0: Stop seasonal workers/haulers walking empty energy-spending tasks",
+        "type": "Issue",
+        "updatedAt": "2026-06-06T19:28:22Z",
+        "url": "https://github.com/lanyusea/screeps/issues/1731"
+      },
+      {
+        "createdAt": "2026-06-06T04:51:10Z",
+        "domain": "Change-control",
+        "domainSource": "heuristic",
+        "kind": "bug",
+        "labels": [
+          "kind:bug",
+          "priority:p0",
+          "roadmap",
+          "roadmap:rl-flywheel"
+        ],
+        "milestone": "P1: RL strategy flywheel gate",
+        "number": 1729,
         "priority": "P0",
         "state": "OPEN",
         "status": "Ready",
-        "title": "P0: Populate creep-memory worker evidence in runtime summaries",
+        "title": "P0: Restore rewardDecisionId propagation after latest Loop B null regression",
         "type": "Issue",
-        "updatedAt": "2026-06-05T19:55:06Z",
-        "url": "https://github.com/lanyusea/screeps/issues/1703"
+        "updatedAt": "2026-06-06T18:26:06Z",
+        "url": "https://github.com/lanyusea/screeps/issues/1729"
+      },
+      {
+        "createdAt": "2026-06-06T02:30:31Z",
+        "domain": "Change-control",
+        "domainSource": "heuristic",
+        "kind": "incident",
+        "labels": [
+          "kind:incident",
+          "priority:p1",
+          "runtime-alert"
+        ],
+        "milestone": "Phase C: Runtime telemetry / monitor gate",
+        "number": 1726,
+        "priority": "P1",
+        "state": "OPEN",
+        "status": "Backlog",
+        "title": "Runtime alert: E29N55 rampart damage unsuppressed at 35,29",
+        "type": "Issue",
+        "updatedAt": "2026-06-06T05:07:55Z",
+        "url": "https://github.com/lanyusea/screeps/issues/1726"
+      },
+      {
+        "createdAt": "2026-06-05T22:38:49Z",
+        "domain": "Territory/Economy",
+        "domainSource": "heuristic",
+        "kind": "bug",
+        "labels": [
+          "kind:bug",
+          "priority:p0",
+          "roadmap",
+          "roadmap:territory-economy",
+          "runtime-alert"
+        ],
+        "milestone": "P1: Territory/Economy gameplay gate",
+        "number": 1715,
+        "priority": "P0",
+        "state": "OPEN",
+        "status": "Ready",
+        "title": "P0: Fix cross-room construction assignment suppression under worker_assignment_gap",
+        "type": "Issue",
+        "updatedAt": "2026-06-06T19:26:52Z",
+        "url": "https://github.com/lanyusea/screeps/issues/1715"
       },
       {
         "createdAt": "2026-06-05T16:28:48Z",
@@ -122,19 +167,19 @@
         "labels": [
           "bug",
           "kind:code",
-          "priority:p1",
+          "priority:p0",
           "roadmap",
           "roadmap:seasonal-world",
           "seasonal-smoke"
         ],
         "milestone": "Seasonal World: smoke readiness gate",
         "number": 1700,
-        "priority": "P1",
+        "priority": "P0",
         "state": "OPEN",
         "status": "Ready",
         "title": "P1: Seasonal E9S28 reserve-first remote mining and road bootstrap",
         "type": "Issue",
-        "updatedAt": "2026-06-05T16:42:34Z",
+        "updatedAt": "2026-06-06T07:22:03Z",
         "url": "https://github.com/lanyusea/screeps/issues/1700"
       },
       {
@@ -206,27 +251,6 @@
         "url": "https://github.com/lanyusea/screeps/issues/1583"
       },
       {
-        "createdAt": "2026-06-01T05:08:36Z",
-        "domain": "RL flywheel",
-        "domainSource": "heuristic",
-        "kind": "bug",
-        "labels": [
-          "kind:bug",
-          "priority:p0",
-          "roadmap",
-          "roadmap:rl-flywheel"
-        ],
-        "milestone": "P1: RL strategy flywheel gate",
-        "number": 1566,
-        "priority": "P0",
-        "state": "OPEN",
-        "status": "Ready",
-        "title": "P0: Repair RL multi-tier objective activation proof before paid validation",
-        "type": "Issue",
-        "updatedAt": "2026-06-05T11:46:37Z",
-        "url": "https://github.com/lanyusea/screeps/issues/1566"
-      },
-      {
         "createdAt": "2026-05-31T08:17:40Z",
         "domain": "RL flywheel",
         "domainSource": "heuristic",
@@ -246,28 +270,6 @@
         "type": "Issue",
         "updatedAt": "2026-06-03T18:08:37Z",
         "url": "https://github.com/lanyusea/screeps/issues/1543"
-      },
-      {
-        "createdAt": "2026-05-31T00:43:51Z",
-        "domain": "Combat",
-        "domainSource": "heuristic",
-        "kind": "code",
-        "labels": [
-          "blocked",
-          "kind:code",
-          "priority:p1",
-          "roadmap",
-          "roadmap:combat"
-        ],
-        "milestone": "P1: Territory/Economy gameplay gate",
-        "number": 1528,
-        "priority": "P1",
-        "state": "OPEN",
-        "status": "Backlog",
-        "title": "P1: Build first E29N56 tower after RCL4 unlock",
-        "type": "Issue",
-        "updatedAt": "2026-05-31T00:47:21Z",
-        "url": "https://github.com/lanyusea/screeps/issues/1528"
       },
       {
         "createdAt": "2026-05-29T10:58:38Z",
@@ -312,7 +314,7 @@
         "status": "Backlog",
         "title": "P0: CPU bucket critical recurrence after #1433 in official MMO runtime",
         "type": "Issue",
-        "updatedAt": "2026-06-04T16:09:22Z",
+        "updatedAt": "2026-06-06T05:30:51Z",
         "url": "https://github.com/lanyusea/screeps/issues/1490"
       },
       {
@@ -466,7 +468,7 @@
         "status": "Backlog",
         "title": "P0: Scale-first offline/private RL training campaign",
         "type": "Issue",
-        "updatedAt": "2026-06-05T11:10:52Z",
+        "updatedAt": "2026-06-06T17:01:22Z",
         "url": "https://github.com/lanyusea/screeps/issues/1032"
       },
       {
@@ -3578,39 +3580,20 @@
         {
           "domain": "Runtime monitor",
           "domainSource": "project",
-          "evidence": "",
+          "evidence": "2026-06-06T05:00Z fresh postmerge monitor: alert=false health ok at tick 1849304; prior rampart alert not currently active.",
           "kind": "ops",
           "lane": "Runtime monitor",
           "nextAction": "",
-          "number": 1703,
-          "priority": "P0",
+          "number": 1726,
+          "priority": "P1",
           "projectDomain": "Runtime monitor",
           "state": "",
-          "status": "In review",
-          "title": "P0: Populate creep-memory worker evidence in runtime summaries",
+          "status": "Ready",
+          "title": "Runtime alert: E29N55 rampart damage unsuppressed at 35,29",
           "type": "Issue",
           "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/1703",
-          "visionLayer": "resources"
-        },
-        {
-          "createdAt": "2026-06-05T20:03:53Z",
-          "domain": "Runtime monitor",
-          "domainSource": "project",
-          "evidence": "PR #1708 opened at b084f670; issue body gate passed; controller verification PASS with full prod suite and bundle build.",
-          "kind": "code",
-          "lane": "Runtime monitor",
-          "nextAction": "",
-          "number": 1708,
-          "priority": "P0",
-          "projectDomain": "Runtime monitor",
-          "state": "",
-          "status": "In review",
-          "title": "fix: preserve runtime worker evidence in summaries",
-          "type": "PullRequest",
-          "updatedAt": "2026-06-05T20:12:58Z",
-          "url": "https://github.com/lanyusea/screeps/pull/1708",
-          "visionLayer": "territory"
+          "url": "https://github.com/lanyusea/screeps/issues/1726",
+          "visionLayer": "enemy kills"
         },
         {
           "domain": "Runtime monitor",
@@ -3791,6 +3774,24 @@
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/issues/1324",
           "visionLayer": "territory"
+        },
+        {
+          "domain": "Runtime monitor",
+          "domainSource": "project",
+          "evidence": "2026-06-05 20:40Z code merged/deployed: PR #1708 -> 267332c1, deploy run 27038718442 ok, live console capture runtime-summary-console-20260605T204017Z.log shows workerAssignmentEvidenceAvailable=true in E29N55/E29N56/E29N57.",
+          "kind": "ops",
+          "lane": "Runtime monitor",
+          "nextAction": "",
+          "number": 1703,
+          "priority": "P0",
+          "projectDomain": "Runtime monitor",
+          "state": "",
+          "status": "Done",
+          "title": "P0: Populate creep-memory worker evidence in runtime summaries",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/1703",
+          "visionLayer": "resources"
         },
         {
           "domain": "Runtime monitor",
@@ -4096,6 +4097,24 @@
           "type": "PullRequest",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/pull/1509",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Runtime monitor",
+          "domainSource": "project",
+          "evidence": "2026-06-05 20:40Z merged as 267332c1, official deploy run 27038718442 ok, live console capture tick 1836259 proves worker evidence restored in all owned rooms.",
+          "kind": "code",
+          "lane": "Runtime monitor",
+          "nextAction": "",
+          "number": 1708,
+          "priority": "P0",
+          "projectDomain": "Runtime monitor",
+          "state": "",
+          "status": "Done",
+          "title": "fix: preserve runtime worker evidence in summaries",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1708",
           "visionLayer": "territory"
         },
         {
@@ -5753,6 +5772,24 @@
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/pull/81",
           "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "Bot capability",
+          "domainSource": "heuristic",
+          "evidence": "PR #1718 merged efd1ced9 and deployed to Seasonal activeWorld; deploy artifact e9s28-dropped-energy-deploy/20260606T071718Z shows ok=true, artifact hash 39684877, activeWorld match, persistentNoImpact=true. Live proof artifact e9s28-dropped-energy-proof/20260606T071859Z sampled to tick 92210: E9S28 has invader, no friendly creeps, no dropped resources, no containers, source container sites still 0 progress.",
+          "kind": "bug",
+          "lane": "",
+          "nextAction": "",
+          "number": 1718,
+          "priority": "P0",
+          "projectDomain": "",
+          "state": "",
+          "status": "In review",
+          "title": "seasonal: support reserve-first remote mining",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1718",
+          "visionLayer": "territory"
         },
         {
           "domain": "Bot capability",
@@ -9410,6 +9447,24 @@
         },
         {
           "domain": "Bot capability",
+          "domainSource": "heuristic",
+          "evidence": "2026-06-06T02:21Z PR #1724 opened for issue #1528 at Codex commit 6a8aa177 (bot). Controller verification passed diff-check/typecheck/focused+full Jest/build. Exact-head issue gate/prod-ci/roadmap checks green; GraphQL threads=0; CodeRabbit status pending; mergeState UNSTABLE until bot completes.",
+          "kind": "code",
+          "lane": "",
+          "nextAction": "",
+          "number": 1724,
+          "priority": "P1",
+          "projectDomain": "",
+          "state": "",
+          "status": "Done",
+          "title": "construction: cover E29N56 first tower priority",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1724",
+          "visionLayer": "enemy kills"
+        },
+        {
+          "domain": "Bot capability",
           "domainSource": "project",
           "evidence": "Post-merge/deploy watch 2026-05-12T23:25Z: deploy run 25766188283 @ d7cf26b includes #984; live alert=false, tactical=[SILENT], owned_spawns=1, owned_creeps=7, hostiles=0.",
           "kind": "code",
@@ -12201,24 +12256,6 @@
         {
           "domain": "Combat",
           "domainSource": "project",
-          "evidence": "2026-05-31T16:55Z state-audit repair: issue has blocked label and is not executable until E29N56 reaches RCL4; moved out of Ready to avoid false P1 scheduling.",
-          "kind": "code",
-          "lane": "Combat",
-          "nextAction": "",
-          "number": 1528,
-          "priority": "P1",
-          "projectDomain": "Combat",
-          "state": "",
-          "status": "Backlog",
-          "title": "P1: Build first E29N56 tower after RCL4 unlock",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/1528",
-          "visionLayer": "territory"
-        },
-        {
-          "domain": "Combat",
-          "domainSource": "project",
           "evidence": "Post-closure 2026-05-12T23:25Z: live alert=false, tactical=[SILENT], owned_spawns=1, owned_creeps=7, hostiles=0. Tower remains 0 but is strategic progression under #879/#979, not active defense incident.",
           "kind": "code",
           "lane": "Combat",
@@ -12741,6 +12778,24 @@
         {
           "domain": "Combat",
           "domainSource": "project",
+          "evidence": "Done 2026-06-06T02:41Z: PR #1724 merged as d2faf0a2 after exact-head checks/CodeRabbit/threads gate; live Screeps API room-objects for shardX/E29N56 shows completed tower id 6a1abe62968b6e64b423baff at (24,24), hits 3000/3000.",
+          "kind": "code",
+          "lane": "Combat",
+          "nextAction": "",
+          "number": 1528,
+          "priority": "P1",
+          "projectDomain": "Combat",
+          "state": "",
+          "status": "Done",
+          "title": "P1: Build first E29N56 tower after RCL4 unlock",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/1528",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Combat",
+          "domainSource": "project",
           "evidence": "",
           "kind": "bug",
           "lane": "Combat",
@@ -13245,7 +13300,7 @@
         {
           "domain": "Territory/Economy",
           "domainSource": "project",
-          "evidence": "2026-06-05 02:04 +08 CPU acceptance remains open: latest runtime-summary-console capture is now >2000 ticks old; 7ee147327ba6 capture run requested but no fresh output due cron cadence stall; no closure from stale CPU data.",
+          "evidence": "2026-06-06T05:28Z: CPU still degraded; console tick 1849538 bucket=1845 used=64.85/70; GE review says constructionScoring skipped usedOverLimit; E29N56 build partly active.",
           "kind": "bug",
           "lane": "Territory/Economy",
           "nextAction": "",
@@ -13263,43 +13318,25 @@
         {
           "domain": "Territory/Economy",
           "domainSource": "project",
-          "evidence": "2026-06-05T18:49Z PR #1702 code is live: official deploy run 27033591689 for main 04f604d mode=deploy ok=true, artifact sha da8f8cb6 matches local dist, branch/activeWorld main matched, health gate ok, alert=false. Postdeploy console runtime-summary-console-20260605T184940Z shows rooms alive and productive/build tasks.",
-          "kind": "code",
-          "lane": "Territory/Economy",
-          "nextAction": "",
-          "number": 1700,
-          "priority": "P1",
-          "projectDomain": "Territory/Economy",
-          "state": "",
-          "status": "In progress",
-          "title": "P1: Seasonal E9S28 reserve-first remote mining and road bootstrap",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/1700",
-          "visionLayer": "territory"
-        },
-        {
-          "domain": "Territory/Economy",
-          "domainSource": "project",
-          "evidence": "Created from Gameplay Review CLOSED_LOOP_FAILED lines 362-374/430-436; fresh console tick 1834937 has E29N55 buildProgress=15 but E29N57/E29N56 still cpu_shed with backlog; #1703 will repair definitive worker evidence.",
+          "evidence": "2026-06-06T19:46Z: #1743 deployed but postdeploy acceptance still failed; residual Codex commit 73681c3d opened PR #1744; controller verification PASS.",
           "kind": "bug",
           "lane": "Territory/Economy",
           "nextAction": "",
-          "number": 1707,
+          "number": 1715,
           "priority": "P0",
           "projectDomain": "Territory/Economy",
           "state": "",
-          "status": "Ready",
-          "title": "P0: Verify and repair cross-room construction execution gate after failed acceptance",
+          "status": "In progress",
+          "title": "P0: Fix cross-room construction assignment suppression under worker_assignment_gap",
           "type": "Issue",
           "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/1707",
+          "url": "https://github.com/lanyusea/screeps/issues/1715",
           "visionLayer": "territory"
         },
         {
           "domain": "Territory/Economy",
           "domainSource": "project",
-          "evidence": "2026-06-05T18:55Z fresh postdeploy console/runtime alert evidence improved: E29N56 energy 950/950, workerCount=5, productiveAssignmentCount=3, build=1, transfer=2 at ticks 1833531/1833542; all-owned-room health gate ok at tick 1833700. Acceptance still needs sustained 24-capture buffer/build proof.",
+          "evidence": "2026-06-05 21:10Z validation refreshed. Latest console runtime-summary-console-20260605T205957Z: E29N56 ticks 1836739/1836748 buffer healthy 750-800/1000 threshold 500, build tasks=2, buildCarriedEnergy=200 then 150, worker assignment evidence true. Fresh monitor health tick 1837034: E29N56 owned_spawns=1, owned_creeps=12, hostiles=0.",
           "kind": "ops",
           "lane": "Territory/Economy",
           "nextAction": "",
@@ -13307,11 +13344,67 @@
           "priority": "P1",
           "projectDomain": "Territory/Economy",
           "state": "",
-          "status": "Ready",
+          "status": "In progress",
           "title": "P1: E29N56 energy buffer recovery follow-up after CPU fix",
           "type": "Issue",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/issues/1664",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "project",
+          "evidence": "2026-06-06T19:46Z: fresh console shows E29N55 buffer 783 and E29N57 1437; buildCarriedEnergy=0 with worker_assignment_gap; PR #1744 opened for #1715 residual.",
+          "kind": "bug",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 1738,
+          "priority": "P1",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "In progress",
+          "title": "P1: Recover energy buffer collapse and construction unblock after Loop B alert",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/1738",
+          "visionLayer": "territory"
+        },
+        {
+          "createdAt": "2026-06-06T19:45:55Z",
+          "domain": "Territory/Economy",
+          "domainSource": "project",
+          "evidence": "2026-06-06T19:46Z: PR #1744 head 73681c3d; controller diff/typecheck/Jest 105/2354/build PASS; CodeRabbit rate-limited; prod-ci pending.",
+          "kind": "bug",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 1744,
+          "priority": "P0",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "In review",
+          "title": "fix: recover build assignment from retained upgrade task",
+          "type": "PullRequest",
+          "updatedAt": "2026-06-06T19:46:36Z",
+          "url": "https://github.com/lanyusea/screeps/pull/1744",
+          "visionLayer": "territory"
+        },
+        {
+          "createdAt": "2026-06-06T09:37:56Z",
+          "domain": "Territory/Economy",
+          "domainSource": "heuristic",
+          "evidence": "2026-06-06T19:28Z: update-branch completed to b5ca018a; exact-head checks green, CodeRabbit status success, GraphQL review threads=0. Merge intentionally sequenced behind hard-P0 #1715 residual Codex proc_[redacted].",
+          "kind": "bug",
+          "lane": "",
+          "nextAction": "",
+          "number": 1733,
+          "priority": "P0",
+          "projectDomain": "",
+          "state": "",
+          "status": "In review",
+          "title": "seasonal: prevent empty worker/hauler task walking",
+          "type": "PullRequest",
+          "updatedAt": "2026-06-06T19:28:21Z",
+          "url": "https://github.com/lanyusea/screeps/pull/1733",
           "visionLayer": "territory"
         },
         {
@@ -13695,6 +13788,24 @@
         {
           "domain": "Territory/Economy",
           "domainSource": "project",
+          "evidence": "Done 2026-06-06: PR #1737 merged at e99dbfad, deploy run 27065225678 succeeded; PR #1735 follow-up deployed run 27065462593; final live monitor shows all owned rooms alert=false/health ok with sourceHarvesters/haulers/workers harvesting and repairing.",
+          "kind": "bug",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 1736,
+          "priority": "P0",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "Done",
+          "title": "P0: Normal-world rooms lack local harvest/haul recovery and mutual repair pressure",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/1736",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "project",
           "evidence": "PR #910 merged 2026-05-10T19:06Z (squash 1c5ae92). Gemini critical feedback addressed: claimedAt preserved during recovery. postClaimBootstrap now accepts claimedAt input. Tests verify timestamp preservation.",
           "kind": "bug",
           "lane": "Territory/Economy",
@@ -13839,6 +13950,24 @@
         {
           "domain": "Territory/Economy",
           "domainSource": "project",
+          "evidence": "2026-06-05 20:40Z closed completed. Deploy run 27038718442 ok; live console capture runtime-summary-console-20260605T204017Z tick 1836259 shows build evidence or bounded cpu_shed suppression across all rooms.",
+          "kind": "bug",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 1707,
+          "priority": "P0",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "Done",
+          "title": "P0: Verify and repair cross-room construction execution gate after failed acceptance",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/1707",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "project",
           "evidence": "2026-05-23T23:33Z scheduler-check-20260523T233337Z: E29N55/E29N56/E29N57 all owned by lanyusea with spawns+creeps; alert=false health_gate.ok=true. E29N55 recovery/retarget acceptance met; #1103 closed.",
           "kind": "ops",
           "lane": "Territory/Economy",
@@ -13929,6 +14058,24 @@
         {
           "domain": "Territory/Economy",
           "domainSource": "project",
+          "evidence": "Merged as 36fa83af; deploy run 27052669691 succeeded with activeWorld/main matched, postdeploy health ok=true and alert=false.",
+          "kind": "code",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 1721,
+          "priority": "P0",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "Done",
+          "title": "cpu: preserve construction planning under CPU overrun",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1721",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "project",
           "evidence": "Merged as 023212a6; official deploy run 26938143819 ok + health gate ok. Postdeploy CPU acceptance still failed; follow-up moved to #1490 proc_[redacted].",
           "kind": "code",
           "lane": "Territory/Economy",
@@ -13996,6 +14143,114 @@
           "type": "PullRequest",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/pull/1043",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "project",
+          "evidence": "PR #1740 exact head 51f1e7b9; issue-completion/prod-ci/roadmap checks green and GraphQL unresolved threads=0; CodeRabbit status is SUCCESS but top-level comment says review limit/usage credits, not substantive review.",
+          "kind": "code",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 1740,
+          "priority": "P0",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "Done",
+          "title": "economy: account for refill acquisition coverage",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1740",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "project",
+          "evidence": "2026-06-06T12:55Z merged #1734 at 605975db after exact-head checks/CodeRabbit/threads gate; deploy run 27062882473 succeeded. Postdeploy all-owned acceptance still failed for #1715, so PR #1734 is Done as a merged slice and successor Codex lane proc_[redacted] owns remaining incident.",
+          "kind": "code",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 1734,
+          "priority": "P0",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "Done",
+          "title": "economy: allow bootstrap storage construction before refill",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1734",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "project",
+          "evidence": "Done 2026-06-06: PR #1735 merged at b03d00e1 and deployed via official workflow run 27065462593; final monitor postdeploy-1715-1736-final-20260606T145746Z alert=false and health ok.",
+          "kind": "bug",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 1735,
+          "priority": "P0",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "Done",
+          "title": "economy: clear postdeploy worker assignment gap",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1735",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "project",
+          "evidence": "2026-06-06T10:27Z merged as 0551b9b6 after exact-head acae7d5 gate: elapsed>15m, checks green, CodeRabbit approved, review threads resolved, controller typecheck/Jest/build passed.",
+          "kind": "code",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 1732,
+          "priority": "P0",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "Done",
+          "title": "economy: recover E29N56 postdeploy construction assignment",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1732",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "project",
+          "evidence": "Done 2026-06-06: PR #1737 merged at e99dbfad and deployed via official workflow run 27065225678; final monitor after companion deploy shows rooms harvesting and repairing with alert=false.",
+          "kind": "bug",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 1737,
+          "priority": "P0",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "Done",
+          "title": "economy: recover local harvest and refill pressure",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1737",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "project",
+          "evidence": "PR #1719 merged as 82b52990 and deployed in run 27057459484. Deploy/upload and primary E29N55 health ok, but all-owned acceptance still failed for #1715 (E29N56 worker_assignment_gap_sustained tick 1854811); this PR remains Done while #1715 follow-up Codex proc_[redacted] handles residual blocker.",
+          "kind": "code",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 1719,
+          "priority": "P0",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "Done",
+          "title": "economy: unblock full-energy construction assignment",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1719",
           "visionLayer": "territory"
         },
         {
@@ -14248,6 +14503,42 @@
           "type": "PullRequest",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/pull/1513",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "project",
+          "evidence": "2026-06-06T19:26Z: merged/deployed as 49713d9c via official run 27071513534; deploy ok/activeWorld matched/health ok. All-owned acceptance still failed at runtime-artifacts/screeps-monitor/postdeploy-pr1743-20260606T192304Z, routed to residual Codex proc_[redacted].",
+          "kind": "bug",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 1743,
+          "priority": "P0",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "Done",
+          "title": "fix: recover construction assignment after worker gap alert",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1743",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "project",
+          "evidence": "2026-06-06T18:03Z Deploy run 27069646426 succeeded for b6557886 (deploy ok, activeWorld matched, health ok, alert=false for target E29N55). Artifact archived under runtime-artifacts/official-screeps-deploy/*-27069646426.json. All-owned acceptance remains with #1715/#1738.",
+          "kind": "bug",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 1741,
+          "priority": "P0",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "Done",
+          "title": "fix: recover worker assignments after postdeploy gap",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1741",
           "visionLayer": "territory"
         },
         {
@@ -21975,7 +22266,7 @@
         {
           "domain": "RL flywheel",
           "domainSource": "project",
-          "evidence": "2026-06-05T16:15Z candidate scorecard exists and trustedGradientUpdate=true, but live canary blocked by rewardDecisionId=null and no fresh gate.",
+          "evidence": "2026-06-05T22:30Z: rewardDecisionId now present in manual Loop A artifact (RD-AUTO-67014b3ef07a) and #1566 activation proof closed; live canary still blocked by no online rollout gate, CPU #1490, and #1714 ledger anomaly.",
           "kind": "ops",
           "lane": "RL flywheel",
           "nextAction": "",
@@ -21993,7 +22284,7 @@
         {
           "domain": "RL flywheel",
           "domainSource": "project",
-          "evidence": "2026-06-05T16:22Z conclusion registry parsed: total 17, OPEN=1 ACTIONED=3 VALIDATING=3 CLOSED=10, stale/escalated=0.",
+          "evidence": "2026-06-05T22:33Z conclusion-registry.json updated artifact-first: total 17, CLOSED=11, ACTIONED=3, VALIDATING=3; linked #1713/#1714/#1490 and closed #1566 acceptance scope.",
           "kind": "ops",
           "lane": "RL flywheel",
           "nextAction": "",
@@ -22011,25 +22302,7 @@
         {
           "domain": "RL flywheel",
           "domainSource": "project",
-          "evidence": "2026-06-05T16:15Z Loop A completed local trusted gradient but rewardDecisionId remains null, blocking deployable objective activation proof.",
-          "kind": "bug",
-          "lane": "RL flywheel",
-          "nextAction": "",
-          "number": 1566,
-          "priority": "P0",
-          "projectDomain": "RL flywheel",
-          "state": "",
-          "status": "In progress",
-          "title": "P0: Repair RL multi-tier objective activation proof before paid validation",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/1566",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "RL flywheel",
-          "domainSource": "project",
-          "evidence": "2026-06-05T16:36Z: #1698/#1681 known_hosts hardening merged; latest tencent-pg-20260605t163003z still safely skipped run-single, ASG 0/0/0.",
+          "evidence": "2026-06-06T14:42Z: latest Tencent summaries through tencent-pg-20260606t144004z and preflight cron-batch-preflight-20260606t143417... all skipped by paid_failure_recurrence_launch_guard; ASG desired/in-service 0/0; billing guard OK.",
           "kind": "ops",
           "lane": "RL flywheel",
           "nextAction": "",
@@ -22047,7 +22320,25 @@
         {
           "domain": "RL flywheel",
           "domainSource": "project",
-          "evidence": "2026-06-05T16:36Z: #1698 known_hosts hardening merged; Loop A local training completed trustedGradientUpdate=true but rewardDecisionId=null; Tencent held.",
+          "evidence": "2026-06-06T18:23Z: PR #1730 merged as d081959e; latest Loop A ledger runtime-artifacts/rl-control-loop/20260606T174933Z-training-ledger.json now has rewardDecisionId=construction-priority.pg.risk-aware-seed.v1. Latest Loop B remains 20260606T160607Z/stale for full acceptance.",
+          "kind": "bug",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 1729,
+          "priority": "P0",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "In progress",
+          "title": "P0: Restore rewardDecisionId propagation after latest Loop B null regression",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/1729",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "project",
+          "evidence": "2026-06-06T17:00Z: stuck local runner PID 3701954 was terminated after diagnostic artifact runtime-artifacts/rl-training/stuck-runner-diagnostics-20260606T1700Z.json (futex_wait_queue, >10h, swap full). No active local/Tencent runner remains; #1715 Codex proc_[redacted] is active.",
           "kind": "ops",
           "lane": "RL flywheel",
           "nextAction": "",
@@ -22083,93 +22374,73 @@
         {
           "domain": "RL flywheel",
           "domainSource": "project",
-          "evidence": "PR #1709 head 9685c42 has equivalent active rewardDecision carryover threads PRRT_kwDOSMSsO86Hd5tV and PRRT_kwDOSMSsO86Hd-iy; Codex triage/fix proc_[redacted] is editing the shared root cause.",
-          "kind": "code",
+          "evidence": "2026-06-06T17:00Z diagnostic artifact runtime-artifacts/rl-training/stuck-runner-diagnostics-20260606T1700Z.json captured PID 3701954 stuck in futex_wait_queue at >10h with swap 1987/1987MB. SIGTERM then SIGKILL cleared PID; RAM available rose to ~3817MB, swap free 59MB.",
+          "kind": "ops",
           "lane": "RL flywheel",
           "nextAction": "",
-          "number": 1705,
-          "priority": "P1",
+          "number": 1739,
+          "priority": "P2",
           "projectDomain": "RL flywheel",
           "state": "",
-          "status": "In review",
-          "title": "P1: Propagate rewardDecisionId into RL policy advantage artifacts",
+          "status": "In progress",
+          "title": "P2: Diagnose RL training runner swap exhaustion",
           "type": "Issue",
           "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/1705",
+          "url": "https://github.com/lanyusea/screeps/issues/1739",
           "visionLayer": "foundation blocker"
         },
         {
           "domain": "RL flywheel",
-          "domainSource": "project",
-          "evidence": "",
+          "domainSource": "heuristic",
+          "evidence": "2026-06-06T19:28Z: PR #1733 head b5ca018a is clean/green/threads=0 after update-branch; held only behind active hard-P0 #1715 residual Codex proc_[redacted].",
           "kind": "bug",
-          "lane": "RL flywheel",
+          "lane": "",
           "nextAction": "",
-          "number": 1706,
-          "priority": "P1",
-          "projectDomain": "RL flywheel",
+          "number": 1731,
+          "priority": "P0",
+          "projectDomain": "",
           "state": "",
           "status": "In review",
-          "title": "P1: Validate Tencent room-busy recurrence guard after prior fix",
+          "title": "P0: Stop seasonal workers/haulers walking empty energy-spending tasks",
           "type": "Issue",
           "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/1706",
+          "url": "https://github.com/lanyusea/screeps/issues/1731",
+          "visionLayer": "resources"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "heuristic",
+          "evidence": "PR #1718 merged efd1ced9 and deployed to Seasonal activeWorld; deploy artifact e9s28-dropped-energy-deploy/20260606T071718Z shows ok=true, artifact hash 39684877, activeWorld match, persistentNoImpact=true. Live proof artifact e9s28-dropped-energy-proof/20260606T071859Z sampled to tick 92210: E9S28 has invader, no friendly creeps, no dropped resources, no containers, source container sites still 0 progress.",
+          "kind": "bug",
+          "lane": "",
+          "nextAction": "",
+          "number": 1700,
+          "priority": "P0",
+          "projectDomain": "",
+          "state": "",
+          "status": "In review",
+          "title": "P1: Seasonal E9S28 reserve-first remote mining and road bootstrap",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/1700",
           "visionLayer": "territory"
         },
         {
-          "createdAt": "2026-06-05T20:11:32Z",
           "domain": "RL flywheel",
           "domainSource": "project",
-          "evidence": "PR #1711 opened at b748f977; issue body gate passed; controller verification PASS for Tencent runner tests and no-paid safety.",
-          "kind": "bug",
+          "evidence": "2026-06-06T18:21Z: no active RL/Tencent runners; latest Loop A 20260606T174933Z records localRunnerExitedWithoutReport and Tencent guard held. RL diagnostic remains Ready but hard P0 #1715 preempts this steward slot.",
+          "kind": "ops",
           "lane": "RL flywheel",
           "nextAction": "",
-          "number": 1711,
-          "priority": "P1",
-          "projectDomain": "RL flywheel",
-          "state": "",
-          "status": "In review",
-          "title": "fix: preserve Tencent recurrence recovery evidence",
-          "type": "PullRequest",
-          "updatedAt": "2026-06-05T20:12:38Z",
-          "url": "https://github.com/lanyusea/screeps/pull/1711",
-          "visionLayer": "territory"
-        },
-        {
-          "createdAt": "2026-06-05T20:03:57Z",
-          "domain": "RL flywheel",
-          "domainSource": "project",
-          "evidence": "PR #1709 head 9685c42 has equivalent active rewardDecision carryover threads PRRT_kwDOSMSsO86Hd5tV and PRRT_kwDOSMSsO86Hd-iy; Codex triage/fix proc_[redacted] is editing the shared root cause.",
-          "kind": "code",
-          "lane": "RL flywheel",
-          "nextAction": "",
-          "number": 1709,
-          "priority": "P1",
-          "projectDomain": "RL flywheel",
-          "state": "",
-          "status": "In review",
-          "title": "fix: propagate RL reward decision provenance",
-          "type": "PullRequest",
-          "updatedAt": "2026-06-05T20:11:25Z",
-          "url": "https://github.com/lanyusea/screeps/pull/1709",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "RL flywheel",
-          "domainSource": "project",
-          "evidence": "Created from #1706 CODEX_1706_HELD: room-busy evidence is historical; latest partial simulator progress has 19/20 env rows succeeded and one private-server HTTP readiness timeout after 900s.",
-          "kind": "bug",
-          "lane": "RL flywheel",
-          "nextAction": "",
-          "number": 1710,
+          "number": 1742,
           "priority": "P1",
           "projectDomain": "RL flywheel",
           "state": "",
           "status": "Ready",
-          "title": "P1: Repair Tencent post-fix validation private-server HTTP readiness timeout",
+          "title": "P1: Diagnose local RL training runner exit without report after futex hang",
           "type": "Issue",
           "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/1710",
+          "url": "https://github.com/lanyusea/screeps/issues/1742",
           "visionLayer": "foundation blocker"
         },
         {
@@ -22877,6 +23148,24 @@
         {
           "domain": "RL flywheel",
           "domainSource": "project",
+          "evidence": "Done 2026-06-06T02:01Z: PR #1723 squash-merged at b75379a0; generated/validated host-sized Loop A local-fallback card runtime-artifacts/rl-experiment-cards/experiment_card.json from E1 gate e1-gate-20260605T191602Z dataset rl-e93cefe304b9; workers=1 scale=5 minConcurrent=1, liveEffect=false.",
+          "kind": "code",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 1722,
+          "priority": "P0",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "Done",
+          "title": "P0: Generate host-sized RL experiment card for latest E1 gate",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/1722",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "project",
           "evidence": "2026-05-19T22:43Z: Issue closed by merged PR #1247 commit 11b15f9993ad074b845c084f514dcbd899fafd2e. Post-merge main verification passed: 139 pytest, 60 subtests; py_compile passed.",
           "kind": "code",
           "lane": "RL flywheel",
@@ -22891,6 +23180,24 @@
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/issues/1244",
           "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "project",
+          "evidence": "Merged PR #1727 at main 5b6f221f; deployed official run 27051623684 ok=true activeWorld/main matched health_ok=true alert=false.",
+          "kind": "ops",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 1725,
+          "priority": "P0",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "Done",
+          "title": "P0: Investigate territory-shadow rollback reliability collapse",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/1725",
+          "visionLayer": "territory"
         },
         {
           "domain": "RL flywheel",
@@ -23345,6 +23652,24 @@
         {
           "domain": "RL flywheel",
           "domainSource": "project",
+          "evidence": "2026-06-05T22:32Z: objective activation proof satisfied by training report local2w-20260603T0832Z and Loop A artifact 20260605T223036Z: objectiveSignalObserved true, passing activation samples, RUN_VALIDATED, rewardDecisionId RD-AUTO-67014b3ef07a.",
+          "kind": "bug",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 1566,
+          "priority": "P0",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "Done",
+          "title": "P0: Repair RL multi-tier objective activation proof before paid validation",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/1566",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "project",
           "evidence": "2026-05-20T17:57Z: PR #1272 merged as 36b975d8 after gate PASS (age>15m, prod-ci+CodeRabbit success, threads resolved, mergeState CLEAN). Main fast-forwarded; post-merge py_compile + unittest 147 OK + pytest scorecard 18 passed + diff-check passed.",
           "kind": "code",
           "lane": "RL flywheel",
@@ -23467,6 +23792,24 @@
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/issues/1381",
           "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "project",
+          "evidence": "2026-06-06: PR #1720 merged 271de482; postmerge summary tick 1849256 workerAssignmentEvidenceAvailable=true all rooms; alert=false health ok.",
+          "kind": "bug",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 1717,
+          "priority": "P0",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "Done",
+          "title": "P0: Restore creep-memory worker assignment evidence in runtime summaries",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/1717",
+          "visionLayer": "resources"
         },
         {
           "domain": "RL flywheel",
@@ -25775,6 +26118,24 @@
         {
           "domain": "RL flywheel",
           "domainSource": "project",
+          "evidence": "2026-06-06: PR #1720 merged 271de482; postmerge summary tick 1849256 workerAssignmentEvidenceAvailable=true all rooms; alert=false health ok.",
+          "kind": "code",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 1720,
+          "priority": "P0",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "Done",
+          "title": "monitor: capture bounded creep task evidence",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1720",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "project",
           "evidence": "Merged 2026-06-05T10:43Z as 14b2f515; checks green; controller py_compile+unittest OK; postmerge policy artifact 20260605T110330Z rewardDecisionId RD-AUTO-67014b3ef07a.",
           "kind": "code",
           "lane": "RL flywheel",
@@ -25847,6 +26208,24 @@
         {
           "domain": "RL flywheel",
           "domainSource": "project",
+          "evidence": "Done 2026-06-06T02:01Z: PR #1723 squash-merged at b75379a0; generated/validated host-sized Loop A local-fallback card runtime-artifacts/rl-experiment-cards/experiment_card.json from E1 gate e1-gate-20260605T191602Z dataset rl-e93cefe304b9; workers=1 scale=5 minConcurrent=1, liveEffect=false.",
+          "kind": "code",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 1723,
+          "priority": "P0",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "Done",
+          "title": "rl: generate host-sized latest E1 card",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1723",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "project",
           "evidence": "2026-06-04T23:55Z: PR #1673 merged as 3378fbb5 after exact-head green checks, CodeRabbit APPROVED/SUCCESS, threads=0; main fast-forwarded and 353 post-merge tests passed.",
           "kind": "code",
           "lane": "RL flywheel",
@@ -25860,6 +26239,42 @@
           "type": "PullRequest",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/pull/1673",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "project",
+          "evidence": "2026-06-06T15:16Z: PR #1730 merged as d081959e after exact-head checks green and all review threads resolved; postmerge py_compile/unittest passed; policy-advantage artifact now carries RD-AUTO-9f33873ce71c.",
+          "kind": "code",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 1730,
+          "priority": "P0",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "Done",
+          "title": "rl: recover reward decision provenance in ledgers",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1730",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "project",
+          "evidence": "Squash-merged as 5b6f221f and deployed by official run 27051623684 with branchCode/activeWorld matched and postdeploy health ok.",
+          "kind": "code",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 1727,
+          "priority": "P0",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "Done",
+          "title": "rl: scope rollout monitoring to consumed policies",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1727",
           "visionLayer": "foundation blocker"
         },
         {
@@ -26927,6 +27342,24 @@
         {
           "domain": "RL flywheel",
           "domainSource": "project",
+          "evidence": "2026-06-05 20:43Z PR #1709 merged as c779226f after exact-head 4d662bb3 gate: elapsed 39m, green checks, CodeRabbit APPROVED, reviewThreads=0; post-merge main py_compile + unittest(15) + diff-check PASS.",
+          "kind": "code",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 1705,
+          "priority": "P1",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "Done",
+          "title": "P1: Propagate rewardDecisionId into RL policy advantage artifacts",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/1705",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "project",
           "evidence": "",
           "kind": "code",
           "lane": "RL flywheel",
@@ -27431,6 +27864,24 @@
         {
           "domain": "RL flywheel",
           "domainSource": "project",
+          "evidence": "2026-06-05T22:26Z: PR #1713 merged as 0861961d; postmerge no-paid preflight postmerge-1713-preflight-20260605t222625z wrote controller-summary with computeAttempted=false, scaleOutAttempted=false, finalStatus=skipped_paid_failure_recurrence_launch_guard.",
+          "kind": "bug",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 1710,
+          "priority": "P1",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "Done",
+          "title": "P1: Repair Tencent post-fix validation private-server HTTP readiness timeout",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/1710",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "project",
           "evidence": "2026-05-21T23:18Z: PR #1311 merged as 06f2ee7c; main post-merge verification passed diff-check, py_compile, 190 unittest for simulator/training runner.",
           "kind": "code",
           "lane": "RL flywheel",
@@ -27702,6 +28153,24 @@
           "domain": "RL flywheel",
           "domainSource": "project",
           "evidence": "",
+          "kind": "bug",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 1714,
+          "priority": "P1",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "Done",
+          "title": "P1: Suppress stale E1_GATE_STALE anomaly after fresh full gate",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/1714",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "project",
+          "evidence": "",
           "kind": "code",
           "lane": "RL flywheel",
           "nextAction": "",
@@ -27715,6 +28184,24 @@
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/issues/1182",
           "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "project",
+          "evidence": "2026-06-05: PR #1711 merged as 0925c8d3; postmerge preflight postmerge-1711-preflight-20260605t215816z preserves partialSimulatorProgress and confirms no fresh room-busy compute.",
+          "kind": "bug",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 1706,
+          "priority": "P1",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "Done",
+          "title": "P1: Validate Tencent room-busy recurrence guard after prior fix",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/1706",
+          "visionLayer": "territory"
         },
         {
           "domain": "RL flywheel",
@@ -29662,6 +30149,24 @@
         },
         {
           "domain": "RL flywheel",
+          "domainSource": "project",
+          "evidence": "2026-06-05T22:25Z: PR #1713 merged after elapsed>15m, all checks pass, CodeRabbit exact-head APPROVED, review threads 0; merge commit 0861961d. Postmerge preflight artifact postmerge-1713-preflight-20260605t222625z no-paid/ASG 0.",
+          "kind": "code",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 1713,
+          "priority": "P1",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "Done",
+          "title": "fix: classify Tencent HTTP readiness timeouts",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1713",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
           "domainSource": "heuristic",
           "evidence": "2026-06-03T01:25Z: MERGED as squash 76792938; main fast-forwarded; post-merge py_compile+148 unittest PASS; no unresolved review threads; CodeRabbit exact-head approval/no actionable comments.",
           "kind": "code",
@@ -29694,6 +30199,42 @@
           "type": "PullRequest",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/pull/1638",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "project",
+          "evidence": "Merged 2026-06-05 21:57 UTC as 0925c8d3 after elapsed 105m, green checks, CodeRabbit exact-head approval, reviewThreads=0, local py_compile+177 unittest+diff-check.",
+          "kind": "bug",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 1711,
+          "priority": "P1",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "Done",
+          "title": "fix: preserve Tencent recurrence recovery evidence",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1711",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "project",
+          "evidence": "2026-06-05 20:43Z PR #1709 merged as c779226f after exact-head 4d662bb3 gate: elapsed 39m, green checks, CodeRabbit APPROVED, reviewThreads=0; post-merge main py_compile + unittest(15) + diff-check PASS.",
+          "kind": "code",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 1709,
+          "priority": "P1",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "Done",
+          "title": "fix: propagate RL reward decision provenance",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1709",
           "visionLayer": "foundation blocker"
         },
         {
@@ -29915,6 +30456,24 @@
         {
           "domain": "RL flywheel",
           "domainSource": "project",
+          "evidence": "",
+          "kind": "bug",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 1716,
+          "priority": "P1",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "Done",
+          "title": "rl: suppress fresh full E1 stale anomaly",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1716",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "project",
           "evidence": "PR #1649 merged as ed934ce2; official deploy workflow run 26920618355 completed success. Deploy evidence pr1649-official-screeps-deploy-26920618355.json: activeWorld main matched sha256 704729..., branch main activeWorld=true; postdeploy health gate ok=true, alert=false, E29N55 owned_spawns=1 owned_creeps=10 hostiles=0.",
           "kind": "code",
           "lane": "RL flywheel",
@@ -29946,6 +30505,25 @@
           "type": "PullRequest",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/pull/1013",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "createdAt": "2026-06-06T04:21:12Z",
+          "domain": "Docs/process",
+          "domainSource": "project",
+          "evidence": "2026-06-06T18:04Z live audit repaired stale evidence: PR #1728 head b5dce126 is BEHIND current main b6557886 and issue-completion gate is failing; prod-ci/pages and CodeRabbit context are stale pre-update successes.",
+          "kind": "docs",
+          "lane": "Docs/process",
+          "nextAction": "",
+          "number": 1728,
+          "priority": "P2",
+          "projectDomain": "Docs/process",
+          "state": "",
+          "status": "In review",
+          "title": "chore(roadmap): refresh Pages artifacts",
+          "type": "PullRequest",
+          "updatedAt": "2026-06-06T14:08:55Z",
+          "url": "https://github.com/lanyusea/screeps/pull/1728",
           "visionLayer": "foundation blocker"
         },
         {
@@ -30540,6 +31118,24 @@
           "type": "PullRequest",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/pull/1684",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "Docs/process",
+          "domainSource": "project",
+          "evidence": "2026-06-05T23:07Z PR #1712 merged as 369d81f4 after gate: elapsed 10345s, checks SUCCESS, CodeRabbit no-actionable exact head 87510315, threads=[], mergeState=CLEAN; main fast-forwarded clean.",
+          "kind": "docs",
+          "lane": "Docs/process",
+          "nextAction": "",
+          "number": 1712,
+          "priority": "P2",
+          "projectDomain": "Docs/process",
+          "state": "",
+          "status": "Done",
+          "title": "chore(roadmap): refresh Pages artifacts",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1712",
           "visionLayer": "foundation blocker"
         },
         {
@@ -32588,7 +33184,26 @@
               "status": "Backlog"
             },
             {
-              "cards": [],
+              "cards": [
+                {
+                  "domain": "Runtime monitor",
+                  "domainSource": "project",
+                  "evidence": "2026-06-06T05:00Z fresh postmerge monitor: alert=false health ok at tick 1849304; prior rampart alert not currently active.",
+                  "kind": "ops",
+                  "lane": "Runtime monitor",
+                  "nextAction": "",
+                  "number": 1726,
+                  "priority": "P1",
+                  "projectDomain": "Runtime monitor",
+                  "state": "",
+                  "status": "Ready",
+                  "title": "Runtime alert: E29N55 rampart damage unsuppressed at 35,29",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/1726",
+                  "visionLayer": "enemy kills"
+                }
+              ],
               "status": "Ready"
             },
             {
@@ -32596,45 +33211,7 @@
               "status": "In progress"
             },
             {
-              "cards": [
-                {
-                  "domain": "Runtime monitor",
-                  "domainSource": "project",
-                  "evidence": "",
-                  "kind": "ops",
-                  "lane": "Runtime monitor",
-                  "nextAction": "",
-                  "number": 1703,
-                  "priority": "P0",
-                  "projectDomain": "Runtime monitor",
-                  "state": "",
-                  "status": "In review",
-                  "title": "P0: Populate creep-memory worker evidence in runtime summaries",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/1703",
-                  "visionLayer": "resources"
-                },
-                {
-                  "createdAt": "2026-06-05T20:03:53Z",
-                  "domain": "Runtime monitor",
-                  "domainSource": "project",
-                  "evidence": "PR #1708 opened at b084f670; issue body gate passed; controller verification PASS with full prod suite and bundle build.",
-                  "kind": "code",
-                  "lane": "Runtime monitor",
-                  "nextAction": "",
-                  "number": 1708,
-                  "priority": "P0",
-                  "projectDomain": "Runtime monitor",
-                  "state": "",
-                  "status": "In review",
-                  "title": "fix: preserve runtime worker evidence in summaries",
-                  "type": "PullRequest",
-                  "updatedAt": "2026-06-05T20:12:58Z",
-                  "url": "https://github.com/lanyusea/screeps/pull/1708",
-                  "visionLayer": "territory"
-                }
-              ],
+              "cards": [],
               "status": "In review"
             },
             {
@@ -32818,6 +33395,24 @@
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/issues/1324",
                   "visionLayer": "territory"
+                },
+                {
+                  "domain": "Runtime monitor",
+                  "domainSource": "project",
+                  "evidence": "2026-06-05 20:40Z code merged/deployed: PR #1708 -> 267332c1, deploy run 27038718442 ok, live console capture runtime-summary-console-20260605T204017Z.log shows workerAssignmentEvidenceAvailable=true in E29N55/E29N56/E29N57.",
+                  "kind": "ops",
+                  "lane": "Runtime monitor",
+                  "nextAction": "",
+                  "number": 1703,
+                  "priority": "P0",
+                  "projectDomain": "Runtime monitor",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P0: Populate creep-memory worker evidence in runtime summaries",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/1703",
+                  "visionLayer": "resources"
                 },
                 {
                   "domain": "Runtime monitor",
@@ -33123,6 +33718,24 @@
                   "type": "PullRequest",
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/pull/1509",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Runtime monitor",
+                  "domainSource": "project",
+                  "evidence": "2026-06-05 20:40Z merged as 267332c1, official deploy run 27038718442 ok, live console capture tick 1836259 proves worker evidence restored in all owned rooms.",
+                  "kind": "code",
+                  "lane": "Runtime monitor",
+                  "nextAction": "",
+                  "number": 1708,
+                  "priority": "P0",
+                  "projectDomain": "Runtime monitor",
+                  "state": "",
+                  "status": "Done",
+                  "title": "fix: preserve runtime worker evidence in summaries",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1708",
                   "visionLayer": "territory"
                 },
                 {
@@ -40119,26 +40732,7 @@
           "lane": "Combat",
           "statuses": [
             {
-              "cards": [
-                {
-                  "domain": "Combat",
-                  "domainSource": "project",
-                  "evidence": "2026-05-31T16:55Z state-audit repair: issue has blocked label and is not executable until E29N56 reaches RCL4; moved out of Ready to avoid false P1 scheduling.",
-                  "kind": "code",
-                  "lane": "Combat",
-                  "nextAction": "",
-                  "number": 1528,
-                  "priority": "P1",
-                  "projectDomain": "Combat",
-                  "state": "",
-                  "status": "Backlog",
-                  "title": "P1: Build first E29N56 tower after RCL4 unlock",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/1528",
-                  "visionLayer": "territory"
-                }
-              ],
+              "cards": [],
               "status": "Backlog"
             },
             {
@@ -40644,6 +41238,24 @@
                 {
                   "domain": "Combat",
                   "domainSource": "project",
+                  "evidence": "Done 2026-06-06T02:41Z: PR #1724 merged as d2faf0a2 after exact-head checks/CodeRabbit/threads gate; live Screeps API room-objects for shardX/E29N56 shows completed tower id 6a1abe62968b6e64b423baff at (24,24), hits 3000/3000.",
+                  "kind": "code",
+                  "lane": "Combat",
+                  "nextAction": "",
+                  "number": 1528,
+                  "priority": "P1",
+                  "projectDomain": "Combat",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P1: Build first E29N56 tower after RCL4 unlock",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/1528",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Combat",
+                  "domainSource": "project",
                   "evidence": "",
                   "kind": "bug",
                   "lane": "Combat",
@@ -40997,44 +41609,7 @@
               "status": "Backlog"
             },
             {
-              "cards": [
-                {
-                  "domain": "Territory/Economy",
-                  "domainSource": "project",
-                  "evidence": "Created from Gameplay Review CLOSED_LOOP_FAILED lines 362-374/430-436; fresh console tick 1834937 has E29N55 buildProgress=15 but E29N57/E29N56 still cpu_shed with backlog; #1703 will repair definitive worker evidence.",
-                  "kind": "bug",
-                  "lane": "Territory/Economy",
-                  "nextAction": "",
-                  "number": 1707,
-                  "priority": "P0",
-                  "projectDomain": "Territory/Economy",
-                  "state": "",
-                  "status": "Ready",
-                  "title": "P0: Verify and repair cross-room construction execution gate after failed acceptance",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/1707",
-                  "visionLayer": "territory"
-                },
-                {
-                  "domain": "Territory/Economy",
-                  "domainSource": "project",
-                  "evidence": "2026-06-05T18:55Z fresh postdeploy console/runtime alert evidence improved: E29N56 energy 950/950, workerCount=5, productiveAssignmentCount=3, build=1, transfer=2 at ticks 1833531/1833542; all-owned-room health gate ok at tick 1833700. Acceptance still needs sustained 24-capture buffer/build proof.",
-                  "kind": "ops",
-                  "lane": "Territory/Economy",
-                  "nextAction": "",
-                  "number": 1664,
-                  "priority": "P1",
-                  "projectDomain": "Territory/Economy",
-                  "state": "",
-                  "status": "Ready",
-                  "title": "P1: E29N56 energy buffer recovery follow-up after CPU fix",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/1664",
-                  "visionLayer": "territory"
-                }
-              ],
+              "cards": [],
               "status": "Ready"
             },
             {
@@ -41042,7 +41617,7 @@
                 {
                   "domain": "Territory/Economy",
                   "domainSource": "project",
-                  "evidence": "2026-06-05 02:04 +08 CPU acceptance remains open: latest runtime-summary-console capture is now >2000 ticks old; 7ee147327ba6 capture run requested but no fresh output due cron cadence stall; no closure from stale CPU data.",
+                  "evidence": "2026-06-06T05:28Z: CPU still degraded; console tick 1849538 bucket=1845 used=64.85/70; GE review says constructionScoring skipped usedOverLimit; E29N56 build partly active.",
                   "kind": "bug",
                   "lane": "Territory/Economy",
                   "nextAction": "",
@@ -41060,26 +41635,82 @@
                 {
                   "domain": "Territory/Economy",
                   "domainSource": "project",
-                  "evidence": "2026-06-05T18:49Z PR #1702 code is live: official deploy run 27033591689 for main 04f604d mode=deploy ok=true, artifact sha da8f8cb6 matches local dist, branch/activeWorld main matched, health gate ok, alert=false. Postdeploy console runtime-summary-console-20260605T184940Z shows rooms alive and productive/build tasks.",
-                  "kind": "code",
+                  "evidence": "2026-06-06T19:46Z: #1743 deployed but postdeploy acceptance still failed; residual Codex commit 73681c3d opened PR #1744; controller verification PASS.",
+                  "kind": "bug",
                   "lane": "Territory/Economy",
                   "nextAction": "",
-                  "number": 1700,
+                  "number": 1715,
+                  "priority": "P0",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "In progress",
+                  "title": "P0: Fix cross-room construction assignment suppression under worker_assignment_gap",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/1715",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
+                  "evidence": "2026-06-05 21:10Z validation refreshed. Latest console runtime-summary-console-20260605T205957Z: E29N56 ticks 1836739/1836748 buffer healthy 750-800/1000 threshold 500, build tasks=2, buildCarriedEnergy=200 then 150, worker assignment evidence true. Fresh monitor health tick 1837034: E29N56 owned_spawns=1, owned_creeps=12, hostiles=0.",
+                  "kind": "ops",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 1664,
                   "priority": "P1",
                   "projectDomain": "Territory/Economy",
                   "state": "",
                   "status": "In progress",
-                  "title": "P1: Seasonal E9S28 reserve-first remote mining and road bootstrap",
+                  "title": "P1: E29N56 energy buffer recovery follow-up after CPU fix",
                   "type": "Issue",
                   "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/1700",
+                  "url": "https://github.com/lanyusea/screeps/issues/1664",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
+                  "evidence": "2026-06-06T19:46Z: fresh console shows E29N55 buffer 783 and E29N57 1437; buildCarriedEnergy=0 with worker_assignment_gap; PR #1744 opened for #1715 residual.",
+                  "kind": "bug",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 1738,
+                  "priority": "P1",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "In progress",
+                  "title": "P1: Recover energy buffer collapse and construction unblock after Loop B alert",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/1738",
                   "visionLayer": "territory"
                 }
               ],
               "status": "In progress"
             },
             {
-              "cards": [],
+              "cards": [
+                {
+                  "createdAt": "2026-06-06T19:45:55Z",
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
+                  "evidence": "2026-06-06T19:46Z: PR #1744 head 73681c3d; controller diff/typecheck/Jest 105/2354/build PASS; CodeRabbit rate-limited; prod-ci pending.",
+                  "kind": "bug",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 1744,
+                  "priority": "P0",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "In review",
+                  "title": "fix: recover build assignment from retained upgrade task",
+                  "type": "PullRequest",
+                  "updatedAt": "2026-06-06T19:46:36Z",
+                  "url": "https://github.com/lanyusea/screeps/pull/1744",
+                  "visionLayer": "territory"
+                }
+              ],
               "status": "In review"
             },
             {
@@ -41465,6 +42096,24 @@
                 {
                   "domain": "Territory/Economy",
                   "domainSource": "project",
+                  "evidence": "Done 2026-06-06: PR #1737 merged at e99dbfad, deploy run 27065225678 succeeded; PR #1735 follow-up deployed run 27065462593; final live monitor shows all owned rooms alert=false/health ok with sourceHarvesters/haulers/workers harvesting and repairing.",
+                  "kind": "bug",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 1736,
+                  "priority": "P0",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P0: Normal-world rooms lack local harvest/haul recovery and mutual repair pressure",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/1736",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
                   "evidence": "PR #910 merged 2026-05-10T19:06Z (squash 1c5ae92). Gemini critical feedback addressed: claimedAt preserved during recovery. postClaimBootstrap now accepts claimedAt input. Tests verify timestamp preservation.",
                   "kind": "bug",
                   "lane": "Territory/Economy",
@@ -41609,6 +42258,24 @@
                 {
                   "domain": "Territory/Economy",
                   "domainSource": "project",
+                  "evidence": "2026-06-05 20:40Z closed completed. Deploy run 27038718442 ok; live console capture runtime-summary-console-20260605T204017Z tick 1836259 shows build evidence or bounded cpu_shed suppression across all rooms.",
+                  "kind": "bug",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 1707,
+                  "priority": "P0",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P0: Verify and repair cross-room construction execution gate after failed acceptance",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/1707",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
                   "evidence": "2026-05-23T23:33Z scheduler-check-20260523T233337Z: E29N55/E29N56/E29N57 all owned by lanyusea with spawns+creeps; alert=false health_gate.ok=true. E29N55 recovery/retarget acceptance met; #1103 closed.",
                   "kind": "ops",
                   "lane": "Territory/Economy",
@@ -41699,6 +42366,24 @@
                 {
                   "domain": "Territory/Economy",
                   "domainSource": "project",
+                  "evidence": "Merged as 36fa83af; deploy run 27052669691 succeeded with activeWorld/main matched, postdeploy health ok=true and alert=false.",
+                  "kind": "code",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 1721,
+                  "priority": "P0",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "Done",
+                  "title": "cpu: preserve construction planning under CPU overrun",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1721",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
                   "evidence": "Merged as 023212a6; official deploy run 26938143819 ok + health gate ok. Postdeploy CPU acceptance still failed; follow-up moved to #1490 proc_[redacted].",
                   "kind": "code",
                   "lane": "Territory/Economy",
@@ -41766,6 +42451,114 @@
                   "type": "PullRequest",
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/pull/1043",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
+                  "evidence": "PR #1740 exact head 51f1e7b9; issue-completion/prod-ci/roadmap checks green and GraphQL unresolved threads=0; CodeRabbit status is SUCCESS but top-level comment says review limit/usage credits, not substantive review.",
+                  "kind": "code",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 1740,
+                  "priority": "P0",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "Done",
+                  "title": "economy: account for refill acquisition coverage",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1740",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
+                  "evidence": "2026-06-06T12:55Z merged #1734 at 605975db after exact-head checks/CodeRabbit/threads gate; deploy run 27062882473 succeeded. Postdeploy all-owned acceptance still failed for #1715, so PR #1734 is Done as a merged slice and successor Codex lane proc_[redacted] owns remaining incident.",
+                  "kind": "code",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 1734,
+                  "priority": "P0",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "Done",
+                  "title": "economy: allow bootstrap storage construction before refill",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1734",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
+                  "evidence": "Done 2026-06-06: PR #1735 merged at b03d00e1 and deployed via official workflow run 27065462593; final monitor postdeploy-1715-1736-final-20260606T145746Z alert=false and health ok.",
+                  "kind": "bug",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 1735,
+                  "priority": "P0",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "Done",
+                  "title": "economy: clear postdeploy worker assignment gap",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1735",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
+                  "evidence": "2026-06-06T10:27Z merged as 0551b9b6 after exact-head acae7d5 gate: elapsed>15m, checks green, CodeRabbit approved, review threads resolved, controller typecheck/Jest/build passed.",
+                  "kind": "code",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 1732,
+                  "priority": "P0",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "Done",
+                  "title": "economy: recover E29N56 postdeploy construction assignment",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1732",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
+                  "evidence": "Done 2026-06-06: PR #1737 merged at e99dbfad and deployed via official workflow run 27065225678; final monitor after companion deploy shows rooms harvesting and repairing with alert=false.",
+                  "kind": "bug",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 1737,
+                  "priority": "P0",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "Done",
+                  "title": "economy: recover local harvest and refill pressure",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1737",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
+                  "evidence": "PR #1719 merged as 82b52990 and deployed in run 27057459484. Deploy/upload and primary E29N55 health ok, but all-owned acceptance still failed for #1715 (E29N56 worker_assignment_gap_sustained tick 1854811); this PR remains Done while #1715 follow-up Codex proc_[redacted] handles residual blocker.",
+                  "kind": "code",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 1719,
+                  "priority": "P0",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "Done",
+                  "title": "economy: unblock full-energy construction assignment",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1719",
                   "visionLayer": "territory"
                 },
                 {
@@ -42018,6 +42811,42 @@
                   "type": "PullRequest",
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/pull/1513",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
+                  "evidence": "2026-06-06T19:26Z: merged/deployed as 49713d9c via official run 27071513534; deploy ok/activeWorld matched/health ok. All-owned acceptance still failed at runtime-artifacts/screeps-monitor/postdeploy-pr1743-20260606T192304Z, routed to residual Codex proc_[redacted].",
+                  "kind": "bug",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 1743,
+                  "priority": "P0",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "Done",
+                  "title": "fix: recover construction assignment after worker gap alert",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1743",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
+                  "evidence": "2026-06-06T18:03Z Deploy run 27069646426 succeeded for b6557886 (deploy ok, activeWorld matched, health ok, alert=false for target E29N55). Artifact archived under runtime-artifacts/official-screeps-deploy/*-27069646426.json. All-owned acceptance remains with #1715/#1738.",
+                  "kind": "bug",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 1741,
+                  "priority": "P0",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "Done",
+                  "title": "fix: recover worker assignments after postdeploy gap",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1741",
                   "visionLayer": "territory"
                 },
                 {
@@ -46458,19 +47287,19 @@
                 {
                   "domain": "RL flywheel",
                   "domainSource": "project",
-                  "evidence": "Created from #1706 CODEX_1706_HELD: room-busy evidence is historical; latest partial simulator progress has 19/20 env rows succeeded and one private-server HTTP readiness timeout after 900s.",
-                  "kind": "bug",
+                  "evidence": "2026-06-06T18:21Z: no active RL/Tencent runners; latest Loop A 20260606T174933Z records localRunnerExitedWithoutReport and Tencent guard held. RL diagnostic remains Ready but hard P0 #1715 preempts this steward slot.",
+                  "kind": "ops",
                   "lane": "RL flywheel",
                   "nextAction": "",
-                  "number": 1710,
+                  "number": 1742,
                   "priority": "P1",
                   "projectDomain": "RL flywheel",
                   "state": "",
                   "status": "Ready",
-                  "title": "P1: Repair Tencent post-fix validation private-server HTTP readiness timeout",
+                  "title": "P1: Diagnose local RL training runner exit without report after futex hang",
                   "type": "Issue",
                   "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/1710",
+                  "url": "https://github.com/lanyusea/screeps/issues/1742",
                   "visionLayer": "foundation blocker"
                 }
               ],
@@ -46481,7 +47310,7 @@
                 {
                   "domain": "RL flywheel",
                   "domainSource": "project",
-                  "evidence": "2026-06-05T16:15Z candidate scorecard exists and trustedGradientUpdate=true, but live canary blocked by rewardDecisionId=null and no fresh gate.",
+                  "evidence": "2026-06-05T22:30Z: rewardDecisionId now present in manual Loop A artifact (RD-AUTO-67014b3ef07a) and #1566 activation proof closed; live canary still blocked by no online rollout gate, CPU #1490, and #1714 ledger anomaly.",
                   "kind": "ops",
                   "lane": "RL flywheel",
                   "nextAction": "",
@@ -46499,7 +47328,7 @@
                 {
                   "domain": "RL flywheel",
                   "domainSource": "project",
-                  "evidence": "2026-06-05T16:22Z conclusion registry parsed: total 17, OPEN=1 ACTIONED=3 VALIDATING=3 CLOSED=10, stale/escalated=0.",
+                  "evidence": "2026-06-05T22:33Z conclusion-registry.json updated artifact-first: total 17, CLOSED=11, ACTIONED=3, VALIDATING=3; linked #1713/#1714/#1490 and closed #1566 acceptance scope.",
                   "kind": "ops",
                   "lane": "RL flywheel",
                   "nextAction": "",
@@ -46517,25 +47346,7 @@
                 {
                   "domain": "RL flywheel",
                   "domainSource": "project",
-                  "evidence": "2026-06-05T16:15Z Loop A completed local trusted gradient but rewardDecisionId remains null, blocking deployable objective activation proof.",
-                  "kind": "bug",
-                  "lane": "RL flywheel",
-                  "nextAction": "",
-                  "number": 1566,
-                  "priority": "P0",
-                  "projectDomain": "RL flywheel",
-                  "state": "",
-                  "status": "In progress",
-                  "title": "P0: Repair RL multi-tier objective activation proof before paid validation",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/1566",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "RL flywheel",
-                  "domainSource": "project",
-                  "evidence": "2026-06-05T16:36Z: #1698/#1681 known_hosts hardening merged; latest tencent-pg-20260605t163003z still safely skipped run-single, ASG 0/0/0.",
+                  "evidence": "2026-06-06T14:42Z: latest Tencent summaries through tencent-pg-20260606t144004z and preflight cron-batch-preflight-20260606t143417... all skipped by paid_failure_recurrence_launch_guard; ASG desired/in-service 0/0; billing guard OK.",
                   "kind": "ops",
                   "lane": "RL flywheel",
                   "nextAction": "",
@@ -46553,7 +47364,25 @@
                 {
                   "domain": "RL flywheel",
                   "domainSource": "project",
-                  "evidence": "2026-06-05T16:36Z: #1698 known_hosts hardening merged; Loop A local training completed trustedGradientUpdate=true but rewardDecisionId=null; Tencent held.",
+                  "evidence": "2026-06-06T18:23Z: PR #1730 merged as d081959e; latest Loop A ledger runtime-artifacts/rl-control-loop/20260606T174933Z-training-ledger.json now has rewardDecisionId=construction-priority.pg.risk-aware-seed.v1. Latest Loop B remains 20260606T160607Z/stale for full acceptance.",
+                  "kind": "bug",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 1729,
+                  "priority": "P0",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "In progress",
+                  "title": "P0: Restore rewardDecisionId propagation after latest Loop B null regression",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/1729",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
+                  "evidence": "2026-06-06T17:00Z: stuck local runner PID 3701954 was terminated after diagnostic artifact runtime-artifacts/rl-training/stuck-runner-diagnostics-20260606T1700Z.json (futex_wait_queue, >10h, swap full). No active local/Tencent runner remains; #1715 Codex proc_[redacted] is active.",
                   "kind": "ops",
                   "lane": "RL flywheel",
                   "nextAction": "",
@@ -46567,87 +47396,30 @@
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/issues/1032",
                   "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
+                  "evidence": "2026-06-06T17:00Z diagnostic artifact runtime-artifacts/rl-training/stuck-runner-diagnostics-20260606T1700Z.json captured PID 3701954 stuck in futex_wait_queue at >10h with swap 1987/1987MB. SIGTERM then SIGKILL cleared PID; RAM available rose to ~3817MB, swap free 59MB.",
+                  "kind": "ops",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 1739,
+                  "priority": "P2",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "In progress",
+                  "title": "P2: Diagnose RL training runner swap exhaustion",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/1739",
+                  "visionLayer": "foundation blocker"
                 }
               ],
               "status": "In progress"
             },
             {
-              "cards": [
-                {
-                  "domain": "RL flywheel",
-                  "domainSource": "project",
-                  "evidence": "PR #1709 head 9685c42 has equivalent active rewardDecision carryover threads PRRT_kwDOSMSsO86Hd5tV and PRRT_kwDOSMSsO86Hd-iy; Codex triage/fix proc_[redacted] is editing the shared root cause.",
-                  "kind": "code",
-                  "lane": "RL flywheel",
-                  "nextAction": "",
-                  "number": 1705,
-                  "priority": "P1",
-                  "projectDomain": "RL flywheel",
-                  "state": "",
-                  "status": "In review",
-                  "title": "P1: Propagate rewardDecisionId into RL policy advantage artifacts",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/1705",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "RL flywheel",
-                  "domainSource": "project",
-                  "evidence": "",
-                  "kind": "bug",
-                  "lane": "RL flywheel",
-                  "nextAction": "",
-                  "number": 1706,
-                  "priority": "P1",
-                  "projectDomain": "RL flywheel",
-                  "state": "",
-                  "status": "In review",
-                  "title": "P1: Validate Tencent room-busy recurrence guard after prior fix",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/1706",
-                  "visionLayer": "territory"
-                },
-                {
-                  "createdAt": "2026-06-05T20:11:32Z",
-                  "domain": "RL flywheel",
-                  "domainSource": "project",
-                  "evidence": "PR #1711 opened at b748f977; issue body gate passed; controller verification PASS for Tencent runner tests and no-paid safety.",
-                  "kind": "bug",
-                  "lane": "RL flywheel",
-                  "nextAction": "",
-                  "number": 1711,
-                  "priority": "P1",
-                  "projectDomain": "RL flywheel",
-                  "state": "",
-                  "status": "In review",
-                  "title": "fix: preserve Tencent recurrence recovery evidence",
-                  "type": "PullRequest",
-                  "updatedAt": "2026-06-05T20:12:38Z",
-                  "url": "https://github.com/lanyusea/screeps/pull/1711",
-                  "visionLayer": "territory"
-                },
-                {
-                  "createdAt": "2026-06-05T20:03:57Z",
-                  "domain": "RL flywheel",
-                  "domainSource": "project",
-                  "evidence": "PR #1709 head 9685c42 has equivalent active rewardDecision carryover threads PRRT_kwDOSMSsO86Hd5tV and PRRT_kwDOSMSsO86Hd-iy; Codex triage/fix proc_[redacted] is editing the shared root cause.",
-                  "kind": "code",
-                  "lane": "RL flywheel",
-                  "nextAction": "",
-                  "number": 1709,
-                  "priority": "P1",
-                  "projectDomain": "RL flywheel",
-                  "state": "",
-                  "status": "In review",
-                  "title": "fix: propagate RL reward decision provenance",
-                  "type": "PullRequest",
-                  "updatedAt": "2026-06-05T20:11:25Z",
-                  "url": "https://github.com/lanyusea/screeps/pull/1709",
-                  "visionLayer": "foundation blocker"
-                }
-              ],
+              "cards": [],
               "status": "In review"
             },
             {
@@ -47267,6 +48039,24 @@
                 {
                   "domain": "RL flywheel",
                   "domainSource": "project",
+                  "evidence": "Done 2026-06-06T02:01Z: PR #1723 squash-merged at b75379a0; generated/validated host-sized Loop A local-fallback card runtime-artifacts/rl-experiment-cards/experiment_card.json from E1 gate e1-gate-20260605T191602Z dataset rl-e93cefe304b9; workers=1 scale=5 minConcurrent=1, liveEffect=false.",
+                  "kind": "code",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 1722,
+                  "priority": "P0",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P0: Generate host-sized RL experiment card for latest E1 gate",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/1722",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
                   "evidence": "2026-05-19T22:43Z: Issue closed by merged PR #1247 commit 11b15f9993ad074b845c084f514dcbd899fafd2e. Post-merge main verification passed: 139 pytest, 60 subtests; py_compile passed.",
                   "kind": "code",
                   "lane": "RL flywheel",
@@ -47281,6 +48071,24 @@
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/issues/1244",
                   "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
+                  "evidence": "Merged PR #1727 at main 5b6f221f; deployed official run 27051623684 ok=true activeWorld/main matched health_ok=true alert=false.",
+                  "kind": "ops",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 1725,
+                  "priority": "P0",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P0: Investigate territory-shadow rollback reliability collapse",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/1725",
+                  "visionLayer": "territory"
                 },
                 {
                   "domain": "RL flywheel",
@@ -47735,6 +48543,24 @@
                 {
                   "domain": "RL flywheel",
                   "domainSource": "project",
+                  "evidence": "2026-06-05T22:32Z: objective activation proof satisfied by training report local2w-20260603T0832Z and Loop A artifact 20260605T223036Z: objectiveSignalObserved true, passing activation samples, RUN_VALIDATED, rewardDecisionId RD-AUTO-67014b3ef07a.",
+                  "kind": "bug",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 1566,
+                  "priority": "P0",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P0: Repair RL multi-tier objective activation proof before paid validation",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/1566",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
                   "evidence": "2026-05-20T17:57Z: PR #1272 merged as 36b975d8 after gate PASS (age>15m, prod-ci+CodeRabbit success, threads resolved, mergeState CLEAN). Main fast-forwarded; post-merge py_compile + unittest 147 OK + pytest scorecard 18 passed + diff-check passed.",
                   "kind": "code",
                   "lane": "RL flywheel",
@@ -47857,6 +48683,24 @@
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/issues/1381",
                   "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
+                  "evidence": "2026-06-06: PR #1720 merged 271de482; postmerge summary tick 1849256 workerAssignmentEvidenceAvailable=true all rooms; alert=false health ok.",
+                  "kind": "bug",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 1717,
+                  "priority": "P0",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P0: Restore creep-memory worker assignment evidence in runtime summaries",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/1717",
+                  "visionLayer": "resources"
                 },
                 {
                   "domain": "RL flywheel",
@@ -50129,6 +50973,24 @@
                 {
                   "domain": "RL flywheel",
                   "domainSource": "project",
+                  "evidence": "2026-06-06: PR #1720 merged 271de482; postmerge summary tick 1849256 workerAssignmentEvidenceAvailable=true all rooms; alert=false health ok.",
+                  "kind": "code",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 1720,
+                  "priority": "P0",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "Done",
+                  "title": "monitor: capture bounded creep task evidence",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1720",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
                   "evidence": "Merged 2026-06-05T10:43Z as 14b2f515; checks green; controller py_compile+unittest OK; postmerge policy artifact 20260605T110330Z rewardDecisionId RD-AUTO-67014b3ef07a.",
                   "kind": "code",
                   "lane": "RL flywheel",
@@ -50201,6 +51063,24 @@
                 {
                   "domain": "RL flywheel",
                   "domainSource": "project",
+                  "evidence": "Done 2026-06-06T02:01Z: PR #1723 squash-merged at b75379a0; generated/validated host-sized Loop A local-fallback card runtime-artifacts/rl-experiment-cards/experiment_card.json from E1 gate e1-gate-20260605T191602Z dataset rl-e93cefe304b9; workers=1 scale=5 minConcurrent=1, liveEffect=false.",
+                  "kind": "code",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 1723,
+                  "priority": "P0",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "Done",
+                  "title": "rl: generate host-sized latest E1 card",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1723",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
                   "evidence": "2026-06-04T23:55Z: PR #1673 merged as 3378fbb5 after exact-head green checks, CodeRabbit APPROVED/SUCCESS, threads=0; main fast-forwarded and 353 post-merge tests passed.",
                   "kind": "code",
                   "lane": "RL flywheel",
@@ -50214,6 +51094,42 @@
                   "type": "PullRequest",
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/pull/1673",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
+                  "evidence": "2026-06-06T15:16Z: PR #1730 merged as d081959e after exact-head checks green and all review threads resolved; postmerge py_compile/unittest passed; policy-advantage artifact now carries RD-AUTO-9f33873ce71c.",
+                  "kind": "code",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 1730,
+                  "priority": "P0",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "Done",
+                  "title": "rl: recover reward decision provenance in ledgers",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1730",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
+                  "evidence": "Squash-merged as 5b6f221f and deployed by official run 27051623684 with branchCode/activeWorld matched and postdeploy health ok.",
+                  "kind": "code",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 1727,
+                  "priority": "P0",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "Done",
+                  "title": "rl: scope rollout monitoring to consumed policies",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1727",
                   "visionLayer": "foundation blocker"
                 },
                 {
@@ -51245,6 +52161,24 @@
                 {
                   "domain": "RL flywheel",
                   "domainSource": "project",
+                  "evidence": "2026-06-05 20:43Z PR #1709 merged as c779226f after exact-head 4d662bb3 gate: elapsed 39m, green checks, CodeRabbit APPROVED, reviewThreads=0; post-merge main py_compile + unittest(15) + diff-check PASS.",
+                  "kind": "code",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 1705,
+                  "priority": "P1",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P1: Propagate rewardDecisionId into RL policy advantage artifacts",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/1705",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
                   "evidence": "",
                   "kind": "code",
                   "lane": "RL flywheel",
@@ -51731,6 +52665,24 @@
                 {
                   "domain": "RL flywheel",
                   "domainSource": "project",
+                  "evidence": "2026-06-05T22:26Z: PR #1713 merged as 0861961d; postmerge no-paid preflight postmerge-1713-preflight-20260605t222625z wrote controller-summary with computeAttempted=false, scaleOutAttempted=false, finalStatus=skipped_paid_failure_recurrence_launch_guard.",
+                  "kind": "bug",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 1710,
+                  "priority": "P1",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P1: Repair Tencent post-fix validation private-server HTTP readiness timeout",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/1710",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
                   "evidence": "2026-05-21T23:18Z: PR #1311 merged as 06f2ee7c; main post-merge verification passed diff-check, py_compile, 190 unittest for simulator/training runner.",
                   "kind": "code",
                   "lane": "RL flywheel",
@@ -51984,6 +52936,24 @@
                   "domain": "RL flywheel",
                   "domainSource": "project",
                   "evidence": "",
+                  "kind": "bug",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 1714,
+                  "priority": "P1",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P1: Suppress stale E1_GATE_STALE anomaly after fresh full gate",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/1714",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
+                  "evidence": "",
                   "kind": "code",
                   "lane": "RL flywheel",
                   "nextAction": "",
@@ -51997,6 +52967,24 @@
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/issues/1182",
                   "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
+                  "evidence": "2026-06-05: PR #1711 merged as 0925c8d3; postmerge preflight postmerge-1711-preflight-20260605t215816z preserves partialSimulatorProgress and confirms no fresh room-busy compute.",
+                  "kind": "bug",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 1706,
+                  "priority": "P1",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P1: Validate Tencent room-busy recurrence guard after prior fix",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/1706",
+                  "visionLayer": "territory"
                 },
                 {
                   "domain": "RL flywheel",
@@ -53369,6 +54357,24 @@
                 {
                   "domain": "RL flywheel",
                   "domainSource": "project",
+                  "evidence": "2026-06-05T22:25Z: PR #1713 merged after elapsed>15m, all checks pass, CodeRabbit exact-head APPROVED, review threads 0; merge commit 0861961d. Postmerge preflight artifact postmerge-1713-preflight-20260605t222625z no-paid/ASG 0.",
+                  "kind": "code",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 1713,
+                  "priority": "P1",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "Done",
+                  "title": "fix: classify Tencent HTTP readiness timeouts",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1713",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
                   "evidence": "",
                   "kind": "code",
                   "lane": "RL flywheel",
@@ -53382,6 +54388,42 @@
                   "type": "PullRequest",
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/pull/1638",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
+                  "evidence": "Merged 2026-06-05 21:57 UTC as 0925c8d3 after elapsed 105m, green checks, CodeRabbit exact-head approval, reviewThreads=0, local py_compile+177 unittest+diff-check.",
+                  "kind": "bug",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 1711,
+                  "priority": "P1",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "Done",
+                  "title": "fix: preserve Tencent recurrence recovery evidence",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1711",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
+                  "evidence": "2026-06-05 20:43Z PR #1709 merged as c779226f after exact-head 4d662bb3 gate: elapsed 39m, green checks, CodeRabbit APPROVED, reviewThreads=0; post-merge main py_compile + unittest(15) + diff-check PASS.",
+                  "kind": "code",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 1709,
+                  "priority": "P1",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "Done",
+                  "title": "fix: propagate RL reward decision provenance",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1709",
                   "visionLayer": "foundation blocker"
                 },
                 {
@@ -53603,6 +54645,24 @@
                 {
                   "domain": "RL flywheel",
                   "domainSource": "project",
+                  "evidence": "",
+                  "kind": "bug",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 1716,
+                  "priority": "P1",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "Done",
+                  "title": "rl: suppress fresh full E1 stale anomaly",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1716",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
                   "evidence": "PR #1649 merged as ed934ce2; official deploy workflow run 26920618355 completed success. Deploy evidence pr1649-official-screeps-deploy-26920618355.json: activeWorld main matched sha256 704729..., branch main activeWorld=true; postdeploy health gate ok=true, alert=false, E29N55 owned_spawns=1 owned_creeps=10 hostiles=0.",
                   "kind": "code",
                   "lane": "RL flywheel",
@@ -53658,7 +54718,27 @@
               "status": "In progress"
             },
             {
-              "cards": [],
+              "cards": [
+                {
+                  "createdAt": "2026-06-06T04:21:12Z",
+                  "domain": "Docs/process",
+                  "domainSource": "project",
+                  "evidence": "2026-06-06T18:04Z live audit repaired stale evidence: PR #1728 head b5dce126 is BEHIND current main b6557886 and issue-completion gate is failing; prod-ci/pages and CodeRabbit context are stale pre-update successes.",
+                  "kind": "docs",
+                  "lane": "Docs/process",
+                  "nextAction": "",
+                  "number": 1728,
+                  "priority": "P2",
+                  "projectDomain": "Docs/process",
+                  "state": "",
+                  "status": "In review",
+                  "title": "chore(roadmap): refresh Pages artifacts",
+                  "type": "PullRequest",
+                  "updatedAt": "2026-06-06T14:08:55Z",
+                  "url": "https://github.com/lanyusea/screeps/pull/1728",
+                  "visionLayer": "foundation blocker"
+                }
+              ],
               "status": "In review"
             },
             {
@@ -54188,6 +55268,24 @@
                 {
                   "domain": "Docs/process",
                   "domainSource": "project",
+                  "evidence": "2026-06-05T23:07Z PR #1712 merged as 369d81f4 after gate: elapsed 10345s, checks SUCCESS, CodeRabbit no-actionable exact head 87510315, threads=[], mergeState=CLEAN; main fast-forwarded clean.",
+                  "kind": "docs",
+                  "lane": "Docs/process",
+                  "nextAction": "",
+                  "number": 1712,
+                  "priority": "P2",
+                  "projectDomain": "Docs/process",
+                  "state": "",
+                  "status": "Done",
+                  "title": "chore(roadmap): refresh Pages artifacts",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1712",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "Docs/process",
+                  "domainSource": "project",
                   "evidence": "",
                   "kind": "code",
                   "lane": "Docs/process",
@@ -54224,17 +55322,17 @@
       {
         "instrumented": true,
         "label": "Blocked cards",
-        "value": 48
+        "value": 52
       },
       {
         "instrumented": true,
         "label": "Project cards",
-        "value": 1669
+        "value": 1702
       },
       {
         "instrumented": true,
         "label": "In progress",
-        "value": 13
+        "value": 16
       },
       {
         "instrumented": true,
@@ -55089,7 +56187,7 @@
         "blockedBy": "",
         "domain": "Release/deploy",
         "domainSource": "project",
-        "evidence": "2026-05-24T04:06Z: deployment floor refreshed for main 03dbde3 via official-screeps-deploy run 26351424036. Upload ok, activeWorld main matched, artifact sha256 736273b9..., postdeploy health ok, alert=false, all 3 owned rooms observed alive in local postdeploy monitor.",
+        "evidence": "2026-06-06T14:58Z: deployment floor refreshed for main b03d00e via official-screeps-deploy run 27065462593; upload ok, activeWorld main matched, artifact sha256 43a00685..., postdeploy health ok; fresh all-owned monitor health ok/alert=false.",
         "kind": "ops",
         "labels": [
           "kind:ops",
@@ -75442,7 +76540,7 @@
         "blockedBy": "",
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "2026-06-05T16:36Z: #1698 known_hosts hardening merged; Loop A local training completed trustedGradientUpdate=true but rewardDecisionId=null; Tencent held.",
+        "evidence": "2026-06-06T17:00Z: stuck local runner PID 3701954 was terminated after diagnostic artifact runtime-artifacts/rl-training/stuck-runner-diagnostics-20260606T1700Z.json (futex_wait_queue, >10h, swap full). No active local/Tencent runner remains; #1715 Codex proc_[redacted] is active.",
         "kind": "ops",
         "labels": [
           "blocked",
@@ -79830,7 +80928,7 @@
         "blockedBy": "",
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "2026-06-05T16:36Z: #1698/#1681 known_hosts hardening merged; latest tencent-pg-20260605t163003z still safely skipped run-single, ASG 0/0/0.",
+        "evidence": "2026-06-06T14:42Z: latest Tencent summaries through tencent-pg-20260606t144004z and preflight cron-batch-preflight-20260606t143417... all skipped by paid_failure_recurrence_launch_guard; ASG desired/in-service 0/0; billing guard OK.",
         "kind": "ops",
         "labels": [
           "blocked",
@@ -85338,7 +86436,7 @@
         "blockedBy": "",
         "domain": "Territory/Economy",
         "domainSource": "project",
-        "evidence": "2026-06-05 02:04 +08 CPU acceptance remains open: latest runtime-summary-console capture is now >2000 ticks old; 7ee147327ba6 capture run requested but no fresh output due cron cadence stall; no closure from stale CPU data.",
+        "evidence": "2026-06-06T05:28Z: CPU still degraded; console tick 1849538 bucket=1845 used=64.85/70; GE review says constructionScoring skipped usedOverLimit; E29N56 build partly active.",
         "kind": "bug",
         "labels": [
           "blocked",
@@ -86155,10 +87253,9 @@
         "blockedBy": "",
         "domain": "Combat",
         "domainSource": "project",
-        "evidence": "2026-05-31T16:55Z state-audit repair: issue has blocked label and is not executable until E29N56 reaches RCL4; moved out of Ready to avoid false P1 scheduling.",
+        "evidence": "Done 2026-06-06T02:41Z: PR #1724 merged as d2faf0a2 after exact-head checks/CodeRabbit/threads gate; live Screeps API room-objects for shardX/E29N56 shows completed tower id 6a1abe62968b6e64b423baff at (24,24), hits 3000/3000.",
         "kind": "code",
         "labels": [
-          "blocked",
           "kind:code",
           "priority:p1",
           "roadmap",
@@ -86170,7 +87267,7 @@
         "priority": "P1",
         "projectDomain": "Combat",
         "state": "",
-        "status": "Backlog",
+        "status": "Done",
         "title": "P1: Build first E29N56 tower after RCL4 unlock",
         "type": "Issue",
         "updatedAt": "",
@@ -86478,7 +87575,7 @@
         "blockedBy": "",
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "2026-06-05T16:22Z conclusion registry parsed: total 17, OPEN=1 ACTIONED=3 VALIDATING=3 CLOSED=10, stale/escalated=0.",
+        "evidence": "2026-06-05T22:33Z conclusion-registry.json updated artifact-first: total 17, CLOSED=11, ACTIONED=3, VALIDATING=3; linked #1713/#1714/#1490 and closed #1566 acceptance scope.",
         "kind": "ops",
         "labels": [
           "kind:ops",
@@ -86970,7 +88067,7 @@
         "blockedBy": "",
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "2026-06-05T16:15Z Loop A completed local trusted gradient but rewardDecisionId remains null, blocking deployable objective activation proof.",
+        "evidence": "2026-06-05T22:32Z: objective activation proof satisfied by training report local2w-20260603T0832Z and Loop A artifact 20260605T223036Z: objectiveSignalObserved true, passing activation samples, RUN_VALIDATED, rewardDecisionId RD-AUTO-67014b3ef07a.",
         "kind": "bug",
         "labels": [
           "kind:bug",
@@ -86984,7 +88081,7 @@
         "priority": "P0",
         "projectDomain": "RL flywheel",
         "state": "",
-        "status": "In progress",
+        "status": "Done",
         "title": "P0: Repair RL multi-tier objective activation proof before paid validation",
         "type": "Issue",
         "updatedAt": "",
@@ -87335,7 +88432,7 @@
         "blockedBy": "",
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "2026-06-05T16:15Z candidate scorecard exists and trustedGradientUpdate=true, but live canary blocked by rewardDecisionId=null and no fresh gate.",
+        "evidence": "2026-06-05T22:30Z: rewardDecisionId now present in manual Loop A artifact (RD-AUTO-67014b3ef07a) and #1566 activation proof closed; live canary still blocked by no online rollout gate, CPU #1490, and #1714 ledger anomaly.",
         "kind": "ops",
         "labels": [
           "blocked",
@@ -89087,7 +90184,7 @@
         "blockedBy": "",
         "domain": "Territory/Economy",
         "domainSource": "project",
-        "evidence": "2026-06-05T18:55Z fresh postdeploy console/runtime alert evidence improved: E29N56 energy 950/950, workerCount=5, productiveAssignmentCount=3, build=1, transfer=2 at ticks 1833531/1833542; all-owned-room health gate ok at tick 1833700. Acceptance still needs sustained 24-capture buffer/build proof.",
+        "evidence": "2026-06-05 21:10Z validation refreshed. Latest console runtime-summary-console-20260605T205957Z: E29N56 ticks 1836739/1836748 buffer healthy 750-800/1000 threshold 500, build tasks=2, buildCarriedEnergy=200 then 150, worker assignment evidence true. Fresh monitor health tick 1837034: E29N56 owned_spawns=1, owned_creeps=12, hostiles=0.",
         "kind": "ops",
         "labels": [
           "blocked",
@@ -89103,7 +90200,7 @@
         "priority": "P1",
         "projectDomain": "Territory/Economy",
         "state": "",
-        "status": "Ready",
+        "status": "In progress",
         "title": "P1: E29N56 energy buffer recovery follow-up after CPU fix",
         "type": "Issue",
         "updatedAt": "",
@@ -89873,14 +90970,14 @@
       },
       {
         "blockedBy": "",
-        "domain": "Territory/Economy",
-        "domainSource": "project",
-        "evidence": "2026-06-05T18:49Z PR #1702 code is live: official deploy run 27033591689 for main 04f604d mode=deploy ok=true, artifact sha da8f8cb6 matches local dist, branch/activeWorld main matched, health gate ok, alert=false. Postdeploy console runtime-summary-console-20260605T184940Z shows rooms alive and productive/build tasks.",
-        "kind": "code",
+        "domain": "RL flywheel",
+        "domainSource": "heuristic",
+        "evidence": "PR #1718 merged efd1ced9 and deployed to Seasonal activeWorld; deploy artifact e9s28-dropped-energy-deploy/20260606T071718Z shows ok=true, artifact hash 39684877, activeWorld match, persistentNoImpact=true. Live proof artifact e9s28-dropped-energy-proof/20260606T071859Z sampled to tick 92210: E9S28 has invader, no friendly creeps, no dropped resources, no containers, source container sites still 0 progress.",
+        "kind": "bug",
         "labels": [
           "bug",
           "kind:code",
-          "priority:p1",
+          "priority:p0",
           "roadmap",
           "roadmap:seasonal-world",
           "seasonal-smoke"
@@ -89888,10 +90985,10 @@
         "milestone": "Seasonal World: smoke readiness gate",
         "nextAction": "",
         "number": 1700,
-        "priority": "P1",
-        "projectDomain": "Territory/Economy",
+        "priority": "P0",
+        "projectDomain": "",
         "state": "",
-        "status": "In progress",
+        "status": "In review",
         "title": "P1: Seasonal E9S28 reserve-first remote mining and road bootstrap",
         "type": "Issue",
         "updatedAt": "",
@@ -89944,7 +91041,7 @@
         "blockedBy": "",
         "domain": "Runtime monitor",
         "domainSource": "project",
-        "evidence": "",
+        "evidence": "2026-06-05 20:40Z code merged/deployed: PR #1708 -> 267332c1, deploy run 27038718442 ok, live console capture runtime-summary-console-20260605T204017Z.log shows workerAssignmentEvidenceAvailable=true in E29N55/E29N56/E29N57.",
         "kind": "ops",
         "labels": [
           "kind:ops",
@@ -89958,7 +91055,7 @@
         "priority": "P0",
         "projectDomain": "Runtime monitor",
         "state": "",
-        "status": "In review",
+        "status": "Done",
         "title": "P0: Populate creep-memory worker evidence in runtime summaries",
         "type": "Issue",
         "updatedAt": "",
@@ -89992,7 +91089,7 @@
         "blockedBy": "",
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "PR #1709 head 9685c42 has equivalent active rewardDecision carryover threads PRRT_kwDOSMSsO86Hd5tV and PRRT_kwDOSMSsO86Hd-iy; Codex triage/fix proc_[redacted] is editing the shared root cause.",
+        "evidence": "2026-06-05 20:43Z PR #1709 merged as c779226f after exact-head 4d662bb3 gate: elapsed 39m, green checks, CodeRabbit APPROVED, reviewThreads=0; post-merge main py_compile + unittest(15) + diff-check PASS.",
         "kind": "code",
         "labels": [
           "kind:code",
@@ -90006,11 +91103,178 @@
         "priority": "P1",
         "projectDomain": "RL flywheel",
         "state": "",
-        "status": "In review",
+        "status": "Done",
         "title": "P1: Propagate rewardDecisionId into RL policy advantage artifacts",
         "type": "Issue",
         "updatedAt": "",
         "url": "https://github.com/lanyusea/screeps/issues/1705"
+      },
+      {
+        "blockedBy": "",
+        "domain": "RL flywheel",
+        "domainSource": "project",
+        "evidence": "2026-06-05: PR #1711 merged as 0925c8d3; postmerge preflight postmerge-1711-preflight-20260605t215816z preserves partialSimulatorProgress and confirms no fresh room-busy compute.",
+        "kind": "bug",
+        "labels": [
+          "kind:bug",
+          "priority:p1",
+          "roadmap",
+          "roadmap:rl-flywheel"
+        ],
+        "milestone": "P1: RL strategy flywheel gate",
+        "nextAction": "",
+        "number": 1706,
+        "priority": "P1",
+        "projectDomain": "RL flywheel",
+        "state": "",
+        "status": "Done",
+        "title": "P1: Validate Tencent room-busy recurrence guard after prior fix",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/1706"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "project",
+        "evidence": "2026-06-05 20:40Z closed completed. Deploy run 27038718442 ok; live console capture runtime-summary-console-20260605T204017Z tick 1836259 shows build evidence or bounded cpu_shed suppression across all rooms.",
+        "kind": "bug",
+        "labels": [
+          "kind:bug",
+          "priority:p0",
+          "roadmap",
+          "roadmap:territory-economy"
+        ],
+        "milestone": "P1: Territory/Economy gameplay gate",
+        "nextAction": "",
+        "number": 1707,
+        "priority": "P0",
+        "projectDomain": "Territory/Economy",
+        "state": "",
+        "status": "Done",
+        "title": "P0: Verify and repair cross-room construction execution gate after failed acceptance",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/1707"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Runtime monitor",
+        "domainSource": "project",
+        "evidence": "2026-06-05 20:40Z merged as 267332c1, official deploy run 27038718442 ok, live console capture tick 1836259 proves worker evidence restored in all owned rooms.",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1708,
+        "priority": "P0",
+        "projectDomain": "Runtime monitor",
+        "state": "",
+        "status": "Done",
+        "title": "fix: preserve runtime worker evidence in summaries",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1708"
+      },
+      {
+        "blockedBy": "",
+        "domain": "RL flywheel",
+        "domainSource": "project",
+        "evidence": "2026-06-05 20:43Z PR #1709 merged as c779226f after exact-head 4d662bb3 gate: elapsed 39m, green checks, CodeRabbit APPROVED, reviewThreads=0; post-merge main py_compile + unittest(15) + diff-check PASS.",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1709,
+        "priority": "P1",
+        "projectDomain": "RL flywheel",
+        "state": "",
+        "status": "Done",
+        "title": "fix: propagate RL reward decision provenance",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1709"
+      },
+      {
+        "blockedBy": "",
+        "domain": "RL flywheel",
+        "domainSource": "project",
+        "evidence": "2026-06-05T22:26Z: PR #1713 merged as 0861961d; postmerge no-paid preflight postmerge-1713-preflight-20260605t222625z wrote controller-summary with computeAttempted=false, scaleOutAttempted=false, finalStatus=skipped_paid_failure_recurrence_launch_guard.",
+        "kind": "bug",
+        "labels": [
+          "kind:bug",
+          "priority:p1",
+          "roadmap",
+          "roadmap:rl-flywheel"
+        ],
+        "milestone": "P1: RL strategy flywheel gate",
+        "nextAction": "",
+        "number": 1710,
+        "priority": "P1",
+        "projectDomain": "RL flywheel",
+        "state": "",
+        "status": "Done",
+        "title": "P1: Repair Tencent post-fix validation private-server HTTP readiness timeout",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/1710"
+      },
+      {
+        "blockedBy": "",
+        "domain": "RL flywheel",
+        "domainSource": "project",
+        "evidence": "Merged 2026-06-05 21:57 UTC as 0925c8d3 after elapsed 105m, green checks, CodeRabbit exact-head approval, reviewThreads=0, local py_compile+177 unittest+diff-check.",
+        "kind": "bug",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1711,
+        "priority": "P1",
+        "projectDomain": "RL flywheel",
+        "state": "",
+        "status": "Done",
+        "title": "fix: preserve Tencent recurrence recovery evidence",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1711"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Docs/process",
+        "domainSource": "project",
+        "evidence": "2026-06-05T23:07Z PR #1712 merged as 369d81f4 after gate: elapsed 10345s, checks SUCCESS, CodeRabbit no-actionable exact head 87510315, threads=[], mergeState=CLEAN; main fast-forwarded clean.",
+        "kind": "docs",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1712,
+        "priority": "P2",
+        "projectDomain": "Docs/process",
+        "state": "",
+        "status": "Done",
+        "title": "chore(roadmap): refresh Pages artifacts",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1712"
+      },
+      {
+        "blockedBy": "",
+        "domain": "RL flywheel",
+        "domainSource": "project",
+        "evidence": "2026-06-05T22:25Z: PR #1713 merged after elapsed>15m, all checks pass, CodeRabbit exact-head APPROVED, review threads 0; merge commit 0861961d. Postmerge preflight artifact postmerge-1713-preflight-20260605t222625z no-paid/ASG 0.",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1713,
+        "priority": "P1",
+        "projectDomain": "RL flywheel",
+        "state": "",
+        "status": "Done",
+        "title": "fix: classify Tencent HTTP readiness timeouts",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1713"
       },
       {
         "blockedBy": "",
@@ -90026,127 +91290,663 @@
         ],
         "milestone": "P1: RL strategy flywheel gate",
         "nextAction": "",
-        "number": 1706,
+        "number": 1714,
         "priority": "P1",
         "projectDomain": "RL flywheel",
         "state": "",
-        "status": "In review",
-        "title": "P1: Validate Tencent room-busy recurrence guard after prior fix",
+        "status": "Done",
+        "title": "P1: Suppress stale E1_GATE_STALE anomaly after fresh full gate",
         "type": "Issue",
         "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/1706"
+        "url": "https://github.com/lanyusea/screeps/issues/1714"
       },
       {
         "blockedBy": "",
         "domain": "Territory/Economy",
         "domainSource": "project",
-        "evidence": "Created from Gameplay Review CLOSED_LOOP_FAILED lines 362-374/430-436; fresh console tick 1834937 has E29N55 buildProgress=15 but E29N57/E29N56 still cpu_shed with backlog; #1703 will repair definitive worker evidence.",
+        "evidence": "2026-06-06T19:46Z: #1743 deployed but postdeploy acceptance still failed; residual Codex commit 73681c3d opened PR #1744; controller verification PASS.",
         "kind": "bug",
         "labels": [
           "kind:bug",
           "priority:p0",
           "roadmap",
-          "roadmap:territory-economy"
+          "roadmap:territory-economy",
+          "runtime-alert"
         ],
         "milestone": "P1: Territory/Economy gameplay gate",
         "nextAction": "",
-        "number": 1707,
+        "number": 1715,
         "priority": "P0",
         "projectDomain": "Territory/Economy",
         "state": "",
-        "status": "Ready",
-        "title": "P0: Verify and repair cross-room construction execution gate after failed acceptance",
+        "status": "In progress",
+        "title": "P0: Fix cross-room construction assignment suppression under worker_assignment_gap",
         "type": "Issue",
         "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/1707"
+        "url": "https://github.com/lanyusea/screeps/issues/1715"
+      },
+      {
+        "blockedBy": "",
+        "domain": "RL flywheel",
+        "domainSource": "project",
+        "evidence": "",
+        "kind": "bug",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1716,
+        "priority": "P1",
+        "projectDomain": "RL flywheel",
+        "state": "",
+        "status": "Done",
+        "title": "rl: suppress fresh full E1 stale anomaly",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1716"
+      },
+      {
+        "blockedBy": "",
+        "domain": "RL flywheel",
+        "domainSource": "project",
+        "evidence": "2026-06-06: PR #1720 merged 271de482; postmerge summary tick 1849256 workerAssignmentEvidenceAvailable=true all rooms; alert=false health ok.",
+        "kind": "bug",
+        "labels": [
+          "kind:bug",
+          "priority:p0",
+          "roadmap",
+          "roadmap:rl-flywheel"
+        ],
+        "milestone": "P1: RL strategy flywheel gate",
+        "nextAction": "",
+        "number": 1717,
+        "priority": "P0",
+        "projectDomain": "RL flywheel",
+        "state": "",
+        "status": "Done",
+        "title": "P0: Restore creep-memory worker assignment evidence in runtime summaries",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/1717"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Bot capability",
+        "domainSource": "heuristic",
+        "evidence": "PR #1718 merged efd1ced9 and deployed to Seasonal activeWorld; deploy artifact e9s28-dropped-energy-deploy/20260606T071718Z shows ok=true, artifact hash 39684877, activeWorld match, persistentNoImpact=true. Live proof artifact e9s28-dropped-energy-proof/20260606T071859Z sampled to tick 92210: E9S28 has invader, no friendly creeps, no dropped resources, no containers, source container sites still 0 progress.",
+        "kind": "bug",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1718,
+        "priority": "P0",
+        "projectDomain": "",
+        "state": "",
+        "status": "In review",
+        "title": "seasonal: support reserve-first remote mining",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1718"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "project",
+        "evidence": "PR #1719 merged as 82b52990 and deployed in run 27057459484. Deploy/upload and primary E29N55 health ok, but all-owned acceptance still failed for #1715 (E29N56 worker_assignment_gap_sustained tick 1854811); this PR remains Done while #1715 follow-up Codex proc_[redacted] handles residual blocker.",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1719,
+        "priority": "P0",
+        "projectDomain": "Territory/Economy",
+        "state": "",
+        "status": "Done",
+        "title": "economy: unblock full-energy construction assignment",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1719"
+      },
+      {
+        "blockedBy": "",
+        "domain": "RL flywheel",
+        "domainSource": "project",
+        "evidence": "2026-06-06: PR #1720 merged 271de482; postmerge summary tick 1849256 workerAssignmentEvidenceAvailable=true all rooms; alert=false health ok.",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1720,
+        "priority": "P0",
+        "projectDomain": "RL flywheel",
+        "state": "",
+        "status": "Done",
+        "title": "monitor: capture bounded creep task evidence",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1720"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "project",
+        "evidence": "Merged as 36fa83af; deploy run 27052669691 succeeded with activeWorld/main matched, postdeploy health ok=true and alert=false.",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1721,
+        "priority": "P0",
+        "projectDomain": "Territory/Economy",
+        "state": "",
+        "status": "Done",
+        "title": "cpu: preserve construction planning under CPU overrun",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1721"
+      },
+      {
+        "blockedBy": "",
+        "domain": "RL flywheel",
+        "domainSource": "project",
+        "evidence": "Done 2026-06-06T02:01Z: PR #1723 squash-merged at b75379a0; generated/validated host-sized Loop A local-fallback card runtime-artifacts/rl-experiment-cards/experiment_card.json from E1 gate e1-gate-20260605T191602Z dataset rl-e93cefe304b9; workers=1 scale=5 minConcurrent=1, liveEffect=false.",
+        "kind": "code",
+        "labels": [
+          "domain:rl-flywheel",
+          "kind:code",
+          "priority:p0",
+          "roadmap",
+          "roadmap:rl-flywheel"
+        ],
+        "milestone": "P1: RL strategy flywheel gate",
+        "nextAction": "",
+        "number": 1722,
+        "priority": "P0",
+        "projectDomain": "RL flywheel",
+        "state": "",
+        "status": "Done",
+        "title": "P0: Generate host-sized RL experiment card for latest E1 gate",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/1722"
+      },
+      {
+        "blockedBy": "",
+        "domain": "RL flywheel",
+        "domainSource": "project",
+        "evidence": "Done 2026-06-06T02:01Z: PR #1723 squash-merged at b75379a0; generated/validated host-sized Loop A local-fallback card runtime-artifacts/rl-experiment-cards/experiment_card.json from E1 gate e1-gate-20260605T191602Z dataset rl-e93cefe304b9; workers=1 scale=5 minConcurrent=1, liveEffect=false.",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1723,
+        "priority": "P0",
+        "projectDomain": "RL flywheel",
+        "state": "",
+        "status": "Done",
+        "title": "rl: generate host-sized latest E1 card",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1723"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Bot capability",
+        "domainSource": "heuristic",
+        "evidence": "2026-06-06T02:21Z PR #1724 opened for issue #1528 at Codex commit 6a8aa177 (bot). Controller verification passed diff-check/typecheck/focused+full Jest/build. Exact-head issue gate/prod-ci/roadmap checks green; GraphQL threads=0; CodeRabbit status pending; mergeState UNSTABLE until bot completes.",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1724,
+        "priority": "P1",
+        "projectDomain": "",
+        "state": "",
+        "status": "Done",
+        "title": "construction: cover E29N56 first tower priority",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1724"
+      },
+      {
+        "blockedBy": "",
+        "domain": "RL flywheel",
+        "domainSource": "project",
+        "evidence": "Merged PR #1727 at main 5b6f221f; deployed official run 27051623684 ok=true activeWorld/main matched health_ok=true alert=false.",
+        "kind": "ops",
+        "labels": [
+          "domain:rl-flywheel",
+          "kind:ops",
+          "priority:p0",
+          "roadmap",
+          "roadmap:rl-flywheel"
+        ],
+        "milestone": "P1: RL strategy flywheel gate",
+        "nextAction": "",
+        "number": 1725,
+        "priority": "P0",
+        "projectDomain": "RL flywheel",
+        "state": "",
+        "status": "Done",
+        "title": "P0: Investigate territory-shadow rollback reliability collapse",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/1725"
       },
       {
         "blockedBy": "",
         "domain": "Runtime monitor",
         "domainSource": "project",
-        "evidence": "PR #1708 opened at b084f670; issue body gate passed; controller verification PASS with full prod suite and bundle build.",
-        "kind": "code",
-        "labels": [],
-        "milestone": "",
+        "evidence": "2026-06-06T05:00Z fresh postmerge monitor: alert=false health ok at tick 1849304; prior rampart alert not currently active.",
+        "kind": "ops",
+        "labels": [
+          "kind:incident",
+          "priority:p1",
+          "runtime-alert"
+        ],
+        "milestone": "Phase C: Runtime telemetry / monitor gate",
         "nextAction": "",
-        "number": 1708,
-        "priority": "P0",
+        "number": 1726,
+        "priority": "P1",
         "projectDomain": "Runtime monitor",
         "state": "",
-        "status": "In review",
-        "title": "fix: preserve runtime worker evidence in summaries",
-        "type": "PullRequest",
+        "status": "Ready",
+        "title": "Runtime alert: E29N55 rampart damage unsuppressed at 35,29",
+        "type": "Issue",
         "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/1708"
+        "url": "https://github.com/lanyusea/screeps/issues/1726"
       },
       {
         "blockedBy": "",
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "PR #1709 head 9685c42 has equivalent active rewardDecision carryover threads PRRT_kwDOSMSsO86Hd5tV and PRRT_kwDOSMSsO86Hd-iy; Codex triage/fix proc_[redacted] is editing the shared root cause.",
+        "evidence": "Squash-merged as 5b6f221f and deployed by official run 27051623684 with branchCode/activeWorld matched and postdeploy health ok.",
         "kind": "code",
         "labels": [],
         "milestone": "",
         "nextAction": "",
-        "number": 1709,
-        "priority": "P1",
+        "number": 1727,
+        "priority": "P0",
         "projectDomain": "RL flywheel",
         "state": "",
-        "status": "In review",
-        "title": "fix: propagate RL reward decision provenance",
+        "status": "Done",
+        "title": "rl: scope rollout monitoring to consumed policies",
         "type": "PullRequest",
         "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/1709"
+        "url": "https://github.com/lanyusea/screeps/pull/1727"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Docs/process",
+        "domainSource": "project",
+        "evidence": "2026-06-06T18:04Z live audit repaired stale evidence: PR #1728 head b5dce126 is BEHIND current main b6557886 and issue-completion gate is failing; prod-ci/pages and CodeRabbit context are stale pre-update successes.",
+        "kind": "docs",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1728,
+        "priority": "P2",
+        "projectDomain": "Docs/process",
+        "state": "",
+        "status": "In review",
+        "title": "chore(roadmap): refresh Pages artifacts",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1728"
       },
       {
         "blockedBy": "",
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "Created from #1706 CODEX_1706_HELD: room-busy evidence is historical; latest partial simulator progress has 19/20 env rows succeeded and one private-server HTTP readiness timeout after 900s.",
+        "evidence": "2026-06-06T18:23Z: PR #1730 merged as d081959e; latest Loop A ledger runtime-artifacts/rl-control-loop/20260606T174933Z-training-ledger.json now has rewardDecisionId=construction-priority.pg.risk-aware-seed.v1. Latest Loop B remains 20260606T160607Z/stale for full acceptance.",
         "kind": "bug",
         "labels": [
           "kind:bug",
+          "priority:p0",
+          "roadmap",
+          "roadmap:rl-flywheel"
+        ],
+        "milestone": "P1: RL strategy flywheel gate",
+        "nextAction": "",
+        "number": 1729,
+        "priority": "P0",
+        "projectDomain": "RL flywheel",
+        "state": "",
+        "status": "In progress",
+        "title": "P0: Restore rewardDecisionId propagation after latest Loop B null regression",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/1729"
+      },
+      {
+        "blockedBy": "",
+        "domain": "RL flywheel",
+        "domainSource": "project",
+        "evidence": "2026-06-06T15:16Z: PR #1730 merged as d081959e after exact-head checks green and all review threads resolved; postmerge py_compile/unittest passed; policy-advantage artifact now carries RD-AUTO-9f33873ce71c.",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1730,
+        "priority": "P0",
+        "projectDomain": "RL flywheel",
+        "state": "",
+        "status": "Done",
+        "title": "rl: recover reward decision provenance in ledgers",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1730"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "project",
+        "evidence": "2026-06-06T10:27Z merged as 0551b9b6 after exact-head acae7d5 gate: elapsed>15m, checks green, CodeRabbit approved, review threads resolved, controller typecheck/Jest/build passed.",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1732,
+        "priority": "P0",
+        "projectDomain": "Territory/Economy",
+        "state": "",
+        "status": "Done",
+        "title": "economy: recover E29N56 postdeploy construction assignment",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1732"
+      },
+      {
+        "blockedBy": "",
+        "domain": "RL flywheel",
+        "domainSource": "heuristic",
+        "evidence": "2026-06-06T19:28Z: PR #1733 head b5ca018a is clean/green/threads=0 after update-branch; held only behind active hard-P0 #1715 residual Codex proc_[redacted].",
+        "kind": "bug",
+        "labels": [
+          "blocked",
+          "kind:bug",
+          "priority:p0",
+          "roadmap",
+          "roadmap:seasonal-world",
+          "seasonal-smoke"
+        ],
+        "milestone": "Seasonal World: smoke readiness gate",
+        "nextAction": "",
+        "number": 1731,
+        "priority": "P0",
+        "projectDomain": "",
+        "state": "",
+        "status": "In review",
+        "title": "P0: Stop seasonal workers/haulers walking empty energy-spending tasks",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/1731"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "heuristic",
+        "evidence": "2026-06-06T19:28Z: update-branch completed to b5ca018a; exact-head checks green, CodeRabbit status success, GraphQL review threads=0. Merge intentionally sequenced behind hard-P0 #1715 residual Codex proc_[redacted].",
+        "kind": "bug",
+        "labels": [
+          "blocked"
+        ],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1733,
+        "priority": "P0",
+        "projectDomain": "",
+        "state": "",
+        "status": "In review",
+        "title": "seasonal: prevent empty worker/hauler task walking",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1733"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "project",
+        "evidence": "2026-06-06T12:55Z merged #1734 at 605975db after exact-head checks/CodeRabbit/threads gate; deploy run 27062882473 succeeded. Postdeploy all-owned acceptance still failed for #1715, so PR #1734 is Done as a merged slice and successor Codex lane proc_[redacted] owns remaining incident.",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1734,
+        "priority": "P0",
+        "projectDomain": "Territory/Economy",
+        "state": "",
+        "status": "Done",
+        "title": "economy: allow bootstrap storage construction before refill",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1734"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "project",
+        "evidence": "Done 2026-06-06: PR #1735 merged at b03d00e1 and deployed via official workflow run 27065462593; final monitor postdeploy-1715-1736-final-20260606T145746Z alert=false and health ok.",
+        "kind": "bug",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1735,
+        "priority": "P0",
+        "projectDomain": "Territory/Economy",
+        "state": "",
+        "status": "Done",
+        "title": "economy: clear postdeploy worker assignment gap",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1735"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "project",
+        "evidence": "Done 2026-06-06: PR #1737 merged at e99dbfad, deploy run 27065225678 succeeded; PR #1735 follow-up deployed run 27065462593; final live monitor shows all owned rooms alert=false/health ok with sourceHarvesters/haulers/workers harvesting and repairing.",
+        "kind": "bug",
+        "labels": [
+          "kind:bug",
+          "priority:p0",
+          "roadmap",
+          "roadmap:territory-economy",
+          "runtime-alert"
+        ],
+        "milestone": "P1: Territory/Economy gameplay gate",
+        "nextAction": "",
+        "number": 1736,
+        "priority": "P0",
+        "projectDomain": "Territory/Economy",
+        "state": "",
+        "status": "Done",
+        "title": "P0: Normal-world rooms lack local harvest/haul recovery and mutual repair pressure",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/1736"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "project",
+        "evidence": "Done 2026-06-06: PR #1737 merged at e99dbfad and deployed via official workflow run 27065225678; final monitor after companion deploy shows rooms harvesting and repairing with alert=false.",
+        "kind": "bug",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1737,
+        "priority": "P0",
+        "projectDomain": "Territory/Economy",
+        "state": "",
+        "status": "Done",
+        "title": "economy: recover local harvest and refill pressure",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1737"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "project",
+        "evidence": "2026-06-06T19:46Z: fresh console shows E29N55 buffer 783 and E29N57 1437; buildCarriedEnergy=0 with worker_assignment_gap; PR #1744 opened for #1715 residual.",
+        "kind": "bug",
+        "labels": [
+          "blocked",
+          "kind:bug",
+          "priority:p1",
+          "roadmap",
+          "roadmap:territory-economy"
+        ],
+        "milestone": "P1: Territory/Economy gameplay gate",
+        "nextAction": "",
+        "number": 1738,
+        "priority": "P1",
+        "projectDomain": "Territory/Economy",
+        "state": "",
+        "status": "In progress",
+        "title": "P1: Recover energy buffer collapse and construction unblock after Loop B alert",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/1738"
+      },
+      {
+        "blockedBy": "",
+        "domain": "RL flywheel",
+        "domainSource": "project",
+        "evidence": "2026-06-06T17:00Z diagnostic artifact runtime-artifacts/rl-training/stuck-runner-diagnostics-20260606T1700Z.json captured PID 3701954 stuck in futex_wait_queue at >10h with swap 1987/1987MB. SIGTERM then SIGKILL cleared PID; RAM available rose to ~3817MB, swap free 59MB.",
+        "kind": "ops",
+        "labels": [
+          "kind:ops",
+          "priority:p2",
+          "roadmap",
+          "roadmap:rl-flywheel"
+        ],
+        "milestone": "P1: RL strategy flywheel gate",
+        "nextAction": "",
+        "number": 1739,
+        "priority": "P2",
+        "projectDomain": "RL flywheel",
+        "state": "",
+        "status": "In progress",
+        "title": "P2: Diagnose RL training runner swap exhaustion",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/1739"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "project",
+        "evidence": "PR #1740 exact head 51f1e7b9; issue-completion/prod-ci/roadmap checks green and GraphQL unresolved threads=0; CodeRabbit status is SUCCESS but top-level comment says review limit/usage credits, not substantive review.",
+        "kind": "code",
+        "labels": [
+          "blocked"
+        ],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1740,
+        "priority": "P0",
+        "projectDomain": "Territory/Economy",
+        "state": "",
+        "status": "Done",
+        "title": "economy: account for refill acquisition coverage",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1740"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "project",
+        "evidence": "2026-06-06T18:03Z Deploy run 27069646426 succeeded for b6557886 (deploy ok, activeWorld matched, health ok, alert=false for target E29N55). Artifact archived under runtime-artifacts/official-screeps-deploy/*-27069646426.json. All-owned acceptance remains with #1715/#1738.",
+        "kind": "bug",
+        "labels": [
+          "kind:bug",
+          "priority:p0",
+          "roadmap",
+          "roadmap:territory-economy",
+          "runtime-alert"
+        ],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1741,
+        "priority": "P0",
+        "projectDomain": "Territory/Economy",
+        "state": "",
+        "status": "Done",
+        "title": "fix: recover worker assignments after postdeploy gap",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1741"
+      },
+      {
+        "blockedBy": "",
+        "domain": "RL flywheel",
+        "domainSource": "project",
+        "evidence": "2026-06-06T18:21Z: no active RL/Tencent runners; latest Loop A 20260606T174933Z records localRunnerExitedWithoutReport and Tencent guard held. RL diagnostic remains Ready but hard P0 #1715 preempts this steward slot.",
+        "kind": "ops",
+        "labels": [
+          "kind:ops",
           "priority:p1",
           "roadmap",
           "roadmap:rl-flywheel"
         ],
         "milestone": "P1: RL strategy flywheel gate",
         "nextAction": "",
-        "number": 1710,
+        "number": 1742,
         "priority": "P1",
         "projectDomain": "RL flywheel",
         "state": "",
         "status": "Ready",
-        "title": "P1: Repair Tencent post-fix validation private-server HTTP readiness timeout",
+        "title": "P1: Diagnose local RL training runner exit without report after futex hang",
         "type": "Issue",
         "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/1710"
+        "url": "https://github.com/lanyusea/screeps/issues/1742"
       },
       {
         "blockedBy": "",
-        "domain": "RL flywheel",
+        "domain": "Territory/Economy",
         "domainSource": "project",
-        "evidence": "PR #1711 opened at b748f977; issue body gate passed; controller verification PASS for Tencent runner tests and no-paid safety.",
+        "evidence": "2026-06-06T19:26Z: merged/deployed as 49713d9c via official run 27071513534; deploy ok/activeWorld matched/health ok. All-owned acceptance still failed at runtime-artifacts/screeps-monitor/postdeploy-pr1743-20260606T192304Z, routed to residual Codex proc_[redacted].",
         "kind": "bug",
         "labels": [],
         "milestone": "",
         "nextAction": "",
-        "number": 1711,
-        "priority": "P1",
-        "projectDomain": "RL flywheel",
+        "number": 1743,
+        "priority": "P0",
+        "projectDomain": "Territory/Economy",
         "state": "",
-        "status": "In review",
-        "title": "fix: preserve Tencent recurrence recovery evidence",
+        "status": "Done",
+        "title": "fix: recover construction assignment after worker gap alert",
         "type": "PullRequest",
         "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/1711"
+        "url": "https://github.com/lanyusea/screeps/pull/1743"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "project",
+        "evidence": "2026-06-06T19:46Z: PR #1744 head 73681c3d; controller diff/typecheck/Jest 105/2354/build PASS; CodeRabbit rate-limited; prod-ci pending.",
+        "kind": "bug",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1744,
+        "priority": "P0",
+        "projectDomain": "Territory/Economy",
+        "state": "",
+        "status": "In review",
+        "title": "fix: recover build assignment from retained upgrade task",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1744"
       }
     ],
     "projectItemsCompleteness": {
       "complete": true,
       "limit": 2000,
-      "returnedCount": 1669,
-      "totalCount": 1669
+      "returnedCount": 1702,
+      "totalCount": 1701
     },
     "projectItemsSource": "live",
     "projectTextFieldHydration": {
@@ -90166,7 +91966,7 @@
           "observedKeys": []
         }
       },
-      "itemsInspected": 1669,
+      "itemsInspected": 1702,
       "source": "gh project item-list"
     },
     "pullRequests": [
@@ -90177,22 +91977,22 @@
           "success": 4,
           "total": 4
         },
-        "createdAt": "2026-06-05T20:11:32Z",
+        "createdAt": "2026-06-06T19:45:55Z",
         "domain": "Bot capability",
         "domainSource": "heuristic",
         "isDraft": false,
         "kind": "code",
         "labels": [],
         "milestone": "",
-        "number": 1711,
+        "number": 1744,
         "priority": "P1",
         "reviewDecision": "",
         "state": "OPEN",
         "status": "In review",
-        "title": "fix: preserve Tencent recurrence recovery evidence",
+        "title": "fix: recover build assignment from retained upgrade task",
         "type": "PullRequest",
-        "updatedAt": "2026-06-05T20:12:38Z",
-        "url": "https://github.com/lanyusea/screeps/pull/1711"
+        "updatedAt": "2026-06-06T19:46:36Z",
+        "url": "https://github.com/lanyusea/screeps/pull/1744"
       },
       {
         "checks": {
@@ -90201,46 +92001,48 @@
           "success": 4,
           "total": 4
         },
-        "createdAt": "2026-06-05T20:03:57Z",
-        "domain": "Change-control",
-        "domainSource": "heuristic",
-        "isDraft": false,
-        "kind": "code",
-        "labels": [],
-        "milestone": "",
-        "number": 1709,
-        "priority": "P1",
-        "reviewDecision": "CHANGES_REQUESTED",
-        "state": "OPEN",
-        "status": "In review",
-        "title": "fix: propagate RL reward decision provenance",
-        "type": "PullRequest",
-        "updatedAt": "2026-06-05T20:11:25Z",
-        "url": "https://github.com/lanyusea/screeps/pull/1709"
-      },
-      {
-        "checks": {
-          "failure": 0,
-          "pending": 0,
-          "success": 4,
-          "total": 4
-        },
-        "createdAt": "2026-06-05T20:03:53Z",
+        "createdAt": "2026-06-06T09:37:56Z",
         "domain": "Territory/Economy",
         "domainSource": "heuristic",
         "isDraft": false,
         "kind": "code",
-        "labels": [],
+        "labels": [
+          "blocked"
+        ],
         "milestone": "",
-        "number": 1708,
+        "number": 1733,
         "priority": "P1",
         "reviewDecision": "",
         "state": "OPEN",
         "status": "In review",
-        "title": "fix: preserve runtime worker evidence in summaries",
+        "title": "seasonal: prevent empty worker/hauler task walking",
         "type": "PullRequest",
-        "updatedAt": "2026-06-05T20:12:58Z",
-        "url": "https://github.com/lanyusea/screeps/pull/1708"
+        "updatedAt": "2026-06-06T19:28:21Z",
+        "url": "https://github.com/lanyusea/screeps/pull/1733"
+      },
+      {
+        "checks": {
+          "failure": 1,
+          "pending": 0,
+          "success": 3,
+          "total": 4
+        },
+        "createdAt": "2026-06-06T04:21:12Z",
+        "domain": "Bot capability",
+        "domainSource": "heuristic",
+        "isDraft": false,
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "number": 1728,
+        "priority": "P1",
+        "reviewDecision": "",
+        "state": "OPEN",
+        "status": "In review",
+        "title": "chore(roadmap): refresh Pages artifacts",
+        "type": "PullRequest",
+        "updatedAt": "2026-06-06T14:08:55Z",
+        "url": "https://github.com/lanyusea/screeps/pull/1728"
       }
     ],
     "roadmapCards": [
@@ -90262,7 +92064,7 @@
       {
         "domain": "Territory/Economy",
         "domainSource": "project",
-        "evidence": "2026-06-05 02:04 +08 CPU acceptance remains open: latest runtime-summary-console capture is now >2000 ticks old; 7ee147327ba6 capture run requested but no fresh output due cron cadence stall; no closure from stale CPU data.",
+        "evidence": "2026-06-06T05:28Z: CPU still degraded; console tick 1849538 bucket=1845 used=64.85/70; GE review says constructionScoring skipped usedOverLimit; E29N56 build partly active.",
         "milestone": "P1: Territory/Economy gameplay gate",
         "nextAction": "",
         "number": 1490,
@@ -90305,9 +92107,24 @@
         "visionLayer": "resources"
       },
       {
+        "domain": "Territory/Economy",
+        "domainSource": "project",
+        "evidence": "2026-06-06T19:46Z: #1743 deployed but postdeploy acceptance still failed; residual Codex commit 73681c3d opened PR #1744; controller verification PASS.",
+        "milestone": "P1: Territory/Economy gameplay gate",
+        "nextAction": "",
+        "number": 1715,
+        "priority": "P0",
+        "projectDomain": "Territory/Economy",
+        "status": "In progress",
+        "title": "P0: Fix cross-room construction assignment suppression under worker_assignment_gap",
+        "type": "Issue",
+        "url": "https://github.com/lanyusea/screeps/issues/1715",
+        "visionLayer": "territory"
+      },
+      {
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "2026-06-05T16:15Z candidate scorecard exists and trustedGradientUpdate=true, but live canary blocked by rewardDecisionId=null and no fresh gate.",
+        "evidence": "2026-06-05T22:30Z: rewardDecisionId now present in manual Loop A artifact (RD-AUTO-67014b3ef07a) and #1566 activation proof closed; live canary still blocked by no online rollout gate, CPU #1490, and #1714 ledger anomaly.",
         "milestone": "P1: RL strategy flywheel gate",
         "nextAction": "",
         "number": 1583,
@@ -90337,7 +92154,7 @@
       {
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "2026-06-05T16:22Z conclusion registry parsed: total 17, OPEN=1 ACTIONED=3 VALIDATING=3 CLOSED=10, stale/escalated=0.",
+        "evidence": "2026-06-05T22:33Z conclusion-registry.json updated artifact-first: total 17, CLOSED=11, ACTIONED=3, VALIDATING=3; linked #1713/#1714/#1490 and closed #1566 acceptance scope.",
         "milestone": "P1: RL strategy flywheel gate",
         "nextAction": "",
         "number": 1543,
@@ -90352,22 +92169,7 @@
       {
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "2026-06-05T16:15Z Loop A completed local trusted gradient but rewardDecisionId remains null, blocking deployable objective activation proof.",
-        "milestone": "P1: RL strategy flywheel gate",
-        "nextAction": "",
-        "number": 1566,
-        "priority": "P0",
-        "projectDomain": "RL flywheel",
-        "status": "In progress",
-        "title": "P0: Repair RL multi-tier objective activation proof before paid validation",
-        "type": "Issue",
-        "url": "https://github.com/lanyusea/screeps/issues/1566",
-        "visionLayer": "foundation blocker"
-      },
-      {
-        "domain": "RL flywheel",
-        "domainSource": "project",
-        "evidence": "2026-06-05T16:36Z: #1698/#1681 known_hosts hardening merged; latest tencent-pg-20260605t163003z still safely skipped run-single, ASG 0/0/0.",
+        "evidence": "2026-06-06T14:42Z: latest Tencent summaries through tencent-pg-20260606t144004z and preflight cron-batch-preflight-20260606t143417... all skipped by paid_failure_recurrence_launch_guard; ASG desired/in-service 0/0; billing guard OK.",
         "milestone": "P1: RL strategy flywheel gate",
         "nextAction": "",
         "number": 1233,
@@ -90382,7 +92184,22 @@
       {
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "2026-06-05T16:36Z: #1698 known_hosts hardening merged; Loop A local training completed trustedGradientUpdate=true but rewardDecisionId=null; Tencent held.",
+        "evidence": "2026-06-06T18:23Z: PR #1730 merged as d081959e; latest Loop A ledger runtime-artifacts/rl-control-loop/20260606T174933Z-training-ledger.json now has rewardDecisionId=construction-priority.pg.risk-aware-seed.v1. Latest Loop B remains 20260606T160607Z/stale for full acceptance.",
+        "milestone": "P1: RL strategy flywheel gate",
+        "nextAction": "",
+        "number": 1729,
+        "priority": "P0",
+        "projectDomain": "RL flywheel",
+        "status": "In progress",
+        "title": "P0: Restore rewardDecisionId propagation after latest Loop B null regression",
+        "type": "Issue",
+        "url": "https://github.com/lanyusea/screeps/issues/1729",
+        "visionLayer": "foundation blocker"
+      },
+      {
+        "domain": "RL flywheel",
+        "domainSource": "project",
+        "evidence": "2026-06-06T17:00Z: stuck local runner PID 3701954 was terminated after diagnostic artifact runtime-artifacts/rl-training/stuck-runner-diagnostics-20260606T1700Z.json (futex_wait_queue, >10h, swap full). No active local/Tencent runner remains; #1715 Codex proc_[redacted] is active.",
         "milestone": "P1: RL strategy flywheel gate",
         "nextAction": "",
         "number": 1032,
@@ -90395,34 +92212,19 @@
         "visionLayer": "foundation blocker"
       },
       {
-        "domain": "Runtime monitor",
-        "domainSource": "project",
-        "evidence": "",
-        "milestone": "Phase C: Runtime telemetry / monitor gate",
+        "domain": "RL flywheel",
+        "domainSource": "heuristic",
+        "evidence": "2026-06-06T19:28Z: PR #1733 head b5ca018a is clean/green/threads=0 after update-branch; held only behind active hard-P0 #1715 residual Codex proc_[redacted].",
+        "milestone": "Seasonal World: smoke readiness gate",
         "nextAction": "",
-        "number": 1703,
+        "number": 1731,
         "priority": "P0",
-        "projectDomain": "Runtime monitor",
+        "projectDomain": "",
         "status": "In review",
-        "title": "P0: Populate creep-memory worker evidence in runtime summaries",
+        "title": "P0: Stop seasonal workers/haulers walking empty energy-spending tasks",
         "type": "Issue",
-        "url": "https://github.com/lanyusea/screeps/issues/1703",
+        "url": "https://github.com/lanyusea/screeps/issues/1731",
         "visionLayer": "resources"
-      },
-      {
-        "domain": "Territory/Economy",
-        "domainSource": "project",
-        "evidence": "Created from Gameplay Review CLOSED_LOOP_FAILED lines 362-374/430-436; fresh console tick 1834937 has E29N55 buildProgress=15 but E29N57/E29N56 still cpu_shed with backlog; #1703 will repair definitive worker evidence.",
-        "milestone": "P1: Territory/Economy gameplay gate",
-        "nextAction": "",
-        "number": 1707,
-        "priority": "P0",
-        "projectDomain": "Territory/Economy",
-        "status": "Ready",
-        "title": "P0: Verify and repair cross-room construction execution gate after failed acceptance",
-        "type": "Issue",
-        "url": "https://github.com/lanyusea/screeps/issues/1707",
-        "visionLayer": "territory"
       }
     ],
     "seededFallbackIssueCount": 0,
@@ -90554,7 +92356,7 @@
             "categoryLabel": "Resources / Economy",
             "description": "Energy held in room stores in the latest runtime KPI window.",
             "details": {},
-            "formattedValue": "8307",
+            "formattedValue": "10835",
             "instrumented": true,
             "key": "stored_energy",
             "label": "Stored energy",
@@ -90565,7 +92367,7 @@
             "source": "runtime-summary resource fields",
             "status": "observed",
             "unit": "energy",
-            "value": 8307
+            "value": 10835
           },
           {
             "category": "resources",
@@ -90590,7 +92392,7 @@
             "categoryLabel": "Resources / Economy",
             "description": "Energy currently carried by workers.",
             "details": {},
-            "formattedValue": "996",
+            "formattedValue": "1626",
             "instrumented": true,
             "key": "worker_carried_energy",
             "label": "Worker carried energy",
@@ -90601,7 +92403,7 @@
             "source": "runtime-summary resource fields",
             "status": "observed",
             "unit": "energy",
-            "value": 996
+            "value": 1626
           },
           {
             "category": "resources",
@@ -91092,7 +92894,7 @@
           "instrumented": false,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91106,6 +92908,13 @@
             "worldId": "persistent"
           },
           "sourceKind": "runtime-summary-artifact",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-06-06T19:47:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -91129,7 +92938,7 @@
           "instrumented": false,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91143,6 +92952,13 @@
             "worldId": "persistent"
           },
           "sourceKind": "runtime-summary-artifact",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-06-06T19:47:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -91166,7 +92982,7 @@
           "instrumented": true,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91180,6 +92996,13 @@
             "worldId": "persistent"
           },
           "sourceKind": "runtime-summary-artifact",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
+          "sampledAt": "2026-06-06T19:47:20Z",
           "status": "not observed",
           "value": null
         }
@@ -91203,7 +93026,7 @@
           "instrumented": true,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91217,6 +93040,13 @@
             "worldId": "persistent"
           },
           "sourceKind": "runtime-summary-artifact",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
+          "sampledAt": "2026-06-06T19:47:20Z",
           "status": "not observed",
           "value": null
         }
@@ -91240,7 +93070,7 @@
           "instrumented": true,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91254,6 +93084,13 @@
             "worldId": "persistent"
           },
           "sourceKind": "runtime-summary-artifact",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
+          "sampledAt": "2026-06-06T19:47:20Z",
           "status": "not observed",
           "value": null
         }
@@ -91277,7 +93114,7 @@
           "instrumented": true,
           "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91293,6 +93130,13 @@
           "sourceKind": "runtime-summary-artifact",
           "status": "observed",
           "value": 15
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-06-06T19:47:20Z",
+          "status": "observed",
+          "value": 15.0
         }
       ],
       "controller_progress_delta": [
@@ -91314,7 +93158,7 @@
           "instrumented": true,
           "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91330,6 +93174,13 @@
           "sourceKind": "runtime-summary-artifact",
           "status": "observed",
           "value": 0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-06-06T19:47:20Z",
+          "status": "observed",
+          "value": 0.0
         }
       ],
       "cpu_bucket": [
@@ -91351,7 +93202,7 @@
           "instrumented": false,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91365,6 +93216,13 @@
             "worldId": "persistent"
           },
           "sourceKind": "runtime-summary-artifact",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-06-06T19:47:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -91388,7 +93246,7 @@
           "instrumented": false,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91402,6 +93260,13 @@
             "worldId": "persistent"
           },
           "sourceKind": "runtime-summary-artifact",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-06-06T19:47:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -91425,7 +93290,7 @@
           "instrumented": true,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91439,6 +93304,13 @@
             "worldId": "persistent"
           },
           "sourceKind": "runtime-summary-artifact",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
+          "sampledAt": "2026-06-06T19:47:20Z",
           "status": "not observed",
           "value": null
         }
@@ -91462,7 +93334,7 @@
           "instrumented": true,
           "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91478,6 +93350,13 @@
           "sourceKind": "runtime-summary-artifact",
           "status": "observed",
           "value": 0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-06-06T19:47:20Z",
+          "status": "observed",
+          "value": 0.0
         }
       ],
       "enemy_kills": [
@@ -91499,7 +93378,7 @@
           "instrumented": false,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91513,6 +93392,13 @@
             "worldId": "persistent"
           },
           "sourceKind": "runtime-summary-artifact",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-06-06T19:47:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -91536,7 +93422,7 @@
           "instrumented": false,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91550,6 +93436,13 @@
             "worldId": "persistent"
           },
           "sourceKind": "runtime-summary-artifact",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-06-06T19:47:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -91573,7 +93466,7 @@
           "instrumented": true,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91587,6 +93480,13 @@
             "worldId": "persistent"
           },
           "sourceKind": "runtime-summary-artifact",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
+          "sampledAt": "2026-06-06T19:47:20Z",
           "status": "not observed",
           "value": null
         }
@@ -91610,7 +93510,7 @@
           "instrumented": true,
           "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91626,6 +93526,13 @@
           "sourceKind": "runtime-summary-artifact",
           "status": "observed",
           "value": 0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-06-06T19:47:20Z",
+          "status": "observed",
+          "value": 0.0
         }
       ],
       "hostile_structures": [
@@ -91647,7 +93554,7 @@
           "instrumented": true,
           "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91663,6 +93570,13 @@
           "sourceKind": "runtime-summary-artifact",
           "status": "observed",
           "value": 0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-06-06T19:47:20Z",
+          "status": "observed",
+          "value": 0.0
         }
       ],
       "kpi_artifact_files": [
@@ -91684,7 +93598,7 @@
           "instrumented": false,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91700,6 +93614,13 @@
           "sourceKind": "runtime-summary-artifact",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-06-06T19:47:20Z",
+          "status": "observed",
+          "value": 1.0
         }
       ],
       "objects_destroyed": [
@@ -91721,7 +93642,7 @@
           "instrumented": true,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91735,6 +93656,13 @@
             "worldId": "persistent"
           },
           "sourceKind": "runtime-summary-artifact",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
+          "sampledAt": "2026-06-06T19:47:20Z",
           "status": "not observed",
           "value": null
         }
@@ -91758,7 +93686,7 @@
           "instrumented": false,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91772,6 +93700,13 @@
             "worldId": "persistent"
           },
           "sourceKind": "runtime-summary-artifact",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-06-06T19:47:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -91795,7 +93730,7 @@
           "instrumented": true,
           "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91811,6 +93746,13 @@
           "sourceKind": "runtime-summary-artifact",
           "status": "observed",
           "value": 0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-06-06T19:47:20Z",
+          "status": "observed",
+          "value": 0.0
         }
       ],
       "owned_rooms": [
@@ -91832,7 +93774,7 @@
           "instrumented": true,
           "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91848,6 +93790,13 @@
           "sourceKind": "runtime-summary-artifact",
           "status": "observed",
           "value": 3
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-06-06T19:47:20Z",
+          "status": "observed",
+          "value": 3.0
         }
       ],
       "reserved_remote_rooms": [
@@ -91869,7 +93818,7 @@
           "instrumented": false,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91883,6 +93832,13 @@
             "worldId": "persistent"
           },
           "sourceKind": "runtime-summary-artifact",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-06-06T19:47:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -91906,7 +93862,7 @@
           "instrumented": false,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91920,6 +93876,13 @@
             "worldId": "persistent"
           },
           "sourceKind": "runtime-summary-artifact",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-06-06T19:47:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -91943,7 +93906,7 @@
           "instrumented": true,
           "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91959,6 +93922,13 @@
           "sourceKind": "runtime-summary-artifact",
           "status": "observed",
           "value": 1
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-06-06T19:47:20Z",
+          "status": "observed",
+          "value": 1.0
         }
       ],
       "source_count": [
@@ -91980,7 +93950,7 @@
           "instrumented": true,
           "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -91996,6 +93966,13 @@
           "sourceKind": "runtime-summary-artifact",
           "status": "observed",
           "value": 4
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-06-06T19:47:20Z",
+          "status": "observed",
+          "value": 4.0
         }
       ],
       "spawn_queue_pressure": [
@@ -92017,7 +93994,7 @@
           "instrumented": false,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -92031,6 +94008,13 @@
             "worldId": "persistent"
           },
           "sourceKind": "runtime-summary-artifact",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-06-06T19:47:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -92054,7 +94038,7 @@
           "instrumented": false,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -92068,6 +94052,13 @@
             "worldId": "persistent"
           },
           "sourceKind": "runtime-summary-artifact",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-06-06T19:47:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -92091,7 +94082,7 @@
           "instrumented": true,
           "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -92106,7 +94097,14 @@
           },
           "sourceKind": "runtime-summary-artifact",
           "status": "observed",
-          "value": 8307
+          "value": 10835
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-06-06T19:47:20Z",
+          "status": "observed",
+          "value": 10835.0
         }
       ],
       "stored_energy_delta": [
@@ -92128,7 +94126,7 @@
           "instrumented": true,
           "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -92144,6 +94142,13 @@
           "sourceKind": "runtime-summary-artifact",
           "status": "observed",
           "value": 0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-06-06T19:47:20Z",
+          "status": "observed",
+          "value": 0.0
         }
       ],
       "telemetry_silence_minutes": [
@@ -92165,7 +94170,7 @@
           "instrumented": false,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -92179,6 +94184,13 @@
             "worldId": "persistent"
           },
           "sourceKind": "runtime-summary-artifact",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-06-06T19:47:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -92202,7 +94214,7 @@
           "instrumented": true,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -92216,6 +94228,13 @@
             "worldId": "persistent"
           },
           "sourceKind": "runtime-summary-artifact",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
+          "sampledAt": "2026-06-06T19:47:20Z",
           "status": "not observed",
           "value": null
         }
@@ -92239,7 +94258,7 @@
           "instrumented": true,
           "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -92254,7 +94273,14 @@
           },
           "sourceKind": "runtime-summary-artifact",
           "status": "observed",
-          "value": 996
+          "value": 1626
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-06-06T19:47:20Z",
+          "status": "observed",
+          "value": 1626.0
         }
       ],
       "worker_recovery_state": [
@@ -92276,7 +94302,7 @@
           "instrumented": false,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-05T20:13:41Z",
+          "sampledAt": "2026-06-06T19:47:19Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -92290,6 +94316,13 @@
             "worldId": "persistent"
           },
           "sourceKind": "runtime-summary-artifact",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-06-06T19:47:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -92386,22 +94419,13 @@
       {
         "items": [
           {
-            "description": "In review \u00b7 Runtime monitor \u00b7 2026-06-05T19:55:06Z P0: Populate creep-memory worker evidence in runtime summa...",
+            "description": "Ready \u00b7 Runtime monitor \u00b7 2026-06-06T05:00Z fresh postmerge monitor: alert=false health ok at tick 1849304; p...",
             "domain": "Runtime monitor",
-            "number": 1703,
-            "priority": "P0",
-            "status": "In review",
-            "title": "#1703 P0: Populate creep-memory worker evidence in runtime summaries",
-            "url": "https://github.com/lanyusea/screeps/issues/1703"
-          },
-          {
-            "description": "In review \u00b7 Runtime monitor \u00b7 PR #1708 opened at b084f670; issue body gate passed; controller verification PA...",
-            "domain": "Runtime monitor",
-            "number": 1708,
-            "priority": "P0",
-            "status": "In review",
-            "title": "#1708 fix: preserve runtime worker evidence in summaries",
-            "url": "https://github.com/lanyusea/screeps/pull/1708"
+            "number": 1726,
+            "priority": "P1",
+            "status": "Ready",
+            "title": "#1726 Runtime alert: E29N55 rampart damage unsuppressed at 35,29",
+            "url": "https://github.com/lanyusea/screeps/issues/1726"
           }
         ],
         "title": "Runtime monitor"
@@ -92415,23 +94439,13 @@
         "title": "Bot capability"
       },
       {
-        "items": [
-          {
-            "description": "Backlog \u00b7 Combat \u00b7 2026-05-31T16:55Z state-audit repair: issue has blocked label and is not executable until...",
-            "domain": "Combat",
-            "number": 1528,
-            "priority": "P1",
-            "status": "Backlog",
-            "title": "#1528 P1: Build first E29N56 tower after RCL4 unlock",
-            "url": "https://github.com/lanyusea/screeps/issues/1528"
-          }
-        ],
+        "items": [],
         "title": "Combat"
       },
       {
         "items": [
           {
-            "description": "In progress \u00b7 Territory/Economy \u00b7 2026-06-05 02:04 +08 CPU acceptance remains open: latest runtime-summary-co...",
+            "description": "In progress \u00b7 Territory/Economy \u00b7 2026-06-06T05:28Z: CPU still degraded; console tick 1849538 bucket=1845 use...",
             "domain": "Territory/Economy",
             "number": 1490,
             "priority": "P0",
@@ -92440,31 +94454,31 @@
             "url": "https://github.com/lanyusea/screeps/issues/1490"
           },
           {
-            "description": "In progress \u00b7 Territory/Economy \u00b7 2026-06-05T18:49Z PR #1702 code is live: official deploy run 27033591689 fo...",
+            "description": "In progress \u00b7 Territory/Economy \u00b7 2026-06-06T19:46Z: #1743 deployed but postdeploy acceptance still failed; r...",
             "domain": "Territory/Economy",
-            "number": 1700,
-            "priority": "P1",
-            "status": "In progress",
-            "title": "#1700 P1: Seasonal E9S28 reserve-first remote mining and road bootstrap",
-            "url": "https://github.com/lanyusea/screeps/issues/1700"
-          },
-          {
-            "description": "Ready \u00b7 Territory/Economy \u00b7 Created from Gameplay Review CLOSED_LOOP_FAILED lines 362-374/430-436; fresh cons...",
-            "domain": "Territory/Economy",
-            "number": 1707,
+            "number": 1715,
             "priority": "P0",
-            "status": "Ready",
-            "title": "#1707 P0: Verify and repair cross-room construction execution gate af...",
-            "url": "https://github.com/lanyusea/screeps/issues/1707"
+            "status": "In progress",
+            "title": "#1715 P0: Fix cross-room construction assignment suppression under wo...",
+            "url": "https://github.com/lanyusea/screeps/issues/1715"
           },
           {
-            "description": "Ready \u00b7 Territory/Economy \u00b7 2026-06-05T18:55Z fresh postdeploy console/runtime alert evidence improved: E29N5...",
+            "description": "In progress \u00b7 Territory/Economy \u00b7 2026-06-05 21:10Z validation refreshed. Latest console runtime-summary-cons...",
             "domain": "Territory/Economy",
             "number": 1664,
             "priority": "P1",
-            "status": "Ready",
+            "status": "In progress",
             "title": "#1664 P1: E29N56 energy buffer recovery follow-up after CPU fix",
             "url": "https://github.com/lanyusea/screeps/issues/1664"
+          },
+          {
+            "description": "In progress \u00b7 Territory/Economy \u00b7 2026-06-06T19:46Z: fresh console shows E29N55 buffer 783 and E29N57 1437; b...",
+            "domain": "Territory/Economy",
+            "number": 1738,
+            "priority": "P1",
+            "status": "In progress",
+            "title": "#1738 P1: Recover energy buffer collapse and construction unblock aft...",
+            "url": "https://github.com/lanyusea/screeps/issues/1738"
           }
         ],
         "title": "Territory/Economy"
@@ -92476,7 +94490,7 @@
       {
         "items": [
           {
-            "description": "In progress \u00b7 RL flywheel \u00b7 2026-06-05T16:36Z: #1698 known_hosts hardening merged; Loop A local training comp...",
+            "description": "In progress \u00b7 RL flywheel \u00b7 2026-06-06T17:00Z: stuck local runner PID 3701954 was terminated after diagnostic...",
             "domain": "RL flywheel",
             "number": 1032,
             "priority": "P0",
@@ -92485,7 +94499,7 @@
             "url": "https://github.com/lanyusea/screeps/issues/1032"
           },
           {
-            "description": "In progress \u00b7 RL flywheel \u00b7 2026-06-05T16:36Z: #1698/#1681 known_hosts hardening merged; latest tencent-pg-20...",
+            "description": "In progress \u00b7 RL flywheel \u00b7 2026-06-06T14:42Z: latest Tencent summaries through tencent-pg-20260606t144004z a...",
             "domain": "RL flywheel",
             "number": 1233,
             "priority": "P0",
@@ -92494,7 +94508,7 @@
             "url": "https://github.com/lanyusea/screeps/issues/1233"
           },
           {
-            "description": "In progress \u00b7 RL flywheel \u00b7 2026-06-05T16:22Z conclusion registry parsed: total 17, OPEN=1 ACTIONED=3 VALIDAT...",
+            "description": "In progress \u00b7 RL flywheel \u00b7 2026-06-05T22:33Z conclusion-registry.json updated artifact-first: total 17, CLOS...",
             "domain": "RL flywheel",
             "number": 1543,
             "priority": "P0",
@@ -92503,19 +94517,29 @@
             "url": "https://github.com/lanyusea/screeps/issues/1543"
           },
           {
-            "description": "In progress \u00b7 RL flywheel \u00b7 2026-06-05T16:15Z Loop A completed local trusted gradient but rewardDecisionId re...",
+            "description": "In progress \u00b7 RL flywheel \u00b7 2026-06-05T22:30Z: rewardDecisionId now present in manual Loop A artifact (RD-AUT...",
             "domain": "RL flywheel",
-            "number": 1566,
+            "number": 1583,
             "priority": "P0",
             "status": "In progress",
-            "title": "#1566 P0: Repair RL multi-tier objective activation proof before paid...",
-            "url": "https://github.com/lanyusea/screeps/issues/1566"
+            "title": "#1583 P0: Land first bounded RL live canary from fresh-gate candidate",
+            "url": "https://github.com/lanyusea/screeps/issues/1583"
           }
         ],
         "title": "RL flywheel"
       },
       {
-        "items": [],
+        "items": [
+          {
+            "description": "In review \u00b7 Docs/process \u00b7 2026-06-06T18:04Z live audit repaired stale evidence: PR #1728 head b5dce126 is BE...",
+            "domain": "Docs/process",
+            "number": 1728,
+            "priority": "P2",
+            "status": "In review",
+            "title": "#1728 chore(roadmap): refresh Pages artifacts",
+            "url": "https://github.com/lanyusea/screeps/pull/1728"
+          }
+        ],
         "title": "Docs/process"
       }
     ],
@@ -92523,19 +94547,18 @@
     "kpiCards": [
       {
         "dates": [
-          "5/31",
           "6/1",
           "6/2",
           "6/3",
           "6/4",
           "6/5",
-          "6/6"
+          "6/6",
+          "6/7"
         ],
-        "footer": "History collecting (2/7 days observed; insufficient for a complete 7d trend); missing buckets stay blank.",
+        "footer": "History collecting (3/7 days observed; insufficient for a complete 7d trend); missing buckets stay blank.",
         "history": {
           "insufficient": true,
           "missingDateLabels": [
-            "5/31",
             "6/1",
             "6/2",
             "6/3",
@@ -92543,9 +94566,10 @@
           ],
           "observedDateLabels": [
             "6/5",
-            "6/6"
+            "6/6",
+            "6/7"
           ],
-          "observedDays": 2,
+          "observedDays": 3,
           "source": {
             "runtimeArtifacts": {
               "dailyBucketDays": 1,
@@ -92591,7 +94615,7 @@
               "missing",
               "missing",
               "missing",
-              "missing",
+              "observed",
               "observed",
               "observed"
             ],
@@ -92600,7 +94624,7 @@
               null,
               null,
               null,
-              null,
+              3,
               3,
               3
             ],
@@ -92615,7 +94639,7 @@
               "missing",
               "missing",
               "missing",
-              "missing",
+              "observed",
               "observed",
               "observed"
             ],
@@ -92624,7 +94648,7 @@
               null,
               null,
               null,
-              null,
+              15,
               15,
               15
             ],
@@ -92640,7 +94664,7 @@
               "missing",
               "missing",
               "missing",
-              "missing",
+              "observed",
               "observed",
               "observed"
             ],
@@ -92649,7 +94673,7 @@
               null,
               null,
               null,
-              null,
+              0,
               0,
               0
             ],
@@ -92666,19 +94690,18 @@
       },
       {
         "dates": [
-          "5/31",
           "6/1",
           "6/2",
           "6/3",
           "6/4",
           "6/5",
-          "6/6"
+          "6/6",
+          "6/7"
         ],
-        "footer": "History collecting (2/7 days observed; insufficient for a complete 7d trend); missing buckets stay blank.",
+        "footer": "History collecting (3/7 days observed; insufficient for a complete 7d trend); missing buckets stay blank.",
         "history": {
           "insufficient": true,
           "missingDateLabels": [
-            "5/31",
             "6/1",
             "6/2",
             "6/3",
@@ -92686,9 +94709,10 @@
           ],
           "observedDateLabels": [
             "6/5",
-            "6/6"
+            "6/6",
+            "6/7"
           ],
-          "observedDays": 2,
+          "observedDays": 3,
           "source": {
             "runtimeArtifacts": {
               "dailyBucketDays": 1,
@@ -92722,7 +94746,7 @@
           "windowDays": 7
         },
         "key": "resources",
-        "max": 9000,
+        "max": 20000,
         "pill": "energy",
         "series": [
           {
@@ -92734,7 +94758,7 @@
               "missing",
               "missing",
               "missing",
-              "missing",
+              "observed",
               "observed",
               "observed"
             ],
@@ -92743,9 +94767,9 @@
               null,
               null,
               null,
-              null,
               6834,
-              8307
+              8307,
+              10835
             ],
             "width": 2
           },
@@ -92758,7 +94782,7 @@
               "missing",
               "missing",
               "missing",
-              "missing",
+              "not observed",
               "not observed",
               "not observed"
             ],
@@ -92783,7 +94807,7 @@
               "missing",
               "missing",
               "missing",
-              "missing",
+              "observed",
               "observed",
               "observed"
             ],
@@ -92792,9 +94816,9 @@
               null,
               null,
               null,
-              null,
               1404,
-              996
+              996,
+              1626
             ],
             "width": 3
           }
@@ -92802,26 +94826,25 @@
         "subtitle": "stored energy \u00b7 harvest delta \u00b7 carried energy",
         "ticks": [
           0,
-          4500.0,
-          9000
+          10000.0,
+          20000
         ],
         "title": "Resources"
       },
       {
         "dates": [
-          "5/31",
           "6/1",
           "6/2",
           "6/3",
           "6/4",
           "6/5",
-          "6/6"
+          "6/6",
+          "6/7"
         ],
-        "footer": "History collecting (2/7 days observed; insufficient for a complete 7d trend); missing buckets stay blank.",
+        "footer": "History collecting (3/7 days observed; insufficient for a complete 7d trend); missing buckets stay blank.",
         "history": {
           "insufficient": true,
           "missingDateLabels": [
-            "5/31",
             "6/1",
             "6/2",
             "6/3",
@@ -92829,9 +94852,10 @@
           ],
           "observedDateLabels": [
             "6/5",
-            "6/6"
+            "6/6",
+            "6/7"
           ],
-          "observedDays": 2,
+          "observedDays": 3,
           "source": {
             "runtimeArtifacts": {
               "dailyBucketDays": 1,
@@ -92877,7 +94901,7 @@
               "missing",
               "missing",
               "missing",
-              "missing",
+              "not instrumented",
               "not instrumented",
               "not instrumented"
             ],
@@ -92901,7 +94925,7 @@
               "missing",
               "missing",
               "missing",
-              "missing",
+              "observed",
               "observed",
               "observed"
             ],
@@ -92910,7 +94934,7 @@
               null,
               null,
               null,
-              null,
+              0,
               0,
               0
             ],
@@ -92926,7 +94950,7 @@
               "missing",
               "missing",
               "missing",
-              "missing",
+              "not instrumented",
               "not instrumented",
               "not instrumented"
             ],
@@ -92953,28 +94977,28 @@
     ],
     "processCards": [
       {
-        "delta": "+4",
+        "delta": "+21",
         "detail": "git rev-list --count HEAD",
         "label": "Commits",
-        "rawValue": 1007,
+        "rawValue": 1028,
         "source": "git rev-list --count HEAD",
-        "value": 1007
+        "value": 1028
       },
       {
-        "delta": "+8",
+        "delta": "+12",
         "detail": "23 open",
         "label": "Issues",
-        "rawValue": 823,
+        "rawValue": 835,
         "source": "github",
-        "value": 823
+        "value": 835
       },
       {
-        "delta": "+6",
-        "detail": "868 merged",
+        "delta": "+21",
+        "detail": "889 merged",
         "label": "PRs",
-        "rawValue": 888,
+        "rawValue": 909,
         "source": "github",
-        "value": 888
+        "value": 909
       },
       {
         "delta": "n/a",
@@ -93002,8 +95026,8 @@
           ],
           "window": {
             "days": 7,
-            "end": "2026-06-05T20:13:41Z",
-            "start": "2026-05-29T20:13:41Z"
+            "end": "2026-06-06T19:47:20Z",
+            "start": "2026-05-30T19:47:20Z"
           }
         },
         "source": "unavailable",
@@ -93035,8 +95059,8 @@
           ],
           "window": {
             "days": 7,
-            "end": "2026-06-05T20:13:41Z",
-            "start": "2026-05-29T20:13:41Z"
+            "end": "2026-06-06T19:47:20Z",
+            "start": "2026-05-30T19:47:20Z"
           }
         },
         "source": "unavailable",
@@ -93068,8 +95092,8 @@
           ],
           "window": {
             "days": 7,
-            "end": "2026-06-05T20:13:41Z",
-            "start": "2026-05-29T20:13:41Z"
+            "end": "2026-06-06T19:47:20Z",
+            "start": "2026-05-30T19:47:20Z"
           }
         },
         "source": "local cache",
@@ -93101,8 +95125,8 @@
           ],
           "window": {
             "days": 7,
-            "end": "2026-06-05T20:13:41Z",
-            "start": "2026-05-29T20:13:41Z"
+            "end": "2026-06-06T19:47:20Z",
+            "start": "2026-05-30T19:47:20Z"
           }
         },
         "source": "local cache",
@@ -93134,8 +95158,8 @@
           ],
           "window": {
             "days": 7,
-            "end": "2026-06-05T20:13:41Z",
-            "start": "2026-05-29T20:13:41Z"
+            "end": "2026-06-06T19:47:20Z",
+            "start": "2026-05-30T19:47:20Z"
           }
         },
         "source": "local cache",
@@ -93170,8 +95194,8 @@
           ],
           "window": {
             "days": 7,
-            "end": "2026-06-05T20:13:41Z",
-            "start": "2026-05-29T20:13:41Z"
+            "end": "2026-06-06T19:47:20Z",
+            "start": "2026-05-30T19:47:20Z"
           }
         },
         "source": "local cache",
@@ -93203,8 +95227,8 @@
           ],
           "window": {
             "days": 7,
-            "end": "2026-06-05T20:13:41Z",
-            "start": "2026-05-29T20:13:41Z"
+            "end": "2026-06-06T19:47:20Z",
+            "start": "2026-05-30T19:47:20Z"
           }
         },
         "source": "local cache",
@@ -93237,16 +95261,16 @@
         "url": "https://github.com/lanyusea/screeps/issues/22"
       },
       {
-        "activeItems": 2,
+        "activeItems": 1,
         "domain": "Runtime monitor",
-        "doneItems": 91,
+        "doneItems": 93,
         "goal": "Turn live Screeps telemetry into reliable KPI, alert, and report evidence.",
-        "next": "Current: #1703 In review - P0: Populate creep-memory worker evidence in runtime summaries",
-        "progress": 98,
-        "status": "93 Project items \u00b7 2 active \u00b7 91 done",
+        "next": "Current: #1726 Ready - 2026-06-06T05:00Z fresh postmerge monitor: alert=false health ok at ti...",
+        "progress": 99,
+        "status": "94 Project items \u00b7 1 active \u00b7 93 done",
         "title": "Runtime monitor",
-        "totalItems": 93,
-        "url": "https://github.com/lanyusea/screeps/issues/1703"
+        "totalItems": 94,
+        "url": "https://github.com/lanyusea/screeps/issues/1726"
       },
       {
         "activeItems": 0,
@@ -93273,27 +95297,27 @@
         "url": "https://github.com/lanyusea/screeps/issues/362"
       },
       {
-        "activeItems": 1,
+        "activeItems": 0,
         "domain": "Combat",
-        "doneItems": 46,
+        "doneItems": 47,
         "goal": "Protect survival, hostile response, and defense/combat readiness.",
-        "next": "Current: #1528 Backlog - 2026-05-31T16:55Z state-audit repair: issue has blocked label and is...",
-        "progress": 98,
-        "status": "47 Project items \u00b7 1 active \u00b7 46 done",
+        "next": "No active item; latest tracked: #977 Done - Post-closure 2026-05-12T23:25Z: live alert=false,...",
+        "progress": 100,
+        "status": "47 Project items \u00b7 0 active \u00b7 47 done",
         "title": "Combat",
         "totalItems": 47,
-        "url": "https://github.com/lanyusea/screeps/issues/1528"
+        "url": "https://github.com/lanyusea/screeps/issues/977"
       },
       {
-        "activeItems": 4,
+        "activeItems": 5,
         "domain": "Territory/Economy",
-        "doneItems": 288,
+        "doneItems": 299,
         "goal": "Advance expansion, controller pressure, worker efficiency, and resource throughput.",
-        "next": "Current: #1490 In progress - 2026-06-05 02:04 +08 CPU acceptance remains open: latest runtime...",
-        "progress": 99,
-        "status": "292 Project items \u00b7 4 active \u00b7 288 done",
+        "next": "Current: #1490 In progress - 2026-06-06T05:28Z: CPU still degraded; console tick 1849538 buck...",
+        "progress": 98,
+        "status": "304 Project items \u00b7 5 active \u00b7 299 done",
         "title": "Territory/Economy",
-        "totalItems": 292,
+        "totalItems": 304,
         "url": "https://github.com/lanyusea/screeps/issues/1490"
       },
       {
@@ -93309,15 +95333,15 @@
         "url": "https://github.com/lanyusea/screeps/issues/878"
       },
       {
-        "activeItems": 12,
+        "activeItems": 9,
         "domain": "RL flywheel",
-        "doneItems": 388,
+        "doneItems": 404,
         "goal": "Drive offline/simulator/data/training/validation work for safe strategy self-evolution.",
-        "next": "Current: #1032 In progress - 2026-06-05T16:36Z: #1698 known_hosts hardening merged; Loop A lo...",
-        "progress": 97,
-        "status": "400 Project items \u00b7 12 active \u00b7 388 done",
+        "next": "Current: #1032 In progress - 2026-06-06T17:00Z: stuck local runner PID 3701954 was terminated...",
+        "progress": 98,
+        "status": "413 Project items \u00b7 9 active \u00b7 404 done",
         "title": "RL flywheel",
-        "totalItems": 400,
+        "totalItems": 413,
         "url": "https://github.com/lanyusea/screeps/issues/1032"
       }
     ]
@@ -93334,8 +95358,8 @@
       "skippedFileCount": 0
     },
     "window": {
-      "firstTick": 1835607,
-      "latestTick": 1835607
+      "firstTick": 1872645,
+      "latestTick": 1872645
     }
   },
   "schemaVersion": 1,

--- a/docs/roadmap-kpi.sqlite
+++ b/docs/roadmap-kpi.sqlite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6176f6c09132727eeb5edde1a397d655d945fc3d7fae70dbf1e686bee2c2276c
-size 380928
+oid sha256:3a147aa3737fd8f7cbf0196809d4955b2cff75d1ffccb6e5aff8f988fc6d7795
+size 385024


### PR DESCRIPTION
Refreshes the generated roadmap Pages artifacts.

Generated by the scheduled roadmap Pages refresh workflow.

## Universal task Done gate

- [x] Task type: generated documentation artifact refresh.
- [x] Expected observable outcome / named deliverable: refreshed roadmap Pages artifacts in `docs/index.html`, `docs/roadmap-data.json`, and `docs/roadmap-kpi.sqlite` reflect current GitHub Project data.
- [x] Non-goals / accepted substitutes: production bot behavior, official MMO deploy, and gameplay runtime changes are excluded; generated roadmap artifact sync is the accepted deliverable.
- [x] Verification evidence required before Done: GitHub `Verify roadmap Pages contracts` check passed; GitHub `Verify prod TypeScript, Jest, and bundle` check passed; GitHub issue-completion gate validates this PR body.
- [x] Project Evidence / Next action / Blocked by: PR #1728 Project item records In review status, exact head `43bab6fc`, green artifact checks, and no dependency text.
- [x] Post-merge/deploy/runtime proof: merge commit carrying the refreshed docs artifacts is the proof surface; no official MMO deploy is required for docs-only generated artifacts.
- [x] Named deliverable proof: PR file list contains `docs/index.html`, `docs/roadmap-data.json`, and `docs/roadmap-kpi.sqlite` refreshed by the scheduled roadmap Pages workflow.
