### PR TITLE
worker: recover retained build energy acquisition

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35004,6 +35004,8 @@ function runWorker(creep) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptLowLoadReturnTaskForEnergyAcquisition(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
+  } else if (shouldPreemptBuildTaskForConstructionEnergyAcquisition(creep, currentTask, selectedTask)) {
+    taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptTransferTaskForControllerDowngradeGuard(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptTransferTaskForConstructionBacklog(creep, currentTask, selectedTask)) {
@@ -35180,13 +35182,31 @@ function selectWorkerTaskContext(creep, currentTask) {
     currentTask,
     effectiveEnergyCriticalTask != null ? effectiveEnergyCriticalTask : baseSelectedTask
   );
-  const selectedTask = (_a2 = spawnReservationRefillTask != null ? spawnReservationRefillTask : effectiveEnergyCriticalTask) != null ? _a2 : baseSelectedTask;
+  const selectedTask = selectAssignedBuildEnergyAcquisitionTask(
+    creep,
+    currentTask,
+    (_a2 = spawnReservationRefillTask != null ? spawnReservationRefillTask : effectiveEnergyCriticalTask) != null ? _a2 : baseSelectedTask
+  );
   return {
     baseSelectedTask,
     energyCriticalTask: effectiveEnergyCriticalTask,
     selectedTask,
     spawnReservationRefillTask
   };
+}
+function selectAssignedBuildEnergyAcquisitionTask(creep, currentTask, selectedTask) {
+  var _a2, _b;
+  if ((currentTask == null ? void 0 : currentTask.type) !== "build" || selectedTask !== null && selectedTask.type !== "build") {
+    return selectedTask;
+  }
+  if (getFreeTransferEnergyCapacity(creep) <= 0 || getActiveWorkParts3(creep) <= 0 || hasVisibleHostileCreeps2(creep.room)) {
+    return selectedTask;
+  }
+  const carriedEnergy = getUsedTransferEnergy(creep);
+  if (carriedEnergy > 0 && !hasLowWorkerEnergyLoad(creep)) {
+    return selectedTask;
+  }
+  return (_b = (_a2 = selectConstructionBacklogEnergyAcquisitionTask(creep)) != null ? _a2 : selectWorkerEnergyCriticalAcquisitionTask(creep)) != null ? _b : selectedTask;
 }
 function applyWorkerAssignmentGapRecoveryTask(creep, currentTask, selectionContext) {
   const recoveryTask = selectWorkerAssignmentGapRecoveryTask(creep, currentTask, selectionContext);
@@ -36427,6 +36447,9 @@ function shouldPreemptLowLoadReturnTaskForEnergyAcquisition(creep, task, selecte
   }
   const sample = (_a2 = creep.memory) == null ? void 0 : _a2.workerEfficiency;
   return (sample == null ? void 0 : sample.type) === "nearbyEnergyChoice" && sample.selectedTask === selectedTask.type && sample.targetId === String(selectedTask.targetId) && isCurrentWorkerEfficiencySample(sample);
+}
+function shouldPreemptBuildTaskForConstructionEnergyAcquisition(creep, task, selectedTask) {
+  return task.type === "build" && selectedTask !== null && isEnergyAcquisitionTask2(selectedTask) && canExecuteTask(creep, selectedTask) && hasLowWorkerEnergyLoad(creep);
 }
 function shouldPreemptTransferTaskForBetterEnergySink(creep, task, selectedTask) {
   var _a2;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -9,6 +9,8 @@ import {
   isUpgraderBoostActive,
   isWorkerRepairTargetComplete,
   selectWorkerTask,
+  selectConstructionBacklogEnergyAcquisitionTask,
+  selectWorkerEnergyCriticalAcquisitionTask,
   canSpendWorkerEnergyOnConstructionSite,
   shouldSwitchLowLoadWorkerEnergyAcquisitionTaskForYield,
   shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill
@@ -213,6 +215,8 @@ export function runWorker(creep: Creep): void {
   } else if (shouldPreemptEnergyAcquisitionTaskForNearbyEnergyChoice(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptLowLoadReturnTaskForEnergyAcquisition(creep, currentTask, selectedTask)) {
+    taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
+  } else if (shouldPreemptBuildTaskForConstructionEnergyAcquisition(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptTransferTaskForControllerDowngradeGuard(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
@@ -456,13 +460,46 @@ function selectWorkerTaskContext(
     currentTask,
     effectiveEnergyCriticalTask ?? baseSelectedTask
   );
-  const selectedTask = spawnReservationRefillTask ?? effectiveEnergyCriticalTask ?? baseSelectedTask;
+  const selectedTask = selectAssignedBuildEnergyAcquisitionTask(
+    creep,
+    currentTask,
+    spawnReservationRefillTask ?? effectiveEnergyCriticalTask ?? baseSelectedTask
+  );
   return {
     baseSelectedTask,
     energyCriticalTask: effectiveEnergyCriticalTask,
     selectedTask,
     spawnReservationRefillTask
   };
+}
+
+function selectAssignedBuildEnergyAcquisitionTask(
+  creep: Creep,
+  currentTask: CreepTaskMemory | null | undefined,
+  selectedTask: CreepTaskMemory | null
+): CreepTaskMemory | null {
+  if (currentTask?.type !== 'build' || (selectedTask !== null && selectedTask.type !== 'build')) {
+    return selectedTask;
+  }
+
+  if (
+    getFreeTransferEnergyCapacity(creep) <= 0 ||
+    getActiveWorkParts(creep) <= 0 ||
+    hasVisibleHostileCreeps(creep.room)
+  ) {
+    return selectedTask;
+  }
+
+  const carriedEnergy = getUsedTransferEnergy(creep);
+  if (carriedEnergy > 0 && !hasLowWorkerEnergyLoad(creep)) {
+    return selectedTask;
+  }
+
+  return (
+    selectConstructionBacklogEnergyAcquisitionTask(creep) ??
+    selectWorkerEnergyCriticalAcquisitionTask(creep) ??
+    selectedTask
+  );
 }
 
 function applyWorkerAssignmentGapRecoveryTask(
@@ -2489,6 +2526,20 @@ function shouldPreemptLowLoadReturnTaskForEnergyAcquisition(
     sample.selectedTask === selectedTask.type &&
     sample.targetId === String(selectedTask.targetId) &&
     isCurrentWorkerEfficiencySample(sample)
+  );
+}
+
+function shouldPreemptBuildTaskForConstructionEnergyAcquisition(
+  creep: Creep,
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  return (
+    task.type === 'build' &&
+    selectedTask !== null &&
+    isEnergyAcquisitionTask(selectedTask) &&
+    canExecuteTask(creep, selectedTask) &&
+    hasLowWorkerEnergyLoad(creep)
   );
 }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -5795,7 +5795,9 @@ function selectBuilderEnergyAcquisitionTask(creep: Creep): BuilderEnergyAcquisit
   return candidates.sort(compareBuilderEnergyAcquisitionCandidates)[0].task;
 }
 
-function selectConstructionBacklogEnergyAcquisitionTask(creep: Creep): BuilderEnergyAcquisitionTask | null {
+export function selectConstructionBacklogEnergyAcquisitionTask(
+  creep: Creep
+): Extract<CreepTaskMemory, { type: 'harvest' | 'pickup' | 'withdraw' }> | null {
   if (getFreeEnergyCapacity(creep) <= 0 || getActiveWorkParts(creep) <= 0) {
     return null;
   }

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -9288,6 +9288,133 @@ describe('runWorker', () => {
     expect(build).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['empty', 0, 100],
+    ['low-load', 18, 82]
+  ])(
+    'tops up a retained %s construction assignment from source energy when the selector still returns build',
+    (_label, carriedEnergy, freeCapacity) => {
+      const source = {
+        id: 'source1',
+        energy: 300,
+        pos: { x: 15, y: 20, roomName: 'E29N57' } as RoomPosition
+      } as Source;
+      const site = {
+        id: 'road-site1',
+        my: true,
+        structureType: 'road',
+        progress: 4_715,
+        progressTotal: 5_000,
+        pos: { x: 20, y: 21, roomName: 'E29N57' } as RoomPosition
+      } as ConstructionSite;
+      const controller = {
+        id: 'controller1',
+        my: true,
+        level: 5,
+        ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+      } as StructureController;
+      const roomCreeps: Creep[] = [];
+      const room = {
+        name: 'E29N57',
+        energyAvailable: 1_800,
+        energyCapacityAvailable: 1_800,
+        controller,
+        find: jest.fn(
+          (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+            if (type === FIND_CONSTRUCTION_SITES) {
+              return [site];
+            }
+
+            if (type === FIND_SOURCES) {
+              return [source];
+            }
+
+            if (type === FIND_MY_CREEPS) {
+              return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+            }
+
+            if (
+              type === FIND_MY_STRUCTURES ||
+              type === FIND_STRUCTURES ||
+              type === FIND_DROPPED_RESOURCES ||
+              type === FIND_HOSTILE_CREEPS
+            ) {
+              return [];
+            }
+
+            return [];
+          }
+        )
+      } as unknown as Room;
+      const selectedBuildTask = { type: 'build', targetId: 'road-site1' as Id<ConstructionSite> } as const;
+      const build = jest.fn();
+      const harvest = jest.fn().mockReturnValue(0);
+      const creep = {
+        name: 'RetainedBuilder',
+        memory: {
+          role: 'worker',
+          colony: 'E29N57',
+          task: selectedBuildTask
+        },
+        getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+        pos: { x: 18, y: 20, roomName: 'E29N57' } as RoomPosition,
+        store: {
+          getUsedCapacity: jest.fn((resource?: ResourceConstant) =>
+            resource === RESOURCE_ENERGY ? carriedEnergy : 0
+          ),
+          getFreeCapacity: jest.fn((resource?: ResourceConstant) =>
+            resource === RESOURCE_ENERGY ? freeCapacity : 0
+          ),
+          getCapacity: jest.fn((resource?: ResourceConstant) =>
+            resource === RESOURCE_ENERGY ? carriedEnergy + freeCapacity : 0
+          )
+        },
+        room,
+        build,
+        harvest,
+        moveTo: jest.fn()
+      } as unknown as Creep;
+      roomCreeps.push(creep);
+      const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(selectedBuildTask);
+      const selectWorkerEnergyCriticalTask = jest
+        .spyOn(workerTaskPolicy, 'selectWorkerEnergyCriticalTask')
+        .mockReturnValue(null);
+      (globalThis as unknown as { Game: Partial<Game> }).Game = {
+        creeps: { RetainedBuilder: creep },
+        rooms: { E29N57: room },
+        time: 2_124_541,
+        getObjectById: jest.fn((id: string) => {
+          if (id === 'road-site1') {
+            return site;
+          }
+
+          return id === 'source1' ? source : null;
+        })
+      };
+
+      try {
+        runWorker(creep);
+
+        expect(creep.memory.task).toEqual({ type: 'harvest', targetId: 'source1' });
+        expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+          currentTask: 'build',
+          currentTargetId: 'road-site1',
+          baseSelectedTask: 'build',
+          baseSelectedTargetId: 'road-site1',
+          selectedTask: 'harvest',
+          selectedTargetId: 'source1',
+          assignedTask: 'harvest',
+          assignedTargetId: 'source1'
+        });
+        expect(harvest).toHaveBeenCalledWith(source);
+        expect(build).not.toHaveBeenCalled();
+      } finally {
+        selectWorkerTask.mockRestore();
+        selectWorkerEnergyCriticalTask.mockRestore();
+      }
+    }
+  );
+
   it('preempts an E29N55 tower refill transfer for construction backlog while CPU shedding', () => {
     const site = {
       id: 'road-site1',


### PR DESCRIPTION
## Summary
- recovers retained construction builders that are already assigned build work but are empty or carrying only a tiny load when the selector still returns the same build task.
- routes those retained builders through construction-scoped energy acquisition first, then the existing safe general energy-critical fallback when no construction-specific stored/dropped energy is available.
- adds regression coverage for retained empty and low-load construction assignments, and regenerates `prod/dist/main.js` from the verified production build.

Related issue: #1831

## Verification
- [x] Local check: `git diff --check` passed.
- [x] Local check: `cd prod && npm run typecheck` passed.
- [x] Local check: `cd prod && npm test -- --runInBand` passed: 105 suites, 2435 tests.
- [x] Local check: `cd prod && npm run build` passed.
- [x] GitHub Project issue/PR fields are current: PR #1855 is `In review`; issue #1831 is `In progress`; RL hold issues #1233/#1032/#1583 cite this gate.
- [ ] Automated review has no blocking findings, or a CodeRabbit/Gemini reliability bypass is recorded with reviewer/head/reason; review threads are resolved/outdated/non-blocking. Awaiting automated review.
- [ ] QA gate: queued for PR gate/acceptance validation.
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate
- [x] Task type: code behavior bugfix / production gameplay hotfix with bundled artifact sync.
- [x] Expected observable outcome / named deliverable: retained empty or low-load construction builders switch to energy acquisition instead of staying ineffective on the retained build assignment.
- [x] Non-goals / accepted substitutes: no expansion retargeting, no RL compute launch, no deploy workflow change, and no issue closure from this pull request alone.
- [x] Verification evidence required before Done: controller verification passed `git diff --check`, `npm run typecheck`, `npm test -- --runInBand`, and `npm run build` on commit `afd6b7fa`.
- [x] Project Evidence / Next action / Blocked by: Project fields list PR #1855 as `In review` and issue #1831 as `In progress` with review, deploy, and runtime acceptance path recorded.
- [x] Post-merge/deploy/runtime proof: runtime acceptance evidence is defined as fresh console plus all-room health-gate artifacts for E29N55, E29N56, and E29N57; this pull request supplies the verified code artifact.
- [x] Named deliverable proof: source changes, Jest regression coverage, and bundled artifact are present in commit `afd6b7fa`.

## Issue closure gate
No closing-keyword issue links are used in this PR body. Issue #1831 stays open until postdeploy all-room construction acceptance is proven.

## Runtime / deployment impact
- [ ] No gameplay/runtime/deployment impact.
- [x] Gameplay/runtime/deployment impact; Deployment Floor evidence or HELD blocker is recorded. This is a Screeps runtime worker hotfix and must be deployed/observed after merge before issue #1831 can close.

## Notes
- This change came from the recovered Codex worktree `/root/screeps-worktrees/1831-post1854-deploy-failure-20260613T1002Z`; Codex could not create the real git commit because the linked worktree gitdir was read-only inside its sandbox, so the controller made a mechanical commit preserving `lanyusea's bot <lanyusea@gmail.com>` authorship after full verification.
