### PR TITLE
rl: recover reward decision provenance in ledgers

### DIFF
--- a/scripts/screeps_rl_control_loop_ledgers.py
+++ b/scripts/screeps_rl_control_loop_ledgers.py
@@ -29,6 +29,8 @@ DEFAULT_ARTIFACT_ROOT = Path("runtime-artifacts")
 DEFAULT_CONTROL_LOOP_DIR = Path("runtime-artifacts/rl-control-loop")
 DEFAULT_MAX_FILES_PER_ROOT = 25
 DEFAULT_STDOUT_BYTES = 4096
+MAX_JSON_ARTIFACT_BYTES = 8 * 1024 * 1024
+MAX_JSON_ARTIFACT_DEPTH = 100
 E1_FULL_GATE_MIN_SAMPLE_COUNT = 200
 E1_GATE_STALE_FRESHNESS_SECONDS = 86400
 HISTORICAL_CONTEXT_ISSUES = [879, 893, 1589]
@@ -47,6 +49,8 @@ REWARD_DECISION_NULL_TEXT_MARKERS = (
     "null value breaks downstream",
 )
 POLICY_METRIC_CATEGORIES = ("territory", "resources", "combat", "reliability", "logistics")
+JSON_DEPTH_LIMIT_MARKER = "[json depth limit exceeded]"
+JSON_CIRCULAR_REFERENCE_MARKER = "[circular reference omitted]"
 
 JsonObject = dict[str, Any]
 
@@ -88,25 +92,67 @@ def write_json_atomic(path: Path, payload: Any) -> None:
 
 
 def json_safe(value: Any) -> Any:
+    return json_safe_bounded(value, depth=0, active=set())
+
+
+def json_safe_bounded(value: Any, *, depth: int, active: set[int]) -> Any:
+    if depth > MAX_JSON_ARTIFACT_DEPTH:
+        return JSON_DEPTH_LIMIT_MARKER
     if isinstance(value, Path):
         return value.as_posix()
     if isinstance(value, datetime):
         return value.isoformat().replace("+00:00", "Z")
     if isinstance(value, dict):
-        return {str(key): json_safe(item) for key, item in value.items()}
+        object_id = id(value)
+        if object_id in active:
+            return JSON_CIRCULAR_REFERENCE_MARKER
+        active.add(object_id)
+        try:
+            return {str(key): json_safe_bounded(item, depth=depth + 1, active=active) for key, item in value.items()}
+        finally:
+            active.remove(object_id)
     if isinstance(value, (list, tuple)):
-        return [json_safe(item) for item in value]
+        object_id = id(value)
+        if object_id in active:
+            return JSON_CIRCULAR_REFERENCE_MARKER
+        active.add(object_id)
+        try:
+            return [json_safe_bounded(item, depth=depth + 1, active=active) for item in value]
+        finally:
+            active.remove(object_id)
     return value
+
+
+def json_depth_within_limit(value: Any) -> bool:
+    stack: list[tuple[Any, int]] = [(value, 0)]
+    while stack:
+        item, depth = stack.pop()
+        if depth > MAX_JSON_ARTIFACT_DEPTH:
+            return False
+        if isinstance(item, dict):
+            stack.extend((child, depth + 1) for child in item.values())
+        elif isinstance(item, list):
+            stack.extend((child, depth + 1) for child in item)
+    return True
 
 
 def load_json(path: Path | None) -> JsonObject | None:
     if path is None:
         return None
     try:
-        parsed = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+        with path.open("rb") as handle:
+            raw = handle.read(MAX_JSON_ARTIFACT_BYTES + 1)
+    except OSError:
         return None
-    return parsed if isinstance(parsed, dict) else None
+    if len(raw) > MAX_JSON_ARTIFACT_BYTES:
+        return None
+    try:
+        parsed = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError):
+        return None
+    if not isinstance(parsed, dict) or not json_depth_within_limit(parsed):
+        return None
+    return parsed
 
 
 def as_dict(value: Any) -> JsonObject:
@@ -1905,12 +1951,35 @@ def reward_decision_missing_regression(
 
 
 def reward_decision_null_text_present(value: Any) -> bool:
+    return reward_decision_null_text_present_bounded(value, depth=0, active=set())
+
+
+def reward_decision_null_text_present_bounded(value: Any, *, depth: int, active: set[int]) -> bool:
+    if depth > MAX_JSON_ARTIFACT_DEPTH:
+        return False
     if isinstance(value, str):
         return any(marker in value for marker in REWARD_DECISION_NULL_TEXT_MARKERS)
-    if isinstance(value, list):
-        return any(reward_decision_null_text_present(item) for item in value)
+    if isinstance(value, (list, tuple)):
+        object_id = id(value)
+        if object_id in active:
+            return False
+        active.add(object_id)
+        try:
+            return any(reward_decision_null_text_present_bounded(item, depth=depth + 1, active=active) for item in value)
+        finally:
+            active.remove(object_id)
     if isinstance(value, dict):
-        return any(reward_decision_null_text_present(item) for item in value.values())
+        object_id = id(value)
+        if object_id in active:
+            return False
+        active.add(object_id)
+        try:
+            return any(
+                reward_decision_null_text_present_bounded(item, depth=depth + 1, active=active)
+                for item in value.values()
+            )
+        finally:
+            active.remove(object_id)
     return False
 
 
@@ -1926,29 +1995,53 @@ def reward_decision_consistent_text(
     reward_decision_id: str | None,
     reward_decision_artifact_path: str | None,
     field: str,
+    _depth: int = 0,
+    _active: set[int] | None = None,
 ) -> Any:
+    if _depth > MAX_JSON_ARTIFACT_DEPTH:
+        return value
     if reward_decision_id is None or not reward_decision_null_text_present(value):
         return value
+    if _active is None:
+        _active = set()
     if isinstance(value, dict):
-        return {
-            key: reward_decision_consistent_text(
-                item,
-                reward_decision_id=reward_decision_id,
-                reward_decision_artifact_path=reward_decision_artifact_path,
-                field=field if field == "rolloutGate" and key == "reason" else f"{field}.{key}",
-            )
-            for key, item in value.items()
-        }
-    if isinstance(value, list):
-        return [
-            reward_decision_consistent_text(
-                item,
-                reward_decision_id=reward_decision_id,
-                reward_decision_artifact_path=reward_decision_artifact_path,
-                field=f"{field}[]",
-            )
-            for item in value
-        ]
+        object_id = id(value)
+        if object_id in _active:
+            return value
+        _active.add(object_id)
+        try:
+            return {
+                key: reward_decision_consistent_text(
+                    item,
+                    reward_decision_id=reward_decision_id,
+                    reward_decision_artifact_path=reward_decision_artifact_path,
+                    field=field if field == "rolloutGate" and key == "reason" else f"{field}.{key}",
+                    _depth=_depth + 1,
+                    _active=_active,
+                )
+                for key, item in value.items()
+            }
+        finally:
+            _active.remove(object_id)
+    if isinstance(value, (list, tuple)):
+        object_id = id(value)
+        if object_id in _active:
+            return value
+        _active.add(object_id)
+        try:
+            return [
+                reward_decision_consistent_text(
+                    item,
+                    reward_decision_id=reward_decision_id,
+                    reward_decision_artifact_path=reward_decision_artifact_path,
+                    field=f"{field}[]",
+                    _depth=_depth + 1,
+                    _active=_active,
+                )
+                for item in value
+            ]
+        finally:
+            _active.remove(object_id)
     if not isinstance(value, str):
         return value
     resolved = reward_decision_resolved_reference(reward_decision_id, reward_decision_artifact_path)

--- a/scripts/screeps_rl_control_loop_ledgers.py
+++ b/scripts/screeps_rl_control_loop_ledgers.py
@@ -892,6 +892,29 @@ def latest_root_training_report_payload_from_summary(
     return normalize_root_training_report_payload(path, payload)
 
 
+def training_payload_for_evidence_windows(
+    training_payload: JsonObject | None,
+    root_training_payload: JsonObject | None,
+) -> JsonObject | None:
+    if training_payload is None:
+        return root_training_payload
+    if root_training_payload is None:
+        return training_payload
+
+    training_report_ids = set(referenced_training_report_ids(as_dict(training_payload)))
+    root_report_ids = set(referenced_training_report_ids(as_dict(root_training_payload)))
+    if training_report_ids and root_report_ids and training_report_ids.intersection(root_report_ids):
+        return root_training_payload
+
+    training_candidate = training_evidence_candidate_policy_id(as_dict(training_payload))
+    root_candidate = training_evidence_candidate_policy_id(as_dict(root_training_payload))
+    if not training_report_ids and training_candidate is None:
+        return root_training_payload
+    if training_candidate is not None and training_candidate == root_candidate:
+        return root_training_payload
+    return training_payload
+
+
 def selected_scorecard_comparison(training_payload: JsonObject | None) -> JsonObject:
     payload = as_dict(training_payload)
     scorecard_set = as_dict(payload.get("candidateScorecards"))
@@ -1982,7 +2005,7 @@ def build_policy_advantage(
     previous = latest_artifact_payload(summary, "policyAdvantage", repo_root)
     training_payload = normalized_latest_training_payload(summary, artifact_root, repo_root)
     root_training_payload = latest_root_training_report_payload_from_summary(summary, artifact_root, repo_root)
-    evidence_training_payload = root_training_payload or training_payload
+    evidence_training_payload = training_payload_for_evidence_windows(training_payload, root_training_payload)
     policy = as_dict(summary.get("policy"))
     training = as_dict(summary.get("training"))
     git = git_metadata(repo_root)

--- a/scripts/screeps_rl_control_loop_ledgers.py
+++ b/scripts/screeps_rl_control_loop_ledgers.py
@@ -35,6 +35,17 @@ HISTORICAL_CONTEXT_ISSUES = [879, 893, 1589]
 REWARD_DECISION_SOURCE_ISSUE = 1690
 REWARD_DECISION_RELATED_ISSUES = [907, 924]
 REWARD_DECISION_PLACEHOLDER_CANDIDATE_IDS = {"NO_STABLE_CANDIDATE", "N/A", "UNKNOWN"}
+REWARD_DECISION_NULL_TEXT_MARKERS = (
+    "rewardDecisionId=null",
+    "rewardDecisionId is null",
+    "rewardDecisionId was null",
+    "currently null regression",
+    "RESTORE rewardDecisionId",
+    "latest ledger shows null",
+    "rewardDecisionId_null_regression",
+    "rewardDecisionId_missing",
+    "null value breaks downstream",
+)
 POLICY_METRIC_CATEGORIES = ("territory", "resources", "combat", "reliability", "logistics")
 
 JsonObject = dict[str, Any]
@@ -533,11 +544,125 @@ def normalize_root_training_report_payload(path: Path, payload: JsonObject) -> J
     return normalized
 
 
+def training_evidence_candidate_policy_id(payload: JsonObject) -> str | None:
+    policy_update = as_dict(payload.get("policyUpdate"))
+    artifacts = as_dict(payload.get("trainingArtifacts"))
+    metrics_fields = as_dict(payload.get("metricsFields"))
+    candidate_policy_ids = as_list(artifacts.get("candidatePolicyIds"))
+    return candidate_policy_text(
+        metrics_fields.get("candidatePolicyId"),
+        payload.get("policyUpdateCandidatePolicyId"),
+        payload.get("candidatePolicyId"),
+        as_dict(policy_update.get("nextCandidatePolicy")).get("candidatePolicyId"),
+        candidate_policy_ids[-1] if candidate_policy_ids else None,
+        as_dict(payload.get("candidateScorecard")).get("candidateStrategyId"),
+    )
+
+
+def referenced_training_report_ids(payload: JsonObject) -> list[str]:
+    artifacts = as_dict(payload.get("trainingArtifacts"))
+    metrics_fields = as_dict(payload.get("metricsFields"))
+    return unique_text_values(
+        [
+            payload.get("trainingReportId"),
+            as_list(payload.get("trainingReportIds")),
+            as_list(artifacts.get("trainingReportIds")),
+            as_list(metrics_fields.get("trainingReportIds")),
+        ]
+    )
+
+
+def root_training_report_path_for_id(artifact_root: Path, report_id: str) -> Path | None:
+    if "/" in report_id or "\\" in report_id:
+        return None
+    return artifact_root / "rl-training" / f"{report_id}.json"
+
+
+def referenced_root_training_report_payload(payload: JsonObject, artifact_root: Path) -> JsonObject | None:
+    payload_candidate = training_evidence_candidate_policy_id(payload)
+    for report_id in reversed(referenced_training_report_ids(payload)):
+        report_path = root_training_report_path_for_id(artifact_root, report_id)
+        if report_path is None:
+            continue
+        report_payload = load_json(report_path)
+        if report_payload is None or not is_root_rl_training_report(report_path, artifact_root, report_payload):
+            continue
+        normalized = normalize_root_training_report_payload(report_path, report_payload)
+        report_candidate = training_evidence_candidate_policy_id(normalized)
+        if payload_candidate is not None and report_candidate is not None and payload_candidate != report_candidate:
+            continue
+        return normalized
+    return None
+
+
+def fill_missing_mapping_values(target: JsonObject, source: JsonObject, keys: Sequence[str]) -> JsonObject:
+    merged = dict(target)
+    for key in keys:
+        source_value = source.get(key)
+        if source_value is None:
+            continue
+        target_value = merged.get(key)
+        if target_value is None or target_value == [] or target_value == {}:
+            merged[key] = source_value
+    return merged
+
+
+def enrich_training_ledger_from_referenced_report(payload: JsonObject, artifact_root: Path) -> JsonObject:
+    report_payload = referenced_root_training_report_payload(payload, artifact_root)
+    if report_payload is None:
+        return payload
+    enriched = fill_missing_mapping_values(
+        payload,
+        report_payload,
+        (
+            "policyUpdateCandidatePolicyId",
+            "policyUpdateArtifactPath",
+            "policyUpdate",
+            "policyUpdatePromotionGate",
+            "scorecardId",
+            "scorecardArtifactPath",
+            "candidateScorecard",
+            "candidateScorecards",
+            "trueGradient",
+            "gradientStable",
+            "trustedGradientUpdate",
+            "highVariance",
+        ),
+    )
+    enriched["trainingArtifacts"] = fill_missing_mapping_values(
+        as_dict(payload.get("trainingArtifacts")),
+        as_dict(report_payload.get("trainingArtifacts")),
+        (
+            "experimentCard",
+            "experimentCardPath",
+            "simulatorRunIds",
+            "trainingReportIds",
+            "candidatePolicyIds",
+            "latestTrainingReport",
+            "policyUpdateArtifactPath",
+            "scorecardId",
+            "scorecardArtifactPath",
+        ),
+    )
+    enriched["metricsFields"] = fill_missing_mapping_values(
+        as_dict(payload.get("metricsFields")),
+        as_dict(report_payload.get("metricsFields")),
+        (
+            "candidatePolicyId",
+            "simulatorRunCount",
+            "simulationTicksPerRun",
+        ),
+    )
+    return enriched
+
+
 def normalize_training_evidence_payload(path: Path | None, artifact_root: Path, payload: JsonObject | None) -> JsonObject | None:
     if payload is None or path is None:
         return payload
     if is_root_rl_training_report(path, artifact_root, payload):
         return normalize_root_training_report_payload(path, payload)
+    if payload.get("type") == TRAINING_LEDGER_TYPE:
+        return enrich_training_ledger_from_referenced_report(payload, artifact_root)
     return payload
 
 
@@ -599,7 +724,13 @@ def latest_training_evidence_artifact(
     candidates: list[static_dashboard.LoadedArtifact] = []
     latest_training = latest_external_dashboard_artifact(bounded_artifacts, "training_ledger")
     if latest_training is not None:
-        candidates.append(latest_training)
+        candidates.append(
+            static_dashboard.LoadedArtifact(
+                path=latest_training.path,
+                payload=normalize_training_evidence_payload(latest_training.path, artifact_root, latest_training.payload) or latest_training.payload,
+                timestamp=latest_training.timestamp,
+            )
+        )
     latest_report, report_scan = latest_root_training_report_artifact(
         artifact_root,
         repo_root,
@@ -741,6 +872,24 @@ def normalized_latest_training_payload(
         artifact_root,
         latest_artifact_payload(summary, "trainingLedger", repo_root),
     )
+
+
+def latest_root_training_report_payload_from_summary(
+    summary: JsonObject,
+    artifact_root: Path,
+    repo_root: Path,
+) -> JsonObject | None:
+    scan = as_dict(as_dict(summary.get("scan")).get("rootTrainingReportScan"))
+    selected = text_value(scan.get("selected"))
+    if selected is None:
+        return None
+    path = Path(selected)
+    if not path.is_absolute():
+        path = repo_root / path
+    payload = load_json(path)
+    if payload is None or not is_root_rl_training_report(path, artifact_root, payload):
+        return None
+    return normalize_root_training_report_payload(path, payload)
 
 
 def selected_scorecard_comparison(training_payload: JsonObject | None) -> JsonObject:
@@ -1380,6 +1529,7 @@ def policy_evidence_windows(
     summary: JsonObject,
     training: JsonObject,
     repo_root: Path,
+    training_payload: JsonObject | None = None,
 ) -> JsonObject:
     previous_windows = as_dict((previous or {}).get("evidenceWindows"))
     windows: JsonObject = dict(previous_windows) if previous_windows else {
@@ -1393,12 +1543,16 @@ def policy_evidence_windows(
         "latestTrainingLedger": latest_artifact_path(summary, "trainingLedger", repo_root),
         "latestPolicyAdvantage": latest_artifact_path(summary, "policyAdvantage", repo_root),
     }
-    windows["trainingReportIds"] = unique_text_values(
-        [
-            as_list(windows.get("trainingReportIds")),
-            training_report_ids_from_training(training),
-        ]
-    )
+    current_training_report_ids = referenced_training_report_ids(as_dict(training_payload))
+    if current_training_report_ids:
+        windows["trainingReportIds"] = current_training_report_ids
+    else:
+        windows["trainingReportIds"] = unique_text_values(
+            [
+                as_list(windows.get("trainingReportIds")),
+                training_report_ids_from_training(training),
+            ]
+        )
     windows["latestTrainingLedger"] = latest_artifact_path(summary, "trainingLedger", repo_root)
     windows["latestPolicyAdvantage"] = latest_artifact_path(summary, "policyAdvantage", repo_root)
     return windows
@@ -1688,6 +1842,111 @@ def policy_regressions(metrics: JsonObject) -> list[JsonObject]:
     return regressions[:8]
 
 
+def reward_decision_missing_regression(
+    *,
+    scorecard: JsonObject,
+    candidate_policy_id: str | None,
+    training_payload: JsonObject | None,
+) -> JsonObject:
+    payload = as_dict(training_payload)
+    artifacts = as_dict(payload.get("trainingArtifacts"))
+    scorecard_id = text_value(scorecard.get("scorecardId"))
+    candidate = candidate_policy_text(candidate_policy_id)
+    if candidate is None:
+        reason = "candidate policy id is missing or placeholder"
+    elif scorecard_id is None:
+        reason = "selected scorecard evidence is missing for the candidate policy"
+    else:
+        reason = "no matching reward decision could be carried or generated for the selected scorecard and candidate"
+    return {
+        "metric": "rewardDecisionId_missing",
+        "severity": "P0",
+        "delta": f"BLOCKED: rewardDecisionId is null because {reason}.",
+        "evidence": {
+            "candidatePolicyId": candidate,
+            "scorecardId": scorecard_id,
+            "scorecardArtifactPath": scorecard.get("scorecardArtifactPath"),
+            "trainingReportIds": referenced_training_report_ids(payload),
+            "policyUpdateArtifactPath": artifacts.get("policyUpdateArtifactPath"),
+            "rewardDecisionId": None,
+        },
+        "trainingFeedback": (
+            "Loop B requires a non-null rewardDecisionId before deployability can pass; "
+            "propagate an exact matching decision or preserve this blocker."
+        ),
+    }
+
+
+def reward_decision_null_text_present(value: Any) -> bool:
+    if isinstance(value, str):
+        return any(marker in value for marker in REWARD_DECISION_NULL_TEXT_MARKERS)
+    if isinstance(value, list):
+        return any(reward_decision_null_text_present(item) for item in value)
+    if isinstance(value, dict):
+        return any(reward_decision_null_text_present(item) for item in value.values())
+    return False
+
+
+def reward_decision_resolved_reference(reward_decision_id: str, reward_decision_artifact_path: str | None) -> str:
+    if reward_decision_artifact_path:
+        return f"rewardDecisionId {reward_decision_id} is available at {reward_decision_artifact_path}"
+    return f"rewardDecisionId {reward_decision_id} is available"
+
+
+def reward_decision_consistent_text(
+    value: Any,
+    *,
+    reward_decision_id: str | None,
+    reward_decision_artifact_path: str | None,
+    field: str,
+) -> Any:
+    if reward_decision_id is None or not isinstance(value, str) or not reward_decision_null_text_present(value):
+        return value
+    resolved = reward_decision_resolved_reference(reward_decision_id, reward_decision_artifact_path)
+    text = value
+    text = text.replace("rewardDecisionId propagated (currently null regression), ", "")
+    text = text.replace(
+        "RESTORE rewardDecisionId provenance \u2014 investigate why latest ledger shows null",
+        f"{resolved}; keep provenance guard active",
+    )
+    if not reward_decision_null_text_present(text):
+        return text
+    if field == "rolloutGate":
+        return (
+            f"BLOCKED. {resolved}; rollout still requires remaining non-reward gates, fresh validation evidence, "
+            "and explicit deployment authorization before any live promotion."
+        )
+    if field == "nextExperimentCardDelta":
+        return (
+            f"{resolved}; continue with remaining non-reward blockers: experiment card/local runner validation, "
+            "gate freshness, and guarded post-fix validation."
+        )
+    return (
+        f"{resolved}; no current missing reward decision blocker remains. Keep remaining rollout and training "
+        "blockers explicit before promotion."
+    )
+
+
+def reward_decision_consistent_training_feedback(
+    feedback: Any,
+    *,
+    reward_decision_id: str | None,
+    reward_decision_artifact_path: str | None,
+) -> Any:
+    if reward_decision_id is None or not isinstance(feedback, dict):
+        return feedback
+    updated = dict(feedback)
+    for key, value in list(updated.items()):
+        if reward_decision_null_text_present(value):
+            updated[key] = reward_decision_consistent_text(
+                value,
+                reward_decision_id=reward_decision_id,
+                reward_decision_artifact_path=reward_decision_artifact_path,
+                field=f"trainingStrategyFeedback.{key}",
+            )
+    return updated
+
+
 def build_policy_advantage(
     *,
     repo_root: Path,
@@ -1700,6 +1959,8 @@ def build_policy_advantage(
     summary = dashboard_summary(repo_root, artifact_root, created_at, max_files_per_root)
     previous = latest_artifact_payload(summary, "policyAdvantage", repo_root)
     training_payload = normalized_latest_training_payload(summary, artifact_root, repo_root)
+    root_training_payload = latest_root_training_report_payload_from_summary(summary, artifact_root, repo_root)
+    evidence_training_payload = root_training_payload or training_payload
     policy = as_dict(summary.get("policy"))
     training = as_dict(summary.get("training"))
     git = git_metadata(repo_root)
@@ -1743,7 +2004,13 @@ def build_policy_advantage(
         policy.get("baseline"),
         "incumbent",
     )
-    evidence_windows = policy_evidence_windows(previous, summary, training, repo_root)
+    evidence_windows = policy_evidence_windows(
+        previous,
+        summary,
+        training,
+        repo_root,
+        evidence_training_payload,
+    )
     carried_reward_decision_id = existing_reward_decision_id(previous, training_payload)
     reward_decision_id, reward_decision_artifact_path = emit_scorecard_reward_decision_if_missing(
         previous_policy=previous,
@@ -1762,6 +2029,53 @@ def build_policy_advantage(
         current_policy_advantage_path=current_policy_advantage_path,
     )
     emitted_reward_decision = carried_reward_decision_id is None and reward_decision_id is not None
+    if reward_decision_id is None:
+        missing_regression = reward_decision_missing_regression(
+            scorecard=scorecard,
+            candidate_policy_id=candidate_policy_id,
+            training_payload=training_payload,
+        )
+        if not any(as_dict(item).get("metric") == missing_regression["metric"] for item in regressions):
+            regressions.append(missing_regression)
+        deployability = "BLOCKED"
+        if str(as_dict(rollout_gate).get("status", "")).upper() not in {"BLOCKED", "HOLD"}:
+            rollout_gate = {
+                "status": "BLOCKED",
+                "reason": missing_regression["delta"],
+                "source": "reward_decision_generation",
+            }
+    else:
+        rollout_gate = reward_decision_consistent_text(
+            rollout_gate,
+            reward_decision_id=reward_decision_id,
+            reward_decision_artifact_path=reward_decision_artifact_path,
+            field="rolloutGate",
+        )
+    training_strategy_feedback = reward_decision_consistent_training_feedback(
+        field_from(
+            previous,
+            "trainingStrategyFeedback",
+            {
+                "rewardChanges": [],
+                "scenarioChanges": ["collect bounded online KPI evidence before promotion"],
+                "dataWeightingChanges": [],
+                "frameworkInstrumentationChanges": [] if training.get("hasComputeEvidence") else ["restore Loop A compute evidence"],
+                "candidateGenerationChanges": [],
+            },
+        ),
+        reward_decision_id=reward_decision_id,
+        reward_decision_artifact_path=reward_decision_artifact_path,
+    )
+    next_experiment_card_delta = reward_decision_consistent_text(
+        field_from(
+            previous,
+            "nextExperimentCardDelta",
+            "Produce a candidate with fresh Loop A compute evidence and a pre/post KPI measurement window.",
+        ),
+        reward_decision_id=reward_decision_id,
+        reward_decision_artifact_path=reward_decision_artifact_path,
+        field="nextExperimentCardDelta",
+    )
 
     return {
         "type": POLICY_ADVANTAGE_TYPE,
@@ -1789,22 +2103,8 @@ def build_policy_advantage(
         "evidenceWindows": evidence_windows,
         "metrics": metrics,
         "regressions": regressions,
-        "trainingStrategyFeedback": field_from(
-            previous,
-            "trainingStrategyFeedback",
-            {
-                "rewardChanges": [],
-                "scenarioChanges": ["collect bounded online KPI evidence before promotion"],
-                "dataWeightingChanges": [],
-                "frameworkInstrumentationChanges": [] if training.get("hasComputeEvidence") else ["restore Loop A compute evidence"],
-                "candidateGenerationChanges": [],
-            },
-        ),
-        "nextExperimentCardDelta": field_from(
-            previous,
-            "nextExperimentCardDelta",
-            "Produce a candidate with fresh Loop A compute evidence and a pre/post KPI measurement window.",
-        ),
+        "trainingStrategyFeedback": training_strategy_feedback,
+        "nextExperimentCardDelta": next_experiment_card_delta,
         "rewardDecisionId": reward_decision_id,
         "rewardDecisionArtifactPath": reward_decision_artifact_path,
         "scorecardId": scorecard.get("scorecardId"),

--- a/scripts/screeps_rl_control_loop_ledgers.py
+++ b/scripts/screeps_rl_control_loop_ledgers.py
@@ -1900,7 +1900,29 @@ def reward_decision_consistent_text(
     reward_decision_artifact_path: str | None,
     field: str,
 ) -> Any:
-    if reward_decision_id is None or not isinstance(value, str) or not reward_decision_null_text_present(value):
+    if reward_decision_id is None or not reward_decision_null_text_present(value):
+        return value
+    if isinstance(value, dict):
+        return {
+            key: reward_decision_consistent_text(
+                item,
+                reward_decision_id=reward_decision_id,
+                reward_decision_artifact_path=reward_decision_artifact_path,
+                field=field if field == "rolloutGate" and key == "reason" else f"{field}.{key}",
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            reward_decision_consistent_text(
+                item,
+                reward_decision_id=reward_decision_id,
+                reward_decision_artifact_path=reward_decision_artifact_path,
+                field=f"{field}[]",
+            )
+            for item in value
+        ]
+    if not isinstance(value, str):
         return value
     resolved = reward_decision_resolved_reference(reward_decision_id, reward_decision_artifact_path)
     text = value

--- a/scripts/screeps_rl_control_loop_ledgers.py
+++ b/scripts/screeps_rl_control_loop_ledgers.py
@@ -907,10 +907,7 @@ def training_payload_for_evidence_windows(
         return root_training_payload
 
     training_candidate = training_evidence_candidate_policy_id(as_dict(training_payload))
-    root_candidate = training_evidence_candidate_policy_id(as_dict(root_training_payload))
     if not training_report_ids and training_candidate is None:
-        return root_training_payload
-    if training_candidate is not None and training_candidate == root_candidate:
         return root_training_payload
     return training_payload
 

--- a/scripts/screeps_rl_control_loop_ledgers.py
+++ b/scripts/screeps_rl_control_loop_ledgers.py
@@ -1490,8 +1490,15 @@ def emit_scorecard_reward_decision_if_missing(
             artifact_root=artifact_root,
             repo_root=repo_root,
         )
+    reward_decision_artifact_path = repo_display_path(path, repo_root)
+    decision_rollout_gate = reward_decision_consistent_text(
+        rollout_gate,
+        reward_decision_id=reward_decision_id,
+        reward_decision_artifact_path=reward_decision_artifact_path,
+        field="rolloutGate",
+    )
     linked_artifact_paths: JsonObject = {
-        "rewardDecisionArtifactPath": repo_display_path(path, repo_root),
+        "rewardDecisionArtifactPath": reward_decision_artifact_path,
         "policyAdvantageArtifactPath": repo_display_path(current_policy_advantage_path, repo_root) if current_policy_advantage_path else None,
         "trainingLedgerPath": repo_display_path(as_dict(training).get("latestPath"), repo_root),
         "scorecardArtifactPath": scorecard.get("scorecardArtifactPath"),
@@ -1510,13 +1517,13 @@ def emit_scorecard_reward_decision_if_missing(
             training=training,
             evidence_windows=evidence_windows,
             linked_artifact_paths=linked_artifact_paths,
-            rollout_gate=rollout_gate,
+            rollout_gate=decision_rollout_gate,
             deployability_status=deployability_status,
             online_utility_status=online_utility_status,
         ),
         created_at,
     )
-    return reward_decision_id, repo_display_path(path, repo_root)
+    return reward_decision_id, reward_decision_artifact_path
 
 
 def metric_list_to_category_map(metrics: Sequence[Any]) -> JsonObject:

--- a/scripts/screeps_rl_control_loop_ledgers.py
+++ b/scripts/screeps_rl_control_loop_ledgers.py
@@ -947,13 +947,18 @@ def training_payload_for_evidence_windows(
     if root_training_payload is None:
         return training_payload
 
-    training_report_ids = set(referenced_training_report_ids(as_dict(training_payload)))
+    training_payload_dict = as_dict(training_payload)
+    training_report_ids = set(referenced_training_report_ids(training_payload_dict))
     root_report_ids = set(referenced_training_report_ids(as_dict(root_training_payload)))
     if training_report_ids and root_report_ids and training_report_ids.intersection(root_report_ids):
         return root_training_payload
 
-    training_candidate = training_evidence_candidate_policy_id(as_dict(training_payload))
-    if not training_report_ids and training_candidate is None:
+    training_candidate = training_evidence_candidate_policy_id(training_payload_dict)
+    if (
+        training_payload_dict.get("type") != TRAINING_LEDGER_TYPE
+        and not training_report_ids
+        and training_candidate is None
+    ):
         return root_training_payload
     return training_payload
 

--- a/scripts/test_screeps_rl_control_loop_ledgers.py
+++ b/scripts/test_screeps_rl_control_loop_ledgers.py
@@ -979,10 +979,14 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
                             f"{report_id} (RUN_WITH_ANOMALY: trueGradient=true, rewardDecisionId=null)",
                         ],
                     },
-                    "rolloutGate": (
-                        "BLOCKED. Rollout still requires: rewardDecisionId propagated (currently null regression), "
-                        "local fallback card fix, and a fresh training pass."
-                    ),
+                    "rolloutGate": {
+                        "status": "BLOCKED",
+                        "reason": (
+                            "rewardDecisionId is null; local fallback card fix and a fresh training pass are still "
+                            "required."
+                        ),
+                        "source": "reward_decision_generation",
+                    },
                     "nextExperimentCardDelta": (
                         "(1) FIX experiment card path. "
                         "(2) RESTORE rewardDecisionId provenance \u2014 investigate why latest ledger shows null. "
@@ -1045,6 +1049,11 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
         self.assertEqual(payload["rewardDecisionArtifactPath"], reward_decision_path)
         self.assertEqual(payload["deployabilityStatus"], "BLOCKED")
         self.assertEqual(payload["evidenceWindows"]["trainingReportIds"], [report_id])
+        self.assertEqual(payload["rolloutGate"]["status"], "BLOCKED")
+        self.assertIn(
+            f"rewardDecisionId {reward_decision_id} is available",
+            payload["rolloutGate"]["reason"],
+        )
         self.assertNotIn("rewardDecisionId_null_regression", regression_metrics)
         self.assertNotIn("rewardDecisionId_missing", regression_metrics)
         for marker in ledgers.REWARD_DECISION_NULL_TEXT_MARKERS:

--- a/scripts/test_screeps_rl_control_loop_ledgers.py
+++ b/scripts/test_screeps_rl_control_loop_ledgers.py
@@ -878,6 +878,178 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
         self.assertEqual(payload["rewardDecisionId"], reward_decision_id)
         self.assertEqual(payload["rewardDecisionArtifactPath"], reward_decision_path)
 
+    def test_policy_advantage_recovers_scorecard_from_referenced_root_training_report(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root, report_id = write_root_local2w_training_report_artifacts(
+                root,
+                include_positive_policy=True,
+                trusted_gradient_update=True,
+            )
+            candidate_policy_id = local2w_next_policy_id()
+            write_json(
+                artifact_root / "rl-control-loop" / "20260605T010000Z-training-ledger.json",
+                {
+                    "type": ledgers.TRAINING_LEDGER_TYPE,
+                    "createdAt": "2026-06-05T01:00:00Z",
+                    "status": "RUN_WITH_ANOMALY",
+                    "trainingDidRun": True,
+                    "environmentExecution": {"started": 80, "completed": 80, "failed": 0, "successRate": 1.0},
+                    "iterationExecution": {
+                        "simulatorTicksRequested": 160000,
+                        "simulatorTicksRun": 160000,
+                        "episodesRun": 80,
+                        "candidateEvaluationIterations": 1,
+                        "policyUpdateIterations": 1,
+                    },
+                    "trainingArtifacts": {
+                        "trainingReportIds": [report_id],
+                        "candidatePolicyIds": [candidate_policy_id],
+                        "scorecardCount": 3,
+                        "rewardDecisionId": None,
+                        "rewardDecisionArtifactPath": None,
+                    },
+                    "metricsFields": {
+                        "envCompleted": 80,
+                        "ticksRun": 160000,
+                        "episodes": 80,
+                        "policyUpdateIterations": 1,
+                        "trainingReportIds": [report_id],
+                        "candidatePolicyId": candidate_policy_id,
+                        "rewardDecisionId": None,
+                    },
+                    "anomalies": [{"severity": "P1", "code": "REWARD_DECISION_ID_NULL"}],
+                },
+            )
+            output = root / "out" / "policy-advantage.json"
+
+            exit_code = ledgers.main(
+                [
+                    "policy-advantage",
+                    "--repo-root",
+                    str(root),
+                    "--artifact-root",
+                    str(artifact_root),
+                    "--output",
+                    str(output),
+                    "--created-at",
+                    "2026-06-05T01:01:00Z",
+                    "--max-files-per-root",
+                    "4",
+                ],
+                stdout=io.StringIO(),
+                stderr=io.StringIO(),
+            )
+            payload = read_json(output)
+            decision = read_json(root / payload["rewardDecisionArtifactPath"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["candidatePolicyId"], candidate_policy_id)
+        self.assertEqual(payload["scorecardId"], local2w_scorecard_id())
+        self.assertIsNotNone(payload["rewardDecisionId"])
+        self.assertEqual(decision["rewardDecisionId"], payload["rewardDecisionId"])
+        self.assertEqual(decision["candidatePolicyId"], candidate_policy_id)
+        self.assertEqual(decision["scorecardId"], local2w_scorecard_id())
+        self.assertEqual(decision["validationEvidence"]["trustedGradientUpdate"], True)
+
+    def test_policy_advantage_scrubs_stale_reward_null_narrative_when_decision_recovered(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root, report_id = write_root_local2w_training_report_artifacts(root, trusted_gradient_update=True)
+            candidate_policy_id = local2w_next_policy_id()
+            reward_decision_id, reward_decision_path = write_legacy_scorecard_reward_decision(
+                root,
+                artifact_root,
+                scorecard_id="legacy-selected-scorecard",
+                candidate_policy_id=candidate_policy_id,
+            )
+            write_json(
+                artifact_root / "rl-control-loop" / "20260605T010000Z-policy-advantage.json",
+                {
+                    "type": ledgers.POLICY_ADVANTAGE_TYPE,
+                    "createdAt": "2026-06-05T01:00:00Z",
+                    "candidatePolicyId": candidate_policy_id,
+                    "baselinePolicyId": "incumbent",
+                    "onlineUtilityStatus": "UNPROVEN",
+                    "rewardDecisionId": None,
+                    "rewardDecisionArtifactPath": None,
+                    "metrics": {},
+                    "evidenceWindows": {
+                        "trainingReportIds": [
+                            f"{report_id} (RUN_WITH_ANOMALY: trueGradient=true, rewardDecisionId=null)",
+                        ],
+                    },
+                    "rolloutGate": (
+                        "BLOCKED. Rollout still requires: rewardDecisionId propagated (currently null regression), "
+                        "local fallback card fix, and a fresh training pass."
+                    ),
+                    "nextExperimentCardDelta": (
+                        "(1) FIX experiment card path. "
+                        "(2) RESTORE rewardDecisionId provenance \u2014 investigate why latest ledger shows null. "
+                        "(3) RESOLVE Tencent blocked."
+                    ),
+                    "trainingStrategyFeedback": {
+                        "rewardChanges": (
+                            "CRITICAL REGRESSION: rewardDecisionId=null in latest training ledger. "
+                            "The null value breaks downstream consumers."
+                        ),
+                        "scenarioChanges": [],
+                        "dataWeightingChanges": [],
+                        "frameworkInstrumentationChanges": [],
+                        "candidateGenerationChanges": [],
+                    },
+                },
+            )
+            write_json(
+                artifact_root / "rl-control-loop" / "20260605T010100Z-training-ledger-read-only-preflight.json",
+                {
+                    "kind": "rl_training_ledger_read_only_preflight",
+                    "parsed": {"type": "screeps-rl-batch-preflight-context"},
+                    "raw": {"ok": True, "returncode": 0},
+                    "script": "preflight.py",
+                },
+            )
+            output = root / "out" / "policy-advantage.json"
+
+            exit_code = ledgers.main(
+                [
+                    "policy-advantage",
+                    "--repo-root",
+                    str(root),
+                    "--artifact-root",
+                    str(artifact_root),
+                    "--output",
+                    str(output),
+                    "--created-at",
+                    "2026-06-05T01:02:00Z",
+                    "--max-files-per-root",
+                    "4",
+                ],
+                stdout=io.StringIO(),
+                stderr=io.StringIO(),
+            )
+            payload = read_json(output)
+
+        checked_text = json.dumps(
+            {
+                "nextExperimentCardDelta": payload["nextExperimentCardDelta"],
+                "rolloutGate": payload["rolloutGate"],
+                "evidenceWindows": payload["evidenceWindows"],
+                "trainingStrategyFeedback": payload["trainingStrategyFeedback"],
+            },
+            sort_keys=True,
+        )
+        regression_metrics = {item["metric"] for item in payload["regressions"]}
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["rewardDecisionId"], reward_decision_id)
+        self.assertEqual(payload["rewardDecisionArtifactPath"], reward_decision_path)
+        self.assertEqual(payload["deployabilityStatus"], "BLOCKED")
+        self.assertEqual(payload["evidenceWindows"]["trainingReportIds"], [report_id])
+        self.assertNotIn("rewardDecisionId_null_regression", regression_metrics)
+        self.assertNotIn("rewardDecisionId_missing", regression_metrics)
+        for marker in ledgers.REWARD_DECISION_NULL_TEXT_MARKERS:
+            self.assertNotIn(marker, checked_text)
+
     def test_policy_advantage_emits_reward_decision_for_trusted_selected_scorecard(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -1069,6 +1241,8 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
         self.assertIsNone(payload["rewardDecisionId"])
         self.assertIsNone(payload["rewardDecisionArtifactPath"])
         self.assertIsNone(payload["scorecardId"])
+        self.assertEqual(payload["deployabilityStatus"], "BLOCKED")
+        self.assertIn("rewardDecisionId_missing", {item["metric"] for item in payload["regressions"]})
         self.assertFalse(decision_dir_exists)
 
     def test_steward_digest_uses_bounded_scan_without_github_side_effects(self) -> None:

--- a/scripts/test_screeps_rl_control_loop_ledgers.py
+++ b/scripts/test_screeps_rl_control_loop_ledgers.py
@@ -952,6 +952,128 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
         self.assertEqual(decision["scorecardId"], local2w_scorecard_id())
         self.assertEqual(decision["validationEvidence"]["trustedGradientUpdate"], True)
 
+    def test_policy_advantage_keeps_evidence_on_selected_ledger_report_when_latest_root_unrelated(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root, report_id = write_root_local2w_training_report_artifacts(
+                root,
+                include_positive_policy=True,
+                trusted_gradient_update=True,
+            )
+            candidate_policy_id = local2w_next_policy_id()
+            unrelated_report_id = "unrelated-root-training-report-20260605T0030Z"
+            unrelated_candidate_policy_id = "construction-priority.pg.unrelated-seed.v1"
+            unrelated_scorecard_path = (
+                "runtime-artifacts/rl-training/candidate-scorecards/"
+                f"{unrelated_report_id}/rl-scorecard-{unrelated_report_id}.json"
+            )
+            write_json(
+                artifact_root / "rl-training" / f"{unrelated_report_id}.json",
+                {
+                    "type": "screeps-rl-training-report",
+                    "schemaVersion": 1,
+                    "generatedAt": "2026-06-05T00:30:00Z",
+                    "status": "shadow",
+                    "reportId": unrelated_report_id,
+                    "artifactCount": 1,
+                    "batchScale": {"environmentRows": 1, "simulatorTicks": 2000},
+                    "simulation": {"repetitions": 1, "ticks": 2000, "workers": 1},
+                    "source": {"simulatorRunCount": 1, "simulatorRunIds": [f"{unrelated_report_id}-r01"]},
+                    "variantResults": [
+                        {
+                            "variantId": unrelated_candidate_policy_id,
+                            "candidatePolicyId": unrelated_candidate_policy_id,
+                            "ok": True,
+                            "sampleCount": 1,
+                        },
+                    ],
+                    "policyUpdateIterations": 1,
+                    "trueGradient": True,
+                    "trustedGradientUpdate": True,
+                    "gradientStable": True,
+                    "policyUpdateCandidatePolicyId": unrelated_candidate_policy_id,
+                    "policyUpdate": {
+                        "iterations": 1,
+                        "nextCandidatePolicy": {"candidatePolicyId": unrelated_candidate_policy_id},
+                    },
+                    "scorecardId": f"rl-scorecard-{unrelated_report_id}",
+                    "scorecardArtifactPath": unrelated_scorecard_path,
+                    "candidateScorecard": {
+                        "status": "ready",
+                        "classification": "runtime_injected_candidate_scorecard_ready",
+                        "scorecardId": f"rl-scorecard-{unrelated_report_id}",
+                        "scorecardArtifactPath": unrelated_scorecard_path,
+                        "candidateStrategyId": unrelated_candidate_policy_id,
+                        "baselineStrategyId": "construction-priority.pg.incumbent-seed.v1",
+                        "validationScaleComputeBlocked": False,
+                        "scorecardUsable": True,
+                    },
+                },
+            )
+            write_json(
+                artifact_root / "rl-control-loop" / "20260605T010000Z-training-ledger.json",
+                {
+                    "type": ledgers.TRAINING_LEDGER_TYPE,
+                    "createdAt": "2026-06-05T01:00:00Z",
+                    "status": "RUN_WITH_ANOMALY",
+                    "trainingDidRun": True,
+                    "environmentExecution": {"started": 80, "completed": 80, "failed": 0, "successRate": 1.0},
+                    "iterationExecution": {
+                        "simulatorTicksRequested": 160000,
+                        "simulatorTicksRun": 160000,
+                        "episodesRun": 80,
+                        "candidateEvaluationIterations": 1,
+                        "policyUpdateIterations": 1,
+                    },
+                    "trainingArtifacts": {
+                        "trainingReportIds": [report_id],
+                        "candidatePolicyIds": [candidate_policy_id],
+                        "scorecardCount": 3,
+                        "rewardDecisionId": None,
+                        "rewardDecisionArtifactPath": None,
+                    },
+                    "metricsFields": {
+                        "envCompleted": 80,
+                        "ticksRun": 160000,
+                        "episodes": 80,
+                        "policyUpdateIterations": 1,
+                        "trainingReportIds": [report_id],
+                        "candidatePolicyId": candidate_policy_id,
+                        "rewardDecisionId": None,
+                    },
+                    "anomalies": [{"severity": "P1", "code": "REWARD_DECISION_ID_NULL"}],
+                },
+            )
+            output = root / "out" / "policy-advantage.json"
+
+            exit_code = ledgers.main(
+                [
+                    "policy-advantage",
+                    "--repo-root",
+                    str(root),
+                    "--artifact-root",
+                    str(artifact_root),
+                    "--output",
+                    str(output),
+                    "--created-at",
+                    "2026-06-05T01:02:00Z",
+                    "--max-files-per-root",
+                    "8",
+                ],
+                stdout=io.StringIO(),
+                stderr=io.StringIO(),
+            )
+            payload = read_json(output)
+            decision = read_json(root / payload["rewardDecisionArtifactPath"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["candidatePolicyId"], candidate_policy_id)
+        self.assertEqual(payload["scorecardId"], local2w_scorecard_id())
+        self.assertEqual(payload["evidenceWindows"]["trainingReportIds"], [report_id])
+        self.assertEqual(decision["linkedTrainingRuns"], [report_id])
+        self.assertNotIn(unrelated_report_id, payload["evidenceWindows"]["trainingReportIds"])
+        self.assertNotIn(unrelated_report_id, decision["linkedTrainingRuns"])
+
     def test_policy_advantage_scrubs_stale_reward_null_narrative_when_decision_recovered(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_control_loop_ledgers.py
+++ b/scripts/test_screeps_rl_control_loop_ledgers.py
@@ -1224,6 +1224,68 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
         self.assertEqual(decision["linkedTrainingRuns"], [report_id])
         self.assertIn("runtime-artifacts/rl-training/candidate-scorecards", decision["linkedArtifactPaths"]["scorecardArtifactPath"])
 
+    def test_policy_advantage_scrubs_emitted_decision_rollout_gate_from_stale_previous_null_reason(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root, report_id = write_root_local2w_training_report_artifacts(
+                root,
+                include_positive_policy=True,
+                trusted_gradient_update=True,
+            )
+            candidate_policy_id = local2w_next_policy_id()
+            output = root / "out" / "policy-advantage.json"
+            write_json(
+                artifact_root / "rl-control-loop" / "20260604T230000Z-policy-advantage.json",
+                {
+                    "type": ledgers.POLICY_ADVANTAGE_TYPE,
+                    "createdAt": "2026-06-04T23:00:00Z",
+                    "candidatePolicyId": candidate_policy_id,
+                    "baselinePolicyId": "incumbent",
+                    "onlineUtilityStatus": "PROVEN",
+                    "metrics": {
+                        "territory": {"advantage": "advantage", "candidateValue": 2, "baselineValue": 1, "delta": 1},
+                        "resources": {"advantage": "tie", "candidateValue": 1, "baselineValue": 1, "delta": 0},
+                    },
+                    "regressions": [],
+                    "evidenceWindows": {"trainingReportIds": [report_id]},
+                    "rolloutGate": {
+                        "status": "BLOCKED",
+                        "reason": "rewardDecisionId is null; preserve the previous blocker until provenance is restored.",
+                        "source": "reward_decision_generation",
+                    },
+                },
+            )
+
+            exit_code = ledgers.main(
+                [
+                    "policy-advantage",
+                    "--repo-root",
+                    str(root),
+                    "--artifact-root",
+                    str(artifact_root),
+                    "--output",
+                    str(output),
+                    "--created-at",
+                    "2026-06-05T00:00:01Z",
+                    "--max-files-per-root",
+                    "4",
+                ],
+                stdout=io.StringIO(),
+                stderr=io.StringIO(),
+            )
+            payload = read_json(output)
+            decision = read_json(root / payload["rewardDecisionArtifactPath"])
+
+        decision_rollout_gate = decision["validationEvidence"]["rolloutGate"]
+        gate_text = json.dumps(decision_rollout_gate, sort_keys=True)
+        self.assertEqual(exit_code, 0)
+        self.assertIsNotNone(payload["rewardDecisionId"])
+        self.assertEqual(decision["rewardDecisionId"], payload["rewardDecisionId"])
+        self.assertEqual(payload["rolloutGate"], decision_rollout_gate)
+        self.assertIn(f"rewardDecisionId {payload['rewardDecisionId']} is available", decision_rollout_gate["reason"])
+        for marker in ledgers.REWARD_DECISION_NULL_TEXT_MARKERS:
+            self.assertNotIn(marker, gate_text)
+
     def test_policy_advantage_keeps_untrusted_root_training_report_blocked(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_control_loop_ledgers.py
+++ b/scripts/test_screeps_rl_control_loop_ledgers.py
@@ -1158,6 +1158,42 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
             decision["validationEvidence"]["evidenceWindows"]["trainingReportIds"],
         )
 
+    def test_policy_evidence_windows_keeps_identityless_ledger_when_root_unmatched(self) -> None:
+        selected_ledger = {
+            "type": ledgers.TRAINING_LEDGER_TYPE,
+            "status": "RUN_VALIDATED",
+            "trainingDidRun": True,
+            "trainingArtifacts": {"scorecardCount": 1},
+            "metricsFields": {"envCompleted": 80},
+        }
+        latest_root_report = {
+            "type": "screeps-rl-training-report",
+            "trainingArtifacts": {"trainingReportIds": ["unrelated-root-report"]},
+            "metricsFields": {
+                "trainingReportIds": ["unrelated-root-report"],
+                "candidatePolicyId": "unrelated-candidate",
+            },
+        }
+        summary = {
+            "artifacts": {
+                "trainingLedger": "runtime-artifacts/rl-control-loop/selected-training-ledger.json",
+                "policyAdvantage": "runtime-artifacts/rl-control-loop/policy-advantage.json",
+            }
+        }
+
+        evidence_payload = ledgers.training_payload_for_evidence_windows(selected_ledger, latest_root_report)
+        windows = ledgers.policy_evidence_windows(
+            None,
+            summary,
+            {"identity": {"report": ["selected-dashboard-report"]}},
+            Path("/repo"),
+            evidence_payload,
+        )
+
+        self.assertIs(evidence_payload, selected_ledger)
+        self.assertEqual(windows["trainingReportIds"], ["selected-dashboard-report"])
+        self.assertNotIn("unrelated-root-report", windows["trainingReportIds"])
+
     def test_policy_advantage_scrubs_stale_reward_null_narrative_when_decision_recovered(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_control_loop_ledgers.py
+++ b/scripts/test_screeps_rl_control_loop_ledgers.py
@@ -309,6 +309,85 @@ def write_legacy_scorecard_reward_decision(
 
 
 class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
+    def test_load_json_rejects_artifact_over_byte_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            path = root / "oversized.json"
+            original_limit = ledgers.MAX_JSON_ARTIFACT_BYTES
+            try:
+                ledgers.MAX_JSON_ARTIFACT_BYTES = 32
+                path.write_text(json.dumps({"payload": "x" * 64}), encoding="utf-8")
+
+                payload = ledgers.load_json(path)
+            finally:
+                ledgers.MAX_JSON_ARTIFACT_BYTES = original_limit
+
+        self.assertIsNone(payload)
+
+    def test_load_json_rejects_artifact_over_depth_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            path = root / "deep.json"
+            original_limit = ledgers.MAX_JSON_ARTIFACT_DEPTH
+            try:
+                ledgers.MAX_JSON_ARTIFACT_DEPTH = 2
+                write_json(path, {"a": {"b": {"c": "too deep"}}})
+
+                payload = ledgers.load_json(path)
+            finally:
+                ledgers.MAX_JSON_ARTIFACT_DEPTH = original_limit
+
+        self.assertIsNone(payload)
+
+    def test_json_safe_marks_over_depth_and_circular_branches(self) -> None:
+        circular: list[Any] = []
+        circular.append(circular)
+        original_limit = ledgers.MAX_JSON_ARTIFACT_DEPTH
+        try:
+            ledgers.MAX_JSON_ARTIFACT_DEPTH = 2
+
+            payload = ledgers.json_safe(
+                {
+                    "path": Path("runtime-artifacts/rl-control-loop/example.json"),
+                    "deep": {"a": {"b": {"c": "too deep"}}},
+                    "circular": circular,
+                }
+            )
+        finally:
+            ledgers.MAX_JSON_ARTIFACT_DEPTH = original_limit
+
+        self.assertEqual(payload["path"], "runtime-artifacts/rl-control-loop/example.json")
+        self.assertEqual(payload["deep"]["a"]["b"], ledgers.JSON_DEPTH_LIMIT_MARKER)
+        self.assertEqual(payload["circular"], [ledgers.JSON_CIRCULAR_REFERENCE_MARKER])
+
+    def test_reward_decision_text_scrub_ignores_over_depth_branch_without_recursion_error(self) -> None:
+        nested: Any = "rewardDecisionId=null"
+        for _ in range(sys.getrecursionlimit() + 20):
+            nested = [nested]
+
+        payload = ledgers.reward_decision_consistent_text(
+            nested,
+            reward_decision_id="reward-decision-test",
+            reward_decision_artifact_path="runtime-artifacts/rl-control-loop/reward-decisions/reward-decision-test.json",
+            field="rolloutGate",
+        )
+
+        self.assertIs(payload, nested)
+
+    def test_reward_decision_text_scrub_handles_circular_branch(self) -> None:
+        circular: JsonObject = {"reason": "rewardDecisionId=null"}
+        circular["self"] = circular
+
+        payload = ledgers.reward_decision_consistent_text(
+            circular,
+            reward_decision_id="reward-decision-test",
+            reward_decision_artifact_path=None,
+            field="rolloutGate",
+        )
+
+        self.assertIs(payload["self"], circular)
+        self.assertTrue(payload["reason"].startswith("BLOCKED. rewardDecisionId reward-decision-test is available"))
+
     def test_training_ledger_writes_artifact_when_stdout_is_closed(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_control_loop_ledgers.py
+++ b/scripts/test_screeps_rl_control_loop_ledgers.py
@@ -952,7 +952,7 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
         self.assertEqual(decision["scorecardId"], local2w_scorecard_id())
         self.assertEqual(decision["validationEvidence"]["trustedGradientUpdate"], True)
 
-    def test_policy_advantage_keeps_evidence_on_selected_ledger_report_when_latest_root_unrelated(self) -> None:
+    def test_policy_advantage_keeps_evidence_on_selected_ledger_report_when_latest_root_reuses_candidate(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             artifact_root, report_id = write_root_local2w_training_report_artifacts(
@@ -962,7 +962,7 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
             )
             candidate_policy_id = local2w_next_policy_id()
             unrelated_report_id = "unrelated-root-training-report-20260605T0030Z"
-            unrelated_candidate_policy_id = "construction-priority.pg.unrelated-seed.v1"
+            reused_candidate_policy_id = candidate_policy_id
             unrelated_scorecard_path = (
                 "runtime-artifacts/rl-training/candidate-scorecards/"
                 f"{unrelated_report_id}/rl-scorecard-{unrelated_report_id}.json"
@@ -981,8 +981,8 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
                     "source": {"simulatorRunCount": 1, "simulatorRunIds": [f"{unrelated_report_id}-r01"]},
                     "variantResults": [
                         {
-                            "variantId": unrelated_candidate_policy_id,
-                            "candidatePolicyId": unrelated_candidate_policy_id,
+                            "variantId": reused_candidate_policy_id,
+                            "candidatePolicyId": reused_candidate_policy_id,
                             "ok": True,
                             "sampleCount": 1,
                         },
@@ -991,10 +991,10 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
                     "trueGradient": True,
                     "trustedGradientUpdate": True,
                     "gradientStable": True,
-                    "policyUpdateCandidatePolicyId": unrelated_candidate_policy_id,
+                    "policyUpdateCandidatePolicyId": reused_candidate_policy_id,
                     "policyUpdate": {
                         "iterations": 1,
-                        "nextCandidatePolicy": {"candidatePolicyId": unrelated_candidate_policy_id},
+                        "nextCandidatePolicy": {"candidatePolicyId": reused_candidate_policy_id},
                     },
                     "scorecardId": f"rl-scorecard-{unrelated_report_id}",
                     "scorecardArtifactPath": unrelated_scorecard_path,
@@ -1003,7 +1003,7 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
                         "classification": "runtime_injected_candidate_scorecard_ready",
                         "scorecardId": f"rl-scorecard-{unrelated_report_id}",
                         "scorecardArtifactPath": unrelated_scorecard_path,
-                        "candidateStrategyId": unrelated_candidate_policy_id,
+                        "candidateStrategyId": reused_candidate_policy_id,
                         "baselineStrategyId": "construction-priority.pg.incumbent-seed.v1",
                         "validationScaleComputeBlocked": False,
                         "scorecardUsable": True,
@@ -1071,8 +1071,13 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
         self.assertEqual(payload["scorecardId"], local2w_scorecard_id())
         self.assertEqual(payload["evidenceWindows"]["trainingReportIds"], [report_id])
         self.assertEqual(decision["linkedTrainingRuns"], [report_id])
+        self.assertEqual(decision["validationEvidence"]["evidenceWindows"]["trainingReportIds"], [report_id])
         self.assertNotIn(unrelated_report_id, payload["evidenceWindows"]["trainingReportIds"])
         self.assertNotIn(unrelated_report_id, decision["linkedTrainingRuns"])
+        self.assertNotIn(
+            unrelated_report_id,
+            decision["validationEvidence"]["evidenceWindows"]["trainingReportIds"],
+        )
 
     def test_policy_advantage_scrubs_stale_reward_null_narrative_when_decision_recovered(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

Related issue: #1729

- Recover Loop A/Loop B reward-decision provenance when trusted scorecard/change-control evidence can identify the selected candidate.
- Emit a non-null synthetic rewardDecisionId record from the scorecard evidence instead of carrying stale `rewardDecisionId=null` blocker text.
- Fix Gemini thread `PRRT_kwDOSMSsO86Hihzp` by recursively scrubbing stale reward-decision-null blockers inside dict/list values, including dict-shaped `rolloutGate.reason`.
- Add deterministic regression coverage for training-ledger propagation, policy-advantage recovery, stale-null narrative scrubbing, legacy scorecard recovery, no-scorecard safety, and nested rolloutGate scrubbing.

## Verification

- `python3 -m py_compile scripts/screeps_rl_control_loop_ledgers.py scripts/test_screeps_rl_control_loop_ledgers.py`
- `python3 -m unittest scripts.test_screeps_rl_control_loop_ledgers -v` — 18 tests OK
- `git diff --check`
- Local proof artifact: `/tmp/issue1729-proof-reviewfix-controller/policy-advantage-proof.json`
  - `rewardDecisionId=RD-AUTO-9f33873ce71c`
  - `onlineUtilityStatus=UNPROVEN`
  - `deployabilityStatus=BLOCKED` because rollout safety remains separate from reward-decision provenance
  - stale nested reward-decision-null blockers absent from the proof artifact
  - `githubComment=skipped_no_atomic_issue`, no official MMO writes, no paid Tencent compute

## Review triage

- Gemini thread `PRRT_kwDOSMSsO86Hihzp`: `FIX` — dict/list-shaped fields could retain stale `rewardDecisionId is null` text after a non-null reward decision was recovered.
- Fix commit: `3209f98745b997752ec4f925dd30863463058ec4` (`rl: scrub nested reward decision blockers`)
- Review-fix proof: `/tmp/issue1729-proof-reviewfix-controller/policy-advantage-proof.json`

## Universal task Done gate

- [x] Task type: P0 RL flywheel bugfix for reward-decision provenance in control-loop ledger generation.
- [x] Expected observable outcome / named deliverable: Loop B policy-advantage output carries a non-null `rewardDecisionId` when trusted scorecard/change-control evidence exists; proof artifact `/tmp/issue1729-proof-reviewfix-controller/policy-advantage-proof.json` produced `RD-AUTO-9f33873ce71c`.
- [x] Non-goals / accepted substitutes: no official MMO write, no paid Tencent compute, no rollout/canary promotion, and no routine issue-comment ledger sink.
- [x] Verification evidence required before Done: py_compile, focused unittest suite with 18 passing tests, `git diff --check`, and the local proof artifact listed above.
- [x] Project Evidence / Next action / Blocked by: #1729 and PR #1730 Project items are In review with exact head SHA `3209f98745b997752ec4f925dd30863463058ec4`, verification evidence, and the active PR-gate review/check sequence.
- [x] Post-merge/deploy/runtime proof: no MMO deploy is part of this script-only change; merged-script proof surface is the next Loop B/steward artifact using `main` plus the deterministic local proof above.
- [x] Named deliverable proof: commits `749812c5a5611531319a323cdf0ebe165bbff739` and `3209f98745b997752ec4f925dd30863463058ec4`, plus proof artifact `/tmp/issue1729-proof-reviewfix-controller/policy-advantage-proof.json`.