### PR TITLE
runtime-monitor: restore postdeploy health self-test

### DIFF
--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -8644,6 +8644,8 @@ def command_self_test(_args: argparse.Namespace) -> int:
                             "owner": "owner",
                             "spawns": 1,
                             "owned_spawns": 1,
+                            "constructionSiteCount": 0,
+                            "pendingBuildProgress": 0,
                         }
                     ],
                 },
@@ -8755,6 +8757,8 @@ def command_self_test(_args: argparse.Namespace) -> int:
                             "owner": "owner",
                             "energyCapacity": 300,
                             "energyBufferHealth": {"threshold": 300},
+                            "constructionSiteCount": 0,
+                            "pendingBuildProgress": 0,
                         },
                         {
                             "room": "shardTest/E2N2",
@@ -8763,6 +8767,8 @@ def command_self_test(_args: argparse.Namespace) -> int:
                             "owner": "owner",
                             "energyCapacity": 300,
                             "energyBufferHealth": {"threshold": 250},
+                            "constructionSiteCount": 0,
+                            "pendingBuildProgress": 0,
                         },
                     ],
                 },
@@ -8810,6 +8816,8 @@ def command_self_test(_args: argparse.Namespace) -> int:
                             "expected_owner": "owner",
                             "spawns": 0,
                             "owned_spawns": 0,
+                            "constructionSiteCount": 0,
+                            "pendingBuildProgress": 0,
                         }
                     ],
                 },


### PR DESCRIPTION
Related to issue 1835. Do not auto-close; issue 1835 stays open until the post-merge official-screeps-deploy workflow rerun proves the deploy floor is unblocked or records a fresh blocker.

## Summary
- Add explicit zero construction counters to runtime monitor self-test fixtures that exercise postdeploy health-gate paths.
- Restore the deploy helper self-test suite so official deploy validation can run before upload.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps-runtime-monitor.py`
- `python3 scripts/screeps-runtime-monitor.py self-test` — 42 tests PASS

## Issue acceptance gate
- [x] issue 1835 repair slice: self-test fixtures include `constructionSiteCount: 0` and `pendingBuildProgress: 0` where the construction acceptance gate expects those fields; `python3 scripts/screeps-runtime-monitor.py self-test` passes 42/42 at PR head `243b8d49`.
- [ ] issue 1835 post-merge deploy-floor proof: rerun `official-screeps-deploy.yml` on merged `main` and archive deploy/helper evidence, or record the next exact blocker. This remains owned by issue 1835 after this PR merges.

## Universal task Done gate
- [x] Task type: Release/deploy P0 runtime-monitor self-test repair.
- [x] Expected observable outcome / named deliverable: official-screeps-deploy helper self-test accepts healthy zero-site postdeploy fixtures and permits deploy validation to reach upload steps.
- [x] Non-goals / accepted substitutes: no production bot behavior change; no Screeps API writes from this PR.
- [x] Verification evidence required before Done: `git diff --check`, `python3 -m py_compile scripts/screeps-runtime-monitor.py`, and `python3 scripts/screeps-runtime-monitor.py self-test` pass locally; GitHub checks are green at PR head `243b8d49`.
- [x] Project Evidence / Next action / Blocked by: Project item records PR head `243b8d49`, self-test PASS evidence, exact-head CI/review-gate state, no owner action; issue 1835 remains active for deploy workflow rerun.
- [x] Post-merge/deploy/runtime proof: not claimed by this PR; post-merge deploy-floor proof remains tracked by issue 1835.
- [x] Named deliverable proof: `scripts/screeps-runtime-monitor.py self-test` reports `Ran 42 tests` and `OK` with the patched fixture schema.
