### PR TITLE
fix: expand residual construction road seeding search

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -15044,11 +15044,35 @@ function selectResidualRoadSeedPosition(room, colony) {
   if (!lookups.terrain) {
     return null;
   }
-  for (const anchor of selectResidualRoadSeedAnchors(room, colony, lookups)) {
-    for (const position of getResidualRoadSeedCandidatePositions(anchor, room.name)) {
-      if (canPlaceResidualRoadSeed(lookups, position)) {
-        return position;
-      }
+  const anchors = selectResidualRoadSeedAnchors(room, colony, lookups);
+  const nearbyPosition = selectResidualRoadSeedPositionFromAnchors(
+    lookups,
+    anchors,
+    room.name,
+    1,
+    RESIDUAL_ROAD_SEED_MAX_RADIUS
+  );
+  if (nearbyPosition) {
+    return nearbyPosition;
+  }
+  return selectResidualRoadSeedPositionFromAnchors(
+    lookups,
+    anchors,
+    room.name,
+    RESIDUAL_ROAD_SEED_MAX_RADIUS + 1
+  );
+}
+function selectResidualRoadSeedPositionFromAnchors(lookups, anchors, roomName, minimumRadius, maximumRadius) {
+  for (const anchor of anchors) {
+    const position = selectResidualRoadSeedPositionNearAnchor(
+      lookups,
+      anchor,
+      roomName,
+      minimumRadius,
+      maximumRadius
+    );
+    if (position) {
+      return position;
     }
   }
   return null;
@@ -15131,19 +15155,38 @@ function selectResidualRoadSeedAnchors(room, colony, lookups) {
   }
   return dedupeCandidatePositions(anchors);
 }
-function getResidualRoadSeedCandidatePositions(anchor, roomName) {
-  const positions = [];
-  for (let radius = 1; radius <= RESIDUAL_ROAD_SEED_MAX_RADIUS; radius += 1) {
-    for (let y = anchor.y - radius; y <= anchor.y + radius; y += 1) {
-      for (let x = anchor.x - radius; x <= anchor.x + radius; x += 1) {
+function selectResidualRoadSeedPositionNearAnchor(lookups, anchor, roomName, minimumRadius, maximumRadius) {
+  const firstRadius = Math.max(1, Math.floor(minimumRadius));
+  const lastRadius = Math.min(
+    getMaximumResidualRoadSeedScanRadius(anchor),
+    maximumRadius === void 0 ? Number.MAX_SAFE_INTEGER : Math.max(0, Math.floor(maximumRadius))
+  );
+  for (let radius = firstRadius; radius <= lastRadius; radius += 1) {
+    const top = Math.max(ROOM_EDGE_MIN8, anchor.y - radius);
+    const left = Math.max(ROOM_EDGE_MIN8, anchor.x - radius);
+    const bottom = Math.min(ROOM_EDGE_MAX8, anchor.y + radius);
+    const right = Math.min(ROOM_EDGE_MAX8, anchor.x + radius);
+    for (let y = top; y <= bottom; y += 1) {
+      for (let x = left; x <= right; x += 1) {
         if (Math.max(Math.abs(x - anchor.x), Math.abs(y - anchor.y)) !== radius) {
           continue;
         }
-        positions.push({ x, y, roomName });
+        const position = { x, y, roomName };
+        if (canPlaceResidualRoadSeed(lookups, position)) {
+          return position;
+        }
       }
     }
   }
-  return positions;
+  return null;
+}
+function getMaximumResidualRoadSeedScanRadius(anchor) {
+  return Math.max(
+    Math.abs(anchor.x - ROOM_EDGE_MIN8),
+    Math.abs(ROOM_EDGE_MAX8 - anchor.x),
+    Math.abs(anchor.y - ROOM_EDGE_MIN8),
+    Math.abs(ROOM_EDGE_MAX8 - anchor.y)
+  );
 }
 function canPlaceResidualRoadSeed(lookups, position) {
   return isWithinRoomBuildBounds2(position) && !lookups.blockingPositions.has(getPositionKey7(position)) && !lookups.existingRoadPositions.has(getPositionKey7(position)) && !isTerrainWall7(lookups.terrain, position);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -15162,23 +15162,59 @@ function selectResidualRoadSeedPositionNearAnchor(lookups, anchor, roomName, min
     maximumRadius === void 0 ? Number.MAX_SAFE_INTEGER : Math.max(0, Math.floor(maximumRadius))
   );
   for (let radius = firstRadius; radius <= lastRadius; radius += 1) {
-    const top = Math.max(ROOM_EDGE_MIN8, anchor.y - radius);
-    const left = Math.max(ROOM_EDGE_MIN8, anchor.x - radius);
-    const bottom = Math.min(ROOM_EDGE_MAX8, anchor.y + radius);
-    const right = Math.min(ROOM_EDGE_MAX8, anchor.x + radius);
-    for (let y = top; y <= bottom; y += 1) {
-      for (let x = left; x <= right; x += 1) {
-        if (Math.max(Math.abs(x - anchor.x), Math.abs(y - anchor.y)) !== radius) {
-          continue;
-        }
-        const position = { x, y, roomName };
-        if (canPlaceResidualRoadSeed(lookups, position)) {
-          return position;
-        }
-      }
+    const position = selectResidualRoadSeedPositionInRadiusShell(lookups, anchor, roomName, radius);
+    if (position) {
+      return position;
     }
   }
   return null;
+}
+function selectResidualRoadSeedPositionInRadiusShell(lookups, anchor, roomName, radius) {
+  const top = anchor.y - radius;
+  const left = anchor.x - radius;
+  const bottom = anchor.y + radius;
+  const right = anchor.x + radius;
+  const clippedLeft = Math.max(ROOM_EDGE_MIN8, left);
+  const clippedRight = Math.min(ROOM_EDGE_MAX8, right);
+  if (top >= ROOM_EDGE_MIN8 && top <= ROOM_EDGE_MAX8) {
+    const position = selectResidualRoadSeedPositionInRow(lookups, roomName, top, clippedLeft, clippedRight);
+    if (position) {
+      return position;
+    }
+  }
+  const sideTop = Math.max(ROOM_EDGE_MIN8, top + 1);
+  const sideBottom = Math.min(ROOM_EDGE_MAX8, bottom - 1);
+  for (let y = sideTop; y <= sideBottom; y += 1) {
+    if (left >= ROOM_EDGE_MIN8 && left <= ROOM_EDGE_MAX8) {
+      const position = selectResidualRoadSeedCandidate(lookups, roomName, left, y);
+      if (position) {
+        return position;
+      }
+    }
+    if (right >= ROOM_EDGE_MIN8 && right <= ROOM_EDGE_MAX8 && right !== left) {
+      const position = selectResidualRoadSeedCandidate(lookups, roomName, right, y);
+      if (position) {
+        return position;
+      }
+    }
+  }
+  if (bottom >= ROOM_EDGE_MIN8 && bottom <= ROOM_EDGE_MAX8 && bottom !== top) {
+    return selectResidualRoadSeedPositionInRow(lookups, roomName, bottom, clippedLeft, clippedRight);
+  }
+  return null;
+}
+function selectResidualRoadSeedPositionInRow(lookups, roomName, y, left, right) {
+  for (let x = left; x <= right; x += 1) {
+    const position = selectResidualRoadSeedCandidate(lookups, roomName, x, y);
+    if (position) {
+      return position;
+    }
+  }
+  return null;
+}
+function selectResidualRoadSeedCandidate(lookups, roomName, x, y) {
+  const position = { x, y, roomName };
+  return canPlaceResidualRoadSeed(lookups, position) ? position : null;
 }
 function getMaximumResidualRoadSeedScanRadius(anchor) {
   return Math.max(

--- a/prod/src/construction/planner.ts
+++ b/prod/src/construction/planner.ts
@@ -734,11 +734,43 @@ function selectResidualRoadSeedPosition(room: Room, colony: ColonySnapshot): Can
     return null;
   }
 
-  for (const anchor of selectResidualRoadSeedAnchors(room, colony, lookups)) {
-    for (const position of getResidualRoadSeedCandidatePositions(anchor, room.name)) {
-      if (canPlaceResidualRoadSeed(lookups, position)) {
-        return position;
-      }
+  const anchors = selectResidualRoadSeedAnchors(room, colony, lookups);
+  const nearbyPosition = selectResidualRoadSeedPositionFromAnchors(
+    lookups,
+    anchors,
+    room.name,
+    1,
+    RESIDUAL_ROAD_SEED_MAX_RADIUS
+  );
+  if (nearbyPosition) {
+    return nearbyPosition;
+  }
+
+  return selectResidualRoadSeedPositionFromAnchors(
+    lookups,
+    anchors,
+    room.name,
+    RESIDUAL_ROAD_SEED_MAX_RADIUS + 1
+  );
+}
+
+function selectResidualRoadSeedPositionFromAnchors(
+  lookups: ResidualRoadSeedLookups,
+  anchors: CandidatePosition[],
+  roomName: string,
+  minimumRadius: number,
+  maximumRadius?: number
+): CandidatePosition | null {
+  for (const anchor of anchors) {
+    const position = selectResidualRoadSeedPositionNearAnchor(
+      lookups,
+      anchor,
+      roomName,
+      minimumRadius,
+      maximumRadius
+    );
+    if (position) {
+      return position;
     }
   }
 
@@ -840,21 +872,47 @@ function selectResidualRoadSeedAnchors(
   return dedupeCandidatePositions(anchors);
 }
 
-function getResidualRoadSeedCandidatePositions(anchor: CandidatePosition, roomName: string): CandidatePosition[] {
-  const positions: CandidatePosition[] = [];
-  for (let radius = 1; radius <= RESIDUAL_ROAD_SEED_MAX_RADIUS; radius += 1) {
-    for (let y = anchor.y - radius; y <= anchor.y + radius; y += 1) {
-      for (let x = anchor.x - radius; x <= anchor.x + radius; x += 1) {
+function selectResidualRoadSeedPositionNearAnchor(
+  lookups: ResidualRoadSeedLookups,
+  anchor: CandidatePosition,
+  roomName: string,
+  minimumRadius: number,
+  maximumRadius?: number
+): CandidatePosition | null {
+  const firstRadius = Math.max(1, Math.floor(minimumRadius));
+  const lastRadius = Math.min(
+    getMaximumResidualRoadSeedScanRadius(anchor),
+    maximumRadius === undefined ? Number.MAX_SAFE_INTEGER : Math.max(0, Math.floor(maximumRadius))
+  );
+  for (let radius = firstRadius; radius <= lastRadius; radius += 1) {
+    const top = Math.max(ROOM_EDGE_MIN, anchor.y - radius);
+    const left = Math.max(ROOM_EDGE_MIN, anchor.x - radius);
+    const bottom = Math.min(ROOM_EDGE_MAX, anchor.y + radius);
+    const right = Math.min(ROOM_EDGE_MAX, anchor.x + radius);
+    for (let y = top; y <= bottom; y += 1) {
+      for (let x = left; x <= right; x += 1) {
         if (Math.max(Math.abs(x - anchor.x), Math.abs(y - anchor.y)) !== radius) {
           continue;
         }
 
-        positions.push({ x, y, roomName });
+        const position = { x, y, roomName };
+        if (canPlaceResidualRoadSeed(lookups, position)) {
+          return position;
+        }
       }
     }
   }
 
-  return positions;
+  return null;
+}
+
+function getMaximumResidualRoadSeedScanRadius(anchor: CandidatePosition): number {
+  return Math.max(
+    Math.abs(anchor.x - ROOM_EDGE_MIN),
+    Math.abs(ROOM_EDGE_MAX - anchor.x),
+    Math.abs(anchor.y - ROOM_EDGE_MIN),
+    Math.abs(ROOM_EDGE_MAX - anchor.y)
+  );
 }
 
 function canPlaceResidualRoadSeed(lookups: ResidualRoadSeedLookups, position: CandidatePosition): boolean {

--- a/prod/src/construction/planner.ts
+++ b/prod/src/construction/planner.ts
@@ -885,25 +885,85 @@ function selectResidualRoadSeedPositionNearAnchor(
     maximumRadius === undefined ? Number.MAX_SAFE_INTEGER : Math.max(0, Math.floor(maximumRadius))
   );
   for (let radius = firstRadius; radius <= lastRadius; radius += 1) {
-    const top = Math.max(ROOM_EDGE_MIN, anchor.y - radius);
-    const left = Math.max(ROOM_EDGE_MIN, anchor.x - radius);
-    const bottom = Math.min(ROOM_EDGE_MAX, anchor.y + radius);
-    const right = Math.min(ROOM_EDGE_MAX, anchor.x + radius);
-    for (let y = top; y <= bottom; y += 1) {
-      for (let x = left; x <= right; x += 1) {
-        if (Math.max(Math.abs(x - anchor.x), Math.abs(y - anchor.y)) !== radius) {
-          continue;
-        }
-
-        const position = { x, y, roomName };
-        if (canPlaceResidualRoadSeed(lookups, position)) {
-          return position;
-        }
-      }
+    const position = selectResidualRoadSeedPositionInRadiusShell(lookups, anchor, roomName, radius);
+    if (position) {
+      return position;
     }
   }
 
   return null;
+}
+
+function selectResidualRoadSeedPositionInRadiusShell(
+  lookups: ResidualRoadSeedLookups,
+  anchor: CandidatePosition,
+  roomName: string,
+  radius: number
+): CandidatePosition | null {
+  const top = anchor.y - radius;
+  const left = anchor.x - radius;
+  const bottom = anchor.y + radius;
+  const right = anchor.x + radius;
+  const clippedLeft = Math.max(ROOM_EDGE_MIN, left);
+  const clippedRight = Math.min(ROOM_EDGE_MAX, right);
+
+  if (top >= ROOM_EDGE_MIN && top <= ROOM_EDGE_MAX) {
+    const position = selectResidualRoadSeedPositionInRow(lookups, roomName, top, clippedLeft, clippedRight);
+    if (position) {
+      return position;
+    }
+  }
+
+  const sideTop = Math.max(ROOM_EDGE_MIN, top + 1);
+  const sideBottom = Math.min(ROOM_EDGE_MAX, bottom - 1);
+  for (let y = sideTop; y <= sideBottom; y += 1) {
+    if (left >= ROOM_EDGE_MIN && left <= ROOM_EDGE_MAX) {
+      const position = selectResidualRoadSeedCandidate(lookups, roomName, left, y);
+      if (position) {
+        return position;
+      }
+    }
+
+    if (right >= ROOM_EDGE_MIN && right <= ROOM_EDGE_MAX && right !== left) {
+      const position = selectResidualRoadSeedCandidate(lookups, roomName, right, y);
+      if (position) {
+        return position;
+      }
+    }
+  }
+
+  if (bottom >= ROOM_EDGE_MIN && bottom <= ROOM_EDGE_MAX && bottom !== top) {
+    return selectResidualRoadSeedPositionInRow(lookups, roomName, bottom, clippedLeft, clippedRight);
+  }
+
+  return null;
+}
+
+function selectResidualRoadSeedPositionInRow(
+  lookups: ResidualRoadSeedLookups,
+  roomName: string,
+  y: number,
+  left: number,
+  right: number
+): CandidatePosition | null {
+  for (let x = left; x <= right; x += 1) {
+    const position = selectResidualRoadSeedCandidate(lookups, roomName, x, y);
+    if (position) {
+      return position;
+    }
+  }
+
+  return null;
+}
+
+function selectResidualRoadSeedCandidate(
+  lookups: ResidualRoadSeedLookups,
+  roomName: string,
+  x: number,
+  y: number
+): CandidatePosition | null {
+  const position = { x, y, roomName };
+  return canPlaceResidualRoadSeed(lookups, position) ? position : null;
 }
 
 function getMaximumResidualRoadSeedScanRadius(anchor: CandidatePosition): number {

--- a/prod/test/constructionPlanner.test.ts
+++ b/prod/test/constructionPlanner.test.ts
@@ -1004,6 +1004,59 @@ describe('owned room construction planner', () => {
     expect(room.createConstructionSite).toHaveBeenCalledWith(42, 42, TEST_GLOBALS.STRUCTURE_ROAD);
   });
 
+  it('keeps residual seeding alive when every anchor is saturated through the nearby radius', () => {
+    installOpenTerrain();
+    const controllerStructures = makeControllerStructures();
+    controllerStructures.container[6] = 0;
+    (globalThis as unknown as { CONTROLLER_STRUCTURES: ReturnType<typeof makeControllerStructures> }).CONTROLLER_STRUCTURES =
+      controllerStructures;
+    const source = makeSource('source-a', 35, 35);
+    const { room, colony } = makeColony({
+      controllerLevel: 6,
+      energyAvailable: 0,
+      energyCapacityAvailable: 2_300,
+      structures: [
+        ...makeRecoveredRcl6ResidualConstructionStructures(source),
+        ...makeResidualAnchorRoadShell('spawn-shell', 10, 10, 6),
+        ...makeResidualAnchorRoadShell('storage-shell', 18, 24, 6),
+        ...makeResidualAnchorRoadShell('controller-shell', 25, 25, 6),
+        ...makeResidualAnchorRoadShell('source-shell', source.pos.x, source.pos.y, 6)
+      ],
+      sources: [source],
+      pathsByTarget: {}
+    });
+
+    const result = planConstructionForColony(colony, {
+      creeps: makeWorkerCreeps(4),
+      respectRoomEnergyBuffer: true,
+      strategyRegistry: DEFAULT_STRATEGY_REGISTRY,
+      runtimeStrategyConstructionEnabled: true,
+      runtimeStrategyConstructionFallbackPriorities: false,
+      maxPlacementsPerRoom: 1,
+      maxContainerSitesPerTick: 1,
+      maxPendingContainerSites: 1,
+      roadOptions: {
+        maxSitesPerTick: 1,
+        maxPendingRoadSites: 1,
+        maxTargetsPerTick: 1
+      }
+    });
+
+    expect(result.placements).toEqual([
+      {
+        priority: 'road',
+        roomName: 'W1N1',
+        structureType: TEST_GLOBALS.STRUCTURE_ROAD,
+        result: OK_CODE,
+        energyReserved: 50,
+        x: 11,
+        y: 17
+      }
+    ]);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(11, 17, TEST_GLOBALS.STRUCTURE_ROAD);
+  });
+
   it('does not seed the residual stored-energy road without assigned worker coverage', () => {
     installOpenTerrain();
     const source = makeSource('source-a', 35, 35);


### PR DESCRIPTION
## Summary
- Expand residual road-site seeding so saturated near-anchor shells do not permanently stop safe owned-room construction recovery.
- Preserve existing hard gates for hostile/survival/rampart safety, owned spawn, worker coverage, stored-energy, pending-site, and placement limits.
- Add regression coverage for saturated residual seed anchors and rebuild the Screeps bundle.

## Related issue
Refs #1781.

## Verification
- `git diff --check` - PASS.
- `cd prod && npm run typecheck` - PASS.
- `cd prod && npm test -- --runInBand` - PASS, 105 suites / 2401 tests.
- `cd prod && npm run build` - PASS.
- `python3 scripts/check_issue_completion_gate.py --body-file /tmp/pr1781-post-1804-no-sites-body.md` - PASS.

## Universal task Done gate
- [x] Task type: Production code hotfix PR for residual construction-site seeding.
- [x] Expected observable outcome / named deliverable: safe owned rooms with stored-energy construction capacity and worker coverage can search beyond the saturated nearby residual-seed ring and place one deterministic road construction site when normal planning returns zero placements.
- [x] Non-goals / accepted substitutes: no deploy, no merge, no GitHub Project mutation from Codex, no RL parameter change, no expansion-selection behavior change, and no relaxation of hostile/survival/rampart safety gates.
- [x] Verification evidence required before Done: `git diff --check`, `npm run typecheck`, `npm test -- --runInBand`, `npm run build`, and the PR-body completion gate pass with the rebuilt bundle included.
- [x] Project Evidence / Next action / Blocked by: controller refreshes Project `screeps` Evidence/Next action/Blocked by after PR creation; this PR is expected to enter review gates for CI, CodeRabbit/Gemini, review threads, and elapsed review.
- [x] Post-merge/deploy/runtime proof: controller-owned official deploy and runtime acceptance use fresh postdeploy monitor/console snapshots showing construction site, build energy/progress, or a concrete no-site terminal state while `alert=false` and all rooms stay alive.
- [x] Named deliverable proof: `prod/src/construction/planner.ts`, `prod/test/constructionPlanner.test.ts`, and generated `prod/dist/main.js` contain the expanded residual road-site seed search and regression coverage.

## Runtime/deployment impact
This changes only the final residual construction seed fallback after higher-priority planning returns no placements. It can create at most one additional road construction site in a safe owned room that already has worker coverage and stored construction energy, while preserving hostile/survival/rampart/CPU safeguards. Official deploy and postdeploy runtime acceptance remain controller-owned.