### PR TITLE
economy: account for refill acquisition coverage

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -28258,14 +28258,46 @@ function getOtherNearTermSpawnExtensionRefillCoverageEnergy(creep, spawnExtensio
   const spawnExtensionEnergyStructureIds = new Set(
     spawnExtensionEnergyStructures.map((structure) => String(structure.id))
   );
-  return getSameRoomLoadedWorkersForRefillReservations(creep).filter((worker) => !isSameCreep2(worker, creep)).filter(
-    (worker) => isWorkerRefillBoundOrReservableForSpawnExtensionDelivery(worker, spawnExtensionEnergyStructureIds)
-  ).reduce((total, worker) => total + getUsedEnergy2(worker), 0);
+  return getRoomOwnedCreeps(creep.room).filter((worker) => !isSameCreep2(worker, creep) && isSameRoomWorker(worker, creep.room)).reduce((total, worker) => {
+    if (isWorkerRefillBoundOrReservableForSpawnExtensionDelivery(worker, spawnExtensionEnergyStructureIds)) {
+      return total + getUsedEnergy2(worker);
+    }
+    return total + getNearTermSpawnExtensionRefillAcquisitionCoverageEnergy(worker);
+  }, 0);
 }
 function isWorkerRefillBoundOrReservableForSpawnExtensionDelivery(worker, spawnExtensionEnergyStructureIds) {
   var _a2;
   const task = (_a2 = worker.memory) == null ? void 0 : _a2.task;
-  return task == null || (task == null ? void 0 : task.type) === "transfer" && task.targetId !== void 0 && spawnExtensionEnergyStructureIds.has(String(task.targetId));
+  return getUsedEnergy2(worker) > 0 && (task == null || (task == null ? void 0 : task.type) === "transfer" && task.targetId !== void 0 && spawnExtensionEnergyStructureIds.has(String(task.targetId)));
+}
+function getNearTermSpawnExtensionRefillAcquisitionCoverageEnergy(worker) {
+  var _a2;
+  const task = (_a2 = worker.memory) == null ? void 0 : _a2.task;
+  if (!isWorkerEnergyAcquisitionReservationTask(task) || isWorkerConstructionEnergyAcquisitionReservationTask(task)) {
+    return 0;
+  }
+  const freeCapacity = getFreeEnergyCapacity8(worker);
+  if (freeCapacity <= 0) {
+    return 0;
+  }
+  const targetId = String(task.targetId);
+  const availableEnergy = task.type === "pickup" ? getVisibleDroppedEnergyAmount(worker.room, targetId) : getVisibleRefillAcquisitionSourceEnergy(worker, targetId);
+  return Math.min(freeCapacity, availableEnergy);
+}
+function getVisibleDroppedEnergyAmount(room, targetId) {
+  const resource = findDroppedResources(room).find((candidate) => String(candidate.id) === targetId);
+  return resource && isDroppedEnergy(resource, 1) ? Math.max(0, Math.floor(resource.amount)) : 0;
+}
+function getVisibleRefillAcquisitionSourceEnergy(worker, targetId) {
+  const context = {
+    creepOwnerUsername: getCreepOwnerUsername2(worker),
+    hasHostilePresence: hasVisibleHostilePresence3(worker.room),
+    room: worker.room
+  };
+  const source = findVisibleRoomStructures(worker.room).find(
+    (structure) => String(structure.id) === targetId && isSafeStoredEnergySource(structure, context)
+  );
+  return source ? getStoredEnergy15(source) : 0;
 }
 function shouldGuardControllerDowngradeForWorkerLoad(creep, controller, options = {}) {
   var _a2;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -2088,12 +2088,15 @@ function getOtherNearTermSpawnExtensionRefillCoverageEnergy(
     spawnExtensionEnergyStructures.map((structure) => String(structure.id))
   );
 
-  return getSameRoomLoadedWorkersForRefillReservations(creep)
-    .filter((worker) => !isSameCreep(worker, creep))
-    .filter((worker) =>
-      isWorkerRefillBoundOrReservableForSpawnExtensionDelivery(worker, spawnExtensionEnergyStructureIds)
-    )
-    .reduce((total, worker) => total + getUsedEnergy(worker), 0);
+  return getRoomOwnedCreeps(creep.room)
+    .filter((worker) => !isSameCreep(worker, creep) && isSameRoomWorker(worker, creep.room))
+    .reduce((total, worker) => {
+      if (isWorkerRefillBoundOrReservableForSpawnExtensionDelivery(worker, spawnExtensionEnergyStructureIds)) {
+        return total + getUsedEnergy(worker);
+      }
+
+      return total + getNearTermSpawnExtensionRefillAcquisitionCoverageEnergy(worker);
+    }, 0);
 }
 
 function isWorkerRefillBoundOrReservableForSpawnExtensionDelivery(
@@ -2101,11 +2104,52 @@ function isWorkerRefillBoundOrReservableForSpawnExtensionDelivery(
   spawnExtensionEnergyStructureIds: ReadonlySet<string>
 ): boolean {
   const task = worker.memory?.task as Partial<CreepTaskMemory> | null | undefined;
-  return task == null || (
-    task?.type === 'transfer' &&
-    task.targetId !== undefined &&
-    spawnExtensionEnergyStructureIds.has(String(task.targetId))
+  return (
+    getUsedEnergy(worker) > 0 &&
+    (task == null ||
+      (task?.type === 'transfer' &&
+        task.targetId !== undefined &&
+        spawnExtensionEnergyStructureIds.has(String(task.targetId))))
   );
+}
+
+function getNearTermSpawnExtensionRefillAcquisitionCoverageEnergy(worker: Creep): number {
+  const task = worker.memory?.task as Partial<CreepTaskMemory> | undefined;
+  if (
+    !isWorkerEnergyAcquisitionReservationTask(task) ||
+    isWorkerConstructionEnergyAcquisitionReservationTask(task)
+  ) {
+    return 0;
+  }
+
+  const freeCapacity = getFreeEnergyCapacity(worker);
+  if (freeCapacity <= 0) {
+    return 0;
+  }
+
+  const targetId = String(task.targetId);
+  const availableEnergy =
+    task.type === 'pickup'
+      ? getVisibleDroppedEnergyAmount(worker.room, targetId)
+      : getVisibleRefillAcquisitionSourceEnergy(worker, targetId);
+  return Math.min(freeCapacity, availableEnergy);
+}
+
+function getVisibleDroppedEnergyAmount(room: Room, targetId: string): number {
+  const resource = findDroppedResources(room).find((candidate) => String(candidate.id) === targetId);
+  return resource && isDroppedEnergy(resource, 1) ? Math.max(0, Math.floor(resource.amount)) : 0;
+}
+
+function getVisibleRefillAcquisitionSourceEnergy(worker: Creep, targetId: string): number {
+  const context: StoredEnergySourceContext = {
+    creepOwnerUsername: getCreepOwnerUsername(worker),
+    hasHostilePresence: hasVisibleHostilePresence(worker.room),
+    room: worker.room
+  };
+  const source = findVisibleRoomStructures(worker.room).find(
+    (structure) => String(structure.id) === targetId && isSafeStoredEnergySource(structure, context)
+  );
+  return source ? getStoredEnergy(source) : 0;
 }
 
 function shouldGuardControllerDowngradeForWorkerLoad(

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -8902,6 +8902,147 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(builder)).toEqual({ type: 'build', targetId: 'road-site1' });
   });
 
+  it('lets a loaded E29N55 worker build when another worker is already acquiring refill energy', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 820,
+      progressTotal: 1_000,
+      pos: makeRoomPosition(20, 23, 'E29N55')
+    } as ConstructionSite;
+    const fullSpawn = makeEnergySinkWithEnergy('spawn-full', 'spawn' as StructureConstant, 300, 0, {
+      my: true,
+      pos: makeRoomPosition(17, 24, 'E29N55')
+    }) as StructureSpawn;
+    const refillExtension = makeEnergySinkWithEnergy('extension-needs-energy', 'extension' as StructureConstant, 0, 50, {
+      my: true,
+      pos: makeRoomPosition(18, 24, 'E29N55')
+    }) as StructureExtension;
+    const storage = makeStoredEnergyStructure('storage-local', 'storage' as StructureConstant, 1_655, {
+      my: true,
+      pos: makeRoomPosition(18, 23, 'E29N55')
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 6,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N55',
+      constructionSites: [site],
+      controller,
+      energyAvailable: MINIMUM_WORKER_SPAWN_ENERGY - 50,
+      energyCapacityAvailable: 2_300,
+      myStructures: [fullSpawn as AnyOwnedStructure, refillExtension as AnyOwnedStructure],
+      structures: [fullSpawn as AnyStructure, refillExtension as AnyStructure, storage as AnyStructure]
+    });
+    const builder = {
+      name: 'worker-E29N55-loaded',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'transfer', targetId: 'extension-needs-energy' as Id<AnyStoreStructure> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'road-site1' ? 3 : 2))
+      },
+      room
+    } as unknown as Creep;
+    const refillAcquirer = {
+      name: 'worker-E29N55-refill-acquirer',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'withdraw', targetId: 'storage-local' as Id<AnyStoreStructure> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      pos: { getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'storage-local' ? 1 : 5)) },
+      room
+    } as unknown as Creep;
+    recordSurvivalMode('LOCAL_STABLE', 1_865_811);
+    setGameCreeps({ Builder: builder, RefillAcquirer: refillAcquirer });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      ...((globalThis as unknown as { Game?: Partial<Game> }).Game ?? {}),
+      time: 1_865_811
+    };
+
+    expect(selectWorkerTask(builder)).toEqual({ type: 'build', targetId: 'road-site1' });
+  });
+
+  it('keeps ordinary refill before construction when no worker covers the spawn floor', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 820,
+      progressTotal: 1_000,
+      pos: makeRoomPosition(20, 23, 'E29N55')
+    } as ConstructionSite;
+    const refillExtension = makeEnergySinkWithEnergy('extension-needs-energy', 'extension' as StructureConstant, 0, 50, {
+      my: true,
+      pos: makeRoomPosition(18, 24, 'E29N55')
+    }) as StructureExtension;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 6,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N55',
+      constructionSites: [site],
+      controller,
+      energyAvailable: MINIMUM_WORKER_SPAWN_ENERGY - 50,
+      energyCapacityAvailable: 2_300,
+      myStructures: [refillExtension as AnyOwnedStructure],
+      structures: [refillExtension as AnyStructure]
+    });
+    const builder = {
+      name: 'worker-E29N55-loaded',
+      memory: { role: 'worker', colony: 'E29N55' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'road-site1' ? 3 : 2))
+      },
+      room
+    } as unknown as Creep;
+    const idleWorker = {
+      name: 'worker-E29N55-idle',
+      memory: { role: 'worker', colony: 'E29N55' },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room
+    } as unknown as Creep;
+    recordSurvivalMode('LOCAL_STABLE', 1_865_812);
+    setGameCreeps({ Builder: builder, IdleWorker: idleWorker });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      ...((globalThis as unknown as { Game?: Partial<Game> }).Game ?? {}),
+      time: 1_865_812
+    };
+
+    expect(selectWorkerTask(builder)).toEqual({ type: 'transfer', targetId: 'extension-needs-energy' });
+  });
+
   it('keeps critical spawn refill before bootstrap storage backlog', () => {
     const site = {
       id: 'storage-site1',


### PR DESCRIPTION
## Summary

Related to issue #1715.

- Account for near-term same-room worker refill coverage when the refill worker is still acquiring energy from a visible storage/container/drop instead of already carrying it.
- Prevent a loaded worker from being held on spawn/extension refill when another worker is already committed to acquire enough refill energy for the spawn floor.
- Keep ordinary refill priority intact when no other worker covers the spawn/extension floor, with focused regression coverage.
- Rebuild the Screeps bundle from the verified source change.

## Root cause

The residual postdeploy `worker_assignment_gap_sustained` evidence showed loaded workers still blocked from construction/repair while another same-room worker was already acquiring refill energy. The previous reservation coverage only counted workers already carrying energy or directly bound to transfer targets, so acquisition tasks such as `withdraw` from visible storage did not count as near-term refill coverage. That made builders keep deferring to refill even when the floor was already effectively covered.

## Verification

From `/root/screeps-worktrees/issue-1715-residual-worker-assignment-20260606`:

- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 105 suites / 2348 tests passed
- `cd prod && npm run build`
- Commit-only recovery verified `51f1e7b9 lanyusea's bot <lanyusea@gmail.com> economy: account for refill acquisition coverage`

## Universal task Done gate

- [x] Task type: P0 official-MMO gameplay bugfix for residual `worker_assignment_gap_sustained` construction suppression.
- [x] Expected observable outcome / named deliverable: A loaded worker may select build/repair when another same-room worker already covers spawn/extension refill via visible energy acquisition; ordinary refill remains preferred when coverage is absent.
- [x] Non-goals / accepted substitutes: No direct Screeps deploy from this PR and no owner/manual action; post-merge official deploy and runtime acceptance remain controller follow-up under #1715/#1738.
- [x] Verification evidence required before Done: diff check, TypeScript typecheck, full Jest 105 suites / 2348 tests, and bundle build passed before commit `51f1e7b9`.
- [x] Project Evidence / Next action / Blocked by: Controller will add this PR to Project `screeps`, set In review, and route post-merge deploy/runtime acceptance through #1715 and #1738.
- [x] Post-merge/deploy/runtime proof: Runtime proof is a follow-up acceptance gate, not a prerequisite for this code PR; expected proof is fresh runtime-summary/alert evidence showing build activity resumes and worker_assignment_gap clears or materially decreases after deploy.
- [x] Named deliverable proof: Commit `51f1e7b9` changes `prod/src/tasks/workerTasks.ts`, `prod/test/workerTasks.test.ts`, and regenerated `prod/dist/main.js`.

## Live follow-up

After merge, deploy current main to official MMO and capture fresh all-owned-room runtime-summary/alert evidence. Keep #1715 open until the runtime alert clears or a successor issue captures any remaining residual; #1738 tracks the related buffer/construction acceptance watch.