### PR TITLE
construction: clarify CPU-suppressed site seeding

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -42540,13 +42540,16 @@ function selectViableConstructionActivityCandidate(constructionPriority) {
   };
 }
 function isConstructionActivitySuppressed(productiveEnergy, cpuBudget) {
+  if (!shouldRunConstructionCpuWork(cpuBudget)) {
+    return true;
+  }
   if (productiveEnergy.constructionSiteCount <= 0 && productiveEnergy.pendingBuildProgress <= 0) {
     return false;
   }
   return shouldShedNonessentialCpuWork(cpuBudget) || productiveEnergy.buildBlockedReason === "energy_buffer_blocked" || productiveEnergy.buildBlockedReason === "worker_assignment_gap" || productiveEnergy.workerAssignmentBlockedDetail === "spawn_reserving_energy";
 }
 function selectConstructionActivitySuppressedReason(productiveEnergy, cpuBudget) {
-  if (shouldShedNonessentialCpuWork(cpuBudget)) {
+  if (!shouldRunConstructionCpuWork(cpuBudget) || shouldShedNonessentialCpuWork(cpuBudget)) {
     return "cpu_shed";
   }
   if (productiveEnergy.workerAssignmentBlockedDetail === "spawn_reserving_energy") {

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -1642,6 +1642,10 @@ function isConstructionActivitySuppressed(
   productiveEnergy: RuntimeProductiveEnergySummary,
   cpuBudget: RuntimeCpuBudget
 ): boolean {
+  if (!shouldRunConstructionCpuWork(cpuBudget)) {
+    return true;
+  }
+
   if (productiveEnergy.constructionSiteCount <= 0 && productiveEnergy.pendingBuildProgress <= 0) {
     return false;
   }
@@ -1658,7 +1662,7 @@ function selectConstructionActivitySuppressedReason(
   productiveEnergy: RuntimeProductiveEnergySummary,
   cpuBudget: RuntimeCpuBudget
 ): RuntimeConstructionActivityReason {
-  if (shouldShedNonessentialCpuWork(cpuBudget)) {
+  if (!shouldRunConstructionCpuWork(cpuBudget) || shouldShedNonessentialCpuWork(cpuBudget)) {
     return 'cpu_shed';
   }
 

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -2355,8 +2355,15 @@ describe('runtime telemetry summaries', () => {
       ]
     });
     expect(room.constructionActivity).toMatchObject({
+      state: 'candidate_suppressed',
+      accepted: true,
+      reason: 'cpu_shed',
       cpuPressure: 'degraded',
       cpuReasons: ['lowBucket']
+    });
+    expect(room.constructionScoring).toMatchObject({
+      skipped: true,
+      skipReason: 'lowBucket'
     });
   });
 


### PR DESCRIPTION
## Summary
- Clarify construction runtime telemetry so CPU-suppressed site-seeding windows report `constructionActivity.state=candidate_suppressed` and `reason=cpu_shed` instead of masquerading as `no_viable_candidate`.
- Preserve the existing CPU/spawn safety guards while making issue #1831 runtime acceptance distinguish true planner candidate starvation from intentionally skipped construction scoring.
- Regenerate `prod/dist/main.js` from the verified TypeScript source.

## Verification
- `npm run typecheck`
- `npm test -- --runInBand` — 105 suites / 2414 tests passed
- `npm run build`
- `git diff --check`

Related to issue 1831.

## Universal task Done gate
- [x] Task type: P1 Territory/Economy gameplay telemetry/diagnostic repair for issue 1831.
- [x] Expected observable outcome / named deliverable: runtime summaries distinguish CPU-suppressed construction scoring from true no-viable-candidate planner output.
- [x] Non-goals / accepted substitutes: no immediate issue closure, no owner action, and no direct MMO deploy from this PR; runtime construction-site acceptance remains on issue 1831 after deploy.
- [x] Verification evidence required before Done: controller verified typecheck, full Jest run, production build, and diff-check on Codex-authored commit 0379b971.
- [x] Project Evidence / Next action / Blocked by: Project will reference PR gate state and post-deploy runtime acceptance; no owner blocker for the code path.
- [x] Post-merge/deploy/runtime proof: after deploy, runtime-summary-console should show `cpu_shed` during CPU-guarded construction windows, and issue 1831 remains open until scoring runs with construction-site/build activity evidence.
- [x] Named deliverable proof: `prod/src/telemetry/runtimeSummary.ts`, `prod/test/runtimeSummary.test.ts`, and generated `prod/dist/main.js` contain the telemetry behavior and regression coverage.
