### PR TITLE
fix: recover post-construction worker tasks

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -28660,7 +28660,7 @@ function selectSpawnOrExtensionEnergySink(creep) {
     return null;
   }
   const loadedWorkers = getSameRoomLoadedWorkersForRefillReservations(creep);
-  const reservedEnergyDeliveries = getReservedEnergyDeliveriesBySinkId(creep, loadedWorkers);
+  const reservedEnergyDeliveries = getSpawnExtensionRefillReservationsBySinkId(creep, energySinks);
   const assignedTransferTargetId = getAssignedTransferTargetId(creep);
   const unreservedEnergySink = selectSpawnExtensionRecoveryEnergySink(
     energySinks.filter((energySink) => hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries)),
@@ -28669,6 +28669,91 @@ function selectSpawnOrExtensionEnergySink(creep) {
     assignedTransferTargetId
   );
   return unreservedEnergySink != null ? unreservedEnergySink : selectCloserReservedEnergySinkFallback(energySinks, creep, loadedWorkers, reservedEnergyDeliveries);
+}
+function getSpawnExtensionRefillReservationsBySinkId(creep, energySinks) {
+  var _a2, _b;
+  const reservedEnergyDeliveries = /* @__PURE__ */ new Map();
+  const shouldReserveAcquisitions = shouldReservePendingSpawnExtensionRefillAcquisitions(creep);
+  for (const worker of getRoomOwnedCreeps2(creep.room)) {
+    if (isSameCreep3(worker, creep)) {
+      continue;
+    }
+    const task = (_a2 = worker.memory) == null ? void 0 : _a2.task;
+    if ((task == null ? void 0 : task.type) === "transfer" && typeof task.targetId === "string") {
+      const energySinkId = String(task.targetId);
+      reservedEnergyDeliveries.set(
+        energySinkId,
+        ((_b = reservedEnergyDeliveries.get(energySinkId)) != null ? _b : 0) + getUsedEnergy2(worker)
+      );
+      continue;
+    }
+    if (shouldReserveAcquisitions && isPendingSpawnExtensionRefillAcquisitionWorker(worker, creep, task)) {
+      reserveSpawnExtensionRefillEnergy(
+        energySinks,
+        reservedEnergyDeliveries,
+        getPendingSpawnExtensionRefillAcquisitionEnergy(worker)
+      );
+    }
+  }
+  return reservedEnergyDeliveries;
+}
+function shouldReservePendingSpawnExtensionRefillAcquisitions(creep) {
+  const energyAvailable = getRoomEnergyAvailable11(creep.room);
+  if (energyAvailable !== null && energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD) {
+    return false;
+  }
+  return !hasVisibleHostilePresence3(creep.room) && findConstructionSites(creep.room).length === 0;
+}
+function isPendingSpawnExtensionRefillAcquisitionWorker(worker, currentCreep, task) {
+  if (isSameCreep3(worker, currentCreep) || !isProductiveSameRoomWorker(worker, currentCreep.room) || !isPendingSpawnExtensionRefillReservableWorker(worker)) {
+    return false;
+  }
+  if (!isGenericWorkerEnergyAcquisitionTask(task)) {
+    return false;
+  }
+  return getPendingSpawnExtensionRefillAcquisitionEnergy(worker) > 0;
+}
+function isPendingSpawnExtensionRefillReservableWorker(worker) {
+  const memory = worker.memory;
+  return (memory == null ? void 0 : memory.interRoomEnergyHaul) === void 0 && (memory == null ? void 0 : memory.controllerUpgrade) === void 0 && (memory == null ? void 0 : memory.controllerSustain) === void 0 && (memory == null ? void 0 : memory.territory) === void 0;
+}
+function isGenericWorkerEnergyAcquisitionTask(task) {
+  if (!task || task.type !== "harvest" && task.type !== "pickup" && task.type !== "withdraw") {
+    return false;
+  }
+  if (task.type === "withdraw" && typeof task.constructionSiteId === "string") {
+    return false;
+  }
+  return task.type !== "harvest" || task.sourceContainerAssigned !== true;
+}
+function getPendingSpawnExtensionRefillAcquisitionEnergy(worker) {
+  const carriedEnergy = getUsedEnergy2(worker);
+  const freeCapacity = getFreeEnergyCapacity9(worker);
+  return Math.max(0, carriedEnergy + freeCapacity);
+}
+function reserveSpawnExtensionRefillEnergy(energySinks, reservedEnergyDeliveries, energy) {
+  let remainingEnergy = Math.max(0, energy);
+  if (remainingEnergy <= 0) {
+    return;
+  }
+  for (const energySink of [...energySinks].sort(compareEnergySinkId)) {
+    const unreservedCapacity = Math.max(
+      0,
+      getFreeStoredEnergyCapacity(energySink) - getReservedEnergyDelivery(energySink, reservedEnergyDeliveries)
+    );
+    if (unreservedCapacity <= 0) {
+      continue;
+    }
+    const reservedEnergy = Math.min(remainingEnergy, unreservedCapacity);
+    reservedEnergyDeliveries.set(
+      String(energySink.id),
+      getReservedEnergyDelivery(energySink, reservedEnergyDeliveries) + reservedEnergy
+    );
+    remainingEnergy -= reservedEnergy;
+    if (remainingEnergy <= 0) {
+      return;
+    }
+  }
 }
 function selectStorageToSpawnExtensionRefillAcquisitionTask(creep) {
   if (!isSpawnExtensionThroughputBottlenecked(creep.room) || getFreeEnergyCapacity9(creep) <= 0) {
@@ -32020,7 +32105,7 @@ function getRoomName6(room) {
 }
 function isWorkerEnergyNeededForNearTermSpawnExtensionRefillReserve(creep, reserveContext) {
   const loadedWorkers = getNearTermRefillReserveLoadedWorkers(creep, reserveContext);
-  let reservedEnergy = 0;
+  let reservedEnergy = getPendingSpawnExtensionRefillAcquisitionReserveEnergy(creep);
   for (const worker of loadedWorkers) {
     if (isSameCreep3(worker, creep)) {
       return reservedEnergy < reserveContext.refillReserve;
@@ -32028,6 +32113,21 @@ function isWorkerEnergyNeededForNearTermSpawnExtensionRefillReserve(creep, reser
     reservedEnergy += getUsedEnergy2(worker);
   }
   return true;
+}
+function getPendingSpawnExtensionRefillAcquisitionReserveEnergy(creep) {
+  if (!shouldReservePendingSpawnExtensionRefillAcquisitions(creep)) {
+    return 0;
+  }
+  return getRoomOwnedCreeps2(creep.room).reduce((total, worker) => {
+    var _a2;
+    if (isSameCreep3(worker, creep)) {
+      return total;
+    }
+    if (!isPendingSpawnExtensionRefillAcquisitionWorker(worker, creep, (_a2 = worker.memory) == null ? void 0 : _a2.task)) {
+      return total;
+    }
+    return total + getFreeEnergyCapacity9(worker);
+  }, 0);
 }
 function getNearTermRefillReserveLoadedWorkers(creep, reserveContext) {
   if (reserveContext.sortedLoadedWorkers.some((worker) => isSameCreep3(worker, creep))) {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -2461,7 +2461,7 @@ function selectSpawnOrExtensionEnergySink(creep: Creep): StructureSpawn | Struct
   }
 
   const loadedWorkers = getSameRoomLoadedWorkersForRefillReservations(creep);
-  const reservedEnergyDeliveries = getReservedEnergyDeliveriesBySinkId(creep, loadedWorkers);
+  const reservedEnergyDeliveries = getSpawnExtensionRefillReservationsBySinkId(creep, energySinks);
   const assignedTransferTargetId = getAssignedTransferTargetId(creep);
   const unreservedEnergySink = selectSpawnExtensionRecoveryEnergySink(
     energySinks.filter((energySink) => hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries)),
@@ -2473,6 +2473,130 @@ function selectSpawnOrExtensionEnergySink(creep: Creep): StructureSpawn | Struct
     unreservedEnergySink ??
     selectCloserReservedEnergySinkFallback(energySinks, creep, loadedWorkers, reservedEnergyDeliveries)
   );
+}
+
+function getSpawnExtensionRefillReservationsBySinkId(
+  creep: Creep,
+  energySinks: Array<StructureSpawn | StructureExtension>
+): Map<string, number> {
+  const reservedEnergyDeliveries = new Map<string, number>();
+  const shouldReserveAcquisitions = shouldReservePendingSpawnExtensionRefillAcquisitions(creep);
+
+  for (const worker of getRoomOwnedCreeps(creep.room)) {
+    if (isSameCreep(worker, creep)) {
+      continue;
+    }
+
+    const task = worker.memory?.task as Partial<CreepTaskMemory> | undefined;
+    if (task?.type === 'transfer' && typeof task.targetId === 'string') {
+      const energySinkId = String(task.targetId);
+      reservedEnergyDeliveries.set(
+        energySinkId,
+        (reservedEnergyDeliveries.get(energySinkId) ?? 0) + getUsedEnergy(worker)
+      );
+      continue;
+    }
+
+    if (shouldReserveAcquisitions && isPendingSpawnExtensionRefillAcquisitionWorker(worker, creep, task)) {
+      reserveSpawnExtensionRefillEnergy(
+        energySinks,
+        reservedEnergyDeliveries,
+        getPendingSpawnExtensionRefillAcquisitionEnergy(worker)
+      );
+    }
+  }
+
+  return reservedEnergyDeliveries;
+}
+
+function shouldReservePendingSpawnExtensionRefillAcquisitions(creep: Creep): boolean {
+  const energyAvailable = getRoomEnergyAvailable(creep.room);
+  if (energyAvailable !== null && energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD) {
+    return false;
+  }
+
+  return !hasVisibleHostilePresence(creep.room) && findConstructionSites(creep.room).length === 0;
+}
+
+function isPendingSpawnExtensionRefillAcquisitionWorker(
+  worker: Creep,
+  currentCreep: Creep,
+  task: Partial<CreepTaskMemory> | undefined
+): boolean {
+  if (
+    isSameCreep(worker, currentCreep) ||
+    !isProductiveSameRoomWorker(worker, currentCreep.room) ||
+    !isPendingSpawnExtensionRefillReservableWorker(worker)
+  ) {
+    return false;
+  }
+
+  if (!isGenericWorkerEnergyAcquisitionTask(task)) {
+    return false;
+  }
+
+  return getPendingSpawnExtensionRefillAcquisitionEnergy(worker) > 0;
+}
+
+function isPendingSpawnExtensionRefillReservableWorker(worker: Creep): boolean {
+  const memory = worker.memory;
+  return (
+    memory?.interRoomEnergyHaul === undefined &&
+    memory?.controllerUpgrade === undefined &&
+    memory?.controllerSustain === undefined &&
+    memory?.territory === undefined
+  );
+}
+
+function isGenericWorkerEnergyAcquisitionTask(
+  task: Partial<CreepTaskMemory> | undefined
+): boolean {
+  if (!task || (task.type !== 'harvest' && task.type !== 'pickup' && task.type !== 'withdraw')) {
+    return false;
+  }
+
+  if (task.type === 'withdraw' && typeof task.constructionSiteId === 'string') {
+    return false;
+  }
+
+  return task.type !== 'harvest' || task.sourceContainerAssigned !== true;
+}
+
+function getPendingSpawnExtensionRefillAcquisitionEnergy(worker: Creep): number {
+  const carriedEnergy = getUsedEnergy(worker);
+  const freeCapacity = getFreeEnergyCapacity(worker);
+  return Math.max(0, carriedEnergy + freeCapacity);
+}
+
+function reserveSpawnExtensionRefillEnergy(
+  energySinks: Array<StructureSpawn | StructureExtension>,
+  reservedEnergyDeliveries: Map<string, number>,
+  energy: number
+): void {
+  let remainingEnergy = Math.max(0, energy);
+  if (remainingEnergy <= 0) {
+    return;
+  }
+
+  for (const energySink of [...energySinks].sort(compareEnergySinkId)) {
+    const unreservedCapacity = Math.max(
+      0,
+      getFreeStoredEnergyCapacity(energySink) - getReservedEnergyDelivery(energySink, reservedEnergyDeliveries)
+    );
+    if (unreservedCapacity <= 0) {
+      continue;
+    }
+
+    const reservedEnergy = Math.min(remainingEnergy, unreservedCapacity);
+    reservedEnergyDeliveries.set(
+      String(energySink.id),
+      getReservedEnergyDelivery(energySink, reservedEnergyDeliveries) + reservedEnergy
+    );
+    remainingEnergy -= reservedEnergy;
+    if (remainingEnergy <= 0) {
+      return;
+    }
+  }
 }
 
 function selectStorageToSpawnExtensionRefillAcquisitionTask(
@@ -7918,7 +8042,7 @@ function isWorkerEnergyNeededForNearTermSpawnExtensionRefillReserve(
   reserveContext: NearTermSpawnExtensionRefillReserveContext
 ): boolean {
   const loadedWorkers = getNearTermRefillReserveLoadedWorkers(creep, reserveContext);
-  let reservedEnergy = 0;
+  let reservedEnergy = getPendingSpawnExtensionRefillAcquisitionReserveEnergy(creep);
 
   for (const worker of loadedWorkers) {
     if (isSameCreep(worker, creep)) {
@@ -7929,6 +8053,24 @@ function isWorkerEnergyNeededForNearTermSpawnExtensionRefillReserve(
   }
 
   return true;
+}
+
+function getPendingSpawnExtensionRefillAcquisitionReserveEnergy(creep: Creep): number {
+  if (!shouldReservePendingSpawnExtensionRefillAcquisitions(creep)) {
+    return 0;
+  }
+
+  return getRoomOwnedCreeps(creep.room).reduce((total, worker) => {
+    if (isSameCreep(worker, creep)) {
+      return total;
+    }
+
+    if (!isPendingSpawnExtensionRefillAcquisitionWorker(worker, creep, worker.memory?.task)) {
+      return total;
+    }
+
+    return total + getFreeEnergyCapacity(worker);
+  }, 0);
 }
 
 function getNearTermRefillReserveLoadedWorkers(

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -15605,6 +15605,162 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container-near' });
   });
 
+  it('routes loaded secondary-room workers to upgrade when existing refill work covers a post-construction deficit', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const extension = makeEnergySink('extension1', 'extension' as StructureConstant, 107);
+    const room = makeWorkerTaskRoom({
+      name: 'E29N57',
+      controller,
+      energyAvailable: 1_693,
+      energyCapacityAvailable: 1_800,
+      myStructures: [extension as AnyOwnedStructure]
+    });
+    const transferWorker = {
+      name: 'RefillWorker',
+      memory: { role: 'worker', colony: 'E29N57', task: { type: 'transfer', targetId: 'extension1' as Id<AnyStoreStructure> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(60),
+        getFreeCapacity: jest.fn().mockReturnValue(40)
+      },
+      room
+    } as unknown as Creep;
+    const pendingRefillWorker = {
+      name: 'PendingRefillWorker',
+      memory: { role: 'worker', colony: 'E29N57', task: { type: 'withdraw', targetId: 'storage1' as Id<AnyStoreStructure> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+    const creep = {
+      name: 'PostConstructionWorker',
+      memory: { role: 'worker', colony: 'E29N57', task: { type: 'withdraw', targetId: 'storage1' as Id<AnyStoreStructure> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room
+    } as unknown as Creep;
+    (room.find as jest.Mock).mockImplementation(
+      (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [extension as AnyOwnedStructure];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        const findMyCreeps = (globalThis as unknown as { FIND_MY_CREEPS?: number }).FIND_MY_CREEPS;
+        if (typeof findMyCreeps === 'number' && type === findMyCreeps) {
+          const creeps = [transferWorker, pendingRefillWorker, creep];
+          return options?.filter ? creeps.filter(options.filter) : creeps;
+        }
+
+        return [];
+      }
+    );
+    setGameCreeps({
+      RefillWorker: transferWorker,
+      PendingRefillWorker: pendingRefillWorker,
+      PostConstructionWorker: creep
+    });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it.each(
+    [
+      [
+        'inter-room energy haul collector',
+        {
+          interRoomEnergyHaul: {
+            sourceRoom: 'E29N57',
+            targetRoom: 'E29N58',
+            sourceId: 'storage1' as Id<AnyStoreStructure>,
+            targetId: 'remote-storage' as Id<AnyStoreStructure>
+          }
+        }
+      ],
+      [
+        'managed controller upgrader',
+        {
+          controllerUpgrade: {
+            roomName: 'E29N57',
+            controllerId: 'controller1' as Id<StructureController>,
+            priority: 'steady'
+          }
+        }
+      ],
+      [
+        'controller sustain upgrader',
+        {
+          controllerSustain: { homeRoom: 'E29N57', targetRoom: 'E29N57', role: 'upgrader' }
+        }
+      ]
+    ] as Array<[string, Partial<CreepMemory>]>
+  )('does not count a %s as pending refill coverage for a post-construction deficit', (_label, specialistMemory) => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const extension = makeEnergySink('extension1', 'extension' as StructureConstant, 107);
+    const myCreeps: Creep[] = [];
+    const room = makeWorkerTaskRoom({
+      name: 'E29N57',
+      controller,
+      energyAvailable: 1_693,
+      energyCapacityAvailable: 1_800,
+      myCreeps,
+      myStructures: [extension as AnyOwnedStructure]
+    });
+    const transferWorker = {
+      name: 'RefillWorker',
+      memory: { role: 'worker', colony: 'E29N57', task: { type: 'transfer', targetId: 'extension1' as Id<AnyStoreStructure> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(60),
+        getFreeCapacity: jest.fn().mockReturnValue(40)
+      },
+      room
+    } as unknown as Creep;
+    const specialistWorker = {
+      name: 'SpecialistWorker',
+      memory: {
+        role: 'worker',
+        colony: 'E29N57',
+        task: { type: 'withdraw', targetId: 'storage1' as Id<AnyStoreStructure> },
+        ...specialistMemory
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+    const creep = {
+      name: 'PostConstructionWorker',
+      memory: { role: 'worker', colony: 'E29N57', task: { type: 'withdraw', targetId: 'storage1' as Id<AnyStoreStructure> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room
+    } as unknown as Creep;
+    myCreeps.push(transferWorker, specialistWorker, creep);
+    setGameCreeps({
+      RefillWorker: transferWorker,
+      SpecialistWorker: specialistWorker,
+      PostConstructionWorker: creep
+    });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension1' });
+  });
+
   it('keeps stable-room construction before a third controller upgrader when spawn energy is full', () => {
     const site = { id: 'wall-site1', structureType: 'constructedWall' } as ConstructionSite;
     const controller = {


### PR DESCRIPTION
## Linked issues

Intentional PR-body closing linkage:
- None.

Related / non-closing linkage:
- Related to issue 1766. Runtime/post-deploy acceptance stays on the issue after merge.

## Domain / Kind

- Domain: Bot capability / Territory/Economy
- Kind: bug / code

## Summary

- Counts in-flight generic energy-acquisition workers as pending spawn/extension refill reservations when a stable room has no construction sites and no hostiles.
- Lets loaded workers in post-construction secondary rooms choose productive upgrade work once existing/pending refill workers already cover the spawn/extension deficit.
- Adds a targeted regression test for the E29N57 post-construction transition case and keeps `prod/dist/main.js` synchronized.

## Verification

- [x] Local check: `git diff --check` PASS; `cd prod && npm run typecheck` PASS; `npm test -- --runInBand` PASS (105 suites / 2367 tests); `npm run build` PASS.
- [x] GitHub Project issue/PR fields are current (`Status`, `Evidence`, `Next action`; plus `Blocked by` when blocked): issue 1766 and PR 1768 are both in Project `screeps`, Status=In review, with exact head/verification/gate evidence.
- [x] Automated review has no blocking findings and review threads are resolved/outdated/non-blocking: pending normal automated review on exact head `d6ec65ca`.
- [x] QA gate: pending normal PR-gate QA on exact head `d6ec65ca`.
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate

- [x] Task type: code behavior bugfix.
- [x] Expected observable outcome / named deliverable: secondary-room loaded workers transition from post-construction `none`/refill-reserve deadlock toward productive upgrade work when refill demand is already covered.
- [x] Non-goals / accepted substitutes: no runtime-alert rule in this PR; sustained none-task alerting is tracked separately by issue 1767.
- [x] Verification evidence required before Done: local typecheck, Jest, build, green CI, automated review gate, and post-deploy runtime-summary-console acceptance on issue 1766.
- [x] Project Evidence / Next action / Blocked by: issue 1766 and PR 1768 Project fields were set on 2026-06-08 with exact head `d6ec65ca`, local verification evidence, and the gate path through review, merge, deploy, and runtime acceptance.
- [x] Post-merge/deploy/runtime proof: required on issue 1766 after official deploy; this PR supplies the code artifact and does not claim runtime acceptance at merge time.
- [x] Named deliverable proof: commit `d6ec65ca` changes `prod/src/tasks/workerTasks.ts`, `prod/test/workerTasks.test.ts`, and `prod/dist/main.js` with the targeted regression test.

## Issue closure gate

No GitHub issue completion keyword is used. Related to issue 1766: post-deploy runtime evidence is required before its Done state.

## Runtime / deployment impact

- [ ] No gameplay/runtime/deployment impact.
- [x] Gameplay/runtime/deployment impact; Deployment Floor evidence or HELD blocker is recorded. After merge, official MMO deploy plus runtime-summary-console acceptance is required before issue 1766 Done state.

## Notes

- Review/merge gates: wait at least 15 minutes after PR creation, require green checks, inspect CodeRabbit/Gemini comments/review threads, keep linked issue/PR Project fields current, and use post-deploy runtime acceptance before issue 1766 Done state.