### PR TITLE
gameplay: hydrate newly assigned build workers

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35207,13 +35207,17 @@ function selectWorkerTaskContext(creep, currentTask) {
 }
 function selectAssignedBuildEnergyAcquisitionTask(creep, currentTask, selectedTask) {
   var _a2, _b;
-  if ((currentTask == null ? void 0 : currentTask.type) !== "build" || selectedTask !== null && selectedTask.type !== "build") {
+  const buildTask = (selectedTask == null ? void 0 : selectedTask.type) === "build" ? selectedTask : (currentTask == null ? void 0 : currentTask.type) === "build" ? currentTask : null;
+  if (!buildTask || selectedTask !== null && selectedTask.type !== "build") {
     return selectedTask;
   }
   if (getFreeTransferEnergyCapacity(creep) <= 0 || getActiveWorkParts3(creep) <= 0 || hasVisibleHostileCreeps2(creep.room)) {
     return selectedTask;
   }
   const carriedEnergy = getUsedTransferEnergy(creep);
+  if ((currentTask == null ? void 0 : currentTask.type) !== "build" && carriedEnergy > 0) {
+    return selectedTask;
+  }
   if (carriedEnergy > 0 && !hasLowWorkerEnergyLoad(creep)) {
     return selectedTask;
   }

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -484,7 +484,13 @@ function selectAssignedBuildEnergyAcquisitionTask(
   currentTask: CreepTaskMemory | null | undefined,
   selectedTask: CreepTaskMemory | null
 ): CreepTaskMemory | null {
-  if (currentTask?.type !== 'build' || (selectedTask !== null && selectedTask.type !== 'build')) {
+  const buildTask =
+    selectedTask?.type === 'build'
+      ? selectedTask
+      : currentTask?.type === 'build'
+        ? currentTask
+        : null;
+  if (!buildTask || (selectedTask !== null && selectedTask.type !== 'build')) {
     return selectedTask;
   }
 
@@ -497,6 +503,10 @@ function selectAssignedBuildEnergyAcquisitionTask(
   }
 
   const carriedEnergy = getUsedTransferEnergy(creep);
+  if (currentTask?.type !== 'build' && carriedEnergy > 0) {
+    return selectedTask;
+  }
+
   if (carriedEnergy > 0 && !hasLowWorkerEnergyLoad(creep)) {
     return selectedTask;
   }

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -9486,6 +9486,131 @@ describe('runWorker', () => {
     expect(build).not.toHaveBeenCalled();
   });
 
+  it('turns a newly selected empty build assignment into construction energy withdrawal', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 4_886,
+      progressTotal: 5_000,
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'storage1' ? 3 : 99))
+      }
+    } as unknown as ConstructionSite;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'FreshBuilder' ? 3 : 1))
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 590_234 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(10_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N57',
+      energyAvailable: 1_800,
+      energyCapacityAvailable: 1_800,
+      controller,
+      storage,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [storage] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [storage];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          if (type === FIND_HOSTILE_CREEPS || type === FIND_SOURCES || type === FIND_DROPPED_RESOURCES) {
+            return [];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const selectedBuildTask = { type: 'build', targetId: 'road-site1' as Id<ConstructionSite> } as const;
+    const build = jest.fn();
+    const withdraw = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'FreshBuilder',
+      memory: { role: 'worker', colony: 'E29N57' },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'storage1' ? 3 : 99))
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room,
+      build,
+      withdraw,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    roomCreeps.push(creep);
+    const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(selectedBuildTask);
+    const selectWorkerEnergyCriticalTask = jest
+      .spyOn(workerTaskPolicy, 'selectWorkerEnergyCriticalTask')
+      .mockReturnValue(null);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { FreshBuilder: creep },
+      rooms: { E29N57: room },
+      time: 2_123_186,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({
+        type: 'withdraw',
+        targetId: 'storage1',
+        constructionSiteId: 'road-site1'
+      });
+      expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+        tick: 2_123_186,
+        reason: 'assigned_selected_task',
+        baseSelectedTask: 'build',
+        baseSelectedTargetId: 'road-site1',
+        selectedTask: 'withdraw',
+        selectedTargetId: 'storage1',
+        assignedTask: 'withdraw',
+        assignedTargetId: 'storage1'
+      });
+      expect(withdraw).toHaveBeenCalledWith(storage, RESOURCE_ENERGY, 100);
+      expect(build).not.toHaveBeenCalled();
+    } finally {
+      selectWorkerTask.mockRestore();
+      selectWorkerEnergyCriticalTask.mockRestore();
+    }
+  });
+
   it.each([
     ['empty', 0, 100],
     ['low-load', 18, 82]


### PR DESCRIPTION
## Summary
- routes newly selected empty build assignments to a construction-site-aware energy withdrawal task so workers hydrate before attempting build work
- preserves the existing behavior for workers already carrying enough energy or assigned to non-build tasks
- adds regression coverage for a fresh builder selecting a build target with storage energy available

Related to issue 1873.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (105 suites / 2440 tests passed)
- `cd prod && npm run build`

## Universal task Done gate
- [x] Task type: Production code behavior fix with generated bundle refresh for the worker construction-energy execution path.
- [x] Expected observable outcome / named deliverable: Fresh build-selected workers with empty stores choose storage withdrawal tied to the construction site, then construction execution can report build action telemetry instead of assignment-only stalling.
- [x] Non-goals / accepted substitutes: No expansion scoring rewrite, no RL reward change, no deploy workflow change, and no owner-side manual gameplay action in this PR.
- [x] Verification evidence required before Done: Controller ran git diff --check, prod typecheck, prod Jest runInBand with 105 suites and 2440 tests passing, and prod build on commit 260f4a68.
- [x] Project Evidence / Next action / Blocked by: Project evidence should reference commit 260f4a68, this PR number, the controller verification commands, and exact-head PR gate checks.
- [x] Post-merge/deploy/runtime proof: Official deploy evidence and runtime-alert artifacts should show all owned rooms alive with construction_acceptance ok true or worker_assignment_gap_sustained absent for the affected rooms.
- [x] Named deliverable proof: Commit 260f4a68 updates prod/src/creeps/workerRunner.ts, prod/test/workerRunner.test.ts, and prod/dist/main.js with the tested construction-energy hydration path.
