### PR TITLE
telemetry: emit build action result evidence

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -34803,16 +34803,22 @@ function summarizeAndResetWorkerBuildActionTelemetry(workers) {
   );
   const actionCount = sumBuildActionResultCounts(resultCounts);
   const buildFailCount = sumBuildFailureResultCounts(resultCounts);
+  const buildActionResult = selectDominantBuildActionResult(resultCounts);
+  const suppressedCount = resultCounts.suppressed_by_policy;
   for (const worker of workers) {
     delete worker.memory.buildActionTelemetry;
   }
   return {
+    buildActionResult,
+    buildFailCount,
+    buildSuppressedCount: suppressedCount,
+    buildActionResultCounts: resultCounts,
     buildActionResults: {
       source: "runtime-summary",
-      buildActionResult: selectDominantBuildActionResult(resultCounts),
+      buildActionResult,
       actionCount,
       buildFailCount,
-      suppressedCount: resultCounts.suppressed_by_policy,
+      suppressedCount,
       resultCounts,
       workers: workerSummaries
     }

--- a/prod/src/telemetry/buildActionTelemetry.ts
+++ b/prod/src/telemetry/buildActionTelemetry.ts
@@ -28,6 +28,14 @@ export interface RuntimeBuildActionSummary {
   workers: RuntimeBuildActionWorkerSummary[];
 }
 
+export interface RuntimeBuildActionRoomFields {
+  buildActionResult: WorkerBuildActionResult;
+  buildFailCount: number;
+  buildSuppressedCount: number;
+  buildActionResultCounts: RuntimeBuildActionResultCounts;
+  buildActionResults: RuntimeBuildActionSummary;
+}
+
 const BUILD_ACTION_RESULT_KEYS: WorkerBuildActionResult[] = [
   'succeeded',
   'failed_no_energy',
@@ -77,7 +85,7 @@ export function recordWorkerBuildActionResult(
 
 export function summarizeAndResetWorkerBuildActionTelemetry(
   workers: Creep[]
-): { buildActionResults?: RuntimeBuildActionSummary } {
+): Partial<RuntimeBuildActionRoomFields> {
   const workerSummaries = workers
     .map(toRuntimeBuildActionWorkerSummary)
     .filter((summary): summary is RuntimeBuildActionWorkerSummary => summary !== null)
@@ -93,18 +101,24 @@ export function summarizeAndResetWorkerBuildActionTelemetry(
   );
   const actionCount = sumBuildActionResultCounts(resultCounts);
   const buildFailCount = sumBuildFailureResultCounts(resultCounts);
+  const buildActionResult = selectDominantBuildActionResult(resultCounts);
+  const suppressedCount = resultCounts.suppressed_by_policy;
 
   for (const worker of workers) {
     delete worker.memory.buildActionTelemetry;
   }
 
   return {
+    buildActionResult,
+    buildFailCount,
+    buildSuppressedCount: suppressedCount,
+    buildActionResultCounts: resultCounts,
     buildActionResults: {
       source: 'runtime-summary',
-      buildActionResult: selectDominantBuildActionResult(resultCounts),
+      buildActionResult,
       actionCount,
       buildFailCount,
-      suppressedCount: resultCounts.suppressed_by_policy,
+      suppressedCount,
       resultCounts,
       workers: workerSummaries
     }

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -362,6 +362,10 @@ interface RuntimeRoomSummary {
   constructionDeadlockTicks: number;
   constructionActivity: RuntimeConstructionActivitySummary;
   constructionScoring: RuntimeConstructionScoringSummary;
+  buildActionResult?: WorkerBuildActionResult;
+  buildFailCount?: number;
+  buildSuppressedCount?: number;
+  buildActionResultCounts?: RuntimeBuildActionSummary['resultCounts'];
   buildActionResults?: RuntimeBuildActionSummary;
   behavior?: RuntimeBehaviorSummary;
   structures?: RuntimeStructureSnapshotSummary;

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -1655,6 +1655,17 @@ describe('runtime telemetry summaries', () => {
 
     const payload = parseLoggedSummary();
     const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.buildActionResult).toBe('failed_no_path');
+    expect(room.buildFailCount).toBe(3);
+    expect(room.buildSuppressedCount).toBe(1);
+    expect(room.buildActionResultCounts).toEqual({
+      succeeded: 1,
+      failed_no_energy: 0,
+      failed_no_work: 0,
+      failed_no_path: 2,
+      failed_site_invalid: 0,
+      suppressed_by_policy: 1
+    });
     expect(room.buildActionResults).toEqual({
       source: 'runtime-summary',
       buildActionResult: 'failed_no_path',

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -126,6 +126,17 @@ RUNTIME_SUMMARY_CPU_METADATA_KEY = "__runtimeSummaryCpu"
 MONITOR_RUNTIME_SUMMARY_SOURCE = "screeps-runtime-monitor"
 ASSIGNED_WORKER_TASK_NAMES = ("harvest", "pickup", "withdraw", "transfer", "build", "repair", "upgrade")
 WORKER_TASK_COUNT_NAMES = ("harvest", "transfer", "build", "repair", "upgrade")
+BUILD_ACTION_RESULT_NAMES = (
+    "succeeded",
+    "failed_no_energy",
+    "failed_no_work",
+    "failed_no_path",
+    "failed_site_invalid",
+    "suppressed_by_policy",
+)
+BUILD_ACTION_FAILURE_RESULT_NAMES = tuple(
+    result for result in BUILD_ACTION_RESULT_NAMES if result != "succeeded"
+)
 MAX_CREEP_MEMORY_ASSIGNMENT_EVIDENCE_PER_ROOM = 12
 MAX_CREEP_MEMORY_ASSIGNMENT_STRING_LENGTH = 96
 MAX_WORKER_ASSIGNMENT_BLOCKED_WORKERS = 12
@@ -1986,6 +1997,82 @@ def runtime_build_carried_energy(room: dict[str, Any] | None) -> int | float | N
     ):
         return sampled_build_energy
     return reported_build_energy
+
+
+def runtime_build_action_results(room: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(room, dict):
+        return {}
+    for path in (
+        ("buildActionResults",),
+        ("resources", "productiveEnergy", "buildActionResults"),
+        ("productiveEnergy", "buildActionResults"),
+    ):
+        value = as_dict(nested_value(room, *path))
+        if value:
+            return value
+    return {}
+
+
+def runtime_build_action_result(room: dict[str, Any] | None) -> str | None:
+    if not isinstance(room, dict):
+        return None
+    for value in (
+        room.get("buildActionResult"),
+        nested_value(room, "buildActionResults", "buildActionResult"),
+        nested_value(room, "resources", "productiveEnergy", "buildActionResult"),
+        nested_value(room, "resources", "productiveEnergy", "buildActionResults", "buildActionResult"),
+        nested_value(room, "productiveEnergy", "buildActionResult"),
+        nested_value(room, "productiveEnergy", "buildActionResults", "buildActionResult"),
+    ):
+        result = string_value(value)
+        if result in BUILD_ACTION_RESULT_NAMES:
+            return result
+    return None
+
+
+def runtime_build_fail_count(room: dict[str, Any] | None) -> int | float | None:
+    if not isinstance(room, dict):
+        return None
+    return first_number_value(
+        room,
+        ("buildFailCount",),
+        ("buildActionResults", "buildFailCount"),
+        ("resources", "productiveEnergy", "buildFailCount"),
+        ("resources", "productiveEnergy", "buildActionResults", "buildFailCount"),
+        ("productiveEnergy", "buildFailCount"),
+        ("productiveEnergy", "buildActionResults", "buildFailCount"),
+    )
+
+
+def runtime_build_suppressed_count(room: dict[str, Any] | None) -> int | float | None:
+    if not isinstance(room, dict):
+        return None
+    return first_number_value(
+        room,
+        ("buildSuppressedCount",),
+        ("buildActionResults", "suppressedCount"),
+        ("resources", "productiveEnergy", "buildSuppressedCount"),
+        ("resources", "productiveEnergy", "buildActionResults", "suppressedCount"),
+        ("productiveEnergy", "buildSuppressedCount"),
+        ("productiveEnergy", "buildActionResults", "suppressedCount"),
+    )
+
+
+def runtime_build_action_result_counts(room: dict[str, Any] | None) -> dict[str, int]:
+    if not isinstance(room, dict):
+        return {}
+    for path in (
+        ("buildActionResultCounts",),
+        ("buildActionResults", "resultCounts"),
+        ("resources", "productiveEnergy", "buildActionResultCounts"),
+        ("resources", "productiveEnergy", "buildActionResults", "resultCounts"),
+        ("productiveEnergy", "buildActionResultCounts"),
+        ("productiveEnergy", "buildActionResults", "resultCounts"),
+    ):
+        counts = normalized_build_action_result_counts(nested_value(room, *path))
+        if build_action_count(counts) > 0:
+            return counts
+    return {}
 
 
 def runtime_worker_assignment_build_carried_energy(room: dict[str, Any]) -> int | float | None:
@@ -5798,6 +5885,109 @@ def worker_task_counts(owned_creeps: list[dict[str, Any]]) -> dict[str, int]:
     return counts
 
 
+def empty_build_action_result_counts() -> dict[str, int]:
+    return {result: 0 for result in BUILD_ACTION_RESULT_NAMES}
+
+
+def build_action_telemetry_memory(creep: dict[str, Any]) -> dict[str, Any]:
+    return as_dict(creep_memory(creep).get("buildActionTelemetry"))
+
+
+def normalized_build_action_result_counts(value: Any) -> dict[str, int]:
+    raw_counts = as_dict(value)
+    counts = empty_build_action_result_counts()
+    for result in BUILD_ACTION_RESULT_NAMES:
+        counts[result] = non_negative_int(raw_counts.get(result))
+    return counts
+
+
+def build_action_count(result_counts: dict[str, int]) -> int:
+    return sum(result_counts.get(result, 0) for result in BUILD_ACTION_RESULT_NAMES)
+
+
+def build_action_failure_count(result_counts: dict[str, int]) -> int:
+    return sum(result_counts.get(result, 0) for result in BUILD_ACTION_FAILURE_RESULT_NAMES)
+
+
+def dominant_build_action_result(result_counts: dict[str, int]) -> str:
+    dominant = BUILD_ACTION_RESULT_NAMES[0]
+    for result in BUILD_ACTION_RESULT_NAMES:
+        if result_counts.get(result, 0) > result_counts.get(dominant, 0):
+            dominant = result
+    return dominant
+
+
+def build_action_worker_summary(creep: dict[str, Any]) -> dict[str, Any] | None:
+    telemetry = build_action_telemetry_memory(creep)
+    if not telemetry:
+        return None
+
+    result_counts = normalized_build_action_result_counts(telemetry.get("resultCounts"))
+    action_count = build_action_count(result_counts)
+    if action_count <= 0:
+        return None
+
+    last_result = string_value(telemetry.get("lastResult"))
+    build_action_result = (
+        last_result
+        if last_result in BUILD_ACTION_RESULT_NAMES
+        else dominant_build_action_result(result_counts)
+    )
+    summary: dict[str, Any] = {
+        **({"name": creep_name(creep)} if creep_name(creep) else {}),
+        "buildActionResult": build_action_result,
+        "actionCount": action_count,
+        "buildFailCount": build_action_failure_count(result_counts),
+        "suppressedCount": result_counts["suppressed_by_policy"],
+        "resultCounts": result_counts,
+    }
+    last_target_id = safe_assignment_string(telemetry.get("lastTargetId"))
+    if last_target_id is not None:
+        summary["lastTargetId"] = last_target_id
+    last_tick = number_value(telemetry.get("lastTick"))
+    if last_tick is not None:
+        summary["lastTick"] = math.floor(last_tick)
+    return summary
+
+
+def build_action_worker_sort_key(worker: dict[str, Any]) -> tuple[int, int, str, str]:
+    return (
+        -non_negative_int(worker.get("buildFailCount")),
+        -non_negative_int(worker.get("actionCount")),
+        string_value(worker.get("buildActionResult")) or "",
+        string_value(worker.get("name")) or "",
+    )
+
+
+def build_action_results_summary(owned_creeps: list[dict[str, Any]]) -> dict[str, Any] | None:
+    workers = sorted(
+        (
+            summary
+            for summary in (build_action_worker_summary(creep) for creep in owned_creeps)
+            if summary is not None
+        ),
+        key=build_action_worker_sort_key,
+    )
+    if not workers:
+        return None
+
+    result_counts = empty_build_action_result_counts()
+    for worker in workers:
+        worker_counts = normalized_build_action_result_counts(worker.get("resultCounts"))
+        for result in BUILD_ACTION_RESULT_NAMES:
+            result_counts[result] += worker_counts[result]
+
+    return {
+        "source": "runtime-summary",
+        "buildActionResult": dominant_build_action_result(result_counts),
+        "actionCount": build_action_count(result_counts),
+        "buildFailCount": build_action_failure_count(result_counts),
+        "suppressedCount": result_counts["suppressed_by_policy"],
+        "resultCounts": result_counts,
+        "workers": workers,
+    }
+
+
 def string_value(value: Any) -> str | None:
     if isinstance(value, str) and value:
         return value
@@ -5971,6 +6161,39 @@ def sanitize_worker_dispatch_diagnostic_memory(value: Any) -> dict[str, Any] | N
     return result or None
 
 
+def non_negative_int(value: Any) -> int:
+    numeric = number_value(value)
+    if numeric is None:
+        return 0
+    return max(0, math.floor(numeric))
+
+
+def sanitize_build_action_result_counts(value: Any) -> dict[str, int]:
+    raw_counts = as_dict(value)
+    return {result: non_negative_int(raw_counts.get(result)) for result in BUILD_ACTION_RESULT_NAMES}
+
+
+def sanitize_build_action_telemetry_memory(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+
+    result_counts = sanitize_build_action_result_counts(value.get("resultCounts"))
+    if sum(result_counts.values()) <= 0:
+        return None
+
+    result: dict[str, Any] = {"resultCounts": result_counts}
+    last_result = string_value(value.get("lastResult"))
+    if last_result in BUILD_ACTION_RESULT_NAMES:
+        result["lastResult"] = last_result
+    last_target_id = safe_assignment_string(value.get("lastTargetId"))
+    if last_target_id is not None:
+        result["lastTargetId"] = last_target_id
+    last_tick = number_value(value.get("lastTick"))
+    if last_tick is not None:
+        result["lastTick"] = math.floor(last_tick)
+    return result
+
+
 def sanitize_creep_assignment_memory(value: Any) -> dict[str, Any]:
     memory = as_dict(value)
     result: dict[str, Any] = {}
@@ -5984,6 +6207,9 @@ def sanitize_creep_assignment_memory(value: Any) -> dict[str, Any]:
     diagnostic = sanitize_worker_dispatch_diagnostic_memory(memory.get("workerDispatchDiagnostic"))
     if diagnostic is not None:
         result["workerDispatchDiagnostic"] = diagnostic
+    build_action_telemetry = sanitize_build_action_telemetry_memory(memory.get("buildActionTelemetry"))
+    if build_action_telemetry is not None:
+        result["buildActionTelemetry"] = build_action_telemetry
     return result
 
 
@@ -6750,6 +6976,18 @@ def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
         else {}
     )
     construction_activity = construction_activity_summary(snapshot, metrics, assignment_blocked_fields)
+    build_action_results = build_action_results_summary(owned_creeps)
+    build_action_fields = (
+        {
+            "buildActionResult": build_action_results["buildActionResult"],
+            "buildFailCount": build_action_results["buildFailCount"],
+            "buildSuppressedCount": build_action_results["suppressedCount"],
+            "buildActionResultCounts": build_action_results["resultCounts"],
+            "buildActionResults": build_action_results,
+        }
+        if build_action_results is not None
+        else {}
+    )
     worker_carried_energy = sum(store_energy(obj) for obj in owned_creeps)
     productive_energy = {
         "assignedWorkerCount": metrics.worker_assignment_evidence.get("assignedTaskCount", 0),
@@ -6764,6 +7002,7 @@ def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
         **assignment_evidence_unavailable_fields,
         "constructionActivity": construction_activity,
         "buildBlockedReason": metrics.build_blocked_reason,
+        **build_action_fields,
         **assignment_blocked_fields,
     }
 
@@ -6778,6 +7017,7 @@ def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
         "buildCarriedEnergy": metrics.build_carried_energy,
         "constructionDeadlockTicks": metrics.construction_deadlock_ticks,
         "buildBlockedReason": metrics.build_blocked_reason,
+        **build_action_fields,
         **assignment_blocked_fields,
         "constructionActivity": construction_activity,
         "constructionSiteCount": len(metrics.construction_sites),
@@ -7326,6 +7566,21 @@ def enrich_room_summaries_from_runtime_artifact(room_summaries: list[Any], artif
         build_carried_energy = runtime_build_carried_energy(runtime_room)
         if number_value(room.get("buildCarriedEnergy")) is None and build_carried_energy is not None:
             room["buildCarriedEnergy"] = build_carried_energy
+        build_action_result = runtime_build_action_result(runtime_room)
+        if not isinstance(room.get("buildActionResult"), str) and build_action_result is not None:
+            room["buildActionResult"] = build_action_result
+        build_fail_count = runtime_build_fail_count(runtime_room)
+        if number_value(room.get("buildFailCount")) is None and build_fail_count is not None:
+            room["buildFailCount"] = build_fail_count
+        build_suppressed_count = runtime_build_suppressed_count(runtime_room)
+        if number_value(room.get("buildSuppressedCount")) is None and build_suppressed_count is not None:
+            room["buildSuppressedCount"] = build_suppressed_count
+        build_action_result_counts = runtime_build_action_result_counts(runtime_room)
+        if not as_dict(room.get("buildActionResultCounts")) and build_action_result_counts:
+            room["buildActionResultCounts"] = dict(build_action_result_counts)
+        build_action_results = runtime_build_action_results(runtime_room)
+        if not as_dict(room.get("buildActionResults")) and build_action_results:
+            room["buildActionResults"] = dict(build_action_results)
         build_blocked_reason = runtime_build_blocked_reason(runtime_room)
         if not isinstance(room.get("buildBlockedReason"), str) and build_blocked_reason is not None:
             room["buildBlockedReason"] = build_blocked_reason
@@ -7373,6 +7628,11 @@ def postdeploy_construction_acceptance_room(room: dict[str, Any]) -> dict[str, A
     build_progress = postdeploy_construction_build_progress(room)
     build_count = postdeploy_construction_build_task_count(room)
     build_blocked_reason = runtime_build_blocked_reason(room)
+    build_action_result = runtime_build_action_result(room)
+    build_fail_count = runtime_build_fail_count(room)
+    build_suppressed_count = runtime_build_suppressed_count(room)
+    build_action_result_counts = runtime_build_action_result_counts(room)
+    build_action_success_count = build_action_result_counts.get("succeeded", 0) if build_action_result_counts else 0
 
     result: dict[str, Any] = {"room": room_name}
     for key, value in (
@@ -7381,11 +7641,17 @@ def postdeploy_construction_acceptance_room(room: dict[str, Any]) -> dict[str, A
         ("buildCarriedEnergy", build_carried_energy),
         ("buildProgress", build_progress),
         ("build", build_count),
+        ("buildFailCount", build_fail_count),
+        ("buildSuppressedCount", build_suppressed_count),
     ):
         if value is not None:
             result[key] = value
     if build_blocked_reason is not None:
         result["buildBlockedReason"] = build_blocked_reason
+    if build_action_result is not None:
+        result["buildActionResult"] = build_action_result
+    if build_action_result_counts:
+        result["buildActionResultCounts"] = build_action_result_counts
 
     if construction_site_count is None or pending_build_progress is None:
         missing = [
@@ -7412,6 +7678,15 @@ def postdeploy_construction_acceptance_room(room: dict[str, Any]) -> dict[str, A
             "status": "pass",
             "reason": "no_construction_backlog",
             "message": f"{room_name}: no construction backlog visible",
+        }
+
+    if build_action_success_count > 0 or build_action_result == "succeeded":
+        return {
+            **result,
+            "ok": True,
+            "status": "pass",
+            "reason": "build_action_succeeded",
+            "message": f"{room_name}: construction acceptance passed with build action success telemetry",
         }
 
     if build_carried_energy is not None and build_carried_energy > 0:
@@ -7441,6 +7716,18 @@ def postdeploy_construction_acceptance_room(room: dict[str, Any]) -> dict[str, A
             "message": (
                 f"{room_name}: construction backlog is visible, but buildCarriedEnergy/buildProgress telemetry "
                 "is missing"
+            ),
+        }
+
+    if build_fail_count is not None and build_fail_count > 0:
+        blocked_reason = build_action_result or build_blocked_reason or "build_action_failed"
+        return {
+            **result,
+            "ok": False,
+            "status": "blocked",
+            "reason": blocked_reason,
+            "message": (
+                f"{room_name}: construction backlog is visible with build action result {blocked_reason}"
             ),
         }
 

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -1272,6 +1272,64 @@ class PostdeployConstructionAcceptanceTest(unittest.TestCase):
         self.assertEqual(acceptance["status"], "pass")
         self.assertEqual(acceptance["rooms"][0]["reason"], "no_construction_backlog")
 
+    def test_construction_acceptance_uses_build_action_result_telemetry(self) -> None:
+        room = {
+            "roomName": "E26S49",
+            "constructionSiteCount": 1,
+            "pendingBuildProgress": 100,
+            "buildCarriedEnergy": 0,
+            "constructionActivity": {"buildProgress": 0},
+            "buildActionResult": "succeeded",
+            "buildFailCount": 0,
+            "buildActionResultCounts": {
+                "succeeded": 1,
+                "failed_no_energy": 0,
+                "failed_no_work": 0,
+                "failed_no_path": 0,
+                "failed_site_invalid": 0,
+                "suppressed_by_policy": 0,
+            },
+        }
+
+        result = monitor.postdeploy_construction_acceptance_room(room)
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["status"], "pass")
+        self.assertEqual(result["reason"], "build_action_succeeded")
+        self.assertEqual(result["buildActionResult"], "succeeded")
+        self.assertEqual(result["buildFailCount"], 0)
+
+    def test_construction_acceptance_blocks_on_build_action_failure_telemetry(self) -> None:
+        room = {
+            "roomName": "E26S49",
+            "constructionSiteCount": 1,
+            "pendingBuildProgress": 100,
+            "buildCarriedEnergy": 0,
+            "constructionActivity": {"buildProgress": 0},
+            "buildActionResults": {
+                "buildActionResult": "failed_no_path",
+                "buildFailCount": 2,
+                "suppressedCount": 1,
+                "resultCounts": {
+                    "succeeded": 0,
+                    "failed_no_energy": 0,
+                    "failed_no_work": 0,
+                    "failed_no_path": 1,
+                    "failed_site_invalid": 0,
+                    "suppressed_by_policy": 1,
+                },
+            },
+        }
+
+        result = monitor.postdeploy_construction_acceptance_room(room)
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["status"], "blocked")
+        self.assertEqual(result["reason"], "failed_no_path")
+        self.assertEqual(result["buildActionResult"], "failed_no_path")
+        self.assertEqual(result["buildFailCount"], 2)
+        self.assertEqual(result["buildSuppressedCount"], 1)
+
     def test_health_gate_command_fails_when_construction_acceptance_is_blocked(self) -> None:
         summary_payload = {
             "ok": True,
@@ -4156,6 +4214,154 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         self.assertEqual(payload["rooms"][0]["cpuBucket"], 9123)
         self.assertEqual(payload["cpu"], {"used": 7.25, "bucket": 9123})
         self.assertEqual(payload["rooms"][0]["combat"]["hostileCreepCount"], 1)
+
+    def test_creep_memory_sanitizer_preserves_build_action_telemetry(self) -> None:
+        sanitized = monitor.sanitize_creep_assignment_memory(
+            {
+                "role": "worker",
+                "task": {"type": "build", "targetId": "site-safe"},
+                "buildActionTelemetry": {
+                    "resultCounts": {
+                        "succeeded": 1,
+                        "failed_no_path": 2,
+                        "suppressed_by_policy": 1,
+                        "unexpected_result": 99,
+                    },
+                    "lastResult": "suppressed_by_policy",
+                    "lastTargetId": "site-safe",
+                    "lastTick": 265631.8,
+                    "secretToken": "do-not-copy",
+                },
+            }
+        )
+
+        self.assertEqual(
+            sanitized["buildActionTelemetry"],
+            {
+                "resultCounts": {
+                    "succeeded": 1,
+                    "failed_no_energy": 0,
+                    "failed_no_work": 0,
+                    "failed_no_path": 2,
+                    "failed_site_invalid": 0,
+                    "suppressed_by_policy": 1,
+                },
+                "lastResult": "suppressed_by_policy",
+                "lastTargetId": "site-safe",
+                "lastTick": 265631,
+            },
+        )
+        self.assertNotIn("secretToken", sanitized["buildActionTelemetry"])
+
+    def test_runtime_summary_payload_reports_build_action_results_from_creep_memory(self) -> None:
+        snapshot = monitor.RoomSnapshot(
+            ref=monitor.RoomRef(shard="shardX", room="E26S49"),
+            terrain="0" * monitor.TERRAIN_CELLS,
+            objects=monitor.normalize_objects(
+                {
+                    "worker-success": {
+                        "type": "creep",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "name": "BuilderSuccess",
+                        "store": {"energy": 0, "capacity": 50},
+                        "memory": {
+                            "role": "worker",
+                            "buildActionTelemetry": {
+                                "resultCounts": {"succeeded": 1},
+                                "lastResult": "succeeded",
+                                "lastTargetId": "site-success",
+                                "lastTick": 265631,
+                            },
+                        },
+                    },
+                    "worker-blocked": {
+                        "type": "creep",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "name": "BuilderBlocked",
+                        "store": {"energy": 50, "capacity": 50},
+                        "memory": {
+                            "role": "worker",
+                            "buildActionTelemetry": {
+                                "resultCounts": {"failed_no_path": 2, "suppressed_by_policy": 1},
+                                "lastResult": "suppressed_by_policy",
+                                "lastTargetId": "site-blocked",
+                                "lastTick": 265632,
+                            },
+                        },
+                    },
+                }
+            ),
+            tick=265632,
+            owner="lanyusea",
+            info={},
+        )
+
+        payload = monitor.runtime_summary_payload_from_snapshots([snapshot])
+        room = payload["rooms"][0]
+        expected_counts = {
+            "succeeded": 1,
+            "failed_no_energy": 0,
+            "failed_no_work": 0,
+            "failed_no_path": 2,
+            "failed_site_invalid": 0,
+            "suppressed_by_policy": 1,
+        }
+
+        self.assertEqual(room["buildActionResult"], "failed_no_path")
+        self.assertEqual(room["buildFailCount"], 3)
+        self.assertEqual(room["buildSuppressedCount"], 1)
+        self.assertEqual(room["buildActionResultCounts"], expected_counts)
+        self.assertEqual(room["resources"]["productiveEnergy"]["buildActionResultCounts"], expected_counts)
+        self.assertEqual(
+            room["buildActionResults"],
+            {
+                "source": "runtime-summary",
+                "buildActionResult": "failed_no_path",
+                "actionCount": 4,
+                "buildFailCount": 3,
+                "suppressedCount": 1,
+                "resultCounts": expected_counts,
+                "workers": [
+                    {
+                        "name": "BuilderBlocked",
+                        "buildActionResult": "suppressed_by_policy",
+                        "actionCount": 3,
+                        "buildFailCount": 3,
+                        "suppressedCount": 1,
+                        "resultCounts": {
+                            "succeeded": 0,
+                            "failed_no_energy": 0,
+                            "failed_no_work": 0,
+                            "failed_no_path": 2,
+                            "failed_site_invalid": 0,
+                            "suppressed_by_policy": 1,
+                        },
+                        "lastTargetId": "site-blocked",
+                        "lastTick": 265632,
+                    },
+                    {
+                        "name": "BuilderSuccess",
+                        "buildActionResult": "succeeded",
+                        "actionCount": 1,
+                        "buildFailCount": 0,
+                        "suppressedCount": 0,
+                        "resultCounts": {
+                            "succeeded": 1,
+                            "failed_no_energy": 0,
+                            "failed_no_work": 0,
+                            "failed_no_path": 0,
+                            "failed_site_invalid": 0,
+                            "suppressed_by_policy": 0,
+                        },
+                        "lastTargetId": "site-success",
+                        "lastTick": 265631,
+                    },
+                ],
+            },
+        )
+        self.assertEqual(room["resources"]["productiveEnergy"]["buildActionResults"], room["buildActionResults"])
 
     def test_runtime_summary_payload_reports_null_controller_sign_evidence(self) -> None:
         snapshot = monitor.RoomSnapshot(


### PR DESCRIPTION
## Summary

Related to issue 1752.

- Emits structured build action result evidence in runtime telemetry so construction-stall diagnosis can distinguish attempted, successful, and failed build actions.
- Carries the new fields through runtime summary generation and monitor tactical-response parsing.
- Adds regression coverage for the runtime summary and monitor response paths.

## Verification

Controller-side verification on rebased head `9a1cefdb6cd016ddf05302b94603b37b8b39eec1`:

- `git diff --check`
- `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py`
- `python3 -m unittest scripts.test_screeps_runtime_monitor_tactical_response -q`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`

## Universal task Done gate

- [x] Task type: code and telemetry implementation slice.
- [x] Expected observable outcome / named deliverable: runtime telemetry includes build action result counts plus monitor tactical-response evidence for construction stalls.
- [x] Non-goals / accepted substitutes: this PR does not assert live runtime acceptance for issue 1752; runtime proof is recorded by the issue gate.
- [x] Verification evidence required before Done: diff check, Python compile, focused monitor unittest, TypeScript typecheck, Jest run-in-band, and production bundle build all pass on the rebased head.
- [x] Project Evidence / Next action / Blocked by: Project fields cite PR review gate, verification commands, and runtime proof requirement for issue 1752.
- [x] Post-merge/deploy/runtime proof: issue 1752 closes from a fresh runtime-summary or monitor capture showing the named build action result telemetry fields.
- [x] Named deliverable proof: commit `9a1cefdb6cd016ddf05302b94603b37b8b39eec1` updates `prod/src/telemetry/buildActionTelemetry.ts`, runtime summary plumbing, monitor parser, tests, and `prod/dist/main.js`.
