### PR TITLE
runtime-monitor: enforce all-room postdeploy construction gate

### DIFF
--- a/.github/workflows/official-screeps-deploy.yml
+++ b/.github/workflows/official-screeps-deploy.yml
@@ -24,7 +24,7 @@ on:
         type: boolean
         default: false
       confirmation:
-        description: "Required for deploy mode: deploy main to shardX/E29N55"
+        description: "Required for deploy mode: deploy main to shardX/E29N55 (primary upload target; postdeploy construction gate covers all owned rooms)."
         required: false
         type: string
 
@@ -127,7 +127,7 @@ jobs:
             --confirm "$CONFIRMATION" \
             --evidence-path "$EVIDENCE_DIR/official-screeps-deploy.json"
 
-      - name: Post-deploy live survival gate
+      - name: Post-deploy live all-owned-room health and construction gate
         if: ${{ inputs.mode == 'deploy' }}
         env:
           SCREEPS_AUTH_TOKEN: ${{ secrets.SCREEPS_AUTH_TOKEN }}
@@ -137,12 +137,10 @@ jobs:
         run: |
           mkdir -p runtime-artifacts/runtime-summary-console
           python3 scripts/screeps-runtime-monitor.py summary \
-            --room "$SCREEPS_SHARD/$SCREEPS_ROOM" \
             --out-dir runtime-artifacts/screeps-monitor \
             --runtime-summary-out-dir runtime-artifacts/runtime-summary-console \
             > "$EVIDENCE_DIR/postdeploy-summary.json"
           python3 scripts/screeps-runtime-monitor.py alert \
-            --room "$SCREEPS_SHARD/$SCREEPS_ROOM" \
             --out-dir runtime-artifacts/screeps-monitor \
             --runtime-summary-dir runtime-artifacts/runtime-summary-console \
             --force-alert-image \

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -369,6 +369,10 @@ NO_OWNED_SPAWN_REASON_KINDS = {
     "postdeploy_no_owned_spawn",
 }
 
+POSTDEPLOY_COLLECTION_ATTEMPT_WARNING_RE = re.compile(
+    r"\bcollection attempt (?P<attempt>\d+)/(?P<attempts>\d+) failed\b"
+)
+
 DEBOUNCE_BYPASS_REASON_KINDS = {
     "room_dead",
 }
@@ -7280,12 +7284,72 @@ def evaluate_postdeploy_construction_acceptance(room_summaries: Any) -> dict[str
     }
 
 
+def postdeploy_room_coverage_warning_reason(source: str, warning: Any) -> dict[str, Any] | None:
+    if not isinstance(warning, str):
+        return None
+    if warning.startswith("owned room discovery unavailable:"):
+        return {
+            "kind": "postdeploy_room_coverage_incomplete",
+            "source": source,
+            "message": f"{source}: owned-room discovery unavailable during post-deploy health capture",
+            "warning": warning,
+        }
+    if warning.startswith("falling back to configured room "):
+        return {
+            "kind": "postdeploy_room_coverage_incomplete",
+            "source": source,
+            "message": f"{source}: all-room health capture fell back to one configured room",
+            "warning": warning,
+        }
+
+    match = POSTDEPLOY_COLLECTION_ATTEMPT_WARNING_RE.search(warning)
+    if match is None:
+        return None
+    if int(match.group("attempt")) < int(match.group("attempts")):
+        return None
+    return {
+        "kind": "postdeploy_room_coverage_incomplete",
+        "source": source,
+        "message": f"{source}: a discovered room did not produce post-deploy health evidence",
+        "warning": warning,
+    }
+
+
+def postdeploy_room_coverage_reasons(payload: dict[str, Any], source: str) -> list[dict[str, Any]]:
+    if payload.get("room_scope") == "single-room":
+        return []
+
+    reasons: list[dict[str, Any]] = []
+    for warning in payload.get("warnings") if isinstance(payload.get("warnings"), list) else []:
+        reason = postdeploy_room_coverage_warning_reason(source, warning)
+        if reason is not None:
+            reasons.append(reason)
+
+    expected_rooms = string_list_values(payload.get("overview_rooms"))
+    collected_rooms = string_list_values(payload.get("rooms"))
+    missing_rooms = sorted(set(expected_rooms) - set(collected_rooms))
+    if missing_rooms:
+        reasons.append(
+            {
+                "kind": "postdeploy_room_coverage_incomplete",
+                "source": source,
+                "message": f"{source}: post-deploy health capture missed discovered owned rooms",
+                "missing_rooms": missing_rooms,
+                "expected_rooms": expected_rooms,
+                "collected_rooms": collected_rooms,
+            }
+        )
+    return reasons
+
+
 def evaluate_postdeploy_health_gate(summary_payload: dict[str, Any], alert_payload: dict[str, Any]) -> dict[str, Any]:
     reasons: list[dict[str, Any]] = []
     if summary_payload.get("ok") is not True:
         reasons.append({"kind": "postdeploy_summary_failed", "message": "post-deploy summary did not report ok=true"})
     if alert_payload.get("ok") is not True:
         reasons.append({"kind": "postdeploy_alert_failed", "message": "post-deploy alert did not report ok=true"})
+    reasons.extend(postdeploy_room_coverage_reasons(summary_payload, "summary"))
+    reasons.extend(postdeploy_room_coverage_reasons(alert_payload, "alert"))
     if alert_payload.get("alert") is True:
         for reason in alert_payload.get("reasons") if isinstance(alert_payload.get("reasons"), list) else []:
             if isinstance(reason, dict):
@@ -7371,7 +7435,7 @@ def command_health_gate(args: argparse.Namespace) -> int:
 
 def command_summary(args: argparse.Namespace) -> int:
     ctx = context_from_env(args.world_profile)
-    snapshots, warnings, _overview_refs = collect_snapshots(ctx, args.room)
+    snapshots, warnings, overview_refs = collect_snapshots(ctx, args.room)
     images: list[str] = []
     room_summaries: list[dict[str, Any]] = []
     out_dir = Path(args.out_dir)
@@ -7397,6 +7461,8 @@ def command_summary(args: argparse.Namespace) -> int:
         "summary": summarize_rooms(snapshots),
         "images": images,
         "rooms": [snapshot.ref.key for snapshot in snapshots],
+        "overview_rooms": [ref.key for ref in overview_refs],
+        "room_scope": "single-room" if args.room else "all-owned",
         "room_summaries": room_summaries,
         "runtime_summary_artifact": runtime_summary_artifact,
         "warnings": warnings,
@@ -7472,6 +7538,8 @@ def command_alert(args: argparse.Namespace) -> int:
         "reasons": all_emitted,
         "images": images,
         "rooms": [snapshot.ref.key for snapshot in snapshots],
+        "overview_rooms": [ref.key for ref in overview_refs],
+        "room_scope": "single-room" if args.room else "all-owned",
         "summary": summarize_rooms(snapshots),
         "room_summaries": [room_summary(snapshot) for snapshot in snapshots],
         "state_file": str(ctx.state_file),

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -8777,6 +8777,46 @@ def command_self_test(_args: argparse.Namespace) -> int:
 
             self.assertTrue(result["ok"])
 
+        def test_postdeploy_health_gate_rejects_secondary_room_construction_blocker(self) -> None:
+            result = evaluate_postdeploy_health_gate(
+                {
+                    "ok": True,
+                    "mode": "summary",
+                    "room_summaries": [
+                        {
+                            "room": "shardTest/E1N1",
+                            "owned_creeps": 2,
+                            "owned_spawns": 1,
+                            "owner": "owner",
+                            "constructionSiteCount": 0,
+                            "pendingBuildProgress": 0,
+                        },
+                        {
+                            "room": "shardTest/E2N2",
+                            "owned_creeps": 2,
+                            "owned_spawns": 1,
+                            "owner": "owner",
+                            "constructionSiteCount": 3,
+                            "pendingBuildProgress": 1200,
+                            "buildCarriedEnergy": 0,
+                            "buildProgress": 0,
+                            "taskCounts": {"build": 0},
+                            "buildBlockedReason": "no_build_execution",
+                        },
+                    ],
+                },
+                {"ok": True, "mode": "alert", "alert": False, "reasons": []},
+            )
+
+            construction = result["construction_acceptance"]
+            secondary = next(room for room in construction["rooms"] if room["room"] == "shardTest/E2N2")
+            self.assertFalse(result["ok"])
+            self.assertEqual(construction["status"], "blocked")
+            self.assertEqual(construction["pass_count"], 1)
+            self.assertEqual(construction["blocked_count"], 1)
+            self.assertEqual(secondary["status"], "blocked")
+            self.assertEqual(secondary["reason"], "no_build_execution")
+
         def test_postdeploy_health_gate_rejects_enemy_spawn_without_owned_recovery(self) -> None:
             result = evaluate_postdeploy_health_gate(
                 {

--- a/scripts/screeps_official_deploy.py
+++ b/scripts/screeps_official_deploy.py
@@ -37,7 +37,7 @@ DEFAULT_BRANCH = "main"
 DEFAULT_SHARD = world_profiles.PERSISTENT_DEFAULTS.shard
 DEFAULT_ROOM = world_profiles.PERSISTENT_DEFAULTS.room
 DEFAULT_TIMEOUT_SECONDS = 30
-DEFAULT_MONITOR_TIMEOUT_SECONDS = 120
+DEFAULT_MONITOR_TIMEOUT_SECONDS = 660
 DEFAULT_ROLLBACK_RECOVERY_TIMEOUT_SECONDS = 300
 DEFAULT_ROLLBACK_RECOVERY_POLL_SECONDS = 15
 AUTH_TOKEN_ENV = "SCREEPS_AUTH_TOKEN"
@@ -944,16 +944,15 @@ def run_postdeploy_health_gate(
 ) -> dict[str, Any]:
     """Capture post-deploy summary/alert evidence and evaluate the health gate."""
     cfg.evidence_dir.mkdir(parents=True, exist_ok=True)
-    room = f"{cfg.shard}/{cfg.room}"
     out_dir = cfg.repo_root / "runtime-artifacts" / "screeps-monitor"
     summary_path = cfg.evidence_dir / "postdeploy-summary.json"
     alert_path = cfg.evidence_dir / "postdeploy-alert.json"
     health_path = postdeploy_health_gate_path(cfg)
 
-    run_monitor_json(cfg, ["summary", "--room", room, "--out-dir", str(out_dir)], summary_path, env=env, runner=runner)
+    run_monitor_json(cfg, ["summary", "--out-dir", str(out_dir)], summary_path, env=env, runner=runner)
     run_monitor_json(
         cfg,
-        ["alert", "--room", room, "--out-dir", str(out_dir), "--force-alert-image"],
+        ["alert", "--out-dir", str(out_dir), "--force-alert-image"],
         alert_path,
         env=env,
         runner=runner,

--- a/scripts/screeps_official_deploy.py
+++ b/scripts/screeps_official_deploy.py
@@ -61,6 +61,7 @@ ROLLBACK_SOURCE_PATHS = (
     "prod/jest.config.cjs",
 )
 ROLLBACK_ISSUE_TITLE = "P0: Auto-rollback deployed after room_dead health gate failure"
+RoomTarget = tuple[str, str]
 
 
 class DeployError(RuntimeError):
@@ -1064,21 +1065,148 @@ def wait_for_room_recovery(
         sleeper(min(float(poll_seconds), remaining))
 
 
+def recovery_status_from_targets(payload: dict[str, Any], targets: list[RoomTarget]) -> dict[str, Any]:
+    """Return whether monitor JSON proves rollback recovery for every target."""
+    if len(targets) == 1:
+        shard, room = targets[0]
+        return recovery_status_from_payload(payload, shard, room)
+
+    rooms: list[dict[str, Any]] = []
+    for shard, room in targets:
+        status = recovery_status_from_payload(payload, shard, room)
+        status.setdefault("target", f"{shard}/{room}")
+        rooms.append(status)
+    return {
+        "ok": bool(rooms) and all(status.get("ok") is True for status in rooms),
+        "rooms": rooms,
+        "target_count": len(targets),
+        "recovered_count": sum(1 for status in rooms if status.get("ok") is True),
+    }
+
+
+def wait_for_recovery_targets(
+    targets: list[RoomTarget],
+    reader: Callable[[], dict[str, Any]],
+    *,
+    timeout_seconds: int,
+    poll_seconds: int,
+    sleeper: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> dict[str, Any]:
+    """Poll monitor JSON until every rollback-triggering room recovered."""
+    deadline = monotonic() + timeout_seconds
+    attempts = 0
+    last_status: dict[str, Any] = {"ok": False, "reason": "not checked"}
+    while True:
+        attempts += 1
+        last_status = recovery_status_from_targets(reader(), targets)
+        last_status["attempts"] = attempts
+        if last_status["ok"]:
+            return last_status
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            last_status["ok"] = False
+            last_status.setdefault("reason", "recovery verification timed out")
+            return last_status
+        sleeper(min(float(poll_seconds), remaining))
+
+
+def format_room_target(target: RoomTarget) -> str:
+    """Return a shard-qualified room target."""
+    shard, room = target
+    return f"{shard}/{room}"
+
+
+def room_target_from_value(value: Any, default_shard: str) -> RoomTarget | None:
+    """Parse a reason room value into a rollback recovery target."""
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    if "/" in text:
+        shard, room = text.split("/", 1)
+        if SHARD_RE.fullmatch(shard) and ROOM_RE.fullmatch(room):
+            return (shard, room)
+        return None
+    if ROOM_RE.fullmatch(text):
+        return (default_shard, text)
+    return None
+
+
+def rollback_trigger_room_targets_from_reason(
+    reason: Any,
+    default_shard: str,
+    inherited_room: Any = None,
+) -> list[RoomTarget]:
+    """Return rollback-triggering room targets from a health-gate reason tree."""
+    if not isinstance(reason, dict):
+        return []
+
+    room_value = reason.get("room", inherited_room)
+    targets: list[RoomTarget] = []
+    kind = reason.get("kind")
+    if isinstance(kind, str) and kind in ROLLBACK_TRIGGER_REASON_KINDS:
+        target = room_target_from_value(room_value, default_shard)
+        if target is not None:
+            targets.append(target)
+
+    source = reason.get("source")
+    if isinstance(source, dict):
+        targets.extend(rollback_trigger_room_targets_from_reason(source, default_shard, room_value))
+    return targets
+
+
+def auto_rollback_recovery_targets(cfg: DeployConfig, failed_health_gate: dict[str, Any]) -> list[RoomTarget]:
+    """Return rooms that must recover before auto-rollback is considered successful."""
+    targets: list[RoomTarget] = []
+    reasons = failed_health_gate.get("reasons")
+    if isinstance(reasons, list):
+        for reason in reasons:
+            reason_targets = rollback_trigger_room_targets_from_reason(reason, cfg.shard)
+            if not reason_targets and reason_triggers_auto_rollback(reason):
+                reason_targets = [(cfg.shard, cfg.room)]
+            for target in reason_targets:
+                if target not in targets:
+                    targets.append(target)
+    return targets or [(cfg.shard, cfg.room)]
+
+
 def make_runtime_summary_reader(
     cfg: DeployConfig,
     *,
+    target_rooms: list[RoomTarget] | None = None,
     env: dict[str, str] | None = None,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
 ) -> Callable[[], dict[str, Any]]:
     """Build a reader that captures fresh runtime summary JSON for recovery."""
-    room = f"{cfg.shard}/{cfg.room}"
     out_dir = cfg.repo_root / "runtime-artifacts" / "screeps-monitor"
     recovery_path = cfg.evidence_dir / "auto-rollback-recovery-summary.json"
+    targets = target_rooms or [(cfg.shard, cfg.room)]
+    room_args = ["--room", format_room_target(targets[0])] if len(targets) == 1 else []
 
     def read() -> dict[str, Any]:
-        return run_monitor_json(cfg, ["summary", "--room", room, "--out-dir", str(out_dir)], recovery_path, env=env, runner=runner)
+        return run_monitor_json(cfg, ["summary", *room_args, "--out-dir", str(out_dir)], recovery_path, env=env, runner=runner)
 
     return read
+
+
+def recovery_issue_summary(recovery: Any) -> str:
+    """Return a compact recovery summary for incident issue text."""
+    if not isinstance(recovery, dict):
+        return "unknown"
+    rooms = recovery.get("rooms")
+    if isinstance(rooms, list):
+        parts: list[str] = []
+        for room in rooms:
+            if not isinstance(room, dict):
+                continue
+            parts.append(
+                f"{room.get('room', room.get('target', 'unknown'))}: "
+                f"spawn={room.get('owned_spawns')} creeps={room.get('owned_creeps')} ok={room.get('ok')}"
+            )
+        return "; ".join(parts) or "unknown"
+    return f"spawn={recovery.get('owned_spawns')} creeps={recovery.get('owned_creeps')} ok={recovery.get('ok')}"
 
 
 def github_repository(repo_root: Path, env: dict[str, str] | None = None) -> str | None:
@@ -1142,7 +1270,8 @@ def build_auto_rollback_issue_body(cfg: DeployConfig, summary: dict[str, Any]) -
             f"- Previous deploy evidence: {summary.get('previousDeployEvidencePath', 'unknown')}",
             f"- Previous health gate evidence: {summary.get('previousHealthGateEvidencePath', 'unknown')}",
             f"- Rollback deploy evidence: {summary.get('rollbackDeployEvidencePath', 'unknown')}",
-            f"- Recovery: spawn={summary.get('recovery', {}).get('owned_spawns')} creeps={summary.get('recovery', {}).get('owned_creeps')}",
+            f"- Recovery targets: {', '.join(summary.get('recoveryTargets', [])) or summary.get('target', 'unknown')}",
+            f"- Recovery: {recovery_issue_summary(summary.get('recovery'))}",
         ]
     )
 
@@ -1211,10 +1340,15 @@ def execute_auto_rollback(
         rollback_evidence = run_deploy(rollback_cfg, env=env, transport=transport)
         write_json_object(rollback_deploy_path, rollback_evidence)
 
-        reader = recovery_reader or make_runtime_summary_reader(cfg, env=env, runner=command_runner)
-        recovery = wait_for_room_recovery(
-            cfg.shard,
-            cfg.room,
+        recovery_targets = auto_rollback_recovery_targets(cfg, failed_health_gate)
+        reader = recovery_reader or make_runtime_summary_reader(
+            cfg,
+            target_rooms=recovery_targets,
+            env=env,
+            runner=command_runner,
+        )
+        recovery = wait_for_recovery_targets(
+            recovery_targets,
             reader,
             timeout_seconds=cfg.rollback_recovery_timeout_seconds,
             poll_seconds=cfg.rollback_recovery_poll_seconds,
@@ -1230,6 +1364,7 @@ def execute_auto_rollback(
             "failedCommit": failed_commit or "unknown",
             "rollbackCommit": previous.commit,
             "triggerReasonKinds": trigger_reason_kinds(failed_health_gate),
+            "recoveryTargets": [format_room_target(target) for target in recovery_targets],
             "failedDeployEvidencePath": safe_path_for_repo(cfg.evidence_path, cfg.repo_root) if cfg.evidence_path else None,
             "failedHealthGateEvidencePath": safe_path_for_repo(postdeploy_health_gate_path(cfg), cfg.repo_root),
             "previousDeployEvidencePath": safe_path_for_repo(previous.deploy_path, cfg.repo_root),

--- a/scripts/test_screeps_official_deploy.py
+++ b/scripts/test_screeps_official_deploy.py
@@ -490,8 +490,10 @@ class OfficialDeployTest(unittest.TestCase):
                 evidence_path=deploy_path,
                 repo_root=repo_root,
             )
+            commands: list[list[str]] = []
 
             def command_runner(command: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+                commands.append(command)
                 return subprocess.CompletedProcess(command, 0, stdout='{"ok": true}\n', stderr="")
 
             health_gate = deploy.run_postdeploy_health_gate(cfg, env={}, runner=command_runner)
@@ -500,6 +502,11 @@ class OfficialDeployTest(unittest.TestCase):
             self.assertTrue(health_gate["ok"])
             self.assertTrue(paired_path.exists())
             self.assertFalse((evidence_dir / "postdeploy-health-gate.json").exists())
+            self.assertEqual(commands[0][1:3], [str(repo_root / "scripts" / "screeps-runtime-monitor.py"), "summary"])
+            self.assertNotIn("--room", commands[0])
+            self.assertEqual(commands[1][1:3], [str(repo_root / "scripts" / "screeps-runtime-monitor.py"), "alert"])
+            self.assertNotIn("--room", commands[1])
+            self.assertIn("--force-alert-image", commands[1])
 
     def test_postdeploy_health_gate_uses_default_path_without_deploy_evidence_path(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/test_screeps_official_deploy.py
+++ b/scripts/test_screeps_official_deploy.py
@@ -394,6 +394,52 @@ class OfficialDeployTest(unittest.TestCase):
         )
         self.assertFalse(deploy.health_gate_triggers_auto_rollback({"ok": True, "reasons": [{"kind": "room_dead"}]}))
 
+    def test_auto_rollback_recovery_targets_use_triggering_reason_rooms(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            artifact = self.write_artifact(Path(tmp))
+            cfg = self.config(artifact)
+
+            targets = deploy.auto_rollback_recovery_targets(
+                cfg,
+                {
+                    "ok": False,
+                    "reasons": [
+                        {"kind": "postdeploy_room_dead", "room": "shardX/E29N58"},
+                        {"kind": "postdeploy_no_owned_spawn", "room": "E29N59"},
+                        {"kind": "postdeploy_room_dead"},
+                        {
+                            "kind": "postdeploy_active_alert",
+                            "room": "E29N60",
+                            "source": {"kind": "room_dead"},
+                        },
+                        {"kind": "postdeploy_summary_failed", "room": "E1N1"},
+                        {"kind": "postdeploy_room_dead", "room": "shardX/E29N58"},
+                    ],
+                },
+            )
+
+        self.assertEqual(
+            targets,
+            [
+                ("shardX", "E29N58"),
+                ("shardX", "E29N59"),
+                ("shardX", "E19S57"),
+                ("shardX", "E29N60"),
+            ],
+        )
+
+    def test_auto_rollback_recovery_targets_fall_back_to_configured_room(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            artifact = self.write_artifact(Path(tmp))
+            cfg = self.config(artifact)
+
+            targets = deploy.auto_rollback_recovery_targets(
+                cfg,
+                {"ok": False, "reasons": [{"kind": "postdeploy_room_dead"}]},
+            )
+
+        self.assertEqual(targets, [("shardX", "E19S57")])
+
     def test_previous_evidence_lookup_finds_last_healthy_deploy(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             evidence_dir = Path(tmp)
@@ -524,6 +570,41 @@ class OfficialDeployTest(unittest.TestCase):
             self.assertTrue(health_gate["ok"])
             self.assertTrue(default_path.exists())
 
+    def test_recovery_summary_reader_scopes_single_target_and_collects_all_for_multiple_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            artifact = self.write_artifact(repo_root)
+            evidence_dir = repo_root / "runtime-artifacts" / "official-screeps-deploy"
+            cfg = self.config(artifact, evidence_dir=evidence_dir, repo_root=repo_root)
+            commands: list[list[str]] = []
+
+            def command_runner(command: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+                commands.append(command)
+                return subprocess.CompletedProcess(command, 0, stdout='{"ok": true}\n', stderr="")
+
+            single_reader = deploy.make_runtime_summary_reader(
+                cfg,
+                target_rooms=[("shardX", "E29N58")],
+                env={},
+                runner=command_runner,
+            )
+            single_reader()
+
+            self.assertIn("--room", commands[0])
+            self.assertIn("shardX/E29N58", commands[0])
+            self.assertNotIn("shardX/E19S57", commands[0])
+
+            commands.clear()
+            multi_reader = deploy.make_runtime_summary_reader(
+                cfg,
+                target_rooms=[("shardX", "E19S57"), ("shardX", "E29N58")],
+                env={},
+                runner=command_runner,
+            )
+            multi_reader()
+
+            self.assertNotIn("--room", commands[0])
+
     def test_recovery_verification_requires_spawn_and_owned_creep(self) -> None:
         recovered = deploy.recovery_status_from_payload(
             {
@@ -631,6 +712,70 @@ class OfficialDeployTest(unittest.TestCase):
         self.assertEqual(issues[0]["title"], deploy.ROLLBACK_ISSUE_TITLE)
         self.assertEqual(issues[0]["labels"], ["priority:p0"])
         self.assertTrue(rollback_deploy_written)
+
+    def test_auto_rollback_escalates_when_triggering_secondary_room_does_not_recover(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            evidence_dir = repo_root / "runtime-artifacts" / "official-screeps-deploy"
+            evidence_dir.mkdir(parents=True)
+            prod_dist = repo_root / "prod" / "dist"
+            prod_dist.mkdir(parents=True)
+            artifact_body = "module.exports.loop = function () { return 1; };\n"
+            artifact = self.write_artifact(prod_dist, artifact_body)
+            self.write_deploy_evidence(
+                evidence_dir,
+                "healthy",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                timestamp="2026-05-01T00:00:00Z",
+            )
+            cfg = self.config(
+                artifact,
+                deploy_mode=True,
+                activate_world=False,
+                confirm="deploy main to shardX/E19S57",
+                evidence_dir=evidence_dir,
+                repo_root=repo_root,
+            )
+            responses = [
+                deploy.HttpResult(200, {"ok": 1, "list": [{"branch": "main", "activeWorld": True}]}, {}),
+                deploy.HttpResult(200, {"ok": 1, "list": [{"branch": "main", "activeWorld": True}]}, {}),
+                deploy.HttpResult(200, {"ok": 1, "timestamp": 123}, {}),
+                deploy.HttpResult(200, {"ok": 1, "modules": {"main": artifact_body}}, {}),
+            ]
+            fake = FakeTransport(responses)
+            commands: list[list[str]] = []
+            monotonic_values = iter([0.0, 301.0])
+
+            def command_runner(command: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+                commands.append(command)
+                return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+            with self.assertRaisesRegex(deploy.DeployError, "AUTO-ROLLBACK ESCALATION") as raised:
+                deploy.execute_auto_rollback(
+                    cfg,
+                    {
+                        "git": {"commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+                        "target": self.deploy_target(),
+                    },
+                    {"ok": False, "reasons": [{"kind": "postdeploy_room_dead", "room": "shardX/E29N58"}]},
+                    env={deploy.AUTH_TOKEN_ENV: "fixture-value"},
+                    transport=fake,
+                    command_runner=command_runner,
+                    recovery_reader=lambda: {
+                        "ok": True,
+                        "room_summaries": [
+                            {"room": "shardX/E19S57", "owned_spawns": 1, "owned_creeps": 1},
+                            {"room": "shardX/E29N58", "owned_spawns": 0, "owned_creeps": 0},
+                        ],
+                    },
+                    issue_creator=lambda *_args: self.fail("no issue expected before recovery is verified"),
+                    sleeper=lambda _seconds: None,
+                    monotonic=lambda: next(monotonic_values),
+                )
+
+        self.assertIn("E29N58", str(raised.exception))
+        self.assertIn(["git", "checkout", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "--", *deploy.ROLLBACK_SOURCE_PATHS], commands)
+        self.assertIn(["npm", "run", "build"], commands)
 
     def test_auto_rollback_escalates_when_previous_evidence_is_missing(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/test_screeps_official_deploy.py
+++ b/scripts/test_screeps_official_deploy.py
@@ -544,13 +544,20 @@ class OfficialDeployTest(unittest.TestCase):
 
             health_gate = deploy.run_postdeploy_health_gate(cfg, env={}, runner=command_runner)
             paired_path = evidence_dir / "postdeploy-health-gate-rollback.json"
+            expected_out_dir = repo_root / "runtime-artifacts" / "screeps-monitor"
 
             self.assertTrue(health_gate["ok"])
             self.assertTrue(paired_path.exists())
             self.assertFalse((evidence_dir / "postdeploy-health-gate.json").exists())
             self.assertEqual(commands[0][1:3], [str(repo_root / "scripts" / "screeps-runtime-monitor.py"), "summary"])
+            self.assertIn("--out-dir", commands[0])
+            summary_out_dir_index = commands[0].index("--out-dir")
+            self.assertEqual(commands[0][summary_out_dir_index + 1], str(expected_out_dir))
             self.assertNotIn("--room", commands[0])
             self.assertEqual(commands[1][1:3], [str(repo_root / "scripts" / "screeps-runtime-monitor.py"), "alert"])
+            self.assertIn("--out-dir", commands[1])
+            alert_out_dir_index = commands[1].index("--out-dir")
+            self.assertEqual(commands[1][alert_out_dir_index + 1], str(expected_out_dir))
             self.assertNotIn("--room", commands[1])
             self.assertIn("--force-alert-image", commands[1])
 

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -961,6 +961,127 @@ class PostdeployConstructionAcceptanceTest(unittest.TestCase):
             {"ok": True, "mode": "alert", "alert": False, "reasons": []},
         )
 
+    def test_health_gate_fails_closed_on_owned_room_discovery_fallback(self) -> None:
+        health = monitor.evaluate_postdeploy_health_gate(
+            {
+                "ok": True,
+                "mode": "summary",
+                "rooms": ["shardX/E26S49"],
+                "room_summaries": [
+                    {
+                        "room": "shardX/E26S49",
+                        "owner": "owner",
+                        "owned_creeps": 2,
+                        "owned_spawns": 1,
+                        "constructionSiteCount": 0,
+                        "pendingBuildProgress": 0,
+                    }
+                ],
+                "warnings": [
+                    "owned room discovery unavailable: timeout",
+                    "falling back to configured room shardX/E26S49",
+                ],
+            },
+            {"ok": True, "mode": "alert", "alert": False, "reasons": [], "warnings": []},
+        )
+
+        self.assertFalse(health["ok"])
+        self.assertIn("postdeploy_room_coverage_incomplete", [reason["kind"] for reason in health["reasons"]])
+
+    def test_health_gate_fails_closed_when_discovered_room_is_not_collected(self) -> None:
+        health = monitor.evaluate_postdeploy_health_gate(
+            {
+                "ok": True,
+                "mode": "summary",
+                "rooms": ["shardX/E26S49"],
+                "overview_rooms": ["shardX/E26S49", "shardX/E27S49"],
+                "room_summaries": [
+                    {
+                        "room": "shardX/E26S49",
+                        "owner": "owner",
+                        "owned_creeps": 2,
+                        "owned_spawns": 1,
+                        "constructionSiteCount": 0,
+                        "pendingBuildProgress": 0,
+                    }
+                ],
+                "warnings": ["shardX/E27S49 collection attempt 3/3 failed: timeout"],
+            },
+            {
+                "ok": True,
+                "mode": "alert",
+                "alert": False,
+                "reasons": [],
+                "rooms": ["shardX/E26S49"],
+                "overview_rooms": ["shardX/E26S49", "shardX/E27S49"],
+            },
+        )
+
+        coverage_reasons = [
+            reason for reason in health["reasons"] if reason["kind"] == "postdeploy_room_coverage_incomplete"
+        ]
+        self.assertFalse(health["ok"])
+        self.assertTrue(coverage_reasons)
+        self.assertTrue(any(reason.get("missing_rooms") == ["shardX/E27S49"] for reason in coverage_reasons))
+
+    def test_health_gate_allows_non_coverage_monitor_warnings(self) -> None:
+        health = monitor.evaluate_postdeploy_health_gate(
+            {
+                "ok": True,
+                "mode": "summary",
+                "rooms": ["shardX/E26S49"],
+                "overview_rooms": ["shardX/E26S49"],
+                "room_summaries": [
+                    {
+                        "room": "shardX/E26S49",
+                        "owner": "owner",
+                        "owned_creeps": 2,
+                        "owned_spawns": 1,
+                        "constructionSiteCount": 0,
+                        "pendingBuildProgress": 0,
+                    }
+                ],
+                "warnings": ["summary image render failed for shardX/E26S49: renderer unavailable"],
+            },
+            {
+                "ok": True,
+                "mode": "alert",
+                "alert": False,
+                "reasons": [],
+                "rooms": ["shardX/E26S49"],
+                "overview_rooms": ["shardX/E26S49"],
+                "warnings": ["alert image render failed for shardX/E26S49: renderer unavailable"],
+            },
+        )
+
+        self.assertTrue(health["ok"])
+
+    def test_health_gate_allows_single_room_scope_with_overview_subset(self) -> None:
+        payload = {
+            "ok": True,
+            "rooms": ["shardX/E26S49"],
+            "overview_rooms": ["shardX/E26S49", "shardX/E27S49"],
+            "room_scope": "single-room",
+            "room_summaries": [
+                {
+                    "room": "shardX/E26S49",
+                    "owner": "owner",
+                    "owned_creeps": 2,
+                    "owned_spawns": 1,
+                    "constructionSiteCount": 0,
+                    "pendingBuildProgress": 0,
+                }
+            ],
+            "warnings": ["owned room discovery unavailable: timeout"],
+        }
+
+        health = monitor.evaluate_postdeploy_health_gate(
+            {"mode": "summary", **payload},
+            {"mode": "alert", "alert": False, "reasons": [], **payload},
+        )
+
+        self.assertTrue(health["ok"])
+
     def test_construction_acceptance_blocks_backlog_without_build_execution(self) -> None:
         health = self.health_gate_for_room(
             {


### PR DESCRIPTION
## Linked issues

Intentional PR-body closing linkage:
- None; #1846 should remain open until this workflow change is merged and a later deploy proves the all-owned-room gate in live postdeploy evidence.

Related / non-closing linkage:
- Refs #1846

## Domain / Kind

- Domain: Runtime monitor
- Kind: code

## Summary

- Make the official postdeploy monitor capture all owned rooms instead of passing `--room` for only the primary target.
- Extend `scripts/screeps_official_deploy.py` postdeploy health capture the same way and lengthen the monitor timeout for all-room evidence.
- Add regression coverage that a secondary-room construction blocker fails the postdeploy health gate.

## Verification

- [x] Local check: `git diff --check` passed.
- [x] Local check: `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/screeps_official_deploy.py scripts/test_screeps_official_deploy.py scripts/test_screeps_runtime_monitor_tactical_response.py` passed.
- [x] Local check: `python3 scripts/screeps-runtime-monitor.py self-test` passed (43 tests).
- [x] Local check: `python3 -m unittest scripts/test_screeps_official_deploy.py scripts/test_screeps_runtime_monitor_tactical_response.py` passed (151 tests).
- [x] Local check: workflow YAML parsed with PyYAML.
- [ ] GitHub Project issue/PR fields are current (`Status`, `Evidence`, `Next action`; plus `Blocked by` when blocked).
- [ ] Automated review has no blocking findings, or a CodeRabbit/Gemini reliability bypass is recorded with reviewer/head/reason; review threads are resolved/outdated/non-blocking.
- [ ] QA gate: pending after PR checks/review.
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate

- [x] Task type: code behavior / ops service.
- [x] Expected observable outcome / named deliverable: official deploy postdeploy summary/alert/health gate covers every owned room so secondary-room construction blockers fail the gate.
- [x] Non-goals / accepted substitutes: this hardens the release/postdeploy gate only; the separate worker-assignment bug tracked by issue 1831 remains owned by its own acceptance lane.
- [x] Verification evidence required before Done: local diff-check, py_compile, monitor self-test, deploy-script unit tests, tactical-response tests, workflow YAML parse, green PR checks, automated review gate.
- [x] Project Evidence / Next action / Blocked by: #1846 has a live Project item; this controller slice records commit `a09df6f6`, verification evidence, and the PR review/merge plus later deploy-proof gate as the current blocker.
- [x] Post-merge/deploy/runtime proof: required before closing #1846; leave #1846 open until a later official deploy produces all-owned-room postdeploy evidence from the merged workflow.
- [x] Named deliverable proof: workflow and deploy helper no longer pass a single `--room`; regression test proves secondary-room construction blockers make the health gate fail.

## Issue closure gate

For every issue linked above in the PR body with a closing keyword:

- [x] None.
- [x] No closed issue still needs post-merge validation, runtime/process proof, owner action, successor/follow-up work, partial-fix completion, or any other blocker.

## Runtime / deployment impact

- [ ] No gameplay/runtime/deployment impact.
- [x] Gameplay/runtime/deployment impact; Deployment Floor evidence or HELD blocker is recorded. This changes the official deploy workflow's postdeploy evidence scope only; it does not alter live Screeps bot behavior until the workflow runs after merge.

## Notes

- Commit `a09df6f6` is a controller mechanical recovery commit preserving Codex-authored dirty edits because `codex exec --profile max` could not write the linked worktree git index (`index.lock` read-only). Controller verification passed before the mechanical commit.
