### PR TITLE
worker: allow builders to pull distant storage energy

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -31275,7 +31275,7 @@ function findBuilderEnergyAcquisitionCandidates(creep, constructionSite) {
   const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
   const storedEnergyCandidates = findVisibleRoomStructures(creep.room).filter(
     (structure) => isSafeStoredEnergySource(structure, context) || isBuilderConstructionBufferSpawnSource(creep, structure, context, reservationContext) || isBuilderConstructionPreBufferExtension(creep, constructionSite, structure)
-  ).filter((source) => isConstructionSiteNearSource(constructionSite, source, BUILDER_STORAGE_ACQUISITION_SITE_RANGE)).flatMap((source) => {
+  ).filter((source) => isBuilderConstructionEnergySourceForSite(constructionSite, source)).flatMap((source) => {
     const candidate = createUnreservedBuilderStoredEnergyAcquisitionCandidate(
       creep,
       source,
@@ -31307,6 +31307,12 @@ function findBuilderEnergyAcquisitionCandidates(creep, constructionSite) {
     return candidate ? [toBuilderEnergyAcquisitionCandidate(candidate)] : [];
   }).sort(compareBuilderEnergyAcquisitionCandidates).slice(0, MAX_DROPPED_ENERGY_REACHABILITY_CHECKS).filter((candidate) => isReachable(creep, candidate.source));
   return [...storedEnergyCandidates, ...droppedEnergyCandidates].sort(compareBuilderEnergyAcquisitionCandidates);
+}
+function isBuilderConstructionEnergySourceForSite(constructionSite, source) {
+  return isConstructionSiteNearSource(constructionSite, source, BUILDER_STORAGE_ACQUISITION_SITE_RANGE) || isDurableBuilderStoredEnergySource(source);
+}
+function isDurableBuilderStoredEnergySource(source) {
+  return matchesStructureType19(source.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType19(source.structureType, "STRUCTURE_TERMINAL", "terminal");
 }
 function selectUnreservedConstructionBacklogEnergyTarget(creep, constructionSites, constructionReservationContext, priorityContext) {
   const candidates = constructionSites.filter(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -5639,7 +5639,7 @@ export function findBuilderEnergyAcquisitionCandidates(
         isBuilderConstructionBufferSpawnSource(creep, structure, context, reservationContext) ||
         isBuilderConstructionPreBufferExtension(creep, constructionSite, structure)
     )
-    .filter((source) => isConstructionSiteNearSource(constructionSite, source, BUILDER_STORAGE_ACQUISITION_SITE_RANGE))
+    .filter((source) => isBuilderConstructionEnergySourceForSite(constructionSite, source))
     .flatMap((source) => {
       const candidate = createUnreservedBuilderStoredEnergyAcquisitionCandidate(
         creep,
@@ -5682,6 +5682,25 @@ export function findBuilderEnergyAcquisitionCandidates(
     .filter((candidate) => isReachable(creep, candidate.source));
 
   return [...storedEnergyCandidates, ...droppedEnergyCandidates].sort(compareBuilderEnergyAcquisitionCandidates);
+}
+
+function isBuilderConstructionEnergySourceForSite(
+  constructionSite: ConstructionSite,
+  source: BuilderStoredEnergySource
+): boolean {
+  return (
+    isConstructionSiteNearSource(constructionSite, source, BUILDER_STORAGE_ACQUISITION_SITE_RANGE) ||
+    isDurableBuilderStoredEnergySource(source)
+  );
+}
+
+function isDurableBuilderStoredEnergySource(
+  source: BuilderStoredEnergySource
+): source is StructureStorage | StructureTerminal {
+  return (
+    matchesStructureType(source.structureType, 'STRUCTURE_STORAGE', 'storage') ||
+    matchesStructureType(source.structureType, 'STRUCTURE_TERMINAL', 'terminal')
+  );
 }
 
 function selectUnreservedConstructionBacklogEnergyTarget(

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1962,6 +1962,103 @@ describe('runWorker', () => {
     expect(withdraw).toHaveBeenCalledWith(container, RESOURCE_ENERGY, 50);
   });
 
+  it('retargets a retained generic secondary-room storage withdraw to distant construction recovery', () => {
+    const site = withRangeTo(
+      {
+        id: 'remote-road-site1',
+        my: true,
+        structureType: 'road',
+        progress: 4_453,
+        progressTotal: 5_000
+      } as ConstructionSite,
+      { storage1: 12 }
+    );
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 585_250 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(200_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 3_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N57',
+      energyAvailable: 1_800,
+      energyCapacityAvailable: 1_800,
+      controller,
+      storage,
+      find: jest.fn((type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [storage] as unknown as AnyOwnedStructure[];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [storage];
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+        }
+
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const withdraw = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'Builder',
+      memory: {
+        role: 'worker',
+        colony: 'E29N57',
+        task: { type: 'withdraw', targetId: 'storage1' as Id<AnyStoreStructure> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'storage1' ? 3 : 10))
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room,
+      withdraw,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    roomCreeps.push(creep);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Builder: creep },
+      rooms: { E29N57: room },
+      time: 2_111_243,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'remote-road-site1') {
+          return site;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({
+      type: 'withdraw',
+      targetId: 'storage1',
+      constructionSiteId: 'remote-road-site1'
+    });
+    expect(withdraw).toHaveBeenCalledWith(storage, RESOURCE_ENERGY, 100);
+  });
+
   it('signs an owned controller when controller management reports a missing signature', () => {
     const controller = {
       id: 'controller1',


### PR DESCRIPTION
## Linked issues

Intentional PR-body closing linkage:
- None.

Related / non-closing linkage:
- Related to issue 1831. This PR is a follow-up implementation slice for construction acceptance; the issue stays open for separate deploy/runtime acceptance proof.

## Domain / Kind

- Domain: Territory/Economy
- Kind: code

## Summary

- Allows builder construction energy acquisition to use durable storage/terminal sources even when the construction site is outside the short local acquisition radius.
- Adds regression coverage for a secondary-room builder retaining a storage withdraw task for distant construction recovery.
- Regenerates the Screeps bundle artifact.

## Verification

- [x] Local check: `git diff --check` passed.
- [x] Local check: `cd prod && npm run typecheck` passed.
- [x] Local check: `cd prod && npm test -- --runInBand` passed: 105 suites / 2425 tests.
- [x] Local check: `cd prod && npm run build` passed.
- [x] GitHub Project issue/PR fields are current (`Status`, `Evidence`, `Next action`; plus `Blocked by` when blocked).
- [x] Automated review has no blocking findings, or a CodeRabbit/Gemini reliability bypass is recorded with reviewer/head/reason; review threads are resolved/outdated/non-blocking. Gemini reported no feedback on exact head; CodeRabbit rate-limit/usage-credit skip recorded as exact-head reliability bypass; GraphQL threads=0.
- [x] QA gate: controller QA PASS — changed-file scope is prod task/test/bundle only; scoped secret scan hits none; local and GitHub checks passed.
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate

- [x] Task type: code behavior / bugfix.
- [x] Expected observable outcome / named deliverable: secondary-room builders can pull durable storage energy for distant construction recovery instead of staying in worker-assignment gap.
- [x] Non-goals / accepted substitutes: runtime acceptance, deployment, RL compute release, canary release, and full construction issue closure are separate tracked gates.
- [x] Verification evidence required before Done: local typecheck/tests/build passed at commit `21696beaf6dc50ca48b76bb507c5ec4013d16c47`; GitHub checks/review/QA use the normal PR gate.
- [x] Project Evidence / Next action / Blocked by: issue 1831 and PR 1845 Project items name commit `21696bea`, verification PASS, PR gate, deploy, and construction acceptance next steps.
- [x] Post-merge/deploy/runtime proof: runtime proof belongs to active issue 1831 acceptance gate; this PR supplies code/test/build evidence.
- [x] Named deliverable proof: test `retargets a retained generic secondary-room storage withdraw to distant construction recovery` covers the targeted worker behavior.

## Issue closure gate

For every issue linked above in the PR body with a closing keyword:

- [x] None.
- [x] No closed issue still needs post-merge validation, runtime/process proof, owner action, successor/follow-up work, partial-fix completion, or any other blocker.

## Runtime / deployment impact

- [ ] No gameplay/runtime/deployment impact.
- [x] Gameplay/runtime/deployment impact; Deployment Floor evidence or HELD blocker is recorded. This PR changes production worker construction behavior and will require official deploy plus all-room construction acceptance after merge.

## Notes

- Review/merge gates: wait at least 15 minutes after PR creation, require green checks, keep review threads resolved/outdated/non-blocking, and keep linked GitHub issue/PR/Project state current until merged or explicitly closed. CodeRabbit/Gemini can be bypassed only when unreliable/unavailable/non-substantive and the bypass evidence is recorded.
- Commit message contains no GitHub closing keyword for tracked issues.
