### PR TITLE
worker: allow covered spawn-floor build recovery

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -34983,7 +34983,10 @@ function selectWorkerAssignmentGapRecoveryConstructionSite(creep) {
     return null;
   }
   const sites = creep.room.find(FIND_CONSTRUCTION_SITES);
-  return (_b = sites.filter((site) => site.my !== false).filter((site) => !isBuildTargetSuppressedForWorker(creep, site)).filter((site) => canSpendWorkerEnergyOnConstructionSite(creep, site)).sort((left, right) => compareRoomObjectsByRangeAndId2(creep, left, right))[0]) != null ? _b : null;
+  return (_b = sites.filter((site) => site.my !== false).filter((site) => !isBuildTargetSuppressedForWorker(creep, site)).filter((site) => canSpendWorkerEnergyOnAssignmentGapRecoveryConstructionSite(creep, site)).sort((left, right) => compareRoomObjectsByRangeAndId2(creep, left, right))[0]) != null ? _b : null;
+}
+function canSpendWorkerEnergyOnAssignmentGapRecoveryConstructionSite(creep, site) {
+  return canSpendWorkerEnergyOnConstructionSite(creep, site) || hasCoveredStoredEnergyForAssignmentGapRecoveryConstruction(creep, site);
 }
 function shouldAllowAssignmentGapRecoveryBuildWorker(creep, currentTask, selectedTask, constructionSite) {
   if (!hasOtherSameRoomBuildAssignment(creep)) {
@@ -35070,11 +35073,51 @@ function hasSafeAssignmentGapRecoveryConstructionEnergy(creep, recoveryTask) {
   if (spawnReservationTarget) {
     return shouldDeferSpawnReservationRefillForProductiveWork(creep, recoveryTask, spawnReservationTarget);
   }
-  return !hasActiveSpawningSpawn2(creep.room) && (hasHealthyRoomEnergyBuffer2(creep.room) || hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room));
+  return !hasActiveSpawningSpawn2(creep.room) && (hasHealthyRoomEnergyBuffer2(creep.room) || hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room) || hasCoveredStoredEnergyForAssignmentGapRecoveryConstruction(creep, getTaskTarget(recoveryTask)));
 }
 function hasStoredEnergyForAssignmentGapRecoveryConstruction(room) {
   const energyAvailable = getRoomEnergyAvailable13(room);
   return energyAvailable !== null && energyAvailable >= MINIMUM_WORKER_SPAWN_ENERGY && getRoomStoredEnergyAvailableForConstruction(room) >= CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY;
+}
+function hasCoveredStoredEnergyForAssignmentGapRecoveryConstruction(creep, site) {
+  var _a2;
+  return getUsedTransferEnergy(creep) > 0 && isCriticalConstructionSite(site) && site.my !== false && ((_a2 = creep.room.controller) == null ? void 0 : _a2.my) === true && !hasActiveSpawningSpawn2(creep.room) && !isControllerDowngradeGuardActive2(creep.room) && getRoomStoredEnergyAvailableForConstruction(creep.room) >= CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY && isMinimumWorkerSpawnEnergyFloorCoveredForAssignmentGapRecovery(creep);
+}
+function isMinimumWorkerSpawnEnergyFloorCoveredForAssignmentGapRecovery(creep) {
+  const energyAvailable = getRoomEnergyAvailable13(creep.room);
+  if (energyAvailable === null) {
+    return false;
+  }
+  const energyGap = Math.max(0, MINIMUM_WORKER_SPAWN_ENERGY - energyAvailable);
+  return energyGap === 0 || getOtherSameRoomImmediateSpawnRefillEnergy(creep) >= energyGap;
+}
+function getOtherSameRoomImmediateSpawnRefillEnergy(creep) {
+  const remainingCapacityByTargetId = /* @__PURE__ */ new Map();
+  return getRoomOwnedCreeps3(creep.room).reduce((total, worker) => {
+    var _a2, _b;
+    if (isSameCreep4(worker, creep) || !isProductiveSameRoomWorker2(worker, creep.room)) {
+      return total;
+    }
+    const task = (_a2 = worker.memory) == null ? void 0 : _a2.task;
+    if ((task == null ? void 0 : task.type) !== "transfer") {
+      return total;
+    }
+    const target = getTaskTarget(task);
+    if (getTransferSinkPriority(target) < 2) {
+      return total;
+    }
+    const carriedEnergy = getUsedTransferEnergy(worker);
+    if (carriedEnergy <= 0) {
+      return total;
+    }
+    const targetId = getObjectId10(target);
+    const remainingCapacity = targetId ? (_b = remainingCapacityByTargetId.get(targetId)) != null ? _b : getFreeTransferEnergyCapacity(target) : getFreeTransferEnergyCapacity(target);
+    const coveredEnergy = Math.min(carriedEnergy, Math.max(0, remainingCapacity));
+    if (targetId) {
+      remainingCapacityByTargetId.set(targetId, Math.max(0, remainingCapacity - coveredEnergy));
+    }
+    return total + coveredEnergy;
+  }, 0);
 }
 function isCriticalSpawnRefillTask(task) {
   return (task == null ? void 0 : task.type) === "transfer" && getTransferSinkPriority(getTaskTarget(task)) >= 3;
@@ -35982,7 +36025,9 @@ function shouldPreemptEnergyAcquisitionTaskForProductiveBacklog(creep, task, sel
   }
   if (selectedTask.type === "build") {
     const constructionSite = getTaskTarget(selectedTask);
-    return Boolean(constructionSite && canSpendWorkerEnergyOnConstructionSite(creep, constructionSite));
+    return Boolean(
+      constructionSite && canSpendWorkerEnergyOnAssignmentGapRecoveryConstructionSite(creep, constructionSite)
+    );
   }
   if (selectedTask.type === "repair") {
     const repairTarget = getTaskTarget(selectedTask);
@@ -36541,7 +36586,7 @@ function classifyBuildActionPrecheck(creep, target) {
   if (getActiveWorkParts3(creep) <= 0) {
     return { result: "failed_no_work", returnCode: getErrNoBodyPartCode() };
   }
-  if (!canSpendWorkerEnergyOnConstructionSite(creep, target)) {
+  if (!canSpendWorkerEnergyOnAssignmentGapRecoveryConstructionSite(creep, target)) {
     return { result: "suppressed_by_policy", returnCode: ERR_NOT_ENOUGH_RESOURCES_CODE2 };
   }
   return null;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -567,8 +567,18 @@ function selectWorkerAssignmentGapRecoveryConstructionSite(creep: Creep): Constr
     sites
       .filter((site) => site.my !== false)
       .filter((site) => !isBuildTargetSuppressedForWorker(creep, site))
-      .filter((site) => canSpendWorkerEnergyOnConstructionSite(creep, site))
+      .filter((site) => canSpendWorkerEnergyOnAssignmentGapRecoveryConstructionSite(creep, site))
       .sort((left, right) => compareRoomObjectsByRangeAndId(creep, left, right))[0] ?? null
+  );
+}
+
+function canSpendWorkerEnergyOnAssignmentGapRecoveryConstructionSite(
+  creep: Creep,
+  site: ConstructionSite
+): boolean {
+  return (
+    canSpendWorkerEnergyOnConstructionSite(creep, site) ||
+    hasCoveredStoredEnergyForAssignmentGapRecoveryConstruction(creep, site)
   );
 }
 
@@ -703,7 +713,9 @@ function hasSafeAssignmentGapRecoveryConstructionEnergy(
 
   return (
     !hasActiveSpawningSpawn(creep.room) &&
-    (hasHealthyRoomEnergyBuffer(creep.room) || hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room))
+    (hasHealthyRoomEnergyBuffer(creep.room) ||
+      hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room) ||
+      hasCoveredStoredEnergyForAssignmentGapRecoveryConstruction(creep, getTaskTarget(recoveryTask)))
   );
 }
 
@@ -714,6 +726,67 @@ function hasStoredEnergyForAssignmentGapRecoveryConstruction(room: Room): boolea
     energyAvailable >= MINIMUM_WORKER_SPAWN_ENERGY &&
     getRoomStoredEnergyAvailableForConstruction(room) >= CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY
   );
+}
+
+function hasCoveredStoredEnergyForAssignmentGapRecoveryConstruction(
+  creep: Creep,
+  site: unknown
+): site is ConstructionSite {
+  return (
+    getUsedTransferEnergy(creep) > 0 &&
+    isCriticalConstructionSite(site) &&
+    (site as ConstructionSite).my !== false &&
+    creep.room.controller?.my === true &&
+    !hasActiveSpawningSpawn(creep.room) &&
+    !isControllerDowngradeGuardActive(creep.room) &&
+    getRoomStoredEnergyAvailableForConstruction(creep.room) >= CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY &&
+    isMinimumWorkerSpawnEnergyFloorCoveredForAssignmentGapRecovery(creep)
+  );
+}
+
+function isMinimumWorkerSpawnEnergyFloorCoveredForAssignmentGapRecovery(creep: Creep): boolean {
+  const energyAvailable = getRoomEnergyAvailable(creep.room);
+  if (energyAvailable === null) {
+    return false;
+  }
+
+  const energyGap = Math.max(0, MINIMUM_WORKER_SPAWN_ENERGY - energyAvailable);
+  return energyGap === 0 || getOtherSameRoomImmediateSpawnRefillEnergy(creep) >= energyGap;
+}
+
+function getOtherSameRoomImmediateSpawnRefillEnergy(creep: Creep): number {
+  const remainingCapacityByTargetId = new Map<string, number>();
+  return getRoomOwnedCreeps(creep.room).reduce((total, worker) => {
+    if (isSameCreep(worker, creep) || !isProductiveSameRoomWorker(worker, creep.room)) {
+      return total;
+    }
+
+    const task = worker.memory?.task;
+    if (task?.type !== 'transfer') {
+      return total;
+    }
+
+    const target = getTaskTarget(task);
+    if (getTransferSinkPriority(target) < 2) {
+      return total;
+    }
+
+    const carriedEnergy = getUsedTransferEnergy(worker);
+    if (carriedEnergy <= 0) {
+      return total;
+    }
+
+    const targetId = getObjectId(target);
+    const remainingCapacity = targetId
+      ? remainingCapacityByTargetId.get(targetId) ?? getFreeTransferEnergyCapacity(target)
+      : getFreeTransferEnergyCapacity(target);
+    const coveredEnergy = Math.min(carriedEnergy, Math.max(0, remainingCapacity));
+    if (targetId) {
+      remainingCapacityByTargetId.set(targetId, Math.max(0, remainingCapacity - coveredEnergy));
+    }
+
+    return total + coveredEnergy;
+  }, 0);
 }
 
 function isCriticalSpawnRefillTask(task: CreepTaskMemory | null | undefined): boolean {
@@ -2153,7 +2226,10 @@ function shouldPreemptEnergyAcquisitionTaskForProductiveBacklog(
 
   if (selectedTask.type === 'build') {
     const constructionSite = getTaskTarget(selectedTask) as ConstructionSite | null;
-    return Boolean(constructionSite && canSpendWorkerEnergyOnConstructionSite(creep, constructionSite));
+    return Boolean(
+      constructionSite &&
+      canSpendWorkerEnergyOnAssignmentGapRecoveryConstructionSite(creep, constructionSite)
+    );
   }
 
   if (selectedTask.type === 'repair') {
@@ -3003,7 +3079,7 @@ function classifyBuildActionPrecheck(
     return { result: 'failed_no_work', returnCode: getErrNoBodyPartCode() };
   }
 
-  if (!canSpendWorkerEnergyOnConstructionSite(creep, target)) {
+  if (!canSpendWorkerEnergyOnAssignmentGapRecoveryConstructionSite(creep, target)) {
     return { result: 'suppressed_by_policy', returnCode: ERR_NOT_ENOUGH_RESOURCES_CODE };
   }
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -7755,6 +7755,164 @@ describe('runWorker', () => {
     }
   });
 
+  it('recovers E29N55 build assignment from spawn-critical harvest when another worker covers spawn floor', () => {
+    const source = {
+      id: 'source1',
+      energy: 3_000
+    } as Source;
+    const site = {
+      id: 'tower-site1',
+      my: true,
+      structureType: 'tower',
+      progress: 1_093,
+      progressTotal: 5_000,
+      pos: { x: 22, y: 21, roomName: 'E29N55' } as RoomPosition
+    } as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 175 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 125 : 0))
+      }
+    } as unknown as StructureSpawn;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 2_455 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(10_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 6,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N55',
+      energyAvailable: 175,
+      energyCapacityAvailable: 2_300,
+      controller,
+      storage,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn, storage] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [spawn, storage];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          if (type === FIND_SOURCES) {
+            return [source];
+          }
+
+          if (type === FIND_HOSTILE_CREEPS) {
+            return [];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const harvest = jest.fn();
+    const selectedUpgradeTask = { type: 'upgrade', targetId: 'controller1' as Id<StructureController> } as const;
+    const creep = {
+      name: 'LoadedHarvester',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'harvest', targetId: 'source1' as Id<Source> }
+      },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 75 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 25 : 0))
+      },
+      room,
+      build,
+      harvest,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const spawnRefillWorker = {
+      name: 'SpawnRefillWorker',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'transfer', targetId: 'spawn1' as Id<AnyStoreStructure> }
+      },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 30 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 70 : 0))
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, spawnRefillWorker);
+    const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(selectedUpgradeTask);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { LoadedHarvester: creep, SpawnRefillWorker: spawnRefillWorker },
+      rooms: { E29N55: room },
+      time: 2_083_286,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'tower-site1') {
+          return site;
+        }
+
+        if (id === 'source1') {
+          return source;
+        }
+
+        if (id === 'spawn1') {
+          return spawn;
+        }
+
+        if (id === 'controller1') {
+          return controller;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({ type: 'build', targetId: 'tower-site1' });
+      expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+        currentTask: 'harvest',
+        currentTargetId: 'source1',
+        baseSelectedTask: 'upgrade',
+        baseSelectedTargetId: 'controller1',
+        energyCriticalTask: 'harvest',
+        energyCriticalTargetId: 'source1',
+        selectedTask: 'build',
+        selectedTargetId: 'tower-site1',
+        assignedTask: 'build',
+        assignedTargetId: 'tower-site1'
+      });
+      expect(build).toHaveBeenCalledWith(site);
+      expect(harvest).not.toHaveBeenCalled();
+    } finally {
+      selectWorkerTask.mockRestore();
+    }
+  });
+
   it('recovers construction assignment from retained controller progress when stored energy can cover construction', () => {
     const site = {
       id: 'road-site1',


### PR DESCRIPTION
## Summary
- Allows a loaded worker to take a critical construction-site recovery build when room storage has enough construction energy and another same-room worker is already covering the minimum spawn-energy floor.
- Keeps the existing controller-downgrade, active-spawning, owned-site, and critical-construction guards in place.
- Adds a regression test matching the E29N55 worker-assignment-gap evidence and rebuilds the Screeps bundle.

Refs #1781.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (105 suites, 2409 tests)
- `cd prod && npm run build`

## Safety
- No official MMO API write, deploy, cron mutation, secret access, Tencent paid compute, or owner-side action was performed in this PR.
- Runtime acceptance remains tracked by #1781 using fresh runtime-summary/alert windows for `buildCarriedEnergy`, build tasks, build progress, and `worker_assignment_gap` clearance.

## Universal task Done gate
- [x] Task type: code
- [x] Expected observable outcome / named deliverable: `prod/src/creeps/workerRunner.ts` covered spawn-floor recovery path, regression test, and synchronized `prod/dist/main.js` bundle.
- [x] Non-goals / accepted substitutes: no deploy, no Project closure, no Tencent paid compute, and no official MMO write in this PR.
- [x] Verification evidence required before Done: controller-run `git diff --check`, prod typecheck, Jest 105-suite run, and build all passed on commit `edc772a66b3d0e97816a14b6676fd9a32cf2effe`.
- [x] Project Evidence / Next action / Blocked by: #1781 and this PR are maintained in Project `screeps`; next action is PR review gate, deploy, then runtime acceptance windows under #1781.
- [x] Post-merge/deploy/runtime proof: #1781 remains the runtime acceptance tracker for deploy evidence plus fresh monitor windows; this PR supplies the named code/test/bundle deliverable.
- [x] Named deliverable proof: commit `edc772a66b3d0e97816a14b6676fd9a32cf2effe` modifies `workerRunner.ts`, `workerRunner.test.ts`, and `dist/main.js` only.
