### PR TITLE
gameplay: allow covered sustain upgrader construction yield

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -28895,7 +28895,10 @@ function shouldYieldControllerSustainUpgradeToConstruction(creep, sustain) {
 }
 function shouldYieldLocalControllerSustainUpgradeToConstruction(creep) {
   var _a2;
-  return ((_a2 = creep.room.controller) == null ? void 0 : _a2.my) === true && !isControllerDowngradeImminentForLowLoadReturn(creep.room.controller) && !hasVisibleHostilePresence3(creep.room) && !hasActiveSpawningSpawn(creep.room) && !hasSameRoomWorkerAssignedToTask(creep.room, creep, "build") && hasMinimumProductiveWorkerCoverageForBoundedConstruction(creep) && hasSpendableConstructionBacklog(creep);
+  return ((_a2 = creep.room.controller) == null ? void 0 : _a2.my) === true && !isControllerDowngradeImminentForLowLoadReturn(creep.room.controller) && !hasVisibleHostilePresence3(creep.room) && !shouldActiveSpawnBlockControllerSustainConstructionYield(creep) && !hasSameRoomWorkerAssignedToTask(creep.room, creep, "build") && hasMinimumProductiveWorkerCoverageForBoundedConstruction(creep) && hasSpendableConstructionBacklog(creep);
+}
+function shouldActiveSpawnBlockControllerSustainConstructionYield(creep) {
+  return hasActiveSpawningSpawn(creep.room) && shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep);
 }
 function hasVisibleOwnedConstructionDemand(room) {
   if (typeof FIND_CONSTRUCTION_SITES !== "number" || typeof (room == null ? void 0 : room.find) !== "function") {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1796,11 +1796,15 @@ function shouldYieldLocalControllerSustainUpgradeToConstruction(creep: Creep): b
     creep.room.controller?.my === true &&
     !isControllerDowngradeImminentForLowLoadReturn(creep.room.controller) &&
     !hasVisibleHostilePresence(creep.room) &&
-    !hasActiveSpawningSpawn(creep.room) &&
+    !shouldActiveSpawnBlockControllerSustainConstructionYield(creep) &&
     !hasSameRoomWorkerAssignedToTask(creep.room, creep, 'build') &&
     hasMinimumProductiveWorkerCoverageForBoundedConstruction(creep) &&
     hasSpendableConstructionBacklog(creep)
   );
+}
+
+function shouldActiveSpawnBlockControllerSustainConstructionYield(creep: Creep): boolean {
+  return hasActiveSpawningSpawn(creep.room) && shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep);
 }
 
 function hasVisibleOwnedConstructionDemand(room: Room | undefined): boolean {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -15481,6 +15481,66 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(sustainUpgrader)).toEqual({ type: 'build', targetId: 'container-site1' });
   });
 
+  it('uses a loaded E29N56 sustain upgrader on uncovered construction when an active spawn refill is covered', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 700,
+      progressTotal: 1_000,
+      pos: makeRoomPosition(20, 24, 'E29N56')
+    } as ConstructionSite;
+    const activeSpawn = makeEnergySinkWithEnergy('spawn1', 'spawn' as StructureConstant, 300, 0, {
+      my: true,
+      spawning: { name: 'worker-E29N56-next', remainingTime: 10 },
+      pos: makeRoomPosition(17, 24, 'E29N56')
+    }) as StructureSpawn;
+    const storage = makeStoredEnergyStructure('storage1', 'storage' as StructureConstant, 603_990, {
+      my: true,
+      pos: makeRoomPosition(18, 23, 'E29N56')
+    }) as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N56',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      myStructures: [activeSpawn as AnyOwnedStructure],
+      structures: [activeSpawn as unknown as AnyStructure, storage as AnyStructure]
+    });
+    (room as { storage?: StructureStorage }).storage = storage;
+    const sustainUpgrader = {
+      name: 'worker-E29N56-2167049',
+      memory: {
+        role: 'worker',
+        colony: 'E29N56',
+        controllerSustain: { homeRoom: 'E29N56', targetRoom: 'E29N56', role: 'upgrader' },
+        task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      pos: { getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'road-site1' ? 4 : 3)) },
+      room
+    } as unknown as Creep;
+    const controllerCoverage = makeLoadedWorker(room, {
+      type: 'upgrade',
+      targetId: 'controller1' as Id<StructureController>
+    });
+    setGameCreeps({ SustainUpgrader: sustainUpgrader, ControllerCoverage: controllerCoverage });
+
+    expect(selectWorkerTask(sustainUpgrader)).toEqual({ type: 'build', targetId: 'road-site1' });
+  });
+
   it('keeps local E29N57 controller sustain upgrading when construction already has builder coverage', () => {
     const site = {
       id: 'container-site1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -31,6 +31,7 @@ import {
   selectWorkerEnergyCriticalAcquisitionTask,
   isWorkerRepairTargetComplete,
   selectWorkerTask,
+  shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill,
   shouldSwitchLowLoadWorkerEnergyAcquisitionTaskForYield
 } from '../src/tasks/workerTasks';
 import { BOOTSTRAP_DEFENSE_FLOOR_REPAIR_HITS_CEILING } from '../src/defense/defensePlanner';
@@ -15536,7 +15537,30 @@ describe('selectWorkerTask', () => {
       type: 'upgrade',
       targetId: 'controller1' as Id<StructureController>
     });
+    const spawnRefillCoverage = {
+      name: 'SpawnRefillCoverage',
+      memory: {
+        role: 'worker',
+        colony: 'E29N56',
+        task: { type: 'transfer', targetId: 'spawn1' as Id<AnyStoreStructure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 1_300 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      },
+      pos: { getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'spawn1' ? 1 : 4)) },
+      room
+    } as unknown as Creep;
+
     setGameCreeps({ SustainUpgrader: sustainUpgrader, ControllerCoverage: controllerCoverage });
+    expect(shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(sustainUpgrader)).toBe(true);
+
+    setGameCreeps({
+      SustainUpgrader: sustainUpgrader,
+      ControllerCoverage: controllerCoverage,
+      SpawnRefillCoverage: spawnRefillCoverage
+    });
+    expect(shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(sustainUpgrader)).toBe(false);
 
     expect(selectWorkerTask(sustainUpgrader)).toEqual({ type: 'build', targetId: 'road-site1' });
   });


### PR DESCRIPTION
## Summary
- Allows a loaded local controller-sustain worker to yield to uncovered construction when an active spawn's near-term refill is already covered.
- Adds an E29N56 regression test for the active-spawn + covered-refill construction-yield case.
- Regenerates the bundled Screeps artifact.

Refs #1878

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` (105 suites / 2448 tests)
- `npm run build`



## Review-fix triage
- source/thread: CodeRabbit `PRRT_kwDOSMSsO86JZgxA` / discussion `PRRC_kwDOSMSsO87LOXGr` on `prod/test/workerTasks.test.ts`
- classification: FIX
- criticality: critical test-coverage gap; the prior test could claim spawn-refill coverage without proving a refill worker covered the active spawn reserve.
- evidence: commit `589b6010` adds `SpawnRefillCoverage` with transfer task targeting `spawn1` and asserts `shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill` flips true -> false before expecting the sustain upgrader to build.
- action: pushed review-fix commit `589b6010e975d19274e9de64561d7b0e2e344b91`.
- verification: controller ran `git diff --check`, `npm run typecheck`, focused `npm test -- --runInBand test/workerTasks.test.ts` (540 tests), full `npm test -- --runInBand` (105 suites / 2448 tests), and `npm run build` after the review-fix diff.

## Universal task Done gate
- [x] Task type: code
- [x] Expected observable outcome / named deliverable: E29N56 sustain upgrader assignment can select uncovered construction in the covered active-spawn refill case.
- [x] Non-goals / accepted substitutes: Live acceptance remains owned by issue 1878; this PR delivers the code slice and regression coverage.
- [x] Verification evidence required before Done: Controller verification passed diff-check, typecheck, full Jest, and build on commit 381493326ec17eb34a47aa8824496a401222717d; review-fix commit 589b6010e975d19274e9de64561d7b0e2e344b91 was then controller-verified with diff-check, typecheck, focused workerTasks Jest, full Jest, and build.
- [x] Project Evidence / Next action / Blocked by: Project records issue 1878 as In progress with this PR as the code gate and runtime acceptance as the issue gate.
- [x] Post-merge/deploy/runtime proof: Not applicable to this PR slice; official MMO evidence belongs to issue 1878 acceptance.
- [x] Named deliverable proof: Regression test in prod/test/workerTasks.test.ts plus regenerated prod/dist/main.js.

