### PR TITLE
runtime-monitor: alert on sustained none-task workers

### DIFF
--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -110,6 +110,11 @@ WORKER_ASSIGNMENT_GAP_RECOVERY_TICK_TOLERANCE = 0
 WORKER_ASSIGNMENT_STALL_KIND = "worker_assignment_stall"
 WORKER_ASSIGNMENT_STALL_REQUIRED_TICKS = 100
 WORKER_ASSIGNMENT_STALL_REQUIRED_CONSECUTIVE_CAPTURES = 4
+OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND = "owned_room_none_task_worker_ratio_sustained"
+OWNED_ROOM_NONE_TASK_WORKER_RATIO_THRESHOLD = 0.5
+OWNED_ROOM_NONE_TASK_WORKER_COUNT_THRESHOLD = 2
+OWNED_ROOM_NONE_TASK_WORKER_RATIO_REQUIRED_TICKS = 100
+OWNED_ROOM_NONE_TASK_WORKER_RATIO_REQUIRED_CONSECUTIVE_CAPTURES = 2
 RUNTIME_SUMMARY_CAPTURE_HISTORY_LIMIT = 12
 RUNTIME_SUMMARY_TICK_METADATA_KEY = "__runtimeSummaryTick"
 RUNTIME_SUMMARY_ARTIFACT_TIMESTAMP_METADATA_KEY = "__runtimeSummaryArtifactTimestamp"
@@ -267,6 +272,11 @@ WORKER_ASSIGNMENT_STALL_ROUTES = [
     {"issue": "#1573", "topic": "worker_deadlock_alert"},
     {"issue": "#906", "topic": "gameplay_behavior_metric"},
 ]
+OWNED_ROOM_NONE_TASK_WORKER_RATIO_ROUTES = [
+    {"issue": "#1767", "topic": "runtime_monitor_alert"},
+    {"issue": "#1776", "topic": "secondary_room_standby_behavior"},
+    {"issue": "#906", "topic": "gameplay_behavior_metric"},
+]
 
 ROOM_SIZE = 50
 TERRAIN_CELLS = ROOM_SIZE * ROOM_SIZE
@@ -413,6 +423,22 @@ TACTICAL_CATEGORY_RULES: dict[str, dict[str, Any]] = {
             "routes_to": WORKER_ASSIGNMENT_STALL_ROUTES,
         },
     },
+    OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND: {
+        "severity": "high",
+        "decision": "codex_hotfix",
+        "actions": ["capture_runtime_context", "inspect_resource_state", "start_hotfix_gate"],
+        "metadata": {
+            "metric": "taskCounts.none / workerCount",
+            "related_issues": [str(route["issue"]) for route in OWNED_ROOM_NONE_TASK_WORKER_RATIO_ROUTES],
+            "thresholds": {
+                "P1_ratio": OWNED_ROOM_NONE_TASK_WORKER_RATIO_THRESHOLD,
+                "P1_none_workers": OWNED_ROOM_NONE_TASK_WORKER_COUNT_THRESHOLD,
+                "P1_ticks": OWNED_ROOM_NONE_TASK_WORKER_RATIO_REQUIRED_TICKS,
+                "P1_consecutive_captures": OWNED_ROOM_NONE_TASK_WORKER_RATIO_REQUIRED_CONSECUTIVE_CAPTURES,
+            },
+            "routes_to": OWNED_ROOM_NONE_TASK_WORKER_RATIO_ROUTES,
+        },
+    },
     "downgrade_risk": {
         "severity": "high",
         "decision": "owner_action_or_codex_hotfix",
@@ -529,6 +555,7 @@ TACTICAL_REASON_CATEGORY_MAP = {
     EXTENSION_COUNT_ZERO_AT_RCL_GE_2_KIND: [EXTENSION_COUNT_ZERO_AT_RCL_GE_2_KIND],
     WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND: [WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND],
     WORKER_ASSIGNMENT_STALL_KIND: [WORKER_ASSIGNMENT_STALL_KIND],
+    OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND: [OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND],
     "postdeploy_no_owned_spawn": ["spawn_collapse"],
     "owned_spawns=0": ["spawn_collapse"],
     "controller_downgrade_risk": ["downgrade_risk"],
@@ -1488,6 +1515,20 @@ def worker_assignment_stall_metadata() -> dict[str, Any]:
             "P2_consecutive_captures": WORKER_ASSIGNMENT_STALL_REQUIRED_CONSECUTIVE_CAPTURES,
         },
         "routes_to": [dict(route) for route in WORKER_ASSIGNMENT_STALL_ROUTES],
+    }
+
+
+def owned_room_none_task_worker_ratio_metadata() -> dict[str, Any]:
+    return {
+        "metric": "taskCounts.none / workerCount",
+        "related_issues": [str(route["issue"]) for route in OWNED_ROOM_NONE_TASK_WORKER_RATIO_ROUTES],
+        "thresholds": {
+            "P1_ratio": OWNED_ROOM_NONE_TASK_WORKER_RATIO_THRESHOLD,
+            "P1_none_workers": OWNED_ROOM_NONE_TASK_WORKER_COUNT_THRESHOLD,
+            "P1_ticks": OWNED_ROOM_NONE_TASK_WORKER_RATIO_REQUIRED_TICKS,
+            "P1_consecutive_captures": OWNED_ROOM_NONE_TASK_WORKER_RATIO_REQUIRED_CONSECUTIVE_CAPTURES,
+        },
+        "routes_to": [dict(route) for route in OWNED_ROOM_NONE_TASK_WORKER_RATIO_ROUTES],
     }
 
 
@@ -2752,6 +2793,328 @@ def worker_assignment_capture_window_evidence(
     return evidence, worker_assignment_capture_state(captures, evidence.get("runtimeSummaryTick"))
 
 
+def runtime_worker_summary_tick(room: dict[str, Any] | None) -> int | None:
+    if not isinstance(room, dict):
+        return None
+    for value in (
+        room.get(RUNTIME_SUMMARY_TICK_METADATA_KEY),
+        nested_value(room, "workerAssignmentEvidence", "tick"),
+        room.get("tick"),
+    ):
+        tick = tick_number(value)
+        if tick is not None:
+            return tick
+    return None
+
+
+def runtime_worker_count_from_summary(room: dict[str, Any] | None) -> int | float | None:
+    if not isinstance(room, dict):
+        return None
+    worker_count = first_number_value(
+        room,
+        ("workerCount",),
+        ("workerAssignmentEvidence", "workerCount"),
+        ("resources", "productiveEnergy", "workerCount"),
+        ("productiveEnergy", "workerCount"),
+    )
+    if worker_count is not None:
+        return max(0, worker_count)
+
+    task_counts = as_dict(room.get("taskCounts"))
+    counted_workers = sum(value for value in (number_value(item) for item in task_counts.values()) if value is not None)
+    return counted_workers if counted_workers > 0 else None
+
+
+def runtime_none_task_worker_count(room: dict[str, Any] | None) -> int | float | None:
+    if not isinstance(room, dict):
+        return None
+    none_count = runtime_task_count(room, "none")
+    if none_count is not None:
+        return max(0, none_count)
+    fallback_count = first_number_value(
+        room,
+        ("workerAssignmentEvidence", "unassignedWorkerCount"),
+        ("resources", "productiveEnergy", "unassignedWorkerCount"),
+        ("productiveEnergy", "unassignedWorkerCount"),
+        ("unassignedWorkerCount",),
+    )
+    return max(0, fallback_count) if fallback_count is not None else None
+
+
+def runtime_assigned_task_count(room: dict[str, Any] | None) -> int | float | None:
+    if not isinstance(room, dict):
+        return None
+    assigned = first_number_value(
+        room,
+        ("workerAssignmentEvidence", "assignedTaskCount"),
+        ("assignedTaskCount",),
+    )
+    if assigned is not None:
+        return assigned
+    worker_count = runtime_worker_count_from_summary(room)
+    none_count = runtime_none_task_worker_count(room)
+    if worker_count is None or none_count is None:
+        return None
+    return max(0, worker_count - none_count)
+
+
+def runtime_idle_reason_counts(room: dict[str, Any] | None) -> dict[str, int | float]:
+    if not isinstance(room, dict):
+        return {}
+    counts = as_dict(nested_value(room, "workerAssignmentEvidence", "idleReasonCounts"))
+    if not counts:
+        counts = as_dict(room.get("idleReasonCounts"))
+    result: dict[str, int | float] = {}
+    for key, value in counts.items():
+        if not isinstance(key, str) or not key:
+            continue
+        count = number_value(value)
+        if count is not None:
+            result[key] = count
+    return result
+
+
+def sanitized_idle_worker(worker: Any) -> dict[str, Any] | None:
+    if not isinstance(worker, dict):
+        return None
+    result: dict[str, Any] = {}
+    for key in ("name", "reason", "dispatchReason"):
+        value = worker.get(key)
+        if isinstance(value, str) and value:
+            result[key] = short_text(value, MAX_CREEP_MEMORY_ASSIGNMENT_STRING_LENGTH)
+    for key in ("carriedEnergy", "freeCapacity", "dispatchTick"):
+        value = number_value(worker.get(key))
+        if value is not None:
+            result[key] = value
+    return result or None
+
+
+def runtime_idle_workers(room: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(room, dict):
+        return []
+    for candidate in (
+        nested_value(room, "workerAssignmentEvidence", "idleWorkers"),
+        room.get("idleWorkers"),
+    ):
+        if not isinstance(candidate, list):
+            continue
+        workers = [sanitized for item in candidate if (sanitized := sanitized_idle_worker(item)) is not None]
+        if workers:
+            return workers[:MAX_WORKER_ASSIGNMENT_BLOCKED_WORKERS]
+    return []
+
+
+def owned_room_none_task_worker_ratio_evidence(runtime_room: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(runtime_room, dict):
+        return None
+    if not runtime_worker_assignment_evidence_available(runtime_room):
+        return None
+
+    worker_count = runtime_worker_count_from_summary(runtime_room)
+    none_count = runtime_none_task_worker_count(runtime_room)
+    if worker_count is None or none_count is None or worker_count <= 0 or none_count <= 0:
+        return None
+
+    none_ratio = none_count / worker_count
+    if (
+        none_count < OWNED_ROOM_NONE_TASK_WORKER_COUNT_THRESHOLD
+        or none_ratio < OWNED_ROOM_NONE_TASK_WORKER_RATIO_THRESHOLD
+    ):
+        return None
+
+    task_counts = dict(as_dict(runtime_room.get("taskCounts")))
+    evidence: dict[str, Any] = {
+        "workerCount": worker_count,
+        "noneTaskWorkerCount": none_count,
+        "noneTaskWorkerRatio": round(none_ratio, 3),
+        "noneTaskWorkerRatioThreshold": OWNED_ROOM_NONE_TASK_WORKER_RATIO_THRESHOLD,
+        "noneTaskWorkerCountThreshold": OWNED_ROOM_NONE_TASK_WORKER_COUNT_THRESHOLD,
+        "assignedTaskCount": runtime_assigned_task_count(runtime_room),
+        "productiveAssignmentCount": runtime_productive_assignment_count(runtime_room),
+        "task_counts": task_counts,
+        "idleReasonCounts": runtime_idle_reason_counts(runtime_room),
+        "runtimeSummaryTick": runtime_worker_summary_tick(runtime_room),
+    }
+    idle_workers = runtime_idle_workers(runtime_room)
+    if idle_workers:
+        evidence["idleWorkers"] = idle_workers
+    artifact_timestamp = runtime_room.get(RUNTIME_SUMMARY_ARTIFACT_TIMESTAMP_METADATA_KEY)
+    if isinstance(artifact_timestamp, (int, float, str)) and artifact_timestamp:
+        evidence["runtimeSummaryArtifactTimestamp"] = artifact_timestamp
+    artifact_path = runtime_room.get(RUNTIME_SUMMARY_ARTIFACT_PATH_METADATA_KEY)
+    if isinstance(artifact_path, str) and artifact_path:
+        evidence["runtimeSummaryArtifactPath"] = artifact_path
+    artifact_line = number_value(runtime_room.get(RUNTIME_SUMMARY_ARTIFACT_LINE_METADATA_KEY))
+    if artifact_line is not None:
+        evidence["runtimeSummaryArtifactLine"] = int(artifact_line)
+    return evidence
+
+
+def owned_room_none_task_capture_matches(capture: dict[str, Any]) -> bool:
+    return owned_room_none_task_worker_ratio_evidence(capture) is not None
+
+
+def owned_room_none_task_consecutive_captures(runtime_room: dict[str, Any] | None) -> list[dict[str, Any]]:
+    captures = runtime_summary_capture_history(runtime_room)
+    if not captures:
+        return []
+    consecutive: list[dict[str, Any]] = []
+    for capture in captures:
+        if not owned_room_none_task_capture_matches(capture):
+            break
+        consecutive.append(capture)
+    return consecutive
+
+
+def owned_room_none_task_ratio_previous_state(value: Any) -> dict[str, int]:
+    if not isinstance(value, dict):
+        return {}
+    result: dict[str, int] = {}
+    for key in ("start_tick", "last_tick", "consecutive_ticks", "consecutive_captures"):
+        tick = tick_number(value.get(key))
+        if tick is not None:
+            result[key] = tick
+    return result
+
+
+def owned_room_none_task_ratio_next_state(previous_state: dict[str, int], current_tick: int) -> dict[str, int]:
+    previous_start_tick = previous_state.get("start_tick")
+    previous_last_tick = previous_state.get("last_tick")
+    if previous_start_tick is None or previous_last_tick is None or current_tick < previous_last_tick:
+        start_tick = current_tick
+        consecutive_captures = 1
+    else:
+        start_tick = previous_start_tick
+        previous_captures = previous_state.get("consecutive_captures")
+        consecutive_captures = (previous_captures if previous_captures is not None else 1) + 1
+    return {
+        "start_tick": start_tick,
+        "last_tick": current_tick,
+        "consecutive_ticks": max(0, current_tick - start_tick),
+        "consecutive_captures": consecutive_captures,
+    }
+
+
+def owned_room_none_task_capture_state(captures: list[dict[str, Any]], current_tick_value: Any) -> dict[str, int]:
+    current_tick = tick_number(captures[0].get("runtimeSummaryTick")) if captures else None
+    start_tick = tick_number(captures[-1].get("runtimeSummaryTick")) if captures else None
+    if current_tick is None:
+        current_tick = tick_number(current_tick_value)
+    if start_tick is None:
+        start_tick = current_tick
+    if current_tick is None:
+        current_tick = start_tick if start_tick is not None else 0
+    if start_tick is None:
+        start_tick = current_tick
+    return {
+        "start_tick": start_tick,
+        "last_tick": current_tick,
+        "consecutive_ticks": max(0, current_tick - start_tick),
+        "consecutive_captures": len(captures),
+    }
+
+
+def owned_room_none_task_capture_window_evidence(
+    runtime_room: dict[str, Any] | None,
+    current_tick_value: Any,
+) -> tuple[dict[str, Any], dict[str, int]] | None:
+    captures = owned_room_none_task_consecutive_captures(runtime_room)
+    if len(captures) < OWNED_ROOM_NONE_TASK_WORKER_RATIO_REQUIRED_CONSECUTIVE_CAPTURES:
+        return None
+    state = owned_room_none_task_capture_state(captures, current_tick_value)
+    if state["consecutive_ticks"] < OWNED_ROOM_NONE_TASK_WORKER_RATIO_REQUIRED_TICKS:
+        return None
+    evidence = owned_room_none_task_worker_ratio_evidence(runtime_room)
+    if evidence is None:
+        evidence = owned_room_none_task_worker_ratio_evidence(captures[0])
+    if evidence is None:
+        return None
+    evidence["consecutiveCaptures"] = len(captures)
+    evidence["thresholdCaptures"] = OWNED_ROOM_NONE_TASK_WORKER_RATIO_REQUIRED_CONSECUTIVE_CAPTURES
+    evidence["runtimeSummaryCaptures"] = captures
+    evidence["runtimeSummaryCapturePaths"] = worker_assignment_capture_paths(captures)
+    return evidence, state
+
+
+def build_owned_room_none_task_worker_ratio_reason(
+    ref: RoomRef,
+    evidence: dict[str, Any],
+    state: dict[str, int],
+) -> dict[str, Any]:
+    consecutive_captures = number_value(evidence.get("consecutiveCaptures"))
+    capture_duration = (
+        f"across {format_energy_value(consecutive_captures)} consecutive runtime-summary captures "
+        f"over {state['consecutive_ticks']} ticks"
+        if consecutive_captures is not None
+        else f"for {state['consecutive_ticks']} ticks"
+    )
+    return {
+        "kind": OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND,
+        "room": ref.key,
+        "shard": ref.shard,
+        "room_name": ref.room,
+        "severity": "high",
+        "priority": "P1",
+        **evidence,
+        "start_tick": state["start_tick"],
+        "current_tick": state["last_tick"],
+        "consecutive_ticks": state["consecutive_ticks"],
+        "consecutiveCaptures": state["consecutive_captures"],
+        "threshold": OWNED_ROOM_NONE_TASK_WORKER_RATIO_THRESHOLD,
+        "next_action": (
+            "Codex triage: inspect owned-room worker assignment and standby behavior; verify "
+            "taskCounts.none falls below the sustained ratio threshold in fresh runtime-summary captures."
+        ),
+        "owner_ping": False,
+        "metadata": owned_room_none_task_worker_ratio_metadata(),
+        "message": (
+            f"{OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND} in {ref.key}: "
+            f"taskCounts.none={format_energy_value(evidence.get('noneTaskWorkerCount'))}/"
+            f"{format_energy_value(evidence.get('workerCount'))} "
+            f"({evidence.get('noneTaskWorkerRatio')}) {capture_duration}; "
+            f"idleReasonCounts={evidence.get('idleReasonCounts') or {}}."
+        ),
+        "signature": f"{OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND}:{ref.key}",
+    }
+
+
+def detect_owned_room_none_task_worker_ratio_reason(
+    ref: RoomRef,
+    runtime_room: dict[str, Any] | None,
+    previous_rule_state: Any,
+    current_tick_value: Any,
+) -> tuple[dict[str, Any] | None, dict[str, int] | int]:
+    capture_window = owned_room_none_task_capture_window_evidence(runtime_room, current_tick_value)
+    if capture_window is not None:
+        evidence, state = capture_window
+        return build_owned_room_none_task_worker_ratio_reason(ref, evidence, state), state
+
+    evidence = owned_room_none_task_worker_ratio_evidence(runtime_room)
+    if evidence is None:
+        return None, 0
+
+    current_tick = tick_number(evidence.get("runtimeSummaryTick"))
+    if current_tick is None:
+        current_tick = tick_number(current_tick_value)
+    if current_tick is None:
+        preserved_state = owned_room_none_task_ratio_previous_state(previous_rule_state)
+        return None, preserved_state or 0
+
+    previous_state = owned_room_none_task_ratio_previous_state(previous_rule_state)
+    previous_last_tick = previous_state.get("last_tick")
+    state = owned_room_none_task_ratio_next_state(previous_state, current_tick)
+    evidence["consecutiveCaptures"] = state["consecutive_captures"]
+    evidence["thresholdCaptures"] = OWNED_ROOM_NONE_TASK_WORKER_RATIO_REQUIRED_CONSECUTIVE_CAPTURES
+    if current_tick == previous_last_tick:
+        return None, state
+    if (
+        state["consecutive_ticks"] >= OWNED_ROOM_NONE_TASK_WORKER_RATIO_REQUIRED_TICKS
+        and state["consecutive_captures"] >= OWNED_ROOM_NONE_TASK_WORKER_RATIO_REQUIRED_CONSECUTIVE_CAPTURES
+    ):
+        return build_owned_room_none_task_worker_ratio_reason(ref, evidence, state), state
+    return None, state
+
+
 def build_worker_assignment_stall_reason(
     ref: RoomRef,
     evidence: dict[str, Any],
@@ -3073,6 +3436,17 @@ def evaluate_room_alert(
     rule_counts[WORKER_ASSIGNMENT_STALL_KIND] = worker_assignment_stall_state
     if worker_assignment_stall_candidate is not None:
         detected.append(worker_assignment_stall_candidate)
+
+    previous_none_task_ratio_state = rule_counts.get(OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND)
+    none_task_ratio_candidate, none_task_ratio_state = detect_owned_room_none_task_worker_ratio_reason(
+        snapshot.ref,
+        runtime_room_summary if owned_room_for_worker_alerts else None,
+        previous_none_task_ratio_state,
+        snapshot.tick,
+    )
+    rule_counts[OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND] = none_task_ratio_state
+    if none_task_ratio_candidate is not None:
+        detected.append(none_task_ratio_candidate)
 
     previous_worker_assignment_gap_state = rule_counts.get(WORKER_ASSIGNMENT_GAP_SUSTAINED_KIND)
     worker_assignment_gap_candidate, worker_assignment_gap_state = detect_worker_assignment_gap_sustained_reason(
@@ -4777,6 +5151,18 @@ def runtime_summary_capture_history_entry(room: dict[str, Any]) -> dict[str, Any
     productive_assignment_count = runtime_productive_assignment_count(room)
     if productive_assignment_count is not None:
         entry["productiveAssignmentCount"] = productive_assignment_count
+    assigned_task_count = runtime_assigned_task_count(room)
+    if assigned_task_count is not None:
+        entry["assignedTaskCount"] = assigned_task_count
+    none_task_worker_count = runtime_none_task_worker_count(room)
+    if none_task_worker_count is not None:
+        entry["noneTaskWorkerCount"] = none_task_worker_count
+    idle_reason_counts = runtime_idle_reason_counts(room)
+    if idle_reason_counts:
+        entry["idleReasonCounts"] = idle_reason_counts
+    idle_workers = runtime_idle_workers(room)
+    if idle_workers:
+        entry["idleWorkers"] = idle_workers
     blocked_detail = runtime_worker_assignment_blocked_detail(room)
     if blocked_detail is not None:
         entry["workerAssignmentBlockedDetail"] = blocked_detail

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -2980,6 +2980,17 @@ def owned_room_none_task_ratio_previous_state(value: Any) -> dict[str, int]:
 def owned_room_none_task_ratio_next_state(previous_state: dict[str, int], current_tick: int) -> dict[str, int]:
     previous_start_tick = previous_state.get("start_tick")
     previous_last_tick = previous_state.get("last_tick")
+    if previous_start_tick is not None and previous_last_tick is not None and current_tick <= previous_last_tick:
+        previous_captures = previous_state.get("consecutive_captures")
+        previous_ticks = previous_state.get("consecutive_ticks")
+        return {
+            "start_tick": previous_start_tick,
+            "last_tick": previous_last_tick,
+            "consecutive_ticks": (
+                previous_ticks if previous_ticks is not None else max(0, previous_last_tick - previous_start_tick)
+            ),
+            "consecutive_captures": previous_captures if previous_captures is not None else 1,
+        }
     if previous_start_tick is None or previous_last_tick is None or current_tick < previous_last_tick:
         start_tick = current_tick
         consecutive_captures = 1
@@ -3020,6 +3031,8 @@ def owned_room_none_task_capture_window_evidence(
 ) -> tuple[dict[str, Any], dict[str, int]] | None:
     captures = owned_room_none_task_consecutive_captures(runtime_room)
     if len(captures) < OWNED_ROOM_NONE_TASK_WORKER_RATIO_REQUIRED_CONSECUTIVE_CAPTURES:
+        return None
+    if not worker_assignment_capture_window_is_fresh(captures, current_tick_value):
         return None
     state = owned_room_none_task_capture_state(captures, current_tick_value)
     if state["consecutive_ticks"] < OWNED_ROOM_NONE_TASK_WORKER_RATIO_REQUIRED_TICKS:
@@ -3105,7 +3118,7 @@ def detect_owned_room_none_task_worker_ratio_reason(
     state = owned_room_none_task_ratio_next_state(previous_state, current_tick)
     evidence["consecutiveCaptures"] = state["consecutive_captures"]
     evidence["thresholdCaptures"] = OWNED_ROOM_NONE_TASK_WORKER_RATIO_REQUIRED_CONSECUTIVE_CAPTURES
-    if current_tick == previous_last_tick:
+    if previous_last_tick is not None and current_tick <= previous_last_tick:
         return None, state
     if (
         state["consecutive_ticks"] >= OWNED_ROOM_NONE_TASK_WORKER_RATIO_REQUIRED_TICKS

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -1126,6 +1126,77 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual([item["kind"] for item in health["reasons"]], ["postdeploy_active_alert"])
         self.assertEqual(health["reasons"][0]["source"]["kind"], monitor.OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND)
 
+    def test_owned_room_same_tick_none_task_ratio_state_is_idempotent(self) -> None:
+        tick = 2090237
+        previous_ratio_state = {
+            "start_tick": tick - 150,
+            "last_tick": tick,
+            "consecutive_ticks": 150,
+            "consecutive_captures": 1,
+        }
+
+        emitted, suppressed, next_state = monitor.evaluate_room_alert(
+            make_owned_room_snapshot("E29N57", tick, worker_count=4),
+            {
+                "baseline_established": True,
+                "owner": "lanyusea",
+                "rule_counts": {monitor.OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND: previous_ratio_state},
+            },
+            now=200,
+            debounce_seconds=300,
+            runtime_room_summary=none_task_runtime_room("E29N57", tick, worker_count=4, none_count=2),
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertNotIn(monitor.OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND, [reason["kind"] for reason in emitted])
+        self.assertEqual(
+            next_state["rule_counts"][monitor.OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND],
+            previous_ratio_state,
+        )
+
+    def test_owned_room_none_task_console_capture_window_requires_fresh_latest_capture(self) -> None:
+        room = "E29N57"
+        ticks = [1630662, 1630800]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_dir = Path(temp_dir)
+            for index, tick in enumerate(ticks, start=1):
+                (runtime_dir / f"runtime-summary-console-20260601T00000{index}Z.log").write_text(
+                    "#runtime-summary "
+                    + json.dumps(
+                        {
+                            "type": "runtime-summary",
+                            "tick": tick,
+                            "rooms": [none_task_runtime_room(room, tick, worker_count=4, none_count=2)],
+                        }
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+
+            warnings: list[str] = []
+            runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                runtime_dir,
+                [monitor.RoomRef(shard="shardX", room=room)],
+                warnings,
+            )
+
+        self.assertEqual(warnings, [])
+        runtime_room = runtime_rooms[f"shardX/{room}"]
+        self.assertEqual(
+            runtime_room[monitor.RUNTIME_SUMMARY_CAPTURE_HISTORY_METADATA_KEY][0]["runtimeSummaryTick"],
+            ticks[-1],
+        )
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            make_owned_room_snapshot(room, ticks[-1] + 25, worker_count=4),
+            {"baseline_established": True, "owner": "lanyusea"},
+            now=200,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_room,
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertNotIn(monitor.OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND, [reason["kind"] for reason in emitted])
+
     def test_owned_room_one_off_cpu_shed_none_task_ratio_stays_silent(self) -> None:
         snapshot = make_owned_room_snapshot("E29N57", 2090237, worker_count=4)
         runtime_room = none_task_runtime_room(

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -246,6 +246,126 @@ def make_owned_worker_room_snapshot(room: str, tick: int) -> monitor.RoomSnapsho
     )
 
 
+def make_owned_room_snapshot(room: str, tick: int, worker_count: int = 4) -> monitor.RoomSnapshot:
+    objects: dict[str, dict[str, object]] = {
+        "spawn1": {
+            "type": "spawn",
+            "my": True,
+            "owner": {"username": "lanyusea"},
+            "x": 17,
+            "y": 24,
+            "hits": 5000,
+            "hitsMax": 5000,
+        },
+        "ctrl": {
+            "type": "controller",
+            "my": True,
+            "owner": {"username": "lanyusea"},
+            "level": 5,
+            "x": 5,
+            "y": 36,
+        },
+        "extension1": {
+            "type": "extension",
+            "my": True,
+            "owner": {"username": "lanyusea"},
+            "x": 18,
+            "y": 24,
+            "hits": 1000,
+            "hitsMax": 1000,
+        },
+    }
+    for index in range(worker_count):
+        objects[f"worker{index}"] = {
+            "type": "creep",
+            "my": True,
+            "owner": {"username": "lanyusea"},
+            "name": f"worker-{room}-{index}",
+            "memory": {"role": "worker"},
+        }
+    return monitor.RoomSnapshot(
+        ref=monitor.RoomRef("shardX", room),
+        terrain="0" * monitor.TERRAIN_CELLS,
+        objects=monitor.normalize_objects(objects),
+        tick=tick,
+        owner="lanyusea",
+        info={"energyAvailable": 1800},
+        expected_owner="lanyusea",
+    )
+
+
+def none_task_runtime_room(
+    room: str,
+    tick: int,
+    *,
+    worker_count: int = 4,
+    none_count: int = 2,
+    idle_reason_counts: dict[str, int] | None = None,
+) -> dict[str, object]:
+    productive_count = max(0, worker_count - none_count)
+    repair_count = min(1, productive_count)
+    upgrade_count = max(0, productive_count - repair_count)
+    reasons = idle_reason_counts or {
+        "controller_upgrade_saturated_standby": 0,
+        "cpu_shed_assignment_skipped": 1 if none_count else 0,
+        "no_task_available": max(0, none_count - 1),
+        "role_body_unavailable": 0,
+        "room_snapshot_missing_creep_memory": 0,
+        "task_assignment_not_observed": 0,
+    }
+    idle_workers = [
+        {
+            "name": f"worker-{room}-idle-{index}",
+            "reason": "cpu_shed_assignment_skipped" if index == 0 else "no_task_available",
+            "carriedEnergy": 100 if index > 0 else 0,
+            "freeCapacity": 0 if index > 0 else 100,
+            "dispatchReason": "no_selected_task_idle",
+            "dispatchTick": tick,
+        }
+        for index in range(none_count)
+    ]
+    return {
+        "roomName": room,
+        "shard": "shardX",
+        monitor.RUNTIME_SUMMARY_TICK_METADATA_KEY: tick,
+        "workerCount": worker_count,
+        "workerAssignmentEvidenceAvailable": True,
+        "workerAssignmentEvidence": {
+            "source": "runtime-summary",
+            "available": True,
+            "tick": tick,
+            "workerCount": worker_count,
+            "assignedTaskCount": productive_count,
+            "productiveAssignmentCount": productive_count,
+            "unassignedWorkerCount": none_count,
+            "idleReasonCounts": reasons,
+            "idleWorkers": idle_workers,
+        },
+        "taskCounts": {
+            "harvest": 0,
+            "pickup": 0,
+            "withdraw": 0,
+            "transfer": 0,
+            "build": 0,
+            "repair": repair_count,
+            "upgrade": upgrade_count,
+            "none": none_count,
+        },
+        "constructionSiteCount": 0,
+        "constructionDeadlockTicks": 0,
+        "resources": {
+            "productiveEnergy": {
+                "workerAssignmentEvidenceAvailable": True,
+                "assignedWorkerCount": productive_count,
+                "constructionSiteCount": 0,
+                "constructionDeadlockTicks": 0,
+                "pendingBuildProgress": 0,
+                "buildBlockedReason": "no_construction_sites",
+            }
+        },
+    }
+
+
 def worker_deadlock_runtime_summary_payload(
     room: str,
     tick: int,
@@ -881,6 +1001,184 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(report["severity"], "none")
         self.assertIsNone(report["priority"])
         self.assertEqual(report["scheduler"]["recommended_output"], "[SILENT]")
+
+    def test_owned_room_none_task_ratio_healthy_room_stays_silent(self) -> None:
+        snapshot = make_owned_room_snapshot("E29N56", 2090237, worker_count=5)
+        runtime_room = none_task_runtime_room(
+            "E29N56",
+            2090237,
+            worker_count=5,
+            none_count=1,
+            idle_reason_counts={
+                "controller_upgrade_saturated_standby": 0,
+                "cpu_shed_assignment_skipped": 0,
+                "no_task_available": 1,
+                "role_body_unavailable": 0,
+                "room_snapshot_missing_creep_memory": 0,
+                "task_assignment_not_observed": 0,
+            },
+        )
+
+        emitted, suppressed, next_state = monitor.evaluate_room_alert(
+            snapshot,
+            {
+                "baseline_established": True,
+                "owner": "lanyusea",
+                "rule_counts": {
+                    monitor.OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND: {
+                        "start_tick": 2090000,
+                        "last_tick": 2090100,
+                        "consecutive_ticks": 100,
+                        "consecutive_captures": 2,
+                    }
+                },
+            },
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_room,
+        )
+
+        self.assertEqual(emitted, [])
+        self.assertEqual(suppressed, [])
+        self.assertEqual(next_state["rule_counts"][monitor.OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND], 0)
+
+    def test_owned_room_sustained_none_task_ratio_alerts_without_room_dead(self) -> None:
+        first_tick = 2090100
+        second_tick = 2090237
+        first_snapshot = make_owned_room_snapshot("E29N57", first_tick, worker_count=4)
+        second_snapshot = make_owned_room_snapshot("E29N57", second_tick, worker_count=4)
+
+        first_emitted, first_suppressed, first_state = monitor.evaluate_room_alert(
+            first_snapshot,
+            {"baseline_established": True, "owner": "lanyusea"},
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=none_task_runtime_room("E29N57", first_tick, worker_count=4, none_count=2),
+        )
+        self.assertEqual(first_emitted, [])
+        self.assertEqual(first_suppressed, [])
+        self.assertEqual(
+            first_state["rule_counts"][monitor.OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND],
+            {
+                "start_tick": first_tick,
+                "last_tick": first_tick,
+                "consecutive_ticks": 0,
+                "consecutive_captures": 1,
+            },
+        )
+
+        second_emitted, second_suppressed, second_state = monitor.evaluate_room_alert(
+            second_snapshot,
+            first_state,
+            now=200,
+            debounce_seconds=300,
+            runtime_room_summary=none_task_runtime_room("E29N57", second_tick, worker_count=4, none_count=2),
+        )
+
+        self.assertEqual(second_suppressed, [])
+        self.assertNotIn("room_dead", [reason["kind"] for reason in second_emitted])
+        reason = next(
+            reason
+            for reason in second_emitted
+            if reason["kind"] == monitor.OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND
+        )
+        self.assertEqual(reason["room"], "shardX/E29N57")
+        self.assertEqual(reason["severity"], "high")
+        self.assertEqual(reason["priority"], "P1")
+        self.assertEqual(reason["workerCount"], 4)
+        self.assertEqual(reason["noneTaskWorkerCount"], 2)
+        self.assertEqual(reason["noneTaskWorkerRatio"], 0.5)
+        self.assertEqual(reason["idleReasonCounts"]["cpu_shed_assignment_skipped"], 1)
+        self.assertEqual(reason["idleReasonCounts"]["no_task_available"], 1)
+        self.assertEqual(reason["start_tick"], first_tick)
+        self.assertEqual(reason["current_tick"], second_tick)
+        self.assertEqual(reason["consecutive_ticks"], second_tick - first_tick)
+        self.assertEqual(reason["consecutiveCaptures"], 2)
+        self.assertEqual(reason["metadata"]["related_issues"], ["#1767", "#1776", "#906"])
+        self.assertIn("next_action", reason)
+        self.assertFalse(reason["owner_ping"])
+        self.assertEqual(
+            second_state["rule_counts"][monitor.OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND]["consecutive_ticks"],
+            second_tick - first_tick,
+        )
+
+        tactical = monitor.build_tactical_response_report(
+            {"ok": True, "mode": "alert", "alert": True, "reasons": [reason], "rooms": ["shardX/E29N57"]}
+        )
+        self.assertTrue(tactical["emergency"])
+        self.assertEqual(tactical["severity"], "high")
+        self.assertEqual(tactical["priority"], "P1")
+        self.assertEqual(tactical["categories"], [monitor.OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND])
+        self.assertEqual(tactical["triggers"][0]["decision"], "codex_hotfix")
+        self.assertEqual(tactical["triggers"][0]["metadata"]["routes_to"][0]["issue"], "#1767")
+
+        health = monitor.evaluate_postdeploy_health_gate(
+            {
+                "ok": True,
+                "mode": "summary",
+                "room_summaries": [
+                    {"room": "shardX/E29N57", "owner": "lanyusea", "owned_creeps": 4, "owned_spawns": 1}
+                ],
+            },
+            {"ok": True, "mode": "alert", "alert": True, "reasons": [reason]},
+        )
+        self.assertFalse(health["ok"])
+        self.assertEqual([item["kind"] for item in health["reasons"]], ["postdeploy_active_alert"])
+        self.assertEqual(health["reasons"][0]["source"]["kind"], monitor.OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND)
+
+    def test_owned_room_one_off_cpu_shed_none_task_ratio_stays_silent(self) -> None:
+        snapshot = make_owned_room_snapshot("E29N57", 2090237, worker_count=4)
+        runtime_room = none_task_runtime_room(
+            "E29N57",
+            2090237,
+            worker_count=4,
+            none_count=2,
+            idle_reason_counts={
+                "controller_upgrade_saturated_standby": 0,
+                "cpu_shed_assignment_skipped": 2,
+                "no_task_available": 0,
+                "role_body_unavailable": 0,
+                "room_snapshot_missing_creep_memory": 0,
+                "task_assignment_not_observed": 0,
+            },
+        )
+
+        emitted, suppressed, next_state = monitor.evaluate_room_alert(
+            snapshot,
+            {"baseline_established": True, "owner": "lanyusea"},
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_room,
+        )
+
+        self.assertEqual(emitted, [])
+        self.assertEqual(suppressed, [])
+        self.assertEqual(
+            next_state["rule_counts"][monitor.OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND]["consecutive_captures"],
+            1,
+        )
+
+    def test_none_task_ratio_ignored_when_room_is_not_owned(self) -> None:
+        snapshot = monitor.RoomSnapshot(
+            ref=monitor.RoomRef("shardX", "E29N57"),
+            terrain="0" * monitor.TERRAIN_CELLS,
+            objects=monitor.normalize_objects({}),
+            tick=2090237,
+            owner=None,
+            info={},
+        )
+
+        emitted, suppressed, next_state = monitor.evaluate_room_alert(
+            snapshot,
+            {},
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=none_task_runtime_room("E29N57", 2090237, worker_count=4, none_count=4),
+        )
+
+        self.assertEqual(emitted, [])
+        self.assertEqual(suppressed, [])
+        self.assertEqual(next_state["rule_counts"][monitor.OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND], 0)
 
     def test_energy_buffer_unhealthy_alerts_on_second_consecutive_capture(self) -> None:
         snapshot = make_snapshot(


### PR DESCRIPTION
## Summary
- Adds a sustained owned-room none-task worker ratio runtime-alert rule.
- Routes high sustained none-task ratios to #1767/#1776/#906 metadata without room-dead/owner-action misclassification.
- Adds tactical-response/postdeploy-health regression coverage for sustained alerts, one-off CPU shedding, and non-owned room silence.

Related to #1767.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps-runtime-monitor.py`
- `python3 scripts/test_screeps_runtime_monitor_tactical_response.py` (118 tests OK)

## Universal task Done gate
- [x] Task type: Runtime monitor / alerting code slice.
- [x] Expected observable outcome / named deliverable: sustained owned-room none-task worker ratio alert appears in monitor alert/tactical/health-gate output with room/count/ratio/tick metadata.
- [x] Non-goals / accepted substitutes: no production bot behavior change, no MMO deploy action from this PR, no owner decision required.
- [x] Verification evidence required before Done: diff-check, Python compile, and tactical-response monitor tests passed on the PR branch.
- [x] Project Evidence / Next action / Blocked by: #1767 Project item updated by controller with commit/PR evidence and next PR-gate action.
- [x] Post-merge/deploy/runtime proof: runtime-alert cron will provide post-merge proof when a sustained none-task ratio recurs; this PR only adds detection logic.
- [x] Named deliverable proof: commit dd11a6cf65bc40db0777e6f2a87ee240f14d341d changes `scripts/screeps-runtime-monitor.py` and `scripts/test_screeps_runtime_monitor_tactical_response.py`.