### PR TITLE
fix: allow construction during CPU recovery over-limit ticks

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1081,7 +1081,26 @@ function hasUsedOverLimitPressure(budget) {
   return budget.reasons.includes("usedOverLimit");
 }
 function hasHardConstructionCpuPressure(budget) {
-  return budget.lowCpuLimit || budget.critical || budget.reasons.includes("lowBucket") || budget.reasons.includes("criticalBucket") || hasUsedOverLimitPressure(budget);
+  if (budget.lowCpuLimit || budget.critical || budget.reasons.includes("lowBucket") || budget.reasons.includes("criticalBucket")) {
+    return true;
+  }
+  if (!hasUsedOverLimitPressure(budget)) {
+    return false;
+  }
+  return !hasConstructionRecoveryBucketHeadroom(budget.sample);
+}
+function hasConstructionRecoveryBucketHeadroom(sample) {
+  const projectedBucket = getProjectedPostTickBucket(sample);
+  if (projectedBucket === void 0) {
+    return false;
+  }
+  return projectedBucket >= LOW_CPU_BUCKET_THRESHOLD && projectedBucket <= LOW_CPU_BUCKET_THRESHOLD + getCpuBucketRecoveryHeadroom(sample.limit);
+}
+function getProjectedPostTickBucket(sample) {
+  if (sample.bucket === void 0 || sample.used === void 0 || sample.limit === void 0 || sample.limit <= 0) {
+    return void 0;
+  }
+  return sample.bucket - Math.max(0, sample.used - sample.limit);
 }
 function hasLowBucketRecoveryPressure(sample) {
   if (sample.bucket === void 0 || sample.bucket < LOW_CPU_BUCKET_THRESHOLD) {

--- a/prod/src/runtime/cpuBudget.ts
+++ b/prod/src/runtime/cpuBudget.ts
@@ -238,13 +238,45 @@ function hasUsedOverLimitPressure(budget: RuntimeCpuBudget): boolean {
 }
 
 function hasHardConstructionCpuPressure(budget: RuntimeCpuBudget): boolean {
-  return (
+  if (
     budget.lowCpuLimit ||
     budget.critical ||
     budget.reasons.includes('lowBucket') ||
-    budget.reasons.includes('criticalBucket') ||
-    hasUsedOverLimitPressure(budget)
+    budget.reasons.includes('criticalBucket')
+  ) {
+    return true;
+  }
+
+  if (!hasUsedOverLimitPressure(budget)) {
+    return false;
+  }
+
+  return !hasConstructionRecoveryBucketHeadroom(budget.sample);
+}
+
+function hasConstructionRecoveryBucketHeadroom(sample: RuntimeCpuSample): boolean {
+  const projectedBucket = getProjectedPostTickBucket(sample);
+  if (projectedBucket === undefined) {
+    return false;
+  }
+
+  return (
+    projectedBucket >= LOW_CPU_BUCKET_THRESHOLD &&
+    projectedBucket <= LOW_CPU_BUCKET_THRESHOLD + getCpuBucketRecoveryHeadroom(sample.limit)
   );
+}
+
+function getProjectedPostTickBucket(sample: RuntimeCpuSample): number | undefined {
+  if (
+    sample.bucket === undefined ||
+    sample.used === undefined ||
+    sample.limit === undefined ||
+    sample.limit <= 0
+  ) {
+    return undefined;
+  }
+
+  return sample.bucket - Math.max(0, sample.used - sample.limit);
 }
 
 function hasLowBucketRecoveryPressure(sample: RuntimeCpuSample): boolean {

--- a/prod/test/cpuBudget.test.ts
+++ b/prod/test/cpuBudget.test.ts
@@ -202,7 +202,7 @@ describe('runtime CPU budget policy', () => {
     }
   });
 
-  it('treats postdeploy over-limit recovery buckets as low-bucket recovery pressure', () => {
+  it('keeps construction enabled during postdeploy over-limit recovery buckets', () => {
     const budgets = [
       buildRuntimeCpuBudget({
         tick: 1781934,
@@ -259,8 +259,49 @@ describe('runtime CPU budget policy', () => {
       expect(shouldRunOptionalCpuWork(budget, 'economy-global-optional')).toBe(false);
       expect(shouldRunOptionalCpuRoomWork(budget, 'E29N55')).toBe(false);
       expect(shouldShedNonessentialCpuWork(budget)).toBe(true);
-      expect(shouldRunConstructionCpuWork(budget)).toBe(false);
+      expect(shouldRunConstructionCpuWork(budget)).toBe(true);
     }
+  });
+
+  it('keeps construction enabled when over-limit CPU projects into the recovery corridor', () => {
+    const budget = buildRuntimeCpuBudget({
+      tick: 2039860,
+      used: 78.23037710000062,
+      limit: 70,
+      bucket: 1_842,
+      tickLimit: 500
+    });
+
+    expect(budget).toMatchObject({
+      pressure: 'degraded',
+      degraded: true,
+      critical: false,
+      lowCpuLimit: false,
+      reasons: ['usedOverLimit']
+    });
+    expect(shouldRunOptionalCpuWork(budget, 'economy-global-optional')).toBe(false);
+    expect(shouldRunOptionalCpuRoomWork(budget, 'E29N55')).toBe(false);
+    expect(shouldShedNonessentialCpuWork(budget)).toBe(true);
+    expect(shouldRunConstructionCpuWork(budget)).toBe(true);
+  });
+
+  it('keeps construction guarded when over-limit CPU would drain below the low-bucket floor', () => {
+    const budget = buildRuntimeCpuBudget({
+      tick: 2039861,
+      used: 90,
+      limit: 70,
+      bucket: 1_010,
+      tickLimit: 500
+    });
+
+    expect(budget).toMatchObject({
+      pressure: 'degraded',
+      degraded: true,
+      critical: false,
+      lowCpuLimit: false,
+      reasons: ['lowBucketRecovery', 'usedOverLimit']
+    });
+    expect(shouldRunConstructionCpuWork(budget)).toBe(false);
   });
 
   it('resumes optional work only after the widened low-bucket recovery boundary', () => {

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -2121,7 +2121,7 @@ describe('runEconomy', () => {
     expect(worker.moveTo).not.toHaveBeenCalled();
   });
 
-  it('attempts E29N55 source-container construction during safe low-bucket recovery', () => {
+  it('attempts E29N55 source-container construction during postdeploy over-limit recovery', () => {
     (globalThis as unknown as {
       FIND_MY_STRUCTURES: number;
       FIND_MY_CONSTRUCTION_SITES: number;
@@ -2223,9 +2223,9 @@ describe('runEconomy', () => {
       spawns: { Spawn2: spawn },
       creeps: workers,
       cpu: {
-        getUsed: jest.fn().mockReturnValue(8),
+        getUsed: jest.fn().mockReturnValue(78.23037710000062),
         limit: 70,
-        bucket: 1_840,
+        bucket: 1_842,
         tickLimit: 500
       } as unknown as CPU,
       map: {


### PR DESCRIPTION
## Summary
- Keeps construction-site CPU work enabled when the only hard pressure is an over-limit tick whose projected bucket remains inside the low-bucket recovery corridor.
- Preserves construction suppression for critical/low-bucket states and for over-limit ticks that would drain below the low-bucket floor.
- Adds CPU-budget/economy-loop coverage and regenerates `prod/dist/main.js`.

Tracking issue: 1781.

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` — 105 suites / 2378 tests passed
- `npm run build`

## Universal task Done gate
- [x] Task type: production-code hotfix for Territory/Economy construction CPU-gate behavior.
- [x] Expected observable outcome / named deliverable: construction CPU work is allowed during safe postdeploy over-limit recovery ticks while critical and low-bucket floors still suppress construction.
- [x] Non-goals / accepted substitutes: runtime MMO deployment and construction acceptance evidence stay on issue 1781 as the separate acceptance surface for this gameplay bottleneck.
- [x] Verification evidence required before Done: controller verification passed `git diff --check`, `npm run typecheck`, Jest 105 suites / 2378 tests, and `npm run build` on commit `291b2588`.
- [x] Project Evidence / Next action / Blocked by: Project update sets issue 1781 and this PR to In review with commit `291b2588`, verification evidence, exact-head CI and automated review gate as next controller actions, and no owner-side blocker.
- [x] Post-merge/deploy/runtime proof: runtime proof surface is issue 1781; fresh runtime-summary-console evidence must show constructionSiteCount greater than 0 or build progress before that issue reaches Done.
- [x] Named deliverable proof: commit `291b2588` changes `prod/src/runtime/cpuBudget.ts`, `prod/test/cpuBudget.test.ts`, `prod/test/economyLoop.test.ts`, and regenerated `prod/dist/main.js`.
