### PR TITLE
construction: assign workers to safe recovery sites

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -34272,11 +34272,17 @@ function isWorkerAssignmentGapRecoverySelection(creep, currentTask, selectedTask
   if (!currentTask && !selectedTask) {
     return true;
   }
+  if (getRuntimeCpuBudget().critical && ((currentTask == null ? void 0 : currentTask.type) === "repair" || (selectedTask == null ? void 0 : selectedTask.type) === "repair")) {
+    return false;
+  }
   const allowUpgradeRecovery = !isControllerDowngradeGuardActive2(creep.room);
-  return isWorkerAssignmentGapRecoveryTask(currentTask, allowUpgradeRecovery) && isWorkerAssignmentGapRecoveryTask(selectedTask, allowUpgradeRecovery);
+  return isWorkerAssignmentGapRecoveryTask(creep, currentTask, allowUpgradeRecovery, { allowRepair: true }) && isWorkerAssignmentGapRecoveryTask(creep, selectedTask, allowUpgradeRecovery);
 }
-function isWorkerAssignmentGapRecoveryTask(task, allowUpgradeRecovery) {
-  return task === void 0 || task === null || isEnergyAcquisitionTask2(task) || task.type === "transfer" || allowUpgradeRecovery && task.type === "upgrade";
+function isWorkerAssignmentGapRecoveryTask(creep, task, allowUpgradeRecovery, options = {}) {
+  return task === void 0 || task === null || isEnergyAcquisitionTask2(task) || task.type === "transfer" || options.allowRepair === true && isWorkerAssignmentGapRecoveryRepairTask(creep, task) || allowUpgradeRecovery && task.type === "upgrade";
+}
+function isWorkerAssignmentGapRecoveryRepairTask(creep, task) {
+  return (task == null ? void 0 : task.type) === "repair" && !isProtectedRepairTargetForConstructionBacklog(creep, getTaskTarget(task));
 }
 function selectWorkerAssignmentGapRecoveryConstructionSite(creep) {
   var _a2, _b;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -521,22 +521,38 @@ function isWorkerAssignmentGapRecoverySelection(
     return true;
   }
 
+  if (getRuntimeCpuBudget().critical && (currentTask?.type === 'repair' || selectedTask?.type === 'repair')) {
+    return false;
+  }
+
   const allowUpgradeRecovery = !isControllerDowngradeGuardActive(creep.room);
-  return isWorkerAssignmentGapRecoveryTask(currentTask, allowUpgradeRecovery) &&
-    isWorkerAssignmentGapRecoveryTask(selectedTask, allowUpgradeRecovery);
+  return (
+    isWorkerAssignmentGapRecoveryTask(creep, currentTask, allowUpgradeRecovery, { allowRepair: true }) &&
+    isWorkerAssignmentGapRecoveryTask(creep, selectedTask, allowUpgradeRecovery)
+  );
 }
 
 function isWorkerAssignmentGapRecoveryTask(
+  creep: Creep,
   task: CreepTaskMemory | null | undefined,
-  allowUpgradeRecovery: boolean
+  allowUpgradeRecovery: boolean,
+  options: { allowRepair?: boolean } = {}
 ): boolean {
   return (
     task === undefined ||
     task === null ||
     isEnergyAcquisitionTask(task) ||
     task.type === 'transfer' ||
+    (options.allowRepair === true && isWorkerAssignmentGapRecoveryRepairTask(creep, task)) ||
     (allowUpgradeRecovery && task.type === 'upgrade')
   );
+}
+
+function isWorkerAssignmentGapRecoveryRepairTask(
+  creep: Creep,
+  task: CreepTaskMemory | null | undefined
+): task is Extract<CreepTaskMemory, { type: 'repair' }> {
+  return task?.type === 'repair' && !isProtectedRepairTargetForConstructionBacklog(creep, getTaskTarget(task));
 }
 
 function selectWorkerAssignmentGapRecoveryConstructionSite(creep: Creep): ConstructionSite | null {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -7163,6 +7163,141 @@ describe('runWorker', () => {
     }
   });
 
+  it('recovers construction assignment from retained routine repair under storage-critical transfer selection', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 497,
+      progressTotal: 500
+    } as ConstructionSite;
+    const routineWall = {
+      id: 'wall-routine',
+      structureType: 'constructedWall',
+      hits: IDLE_RAMPART_REPAIR_HITS_CEILING - 1,
+      hitsMax: 300_000_000
+    } as StructureWall;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 750 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(10_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 6,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N55',
+      energyAvailable: 2_300,
+      energyCapacityAvailable: 2_300,
+      controller,
+      storage,
+      find: jest.fn((type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [storage] as unknown as AnyOwnedStructure[];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [storage, routineWall];
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+        }
+
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        if (type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
+          return [];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const repair = jest.fn();
+    const transfer = jest.fn();
+    const repairTask = { type: 'repair', targetId: 'wall-routine' as Id<Structure> } as const;
+    const creep = {
+      name: 'LoadedRepairWorker',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: repairTask
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      },
+      room,
+      build,
+      repair,
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const supportWorker = {
+      name: 'SupportWorker',
+      memory: { role: 'worker', colony: 'E29N55' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, supportWorker);
+    const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(repairTask);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { LoadedRepairWorker: creep, SupportWorker: supportWorker },
+      rooms: { E29N55: room },
+      time: 2_050_073,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        if (id === 'wall-routine') {
+          return routineWall;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({ type: 'build', targetId: 'road-site1' });
+      expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+        currentTask: 'repair',
+        currentTargetId: 'wall-routine',
+        baseSelectedTask: 'repair',
+        baseSelectedTargetId: 'wall-routine',
+        energyCriticalTask: 'transfer',
+        energyCriticalTargetId: 'storage1',
+        selectedTask: 'build',
+        selectedTargetId: 'road-site1',
+        assignedTask: 'build',
+        assignedTargetId: 'road-site1'
+      });
+      expect(build).toHaveBeenCalledWith(site);
+      expect(repair).not.toHaveBeenCalled();
+      expect(transfer).not.toHaveBeenCalled();
+    } finally {
+      selectWorkerTask.mockRestore();
+    }
+  });
+
   it('preempts a stale E29N57 spawn reservation transfer when stored energy can cover construction', () => {
     const site = {
       id: 'road-site1',


### PR DESCRIPTION
## Summary
- lets worker-assignment-gap recovery preempt a retained routine `repair` task when a safe owned construction site exists and the CPU bucket is not critical
- preserves critical repair and controller-downgrade guard behavior while keeping worker recovery bounded to the observed safe-construction gap
- adds a focused regression matching the deploy evidence shape: routine repair retained, energy-critical transfer selected, safe site present, final worker action becomes `build`
- rebuilds `prod/dist/main.js`

## Related issue
Related to issue #1781. The issue-level runtime acceptance gate stays open for deploy evidence after this PR lands.

## Verification
Controller-side verification from `/root/screeps-worktrees/1781-worker-assignment-gap/prod`:
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` — 105 suites / 2385 tests passed
- `npm run build`

Codex commit-only evidence:
- commit `f85faa1f9ad12343b2230bc45c3f3af651527c77`
- author `lanyusea's bot <lanyusea@gmail.com>`
- files: `prod/src/creeps/workerRunner.ts`, `prod/test/workerRunner.test.ts`, `prod/dist/main.js`

## Universal task Done gate
- [x] Task type: P0 gameplay bugfix PR for worker construction assignment recovery.
- [x] Expected observable outcome / named deliverable: Verified source/test/bundle change that can route a loaded worker from routine repair into safe construction when postdeploy evidence shows owned sites and zero build work.
- [x] Non-goals / accepted substitutes: PR merge alone is not issue Done; issue acceptance uses runtime construction snapshots, with no owner-side choice required.
- [x] Verification evidence required before Done: Controller ran diff-check, typecheck, full Jest, and build successfully; PR CI and review-thread gates still apply.
- [x] Project Evidence / Next action / Blocked by: Project #1781 records commit recovery evidence and next deploy-observation action; no owner-side blocker.
- [x] Post-merge/deploy/runtime proof: Official deploy artifact plus fresh runtime-summary evidence must show buildCarriedEnergy, taskCounts.build, buildProgress, or cleared construction sites.
- [x] Named deliverable proof: Commit f85faa1f contains the verified workerRunner source, regression test, and rebuilt bundle deliverable.
