### PR TITLE
economy: allow bootstrap storage construction before refill

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -27431,6 +27431,26 @@ function selectHeuristicWorkerTask(creep) {
       targetId: bootstrapExtensionConstructionSite.id
     });
   }
+  const bootstrapCriticalRepairTarget = bootstrapNonCriticalWorkSuppressed && isWorkerInColonyRoom(creep) && !shouldKeepSpawnExtensionRefillBeforeBootstrapExtension(creep, spawnOrExtensionEnergySink) ? selectCriticalInfrastructureRepairTarget(creep) : null;
+  if (bootstrapCriticalRepairTarget) {
+    return applyMinimumUsefulLoadPolicy(creep, {
+      type: "repair",
+      targetId: bootstrapCriticalRepairTarget.id
+    });
+  }
+  const bootstrapStorageConstructionSite = selectBootstrapStorageConstructionSiteBeforeRefill(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    survivalAssessment,
+    controller
+  );
+  if (bootstrapStorageConstructionSite && !shouldKeepSpawnExtensionRefillBeforeBootstrapExtension(creep, spawnOrExtensionEnergySink)) {
+    return applyMinimumUsefulLoadPolicy(creep, {
+      type: "build",
+      targetId: bootstrapStorageConstructionSite.id
+    });
+  }
   if (!bootstrapNonCriticalWorkSuppressed && !remoteProductiveSpendingSuppressed) {
     const productiveTaskBeforeIdleRefill = selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(
       creep,
@@ -29786,6 +29806,24 @@ function selectBootstrapExtensionConstructionSiteBeforeRefill(creep, constructio
 function shouldPrioritizeBootstrapExtensionConstructionBeforeRefill(creep, survivalAssessment, controller) {
   return (survivalAssessment == null ? void 0 : survivalAssessment.mode) === "BOOTSTRAP" && isWorkerInColonyRoom(creep) && getUsedEnergy2(creep) > 0 && (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && controller.level >= 2 && shouldPrioritizeExtensionCapacity(creep.room);
 }
+function selectBootstrapStorageConstructionSiteBeforeRefill(creep, constructionSites, constructionReservationContext, survivalAssessment, controller) {
+  if (!shouldPrioritizeBootstrapStorageConstructionBeforeRefill(creep, survivalAssessment, controller)) {
+    return null;
+  }
+  return selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    isStorageConstructionSite,
+    {
+      priorityContext: buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites),
+      requireReasonableRange: true
+    }
+  );
+}
+function shouldPrioritizeBootstrapStorageConstructionBeforeRefill(creep, survivalAssessment, controller) {
+  return (survivalAssessment == null ? void 0 : survivalAssessment.mode) === "BOOTSTRAP" && isWorkerInColonyRoom(creep) && getUsedEnergy2(creep) > 0 && getActiveWorkParts2(creep) > 0 && (controller == null ? void 0 : controller.my) === true && getControllerLevel2(controller) >= 4 && !shouldGuardControllerDowngrade2(controller) && !hasVisibleHostilePresence3(creep.room) && checkEnergyBufferForStoredConstructionSpending(creep.room) && !hasOtherSameRoomLoadedBuildWorker(creep);
+}
 function shouldKeepSpawnExtensionRefillBeforeBootstrapExtension(creep, spawnOrExtensionEnergySink) {
   return spawnOrExtensionEnergySink !== null && (hasEmergencySpawnExtensionRefillDemand(creep) || isCriticalSpawnEnergySink(spawnOrExtensionEnergySink));
 }
@@ -29966,6 +30004,9 @@ function isExtensionConstructionSite(site) {
 }
 function isContainerConstructionSite3(site) {
   return matchesStructureType19(site.structureType, "STRUCTURE_CONTAINER", "container");
+}
+function isStorageConstructionSite(site) {
+  return matchesStructureType19(site.structureType, "STRUCTURE_STORAGE", "storage");
 }
 function isRoadConstructionSite2(site) {
   return matchesStructureType19(site.structureType, "STRUCTURE_ROAD", "road");

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -27431,7 +27431,7 @@ function selectHeuristicWorkerTask(creep) {
       targetId: bootstrapExtensionConstructionSite.id
     });
   }
-  const bootstrapCriticalRepairTarget = bootstrapNonCriticalWorkSuppressed && isWorkerInColonyRoom(creep) && !shouldKeepSpawnExtensionRefillBeforeBootstrapExtension(creep, spawnOrExtensionEnergySink) ? selectCriticalInfrastructureRepairTarget(creep) : null;
+  const bootstrapCriticalRepairTarget = bootstrapNonCriticalWorkSuppressed && isWorkerInColonyRoom(creep) && !shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) && !shouldKeepSpawnExtensionRefillBeforeBootstrapExtension(creep, spawnOrExtensionEnergySink) ? selectCriticalInfrastructureRepairTarget(creep) : null;
   if (bootstrapCriticalRepairTarget) {
     return applyMinimumUsefulLoadPolicy(creep, {
       type: "repair",
@@ -27445,7 +27445,7 @@ function selectHeuristicWorkerTask(creep) {
     survivalAssessment,
     controller
   );
-  if (bootstrapStorageConstructionSite && !shouldKeepSpawnExtensionRefillBeforeBootstrapExtension(creep, spawnOrExtensionEnergySink)) {
+  if (bootstrapStorageConstructionSite && !shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) && !shouldKeepSpawnExtensionRefillBeforeBootstrapExtension(creep, spawnOrExtensionEnergySink)) {
     return applyMinimumUsefulLoadPolicy(creep, {
       type: "build",
       targetId: bootstrapStorageConstructionSite.id

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -908,6 +908,36 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     });
   }
 
+  const bootstrapCriticalRepairTarget =
+    bootstrapNonCriticalWorkSuppressed &&
+    isWorkerInColonyRoom(creep) &&
+    !shouldKeepSpawnExtensionRefillBeforeBootstrapExtension(creep, spawnOrExtensionEnergySink)
+      ? selectCriticalInfrastructureRepairTarget(creep)
+      : null;
+  if (bootstrapCriticalRepairTarget) {
+    return applyMinimumUsefulLoadPolicy(creep, {
+      type: 'repair',
+      targetId: bootstrapCriticalRepairTarget.id as Id<Structure>
+    });
+  }
+
+  const bootstrapStorageConstructionSite = selectBootstrapStorageConstructionSiteBeforeRefill(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    survivalAssessment,
+    controller
+  );
+  if (
+    bootstrapStorageConstructionSite &&
+    !shouldKeepSpawnExtensionRefillBeforeBootstrapExtension(creep, spawnOrExtensionEnergySink)
+  ) {
+    return applyMinimumUsefulLoadPolicy(creep, {
+      type: 'build',
+      targetId: bootstrapStorageConstructionSite.id
+    });
+  }
+
   if (!bootstrapNonCriticalWorkSuppressed && !remoteProductiveSpendingSuppressed) {
     const productiveTaskBeforeIdleRefill = selectProductiveEnergySinkBeforeIdleSpawnExtensionRefill(
       creep,
@@ -4550,6 +4580,48 @@ function shouldPrioritizeBootstrapExtensionConstructionBeforeRefill(
   );
 }
 
+function selectBootstrapStorageConstructionSiteBeforeRefill(
+  creep: Creep,
+  constructionSites: ConstructionSite[],
+  constructionReservationContext: ConstructionReservationContext,
+  survivalAssessment: ColonySurvivalAssessment | null,
+  controller: StructureController | undefined
+): ConstructionSite | null {
+  if (!shouldPrioritizeBootstrapStorageConstructionBeforeRefill(creep, survivalAssessment, controller)) {
+    return null;
+  }
+
+  return selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    isStorageConstructionSite,
+    {
+      priorityContext: buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites),
+      requireReasonableRange: true
+    }
+  );
+}
+
+function shouldPrioritizeBootstrapStorageConstructionBeforeRefill(
+  creep: Creep,
+  survivalAssessment: ColonySurvivalAssessment | null,
+  controller: StructureController | undefined
+): boolean {
+  return (
+    survivalAssessment?.mode === 'BOOTSTRAP' &&
+    isWorkerInColonyRoom(creep) &&
+    getUsedEnergy(creep) > 0 &&
+    getActiveWorkParts(creep) > 0 &&
+    controller?.my === true &&
+    getControllerLevel(controller) >= 4 &&
+    !shouldGuardControllerDowngrade(controller) &&
+    !hasVisibleHostilePresence(creep.room) &&
+    checkEnergyBufferForStoredConstructionSpending(creep.room) &&
+    !hasOtherSameRoomLoadedBuildWorker(creep)
+  );
+}
+
 function shouldKeepSpawnExtensionRefillBeforeBootstrapExtension(
   creep: Creep,
   spawnOrExtensionEnergySink: StructureSpawn | StructureExtension | null
@@ -4847,6 +4919,10 @@ function isExtensionConstructionSite(site: ConstructionSite): boolean {
 
 function isContainerConstructionSite(site: ConstructionSite): boolean {
   return matchesStructureType(site.structureType, 'STRUCTURE_CONTAINER', 'container');
+}
+
+function isStorageConstructionSite(site: ConstructionSite): boolean {
+  return matchesStructureType(site.structureType, 'STRUCTURE_STORAGE', 'storage');
 }
 
 function isRoadConstructionSite(site: ConstructionSite): boolean {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -911,6 +911,7 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
   const bootstrapCriticalRepairTarget =
     bootstrapNonCriticalWorkSuppressed &&
     isWorkerInColonyRoom(creep) &&
+    !shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) &&
     !shouldKeepSpawnExtensionRefillBeforeBootstrapExtension(creep, spawnOrExtensionEnergySink)
       ? selectCriticalInfrastructureRepairTarget(creep)
       : null;
@@ -930,6 +931,7 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
   );
   if (
     bootstrapStorageConstructionSite &&
+    !shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) &&
     !shouldKeepSpawnExtensionRefillBeforeBootstrapExtension(creep, spawnOrExtensionEnergySink)
   ) {
     return applyMinimumUsefulLoadPolicy(creep, {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -8602,6 +8602,227 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toBeNull();
   });
 
+  it('assigns E29N56 bootstrap storage backlog before ordinary refill when stored construction energy is safe', () => {
+    const site = {
+      id: 'storage-site1',
+      my: true,
+      structureType: 'storage',
+      progress: 10_563,
+      progressTotal: 30_000,
+      pos: makeRoomPosition(18, 24, 'E29N56')
+    } as ConstructionSite;
+    const spawn = makeEnergySinkWithEnergy('spawn-needs-energy', 'spawn' as StructureConstant, 250, 50, {
+      my: true,
+      pos: makeRoomPosition(17, 24, 'E29N56')
+    }) as StructureSpawn;
+    const storage = makeStoredEnergyStructure('storage-built', 'storage' as StructureConstant, 1_816, {
+      my: true,
+      pos: makeRoomPosition(18, 23, 'E29N56')
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 3_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N56',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 250,
+      energyCapacityAvailable: 1_300,
+      myStructures: [spawn as AnyOwnedStructure],
+      structures: [spawn as AnyStructure, storage as AnyStructure]
+    });
+    const builder = {
+      name: 'worker-E29N56-1857320',
+      memory: {
+        role: 'worker',
+        colony: 'E29N56',
+        task: { type: 'transfer', targetId: 'spawn-needs-energy' as Id<AnyStoreStructure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 82 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 18 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'storage-site1' ? 4 : 2))
+      },
+      room
+    } as unknown as Creep;
+    const refiller = {
+      name: 'RefillCoverage',
+      memory: {
+        role: 'worker',
+        colony: 'E29N56',
+        task: { type: 'transfer', targetId: 'spawn-needs-energy' as Id<AnyStoreStructure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      },
+      room
+    } as unknown as Creep;
+    const assessment = assessColonySurvival({
+      roomName: 'E29N56',
+      totalCreeps: 10,
+      workerCapacity: 4,
+      workerTarget: 4,
+      energyAvailable: 250,
+      energyCapacityAvailable: 1_300,
+      defenseFloorReady: true,
+      controller: { my: true, level: 4, ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 3_000 },
+      hostileCreepCount: 0
+    });
+    expect(assessment.mode).toBe('BOOTSTRAP');
+    recordColonySurvivalAssessment('E29N56', assessment, 1_857_841);
+    setGameCreeps({ Builder: builder, RefillCoverage: refiller });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      ...((globalThis as unknown as { Game?: Partial<Game> }).Game ?? {}),
+      time: 1_857_841
+    };
+
+    expect(selectWorkerTask(builder)).toEqual({ type: 'build', targetId: 'storage-site1' });
+  });
+
+  it('keeps critical spawn refill before bootstrap storage backlog', () => {
+    const site = {
+      id: 'storage-site1',
+      my: true,
+      structureType: 'storage',
+      progress: 10_563,
+      progressTotal: 30_000,
+      pos: makeRoomPosition(18, 24, 'E29N56')
+    } as ConstructionSite;
+    const criticalSpawn = makeEnergySinkWithEnergy(
+      'spawn-critical',
+      'spawn' as StructureConstant,
+      CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+      101,
+      { my: true, pos: makeRoomPosition(17, 24, 'E29N56') }
+    ) as StructureSpawn;
+    const storage = makeStoredEnergyStructure('storage-built', 'storage' as StructureConstant, 1_816, {
+      my: true,
+      pos: makeRoomPosition(18, 23, 'E29N56')
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 3_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N56',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 250,
+      energyCapacityAvailable: 1_300,
+      myStructures: [criticalSpawn as AnyOwnedStructure],
+      structures: [criticalSpawn as AnyStructure, storage as AnyStructure]
+    });
+    const creep = {
+      name: 'worker-E29N56-1857320',
+      memory: { role: 'worker', colony: 'E29N56' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(82) },
+      pos: { getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'storage-site1' ? 4 : 2)) },
+      room
+    } as unknown as Creep;
+    const assessment = assessColonySurvival({
+      roomName: 'E29N56',
+      totalCreeps: 10,
+      workerCapacity: 4,
+      workerTarget: 4,
+      energyAvailable: 250,
+      energyCapacityAvailable: 1_300,
+      defenseFloorReady: true,
+      controller: { my: true, level: 4, ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 3_000 },
+      hostileCreepCount: 0
+    });
+    expect(assessment.mode).toBe('BOOTSTRAP');
+    recordColonySurvivalAssessment('E29N56', assessment, 1_857_841);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      ...((globalThis as unknown as { Game?: Partial<Game> }).Game ?? {}),
+      time: 1_857_841
+    };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-critical' });
+  });
+
+  it('keeps critical repair before bootstrap storage backlog', () => {
+    const site = {
+      id: 'storage-site1',
+      my: true,
+      structureType: 'storage',
+      progress: 10_563,
+      progressTotal: 30_000,
+      pos: makeRoomPosition(18, 24, 'E29N56')
+    } as ConstructionSite;
+    const spawn = makeEnergySinkWithEnergy('spawn-needs-energy', 'spawn' as StructureConstant, 250, 50, {
+      my: true,
+      pos: makeRoomPosition(17, 24, 'E29N56')
+    }) as StructureSpawn;
+    const storage = makeStoredEnergyStructure('storage-built', 'storage' as StructureConstant, 1_816, {
+      my: true,
+      pos: makeRoomPosition(18, 23, 'E29N56')
+    });
+    const criticalContainer = makeStoredEnergyContainerWithCapacity('critical-container1', 500, 2_000, {
+      hits: 800,
+      hitsMax: 2_000,
+      pos: makeRoomPosition(20, 24, 'E29N56')
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 3_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N56',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 250,
+      energyCapacityAvailable: 1_300,
+      myStructures: [spawn as AnyOwnedStructure],
+      structures: [spawn as AnyStructure, storage as AnyStructure, criticalContainer as AnyStructure]
+    });
+    const creep = {
+      name: 'worker-E29N56-1857320',
+      memory: { role: 'worker', colony: 'E29N56' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(82) },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => {
+          const ranges: Record<string, number> = {
+            'critical-container1': 2,
+            'storage-site1': 4,
+            'spawn-needs-energy': 2
+          };
+          return ranges[String(target.id)] ?? 10;
+        })
+      },
+      room
+    } as unknown as Creep;
+    const assessment = assessColonySurvival({
+      roomName: 'E29N56',
+      totalCreeps: 10,
+      workerCapacity: 4,
+      workerTarget: 4,
+      energyAvailable: 250,
+      energyCapacityAvailable: 1_300,
+      defenseFloorReady: true,
+      controller: { my: true, level: 4, ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 3_000 },
+      hostileCreepCount: 0
+    });
+    expect(assessment.mode).toBe('BOOTSTRAP');
+    recordColonySurvivalAssessment('E29N56', assessment, 1_857_841);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      ...((globalThis as unknown as { Game?: Partial<Game> }).Game ?? {}),
+      time: 1_857_841
+    };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'critical-container1' });
+  });
+
   it('allows home critical infrastructure repair during bootstrap', () => {
     recordSurvivalMode('BOOTSTRAP');
     const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0, {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -8749,6 +8749,67 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-critical' });
   });
 
+  it('keeps near-term spawn refill reserve before bootstrap storage backlog', () => {
+    const site = {
+      id: 'storage-site1',
+      my: true,
+      structureType: 'storage',
+      progress: 10_563,
+      progressTotal: 30_000,
+      pos: makeRoomPosition(18, 24, 'E29N56')
+    } as ConstructionSite;
+    const spawn = makeEnergySinkWithEnergy('spawn-needs-energy', 'spawn' as StructureConstant, 250, 50, {
+      my: true,
+      pos: makeRoomPosition(17, 24, 'E29N56')
+    }) as StructureSpawn;
+    const storage = makeStoredEnergyStructure('storage-built', 'storage' as StructureConstant, 1_816, {
+      my: true,
+      pos: makeRoomPosition(18, 23, 'E29N56')
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 3_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N56',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 250,
+      energyCapacityAvailable: 1_300,
+      myStructures: [spawn as AnyOwnedStructure],
+      structures: [spawn as AnyStructure, storage as AnyStructure]
+    });
+    const creep = {
+      name: 'worker-E29N56-1857320',
+      memory: { role: 'worker', colony: 'E29N56' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(82) },
+      pos: { getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'storage-site1' ? 4 : 2)) },
+      room
+    } as unknown as Creep;
+    const assessment = assessColonySurvival({
+      roomName: 'E29N56',
+      totalCreeps: 10,
+      workerCapacity: 4,
+      workerTarget: 4,
+      energyAvailable: 250,
+      energyCapacityAvailable: 1_300,
+      defenseFloorReady: true,
+      controller: { my: true, level: 4, ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 3_000 },
+      hostileCreepCount: 0
+    });
+    expect(assessment.mode).toBe('BOOTSTRAP');
+    recordColonySurvivalAssessment('E29N56', assessment, 1_857_841);
+    setGameCreeps({ Builder: creep });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      ...((globalThis as unknown as { Game?: Partial<Game> }).Game ?? {}),
+      time: 1_857_841
+    };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-needs-energy' });
+  });
+
   it('keeps critical repair before bootstrap storage backlog', () => {
     const site = {
       id: 'storage-site1',
@@ -8802,6 +8863,7 @@ describe('selectWorkerTask', () => {
       },
       room
     } as unknown as Creep;
+    const refiller = makeRefillReserveWorker(room, 'RefillCoverage', 100, 1);
     const assessment = assessColonySurvival({
       roomName: 'E29N56',
       totalCreeps: 10,
@@ -8815,12 +8877,74 @@ describe('selectWorkerTask', () => {
     });
     expect(assessment.mode).toBe('BOOTSTRAP');
     recordColonySurvivalAssessment('E29N56', assessment, 1_857_841);
+    setGameCreeps({ Repairer: creep, RefillCoverage: refiller });
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       ...((globalThis as unknown as { Game?: Partial<Game> }).Game ?? {}),
       time: 1_857_841
     };
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'critical-container1' });
+  });
+
+  it('keeps near-term spawn refill reserve before bootstrap critical repair', () => {
+    const spawn = makeEnergySinkWithEnergy('spawn-needs-energy', 'spawn' as StructureConstant, 250, 50, {
+      my: true,
+      pos: makeRoomPosition(17, 24, 'E29N56')
+    }) as StructureSpawn;
+    const criticalContainer = makeStoredEnergyContainerWithCapacity('critical-container1', 500, 2_000, {
+      hits: 800,
+      hitsMax: 2_000,
+      pos: makeRoomPosition(20, 24, 'E29N56')
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 3_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N56',
+      controller,
+      energyAvailable: 250,
+      energyCapacityAvailable: 1_300,
+      myStructures: [spawn as AnyOwnedStructure],
+      structures: [spawn as AnyStructure, criticalContainer as AnyStructure]
+    });
+    const creep = {
+      name: 'worker-E29N56-1857320',
+      memory: { role: 'worker', colony: 'E29N56' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(82) },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => {
+          const ranges: Record<string, number> = {
+            'critical-container1': 2,
+            'spawn-needs-energy': 2
+          };
+          return ranges[String(target.id)] ?? 10;
+        })
+      },
+      room
+    } as unknown as Creep;
+    const assessment = assessColonySurvival({
+      roomName: 'E29N56',
+      totalCreeps: 10,
+      workerCapacity: 4,
+      workerTarget: 4,
+      energyAvailable: 250,
+      energyCapacityAvailable: 1_300,
+      defenseFloorReady: true,
+      controller: { my: true, level: 4, ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 3_000 },
+      hostileCreepCount: 0
+    });
+    expect(assessment.mode).toBe('BOOTSTRAP');
+    recordColonySurvivalAssessment('E29N56', assessment, 1_857_841);
+    setGameCreeps({ Repairer: creep });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      ...((globalThis as unknown as { Game?: Partial<Game> }).Game ?? {}),
+      time: 1_857_841
+    };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-needs-energy' });
   });
 
   it('allows home critical infrastructure repair during bootstrap', () => {


### PR DESCRIPTION
## Summary
- Adds a guarded bootstrap pre-refill path so owned RCL4+ rooms with safe stored construction energy can assign a loaded same-room worker to storage construction before ordinary spawn/extension refill.
- Keeps emergency/critical spawn refill and local critical infrastructure repair ahead of that storage build path, preserving spawn-recovery safety.
- Adds E29N56-shaped regression coverage for the storage backlog case plus critical refill/repair precedence, and regenerates the Screeps bundle.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` → `105 passed, 2329 tests passed`
- `cd prod && npm run build`

Refs #1715

## Issue / postdeploy closure gate
- [x] #1715: PR implementation targets the fresh postdeploy successor blocker (`worker_assignment_gap_sustained` in shardX/E29N56 with one storage construction site, buildCarriedEnergy=0, taskCounts.build=0); keep the issue open until official deploy plus fresh all-owned runtime monitor acceptance proves the alert clears or exposes a more precise successor blocker.

## Universal task Done gate
- [x] Task type: Territory/Economy gameplay production-code bugfix.
- [x] Expected observable outcome / named deliverable: E29N56 can assign safe loaded local workers to bootstrap storage construction instead of losing the build task to ordinary refill while critical spawn refill and critical repair still win.
- [x] Non-goals / accepted substitutes: no paid compute, no learned-policy rollout, no owner-side decision, no destructive game action, and no direct manual edit on main.
- [x] Verification evidence required before Done: controller-side `git diff --check`, prod typecheck, full Jest `105 passed / 2329 tests`, and prod build all passed before Codex-authored commit `28c531dd`.
- [x] Project Evidence / Next action / Blocked by: next controller action is exact-head issue-completion/prod-ci/CodeRabbit/review-thread gate, then merge/deploy/runtime acceptance; Project field sync is handled by the scheduler.
- [x] Post-merge/deploy/runtime proof: official MMO deploy plus fresh all-owned monitor must show `worker_assignment_gap_sustained` cleared for shardX/E29N56 or a precise non-generic successor blocker.
- [x] Named deliverable proof: commit `28c531dd` changes `prod/src/tasks/workerTasks.ts`, `prod/test/workerTasks.test.ts`, and regenerated `prod/dist/main.js`.
