### PR TITLE
fix: alert on sustained energy buffer collapse

### DIFF
--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -462,10 +462,12 @@ TACTICAL_CATEGORY_RULES: dict[str, dict[str, Any]] = {
     },
     "energy_buffer_unhealthy": {
         "severity": "high",
-        "decision": "metric_taxonomy_and_reward_decision_followup",
-        "actions": ["capture_runtime_context", "inspect_resource_state", "open_incident_issue"],
+        "decision": "open_issue_or_codex_hotfix",
+        "actions": ["capture_runtime_context", "inspect_energy_buffer", "open_incident_issue"],
         "metadata": {
+            "metric": "energyBufferHealth",
             "related_issues": ["#906", "#907"],
+            "thresholds": {"P1_consecutive_captures": ENERGY_BUFFER_UNHEALTHY_REQUIRED_CONSECUTIVE},
             "routes_to": ENERGY_BUFFER_UNHEALTHY_ROUTES,
         },
     },
@@ -608,6 +610,11 @@ TACTICAL_ACTION_CATALOG: dict[str, dict[str, Any]] = {
         "owner": "main-agent",
         "action": "Check available energy, worker carry, dropped energy, sources, spawn queue, and whether the bot can recover harvesting without owner action.",
         "decision": "owner_action_or_hotfix",
+    },
+    "inspect_energy_buffer": {
+        "owner": "main-agent",
+        "action": "Check energyBufferHealth evidence, room energy reserves, spawn refill demand, worker assignments, and whether a Codex hotfix or incident issue is needed.",
+        "decision": "open_issue_or_codex_hotfix",
     },
     "inspect_private_smoke_report": {
         "owner": "main-agent",
@@ -1447,7 +1454,9 @@ def runtime_energy_at_risk(room: dict[str, Any]) -> tuple[bool, int | float | No
 
 def energy_buffer_route_metadata() -> dict[str, Any]:
     return {
+        "metric": "energyBufferHealth",
         "related_issues": [str(route["issue"]) for route in ENERGY_BUFFER_UNHEALTHY_ROUTES],
+        "thresholds": {"P1_consecutive_captures": ENERGY_BUFFER_UNHEALTHY_REQUIRED_CONSECUTIVE},
         "routes_to": [dict(route) for route in ENERGY_BUFFER_UNHEALTHY_ROUTES],
     }
 
@@ -1660,6 +1669,7 @@ def build_energy_buffer_unhealthy_reason(
         "upgrade": upgrade_count,
         "task_counts": dict(as_dict(room.get("taskCounts"))),
         "energy_buffer_health": dict(buffer_health),
+        "energy_buffer_healthy": buffer_health.get("healthy"),
         "current_energy": current_energy,
         "threshold": threshold,
         "energy_buffer_threshold": threshold,
@@ -1675,6 +1685,16 @@ def build_energy_buffer_unhealthy_reason(
     }
 
 
+def energy_buffer_health_collapsed(buffer_health: dict[str, Any]) -> bool:
+    if buffer_health.get("healthy") is not False:
+        return False
+    current_energy = number_value(buffer_health.get("currentEnergy"))
+    threshold = number_value(buffer_health.get("threshold"))
+    if current_energy is None or threshold is None:
+        return True
+    return current_energy < threshold
+
+
 def detect_energy_buffer_unhealthy_reason(
     ref: RoomRef,
     runtime_room: dict[str, Any] | None,
@@ -1684,13 +1704,11 @@ def detect_energy_buffer_unhealthy_reason(
         return None
 
     buffer_health = as_dict(runtime_room.get("energyBufferHealth"))
-    if buffer_health.get("healthy") is not False:
+    if not energy_buffer_health_collapsed(buffer_health):
         return None
 
     build_count = runtime_task_count(runtime_room, "build")
     upgrade_count = runtime_task_count(runtime_room, "upgrade")
-    if build_count != 0 or upgrade_count != 0:
-        return None
 
     return build_energy_buffer_unhealthy_reason(
         ref,
@@ -3193,19 +3211,7 @@ def energy_buffer_unhealthy_reason_is_actionable(reason: dict[str, Any]) -> bool
         return True
     consecutive = number_from_reason(reason, "consecutive", "consecutive_captures", "consecutiveCaptures") or 0
     buffer_health = as_dict(reason.get("energy_buffer_health")) or as_dict(reason.get("energyBufferHealth"))
-    task_counts = as_dict(reason.get("task_counts")) or as_dict(reason.get("taskCounts"))
-    build_count = number_value(reason.get("build"))
-    if build_count is None:
-        build_count = number_value(task_counts.get("build"))
-    upgrade_count = number_value(reason.get("upgrade"))
-    if upgrade_count is None:
-        upgrade_count = number_value(task_counts.get("upgrade"))
-    return (
-        consecutive >= ENERGY_BUFFER_UNHEALTHY_REQUIRED_CONSECUTIVE
-        and buffer_health.get("healthy") is False
-        and build_count == 0
-        and upgrade_count == 0
-    )
+    return consecutive >= ENERGY_BUFFER_UNHEALTHY_REQUIRED_CONSECUTIVE and energy_buffer_health_collapsed(buffer_health)
 
 
 def copy_tactical_metadata(value: Any) -> Any:
@@ -7715,7 +7721,7 @@ def command_self_test(_args: argparse.Namespace) -> int:
                 "roomName": "E1N1",
                 "energyAvailable": 250,
                 "energyCapacity": 300,
-                "energyBufferHealth": {"currentEnergy": 250, "threshold": 300, "healthy": False},
+                "energyBufferHealth": {"currentEnergy": 300, "threshold": 300, "healthy": True},
                 "workerCount": 2,
                 "spawnStatus": [{"name": "Spawn1", "status": "idle"}],
                 "taskCounts": {"harvest": 0, "upgrade": 0, "transfer": 0, "build": 1, "repair": 0, "none": 2},

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -1012,6 +1012,92 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         )
         self.assertTrue(report["silent"])
 
+    def test_energy_buffer_unhealthy_alerts_alive_room_without_room_dead_escalation(self) -> None:
+        snapshot = make_snapshot(
+            {
+                "spawn1": {
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                },
+                "worker-1": {
+                    "type": "creep",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "name": "worker-1",
+                    "x": 23,
+                    "y": 25,
+                },
+            }
+        )
+        runtime_room = {
+            "roomName": "E26S49",
+            "energyBufferHealth": {"currentEnergy": 250, "threshold": 300, "healthy": False},
+            "taskCounts": {"harvest": 1, "upgrade": 1, "build": 1, "transfer": 1},
+        }
+        previous = {"baseline_established": True, "owner": "owner"}
+
+        first_emitted, first_suppressed, first_state = monitor.evaluate_room_alert(
+            snapshot,
+            previous,
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_room,
+        )
+        self.assertEqual(first_emitted, [])
+        self.assertEqual(first_suppressed, [])
+        self.assertEqual(first_state["rule_counts"][monitor.ENERGY_BUFFER_UNHEALTHY_KIND], 1)
+
+        second_emitted, second_suppressed, second_state = monitor.evaluate_room_alert(
+            snapshot,
+            first_state,
+            now=200,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_room,
+        )
+
+        self.assertEqual([reason["kind"] for reason in second_emitted], [monitor.ENERGY_BUFFER_UNHEALTHY_KIND])
+        self.assertEqual(second_suppressed, [])
+        self.assertEqual(second_state["rule_counts"][monitor.ENERGY_BUFFER_UNHEALTHY_KIND], 2)
+        reason = second_emitted[0]
+        self.assertEqual(reason["priority"], "P1")
+        self.assertEqual(reason["current_energy"], 250)
+        self.assertEqual(reason["energy_buffer_threshold"], 300)
+        self.assertEqual(reason["build"], 1)
+        self.assertEqual(reason["upgrade"], 1)
+        self.assertEqual(reason["metadata"]["metric"], "energyBufferHealth")
+        self.assertEqual(reason["metadata"]["thresholds"], {"P1_consecutive_captures": 2})
+
+        alert_payload = {
+            "ok": True,
+            "mode": "alert",
+            "alert": True,
+            "reasons": second_emitted,
+            "rooms": ["shardX/E26S49"],
+            "room_summaries": [monitor.room_summary(snapshot)],
+        }
+        report = monitor.build_tactical_response_report(alert_payload)
+
+        self.assertTrue(report["emergency"])
+        self.assertFalse(report["silent"])
+        self.assertEqual(report["severity"], "high")
+        self.assertEqual(report["priority"], "P1")
+        self.assertEqual(report["categories"], [monitor.ENERGY_BUFFER_UNHEALTHY_KIND])
+        self.assertNotIn("room_dead", report["categories"])
+        self.assertNotIn("spawn_collapse", report["categories"])
+        self.assertEqual(report["triggers"][0]["decision"], "open_issue_or_codex_hotfix")
+        self.assertEqual(report["triggers"][0]["priority"], "P1")
+        self.assertEqual(report["triggers"][0]["metadata"]["metric"], "energyBufferHealth")
+        self.assertIn("inspect_energy_buffer", {action["id"] for action in report["next_actions"]})
+        self.assertNotIn("start_autonomous_recovery", {action["id"] for action in report["next_actions"]})
+        self.assertFalse(
+            any("owner_action" in str(action.get("decision", "")) for action in report["next_actions"])
+        )
+
     def test_energy_buffer_unhealthy_single_capture_reason_is_non_actionable(self) -> None:
         report = monitor.build_tactical_response_report(
             {


### PR DESCRIPTION
## Linked issues

Intentional PR-body closing linkage:
- Fixes #1749.

Related / non-closing linkage:
- Related to issue 906 and issue 907 as runtime-monitor evidence feeding metric taxonomy and reward-decision follow-up surfaces.

## Domain / Kind

- Domain: Runtime monitor
- Kind: bug

## Summary

- Detect `energyBufferHealth.healthy=false` as a sustained P1 runtime alert even when workers are already building/upgrading.
- Route the tactical response to main-agent issue/hotfix handling without room-dead or owner-action escalation for alive rooms.
- Add focused tactical-response regression coverage for alive-room buffer collapse.

## Verification

- [x] Local check: `git diff --check origin/main...HEAD` passed after merging current `origin/main`.
- [x] Local check: `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py` passed.
- [x] Local check: `python3 -m unittest scripts/test_screeps_runtime_monitor_tactical_response.py` passed, 114 tests.
- [x] Local check: `python3 scripts/screeps-runtime-monitor.py self-test` passed, 42 tests.
- [x] GitHub Project issue/PR fields are current (`Status`, `Evidence`, `Next action`; plus `Blocked by` when blocked).
- [x] Automated review has no blocking findings and review threads are resolved/outdated/non-blocking.
- [x] QA gate: controller-side verification passed for the script/test scope; independent post-PR bot review gate remains the repository merge gate.
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate

- [x] Task type: bugfix / runtime monitor.
- [x] Expected observable outcome / named deliverable: sustained unhealthy energy-buffer evidence creates a P1 runtime-alert/tactical-response category for alive owned rooms.
- [x] Non-goals / accepted substitutes: no gameplay bot code change, no official MMO deploy, no owner-action escalation change for room-dead/hostile/damage paths.
- [x] Verification evidence required before Done: local diff check, py_compile, focused unittest, and monitor self-test listed above.
- [x] Project Evidence / Next action / Blocked by: issue 1749 is updated to In review with this PR and local verification evidence; no blocker is claimed by this PR body.
- [x] Post-merge/deploy/runtime proof: script-only monitor behavior verified by local self-test and focused tactical-response tests; official MMO deploy unchanged.
- [x] Named deliverable proof: `energy_buffer_unhealthy` emits P1 tactical metadata and `inspect_energy_buffer` next action in the focused regression test.

## Issue closure gate

For every issue linked above in the PR body with a closing keyword:

- [x] #1749: original acceptance criteria are satisfied by sustained-buffer detection, P1 alert/tactical metadata, alive-room non-room-dead behavior, and focused tests.
- [x] No closed issue still needs post-merge validation, runtime/process proof, owner action, successor/follow-up work, partial-fix completion, or any other blocker.

## Runtime / deployment impact

- [x] No gameplay/runtime/deployment impact.
- [ ] Gameplay/runtime/deployment impact; Deployment Floor evidence or HELD blocker is recorded.

## Notes

- Review/merge gates: wait at least 15 minutes after PR creation, require green checks, inspect CodeRabbit/Gemini comments and GraphQL review threads, and keep linked GitHub issue/PR/Project state current until merged or explicitly closed.


