### PR TITLE
worker-task: improve E29N56 construction acceptance

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -27854,7 +27854,15 @@ function selectCriticalCpuWorkerTask(creep, cpuBudget) {
     return selectCriticalCpuEnergyAcquisitionTask(creep);
   }
   const controller = creep.room.controller;
-  if (controller && shouldGuardControllerDowngradeForWorkerLoad(creep, controller, { allowConstructionBacklogYield: false }) && canUpgradeController(controller)) {
+  const constructionSites = findConstructionSites(creep.room);
+  const constructionReservationContext = constructionSites.length > 0 ? createConstructionReservationContext(creep.room) : createEmptyConstructionReservationContext();
+  const controllerSustainConstructionBacklogTask = selectLocalConstructionBacklogBeforeControllerSustainUpgradeTask(
+    creep,
+    controller,
+    constructionSites,
+    constructionReservationContext
+  );
+  if (controller && shouldGuardControllerDowngradeForWorkerLoad(creep, controller, { allowConstructionBacklogYield: false }) && canUpgradeController(controller) && !controllerSustainConstructionBacklogTask) {
     return { type: "upgrade", targetId: controller.id };
   }
   const criticalSpawnRepairTarget = selectCriticalOwnedSpawnRepairTarget(creep);
@@ -27905,8 +27913,6 @@ function selectCriticalCpuWorkerTask(creep, cpuBudget) {
     };
   }
   const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
-  const constructionSites = findConstructionSites(creep.room);
-  const constructionReservationContext = constructionSites.length > 0 ? createConstructionReservationContext(creep.room) : createEmptyConstructionReservationContext();
   const boundedConstructionBacklogTask = priorityTowerEnergySink ? selectBoundedConstructionBacklogTaskBeforeNonCriticalRefill(
     creep,
     constructionSites,
@@ -27929,12 +27935,6 @@ function selectCriticalCpuWorkerTask(creep, cpuBudget) {
       targetId: criticalRepairTarget.id
     });
   }
-  const controllerSustainConstructionBacklogTask = selectLocalConstructionBacklogBeforeControllerSustainUpgradeTask(
-    creep,
-    creep.room.controller,
-    constructionSites,
-    constructionReservationContext
-  );
   if (controllerSustainConstructionBacklogTask) {
     return applyMinimumUsefulLoadPolicy(creep, controllerSustainConstructionBacklogTask);
   }

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -370,10 +370,22 @@ function selectCriticalCpuWorkerTask(creep: Creep, cpuBudget: RuntimeCpuBudget):
   }
 
   const controller = creep.room.controller;
+  const constructionSites = findConstructionSites(creep.room);
+  const constructionReservationContext =
+    constructionSites.length > 0
+      ? createConstructionReservationContext(creep.room)
+      : createEmptyConstructionReservationContext();
+  const controllerSustainConstructionBacklogTask = selectLocalConstructionBacklogBeforeControllerSustainUpgradeTask(
+    creep,
+    controller,
+    constructionSites,
+    constructionReservationContext
+  );
   if (
     controller &&
     shouldGuardControllerDowngradeForWorkerLoad(creep, controller, { allowConstructionBacklogYield: false }) &&
-    canUpgradeController(controller)
+    canUpgradeController(controller) &&
+    !controllerSustainConstructionBacklogTask
   ) {
     return { type: 'upgrade', targetId: controller.id };
   }
@@ -434,11 +446,6 @@ function selectCriticalCpuWorkerTask(creep: Creep, cpuBudget: RuntimeCpuBudget):
   }
 
   const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
-  const constructionSites = findConstructionSites(creep.room);
-  const constructionReservationContext =
-    constructionSites.length > 0
-      ? createConstructionReservationContext(creep.room)
-      : createEmptyConstructionReservationContext();
   const boundedConstructionBacklogTask = priorityTowerEnergySink
     ? selectBoundedConstructionBacklogTaskBeforeNonCriticalRefill(
       creep,
@@ -466,12 +473,6 @@ function selectCriticalCpuWorkerTask(creep: Creep, cpuBudget: RuntimeCpuBudget):
     });
   }
 
-  const controllerSustainConstructionBacklogTask = selectLocalConstructionBacklogBeforeControllerSustainUpgradeTask(
-    creep,
-    creep.room.controller,
-    constructionSites,
-    constructionReservationContext
-  );
   if (controllerSustainConstructionBacklogTask) {
     return applyMinimumUsefulLoadPolicy(creep, controllerSustainConstructionBacklogTask);
   }

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -15650,6 +15650,65 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(sustainUpgrader)).toEqual({ type: 'build', targetId: 'wall-site1' });
   });
 
+  it('lets non-imminent E29N56 downgrade guard yield to local sustain construction under low bucket', () => {
+    const site = {
+      id: 'wall-site1',
+      my: true,
+      structureType: 'constructedWall',
+      progress: 270,
+      progressTotal: 1_005,
+      pos: makeRoomPosition(20, 24, 'E29N56')
+    } as ConstructionSite;
+    const spawn = makeFullSpawnEnergyStructure('spawn1', 'E29N56');
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS - 201
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N56',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      myStructures: [spawn as AnyOwnedStructure],
+      structures: [spawn as AnyStructure]
+    });
+    const sustainUpgrader = {
+      name: 'worker-E29N56-2176240',
+      memory: {
+        role: 'worker',
+        colony: 'E29N56',
+        controllerSustain: { homeRoom: 'E29N56', targetRoom: 'E29N56', role: 'upgrader' },
+        task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 88 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 12 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      pos: { getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'wall-site1' ? 4 : 3)) },
+      room
+    } as unknown as Creep;
+    const idleWorker = {
+      name: 'worker-E29N56-2176048',
+      memory: { role: 'worker', colony: 'E29N56' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ SustainUpgrader: sustainUpgrader, IdleWorker: idleWorker });
+    setCpuBucket(791);
+
+    expect(selectWorkerTask(sustainUpgrader)).toEqual({ type: 'build', targetId: 'wall-site1' });
+  });
+
   it('keeps critical CPU repair before E29N56 local sustain construction', () => {
     const site = {
       id: 'wall-site1',


### PR DESCRIPTION
## Summary

Related issue: #1878.

This PR recovers the verified Codex follow-up for the E29N56 construction acceptance regression observed after PR #1893 deploy run 27505176437. It lets the non-imminent controller downgrade guard yield to the already-computed local sustain construction handoff under low-bucket conditions, while keeping critical repairs/refills and imminent downgrade protection ahead of construction.

## Evidence

- Deployed baseline: main `4ae929ca896e3c92da120cdf6e11362384aea410`, deploy run 27505176437 upload/activeWorld matched.
- Failing postdeploy health artifact: `runtime-artifacts/official-screeps-deploy/postdeploy-health-gate-27505176437.json` reported E29N56 alive with `constructionSiteCount=1`, `pendingBuildProgress=735`, `build=0`, `buildCarriedEnergy=0`, `reason=worker_assignment_gap`.
- Codex triage artifact: `/tmp/issue1878-post1893-triage.md` classified the remaining defect and recorded the verified implementation.

## Verification

- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 105 suites / 2454 tests passed
- `cd prod && npm run build`

## Universal task Done gate

- [x] Task type: P0 Territory/Economy production-code runtime acceptance follow-up.
- [x] Expected observable outcome / named deliverable: `worker-task: improve E29N56 construction acceptance` changes `prod/src/tasks/workerTasks.ts`, `prod/test/workerTasks.test.ts`, and rebuilt `prod/dist/main.js`.
- [x] Non-goals / accepted substitutes: this PR keeps issue 1878 open; runtime acceptance stays on issue 1878 until a later deploy/monitor window proves E29N56 construction execution or no backlog.
- [x] Verification evidence required before Done: local diff/typecheck/Jest/build evidence listed above passed on commit `f0417db85d5b4815624c1609f9635361895799ad`.
- [x] Project Evidence / Next action / Blocked by: controller updates the #1878 and PR Project items with exact head SHA, verification, PR gate state, and deploy/runtime acceptance next action.
- [x] Post-merge/deploy/runtime proof: #1878 remains the runtime acceptance surface for official deploy evidence and fresh all-owned-room monitor proof.
- [x] Named deliverable proof: regression test `lets non-imminent E29N56 downgrade guard yield to local sustain construction under low bucket` covers the deployed E29N56 conditions.

## Safety

No secrets or destructive Screeps API calls are included. Official MMO deploy and runtime validation remain controller-managed after PR gates pass.
