### PR TITLE
worker-task: finish construction assignment recovery

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -27938,6 +27938,10 @@ function selectCriticalCpuWorkerTask(creep, cpuBudget) {
   if (controllerSustainConstructionBacklogTask) {
     return applyMinimumUsefulLoadPolicy(creep, controllerSustainConstructionBacklogTask);
   }
+  const constructionRecoveryTask = canUseCriticalCpuConstructionRecovery(creep) ? selectConstructionRecoveryCpuWorkerTask(creep) : null;
+  if (constructionRecoveryTask) {
+    return constructionRecoveryTask;
+  }
   const loadedControllerProgressTask = selectNonCriticalCpuLoadedControllerProgressTask(
     creep,
     cpuBudget,
@@ -28091,7 +28095,7 @@ function isStoredProtectedConstructionBacklogSite(site, priorityContext) {
   return isRoadConstructionSite2(site) || isHighImpactConstructionSite(site, priorityContext);
 }
 function selectCriticalCpuEnergyAcquisitionTask(creep) {
-  var _a2, _b;
+  var _a2, _b, _c;
   if (getFreeEnergyCapacity9(creep) <= 0) {
     return null;
   }
@@ -28120,7 +28124,15 @@ function selectCriticalCpuEnergyAcquisitionTask(creep) {
   if (hasCriticalCpuRepairDemand(creep)) {
     return selectWorkerEnergyCriticalAcquisitionTask(creep);
   }
-  return (_b = selectStoredProtectedSourceContainerConstructionEnergyAcquisitionTask(creep)) != null ? _b : selectStoredProtectedConstructionBacklogEnergyAcquisitionTask(creep);
+  const storedProtectedConstructionEnergyTask = (_b = selectStoredProtectedSourceContainerConstructionEnergyAcquisitionTask(creep)) != null ? _b : selectStoredProtectedConstructionBacklogEnergyAcquisitionTask(creep);
+  if (storedProtectedConstructionEnergyTask) {
+    return storedProtectedConstructionEnergyTask;
+  }
+  return canUseCriticalCpuConstructionRecovery(creep) ? (_c = selectConstructionBacklogEnergyAcquisitionTask(creep)) != null ? _c : selectConstructionBacklogFallbackEnergyAcquisitionTask(creep) : null;
+}
+function canUseCriticalCpuConstructionRecovery(creep) {
+  const memory = creep.memory;
+  return (memory == null ? void 0 : memory.role) === "worker" && memory.controllerSustain === void 0 && memory.interRoomEnergyHaul === void 0 && memory.spawnSupport === void 0 && memory.territory === void 0;
 }
 function hasCriticalCpuRepairDemand(creep) {
   return selectCriticalOwnedSpawnRepairTarget(creep) !== null || selectEmergencyOwnedRampartRepairTarget(creep) !== null || selectThreatenedBarrierRepairTarget(creep) !== null || selectCriticalInfrastructureRepairTarget(creep) !== null;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -27851,7 +27851,7 @@ function hasActiveTerritoryControlAssignment(creep) {
 function selectCriticalCpuWorkerTask(creep, cpuBudget) {
   const carriedEnergy = getUsedEnergy2(creep);
   if (carriedEnergy <= 0) {
-    return selectCriticalCpuEnergyAcquisitionTask(creep);
+    return selectCriticalCpuEnergyAcquisitionTask(creep, cpuBudget);
   }
   const controller = creep.room.controller;
   const constructionSites = findConstructionSites(creep.room);
@@ -27938,7 +27938,7 @@ function selectCriticalCpuWorkerTask(creep, cpuBudget) {
   if (controllerSustainConstructionBacklogTask) {
     return applyMinimumUsefulLoadPolicy(creep, controllerSustainConstructionBacklogTask);
   }
-  const constructionRecoveryTask = canUseCriticalCpuConstructionRecovery(creep) ? selectConstructionRecoveryCpuWorkerTask(creep) : null;
+  const constructionRecoveryTask = canUseCriticalCpuConstructionRecovery(creep, cpuBudget) ? selectConstructionRecoveryCpuWorkerTask(creep) : null;
   if (constructionRecoveryTask) {
     return constructionRecoveryTask;
   }
@@ -28094,7 +28094,7 @@ function canSpendOnStoredProtectedConstructionBacklog(creep, site, priorityConte
 function isStoredProtectedConstructionBacklogSite(site, priorityContext) {
   return isRoadConstructionSite2(site) || isHighImpactConstructionSite(site, priorityContext);
 }
-function selectCriticalCpuEnergyAcquisitionTask(creep) {
+function selectCriticalCpuEnergyAcquisitionTask(creep, cpuBudget) {
   var _a2, _b, _c;
   if (getFreeEnergyCapacity9(creep) <= 0) {
     return null;
@@ -28128,11 +28128,11 @@ function selectCriticalCpuEnergyAcquisitionTask(creep) {
   if (storedProtectedConstructionEnergyTask) {
     return storedProtectedConstructionEnergyTask;
   }
-  return canUseCriticalCpuConstructionRecovery(creep) ? (_c = selectConstructionBacklogEnergyAcquisitionTask(creep)) != null ? _c : selectConstructionBacklogFallbackEnergyAcquisitionTask(creep) : null;
+  return canUseCriticalCpuConstructionRecovery(creep, cpuBudget) ? (_c = selectConstructionBacklogEnergyAcquisitionTask(creep)) != null ? _c : selectConstructionBacklogFallbackEnergyAcquisitionTask(creep) : null;
 }
-function canUseCriticalCpuConstructionRecovery(creep) {
+function canUseCriticalCpuConstructionRecovery(creep, cpuBudget) {
   const memory = creep.memory;
-  return (memory == null ? void 0 : memory.role) === "worker" && memory.controllerSustain === void 0 && memory.interRoomEnergyHaul === void 0 && memory.spawnSupport === void 0 && memory.territory === void 0;
+  return !cpuBudget.critical && (memory == null ? void 0 : memory.role) === "worker" && memory.controllerSustain === void 0 && memory.interRoomEnergyHaul === void 0 && memory.spawnSupport === void 0 && memory.territory === void 0;
 }
 function hasCriticalCpuRepairDemand(creep) {
   return selectCriticalOwnedSpawnRepairTarget(creep) !== null || selectEmergencyOwnedRampartRepairTarget(creep) !== null || selectThreatenedBarrierRepairTarget(creep) !== null || selectCriticalInfrastructureRepairTarget(creep) !== null;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -477,6 +477,13 @@ function selectCriticalCpuWorkerTask(creep: Creep, cpuBudget: RuntimeCpuBudget):
     return applyMinimumUsefulLoadPolicy(creep, controllerSustainConstructionBacklogTask);
   }
 
+  const constructionRecoveryTask = canUseCriticalCpuConstructionRecovery(creep)
+    ? selectConstructionRecoveryCpuWorkerTask(creep)
+    : null;
+  if (constructionRecoveryTask) {
+    return constructionRecoveryTask;
+  }
+
   const loadedControllerProgressTask = selectNonCriticalCpuLoadedControllerProgressTask(
     creep,
     cpuBudget,
@@ -749,9 +756,27 @@ function selectCriticalCpuEnergyAcquisitionTask(
     return selectWorkerEnergyCriticalAcquisitionTask(creep);
   }
 
-  return (
+  const storedProtectedConstructionEnergyTask =
     selectStoredProtectedSourceContainerConstructionEnergyAcquisitionTask(creep) ??
-    selectStoredProtectedConstructionBacklogEnergyAcquisitionTask(creep)
+    selectStoredProtectedConstructionBacklogEnergyAcquisitionTask(creep);
+  if (storedProtectedConstructionEnergyTask) {
+    return storedProtectedConstructionEnergyTask;
+  }
+
+  return canUseCriticalCpuConstructionRecovery(creep)
+    ? selectConstructionBacklogEnergyAcquisitionTask(creep) ??
+        selectConstructionBacklogFallbackEnergyAcquisitionTask(creep)
+    : null;
+}
+
+function canUseCriticalCpuConstructionRecovery(creep: Creep): boolean {
+  const memory = creep.memory;
+  return (
+    memory?.role === 'worker' &&
+    memory.controllerSustain === undefined &&
+    memory.interRoomEnergyHaul === undefined &&
+    memory.spawnSupport === undefined &&
+    memory.territory === undefined
   );
 }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -366,7 +366,7 @@ function hasActiveTerritoryControlAssignment(creep: Creep): boolean {
 function selectCriticalCpuWorkerTask(creep: Creep, cpuBudget: RuntimeCpuBudget): CreepTaskMemory | null {
   const carriedEnergy = getUsedEnergy(creep);
   if (carriedEnergy <= 0) {
-    return selectCriticalCpuEnergyAcquisitionTask(creep);
+    return selectCriticalCpuEnergyAcquisitionTask(creep, cpuBudget);
   }
 
   const controller = creep.room.controller;
@@ -477,7 +477,7 @@ function selectCriticalCpuWorkerTask(creep: Creep, cpuBudget: RuntimeCpuBudget):
     return applyMinimumUsefulLoadPolicy(creep, controllerSustainConstructionBacklogTask);
   }
 
-  const constructionRecoveryTask = canUseCriticalCpuConstructionRecovery(creep)
+  const constructionRecoveryTask = canUseCriticalCpuConstructionRecovery(creep, cpuBudget)
     ? selectConstructionRecoveryCpuWorkerTask(creep)
     : null;
   if (constructionRecoveryTask) {
@@ -716,7 +716,8 @@ function isStoredProtectedConstructionBacklogSite(
 }
 
 function selectCriticalCpuEnergyAcquisitionTask(
-  creep: Creep
+  creep: Creep,
+  cpuBudget: RuntimeCpuBudget
 ): Extract<CreepTaskMemory, { type: 'harvest' | 'pickup' | 'withdraw' }> | null {
   if (getFreeEnergyCapacity(creep) <= 0) {
     return null;
@@ -763,15 +764,16 @@ function selectCriticalCpuEnergyAcquisitionTask(
     return storedProtectedConstructionEnergyTask;
   }
 
-  return canUseCriticalCpuConstructionRecovery(creep)
+  return canUseCriticalCpuConstructionRecovery(creep, cpuBudget)
     ? selectConstructionBacklogEnergyAcquisitionTask(creep) ??
         selectConstructionBacklogFallbackEnergyAcquisitionTask(creep)
     : null;
 }
 
-function canUseCriticalCpuConstructionRecovery(creep: Creep): boolean {
+function canUseCriticalCpuConstructionRecovery(creep: Creep, cpuBudget: RuntimeCpuBudget): boolean {
   const memory = creep.memory;
   return (
+    !cpuBudget.critical &&
     memory?.role === 'worker' &&
     memory.controllerSustain === undefined &&
     memory.interRoomEnergyHaul === undefined &&

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -14929,6 +14929,112 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(builder)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
+  it('keeps safe all-owned construction productive during low-bucket shedding', () => {
+    const fullSpawn = makeFullSpawnEnergyStructure('spawn-full', 'E29N55');
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 935,
+      progressTotal: 5_000,
+      pos: makeRoomPosition(22, 21, 'E29N55')
+    } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 6,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N55',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 820,
+      energyCapacityAvailable: 2_300,
+      myStructures: [fullSpawn as AnyOwnedStructure]
+    });
+    const builder = {
+      name: 'LowBucketBuilder',
+      memory: { role: 'worker', colony: 'E29N55' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room
+    } as unknown as Creep;
+    const coverageWorker = {
+      name: 'CoverageWorker',
+      memory: { role: 'worker', colony: 'E29N55' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ LowBucketBuilder: builder, CoverageWorker: coverageWorker });
+    setCpuBucket(758);
+
+    expect(canSpendWorkerEnergyOnConstructionSite(builder, site)).toBe(true);
+    expect(selectWorkerTask(builder)).toEqual({ type: 'build', targetId: 'road-site1' });
+  });
+
+  it('tags storage-rich construction acquisition during low-bucket shedding', () => {
+    const fullSpawn = makeFullSpawnEnergyStructure('spawn-full', 'E29N56');
+    const site = {
+      id: 'rampart-site1',
+      my: true,
+      structureType: 'rampart',
+      progress: 660,
+      progressTotal: 5_000,
+      pos: makeRoomPosition(24, 24, 'E29N56')
+    } as ConstructionSite;
+    const storage = makeStoredEnergyStructure('storage1', 'storage' as StructureConstant, 628_626, {
+      my: true,
+      pos: makeRoomPosition(20, 20, 'E29N56')
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N56',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 800,
+      energyCapacityAvailable: 1_300,
+      myStructures: [fullSpawn as AnyOwnedStructure],
+      structures: [storage as AnyStructure]
+    });
+    const worker = {
+      name: 'ConstructionWithdrawWorker',
+      memory: { role: 'worker', colony: 'E29N56' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(100)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => {
+          const ranges: Record<string, number> = {
+            storage1: 2,
+            'rampart-site1': 6
+          };
+          return ranges[String(target.id)] ?? 99;
+        })
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ ConstructionWithdrawWorker: worker });
+    setCpuBucket(758);
+
+    expect(selectWorkerTask(worker)).toEqual({
+      type: 'withdraw',
+      targetId: 'storage1',
+      constructionSiteId: 'rampart-site1'
+    });
+  });
+
   it('reserves a loaded worker for container construction when container surplus protects recovery energy', () => {
     const site = {
       id: 'source-container-site1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -14977,6 +14977,54 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(builder)).toEqual({ type: 'build', targetId: 'road-site1' });
   });
 
+  it('suppresses generic construction recovery during critical CPU bucket pressure', () => {
+    const fullSpawn = makeFullSpawnEnergyStructure('spawn-full', 'E29N55');
+    const site = {
+      id: 'wall-site1',
+      my: true,
+      structureType: 'constructedWall',
+      progress: 935,
+      progressTotal: 5_000,
+      pos: makeRoomPosition(22, 21, 'E29N55')
+    } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 6,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N55',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 820,
+      energyCapacityAvailable: 2_300,
+      myStructures: [fullSpawn as AnyOwnedStructure]
+    });
+    const builder = {
+      name: 'CriticalBucketBuilder',
+      memory: { role: 'worker', colony: 'E29N55' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room
+    } as unknown as Creep;
+    const coverageWorker = {
+      name: 'CoverageWorker',
+      memory: { role: 'worker', colony: 'E29N55' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ CriticalBucketBuilder: builder, CoverageWorker: coverageWorker });
+    setCpuBucket(43);
+
+    expect(canSpendWorkerEnergyOnConstructionSite(builder, site)).toBe(true);
+    expect(selectWorkerTask(builder)).toBeNull();
+  });
+
   it('tags storage-rich construction acquisition during low-bucket shedding', () => {
     const fullSpawn = makeFullSpawnEnergyStructure('spawn-full', 'E29N56');
     const site = {
@@ -15033,6 +15081,60 @@ describe('selectWorkerTask', () => {
       targetId: 'storage1',
       constructionSiteId: 'rampart-site1'
     });
+  });
+
+  it('suppresses generic construction acquisition during critical CPU bucket pressure', () => {
+    const fullSpawn = makeFullSpawnEnergyStructure('spawn-full', 'E29N56');
+    const site = {
+      id: 'wall-site1',
+      my: true,
+      structureType: 'constructedWall',
+      progress: 660,
+      progressTotal: 5_000,
+      pos: makeRoomPosition(24, 24, 'E29N56')
+    } as ConstructionSite;
+    const storage = makeStoredEnergyStructure('storage1', 'storage' as StructureConstant, 628_626, {
+      my: true,
+      pos: makeRoomPosition(20, 20, 'E29N56')
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N56',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 800,
+      energyCapacityAvailable: 1_300,
+      myStructures: [fullSpawn as AnyOwnedStructure],
+      structures: [storage as AnyStructure]
+    });
+    const worker = {
+      name: 'CriticalConstructionWithdrawWorker',
+      memory: { role: 'worker', colony: 'E29N56' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(100)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => {
+          const ranges: Record<string, number> = {
+            storage1: 2,
+            'wall-site1': 6
+          };
+          return ranges[String(target.id)] ?? 99;
+        })
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ CriticalConstructionWithdrawWorker: worker });
+    setCpuBucket(43);
+
+    expect(selectWorkerTask(worker)).toBeNull();
   });
 
   it('reserves a loaded worker for container construction when container surplus protects recovery energy', () => {


### PR DESCRIPTION
## Summary
- Finish the construction assignment recovery path for rooms with visible construction backlog but no carried build energy.
- Route idle/generic workers into construction energy pickup/execution without weakening spawn-refill or controller-sustain safeguards.
- Add focused worker-task tests and regenerate `prod/dist/main.js` from the verified source changes.

## Related issue
Related to issue 1901. Issue closure stays with post-merge official deploy and fresh all-owned construction acceptance evidence; this PR is the next implementation slice.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 105 suites / 2466 tests passed
- `cd prod && npm run build`

## Universal task Done gate
- [x] Task type: production code hotfix for Screeps worker construction assignment recovery.
- [x] Expected observable outcome / named deliverable: `prod/src/tasks/workerTasks.ts` selects construction recovery work for rooms with construction backlog and zero carried build energy so E29N55/E29N56 can resume build progress.
- [x] Non-goals / accepted substitutes: no direct official MMO deploy from this branch and no learned-policy/RL runtime behavior change.
- [x] Verification evidence required before Done: controller-side `git diff --check`, `npm run typecheck`, full Jest `npm test -- --runInBand`, and `npm run build` completed successfully on commit `37619df5`.
- [x] Project Evidence / Next action / Blocked by: Project item for issue 1901 and this PR must record commit `37619df5`, controller verification, PR gate state, and post-merge deploy/health-gate follow-up.
- [x] Post-merge/deploy/runtime proof: official deploy plus all-owned construction health evidence must show E29N55/E29N56 construction acceptance movement before issue 1901 is marked Done.
- [x] Named deliverable proof: `prod/src/tasks/workerTasks.ts`, `prod/test/workerTasks.test.ts`, and regenerated `prod/dist/main.js` are the changed tracked files.
