### PR TITLE
task: route bootstrap workers to post-construction upgrades

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -28293,7 +28293,24 @@ function selectBootstrapSurvivalSpendingTask(creep, controller, constructionSite
   if (throughputRecoveryConstructionSite) {
     return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: throughputRecoveryConstructionSite.id });
   }
+  const postConstructionControllerProgressTask = selectBootstrapPostConstructionControllerProgressTask(
+    creep,
+    controller,
+    constructionSites
+  );
+  if (postConstructionControllerProgressTask) {
+    return applyMinimumUsefulLoadPolicy(creep, postConstructionControllerProgressTask);
+  }
   return null;
+}
+function selectBootstrapPostConstructionControllerProgressTask(creep, controller, constructionSites) {
+  if (constructionSites.length > 0 || !isWorkerInColonyRoom(creep) || hasVisibleHostilePresence3(creep.room) || (controller == null ? void 0 : controller.my) !== true || !canUpgradeController(controller)) {
+    return null;
+  }
+  if (!hasRecoverableSurplusEnergy(creep) && !hasFullRoomEnergyForControllerProgress(creep.room)) {
+    return null;
+  }
+  return { type: "upgrade", targetId: controller.id };
 }
 function selectBootstrapSurvivalConstructionSite(creep, constructionSites, constructionReservationContext) {
   if (getUsedEnergy2(creep) <= 0 || hasOtherSameRoomLoadedBuildWorker(creep)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -28307,7 +28307,7 @@ function selectBootstrapPostConstructionControllerProgressTask(creep, controller
   if (constructionSites.length > 0 || !isWorkerInColonyRoom(creep) || hasVisibleHostilePresence3(creep.room) || (controller == null ? void 0 : controller.my) !== true || !canUpgradeController(controller)) {
     return null;
   }
-  if (!hasRecoverableSurplusEnergy(creep) && !hasFullRoomEnergyForControllerProgress(creep.room)) {
+  if (getUsedEnergy2(creep) <= 0 && !hasRecoverableSurplusEnergy(creep) && !hasFullRoomEnergyForControllerProgress(creep.room)) {
     return null;
   }
   return { type: "upgrade", targetId: controller.id };

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1899,7 +1899,11 @@ function selectBootstrapPostConstructionControllerProgressTask(
     return null;
   }
 
-  if (!hasRecoverableSurplusEnergy(creep) && !hasFullRoomEnergyForControllerProgress(creep.room)) {
+  if (
+    getUsedEnergy(creep) <= 0 &&
+    !hasRecoverableSurplusEnergy(creep) &&
+    !hasFullRoomEnergyForControllerProgress(creep.room)
+  ) {
     return null;
   }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1872,7 +1872,38 @@ function selectBootstrapSurvivalSpendingTask(
     return applyMinimumUsefulLoadPolicy(creep, { type: 'build', targetId: throughputRecoveryConstructionSite.id });
   }
 
+  const postConstructionControllerProgressTask = selectBootstrapPostConstructionControllerProgressTask(
+    creep,
+    controller,
+    constructionSites
+  );
+  if (postConstructionControllerProgressTask) {
+    return applyMinimumUsefulLoadPolicy(creep, postConstructionControllerProgressTask);
+  }
+
   return null;
+}
+
+function selectBootstrapPostConstructionControllerProgressTask(
+  creep: Creep,
+  controller: StructureController | undefined,
+  constructionSites: ConstructionSite[]
+): Extract<CreepTaskMemory, { type: 'upgrade' }> | null {
+  if (
+    constructionSites.length > 0 ||
+    !isWorkerInColonyRoom(creep) ||
+    hasVisibleHostilePresence(creep.room) ||
+    controller?.my !== true ||
+    !canUpgradeController(controller)
+  ) {
+    return null;
+  }
+
+  if (!hasRecoverableSurplusEnergy(creep) && !hasFullRoomEnergyForControllerProgress(creep.room)) {
+    return null;
+  }
+
+  return { type: 'upgrade', targetId: controller.id };
 }
 
 function selectBootstrapSurvivalConstructionSite(

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -15672,6 +15672,95 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
+  it('routes loaded E29N56 bootstrap workers to upgrade after construction completes when refill is covered', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const spawn = makeEnergySinkWithEnergy('spawn-needs-energy', 'spawn' as StructureConstant, 200, 100, {
+      my: true,
+      pos: makeRoomPosition(17, 24, 'E29N56')
+    }) as StructureSpawn;
+    const storage = makeStoredEnergyStructure('storage-built', 'storage' as StructureConstant, 113_639, {
+      my: true,
+      pos: makeRoomPosition(18, 23, 'E29N56')
+    }) as StructureStorage;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N56',
+      controller,
+      energyAvailable: 1_200,
+      energyCapacityAvailable: 1_300,
+      myStructures: [spawn as AnyOwnedStructure],
+      structures: [spawn as AnyStructure, storage as AnyStructure]
+    });
+    (room as { storage?: StructureStorage }).storage = storage;
+    const refillCoverage = {
+      name: 'RefillCoverage',
+      memory: {
+        role: 'worker',
+        colony: 'E29N56',
+        task: { type: 'transfer', targetId: 'spawn-needs-energy' as Id<AnyStoreStructure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 150 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      },
+      pos: { getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'spawn-needs-energy' ? 1 : 5)) },
+      room
+    } as unknown as Creep;
+    const workers = Array.from({ length: 6 }, (_, index) => ({
+      name: `worker-E29N56-post-construction-${index}`,
+      memory: { role: 'worker', colony: 'E29N56' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => {
+          const ranges: Record<string, number> = {
+            'spawn-needs-energy': 4,
+            'storage-built': 2
+          };
+          return ranges[String(target.id)] ?? 6;
+        })
+      },
+      room
+    } as unknown as Creep));
+    const assessment = {
+      mode: 'BOOTSTRAP',
+      stage: 'BOOTSTRAP',
+      roomName: 'E29N56',
+      totalCreeps: 12,
+      spawnEnergyAvailable: 1_200,
+      workerCapacity: 6,
+      workerTarget: 6,
+      survivalWorkerFloor: 3,
+      bootstrapRecovery: true,
+      controllerDowngradeGuard: false,
+      hostilePresence: false,
+      territoryReady: false,
+      suppressionReasons: ['bootstrapRecovery']
+    } as ReturnType<typeof assessColonySurvival>;
+    recordColonySurvivalAssessment('E29N56', assessment, 1_909_293);
+    setGameCreeps({
+      RefillCoverage: refillCoverage,
+      ...Object.fromEntries(workers.map((worker) => [worker.name, worker]))
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      ...((globalThis as unknown as { Game?: Partial<Game> }).Game ?? {}),
+      rooms: { E29N56: room },
+      time: 1_909_293
+    };
+
+    for (const worker of workers) {
+      expect(selectWorkerTask(worker)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+    }
+  });
+
   it.each(
     [
       [

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -15672,6 +15672,34 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
+  it('routes loaded bootstrap workers to upgrade after construction completes without ambient surplus', () => {
+    recordSurvivalMode('BOOTSTRAP');
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      controller,
+      energyAvailable: 1_200,
+      energyCapacityAvailable: 1_300
+    });
+    const creep = {
+      name: 'PostConstructionWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ PostConstructionWorker: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
   it('routes loaded E29N56 bootstrap workers to upgrade after construction completes when refill is covered', () => {
     const controller = {
       id: 'controller1',


### PR DESCRIPTION
## Summary

Related to #1766.

This follow-up routes loaded bootstrap workers to controller progress when construction has completed, the room is owned and safe, and refill coverage or full room energy makes controller work appropriate. The goal is to clear the postdeploy acceptance failure where E29N56 showed `none=6/6` at tick 1909293 after PR #1768 landed.

## Verification

Controller-side verification in `/root/screeps-worktrees/worker-idle-transition-1766-followup/prod`:
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` — 105 suites, 2371 tests passed
- `npm run build`

## Universal task Done gate
- [x] Task type: P1 Bot capability code change with generated bundle update.
- [x] Expected observable outcome / named deliverable: bootstrap workers in completed secondary rooms choose upgrade/controller progress work instead of staying on `none` when refill coverage or full room energy makes spending safe.
- [x] Non-goals / accepted substitutes: no new expansion policy, no Tencent compute, no local training dispatch, and no issue auto-closure in this PR body.
- [x] Verification evidence required before Done: controller verification passed diff-check, typecheck, Jest 105 suites and 2371 tests, and build at 2026-06-07T19:15Z.
- [x] Project Evidence / Next action / Blocked by: Project item for issue 1766 records this PR branch/head and names exact-head review, deploy, and runtime acceptance as the next controller sequence; Blocked by field tracks repository gates only.
- [x] Post-merge/deploy/runtime proof: official deploy workflow plus all-room runtime-summary acceptance capture must show E29N56 workers leaving sustained `none` state and assigning controller progress or other productive work.
- [x] Named deliverable proof: commit `561ef769e63757c0f517e5edc2bbed2c65801b4e` changes `prod/src/tasks/workerTasks.ts`, `prod/test/workerTasks.test.ts`, and regenerated `prod/dist/main.js` with the verified post-construction upgrade path.
