### PR TITLE
fix: seed residual construction road sites

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -14662,9 +14662,13 @@ var DEFAULT_MAX_DEFENSE_FLOOR_SITES_PER_TICK = 2;
 var MIN_RCL_FOR_SOURCE_LOGISTICS_STARVATION_PRIORITY2 = 4;
 var SOURCE_LOGISTICS_STARVATION_ENERGY_RATIO2 = 0.5;
 var SPAWN_ENERGY_CAPACITY_FALLBACK2 = 300;
+var ROOM_EDGE_MIN8 = 1;
+var ROOM_EDGE_MAX8 = 48;
 var SPAWN_EDGE_MIN = 2;
 var SPAWN_EDGE_MAX = 47;
 var MAX_SPAWN_SITE_SCAN_RADIUS = 8;
+var RESIDUAL_ROAD_SEED_MAX_RADIUS = 3;
+var MIN_RESIDUAL_CONSTRUCTION_SEED_WORKERS = 1;
 var DEFAULT_TERRAIN_WALL_MASK12 = 1;
 var OK_CODE7 = 0;
 var ERR_FULL_CODE3 = -8;
@@ -14770,6 +14774,7 @@ function planConstructionForColony(colony, options = {}) {
       }
     }
     planStorage(colony, result, budgetState, options);
+    planResidualStoredEnergyRoadSeed(colony, result, budgetState, options);
     return result;
   }
   let priorityTowerDefenseSiteState = shouldPrioritizeFirstTowerDefenseSiteBeforeRoutineConstruction(room, rcl, options) ? planPriorityTowerDefenseSiteIfNeeded(colony, result, budgetState, options, rcl) : "notNeeded";
@@ -14842,6 +14847,7 @@ function planConstructionForColony(colony, options = {}) {
     }
   }
   planStorage(colony, result, budgetState, options);
+  planResidualStoredEnergyRoadSeed(colony, result, budgetState, options);
   return result;
 }
 function planCapacityBootstrapExtensionForColony(colony, options = {}) {
@@ -14979,6 +14985,190 @@ function planStorage(colony, result, budgetState, options) {
     recordPlacement(result, budgetState, "storage", storageResult, options);
   }
 }
+function planResidualStoredEnergyRoadSeed(colony, result, budgetState, options) {
+  if (!shouldPlanResidualStoredEnergyRoadSeed(colony, result, budgetState, options)) {
+    return;
+  }
+  const position = selectResidualRoadSeedPosition(colony.room, colony);
+  if (!position) {
+    return;
+  }
+  const placementResult = colony.room.createConstructionSite(
+    position.x,
+    position.y,
+    getStructureConstant6("STRUCTURE_ROAD")
+  );
+  if (placementResult === getOkCode5() || isFatalConstructionSiteResult3(placementResult)) {
+    recordPlacement(result, budgetState, "road", placementResult, options, position);
+  }
+}
+function shouldPlanResidualStoredEnergyRoadSeed(colony, result, budgetState, options) {
+  return result.placements.length <= 0 && !hasReachedPlacementLimit(result, options) && shouldUseStoredEnergyConstructionSeedSlot(colony.room, budgetState) && hasRemainingStructureCapacity(colony.room, "road") && hasResidualConstructionWorkerCoverage(colony.room.name, options.creeps) && isResidualConstructionSeedRoomSafe(colony);
+}
+function hasResidualConstructionWorkerCoverage(roomName, creeps) {
+  if (!creeps || creeps.length < MIN_RESIDUAL_CONSTRUCTION_SEED_WORKERS) {
+    return false;
+  }
+  let workers = 0;
+  for (const creep of creeps) {
+    if (!isResidualConstructionWorker(roomName, creep)) {
+      continue;
+    }
+    workers += 1;
+    if (workers >= MIN_RESIDUAL_CONSTRUCTION_SEED_WORKERS) {
+      return true;
+    }
+  }
+  return false;
+}
+function isResidualConstructionWorker(roomName, creep) {
+  var _a2;
+  const memory = creep.memory;
+  const ttl = creep.ticksToLive;
+  const creepRoomName = (_a2 = creep.room) == null ? void 0 : _a2.name;
+  return memory.role === "worker" && (memory.colony === roomName || creepRoomName === roomName) && (typeof ttl !== "number" || ttl > 0);
+}
+function isResidualConstructionSeedRoomSafe(colony) {
+  var _a2;
+  const room = colony.room;
+  return ((_a2 = room.controller) == null ? void 0 : _a2.my) === true && getOwnedRoomRcl6(room) >= 2 && hasOwnedSpawn(colony) && countVisibleHostileThreats(room) <= 0;
+}
+function countVisibleHostileThreats(room) {
+  return findRoomObjects18(room, "FIND_HOSTILE_CREEPS").length + findRoomObjects18(room, "FIND_HOSTILE_STRUCTURES").length;
+}
+function selectResidualRoadSeedPosition(room, colony) {
+  const lookups = buildResidualRoadSeedLookups(room);
+  if (!lookups.terrain) {
+    return null;
+  }
+  for (const anchor of selectResidualRoadSeedAnchors(room, colony, lookups)) {
+    for (const position of getResidualRoadSeedCandidatePositions(anchor, room.name)) {
+      if (canPlaceResidualRoadSeed(lookups, position)) {
+        return position;
+      }
+    }
+  }
+  return null;
+}
+function buildResidualRoadSeedLookups(room) {
+  const structures = findUniqueRoomObjectsByStableKey([
+    ...findRoomObjects18(room, "FIND_STRUCTURES"),
+    ...findRoomObjects18(room, "FIND_MY_STRUCTURES")
+  ]);
+  const sites = findUniqueRoomObjectsByStableKey([
+    ...findRoomObjects18(room, "FIND_CONSTRUCTION_SITES"),
+    ...findRoomObjects18(room, "FIND_MY_CONSTRUCTION_SITES")
+  ]);
+  const blockingPositions = /* @__PURE__ */ new Set();
+  const existingRoadPositions = /* @__PURE__ */ new Set();
+  for (const object of [room.controller, ...getSortedSources3(room)]) {
+    const position = getAnyObjectPosition(object);
+    if (position !== null && isSameRoomPosition6(position, room.name)) {
+      blockingPositions.add(getPositionKey7(position));
+    }
+  }
+  for (const structure of structures) {
+    const position = getAnyObjectPosition(structure);
+    if (position === null || !isSameRoomPosition6(position, room.name)) {
+      continue;
+    }
+    if (structure.structureType === getStructureConstant6("STRUCTURE_ROAD")) {
+      existingRoadPositions.add(getPositionKey7(position));
+      continue;
+    }
+    if (!isRoadSeedPassableRampart(structure)) {
+      blockingPositions.add(getPositionKey7(position));
+    }
+  }
+  for (const site of sites) {
+    const position = getAnyObjectPosition(site);
+    if (position === null || !isSameRoomPosition6(position, room.name)) {
+      continue;
+    }
+    if (site.structureType === getStructureConstant6("STRUCTURE_ROAD")) {
+      existingRoadPositions.add(getPositionKey7(position));
+    } else {
+      blockingPositions.add(getPositionKey7(position));
+    }
+  }
+  return {
+    structures,
+    blockingPositions,
+    existingRoadPositions,
+    terrain: getRoomTerrain9(room)
+  };
+}
+function selectResidualRoadSeedAnchors(room, colony, lookups) {
+  const anchors = [];
+  const storageType = getStructureConstant6("STRUCTURE_STORAGE");
+  for (const structure of lookups.structures) {
+    if (structure.structureType !== storageType) {
+      continue;
+    }
+    const position = getAnyObjectPosition(structure);
+    if (position !== null && isSameRoomPosition6(position, room.name)) {
+      anchors.push(position);
+    }
+  }
+  for (const spawn of colony.spawns) {
+    const position = getAnyObjectPosition(spawn);
+    if (position !== null && isSameRoomPosition6(position, room.name)) {
+      anchors.push(position);
+    }
+  }
+  const controllerPosition = getAnyObjectPosition(room.controller);
+  if (controllerPosition !== null && isSameRoomPosition6(controllerPosition, room.name)) {
+    anchors.push(controllerPosition);
+  }
+  return dedupeCandidatePositions(anchors);
+}
+function getResidualRoadSeedCandidatePositions(anchor, roomName) {
+  const positions = [];
+  for (let radius = 1; radius <= RESIDUAL_ROAD_SEED_MAX_RADIUS; radius += 1) {
+    for (let y = anchor.y - radius; y <= anchor.y + radius; y += 1) {
+      for (let x = anchor.x - radius; x <= anchor.x + radius; x += 1) {
+        if (Math.max(Math.abs(x - anchor.x), Math.abs(y - anchor.y)) !== radius) {
+          continue;
+        }
+        positions.push({ x, y, roomName });
+      }
+    }
+  }
+  return positions;
+}
+function canPlaceResidualRoadSeed(lookups, position) {
+  return isWithinRoomBuildBounds2(position) && !lookups.blockingPositions.has(getPositionKey7(position)) && !lookups.existingRoadPositions.has(getPositionKey7(position)) && !isTerrainWall7(lookups.terrain, position);
+}
+function isRoadSeedPassableRampart(structure) {
+  return structure.structureType === getStructureConstant6("STRUCTURE_RAMPART") && structure.my !== false;
+}
+function dedupeCandidatePositions(positions) {
+  var _a2;
+  const seen = /* @__PURE__ */ new Set();
+  const deduped = [];
+  for (const position of positions) {
+    const key = `${(_a2 = position.roomName) != null ? _a2 : ""}:${getPositionKey7(position)}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(position);
+  }
+  return deduped;
+}
+function findUniqueRoomObjectsByStableKey(objects) {
+  const seen = /* @__PURE__ */ new Set();
+  const uniqueObjects = [];
+  objects.forEach((object, index) => {
+    const key = getObjectStableKey(object, index);
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    uniqueObjects.push(object);
+  });
+  return uniqueObjects;
+}
 function planRuntimeStrategyPrioritizedConstruction(colony, result, budgetState, options, priorityTowerDefenseSiteState, sourceLogisticsStarved, rcl) {
   if (options.runtimeStrategyConstructionEnabled !== true) {
     return false;
@@ -15000,6 +15190,7 @@ function planRuntimeStrategyPrioritizedConstruction(colony, result, budgetState,
   if (priorities.length === 0) {
     return false;
   }
+  const initialPlacementCount = result.placements.length;
   let activePriorityTowerDefenseSiteState = priorityTowerDefenseSiteState;
   for (const priority of priorities) {
     activePriorityTowerDefenseSiteState = planRuntimeConstructionPlannerPriority(
@@ -15015,7 +15206,7 @@ function planRuntimeStrategyPrioritizedConstruction(colony, result, budgetState,
       return true;
     }
   }
-  return true;
+  return result.placements.length > initialPlacementCount || hasBlockingPlacementFailure(result);
 }
 function recordStrategyRegistryRuntimeUse(options, strategyEntry) {
   if (!options.onStrategyRegistryRuntimeUse) {
@@ -15614,7 +15805,13 @@ function lookForArea2(room, lookConstantName, anchor, maximumScanRadius) {
   }
 }
 function canPlaceSpawn(lookups, position) {
-  return position.x >= SPAWN_EDGE_MIN && position.x <= SPAWN_EDGE_MAX && position.y >= SPAWN_EDGE_MIN && position.y <= SPAWN_EDGE_MAX && !lookups.blockingPositions.has(getPositionKey7(position)) && !lookups.mineralPositions.has(getPositionKey7(position)) && hasMinimumSpawnRange2(lookups, position) && !isTerrainWall7(lookups.terrain, position);
+  return isWithinSpawnBuildBounds(position) && !lookups.blockingPositions.has(getPositionKey7(position)) && !lookups.mineralPositions.has(getPositionKey7(position)) && hasMinimumSpawnRange2(lookups, position) && !isTerrainWall7(lookups.terrain, position);
+}
+function isWithinSpawnBuildBounds(position) {
+  return position.x >= SPAWN_EDGE_MIN && position.x <= SPAWN_EDGE_MAX && position.y >= SPAWN_EDGE_MIN && position.y <= SPAWN_EDGE_MAX;
+}
+function isWithinRoomBuildBounds2(position) {
+  return position.x >= ROOM_EDGE_MIN8 && position.x <= ROOM_EDGE_MAX8 && position.y >= ROOM_EDGE_MIN8 && position.y <= ROOM_EDGE_MAX8;
 }
 function hasMinimumSpawnRange2(lookups, position) {
   return lookups.rangeReservedPositions.every(
@@ -16864,8 +17061,8 @@ function getGameTime20() {
 
 // src/construction/sourceContainerPlanner.ts
 var MIN_CONTROLLER_LEVEL_FOR_SOURCE_CONTAINERS = 2;
-var ROOM_EDGE_MIN8 = 1;
-var ROOM_EDGE_MAX8 = 48;
+var ROOM_EDGE_MIN9 = 1;
+var ROOM_EDGE_MAX9 = 48;
 var DEFAULT_TERRAIN_WALL_MASK13 = 1;
 function planSourceContainerConstruction2(colony, options = {}) {
   var _a2, _b;
@@ -16997,7 +17194,7 @@ function getAdjacentSourceContainerPositions(sourcePosition) {
   return positions;
 }
 function canPlaceSourceContainer2(lookups, position) {
-  if (position.x < ROOM_EDGE_MIN8 || position.x > ROOM_EDGE_MAX8 || position.y < ROOM_EDGE_MIN8 || position.y > ROOM_EDGE_MAX8) {
+  if (position.x < ROOM_EDGE_MIN9 || position.x > ROOM_EDGE_MAX9 || position.y < ROOM_EDGE_MIN9 || position.y > ROOM_EDGE_MAX9) {
     return false;
   }
   if ((lookups.terrain.get(position.x, position.y) & getTerrainWallMask8()) !== 0) {
@@ -40882,8 +41079,8 @@ function getGlobalNumber17(name) {
 }
 
 // src/economy/sourceContainerPlanner.ts
-var ROOM_EDGE_MIN9 = 1;
-var ROOM_EDGE_MAX9 = 48;
+var ROOM_EDGE_MIN10 = 1;
+var ROOM_EDGE_MAX10 = 48;
 var DEFAULT_TERRAIN_WALL_MASK15 = 1;
 var ERR_INVALID_TARGET_CODE5 = -7;
 var REMOTE_HARVESTER_ROLE2 = "remoteHarvester";
@@ -41173,7 +41370,7 @@ function getRoomTerrain12(room) {
   return typeof ((_a2 = game == null ? void 0 : game.map) == null ? void 0 : _a2.getRoomTerrain) === "function" ? game.map.getRoomTerrain(room.name) : null;
 }
 function isWithinBuildableRoomBounds4(position) {
-  return position.x >= ROOM_EDGE_MIN9 && position.x <= ROOM_EDGE_MAX9 && position.y >= ROOM_EDGE_MIN9 && position.y <= ROOM_EDGE_MAX9;
+  return position.x >= ROOM_EDGE_MIN10 && position.x <= ROOM_EDGE_MAX10 && position.y >= ROOM_EDGE_MIN10 && position.y <= ROOM_EDGE_MAX10;
 }
 function isTerrainWall8(terrain, position) {
   return (terrain.get(position.x, position.y) & getTerrainWallMask11()) !== 0;

--- a/prod/src/construction/planner.ts
+++ b/prod/src/construction/planner.ts
@@ -93,7 +93,9 @@ type FindConstantGlobal =
   | 'FIND_STRUCTURES'
   | 'FIND_CONSTRUCTION_SITES'
   | 'FIND_MY_STRUCTURES'
-  | 'FIND_MY_CONSTRUCTION_SITES';
+  | 'FIND_MY_CONSTRUCTION_SITES'
+  | 'FIND_HOSTILE_CREEPS'
+  | 'FIND_HOSTILE_STRUCTURES';
 type LookConstantGlobal = 'LOOK_STRUCTURES' | 'LOOK_CONSTRUCTION_SITES' | 'LOOK_MINERALS';
 type StructureConstantGlobal =
   | 'STRUCTURE_SPAWN'
@@ -116,6 +118,13 @@ interface SpawnPlacementLookups {
   blockingPositions: Set<string>;
   mineralPositions: Set<string>;
   rangeReservedPositions: CandidatePosition[];
+  terrain: RoomTerrain | null;
+}
+
+interface ResidualRoadSeedLookups {
+  structures: Structure[];
+  blockingPositions: Set<string>;
+  existingRoadPositions: Set<string>;
   terrain: RoomTerrain | null;
 }
 
@@ -143,6 +152,8 @@ const ROOM_EDGE_MAX = 48;
 const SPAWN_EDGE_MIN = 2;
 const SPAWN_EDGE_MAX = 47;
 const MAX_SPAWN_SITE_SCAN_RADIUS = 8;
+const RESIDUAL_ROAD_SEED_MAX_RADIUS = 3;
+const MIN_RESIDUAL_CONSTRUCTION_SEED_WORKERS = 1;
 const DEFAULT_TERRAIN_WALL_MASK = 1;
 const OK_CODE = 0 as ScreepsReturnCode;
 const ERR_FULL_CODE = -8 as ScreepsReturnCode;
@@ -284,6 +295,7 @@ export function planConstructionForColony(
     }
 
     planStorage(colony, result, budgetState, options);
+    planResidualStoredEnergyRoadSeed(colony, result, budgetState, options);
     return result;
   }
 
@@ -372,6 +384,7 @@ export function planConstructionForColony(
     }
   }
   planStorage(colony, result, budgetState, options);
+  planResidualStoredEnergyRoadSeed(colony, result, budgetState, options);
 
   return result;
 }
@@ -618,6 +631,264 @@ function planStorage(
   }
 }
 
+function planResidualStoredEnergyRoadSeed(
+  colony: ColonySnapshot,
+  result: RoomConstructionPlannerResult,
+  budgetState: ConstructionBudgetState,
+  options: ConstructionPlannerOptions
+): void {
+  if (!shouldPlanResidualStoredEnergyRoadSeed(colony, result, budgetState, options)) {
+    return;
+  }
+
+  const position = selectResidualRoadSeedPosition(colony.room, colony);
+  if (!position) {
+    return;
+  }
+
+  const placementResult = colony.room.createConstructionSite(
+    position.x,
+    position.y,
+    getStructureConstant('STRUCTURE_ROAD')
+  );
+  if (placementResult === getOkCode() || isFatalConstructionSiteResult(placementResult)) {
+    recordPlacement(result, budgetState, 'road', placementResult, options, position);
+  }
+}
+
+function shouldPlanResidualStoredEnergyRoadSeed(
+  colony: ColonySnapshot,
+  result: RoomConstructionPlannerResult,
+  budgetState: ConstructionBudgetState,
+  options: ConstructionPlannerOptions
+): boolean {
+  return (
+    result.placements.length <= 0 &&
+    !hasReachedPlacementLimit(result, options) &&
+    shouldUseStoredEnergyConstructionSeedSlot(colony.room, budgetState) &&
+    hasRemainingStructureCapacity(colony.room, 'road') &&
+    hasResidualConstructionWorkerCoverage(colony.room.name, options.creeps) &&
+    isResidualConstructionSeedRoomSafe(colony)
+  );
+}
+
+function hasResidualConstructionWorkerCoverage(roomName: string, creeps: Creep[] | undefined): boolean {
+  if (!creeps || creeps.length < MIN_RESIDUAL_CONSTRUCTION_SEED_WORKERS) {
+    return false;
+  }
+
+  let workers = 0;
+  for (const creep of creeps) {
+    if (!isResidualConstructionWorker(roomName, creep)) {
+      continue;
+    }
+
+    workers += 1;
+    if (workers >= MIN_RESIDUAL_CONSTRUCTION_SEED_WORKERS) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isResidualConstructionWorker(roomName: string, creep: Creep): boolean {
+  const memory = creep.memory as { role?: unknown; colony?: unknown };
+  const ttl = (creep as { ticksToLive?: unknown }).ticksToLive;
+  const creepRoomName = (creep as { room?: { name?: unknown } }).room?.name;
+  return (
+    memory.role === 'worker' &&
+    (memory.colony === roomName || creepRoomName === roomName) &&
+    (typeof ttl !== 'number' || ttl > 0)
+  );
+}
+
+function isResidualConstructionSeedRoomSafe(colony: ColonySnapshot): boolean {
+  const room = colony.room;
+  return (
+    room.controller?.my === true &&
+    getOwnedRoomRcl(room) >= 2 &&
+    hasOwnedSpawn(colony) &&
+    countVisibleHostileThreats(room) <= 0
+  );
+}
+
+function countVisibleHostileThreats(room: Room): number {
+  return (
+    findRoomObjects<Creep>(room, 'FIND_HOSTILE_CREEPS').length +
+    findRoomObjects<Structure>(room, 'FIND_HOSTILE_STRUCTURES').length
+  );
+}
+
+function selectResidualRoadSeedPosition(room: Room, colony: ColonySnapshot): CandidatePosition | null {
+  const lookups = buildResidualRoadSeedLookups(room);
+  if (!lookups.terrain) {
+    return null;
+  }
+
+  for (const anchor of selectResidualRoadSeedAnchors(room, colony, lookups)) {
+    for (const position of getResidualRoadSeedCandidatePositions(anchor, room.name)) {
+      if (canPlaceResidualRoadSeed(lookups, position)) {
+        return position;
+      }
+    }
+  }
+
+  return null;
+}
+
+function buildResidualRoadSeedLookups(room: Room): ResidualRoadSeedLookups {
+  const structures = findUniqueRoomObjectsByStableKey<Structure>([
+    ...findRoomObjects<Structure>(room, 'FIND_STRUCTURES'),
+    ...findRoomObjects<Structure>(room, 'FIND_MY_STRUCTURES')
+  ]);
+  const sites = findUniqueRoomObjectsByStableKey<ConstructionSite>([
+    ...findRoomObjects<ConstructionSite>(room, 'FIND_CONSTRUCTION_SITES'),
+    ...findRoomObjects<ConstructionSite>(room, 'FIND_MY_CONSTRUCTION_SITES')
+  ]);
+  const blockingPositions = new Set<string>();
+  const existingRoadPositions = new Set<string>();
+  for (const object of [room.controller, ...getSortedSources(room)]) {
+    const position = getAnyObjectPosition(object);
+    if (position !== null && isSameRoomPosition(position, room.name)) {
+      blockingPositions.add(getPositionKey(position));
+    }
+  }
+
+  for (const structure of structures) {
+    const position = getAnyObjectPosition(structure);
+    if (position === null || !isSameRoomPosition(position, room.name)) {
+      continue;
+    }
+
+    if (structure.structureType === getStructureConstant('STRUCTURE_ROAD')) {
+      existingRoadPositions.add(getPositionKey(position));
+      continue;
+    }
+
+    if (!isRoadSeedPassableRampart(structure)) {
+      blockingPositions.add(getPositionKey(position));
+    }
+  }
+
+  for (const site of sites) {
+    const position = getAnyObjectPosition(site);
+    if (position === null || !isSameRoomPosition(position, room.name)) {
+      continue;
+    }
+
+    if (site.structureType === getStructureConstant('STRUCTURE_ROAD')) {
+      existingRoadPositions.add(getPositionKey(position));
+    } else {
+      blockingPositions.add(getPositionKey(position));
+    }
+  }
+
+  return {
+    structures,
+    blockingPositions,
+    existingRoadPositions,
+    terrain: getRoomTerrain(room)
+  };
+}
+
+function selectResidualRoadSeedAnchors(
+  room: Room,
+  colony: ColonySnapshot,
+  lookups: ResidualRoadSeedLookups
+): CandidatePosition[] {
+  const anchors: CandidatePosition[] = [];
+  const storageType = getStructureConstant('STRUCTURE_STORAGE');
+  for (const structure of lookups.structures) {
+    if (structure.structureType !== storageType) {
+      continue;
+    }
+
+    const position = getAnyObjectPosition(structure);
+    if (position !== null && isSameRoomPosition(position, room.name)) {
+      anchors.push(position);
+    }
+  }
+
+  for (const spawn of colony.spawns) {
+    const position = getAnyObjectPosition(spawn);
+    if (position !== null && isSameRoomPosition(position, room.name)) {
+      anchors.push(position);
+    }
+  }
+
+  const controllerPosition = getAnyObjectPosition(room.controller as RoomObject | undefined);
+  if (controllerPosition !== null && isSameRoomPosition(controllerPosition, room.name)) {
+    anchors.push(controllerPosition);
+  }
+
+  return dedupeCandidatePositions(anchors);
+}
+
+function getResidualRoadSeedCandidatePositions(anchor: CandidatePosition, roomName: string): CandidatePosition[] {
+  const positions: CandidatePosition[] = [];
+  for (let radius = 1; radius <= RESIDUAL_ROAD_SEED_MAX_RADIUS; radius += 1) {
+    for (let y = anchor.y - radius; y <= anchor.y + radius; y += 1) {
+      for (let x = anchor.x - radius; x <= anchor.x + radius; x += 1) {
+        if (Math.max(Math.abs(x - anchor.x), Math.abs(y - anchor.y)) !== radius) {
+          continue;
+        }
+
+        positions.push({ x, y, roomName });
+      }
+    }
+  }
+
+  return positions;
+}
+
+function canPlaceResidualRoadSeed(lookups: ResidualRoadSeedLookups, position: CandidatePosition): boolean {
+  return (
+    isWithinRoomBuildBounds(position) &&
+    !lookups.blockingPositions.has(getPositionKey(position)) &&
+    !lookups.existingRoadPositions.has(getPositionKey(position)) &&
+    !isTerrainWall(lookups.terrain, position)
+  );
+}
+
+function isRoadSeedPassableRampart(structure: Structure): boolean {
+  return (
+    structure.structureType === getStructureConstant('STRUCTURE_RAMPART') &&
+    (structure as { my?: unknown }).my !== false
+  );
+}
+
+function dedupeCandidatePositions(positions: CandidatePosition[]): CandidatePosition[] {
+  const seen = new Set<string>();
+  const deduped: CandidatePosition[] = [];
+  for (const position of positions) {
+    const key = `${position.roomName ?? ''}:${getPositionKey(position)}`;
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    deduped.push(position);
+  }
+
+  return deduped;
+}
+
+function findUniqueRoomObjectsByStableKey<T extends Structure | ConstructionSite>(objects: T[]): T[] {
+  const seen = new Set<string>();
+  const uniqueObjects: T[] = [];
+  objects.forEach((object, index) => {
+    const key = getObjectStableKey(object, index);
+    if (seen.has(key)) {
+      return;
+    }
+
+    seen.add(key);
+    uniqueObjects.push(object);
+  });
+  return uniqueObjects;
+}
+
 function planRuntimeStrategyPrioritizedConstruction(
   colony: ColonySnapshot,
   result: RoomConstructionPlannerResult,
@@ -651,6 +922,7 @@ function planRuntimeStrategyPrioritizedConstruction(
     return false;
   }
 
+  const initialPlacementCount = result.placements.length;
   let activePriorityTowerDefenseSiteState = priorityTowerDefenseSiteState;
   for (const priority of priorities) {
     activePriorityTowerDefenseSiteState = planRuntimeConstructionPlannerPriority(
@@ -667,7 +939,7 @@ function planRuntimeStrategyPrioritizedConstruction(
     }
   }
 
-  return true;
+  return result.placements.length > initialPlacementCount || hasBlockingPlacementFailure(result);
 }
 
 function recordStrategyRegistryRuntimeUse(
@@ -1519,14 +1791,29 @@ function lookForArea(
 
 function canPlaceSpawn(lookups: SpawnPlacementLookups, position: CandidatePosition): boolean {
   return (
-    position.x >= SPAWN_EDGE_MIN &&
-    position.x <= SPAWN_EDGE_MAX &&
-    position.y >= SPAWN_EDGE_MIN &&
-    position.y <= SPAWN_EDGE_MAX &&
+    isWithinSpawnBuildBounds(position) &&
     !lookups.blockingPositions.has(getPositionKey(position)) &&
     !lookups.mineralPositions.has(getPositionKey(position)) &&
     hasMinimumSpawnRange(lookups, position) &&
     !isTerrainWall(lookups.terrain, position)
+  );
+}
+
+function isWithinSpawnBuildBounds(position: CandidatePosition): boolean {
+  return (
+    position.x >= SPAWN_EDGE_MIN &&
+    position.x <= SPAWN_EDGE_MAX &&
+    position.y >= SPAWN_EDGE_MIN &&
+    position.y <= SPAWN_EDGE_MAX
+  );
+}
+
+function isWithinRoomBuildBounds(position: CandidatePosition): boolean {
+  return (
+    position.x >= ROOM_EDGE_MIN &&
+    position.x <= ROOM_EDGE_MAX &&
+    position.y >= ROOM_EDGE_MIN &&
+    position.y <= ROOM_EDGE_MAX
   );
 }
 

--- a/prod/test/constructionPlanner.test.ts
+++ b/prod/test/constructionPlanner.test.ts
@@ -26,6 +26,8 @@ const TEST_GLOBALS = {
   FIND_MY_CONSTRUCTION_SITES: 3,
   FIND_STRUCTURES: 4,
   FIND_CONSTRUCTION_SITES: 5,
+  FIND_HOSTILE_CREEPS: 6,
+  FIND_HOSTILE_STRUCTURES: 7,
   LOOK_STRUCTURES: 'structure',
   LOOK_CONSTRUCTION_SITES: 'constructionSite',
   LOOK_MINERALS: 'mineral',
@@ -818,6 +820,113 @@ describe('owned room construction planner', () => {
     expect(room.createConstructionSite).toHaveBeenCalledWith(10, 10, TEST_GLOBALS.STRUCTURE_RAMPART);
   });
 
+  it('seeds a stored-energy road when runtime priority leaves a safe staffed room with no sites', () => {
+    installOpenTerrain();
+    const source = makeSource('source-a', 35, 35);
+    const { room, colony } = makeColony({
+      controllerLevel: 6,
+      energyAvailable: 0,
+      energyCapacityAvailable: 2_300,
+      structures: makeRecoveredRcl6ResidualConstructionStructures(source),
+      sources: [source],
+      pathsByTarget: {}
+    });
+
+    const result = planConstructionForColony(colony, {
+      creeps: makeWorkerCreeps(5),
+      respectRoomEnergyBuffer: true,
+      strategyRegistry: DEFAULT_STRATEGY_REGISTRY,
+      runtimeStrategyConstructionEnabled: true,
+      runtimeStrategyConstructionFallbackPriorities: false,
+      maxPlacementsPerRoom: 1,
+      maxContainerSitesPerTick: 1,
+      maxPendingContainerSites: 1,
+      roadOptions: {
+        maxSitesPerTick: 1,
+        maxPendingRoadSites: 1,
+        maxTargetsPerTick: 1
+      }
+    });
+
+    expect(result.placements).toEqual([
+      {
+        priority: 'road',
+        roomName: 'W1N1',
+        structureType: TEST_GLOBALS.STRUCTURE_ROAD,
+        result: OK_CODE,
+        energyReserved: 50,
+        x: 18,
+        y: 23
+      }
+    ]);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(18, 23, TEST_GLOBALS.STRUCTURE_ROAD);
+  });
+
+  it('does not seed the residual stored-energy road without assigned worker coverage', () => {
+    installOpenTerrain();
+    const source = makeSource('source-a', 35, 35);
+    const { room, colony } = makeColony({
+      controllerLevel: 6,
+      energyAvailable: 0,
+      energyCapacityAvailable: 2_300,
+      structures: makeRecoveredRcl6ResidualConstructionStructures(source),
+      sources: [source],
+      pathsByTarget: {}
+    });
+
+    const result = planConstructionForColony(colony, {
+      respectRoomEnergyBuffer: true,
+      strategyRegistry: DEFAULT_STRATEGY_REGISTRY,
+      runtimeStrategyConstructionEnabled: true,
+      runtimeStrategyConstructionFallbackPriorities: false,
+      maxPlacementsPerRoom: 1,
+      maxContainerSitesPerTick: 1,
+      maxPendingContainerSites: 1,
+      roadOptions: {
+        maxSitesPerTick: 1,
+        maxPendingRoadSites: 1,
+        maxTargetsPerTick: 1
+      }
+    });
+
+    expect(result.placements).toEqual([]);
+    expect(room.createConstructionSite).not.toHaveBeenCalled();
+  });
+
+  it('does not seed the residual stored-energy road under visible hostile pressure', () => {
+    installOpenTerrain();
+    const source = makeSource('source-a', 35, 35);
+    const { room, colony } = makeColony({
+      controllerLevel: 6,
+      energyAvailable: 0,
+      energyCapacityAvailable: 2_300,
+      structures: makeRecoveredRcl6ResidualConstructionStructures(source),
+      hostileCreeps: [makeHostileCreep('invader-1', 20, 20)],
+      sources: [source],
+      pathsByTarget: {}
+    });
+
+    const result = planConstructionForColony(colony, {
+      creeps: makeWorkerCreeps(5),
+      respectRoomEnergyBuffer: true,
+      strategyRegistry: DEFAULT_STRATEGY_REGISTRY,
+      runtimeStrategyConstructionEnabled: true,
+      runtimeStrategyConstructionFallbackPriorities: false,
+      maxPlacementsPerRoom: 1,
+      maxContainerSitesPerTick: 1,
+      maxPendingContainerSites: 1,
+      roadOptions: {
+        maxSitesPerTick: 1,
+        maxPendingRoadSites: 1,
+        maxTargetsPerTick: 1
+      }
+    });
+
+    expect(result.placements).toEqual([]);
+    expect(room.createConstructionSite).not.toHaveBeenCalled();
+  });
+
   it('respects CONTROLLER_STRUCTURES counts before calling lower-level planners', () => {
     const controllerStructures = makeControllerStructures();
     controllerStructures.extension[2] = 1;
@@ -979,6 +1088,8 @@ interface MakeColonyOptions {
   includeSpawn?: boolean;
   structures?: Structure[];
   constructionSites?: ConstructionSite[];
+  hostileCreeps?: Creep[];
+  hostileStructures?: Structure[];
   sources: Source[];
   pathsByTarget: Record<string, TestPosition[]>;
 }
@@ -1014,6 +1125,10 @@ function makeColony(options: MakeColonyOptions): { room: MockRoom; colony: Colon
       const targets =
         findType === TEST_GLOBALS.FIND_SOURCES
           ? options.sources
+          : findType === TEST_GLOBALS.FIND_HOSTILE_CREEPS
+            ? (options.hostileCreeps ?? [])
+            : findType === TEST_GLOBALS.FIND_HOSTILE_STRUCTURES
+              ? (options.hostileStructures ?? [])
           : findType === TEST_GLOBALS.FIND_MY_STRUCTURES || findType === TEST_GLOBALS.FIND_STRUCTURES
             ? structures
             : findType === TEST_GLOBALS.FIND_MY_CONSTRUCTION_SITES ||
@@ -1139,6 +1254,57 @@ function makeWorkerCreeps(count: number): Creep[] {
         memory: { role: 'worker', colony: 'W1N1' }
       }) as Creep
   );
+}
+
+function makeRecoveredRcl6ResidualConstructionStructures(source: Source): Structure[] {
+  const sourceRoadOffsets = [
+    [-1, -1],
+    [0, -1],
+    [1, -1],
+    [-1, 0],
+    [1, 0],
+    [-1, 1],
+    [0, 1],
+    [1, 1]
+  ] as const;
+  const spawnWallOffsets = [
+    [-1, -1],
+    [1, -1],
+    [-1, 1],
+    [1, 1]
+  ] as const;
+
+  return [
+    ...Array.from({ length: 40 }, (_, index) =>
+      makeStructure(
+        `extension-${index}`,
+        TEST_GLOBALS.STRUCTURE_EXTENSION,
+        30 + (index % 10),
+        30 + Math.floor(index / 10)
+      )
+    ),
+    makeStructure('tower-a', TEST_GLOBALS.STRUCTURE_TOWER, 17, 23),
+    makeStructure('tower-b', TEST_GLOBALS.STRUCTURE_TOWER, 16, 24),
+    makeStoredStructure('storage-existing', TEST_GLOBALS.STRUCTURE_STORAGE, 18, 24, 2_000),
+    makeStructure('spawn-rampart', TEST_GLOBALS.STRUCTURE_RAMPART, 10, 10, true),
+    ...spawnWallOffsets.map(([dx, dy], index) =>
+      makeStructure(`spawn-wall-${index}`, TEST_GLOBALS.STRUCTURE_WALL, 10 + dx, 10 + dy)
+    ),
+    makeStructure('tower-a-rampart', TEST_GLOBALS.STRUCTURE_RAMPART, 17, 23, true),
+    makeStructure('tower-b-rampart', TEST_GLOBALS.STRUCTURE_RAMPART, 16, 24, true),
+    makeStructure('controller-rampart', TEST_GLOBALS.STRUCTURE_RAMPART, 24, 24, true),
+    ...sourceRoadOffsets.map(([dx, dy], index) =>
+      makeStructure(`source-road-${index}`, TEST_GLOBALS.STRUCTURE_ROAD, source.pos.x + dx, source.pos.y + dy)
+    )
+  ];
+}
+
+function makeHostileCreep(id: string, x: number, y: number): Creep {
+  return {
+    id,
+    owner: { username: 'Invader' },
+    pos: makeRoomPosition(x, y)
+  } as unknown as Creep;
 }
 
 function getAreaLookResults(


### PR DESCRIPTION
## Summary
- Add a residual stored-energy road-site seeding fallback in the construction planner so a safe owned room with worker coverage can still create one low-cost construction site when higher-priority placement logic returns zero placements.
- Prefer nearby storage/spawn/controller anchors, avoid walls and blocking structures/sites, and suppress the fallback when hostiles are visible or no worker coverage exists.
- Cover the fallback with targeted construction planner tests and rebuild the Screeps bundle.

## Related issue
Refs #1781. Runtime acceptance remains owned by issue #1781 until fresh official postdeploy construction snapshots prove build execution or a valid no-site terminal state.

## Verification
- `git diff --check` — PASS.
- `npm run typecheck` — PASS.
- `npm test -- --runInBand` — PASS, 105 suites / 2395 tests.
- `npm run build` — PASS.

## Universal task Done gate
- [x] Task type: Production code hotfix PR for residual construction-site seeding.
- [x] Expected observable outcome / named deliverable: `planResidualStoredEnergyRoadSeed` creates one safe road construction site when normal construction planning creates zero placements and the room has residual stored-energy seed capacity plus worker coverage.
- [x] Non-goals / accepted substitutes: No direct official deploy from this branch, no RL reward tuning, no new expansion selection logic, and no owner-side decision requirement.
- [x] Verification evidence required before Done: controller verification passed with `git diff --check`, `npm run typecheck`, `npm test -- --runInBand` (105 suites / 2395 tests), and `npm run build` from `prod/`.
- [x] Project Evidence / Next action / Blocked by: controller records commit `d3493a5865e286924c0a87af8ef1f3a2b6cde187`, verification commands, PR review gates, deploy gate, and issue #1781 runtime-acceptance criteria in Project `screeps`; Blocked by is empty unless CI, review, deploy, or runtime acceptance reports a concrete failure.
- [x] Post-merge/deploy/runtime proof: official deploy evidence plus three fresh runtime-summary windows showing `buildCarriedEnergy > 0` or `constructionSiteCount=0` with `buildBlockedReason=no_construction_sites`, while health gate remains ok and alert remains false.
- [x] Named deliverable proof: commit `d3493a5865e286924c0a87af8ef1f3a2b6cde187` changes `prod/src/construction/planner.ts`, `prod/test/constructionPlanner.test.ts`, and generated `prod/dist/main.js` for the residual road-site seed deliverable.
