### PR TITLE
monitor: add CPU recovery acceptance evidence gate

### DIFF
--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -212,6 +212,8 @@ ENERGY_BUFFER_UNHEALTHY_ROUTES = [
 ]
 CPU_BUCKET_LOW_KIND = "cpu_bucket_low"
 CPU_BUCKET_CRITICAL_KIND = "cpu_bucket_critical"
+CPU_USED_OVER_LIMIT_KIND = "cpu_used_over_limit"
+CPU_TELEMETRY_MISSING_KIND = "cpu_telemetry_missing"
 CPU_BUCKET_LOW_THRESHOLD = 1_000
 CPU_BUCKET_CRITICAL_THRESHOLD = 100
 CPU_BUCKET_ROUTES = [
@@ -490,6 +492,28 @@ TACTICAL_CATEGORY_RULES: dict[str, dict[str, Any]] = {
             "routes_to": CPU_BUCKET_ROUTES,
         },
     },
+    CPU_USED_OVER_LIMIT_KIND: {
+        "severity": "high",
+        "decision": "codex_hotfix",
+        "actions": ["capture_runtime_context", "inspect_recent_deploy", "start_hotfix_gate"],
+        "metadata": {
+            "metric": "cpu.used",
+            "related_issues": ["#1490", "#906", "#924"],
+            "thresholds": {"P1": "cpu.used > cpu.limit"},
+            "routes_to": CPU_BUCKET_ROUTES,
+        },
+    },
+    CPU_TELEMETRY_MISSING_KIND: {
+        "severity": "high",
+        "decision": "monitor_fix",
+        "actions": ["capture_runtime_context", "inspect_monitor_state", "restore_telemetry"],
+        "metadata": {
+            "metric": "cpu.telemetry",
+            "related_issues": ["#1490", "#906", "#924"],
+            "expected_fields": ["cpu.used", "cpu.bucket"],
+            "routes_to": CPU_BUCKET_ROUTES,
+        },
+    },
     "energy_buffer_unhealthy": {
         "severity": "high",
         "decision": "open_issue_or_codex_hotfix",
@@ -572,6 +596,8 @@ TACTICAL_REASON_CATEGORY_MAP = {
     "resource_crisis": ["resource_crisis"],
     CPU_BUCKET_CRITICAL_KIND: [CPU_BUCKET_CRITICAL_KIND],
     CPU_BUCKET_LOW_KIND: [CPU_BUCKET_LOW_KIND],
+    CPU_USED_OVER_LIMIT_KIND: [CPU_USED_OVER_LIMIT_KIND],
+    CPU_TELEMETRY_MISSING_KIND: [CPU_TELEMETRY_MISSING_KIND],
     "energy_buffer_unhealthy": ["energy_buffer_unhealthy"],
     CONSTRUCTION_DEADLOCK_KIND: [CONSTRUCTION_DEADLOCK_KIND],
     TERRITORY_EXPANSION_STAGNATION_KIND: [TERRITORY_EXPANSION_STAGNATION_KIND],
@@ -1553,6 +1579,24 @@ def cpu_bucket_metadata() -> dict[str, Any]:
     }
 
 
+def cpu_used_over_limit_metadata() -> dict[str, Any]:
+    return {
+        "metric": "cpu.used",
+        "related_issues": [str(route["issue"]) for route in CPU_BUCKET_ROUTES],
+        "thresholds": {"P1": "cpu.used > cpu.limit"},
+        "routes_to": [dict(route) for route in CPU_BUCKET_ROUTES],
+    }
+
+
+def cpu_telemetry_missing_metadata() -> dict[str, Any]:
+    return {
+        "metric": "cpu.telemetry",
+        "related_issues": [str(route["issue"]) for route in CPU_BUCKET_ROUTES],
+        "expected_fields": ["cpu.used", "cpu.bucket"],
+        "routes_to": [dict(route) for route in CPU_BUCKET_ROUTES],
+    }
+
+
 def string_list_values(value: Any) -> list[str]:
     if not isinstance(value, list):
         return []
@@ -1620,6 +1664,26 @@ def runtime_low_bucket_ticks(room: dict[str, Any]) -> int | float | None:
     )
 
 
+def runtime_cpu_has_current_evidence(room: dict[str, Any]) -> bool:
+    return (
+        runtime_cpu_bucket(room) is not None
+        or runtime_cpu_used(room) is not None
+        or runtime_low_bucket_ticks(room) is not None
+        or runtime_cpu_pressure(room) is not None
+        or bool(runtime_cpu_signal_values(room, "alerts"))
+        or bool(runtime_cpu_signal_values(room, "reasons"))
+    )
+
+
+def runtime_cpu_evidence_expected(room: dict[str, Any]) -> bool:
+    return (
+        "cpu" in room
+        or RUNTIME_SUMMARY_CPU_METADATA_KEY in room
+        or any(field in room for field in ("cpuUsed", "cpuBucket", "cpuLimit", "lowBucketTicks"))
+        or room.get(RUNTIME_SUMMARY_SOURCE_METADATA_KEY) == MONITOR_RUNTIME_SUMMARY_SOURCE
+    )
+
+
 def detect_cpu_bucket_kind(runtime_room: dict[str, Any] | None) -> str | None:
     if not isinstance(runtime_room, dict):
         return None
@@ -1631,6 +1695,7 @@ def detect_cpu_bucket_kind(runtime_room: dict[str, Any] | None) -> str | None:
 
     critical_bucket = (
         pressure == "critical"
+        or "criticalBucket" in alerts
         or "criticalBucket" in reasons
         or (bucket is not None and bucket <= CPU_BUCKET_CRITICAL_THRESHOLD)
     )
@@ -1639,7 +1704,9 @@ def detect_cpu_bucket_kind(runtime_room: dict[str, Any] | None) -> str | None:
 
     low_bucket = (
         "lowBucket" in alerts
+        or "lowBucketRecovery" in alerts
         or "lowBucket" in reasons
+        or "lowBucketRecovery" in reasons
         or (bucket is not None and bucket < CPU_BUCKET_LOW_THRESHOLD)
     )
     if low_bucket:
@@ -1692,6 +1759,118 @@ def detect_cpu_bucket_reason(ref: RoomRef, runtime_room: dict[str, Any] | None) 
     if kind is None or not isinstance(runtime_room, dict):
         return None
     return build_cpu_bucket_reason(ref, runtime_room, kind)
+
+
+def detect_cpu_used_over_limit(runtime_room: dict[str, Any] | None) -> bool:
+    if not isinstance(runtime_room, dict):
+        return False
+    used = runtime_cpu_used(runtime_room)
+    limit = runtime_cpu_limit(runtime_room)
+    return used is not None and limit is not None and used > limit
+
+
+def build_cpu_used_over_limit_reason(ref: RoomRef, runtime_room: dict[str, Any]) -> dict[str, Any]:
+    used = runtime_cpu_used(runtime_room)
+    limit = runtime_cpu_limit(runtime_room)
+    bucket = runtime_cpu_bucket(runtime_room)
+    pressure = runtime_cpu_pressure(runtime_room)
+    alerts = runtime_cpu_signal_values(runtime_room, "alerts")
+    reasons = runtime_cpu_signal_values(runtime_room, "reasons")
+    return {
+        "kind": CPU_USED_OVER_LIMIT_KIND,
+        "room": ref.key,
+        "room_name": ref.room,
+        "severity": "high",
+        "priority": "P1",
+        "cpuUsed": used,
+        "cpuLimit": limit,
+        "cpuBucket": bucket,
+        "cpu_bucket": bucket,
+        "bucket": bucket,
+        "pressure": pressure,
+        "alerts": alerts,
+        "reasons": reasons,
+        "metadata": cpu_used_over_limit_metadata(),
+        "message": (
+            f"{CPU_USED_OVER_LIMIT_KIND} in {ref.key}: cpu used {format_energy_value(used)} "
+            f"exceeds limit {format_energy_value(limit)}; bucket={format_energy_value(bucket)}, "
+            f"pressure={pressure or 'unknown'}."
+        ),
+        "signature": f"{CPU_USED_OVER_LIMIT_KIND}:{ref.key}",
+    }
+
+
+def detect_cpu_used_over_limit_reason(ref: RoomRef, runtime_room: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(runtime_room, dict) or not detect_cpu_used_over_limit(runtime_room):
+        return None
+    return build_cpu_used_over_limit_reason(ref, runtime_room)
+
+
+def build_cpu_telemetry_missing_reason(ref: RoomRef, runtime_room: dict[str, Any] | None) -> dict[str, Any]:
+    room = runtime_room if isinstance(runtime_room, dict) else {}
+    missing_fields = [
+        field
+        for field, value in (
+            ("cpu.used", runtime_cpu_used(room)),
+            ("cpu.bucket", runtime_cpu_bucket(room)),
+        )
+        if value is None
+    ]
+    return {
+        "kind": CPU_TELEMETRY_MISSING_KIND,
+        "room": ref.key,
+        "room_name": ref.room,
+        "severity": "high",
+        "priority": "P1",
+        "status": "unknown",
+        "cpuEvidenceState": "unknown",
+        "cpu_evidence_state": "unknown",
+        "missing": missing_fields,
+        "cpuUsed": runtime_cpu_used(room),
+        "cpuBucket": runtime_cpu_bucket(room),
+        "cpuLimit": runtime_cpu_limit(room),
+        "pressure": runtime_cpu_pressure(room),
+        "alerts": runtime_cpu_signal_values(room, "alerts"),
+        "reasons": runtime_cpu_signal_values(room, "reasons"),
+        "metadata": cpu_telemetry_missing_metadata(),
+        "message": f"{CPU_TELEMETRY_MISSING_KIND} in {ref.key}: missing current CPU telemetry {missing_fields or ['cpu.used', 'cpu.bucket']}",
+        "signature": f"{CPU_TELEMETRY_MISSING_KIND}:{ref.key}",
+    }
+
+
+def detect_cpu_telemetry_missing_reason(
+    ref: RoomRef,
+    runtime_room: dict[str, Any] | None,
+    *,
+    require_cpu_evidence: bool = False,
+) -> dict[str, Any] | None:
+    if not isinstance(runtime_room, dict):
+        return build_cpu_telemetry_missing_reason(ref, runtime_room) if require_cpu_evidence else None
+    if runtime_cpu_has_current_evidence(runtime_room):
+        return None
+    if not require_cpu_evidence and not runtime_cpu_evidence_expected(runtime_room):
+        return None
+    return build_cpu_telemetry_missing_reason(ref, runtime_room)
+
+
+def detect_cpu_runtime_reasons(
+    ref: RoomRef,
+    runtime_room: dict[str, Any] | None,
+    *,
+    require_cpu_evidence: bool = False,
+) -> list[dict[str, Any]]:
+    missing = detect_cpu_telemetry_missing_reason(ref, runtime_room, require_cpu_evidence=require_cpu_evidence)
+    if missing is not None:
+        return [missing]
+
+    reasons: list[dict[str, Any]] = []
+    bucket_reason = detect_cpu_bucket_reason(ref, runtime_room)
+    if bucket_reason is not None:
+        reasons.append(bucket_reason)
+    used_over_limit_reason = detect_cpu_used_over_limit_reason(ref, runtime_room)
+    if used_over_limit_reason is not None and bucket_reason is None:
+        reasons.append(used_over_limit_reason)
+    return reasons
 
 
 def build_energy_buffer_unhealthy_reason(
@@ -3527,9 +3706,7 @@ def evaluate_room_alert(
     if territory_expansion_stagnation_candidate is not None:
         detected.append(territory_expansion_stagnation_candidate)
 
-    cpu_bucket_candidate = detect_cpu_bucket_reason(snapshot.ref, runtime_room_summary)
-    if cpu_bucket_candidate is not None:
-        detected.append(cpu_bucket_candidate)
+    detected.extend(detect_cpu_runtime_reasons(snapshot.ref, runtime_room_summary))
 
     previous_energy_buffer_unhealthy_count = number_value(rule_counts.get(ENERGY_BUFFER_UNHEALTHY_KIND)) or 0
     energy_buffer_unhealthy_candidate = detect_energy_buffer_unhealthy_reason(
@@ -4037,7 +4214,10 @@ def infer_tactical_categories(reason: dict[str, Any]) -> list[str]:
         categories.append("hostiles")
     if "downgrade" in lowered_kind or "downgrade" in message:
         categories.append("downgrade_risk")
-    if "telemetry" in lowered_kind or "runtime-summary" in lowered_kind or "loop_exception" in lowered_kind:
+    if (
+        lowered_kind != CPU_TELEMETRY_MISSING_KIND
+        and ("telemetry" in lowered_kind or "runtime-summary" in lowered_kind or "loop_exception" in lowered_kind)
+    ):
         categories.append("telemetry_silence")
     if "silence" in lowered_kind or "silent" in lowered_kind:
         categories.append("telemetry_silence")
@@ -4055,7 +4235,10 @@ def infer_tactical_categories(reason: dict[str, Any]) -> list[str]:
         categories.append("monitor_integrity")
     if "damage" in lowered_kind:
         categories.append("owned_structure_damage")
-    if "missing" in lowered_kind or "disappear" in lowered_kind or "destroyed" in lowered_kind:
+    if (
+        lowered_kind != CPU_TELEMETRY_MISSING_KIND
+        and ("missing" in lowered_kind or "disappear" in lowered_kind or "destroyed" in lowered_kind)
+    ):
         categories.append("owned_structure_disappearance")
 
     current_hits = number_from_reason(reason, "current_hits", "currentHits", "hits")
@@ -7405,9 +7588,7 @@ def evaluate_postdeploy_health_gate(summary_payload: dict[str, Any], alert_paylo
             threshold_reason = threshold_exceeds_capacity_reason(room)
             if threshold_reason is not None:
                 reasons.append(threshold_reason)
-            cpu_reason = detect_cpu_bucket_reason(runtime_summary_room_ref(room), room)
-            if cpu_reason is not None:
-                reasons.append(cpu_reason)
+            reasons.extend(detect_cpu_runtime_reasons(runtime_summary_room_ref(room), room))
             if owner_missing:
                 creeps = 0
                 spawns = 0

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -7588,7 +7588,7 @@ def evaluate_postdeploy_health_gate(summary_payload: dict[str, Any], alert_paylo
             threshold_reason = threshold_exceeds_capacity_reason(room)
             if threshold_reason is not None:
                 reasons.append(threshold_reason)
-            reasons.extend(detect_cpu_runtime_reasons(runtime_summary_room_ref(room), room))
+            reasons.extend(detect_cpu_runtime_reasons(runtime_summary_room_ref(room), room, require_cpu_evidence=True))
             if owner_missing:
                 creeps = 0
                 spawns = 0

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -954,6 +954,8 @@ class PostdeployConstructionAcceptanceTest(unittest.TestCase):
                         "owner": "owner",
                         "owned_creeps": 2,
                         "owned_spawns": 1,
+                        "cpuUsed": 10,
+                        "cpuBucket": 9000,
                         **room,
                     }
                 ],
@@ -973,6 +975,8 @@ class PostdeployConstructionAcceptanceTest(unittest.TestCase):
                         "owner": "owner",
                         "owned_creeps": 2,
                         "owned_spawns": 1,
+                        "cpuUsed": 10,
+                        "cpuBucket": 9000,
                         "constructionSiteCount": 0,
                         "pendingBuildProgress": 0,
                     }
@@ -1001,6 +1005,8 @@ class PostdeployConstructionAcceptanceTest(unittest.TestCase):
                         "owner": "owner",
                         "owned_creeps": 2,
                         "owned_spawns": 1,
+                        "cpuUsed": 10,
+                        "cpuBucket": 9000,
                         "constructionSiteCount": 0,
                         "pendingBuildProgress": 0,
                     }
@@ -1037,6 +1043,8 @@ class PostdeployConstructionAcceptanceTest(unittest.TestCase):
                         "owner": "owner",
                         "owned_creeps": 2,
                         "owned_spawns": 1,
+                        "cpuUsed": 10,
+                        "cpuBucket": 9000,
                         "constructionSiteCount": 0,
                         "pendingBuildProgress": 0,
                     }
@@ -1068,6 +1076,8 @@ class PostdeployConstructionAcceptanceTest(unittest.TestCase):
                     "owner": "owner",
                     "owned_creeps": 2,
                     "owned_spawns": 1,
+                    "cpuUsed": 10,
+                    "cpuBucket": 9000,
                     "constructionSiteCount": 0,
                     "pendingBuildProgress": 0,
                 }
@@ -1221,6 +1231,7 @@ class PostdeployConstructionAcceptanceTest(unittest.TestCase):
         payload = {
             "type": "runtime-summary",
             "tick": 1200,
+            "cpu": {"used": 10, "bucket": 9000},
             "rooms": [
                 {
                     "roomName": "E26S49",
@@ -1271,6 +1282,8 @@ class PostdeployConstructionAcceptanceTest(unittest.TestCase):
                     "owner": "owner",
                     "owned_creeps": 2,
                     "owned_spawns": 1,
+                    "cpuUsed": 10,
+                    "cpuBucket": 9000,
                     "constructionSiteCount": 1,
                     "pendingBuildProgress": 300,
                     "buildCarriedEnergy": 0,
@@ -1475,7 +1488,14 @@ class TacticalResponseBridgeTest(unittest.TestCase):
                 "ok": True,
                 "mode": "summary",
                 "room_summaries": [
-                    {"room": "shardX/E29N57", "owner": "lanyusea", "owned_creeps": 4, "owned_spawns": 1}
+                    {
+                        "room": "shardX/E29N57",
+                        "owner": "lanyusea",
+                        "owned_creeps": 4,
+                        "owned_spawns": 1,
+                        "cpuUsed": 10,
+                        "cpuBucket": 9000,
+                    }
                 ],
             },
             {"ok": True, "mode": "alert", "alert": True, "reasons": [reason]},
@@ -2847,6 +2867,34 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertFalse(missing_health["ok"])
         self.assertIn(monitor.CPU_TELEMETRY_MISSING_KIND, [reason["kind"] for reason in missing_health["reasons"]])
         self.assertNotIn("postdeploy_room_dead", [reason["kind"] for reason in missing_health["reasons"]])
+
+    def test_postdeploy_health_gate_fails_closed_when_cpu_keys_are_absent(self) -> None:
+        health = monitor.evaluate_postdeploy_health_gate(
+            {
+                "ok": True,
+                "mode": "summary",
+                "room_summaries": [
+                    {
+                        "room": "shardX/E26S49",
+                        "owned_creeps": 1,
+                        "owned_spawns": 1,
+                        "creeps": 1,
+                        "spawns": 1,
+                        "owner": "owner",
+                        "constructionSiteCount": 0,
+                        "pendingBuildProgress": 0,
+                    }
+                ],
+            },
+            {"ok": True, "mode": "alert", "alert": False, "reasons": []},
+        )
+
+        self.assertFalse(health["ok"])
+        cpu_reason = next(
+            reason for reason in health["reasons"] if reason["kind"] == monitor.CPU_TELEMETRY_MISSING_KIND
+        )
+        self.assertEqual(cpu_reason["missing"], ["cpu.used", "cpu.bucket"])
+        self.assertNotIn("postdeploy_room_dead", [reason["kind"] for reason in health["reasons"]])
 
     def test_cpu_bucket_alert_does_not_mask_hostile_or_damage_alerts(self) -> None:
         previous = {

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -2523,7 +2523,245 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(report["priority"], "P1")
         self.assertEqual(report["categories"], [monitor.CPU_BUCKET_LOW_KIND])
 
-    def test_cpu_bucket_healthy_or_missing_summary_stays_silent(self) -> None:
+    def test_low_bucket_recovery_alerts_health_gate_and_tactical_response(self) -> None:
+        snapshot = make_snapshot(
+            {
+                "spawn1": {
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                },
+                "worker-1": {
+                    "type": "creep",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "name": "worker-1",
+                    "x": 23,
+                    "y": 25,
+                },
+            }
+        )
+        runtime_room = {
+            "room": "shardX/E26S49",
+            "roomName": "E26S49",
+            monitor.RUNTIME_SUMMARY_CPU_METADATA_KEY: {
+                "used": 20.5,
+                "limit": 70,
+                "bucket": 1744,
+                "pressure": "degraded",
+                "alerts": ["lowBucketRecovery"],
+                "reasons": ["lowBucketRecovery"],
+            },
+            "constructionSiteCount": 0,
+            "pendingBuildProgress": 0,
+        }
+
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            snapshot,
+            {"baseline_established": True, "owner": "owner"},
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_room,
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertEqual([reason["kind"] for reason in emitted], [monitor.CPU_BUCKET_LOW_KIND])
+        self.assertEqual(emitted[0]["priority"], "P1")
+        self.assertEqual(emitted[0]["reasons"], ["lowBucketRecovery"])
+
+        health = monitor.evaluate_postdeploy_health_gate(
+            {
+                "ok": True,
+                "mode": "summary",
+                "room_summaries": [
+                    {
+                        **runtime_room,
+                        "owned_creeps": 1,
+                        "owned_spawns": 1,
+                        "creeps": 1,
+                        "spawns": 1,
+                        "owner": "owner",
+                    }
+                ],
+            },
+            {"ok": True, "mode": "alert", "alert": True, "reasons": emitted, "rooms": ["shardX/E26S49"]},
+        )
+
+        self.assertFalse(health["ok"])
+        self.assertIn(monitor.CPU_BUCKET_LOW_KIND, [reason["kind"] for reason in health["reasons"]])
+
+        report = monitor.build_tactical_response_report(
+            {"ok": True, "mode": "alert", "alert": True, "reasons": emitted, "rooms": ["shardX/E26S49"]}
+        )
+        self.assertTrue(report["emergency"])
+        self.assertEqual(report["severity"], "high")
+        self.assertEqual(report["priority"], "P1")
+        self.assertEqual(report["categories"], [monitor.CPU_BUCKET_LOW_KIND])
+
+    def test_cpu_used_over_limit_alerts_health_gate_and_tactical_response(self) -> None:
+        snapshot = make_snapshot(
+            {
+                "spawn1": {
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                },
+                "worker-1": {
+                    "type": "creep",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "name": "worker-1",
+                    "x": 23,
+                    "y": 25,
+                },
+            }
+        )
+        runtime_room = {
+            "room": "shardX/E26S49",
+            "roomName": "E26S49",
+            monitor.RUNTIME_SUMMARY_CPU_METADATA_KEY: {
+                "used": 71.25,
+                "limit": 70,
+                "bucket": 9000,
+                "pressure": "normal",
+            },
+            "constructionSiteCount": 0,
+            "pendingBuildProgress": 0,
+        }
+
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            snapshot,
+            {"baseline_established": True, "owner": "owner"},
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_room,
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertEqual([reason["kind"] for reason in emitted], [monitor.CPU_USED_OVER_LIMIT_KIND])
+        self.assertEqual(emitted[0]["cpuUsed"], 71.25)
+        self.assertEqual(emitted[0]["cpuLimit"], 70)
+
+        health = monitor.evaluate_postdeploy_health_gate(
+            {
+                "ok": True,
+                "mode": "summary",
+                "room_summaries": [
+                    {
+                        **runtime_room,
+                        "owned_creeps": 1,
+                        "owned_spawns": 1,
+                        "creeps": 1,
+                        "spawns": 1,
+                        "owner": "owner",
+                    }
+                ],
+            },
+            {"ok": True, "mode": "alert", "alert": True, "reasons": emitted, "rooms": ["shardX/E26S49"]},
+        )
+
+        self.assertFalse(health["ok"])
+        self.assertIn(monitor.CPU_USED_OVER_LIMIT_KIND, [reason["kind"] for reason in health["reasons"]])
+
+        report = monitor.build_tactical_response_report(
+            {"ok": True, "mode": "alert", "alert": True, "reasons": emitted, "rooms": ["shardX/E26S49"]}
+        )
+        self.assertTrue(report["emergency"])
+        self.assertEqual(report["severity"], "high")
+        self.assertEqual(report["priority"], "P1")
+        self.assertEqual(report["categories"], [monitor.CPU_USED_OVER_LIMIT_KIND])
+        self.assertEqual(report["triggers"][0]["metadata"]["metric"], "cpu.used")
+
+    def test_missing_cpu_evidence_alerts_unknown_without_room_dead_false_positive(self) -> None:
+        snapshot = make_snapshot(
+            {
+                "spawn1": {
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                },
+                "worker-1": {
+                    "type": "creep",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "name": "worker-1",
+                    "x": 23,
+                    "y": 25,
+                },
+            }
+        )
+        runtime_room = {
+            "room": "shardX/E26S49",
+            "roomName": "E26S49",
+            monitor.RUNTIME_SUMMARY_SOURCE_METADATA_KEY: monitor.MONITOR_RUNTIME_SUMMARY_SOURCE,
+            "cpu": {"used": None, "bucket": None},
+            "cpuUsed": None,
+            "cpuBucket": None,
+            "workerCount": 1,
+            "constructionSiteCount": 0,
+            "pendingBuildProgress": 0,
+        }
+
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            snapshot,
+            {"baseline_established": True, "owner": "owner"},
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_room,
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertEqual([reason["kind"] for reason in emitted], [monitor.CPU_TELEMETRY_MISSING_KIND])
+        self.assertEqual(emitted[0]["cpuEvidenceState"], "unknown")
+        self.assertIn("cpu.used", emitted[0]["missing"])
+        self.assertIn("cpu.bucket", emitted[0]["missing"])
+        self.assertNotIn("room_dead", [reason["kind"] for reason in emitted])
+
+        health = monitor.evaluate_postdeploy_health_gate(
+            {
+                "ok": True,
+                "mode": "summary",
+                "room_summaries": [
+                    {
+                        **runtime_room,
+                        "owned_creeps": 1,
+                        "owned_spawns": 1,
+                        "creeps": 1,
+                        "spawns": 1,
+                        "owner": "owner",
+                    }
+                ],
+            },
+            {"ok": True, "mode": "alert", "alert": True, "reasons": emitted, "rooms": ["shardX/E26S49"]},
+        )
+
+        self.assertFalse(health["ok"])
+        health_kinds = [reason["kind"] for reason in health["reasons"]]
+        self.assertIn(monitor.CPU_TELEMETRY_MISSING_KIND, health_kinds)
+        self.assertNotIn("postdeploy_room_dead", health_kinds)
+        self.assertNotIn("postdeploy_no_owned_spawn", health_kinds)
+
+        report = monitor.build_tactical_response_report(
+            {"ok": True, "mode": "alert", "alert": True, "reasons": emitted, "rooms": ["shardX/E26S49"]}
+        )
+        self.assertTrue(report["emergency"])
+        self.assertEqual(report["priority"], "P1")
+        self.assertIn(monitor.CPU_TELEMETRY_MISSING_KIND, report["categories"])
+        self.assertNotIn("room_dead", report["categories"])
+
+    def test_cpu_bucket_healthy_or_missing_alert_summary_stays_silent(self) -> None:
         snapshot = make_snapshot(
             {
                 "spawn1": {
@@ -2563,35 +2801,52 @@ class TacticalResponseBridgeTest(unittest.TestCase):
                 self.assertNotIn(monitor.CPU_BUCKET_CRITICAL_KIND, [reason["kind"] for reason in emitted])
                 self.assertNotIn(monitor.CPU_BUCKET_LOW_KIND, [reason["kind"] for reason in emitted])
 
-        for room_summary in (
+        health = monitor.evaluate_postdeploy_health_gate(
             {
-                "room": "shardX/E26S49",
-                "owned_creeps": 1,
-                "owned_spawns": 1,
-                "creeps": 1,
-                "spawns": 1,
-                "owner": "owner",
-                "cpuBucket": 9000,
-                "constructionSiteCount": 0,
-                "pendingBuildProgress": 0,
+                "ok": True,
+                "mode": "summary",
+                "room_summaries": [
+                    {
+                        "room": "shardX/E26S49",
+                        "owned_creeps": 1,
+                        "owned_spawns": 1,
+                        "creeps": 1,
+                        "spawns": 1,
+                        "owner": "owner",
+                        "cpuBucket": 9000,
+                        "constructionSiteCount": 0,
+                        "pendingBuildProgress": 0,
+                    }
+                ],
             },
+            {"ok": True, "mode": "alert", "alert": False, "reasons": []},
+        )
+        self.assertTrue(health["ok"])
+
+        missing_health = monitor.evaluate_postdeploy_health_gate(
             {
-                "room": "shardX/E26S49",
-                "owned_creeps": 1,
-                "owned_spawns": 1,
-                "creeps": 1,
-                "spawns": 1,
-                "owner": "owner",
-                "constructionSiteCount": 0,
-                "pendingBuildProgress": 0,
+                "ok": True,
+                "mode": "summary",
+                "room_summaries": [
+                    {
+                        "room": "shardX/E26S49",
+                        "owned_creeps": 1,
+                        "owned_spawns": 1,
+                        "creeps": 1,
+                        "spawns": 1,
+                        "owner": "owner",
+                        "cpuUsed": None,
+                        "cpuBucket": None,
+                        "constructionSiteCount": 0,
+                        "pendingBuildProgress": 0,
+                    }
+                ],
             },
-        ):
-            with self.subTest(room_summary=room_summary):
-                health = monitor.evaluate_postdeploy_health_gate(
-                    {"ok": True, "mode": "summary", "room_summaries": [room_summary]},
-                    {"ok": True, "mode": "alert", "alert": False, "reasons": []},
-                )
-                self.assertTrue(health["ok"])
+            {"ok": True, "mode": "alert", "alert": False, "reasons": []},
+        )
+        self.assertFalse(missing_health["ok"])
+        self.assertIn(monitor.CPU_TELEMETRY_MISSING_KIND, [reason["kind"] for reason in missing_health["reasons"]])
+        self.assertNotIn("postdeploy_room_dead", [reason["kind"] for reason in missing_health["reasons"]])
 
     def test_cpu_bucket_alert_does_not_mask_hostile_or_damage_alerts(self) -> None:
         previous = {


### PR DESCRIPTION
## Linked issues

Intentional PR-body closing linkage:
- None.

Related / non-closing linkage:
- Related to issue 1490; this PR adds acceptance/monitor evidence plumbing only. The issue remains open for post-merge/deploy CPU-bearing runtime proof.

## Domain / Kind

- Domain: Runtime monitor
- Kind: bug

## Summary

- Treat missing CPU telemetry as a postdeploy health-gate blocker instead of allowing null CPU fields to look healthy.
- Preserve room-dead and hostile/damage alert behavior while adding CPU recovery evidence expectations.
- Extend focused runtime-monitor tests around missing CPU telemetry and CPU alert interactions.

## Verification

- [x] Local check: `git diff --check` passed.
- [x] Local check: `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py` passed.
- [x] Local check: `python3 -m unittest scripts.test_screeps_runtime_monitor_tactical_response -q` passed (134 tests OK).
- [x] GitHub Project issue/PR fields are current (`Status`, `Evidence`, `Next action`; plus `Blocked by` when blocked): issue item updated; PR item to be added after PR creation.
- [x] Automated review has no blocking findings, or a CodeRabbit/Gemini reliability bypass is recorded with reviewer/head/reason; review threads are resolved/outdated/non-blocking: pending initial automated review after PR creation.
- [x] QA gate: controller verification only; independent QA pending PR gate if requested by scheduler.
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate

- [x] Task type: runtime-monitor bugfix / acceptance-gate hardening.
- [x] Expected observable outcome / named deliverable: missing CPU telemetry is surfaced as an unhealthy postdeploy/runtime acceptance condition, so issue 1490 cannot close from null CPU fields.
- [x] Non-goals / accepted substitutes: this does not prove CPU bucket recovery and does not resume RL/Tencent compute.
- [x] Verification evidence required before Done: local diff check, py_compile, focused unittest, PR checks/review, then post-merge/deploy runtime evidence with fresh CPU-bearing telemetry.
- [x] Project Evidence / Next action / Blocked by: issue 1490 Project fields record commit recovery and the post-merge CPU-bearing runtime acceptance evidence target.
- [x] Post-merge/deploy/runtime proof: not claimed by this PR; issue 1490 must remain open until fresh CPU-bearing runtime-summary/monitor evidence proves no low-bucket recurrence.
- [x] Named deliverable proof: monitor/test changes are in this PR; runtime proof remains the issue acceptance gate.

## Issue closure gate

For every issue linked above in the PR body with a closing keyword:

- [x] No closing-keyword issue linkage is used; issue 1490 remains open for runtime acceptance.

## Runtime / deployment impact

- [ ] No gameplay/runtime/deployment impact.
- [x] Gameplay/runtime/deployment impact; Deployment Floor evidence or HELD blocker is recorded: monitor acceptance behavior changes only; no Screeps bot gameplay bundle change. Post-merge deploy is not required solely for this scripts-only PR unless the scheduler decides monitor scripts must be live in the deployment floor.

## Notes

- Fresh steward monitor bundle `/root/screeps/runtime-artifacts/screeps-monitor/rl-steward-check-20260613T164801Z/` still has `cpuBucket=null` and separately shows worker-assignment recurrence now tracked by issue 1858. RL compute/canary stays held behind issue 1490 + issue 1858.

