### PR TITLE
economy: count direct stores for construction reserves

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3960,7 +3960,8 @@ function findRoomStructures(room) {
   const structures = [];
   for (const structure of [
     ...findRoomObjects5(room, "FIND_MY_STRUCTURES"),
-    ...findRoomObjects5(room, "FIND_STRUCTURES")
+    ...findRoomObjects5(room, "FIND_STRUCTURES"),
+    ...getDirectRoomStoreStructures(room)
   ]) {
     const stableId = getObjectId4(structure);
     if (stableId && seenIds.has(stableId)) {
@@ -3972,6 +3973,16 @@ function findRoomStructures(room) {
     structures.push(structure);
   }
   return structures;
+}
+function getDirectRoomStoreStructures(room) {
+  const roomStores = room;
+  const directStores = [
+    roomStores.storage,
+    roomStores.terminal
+  ];
+  return directStores.filter(
+    (structure) => structure !== void 0 && structure !== null
+  );
 }
 function findRoomObjects5(room, globalName) {
   const findConstant = globalThis[globalName];
@@ -3990,13 +4001,13 @@ function getStoredEnergy(target) {
   var _a2;
   const store = target == null ? void 0 : target.store;
   const energyResource = getEnergyResource2();
-  const usedCapacity = (_a2 = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a2.call(store, energyResource);
-  if (typeof usedCapacity === "number" && Number.isFinite(usedCapacity)) {
-    return Math.max(0, usedCapacity);
-  }
   const storedEnergy = store == null ? void 0 : store[energyResource];
   if (typeof storedEnergy === "number" && Number.isFinite(storedEnergy)) {
     return Math.max(0, storedEnergy);
+  }
+  const usedCapacity = (_a2 = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a2.call(store, energyResource);
+  if (typeof usedCapacity === "number" && Number.isFinite(usedCapacity)) {
+    return Math.max(0, usedCapacity);
   }
   const legacyEnergy = target == null ? void 0 : target.energy;
   return typeof legacyEnergy === "number" && Number.isFinite(legacyEnergy) ? Math.max(0, legacyEnergy) : 0;

--- a/prod/src/economy/energyBuffer.ts
+++ b/prod/src/economy/energyBuffer.ts
@@ -410,7 +410,8 @@ function findRoomStructures(room: Room): AnyStructure[] {
   const structures: AnyStructure[] = [];
   for (const structure of [
     ...findRoomObjects<AnyStructure>(room, 'FIND_MY_STRUCTURES'),
-    ...findRoomObjects<AnyStructure>(room, 'FIND_STRUCTURES')
+    ...findRoomObjects<AnyStructure>(room, 'FIND_STRUCTURES'),
+    ...getDirectRoomStoreStructures(room)
   ]) {
     const stableId = getObjectId(structure);
     if (stableId && seenIds.has(stableId)) {
@@ -424,6 +425,20 @@ function findRoomStructures(room: Room): AnyStructure[] {
   }
 
   return structures;
+}
+
+function getDirectRoomStoreStructures(room: Room): AnyStructure[] {
+  const roomStores = room as Room & {
+    storage?: StructureStorage | null;
+    terminal?: StructureTerminal | null;
+  };
+  const directStores: Array<StructureStorage | StructureTerminal | null | undefined> = [
+    roomStores.storage,
+    roomStores.terminal
+  ];
+  return directStores.filter(
+    (structure): structure is StructureStorage | StructureTerminal => structure !== undefined && structure !== null
+  );
 }
 
 function findRoomObjects<T>(room: Room, globalName: FindConstantGlobal): T[] {
@@ -452,14 +467,14 @@ function getStoredEnergy(target: unknown): number {
     } | null
   )?.store;
   const energyResource = getEnergyResource();
-  const usedCapacity = store?.getUsedCapacity?.(energyResource);
-  if (typeof usedCapacity === 'number' && Number.isFinite(usedCapacity)) {
-    return Math.max(0, usedCapacity);
-  }
-
   const storedEnergy = store?.[energyResource];
   if (typeof storedEnergy === 'number' && Number.isFinite(storedEnergy)) {
     return Math.max(0, storedEnergy);
+  }
+
+  const usedCapacity = store?.getUsedCapacity?.(energyResource);
+  if (typeof usedCapacity === 'number' && Number.isFinite(usedCapacity)) {
+    return Math.max(0, usedCapacity);
   }
 
   const legacyEnergy = (target as { energy?: unknown } | null)?.energy;

--- a/prod/test/constructionPlanner.test.ts
+++ b/prod/test/constructionPlanner.test.ts
@@ -30,6 +30,7 @@ const TEST_GLOBALS = {
   FIND_HOSTILE_CREEPS: 6,
   FIND_HOSTILE_STRUCTURES: 7,
   FIND_MY_CREEPS: 8,
+  RESOURCE_ENERGY: 'energy',
   LOOK_STRUCTURES: 'structure',
   LOOK_CONSTRUCTION_SITES: 'constructionSite',
   LOOK_MINERALS: 'mineral',
@@ -791,6 +792,62 @@ describe('owned room construction planner', () => {
     expect(result.placements.map((placement) => placement.priority)).toEqual(['extension']);
     expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
     expect(room.createConstructionSite).toHaveBeenCalledWith(9, 9, STRUCTURE_EXTENSION);
+  });
+
+  it('seeds a residual road from indexed stored energy when storage capacity APIs disagree', () => {
+    installOpenTerrain();
+    const source = makeSource('source-a', 35, 35);
+    const storage = makeStoredStructure(
+      'storage-existing',
+      TEST_GLOBALS.STRUCTURE_STORAGE,
+      18,
+      24,
+      2_000,
+      { indexedEnergy: 2_000, usedCapacityEnergy: 0 }
+    );
+    const { room, colony } = makeColony({
+      controllerLevel: 6,
+      energyAvailable: 0,
+      energyCapacityAvailable: 2_300,
+      structures: [
+        ...makeRecoveredRcl6ResidualConstructionStructures(source).filter(
+          (structure) => structure.id !== 'storage-existing'
+        ),
+        storage
+      ],
+      sources: [source],
+      pathsByTarget: {}
+    });
+
+    const result = planConstructionForColony(colony, {
+      creeps: makeWorkerCreeps(5),
+      respectRoomEnergyBuffer: true,
+      strategyRegistry: DEFAULT_STRATEGY_REGISTRY,
+      runtimeStrategyConstructionEnabled: true,
+      runtimeStrategyConstructionFallbackPriorities: false,
+      maxPlacementsPerRoom: 1,
+      maxContainerSitesPerTick: 1,
+      maxPendingContainerSites: 1,
+      roadOptions: {
+        maxSitesPerTick: 1,
+        maxPendingRoadSites: 1,
+        maxTargetsPerTick: 1
+      }
+    });
+
+    expect(result.placements).toEqual([
+      {
+        priority: 'road',
+        roomName: 'W1N1',
+        structureType: TEST_GLOBALS.STRUCTURE_ROAD,
+        result: OK_CODE,
+        energyReserved: 50,
+        x: 18,
+        y: 23
+      }
+    ]);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(18, 23, STRUCTURE_ROAD);
   });
 
   it('prioritizes spawn-only bootstrap extension construction while preserving worker spawn energy', () => {
@@ -1870,14 +1927,16 @@ function makeStoredStructure(
   structureType: StructureConstant,
   x: number,
   y: number,
-  energy: number
+  energy: number,
+  options: { indexedEnergy?: number; usedCapacityEnergy?: number } = {}
 ): Structure {
   return {
     id,
     structureType,
     pos: makeRoomPosition(x, y),
     store: {
-      getUsedCapacity: jest.fn().mockReturnValue(energy)
+      ...(options.indexedEnergy === undefined ? {} : { [TEST_GLOBALS.RESOURCE_ENERGY]: options.indexedEnergy }),
+      getUsedCapacity: jest.fn().mockReturnValue(options.usedCapacityEnergy ?? energy)
     }
   } as unknown as Structure;
 }

--- a/prod/test/energyBuffer.test.ts
+++ b/prod/test/energyBuffer.test.ts
@@ -6,6 +6,7 @@ import {
   getEffectiveRoomEnergyBufferThreshold,
   getRoomEnergyBufferHealth,
   getRoomEnergyBufferThreshold,
+  getRoomStoredEnergyAvailableForConstruction,
   getStorageEnergyAvailableForWithdrawal,
   getStorageEnergyReserveThreshold,
   MINIMUM_WORKER_SPAWN_ENERGY,
@@ -149,6 +150,19 @@ describe('energyBuffer', () => {
     expect(getStorageEnergyAvailableForWithdrawal(room, storage)).toBe(20);
     expect(withdrawFromStorage(room, 20)).toBe(true);
     expect(withdrawFromStorage(room, 21)).toBe(false);
+  });
+
+  it('counts direct indexed room storage for construction availability when structure scans miss it', () => {
+    const storage = makeStorage(1_200, { indexedEnergy: 1_200, usedCapacityEnergy: 0 });
+    const room = makeRoom({
+      level: 6,
+      energyAvailable: 2_300,
+      energyCapacityAvailable: 2_300,
+      storage,
+      includeStorageInFind: false
+    });
+
+    expect(getRoomStoredEnergyAvailableForConstruction(room)).toBe(400);
   });
 
   it('gates construction spending against spawn and extension energy', () => {
@@ -318,15 +332,20 @@ function makeRoom({
   energyCapacityAvailable,
   level,
   myStructures = [],
-  storage
+  storage,
+  includeStorageInFind = true
 }: {
   energyAvailable?: number;
   energyCapacityAvailable?: number;
   level?: number;
   myStructures?: AnyOwnedStructure[];
   storage?: StructureStorage;
+  includeStorageInFind?: boolean;
 }): Room {
-  const visibleStructures = storage ? [storage as unknown as AnyOwnedStructure, ...myStructures] : myStructures;
+  const visibleStructures =
+    storage && includeStorageInFind !== false
+      ? [storage as unknown as AnyOwnedStructure, ...myStructures]
+      : myStructures;
   return {
     name: 'W1N1',
     energyAvailable,
@@ -343,12 +362,18 @@ function makeRoom({
   } as unknown as Room;
 }
 
-function makeStorage(energy: number): StructureStorage {
+function makeStorage(
+  energy: number,
+  options: { indexedEnergy?: number; usedCapacityEnergy?: number } = {}
+): StructureStorage {
   return {
     id: 'storage1',
     structureType: 'storage',
     store: {
-      getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? energy : 0))
+      ...(options.indexedEnergy === undefined ? {} : { [RESOURCE_ENERGY]: options.indexedEnergy }),
+      getUsedCapacity: jest.fn((resource?: ResourceConstant) =>
+        resource === RESOURCE_ENERGY ? options.usedCapacityEnergy ?? energy : 0
+      )
     }
   } as unknown as StructureStorage;
 }


### PR DESCRIPTION
## Summary
- Count direct `room.storage` / `room.terminal` stores when computing construction reserve availability, even when the room's `find` fixtures omit them.
- Prefer indexed `store[RESOURCE_ENERGY]` before `getUsedCapacity(RESOURCE_ENERGY)` so reserve math matches runtime-summary evidence.
- Add regression coverage for residual road seeding and direct room storage reserve availability; rebuild `prod/dist/main.js`.

Refs #1831.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 105 suites / 2422 tests passed
- `cd prod && npm run build`

## Universal task Done gate
- [x] Task type: code
- [x] Expected observable outcome / named deliverable: construction reserve calculations see direct room storage/terminal energy and allow residual road site seeding when safe reserve energy exists
- [x] Non-goals / accepted substitutes: no extension-limit change, no expansion planner rewrite, no official deploy, no Project mutation by Codex
- [x] Verification evidence required before Done: controller ran diff-check, typecheck, Jest runInBand, and build on commit 00072b8bd3041832cc5dc425132096755e973ef3
- [x] Project Evidence / Next action / Blocked by: Project item for issue 1831 is In review with PR link, exact commit, green local verification, and next action to run exact-head CI plus automated review
- [x] Post-merge/deploy/runtime proof: official deploy and fresh runtime-summary acceptance should confirm construction planner no longer reports residual_road_seed_stored_energy_unavailable when stored energy is available
- [x] Named deliverable proof: commit 00072b8bd3041832cc5dc425132096755e973ef3 changes prod/src/economy/energyBuffer.ts, prod/test/constructionPlanner.test.ts, prod/test/energyBuffer.test.ts, and prod/dist/main.js with local verification passing
