### PR TITLE
worker: stabilize secondary construction backlog recovery

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -30309,19 +30309,23 @@ function selectConstructionSite(creep, constructionSites, predicate = () => true
     ...buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites),
     ...options.priorityContext
   };
-  const candidates = constructionSites.filter(
-    (site) => predicate(site) && !isConstructionSiteSuppressedForWorker(creep, site) && canSpendCreepEnergyOnConstructionSite(creep, site, priorityContext) && (!options.requireReasonableRange || isConstructionSiteWithinReasonableRange(creep, site, DEFAULT_REASONABLE_CONSTRUCTION_SITE_RANGE))
+  const eligibleCandidates = constructionSites.filter(
+    (site) => predicate(site) && canSpendCreepEnergyOnConstructionSite(creep, site, priorityContext) && (!options.requireReasonableRange || isConstructionSiteWithinReasonableRange(creep, site, DEFAULT_REASONABLE_CONSTRUCTION_SITE_RANGE))
   );
-  if (candidates.length === 0) {
+  const candidates = eligibleCandidates.filter((site) => !isConstructionSiteSuppressedForWorker(creep, site));
+  const activeCandidates = candidates.length > 0 ? candidates : eligibleCandidates.filter(
+    (site) => shouldRetrySuppressedStoredProtectedConstructionBacklogSite(creep, site, eligibleCandidates, priorityContext)
+  );
+  if (activeCandidates.length === 0) {
     return null;
   }
   const position = creep.pos;
   if (typeof (position == null ? void 0 : position.getRangeTo) === "function") {
-    return [...candidates].sort(
+    return [...activeCandidates].sort(
       (left, right) => compareConstructionSiteCandidates(creep, left, right, constructionReservationContext, priorityContext)
     )[0];
   }
-  const topImpactCandidates = selectTopImpactConstructionSiteCandidates(candidates, priorityContext);
+  const topImpactCandidates = selectTopImpactConstructionSiteCandidates(activeCandidates, priorityContext);
   const finishPriorityConstructionSite = selectFinishPriorityConstructionSite(
     creep,
     topImpactCandidates,
@@ -30335,6 +30339,9 @@ function selectConstructionSite(creep, constructionSites, predicate = () => true
     return (_a2 = position.findClosestByRange(candidatesByStableId)) != null ? _a2 : candidatesByStableId[0];
   }
   return topImpactCandidates.sort(compareConstructionSiteId)[0];
+}
+function shouldRetrySuppressedStoredProtectedConstructionBacklogSite(creep, site, eligibleCandidates, priorityContext) {
+  return eligibleCandidates.length === 1 && getUsedEnergy2(creep) > 0 && canSpendOnStoredProtectedConstructionBacklog(creep, site, priorityContext);
 }
 function isConstructionSiteSuppressedForWorker(creep, site) {
   var _a2;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -3995,15 +3995,21 @@ function selectConstructionSite(
     ...buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites),
     ...options.priorityContext
   };
-  const candidates = constructionSites.filter(
+  const eligibleCandidates = constructionSites.filter(
     (site) =>
       predicate(site) &&
-      !isConstructionSiteSuppressedForWorker(creep, site) &&
       canSpendCreepEnergyOnConstructionSite(creep, site, priorityContext) &&
       (!options.requireReasonableRange ||
         isConstructionSiteWithinReasonableRange(creep, site, DEFAULT_REASONABLE_CONSTRUCTION_SITE_RANGE))
   );
-  if (candidates.length === 0) {
+  const candidates = eligibleCandidates.filter((site) => !isConstructionSiteSuppressedForWorker(creep, site));
+  const activeCandidates =
+    candidates.length > 0
+      ? candidates
+      : eligibleCandidates.filter((site) =>
+          shouldRetrySuppressedStoredProtectedConstructionBacklogSite(creep, site, eligibleCandidates, priorityContext)
+        );
+  if (activeCandidates.length === 0) {
     return null;
   }
 
@@ -4015,12 +4021,12 @@ function selectConstructionSite(
   }).pos;
 
   if (typeof position?.getRangeTo === 'function') {
-    return [...candidates].sort((left, right) =>
+    return [...activeCandidates].sort((left, right) =>
       compareConstructionSiteCandidates(creep, left, right, constructionReservationContext, priorityContext)
     )[0];
   }
 
-  const topImpactCandidates = selectTopImpactConstructionSiteCandidates(candidates, priorityContext);
+  const topImpactCandidates = selectTopImpactConstructionSiteCandidates(activeCandidates, priorityContext);
   const finishPriorityConstructionSite = selectFinishPriorityConstructionSite(
     creep,
     topImpactCandidates,
@@ -4036,6 +4042,19 @@ function selectConstructionSite(
   }
 
   return topImpactCandidates.sort(compareConstructionSiteId)[0];
+}
+
+function shouldRetrySuppressedStoredProtectedConstructionBacklogSite(
+  creep: Creep,
+  site: ConstructionSite,
+  eligibleCandidates: ConstructionSite[],
+  priorityContext: ConstructionSiteImpactPriorityContext
+): boolean {
+  return (
+    eligibleCandidates.length === 1 &&
+    getUsedEnergy(creep) > 0 &&
+    canSpendOnStoredProtectedConstructionBacklog(creep, site, priorityContext)
+  );
 }
 
 function isConstructionSiteSuppressedForWorker(creep: Creep, site: ConstructionSite): boolean {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1680,6 +1680,63 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'open-site' });
   });
 
+  it('retries the lone suppressed stored-protected road backlog instead of idling loaded workers', () => {
+    (globalThis as unknown as { FIND_MY_CREEPS: number }).FIND_MY_CREEPS = 10;
+    const roadSite = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 200,
+      progressTotal: 500,
+      pos: makeRoomPosition(22, 21, 'E29N57')
+    } as ConstructionSite;
+    const storage = makeStoredEnergyStructure('storage1', 'storage' as StructureConstant, 600_000);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const myCreeps: Creep[] = [];
+    const room = makeWorkerTaskRoom({
+      name: 'E29N57',
+      constructionSites: [roadSite],
+      controller,
+      energyAvailable: 650,
+      energyCapacityAvailable: 1_800,
+      myCreeps,
+      structures: [storage as AnyStructure]
+    });
+    const creep = {
+      name: 'LoadedBuilder',
+      memory: {
+        role: 'worker',
+        colony: 'E29N57',
+        blockedBuildTarget: {
+          targetId: 'road-site1',
+          blockedAt: 2114360,
+          until: 2114380,
+          reason: 'stuck'
+        }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 61 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 39 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      pos: { getRangeTo: jest.fn().mockReturnValue(4) },
+      room
+    } as unknown as Creep;
+    myCreeps.push(creep);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { LoadedBuilder: creep },
+      time: 2114374
+    };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
+  });
+
   it('lets spare loaded workers finish construction below the general spend floor', () => {
     const constructionSite = {
       id: 'extension-site',


### PR DESCRIPTION
Related to issue #1831.

## Summary
- Retry the lone suppressed stored-protected construction backlog site for loaded workers so secondary rooms do not idle through road/protected-site recovery.
- Add regression coverage for the E29N57-style stored-energy road backlog with a loaded worker and a blocked build target.
- Rebuild prod/dist/main.js.

## Verification
- git diff --check
- cd prod && npm run typecheck
- cd prod && npm test -- --runInBand (105 suites / 2428 tests passed)
- cd prod && npm run build

## Runtime evidence
- Fresh alert artifact: /root/screeps/runtime-artifacts/screeps-monitor/runtime-alert-20260613T031331Z/alert.json
- Fresh health gate: /root/screeps/runtime-artifacts/screeps-monitor/runtime-alert-20260613T031331Z/health-gate.json
- Fresh summary: /root/screeps/runtime-artifacts/screeps-monitor/runtime-alert-20260613T031331Z/summary.json

## Universal task Done gate

- [x] Task type: code hotfix PR for #1831 secondary-room construction assignment recovery.
- [x] Expected observable outcome / named deliverable: PR #1848 commit 8d7b757a adds a stored-protected backlog retry path plus Jest coverage for the E29N57-style road-site case.
- [x] Non-goals / accepted substitutes: no owner UI action, no credential/admin action, no destructive gameplay authorization, and no unrelated planner rewrite.
- [x] Verification evidence required before Done: `git diff --check`; `npm run typecheck`; `npm test -- --runInBand` (105 suites / 2428 tests passed); `npm run build` passed in `/root/screeps-worktrees/1831-post1847-residual-20260613T0303Z`.
- [x] Project Evidence / Next action / Blocked by: #1831 Project evidence was refreshed with runtime-alert-20260613T031331Z evidence; PR #1848 Project sync is queued for the GitHub GraphQL reset window; no owner action.
- [x] Post-merge/deploy/runtime proof: issue #1831 runtime acceptance remains governed by the all-room monitor artifacts listed above and the next official deploy evidence for this PR.
- [x] Named deliverable proof: https://github.com/lanyusea/screeps/pull/1848 at head `8d7b757a74dc348581af7ee0bc544fdab502c915`.
