### PR TITLE
rl: harden policy advantage ledger final output

### DIFF
--- a/scripts/screeps_cli_io.py
+++ b/scripts/screeps_cli_io.py
@@ -3,12 +3,14 @@
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 from typing import Any, TextIO
 
 
 DEFAULT_MAX_JSON_LINE_BYTES = 4096
+BROKEN_PIPE_ERRNOS = {errno.EPIPE, errno.ECONNABORTED, errno.ECONNRESET}
 
 
 def canonical_json(value: Any) -> str:
@@ -53,18 +55,35 @@ def bounded_json_line(value: dict[str, Any], *, max_bytes: int = DEFAULT_MAX_JSO
     return encoded[: max(0, max_bytes - 1)].decode("utf-8", errors="ignore") + "\n"
 
 
+def is_broken_pipe_error(error: BaseException) -> bool:
+    if isinstance(error, (BrokenPipeError, ConnectionAbortedError, ConnectionResetError)):
+        return True
+    if getattr(error, "errno", None) in BROKEN_PIPE_ERRNOS:
+        return True
+    if isinstance(error, RuntimeError):
+        message = str(error).lower()
+        return any(marker in message for marker in ("broken pipe", "connection reset", "connection aborted"))
+    return False
+
+
+def redirect_stream_to_devnull(stream: TextIO) -> None:
+    try:
+        with open(os.devnull, "w", encoding="utf-8") as devnull:
+            os.dup2(devnull.fileno(), stream.fileno())
+    except (OSError, AttributeError, ValueError):
+        pass
+
+
 def write_text(stream: TextIO, text: str) -> bool:
     """Write text unless the receiver has already closed the pipe."""
     try:
         stream.write(text)
         stream.flush()
         return True
-    except (BrokenPipeError, ConnectionAbortedError, ConnectionResetError):
-        try:
-            with open(os.devnull, "w", encoding="utf-8") as devnull:
-                os.dup2(devnull.fileno(), stream.fileno())
-        except (OSError, AttributeError, ValueError):
-            pass
+    except (OSError, RuntimeError) as error:
+        if not is_broken_pipe_error(error):
+            raise
+        redirect_stream_to_devnull(stream)
         return False
 
 

--- a/scripts/test_screeps_rl_control_loop_ledgers.py
+++ b/scripts/test_screeps_rl_control_loop_ledgers.py
@@ -40,6 +40,33 @@ class FlushBrokenWriter:
         raise OSError("test stream has no file descriptor")
 
 
+class RuntimeBrokenWriter(io.StringIO):
+    def __init__(self) -> None:
+        super().__init__()
+        self.write_attempts = 0
+
+    def write(self, _text: str) -> int:
+        self.write_attempts += 1
+        raise RuntimeError("[Errno 32] Broken pipe")
+
+
+class RuntimeFlushBrokenWriter:
+    def __init__(self) -> None:
+        self.flush_attempts = 0
+        self.write_attempts = 0
+
+    def write(self, text: str) -> int:
+        self.write_attempts += 1
+        return len(text)
+
+    def flush(self) -> None:
+        self.flush_attempts += 1
+        raise RuntimeError("[Errno 32] Broken pipe")
+
+    def fileno(self) -> int:
+        raise OSError("test stream has no file descriptor")
+
+
 def write_json(path: Path, payload: JsonObject) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
@@ -1237,6 +1264,75 @@ class ScreepsRlControlLoopLedgersTest(unittest.TestCase):
         self.assertEqual(payload["onlineUtilityStatus"], "UNPROVEN")
         self.assertEqual(payload["candidatePolicyId"], "candidate-a")
         self.assertEqual(json.loads(emitted)["artifact"], "out/policy-advantage.json")
+
+    def test_policy_advantage_treats_runtime_broken_stdout_as_delivery_only(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = write_fixture_artifacts(root)
+            output = root / "out" / "policy-advantage.json"
+            stdout = RuntimeBrokenWriter()
+            stderr = io.StringIO()
+
+            exit_code = ledgers.main(
+                [
+                    "policy-advantage",
+                    "--repo-root",
+                    str(root),
+                    "--artifact-root",
+                    str(artifact_root),
+                    "--output",
+                    str(output),
+                    "--created-at",
+                    "2026-06-05T00:00:01Z",
+                    "--stdout-bytes",
+                    "180",
+                ],
+                stdout=stdout,
+                stderr=stderr,
+            )
+            payload = read_json(output)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stderr.getvalue(), "")
+        self.assertEqual(stdout.write_attempts, 1)
+        self.assertEqual(payload["type"], ledgers.POLICY_ADVANTAGE_TYPE)
+        self.assertEqual(payload["onlineUtilityStatus"], "UNPROVEN")
+        self.assertEqual(payload["githubComment"], "skipped_no_atomic_issue")
+
+    def test_policy_advantage_treats_runtime_flush_broken_stdout_as_delivery_only(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = write_fixture_artifacts(root)
+            output = root / "out" / "policy-advantage.json"
+            stdout = RuntimeFlushBrokenWriter()
+            stderr = io.StringIO()
+
+            exit_code = ledgers.main(
+                [
+                    "policy-advantage",
+                    "--repo-root",
+                    str(root),
+                    "--artifact-root",
+                    str(artifact_root),
+                    "--output",
+                    str(output),
+                    "--created-at",
+                    "2026-06-05T00:00:01Z",
+                    "--stdout-bytes",
+                    "180",
+                ],
+                stdout=stdout,
+                stderr=stderr,
+            )
+            payload = read_json(output)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stderr.getvalue(), "")
+        self.assertEqual(stdout.write_attempts, 1)
+        self.assertEqual(stdout.flush_attempts, 1)
+        self.assertEqual(payload["type"], ledgers.POLICY_ADVANTAGE_TYPE)
+        self.assertEqual(payload["onlineUtilityStatus"], "UNPROVEN")
+        self.assertEqual(payload["githubComment"], "skipped_no_atomic_issue")
 
     def test_policy_advantage_derives_evidence_fields_from_current_policy(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

Fixes #1870.

This hardens bounded CLI output handling so the RL policy-advantage producer treats `RuntimeError: [Errno 32] Broken pipe`/connection reset/aborted stdout failures as delivery-only failures after the durable artifact has been written, matching the existing `BrokenPipeError` behavior.

## Verification

- `git diff --check`
- `python3 -m py_compile scripts/screeps_cli_io.py scripts/screeps_rl_control_loop_ledgers.py scripts/test_screeps_rl_control_loop_ledgers.py`
- `python3 -m unittest scripts.test_screeps_rl_control_loop_ledgers.ScreepsRlControlLoopLedgersTest.test_policy_advantage_treats_runtime_broken_stdout_as_delivery_only scripts.test_screeps_rl_control_loop_ledgers.ScreepsRlControlLoopLedgersTest.test_policy_advantage_treats_runtime_flush_broken_stdout_as_delivery_only`
- `python3 scripts/screeps_rl_control_loop_ledgers.py policy-advantage --repo-root /root/screeps-worktrees/issue-1870-policy-advantage-bp --artifact-root /root/screeps-worktrees/issue-1870-policy-advantage-bp/runtime-artifacts --out-dir /tmp/issue1870-postcommit-policy --stdout-bytes 180` emitted `ok=true`, `status=UNPROVEN`, `githubComment=skipped_no_atomic_issue`.

## Issue closure gate

- [x] #1870: Added focused runtime-broken-stdout and runtime-broken-flush tests for the policy-advantage producer, and verified the producer still writes bounded artifact-first JSON output without a GitHub issue comment sink.

## Universal task Done gate

- [x] Task type: P0 RL flywheel bug fix for policy-advantage ledger final-output handling.
- [x] Expected observable outcome / named deliverable: Codex-authored branch/PR hardening `scripts/screeps_cli_io.py` plus regression tests in `scripts/test_screeps_rl_control_loop_ledgers.py`.
- [x] Non-goals / accepted substitutes: No paid Tencent compute, no official MMO writes, no cron schedule changes, and no routine issue-comment ledger sink.
- [x] Verification evidence required before Done: local controller verification commands listed above plus exact-head CI/review gates on this PR.
- [x] Project Evidence / Next action / Blocked by: Project item for #1870 and this PR records commit `c4990ba5`, verification commands, and exact-head PR gate evidence.
- [x] Post-merge/deploy/runtime proof: scheduled policy-advantage proof target is one bounded JSON response line plus a durable `runtime-artifacts/rl-control-loop/*-policy-advantage.json` artifact from the policy-advantage producer.
- [x] Named deliverable proof: commit `c4990ba5b969d47477f803f5c77d6901aeaae757` with changed files `scripts/screeps_cli_io.py` and `scripts/test_screeps_rl_control_loop_ledgers.py`.
