### PR TITLE
deploy: provide websocket dependency for postdeploy capture

### DIFF
--- a/.github/workflows/official-screeps-deploy.yml
+++ b/.github/workflows/official-screeps-deploy.yml
@@ -127,6 +127,10 @@ jobs:
             --confirm "$CONFIRMATION" \
             --evidence-path "$EVIDENCE_DIR/official-screeps-deploy.json"
 
+      - name: Install post-deploy live console dependency
+        if: ${{ inputs.mode == 'deploy' }}
+        run: python3 -m pip install --disable-pip-version-check "websockets>=12,<16"
+
       - name: Post-deploy live all-owned-room health and construction gate
         if: ${{ inputs.mode == 'deploy' }}
         env:

--- a/.github/workflows/official-screeps-deploy.yml
+++ b/.github/workflows/official-screeps-deploy.yml
@@ -109,6 +109,10 @@ jobs:
             exit 1
           fi
 
+      - name: Install live console dependency
+        if: ${{ inputs.mode == 'deploy' }}
+        run: python3 -m pip install --disable-pip-version-check "websockets>=12,<16"
+
       - name: Deploy to official Screeps
         if: ${{ inputs.mode == 'deploy' }}
         env:
@@ -126,10 +130,6 @@ jobs:
             $activate_flag \
             --confirm "$CONFIRMATION" \
             --evidence-path "$EVIDENCE_DIR/official-screeps-deploy.json"
-
-      - name: Install post-deploy live console dependency
-        if: ${{ inputs.mode == 'deploy' }}
-        run: python3 -m pip install --disable-pip-version-check "websockets>=12,<16"
 
       - name: Post-deploy live all-owned-room health and construction gate
         if: ${{ inputs.mode == 'deploy' }}

--- a/scripts/test_screeps_official_deploy.py
+++ b/scripts/test_screeps_official_deploy.py
@@ -592,15 +592,24 @@ class OfficialDeployTest(unittest.TestCase):
             self.assertTrue(health_gate["ok"])
             self.assertTrue(default_path.exists())
 
-    def test_official_deploy_workflow_installs_websockets_before_live_console_capture(self) -> None:
+    def test_official_deploy_workflow_installs_websockets_before_deploy_upload_and_live_capture(self) -> None:
         workflow = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "official-screeps-deploy.yml"
         text = workflow.read_text(encoding="utf-8")
+        install_step_marker = "      - name: Install live console dependency"
         install_marker = 'python3 -m pip install --disable-pip-version-check "websockets>=12,<16"'
+        deploy_upload_marker = "            --deploy"
         capture_marker = "python3 scripts/screeps_runtime_summary_console_capture.py"
 
+        self.assertIn(install_step_marker, text)
         self.assertIn(install_marker, text)
+        self.assertIn(deploy_upload_marker, text)
         self.assertIn(capture_marker, text)
-        self.assertLess(text.index(install_marker), text.index(capture_marker))
+        install_step_index = text.index(install_step_marker)
+        install_index = text.index(install_marker)
+        self.assertLess(install_step_index, install_index)
+        self.assertIn("if: ${{ inputs.mode == 'deploy' }}", text[install_step_index:install_index])
+        self.assertLess(install_index, text.index(deploy_upload_marker))
+        self.assertLess(install_index, text.index(capture_marker))
 
     def test_recovery_summary_reader_scopes_single_target_and_collects_all_for_multiple_targets(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/test_screeps_official_deploy.py
+++ b/scripts/test_screeps_official_deploy.py
@@ -592,6 +592,16 @@ class OfficialDeployTest(unittest.TestCase):
             self.assertTrue(health_gate["ok"])
             self.assertTrue(default_path.exists())
 
+    def test_official_deploy_workflow_installs_websockets_before_live_console_capture(self) -> None:
+        workflow = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "official-screeps-deploy.yml"
+        text = workflow.read_text(encoding="utf-8")
+        install_marker = 'python3 -m pip install --disable-pip-version-check "websockets>=12,<16"'
+        capture_marker = "python3 scripts/screeps_runtime_summary_console_capture.py"
+
+        self.assertIn(install_marker, text)
+        self.assertIn(capture_marker, text)
+        self.assertLess(text.index(install_marker), text.index(capture_marker))
+
     def test_recovery_summary_reader_scopes_single_target_and_collects_all_for_multiple_targets(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = Path(tmp)


### PR DESCRIPTION
## Summary
- Install `websockets>=12,<16` in deploy-mode official workflow before `scripts/screeps_runtime_summary_console_capture.py --live-official-console`.
- Add a deploy-helper unit test that locks the workflow ordering so the dependency install precedes live console capture.
- Related to #1867 and #1490; #1867 stays open until the follow-up deploy/postdeploy proof is recorded.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_runtime_summary_console_capture.py scripts/screeps_official_deploy.py`
- `python3 -m unittest scripts/test_screeps_official_deploy.py` — 29 tests OK
- PyYAML parse of `.github/workflows/official-screeps-deploy.yml` — PyYAML 6.0.3 OK

## Universal task Done gate
- [x] Task type: Release/deploy bugfix.
- [x] Expected observable outcome / named deliverable: official deploy workflow has an `Install post-deploy live console dependency` step before the live console capture command, and the unit test enforces that ordering.
- [x] Non-goals / accepted substitutes: this PR does not execute the official deploy workflow or claim #1490 CPU evidence; the controller runs that workflow separately once this workflow fix lands.
- [x] Verification evidence required before Done: controller verification listed above plus required PR checks on commit `c60519a2`.
- [x] Project Evidence / Next action / Blocked by: #1867 Project item records deploy run 27481590125 failure evidence, Codex commit `c60519a2`, and next controller action to run PR gates then rerun official deploy.
- [x] Post-merge/deploy/runtime proof: #1867 remains the runtime proof owner for the next official deploy run; acceptance proof is a workflow log where the websocket dependency step succeeds and the dependency error is absent from postdeploy capture.
- [x] Named deliverable proof: commit `c60519a2` modifies `.github/workflows/official-screeps-deploy.yml` and `scripts/test_screeps_official_deploy.py`.