### PR TITLE
economy: recover E29N56 postdeploy construction assignment

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -29822,7 +29822,7 @@ function selectReadyFollowUpProductiveEnergySinkTask(creep, capacityConstruction
   return criticalRoadConstructionSite ? { type: "build", targetId: criticalRoadConstructionSite.id } : null;
 }
 function selectNearFullConstructionBacklogTaskBeforeCriticalRepair(creep, constructionSites, constructionReservationContext, getShouldYieldSpawnReservationToConstructionBacklog) {
-  if (!isRoomEnergyFullOrCoveredByCarriedEnergy(creep.room, getUsedEnergy2(creep)) || !getShouldYieldSpawnReservationToConstructionBacklog() || shouldUpgradeForRcl3DefenseUnlock(creep, creep.room.controller)) {
+  if (!hasSafeSurplusConstructionBacklogBeforeCriticalRepair(creep) || !getShouldYieldSpawnReservationToConstructionBacklog() || shouldUpgradeForRcl3DefenseUnlock(creep, creep.room.controller)) {
     return null;
   }
   const constructionPriorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
@@ -29834,6 +29834,13 @@ function selectNearFullConstructionBacklogTaskBeforeCriticalRepair(creep, constr
     { priorityContext: constructionPriorityContext }
   );
   return constructionSite ? { type: "build", targetId: constructionSite.id } : null;
+}
+function hasSafeSurplusConstructionBacklogBeforeCriticalRepair(creep) {
+  const carriedEnergy = getUsedEnergy2(creep);
+  if (isRoomEnergyFullOrCoveredByCarriedEnergy(creep.room, carriedEnergy)) {
+    return true;
+  }
+  return carriedEnergy > 0 && (hasHealthyRoomEnergyBuffer(creep.room) || checkEnergyBufferForStoredConstructionSpending(creep.room));
 }
 function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(creep, spawnOrExtensionEnergySink, constructionSites, constructionReservationContext, getShouldYieldSpawnReservationToConstructionBacklog) {
   const deferForHealthyBuffer = shouldDeferIdleSpawnExtensionRefillForHealthyBuffer(
@@ -33698,7 +33705,7 @@ function isProtectedRepairTargetForConstructionBacklog(creep, target) {
     }
     return isRoomThreatened(creep);
   }
-  return isBuildPreemptionCriticalRoadOrContainerRepairTarget(target);
+  return isBuildPreemptionCriticalRoadOrContainerRepairTarget(target) && !hasOtherSameRoomRepairAssignmentForTarget(creep, target);
 }
 function isRepairPreemptionStructure(target) {
   const structure = target;
@@ -33715,6 +33722,20 @@ function isBuildPreemptionOwnedRampart(structure) {
 }
 function isBuildPreemptionCriticalRoadOrContainerRepairTarget(structure) {
   return (isBuildPreemptionRepairStructureType(structure, "STRUCTURE_ROAD", "road") || isBuildPreemptionRepairStructureType(structure, "STRUCTURE_CONTAINER", "container")) && getCriticalCpuRepairHitsRatio(structure) <= CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO;
+}
+function hasOtherSameRoomRepairAssignmentForTarget(creep, target) {
+  const targetId = getObjectId10(target);
+  if (targetId.length === 0) {
+    return false;
+  }
+  return getRoomOwnedCreeps2(creep.room).some((worker) => {
+    var _a2;
+    if (isSameCreep3(worker, creep) || !isProductiveSameRoomWorker2(worker, creep.room)) {
+      return false;
+    }
+    const task = (_a2 = worker.memory) == null ? void 0 : _a2.task;
+    return (task == null ? void 0 : task.type) === "repair" && String(task.targetId) === targetId;
+  });
 }
 function isBuildPreemptionRepairStructureType(structure, globalConstantName, fallback) {
   const globalConstant = globalThis[globalConstantName];

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -29840,7 +29840,25 @@ function hasSafeSurplusConstructionBacklogBeforeCriticalRepair(creep) {
   if (isRoomEnergyFullOrCoveredByCarriedEnergy(creep.room, carriedEnergy)) {
     return true;
   }
-  return carriedEnergy > 0 && (hasHealthyRoomEnergyBuffer(creep.room) || checkEnergyBufferForStoredConstructionSpending(creep.room));
+  if (carriedEnergy <= 0 || !hasHealthyRoomEnergyBuffer(creep.room) && !checkEnergyBufferForStoredConstructionSpending(creep.room)) {
+    return false;
+  }
+  const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
+  return criticalRepairTarget === null || hasOtherSameRoomCapableRepairAssignmentForTarget(creep, criticalRepairTarget);
+}
+function hasOtherSameRoomCapableRepairAssignmentForTarget(creep, target) {
+  const targetId = String(target.id);
+  if (targetId.length === 0) {
+    return false;
+  }
+  return getRoomOwnedCreeps(creep.room).some((worker) => {
+    var _a2;
+    if (isSameCreep2(worker, creep) || !isProductiveSameRoomWorker(worker, creep.room)) {
+      return false;
+    }
+    const task = (_a2 = worker.memory) == null ? void 0 : _a2.task;
+    return (task == null ? void 0 : task.type) === "repair" && String(task.targetId) === targetId && getUsedEnergy2(worker) > 0 && getActiveWorkParts2(worker) > 0;
+  });
 }
 function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(creep, spawnOrExtensionEnergySink, constructionSites, constructionReservationContext, getShouldYieldSpawnReservationToConstructionBacklog) {
   const deferForHealthyBuffer = shouldDeferIdleSpawnExtensionRefillForHealthyBuffer(
@@ -33734,8 +33752,36 @@ function hasOtherSameRoomRepairAssignmentForTarget(creep, target) {
       return false;
     }
     const task = (_a2 = worker.memory) == null ? void 0 : _a2.task;
-    return (task == null ? void 0 : task.type) === "repair" && String(task.targetId) === targetId;
+    return (task == null ? void 0 : task.type) === "repair" && String(task.targetId) === targetId && getUsedTransferEnergy(worker) > 0 && getActiveWorkParts3(worker) > 0;
   });
+}
+function getActiveWorkParts3(creep) {
+  var _a2;
+  const workPart = getBodyPartConstant4("WORK", "work");
+  const activeWorkParts = (_a2 = creep.getActiveBodyparts) == null ? void 0 : _a2.call(creep, workPart);
+  if (typeof activeWorkParts === "number" && Number.isFinite(activeWorkParts)) {
+    return Math.max(0, Math.floor(activeWorkParts));
+  }
+  const bodyWorkParts = countActiveBodyParts2(creep.body, workPart);
+  return bodyWorkParts != null ? bodyWorkParts : 1;
+}
+function countActiveBodyParts2(body, bodyPartType) {
+  if (!Array.isArray(body)) {
+    return null;
+  }
+  return body.filter((part) => isActiveBodyPart4(part, bodyPartType)).length;
+}
+function isActiveBodyPart4(part, bodyPartType) {
+  if (typeof part !== "object" || part === null) {
+    return false;
+  }
+  const bodyPart = part;
+  return bodyPart.type === bodyPartType && typeof bodyPart.hits === "number" && bodyPart.hits > 0;
+}
+function getBodyPartConstant4(globalName, fallback) {
+  var _a2;
+  const constants = globalThis;
+  return (_a2 = constants[globalName]) != null ? _a2 : fallback;
 }
 function isBuildPreemptionRepairStructureType(structure, globalConstantName, fallback) {
   const globalConstant = globalThis[globalConstantName];
@@ -38888,7 +38934,7 @@ function canSatisfyDefenderSpawnCapacity(creep) {
 }
 function hasActiveAttackPart2(creep) {
   var _a2;
-  const attackPart = getBodyPartConstant4("ATTACK", "attack");
+  const attackPart = getBodyPartConstant5("ATTACK", "attack");
   const activeParts = (_a2 = creep.getActiveBodyparts) == null ? void 0 : _a2.call(creep, attackPart);
   if (typeof activeParts === "number") {
     return activeParts > 0;
@@ -38898,7 +38944,7 @@ function hasActiveAttackPart2(creep) {
   }
   return creep.body.some((part) => part.type === attackPart && part.hits > 0);
 }
-function getBodyPartConstant4(globalName, fallback) {
+function getBodyPartConstant5(globalName, fallback) {
   const value = globalThis[globalName];
   return value != null ? value : fallback;
 }
@@ -43062,7 +43108,7 @@ function getSourceAssignmentLoads(roomName, sources, creeps) {
     const currentLoad = (_f = assignmentLoads.get(assignedSourceId)) != null ? _f : createEmptySourceAssignmentLoad();
     assignmentLoads.set(assignedSourceId, {
       assignedHarvesters: currentLoad.assignedHarvesters + 1,
-      assignedWorkParts: currentLoad.assignedWorkParts + getActiveWorkParts3(creep)
+      assignedWorkParts: currentLoad.assignedWorkParts + getActiveWorkParts4(creep)
     });
   }
   return assignmentLoads;
@@ -43131,24 +43177,24 @@ function getSourceEnergyRegenTicks2() {
   const regenTicks = globalThis.ENERGY_REGEN_TIME;
   return typeof regenTicks === "number" && Number.isFinite(regenTicks) && regenTicks > 0 ? regenTicks : DEFAULT_SOURCE_ENERGY_REGEN_TICKS2;
 }
-function getActiveWorkParts3(creep) {
+function getActiveWorkParts4(creep) {
   var _a2;
-  const workPart = getBodyPartConstant5("WORK", "work");
+  const workPart = getBodyPartConstant6("WORK", "work");
   const activeWorkParts = (_a2 = creep.getActiveBodyparts) == null ? void 0 : _a2.call(creep, workPart);
   if (typeof activeWorkParts === "number" && Number.isFinite(activeWorkParts)) {
     return Math.max(0, Math.floor(activeWorkParts));
   }
-  const bodyWorkParts = Array.isArray(creep.body) ? creep.body.filter((part) => isActiveBodyPart4(part, workPart)).length : 0;
+  const bodyWorkParts = Array.isArray(creep.body) ? creep.body.filter((part) => isActiveBodyPart5(part, workPart)).length : 0;
   return bodyWorkParts > 0 ? bodyWorkParts : 1;
 }
-function isActiveBodyPart4(part, bodyPartType) {
+function isActiveBodyPart5(part, bodyPartType) {
   if (typeof part !== "object" || part === null) {
     return false;
   }
   const bodyPart = part;
   return bodyPart.type === bodyPartType && typeof bodyPart.hits === "number" && bodyPart.hits > 0;
 }
-function getBodyPartConstant5(globalName, fallback) {
+function getBodyPartConstant6(globalName, fallback) {
   var _a2;
   const constants = globalThis;
   return (_a2 = constants[globalName]) != null ? _a2 : fallback;
@@ -46915,21 +46961,21 @@ function isForeignReservedController3(controller, colony) {
 }
 function getKnownActiveClaimPartCount(creep) {
   var _a2;
-  const claimPart = getBodyPartConstant6("CLAIM", "claim");
+  const claimPart = getBodyPartConstant7("CLAIM", "claim");
   const activeClaimParts = (_a2 = creep.getActiveBodyparts) == null ? void 0 : _a2.call(creep, claimPart);
   if (typeof activeClaimParts === "number") {
     return activeClaimParts;
   }
-  return Array.isArray(creep.body) ? creep.body.filter((part) => isActiveBodyPart5(part, claimPart)).length : null;
+  return Array.isArray(creep.body) ? creep.body.filter((part) => isActiveBodyPart6(part, claimPart)).length : null;
 }
-function isActiveBodyPart5(part, bodyPartType) {
+function isActiveBodyPart6(part, bodyPartType) {
   if (typeof part !== "object" || part === null) {
     return false;
   }
   const bodyPart = part;
   return bodyPart.type === bodyPartType && typeof bodyPart.hits === "number" && bodyPart.hits > 0;
 }
-function getBodyPartConstant6(globalName, fallback) {
+function getBodyPartConstant7(globalName, fallback) {
   var _a2;
   const constants = globalThis;
   return (_a2 = constants[globalName]) != null ? _a2 : fallback;
@@ -47899,7 +47945,7 @@ function getGameTime40() {
 }
 function isCreepKnownToHaveNoActiveClaimParts(creep) {
   var _a2;
-  const claimPart = getBodyPartConstant7("CLAIM", "claim");
+  const claimPart = getBodyPartConstant8("CLAIM", "claim");
   const activeClaimParts = (_a2 = creep.getActiveBodyparts) == null ? void 0 : _a2.call(creep, claimPart);
   if (typeof activeClaimParts === "number") {
     return activeClaimParts <= 0;
@@ -47907,16 +47953,16 @@ function isCreepKnownToHaveNoActiveClaimParts(creep) {
   if (!Array.isArray(creep.body)) {
     return false;
   }
-  return !creep.body.some((part) => isActiveBodyPart6(part, claimPart));
+  return !creep.body.some((part) => isActiveBodyPart7(part, claimPart));
 }
-function isActiveBodyPart6(part, bodyPartType) {
+function isActiveBodyPart7(part, bodyPartType) {
   if (typeof part !== "object" || part === null) {
     return false;
   }
   const bodyPart = part;
   return bodyPart.type === bodyPartType && typeof bodyPart.hits === "number" && bodyPart.hits > 0;
 }
-function getBodyPartConstant7(globalName, fallback) {
+function getBodyPartConstant8(globalName, fallback) {
   var _a2;
   const constants = globalThis;
   return (_a2 = constants[globalName]) != null ? _a2 : fallback;
@@ -50013,20 +50059,20 @@ function getControllerOwnerUsername15(controller) {
 }
 function getActiveClaimPartCount2(creep) {
   var _a2;
-  const claimPart = getBodyPartConstant8("CLAIM", "claim");
+  const claimPart = getBodyPartConstant9("CLAIM", "claim");
   const activeClaimParts = (_a2 = creep.getActiveBodyparts) == null ? void 0 : _a2.call(creep, claimPart);
   if (typeof activeClaimParts === "number") {
     return Math.max(0, Math.floor(activeClaimParts));
   }
-  return Array.isArray(creep.body) ? creep.body.filter((part) => isActiveBodyPart7(part, claimPart)).length : 0;
+  return Array.isArray(creep.body) ? creep.body.filter((part) => isActiveBodyPart8(part, claimPart)).length : 0;
 }
-function isActiveBodyPart7(part, bodyPartType) {
+function isActiveBodyPart8(part, bodyPartType) {
   if (!isRecord40(part)) {
     return false;
   }
   return part.type === bodyPartType && typeof part.hits === "number" && part.hits > 0;
 }
-function getBodyPartConstant8(globalName, fallback) {
+function getBodyPartConstant9(globalName, fallback) {
   var _a2;
   const constants = globalThis;
   return (_a2 = constants[globalName]) != null ? _a2 : fallback;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -596,7 +596,10 @@ function isProtectedRepairTargetForConstructionBacklog(creep: Creep, target: unk
     return isRoomThreatened(creep);
   }
 
-  return isBuildPreemptionCriticalRoadOrContainerRepairTarget(target);
+  return (
+    isBuildPreemptionCriticalRoadOrContainerRepairTarget(target) &&
+    !hasOtherSameRoomRepairAssignmentForTarget(creep, target)
+  );
 }
 
 function isRepairPreemptionStructure(target: unknown): target is Structure {
@@ -636,6 +639,22 @@ function isBuildPreemptionCriticalRoadOrContainerRepairTarget(structure: Structu
       isBuildPreemptionRepairStructureType(structure, 'STRUCTURE_CONTAINER', 'container')) &&
     getCriticalCpuRepairHitsRatio(structure) <= CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO
   );
+}
+
+function hasOtherSameRoomRepairAssignmentForTarget(creep: Creep, target: Structure): boolean {
+  const targetId = getObjectId(target);
+  if (targetId.length === 0) {
+    return false;
+  }
+
+  return getRoomOwnedCreeps(creep.room).some((worker) => {
+    if (isSameCreep(worker, creep) || !isProductiveSameRoomWorker(worker, creep.room)) {
+      return false;
+    }
+
+    const task = worker.memory?.task as Partial<CreepTaskMemory> | undefined;
+    return task?.type === 'repair' && String(task.targetId) === targetId;
+  });
 }
 
 function isBuildPreemptionRepairStructureType(

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -653,8 +653,46 @@ function hasOtherSameRoomRepairAssignmentForTarget(creep: Creep, target: Structu
     }
 
     const task = worker.memory?.task as Partial<CreepTaskMemory> | undefined;
-    return task?.type === 'repair' && String(task.targetId) === targetId;
+    return (
+      task?.type === 'repair' &&
+      String(task.targetId) === targetId &&
+      getUsedTransferEnergy(worker) > 0 &&
+      getActiveWorkParts(worker) > 0
+    );
   });
+}
+
+function getActiveWorkParts(creep: Creep): number {
+  const workPart = getBodyPartConstant('WORK', 'work');
+  const activeWorkParts = creep.getActiveBodyparts?.(workPart);
+  if (typeof activeWorkParts === 'number' && Number.isFinite(activeWorkParts)) {
+    return Math.max(0, Math.floor(activeWorkParts));
+  }
+
+  const bodyWorkParts = countActiveBodyParts(creep.body, workPart);
+  return bodyWorkParts ?? 1;
+}
+
+function countActiveBodyParts(body: unknown, bodyPartType: BodyPartConstant): number | null {
+  if (!Array.isArray(body)) {
+    return null;
+  }
+
+  return body.filter((part) => isActiveBodyPart(part, bodyPartType)).length;
+}
+
+function isActiveBodyPart(part: unknown, bodyPartType: BodyPartConstant): boolean {
+  if (typeof part !== 'object' || part === null) {
+    return false;
+  }
+
+  const bodyPart = part as Partial<BodyPartDefinition>;
+  return bodyPart.type === bodyPartType && typeof bodyPart.hits === 'number' && bodyPart.hits > 0;
+}
+
+function getBodyPartConstant(globalName: 'WORK', fallback: BodyPartConstant): BodyPartConstant {
+  const constants = globalThis as unknown as Partial<Record<'WORK', BodyPartConstant>>;
+  return constants[globalName] ?? fallback;
 }
 
 function isBuildPreemptionRepairStructureType(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -4612,7 +4612,7 @@ function selectNearFullConstructionBacklogTaskBeforeCriticalRepair(
   getShouldYieldSpawnReservationToConstructionBacklog: () => boolean
 ): Extract<CreepTaskMemory, { type: 'build' }> | null {
   if (
-    !isRoomEnergyFullOrCoveredByCarriedEnergy(creep.room, getUsedEnergy(creep)) ||
+    !hasSafeSurplusConstructionBacklogBeforeCriticalRepair(creep) ||
     !getShouldYieldSpawnReservationToConstructionBacklog() ||
     shouldUpgradeForRcl3DefenseUnlock(creep, creep.room.controller)
   ) {
@@ -4628,6 +4628,18 @@ function selectNearFullConstructionBacklogTaskBeforeCriticalRepair(
     { priorityContext: constructionPriorityContext }
   );
   return constructionSite ? { type: 'build', targetId: constructionSite.id } : null;
+}
+
+function hasSafeSurplusConstructionBacklogBeforeCriticalRepair(creep: Creep): boolean {
+  const carriedEnergy = getUsedEnergy(creep);
+  if (isRoomEnergyFullOrCoveredByCarriedEnergy(creep.room, carriedEnergy)) {
+    return true;
+  }
+
+  return (
+    carriedEnergy > 0 &&
+    (hasHealthyRoomEnergyBuffer(creep.room) || checkEnergyBufferForStoredConstructionSpending(creep.room))
+  );
 }
 
 function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -4636,10 +4636,42 @@ function hasSafeSurplusConstructionBacklogBeforeCriticalRepair(creep: Creep): bo
     return true;
   }
 
+  if (
+    carriedEnergy <= 0 ||
+    (!hasHealthyRoomEnergyBuffer(creep.room) && !checkEnergyBufferForStoredConstructionSpending(creep.room))
+  ) {
+    return false;
+  }
+
+  const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
   return (
-    carriedEnergy > 0 &&
-    (hasHealthyRoomEnergyBuffer(creep.room) || checkEnergyBufferForStoredConstructionSpending(creep.room))
+    criticalRepairTarget === null ||
+    hasOtherSameRoomCapableRepairAssignmentForTarget(creep, criticalRepairTarget)
   );
+}
+
+function hasOtherSameRoomCapableRepairAssignmentForTarget(
+  creep: Creep,
+  target: CriticalInfrastructureRepairTarget
+): boolean {
+  const targetId = String(target.id);
+  if (targetId.length === 0) {
+    return false;
+  }
+
+  return getRoomOwnedCreeps(creep.room).some((worker) => {
+    if (isSameCreep(worker, creep) || !isProductiveSameRoomWorker(worker, creep.room)) {
+      return false;
+    }
+
+    const task = worker.memory?.task as Partial<CreepTaskMemory> | undefined;
+    return (
+      task?.type === 'repair' &&
+      String(task.targetId) === targetId &&
+      getUsedEnergy(worker) > 0 &&
+      getActiveWorkParts(worker) > 0
+    );
+  });
 }
 
 function selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -6287,6 +6287,116 @@ describe('runWorker', () => {
     expect(transfer).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['zero energy', 0, 1],
+    ['no active WORK parts', 85, 0]
+  ])(
+    'keeps critical container repair when same-target coverage has %s',
+    (_label, coverageEnergy, coverageWorkParts) => {
+      const site = {
+        id: 'storage-site1',
+        my: true,
+        structureType: 'storage',
+        progress: 6_846,
+        progressTotal: 30_000
+      } as ConstructionSite;
+      const damagedContainer = {
+        id: 'critical-container1',
+        structureType: 'container',
+        hits: 900,
+        hitsMax: 2_000
+      } as StructureContainer;
+      const controller = {
+        id: 'controller1',
+        my: true,
+        level: 4,
+        ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 3_000
+      } as StructureController;
+      const roomCreeps: Creep[] = [];
+      const room = {
+        name: 'E29N56',
+        energyAvailable: 500,
+        energyCapacityAvailable: 1_300,
+        controller,
+        find: jest.fn((type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
+            return [];
+          }
+
+          if (type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES || type === FIND_CONSTRUCTION_SITES) {
+            return [];
+          }
+
+          return [];
+        })
+      } as unknown as Room;
+      const build = jest.fn().mockReturnValue(0);
+      const repair = jest.fn().mockReturnValue(0);
+      const selectedBuildTask = { type: 'build', targetId: 'storage-site1' as Id<ConstructionSite> } as const;
+      const creep = {
+        name: 'Builder',
+        memory: {
+          role: 'worker',
+          colony: 'E29N56',
+          task: { type: 'repair', targetId: 'critical-container1' as Id<Structure> }
+        },
+        store: {
+          getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 58 : 0)),
+          getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 42 : 0))
+        },
+        room,
+        build,
+        repair,
+        moveTo: jest.fn()
+      } as unknown as Creep;
+      const staleCoverage = {
+        name: 'StaleCoverage',
+        memory: {
+          role: 'worker',
+          colony: 'E29N56',
+          task: { type: 'repair', targetId: 'critical-container1' as Id<Structure> }
+        },
+        store: {
+          getUsedCapacity: jest.fn((resource?: ResourceConstant) =>
+            resource === RESOURCE_ENERGY ? coverageEnergy : 0
+          )
+        },
+        getActiveBodyparts: jest.fn((part?: BodyPartConstant) =>
+          part === 'work' ? coverageWorkParts : 0
+        ),
+        room
+      } as unknown as Creep;
+      roomCreeps.push(creep, staleCoverage);
+      const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(selectedBuildTask);
+      (globalThis as unknown as { Game: Partial<Game> }).Game = {
+        creeps: { Builder: creep, StaleCoverage: staleCoverage },
+        rooms: { E29N56: room },
+        time: 1_854_806,
+        getObjectById: jest.fn((id: string) => {
+          if (id === 'storage-site1') {
+            return site;
+          }
+
+          return id === 'critical-container1' ? damagedContainer : null;
+        })
+      };
+
+      try {
+        runWorker(creep);
+
+        expect(creep.memory.task).toEqual({ type: 'repair', targetId: 'critical-container1' });
+        expect(repair).toHaveBeenCalledWith(damagedContainer);
+        expect(build).not.toHaveBeenCalled();
+      } finally {
+        selectWorkerTask.mockRestore();
+      }
+    }
+  );
+
   it('keeps an existing near-full build assignment when storage-critical acquisition yields', () => {
     const site = {
       id: 'container-site1',

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -6123,6 +6123,170 @@ describe('runWorker', () => {
     expect(repair).not.toHaveBeenCalled();
   });
 
+  it('preempts covered E29N56 critical container repair for safe storage construction under a spawn reserve signal', () => {
+    const site = {
+      id: 'storage-site1',
+      my: true,
+      structureType: 'storage',
+      progress: 6_846,
+      progressTotal: 30_000
+    } as ConstructionSite;
+    const damagedContainer = {
+      id: 'critical-container1',
+      structureType: 'container',
+      hits: 900,
+      hitsMax: 2_000,
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 2_188 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) =>
+          resource === undefined || resource === RESOURCE_ENERGY ? 2_500 : 0
+        )
+      }
+    } as unknown as StructureContainer;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 250 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+      },
+      pos: { getRangeTo: jest.fn().mockReturnValue(1) }
+    } as unknown as StructureSpawn;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 3_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N56',
+      energyAvailable: 300,
+      energyCapacityAvailable: 1_300,
+      controller,
+      find: jest.fn((type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn] as unknown as AnyOwnedStructure[];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [damagedContainer];
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+        }
+
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        if (type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
+          return [];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const repair = jest.fn().mockReturnValue(0);
+    const transfer = jest.fn();
+    const creep = {
+      name: 'Builder',
+      memory: {
+        role: 'worker',
+        colony: 'E29N56',
+        task: { type: 'repair', targetId: 'critical-container1' as Id<Structure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 58 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 42 : 0))
+      },
+      room,
+      build,
+      repair,
+      transfer,
+      moveTo: jest.fn(),
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0))
+    } as unknown as Creep;
+    const repairCoverage = {
+      name: 'RepairCoverage',
+      memory: {
+        role: 'worker',
+        colony: 'E29N56',
+        task: { type: 'repair', targetId: 'critical-container1' as Id<Structure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 85 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 15 : 0))
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, repairCoverage);
+    const assessment = assessColonySurvival({
+      roomName: 'E29N56',
+      totalCreeps: 10,
+      workerCapacity: 3,
+      workerTarget: 4,
+      energyAvailable: 300,
+      energyCapacityAvailable: 1_300,
+      defenseFloorReady: true,
+      controller: { my: true, level: 4, ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 3_000 },
+      hostileCreepCount: 0
+    });
+    expect(assessment.mode).toBe('LOCAL_STABLE');
+    recordColonySurvivalAssessment('E29N56', assessment, 1_854_806);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      economy: {
+        spawnEnergyReservation: {
+          updatedAt: 1_854_805,
+          rooms: {
+            E29N56: {
+              bodyCost: 1_300,
+              creepName: 'worker-E29N56-next',
+              reservedAt: 1_854_805,
+              reservedEnergy: 1_300,
+              role: 'worker',
+              roomName: 'E29N56',
+              updatedAt: 1_854_805
+            }
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Builder: creep, RepairCoverage: repairCoverage },
+      rooms: { E29N56: room },
+      time: 1_854_806,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'storage-site1') {
+          return site;
+        }
+
+        if (id === 'critical-container1') {
+          return damagedContainer;
+        }
+
+        return id === 'spawn1' ? spawn : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'storage-site1' });
+    expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+      currentTask: 'repair',
+      selectedTask: 'build',
+      assignedTask: 'build'
+    });
+    expect(creep.memory.workerDispatchDiagnostic?.spawnReservationTask).toBeUndefined();
+    expect(build).toHaveBeenCalledWith(site);
+    expect(repair).not.toHaveBeenCalled();
+    expect(transfer).not.toHaveBeenCalled();
+  });
+
   it('keeps an existing near-full build assignment when storage-critical acquisition yields', () => {
     const site = {
       id: 'container-site1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -13430,6 +13430,74 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(builder)).toEqual({ type: 'build', targetId: 'container-site1' });
   });
 
+  it('routes E29N56 storage construction before covered critical container repair when stored surplus is safe', () => {
+    const site = {
+      id: 'storage-site1',
+      my: true,
+      structureType: 'storage',
+      progress: 6_846,
+      progressTotal: 30_000
+    } as ConstructionSite;
+    const damagedContainer = makeStoredEnergyContainerWithCapacity('critical-container1', 2_188, 2_500, {
+      hits: 900,
+      hitsMax: 2_000
+    });
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 50);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 3_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N56',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 300,
+      energyCapacityAvailable: 1_300,
+      myStructures: [spawn as AnyOwnedStructure],
+      structures: [damagedContainer as AnyStructure]
+    });
+    const builder = {
+      name: 'BuilderCandidate',
+      memory: { role: 'worker', colony: 'E29N56' },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 58 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 42 : 0))
+      },
+      room
+    } as unknown as Creep;
+    const repairer = {
+      name: 'RepairCoverage',
+      memory: {
+        role: 'worker',
+        colony: 'E29N56',
+        task: { type: 'repair', targetId: 'critical-container1' as Id<Structure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 85 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 15 : 0))
+      },
+      room
+    } as unknown as Creep;
+    const assessment = assessColonySurvival({
+      roomName: 'E29N56',
+      totalCreeps: 10,
+      workerCapacity: 3,
+      workerTarget: 4,
+      energyAvailable: 300,
+      energyCapacityAvailable: 1_300,
+      defenseFloorReady: true,
+      controller: { my: true, level: 4, ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 3_000 },
+      hostileCreepCount: 0
+    });
+    expect(assessment.mode).toBe('LOCAL_STABLE');
+    recordColonySurvivalAssessment('E29N56', assessment, 1_854_806);
+    setGameCreeps({ BuilderCandidate: builder, RepairCoverage: repairer });
+
+    expect(selectWorkerTask(builder)).toEqual({ type: 'build', targetId: 'storage-site1' });
+  });
+
   it('reserves a loaded worker for construction when healthy energy and idle workers leave build coverage empty', () => {
     const site = { id: 'wall-site1', structureType: 'constructedWall' } as ConstructionSite;
     const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 317, {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -12612,6 +12612,60 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'container-critical' });
   });
 
+  it('keeps healthy-buffer construction behind critical container repair without live same-target coverage', () => {
+    const site = {
+      id: 'storage-site1',
+      my: true,
+      structureType: 'storage',
+      progress: 6_846,
+      progressTotal: 30_000
+    } as ConstructionSite;
+    const criticalContainer = makeStructure(
+      'container-critical',
+      'container' as StructureConstant,
+      900,
+      2_000
+    );
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 3_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [site],
+      controller,
+      energyAvailable: 500,
+      energyCapacityAvailable: 1_300,
+      structures: [criticalContainer]
+    });
+    const creep = {
+      name: 'LoadedBuilder',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 58 : 0))
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      room
+    } as unknown as Creep;
+    const emptyStaleRepairer = {
+      name: 'EmptyStaleRepairer',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'repair', targetId: 'container-critical' as Id<Structure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      room
+    } as unknown as Creep;
+    setGameCreeps({ LoadedBuilder: creep, EmptyStaleRepairer: emptyStaleRepairer });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'container-critical' });
+  });
+
   it('keeps carried spawn recovery ahead of near-floor rampart repair under critical CPU bucket pressure', () => {
     const spawnSite = {
       id: 'spawn-site1',


### PR DESCRIPTION
## Summary
- Routes E29N56 workers away from already-covered critical container repair so construction can proceed when another same-room worker is handling the repair target.
- Allows safe carried-energy construction spending under a spawn-reservation signal when room surplus or stored buffer coverage is healthy.
- Adds regression coverage for the postdeploy `worker_assignment_gap_sustained` case and regenerates the Screeps bundle.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` → `105 passed, 2323 tests passed`
- `cd prod && npm run build`

Refs #1715

## Issue / postdeploy closure gate
- [x] #1715: PR implementation targets the fresh postdeploy successor blocker (`worker_assignment_gap_sustained` in shardX/E29N56 with one construction site and covered repair work); keep the issue open until official deploy plus fresh runtime monitor acceptance proves the alert clears or exposes a more precise successor blocker.

## Universal task Done gate
- [x] Task type: Territory/Economy gameplay production-code bugfix.
- [x] Expected observable outcome / named deliverable: E29N56 workers can build from safe surplus while covered repair work remains protected by another same-room repair assignment.
- [x] Non-goals / accepted substitutes: no paid compute, no learned-policy rollout, no owner-side decision, no destructive game action, and no direct manual edit on main.
- [x] Verification evidence required before Done: controller-side `git diff --check`, prod typecheck, full Jest `105 passed / 2323 tests`, and prod build all passed before Codex-authored commit `eb20b51a`.
- [x] Project Evidence / Next action / Blocked by: next controller action is exact-head CI/CodeRabbit/thread gate, then merge/deploy/runtime acceptance; Project field sync is handled by the scheduler when GraphQL quota is available.
- [x] Post-merge/deploy/runtime proof: after official MMO deploy, runtime alert/summary must show `worker_assignment_gap_sustained` cleared for shardX/E29N56 or a precise non-generic successor blocker.
- [x] Named deliverable proof: commit `eb20b51a` changes `prod/src/creeps/workerRunner.ts`, `prod/src/tasks/workerTasks.ts`, `prod/test/workerRunner.test.ts`, `prod/test/workerTasks.test.ts`, and regenerated `prod/dist/main.js`.