### PR TITLE
rl: guard local training on swap pressure

### DIFF
--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -43,6 +43,13 @@ DEFAULT_RESOURCE_NORMALIZER = 1000.0
 DEFAULT_RUN_REPETITIONS = 1
 DEFAULT_STEAM_KEY_ENV_FILE = screeps_secret_env.DEFAULT_LOCAL_SECRET_ENV_FILE
 STEAM_KEY_ENV_FILE_ENV = "SCREEPS_RL_STEAM_KEY_ENV_FILE"
+HOST_RESOURCE_PREFLIGHT_TYPE = "screeps-rl-host-resource-preflight"
+HOST_RESOURCE_PREFLIGHT_FAILED_ERROR_CODE = "HOST_RESOURCE_PREFLIGHT_FAILED"
+HOST_RESOURCE_PREFLIGHT_UNAVAILABLE_ERROR_CODE = "HOST_RESOURCE_PREFLIGHT_UNAVAILABLE"
+HOST_SWAP_EXHAUSTED_ERROR_CODE = "HOST_SWAP_EXHAUSTED"
+DEFAULT_HOST_MEMINFO_PATH = Path("/proc/meminfo")
+DEFAULT_MIN_SWAP_FREE_BYTES = 512 * 1024 * 1024
+DEFAULT_MAX_SWAP_USED_RATIO = 0.90
 PRE_SCALE_TRAINABILITY_SMOKE_TICKS = 2
 DEFAULT_POLICY_UPDATE_LEARNING_RATE = 0.25
 RANK_WEIGHTED_FINITE_DIFFERENCE_ALGORITHM = "rank_weighted_finite_difference_v1"
@@ -137,6 +144,27 @@ class TrainingRunnerInterrupted(KeyboardInterrupt):
         signal_name = signal_name_for_number(signum)
         detail = f" by {signal_name}" if signal_name is not None else ""
         super().__init__(f"training runner interrupted{detail}")
+
+
+class HostResourcePreflightError(RuntimeError):
+    """Raised when the local simulator host is unsafe for a training launch."""
+
+    def __init__(self, preflight: JsonObject) -> None:
+        self.host_resource_preflight = copy.deepcopy(preflight)
+        blocker = self.host_resource_preflight.get("blocker")
+        if isinstance(blocker, dict):
+            raw_code = blocker.get("errorCode")
+            raw_message = blocker.get("message")
+        else:
+            raw_code = None
+            raw_message = None
+        self.error_code = (
+            raw_code
+            if isinstance(raw_code, str) and raw_code
+            else HOST_RESOURCE_PREFLIGHT_FAILED_ERROR_CODE
+        )
+        message = raw_message if isinstance(raw_message, str) and raw_message else "host resource preflight failed"
+        super().__init__(f"{self.error_code}: {message}")
 
 
 @dataclass(frozen=True)
@@ -1076,6 +1104,180 @@ def text_or_none(value: Any) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
+def host_resource_bytes_from_meminfo(text: str) -> dict[str, int]:
+    values: dict[str, int] = {}
+    for line in text.splitlines():
+        parts = line.split()
+        if len(parts) < 2 or not parts[0].endswith(":"):
+            continue
+        raw_value = parts[1]
+        if not raw_value.isdigit():
+            continue
+        unit = parts[2].lower() if len(parts) >= 3 else "b"
+        multiplier = 1024 if unit == "kb" else 1
+        values[parts[0][:-1]] = int(raw_value) * multiplier
+    return values
+
+
+def ratio_or_none(numerator: int, denominator: int) -> float | None:
+    if denominator <= 0:
+        return None
+    return round(numerator / denominator, 6)
+
+
+def mib_string(byte_count: int) -> str:
+    return f"{byte_count / (1024 * 1024):.1f} MiB"
+
+
+def sanitized_min_swap_free_bytes(value: int) -> int:
+    return max(0, int(value))
+
+
+def sanitized_max_swap_used_ratio(value: float) -> float:
+    if not math.isfinite(value):
+        return DEFAULT_MAX_SWAP_USED_RATIO
+    return min(1.0, max(0.0, float(value)))
+
+
+def statvfs_probe_path(path: Path) -> Path:
+    target = path
+    while not target.exists():
+        parent = target.parent
+        if parent == target:
+            return target
+        target = parent
+    return target
+
+
+def collect_disk_preflight(path: Path, statvfs_reader: Callable[[Path], Any]) -> JsonObject:
+    checked_path = statvfs_probe_path(path)
+    disk: JsonObject = {
+        "path": dataset_export.display_path(path),
+        "checkedPath": dataset_export.display_path(checked_path),
+    }
+    try:
+        stat = statvfs_reader(checked_path)
+        fragment_size = int(getattr(stat, "f_frsize", 0) or getattr(stat, "f_bsize", 0) or 0)
+        disk["freeBytes"] = int(getattr(stat, "f_bfree", 0)) * fragment_size
+        disk["availableBytes"] = int(getattr(stat, "f_bavail", 0)) * fragment_size
+        disk["totalBytes"] = int(getattr(stat, "f_blocks", 0)) * fragment_size
+    except OSError as error:
+        disk["error"] = dataset_export.redact_text(str(error))
+    return disk
+
+
+def build_host_resource_preflight_blocker(
+    *,
+    reasons: Sequence[str],
+    error_code: str,
+) -> JsonObject:
+    joined_reasons = "; ".join(reasons)
+    return {
+        "errorCode": error_code,
+        "message": joined_reasons,
+        "action": (
+            "Stop or wait for memory-heavy RL/simulator processes, free swap, add RAM/swap, "
+            "or run the training on a host with safe memory headroom before relaunching local RL."
+        ),
+    }
+
+
+def collect_host_resource_preflight(
+    out_dir: Path,
+    *,
+    meminfo_path: Path | None = None,
+    statvfs_reader: Callable[[Path], Any] | None = None,
+    min_swap_free_bytes: int = DEFAULT_MIN_SWAP_FREE_BYTES,
+    max_swap_used_ratio: float = DEFAULT_MAX_SWAP_USED_RATIO,
+) -> JsonObject:
+    resolved_meminfo_path = meminfo_path or DEFAULT_HOST_MEMINFO_PATH
+    resolved_statvfs_reader = statvfs_reader or os.statvfs
+    safe_min_swap_free_bytes = sanitized_min_swap_free_bytes(min_swap_free_bytes)
+    safe_max_swap_used_ratio = sanitized_max_swap_used_ratio(max_swap_used_ratio)
+    preflight: JsonObject = {
+        "type": HOST_RESOURCE_PREFLIGHT_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "ok": True,
+        "checkedAt": utc_now_iso(),
+        "meminfoPath": dataset_export.display_path(resolved_meminfo_path),
+        "thresholds": {
+            "minSwapFreeBytes": safe_min_swap_free_bytes,
+            "maxSwapUsedRatio": safe_max_swap_used_ratio,
+        },
+        "disk": collect_disk_preflight(out_dir, resolved_statvfs_reader),
+    }
+    try:
+        meminfo_values = host_resource_bytes_from_meminfo(resolved_meminfo_path.read_text(encoding="utf-8"))
+    except OSError as error:
+        preflight["ok"] = False
+        preflight["blocker"] = build_host_resource_preflight_blocker(
+            reasons=[f"could not read host meminfo: {dataset_export.redact_text(str(error))}"],
+            error_code=HOST_RESOURCE_PREFLIGHT_UNAVAILABLE_ERROR_CODE,
+        )
+        return preflight
+
+    mem_total_bytes = meminfo_values.get("MemTotal", 0)
+    mem_available_bytes = meminfo_values.get("MemAvailable", 0)
+    swap_total_bytes = meminfo_values.get("SwapTotal", 0)
+    swap_free_bytes = meminfo_values.get("SwapFree", 0)
+    swap_used_bytes = max(0, swap_total_bytes - swap_free_bytes)
+    swap_used_ratio = ratio_or_none(swap_used_bytes, swap_total_bytes)
+    preflight["memory"] = {
+        "memTotalBytes": mem_total_bytes,
+        "memAvailableBytes": mem_available_bytes,
+    }
+    preflight["swap"] = {
+        "present": swap_total_bytes > 0,
+        "totalBytes": swap_total_bytes,
+        "freeBytes": swap_free_bytes,
+        "usedBytes": swap_used_bytes,
+        "usedRatio": swap_used_ratio,
+    }
+
+    reasons: list[str] = []
+    if swap_total_bytes > 0:
+        if swap_free_bytes < safe_min_swap_free_bytes:
+            reasons.append(
+                f"swap free {mib_string(swap_free_bytes)} is below required "
+                f"{mib_string(safe_min_swap_free_bytes)}"
+            )
+        if swap_used_ratio is not None and swap_used_ratio >= safe_max_swap_used_ratio:
+            reasons.append(
+                f"swap used ratio {swap_used_ratio:.3f} is at or above limit "
+                f"{safe_max_swap_used_ratio:.3f}"
+            )
+    if reasons:
+        preflight["ok"] = False
+        preflight["blocker"] = build_host_resource_preflight_blocker(
+            reasons=reasons,
+            error_code=HOST_SWAP_EXHAUSTED_ERROR_CODE,
+        )
+    return preflight
+
+
+def assert_local_training_host_resources_safe(
+    *,
+    simulator_runner: SimulatorRunner,
+    out_dir: Path,
+    meminfo_path: Path | None = None,
+    statvfs_reader: Callable[[Path], Any] | None = None,
+    min_swap_free_bytes: int = DEFAULT_MIN_SWAP_FREE_BYTES,
+    max_swap_used_ratio: float = DEFAULT_MAX_SWAP_USED_RATIO,
+) -> JsonObject | None:
+    if simulator_runner is not simulator_harness.run_simulator:
+        return None
+    preflight = collect_host_resource_preflight(
+        out_dir,
+        meminfo_path=meminfo_path,
+        statvfs_reader=statvfs_reader,
+        min_swap_free_bytes=min_swap_free_bytes,
+        max_swap_used_ratio=max_swap_used_ratio,
+    )
+    if preflight.get("ok") is not True:
+        raise HostResourcePreflightError(preflight)
+    return preflight
+
+
 def scalar_weighted_sum_authorized(raw: Any) -> bool:
     if not isinstance(raw, dict):
         return False
@@ -1155,6 +1357,10 @@ def run_training_experiment(
     simulator_runner: SimulatorRunner = simulator_harness.run_simulator,
     steam_key_env_file: Path | None = None,
     stdout: TextIO | None = None,
+    host_meminfo_path: Path | None = None,
+    host_statvfs_reader: Callable[[Path], Any] | None = None,
+    min_swap_free_bytes: int = DEFAULT_MIN_SWAP_FREE_BYTES,
+    max_swap_used_ratio: float = DEFAULT_MAX_SWAP_USED_RATIO,
 ) -> JsonObject:
     """Run all card variants through the simulator harness and write a JSON report."""
     card = load_experiment_card(card_path)
@@ -1167,8 +1373,16 @@ def run_training_experiment(
     reward_options = reward_options_from_card(card)
     resolved_report_id = report_id or default_report_id(card, variants, config)
     validate_report_id(resolved_report_id)
-    ensure_steam_key_for_training(simulator_runner=simulator_runner, env_file=steam_key_env_file)
     resolved_out_dir = out_dir.expanduser()
+    assert_local_training_host_resources_safe(
+        simulator_runner=simulator_runner,
+        out_dir=resolved_out_dir,
+        meminfo_path=host_meminfo_path,
+        statvfs_reader=host_statvfs_reader,
+        min_swap_free_bytes=min_swap_free_bytes,
+        max_swap_used_ratio=max_swap_used_ratio,
+    )
+    ensure_steam_key_for_training(simulator_runner=simulator_runner, env_file=steam_key_env_file)
     previous_gradient_momentum_state = load_policy_gradient_momentum_state(
         policy_gradient_metadata_from_card(card),
         resolved_out_dir,
@@ -8209,6 +8423,8 @@ def build_generation_summary(report: JsonObject) -> JsonObject:
 
 
 def training_failure_classification(error: BaseException) -> str:
+    if isinstance(error, HostResourcePreflightError):
+        return "host_resource_preflight_failed"
     if isinstance(error, (TrainingRunnerInterrupted, KeyboardInterrupt)):
         return "interrupted"
     if isinstance(error, TimeoutError):
@@ -8311,6 +8527,8 @@ def build_training_failure_report(
         "exceptionType": type(error).__name__,
         "error": error_text,
     }
+    if isinstance(error, HostResourcePreflightError):
+        failure["errorCode"] = error.error_code
     if isinstance(error, TrainingRunnerInterrupted):
         signal_name = signal_name_for_number(error.signum)
         if error.signum is not None:
@@ -8342,6 +8560,8 @@ def build_training_failure_report(
         report["requestedReportId"] = requested_report_id
     if isinstance(context.get("experimentCardSummary"), dict):
         report["experimentCardSummary"] = copy.deepcopy(context["experimentCardSummary"])
+    if isinstance(error, HostResourcePreflightError):
+        report["hostResourcePreflight"] = copy.deepcopy(error.host_resource_preflight)
     warnings = context.get("warnings")
     if isinstance(warnings, list) and warnings:
         report["warnings"] = copy.deepcopy(warnings)

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -1149,12 +1149,15 @@ def statvfs_probe_path(path: Path) -> Path:
     return target
 
 
-def collect_disk_preflight(path: Path, statvfs_reader: Callable[[Path], Any]) -> JsonObject:
+def collect_disk_preflight(path: Path, statvfs_reader: Callable[[Path], Any] | None) -> JsonObject:
     checked_path = statvfs_probe_path(path)
     disk: JsonObject = {
         "path": dataset_export.display_path(path),
         "checkedPath": dataset_export.display_path(checked_path),
     }
+    if statvfs_reader is None:
+        disk["error"] = "host statvfs unavailable"
+        return disk
     try:
         stat = statvfs_reader(checked_path)
         fragment_size = int(getattr(stat, "f_frsize", 0) or getattr(stat, "f_bsize", 0) or 0)
@@ -1191,7 +1194,9 @@ def collect_host_resource_preflight(
     max_swap_used_ratio: float = DEFAULT_MAX_SWAP_USED_RATIO,
 ) -> JsonObject:
     resolved_meminfo_path = meminfo_path or DEFAULT_HOST_MEMINFO_PATH
-    resolved_statvfs_reader = statvfs_reader or os.statvfs
+    resolved_statvfs_reader = (
+        statvfs_reader if statvfs_reader is not None else getattr(os, "statvfs", None)
+    )
     safe_min_swap_free_bytes = sanitized_min_swap_free_bytes(min_swap_free_bytes)
     safe_max_swap_used_ratio = sanitized_max_swap_used_ratio(max_swap_used_ratio)
     preflight: JsonObject = {
@@ -1209,6 +1214,14 @@ def collect_host_resource_preflight(
     try:
         meminfo_values = host_resource_bytes_from_meminfo(resolved_meminfo_path.read_text(encoding="utf-8"))
     except OSError as error:
+        if meminfo_path is None and isinstance(error, FileNotFoundError):
+            preflight["warnings"] = [
+                (
+                    f"default host meminfo {dataset_export.display_path(resolved_meminfo_path)} is unavailable; "
+                    "skipping swap checks"
+                )
+            ]
+            return preflight
         preflight["ok"] = False
         preflight["blocker"] = build_host_resource_preflight_blocker(
             reasons=[f"could not read host meminfo: {dataset_export.redact_text(str(error))}"],

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -35,6 +35,49 @@ def read_json(path: Path) -> JsonObject:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+class FakeStatvfsResult:
+    def __init__(self, *, total_mib: int = 10240, free_mib: int = 4096, available_mib: int | None = None) -> None:
+        self.f_frsize = 1024 * 1024
+        self.f_bsize = self.f_frsize
+        self.f_blocks = total_mib
+        self.f_bfree = free_mib
+        self.f_bavail = free_mib if available_mib is None else available_mib
+
+
+def fake_statvfs_result(
+    *,
+    total_mib: int = 10240,
+    free_mib: int = 4096,
+    available_mib: int | None = None,
+):
+    def fake_statvfs(_path: Path) -> FakeStatvfsResult:
+        return FakeStatvfsResult(total_mib=total_mib, free_mib=free_mib, available_mib=available_mib)
+
+    return fake_statvfs
+
+
+def write_meminfo(
+    path: Path,
+    *,
+    mem_total_mib: int = 7680,
+    mem_available_mib: int = 2048,
+    swap_total_mib: int = 2048,
+    swap_free_mib: int = 1536,
+) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                f"MemTotal:       {mem_total_mib * 1024} kB",
+                f"MemAvailable:   {mem_available_mib * 1024} kB",
+                f"SwapTotal:      {swap_total_mib * 1024} kB",
+                f"SwapFree:       {swap_free_mib * 1024} kB",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
 def reinforce_stability_policy_gradient() -> JsonObject:
     return {
         "targetFamily": "test-family",
@@ -1515,6 +1558,157 @@ class RlTrainingRunnerTest(unittest.TestCase):
 
                 self.assertEqual(str(caught.exception), "STEAM_KEY environment variable is required for run mode")
                 self.assertEqual(simulator.observed_steam_keys, [None])
+
+    def test_host_resource_preflight_safe_swap_passes_real_local_runner(self) -> None:
+        start = tick(1, [room("W1N1", energy=100)])
+        baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200)])])
+        candidate = variant_result("candidate", [start, tick(2, [room("W1N1", energy=250)])])
+        simulator = MockSimulator({"baseline": baseline, "candidate": candidate})
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            meminfo_path = root / "meminfo"
+            write_json(card_path, base_card())
+            write_meminfo(meminfo_path, swap_total_mib=2048, swap_free_mib=1536)
+
+            with (
+                mock.patch.object(runner.simulator_harness, "run_simulator", simulator),
+                mock.patch.dict(os.environ, {"STEAM_KEY": "steam-key-for-test"}, clear=True),
+            ):
+                report = runner.run_training_experiment(
+                    card_path,
+                    root / "reports",
+                    report_id="safe-swap-preflight",
+                    simulator_runner=runner.simulator_harness.run_simulator,
+                    host_meminfo_path=meminfo_path,
+                    host_statvfs_reader=fake_statvfs_result(free_mib=4096),
+                )
+
+        self.assertEqual(report["reportId"], "safe-swap-preflight")
+        self.assertEqual(len(simulator.calls), 1)
+
+    def test_host_resource_preflight_blocks_low_free_high_used_swap_before_launch(self) -> None:
+        simulator = MockSimulator({
+            "baseline": variant_result("baseline", []),
+            "candidate": variant_result("candidate", []),
+        })
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            meminfo_path = root / "meminfo"
+            write_json(card_path, base_card())
+            write_meminfo(meminfo_path, swap_total_mib=2048, swap_free_mib=128)
+
+            with (
+                mock.patch.object(runner.simulator_harness, "run_simulator", simulator),
+                mock.patch.object(
+                    runner,
+                    "ensure_steam_key_for_training",
+                    side_effect=AssertionError("preflight did not block before STEAM_KEY"),
+                ),
+                mock.patch.dict(os.environ, {}, clear=True),
+            ):
+                with self.assertRaisesRegex(
+                    runner.HostResourcePreflightError,
+                    runner.HOST_SWAP_EXHAUSTED_ERROR_CODE,
+                ) as caught:
+                    runner.run_training_experiment(
+                        card_path,
+                        root / "reports",
+                        report_id="swap-blocked-before-launch",
+                        simulator_runner=runner.simulator_harness.run_simulator,
+                        host_meminfo_path=meminfo_path,
+                        host_statvfs_reader=fake_statvfs_result(free_mib=4096),
+                    )
+
+        preflight = caught.exception.host_resource_preflight
+        self.assertEqual(simulator.calls, [])
+        self.assertFalse(preflight["ok"])
+        self.assertEqual(preflight["blocker"]["errorCode"], runner.HOST_SWAP_EXHAUSTED_ERROR_CODE)
+        self.assertEqual(preflight["swap"]["freeBytes"], 128 * 1024 * 1024)
+        self.assertGreaterEqual(preflight["swap"]["usedRatio"], runner.DEFAULT_MAX_SWAP_USED_RATIO)
+        self.assertIn("availableBytes", preflight["disk"])
+
+    def test_main_writes_host_resource_preflight_failure_artifact(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            meminfo_path = root / "meminfo"
+            out_dir = root / "reports"
+            write_json(card_path, base_card())
+            write_meminfo(meminfo_path, swap_total_mib=2048, swap_free_mib=64)
+
+            with (
+                mock.patch.object(runner, "DEFAULT_HOST_MEMINFO_PATH", meminfo_path),
+                mock.patch.object(runner.os, "statvfs", side_effect=fake_statvfs_result(free_mib=4096)),
+                mock.patch.object(
+                    runner,
+                    "ensure_steam_key_for_training",
+                    side_effect=AssertionError("preflight did not block before STEAM_KEY"),
+                ),
+                mock.patch.dict(os.environ, {}, clear=True),
+            ):
+                exit_code = runner.main(
+                    [
+                        "--experiment-card",
+                        str(card_path),
+                        "--out-dir",
+                        str(out_dir),
+                        "--report-id",
+                        "swap-preflight-failure",
+                    ],
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+
+            failure = read_json(out_dir / "swap-preflight-failure.failure.json")
+
+        self.assertEqual(exit_code, 2)
+        self.assertEqual(failure["type"], runner.FAILURE_REPORT_TYPE)
+        self.assertEqual(failure["failure"]["classification"], "host_resource_preflight_failed")
+        self.assertEqual(failure["failure"]["exceptionType"], "HostResourcePreflightError")
+        self.assertEqual(failure["failure"]["errorCode"], runner.HOST_SWAP_EXHAUSTED_ERROR_CODE)
+        self.assertEqual(
+            failure["hostResourcePreflight"]["blocker"]["errorCode"],
+            runner.HOST_SWAP_EXHAUSTED_ERROR_CODE,
+        )
+        self.assertEqual(failure["hostResourcePreflight"]["swap"]["freeBytes"], 64 * 1024 * 1024)
+        self.assertFalse(failure["trainingReportProduced"])
+        self.assertIn("failure-artifact:", stderr.getvalue())
+
+    def test_host_resource_preflight_no_swap_does_not_false_block(self) -> None:
+        start = tick(1, [room("W1N1", energy=100)])
+        baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200)])])
+        candidate = variant_result("candidate", [start, tick(2, [room("W1N1", energy=250)])])
+        simulator = MockSimulator({"baseline": baseline, "candidate": candidate})
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            meminfo_path = root / "meminfo"
+            write_json(card_path, base_card())
+            write_meminfo(meminfo_path, swap_total_mib=0, swap_free_mib=0)
+
+            with (
+                mock.patch.object(runner.simulator_harness, "run_simulator", simulator),
+                mock.patch.dict(os.environ, {"STEAM_KEY": "steam-key-for-test"}, clear=True),
+            ):
+                report = runner.run_training_experiment(
+                    card_path,
+                    root / "reports",
+                    report_id="no-swap-preflight",
+                    simulator_runner=runner.simulator_harness.run_simulator,
+                    host_meminfo_path=meminfo_path,
+                    host_statvfs_reader=fake_statvfs_result(free_mib=4096),
+                )
+
+        self.assertEqual(report["reportId"], "no-swap-preflight")
+        self.assertEqual(len(simulator.calls), 1)
 
     def test_main_redacts_steam_key_from_error_output(self) -> None:
         secret = "steam-secret-token-123456"

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -1588,6 +1588,56 @@ class RlTrainingRunnerTest(unittest.TestCase):
         self.assertEqual(report["reportId"], "safe-swap-preflight")
         self.assertEqual(len(simulator.calls), 1)
 
+    def test_host_resource_preflight_records_disk_error_when_statvfs_unavailable(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            meminfo_path = root / "meminfo"
+            write_meminfo(meminfo_path, swap_total_mib=2048, swap_free_mib=1536)
+
+            with mock.patch.object(runner.os, "statvfs", None, create=True):
+                preflight = runner.collect_host_resource_preflight(
+                    root / "reports",
+                    meminfo_path=meminfo_path,
+                )
+
+        self.assertTrue(preflight["ok"])
+        self.assertEqual(preflight["disk"]["error"], "host statvfs unavailable")
+        self.assertEqual(preflight["swap"]["freeBytes"], 1536 * 1024 * 1024)
+
+    def test_host_resource_preflight_skips_default_missing_meminfo(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            missing_meminfo_path = root / "missing-meminfo"
+
+            with mock.patch.object(runner, "DEFAULT_HOST_MEMINFO_PATH", missing_meminfo_path):
+                preflight = runner.collect_host_resource_preflight(
+                    root / "reports",
+                    statvfs_reader=fake_statvfs_result(free_mib=4096),
+                )
+
+        self.assertTrue(preflight["ok"])
+        self.assertNotIn("blocker", preflight)
+        self.assertNotIn("swap", preflight)
+        self.assertTrue(any("skipping swap checks" in warning for warning in preflight["warnings"]))
+
+    def test_host_resource_preflight_blocks_explicit_missing_meminfo(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            missing_meminfo_path = root / "missing-meminfo"
+
+            preflight = runner.collect_host_resource_preflight(
+                root / "reports",
+                meminfo_path=missing_meminfo_path,
+                statvfs_reader=fake_statvfs_result(free_mib=4096),
+            )
+
+        self.assertFalse(preflight["ok"])
+        self.assertEqual(
+            preflight["blocker"]["errorCode"],
+            runner.HOST_RESOURCE_PREFLIGHT_UNAVAILABLE_ERROR_CODE,
+        )
+        self.assertIn("could not read host meminfo", preflight["blocker"]["message"])
+
     def test_host_resource_preflight_blocks_low_free_high_used_swap_before_launch(self) -> None:
         simulator = MockSimulator({
             "baseline": variant_result("baseline", []),
@@ -1645,7 +1695,12 @@ class RlTrainingRunnerTest(unittest.TestCase):
 
             with (
                 mock.patch.object(runner, "DEFAULT_HOST_MEMINFO_PATH", meminfo_path),
-                mock.patch.object(runner.os, "statvfs", side_effect=fake_statvfs_result(free_mib=4096)),
+                mock.patch.object(
+                    runner.os,
+                    "statvfs",
+                    side_effect=fake_statvfs_result(free_mib=4096),
+                    create=True,
+                ),
                 mock.patch.object(
                     runner,
                     "ensure_steam_key_for_training",


### PR DESCRIPTION
## Linked issues

Intentional non-closing linkage:
- Refs #1739

## Domain / Kind

- Domain: RL flywheel
- Kind: ops/code guard

## Summary

- Adds a host-resource preflight for the local RL training runner before the real simulator path starts.
- Blocks unsafe launches when swap is present and either free swap is below 512 MiB or swap usage is at/above 90%.
- Writes structured failure evidence with `HOST_SWAP_EXHAUSTED`, `hostResourcePreflight`, memory/swap thresholds, and disk availability instead of silently entering a futex/OOM-prone run.
- Keeps no-swap hosts and safe-swap hosts unblocked, and keeps test/mock simulator paths injectable.

## Verification

- [x] Controller verification on commits `3a370e500053dc9a74ddb24370d01ce92f65f16f` and `c0cf1e42`: `git diff --check`; `python3 -m py_compile scripts/screeps_rl_training_runner.py scripts/test_screeps_rl_training_runner.py`; `python3 -m unittest scripts/test_screeps_rl_training_runner.py` — 158 tests OK after review-fix.
- [ ] GitHub required checks are green on the PR head.
- [ ] Automated review has no blocking findings and review threads are resolved/outdated/non-blocking.
- [ ] QA gate: pending normal PR gate.
- [x] No secrets, official MMO writes, Tencent paid compute, or unsafe owner-facing attachment-trigger text.

## Universal task Done gate

- [x] Task type: RL local-training host safety guard.
- [x] Expected observable outcome / named deliverable: `scripts/screeps_rl_training_runner.py` refuses to start the real local simulator runner under unsafe swap pressure and emits structured `HOST_SWAP_EXHAUSTED` failure evidence.
- [x] Non-goals / accepted substitutes: no paid Tencent run, no official MMO deploy, no long local training/simulator run, no Project/issue sink comments from Codex.
- [x] Verification evidence required before Done: commits `3a370e500053dc9a74ddb24370d01ce92f65f16f` and `c0cf1e42` passed controller `diff-check`, `py_compile`, and `python3 -m unittest scripts/test_screeps_rl_training_runner.py` with 158 tests OK after review-fix.
- [x] Project Evidence / Next action / Blocked by: Project fields are updated by Hermes after PR creation; issue #1739 remains active until Loop A proves the guard is consumed.
- [x] Post-merge/deploy/runtime proof: not applicable to this PR deliverable; no official deployment or runtime bot change is needed to verify the offline script guard.
- [x] Named deliverable proof: host preflight constants/error type, meminfo/statvfs probes, swap blocker, failure report integration, portability hardening, and safe/block/no-swap/statvfs/missing-meminfo tests are present in commits `3a370e500053dc9a74ddb24370d01ce92f65f16f` and `c0cf1e42`.

## Runtime / deployment impact

- [x] No gameplay/runtime/deployment impact for official MMO bot bundle.
- [ ] Gameplay/runtime/deployment impact; Deployment Floor evidence or HELD blocker is recorded.

## Notes

- Review/merge gates: wait at least 15 minutes after PR creation, require green checks, substantive automated review with no blocking findings, resolved/outdated/non-blocking review threads, QA, and current Project fields before merge.
- Issue #1739 should not close from this PR alone; keep it active for Loop A evidence after merge.



## Review-fix triage

- Gemini `PRRT_kwDOSMSsO86HnnYz`: `FIX` — `collect_disk_preflight` now accepts unavailable statvfs and records `host statvfs unavailable`; covered by `test_host_resource_preflight_records_disk_error_when_statvfs_unavailable`.
- Gemini `PRRT_kwDOSMSsO86HnnY3`: `FIX` — default statvfs lookup now uses `getattr(os, "statvfs", None)`.
- Gemini `PRRT_kwDOSMSsO86HnnY4`: `FIX` — missing implicit default meminfo now emits an OK warning and skips swap checks, while explicit meminfo-path failures still block.
- Gemini `PRRT_kwDOSMSsO86HnnY5`: `FIX` — test patch for `os.statvfs` uses `create=True`.

Issue #1739 remains the separate acceptance owner for later Loop A/training-ledger evidence; this PR supplies the offline script guard only.
