### PR TITLE
worker-task: recover construction energy acquisition

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35338,10 +35338,11 @@ function selectWorkerTaskContext(creep, currentTask) {
     currentTask,
     (_a2 = spawnReservationRefillTask != null ? spawnReservationRefillTask : effectiveEnergyCriticalTask) != null ? _a2 : baseSelectedTask
   );
+  const constructionRecoveryTask = effectiveEnergyCriticalTask === null ? constructionBacklogEnergyAcquisitionTask : null;
   const selectedTaskAfterBuildEnergyAcquisition = selectAssignedBuildEnergyAcquisitionTask(
     creep,
     currentTask,
-    (_c = (_b = constructionBacklogEnergyAcquisitionTask != null ? constructionBacklogEnergyAcquisitionTask : spawnReservationRefillTask) != null ? _b : effectiveEnergyCriticalTask) != null ? _c : baseSelectedTask
+    (_c = (_b = constructionRecoveryTask != null ? constructionRecoveryTask : spawnReservationRefillTask) != null ? _b : effectiveEnergyCriticalTask) != null ? _c : baseSelectedTask
   );
   const selectedTask = (_d = selectConstructionWithdrawCompletionBuildTask(
     creep,

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35133,6 +35133,8 @@ function runWorker(creep) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForSpawnReservationRefill(currentTask, spawnReservationRefillTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
+  } else if (shouldPreemptEnergyAcquisitionTaskForConstructionBacklog(creep, currentTask, selectedTask)) {
+    taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForNearFullConstruction(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForProductiveBacklog(creep, currentTask, selectedTask)) {
@@ -35154,6 +35156,8 @@ function runWorker(creep) {
   } else if (shouldPreemptBuildTaskForConstructionEnergyAcquisition(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptTransferTaskForControllerDowngradeGuard(creep, currentTask, selectedTask)) {
+    taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
+  } else if (shouldPreemptTransferTaskForConstructionEnergyAcquisition(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptTransferTaskForConstructionBacklog(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
@@ -35316,7 +35320,7 @@ function selectWorkerTaskForRunner(creep) {
   return fallbackToEnergyOnNullSelectionLoop(creep, selectedTask);
 }
 function selectWorkerTaskContext(creep, currentTask) {
-  var _a2, _b;
+  var _a2, _b, _c, _d;
   const baseSelectedTask = selectWorkerTaskForRunner(creep);
   const energyCriticalTask = selectWorkerEnergyCriticalTask(creep, currentTask, baseSelectedTask);
   const effectiveEnergyCriticalTask = shouldYieldStorageCriticalAcquisitionToNearFullConstruction(
@@ -35329,22 +35333,52 @@ function selectWorkerTaskContext(creep, currentTask) {
     currentTask,
     effectiveEnergyCriticalTask != null ? effectiveEnergyCriticalTask : baseSelectedTask
   );
-  const selectedTaskAfterBuildEnergyAcquisition = selectAssignedBuildEnergyAcquisitionTask(
+  const constructionBacklogEnergyAcquisitionTask = selectConstructionBacklogEnergyAcquisitionRecoveryTask(
     creep,
     currentTask,
     (_a2 = spawnReservationRefillTask != null ? spawnReservationRefillTask : effectiveEnergyCriticalTask) != null ? _a2 : baseSelectedTask
   );
-  const selectedTask = (_b = selectConstructionWithdrawCompletionBuildTask(
+  const selectedTaskAfterBuildEnergyAcquisition = selectAssignedBuildEnergyAcquisitionTask(
+    creep,
+    currentTask,
+    (_c = (_b = constructionBacklogEnergyAcquisitionTask != null ? constructionBacklogEnergyAcquisitionTask : spawnReservationRefillTask) != null ? _b : effectiveEnergyCriticalTask) != null ? _c : baseSelectedTask
+  );
+  const selectedTask = (_d = selectConstructionWithdrawCompletionBuildTask(
     creep,
     currentTask,
     selectedTaskAfterBuildEnergyAcquisition
-  )) != null ? _b : selectedTaskAfterBuildEnergyAcquisition;
+  )) != null ? _d : selectedTaskAfterBuildEnergyAcquisition;
   return {
     baseSelectedTask,
     energyCriticalTask: effectiveEnergyCriticalTask,
     selectedTask,
     spawnReservationRefillTask
   };
+}
+function selectConstructionBacklogEnergyAcquisitionRecoveryTask(creep, currentTask, selectedTask) {
+  if (!shouldSelectConstructionBacklogEnergyAcquisitionRecoveryTask(creep, currentTask, selectedTask)) {
+    return null;
+  }
+  const constructionTask = selectConstructionBacklogEnergyAcquisitionTask(creep);
+  return constructionTask && canExecuteTask(creep, constructionTask) ? constructionTask : null;
+}
+function shouldSelectConstructionBacklogEnergyAcquisitionRecoveryTask(creep, currentTask, selectedTask) {
+  if (getFreeTransferEnergyCapacity(creep) <= 0 || getActiveWorkParts3(creep) <= 0 || hasVisibleHostileCreeps2(creep.room)) {
+    return false;
+  }
+  if (!hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room)) {
+    return false;
+  }
+  if (isDowngradeGuardUpgradeTask(creep, currentTask != null ? currentTask : null) || isDowngradeGuardUpgradeTask(creep, selectedTask)) {
+    return false;
+  }
+  if (isCriticalSpawnRefillTask(currentTask) || isCriticalSpawnRefillTask(selectedTask)) {
+    return false;
+  }
+  return isConstructionBacklogEnergyAcquisitionRecoveryTask(currentTask) && isConstructionBacklogEnergyAcquisitionRecoveryTask(selectedTask);
+}
+function isConstructionBacklogEnergyAcquisitionRecoveryTask(task) {
+  return task === void 0 || task === null || isEnergyAcquisitionTask2(task) && !isConstructionWithdrawReservationTask(task) || task.type === "transfer" || task.type === "upgrade";
 }
 function selectAssignedBuildEnergyAcquisitionTask(creep, currentTask, selectedTask) {
   var _a2, _b;
@@ -35375,7 +35409,7 @@ function selectConstructionWithdrawCompletionBuildTask(creep, currentTask, selec
   return { type: "build", targetId: constructionSite.id };
 }
 function canConstructionWithdrawCompletionOverrideSelectedTask(creep, selectedTask) {
-  return selectedTask === null || isEnergyAcquisitionTask2(selectedTask) || selectedTask.type === "build" || selectedTask.type === "upgrade" && !isDowngradeGuardUpgradeTask(creep, selectedTask);
+  return selectedTask === null || isEnergyAcquisitionTask2(selectedTask) || selectedTask.type === "build" || selectedTask.type === "transfer" && !isCriticalSpawnRefillTask(selectedTask) || selectedTask.type === "upgrade" && !isDowngradeGuardUpgradeTask(creep, selectedTask);
 }
 function shouldKeepConstructionWithdrawTaskForMoreEnergy(creep, currentTask, selectedTask) {
   return getFreeTransferEnergyCapacity(creep) > 0 && selectedTask !== null && isSameTask2(currentTask, selectedTask);
@@ -36495,10 +36529,7 @@ function recordInvalidBuildActionTarget(creep, task) {
   recordWorkerBuildActionResult(creep, "failed_site_invalid", { targetId: String(task.targetId) });
 }
 function assignNextTask(creep) {
-  var _a2;
-  const baseTask = selectWorkerTaskForRunner(creep);
-  const task = (_a2 = selectWorkerEnergyCriticalTask(creep, creep.memory.task, baseTask)) != null ? _a2 : baseTask;
-  return assignSelectedTask(creep, task);
+  return assignSelectedTask(creep, selectWorkerTaskContext(creep, creep.memory.task).selectedTask);
 }
 function shouldReplaceTask(creep, task) {
   if (isTerritoryControlTask2(task)) {
@@ -36570,6 +36601,9 @@ function shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, task, selecte
 }
 function shouldPreemptEnergyAcquisitionTaskForSpawnReservationRefill(task, spawnReservationRefillTask) {
   return isEnergyAcquisitionTask2(task) && (spawnReservationRefillTask == null ? void 0 : spawnReservationRefillTask.type) === "transfer" && !isSameTask2(task, spawnReservationRefillTask);
+}
+function shouldPreemptEnergyAcquisitionTaskForConstructionBacklog(creep, task, selectedTask) {
+  return isEnergyAcquisitionTask2(task) && !isConstructionWithdrawReservationTask(task) && !isDedicatedSourceContainerHarvestTask(creep, task) && isConstructionWithdrawReservationTask(selectedTask) && !isSameTask2(task, selectedTask);
 }
 function shouldPreemptEnergyAcquisitionTaskForNearFullConstruction(creep, task, selectedTask) {
   return isEnergyAcquisitionTask2(task) && selectedTask !== null && !isSameTask2(task, selectedTask) && shouldYieldStorageCriticalAcquisitionToNearFullConstruction(creep, task, selectedTask);
@@ -36716,6 +36750,9 @@ function shouldPreemptTransferTaskForControllerDowngradeGuard(creep, task, selec
     return false;
   }
   return isDowngradeGuardUpgradeTask(creep, selectedTask);
+}
+function shouldPreemptTransferTaskForConstructionEnergyAcquisition(creep, task, selectedTask) {
+  return task.type === "transfer" && isConstructionWithdrawReservationTask(selectedTask) && !isSameTask2(task, selectedTask) && getFreeTransferEnergyCapacity(creep) > 0 && !isCriticalSpawnRefillTask(task);
 }
 function shouldPreemptTransferTaskForConstructionBacklog(creep, task, selectedTask) {
   if (task.type !== "transfer" || (selectedTask == null ? void 0 : selectedTask.type) !== "build" || isSameTask2(task, selectedTask)) {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -469,10 +469,12 @@ function selectWorkerTaskContext(
     currentTask,
     spawnReservationRefillTask ?? effectiveEnergyCriticalTask ?? baseSelectedTask
   );
+  const constructionRecoveryTask =
+    effectiveEnergyCriticalTask === null ? constructionBacklogEnergyAcquisitionTask : null;
   const selectedTaskAfterBuildEnergyAcquisition = selectAssignedBuildEnergyAcquisitionTask(
     creep,
     currentTask,
-    constructionBacklogEnergyAcquisitionTask ??
+    constructionRecoveryTask ??
       spawnReservationRefillTask ??
       effectiveEnergyCriticalTask ??
       baseSelectedTask

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -198,6 +198,8 @@ export function runWorker(creep: Creep): void {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForSpawnReservationRefill(currentTask, spawnReservationRefillTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
+  } else if (shouldPreemptEnergyAcquisitionTaskForConstructionBacklog(creep, currentTask, selectedTask)) {
+    taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForNearFullConstruction(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForProductiveBacklog(creep, currentTask, selectedTask)) {
@@ -219,6 +221,8 @@ export function runWorker(creep: Creep): void {
   } else if (shouldPreemptBuildTaskForConstructionEnergyAcquisition(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptTransferTaskForControllerDowngradeGuard(creep, currentTask, selectedTask)) {
+    taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
+  } else if (shouldPreemptTransferTaskForConstructionEnergyAcquisition(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptTransferTaskForConstructionBacklog(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
@@ -460,10 +464,18 @@ function selectWorkerTaskContext(
     currentTask,
     effectiveEnergyCriticalTask ?? baseSelectedTask
   );
-  const selectedTaskAfterBuildEnergyAcquisition = selectAssignedBuildEnergyAcquisitionTask(
+  const constructionBacklogEnergyAcquisitionTask = selectConstructionBacklogEnergyAcquisitionRecoveryTask(
     creep,
     currentTask,
     spawnReservationRefillTask ?? effectiveEnergyCriticalTask ?? baseSelectedTask
+  );
+  const selectedTaskAfterBuildEnergyAcquisition = selectAssignedBuildEnergyAcquisitionTask(
+    creep,
+    currentTask,
+    constructionBacklogEnergyAcquisitionTask ??
+      spawnReservationRefillTask ??
+      effectiveEnergyCriticalTask ??
+      baseSelectedTask
   );
   const selectedTask =
     selectConstructionWithdrawCompletionBuildTask(
@@ -477,6 +489,62 @@ function selectWorkerTaskContext(
     selectedTask,
     spawnReservationRefillTask
   };
+}
+
+function selectConstructionBacklogEnergyAcquisitionRecoveryTask(
+  creep: Creep,
+  currentTask: CreepTaskMemory | null | undefined,
+  selectedTask: CreepTaskMemory | null
+): Extract<CreepTaskMemory, { type: 'harvest' | 'pickup' | 'withdraw' }> | null {
+  if (!shouldSelectConstructionBacklogEnergyAcquisitionRecoveryTask(creep, currentTask, selectedTask)) {
+    return null;
+  }
+
+  const constructionTask = selectConstructionBacklogEnergyAcquisitionTask(creep);
+  return constructionTask && canExecuteTask(creep, constructionTask) ? constructionTask : null;
+}
+
+function shouldSelectConstructionBacklogEnergyAcquisitionRecoveryTask(
+  creep: Creep,
+  currentTask: CreepTaskMemory | null | undefined,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  if (
+    getFreeTransferEnergyCapacity(creep) <= 0 ||
+    getActiveWorkParts(creep) <= 0 ||
+    hasVisibleHostileCreeps(creep.room)
+  ) {
+    return false;
+  }
+
+  if (!hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room)) {
+    return false;
+  }
+
+  if (isDowngradeGuardUpgradeTask(creep, currentTask ?? null) || isDowngradeGuardUpgradeTask(creep, selectedTask)) {
+    return false;
+  }
+
+  if (isCriticalSpawnRefillTask(currentTask) || isCriticalSpawnRefillTask(selectedTask)) {
+    return false;
+  }
+
+  return (
+    isConstructionBacklogEnergyAcquisitionRecoveryTask(currentTask) &&
+    isConstructionBacklogEnergyAcquisitionRecoveryTask(selectedTask)
+  );
+}
+
+function isConstructionBacklogEnergyAcquisitionRecoveryTask(
+  task: CreepTaskMemory | null | undefined
+): boolean {
+  return (
+    task === undefined ||
+    task === null ||
+    (isEnergyAcquisitionTask(task) && !isConstructionWithdrawReservationTask(task)) ||
+    task.type === 'transfer' ||
+    task.type === 'upgrade'
+  );
 }
 
 function selectAssignedBuildEnergyAcquisitionTask(
@@ -554,6 +622,7 @@ function canConstructionWithdrawCompletionOverrideSelectedTask(
     selectedTask === null ||
     isEnergyAcquisitionTask(selectedTask) ||
     selectedTask.type === 'build' ||
+    (selectedTask.type === 'transfer' && !isCriticalSpawnRefillTask(selectedTask)) ||
     (selectedTask.type === 'upgrade' && !isDowngradeGuardUpgradeTask(creep, selectedTask))
   );
 }
@@ -2339,9 +2408,7 @@ function recordInvalidBuildActionTarget(creep: Creep, task: CreepTaskMemory): vo
 }
 
 function assignNextTask(creep: Creep): CreepTaskMemory | null {
-  const baseTask = selectWorkerTaskForRunner(creep);
-  const task = selectWorkerEnergyCriticalTask(creep, creep.memory.task, baseTask) ?? baseTask;
-  return assignSelectedTask(creep, task);
+  return assignSelectedTask(creep, selectWorkerTaskContext(creep, creep.memory.task).selectedTask);
 }
 
 function shouldReplaceTask(creep: Creep, task: CreepTaskMemory): boolean {
@@ -2477,6 +2544,20 @@ function shouldPreemptEnergyAcquisitionTaskForSpawnReservationRefill(
     isEnergyAcquisitionTask(task) &&
     spawnReservationRefillTask?.type === 'transfer' &&
     !isSameTask(task, spawnReservationRefillTask)
+  );
+}
+
+function shouldPreemptEnergyAcquisitionTaskForConstructionBacklog(
+  creep: Creep,
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  return (
+    isEnergyAcquisitionTask(task) &&
+    !isConstructionWithdrawReservationTask(task) &&
+    !isDedicatedSourceContainerHarvestTask(creep, task) &&
+    isConstructionWithdrawReservationTask(selectedTask) &&
+    !isSameTask(task, selectedTask)
   );
 }
 
@@ -2747,6 +2828,20 @@ function shouldPreemptTransferTaskForControllerDowngradeGuard(
   }
 
   return isDowngradeGuardUpgradeTask(creep, selectedTask);
+}
+
+function shouldPreemptTransferTaskForConstructionEnergyAcquisition(
+  creep: Creep,
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  return (
+    task.type === 'transfer' &&
+    isConstructionWithdrawReservationTask(selectedTask) &&
+    !isSameTask(task, selectedTask) &&
+    getFreeTransferEnergyCapacity(creep) > 0 &&
+    !isCriticalSpawnRefillTask(task)
+  );
 }
 
 function shouldPreemptTransferTaskForConstructionBacklog(

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -8921,6 +8921,125 @@ describe('runWorker', () => {
     }
   });
 
+  it('keeps spawn-critical acquisition ahead of construction recovery for an idle empty worker', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 4_754,
+      progressTotal: 5_000,
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'storage1' ? 2 : 99))
+      }
+    } as unknown as ConstructionSite;
+    const storage = {
+      id: 'storage1',
+      my: true,
+      structureType: 'storage',
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { name?: string }).name) === 'IdleWorker' ? 1 : 2))
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 25_000 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(10_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N56',
+      energyAvailable: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD + 50,
+      energyCapacityAvailable: 1_300,
+      controller,
+      storage,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES) {
+            const structures = [storage] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const withdraw = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'IdleWorker',
+      memory: {
+        role: 'worker',
+        colony: 'E29N56',
+        workerEnergyCriticalPolicy: {
+          type: 'workerEnergyCriticalPolicy',
+          schemaVersion: 1,
+          active: true,
+          reason: 'spawn',
+          enteredAt: 2_188_030,
+          updatedAt: 2_188_030,
+          spawnEnergy: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+          spawnEnterThreshold: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD,
+          spawnExitThreshold: WORKER_ENERGY_CRITICAL_SPAWN_EXIT_THRESHOLD
+        }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'storage1' ? 1 : 99))
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room,
+      withdraw,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    roomCreeps.push(creep);
+    const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(null);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { IdleWorker: creep },
+      rooms: { E29N56: room },
+      time: 2_188_031,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({
+        type: 'withdraw',
+        targetId: 'storage1'
+      });
+      expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+        energyCriticalTask: 'withdraw',
+        selectedTask: 'withdraw',
+        assignedTask: 'withdraw'
+      });
+      expect(creep.memory.task).not.toHaveProperty('constructionSiteId');
+      expect(withdraw).toHaveBeenCalledWith(storage, RESOURCE_ENERGY, 100);
+    } finally {
+      selectWorkerTask.mockRestore();
+    }
+  });
+
   it('recovers construction assignment from retained noncritical extension refill selection', () => {
     const site = {
       id: 'road-site1',

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -10649,6 +10649,334 @@ describe('runWorker', () => {
     expect(withdraw).toHaveBeenCalledWith(storage, RESOURCE_ENERGY, 100);
   });
 
+  it('preempts a generic storage withdrawal for a construction-tagged backlog withdrawal', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 0,
+      progressTotal: 5_000,
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'storage1' ? 4 : 99))
+      }
+    } as unknown as ConstructionSite;
+    const storage = {
+      id: 'storage1',
+      my: true,
+      structureType: 'storage',
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) =>
+          String((target as { name?: string }).name) === 'GenericWithdrawer' ? 3 : 1
+        )
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 636_718 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(363_282)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N56',
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      controller,
+      storage,
+      find: jest.fn((type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES) {
+          const structures = [storage] as unknown as AnyOwnedStructure[];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+        }
+
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        if (type === FIND_HOSTILE_CREEPS || type === FIND_SOURCES || type === FIND_DROPPED_RESOURCES) {
+          return [];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const withdraw = jest.fn().mockReturnValue(ERR_NOT_IN_RANGE);
+    const creep = {
+      name: 'GenericWithdrawer',
+      memory: {
+        role: 'worker',
+        colony: 'E29N56',
+        task: { type: 'withdraw', targetId: 'storage1' as Id<StructureStorage> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'storage1' ? 3 : 99))
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room,
+      withdraw,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    roomCreeps.push(creep);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { GenericWithdrawer: creep },
+      rooms: { E29N56: room },
+      time: 2_188_026,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({
+      type: 'withdraw',
+      targetId: 'storage1',
+      constructionSiteId: 'road-site1'
+    });
+    expect(withdraw).toHaveBeenCalledWith(storage, RESOURCE_ENERGY, 100);
+  });
+
+  it('preempts low-load transfer work for a construction-tagged withdrawal when backlog is visible', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 0,
+      progressTotal: 5_000,
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'storage1' ? 4 : 99))
+      }
+    } as unknown as ConstructionSite;
+    const storage = {
+      id: 'storage1',
+      my: true,
+      structureType: 'storage',
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) =>
+          String((target as { name?: string }).name) === 'LowLoadTransferWorker' ? 3 : 1
+        )
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 636_718 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(363_282)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N56',
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      controller,
+      storage,
+      find: jest.fn((type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES) {
+          const structures = [storage] as unknown as AnyOwnedStructure[];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+        }
+
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        if (type === FIND_HOSTILE_CREEPS || type === FIND_SOURCES || type === FIND_DROPPED_RESOURCES) {
+          return [];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const transfer = jest.fn();
+    const withdraw = jest.fn().mockReturnValue(ERR_NOT_IN_RANGE);
+    const creep = {
+      name: 'LowLoadTransferWorker',
+      memory: {
+        role: 'worker',
+        colony: 'E29N56',
+        task: { type: 'transfer', targetId: 'storage1' as Id<StructureStorage> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'storage1' ? 3 : 99))
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 12 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 88 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room,
+      transfer,
+      withdraw,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    roomCreeps.push(creep);
+    const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue({
+      type: 'transfer',
+      targetId: 'storage1' as Id<StructureStorage>
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { LowLoadTransferWorker: creep },
+      rooms: { E29N56: room },
+      time: 2_188_027,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({
+        type: 'withdraw',
+        targetId: 'storage1',
+        constructionSiteId: 'road-site1'
+      });
+      expect(withdraw).toHaveBeenCalledWith(storage, RESOURCE_ENERGY, 88);
+      expect(transfer).not.toHaveBeenCalled();
+    } finally {
+      selectWorkerTask.mockRestore();
+    }
+  });
+
+  it('keeps urgent controller downgrade guard ahead of construction withdrawal recovery', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 0,
+      progressTotal: 5_000,
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'storage1' ? 4 : 99))
+      }
+    } as unknown as ConstructionSite;
+    const storage = {
+      id: 'storage1',
+      my: true,
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 636_718 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(363_282)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N56',
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      controller,
+      storage,
+      find: jest.fn((type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES) {
+          const structures = [storage] as unknown as AnyOwnedStructure[];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+        }
+
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        if (type === FIND_HOSTILE_CREEPS || type === FIND_SOURCES || type === FIND_DROPPED_RESOURCES) {
+          return [];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const transfer = jest.fn();
+    const withdraw = jest.fn();
+    const upgradeController = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'DowngradeGuardWorker',
+      memory: {
+        role: 'worker',
+        colony: 'E29N56',
+        task: { type: 'transfer', targetId: 'storage1' as Id<StructureStorage> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room,
+      transfer,
+      withdraw,
+      upgradeController,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    roomCreeps.push(creep);
+    const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue({
+      type: 'upgrade',
+      targetId: 'controller1' as Id<StructureController>
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { DowngradeGuardWorker: creep },
+      rooms: { E29N56: room },
+      time: 2_188_028,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        if (id === 'storage1') {
+          return storage;
+        }
+
+        return id === 'controller1' ? controller : null;
+      })
+    };
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({ type: 'upgrade', targetId: 'controller1' });
+      expect(upgradeController).toHaveBeenCalledWith(controller);
+      expect(withdraw).not.toHaveBeenCalled();
+      expect(transfer).not.toHaveBeenCalled();
+    } finally {
+      selectWorkerTask.mockRestore();
+    }
+  });
+
   it('turns an empty retained build assignment into construction energy withdrawal', () => {
     const site = {
       id: 'road-site1',


### PR DESCRIPTION
## Summary
- Recover construction energy acquisition for rooms with visible construction backlog and stored energy so workers can switch from generic energy/transfer/upgrade work into construction-tagged withdrawals.
- Preserve spawn-refill and controller-downgrade guards while allowing low-load transfer/generic withdrawal workers to refill for construction.
- Rebuild `prod/dist/main.js` from the verified source changes.

## Related issue
Related to issue 1901. Issue closure stays with the post-deploy runtime acceptance evidence described there.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 105 suites / 2463 tests passed
- `cd prod && npm run build`

## Universal task Done gate
- [x] Task type: production code hotfix for Screeps worker construction energy acquisition.
- [x] Expected observable outcome / named deliverable: `prod/src/creeps/workerRunner.ts` selects and preempts into construction-tagged energy acquisition when a construction backlog and stored energy are present.
- [x] Non-goals / accepted substitutes: no official MMO deploy from this PR branch and no learned-policy or RL runtime behavior change.
- [x] Verification evidence required before Done: controller-side `git diff --check`, `npm run typecheck`, full Jest `npm test -- --runInBand`, and `npm run build` completed successfully on commit `f1a55da`.
- [x] Project Evidence / Next action / Blocked by: Project item for issue 1901 and this PR must record the commit, verification, PR gate state, and post-merge deploy/health-gate follow-up.
- [x] Post-merge/deploy/runtime proof: official deploy plus all-owned construction health evidence must show E29N56/E29N55 construction acceptance movement before issue 1901 is marked Done.
- [x] Named deliverable proof: `workerRunner.ts`, `workerRunner.test.ts`, and regenerated `prod/dist/main.js` are the changed tracked files.
