### PR TITLE
gameplay: keep builders supplied before controller yield

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -29749,9 +29749,9 @@ function selectInterRoomForeignRoomRecallTask(creep, carriedEnergy) {
   return carriedEnergy > 0 ? selectInterRoomForeignRoomReturnTask(creep, carriedEnergy) : selectInterRoomHomeEnergyAcquisitionTask(creep);
 }
 function selectForeignColonyConstructionBacklogEnergyAcquisitionTask(creep) {
-  var _a2, _b, _c, _d, _e;
+  var _a2, _b, _c, _d, _e, _f, _g;
   const colonyRoom = getCreepColonyRoom(creep);
-  if (!colonyRoom || isWorkerInColonyRoom(creep) || ((_a2 = creep.memory) == null ? void 0 : _a2.role) !== "worker" || ((_b = creep.memory) == null ? void 0 : _b.territory) !== void 0 || ((_c = creep.memory) == null ? void 0 : _c.spawnSupport) !== void 0 || ((_d = creep.memory) == null ? void 0 : _d.interRoomEnergyHaul) !== void 0 || getFreeEnergyCapacity9(creep) <= 0 || getActiveWorkParts2(creep) <= 0 || ((_e = colonyRoom.controller) == null ? void 0 : _e.my) !== true || shouldGuardControllerDowngrade2(colonyRoom.controller) || hasVisibleHostilePresence3(colonyRoom) || !checkEnergyBufferForStoredConstructionSpending(colonyRoom)) {
+  if (!colonyRoom || isWorkerInColonyRoom(creep) || ((_a2 = creep.memory) == null ? void 0 : _a2.role) !== "worker" || ((_c = (_b = creep.memory) == null ? void 0 : _b.controllerSustain) == null ? void 0 : _c.role) === "upgrader" || ((_d = creep.memory) == null ? void 0 : _d.territory) !== void 0 || ((_e = creep.memory) == null ? void 0 : _e.spawnSupport) !== void 0 || ((_f = creep.memory) == null ? void 0 : _f.interRoomEnergyHaul) !== void 0 || getFreeEnergyCapacity9(creep) <= 0 || getActiveWorkParts2(creep) <= 0 || ((_g = colonyRoom.controller) == null ? void 0 : _g.my) !== true || shouldGuardControllerDowngrade2(colonyRoom.controller) || hasVisibleHostilePresence3(colonyRoom) || !checkEnergyBufferForStoredConstructionSpending(colonyRoom)) {
     return null;
   }
   const constructionSite = selectForeignColonyConstructionBacklogEnergyTarget(creep, colonyRoom);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -28175,12 +28175,16 @@ function selectHeuristicWorkerTask(creep) {
     if (isTerritoryControlTask(territoryControllerTask)) {
       return territoryControllerTask;
     }
-    const interRoomRecallTask = selectInterRoomForeignRoomRecallTask(creep, carriedEnergy);
-    if (interRoomRecallTask) {
-      return interRoomRecallTask;
-    }
     let hasPriorityEnergySink = false;
     if (getFreeEnergyCapacity9(creep) > 0) {
+      const foreignColonyConstructionBacklogEnergyAcquisitionTask = selectForeignColonyConstructionBacklogEnergyAcquisitionTask(creep);
+      if (foreignColonyConstructionBacklogEnergyAcquisitionTask) {
+        return foreignColonyConstructionBacklogEnergyAcquisitionTask;
+      }
+      const interRoomRecallTask = selectInterRoomForeignRoomRecallTask(creep, carriedEnergy);
+      if (interRoomRecallTask) {
+        return interRoomRecallTask;
+      }
       const storedProtectedConstructionEnergyAcquisitionTask = selectStoredProtectedSourceContainerConstructionEnergyAcquisitionTask(creep);
       if (storedProtectedConstructionEnergyAcquisitionTask) {
         return storedProtectedConstructionEnergyAcquisitionTask;
@@ -29744,6 +29748,55 @@ function selectInterRoomForeignRoomRecallTask(creep, carriedEnergy) {
   }
   return carriedEnergy > 0 ? selectInterRoomForeignRoomReturnTask(creep, carriedEnergy) : selectInterRoomHomeEnergyAcquisitionTask(creep);
 }
+function selectForeignColonyConstructionBacklogEnergyAcquisitionTask(creep) {
+  var _a2, _b, _c, _d, _e;
+  const colonyRoom = getCreepColonyRoom(creep);
+  if (!colonyRoom || isWorkerInColonyRoom(creep) || ((_a2 = creep.memory) == null ? void 0 : _a2.role) !== "worker" || ((_b = creep.memory) == null ? void 0 : _b.territory) !== void 0 || ((_c = creep.memory) == null ? void 0 : _c.spawnSupport) !== void 0 || ((_d = creep.memory) == null ? void 0 : _d.interRoomEnergyHaul) !== void 0 || getFreeEnergyCapacity9(creep) <= 0 || getActiveWorkParts2(creep) <= 0 || ((_e = colonyRoom.controller) == null ? void 0 : _e.my) !== true || shouldGuardControllerDowngrade2(colonyRoom.controller) || hasVisibleHostilePresence3(colonyRoom) || !checkEnergyBufferForStoredConstructionSpending(colonyRoom)) {
+    return null;
+  }
+  const constructionSite = selectForeignColonyConstructionBacklogEnergyTarget(creep, colonyRoom);
+  if (!constructionSite) {
+    return null;
+  }
+  const source = selectForeignColonyConstructionBacklogStorageSource(creep, colonyRoom, constructionSite);
+  return source ? {
+    type: "withdraw",
+    targetId: source.id,
+    constructionSiteId: constructionSite.id
+  } : null;
+}
+function selectForeignColonyConstructionBacklogEnergyTarget(creep, colonyRoom) {
+  const constructionSites = findConstructionSites(colonyRoom).filter((site) => site.my !== false);
+  if (constructionSites.length === 0) {
+    return null;
+  }
+  const constructionReservationContext = createConstructionReservationContext(colonyRoom);
+  const priorityContext = buildWorkerConstructionSiteImpactPriorityContextForRoom(
+    creep,
+    colonyRoom,
+    constructionSites
+  );
+  return selectUnreservedConstructionBacklogEnergyTarget(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    priorityContext
+  );
+}
+function selectForeignColonyConstructionBacklogStorageSource(creep, colonyRoom, constructionSite) {
+  const storage = getVisibleRoomStorage(colonyRoom);
+  if (!storage || !isBuilderConstructionEnergySourceForSite(constructionSite, storage) || !isSafeStoredEnergySource(storage, {
+    creepOwnerUsername: getCreepOwnerUsername2(creep),
+    hasHostilePresence: false,
+    room: colonyRoom
+  })) {
+    return null;
+  }
+  const storedEnergy = getStoredEnergy16(storage);
+  const availableEnergy = getStorageEnergyAvailableForWithdrawal(colonyRoom, storage, storedEnergy);
+  const plannedWithdrawal = Math.min(getFreeEnergyCapacity9(creep), availableEnergy);
+  return plannedWithdrawal > 0 && withdrawFromStorage(colonyRoom, plannedWithdrawal, storage, storedEnergy) ? storage : null;
+}
 function selectInterRoomEnergyHaulingTask(creep, carriedEnergy) {
   var _a2;
   if (!isEligibleInterRoomEnergyHaulWorker(creep)) {
@@ -30376,22 +30429,25 @@ function selectUnreservedConstructionSite(creep, constructionSites, construction
   );
 }
 function buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites) {
+  return buildWorkerConstructionSiteImpactPriorityContextForRoom(creep, creep.room, constructionSites);
+}
+function buildWorkerConstructionSiteImpactPriorityContextForRoom(creep, room, constructionSites) {
   var _a2;
-  const context = ((_a2 = creep.room.controller) == null ? void 0 : _a2.my) === true ? { claimedRoomName: creep.room.name } : {};
-  if (isPostClaimConstructionRoom(creep.room.name)) {
-    context.postClaimRoomName = creep.room.name;
+  const context = ((_a2 = room.controller) == null ? void 0 : _a2.my) === true ? { claimedRoomName: room.name } : {};
+  if (isPostClaimConstructionRoom(room.name)) {
+    context.postClaimRoomName = room.name;
   }
-  if (shouldPrioritizeSourceLogisticsConstruction(creep.room)) {
+  if (shouldPrioritizeSourceLogisticsConstruction(room)) {
     context.prioritizeSourceLogisticsForEnergyStarvation = true;
   }
   if (constructionSites.some(isRoadConstructionSite2)) {
-    context.criticalRoadContext = buildWorkerCriticalRoadLogisticsContext(creep);
+    context.criticalRoadContext = buildCriticalRoadLogisticsContext(room, { colonyRoomName: getCreepColonyName(creep) });
   }
   if (constructionSites.some(isContainerConstructionSite3)) {
-    context.sources = findConstructionPrioritySources(creep.room);
+    context.sources = findConstructionPrioritySources(room);
   }
   if (constructionSites.some(isRampartConstructionSite2)) {
-    context.protectedRampartAnchors = findConstructionPriorityProtectedRampartAnchors(creep.room);
+    context.protectedRampartAnchors = findConstructionPriorityProtectedRampartAnchors(room);
   }
   return context;
 }

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -3150,6 +3150,7 @@ function selectForeignColonyConstructionBacklogEnergyAcquisitionTask(
     !colonyRoom ||
     isWorkerInColonyRoom(creep) ||
     creep.memory?.role !== 'worker' ||
+    creep.memory?.controllerSustain?.role === 'upgrader' ||
     creep.memory?.territory !== undefined ||
     creep.memory?.spawnSupport !== undefined ||
     creep.memory?.interRoomEnergyHaul !== undefined ||

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -825,13 +825,19 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
       return territoryControllerTask;
     }
 
-    const interRoomRecallTask = selectInterRoomForeignRoomRecallTask(creep, carriedEnergy);
-    if (interRoomRecallTask) {
-      return interRoomRecallTask;
-    }
-
     let hasPriorityEnergySink = false;
     if (getFreeEnergyCapacity(creep) > 0) {
+      const foreignColonyConstructionBacklogEnergyAcquisitionTask =
+        selectForeignColonyConstructionBacklogEnergyAcquisitionTask(creep);
+      if (foreignColonyConstructionBacklogEnergyAcquisitionTask) {
+        return foreignColonyConstructionBacklogEnergyAcquisitionTask;
+      }
+
+      const interRoomRecallTask = selectInterRoomForeignRoomRecallTask(creep, carriedEnergy);
+      if (interRoomRecallTask) {
+        return interRoomRecallTask;
+      }
+
       const storedProtectedConstructionEnergyAcquisitionTask =
         selectStoredProtectedSourceContainerConstructionEnergyAcquisitionTask(creep);
       if (storedProtectedConstructionEnergyAcquisitionTask) {
@@ -3136,6 +3142,91 @@ function selectInterRoomForeignRoomRecallTask(
     : selectInterRoomHomeEnergyAcquisitionTask(creep);
 }
 
+function selectForeignColonyConstructionBacklogEnergyAcquisitionTask(
+  creep: Creep
+): Extract<CreepTaskMemory, { type: 'withdraw' }> | null {
+  const colonyRoom = getCreepColonyRoom(creep);
+  if (
+    !colonyRoom ||
+    isWorkerInColonyRoom(creep) ||
+    creep.memory?.role !== 'worker' ||
+    creep.memory?.territory !== undefined ||
+    creep.memory?.spawnSupport !== undefined ||
+    creep.memory?.interRoomEnergyHaul !== undefined ||
+    getFreeEnergyCapacity(creep) <= 0 ||
+    getActiveWorkParts(creep) <= 0 ||
+    colonyRoom.controller?.my !== true ||
+    shouldGuardControllerDowngrade(colonyRoom.controller) ||
+    hasVisibleHostilePresence(colonyRoom) ||
+    !checkEnergyBufferForStoredConstructionSpending(colonyRoom)
+  ) {
+    return null;
+  }
+
+  const constructionSite = selectForeignColonyConstructionBacklogEnergyTarget(creep, colonyRoom);
+  if (!constructionSite) {
+    return null;
+  }
+
+  const source = selectForeignColonyConstructionBacklogStorageSource(creep, colonyRoom, constructionSite);
+  return source
+    ? {
+        type: 'withdraw',
+        targetId: source.id as Id<AnyStoreStructure>,
+        constructionSiteId: constructionSite.id
+      }
+    : null;
+}
+
+function selectForeignColonyConstructionBacklogEnergyTarget(
+  creep: Creep,
+  colonyRoom: Room
+): ConstructionSite | null {
+  const constructionSites = findConstructionSites(colonyRoom).filter((site) => site.my !== false);
+  if (constructionSites.length === 0) {
+    return null;
+  }
+
+  const constructionReservationContext = createConstructionReservationContext(colonyRoom);
+  const priorityContext = buildWorkerConstructionSiteImpactPriorityContextForRoom(
+    creep,
+    colonyRoom,
+    constructionSites
+  );
+  return selectUnreservedConstructionBacklogEnergyTarget(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    priorityContext
+  );
+}
+
+function selectForeignColonyConstructionBacklogStorageSource(
+  creep: Creep,
+  colonyRoom: Room,
+  constructionSite: ConstructionSite
+): StructureStorage | null {
+  const storage = getVisibleRoomStorage(colonyRoom);
+  if (
+    !storage ||
+    !isBuilderConstructionEnergySourceForSite(constructionSite, storage) ||
+    !isSafeStoredEnergySource(storage as AnyStructure, {
+      creepOwnerUsername: getCreepOwnerUsername(creep),
+      hasHostilePresence: false,
+      room: colonyRoom
+    })
+  ) {
+    return null;
+  }
+
+  const storedEnergy = getStoredEnergy(storage);
+  const availableEnergy = getStorageEnergyAvailableForWithdrawal(colonyRoom, storage, storedEnergy);
+  const plannedWithdrawal = Math.min(getFreeEnergyCapacity(creep), availableEnergy);
+  return plannedWithdrawal > 0 && withdrawFromStorage(colonyRoom, plannedWithdrawal, storage, storedEnergy)
+    ? storage
+    : null;
+}
+
 function selectInterRoomEnergyHaulingTask(
   creep: Creep,
   carriedEnergy: number
@@ -4106,24 +4197,32 @@ function buildWorkerConstructionSiteImpactPriorityContext(
   creep: Creep,
   constructionSites: ConstructionSite[]
 ): ConstructionSiteImpactPriorityContext {
+  return buildWorkerConstructionSiteImpactPriorityContextForRoom(creep, creep.room, constructionSites);
+}
+
+function buildWorkerConstructionSiteImpactPriorityContextForRoom(
+  creep: Creep,
+  room: Room,
+  constructionSites: ConstructionSite[]
+): ConstructionSiteImpactPriorityContext {
   const context: ConstructionSiteImpactPriorityContext =
-    creep.room.controller?.my === true ? { claimedRoomName: creep.room.name } : {};
-  if (isPostClaimConstructionRoom(creep.room.name)) {
-    context.postClaimRoomName = creep.room.name;
+    room.controller?.my === true ? { claimedRoomName: room.name } : {};
+  if (isPostClaimConstructionRoom(room.name)) {
+    context.postClaimRoomName = room.name;
   }
-  if (shouldPrioritizeSourceLogisticsConstruction(creep.room)) {
+  if (shouldPrioritizeSourceLogisticsConstruction(room)) {
     context.prioritizeSourceLogisticsForEnergyStarvation = true;
   }
   if (constructionSites.some(isRoadConstructionSite)) {
-    context.criticalRoadContext = buildWorkerCriticalRoadLogisticsContext(creep);
+    context.criticalRoadContext = buildCriticalRoadLogisticsContext(room, { colonyRoomName: getCreepColonyName(creep) });
   }
 
   if (constructionSites.some(isContainerConstructionSite)) {
-    context.sources = findConstructionPrioritySources(creep.room);
+    context.sources = findConstructionPrioritySources(room);
   }
 
   if (constructionSites.some(isRampartConstructionSite)) {
-    context.protectedRampartAnchors = findConstructionPriorityProtectedRampartAnchors(creep.room);
+    context.protectedRampartAnchors = findConstructionPriorityProtectedRampartAnchors(room);
   }
 
   return context;

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -9571,7 +9571,7 @@ describe('runWorker', () => {
     }
   });
 
-  it('recalls an empty E29N56 controller-sustain worker for visible home construction backlog', () => {
+  it('keeps an empty E29N56 controller-sustain upgrader off home construction withdraws', () => {
     const site = {
       id: 'storage-site1',
       my: true,
@@ -9707,19 +9707,12 @@ describe('runWorker', () => {
 
     runWorker(creep);
 
-    expect(creep.memory.task).toEqual({
-      type: 'withdraw',
-      targetId: 'storage1',
-      constructionSiteId: 'storage-site1'
-    });
+    expect(creep.memory.task).toBeUndefined();
     expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
-      selectedTask: 'withdraw',
-      selectedTargetId: 'storage1',
-      assignedTask: 'withdraw',
-      assignedTargetId: 'storage1'
+      reason: 'no_selected_task_idle'
     });
-    expect(withdraw).toHaveBeenCalledWith(storage, RESOURCE_ENERGY, 100);
-    expect(moveTo).toHaveBeenCalledWith(storage, { range: 1 });
+    expect(withdraw).not.toHaveBeenCalled();
+    expect(moveTo).not.toHaveBeenCalled();
   });
 
   it('assigns an E29N57 construction withdraw when backlog exists and stored energy is nearby', () => {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -9571,6 +9571,157 @@ describe('runWorker', () => {
     }
   });
 
+  it('recalls an empty E29N56 controller-sustain worker for visible home construction backlog', () => {
+    const site = {
+      id: 'storage-site1',
+      my: true,
+      structureType: 'storage',
+      progress: 2_785,
+      progressTotal: 4_000,
+      pos: { x: 23, y: 22, roomName: 'E29N56' } as RoomPosition
+    } as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      my: true,
+      structureType: 'spawn',
+      spawning: { name: 'worker-E29N56-next', remainingTime: 8 },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 300 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      }
+    } as unknown as StructureSpawn;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      pos: { x: 24, y: 22, roomName: 'E29N56' } as RoomPosition,
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 617_846 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(10_000)
+      }
+    } as unknown as StructureStorage;
+    const homeController = {
+      id: 'home-controller',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const homeRoom = {
+      name: 'E29N56',
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      controller: homeController,
+      storage,
+      find: jest.fn((type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES) {
+          const structures = [spawn, storage] as unknown as AnyOwnedStructure[];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        if (type === FIND_MY_CREEPS || type === FIND_HOSTILE_CREEPS || type === FIND_SOURCES || type === FIND_DROPPED_RESOURCES) {
+          return [];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const targetController = {
+      id: 'target-controller',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const targetRoom = {
+      name: 'E29N57',
+      energyAvailable: 1_800,
+      energyCapacityAvailable: 1_800,
+      controller: targetController,
+      find: jest.fn((type: number, options?: { filter?: (object: Creep) => boolean }) => {
+        if (type === FIND_MY_CREEPS) {
+          const creeps = [creep] as Creep[];
+          return options?.filter ? creeps.filter(options.filter) : creeps;
+        }
+
+        if (
+          type === FIND_MY_STRUCTURES ||
+          type === FIND_STRUCTURES ||
+          type === FIND_CONSTRUCTION_SITES ||
+          type === FIND_HOSTILE_CREEPS ||
+          type === FIND_SOURCES ||
+          type === FIND_DROPPED_RESOURCES
+        ) {
+          return [];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const withdraw = jest.fn().mockReturnValue(ERR_NOT_IN_RANGE);
+    const moveTo = jest.fn();
+    const creep = {
+      name: 'worker-E29N56-2170225',
+      memory: {
+        role: 'worker',
+        colony: 'E29N56',
+        controllerSustain: {
+          homeRoom: 'E29N56',
+          targetRoom: 'E29N57',
+          role: 'upgrader'
+        }
+      },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      pos: {
+        getRangeTo: jest.fn().mockReturnValue(50)
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room: targetRoom,
+      withdraw,
+      moveTo
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { [creep.name]: creep },
+      rooms: { E29N56: homeRoom, E29N57: targetRoom },
+      time: 2_170_816,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'storage-site1') {
+          return site;
+        }
+
+        if (id === 'storage1') {
+          return storage;
+        }
+
+        if (id === 'home-controller') {
+          return homeController;
+        }
+
+        return id === 'target-controller' ? targetController : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({
+      type: 'withdraw',
+      targetId: 'storage1',
+      constructionSiteId: 'storage-site1'
+    });
+    expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+      selectedTask: 'withdraw',
+      selectedTargetId: 'storage1',
+      assignedTask: 'withdraw',
+      assignedTargetId: 'storage1'
+    });
+    expect(withdraw).toHaveBeenCalledWith(storage, RESOURCE_ENERGY, 100);
+    expect(moveTo).toHaveBeenCalledWith(storage, { range: 1 });
+  });
+
   it('assigns an E29N57 construction withdraw when backlog exists and stored energy is nearby', () => {
     const site = {
       id: 'road-site1',


### PR DESCRIPTION
## Summary
- Strengthen the E29N56 construction recovery path so build workers stay supplied before controller-yield behavior can strand the remaining construction site.
- Add worker-runner coverage for the recurrence and keep the bundled Screeps artifact synchronized.

Refs #1878.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`

## Universal task Done gate

- [x] Task type: bugfix
- [x] Expected observable outcome / named deliverable: Construction workers should refill/continue build execution for the E29N56 worker_assignment_gap recurrence instead of yielding away from the remaining site.
- [x] Non-goals / accepted substitutes: This PR does not claim postdeploy runtime acceptance or close the runtime incident; it is the smallest code/test follow-up for the observed recurrence.
- [x] Verification evidence required before Done: Controller-side `git diff --check`, prod typecheck, full Jest run with 2449 passing tests, and prod build all passed before the commit.
- [x] Project Evidence / Next action / Blocked by: PR and issue Project items should move to In review with evidence naming commit 48c4691 and the required CI/review/postdeploy gate; Blocked by remains postdeploy runtime acceptance for #1878 until fresh monitor evidence clears it.
- [x] Post-merge/deploy/runtime proof: Not applicable for the PR-level Done gate; local tests and bundle verification are the proof surface for this code slice.
- [x] Named deliverable proof: Code and tests in `prod/src/tasks/workerTasks.ts`, `prod/test/workerRunner.test.ts`, and regenerated `prod/dist/main.js` implement the follow-up behavior and preserve a reproducible bundle.
