### PR TITLE
construction: recover post-1806 residual site seeding

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -14668,6 +14668,7 @@ var SPAWN_EDGE_MIN = 2;
 var SPAWN_EDGE_MAX = 47;
 var MAX_SPAWN_SITE_SCAN_RADIUS = 8;
 var RESIDUAL_ROAD_SEED_MAX_RADIUS = 6;
+var RESIDUAL_ROAD_SEED_MAX_PLACEMENT_ATTEMPTS = 4;
 var MIN_RESIDUAL_CONSTRUCTION_SEED_WORKERS = 1;
 var DEFAULT_TERRAIN_WALL_MASK12 = 1;
 var OK_CODE7 = 0;
@@ -14989,17 +14990,25 @@ function planResidualStoredEnergyRoadSeed(colony, result, budgetState, options) 
   if (!shouldPlanResidualStoredEnergyRoadSeed(colony, result, budgetState, options)) {
     return;
   }
-  const position = selectResidualRoadSeedPosition(colony.room, colony);
-  if (!position) {
+  const seedPlan = createResidualRoadSeedPlan(colony.room, colony);
+  if (!seedPlan) {
     return;
   }
-  const placementResult = colony.room.createConstructionSite(
-    position.x,
-    position.y,
-    getStructureConstant6("STRUCTURE_ROAD")
-  );
-  if (placementResult === getOkCode5() || isFatalConstructionSiteResult3(placementResult)) {
-    recordPlacement(result, budgetState, "road", placementResult, options, position);
+  for (let attempt = 0; attempt < RESIDUAL_ROAD_SEED_MAX_PLACEMENT_ATTEMPTS; attempt += 1) {
+    const position = selectResidualRoadSeedPosition(seedPlan);
+    if (!position) {
+      return;
+    }
+    const placementResult = colony.room.createConstructionSite(
+      position.x,
+      position.y,
+      getStructureConstant6("STRUCTURE_ROAD")
+    );
+    if (placementResult === getOkCode5() || isFatalConstructionSiteResult3(placementResult)) {
+      recordPlacement(result, budgetState, "road", placementResult, options, position);
+      return;
+    }
+    seedPlan.lookups.blockingPositions.add(getPositionKey7(position));
   }
 }
 function shouldPlanResidualStoredEnergyRoadSeed(colony, result, budgetState, options) {
@@ -15039,16 +15048,23 @@ function isResidualConstructionSeedRoomSafe(colony) {
 function countVisibleHostileThreats(room) {
   return findRoomObjects18(room, "FIND_HOSTILE_CREEPS").length + findRoomObjects18(room, "FIND_HOSTILE_STRUCTURES").length;
 }
-function selectResidualRoadSeedPosition(room, colony) {
+function createResidualRoadSeedPlan(room, colony) {
   const lookups = buildResidualRoadSeedLookups(room);
   if (!lookups.terrain) {
     return null;
   }
   const anchors = selectResidualRoadSeedAnchors(room, colony, lookups);
-  const nearbyPosition = selectResidualRoadSeedPositionFromAnchors(
-    lookups,
+  return {
     anchors,
-    room.name,
+    lookups,
+    roomName: room.name
+  };
+}
+function selectResidualRoadSeedPosition(plan) {
+  const nearbyPosition = selectResidualRoadSeedPositionFromAnchors(
+    plan.lookups,
+    plan.anchors,
+    plan.roomName,
     1,
     RESIDUAL_ROAD_SEED_MAX_RADIUS
   );
@@ -15056,9 +15072,9 @@ function selectResidualRoadSeedPosition(room, colony) {
     return nearbyPosition;
   }
   return selectResidualRoadSeedPositionFromAnchors(
-    lookups,
-    anchors,
-    room.name,
+    plan.lookups,
+    plan.anchors,
+    plan.roomName,
     RESIDUAL_ROAD_SEED_MAX_RADIUS + 1
   );
 }

--- a/prod/src/construction/planner.ts
+++ b/prod/src/construction/planner.ts
@@ -129,6 +129,12 @@ interface ResidualRoadSeedLookups {
   terrain: RoomTerrain | null;
 }
 
+interface ResidualRoadSeedPlan {
+  anchors: CandidatePosition[];
+  lookups: ResidualRoadSeedLookups;
+  roomName: string;
+}
+
 interface SpawnPlacementResult {
   result: ScreepsReturnCode;
   position?: CandidatePosition;
@@ -154,6 +160,7 @@ const SPAWN_EDGE_MIN = 2;
 const SPAWN_EDGE_MAX = 47;
 const MAX_SPAWN_SITE_SCAN_RADIUS = 8;
 const RESIDUAL_ROAD_SEED_MAX_RADIUS = 6;
+const RESIDUAL_ROAD_SEED_MAX_PLACEMENT_ATTEMPTS = 4;
 const MIN_RESIDUAL_CONSTRUCTION_SEED_WORKERS = 1;
 const DEFAULT_TERRAIN_WALL_MASK = 1;
 const OK_CODE = 0 as ScreepsReturnCode;
@@ -642,18 +649,28 @@ function planResidualStoredEnergyRoadSeed(
     return;
   }
 
-  const position = selectResidualRoadSeedPosition(colony.room, colony);
-  if (!position) {
+  const seedPlan = createResidualRoadSeedPlan(colony.room, colony);
+  if (!seedPlan) {
     return;
   }
 
-  const placementResult = colony.room.createConstructionSite(
-    position.x,
-    position.y,
-    getStructureConstant('STRUCTURE_ROAD')
-  );
-  if (placementResult === getOkCode() || isFatalConstructionSiteResult(placementResult)) {
-    recordPlacement(result, budgetState, 'road', placementResult, options, position);
+  for (let attempt = 0; attempt < RESIDUAL_ROAD_SEED_MAX_PLACEMENT_ATTEMPTS; attempt += 1) {
+    const position = selectResidualRoadSeedPosition(seedPlan);
+    if (!position) {
+      return;
+    }
+
+    const placementResult = colony.room.createConstructionSite(
+      position.x,
+      position.y,
+      getStructureConstant('STRUCTURE_ROAD')
+    );
+    if (placementResult === getOkCode() || isFatalConstructionSiteResult(placementResult)) {
+      recordPlacement(result, budgetState, 'road', placementResult, options, position);
+      return;
+    }
+
+    seedPlan.lookups.blockingPositions.add(getPositionKey(position));
   }
 }
 
@@ -728,17 +745,25 @@ function countVisibleHostileThreats(room: Room): number {
   );
 }
 
-function selectResidualRoadSeedPosition(room: Room, colony: ColonySnapshot): CandidatePosition | null {
+function createResidualRoadSeedPlan(room: Room, colony: ColonySnapshot): ResidualRoadSeedPlan | null {
   const lookups = buildResidualRoadSeedLookups(room);
   if (!lookups.terrain) {
     return null;
   }
 
   const anchors = selectResidualRoadSeedAnchors(room, colony, lookups);
-  const nearbyPosition = selectResidualRoadSeedPositionFromAnchors(
-    lookups,
+  return {
     anchors,
-    room.name,
+    lookups,
+    roomName: room.name
+  };
+}
+
+function selectResidualRoadSeedPosition(plan: ResidualRoadSeedPlan): CandidatePosition | null {
+  const nearbyPosition = selectResidualRoadSeedPositionFromAnchors(
+    plan.lookups,
+    plan.anchors,
+    plan.roomName,
     1,
     RESIDUAL_ROAD_SEED_MAX_RADIUS
   );
@@ -747,9 +772,9 @@ function selectResidualRoadSeedPosition(room: Room, colony: ColonySnapshot): Can
   }
 
   return selectResidualRoadSeedPositionFromAnchors(
-    lookups,
-    anchors,
-    room.name,
+    plan.lookups,
+    plan.anchors,
+    plan.roomName,
     RESIDUAL_ROAD_SEED_MAX_RADIUS + 1
   );
 }

--- a/prod/test/constructionPlanner.test.ts
+++ b/prod/test/constructionPlanner.test.ts
@@ -17,6 +17,7 @@ const mockPlanExpansionDefenseBarrierPlacements =
   planExpansionDefenseBarrierPlacements as jest.MockedFunction<typeof planExpansionDefenseBarrierPlacements>;
 
 const OK_CODE = 0 as ScreepsReturnCode;
+const ERR_INVALID_TARGET_CODE = -7 as ScreepsReturnCode;
 const ERR_FULL_CODE = -8 as ScreepsReturnCode;
 const FIRST_RCL3_TOWER_PRIORITY_ENERGY = Math.max(500, TERRITORY_CONTROLLER_BODY_COST - 100);
 
@@ -1055,6 +1056,51 @@ describe('owned room construction planner', () => {
     ]);
     expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
     expect(room.createConstructionSite).toHaveBeenCalledWith(11, 17, TEST_GLOBALS.STRUCTURE_ROAD);
+  });
+
+  it('tries the next residual road candidate after Screeps rejects the first safe tile', () => {
+    installOpenTerrain();
+    const source = makeSource('source-a', 35, 35);
+    const { room, colony } = makeColony({
+      controllerLevel: 6,
+      energyAvailable: 2_250,
+      energyCapacityAvailable: 2_300,
+      structures: makeRecoveredRcl6ResidualConstructionStructures(source),
+      sources: [source],
+      pathsByTarget: {}
+    });
+    room.createConstructionSite.mockReturnValueOnce(ERR_INVALID_TARGET_CODE);
+
+    const result = planConstructionForColony(colony, {
+      creeps: makeWorkerCreeps(5),
+      respectRoomEnergyBuffer: true,
+      strategyRegistry: DEFAULT_STRATEGY_REGISTRY,
+      runtimeStrategyConstructionEnabled: true,
+      runtimeStrategyConstructionFallbackPriorities: false,
+      maxPlacementsPerRoom: 1,
+      maxContainerSitesPerTick: 1,
+      maxPendingContainerSites: 1,
+      roadOptions: {
+        maxSitesPerTick: 1,
+        maxPendingRoadSites: 1,
+        maxTargetsPerTick: 1
+      }
+    });
+
+    expect(result.placements).toEqual([
+      {
+        priority: 'road',
+        roomName: 'W1N1',
+        structureType: TEST_GLOBALS.STRUCTURE_ROAD,
+        result: OK_CODE,
+        energyReserved: 50,
+        x: 19,
+        y: 23
+      }
+    ]);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(2);
+    expect(room.createConstructionSite).toHaveBeenNthCalledWith(1, 18, 23, TEST_GLOBALS.STRUCTURE_ROAD);
+    expect(room.createConstructionSite).toHaveBeenNthCalledWith(2, 19, 23, TEST_GLOBALS.STRUCTURE_ROAD);
   });
 
   it('does not seed the residual stored-energy road without assigned worker coverage', () => {


### PR DESCRIPTION
## Summary
- Retries bounded residual road seed candidates when Screeps rejects the first candidate with a recoverable return code, instead of repeating the same invalid tile every tick.
- Preserves existing construction safety gates and fatal stop behavior for `ERR_FULL` / `ERR_RCL_NOT_ENOUGH`.
- Adds focused coverage for the post-PR-1806 residual no-site shape: safe high-energy RCL6 room, no sites, first road seed candidate rejected, second candidate seeded successfully.

Refs #1781

## Verification
- Controller: `git diff --check`
- Controller: `cd prod && npm run typecheck`
- Controller: `cd prod && npm test -- --runInBand` — 105 suites / 2402 tests passed
- Controller: `cd prod && npm run build`
- Controller: `git diff --check HEAD~1..HEAD`

## Universal task Done gate

- [x] Task type: production code bugfix with focused Jest coverage and regenerated Screeps bundle.
- [x] Expected observable outcome / named deliverable: residual construction seeding can skip a recoverably rejected road tile and create the next safe construction site candidate.
- [x] Non-goals / accepted substitutes: no expansion logic rewrite, no CPU guard loosening, no GitHub Project mutation by Codex, no official MMO API writes from the implementation lane.
- [x] Verification evidence required before Done: controller verification passed with diff-check, typecheck, Jest 105 suites and 2402 tests, build, and commit diff-check on commit 6cd43a3d.
- [x] Project Evidence / Next action / Blocked by: source issue 1781 Project evidence cites commit 6cd43a3d, verification commands, PR gate state, and runtime acceptance criteria; Blocked by field records only active PR-review/deploy gates when present.
- [x] Post-merge/deploy/runtime proof: source issue 1781 records official deploy evidence and runtime monitor snapshots for the merged head before issue completion.
- [x] Named deliverable proof: commit 6cd43a3d changes `prod/src/construction/planner.ts`, `prod/test/constructionPlanner.test.ts`, and `prod/dist/main.js`; generated bundle is rebuilt from the verified source.
