### PR TITLE
feat: add Codex quota budget guard

### DIFF
--- a/docs/ops/cron-and-route-registry.md
+++ b/docs/ops/cron-and-route-registry.md
@@ -1,7 +1,7 @@
 # Screeps Cron and Route Registry
 
-Last updated: 2026-05-23
-Tracking issues: https://github.com/lanyusea/screeps/issues/620, https://github.com/lanyusea/screeps/issues/1122, https://github.com/lanyusea/screeps/issues/1170, https://github.com/lanyusea/screeps/issues/1178
+Last updated: 2026-06-11
+Tracking issues: https://github.com/lanyusea/screeps/issues/620, https://github.com/lanyusea/screeps/issues/1122, https://github.com/lanyusea/screeps/issues/1170, https://github.com/lanyusea/screeps/issues/1178, https://github.com/lanyusea/screeps/issues/1783
 
 This registry is the expected-state contract for Screeps/Hermes cron jobs and Discord delivery routes. It is not passive documentation: P0 monitor, scheduler, and acceptance checks must compare live cron metadata against this file with `scripts/check_cron_registry.py`.
 
@@ -11,6 +11,7 @@ This registry is the expected-state contract for Screeps/Hermes cron jobs and Di
 - Live cron metadata (`cronjob list` / `~/.hermes/cron/jobs.json`) says what currently exists; this registry says what should exist.
 - A job missing from live metadata, an unexpected recurring live job, wrong cadence, wrong delivery target, wrong provider/model, wrong repeat policy, wrong workdir, or paused expected job is Agent OS drift.
 - Drift is P0 when it affects scheduler, P0 monitor, runtime alerting, owner-decision routing, deploy/runtime safety, or GitHub/Project reconciliation.
+- Codex-dispatching cron runners must evaluate the weekly quota budget guard before launching Codex work. The guard reads the full recurring-job registry so suppression is cross-cron aware instead of per-job-local.
 - Old cron outputs and reporter state files are caches/history, not authority.
 - Before changing any live cron definition, create a rollback snapshot of `~/.hermes/cron/jobs.json` and relevant docs; after changing, run `cronjob list` and `python3 scripts/check_cron_registry.py --strict`. Expected recurring jobs are healthy when `enabled=true` and state is either `scheduled` or transiently `running`; paused/disabled/error states are drift unless explicitly documented as an active maintenance window.
 
@@ -18,6 +19,7 @@ Verification command:
 
 ```bash
 python3 scripts/check_cron_registry.py --strict
+python3 scripts/check_codex_quota_budget.py --json
 ```
 
 ## Current target
@@ -68,6 +70,27 @@ Repeat policy values:
 
 `Workdir` uses `-` to mean an explicit expectation that the job has no durable cron workdir. This is different from "unknown": the verifier should flag a live workdir on a `-` row because shared workdirs can serialize otherwise independent jobs behind repo-bound workers.
 
+### Codex weekly quota budget guard
+
+`scripts/check_codex_quota_budget.py` is the repo-contained preflight for issue #1783. It consumes this registry plus either a redacted quota JSON export or local Codex session logs, then emits machine-readable JSON decisions for every expected recurring job.
+
+Controller contract:
+
+- Default low-quota threshold: suppress non-P0 `openai-codex` jobs when weekly remaining quota is below `10%`.
+- Protected Codex runway: continuation worker `f66ed36d7be0`, runtime alert `1df5ef0c3835`, and RL flywheel steward `aed8362e4501`.
+- Unknown, missing, or malformed quota telemetry fails safe by allowing protected P0 Codex jobs and suppressing non-P0 Codex jobs with an explicit `UNKNOWN_QUOTA` report.
+- Reset self-healing: if the telemetry `resetAt`/`resets_at` time is in the past, the guard treats the weekly budget as reset and previously suppressed jobs become eligible without manual state cleanup.
+- Do not attach raw Codex session logs to Discord or GitHub; pass a redacted quota JSON export when possible.
+
+Example controller preflight:
+
+```bash
+python3 scripts/check_codex_quota_budget.py \
+  --quota-json runtime-artifacts/codex-quota/redacted-latest.json \
+  --threshold-remaining-percent 10 \
+  --json
+```
+
 | Job | ID | Schedule | Delivery | Provider | Model | Workdir | Repeat | Criticality | Purpose |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Screeps autonomous continuation worker | `f66ed36d7be0` | `8,28,48 * * * *` | `discord:#task-queue` | `openai-codex` | `gpt-5.5` | `/root/screeps` | `high-horizon` | P0 | Dispatcher/reconciler for safe work lanes. |
@@ -81,7 +104,7 @@ Repeat policy values:
 | Screeps 6h development report | `dfcaf65d7ea7` | `47 */6 * * *` | `discord:1497587260835758222:1497833662241181746` | `deepseek` | `deepseek-v4-flash` | `-` | `high-horizon` | P1 | Threaded 6h health/progress report. |
 | Screeps Gameplay Evolution Review | `c7b3dda8f1ac` | `0 */8 * * *` | `discord:#task-queue` | `deepseek` | `deepseek-v4-flash` | `-` | `high-horizon` | P1 | 8h strategy review for current target `E29N55`. |
 | Screeps Gameplay Evolution Review decisions archive | `dc1c46787f2e` | `15 */8 * * *` | `discord:1497586175580311654` | `deepseek` | `deepseek-v4-flash` | `-` | `high-horizon` | P1 | Archive accepted strategy decisions/current strategy. |
-| Screeps RL flywheel steward | `aed8362e4501` | `17 * * * *` | `discord:#task-queue` | `openai-codex` | `gpt-5.5` | `/root/screeps` | `high-horizon` | P1 | RL flywheel stewardship and issue/Project reconciliation. |
+| Screeps RL flywheel steward | `aed8362e4501` | `17 * * * *` | `discord:#task-queue` | `openai-codex` | `gpt-5.5` | `/root/screeps` | `high-horizon` | P0 | RL flywheel stewardship and issue/Project reconciliation. |
 | Screeps RL shadow-eval bounded gate | `d6cff532edd4` | `5 * * * *` | `discord:#task-queue` | `deepseek` | `deepseek-v4-flash` | `-` | `high-horizon` | P1 | Shadow-eval ledger producer for RL candidate/baseline evidence; routine output is stdout/artifacts only and must not comment on historical #879. |
 | Screeps RL training execution ledger | `5c869e7d8a1d` | `14,44 * * * *` | `discord:#task-queue` | `deepseek` | `deepseek-v4-flash` | `-` | `high-horizon` | P1 | Training execution ledger for offline/private RL campaigns; owns Tencent RL utilization control through its preflight instead of a standalone cron. |
 | Screeps RL policy online advantage ledger | `01609968392a` | `27,57 * * * *` | `discord:#task-queue` | `deepseek` | `deepseek-v4-flash` | `/root/screeps` | `high-horizon` | P1 | Online advantage ledger comparing candidate policy signals against baseline. |
@@ -101,6 +124,7 @@ Transient one-shot jobs must have an expiry condition and tracking issue. They s
 
 - Every cron prompt that reasons about room state for gameplay/bot-deployment purposes must use `shardX/E29N55` as current target. Runtime monitoring/alerting jobs that auto-discover rooms via API are exempt from single-room targeting.
 - P0 monitor and continuation/scheduler jobs must consult the registry diff before reporting cron health as OK or dispatching unrelated non-urgent work.
+- Codex-dispatching scheduler paths must consult `scripts/check_codex_quota_budget.py` before launch; when the guard reports low or unknown weekly quota, suppress non-P0 Codex dispatches and report the suppression artifact instead of consuming more Codex quota.
 - Tencent Cloud cost monitoring is owned by P0 agent operations monitor `75cedbb77150`; standalone billing-guard cron jobs are retired and must not be recreated.
 - Tencent RL batch utilization is owned by RL training execution ledger `5c869e7d8a1d`; standalone utilization-controller cron jobs are retired and must not deliver directly to Discord.
 - Incident/postdeploy/Project-field follow-ups should reuse runtime alert/summary, continuation worker, P0 monitor, or RL ledger mechanisms instead of creating ad-hoc temporary crons unless the owner explicitly approves a non-spamming new surface.

--- a/scripts/check_codex_quota_budget.py
+++ b/scripts/check_codex_quota_budget.py
@@ -73,13 +73,16 @@ def parse_timestamp(value: Any) -> datetime | None:
     if value is None:
         return None
     if isinstance(value, (int, float)) and math.isfinite(float(value)):
-        return datetime.fromtimestamp(float(value), timezone.utc)
+        try:
+            return datetime.fromtimestamp(float(value), timezone.utc)
+        except (OverflowError, OSError, ValueError):
+            return None
     text = str(value).strip()
     if not text:
         return None
     try:
         return datetime.fromtimestamp(float(text), timezone.utc)
-    except ValueError:
+    except (OverflowError, OSError, ValueError):
         pass
     try:
         parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))

--- a/scripts/check_codex_quota_budget.py
+++ b/scripts/check_codex_quota_budget.py
@@ -1,0 +1,558 @@
+#!/usr/bin/env python3
+"""Decide which Screeps Codex cron jobs may run under weekly quota.
+
+The guard is intentionally repo-contained: it reads the expected cron surface
+from docs/ops/cron-and-route-registry.md plus either a redacted quota JSON
+export or local Codex session logs. It never mutates live Hermes cron state.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+import check_cron_registry
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_REGISTRY = REPO_ROOT / "docs" / "ops" / "cron-and-route-registry.md"
+DEFAULT_SESSION_ROOT = Path("/root/.codex/sessions")
+CODEX_SESSION_PATTERN = "rollout-*.jsonl"
+CODEX_PROVIDER = "openai-codex"
+DEFAULT_REMAINING_THRESHOLD_PERCENT = 10.0
+DEFAULT_WEEKLY_WINDOW_MINUTES = 10080
+
+# P0 runway protected by issue #1783. The registry criticality is still the
+# primary source; these ids make the reserve explicit if a row is reclassified.
+DEFAULT_RESERVED_CODEX_JOB_IDS = frozenset(
+    {
+        "f66ed36d7be0",  # autonomous continuation worker
+        "1df5ef0c3835",  # runtime room alert text check
+        "aed8362e4501",  # RL flywheel steward
+    }
+)
+
+PERCENT_FIELDS = (
+    "remaining_percent",
+    "remainingPercent",
+    "remaining_percentage",
+    "remainingPercentage",
+    "remaining",
+)
+USED_FIELDS = ("used_percent", "usedPercent", "used_percentage", "usedPercentage", "used")
+RESET_FIELDS = ("resets_at", "resetsAt", "reset_at", "resetAt")
+WINDOW_FIELDS = ("window_minutes", "windowMinutes", "window")
+
+
+JsonObject = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class QuotaSnapshot:
+    source: str
+    observed_at: datetime | None
+    used_percent: float | None
+    remaining_percent: float | None
+    reset_at: datetime | None
+    window_minutes: int | None
+
+
+@dataclass(frozen=True)
+class QuotaReadResult:
+    snapshot: QuotaSnapshot | None
+    errors: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+
+def parse_timestamp(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)) and math.isfinite(float(value)):
+        return datetime.fromtimestamp(float(value), timezone.utc)
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromtimestamp(float(text), timezone.utc)
+    except ValueError:
+        pass
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def format_timestamp(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def read_number(mapping: Mapping[str, Any], fields: Sequence[str]) -> tuple[float | None, str | None]:
+    for field in fields:
+        if field not in mapping:
+            continue
+        value = mapping.get(field)
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return None, f"{field} is not numeric: {value!r}"
+        if not math.isfinite(number):
+            return None, f"{field} is not finite: {value!r}"
+        return number, None
+    return None, None
+
+
+def read_int(mapping: Mapping[str, Any], fields: Sequence[str]) -> int | None:
+    number, error = read_number(mapping, fields)
+    if error is not None or number is None:
+        return None
+    return int(number)
+
+
+def read_reset_at(mapping: Mapping[str, Any]) -> tuple[datetime | None, str | None]:
+    for field in RESET_FIELDS:
+        if field not in mapping:
+            continue
+        value = mapping.get(field)
+        parsed = parse_timestamp(value)
+        if parsed is None:
+            return None, f"{field} is not a timestamp: {value!r}"
+        return parsed, None
+    return None, None
+
+
+def normalize_percent(value: float | None, field: str) -> tuple[float | None, str | None]:
+    if value is None:
+        return None, None
+    if value < 0 or value > 100:
+        return None, f"{field} outside 0..100: {value!r}"
+    return value, None
+
+
+def rate_limit_candidates(value: Any) -> Iterable[tuple[Mapping[str, Any], str]]:
+    if not isinstance(value, Mapping):
+        return
+    yield value, "root"
+    payload = value.get("payload")
+    if isinstance(payload, Mapping):
+        yield payload, "payload"
+        rate_limits = payload.get("rate_limits")
+        if isinstance(rate_limits, Mapping):
+            yield rate_limits, "payload.rate_limits"
+            for key, child in rate_limits.items():
+                if isinstance(child, Mapping):
+                    yield child, f"payload.rate_limits.{key}"
+    rate_limits = value.get("rate_limits")
+    if isinstance(rate_limits, Mapping):
+        yield rate_limits, "rate_limits"
+        for key, child in rate_limits.items():
+            if isinstance(child, Mapping):
+                yield child, f"rate_limits.{key}"
+    for key in ("primary", "secondary", "weekly", "quota"):
+        child = value.get(key)
+        if isinstance(child, Mapping):
+            yield child, key
+
+
+def snapshot_from_mapping(
+    value: Mapping[str, Any],
+    *,
+    source: str,
+    target_window_minutes: int = DEFAULT_WEEKLY_WINDOW_MINUTES,
+) -> tuple[QuotaSnapshot | None, tuple[str, ...]]:
+    observed_at = parse_timestamp(value.get("timestamp") or value.get("observed_at") or value.get("observedAt"))
+    errors: list[str] = []
+    best: QuotaSnapshot | None = None
+
+    for candidate, candidate_path in rate_limit_candidates(value):
+        window_minutes = read_int(candidate, WINDOW_FIELDS)
+        if window_minutes is not None and window_minutes != target_window_minutes:
+            continue
+
+        remaining, remaining_error = read_number(candidate, PERCENT_FIELDS)
+        used, used_error = read_number(candidate, USED_FIELDS)
+        reset_at, reset_error = read_reset_at(candidate)
+        candidate_errors = [error for error in (remaining_error, used_error, reset_error) if error]
+        if candidate_errors:
+            errors.extend(f"{candidate_path}: {error}" for error in candidate_errors)
+            continue
+        if remaining is None and used is None:
+            continue
+        remaining, remaining_error = normalize_percent(remaining, "remaining_percent")
+        used, used_error = normalize_percent(used, "used_percent")
+        candidate_errors = [error for error in (remaining_error, used_error) if error]
+        if candidate_errors:
+            errors.extend(f"{candidate_path}: {error}" for error in candidate_errors)
+            continue
+        if remaining is None and used is not None:
+            remaining = max(0.0, 100.0 - used)
+        if used is None and remaining is not None:
+            used = max(0.0, 100.0 - remaining)
+
+        snapshot = QuotaSnapshot(
+            source=f"{source}:{candidate_path}",
+            observed_at=observed_at,
+            used_percent=used,
+            remaining_percent=remaining,
+            reset_at=reset_at,
+            window_minutes=window_minutes,
+        )
+        if window_minutes == target_window_minutes:
+            return snapshot, tuple(errors)
+        if best is None:
+            best = snapshot
+
+    return best, tuple(errors)
+
+
+def snapshot_sort_key(snapshot: QuotaSnapshot) -> tuple[float, str]:
+    observed = snapshot.observed_at.timestamp() if snapshot.observed_at is not None else 0.0
+    return observed, snapshot.source
+
+
+def load_quota_json(path: Path, *, target_window_minutes: int = DEFAULT_WEEKLY_WINDOW_MINUTES) -> QuotaReadResult:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        return QuotaReadResult(None, errors=(f"quota JSON unreadable: {path}: {exc}",))
+    except json.JSONDecodeError as exc:
+        return QuotaReadResult(None, errors=(f"quota JSON malformed: {path}: {exc}",))
+
+    snapshots: list[QuotaSnapshot] = []
+    errors: list[str] = []
+    items = data if isinstance(data, list) else [data]
+    for index, item in enumerate(items):
+        if not isinstance(item, Mapping):
+            errors.append(f"quota JSON item {index} is not an object")
+            continue
+        snapshot, item_errors = snapshot_from_mapping(
+            item,
+            source=f"{path}#{index}" if isinstance(data, list) else str(path),
+            target_window_minutes=target_window_minutes,
+        )
+        errors.extend(item_errors)
+        if snapshot is not None:
+            snapshots.append(snapshot)
+    if snapshots:
+        return QuotaReadResult(max(snapshots, key=snapshot_sort_key), errors=tuple(errors))
+    errors.append("no weekly quota telemetry found in quota JSON")
+    return QuotaReadResult(None, errors=tuple(errors))
+
+
+def scan_session_log(path: Path, *, target_window_minutes: int = DEFAULT_WEEKLY_WINDOW_MINUTES) -> QuotaReadResult:
+    snapshots: list[QuotaSnapshot] = []
+    errors: list[str] = []
+    try:
+        with path.open("r", encoding="utf-8", errors="ignore") as handle:
+            for line_number, line in enumerate(handle, start=1):
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(record, Mapping):
+                    continue
+                snapshot, item_errors = snapshot_from_mapping(
+                    record,
+                    source=f"{path}:{line_number}",
+                    target_window_minutes=target_window_minutes,
+                )
+                errors.extend(item_errors)
+                if snapshot is not None:
+                    snapshots.append(snapshot)
+    except OSError as exc:
+        return QuotaReadResult(None, errors=(f"session log unreadable: {path}: {exc}",))
+    if not snapshots:
+        return QuotaReadResult(None, errors=tuple(errors))
+    return QuotaReadResult(max(snapshots, key=snapshot_sort_key), errors=tuple(errors))
+
+
+def find_session_logs(root: Path, *, max_files: int) -> list[Path]:
+    def mtime(path: Path) -> float:
+        try:
+            return path.stat().st_mtime
+        except OSError:
+            return 0.0
+
+    try:
+        paths = [path for path in root.glob(f"**/{CODEX_SESSION_PATTERN}") if path.is_file()]
+    except OSError:
+        return []
+    paths.sort(key=mtime, reverse=True)
+    return paths[:max_files]
+
+
+def load_quota_from_sessions(
+    *,
+    session_root: Path,
+    session_logs: Sequence[Path] = (),
+    max_session_files: int = 200,
+    target_window_minutes: int = DEFAULT_WEEKLY_WINDOW_MINUTES,
+) -> QuotaReadResult:
+    paths = list(session_logs)
+    if not paths:
+        if not session_root.exists():
+            return QuotaReadResult(None, errors=(f"Codex session root does not exist: {session_root}",))
+        paths = find_session_logs(session_root, max_files=max_session_files)
+    if not paths:
+        return QuotaReadResult(None, errors=("no Codex session logs found",))
+
+    snapshots: list[QuotaSnapshot] = []
+    errors: list[str] = []
+    for path in paths:
+        result = scan_session_log(path, target_window_minutes=target_window_minutes)
+        errors.extend(result.errors)
+        if result.snapshot is not None:
+            snapshots.append(result.snapshot)
+    if snapshots:
+        return QuotaReadResult(max(snapshots, key=snapshot_sort_key), errors=tuple(errors))
+    errors.append("no weekly quota telemetry found in Codex session logs")
+    return QuotaReadResult(None, errors=tuple(errors))
+
+
+def quota_status(
+    snapshot: QuotaSnapshot | None,
+    *,
+    now: datetime,
+    threshold_remaining_percent: float,
+    errors: Sequence[str] = (),
+) -> JsonObject:
+    base: JsonObject = {
+        "thresholdRemainingPercent": threshold_remaining_percent,
+        "errors": list(errors),
+    }
+    if snapshot is None:
+        return {
+            **base,
+            "state": "UNKNOWN_QUOTA",
+            "effectiveRemainingPercent": None,
+            "reason": "weekly quota telemetry is missing or malformed",
+            "source": None,
+        }
+
+    observed_remaining = snapshot.remaining_percent
+    observed_used = snapshot.used_percent
+    reset_elapsed = snapshot.reset_at is not None and now >= snapshot.reset_at
+    if reset_elapsed:
+        state = "RESET_ELAPSED"
+        effective_remaining = 100.0
+        effective_used = 0.0
+        reason = "weekly quota reset time has elapsed; suppressed jobs are eligible again"
+    elif observed_remaining is None:
+        state = "UNKNOWN_QUOTA"
+        effective_remaining = None
+        effective_used = None
+        reason = "weekly quota remaining percent is unavailable"
+    elif observed_remaining < threshold_remaining_percent:
+        state = "LOW_QUOTA"
+        effective_remaining = observed_remaining
+        effective_used = observed_used
+        reason = "weekly quota remaining percent is below threshold"
+    else:
+        state = "HEALTHY_QUOTA"
+        effective_remaining = observed_remaining
+        effective_used = observed_used
+        reason = "weekly quota remaining percent is at or above threshold"
+
+    return {
+        **base,
+        "state": state,
+        "reason": reason,
+        "source": snapshot.source,
+        "observedAt": format_timestamp(snapshot.observed_at),
+        "resetAt": format_timestamp(snapshot.reset_at),
+        "resetElapsed": reset_elapsed,
+        "windowMinutes": snapshot.window_minutes,
+        "observedUsedPercent": observed_used,
+        "observedRemainingPercent": observed_remaining,
+        "effectiveUsedPercent": effective_used,
+        "effectiveRemainingPercent": effective_remaining,
+    }
+
+
+def is_codex_job(spec: Mapping[str, Any]) -> bool:
+    return str(spec.get("provider") or "").strip() == CODEX_PROVIDER
+
+
+def is_protected_codex_job(
+    job_id: str,
+    spec: Mapping[str, Any],
+    *,
+    reserved_job_ids: set[str],
+) -> tuple[bool, str | None]:
+    if not is_codex_job(spec):
+        return False, None
+    criticality = str(spec.get("criticality") or "").strip().upper()
+    if criticality == "P0":
+        return True, "criticality:P0"
+    if job_id in reserved_job_ids:
+        return True, "reserved_codex_job_id"
+    return False, None
+
+
+def evaluate_budget(
+    expected_jobs: Mapping[str, Mapping[str, Any]],
+    quota: QuotaReadResult,
+    *,
+    now: datetime,
+    threshold_remaining_percent: float = DEFAULT_REMAINING_THRESHOLD_PERCENT,
+    reserved_job_ids: set[str] | None = None,
+) -> JsonObject:
+    reserved = set(DEFAULT_RESERVED_CODEX_JOB_IDS if reserved_job_ids is None else reserved_job_ids)
+    quota_info = quota_status(
+        quota.snapshot,
+        now=now,
+        threshold_remaining_percent=threshold_remaining_percent,
+        errors=quota.errors,
+    )
+    suppress_non_p0 = quota_info["state"] in {"LOW_QUOTA", "UNKNOWN_QUOTA"}
+
+    decisions: list[JsonObject] = []
+    for job_id, spec in sorted(expected_jobs.items()):
+        codex_job = is_codex_job(spec)
+        protected, protected_by = is_protected_codex_job(job_id, spec, reserved_job_ids=reserved)
+        criticality = str(spec.get("criticality") or "").strip() or None
+        if not codex_job:
+            decision = "ALLOW"
+            reason = "not_codex_provider"
+        elif protected:
+            decision = "ALLOW"
+            reason = protected_by or "protected_codex_job"
+        elif suppress_non_p0:
+            decision = "SUPPRESS"
+            reason = quota_info["state"].lower()
+        else:
+            decision = "ALLOW"
+            reason = quota_info["state"].lower()
+        decisions.append(
+            {
+                "id": job_id,
+                "job": spec.get("job"),
+                "provider": spec.get("provider"),
+                "model": spec.get("model"),
+                "criticality": criticality,
+                "codex": codex_job,
+                "protected": protected,
+                "protectedBy": protected_by,
+                "decision": decision,
+                "reason": reason,
+            }
+        )
+
+    suppressed = [item for item in decisions if item["decision"] == "SUPPRESS"]
+    codex_jobs = [item for item in decisions if item["codex"]]
+    protected_codex = [item for item in codex_jobs if item["protected"]]
+    status = "ALLOW_ALL"
+    if quota_info["state"] == "UNKNOWN_QUOTA":
+        status = "UNKNOWN_QUOTA"
+    elif suppressed:
+        status = "SUPPRESSING"
+
+    return {
+        "ok": True,
+        "status": status,
+        "now": format_timestamp(now),
+        "dispatchPolicy": "suppress_non_p0_codex" if suppress_non_p0 else "allow_all",
+        "quota": quota_info,
+        "summary": {
+            "totalJobs": len(decisions),
+            "codexJobs": len(codex_jobs),
+            "protectedCodexJobs": len(protected_codex),
+            "nonProtectedCodexJobs": len(codex_jobs) - len(protected_codex),
+            "allowedCount": len(decisions) - len(suppressed),
+            "suppressedCount": len(suppressed),
+            "suppressedJobIds": [item["id"] for item in suppressed],
+        },
+        "decisions": decisions,
+    }
+
+
+def parse_reserved_ids(values: Sequence[str]) -> set[str]:
+    if not values:
+        return set(DEFAULT_RESERVED_CODEX_JOB_IDS)
+    result: set[str] = set()
+    for value in values:
+        for item in value.split(","):
+            normalized = item.strip()
+            if normalized:
+                result.add(normalized)
+    return result
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY)
+    parser.add_argument("--quota-json", type=Path, help="redacted quota JSON fixture/export")
+    parser.add_argument(
+        "--session-root",
+        type=Path,
+        default=DEFAULT_SESSION_ROOT,
+        help="Codex session root to scan when --quota-json is not provided",
+    )
+    parser.add_argument("--session-log", type=Path, action="append", default=[], help="specific Codex session JSONL file to scan")
+    parser.add_argument("--max-session-files", type=int, default=200)
+    parser.add_argument("--window-minutes", type=int, default=DEFAULT_WEEKLY_WINDOW_MINUTES)
+    parser.add_argument("--threshold-remaining-percent", type=float, default=DEFAULT_REMAINING_THRESHOLD_PERCENT)
+    parser.add_argument("--now", help="UTC timestamp override for deterministic tests")
+    parser.add_argument("--json", action="store_true", help="print machine-readable JSON; accepted for checker parity")
+    parser.add_argument(
+        "--reserve-job-id",
+        action="append",
+        default=[],
+        help="protected Codex job id; comma-separated values accepted; overrides defaults when supplied",
+    )
+    parser.add_argument("--job-id", help="only print the decision for one job id")
+    parser.add_argument("--strict", action="store_true", help="exit nonzero if the selected scope contains a suppression")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    now = parse_timestamp(args.now) if args.now else datetime.now(timezone.utc)
+    if now is None:
+        print(json.dumps({"ok": False, "error": f"invalid --now timestamp: {args.now!r}"}, sort_keys=True), file=sys.stderr)
+        return 2
+    expected = check_cron_registry.parse_registry(args.registry)
+    quota = (
+        load_quota_json(args.quota_json, target_window_minutes=args.window_minutes)
+        if args.quota_json is not None
+        else load_quota_from_sessions(
+            session_root=args.session_root,
+            session_logs=args.session_log,
+            max_session_files=max(1, args.max_session_files),
+            target_window_minutes=args.window_minutes,
+        )
+    )
+    result = evaluate_budget(
+        expected,
+        quota,
+        now=now,
+        threshold_remaining_percent=args.threshold_remaining_percent,
+        reserved_job_ids=parse_reserved_ids(args.reserve_job_id),
+    )
+    if args.job_id:
+        decisions = [item for item in result["decisions"] if item["id"] == args.job_id]
+        result = {**result, "decisions": decisions, "selectedJobId": args.job_id}
+        if not decisions:
+            result["ok"] = False
+            result["status"] = "UNKNOWN_JOB"
+
+    print(json.dumps(result, indent=2, sort_keys=True, ensure_ascii=True))
+    if args.strict:
+        if result.get("status") == "UNKNOWN_JOB":
+            return 2
+        if any(item.get("decision") == "SUPPRESS" for item in result.get("decisions", [])):
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_codex_quota_budget.py
+++ b/scripts/check_codex_quota_budget.py
@@ -72,6 +72,8 @@ class QuotaReadResult:
 def parse_timestamp(value: Any) -> datetime | None:
     if value is None:
         return None
+    if isinstance(value, bool):
+        return None
     if isinstance(value, (int, float)) and math.isfinite(float(value)):
         try:
             return datetime.fromtimestamp(float(value), timezone.utc)
@@ -104,6 +106,8 @@ def read_number(mapping: Mapping[str, Any], fields: Sequence[str]) -> tuple[floa
         if field not in mapping:
             continue
         value = mapping.get(field)
+        if isinstance(value, bool):
+            return None, f"{field} is not numeric: {value!r}"
         try:
             number = float(value)
         except (TypeError, ValueError):

--- a/scripts/test_check_codex_quota_budget.py
+++ b/scripts/test_check_codex_quota_budget.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import check_codex_quota_budget as guard
+
+
+NOW = datetime(2026, 6, 11, 12, 0, tzinfo=timezone.utc)
+RESET_FUTURE = datetime(2026, 6, 12, 12, 0, tzinfo=timezone.utc)
+RESET_PAST = datetime(2026, 6, 10, 12, 0, tzinfo=timezone.utc)
+
+
+def write_registry(path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "# Test cron registry",
+                "",
+                "## Expected recurring cron jobs",
+                "",
+                "| Job | ID | Schedule | Delivery | Provider | Model | Workdir | Repeat | Criticality | Purpose |",
+                "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+                (
+                    "| Screeps autonomous continuation worker | `f66ed36d7be0` | `8,28,48 * * * *` | "
+                    "`discord:#task-queue` | `openai-codex` | `gpt-5.5` | `/root/screeps` | "
+                    "`high-horizon` | P0 | Dispatcher/reconciler for safe work lanes. |"
+                ),
+                (
+                    "| Screeps runtime room alert text check | `1df5ef0c3835` | `1,16,31,46 * * * *` | "
+                    "`discord:1497588512436785284` | `openai-codex` | `gpt-5.5` | `-` | "
+                    "`forever` | P0 | Runtime alert/tactical response. |"
+                ),
+                (
+                    "| Routine Codex maintenance lane | `routine-codex` | `0 * * * *` | `discord:#task-queue` | "
+                    "`openai-codex` | `gpt-5.5` | `-` | `forever` | P1 | Non-P0 Codex work. |"
+                ),
+                (
+                    "| DeepSeek fanout reporter | `deepseek-report` | `30 * * * *` | `discord:#dev-log` | "
+                    "`deepseek` | `deepseek-v4-flash` | `-` | `forever` | P1 | Non-Codex reporting. |"
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def expected_jobs() -> dict[str, dict[str, str | None]]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        registry = Path(tmpdir) / "registry.md"
+        write_registry(registry)
+        return guard.check_cron_registry.parse_registry(registry)
+
+
+def quota_from_payload(used_percent: float, reset_at: datetime) -> guard.QuotaReadResult:
+    payload = {
+        "timestamp": NOW.isoformat().replace("+00:00", "Z"),
+        "payload": {
+            "type": "token_count",
+            "rate_limits": {
+                "primary": {
+                    "used_percent": 1.0,
+                    "window_minutes": 300,
+                    "resets_at": int(RESET_FUTURE.timestamp()),
+                },
+                "secondary": {
+                    "used_percent": used_percent,
+                    "window_minutes": guard.DEFAULT_WEEKLY_WINDOW_MINUTES,
+                    "resets_at": int(reset_at.timestamp()),
+                },
+            },
+        },
+    }
+    snapshot, errors = guard.snapshot_from_mapping(payload, source="fixture")
+    return guard.QuotaReadResult(snapshot, errors=errors)
+
+
+class CodexQuotaBudgetGuardTests(unittest.TestCase):
+    def test_healthy_quota_allows_all_jobs(self) -> None:
+        result = guard.evaluate_budget(expected_jobs(), quota_from_payload(used_percent=50.0, reset_at=RESET_FUTURE), now=NOW)
+
+        self.assertEqual(result["status"], "ALLOW_ALL", result)
+        self.assertEqual(result["quota"]["state"], "HEALTHY_QUOTA")
+        self.assertEqual(result["summary"]["suppressedCount"], 0)
+        self.assertTrue(all(item["decision"] == "ALLOW" for item in result["decisions"]))
+
+    def test_low_quota_allows_p0_and_suppresses_non_p0_codex(self) -> None:
+        result = guard.evaluate_budget(expected_jobs(), quota_from_payload(used_percent=93.0, reset_at=RESET_FUTURE), now=NOW)
+        decisions = {item["id"]: item for item in result["decisions"]}
+
+        self.assertEqual(result["status"], "SUPPRESSING", result)
+        self.assertEqual(result["quota"]["state"], "LOW_QUOTA")
+        self.assertEqual(decisions["f66ed36d7be0"]["decision"], "ALLOW")
+        self.assertEqual(decisions["1df5ef0c3835"]["decision"], "ALLOW")
+        self.assertEqual(decisions["routine-codex"]["decision"], "SUPPRESS")
+        self.assertEqual(decisions["routine-codex"]["reason"], "low_quota")
+        self.assertEqual(decisions["deepseek-report"]["decision"], "ALLOW")
+        self.assertEqual(result["summary"]["suppressedJobIds"], ["routine-codex"])
+
+    def test_reset_time_in_past_self_heals_stale_low_quota(self) -> None:
+        result = guard.evaluate_budget(expected_jobs(), quota_from_payload(used_percent=99.0, reset_at=RESET_PAST), now=NOW)
+
+        self.assertEqual(result["status"], "ALLOW_ALL", result)
+        self.assertEqual(result["quota"]["state"], "RESET_ELAPSED")
+        self.assertTrue(result["quota"]["resetElapsed"])
+        self.assertEqual(result["quota"]["effectiveRemainingPercent"], 100.0)
+        self.assertEqual(result["summary"]["suppressedCount"], 0)
+
+    def test_missing_quota_data_fails_safe_with_clear_report(self) -> None:
+        quota = guard.QuotaReadResult(None, errors=("no weekly quota telemetry found",))
+        result = guard.evaluate_budget(expected_jobs(), quota, now=NOW)
+        decisions = {item["id"]: item for item in result["decisions"]}
+
+        self.assertEqual(result["status"], "UNKNOWN_QUOTA", result)
+        self.assertEqual(result["quota"]["state"], "UNKNOWN_QUOTA")
+        self.assertIn("no weekly quota telemetry found", result["quota"]["errors"])
+        self.assertEqual(decisions["f66ed36d7be0"]["decision"], "ALLOW")
+        self.assertEqual(decisions["routine-codex"]["decision"], "SUPPRESS")
+
+    def test_malformed_quota_json_fails_safe_with_clear_report(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            quota_path = Path(tmpdir) / "quota.json"
+            quota_path.write_text("{not-json", encoding="utf-8")
+
+            quota = guard.load_quota_json(quota_path)
+            result = guard.evaluate_budget(expected_jobs(), quota, now=NOW)
+
+        self.assertEqual(result["status"], "UNKNOWN_QUOTA", result)
+        self.assertTrue(any("quota JSON malformed" in error for error in result["quota"]["errors"]), result)
+        self.assertEqual(result["summary"]["suppressedJobIds"], ["routine-codex"])
+
+    def test_cross_cron_aggregate_decisions_are_emitted(self) -> None:
+        result = guard.evaluate_budget(expected_jobs(), quota_from_payload(used_percent=91.0, reset_at=RESET_FUTURE), now=NOW)
+
+        self.assertEqual(result["summary"]["totalJobs"], 4)
+        self.assertEqual(result["summary"]["codexJobs"], 3)
+        self.assertEqual(result["summary"]["protectedCodexJobs"], 2)
+        self.assertEqual(result["summary"]["nonProtectedCodexJobs"], 1)
+        self.assertEqual([item["id"] for item in result["decisions"]], [
+            "1df5ef0c3835",
+            "deepseek-report",
+            "f66ed36d7be0",
+            "routine-codex",
+        ])
+
+    def test_session_log_loader_uses_latest_weekly_quota_sample(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session_log = Path(tmpdir) / "rollout-test.jsonl"
+            records = [
+                {
+                    "timestamp": "2026-06-11T11:00:00Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "rate_limits": {
+                            "secondary": {
+                                "used_percent": 30.0,
+                                "window_minutes": guard.DEFAULT_WEEKLY_WINDOW_MINUTES,
+                                "resets_at": int(RESET_FUTURE.timestamp()),
+                            }
+                        },
+                    },
+                },
+                {
+                    "timestamp": "2026-06-11T11:30:00Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "rate_limits": {
+                            "secondary": {
+                                "used_percent": 92.0,
+                                "window_minutes": guard.DEFAULT_WEEKLY_WINDOW_MINUTES,
+                                "resets_at": int(RESET_FUTURE.timestamp()),
+                            }
+                        },
+                    },
+                },
+            ]
+            session_log.write_text("\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n", encoding="utf-8")
+
+            quota = guard.scan_session_log(session_log)
+            result = guard.evaluate_budget(expected_jobs(), quota, now=NOW)
+
+        self.assertIsNotNone(quota.snapshot)
+        self.assertEqual(quota.snapshot.remaining_percent, 8.0)
+        self.assertEqual(result["quota"]["state"], "LOW_QUOTA")
+        self.assertEqual(result["summary"]["suppressedJobIds"], ["routine-codex"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_codex_quota_budget.py
+++ b/scripts/test_check_codex_quota_budget.py
@@ -86,12 +86,69 @@ def quota_from_payload(used_percent: float, reset_at: datetime) -> guard.QuotaRe
     return guard.QuotaReadResult(snapshot, errors=errors)
 
 
+def quota_from_weekly_candidate(candidate: dict[str, object]) -> guard.QuotaReadResult:
+    payload = {
+        "timestamp": NOW.isoformat().replace("+00:00", "Z"),
+        "payload": {
+            "type": "token_count",
+            "rate_limits": {
+                "secondary": {
+                    "window_minutes": guard.DEFAULT_WEEKLY_WINDOW_MINUTES,
+                    **candidate,
+                },
+            },
+        },
+    }
+    snapshot, errors = guard.snapshot_from_mapping(payload, source="fixture")
+    return guard.QuotaReadResult(snapshot, errors=errors)
+
+
 class CodexQuotaBudgetGuardTests(unittest.TestCase):
+    def assert_unknown_quota_suppresses_non_p0(self, quota: guard.QuotaReadResult) -> None:
+        result = guard.evaluate_budget(expected_jobs(), quota, now=NOW)
+        decisions = {item["id"]: item for item in result["decisions"]}
+
+        self.assertEqual(result["status"], "UNKNOWN_QUOTA", result)
+        self.assertEqual(result["quota"]["state"], "UNKNOWN_QUOTA")
+        self.assertEqual(decisions["f66ed36d7be0"]["decision"], "ALLOW")
+        self.assertEqual(decisions["1df5ef0c3835"]["decision"], "ALLOW")
+        self.assertEqual(decisions["routine-codex"]["decision"], "SUPPRESS")
+        self.assertEqual(decisions["deepseek-report"]["decision"], "ALLOW")
+        self.assertEqual(result["summary"]["suppressedJobIds"], ["routine-codex"])
+
     def test_parse_timestamp_rejects_out_of_range_numeric_epoch(self) -> None:
         self.assertIsNone(guard.parse_timestamp(10**20))
 
     def test_parse_timestamp_rejects_out_of_range_numeric_string_epoch(self) -> None:
         self.assertIsNone(guard.parse_timestamp(str(10**20)))
+
+    def test_boolean_reset_timestamp_fails_safe(self) -> None:
+        for field in ("resets_at", "reset_at"):
+            with self.subTest(field=field):
+                quota = quota_from_weekly_candidate(
+                    {
+                        "used_percent": 50.0,
+                        field: False,
+                    }
+                )
+
+                self.assertIsNone(quota.snapshot)
+                self.assertTrue(any(f"{field} is not a timestamp: False" in error for error in quota.errors), quota)
+                self.assert_unknown_quota_suppresses_non_p0(quota)
+
+    def test_boolean_percent_fails_safe(self) -> None:
+        for field in ("used_percent", "remaining_percent"):
+            with self.subTest(field=field):
+                quota = quota_from_weekly_candidate(
+                    {
+                        field: False,
+                        "resets_at": int(RESET_FUTURE.timestamp()),
+                    }
+                )
+
+                self.assertIsNone(quota.snapshot)
+                self.assertTrue(any(f"{field} is not numeric: False" in error for error in quota.errors), quota)
+                self.assert_unknown_quota_suppresses_non_p0(quota)
 
     def test_healthy_quota_allows_all_jobs(self) -> None:
         result = guard.evaluate_budget(expected_jobs(), quota_from_payload(used_percent=50.0, reset_at=RESET_FUTURE), now=NOW)

--- a/scripts/test_check_codex_quota_budget.py
+++ b/scripts/test_check_codex_quota_budget.py
@@ -87,6 +87,12 @@ def quota_from_payload(used_percent: float, reset_at: datetime) -> guard.QuotaRe
 
 
 class CodexQuotaBudgetGuardTests(unittest.TestCase):
+    def test_parse_timestamp_rejects_out_of_range_numeric_epoch(self) -> None:
+        self.assertIsNone(guard.parse_timestamp(10**20))
+
+    def test_parse_timestamp_rejects_out_of_range_numeric_string_epoch(self) -> None:
+        self.assertIsNone(guard.parse_timestamp(str(10**20)))
+
     def test_healthy_quota_allows_all_jobs(self) -> None:
         result = guard.evaluate_budget(expected_jobs(), quota_from_payload(used_percent=50.0, reset_at=RESET_FUTURE), now=NOW)
 


### PR DESCRIPTION
## Linked issues

Intentional PR-body closing linkage:
- Fixes #1783

Related / non-closing linkage:
- None.

## Domain / Kind

- Domain: Agent OS
- Kind: ops

## Summary

- Add `scripts/check_codex_quota_budget.py` to read the documented cron registry plus recent Codex session/quota exports and decide whether non-P0 Codex jobs should be suppressed.
- Protect reserved P0 Codex jobs (`f66ed36d7be0`, `1df5ef0c3835`, `aed8362e4501`) and registry jobs marked `criticality: p0` from quota suppression.
- Add unit coverage for low-quota suppression, stale-reset handling, unknown-quota behavior, and registry-based P0 protection.
- Document the quota-budget guard in `docs/ops/cron-and-route-registry.md`.

## Verification

- [x] Local check: `python3 -m py_compile scripts/check_codex_quota_budget.py scripts/test_check_codex_quota_budget.py scripts/check_cron_registry.py` passed.
- [x] Local check: `python3 -m unittest scripts/test_check_codex_quota_budget.py` passed (9 tests).
- [x] Local check: `python3 scripts/check_codex_quota_budget.py --json` passed; live result `status=ALLOW_ALL`, `quota_state=HEALTHY_QUOTA`, `suppressed=[]`.
- [x] Local check: `git diff --check` passed.
- [x] GitHub Project issue/PR fields are current (`Status`, `Evidence`, `Next action`; plus `Blocked by` when blocked).
- [ ] Automated review has no blocking findings and review threads are resolved/outdated/non-blocking: CodeRabbit critical timestamp-overflow thread was fixed in commit `f80ca4a1`; fresh CodeRabbit re-review/checks are pending. Gemini exact-head review on the previous head reported no feedback; re-query final review threads before merge.
- [x] QA gate: controller verification passed for scripts/docs scope; GitHub checks and automated review gate still apply before merge.
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate

- [x] Task type: ops/code guard for Agent OS scheduling.
- [x] Expected observable outcome / named deliverable: Codex quota-budget checker script plus tests and cron-registry documentation.
- [x] Non-goals / accepted substitutes: no live cron prompt mutation, no quota service deployment, no gameplay/runtime bot behavior change.
- [x] Verification evidence required before Done: py_compile, focused unittest, live checker JSON smoke, diff-check, PR checks, automated review gate, Project fields current.
- [x] Project Evidence / Next action / Blocked by: issue and PR Project items record PR, commit `f80ca4a1`, controller checks, and review gate; no blocker.
- [x] Post-merge/deploy/runtime proof: not applicable; this scripts/docs guard has no official MMO runtime deployment surface.
- [x] Named deliverable proof: `scripts/check_codex_quota_budget.py`, `scripts/test_check_codex_quota_budget.py`, and documented cron-registry contract are included in commit `f80ca4a1`.

## Issue closure gate

For every issue linked above in the PR body with a closing keyword:

- [x] #1783: Codex quota-budget checker, focused unit tests, live JSON smoke, and registry docs are included at commit `f80ca4a1`; the issue can close when this PR merges after normal review gates.
- [x] No closed issue still needs post-merge validation, runtime/process proof, owner action, successor/follow-up work, partial-fix completion, or any other blocker.

## Runtime / deployment impact

- [x] No gameplay/runtime/deployment impact.
- [ ] Gameplay/runtime/deployment impact; Deployment Floor evidence or HELD blocker is recorded.

## Notes

- Review/merge gates: wait at least 15 minutes after PR creation, require green checks, and keep linked GitHub issue/PR/Project state current until merged or explicitly closed.
