### PR TITLE
monitor: surface postdeploy CPU console telemetry

### DIFF
--- a/.github/workflows/official-screeps-deploy.yml
+++ b/.github/workflows/official-screeps-deploy.yml
@@ -136,6 +136,12 @@ jobs:
           SCREEPS_MONITOR_CACHE_DIR: runtime-artifacts/screeps-monitor/terrain-cache
         run: |
           mkdir -p runtime-artifacts/runtime-summary-console
+          python3 scripts/screeps_runtime_summary_console_capture.py \
+            --live-official-console \
+            --out-dir runtime-artifacts/runtime-summary-console \
+            --artifact-name postdeploy-runtime-summary-console.log \
+            --format status-line \
+            --live-timeout-seconds 45 || true
           python3 scripts/screeps-runtime-monitor.py summary \
             --out-dir runtime-artifacts/screeps-monitor \
             --runtime-summary-out-dir runtime-artifacts/runtime-summary-console \

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -42390,7 +42390,7 @@ var RUNTIME_SUMMARY_PREFIX = "#runtime-summary ";
 var RUNTIME_CPU_SUMMARY_PREFIX = "#cpu-summary ";
 var RUNTIME_SUMMARY_INTERVAL = 20;
 var DEGRADED_RUNTIME_SUMMARY_INTERVAL = RUNTIME_SUMMARY_INTERVAL * 5;
-var RUNTIME_CPU_SUMMARY_REPEAT_INTERVAL = DEGRADED_RUNTIME_SUMMARY_INTERVAL;
+var RUNTIME_CPU_SUMMARY_REPEAT_INTERVAL = 5;
 var MAX_REPORTED_EVENTS = 10;
 var MAX_WORKER_EFFICIENCY_SAMPLES = 5;
 var MAX_WORKER_BEHAVIOR_SAMPLES = 10;
@@ -45170,7 +45170,7 @@ function shouldEmitRuntimeCpuSummary(cpu, tick) {
   const previousSignal = getPreviousRuntimeCpuSummarySignal(tick);
   recordRuntimeCpuSummarySignal(signal, tick);
   if (!signal) {
-    return false;
+    return isRuntimeCpuSummaryRepeatTick(tick);
   }
   return signal !== previousSignal || isRuntimeCpuSummaryRepeatTick(tick);
 }

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -109,7 +109,7 @@ export const RUNTIME_SUMMARY_PREFIX = '#runtime-summary ';
 export const RUNTIME_CPU_SUMMARY_PREFIX = '#cpu-summary ';
 export const RUNTIME_SUMMARY_INTERVAL = 20;
 const DEGRADED_RUNTIME_SUMMARY_INTERVAL = RUNTIME_SUMMARY_INTERVAL * 5;
-const RUNTIME_CPU_SUMMARY_REPEAT_INTERVAL = DEGRADED_RUNTIME_SUMMARY_INTERVAL;
+const RUNTIME_CPU_SUMMARY_REPEAT_INTERVAL = 5;
 const MAX_REPORTED_EVENTS = 10;
 const MAX_WORKER_EFFICIENCY_SAMPLES = 5;
 const MAX_WORKER_BEHAVIOR_SAMPLES = 10;
@@ -5017,7 +5017,7 @@ function shouldEmitRuntimeCpuSummary(cpu: RuntimeCpuSummary, tick: number): bool
   const previousSignal = getPreviousRuntimeCpuSummarySignal(tick);
   recordRuntimeCpuSummarySignal(signal, tick);
   if (!signal) {
-    return false;
+    return isRuntimeCpuSummaryRepeatTick(tick);
   }
 
   return signal !== previousSignal || isRuntimeCpuSummaryRepeatTick(tick);

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -435,6 +435,22 @@ describe('runtime telemetry summaries', () => {
     expect(logSpy).not.toHaveBeenCalled();
   });
 
+  it('emits compact healthy CPU evidence on the short CPU cadence without a full room summary', () => {
+    const colony = makeColony({ time: 5 });
+
+    emitRuntimeSummary([colony], []);
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const [message] = logSpy.mock.calls[0];
+    expect(typeof message).toBe('string');
+    expect((message as string).startsWith(RUNTIME_CPU_SUMMARY_PREFIX)).toBe(true);
+    const payload = JSON.parse((message as string).slice(RUNTIME_CPU_SUMMARY_PREFIX.length)) as Record<string, unknown>;
+    expect(payload).toEqual({
+      used: 4.2,
+      bucket: 9000
+    });
+  });
+
   it('emits compact CPU alerts without a full room summary under degraded cadence', () => {
     const colony = makeColony({ time: 1 });
     (Game as Partial<Game>).cpu = {
@@ -1447,7 +1463,12 @@ describe('runtime telemetry summaries', () => {
       emitRuntimeSummary([colony], [worker], [], { persistOccupationRecommendations: false });
     }
 
-    expect(logSpy).not.toHaveBeenCalled();
+    expect(
+      logSpy.mock.calls.every(([message]) =>
+        typeof message === 'string' && message.startsWith(RUNTIME_CPU_SUMMARY_PREFIX)
+      )
+    ).toBe(true);
+    expect(logSpy).toHaveBeenCalledTimes(3);
     expect(roomFind).toHaveBeenCalledTimes(RUNTIME_SUMMARY_INTERVAL - 1);
     expect(roomFind.mock.calls.every(([findType]) => findType === TEST_GLOBALS.FIND_MY_CONSTRUCTION_SITES)).toBe(true);
     expect(getEventLog).not.toHaveBeenCalled();

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -5079,7 +5079,11 @@ def render_room_snapshot(
     return png_path.resolve()
 
 
-def room_summary(snapshot: RoomSnapshot, image: str | None = None) -> dict[str, Any]:
+def room_summary(
+    snapshot: RoomSnapshot,
+    image: str | None = None,
+    runtime_room_summary: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     info = snapshot.info if isinstance(snapshot.info, dict) else {}
     hostiles = detect_hostile_creeps(snapshot.objects, snapshot.owner)
     metrics = compute_room_summary_metrics(snapshot)
@@ -5139,7 +5143,7 @@ def room_summary(snapshot: RoomSnapshot, image: str | None = None) -> dict[str, 
         summary["behavior"] = {"totals": behavior_totals}
     if image:
         summary["image"] = image
-    return summary
+    return room_with_runtime_cpu_evidence(summary, runtime_room_summary)
 
 
 def summarize_rooms(snapshots: list[RoomSnapshot]) -> dict[str, Any]:
@@ -5404,8 +5408,8 @@ def runtime_summary_room_with_metadata(
     return result
 
 
-def runtime_cpu_summary_room(ref: RoomRef, cpu: dict[str, Any]) -> dict[str, Any]:
-    result: dict[str, Any] = {"room": ref.key, "roomName": ref.room, "shard": ref.shard}
+def runtime_cpu_summary_fields(cpu: dict[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
     used = number_value(cpu.get("used"))
     if used is not None:
         result["cpuUsed"] = used
@@ -5419,6 +5423,15 @@ def runtime_cpu_summary_room(ref: RoomRef, cpu: dict[str, Any]) -> dict[str, Any
     if low_bucket_ticks is not None:
         result["lowBucketTicks"] = low_bucket_ticks
     return result
+
+
+def runtime_cpu_summary_room(ref: RoomRef, cpu: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "room": ref.key,
+        "roomName": ref.room,
+        "shard": ref.shard,
+        **runtime_cpu_summary_fields(cpu),
+    }
 
 
 def runtime_summary_room_with_cpu_fields(base: dict[str, Any], cpu_room: dict[str, Any]) -> dict[str, Any]:
@@ -5446,6 +5459,19 @@ def runtime_summary_room_with_cpu_fields(base: dict[str, Any], cpu_room: dict[st
         if field in cpu_room:
             result[field] = cpu_room[field]
     return result
+
+
+def room_with_runtime_cpu_evidence(
+    room: dict[str, Any],
+    runtime_room_summary: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if not isinstance(runtime_room_summary, dict):
+        return room
+    if not runtime_summary_room_has_cpu_fields(runtime_room_summary) and not as_dict(
+        runtime_room_summary.get(RUNTIME_SUMMARY_CPU_METADATA_KEY)
+    ):
+        return room
+    return runtime_summary_room_with_cpu_fields(room, runtime_room_summary)
 
 
 def runtime_summary_capture_history_entry(room: dict[str, Any]) -> dict[str, Any]:
@@ -7056,21 +7082,38 @@ def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
     return summary
 
 
-def runtime_summary_payload_from_snapshots(snapshots: list[RoomSnapshot]) -> dict[str, Any]:
+def runtime_summary_payload_from_snapshots(
+    snapshots: list[RoomSnapshot],
+    runtime_room_summaries: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     ticks = [snapshot.tick for snapshot in snapshots if isinstance(snapshot.tick, int)]
+    rooms = [
+        room_with_runtime_cpu_evidence(
+            runtime_summary_room(snapshot),
+            runtime_room_summaries.get(snapshot.ref.key) if runtime_room_summaries is not None else None,
+        )
+        for snapshot in snapshots
+    ]
     cpu_used = next((value for value in (snapshot_cpu_used(snapshot) for snapshot in snapshots) if value is not None), None)
+    if cpu_used is None:
+        cpu_used = next((runtime_cpu_used(room) for room in rooms if runtime_cpu_used(room) is not None), None)
     cpu_bucket = next((value for value in (snapshot_cpu_bucket(snapshot) for snapshot in snapshots) if value is not None), None)
+    if cpu_bucket is None:
+        cpu_bucket = next((runtime_cpu_bucket(room) for room in rooms if runtime_cpu_bucket(room) is not None), None)
     return {
         "type": "runtime-summary",
         "tick": max(ticks) if ticks else None,
-        "rooms": [runtime_summary_room(snapshot) for snapshot in snapshots],
+        "rooms": rooms,
         "cpu": {"used": cpu_used, "bucket": cpu_bucket},
         "source": MONITOR_RUNTIME_SUMMARY_SOURCE,
     }
 
 
-def runtime_summary_artifact_line(snapshots: list[RoomSnapshot]) -> str:
-    payload = runtime_summary_payload_from_snapshots(snapshots)
+def runtime_summary_artifact_line(
+    snapshots: list[RoomSnapshot],
+    runtime_room_summaries: dict[str, dict[str, Any]] | None = None,
+) -> str:
+    payload = runtime_summary_payload_from_snapshots(snapshots, runtime_room_summaries=runtime_room_summaries)
     return "#runtime-summary " + json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n"
 
 
@@ -7102,10 +7145,14 @@ def link_artifact_exclusively(temp_path: Path, path: Path) -> Path:
     raise FileExistsError(f"could not choose a unique artifact path for {path}")
 
 
-def write_runtime_summary_artifact(snapshots: list[RoomSnapshot], out_dir: Path) -> Path:
+def write_runtime_summary_artifact(
+    snapshots: list[RoomSnapshot],
+    out_dir: Path,
+    runtime_room_summaries: dict[str, dict[str, Any]] | None = None,
+) -> Path:
     out_dir.mkdir(parents=True, exist_ok=True)
     target = out_dir / runtime_summary_artifact_name()
-    payload = runtime_summary_artifact_line(snapshots)
+    payload = runtime_summary_artifact_line(snapshots, runtime_room_summaries=runtime_room_summaries)
     temp_fd: int | None = None
     temp_path: Path | None = None
     try:
@@ -7502,20 +7549,46 @@ def runtime_summary_lookup_keys(room: dict[str, Any]) -> list[str]:
 
 
 def load_runtime_summary_artifact_rooms(artifact_path: str) -> dict[str, dict[str, Any]]:
+    path = Path(artifact_path)
     try:
-        lines = Path(artifact_path).read_text(encoding="utf-8").splitlines()
+        lines = path.read_text(encoding="utf-8").splitlines()
     except OSError:
         return {}
 
+    cpu_room: dict[str, Any] | None = None
+    cpu_key: tuple[bool, float, int, bool, int, str] | None = None
+    for line_index, line in enumerate(lines):
+        cpu_payload = parse_runtime_cpu_summary_line(line)
+        if cpu_payload is None:
+            continue
+        candidate_key = runtime_summary_freshness_key(cpu_payload, path, line_index)
+        if cpu_key is not None and candidate_key <= cpu_key:
+            continue
+        cpu = as_dict(cpu_payload.get("cpu"))
+        cpu_room = runtime_summary_room_with_metadata(
+            cpu_payload,
+            path,
+            runtime_cpu_summary_fields(cpu),
+            line_index,
+        )
+        cpu_key = candidate_key
+
     result: dict[str, dict[str, Any]] = {}
-    for line in reversed(lines):
+    for line_index, line in reversed(list(enumerate(lines))):
         payload = parse_runtime_summary_line(line)
         if payload is None:
             continue
+        runtime_key = runtime_summary_freshness_key(payload, path, line_index)
         for room in payload_runtime_rooms(payload):
             if not runtime_summary_room_has_monitor_alert_fields(room, payload):
                 continue
-            runtime_room = runtime_summary_room_with_metadata(payload, Path(artifact_path), room)
+            runtime_room = runtime_summary_room_with_metadata(payload, path, room, line_index)
+            if cpu_room is not None and (
+                not runtime_summary_room_has_cpu_fields(runtime_room)
+                or cpu_key is not None
+                and cpu_key > runtime_key
+            ):
+                runtime_room = runtime_summary_room_with_cpu_fields(runtime_room, cpu_room)
             for key in runtime_summary_lookup_keys(room):
                 result.setdefault(key, runtime_room)
         if result:
@@ -7935,6 +8008,16 @@ def command_health_gate(args: argparse.Namespace) -> int:
 def command_summary(args: argparse.Namespace) -> int:
     ctx = context_from_env(args.world_profile)
     snapshots, warnings, overview_refs = collect_snapshots(ctx, args.room)
+    runtime_room_summaries = (
+        load_latest_runtime_room_summaries(
+            Path(args.runtime_summary_out_dir).expanduser(),
+            [snapshot.ref for snapshot in snapshots],
+            warnings,
+            disambiguation_refs=overview_refs,
+        )
+        if not args.no_runtime_summary_artifact
+        else {}
+    )
     images: list[str] = []
     room_summaries: list[dict[str, Any]] = []
     out_dir = Path(args.out_dir)
@@ -7945,12 +8028,24 @@ def command_summary(args: argparse.Namespace) -> int:
             images.append(image)
         except Exception as exc:  # noqa: BLE001 - JSON summary evidence must survive renderer outages
             warnings.append(f"summary image render failed for {snapshot.ref.key}: {short_text(redact_secrets(str(exc), [ctx.token]), 180)}")
-        room_summaries.append(room_summary(snapshot, image=image))
+        room_summaries.append(
+            room_summary(
+                snapshot,
+                image=image,
+                runtime_room_summary=runtime_room_summaries.get(snapshot.ref.key),
+            )
+        )
 
     runtime_summary_artifact: str | None = None
     if not args.no_runtime_summary_artifact:
         try:
-            runtime_summary_artifact = str(write_runtime_summary_artifact(snapshots, Path(args.runtime_summary_out_dir)))
+            runtime_summary_artifact = str(
+                write_runtime_summary_artifact(
+                    snapshots,
+                    Path(args.runtime_summary_out_dir),
+                    runtime_room_summaries=runtime_room_summaries,
+                )
+            )
         except Exception as exc:  # noqa: BLE001 - keep image delivery alive; report sanitized warning
             warnings.append(f"runtime-summary artifact unavailable: {short_text(exc, 160)}")
 

--- a/scripts/screeps_official_deploy.py
+++ b/scripts/screeps_official_deploy.py
@@ -938,6 +938,11 @@ def run_monitor_json(
     return payload
 
 
+def postdeploy_runtime_summary_console_dir(cfg: DeployConfig) -> Path:
+    """Return the post-deploy console telemetry directory for this checkout."""
+    return cfg.repo_root / "runtime-artifacts" / "runtime-summary-console"
+
+
 def run_postdeploy_console_capture(
     cfg: DeployConfig,
     *,
@@ -946,7 +951,7 @@ def run_postdeploy_console_capture(
 ) -> subprocess.CompletedProcess[str]:
     """Capture compact runtime console telemetry for the post-deploy health gate."""
     script = cfg.repo_root / "scripts" / "screeps_runtime_summary_console_capture.py"
-    out_dir = cfg.repo_root / "runtime-artifacts" / "runtime-summary-console"
+    out_dir = postdeploy_runtime_summary_console_dir(cfg)
     return run_checked_command(
         "runtime summary console capture",
         [
@@ -979,16 +984,36 @@ def run_postdeploy_health_gate(
 ) -> dict[str, Any]:
     """Capture post-deploy summary/alert evidence and evaluate the health gate."""
     cfg.evidence_dir.mkdir(parents=True, exist_ok=True)
-    out_dir = cfg.repo_root / "runtime-artifacts" / "screeps-monitor"
+    monitor_out_dir = cfg.repo_root / "runtime-artifacts" / "screeps-monitor"
+    runtime_summary_dir = postdeploy_runtime_summary_console_dir(cfg)
     summary_path = cfg.evidence_dir / "postdeploy-summary.json"
     alert_path = cfg.evidence_dir / "postdeploy-alert.json"
     health_path = postdeploy_health_gate_path(cfg)
 
     run_postdeploy_console_capture(cfg, env=env, runner=runner)
-    run_monitor_json(cfg, ["summary", "--out-dir", str(out_dir)], summary_path, env=env, runner=runner)
     run_monitor_json(
         cfg,
-        ["alert", "--out-dir", str(out_dir), "--force-alert-image"],
+        [
+            "summary",
+            "--out-dir",
+            str(monitor_out_dir),
+            "--runtime-summary-out-dir",
+            str(runtime_summary_dir),
+        ],
+        summary_path,
+        env=env,
+        runner=runner,
+    )
+    run_monitor_json(
+        cfg,
+        [
+            "alert",
+            "--out-dir",
+            str(monitor_out_dir),
+            "--runtime-summary-dir",
+            str(runtime_summary_dir),
+            "--force-alert-image",
+        ],
         alert_path,
         env=env,
         runner=runner,

--- a/scripts/screeps_official_deploy.py
+++ b/scripts/screeps_official_deploy.py
@@ -40,6 +40,7 @@ DEFAULT_TIMEOUT_SECONDS = 30
 DEFAULT_MONITOR_TIMEOUT_SECONDS = 660
 DEFAULT_ROLLBACK_RECOVERY_TIMEOUT_SECONDS = 300
 DEFAULT_ROLLBACK_RECOVERY_POLL_SECONDS = 15
+DEFAULT_POSTDEPLOY_CONSOLE_CAPTURE_TIMEOUT_SECONDS = 45
 AUTH_TOKEN_ENV = "SCREEPS_AUTH_TOKEN"
 SECRET_KEY_RE = re.compile(r"(authorization|password|secret|steam[_-]?key|token|x[_-]?token|x[_-]?username)", re.I)
 BRANCH_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
@@ -937,6 +938,39 @@ def run_monitor_json(
     return payload
 
 
+def run_postdeploy_console_capture(
+    cfg: DeployConfig,
+    *,
+    env: dict[str, str] | None = None,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> subprocess.CompletedProcess[str]:
+    """Capture compact runtime console telemetry for the post-deploy health gate."""
+    script = cfg.repo_root / "scripts" / "screeps_runtime_summary_console_capture.py"
+    out_dir = cfg.repo_root / "runtime-artifacts" / "runtime-summary-console"
+    return run_checked_command(
+        "runtime summary console capture",
+        [
+            sys.executable,
+            str(script),
+            "--live-official-console",
+            "--out-dir",
+            str(out_dir),
+            "--artifact-name",
+            "postdeploy-runtime-summary-console.log",
+            "--format",
+            "status-line",
+            "--live-timeout-seconds",
+            str(DEFAULT_POSTDEPLOY_CONSOLE_CAPTURE_TIMEOUT_SECONDS),
+        ],
+        cwd=cfg.repo_root,
+        env=monitor_env(env, cfg),
+        runner=runner,
+        timeout_seconds=DEFAULT_POSTDEPLOY_CONSOLE_CAPTURE_TIMEOUT_SECONDS + 15,
+        allow_failure=True,
+        secrets=[(env or os.environ).get(AUTH_TOKEN_ENV, "")],
+    )
+
+
 def run_postdeploy_health_gate(
     cfg: DeployConfig,
     *,
@@ -950,6 +984,7 @@ def run_postdeploy_health_gate(
     alert_path = cfg.evidence_dir / "postdeploy-alert.json"
     health_path = postdeploy_health_gate_path(cfg)
 
+    run_postdeploy_console_capture(cfg, env=env, runner=runner)
     run_monitor_json(cfg, ["summary", "--out-dir", str(out_dir)], summary_path, env=env, runner=runner)
     run_monitor_json(
         cfg,

--- a/scripts/test_screeps_official_deploy.py
+++ b/scripts/test_screeps_official_deploy.py
@@ -545,6 +545,7 @@ class OfficialDeployTest(unittest.TestCase):
             health_gate = deploy.run_postdeploy_health_gate(cfg, env={}, runner=command_runner)
             paired_path = evidence_dir / "postdeploy-health-gate-rollback.json"
             expected_out_dir = repo_root / "runtime-artifacts" / "screeps-monitor"
+            expected_runtime_summary_dir = repo_root / "runtime-artifacts" / "runtime-summary-console"
 
             self.assertTrue(health_gate["ok"])
             self.assertTrue(paired_path.exists())
@@ -555,20 +556,23 @@ class OfficialDeployTest(unittest.TestCase):
             )
             self.assertIn("--out-dir", commands[0])
             capture_out_dir_index = commands[0].index("--out-dir")
-            self.assertEqual(
-                commands[0][capture_out_dir_index + 1],
-                str(repo_root / "runtime-artifacts" / "runtime-summary-console"),
-            )
+            self.assertEqual(commands[0][capture_out_dir_index + 1], str(expected_runtime_summary_dir))
             self.assertIn("--live-timeout-seconds", commands[0])
             self.assertEqual(commands[1][1:3], [str(repo_root / "scripts" / "screeps-runtime-monitor.py"), "summary"])
             self.assertIn("--out-dir", commands[1])
             summary_out_dir_index = commands[1].index("--out-dir")
             self.assertEqual(commands[1][summary_out_dir_index + 1], str(expected_out_dir))
+            self.assertIn("--runtime-summary-out-dir", commands[1])
+            summary_runtime_dir_index = commands[1].index("--runtime-summary-out-dir")
+            self.assertEqual(commands[1][summary_runtime_dir_index + 1], str(expected_runtime_summary_dir))
             self.assertNotIn("--room", commands[1])
             self.assertEqual(commands[2][1:3], [str(repo_root / "scripts" / "screeps-runtime-monitor.py"), "alert"])
             self.assertIn("--out-dir", commands[2])
             alert_out_dir_index = commands[2].index("--out-dir")
             self.assertEqual(commands[2][alert_out_dir_index + 1], str(expected_out_dir))
+            self.assertIn("--runtime-summary-dir", commands[2])
+            alert_runtime_dir_index = commands[2].index("--runtime-summary-dir")
+            self.assertEqual(commands[2][alert_runtime_dir_index + 1], str(expected_runtime_summary_dir))
             self.assertNotIn("--room", commands[2])
             self.assertIn("--force-alert-image", commands[2])
 

--- a/scripts/test_screeps_official_deploy.py
+++ b/scripts/test_screeps_official_deploy.py
@@ -549,17 +549,28 @@ class OfficialDeployTest(unittest.TestCase):
             self.assertTrue(health_gate["ok"])
             self.assertTrue(paired_path.exists())
             self.assertFalse((evidence_dir / "postdeploy-health-gate.json").exists())
-            self.assertEqual(commands[0][1:3], [str(repo_root / "scripts" / "screeps-runtime-monitor.py"), "summary"])
+            self.assertEqual(
+                commands[0][1:3],
+                [str(repo_root / "scripts" / "screeps_runtime_summary_console_capture.py"), "--live-official-console"],
+            )
             self.assertIn("--out-dir", commands[0])
-            summary_out_dir_index = commands[0].index("--out-dir")
-            self.assertEqual(commands[0][summary_out_dir_index + 1], str(expected_out_dir))
-            self.assertNotIn("--room", commands[0])
-            self.assertEqual(commands[1][1:3], [str(repo_root / "scripts" / "screeps-runtime-monitor.py"), "alert"])
+            capture_out_dir_index = commands[0].index("--out-dir")
+            self.assertEqual(
+                commands[0][capture_out_dir_index + 1],
+                str(repo_root / "runtime-artifacts" / "runtime-summary-console"),
+            )
+            self.assertIn("--live-timeout-seconds", commands[0])
+            self.assertEqual(commands[1][1:3], [str(repo_root / "scripts" / "screeps-runtime-monitor.py"), "summary"])
             self.assertIn("--out-dir", commands[1])
-            alert_out_dir_index = commands[1].index("--out-dir")
-            self.assertEqual(commands[1][alert_out_dir_index + 1], str(expected_out_dir))
+            summary_out_dir_index = commands[1].index("--out-dir")
+            self.assertEqual(commands[1][summary_out_dir_index + 1], str(expected_out_dir))
             self.assertNotIn("--room", commands[1])
-            self.assertIn("--force-alert-image", commands[1])
+            self.assertEqual(commands[2][1:3], [str(repo_root / "scripts" / "screeps-runtime-monitor.py"), "alert"])
+            self.assertIn("--out-dir", commands[2])
+            alert_out_dir_index = commands[2].index("--out-dir")
+            self.assertEqual(commands[2][alert_out_dir_index + 1], str(expected_out_dir))
+            self.assertNotIn("--room", commands[2])
+            self.assertIn("--force-alert-image", commands[2])
 
     def test_postdeploy_health_gate_uses_default_path_without_deploy_evidence_path(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -2143,6 +2143,8 @@ class TacticalResponseBridgeTest(unittest.TestCase):
                             "creeps": 1,
                             "spawns": 1,
                             "owner": "owner",
+                            "constructionSiteCount": 0,
+                            "pendingBuildProgress": 0,
                         }
                     ],
                     "runtime_summary_artifact": str(artifact),
@@ -2154,6 +2156,54 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         cpu_reason = next(reason for reason in health["reasons"] if reason["kind"] == monitor.CPU_BUCKET_CRITICAL_KIND)
         self.assertEqual(cpu_reason["cpuBucket"], 4)
         self.assertEqual(cpu_reason["pressure"], "critical")
+
+    def test_postdeploy_health_gate_enriches_compact_cpu_fields_from_runtime_summary_artifact(self) -> None:
+        payload = {
+            "type": "runtime-summary",
+            "tick": 1200,
+            "cpu": {"used": None, "bucket": None},
+            "rooms": [
+                {
+                    "roomName": "E26S49",
+                    "shard": "shardX",
+                    "workerCount": 1,
+                    "cpuUsed": None,
+                    "cpuBucket": None,
+                }
+            ],
+        }
+        compact_cpu_payload = {"used": 13.1, "limit": 70, "bucket": 1775}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact = Path(temp_dir) / "runtime-summary-monitor-20260529T001418Z.log"
+            artifact.write_text(
+                "#runtime-summary " + json.dumps(payload) + "\n"
+                "#cpu-summary " + json.dumps(compact_cpu_payload) + "\n",
+                encoding="utf-8",
+            )
+
+            health = monitor.evaluate_postdeploy_health_gate(
+                {
+                    "ok": True,
+                    "mode": "summary",
+                    "room_summaries": [
+                        {
+                            "room": "shardX/E26S49",
+                            "owned_creeps": 1,
+                            "owned_spawns": 1,
+                            "creeps": 1,
+                            "spawns": 1,
+                            "owner": "owner",
+                            "constructionSiteCount": 0,
+                            "pendingBuildProgress": 0,
+                        }
+                    ],
+                    "runtime_summary_artifact": str(artifact),
+                },
+                {"ok": True, "mode": "alert", "alert": False, "reasons": [], "rooms": ["shardX/E26S49"]},
+            )
+
+        self.assertTrue(health["ok"], health["reasons"])
 
     def test_compact_cpu_summary_alerts_health_gate_and_tactical_response(self) -> None:
         old_room_payload = {
@@ -4406,6 +4456,35 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         self.assertEqual(payload["rooms"][0]["roomName"], "E26S49")
         self.assertEqual(payload["rooms"][0]["constructionActivity"]["state"], "no_viable_candidate")
         self.assertFalse(payload["rooms"][0]["constructionActivity"]["accepted"])
+
+    def test_runtime_summary_artifact_line_applies_external_cpu_evidence(self) -> None:
+        snapshot = monitor.RoomSnapshot(
+            ref=monitor.RoomRef(shard="shardX", room="E26S49"),
+            terrain="0" * monitor.TERRAIN_CELLS,
+            objects={},
+            tick=265631,
+            owner="lanyusea",
+            info={},
+        )
+
+        line = monitor.runtime_summary_artifact_line(
+            [snapshot],
+            runtime_room_summaries={
+                "shardX/E26S49": {
+                    "room": "shardX/E26S49",
+                    "roomName": "E26S49",
+                    "shard": "shardX",
+                    "cpuUsed": 13.1,
+                    "cpuBucket": 1775,
+                    monitor.RUNTIME_SUMMARY_CPU_METADATA_KEY: {"used": 13.1, "bucket": 1775},
+                }
+            },
+        )
+
+        payload = json.loads(line.split(" ", 1)[1])
+        self.assertEqual(payload["cpu"], {"used": 13.1, "bucket": 1775})
+        self.assertEqual(payload["rooms"][0]["cpuUsed"], 13.1)
+        self.assertEqual(payload["rooms"][0]["cpuBucket"], 1775)
 
     def test_runtime_summary_preserves_explicit_pathing_totals(self) -> None:
         snapshot = monitor.RoomSnapshot(


### PR DESCRIPTION
## Summary

Refs #1490.

- emit compact `#cpu-summary` console telemetry on a short repeat cadence so postdeploy monitors have fresh CPU evidence even when broader runtime state is unchanged
- fold console CPU summary fields into monitor room summaries and runtime-summary artifacts
- run the console telemetry capture during official deploy postdeploy health collection before summary/alert/health-gate evaluation

## Verification

Controller verification after rebasing onto `origin/main` (`2b4c9c4`):

- `git diff --check`
- `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/screeps_official_deploy.py scripts/check_cron_output_finalization.py`
- `python3 -m pytest scripts/test_screeps_official_deploy.py scripts/test_screeps_runtime_monitor_tactical_response.py -q`
- `python3 -m unittest scripts.test_check_cron_output_finalization -q`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (`105` suites / `2439` tests passed)
- `cd prod && npm run build`

Fresh scheduler health evidence before PR creation: `/tmp/screeps-scheduler-health.OX8heQ/summary.json` at tick `2144769` showed `shardX/E29N55`, `shardX/E29N57`, and `shardX/E29N56` alive with owned spawns and owned creeps; health remained failed because CPU telemetry was still missing before this fix is deployed.

## Universal task Done gate

- [x] Task type: P0 runtime monitor / deploy-health telemetry hotfix.
- [x] Expected observable outcome / named deliverable: postdeploy monitor artifacts can ingest fresh console CPU telemetry so `cpu.used` and `cpu.bucket` become available to runtime summary, alert, and health-gate checks when the bot emits console telemetry.
- [x] Non-goals / accepted substitutes: Related to issue 1490; this PR avoids claiming live CPU-bucket recovery, and issue 1490 stays the runtime-acceptance owner until an official deploy and postdeploy health artifact prove CPU-bearing evidence.
- [x] Verification evidence required before Done: exact-head CI plus controller verification commands listed above pass for the code, tests, bundle, deploy helper, monitor parser, and issue-completion validation.
- [x] Project Evidence / Next action / Blocked by: Project fields for #1490 and this PR record recovered Codex commit `6d959daa`, controller verification, exact-head review/CI gates, and the follow-up deploy/runtime acceptance path.
- [x] Post-merge/deploy/runtime proof: the PR-level deliverable is the telemetry/deploy-path implementation; live runtime acceptance remains represented by #1490 with required official deploy and CPU-bearing postdeploy artifacts.
- [x] Named deliverable proof: changed files include `prod/src/telemetry/runtimeSummary.ts`, monitor/deploy helper code, targeted tests, workflow postdeploy capture, and regenerated `prod/dist/main.js`.
