### PR TITLE
telemetry: classify standby and acquisition worker tasks

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -27452,6 +27452,7 @@ function selectHeuristicWorkerTask(creep) {
     }
     if (getFreeEnergyCapacity9(creep) > 0) {
       if (shouldStandbySurplusWorkerInsteadOfAcquiring(creep, creep.room.controller)) {
+        recordControllerUpgradeSaturatedStandbyTelemetry(creep, creep.room.controller);
         return null;
       }
       const upgraderBoostEnergyAcquisitionTask = selectUpgraderBoostEnergyAcquisitionTask(creep, creep.room.controller);
@@ -28602,7 +28603,23 @@ function clearWorkerTaskSelectionTelemetry(creep) {
   if (memory) {
     delete memory.workerEfficiency;
     delete memory.spawnCriticalRefill;
+    delete memory.workerTaskSelectionStandby;
   }
+}
+function recordControllerUpgradeSaturatedStandbyTelemetry(creep, controller) {
+  var _a2;
+  if (isWorkerTaskSelectionTelemetrySuppressed()) {
+    return;
+  }
+  const memory = creep.memory;
+  if (!memory) {
+    return;
+  }
+  memory.workerTaskSelectionStandby = {
+    reason: "controller_upgrade_saturated",
+    tick: (_a2 = getGameTick3()) != null ? _a2 : 0,
+    ...controller ? { controllerId: String(controller.id) } : {}
+  };
 }
 function recordSpawnCriticalRefillTelemetry(creep, spawn) {
   var _a2, _b;
@@ -34006,6 +34023,9 @@ function selectWorkerDispatchDiagnosticReason(creep, context, assignedTask) {
     return "preempted_for_new_task";
   }
   if (!selectedTask) {
+    if (!currentTask && hasCurrentControllerUpgradeSaturatedStandby(creep)) {
+      return "controller_upgrade_saturated_standby";
+    }
     return currentTask ? "selected_null_retained_current_task" : "no_selected_task_idle";
   }
   if (!currentTask) {
@@ -34033,6 +34053,11 @@ function selectWorkerDispatchDiagnosticReason(creep, context, assignedTask) {
     return "retained_upgrade_task";
   }
   return "retained_current_task";
+}
+function hasCurrentControllerUpgradeSaturatedStandby(creep) {
+  var _a2;
+  const standby = (_a2 = creep.memory) == null ? void 0 : _a2.workerTaskSelectionStandby;
+  return (standby == null ? void 0 : standby.reason) === "controller_upgrade_saturated" && typeof standby.tick === "number" && standby.tick === getGameTick4();
 }
 function isSameOptionalTask(left, right) {
   return left !== null && right !== null && isSameTask2(left, right);
@@ -41078,7 +41103,7 @@ var REFILL_DELIVERY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 var SPAWN_CRITICAL_REFILL_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 var OBSERVED_RAMPART_REPAIR_HITS_CEILING = 15e4;
 var TERRITORY_EXPANSION_PROGRESS_CPU_BUCKET_FLOOR = 500;
-var WORKER_TASK_TYPES = ["harvest", "transfer", "build", "repair", "upgrade"];
+var WORKER_TASK_TYPES = ["harvest", "pickup", "withdraw", "transfer", "build", "repair", "upgrade"];
 var PRODUCTIVE_WORKER_TASK_TYPES = ["build", "repair", "upgrade"];
 var PRODUCTIVE_WORKER_ASSIGNMENT_TASK_TYPES = ["harvest", "pickup", "withdraw", "transfer", "build", "repair", "upgrade"];
 var DEFAULT_EXTENSION_ENERGY_CAPACITY = 50;
@@ -41355,6 +41380,7 @@ function summarizeWorkerIdleReasons(workers, cpuBudget) {
 }
 function createEmptyWorkerIdleReasonCounts() {
   return {
+    controller_upgrade_saturated_standby: 0,
     cpu_shed_assignment_skipped: 0,
     no_task_available: 0,
     role_body_unavailable: 0,
@@ -41374,6 +41400,9 @@ function selectWorkerIdleReason(worker, cpuBudget) {
     return "role_body_unavailable";
   }
   const diagnostic = getCurrentWorkerDispatchDiagnostic(worker);
+  if ((diagnostic == null ? void 0 : diagnostic.reason) === "controller_upgrade_saturated_standby") {
+    return "controller_upgrade_saturated_standby";
+  }
   if ((diagnostic == null ? void 0 : diagnostic.reason) === "no_selected_task_idle") {
     return "no_task_available";
   }
@@ -42147,6 +42176,8 @@ function countWorkerTasks(workers) {
   var _a2;
   const counts = {
     harvest: 0,
+    pickup: 0,
+    withdraw: 0,
     transfer: 0,
     build: 0,
     repair: 0,

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -341,6 +341,10 @@ function selectWorkerDispatchDiagnosticReason(
   }
 
   if (!selectedTask) {
+    if (!currentTask && hasCurrentControllerUpgradeSaturatedStandby(creep)) {
+      return 'controller_upgrade_saturated_standby';
+    }
+
     return currentTask ? 'selected_null_retained_current_task' : 'no_selected_task_idle';
   }
 
@@ -379,6 +383,15 @@ function selectWorkerDispatchDiagnosticReason(
   }
 
   return 'retained_current_task';
+}
+
+function hasCurrentControllerUpgradeSaturatedStandby(creep: Creep): boolean {
+  const standby = creep.memory?.workerTaskSelectionStandby;
+  return (
+    standby?.reason === 'controller_upgrade_saturated' &&
+    typeof standby.tick === 'number' &&
+    standby.tick === getGameTick()
+  );
 }
 
 function isSameOptionalTask(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -693,6 +693,7 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
 
     if (getFreeEnergyCapacity(creep) > 0) {
       if (shouldStandbySurplusWorkerInsteadOfAcquiring(creep, creep.room.controller)) {
+        recordControllerUpgradeSaturatedStandbyTelemetry(creep, creep.room.controller);
         return null;
       }
 
@@ -2399,7 +2400,28 @@ function clearWorkerTaskSelectionTelemetry(creep: Creep): void {
   if (memory) {
     delete memory.workerEfficiency;
     delete memory.spawnCriticalRefill;
+    delete memory.workerTaskSelectionStandby;
   }
+}
+
+function recordControllerUpgradeSaturatedStandbyTelemetry(
+  creep: Creep,
+  controller: StructureController | undefined
+): void {
+  if (isWorkerTaskSelectionTelemetrySuppressed()) {
+    return;
+  }
+
+  const memory = creep.memory;
+  if (!memory) {
+    return;
+  }
+
+  memory.workerTaskSelectionStandby = {
+    reason: 'controller_upgrade_saturated',
+    tick: getGameTick() ?? 0,
+    ...(controller ? { controllerId: String(controller.id) } : {})
+  };
 }
 
 function recordSpawnCriticalRefillTelemetry(creep: Creep, spawn: StructureSpawn): void {

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -117,7 +117,7 @@ const SPAWN_CRITICAL_REFILL_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 const OBSERVED_RAMPART_REPAIR_HITS_CEILING = 150_000;
 const TERRITORY_EXPANSION_PROGRESS_CPU_BUCKET_FLOOR = 500;
 
-const WORKER_TASK_TYPES = ['harvest', 'transfer', 'build', 'repair', 'upgrade'] as const;
+const WORKER_TASK_TYPES = ['harvest', 'pickup', 'withdraw', 'transfer', 'build', 'repair', 'upgrade'] as const;
 const PRODUCTIVE_WORKER_TASK_TYPES = ['build', 'repair', 'upgrade'] as const;
 const PRODUCTIVE_WORKER_ASSIGNMENT_TASK_TYPES = ['harvest', 'pickup', 'withdraw', 'transfer', 'build', 'repair', 'upgrade'] as const;
 const DEFAULT_EXTENSION_ENERGY_CAPACITY = 50;
@@ -146,6 +146,7 @@ type RuntimeConstructionActivityReason =
   | 'construction_site_progress_unavailable'
   | 'no_viable_candidate';
 type RuntimeWorkerIdleReason =
+  | 'controller_upgrade_saturated_standby'
   | 'cpu_shed_assignment_skipped'
   | 'no_task_available'
   | 'role_body_unavailable'
@@ -1355,6 +1356,7 @@ function summarizeWorkerIdleReasons(
 
 function createEmptyWorkerIdleReasonCounts(): RuntimeWorkerIdleReasonCounts {
   return {
+    controller_upgrade_saturated_standby: 0,
     cpu_shed_assignment_skipped: 0,
     no_task_available: 0,
     role_body_unavailable: 0,
@@ -1381,6 +1383,10 @@ function selectWorkerIdleReason(
   }
 
   const diagnostic = getCurrentWorkerDispatchDiagnostic(worker);
+  if (diagnostic?.reason === 'controller_upgrade_saturated_standby') {
+    return 'controller_upgrade_saturated_standby';
+  }
+
   if (diagnostic?.reason === 'no_selected_task_idle') {
     return 'no_task_available';
   }
@@ -2519,6 +2525,8 @@ function summarizeSpawn(spawn: StructureSpawn): RuntimeSpawnStatus {
 function countWorkerTasks(workers: Creep[]): WorkerTaskCounts {
   const counts: WorkerTaskCounts = {
     harvest: 0,
+    pickup: 0,
+    withdraw: 0,
     transfer: 0,
     build: 0,
     repair: 0,

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -43,6 +43,7 @@ declare global {
     colony?: string;
     task?: CreepTaskMemory;
     workerTaskSelectionNullLoop?: WorkerTaskSelectionNullLoopMemory;
+    workerTaskSelectionStandby?: WorkerTaskSelectionStandbyMemory;
     defense?: CreepDefenseMemory;
     territory?: CreepTerritoryMemory;
     controllerSustain?: CreepControllerSustainMemory;
@@ -1198,8 +1199,15 @@ declare global {
     idleStartTick: number;
   }
 
+  interface WorkerTaskSelectionStandbyMemory {
+    reason: 'controller_upgrade_saturated';
+    tick: number;
+    controllerId?: string;
+  }
+
   type WorkerDispatchDiagnosticReason =
     | 'assigned_selected_task'
+    | 'controller_upgrade_saturated_standby'
     | 'no_selected_task_idle'
     | 'selected_same_as_current'
     | 'selected_task_not_assigned'

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -117,6 +117,7 @@ describe('runtime telemetry summaries', () => {
             productiveAssignmentCount: 1,
             unassignedWorkerCount: 1,
             idleReasonCounts: {
+              controller_upgrade_saturated_standby: 0,
               cpu_shed_assignment_skipped: 0,
               no_task_available: 0,
               role_body_unavailable: 0,
@@ -142,6 +143,8 @@ describe('runtime telemetry summaries', () => {
           taskCounts: {
             none: 1,
             harvest: 1,
+            pickup: 0,
+            withdraw: 0,
             transfer: 0,
             build: 0,
             repair: 0,
@@ -2012,6 +2015,7 @@ describe('runtime telemetry summaries', () => {
       productiveAssignmentCount: 0,
       unassignedWorkerCount: 1,
       idleReasonCounts: {
+        controller_upgrade_saturated_standby: 0,
         cpu_shed_assignment_skipped: 0,
         no_task_available: 0,
         role_body_unavailable: 0,
@@ -2127,6 +2131,52 @@ describe('runtime telemetry summaries', () => {
           carriedEnergy: 50,
           freeCapacity: 0,
           dispatchReason: 'no_selected_task_idle',
+          dispatchTick: RUNTIME_SUMMARY_INTERVAL
+        }
+      ]
+    });
+  });
+
+  it('reports controller-upgrade saturation standby as a guarded idle reason', () => {
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      includeEventLog: false
+    });
+    const idleWorker = makeWorker(
+      {
+        role: 'worker',
+        colony: 'W1N1',
+        workerDispatchDiagnostic: {
+          tick: RUNTIME_SUMMARY_INTERVAL,
+          reason: 'controller_upgrade_saturated_standby',
+          carriedEnergy: 0,
+          freeCapacity: 100
+        }
+      },
+      0,
+      'StandbyWorker'
+    );
+
+    emitRuntimeSummary([colony], [idleWorker]);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.workerAssignmentEvidence).toMatchObject({
+      workerCount: 1,
+      assignedTaskCount: 0,
+      unassignedWorkerCount: 1,
+      idleReasonCounts: {
+        controller_upgrade_saturated_standby: 1,
+        no_task_available: 0,
+        task_assignment_not_observed: 0
+      },
+      idleWorkers: [
+        {
+          name: 'StandbyWorker',
+          reason: 'controller_upgrade_saturated_standby',
+          carriedEnergy: 0,
+          freeCapacity: 0,
+          dispatchReason: 'controller_upgrade_saturated_standby',
           dispatchTick: RUNTIME_SUMMARY_INTERVAL
         }
       ]
@@ -2252,10 +2302,12 @@ describe('runtime telemetry summaries', () => {
     expect(room.taskCounts).toMatchObject({
       build: 0,
       harvest: 0,
-      none: 3,
+      none: 1,
+      pickup: 1,
       repair: 0,
       transfer: 0,
-      upgrade: 0
+      upgrade: 0,
+      withdraw: 1
     });
     expect(room.workerAssignmentEvidence).toMatchObject({
       workerCount: 3,
@@ -2412,10 +2464,12 @@ describe('runtime telemetry summaries', () => {
     expect(room.taskCounts).toMatchObject({
       build: 0,
       harvest: 1,
-      none: 2,
+      none: 0,
+      pickup: 1,
       repair: 0,
       transfer: 1,
-      upgrade: 0
+      upgrade: 0,
+      withdraw: 1
     });
     expect(room.workerAssignmentEvidence).toMatchObject({
       workerCount: 4,
@@ -2569,10 +2623,11 @@ describe('runtime telemetry summaries', () => {
     expect(room.taskCounts).toMatchObject({
       build: 0,
       harvest: 0,
-      none: 1,
+      none: 0,
       repair: 0,
       transfer: 0,
-      upgrade: 0
+      upgrade: 0,
+      withdraw: 1
     });
     expect(room.workerAssignmentEvidence).toMatchObject({
       workerCount: 1,

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -4474,6 +4474,92 @@ describe('runWorker', () => {
     expect(workers.every((worker) => (worker.transfer as jest.Mock).mock.calls.length === 0)).toBe(true);
   });
 
+  it('reports saturated RCL4 controller upgrade standby instead of a generic no-task idle', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      progress: 58_331,
+      progressTotal: 405_000,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000,
+      pos: { x: 25, y: 25, roomName: 'E29N56' } as RoomPosition
+    } as StructureController;
+    const workers: Creep[] = [];
+    const room = {
+      name: 'E29N56',
+      energyAvailable: 1_000,
+      energyCapacityAvailable: 1_000,
+      controller,
+      find: jest.fn((type: number) => {
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [];
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return workers;
+        }
+
+        if (type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES) {
+          return [];
+        }
+
+        if (type === FIND_SOURCES || type === FIND_DROPPED_RESOURCES) {
+          return [];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const makeLoadedUpgrader = (index: number): Creep =>
+      ({
+        name: `worker-E29N56-upgrader-${index}`,
+        memory: {
+          role: 'worker',
+          colony: 'E29N56',
+          task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }
+        },
+        store: {
+          getUsedCapacity: jest.fn().mockReturnValue(50),
+          getFreeCapacity: jest.fn().mockReturnValue(50),
+          getCapacity: jest.fn().mockReturnValue(100)
+        },
+        room
+      }) as unknown as Creep;
+    const standbyWorker = {
+      name: 'worker-E29N56-standby',
+      memory: { role: 'worker', colony: 'E29N56' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(100),
+        getCapacity: jest.fn().mockReturnValue(100)
+      },
+      room,
+      harvest: jest.fn(),
+      withdraw: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    workers.push(makeLoadedUpgrader(1), makeLoadedUpgrader(2), standbyWorker);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 1_912_315,
+      creeps: Object.fromEntries(workers.map((worker) => [worker.name, worker])),
+      getObjectById: jest.fn((id: string) => (id === 'controller1' ? controller : null))
+    };
+
+    runWorker(standbyWorker);
+
+    expect(standbyWorker.memory.task).toBeUndefined();
+    expect(standbyWorker.memory.workerDispatchDiagnostic).toMatchObject({
+      reason: 'controller_upgrade_saturated_standby',
+      carriedEnergy: 0,
+      freeCapacity: 100
+    });
+    expect(standbyWorker.memory.workerTaskSelectionStandby).toMatchObject({
+      reason: 'controller_upgrade_saturated',
+      controllerId: 'controller1',
+      tick: 1_912_315
+    });
+  });
+
   it('bounds healthy E29N55 RCL3 routine repair saturation after construction clears', () => {
     const controller = {
       id: 'controller1',


### PR DESCRIPTION
## Summary
- Classify worker acquisition tasks (`pickup`/`withdraw`) in runtime summaries instead of folding them into `none`.
- Add telemetry for controller-upgrade-saturated standby workers so intentional standby is distinguishable from unexplained idling.
- Extend tests and regenerate the bundled Screeps artifact.

Related work item: issue 1766.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 105 suites and 2374 tests passed
- `cd prod && npm run build`

## Universal task Done gate
- [x] Task type: production telemetry code and generated bundle update.
- [x] Expected observable outcome / named deliverable: runtime summary reports pickup and withdraw task counts plus controller-upgrade-saturated standby idle reason from the Screeps bundle.
- [x] Non-goals / accepted substitutes: no direct official MMO deployment, no Project automation rewrite, and no learned-policy runtime change in this PR.
- [x] Verification evidence required before Done: diff-check, TypeScript typecheck, full Jest run, and build all passed on branch fix/worker-idle-transition-1766-residual at d9ad1e267d424ba053e5353d402ce6aa9f5336cc.
- [x] Project Evidence / Next action / Blocked by: issue 1766 Project evidence points to this PR, commit d9ad1e267d424ba053e5353d402ce6aa9f5336cc, and the exact review gate; no issue-level blocker is introduced by this PR.
- [x] Post-merge/deploy/runtime proof: issue 1766 acceptance metric is a fresh runtime-summary-console capture where acquisition workers are counted as pickup or withdraw and intentional controller-saturation standby has its own reason.
- [x] Named deliverable proof: changed files are prod/src/telemetry/runtimeSummary.ts, prod/src/tasks/workerTasks.ts, prod/src/creeps/workerRunner.ts, prod/src/types.d.ts, tests, and prod/dist/main.js.
