### PR TITLE
worker: continue stored-construction backlog under CPU shedding

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -27891,6 +27891,10 @@ function selectCriticalCpuWorkerTask(creep, cpuBudget) {
   if (storedProtectedConstructionTask) {
     return applyMinimumUsefulLoadPolicy(creep, storedProtectedConstructionTask);
   }
+  const storedProtectedConstructionBacklogTask = selectStoredProtectedConstructionBacklogTask(creep);
+  if (storedProtectedConstructionBacklogTask) {
+    return applyMinimumUsefulLoadPolicy(creep, storedProtectedConstructionBacklogTask);
+  }
   if (spawnOrExtensionEnergySink) {
     return {
       type: "transfer",
@@ -28016,8 +28020,66 @@ function selectStoredProtectedSourceContainerConstructionSite(creep, constructio
     { priorityContext }
   );
 }
-function selectCriticalCpuEnergyAcquisitionTask(creep) {
+function selectStoredProtectedConstructionBacklogTask(creep, constructionSites, constructionReservationContext) {
+  const constructionSite = selectStoredProtectedConstructionBacklogSite(
+    creep,
+    constructionSites,
+    constructionReservationContext
+  );
+  return constructionSite ? { type: "build", targetId: constructionSite.id } : null;
+}
+function selectStoredProtectedConstructionBacklogEnergyAcquisitionTask(creep) {
+  const constructionSite = selectStoredProtectedConstructionBacklogEnergyAcquisitionSite(creep);
+  if (!constructionSite) {
+    return null;
+  }
+  const candidates = findBuilderEnergyAcquisitionCandidates(creep, constructionSite);
+  if (candidates.length === 0) {
+    return null;
+  }
+  return candidates.sort(compareBuilderEnergyAcquisitionCandidates)[0].task;
+}
+function selectStoredProtectedConstructionBacklogEnergyAcquisitionSite(creep) {
+  const constructionSites = findConstructionSites(creep.room);
+  if (constructionSites.length === 0) {
+    return null;
+  }
+  const constructionReservationContext = createConstructionReservationContext(creep.room);
+  const priorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  const storedProtectedConstructionSites = constructionSites.filter(
+    (site) => canSpendOnStoredProtectedConstructionBacklog(creep, site, priorityContext)
+  );
+  return selectUnreservedConstructionBacklogEnergyTarget(
+    creep,
+    storedProtectedConstructionSites,
+    constructionReservationContext,
+    priorityContext
+  );
+}
+function selectStoredProtectedConstructionBacklogSite(creep, constructionSites, constructionReservationContext) {
+  const sites = constructionSites != null ? constructionSites : findConstructionSites(creep.room);
+  if (sites.length === 0) {
+    return null;
+  }
+  const reservations = constructionReservationContext != null ? constructionReservationContext : createConstructionReservationContext(creep.room);
+  const priorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, sites);
+  return selectUnreservedConstructionSite(
+    creep,
+    sites,
+    reservations,
+    (site) => canSpendOnStoredProtectedConstructionBacklog(creep, site, priorityContext),
+    { priorityContext }
+  );
+}
+function canSpendOnStoredProtectedConstructionBacklog(creep, site, priorityContext) {
   var _a2;
+  return site.my !== false && ((_a2 = creep.room.controller) == null ? void 0 : _a2.my) === true && !hasVisibleHostilePresence3(creep.room) && !shouldGuardControllerDowngrade2(creep.room.controller) && checkEnergyBufferForStoredConstructionSpending(creep.room) && isStoredProtectedConstructionBacklogSite(site, priorityContext);
+}
+function isStoredProtectedConstructionBacklogSite(site, priorityContext) {
+  return isRoadConstructionSite2(site) || isHighImpactConstructionSite(site, priorityContext);
+}
+function selectCriticalCpuEnergyAcquisitionTask(creep) {
+  var _a2, _b;
   if (getFreeEnergyCapacity9(creep) <= 0) {
     return null;
   }
@@ -28046,7 +28108,7 @@ function selectCriticalCpuEnergyAcquisitionTask(creep) {
   if (hasCriticalCpuRepairDemand(creep)) {
     return selectWorkerEnergyCriticalAcquisitionTask(creep);
   }
-  return selectStoredProtectedSourceContainerConstructionEnergyAcquisitionTask(creep);
+  return (_b = selectStoredProtectedSourceContainerConstructionEnergyAcquisitionTask(creep)) != null ? _b : selectStoredProtectedConstructionBacklogEnergyAcquisitionTask(creep);
 }
 function hasCriticalCpuRepairDemand(creep) {
   return selectCriticalOwnedSpawnRepairTarget(creep) !== null || selectEmergencyOwnedRampartRepairTarget(creep) !== null || selectThreatenedBarrierRepairTarget(creep) !== null || selectCriticalInfrastructureRepairTarget(creep) !== null;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -417,6 +417,11 @@ function selectCriticalCpuWorkerTask(creep: Creep, cpuBudget: RuntimeCpuBudget):
     return applyMinimumUsefulLoadPolicy(creep, storedProtectedConstructionTask);
   }
 
+  const storedProtectedConstructionBacklogTask = selectStoredProtectedConstructionBacklogTask(creep);
+  if (storedProtectedConstructionBacklogTask) {
+    return applyMinimumUsefulLoadPolicy(creep, storedProtectedConstructionBacklogTask);
+  }
+
   if (spawnOrExtensionEnergySink) {
     return {
       type: 'transfer',
@@ -596,6 +601,98 @@ function selectStoredProtectedSourceContainerConstructionSite(
   );
 }
 
+function selectStoredProtectedConstructionBacklogTask(
+  creep: Creep,
+  constructionSites?: ConstructionSite[],
+  constructionReservationContext?: ConstructionReservationContext
+): Extract<CreepTaskMemory, { type: 'build' }> | null {
+  const constructionSite = selectStoredProtectedConstructionBacklogSite(
+    creep,
+    constructionSites,
+    constructionReservationContext
+  );
+  return constructionSite ? { type: 'build', targetId: constructionSite.id } : null;
+}
+
+function selectStoredProtectedConstructionBacklogEnergyAcquisitionTask(
+  creep: Creep
+): BuilderEnergyAcquisitionTask | null {
+  const constructionSite = selectStoredProtectedConstructionBacklogEnergyAcquisitionSite(creep);
+  if (!constructionSite) {
+    return null;
+  }
+
+  const candidates = findBuilderEnergyAcquisitionCandidates(creep, constructionSite);
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  return candidates.sort(compareBuilderEnergyAcquisitionCandidates)[0].task;
+}
+
+function selectStoredProtectedConstructionBacklogEnergyAcquisitionSite(creep: Creep): ConstructionSite | null {
+  const constructionSites = findConstructionSites(creep.room);
+  if (constructionSites.length === 0) {
+    return null;
+  }
+
+  const constructionReservationContext = createConstructionReservationContext(creep.room);
+  const priorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
+  const storedProtectedConstructionSites = constructionSites.filter((site) =>
+    canSpendOnStoredProtectedConstructionBacklog(creep, site, priorityContext)
+  );
+
+  return selectUnreservedConstructionBacklogEnergyTarget(
+    creep,
+    storedProtectedConstructionSites,
+    constructionReservationContext,
+    priorityContext
+  );
+}
+
+function selectStoredProtectedConstructionBacklogSite(
+  creep: Creep,
+  constructionSites?: ConstructionSite[],
+  constructionReservationContext?: ConstructionReservationContext
+): ConstructionSite | null {
+  const sites = constructionSites ?? findConstructionSites(creep.room);
+  if (sites.length === 0) {
+    return null;
+  }
+
+  const reservations = constructionReservationContext ?? createConstructionReservationContext(creep.room);
+  const priorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, sites);
+  return selectUnreservedConstructionSite(
+    creep,
+    sites,
+    reservations,
+    (site) => canSpendOnStoredProtectedConstructionBacklog(creep, site, priorityContext),
+    { priorityContext }
+  );
+}
+
+function canSpendOnStoredProtectedConstructionBacklog(
+  creep: Creep,
+  site: ConstructionSite,
+  priorityContext: ConstructionSiteImpactPriorityContext
+): boolean {
+  return (
+    site.my !== false &&
+    creep.room.controller?.my === true &&
+    !hasVisibleHostilePresence(creep.room) &&
+    !shouldGuardControllerDowngrade(creep.room.controller) &&
+    checkEnergyBufferForStoredConstructionSpending(creep.room) &&
+    isStoredProtectedConstructionBacklogSite(site, priorityContext)
+  );
+}
+
+function isStoredProtectedConstructionBacklogSite(
+  site: ConstructionSite,
+  priorityContext: ConstructionSiteImpactPriorityContext
+): boolean {
+  return isRoadConstructionSite(site) || isHighImpactConstructionSite(site, priorityContext);
+}
+
 function selectCriticalCpuEnergyAcquisitionTask(
   creep: Creep
 ): Extract<CreepTaskMemory, { type: 'harvest' | 'pickup' | 'withdraw' }> | null {
@@ -637,7 +734,10 @@ function selectCriticalCpuEnergyAcquisitionTask(
     return selectWorkerEnergyCriticalAcquisitionTask(creep);
   }
 
-  return selectStoredProtectedSourceContainerConstructionEnergyAcquisitionTask(creep);
+  return (
+    selectStoredProtectedSourceContainerConstructionEnergyAcquisitionTask(creep) ??
+    selectStoredProtectedConstructionBacklogEnergyAcquisitionTask(creep)
+  );
 }
 
 function hasCriticalCpuRepairDemand(creep: Creep): boolean {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -14897,6 +14897,107 @@ describe('selectWorkerTask', () => {
     });
   });
 
+  it('keeps a loaded E29N57 road builder productive during low-bucket shedding when storage protects construction', () => {
+    const site = {
+      id: 'remote-road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 0,
+      progressTotal: 1_500,
+      pos: makeRoomPosition(32, 20, 'E29N57')
+    } as ConstructionSite;
+    const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 592_596, {
+      my: true,
+      pos: makeRoomPosition(35, 27, 'E29N57')
+    }) as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N57',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 1_800,
+      energyCapacityAvailable: 1_800,
+      structures: [storage as AnyStructure]
+    });
+    (room as { storage?: StructureStorage }).storage = storage;
+    const creep = {
+      name: 'LoadedRoadBuilder',
+      memory: { role: 'worker', colony: 'E29N57' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ LoadedRoadBuilder: creep });
+    setCpuBucket(948);
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'remote-road-site1' });
+  });
+
+  it('withdraws distant E29N56 storage energy for road construction during low-bucket shedding', () => {
+    const site = {
+      id: 'swamp-road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 275,
+      progressTotal: 1_500,
+      pos: {
+        ...makeRoomPosition(26, 27, 'E29N56'),
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'storage-surplus' ? 12 : 99))
+      }
+    } as unknown as ConstructionSite;
+    const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 605_307, {
+      my: true,
+      pos: makeRoomPosition(22, 25, 'E29N56')
+    }) as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N56',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      structures: [storage as AnyStructure]
+    });
+    (room as { storage?: StructureStorage }).storage = storage;
+    const creep = {
+      name: 'EmptyRoadBuilder',
+      memory: { role: 'worker', colony: 'E29N56' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      pos: {
+        ...makeRoomPosition(23, 25, 'E29N56'),
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'storage-surplus' ? 1 : 12))
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ EmptyRoadBuilder: creep });
+    setCpuBucket(948);
+
+    expect(selectWorkerTask(creep)).toEqual({
+      type: 'withdraw',
+      targetId: 'storage-surplus',
+      constructionSiteId: 'swamp-road-site1'
+    });
+  });
+
   it('refills uncovered E29N57 source-container construction from storage before spawn recovery', () => {
     const source = makeSource('source1', 20, 20, 'E29N57');
     const site = {


### PR DESCRIPTION
## Summary
- Keeps workers productive on stored-protected road/high-impact construction backlogs during critical CPU shedding.
- Adds E29N57 loaded-builder and E29N56 storage-withdraw regression coverage for the fresh post-#1845 construction acceptance gap.
- Rebuilds `prod/dist/main.js` from the verified source change.

Refs #1831.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`

## Universal task Done gate

- [x] Task type: bugfix
- [x] Expected observable outcome / named deliverable: stored-energy secondary-room construction workers can select build/withdraw work under critical CPU shedding instead of staying idle while construction backlog exists.
- [x] Non-goals / accepted substitutes: no new room expansion, no reward tuning, no Tencent/paid RL compute, and no postdeploy acceptance closure in this PR.
- [x] Verification evidence required before Done: controller verification passed locally on commit `46df3344f63b2bf51196fa414d68c693768cac9b` with diff check, typecheck, Jest, and build.
- [x] Project Evidence / Next action / Blocked by: issue and PR Project fields must remain current; issue #1831 stays active until official deploy plus fresh all-room construction acceptance evidence clears E29N56/E29N57.
- [x] Post-merge/deploy/runtime proof: not claimed by this PR; required follow-up is official deploy and fresh all-room runtime monitor showing no worker_assignment_gap_sustained plus build progress or build energy in E29N56/E29N57.
- [x] Named deliverable proof: source/tests/dist change implements the bounded #1831 follow-up; runtime acceptance remains on issue #1831.
