### PR TITLE
docs: add construction-fix acceptance checklist

### DIFF
--- a/docs/ops/official-mmo-deploy.md
+++ b/docs/ops/official-mmo-deploy.md
@@ -150,6 +150,51 @@ Normal gameplay releases follow the 8h Gameplay Evolution Review cycle (cron `c7
 4. **Post-deploy acceptance**: The next Gameplay Evolution Review (or explicit post-deploy observation within 30 min) must verify expected KPI movement or record regression against the prior review's `Expected KPI movement` column.
 5. **Hold conditions**: Deploy is HELD when private-smoke is unavailable, the room is in a survival emergency, a deploy is already in-flight, or the review recommends Hold/Observe.
 
+## Construction-Fix Post-Deploy Verification
+
+Named checklist: `postConstructionFixVerification`.
+
+Run this checklist before marking any construction-deadlock fix accepted when the deployed issue or PR claims to resolve `worker_assignment_gap`, `stalled-construction`, `build=0`, `buildCarriedEnergy=0`, frozen `pendingBuildProgress`, construction-priority dispatch failure, or any equivalent construction execution blocker. This checklist is in addition to the normal post-deploy health gate; it does not authorize deploys, issue closure, or Project updates without controller verification.
+
+Required evidence:
+
+- Deploy evidence JSON or workflow artifact for the deployed commit.
+- Runtime monitor summary and alert artifacts for every affected owned room, including the primary target when the fix can affect shared worker/economy behavior.
+- Runtime-summary console capture paths under `runtime-artifacts/runtime-summary-console/`, or another explicit saved artifact path containing exact-prefix `#runtime-summary ` lines.
+- The relevant issue/PR identifiers and the controller's post-verification Project `Evidence` and `Next action` update text.
+
+Active-site pass condition:
+
+- If any affected room has active construction sites after deploy, collect at least 3 fresh post-deploy runtime-summary or console snapshots from that room. Fresh means captured after the deployed SHA/upload evidence, not reused from the pre-deploy review.
+- The 3-snapshot window must show actual build execution: either `buildCarriedEnergy > 0` appears in the affected room snapshots, or `buildProgress` increases while `pendingBuildProgress` decreases across the window.
+- Do not accept a construction fix from `taskCounts.build > 0`, construction scoring, or a release recommendation alone. The acceptance evidence must show carried build energy or completed build progress movement.
+
+No-site success condition:
+
+- If construction sites are already gone before the post-deploy window can observe active building, acceptance may use the no-site state instead of build-execution evidence.
+- Cite fresh evidence for the affected room with `constructionSiteCount=0`, `pendingBuildProgress=0`, and `buildBlockedReason=no_construction_sites`.
+- When the no-site evidence comes from a secondary artifact such as a policy-advantage report or steward summary rather than the latest runtime-summary console capture, keep the issue/PR open until the controller records the exact artifact path and confirms the affected room identity.
+
+Survival guardrails:
+
+- Owned spawns and owned creeps remain present in the affected room set: `owned_spawns >= 1` and `owned_creeps >= 1` where those monitor fields are available, or equivalent runtime-summary ownership fields for that room.
+- No `ROOM_DEAD`, `room_dead`, `postdeploy_room_dead`, or `postdeploy_no_owned_spawn` signal appears in runtime alerts, summaries, or the Gameplay Evolution Review.
+- No hostile or owned-structure damage regression appears in the alert artifact, monitor image evidence, or review window.
+- CPU bucket is not worsened below the current recovery band recorded by the prior review or issue. The controller must name the pre-deploy bucket band or floor, then reject acceptance if the post-deploy snapshots fall below that floor, add new critical CPU pressure, or make construction progress evidence untrustworthy.
+
+Controller completion contract:
+
+- After controller verification, update the relevant issue/PR Project `Evidence` with the deploy evidence path, runtime monitor artifact paths, runtime-summary console artifact paths, affected room names, snapshot ticks/timestamps, and pass/fail result for active-site or no-site acceptance.
+- Set Project `Next action` to the next bounded action: close/merge if accepted and all other gates pass, continue observation if evidence is incomplete, or open/dispatch a follow-up if build execution remains stalled.
+- Do not close a construction-deadlock issue only because a deploy succeeded or a runtime alert is silent. The construction-specific evidence above is required.
+
+Historical example from the 2026-06-07 Gameplay Evolution Review artifact:
+
+- Artifact: `/root/.hermes/cron/output/c7b3dda8f1ac/2026-06-07_16-42-18.md`.
+- E29N55 no-site acceptance evidence in that artifact cites runtime console capture `20260607T081617Z.log`, tick `1892633`, with `constructionSiteCount=0`, `pendingBuildProgress=0`, `buildCarriedEnergy=0`, and `buildBlockedReason=no_construction_sites`. Under this checklist, that is a no-site success case, not evidence that workers were actively building at that tick.
+- The same review says the latest policy-advantage/steward evidence showed all rooms at `0` construction sites and flagged #1758/E29N57 as likely satisfied, while also noting an E29N57 latest-console capture gap. Under this checklist, the controller should cite the exact E29N57 artifact path before updating or closing #1758.
+- The earlier #1747 acceptance would not have passed the active-site condition because `buildCarriedEnergy=0` persisted while construction backlog remained. The durable guard is the 3 fresh build-execution snapshots, or the explicit no-site success evidence when the backlog is already gone.
+
 ## Post-Deploy Monitoring
 
 After a successful live deploy, capture runtime evidence for `shardX/E29N55`:

--- a/docs/ops/runtime-room-monitor.md
+++ b/docs/ops/runtime-room-monitor.md
@@ -294,6 +294,18 @@ SCREEPS_MONITOR_STATE_FILE=/tmp/screeps-monitor-alert-smoke-state.json \
   python3 scripts/screeps-runtime-monitor.py alert --room shardX/E29N55 --out-dir /root/screeps/runtime-artifacts/screeps-monitor-smoke
 ```
 
+### Construction-fix acceptance capture
+
+Use this capture pattern when `docs/ops/official-mmo-deploy.md` requires `postConstructionFixVerification` for a deployed construction-deadlock fix.
+
+1. Capture runtime-summary console evidence after the deployed SHA/upload evidence exists. Save the command output and the generated console artifact path; do not rely on pre-deploy review snapshots.
+2. Capture monitor `summary` and `alert` artifacts for each affected owned room. A silent alert is useful survival evidence, but it does not prove construction execution by itself.
+3. For active construction sites, collect at least 3 fresh runtime-summary or console snapshots from the affected room and record the ticks/timestamps. The snapshots must show `buildCarriedEnergy > 0`, or show `buildProgress` increasing while `pendingBuildProgress` decreases.
+4. For the no-site success case, record `constructionSiteCount=0`, `pendingBuildProgress=0`, and `buildBlockedReason=no_construction_sites` from a fresh artifact. If the affected room is only covered by a secondary steward/policy report, cite that path explicitly and have the controller verify room identity before closing or updating the issue.
+5. Pair construction evidence with survival guardrails: owned spawn/creep presence, no `ROOM_DEAD` or `postdeploy_no_owned_spawn`, no hostile/damage regression, and CPU bucket not below the current recovery band named by the issue or review.
+
+The controller should copy only artifact paths, ticks/timestamps, room names, and the pass/fail result into the relevant Project `Evidence` and `Next action` fields. Do not paste raw console captures into owner-facing reports when a saved artifact path is sufficient.
+
 ## Scheduled delivery design
 
 Use Hermes cron jobs rather than putting Discord tokens in the repo.


### PR DESCRIPTION
Fixes #1763

## Summary
- Add named `postConstructionFixVerification` acceptance checklist to `docs/ops/official-mmo-deploy.md` for construction-deadlock fixes.
- Add matching runtime-summary/monitor capture guidance to `docs/ops/runtime-room-monitor.md`.
- Document active-site, no-site, survival-guardrail, and Project evidence requirements using the 2026-06-07 E29N55/E29N57 resolved-construction review as a bounded historical example.

## Verification
- `git diff --check`
- Controller verified commit identity and changed files with `git log -1 --format='%H %an <%ae> %s'` and `git show --name-status --oneline HEAD`.

## Universal task Done gate
- [x] Task type: docs/process runbook update for Release/deploy and Runtime monitor acceptance.
- [x] Expected observable outcome / named deliverable: `postConstructionFixVerification` checklist exists in durable ops docs and names active-site, no-site, survival, and Project-evidence acceptance requirements.
- [x] Non-goals / accepted substitutes: no production bot behavior change, no generated bundle update, no official MMO deploy.
- [x] Verification evidence required before Done: `git diff --check` passes and exact changed files are `docs/ops/official-mmo-deploy.md` plus `docs/ops/runtime-room-monitor.md` in Codex-authored commit `1bf62b52862378aab2873352e41371a105ea5f29`.
- [x] Project Evidence / Next action / Blocked by: Project screeps records this PR in review with evidence for commit `1bf62b52`, diff-check pass, CodeRabbit/check/thread gate state, and no owner/deploy blocker.
- [x] Post-merge/deploy/runtime proof: docs-only acceptance contract lands on `main`; no MMO deploy is required because runtime bot code and deploy artifact are unchanged.
- [x] Named deliverable proof: `docs/ops/official-mmo-deploy.md` contains the `Construction-Fix Post-Deploy Verification` section and `docs/ops/runtime-room-monitor.md` contains `Construction-fix acceptance capture`.

## Issue closure gate
- [x] #1763: Durable post-construction-fix deploy acceptance checklist added to official deploy and runtime monitor docs with active-site/no-site evidence rules, survival guardrails, and Project evidence update contract; verified by `git diff --check` on Codex-authored commit `1bf62b52`.
