### PR TITLE
fix: recover build assignment from retained upgrade task

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -33780,7 +33780,7 @@ function applyWorkerAssignmentGapRecoveryTask(creep, currentTask, selectionConte
   return recoveryTask ? { ...selectionContext, selectedTask: recoveryTask } : selectionContext;
 }
 function selectWorkerAssignmentGapRecoveryTask(creep, currentTask, selectionContext) {
-  if (!isWorkerAssignmentGapRecoverySelection(currentTask, selectionContext.selectedTask)) {
+  if (!isWorkerAssignmentGapRecoverySelection(creep, currentTask, selectionContext.selectedTask)) {
     return null;
   }
   if (getUsedTransferEnergy(creep) <= 0 || getActiveWorkParts3(creep) <= 0 || !hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep) || hasVisibleHostileCreeps2(creep.room) || currentTask && isDedicatedSourceContainerHarvestTask(creep, currentTask)) {
@@ -33799,11 +33799,15 @@ function selectWorkerAssignmentGapRecoveryTask(creep, currentTask, selectionCont
   }
   return recoveryTask;
 }
-function isWorkerAssignmentGapRecoverySelection(currentTask, selectedTask) {
+function isWorkerAssignmentGapRecoverySelection(creep, currentTask, selectedTask) {
   if (!currentTask && !selectedTask) {
     return true;
   }
-  return (currentTask === void 0 || currentTask === null || isEnergyAcquisitionTask2(currentTask) || currentTask.type === "transfer") && (selectedTask === null || isEnergyAcquisitionTask2(selectedTask) || selectedTask.type === "transfer");
+  const allowUpgradeRecovery = !isControllerDowngradeGuardActive2(creep.room);
+  return isWorkerAssignmentGapRecoveryTask(currentTask, allowUpgradeRecovery) && isWorkerAssignmentGapRecoveryTask(selectedTask, allowUpgradeRecovery);
+}
+function isWorkerAssignmentGapRecoveryTask(task, allowUpgradeRecovery) {
+  return task === void 0 || task === null || isEnergyAcquisitionTask2(task) || task.type === "transfer" || allowUpgradeRecovery && task.type === "upgrade";
 }
 function selectWorkerAssignmentGapRecoveryConstructionSite(creep) {
   var _a2, _b;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -464,7 +464,7 @@ function selectWorkerAssignmentGapRecoveryTask(
   currentTask: CreepTaskMemory | null | undefined,
   selectionContext: WorkerTaskSelectionContext
 ): Extract<CreepTaskMemory, { type: 'build' }> | null {
-  if (!isWorkerAssignmentGapRecoverySelection(currentTask, selectionContext.selectedTask)) {
+  if (!isWorkerAssignmentGapRecoverySelection(creep, currentTask, selectionContext.selectedTask)) {
     return null;
   }
 
@@ -501,6 +501,7 @@ function selectWorkerAssignmentGapRecoveryTask(
 }
 
 function isWorkerAssignmentGapRecoverySelection(
+  creep: Creep,
   currentTask: CreepTaskMemory | null | undefined,
   selectedTask: CreepTaskMemory | null
 ): boolean {
@@ -508,9 +509,21 @@ function isWorkerAssignmentGapRecoverySelection(
     return true;
   }
 
+  const allowUpgradeRecovery = !isControllerDowngradeGuardActive(creep.room);
+  return isWorkerAssignmentGapRecoveryTask(currentTask, allowUpgradeRecovery) &&
+    isWorkerAssignmentGapRecoveryTask(selectedTask, allowUpgradeRecovery);
+}
+
+function isWorkerAssignmentGapRecoveryTask(
+  task: CreepTaskMemory | null | undefined,
+  allowUpgradeRecovery: boolean
+): boolean {
   return (
-    (currentTask === undefined || currentTask === null || isEnergyAcquisitionTask(currentTask) || currentTask.type === 'transfer') &&
-    (selectedTask === null || isEnergyAcquisitionTask(selectedTask) || selectedTask.type === 'transfer')
+    task === undefined ||
+    task === null ||
+    isEnergyAcquisitionTask(task) ||
+    task.type === 'transfer' ||
+    (allowUpgradeRecovery && task.type === 'upgrade')
   );
 }
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -7065,6 +7065,132 @@ describe('runWorker', () => {
     }
   });
 
+  it('recovers construction assignment from retained controller progress when stored energy can cover construction', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 1_429,
+      progressTotal: 5_000,
+      pos: { x: 22, y: 21, roomName: 'E29N57' } as RoomPosition
+    } as ConstructionSite;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 2_438 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(10_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N57',
+      energyAvailable: 650,
+      energyCapacityAvailable: 1_800,
+      controller,
+      storage,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [storage] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [storage];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          if (type === FIND_HOSTILE_CREEPS) {
+            return [];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const upgradeController = jest.fn();
+    const selectedUpgradeTask = { type: 'upgrade', targetId: 'controller1' as Id<StructureController> } as const;
+    const creep = {
+      name: 'LoadedUpgrader',
+      memory: {
+        role: 'worker',
+        colony: 'E29N57',
+        task: selectedUpgradeTask
+      },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 97 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 3 : 0))
+      },
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'road-site1' ? 3 : 12))
+      },
+      room,
+      build,
+      upgradeController,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const recoveryWorker = {
+      name: 'RecoveryWorker',
+      memory: { role: 'worker', colony: 'E29N57' },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, recoveryWorker);
+    const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(selectedUpgradeTask);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { LoadedUpgrader: creep, RecoveryWorker: recoveryWorker },
+      rooms: { E29N57: room },
+      time: 1_871_982,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        if (id === 'controller1') {
+          return controller;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({ type: 'build', targetId: 'road-site1' });
+      expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+        currentTask: 'upgrade',
+        baseSelectedTask: 'upgrade',
+        selectedTask: 'build',
+        assignedTask: 'build'
+      });
+      expect(build).toHaveBeenCalledWith(site);
+      expect(upgradeController).not.toHaveBeenCalled();
+    } finally {
+      selectWorkerTask.mockRestore();
+    }
+  });
+
   it('recovers construction assignment from retained noncritical extension refill selection', () => {
     const site = {
       id: 'road-site1',


### PR DESCRIPTION
## Linked issues

Intentional PR-body closing linkage:
-

Related / non-closing linkage:
- Related to issue 1715.
- Related to issue 1738.

## Domain / Kind

- Domain: Territory/Economy
- Kind: bug

## Summary

- Extends the worker-assignment-gap recovery path so a loaded worker can preempt retained upgrade work for construction when the controller downgrade guard is not active.
- Keeps upgrade retention protected when the controller downgrade guard is active, preserving safety while letting healthy rooms resume building.
- Adds focused worker-runner regression coverage and rebuilds the bundled Screeps artifact.

## Verification

- [x] Local check: `git diff --check` passed before commit and after commit range verification.
- [x] Local check: `npm --prefix prod run typecheck` passed.
- [x] Local check: `npm --prefix prod test -- --runInBand` passed: 105 suites / 2354 tests passed.
- [x] Local check: `npm --prefix prod run build` passed and regenerated `prod/dist/main.js`.
- [x] GitHub Project issue/PR fields are current (`Status`, `Evidence`, `Next action`; plus `Blocked by` when relevant). Controller will add this PR item and refresh issue 1715 / issue 1738 after PR creation.
- [x] Automated review has no blocking findings and review threads are resolved/outdated/non-blocking. Gate remains active until checks and review complete on this exact head.
- [x] QA gate: independent QA is required before merge for this runtime fix.
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate

- [x] Task type: code behavior / runtime bugfix.
- [x] Expected observable outcome / named deliverable: workers carrying energy can join construction during assignment-gap recovery instead of retaining non-urgent upgrade work when construction backlog exists.
- [x] Non-goals / accepted substitutes: no learned-policy rollout, no direct official MMO deploy from the PR branch, and no linked issue closure in this PR body.
- [x] Verification evidence required before Done: `git diff --check`, `npm --prefix prod run typecheck`, full Jest, and `npm --prefix prod run build` passed on commit `73681c3d`.
- [x] Project Evidence / Next action / Blocked by: Project state is keyed to this PR head `73681c3d`, issue 1715 runtime acceptance, and issue 1738 construction unblock / buffer acceptance.
- [x] Post-merge/deploy/runtime proof: operational acceptance criterion is fresh all-owned monitor evidence from the official main deployment clearing `worker_assignment_gap_sustained` for E29N55 and E29N57 and showing build/repair carried energy or construction progress.
- [x] Named deliverable proof: commit `73681c3d` updates `prod/src/creeps/workerRunner.ts`, `prod/test/workerRunner.test.ts`, and `prod/dist/main.js` with passing controller verification.

## Issue closure gate

For every issue linked above in the PR body with a closing keyword:

- [x] No closing keyword is used for the linked runtime issues because runtime acceptance is handled by Project evidence.
- [x] Closed tracked issues have no leftover runtime/process proof or owner action in this PR body.

## Runtime / deployment impact

- [ ] No gameplay/runtime/deployment impact.
- [x] Gameplay/runtime/deployment impact; Deployment Floor evidence or HELD blocker is recorded. This PR must be deployed after merge, then accepted only with fresh all-owned monitor evidence clearing the worker-assignment gap and confirming construction progress.

## Notes

- Review/merge gates: wait at least 15 minutes after PR creation, require green checks, substantive automated review/no active review threads, current Project state, and post-deploy monitor acceptance before linked runtime issues are closed.
