### PR TITLE
fix: reduce sustained none-task worker standby recurrence

### DIFF
--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -126,7 +126,7 @@ RUNTIME_SUMMARY_SOURCE_METADATA_KEY = "__runtimeSummarySource"
 RUNTIME_SUMMARY_CPU_METADATA_KEY = "__runtimeSummaryCpu"
 MONITOR_RUNTIME_SUMMARY_SOURCE = "screeps-runtime-monitor"
 ASSIGNED_WORKER_TASK_NAMES = ("harvest", "pickup", "withdraw", "transfer", "build", "repair", "upgrade")
-WORKER_TASK_COUNT_NAMES = ("harvest", "transfer", "build", "repair", "upgrade")
+WORKER_TASK_COUNT_NAMES = ASSIGNED_WORKER_TASK_NAMES
 BUILD_ACTION_RESULT_NAMES = (
     "succeeded",
     "failed_no_energy",
@@ -3252,6 +3252,28 @@ def runtime_none_task_worker_count(room: dict[str, Any] | None) -> int | float |
     return max(0, fallback_count) if fallback_count is not None else None
 
 
+def runtime_none_task_count_explained_by_productive_assignments(
+    room: dict[str, Any] | None,
+    worker_count: int | float,
+) -> bool:
+    if not isinstance(room, dict) or worker_count <= 0:
+        return False
+    assigned_count = runtime_assigned_task_count(room)
+    productive_count = runtime_productive_assignment_count(room)
+    if assigned_count is None or productive_count is None:
+        return False
+    if assigned_count < worker_count or productive_count < worker_count:
+        return False
+    unassigned_count = first_number_value(
+        room,
+        ("workerAssignmentEvidence", "unassignedWorkerCount"),
+        ("resources", "productiveEnergy", "unassignedWorkerCount"),
+        ("productiveEnergy", "unassignedWorkerCount"),
+        ("unassignedWorkerCount",),
+    )
+    return unassigned_count is None or unassigned_count <= 0
+
+
 def runtime_assigned_task_count(room: dict[str, Any] | None) -> int | float | None:
     if not isinstance(room, dict):
         return None
@@ -3324,6 +3346,8 @@ def owned_room_none_task_worker_ratio_evidence(runtime_room: dict[str, Any] | No
     worker_count = runtime_worker_count_from_summary(runtime_room)
     none_count = runtime_none_task_worker_count(runtime_room)
     if worker_count is None or none_count is None or worker_count <= 0 or none_count <= 0:
+        return None
+    if runtime_none_task_count_explained_by_productive_assignments(runtime_room, worker_count):
         return None
 
     none_ratio = none_count / worker_count

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -366,6 +366,78 @@ def none_task_runtime_room(
     }
 
 
+def productive_assignment_legacy_none_task_runtime_room(
+    room: str,
+    tick: int,
+    *,
+    worker_tasks: list[str],
+    task_counts: dict[str, int],
+) -> dict[str, object]:
+    worker_count = len(worker_tasks)
+    return {
+        "roomName": room,
+        "shard": "shardX",
+        monitor.RUNTIME_SUMMARY_SOURCE_METADATA_KEY: monitor.MONITOR_RUNTIME_SUMMARY_SOURCE,
+        monitor.RUNTIME_SUMMARY_TICK_METADATA_KEY: tick,
+        "workerCount": worker_count,
+        "workerAssignmentEvidenceAvailable": True,
+        "workerAssignmentEvidence": {
+            "source": "runtime-summary",
+            "available": True,
+            "tick": tick,
+            "workerCount": worker_count,
+            "assignedTaskCount": worker_count,
+            "productiveAssignmentCount": worker_count,
+            "unassignedWorkerCount": 0,
+            "creepSamples": [
+                {
+                    "name": f"worker-{room}-{index}",
+                    "role": "worker",
+                    "task": task,
+                    "dispatchAssignedTask": task,
+                    "dispatchSelectedTask": task,
+                    "dispatchTick": tick,
+                    "memoryAvailable": True,
+                }
+                for index, task in enumerate(worker_tasks, start=1)
+            ],
+        },
+        "taskCounts": dict(task_counts),
+        "constructionSiteCount": 0,
+        "constructionDeadlockTicks": 0,
+        "resources": {
+            "productiveEnergy": {
+                "workerAssignmentEvidenceAvailable": True,
+                "assignedWorkerCount": worker_count,
+                "productiveAssignmentCount": worker_count,
+                "constructionSiteCount": 0,
+                "constructionDeadlockTicks": 0,
+                "pendingBuildProgress": 0,
+                "buildBlockedReason": "no_construction_sites",
+            }
+        },
+    }
+
+
+def productive_assignment_legacy_none_task_capture(
+    room: str,
+    tick: int,
+    *,
+    worker_count: int,
+    task_counts: dict[str, int],
+) -> dict[str, object]:
+    return {
+        "roomName": room,
+        "shard": "shardX",
+        "runtimeSummaryTick": tick,
+        "workerCount": worker_count,
+        "assignedTaskCount": worker_count,
+        "productiveAssignmentCount": worker_count,
+        "noneTaskWorkerCount": task_counts.get("none", 0),
+        "taskCounts": dict(task_counts),
+    }
+
+
 def worker_deadlock_runtime_summary_payload(
     room: str,
     tick: int,
@@ -1470,6 +1542,114 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(emitted, [])
         self.assertEqual(suppressed, [])
         self.assertEqual(next_state["rule_counts"][monitor.OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND], 0)
+
+    def test_monitor_task_counts_classify_energy_acquisition_assignments(self) -> None:
+        counts = monitor.worker_task_counts(
+            [
+                {
+                    "type": "creep",
+                    "name": "worker-pickup",
+                    "memory": {"role": "worker", "task": {"type": "pickup", "targetId": "drop1"}},
+                },
+                {
+                    "type": "creep",
+                    "name": "worker-withdraw",
+                    "memory": {"role": "worker", "task": {"type": "withdraw", "targetId": "container1"}},
+                },
+                {
+                    "type": "creep",
+                    "name": "worker-unknown",
+                    "memory": {"role": "worker", "task": {"type": "signController", "targetId": "ctrl1"}},
+                },
+            ]
+        )
+
+        self.assertEqual(counts["pickup"], 1)
+        self.assertEqual(counts["withdraw"], 1)
+        self.assertEqual(counts["none"], 1)
+
+    def test_owned_room_legacy_none_task_ratio_productive_assignments_stay_silent(self) -> None:
+        cases = [
+            (
+                "E29N55",
+                {
+                    "build": 0,
+                    "harvest": 0,
+                    "none": 2,
+                    "repair": 0,
+                    "transfer": 0,
+                    "upgrade": 2,
+                },
+                ["upgrade", "upgrade", "pickup", "withdraw"],
+                3,
+                2359,
+            ),
+            (
+                "E29N57",
+                {
+                    "build": 1,
+                    "harvest": 0,
+                    "none": 3,
+                    "repair": 0,
+                    "transfer": 0,
+                    "upgrade": 0,
+                },
+                ["build", "withdraw", "withdraw", "withdraw"],
+                2,
+                1146,
+            ),
+        ]
+
+        for room, task_counts, worker_tasks, consecutive_captures, consecutive_ticks in cases:
+            with self.subTest(room=room):
+                tick = 2161274
+                runtime_room = productive_assignment_legacy_none_task_runtime_room(
+                    room,
+                    tick,
+                    worker_tasks=worker_tasks,
+                    task_counts=task_counts,
+                )
+                runtime_room[monitor.RUNTIME_SUMMARY_CAPTURE_HISTORY_METADATA_KEY] = [
+                    productive_assignment_legacy_none_task_capture(
+                        room,
+                        tick,
+                        worker_count=len(worker_tasks),
+                        task_counts=task_counts,
+                    ),
+                    productive_assignment_legacy_none_task_capture(
+                        room,
+                        tick - consecutive_ticks,
+                        worker_count=len(worker_tasks),
+                        task_counts=task_counts,
+                    ),
+                ]
+                previous_state = {
+                    "baseline_established": True,
+                    "owner": "lanyusea",
+                    "rule_counts": {
+                        monitor.OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND: {
+                            "start_tick": tick - consecutive_ticks,
+                            "last_tick": tick,
+                            "consecutive_ticks": consecutive_ticks,
+                            "consecutive_captures": consecutive_captures,
+                        }
+                    },
+                }
+
+                emitted, suppressed, next_state = monitor.evaluate_room_alert(
+                    make_owned_room_snapshot(room, tick, worker_count=len(worker_tasks)),
+                    previous_state,
+                    now=200,
+                    debounce_seconds=300,
+                    runtime_room_summary=runtime_room,
+                )
+
+                self.assertEqual(suppressed, [])
+                self.assertNotIn(
+                    monitor.OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND,
+                    [reason["kind"] for reason in emitted],
+                )
+                self.assertEqual(next_state["rule_counts"][monitor.OWNED_ROOM_NONE_TASK_WORKER_RATIO_KIND], 0)
 
     def test_owned_room_sustained_none_task_ratio_alerts_without_room_dead(self) -> None:
         first_tick = 2090100
@@ -4823,7 +5003,16 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         self.assertEqual(room["workerLoadEfficiency"]["unavailableReason"], unavailable_reason)
         self.assertEqual(
             room["taskCounts"],
-            {"harvest": 0, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0, "none": 0},
+            {
+                "harvest": 0,
+                "pickup": 0,
+                "withdraw": 0,
+                "transfer": 0,
+                "build": 0,
+                "repair": 0,
+                "upgrade": 0,
+                "none": 0,
+            },
         )
         self.assertEqual(room["workerCarriedEnergy"], 48)
         self.assertEqual(room["resources"]["workerCarriedEnergy"], 48)
@@ -5287,7 +5476,16 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         self.assertNotIn("workerAssignmentEvidenceUnavailableReason", productive_energy)
         self.assertEqual(
             room["taskCounts"],
-            {"harvest": 0, "transfer": 0, "build": 0, "repair": 0, "upgrade": 0, "none": 0},
+            {
+                "harvest": 0,
+                "pickup": 0,
+                "withdraw": 0,
+                "transfer": 0,
+                "build": 0,
+                "repair": 0,
+                "upgrade": 0,
+                "none": 0,
+            },
         )
         self.assertEqual(room["constructionDeadlockTicks"], 0)
         self.assertNotIn("buildBlockedReason", room)


### PR DESCRIPTION
## Linked issues

Intentional PR-body closing linkage:
- None.

Related / non-closing linkage:
- Refs #1884.
- Refs #1875.

## Domain / Kind

- Domain: Runtime monitor / Territory-Economy acceptance
- Kind: bug

## Summary

- Classifies `pickup` and `withdraw` worker assignments explicitly in the runtime monitor instead of folding them into `taskCounts.none`.
- Adds a narrow legacy-capture suppression for sustained none-task worker ratios only when runtime assignment evidence proves every worker has a productive assignment and no unassigned workers remain.
- Keeps unknown idle/unassigned worker cases blocking; the existing sustained none-task alert still fires when productive assignment evidence is missing or incomplete.
- Adds regression coverage for the observed E29N55 and E29N57 patterns from `/root/screeps/runtime-artifacts/screeps-monitor/issue-1875-postmerge-20260614T073820Z/`.

## Verification

- [x] Local check: controller ran `git diff --check HEAD~1..HEAD`, `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py`, `python3 -m unittest scripts.test_screeps_runtime_monitor_tactical_response` (149 tests OK), and `python3 scripts/screeps-runtime-monitor.py self-test` (43 tests OK) on branch head `e26f142030247d7aa88c1a8a6924216a6e3390c8`.
- [x] GitHub Project issue/PR fields are current (`Status`, `Evidence`, `Next action`; plus `Blocked by` when blocked): issue 1884 and issue 1875 are being updated with this PR gate and postdeploy acceptance blocker.
- [x] Automated review has no blocking findings, or a CodeRabbit/Gemini reliability bypass is recorded with reviewer/head/reason; review threads are resolved/outdated/non-blocking: initial PR creation; review/checks will run on head `e26f142030247d7aa88c1a8a6924216a6e3390c8`.
- [x] QA gate: controller script verification passed; postmerge/deploy runtime acceptance is required after merge.
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate

- [x] Task type: runtime-monitor classification bugfix for postdeploy health acceptance.
- [x] Expected observable outcome / named deliverable: health gate no longer blocks on legacy `taskCounts.none` ratios when productive assignment evidence proves workers are actually assigned to energy acquisition/build/upgrade, while true unassigned idle workers remain blocking.
- [x] Non-goals / accepted substitutes: no production bot behavior change, no direct deploy from this PR, no claim that issue 1884 or issue 1875 is closed before fresh postmerge/deploy monitor evidence.
- [x] Verification evidence required before Done: branch head `e26f142030247d7aa88c1a8a6924216a6e3390c8` passed controller diff-check, Python compile, tactical-response unittest suite, and runtime monitor self-test.
- [x] Project Evidence / Next action / Blocked by: issue 1884 Project is moving to In review after PR creation; issue 1875 remains In progress and blocked by issue 1884 until postmerge/deploy health evidence clears.
- [x] Post-merge/deploy/runtime proof: PR-scope runtime replay over `runtime-summary-monitor-20260614T074013Z.log` returns no E29N55/E29N57 sustained-none alert when productive assignment evidence covers all workers; live issue closure uses Project issue state.
- [x] Named deliverable proof: tests cover `pickup`/`withdraw` classification, the E29N55/E29N57 productive-assignment legacy pattern, and the negative case where true sustained `none` workers still alert.

## Issue closure gate

- [x] No issue closure linkage in this PR body; issue 1884 and issue 1875 stay open for postmerge/deploy/runtime acceptance evidence.

## Runtime / deployment impact

- [ ] No gameplay/runtime/deployment impact.
- [x] Gameplay/runtime/deployment impact; Deployment Floor evidence or HELD blocker is recorded.

## Notes

- Initial Codex run `proc_f65efb09e8dd` produced and verified the script/test diff but could not commit because the linked worktree gitdir was outside its sandbox.
- Narrow commit-only Codex recovery created commit `e26f142030247d7aa88c1a8a6924216a6e3390c8` with `lanyusea's bot <lanyusea@gmail.com>` authorship and no file-content edits.

