### PR TITLE
worker-task: recover E29N56 construction assignment

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -36026,7 +36026,9 @@ function hasHealthyRoomEnergyBuffer2(room) {
   return energyAvailable !== null && energyAvailable >= getEffectiveRoomEnergyBufferThreshold(room);
 }
 function isControllerDowngradeGuardActive2(room) {
-  const controller = room.controller;
+  return isOwnedControllerDowngradeGuardActive(room.controller);
+}
+function isOwnedControllerDowngradeGuardActive(controller) {
   return (controller == null ? void 0 : controller.my) === true && typeof controller.ticksToDowngrade === "number" && controller.ticksToDowngrade <= CONTROLLER_DOWNGRADE_GUARD_TICKS;
 }
 function hasActiveSpawningSpawn2(room) {
@@ -36143,7 +36145,7 @@ function runControllerSustainMovement(creep) {
   return true;
 }
 function selectControllerSustainHomeConstructionTask(creep, sustain, roomName) {
-  if (sustain.role !== "upgrader" || roomName !== sustain.homeRoom || sustain.homeRoom === sustain.targetRoom) {
+  if (sustain.role !== "upgrader" || roomName !== sustain.homeRoom || sustain.homeRoom === sustain.targetRoom || isControllerSustainTargetDowngradeGuardActive(sustain)) {
     return null;
   }
   const currentTask = creep.memory.task;
@@ -36169,6 +36171,9 @@ function selectControllerSustainHomeConstructionTask(creep, sustain, roomName) {
   }
   const constructionSite = getTaskTarget(selectedTask);
   return isConstructionSite(constructionSite) && isRoomObjectInRoom(constructionSite, sustain.homeRoom) ? selectedTask : null;
+}
+function isControllerSustainTargetDowngradeGuardActive(sustain) {
+  return isOwnedControllerDowngradeGuardActive(getVisibleRoomController2(sustain.targetRoom));
 }
 function isControllerSustainHomeConstructionTask(task, homeRoom) {
   if (task.type === "build") {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -36120,6 +36120,14 @@ function runControllerSustainMovement(creep) {
     }
     return false;
   }
+  const homeConstructionTask = selectControllerSustainHomeConstructionTask(creep, sustain, roomName);
+  if (homeConstructionTask) {
+    clearEnergyDropoffOptimizationMemory(creep);
+    clearBuildTargetStuckTelemetry(creep);
+    creep.memory.task = homeConstructionTask;
+    executeAssignedTask(creep, homeConstructionTask);
+    return true;
+  }
   if (sustain.role === "hauler" && shouldControllerSustainHaulerLoadAtHome(creep, sustain, roomName)) {
     const energyTask = selectControllerSustainHaulerEnergyTask(creep);
     if (energyTask) {
@@ -36133,6 +36141,25 @@ function runControllerSustainMovement(creep) {
   clearAssignedTask(creep);
   moveTowardRoom3(creep, selectControllerSustainDestinationRoom(creep, sustain, roomName));
   return true;
+}
+function selectControllerSustainHomeConstructionTask(creep, sustain, roomName) {
+  if (sustain.role !== "upgrader" || roomName !== sustain.homeRoom || sustain.homeRoom === sustain.targetRoom || creep.memory.task !== void 0 || getActiveWorkParts3(creep) <= 0 || hasVisibleHostileCreeps2(creep.room)) {
+    return null;
+  }
+  if (getCarriedEnergy4(creep) <= 0) {
+    return selectConstructionBacklogEnergyAcquisitionTask(creep);
+  }
+  const selectedTask = selectWorkerTaskForRunner(creep);
+  if ((selectedTask == null ? void 0 : selectedTask.type) !== "build") {
+    return null;
+  }
+  const constructionSite = getTaskTarget(selectedTask);
+  return isConstructionSite(constructionSite) && isRoomObjectInRoom(constructionSite, sustain.homeRoom) ? selectedTask : null;
+}
+function isRoomObjectInRoom(object, roomName) {
+  var _a2;
+  const objectRoomName = (_a2 = object.pos) == null ? void 0 : _a2.roomName;
+  return typeof objectRoomName !== "string" || objectRoomName === roomName;
 }
 function shouldControllerSustainHaulerLoadAtHome(creep, sustain, roomName) {
   return roomName === sustain.homeRoom && getFreeTransferEnergyCapacity(creep) > 0;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -36143,8 +36143,22 @@ function runControllerSustainMovement(creep) {
   return true;
 }
 function selectControllerSustainHomeConstructionTask(creep, sustain, roomName) {
-  if (sustain.role !== "upgrader" || roomName !== sustain.homeRoom || sustain.homeRoom === sustain.targetRoom || creep.memory.task !== void 0 || getActiveWorkParts3(creep) <= 0 || hasVisibleHostileCreeps2(creep.room)) {
+  if (sustain.role !== "upgrader" || roomName !== sustain.homeRoom || sustain.homeRoom === sustain.targetRoom) {
     return null;
+  }
+  const currentTask = creep.memory.task;
+  if (currentTask) {
+    if (!isControllerSustainHomeConstructionTask(currentTask, sustain.homeRoom)) {
+      return null;
+    }
+  }
+  if (getActiveWorkParts3(creep) <= 0 || hasVisibleHostileCreeps2(creep.room)) {
+    return null;
+  }
+  if (currentTask) {
+    if (!shouldReplaceTask(creep, currentTask)) {
+      return currentTask;
+    }
   }
   if (getCarriedEnergy4(creep) <= 0) {
     return selectConstructionBacklogEnergyAcquisitionTask(creep);
@@ -36155,6 +36169,19 @@ function selectControllerSustainHomeConstructionTask(creep, sustain, roomName) {
   }
   const constructionSite = getTaskTarget(selectedTask);
   return isConstructionSite(constructionSite) && isRoomObjectInRoom(constructionSite, sustain.homeRoom) ? selectedTask : null;
+}
+function isControllerSustainHomeConstructionTask(task, homeRoom) {
+  if (task.type === "build") {
+    const constructionSite2 = getTaskTarget(task);
+    return isConstructionSite(constructionSite2) && isRoomObjectInRoom(constructionSite2, homeRoom);
+  }
+  if (!isConstructionWithdrawReservationTask(task)) {
+    return false;
+  }
+  const game = globalThis.Game;
+  const getObjectById6 = game == null ? void 0 : game.getObjectById;
+  const constructionSite = typeof getObjectById6 === "function" ? getObjectById6(String(task.constructionSiteId)) : null;
+  return isConstructionSite(constructionSite) && isRoomObjectInRoom(constructionSite, homeRoom);
 }
 function isRoomObjectInRoom(object, roomName) {
   var _a2;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -1829,12 +1829,26 @@ function selectControllerSustainHomeConstructionTask(
   if (
     sustain.role !== 'upgrader' ||
     roomName !== sustain.homeRoom ||
-    sustain.homeRoom === sustain.targetRoom ||
-    creep.memory.task !== undefined ||
-    getActiveWorkParts(creep) <= 0 ||
-    hasVisibleHostileCreeps(creep.room)
+    sustain.homeRoom === sustain.targetRoom
   ) {
     return null;
+  }
+
+  const currentTask = creep.memory.task;
+  if (currentTask) {
+    if (!isControllerSustainHomeConstructionTask(currentTask, sustain.homeRoom)) {
+      return null;
+    }
+  }
+
+  if (getActiveWorkParts(creep) <= 0 || hasVisibleHostileCreeps(creep.room)) {
+    return null;
+  }
+
+  if (currentTask) {
+    if (!shouldReplaceTask(creep, currentTask)) {
+      return currentTask;
+    }
   }
 
   if (getCarriedEnergy(creep) <= 0) {
@@ -1850,6 +1864,23 @@ function selectControllerSustainHomeConstructionTask(
   return isConstructionSite(constructionSite) && isRoomObjectInRoom(constructionSite, sustain.homeRoom)
     ? selectedTask
     : null;
+}
+
+function isControllerSustainHomeConstructionTask(task: CreepTaskMemory, homeRoom: string): boolean {
+  if (task.type === 'build') {
+    const constructionSite = getTaskTarget(task);
+    return isConstructionSite(constructionSite) && isRoomObjectInRoom(constructionSite, homeRoom);
+  }
+
+  if (!isConstructionWithdrawReservationTask(task)) {
+    return false;
+  }
+
+  const game = (globalThis as unknown as { Game?: Partial<Pick<Game, 'getObjectById'>> }).Game;
+  const getObjectById = game?.getObjectById as ((id: string) => unknown) | undefined;
+  const constructionSite =
+    typeof getObjectById === 'function' ? getObjectById(String(task.constructionSiteId)) : null;
+  return isConstructionSite(constructionSite) && isRoomObjectInRoom(constructionSite, homeRoom);
 }
 
 function isRoomObjectInRoom(object: RoomObject, roomName: string): boolean {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -1657,7 +1657,10 @@ function hasHealthyRoomEnergyBuffer(room: Room): boolean {
 }
 
 function isControllerDowngradeGuardActive(room: Room): boolean {
-  const controller = room.controller;
+  return isOwnedControllerDowngradeGuardActive(room.controller);
+}
+
+function isOwnedControllerDowngradeGuardActive(controller: StructureController | null | undefined): boolean {
   return (
     controller?.my === true &&
     typeof controller.ticksToDowngrade === 'number' &&
@@ -1829,7 +1832,8 @@ function selectControllerSustainHomeConstructionTask(
   if (
     sustain.role !== 'upgrader' ||
     roomName !== sustain.homeRoom ||
-    sustain.homeRoom === sustain.targetRoom
+    sustain.homeRoom === sustain.targetRoom ||
+    isControllerSustainTargetDowngradeGuardActive(sustain)
   ) {
     return null;
   }
@@ -1864,6 +1868,10 @@ function selectControllerSustainHomeConstructionTask(
   return isConstructionSite(constructionSite) && isRoomObjectInRoom(constructionSite, sustain.homeRoom)
     ? selectedTask
     : null;
+}
+
+function isControllerSustainTargetDowngradeGuardActive(sustain: CreepControllerSustainMemory): boolean {
+  return isOwnedControllerDowngradeGuardActive(getVisibleRoomController(sustain.targetRoom));
 }
 
 function isControllerSustainHomeConstructionTask(task: CreepTaskMemory, homeRoom: string): boolean {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -1796,6 +1796,15 @@ function runControllerSustainMovement(creep: Creep): boolean {
     return false;
   }
 
+  const homeConstructionTask = selectControllerSustainHomeConstructionTask(creep, sustain, roomName);
+  if (homeConstructionTask) {
+    clearEnergyDropoffOptimizationMemory(creep);
+    clearBuildTargetStuckTelemetry(creep);
+    creep.memory.task = homeConstructionTask;
+    executeAssignedTask(creep, homeConstructionTask);
+    return true;
+  }
+
   if (sustain.role === 'hauler' && shouldControllerSustainHaulerLoadAtHome(creep, sustain, roomName)) {
     const energyTask = selectControllerSustainHaulerEnergyTask(creep);
     if (energyTask) {
@@ -1810,6 +1819,42 @@ function runControllerSustainMovement(creep: Creep): boolean {
   clearAssignedTask(creep);
   moveTowardRoom(creep, selectControllerSustainDestinationRoom(creep, sustain, roomName));
   return true;
+}
+
+function selectControllerSustainHomeConstructionTask(
+  creep: Creep,
+  sustain: CreepControllerSustainMemory,
+  roomName: string | undefined
+): CreepTaskMemory | null {
+  if (
+    sustain.role !== 'upgrader' ||
+    roomName !== sustain.homeRoom ||
+    sustain.homeRoom === sustain.targetRoom ||
+    creep.memory.task !== undefined ||
+    getActiveWorkParts(creep) <= 0 ||
+    hasVisibleHostileCreeps(creep.room)
+  ) {
+    return null;
+  }
+
+  if (getCarriedEnergy(creep) <= 0) {
+    return selectConstructionBacklogEnergyAcquisitionTask(creep);
+  }
+
+  const selectedTask = selectWorkerTaskForRunner(creep);
+  if (selectedTask?.type !== 'build') {
+    return null;
+  }
+
+  const constructionSite = getTaskTarget(selectedTask);
+  return isConstructionSite(constructionSite) && isRoomObjectInRoom(constructionSite, sustain.homeRoom)
+    ? selectedTask
+    : null;
+}
+
+function isRoomObjectInRoom(object: RoomObject, roomName: string): boolean {
+  const objectRoomName = (object as RoomObject & { pos?: { roomName?: unknown } }).pos?.roomName;
+  return typeof objectRoomName !== 'string' || objectRoomName === roomName;
 }
 
 function shouldControllerSustainHaulerLoadAtHome(

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -9996,6 +9996,260 @@ describe('runWorker', () => {
     expect(moveTo).not.toHaveBeenCalledWith(targetController);
   });
 
+  it('retains an E29N56 sustain upgrader construction withdrawal across home ticks', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 0,
+      progressTotal: 5_000,
+      pos: { x: 22, y: 21, roomName: 'E29N56' } as RoomPosition
+    } as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      my: true,
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 300 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      }
+    } as unknown as StructureSpawn;
+    const storage = {
+      id: 'storage1',
+      my: true,
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 651_820 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(348_180)
+      }
+    } as unknown as StructureStorage;
+    const homeController = {
+      id: 'home-controller',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const targetController = {
+      id: 'target-controller',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const homeRoom = {
+      name: 'E29N56',
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      controller: homeController,
+      storage,
+      find: jest.fn((type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn, storage] as unknown as AnyOwnedStructure[];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [spawn, storage];
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+        }
+
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        if (type === FIND_HOSTILE_CREEPS || type === FIND_SOURCES || type === FIND_DROPPED_RESOURCES) {
+          return [];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const targetRoom = {
+      name: 'E29N57',
+      controller: targetController,
+      find: jest.fn().mockReturnValue([])
+    } as unknown as Room;
+    const withdraw = jest.fn().mockReturnValue(ERR_NOT_IN_RANGE);
+    const moveTo = jest.fn();
+    const creep = {
+      name: 'worker-E29N56-E29N57-upgrader-2183356',
+      memory: {
+        role: 'worker',
+        colony: 'E29N57',
+        controllerSustain: {
+          homeRoom: 'E29N56',
+          targetRoom: 'E29N57',
+          role: 'upgrader'
+        },
+        task: {
+          type: 'withdraw',
+          targetId: 'storage1' as Id<StructureStorage>,
+          constructionSiteId: 'road-site1' as Id<ConstructionSite>
+        }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'storage1' ? 5 : 99))
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room: homeRoom,
+      withdraw,
+      moveTo
+    } as unknown as Creep;
+    roomCreeps.push(creep);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { [creep.name]: creep },
+      rooms: { E29N56: homeRoom, E29N57: targetRoom },
+      time: 2_184_338,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(14.38),
+        limit: 70,
+        bucket: 1_049,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        if (id === 'storage1') {
+          return storage;
+        }
+
+        if (id === 'home-controller') {
+          return homeController;
+        }
+
+        return id === 'target-controller' ? targetController : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({
+      type: 'withdraw',
+      targetId: 'storage1',
+      constructionSiteId: 'road-site1'
+    });
+    expect(withdraw).toHaveBeenCalledWith(storage, RESOURCE_ENERGY, 100);
+    expect(moveTo).toHaveBeenCalledWith(storage, { range: 1 });
+    expect(moveTo).not.toHaveBeenCalledWith(targetController);
+  });
+
+  it('retains an E29N56 sustain upgrader home build assignment before departing', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 125,
+      progressTotal: 5_000,
+      pos: { x: 22, y: 21, roomName: 'E29N56' } as RoomPosition
+    } as ConstructionSite;
+    const homeController = {
+      id: 'home-controller',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const targetController = {
+      id: 'target-controller',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const homeRoom = {
+      name: 'E29N56',
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      controller: homeController,
+      find: jest.fn((type: number) => {
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        if (
+          type === FIND_HOSTILE_CREEPS ||
+          type === FIND_MY_CREEPS ||
+          type === FIND_MY_STRUCTURES ||
+          type === FIND_STRUCTURES ||
+          type === FIND_SOURCES ||
+          type === FIND_DROPPED_RESOURCES
+        ) {
+          return [];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const targetRoom = {
+      name: 'E29N57',
+      controller: targetController,
+      find: jest.fn().mockReturnValue([])
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(ERR_NOT_IN_RANGE);
+    const moveTo = jest.fn();
+    const creep = {
+      name: 'worker-E29N56-E29N57-upgrader-2183357',
+      memory: {
+        role: 'worker',
+        colony: 'E29N57',
+        controllerSustain: {
+          homeRoom: 'E29N56',
+          targetRoom: 'E29N57',
+          role: 'upgrader'
+        },
+        task: { type: 'build', targetId: 'road-site1' as Id<ConstructionSite> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'road-site1' ? 5 : 99))
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+      },
+      room: homeRoom,
+      build,
+      moveTo
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { [creep.name]: creep },
+      rooms: { E29N56: homeRoom, E29N57: targetRoom },
+      time: 2_184_339,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(14.38),
+        limit: 70,
+        bucket: 1_049,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        if (id === 'home-controller') {
+          return homeController;
+        }
+
+        return id === 'target-controller' ? targetController : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'road-site1' });
+    expect(build).toHaveBeenCalledWith(site);
+    expect(moveTo).toHaveBeenCalledWith(site, { range: 3, ignoreCreeps: true });
+    expect(moveTo).not.toHaveBeenCalledWith(targetController);
+  });
+
   it('assigns an E29N57 construction withdraw when backlog exists and stored energy is nearby', () => {
     const site = {
       id: 'road-site1',

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -9852,6 +9852,150 @@ describe('runWorker', () => {
     expect(moveTo).not.toHaveBeenCalled();
   });
 
+  it('keeps an empty E29N56 sustain upgrader home for uncovered construction withdrawal before departing', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 0,
+      progressTotal: 5_000,
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'storage1' ? 5 : 99))
+      }
+    } as unknown as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      my: true,
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 300 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      }
+    } as unknown as StructureSpawn;
+    const storage = {
+      id: 'storage1',
+      my: true,
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 651_820 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(348_180)
+      }
+    } as unknown as StructureStorage;
+    const homeController = {
+      id: 'home-controller',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const targetController = {
+      id: 'target-controller',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const homeRoom = {
+      name: 'E29N56',
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      controller: homeController,
+      storage,
+      find: jest.fn((type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn, storage] as unknown as AnyOwnedStructure[];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [spawn, storage];
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+        }
+
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        if (type === FIND_HOSTILE_CREEPS || type === FIND_SOURCES || type === FIND_DROPPED_RESOURCES) {
+          return [];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const targetRoom = {
+      name: 'E29N57',
+      controller: targetController,
+      find: jest.fn().mockReturnValue([])
+    } as unknown as Room;
+    const withdraw = jest.fn().mockReturnValue(ERR_NOT_IN_RANGE);
+    const moveTo = jest.fn();
+    const creep = {
+      name: 'worker-E29N56-E29N57-upgrader-2183356',
+      memory: {
+        role: 'worker',
+        colony: 'E29N57',
+        controllerSustain: {
+          homeRoom: 'E29N56',
+          targetRoom: 'E29N57',
+          role: 'upgrader'
+        }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'storage1' ? 5 : 99))
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room: homeRoom,
+      withdraw,
+      moveTo
+    } as unknown as Creep;
+    roomCreeps.push(creep);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { [creep.name]: creep },
+      rooms: { E29N56: homeRoom, E29N57: targetRoom },
+      time: 2_184_337,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(14.38),
+        limit: 70,
+        bucket: 1_049,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        if (id === 'storage1') {
+          return storage;
+        }
+
+        if (id === 'home-controller') {
+          return homeController;
+        }
+
+        return id === 'target-controller' ? targetController : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({
+      type: 'withdraw',
+      targetId: 'storage1',
+      constructionSiteId: 'road-site1'
+    });
+    expect(withdraw).toHaveBeenCalledWith(storage, RESOURCE_ENERGY, 100);
+    expect(moveTo).toHaveBeenCalledWith(storage, { range: 1 });
+    expect(moveTo).not.toHaveBeenCalledWith(targetController);
+  });
+
   it('assigns an E29N57 construction withdraw when backlog exists and stored energy is nearby', () => {
     const site = {
       id: 'road-site1',
@@ -9950,6 +10094,158 @@ describe('runWorker', () => {
       type: 'withdraw',
       targetId: 'storage1',
       constructionSiteId: 'road-site1'
+    });
+    expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+      baseSelectedTask: 'withdraw',
+      selectedTask: 'withdraw',
+      assignedTask: 'withdraw'
+    });
+    expect(withdraw).toHaveBeenCalledWith(storage, RESOURCE_ENERGY, 100);
+  });
+
+  it('assigns an E29N56 construction withdraw under low-bucket recovery when local backlog is uncovered', () => {
+    const roadSite = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 0,
+      progressTotal: 5_000,
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'storage1' ? 6 : 99))
+      }
+    } as unknown as ConstructionSite;
+    const rampartSite = {
+      id: 'rampart-site1',
+      my: true,
+      structureType: 'rampart',
+      progress: 0,
+      progressTotal: 255,
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'storage1' ? 4 : 99))
+      }
+    } as unknown as ConstructionSite;
+    const storage = {
+      id: 'storage1',
+      my: true,
+      structureType: 'storage',
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) =>
+          String((target as { id?: string }).id) === 'worker-E29N56-2183356' ? 5 : 1
+        )
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 651_820 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(348_180)
+      }
+    } as unknown as StructureStorage;
+    const spawn = {
+      id: 'spawn1',
+      my: true,
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 300 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      }
+    } as unknown as StructureSpawn;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N56',
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      controller,
+      storage,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn, storage] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [spawn, storage];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [roadSite, rampartSite];
+          }
+
+          if (type === FIND_HOSTILE_CREEPS || type === FIND_SOURCES || type === FIND_DROPPED_RESOURCES) {
+            return [];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const sourceHarvester = {
+      name: 'sourceHarvester-E29N56-2183547',
+      memory: { role: 'sourceHarvester', colony: 'E29N56' },
+      room,
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      }
+    } as unknown as Creep;
+    const withdraw = jest.fn().mockReturnValue(ERR_NOT_IN_RANGE);
+    const creep = {
+      name: 'worker-E29N56-2183356',
+      memory: { role: 'worker', colony: 'E29N56' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'storage1' ? 5 : 99))
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room,
+      withdraw,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    roomCreeps.push(sourceHarvester, creep);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {
+        [sourceHarvester.name]: sourceHarvester,
+        [creep.name]: creep
+      },
+      rooms: { E29N56: room },
+      time: 2_184_337,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(14.38),
+        limit: 70,
+        bucket: 1_049,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return roadSite;
+        }
+
+        if (id === 'rampart-site1') {
+          return rampartSite;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({
+      type: 'withdraw',
+      targetId: 'storage1',
+      constructionSiteId: 'rampart-site1'
     });
     expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
       baseSelectedTask: 'withdraw',

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -9996,6 +9996,146 @@ describe('runWorker', () => {
     expect(moveTo).not.toHaveBeenCalledWith(targetController);
   });
 
+  it('sends an empty E29N56 sustain upgrader to an urgent visible target controller before home construction', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 0,
+      progressTotal: 5_000,
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'storage1' ? 5 : 99))
+      }
+    } as unknown as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      my: true,
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 300 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      }
+    } as unknown as StructureSpawn;
+    const storage = {
+      id: 'storage1',
+      my: true,
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 651_820 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(348_180)
+      }
+    } as unknown as StructureStorage;
+    const homeController = {
+      id: 'home-controller',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const targetController = {
+      id: 'target-controller',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const homeRoom = {
+      name: 'E29N56',
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      controller: homeController,
+      storage,
+      find: jest.fn((type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn, storage] as unknown as AnyOwnedStructure[];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [spawn, storage];
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+        }
+
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        if (type === FIND_HOSTILE_CREEPS || type === FIND_SOURCES || type === FIND_DROPPED_RESOURCES) {
+          return [];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const targetRoom = {
+      name: 'E29N57',
+      controller: targetController,
+      find: jest.fn().mockReturnValue([])
+    } as unknown as Room;
+    const withdraw = jest.fn().mockReturnValue(ERR_NOT_IN_RANGE);
+    const moveTo = jest.fn();
+    const creep = {
+      name: 'worker-E29N56-E29N57-upgrader-2183356',
+      memory: {
+        role: 'worker',
+        colony: 'E29N57',
+        controllerSustain: {
+          homeRoom: 'E29N56',
+          targetRoom: 'E29N57',
+          role: 'upgrader'
+        }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'storage1' ? 5 : 99))
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room: homeRoom,
+      withdraw,
+      moveTo
+    } as unknown as Creep;
+    roomCreeps.push(creep);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { [creep.name]: creep },
+      rooms: { E29N56: homeRoom, E29N57: targetRoom },
+      time: 2_184_337,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(14.38),
+        limit: 70,
+        bucket: 1_049,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        if (id === 'storage1') {
+          return storage;
+        }
+
+        if (id === 'home-controller') {
+          return homeController;
+        }
+
+        return id === 'target-controller' ? targetController : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toBeUndefined();
+    expect(withdraw).not.toHaveBeenCalled();
+    expect(moveTo).toHaveBeenCalledWith(targetController);
+    expect(moveTo).not.toHaveBeenCalledWith(storage, { range: 1 });
+  });
+
   it('retains an E29N56 sustain upgrader construction withdrawal across home ticks', () => {
     const site = {
       id: 'road-site1',


### PR DESCRIPTION
## Summary
- Keeps remote controller-sustain upgraders in their home room long enough to pick up safe local construction energy before departing.
- Adds E29N56-focused worker-runner regression coverage for the empty sustain-upgrader construction-withdraw path and adjacent movement guard.
- Rebuilds the Screeps bundle artifact.

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`
- Controller recovery verifier `proc_2d9119668385`: 105 Jest suites / 2457 tests passed, bundle rebuilt, final diff-check clean.

## Runtime / issue handling
- Related to issue 1901.
- Issue 1901 stays active for official deploy and all-room construction acceptance evidence on E29N56.
- Runtime target evidence: `/root/screeps/runtime-artifacts/screeps-monitor/cron-check-20260614T212231Z` shows E29N56 alive with `worker_assignment_gap_sustained`, `pendingBuildProgress=5255`, `build=0`, `buildCarriedEnergy=0`.

## Universal task Done gate
- [x] Task type: production code hotfix with focused Jest coverage and rebuilt Screeps bundle.
- [x] Expected observable outcome / named deliverable: `worker-task: recover E29N56 construction assignment` commit `14c44341`, changing `prod/src/creeps/workerRunner.ts`, `prod/test/workerRunner.test.ts`, and `prod/dist/main.js`.
- [x] Non-goals / accepted substitutes: no GitHub/Project mutation from Codex, no deploy from the implementation lane, no planner threshold change from PR #1900 scope.
- [x] Verification evidence required before Done: controller verifier `proc_2d9119668385` passed `git diff --check`, `npm run typecheck`, `npm test -- --runInBand` with 105/105 suites and 2457/2457 tests, `npm run build`, and final `git diff --check`.
- [x] Project Evidence / Next action / Blocked by: issue 1901 Project item records the dirty Codex recovery, verifier process, and commit-only handoff; PR Project item will record exact head, checks, and review gate once opened.
- [x] Post-merge/deploy/runtime proof: official deploy and E29N56 construction acceptance remain owned by issue 1901 before issue closure; this PR provides the code/bundle deliverable for that runtime proof.
- [x] Named deliverable proof: commit `14c44341` by `lanyusea's bot <lanyusea@gmail.com>` with no issue-closing keyword in the commit message.
