### PR TITLE
construction: surface planner site-seeding blockers

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -42204,11 +42204,19 @@ function shouldEmitRuntimeSummary(tick, events, cpuBudget = getRuntimeCpuBudget(
     }
     return tick > 0 && tick % DEGRADED_RUNTIME_SUMMARY_INTERVAL === 0;
   }
-  if (events.length > 0) {
+  if (hasImmediateRuntimeSummaryEvent(events)) {
     return true;
   }
   const interval = shouldThrottleRuntimeSummaryCadence(cpuBudget) ? DEGRADED_RUNTIME_SUMMARY_INTERVAL : RUNTIME_SUMMARY_INTERVAL;
   return tick > 0 && tick % interval === 0;
+}
+function hasImmediateRuntimeSummaryEvent(events) {
+  return events.some((event) => {
+    if (event.type !== "constructionPlacement") {
+      return true;
+    }
+    return event.mode !== "normal" || event.blockedReason === void 0;
+  });
 }
 function hasCriticalRuntimeSummaryEvent(events) {
   return events.some((event) => {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -14994,7 +14994,7 @@ function planResidualStoredEnergyRoadSeed(colony, result, budgetState, options) 
   }
   const blocker = getResidualStoredEnergyRoadSeedBlocker(colony, result, budgetState, options);
   if (blocker) {
-    recordBlockedPlacement(result, "road", blocker, options);
+    recordBlockedPlacement(result, "road", blocker.reason, options, { details: blocker.details });
     return;
   }
   const seedPlan = createResidualRoadSeedPlan(colony.room, colony);
@@ -15037,31 +15037,73 @@ function planResidualStoredEnergyRoadSeed(colony, result, budgetState, options) 
 }
 function getResidualStoredEnergyRoadSeedBlocker(colony, result, budgetState, options) {
   if (hasReachedPlacementLimit(result, options)) {
-    return "residual_road_seed_placement_limit_reached";
+    return {
+      reason: "residual_road_seed_placement_limit_reached",
+      details: {
+        successfulPlacementCount: countSuccessfulPlacements(result),
+        maxPlacementsPerRoom: getMaxPlacementsPerRoom(options)
+      }
+    };
   }
-  if (countPendingRoomConstructionSites(colony.room) > 0) {
-    return "residual_road_seed_existing_site";
+  const pendingConstructionSiteCount = countPendingRoomConstructionSites(colony.room);
+  if (pendingConstructionSiteCount > 0) {
+    return {
+      reason: "residual_road_seed_existing_site",
+      details: { pendingConstructionSiteCount }
+    };
   }
-  if (!shouldUseStoredEnergyConstructionSeedSlot(colony.room, budgetState)) {
-    return "residual_road_seed_stored_energy_unavailable";
+  const storedEnergyAvailableForConstruction = getRoomStoredEnergyAvailableForConstruction(colony.room);
+  if (budgetState.energyReserved > 0 || storedEnergyAvailableForConstruction < CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY) {
+    return {
+      reason: "residual_road_seed_stored_energy_unavailable",
+      details: {
+        storedEnergyAvailableForConstruction,
+        storedEnergyMinimum: CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY,
+        pendingConstructionSiteCount,
+        successfulPlacementCount: countSuccessfulPlacements(result)
+      }
+    };
   }
-  if (!hasRemainingStructureCapacity(colony.room, "road")) {
-    return "residual_road_seed_road_capacity_full";
+  const remainingStructureCapacity = getRemainingStructureCapacity(colony.room, "road");
+  if (remainingStructureCapacity <= 0) {
+    return {
+      reason: "residual_road_seed_road_capacity_full",
+      details: { remainingStructureCapacity }
+    };
   }
-  if (!hasResidualConstructionWorkerCoverage(colony.room, options.creeps)) {
-    return "residual_road_seed_worker_coverage_missing";
+  const workerCoverageCount = countResidualConstructionWorkerCoverage(colony.room, options.creeps);
+  if (workerCoverageCount < MIN_RESIDUAL_CONSTRUCTION_SEED_WORKERS) {
+    return {
+      reason: "residual_road_seed_worker_coverage_missing",
+      details: {
+        workerCoverageCount,
+        workerCoverageMinimum: MIN_RESIDUAL_CONSTRUCTION_SEED_WORKERS
+      }
+    };
   }
-  if (!isResidualConstructionSeedRoomSafe(colony)) {
-    return "residual_road_seed_room_unsafe";
+  const hostileThreatCount = countVisibleHostileThreats(colony.room);
+  const rcl = getOwnedRoomRcl6(colony.room);
+  if (!isResidualConstructionSeedRoomSafe(colony, hostileThreatCount, rcl)) {
+    return {
+      reason: "residual_road_seed_room_unsafe",
+      details: {
+        hostileThreatCount,
+        rcl,
+        ownedSpawnCount: countExistingStructures(colony.room, "spawn") + colony.spawns.length
+      }
+    };
   }
   return null;
 }
-function hasResidualConstructionWorkerCoverage(room, creeps) {
-  return hasResidualConstructionWorkerEvidence(room.name, creeps) || hasResidualConstructionWorkerEvidence(room.name, findRoomObjects18(room, "FIND_MY_CREEPS"));
+function countResidualConstructionWorkerCoverage(room, creeps) {
+  return Math.max(
+    countResidualConstructionWorkerEvidence(room.name, creeps),
+    countResidualConstructionWorkerEvidence(room.name, findRoomObjects18(room, "FIND_MY_CREEPS"))
+  );
 }
-function hasResidualConstructionWorkerEvidence(roomName, creeps) {
-  if (!creeps || creeps.length < MIN_RESIDUAL_CONSTRUCTION_SEED_WORKERS) {
-    return false;
+function countResidualConstructionWorkerEvidence(roomName, creeps) {
+  if (!creeps || creeps.length === 0) {
+    return 0;
   }
   let workers = 0;
   for (const creep of creeps) {
@@ -15070,10 +15112,10 @@ function hasResidualConstructionWorkerEvidence(roomName, creeps) {
     }
     workers += 1;
     if (workers >= MIN_RESIDUAL_CONSTRUCTION_SEED_WORKERS) {
-      return true;
+      return workers;
     }
   }
-  return false;
+  return workers;
 }
 function isResidualConstructionWorker(roomName, creep) {
   var _a2;
@@ -15082,10 +15124,10 @@ function isResidualConstructionWorker(roomName, creep) {
   const creepRoomName = (_a2 = creep.room) == null ? void 0 : _a2.name;
   return memory.role === "worker" && (memory.colony === roomName || creepRoomName === roomName) && (typeof ttl !== "number" || ttl > 0);
 }
-function isResidualConstructionSeedRoomSafe(colony) {
+function isResidualConstructionSeedRoomSafe(colony, hostileThreatCount = countVisibleHostileThreats(colony.room), rcl = getOwnedRoomRcl6(colony.room)) {
   var _a2;
   const room = colony.room;
-  return ((_a2 = room.controller) == null ? void 0 : _a2.my) === true && getOwnedRoomRcl6(room) >= 2 && hasOwnedSpawn(colony) && countVisibleHostileThreats(room) <= 0;
+  return ((_a2 = room.controller) == null ? void 0 : _a2.my) === true && rcl >= 2 && hasOwnedSpawn(colony) && hostileThreatCount <= 0;
 }
 function countVisibleHostileThreats(room) {
   return findRoomObjects18(room, "FIND_HOSTILE_CREEPS").length + findRoomObjects18(room, "FIND_HOSTILE_STRUCTURES").length;
@@ -15740,6 +15782,7 @@ function recordBlockedPlacement(result, priority, blockedReason, options, contex
     structureType: getStructureConstant6(PRIORITY_STRUCTURE_TYPES[priority]),
     blockedReason,
     ...context.candidate ? { candidate: toConstructionPlannerCandidateDiagnostic(context.candidate) } : {},
+    ...context.details ? { details: context.details } : {},
     ...context.result !== void 0 ? { result: context.result } : {},
     ...context.position ? { x: context.position.x, y: context.position.y } : {}
   });
@@ -15765,7 +15808,10 @@ function hasReachedPlacementLimit(result, options) {
   if (maxPlacements === Number.MAX_SAFE_INTEGER) {
     return false;
   }
-  return result.placements.filter((placement) => placement.result === getOkCode5()).length >= maxPlacements;
+  return countSuccessfulPlacements(result) >= maxPlacements;
+}
+function countSuccessfulPlacements(result) {
+  return result.placements.filter((placement) => placement.result === getOkCode5()).length;
 }
 function getMaxPlacementsPerRoom(options) {
   const value = options.maxPlacementsPerRoom;
@@ -42115,12 +42161,13 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   }
   creepsByColony != null ? creepsByColony : creepsByColony = groupCreepsByColony(creeps, colonies);
   const reportedEvents = events.slice(0, MAX_REPORTED_EVENTS);
+  const constructionPlacementEventsByRoom = groupConstructionPlacementEventsByRoom(events);
   const persistOccupationRecommendations = options.persistOccupationRecommendations !== false;
   const includeOptionalSummary = !cpuBudget.lowCpuLimit && !shouldShedNonessentialCpuWork(cpuBudget);
   const includeConstructionScoring = shouldRunConstructionCpuWork(cpuBudget);
   const rooms = colonies.map(
     (colony) => {
-      var _a2, _b;
+      var _a2, _b, _c;
       return summarizeRoom(
         colony,
         (_a2 = creepsByColony.get(colony.room.name)) != null ? _a2 : [],
@@ -42129,6 +42176,7 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
         shouldBuildStructureSnapshot(tick),
         options.strategyRegistry,
         options.onStrategyRegistryRuntimeUse,
+        (_c = constructionPlacementEventsByRoom.get(colony.room.name)) != null ? _c : [],
         includeOptionalSummary,
         includeConstructionScoring,
         cpuBudget
@@ -42195,6 +42243,19 @@ function groupCreepsByColony(creeps, colonies) {
   }
   return creepsByColony;
 }
+function groupConstructionPlacementEventsByRoom(events) {
+  var _a2;
+  const eventsByRoom = /* @__PURE__ */ new Map();
+  for (const event of events) {
+    if (event.type !== "constructionPlacement") {
+      continue;
+    }
+    const roomEvents = (_a2 = eventsByRoom.get(event.roomName)) != null ? _a2 : [];
+    roomEvents.push(event);
+    eventsByRoom.set(event.roomName, roomEvents);
+  }
+  return eventsByRoom;
+}
 function addCreepToColonyGroup(creepsByColony, colonyName, creep) {
   var _a2;
   const colonyCreeps = (_a2 = creepsByColony.get(colonyName)) != null ? _a2 : [];
@@ -42228,7 +42289,7 @@ function buildRoomEventMetricsByRoom(colonies, refillTargetIdsByRoom) {
   }
   return eventMetricsByRoom;
 }
-function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, eventMetrics, includeStructureSnapshot, strategyRegistry, onStrategyRegistryRuntimeUse, includeOptionalSummary, includeConstructionScoring, cpuBudget) {
+function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, eventMetrics, includeStructureSnapshot, strategyRegistry, onStrategyRegistryRuntimeUse, constructionPlacementEvents, includeOptionalSummary, includeConstructionScoring, cpuBudget) {
   const tick = getGameTime34();
   const colonyWorkers = colonyCreeps.filter((creep) => creep.memory.role === "worker");
   const roleCounts = countCreepsByRole(colonyCreeps, colony.room.name);
@@ -42267,6 +42328,7 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     resourcesWithoutActivity.productiveEnergy,
     constructionPriority,
     eventMetrics.resources,
+    selectLatestConstructionPlacementEvent(constructionPlacementEvents),
     cpuBudget
   );
   const resources = {
@@ -42455,10 +42517,11 @@ function summarizeWorkerAssignmentBlockedRoomFields(productiveEnergy) {
     ...productiveEnergy.workerAssignmentBlockedWorkers ? { workerAssignmentBlockedWorkers: productiveEnergy.workerAssignmentBlockedWorkers } : {}
   };
 }
-function summarizeConstructionActivity(productiveEnergy, constructionPriority, events, cpuBudget) {
+function summarizeConstructionActivity(productiveEnergy, constructionPriority, events, constructionPlacementEvent, cpuBudget) {
   var _a2;
   const buildProgress = Math.max(0, Math.ceil((_a2 = events == null ? void 0 : events.builtProgress) != null ? _a2 : 0));
   const candidate = selectViableConstructionActivityCandidate(constructionPriority);
+  const planner = constructionPlacementEvent ? summarizeConstructionPlacementEvent(constructionPlacementEvent) : void 0;
   const common = {
     source: "runtime-summary",
     constructionSiteCount: productiveEnergy.constructionSiteCount,
@@ -42469,6 +42532,7 @@ function summarizeConstructionActivity(productiveEnergy, constructionPriority, e
     ...productiveEnergy.buildBlockedReason ? { buildBlockedReason: productiveEnergy.buildBlockedReason } : {},
     ...productiveEnergy.workerAssignmentBlockedDetail ? { workerAssignmentBlockedDetail: productiveEnergy.workerAssignmentBlockedDetail } : {},
     ...candidate ? { candidate } : {},
+    ...planner ? { planner } : {},
     ...cpuBudget.pressure !== "normal" ? { cpuPressure: cpuBudget.pressure } : {},
     ...cpuBudget.reasons.length > 0 ? { cpuReasons: cpuBudget.reasons } : {}
   };
@@ -42495,6 +42559,33 @@ function summarizeConstructionActivity(productiveEnergy, constructionPriority, e
       accepted: true,
       reason: selectConstructionActivitySuppressedReason(productiveEnergy, cpuBudget)
     };
+  }
+  if (constructionPlacementEvent && productiveEnergy.constructionSiteCount <= 0 && productiveEnergy.pendingBuildProgress <= 0) {
+    const placementResult = constructionPlacementEvent.result;
+    if (constructionPlacementEvent.blockedReason) {
+      return {
+        ...common,
+        state: "planner_blocked",
+        accepted: false,
+        reason: "planner_blocked"
+      };
+    }
+    if (placementResult === 0) {
+      return {
+        ...common,
+        state: "active",
+        accepted: true,
+        reason: "site_placement_observed"
+      };
+    }
+    if (placementResult !== void 0) {
+      return {
+        ...common,
+        state: "planner_blocked",
+        accepted: false,
+        reason: "site_placement_failed"
+      };
+    }
   }
   if (productiveEnergy.constructionSiteCount > 0 && productiveEnergy.pendingBuildProgress <= 0) {
     return {
@@ -42525,6 +42616,21 @@ function summarizeConstructionActivity(productiveEnergy, constructionPriority, e
     state: "no_viable_candidate",
     accepted: false,
     reason: "no_viable_candidate"
+  };
+}
+function selectLatestConstructionPlacementEvent(events) {
+  return events[events.length - 1];
+}
+function summarizeConstructionPlacementEvent(event) {
+  return {
+    mode: event.mode,
+    priority: event.priority,
+    structureType: event.structureType,
+    ...event.result !== void 0 ? { result: event.result } : {},
+    ...event.blockedReason ? { blockedReason: event.blockedReason } : {},
+    ...event.details ? { details: event.details } : {},
+    ...event.x !== void 0 ? { x: event.x } : {},
+    ...event.y !== void 0 ? { y: event.y } : {}
   };
 }
 function selectViableConstructionActivityCandidate(constructionPriority) {
@@ -52807,16 +52913,17 @@ function runClaimedRoomConstructionForCpuBudget(colony, creeps, options, telemet
     creeps,
     strategyRegistry: options.strategyRegistry,
     runtimeStrategyConstructionEnabled: options.runtimeStrategyConstructionEnabled,
+    emitConstructionBlockerDiagnostics: true,
     onStrategyRegistryRuntimeUse: options.onStrategyRegistryRuntimeUse
   };
   const activeConstructionOptions = mode === "recoverySeed" ? buildCpuRecoveryConstructionSeedOptions(constructionOptions) : constructionOptions;
   if (deferred) {
     const result2 = planDeferredClaimedRoomCapacityConstruction(colony, activeConstructionOptions);
-    recordRecoveryConstructionPlacementTelemetry(telemetryEvents, result2.placements, result2.blockedPlacements, mode);
+    recordConstructionPlacementTelemetry(telemetryEvents, result2.placements, result2.blockedPlacements, mode);
     return;
   }
   const result = planClaimedRoomConstruction(colony, activeConstructionOptions);
-  recordRecoveryConstructionPlacementTelemetry(telemetryEvents, result.placements, result.blockedPlacements, mode);
+  recordConstructionPlacementTelemetry(telemetryEvents, result.placements, result.blockedPlacements, mode);
 }
 function selectConstructionCpuMode(cpuBudget) {
   return shouldShedNonessentialCpuWork(cpuBudget) && shouldRunConstructionCpuWork(cpuBudget) ? "recoverySeed" : "normal";
@@ -52840,10 +52947,7 @@ function buildCpuRecoveryConstructionSeedOptions(options) {
     }
   };
 }
-function recordRecoveryConstructionPlacementTelemetry(telemetryEvents, placements, blockedPlacements, mode) {
-  if (mode !== "recoverySeed") {
-    return;
-  }
+function recordConstructionPlacementTelemetry(telemetryEvents, placements, blockedPlacements, mode) {
   for (const placement of placements) {
     telemetryEvents.push({
       type: "constructionPlacement",
@@ -52851,7 +52955,7 @@ function recordRecoveryConstructionPlacementTelemetry(telemetryEvents, placement
       priority: placement.priority,
       structureType: String(placement.structureType),
       result: placement.result,
-      mode: "recoverySeed",
+      mode,
       ...placement.x !== void 0 ? { x: placement.x } : {},
       ...placement.y !== void 0 ? { y: placement.y } : {}
     });
@@ -52862,10 +52966,11 @@ function recordRecoveryConstructionPlacementTelemetry(telemetryEvents, placement
       roomName: placement.roomName,
       priority: placement.priority,
       structureType: String(placement.structureType),
-      mode: "recoverySeed",
+      mode,
       blockedReason: placement.blockedReason,
       ...placement.result !== void 0 ? { result: placement.result } : {},
       ...placement.candidate ? { candidate: placement.candidate } : {},
+      ...placement.details ? { details: placement.details } : {},
       ...placement.x !== void 0 ? { x: placement.x } : {},
       ...placement.y !== void 0 ? { y: placement.y } : {}
     });

--- a/prod/src/construction/planner.ts
+++ b/prod/src/construction/planner.ts
@@ -87,6 +87,20 @@ export type ConstructionPlannerBlockerReason =
   | 'residual_road_seed_no_candidate'
   | 'residual_road_seed_rejected';
 
+export interface ConstructionPlannerBlockerDetails {
+  successfulPlacementCount?: number;
+  maxPlacementsPerRoom?: number;
+  pendingConstructionSiteCount?: number;
+  storedEnergyAvailableForConstruction?: number;
+  storedEnergyMinimum?: number;
+  remainingStructureCapacity?: number;
+  workerCoverageCount?: number;
+  workerCoverageMinimum?: number;
+  hostileThreatCount?: number;
+  rcl?: number;
+  ownedSpawnCount?: number;
+}
+
 export interface ConstructionPlannerCandidateDiagnostic {
   buildItem: string;
   buildType: string;
@@ -101,6 +115,7 @@ export interface ConstructionPlannerBlockedPlacement {
   structureType: BuildableStructureConstant;
   blockedReason: ConstructionPlannerBlockerReason;
   candidate?: ConstructionPlannerCandidateDiagnostic;
+  details?: ConstructionPlannerBlockerDetails;
   result?: ScreepsReturnCode;
   x?: number;
   y?: number;
@@ -169,6 +184,11 @@ interface ResidualRoadSeedPlan {
   anchors: CandidatePosition[];
   lookups: ResidualRoadSeedLookups;
   roomName: string;
+}
+
+interface ResidualRoadSeedBlocker {
+  reason: ConstructionPlannerBlockerReason;
+  details?: ConstructionPlannerBlockerDetails;
 }
 
 interface SpawnPlacementResult {
@@ -690,7 +710,7 @@ function planResidualStoredEnergyRoadSeed(
 
   const blocker = getResidualStoredEnergyRoadSeedBlocker(colony, result, budgetState, options);
   if (blocker) {
-    recordBlockedPlacement(result, 'road', blocker, options);
+    recordBlockedPlacement(result, 'road', blocker.reason, options, { details: blocker.details });
     return;
   }
 
@@ -742,44 +762,86 @@ function getResidualStoredEnergyRoadSeedBlocker(
   result: RoomConstructionPlannerResult,
   budgetState: ConstructionBudgetState,
   options: ConstructionPlannerOptions
-): ConstructionPlannerBlockerReason | null {
+): ResidualRoadSeedBlocker | null {
   if (hasReachedPlacementLimit(result, options)) {
-    return 'residual_road_seed_placement_limit_reached';
+    return {
+      reason: 'residual_road_seed_placement_limit_reached',
+      details: {
+        successfulPlacementCount: countSuccessfulPlacements(result),
+        maxPlacementsPerRoom: getMaxPlacementsPerRoom(options)
+      }
+    };
   }
 
-  if (countPendingRoomConstructionSites(colony.room) > 0) {
-    return 'residual_road_seed_existing_site';
+  const pendingConstructionSiteCount = countPendingRoomConstructionSites(colony.room);
+  if (pendingConstructionSiteCount > 0) {
+    return {
+      reason: 'residual_road_seed_existing_site',
+      details: { pendingConstructionSiteCount }
+    };
   }
 
-  if (!shouldUseStoredEnergyConstructionSeedSlot(colony.room, budgetState)) {
-    return 'residual_road_seed_stored_energy_unavailable';
+  const storedEnergyAvailableForConstruction = getRoomStoredEnergyAvailableForConstruction(colony.room);
+  if (
+    budgetState.energyReserved > 0 ||
+    storedEnergyAvailableForConstruction < CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY
+  ) {
+    return {
+      reason: 'residual_road_seed_stored_energy_unavailable',
+      details: {
+        storedEnergyAvailableForConstruction,
+        storedEnergyMinimum: CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY,
+        pendingConstructionSiteCount,
+        successfulPlacementCount: countSuccessfulPlacements(result)
+      }
+    };
   }
 
-  if (!hasRemainingStructureCapacity(colony.room, 'road')) {
-    return 'residual_road_seed_road_capacity_full';
+  const remainingStructureCapacity = getRemainingStructureCapacity(colony.room, 'road');
+  if (remainingStructureCapacity <= 0) {
+    return {
+      reason: 'residual_road_seed_road_capacity_full',
+      details: { remainingStructureCapacity }
+    };
   }
 
-  if (!hasResidualConstructionWorkerCoverage(colony.room, options.creeps)) {
-    return 'residual_road_seed_worker_coverage_missing';
+  const workerCoverageCount = countResidualConstructionWorkerCoverage(colony.room, options.creeps);
+  if (workerCoverageCount < MIN_RESIDUAL_CONSTRUCTION_SEED_WORKERS) {
+    return {
+      reason: 'residual_road_seed_worker_coverage_missing',
+      details: {
+        workerCoverageCount,
+        workerCoverageMinimum: MIN_RESIDUAL_CONSTRUCTION_SEED_WORKERS
+      }
+    };
   }
 
-  if (!isResidualConstructionSeedRoomSafe(colony)) {
-    return 'residual_road_seed_room_unsafe';
+  const hostileThreatCount = countVisibleHostileThreats(colony.room);
+  const rcl = getOwnedRoomRcl(colony.room);
+  if (!isResidualConstructionSeedRoomSafe(colony, hostileThreatCount, rcl)) {
+    return {
+      reason: 'residual_road_seed_room_unsafe',
+      details: {
+        hostileThreatCount,
+        rcl,
+        ownedSpawnCount: countExistingStructures(colony.room, 'spawn') + colony.spawns.length
+      }
+    };
   }
 
   return null;
 }
 
-function hasResidualConstructionWorkerCoverage(room: Room, creeps: Creep[] | undefined): boolean {
-  return (
-    hasResidualConstructionWorkerEvidence(room.name, creeps) ||
-    hasResidualConstructionWorkerEvidence(room.name, findRoomObjects<Creep>(room, 'FIND_MY_CREEPS'))
+function countResidualConstructionWorkerCoverage(room: Room, creeps: Creep[] | undefined): number {
+  return Math.max(
+    countResidualConstructionWorkerEvidence(room.name, creeps),
+    countResidualConstructionWorkerEvidence(room.name, findRoomObjects<Creep>(room, 'FIND_MY_CREEPS'))
   );
 }
 
-function hasResidualConstructionWorkerEvidence(roomName: string, creeps: Creep[] | undefined): boolean {
-  if (!creeps || creeps.length < MIN_RESIDUAL_CONSTRUCTION_SEED_WORKERS) {
-    return false;
+function countResidualConstructionWorkerEvidence(roomName: string, creeps: Creep[] | undefined): number {
+  if (!creeps || creeps.length === 0) {
+    return 0;
   }
 
   let workers = 0;
@@ -790,11 +852,11 @@ function hasResidualConstructionWorkerEvidence(roomName: string, creeps: Creep[]
 
     workers += 1;
     if (workers >= MIN_RESIDUAL_CONSTRUCTION_SEED_WORKERS) {
-      return true;
+      return workers;
     }
   }
 
-  return false;
+  return workers;
 }
 
 function isResidualConstructionWorker(roomName: string, creep: Creep): boolean {
@@ -808,13 +870,17 @@ function isResidualConstructionWorker(roomName: string, creep: Creep): boolean {
   );
 }
 
-function isResidualConstructionSeedRoomSafe(colony: ColonySnapshot): boolean {
+function isResidualConstructionSeedRoomSafe(
+  colony: ColonySnapshot,
+  hostileThreatCount = countVisibleHostileThreats(colony.room),
+  rcl = getOwnedRoomRcl(colony.room)
+): boolean {
   const room = colony.room;
   return (
     room.controller?.my === true &&
-    getOwnedRoomRcl(room) >= 2 &&
+    rcl >= 2 &&
     hasOwnedSpawn(colony) &&
-    countVisibleHostileThreats(room) <= 0
+    hostileThreatCount <= 0
   );
 }
 
@@ -1709,6 +1775,7 @@ function recordBlockedPlacement(
   options: ConstructionPlannerOptions,
   context: {
     candidate?: ConstructionPriorityScore;
+    details?: ConstructionPlannerBlockerDetails;
     position?: CandidatePosition;
     result?: ScreepsReturnCode;
   } = {}
@@ -1723,6 +1790,7 @@ function recordBlockedPlacement(
     structureType: getStructureConstant(PRIORITY_STRUCTURE_TYPES[priority]),
     blockedReason,
     ...(context.candidate ? { candidate: toConstructionPlannerCandidateDiagnostic(context.candidate) } : {}),
+    ...(context.details ? { details: context.details } : {}),
     ...(context.result !== undefined ? { result: context.result } : {}),
     ...(context.position ? { x: context.position.x, y: context.position.y } : {})
   });
@@ -1761,7 +1829,11 @@ function hasReachedPlacementLimit(
     return false;
   }
 
-  return result.placements.filter((placement) => placement.result === getOkCode()).length >= maxPlacements;
+  return countSuccessfulPlacements(result) >= maxPlacements;
+}
+
+function countSuccessfulPlacements(result: RoomConstructionPlannerResult): number {
+  return result.placements.filter((placement) => placement.result === getOkCode()).length;
 }
 
 function getMaxPlacementsPerRoom(options: ConstructionPlannerOptions): number {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -589,6 +589,7 @@ function runClaimedRoomConstructionForCpuBudget(
     creeps,
     strategyRegistry: options.strategyRegistry,
     runtimeStrategyConstructionEnabled: options.runtimeStrategyConstructionEnabled,
+    emitConstructionBlockerDiagnostics: true,
     onStrategyRegistryRuntimeUse: options.onStrategyRegistryRuntimeUse
   };
   const activeConstructionOptions =
@@ -598,12 +599,12 @@ function runClaimedRoomConstructionForCpuBudget(
 
   if (deferred) {
     const result = planDeferredClaimedRoomCapacityConstruction(colony, activeConstructionOptions);
-    recordRecoveryConstructionPlacementTelemetry(telemetryEvents, result.placements, result.blockedPlacements, mode);
+    recordConstructionPlacementTelemetry(telemetryEvents, result.placements, result.blockedPlacements, mode);
     return;
   }
 
   const result = planClaimedRoomConstruction(colony, activeConstructionOptions);
-  recordRecoveryConstructionPlacementTelemetry(telemetryEvents, result.placements, result.blockedPlacements, mode);
+  recordConstructionPlacementTelemetry(telemetryEvents, result.placements, result.blockedPlacements, mode);
 }
 
 function selectConstructionCpuMode(cpuBudget: RuntimeCpuBudget): ConstructionCpuMode {
@@ -633,16 +634,12 @@ function buildCpuRecoveryConstructionSeedOptions(
   };
 }
 
-function recordRecoveryConstructionPlacementTelemetry(
+function recordConstructionPlacementTelemetry(
   telemetryEvents: RuntimeTelemetryEvent[],
   placements: ConstructionPlannerPlacement[],
   blockedPlacements: ConstructionPlannerBlockedPlacement[],
   mode: ConstructionCpuMode
 ): void {
-  if (mode !== 'recoverySeed') {
-    return;
-  }
-
   for (const placement of placements) {
     telemetryEvents.push({
       type: 'constructionPlacement',
@@ -650,7 +647,7 @@ function recordRecoveryConstructionPlacementTelemetry(
       priority: placement.priority,
       structureType: String(placement.structureType),
       result: placement.result,
-      mode: 'recoverySeed',
+      mode,
       ...(placement.x !== undefined ? { x: placement.x } : {}),
       ...(placement.y !== undefined ? { y: placement.y } : {})
     });
@@ -662,10 +659,11 @@ function recordRecoveryConstructionPlacementTelemetry(
       roomName: placement.roomName,
       priority: placement.priority,
       structureType: String(placement.structureType),
-      mode: 'recoverySeed',
+      mode,
       blockedReason: placement.blockedReason,
       ...(placement.result !== undefined ? { result: placement.result } : {}),
       ...(placement.candidate ? { candidate: placement.candidate } : {}),
+      ...(placement.details ? { details: placement.details } : {}),
       ...(placement.x !== undefined ? { x: placement.x } : {}),
       ...(placement.y !== undefined ? { y: placement.y } : {})
     });

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -15,6 +15,7 @@ import {
   type ConstructionPriorityUrgency
 } from '../construction/constructionPriority';
 import type {
+  ConstructionPlannerBlockerDetails,
   ConstructionPlannerBlockerReason,
   ConstructionPlannerCandidateDiagnostic
 } from '../construction/planner';
@@ -141,11 +142,15 @@ type RuntimeBuildBlockedReason =
 type RuntimeConstructionActivityState =
   | 'active'
   | 'candidate_suppressed'
+  | 'planner_blocked'
   | 'no_viable_candidate';
 type RuntimeConstructionActivityReason =
   | 'build_progress_observed'
   | 'build_energy_carried'
   | 'site_backlog_visible'
+  | 'site_placement_observed'
+  | 'site_placement_failed'
+  | 'planner_blocked'
   | 'cpu_shed'
   | 'energy_buffer_blocked'
   | 'spawn_reserving_energy'
@@ -308,7 +313,8 @@ export interface RuntimeConstructionPlacementTelemetryEvent {
   result?: ScreepsReturnCode;
   blockedReason?: ConstructionPlannerBlockerReason;
   candidate?: ConstructionPlannerCandidateDiagnostic;
-  mode: 'recoverySeed';
+  details?: ConstructionPlannerBlockerDetails;
+  mode: 'normal' | 'recoverySeed';
   x?: number;
   y?: number;
 }
@@ -670,6 +676,7 @@ interface RuntimeConstructionActivitySummary {
   buildBlockedReason?: RuntimeBuildBlockedReason;
   workerAssignmentBlockedDetail?: RuntimeWorkerAssignmentBlockedDetail;
   candidate?: RuntimeConstructionActivityCandidateSummary;
+  planner?: RuntimeConstructionActivityPlannerSummary;
   cpuPressure?: RuntimeCpuPressure;
   cpuReasons?: RuntimeCpuPressureReason[];
 }
@@ -680,6 +687,17 @@ interface RuntimeConstructionActivityCandidateSummary {
   score: number;
   urgency: ConstructionPriorityUrgency;
   policyAction?: ConstructionPriorityPolicyAction;
+}
+
+interface RuntimeConstructionActivityPlannerSummary {
+  mode: RuntimeConstructionPlacementTelemetryEvent['mode'];
+  priority: string;
+  structureType: string;
+  result?: ScreepsReturnCode;
+  blockedReason?: ConstructionPlannerBlockerReason;
+  details?: ConstructionPlannerBlockerDetails;
+  x?: number;
+  y?: number;
 }
 
 type RuntimeConstructionScoringSkipReason =
@@ -1074,6 +1092,7 @@ export function emitRuntimeSummary(
 
   creepsByColony ??= groupCreepsByColony(creeps, colonies);
   const reportedEvents = events.slice(0, MAX_REPORTED_EVENTS);
+  const constructionPlacementEventsByRoom = groupConstructionPlacementEventsByRoom(events);
   const persistOccupationRecommendations = options.persistOccupationRecommendations !== false;
   const includeOptionalSummary = !cpuBudget.lowCpuLimit && !shouldShedNonessentialCpuWork(cpuBudget);
   const includeConstructionScoring = shouldRunConstructionCpuWork(cpuBudget);
@@ -1086,6 +1105,7 @@ export function emitRuntimeSummary(
       shouldBuildStructureSnapshot(tick),
       options.strategyRegistry,
       options.onStrategyRegistryRuntimeUse,
+      constructionPlacementEventsByRoom.get(colony.room.name) ?? [],
       includeOptionalSummary,
       includeConstructionScoring,
       cpuBudget
@@ -1185,6 +1205,23 @@ function groupCreepsByColony(creeps: Creep[], colonies: ColonySnapshot[]): Map<s
   return creepsByColony;
 }
 
+function groupConstructionPlacementEventsByRoom(
+  events: RuntimeTelemetryEvent[]
+): Map<string, RuntimeConstructionPlacementTelemetryEvent[]> {
+  const eventsByRoom = new Map<string, RuntimeConstructionPlacementTelemetryEvent[]>();
+  for (const event of events) {
+    if (event.type !== 'constructionPlacement') {
+      continue;
+    }
+
+    const roomEvents = eventsByRoom.get(event.roomName) ?? [];
+    roomEvents.push(event);
+    eventsByRoom.set(event.roomName, roomEvents);
+  }
+
+  return eventsByRoom;
+}
+
 function addCreepToColonyGroup(creepsByColony: Map<string, Creep[]>, colonyName: string, creep: Creep): void {
   const colonyCreeps = creepsByColony.get(colonyName) ?? [];
   colonyCreeps.push(creep);
@@ -1235,6 +1272,7 @@ function summarizeRoom(
   includeStructureSnapshot: boolean,
   strategyRegistry: StrategyRegistryEntry[] | undefined,
   onStrategyRegistryRuntimeUse: ((entry: StrategyRegistryEntry) => void) | undefined,
+  constructionPlacementEvents: RuntimeConstructionPlacementTelemetryEvent[],
   includeOptionalSummary: boolean,
   includeConstructionScoring: boolean,
   cpuBudget: RuntimeCpuBudget
@@ -1281,6 +1319,7 @@ function summarizeRoom(
     resourcesWithoutActivity.productiveEnergy,
     constructionPriority,
     eventMetrics.resources,
+    selectLatestConstructionPlacementEvent(constructionPlacementEvents),
     cpuBudget
   );
   const resources: RuntimeResourceSummary = {
@@ -1533,10 +1572,14 @@ function summarizeConstructionActivity(
   productiveEnergy: RuntimeProductiveEnergySummary,
   constructionPriority: RuntimeConstructionPrioritySummary,
   events: RuntimeResourceEventSummary | undefined,
+  constructionPlacementEvent: RuntimeConstructionPlacementTelemetryEvent | undefined,
   cpuBudget: RuntimeCpuBudget
 ): RuntimeConstructionActivitySummary {
   const buildProgress = Math.max(0, Math.ceil(events?.builtProgress ?? 0));
   const candidate = selectViableConstructionActivityCandidate(constructionPriority);
+  const planner = constructionPlacementEvent
+    ? summarizeConstructionPlacementEvent(constructionPlacementEvent)
+    : undefined;
   const common = {
     source: 'runtime-summary' as const,
     constructionSiteCount: productiveEnergy.constructionSiteCount,
@@ -1551,6 +1594,7 @@ function summarizeConstructionActivity(
       ? { workerAssignmentBlockedDetail: productiveEnergy.workerAssignmentBlockedDetail }
       : {}),
     ...(candidate ? { candidate } : {}),
+    ...(planner ? { planner } : {}),
     ...(cpuBudget.pressure !== 'normal' ? { cpuPressure: cpuBudget.pressure } : {}),
     ...(cpuBudget.reasons.length > 0 ? { cpuReasons: cpuBudget.reasons } : {})
   };
@@ -1580,6 +1624,40 @@ function summarizeConstructionActivity(
       accepted: true,
       reason: selectConstructionActivitySuppressedReason(productiveEnergy, cpuBudget)
     };
+  }
+
+  if (
+    constructionPlacementEvent &&
+    productiveEnergy.constructionSiteCount <= 0 &&
+    productiveEnergy.pendingBuildProgress <= 0
+  ) {
+    const placementResult = constructionPlacementEvent.result;
+    if (constructionPlacementEvent.blockedReason) {
+      return {
+        ...common,
+        state: 'planner_blocked',
+        accepted: false,
+        reason: 'planner_blocked'
+      };
+    }
+
+    if (placementResult === 0) {
+      return {
+        ...common,
+        state: 'active',
+        accepted: true,
+        reason: 'site_placement_observed'
+      };
+    }
+
+    if (placementResult !== undefined) {
+      return {
+        ...common,
+        state: 'planner_blocked',
+        accepted: false,
+        reason: 'site_placement_failed'
+      };
+    }
   }
 
   if (productiveEnergy.constructionSiteCount > 0 && productiveEnergy.pendingBuildProgress <= 0) {
@@ -1614,6 +1692,27 @@ function summarizeConstructionActivity(
     state: 'no_viable_candidate',
     accepted: false,
     reason: 'no_viable_candidate'
+  };
+}
+
+function selectLatestConstructionPlacementEvent(
+  events: RuntimeConstructionPlacementTelemetryEvent[]
+): RuntimeConstructionPlacementTelemetryEvent | undefined {
+  return events[events.length - 1];
+}
+
+function summarizeConstructionPlacementEvent(
+  event: RuntimeConstructionPlacementTelemetryEvent
+): RuntimeConstructionActivityPlannerSummary {
+  return {
+    mode: event.mode,
+    priority: event.priority,
+    structureType: event.structureType,
+    ...(event.result !== undefined ? { result: event.result } : {}),
+    ...(event.blockedReason ? { blockedReason: event.blockedReason } : {}),
+    ...(event.details ? { details: event.details } : {}),
+    ...(event.x !== undefined ? { x: event.x } : {}),
+    ...(event.y !== undefined ? { y: event.y } : {})
   };
 }
 

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -1141,7 +1141,7 @@ export function shouldEmitRuntimeSummary(
     return tick > 0 && tick % DEGRADED_RUNTIME_SUMMARY_INTERVAL === 0;
   }
 
-  if (events.length > 0) {
+  if (hasImmediateRuntimeSummaryEvent(events)) {
     return true;
   }
 
@@ -1149,6 +1149,16 @@ export function shouldEmitRuntimeSummary(
     ? DEGRADED_RUNTIME_SUMMARY_INTERVAL
     : RUNTIME_SUMMARY_INTERVAL;
   return tick > 0 && tick % interval === 0;
+}
+
+function hasImmediateRuntimeSummaryEvent(events: RuntimeTelemetryEvent[]): boolean {
+  return events.some((event) => {
+    if (event.type !== 'constructionPlacement') {
+      return true;
+    }
+
+    return event.mode !== 'normal' || event.blockedReason === undefined;
+  });
 }
 
 function hasCriticalRuntimeSummaryEvent(events: RuntimeTelemetryEvent[]): boolean {

--- a/prod/test/constructionPlanner.test.ts
+++ b/prod/test/constructionPlanner.test.ts
@@ -1348,6 +1348,50 @@ describe('owned room construction planner', () => {
     expect(room.createConstructionSite).not.toHaveBeenCalled();
   });
 
+  it('reports the residual road worker-coverage gate with its threshold', () => {
+    installOpenTerrain();
+    const source = makeSource('source-a', 35, 35);
+    const { room, colony } = makeColony({
+      controllerLevel: 6,
+      energyAvailable: 0,
+      energyCapacityAvailable: 2_300,
+      structures: makeRecoveredRcl6ResidualConstructionStructures(source),
+      sources: [source],
+      pathsByTarget: {}
+    });
+
+    const result = planConstructionForColony(colony, {
+      respectRoomEnergyBuffer: true,
+      strategyRegistry: DEFAULT_STRATEGY_REGISTRY,
+      runtimeStrategyConstructionEnabled: true,
+      runtimeStrategyConstructionFallbackPriorities: false,
+      emitConstructionBlockerDiagnostics: true,
+      maxPlacementsPerRoom: 1,
+      maxContainerSitesPerTick: 1,
+      maxPendingContainerSites: 1,
+      roadOptions: {
+        maxSitesPerTick: 1,
+        maxPendingRoadSites: 1,
+        maxTargetsPerTick: 1
+      }
+    });
+
+    expect(result.placements).toEqual([]);
+    expect(result.blockedPlacements).toEqual([
+      {
+        priority: 'road',
+        roomName: 'W1N1',
+        structureType: TEST_GLOBALS.STRUCTURE_ROAD,
+        blockedReason: 'residual_road_seed_worker_coverage_missing',
+        details: {
+          workerCoverageCount: 0,
+          workerCoverageMinimum: 1
+        }
+      }
+    ]);
+    expect(room.createConstructionSite).not.toHaveBeenCalled();
+  });
+
   it('does not seed the residual stored-energy road under visible hostile pressure', () => {
     installOpenTerrain();
     const source = makeSource('source-a', 35, 35);

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -1911,6 +1911,109 @@ describe('runtime telemetry summaries', () => {
     expect(productiveEnergy.constructionActivity).toEqual(room.constructionActivity);
   });
 
+  it('reports a construction planner blocker instead of a generic no viable candidate state', () => {
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      includeEventLog: false
+    });
+    (colony.room.controller as StructureController).level = 1;
+
+    emitRuntimeSummary(
+      [colony],
+      [],
+      [
+        {
+          type: 'constructionPlacement',
+          roomName: 'W1N1',
+          priority: 'road',
+          structureType: TEST_GLOBALS.STRUCTURE_ROAD,
+          mode: 'normal',
+          blockedReason: 'residual_road_seed_worker_coverage_missing',
+          details: {
+            workerCoverageCount: 0,
+            workerCoverageMinimum: 1
+          }
+        }
+      ]
+    );
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    const productiveEnergy = (room.resources as Record<string, Record<string, unknown>>).productiveEnergy;
+    expect(room.constructionActivity).toMatchObject({
+      source: 'runtime-summary',
+      state: 'planner_blocked',
+      accepted: false,
+      reason: 'planner_blocked',
+      constructionSiteCount: 0,
+      pendingBuildProgress: 0,
+      buildCarriedEnergy: 0,
+      buildProgress: 0,
+      workerAssignmentEvidenceAvailable: true,
+      buildBlockedReason: 'no_construction_sites',
+      planner: {
+        mode: 'normal',
+        priority: 'road',
+        structureType: TEST_GLOBALS.STRUCTURE_ROAD,
+        blockedReason: 'residual_road_seed_worker_coverage_missing',
+        details: {
+          workerCoverageCount: 0,
+          workerCoverageMinimum: 1
+        }
+      }
+    });
+    expect(productiveEnergy.constructionActivity).toEqual(room.constructionActivity);
+  });
+
+  it('reports a successful construction placement as active while the new site is not yet visible', () => {
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      includeEventLog: false
+    });
+
+    emitRuntimeSummary(
+      [colony],
+      [],
+      [
+        {
+          type: 'constructionPlacement',
+          roomName: 'W1N1',
+          priority: 'road',
+          structureType: TEST_GLOBALS.STRUCTURE_ROAD,
+          mode: 'normal',
+          result: 0 as ScreepsReturnCode,
+          x: 18,
+          y: 23
+        }
+      ]
+    );
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    const productiveEnergy = (room.resources as Record<string, Record<string, unknown>>).productiveEnergy;
+    expect(room.constructionActivity).toMatchObject({
+      source: 'runtime-summary',
+      state: 'active',
+      accepted: true,
+      reason: 'site_placement_observed',
+      constructionSiteCount: 0,
+      pendingBuildProgress: 0,
+      buildCarriedEnergy: 0,
+      buildProgress: 0,
+      workerAssignmentEvidenceAvailable: true,
+      buildBlockedReason: 'no_construction_sites',
+      planner: {
+        mode: 'normal',
+        priority: 'road',
+        structureType: TEST_GLOBALS.STRUCTURE_ROAD,
+        result: 0,
+        x: 18,
+        y: 23
+      }
+    });
+    expect(productiveEnergy.constructionActivity).toEqual(room.constructionActivity);
+  });
+
   it('distinguishes visible construction sites without pending progress from absent construction sites', () => {
     const colony = makeColony({
       time: RUNTIME_SUMMARY_INTERVAL,

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -4538,6 +4538,25 @@ describe('runtime telemetry summaries', () => {
       damagedCriticalStructureCount: 1,
       tick: RUNTIME_SUMMARY_INTERVAL
     };
+    const normalConstructionBlockerEvent: RuntimeTelemetryEvent = {
+      type: 'constructionPlacement',
+      roomName: 'W1N1',
+      priority: 'road',
+      structureType: TEST_GLOBALS.STRUCTURE_ROAD,
+      mode: 'normal',
+      blockedReason: 'residual_road_seed_existing_site',
+      details: { pendingConstructionSiteCount: 1 }
+    };
+    const normalConstructionPlacementEvent: RuntimeTelemetryEvent = {
+      type: 'constructionPlacement',
+      roomName: 'W1N1',
+      priority: 'road',
+      structureType: TEST_GLOBALS.STRUCTURE_ROAD,
+      mode: 'normal',
+      result: 0 as ScreepsReturnCode,
+      x: 12,
+      y: 13
+    };
 
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [], lowBucketBudget)).toBe(false);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL * 5, [], lowBucketBudget)).toBe(true);
@@ -4559,6 +4578,9 @@ describe('runtime telemetry summaries', () => {
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [spawnEvent], overLimitBudget)).toBe(false);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL * 5, [spawnEvent], overLimitBudget)).toBe(true);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [safeModeEvent], overLimitBudget)).toBe(true);
+    expect(shouldEmitRuntimeSummary(1, [normalConstructionBlockerEvent])).toBe(false);
+    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [normalConstructionBlockerEvent])).toBe(true);
+    expect(shouldEmitRuntimeSummary(1, [normalConstructionPlacementEvent])).toBe(true);
   });
 
   it('reports construction-priority runtime use from runtime summary scoring', () => {

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -1965,6 +1965,36 @@ describe('runtime telemetry summaries', () => {
     expect(productiveEnergy.constructionActivity).toEqual(room.constructionActivity);
   });
 
+  it('does not emit an immediate runtime summary for a normal construction planner blocker', () => {
+    const colony = makeColony({
+      time: 1,
+      includeEventLog: false
+    });
+
+    const summary = emitRuntimeSummary(
+      [colony],
+      [],
+      [
+        {
+          type: 'constructionPlacement',
+          roomName: 'W1N1',
+          priority: 'road',
+          structureType: TEST_GLOBALS.STRUCTURE_ROAD,
+          mode: 'normal',
+          blockedReason: 'residual_road_seed_existing_site',
+          details: { pendingConstructionSiteCount: 1 }
+        }
+      ]
+    );
+
+    expect(summary).toBeUndefined();
+    expect(
+      logSpy.mock.calls.some(
+        ([message]) => typeof message === 'string' && message.startsWith(RUNTIME_SUMMARY_PREFIX)
+      )
+    ).toBe(false);
+  });
+
   it('reports a successful construction placement as active while the new site is not yet visible', () => {
     const colony = makeColony({
       time: RUNTIME_SUMMARY_INTERVAL,


### PR DESCRIPTION
## Summary
- surfaces construction planner site-seeding rejection details in runtime telemetry so `no_viable_candidate` can be diagnosed per room
- adjusts economy construction planning to preserve actionable candidate evidence for the post-recovery planner stall
- keeps normal blocked construction-placement diagnostics on scheduled runtime summaries without forcing per-tick event-triggered summaries
- adds construction planner and runtime-summary coverage for rejected site-seeding candidates and summary cadence behavior

## Verification
- `npm run typecheck`
- `npm test -- --runInBand` — 105 suites / 2417 tests passed
- `npm run build`
- `git diff --check`

Related issue: #1831

## Review-triage evidence
- Thread `PRRT_kwDOSMSsO86JPgqO`: classified `FIX` in `/tmp/pr1837-codex-triage.md`; commit `bd23aa160bb2492b93b061e07bed6af1bafe1fdb` prevents routine normal construction blocker diagnostics from waking runtime summaries every tick while preserving scheduled-summary visibility.

## Universal task Done gate
- [x] Task type: production code and telemetry test slice for construction planner diagnosis.
- [x] Expected observable outcome / named deliverable: runtime summaries expose planner site-seeding rejection details and tests cover candidate rejection telemetry plus immediate-summary cadence behavior.
- [x] Non-goals / accepted substitutes: no official MMO write, deploy, or issue closure is included in this branch.
- [x] Verification evidence required before Done: controller/Codex ran typecheck, Jest runInBand, build, and diff-check on commits c6fe8a80e73d41f447dad974c7bcdabc12f1d3cd and bd23aa160bb2492b93b061e07bed6af1bafe1fdb.
- [x] Project Evidence / Next action / Blocked by: issue 1831 and PR 1837 Project items record the current head, review thread, and gate route; next controller action is exact-head PR gate plus official deploy and runtime acceptance collection.
- [x] Post-merge/deploy/runtime proof: official deploy evidence and runtime-summary-console windows must show planner rejection detail, construction sites, or build task movement for acceptance.
- [x] Named deliverable proof: commits c6fe8a80 and bd23aa16 update planner, economy loop, runtime summary telemetry, tests, and generated bundle.
