### PR TITLE
worker: recover loaded secondary construction builders

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35201,7 +35201,7 @@ function shouldAllowAssignmentGapRecoveryBuildWorker(creep, currentTask, selecte
   if (hasUncoveredAssignmentGapConstructionProgress(creep, constructionSite)) {
     return true;
   }
-  return !currentTask && selectedTask === null && getFreeTransferEnergyCapacity(creep) <= 0;
+  return !currentTask && (selectedTask === null || selectedTask.type === "transfer") && getUsedTransferEnergy(creep) > 0;
 }
 function hasUncoveredAssignmentGapConstructionProgress(creep, constructionSite) {
   const pendingProgress = getRoomConstructionPendingProgress(creep.room);
@@ -35277,7 +35277,7 @@ function getBuildPower2() {
 function hasSafeAssignmentGapRecoveryConstructionEnergy(creep, recoveryTask) {
   const spawnReservationTarget = selectSpawnEnergyReservationRefillTarget(creep);
   if (spawnReservationTarget) {
-    return shouldDeferSpawnReservationRefillForProductiveWork(creep, recoveryTask, spawnReservationTarget);
+    return shouldDeferSpawnReservationRefillForProductiveWork(creep, recoveryTask, spawnReservationTarget) || hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room);
   }
   const hasStoredConstructionEnergy = hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room);
   const hasSafeConstructionEnergy = hasHealthyRoomEnergyBuffer2(creep.room) || hasStoredConstructionEnergy || hasCoveredStoredEnergyForAssignmentGapRecoveryConstruction(creep, getTaskTarget(recoveryTask));

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -602,7 +602,11 @@ function shouldAllowAssignmentGapRecoveryBuildWorker(
     return true;
   }
 
-  return !currentTask && selectedTask === null && getFreeTransferEnergyCapacity(creep) <= 0;
+  return (
+    !currentTask &&
+    (selectedTask === null || selectedTask.type === 'transfer') &&
+    getUsedTransferEnergy(creep) > 0
+  );
 }
 
 function hasUncoveredAssignmentGapConstructionProgress(creep: Creep, constructionSite: ConstructionSite): boolean {
@@ -714,7 +718,10 @@ function hasSafeAssignmentGapRecoveryConstructionEnergy(
 ): boolean {
   const spawnReservationTarget = selectSpawnEnergyReservationRefillTarget(creep);
   if (spawnReservationTarget) {
-    return shouldDeferSpawnReservationRefillForProductiveWork(creep, recoveryTask, spawnReservationTarget);
+    return (
+      shouldDeferSpawnReservationRefillForProductiveWork(creep, recoveryTask, spawnReservationTarget) ||
+      hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room)
+    );
   }
 
   const hasStoredConstructionEnergy = hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room);

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -8638,6 +8638,150 @@ describe('runWorker', () => {
     }
   });
 
+  it('recovers post-deploy E29N57 construction from loaded idle workers behind nominal build coverage', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 479,
+      progressTotal: 500,
+      pos: { x: 22, y: 21, roomName: 'E29N57' } as RoomPosition
+    } as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 250 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+      }
+    } as unknown as StructureSpawn;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 608_724 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(10_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N57',
+      energyAvailable: 1_200,
+      energyCapacityAvailable: 1_800,
+      controller,
+      storage,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn, storage] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [spawn, storage];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          if (type === FIND_HOSTILE_CREEPS) {
+            return [];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'LoadedIdleWorker',
+      memory: { role: 'worker', colony: 'E29N57' },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+      },
+      room,
+      build,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const existingBuilder = {
+      name: 'ExistingBuilder',
+      memory: {
+        role: 'worker',
+        colony: 'E29N57',
+        task: { type: 'build', targetId: 'road-site1' as Id<ConstructionSite> }
+      },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, existingBuilder);
+    const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(null);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      economy: {
+        spawnEnergyReservation: {
+          updatedAt: 2_116_688,
+          rooms: {
+            E29N57: {
+              bodyCost: 1_800,
+              creepName: 'worker-E29N57-next',
+              reservedAt: 2_116_688,
+              reservedEnergy: 1_800,
+              role: 'worker',
+              roomName: 'E29N57',
+              updatedAt: 2_116_688
+            }
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { LoadedIdleWorker: creep, ExistingBuilder: existingBuilder },
+      rooms: { E29N57: room },
+      time: 2_116_693,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        if (id === 'spawn1') {
+          return spawn;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({ type: 'build', targetId: 'road-site1' });
+      expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+        selectedTask: 'build',
+        assignedTask: 'build'
+      });
+      expect(build).toHaveBeenCalledWith(site);
+    } finally {
+      selectWorkerTask.mockRestore();
+    }
+  });
+
   it('recovers E29N56 storage construction while the spawn is active when stored energy covers construction', () => {
     const site = {
       id: 'storage-site1',


### PR DESCRIPTION
## Summary
- Allows loaded secondary-room workers to recover construction when normal task selection falls back to transfer/null despite an existing nominal builder.
- Lets stored-energy construction recovery bypass spawn-reservation deferral when the room storage has enough energy to cover construction safely.
- Adds a post-deploy E29N57 regression test for the loaded-idle-worker path and rebuilds `prod/dist/main.js`.

Refs #1831.

## Verification
- `git diff --check`
- `git diff HEAD^ HEAD --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (105 suites / 2429 tests)
- `cd prod && npm run build`
- Mechanical controller commit recovery used only after Codex commit-only session `019ebf72-13d4-76a1-8d4e-05de3a63543a` failed to write the linked worktree git index; Codex had inspected the hunks and controller verification passed before the mechanical commit preserving `lanyusea's bot <lanyusea@gmail.com>` authorship.

## Universal task Done gate

- [x] Task type: bugfix
- [x] Expected observable outcome / named deliverable: loaded secondary-room workers can take over construction recovery for E29N57/E29N56 residual worker-assignment gaps after PR #1848.
- [x] Non-goals / accepted substitutes: no RL reward tuning, no Tencent/paid compute, no new room expansion, and no claim that #1831 runtime acceptance is complete.
- [x] Verification evidence required before Done: local controller verification passed on commit `39db8660` with diff checks, typecheck, Jest, and build.
- [x] Project Evidence / Next action / Blocked by: PR and issue Project fields must stay current; #1831 remains active until merge, deploy, and fresh all-room construction acceptance evidence clears E29N56/E29N57.
- [x] Post-merge/deploy/runtime proof: not claimed by this PR; required follow-up is official deploy plus all-room monitor acceptance showing `health_gate.ok=true`, no `worker_assignment_gap_sustained`, and construction progress/build energy in E29N56/E29N57.
- [x] Named deliverable proof: source/test/dist change implements the bounded residual #1831 recovery path for loaded secondary-room builders; runtime acceptance stays on #1831.
