### PR TITLE
monitor: discover authenticated console channel

### DIFF
--- a/scripts/screeps_runtime_summary_console_capture.py
+++ b/scripts/screeps_runtime_summary_console_capture.py
@@ -11,6 +11,7 @@ import os
 import re
 import sys
 import tempfile
+import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -39,6 +40,10 @@ CONSOLE_CHANNELS_ENV = "SCREEPS_CONSOLE_CHANNELS"
 LIVE_TIMEOUT_ENV = "SCREEPS_CONSOLE_CAPTURE_TIMEOUT_SECONDS"
 LIVE_MAX_MESSAGES_ENV = "SCREEPS_CONSOLE_CAPTURE_MAX_MESSAGES"
 WORLD_PROFILE_ENV = world_profiles.WORLD_PROFILE_ENV
+CHANNEL_SOURCE_CLI = "cli"
+CHANNEL_SOURCE_ENV = "env"
+CHANNEL_SOURCE_AUTHENTICATED_USER = "authenticated-user"
+CHANNEL_SOURCE_FALLBACK_DEFAULT = "fallback-default"
 SAFE_ARTIFACT_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 CAPTURE_STATUS_CLEAN_RUNTIME_SUMMARY = "clean_runtime_summary"
 CAPTURE_STATUS_CPU_ONLY = "cpu_only"
@@ -87,6 +92,7 @@ class LiveConsoleContext:
     channels: list[str]
     timeout_seconds: float
     max_messages: int
+    channel_metadata: dict[str, object] | None = None
 
     @property
     def base_ws(self) -> str:
@@ -472,16 +478,79 @@ def resolve_console_channels(cli_channels: list[str] | None) -> list[str]:
     return parse_console_channels(os.environ.get(CONSOLE_CHANNELS_ENV))
 
 
+def short_error_text(value: object, limit: int = 180) -> str:
+    text = str(value).replace("\n", " ").strip()
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 3)].rstrip() + "..."
+
+
+def fetch_authenticated_user_id(base_http: str, token: str) -> str:
+    request = urllib.request.Request(
+        base_http.rstrip("/") + "/api/auth/me",
+        headers={
+            "X-Token": token,
+            "User-Agent": "screeps-runtime-summary-console-capture/1.0",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        payload = json.load(response)
+    if not isinstance(payload, dict):
+        raise RuntimeError("authenticated user response was not a JSON object")
+    for key in ("_id", "id", "userId", "user_id"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    raise RuntimeError("authenticated user response did not include a user id")
+
+
+def default_live_console_channels(base_http: str, token: str) -> tuple[list[str], dict[str, object]]:
+    try:
+        user_id = fetch_authenticated_user_id(base_http, token)
+    except Exception as exc:  # noqa: BLE001 - fallback remains diagnosable in the status sidecar
+        return (
+            list(DEFAULT_CONSOLE_CHANNELS),
+            {
+                "channelSource": CHANNEL_SOURCE_FALLBACK_DEFAULT,
+                "channelDiscoveryStatus": "unavailable",
+                "channelDiscoveryError": sanitize_error_text(short_error_text(exc), [token]),
+            },
+        )
+    return (
+        [f"user:{user_id}/console"],
+        {
+            "channelSource": CHANNEL_SOURCE_AUTHENTICATED_USER,
+            "channelDiscoveryStatus": "ok",
+        },
+    )
+
+
+def resolve_live_console_channels(
+    cli_channels: list[str] | None,
+    base_http: str,
+    token: str,
+) -> tuple[list[str], dict[str, object]]:
+    if cli_channels:
+        return parse_console_channels(",".join(cli_channels)), {"channelSource": CHANNEL_SOURCE_CLI}
+    env_channels = os.environ.get(CONSOLE_CHANNELS_ENV)
+    if env_channels is not None and env_channels.strip():
+        return parse_console_channels(env_channels), {"channelSource": CHANNEL_SOURCE_ENV}
+    return default_live_console_channels(base_http, token)
+
+
 def live_console_context_from_args(args: argparse.Namespace) -> LiveConsoleContext:
     token = os.environ.get(AUTH_TOKEN_ENV)
     if not token:
         raise RuntimeError(f"{AUTH_TOKEN_ENV} is required for --live-official-console")
+    base_http = str(args.api_url).rstrip("/")
+    channels, channel_metadata = resolve_live_console_channels(args.console_channel, base_http, token)
     return LiveConsoleContext(
-        base_http=str(args.api_url).rstrip("/"),
+        base_http=base_http,
         token=token,
-        channels=resolve_console_channels(args.console_channel),
+        channels=channels,
         timeout_seconds=args.live_timeout_seconds,
         max_messages=args.live_max_messages,
+        channel_metadata=channel_metadata,
     )
 
 
@@ -556,13 +625,16 @@ def persist_live_official_console_artifact(
     websockets_module: Any | None = None,
 ) -> PersistResult:
     capture = asyncio.run(collect_live_official_console_lines(ctx, websockets_module=websockets_module))
+    metadata_extra = capture.metadata()
+    if ctx.channel_metadata:
+        metadata_extra.update(ctx.channel_metadata)
     return persist_runtime_summary_artifact(
         input_paths=["live-official-console"],
         out_dir=out_dir,
         out_file=out_file,
         artifact_name=artifact_name,
         input_lines=capture.console_lines,
-        metadata_extra=capture.metadata(),
+        metadata_extra=metadata_extra,
     )
 
 
@@ -742,7 +814,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="append",
         help=(
             "Console websocket channel to subscribe. May be repeated or comma-separated. "
-            f"Default: ${CONSOLE_CHANNELS_ENV} or {','.join(DEFAULT_CONSOLE_CHANNELS)}."
+            f"Default: ${CONSOLE_CHANNELS_ENV}, or the authenticated user's console channel in live mode."
         ),
     )
     parser.add_argument(
@@ -772,10 +844,12 @@ def main(
         parser.error("inputs cannot be used with --live-official-console")
 
     status_path = resolve_status_path(args)
+    live_context: LiveConsoleContext | None = None
     try:
         if args.live_official_console:
+            live_context = live_console_context_from_args(args)
             result = persist_live_official_console_artifact(
-                ctx=live_console_context_from_args(args),
+                ctx=live_context,
                 out_dir=Path(args.out_dir),
                 out_file=Path(args.out_file) if args.out_file else None,
                 artifact_name=args.artifact_name,
@@ -793,6 +867,11 @@ def main(
             token = os.environ.get(AUTH_TOKEN_ENV, "")
             error_text = sanitize_error_text(str(exc), [token])
             error_metadata = build_error_metadata(args, error_text)
+            if live_context is not None:
+                error_metadata["requestedChannels"] = live_context.channels
+                error_metadata["websocketUrl"] = live_context.websocket_url
+                if live_context.channel_metadata:
+                    error_metadata.update(live_context.channel_metadata)
             try_write_status_file(
                 status_path,
                 build_status_payload(

--- a/scripts/test_screeps_runtime_summary_console_capture.py
+++ b/scripts/test_screeps_runtime_summary_console_capture.py
@@ -426,6 +426,34 @@ class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
         self.assertNotIn(secret, metadata_text)
         self.assertNotIn("#runtime-summary", metadata_text)
 
+    def test_live_official_console_default_resolves_authenticated_user_channel(self) -> None:
+        secret = "SECRET_TOKEN_VALUE"
+        with (
+            mock.patch.dict(capture.os.environ, {capture.AUTH_TOKEN_ENV: secret}, clear=True),
+            mock.patch.object(capture, "fetch_authenticated_user_id", return_value="610fbfda4f18fea6135e8fad"),
+        ):
+            args = capture.build_parser().parse_args(["--live-official-console"])
+            ctx = capture.live_console_context_from_args(args)
+
+        self.assertEqual(ctx.channels, ["user:610fbfda4f18fea6135e8fad/console"])
+        self.assertEqual(ctx.channel_metadata["channelSource"], capture.CHANNEL_SOURCE_AUTHENTICATED_USER)
+        self.assertEqual(ctx.channel_metadata["channelDiscoveryStatus"], "ok")
+
+    def test_live_official_console_default_falls_back_with_channel_diagnostic(self) -> None:
+        secret = "SECRET_TOKEN_VALUE"
+        with mock.patch.object(
+            capture,
+            "fetch_authenticated_user_id",
+            side_effect=RuntimeError(f"auth failed for {secret}"),
+        ):
+            channels, metadata = capture.default_live_console_channels("https://screeps.com", secret)
+
+        self.assertEqual(channels, ["console"])
+        self.assertEqual(metadata["channelSource"], capture.CHANNEL_SOURCE_FALLBACK_DEFAULT)
+        self.assertEqual(metadata["channelDiscoveryStatus"], "unavailable")
+        self.assertIn("[redacted]", metadata["channelDiscoveryError"])
+        self.assertNotIn(secret, json.dumps(metadata, sort_keys=True))
+
     def test_cli_live_official_console_reports_channels_without_secrets_or_artifact_contents(self) -> None:
         secret = "VERY_SECRET_TOKEN_VALUE"
         websocket = FakeWebSocket(
@@ -491,6 +519,7 @@ class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
         self.assertEqual(status["runtimeSummaryLineCount"], 1)
         self.assertEqual(status["cpuSummaryLineCount"], 0)
         self.assertEqual(status["statusPath"], str(status_path))
+        self.assertEqual(status["channelSource"], capture.CHANNEL_SOURCE_ENV)
         self.assertIn("outer_cron_finalization", status["finalizationHint"])
         self.assertEqual(websocket.sent, [f"auth {secret}", "subscribe console", "subscribe console:shardX"])
         self.assertNotIn(secret, output.getvalue())
@@ -503,7 +532,7 @@ class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
                 "auth ok",
                 json.dumps(
                     [
-                        "console",
+                        "user:610fbfda4f18fea6135e8fad/console",
                         {
                             "messages": {
                                 "log": [
@@ -525,6 +554,7 @@ class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
             with (
                 mock.patch.dict(capture.os.environ, {capture.AUTH_TOKEN_ENV: secret}),
                 mock.patch.object(capture, "import_websockets_module", return_value=websockets_module),
+                mock.patch.object(capture, "fetch_authenticated_user_id", return_value="610fbfda4f18fea6135e8fad"),
             ):
                 exit_code = capture.main(
                     [
@@ -561,6 +591,13 @@ class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
         self.assertFalse(status["captureOk"])
         self.assertEqual(status["runtimeSummaryLineCount"], 0)
         self.assertEqual(status["cpuSummaryLineCount"], 1)
+        self.assertEqual(status["requestedChannels"], ["user:610fbfda4f18fea6135e8fad/console"])
+        self.assertEqual(status["channelSource"], capture.CHANNEL_SOURCE_AUTHENTICATED_USER)
+        self.assertEqual(status["channelDiscoveryStatus"], "ok")
+        self.assertEqual(
+            websocket.sent,
+            [f"auth {secret}", "subscribe user:610fbfda4f18fea6135e8fad/console"],
+        )
         self.assertEqual(artifact_text, "#cpu-summary {\"used\":13.1,\"bucket\":1775}")
         self.assertNotIn(secret, json.dumps(status, sort_keys=True))
 
@@ -576,6 +613,7 @@ class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
             with (
                 mock.patch.dict(capture.os.environ, {capture.AUTH_TOKEN_ENV: secret}),
                 mock.patch.object(capture, "import_websockets_module", return_value=websockets_module),
+                mock.patch.object(capture, "fetch_authenticated_user_id", return_value="610fbfda4f18fea6135e8fad"),
             ):
                 exit_code = capture.main(
                     [
@@ -605,9 +643,11 @@ class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
         self.assertEqual(report["persistedLineCount"], 0)
         self.assertEqual(report["outputPath"], None)
         self.assertEqual(report["receivedMessageCount"], 0)
+        self.assertEqual(report["requestedChannels"], ["user:610fbfda4f18fea6135e8fad/console"])
         self.assertEqual(status["processStatus"], "completed")
         self.assertEqual(status["captureStatus"], capture.CAPTURE_STATUS_NO_MESSAGES)
         self.assertFalse(status["captureOk"])
+        self.assertEqual(websocket.sent, [f"auth {secret}", "subscribe user:610fbfda4f18fea6135e8fad/console"])
         self.assertFalse((out_dir / "empty.log").exists())
 
     def test_live_official_console_timeout_without_match_does_not_write_artifact(self) -> None:
@@ -653,6 +693,7 @@ class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
             error = io.StringIO()
             with (
                 mock.patch.dict(capture.os.environ, {capture.AUTH_TOKEN_ENV: secret}),
+                mock.patch.object(capture, "fetch_authenticated_user_id", return_value="610fbfda4f18fea6135e8fad"),
                 mock.patch.object(
                     capture,
                     "import_websockets_module",
@@ -683,6 +724,8 @@ class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
         self.assertEqual(status["processStatus"], "capture_error")
         self.assertEqual(status["exitCode"], 1)
         self.assertEqual(status["captureStatus"], capture.CAPTURE_STATUS_ERROR)
+        self.assertEqual(status["requestedChannels"], ["user:610fbfda4f18fea6135e8fad/console"])
+        self.assertEqual(status["channelSource"], capture.CHANNEL_SOURCE_AUTHENTICATED_USER)
         self.assertIn("websockets", status["error"])
         self.assertNotIn(secret, json.dumps(status, sort_keys=True))
 


### PR DESCRIPTION
## Summary

Refs #1490.

This changes the live official console capture default from the generic `console` channel to the authenticated Screeps user console channel discovered via `/api/auth/me`, while preserving explicit CLI/env channel overrides and recording diagnostic channel metadata in the status sidecar. The goal is to stop postdeploy health gates from missing CPU telemetry because the capture subscribed to the wrong websocket channel.

## Verification

- `git diff --check`
- `python3 -m py_compile scripts/screeps_runtime_summary_console_capture.py scripts/test_screeps_runtime_summary_console_capture.py`
- `python3 -m unittest scripts.test_screeps_runtime_summary_console_capture` (20 tests OK)
- Live bounded smoke: `scripts/screeps_runtime_summary_console_capture.py --live-official-console --live-timeout-seconds 30 ...` recorded `channelSource=authenticated-user`, `channelDiscoveryStatus=ok`, `requestedChannels=["user:610fbfda4f18fea6135e8fad/console"]`, and `cpuSummaryLineCount=3`.

## Universal task Done gate

- [x] Task type: P0 runtime monitor / deploy-acceptance bug fix for official console CPU telemetry capture.
- [x] Expected observable outcome / named deliverable: Codex-authored branch/PR updating `scripts/screeps_runtime_summary_console_capture.py` plus regression tests in `scripts/test_screeps_runtime_summary_console_capture.py`.
- [x] Non-goals / accepted substitutes: No production bot behavior change, no Screeps write/deploy from this PR, no cron schedule change, and no owner action.
- [x] Verification evidence required before Done: local controller verification commands listed above plus exact-head CI/review gates on this PR.
- [x] Project Evidence / Next action / Blocked by: Project item for #1490 and this PR records commit `d290b5ce`, controller verification, and the deploy-proof follow-up.
- [x] Post-merge/deploy/runtime proof: official deploy acceptance target is a postdeploy console capture/status artifact with authenticated-user channel metadata and nonzero `cpuSummaryLineCount` so the health gate no longer reports `cpu_telemetry_missing`.
- [x] Named deliverable proof: commit `d290b5ce68957454db3b687bfa787d5bcf4053c3` with changed files `scripts/screeps_runtime_summary_console_capture.py` and `scripts/test_screeps_runtime_summary_console_capture.py`.
