### PR TITLE
fix: allow safe construction seed during cpu recovery

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -14712,7 +14712,7 @@ function planConstructionForColony(colony, options = {}) {
     energyReserved: 0,
     placements: []
   };
-  if (rcl <= 0 || typeof room.createConstructionSite !== "function") {
+  if (rcl <= 0 || typeof room.createConstructionSite !== "function" || getMaxPlacementsPerRoom(options) <= 0) {
     return result;
   }
   const extensionBootstrapPriority = shouldPrioritizeExtensionBootstrapConstruction(
@@ -14728,33 +14728,33 @@ function planConstructionForColony(colony, options = {}) {
   const spawnPlacement = planSpawnIfMissing(colony);
   if (spawnPlacement) {
     recordPlacement(result, budgetState, "spawn", spawnPlacement.result, options, spawnPlacement.position);
-    if (spawnPlacement.result !== getOkCode5()) {
+    if (spawnPlacement.result !== getOkCode5() || hasReachedPlacementLimit(result, options)) {
       return result;
     }
   }
-  if (extensionBootstrapPriority && planBootstrapExtension(colony, result, budgetState, options) && options.respectRoomEnergyBuffer === true) {
+  if (extensionBootstrapPriority && planBootstrapExtension(colony, result, budgetState, options) && (options.respectRoomEnergyBuffer === true || hasReachedPlacementLimit(result, options))) {
     return result;
   }
   if (options.postClaimPriorityOrder === true) {
     planExtensions(colony, result, budgetState, options);
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
     planContainers(colony, result, budgetState, options);
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
     planRoads(colony, result, budgetState, options);
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
     planTowers(colony, result, budgetState, options);
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
     if (options.includePostClaimRamparts === true) {
       planRamparts(colony, result, budgetState, options);
-      if (hasBlockingPlacementFailure(result)) {
+      if (shouldStopConstructionPlanning(result, options)) {
         return result;
       }
     }
@@ -14762,16 +14762,16 @@ function planConstructionForColony(colony, options = {}) {
     return result;
   }
   let priorityTowerDefenseSiteState = shouldPrioritizeFirstTowerDefenseSiteBeforeRoutineConstruction(room, rcl, options) ? planPriorityTowerDefenseSiteIfNeeded(colony, result, budgetState, options, rcl) : "notNeeded";
-  if (hasBlockingPlacementFailure(result)) {
+  if (shouldStopConstructionPlanning(result, options)) {
     return result;
   }
   if (sourceLogisticsStarved) {
     planContainers(colony, result, budgetState, options, { includeStagingContainers: false });
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
     planRoads(colony, result, budgetState, buildSourceLogisticsStarvationRoadOptions(colony, options));
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
   }
@@ -14787,16 +14787,16 @@ function planConstructionForColony(colony, options = {}) {
     return result;
   }
   planExtensions(colony, result, budgetState, options);
-  if (hasBlockingPlacementFailure(result)) {
+  if (shouldStopConstructionPlanning(result, options)) {
     return result;
   }
   if (!sourceLogisticsStarved) {
     planContainers(colony, result, budgetState, options);
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
     planRoads(colony, result, budgetState, options);
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
   }
@@ -14808,24 +14808,27 @@ function planConstructionForColony(colony, options = {}) {
       options,
       rcl
     );
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
   }
   if (priorityTowerDefenseSiteState !== "blocked") {
     planBootstrapDefenseFloor(colony, result, budgetState, options);
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
   }
   if (options.includePostClaimRamparts === true) {
     planRamparts(colony, result, budgetState, options);
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
   }
   if (priorityTowerDefenseSiteState === "notNeeded") {
     planTowers(colony, result, budgetState, options);
+    if (shouldStopConstructionPlanning(result, options)) {
+      return result;
+    }
   }
   planStorage(colony, result, budgetState, options);
   return result;
@@ -14896,6 +14899,9 @@ function planExtensions(colony, result, budgetState, options) {
   const extensionResult = planExtensionConstruction(colony);
   if (extensionResult !== null) {
     recordPlacement(result, budgetState, "extension", extensionResult, options);
+    if (hasReachedPlacementLimit(result, options)) {
+      return;
+    }
   }
 }
 function planTowers(colony, result, budgetState, options) {
@@ -14944,6 +14950,9 @@ function planBootstrapDefenseFloor(colony, result, budgetState, options) {
     );
     if (placementResult === getOkCode5() || isFatalConstructionSiteResult3(placementResult)) {
       recordPlacement(result, budgetState, priority, placementResult, options, placement);
+      if (hasReachedPlacementLimit(result, options)) {
+        return;
+      }
     }
     if (placementResult !== getOkCode5()) {
       return;
@@ -14973,7 +14982,10 @@ function planRuntimeStrategyPrioritizedConstruction(colony, result, budgetState,
   }
   const report = buildRuntimeConstructionPriorityReport(colony, options.creeps, { strategyParameters });
   recordStrategyRegistryRuntimeUse(options, strategyEntry);
-  const priorities = runtimeConstructionPlannerPriorityOrder(report, { sourceLogisticsStarved });
+  const priorities = runtimeConstructionPlannerPriorityOrder(report, {
+    sourceLogisticsStarved,
+    includeDefaultPriorities: options.runtimeStrategyConstructionFallbackPriorities !== false
+  });
   if (priorities.length === 0) {
     return false;
   }
@@ -14988,7 +15000,7 @@ function planRuntimeStrategyPrioritizedConstruction(colony, result, budgetState,
       activePriorityTowerDefenseSiteState,
       rcl
     );
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return true;
     }
   }
@@ -15017,9 +15029,11 @@ function runtimeConstructionPlannerPriorityOrder(report, options = {}) {
       }
     }
   }
-  for (const priority of DEFAULT_ROUTINE_CONSTRUCTION_PRIORITIES) {
-    if (!shouldSkipRuntimeConstructionPriority(priority, options) && !priorities.includes(priority)) {
-      priorities.push(priority);
+  if (options.includeDefaultPriorities !== false) {
+    for (const priority of DEFAULT_ROUTINE_CONSTRUCTION_PRIORITIES) {
+      if (!shouldSkipRuntimeConstructionPriority(priority, options) && !priorities.includes(priority)) {
+        priorities.push(priority);
+      }
     }
   }
   return priorities;
@@ -15073,7 +15087,7 @@ function planRuntimeConstructionPlannerPriority(priority, colony, result, budget
         options,
         rcl
       );
-      if (hasBlockingPlacementFailure(result)) {
+      if (shouldStopConstructionPlanning(result, options)) {
         return priorityTowerDefenseSiteState;
       }
       if (priorityTowerDefenseSiteState === "notNeeded") {
@@ -15090,13 +15104,13 @@ function planRuntimeConstructionPlannerPriority(priority, colony, result, budget
           options,
           rcl
         );
-        if (hasBlockingPlacementFailure(result)) {
+        if (shouldStopConstructionPlanning(result, options)) {
           return priorityTowerDefenseSiteState;
         }
       }
       if (priorityTowerDefenseSiteState !== "blocked") {
         planBootstrapDefenseFloor(colony, result, budgetState, options);
-        if (hasBlockingPlacementFailure(result)) {
+        if (shouldStopConstructionPlanning(result, options)) {
           return priorityTowerDefenseSiteState;
         }
       }
@@ -15153,7 +15167,7 @@ function planRoads(colony, result, budgetState, options) {
   });
   for (const roadResult of roadResults) {
     recordPlacement(result, budgetState, "road", roadResult, options);
-    if (roadResult !== getOkCode5()) {
+    if (roadResult !== getOkCode5() || hasReachedPlacementLimit(result, options)) {
       return;
     }
   }
@@ -15175,7 +15189,7 @@ function planContainers(colony, result, budgetState, options, containerOptions =
   });
   for (const containerResult of containerResults) {
     recordPlacement(result, budgetState, "container", containerResult, options);
-    if (containerResult !== getOkCode5()) {
+    if (containerResult !== getOkCode5() || hasReachedPlacementLimit(result, options)) {
       return;
     }
     remainingContainerSitesThisTick -= 1;
@@ -15190,7 +15204,7 @@ function planContainers(colony, result, budgetState, options, containerOptions =
     });
     for (const stagingContainerResult of stagingContainerResults) {
       recordPlacement(result, budgetState, "container", stagingContainerResult, options);
-      if (stagingContainerResult !== getOkCode5()) {
+      if (stagingContainerResult !== getOkCode5() || hasReachedPlacementLimit(result, options)) {
         return;
       }
       remainingContainerSitesThisTick -= 1;
@@ -15268,6 +15282,26 @@ function recordPlacement(result, budgetState, priority, placementResult, options
 function hasBlockingPlacementFailure(result) {
   const lastPlacement = result.placements[result.placements.length - 1];
   return lastPlacement !== void 0 && lastPlacement.result !== getOkCode5();
+}
+function shouldStopConstructionPlanning(result, options) {
+  return hasBlockingPlacementFailure(result) || hasReachedPlacementLimit(result, options);
+}
+function hasReachedPlacementLimit(result, options) {
+  const maxPlacements = getMaxPlacementsPerRoom(options);
+  if (maxPlacements === Number.MAX_SAFE_INTEGER) {
+    return false;
+  }
+  return result.placements.filter((placement) => placement.result === getOkCode5()).length >= maxPlacements;
+}
+function getMaxPlacementsPerRoom(options) {
+  const value = options.maxPlacementsPerRoom;
+  if (value === void 0) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.floor(value));
 }
 function hasSpawnCoverage2(colony) {
   return hasOwnedSpawn(colony) || countPendingConstructionSites(colony.room, "spawn") > 0;
@@ -51655,8 +51689,10 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
             colony,
             creeps,
             options,
+            telemetryEvents,
             postClaimBootstrapFocusRoomName,
-            postClaimBootstrapRefresh2.deferred === true
+            postClaimBootstrapRefresh2.deferred === true,
+            selectConstructionCpuMode(roomCpuBudget)
           );
         }
         continue;
@@ -51690,8 +51726,10 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
         colony,
         creeps,
         options,
+        telemetryEvents,
         postClaimBootstrapFocusRoomName,
-        postClaimBootstrapRefresh.deferred === true
+        postClaimBootstrapRefresh.deferred === true,
+        selectConstructionCpuMode(roomCpuBudget)
       );
     }
     if (survivalAssessment.mode === "TERRITORY_READY" && shouldRunTerritoryPlanning(roomCpuBudget, runOptionalRoomWork)) {
@@ -51924,7 +51962,7 @@ function shouldRunShedCpuColonyPlanning(colony, roleCounts, survivalAssessment) 
   }
   return isColonyRoomThreatened(colony.room.name, Game.time);
 }
-function runClaimedRoomConstructionForCpuBudget(colony, creeps, options, postClaimBootstrapFocusRoomName, deferred) {
+function runClaimedRoomConstructionForCpuBudget(colony, creeps, options, telemetryEvents, postClaimBootstrapFocusRoomName, deferred, mode = "normal") {
   refreshPostClaimDefenseConstruction(colony, { focusRoomName: postClaimBootstrapFocusRoomName });
   const constructionOptions = {
     respectRoomEnergyBuffer: true,
@@ -51933,11 +51971,52 @@ function runClaimedRoomConstructionForCpuBudget(colony, creeps, options, postCla
     runtimeStrategyConstructionEnabled: options.runtimeStrategyConstructionEnabled,
     onStrategyRegistryRuntimeUse: options.onStrategyRegistryRuntimeUse
   };
+  const activeConstructionOptions = mode === "recoverySeed" ? buildCpuRecoveryConstructionSeedOptions(constructionOptions) : constructionOptions;
   if (deferred) {
-    planDeferredClaimedRoomCapacityConstruction(colony, constructionOptions);
+    const result2 = planDeferredClaimedRoomCapacityConstruction(colony, activeConstructionOptions);
+    recordRecoveryConstructionPlacementTelemetry(telemetryEvents, result2.placements, mode);
     return;
   }
-  planClaimedRoomConstruction(colony, constructionOptions);
+  const result = planClaimedRoomConstruction(colony, activeConstructionOptions);
+  recordRecoveryConstructionPlacementTelemetry(telemetryEvents, result.placements, mode);
+}
+function selectConstructionCpuMode(cpuBudget) {
+  return shouldShedNonessentialCpuWork(cpuBudget) && shouldRunConstructionCpuWork(cpuBudget) ? "recoverySeed" : "normal";
+}
+function buildCpuRecoveryConstructionSeedOptions(options) {
+  var _a2;
+  return {
+    ...options,
+    strategyRegistry: (_a2 = options.strategyRegistry) != null ? _a2 : DEFAULT_STRATEGY_REGISTRY,
+    runtimeStrategyConstructionEnabled: true,
+    runtimeStrategyConstructionFallbackPriorities: false,
+    includePostClaimRamparts: true,
+    maxPlacementsPerRoom: 1,
+    maxContainerSitesPerTick: 1,
+    maxPendingContainerSites: 1,
+    roadOptions: {
+      ...options.roadOptions,
+      maxSitesPerTick: 1,
+      maxTargetsPerTick: 1
+    }
+  };
+}
+function recordRecoveryConstructionPlacementTelemetry(telemetryEvents, placements, mode) {
+  if (mode !== "recoverySeed") {
+    return;
+  }
+  for (const placement of placements) {
+    telemetryEvents.push({
+      type: "constructionPlacement",
+      roomName: placement.roomName,
+      priority: placement.priority,
+      structureType: String(placement.structureType),
+      result: placement.result,
+      mode: "recoverySeed",
+      ...placement.x !== void 0 ? { x: placement.x } : {},
+      ...placement.y !== void 0 ? { y: placement.y } : {}
+    });
+  }
 }
 function isDowngradeGuardControllerCreep(creep) {
   var _a2, _b, _c;

--- a/prod/src/construction/planner.ts
+++ b/prod/src/construction/planner.ts
@@ -55,8 +55,10 @@ export interface ConstructionPlannerOptions {
   includePostClaimRamparts?: boolean;
   includeStorage?: boolean;
   postClaimPriorityOrder?: boolean;
+  maxPlacementsPerRoom?: number;
   strategyRegistry?: StrategyRegistryEntry[];
   runtimeStrategyConstructionEnabled?: boolean;
+  runtimeStrategyConstructionFallbackPriorities?: boolean;
   onStrategyRegistryRuntimeUse?: (entry: StrategyRegistryEntry) => void;
 }
 
@@ -219,7 +221,11 @@ export function planConstructionForColony(
     placements: []
   };
 
-  if (rcl <= 0 || typeof room.createConstructionSite !== 'function') {
+  if (
+    rcl <= 0 ||
+    typeof room.createConstructionSite !== 'function' ||
+    getMaxPlacementsPerRoom(options) <= 0
+  ) {
     return result;
   }
   const extensionBootstrapPriority = shouldPrioritizeExtensionBootstrapConstruction(
@@ -236,7 +242,7 @@ export function planConstructionForColony(
   const spawnPlacement = planSpawnIfMissing(colony);
   if (spawnPlacement) {
     recordPlacement(result, budgetState, 'spawn', spawnPlacement.result, options, spawnPlacement.position);
-    if (spawnPlacement.result !== getOkCode()) {
+    if (spawnPlacement.result !== getOkCode() || hasReachedPlacementLimit(result, options)) {
       return result;
     }
   }
@@ -244,35 +250,35 @@ export function planConstructionForColony(
   if (
     extensionBootstrapPriority &&
     planBootstrapExtension(colony, result, budgetState, options) &&
-    options.respectRoomEnergyBuffer === true
+    (options.respectRoomEnergyBuffer === true || hasReachedPlacementLimit(result, options))
   ) {
     return result;
   }
 
   if (options.postClaimPriorityOrder === true) {
     planExtensions(colony, result, budgetState, options);
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
 
     planContainers(colony, result, budgetState, options);
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
 
     planRoads(colony, result, budgetState, options);
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
 
     planTowers(colony, result, budgetState, options);
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
 
     if (options.includePostClaimRamparts === true) {
       planRamparts(colony, result, budgetState, options);
-      if (hasBlockingPlacementFailure(result)) {
+      if (shouldStopConstructionPlanning(result, options)) {
         return result;
       }
     }
@@ -285,18 +291,18 @@ export function planConstructionForColony(
     shouldPrioritizeFirstTowerDefenseSiteBeforeRoutineConstruction(room, rcl, options)
       ? planPriorityTowerDefenseSiteIfNeeded(colony, result, budgetState, options, rcl)
       : 'notNeeded';
-  if (hasBlockingPlacementFailure(result)) {
+  if (shouldStopConstructionPlanning(result, options)) {
     return result;
   }
 
   if (sourceLogisticsStarved) {
     planContainers(colony, result, budgetState, options, { includeStagingContainers: false });
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
 
     planRoads(colony, result, budgetState, buildSourceLogisticsStarvationRoadOptions(colony, options));
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
   }
@@ -316,18 +322,18 @@ export function planConstructionForColony(
   }
 
   planExtensions(colony, result, budgetState, options);
-  if (hasBlockingPlacementFailure(result)) {
+  if (shouldStopConstructionPlanning(result, options)) {
     return result;
   }
 
   if (!sourceLogisticsStarved) {
     planContainers(colony, result, budgetState, options);
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
 
     planRoads(colony, result, budgetState, options);
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
   }
@@ -340,27 +346,30 @@ export function planConstructionForColony(
       options,
       rcl
     );
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
   }
 
   if (priorityTowerDefenseSiteState !== 'blocked') {
     planBootstrapDefenseFloor(colony, result, budgetState, options);
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
   }
 
   if (options.includePostClaimRamparts === true) {
     planRamparts(colony, result, budgetState, options);
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return result;
     }
   }
 
   if (priorityTowerDefenseSiteState === 'notNeeded') {
     planTowers(colony, result, budgetState, options);
+    if (shouldStopConstructionPlanning(result, options)) {
+      return result;
+    }
   }
   planStorage(colony, result, budgetState, options);
 
@@ -477,6 +486,9 @@ function planExtensions(
   const extensionResult = planExtensionConstruction(colony);
   if (extensionResult !== null) {
     recordPlacement(result, budgetState, 'extension', extensionResult, options);
+    if (hasReachedPlacementLimit(result, options)) {
+      return;
+    }
   }
 }
 
@@ -575,6 +587,9 @@ function planBootstrapDefenseFloor(
     );
     if (placementResult === getOkCode() || isFatalConstructionSiteResult(placementResult)) {
       recordPlacement(result, budgetState, priority, placementResult, options, placement);
+      if (hasReachedPlacementLimit(result, options)) {
+        return;
+      }
     }
 
     if (placementResult !== getOkCode()) {
@@ -628,7 +643,10 @@ function planRuntimeStrategyPrioritizedConstruction(
 
   const report = buildRuntimeConstructionPriorityReport(colony, options.creeps, { strategyParameters });
   recordStrategyRegistryRuntimeUse(options, strategyEntry);
-  const priorities = runtimeConstructionPlannerPriorityOrder(report, { sourceLogisticsStarved });
+  const priorities = runtimeConstructionPlannerPriorityOrder(report, {
+    sourceLogisticsStarved,
+    includeDefaultPriorities: options.runtimeStrategyConstructionFallbackPriorities !== false
+  });
   if (priorities.length === 0) {
     return false;
   }
@@ -644,7 +662,7 @@ function planRuntimeStrategyPrioritizedConstruction(
       activePriorityTowerDefenseSiteState,
       rcl
     );
-    if (hasBlockingPlacementFailure(result)) {
+    if (shouldStopConstructionPlanning(result, options)) {
       return true;
     }
   }
@@ -670,7 +688,7 @@ function recordStrategyRegistryRuntimeUse(
 
 function runtimeConstructionPlannerPriorityOrder(
   report: ConstructionPriorityReport,
-  options: { sourceLogisticsStarved?: boolean } = {}
+  options: { sourceLogisticsStarved?: boolean; includeDefaultPriorities?: boolean } = {}
 ): ConstructionPlannerPriority[] {
   const priorities: ConstructionPlannerPriority[] = [];
   for (const score of report.candidates) {
@@ -684,9 +702,11 @@ function runtimeConstructionPlannerPriorityOrder(
     }
   }
 
-  for (const priority of DEFAULT_ROUTINE_CONSTRUCTION_PRIORITIES) {
-    if (!shouldSkipRuntimeConstructionPriority(priority, options) && !priorities.includes(priority)) {
-      priorities.push(priority);
+  if (options.includeDefaultPriorities !== false) {
+    for (const priority of DEFAULT_ROUTINE_CONSTRUCTION_PRIORITIES) {
+      if (!shouldSkipRuntimeConstructionPriority(priority, options) && !priorities.includes(priority)) {
+        priorities.push(priority);
+      }
     }
   }
 
@@ -758,7 +778,7 @@ function planRuntimeConstructionPlannerPriority(
         options,
         rcl
       );
-      if (hasBlockingPlacementFailure(result)) {
+      if (shouldStopConstructionPlanning(result, options)) {
         return priorityTowerDefenseSiteState;
       }
 
@@ -776,14 +796,14 @@ function planRuntimeConstructionPlannerPriority(
           options,
           rcl
         );
-        if (hasBlockingPlacementFailure(result)) {
+        if (shouldStopConstructionPlanning(result, options)) {
           return priorityTowerDefenseSiteState;
         }
       }
 
       if (priorityTowerDefenseSiteState !== 'blocked') {
         planBootstrapDefenseFloor(colony, result, budgetState, options);
-        if (hasBlockingPlacementFailure(result)) {
+        if (shouldStopConstructionPlanning(result, options)) {
           return priorityTowerDefenseSiteState;
         }
       }
@@ -853,7 +873,7 @@ function planRoads(
   });
   for (const roadResult of roadResults) {
     recordPlacement(result, budgetState, 'road', roadResult, options);
-    if (roadResult !== getOkCode()) {
+    if (roadResult !== getOkCode() || hasReachedPlacementLimit(result, options)) {
       return;
     }
   }
@@ -883,7 +903,7 @@ function planContainers(
   });
   for (const containerResult of containerResults) {
     recordPlacement(result, budgetState, 'container', containerResult, options);
-    if (containerResult !== getOkCode()) {
+    if (containerResult !== getOkCode() || hasReachedPlacementLimit(result, options)) {
       return;
     }
 
@@ -904,7 +924,7 @@ function planContainers(
     });
     for (const stagingContainerResult of stagingContainerResults) {
       recordPlacement(result, budgetState, 'container', stagingContainerResult, options);
-      if (stagingContainerResult !== getOkCode()) {
+      if (stagingContainerResult !== getOkCode() || hasReachedPlacementLimit(result, options)) {
         return;
       }
 
@@ -1023,6 +1043,38 @@ function recordPlacement(
 function hasBlockingPlacementFailure(result: RoomConstructionPlannerResult): boolean {
   const lastPlacement = result.placements[result.placements.length - 1];
   return lastPlacement !== undefined && lastPlacement.result !== getOkCode();
+}
+
+function shouldStopConstructionPlanning(
+  result: RoomConstructionPlannerResult,
+  options: ConstructionPlannerOptions
+): boolean {
+  return hasBlockingPlacementFailure(result) || hasReachedPlacementLimit(result, options);
+}
+
+function hasReachedPlacementLimit(
+  result: RoomConstructionPlannerResult,
+  options: ConstructionPlannerOptions
+): boolean {
+  const maxPlacements = getMaxPlacementsPerRoom(options);
+  if (maxPlacements === Number.MAX_SAFE_INTEGER) {
+    return false;
+  }
+
+  return result.placements.filter((placement) => placement.result === getOkCode()).length >= maxPlacements;
+}
+
+function getMaxPlacementsPerRoom(options: ConstructionPlannerOptions): number {
+  const value = options.maxPlacementsPerRoom;
+  if (value === undefined) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.floor(value));
 }
 
 function hasSpawnCoverage(colony: ColonySnapshot): boolean {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -8,7 +8,8 @@ import {
 } from '../colony/colonyStage';
 import {
   planClaimedRoomConstruction,
-  planDeferredClaimedRoomCapacityConstruction
+  planDeferredClaimedRoomCapacityConstruction,
+  type ClaimedRoomConstructionPlannerOptions
 } from '../construction/claimed-room-planner';
 import { countCreepsByRole, getWorkerCapacity, type RoleCounts } from '../creeps/roleCounts';
 import { runWorker } from '../creeps/workerRunner';
@@ -35,7 +36,7 @@ import {
   type RuntimeSummary,
   type RuntimeTelemetryEvent
 } from '../telemetry/runtimeSummary';
-import type { StrategyRegistryEntry } from '../strategy/strategyRegistry';
+import { DEFAULT_STRATEGY_REGISTRY, type StrategyRegistryEntry } from '../strategy/strategyRegistry';
 import { getRuntimeFeatureGates, type RuntimeFeatureGates } from '../runtime/featureGates';
 import {
   getRuntimeCpuBudget,
@@ -133,6 +134,8 @@ const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
 const OK_CODE = 0 as ScreepsReturnCode;
 const BOOTSTRAP_WORKER_BUFFER_BYPASS_MIN_ENERGY = 300;
 const LOW_ROOM_ENERGY_TASK_PRIORITY_RATIO = 0.5;
+
+type ConstructionCpuMode = 'normal' | 'recoverySeed';
 
 interface SpawnAttemptOutcome {
   spawn: StructureSpawn;
@@ -233,8 +236,10 @@ export function runEconomy(
             colony,
             creeps,
             options,
+            telemetryEvents,
             postClaimBootstrapFocusRoomName,
-            postClaimBootstrapRefresh.deferred === true
+            postClaimBootstrapRefresh.deferred === true,
+            selectConstructionCpuMode(roomCpuBudget)
           );
         }
         continue;
@@ -272,8 +277,10 @@ export function runEconomy(
         colony,
         creeps,
         options,
+        telemetryEvents,
         postClaimBootstrapFocusRoomName,
-        postClaimBootstrapRefresh.deferred === true
+        postClaimBootstrapRefresh.deferred === true,
+        selectConstructionCpuMode(roomCpuBudget)
       );
     }
     if (survivalAssessment.mode === 'TERRITORY_READY' && shouldRunTerritoryPlanning(roomCpuBudget, runOptionalRoomWork)) {
@@ -567,24 +574,88 @@ function runClaimedRoomConstructionForCpuBudget(
   colony: ColonySnapshot,
   creeps: Creep[],
   options: EconomyRuntimeOptions,
+  telemetryEvents: RuntimeTelemetryEvent[],
   postClaimBootstrapFocusRoomName: string | null,
-  deferred: boolean
+  deferred: boolean,
+  mode: ConstructionCpuMode = 'normal'
 ): void {
   refreshPostClaimDefenseConstruction(colony, { focusRoomName: postClaimBootstrapFocusRoomName });
-  const constructionOptions = {
+  const constructionOptions: ClaimedRoomConstructionPlannerOptions = {
     respectRoomEnergyBuffer: true,
     creeps,
     strategyRegistry: options.strategyRegistry,
     runtimeStrategyConstructionEnabled: options.runtimeStrategyConstructionEnabled,
     onStrategyRegistryRuntimeUse: options.onStrategyRegistryRuntimeUse
   };
+  const activeConstructionOptions =
+    mode === 'recoverySeed'
+      ? buildCpuRecoveryConstructionSeedOptions(constructionOptions)
+      : constructionOptions;
 
   if (deferred) {
-    planDeferredClaimedRoomCapacityConstruction(colony, constructionOptions);
+    const result = planDeferredClaimedRoomCapacityConstruction(colony, activeConstructionOptions);
+    recordRecoveryConstructionPlacementTelemetry(telemetryEvents, result.placements, mode);
     return;
   }
 
-  planClaimedRoomConstruction(colony, constructionOptions);
+  const result = planClaimedRoomConstruction(colony, activeConstructionOptions);
+  recordRecoveryConstructionPlacementTelemetry(telemetryEvents, result.placements, mode);
+}
+
+function selectConstructionCpuMode(cpuBudget: RuntimeCpuBudget): ConstructionCpuMode {
+  return shouldShedNonessentialCpuWork(cpuBudget) && shouldRunConstructionCpuWork(cpuBudget)
+    ? 'recoverySeed'
+    : 'normal';
+}
+
+function buildCpuRecoveryConstructionSeedOptions(
+  options: ClaimedRoomConstructionPlannerOptions
+): ClaimedRoomConstructionPlannerOptions {
+  return {
+    ...options,
+    strategyRegistry: options.strategyRegistry ?? DEFAULT_STRATEGY_REGISTRY,
+    runtimeStrategyConstructionEnabled: true,
+    runtimeStrategyConstructionFallbackPriorities: false,
+    includePostClaimRamparts: true,
+    maxPlacementsPerRoom: 1,
+    maxContainerSitesPerTick: 1,
+    maxPendingContainerSites: 1,
+    roadOptions: {
+      ...options.roadOptions,
+      maxSitesPerTick: 1,
+      maxTargetsPerTick: 1
+    }
+  };
+}
+
+function recordRecoveryConstructionPlacementTelemetry(
+  telemetryEvents: RuntimeTelemetryEvent[],
+  placements: Array<{
+    priority: string;
+    roomName: string;
+    structureType: BuildableStructureConstant;
+    result: ScreepsReturnCode;
+    x?: number;
+    y?: number;
+  }>,
+  mode: ConstructionCpuMode
+): void {
+  if (mode !== 'recoverySeed') {
+    return;
+  }
+
+  for (const placement of placements) {
+    telemetryEvents.push({
+      type: 'constructionPlacement',
+      roomName: placement.roomName,
+      priority: placement.priority,
+      structureType: String(placement.structureType),
+      result: placement.result,
+      mode: 'recoverySeed',
+      ...(placement.x !== undefined ? { x: placement.x } : {}),
+      ...(placement.y !== undefined ? { y: placement.y } : {})
+    });
+  }
 }
 
 function isDowngradeGuardControllerCreep(creep: Creep): boolean {

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -190,6 +190,7 @@ export type RuntimeTelemetryEvent =
   | RuntimeTerritoryScoutTelemetryEvent
   | RuntimePostClaimBootstrapTelemetryEvent
   | RuntimeSpawnSitePlacedTelemetryEvent
+  | RuntimeConstructionPlacementTelemetryEvent
   | RuntimeStrategyRecommendationTelemetryEvent;
 
 export type RuntimeTerritoryClaimTelemetryReason =
@@ -289,6 +290,17 @@ export interface RuntimeSpawnSitePlacedTelemetryEvent {
   result: ScreepsReturnCode;
   spawnSite: TerritoryPostClaimBootstrapSpawnSiteMemory;
   existing?: boolean;
+}
+
+export interface RuntimeConstructionPlacementTelemetryEvent {
+  type: 'constructionPlacement';
+  roomName: string;
+  priority: string;
+  structureType: string;
+  result: ScreepsReturnCode;
+  mode: 'recoverySeed';
+  x?: number;
+  y?: number;
 }
 
 export interface RuntimeStrategyRecommendationTelemetryEvent {

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -2121,7 +2121,76 @@ describe('runEconomy', () => {
     expect(worker.moveTo).not.toHaveBeenCalled();
   });
 
-  it('attempts E29N55 source-container construction during near-corridor over-limit recovery', () => {
+  it('seeds one accepted construction candidate during low-bucket recovery', () => {
+    installRecoveryConstructionSeedGlobals();
+    const { room, spawn } = makeRecoveryConstructionSeedRoom('E29N55');
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 2_048_800,
+      rooms: { E29N55: room },
+      spawns: { Spawn1: spawn },
+      creeps: {
+        Worker1: makeEconomyWorker(room),
+        Worker2: makeEconomyWorker(room),
+        Worker3: makeEconomyWorker(room)
+      },
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(10.139446899999712),
+        limit: 70,
+        bucket: 1_782,
+        tickLimit: 500
+      } as unknown as CPU,
+      map: {
+        getRoomTerrain: jest.fn().mockReturnValue({ get: jest.fn().mockReturnValue(0) })
+      } as unknown as GameMap
+    };
+
+    const summary = runEconomy();
+
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(11, 11, STRUCTURE_CONTAINER);
+    expect(summary?.events).toEqual(
+      expect.arrayContaining([
+        {
+          type: 'constructionPlacement',
+          roomName: 'E29N55',
+          priority: 'container',
+          structureType: STRUCTURE_CONTAINER,
+          result: OK_CODE,
+          mode: 'recoverySeed'
+        }
+      ])
+    );
+  });
+
+  it('keeps construction seed suppressed while the CPU bucket is critical', () => {
+    installRecoveryConstructionSeedGlobals();
+    const { room, spawn } = makeRecoveryConstructionSeedRoom('E29N55');
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 2_048_801,
+      rooms: { E29N55: room },
+      spawns: { Spawn1: spawn },
+      creeps: {
+        Worker1: makeEconomyWorker(room),
+        Worker2: makeEconomyWorker(room),
+        Worker3: makeEconomyWorker(room)
+      },
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(10),
+        limit: 70,
+        bucket: 1,
+        tickLimit: 500
+      } as unknown as CPU,
+      map: {
+        getRoomTerrain: jest.fn().mockReturnValue({ get: jest.fn().mockReturnValue(0) })
+      } as unknown as GameMap
+    };
+
+    runEconomy();
+
+    expect(room.createConstructionSite).not.toHaveBeenCalled();
+  });
+
+  it('bounds E29N55 source-container construction during near-corridor over-limit recovery', () => {
     (globalThis as unknown as {
       FIND_MY_STRUCTURES: number;
       FIND_MY_CONSTRUCTION_SITES: number;
@@ -2235,18 +2304,8 @@ describe('runEconomy', () => {
 
     runEconomy();
 
-    const constructionSiteCalls = (room.createConstructionSite as jest.Mock).mock.calls as Array<
-      [number, number, StructureConstant]
-    >;
-    expect(room.createConstructionSite).toHaveBeenCalledTimes(4);
-    expect(room.createConstructionSite).toHaveBeenNthCalledWith(1, 11, 11, STRUCTURE_CONTAINER);
-    expect(room.createConstructionSite).toHaveBeenNthCalledWith(2, 24, 24, STRUCTURE_TOWER);
-    expect(constructionSiteCalls.map(([, , structureType]) => structureType)).toEqual([
-      STRUCTURE_CONTAINER,
-      STRUCTURE_TOWER,
-      STRUCTURE_RAMPART,
-      STRUCTURE_WALL
-    ]);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(11, 11, STRUCTURE_CONTAINER);
   });
 
   it('runs existing worker creeps', () => {
@@ -5043,6 +5102,47 @@ function installMultiRoomSpawnQueueGlobals(): void {
   (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
 }
 
+function installRecoveryConstructionSeedGlobals(): void {
+  (globalThis as unknown as {
+    FIND_SOURCES: number;
+    FIND_MY_STRUCTURES: number;
+    FIND_MY_CONSTRUCTION_SITES: number;
+    FIND_STRUCTURES: number;
+    FIND_CONSTRUCTION_SITES: number;
+    FIND_HOSTILE_CREEPS: number;
+    FIND_HOSTILE_STRUCTURES: number;
+    RESOURCE_ENERGY: ResourceConstant;
+    STRUCTURE_SPAWN: StructureConstant;
+    STRUCTURE_EXTENSION: StructureConstant;
+    STRUCTURE_CONTAINER: StructureConstant;
+    STRUCTURE_TOWER: StructureConstant;
+    STRUCTURE_RAMPART: StructureConstant;
+    STRUCTURE_WALL: StructureConstant;
+    LOOK_STRUCTURES: LOOK_STRUCTURES;
+    LOOK_CONSTRUCTION_SITES: LOOK_CONSTRUCTION_SITES;
+    TERRAIN_MASK_WALL: number;
+    OK: ScreepsReturnCode;
+  }).FIND_SOURCES = 1;
+  (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 2;
+  (globalThis as unknown as { FIND_MY_CONSTRUCTION_SITES: number }).FIND_MY_CONSTRUCTION_SITES = 3;
+  (globalThis as unknown as { FIND_STRUCTURES: number }).FIND_STRUCTURES = 4;
+  (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 5;
+  (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 6;
+  (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 7;
+  (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+  (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
+  (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
+  (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+  (globalThis as unknown as { STRUCTURE_TOWER: StructureConstant }).STRUCTURE_TOWER = 'tower';
+  (globalThis as unknown as { STRUCTURE_RAMPART: StructureConstant }).STRUCTURE_RAMPART = 'rampart';
+  (globalThis as unknown as { STRUCTURE_WALL: StructureConstant }).STRUCTURE_WALL = 'constructedWall';
+  (globalThis as unknown as { LOOK_STRUCTURES: LOOK_STRUCTURES }).LOOK_STRUCTURES = 'structure';
+  (globalThis as unknown as { LOOK_CONSTRUCTION_SITES: LOOK_CONSTRUCTION_SITES }).LOOK_CONSTRUCTION_SITES =
+    'constructionSite';
+  (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+  (globalThis as unknown as { OK: ScreepsReturnCode }).OK = OK_CODE;
+}
+
 function makeSpawnCoordinationRoom({
   roomName,
   energyAvailable,
@@ -5068,6 +5168,73 @@ function makeSpawnCoordinationRoom({
     memory: {},
     find: jest.fn((type: number) => (type === FIND_SOURCES ? [{ id: `${roomName}-source` } as Source] : []))
   } as unknown as Room;
+}
+
+function makeRecoveryConstructionSeedRoom(roomName: string): {
+  room: Room & { createConstructionSite: jest.Mock };
+  spawn: StructureSpawn;
+} {
+  const constructionSites: ConstructionSite[] = [];
+  const source = {
+    id: `${roomName}-source`,
+    pos: { x: 10, y: 10, roomName } as RoomPosition
+  } as Source;
+  let spawn = {} as StructureSpawn;
+  const extensions = Array.from(
+    { length: 10 },
+    (_, index) =>
+      ({
+        id: `${roomName}-extension-${index}`,
+        structureType: 'extension',
+        pos: { x: 30 + index, y: 30, roomName } as RoomPosition
+      }) as StructureExtension
+  );
+  const room = {
+    name: roomName,
+    energyAvailable: 800,
+    energyCapacityAvailable: 800,
+    controller: {
+      id: `${roomName}-controller`,
+      my: true,
+      owner: { username: 'me' },
+      level: 3,
+      ticksToDowngrade: 10_000,
+      pos: { x: 25, y: 25, roomName } as RoomPosition
+    } as StructureController,
+    memory: {},
+    find: jest.fn((type: number, options?: { filter?: (target: unknown) => boolean }) => {
+      const targets =
+        type === FIND_SOURCES
+          ? [source]
+          : type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES
+            ? ([spawn as unknown as AnyOwnedStructure, ...extensions] as unknown[])
+            : type === FIND_MY_CONSTRUCTION_SITES || type === FIND_CONSTRUCTION_SITES
+              ? constructionSites
+              : [];
+
+      return options?.filter ? targets.filter(options.filter) : targets;
+    }),
+    lookForAtArea: jest.fn().mockReturnValue([]),
+    createConstructionSite: jest.fn((x: number, y: number, structureType: StructureConstant) => {
+      constructionSites.push({
+        id: `${roomName}-site-${x}-${y}`,
+        structureType,
+        pos: { x, y, roomName } as RoomPosition
+      } as ConstructionSite);
+      return OK_CODE;
+    })
+  } as unknown as Room & { createConstructionSite: jest.Mock };
+  spawn = {
+    id: `${roomName}-spawn`,
+    name: 'Spawn1',
+    room,
+    structureType: 'spawn',
+    pos: { x: 25, y: 25, roomName } as RoomPosition,
+    spawning: null,
+    spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+  } as unknown as StructureSpawn;
+
+  return { room, spawn };
 }
 
 function makeClaimedSpawnlessEconomyRoom({


### PR DESCRIPTION
## Linked issues

Intentional PR-body closing linkage:
- None.

Related / non-closing linkage:
- Refs #1781

## Domain / Kind

- Domain: Territory/Economy
- Kind: bug

## Summary

- Allows a single bounded construction-site seed while CPU pressure is in low-bucket recovery when the room already has an accepted construction candidate, available workers/energy, and no active construction sites.
- Preserves critical CPU safety by keeping true critical/emergency CPU protections in place.
- Adds telemetry/test coverage for the accepted-candidate suppression path so future runtime summaries expose whether seeding is allowed or skipped.

## Verification

- [x] Local check: `git diff --check`; `cd prod && npm run typecheck`; `npm test -- --runInBand` (105 suites / 2384 tests passed); `npm run build`.
- [x] GitHub Project issue/PR fields are current (`Status`, `Evidence`, `Next action`; plus `Blocked by` when blocked): issue 1781 fields refreshed; PR #1792 Project item created and field updates recorded.
- [x] Automated review has no blocking findings and review threads are resolved/outdated/non-blocking: required before merge by standard gate.
- [x] QA gate: controller verification passed; independent PR gate still applies.
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate

- [x] Task type: code behavior bugfix.
- [x] Expected observable outcome / named deliverable: bounded lowBucketRecovery construction seeding path for accepted candidates, with critical CPU protection retained.
- [x] Non-goals / accepted substitutes: no learned-policy rollout, no Tencent compute launch, no owner-action request, no broad construction rewrite.
- [x] Verification evidence required before Done: commit 59ee536c; diff-check, prod typecheck, Jest 105/2384, and prod build all passed from the PR worktree.
- [x] Project Evidence / Next action / Blocked by: issue 1781 Project item records active PR handoff; PR 1792 Project item records in-review gate fields.
- [x] Post-merge/deploy/runtime proof: issue 1781 carries runtime acceptance for constructionSiteCount, build task, build energy, or build progress evidence.
- [x] Named deliverable proof: commit 59ee536c changes planner, economy loop, runtime summary telemetry, Jest coverage, and bundled dist artifact.

## Issue closure gate

For every issue linked above in the PR body with a closing keyword:

- None.

## Runtime / deployment impact

- [ ] No gameplay/runtime/deployment impact.
- [x] Gameplay/runtime/deployment impact; Deployment Floor evidence or HELD blocker is recorded.

## Notes

- Review/merge gates: wait at least 15 minutes after PR creation, require green checks, inspect CodeRabbit/Gemini comments and GraphQL threads, keep issue/PR Project state current, then merge/deploy only when all gates pass.
- Runtime acceptance stays with issue 1781 until fresh official MMO evidence shows construction site/build/progress recovery or a concrete non-actionable no-capacity reason.
