### PR TITLE
fix: improve secondary-room standby worker productivity

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -32295,10 +32295,16 @@ function hasNonControllerWorkerEnergyDemand(creep) {
   return selectCriticalInfrastructureRepairTarget(creep) !== null || selectRepairTarget(creep) !== null || selectRoutineBarrierMaintenanceRepairTarget(creep) !== null;
 }
 function hasPostConstructionControllerUpgradeEnergy(creep, controller) {
-  return isLowRclControllerProgressTarget(controller) && !hasVisibleHostilePresence3(creep.room) && !hasVisibleOwnedConstructionDemand(creep.room) && (findWorkerEnergyAcquisitionCandidates(creep).length > 0 || hasFullRoomEnergyForControllerProgress(creep.room));
+  return isPostConstructionControllerProgressTarget(controller) && !hasVisibleHostilePresence3(creep.room) && !hasVisibleOwnedConstructionDemand(creep.room) && hasPostConstructionControllerProgressEnergyRoute(creep);
 }
-function isLowRclControllerProgressTarget(controller) {
-  return canLevelUpController2(controller) && controller.level >= 2 && controller.level <= 3;
+function isPostConstructionControllerProgressTarget(controller) {
+  return canLevelUpController2(controller) && controller.level >= 2;
+}
+function hasPostConstructionControllerProgressEnergyRoute(creep) {
+  if (findWorkerEnergyAcquisitionCandidates(creep).length > 0) {
+    return true;
+  }
+  return hasFullRoomEnergyForControllerProgress(creep.room) && selectHarvestSource(creep) !== null;
 }
 function isControllerUpgradeSaturated(creep, controller, options = {}) {
   if (controller.my !== true || shouldGuardControllerDowngrade2(controller)) {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -8337,16 +8337,23 @@ function hasNonControllerWorkerEnergyDemand(creep: Creep): boolean {
 
 function hasPostConstructionControllerUpgradeEnergy(creep: Creep, controller: StructureController): boolean {
   return (
-    isLowRclControllerProgressTarget(controller) &&
+    isPostConstructionControllerProgressTarget(controller) &&
     !hasVisibleHostilePresence(creep.room) &&
     !hasVisibleOwnedConstructionDemand(creep.room) &&
-    (findWorkerEnergyAcquisitionCandidates(creep).length > 0 ||
-      hasFullRoomEnergyForControllerProgress(creep.room))
+    hasPostConstructionControllerProgressEnergyRoute(creep)
   );
 }
 
-function isLowRclControllerProgressTarget(controller: StructureController): boolean {
-  return canLevelUpController(controller) && controller.level >= 2 && controller.level <= 3;
+function isPostConstructionControllerProgressTarget(controller: StructureController): boolean {
+  return canLevelUpController(controller) && controller.level >= 2;
+}
+
+function hasPostConstructionControllerProgressEnergyRoute(creep: Creep): boolean {
+  if (findWorkerEnergyAcquisitionCandidates(creep).length > 0) {
+    return true;
+  }
+
+  return hasFullRoomEnergyForControllerProgress(creep.room) && selectHarvestSource(creep) !== null;
 }
 
 function isControllerUpgradeSaturated(

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -4560,6 +4560,100 @@ describe('runWorker', () => {
     });
   });
 
+  it('routes full-buffer E29N56 saturated surplus workers to harvest instead of standby', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      progress: 58_331,
+      progressTotal: 405_000,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000,
+      pos: { x: 25, y: 25, roomName: 'E29N56' } as RoomPosition
+    } as StructureController;
+    const source = {
+      id: 'source1',
+      energy: 3_000,
+      pos: { x: 20, y: 20, roomName: 'E29N56' } as RoomPosition
+    } as Source;
+    const workers: Creep[] = [];
+    const room = {
+      name: 'E29N56',
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      controller,
+      find: jest.fn((type: number) => {
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [];
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return workers;
+        }
+
+        if (type === FIND_SOURCES) {
+          return [source];
+        }
+
+        if (type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES || type === FIND_DROPPED_RESOURCES) {
+          return [];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const upgrader = {
+      name: 'worker-E29N56-upgrader',
+      memory: {
+        role: 'worker',
+        colony: 'E29N56',
+        task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+    const surplusWorker = {
+      name: 'worker-E29N56-surplus',
+      memory: { role: 'worker', colony: 'E29N56' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(100),
+        getCapacity: jest.fn().mockReturnValue(100)
+      },
+      room,
+      harvest: jest.fn().mockReturnValue(ERR_NOT_IN_RANGE),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    workers.push(upgrader, surplusWorker);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 1_919_363,
+      creeps: Object.fromEntries(workers.map((worker) => [worker.name, worker])),
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'source1') {
+          return source;
+        }
+
+        return id === 'controller1' ? controller : null;
+      })
+    };
+
+    runWorker(surplusWorker);
+
+    expect(surplusWorker.memory.task).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(surplusWorker.memory.workerTaskSelectionStandby).toBeUndefined();
+    expect(surplusWorker.memory.workerDispatchDiagnostic).toMatchObject({
+      reason: 'assigned_selected_task',
+      selectedTask: 'harvest',
+      selectedTargetId: 'source1',
+      assignedTask: 'harvest',
+      assignedTargetId: 'source1'
+    });
+    expect(surplusWorker.harvest).toHaveBeenCalledWith(source);
+    expect(surplusWorker.moveTo).toHaveBeenCalledWith(source, { range: 1 });
+  });
+
   it('bounds healthy E29N55 RCL3 routine repair saturation after construction clears', () => {
     const controller = {
       id: 'controller1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -15462,6 +15462,39 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toBeNull();
   });
 
+  it('lets a full-buffer RCL4 secondary-room surplus worker harvest after construction clears', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const source = makeSource('source1', 20, 20, 'E29N56');
+    const room = makeWorkerTaskRoom({
+      name: 'E29N56',
+      controller,
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      sources: [source]
+    });
+    const creep = {
+      name: 'SurplusWorker',
+      memory: { role: 'worker', colony: 'E29N56' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({
+      Upgrader: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }),
+      SurplusWorker: creep
+    });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(creep.memory.workerTaskSelectionStandby).toBeUndefined();
+  });
+
   it('withdraws stored energy for post-construction RCL2 controller progress when one worker is already upgrading', () => {
     const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 4_399, {
       my: true


### PR DESCRIPTION
## Linked issues

Non-closing linkage:
- Refs #1776.
- Related to issue 1767 as the monitor/alert companion; this PR owns the behavior fix only.

## Domain / Kind

- Domain: Territory/Economy
- Kind: bug

## Summary

- Treat the fresh E29N56-style case as a productivity bug: surplus secondary-room workers with full buffers, no construction, no hostiles, and a viable energy route should acquire energy instead of reporting `controller_upgrade_saturated_standby`.
- Preserve intentional standby classification when no useful acquisition route exists.
- Add focused worker task-selection and runner/dispatch telemetry coverage.
- Regenerate the Screeps bundle through `npm run build`.

## Verification

- [x] Local check: `git diff --check` passed before commit.
- [x] Local check: `cd prod && npm run typecheck` passed.
- [x] Local check: `cd prod && npm test -- --runInBand` passed, 105 suites / 2376 tests.
- [x] Local check: `cd prod && npm run build` passed and regenerated `prod/dist/main.js`.
- [x] Branch reconciliation: merged latest `origin/main` (`9af7127d`) into the worktree and verified `origin/main` is an ancestor of `HEAD`.
- [x] GitHub Project issue fields are current for #1776.
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Authorship / recovery note

- Implementation edits were produced by Codex process `proc_5a97d496fa23` in `/root/screeps-worktrees/secondary-standby-1776`.
- Codex verification passed but its in-sandbox commit failed because the linked worktree gitdir was read-only.
- A narrow Codex commit-only recovery attempt then hit Codex usage quota. The controller preserved the verified Codex-authored changes in commit `52ab9162` with author `lanyusea's bot <lanyusea@gmail.com>`, then merged current `origin/main` and reran full prod verification.

## Universal task Done gate

- [x] Task type: bugfix / production bot behavior.
- [x] Expected observable outcome / named deliverable: secondary-room surplus workers no longer default to standby/`none` when there is productive post-construction energy acquisition available.
- [x] Non-goals / accepted substitutes: no official MMO deploy in this PR; no change to CPU bucket safety, controller downgrade guards, room-dead/energy-buffer recovery, construction/backlog priorities, or source-container construction logic.
- [x] Verification evidence required before Done: prod typecheck, Jest, build, and generated bundle sync listed above.
- [x] Project Evidence / Next action / Blocked by: #1776 Project item is In review with PR/check gate evidence; runtime acceptance remains post-merge/deploy.
- [x] Post-merge/deploy/runtime proof: not claimed by this PR body; #1776 remains open until deployment/runtime console evidence validates E29N56/E29N57 assignment behavior.
- [x] Named deliverable proof: focused tests cover productive acquisition for full-buffer RCL4 secondary-room surplus workers and intentional standby when no useful route exists.

## Issue closure gate

No close-keyword linkage is used. Issue 1776 should remain open after this PR merges until post-deploy/runtime acceptance evidence lands.

## Runtime / deployment impact

- [ ] No gameplay/runtime/deployment impact.
- [x] Gameplay/runtime/deployment impact; Deployment Floor evidence or HELD blocker must be recorded after merge before #1776 closure.

## Notes

- Review/merge gates: wait at least 15 minutes after PR creation, require green checks, inspect CodeRabbit/Gemini comments and GraphQL review threads, keep linked GitHub issue/PR/Project state current, and keep issue 1776 open until runtime acceptance evidence is captured.
