### PR TITLE
Recover construction site seeding after deploy

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -15003,9 +15003,12 @@ function planResidualStoredEnergyRoadSeed(colony, result, budgetState, options) 
   }
 }
 function shouldPlanResidualStoredEnergyRoadSeed(colony, result, budgetState, options) {
-  return result.placements.length <= 0 && !hasReachedPlacementLimit(result, options) && shouldUseStoredEnergyConstructionSeedSlot(colony.room, budgetState) && hasRemainingStructureCapacity(colony.room, "road") && hasResidualConstructionWorkerCoverage(colony.room.name, options.creeps) && isResidualConstructionSeedRoomSafe(colony);
+  return result.placements.length <= 0 && !hasReachedPlacementLimit(result, options) && shouldUseStoredEnergyConstructionSeedSlot(colony.room, budgetState) && hasRemainingStructureCapacity(colony.room, "road") && hasResidualConstructionWorkerCoverage(colony.room, options.creeps) && isResidualConstructionSeedRoomSafe(colony);
 }
-function hasResidualConstructionWorkerCoverage(roomName, creeps) {
+function hasResidualConstructionWorkerCoverage(room, creeps) {
+  return hasResidualConstructionWorkerEvidence(room.name, creeps) || hasResidualConstructionWorkerEvidence(room.name, findRoomObjects18(room, "FIND_MY_CREEPS"));
+}
+function hasResidualConstructionWorkerEvidence(roomName, creeps) {
   if (!creeps || creeps.length < MIN_RESIDUAL_CONSTRUCTION_SEED_WORKERS) {
     return false;
   }
@@ -15119,6 +15122,12 @@ function selectResidualRoadSeedAnchors(room, colony, lookups) {
   const controllerPosition = getAnyObjectPosition(room.controller);
   if (controllerPosition !== null && isSameRoomPosition6(controllerPosition, room.name)) {
     anchors.push(controllerPosition);
+  }
+  for (const source of getSortedSources3(room)) {
+    const position = getAnyObjectPosition(source);
+    if (position !== null && isSameRoomPosition6(position, room.name)) {
+      anchors.push(position);
+    }
   }
   return dedupeCandidatePositions(anchors);
 }

--- a/prod/src/construction/planner.ts
+++ b/prod/src/construction/planner.ts
@@ -94,6 +94,7 @@ type FindConstantGlobal =
   | 'FIND_CONSTRUCTION_SITES'
   | 'FIND_MY_STRUCTURES'
   | 'FIND_MY_CONSTRUCTION_SITES'
+  | 'FIND_MY_CREEPS'
   | 'FIND_HOSTILE_CREEPS'
   | 'FIND_HOSTILE_STRUCTURES';
 type LookConstantGlobal = 'LOOK_STRUCTURES' | 'LOOK_CONSTRUCTION_SITES' | 'LOOK_MINERALS';
@@ -667,12 +668,19 @@ function shouldPlanResidualStoredEnergyRoadSeed(
     !hasReachedPlacementLimit(result, options) &&
     shouldUseStoredEnergyConstructionSeedSlot(colony.room, budgetState) &&
     hasRemainingStructureCapacity(colony.room, 'road') &&
-    hasResidualConstructionWorkerCoverage(colony.room.name, options.creeps) &&
+    hasResidualConstructionWorkerCoverage(colony.room, options.creeps) &&
     isResidualConstructionSeedRoomSafe(colony)
   );
 }
 
-function hasResidualConstructionWorkerCoverage(roomName: string, creeps: Creep[] | undefined): boolean {
+function hasResidualConstructionWorkerCoverage(room: Room, creeps: Creep[] | undefined): boolean {
+  return (
+    hasResidualConstructionWorkerEvidence(room.name, creeps) ||
+    hasResidualConstructionWorkerEvidence(room.name, findRoomObjects<Creep>(room, 'FIND_MY_CREEPS'))
+  );
+}
+
+function hasResidualConstructionWorkerEvidence(roomName: string, creeps: Creep[] | undefined): boolean {
   if (!creeps || creeps.length < MIN_RESIDUAL_CONSTRUCTION_SEED_WORKERS) {
     return false;
   }
@@ -820,6 +828,13 @@ function selectResidualRoadSeedAnchors(
   const controllerPosition = getAnyObjectPosition(room.controller as RoomObject | undefined);
   if (controllerPosition !== null && isSameRoomPosition(controllerPosition, room.name)) {
     anchors.push(controllerPosition);
+  }
+
+  for (const source of getSortedSources(room)) {
+    const position = getAnyObjectPosition(source);
+    if (position !== null && isSameRoomPosition(position, room.name)) {
+      anchors.push(position);
+    }
   }
 
   return dedupeCandidatePositions(anchors);

--- a/prod/test/constructionPlanner.test.ts
+++ b/prod/test/constructionPlanner.test.ts
@@ -28,6 +28,7 @@ const TEST_GLOBALS = {
   FIND_CONSTRUCTION_SITES: 5,
   FIND_HOSTILE_CREEPS: 6,
   FIND_HOSTILE_STRUCTURES: 7,
+  FIND_MY_CREEPS: 8,
   LOOK_STRUCTURES: 'structure',
   LOOK_CONSTRUCTION_SITES: 'constructionSite',
   LOOK_MINERALS: 'mineral',
@@ -863,6 +864,103 @@ describe('owned room construction planner', () => {
     expect(room.createConstructionSite).toHaveBeenCalledWith(18, 23, TEST_GLOBALS.STRUCTURE_ROAD);
   });
 
+  it('seeds a stored-energy road from visible workers when planner options omit creeps', () => {
+    installOpenTerrain();
+    const source = makeSource('source-a', 35, 35);
+    const { room, colony } = makeColony({
+      controllerLevel: 6,
+      energyAvailable: 0,
+      energyCapacityAvailable: 2_300,
+      structures: makeRecoveredRcl6ResidualConstructionStructures(source),
+      myCreeps: makeWorkerCreeps(4),
+      sources: [source],
+      pathsByTarget: {}
+    });
+
+    const result = planConstructionForColony(colony, {
+      respectRoomEnergyBuffer: true,
+      strategyRegistry: DEFAULT_STRATEGY_REGISTRY,
+      runtimeStrategyConstructionEnabled: true,
+      runtimeStrategyConstructionFallbackPriorities: false,
+      maxPlacementsPerRoom: 1,
+      maxContainerSitesPerTick: 1,
+      maxPendingContainerSites: 1,
+      roadOptions: {
+        maxSitesPerTick: 1,
+        maxPendingRoadSites: 1,
+        maxTargetsPerTick: 1
+      }
+    });
+
+    expect(result.placements).toEqual([
+      {
+        priority: 'road',
+        roomName: 'W1N1',
+        structureType: TEST_GLOBALS.STRUCTURE_ROAD,
+        result: OK_CODE,
+        energyReserved: 50,
+        x: 18,
+        y: 23
+      }
+    ]);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(18, 23, TEST_GLOBALS.STRUCTURE_ROAD);
+  });
+
+  it('falls back to source-area residual roads when core room anchors are exhausted', () => {
+    installOpenTerrain();
+    const controllerStructures = makeControllerStructures();
+    controllerStructures.container[6] = 0;
+    (globalThis as unknown as { CONTROLLER_STRUCTURES: ReturnType<typeof makeControllerStructures> }).CONTROLLER_STRUCTURES =
+      controllerStructures;
+    const coveredSource = makeSource('source-a', 35, 35);
+    const openSource = makeSource('source-b', 42, 42);
+    const { room, colony } = makeColony({
+      controllerLevel: 6,
+      energyAvailable: 0,
+      energyCapacityAvailable: 2_300,
+      structures: [
+        ...makeRecoveredRcl6ResidualConstructionStructures(coveredSource),
+        ...makeResidualAnchorRoadShell('spawn-shell', 10, 10),
+        ...makeResidualAnchorRoadShell('storage-shell', 18, 24),
+        ...makeResidualAnchorRoadShell('controller-shell', 25, 25),
+        ...makeResidualAnchorRoadShell('covered-source-shell', coveredSource.pos.x, coveredSource.pos.y)
+      ],
+      sources: [coveredSource, openSource],
+      pathsByTarget: {}
+    });
+
+    const result = planConstructionForColony(colony, {
+      creeps: makeWorkerCreeps(4),
+      respectRoomEnergyBuffer: true,
+      strategyRegistry: DEFAULT_STRATEGY_REGISTRY,
+      runtimeStrategyConstructionEnabled: true,
+      runtimeStrategyConstructionFallbackPriorities: false,
+      maxPlacementsPerRoom: 1,
+      maxContainerSitesPerTick: 1,
+      maxPendingContainerSites: 1,
+      roadOptions: {
+        maxSitesPerTick: 1,
+        maxPendingRoadSites: 1,
+        maxTargetsPerTick: 1
+      }
+    });
+
+    expect(result.placements).toEqual([
+      {
+        priority: 'road',
+        roomName: 'W1N1',
+        structureType: TEST_GLOBALS.STRUCTURE_ROAD,
+        result: OK_CODE,
+        energyReserved: 50,
+        x: 41,
+        y: 41
+      }
+    ]);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(41, 41, TEST_GLOBALS.STRUCTURE_ROAD);
+  });
+
   it('does not seed the residual stored-energy road without assigned worker coverage', () => {
     installOpenTerrain();
     const source = makeSource('source-a', 35, 35);
@@ -1088,6 +1186,7 @@ interface MakeColonyOptions {
   includeSpawn?: boolean;
   structures?: Structure[];
   constructionSites?: ConstructionSite[];
+  myCreeps?: Creep[];
   hostileCreeps?: Creep[];
   hostileStructures?: Structure[];
   sources: Source[];
@@ -1125,6 +1224,8 @@ function makeColony(options: MakeColonyOptions): { room: MockRoom; colony: Colon
       const targets =
         findType === TEST_GLOBALS.FIND_SOURCES
           ? options.sources
+          : findType === TEST_GLOBALS.FIND_MY_CREEPS
+            ? (options.myCreeps ?? [])
           : findType === TEST_GLOBALS.FIND_HOSTILE_CREEPS
             ? (options.hostileCreeps ?? [])
             : findType === TEST_GLOBALS.FIND_HOSTILE_STRUCTURES
@@ -1297,6 +1398,23 @@ function makeRecoveredRcl6ResidualConstructionStructures(source: Source): Struct
       makeStructure(`source-road-${index}`, TEST_GLOBALS.STRUCTURE_ROAD, source.pos.x + dx, source.pos.y + dy)
     )
   ];
+}
+
+function makeResidualAnchorRoadShell(prefix: string, anchorX: number, anchorY: number): Structure[] {
+  const structures: Structure[] = [];
+  for (let radius = 1; radius <= 3; radius += 1) {
+    for (let y = anchorY - radius; y <= anchorY + radius; y += 1) {
+      for (let x = anchorX - radius; x <= anchorX + radius; x += 1) {
+        if (Math.max(Math.abs(x - anchorX), Math.abs(y - anchorY)) !== radius) {
+          continue;
+        }
+
+        structures.push(makeStructure(`${prefix}-${x}-${y}`, TEST_GLOBALS.STRUCTURE_ROAD, x, y));
+      }
+    }
+  }
+
+  return structures;
 }
 
 function makeHostileCreep(id: string, x: number, y: number): Creep {


### PR DESCRIPTION
Refs #1781

Summary:
- Let the residual stored-energy road seed use visible `FIND_MY_CREEPS` worker evidence when the caller omits `options.creeps`.
- Add source positions as final residual road seed anchors after storage, spawn, and controller anchors.
- Add focused Jest coverage for the postdeploy no-sites condition and regenerate `prod/dist/main.js` through the build.

Verification:
- `npm run typecheck` from `prod/`: passed.
- `npm test -- --runInBand` from `prod/`: passed, 105 suites and 2397 tests.
- `npm run build` from `prod/`: passed, regenerated `prod/dist/main.js`.
- `git diff --check` from repo root: passed.

Safety note:
Residual seeding still only runs after normal construction planning leaves zero placements and the room has no active construction sites, enough stored construction energy, remaining road capacity, owned-spawn/RCL safety, visible no-hostile safety, and worker coverage. Source anchors are a last-resort candidate source after storage, spawn, and controller anchors, so this does not preempt spawn/economy recovery, tower/rampart/storage planning, or CPU-recovery placement limits.

## Universal task Done gate
- [x] Task type: code
- [x] Expected observable outcome / named deliverable: E29N55 residual construction planner seeds viable road sites when normal placement leaves zero sites, using visible workers and source fallback anchors.
- [x] Non-goals / accepted substitutes: no learned-policy rollout, no expansion retarget, no defense-priority reorder, and no direct runtime deployment from this PR alone.
- [x] Verification evidence required before Done: `npm run typecheck`, `npm test -- --runInBand`, `npm run build`, and `git diff --check` pass on commit `6a021217`; repository checks include prod-ci success and CodeRabbit approval.
- [x] Project Evidence / Next action / Blocked by: Project item records PR #1801 head `6a021217`, CodeRabbit approval, prod-ci success, issue-completion body repair, and next controller gate for merge/deploy/runtime construction evidence; Blocked by check-rerun and merge-state refresh.
- [x] Post-merge/deploy/runtime proof: official deploy evidence plus three runtime-summary construction windows will prove site seeding and build-progress behavior before #1781 is marked Done.
- [x] Named deliverable proof: PR #1801 diff changes `prod/src/construction/planner.ts`, `prod/test/constructionPlanner.test.ts`, and regenerated `prod/dist/main.js` with focused postdeploy no-sites coverage.
