### PR TITLE
fix: recover construction assignment after worker gap alert

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -33543,7 +33543,12 @@ function runWorker(creep) {
     executeAssignedTask(creep, (_a2 = criticalCpuTaskRetention.retainedTask) != null ? _a2 : null);
     return;
   }
-  const selectionContext = (_b = criticalCpuTaskRetention.selectionContext) != null ? _b : selectWorkerTaskContext(creep, currentTask);
+  const initialSelectionContext = (_b = criticalCpuTaskRetention.selectionContext) != null ? _b : selectWorkerTaskContext(creep, currentTask);
+  const selectionContext = applyWorkerAssignmentGapRecoveryTask(
+    creep,
+    currentTask,
+    initialSelectionContext
+  );
   const { baseSelectedTask, energyCriticalTask, selectedTask, spawnReservationRefillTask } = selectionContext;
   let taskAssignedThisTick = false;
   if (!currentTask) {
@@ -33577,6 +33582,8 @@ function runWorker(creep) {
   } else if (shouldPreemptEnergyAcquisitionTaskForSpawnReservationRefill(currentTask, spawnReservationRefillTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForNearFullConstruction(creep, currentTask, selectedTask)) {
+    taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
+  } else if (shouldPreemptEnergyAcquisitionTaskForProductiveBacklog(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
@@ -33767,6 +33774,89 @@ function selectWorkerTaskContext(creep, currentTask) {
     selectedTask,
     spawnReservationRefillTask
   };
+}
+function applyWorkerAssignmentGapRecoveryTask(creep, currentTask, selectionContext) {
+  const recoveryTask = selectWorkerAssignmentGapRecoveryTask(creep, currentTask, selectionContext);
+  return recoveryTask ? { ...selectionContext, selectedTask: recoveryTask } : selectionContext;
+}
+function selectWorkerAssignmentGapRecoveryTask(creep, currentTask, selectionContext) {
+  if (!isWorkerAssignmentGapRecoverySelection(currentTask, selectionContext.selectedTask)) {
+    return null;
+  }
+  if (getUsedTransferEnergy(creep) <= 0 || getActiveWorkParts3(creep) <= 0 || !hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep) || hasVisibleHostileCreeps2(creep.room) || currentTask && isDedicatedSourceContainerHarvestTask(creep, currentTask)) {
+    return null;
+  }
+  const constructionSite = selectWorkerAssignmentGapRecoveryConstructionSite(creep);
+  if (!constructionSite) {
+    return null;
+  }
+  const recoveryTask = {
+    type: "build",
+    targetId: constructionSite.id
+  };
+  if (!canExecuteTask(creep, recoveryTask) || isCriticalSpawnRefillTask(currentTask) || isCriticalSpawnRefillTask(selectionContext.selectedTask) || !shouldAllowAssignmentGapRecoveryBuildWorker(creep, currentTask, selectionContext.selectedTask) || !hasSafeAssignmentGapRecoveryConstructionEnergy(creep, recoveryTask)) {
+    return null;
+  }
+  return recoveryTask;
+}
+function isWorkerAssignmentGapRecoverySelection(currentTask, selectedTask) {
+  if (!currentTask && !selectedTask) {
+    return true;
+  }
+  return (currentTask === void 0 || currentTask === null || isEnergyAcquisitionTask2(currentTask) || currentTask.type === "transfer") && (selectedTask === null || isEnergyAcquisitionTask2(selectedTask) || selectedTask.type === "transfer");
+}
+function selectWorkerAssignmentGapRecoveryConstructionSite(creep) {
+  var _a2, _b;
+  if (typeof FIND_CONSTRUCTION_SITES !== "number" || typeof ((_a2 = creep.room) == null ? void 0 : _a2.find) !== "function") {
+    return null;
+  }
+  const sites = creep.room.find(FIND_CONSTRUCTION_SITES);
+  return (_b = sites.filter((site) => site.my !== false).filter((site) => !isBuildTargetSuppressedForWorker(creep, site)).filter((site) => canSpendWorkerEnergyOnConstructionSite(creep, site)).sort((left, right) => compareRoomObjectsByRangeAndId2(creep, left, right))[0]) != null ? _b : null;
+}
+function shouldAllowAssignmentGapRecoveryBuildWorker(creep, currentTask, selectedTask) {
+  if (!hasOtherSameRoomBuildAssignment(creep)) {
+    return true;
+  }
+  return !currentTask && selectedTask === null && getFreeTransferEnergyCapacity(creep) <= 0;
+}
+function hasSafeAssignmentGapRecoveryConstructionEnergy(creep, recoveryTask) {
+  const spawnReservationTarget = selectSpawnEnergyReservationRefillTarget(creep);
+  if (spawnReservationTarget) {
+    return shouldDeferSpawnReservationRefillForProductiveWork(creep, recoveryTask, spawnReservationTarget);
+  }
+  return !hasActiveSpawningSpawn2(creep.room) && (hasHealthyRoomEnergyBuffer2(creep.room) || hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room));
+}
+function hasStoredEnergyForAssignmentGapRecoveryConstruction(room) {
+  const energyAvailable = getRoomEnergyAvailable12(room);
+  return energyAvailable !== null && energyAvailable >= MINIMUM_WORKER_SPAWN_ENERGY && getRoomStoredEnergyAvailableForConstruction(room) >= CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY;
+}
+function isCriticalSpawnRefillTask(task) {
+  return (task == null ? void 0 : task.type) === "transfer" && getTransferSinkPriority(getTaskTarget(task)) >= 3;
+}
+function isBuildTargetSuppressedForWorker(creep, site) {
+  var _a2;
+  const blockedBuildTarget = (_a2 = creep.memory) == null ? void 0 : _a2.blockedBuildTarget;
+  if (!blockedBuildTarget) {
+    return false;
+  }
+  const tick = getGameTick4();
+  if (blockedBuildTarget.until <= tick) {
+    delete creep.memory.blockedBuildTarget;
+    return false;
+  }
+  return String(blockedBuildTarget.targetId) === String(site.id);
+}
+function hasVisibleHostileCreeps2(room) {
+  const findHostileCreeps4 = globalThis.FIND_HOSTILE_CREEPS;
+  if (typeof findHostileCreeps4 !== "number" || typeof (room == null ? void 0 : room.find) !== "function") {
+    return false;
+  }
+  try {
+    const findRoomObjects36 = room.find;
+    return findRoomObjects36(findHostileCreeps4).length > 0;
+  } catch {
+    return false;
+  }
 }
 function getCriticalCpuTaskRetentionDecision(creep, task) {
   if (!getRuntimeCpuBudget().critical || !task || !canExecuteTask(creep, task)) {
@@ -34611,6 +34701,23 @@ function shouldPreemptEnergyAcquisitionTaskForSpawnReservationRefill(task, spawn
 }
 function shouldPreemptEnergyAcquisitionTaskForNearFullConstruction(creep, task, selectedTask) {
   return isEnergyAcquisitionTask2(task) && selectedTask !== null && !isSameTask2(task, selectedTask) && shouldYieldStorageCriticalAcquisitionToNearFullConstruction(creep, task, selectedTask);
+}
+function shouldPreemptEnergyAcquisitionTaskForProductiveBacklog(creep, task, selectedTask) {
+  if (!isEnergyAcquisitionTask2(task) || selectedTask === null || isSameTask2(task, selectedTask) || !canExecuteTask(creep, selectedTask) || getUsedTransferEnergy(creep) <= 0) {
+    return false;
+  }
+  if (isDedicatedSourceContainerHarvestTask(creep, task)) {
+    return false;
+  }
+  if (selectedTask.type === "build") {
+    const constructionSite = getTaskTarget(selectedTask);
+    return Boolean(constructionSite && canSpendWorkerEnergyOnConstructionSite(creep, constructionSite));
+  }
+  if (selectedTask.type === "repair") {
+    const repairTarget = getTaskTarget(selectedTask);
+    return isRepairPreemptionStructure(repairTarget) && !isWorkerRepairTargetComplete(repairTarget);
+  }
+  return false;
 }
 function shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, task, selectedTask) {
   var _a2;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -150,8 +150,13 @@ export function runWorker(creep: Creep): void {
     return;
   }
 
-  const selectionContext =
+  const initialSelectionContext =
     criticalCpuTaskRetention.selectionContext ?? selectWorkerTaskContext(creep, currentTask);
+  const selectionContext = applyWorkerAssignmentGapRecoveryTask(
+    creep,
+    currentTask,
+    initialSelectionContext
+  );
   const { baseSelectedTask, energyCriticalTask, selectedTask, spawnReservationRefillTask } =
     selectionContext;
   let taskAssignedThisTick = false;
@@ -190,6 +195,8 @@ export function runWorker(creep: Creep): void {
   } else if (shouldPreemptEnergyAcquisitionTaskForSpawnReservationRefill(currentTask, spawnReservationRefillTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForNearFullConstruction(creep, currentTask, selectedTask)) {
+    taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
+  } else if (shouldPreemptEnergyAcquisitionTaskForProductiveBacklog(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
@@ -441,6 +448,154 @@ function selectWorkerTaskContext(
     selectedTask,
     spawnReservationRefillTask
   };
+}
+
+function applyWorkerAssignmentGapRecoveryTask(
+  creep: Creep,
+  currentTask: CreepTaskMemory | null | undefined,
+  selectionContext: WorkerTaskSelectionContext
+): WorkerTaskSelectionContext {
+  const recoveryTask = selectWorkerAssignmentGapRecoveryTask(creep, currentTask, selectionContext);
+  return recoveryTask ? { ...selectionContext, selectedTask: recoveryTask } : selectionContext;
+}
+
+function selectWorkerAssignmentGapRecoveryTask(
+  creep: Creep,
+  currentTask: CreepTaskMemory | null | undefined,
+  selectionContext: WorkerTaskSelectionContext
+): Extract<CreepTaskMemory, { type: 'build' }> | null {
+  if (!isWorkerAssignmentGapRecoverySelection(currentTask, selectionContext.selectedTask)) {
+    return null;
+  }
+
+  if (
+    getUsedTransferEnergy(creep) <= 0 ||
+    getActiveWorkParts(creep) <= 0 ||
+    !hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep) ||
+    hasVisibleHostileCreeps(creep.room) ||
+    (currentTask && isDedicatedSourceContainerHarvestTask(creep, currentTask))
+  ) {
+    return null;
+  }
+
+  const constructionSite = selectWorkerAssignmentGapRecoveryConstructionSite(creep);
+  if (!constructionSite) {
+    return null;
+  }
+
+  const recoveryTask: Extract<CreepTaskMemory, { type: 'build' }> = {
+    type: 'build',
+    targetId: constructionSite.id
+  };
+  if (
+    !canExecuteTask(creep, recoveryTask) ||
+    isCriticalSpawnRefillTask(currentTask) ||
+    isCriticalSpawnRefillTask(selectionContext.selectedTask) ||
+    !shouldAllowAssignmentGapRecoveryBuildWorker(creep, currentTask, selectionContext.selectedTask) ||
+    !hasSafeAssignmentGapRecoveryConstructionEnergy(creep, recoveryTask)
+  ) {
+    return null;
+  }
+
+  return recoveryTask;
+}
+
+function isWorkerAssignmentGapRecoverySelection(
+  currentTask: CreepTaskMemory | null | undefined,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  if (!currentTask && !selectedTask) {
+    return true;
+  }
+
+  return (
+    (currentTask === undefined || currentTask === null || isEnergyAcquisitionTask(currentTask) || currentTask.type === 'transfer') &&
+    (selectedTask === null || isEnergyAcquisitionTask(selectedTask) || selectedTask.type === 'transfer')
+  );
+}
+
+function selectWorkerAssignmentGapRecoveryConstructionSite(creep: Creep): ConstructionSite | null {
+  if (typeof FIND_CONSTRUCTION_SITES !== 'number' || typeof creep.room?.find !== 'function') {
+    return null;
+  }
+
+  const sites = creep.room.find(FIND_CONSTRUCTION_SITES) as ConstructionSite[];
+  return (
+    sites
+      .filter((site) => site.my !== false)
+      .filter((site) => !isBuildTargetSuppressedForWorker(creep, site))
+      .filter((site) => canSpendWorkerEnergyOnConstructionSite(creep, site))
+      .sort((left, right) => compareRoomObjectsByRangeAndId(creep, left, right))[0] ?? null
+  );
+}
+
+function shouldAllowAssignmentGapRecoveryBuildWorker(
+  creep: Creep,
+  currentTask: CreepTaskMemory | null | undefined,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  if (!hasOtherSameRoomBuildAssignment(creep)) {
+    return true;
+  }
+
+  return !currentTask && selectedTask === null && getFreeTransferEnergyCapacity(creep) <= 0;
+}
+
+function hasSafeAssignmentGapRecoveryConstructionEnergy(
+  creep: Creep,
+  recoveryTask: Extract<CreepTaskMemory, { type: 'build' }>
+): boolean {
+  const spawnReservationTarget = selectSpawnEnergyReservationRefillTarget(creep);
+  if (spawnReservationTarget) {
+    return shouldDeferSpawnReservationRefillForProductiveWork(creep, recoveryTask, spawnReservationTarget);
+  }
+
+  return (
+    !hasActiveSpawningSpawn(creep.room) &&
+    (hasHealthyRoomEnergyBuffer(creep.room) || hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room))
+  );
+}
+
+function hasStoredEnergyForAssignmentGapRecoveryConstruction(room: Room): boolean {
+  const energyAvailable = getRoomEnergyAvailable(room);
+  return (
+    energyAvailable !== null &&
+    energyAvailable >= MINIMUM_WORKER_SPAWN_ENERGY &&
+    getRoomStoredEnergyAvailableForConstruction(room) >= CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY
+  );
+}
+
+function isCriticalSpawnRefillTask(task: CreepTaskMemory | null | undefined): boolean {
+  return task?.type === 'transfer' && getTransferSinkPriority(getTaskTarget(task)) >= 3;
+}
+
+function isBuildTargetSuppressedForWorker(creep: Creep, site: ConstructionSite): boolean {
+  const blockedBuildTarget = creep.memory?.blockedBuildTarget;
+  if (!blockedBuildTarget) {
+    return false;
+  }
+
+  const tick = getGameTick();
+  if (blockedBuildTarget.until <= tick) {
+    delete creep.memory.blockedBuildTarget;
+    return false;
+  }
+
+  return String(blockedBuildTarget.targetId) === String(site.id);
+}
+
+function hasVisibleHostileCreeps(room: Room): boolean {
+  const findHostileCreeps = (globalThis as unknown as { FIND_HOSTILE_CREEPS?: number }).FIND_HOSTILE_CREEPS;
+  if (typeof findHostileCreeps !== 'number' || typeof room?.find !== 'function') {
+    return false;
+  }
+
+  try {
+    const findRoomObjects = room.find as unknown as (type: number) => unknown[];
+    return findRoomObjects(findHostileCreeps).length > 0;
+  } catch {
+    return false;
+  }
 }
 
 function getCriticalCpuTaskRetentionDecision(
@@ -1781,6 +1936,38 @@ function shouldPreemptEnergyAcquisitionTaskForNearFullConstruction(
     !isSameTask(task, selectedTask) &&
     shouldYieldStorageCriticalAcquisitionToNearFullConstruction(creep, task, selectedTask)
   );
+}
+
+function shouldPreemptEnergyAcquisitionTaskForProductiveBacklog(
+  creep: Creep,
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  if (
+    !isEnergyAcquisitionTask(task) ||
+    selectedTask === null ||
+    isSameTask(task, selectedTask) ||
+    !canExecuteTask(creep, selectedTask) ||
+    getUsedTransferEnergy(creep) <= 0
+  ) {
+    return false;
+  }
+
+  if (isDedicatedSourceContainerHarvestTask(creep, task)) {
+    return false;
+  }
+
+  if (selectedTask.type === 'build') {
+    const constructionSite = getTaskTarget(selectedTask) as ConstructionSite | null;
+    return Boolean(constructionSite && canSpendWorkerEnergyOnConstructionSite(creep, constructionSite));
+  }
+
+  if (selectedTask.type === 'repair') {
+    const repairTarget = getTaskTarget(selectedTask);
+    return isRepairPreemptionStructure(repairTarget) && !isWorkerRepairTargetComplete(repairTarget);
+  }
+
+  return false;
 }
 
 function shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -6935,6 +6935,374 @@ describe('runWorker', () => {
     expect(transfer).not.toHaveBeenCalled();
   });
 
+  it('preempts retained harvest for construction backlog when stored energy can cover construction', () => {
+    const source = {
+      id: 'source1',
+      energy: 3_000
+    } as Source;
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 935,
+      progressTotal: 5_000
+    } as ConstructionSite;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 2_441 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(10_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N57',
+      energyAvailable: 300,
+      energyCapacityAvailable: 1_800,
+      controller,
+      storage,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [storage] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [storage];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          if (type === FIND_SOURCES) {
+            return [source];
+          }
+
+          if (type === FIND_HOSTILE_CREEPS) {
+            return [];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const harvest = jest.fn();
+    const selectedBuildTask = { type: 'build', targetId: 'road-site1' as Id<ConstructionSite> } as const;
+    const creep = {
+      name: 'LoadedHarvester',
+      memory: {
+        role: 'worker',
+        colony: 'E29N57',
+        task: { type: 'harvest', targetId: 'source1' as Id<Source> }
+      },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 15 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 85 : 0))
+      },
+      room,
+      build,
+      harvest,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const recoveryWorker = {
+      name: 'RecoveryWorker',
+      memory: { role: 'worker', colony: 'E29N57' },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, recoveryWorker);
+    const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(selectedBuildTask);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { LoadedHarvester: creep, RecoveryWorker: recoveryWorker },
+      rooms: { E29N57: room },
+      time: 1_870_030,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        if (id === 'source1') {
+          return source;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual(selectedBuildTask);
+      expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+        currentTask: 'harvest',
+        baseSelectedTask: 'build',
+        selectedTask: 'build',
+        assignedTask: 'build'
+      });
+      expect(build).toHaveBeenCalledWith(site);
+      expect(harvest).not.toHaveBeenCalled();
+    } finally {
+      selectWorkerTask.mockRestore();
+    }
+  });
+
+  it('recovers construction assignment from retained noncritical extension refill selection', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 935,
+      progressTotal: 5_000
+    } as ConstructionSite;
+    const extension = {
+      id: 'extension1',
+      structureType: 'extension',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+      }
+    } as unknown as StructureExtension;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 2_287 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(10_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 6,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N55',
+      energyAvailable: 300,
+      energyCapacityAvailable: 2_300,
+      controller,
+      storage,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [extension, storage] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [extension, storage];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          if (type === FIND_HOSTILE_CREEPS) {
+            return [];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const transfer = jest.fn();
+    const selectedTransferTask = { type: 'transfer', targetId: 'extension1' as Id<AnyStoreStructure> } as const;
+    const creep = {
+      name: 'LoadedRefiller',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: selectedTransferTask
+      },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 55 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 45 : 0))
+      },
+      room,
+      build,
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const recoveryWorker = {
+      name: 'RecoveryWorker',
+      memory: { role: 'worker', colony: 'E29N55' },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, recoveryWorker);
+    const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(selectedTransferTask);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { LoadedRefiller: creep, RecoveryWorker: recoveryWorker },
+      rooms: { E29N55: room },
+      time: 1_870_031,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        if (id === 'extension1') {
+          return extension;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({ type: 'build', targetId: 'road-site1' });
+      expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+        currentTask: 'transfer',
+        baseSelectedTask: 'transfer',
+        selectedTask: 'build',
+        assignedTask: 'build'
+      });
+      expect(build).toHaveBeenCalledWith(site);
+      expect(transfer).not.toHaveBeenCalled();
+    } finally {
+      selectWorkerTask.mockRestore();
+    }
+  });
+
+  it('recovers construction assignment for a full idle worker when selection returns null', () => {
+    const site = {
+      id: 'storage-site1',
+      my: true,
+      structureType: 'storage',
+      progress: 334,
+      progressTotal: 4_000
+    } as ConstructionSite;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 3_240 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(10_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N56',
+      energyAvailable: 300,
+      energyCapacityAvailable: 1_300,
+      controller,
+      storage,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [storage] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [storage];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          if (type === FIND_HOSTILE_CREEPS) {
+            return [];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'IdleLoadedWorker',
+      memory: { role: 'worker', colony: 'E29N56' },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      },
+      room,
+      build,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const existingBuilder = {
+      name: 'ExistingBuilder',
+      memory: { role: 'worker', colony: 'E29N56', task: { type: 'build', targetId: 'storage-site1' as Id<ConstructionSite> } },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, existingBuilder);
+    const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(null);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { IdleLoadedWorker: creep, ExistingBuilder: existingBuilder },
+      rooms: { E29N56: room },
+      time: 1_870_032,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'storage-site1') {
+          return site;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({ type: 'build', targetId: 'storage-site1' });
+      expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+        selectedTask: 'build',
+        assignedTask: 'build'
+      });
+      expect(build).toHaveBeenCalledWith(site);
+    } finally {
+      selectWorkerTask.mockRestore();
+    }
+  });
+
   it('preempts an E29N55 tower refill transfer for construction backlog while CPU shedding', () => {
     const site = {
       id: 'road-site1',


### PR DESCRIPTION
## Linked issues

Intentional PR-body closing linkage:
- 

Related / non-closing linkage:
- Related to issue 1715.
- Related to issue 1738.

## Domain / Kind

- Domain: Territory/Economy
- Kind: bug

## Summary

- Recovers the residual postdeploy worker-assignment gap when a full idle worker sees healthy stored construction energy but task selection returns no assignment.
- Splits assignment-gap construction energy safety from spawn-reservation deferral so existing builders do not block an additional eligible full worker from joining construction.
- Adds focused worker-runner regression coverage and rebuilds the bundled Screeps artifact.

## Verification

- [x] Local check: `git diff --check` passed.
- [x] Local check: `npm --prefix prod run typecheck` passed.
- [x] Local check: `npm --prefix prod test -- --runInBand` passed: 105 suites / 2353 tests passed.
- [x] Local check: `npm --prefix prod run build` passed and regenerated `prod/dist/main.js`.
- [x] GitHub Project issue/PR fields are current (`Status`, `Evidence`, `Next action`; plus `Blocked by` when relevant). Controller records this PR item and refreshes issue 1715 / issue 1738 after PR creation.
- [x] Automated review has no blocking findings and review threads are resolved/outdated/non-blocking. Gate remains active until checks and review complete on this exact head.
- [x] QA gate: independent QA is part of the review gate for this runtime fix.
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate

- [x] Task type: code behavior / runtime bugfix.
- [x] Expected observable outcome / named deliverable: a full eligible worker can take construction work during assignment-gap recovery when room energy is healthy and construction backlog exists.
- [x] Non-goals / accepted substitutes: no learned-policy rollout, no direct official MMO deploy from the PR branch, and no linked issue closure in this PR body.
- [x] Verification evidence required before Done: `git diff --check`, `npm --prefix prod run typecheck`, full Jest, and `npm --prefix prod run build` passed on commit `b1cc5ba0`.
- [x] Project Evidence / Next action / Blocked by: Project state is keyed to this PR head `b1cc5ba0`, issue 1715 runtime acceptance, and issue 1738 construction unblock acceptance.
- [x] Post-merge/deploy/runtime proof: operational acceptance criterion is fresh all-owned monitor evidence from the official main deployment clearing `worker_assignment_gap_sustained` for E29N55, E29N56, and E29N57.
- [x] Named deliverable proof: commit `b1cc5ba0` updates `prod/src/creeps/workerRunner.ts`, `prod/test/workerRunner.test.ts`, and `prod/dist/main.js` with passing controller verification.

## Issue closure gate

For every issue linked above in the PR body with a closing keyword:

- [x] No closing keyword is used for the linked runtime issues because runtime acceptance is handled by Project evidence.
- [x] Closed tracked issues have no leftover runtime/process proof or owner action in this PR body.

## Runtime / deployment impact

- [ ] No gameplay/runtime/deployment impact.
- [x] Gameplay/runtime/deployment impact; Deployment Floor evidence or HELD blocker is recorded. This PR must be deployed after merge, then accepted only with fresh all-owned monitor evidence clearing the worker-assignment gap.

## Notes

- Review/merge gates: wait at least 15 minutes after PR creation, require green checks, substantive automated review/no active review threads, current Project state, and post-deploy monitor acceptance before linked runtime issues are closed.
