### PR TITLE
rl: ignore preflight artifacts as training ledgers

### DIFF
--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -1187,7 +1187,9 @@ def conclusion_summary(artifact: LoadedArtifact | None) -> JsonObject:
 def artifact_kind(path: Path, payload: JsonObject) -> str:
     name = path.name.lower()
     type_text = str(payload.get("type", "")).lower()
-    if "training-ledger" in name or "training-execution-ledger" in type_text:
+    if "training-execution-ledger" in type_text:
+        return "training_ledger"
+    if "training-ledger" in name and "preflight" not in name:
         return "training_ledger"
     if "policy-advantage" in name or "policy-online-advantage" in type_text or "policyadvantage" in normalized_key(type_text):
         return "policy_advantage"

--- a/scripts/test_screeps_rl_control_loop_ledgers.py
+++ b/scripts/test_screeps_rl_control_loop_ledgers.py
@@ -554,6 +554,52 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
         self.assertNotIn("TRAINING_LEDGER_MISSING", anomaly_codes)
         self.assertNotIn("activeRunner PID 1012127", payload["nextTrainingCapabilityAction"])
 
+    def test_training_ledger_ignores_newer_read_only_preflight_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root, report_id = write_root_local2w_training_report_artifacts(root)
+            preflight = artifact_root / "rl-control-loop" / "20260605T010100Z-training-ledger-read-only-preflight.json"
+            write_json(
+                preflight,
+                {
+                    "kind": "rl_training_ledger_read_only_preflight",
+                    "parsed": {"type": "screeps-rl-batch-preflight-context"},
+                    "raw": {"ok": True, "returncode": 0},
+                    "script": "preflight.py",
+                },
+            )
+            output = root / "out" / "training-ledger.json"
+
+            exit_code = ledgers.main(
+                [
+                    "training-ledger",
+                    "--repo-root",
+                    str(root),
+                    "--artifact-root",
+                    str(artifact_root),
+                    "--output",
+                    str(output),
+                    "--created-at",
+                    "2026-06-05T02:00:00Z",
+                    "--max-files-per-root",
+                    "4",
+                ],
+                stdout=io.StringIO(),
+                stderr=io.StringIO(),
+            )
+            payload = read_json(output)
+
+        anomaly_codes = {item["code"] for item in payload["anomalies"]}
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["status"], "RUN_VALIDATED")
+        self.assertTrue(payload["trainingDidRun"])
+        self.assertEqual(payload["environmentExecution"]["completed"], 80)
+        self.assertEqual(payload["trainingArtifacts"]["trainingReportIds"], [report_id])
+        self.assertTrue(payload["trainingArtifacts"]["latestTrainingLedger"].endswith(f"{report_id}.json"))
+        self.assertNotIn("training-ledger-read-only-preflight", payload["trainingArtifacts"]["latestTrainingLedger"])
+        self.assertNotIn("TRAINING_COMPUTE_EVIDENCE_MISSING", anomaly_codes)
+        self.assertNotIn("TRAINING_LEDGER_MISSING", anomaly_codes)
+
     def test_training_ledger_propagates_existing_reward_decision_and_clears_null_anomaly(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -1202,7 +1248,7 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
             reward_decision_id, reward_decision_path = write_legacy_scorecard_reward_decision(
                 root,
                 artifact_root,
-                scorecard_id="legacy-selected-scorecard",
+                scorecard_id=local2w_scorecard_id(),
                 candidate_policy_id=candidate_policy_id,
             )
             write_json(


### PR DESCRIPTION
## Summary

Related to #1769.

The Loop A training ledger scan was treating newer `*-training-ledger-read-only-preflight.json` artifacts as if they were real training ledgers because the dashboard classifier matched any filename containing `training-ledger`. This change keeps schema/type-based training ledger detection intact while excluding filename-only preflight artifacts, so real training reports remain the evidence source and the producer can emit a bounded report instead of following the broken preflight path.

## Verification

Controller-side verification in `/root/screeps-worktrees/rl-training-ledger-broken-pipe-1769`:
- `python3 -m py_compile scripts/screeps_rl_dashboard.py scripts/screeps_rl_control_loop_ledgers.py scripts/test_screeps_rl_control_loop_ledgers.py`
- `python3 -m pytest scripts/test_screeps_rl_control_loop_ledgers.py -q` — 32 passed
- closed-pipe command: `python3 scripts/screeps_rl_control_loop_ledgers.py training-ledger --repo-root /root/screeps --artifact-root /root/screeps/runtime-artifacts --output /tmp/issue1769-training-ledger-closed-pipe-controller.json --stdout-bytes 1024 | head -c 0` exited 0
- `git diff --check`

## Universal task Done gate
- [x] Task type: P0 RL flywheel script reliability patch with targeted regression coverage.
- [x] Expected observable outcome / named deliverable: Loop A training ledger logic ignores read-only preflight artifacts when selecting training ledger evidence and keeps real training report artifacts as the training signal source.
- [x] Non-goals / accepted substitutes: no cron schedule edits, no duplicate local training, no paid Tencent compute, and no historical issue sink updates.
- [x] Verification evidence required before Done: py_compile passed, targeted pytest passed with 32 tests, closed-pipe command exited 0, and diff-check passed at 2026-06-07T19:35Z.
- [x] Project Evidence / Next action / Blocked by: Project item for issue 1769 records PR head `ea24cf87794b2c376ddb1e29269c6d0392ff3f98`; next controller sequence is exact-head checks, review, merge gate, and post-merge Loop A observation; Blocked by field tracks repository gates only.
- [x] Post-merge/deploy/runtime proof: the next Loop A ledger cron run must emit a bounded ledger artifact/report without `RuntimeError Broken pipe` and must not select a read-only preflight artifact as latest training ledger evidence.
- [x] Named deliverable proof: commit `ea24cf87794b2c376ddb1e29269c6d0392ff3f98` changes `scripts/screeps_rl_dashboard.py` and `scripts/test_screeps_rl_control_loop_ledgers.py` with regression coverage for preflight-artifact exclusion.
