### PR TITLE
combat: retain urgent rampart repair in energy-critical mode

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -33816,6 +33816,9 @@ function selectWorkerEnergyCriticalTask(creep, currentTask, selectedTask) {
   if ((selectedTask == null ? void 0 : selectedTask.type) === "transfer") {
     return null;
   }
+  if (shouldKeepUrgentRampartRepairDuringEnergyCritical(creep, selectedTask)) {
+    return null;
+  }
   const avoidStorageWithdrawal = isStorageCritical(assessment);
   const freeCapacity = getFreeEnergyCapacity10(creep);
   const shouldPreemptStorageWithdrawal = avoidStorageWithdrawal && freeCapacity > 0 && isRoomStorageWithdrawTask(creep, currentTask);
@@ -33957,6 +33960,16 @@ function shouldReassignWorkerTaskForEnergyCriticalState(creep, task) {
     return true;
   }
   return task.type === "build" && isNonCriticalConstructionTask(task);
+}
+function shouldKeepUrgentRampartRepairDuringEnergyCritical(creep, selectedTask) {
+  return getCarriedEnergy3(creep) > 0 && (selectedTask == null ? void 0 : selectedTask.type) === "repair" && isUrgentOwnedRampartRepairTask(selectedTask);
+}
+function isUrgentOwnedRampartRepairTask(task) {
+  const rampart = getGameObjectById5(String(task.targetId));
+  return Boolean(rampart && isUrgentOwnedRampartRepairTarget(rampart));
+}
+function isUrgentOwnedRampartRepairTarget(structure) {
+  return matchesStructureType20(structure.structureType, "STRUCTURE_RAMPART", "rampart") && structure.my === true && typeof structure.hits === "number" && typeof structure.hitsMax === "number" && Number.isFinite(structure.hits) && Number.isFinite(structure.hitsMax) && structure.hits < Math.min(structure.hitsMax, BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING);
 }
 function isControllerDowngradeGuardTask(creep, task) {
   var _a2;

--- a/prod/src/creeps/workerTaskPolicy.ts
+++ b/prod/src/creeps/workerTaskPolicy.ts
@@ -4,6 +4,7 @@ import {
   CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD,
   selectWorkerEnergyCriticalAcquisitionTask
 } from '../tasks/workerTasks';
+import { BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING } from '../defense/defensePlanner';
 import { getSafeWorkerWithdrawEnergyAmount } from '../economy/workerConstructionWithdrawBudget';
 
 export const WORKER_ENERGY_CRITICAL_SPAWN_EXIT_THRESHOLD =
@@ -44,6 +45,10 @@ export function selectWorkerEnergyCriticalTask(
   }
 
   if (selectedTask?.type === 'transfer') {
+    return null;
+  }
+
+  if (shouldKeepUrgentRampartRepairDuringEnergyCritical(creep, selectedTask)) {
     return null;
   }
 
@@ -236,6 +241,34 @@ function shouldReassignWorkerTaskForEnergyCriticalState(
   }
 
   return task.type === 'build' && isNonCriticalConstructionTask(task);
+}
+
+function shouldKeepUrgentRampartRepairDuringEnergyCritical(
+  creep: Creep,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  return (
+    getCarriedEnergy(creep) > 0 &&
+    selectedTask?.type === 'repair' &&
+    isUrgentOwnedRampartRepairTask(selectedTask)
+  );
+}
+
+function isUrgentOwnedRampartRepairTask(task: Extract<CreepTaskMemory, { type: 'repair' }>): boolean {
+  const rampart = getGameObjectById<StructureRampart>(String(task.targetId));
+  return Boolean(rampart && isUrgentOwnedRampartRepairTarget(rampart));
+}
+
+function isUrgentOwnedRampartRepairTarget(structure: StructureRampart): boolean {
+  return (
+    matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart') &&
+    structure.my === true &&
+    typeof structure.hits === 'number' &&
+    typeof structure.hitsMax === 'number' &&
+    Number.isFinite(structure.hits) &&
+    Number.isFinite(structure.hitsMax) &&
+    structure.hits < Math.min(structure.hitsMax, BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING)
+  );
 }
 
 function isControllerDowngradeGuardTask(
@@ -455,6 +488,7 @@ function matchesStructureType(
     | 'STRUCTURE_CONTAINER'
     | 'STRUCTURE_EXTENSION'
     | 'STRUCTURE_ROAD'
+    | 'STRUCTURE_RAMPART'
     | 'STRUCTURE_SPAWN'
     | 'STRUCTURE_STORAGE'
     | 'STRUCTURE_TOWER',

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -617,6 +617,91 @@ describe('runWorker', () => {
     expect(repair).not.toHaveBeenCalled();
   });
 
+  it('keeps near-floor rampart repair during storage-critical hysteresis when carrying repair energy', () => {
+    const rampart = {
+      id: 'rampart-alert',
+      structureType: 'rampart',
+      my: true,
+      hits: BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING - 1,
+      hitsMax: 30_000_000
+    } as StructureRampart;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(500 + WORKER_ENERGY_CRITICAL_STORAGE_EXIT_MARGIN - 1),
+        getFreeCapacity: jest.fn().mockReturnValue(100_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 100
+    } as StructureController;
+    const room = {
+      name: 'E29N55',
+      controller,
+      energyAvailable: WORKER_ENERGY_CRITICAL_SPAWN_EXIT_THRESHOLD,
+      energyCapacityAvailable: 2_300,
+      storage,
+      find: jest.fn((type: number) => (type === FIND_STRUCTURES ? [rampart, storage] : []))
+    } as unknown as Room;
+    const repair = jest.fn().mockReturnValue(0);
+    const transfer = jest.fn();
+    const creep = {
+      name: 'RampartRepairer',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'repair', targetId: 'rampart-alert' as Id<Structure> },
+        workerEnergyCriticalPolicy: {
+          type: 'workerEnergyCriticalPolicy',
+          schemaVersion: 1,
+          active: true,
+          reason: 'storage',
+          enteredAt: 700,
+          updatedAt: 700,
+          storageEnergy: 499,
+          storageEnterThreshold: 500,
+          storageExitThreshold: 500 + WORKER_ENERGY_CRITICAL_STORAGE_EXIT_MARGIN
+        }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(100),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      repair,
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { RampartRepairer: creep },
+      time: 701,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(21),
+        limit: 70,
+        bucket: 62,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) =>
+        id === 'rampart-alert' ? rampart : id === 'storage1' ? storage : null
+      ) as unknown as Game['getObjectById']
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'repair', targetId: 'rampart-alert' });
+    expect(creep.memory.workerEnergyCriticalPolicy).toMatchObject({
+      active: true,
+      reason: 'storage',
+      storageEnergy: 500 + WORKER_ENERGY_CRITICAL_STORAGE_EXIT_MARGIN - 1
+    });
+    expect(repair).toHaveBeenCalledWith(rampart);
+    expect(transfer).not.toHaveBeenCalled();
+  });
+
   it.each(['claim', 'reserve'] as const)(
     'drops a retained visible %s task under critical CPU when the home room fails the territory gate',
     (action) => {


### PR DESCRIPTION
## Summary
- Refs #1808.
- Retains an urgent owned-rampart repair selected by the base worker planner when the worker is already carrying energy, even during storage/spawn energy-critical hysteresis.
- Keeps ordinary non-critical repair/build preemption behavior intact so colony energy recovery still wins outside the near-floor rampart case.
- Regenerates `prod/dist/main.js` from the verified source.

## Triage
Classification: `FIX`.

Runtime evidence from `/root/screeps/runtime-artifacts/screeps-monitor/steward-postdeploy-1807-20260611T222436Z/` showed E29N55 rampart `6a2a926fc735853f8a3d5397` at `(18,23)` dropped `5601 -> 4701` after #1807 deploy. Worker evidence showed the base selector chose rampart `repair`, then the energy-critical override replaced it with `transfer`. This PR adds the narrow guard so near-floor rampart repair is not discarded by that override.

Triage artifact: `/tmp/issue1808-rampart-recurrence-triage.md`.
Controller verification log: `/tmp/issue1808-controller-verify.log`.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 105 suites, 2403 tests passed
- `cd prod && npm run build`
- `git diff --check`
- `git diff --check HEAD~1..HEAD`

## Universal task Done gate
- [x] Task type: Production combat bugfix for near-floor rampart repair retention during energy-critical worker mode.
- [x] Expected observable outcome / named deliverable: Codex-authored commit `448e2290bb45b3cdc3f54046aa15c26341147437` changes worker task policy, focused Jest coverage, and the generated Screeps bundle.
- [x] Non-goals / accepted substitutes: No scope change to construction scheduling, RL lanes, Project automation, or messaging surfaces.
- [x] Verification evidence required before Done: Controller log `/tmp/issue1808-controller-verify.log` records diff-check, typecheck, 105 Jest suites with 2403 tests, build, and final diff-check passing.
- [x] Project Evidence / Next action / Blocked by: Project item for issue #1808 records the runtime artifact bundle, this PR head, controller verification, and the autonomous release lane acceptance command.
- [x] Post-merge/deploy/runtime proof: Release lane records official deploy JSON for this head and fresh runtime monitor `alert=false` with `health_gate.ok=true` for shardX/E29N55 rampart 18,23.
- [x] Named deliverable proof: `git show --name-status --oneline 448e2290` lists only `prod/src/creeps/workerTaskPolicy.ts`, `prod/test/workerRunner.test.ts`, and `prod/dist/main.js`.
