### PR TITLE
rl: emit Tencent guard validation-plan handoff

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -96,6 +96,10 @@ E1S1_REPEAT_GUARD_NEXT_ACTION = (
 )
 PAID_FAILURE_RECURRENCE_GUARD_TYPE = "screeps-tencent-batch-rl-paid-failure-recurrence-guard"
 PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS = "skipped_paid_failure_recurrence_launch_guard"
+PAID_FAILURE_RECURRENCE_VALIDATION_PLAN_REQUIRED_FINAL_STATUS = "post_fix_validation_plan_required_no_compute"
+PAID_FAILURE_RECURRENCE_VALIDATION_PLAN_HANDOFF_TYPE = (
+    "screeps-tencent-batch-rl-post-fix-validation-plan-handoff"
+)
 PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD = 10
 PAID_FAILURE_RECURRENCE_GUARD_RECENT_SUMMARY_LIMIT = 100
 PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE = "simulator_place_spawn_room_busy"
@@ -1167,6 +1171,30 @@ class Controller:
     def launch_guard_path(self) -> Path:
         return self.artifact_dir / "launch_guard.json"
 
+    def validation_plan_handoff_path(self, signature: str) -> Path:
+        safe_signature = re.sub(r"[^A-Za-z0-9_.-]+", "_", signature).strip("._-") or "unknown"
+        return resolved_artifact_root(self.args) / "validation-plans" / f"{safe_signature}.json"
+
+    def write_validation_plan_handoff(self, guard: dict[str, Any]) -> dict[str, Any]:
+        handoff = build_paid_failure_validation_plan_handoff(guard, run_id=self.run_id)
+        signature = text_value(handoff.get("signature")) or "unknown"
+        path = self.validation_plan_handoff_path(signature)
+        handoff["path"] = str(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(canonical_json(handoff), encoding="utf-8")
+        summary = {
+            "path": str(path),
+            "status": handoff["status"],
+            "signature": handoff["signature"],
+            "requiresExplicitValidationSignature": handoff["requiresExplicitValidationSignature"],
+            "noCompute": True,
+            "paidRunAttempted": False,
+            "reason": handoff.get("reason"),
+            "nextAction": handoff.get("nextAction"),
+        }
+        self.result["validationPlanHandoff"] = summary
+        return summary
+
     def run(self) -> None:
         self.artifact_dir.mkdir(parents=True, exist_ok=True)
         validate_static_inputs(self.args, self.run_id)
@@ -1225,6 +1253,10 @@ class Controller:
         }
         if isinstance(guard.get("postFixValidation"), dict):
             self.result["launchGuard"]["postFixValidation"] = guard["postFixValidation"]
+        validation_plan_handoff = None
+        if paid_failure_guard_requires_explicit_validation_plan(guard):
+            validation_plan_handoff = self.write_validation_plan_handoff(guard)
+            self.result["launchGuard"]["validationPlanHandoff"] = validation_plan_handoff
         self.record_step(
             "e1s1_repeat_launch_guard",
             started,
@@ -1236,14 +1268,16 @@ class Controller:
             activeSignature=evidence.get("activeSignature"),
             evidenceCount=evidence["count"],
             evidenceThreshold=evidence["threshold"],
+            validationPlanRequired=validation_plan_handoff is not None,
         )
         if not guard["blocked"]:
             return False
-        self.final_status = (
-            PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS
-            if guard.get("activeGuard") == "paid_failure_recurrence_guard"
-            else E1S1_REPEAT_GUARD_FINAL_STATUS
-        )
+        if validation_plan_handoff is not None:
+            self.final_status = PAID_FAILURE_RECURRENCE_VALIDATION_PLAN_REQUIRED_FINAL_STATUS
+        elif guard.get("activeGuard") == "paid_failure_recurrence_guard":
+            self.final_status = PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS
+        else:
+            self.final_status = E1S1_REPEAT_GUARD_FINAL_STATUS
         self.finished_at = utc_now_iso()
         self.write_summary()
         return True
@@ -2307,11 +2341,16 @@ def controller_execution_summary(
         if partial_environments is not None:
             environments_run = partial_environments
     preflight_only = bool(getattr(args, "preflight_only", False))
+    validation_plan_required = isinstance(result.get("validationPlanHandoff"), dict)
+    mode = "preflight" if preflight_only else "validation_plan_required" if validation_plan_required else "compute"
     return {
         "command": getattr(args, "command", None),
-        "mode": "preflight" if preflight_only else "compute",
+        "mode": mode,
         "preflightOnly": preflight_only,
         "computeAttempted": compute_attempted,
+        "paidRunAttempted": compute_attempted,
+        "launchGuardNoCompute": validation_plan_required and not compute_attempted,
+        "validationPlanRequired": validation_plan_required,
         "scaleOutAttempted": scale_out_attempted,
         "remoteTrainingAttempted": remote_training_attempted,
         "trainingReportProduced": training_report_produced,
@@ -3221,6 +3260,82 @@ def paid_failure_recurrence_validation_requests(args: argparse.Namespace) -> set
         return set()
     values = raw if isinstance(raw, list) else [raw]
     return {value for value in (text_value(item) for item in values) if value is not None}
+
+
+def paid_failure_guard_requires_explicit_validation_plan(guard: dict[str, Any]) -> bool:
+    if guard.get("activeGuard") != "paid_failure_recurrence_guard":
+        return False
+    if text_value(guard.get("status")) != PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS:
+        return False
+    validation = dict_value(guard.get("postFixValidation"))
+    if validation is None or text_value(validation.get("status")) != "consumed":
+        return False
+    if validation.get("requested") is True:
+        return False
+    recovery = dict_value(validation.get("recoveryEligibility"))
+    if recovery is None:
+        return False
+    if recovery.get("requiresExplicitValidationSignature") is not True or recovery.get("requested") is True:
+        return False
+    reason = text_value(recovery.get("reason")) or ""
+    return "explicit post-fix validation signature" in reason
+
+
+def build_paid_failure_validation_plan_handoff(
+    guard: dict[str, Any],
+    *,
+    run_id: str,
+) -> dict[str, Any]:
+    evidence = dict_value(guard.get("evidence")) or {}
+    validation = dict_value(guard.get("postFixValidation")) or {}
+    recovery = dict_value(validation.get("recoveryEligibility")) or {}
+    checks = dict_value(guard.get("checks")) or {}
+    recurrence_guard = dict_value(checks.get("paidFailureRecurrence")) or {}
+    current_launch = dict_value(recurrence_guard.get("currentLaunch")) or dict_value(guard.get("currentLaunch")) or {}
+    known_fix = dict_value(validation.get("knownFix")) or {}
+    current_validation_plan = dict_value(current_launch.get("validationPlan")) or {}
+    signature = (
+        text_value(validation.get("signature"))
+        or text_value(evidence.get("activeSignature"))
+        or PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE
+    )
+    return {
+        "type": PAID_FAILURE_RECURRENCE_VALIDATION_PLAN_HANDOFF_TYPE,
+        "schemaVersion": 1,
+        "runId": run_id,
+        "createdAt": utc_now_iso(),
+        "status": "validation_plan_required",
+        "signature": signature,
+        "guardStatus": text_value(guard.get("status")),
+        "reason": text_value(recovery.get("reason")) or text_value(guard.get("reason")),
+        "nextAction": text_value(guard.get("nextAction")),
+        "requiresExplicitValidationSignature": True,
+        "requested": False,
+        "requestedSignatures": validation.get("requestedSignatures")
+        if isinstance(validation.get("requestedSignatures"), list)
+        else [],
+        "explicitValidationArgument": f"--allow-paid-failure-recurrence-validation {signature}",
+        "noCompute": True,
+        "paidRunAttempted": False,
+        "currentLaunch": copy.deepcopy(current_launch),
+        "currentValidationPlan": copy.deepcopy(current_validation_plan),
+        "knownFix": copy.deepcopy(known_fix),
+        "priorAttempt": copy.deepcopy(dict_value(validation.get("priorAttempt"))),
+        "recoveryEligibility": copy.deepcopy(recovery),
+        "evidence": {
+            "activeSignature": text_value(evidence.get("activeSignature")),
+            "evidenceCount": evidence.get("count"),
+            "evidenceThreshold": evidence.get("threshold"),
+        },
+        "safety": {
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+            "secretsPrinted": False,
+            "remoteExecutionAttempted": False,
+            "scaleOutAttempted": False,
+        },
+    }
 
 
 def paid_failure_current_validation_plan(args: argparse.Namespace) -> dict[str, Any]:
@@ -6491,7 +6606,11 @@ def main(argv: list[str] | None = None) -> int:
             {"ok": False, "runId": run_id, "artifactDir": str(artifact_dir), "status": controller.final_status},
         )
         return 3
-    if controller.final_status in {E1S1_REPEAT_GUARD_FINAL_STATUS, PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS}:
+    if controller.final_status in {
+        E1S1_REPEAT_GUARD_FINAL_STATUS,
+        PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS,
+        PAID_FAILURE_RECURRENCE_VALIDATION_PLAN_REQUIRED_FINAL_STATUS,
+    }:
         screeps_cli_io.write_json_line(
             sys.stderr,
             {

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -1158,6 +1158,61 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         summary = json.loads((artifact_dir / "controller-summary.json").read_text(encoding="utf-8"))
         return events, controller, guard, summary
 
+    def assert_validation_plan_handoff(
+        self,
+        controller: runner.Controller,
+        summary: dict[str, object],
+        plan: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        self.assertEqual(
+            controller.final_status,
+            runner.PAID_FAILURE_RECURRENCE_VALIDATION_PLAN_REQUIRED_FINAL_STATUS,
+        )
+        self.assertEqual(
+            summary["finalStatus"],
+            runner.PAID_FAILURE_RECURRENCE_VALIDATION_PLAN_REQUIRED_FINAL_STATUS,
+        )
+        execution = summary["execution"]
+        self.assertIsInstance(execution, dict)
+        self.assertEqual(execution["mode"], "validation_plan_required")
+        self.assertFalse(execution["computeAttempted"])
+        self.assertFalse(execution["paidRunAttempted"])
+        self.assertTrue(execution["launchGuardNoCompute"])
+        self.assertTrue(execution["validationPlanRequired"])
+        outputs = summary["outputs"]
+        self.assertIsInstance(outputs, dict)
+        handoff = outputs["validationPlanHandoff"]
+        self.assertIsInstance(handoff, dict)
+        self.assertEqual(handoff["status"], "validation_plan_required")
+        self.assertEqual(handoff["signature"], runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE)
+        self.assertTrue(handoff["requiresExplicitValidationSignature"])
+        self.assertFalse(handoff["paidRunAttempted"])
+        self.assertTrue(handoff["noCompute"])
+        self.assertIn("explicit post-fix validation signature", handoff["reason"])
+        self.assertTrue(handoff["nextAction"])
+        plan_path = Path(handoff["path"])
+        if plan is None:
+            self.assertTrue(plan_path.is_file())
+            plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        self.assertEqual(plan["type"], runner.PAID_FAILURE_RECURRENCE_VALIDATION_PLAN_HANDOFF_TYPE)
+        self.assertEqual(plan["status"], "validation_plan_required")
+        self.assertEqual(plan["signature"], runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE)
+        self.assertFalse(plan["paidRunAttempted"])
+        self.assertTrue(plan["noCompute"])
+        self.assertEqual(plan["path"], str(plan_path))
+        self.assertIn("explicit post-fix validation signature", plan["reason"])
+        self.assertEqual(
+            plan["explicitValidationArgument"],
+            (
+                "--allow-paid-failure-recurrence-validation "
+                f"{runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE}"
+            ),
+        )
+        launch_guard = outputs["launchGuard"]
+        self.assertIsInstance(launch_guard, dict)
+        self.assertEqual(launch_guard["validationPlanHandoff"]["path"], str(plan_path))
+        return plan
+
     def test_controller_summary_records_pid_and_declared_timeout_window(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             args = controller_args()
@@ -5008,9 +5063,11 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 },
             ):
                 events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+            handoff = summary["outputs"]["validationPlanHandoff"]
+            plan_payload = json.loads(Path(handoff["path"]).read_text(encoding="utf-8"))
 
         self.assertEqual(events, [])
-        self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+        plan = self.assert_validation_plan_handoff(controller, summary, plan_payload)
         self.assertTrue(guard["blocked"])
         self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
         recovery = guard["postFixValidation"]["recoveryEligibility"]
@@ -5022,6 +5079,9 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertIn("explicitly larger timeout", guard["nextAction"])
         self.assertIn("smaller validation slice", guard["nextAction"])
         self.assertFalse(summary["execution"]["computeAttempted"])
+        self.assertEqual(plan["recoveryEligibility"]["recoveryClass"], "remote_training_timeout_after_recovery")
+        self.assertEqual(plan["currentValidationPlan"]["workers"], 5)
+        self.assertEqual(plan["currentValidationPlan"]["repetitions"], 5)
 
     def test_paid_failure_recurrence_guard_ignores_preflight_only_recovery_admission(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -5269,15 +5329,20 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 },
             ):
                 events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+            handoff = summary["outputs"]["validationPlanHandoff"]
+            plan_payload = json.loads(Path(handoff["path"]).read_text(encoding="utf-8"))
 
         self.assertEqual(events, [])
-        self.assertEqual(controller.final_status, runner.PAID_FAILURE_RECURRENCE_GUARD_FINAL_STATUS)
+        plan = self.assert_validation_plan_handoff(controller, summary, plan_payload)
         self.assertTrue(guard["blocked"])
         self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
         self.assertEqual(guard["postFixValidation"]["status"], "consumed")
         self.assertFalse(guard["postFixValidation"]["recoveryEligibility"]["eligible"])
         self.assertIn("explicit post-fix validation signature", guard["postFixValidation"]["recoveryEligibility"]["reason"])
         self.assertFalse(summary["execution"]["computeAttempted"])
+        self.assertEqual(plan["priorAttempt"]["runId"], "tencent-postfix-room-busy-v1")
+        self.assertEqual(plan["currentValidationPlan"]["workers"], 5)
+        self.assertEqual(plan["currentValidationPlan"]["repetitions"], 5)
 
     def test_paid_failure_recurrence_guard_blocks_recovery_below_trust_sample_target(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
Fixes #1753.

## Summary

- Changes the paid-failure recurrence guard recovery path so consumed post-fix validation evidence that still requires an explicit validation signature does not keep producing guard-blocked paid-run attempts.
- Writes a machine-readable validation-plan handoff artifact under `runtime-artifacts/tencent-cloud/validation-plans/<signature>.json` and records it in the controller summary.
- Keeps the path shadow/safe: no paid compute, no scale-out, no remote execution, and no official MMO writes until the explicit validation signature is supplied.

## Issue closure gate

- [x] #1753: the Tencent RL runner now exits with `post_fix_validation_plan_required_no_compute`, records `validationPlanHandoff`, and proves `paidRunAttempted=false` for the `simulator_place_spawn_room_busy` guard path before any explicit validation signature is supplied.

## Universal task Done gate

- [x] Task type: P0 RL flywheel bug/code fix for a Tencent paid-run recurrence loop.
- [x] Expected observable outcome / named deliverable: the named deliverable is a validation-plan handoff artifact plus controller summary fields showing `mode=validation_plan_required`, `validationPlanRequired=true`, `launchGuardNoCompute=true`, and `paidRunAttempted=false`.
- [x] Non-goals / accepted substitutes: no paid Tencent compute, no remote batch launch, no official MMO write, no production bot bundle change, and no direct learned-policy rollout.
- [x] Verification evidence required before Done: controller verification passed `git diff --check`, `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`, and `python3 -m pytest scripts/test_screeps_tencent_batch_rl_runner.py -q` with 179 tests and 97 subtests passing.
- [x] Project Evidence / Next action / Blocked by: Project items for #1753 and this PR record the PR head, controller test evidence, Status `In review`, Next action `finish exact-head CI and bot review gates`, and Blocked by `CI and bot review gates`.
- [x] Post-merge/deploy/runtime proof: main contains commit `4a837fb7`; the next Tencent controller/ledger run can cite the validation-plan handoff artifact with `noCompute=true`; official MMO deploy is not applicable for this RL tooling change.
- [x] Named deliverable proof: tests assert the handoff file path, handoff type, explicit validation argument, current validation plan, recovery eligibility, and no-compute safety flags.
