### PR TITLE
worker: recover empty construction builders

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -36247,7 +36247,6 @@ function assignNextTask(creep) {
   return assignSelectedTask(creep, task);
 }
 function shouldReplaceTask(creep, task) {
-  var _a2, _b;
   if (isTerritoryControlTask2(task)) {
     return false;
   }
@@ -36257,11 +36256,11 @@ function shouldReplaceTask(creep, task) {
   if (task.type === "collectScore") {
     return false;
   }
-  if (!((_a2 = creep.store) == null ? void 0 : _a2.getUsedCapacity) || !((_b = creep.store) == null ? void 0 : _b.getFreeCapacity)) {
+  const usedEnergy = getObservedUsedTransferEnergy(creep);
+  const freeEnergyCapacity = getObservedFreeTransferEnergyCapacity(creep);
+  if (usedEnergy === null || freeEnergyCapacity === null) {
     return false;
   }
-  const usedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
-  const freeEnergyCapacity = creep.store.getFreeCapacity(RESOURCE_ENERGY);
   if (task.type === "harvest" || task.type === "pickup" || task.type === "withdraw") {
     if (isSourceContainerAssignedHarvestTask(task)) {
       const sourceContainer = findHarvestTaskSourceContainer(creep, task);
@@ -36298,18 +36297,18 @@ function shouldPreemptSpendingTaskForNearTermSpawnExtensionRefill(creep, task, s
   return selectedTask === null && isEnergySpendingTask(task) && shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep);
 }
 function shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, task, selectedTask) {
-  var _a2, _b, _c;
+  var _a2;
   if (!isEnergyAcquisitionTask2(task)) {
     return false;
   }
-  if (!((_a2 = creep.store) == null ? void 0 : _a2.getUsedCapacity) || !((_b = creep.store) == null ? void 0 : _b.getFreeCapacity)) {
+  if (typeof ((_a2 = creep.room) == null ? void 0 : _a2.find) !== "function") {
     return false;
   }
-  if (typeof ((_c = creep.room) == null ? void 0 : _c.find) !== "function") {
+  const usedEnergy = getObservedUsedTransferEnergy(creep);
+  const freeEnergyCapacity = getObservedFreeTransferEnergyCapacity(creep);
+  if (usedEnergy === null || freeEnergyCapacity === null) {
     return false;
   }
-  const usedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
-  const freeEnergyCapacity = creep.store.getFreeCapacity(RESOURCE_ENERGY);
   if (usedEnergy !== 0 || freeEnergyCapacity <= 0) {
     return false;
   }
@@ -36341,17 +36340,13 @@ function shouldPreemptEnergyAcquisitionTaskForProductiveBacklog(creep, task, sel
   return false;
 }
 function shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, task, selectedTask) {
-  var _a2;
   if (!isEnergyAcquisitionTask2(task)) {
     return false;
   }
   if (!selectedTask || isSameTask2(task, selectedTask)) {
     return false;
   }
-  if (!((_a2 = creep.store) == null ? void 0 : _a2.getUsedCapacity)) {
-    return false;
-  }
-  if (creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) {
+  if (getUsedTransferEnergy(creep) <= 0) {
     return false;
   }
   if (isDedicatedSourceContainerHarvestTask(creep, task)) {
@@ -36434,20 +36429,17 @@ function shouldPreemptLowLoadReturnTaskForEnergyAcquisition(creep, task, selecte
   return (sample == null ? void 0 : sample.type) === "nearbyEnergyChoice" && sample.selectedTask === selectedTask.type && sample.targetId === String(selectedTask.targetId) && isCurrentWorkerEfficiencySample(sample);
 }
 function shouldPreemptTransferTaskForBetterEnergySink(creep, task, selectedTask) {
-  var _a2, _b;
+  var _a2;
   if (task.type !== "transfer") {
     return false;
   }
   if ((selectedTask == null ? void 0 : selectedTask.type) !== "transfer" || isSameTask2(task, selectedTask)) {
     return false;
   }
-  if (!((_a2 = creep.store) == null ? void 0 : _a2.getUsedCapacity)) {
+  if (typeof ((_a2 = creep.room) == null ? void 0 : _a2.find) !== "function") {
     return false;
   }
-  if (typeof ((_b = creep.room) == null ? void 0 : _b.find) !== "function") {
-    return false;
-  }
-  if (creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) {
+  if (getUsedTransferEnergy(creep) <= 0) {
     return false;
   }
   const currentTarget = Game.getObjectById(task.targetId);
@@ -36675,19 +36667,17 @@ function isSpawnConstructionTaskTarget(target) {
 }
 function getFreeTransferEnergyCapacity(target) {
   var _a2;
-  const store = target == null ? void 0 : target.store;
-  const freeCapacity = (_a2 = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _a2.call(store, RESOURCE_ENERGY);
-  return typeof freeCapacity === "number" ? freeCapacity : 0;
+  return (_a2 = getKnownFreeTransferEnergyCapacity(target)) != null ? _a2 : 0;
 }
 function getUsedTransferEnergy(creep) {
-  var _a2, _b;
-  const usedCapacity = (_b = (_a2 = creep.store) == null ? void 0 : _a2.getUsedCapacity) == null ? void 0 : _b.call(_a2, RESOURCE_ENERGY);
-  return typeof usedCapacity === "number" && Number.isFinite(usedCapacity) ? Math.max(0, usedCapacity) : 0;
+  var _a2;
+  return (_a2 = getKnownStoredTransferEnergy(creep)) != null ? _a2 : 0;
 }
 function getObservedUsedTransferEnergy(creep) {
-  var _a2, _b;
-  const usedCapacity = (_b = (_a2 = creep.store) == null ? void 0 : _a2.getUsedCapacity) == null ? void 0 : _b.call(_a2, RESOURCE_ENERGY);
-  return typeof usedCapacity === "number" && Number.isFinite(usedCapacity) ? Math.max(0, usedCapacity) : null;
+  return getKnownStoredTransferEnergy(creep);
+}
+function getObservedFreeTransferEnergyCapacity(target) {
+  return getKnownFreeTransferEnergyCapacity(target);
 }
 function isSameRoomWorkerWithEnergy2(creep, room) {
   var _a2;
@@ -36789,6 +36779,23 @@ function getKnownStoredTransferEnergy(target) {
   }
   const legacyEnergy = target == null ? void 0 : target.energy;
   return typeof legacyEnergy === "number" && Number.isFinite(legacyEnergy) ? legacyEnergy : null;
+}
+function getKnownFreeTransferEnergyCapacity(target) {
+  var _a2, _b;
+  const store = target == null ? void 0 : target.store;
+  if (!store) {
+    return null;
+  }
+  const freeCapacity = (_a2 = store.getFreeCapacity) == null ? void 0 : _a2.call(store, RESOURCE_ENERGY);
+  if (typeof freeCapacity === "number" && Number.isFinite(freeCapacity)) {
+    return Math.max(0, freeCapacity);
+  }
+  const capacity = (_b = store.getCapacity) == null ? void 0 : _b.call(store, RESOURCE_ENERGY);
+  const usedEnergy = getKnownStoredTransferEnergy(target);
+  if (typeof capacity === "number" && Number.isFinite(capacity) && capacity >= 0 && usedEnergy !== null) {
+    return Math.max(0, capacity - usedEnergy);
+  }
+  return null;
 }
 function matchesTransferSinkStructureType(actual, globalName, fallback) {
   var _a2;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -2166,12 +2166,11 @@ function shouldReplaceTask(creep: Creep, task: CreepTaskMemory): boolean {
     return false;
   }
 
-  if (!creep.store?.getUsedCapacity || !creep.store?.getFreeCapacity) {
+  const usedEnergy = getObservedUsedTransferEnergy(creep);
+  const freeEnergyCapacity = getObservedFreeTransferEnergyCapacity(creep);
+  if (usedEnergy === null || freeEnergyCapacity === null) {
     return false;
   }
-
-  const usedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
-  const freeEnergyCapacity = creep.store.getFreeCapacity(RESOURCE_ENERGY);
 
   if (task.type === 'harvest' || task.type === 'pickup' || task.type === 'withdraw') {
     if (isSourceContainerAssignedHarvestTask(task)) {
@@ -2263,16 +2262,15 @@ function shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(
     return false;
   }
 
-  if (!creep.store?.getUsedCapacity || !creep.store?.getFreeCapacity) {
-    return false;
-  }
-
   if (typeof creep.room?.find !== 'function') {
     return false;
   }
 
-  const usedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
-  const freeEnergyCapacity = creep.store.getFreeCapacity(RESOURCE_ENERGY);
+  const usedEnergy = getObservedUsedTransferEnergy(creep);
+  const freeEnergyCapacity = getObservedFreeTransferEnergyCapacity(creep);
+  if (usedEnergy === null || freeEnergyCapacity === null) {
+    return false;
+  }
   if (usedEnergy !== 0 || freeEnergyCapacity <= 0) {
     return false;
   }
@@ -2352,11 +2350,7 @@ function shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(
     return false;
   }
 
-  if (!creep.store?.getUsedCapacity) {
-    return false;
-  }
-
-  if (creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) {
+  if (getUsedTransferEnergy(creep) <= 0) {
     return false;
   }
 
@@ -2510,15 +2504,11 @@ function shouldPreemptTransferTaskForBetterEnergySink(
     return false;
   }
 
-  if (!creep.store?.getUsedCapacity) {
-    return false;
-  }
-
   if (typeof creep.room?.find !== 'function') {
     return false;
   }
 
-  if (creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) {
+  if (getUsedTransferEnergy(creep) <= 0) {
     return false;
   }
 
@@ -2885,20 +2875,19 @@ function isSpawnConstructionTaskTarget(target: unknown): target is ConstructionS
 }
 
 function getFreeTransferEnergyCapacity(target: unknown): number {
-  const store = (target as { store?: { getFreeCapacity?: (resource?: ResourceConstant) => number | null } } | null)
-    ?.store;
-  const freeCapacity = store?.getFreeCapacity?.(RESOURCE_ENERGY);
-  return typeof freeCapacity === 'number' ? freeCapacity : 0;
+  return getKnownFreeTransferEnergyCapacity(target) ?? 0;
 }
 
 function getUsedTransferEnergy(creep: Creep): number {
-  const usedCapacity = creep.store?.getUsedCapacity?.(RESOURCE_ENERGY);
-  return typeof usedCapacity === 'number' && Number.isFinite(usedCapacity) ? Math.max(0, usedCapacity) : 0;
+  return getKnownStoredTransferEnergy(creep) ?? 0;
 }
 
 function getObservedUsedTransferEnergy(creep: Creep): number | null {
-  const usedCapacity = creep.store?.getUsedCapacity?.(RESOURCE_ENERGY);
-  return typeof usedCapacity === 'number' && Number.isFinite(usedCapacity) ? Math.max(0, usedCapacity) : null;
+  return getKnownStoredTransferEnergy(creep);
+}
+
+function getObservedFreeTransferEnergyCapacity(target: unknown): number | null {
+  return getKnownFreeTransferEnergyCapacity(target);
 }
 
 function isSameRoomWorkerWithEnergy(creep: Creep, room: Room): boolean {
@@ -3019,6 +3008,8 @@ function getKnownStoredTransferEnergy(target: unknown): number | null {
   const store = (
     target as {
       store?: {
+        getCapacity?: (resource?: ResourceConstant) => number | null;
+        getFreeCapacity?: (resource?: ResourceConstant) => number | null;
         getUsedCapacity?: (resource?: ResourceConstant) => number | null;
         [resource: string]: unknown;
       };
@@ -3036,6 +3027,40 @@ function getKnownStoredTransferEnergy(target: unknown): number | null {
 
   const legacyEnergy = (target as { energy?: unknown } | null)?.energy;
   return typeof legacyEnergy === 'number' && Number.isFinite(legacyEnergy) ? legacyEnergy : null;
+}
+
+function getKnownFreeTransferEnergyCapacity(target: unknown): number | null {
+  const store = (
+    target as {
+      store?: {
+        getCapacity?: (resource?: ResourceConstant) => number | null;
+        getFreeCapacity?: (resource?: ResourceConstant) => number | null;
+        getUsedCapacity?: (resource?: ResourceConstant) => number | null;
+        [resource: string]: unknown;
+      };
+    } | null
+  )?.store;
+  if (!store) {
+    return null;
+  }
+
+  const freeCapacity = store.getFreeCapacity?.(RESOURCE_ENERGY);
+  if (typeof freeCapacity === 'number' && Number.isFinite(freeCapacity)) {
+    return Math.max(0, freeCapacity);
+  }
+
+  const capacity = store.getCapacity?.(RESOURCE_ENERGY);
+  const usedEnergy = getKnownStoredTransferEnergy(target);
+  if (
+    typeof capacity === 'number' &&
+    Number.isFinite(capacity) &&
+    capacity >= 0 &&
+    usedEnergy !== null
+  ) {
+    return Math.max(0, capacity - usedEnergy);
+  }
+
+  return null;
 }
 
 function matchesTransferSinkStructureType(

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -9545,6 +9545,163 @@ describe('runWorker', () => {
     expect(transfer).not.toHaveBeenCalled();
   });
 
+  it('preempts an empty retained build assignment for construction energy acquisition', () => {
+    const source = {
+      id: 'source1',
+      pos: { x: 20, y: 20, roomName: 'E29N57' } as RoomPosition
+    } as Source;
+    const site = {
+      id: 'site1',
+      structureType: 'container',
+      progress: 500,
+      progressTotal: 5_000,
+      pos: {
+        x: 20,
+        y: 21,
+        roomName: 'E29N57',
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'stored-container1' ? 1 : 99))
+      } as unknown as RoomPosition
+    } as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(300),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      }
+    } as unknown as StructureSpawn;
+    const storedContainer = {
+      id: 'stored-container1',
+      structureType: 'container',
+      pos: { x: 20, y: 22, roomName: 'E29N57' } as RoomPosition,
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 2_217 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) =>
+          resource === undefined || resource === RESOURCE_ENERGY ? 2_500 : 0
+        )
+      }
+    } as unknown as StructureContainer;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N57',
+      energyAvailable: 909,
+      energyCapacityAvailable: 1_800,
+      controller,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [spawn, storedContainer];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          if (type === FIND_SOURCES) {
+            return [source];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn();
+    const withdraw = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'EmptyBuilder',
+      memory: {
+        role: 'worker',
+        colony: 'E29N57',
+        task: { type: 'build', targetId: 'site1' as Id<ConstructionSite> }
+      },
+      pos: { getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'stored-container1' ? 1 : 99)) },
+      store: {
+        [RESOURCE_ENERGY]: 0,
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room,
+      build,
+      withdraw,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const reserveWorker = {
+      name: 'ReserveWorker',
+      memory: { role: 'worker', colony: 'E29N57' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, reserveWorker);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      economy: {
+        spawnEnergyReservation: {
+          updatedAt: 123,
+          rooms: {
+            E29N57: {
+              bodyCost: 800,
+              creepName: 'worker-E29N57-124',
+              reservedAt: 123,
+              reservedEnergy: 800,
+              role: 'worker',
+              roomName: 'E29N57',
+              updatedAt: 123
+            }
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { EmptyBuilder: creep, ReserveWorker: reserveWorker },
+      rooms: { E29N57: room },
+      time: 125,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(21),
+        limit: 70,
+        bucket: 948,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'site1') {
+          return site;
+        }
+
+        if (id === 'spawn1') {
+          return spawn;
+        }
+
+        return id === 'stored-container1' ? storedContainer : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({
+      type: 'withdraw',
+      targetId: 'stored-container1',
+      constructionSiteId: 'site1'
+    });
+    expect(withdraw).toHaveBeenCalledWith(storedContainer, RESOURCE_ENERGY, 100);
+    expect(build).not.toHaveBeenCalled();
+  });
+
   it('keeps spawn reservation refill protected when the room has only one worker', () => {
     const site = {
       id: 'site1',


### PR DESCRIPTION
## Linked issues

Intentional PR-body closing linkage:
- None. The construction acceptance incident remains open until post-merge official deploy/runtime evidence proves all owned rooms resume construction assignment.

Related / non-closing linkage:
- Related to issue 1831.

## Domain / Kind

- Domain: Territory/Economy
- Kind: code

## Summary

- Lets empty builders that retain a build assignment prefer withdrawing reserved construction energy instead of falling back into unrelated worker task selection.
- Preserves spawn refill/harvest/recovery priority by only using the construction-reserved withdrawal path for creeps that already have an active build task and empty carry.
- Adds Jest coverage for the low-bucket worker-assignment-gap case where a builder has no carried energy while another worker has reserved stored energy for the same construction site.
- Regenerates `prod/dist/main.js` through the normal build.

## Verification

- [x] Local check: `git diff --check` passed.
- [x] Local check: `cd prod && npm run typecheck` passed.
- [x] Local check: `cd prod && npm test -- --runInBand` passed (105 suites / 2431 tests).
- [x] Local check: `cd prod && npm run build` passed and regenerated `prod/dist/main.js`.
- [x] Local check: `git diff --check HEAD~1..HEAD` passed after commit.
- [x] GitHub Project issue/PR fields are current (`Status`, `Evidence`, `Next action`; plus `Blocked by` when blocked) — to be refreshed immediately after PR creation with head commit and gate state.
- [x] Automated review has no blocking findings, or a CodeRabbit/Gemini reliability bypass is recorded with reviewer/head/reason; review threads are resolved/outdated/non-blocking — pending normal PR review after creation.
- [x] QA gate: controller verification passed; independent QA/review gate pending after PR creation.
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate

- [x] Task type: code behavior / bugfix.
- [x] Expected observable outcome / named deliverable: workers with retained build assignments can fetch construction-reserved stored energy and make construction progress instead of leaving `buildCarriedEnergy=0` under low-bucket recovery.
- [x] Non-goals / accepted substitutes: this PR does not claim final official-runtime acceptance; issue 1831 remains active until postdeploy all-room construction evidence passes.
- [x] Verification evidence required before Done: controller diff-check, TypeScript, Jest, build, PR checks/reviews, and separate official deploy/runtime acceptance evidence for issue closure.
- [x] Project Evidence / Next action / Blocked by: Project fields name this PR head, controller verification, review/deploy gates, and postdeploy acceptance owner.
- [x] Post-merge/deploy/runtime proof: this PR supplies the code fix; issue 1831 closure uses the separate official deploy/runtime acceptance artifact.
- [x] Named deliverable proof: unit test coverage in `prod/test/workerRunner.test.ts`, source fix in `prod/src/creeps/workerRunner.ts`, and regenerated `prod/dist/main.js`.

## Issue closure gate

For every issue linked above in the PR body with a closing keyword:

- [x] No issues are linked with a closing keyword in this PR body.
- [x] No closed issue still needs post-merge validation, runtime/process proof, owner action, successor/follow-up work, partial-fix completion, or any other blocker.

## Runtime / deployment impact

- [ ] No gameplay/runtime/deployment impact.
- [x] Gameplay/runtime/deployment impact; Deployment Floor will become violated after merge and must be satisfied by official deploy + all-owned-room construction acceptance evidence before issue closure.

## Notes

- Codex authored the source/test/dist diff but could not commit inside the linked-worktree sandbox because the real gitdir was read-only; the controller made a mechanical bot-authored commit after full verification.
