### PR TITLE
worker: recover secondary-room build energy telemetry

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -42438,7 +42438,7 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
       tick,
       cachedEventMetricsTick
     );
-    refreshConstructionDeadlockTelemetry(colonies, creepsByColony, tick);
+    refreshConstructionDeadlockTelemetry(colonies, creepsByColony, creeps, tick);
   }
   const cpuSummary = buildCpuSummary();
   emitRuntimeCpuSummary(cpuSummary.cpu, tick);
@@ -42537,6 +42537,17 @@ function groupCreepsByColony(creeps, colonies) {
   }
   return creepsByColony;
 }
+function groupCreepsByVisibleRoom(creeps) {
+  var _a2;
+  const creepsByVisibleRoom = /* @__PURE__ */ new Map();
+  for (const creep of creeps) {
+    const roomName = (_a2 = creep.room) == null ? void 0 : _a2.name;
+    if (isNonEmptyString31(roomName)) {
+      addCreepToColonyGroup(creepsByVisibleRoom, roomName, creep);
+    }
+  }
+  return creepsByVisibleRoom;
+}
 function groupConstructionPlacementEventsByRoom(events) {
   var _a2;
   const eventsByRoom = /* @__PURE__ */ new Map();
@@ -42592,8 +42603,9 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
   if (persistOccupationRecommendations && includeOptionalSummary) {
     persistOccupationRecommendationFollowUpIntent(territoryRecommendation, tick);
   }
+  const roomTaskWorkers = selectRoomVisibleWorkers(colony, colonyWorkers, colonyCreeps);
   const resourcesWithoutActivity = summarizeResources(colony, colonyWorkers, colonyCreeps, eventMetrics.resources);
-  const taskCounts = countWorkerTasks(colonyWorkers);
+  const taskCounts = countWorkerTasks(roomTaskWorkers);
   const assignedTaskCount = countAssignedWorkerTasks(colonyWorkers);
   const productiveAssignmentCount = countProductiveWorkerAssignments(colonyWorkers);
   const workerAssignmentEvidence = summarizeWorkerAssignmentEvidence(
@@ -43564,12 +43576,15 @@ function countWorkerTasks(workers) {
   }
   return counts;
 }
-function refreshConstructionDeadlockTelemetry(colonies, creepsByColony, tick) {
-  var _a2, _b;
+function refreshConstructionDeadlockTelemetry(colonies, creepsByColony, creeps, tick) {
+  var _a2, _b, _c;
+  const creepsByVisibleRoom = groupCreepsByVisibleRoom(creeps);
   for (const colony of colonies) {
-    const colonyWorkers = ((_a2 = creepsByColony.get(colony.room.name)) != null ? _a2 : []).filter((creep) => creep.memory.role === "worker");
-    const taskCounts = countWorkerTasks(colonyWorkers);
-    const constructionSiteCount = ((_b = findRoomObjects29(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _b : []).length;
+    const colonyCreeps = (_a2 = creepsByColony.get(colony.room.name)) != null ? _a2 : [];
+    const colonyWorkers = colonyCreeps.filter((creep) => creep.memory.role === "worker");
+    const roomTaskWorkers = mergeRoomVisibleWorkers(colonyWorkers, (_b = creepsByVisibleRoom.get(colony.room.name)) != null ? _b : []);
+    const taskCounts = countWorkerTasks(roomTaskWorkers);
+    const constructionSiteCount = ((_c = findRoomObjects29(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _c : []).length;
     updateRoomConstructionDeadlockTicks(colony.room, taskCounts, constructionSiteCount, tick);
   }
 }
@@ -44125,7 +44140,7 @@ function summarizeResources(colony, colonyWorkers, colonyCreeps, events) {
   const roomStructures = (_a2 = findRoomObjects29(colony.room, "FIND_STRUCTURES")) != null ? _a2 : colony.spawns;
   const roomEnergyStructures = findRoomEnergyStoreStructures(colony.room, colony.spawns);
   const roomCreeps = findOwnedRoomCreeps(colony.room, colonyCreeps);
-  const productiveEnergyWorkers = mergeRoomWorkersForProductiveEnergy(colonyWorkers, roomCreeps);
+  const productiveEnergyWorkers = mergeRoomVisibleWorkers(colonyWorkers, roomCreeps);
   const constructionSites = (_b = findRoomObjects29(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _b : [];
   const droppedResources = (_c = findRoomObjects29(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _c : [];
   const sourceContainerCoverage = summarizeSourceContainerCoverage(colony.room);
@@ -44209,7 +44224,10 @@ function findOwnedRoomCreeps(room, colonyCreeps) {
     ...colonyCreeps
   ]);
 }
-function mergeRoomWorkersForProductiveEnergy(colonyWorkers, roomCreeps) {
+function selectRoomVisibleWorkers(colony, colonyWorkers, colonyCreeps) {
+  return mergeRoomVisibleWorkers(colonyWorkers, findOwnedRoomCreeps(colony.room, colonyCreeps));
+}
+function mergeRoomVisibleWorkers(colonyWorkers, roomCreeps) {
   return uniqueRoomObjects2([...colonyWorkers, ...roomCreeps]).filter(isRuntimeWorkerCreep);
 }
 function isRuntimeWorkerCreep(object) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -44125,6 +44125,7 @@ function summarizeResources(colony, colonyWorkers, colonyCreeps, events) {
   const roomStructures = (_a2 = findRoomObjects29(colony.room, "FIND_STRUCTURES")) != null ? _a2 : colony.spawns;
   const roomEnergyStructures = findRoomEnergyStoreStructures(colony.room, colony.spawns);
   const roomCreeps = findOwnedRoomCreeps(colony.room, colonyCreeps);
+  const productiveEnergyWorkers = mergeRoomWorkersForProductiveEnergy(colonyWorkers, roomCreeps);
   const constructionSites = (_b = findRoomObjects29(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _b : [];
   const droppedResources = (_c = findRoomObjects29(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _c : [];
   const sourceContainerCoverage = summarizeSourceContainerCoverage(colony.room);
@@ -44137,7 +44138,7 @@ function summarizeResources(colony, colonyWorkers, colonyCreeps, events) {
     sourceContainers: sourceContainerCoverage,
     productiveEnergy: summarizeProductiveEnergy(
       colony,
-      colonyWorkers,
+      productiveEnergyWorkers,
       constructionSites,
       roomStructures,
       roomEnergyStructures,
@@ -44207,6 +44208,12 @@ function findOwnedRoomCreeps(room, colonyCreeps) {
     ...(_a2 = findRoomObjects29(room, "FIND_MY_CREEPS")) != null ? _a2 : [],
     ...colonyCreeps
   ]);
+}
+function mergeRoomWorkersForProductiveEnergy(colonyWorkers, roomCreeps) {
+  return uniqueRoomObjects2([...colonyWorkers, ...roomCreeps]).filter(isRuntimeWorkerCreep);
+}
+function isRuntimeWorkerCreep(object) {
+  return isRecord30(object) && isRecord30(object.memory) && object.memory.role === "worker";
 }
 function summarizeEnergySurplus(room, colonyWorkers) {
   const state = getRoomEnergySurplusState(room);

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -1081,7 +1081,7 @@ export function emitRuntimeSummary(
       tick,
       cachedEventMetricsTick
     );
-    refreshConstructionDeadlockTelemetry(colonies, creepsByColony, tick);
+    refreshConstructionDeadlockTelemetry(colonies, creepsByColony, creeps, tick);
   }
 
   const cpuSummary = buildCpuSummary();
@@ -1215,6 +1215,19 @@ function groupCreepsByColony(creeps: Creep[], colonies: ColonySnapshot[]): Map<s
   return creepsByColony;
 }
 
+function groupCreepsByVisibleRoom(creeps: Creep[]): Map<string, Creep[]> {
+  const creepsByVisibleRoom = new Map<string, Creep[]>();
+
+  for (const creep of creeps) {
+    const roomName = creep.room?.name;
+    if (isNonEmptyString(roomName)) {
+      addCreepToColonyGroup(creepsByVisibleRoom, roomName, creep);
+    }
+  }
+
+  return creepsByVisibleRoom;
+}
+
 function groupConstructionPlacementEventsByRoom(
   events: RuntimeTelemetryEvent[]
 ): Map<string, RuntimeConstructionPlacementTelemetryEvent[]> {
@@ -1297,8 +1310,9 @@ function summarizeRoom(
   if (persistOccupationRecommendations && includeOptionalSummary) {
     persistOccupationRecommendationFollowUpIntent(territoryRecommendation, tick);
   }
+  const roomTaskWorkers = selectRoomVisibleWorkers(colony, colonyWorkers, colonyCreeps);
   const resourcesWithoutActivity = summarizeResources(colony, colonyWorkers, colonyCreeps, eventMetrics.resources);
-  const taskCounts = countWorkerTasks(colonyWorkers);
+  const taskCounts = countWorkerTasks(roomTaskWorkers);
   const assignedTaskCount = countAssignedWorkerTasks(colonyWorkers);
   const productiveAssignmentCount = countProductiveWorkerAssignments(colonyWorkers);
   const workerAssignmentEvidence = summarizeWorkerAssignmentEvidence(
@@ -2687,11 +2701,15 @@ function countWorkerTasks(workers: Creep[]): WorkerTaskCounts {
 function refreshConstructionDeadlockTelemetry(
   colonies: ColonySnapshot[],
   creepsByColony: Map<string, Creep[]>,
+  creeps: Creep[],
   tick: number
 ): void {
+  const creepsByVisibleRoom = groupCreepsByVisibleRoom(creeps);
   for (const colony of colonies) {
-    const colonyWorkers = (creepsByColony.get(colony.room.name) ?? []).filter((creep) => creep.memory.role === 'worker');
-    const taskCounts = countWorkerTasks(colonyWorkers);
+    const colonyCreeps = creepsByColony.get(colony.room.name) ?? [];
+    const colonyWorkers = colonyCreeps.filter((creep) => creep.memory.role === 'worker');
+    const roomTaskWorkers = mergeRoomVisibleWorkers(colonyWorkers, creepsByVisibleRoom.get(colony.room.name) ?? []);
+    const taskCounts = countWorkerTasks(roomTaskWorkers);
     const constructionSiteCount = (findRoomObjects(colony.room, 'FIND_MY_CONSTRUCTION_SITES') ?? []).length;
     updateRoomConstructionDeadlockTicks(colony.room, taskCounts, constructionSiteCount, tick);
   }
@@ -3605,7 +3623,7 @@ function summarizeResources(
   const roomStructures = findRoomObjects(colony.room, 'FIND_STRUCTURES') ?? colony.spawns;
   const roomEnergyStructures = findRoomEnergyStoreStructures(colony.room, colony.spawns);
   const roomCreeps = findOwnedRoomCreeps(colony.room, colonyCreeps);
-  const productiveEnergyWorkers = mergeRoomWorkersForProductiveEnergy(colonyWorkers, roomCreeps);
+  const productiveEnergyWorkers = mergeRoomVisibleWorkers(colonyWorkers, roomCreeps);
   const constructionSites = findRoomObjects(colony.room, 'FIND_MY_CONSTRUCTION_SITES') ?? [];
   const droppedResources = findRoomObjects(colony.room, 'FIND_DROPPED_RESOURCES') ?? [];
   const sourceContainerCoverage = summarizeSourceContainerCoverage(colony.room);
@@ -3710,7 +3728,11 @@ function findOwnedRoomCreeps(room: Room, colonyCreeps: Creep[]): unknown[] {
   ]);
 }
 
-function mergeRoomWorkersForProductiveEnergy(colonyWorkers: Creep[], roomCreeps: unknown[]): Creep[] {
+function selectRoomVisibleWorkers(colony: ColonySnapshot, colonyWorkers: Creep[], colonyCreeps: Creep[]): Creep[] {
+  return mergeRoomVisibleWorkers(colonyWorkers, findOwnedRoomCreeps(colony.room, colonyCreeps));
+}
+
+function mergeRoomVisibleWorkers(colonyWorkers: Creep[], roomCreeps: unknown[]): Creep[] {
   return uniqueRoomObjects([...colonyWorkers, ...roomCreeps]).filter(isRuntimeWorkerCreep);
 }
 

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -3605,6 +3605,7 @@ function summarizeResources(
   const roomStructures = findRoomObjects(colony.room, 'FIND_STRUCTURES') ?? colony.spawns;
   const roomEnergyStructures = findRoomEnergyStoreStructures(colony.room, colony.spawns);
   const roomCreeps = findOwnedRoomCreeps(colony.room, colonyCreeps);
+  const productiveEnergyWorkers = mergeRoomWorkersForProductiveEnergy(colonyWorkers, roomCreeps);
   const constructionSites = findRoomObjects(colony.room, 'FIND_MY_CONSTRUCTION_SITES') ?? [];
   const droppedResources = findRoomObjects(colony.room, 'FIND_DROPPED_RESOURCES') ?? [];
   const sourceContainerCoverage = summarizeSourceContainerCoverage(colony.room);
@@ -3618,7 +3619,7 @@ function summarizeResources(
     sourceContainers: sourceContainerCoverage,
     productiveEnergy: summarizeProductiveEnergy(
       colony,
-      colonyWorkers,
+      productiveEnergyWorkers,
       constructionSites,
       roomStructures,
       roomEnergyStructures,
@@ -3707,6 +3708,14 @@ function findOwnedRoomCreeps(room: Room, colonyCreeps: Creep[]): unknown[] {
     ...(findRoomObjects(room, 'FIND_MY_CREEPS') ?? []),
     ...colonyCreeps
   ]);
+}
+
+function mergeRoomWorkersForProductiveEnergy(colonyWorkers: Creep[], roomCreeps: unknown[]): Creep[] {
+  return uniqueRoomObjects([...colonyWorkers, ...roomCreeps]).filter(isRuntimeWorkerCreep);
+}
+
+function isRuntimeWorkerCreep(object: unknown): object is Creep {
+  return isRecord(object) && isRecord(object.memory) && object.memory.role === 'worker';
 }
 
 function summarizeEnergySurplus(room: Room, colonyWorkers: Creep[]): RuntimeEnergySurplusSummary {

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -2595,6 +2595,51 @@ describe('runtime telemetry summaries', () => {
     );
   });
 
+  it('counts visible secondary-room builders even when colony memory points elsewhere', () => {
+    const constructionSite = {
+      id: 'road-site',
+      structureType: TEST_GLOBALS.STRUCTURE_ROAD,
+      progress: 240,
+      progressTotal: 500
+    };
+    const builder = makeWorker(
+      {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'build', targetId: 'road-site' as Id<ConstructionSite> }
+      },
+      61,
+      'worker-E29N55-support-2131872'
+    );
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      roomName: 'E29N56',
+      includeEventLog: false,
+      creeps: [builder],
+      constructionSites: [constructionSite]
+    });
+    (builder as Creep & { room: Room }).room = colony.room;
+
+    emitRuntimeSummary([colony], [builder]);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    const productiveEnergy = (room.resources as Record<string, Record<string, unknown>>).productiveEnergy;
+    expect(productiveEnergy).toMatchObject({
+      assignedWorkerCount: 1,
+      buildCarriedEnergy: 61,
+      constructionSiteCount: 1,
+      pendingBuildProgress: 260
+    });
+    expect(productiveEnergy).not.toHaveProperty('buildBlockedReason');
+    expect(room.constructionActivity).toMatchObject({
+      state: 'active',
+      accepted: true,
+      reason: 'build_energy_carried',
+      buildCarriedEnergy: 61
+    });
+  });
+
   it('reports spawn reservation detail for a construction assignment gap with room buffer energy', () => {
     const spawn = {
       id: 'spawn1',

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -2618,6 +2618,12 @@ describe('runtime telemetry summaries', () => {
       creeps: [builder],
       constructionSites: [constructionSite]
     });
+    (Memory.rooms as Record<string, RoomMemory>)[colony.room.name] = {
+      runtime: {
+        constructionDeadlockTicks: 42,
+        constructionDeadlockUpdatedAt: RUNTIME_SUMMARY_INTERVAL - 1
+      }
+    } as RoomMemory;
     (builder as Creep & { room: Room }).room = colony.room;
 
     emitRuntimeSummary([colony], [builder]);
@@ -2625,10 +2631,13 @@ describe('runtime telemetry summaries', () => {
     const payload = parseLoggedSummary();
     const [room] = payload.rooms as Array<Record<string, unknown>>;
     const productiveEnergy = (room.resources as Record<string, Record<string, unknown>>).productiveEnergy;
+    expect(room.taskCounts).toMatchObject({ build: 1 });
+    expect(room.constructionDeadlockTicks).toBe(0);
     expect(productiveEnergy).toMatchObject({
       assignedWorkerCount: 1,
       buildCarriedEnergy: 61,
       constructionSiteCount: 1,
+      constructionDeadlockTicks: 0,
       pendingBuildProgress: 260
     });
     expect(productiveEnergy).not.toHaveProperty('buildBlockedReason');

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -1792,13 +1792,44 @@ def runtime_pending_build_progress(room: dict[str, Any] | None) -> int | float |
 def runtime_build_carried_energy(room: dict[str, Any] | None) -> int | float | None:
     if not isinstance(room, dict):
         return None
-    return first_number_value(
+    reported_build_energy = first_number_value(
         room,
         ("buildCarriedEnergy",),
         ("resources", "productiveEnergy", "buildCarriedEnergy"),
         ("resources", "buildCarriedEnergy"),
         ("construction", "buildCarriedEnergy"),
     )
+    sampled_build_energy = runtime_worker_assignment_build_carried_energy(room)
+    if (
+        sampled_build_energy is not None
+        and sampled_build_energy > 0
+        and (reported_build_energy is None or reported_build_energy <= 0)
+    ):
+        return sampled_build_energy
+    return reported_build_energy
+
+
+def runtime_worker_assignment_build_carried_energy(room: dict[str, Any]) -> int | float | None:
+    evidence = as_dict(room.get("workerAssignmentEvidence"))
+    samples = evidence.get("creepSamples")
+    if not isinstance(samples, list):
+        return None
+
+    total = 0
+    observed_build_sample = False
+    for sample in samples:
+        if not isinstance(sample, dict):
+            continue
+        task = string_value(sample.get("task")) or string_value(sample.get("dispatchAssignedTask"))
+        if task != "build":
+            continue
+        carried = number_value(sample.get("carriedEnergy"))
+        if carried is None:
+            continue
+        observed_build_sample = True
+        total += max(0, carried)
+
+    return total if observed_build_sample else None
 
 
 def build_construction_deadlock_reason(

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -1104,6 +1104,24 @@ class PostdeployConstructionAcceptanceTest(unittest.TestCase):
         cases = (
             ({"buildCarriedEnergy": 25, "taskCounts": {"build": 0}}, "build_energy_carried"),
             ({"buildCarriedEnergy": 0, "constructionActivity": {"buildProgress": 5}}, "build_progress_observed"),
+            (
+                {
+                    "buildCarriedEnergy": 0,
+                    "taskCounts": {"build": 1},
+                    "workerAssignmentEvidence": {
+                        "available": True,
+                        "creepSamples": [
+                            {
+                                "name": "worker-E29N56-2131813",
+                                "role": "worker",
+                                "task": "build",
+                                "carriedEnergy": 100,
+                            }
+                        ],
+                    },
+                },
+                "build_energy_carried",
+            ),
         )
 
         for evidence, expected_reason in cases:
@@ -1121,11 +1139,32 @@ class PostdeployConstructionAcceptanceTest(unittest.TestCase):
                 self.assertTrue(acceptance["ok"])
                 self.assertEqual(acceptance["status"], "pass")
                 self.assertEqual(acceptance["rooms"][0]["reason"], expected_reason)
+                if "workerAssignmentEvidence" in evidence:
+                    self.assertEqual(acceptance["rooms"][0]["buildCarriedEnergy"], 100)
 
     def test_construction_acceptance_does_not_pass_on_build_assignment_alone(self) -> None:
         cases = (
             (
                 {"buildCarriedEnergy": 0, "constructionActivity": {"buildProgress": 0}, "taskCounts": {"build": 1}},
+                "blocked",
+                "no_build_execution",
+            ),
+            (
+                {
+                    "buildCarriedEnergy": 0,
+                    "taskCounts": {"build": 1},
+                    "workerAssignmentEvidence": {
+                        "available": True,
+                        "creepSamples": [
+                            {
+                                "name": "worker-E29N56-empty",
+                                "role": "worker",
+                                "task": "build",
+                                "carriedEnergy": 0,
+                            }
+                        ],
+                    },
+                },
                 "blocked",
                 "no_build_execution",
             ),


### PR DESCRIPTION
## Summary
- Adds runtime-summary accounting for visible secondary-room worker creeps even when their memory colony points at a support room.
- Lets the runtime monitor derive build carried energy from worker assignment samples when the summarized buildCarriedEnergy field is zero.
- Adds TypeScript and Python coverage for secondary-room builders with carried energy versus empty build assignments.

Related to issue 1831.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py`
- `python3 -m unittest scripts.test_screeps_runtime_monitor_tactical_response -q`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`

## Universal task Done gate
- [x] Task type: Code plus runtime monitor telemetry recovery slice for construction acceptance.
- [x] Expected observable outcome / named deliverable: Runtime summaries and monitor acceptance classify visible secondary-room builders carrying energy as construction execution evidence.
- [x] Non-goals / accepted substitutes: No gameplay policy retune, no paid RL compute, no issue lifecycle change, and no direct deploy from this branch.
- [x] Verification evidence required before Done: Controller verification passed diff check, Python compile, Python unittest, TypeScript typecheck, Jest all suites, and production bundle build on commit 1aaa7ba.
- [x] Project Evidence / Next action / Blocked by: Project evidence will name PR head 1aaa7ba, verification commands, and PR gate; Next action is review, merge gate, deploy, and all-room construction acceptance; Blocked by equals none for initial review.
- [x] Post-merge/deploy/runtime proof: Official deploy evidence plus fresh all-room construction acceptance must show E29N56 and E29N57 buildCarriedEnergy above zero or pendingBuildProgress decreasing before issue 1831 status advances to Done.
- [x] Named deliverable proof: Commit 1aaa7ba changes runtimeSummary telemetry, runtime monitor acceptance, tests, and generated prod/dist/main.js with successful local build output.
