### PR TITLE
fix: restore source-container site placement after recovery

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -13107,7 +13107,9 @@ function createSourceContainerPlannerLookups(room, sources) {
   }
   for (const structure of structures) {
     const position = getRoomObjectPosition4(structure);
-    addBlockingPosition(lookups, position);
+    if (isSourceContainerPlacementBlockingStructure(structure)) {
+      addBlockingPosition(lookups, position);
+    }
     if (matchesStructureType10(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
       addPosition(lookups.existingContainerPositions, position);
     }
@@ -13120,6 +13122,9 @@ function createSourceContainerPlannerLookups(room, sources) {
     }
   }
   return lookups;
+}
+function isSourceContainerPlacementBlockingStructure(structure) {
+  return !matchesStructureType10(structure.structureType, "STRUCTURE_ROAD", "road") && !matchesStructureType10(structure.structureType, "STRUCTURE_RAMPART", "rampart");
 }
 function addBlockingPosition(lookups, position) {
   if (position) {
@@ -16908,7 +16913,9 @@ function createSourceContainerPlannerLookups2(room) {
   for (const structure of room.find(FIND_STRUCTURES)) {
     const position = getRoomObjectPosition(structure);
     if (position && isSameRoomPosition(position, room.name)) {
-      lookups.blockedPositions.add(getPositionKey2(position));
+      if (isSourceContainerPlacementBlockingStructure2(structure)) {
+        lookups.blockedPositions.add(getPositionKey2(position));
+      }
     }
   }
   for (const site of room.find(FIND_CONSTRUCTION_SITES)) {
@@ -16923,6 +16930,9 @@ function createSourceContainerPlannerLookups2(room) {
     }
   }
   return lookups;
+}
+function isSourceContainerPlacementBlockingStructure2(structure) {
+  return structure.structureType !== getRoadStructureType2() && structure.structureType !== getRampartStructureType();
 }
 function getSortedSources4(room) {
   return room.find(FIND_SOURCES).filter((source) => {
@@ -17007,6 +17017,14 @@ function isContainerConstructionSite2(site) {
 function getContainerStructureType3() {
   var _a2;
   return (_a2 = globalThis.STRUCTURE_CONTAINER) != null ? _a2 : "container";
+}
+function getRoadStructureType2() {
+  var _a2;
+  return (_a2 = globalThis.STRUCTURE_ROAD) != null ? _a2 : "road";
+}
+function getRampartStructureType() {
+  var _a2;
+  return (_a2 = globalThis.STRUCTURE_RAMPART) != null ? _a2 : "rampart";
 }
 function getOkCode6() {
   var _a2;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -12902,11 +12902,11 @@ function planSourceContainerConstruction(colony, options = {}) {
     }
     const result = room.createConstructionSite(position.x, position.y, getContainerStructureType());
     results.push(result);
+    lookups.blockingPositions.add(getPositionKey6(position));
     if (result !== getOkCode3()) {
       break;
     }
     lookups.pendingContainerPositions.push(position);
-    lookups.blockingPositions.add(getPositionKey6(position));
   }
   return results;
 }
@@ -13124,7 +13124,7 @@ function createSourceContainerPlannerLookups(room, sources) {
   return lookups;
 }
 function isSourceContainerPlacementBlockingStructure(structure) {
-  return !matchesStructureType10(structure.structureType, "STRUCTURE_ROAD", "road") && !matchesStructureType10(structure.structureType, "STRUCTURE_RAMPART", "rampart");
+  return !matchesStructureType10(structure.structureType, "STRUCTURE_RAMPART", "rampart");
 }
 function addBlockingPosition(lookups, position) {
   if (position) {
@@ -16881,9 +16881,10 @@ function planSourceContainerConstruction2(colony, options = {}) {
       continue;
     }
     const result = room.createConstructionSite(position.x, position.y, getContainerStructureType3());
+    const positionKey = getPositionKey2(position);
+    lookups.blockedPositions.add(positionKey);
     if (result === getOkCode6()) {
-      lookups.blockedPositions.add(getPositionKey2(position));
-      lookups.pendingContainerPositions.add(getPositionKey2(position));
+      lookups.pendingContainerPositions.add(positionKey);
     }
     return result;
   }
@@ -16932,7 +16933,7 @@ function createSourceContainerPlannerLookups2(room) {
   return lookups;
 }
 function isSourceContainerPlacementBlockingStructure2(structure) {
-  return structure.structureType !== getRoadStructureType2() && structure.structureType !== getRampartStructureType();
+  return structure.structureType !== getRampartStructureType();
 }
 function getSortedSources4(room) {
   return room.find(FIND_SOURCES).filter((source) => {
@@ -17017,10 +17018,6 @@ function isContainerConstructionSite2(site) {
 function getContainerStructureType3() {
   var _a2;
   return (_a2 = globalThis.STRUCTURE_CONTAINER) != null ? _a2 : "container";
-}
-function getRoadStructureType2() {
-  var _a2;
-  return (_a2 = globalThis.STRUCTURE_ROAD) != null ? _a2 : "road";
 }
 function getRampartStructureType() {
   var _a2;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -13124,7 +13124,13 @@ function createSourceContainerPlannerLookups(room, sources) {
   return lookups;
 }
 function isSourceContainerPlacementBlockingStructure(structure) {
-  return !matchesStructureType10(structure.structureType, "STRUCTURE_RAMPART", "rampart");
+  if (!matchesStructureType10(structure.structureType, "STRUCTURE_RAMPART", "rampart")) {
+    return true;
+  }
+  return !isOwnedSourceContainerPlacementRampart(structure);
+}
+function isOwnedSourceContainerPlacementRampart(structure) {
+  return structure.my === true;
 }
 function addBlockingPosition(lookups, position) {
   if (position) {
@@ -16933,7 +16939,13 @@ function createSourceContainerPlannerLookups2(room) {
   return lookups;
 }
 function isSourceContainerPlacementBlockingStructure2(structure) {
-  return structure.structureType !== getRampartStructureType();
+  if (structure.structureType !== getRampartStructureType()) {
+    return true;
+  }
+  return !isOwnedSourceContainerPlacementRampart2(structure);
+}
+function isOwnedSourceContainerPlacementRampart2(structure) {
+  return structure.my === true;
 }
 function getSortedSources4(room) {
   return room.find(FIND_SOURCES).filter((source) => {

--- a/prod/src/construction/constructionPriority.ts
+++ b/prod/src/construction/constructionPriority.ts
@@ -1225,7 +1225,15 @@ function createSourceContainerPlannerLookups(
 }
 
 function isSourceContainerPlacementBlockingStructure(structure: Structure): boolean {
-  return !matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart');
+  if (!matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart')) {
+    return true;
+  }
+
+  return !isOwnedSourceContainerPlacementRampart(structure);
+}
+
+function isOwnedSourceContainerPlacementRampart(structure: Structure): structure is StructureRampart {
+  return (structure as Partial<StructureRampart>).my === true;
 }
 
 function addBlockingPosition(

--- a/prod/src/construction/constructionPriority.ts
+++ b/prod/src/construction/constructionPriority.ts
@@ -881,12 +881,12 @@ export function planSourceContainerConstruction(
 
     const result = room.createConstructionSite(position.x, position.y, getContainerStructureType());
     results.push(result);
+    lookups.blockingPositions.add(getPositionKey(position));
     if (result !== getOkCode()) {
       break;
     }
 
     lookups.pendingContainerPositions.push(position);
-    lookups.blockingPositions.add(getPositionKey(position));
   }
 
   return results;
@@ -1225,10 +1225,7 @@ function createSourceContainerPlannerLookups(
 }
 
 function isSourceContainerPlacementBlockingStructure(structure: Structure): boolean {
-  return (
-    !matchesStructureType(structure.structureType, 'STRUCTURE_ROAD', 'road') &&
-    !matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart')
-  );
+  return !matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart');
 }
 
 function addBlockingPosition(

--- a/prod/src/construction/constructionPriority.ts
+++ b/prod/src/construction/constructionPriority.ts
@@ -1205,7 +1205,9 @@ function createSourceContainerPlannerLookups(
 
   for (const structure of structures) {
     const position = getRoomObjectPosition(structure);
-    addBlockingPosition(lookups, position);
+    if (isSourceContainerPlacementBlockingStructure(structure)) {
+      addBlockingPosition(lookups, position);
+    }
     if (matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container')) {
       addPosition(lookups.existingContainerPositions, position);
     }
@@ -1220,6 +1222,13 @@ function createSourceContainerPlannerLookups(
   }
 
   return lookups;
+}
+
+function isSourceContainerPlacementBlockingStructure(structure: Structure): boolean {
+  return (
+    !matchesStructureType(structure.structureType, 'STRUCTURE_ROAD', 'road') &&
+    !matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart')
+  );
 }
 
 function addBlockingPosition(

--- a/prod/src/construction/sourceContainerPlanner.ts
+++ b/prod/src/construction/sourceContainerPlanner.ts
@@ -59,9 +59,10 @@ export function planSourceContainerConstruction(
     }
 
     const result = room.createConstructionSite(position.x, position.y, getContainerStructureType());
+    const positionKey = getPositionKey(position);
+    lookups.blockedPositions.add(positionKey);
     if (result === getOkCode()) {
-      lookups.blockedPositions.add(getPositionKey(position));
-      lookups.pendingContainerPositions.add(getPositionKey(position));
+      lookups.pendingContainerPositions.add(positionKey);
     }
 
     return result;
@@ -121,10 +122,7 @@ function createSourceContainerPlannerLookups(room: Room): SourceContainerPlanner
 }
 
 function isSourceContainerPlacementBlockingStructure(structure: Structure): boolean {
-  return (
-    structure.structureType !== getRoadStructureType() &&
-    structure.structureType !== getRampartStructureType()
-  );
+  return structure.structureType !== getRampartStructureType();
 }
 
 function getSortedSources(room: Room): Source[] {
@@ -249,11 +247,6 @@ function isContainerConstructionSite(site: ConstructionSite): boolean {
 function getContainerStructureType(): BuildableStructureConstant {
   return ((globalThis as unknown as { STRUCTURE_CONTAINER?: StructureConstant }).STRUCTURE_CONTAINER ??
     'container') as BuildableStructureConstant;
-}
-
-function getRoadStructureType(): StructureConstant {
-  return ((globalThis as unknown as { STRUCTURE_ROAD?: StructureConstant }).STRUCTURE_ROAD ??
-    'road') as StructureConstant;
 }
 
 function getRampartStructureType(): StructureConstant {

--- a/prod/src/construction/sourceContainerPlanner.ts
+++ b/prod/src/construction/sourceContainerPlanner.ts
@@ -122,7 +122,15 @@ function createSourceContainerPlannerLookups(room: Room): SourceContainerPlanner
 }
 
 function isSourceContainerPlacementBlockingStructure(structure: Structure): boolean {
-  return structure.structureType !== getRampartStructureType();
+  if (structure.structureType !== getRampartStructureType()) {
+    return true;
+  }
+
+  return !isOwnedSourceContainerPlacementRampart(structure);
+}
+
+function isOwnedSourceContainerPlacementRampart(structure: Structure): structure is StructureRampart {
+  return (structure as Partial<StructureRampart>).my === true;
 }
 
 function getSortedSources(room: Room): Source[] {

--- a/prod/src/construction/sourceContainerPlanner.ts
+++ b/prod/src/construction/sourceContainerPlanner.ts
@@ -98,7 +98,9 @@ function createSourceContainerPlannerLookups(room: Room): SourceContainerPlanner
   for (const structure of room.find(FIND_STRUCTURES)) {
     const position = getRoomObjectPosition(structure);
     if (position && isSameRoomPosition(position, room.name)) {
-      lookups.blockedPositions.add(getPositionKey(position));
+      if (isSourceContainerPlacementBlockingStructure(structure)) {
+        lookups.blockedPositions.add(getPositionKey(position));
+      }
     }
   }
 
@@ -116,6 +118,13 @@ function createSourceContainerPlannerLookups(room: Room): SourceContainerPlanner
   }
 
   return lookups;
+}
+
+function isSourceContainerPlacementBlockingStructure(structure: Structure): boolean {
+  return (
+    structure.structureType !== getRoadStructureType() &&
+    structure.structureType !== getRampartStructureType()
+  );
 }
 
 function getSortedSources(room: Room): Source[] {
@@ -240,6 +249,16 @@ function isContainerConstructionSite(site: ConstructionSite): boolean {
 function getContainerStructureType(): BuildableStructureConstant {
   return ((globalThis as unknown as { STRUCTURE_CONTAINER?: StructureConstant }).STRUCTURE_CONTAINER ??
     'container') as BuildableStructureConstant;
+}
+
+function getRoadStructureType(): StructureConstant {
+  return ((globalThis as unknown as { STRUCTURE_ROAD?: StructureConstant }).STRUCTURE_ROAD ??
+    'road') as StructureConstant;
+}
+
+function getRampartStructureType(): StructureConstant {
+  return ((globalThis as unknown as { STRUCTURE_RAMPART?: StructureConstant }).STRUCTURE_RAMPART ??
+    'rampart') as StructureConstant;
 }
 
 function getOkCode(): ScreepsReturnCode {

--- a/prod/test/constructionPlanner.test.ts
+++ b/prod/test/constructionPlanner.test.ts
@@ -661,14 +661,14 @@ describe('owned room construction planner', () => {
     expect(room.createConstructionSite.mock.calls[0][2]).toBe(STRUCTURE_CONTAINER);
   });
 
-  it('places source containers on source-adjacent road overlays', () => {
+  it('places source containers on rampart overlays while roads block source-adjacent tiles', () => {
     installOpenTerrain();
     const source = makeSource('source-a', 20, 10);
+    const rampartOffset = [-1, 0] as const;
     const roadOffsets = [
       [-1, -1],
       [0, -1],
       [1, -1],
-      [-1, 0],
       [1, 0],
       [-1, 1],
       [0, 1],
@@ -684,6 +684,12 @@ describe('owned room construction planner', () => {
         ),
         ...roadOffsets.map(([dx, dy], index) =>
           makeStructure(`source-road-${index}`, TEST_GLOBALS.STRUCTURE_ROAD, source.pos.x + dx, source.pos.y + dy)
+        ),
+        makeStructure(
+          'source-rampart',
+          TEST_GLOBALS.STRUCTURE_RAMPART,
+          source.pos.x + rampartOffset[0],
+          source.pos.y + rampartOffset[1]
         )
       ],
       sources: [source],
@@ -697,7 +703,7 @@ describe('owned room construction planner', () => {
 
     expect(result.placements.map((placement) => placement.priority)).toEqual(['container']);
     expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
-    expect(room.createConstructionSite).toHaveBeenCalledWith(19, 9, STRUCTURE_CONTAINER);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(19, 10, STRUCTURE_CONTAINER);
   });
 
   it('creates harvest-to-spawn road sites before extensions when off-route road backlog exists during starvation', () => {

--- a/prod/test/constructionPlanner.test.ts
+++ b/prod/test/constructionPlanner.test.ts
@@ -661,6 +661,45 @@ describe('owned room construction planner', () => {
     expect(room.createConstructionSite.mock.calls[0][2]).toBe(STRUCTURE_CONTAINER);
   });
 
+  it('places source containers on source-adjacent road overlays', () => {
+    installOpenTerrain();
+    const source = makeSource('source-a', 20, 10);
+    const roadOffsets = [
+      [-1, -1],
+      [0, -1],
+      [1, -1],
+      [-1, 0],
+      [1, 0],
+      [-1, 1],
+      [0, 1],
+      [1, 1]
+    ] as const;
+    const { room, colony } = makeColony({
+      controllerLevel: 6,
+      energyAvailable: 1_599,
+      energyCapacityAvailable: 2_300,
+      structures: [
+        ...Array.from({ length: 40 }, (_, index) =>
+          makeStructure(`extension-${index}`, TEST_GLOBALS.STRUCTURE_EXTENSION, 20 + index, 30)
+        ),
+        ...roadOffsets.map(([dx, dy], index) =>
+          makeStructure(`source-road-${index}`, TEST_GLOBALS.STRUCTURE_ROAD, source.pos.x + dx, source.pos.y + dy)
+        )
+      ],
+      sources: [source],
+      pathsByTarget: {}
+    });
+
+    const result = planConstructionForColony(colony, {
+      respectRoomEnergyBuffer: true,
+      maxPlacementsPerRoom: 1
+    });
+
+    expect(result.placements.map((placement) => placement.priority)).toEqual(['container']);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(19, 9, STRUCTURE_CONTAINER);
+  });
+
   it('creates harvest-to-spawn road sites before extensions when off-route road backlog exists during starvation', () => {
     installOpenTerrain();
     const { room, colony } = makeColony({

--- a/prod/test/constructionPlanner.test.ts
+++ b/prod/test/constructionPlanner.test.ts
@@ -661,13 +661,13 @@ describe('owned room construction planner', () => {
     expect(room.createConstructionSite.mock.calls[0][2]).toBe(STRUCTURE_CONTAINER);
   });
 
-  it('places source containers on rampart overlays while roads block source-adjacent tiles', () => {
+  it('skips foreign ramparts while placing source containers on owned rampart overlays', () => {
     installOpenTerrain();
     const source = makeSource('source-a', 20, 10);
-    const rampartOffset = [-1, 0] as const;
+    const ownedRampartOffset = [0, -1] as const;
+    const foreignRampartOffset = [-1, 0] as const;
     const roadOffsets = [
       [-1, -1],
-      [0, -1],
       [1, -1],
       [1, 0],
       [-1, 1],
@@ -686,10 +686,18 @@ describe('owned room construction planner', () => {
           makeStructure(`source-road-${index}`, TEST_GLOBALS.STRUCTURE_ROAD, source.pos.x + dx, source.pos.y + dy)
         ),
         makeStructure(
-          'source-rampart',
+          'foreign-source-rampart',
           TEST_GLOBALS.STRUCTURE_RAMPART,
-          source.pos.x + rampartOffset[0],
-          source.pos.y + rampartOffset[1]
+          source.pos.x + foreignRampartOffset[0],
+          source.pos.y + foreignRampartOffset[1],
+          false
+        ),
+        makeStructure(
+          'owned-source-rampart',
+          TEST_GLOBALS.STRUCTURE_RAMPART,
+          source.pos.x + ownedRampartOffset[0],
+          source.pos.y + ownedRampartOffset[1],
+          true
         )
       ],
       sources: [source],
@@ -703,7 +711,7 @@ describe('owned room construction planner', () => {
 
     expect(result.placements.map((placement) => placement.priority)).toEqual(['container']);
     expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
-    expect(room.createConstructionSite).toHaveBeenCalledWith(19, 10, STRUCTURE_CONTAINER);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(20, 9, STRUCTURE_CONTAINER);
   });
 
   it('creates harvest-to-spawn road sites before extensions when off-route road backlog exists during starvation', () => {
@@ -1158,10 +1166,17 @@ function makeSource(id: string, x: number, y: number, roomName = 'W1N1'): Source
   } as unknown as Source;
 }
 
-function makeStructure(id: string, structureType: StructureConstant, x: number, y: number): Structure {
+function makeStructure(
+  id: string,
+  structureType: StructureConstant,
+  x: number,
+  y: number,
+  my?: boolean
+): Structure {
   return {
     id,
     structureType,
+    ...(my === undefined ? {} : { my }),
     pos: makeRoomPosition(x, y)
   } as unknown as Structure;
 }

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -2162,6 +2162,54 @@ describe('runEconomy', () => {
     );
   });
 
+  it('seeds a source-container candidate over roaded source tiles during low-bucket recovery', () => {
+    installRecoveryConstructionSeedGlobals();
+    const { room, spawn } = makeRecoveryConstructionSeedRoom('E29N55', {
+      controllerLevel: 6,
+      energyAvailable: 1_599,
+      energyCapacityAvailable: 2_300,
+      extensionCount: 40,
+      roadedSourceAdjacency: true
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 2_051_500,
+      rooms: { E29N55: room },
+      spawns: { Spawn1: spawn },
+      creeps: {
+        Worker1: makeEconomyWorker(room),
+        Worker2: makeEconomyWorker(room),
+        Worker3: makeEconomyWorker(room),
+        Worker4: makeEconomyWorker(room)
+      },
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(12.34404209999957),
+        limit: 70,
+        bucket: 1_830,
+        tickLimit: 500
+      } as unknown as CPU,
+      map: {
+        getRoomTerrain: jest.fn().mockReturnValue({ get: jest.fn().mockReturnValue(0) })
+      } as unknown as GameMap
+    };
+
+    const summary = runEconomy();
+
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(11, 11, STRUCTURE_CONTAINER);
+    expect(summary?.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'constructionPlacement',
+          roomName: 'E29N55',
+          priority: 'container',
+          structureType: STRUCTURE_CONTAINER,
+          result: OK_CODE,
+          mode: 'recoverySeed'
+        })
+      ])
+    );
+  });
+
   it('keeps construction seed suppressed while the CPU bucket is critical', () => {
     installRecoveryConstructionSeedGlobals();
     const { room, spawn } = makeRecoveryConstructionSeedRoom('E29N55');
@@ -5115,6 +5163,7 @@ function installRecoveryConstructionSeedGlobals(): void {
     STRUCTURE_SPAWN: StructureConstant;
     STRUCTURE_EXTENSION: StructureConstant;
     STRUCTURE_CONTAINER: StructureConstant;
+    STRUCTURE_ROAD: StructureConstant;
     STRUCTURE_TOWER: StructureConstant;
     STRUCTURE_RAMPART: StructureConstant;
     STRUCTURE_WALL: StructureConstant;
@@ -5133,6 +5182,7 @@ function installRecoveryConstructionSeedGlobals(): void {
   (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
   (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
   (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+  (globalThis as unknown as { STRUCTURE_ROAD: StructureConstant }).STRUCTURE_ROAD = 'road';
   (globalThis as unknown as { STRUCTURE_TOWER: StructureConstant }).STRUCTURE_TOWER = 'tower';
   (globalThis as unknown as { STRUCTURE_RAMPART: StructureConstant }).STRUCTURE_RAMPART = 'rampart';
   (globalThis as unknown as { STRUCTURE_WALL: StructureConstant }).STRUCTURE_WALL = 'constructedWall';
@@ -5170,7 +5220,16 @@ function makeSpawnCoordinationRoom({
   } as unknown as Room;
 }
 
-function makeRecoveryConstructionSeedRoom(roomName: string): {
+function makeRecoveryConstructionSeedRoom(
+  roomName: string,
+  options: {
+    controllerLevel?: number;
+    energyAvailable?: number;
+    energyCapacityAvailable?: number;
+    extensionCount?: number;
+    roadedSourceAdjacency?: boolean;
+  } = {}
+): {
   room: Room & { createConstructionSite: jest.Mock };
   spawn: StructureSpawn;
 } {
@@ -5181,7 +5240,7 @@ function makeRecoveryConstructionSeedRoom(roomName: string): {
   } as Source;
   let spawn = {} as StructureSpawn;
   const extensions = Array.from(
-    { length: 10 },
+    { length: options.extensionCount ?? 10 },
     (_, index) =>
       ({
         id: `${roomName}-extension-${index}`,
@@ -5189,15 +5248,35 @@ function makeRecoveryConstructionSeedRoom(roomName: string): {
         pos: { x: 30 + index, y: 30, roomName } as RoomPosition
       }) as StructureExtension
   );
+  const sourceAdjacentRoads = options.roadedSourceAdjacency === true
+    ? Array.from({ length: 8 }, (_value, index) => {
+        const offsets = [
+          [-1, -1],
+          [0, -1],
+          [1, -1],
+          [-1, 0],
+          [1, 0],
+          [-1, 1],
+          [0, 1],
+          [1, 1]
+        ] as const;
+        const [dx, dy] = offsets[index];
+        return {
+          id: `${roomName}-source-road-${index}`,
+          structureType: 'road',
+          pos: { x: source.pos.x + dx, y: source.pos.y + dy, roomName } as RoomPosition
+        } as StructureRoad;
+      })
+    : [];
   const room = {
     name: roomName,
-    energyAvailable: 800,
-    energyCapacityAvailable: 800,
+    energyAvailable: options.energyAvailable ?? 800,
+    energyCapacityAvailable: options.energyCapacityAvailable ?? 800,
     controller: {
       id: `${roomName}-controller`,
       my: true,
       owner: { username: 'me' },
-      level: 3,
+      level: options.controllerLevel ?? 3,
       ticksToDowngrade: 10_000,
       pos: { x: 25, y: 25, roomName } as RoomPosition
     } as StructureController,
@@ -5207,7 +5286,7 @@ function makeRecoveryConstructionSeedRoom(roomName: string): {
         type === FIND_SOURCES
           ? [source]
           : type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES
-            ? ([spawn as unknown as AnyOwnedStructure, ...extensions] as unknown[])
+            ? ([spawn as unknown as AnyOwnedStructure, ...extensions, ...sourceAdjacentRoads] as unknown[])
             : type === FIND_MY_CONSTRUCTION_SITES || type === FIND_CONSTRUCTION_SITES
               ? constructionSites
               : [];

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -5265,6 +5265,7 @@ function makeRecoveryConstructionSeedRoom(
         return {
           id: `${roomName}-source-rampart`,
           structureType: 'rampart',
+          my: true,
           pos: { x: source.pos.x + dx, y: source.pos.y + dy, roomName } as RoomPosition
         } as StructureRampart;
       })()

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -2162,7 +2162,7 @@ describe('runEconomy', () => {
     );
   });
 
-  it('seeds a source-container candidate over roaded source tiles during low-bucket recovery', () => {
+  it('seeds a source-container candidate on a rampart opening around roaded source tiles during low-bucket recovery', () => {
     installRecoveryConstructionSeedGlobals();
     const { room, spawn } = makeRecoveryConstructionSeedRoom('E29N55', {
       controllerLevel: 6,
@@ -2195,7 +2195,7 @@ describe('runEconomy', () => {
     const summary = runEconomy();
 
     expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
-    expect(room.createConstructionSite).toHaveBeenCalledWith(11, 11, STRUCTURE_CONTAINER);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(10, 11, STRUCTURE_CONTAINER);
     expect(summary?.events).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -5249,25 +5249,28 @@ function makeRecoveryConstructionSeedRoom(
       }) as StructureExtension
   );
   const sourceAdjacentRoads = options.roadedSourceAdjacency === true
-    ? Array.from({ length: 8 }, (_value, index) => {
-        const offsets = [
-          [-1, -1],
-          [0, -1],
-          [1, -1],
-          [-1, 0],
-          [1, 0],
-          [-1, 1],
-          [0, 1],
-          [1, 1]
-        ] as const;
-        const [dx, dy] = offsets[index];
-        return {
-          id: `${roomName}-source-road-${index}`,
-          structureType: 'road',
-          pos: { x: source.pos.x + dx, y: source.pos.y + dy, roomName } as RoomPosition
-        } as StructureRoad;
-      })
+    ? getSourceAdjacentOffsets()
+        .filter(([dx, dy]) => dx !== 0 || dy !== 1)
+        .map(([dx, dy], index) => {
+          return {
+            id: `${roomName}-source-road-${index}`,
+            structureType: 'road',
+            pos: { x: source.pos.x + dx, y: source.pos.y + dy, roomName } as RoomPosition
+          } as StructureRoad;
+        })
     : [];
+  const sourceAdjacentRamparts = options.roadedSourceAdjacency === true
+    ? (() => {
+        const [dx, dy] = [0, 1] as const;
+        return {
+          id: `${roomName}-source-rampart`,
+          structureType: 'rampart',
+          pos: { x: source.pos.x + dx, y: source.pos.y + dy, roomName } as RoomPosition
+        } as StructureRampart;
+      })()
+    : null;
+  const sourceAdjacentStructures =
+    sourceAdjacentRamparts === null ? sourceAdjacentRoads : [...sourceAdjacentRoads, sourceAdjacentRamparts];
   const room = {
     name: roomName,
     energyAvailable: options.energyAvailable ?? 800,
@@ -5286,7 +5289,7 @@ function makeRecoveryConstructionSeedRoom(
         type === FIND_SOURCES
           ? [source]
           : type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES
-            ? ([spawn as unknown as AnyOwnedStructure, ...extensions, ...sourceAdjacentRoads] as unknown[])
+            ? ([spawn as unknown as AnyOwnedStructure, ...extensions, ...sourceAdjacentStructures] as unknown[])
             : type === FIND_MY_CONSTRUCTION_SITES || type === FIND_CONSTRUCTION_SITES
               ? constructionSites
               : [];
@@ -5314,6 +5317,19 @@ function makeRecoveryConstructionSeedRoom(
   } as unknown as StructureSpawn;
 
   return { room, spawn };
+}
+
+function getSourceAdjacentOffsets(): ReadonlyArray<readonly [number, number]> {
+  return [
+    [-1, -1],
+    [0, -1],
+    [1, -1],
+    [-1, 0],
+    [1, 0],
+    [-1, 1],
+    [0, 1],
+    [1, 1]
+  ] as const;
 }
 
 function makeClaimedSpawnlessEconomyRoom({

--- a/prod/test/sourceContainerPlanner.test.ts
+++ b/prod/test/sourceContainerPlanner.test.ts
@@ -9,6 +9,8 @@ describe('source container planner', () => {
     (globalThis as unknown as { FIND_STRUCTURES: number }).FIND_STRUCTURES = 2;
     (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 3;
     (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+    (globalThis as unknown as { STRUCTURE_RAMPART: StructureConstant }).STRUCTURE_RAMPART = 'rampart';
+    (globalThis as unknown as { STRUCTURE_ROAD: StructureConstant }).STRUCTURE_ROAD = 'road';
     (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
     (globalThis as unknown as { OK: ScreepsReturnCode }).OK = OK_CODE;
   });
@@ -44,6 +46,34 @@ describe('source container planner', () => {
     expect(planSourceContainerConstruction(colony)).toBeNull();
 
     expect(room.createConstructionSite).not.toHaveBeenCalled();
+  });
+
+  it('treats source-adjacent roads as blocking while allowing rampart overlays', () => {
+    const source = makeSource('source1', 10, 10);
+    const rampartOffset = [-1, 0] as const;
+    const roadOffsets = [
+      [-1, -1],
+      [0, -1],
+      [1, -1],
+      [1, 0],
+      [-1, 1],
+      [0, 1],
+      [1, 1]
+    ] as const;
+    const { room, colony } = makeColony({
+      sources: [source],
+      structures: [
+        ...roadOffsets.map(([dx, dy], index) =>
+          makeStructure(`source-road-${index}`, 'road', source.pos.x + dx, source.pos.y + dy)
+        ),
+        makeStructure('source-rampart', 'rampart', source.pos.x + rampartOffset[0], source.pos.y + rampartOffset[1])
+      ]
+    });
+
+    expect(planSourceContainerConstruction(colony)).toBe(OK_CODE);
+
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(9, 10, STRUCTURE_CONTAINER);
   });
 });
 

--- a/prod/test/sourceContainerPlanner.test.ts
+++ b/prod/test/sourceContainerPlanner.test.ts
@@ -48,7 +48,7 @@ describe('source container planner', () => {
     expect(room.createConstructionSite).not.toHaveBeenCalled();
   });
 
-  it('treats source-adjacent roads as blocking while allowing rampart overlays', () => {
+  it('treats source-adjacent roads as blocking while allowing owned rampart overlays', () => {
     const source = makeSource('source1', 10, 10);
     const rampartOffset = [-1, 0] as const;
     const roadOffsets = [
@@ -66,7 +66,13 @@ describe('source container planner', () => {
         ...roadOffsets.map(([dx, dy], index) =>
           makeStructure(`source-road-${index}`, 'road', source.pos.x + dx, source.pos.y + dy)
         ),
-        makeStructure('source-rampart', 'rampart', source.pos.x + rampartOffset[0], source.pos.y + rampartOffset[1])
+        makeStructure(
+          'source-rampart',
+          'rampart',
+          source.pos.x + rampartOffset[0],
+          source.pos.y + rampartOffset[1],
+          true
+        )
       ]
     });
 
@@ -74,6 +80,33 @@ describe('source container planner', () => {
 
     expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
     expect(room.createConstructionSite).toHaveBeenCalledWith(9, 10, STRUCTURE_CONTAINER);
+  });
+
+  it('keeps foreign ramparts blocking source-container placement', () => {
+    const source = makeSource('source1', 10, 10);
+    const roadOffsets = [
+      [-1, -1],
+      [1, -1],
+      [1, 0],
+      [-1, 1],
+      [0, 1],
+      [1, 1]
+    ] as const;
+    const { room, colony } = makeColony({
+      sources: [source],
+      structures: [
+        ...roadOffsets.map(([dx, dy], index) =>
+          makeStructure(`source-road-${index}`, 'road', source.pos.x + dx, source.pos.y + dy)
+        ),
+        makeStructure('foreign-rampart', 'rampart', source.pos.x - 1, source.pos.y, false),
+        makeStructure('owned-rampart', 'rampart', source.pos.x, source.pos.y - 1, true)
+      ]
+    });
+
+    expect(planSourceContainerConstruction(colony)).toBe(OK_CODE);
+
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(10, 9, STRUCTURE_CONTAINER);
   });
 });
 
@@ -140,10 +173,17 @@ function makeSource(id: string, x: number, y: number): Source {
   } as unknown as Source;
 }
 
-function makeStructure(id: string, structureType: StructureConstant, x: number, y: number): AnyStructure {
+function makeStructure(
+  id: string,
+  structureType: StructureConstant,
+  x: number,
+  y: number,
+  my?: boolean
+): AnyStructure {
   return {
     id,
     structureType,
+    ...(my === undefined ? {} : { my }),
     pos: { x, y, roomName: 'W1N1' } as RoomPosition
   } as unknown as AnyStructure;
 }


### PR DESCRIPTION
## Summary
- restores source-container site placement when the room is in the safe CPU recovery corridor and postdeploy evidence shows the candidate is accepted but sites disappear again
- tightens the source-container planning path so already-planned source-container sites are treated as viable recovery work instead of falling back to no-site suppression
- adds focused regressions for the post-#1793 evidence shape and rebuilds `prod/dist/main.js`

## Related issue
Related to issue #1781. The issue-level runtime acceptance gate stays open for deploy evidence after this PR lands.

## Verification
Controller-side verification from `/root/screeps-worktrees/1781-postdeploy-suppressed-after-1793/prod`:
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` — 105 suites / 2387 tests passed
- `npm run build`
- `git diff --check HEAD~1..HEAD`

Codex commit-only evidence:
- commit `09629b407d2e755312ca1e7f732ea9e7b141711e`
- author `lanyusea's bot <lanyusea@gmail.com>`
- files: `prod/src/construction/constructionPriority.ts`, `prod/src/construction/sourceContainerPlanner.ts`, `prod/test/constructionPlanner.test.ts`, `prod/test/economyLoop.test.ts`, `prod/dist/main.js`

## Universal task Done gate
- [x] Task type: P0 gameplay bugfix PR for postdeploy construction site-placement recovery.
- [x] Expected observable outcome / named deliverable: Verified source/test/bundle change that preserves accepted source-container construction candidates as viable work during safe CPU recovery after #1793.
- [x] Non-goals / accepted substitutes: PR merge alone is not issue Done; issue acceptance uses runtime construction snapshots, with no owner-side choice required.
- [x] Verification evidence required before Done: Controller ran diff-check, typecheck, full Jest, build, and PR-range diff-check successfully; PR CI and review-thread gates still apply.
- [x] Project Evidence / Next action / Blocked by: Project #1781 records commit recovery evidence and next deploy-observation action; no owner-side blocker.
- [x] Post-merge/deploy/runtime proof: Official deploy artifact plus fresh runtime-summary evidence must show constructionSiteCount, taskCounts.build, buildCarriedEnergy, buildProgress, or a concrete non-actionable clear condition.
- [x] Named deliverable proof: Commit 09629b40 contains the verified construction source, regression tests, and rebuilt bundle deliverable.
