### PR TITLE
fix(rl): enforce linked conclusion issue routing

### DIFF
--- a/scripts/rl_conclusion_registry.py
+++ b/scripts/rl_conclusion_registry.py
@@ -35,6 +35,15 @@ ACTIONABLE_STALE_CONCLUSION_PREVIEW_LIMIT = 10
 STALE_CONCLUSION_AGGREGATE_ROUTING_ISSUE = "#1543"
 STALE_CONCLUSION_AGGREGATE_ROUTING_ISSUE_NUMBER = 1543
 MIN_STALE_CONCLUSION_TRIAGE_DECISIONS_PER_STEWARD_CYCLE = 3
+LINKED_ISSUE_REQUIRED_STATUSES = ("OPEN",)
+LINKED_ISSUE_REQUIRED_SEVERITIES = ("P0", "P1", "P2")
+LINKED_ISSUE_PREVIEW_LIMIT = 20
+FORBIDDEN_LINKED_ISSUE_SINKS = (
+    "#879",
+    "#893",
+    "#1589",
+    STALE_CONCLUSION_AGGREGATE_ROUTING_ISSUE,
+)
 
 JsonObject = dict[str, Any]
 
@@ -258,6 +267,7 @@ def summarize_conclusions(
         "unknown": unknown_count,
         "actionableIssueGate": high_priority_stale_issue_gate(records),
         "staleConclusionActionPlan": build_stale_conclusion_action_plan(records),
+        "linkedIssueGate": build_open_conclusion_linked_issue_gate(records),
     }
 
 
@@ -393,6 +403,117 @@ def build_stale_conclusion_action_plan(
             "targetStaleTransitionsThisCycle": target_transitions,
         },
     }
+
+
+def build_open_conclusion_linked_issue_gate(
+    registry_or_conclusions: Any,
+    *,
+    preview_limit: int = LINKED_ISSUE_PREVIEW_LIMIT,
+) -> JsonObject:
+    """Build an artifact-first guard for OPEN P0/P1/P2 conclusions without issues."""
+    if preview_limit < 0:
+        raise ConclusionRegistryError("preview_limit must be non-negative")
+
+    records = normalize_conclusions(registry_or_conclusions)
+    blockers = sorted(
+        (
+            record
+            for record in records.values()
+            if is_open_conclusion_missing_linked_issue(record)
+        ),
+        key=open_linked_issue_gate_priority_key,
+    )
+    blocker_count = len(blockers)
+    counts_by_severity = {
+        severity: sum(1 for record in blockers if conclusion_severity(record) == severity)
+        for severity in LINKED_ISSUE_REQUIRED_SEVERITIES
+    }
+    highest_priority_ids = [
+        conclusion_id
+        for conclusion_id in (record.get("conclusionId") for record in blockers)
+        if isinstance(conclusion_id, str) and conclusion_id
+    ][:preview_limit]
+
+    status = "ACTION_REQUIRED" if blocker_count else "OK"
+    gate: JsonObject = {
+        "name": "open_p0_p1_p2_conclusion_linked_issues",
+        "status": status,
+        "ok": blocker_count == 0,
+        "requiredStatuses": list(LINKED_ISSUE_REQUIRED_STATUSES),
+        "requiredSeverities": list(LINKED_ISSUE_REQUIRED_SEVERITIES),
+        "requiredField": "linkedIssues",
+        "blockedConclusionCount": blocker_count,
+        "countsBySeverity": counts_by_severity,
+        "highestPriorityConclusionIds": highest_priority_ids,
+        "blockingConclusions": [
+            linked_issue_gate_record(record)
+            for record in blockers[:preview_limit]
+        ],
+        "routingPolicy": {
+            "artifactFirst": True,
+            "requiredRouting": "exact_atomic_issue_per_open_conclusion",
+            "forbiddenBroadIssueSinks": list(FORBIDDEN_LINKED_ISSUE_SINKS),
+            "githubComments": "do_not_write_routine_comments",
+        },
+        "projectEvidence": {
+            "status": "BLOCKED_MISSING_LINKED_ISSUES" if blocker_count else "OK",
+            "evidence": (
+                f"unlinkedOpenConclusions={blocker_count}; "
+                f"ids={','.join(highest_priority_ids) if highest_priority_ids else 'none'}"
+            ),
+            "nextAction": (
+                "Create or attach exact atomic linkedIssues for each blocking conclusion, "
+                "then rerun this registry check."
+                if blocker_count
+                else "No unlinked OPEN P0/P1/P2 conclusions."
+            ),
+        },
+    }
+    if blocker_count:
+        gate["recommendedAction"] = "route_each_open_conclusion_to_exact_atomic_issue"
+        gate["evidence"] = (
+            f"{blocker_count} OPEN P0/P1/P2 conclusions are missing linkedIssues: "
+            f"{', '.join(highest_priority_ids)}"
+        )
+    return gate
+
+
+def is_open_conclusion_missing_linked_issue(record: JsonObject) -> bool:
+    return (
+        conclusion_status(record) in LINKED_ISSUE_REQUIRED_STATUSES
+        and conclusion_severity(record) in LINKED_ISSUE_REQUIRED_SEVERITIES
+        and not normalize_linked_issues(record.get("linkedIssues"))
+    )
+
+
+def linked_issue_gate_record(record: JsonObject) -> JsonObject:
+    gate_record: JsonObject = {
+        "conclusionId": str(record.get("conclusionId") or ""),
+        "status": conclusion_status(record),
+        "severity": conclusion_severity(record),
+        "category": conclusion_category(record),
+        "linkedIssues": normalize_linked_issues(record.get("linkedIssues")),
+        "requiredField": "linkedIssues",
+        "recommendedAction": "attach_exact_atomic_issue",
+    }
+    for field in ("ownerCron", "lastSeenAt", "nextVerification", "requiredLandingEvidence"):
+        value = record.get(field)
+        if has_evidence_value(value):
+            gate_record[field] = value
+    statement = record.get("statement")
+    if isinstance(statement, str) and statement.strip():
+        gate_record["statement"] = statement.strip()
+    return gate_record
+
+
+def open_linked_issue_gate_priority_key(record: JsonObject) -> tuple[int, str, str, str]:
+    severity_order = {"P0": 0, "P1": 1, "P2": 2}
+    return (
+        severity_order.get(conclusion_severity(record), 99),
+        str(record.get("lastSeenAt") or record.get("nextVerification") or ""),
+        conclusion_category(record),
+        str(record.get("conclusionId") or ""),
+    )
 
 
 def is_stale_action_plan_candidate(record: JsonObject) -> bool:

--- a/scripts/rl_conclusion_registry.py
+++ b/scripts/rl_conclusion_registry.py
@@ -44,6 +44,10 @@ FORBIDDEN_LINKED_ISSUE_SINKS = (
     "#1589",
     STALE_CONCLUSION_AGGREGATE_ROUTING_ISSUE,
 )
+FORBIDDEN_LINKED_ISSUE_SINK_NUMBERS = frozenset(
+    sink[1:] if sink.startswith("#") else sink
+    for sink in FORBIDDEN_LINKED_ISSUE_SINKS
+)
 
 JsonObject = dict[str, Any]
 
@@ -482,20 +486,26 @@ def is_open_conclusion_missing_linked_issue(record: JsonObject) -> bool:
     return (
         conclusion_status(record) in LINKED_ISSUE_REQUIRED_STATUSES
         and conclusion_severity(record) in LINKED_ISSUE_REQUIRED_SEVERITIES
-        and not normalize_linked_issues(record.get("linkedIssues"))
+        and not allowed_linked_issues(record.get("linkedIssues"))
     )
 
 
 def linked_issue_gate_record(record: JsonObject) -> JsonObject:
+    linked_issues = normalize_linked_issues(record.get("linkedIssues"))
+    forbidden_linked_issue_sinks = [
+        issue for issue in linked_issues if is_forbidden_linked_issue_sink(issue)
+    ]
     gate_record: JsonObject = {
         "conclusionId": str(record.get("conclusionId") or ""),
         "status": conclusion_status(record),
         "severity": conclusion_severity(record),
         "category": conclusion_category(record),
-        "linkedIssues": normalize_linked_issues(record.get("linkedIssues")),
+        "linkedIssues": linked_issues,
         "requiredField": "linkedIssues",
         "recommendedAction": "attach_exact_atomic_issue",
     }
+    if forbidden_linked_issue_sinks:
+        gate_record["forbiddenLinkedIssueSinks"] = forbidden_linked_issue_sinks
     for field in ("ownerCron", "lastSeenAt", "nextVerification", "requiredLandingEvidence"):
         value = record.get(field)
         if has_evidence_value(value):
@@ -628,6 +638,18 @@ def normalize_linked_issues(value: Any) -> list[str]:
         values = [value]
     normalized = [stable_text_value(item) for item in values if has_evidence_value(item)]
     return sorted(dict.fromkeys(item for item in normalized if item))
+
+
+def allowed_linked_issues(value: Any) -> list[str]:
+    return [
+        issue for issue in normalize_linked_issues(value)
+        if not is_forbidden_linked_issue_sink(issue)
+    ]
+
+
+def is_forbidden_linked_issue_sink(issue: str) -> bool:
+    issue_number = issue[1:] if issue.startswith("#") else issue
+    return issue_number in FORBIDDEN_LINKED_ISSUE_SINK_NUMBERS
 
 
 def stable_text_value(value: Any) -> str:

--- a/scripts/rl_conclusion_registry.py
+++ b/scripts/rl_conclusion_registry.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import fcntl
 import json
 import os
+import re
 import stat
 import tempfile
 from collections import Counter
@@ -47,6 +48,11 @@ FORBIDDEN_LINKED_ISSUE_SINKS = (
 FORBIDDEN_LINKED_ISSUE_SINK_NUMBERS = frozenset(
     sink[1:] if sink.startswith("#") else sink
     for sink in FORBIDDEN_LINKED_ISSUE_SINKS
+)
+BARE_ISSUE_NUMBER_RE = re.compile(r"^[1-9][0-9]*$")
+HASH_ISSUE_NUMBER_RE = re.compile(r"^#([1-9][0-9]*)$")
+GITHUB_ISSUE_URL_RE = re.compile(
+    r"^https://github\.com/[^/\s]+/[^/\s]+/issues/([1-9][0-9]*)/?$"
 )
 
 JsonObject = dict[str, Any]
@@ -482,6 +488,36 @@ def build_open_conclusion_linked_issue_gate(
     return gate
 
 
+def build_invalid_registry_linked_issue_gate(error: Exception | str) -> JsonObject:
+    error_text = str(error)
+    return {
+        "name": "open_p0_p1_p2_conclusion_linked_issues",
+        "status": "INVALID_REGISTRY",
+        "ok": False,
+        "requiredStatuses": list(LINKED_ISSUE_REQUIRED_STATUSES),
+        "requiredSeverities": list(LINKED_ISSUE_REQUIRED_SEVERITIES),
+        "requiredField": "linkedIssues",
+        "blockedConclusionCount": None,
+        "countsBySeverity": {
+            severity: None for severity in LINKED_ISSUE_REQUIRED_SEVERITIES
+        },
+        "highestPriorityConclusionIds": [],
+        "blockingConclusions": [],
+        "error": error_text,
+        "routingPolicy": {
+            "artifactFirst": True,
+            "requiredRouting": "exact_atomic_issue_per_open_conclusion",
+            "forbiddenBroadIssueSinks": list(FORBIDDEN_LINKED_ISSUE_SINKS),
+            "githubComments": "do_not_write_routine_comments",
+        },
+        "projectEvidence": {
+            "status": "BLOCKED_INVALID_CONCLUSION_REGISTRY",
+            "evidence": f"conclusionRegistryInvalid={error_text}",
+            "nextAction": "Repair conclusion-registry.json, then rerun this registry check.",
+        },
+    }
+
+
 def is_open_conclusion_missing_linked_issue(record: JsonObject) -> bool:
     return (
         conclusion_status(record) in LINKED_ISSUE_REQUIRED_STATUSES
@@ -492,6 +528,9 @@ def is_open_conclusion_missing_linked_issue(record: JsonObject) -> bool:
 
 def linked_issue_gate_record(record: JsonObject) -> JsonObject:
     linked_issues = normalize_linked_issues(record.get("linkedIssues"))
+    invalid_linked_issue_values = [
+        issue for issue in linked_issues if issue_number_from_linked_issue(issue) is None
+    ]
     forbidden_linked_issue_sinks = [
         issue for issue in linked_issues if is_forbidden_linked_issue_sink(issue)
     ]
@@ -504,6 +543,8 @@ def linked_issue_gate_record(record: JsonObject) -> JsonObject:
         "requiredField": "linkedIssues",
         "recommendedAction": "attach_exact_atomic_issue",
     }
+    if invalid_linked_issue_values:
+        gate_record["invalidLinkedIssueValues"] = invalid_linked_issue_values
     if forbidden_linked_issue_sinks:
         gate_record["forbiddenLinkedIssueSinks"] = forbidden_linked_issue_sinks
     for field in ("ownerCron", "lastSeenAt", "nextVerification", "requiredLandingEvidence"):
@@ -643,13 +684,27 @@ def normalize_linked_issues(value: Any) -> list[str]:
 def allowed_linked_issues(value: Any) -> list[str]:
     return [
         issue for issue in normalize_linked_issues(value)
+        if issue_number_from_linked_issue(issue) is not None
         if not is_forbidden_linked_issue_sink(issue)
     ]
 
 
 def is_forbidden_linked_issue_sink(issue: str) -> bool:
-    issue_number = issue[1:] if issue.startswith("#") else issue
+    issue_number = issue_number_from_linked_issue(issue)
     return issue_number in FORBIDDEN_LINKED_ISSUE_SINK_NUMBERS
+
+
+def issue_number_from_linked_issue(issue: str) -> str | None:
+    text = issue.strip()
+    if BARE_ISSUE_NUMBER_RE.fullmatch(text):
+        return text
+    hash_match = HASH_ISSUE_NUMBER_RE.fullmatch(text)
+    if hash_match is not None:
+        return hash_match.group(1)
+    url_match = GITHUB_ISSUE_URL_RE.fullmatch(text)
+    if url_match is not None:
+        return url_match.group(1)
+    return None
 
 
 def stable_text_value(value: Any) -> str:

--- a/scripts/screeps_rl_control_loop_ledgers.py
+++ b/scripts/screeps_rl_control_loop_ledgers.py
@@ -2281,7 +2281,10 @@ def build_steward_digest(
     p0_unresolved = as_list(conclusions.get("p0Unresolved"))
     lanes = as_list(summary.get("lanes"))
     blocked_lanes = [item for item in lanes if isinstance(item, dict) and str(item.get("status", "")).upper() == "BLOCKED"]
-    linked_issue_blocked = str(linked_issue_gate.get("status", "")).upper() == "ACTION_REQUIRED"
+    linked_issue_blocked = str(linked_issue_gate.get("status", "")).upper() in {
+        "ACTION_REQUIRED",
+        "INVALID_REGISTRY",
+    }
     project_evidence = as_dict(linked_issue_gate.get("projectEvidence"))
     if linked_issue_blocked:
         status = "ACTION_REQUIRED"
@@ -2317,35 +2320,6 @@ def build_steward_digest(
     }
 
 
-def invalid_registry_linked_issue_gate(error: Exception) -> JsonObject:
-    return {
-        "name": "open_p0_p1_p2_conclusion_linked_issues",
-        "status": "INVALID_REGISTRY",
-        "ok": False,
-        "requiredStatuses": list(rl_conclusion_registry.LINKED_ISSUE_REQUIRED_STATUSES),
-        "requiredSeverities": list(rl_conclusion_registry.LINKED_ISSUE_REQUIRED_SEVERITIES),
-        "requiredField": "linkedIssues",
-        "blockedConclusionCount": None,
-        "countsBySeverity": {
-            severity: None for severity in rl_conclusion_registry.LINKED_ISSUE_REQUIRED_SEVERITIES
-        },
-        "highestPriorityConclusionIds": [],
-        "blockingConclusions": [],
-        "error": str(error),
-        "routingPolicy": {
-            "artifactFirst": True,
-            "requiredRouting": "exact_atomic_issue_per_open_conclusion",
-            "forbiddenBroadIssueSinks": list(rl_conclusion_registry.FORBIDDEN_LINKED_ISSUE_SINKS),
-            "githubComments": "do_not_write_routine_comments",
-        },
-        "projectEvidence": {
-            "status": "BLOCKED_INVALID_CONCLUSION_REGISTRY",
-            "evidence": f"conclusionRegistryInvalid={str(error)}",
-            "nextAction": "Repair conclusion-registry.json, then rerun this registry check.",
-        },
-    }
-
-
 def build_conclusion_linked_issues_check(
     *,
     repo_root: Path,
@@ -2362,7 +2336,7 @@ def build_conclusion_linked_issues_check(
         linked_issue_gate = rl_conclusion_registry.build_open_conclusion_linked_issue_gate(registry_payload)
     except rl_conclusion_registry.ConclusionRegistryError as error:
         registry_error = str(error)
-        linked_issue_gate = invalid_registry_linked_issue_gate(error)
+        linked_issue_gate = rl_conclusion_registry.build_invalid_registry_linked_issue_gate(error)
 
     ok = bool(linked_issue_gate.get("ok"))
     return {

--- a/scripts/screeps_rl_control_loop_ledgers.py
+++ b/scripts/screeps_rl_control_loop_ledgers.py
@@ -2330,13 +2330,20 @@ def build_conclusion_linked_issues_check(
     registry_path = artifact_root / "rl-control-loop" / "conclusion-registry.json"
     registry_loaded = False
     registry_error: str | None = None
-    try:
-        registry_payload = rl_conclusion_registry.load_registry(registry_path)
-        registry_loaded = bool(registry_payload)
-        linked_issue_gate = rl_conclusion_registry.build_open_conclusion_linked_issue_gate(registry_payload)
-    except rl_conclusion_registry.ConclusionRegistryError as error:
-        registry_error = str(error)
-        linked_issue_gate = rl_conclusion_registry.build_invalid_registry_linked_issue_gate(error)
+    if not registry_path.exists():
+        registry_error = (
+            "missing conclusion-registry.json: "
+            f"{repo_display_path(registry_path, repo_root)}"
+        )
+        linked_issue_gate = rl_conclusion_registry.build_invalid_registry_linked_issue_gate(registry_error)
+    else:
+        try:
+            registry_payload = rl_conclusion_registry.load_registry(registry_path)
+            registry_loaded = bool(registry_payload)
+            linked_issue_gate = rl_conclusion_registry.build_open_conclusion_linked_issue_gate(registry_payload)
+        except rl_conclusion_registry.ConclusionRegistryError as error:
+            registry_error = str(error)
+            linked_issue_gate = rl_conclusion_registry.build_invalid_registry_linked_issue_gate(error)
 
     ok = bool(linked_issue_gate.get("ok"))
     return {

--- a/scripts/screeps_rl_control_loop_ledgers.py
+++ b/scripts/screeps_rl_control_loop_ledgers.py
@@ -2283,6 +2283,12 @@ def build_steward_digest(
     blocked_lanes = [item for item in lanes if isinstance(item, dict) and str(item.get("status", "")).upper() == "BLOCKED"]
     linked_issue_blocked = str(linked_issue_gate.get("status", "")).upper() == "ACTION_REQUIRED"
     project_evidence = as_dict(linked_issue_gate.get("projectEvidence"))
+    if linked_issue_blocked:
+        status = "ACTION_REQUIRED"
+    elif blocked_lanes:
+        status = "BLOCKED"
+    else:
+        status = "OK"
     return {
         "type": STEWARD_DIGEST_TYPE,
         "schemaVersion": SCHEMA_VERSION,
@@ -2291,7 +2297,7 @@ def build_steward_digest(
         "sourceIssue": None,
         "historicalContextIssues": HISTORICAL_CONTEXT_ISSUES,
         **git_metadata(repo_root),
-        "status": "ACTION_REQUIRED" if linked_issue_blocked else "OK",
+        "status": status,
         "latestArtifacts": json_safe(as_dict(summary.get("artifacts"))),
         "conclusionCounts": conclusions.get("counts", {status: 0 for status in rl_conclusion_registry.CONCLUSION_STATUSES}),
         "linkedIssueGate": json_safe(linked_issue_gate),

--- a/scripts/screeps_rl_control_loop_ledgers.py
+++ b/scripts/screeps_rl_control_loop_ledgers.py
@@ -25,6 +25,7 @@ TRAINING_LEDGER_TYPE = "screeps-rl-training-execution-ledger"
 POLICY_ADVANTAGE_TYPE = "screeps-rl-policy-online-advantage-report"
 REWARD_DECISION_RECORD_TYPE = "screeps-rl-reward-decision-record"
 STEWARD_DIGEST_TYPE = "screeps-rl-steward-bounded-digest"
+CONCLUSION_LINKED_ISSUES_CHECK_TYPE = "screeps-rl-conclusion-linked-issues-check"
 DEFAULT_ARTIFACT_ROOT = Path("runtime-artifacts")
 DEFAULT_CONTROL_LOOP_DIR = Path("runtime-artifacts/rl-control-loop")
 DEFAULT_MAX_FILES_PER_ROOT = 25
@@ -2276,9 +2277,12 @@ def build_steward_digest(
 ) -> JsonObject:
     summary = dashboard_summary(repo_root, artifact_root, created_at, max_files_per_root)
     conclusions = as_dict(summary.get("conclusions"))
+    linked_issue_gate = as_dict(conclusions.get("linkedIssueGate"))
     p0_unresolved = as_list(conclusions.get("p0Unresolved"))
     lanes = as_list(summary.get("lanes"))
     blocked_lanes = [item for item in lanes if isinstance(item, dict) and str(item.get("status", "")).upper() == "BLOCKED"]
+    linked_issue_blocked = str(linked_issue_gate.get("status", "")).upper() == "ACTION_REQUIRED"
+    project_evidence = as_dict(linked_issue_gate.get("projectEvidence"))
     return {
         "type": STEWARD_DIGEST_TYPE,
         "schemaVersion": SCHEMA_VERSION,
@@ -2287,12 +2291,15 @@ def build_steward_digest(
         "sourceIssue": None,
         "historicalContextIssues": HISTORICAL_CONTEXT_ISSUES,
         **git_metadata(repo_root),
+        "status": "ACTION_REQUIRED" if linked_issue_blocked else "OK",
         "latestArtifacts": json_safe(as_dict(summary.get("artifacts"))),
         "conclusionCounts": conclusions.get("counts", {status: 0 for status in rl_conclusion_registry.CONCLUSION_STATUSES}),
+        "linkedIssueGate": json_safe(linked_issue_gate),
         "p0Unresolved": json_safe(p0_unresolved[:8]),
         "lanes": json_safe(lanes),
         "blockedLanes": json_safe(blocked_lanes[:8]),
         "nextAction": (
+            text_value(project_evidence.get("nextAction")) if linked_issue_blocked else
             text_value(blocked_lanes[0].get("blocker")) if blocked_lanes and isinstance(blocked_lanes[0], dict) else
             "No bounded blocked lane was selected; inspect latest Loop A/B artifacts."
         ),
@@ -2304,6 +2311,73 @@ def build_steward_digest(
     }
 
 
+def invalid_registry_linked_issue_gate(error: Exception) -> JsonObject:
+    return {
+        "name": "open_p0_p1_p2_conclusion_linked_issues",
+        "status": "INVALID_REGISTRY",
+        "ok": False,
+        "requiredStatuses": list(rl_conclusion_registry.LINKED_ISSUE_REQUIRED_STATUSES),
+        "requiredSeverities": list(rl_conclusion_registry.LINKED_ISSUE_REQUIRED_SEVERITIES),
+        "requiredField": "linkedIssues",
+        "blockedConclusionCount": None,
+        "countsBySeverity": {
+            severity: None for severity in rl_conclusion_registry.LINKED_ISSUE_REQUIRED_SEVERITIES
+        },
+        "highestPriorityConclusionIds": [],
+        "blockingConclusions": [],
+        "error": str(error),
+        "routingPolicy": {
+            "artifactFirst": True,
+            "requiredRouting": "exact_atomic_issue_per_open_conclusion",
+            "forbiddenBroadIssueSinks": list(rl_conclusion_registry.FORBIDDEN_LINKED_ISSUE_SINKS),
+            "githubComments": "do_not_write_routine_comments",
+        },
+        "projectEvidence": {
+            "status": "BLOCKED_INVALID_CONCLUSION_REGISTRY",
+            "evidence": f"conclusionRegistryInvalid={str(error)}",
+            "nextAction": "Repair conclusion-registry.json, then rerun this registry check.",
+        },
+    }
+
+
+def build_conclusion_linked_issues_check(
+    *,
+    repo_root: Path,
+    artifact_root: Path,
+    created_at: str,
+    source_cron: str,
+) -> JsonObject:
+    registry_path = artifact_root / "rl-control-loop" / "conclusion-registry.json"
+    registry_loaded = False
+    registry_error: str | None = None
+    try:
+        registry_payload = rl_conclusion_registry.load_registry(registry_path)
+        registry_loaded = bool(registry_payload)
+        linked_issue_gate = rl_conclusion_registry.build_open_conclusion_linked_issue_gate(registry_payload)
+    except rl_conclusion_registry.ConclusionRegistryError as error:
+        registry_error = str(error)
+        linked_issue_gate = invalid_registry_linked_issue_gate(error)
+
+    ok = bool(linked_issue_gate.get("ok"))
+    return {
+        "type": CONCLUSION_LINKED_ISSUES_CHECK_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "createdAt": created_at,
+        "sourceCron": source_cron,
+        "sourceIssue": None,
+        **git_metadata(repo_root),
+        "ok": ok,
+        "status": "OK" if ok else "BLOCKED",
+        "exitCode": 0 if ok else 2,
+        "registryPath": repo_display_path(registry_path, repo_root),
+        "registryLoaded": registry_loaded,
+        "registryError": registry_error,
+        "linkedIssueGate": json_safe(linked_issue_gate),
+        "projectEvidence": json_safe(as_dict(linked_issue_gate.get("projectEvidence"))),
+        "githubComment": "skipped_no_atomic_issue",
+    }
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Write bounded Screeps RL control-loop artifacts for cron usage.")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -2311,6 +2385,11 @@ def build_parser() -> argparse.ArgumentParser:
         ("training-ledger", "write a bounded Loop A training execution ledger", "Screeps RL training execution ledger"),
         ("policy-advantage", "write a bounded Loop B policy online advantage report", "Screeps RL policy online advantage ledger"),
         ("steward-digest", "write a bounded RL steward digest", "Screeps RL flywheel steward"),
+        (
+            "linked-issues-check",
+            "validate OPEN P0/P1/P2 conclusions have exact linked issues",
+            "Screeps RL conclusion linked-issues guard",
+        ),
     ):
         sub = subparsers.add_parser(command, help=help_text)
         sub.add_argument("--repo-root", type=Path, default=Path.cwd())
@@ -2365,6 +2444,14 @@ def run_command(args: argparse.Namespace) -> tuple[Path, JsonObject]:
             max_files_per_root=max_files,
         )
         path = resolve_against_repo(args.output, repo_root) if args.output else output_path(out_dir, created_at, "steward-digest")
+    elif args.command == "linked-issues-check":
+        payload = build_conclusion_linked_issues_check(
+            repo_root=repo_root,
+            artifact_root=artifact_root,
+            created_at=created_at,
+            source_cron=args.source_cron,
+        )
+        path = resolve_against_repo(args.output, repo_root) if args.output else output_path(out_dir, created_at, "linked-issues-check")
     else:
         raise ControlLoopLedgerError(f"unsupported command: {args.command}")
     write_json_atomic(path, payload)
@@ -2383,15 +2470,17 @@ def main(argv: list[str] | None = None, stdout: TextIO = sys.stdout, stderr: Tex
             max_bytes=max(256, int(getattr(args, "stdout_bytes", DEFAULT_STDOUT_BYTES))),
         )
         return 2
+    exit_code = int(payload.get("exitCode", 0)) if isinstance(payload.get("exitCode"), int) else 0
+    payload_ok = payload.get("ok")
     summary = {
-        "ok": True,
+        "ok": bool(payload_ok) if isinstance(payload_ok, bool) else exit_code == 0,
         "type": payload.get("type"),
         "artifact": repo_display_path(path, args.repo_root.expanduser().resolve()),
         "status": payload.get("status") or payload.get("onlineUtilityStatus") or "written",
         "githubComment": payload.get("githubComment"),
     }
     screeps_cli_io.write_json_line(stdout, summary, max_bytes=max(256, int(args.stdout_bytes)))
-    return 0
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -1139,7 +1139,10 @@ def conclusion_summary(artifact: LoadedArtifact | None) -> JsonObject:
             "hasData": False,
         }
 
-    conclusions_by_id = rl_conclusion_registry.normalize_conclusions(artifact.payload)
+    try:
+        conclusions_by_id = rl_conclusion_registry.normalize_conclusions(artifact.payload)
+    except rl_conclusion_registry.ConclusionRegistryError:
+        conclusions_by_id = {}
     conclusions = list(conclusions_by_id.values())
     counts = Counter(str(item.get("status", "UNKNOWN")).upper() for item in conclusions)
     p0_unresolved = [

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -1141,8 +1141,16 @@ def conclusion_summary(artifact: LoadedArtifact | None) -> JsonObject:
 
     try:
         conclusions_by_id = rl_conclusion_registry.normalize_conclusions(artifact.payload)
-    except rl_conclusion_registry.ConclusionRegistryError:
-        conclusions_by_id = {}
+    except rl_conclusion_registry.ConclusionRegistryError as error:
+        return {
+            "counts": {status: 0 for status in CONCLUSION_STATUSES},
+            "otherCounts": {},
+            "p0Unresolved": [],
+            "linkedIssueGate": rl_conclusion_registry.build_invalid_registry_linked_issue_gate(error),
+            "latestArtifact": artifact.path,
+            "updatedAt": display_timestamp(artifact.payload.get("updatedAt") or artifact.timestamp),
+            "hasData": True,
+        }
     conclusions = list(conclusions_by_id.values())
     counts = Counter(str(item.get("status", "UNKNOWN")).upper() for item in conclusions)
     p0_unresolved = [

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -1129,11 +1129,17 @@ def display_value(value: Any) -> str:
 
 def conclusion_summary(artifact: LoadedArtifact | None) -> JsonObject:
     if artifact is None:
+        missing_registry_error = (
+            "missing conclusion-registry artifact: "
+            "runtime-artifacts/rl-control-loop/conclusion-registry.json"
+        )
         return {
             "counts": {status: 0 for status in CONCLUSION_STATUSES},
             "otherCounts": {},
             "p0Unresolved": [],
-            "linkedIssueGate": rl_conclusion_registry.build_open_conclusion_linked_issue_gate({}),
+            "linkedIssueGate": rl_conclusion_registry.build_invalid_registry_linked_issue_gate(
+                missing_registry_error
+            ),
             "latestArtifact": "N/A",
             "updatedAt": "N/A",
             "hasData": False,

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 
+import rl_conclusion_registry
 import screeps_rl_experiment_card as experiment_card
 
 
@@ -1132,14 +1133,14 @@ def conclusion_summary(artifact: LoadedArtifact | None) -> JsonObject:
             "counts": {status: 0 for status in CONCLUSION_STATUSES},
             "otherCounts": {},
             "p0Unresolved": [],
+            "linkedIssueGate": rl_conclusion_registry.build_open_conclusion_linked_issue_gate({}),
             "latestArtifact": "N/A",
             "updatedAt": "N/A",
             "hasData": False,
         }
 
-    raw_conclusions = artifact.payload.get("conclusions")
-    conclusion_values = raw_conclusions.values() if isinstance(raw_conclusions, dict) else as_list(raw_conclusions)
-    conclusions = [item for item in conclusion_values if isinstance(item, dict)]
+    conclusions_by_id = rl_conclusion_registry.normalize_conclusions(artifact.payload)
+    conclusions = list(conclusions_by_id.values())
     counts = Counter(str(item.get("status", "UNKNOWN")).upper() for item in conclusions)
     p0_unresolved = [
         item
@@ -1159,6 +1160,7 @@ def conclusion_summary(artifact: LoadedArtifact | None) -> JsonObject:
             status: count for status, count in sorted(counts.items()) if status not in CONCLUSION_STATUSES
         },
         "p0Unresolved": p0_unresolved[:8],
+        "linkedIssueGate": rl_conclusion_registry.build_open_conclusion_linked_issue_gate(conclusions_by_id),
         "latestArtifact": artifact.path,
         "updatedAt": display_timestamp(artifact.payload.get("updatedAt") or artifact.timestamp),
         "hasData": True,

--- a/scripts/test_rl_conclusion_registry.py
+++ b/scripts/test_rl_conclusion_registry.py
@@ -459,6 +459,108 @@ class RlConclusionRegistryTest(unittest.TestCase):
         self.assertEqual(list(single_record), ["TOP-LEVEL-SINGLE"])
         self.assertEqual(single_record["TOP-LEVEL-SINGLE"]["status"], "VALIDATING")
 
+    def test_linked_issue_gate_flags_unlinked_open_high_priority_conclusions(self) -> None:
+        payload = {
+            "schemaVersion": 1,
+            "registryType": "rl-conclusion-registry",
+            "conclusions": {
+                "P1-UNLINKED": {
+                    "conclusionId": "P1-UNLINKED",
+                    "status": "OPEN",
+                    "severity": "P1",
+                    "category": "economy",
+                    "lastSeenAt": "2026-06-07T00:00:00Z",
+                    "statement": "Energy buffer collapse needs an atomic issue.",
+                },
+                "P2-EMPTY-LINKS": {
+                    "conclusionId": "P2-EMPTY-LINKS",
+                    "status": "OPEN",
+                    "severity": "P2",
+                    "linkedIssues": [],
+                    "lastSeenAt": "2026-06-07T00:01:00Z",
+                },
+            },
+            "entries": [
+                {
+                    "conclusionId": "P0-WHITESPACE-LINK",
+                    "status": "OPEN",
+                    "severity": "P0",
+                    "linkedIssues": ["  "],
+                    "lastSeenAt": "2026-06-07T00:02:00Z",
+                }
+            ],
+        }
+
+        gate = registry.build_open_conclusion_linked_issue_gate(payload)
+
+        self.assertFalse(gate["ok"])
+        self.assertEqual(gate["status"], "ACTION_REQUIRED")
+        self.assertEqual(gate["requiredStatuses"], ["OPEN"])
+        self.assertEqual(gate["requiredSeverities"], ["P0", "P1", "P2"])
+        self.assertEqual(gate["blockedConclusionCount"], 3)
+        self.assertEqual(gate["countsBySeverity"], {"P0": 1, "P1": 1, "P2": 1})
+        self.assertEqual(
+            gate["highestPriorityConclusionIds"],
+            ["P0-WHITESPACE-LINK", "P1-UNLINKED", "P2-EMPTY-LINKS"],
+        )
+        self.assertEqual(
+            [item["recommendedAction"] for item in gate["blockingConclusions"]],
+            ["attach_exact_atomic_issue", "attach_exact_atomic_issue", "attach_exact_atomic_issue"],
+        )
+        self.assertEqual(gate["projectEvidence"]["status"], "BLOCKED_MISSING_LINKED_ISSUES")
+        self.assertIn("#879", gate["routingPolicy"]["forbiddenBroadIssueSinks"])
+        self.assertIn("#1589", gate["routingPolicy"]["forbiddenBroadIssueSinks"])
+
+    def test_linked_issue_gate_accepts_linked_and_non_open_or_lower_severity_shapes(self) -> None:
+        payload = {
+            "schemaVersion": 1,
+            "type": "screeps-rl-conclusion-registry",
+            "conclusions": [
+                {
+                    "conclusionId": "P1-LINKED",
+                    "status": "OPEN",
+                    "severity": "P1",
+                    "linkedIssues": ["#1748"],
+                },
+                {
+                    "conclusionId": "P0-ACTIONED-UNLINKED",
+                    "status": "ACTIONED",
+                    "severity": "P0",
+                },
+            ],
+            "entries": [
+                {
+                    "conclusionId": "P2-STALE-UNLINKED",
+                    "status": "STALE",
+                    "severity": "P2",
+                },
+                {
+                    "conclusionId": "P3-OPEN-UNLINKED",
+                    "status": "OPEN",
+                    "severity": "P3",
+                },
+                {
+                    "conclusionId": "UNRANKED-OPEN-UNLINKED",
+                    "status": "OPEN",
+                    "severity": "HIGH",
+                },
+            ],
+        }
+
+        gate = registry.build_open_conclusion_linked_issue_gate(payload)
+
+        self.assertTrue(gate["ok"])
+        self.assertEqual(gate["status"], "OK")
+        self.assertEqual(gate["blockedConclusionCount"], 0)
+        self.assertEqual(gate["countsBySeverity"], {"P0": 0, "P1": 0, "P2": 0})
+        self.assertEqual(gate["highestPriorityConclusionIds"], [])
+        self.assertEqual(gate["blockingConclusions"], [])
+        self.assertEqual(gate["projectEvidence"]["status"], "OK")
+        self.assertEqual(
+            registry.summarize_conclusions(registry.normalize_conclusions(payload))["linkedIssueGate"],
+            gate,
+        )
+
     def test_merge_registry_file_accepts_metadata_only_existing_registry(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             path = Path(temp_dir) / "conclusion-registry.json"

--- a/scripts/test_rl_conclusion_registry.py
+++ b/scripts/test_rl_conclusion_registry.py
@@ -511,6 +511,69 @@ class RlConclusionRegistryTest(unittest.TestCase):
         self.assertIn("#879", gate["routingPolicy"]["forbiddenBroadIssueSinks"])
         self.assertIn("#1589", gate["routingPolicy"]["forbiddenBroadIssueSinks"])
 
+    def test_linked_issue_gate_rejects_forbidden_broad_issue_sinks(self) -> None:
+        payload = {
+            "schemaVersion": 1,
+            "registryType": "rl-conclusion-registry",
+            "conclusions": {
+                "P1-BROAD-879": {
+                    "conclusionId": "P1-BROAD-879",
+                    "status": "OPEN",
+                    "severity": "P1",
+                    "category": "runtime",
+                    "linkedIssues": ["#879"],
+                },
+                "P2-BROAD-893": {
+                    "conclusionId": "P2-BROAD-893",
+                    "status": "OPEN",
+                    "severity": "P2",
+                    "category": "economy",
+                    "linkedIssues": ["#893"],
+                },
+                "P1-BROAD-1589": {
+                    "conclusionId": "P1-BROAD-1589",
+                    "status": "OPEN",
+                    "severity": "P1",
+                    "category": "ops",
+                    "linkedIssues": ["#1589"],
+                },
+                "P0-BROAD-1543": {
+                    "conclusionId": "P0-BROAD-1543",
+                    "status": "OPEN",
+                    "severity": "P0",
+                    "category": "rl",
+                    "linkedIssues": ["#1543"],
+                },
+            },
+        }
+
+        gate = registry.build_open_conclusion_linked_issue_gate(payload)
+
+        self.assertFalse(gate["ok"])
+        self.assertEqual(gate["status"], "ACTION_REQUIRED")
+        self.assertEqual(gate["blockedConclusionCount"], 4)
+        self.assertEqual(gate["countsBySeverity"], {"P0": 1, "P1": 2, "P2": 1})
+        self.assertEqual(
+            gate["routingPolicy"]["forbiddenBroadIssueSinks"],
+            ["#879", "#893", "#1589", "#1543"],
+        )
+        self.assertEqual(
+            gate["routingPolicy"]["requiredRouting"],
+            "exact_atomic_issue_per_open_conclusion",
+        )
+        blocking_by_id = {
+            item["conclusionId"]: item
+            for item in gate["blockingConclusions"]
+        }
+        self.assertEqual(blocking_by_id["P1-BROAD-879"]["linkedIssues"], ["#879"])
+        self.assertEqual(blocking_by_id["P1-BROAD-879"]["forbiddenLinkedIssueSinks"], ["#879"])
+        self.assertEqual(blocking_by_id["P2-BROAD-893"]["linkedIssues"], ["#893"])
+        self.assertEqual(blocking_by_id["P2-BROAD-893"]["forbiddenLinkedIssueSinks"], ["#893"])
+        self.assertEqual(blocking_by_id["P1-BROAD-1589"]["linkedIssues"], ["#1589"])
+        self.assertEqual(blocking_by_id["P1-BROAD-1589"]["forbiddenLinkedIssueSinks"], ["#1589"])
+        self.assertEqual(blocking_by_id["P0-BROAD-1543"]["linkedIssues"], ["#1543"])
+        self.assertEqual(blocking_by_id["P0-BROAD-1543"]["forbiddenLinkedIssueSinks"], ["#1543"])
+
     def test_linked_issue_gate_accepts_linked_and_non_open_or_lower_severity_shapes(self) -> None:
         payload = {
             "schemaVersion": 1,
@@ -521,6 +584,12 @@ class RlConclusionRegistryTest(unittest.TestCase):
                     "status": "OPEN",
                     "severity": "P1",
                     "linkedIssues": ["#1748"],
+                },
+                {
+                    "conclusionId": "P2-MIXED-BROAD-AND-ATOMIC",
+                    "status": "OPEN",
+                    "severity": "P2",
+                    "linkedIssues": ["#879", "#1750"],
                 },
                 {
                     "conclusionId": "P0-ACTIONED-UNLINKED",

--- a/scripts/test_rl_conclusion_registry.py
+++ b/scripts/test_rl_conclusion_registry.py
@@ -511,17 +511,88 @@ class RlConclusionRegistryTest(unittest.TestCase):
         self.assertIn("#879", gate["routingPolicy"]["forbiddenBroadIssueSinks"])
         self.assertIn("#1589", gate["routingPolicy"]["forbiddenBroadIssueSinks"])
 
+    def test_linked_issue_gate_rejects_placeholder_linked_issue_values(self) -> None:
+        payload = {
+            "schemaVersion": 1,
+            "registryType": "rl-conclusion-registry",
+            "conclusions": {
+                "P1-TBD": {
+                    "conclusionId": "P1-TBD",
+                    "status": "OPEN",
+                    "severity": "P1",
+                    "linkedIssues": "TBD",
+                },
+                "P2-NEEDS-ISSUE": {
+                    "conclusionId": "P2-NEEDS-ISSUE",
+                    "status": "OPEN",
+                    "severity": "P2",
+                    "linkedIssues": ["needs issue"],
+                },
+                "P1-VALID-HASH": {
+                    "conclusionId": "P1-VALID-HASH",
+                    "status": "OPEN",
+                    "severity": "P1",
+                    "linkedIssues": "#1748",
+                },
+                "P2-VALID-URL": {
+                    "conclusionId": "P2-VALID-URL",
+                    "status": "OPEN",
+                    "severity": "P2",
+                    "linkedIssues": "https://github.com/lanyusea/screeps/issues/1750",
+                },
+            },
+        }
+
+        gate = registry.build_open_conclusion_linked_issue_gate(payload)
+
+        self.assertFalse(gate["ok"])
+        self.assertEqual(gate["status"], "ACTION_REQUIRED")
+        self.assertEqual(gate["blockedConclusionCount"], 2)
+        self.assertEqual(gate["highestPriorityConclusionIds"], ["P1-TBD", "P2-NEEDS-ISSUE"])
+        blocking_by_id = {
+            item["conclusionId"]: item
+            for item in gate["blockingConclusions"]
+        }
+        self.assertEqual(blocking_by_id["P1-TBD"]["linkedIssues"], ["TBD"])
+        self.assertEqual(blocking_by_id["P1-TBD"]["invalidLinkedIssueValues"], ["TBD"])
+        self.assertEqual(blocking_by_id["P2-NEEDS-ISSUE"]["linkedIssues"], ["needs issue"])
+        self.assertEqual(
+            blocking_by_id["P2-NEEDS-ISSUE"]["invalidLinkedIssueValues"],
+            ["needs issue"],
+        )
+        self.assertNotIn("P1-VALID-HASH", blocking_by_id)
+        self.assertNotIn("P2-VALID-URL", blocking_by_id)
+        self.assertEqual(registry.allowed_linked_issues("TBD"), [])
+        self.assertEqual(
+            registry.allowed_linked_issues(["needs issue", "#1748"]),
+            ["#1748"],
+        )
+
     def test_linked_issue_gate_rejects_forbidden_broad_issue_sinks(self) -> None:
         payload = {
             "schemaVersion": 1,
             "registryType": "rl-conclusion-registry",
             "conclusions": {
-                "P1-BROAD-879": {
-                    "conclusionId": "P1-BROAD-879",
+                "P1-BROAD-879-HASH": {
+                    "conclusionId": "P1-BROAD-879-HASH",
                     "status": "OPEN",
                     "severity": "P1",
                     "category": "runtime",
                     "linkedIssues": ["#879"],
+                },
+                "P1-BROAD-879-BARE": {
+                    "conclusionId": "P1-BROAD-879-BARE",
+                    "status": "OPEN",
+                    "severity": "P1",
+                    "category": "runtime",
+                    "linkedIssues": [879],
+                },
+                "P1-BROAD-879-URL": {
+                    "conclusionId": "P1-BROAD-879-URL",
+                    "status": "OPEN",
+                    "severity": "P1",
+                    "category": "runtime",
+                    "linkedIssues": ["https://github.com/lanyusea/screeps/issues/879"],
                 },
                 "P2-BROAD-893": {
                     "conclusionId": "P2-BROAD-893",
@@ -551,8 +622,8 @@ class RlConclusionRegistryTest(unittest.TestCase):
 
         self.assertFalse(gate["ok"])
         self.assertEqual(gate["status"], "ACTION_REQUIRED")
-        self.assertEqual(gate["blockedConclusionCount"], 4)
-        self.assertEqual(gate["countsBySeverity"], {"P0": 1, "P1": 2, "P2": 1})
+        self.assertEqual(gate["blockedConclusionCount"], 6)
+        self.assertEqual(gate["countsBySeverity"], {"P0": 1, "P1": 4, "P2": 1})
         self.assertEqual(
             gate["routingPolicy"]["forbiddenBroadIssueSinks"],
             ["#879", "#893", "#1589", "#1543"],
@@ -565,8 +636,18 @@ class RlConclusionRegistryTest(unittest.TestCase):
             item["conclusionId"]: item
             for item in gate["blockingConclusions"]
         }
-        self.assertEqual(blocking_by_id["P1-BROAD-879"]["linkedIssues"], ["#879"])
-        self.assertEqual(blocking_by_id["P1-BROAD-879"]["forbiddenLinkedIssueSinks"], ["#879"])
+        self.assertEqual(blocking_by_id["P1-BROAD-879-HASH"]["linkedIssues"], ["#879"])
+        self.assertEqual(blocking_by_id["P1-BROAD-879-HASH"]["forbiddenLinkedIssueSinks"], ["#879"])
+        self.assertEqual(blocking_by_id["P1-BROAD-879-BARE"]["linkedIssues"], ["879"])
+        self.assertEqual(blocking_by_id["P1-BROAD-879-BARE"]["forbiddenLinkedIssueSinks"], ["879"])
+        self.assertEqual(
+            blocking_by_id["P1-BROAD-879-URL"]["linkedIssues"],
+            ["https://github.com/lanyusea/screeps/issues/879"],
+        )
+        self.assertEqual(
+            blocking_by_id["P1-BROAD-879-URL"]["forbiddenLinkedIssueSinks"],
+            ["https://github.com/lanyusea/screeps/issues/879"],
+        )
         self.assertEqual(blocking_by_id["P2-BROAD-893"]["linkedIssues"], ["#893"])
         self.assertEqual(blocking_by_id["P2-BROAD-893"]["forbiddenLinkedIssueSinks"], ["#893"])
         self.assertEqual(blocking_by_id["P1-BROAD-1589"]["linkedIssues"], ["#1589"])
@@ -584,6 +665,12 @@ class RlConclusionRegistryTest(unittest.TestCase):
                     "status": "OPEN",
                     "severity": "P1",
                     "linkedIssues": ["#1748"],
+                },
+                {
+                    "conclusionId": "P1-LINKED-BARE-NUMBER",
+                    "status": "OPEN",
+                    "severity": "P1",
+                    "linkedIssues": [1749],
                 },
                 {
                     "conclusionId": "P2-MIXED-BROAD-AND-ATOMIC",

--- a/scripts/test_screeps_rl_control_loop_ledgers.py
+++ b/scripts/test_screeps_rl_control_loop_ledgers.py
@@ -1589,6 +1589,172 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
         self.assertIn("lanes", payload)
         self.assertIn("boundedProducer", payload)
 
+    def test_steward_digest_surfaces_unlinked_open_conclusion_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = write_fixture_artifacts(root)
+            write_json(
+                artifact_root / "rl-control-loop" / "conclusion-registry.json",
+                {
+                    "schemaVersion": 1,
+                    "registryType": "rl-conclusion-registry",
+                    "conclusions": {
+                        "P1-UNLINKED": {
+                            "conclusionId": "P1-UNLINKED",
+                            "status": "OPEN",
+                            "severity": "P1",
+                            "linkedIssues": [],
+                        }
+                    },
+                },
+            )
+            output = root / "out" / "steward-digest.json"
+
+            exit_code = ledgers.main(
+                [
+                    "steward-digest",
+                    "--repo-root",
+                    str(root),
+                    "--artifact-root",
+                    str(artifact_root),
+                    "--output",
+                    str(output),
+                    "--created-at",
+                    "2026-06-05T00:00:02Z",
+                    "--max-files-per-root",
+                    "4",
+                ],
+                stdout=io.StringIO(),
+                stderr=io.StringIO(),
+            )
+            payload = read_json(output)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["status"], "ACTION_REQUIRED")
+        self.assertEqual(payload["linkedIssueGate"]["status"], "ACTION_REQUIRED")
+        self.assertEqual(payload["linkedIssueGate"]["blockedConclusionCount"], 1)
+        self.assertEqual(payload["linkedIssueGate"]["highestPriorityConclusionIds"], ["P1-UNLINKED"])
+        self.assertIn("exact atomic linkedIssues", payload["nextAction"])
+
+    def test_linked_issues_check_writes_artifact_and_fails_for_unlinked_open_p1(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            write_json(
+                artifact_root / "rl-control-loop" / "conclusion-registry.json",
+                {
+                    "schemaVersion": 1,
+                    "registryType": "rl-conclusion-registry",
+                    "conclusions": {
+                        "L20260606T160607Z-LOOP_B-ENERGY_BUFFER_COLLAPSE": {
+                            "conclusionId": "L20260606T160607Z-LOOP_B-ENERGY_BUFFER_COLLAPSE",
+                            "status": "OPEN",
+                            "severity": "P1",
+                            "category": "economy",
+                            "linkedIssues": [],
+                            "statement": "Energy buffer collapse lacks an atomic issue.",
+                        }
+                    },
+                },
+            )
+            output = root / "out" / "linked-issues-check.json"
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+
+            exit_code = ledgers.main(
+                [
+                    "linked-issues-check",
+                    "--repo-root",
+                    str(root),
+                    "--artifact-root",
+                    str(artifact_root),
+                    "--output",
+                    str(output),
+                    "--created-at",
+                    "2026-06-07T00:00:00Z",
+                ],
+                stdout=stdout,
+                stderr=stderr,
+            )
+            payload = read_json(output)
+            emitted = json.loads(stdout.getvalue())
+
+        self.assertEqual(exit_code, 2)
+        self.assertEqual(stderr.getvalue(), "")
+        self.assertFalse(emitted["ok"])
+        self.assertEqual(emitted["type"], ledgers.CONCLUSION_LINKED_ISSUES_CHECK_TYPE)
+        self.assertEqual(emitted["status"], "BLOCKED")
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["type"], ledgers.CONCLUSION_LINKED_ISSUES_CHECK_TYPE)
+        self.assertEqual(payload["status"], "BLOCKED")
+        self.assertEqual(payload["exitCode"], 2)
+        self.assertEqual(payload["githubComment"], "skipped_no_atomic_issue")
+        self.assertNotIn("historicalContextIssues", payload)
+        self.assertEqual(payload["linkedIssueGate"]["status"], "ACTION_REQUIRED")
+        self.assertEqual(payload["linkedIssueGate"]["blockedConclusionCount"], 1)
+        self.assertEqual(
+            payload["linkedIssueGate"]["highestPriorityConclusionIds"],
+            ["L20260606T160607Z-LOOP_B-ENERGY_BUFFER_COLLAPSE"],
+        )
+        self.assertEqual(
+            payload["projectEvidence"]["status"],
+            "BLOCKED_MISSING_LINKED_ISSUES",
+        )
+
+    def test_linked_issues_check_accepts_linked_and_non_blocking_conclusions(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            write_json(
+                artifact_root / "rl-control-loop" / "conclusion-registry.json",
+                {
+                    "schemaVersion": 1,
+                    "registryType": "rl-conclusion-registry",
+                    "entries": [
+                        {
+                            "conclusionId": "P1-LINKED",
+                            "status": "OPEN",
+                            "severity": "P1",
+                            "linkedIssues": ["#1748"],
+                        },
+                        {
+                            "conclusionId": "P2-CLOSED-UNLINKED",
+                            "status": "CLOSED",
+                            "severity": "P2",
+                        },
+                        {
+                            "conclusionId": "P3-OPEN-UNLINKED",
+                            "status": "OPEN",
+                            "severity": "P3",
+                        },
+                    ],
+                },
+            )
+            output = root / "out" / "linked-issues-check.json"
+
+            exit_code = ledgers.main(
+                [
+                    "linked-issues-check",
+                    "--repo-root",
+                    str(root),
+                    "--artifact-root",
+                    str(artifact_root),
+                    "--output",
+                    str(output),
+                    "--created-at",
+                    "2026-06-07T00:00:00Z",
+                ],
+                stdout=io.StringIO(),
+                stderr=io.StringIO(),
+            )
+            payload = read_json(output)
+
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["status"], "OK")
+        self.assertEqual(payload["linkedIssueGate"]["blockedConclusionCount"], 0)
+        self.assertEqual(payload["projectEvidence"]["nextAction"], "No unlinked OPEN P0/P1/P2 conclusions.")
+
     def test_steward_digest_sees_root_level_training_report_but_keeps_rollout_blocked(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_control_loop_ledgers.py
+++ b/scripts/test_screeps_rl_control_loop_ledgers.py
@@ -1681,6 +1681,50 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
         self.assertIn("Repair conclusion-registry.json", payload["nextAction"])
         self.assertIn("each conclusion record", payload["linkedIssueGate"]["error"])
 
+    def test_linked_issues_check_blocks_when_registry_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            output = root / "out" / "linked-issues-check.json"
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+
+            exit_code = ledgers.main(
+                [
+                    "linked-issues-check",
+                    "--repo-root",
+                    str(root),
+                    "--artifact-root",
+                    str(artifact_root),
+                    "--output",
+                    str(output),
+                    "--created-at",
+                    "2026-06-07T00:00:00Z",
+                ],
+                stdout=stdout,
+                stderr=stderr,
+            )
+            payload = read_json(output)
+            emitted = json.loads(stdout.getvalue())
+
+        self.assertEqual(exit_code, 2)
+        self.assertEqual(stderr.getvalue(), "")
+        self.assertFalse(emitted["ok"])
+        self.assertEqual(emitted["status"], "BLOCKED")
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["status"], "BLOCKED")
+        self.assertEqual(payload["exitCode"], 2)
+        self.assertFalse(payload["registryLoaded"])
+        self.assertIn("missing conclusion-registry.json", payload["registryError"])
+        self.assertEqual(payload["linkedIssueGate"]["status"], "INVALID_REGISTRY")
+        self.assertFalse(payload["linkedIssueGate"]["ok"])
+        self.assertIn("missing conclusion-registry.json", payload["linkedIssueGate"]["error"])
+        self.assertEqual(
+            payload["projectEvidence"]["status"],
+            "BLOCKED_INVALID_CONCLUSION_REGISTRY",
+        )
+        self.assertIn("missing conclusion-registry.json", payload["projectEvidence"]["evidence"])
+
     def test_linked_issues_check_writes_artifact_and_fails_for_unlinked_open_p1(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -1800,7 +1844,7 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
         self.assertEqual(payload["linkedIssueGate"]["blockedConclusionCount"], 0)
         self.assertEqual(payload["projectEvidence"]["nextAction"], "No unlinked OPEN P0/P1/P2 conclusions.")
 
-    def test_steward_digest_sees_root_level_training_report_but_keeps_rollout_blocked(self) -> None:
+    def test_steward_digest_sees_root_level_training_report_and_blocks_missing_registry(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             artifact_root, report_id = write_root_local2w_training_report_artifacts(root)
@@ -1828,12 +1872,14 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
         lanes = {item["name"]: item for item in payload["lanes"]}
         blocked_lane_names = {item["name"] for item in payload["blockedLanes"]}
         self.assertEqual(exit_code, 0)
-        self.assertEqual(payload["status"], "BLOCKED")
+        self.assertEqual(payload["status"], "ACTION_REQUIRED")
+        self.assertEqual(payload["linkedIssueGate"]["status"], "INVALID_REGISTRY")
+        self.assertIn("missing conclusion-registry artifact", payload["linkedIssueGate"]["error"])
         self.assertEqual(lanes["training"]["status"], "OK")
         self.assertTrue(str(lanes["training"]["latestArtifact"]).endswith(f"{report_id}.json"))
         self.assertIn("strategy comparison", blocked_lane_names)
         self.assertIn("rollout", blocked_lane_names)
-        self.assertEqual(payload["nextAction"], lanes["strategy comparison"]["blocker"])
+        self.assertIn("Repair conclusion-registry.json", payload["nextAction"])
 
 
 if __name__ == "__main__":

--- a/scripts/test_screeps_rl_control_loop_ledgers.py
+++ b/scripts/test_screeps_rl_control_loop_ledgers.py
@@ -1783,10 +1783,12 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
         lanes = {item["name"]: item for item in payload["lanes"]}
         blocked_lane_names = {item["name"] for item in payload["blockedLanes"]}
         self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["status"], "BLOCKED")
         self.assertEqual(lanes["training"]["status"], "OK")
         self.assertTrue(str(lanes["training"]["latestArtifact"]).endswith(f"{report_id}.json"))
         self.assertIn("strategy comparison", blocked_lane_names)
         self.assertIn("rollout", blocked_lane_names)
+        self.assertEqual(payload["nextAction"], lanes["strategy comparison"]["blocker"])
 
 
 if __name__ == "__main__":

--- a/scripts/test_screeps_rl_control_loop_ledgers.py
+++ b/scripts/test_screeps_rl_control_loop_ledgers.py
@@ -1636,6 +1636,51 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
         self.assertEqual(payload["linkedIssueGate"]["highestPriorityConclusionIds"], ["P1-UNLINKED"])
         self.assertIn("exact atomic linkedIssues", payload["nextAction"])
 
+    def test_steward_digest_blocks_on_malformed_conclusion_registry(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = write_fixture_artifacts(root)
+            write_json(
+                artifact_root / "rl-control-loop" / "conclusion-registry.json",
+                {
+                    "schemaVersion": 1,
+                    "registryType": "rl-conclusion-registry",
+                    "updatedAt": "2026-06-05T00:00:01Z",
+                    "conclusions": ["not-a-conclusion-record"],
+                },
+            )
+            output = root / "out" / "steward-digest.json"
+
+            exit_code = ledgers.main(
+                [
+                    "steward-digest",
+                    "--repo-root",
+                    str(root),
+                    "--artifact-root",
+                    str(artifact_root),
+                    "--output",
+                    str(output),
+                    "--created-at",
+                    "2026-06-05T00:00:02Z",
+                    "--max-files-per-root",
+                    "4",
+                ],
+                stdout=io.StringIO(),
+                stderr=io.StringIO(),
+            )
+            payload = read_json(output)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["status"], "ACTION_REQUIRED")
+        self.assertEqual(payload["linkedIssueGate"]["status"], "INVALID_REGISTRY")
+        self.assertFalse(payload["linkedIssueGate"]["ok"])
+        self.assertEqual(
+            payload["linkedIssueGate"]["projectEvidence"]["status"],
+            "BLOCKED_INVALID_CONCLUSION_REGISTRY",
+        )
+        self.assertIn("Repair conclusion-registry.json", payload["nextAction"])
+        self.assertIn("each conclusion record", payload["linkedIssueGate"]["error"])
+
     def test_linked_issues_check_writes_artifact_and_fails_for_unlinked_open_p1(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -134,6 +134,28 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(summary["counts"]["CLOSED"], 0)
         self.assertEqual([item["conclusionId"] for item in summary["p0Unresolved"]], ["E1-OPEN"])
 
+    def test_conclusion_summary_tolerates_malformed_registry_payload(self) -> None:
+        artifact = loaded_artifact(
+            Path("runtime-artifacts/rl-control-loop/conclusion-registry.json"),
+            {
+                "updatedAt": "2026-05-23T00:02:00Z",
+                "conclusions": ["not-a-conclusion-record"],
+            },
+        )
+
+        summary = dashboard.conclusion_summary(artifact)
+
+        self.assertEqual(summary["counts"], {status: 0 for status in dashboard.CONCLUSION_STATUSES})
+        self.assertEqual(summary["otherCounts"], {})
+        self.assertEqual(summary["p0Unresolved"], [])
+        self.assertEqual(
+            summary["linkedIssueGate"],
+            dashboard.rl_conclusion_registry.build_open_conclusion_linked_issue_gate({}),
+        )
+        self.assertEqual(summary["latestArtifact"], artifact.path)
+        self.assertEqual(summary["updatedAt"], "2026-05-23T00:02:00Z")
+        self.assertTrue(summary["hasData"])
+
     def test_dashboard_prefers_fresh_acceptable_gate_data_over_stale_dataset_gate_and_embedded_ledger_gate(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -148,10 +148,17 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertEqual(summary["counts"], {status: 0 for status in dashboard.CONCLUSION_STATUSES})
         self.assertEqual(summary["otherCounts"], {})
         self.assertEqual(summary["p0Unresolved"], [])
+        self.assertEqual(summary["linkedIssueGate"]["status"], "INVALID_REGISTRY")
+        self.assertFalse(summary["linkedIssueGate"]["ok"])
         self.assertEqual(
-            summary["linkedIssueGate"],
-            dashboard.rl_conclusion_registry.build_open_conclusion_linked_issue_gate({}),
+            summary["linkedIssueGate"]["projectEvidence"]["status"],
+            "BLOCKED_INVALID_CONCLUSION_REGISTRY",
         )
+        self.assertIn(
+            "Repair conclusion-registry.json",
+            summary["linkedIssueGate"]["projectEvidence"]["nextAction"],
+        )
+        self.assertIn("each conclusion record", summary["linkedIssueGate"]["error"])
         self.assertEqual(summary["latestArtifact"], artifact.path)
         self.assertEqual(summary["updatedAt"], "2026-05-23T00:02:00Z")
         self.assertTrue(summary["hasData"])

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -104,6 +104,23 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertTrue(dashboard.value_has_reference(["0", "2.5"]))
         self.assertTrue(dashboard.value_has_reference("training-report-a"))
 
+    def test_conclusion_summary_flags_missing_registry_as_invalid_gate(self) -> None:
+        summary = dashboard.conclusion_summary(None)
+
+        self.assertEqual(summary["counts"], {status: 0 for status in dashboard.CONCLUSION_STATUSES})
+        self.assertEqual(summary["otherCounts"], {})
+        self.assertEqual(summary["p0Unresolved"], [])
+        self.assertEqual(summary["latestArtifact"], "N/A")
+        self.assertEqual(summary["updatedAt"], "N/A")
+        self.assertFalse(summary["hasData"])
+        self.assertEqual(summary["linkedIssueGate"]["status"], "INVALID_REGISTRY")
+        self.assertFalse(summary["linkedIssueGate"]["ok"])
+        self.assertIn("missing conclusion-registry artifact", summary["linkedIssueGate"]["error"])
+        self.assertIn(
+            "missing conclusion-registry artifact",
+            summary["linkedIssueGate"]["projectEvidence"]["evidence"],
+        )
+
     def test_conclusion_summary_counts_mapping_registry_shape(self) -> None:
         artifact = loaded_artifact(
             Path("runtime-artifacts/rl-control-loop/conclusion-registry.json"),


### PR DESCRIPTION
## Linked issues

Intentional PR-body closing linkage:
- Fixes #1748

Related / non-closing linkage:
- Related to RL conclusion-registry contract and artifact-first steward routing.

## Domain / Kind

- Domain: RL flywheel
- Kind: ops

## Summary

- Adds deterministic conclusion-registry detection for OPEN severity P0/P1/P2 conclusions that lack exact linked atomic issues.
- Rejects historical/broad issue sinks and non-issue placeholders so only exact issue-shaped links satisfy the gate.
- Wires the guard into RL control-loop ledger output and dashboard/steward summaries so malformed registries and blocked lanes cannot be reported as OK.
- Adds focused tests for linked-issue detection, historical/broad issue filtering, placeholder rejection, malformed registry failure surfacing, ledger output, and dashboard summary behavior.

## Verification

- [x] Local check on commit cfd354e851f85a6bf6ad80249218a729f5dddef5: `git diff --check`; `python3 -m py_compile scripts/rl_conclusion_registry.py scripts/screeps_rl_control_loop_ledgers.py scripts/screeps_rl_dashboard.py scripts/test_rl_conclusion_registry.py scripts/test_screeps_rl_control_loop_ledgers.py scripts/test_screeps_rl_dashboard.py scripts/test_screeps_rl_live_dashboard.py`; `python3 -m unittest scripts/test_rl_conclusion_registry.py scripts/test_screeps_rl_control_loop_ledgers.py scripts/test_screeps_rl_dashboard.py scripts/test_screeps_rl_live_dashboard.py` — 158 tests OK in controller verification.
- [x] GitHub Project issue/PR fields are current (`Status`, `Evidence`, `Next action`; plus `Blocked by` when blocked).
- [ ] Automated review has no blocking findings and review threads are resolved/outdated/non-blocking. Current state: latest review-fix commit pushed; waiting for current-head CI and any fresh automated review output.
- [ ] QA gate: requested by normal PR gate.
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Automated review triage

- Gemini thread `PRRT_kwDOSMSsO86HnZte`: `FIX`, criticality critical; malformed registry handling was addressed by a8e0918a and hardened by 9faa82f8 so dashboard output stays alive without reporting an OK linked-issue gate for malformed input. Verification: 156-test controller run above.
- Codex connector thread `PRRT_kwDOSMSsO86HnZ-m`: `FIX`, criticality P1; forbidden broad issue sink numbers 879, 893, 1589, and 1543 no longer satisfy linked-issue routing. Verification: focused registry tests plus 156-test controller run.
- Codex connector thread `PRRT_kwDOSMSsO86HnbCj`: `FIX`, criticality P2; steward digest now reports `BLOCKED` when dashboard lanes are blocked even if linked-issue gate is OK. Verification: focused steward digest assertion plus 156-test controller run.
- Codex connector thread `PRRT_kwDOSMSsO86HncNf`: `FIX`, criticality P1; placeholder values such as `TBD` / `needs issue` no longer satisfy the linked-issue gate; issue-shaped links remain accepted. Verification: focused placeholder/URL/bare-number tests plus 156-test controller run.
- CodeRabbit top-level findings `a9149b89d565c5b9f294d1b5` and `e8169b4708b2a601bb7a3d3d`: `FIX`, criticality critical; dashboard emits `INVALID_REGISTRY` and steward treats it as action-required instead of OK. Verification: malformed-dashboard and steward-digest tests plus 158-test controller run.
- Codex connector thread `PRRT_kwDOSMSsO86HnfbW`: `FIX`, criticality P1; missing dashboard conclusion-registry artifacts now surface `INVALID_REGISTRY` instead of an OK empty gate. Verification: focused dashboard missing-registry test plus 158-test controller run.
- Codex connector thread `PRRT_kwDOSMSsO86HnfbY`: `FIX`, criticality P1; linked-issues check now fails with `INVALID_REGISTRY` and exit code 2 when conclusion-registry.json is absent. Verification: focused CLI missing-registry test plus 158-test controller run.

## Universal task Done gate

- [x] Task type: ops/code guard for RL conclusion-registry routing.
- [x] Expected observable outcome / named deliverable: OPEN severity P0/P1/P2 RL conclusions without exact atomic issue-shaped `linkedIssues` are detected as actionable linked-issue gaps by registry/ledger/dashboard surfaces; malformed registry evidence is surfaced as `INVALID_REGISTRY` instead of OK.
- [x] Non-goals / accepted substitutes: no GitHub comments to historical sink issue numbers 879, 893, 1589, or 1543; no new cron jobs, no paid compute, and no official MMO runtime change.
- [x] Verification evidence required before Done: commit cfd354e8 passed `git diff --check`, targeted `py_compile`, and 158 relevant Python unit tests from the controller session.
- [x] Project Evidence / Next action / Blocked by: #1748 and this PR carry commit cfd354e8 verification evidence; next action is current-head CI/automated-review/QA gate; no owner-side blocker.
- [x] Post-merge/deploy/runtime proof: not applicable for offline RL steward/script guard; no official deploy needed.
- [x] Named deliverable proof: registry guard, ledger integration, dashboard summary, invalid-registry gate, issue-shaped link validation, missing-registry gate, lane-status digest preservation, and tests are present in commits 8fc48771, a8e0918a, f9a97818, 450df0dd, 9faa82f8, and cfd354e8.

## Issue closure gate

For every issue linked above in the PR body with a closing keyword:

- [x] #1748: acceptance is satisfied by commits 8fc48771, a8e0918a, f9a97818, 450df0dd, 9faa82f8, and cfd354e8 detecting severity P0/P1/P2 OPEN conclusions with absent exact linked atomic issues, surfacing the guard through ledger/dashboard/steward output, preserving artifact-first no-sink behavior, rejecting placeholder/broad links, surfacing malformed or absent registry input as INVALID_REGISTRY/action-required, and passing targeted tests.
- [x] No closed issue still needs owner action, live runtime/process proof, successor work, partial-fix completion, or any other blocker.

## Runtime / deployment impact

- [x] No gameplay/runtime/deployment impact.
- [ ] Gameplay/runtime/deployment impact; Deployment Floor evidence or HELD blocker is recorded.

## Notes

- Review/merge gates: wait at least 15 minutes after PR creation, require green checks, substantive automated review with no blocking findings, resolved/outdated/non-blocking review threads, QA, and current Project fields before merge.
