### PR TITLE
worker: keep repair recovery eligible for construction gap

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -34969,7 +34969,13 @@ function isWorkerAssignmentGapRecoverySelection(creep, currentTask, selectedTask
     return false;
   }
   const allowUpgradeRecovery = !isControllerDowngradeGuardActive2(creep.room);
-  return isWorkerAssignmentGapRecoveryTask(creep, currentTask, allowUpgradeRecovery, { allowRepair: true }) && isWorkerAssignmentGapRecoveryTask(creep, selectedTask, allowUpgradeRecovery);
+  const allowSelectedRepairRecovery = (currentTask == null ? void 0 : currentTask.type) === "repair" && (selectedTask == null ? void 0 : selectedTask.type) === "repair";
+  return isWorkerAssignmentGapRecoveryTask(creep, currentTask, allowUpgradeRecovery, { allowRepair: true }) && isWorkerAssignmentGapRecoveryTask(
+    creep,
+    selectedTask,
+    allowUpgradeRecovery,
+    allowSelectedRepairRecovery ? { allowRepair: true } : {}
+  );
 }
 function isWorkerAssignmentGapRecoveryTask(creep, task, allowUpgradeRecovery, options = {}) {
   return task === void 0 || task === null || isEnergyAcquisitionTask2(task) || task.type === "transfer" || options.allowRepair === true && isWorkerAssignmentGapRecoveryRepairTask(creep, task) || allowUpgradeRecovery && task.type === "upgrade";

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -528,9 +528,15 @@ function isWorkerAssignmentGapRecoverySelection(
   }
 
   const allowUpgradeRecovery = !isControllerDowngradeGuardActive(creep.room);
+  const allowSelectedRepairRecovery = currentTask?.type === 'repair' && selectedTask?.type === 'repair';
   return (
     isWorkerAssignmentGapRecoveryTask(creep, currentTask, allowUpgradeRecovery, { allowRepair: true }) &&
-    isWorkerAssignmentGapRecoveryTask(creep, selectedTask, allowUpgradeRecovery)
+    isWorkerAssignmentGapRecoveryTask(
+      creep,
+      selectedTask,
+      allowUpgradeRecovery,
+      allowSelectedRepairRecovery ? { allowRepair: true } : {}
+    )
   );
 }
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -7487,6 +7487,124 @@ describe('runWorker', () => {
     }
   });
 
+  it('recovers E29N55 construction assignment when selection keeps routine repair active', () => {
+    const site = {
+      id: 'rampart-site1',
+      my: true,
+      structureType: 'rampart',
+      progress: 2_894,
+      progressTotal: 5_000
+    } as ConstructionSite;
+    const routineRampart = {
+      id: 'rampart-routine',
+      my: true,
+      structureType: 'rampart',
+      hits: BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING + 1,
+      hitsMax: 30_000_000
+    } as StructureRampart;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 6,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N55',
+      energyAvailable: 2_300,
+      energyCapacityAvailable: 2_300,
+      controller,
+      find: jest.fn((type: number, options?: { filter?: (object: Creep) => boolean }) => {
+        if (type === FIND_MY_CREEPS) {
+          return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+        }
+
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [routineRampart];
+        }
+
+        if (type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
+          return [];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const repairTask = { type: 'repair', targetId: 'rampart-routine' as Id<Structure> } as const;
+    const creep = {
+      name: 'worker-E29N55-2086075',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: repairTask
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 97 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 3 : 0))
+      },
+      room,
+      build: jest.fn().mockReturnValue(0),
+      repair: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const emptyWorker = {
+      name: 'worker-E29N55-2085929',
+      memory: { role: 'worker', colony: 'E29N55' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, emptyWorker);
+    const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(repairTask);
+    const selectWorkerEnergyCriticalTask = jest
+      .spyOn(workerTaskPolicy, 'selectWorkerEnergyCriticalTask')
+      .mockReturnValue(null);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {
+        [creep.name]: creep,
+        [emptyWorker.name]: emptyWorker
+      },
+      rooms: { E29N55: room },
+      time: 2_086_489,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'rampart-site1') {
+          return site;
+        }
+
+        return id === 'rampart-routine' ? routineRampart : null;
+      })
+    };
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({ type: 'build', targetId: 'rampart-site1' });
+      expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+        currentTask: 'repair',
+        currentTargetId: 'rampart-routine',
+        baseSelectedTask: 'repair',
+        baseSelectedTargetId: 'rampart-routine',
+        selectedTask: 'build',
+        selectedTargetId: 'rampart-site1',
+        assignedTask: 'build',
+        assignedTargetId: 'rampart-site1'
+      });
+      expect(creep.build).toHaveBeenCalledWith(site);
+      expect(creep.repair).not.toHaveBeenCalled();
+    } finally {
+      selectWorkerTask.mockRestore();
+      selectWorkerEnergyCriticalTask.mockRestore();
+    }
+  });
+
   it('preempts a stale E29N57 spawn reservation transfer when stored energy can cover construction', () => {
     const site = {
       id: 'road-site1',


### PR DESCRIPTION
## Summary
- Keeps a worker's current routine repair assignment eligible for construction-gap recovery when the selector also returns the same routine repair task.
- Adds a regression test for the E29N55 worker-assignment gap where a carried-energy worker stayed on routine rampart repair while an owned construction site had pending progress.
- Regenerates `prod/dist/main.js` from the verified source.

Related to issue 1781. This PR is a code-recovery slice; the issue remains active until official deploy/runtime acceptance proves the construction gap cleared.

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` — 105 suites / 2410 tests passed
- `npm run build`

## Universal task Done gate
- [x] Task type: production code bugfix for Territory/Economy worker assignment.
- [x] Expected observable outcome / named deliverable: `runWorker` can switch a carried-energy worker from same-selected routine repair to the existing construction-site recovery build target during a worker-assignment-gap recovery window.
- [x] Non-goals / accepted substitutes: no GitHub Project mutation, deploy, or runtime issue closure is claimed by this PR body; controller handles PR gates, deploy, and issue 1781 acceptance evidence.
- [x] Verification evidence required before Done: local controller verification passed with `git diff --check`, `npm run typecheck`, `npm test -- --runInBand`, and `npm run build` on commit `ed50fd6e`.
- [x] Project Evidence / Next action / Blocked by: PR and issue 1781 Project fields will be updated to point at commit `ed50fd6e`, controller verification, and the next PR review/deploy gate.
- [x] Post-merge/deploy/runtime proof: official deploy plus fresh runtime monitor windows must show construction assignment recovery before issue 1781 can be closed.
- [x] Named deliverable proof: `prod/test/workerRunner.test.ts` covers the E29N55 repair-to-build recovery case and `prod/dist/main.js` is rebuilt from the changed source.

## Safety
- No secrets printed or changed.
- No official MMO writes were performed by the local verification/commit recovery.
