### PR TITLE
seasonal: prevent empty worker/hauler task walking

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -34181,7 +34181,7 @@ function executeAssignedTask(creep, selectedTask, immediateReselectExecutions = 
   }
   const execution = executeTask(creep, task, target);
   recordTaskBehavior(creep, task, execution);
-  if (shouldImmediatelyReselectAfterTaskResult(task, execution.result)) {
+  if (shouldImmediatelyReselectAfterTaskResult(task, execution.result) || shouldImmediatelyReselectAfterEmptySpendingTaskResult(creep, task)) {
     delete creep.memory.task;
     const nextTask = assignNextTask(creep);
     if (nextTask && !isSameTask2(task, nextTask) && immediateReselectExecutions < MAX_IMMEDIATE_RESELECT_EXECUTIONS) {
@@ -34202,6 +34202,10 @@ function shouldImmediatelyReselectAfterTaskResult(task, result) {
     return result === ERR_FULL_CODE5;
   }
   return isEnergyAcquisitionTask2(task) && isUnavailableEnergyAcquisitionResult(result);
+}
+function shouldImmediatelyReselectAfterEmptySpendingTaskResult(creep, task) {
+  const usedEnergy = getObservedUsedTransferEnergy(creep);
+  return isEnergySpendingMovementTask(task) && usedEnergy !== null && usedEnergy <= 0;
 }
 function isUnavailableEnergyAcquisitionResult(result) {
   return result === ERR_NOT_ENOUGH_RESOURCES_CODE2 || result === ERR_INVALID_TARGET_CODE3;
@@ -34527,6 +34531,9 @@ function isEnergyAcquisitionTask2(task) {
 function isLowLoadReturnTask(task) {
   return task.type === "transfer" || task.type === "build" || task.type === "repair" || task.type === "upgrade";
 }
+function isEnergySpendingMovementTask(task) {
+  return task.type === "transfer" || task.type === "build" || task.type === "repair" || task.type === "upgrade";
+}
 function isRecoverableEnergyTask(task) {
   return (task == null ? void 0 : task.type) === "pickup" || (task == null ? void 0 : task.type) === "withdraw";
 }
@@ -34651,6 +34658,11 @@ function getUsedTransferEnergy(creep) {
   var _a2, _b;
   const usedCapacity = (_b = (_a2 = creep.store) == null ? void 0 : _a2.getUsedCapacity) == null ? void 0 : _b.call(_a2, RESOURCE_ENERGY);
   return typeof usedCapacity === "number" && Number.isFinite(usedCapacity) ? Math.max(0, usedCapacity) : 0;
+}
+function getObservedUsedTransferEnergy(creep) {
+  var _a2, _b;
+  const usedCapacity = (_b = (_a2 = creep.store) == null ? void 0 : _a2.getUsedCapacity) == null ? void 0 : _b.call(_a2, RESOURCE_ENERGY);
+  return typeof usedCapacity === "number" && Number.isFinite(usedCapacity) ? Math.max(0, usedCapacity) : null;
 }
 function isSameRoomWorkerWithEnergy2(creep, room) {
   var _a2;
@@ -36112,6 +36124,7 @@ function hasRemoteHaulerDeliveryDemand(homeRoom) {
 }
 function runHauler(creep) {
   var _a2, _b, _c, _d;
+  clearEmptyEnergyTransferTask(creep);
   const assignment = normalizeRemoteHaulerMemory((_a2 = creep.memory) == null ? void 0 : _a2.remoteHauler);
   if (!assignment && ((_b = creep.memory) == null ? void 0 : _b.remoteHauler) !== void 0) {
     return;
@@ -36335,6 +36348,9 @@ function deliverLocalEnergy(creep) {
   };
   creep.memory.task = task;
   const result = (_a2 = creep.transfer) == null ? void 0 : _a2.call(creep, target, getEnergyResource20());
+  if (shouldClearEmptyEnergyTransferTaskAfterResult(creep, result)) {
+    return;
+  }
   if (result === getErrNotInRangeCode4()) {
     moveTo4(creep, target);
   }
@@ -36389,9 +36405,28 @@ function deliverEnergy2(creep, assignment) {
     return;
   }
   const result = (_b = creep.transfer) == null ? void 0 : _b.call(creep, target, getEnergyResource20());
+  if (shouldClearEmptyEnergyTransferTaskAfterResult(creep, result)) {
+    return;
+  }
   if (result === getErrNotInRangeCode4()) {
     moveTo4(creep, target);
   }
+}
+function clearEmptyEnergyTransferTask(creep) {
+  var _a2;
+  if (((_a2 = creep.memory.task) == null ? void 0 : _a2.type) === "transfer" && getCarriedEnergy6(creep) <= 0) {
+    delete creep.memory.task;
+  }
+}
+function shouldClearEmptyEnergyTransferTaskAfterResult(creep, result) {
+  if (getCarriedEnergy6(creep) > 0) {
+    return false;
+  }
+  if (result === OK_CODE14 || result === ERR_NOT_ENOUGH_RESOURCES_CODE4 || result === ERR_INVALID_TARGET_CODE4 || result === getErrNotInRangeCode4()) {
+    delete creep.memory.task;
+    return true;
+  }
+  return false;
 }
 function compareRemoteHaulerAssignments(left, right) {
   return compareRemoteHaulerAssignmentOverflowRisk(left, right) || right.containerEnergy - left.containerEnergy || left.targetRoom.localeCompare(right.targetRoom) || String(left.sourceId).localeCompare(String(right.sourceId));

--- a/prod/src/creeps/hauler.ts
+++ b/prod/src/creeps/hauler.ts
@@ -91,6 +91,8 @@ function hasRemoteHaulerDeliveryDemand(homeRoom: string): boolean {
 }
 
 export function runHauler(creep: Creep): void {
+  clearEmptyEnergyTransferTask(creep);
+
   const assignment = normalizeRemoteHaulerMemory(creep.memory?.remoteHauler);
   if (!assignment && creep.memory?.remoteHauler !== undefined) {
     return;
@@ -379,6 +381,10 @@ function deliverLocalEnergy(creep: Creep): void {
   };
   creep.memory.task = task;
   const result = creep.transfer?.(target, getEnergyResource());
+  if (shouldClearEmptyEnergyTransferTaskAfterResult(creep, result)) {
+    return;
+  }
+
   if (result === getErrNotInRangeCode()) {
     moveTo(creep, target);
   }
@@ -439,9 +445,40 @@ function deliverEnergy(creep: Creep, assignment: CreepRemoteHaulerMemory): void 
   }
 
   const result = creep.transfer?.(target, getEnergyResource());
+  if (shouldClearEmptyEnergyTransferTaskAfterResult(creep, result)) {
+    return;
+  }
+
   if (result === getErrNotInRangeCode()) {
     moveTo(creep, target);
   }
+}
+
+function clearEmptyEnergyTransferTask(creep: Creep): void {
+  if (creep.memory.task?.type === 'transfer' && getCarriedEnergy(creep) <= 0) {
+    delete creep.memory.task;
+  }
+}
+
+function shouldClearEmptyEnergyTransferTaskAfterResult(
+  creep: Creep,
+  result: ScreepsReturnCode | undefined
+): boolean {
+  if (getCarriedEnergy(creep) > 0) {
+    return false;
+  }
+
+  if (
+    result === OK_CODE ||
+    result === ERR_NOT_ENOUGH_RESOURCES_CODE ||
+    result === ERR_INVALID_TARGET_CODE ||
+    result === getErrNotInRangeCode()
+  ) {
+    delete creep.memory.task;
+    return true;
+  }
+
+  return false;
 }
 
 function compareRemoteHaulerAssignments(left: RemoteSourceAssignment, right: RemoteSourceAssignment): number {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -1377,7 +1377,10 @@ function executeAssignedTask(
 
   const execution = executeTask(creep, task, target);
   recordTaskBehavior(creep, task, execution);
-  if (shouldImmediatelyReselectAfterTaskResult(task, execution.result)) {
+  if (
+    shouldImmediatelyReselectAfterTaskResult(task, execution.result) ||
+    shouldImmediatelyReselectAfterEmptySpendingTaskResult(creep, task)
+  ) {
     delete creep.memory.task;
     const nextTask = assignNextTask(creep);
     if (
@@ -1405,6 +1408,14 @@ function shouldImmediatelyReselectAfterTaskResult(task: CreepTaskMemory, result:
   }
 
   return isEnergyAcquisitionTask(task) && isUnavailableEnergyAcquisitionResult(result);
+}
+
+function shouldImmediatelyReselectAfterEmptySpendingTaskResult(
+  creep: Creep,
+  task: CreepTaskMemory
+): boolean {
+  const usedEnergy = getObservedUsedTransferEnergy(creep);
+  return isEnergySpendingMovementTask(task) && usedEnergy !== null && usedEnergy <= 0;
 }
 
 function isUnavailableEnergyAcquisitionResult(result: ScreepsReturnCode): boolean {
@@ -1956,6 +1967,12 @@ function isLowLoadReturnTask(
   return task.type === 'transfer' || task.type === 'build' || task.type === 'repair' || task.type === 'upgrade';
 }
 
+function isEnergySpendingMovementTask(
+  task: CreepTaskMemory
+): task is Extract<CreepTaskMemory, { type: 'transfer' | 'build' | 'repair' | 'upgrade' }> {
+  return task.type === 'transfer' || task.type === 'build' || task.type === 'repair' || task.type === 'upgrade';
+}
+
 function isRecoverableEnergyTask(
   task: CreepTaskMemory | null
 ): task is Extract<CreepTaskMemory, { type: 'pickup' | 'withdraw' }> {
@@ -2145,6 +2162,11 @@ function getFreeTransferEnergyCapacity(target: unknown): number {
 function getUsedTransferEnergy(creep: Creep): number {
   const usedCapacity = creep.store?.getUsedCapacity?.(RESOURCE_ENERGY);
   return typeof usedCapacity === 'number' && Number.isFinite(usedCapacity) ? Math.max(0, usedCapacity) : 0;
+}
+
+function getObservedUsedTransferEnergy(creep: Creep): number | null {
+  const usedCapacity = creep.store?.getUsedCapacity?.(RESOURCE_ENERGY);
+  return typeof usedCapacity === 'number' && Number.isFinite(usedCapacity) ? Math.max(0, usedCapacity) : null;
 }
 
 function isSameRoomWorkerWithEnergy(creep: Creep, room: Room): boolean {

--- a/prod/test/hauler.test.ts
+++ b/prod/test/hauler.test.ts
@@ -304,6 +304,21 @@ describe('runHauler', () => {
     expect(creep.withdraw).toHaveBeenCalledWith(storage, RESOURCE_ENERGY);
   });
 
+  it('clears stale empty local transfer memory before collecting energy', () => {
+    const spawn = makeStoreStructure('spawn1', STRUCTURE_SPAWN, 100, 200, 300, 10, 10);
+    const storage = makeStoreStructure('storage1', STRUCTURE_STORAGE, 500, 500, 1_000, 3, 3);
+    const room = makeRoom('W1N1', true, [spawn], [], [storage as unknown as Structure]);
+    const creep = makeLocalHauler(room, 0);
+    creep.memory.task = { type: 'transfer', targetId: 'spawn1' as Id<AnyStoreStructure> };
+
+    runHauler(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'withdraw', targetId: 'storage1' });
+    expect(creep.withdraw).toHaveBeenCalledWith(storage, RESOURCE_ENERGY);
+    expect(creep.transfer).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalledWith(spawn, expect.anything());
+  });
+
   it('withdraws visible season score with an empty local hauler when priority delivery is absent', () => {
     (globalThis as unknown as { FIND_SCORE: number }).FIND_SCORE = 42;
     const score = makeScoreContainer('score1', 100, 3, 3);

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -3254,6 +3254,40 @@ describe('runWorker', () => {
     expect(moveTo).toHaveBeenCalledWith(site, { range: 3, ignoreCreeps: true });
   });
 
+  it('reselects acquisition instead of moving when a spending task leaves the worker empty', () => {
+    const site = { id: 'site1' } as ConstructionSite;
+    const source = { id: 'source1', energy: 300 } as Source;
+    let carriedEnergy = 50;
+    const build = jest.fn(() => {
+      carriedEnergy = 0;
+      return ERR_NOT_IN_RANGE;
+    });
+    const harvest = jest.fn().mockReturnValue(0);
+    const moveTo = jest.fn();
+    const getObjectById = jest.fn((id: string) => (id === 'source1' ? source : site));
+    const creep = {
+      memory: { task: { type: 'build', targetId: 'site1' as Id<ConstructionSite> } },
+      store: {
+        getUsedCapacity: jest.fn(() => carriedEnergy),
+        getFreeCapacity: jest.fn(() => 50 - carriedEnergy)
+      },
+      room: { find: jest.fn((type: number) => (type === FIND_SOURCES ? [source] : [])) },
+      build,
+      harvest,
+      moveTo
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById
+    };
+
+    runWorker(creep);
+
+    expect(build).toHaveBeenCalledWith(site);
+    expect(moveTo).not.toHaveBeenCalledWith(site, { range: 3, ignoreCreeps: true });
+    expect(creep.memory.task).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(harvest).toHaveBeenCalledWith(source);
+  });
+
   it('suppresses an existing build target when movement cannot find a path', () => {
     const site = { id: 'site1' } as ConstructionSite;
     const build = jest.fn().mockReturnValue(-9);
@@ -8630,20 +8664,63 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
-  it('switches from spending tasks when creep is empty', () => {
+  it.each([
+    {
+      action: 'transfer',
+      task: { type: 'transfer', targetId: 'stale-transfer' as Id<AnyStoreStructure> },
+      staleTarget: { id: 'stale-transfer', store: { getFreeCapacity: jest.fn().mockReturnValue(50) } },
+      actionMockName: 'transfer'
+    },
+    {
+      action: 'build',
+      task: { type: 'build', targetId: 'stale-site' as Id<ConstructionSite> },
+      staleTarget: { id: 'stale-site' },
+      actionMockName: 'build'
+    },
+    {
+      action: 'repair',
+      task: { type: 'repair', targetId: 'stale-road' as Id<Structure> },
+      staleTarget: { id: 'stale-road', hits: 1_000, hitsMax: 5_000 },
+      actionMockName: 'repair'
+    },
+    {
+      action: 'upgrade',
+      task: { type: 'upgrade', targetId: 'stale-controller' as Id<StructureController> },
+      staleTarget: { id: 'stale-controller', my: true },
+      actionMockName: 'upgradeController'
+    }
+  ] satisfies Array<{
+    action: string;
+    task: CreepTaskMemory;
+    staleTarget: unknown;
+    actionMockName: 'transfer' | 'build' | 'repair' | 'upgradeController';
+  }>)('switches from stale $action when creep is empty', ({ task, staleTarget, actionMockName }) => {
     const source = { id: 'source1' } as Source;
+    const harvest = jest.fn().mockReturnValue(0);
     const creep = {
-      memory: { task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> } },
+      memory: { task },
       store: {
         getUsedCapacity: jest.fn().mockReturnValue(0),
         getFreeCapacity: jest.fn().mockReturnValue(50)
       },
-      room: { find: jest.fn().mockReturnValue([source]) }
+      room: { find: jest.fn((type: number) => (type === FIND_SOURCES ? [source] : [])) },
+      harvest,
+      transfer: jest.fn(),
+      build: jest.fn(),
+      repair: jest.fn(),
+      upgradeController: jest.fn(),
+      moveTo: jest.fn()
     } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn((id: string) => (id === 'source1' ? source : staleTarget)) as unknown as Game['getObjectById']
+    };
 
     runWorker(creep);
 
     expect(creep.memory.task).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(harvest).toHaveBeenCalledWith(source);
+    expect((creep[actionMockName] as jest.Mock)).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalledWith(staleTarget, expect.anything());
   });
 
   it('transfers energy to transfer targets', () => {


### PR DESCRIPTION
## Summary

Related to issue #1731.

- reselect worker tasks immediately when an energy-spending task leaves the worker empty, so it does not keep walking toward transfer/build/repair/upgrade targets with `store.energy <= 0`
- clear stale empty hauler transfer memory before assignment and after empty transfer outcomes, preventing empty haulers from continuing toward delivery sinks
- add focused worker/hauler tests for stale empty spending tasks and rebuild the Screeps bundle

## Root cause

Live seasonal evidence showed workers/haulers retaining energy-spending memory after their carried energy was already exhausted. The worker runner only immediately reselected on unavailable acquisition tasks or full transfer sinks, so an empty spending task could remain/move until a later tick. Haulers similarly allowed stale empty transfer memory to survive local/remote delivery flow.

## Verification

From `prod/`:

- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` — 105 suites / 2326 tests passed
- `npm run build`

## Universal task Done gate

- [x] Task type: Code bugfix for Seasonal World worker/hauler task execution.
- [x] Expected observable outcome / named deliverable: Empty worker/hauler creeps reselect acquisition or stand down instead of walking toward energy-spending targets.
- [x] Non-goals / accepted substitutes: ScoreCollector and claimer travel classification excluded; seasonal runtime proof contract is recorded in Project follow-up state.
- [x] Verification evidence required before Done: diff check, typecheck, full Jest 105 suites / 2326 tests, and bundle build passed on 2026-06-06 for commit 29bc3633.
- [x] Project Evidence / Next action / Blocked by: Project fields were refreshed for issue and PR with implementation evidence and routed follow-up state.
- [x] Post-merge/deploy/runtime proof: Local code gate is complete; seasonal runtime proof contract is recorded in Project follow-up state.
- [x] Named deliverable proof: PR #1733 at commit 29bc3633 contains the code/test/bundle deliverable.

## Live follow-up

Seasonal deploy and fresh `shardSeason` evidence will be collected by the controller under the Project follow-up state before issue completion.
