### PR TITLE
worker: finish construction withdrawal build

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35169,7 +35169,7 @@ function selectWorkerTaskForRunner(creep) {
   return fallbackToEnergyOnNullSelectionLoop(creep, selectedTask);
 }
 function selectWorkerTaskContext(creep, currentTask) {
-  var _a2;
+  var _a2, _b;
   const baseSelectedTask = selectWorkerTaskForRunner(creep);
   const energyCriticalTask = selectWorkerEnergyCriticalTask(creep, currentTask, baseSelectedTask);
   const effectiveEnergyCriticalTask = shouldYieldStorageCriticalAcquisitionToNearFullConstruction(
@@ -35182,11 +35182,16 @@ function selectWorkerTaskContext(creep, currentTask) {
     currentTask,
     effectiveEnergyCriticalTask != null ? effectiveEnergyCriticalTask : baseSelectedTask
   );
-  const selectedTask = selectAssignedBuildEnergyAcquisitionTask(
+  const selectedTaskAfterBuildEnergyAcquisition = selectAssignedBuildEnergyAcquisitionTask(
     creep,
     currentTask,
     (_a2 = spawnReservationRefillTask != null ? spawnReservationRefillTask : effectiveEnergyCriticalTask) != null ? _a2 : baseSelectedTask
   );
+  const selectedTask = (_b = selectConstructionWithdrawCompletionBuildTask(
+    creep,
+    currentTask,
+    selectedTaskAfterBuildEnergyAcquisition
+  )) != null ? _b : selectedTaskAfterBuildEnergyAcquisition;
   return {
     baseSelectedTask,
     energyCriticalTask: effectiveEnergyCriticalTask,
@@ -35207,6 +35212,22 @@ function selectAssignedBuildEnergyAcquisitionTask(creep, currentTask, selectedTa
     return selectedTask;
   }
   return (_b = (_a2 = selectConstructionBacklogEnergyAcquisitionTask(creep)) != null ? _a2 : selectWorkerEnergyCriticalAcquisitionTask(creep)) != null ? _b : selectedTask;
+}
+function selectConstructionWithdrawCompletionBuildTask(creep, currentTask, selectedTask) {
+  if (!isConstructionWithdrawReservationTask(currentTask) || getUsedTransferEnergy(creep) <= 0 || getActiveWorkParts3(creep) <= 0 || hasVisibleHostileCreeps2(creep.room) || shouldKeepConstructionWithdrawTaskForMoreEnergy(creep, currentTask, selectedTask) || !canConstructionWithdrawCompletionOverrideSelectedTask(creep, selectedTask)) {
+    return null;
+  }
+  const constructionSite = Game.getObjectById(currentTask.constructionSiteId);
+  if (!constructionSite || constructionSite.my === false || !canSpendWorkerEnergyOnConstructionSite(creep, constructionSite)) {
+    return null;
+  }
+  return { type: "build", targetId: constructionSite.id };
+}
+function canConstructionWithdrawCompletionOverrideSelectedTask(creep, selectedTask) {
+  return selectedTask === null || isEnergyAcquisitionTask2(selectedTask) || selectedTask.type === "build" || selectedTask.type === "upgrade" && !isDowngradeGuardUpgradeTask(creep, selectedTask);
+}
+function shouldKeepConstructionWithdrawTaskForMoreEnergy(creep, currentTask, selectedTask) {
+  return getFreeTransferEnergyCapacity(creep) > 0 && selectedTask !== null && isSameTask2(currentTask, selectedTask);
 }
 function applyWorkerAssignmentGapRecoveryTask(creep, currentTask, selectionContext) {
   const recoveryTask = selectWorkerAssignmentGapRecoveryTask(creep, currentTask, selectionContext);

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -460,11 +460,17 @@ function selectWorkerTaskContext(
     currentTask,
     effectiveEnergyCriticalTask ?? baseSelectedTask
   );
-  const selectedTask = selectAssignedBuildEnergyAcquisitionTask(
+  const selectedTaskAfterBuildEnergyAcquisition = selectAssignedBuildEnergyAcquisitionTask(
     creep,
     currentTask,
     spawnReservationRefillTask ?? effectiveEnergyCriticalTask ?? baseSelectedTask
   );
+  const selectedTask =
+    selectConstructionWithdrawCompletionBuildTask(
+      creep,
+      currentTask,
+      selectedTaskAfterBuildEnergyAcquisition
+    ) ?? selectedTaskAfterBuildEnergyAcquisition;
   return {
     baseSelectedTask,
     energyCriticalTask: effectiveEnergyCriticalTask,
@@ -499,6 +505,58 @@ function selectAssignedBuildEnergyAcquisitionTask(
     selectConstructionBacklogEnergyAcquisitionTask(creep) ??
     selectWorkerEnergyCriticalAcquisitionTask(creep) ??
     selectedTask
+  );
+}
+
+function selectConstructionWithdrawCompletionBuildTask(
+  creep: Creep,
+  currentTask: CreepTaskMemory | null | undefined,
+  selectedTask: CreepTaskMemory | null
+): Extract<CreepTaskMemory, { type: 'build' }> | null {
+  if (
+    !isConstructionWithdrawReservationTask(currentTask) ||
+    getUsedTransferEnergy(creep) <= 0 ||
+    getActiveWorkParts(creep) <= 0 ||
+    hasVisibleHostileCreeps(creep.room) ||
+    shouldKeepConstructionWithdrawTaskForMoreEnergy(creep, currentTask, selectedTask) ||
+    !canConstructionWithdrawCompletionOverrideSelectedTask(creep, selectedTask)
+  ) {
+    return null;
+  }
+
+  const constructionSite = Game.getObjectById(currentTask.constructionSiteId) as ConstructionSite | null;
+  if (
+    !constructionSite ||
+    constructionSite.my === false ||
+    !canSpendWorkerEnergyOnConstructionSite(creep, constructionSite)
+  ) {
+    return null;
+  }
+
+  return { type: 'build', targetId: constructionSite.id };
+}
+
+function canConstructionWithdrawCompletionOverrideSelectedTask(
+  creep: Creep,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  return (
+    selectedTask === null ||
+    isEnergyAcquisitionTask(selectedTask) ||
+    selectedTask.type === 'build' ||
+    (selectedTask.type === 'upgrade' && !isDowngradeGuardUpgradeTask(creep, selectedTask))
+  );
+}
+
+function shouldKeepConstructionWithdrawTaskForMoreEnergy(
+  creep: Creep,
+  currentTask: Extract<CreepTaskMemory, { type: 'withdraw' }>,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  return (
+    getFreeTransferEnergyCapacity(creep) > 0 &&
+    selectedTask !== null &&
+    isSameTask(currentTask, selectedTask)
   );
 }
 
@@ -1407,8 +1465,8 @@ function getSpawnReservationRefillCoverageEnergy(
 }
 
 function isConstructionWithdrawReservationTask(
-  task: Partial<CreepTaskMemory> | undefined
-): task is Extract<CreepTaskMemory, { type: 'withdraw' }> {
+  task: Partial<CreepTaskMemory> | null | undefined
+): task is Extract<CreepTaskMemory, { type: 'withdraw' }> & { constructionSiteId: Id<ConstructionSite> } {
   return (
     task?.type === 'withdraw' &&
     typeof task.targetId === 'string' &&

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1504,6 +1504,204 @@ describe('runWorker', () => {
     expect(withdraw).toHaveBeenCalledWith(spawn, RESOURCE_ENERGY, 50);
   });
 
+  it('withdraws local storage energy for an empty retained secondary-room builder', () => {
+    const site = withRangeTo(
+      {
+        id: 'extension-site1',
+        my: true,
+        structureType: 'extension',
+        progress: 0,
+        progressTotal: 3_000
+      } as ConstructionSite,
+      { storage1: 1 }
+    );
+    const storage = {
+      id: 'storage1',
+      my: true,
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 1_000 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(10_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const workers: Creep[] = [];
+    const room = {
+      name: 'E29N57',
+      energyAvailable: 1_800,
+      energyCapacityAvailable: 1_800,
+      controller,
+      find: jest.fn((type: number, options?: { filter?: (object: AnyStructure | Creep) => boolean }) => {
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [storage];
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return options?.filter ? workers.filter(options.filter) : workers;
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const withdraw = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'worker-E29N57-builder',
+      memory: {
+        role: 'worker',
+        colony: 'E29N57',
+        task: { type: 'build', targetId: 'extension-site1' as Id<ConstructionSite> }
+      },
+      pos: { getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'storage1' ? 2 : 99)) },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(100)
+      },
+      room,
+      build: jest.fn(),
+      withdraw,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    workers.push(creep);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { [creep.name]: creep },
+      getObjectById: jest.fn((id: string) =>
+        id === 'extension-site1' ? site : id === 'storage1' ? storage : null
+      )
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({
+      type: 'withdraw',
+      targetId: 'storage1',
+      constructionSiteId: 'extension-site1'
+    });
+    expect(withdraw).toHaveBeenCalledWith(storage, RESOURCE_ENERGY, 100);
+    expect(creep.build).not.toHaveBeenCalled();
+  });
+
+  it('builds a retained secondary-room construction withdrawal after filling', () => {
+    const site = withRangeTo(
+      {
+        id: 'extension-site1',
+        my: true,
+        structureType: 'extension',
+        progress: 784,
+        progressTotal: 1_000
+      } as ConstructionSite,
+      { storage1: 1 }
+    );
+    const storage = {
+      id: 'storage1',
+      my: true,
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 1_000 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(10_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const workers: Creep[] = [];
+    const room = {
+      name: 'E29N57',
+      energyAvailable: 1_800,
+      energyCapacityAvailable: 1_800,
+      controller,
+      find: jest.fn((type: number, options?: { filter?: (object: AnyStructure | Creep) => boolean }) => {
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [storage];
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return options?.filter ? workers.filter(options.filter) : workers;
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const withdraw = jest.fn();
+    const creep = {
+      name: 'worker-E29N57-builder',
+      memory: {
+        role: 'worker',
+        colony: 'E29N57',
+        task: {
+          type: 'withdraw',
+          targetId: 'storage1' as Id<AnyStoreStructure>,
+          constructionSiteId: 'extension-site1' as Id<ConstructionSite>
+        }
+      },
+      pos: { getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'extension-site1' ? 2 : 99)) },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(100),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      build,
+      withdraw,
+      upgradeController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const coveringBuilder = {
+      name: 'worker-E29N57-covering-builder',
+      memory: {
+        role: 'worker',
+        colony: 'E29N57',
+        task: { type: 'build', targetId: 'extension-site1' as Id<ConstructionSite> }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(55),
+        getFreeCapacity: jest.fn().mockReturnValue(45)
+      },
+      room,
+      build: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    workers.push(creep, coveringBuilder);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 2126831,
+      creeps: {
+        [creep.name]: creep,
+        [coveringBuilder.name]: coveringBuilder
+      },
+      getObjectById: jest.fn((id: string) =>
+        id === 'extension-site1'
+          ? site
+          : id === 'storage1'
+            ? storage
+            : id === 'controller1'
+              ? controller
+              : null
+      )
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'extension-site1' });
+    expect(build).toHaveBeenCalledWith(site);
+    expect(withdraw).not.toHaveBeenCalled();
+    expect(creep.upgradeController).not.toHaveBeenCalled();
+  });
+
   it('withdraws only construction-safe spawn energy below the E29N55 bootstrap buffer margin', () => {
     const site = withRangeTo(
       { id: 'extension-site1', structureType: 'extension' } as ConstructionSite,


### PR DESCRIPTION
## Summary
- finishes retained construction-scoped withdrawal tasks by switching back to build once the worker has usable energy.
- preserves the construction-specific energy acquisition route for empty retained builders while avoiding a full/loaded worker repeatedly selecting the same withdraw task.
- adds regression coverage for the empty secondary-room builder withdrawal path and the filled retained withdrawal-to-build transition, then regenerates `prod/dist/main.js` from the verified production build.

Related issue: #1831

## Verification
- [x] Local check: `git diff --check` passed.
- [x] Local check: `cd prod && npm run typecheck` passed.
- [x] Local check: `cd prod && npm test -- --runInBand` passed: 105 suites, 2437 tests.
- [x] Local check: `cd prod && npm run build` passed.
- [x] Automated review has no blocking findings, or a CodeRabbit/Gemini reliability bypass is recorded with reviewer/head/reason; review threads are resolved/outdated/non-blocking. 2026-06-13T14:19Z exact head `b1d45b3b`: CodeRabbit issue comment reports review-limit/non-substantive skip, Gemini COMMENTED with no unresolved threads, GraphQL review threads=0, checks green; controller records owner-approved reliability bypass for CodeRabbit on this head.
- [x] QA gate: controller re-verification at 2026-06-13T14:20Z passed `git diff --check`, `npm run typecheck`, `npm test -- --runInBand` (105 suites / 2437 tests), and `npm run build` on the actual PR worktree; runtime acceptance remains post-merge/deploy evidence for #1831.
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate
- [x] Task type: code behavior bugfix / production gameplay hotfix with bundled artifact sync.
- [x] Expected observable outcome / named deliverable: retained builders that already withdrew construction energy resume building the intended site instead of looping on the construction withdrawal assignment.
- [x] Non-goals / accepted substitutes: no expansion retargeting, no RL compute launch, no deploy workflow change, and no issue closure from this pull request alone.
- [x] Verification evidence required before Done: controller verification passed `git diff --check`, `npm run typecheck`, `npm test -- --runInBand`, and `npm run build` on commit `b1d45b3b`.
- [x] Project Evidence / Next action / Blocked by: this pull request is entering review; issue #1831 remains active until review/merge/deploy and fresh all-owned-room construction acceptance pass.
- [x] Post-merge/deploy/runtime proof: runtime acceptance evidence is defined as fresh official deploy artifacts plus all-owned-room construction health/console evidence for E29N55, E29N56, and E29N57; this pull request supplies the verified code artifact only.
- [x] Named deliverable proof: source changes, Jest regression coverage, and bundled artifact are present in commit `b1d45b3b`.

## Issue closure gate
No closing-keyword issue links are used in this PR body. Issue #1831 stays open until postdeploy all-owned-room construction acceptance is proven.

## Runtime / deployment impact
- [ ] No gameplay/runtime/deployment impact.
- [x] Gameplay/runtime/deployment impact; Deployment Floor evidence or HELD blocker is recorded. This is a Screeps runtime worker hotfix and must be deployed/observed after merge before issue #1831 can close.

## Notes
- This change came from the recovered Codex worktree `/root/screeps-worktrees/1831-post1855-deploy-failure-20260613T1130Z`; the original Hermes process handle was unavailable in this controller session, so the controller verified the Codex-authored dirty worktree and made a mechanical commit preserving `lanyusea's bot <lanyusea@gmail.com>` authorship after full verification.