### PR TITLE
gameplay: recover construction assignment gap workers

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35288,10 +35288,13 @@ function applyWorkerAssignmentGapRecoveryTask(creep, currentTask, selectionConte
   return recoveryTask ? { ...selectionContext, selectedTask: recoveryTask } : selectionContext;
 }
 function selectWorkerAssignmentGapRecoveryTask(creep, currentTask, selectionContext) {
+  var _a2;
   if (!isWorkerAssignmentGapRecoverySelection(creep, currentTask, selectionContext.selectedTask)) {
     return null;
   }
-  if (getUsedTransferEnergy(creep) <= 0 || hasLowWorkerEnergyLoad(creep) || getActiveWorkParts3(creep) <= 0 || !hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep) || hasVisibleHostileCreeps2(creep.room) || currentTask && isDedicatedSourceContainerHarvestTask(creep, currentTask)) {
+  const hasStoredConstructionRecoveryEnergy = hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room);
+  const hasMinimumWorkerCoverage = hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep) || hasStoredConstructionRecoveryEnergy && ((currentTask == null ? void 0 : currentTask.type) === "upgrade" || ((_a2 = selectionContext.selectedTask) == null ? void 0 : _a2.type) === "upgrade");
+  if (getUsedTransferEnergy(creep) <= 0 || hasLowWorkerEnergyLoad(creep) || getActiveWorkParts3(creep) <= 0 || !hasMinimumWorkerCoverage || hasVisibleHostileCreeps2(creep.room) || currentTask && isDedicatedSourceContainerHarvestTask(creep, currentTask)) {
     return null;
   }
   const constructionSite = selectWorkerAssignmentGapRecoveryConstructionSite(creep);

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -588,11 +588,16 @@ function selectWorkerAssignmentGapRecoveryTask(
     return null;
   }
 
+  const hasStoredConstructionRecoveryEnergy = hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room);
+  const hasMinimumWorkerCoverage =
+    hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep) ||
+    (hasStoredConstructionRecoveryEnergy &&
+      (currentTask?.type === 'upgrade' || selectionContext.selectedTask?.type === 'upgrade'));
   if (
     getUsedTransferEnergy(creep) <= 0 ||
     hasLowWorkerEnergyLoad(creep) ||
     getActiveWorkParts(creep) <= 0 ||
-    !hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep) ||
+    !hasMinimumWorkerCoverage ||
     hasVisibleHostileCreeps(creep.room) ||
     (currentTask && isDedicatedSourceContainerHarvestTask(creep, currentTask))
   ) {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -24,6 +24,7 @@ import { TERRITORY_RESERVATION_RENEWAL_TICKS } from '../src/territory/territoryP
 import { LOW_CPU_BUCKET_THRESHOLD } from '../src/runtime/cpuBudget';
 import { installVisibleOwnedRcl6ColonyRoomDefault } from './helpers/territoryControlGate';
 import { selectSpawnEnergyReservationRefillTarget } from '../src/economy/spawnEnergyReservation';
+import { MINIMUM_WORKER_SPAWN_ENERGY } from '../src/economy/energyBuffer';
 
 function withRangeTo<T extends { id: string }>(object: T, rangesByTargetId: Record<string, number>): T {
   return {
@@ -8674,6 +8675,246 @@ describe('runWorker', () => {
         assignedTask: 'build'
       });
       expect(build).toHaveBeenCalledWith(site);
+      expect(upgradeController).not.toHaveBeenCalled();
+    } finally {
+      selectWorkerTask.mockRestore();
+    }
+  });
+
+  it('recovers a single retained upgrader to construction when stored surplus preserves spawn recovery', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 4_754,
+      progressTotal: 5_000,
+      pos: { x: 22, y: 24, roomName: 'E29N56' } as RoomPosition
+    } as ConstructionSite;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 593_641 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(10_000)
+      }
+    } as unknown as StructureStorage;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 300 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      }
+    } as unknown as StructureSpawn;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N56',
+      energyAvailable: MINIMUM_WORKER_SPAWN_ENERGY,
+      energyCapacityAvailable: 1_300,
+      controller,
+      storage,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn, storage] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [spawn, storage];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          if (type === FIND_HOSTILE_CREEPS) {
+            return [];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const upgradeController = jest.fn();
+    const selectedUpgradeTask = { type: 'upgrade', targetId: 'controller1' as Id<StructureController> } as const;
+    const creep = {
+      name: 'LoadedUpgrader',
+      memory: {
+        role: 'worker',
+        colony: 'E29N56',
+        task: selectedUpgradeTask
+      },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 73 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 27 : 0))
+      },
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'road-site1' ? 3 : 12))
+      },
+      room,
+      build,
+      upgradeController,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    roomCreeps.push(creep);
+    const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(selectedUpgradeTask);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { LoadedUpgrader: creep },
+      rooms: { E29N56: room },
+      time: 1_882_759,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        if (id === 'controller1') {
+          return controller;
+        }
+
+        if (id === 'spawn1') {
+          return spawn;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({ type: 'build', targetId: 'road-site1' });
+      expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+        currentTask: 'upgrade',
+        baseSelectedTask: 'upgrade',
+        selectedTask: 'build',
+        assignedTask: 'build'
+      });
+      expect(build).toHaveBeenCalledWith(site);
+      expect(upgradeController).not.toHaveBeenCalled();
+    } finally {
+      selectWorkerTask.mockRestore();
+    }
+  });
+
+  it('uses energy recovery instead of assignment-gap construction below the spawn energy floor', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 4_754,
+      progressTotal: 5_000
+    } as ConstructionSite;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 593_641 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(10_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N56',
+      energyAvailable: MINIMUM_WORKER_SPAWN_ENERGY - 1,
+      energyCapacityAvailable: 1_300,
+      controller,
+      storage,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES) {
+            const structures = [storage] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          if (type === FIND_HOSTILE_CREEPS) {
+            return [];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const upgradeController = jest.fn().mockReturnValue(0);
+    const withdraw = jest.fn().mockReturnValue(0);
+    const selectedUpgradeTask = { type: 'upgrade', targetId: 'controller1' as Id<StructureController> } as const;
+    const creep = {
+      name: 'LoadedUpgrader',
+      memory: {
+        role: 'worker',
+        colony: 'E29N56',
+        task: selectedUpgradeTask
+      },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 73 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 27 : 0))
+      },
+      room,
+      build: jest.fn(),
+      withdraw,
+      upgradeController,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    roomCreeps.push(creep);
+    const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(selectedUpgradeTask);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { LoadedUpgrader: creep },
+      rooms: { E29N56: room },
+      time: 1_882_760,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        if (id === 'controller1') {
+          return controller;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({ type: 'withdraw', targetId: 'storage1' });
+      expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+        currentTask: 'upgrade',
+        baseSelectedTask: 'upgrade',
+        energyCriticalTask: 'withdraw',
+        selectedTask: 'withdraw',
+        assignedTask: 'withdraw'
+      });
+      expect(creep.build).not.toHaveBeenCalled();
+      expect(withdraw).toHaveBeenCalledWith(storage, RESOURCE_ENERGY, 27);
       expect(upgradeController).not.toHaveBeenCalled();
     } finally {
       selectWorkerTask.mockRestore();


### PR DESCRIPTION
## Summary
- Allows worker-assignment-gap recovery to convert retained upgrade workers into construction when the room has stored construction-recovery energy and the spawn energy floor is preserved.
- Keeps emergency spawn recovery safety intact: workers below the spawn energy floor still choose energy recovery rather than construction.
- Adds workerRunner regression coverage for E29N56/E29N57 construction-gap recovery scenarios and regenerates `prod/dist/main.js`.

Related to #1886.

## Verification
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`
- `git diff --check`

## Universal task Done gate
- [x] Task type: Production gameplay code change with bundled Screeps artifact regeneration.
- [x] Expected observable outcome / named deliverable: Codex-authored branch commit `a8bf3ad9c1dd3687d7d219b74dfdeaa3a95b0912` updates worker assignment-gap construction recovery plus Jest coverage and the generated bundle.
- [x] Non-goals / accepted substitutes: Release mutation, issue closure, and runtime acceptance are handled by the scheduler acceptance lane for issue 1886 rather than this PR body.
- [x] Verification evidence required before Done: Controller ran `npm run typecheck`, `npm test -- --runInBand` with 105 suites and 2447 tests passing, `npm run build`, and `git diff --check` in `/root/screeps-worktrees/issue-1886-construction-worker-assignment-gap`.
- [x] Project Evidence / Next action / Blocked by: Issue 1886 Project item is In progress with fresh runtime-alert evidence; this PR supplies the code handoff for review, deploy, and monitor acceptance.
- [x] Post-merge/deploy/runtime proof: Runtime proof surface is issue 1886 using postdeploy monitor artifacts that demonstrate reduced worker_assignment_gap_sustained alerts in E29N56/E29N57.
- [x] Named deliverable proof: `git show --name-status a8bf3ad9` lists `prod/src/creeps/workerRunner.ts`, `prod/test/workerRunner.test.ts`, and `prod/dist/main.js`; controller verification passed for the same tree.
