### PR TITLE
construction: seed accepted runtime rampart candidates

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -15408,12 +15408,12 @@ function planAcceptedRuntimeRampartSeed(colony, result, budgetState, options) {
   recordPlacement(result, budgetState, "rampart", placementResult, options, position);
 }
 function selectAcceptedRuntimeRampartSeedPosition(room, colony) {
-  var _a2, _b;
+  var _a2;
   const anchors = selectRuntimeRampartSeedAnchors(room, colony);
   if (anchors.length === 0) {
     return null;
   }
-  return (_b = (_a2 = anchors.find((anchor) => !hasRampartAtPosition(room, anchor))) != null ? _a2 : anchors[0]) != null ? _b : null;
+  return (_a2 = anchors.find((anchor) => !hasRampartAtPosition(room, anchor))) != null ? _a2 : null;
 }
 function selectRuntimeRampartSeedAnchors(room, colony) {
   const structures = findUniqueRoomObjectsByStableKey([

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -15310,6 +15310,15 @@ function planRuntimeStrategyPrioritizedConstruction(colony, result, budgetState,
       return true;
     }
   }
+  if (result.placements.length === initialPlacementCount) {
+    planAcceptedRuntimeConstructionCandidateSeed(
+      report.nextPrimary,
+      colony,
+      result,
+      budgetState,
+      options
+    );
+  }
   return result.placements.length > initialPlacementCount || hasBlockingPlacementFailure(result);
 }
 function recordStrategyRegistryRuntimeUse(options, strategyEntry) {
@@ -15368,6 +15377,88 @@ function constructionPriorityScorePlannerPriorities(score) {
     case "observation":
       return [];
   }
+}
+function planAcceptedRuntimeConstructionCandidateSeed(candidate, colony, result, budgetState, options) {
+  if (!isAcceptedRuntimeConstructionBuildCandidate(candidate)) {
+    return;
+  }
+  if (candidate.buildType === "rampart") {
+    planAcceptedRuntimeRampartSeed(colony, result, budgetState, options);
+  }
+}
+function isAcceptedRuntimeConstructionBuildCandidate(candidate) {
+  return Boolean(
+    candidate && candidate.score > 0 && !candidate.blocked && candidate.policyAction === "build"
+  );
+}
+function planAcceptedRuntimeRampartSeed(colony, result, budgetState, options) {
+  const room = colony.room;
+  if (!hasRemainingStructureCapacity(room, "rampart") || !canReserveConstructionEnergy(room, budgetState, "rampart", options)) {
+    return;
+  }
+  const position = selectAcceptedRuntimeRampartSeedPosition(room, colony);
+  if (!position) {
+    return;
+  }
+  const placementResult = room.createConstructionSite(
+    position.x,
+    position.y,
+    getStructureConstant6("STRUCTURE_RAMPART")
+  );
+  recordPlacement(result, budgetState, "rampart", placementResult, options, position);
+}
+function selectAcceptedRuntimeRampartSeedPosition(room, colony) {
+  var _a2, _b;
+  const anchors = selectRuntimeRampartSeedAnchors(room, colony);
+  if (anchors.length === 0) {
+    return null;
+  }
+  return (_b = (_a2 = anchors.find((anchor) => !hasRampartAtPosition(room, anchor))) != null ? _a2 : anchors[0]) != null ? _b : null;
+}
+function selectRuntimeRampartSeedAnchors(room, colony) {
+  const structures = findUniqueRoomObjectsByStableKey([
+    ...colony.spawns,
+    ...findRoomObjects18(room, "FIND_MY_STRUCTURES"),
+    ...findRoomObjects18(room, "FIND_STRUCTURES")
+  ]);
+  return dedupeCandidatePositions(
+    structures.filter(isRuntimeRampartSeedAnchorStructure).map(getAnyObjectPosition).filter((position) => isSameRoomPosition6(position, room.name))
+  ).sort(compareRuntimeRampartSeedAnchors);
+}
+function isRuntimeRampartSeedAnchorStructure(structure) {
+  return getRuntimeRampartSeedAnchorPriority(structure) !== null;
+}
+function compareRuntimeRampartSeedAnchors(left, right) {
+  return getPositionKey7(left).localeCompare(getPositionKey7(right));
+}
+function hasRampartAtPosition(room, position) {
+  const rampartType = getStructureConstant6("STRUCTURE_RAMPART");
+  const objects = [
+    ...findRoomObjects18(room, "FIND_MY_STRUCTURES"),
+    ...findRoomObjects18(room, "FIND_STRUCTURES"),
+    ...findRoomObjects18(room, "FIND_MY_CONSTRUCTION_SITES"),
+    ...findRoomObjects18(room, "FIND_CONSTRUCTION_SITES")
+  ];
+  return objects.some((object) => {
+    const objectPosition = getAnyObjectPosition(object);
+    return object.structureType === rampartType && objectPosition !== null && isSameRoomPosition6(objectPosition, room.name) && getPositionKey7(objectPosition) === getPositionKey7(position) && object.my !== false;
+  });
+}
+function getRuntimeRampartSeedAnchorPriority(structure) {
+  const structureType = structure.structureType;
+  if (structureType === getStructureConstant6("STRUCTURE_SPAWN")) {
+    return 0;
+  }
+  if (structureType === getStructureConstant6("STRUCTURE_TOWER")) {
+    return 1;
+  }
+  if (structureType === getStructureConstant6("STRUCTURE_STORAGE")) {
+    return 2;
+  }
+  if (structureType === getStructureConstant6("STRUCTURE_CONTAINER")) {
+    return 3;
+  }
+  return null;
 }
 function planRuntimeConstructionPlannerPriority(priority, colony, result, budgetState, options, priorityTowerDefenseSiteState, rcl) {
   switch (priority) {

--- a/prod/src/construction/planner.ts
+++ b/prod/src/construction/planner.ts
@@ -1248,7 +1248,7 @@ function selectAcceptedRuntimeRampartSeedPosition(
     return null;
   }
 
-  return anchors.find((anchor) => !hasRampartAtPosition(room, anchor)) ?? anchors[0] ?? null;
+  return anchors.find((anchor) => !hasRampartAtPosition(room, anchor)) ?? null;
 }
 
 function selectRuntimeRampartSeedAnchors(room: Room, colony: ColonySnapshot): CandidatePosition[] {

--- a/prod/src/construction/planner.ts
+++ b/prod/src/construction/planner.ts
@@ -1097,6 +1097,16 @@ function planRuntimeStrategyPrioritizedConstruction(
     }
   }
 
+  if (result.placements.length === initialPlacementCount) {
+    planAcceptedRuntimeConstructionCandidateSeed(
+      report.nextPrimary,
+      colony,
+      result,
+      budgetState,
+      options
+    );
+  }
+
   return result.placements.length > initialPlacementCount || hasBlockingPlacementFailure(result);
 }
 
@@ -1173,6 +1183,137 @@ function constructionPriorityScorePlannerPriorities(
     case 'observation':
       return [];
   }
+}
+
+function planAcceptedRuntimeConstructionCandidateSeed(
+  candidate: ConstructionPriorityScore | null,
+  colony: ColonySnapshot,
+  result: RoomConstructionPlannerResult,
+  budgetState: ConstructionBudgetState,
+  options: ConstructionPlannerOptions
+): void {
+  if (!isAcceptedRuntimeConstructionBuildCandidate(candidate)) {
+    return;
+  }
+
+  if (candidate.buildType === 'rampart') {
+    planAcceptedRuntimeRampartSeed(colony, result, budgetState, options);
+  }
+}
+
+function isAcceptedRuntimeConstructionBuildCandidate(
+  candidate: ConstructionPriorityScore | null
+): candidate is ConstructionPriorityScore {
+  return Boolean(
+    candidate &&
+    candidate.score > 0 &&
+    !candidate.blocked &&
+    candidate.policyAction === 'build'
+  );
+}
+
+function planAcceptedRuntimeRampartSeed(
+  colony: ColonySnapshot,
+  result: RoomConstructionPlannerResult,
+  budgetState: ConstructionBudgetState,
+  options: ConstructionPlannerOptions
+): void {
+  const room = colony.room;
+  if (
+    !hasRemainingStructureCapacity(room, 'rampart') ||
+    !canReserveConstructionEnergy(room, budgetState, 'rampart', options)
+  ) {
+    return;
+  }
+
+  const position = selectAcceptedRuntimeRampartSeedPosition(room, colony);
+  if (!position) {
+    return;
+  }
+
+  const placementResult = room.createConstructionSite(
+    position.x,
+    position.y,
+    getStructureConstant('STRUCTURE_RAMPART')
+  );
+  recordPlacement(result, budgetState, 'rampart', placementResult, options, position);
+}
+
+function selectAcceptedRuntimeRampartSeedPosition(
+  room: Room,
+  colony: ColonySnapshot
+): CandidatePosition | null {
+  const anchors = selectRuntimeRampartSeedAnchors(room, colony);
+  if (anchors.length === 0) {
+    return null;
+  }
+
+  return anchors.find((anchor) => !hasRampartAtPosition(room, anchor)) ?? anchors[0] ?? null;
+}
+
+function selectRuntimeRampartSeedAnchors(room: Room, colony: ColonySnapshot): CandidatePosition[] {
+  const structures = findUniqueRoomObjectsByStableKey<Structure>([
+    ...colony.spawns,
+    ...findRoomObjects<Structure>(room, 'FIND_MY_STRUCTURES'),
+    ...findRoomObjects<Structure>(room, 'FIND_STRUCTURES')
+  ]);
+
+  return dedupeCandidatePositions(
+    structures
+      .filter(isRuntimeRampartSeedAnchorStructure)
+      .map(getAnyObjectPosition)
+      .filter((position): position is CandidatePosition => isSameRoomPosition(position, room.name))
+  ).sort(compareRuntimeRampartSeedAnchors);
+}
+
+function isRuntimeRampartSeedAnchorStructure(structure: Structure): boolean {
+  return getRuntimeRampartSeedAnchorPriority(structure) !== null;
+}
+
+function compareRuntimeRampartSeedAnchors(left: CandidatePosition, right: CandidatePosition): number {
+  return getPositionKey(left).localeCompare(getPositionKey(right));
+}
+
+function hasRampartAtPosition(room: Room, position: CandidatePosition): boolean {
+  const rampartType = getStructureConstant('STRUCTURE_RAMPART');
+  const objects = [
+    ...findRoomObjects<Structure>(room, 'FIND_MY_STRUCTURES'),
+    ...findRoomObjects<Structure>(room, 'FIND_STRUCTURES'),
+    ...findRoomObjects<ConstructionSite>(room, 'FIND_MY_CONSTRUCTION_SITES'),
+    ...findRoomObjects<ConstructionSite>(room, 'FIND_CONSTRUCTION_SITES')
+  ];
+
+  return objects.some((object) => {
+    const objectPosition = getAnyObjectPosition(object);
+    return (
+      object.structureType === rampartType &&
+      objectPosition !== null &&
+      isSameRoomPosition(objectPosition, room.name) &&
+      getPositionKey(objectPosition) === getPositionKey(position) &&
+      (object as { my?: unknown }).my !== false
+    );
+  });
+}
+
+function getRuntimeRampartSeedAnchorPriority(structure: Structure): number | null {
+  const structureType = structure.structureType;
+  if (structureType === getStructureConstant('STRUCTURE_SPAWN')) {
+    return 0;
+  }
+
+  if (structureType === getStructureConstant('STRUCTURE_TOWER')) {
+    return 1;
+  }
+
+  if (structureType === getStructureConstant('STRUCTURE_STORAGE')) {
+    return 2;
+  }
+
+  if (structureType === getStructureConstant('STRUCTURE_CONTAINER')) {
+    return 3;
+  }
+
+  return null;
 }
 
 function planRuntimeConstructionPlannerPriority(

--- a/prod/test/constructionPlanner.test.ts
+++ b/prod/test/constructionPlanner.test.ts
@@ -507,6 +507,65 @@ describe('owned room construction planner', () => {
     expect(room.createConstructionSite).toHaveBeenCalledWith(18, 24, TEST_GLOBALS.STRUCTURE_RAMPART);
   });
 
+  it('falls through when every accepted runtime rampart seed anchor is already covered', () => {
+    installOpenTerrain();
+    mockPlanExpansionDefenseBarrierPlacements.mockReturnValue([]);
+    const source = makeSource('source-a', 35, 35);
+    const coveredRampartAnchorKeys = new Set(['10,10', '16,24', '17,23', '18,24', '34,35']);
+    const { room, colony } = makeColony({
+      controllerLevel: 6,
+      energyAvailable: 2_300,
+      energyCapacityAvailable: 2_300,
+      structures: [
+        ...makeRecoveredRcl6ResidualConstructionStructures(source),
+        makeStructure('storage-rampart', TEST_GLOBALS.STRUCTURE_RAMPART, 18, 24, true),
+        makeStoredStructure('source-container', TEST_GLOBALS.STRUCTURE_CONTAINER, 34, 35, 1_000),
+        makeStructure('source-container-rampart', TEST_GLOBALS.STRUCTURE_RAMPART, 34, 35, true)
+      ],
+      sources: [source],
+      pathsByTarget: {}
+    });
+    room.createConstructionSite.mockImplementation(
+      (x: number, y: number, structureType: BuildableStructureConstant): ScreepsReturnCode => {
+        if (structureType === TEST_GLOBALS.STRUCTURE_RAMPART && coveredRampartAnchorKeys.has(`${x},${y}`)) {
+          return ERR_INVALID_TARGET_CODE;
+        }
+
+        return OK_CODE;
+      }
+    );
+
+    const result = planConstructionForColony(colony, {
+      creeps: makeWorkerCreeps(4),
+      includePostClaimRamparts: true,
+      respectRoomEnergyBuffer: true,
+      strategyRegistry: DEFAULT_STRATEGY_REGISTRY,
+      runtimeStrategyConstructionEnabled: true,
+      runtimeStrategyConstructionFallbackPriorities: false,
+      maxPlacementsPerRoom: 1,
+      maxContainerSitesPerTick: 1,
+      maxPendingContainerSites: 1,
+      roadOptions: {
+        maxSitesPerTick: 1,
+        maxPendingRoadSites: 1,
+        maxTargetsPerTick: 1
+      }
+    });
+
+    expect(result.placements).toEqual([
+      {
+        priority: 'container',
+        roomName: 'W1N1',
+        structureType: TEST_GLOBALS.STRUCTURE_CONTAINER,
+        result: OK_CODE,
+        energyReserved: 50
+      }
+    ]);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).not.toHaveBeenCalledWith(10, 10, TEST_GLOBALS.STRUCTURE_RAMPART);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(11, 10, TEST_GLOBALS.STRUCTURE_CONTAINER);
+  });
+
   it('records a rejected accepted runtime rampart seed attempt', () => {
     installOpenTerrain();
     mockPlanExpansionDefenseBarrierPlacements.mockReturnValue([]);

--- a/prod/test/constructionPlanner.test.ts
+++ b/prod/test/constructionPlanner.test.ts
@@ -458,6 +458,105 @@ describe('owned room construction planner', () => {
     expect(room.createConstructionSite).not.toHaveBeenCalledWith(26, 24, TEST_GLOBALS.STRUCTURE_RAMPART);
   });
 
+  it('seeds an accepted runtime rampart candidate when mapped planners find no site', () => {
+    installOpenTerrain();
+    mockPlanExpansionDefenseBarrierPlacements.mockReturnValue([]);
+    const source = makeSource('source-a', 35, 35);
+    const { room, colony } = makeColony({
+      controllerLevel: 6,
+      energyAvailable: 2_300,
+      energyCapacityAvailable: 2_300,
+      structures: [
+        ...makeRecoveredRcl6ResidualConstructionStructures(source),
+        makeStoredStructure('source-container', TEST_GLOBALS.STRUCTURE_CONTAINER, 34, 35, 1_000),
+        makeStructure('source-container-rampart', TEST_GLOBALS.STRUCTURE_RAMPART, 34, 35, true)
+      ],
+      sources: [source],
+      pathsByTarget: {}
+    });
+
+    const result = planConstructionForColony(colony, {
+      creeps: makeWorkerCreeps(4),
+      includePostClaimRamparts: true,
+      respectRoomEnergyBuffer: true,
+      strategyRegistry: DEFAULT_STRATEGY_REGISTRY,
+      runtimeStrategyConstructionEnabled: true,
+      runtimeStrategyConstructionFallbackPriorities: false,
+      maxPlacementsPerRoom: 1,
+      maxContainerSitesPerTick: 1,
+      maxPendingContainerSites: 1,
+      roadOptions: {
+        maxSitesPerTick: 1,
+        maxPendingRoadSites: 1,
+        maxTargetsPerTick: 1
+      }
+    });
+
+    expect(result.placements).toEqual([
+      {
+        priority: 'rampart',
+        roomName: 'W1N1',
+        structureType: TEST_GLOBALS.STRUCTURE_RAMPART,
+        result: OK_CODE,
+        energyReserved: 50,
+        x: 18,
+        y: 24
+      }
+    ]);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(18, 24, TEST_GLOBALS.STRUCTURE_RAMPART);
+  });
+
+  it('records a rejected accepted runtime rampart seed attempt', () => {
+    installOpenTerrain();
+    mockPlanExpansionDefenseBarrierPlacements.mockReturnValue([]);
+    const source = makeSource('source-a', 35, 35);
+    const { room, colony } = makeColony({
+      controllerLevel: 6,
+      energyAvailable: 2_300,
+      energyCapacityAvailable: 2_300,
+      structures: [
+        ...makeRecoveredRcl6ResidualConstructionStructures(source),
+        makeStoredStructure('source-container', TEST_GLOBALS.STRUCTURE_CONTAINER, 34, 35, 1_000),
+        makeStructure('source-container-rampart', TEST_GLOBALS.STRUCTURE_RAMPART, 34, 35, true)
+      ],
+      sources: [source],
+      pathsByTarget: {}
+    });
+    room.createConstructionSite.mockReturnValueOnce(ERR_INVALID_TARGET_CODE);
+
+    const result = planConstructionForColony(colony, {
+      creeps: makeWorkerCreeps(4),
+      includePostClaimRamparts: true,
+      respectRoomEnergyBuffer: true,
+      strategyRegistry: DEFAULT_STRATEGY_REGISTRY,
+      runtimeStrategyConstructionEnabled: true,
+      runtimeStrategyConstructionFallbackPriorities: false,
+      maxPlacementsPerRoom: 1,
+      maxContainerSitesPerTick: 1,
+      maxPendingContainerSites: 1,
+      roadOptions: {
+        maxSitesPerTick: 1,
+        maxPendingRoadSites: 1,
+        maxTargetsPerTick: 1
+      }
+    });
+
+    expect(result.placements).toEqual([
+      {
+        priority: 'rampart',
+        roomName: 'W1N1',
+        structureType: TEST_GLOBALS.STRUCTURE_RAMPART,
+        result: ERR_INVALID_TARGET_CODE,
+        energyReserved: 0,
+        x: 18,
+        y: 24
+      }
+    ]);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(18, 24, TEST_GLOBALS.STRUCTURE_RAMPART);
+  });
+
   it('reserves the first RCL3 tower before routine extension logistics when respecting the energy buffer', () => {
     expect(FIRST_RCL3_TOWER_PRIORITY_ENERGY).toBeLessThan(TERRITORY_CONTROLLER_BODY_COST);
     installOpenTerrain();


### PR DESCRIPTION
## Linked issues

Intentional PR-body closing linkage:
- None.

Related / non-closing linkage:
- Related to issue 1781.

## Domain / Kind

- Domain: Territory/Economy
- Kind: code

## Summary

- Adds a bounded runtime rampart seed path when the strategy registry accepts a build-rampart candidate but mapped construction planners return no site.
- Records the placement attempt/result instead of leaving construction telemetry stuck at `candidate_suppressed` / `no_construction_sites` with no action evidence.
- Adds regression coverage for successful and rejected accepted-candidate rampart seed attempts, and regenerates the Screeps bundle.

## Verification

- [x] Controller check: `git diff --check HEAD~1..HEAD` passed.
- [x] Controller check from `prod/`: `npm run typecheck` passed.
- [x] Controller check from `prod/`: `npm test -- --runInBand` passed (105 suites / 2406 tests).
- [x] Controller check from `prod/`: `npm run build` passed and regenerated `prod/dist/main.js`.
- [ ] Automated review gate: exact-head CI and review-bot results to be collected on this PR.

## Universal task Done gate

- [x] Task type: code behavior change with regression tests.
- [x] Expected observable outcome / named deliverable: accepted runtime rampart candidates now produce a bounded site-creation attempt and placement telemetry instead of silent suppression.
- [x] Non-goals / accepted substitutes: no paid RL compute, no deploy workflow trigger, no owner action, and no unrelated expansion/economy rewrite in this PR.
- [x] Verification evidence required before Done: controller diff-check, TypeScript, Jest, bundle build, exact-head CI, review-bot gate, deploy, and three fresh runtime windows recorded on issue 1781.
- [x] Project Evidence / Next action / Blocked by: issue 1781 and this PR Project items name the head SHA, controller verification, review gate, deploy/runtime proof path, and self-actionable next step.
- [x] Post-merge/deploy/runtime proof: issue 1781 is the runtime acceptance owner; proof target is three fresh windows with `constructionSiteCount>0` or `buildProgress>0` and no critical CPU/rampart alert.
- [x] Named deliverable proof: commit `3930dfb2f7eb481ff99977bdcdc9199962ba3f7a` changes `prod/src/construction/planner.ts`, `prod/test/constructionPlanner.test.ts`, and `prod/dist/main.js`.

## Runtime acceptance plan

- Deploy only after PR gates pass.
- Observe fresh runtime-summary console windows for E29N55/E29N56/E29N57.
- Keep issue 1781 active until construction-site or build-progress evidence appears in live runtime telemetry.
