### PR TITLE
rl: record pending Loop A card supply in ledgers

### DIFF
--- a/scripts/screeps_rl_control_loop_ledgers.py
+++ b/scripts/screeps_rl_control_loop_ledgers.py
@@ -173,6 +173,13 @@ def text_value(value: Any) -> str | None:
     return None
 
 
+def first_present(mapping: JsonObject, keys: Sequence[str]) -> Any:
+    for key in keys:
+        if key in mapping:
+            return mapping[key]
+    return None
+
+
 def number_value(value: Any) -> float | None:
     if isinstance(value, bool):
         return None
@@ -823,10 +830,17 @@ def dashboard_summary(repo_root: Path, artifact_root: Path, created_at: str, max
         max_files_per_root=max_files_per_root,
     )
     gate = static_dashboard.latest_gate(gate_infos)
+    standalone_card_supply_candidates = static_dashboard.discover_standalone_card_supply_candidates(
+        artifact_root,
+        warnings=warnings,
+        repo_root=repo_root,
+    )
+    standalone_card_supply = standalone_card_supply_candidates[0] if standalone_card_supply_candidates else None
     simulator = bounded_simulator_health(latest_training)
     training = static_dashboard.training_execution(
         latest_training,
-        standalone_card_supply_candidates=[],
+        standalone_card_supply=standalone_card_supply,
+        standalone_card_supply_candidates=standalone_card_supply_candidates,
         tencent_internal_card_supply_candidates=[],
     )
     policy = static_dashboard.policy_advantage(latest_policy, latest_metrics, training=training)
@@ -853,6 +867,10 @@ def dashboard_summary(repo_root: Path, artifact_root: Path, created_at: str, max
             **source_scan,
             "gateScan": gate_scan,
             "rootTrainingReportScan": root_training_report_scan,
+            "standaloneCardSupply": {
+                "candidateCount": len(standalone_card_supply_candidates),
+                "selected": repo_display_path((standalone_card_supply or {}).get("path"), repo_root),
+            },
             "mode": "bounded-control-loop-ledger-producer",
         },
     }
@@ -881,6 +899,94 @@ def latest_artifact_absolute_path(dashboard: JsonObject, key: str, repo_root: Pa
 def latest_artifact_path(dashboard: JsonObject, key: str, repo_root: Path) -> str | None:
     artifacts = as_dict(dashboard.get("artifacts"))
     return repo_display_path(artifacts.get(key), repo_root)
+
+
+def card_supply_available_for_guarded_training(card_supply: JsonObject) -> bool:
+    return static_dashboard.card_supply_available_for_training(card_supply)
+
+
+def selected_card_supply(summary: JsonObject) -> JsonObject:
+    return as_dict(as_dict(summary.get("training")).get("cardSupply"))
+
+
+def card_supply_reference(card_supply: JsonObject) -> str:
+    card_id = text_value(card_supply.get("cardId")) or "the selected Loop A card"
+    card_path = text_value(card_supply.get("path"))
+    if card_path:
+        return f"{card_id} at {card_path}"
+    return card_id
+
+
+def guard_held_card_supply_evidence(card_supply: JsonObject) -> str:
+    return (
+        f"Paid compute is held pending #1233 guard clearance; Loop A card "
+        f"{card_supply_reference(card_supply)} remains available and unconsumed for the next guarded training attempt."
+    )
+
+
+def guard_held_card_supply_next_action(card_supply: JsonObject) -> str:
+    return (
+        f"Keep paid compute held until #1233 guard clearance records an explicit allowed validation signature; "
+        f"then consume {card_supply_reference(card_supply)} in the next guarded Loop A training attempt. "
+        "Do not create a duplicate card while this supply remains available."
+    )
+
+
+def stale_experiment_card_not_consumed_anomaly(item: JsonObject, current_card_supply: JsonObject) -> bool:
+    if item.get("code") != "EXPERIMENT_CARD_NOT_CONSUMED":
+        return False
+    if not card_supply_available_for_guarded_training(current_card_supply):
+        return False
+    current_card_id = text_value(current_card_supply.get("cardId"))
+    if current_card_id is None:
+        return True
+    return current_card_id not in screeps_cli_io.canonical_json(json_safe(item))
+
+
+def card_supply_path(card_supply: JsonObject, repo_root: Path) -> Path | None:
+    raw_path = text_value(card_supply.get("path"))
+    if raw_path is None:
+        return None
+    path = Path(raw_path)
+    if not path.is_absolute():
+        path = repo_root / path
+    return path
+
+
+def pending_experiment_card_record(card_supply: JsonObject, repo_root: Path) -> JsonObject | None:
+    if not card_supply_available_for_guarded_training(card_supply):
+        return None
+    path = card_supply_path(card_supply, repo_root)
+    card = load_json(path) if path is not None else None
+    supply = as_dict(card_supply.get("cardSupply"))
+    record: JsonObject = {
+        "status": "available_pending_guarded_training",
+        "cardId": text_value(card_supply.get("cardId")),
+        "path": repo_display_path(path if path is not None else card_supply.get("path"), repo_root),
+        "source": text_value(card_supply.get("source")),
+        "classification": text_value(card_supply.get("classification")),
+        "createdAt": text_value(card_supply.get("createdAt")),
+        "datasetRunId": text_value(card_supply.get("datasetRunId")),
+        "trainingApproach": text_value(card_supply.get("trainingApproach")),
+        "availableForTraining": supply.get("available_for_training") is True,
+        "consumedAt": supply.get("consumed_at"),
+        "consumedByReportId": supply.get("consumed_by_report_id"),
+        "cardSupply": supply,
+    }
+    if card is not None:
+        safety = as_dict(card.get("safety"))
+        if safety:
+            record["safety"] = {
+                "liveEffect": safety.get("liveEffect"),
+                "officialMmoWrites": safety.get("officialMmoWrites"),
+                "officialMmoWritesAllowed": safety.get("officialMmoWritesAllowed"),
+                "conservative_actions_only": safety.get("conservative_actions_only"),
+                "ood_rejection": safety.get("ood_rejection"),
+            }
+        source_gate = first_present(card, ("source_gate", "sourceGate"))
+        if isinstance(source_gate, dict):
+            record["sourceGate"] = source_gate
+    return record
 
 
 def field_from(payload: JsonObject | None, key: str, fallback: Any) -> Any:
@@ -1706,6 +1812,7 @@ def training_anomalies(
     gate = as_dict(dashboard.get("gate"))
     anomalies: list[JsonObject] = []
     stale_e1_gate_resolved = selected_gate_resolves_e1_stale_anomaly(dashboard)
+    current_card_supply = selected_card_supply(dashboard)
     if not gate:
         anomalies.append(
             {
@@ -1722,11 +1829,14 @@ def training_anomalies(
     if not training.get("hasComputeEvidence"):
         code = "TRAINING_LEDGER_MISSING" if not training.get("hasData") else "TRAINING_COMPUTE_EVIDENCE_MISSING"
         evidence_path = latest_artifact_path(dashboard, "trainingLedger", repo_root)
+        evidence = text_value(training.get("blocker")) or "No bounded training compute evidence was found."
+        if card_supply_available_for_guarded_training(current_card_supply):
+            evidence = guard_held_card_supply_evidence(current_card_supply)
         anomalies.append(
             {
                 "severity": "P0",
                 "code": code,
-                "evidence": text_value(training.get("blocker")) or "No bounded training compute evidence was found.",
+                "evidence": evidence,
                 "handoffRequired": True,
                 "handoffSeverity": "P0",
                 "blockerClass": "rl_training_artifact_gap",
@@ -1741,12 +1851,17 @@ def training_anomalies(
             continue
         if stale_e1_gate_resolved and item.get("code") == "E1_GATE_STALE":
             continue
+        if stale_experiment_card_not_consumed_anomaly(item, current_card_supply):
+            continue
         if item.get("code") not in {anomaly["code"] for anomaly in anomalies}:
             anomalies.append(item)
     return anomalies[:12]
 
 
 def next_training_capability_action(previous: JsonObject | None, training: JsonObject, did_run: bool) -> str:
+    card_supply = as_dict(training.get("cardSupply"))
+    if not did_run and card_supply_available_for_guarded_training(card_supply):
+        return guard_held_card_supply_next_action(card_supply)
     previous_action = text_value((previous or {}).get("nextTrainingCapabilityAction"))
     if previous_action:
         return previous_action
@@ -1813,6 +1928,18 @@ def build_training_ledger(
         repo_root=repo_root,
     )
     anomalies = training_anomalies(summary, previous, repo_root, reward_decision_id=reward_decision_id)
+    card_supply = as_dict(training.get("cardSupply"))
+    pending_experiment_card = pending_experiment_card_record(card_supply, repo_root)
+    experiment_card_id = (
+        pending_experiment_card.get("cardId")
+        if pending_experiment_card is not None
+        else training_artifacts.get("experimentCard")
+    )
+    experiment_card_path = (
+        pending_experiment_card.get("path")
+        if pending_experiment_card is not None
+        else training_artifacts.get("experimentCardPath")
+    )
 
     return {
         "type": TRAINING_LEDGER_TYPE,
@@ -1865,8 +1992,13 @@ def build_training_ledger(
             "policyUpdateNote": iteration.get("policyUpdateNote") or "bounded artifact producer did not launch training",
         },
         "trainingArtifacts": {
-            "experimentCard": training_artifacts.get("experimentCard"),
-            "experimentCardPath": training_artifacts.get("experimentCardPath"),
+            "experimentCard": experiment_card_id,
+            "experimentCardPath": experiment_card_path,
+            "experimentCardStatus": (
+                pending_experiment_card.get("status") if pending_experiment_card is not None else None
+            ),
+            "pendingExperimentCard": pending_experiment_card,
+            "cardSupply": as_dict(pending_experiment_card.get("cardSupply")) if pending_experiment_card is not None else None,
             "simulatorRunIds": training_artifacts.get("simulatorRunIds", []),
             "trainingReportIds": training_artifacts.get("trainingReportIds", []),
             "candidatePolicyIds": training_artifacts.get("candidatePolicyIds", []),
@@ -1874,6 +2006,8 @@ def build_training_ledger(
             "rewardDecisionArtifactPath": reward_decision_artifact_path,
             "latestTrainingLedger": latest_artifact_path(summary, "trainingLedger", repo_root),
         },
+        "cardSupply": card_supply,
+        "pendingExperimentCard": pending_experiment_card,
         "anomalies": anomalies,
         "nextTrainingCapabilityAction": next_training_capability_action(previous, training, did_run),
         "metricsFields": {

--- a/scripts/screeps_rl_dashboard.py
+++ b/scripts/screeps_rl_dashboard.py
@@ -1813,6 +1813,28 @@ def matching_tencent_card_supply_for_training(
     return max(matches, key=training_card_supply_candidate_key)
 
 
+def best_available_supplied_card_supply(
+    *,
+    standalone_card_supply: JsonObject | None = None,
+    standalone_card_supply_candidates: Sequence[JsonObject] | None = None,
+    tencent_internal_card_supply: JsonObject | None = None,
+    tencent_internal_card_supply_candidates: Sequence[JsonObject] | None = None,
+) -> JsonObject | None:
+    tencent_candidates = combined_tencent_card_supply_candidates(
+        tencent_internal_card_supply,
+        tencent_internal_card_supply_candidates,
+    )
+    available_supply = best_available_tencent_card_supply(tencent_candidates)
+    if available_supply is None:
+        available_supply = best_available_card_supply(
+            combined_card_supply_candidates(
+                standalone_card_supply,
+                standalone_card_supply_candidates,
+            )
+        )
+    return available_supply
+
+
 def reconcile_card_supply_for_training(
     payload: JsonObject,
     *,
@@ -1845,14 +1867,12 @@ def reconcile_card_supply_for_training(
     if not training_did_run:
         if training_claims_compute:
             return blocked_card_supply_summary(text_value(compute_evidence.get("blocker")))
-        available_supply = best_available_tencent_card_supply(tencent_candidates)
-        if available_supply is None:
-            available_supply = best_available_card_supply(
-                combined_card_supply_candidates(
-                    standalone_card_supply,
-                    standalone_card_supply_candidates,
-                )
-            )
+        available_supply = best_available_supplied_card_supply(
+            standalone_card_supply=standalone_card_supply,
+            standalone_card_supply_candidates=standalone_card_supply_candidates,
+            tencent_internal_card_supply=tencent_internal_card_supply,
+            tencent_internal_card_supply_candidates=tencent_internal_card_supply_candidates,
+        )
         if available_supply is not None:
             return dict(available_supply)
     else:
@@ -1884,6 +1904,18 @@ def training_execution(
     tencent_internal_card_supply_candidates: Sequence[JsonObject] | None = None,
 ) -> JsonObject:
     if latest_training is None:
+        supplied_card = best_available_supplied_card_supply(
+            standalone_card_supply=standalone_card_supply,
+            standalone_card_supply_candidates=standalone_card_supply_candidates,
+            tencent_internal_card_supply=tencent_internal_card_supply,
+            tencent_internal_card_supply_candidates=tencent_internal_card_supply_candidates,
+        )
+        card_supply = (
+            dict(supplied_card)
+            if supplied_card is not None
+            else blocked_card_supply_summary("No training ledger found.")
+        )
+        blocker = None if card_supply_available_for_training(card_supply) else "No training ledger found."
         return {
             "hasData": False,
             "status": "N/A",
@@ -1891,9 +1923,9 @@ def training_execution(
             "episodes": None,
             "policyUpdates": None,
             "timestamp": None,
-            "blocker": "No training ledger found.",
+            "blocker": blocker,
             "latestPath": None,
-            "cardSupply": blocked_card_supply_summary("No training ledger found."),
+            "cardSupply": card_supply,
             "hasComputeEvidence": False,
             "computeEvidence": {
                 "hasCompute": False,

--- a/scripts/test_screeps_rl_control_loop_ledgers.py
+++ b/scripts/test_screeps_rl_control_loop_ledgers.py
@@ -12,6 +12,7 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).parent))
 
 import screeps_rl_control_loop_ledgers as ledgers
+import screeps_rl_experiment_card as card_helper
 
 
 JsonObject = dict[str, Any]
@@ -512,6 +513,132 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
         self.assertEqual(payload["environmentExecution"]["completed"], 0)
         self.assertEqual(payload["trainingArtifacts"]["latestTrainingLedger"], None)
         self.assertIn("TRAINING_LEDGER_MISSING", {item["code"] for item in payload["anomalies"]})
+
+    def test_training_ledger_records_fresh_pending_loop_a_card_supply_when_compute_is_held(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            old_card_id = "rl-exp-rl-e93cefe304b9-7d410885d4ee-20260607T022517692025Z298f1b"
+            fresh_gate = card_helper.source_gate_block(
+                gate_id="e1-lite-gate-20260612T140705Z",
+                dataset_run_id="rl-shadow-eval-20260612T140705Z-0b0ad170a80d",
+                gate_report_path=artifact_root / "rl-dataset-gates" / "e1-lite-gate-20260612T140705Z" / "gate_report.json",
+                created_at="2026-06-12T14:07:05Z",
+                gate_report_ok=True,
+                acceptance_rate=1.0,
+                dataset_gate_status="pass",
+                shadow_evaluation_status="pass",
+                sample_count=99,
+                split_counts={"train": 46, "eval": 53},
+            )
+            fresh_card = card_helper.build_card(
+                dataset_run_id="rl-shadow-eval-20260612T140705Z-0b0ad170a80d",
+                code_commit="a" * 40,
+                training_approach="policy_gradient",
+                created_at="2026-06-12T14:23:03Z",
+                loop_a_card_supply=True,
+                source_gate=fresh_gate,
+            )
+            write_json(
+                artifact_root / "rl-dataset-gates" / "e1-lite-gate-20260612T140705Z" / "gate_report.json",
+                {
+                    "type": "screeps-rl-dataset-evaluation-gate",
+                    "ok": True,
+                    "gateId": "e1-lite-gate-20260612T140705Z",
+                    "createdAt": "2026-06-12T14:07:05Z",
+                    "dataset": {"runId": "rl-shadow-eval-20260612T140705Z-0b0ad170a80d", "sampleCount": 99},
+                    "datasetGate": {"status": "pass", "sampleCount": 99},
+                    "quality_checks": {"status": "pass", "samples_accepted": 99, "samples_rejected": 0},
+                    "blockingReasons": [],
+                },
+            )
+            write_json(artifact_root / "rl-experiment-cards" / "experiment_card.json", fresh_card)
+            write_json(
+                artifact_root / "rl-control-loop" / "20260612T161348Z-training-ledger.json",
+                {
+                    "type": ledgers.TRAINING_LEDGER_TYPE,
+                    "createdAt": "2026-06-12T16:13:48Z",
+                    "status": "NOT_RUN",
+                    "trainingDidRun": False,
+                    "trainingArtifacts": {
+                        "experimentCard": old_card_id,
+                        "experimentCardPath": "runtime-artifacts/rl-experiment-cards/old-experiment-card.json",
+                    },
+                    "environmentExecution": {"started": 0, "completed": 0, "failed": 0},
+                    "iterationExecution": {
+                        "simulatorTicksRequested": 0,
+                        "simulatorTicksRun": 0,
+                        "episodesRun": 0,
+                        "candidateEvaluationIterations": 0,
+                        "policyUpdateIterations": 0,
+                    },
+                    "metricsFields": {},
+                    "anomalies": [
+                        {
+                            "severity": "P1",
+                            "code": "EXPERIMENT_CARD_NOT_CONSUMED",
+                            "evidence": f"Mark stale card consumed before continuing: {old_card_id}",
+                            "handoffRequired": True,
+                        }
+                    ],
+                    "nextTrainingCapabilityAction": (
+                        "Mark stale card consumed or create a fresh duplicate from e1-console-gate-20260607T1257Z."
+                    ),
+                },
+            )
+            output = root / "out" / "training-ledger.json"
+
+            exit_code = ledgers.main(
+                [
+                    "training-ledger",
+                    "--repo-root",
+                    str(root),
+                    "--artifact-root",
+                    str(artifact_root),
+                    "--output",
+                    str(output),
+                    "--created-at",
+                    "2026-06-12T16:20:00Z",
+                    "--max-files-per-root",
+                    "8",
+                ],
+                stdout=io.StringIO(),
+                stderr=io.StringIO(),
+            )
+            payload = read_json(output)
+
+        anomaly_codes = {item["code"] for item in payload["anomalies"]}
+        anomaly_text = json.dumps(payload["anomalies"], sort_keys=True)
+        pending = payload["pendingExperimentCard"]
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["status"], "NOT_RUN")
+        self.assertFalse(payload["trainingDidRun"])
+        self.assertEqual(payload["trainingArtifacts"]["experimentCard"], fresh_card["card_id"])
+        self.assertEqual(payload["trainingArtifacts"]["experimentCardPath"], "runtime-artifacts/rl-experiment-cards/experiment_card.json")
+        self.assertEqual(payload["trainingArtifacts"]["experimentCardStatus"], "available_pending_guarded_training")
+        self.assertEqual(payload["trainingArtifacts"]["pendingExperimentCard"], pending)
+        self.assertEqual(payload["cardSupply"]["cardId"], fresh_card["card_id"])
+        self.assertEqual(payload["cardSupply"]["cardSupply"]["state"], "available")
+        self.assertTrue(payload["cardSupply"]["cardSupply"]["available_for_training"])
+        self.assertIsNone(payload["cardSupply"]["cardSupply"]["consumed_at"])
+        self.assertIsNone(payload["cardSupply"]["cardSupply"]["consumed_by_report_id"])
+        self.assertEqual(pending["cardId"], fresh_card["card_id"])
+        self.assertEqual(pending["sourceGate"]["gate_id"], "e1-lite-gate-20260612T140705Z")
+        self.assertEqual(pending["sourceGate"]["sample_count"], 99)
+        self.assertEqual(pending["sourceGate"]["split_counts"], {"train": 46, "eval": 53})
+        self.assertFalse(pending["safety"]["liveEffect"])
+        self.assertFalse(pending["safety"]["officialMmoWrites"])
+        self.assertFalse(pending["safety"]["officialMmoWritesAllowed"])
+        self.assertIn("TRAINING_COMPUTE_EVIDENCE_MISSING", anomaly_codes)
+        self.assertNotIn("EXPERIMENT_CARD_NOT_CONSUMED", anomaly_codes)
+        self.assertIn("#1233", anomaly_text)
+        self.assertIn(fresh_card["card_id"], anomaly_text)
+        self.assertNotIn(old_card_id, anomaly_text)
+        self.assertNotIn("e1-console-gate-20260607T1257Z", anomaly_text)
+        self.assertIn("#1233", payload["nextTrainingCapabilityAction"])
+        self.assertIn(fresh_card["card_id"], payload["nextTrainingCapabilityAction"])
+        self.assertNotIn(old_card_id, payload["nextTrainingCapabilityAction"])
+        self.assertNotIn("e1-console-gate-20260607T1257Z", payload["nextTrainingCapabilityAction"])
 
     def test_training_ledger_ingests_root_level_local2w_training_report(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_rl_control_loop_ledgers.py
+++ b/scripts/test_screeps_rl_control_loop_ledgers.py
@@ -514,6 +514,100 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
         self.assertEqual(payload["trainingArtifacts"]["latestTrainingLedger"], None)
         self.assertIn("TRAINING_LEDGER_MISSING", {item["code"] for item in payload["anomalies"]})
 
+    def test_training_ledger_preserves_pending_loop_a_card_supply_without_prior_ledger(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            fresh_gate = card_helper.source_gate_block(
+                gate_id="e1-lite-gate-20260612T140705Z",
+                dataset_run_id="rl-shadow-eval-20260612T140705Z-0b0ad170a80d",
+                gate_report_path=(
+                    artifact_root
+                    / "rl-dataset-gates"
+                    / "e1-lite-gate-20260612T140705Z"
+                    / "gate_report.json"
+                ),
+                created_at="2026-06-12T14:07:05Z",
+                gate_report_ok=True,
+                acceptance_rate=1.0,
+                dataset_gate_status="pass",
+                shadow_evaluation_status="pass",
+                sample_count=99,
+                split_counts={"train": 46, "eval": 53},
+            )
+            fresh_card = card_helper.build_card(
+                dataset_run_id="rl-shadow-eval-20260612T140705Z-0b0ad170a80d",
+                code_commit="a" * 40,
+                training_approach="policy_gradient",
+                created_at="2026-06-12T14:23:03Z",
+                loop_a_card_supply=True,
+                source_gate=fresh_gate,
+            )
+            write_json(
+                artifact_root / "rl-dataset-gates" / "e1-lite-gate-20260612T140705Z" / "gate_report.json",
+                {
+                    "type": "screeps-rl-dataset-evaluation-gate",
+                    "ok": True,
+                    "gateId": "e1-lite-gate-20260612T140705Z",
+                    "createdAt": "2026-06-12T14:07:05Z",
+                    "dataset": {"runId": "rl-shadow-eval-20260612T140705Z-0b0ad170a80d", "sampleCount": 99},
+                    "datasetGate": {"status": "pass", "sampleCount": 99},
+                    "quality_checks": {"status": "pass", "samples_accepted": 99, "samples_rejected": 0},
+                    "blockingReasons": [],
+                },
+            )
+            write_json(artifact_root / "rl-experiment-cards" / "experiment_card.json", fresh_card)
+            output = root / "out" / "training-ledger.json"
+
+            exit_code = ledgers.main(
+                [
+                    "training-ledger",
+                    "--repo-root",
+                    str(root),
+                    "--artifact-root",
+                    str(artifact_root),
+                    "--output",
+                    str(output),
+                    "--created-at",
+                    "2026-06-12T16:20:00Z",
+                    "--max-files-per-root",
+                    "8",
+                ],
+                stdout=io.StringIO(),
+                stderr=io.StringIO(),
+            )
+            payload = read_json(output)
+
+        anomaly_codes = {item["code"] for item in payload["anomalies"]}
+        training_gap = next(item for item in payload["anomalies"] if item["code"] == "TRAINING_LEDGER_MISSING")
+        pending = payload["pendingExperimentCard"]
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["status"], "NOT_RUN")
+        self.assertFalse(payload["trainingDidRun"])
+        self.assertEqual(payload["trainingArtifacts"]["latestTrainingLedger"], None)
+        self.assertEqual(payload["trainingArtifacts"]["experimentCard"], fresh_card["card_id"])
+        self.assertEqual(payload["trainingArtifacts"]["experimentCardPath"], "runtime-artifacts/rl-experiment-cards/experiment_card.json")
+        self.assertEqual(payload["trainingArtifacts"]["experimentCardStatus"], "available_pending_guarded_training")
+        self.assertEqual(payload["trainingArtifacts"]["pendingExperimentCard"], pending)
+        self.assertEqual(payload["cardSupply"]["cardId"], fresh_card["card_id"])
+        self.assertEqual(payload["cardSupply"]["cardSupply"]["state"], "available")
+        self.assertTrue(payload["cardSupply"]["cardSupply"]["available_for_training"])
+        self.assertIsNone(payload["cardSupply"]["cardSupply"]["consumed_at"])
+        self.assertIsNone(payload["cardSupply"]["cardSupply"]["consumed_by_report_id"])
+        self.assertEqual(pending["cardId"], fresh_card["card_id"])
+        self.assertEqual(pending["sourceGate"]["gate_id"], "e1-lite-gate-20260612T140705Z")
+        self.assertEqual(pending["sourceGate"]["sample_count"], 99)
+        self.assertEqual(pending["sourceGate"]["split_counts"], {"train": 46, "eval": 53})
+        self.assertFalse(pending["safety"]["liveEffect"])
+        self.assertFalse(pending["safety"]["officialMmoWrites"])
+        self.assertFalse(pending["safety"]["officialMmoWritesAllowed"])
+        self.assertIn("TRAINING_LEDGER_MISSING", anomaly_codes)
+        self.assertIn("#1233", training_gap["evidence"])
+        self.assertIn(fresh_card["card_id"], training_gap["evidence"])
+        self.assertIn("#1233", payload["nextTrainingCapabilityAction"])
+        self.assertIn(fresh_card["card_id"], payload["nextTrainingCapabilityAction"])
+        self.assertNotIn("No training ledger found", payload["nextTrainingCapabilityAction"])
+
     def test_training_ledger_records_fresh_pending_loop_a_card_supply_when_compute_is_held(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_dashboard.py
+++ b/scripts/test_screeps_rl_dashboard.py
@@ -318,6 +318,45 @@ class ScreepsRlDashboardCardSupplyTest(unittest.TestCase):
         self.assertIsNone(summary["training"]["blocker"])
         self.assertIsNone(summary["policy"]["cardSupplyFinding"])
 
+    def test_missing_training_ledger_preserves_standalone_card_supply(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "runtime-artifacts"
+            card = card_helper.build_card(
+                dataset_run_id="rl-current-standalone",
+                code_commit="2" * 40,
+                training_approach="policy_gradient",
+                created_at="2026-05-20T18:04:00Z",
+                scenario_id=card_helper.MULTI_TIER_SCENARIO_ID,
+                require_multi_tier_scenario=True,
+                loop_a_card_supply=True,
+            )
+            write_json(artifact_root / "rl-experiment-cards" / "experiment_card.json", card)
+
+            standalone_candidates = dashboard.discover_standalone_card_supply_candidates(
+                artifact_root,
+                warnings=[],
+                repo_root=root,
+            )
+            training = dashboard.training_execution(
+                None,
+                standalone_card_supply=standalone_candidates[0],
+                standalone_card_supply_candidates=standalone_candidates,
+            )
+
+        card_supply = training["cardSupply"]
+        self.assertFalse(training["hasData"])
+        self.assertFalse(training["hasComputeEvidence"])
+        self.assertIsNone(training["blocker"])
+        self.assertEqual(card_supply["status"], "PRIMARY_SATISFIED")
+        self.assertEqual(card_supply["classification"], "STANDALONE_POLICY_GRADIENT_FALLBACK_AVAILABLE")
+        self.assertEqual(card_supply["source"], "standalone_experiment_card")
+        self.assertEqual(card_supply["cardId"], card["card_id"])
+        self.assertEqual(card_supply["cardSupply"]["state"], "available")
+        self.assertTrue(card_supply["cardSupply"]["available_for_training"])
+        self.assertIsNone(card_supply["cardSupply"]["consumed_at"])
+        self.assertIsNone(card_supply["cardSupply"]["consumed_by_report_id"])
+
     def test_not_run_prefers_tencent_supply_over_newer_standalone_fallback(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary
- Record the currently selectable Loop A experiment-card supply in the training ledger even while paid Tencent compute remains held by the #1233 guard.
- Surface `trainingArtifacts.pendingExperimentCard` / `cardSupply` so the next guarded training attempt can consume the fresh card instead of re-reporting only the old June 7 card.
- Suppress stale `EXPERIMENT_CARD_NOT_CONSUMED` anomalies when the anomaly refers to an older card and a newer safe card supply is available.

## Verification
- `python3 -m py_compile scripts/screeps_rl_control_loop_ledgers.py scripts/test_screeps_rl_control_loop_ledgers.py`
- `python3 -m unittest scripts.test_screeps_rl_control_loop_ledgers` — 33 tests OK
- `git diff --check`

Related to #1782.

## Universal task Done gate
- [x] Task type: P0 RL flywheel ledger artifact repair for issue 1782.
- [x] Expected observable outcome / named deliverable: training ledger JSON records the selectable Loop A card-supply and guarded-training handoff when compute guard remains active.
- [x] Non-goals / accepted substitutes: no paid Tencent training launch, no issue closure, no official MMO deploy, and no Project mutation from the Codex commit-only step.
- [x] Verification evidence required before Done: controller verified py_compile, unittest33, and diff-check on Codex-authored commit b9bcdefb0b13d0b2363a19dfa4c05aaec4afc2dc.
- [x] Project Evidence / Next action / Blocked by: Project will reference commit b9bcdefb, PR gate state, and issue 1782 follow-up ledger-consumption proof; no owner action.
- [x] Post-merge/deploy/runtime proof: subsequent Loop A/training-ledger artifact must show the fresh card supply selected or consumed before issue 1782 is Done.
- [x] Named deliverable proof: `scripts/screeps_rl_control_loop_ledgers.py` and `scripts/test_screeps_rl_control_loop_ledgers.py` contain the ledger fields and regression tests.
