### PR TITLE
runtime-monitor: add construction acceptance health gate

### DIFF
--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -4964,6 +4964,11 @@ def runtime_summary_room_has_monitor_alert_fields(room: dict[str, Any], payload:
         runtime_summary_room_has_worker_idle_fields(room)
         or runtime_summary_room_has_cpu_fields(room)
         or runtime_summary_payload_has_cpu_fields(payload)
+        or runtime_construction_site_count(room) is not None
+        or runtime_pending_build_progress(room) is not None
+        or runtime_build_carried_energy(room) is not None
+        or runtime_build_blocked_reason(room) is not None
+        or bool(as_dict(room.get("constructionActivity")))
         or runtime_productive_assignment_count(room) is not None
         or runtime_worker_assignment_blocked_detail(room) is not None
         or bool(runtime_worker_assignment_blocked_workers(room))
@@ -7087,6 +7092,202 @@ def enrich_room_summaries_from_runtime_artifact(room_summaries: list[Any], artif
                 room["energyBufferHealth"] = buffer_health
         if runtime_summary_room_has_cpu_fields(runtime_room) or as_dict(runtime_room.get(RUNTIME_SUMMARY_CPU_METADATA_KEY)):
             room.update(runtime_summary_room_with_cpu_fields(room, runtime_room))
+        if not as_dict(room.get("taskCounts")):
+            task_counts = as_dict(runtime_room.get("taskCounts"))
+            if task_counts:
+                room["taskCounts"] = dict(task_counts)
+        build_count = runtime_task_count(runtime_room, "build")
+        if number_value(room.get("build")) is None and build_count is not None:
+            room["build"] = build_count
+        construction_site_count = runtime_construction_site_count(runtime_room)
+        if number_value(room.get("constructionSiteCount")) is None and construction_site_count is not None:
+            room["constructionSiteCount"] = construction_site_count
+        pending_build_progress = runtime_pending_build_progress(runtime_room)
+        if number_value(room.get("pendingBuildProgress")) is None and pending_build_progress is not None:
+            room["pendingBuildProgress"] = pending_build_progress
+        build_carried_energy = runtime_build_carried_energy(runtime_room)
+        if number_value(room.get("buildCarriedEnergy")) is None and build_carried_energy is not None:
+            room["buildCarriedEnergy"] = build_carried_energy
+        build_blocked_reason = runtime_build_blocked_reason(runtime_room)
+        if not isinstance(room.get("buildBlockedReason"), str) and build_blocked_reason is not None:
+            room["buildBlockedReason"] = build_blocked_reason
+        if not as_dict(room.get("constructionActivity")):
+            construction_activity = as_dict(runtime_room.get("constructionActivity")) or as_dict(
+                nested_value(runtime_room, "resources", "productiveEnergy", "constructionActivity")
+            )
+            if construction_activity:
+                room["constructionActivity"] = dict(construction_activity)
+
+
+def postdeploy_construction_room_name(room: dict[str, Any]) -> str:
+    for key in ("room", "roomName", "name"):
+        value = room.get(key)
+        if isinstance(value, str) and value:
+            if key == "name" and isinstance(room.get("shard"), str) and room.get("shard"):
+                return f"{room['shard']}/{value}"
+            return value
+    return "unknown"
+
+
+def postdeploy_construction_build_progress(room: dict[str, Any]) -> int | float | None:
+    return first_number_value(
+        room,
+        ("buildProgress",),
+        ("constructionActivity", "buildProgress"),
+        ("resources", "productiveEnergy", "buildProgress"),
+        ("resources", "productiveEnergy", "constructionActivity", "buildProgress"),
+        ("construction", "buildProgress"),
+    )
+
+
+def postdeploy_construction_build_task_count(room: dict[str, Any]) -> int | float | None:
+    build_count = runtime_task_count(room, "build")
+    if build_count is not None:
+        return build_count
+    return number_value(room.get("build"))
+
+
+def postdeploy_construction_acceptance_room(room: dict[str, Any]) -> dict[str, Any]:
+    room_name = postdeploy_construction_room_name(room)
+    construction_site_count = runtime_construction_site_count(room)
+    pending_build_progress = runtime_pending_build_progress(room)
+    build_carried_energy = runtime_build_carried_energy(room)
+    build_progress = postdeploy_construction_build_progress(room)
+    build_count = postdeploy_construction_build_task_count(room)
+    build_blocked_reason = runtime_build_blocked_reason(room)
+
+    result: dict[str, Any] = {"room": room_name}
+    for key, value in (
+        ("constructionSiteCount", construction_site_count),
+        ("pendingBuildProgress", pending_build_progress),
+        ("buildCarriedEnergy", build_carried_energy),
+        ("buildProgress", build_progress),
+        ("build", build_count),
+    ):
+        if value is not None:
+            result[key] = value
+    if build_blocked_reason is not None:
+        result["buildBlockedReason"] = build_blocked_reason
+
+    if construction_site_count is None or pending_build_progress is None:
+        missing = [
+            key
+            for key, value in (
+                ("constructionSiteCount", construction_site_count),
+                ("pendingBuildProgress", pending_build_progress),
+            )
+            if value is None
+        ]
+        return {
+            **result,
+            "ok": False,
+            "status": "pending",
+            "reason": "missing_construction_telemetry",
+            "missing": missing,
+            "message": f"{room_name}: construction acceptance pending; missing {', '.join(missing)} telemetry",
+        }
+
+    if construction_site_count <= 0 and pending_build_progress <= 0:
+        return {
+            **result,
+            "ok": True,
+            "status": "pass",
+            "reason": "no_construction_backlog",
+            "message": f"{room_name}: no construction backlog visible",
+        }
+
+    if build_carried_energy is not None and build_carried_energy > 0:
+        return {
+            **result,
+            "ok": True,
+            "status": "pass",
+            "reason": "build_energy_carried",
+            "message": f"{room_name}: construction acceptance passed with buildCarriedEnergy > 0",
+        }
+
+    if build_progress is not None and build_progress > 0:
+        return {
+            **result,
+            "ok": True,
+            "status": "pass",
+            "reason": "build_progress_observed",
+            "message": f"{room_name}: construction acceptance passed with build progress",
+        }
+
+    if build_count is not None and build_count > 0:
+        return {
+            **result,
+            "ok": True,
+            "status": "pass",
+            "reason": "build_task_visible",
+            "message": f"{room_name}: construction acceptance passed with a visible build task",
+        }
+
+    if build_carried_energy is None and build_progress is None and build_count is None:
+        return {
+            **result,
+            "ok": False,
+            "status": "pending",
+            "reason": "missing_build_execution_telemetry",
+            "message": (
+                f"{room_name}: construction backlog is visible, but buildCarriedEnergy/buildProgress/build task "
+                "telemetry is missing"
+            ),
+        }
+
+    blocked_reason = build_blocked_reason or "no_build_execution"
+    return {
+        **result,
+        "ok": False,
+        "status": "blocked",
+        "reason": blocked_reason,
+        "message": (
+            f"{room_name}: construction backlog is visible without build progress, carried build energy, "
+            "or a visible build task"
+        ),
+    }
+
+
+def postdeploy_construction_acceptance_status(room_results: list[dict[str, Any]]) -> str:
+    if any(result.get("status") == "blocked" for result in room_results):
+        return "blocked"
+    if any(result.get("status") == "pending" for result in room_results):
+        return "pending"
+    return "pass"
+
+
+def evaluate_postdeploy_construction_acceptance(room_summaries: Any) -> dict[str, Any]:
+    if not isinstance(room_summaries, list) or not room_summaries:
+        return {
+            "ok": False,
+            "status": "pending",
+            "rooms": [],
+            "message": "construction acceptance pending; no room_summaries telemetry",
+        }
+
+    room_results = [
+        postdeploy_construction_acceptance_room(room)
+        for room in room_summaries
+        if isinstance(room, dict)
+    ]
+    if not room_results:
+        return {
+            "ok": False,
+            "status": "pending",
+            "rooms": [],
+            "message": "construction acceptance pending; room_summaries contained no room objects",
+        }
+
+    status = postdeploy_construction_acceptance_status(room_results)
+    ok = status == "pass"
+    return {
+        "ok": ok,
+        "status": status,
+        "rooms": room_results,
+        "pass_count": sum(1 for result in room_results if result.get("status") == "pass"),
+        "pending_count": sum(1 for result in room_results if result.get("status") == "pending"),
+        "blocked_count": sum(1 for result in room_results if result.get("status") == "blocked"),
+    }
 
 
 def evaluate_postdeploy_health_gate(summary_payload: dict[str, Any], alert_payload: dict[str, Any]) -> dict[str, Any]:
@@ -7162,7 +7363,8 @@ def evaluate_postdeploy_health_gate(summary_payload: dict[str, Any], alert_paylo
                         "message": f"{room_name}: no creeps, no spawn, and <=1 visible structure after deploy",
                     }
                 )
-    return {"ok": not reasons, "reasons": reasons}
+    construction_acceptance = evaluate_postdeploy_construction_acceptance(room_summaries)
+    return {"ok": not reasons, "reasons": reasons, "construction_acceptance": construction_acceptance}
 
 
 def command_health_gate(args: argparse.Namespace) -> int:

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -7214,24 +7214,15 @@ def postdeploy_construction_acceptance_room(room: dict[str, Any]) -> dict[str, A
             "message": f"{room_name}: construction acceptance passed with build progress",
         }
 
-    if build_count is not None and build_count > 0:
-        return {
-            **result,
-            "ok": True,
-            "status": "pass",
-            "reason": "build_task_visible",
-            "message": f"{room_name}: construction acceptance passed with a visible build task",
-        }
-
-    if build_carried_energy is None and build_progress is None and build_count is None:
+    if build_carried_energy is None and build_progress is None:
         return {
             **result,
             "ok": False,
             "status": "pending",
             "reason": "missing_build_execution_telemetry",
             "message": (
-                f"{room_name}: construction backlog is visible, but buildCarriedEnergy/buildProgress/build task "
-                "telemetry is missing"
+                f"{room_name}: construction backlog is visible, but buildCarriedEnergy/buildProgress telemetry "
+                "is missing"
             ),
         }
 
@@ -7242,8 +7233,7 @@ def postdeploy_construction_acceptance_room(room: dict[str, Any]) -> dict[str, A
         "status": "blocked",
         "reason": blocked_reason,
         "message": (
-            f"{room_name}: construction backlog is visible without build progress, carried build energy, "
-            "or a visible build task"
+            f"{room_name}: construction backlog is visible without build progress or carried build energy"
         ),
     }
 
@@ -7364,7 +7354,11 @@ def evaluate_postdeploy_health_gate(summary_payload: dict[str, Any], alert_paylo
                     }
                 )
     construction_acceptance = evaluate_postdeploy_construction_acceptance(room_summaries)
-    return {"ok": not reasons, "reasons": reasons, "construction_acceptance": construction_acceptance}
+    return {
+        "ok": not reasons and construction_acceptance.get("ok") is True,
+        "reasons": reasons,
+        "construction_acceptance": construction_acceptance,
+    }
 
 
 def command_health_gate(args: argparse.Namespace) -> int:

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -972,7 +972,7 @@ class PostdeployConstructionAcceptanceTest(unittest.TestCase):
             }
         )
 
-        self.assertTrue(health["ok"])
+        self.assertFalse(health["ok"])
         acceptance = health["construction_acceptance"]
         self.assertFalse(acceptance["ok"])
         self.assertEqual(acceptance["status"], "blocked")
@@ -983,7 +983,6 @@ class PostdeployConstructionAcceptanceTest(unittest.TestCase):
         cases = (
             ({"buildCarriedEnergy": 25, "taskCounts": {"build": 0}}, "build_energy_carried"),
             ({"buildCarriedEnergy": 0, "constructionActivity": {"buildProgress": 5}}, "build_progress_observed"),
-            ({"buildCarriedEnergy": 0, "taskCounts": {"build": 1}}, "build_task_visible"),
         )
 
         for evidence, expected_reason in cases:
@@ -996,10 +995,38 @@ class PostdeployConstructionAcceptanceTest(unittest.TestCase):
                     }
                 )
 
+                self.assertTrue(health["ok"])
                 acceptance = health["construction_acceptance"]
                 self.assertTrue(acceptance["ok"])
                 self.assertEqual(acceptance["status"], "pass")
                 self.assertEqual(acceptance["rooms"][0]["reason"], expected_reason)
+
+    def test_construction_acceptance_does_not_pass_on_build_assignment_alone(self) -> None:
+        cases = (
+            (
+                {"buildCarriedEnergy": 0, "constructionActivity": {"buildProgress": 0}, "taskCounts": {"build": 1}},
+                "blocked",
+                "no_build_execution",
+            ),
+            ({"taskCounts": {"build": 1}}, "pending", "missing_build_execution_telemetry"),
+        )
+
+        for evidence, expected_status, expected_reason in cases:
+            with self.subTest(expected_status=expected_status, expected_reason=expected_reason):
+                health = self.health_gate_for_room(
+                    {
+                        "constructionSiteCount": 1,
+                        "pendingBuildProgress": 300,
+                        **evidence,
+                    }
+                )
+
+                self.assertFalse(health["ok"])
+                acceptance = health["construction_acceptance"]
+                self.assertFalse(acceptance["ok"])
+                self.assertEqual(acceptance["status"], expected_status)
+                self.assertEqual(acceptance["rooms"][0]["reason"], expected_reason)
+                self.assertEqual(acceptance["rooms"][0]["build"], 1)
 
     def test_construction_acceptance_passes_when_no_backlog_is_visible(self) -> None:
         health = self.health_gate_for_room(
@@ -1011,6 +1038,7 @@ class PostdeployConstructionAcceptanceTest(unittest.TestCase):
             }
         )
 
+        self.assertTrue(health["ok"])
         acceptance = health["construction_acceptance"]
         self.assertTrue(acceptance["ok"])
         self.assertEqual(acceptance["status"], "pass")
@@ -1019,7 +1047,7 @@ class PostdeployConstructionAcceptanceTest(unittest.TestCase):
     def test_construction_acceptance_marks_missing_telemetry_pending_not_pass(self) -> None:
         health = self.health_gate_for_room({})
 
-        self.assertTrue(health["ok"])
+        self.assertFalse(health["ok"])
         acceptance = health["construction_acceptance"]
         self.assertFalse(acceptance["ok"])
         self.assertEqual(acceptance["status"], "pending")
@@ -1068,9 +1096,48 @@ class PostdeployConstructionAcceptanceTest(unittest.TestCase):
             )
 
         acceptance = health["construction_acceptance"]
+        self.assertTrue(health["ok"])
         self.assertTrue(acceptance["ok"])
         self.assertEqual(acceptance["status"], "pass")
         self.assertEqual(acceptance["rooms"][0]["reason"], "no_construction_backlog")
+
+    def test_health_gate_command_fails_when_construction_acceptance_is_blocked(self) -> None:
+        summary_payload = {
+            "ok": True,
+            "mode": "summary",
+            "room_summaries": [
+                {
+                    "room": "shardX/E26S49",
+                    "owner": "owner",
+                    "owned_creeps": 2,
+                    "owned_spawns": 1,
+                    "constructionSiteCount": 1,
+                    "pendingBuildProgress": 300,
+                    "buildCarriedEnergy": 0,
+                    "constructionActivity": {"buildProgress": 0},
+                    "taskCounts": {"build": 1},
+                }
+            ],
+        }
+        alert_payload = {"ok": True, "mode": "alert", "alert": False, "reasons": []}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            summary_path = Path(temp_dir) / "summary.json"
+            alert_path = Path(temp_dir) / "alert.json"
+            summary_path.write_text(json.dumps(summary_payload), encoding="utf-8")
+            alert_path.write_text(json.dumps(alert_payload), encoding="utf-8")
+
+            args = types.SimpleNamespace(summary=str(summary_path), alert=str(alert_path))
+            with mock.patch("sys.stdout", new_callable=io.StringIO) as stdout:
+                rc = monitor.command_health_gate(args)
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(rc, 1)
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["reasons"], [])
+        self.assertFalse(payload["construction_acceptance"]["ok"])
+        self.assertEqual(payload["construction_acceptance"]["status"], "blocked")
+        self.assertEqual(payload["construction_acceptance"]["rooms"][0]["reason"], "no_build_execution")
 
 
 class TacticalResponseBridgeTest(unittest.TestCase):
@@ -2345,6 +2412,8 @@ class TacticalResponseBridgeTest(unittest.TestCase):
                 "spawns": 1,
                 "owner": "owner",
                 "cpuBucket": 9000,
+                "constructionSiteCount": 0,
+                "pendingBuildProgress": 0,
             },
             {
                 "room": "shardX/E26S49",
@@ -2353,6 +2422,8 @@ class TacticalResponseBridgeTest(unittest.TestCase):
                 "creeps": 1,
                 "spawns": 1,
                 "owner": "owner",
+                "constructionSiteCount": 0,
+                "pendingBuildProgress": 0,
             },
         ):
             with self.subTest(room_summary=room_summary):

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -942,6 +942,137 @@ class AlertCommandFailurePayloadTest(unittest.TestCase):
         self.assertNotIn("abcdef123456", payload["error"])
 
 
+class PostdeployConstructionAcceptanceTest(unittest.TestCase):
+    def health_gate_for_room(self, room: dict[str, object]) -> dict[str, object]:
+        return monitor.evaluate_postdeploy_health_gate(
+            {
+                "ok": True,
+                "mode": "summary",
+                "room_summaries": [
+                    {
+                        "room": "shardX/E26S49",
+                        "owner": "owner",
+                        "owned_creeps": 2,
+                        "owned_spawns": 1,
+                        **room,
+                    }
+                ],
+            },
+            {"ok": True, "mode": "alert", "alert": False, "reasons": []},
+        )
+
+    def test_construction_acceptance_blocks_backlog_without_build_execution(self) -> None:
+        health = self.health_gate_for_room(
+            {
+                "constructionSiteCount": 2,
+                "pendingBuildProgress": 700,
+                "buildCarriedEnergy": 0,
+                "taskCounts": {"build": 0, "upgrade": 1},
+                "buildBlockedReason": "worker_assignment_gap",
+            }
+        )
+
+        self.assertTrue(health["ok"])
+        acceptance = health["construction_acceptance"]
+        self.assertFalse(acceptance["ok"])
+        self.assertEqual(acceptance["status"], "blocked")
+        self.assertEqual(acceptance["blocked_count"], 1)
+        self.assertEqual(acceptance["rooms"][0]["reason"], "worker_assignment_gap")
+
+    def test_construction_acceptance_passes_with_build_execution_evidence(self) -> None:
+        cases = (
+            ({"buildCarriedEnergy": 25, "taskCounts": {"build": 0}}, "build_energy_carried"),
+            ({"buildCarriedEnergy": 0, "constructionActivity": {"buildProgress": 5}}, "build_progress_observed"),
+            ({"buildCarriedEnergy": 0, "taskCounts": {"build": 1}}, "build_task_visible"),
+        )
+
+        for evidence, expected_reason in cases:
+            with self.subTest(expected_reason=expected_reason):
+                health = self.health_gate_for_room(
+                    {
+                        "constructionSiteCount": 1,
+                        "pendingBuildProgress": 300,
+                        **evidence,
+                    }
+                )
+
+                acceptance = health["construction_acceptance"]
+                self.assertTrue(acceptance["ok"])
+                self.assertEqual(acceptance["status"], "pass")
+                self.assertEqual(acceptance["rooms"][0]["reason"], expected_reason)
+
+    def test_construction_acceptance_passes_when_no_backlog_is_visible(self) -> None:
+        health = self.health_gate_for_room(
+            {
+                "constructionSiteCount": 0,
+                "pendingBuildProgress": 0,
+                "buildCarriedEnergy": 0,
+                "buildBlockedReason": "no_construction_sites",
+            }
+        )
+
+        acceptance = health["construction_acceptance"]
+        self.assertTrue(acceptance["ok"])
+        self.assertEqual(acceptance["status"], "pass")
+        self.assertEqual(acceptance["rooms"][0]["reason"], "no_construction_backlog")
+
+    def test_construction_acceptance_marks_missing_telemetry_pending_not_pass(self) -> None:
+        health = self.health_gate_for_room({})
+
+        self.assertTrue(health["ok"])
+        acceptance = health["construction_acceptance"]
+        self.assertFalse(acceptance["ok"])
+        self.assertEqual(acceptance["status"], "pending")
+        self.assertEqual(acceptance["pending_count"], 1)
+        self.assertEqual(
+            acceptance["rooms"][0]["missing"],
+            ["constructionSiteCount", "pendingBuildProgress"],
+        )
+
+    def test_construction_acceptance_uses_runtime_summary_artifact_fields(self) -> None:
+        payload = {
+            "type": "runtime-summary",
+            "tick": 1200,
+            "rooms": [
+                {
+                    "roomName": "E26S49",
+                    "shard": "shardX",
+                    "constructionSiteCount": 0,
+                    "pendingBuildProgress": 0,
+                    "buildCarriedEnergy": 0,
+                    "buildBlockedReason": "no_construction_sites",
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact = Path(temp_dir) / "runtime-summary-monitor-20260612T000000Z.log"
+            artifact.write_text(monitor.RUNTIME_SUMMARY_PREFIX + json.dumps(payload) + "\n", encoding="utf-8")
+
+            health = monitor.evaluate_postdeploy_health_gate(
+                {
+                    "ok": True,
+                    "mode": "summary",
+                    "runtime_summary_artifact": str(artifact),
+                    "room_summaries": [
+                        {
+                            "room": "shardX/E26S49",
+                            "name": "E26S49",
+                            "owner": "owner",
+                            "owned_creeps": 2,
+                            "owned_spawns": 1,
+                        }
+                    ],
+                },
+                {"ok": True, "mode": "alert", "alert": False, "reasons": []},
+            )
+
+        acceptance = health["construction_acceptance"]
+        self.assertTrue(acceptance["ok"])
+        self.assertEqual(acceptance["status"], "pass")
+        self.assertEqual(acceptance["rooms"][0]["reason"], "no_construction_backlog")
+
+
 class TacticalResponseBridgeTest(unittest.TestCase):
     def test_no_alert_fixture_is_machine_readable_silent(self) -> None:
         report = monitor.build_tactical_response_report(NO_ALERT_FIXTURE)


### PR DESCRIPTION
## Summary
- Adds a construction-specific acceptance result to `scripts/screeps-runtime-monitor.py` postdeploy health-gate output.
- Classifies each room with visible construction backlog using `constructionSiteCount`, `pendingBuildProgress`, `buildCarriedEnergy`, build progress, and `taskCounts.build`, while treating missing telemetry as an explicit non-pass state.
- Enriches room summaries from persisted `runtime_summary_artifact` payloads so the health gate can use durable construction fields when the top-level summary omits them.
- Adds deterministic unit coverage for backlog-without-build-execution, build-energy/progress/task pass paths, no-backlog success, missing telemetry, and persisted artifact enrichment.

Fixes #1822.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py`
- `python3 -m unittest scripts.test_screeps_runtime_monitor_tactical_response -v` (125 tests OK)

## Issue closure gate
- [x] #1822: postdeploy health-gate construction acceptance is implemented in `scripts/screeps-runtime-monitor.py`, covered by deterministic tests, and aligned with the existing `postConstructionFixVerification` runbook in `docs/ops/official-mmo-deploy.md` lines 153-196.

## Universal task Done gate
- [x] Task type: Runtime monitor / postdeploy health-gate code change.
- [x] Expected observable outcome / named deliverable: `health-gate` JSON now includes `construction_acceptance` with per-room construction capability classification and overall pass/non-pass status.
- [x] Non-goals / accepted substitutes: no production bot behavior change, no Screeps MMO write, no deploy workflow invocation, and no RL compute launch.
- [x] Verification evidence required before Done: diff-check, Python compile, and focused runtime-monitor unit tests all pass on commit `f82eef0d15534e6a7eead2e2eb40e3a429f49933`.
- [x] Project Evidence / Next action / Blocked by: controller updates #1822 and this PR Project items with commit/test evidence and exact-head review-gate action; no owner-action blocker.
- [x] Post-merge/deploy/runtime proof: the next official deploy or postdeploy observer can cite `construction_acceptance` from health-gate output as the named proof surface for construction-fix acceptance.
- [x] Named deliverable proof: commit `f82eef0d15534e6a7eead2e2eb40e3a429f49933` modifies `scripts/screeps-runtime-monitor.py` and `scripts/test_screeps_runtime_monitor_tactical_response.py`.
