### PR TITLE
worker-task: recover E29N56 local worker coverage

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35684,8 +35684,8 @@ function hasVisibleHostileCreeps2(room) {
     return false;
   }
   try {
-    const findRoomObjects36 = room.find;
-    return findRoomObjects36(findHostileCreeps4).length > 0;
+    const findRoomObjects37 = room.find;
+    return findRoomObjects37(findHostileCreeps4).length > 0;
   } catch {
     return false;
   }
@@ -41015,7 +41015,7 @@ function isEmergencyLocalRefillSurvivalEntry(entry, context) {
 }
 function hasLocalSourceHarvesterShortfall(context) {
   var _a2, _b, _c;
-  return context.options.workersOnly !== true && context.survival.hostilePresence !== true && context.survival.controllerDowngradeGuard !== true && ((_a2 = context.colony.room.controller) == null ? void 0 : _a2.my) === true && ((_b = context.colony.room.controller.level) != null ? _b : 0) >= 2 && context.roleCounts.worker >= LOCAL_SUPPORT_WORKER_FLOOR && normalizeNonNegativeInteger16((_c = context.roleCounts.sourceHarvester) != null ? _c : 0) < getSourceCount(context.colony.room);
+  return context.options.workersOnly !== true && context.survival.hostilePresence !== true && context.survival.controllerDowngradeGuard !== true && ((_a2 = context.colony.room.controller) == null ? void 0 : _a2.my) === true && ((_b = context.colony.room.controller.level) != null ? _b : 0) >= 2 && !hasSpawnPresentLocalWorkerRecoveryShortfall(context) && context.roleCounts.worker >= LOCAL_SUPPORT_WORKER_FLOOR && normalizeNonNegativeInteger16((_c = context.roleCounts.sourceHarvester) != null ? _c : 0) < getSourceCount(context.colony.room);
 }
 function hasOwnedRoomHostilePresence() {
   var _a2;
@@ -41079,7 +41079,7 @@ function planLocalSurvivalSpawn(context) {
   return planWorkerSpawn(context.colony, context.roleCounts, context.gameTime, context.options);
 }
 function hasLocalSupportWorkerShortfall(context) {
-  return context.roleCounts.worker < getLocalSupportWorkerFloor(context) && hasLocalSupportWorkerDemand(context);
+  return hasSpawnPresentLocalWorkerRecoveryShortfall(context) || context.roleCounts.worker < getLocalSupportWorkerFloor(context) && hasLocalSupportWorkerDemand(context);
 }
 function getLocalSupportWorkerFloor(context) {
   if (context.workerTarget <= 0) {
@@ -41089,7 +41089,60 @@ function getLocalSupportWorkerFloor(context) {
 }
 function hasLocalSupportWorkerDemand(context) {
   var _a2;
-  return ((_a2 = context.colony.room.controller) == null ? void 0 : _a2.my) === true && !context.survival.hostilePresence && !context.survival.controllerDowngradeGuard && (context.survival.mode === "BOOTSTRAP" || getVisibleConstructionSiteCount(context.colony.room) > 0 || hasSpawnExtensionRefillDemand(context.colony));
+  return ((_a2 = context.colony.room.controller) == null ? void 0 : _a2.my) === true && !context.survival.hostilePresence && !context.survival.controllerDowngradeGuard && (context.survival.mode === "BOOTSTRAP" || getVisibleConstructionSiteCount(context.colony.room) > 0 || hasSpawnExtensionRefillDemand(context.colony) || hasSpawnPresentLocalWorkerRecoveryShortfall(context));
+}
+function hasSpawnPresentLocalWorkerRecoveryShortfall(context) {
+  var _a2;
+  const roomName = context.colony.room.name;
+  if (((_a2 = context.colony.room.controller) == null ? void 0 : _a2.my) !== true || context.survival.hostilePresence || context.survival.controllerDowngradeGuard || !hasOwnedSpawnInRoom2(roomName)) {
+    return false;
+  }
+  const creeps = getGameCreeps4();
+  if (!creeps || countRoomPresentWorkerCreeps(creeps, roomName) > 0) {
+    return false;
+  }
+  return getVisibleConstructionSiteCount(context.colony.room) > 0 || countRoomPresentCreeps(creeps, roomName) === 0 && countAssignedColonyWorkerCreeps(creeps, roomName) > 0;
+}
+function hasOwnedSpawnInRoom2(roomName) {
+  var _a2;
+  const gameSpawns = (_a2 = globalThis.Game) == null ? void 0 : _a2.spawns;
+  if (gameSpawns) {
+    return Object.values(gameSpawns).some((spawn) => {
+      var _a3;
+      return ((_a3 = spawn.room) == null ? void 0 : _a3.name) === roomName && !spawn.spawning;
+    });
+  }
+  return false;
+}
+function getGameCreeps4() {
+  var _a2;
+  const gameCreeps = (_a2 = globalThis.Game) == null ? void 0 : _a2.creeps;
+  return gameCreeps ? Object.values(gameCreeps) : null;
+}
+function countRoomPresentWorkerCreeps(creeps, roomName) {
+  return creeps.filter(
+    (creep) => {
+      var _a2, _b;
+      return ((_a2 = creep.memory) == null ? void 0 : _a2.role) === "worker" && ((_b = creep.room) == null ? void 0 : _b.name) === roomName && canSatisfyWorkerRecoveryCapacity(creep);
+    }
+  ).length;
+}
+function countRoomPresentCreeps(creeps, roomName) {
+  return creeps.filter((creep) => {
+    var _a2;
+    return ((_a2 = creep.room) == null ? void 0 : _a2.name) === roomName;
+  }).length;
+}
+function countAssignedColonyWorkerCreeps(creeps, roomName) {
+  return creeps.filter(
+    (creep) => {
+      var _a2;
+      return ((_a2 = creep.memory) == null ? void 0 : _a2.role) === "worker" && creep.memory.colony === roomName && canSatisfyWorkerRecoveryCapacity(creep);
+    }
+  ).length;
+}
+function canSatisfyWorkerRecoveryCapacity(creep) {
+  return creep.ticksToLive === void 0 || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE;
 }
 function hasSpawnExtensionRefillDemand(colony) {
   return normalizeNonNegativeInteger16(colony.energyCapacityAvailable) > 0 && normalizeNonNegativeInteger16(colony.energyAvailable) < normalizeNonNegativeInteger16(colony.energyCapacityAvailable);
@@ -41133,7 +41186,7 @@ function planLocalEnergyHaulingSpawn(context) {
 }
 function planLocalSourceMiningSpawn(context) {
   var _a2, _b;
-  if (context.options.workersOnly || context.survival.hostilePresence || context.survival.controllerDowngradeGuard || ((_a2 = context.colony.room.controller) == null ? void 0 : _a2.my) !== true || ((_b = context.colony.room.controller.level) != null ? _b : 0) < 2 || context.roleCounts.worker < LOCAL_SUPPORT_WORKER_FLOOR) {
+  if (context.options.workersOnly || context.survival.hostilePresence || context.survival.controllerDowngradeGuard || ((_a2 = context.colony.room.controller) == null ? void 0 : _a2.my) !== true || ((_b = context.colony.room.controller.level) != null ? _b : 0) < 2 || hasSpawnPresentLocalWorkerRecoveryShortfall(context) || context.roleCounts.worker < LOCAL_SUPPORT_WORKER_FLOOR) {
     return null;
   }
   const target = selectLocalSourceHarvesterSpawnTarget(context);
@@ -42295,7 +42348,7 @@ var ROOM_EDGE_MAX10 = 48;
 var DEFAULT_TERRAIN_WALL_MASK15 = 1;
 var ERR_INVALID_TARGET_CODE5 = -7;
 var REMOTE_HARVESTER_ROLE2 = "remoteHarvester";
-function ensureRemoteSourceContainersForAssignedHarvesters(creeps = getGameCreeps4()) {
+function ensureRemoteSourceContainersForAssignedHarvesters(creeps = getGameCreeps5()) {
   const roomResults = getRemoteSourceContainerScans(creeps).map(planSourceContainersForRoom);
   return buildSourceContainerPlannerResult(roomResults);
 }
@@ -42558,7 +42611,7 @@ function getVisibleSpawns() {
   const spawns = (_a2 = globalThis.Game) == null ? void 0 : _a2.spawns;
   return spawns ? Object.values(spawns).filter((spawn) => spawn !== void 0) : [];
 }
-function getGameCreeps4() {
+function getGameCreeps5() {
   var _a2;
   const creeps = (_a2 = globalThis.Game) == null ? void 0 : _a2.creeps;
   return creeps ? Object.values(creeps).filter((creep) => creep !== void 0) : [];
@@ -45536,7 +45589,7 @@ function recordSourceWorkloads(room, creeps, tick) {
     )
   };
 }
-function buildSourceWorkloadRecords(room, sources = findSources4(room), creeps = getGameCreeps5()) {
+function buildSourceWorkloadRecords(room, sources = findSources4(room), creeps = getGameCreeps6()) {
   const roomName = getRoomName8(room);
   const assignmentLoads = getSourceAssignmentLoads(roomName, sources, creeps);
   return sources.filter((source) => hasSourcePositionInRoom(source, room)).sort((left, right) => String(left.id).localeCompare(String(right.id))).map((source) => {
@@ -45675,7 +45728,7 @@ function getBodyPartConstant6(globalName, fallback) {
   const constants = globalThis;
   return (_a2 = constants[globalName]) != null ? _a2 : fallback;
 }
-function getGameCreeps5() {
+function getGameCreeps6() {
   var _a2;
   const creeps = (_a2 = globalThis.Game) == null ? void 0 : _a2.creeps;
   return creeps ? Object.values(creeps) : [];
@@ -49877,9 +49930,9 @@ function isOwnedRoomMissingSpawn(room) {
   if (((_a2 = room.controller) == null ? void 0 : _a2.my) !== true || ((_b = room.controller.level) != null ? _b : 0) < 1) {
     return false;
   }
-  return !hasOwnedSpawnInRoom2(room);
+  return !hasOwnedSpawnInRoom3(room);
 }
-function hasOwnedSpawnInRoom2(room) {
+function hasOwnedSpawnInRoom3(room) {
   var _a2;
   const spawns = (_a2 = globalThis.Game) == null ? void 0 : _a2.spawns;
   if (spawns && Object.values(spawns).some((spawn) => {
@@ -53516,6 +53569,9 @@ function getWorkerShedCpuProbeRoomName(creep) {
   return typeof roomName === "string" && roomName.length > 0 ? roomName : null;
 }
 function shouldRunShedCpuColonyPlanning(colony, roleCounts, survivalAssessment) {
+  if (hasSpawnPresentLocalWorkerRecoveryShortfall2(colony, survivalAssessment)) {
+    return true;
+  }
   if (roleCounts.worker <= 0 || getWorkerCapacity(roleCounts) <= 0) {
     return true;
   }
@@ -53526,6 +53582,65 @@ function shouldRunShedCpuColonyPlanning(colony, roleCounts, survivalAssessment) 
     return true;
   }
   return isColonyRoomThreatened(colony.room.name, Game.time);
+}
+function hasSpawnPresentLocalWorkerRecoveryShortfall2(colony, survivalAssessment) {
+  var _a2, _b;
+  const roomName = colony.room.name;
+  if (((_a2 = colony.room.controller) == null ? void 0 : _a2.my) !== true || survivalAssessment.hostilePresence || survivalAssessment.controllerDowngradeGuard || !hasOwnedIdleSpawnInRoom(roomName)) {
+    return false;
+  }
+  const creeps = Object.values((_b = Game.creeps) != null ? _b : {});
+  if (countRoomPresentWorkerCreeps2(creeps, roomName) > 0) {
+    return false;
+  }
+  return hasVisibleConstructionBacklog(colony.room) || countRoomPresentCreeps2(creeps, roomName) === 0 && countAssignedColonyWorkerCreeps2(creeps, roomName) > 0;
+}
+function hasOwnedIdleSpawnInRoom(roomName) {
+  var _a2;
+  return Object.values((_a2 = Game.spawns) != null ? _a2 : {}).some((spawn) => {
+    var _a3;
+    return ((_a3 = spawn.room) == null ? void 0 : _a3.name) === roomName && !spawn.spawning;
+  });
+}
+function countRoomPresentWorkerCreeps2(creeps, roomName) {
+  return creeps.filter(
+    (creep) => {
+      var _a2, _b;
+      return ((_a2 = creep.memory) == null ? void 0 : _a2.role) === "worker" && ((_b = creep.room) == null ? void 0 : _b.name) === roomName && canSatisfyWorkerRecoveryCapacity2(creep);
+    }
+  ).length;
+}
+function countRoomPresentCreeps2(creeps, roomName) {
+  return creeps.filter((creep) => {
+    var _a2;
+    return ((_a2 = creep.room) == null ? void 0 : _a2.name) === roomName;
+  }).length;
+}
+function countAssignedColonyWorkerCreeps2(creeps, roomName) {
+  return creeps.filter(
+    (creep) => {
+      var _a2;
+      return ((_a2 = creep.memory) == null ? void 0 : _a2.role) === "worker" && creep.memory.colony === roomName && canSatisfyWorkerRecoveryCapacity2(creep);
+    }
+  ).length;
+}
+function canSatisfyWorkerRecoveryCapacity2(creep) {
+  return creep.ticksToLive === void 0 || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE;
+}
+function hasVisibleConstructionBacklog(room) {
+  return findRoomObjects36(room, "FIND_MY_CONSTRUCTION_SITES").length > 0 || findRoomObjects36(room, "FIND_CONSTRUCTION_SITES").some((site) => site.my !== false);
+}
+function findRoomObjects36(room, globalName) {
+  const findConstant = globalThis[globalName];
+  if (typeof findConstant !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  try {
+    const result = room.find(findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return [];
+  }
 }
 function runClaimedRoomConstructionForCpuBudget(colony, creeps, options, telemetryEvents, postClaimBootstrapFocusRoomName, deferred, mode = "normal") {
   refreshPostClaimDefenseConstruction(colony, { focusRoomName: postClaimBootstrapFocusRoomName });
@@ -54163,7 +54278,23 @@ function planSpawnWithEnergyBudget(colony, sourceColony, energyBudget, usedSpawn
   };
 }
 function shouldBypassSpawnEnergyBuffer(spawnRequest, roleCounts, availableEnergy, bodyCost, survivalAssessment) {
-  return roleCounts.worker === 0 || isBootstrapWorkerRecoverySpawnRequest(spawnRequest, roleCounts, availableEnergy, survivalAssessment) || isLocalWorkerRecoverySpawnRequest(spawnRequest, availableEnergy, bodyCost, survivalAssessment) || isLocalSourceMinerRecoverySpawnRequest(spawnRequest, roleCounts, availableEnergy, bodyCost, survivalAssessment) || isTerritoryControllerSpawnRequest(spawnRequest);
+  return roleCounts.worker === 0 || isSpawnPresentLocalWorkerRecoverySpawnRequest(spawnRequest, availableEnergy, bodyCost, survivalAssessment) || isBootstrapWorkerRecoverySpawnRequest(spawnRequest, roleCounts, availableEnergy, survivalAssessment) || isLocalWorkerRecoverySpawnRequest(spawnRequest, availableEnergy, bodyCost, survivalAssessment) || isLocalSourceMinerRecoverySpawnRequest(spawnRequest, roleCounts, availableEnergy, bodyCost, survivalAssessment) || isTerritoryControllerSpawnRequest(spawnRequest);
+}
+function isSpawnPresentLocalWorkerRecoverySpawnRequest(spawnRequest, availableEnergy, bodyCost, survivalAssessment) {
+  var _a2;
+  const roomName = spawnRequest.memory.colony;
+  if (spawnRequest.memory.role !== "worker" || spawnRequest.memory.controllerUpgrade !== void 0 || spawnRequest.memory.controllerSustain !== void 0 || ((_a2 = spawnRequest.spawn.room) == null ? void 0 : _a2.name) !== roomName || survivalAssessment.hostilePresence || survivalAssessment.controllerDowngradeGuard || availableEnergy < bodyCost) {
+    return false;
+  }
+  return hasSpawnPresentLocalWorkerRecoveryShortfall2(
+    {
+      room: spawnRequest.spawn.room,
+      spawns: [spawnRequest.spawn],
+      energyAvailable: availableEnergy,
+      energyCapacityAvailable: spawnRequest.spawn.room.energyCapacityAvailable
+    },
+    survivalAssessment
+  );
 }
 function isBootstrapWorkerRecoverySpawnRequest(spawnRequest, roleCounts, availableEnergy, survivalAssessment) {
   return spawnRequest.memory.role === "worker" && survivalAssessment.mode === "BOOTSTRAP" && (roleCounts.worker < survivalAssessment.survivalWorkerFloor || availableEnergy >= BOOTSTRAP_WORKER_BUFFER_BYPASS_MIN_ENERGY);

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -15,7 +15,12 @@ import type {
   ConstructionPlannerBlockedPlacement,
   ConstructionPlannerPlacement
 } from '../construction/planner';
-import { countCreepsByRole, getWorkerCapacity, type RoleCounts } from '../creeps/roleCounts';
+import {
+  countCreepsByRole,
+  getWorkerCapacity,
+  WORKER_REPLACEMENT_TICKS_TO_LIVE,
+  type RoleCounts
+} from '../creeps/roleCounts';
 import { runWorker } from '../creeps/workerRunner';
 import {
   CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS,
@@ -556,6 +561,10 @@ function shouldRunShedCpuColonyPlanning(
   roleCounts: RoleCounts,
   survivalAssessment: ReturnType<typeof assessColonySnapshotSurvival>
 ): boolean {
+  if (hasSpawnPresentLocalWorkerRecoveryShortfall(colony, survivalAssessment)) {
+    return true;
+  }
+
   if (roleCounts.worker <= 0 || getWorkerCapacity(roleCounts) <= 0) {
     return true;
   }
@@ -572,6 +581,85 @@ function shouldRunShedCpuColonyPlanning(
   }
 
   return isColonyRoomThreatened(colony.room.name, Game.time);
+}
+
+function hasSpawnPresentLocalWorkerRecoveryShortfall(
+  colony: ColonySnapshot,
+  survivalAssessment: ReturnType<typeof assessColonySnapshotSurvival>
+): boolean {
+  const roomName = colony.room.name;
+  if (
+    colony.room.controller?.my !== true ||
+    survivalAssessment.hostilePresence ||
+    survivalAssessment.controllerDowngradeGuard ||
+    !hasOwnedIdleSpawnInRoom(roomName)
+  ) {
+    return false;
+  }
+
+  const creeps = Object.values(Game.creeps ?? {});
+  if (countRoomPresentWorkerCreeps(creeps, roomName) > 0) {
+    return false;
+  }
+
+  return (
+    hasVisibleConstructionBacklog(colony.room) ||
+    (
+      countRoomPresentCreeps(creeps, roomName) === 0 &&
+      countAssignedColonyWorkerCreeps(creeps, roomName) > 0
+    )
+  );
+}
+
+function hasOwnedIdleSpawnInRoom(roomName: string): boolean {
+  return Object.values(Game.spawns ?? {}).some((spawn) => spawn.room?.name === roomName && !spawn.spawning);
+}
+
+function countRoomPresentWorkerCreeps(creeps: Creep[], roomName: string): number {
+  return creeps.filter(
+    (creep) =>
+      creep.memory?.role === 'worker' &&
+      creep.room?.name === roomName &&
+      canSatisfyWorkerRecoveryCapacity(creep)
+  ).length;
+}
+
+function countRoomPresentCreeps(creeps: Creep[], roomName: string): number {
+  return creeps.filter((creep) => creep.room?.name === roomName).length;
+}
+
+function countAssignedColonyWorkerCreeps(creeps: Creep[], roomName: string): number {
+  return creeps.filter(
+    (creep) =>
+      creep.memory?.role === 'worker' &&
+      creep.memory.colony === roomName &&
+      canSatisfyWorkerRecoveryCapacity(creep)
+  ).length;
+}
+
+function canSatisfyWorkerRecoveryCapacity(creep: Creep): boolean {
+  return creep.ticksToLive === undefined || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE;
+}
+
+function hasVisibleConstructionBacklog(room: Room): boolean {
+  return (
+    findRoomObjects<ConstructionSite>(room, 'FIND_MY_CONSTRUCTION_SITES').length > 0 ||
+    findRoomObjects<ConstructionSite>(room, 'FIND_CONSTRUCTION_SITES').some((site) => site.my !== false)
+  );
+}
+
+function findRoomObjects<T>(room: Room, globalName: string): T[] {
+  const findConstant = (globalThis as Record<string, unknown>)[globalName];
+  if (typeof findConstant !== 'number' || typeof room.find !== 'function') {
+    return [];
+  }
+
+  try {
+    const result = (room.find as unknown as (type: number) => unknown[])(findConstant);
+    return Array.isArray(result) ? (result as T[]) : [];
+  } catch {
+    return [];
+  }
 }
 
 function runClaimedRoomConstructionForCpuBudget(
@@ -1508,10 +1596,41 @@ function shouldBypassSpawnEnergyBuffer(
 ): boolean {
   return (
     roleCounts.worker === 0 ||
+    isSpawnPresentLocalWorkerRecoverySpawnRequest(spawnRequest, availableEnergy, bodyCost, survivalAssessment) ||
     isBootstrapWorkerRecoverySpawnRequest(spawnRequest, roleCounts, availableEnergy, survivalAssessment) ||
     isLocalWorkerRecoverySpawnRequest(spawnRequest, availableEnergy, bodyCost, survivalAssessment) ||
     isLocalSourceMinerRecoverySpawnRequest(spawnRequest, roleCounts, availableEnergy, bodyCost, survivalAssessment) ||
     isTerritoryControllerSpawnRequest(spawnRequest)
+  );
+}
+
+function isSpawnPresentLocalWorkerRecoverySpawnRequest(
+  spawnRequest: SpawnRequest,
+  availableEnergy: number,
+  bodyCost: number,
+  survivalAssessment: ReturnType<typeof assessColonySnapshotSurvival>
+): boolean {
+  const roomName = spawnRequest.memory.colony;
+  if (
+    spawnRequest.memory.role !== 'worker' ||
+    spawnRequest.memory.controllerUpgrade !== undefined ||
+    spawnRequest.memory.controllerSustain !== undefined ||
+    spawnRequest.spawn.room?.name !== roomName ||
+    survivalAssessment.hostilePresence ||
+    survivalAssessment.controllerDowngradeGuard ||
+    availableEnergy < bodyCost
+  ) {
+    return false;
+  }
+
+  return hasSpawnPresentLocalWorkerRecoveryShortfall(
+    {
+      room: spawnRequest.spawn.room,
+      spawns: [spawnRequest.spawn],
+      energyAvailable: availableEnergy,
+      energyCapacityAvailable: spawnRequest.spawn.room.energyCapacityAvailable
+    },
+    survivalAssessment
   );
 }
 

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -9,7 +9,12 @@ import {
   hasEmergencyBootstrapCreepShortfall,
   type ColonySurvivalAssessment
 } from '../colony/colonyStage';
-import { countCreepsByRole, getWorkerCapacity, type RoleCounts } from '../creeps/roleCounts';
+import {
+  countCreepsByRole,
+  getWorkerCapacity,
+  WORKER_REPLACEMENT_TICKS_TO_LIVE,
+  type RoleCounts
+} from '../creeps/roleCounts';
 import {
   REMOTE_HARVESTER_ROLE,
   selectRemoteHarvesterAssignment
@@ -559,6 +564,7 @@ function hasLocalSourceHarvesterShortfall(context: SpawnPlanningContext): boolea
     context.survival.controllerDowngradeGuard !== true &&
     context.colony.room.controller?.my === true &&
     (context.colony.room.controller.level ?? 0) >= 2 &&
+    !hasSpawnPresentLocalWorkerRecoveryShortfall(context) &&
     context.roleCounts.worker >= LOCAL_SUPPORT_WORKER_FLOOR &&
     normalizeNonNegativeInteger(context.roleCounts.sourceHarvester ?? 0) < getSourceCount(context.colony.room)
   );
@@ -641,8 +647,11 @@ function planLocalSurvivalSpawn(context: SpawnPlanningContext): SpawnRequest | n
 
 function hasLocalSupportWorkerShortfall(context: SpawnPlanningContext): boolean {
   return (
-    context.roleCounts.worker < getLocalSupportWorkerFloor(context) &&
-    hasLocalSupportWorkerDemand(context)
+    hasSpawnPresentLocalWorkerRecoveryShortfall(context) ||
+    (
+      context.roleCounts.worker < getLocalSupportWorkerFloor(context) &&
+      hasLocalSupportWorkerDemand(context)
+    )
   );
 }
 
@@ -661,8 +670,74 @@ function hasLocalSupportWorkerDemand(context: SpawnPlanningContext): boolean {
     !context.survival.controllerDowngradeGuard &&
     (context.survival.mode === 'BOOTSTRAP' ||
       getVisibleConstructionSiteCount(context.colony.room) > 0 ||
-      hasSpawnExtensionRefillDemand(context.colony))
+      hasSpawnExtensionRefillDemand(context.colony) ||
+      hasSpawnPresentLocalWorkerRecoveryShortfall(context))
   );
+}
+
+function hasSpawnPresentLocalWorkerRecoveryShortfall(context: SpawnPlanningContext): boolean {
+  const roomName = context.colony.room.name;
+  if (
+    context.colony.room.controller?.my !== true ||
+    context.survival.hostilePresence ||
+    context.survival.controllerDowngradeGuard ||
+    !hasOwnedSpawnInRoom(roomName)
+  ) {
+    return false;
+  }
+
+  const creeps = getGameCreeps();
+  if (!creeps || countRoomPresentWorkerCreeps(creeps, roomName) > 0) {
+    return false;
+  }
+
+  return (
+    getVisibleConstructionSiteCount(context.colony.room) > 0 ||
+    (
+      countRoomPresentCreeps(creeps, roomName) === 0 &&
+      countAssignedColonyWorkerCreeps(creeps, roomName) > 0
+    )
+  );
+}
+
+function hasOwnedSpawnInRoom(roomName: string): boolean {
+  const gameSpawns = (globalThis as unknown as { Game?: Partial<Pick<Game, 'spawns'>> }).Game?.spawns;
+  if (gameSpawns) {
+    return Object.values(gameSpawns).some((spawn) => spawn.room?.name === roomName && !spawn.spawning);
+  }
+
+  return false;
+}
+
+function getGameCreeps(): Creep[] | null {
+  const gameCreeps = (globalThis as unknown as { Game?: Partial<Pick<Game, 'creeps'>> }).Game?.creeps;
+  return gameCreeps ? Object.values(gameCreeps) : null;
+}
+
+function countRoomPresentWorkerCreeps(creeps: Creep[], roomName: string): number {
+  return creeps.filter(
+    (creep) =>
+      creep.memory?.role === 'worker' &&
+      creep.room?.name === roomName &&
+      canSatisfyWorkerRecoveryCapacity(creep)
+  ).length;
+}
+
+function countRoomPresentCreeps(creeps: Creep[], roomName: string): number {
+  return creeps.filter((creep) => creep.room?.name === roomName).length;
+}
+
+function countAssignedColonyWorkerCreeps(creeps: Creep[], roomName: string): number {
+  return creeps.filter(
+    (creep) =>
+      creep.memory?.role === 'worker' &&
+      creep.memory.colony === roomName &&
+      canSatisfyWorkerRecoveryCapacity(creep)
+  ).length;
+}
+
+function canSatisfyWorkerRecoveryCapacity(creep: Creep): boolean {
+  return creep.ticksToLive === undefined || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE;
 }
 
 function hasSpawnExtensionRefillDemand(colony: ColonySnapshot): boolean {
@@ -726,6 +801,7 @@ function planLocalSourceMiningSpawn(context: SpawnPlanningContext): SpawnRequest
     context.survival.controllerDowngradeGuard ||
     context.colony.room.controller?.my !== true ||
     (context.colony.room.controller.level ?? 0) < 2 ||
+    hasSpawnPresentLocalWorkerRecoveryShortfall(context) ||
     context.roleCounts.worker < LOCAL_SUPPORT_WORKER_FLOOR
   ) {
     return null;

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -668,6 +668,79 @@ describe('runEconomy', () => {
     });
   });
 
+  it('keeps low-bucket E29N56 local worker recovery while stable E29N57 stays idle', () => {
+    installSpawnCoordinationGlobals();
+    (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    const recoveryRoom = makeSpawnCoordinationRoom({
+      roomName: 'E29N56',
+      energyAvailable: 300,
+      energyCapacityAvailable: 800,
+      controllerLevel: 4
+    });
+    const stableRoom = makeSpawnCoordinationRoom({
+      roomName: 'E29N57',
+      energyAvailable: 800,
+      energyCapacityAvailable: 800,
+      controllerLevel: 5
+    });
+    const recoverySpawn = {
+      name: 'SpawnE29N56',
+      room: recoveryRoom,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const stableSpawn = {
+      name: 'SpawnE29N57',
+      room: stableRoom,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const offRoomRecoveryWorkers = Object.fromEntries(
+      Array.from({ length: 5 }, (_, index) => [
+        `E29N56RemoteWorker${index}`,
+        {
+          name: `worker-E29N56-${index}`,
+          ticksToLive: 1_000,
+          memory: {
+            role: 'worker',
+            colony: 'E29N56',
+            territory: { targetRoom: 'E29N57', action: 'claim' }
+          },
+          room: stableRoom
+        } as Creep
+      ])
+    );
+    const stableWorkers = {
+      E29N57Worker1: makeEconomyWorker(stableRoom),
+      E29N57Worker2: makeEconomyWorker(stableRoom),
+      E29N57Worker3: makeEconomyWorker(stableRoom)
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 2_197_087,
+      rooms: { E29N56: recoveryRoom, E29N57: stableRoom },
+      spawns: { SpawnE29N56: recoverySpawn, SpawnE29N57: stableSpawn },
+      creeps: { ...offRoomRecoveryWorkers, ...stableWorkers },
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(26),
+        limit: 70,
+        bucket: 817,
+        tickLimit: 500
+      } as unknown as CPU
+    };
+
+    runEconomy();
+
+    expect(recoverySpawn.spawnCreep).toHaveBeenCalledWith(
+      ['work', 'work', 'carry', 'move'],
+      'worker-E29N56-2197087',
+      {
+        memory: { role: 'worker', colony: 'E29N56' }
+      }
+    );
+    expect(stableSpawn.spawnCreep).not.toHaveBeenCalled();
+  });
+
   it('spawns an emergency bootstrap worker without requiring the energy buffer', () => {
     const room = {
       name: 'W1N1',

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -6712,6 +6712,47 @@ describe('planSpawn', () => {
     });
   });
 
+  it('plans local E29N56 worker recovery when counted workers are all off-room and construction remains', () => {
+    const { colony, spawn } = makeColony({
+      roomName: 'E29N56',
+      constructionSiteCount: 2,
+      energyAvailable: 800,
+      energyCapacityAvailable: 800,
+      controller: makeSafeOwnedController(4)
+    });
+    const remoteRoom = { name: 'E29N57' } as Room;
+    const offRoomWorkers = Object.fromEntries(
+      Array.from({ length: 5 }, (_, index) => [
+        `RemoteWorker${index}`,
+        {
+          name: `worker-E29N56-${index}`,
+          ticksToLive: 1_000,
+          memory: {
+            role: 'worker',
+            colony: 'E29N56',
+            controllerSustain: {
+              homeRoom: 'E29N56',
+              targetRoom: 'E29N57',
+              role: 'upgrader'
+            }
+          },
+          room: remoteRoom
+        } as Creep
+      ])
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: offRoomWorkers,
+      spawns: { SpawnE29N56: spawn }
+    };
+
+    expect(planSpawn(colony, { worker: 5, sourceHarvester: 0 }, 2_197_087)).toEqual({
+      spawn,
+      body: SCALED_WORKER_800,
+      name: 'worker-E29N56-2197087',
+      memory: { role: 'worker', colony: 'E29N56' }
+    });
+  });
+
   it('plans an affordable worker body below the minimum functional worker target', () => {
     const { colony, spawn } = makeColony({ energyAvailable: 400, energyCapacityAvailable: 600 });
 


### PR DESCRIPTION
## Summary
- Restores an autonomous recovery path for spawn-present owned rooms that have no viable local worker coverage.
- Keeps local E29N56 worker recovery ahead of local source-miner spawning and preserves helper-room energy buffers.
- Adds focused regression coverage for E29N56 zero-local-worker recovery and stable E29N57 behavior.

## Verification
- Codex implementation session: `npm run typecheck` passed.
- Codex implementation session: `npm test -- --runInBand` passed — 105 suites / 2472 tests.
- Codex implementation session: `npm run build` passed and regenerated `prod/dist/main.js`.
- Controller/commit-only recovery: `git diff --check` passed with no output.

## Related issue
Related to issue 1664. Issue acceptance stays open for official deploy and fresh postdeploy E29N56 worker/build KPI evidence.

## Universal task Done gate
- [x] Task type: Production hotfix for owned-room zero-local-worker recovery.
- [x] Expected observable outcome / named deliverable: commit `097e3d875043586fe42e6343471217a117e73da9` delivers spawn/economy recovery logic plus Jest coverage for E29N56 local worker coverage.
- [x] Non-goals / accepted substitutes: This PR changes bot code only; official MMO upload and runtime acceptance are handled by the deploy floor.
- [x] Verification evidence required before Done: local Codex verification ran typecheck, Jest 105 suites / 2472 tests, build, and diff-check; PR CI repeats the repository gates on this exact branch.
- [x] Project Evidence / Next action / Blocked by: issue 1664 and this PR Project items carry the current PR checks, automated review, elapsed gate, deploy-floor handoff, and E29N56 postdeploy KPI evidence target.
- [x] Post-merge/deploy/runtime proof: deploy floor proof target is a successful official MMO deploy for the merged main commit plus fresh postdeploy summary/health-gate evidence showing E29N56 worker recovery and construction activity.
- [x] Named deliverable proof: `prod/src/economy/economyLoop.ts`, `prod/src/spawn/spawnPlanner.ts`, `prod/test/economyLoop.test.ts`, `prod/test/spawnPlanner.test.ts`, and regenerated `prod/dist/main.js` are the complete committed file set.
