### PR TITLE
rl: add bounded canary readiness plan gate

### DIFF
--- a/docs/ops/rl-rollout-rollback.md
+++ b/docs/ops/rl-rollout-rollback.md
@@ -50,6 +50,44 @@ Every contract, dry-run, rollback-check, and compare artifact now carries a `saf
 
 For `canary`, `active`, or `rolled_back` state, missing incumbent baseline, candidate ID, candidate deploy, or rollback refs fail validation. A forbidden live influence surface also fails validation. Training and evaluation remain artifact-only: learned/tuned candidates must not issue raw intents, Memory/RawMemory writes, market orders, or official MMO writes.
 
+## Pre-Canary Readiness Plan
+
+Before the controller launches any bounded official-MMO canary dry-run, create a planning-only readiness record:
+
+```bash
+python3 scripts/screeps_rl_rollout_manager.py canary-plan \
+  --baseline runtime-artifacts/rl-control-loop/baselines/<incumbent-kpi-window>.json \
+  --candidate-id <candidate-id> \
+  --deploy-ref <candidate-policy-or-bundle-ref> \
+  --scorecard-ref runtime-artifacts/rl-control-loop/scorecards/<candidate-id>.json \
+  --incumbent-baseline-ref <incumbent-ref> \
+  --rollback-ref <rollback-ref> \
+  --active-world-ref main \
+  --active-world-status matched_main \
+  --official-deploy-head 14df4ae442fb68e1273aa69c182daa0328e2d868 \
+  --official-deploy-run-id 27530460405 \
+  --deploy-artifact runtime-artifacts/official-screeps-deploy/official-screeps-deploy-27530460405.json \
+  --postdeploy-summary-artifact runtime-artifacts/official-screeps-deploy/postdeploy-summary-27530460405.json \
+  --postdeploy-health-gate-artifact runtime-artifacts/official-screeps-deploy/postdeploy-health-gate-27530460405.json \
+  --postdeploy-alert-artifact runtime-artifacts/official-screeps-deploy/postdeploy-alert-27530460405.json \
+  --health-gate-ok true \
+  --postdeploy-alert false \
+  --construction-acceptance-status pass \
+  --owned-spawns 1 \
+  --owned-creeps 5 \
+  --cpu-baseline-status <pass|hold|fail> \
+  --cpu-baseline-ref runtime-artifacts/rl-control-loop/<cpu-baseline-evidence>.json \
+  --conclusion-registry-ref runtime-artifacts/rl-control-loop/conclusion-registry.json \
+  --conclusion-summary ACTIONED=1,VALIDATING=1,CLOSED=2 \
+  --conclusion RL-CONC-20260612-004=VALIDATING \
+  --conclusion RL-CONC-20260610-002=ACTIONED \
+  --output runtime-artifacts/rl-control-loop/canary-plans/<candidate-id>.json
+```
+
+The output type is `screeps-rl-bounded-live-canary-plan`. It binds the candidate, scorecard, incumbent KPI window, rollback ref, postdeploy health/construction evidence, CPU gate, and current Loop A/Loop B conclusion state before a canary action exists. `readiness.status` is `ready` only when all referenced gates pass; otherwise it is `hold` with machine-readable `blockingReasons`.
+
+This command is deliberately inert. It does not train, launch Tencent paid compute, scale ASGs, deploy code, write official MMO state, or start the live canary. Passing `--paid-compute-allowed` or `--official-mmo-write-allowed` records an unsafe requested state and blocks readiness.
+
 ## Gate Contract
 
 The contract is available as machine-readable JSON:
@@ -221,4 +259,5 @@ Local checks:
 python3 -m py_compile scripts/screeps_rl_rollout_manager.py
 python3 -m py_compile scripts/test_screeps_rl_rollout_manager.py
 python3 scripts/test_screeps_rl_rollout_manager.py
+git diff --check
 ```

--- a/scripts/screeps_rl_rollout_manager.py
+++ b/scripts/screeps_rl_rollout_manager.py
@@ -33,7 +33,7 @@ LIVE_INFLUENCE_STATES = ("none", "shadow", "canary", "active", "rolled_back")
 DEFAULT_LIVE_INFLUENCE_STATE = "none"
 DEFAULT_LIVE_INFLUENCE_SURFACE = "none"
 LIVE_INFLUENCE_STATES_REQUIRING_REFS = ("canary", "active", "rolled_back")
-CANARY_PLAN_PASS_STATUSES = ("pass", "passed", "ok", "stable", "ready")
+CANARY_PLAN_PASS_STATUSES = ("pass", "passed", "ok", "stable", "ready", "accepted")
 CANARY_PLAN_ACTIVE_WORLD_STATUS = "matched_main"
 CANARY_PLAN_SCORECARD_PASS_STATUS = "PASS"
 CANARY_PLAN_SCORECARD_STATUS_VALUES = (
@@ -1309,6 +1309,15 @@ def build_canary_readiness_plan(
                 "actual": cpu_baseline_status,
                 "field": "cpuGate.status",
                 "reason": "cpu_baseline_must_pass",
+                "scope": "cpuGate",
+            }
+        )
+    elif not text_present(cpu_baseline_ref):
+        blocking_reasons.append(
+            {
+                "actual": cpu_baseline_ref,
+                "field": "cpuGate.sourceArtifact",
+                "reason": "missing_cpu_baseline_ref",
                 "scope": "cpuGate",
             }
         )

--- a/scripts/screeps_rl_rollout_manager.py
+++ b/scripts/screeps_rl_rollout_manager.py
@@ -898,7 +898,13 @@ def canary_plan_text_blocking_reasons(fields: tuple[tuple[str, Any, str], ...]) 
     ]
 
 
-def build_candidate_scorecard_gate(scorecard_raw: JsonObject | None, scorecard_ref: str | None) -> JsonObject:
+def build_candidate_scorecard_gate(
+    scorecard_raw: JsonObject | None,
+    scorecard_ref: str | None,
+    *,
+    candidate_id: str | None = None,
+    deploy_ref: str | None = None,
+) -> JsonObject:
     reasons: list[JsonObject] = []
     overall_status: str | None = None
     safety_regressions: list[Any] = []
@@ -930,6 +936,60 @@ def build_candidate_scorecard_gate(scorecard_raw: JsonObject | None, scorecard_r
                     "field": "candidate.scorecard.type",
                     "reason": "invalid_candidate_scorecard_type",
                     "required": SCORECARD_TYPE,
+                    "scope": "scorecardGate",
+                }
+            )
+
+        scorecard_candidate = scorecard_raw.get("candidate")
+        scorecard_candidate = scorecard_candidate if isinstance(scorecard_candidate, dict) else {}
+        scorecard_candidate_id = scorecard_candidate.get("id")
+        if not text_present(scorecard_candidate_id):
+            reasons.append(
+                {
+                    "field": "candidate.scorecard.candidate.id",
+                    "reason": "missing_candidate_scorecard_candidate_id",
+                    "scope": "scorecardGate",
+                }
+            )
+        elif text_present(candidate_id) and scorecard_candidate_id != candidate_id:
+            reasons.append(
+                {
+                    "actual": scorecard_candidate_id,
+                    "field": "candidate.scorecard.candidate.id",
+                    "reason": "candidate_scorecard_candidate_id_mismatch",
+                    "required": candidate_id,
+                    "scope": "scorecardGate",
+                }
+            )
+
+        scorecard_candidate_commit = scorecard_candidate.get("commit")
+        if (
+            text_present(scorecard_candidate_commit)
+            and text_present(deploy_ref)
+            and scorecard_candidate_commit != deploy_ref
+        ):
+            reasons.append(
+                {
+                    "actual": scorecard_candidate_commit,
+                    "field": "candidate.scorecard.candidate.commit",
+                    "reason": "candidate_scorecard_candidate_commit_mismatch",
+                    "required": deploy_ref,
+                    "scope": "scorecardGate",
+                }
+            )
+
+        scorecard_candidate_deploy_ref = scorecard_candidate.get("deployRef")
+        if (
+            text_present(scorecard_candidate_deploy_ref)
+            and text_present(deploy_ref)
+            and scorecard_candidate_deploy_ref != deploy_ref
+        ):
+            reasons.append(
+                {
+                    "actual": scorecard_candidate_deploy_ref,
+                    "field": "candidate.scorecard.candidate.deployRef",
+                    "reason": "candidate_scorecard_candidate_deploy_ref_mismatch",
+                    "required": deploy_ref,
                     "scope": "scorecardGate",
                 }
             )
@@ -1098,7 +1158,12 @@ def build_canary_readiness_plan(
     normalized_cpu = normalize_status_text(cpu_baseline_status)
     spawn_count = number_or_none(owned_spawns)
     creep_count = number_or_none(owned_creeps)
-    scorecard_gate = build_candidate_scorecard_gate(scorecard_raw, scorecard_ref)
+    scorecard_gate = build_candidate_scorecard_gate(
+        scorecard_raw,
+        scorecard_ref,
+        candidate_id=candidate_id,
+        deploy_ref=deploy_ref,
+    )
 
     blocking_reasons: list[JsonObject] = []
     blocking_reasons.extend(baseline["blockingReasons"])

--- a/scripts/screeps_rl_rollout_manager.py
+++ b/scripts/screeps_rl_rollout_manager.py
@@ -20,6 +20,7 @@ SCHEMA_VERSION = 1
 CONTRACT_VERSION = 1
 CONTRACT_TYPE = "screeps-rl-rollout-gate-contract"
 CANARY_CONTRACT_TYPE = "screeps-rl-safe-canary-contract"
+CANARY_PLAN_TYPE = "screeps-rl-bounded-live-canary-plan"
 COMPARISON_TYPE = "screeps-rl-post-rollout-kpi-comparison"
 DECISION_TYPE = "screeps-rl-rollout-decision"
 ROLLBACK_TYPE = "screeps-rl-rollback-check"
@@ -31,6 +32,8 @@ LIVE_INFLUENCE_STATES = ("none", "shadow", "canary", "active", "rolled_back")
 DEFAULT_LIVE_INFLUENCE_STATE = "none"
 DEFAULT_LIVE_INFLUENCE_SURFACE = "none"
 LIVE_INFLUENCE_STATES_REQUIRING_REFS = ("canary", "active", "rolled_back")
+CANARY_PLAN_PASS_STATUSES = ("pass", "passed", "ok", "stable", "ready")
+CANARY_PLAN_ACTIVE_WORLD_STATUS = "matched_main"
 ALLOWED_LIVE_INFLUENCE_SURFACES: dict[str, JsonObject] = {
     "none": {
         "description": "no learned/tuned candidate influence reaches official MMO behavior",
@@ -149,6 +152,38 @@ def normalize_contract_text(value: str | None, default: str) -> str:
     if value is None or value == "":
         return default
     return value
+
+
+def normalize_status_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower().replace("-", "_").replace(" ", "_")
+    return normalized or None
+
+
+def status_is_pass(value: str | None) -> bool:
+    normalized = normalize_status_text(value)
+    return normalized in CANARY_PLAN_PASS_STATUSES if normalized is not None else False
+
+
+def text_present(value: Any) -> bool:
+    return isinstance(value, str) and value.strip() != ""
+
+
+def parse_bool_arg(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized in ("1", "true", "yes", "y", "ok", "pass"):
+        return True
+    if normalized in ("0", "false", "no", "n", "fail", "blocked"):
+        return False
+    raise argparse.ArgumentTypeError(f"expected boolean value, got {value!r}")
+
+
+def parse_key_value_arg(value: str) -> tuple[str, str]:
+    key, separator, status = value.partition("=")
+    if not separator or not key.strip() or not status.strip():
+        raise argparse.ArgumentTypeError("expected KEY=VALUE")
+    return key.strip(), status.strip()
 
 
 def utc_now_iso() -> str:
@@ -684,6 +719,44 @@ def compare_metric(pre_value: Any, post_value: Any, spec: MetricSpec) -> JsonObj
     return result
 
 
+def evaluate_window_requirements(window: JsonObject, label: str) -> list[JsonObject]:
+    checks: list[JsonObject] = []
+
+    duration = number_or_none(window.get("durationHours"))
+    if duration is None:
+        checks.append({"label": label, "reason": "missing_duration_hours", "status": "fail"})
+    elif duration + EPSILON < DEFAULT_OBSERVATION_WINDOW_HOURS:
+        checks.append(
+            {
+                "actualHours": round_float(duration),
+                "label": label,
+                "reason": "duration_below_observation_window",
+                "requiredHours": DEFAULT_OBSERVATION_WINDOW_HOURS,
+                "status": "fail",
+            }
+        )
+    else:
+        checks.append({"actualHours": round_float(duration), "label": label, "status": "pass"})
+
+    sample_count = number_or_none(window.get("sampleCount"))
+    if sample_count is None:
+        checks.append({"label": label, "reason": "missing_sample_count", "status": "fail"})
+    elif sample_count + EPSILON < DEFAULT_MIN_OBSERVATION_SAMPLES:
+        checks.append(
+            {
+                "actualSamples": round_float(sample_count),
+                "label": label,
+                "reason": "samples_below_minimum",
+                "requiredSamples": DEFAULT_MIN_OBSERVATION_SAMPLES,
+                "status": "fail",
+            }
+        )
+    else:
+        checks.append({"actualSamples": round_float(sample_count), "label": label, "status": "pass"})
+
+    return checks
+
+
 def evaluate_observation_contract(
     pre_window: JsonObject,
     post_window: JsonObject,
@@ -700,43 +773,335 @@ def evaluate_observation_contract(
         }
 
     for label, window in (("pre", pre_window), ("post", post_window)):
-        duration = number_or_none(window.get("durationHours"))
-        if duration is None:
-            checks.append({"label": label, "reason": "missing_duration_hours", "status": "fail"})
-        elif duration + EPSILON < DEFAULT_OBSERVATION_WINDOW_HOURS:
-            checks.append(
-                {
-                    "actualHours": round_float(duration),
-                    "label": label,
-                    "reason": "duration_below_observation_window",
-                    "requiredHours": DEFAULT_OBSERVATION_WINDOW_HOURS,
-                    "status": "fail",
-                }
-            )
-        else:
-            checks.append({"actualHours": round_float(duration), "label": label, "status": "pass"})
-
-        sample_count = number_or_none(window.get("sampleCount"))
-        if sample_count is None:
-            checks.append({"label": label, "reason": "missing_sample_count", "status": "fail"})
-        elif sample_count + EPSILON < DEFAULT_MIN_OBSERVATION_SAMPLES:
-            checks.append(
-                {
-                    "actualSamples": round_float(sample_count),
-                    "label": label,
-                    "reason": "samples_below_minimum",
-                    "requiredSamples": DEFAULT_MIN_OBSERVATION_SAMPLES,
-                    "status": "fail",
-                }
-            )
-        else:
-            checks.append({"actualSamples": round_float(sample_count), "label": label, "status": "pass"})
+        checks.extend(evaluate_window_requirements(window, label))
 
     return {
         "checks": checks,
         "requiredHours": DEFAULT_OBSERVATION_WINDOW_HOURS,
         "requiredSamples": DEFAULT_MIN_OBSERVATION_SAMPLES,
         "status": "fail" if any(check["status"] == "fail" for check in checks) else "pass",
+    }
+
+
+def build_baseline_readiness(baseline_raw: JsonObject | None, baseline_source: str | None) -> JsonObject:
+    if baseline_raw is None:
+        return {
+            "blockingReasons": [{"field": "baselineKpi", "reason": "missing_baseline_kpi_window"}],
+            "metrics": {key: None for key in METRIC_ORDER},
+            "observation": {
+                "checks": [],
+                "requiredHours": DEFAULT_OBSERVATION_WINDOW_HOURS,
+                "requiredSamples": DEFAULT_MIN_OBSERVATION_SAMPLES,
+                "status": "fail",
+            },
+            "rawType": None,
+            "status": "fail",
+            "window": {"sourcePath": baseline_source},
+        }
+
+    baseline = normalize_kpi_window(baseline_raw, baseline_source)
+    checks = evaluate_window_requirements(baseline["window"], "baseline")
+    blocking_reasons: list[JsonObject] = [
+        {"scope": "baselineObservation", **check} for check in checks if check.get("status") == "fail"
+    ]
+    metric_checks: list[JsonObject] = []
+    for key, value in baseline["metrics"].items():
+        check = {
+            "metric": key,
+            "reason": "missing_baseline_metric" if value is None else "observed",
+            "status": "fail" if value is None else "pass",
+        }
+        metric_checks.append(check)
+        if value is None:
+            blocking_reasons.append({"metric": key, "reason": "missing_baseline_metric", "scope": "baselineMetric"})
+
+    observation = {
+        "checks": checks,
+        "requiredHours": DEFAULT_OBSERVATION_WINDOW_HOURS,
+        "requiredSamples": DEFAULT_MIN_OBSERVATION_SAMPLES,
+        "status": "fail" if any(check["status"] == "fail" for check in checks) else "pass",
+    }
+    status = "fail" if blocking_reasons else "pass"
+    return {
+        "blockingReasons": blocking_reasons,
+        "metricChecks": metric_checks,
+        "metrics": baseline["metrics"],
+        "observation": observation,
+        "rawType": baseline["rawType"],
+        "status": status,
+        "window": baseline["window"],
+    }
+
+
+def build_planning_safety_guards(
+    *,
+    official_mmo_write_allowed: bool = False,
+    paid_compute_allowed: bool = False,
+) -> JsonObject:
+    return {
+        "deploysCode": False,
+        "launchesCanary": False,
+        "officialMmoWritesAllowedDuringPlanning": official_mmo_write_allowed,
+        "paidComputeAllowed": paid_compute_allowed,
+        "planGeneratedOnly": True,
+        "prohibitedActions": [
+            "do not launch Tencent paid compute",
+            "do not scale ASGs",
+            "do not run official deploy",
+            "do not write official MMO state",
+            "do not train a new model",
+            "do not bypass validation-plan or no-compute guards",
+        ],
+        "trainsModel": False,
+        "writesOfficialMmo": False,
+    }
+
+
+def canary_plan_safety_blocking_reasons(safety: JsonObject) -> list[JsonObject]:
+    reasons: list[JsonObject] = []
+    if safety.get("paidComputeAllowed") is not False:
+        reasons.append({"field": "safetyGuards.paidComputeAllowed", "reason": "paid_compute_must_remain_held"})
+    if safety.get("officialMmoWritesAllowedDuringPlanning") is not False:
+        reasons.append(
+            {
+                "field": "safetyGuards.officialMmoWritesAllowedDuringPlanning",
+                "reason": "official_mmo_writes_must_remain_disallowed",
+            }
+        )
+    for field in ("deploysCode", "launchesCanary", "trainsModel", "writesOfficialMmo"):
+        if safety.get(field) is not False:
+            reasons.append({"field": f"safetyGuards.{field}", "reason": "planning_gate_must_not_execute_actions"})
+    return [{"scope": "safety", **reason} for reason in reasons]
+
+
+def canary_plan_text_blocking_reasons(fields: tuple[tuple[str, Any, str], ...]) -> list[JsonObject]:
+    return [
+        {"field": field, "reason": reason, "scope": "readiness"}
+        for field, value, reason in fields
+        if not text_present(value)
+    ]
+
+
+def build_canary_readiness_plan(
+    *,
+    active_world_ref: str | None = None,
+    active_world_status: str | None = None,
+    baseline_raw: JsonObject | None = None,
+    baseline_source: str | None = None,
+    candidate_id: str | None = None,
+    conclusion_records: list[tuple[str, str]] | None = None,
+    conclusion_registry_ref: str | None = None,
+    conclusion_summary: str | None = None,
+    construction_acceptance_status: str | None = None,
+    cpu_baseline_ref: str | None = None,
+    cpu_baseline_status: str | None = None,
+    created_at: str | None = None,
+    deploy_artifact: str | None = None,
+    deploy_ref: str | None = None,
+    health_gate_ok: bool | None = None,
+    incumbent_baseline_ref: str | None = None,
+    live_influence_state: str | None = "canary",
+    live_influence_surface: str | None = "bounded_high_level_strategy_knobs",
+    official_deploy_head: str | None = None,
+    official_deploy_run_id: str | None = None,
+    official_mmo_write_allowed: bool = False,
+    owned_creeps: float | int | None = None,
+    owned_spawns: float | int | None = None,
+    paid_compute_allowed: bool = False,
+    postdeploy_alert: bool | None = None,
+    postdeploy_alert_artifact: str | None = None,
+    postdeploy_health_gate_artifact: str | None = None,
+    postdeploy_summary_artifact: str | None = None,
+    rollback_ref: str | None = None,
+    scorecard_ref: str | None = None,
+) -> JsonObject:
+    created = created_at or utc_now_iso()
+    baseline = build_baseline_readiness(baseline_raw, baseline_source)
+    canary_contract = build_safe_canary_contract(
+        candidate_id=candidate_id,
+        deploy_ref=deploy_ref,
+        rollback_ref=rollback_ref,
+        incumbent_baseline_ref=incumbent_baseline_ref,
+        live_influence_state=live_influence_state,
+        live_influence_surface=live_influence_surface,
+        created_at=created,
+        baseline_source=baseline_source,
+    )
+    safety = build_planning_safety_guards(
+        official_mmo_write_allowed=official_mmo_write_allowed,
+        paid_compute_allowed=paid_compute_allowed,
+    )
+    normalized_active_world = normalize_status_text(active_world_status)
+    normalized_construction = normalize_status_text(construction_acceptance_status)
+    normalized_cpu = normalize_status_text(cpu_baseline_status)
+    spawn_count = number_or_none(owned_spawns)
+    creep_count = number_or_none(owned_creeps)
+
+    blocking_reasons: list[JsonObject] = []
+    blocking_reasons.extend(baseline["blockingReasons"])
+    blocking_reasons.extend(canary_blocking_reasons(canary_contract))
+    blocking_reasons.extend(canary_plan_safety_blocking_reasons(safety))
+    blocking_reasons.extend(
+        canary_plan_text_blocking_reasons(
+            (
+                ("candidate.scorecardRef", scorecard_ref, "missing_candidate_scorecard_ref"),
+                ("controlLoop.conclusionRegistryRef", conclusion_registry_ref, "missing_conclusion_registry_ref"),
+                ("officialDeploy.head", official_deploy_head, "missing_official_deploy_head"),
+                ("officialDeploy.runId", official_deploy_run_id, "missing_official_deploy_run_id"),
+                ("officialDeploy.artifacts.deploy", deploy_artifact, "missing_official_deploy_artifact"),
+                (
+                    "officialDeploy.artifacts.postdeploySummary",
+                    postdeploy_summary_artifact,
+                    "missing_postdeploy_summary_artifact",
+                ),
+                (
+                    "officialDeploy.artifacts.postdeployHealthGate",
+                    postdeploy_health_gate_artifact,
+                    "missing_postdeploy_health_gate_artifact",
+                ),
+                (
+                    "officialDeploy.artifacts.postdeployAlert",
+                    postdeploy_alert_artifact,
+                    "missing_postdeploy_alert_artifact",
+                ),
+            )
+        )
+    )
+
+    if not conclusion_records:
+        blocking_reasons.append(
+            {
+                "field": "controlLoop.conclusions",
+                "reason": "missing_conclusion_records",
+                "scope": "controlLoop",
+            }
+        )
+    if normalized_active_world != CANARY_PLAN_ACTIVE_WORLD_STATUS:
+        blocking_reasons.append(
+            {
+                "actual": active_world_status,
+                "field": "officialDeploy.activeWorldStatus",
+                "reason": "active_world_must_match_main",
+                "required": CANARY_PLAN_ACTIVE_WORLD_STATUS,
+                "scope": "officialDeploy",
+            }
+        )
+    if health_gate_ok is not True:
+        blocking_reasons.append(
+            {
+                "actual": health_gate_ok,
+                "field": "officialDeploy.healthGateOk",
+                "reason": "postdeploy_health_gate_must_be_ok",
+                "scope": "officialDeploy",
+            }
+        )
+    if postdeploy_alert is not False:
+        blocking_reasons.append(
+            {
+                "actual": postdeploy_alert,
+                "field": "officialDeploy.alert",
+                "reason": "postdeploy_alert_must_be_false",
+                "scope": "officialDeploy",
+            }
+        )
+    if normalized_construction != "pass":
+        blocking_reasons.append(
+            {
+                "actual": construction_acceptance_status,
+                "field": "constructionGate.status",
+                "reason": "construction_acceptance_must_pass",
+                "required": "pass",
+                "scope": "constructionGate",
+            }
+        )
+    if not status_is_pass(cpu_baseline_status):
+        blocking_reasons.append(
+            {
+                "actual": cpu_baseline_status,
+                "field": "cpuGate.status",
+                "reason": "cpu_baseline_must_pass",
+                "scope": "cpuGate",
+            }
+        )
+    if spawn_count is None or spawn_count < 1:
+        blocking_reasons.append(
+            {
+                "actual": owned_spawns,
+                "field": "officialDeploy.ownedSpawns",
+                "reason": "owned_spawn_count_must_be_positive",
+                "scope": "officialDeploy",
+            }
+        )
+    if creep_count is None or creep_count < 1:
+        blocking_reasons.append(
+            {
+                "actual": owned_creeps,
+                "field": "officialDeploy.ownedCreeps",
+                "reason": "owned_creep_count_must_be_positive",
+                "scope": "officialDeploy",
+            }
+        )
+
+    readiness_status = "hold" if blocking_reasons else "ready"
+    return {
+        "type": CANARY_PLAN_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "canaryContract": canary_contract,
+        "candidate": {
+            "deployRef": deploy_ref,
+            "id": candidate_id,
+            "scorecardRef": scorecard_ref,
+        },
+        "controlLoop": {
+            "conclusionRegistryRef": conclusion_registry_ref,
+            "conclusions": [
+                {"conclusionId": conclusion_id, "status": status}
+                for conclusion_id, status in (conclusion_records or [])
+            ],
+            "summary": conclusion_summary,
+        },
+        "createdAt": created,
+        "cpuGate": {
+            "sourceArtifact": cpu_baseline_ref,
+            "status": normalized_cpu,
+        },
+        "constructionGate": {
+            "postdeployHealthGateArtifact": postdeploy_health_gate_artifact,
+            "status": normalized_construction,
+        },
+        "incumbentBaseline": {
+            "kpiWindow": baseline,
+            "ref": incumbent_baseline_ref,
+        },
+        "issue": "#1583",
+        "mode": "planning_only",
+        "officialDeploy": {
+            "activeWorldRef": active_world_ref,
+            "activeWorldStatus": normalized_active_world,
+            "alert": postdeploy_alert,
+            "artifacts": {
+                "deploy": deploy_artifact,
+                "postdeployAlert": postdeploy_alert_artifact,
+                "postdeployHealthGate": postdeploy_health_gate_artifact,
+                "postdeploySummary": postdeploy_summary_artifact,
+            },
+            "head": official_deploy_head,
+            "healthGateOk": health_gate_ok,
+            "ownedCreeps": round_float(creep_count) if creep_count is not None else owned_creeps,
+            "ownedSpawns": round_float(spawn_count) if spawn_count is not None else owned_spawns,
+            "runId": official_deploy_run_id,
+        },
+        "readiness": {
+            "blockingReasons": blocking_reasons,
+            "nextAction": (
+                "controller may run the bounded canary dry-run/rollback gate with these refs"
+                if readiness_status == "ready"
+                else "do not launch canary; satisfy the blocking readiness reasons first"
+            ),
+            "status": readiness_status,
+        },
+        "rollbackTrigger": rollback_trigger_spec(),
+        "safetyGuards": safety,
     }
 
 
@@ -1054,6 +1419,59 @@ def build_parser() -> argparse.ArgumentParser:
     contract = subparsers.add_parser("contract", help="Print the KPI rollout gate contract.")
     contract.add_argument("--output", type=Path, help="Write JSON output to this path instead of stdout.")
 
+    canary_plan = subparsers.add_parser(
+        "canary-plan",
+        help="Build a planning-only bounded live canary readiness record.",
+    )
+    canary_plan.add_argument("--baseline", type=Path, help="Incumbent baseline KPI JSON fixture/report.")
+    canary_plan.add_argument("--candidate-id", help="Candidate strategy/model identifier.")
+    canary_plan.add_argument("--deploy-ref", help="Candidate deploy reference or bundle ref.")
+    canary_plan.add_argument("--scorecard-ref", help="Candidate-vs-baseline scorecard artifact ref.")
+    canary_plan.add_argument("--active-world-ref", help="Active world branch/ref observed after official deploy.")
+    canary_plan.add_argument(
+        "--active-world-status",
+        help="Expected to be matched_main after postdeploy evidence.",
+    )
+    canary_plan.add_argument("--official-deploy-head", help="Official deploy head SHA.")
+    canary_plan.add_argument("--official-deploy-run-id", help="Official deploy workflow run id.")
+    canary_plan.add_argument("--deploy-artifact", help="Official deploy JSON artifact path.")
+    canary_plan.add_argument("--postdeploy-summary-artifact", help="Postdeploy summary artifact path.")
+    canary_plan.add_argument("--postdeploy-health-gate-artifact", help="Postdeploy health-gate artifact path.")
+    canary_plan.add_argument("--postdeploy-alert-artifact", help="Postdeploy alert artifact path.")
+    canary_plan.add_argument("--health-gate-ok", type=parse_bool_arg, help="Whether the postdeploy health gate was ok.")
+    canary_plan.add_argument("--postdeploy-alert", type=parse_bool_arg, help="Whether the postdeploy alert fired.")
+    canary_plan.add_argument("--construction-acceptance-status", help="Postdeploy construction acceptance status.")
+    canary_plan.add_argument("--owned-spawns", type=float, help="Owned spawn count from postdeploy evidence.")
+    canary_plan.add_argument("--owned-creeps", type=float, help="Owned creep count from postdeploy evidence.")
+    canary_plan.add_argument("--cpu-baseline-status", help="CPU baseline gate status.")
+    canary_plan.add_argument("--cpu-baseline-ref", help="CPU baseline artifact/ref.")
+    canary_plan.add_argument("--conclusion-registry-ref", help="RL conclusion registry artifact/ref.")
+    canary_plan.add_argument("--conclusion-summary", help="Conclusion registry summary, for example ACTIONED=1,VALIDATING=1,CLOSED=2.")
+    canary_plan.add_argument(
+        "--conclusion",
+        action="append",
+        default=[],
+        type=parse_key_value_arg,
+        help="Conclusion status in CONCLUSION_ID=STATUS form. May be repeated.",
+    )
+    canary_plan.add_argument(
+        "--paid-compute-allowed",
+        action="store_true",
+        help="Record that paid compute would be allowed; this intentionally blocks readiness.",
+    )
+    canary_plan.add_argument(
+        "--official-mmo-write-allowed",
+        action="store_true",
+        help="Record that planning would allow official MMO writes; this intentionally blocks readiness.",
+    )
+    canary_plan.add_argument("--created-at", help="ISO UTC timestamp to record. Defaults to current UTC second.")
+    canary_plan.add_argument("--output", type=Path, help="Write JSON output to this path instead of stdout.")
+    add_canary_args(
+        canary_plan,
+        default_state="canary",
+        default_surface="bounded_high_level_strategy_knobs",
+    )
+
     dry_run = subparsers.add_parser("dry-run", help="Evaluate a dry-run rollout decision from pre/post KPI fixtures.")
     add_common_kpi_args(dry_run, "pre", "post")
     dry_run.add_argument("--candidate-id", help="Candidate strategy/model identifier.")
@@ -1100,6 +1518,46 @@ def main(argv: list[str] | None = None, stdout: TextIO = sys.stdout, stderr: Tex
     try:
         if args.command == "contract":
             write_output(build_gate_contract(), args.output, stdout)
+            return 0
+
+        if args.command == "canary-plan":
+            baseline = load_json(args.baseline) if args.baseline is not None else None
+            write_output(
+                build_canary_readiness_plan(
+                    active_world_ref=args.active_world_ref,
+                    active_world_status=args.active_world_status,
+                    baseline_raw=baseline,
+                    baseline_source=str(args.baseline) if args.baseline is not None else None,
+                    candidate_id=args.candidate_id,
+                    conclusion_records=args.conclusion,
+                    conclusion_registry_ref=args.conclusion_registry_ref,
+                    conclusion_summary=args.conclusion_summary,
+                    construction_acceptance_status=args.construction_acceptance_status,
+                    cpu_baseline_ref=args.cpu_baseline_ref,
+                    cpu_baseline_status=args.cpu_baseline_status,
+                    created_at=args.created_at,
+                    deploy_artifact=args.deploy_artifact,
+                    deploy_ref=args.deploy_ref,
+                    health_gate_ok=args.health_gate_ok,
+                    incumbent_baseline_ref=args.incumbent_baseline_ref,
+                    live_influence_state=args.live_influence_state,
+                    live_influence_surface=args.live_influence_surface,
+                    official_deploy_head=args.official_deploy_head,
+                    official_deploy_run_id=args.official_deploy_run_id,
+                    official_mmo_write_allowed=args.official_mmo_write_allowed,
+                    owned_creeps=args.owned_creeps,
+                    owned_spawns=args.owned_spawns,
+                    paid_compute_allowed=args.paid_compute_allowed,
+                    postdeploy_alert=args.postdeploy_alert,
+                    postdeploy_alert_artifact=args.postdeploy_alert_artifact,
+                    postdeploy_health_gate_artifact=args.postdeploy_health_gate_artifact,
+                    postdeploy_summary_artifact=args.postdeploy_summary_artifact,
+                    rollback_ref=args.rollback_ref,
+                    scorecard_ref=args.scorecard_ref,
+                ),
+                args.output,
+                stdout,
+            )
             return 0
 
         if args.command == "dry-run":

--- a/scripts/screeps_rl_rollout_manager.py
+++ b/scripts/screeps_rl_rollout_manager.py
@@ -963,6 +963,20 @@ def build_candidate_scorecard_gate(
             )
 
         scorecard_candidate_commit = scorecard_candidate.get("commit")
+        scorecard_candidate_deploy_ref = scorecard_candidate.get("deployRef")
+        if (
+            text_present(deploy_ref)
+            and not text_present(scorecard_candidate_commit)
+            and not text_present(scorecard_candidate_deploy_ref)
+        ):
+            reasons.append(
+                {
+                    "field": "candidate.scorecard.candidate.deployBinding",
+                    "reason": "missing_candidate_scorecard_deploy_binding",
+                    "required": deploy_ref,
+                    "scope": "scorecardGate",
+                }
+            )
         if (
             text_present(scorecard_candidate_commit)
             and text_present(deploy_ref)
@@ -978,7 +992,6 @@ def build_candidate_scorecard_gate(
                 }
             )
 
-        scorecard_candidate_deploy_ref = scorecard_candidate.get("deployRef")
         if (
             text_present(scorecard_candidate_deploy_ref)
             and text_present(deploy_ref)

--- a/scripts/screeps_rl_rollout_manager.py
+++ b/scripts/screeps_rl_rollout_manager.py
@@ -904,6 +904,7 @@ def build_candidate_scorecard_gate(
     *,
     candidate_id: str | None = None,
     deploy_ref: str | None = None,
+    incumbent_baseline_ref: str | None = None,
 ) -> JsonObject:
     reasons: list[JsonObject] = []
     overall_status: str | None = None
@@ -1003,6 +1004,52 @@ def build_candidate_scorecard_gate(
                     "field": "candidate.scorecard.candidate.deployRef",
                     "reason": "candidate_scorecard_candidate_deploy_ref_mismatch",
                     "required": deploy_ref,
+                    "scope": "scorecardGate",
+                }
+            )
+
+        scorecard_baseline = scorecard_raw.get("baseline")
+        scorecard_baseline = scorecard_baseline if isinstance(scorecard_baseline, dict) else {}
+        scorecard_baseline_commit = scorecard_baseline.get("commit")
+        scorecard_baseline_deploy_ref = scorecard_baseline.get("deployRef")
+        if (
+            text_present(incumbent_baseline_ref)
+            and not text_present(scorecard_baseline_commit)
+            and not text_present(scorecard_baseline_deploy_ref)
+        ):
+            reasons.append(
+                {
+                    "field": "candidate.scorecard.baseline.binding",
+                    "reason": "missing_candidate_scorecard_baseline_binding",
+                    "required": incumbent_baseline_ref,
+                    "scope": "scorecardGate",
+                }
+            )
+        if (
+            text_present(scorecard_baseline_commit)
+            and text_present(incumbent_baseline_ref)
+            and scorecard_baseline_commit != incumbent_baseline_ref
+        ):
+            reasons.append(
+                {
+                    "actual": scorecard_baseline_commit,
+                    "field": "candidate.scorecard.baseline.commit",
+                    "reason": "candidate_scorecard_baseline_commit_mismatch",
+                    "required": incumbent_baseline_ref,
+                    "scope": "scorecardGate",
+                }
+            )
+        if (
+            text_present(scorecard_baseline_deploy_ref)
+            and text_present(incumbent_baseline_ref)
+            and scorecard_baseline_deploy_ref != incumbent_baseline_ref
+        ):
+            reasons.append(
+                {
+                    "actual": scorecard_baseline_deploy_ref,
+                    "field": "candidate.scorecard.baseline.deployRef",
+                    "reason": "candidate_scorecard_baseline_deploy_ref_mismatch",
+                    "required": incumbent_baseline_ref,
                     "scope": "scorecardGate",
                 }
             )
@@ -1176,6 +1223,7 @@ def build_canary_readiness_plan(
         scorecard_ref,
         candidate_id=candidate_id,
         deploy_ref=deploy_ref,
+        incumbent_baseline_ref=incumbent_baseline_ref,
     )
 
     blocking_reasons: list[JsonObject] = []

--- a/scripts/screeps_rl_rollout_manager.py
+++ b/scripts/screeps_rl_rollout_manager.py
@@ -21,6 +21,7 @@ CONTRACT_VERSION = 1
 CONTRACT_TYPE = "screeps-rl-rollout-gate-contract"
 CANARY_CONTRACT_TYPE = "screeps-rl-safe-canary-contract"
 CANARY_PLAN_TYPE = "screeps-rl-bounded-live-canary-plan"
+SCORECARD_TYPE = "screeps-rl-evaluation-scorecard"
 COMPARISON_TYPE = "screeps-rl-post-rollout-kpi-comparison"
 DECISION_TYPE = "screeps-rl-rollout-decision"
 ROLLBACK_TYPE = "screeps-rl-rollback-check"
@@ -34,6 +35,14 @@ DEFAULT_LIVE_INFLUENCE_SURFACE = "none"
 LIVE_INFLUENCE_STATES_REQUIRING_REFS = ("canary", "active", "rolled_back")
 CANARY_PLAN_PASS_STATUSES = ("pass", "passed", "ok", "stable", "ready")
 CANARY_PLAN_ACTIVE_WORLD_STATUS = "matched_main"
+CANARY_PLAN_SCORECARD_PASS_STATUS = "PASS"
+CANARY_PLAN_SCORECARD_STATUS_VALUES = (
+    CANARY_PLAN_SCORECARD_PASS_STATUS,
+    "HOLD",
+    "MIXED",
+    "ROLLBACK_REQUIRED",
+    "INCONCLUSIVE",
+)
 ALLOWED_LIVE_INFLUENCE_SURFACES: dict[str, JsonObject] = {
     "none": {
         "description": "no learned/tuned candidate influence reaches official MMO behavior",
@@ -164,6 +173,13 @@ def normalize_status_text(value: str | None) -> str | None:
 def status_is_pass(value: str | None) -> bool:
     normalized = normalize_status_text(value)
     return normalized in CANARY_PLAN_PASS_STATUSES if normalized is not None else False
+
+
+def normalize_scorecard_status(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().upper().replace("-", "_").replace(" ", "_")
+    return normalized or None
 
 
 def text_present(value: Any) -> bool:
@@ -882,6 +898,151 @@ def canary_plan_text_blocking_reasons(fields: tuple[tuple[str, Any, str], ...]) 
     ]
 
 
+def build_candidate_scorecard_gate(scorecard_raw: JsonObject | None, scorecard_ref: str | None) -> JsonObject:
+    reasons: list[JsonObject] = []
+    overall_status: str | None = None
+    safety_regressions: list[Any] = []
+    non_safety_regressions: list[Any] = []
+    runtime_gate: JsonObject = {}
+    monotonic: JsonObject = {}
+
+    if not text_present(scorecard_ref):
+        reasons.append(
+            {
+                "field": "candidate.scorecardRef",
+                "reason": "missing_candidate_scorecard_ref",
+                "scope": "scorecardGate",
+            }
+        )
+    elif scorecard_raw is None:
+        reasons.append(
+            {
+                "field": "candidate.scorecardRef",
+                "reason": "missing_candidate_scorecard_artifact",
+                "scope": "scorecardGate",
+            }
+        )
+    else:
+        if scorecard_raw.get("type") != SCORECARD_TYPE:
+            reasons.append(
+                {
+                    "actual": scorecard_raw.get("type"),
+                    "field": "candidate.scorecard.type",
+                    "reason": "invalid_candidate_scorecard_type",
+                    "required": SCORECARD_TYPE,
+                    "scope": "scorecardGate",
+                }
+            )
+
+        overall_gate = scorecard_raw.get("overallGate")
+        if not isinstance(overall_gate, dict):
+            reasons.append(
+                {
+                    "field": "candidate.scorecard.overallGate",
+                    "reason": "missing_candidate_scorecard_overall_gate",
+                    "scope": "scorecardGate",
+                }
+            )
+            overall_gate = {}
+
+        overall_status = normalize_scorecard_status(overall_gate.get("status"))
+        if overall_status != CANARY_PLAN_SCORECARD_PASS_STATUS:
+            reasons.append(
+                {
+                    "actual": overall_status,
+                    "allowedStatusValues": list(CANARY_PLAN_SCORECARD_STATUS_VALUES),
+                    "field": "candidate.scorecard.overallGate.status",
+                    "reason": "candidate_scorecard_status_must_pass",
+                    "required": CANARY_PLAN_SCORECARD_PASS_STATUS,
+                    "scope": "scorecardGate",
+                }
+            )
+
+        raw_safety_regressions = overall_gate.get("safetyRegressions")
+        safety_regressions = list(raw_safety_regressions) if isinstance(raw_safety_regressions, list) else []
+        if safety_regressions:
+            reasons.append(
+                {
+                    "actual": safety_regressions,
+                    "field": "candidate.scorecard.overallGate.safetyRegressions",
+                    "reason": "candidate_scorecard_safety_regressions",
+                    "required": [],
+                    "scope": "scorecardGate",
+                }
+            )
+
+        raw_non_safety_regressions = overall_gate.get("nonSafetyRegressions")
+        non_safety_regressions = (
+            list(raw_non_safety_regressions) if isinstance(raw_non_safety_regressions, list) else []
+        )
+        if non_safety_regressions:
+            reasons.append(
+                {
+                    "actual": non_safety_regressions,
+                    "field": "candidate.scorecard.overallGate.nonSafetyRegressions",
+                    "reason": "candidate_scorecard_dimension_regressions",
+                    "required": [],
+                    "scope": "scorecardGate",
+                }
+            )
+
+        raw_runtime_gate = overall_gate.get("runtimeCandidateGate")
+        runtime_gate = dict(raw_runtime_gate) if isinstance(raw_runtime_gate, dict) else {}
+        raw_monotonic = overall_gate.get("monotonic")
+        monotonic = dict(raw_monotonic) if isinstance(raw_monotonic, dict) else {}
+
+        if not safety_regressions and monotonic.get("noSafetyRegression") is not True:
+            reasons.append(
+                {
+                    "actual": monotonic.get("noSafetyRegression"),
+                    "field": "candidate.scorecard.overallGate.monotonic.noSafetyRegression",
+                    "reason": "candidate_scorecard_no_safety_regression_not_proven",
+                    "required": True,
+                    "scope": "scorecardGate",
+                }
+            )
+        if not non_safety_regressions and monotonic.get("noDimensionRegression") is not True:
+            reasons.append(
+                {
+                    "actual": monotonic.get("noDimensionRegression"),
+                    "field": "candidate.scorecard.overallGate.monotonic.noDimensionRegression",
+                    "reason": "candidate_scorecard_no_dimension_regression_not_proven",
+                    "required": True,
+                    "scope": "scorecardGate",
+                }
+            )
+
+        runtime_injection_proven = (
+            runtime_gate.get("runtimeParameterInjection") is True
+            and runtime_gate.get("runtimeParameterConsumption") is True
+            and monotonic.get("runtimeParameterInjectionProven") is True
+        )
+        if not runtime_injection_proven:
+            reasons.append(
+                {
+                    "actual": {
+                        "runtimeParameterConsumption": runtime_gate.get("runtimeParameterConsumption"),
+                        "runtimeParameterInjection": runtime_gate.get("runtimeParameterInjection"),
+                        "runtimeParameterInjectionProven": monotonic.get("runtimeParameterInjectionProven"),
+                    },
+                    "field": "candidate.scorecard.overallGate.runtimeCandidateGate",
+                    "reason": "candidate_scorecard_runtime_injection_not_proven",
+                    "required": True,
+                    "scope": "scorecardGate",
+                }
+            )
+
+    return {
+        "blockingReasons": reasons,
+        "nonSafetyRegressions": non_safety_regressions,
+        "overallStatus": overall_status,
+        "runtimeCandidateGate": runtime_gate,
+        "safetyRegressions": safety_regressions,
+        "sourceArtifact": scorecard_ref,
+        "status": "hold" if reasons else "pass",
+    }
+
+
 def build_canary_readiness_plan(
     *,
     active_world_ref: str | None = None,
@@ -913,6 +1074,7 @@ def build_canary_readiness_plan(
     postdeploy_health_gate_artifact: str | None = None,
     postdeploy_summary_artifact: str | None = None,
     rollback_ref: str | None = None,
+    scorecard_raw: JsonObject | None = None,
     scorecard_ref: str | None = None,
 ) -> JsonObject:
     created = created_at or utc_now_iso()
@@ -936,15 +1098,16 @@ def build_canary_readiness_plan(
     normalized_cpu = normalize_status_text(cpu_baseline_status)
     spawn_count = number_or_none(owned_spawns)
     creep_count = number_or_none(owned_creeps)
+    scorecard_gate = build_candidate_scorecard_gate(scorecard_raw, scorecard_ref)
 
     blocking_reasons: list[JsonObject] = []
     blocking_reasons.extend(baseline["blockingReasons"])
     blocking_reasons.extend(canary_blocking_reasons(canary_contract))
+    blocking_reasons.extend(scorecard_gate["blockingReasons"])
     blocking_reasons.extend(canary_plan_safety_blocking_reasons(safety))
     blocking_reasons.extend(
         canary_plan_text_blocking_reasons(
             (
-                ("candidate.scorecardRef", scorecard_ref, "missing_candidate_scorecard_ref"),
                 ("controlLoop.conclusionRegistryRef", conclusion_registry_ref, "missing_conclusion_registry_ref"),
                 ("officialDeploy.head", official_deploy_head, "missing_official_deploy_head"),
                 ("officialDeploy.runId", official_deploy_run_id, "missing_official_deploy_run_id"),
@@ -1065,6 +1228,7 @@ def build_canary_readiness_plan(
             "sourceArtifact": cpu_baseline_ref,
             "status": normalized_cpu,
         },
+        "scorecardGate": scorecard_gate,
         "constructionGate": {
             "postdeployHealthGateArtifact": postdeploy_health_gate_artifact,
             "status": normalized_construction,
@@ -1522,6 +1686,7 @@ def main(argv: list[str] | None = None, stdout: TextIO = sys.stdout, stderr: Tex
 
         if args.command == "canary-plan":
             baseline = load_json(args.baseline) if args.baseline is not None else None
+            scorecard = load_json(Path(args.scorecard_ref)) if text_present(args.scorecard_ref) else None
             write_output(
                 build_canary_readiness_plan(
                     active_world_ref=args.active_world_ref,
@@ -1553,6 +1718,7 @@ def main(argv: list[str] | None = None, stdout: TextIO = sys.stdout, stderr: Tex
                     postdeploy_health_gate_artifact=args.postdeploy_health_gate_artifact,
                     postdeploy_summary_artifact=args.postdeploy_summary_artifact,
                     rollback_ref=args.rollback_ref,
+                    scorecard_raw=scorecard,
                     scorecard_ref=args.scorecard_ref,
                 ),
                 args.output,

--- a/scripts/test_screeps_rl_rollout_manager.py
+++ b/scripts/test_screeps_rl_rollout_manager.py
@@ -148,6 +148,78 @@ class RlRolloutManagerTest(unittest.TestCase):
         self.assertIn("constructionPriority.extensionWeight", canary["strategyKnobLimits"])
         self.assertTrue(canary["validators"]["deterministicVetoRequired"])
 
+    def test_canary_readiness_plan_records_ready_controller_handoff(self) -> None:
+        plan = manager.build_canary_readiness_plan(
+            active_world_ref="14df4ae442fb68e1273aa69c182daa0328e2d868",
+            active_world_status="matched_main",
+            baseline_raw=kpi_window(),
+            baseline_source="runtime-artifacts/rl-control-loop/baselines/incumbent.json",
+            candidate_id="candidate-top-construction",
+            conclusion_records=[
+                ("RL-CONC-20260612-004", "VALIDATING"),
+                ("RL-CONC-20260610-002", "ACTIONED"),
+            ],
+            conclusion_registry_ref="runtime-artifacts/rl-control-loop/conclusion-registry.json",
+            conclusion_summary="ACTIONED=1,VALIDATING=1,CLOSED=2",
+            construction_acceptance_status="pass",
+            cpu_baseline_ref="runtime-artifacts/rl-control-loop/cpu-baseline.json",
+            cpu_baseline_status="pass",
+            created_at="2026-06-15T00:00:00Z",
+            deploy_artifact="runtime-artifacts/official-screeps-deploy/official-screeps-deploy-27530460405.json",
+            deploy_ref="candidate-ref",
+            health_gate_ok=True,
+            incumbent_baseline_ref="incumbent-ref",
+            official_deploy_head="14df4ae442fb68e1273aa69c182daa0328e2d868",
+            official_deploy_run_id="27530460405",
+            owned_creeps=5,
+            owned_spawns=1,
+            postdeploy_alert=False,
+            postdeploy_alert_artifact="runtime-artifacts/official-screeps-deploy/postdeploy-alert-27530460405.json",
+            postdeploy_health_gate_artifact="runtime-artifacts/official-screeps-deploy/postdeploy-health-gate-27530460405.json",
+            postdeploy_summary_artifact="runtime-artifacts/official-screeps-deploy/postdeploy-summary-27530460405.json",
+            rollback_ref="rollback-ref",
+            scorecard_ref="runtime-artifacts/rl-control-loop/scorecards/candidate-top-construction.json",
+        )
+
+        self.assertEqual(plan["type"], manager.CANARY_PLAN_TYPE)
+        self.assertEqual(plan["issue"], "#1583")
+        self.assertEqual(plan["readiness"]["status"], "ready")
+        self.assertEqual(plan["readiness"]["blockingReasons"], [])
+        self.assertFalse(plan["safetyGuards"]["paidComputeAllowed"])
+        self.assertFalse(plan["safetyGuards"]["officialMmoWritesAllowedDuringPlanning"])
+        self.assertFalse(plan["safetyGuards"]["deploysCode"])
+        self.assertEqual(plan["constructionGate"]["status"], "pass")
+        self.assertEqual(plan["cpuGate"]["status"], "pass")
+        self.assertEqual(plan["officialDeploy"]["ownedSpawns"], 1)
+        self.assertEqual(plan["controlLoop"]["conclusions"][0]["conclusionId"], "RL-CONC-20260612-004")
+        self.assertEqual(plan["canaryContract"]["validation"]["status"], "pass")
+        self.assertEqual(plan["incumbentBaseline"]["kpiWindow"]["observation"]["status"], "pass")
+
+    def test_canary_readiness_plan_holds_without_required_gates_or_safety(self) -> None:
+        plan = manager.build_canary_readiness_plan(
+            active_world_status="stale",
+            baseline_raw=kpi_window(hours=1, samples=1),
+            candidate_id="candidate-held",
+            deploy_ref="candidate-ref",
+            health_gate_ok=False,
+            incumbent_baseline_ref="incumbent-ref",
+            paid_compute_allowed=True,
+            postdeploy_alert=True,
+            rollback_ref="rollback-ref",
+        )
+
+        reasons = plan["readiness"]["blockingReasons"]
+        self.assertEqual(plan["readiness"]["status"], "hold")
+        self.assertTrue(any(reason.get("reason") == "duration_below_observation_window" for reason in reasons))
+        self.assertTrue(any(reason.get("reason") == "samples_below_minimum" for reason in reasons))
+        self.assertTrue(any(reason.get("reason") == "missing_candidate_scorecard_ref" for reason in reasons))
+        self.assertTrue(any(reason.get("reason") == "missing_conclusion_registry_ref" for reason in reasons))
+        self.assertTrue(any(reason.get("reason") == "paid_compute_must_remain_held" for reason in reasons))
+        self.assertTrue(any(reason.get("reason") == "postdeploy_health_gate_must_be_ok" for reason in reasons))
+        self.assertTrue(any(reason.get("reason") == "postdeploy_alert_must_be_false" for reason in reasons))
+        self.assertTrue(any(reason.get("reason") == "cpu_baseline_must_pass" for reason in reasons))
+        self.assertTrue(any(reason.get("reason") == "construction_acceptance_must_pass" for reason in reasons))
+
     def test_canary_contract_rejects_forbidden_surface_and_missing_rollback_ref(self) -> None:
         forbidden = manager.build_dry_run_decision(
             kpi_window(),
@@ -354,6 +426,82 @@ class RlRolloutManagerTest(unittest.TestCase):
         self.assertEqual(decision["candidate"]["id"], "fixture-candidate")
         self.assertEqual(decision["comparison"]["metrics"]["resources"]["delta"], 300)
         self.assertEqual(decision["comparison"]["pre"]["metrics"]["reliability"], 1)
+
+    def test_canary_plan_cli_writes_planning_record(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            baseline_path = root / "baseline.json"
+            output_path = root / "canary-plan.json"
+            write_json(baseline_path, kpi_window())
+
+            exit_code = manager.main(
+                [
+                    "canary-plan",
+                    "--baseline",
+                    str(baseline_path),
+                    "--candidate-id",
+                    "candidate-cli",
+                    "--deploy-ref",
+                    "candidate-ref",
+                    "--scorecard-ref",
+                    "runtime-artifacts/rl-control-loop/scorecards/candidate-cli.json",
+                    "--incumbent-baseline-ref",
+                    "incumbent-ref",
+                    "--rollback-ref",
+                    "rollback-ref",
+                    "--active-world-ref",
+                    "14df4ae442fb68e1273aa69c182daa0328e2d868",
+                    "--active-world-status",
+                    "matched_main",
+                    "--official-deploy-head",
+                    "14df4ae442fb68e1273aa69c182daa0328e2d868",
+                    "--official-deploy-run-id",
+                    "27530460405",
+                    "--deploy-artifact",
+                    "runtime-artifacts/official-screeps-deploy/official-screeps-deploy-27530460405.json",
+                    "--postdeploy-summary-artifact",
+                    "runtime-artifacts/official-screeps-deploy/postdeploy-summary-27530460405.json",
+                    "--postdeploy-health-gate-artifact",
+                    "runtime-artifacts/official-screeps-deploy/postdeploy-health-gate-27530460405.json",
+                    "--postdeploy-alert-artifact",
+                    "runtime-artifacts/official-screeps-deploy/postdeploy-alert-27530460405.json",
+                    "--health-gate-ok",
+                    "true",
+                    "--postdeploy-alert",
+                    "false",
+                    "--construction-acceptance-status",
+                    "pass",
+                    "--owned-spawns",
+                    "1",
+                    "--owned-creeps",
+                    "5",
+                    "--cpu-baseline-status",
+                    "pass",
+                    "--cpu-baseline-ref",
+                    "runtime-artifacts/rl-control-loop/cpu-baseline.json",
+                    "--conclusion-registry-ref",
+                    "runtime-artifacts/rl-control-loop/conclusion-registry.json",
+                    "--conclusion-summary",
+                    "ACTIONED=1,VALIDATING=1,CLOSED=2",
+                    "--conclusion",
+                    "RL-CONC-20260612-004=VALIDATING",
+                    "--conclusion",
+                    "RL-CONC-20260610-002=ACTIONED",
+                    "--created-at",
+                    "2026-06-15T00:00:00Z",
+                    "--output",
+                    str(output_path),
+                ],
+                stdout=StringIO(),
+            )
+
+            self.assertEqual(exit_code, 0)
+            plan = json.loads(output_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(plan["readiness"]["status"], "ready")
+        self.assertEqual(plan["mode"], "planning_only")
+        self.assertEqual(plan["officialDeploy"]["runId"], "27530460405")
+        self.assertEqual(plan["controlLoop"]["summary"], "ACTIONED=1,VALIDATING=1,CLOSED=2")
 
 
 if __name__ == "__main__":

--- a/scripts/test_screeps_rl_rollout_manager.py
+++ b/scripts/test_screeps_rl_rollout_manager.py
@@ -105,6 +105,77 @@ def reducer_report(
     }
 
 
+def scorecard_artifact(
+    *,
+    status: str = "PASS",
+    runtime_injection: bool = True,
+    runtime_consumption: bool = True,
+    safety_regressions: list[str] | None = None,
+    non_safety_regressions: list[str] | None = None,
+) -> JsonObject:
+    safety_regressions = list(safety_regressions or [])
+    non_safety_regressions = list(non_safety_regressions or [])
+    return {
+        "type": manager.SCORECARD_TYPE,
+        "overallGate": {
+            "status": status,
+            "runtimeCandidateGate": {
+                "runtimeParameterConsumption": runtime_consumption,
+                "runtimeParameterInjection": runtime_injection,
+                "status": "injected" if runtime_injection and runtime_consumption else "missing",
+            },
+            "monotonic": {
+                "noDimensionRegression": not safety_regressions and not non_safety_regressions,
+                "noSafetyRegression": not safety_regressions,
+                "runtimeParameterInjectionProven": runtime_injection and runtime_consumption,
+            },
+            "nonSafetyRegressions": non_safety_regressions,
+            "safetyRegressions": safety_regressions,
+        },
+    }
+
+
+def ready_canary_plan_kwargs(
+    *,
+    scorecard_raw: JsonObject | None = None,
+    scorecard_ref: str = "runtime-artifacts/rl-control-loop/scorecards/candidate-top-construction.json",
+) -> JsonObject:
+    return {
+        "active_world_ref": "14df4ae442fb68e1273aa69c182daa0328e2d868",
+        "active_world_status": "matched_main",
+        "baseline_raw": kpi_window(),
+        "baseline_source": "runtime-artifacts/rl-control-loop/baselines/incumbent.json",
+        "candidate_id": "candidate-top-construction",
+        "conclusion_records": [
+            ("RL-CONC-20260612-004", "VALIDATING"),
+            ("RL-CONC-20260610-002", "ACTIONED"),
+        ],
+        "conclusion_registry_ref": "runtime-artifacts/rl-control-loop/conclusion-registry.json",
+        "conclusion_summary": "ACTIONED=1,VALIDATING=1,CLOSED=2",
+        "construction_acceptance_status": "pass",
+        "cpu_baseline_ref": "runtime-artifacts/rl-control-loop/cpu-baseline.json",
+        "cpu_baseline_status": "pass",
+        "created_at": "2026-06-15T00:00:00Z",
+        "deploy_artifact": "runtime-artifacts/official-screeps-deploy/official-screeps-deploy-27530460405.json",
+        "deploy_ref": "candidate-ref",
+        "health_gate_ok": True,
+        "incumbent_baseline_ref": "incumbent-ref",
+        "official_deploy_head": "14df4ae442fb68e1273aa69c182daa0328e2d868",
+        "official_deploy_run_id": "27530460405",
+        "owned_creeps": 5,
+        "owned_spawns": 1,
+        "postdeploy_alert": False,
+        "postdeploy_alert_artifact": "runtime-artifacts/official-screeps-deploy/postdeploy-alert-27530460405.json",
+        "postdeploy_health_gate_artifact": (
+            "runtime-artifacts/official-screeps-deploy/postdeploy-health-gate-27530460405.json"
+        ),
+        "postdeploy_summary_artifact": "runtime-artifacts/official-screeps-deploy/postdeploy-summary-27530460405.json",
+        "rollback_ref": "rollback-ref",
+        "scorecard_raw": scorecard_raw if scorecard_raw is not None else scorecard_artifact(),
+        "scorecard_ref": scorecard_ref,
+    }
+
+
 class RlRolloutManagerTest(unittest.TestCase):
     def test_dry_run_passes_when_all_kpis_stay_within_contract(self) -> None:
         decision = manager.build_dry_run_decision(
@@ -149,42 +220,14 @@ class RlRolloutManagerTest(unittest.TestCase):
         self.assertTrue(canary["validators"]["deterministicVetoRequired"])
 
     def test_canary_readiness_plan_records_ready_controller_handoff(self) -> None:
-        plan = manager.build_canary_readiness_plan(
-            active_world_ref="14df4ae442fb68e1273aa69c182daa0328e2d868",
-            active_world_status="matched_main",
-            baseline_raw=kpi_window(),
-            baseline_source="runtime-artifacts/rl-control-loop/baselines/incumbent.json",
-            candidate_id="candidate-top-construction",
-            conclusion_records=[
-                ("RL-CONC-20260612-004", "VALIDATING"),
-                ("RL-CONC-20260610-002", "ACTIONED"),
-            ],
-            conclusion_registry_ref="runtime-artifacts/rl-control-loop/conclusion-registry.json",
-            conclusion_summary="ACTIONED=1,VALIDATING=1,CLOSED=2",
-            construction_acceptance_status="pass",
-            cpu_baseline_ref="runtime-artifacts/rl-control-loop/cpu-baseline.json",
-            cpu_baseline_status="pass",
-            created_at="2026-06-15T00:00:00Z",
-            deploy_artifact="runtime-artifacts/official-screeps-deploy/official-screeps-deploy-27530460405.json",
-            deploy_ref="candidate-ref",
-            health_gate_ok=True,
-            incumbent_baseline_ref="incumbent-ref",
-            official_deploy_head="14df4ae442fb68e1273aa69c182daa0328e2d868",
-            official_deploy_run_id="27530460405",
-            owned_creeps=5,
-            owned_spawns=1,
-            postdeploy_alert=False,
-            postdeploy_alert_artifact="runtime-artifacts/official-screeps-deploy/postdeploy-alert-27530460405.json",
-            postdeploy_health_gate_artifact="runtime-artifacts/official-screeps-deploy/postdeploy-health-gate-27530460405.json",
-            postdeploy_summary_artifact="runtime-artifacts/official-screeps-deploy/postdeploy-summary-27530460405.json",
-            rollback_ref="rollback-ref",
-            scorecard_ref="runtime-artifacts/rl-control-loop/scorecards/candidate-top-construction.json",
-        )
+        plan = manager.build_canary_readiness_plan(**ready_canary_plan_kwargs())
 
         self.assertEqual(plan["type"], manager.CANARY_PLAN_TYPE)
         self.assertEqual(plan["issue"], "#1583")
         self.assertEqual(plan["readiness"]["status"], "ready")
         self.assertEqual(plan["readiness"]["blockingReasons"], [])
+        self.assertEqual(plan["scorecardGate"]["status"], "pass")
+        self.assertEqual(plan["scorecardGate"]["overallStatus"], "PASS")
         self.assertFalse(plan["safetyGuards"]["paidComputeAllowed"])
         self.assertFalse(plan["safetyGuards"]["officialMmoWritesAllowedDuringPlanning"])
         self.assertFalse(plan["safetyGuards"]["deploysCode"])
@@ -194,6 +237,44 @@ class RlRolloutManagerTest(unittest.TestCase):
         self.assertEqual(plan["controlLoop"]["conclusions"][0]["conclusionId"], "RL-CONC-20260612-004")
         self.assertEqual(plan["canaryContract"]["validation"]["status"], "pass")
         self.assertEqual(plan["incumbentBaseline"]["kpiWindow"]["observation"]["status"], "pass")
+
+    def test_canary_readiness_plan_holds_for_rejected_scorecard_outcomes(self) -> None:
+        for status in ("HOLD", "MIXED", "ROLLBACK_REQUIRED"):
+            with self.subTest(status=status):
+                plan = manager.build_canary_readiness_plan(
+                    **ready_canary_plan_kwargs(scorecard_raw=scorecard_artifact(status=status))
+                )
+
+                reasons = plan["readiness"]["blockingReasons"]
+                self.assertEqual(plan["readiness"]["status"], "hold")
+                self.assertEqual(plan["scorecardGate"]["overallStatus"], status)
+                self.assertTrue(
+                    any(reason.get("reason") == "candidate_scorecard_status_must_pass" for reason in reasons)
+                )
+
+    def test_canary_readiness_plan_holds_for_scorecard_safety_regression(self) -> None:
+        plan = manager.build_canary_readiness_plan(
+            **ready_canary_plan_kwargs(
+                scorecard_raw=scorecard_artifact(safety_regressions=["safety_reliability_floor"])
+            )
+        )
+
+        reasons = plan["readiness"]["blockingReasons"]
+        self.assertEqual(plan["readiness"]["status"], "hold")
+        self.assertTrue(any(reason.get("reason") == "candidate_scorecard_safety_regressions" for reason in reasons))
+
+    def test_canary_readiness_plan_holds_without_scorecard_runtime_injection(self) -> None:
+        plan = manager.build_canary_readiness_plan(
+            **ready_canary_plan_kwargs(
+                scorecard_raw=scorecard_artifact(runtime_injection=False, runtime_consumption=False)
+            )
+        )
+
+        reasons = plan["readiness"]["blockingReasons"]
+        self.assertEqual(plan["readiness"]["status"], "hold")
+        self.assertTrue(
+            any(reason.get("reason") == "candidate_scorecard_runtime_injection_not_proven" for reason in reasons)
+        )
 
     def test_canary_readiness_plan_holds_without_required_gates_or_safety(self) -> None:
         plan = manager.build_canary_readiness_plan(
@@ -431,8 +512,10 @@ class RlRolloutManagerTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             baseline_path = root / "baseline.json"
+            scorecard_path = root / "scorecard.json"
             output_path = root / "canary-plan.json"
             write_json(baseline_path, kpi_window())
+            write_json(scorecard_path, scorecard_artifact())
 
             exit_code = manager.main(
                 [
@@ -444,7 +527,7 @@ class RlRolloutManagerTest(unittest.TestCase):
                     "--deploy-ref",
                     "candidate-ref",
                     "--scorecard-ref",
-                    "runtime-artifacts/rl-control-loop/scorecards/candidate-cli.json",
+                    str(scorecard_path),
                     "--incumbent-baseline-ref",
                     "incumbent-ref",
                     "--rollback-ref",
@@ -501,6 +584,7 @@ class RlRolloutManagerTest(unittest.TestCase):
         self.assertEqual(plan["readiness"]["status"], "ready")
         self.assertEqual(plan["mode"], "planning_only")
         self.assertEqual(plan["officialDeploy"]["runId"], "27530460405")
+        self.assertEqual(plan["scorecardGate"]["overallStatus"], "PASS")
         self.assertEqual(plan["controlLoop"]["summary"], "ACTIONED=1,VALIDATING=1,CLOSED=2")
 
 

--- a/scripts/test_screeps_rl_rollout_manager.py
+++ b/scripts/test_screeps_rl_rollout_manager.py
@@ -107,6 +107,9 @@ def reducer_report(
 
 def scorecard_artifact(
     *,
+    candidate_commit: str | None = "candidate-ref",
+    candidate_deploy_ref: str | None = None,
+    candidate_id: str | None = "candidate-top-construction",
     status: str = "PASS",
     runtime_injection: bool = True,
     runtime_consumption: bool = True,
@@ -115,7 +118,7 @@ def scorecard_artifact(
 ) -> JsonObject:
     safety_regressions = list(safety_regressions or [])
     non_safety_regressions = list(non_safety_regressions or [])
-    return {
+    artifact: JsonObject = {
         "type": manager.SCORECARD_TYPE,
         "overallGate": {
             "status": status,
@@ -133,6 +136,16 @@ def scorecard_artifact(
             "safetyRegressions": safety_regressions,
         },
     }
+    candidate: JsonObject = {}
+    if candidate_id is not None:
+        candidate["id"] = candidate_id
+    if candidate_commit is not None:
+        candidate["commit"] = candidate_commit
+    if candidate_deploy_ref is not None:
+        candidate["deployRef"] = candidate_deploy_ref
+    if candidate:
+        artifact["candidate"] = candidate
+    return artifact
 
 
 def ready_canary_plan_kwargs(
@@ -275,6 +288,34 @@ class RlRolloutManagerTest(unittest.TestCase):
         self.assertTrue(
             any(reason.get("reason") == "candidate_scorecard_runtime_injection_not_proven" for reason in reasons)
         )
+
+    def test_canary_readiness_plan_holds_for_scorecard_candidate_mismatch(self) -> None:
+        plan = manager.build_canary_readiness_plan(
+            **ready_canary_plan_kwargs(scorecard_raw=scorecard_artifact(candidate_id="other-candidate"))
+        )
+
+        reasons = plan["readiness"]["blockingReasons"]
+        self.assertEqual(plan["readiness"]["status"], "hold")
+        self.assertTrue(
+            any(reason.get("reason") == "candidate_scorecard_candidate_id_mismatch" for reason in reasons)
+        )
+
+    def test_canary_readiness_plan_holds_for_scorecard_deploy_ref_mismatch(self) -> None:
+        for artifact_kwargs, expected_reason in (
+            ({"candidate_commit": "other-ref"}, "candidate_scorecard_candidate_commit_mismatch"),
+            (
+                {"candidate_commit": None, "candidate_deploy_ref": "other-ref"},
+                "candidate_scorecard_candidate_deploy_ref_mismatch",
+            ),
+        ):
+            with self.subTest(expected_reason=expected_reason):
+                plan = manager.build_canary_readiness_plan(
+                    **ready_canary_plan_kwargs(scorecard_raw=scorecard_artifact(**artifact_kwargs))
+                )
+
+                reasons = plan["readiness"]["blockingReasons"]
+                self.assertEqual(plan["readiness"]["status"], "hold")
+                self.assertTrue(any(reason.get("reason") == expected_reason for reason in reasons))
 
     def test_canary_readiness_plan_holds_without_required_gates_or_safety(self) -> None:
         plan = manager.build_canary_readiness_plan(
@@ -515,7 +556,7 @@ class RlRolloutManagerTest(unittest.TestCase):
             scorecard_path = root / "scorecard.json"
             output_path = root / "canary-plan.json"
             write_json(baseline_path, kpi_window())
-            write_json(scorecard_path, scorecard_artifact())
+            write_json(scorecard_path, scorecard_artifact(candidate_id="candidate-cli"))
 
             exit_code = manager.main(
                 [

--- a/scripts/test_screeps_rl_rollout_manager.py
+++ b/scripts/test_screeps_rl_rollout_manager.py
@@ -317,6 +317,19 @@ class RlRolloutManagerTest(unittest.TestCase):
                 self.assertEqual(plan["readiness"]["status"], "hold")
                 self.assertTrue(any(reason.get("reason") == expected_reason for reason in reasons))
 
+    def test_canary_readiness_plan_holds_without_scorecard_deploy_binding(self) -> None:
+        plan = manager.build_canary_readiness_plan(
+            **ready_canary_plan_kwargs(
+                scorecard_raw=scorecard_artifact(candidate_commit=None, candidate_deploy_ref=None)
+            )
+        )
+
+        reasons = plan["readiness"]["blockingReasons"]
+        self.assertEqual(plan["readiness"]["status"], "hold")
+        self.assertTrue(
+            any(reason.get("reason") == "missing_candidate_scorecard_deploy_binding" for reason in reasons)
+        )
+
     def test_canary_readiness_plan_holds_without_required_gates_or_safety(self) -> None:
         plan = manager.build_canary_readiness_plan(
             active_world_status="stale",

--- a/scripts/test_screeps_rl_rollout_manager.py
+++ b/scripts/test_screeps_rl_rollout_manager.py
@@ -164,8 +164,9 @@ def ready_canary_plan_kwargs(
     *,
     scorecard_raw: JsonObject | None = None,
     scorecard_ref: str = "runtime-artifacts/rl-control-loop/scorecards/candidate-top-construction.json",
+    **overrides: Any,
 ) -> JsonObject:
-    return {
+    kwargs: JsonObject = {
         "active_world_ref": "14df4ae442fb68e1273aa69c182daa0328e2d868",
         "active_world_status": "matched_main",
         "baseline_raw": kpi_window(),
@@ -199,6 +200,8 @@ def ready_canary_plan_kwargs(
         "scorecard_raw": scorecard_raw if scorecard_raw is not None else scorecard_artifact(),
         "scorecard_ref": scorecard_ref,
     }
+    kwargs.update(overrides)
+    return kwargs
 
 
 class RlRolloutManagerTest(unittest.TestCase):
@@ -258,10 +261,45 @@ class RlRolloutManagerTest(unittest.TestCase):
         self.assertFalse(plan["safetyGuards"]["deploysCode"])
         self.assertEqual(plan["constructionGate"]["status"], "pass")
         self.assertEqual(plan["cpuGate"]["status"], "pass")
+        self.assertEqual(plan["cpuGate"]["sourceArtifact"], "runtime-artifacts/rl-control-loop/cpu-baseline.json")
         self.assertEqual(plan["officialDeploy"]["ownedSpawns"], 1)
         self.assertEqual(plan["controlLoop"]["conclusions"][0]["conclusionId"], "RL-CONC-20260612-004")
         self.assertEqual(plan["canaryContract"]["validation"]["status"], "pass")
         self.assertEqual(plan["incumbentBaseline"]["kpiWindow"]["observation"]["status"], "pass")
+
+    def test_canary_readiness_plan_holds_for_passed_cpu_baseline_without_ref(self) -> None:
+        for cpu_status, cpu_ref in (("pass", None), ("accepted", "")):
+            with self.subTest(cpu_status=cpu_status, cpu_ref=cpu_ref):
+                plan = manager.build_canary_readiness_plan(
+                    **ready_canary_plan_kwargs(cpu_baseline_status=cpu_status, cpu_baseline_ref=cpu_ref)
+                )
+
+                reasons = plan["readiness"]["blockingReasons"]
+                self.assertEqual(plan["readiness"]["status"], "hold")
+                self.assertEqual(plan["cpuGate"]["status"], cpu_status)
+                self.assertEqual(plan["cpuGate"]["sourceArtifact"], cpu_ref)
+                self.assertTrue(any(reason.get("reason") == "missing_cpu_baseline_ref" for reason in reasons))
+                self.assertFalse(any(reason.get("reason") == "cpu_baseline_must_pass" for reason in reasons))
+
+    def test_canary_readiness_plan_allows_accepted_cpu_baseline_with_ref(self) -> None:
+        plan = manager.build_canary_readiness_plan(
+            **ready_canary_plan_kwargs(cpu_baseline_status="accepted", cpu_baseline_ref="cpu-baseline-ref")
+        )
+
+        self.assertEqual(plan["readiness"]["status"], "ready")
+        self.assertEqual(plan["readiness"]["blockingReasons"], [])
+        self.assertEqual(plan["cpuGate"]["status"], "accepted")
+        self.assertEqual(plan["cpuGate"]["sourceArtifact"], "cpu-baseline-ref")
+
+    def test_canary_readiness_plan_keeps_failed_cpu_baseline_reason_without_ref(self) -> None:
+        plan = manager.build_canary_readiness_plan(
+            **ready_canary_plan_kwargs(cpu_baseline_status="fail", cpu_baseline_ref=None)
+        )
+
+        reasons = plan["readiness"]["blockingReasons"]
+        self.assertEqual(plan["readiness"]["status"], "hold")
+        self.assertTrue(any(reason.get("reason") == "cpu_baseline_must_pass" for reason in reasons))
+        self.assertFalse(any(reason.get("reason") == "missing_cpu_baseline_ref" for reason in reasons))
 
     def test_canary_readiness_plan_holds_for_rejected_scorecard_outcomes(self) -> None:
         for status in ("HOLD", "MIXED", "ROLLBACK_REQUIRED"):

--- a/scripts/test_screeps_rl_rollout_manager.py
+++ b/scripts/test_screeps_rl_rollout_manager.py
@@ -107,6 +107,9 @@ def reducer_report(
 
 def scorecard_artifact(
     *,
+    baseline_commit: str | None = "incumbent-ref",
+    baseline_deploy_ref: str | None = None,
+    baseline_id: str | None = "incumbent-baseline",
     candidate_commit: str | None = "candidate-ref",
     candidate_deploy_ref: str | None = None,
     candidate_id: str | None = "candidate-top-construction",
@@ -145,6 +148,15 @@ def scorecard_artifact(
         candidate["deployRef"] = candidate_deploy_ref
     if candidate:
         artifact["candidate"] = candidate
+    baseline: JsonObject = {}
+    if baseline_id is not None:
+        baseline["id"] = baseline_id
+    if baseline_commit is not None:
+        baseline["commit"] = baseline_commit
+    if baseline_deploy_ref is not None:
+        baseline["deployRef"] = baseline_deploy_ref
+    if baseline:
+        artifact["baseline"] = baseline
     return artifact
 
 
@@ -328,6 +340,36 @@ class RlRolloutManagerTest(unittest.TestCase):
         self.assertEqual(plan["readiness"]["status"], "hold")
         self.assertTrue(
             any(reason.get("reason") == "missing_candidate_scorecard_deploy_binding" for reason in reasons)
+        )
+
+    def test_canary_readiness_plan_holds_for_scorecard_baseline_mismatch(self) -> None:
+        for artifact_kwargs, expected_reason in (
+            ({"baseline_commit": "other-incumbent-ref"}, "candidate_scorecard_baseline_commit_mismatch"),
+            (
+                {"baseline_commit": None, "baseline_deploy_ref": "other-incumbent-ref"},
+                "candidate_scorecard_baseline_deploy_ref_mismatch",
+            ),
+        ):
+            with self.subTest(expected_reason=expected_reason):
+                plan = manager.build_canary_readiness_plan(
+                    **ready_canary_plan_kwargs(scorecard_raw=scorecard_artifact(**artifact_kwargs))
+                )
+
+                reasons = plan["readiness"]["blockingReasons"]
+                self.assertEqual(plan["readiness"]["status"], "hold")
+                self.assertTrue(any(reason.get("reason") == expected_reason for reason in reasons))
+
+    def test_canary_readiness_plan_holds_without_scorecard_baseline_binding(self) -> None:
+        plan = manager.build_canary_readiness_plan(
+            **ready_canary_plan_kwargs(
+                scorecard_raw=scorecard_artifact(baseline_commit=None, baseline_deploy_ref=None)
+            )
+        )
+
+        reasons = plan["readiness"]["blockingReasons"]
+        self.assertEqual(plan["readiness"]["status"], "hold")
+        self.assertTrue(
+            any(reason.get("reason") == "missing_candidate_scorecard_baseline_binding" for reason in reasons)
         )
 
     def test_canary_readiness_plan_holds_without_required_gates_or_safety(self) -> None:


### PR DESCRIPTION
## Linked issues

Intentional PR-body closing linkage:
- None.

Related / non-closing linkage:
- Refs #1583
- Related to issue 1032
- Related to issue 1233

## Domain / Kind

- Domain: RL flywheel
- Kind: code

## Summary

- Adds a bounded RL canary-readiness plan gate to the rollout manager.
- Captures deploy/health/construction/CPU/control-loop prerequisites in a planning-only artifact before any live canary or paid compute action.
- Documents the readiness gate in the rollout/rollback runbook and adds focused unit/CLI coverage.

## Verification

- [x] `git diff --check`
- [x] `python3 -m py_compile scripts/screeps_rl_rollout_manager.py scripts/test_screeps_rl_rollout_manager.py`
- [x] `python3 scripts/test_screeps_rl_rollout_manager.py` — 16 tests OK
- [x] GitHub Project issue/PR fields are current (`Status`, `Evidence`, `Next action`; plus `Blocked by` when blocked).
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate

- [x] Task type: RL flywheel control-plane code/runbook update.
- [x] Expected observable outcome / named deliverable: rollout manager can emit a planning-only bounded canary-readiness artifact that records deploy refs, incumbent baseline, candidate/rollback refs, CPU/construction gates, and conclusion-registry state before live canary execution.
- [x] Non-goals / accepted substitutes: no Tencent paid compute; no official MMO writes; no canary launch; no reward tuning; no production Screeps bundle change.
- [x] Verification evidence required before Done: local diff check, Python compile, focused rollout-manager tests, GitHub checks, automated-review/thread gate, and Project state update.
- [x] Project Evidence / Next action / Blocked by: issue 1583 moves to In review for this PR; next action is exact-head checks/review, then merge. Live canary execution remains gated by validation-plan/no-compute and baseline KPI evidence.
- [x] Post-merge/deploy/runtime proof: no official runtime deploy required for this scripts/docs-only control-plane change; post-merge proof is a later Loop B/RL steward artifact consuming the canary-readiness gate before any live canary.
- [x] Named deliverable proof: `scripts/screeps_rl_rollout_manager.py` exposes the canary-plan gate and `scripts/test_screeps_rl_rollout_manager.py` covers ready/hold and CLI artifact behavior.

## Issue closure gate

For every issue linked above in the PR body with a closing keyword:

- [x] No closing issue references are present in this PR body.
- [x] No closed issue still needs post-merge validation, runtime/process proof, owner action, successor/follow-up work, partial-fix completion, or any other blocker.

## Runtime / deployment impact

- [x] No gameplay/runtime/deployment impact.
- [ ] Gameplay/runtime/deployment impact; Deployment Floor evidence or HELD blocker is recorded.
