### PR TITLE
rl: persist failure artifacts for interrupted training runs

### DIFF
--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -10,6 +10,7 @@ import json
 import math
 import os
 import re
+import signal
 import statistics
 import sys
 import tempfile
@@ -36,6 +37,7 @@ import screeps_cli_io
 SCHEMA_VERSION = 1
 REPORT_TYPE = "screeps-rl-training-report"
 SUMMARY_TYPE = "screeps-rl-training-generation"
+FAILURE_REPORT_TYPE = "screeps-rl-training-failure-report"
 DEFAULT_OUT_DIR = Path("runtime-artifacts/rl-training")
 DEFAULT_RESOURCE_NORMALIZER = 1000.0
 DEFAULT_RUN_REPETITIONS = 1
@@ -127,6 +129,16 @@ class TrainingCardError(ValueError):
     """Raised when an experiment card is unsafe or structurally invalid."""
 
 
+class TrainingRunnerInterrupted(KeyboardInterrupt):
+    """Raised when the CLI receives a termination signal during a training run."""
+
+    def __init__(self, signum: int | None = None) -> None:
+        self.signum = signum
+        signal_name = signal_name_for_number(signum)
+        detail = f" by {signal_name}" if signal_name is not None else ""
+        super().__init__(f"training runner interrupted{detail}")
+
+
 @dataclass(frozen=True)
 class StrategyVariant:
     """Strategy candidate metadata consumed by the simulator and report."""
@@ -210,6 +222,15 @@ class SimulationConfig:
 
 def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def signal_name_for_number(signum: int | None) -> str | None:
+    if signum is None:
+        return None
+    try:
+        return signal.Signals(signum).name
+    except ValueError:
+        return f"signal-{signum}"
 
 
 def canonical_json(value: Any) -> str:
@@ -8187,6 +8208,202 @@ def build_generation_summary(report: JsonObject) -> JsonObject:
     return summary
 
 
+def training_failure_classification(error: BaseException) -> str:
+    if isinstance(error, (TrainingRunnerInterrupted, KeyboardInterrupt)):
+        return "interrupted"
+    if isinstance(error, TimeoutError):
+        return "timeout"
+    if isinstance(error, TrainingCardError):
+        return "card_validation_failed"
+    if isinstance(error, OSError):
+        return "io_error"
+    return "runner_failed"
+
+
+def training_failure_exit_code(error: BaseException) -> int:
+    if isinstance(error, TrainingRunnerInterrupted) and error.signum is not None:
+        return 128 + int(error.signum)
+    if isinstance(error, KeyboardInterrupt):
+        return 130
+    return 2
+
+
+def training_failure_report_context(
+    *,
+    card_path: Path,
+    report_id: str | None,
+    registry_path: Path | None,
+) -> JsonObject:
+    requested_report_id = text_or_none(report_id)
+    warnings: list[str] = []
+    resolved_report_id: str | None = None
+    artifact_stem: str | None = None
+    card_summary: JsonObject | None = None
+
+    if requested_report_id is not None:
+        try:
+            validate_report_id(requested_report_id)
+            resolved_report_id = requested_report_id
+            artifact_stem = requested_report_id
+        except TrainingCardError as error:
+            artifact_stem = safe_artifact_stem(requested_report_id)
+            warnings.append(f"requested report id was invalid: {dataset_export.redact_text(str(error))}")
+
+    try:
+        card = load_experiment_card(card_path)
+        card_summary = summarize_card(card, card_path)
+        if resolved_report_id is None and requested_report_id is None:
+            variants = load_strategy_variants(card, registry_path=registry_path)
+            variants = apply_policy_gradient_candidate_vectors_to_variants(card, variants)
+            config = simulation_config_from_card(card)
+            variants = expand_scale_environment_strategy_variants(variants, config.scale_environments)
+            resolved_report_id = default_report_id(card, variants, config)
+            artifact_stem = resolved_report_id
+    except Exception as error:  # noqa: BLE001 - failure reporting must survive context collection failures
+        warnings.append(f"training failure context was partial: {dataset_export.redact_text(str(error))}")
+
+    if artifact_stem is None:
+        seed = canonical_hash(
+            {
+                "cardPath": str(card_path),
+                "requestedReportId": requested_report_id,
+            }
+        )[:12]
+        artifact_stem = f"rl-training-failure-{seed}"
+
+    context: JsonObject = {
+        "artifactStem": safe_artifact_stem(artifact_stem),
+        "warnings": warnings,
+    }
+    if resolved_report_id is not None:
+        context["reportId"] = resolved_report_id
+    if requested_report_id is not None:
+        context["requestedReportId"] = requested_report_id
+    if card_summary is not None:
+        context["experimentCardSummary"] = card_summary
+    return context
+
+
+def build_training_failure_report(
+    *,
+    card_path: Path,
+    out_dir: Path,
+    report_id: str | None,
+    registry_path: Path | None,
+    error: BaseException,
+    failure_path: Path,
+    generated_at: str | None = None,
+    context: JsonObject | None = None,
+) -> JsonObject:
+    if context is None:
+        context = training_failure_report_context(
+            card_path=card_path,
+            report_id=report_id,
+            registry_path=registry_path,
+        )
+    resolved_report_id = text_or_none(context.get("reportId"))
+    requested_report_id = text_or_none(context.get("requestedReportId"))
+    classification = training_failure_classification(error)
+    error_text = dataset_export.redact_text(str(error) or type(error).__name__)
+    failure: JsonObject = {
+        "classification": classification,
+        "phase": classification,
+        "exceptionType": type(error).__name__,
+        "error": error_text,
+    }
+    if isinstance(error, TrainingRunnerInterrupted):
+        signal_name = signal_name_for_number(error.signum)
+        if error.signum is not None:
+            failure["signalNumber"] = error.signum
+        if signal_name is not None:
+            failure["signalName"] = signal_name
+
+    report: JsonObject = {
+        "type": FAILURE_REPORT_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "ok": False,
+        "status": "failed",
+        "trainingReportProduced": False,
+        "trainingReportType": REPORT_TYPE,
+        "generatedAt": generated_at or utc_now_iso(),
+        "cardPath": dataset_export.display_path(card_path),
+        "outDir": dataset_export.display_path(out_dir),
+        "failureArtifactPath": dataset_export.display_path(failure_path),
+        "failure": failure,
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+        "safety": safety_metadata(),
+    }
+    if resolved_report_id is not None:
+        report["reportId"] = resolved_report_id
+        report["expectedReportPath"] = dataset_export.display_path(out_dir / f"{resolved_report_id}.json")
+    if requested_report_id is not None:
+        report["requestedReportId"] = requested_report_id
+    if isinstance(context.get("experimentCardSummary"), dict):
+        report["experimentCardSummary"] = copy.deepcopy(context["experimentCardSummary"])
+    warnings = context.get("warnings")
+    if isinstance(warnings, list) and warnings:
+        report["warnings"] = copy.deepcopy(warnings)
+    return report
+
+
+def write_training_failure_report(
+    *,
+    card_path: Path,
+    out_dir: Path,
+    report_id: str | None,
+    registry_path: Path | None,
+    error: BaseException,
+) -> JsonObject:
+    resolved_out_dir = out_dir.expanduser()
+    context = training_failure_report_context(
+        card_path=card_path,
+        report_id=report_id,
+        registry_path=registry_path,
+    )
+    artifact_stem = text_or_none(context.get("artifactStem")) or "rl-training-failure"
+    failure_path = resolved_out_dir / f"{safe_artifact_stem(artifact_stem)}.failure.json"
+    report = build_training_failure_report(
+        card_path=card_path,
+        out_dir=resolved_out_dir,
+        report_id=report_id,
+        registry_path=registry_path,
+        error=error,
+        failure_path=failure_path,
+        context=context,
+    )
+    secret_values = dataset_export.configured_secret_values() + [os.environ.get("STEAM_KEY", "")]
+    assert_no_secret_leak(report, secret_values)
+    write_json_atomic(failure_path, report)
+    return report
+
+
+def raise_training_runner_interrupted(signum: int, _frame: Any) -> None:
+    raise TrainingRunnerInterrupted(signum)
+
+
+def install_training_signal_handlers() -> dict[int, Any]:
+    previous_handlers: dict[int, Any] = {}
+    for signum in (getattr(signal, "SIGTERM", None), getattr(signal, "SIGINT", None)):
+        if signum is None:
+            continue
+        try:
+            previous_handlers[int(signum)] = signal.getsignal(signum)
+            signal.signal(signum, raise_training_runner_interrupted)
+        except (OSError, RuntimeError, ValueError):
+            continue
+    return previous_handlers
+
+
+def restore_training_signal_handlers(previous_handlers: Mapping[int, Any]) -> None:
+    for signum, handler in previous_handlers.items():
+        try:
+            signal.signal(signum, handler)
+        except (OSError, RuntimeError, ValueError):
+            continue
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Run offline Screeps RL strategy experiments through the private simulator harness.",
@@ -8225,6 +8442,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None, stdout: TextIO = sys.stdout, stderr: TextIO = sys.stderr) -> int:
     args = build_parser().parse_args(argv)
+    previous_signal_handlers = install_training_signal_handlers()
     try:
         report = run_training_experiment(
             args.experiment_card,
@@ -8235,9 +8453,28 @@ def main(argv: list[str] | None = None, stdout: TextIO = sys.stdout, stderr: Tex
         )
         screeps_cli_io.write_json(stdout, report if args.print_report else build_generation_summary(report))
         return 0
-    except (RuntimeError, TrainingCardError, OSError) as error:
+    except (TrainingRunnerInterrupted, KeyboardInterrupt, Exception) as error:
         screeps_cli_io.write_text(stderr, f"error: {dataset_export.redact_text(str(error))}\n")
-        return 2
+        try:
+            failure_report = write_training_failure_report(
+                card_path=args.experiment_card,
+                out_dir=args.out_dir,
+                report_id=args.report_id,
+                registry_path=args.registry_path,
+                error=error,
+            )
+            failure_path = text_or_none(failure_report.get("failureArtifactPath"))
+            if failure_path is not None:
+                screeps_cli_io.write_text(stderr, f"failure-artifact: {failure_path}\n")
+        except Exception as artifact_error:  # noqa: BLE001 - preserve the original runner failure exit
+            screeps_cli_io.write_text(
+                stderr,
+                "failure-artifact-error: "
+                f"{dataset_export.redact_text(type(artifact_error).__name__ + ': ' + str(artifact_error))}\n",
+            )
+        return training_failure_exit_code(error)
+    finally:
+        restore_training_signal_handlers(previous_signal_handlers)
 
 
 if __name__ == "__main__":

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -5,6 +5,7 @@ import io
 import copy
 import json
 import os
+import signal
 import sys
 import tempfile
 import unittest
@@ -1520,20 +1521,125 @@ class RlTrainingRunnerTest(unittest.TestCase):
         stdout = io.StringIO()
         stderr = io.StringIO()
 
-        with (
-            mock.patch.dict(os.environ, {"STEAM_KEY": secret}, clear=True),
-            mock.patch.object(
-                runner,
-                "run_training_experiment",
-                side_effect=RuntimeError(f"simulator echoed {secret}"),
-            ),
-        ):
-            exit_code = runner.main(["--experiment-card", "card.json"], stdout=stdout, stderr=stderr)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            write_json(card_path, base_card())
+
+            with (
+                mock.patch.dict(os.environ, {"STEAM_KEY": secret}, clear=True),
+                mock.patch.object(
+                    runner,
+                    "run_training_experiment",
+                    side_effect=RuntimeError(f"simulator echoed {secret}"),
+                ),
+            ):
+                exit_code = runner.main(
+                    [
+                        "--experiment-card",
+                        str(card_path),
+                        "--out-dir",
+                        str(out_dir),
+                        "--report-id",
+                        "secret-redaction",
+                    ],
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+
+            failure = read_json(out_dir / "secret-redaction.failure.json")
+            failure_text = json.dumps(failure, sort_keys=True)
 
         self.assertEqual(exit_code, 2)
         self.assertNotIn(secret, stdout.getvalue())
         self.assertNotIn(secret, stderr.getvalue())
+        self.assertNotIn(secret, failure_text)
         self.assertIn("[REDACTED]", stderr.getvalue())
+        self.assertIn("[REDACTED]", failure["failure"]["error"])
+
+    def test_main_writes_failure_artifact_for_timeout_without_report_id(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            write_json(card_path, base_card())
+
+            with mock.patch.object(
+                runner,
+                "run_training_experiment",
+                side_effect=TimeoutError("simulator child timed out before scoring"),
+            ):
+                exit_code = runner.main(
+                    [
+                        "--experiment-card",
+                        str(card_path),
+                        "--out-dir",
+                        str(out_dir),
+                    ],
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+
+            failure_files = sorted(out_dir.glob("*.failure.json"))
+            self.assertEqual(len(failure_files), 1)
+            failure = read_json(failure_files[0])
+
+        self.assertEqual(exit_code, 2)
+        self.assertEqual(failure["type"], runner.FAILURE_REPORT_TYPE)
+        self.assertFalse(failure["ok"])
+        self.assertFalse(failure["trainingReportProduced"])
+        self.assertEqual(failure["trainingReportType"], runner.REPORT_TYPE)
+        self.assertEqual(failure["failure"]["classification"], "timeout")
+        self.assertEqual(failure["failure"]["exceptionType"], "TimeoutError")
+        self.assertIn("simulator child timed out", failure["failure"]["error"])
+        self.assertTrue(failure_files[0].name.endswith(".failure.json"))
+        self.assertEqual(failure_files[0].name, f"{failure['reportId']}.failure.json")
+        self.assertTrue(str(failure["expectedReportPath"]).endswith(f"{failure['reportId']}.json"))
+        self.assertIn("failure-artifact:", stderr.getvalue())
+
+    def test_main_writes_failure_artifact_for_sigterm_interrupt(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            write_json(card_path, base_card())
+
+            with mock.patch.object(
+                runner,
+                "run_training_experiment",
+                side_effect=runner.TrainingRunnerInterrupted(signal.SIGTERM),
+            ):
+                exit_code = runner.main(
+                    [
+                        "--experiment-card",
+                        str(card_path),
+                        "--out-dir",
+                        str(out_dir),
+                        "--report-id",
+                        "sigterm-run",
+                    ],
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+
+            failure = read_json(out_dir / "sigterm-run.failure.json")
+
+        self.assertEqual(exit_code, 128 + signal.SIGTERM)
+        self.assertEqual(failure["type"], runner.FAILURE_REPORT_TYPE)
+        self.assertFalse(failure["trainingReportProduced"])
+        self.assertEqual(failure["reportId"], "sigterm-run")
+        self.assertEqual(failure["failure"]["classification"], "interrupted")
+        self.assertEqual(failure["failure"]["exceptionType"], "TrainingRunnerInterrupted")
+        self.assertEqual(failure["failure"]["signalNumber"], signal.SIGTERM)
+        self.assertEqual(failure["failure"]["signalName"], "SIGTERM")
+        self.assertIn("failure-artifact:", stderr.getvalue())
 
     def test_main_treats_closed_stdout_as_success_after_report_generation(self) -> None:
         stderr = io.StringIO()


### PR DESCRIPTION
## Summary

- Add deterministic `*.failure.json` training-run artifacts for local RL runner failures, timeouts, and SIGTERM/SIGINT interruptions.
- Preserve secret redaction across stderr and failure artifacts.
- Install and restore CLI signal handlers so interrupted runs exit with conventional signal-aware codes while still leaving machine-readable evidence.

Fixes #1742.

## Verification

- `git diff --check`
- `python3 -m py_compile scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_training_runner.py`
- `python3 -m unittest scripts.test_screeps_rl_training_runner.RlTrainingRunnerTest.test_main_redacts_steam_key_from_error_output scripts.test_screeps_rl_training_runner.RlTrainingRunnerTest.test_main_writes_failure_artifact_for_timeout_without_report_id scripts.test_screeps_rl_training_runner.RlTrainingRunnerTest.test_main_writes_failure_artifact_for_sigterm_interrupt`

## Issue closure gate

- [x] #1742: local RL training runner failure, timeout, and interrupt paths now emit deterministic machine-readable failure artifacts with secret redaction; controller verification passed on commit `d9907dc2`.

## Universal task Done gate

- [x] Task type: RL runner reliability bugfix.
- [x] Expected observable outcome / named deliverable: interrupted or failed local training CLI invocations produce a `*.failure.json` report with status, classification, safe paths, safety metadata, and redacted error text.
- [x] Non-goals / accepted substitutes: paid Tencent compute, official MMO writes, and host memory tuning are excluded; local CLI failure-artifact generation is the accepted deliverable for this issue.
- [x] Verification evidence required before Done: `git diff --check`; `python3 -m py_compile scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_training_runner.py`; focused unittest command listed above with three passing tests.
- [x] Project Evidence / Next action / Blocked by: Project item records this PR, commit `d9907dc2`, verifier commands, and no dependency text.
- [x] Post-merge/deploy/runtime proof: merge commit plus exact-head CI success prove the scripts-only runner reliability deliverable; no official MMO deploy is required for this scripts-only change.
- [x] Named deliverable proof: `scripts/screeps_rl_training_runner.py` writes `*.failure.json`; `scripts/test_screeps_rl_training_runner.py` proves runtime error redaction, timeout artifact creation, and SIGTERM artifact creation.
