### PR TITLE
fix: restore deploy postdeploy capture fallback

### DIFF
--- a/.github/workflows/official-screeps-deploy.yml
+++ b/.github/workflows/official-screeps-deploy.yml
@@ -144,6 +144,7 @@ jobs:
             --live-official-console \
             --out-dir runtime-artifacts/runtime-summary-console \
             --artifact-name postdeploy-runtime-summary-console.log \
+            --status-file "$EVIDENCE_DIR/postdeploy-runtime-summary-console-status.json" \
             --format status-line \
             --live-timeout-seconds 45 || true
           python3 scripts/screeps-runtime-monitor.py summary \
@@ -158,6 +159,7 @@ jobs:
           python3 scripts/screeps-runtime-monitor.py health-gate \
             --summary "$EVIDENCE_DIR/postdeploy-summary.json" \
             --alert "$EVIDENCE_DIR/postdeploy-alert.json" \
+            --console-capture-status "$EVIDENCE_DIR/postdeploy-runtime-summary-console-status.json" \
             > "$EVIDENCE_DIR/postdeploy-health-gate.json"
 
       - name: Upload deploy evidence
@@ -165,5 +167,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: official-screeps-deploy-evidence
-          path: runtime-artifacts/official-screeps-deploy/
+          path: |
+            runtime-artifacts/official-screeps-deploy/
+            runtime-artifacts/runtime-summary-console/
           if-no-files-found: ignore

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -233,6 +233,18 @@ CPU_USED_OVER_LIMIT_KIND = "cpu_used_over_limit"
 CPU_TELEMETRY_MISSING_KIND = "cpu_telemetry_missing"
 CPU_BUCKET_LOW_THRESHOLD = 1_000
 CPU_BUCKET_CRITICAL_THRESHOLD = 100
+POSTDEPLOY_CONSOLE_CAPTURE_UNAVAILABLE_SUPPRESSION = "postdeploy_console_capture_unavailable"
+POSTDEPLOY_OPTIONAL_CAPTURE_ERROR_TERMS = (
+    "websocket",
+    "websockets",
+    "connect",
+    "connection",
+    "timed out",
+    "timeout",
+    "network",
+    "temporary failure",
+    "name or service not known",
+)
 CPU_BUCKET_ROUTES = [
     {"issue": "#1490", "topic": "runtime_alert"},
     {"issue": "#906", "topic": "metric_taxonomy"},
@@ -8089,7 +8101,65 @@ def postdeploy_non_blocking_runtime_reason(reason: dict[str, Any]) -> dict[str, 
     }
 
 
-def evaluate_postdeploy_health_gate(summary_payload: dict[str, Any], alert_payload: dict[str, Any]) -> dict[str, Any]:
+def postdeploy_console_capture_status_summary(status: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: status[key]
+        for key in (
+            "captureStatus",
+            "processStatus",
+            "exitCode",
+            "source",
+            "error",
+            "statusPath",
+            "websocketUrl",
+            "requestedChannels",
+        )
+        if key in status
+    }
+
+
+def postdeploy_console_capture_unavailable(status: dict[str, Any] | None) -> bool:
+    if not isinstance(status, dict):
+        return False
+    if status.get("source") != "live-official-console":
+        return False
+    if status.get("captureOk") is True:
+        return False
+    if status.get("captureStatus") != "capture_error" and status.get("processStatus") != "capture_error":
+        return False
+
+    error = str(status.get("error", "")).lower()
+    return any(term in error for term in POSTDEPLOY_OPTIONAL_CAPTURE_ERROR_TERMS)
+
+
+def postdeploy_missing_cpu_reason_is_optional_capture_failure(
+    reason: dict[str, Any],
+    console_capture_status: dict[str, Any] | None,
+) -> bool:
+    return reason.get("kind") == CPU_TELEMETRY_MISSING_KIND and postdeploy_console_capture_unavailable(
+        console_capture_status
+    )
+
+
+def postdeploy_non_blocking_console_capture_reason(
+    reason: dict[str, Any],
+    console_capture_status: dict[str, Any] | None,
+) -> dict[str, Any]:
+    result = {
+        **reason,
+        "non_blocking": True,
+        "suppression_reason": POSTDEPLOY_CONSOLE_CAPTURE_UNAVAILABLE_SUPPRESSION,
+    }
+    if isinstance(console_capture_status, dict):
+        result["consoleCaptureStatus"] = postdeploy_console_capture_status_summary(console_capture_status)
+    return result
+
+
+def evaluate_postdeploy_health_gate(
+    summary_payload: dict[str, Any],
+    alert_payload: dict[str, Any],
+    console_capture_status: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     reasons: list[dict[str, Any]] = []
     non_blocking_reasons: list[dict[str, Any]] = []
     if summary_payload.get("ok") is not True:
@@ -8106,7 +8176,11 @@ def evaluate_postdeploy_health_gate(summary_payload: dict[str, Any], alert_paylo
                     "message": reason.get("message", "runtime alert active"),
                     "source": reason,
                 }
-                if postdeploy_runtime_reason_blocks_health_gate(reason):
+                if postdeploy_missing_cpu_reason_is_optional_capture_failure(reason, console_capture_status):
+                    non_blocking_reasons.append(
+                        postdeploy_non_blocking_console_capture_reason(active_alert, console_capture_status)
+                    )
+                elif postdeploy_runtime_reason_blocks_health_gate(reason):
                     reasons.append(active_alert)
                 else:
                     non_blocking_reasons.append(postdeploy_non_blocking_runtime_reason(active_alert))
@@ -8131,7 +8205,11 @@ def evaluate_postdeploy_health_gate(summary_payload: dict[str, Any], alert_paylo
             if threshold_reason is not None:
                 reasons.append(threshold_reason)
             for cpu_reason in detect_cpu_runtime_reasons(runtime_summary_room_ref(room), room, require_cpu_evidence=True):
-                if postdeploy_runtime_reason_blocks_health_gate(cpu_reason):
+                if postdeploy_missing_cpu_reason_is_optional_capture_failure(cpu_reason, console_capture_status):
+                    non_blocking_reasons.append(
+                        postdeploy_non_blocking_console_capture_reason(cpu_reason, console_capture_status)
+                    )
+                elif postdeploy_runtime_reason_blocks_health_gate(cpu_reason):
                     reasons.append(cpu_reason)
                 else:
                     non_blocking_reasons.append(postdeploy_non_blocking_runtime_reason(cpu_reason))
@@ -8183,13 +8261,21 @@ def evaluate_postdeploy_health_gate(summary_payload: dict[str, Any], alert_paylo
     }
     if non_blocking_reasons:
         result["non_blocking_reasons"] = non_blocking_reasons
+    if isinstance(console_capture_status, dict):
+        result["console_capture_status"] = postdeploy_console_capture_status_summary(console_capture_status)
     return result
 
 
 def command_health_gate(args: argparse.Namespace) -> int:
     summary_payload = load_json_file(args.summary)
     alert_payload = load_json_file(args.alert)
-    result = evaluate_postdeploy_health_gate(summary_payload, alert_payload)
+    console_capture_status = None
+    console_capture_status_path = getattr(args, "console_capture_status", None)
+    if console_capture_status_path:
+        status_path = Path(console_capture_status_path).expanduser()
+        if status_path.exists():
+            console_capture_status = load_json_file(str(status_path))
+    result = evaluate_postdeploy_health_gate(summary_payload, alert_payload, console_capture_status)
     print_json(result, [os.environ.get("SCREEPS_AUTH_TOKEN", "")])
     return 0 if result["ok"] else 1
 
@@ -8429,6 +8515,14 @@ def build_parser() -> argparse.ArgumentParser:
     health_gate = subcommands.add_parser("health-gate", help="fail when post-deploy summary/alert evidence violates survival invariants")
     health_gate.add_argument("--summary", required=True, help="summary JSON path produced by the summary command")
     health_gate.add_argument("--alert", required=True, help="alert JSON path produced by the alert command")
+    health_gate.add_argument(
+        "--console-capture-status",
+        default=None,
+        help=(
+            "Optional status JSON from screeps_runtime_summary_console_capture.py. "
+            "When live console capture fails at import/connect time, postdeploy CPU telemetry absence is evidence-only."
+        ),
+    )
     health_gate.set_defaults(func=command_health_gate)
 
     tactical_response = subcommands.add_parser(

--- a/scripts/screeps_official_deploy.py
+++ b/scripts/screeps_official_deploy.py
@@ -943,6 +943,11 @@ def postdeploy_runtime_summary_console_dir(cfg: DeployConfig) -> Path:
     return cfg.repo_root / "runtime-artifacts" / "runtime-summary-console"
 
 
+def postdeploy_console_capture_status_path(cfg: DeployConfig) -> Path:
+    """Return the archived live-console capture status sidecar path."""
+    return cfg.evidence_dir / "postdeploy-runtime-summary-console-status.json"
+
+
 def run_postdeploy_console_capture(
     cfg: DeployConfig,
     *,
@@ -962,6 +967,8 @@ def run_postdeploy_console_capture(
             str(out_dir),
             "--artifact-name",
             "postdeploy-runtime-summary-console.log",
+            "--status-file",
+            str(postdeploy_console_capture_status_path(cfg)),
             "--format",
             "status-line",
             "--live-timeout-seconds",
@@ -989,6 +996,7 @@ def run_postdeploy_health_gate(
     summary_path = cfg.evidence_dir / "postdeploy-summary.json"
     alert_path = cfg.evidence_dir / "postdeploy-alert.json"
     health_path = postdeploy_health_gate_path(cfg)
+    capture_status_path = postdeploy_console_capture_status_path(cfg)
 
     run_postdeploy_console_capture(cfg, env=env, runner=runner)
     run_monitor_json(
@@ -1020,7 +1028,15 @@ def run_postdeploy_health_gate(
     )
     return run_monitor_json(
         cfg,
-        ["health-gate", "--summary", str(summary_path), "--alert", str(alert_path)],
+        [
+            "health-gate",
+            "--summary",
+            str(summary_path),
+            "--alert",
+            str(alert_path),
+            "--console-capture-status",
+            str(capture_status_path),
+        ],
         health_path,
         env=env,
         runner=runner,

--- a/scripts/test_screeps_official_deploy.py
+++ b/scripts/test_screeps_official_deploy.py
@@ -546,6 +546,7 @@ class OfficialDeployTest(unittest.TestCase):
             paired_path = evidence_dir / "postdeploy-health-gate-rollback.json"
             expected_out_dir = repo_root / "runtime-artifacts" / "screeps-monitor"
             expected_runtime_summary_dir = repo_root / "runtime-artifacts" / "runtime-summary-console"
+            expected_capture_status_path = evidence_dir / "postdeploy-runtime-summary-console-status.json"
 
             self.assertTrue(health_gate["ok"])
             self.assertTrue(paired_path.exists())
@@ -557,6 +558,9 @@ class OfficialDeployTest(unittest.TestCase):
             self.assertIn("--out-dir", commands[0])
             capture_out_dir_index = commands[0].index("--out-dir")
             self.assertEqual(commands[0][capture_out_dir_index + 1], str(expected_runtime_summary_dir))
+            self.assertIn("--status-file", commands[0])
+            capture_status_index = commands[0].index("--status-file")
+            self.assertEqual(commands[0][capture_status_index + 1], str(expected_capture_status_path))
             self.assertIn("--live-timeout-seconds", commands[0])
             self.assertEqual(commands[1][1:3], [str(repo_root / "scripts" / "screeps-runtime-monitor.py"), "summary"])
             self.assertIn("--out-dir", commands[1])
@@ -575,6 +579,10 @@ class OfficialDeployTest(unittest.TestCase):
             self.assertEqual(commands[2][alert_runtime_dir_index + 1], str(expected_runtime_summary_dir))
             self.assertNotIn("--room", commands[2])
             self.assertIn("--force-alert-image", commands[2])
+            self.assertEqual(commands[3][1:3], [str(repo_root / "scripts" / "screeps-runtime-monitor.py"), "health-gate"])
+            self.assertIn("--console-capture-status", commands[3])
+            health_status_index = commands[3].index("--console-capture-status")
+            self.assertEqual(commands[3][health_status_index + 1], str(expected_capture_status_path))
 
     def test_postdeploy_health_gate_uses_default_path_without_deploy_evidence_path(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -610,6 +618,20 @@ class OfficialDeployTest(unittest.TestCase):
         self.assertIn("if: ${{ inputs.mode == 'deploy' }}", text[install_step_index:install_index])
         self.assertLess(install_index, text.index(deploy_upload_marker))
         self.assertLess(install_index, text.index(capture_marker))
+
+    def test_official_deploy_workflow_archives_and_passes_live_capture_status(self) -> None:
+        workflow = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "official-screeps-deploy.yml"
+        text = workflow.read_text(encoding="utf-8")
+        capture_status_marker = '--status-file "$EVIDENCE_DIR/postdeploy-runtime-summary-console-status.json"'
+        health_gate_status_marker = (
+            '--console-capture-status "$EVIDENCE_DIR/postdeploy-runtime-summary-console-status.json"'
+        )
+
+        self.assertIn(capture_status_marker, text)
+        self.assertIn(health_gate_status_marker, text)
+        self.assertLess(text.index(capture_status_marker), text.index(health_gate_status_marker))
+        self.assertIn("runtime-artifacts/official-screeps-deploy/", text)
+        self.assertIn("runtime-artifacts/runtime-summary-console/", text)
 
     def test_recovery_summary_reader_scopes_single_target_and_collects_all_for_multiple_targets(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -3227,6 +3227,97 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(cpu_reason["missing"], ["cpu.used", "cpu.bucket"])
         self.assertNotIn("postdeploy_room_dead", [reason["kind"] for reason in health["reasons"]])
 
+    def test_postdeploy_health_gate_treats_optional_console_import_failure_as_evidence_only(self) -> None:
+        health = monitor.evaluate_postdeploy_health_gate(
+            {
+                "ok": True,
+                "mode": "summary",
+                "room_summaries": [
+                    {
+                        "room": "shardX/E26S49",
+                        "owned_creeps": 1,
+                        "owned_spawns": 1,
+                        "creeps": 1,
+                        "spawns": 1,
+                        "owner": "owner",
+                        "constructionSiteCount": 0,
+                        "pendingBuildProgress": 0,
+                    }
+                ],
+            },
+            {
+                "ok": True,
+                "mode": "alert",
+                "alert": True,
+                "reasons": [
+                    {
+                        "kind": monitor.CPU_TELEMETRY_MISSING_KIND,
+                        "message": "missing current CPU telemetry",
+                        "room": "shardX/E26S49",
+                    }
+                ],
+            },
+            {
+                "captureOk": False,
+                "captureStatus": "capture_error",
+                "processStatus": "capture_error",
+                "exitCode": 1,
+                "source": "live-official-console",
+                "error": "Python package 'websockets' is required for --live-official-console",
+            },
+        )
+
+        self.assertTrue(health["ok"], health["reasons"])
+        self.assertEqual(health["reasons"], [])
+        non_blocking_reason = next(
+            reason
+            for reason in health["non_blocking_reasons"]
+            if reason["kind"] == monitor.CPU_TELEMETRY_MISSING_KIND
+        )
+        self.assertEqual(
+            non_blocking_reason["suppression_reason"],
+            monitor.POSTDEPLOY_CONSOLE_CAPTURE_UNAVAILABLE_SUPPRESSION,
+        )
+        active_reason = next(
+            reason for reason in health["non_blocking_reasons"] if reason["kind"] == "postdeploy_active_alert"
+        )
+        self.assertEqual(
+            active_reason["suppression_reason"],
+            monitor.POSTDEPLOY_CONSOLE_CAPTURE_UNAVAILABLE_SUPPRESSION,
+        )
+        self.assertEqual(health["console_capture_status"]["captureStatus"], "capture_error")
+
+    def test_postdeploy_health_gate_keeps_missing_cpu_blocking_after_completed_console_capture(self) -> None:
+        health = monitor.evaluate_postdeploy_health_gate(
+            {
+                "ok": True,
+                "mode": "summary",
+                "room_summaries": [
+                    {
+                        "room": "shardX/E26S49",
+                        "owned_creeps": 1,
+                        "owned_spawns": 1,
+                        "creeps": 1,
+                        "spawns": 1,
+                        "owner": "owner",
+                        "constructionSiteCount": 0,
+                        "pendingBuildProgress": 0,
+                    }
+                ],
+            },
+            {"ok": True, "mode": "alert", "alert": False, "reasons": []},
+            {
+                "captureOk": False,
+                "captureStatus": "no_messages",
+                "processStatus": "completed",
+                "exitCode": 0,
+                "source": "live-official-console",
+            },
+        )
+
+        self.assertFalse(health["ok"])
+        self.assertIn(monitor.CPU_TELEMETRY_MISSING_KIND, [reason["kind"] for reason in health["reasons"]])
+
     def test_cpu_bucket_alert_does_not_mask_hostile_or_damage_alerts(self) -> None:
         previous = {
             "baseline_established": True,


### PR DESCRIPTION
## Summary
- Makes the official deploy postdeploy console capture non-fatal when the live official console websocket is unavailable before CPU telemetry is captured.
- Passes the console-capture status artifact into the postdeploy health gate so missing CPU evidence from an optional capture failure is recorded as non-blocking evidence instead of failing the workflow after upload/activeWorld.
- Adds regression coverage for the deploy helper, health-gate CLI, and postdeploy construction acceptance path.

Related to #1887. Runtime/workflow acceptance for issue 1887 remains open until an official deploy workflow run succeeds on current `main` and archived postdeploy artifacts are downloaded/verified.

## Verification
- `git diff --check origin/main...HEAD`
- `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/screeps_official_deploy.py scripts/test_screeps_official_deploy.py scripts/test_screeps_runtime_monitor_tactical_response.py`
- `python3 -m unittest scripts/test_screeps_official_deploy.py scripts/test_screeps_runtime_monitor_tactical_response.py` (181 tests)
- PyYAML parse of `.github/workflows/official-screeps-deploy.yml`
- `git merge-base --is-ancestor origin/main HEAD`

## Universal task Done gate
- [x] Task type: deploy/workflow/script bugfix with tests; no official MMO write from this PR branch.
- [x] Expected observable outcome / named deliverable: PR branch commit `ff66dd678c0733cc4c1ff36bc3ee4dde7d526e3a` contains the deploy postdeploy capture fallback and preserves issue 1887 as the runtime/workflow acceptance owner.
- [x] Non-goals / accepted substitutes: This PR does not claim deploy floor completion; it only supplies the code/workflow fix that must be validated by a later official deploy workflow run from `main`.
- [x] Verification evidence required before Done: controller verified diff-check, py_compile, focused unittest, YAML parse, and `origin/main` ancestry after merging current main into the branch.
- [x] Project Evidence / Next action / Blocked by: issue 1887 Project item should remain In review/In progress until PR gate, merge, official deploy workflow rerun, evidence download, and postdeploy health/artifact verification complete.
- [x] Post-merge/deploy/runtime proof: not claimed here; required proof is a successful `official-screeps-deploy.yml` run on current `main` with uploaded `official-screeps-deploy-evidence` artifacts and postdeploy health/summary/alert JSON archived locally.
- [x] Named deliverable proof: `git show --name-status ff66dd67` lists `.github/workflows/official-screeps-deploy.yml`, `scripts/screeps-runtime-monitor.py`, `scripts/screeps_official_deploy.py`, and their focused tests.
