### PR TITLE
chore(roadmap): refresh Pages artifacts

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -483,7 +483,7 @@ main {
           <p><strong>Project</strong> · Long-running Screeps: World AI and autonomous operations project.</p>
           <p><strong>Links</strong> · <a href="https://github.com/lanyusea/screeps">https://github.com/lanyusea/screeps</a></p>
         </div>
-        <p class="published"><strong>PUBLISHED</strong> · 2026-06-07T17:37:19+08:00</p>
+        <p class="published"><strong>PUBLISHED</strong> · 2026-06-07T22:20:30+08:00</p>
       </div>
       <div class="hero-art">
         <div class="brand-logo-frame"><img class="brand-logo" src="assets/screeps-community-logo.png" alt="Screeps community logo"></div>
@@ -537,10 +537,10 @@ main {
 
             <svg class="chart-svg" role="img" aria-label="Resources 7 day trend" viewBox="0 0 560 260">
               <text x="70.0" y="12" fill="#9a5d25" font-size="14" font-weight="900">energy</text>
-              <line x1="70.0" y1="190.0" x2="500.0" y2="190.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="195.0" text-anchor="end" fill="#8b6d55" font-size="15">0</text><line x1="70.0" y1="107.0" x2="500.0" y2="107.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="112.0" text-anchor="end" fill="#8b6d55" font-size="15">45000</text><line x1="70.0" y1="24.0" x2="500.0" y2="24.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="29.0" text-anchor="end" fill="#8b6d55" font-size="15">90000</text>
+              <line x1="70.0" y1="190.0" x2="500.0" y2="190.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="195.0" text-anchor="end" fill="#8b6d55" font-size="15">0</text><line x1="70.0" y1="107.0" x2="500.0" y2="107.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="112.0" text-anchor="end" fill="#8b6d55" font-size="15">100000</text><line x1="70.0" y1="24.0" x2="500.0" y2="24.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="29.0" text-anchor="end" fill="#8b6d55" font-size="15">200000</text>
               <line x1="70.0" y1="24.0" x2="70.0" y2="190.0" stroke="#cdbba7" stroke-width="1.5"/>
               <line x1="70.0" y1="190.0" x2="500.0" y2="190.0" stroke="#cdbba7" stroke-width="1.5"/>
-              <polyline fill="none" stroke="#25211c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" points="356.7,177.4 428.3,174.7 500.0,38.9"/><circle cx="356.7" cy="177.4" r="4" fill="#25211c"/><text x="356.7" y="166.4" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">6834</text><circle cx="428.3" cy="174.7" r="4" fill="#25211c"/><text x="428.3" y="163.7" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">8307</text><circle cx="500.0" cy="38.9" r="4" fill="#25211c"/><text x="500.0" y="27.9" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">81933</text><polyline fill="none" stroke="#c8945a" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6 6" points="356.7,187.4 428.3,188.2 500.0,187.0"/><circle cx="356.7" cy="187.4" r="4" fill="#c8945a"/><text x="356.7" y="176.4" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">1404</text><circle cx="428.3" cy="188.2" r="4" fill="#c8945a"/><text x="428.3" y="177.2" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">996</text><circle cx="500.0" cy="187.0" r="4" fill="#c8945a"/><text x="500.0" y="176.0" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">1611</text>
+              <polyline fill="none" stroke="#25211c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" points="356.7,184.3 428.3,183.1 500.0,101.4"/><circle cx="356.7" cy="184.3" r="4" fill="#25211c"/><text x="356.7" y="173.3" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">6834</text><circle cx="428.3" cy="183.1" r="4" fill="#25211c"/><text x="428.3" y="172.1" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">8307</text><circle cx="500.0" cy="101.4" r="4" fill="#25211c"/><text x="500.0" y="90.4" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">106743</text><polyline fill="none" stroke="#c8945a" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="6 6" points="356.7,188.8 428.3,189.2 500.0,189.3"/><circle cx="356.7" cy="188.8" r="4" fill="#c8945a"/><text x="356.7" y="177.8" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">1404</text><circle cx="428.3" cy="189.2" r="4" fill="#c8945a"/><text x="428.3" y="178.2" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">996</text><circle cx="500.0" cy="189.3" r="4" fill="#c8945a"/><text x="500.0" y="178.3" text-anchor="middle" fill="#241d17" font-size="14" font-weight="800">887</text>
 
               <text x="70.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/1</text>
 <text x="141.7" y="226" text-anchor="middle" fill="#7b6654" font-size="15">6/2</text>
@@ -635,17 +635,17 @@ main {
           </a>
 
 
-          <a class="roadmap-card" href="https://github.com/lanyusea/screeps/issues/63">
+          <a class="roadmap-card" href="https://github.com/lanyusea/screeps/issues/1763">
             <h3>Release/deploy</h3>
             <div class="roadmap-table">
               <span class="roadmap-label">Goal</span><span>Validate, deploy, and observe accepted changes across private smoke and official MMO gates.</span>
-              <span class="roadmap-label">Next</span><span>No active item; latest tracked: #63 Done - Record expected KPI movement and proof for gamepla...</span>
+              <span class="roadmap-label">Next</span><span>Current: #1763 Ready - 2026-06-07T14:12Z: #1763 remains Ready; #1762 merged, so construction-...</span>
             </div>
             <div class="progress-row">
-              <span class="progress-value">100%</span>
-              <span class="progress-track"><span class="progress-fill" style="width: 100%"></span></span>
+              <span class="progress-value">95%</span>
+              <span class="progress-track"><span class="progress-fill" style="width: 95%"></span></span>
             </div>
-            <div class="roadmap-status">20 Project items · 0 active · 20 done</div>
+            <div class="roadmap-status">21 Project items · 1 active · 20 done</div>
           </a>
 
 
@@ -687,7 +687,7 @@ main {
               <span class="progress-value">99%</span>
               <span class="progress-track"><span class="progress-fill" style="width: 99%"></span></span>
             </div>
-            <div class="roadmap-status">307 Project items · 3 active · 304 done</div>
+            <div class="roadmap-status">308 Project items · 2 active · 306 done</div>
           </a>
 
 
@@ -709,13 +709,13 @@ main {
             <h3>RL flywheel</h3>
             <div class="roadmap-table">
               <span class="roadmap-label">Goal</span><span>Drive offline/simulator/data/training/validation work for safe strategy self-evolution.</span>
-              <span class="roadmap-label">Next</span><span>Current: #1032 In progress - 2026-06-07T09:03Z scale campaign still local-only: pids 886153/8...</span>
+              <span class="roadmap-label">Next</span><span>Current: #1032 In progress - 2026-06-07T13:09Z E1 stale blocker cleared: gate e1-gate-2026060...</span>
             </div>
             <div class="progress-row">
               <span class="progress-value">98%</span>
               <span class="progress-track"><span class="progress-fill" style="width: 98%"></span></span>
             </div>
-            <div class="roadmap-status">421 Project items · 8 active · 413 done</div>
+            <div class="roadmap-status">423 Project items · 8 active · 415 done</div>
           </a>
 
         </div>
@@ -789,9 +789,15 @@ main {
           <article class="kanban-column">
             <div class="column-heading">
               <h3>Release/deploy</h3>
-              <span class="column-count">0</span>
+              <span class="column-count">1</span>
             </div>
-            <div class="kanban-empty">No Live cards</div>
+
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/1763">
+              <span class="kanban-priority">P1</span>
+              <h4>#1763 P1: Add post-construction-fix deploy acceptance checklist</h4>
+              <p>Ready · Release/deploy · 2026-06-07T14:12Z: #1763 remains Ready; #1762 merged, so construction-fix acceptance...</p>
+            </a>
+
           </article>
 
 
@@ -816,7 +822,7 @@ main {
           <article class="kanban-column">
             <div class="column-heading">
               <h3>Territory/Economy</h3>
-              <span class="column-count">3</span>
+              <span class="column-count">2</span>
             </div>
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/1490">
@@ -830,13 +836,6 @@ main {
               <span class="kanban-priority">P1</span>
               <h4>#1664 P1: E29N56 energy buffer recovery follow-up after CPU fix</h4>
               <p>In progress · Territory/Economy · 2026-06-07T07:34Z E29N56 tick 1890989: spawns=1, workers=3 assigned/product...</p>
-            </a>
-
-
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/1758">
-              <span class="kanban-priority">P1</span>
-              <h4>#1758 P1: E29N57 worker_assignment_gap recurs with construction backlog</h4>
-              <p>In progress · Territory/Economy · 2026-06-07T08:30:02Z P1: E29N57 worker_assignment_gap recurs with construct...</p>
             </a>
 
           </article>
@@ -860,28 +859,28 @@ main {
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/1032">
               <span class="kanban-priority">P0</span>
               <h4>#1032 P0: Scale-first offline/private RL training campaign</h4>
-              <p>In progress · RL flywheel · 2026-06-07T09:03Z scale campaign still local-only: pids 886153/886164 live; lates...</p>
+              <p>In progress · RL flywheel · 2026-06-07T13:09Z E1 stale blocker cleared: gate e1-gate-20260607T1257Z ok; Loop...</p>
             </a>
 
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/1233">
               <span class="kanban-priority">P0</span>
               <h4>#1233 P0: Restore RL steward autonomous compute dispatch cadence</h4>
-              <p>In progress · RL flywheel · 2026-06-07T09:03Z no Tencent compute process; local fallback pids 886153/886164 a...</p>
+              <p>In progress · RL flywheel · 2026-06-07T13:09Z E1 stale blocker cleared: gate e1-gate-20260607T1257Z ok; Loop...</p>
             </a>
 
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/1543">
               <span class="kanban-priority">P0</span>
               <h4>#1543 P0: Recover clobbered RL conclusion registry and stale-conclusi...</h4>
-              <p>In progress · RL flywheel · 2026-06-07T07:34Z conclusion registry nested summary repaired: total=21, OPEN=0,...</p>
+              <p>In progress · RL flywheel · 2026-06-07T13:36Z registry now 23 total: ACTIONED=6/CLOSED=14/VALIDATING=3. Added...</p>
             </a>
 
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/1583">
               <span class="kanban-priority">P0</span>
               <h4>#1583 P0: Land first bounded RL live canary from fresh-gate candidate</h4>
-              <p>In progress · RL flywheel · 2026-06-07T02:25Z stale #1714 blocker cleared (closed Done). Fresh local-fallback...</p>
+              <p>In progress · RL flywheel · Policy-advantage #178 20260607T120949Z: deployabilityStatus=BLOCKED. Tencent batc...</p>
             </a>
 
           </article>
@@ -904,23 +903,23 @@ main {
         <div class="process-grid">
 
           <article class="process-card">
-            <p class="process-value">1037</p>
+            <p class="process-value">1040</p>
             <p class="process-label">Commits</p>
             <p class="process-detail">git rev-list --count HEAD</p>
           </article>
 
 
           <article class="process-card">
-            <p class="process-value">843</p>
+            <p class="process-value">845</p>
             <p class="process-label">Issues</p>
             <p class="process-detail">22 open</p>
           </article>
 
 
           <article class="process-card">
-            <p class="process-value">915</p>
+            <p class="process-value">918</p>
             <p class="process-label">PRs</p>
-            <p class="process-detail">898 merged</p>
+            <p class="process-detail">901 merged</p>
           </article>
 
 
@@ -976,7 +975,7 @@ main {
       </section>
 
     </main>
-    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-06-07T09:37:19Z</footer>
+    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-06-07T14:20:30Z</footer>
   </div>
 </body>
 </html>

--- a/docs/roadmap-data.json
+++ b/docs/roadmap-data.json
@@ -3,55 +3,54 @@
     "logo": "assets/screeps-community-logo.png"
   },
   "format": "roadmap-portrait-kpi-kanban-v5",
-  "generatedAt": "2026-06-07T09:37:19Z",
-  "generatedAtCst": "2026-06-07T17:37:19+08:00",
+  "generatedAt": "2026-06-07T14:20:30Z",
+  "generatedAtCst": "2026-06-07T22:20:30+08:00",
   "github": {
     "fetchErrors": [],
     "fetched": true,
     "issues": [
       {
-        "createdAt": "2026-06-07T08:30:02Z",
-        "domain": "Territory/Economy",
-        "domainSource": "heuristic",
-        "kind": "bug",
-        "labels": [
-          "kind:bug",
-          "priority:p1",
-          "roadmap",
-          "roadmap:territory-economy",
-          "runtime-alert"
-        ],
-        "milestone": "P1: Territory/Economy gameplay gate",
-        "number": 1758,
-        "priority": "P1",
-        "state": "OPEN",
-        "status": "Ready",
-        "title": "P1: E29N57 worker_assignment_gap recurs with construction backlog",
-        "type": "Issue",
-        "updatedAt": "2026-06-07T08:30:02Z",
-        "url": "https://github.com/lanyusea/screeps/issues/1758"
-      },
-      {
-        "createdAt": "2026-06-07T07:54:03Z",
-        "domain": "RL flywheel",
+        "createdAt": "2026-06-07T14:01:29Z",
+        "domain": "Release/deploy",
         "domainSource": "heuristic",
         "kind": "ops",
         "labels": [
-          "blocked",
           "kind:ops",
           "priority:p1",
+          "roadmap",
+          "roadmap:phase-c-telemetry"
+        ],
+        "milestone": "Phase C: Runtime telemetry / monitor gate",
+        "number": 1763,
+        "priority": "P1",
+        "state": "OPEN",
+        "status": "Ready",
+        "title": "P1: Add post-construction-fix deploy acceptance checklist",
+        "type": "Issue",
+        "updatedAt": "2026-06-07T14:01:29Z",
+        "url": "https://github.com/lanyusea/screeps/issues/1763"
+      },
+      {
+        "createdAt": "2026-06-07T13:37:22Z",
+        "domain": "RL flywheel",
+        "domainSource": "heuristic",
+        "kind": "bug",
+        "labels": [
+          "domain:rl-flywheel",
+          "kind:bug",
+          "priority:p0",
           "roadmap",
           "roadmap:rl-flywheel"
         ],
         "milestone": "P1: RL strategy flywheel gate",
-        "number": 1757,
-        "priority": "P1",
+        "number": 1761,
+        "priority": "P0",
         "state": "OPEN",
-        "status": "Backlog",
-        "title": "P1: Refresh full E1 gate after stale-threshold breach",
+        "status": "Ready",
+        "title": "P0: Repair recurring Loop B policy-advantage Broken pipe after #1756",
         "type": "Issue",
-        "updatedAt": "2026-06-07T08:02:22Z",
-        "url": "https://github.com/lanyusea/screeps/issues/1757"
+        "updatedAt": "2026-06-07T14:13:38Z",
+        "url": "https://github.com/lanyusea/screeps/issues/1761"
       },
       {
         "createdAt": "2026-06-07T02:38:16Z",
@@ -115,7 +114,7 @@
         "status": "Ready",
         "title": "P2: Diagnose RL training runner swap exhaustion",
         "type": "Issue",
-        "updatedAt": "2026-06-07T06:34:04Z",
+        "updatedAt": "2026-06-07T12:27:01Z",
         "url": "https://github.com/lanyusea/screeps/issues/1739"
       },
       {
@@ -5430,6 +5429,24 @@
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/pull/1581",
           "visionLayer": "resources"
+        },
+        {
+          "domain": "Release/deploy",
+          "domainSource": "project",
+          "evidence": "2026-06-07T14:12Z: #1763 remains Ready; #1762 merged, so construction-fix acceptance checklist work is unblocked except for scheduler priority/active #1761 acceptance.",
+          "kind": "ops",
+          "lane": "Release/deploy",
+          "nextAction": "",
+          "number": 1763,
+          "priority": "P1",
+          "projectDomain": "Release/deploy",
+          "state": "",
+          "status": "Ready",
+          "title": "P1: Add post-construction-fix deploy acceptance checklist",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/1763",
+          "visionLayer": "foundation blocker"
         },
         {
           "domain": "Release/deploy",
@@ -13354,24 +13371,6 @@
         {
           "domain": "Territory/Economy",
           "domainSource": "project",
-          "evidence": "",
-          "kind": "bug",
-          "lane": "Territory/Economy",
-          "nextAction": "",
-          "number": 1758,
-          "priority": "P1",
-          "projectDomain": "Territory/Economy",
-          "state": "",
-          "status": "In progress",
-          "title": "P1: E29N57 worker_assignment_gap recurs with construction backlog",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/1758",
-          "visionLayer": "territory"
-        },
-        {
-          "domain": "Territory/Economy",
-          "domainSource": "project",
           "evidence": "Done: PR #1633 merged at 2026-06-03T03:36:30Z as main commit faa6f035; issue #1632 closed completed at 2026-06-03T03:53:44Z. Official deploy run 26862156412 success for faa6f035; deploy JSON ok=true/mode=deploy, branch and activeWorld code matched, health gate ok=true/reasons=[]; artifacts archived under runtime-artifacts/official-screeps-deploy/. Gemini thread resolved RESOLVE_FALSE_POSITIVE; CodeRabbit/checks green.",
           "kind": "code",
           "lane": "Territory/Economy",
@@ -17003,6 +17002,24 @@
           "type": "Issue",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/issues/1553",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "project",
+          "evidence": "Done 2026-06-07T11:44Z: #1760 merged as 81fba41e, official deploy 27091495323 success, postdeploy tick 1898554 E29N57 sites=0/pending=0/owned_spawns=1/owned_creeps=6; issue closed completed.",
+          "kind": "bug",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 1758,
+          "priority": "P1",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "Done",
+          "title": "P1: E29N57 worker_assignment_gap recurs with construction backlog",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/1758",
           "visionLayer": "territory"
         },
         {
@@ -21760,6 +21777,24 @@
         {
           "domain": "Territory/Economy",
           "domainSource": "project",
+          "evidence": "Merged 2026-06-07T11:39Z as 81fba41e; deploy run 27091495323 success; postdeploy runtime tick 1898554 confirms #1758 acceptance.",
+          "kind": "code",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 1760,
+          "priority": "P1",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "Done",
+          "title": "fix: cover E29N57 build assignment gap",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1760",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "project",
           "evidence": "2026-06-02T01:28Z PR #1604 merged via squash at merge commit be77718b after exact-head gate: elapsed 1669s, checks SUCCESS, threads=0, mergeState CLEAN, Project fields verified. Official deploy run 26792684399 queued for be77718b.",
           "kind": "code",
           "lane": "Territory/Economy",
@@ -22336,7 +22371,7 @@
         {
           "domain": "RL flywheel",
           "domainSource": "project",
-          "evidence": "2026-06-07T02:25Z stale #1714 blocker cleared (closed Done). Fresh local-fallback card exists on main 7d410885, but bounded live canary remains pre-rollout: no online rollout gate/KPI window and CPU bucket degraded.",
+          "evidence": "Policy-advantage #178 20260607T120949Z: deployabilityStatus=BLOCKED. Tencent batch blocked 9+ days. E1 full gate stale 44h. Local training completed 19/20 reps (no candidate differentiation). E29N55 storedEnergy dropped 2795\u21921235. No deployable candidate exists. onlineUtility=UNPROVEN. Runner dead mid-r20. Host disk 99% (3G free).",
           "kind": "ops",
           "lane": "RL flywheel",
           "nextAction": "",
@@ -22354,7 +22389,7 @@
         {
           "domain": "RL flywheel",
           "domainSource": "project",
-          "evidence": "2026-06-07T07:34Z conclusion registry nested summary repaired: total=21, OPEN=0, ACTIONED=5, VALIDATING=3, CLOSED=13; no stale/escalated P0/P1.",
+          "evidence": "2026-06-07T13:36Z registry now 23 total: ACTIONED=6/CLOSED=14/VALIDATING=3. Added ACTIONED L20260607T132113Z-LOOP_B-BROKEN_PIPE_RECURRENCE linked to #1761 after Loop B output 2026-06-07_21-21-13.md failed with Broken pipe.",
           "kind": "ops",
           "lane": "RL flywheel",
           "nextAction": "",
@@ -22372,7 +22407,25 @@
         {
           "domain": "RL flywheel",
           "domainSource": "project",
-          "evidence": "2026-06-07T09:03Z no Tencent compute process; local fallback pids 886153/886164 authoritative; training ledger reports tencent finalStatus=post_fix_validation_plan_required_no_compute.",
+          "evidence": "",
+          "kind": "bug",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 1761,
+          "priority": "P0",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "In progress",
+          "title": "P0: Repair recurring Loop B policy-advantage Broken pipe after #1756",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/1761",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "project",
+          "evidence": "2026-06-07T13:09Z E1 stale blocker cleared: gate e1-gate-20260607T1257Z ok; Loop A 20260607T130053Z no E1_GATE_STALE; Loop B 20260607T130920Z post-gate report. Cadence still blocked by compute/Tencent anomalies.",
           "kind": "ops",
           "lane": "RL flywheel",
           "nextAction": "",
@@ -22390,7 +22443,7 @@
         {
           "domain": "RL flywheel",
           "domainSource": "project",
-          "evidence": "2026-06-07T09:03Z scale campaign still local-only: pids 886153/886164 live; latest training ledger 20260607T085201Z trainingDidRun=true but no completed report in 24h; Tencent preflight no-compute/guarded.",
+          "evidence": "2026-06-07T13:09Z E1 stale blocker cleared: gate e1-gate-20260607T1257Z ok; Loop A 20260607T130053Z no E1_GATE_STALE; Loop B 20260607T130920Z post-gate report. Training still NOT_RUN with compute/Tencent blockers.",
           "kind": "ops",
           "lane": "RL flywheel",
           "nextAction": "",
@@ -22444,7 +22497,7 @@
         {
           "domain": "RL flywheel",
           "domainSource": "project",
-          "evidence": "2026-06-07T09:03Z pids 886153/886164 live 6h05m, RSS 1.1GiB; / 98% used with 3.5GiB free; swap 1.9GiB used with 64Ki free. No Codex training duplicate launched.",
+          "evidence": "",
           "kind": "ops",
           "lane": "RL flywheel",
           "nextAction": "",
@@ -22476,24 +22529,6 @@
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/issues/1700",
           "visionLayer": "territory"
-        },
-        {
-          "domain": "RL flywheel",
-          "domainSource": "project",
-          "evidence": "2026-06-07T09:03Z E1 refresh remains queued while local fallback is live; latest ledger 20260607T085201Z has trainingDidRun=true but no final report; host swap free 64Ki, disk 98%.",
-          "kind": "ops",
-          "lane": "RL flywheel",
-          "nextAction": "",
-          "number": 1757,
-          "priority": "P1",
-          "projectDomain": "RL flywheel",
-          "state": "",
-          "status": "Ready",
-          "title": "P1: Refresh full E1 gate after stale-threshold breach",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/1757",
-          "visionLayer": "foundation blocker"
         },
         {
           "domain": "RL flywheel",
@@ -24257,6 +24292,24 @@
           "type": "PullRequest",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/pull/1591",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "project",
+          "evidence": "2026-06-07T14:12Z: merged as d3d323af. Gate evidence: head 3a334930, issue/prod-ci/Pages checks PASS, CodeRabbit approved/no actionable comments with Codex triage artifact, Gemini no feedback, unresolved threads=0, mergeState CLEAN, elapsed>=15m.",
+          "kind": "docs",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 1762,
+          "priority": "P0",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "Done",
+          "title": "docs: record Loop B broken pipe recurrence diagnostic",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1762",
           "visionLayer": "foundation blocker"
         },
         {
@@ -27934,6 +27987,24 @@
         {
           "domain": "RL flywheel",
           "domainSource": "project",
+          "evidence": "2026-06-07T13:09Z Done: full gate e1-gate-20260607T1257Z ok (200/200 accepted, shadow pass); Loop A 20260607T130053Z no E1_GATE_STALE; Loop B 20260607T130920Z emitted post-gate report.",
+          "kind": "ops",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 1757,
+          "priority": "P1",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "Done",
+          "title": "P1: Refresh full E1 gate after stale-threshold breach",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/1757",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "project",
           "evidence": "2026-06-05T19:18Z CLOSED: e1-gate-20260605T191602Z ok=true, sampleCount=200, accepted=200, qualityAcceptanceRate=1.0, shadowStatus=pass; dataset rl-e93cefe304b9; liveEffect=false.",
           "kind": "ops",
           "lane": "RL flywheel",
@@ -31367,6 +31438,24 @@
           "type": "PullRequest",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/pull/1754",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "Docs/process",
+          "domainSource": "project",
+          "evidence": "Done 2026-06-07T11:48Z: PR #1759 merged as 85440ecd after body gate patch, update-branch head 269fccbd, gh pr checks PASS, CodeRabbit success, threads=0, mergeState=CLEAN.",
+          "kind": "docs",
+          "lane": "Docs/process",
+          "nextAction": "",
+          "number": 1759,
+          "priority": "P2",
+          "projectDomain": "Docs/process",
+          "state": "",
+          "status": "Done",
+          "title": "chore(roadmap): refresh Pages artifacts",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/1759",
           "visionLayer": "foundation blocker"
         },
         {
@@ -35171,7 +35260,26 @@
               "status": "Backlog"
             },
             {
-              "cards": [],
+              "cards": [
+                {
+                  "domain": "Release/deploy",
+                  "domainSource": "project",
+                  "evidence": "2026-06-07T14:12Z: #1763 remains Ready; #1762 merged, so construction-fix acceptance checklist work is unblocked except for scheduler priority/active #1761 acceptance.",
+                  "kind": "ops",
+                  "lane": "Release/deploy",
+                  "nextAction": "",
+                  "number": 1763,
+                  "priority": "P1",
+                  "projectDomain": "Release/deploy",
+                  "state": "",
+                  "status": "Ready",
+                  "title": "P1: Add post-construction-fix deploy acceptance checklist",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/1763",
+                  "visionLayer": "foundation blocker"
+                }
+              ],
               "status": "Ready"
             },
             {
@@ -41916,24 +42024,6 @@
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/issues/1664",
                   "visionLayer": "territory"
-                },
-                {
-                  "domain": "Territory/Economy",
-                  "domainSource": "project",
-                  "evidence": "",
-                  "kind": "bug",
-                  "lane": "Territory/Economy",
-                  "nextAction": "",
-                  "number": 1758,
-                  "priority": "P1",
-                  "projectDomain": "Territory/Economy",
-                  "state": "",
-                  "status": "In progress",
-                  "title": "P1: E29N57 worker_assignment_gap recurs with construction backlog",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/1758",
-                  "visionLayer": "territory"
                 }
               ],
               "status": "In progress"
@@ -44683,6 +44773,24 @@
                 {
                   "domain": "Territory/Economy",
                   "domainSource": "project",
+                  "evidence": "Done 2026-06-07T11:44Z: #1760 merged as 81fba41e, official deploy 27091495323 success, postdeploy tick 1898554 E29N57 sites=0/pending=0/owned_spawns=1/owned_creeps=6; issue closed completed.",
+                  "kind": "bug",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 1758,
+                  "priority": "P1",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P1: E29N57 worker_assignment_gap recurs with construction backlog",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/1758",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
                   "evidence": "DONE audit repair 2026-06-05T18:53Z: PR #1688 for #1669 merged 2026-06-05T06:56Z and is included in official deploy run 27033591689/main 04f604d. Current main 343b132b docs-only ahead; code issue implemented+deployed.",
                   "kind": "code",
                   "lane": "Territory/Economy",
@@ -47059,6 +47167,24 @@
                 {
                   "domain": "Territory/Economy",
                   "domainSource": "project",
+                  "evidence": "Merged 2026-06-07T11:39Z as 81fba41e; deploy run 27091495323 success; postdeploy runtime tick 1898554 confirms #1758 acceptance.",
+                  "kind": "code",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 1760,
+                  "priority": "P1",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "Done",
+                  "title": "fix: cover E29N57 build assignment gap",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1760",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
                   "evidence": "2026-06-02T01:28Z PR #1604 merged via squash at merge commit be77718b after exact-head gate: elapsed 1669s, checks SUCCESS, threads=0, mergeState CLEAN, Project fields verified. Official deploy run 26792684399 queued for be77718b.",
                   "kind": "code",
                   "lane": "Territory/Economy",
@@ -47602,26 +47728,7 @@
               "status": "Backlog"
             },
             {
-              "cards": [
-                {
-                  "domain": "RL flywheel",
-                  "domainSource": "project",
-                  "evidence": "2026-06-07T09:03Z E1 refresh remains queued while local fallback is live; latest ledger 20260607T085201Z has trainingDidRun=true but no final report; host swap free 64Ki, disk 98%.",
-                  "kind": "ops",
-                  "lane": "RL flywheel",
-                  "nextAction": "",
-                  "number": 1757,
-                  "priority": "P1",
-                  "projectDomain": "RL flywheel",
-                  "state": "",
-                  "status": "Ready",
-                  "title": "P1: Refresh full E1 gate after stale-threshold breach",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/1757",
-                  "visionLayer": "foundation blocker"
-                }
-              ],
+              "cards": [],
               "status": "Ready"
             },
             {
@@ -47629,7 +47736,7 @@
                 {
                   "domain": "RL flywheel",
                   "domainSource": "project",
-                  "evidence": "2026-06-07T02:25Z stale #1714 blocker cleared (closed Done). Fresh local-fallback card exists on main 7d410885, but bounded live canary remains pre-rollout: no online rollout gate/KPI window and CPU bucket degraded.",
+                  "evidence": "Policy-advantage #178 20260607T120949Z: deployabilityStatus=BLOCKED. Tencent batch blocked 9+ days. E1 full gate stale 44h. Local training completed 19/20 reps (no candidate differentiation). E29N55 storedEnergy dropped 2795\u21921235. No deployable candidate exists. onlineUtility=UNPROVEN. Runner dead mid-r20. Host disk 99% (3G free).",
                   "kind": "ops",
                   "lane": "RL flywheel",
                   "nextAction": "",
@@ -47647,7 +47754,7 @@
                 {
                   "domain": "RL flywheel",
                   "domainSource": "project",
-                  "evidence": "2026-06-07T07:34Z conclusion registry nested summary repaired: total=21, OPEN=0, ACTIONED=5, VALIDATING=3, CLOSED=13; no stale/escalated P0/P1.",
+                  "evidence": "2026-06-07T13:36Z registry now 23 total: ACTIONED=6/CLOSED=14/VALIDATING=3. Added ACTIONED L20260607T132113Z-LOOP_B-BROKEN_PIPE_RECURRENCE linked to #1761 after Loop B output 2026-06-07_21-21-13.md failed with Broken pipe.",
                   "kind": "ops",
                   "lane": "RL flywheel",
                   "nextAction": "",
@@ -47665,7 +47772,25 @@
                 {
                   "domain": "RL flywheel",
                   "domainSource": "project",
-                  "evidence": "2026-06-07T09:03Z no Tencent compute process; local fallback pids 886153/886164 authoritative; training ledger reports tencent finalStatus=post_fix_validation_plan_required_no_compute.",
+                  "evidence": "",
+                  "kind": "bug",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 1761,
+                  "priority": "P0",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "In progress",
+                  "title": "P0: Repair recurring Loop B policy-advantage Broken pipe after #1756",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/1761",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
+                  "evidence": "2026-06-07T13:09Z E1 stale blocker cleared: gate e1-gate-20260607T1257Z ok; Loop A 20260607T130053Z no E1_GATE_STALE; Loop B 20260607T130920Z post-gate report. Cadence still blocked by compute/Tencent anomalies.",
                   "kind": "ops",
                   "lane": "RL flywheel",
                   "nextAction": "",
@@ -47683,7 +47808,7 @@
                 {
                   "domain": "RL flywheel",
                   "domainSource": "project",
-                  "evidence": "2026-06-07T09:03Z scale campaign still local-only: pids 886153/886164 live; latest training ledger 20260607T085201Z trainingDidRun=true but no completed report in 24h; Tencent preflight no-compute/guarded.",
+                  "evidence": "2026-06-07T13:09Z E1 stale blocker cleared: gate e1-gate-20260607T1257Z ok; Loop A 20260607T130053Z no E1_GATE_STALE; Loop B 20260607T130920Z post-gate report. Training still NOT_RUN with compute/Tencent blockers.",
                   "kind": "ops",
                   "lane": "RL flywheel",
                   "nextAction": "",
@@ -47701,7 +47826,7 @@
                 {
                   "domain": "RL flywheel",
                   "domainSource": "project",
-                  "evidence": "2026-06-07T09:03Z pids 886153/886164 live 6h05m, RSS 1.1GiB; / 98% used with 3.5GiB free; swap 1.9GiB used with 64Ki free. No Codex training duplicate launched.",
+                  "evidence": "",
                   "kind": "ops",
                   "lane": "RL flywheel",
                   "nextAction": "",
@@ -49379,6 +49504,24 @@
                   "type": "PullRequest",
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/pull/1591",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
+                  "evidence": "2026-06-07T14:12Z: merged as d3d323af. Gate evidence: head 3a334930, issue/prod-ci/Pages checks PASS, CodeRabbit approved/no actionable comments with Codex triage artifact, Gemini no feedback, unresolved threads=0, mergeState CLEAN, elapsed>=15m.",
+                  "kind": "docs",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 1762,
+                  "priority": "P0",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "Done",
+                  "title": "docs: record Loop B broken pipe recurrence diagnostic",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1762",
                   "visionLayer": "foundation blocker"
                 },
                 {
@@ -52984,6 +53127,24 @@
                 {
                   "domain": "RL flywheel",
                   "domainSource": "project",
+                  "evidence": "2026-06-07T13:09Z Done: full gate e1-gate-20260607T1257Z ok (200/200 accepted, shadow pass); Loop A 20260607T130053Z no E1_GATE_STALE; Loop B 20260607T130920Z emitted post-gate report.",
+                  "kind": "ops",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 1757,
+                  "priority": "P1",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P1: Refresh full E1 gate after stale-threshold breach",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/1757",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
                   "evidence": "2026-06-05T19:18Z CLOSED: e1-gate-20260605T191602Z ok=true, sampleCount=200, accepted=200, qualityAcceptanceRate=1.0, shadowStatus=pass; dataset rl-e93cefe304b9; liveEffect=false.",
                   "kind": "ops",
                   "lane": "RL flywheel",
@@ -55765,6 +55926,24 @@
                 {
                   "domain": "Docs/process",
                   "domainSource": "project",
+                  "evidence": "Done 2026-06-07T11:48Z: PR #1759 merged as 85440ecd after body gate patch, update-branch head 269fccbd, gh pr checks PASS, CodeRabbit success, threads=0, mergeState=CLEAN.",
+                  "kind": "docs",
+                  "lane": "Docs/process",
+                  "nextAction": "",
+                  "number": 1759,
+                  "priority": "P2",
+                  "projectDomain": "Docs/process",
+                  "state": "",
+                  "status": "Done",
+                  "title": "chore(roadmap): refresh Pages artifacts",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/1759",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "Docs/process",
+                  "domainSource": "project",
                   "evidence": "",
                   "kind": "code",
                   "lane": "Docs/process",
@@ -55801,12 +55980,12 @@
       {
         "instrumented": true,
         "label": "Blocked cards",
-        "value": 52
+        "value": 50
       },
       {
         "instrumented": true,
         "label": "Project cards",
-        "value": 1716
+        "value": 1721
       },
       {
         "instrumented": true,
@@ -77019,7 +77198,7 @@
         "blockedBy": "",
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "2026-06-07T09:03Z scale campaign still local-only: pids 886153/886164 live; latest training ledger 20260607T085201Z trainingDidRun=true but no completed report in 24h; Tencent preflight no-compute/guarded.",
+        "evidence": "2026-06-07T13:09Z E1 stale blocker cleared: gate e1-gate-20260607T1257Z ok; Loop A 20260607T130053Z no E1_GATE_STALE; Loop B 20260607T130920Z post-gate report. Training still NOT_RUN with compute/Tencent blockers.",
         "kind": "ops",
         "labels": [
           "blocked",
@@ -81407,7 +81586,7 @@
         "blockedBy": "",
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "2026-06-07T09:03Z no Tencent compute process; local fallback pids 886153/886164 authoritative; training ledger reports tencent finalStatus=post_fix_validation_plan_required_no_compute.",
+        "evidence": "2026-06-07T13:09Z E1 stale blocker cleared: gate e1-gate-20260607T1257Z ok; Loop A 20260607T130053Z no E1_GATE_STALE; Loop B 20260607T130920Z post-gate report. Cadence still blocked by compute/Tencent anomalies.",
         "kind": "ops",
         "labels": [
           "blocked",
@@ -88054,7 +88233,7 @@
         "blockedBy": "",
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "2026-06-07T07:34Z conclusion registry nested summary repaired: total=21, OPEN=0, ACTIONED=5, VALIDATING=3, CLOSED=13; no stale/escalated P0/P1.",
+        "evidence": "2026-06-07T13:36Z registry now 23 total: ACTIONED=6/CLOSED=14/VALIDATING=3. Added ACTIONED L20260607T132113Z-LOOP_B-BROKEN_PIPE_RECURRENCE linked to #1761 after Loop B output 2026-06-07_21-21-13.md failed with Broken pipe.",
         "kind": "ops",
         "labels": [
           "kind:ops",
@@ -88911,7 +89090,7 @@
         "blockedBy": "",
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "2026-06-07T02:25Z stale #1714 blocker cleared (closed Done). Fresh local-fallback card exists on main 7d410885, but bounded live canary remains pre-rollout: no online rollout gate/KPI window and CPU bucket degraded.",
+        "evidence": "Policy-advantage #178 20260607T120949Z: deployabilityStatus=BLOCKED. Tencent batch blocked 9+ days. E1 full gate stale 44h. Local training completed 19/20 reps (no candidate differentiation). E29N55 storedEnergy dropped 2795\u21921235. No deployable candidate exists. onlineUtility=UNPROVEN. Runner dead mid-r20. Host disk 99% (3G free).",
         "kind": "ops",
         "labels": [
           "blocked",
@@ -92291,7 +92470,7 @@
         "blockedBy": "",
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "2026-06-07T09:03Z pids 886153/886164 live 6h05m, RSS 1.1GiB; / 98% used with 3.5GiB free; swap 1.9GiB used with 64Ki free. No Codex training duplicate launched.",
+        "evidence": "",
         "kind": "ops",
         "labels": [
           "kind:ops",
@@ -92691,10 +92870,9 @@
         "blockedBy": "",
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "2026-06-07T09:03Z E1 refresh remains queued while local fallback is live; latest ledger 20260607T085201Z has trainingDidRun=true but no final report; host swap free 64Ki, disk 98%.",
+        "evidence": "2026-06-07T13:09Z Done: full gate e1-gate-20260607T1257Z ok (200/200 accepted, shadow pass); Loop A 20260607T130053Z no E1_GATE_STALE; Loop B 20260607T130920Z emitted post-gate report.",
         "kind": "ops",
         "labels": [
-          "blocked",
           "kind:ops",
           "priority:p1",
           "roadmap",
@@ -92706,7 +92884,7 @@
         "priority": "P1",
         "projectDomain": "RL flywheel",
         "state": "",
-        "status": "Ready",
+        "status": "Done",
         "title": "P1: Refresh full E1 gate after stale-threshold breach",
         "type": "Issue",
         "updatedAt": "",
@@ -92716,7 +92894,7 @@
         "blockedBy": "",
         "domain": "Territory/Economy",
         "domainSource": "project",
-        "evidence": "",
+        "evidence": "Done 2026-06-07T11:44Z: #1760 merged as 81fba41e, official deploy 27091495323 success, postdeploy tick 1898554 E29N57 sites=0/pending=0/owned_spawns=1/owned_creeps=6; issue closed completed.",
         "kind": "bug",
         "labels": [
           "kind:bug",
@@ -92731,18 +92909,124 @@
         "priority": "P1",
         "projectDomain": "Territory/Economy",
         "state": "",
-        "status": "In progress",
+        "status": "Done",
         "title": "P1: E29N57 worker_assignment_gap recurs with construction backlog",
         "type": "Issue",
         "updatedAt": "",
         "url": "https://github.com/lanyusea/screeps/issues/1758"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "project",
+        "evidence": "Merged 2026-06-07T11:39Z as 81fba41e; deploy run 27091495323 success; postdeploy runtime tick 1898554 confirms #1758 acceptance.",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1760,
+        "priority": "P1",
+        "projectDomain": "Territory/Economy",
+        "state": "",
+        "status": "Done",
+        "title": "fix: cover E29N57 build assignment gap",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1760"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Docs/process",
+        "domainSource": "project",
+        "evidence": "Done 2026-06-07T11:48Z: PR #1759 merged as 85440ecd after body gate patch, update-branch head 269fccbd, gh pr checks PASS, CodeRabbit success, threads=0, mergeState=CLEAN.",
+        "kind": "docs",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1759,
+        "priority": "P2",
+        "projectDomain": "Docs/process",
+        "state": "",
+        "status": "Done",
+        "title": "chore(roadmap): refresh Pages artifacts",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1759"
+      },
+      {
+        "blockedBy": "",
+        "domain": "RL flywheel",
+        "domainSource": "project",
+        "evidence": "",
+        "kind": "bug",
+        "labels": [
+          "domain:rl-flywheel",
+          "kind:bug",
+          "priority:p0",
+          "roadmap",
+          "roadmap:rl-flywheel"
+        ],
+        "milestone": "P1: RL strategy flywheel gate",
+        "nextAction": "",
+        "number": 1761,
+        "priority": "P0",
+        "projectDomain": "RL flywheel",
+        "state": "",
+        "status": "In progress",
+        "title": "P0: Repair recurring Loop B policy-advantage Broken pipe after #1756",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/1761"
+      },
+      {
+        "blockedBy": "",
+        "domain": "RL flywheel",
+        "domainSource": "project",
+        "evidence": "2026-06-07T14:12Z: merged as d3d323af. Gate evidence: head 3a334930, issue/prod-ci/Pages checks PASS, CodeRabbit approved/no actionable comments with Codex triage artifact, Gemini no feedback, unresolved threads=0, mergeState CLEAN, elapsed>=15m.",
+        "kind": "docs",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 1762,
+        "priority": "P0",
+        "projectDomain": "RL flywheel",
+        "state": "",
+        "status": "Done",
+        "title": "docs: record Loop B broken pipe recurrence diagnostic",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/1762"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Release/deploy",
+        "domainSource": "project",
+        "evidence": "2026-06-07T14:12Z: #1763 remains Ready; #1762 merged, so construction-fix acceptance checklist work is unblocked except for scheduler priority/active #1761 acceptance.",
+        "kind": "ops",
+        "labels": [
+          "kind:ops",
+          "priority:p1",
+          "roadmap",
+          "roadmap:phase-c-telemetry"
+        ],
+        "milestone": "Phase C: Runtime telemetry / monitor gate",
+        "nextAction": "",
+        "number": 1763,
+        "priority": "P1",
+        "projectDomain": "Release/deploy",
+        "state": "",
+        "status": "Ready",
+        "title": "P1: Add post-construction-fix deploy acceptance checklist",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/1763"
       }
     ],
     "projectItemsCompleteness": {
       "complete": true,
       "limit": 2000,
-      "returnedCount": 1716,
-      "totalCount": 1716
+      "returnedCount": 1721,
+      "totalCount": 1721
     },
     "projectItemsSource": "live",
     "projectTextFieldHydration": {
@@ -92762,7 +93046,7 @@
           "observedKeys": []
         }
       },
-      "itemsInspected": 1716,
+      "itemsInspected": 1721,
       "source": "gh project item-list"
     },
     "pullRequests": [],
@@ -92830,7 +93114,7 @@
       {
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "2026-06-07T02:25Z stale #1714 blocker cleared (closed Done). Fresh local-fallback card exists on main 7d410885, but bounded live canary remains pre-rollout: no online rollout gate/KPI window and CPU bucket degraded.",
+        "evidence": "Policy-advantage #178 20260607T120949Z: deployabilityStatus=BLOCKED. Tencent batch blocked 9+ days. E1 full gate stale 44h. Local training completed 19/20 reps (no candidate differentiation). E29N55 storedEnergy dropped 2795\u21921235. No deployable candidate exists. onlineUtility=UNPROVEN. Runner dead mid-r20. Host disk 99% (3G free).",
         "milestone": "P1: RL strategy flywheel gate",
         "nextAction": "",
         "number": 1583,
@@ -92860,7 +93144,7 @@
       {
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "2026-06-07T07:34Z conclusion registry nested summary repaired: total=21, OPEN=0, ACTIONED=5, VALIDATING=3, CLOSED=13; no stale/escalated P0/P1.",
+        "evidence": "2026-06-07T13:36Z registry now 23 total: ACTIONED=6/CLOSED=14/VALIDATING=3. Added ACTIONED L20260607T132113Z-LOOP_B-BROKEN_PIPE_RECURRENCE linked to #1761 after Loop B output 2026-06-07_21-21-13.md failed with Broken pipe.",
         "milestone": "P1: RL strategy flywheel gate",
         "nextAction": "",
         "number": 1543,
@@ -92875,7 +93159,22 @@
       {
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "2026-06-07T09:03Z no Tencent compute process; local fallback pids 886153/886164 authoritative; training ledger reports tencent finalStatus=post_fix_validation_plan_required_no_compute.",
+        "evidence": "",
+        "milestone": "P1: RL strategy flywheel gate",
+        "nextAction": "",
+        "number": 1761,
+        "priority": "P0",
+        "projectDomain": "RL flywheel",
+        "status": "In progress",
+        "title": "P0: Repair recurring Loop B policy-advantage Broken pipe after #1756",
+        "type": "Issue",
+        "url": "https://github.com/lanyusea/screeps/issues/1761",
+        "visionLayer": "foundation blocker"
+      },
+      {
+        "domain": "RL flywheel",
+        "domainSource": "project",
+        "evidence": "2026-06-07T13:09Z E1 stale blocker cleared: gate e1-gate-20260607T1257Z ok; Loop A 20260607T130053Z no E1_GATE_STALE; Loop B 20260607T130920Z post-gate report. Cadence still blocked by compute/Tencent anomalies.",
         "milestone": "P1: RL strategy flywheel gate",
         "nextAction": "",
         "number": 1233,
@@ -92890,7 +93189,7 @@
       {
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "2026-06-07T09:03Z scale campaign still local-only: pids 886153/886164 live; latest training ledger 20260607T085201Z trainingDidRun=true but no completed report in 24h; Tencent preflight no-compute/guarded.",
+        "evidence": "2026-06-07T13:09Z E1 stale blocker cleared: gate e1-gate-20260607T1257Z ok; Loop A 20260607T130053Z no E1_GATE_STALE; Loop B 20260607T130920Z post-gate report. Training still NOT_RUN with compute/Tencent blockers.",
         "milestone": "P1: RL strategy flywheel gate",
         "nextAction": "",
         "number": 1032,
@@ -92931,21 +93230,6 @@
         "type": "Issue",
         "url": "https://github.com/lanyusea/screeps/issues/1700",
         "visionLayer": "territory"
-      },
-      {
-        "domain": "RL flywheel",
-        "domainSource": "project",
-        "evidence": "Historical/overloaded #879 quarantined by no-umbrella contract merged in PR #1591 (db7e82e3). Active RL progress comes from atomic Project Domain=RL flywheel issues/PRs; #879 is not a queue or completion proxy.",
-        "milestone": "P1: RL strategy flywheel gate",
-        "nextAction": "",
-        "number": 879,
-        "priority": "P0",
-        "projectDomain": "RL flywheel",
-        "status": "Backlog",
-        "title": "P0: ALL IN RL execution mode \u2014 turn the flywheel into a recurring train/sim/deploy feedback loop",
-        "type": "Issue",
-        "url": "https://github.com/lanyusea/screeps/issues/879",
-        "visionLayer": "foundation blocker"
       }
     ],
     "seededFallbackIssueCount": 0,
@@ -93077,7 +93361,7 @@
             "categoryLabel": "Resources / Economy",
             "description": "Energy held in room stores in the latest runtime KPI window.",
             "details": {},
-            "formattedValue": "81933",
+            "formattedValue": "106743",
             "instrumented": true,
             "key": "stored_energy",
             "label": "Stored energy",
@@ -93088,7 +93372,7 @@
             "source": "runtime-summary resource fields",
             "status": "observed",
             "unit": "energy",
-            "value": 81933
+            "value": 106743
           },
           {
             "category": "resources",
@@ -93113,7 +93397,7 @@
             "categoryLabel": "Resources / Economy",
             "description": "Energy currently carried by workers.",
             "details": {},
-            "formattedValue": "1611",
+            "formattedValue": "887",
             "instrumented": true,
             "key": "worker_carried_energy",
             "label": "Worker carried energy",
@@ -93124,7 +93408,7 @@
             "source": "runtime-summary resource fields",
             "status": "observed",
             "unit": "energy",
-            "value": 1611
+            "value": 887
           },
           {
             "category": "resources",
@@ -93635,8 +93919,15 @@
         {
           "instrumented": false,
           "observed": false,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -93693,8 +93984,15 @@
         {
           "instrumented": false,
           "observed": false,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -93751,8 +94049,15 @@
         {
           "instrumented": true,
           "observed": false,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -93809,8 +94114,15 @@
         {
           "instrumented": true,
           "observed": false,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -93867,8 +94179,15 @@
         {
           "instrumented": true,
           "observed": false,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -93925,8 +94244,15 @@
         {
           "instrumented": true,
           "observed": true,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "observed",
+          "value": 15.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -93983,8 +94309,15 @@
         {
           "instrumented": true,
           "observed": true,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -94041,8 +94374,15 @@
         {
           "instrumented": false,
           "observed": false,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -94099,8 +94439,15 @@
         {
           "instrumented": false,
           "observed": false,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -94157,8 +94504,15 @@
         {
           "instrumented": true,
           "observed": false,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -94215,8 +94569,15 @@
         {
           "instrumented": true,
           "observed": true,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -94273,8 +94634,15 @@
         {
           "instrumented": false,
           "observed": false,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -94331,8 +94699,15 @@
         {
           "instrumented": false,
           "observed": false,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -94389,8 +94764,15 @@
         {
           "instrumented": true,
           "observed": false,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -94447,8 +94829,15 @@
         {
           "instrumented": true,
           "observed": true,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -94505,8 +94894,15 @@
         {
           "instrumented": true,
           "observed": true,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -94561,10 +94957,17 @@
           "value": 1.0
         },
         {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "observed",
+          "value": 1.0
+        },
+        {
           "instrumented": false,
           "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -94621,8 +95024,15 @@
         {
           "instrumented": true,
           "observed": false,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -94679,8 +95089,15 @@
         {
           "instrumented": false,
           "observed": false,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -94737,8 +95154,15 @@
         {
           "instrumented": true,
           "observed": true,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -94795,8 +95219,15 @@
         {
           "instrumented": true,
           "observed": true,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "observed",
+          "value": 3.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -94853,8 +95284,15 @@
         {
           "instrumented": false,
           "observed": false,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -94911,8 +95349,15 @@
         {
           "instrumented": false,
           "observed": false,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -94969,8 +95414,15 @@
         {
           "instrumented": true,
           "observed": true,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "observed",
+          "value": 1.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -95027,8 +95479,15 @@
         {
           "instrumented": true,
           "observed": true,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "observed",
+          "value": 4.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -95085,8 +95544,15 @@
         {
           "instrumented": false,
           "observed": false,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -95143,8 +95609,15 @@
         {
           "instrumented": false,
           "observed": false,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -95201,8 +95674,15 @@
         {
           "instrumented": true,
           "observed": true,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "observed",
+          "value": 106743.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -95217,7 +95697,7 @@
           },
           "sourceKind": "runtime-summary-artifact",
           "status": "observed",
-          "value": 81933
+          "value": 106743
         }
       ],
       "stored_energy_delta": [
@@ -95259,8 +95739,15 @@
         {
           "instrumented": true,
           "observed": true,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -95317,8 +95804,15 @@
         {
           "instrumented": false,
           "observed": false,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -95375,8 +95869,15 @@
         {
           "instrumented": true,
           "observed": false,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -95433,8 +95934,15 @@
         {
           "instrumented": true,
           "observed": true,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "observed",
+          "value": 887.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -95449,7 +95957,7 @@
           },
           "sourceKind": "runtime-summary-artifact",
           "status": "observed",
-          "value": 1611
+          "value": 887
         }
       ],
       "worker_recovery_state": [
@@ -95491,8 +95999,15 @@
         {
           "instrumented": false,
           "observed": false,
+          "sampledAt": "2026-06-07T14:20:30Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
           "reducerSchemaVersion": 1,
-          "sampledAt": "2026-06-07T09:37:19Z",
+          "sampledAt": "2026-06-07T14:20:30Z",
           "scope": {
             "observedRooms": [
               "E29N55",
@@ -95623,7 +96138,17 @@
         "title": "Runtime monitor"
       },
       {
-        "items": [],
+        "items": [
+          {
+            "description": "Ready \u00b7 Release/deploy \u00b7 2026-06-07T14:12Z: #1763 remains Ready; #1762 merged, so construction-fix acceptance...",
+            "domain": "Release/deploy",
+            "number": 1763,
+            "priority": "P1",
+            "status": "Ready",
+            "title": "#1763 P1: Add post-construction-fix deploy acceptance checklist",
+            "url": "https://github.com/lanyusea/screeps/issues/1763"
+          }
+        ],
         "title": "Release/deploy"
       },
       {
@@ -95653,15 +96178,6 @@
             "status": "In progress",
             "title": "#1664 P1: E29N56 energy buffer recovery follow-up after CPU fix",
             "url": "https://github.com/lanyusea/screeps/issues/1664"
-          },
-          {
-            "description": "In progress \u00b7 Territory/Economy \u00b7 2026-06-07T08:30:02Z P1: E29N57 worker_assignment_gap recurs with construct...",
-            "domain": "Territory/Economy",
-            "number": 1758,
-            "priority": "P1",
-            "status": "In progress",
-            "title": "#1758 P1: E29N57 worker_assignment_gap recurs with construction backlog",
-            "url": "https://github.com/lanyusea/screeps/issues/1758"
           }
         ],
         "title": "Territory/Economy"
@@ -95673,7 +96189,7 @@
       {
         "items": [
           {
-            "description": "In progress \u00b7 RL flywheel \u00b7 2026-06-07T09:03Z scale campaign still local-only: pids 886153/886164 live; lates...",
+            "description": "In progress \u00b7 RL flywheel \u00b7 2026-06-07T13:09Z E1 stale blocker cleared: gate e1-gate-20260607T1257Z ok; Loop...",
             "domain": "RL flywheel",
             "number": 1032,
             "priority": "P0",
@@ -95682,7 +96198,7 @@
             "url": "https://github.com/lanyusea/screeps/issues/1032"
           },
           {
-            "description": "In progress \u00b7 RL flywheel \u00b7 2026-06-07T09:03Z no Tencent compute process; local fallback pids 886153/886164 a...",
+            "description": "In progress \u00b7 RL flywheel \u00b7 2026-06-07T13:09Z E1 stale blocker cleared: gate e1-gate-20260607T1257Z ok; Loop...",
             "domain": "RL flywheel",
             "number": 1233,
             "priority": "P0",
@@ -95691,7 +96207,7 @@
             "url": "https://github.com/lanyusea/screeps/issues/1233"
           },
           {
-            "description": "In progress \u00b7 RL flywheel \u00b7 2026-06-07T07:34Z conclusion registry nested summary repaired: total=21, OPEN=0,...",
+            "description": "In progress \u00b7 RL flywheel \u00b7 2026-06-07T13:36Z registry now 23 total: ACTIONED=6/CLOSED=14/VALIDATING=3. Added...",
             "domain": "RL flywheel",
             "number": 1543,
             "priority": "P0",
@@ -95700,7 +96216,7 @@
             "url": "https://github.com/lanyusea/screeps/issues/1543"
           },
           {
-            "description": "In progress \u00b7 RL flywheel \u00b7 2026-06-07T02:25Z stale #1714 blocker cleared (closed Done). Fresh local-fallback...",
+            "description": "In progress \u00b7 RL flywheel \u00b7 Policy-advantage #178 20260607T120949Z: deployabilityStatus=BLOCKED. Tencent batc...",
             "domain": "RL flywheel",
             "number": 1583,
             "priority": "P0",
@@ -95919,7 +96435,7 @@
           "windowDays": 7
         },
         "key": "resources",
-        "max": 90000,
+        "max": 200000,
         "pill": "energy",
         "series": [
           {
@@ -95942,7 +96458,7 @@
               null,
               6834,
               8307,
-              81933
+              106743
             ],
             "width": 2
           },
@@ -95991,7 +96507,7 @@
               null,
               1404,
               996,
-              1611
+              887
             ],
             "width": 3
           }
@@ -95999,8 +96515,8 @@
         "subtitle": "stored energy \u00b7 harvest delta \u00b7 carried energy",
         "ticks": [
           0,
-          45000.0,
-          90000
+          100000.0,
+          200000
         ],
         "title": "Resources"
       },
@@ -96150,28 +96666,28 @@
     ],
     "processCards": [
       {
-        "delta": "+2",
+        "delta": "+3",
         "detail": "git rev-list --count HEAD",
         "label": "Commits",
-        "rawValue": 1037,
+        "rawValue": 1040,
         "source": "git rev-list --count HEAD",
-        "value": 1037
+        "value": 1040
+      },
+      {
+        "delta": "+2",
+        "detail": "22 open",
+        "label": "Issues",
+        "rawValue": 845,
+        "source": "github",
+        "value": 845
       },
       {
         "delta": "+3",
-        "detail": "22 open",
-        "label": "Issues",
-        "rawValue": 843,
-        "source": "github",
-        "value": 843
-      },
-      {
-        "delta": "+2",
-        "detail": "898 merged",
+        "detail": "901 merged",
         "label": "PRs",
-        "rawValue": 915,
+        "rawValue": 918,
         "source": "github",
-        "value": 915
+        "value": 918
       },
       {
         "delta": "n/a",
@@ -96199,8 +96715,8 @@
           ],
           "window": {
             "days": 7,
-            "end": "2026-06-07T09:37:19Z",
-            "start": "2026-05-31T09:37:19Z"
+            "end": "2026-06-07T14:20:30Z",
+            "start": "2026-05-31T14:20:30Z"
           }
         },
         "source": "unavailable",
@@ -96232,8 +96748,8 @@
           ],
           "window": {
             "days": 7,
-            "end": "2026-06-07T09:37:19Z",
-            "start": "2026-05-31T09:37:19Z"
+            "end": "2026-06-07T14:20:30Z",
+            "start": "2026-05-31T14:20:30Z"
           }
         },
         "source": "unavailable",
@@ -96265,8 +96781,8 @@
           ],
           "window": {
             "days": 7,
-            "end": "2026-06-07T09:37:19Z",
-            "start": "2026-05-31T09:37:19Z"
+            "end": "2026-06-07T14:20:30Z",
+            "start": "2026-05-31T14:20:30Z"
           }
         },
         "source": "local cache",
@@ -96298,8 +96814,8 @@
           ],
           "window": {
             "days": 7,
-            "end": "2026-06-07T09:37:19Z",
-            "start": "2026-05-31T09:37:19Z"
+            "end": "2026-06-07T14:20:30Z",
+            "start": "2026-05-31T14:20:30Z"
           }
         },
         "source": "local cache",
@@ -96331,8 +96847,8 @@
           ],
           "window": {
             "days": 7,
-            "end": "2026-06-07T09:37:19Z",
-            "start": "2026-05-31T09:37:19Z"
+            "end": "2026-06-07T14:20:30Z",
+            "start": "2026-05-31T14:20:30Z"
           }
         },
         "source": "local cache",
@@ -96367,8 +96883,8 @@
           ],
           "window": {
             "days": 7,
-            "end": "2026-06-07T09:37:19Z",
-            "start": "2026-05-31T09:37:19Z"
+            "end": "2026-06-07T14:20:30Z",
+            "start": "2026-05-31T14:20:30Z"
           }
         },
         "source": "local cache",
@@ -96400,8 +96916,8 @@
           ],
           "window": {
             "days": 7,
-            "end": "2026-06-07T09:37:19Z",
-            "start": "2026-05-31T09:37:19Z"
+            "end": "2026-06-07T14:20:30Z",
+            "start": "2026-05-31T14:20:30Z"
           }
         },
         "source": "local cache",
@@ -96446,16 +96962,16 @@
         "url": "https://github.com/lanyusea/screeps/issues/1749"
       },
       {
-        "activeItems": 0,
+        "activeItems": 1,
         "domain": "Release/deploy",
         "doneItems": 20,
         "goal": "Validate, deploy, and observe accepted changes across private smoke and official MMO gates.",
-        "next": "No active item; latest tracked: #63 Done - Record expected KPI movement and proof for gamepla...",
-        "progress": 100,
-        "status": "20 Project items \u00b7 0 active \u00b7 20 done",
+        "next": "Current: #1763 Ready - 2026-06-07T14:12Z: #1763 remains Ready; #1762 merged, so construction-...",
+        "progress": 95,
+        "status": "21 Project items \u00b7 1 active \u00b7 20 done",
         "title": "Release/deploy",
-        "totalItems": 20,
-        "url": "https://github.com/lanyusea/screeps/issues/63"
+        "totalItems": 21,
+        "url": "https://github.com/lanyusea/screeps/issues/1763"
       },
       {
         "activeItems": 0,
@@ -96482,15 +96998,15 @@
         "url": "https://github.com/lanyusea/screeps/issues/977"
       },
       {
-        "activeItems": 3,
+        "activeItems": 2,
         "domain": "Territory/Economy",
-        "doneItems": 304,
+        "doneItems": 306,
         "goal": "Advance expansion, controller pressure, worker efficiency, and resource throughput.",
         "next": "Current: #1490 In progress - 2026-06-07T07:34Z console runtime-summary-console-20260607T07102...",
         "progress": 99,
-        "status": "307 Project items \u00b7 3 active \u00b7 304 done",
+        "status": "308 Project items \u00b7 2 active \u00b7 306 done",
         "title": "Territory/Economy",
-        "totalItems": 307,
+        "totalItems": 308,
         "url": "https://github.com/lanyusea/screeps/issues/1490"
       },
       {
@@ -96508,13 +97024,13 @@
       {
         "activeItems": 8,
         "domain": "RL flywheel",
-        "doneItems": 413,
+        "doneItems": 415,
         "goal": "Drive offline/simulator/data/training/validation work for safe strategy self-evolution.",
-        "next": "Current: #1032 In progress - 2026-06-07T09:03Z scale campaign still local-only: pids 886153/8...",
+        "next": "Current: #1032 In progress - 2026-06-07T13:09Z E1 stale blocker cleared: gate e1-gate-2026060...",
         "progress": 98,
-        "status": "421 Project items \u00b7 8 active \u00b7 413 done",
+        "status": "423 Project items \u00b7 8 active \u00b7 415 done",
         "title": "RL flywheel",
-        "totalItems": 421,
+        "totalItems": 423,
         "url": "https://github.com/lanyusea/screeps/issues/1032"
       }
     ]
@@ -96531,8 +97047,8 @@
       "skippedFileCount": 0
     },
     "window": {
-      "firstTick": 1894924,
-      "latestTick": 1894924
+      "firstTick": 1902965,
+      "latestTick": 1902965
     }
   },
   "schemaVersion": 1,

--- a/docs/roadmap-kpi.sqlite
+++ b/docs/roadmap-kpi.sqlite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cf119e65591eafc5ad0dcabbbc9124a2a5bfccb068a82b7e2564fb319f81d3dc
-size 397312
+oid sha256:301347a4d0e03d205252c9ad5193f93d77e69d0f7547a4a2059fb335cfd83c9a
+size 405504


### PR DESCRIPTION
Refreshes the generated roadmap Pages artifacts.

Generated by the scheduled roadmap Pages refresh workflow.

## Universal task Done gate
- [x] Task type: generated roadmap documentation/artifact refresh.
- [x] Expected observable outcome / named deliverable: updated GitHub Pages roadmap surface from `docs/index.html`, `docs/roadmap-data.json`, and `docs/roadmap-kpi.sqlite` at head `66cab74f`.
- [x] Non-goals / accepted substitutes: production bot behavior, official MMO upload, and runtime policy changes are out of scope; this PR carries generated roadmap artifacts only.
- [x] Verification evidence required before Done: `Verify roadmap Pages contracts` passed, `Verify prod TypeScript, Jest, and bundle` passed, CodeRabbit approved with no actionable comments, Gemini commented with no feedback, and review threads are empty.
- [x] Project Evidence / Next action / Blocked by: Project `screeps` item records In review, P2, Docs/process, docs; Evidence names head `66cab74f` and checks; Next action is rerun issue-completion gate and merge when it passes; Blocked by is empty.
- [x] Post-merge/deploy/runtime proof: merge places the generated roadmap artifacts on `main`; GitHub Pages contract verification passed for the generated files; official MMO deploy is outside this docs-only refresh.
- [x] Named deliverable proof: changed files are `docs/index.html`, `docs/roadmap-data.json`, and `docs/roadmap-kpi.sqlite`; the roadmap Pages contract check passed on the PR head.
