### PR TITLE
worker: keep secondary rooms productive after construction

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -27759,7 +27759,10 @@ function selectWorkerTask(creep) {
   clearWorkerTaskSelectionTelemetry(creep);
   const cpuBudget = getRuntimeCpuBudget();
   if (shouldShedNonessentialCpuWork(cpuBudget) && !hasActiveTerritoryControlAssignment(creep)) {
-    const criticalTask = withWorkerTaskSelectionTelemetrySuppressed(true, () => selectCriticalCpuWorkerTask(creep));
+    const criticalTask = withWorkerTaskSelectionTelemetrySuppressed(
+      true,
+      () => selectCriticalCpuWorkerTask(creep, cpuBudget)
+    );
     if (!criticalTask && shouldRunConstructionCpuWork(cpuBudget)) {
       const constructionTask = withWorkerTaskSelectionTelemetrySuppressed(
         true,
@@ -27785,7 +27788,7 @@ function hasActiveTerritoryControlAssignment(creep) {
   const task = (_a2 = creep.memory) == null ? void 0 : _a2.task;
   return (task == null ? void 0 : task.type) === "claim" || (task == null ? void 0 : task.type) === "reserve";
 }
-function selectCriticalCpuWorkerTask(creep) {
+function selectCriticalCpuWorkerTask(creep, cpuBudget) {
   const carriedEnergy = getUsedEnergy2(creep);
   if (carriedEnergy <= 0) {
     return selectCriticalCpuEnergyAcquisitionTask(creep);
@@ -27862,7 +27865,22 @@ function selectCriticalCpuWorkerTask(creep) {
       targetId: criticalRepairTarget.id
     });
   }
+  const loadedControllerProgressTask = selectNonCriticalCpuLoadedControllerProgressTask(
+    creep,
+    cpuBudget,
+    constructionSites
+  );
+  if (loadedControllerProgressTask) {
+    return applyMinimumUsefulLoadPolicy(creep, loadedControllerProgressTask);
+  }
   return null;
+}
+function selectNonCriticalCpuLoadedControllerProgressTask(creep, cpuBudget, constructionSites) {
+  if (cpuBudget.critical || getUsedEnergy2(creep) <= 0 || constructionSites.length > 0 || hasVisibleHostilePresence3(creep.room) || !hasFullRoomEnergyForControllerProgress(creep.room)) {
+    return null;
+  }
+  const controller = creep.room.controller;
+  return (controller == null ? void 0 : controller.my) === true && canUpgradeController(controller) ? { type: "upgrade", targetId: controller.id } : null;
 }
 function selectConstructionRecoveryCpuWorkerTask(creep) {
   var _a2;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -85,7 +85,8 @@ import { selectWorkerTaskWithBcFallback } from '../rl/workerTaskPolicy';
 import {
   getRuntimeCpuBudget,
   shouldRunConstructionCpuWork,
-  shouldShedNonessentialCpuWork
+  shouldShedNonessentialCpuWork,
+  type RuntimeCpuBudget
 } from '../runtime/cpuBudget';
 import { selectSeasonScoreCollectionTask } from '../season/scoreCollection';
 
@@ -327,7 +328,9 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   clearWorkerTaskSelectionTelemetry(creep);
   const cpuBudget = getRuntimeCpuBudget();
   if (shouldShedNonessentialCpuWork(cpuBudget) && !hasActiveTerritoryControlAssignment(creep)) {
-    const criticalTask = withWorkerTaskSelectionTelemetrySuppressed(true, () => selectCriticalCpuWorkerTask(creep));
+    const criticalTask = withWorkerTaskSelectionTelemetrySuppressed(true, () =>
+      selectCriticalCpuWorkerTask(creep, cpuBudget)
+    );
     if (!criticalTask && shouldRunConstructionCpuWork(cpuBudget)) {
       const constructionTask = withWorkerTaskSelectionTelemetrySuppressed(true, () =>
         selectConstructionRecoveryCpuWorkerTask(creep)
@@ -356,7 +359,7 @@ function hasActiveTerritoryControlAssignment(creep: Creep): boolean {
   return task?.type === 'claim' || task?.type === 'reserve';
 }
 
-function selectCriticalCpuWorkerTask(creep: Creep): CreepTaskMemory | null {
+function selectCriticalCpuWorkerTask(creep: Creep, cpuBudget: RuntimeCpuBudget): CreepTaskMemory | null {
   const carriedEnergy = getUsedEnergy(creep);
   if (carriedEnergy <= 0) {
     return selectCriticalCpuEnergyAcquisitionTask(creep);
@@ -454,7 +457,37 @@ function selectCriticalCpuWorkerTask(creep: Creep): CreepTaskMemory | null {
     });
   }
 
+  const loadedControllerProgressTask = selectNonCriticalCpuLoadedControllerProgressTask(
+    creep,
+    cpuBudget,
+    constructionSites
+  );
+  if (loadedControllerProgressTask) {
+    return applyMinimumUsefulLoadPolicy(creep, loadedControllerProgressTask);
+  }
+
   return null;
+}
+
+function selectNonCriticalCpuLoadedControllerProgressTask(
+  creep: Creep,
+  cpuBudget: RuntimeCpuBudget,
+  constructionSites: ConstructionSite[]
+): Extract<CreepTaskMemory, { type: 'upgrade' }> | null {
+  if (
+    cpuBudget.critical ||
+    getUsedEnergy(creep) <= 0 ||
+    constructionSites.length > 0 ||
+    hasVisibleHostilePresence(creep.room) ||
+    !hasFullRoomEnergyForControllerProgress(creep.room)
+  ) {
+    return null;
+  }
+
+  const controller = creep.room.controller;
+  return controller?.my === true && canUpgradeController(controller)
+    ? { type: 'upgrade', targetId: controller.id }
+    : null;
 }
 
 function selectConstructionRecoveryCpuWorkerTask(creep: Creep): CreepTaskMemory | null {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -320,6 +320,29 @@ function setCpuBucket(bucket: number): void {
   };
 }
 
+function setCpuSample({
+  bucket = 10_000,
+  limit = 70,
+  tickLimit = 500,
+  used = 0
+}: {
+  bucket?: number;
+  limit?: number;
+  tickLimit?: number;
+  used?: number;
+} = {}): void {
+  const globalScope = globalThis as unknown as { Game?: Partial<Game> };
+  globalScope.Game = {
+    ...(globalScope.Game ?? {}),
+    cpu: {
+      getUsed: jest.fn().mockReturnValue(used),
+      limit,
+      bucket,
+      tickLimit
+    } as unknown as CPU
+  };
+}
+
 function makePreHarvestSource(
   id: string,
   x: number,
@@ -15673,6 +15696,137 @@ describe('selectWorkerTask', () => {
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
     expect(creep.memory.workerTaskSelectionStandby).toBeUndefined();
+  });
+
+  it('keeps a full-buffer secondary-room loaded worker upgrading during non-critical CPU shedding', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      progress: 530_739,
+      progressTotal: 1_215_000,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 70_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N57',
+      controller,
+      energyAvailable: 1_800,
+      energyCapacityAvailable: 1_800
+    });
+    const repairWorker = makeLoadedWorker(room, { type: 'repair', targetId: 'road1' as Id<Structure> });
+    const upgradeWorker = makeLoadedWorker(room, {
+      type: 'upgrade',
+      targetId: 'controller1' as Id<StructureController>
+    });
+    const creep = {
+      name: 'worker-E29N57-2090163',
+      memory: { role: 'worker', colony: 'E29N57' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(100),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({
+      RepairWorker: repairWorker,
+      UpgradeWorker: upgradeWorker,
+      'worker-E29N57-2090163': creep
+    });
+    setCpuSample({ used: 95, limit: 70, bucket: 1_841 });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('keeps healthy full-buffer secondary-room loaded workers upgrading after construction clears', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 70_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N57',
+      controller,
+      energyAvailable: 1_800,
+      energyCapacityAvailable: 1_800
+    });
+    const creep = {
+      name: 'HealthyLoadedWorker',
+      memory: { role: 'worker', colony: 'E29N57' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(100),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({
+      Upgrader: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }),
+      HealthyLoadedWorker: creep
+    });
+    setCpuSample();
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('does not spend full-buffer surplus workers on post-construction upgrades during critical CPU bucket', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 70_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N57',
+      controller,
+      energyAvailable: 1_800,
+      energyCapacityAvailable: 1_800
+    });
+    const creep = {
+      name: 'CriticalBucketLoadedWorker',
+      memory: { role: 'worker', colony: 'E29N57' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(100),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({
+      Upgrader: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }),
+      CriticalBucketLoadedWorker: creep
+    });
+    setCpuSample({ used: 95, limit: 70, bucket: 50 });
+
+    expect(selectWorkerTask(creep)).toBeNull();
+  });
+
+  it('keeps spawn-floor refill before post-construction upgrades during non-critical CPU shedding', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 70_000
+    } as StructureController;
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 100);
+    const room = makeWorkerTaskRoom({
+      name: 'E29N57',
+      controller,
+      energyAvailable: MINIMUM_WORKER_SPAWN_ENERGY - 50,
+      energyCapacityAvailable: 1_800,
+      myStructures: [spawn as AnyOwnedStructure]
+    });
+    const creep = {
+      name: 'SpawnFloorWorker',
+      memory: { role: 'worker', colony: 'E29N57' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(100),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ SpawnFloorWorker: creep });
+    setCpuSample({ used: 95, limit: 70, bucket: 1_841 });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
   });
 
   it('withdraws stored energy for post-construction RCL2 controller progress when one worker is already upgrading', () => {


### PR DESCRIPTION
## Summary
- Keeps loaded secondary-room workers productive under degraded but non-critical CPU when construction is clear and controller progress is safe.
- Preserves critical CPU suppression, hostile/construction blockers, and spawn-floor refill precedence.
- Adds focused worker-task tests and regenerates the Screeps bundle.

Related to #1776.

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` (105 suites / 2414 tests passed)
- `npm run build`
- `npm test -- --runInBand workerTasks.test.ts` passed in the Codex lane before controller verification

## Universal task Done gate
- [x] Task type: Gameplay behavior / worker-task code slice.
- [x] Expected observable outcome / named deliverable: full-energy secondary-room workers choose safe controller progress instead of `none` during non-critical CPU shedding after construction clears.
- [x] Non-goals / accepted substitutes: no owner action, no direct MMO writes, no deploy from this PR, and no suppression of critical CPU safeguards.
- [x] Verification evidence required before Done: controller diff-check, typecheck, full Jest, and build passed on the PR branch.
- [x] Project Evidence / Next action / Blocked by: #1776 Project item updated by controller with commit/PR evidence and next PR-gate action.
- [x] Post-merge/deploy/runtime proof: runtime-summary acceptance target is E29N57 with zero full-energy `no_task_available` workers under degraded but non-critical CPU; this PR provides source/tests/bundle for that target.
- [x] Named deliverable proof: commit 50d2a48b6836b3a9c31c90c10b7271ba3cdc9337 changes `prod/src/tasks/workerTasks.ts`, `prod/test/workerTasks.test.ts`, and `prod/dist/main.js`.