### PR TITLE
rl: restore E1 runtime-summary sample cadence

### DIFF
--- a/scripts/screeps_rl_dataset_gate.py
+++ b/scripts/screeps_rl_dataset_gate.py
@@ -42,6 +42,8 @@ DEFAULT_HOME_ROOM = world_profiles.PERSISTENT_DEFAULTS.room
 HOME_ROOM_ENV_VAR = "SCREEPS_HOME_ROOM"
 GATE_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 SOURCE_TIMESTAMP_RE = re.compile(r"(\d{8}T\d{6}Z)")
+RUNTIME_ARTIFACTS_DIR_NAME = "runtime-artifacts"
+RUNTIME_SUMMARY_CONSOLE_DIR_NAME = "runtime-summary-console"
 E1_METRIC_FLOOR_KEYS = rollout_manager.METRIC_ORDER
 DERIVED_RUNTIME_KPI_FLOOR_SOURCE = "current_runtime_kpi_window"
 DERIVED_BASELINE_OBJECTIVE_TYPE = "screeps-rl-derived-runtime-kpi-baseline-objective"
@@ -762,14 +764,32 @@ def finite_positive_number(value: Any) -> float | None:
     return None
 
 
+def runtime_summary_console_root_from_path(path: str, *, allow_runtime_artifacts_parent: bool = False) -> str | None:
+    normalized = path.replace("\\", "/").rstrip("/")
+    if not normalized:
+        return None
+    parts = normalized.split("/")
+    if RUNTIME_SUMMARY_CONSOLE_DIR_NAME in parts:
+        index = parts.index(RUNTIME_SUMMARY_CONSOLE_DIR_NAME)
+        return "/".join(parts[: index + 1])
+    if allow_runtime_artifacts_parent and RUNTIME_ARTIFACTS_DIR_NAME in parts:
+        index = parts.index(RUNTIME_ARTIFACTS_DIR_NAME)
+        return "/".join([*parts[: index + 1], RUNTIME_SUMMARY_CONSOLE_DIR_NAME])
+    return None
+
+
 def first_runtime_summary_source_root(input_paths: Sequence[Any]) -> str:
     for path in input_paths:
-        if isinstance(path, str) and "runtime-summary-console" in path.replace("\\", "/"):
-            return path
+        if isinstance(path, str):
+            source_root = runtime_summary_console_root_from_path(path)
+            if source_root is not None:
+                return source_root
     for path in input_paths:
-        if isinstance(path, str) and path:
-            return path
-    return "runtime-artifacts/runtime-summary-console"
+        if isinstance(path, str):
+            source_root = runtime_summary_console_root_from_path(path, allow_runtime_artifacts_parent=True)
+            if source_root is not None:
+                return source_root
+    return dataset_export.CONSOLE_CAPTURE_INPUT_PATHS[-1]
 
 
 def command_string(parts: Sequence[str]) -> str:

--- a/scripts/screeps_rl_dataset_gate.py
+++ b/scripts/screeps_rl_dataset_gate.py
@@ -791,13 +791,15 @@ def build_runtime_sample_cadence_diagnostics(
     source_max_age = finite_positive_number(source_max_age_hours)
     runtime_summary_artifacts = runtime_summary_count if isinstance(runtime_summary_count, int) else None
     samples_per_runtime_artifact: float | None = None
+    precise_samples_per_runtime_artifact: float | None = None
     estimated_additional_runtime_artifacts: int | None = None
     if runtime_summary_artifacts is not None and runtime_summary_artifacts > 0 and sample_count > 0:
-        samples_per_runtime_artifact = round(sample_count / runtime_summary_artifacts, 3)
+        precise_samples_per_runtime_artifact = sample_count / runtime_summary_artifacts
+        samples_per_runtime_artifact = round(precise_samples_per_runtime_artifact, 3)
         if sample_deficit > 0:
             estimated_additional_runtime_artifacts = max(
                 1,
-                math.ceil(sample_deficit / samples_per_runtime_artifact),
+                math.ceil(sample_deficit / precise_samples_per_runtime_artifact),
             )
 
     minimum_sample_cadence_minutes: float | None = None
@@ -805,8 +807,11 @@ def build_runtime_sample_cadence_diagnostics(
     required_successful_captures_per_window: int | None = None
     if source_max_age is not None and min_samples > 0:
         minimum_sample_cadence_minutes = round(source_max_age * 60 / min_samples, 1)
-        if samples_per_runtime_artifact is not None and samples_per_runtime_artifact > 0:
-            required_successful_captures_per_window = max(1, math.ceil(min_samples / samples_per_runtime_artifact))
+        if precise_samples_per_runtime_artifact is not None and precise_samples_per_runtime_artifact > 0:
+            required_successful_captures_per_window = max(
+                1,
+                math.ceil(min_samples / precise_samples_per_runtime_artifact),
+            )
             estimated_capture_cadence_minutes = round(
                 source_max_age * 60 / required_successful_captures_per_window,
                 1,

--- a/scripts/screeps_rl_dataset_gate.py
+++ b/scripts/screeps_rl_dataset_gate.py
@@ -36,6 +36,8 @@ DEFAULT_SHADOW_ARTIFACT_LIMIT = 200
 QUALITY_REJECTED_SAMPLE_LOG_LIMIT = 50
 QUALITY_TOP_REJECTED_BUCKET_LIMIT = 10
 STALE_QUALITY_SOURCE_AGE_HOURS = 24.0
+RUNTIME_SUMMARY_CAPTURE_COMMAND = "python3 scripts/screeps_runtime_summary_console_capture.py"
+CONSOLE_CAPTURE_EXPORT_COMMAND = "python3 scripts/screeps_rl_dataset_export.py"
 DEFAULT_HOME_ROOM = world_profiles.PERSISTENT_DEFAULTS.room
 HOME_ROOM_ENV_VAR = "SCREEPS_HOME_ROOM"
 GATE_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
@@ -752,6 +754,118 @@ def source_max_age_window_text(source_max_age_hours: Any) -> str:
     return "configured max-age window"
 
 
+def finite_positive_number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)) and math.isfinite(float(value)) and float(value) > 0:
+        return float(value)
+    return None
+
+
+def first_runtime_summary_source_root(input_paths: Sequence[Any]) -> str:
+    for path in input_paths:
+        if isinstance(path, str) and "runtime-summary-console" in path.replace("\\", "/"):
+            return path
+    for path in input_paths:
+        if isinstance(path, str) and path:
+            return path
+    return "runtime-artifacts/runtime-summary-console"
+
+
+def command_string(parts: Sequence[str]) -> str:
+    return " ".join(parts)
+
+
+def build_runtime_sample_cadence_diagnostics(
+    *,
+    input_paths: Sequence[Any],
+    sample_count: int,
+    min_samples: int,
+    runtime_summary_count: Any,
+    source_artifact_count: Any,
+    source_max_age_hours: Any,
+    skipped_file_reasons: Any,
+) -> JsonObject:
+    sample_deficit = max(0, min_samples - sample_count)
+    source_root = first_runtime_summary_source_root(input_paths)
+    source_max_age = finite_positive_number(source_max_age_hours)
+    runtime_summary_artifacts = runtime_summary_count if isinstance(runtime_summary_count, int) else None
+    samples_per_runtime_artifact: float | None = None
+    estimated_additional_runtime_artifacts: int | None = None
+    if runtime_summary_artifacts is not None and runtime_summary_artifacts > 0 and sample_count > 0:
+        samples_per_runtime_artifact = round(sample_count / runtime_summary_artifacts, 3)
+        if sample_deficit > 0:
+            estimated_additional_runtime_artifacts = max(
+                1,
+                math.ceil(sample_deficit / samples_per_runtime_artifact),
+            )
+
+    minimum_sample_cadence_minutes: float | None = None
+    estimated_capture_cadence_minutes: float | None = None
+    required_successful_captures_per_window: int | None = None
+    if source_max_age is not None and min_samples > 0:
+        minimum_sample_cadence_minutes = round(source_max_age * 60 / min_samples, 1)
+        if samples_per_runtime_artifact is not None and samples_per_runtime_artifact > 0:
+            required_successful_captures_per_window = max(1, math.ceil(min_samples / samples_per_runtime_artifact))
+            estimated_capture_cadence_minutes = round(
+                source_max_age * 60 / required_successful_captures_per_window,
+                1,
+            )
+
+    capture_command = [
+        *RUNTIME_SUMMARY_CAPTURE_COMMAND.split(),
+        "--live-official-console",
+        "--format",
+        "status-line",
+        "--out-dir",
+        source_root,
+    ]
+    export_command = [
+        *CONSOLE_CAPTURE_EXPORT_COMMAND.split(),
+        "--console-capture-only",
+        "--sample-limit",
+        str(min_samples),
+    ]
+    if source_max_age is not None:
+        export_command.extend(["--source-max-age-hours", f"{source_max_age:g}"])
+
+    older_than_max_age_count = None
+    incomplete_derived_count = None
+    if isinstance(skipped_file_reasons, dict):
+        older_than_max_age = skipped_file_reasons.get("older_than_max_age")
+        incomplete_derived = skipped_file_reasons.get(dataset_export.INCOMPLETE_DERIVED_RUNTIME_SUMMARY_SKIP_REASON)
+        older_than_max_age_count = older_than_max_age if isinstance(older_than_max_age, int) else None
+        incomplete_derived_count = incomplete_derived if isinstance(incomplete_derived, int) else None
+
+    return {
+        "status": "blocked" if sample_deficit > 0 else "pass",
+        "classification": "insufficient_runtime_samples" if sample_deficit > 0 else "sample_floor_satisfied",
+        "minimumSamples": min_samples,
+        "currentSamples": sample_count,
+        "minimumAdditionalSamples": sample_deficit,
+        "runtimeSummaryArtifactCount": runtime_summary_count,
+        "sourceArtifactCount": source_artifact_count,
+        "sourceRoot": source_root,
+        "sourceMaxAgeHours": source_max_age_hours,
+        "olderThanMaxAgeFileCount": older_than_max_age_count,
+        "incompleteDerivedRuntimeSummaryFileCount": incomplete_derived_count,
+        "observedSamplesPerRuntimeSummaryArtifact": samples_per_runtime_artifact,
+        "estimatedAdditionalRuntimeSummaryArtifactsAtObservedDensity": estimated_additional_runtime_artifacts,
+        "minimumAcceptedSampleCadenceMinutes": minimum_sample_cadence_minutes,
+        "estimatedSuccessfulCaptureCadenceMinutesAtObservedDensity": estimated_capture_cadence_minutes,
+        "requiredSuccessfulCapturesPerSourceWindowAtObservedDensity": required_successful_captures_per_window,
+        "successCondition": f"next console-capture-only export reports sampleCount >= {min_samples}",
+        "captureCommand": command_string(capture_command),
+        "captureCommandArgs": capture_command,
+        "exportCheckCommand": command_string(export_command),
+        "exportCheckCommandArgs": export_command,
+        "notes": [
+            "Only exact-prefix #runtime-summary lines increase this floor; #cpu-summary-only captures do not count.",
+            "The capture command reads the official console websocket and persists local artifacts; it does not write MMO state.",
+        ],
+    }
+
+
 def dataset_source_diagnostics(
     dataset_summary: JsonObject,
     run_manifest: JsonObject,
@@ -776,6 +890,16 @@ def dataset_source_diagnostics(
             "classification": "sample_floor_satisfied",
             "inputPaths": input_paths,
         }
+
+    sample_cadence = build_runtime_sample_cadence_diagnostics(
+        input_paths=input_paths,
+        sample_count=sample_count,
+        min_samples=min_samples,
+        runtime_summary_count=runtime_summary_count,
+        source_artifact_count=source_artifact_count,
+        source_max_age_hours=source_max_age_hours,
+        skipped_file_reasons=skipped_file_reasons,
+    )
 
     if (
         source_artifact_count == 0
@@ -807,7 +931,23 @@ def dataset_source_diagnostics(
         )
     else:
         classification = "insufficient_runtime_samples"
-        recommended_action = "Collect more current runtime-summary samples before treating the full E1 gate as fresh."
+        deficit = sample_cadence["minimumAdditionalSamples"]
+        artifact_estimate = sample_cadence["estimatedAdditionalRuntimeSummaryArtifactsAtObservedDensity"]
+        cadence = sample_cadence["estimatedSuccessfulCaptureCadenceMinutesAtObservedDensity"]
+        estimate_text = (
+            f" about {artifact_estimate} more successful runtime-summary captures at the observed density"
+            if isinstance(artifact_estimate, int)
+            else " enough successful runtime-summary captures"
+        )
+        cadence_text = (
+            f"; maintain roughly <= {cadence:g} minutes between successful captures inside the source window"
+            if isinstance(cadence, (int, float))
+            else ""
+        )
+        recommended_action = (
+            f"Need {deficit} more accepted runtime-summary samples before treating the full E1 gate as fresh; "
+            f"collect{estimate_text}{cadence_text}, then rerun the console-capture-only export."
+        )
 
     return {
         "status": "blocked",
@@ -822,6 +962,7 @@ def dataset_source_diagnostics(
         "skippedFileReasons": skipped_file_reasons,
         "skippedSampleCount": skipped_sample_count,
         "skippedSampleReasons": skipped_sample_reasons,
+        "sampleCadence": sample_cadence,
     }
 
 
@@ -852,6 +993,7 @@ def evaluate_dataset_readiness(
             sample_count >= min_samples,
             actual=sample_count,
             required=min_samples,
+            **({"sampleCadence": diagnostics.get("sampleCadence")} if sample_count < min_samples else {}),
         ),
         pass_fail_check("ticks_match_manifest_count", ticks_count == sample_count, ticksRows=ticks_count),
         pass_fail_check(

--- a/scripts/test_screeps_rl_dataset_gate.py
+++ b/scripts/test_screeps_rl_dataset_gate.py
@@ -418,6 +418,79 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
         self.assertIn("configured max-age window", diagnostics["recommendedAction"])
         self.assertNotIn("Noneh", diagnostics["recommendedAction"])
 
+    def test_insufficient_runtime_samples_reports_exact_cadence_requirements(self) -> None:
+        diagnostics = gate.dataset_source_diagnostics(
+            {
+                "sampleCount": 9,
+                "sourceArtifactCount": 69,
+                "runtimeSummaryArtifactCount": 3,
+                "skippedFileReasons": {
+                    "incomplete_derived_runtime_summary": 47,
+                    "older_than_max_age": 6686,
+                },
+                "skippedSampleCount": 0,
+                "skippedSampleReasons": {},
+            },
+            {
+                "source": {
+                    "inputPaths": ["runtime-artifacts/runtime-summary-console"],
+                    "sourceMaxAgeHours": 24.0,
+                    "scannedFiles": 69,
+                    "sourceArtifactCount": 69,
+                    "matchedArtifactCount": 3,
+                    "skippedFileCount": 6733,
+                    "skippedFileReasons": {
+                        "incomplete_derived_runtime_summary": 47,
+                        "older_than_max_age": 6686,
+                    },
+                },
+            },
+            sample_count=9,
+            min_samples=20,
+        )
+
+        cadence = diagnostics["sampleCadence"]
+        self.assertEqual(diagnostics["status"], "blocked")
+        self.assertEqual(diagnostics["classification"], "insufficient_runtime_samples")
+        self.assertIn("Need 11 more accepted runtime-summary samples", diagnostics["recommendedAction"])
+        self.assertIn("about 4 more successful runtime-summary captures", diagnostics["recommendedAction"])
+        self.assertEqual(cadence["minimumSamples"], 20)
+        self.assertEqual(cadence["currentSamples"], 9)
+        self.assertEqual(cadence["minimumAdditionalSamples"], 11)
+        self.assertEqual(cadence["sourceRoot"], "runtime-artifacts/runtime-summary-console")
+        self.assertEqual(cadence["observedSamplesPerRuntimeSummaryArtifact"], 3.0)
+        self.assertEqual(cadence["estimatedAdditionalRuntimeSummaryArtifactsAtObservedDensity"], 4)
+        self.assertEqual(cadence["minimumAcceptedSampleCadenceMinutes"], 72.0)
+        self.assertEqual(cadence["requiredSuccessfulCapturesPerSourceWindowAtObservedDensity"], 7)
+        self.assertEqual(cadence["estimatedSuccessfulCaptureCadenceMinutesAtObservedDensity"], 205.7)
+        self.assertEqual(cadence["olderThanMaxAgeFileCount"], 6686)
+        self.assertEqual(cadence["incompleteDerivedRuntimeSummaryFileCount"], 47)
+        self.assertEqual(
+            cadence["captureCommandArgs"],
+            [
+                "python3",
+                "scripts/screeps_runtime_summary_console_capture.py",
+                "--live-official-console",
+                "--format",
+                "status-line",
+                "--out-dir",
+                "runtime-artifacts/runtime-summary-console",
+            ],
+        )
+        self.assertEqual(
+            cadence["exportCheckCommandArgs"],
+            [
+                "python3",
+                "scripts/screeps_rl_dataset_export.py",
+                "--console-capture-only",
+                "--sample-limit",
+                "20",
+                "--source-max-age-hours",
+                "24",
+            ],
+        )
+        self.assertIn("#cpu-summary-only captures do not count", " ".join(cadence["notes"]))
+
     def test_run_rejects_dead_room_dataset_samples(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_dataset_gate.py
+++ b/scripts/test_screeps_rl_dataset_gate.py
@@ -525,6 +525,48 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
         self.assertEqual(cadence["estimatedSuccessfulCaptureCadenceMinutesAtObservedDensity"], 0.2)
         self.assertIn("about 3000 more successful runtime-summary captures", diagnostics["recommendedAction"])
 
+    def test_recovery_capture_command_uses_console_root_for_parent_artifact_inputs(self) -> None:
+        cases = (
+            (
+                ["/root/screeps/runtime-artifacts"],
+                "/root/screeps/runtime-artifacts/runtime-summary-console",
+            ),
+            (
+                list(dataset_export.DEFAULT_INPUT_PATHS),
+                "/root/screeps/runtime-artifacts/runtime-summary-console",
+            ),
+        )
+        for input_paths, expected_source_root in cases:
+            with self.subTest(input_paths=input_paths):
+                diagnostics = gate.dataset_source_diagnostics(
+                    {
+                        "sampleCount": 1,
+                        "sourceArtifactCount": 1,
+                        "runtimeSummaryArtifactCount": 1,
+                        "skippedFileReasons": {},
+                        "skippedSampleCount": 0,
+                        "skippedSampleReasons": {},
+                    },
+                    {
+                        "source": {
+                            "inputPaths": input_paths,
+                            "sourceMaxAgeHours": 24.0,
+                            "scannedFiles": 1,
+                            "sourceArtifactCount": 1,
+                            "matchedArtifactCount": 1,
+                            "skippedFileCount": 0,
+                            "skippedFileReasons": {},
+                        },
+                    },
+                    sample_count=1,
+                    min_samples=2,
+                )
+
+                cadence = diagnostics["sampleCadence"]
+                self.assertEqual(cadence["sourceRoot"], expected_source_root)
+                self.assertEqual(cadence["captureCommandArgs"][-2:], ["--out-dir", expected_source_root])
+                self.assertNotEqual(cadence["captureCommandArgs"][-1], input_paths[0].rstrip("/"))
+
     def test_run_rejects_dead_room_dataset_samples(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/test_screeps_rl_dataset_gate.py
+++ b/scripts/test_screeps_rl_dataset_gate.py
@@ -491,6 +491,40 @@ class ScreepsRlDatasetGateTest(unittest.TestCase):
         )
         self.assertIn("#cpu-summary-only captures do not count", " ".join(cadence["notes"]))
 
+    def test_sparse_runtime_samples_use_unrounded_density_for_cadence_estimates(self) -> None:
+        diagnostics = gate.dataset_source_diagnostics(
+            {
+                "sampleCount": 1,
+                "sourceArtifactCount": 3000,
+                "runtimeSummaryArtifactCount": 3000,
+                "skippedFileReasons": {},
+                "skippedSampleCount": 0,
+                "skippedSampleReasons": {},
+            },
+            {
+                "source": {
+                    "inputPaths": ["runtime-artifacts/runtime-summary-console"],
+                    "sourceMaxAgeHours": 24.0,
+                    "scannedFiles": 3000,
+                    "sourceArtifactCount": 3000,
+                    "matchedArtifactCount": 3000,
+                    "skippedFileCount": 0,
+                    "skippedFileReasons": {},
+                },
+            },
+            sample_count=1,
+            min_samples=2,
+        )
+
+        cadence = diagnostics["sampleCadence"]
+        self.assertEqual(diagnostics["status"], "blocked")
+        self.assertEqual(diagnostics["classification"], "insufficient_runtime_samples")
+        self.assertEqual(cadence["observedSamplesPerRuntimeSummaryArtifact"], 0.0)
+        self.assertEqual(cadence["estimatedAdditionalRuntimeSummaryArtifactsAtObservedDensity"], 3000)
+        self.assertEqual(cadence["requiredSuccessfulCapturesPerSourceWindowAtObservedDensity"], 6000)
+        self.assertEqual(cadence["estimatedSuccessfulCaptureCadenceMinutesAtObservedDensity"], 0.2)
+        self.assertIn("about 3000 more successful runtime-summary captures", diagnostics["recommendedAction"])
+
     def test_run_rejects_dead_room_dataset_samples(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Linked issues

Intentional PR-body closing linkage:
- Fixes #1914

Related / non-closing linkage:
- Related to issue 1583 canary readiness.
- Related to issue 1909 CPU/baseline gate.

## Domain / Kind

- Domain: RL flywheel
- Kind: code

## Summary

- Add E1 dataset-gate diagnostics that explain the exact runtime-summary sample deficit, required capture cadence, and safe capture/export commands when the full gate lacks enough current samples.
- Surface the diagnostics on the `minimum_samples` check so future steward/continuation runs get an executable recovery path instead of only `9/20` style failure text.
- Keep the change offline-only: no official MMO writes, no live control, no deployment-floor impact.

## Verification

- [x] Local check: `git diff --check`; `python3 -m py_compile scripts/screeps_rl_dataset_gate.py scripts/test_screeps_rl_dataset_gate.py`; `python3 -m unittest scripts/test_screeps_rl_dataset_gate.py` — PASS, 24 tests.
- [x] GitHub Project issue/PR fields are current (`Status`, `Evidence`, `Next action`; plus `Blocked by` when blocked) — #1914 item `PVTI_lAHOACo3ic4BVvO4zgvxTds` and PR #1915 item `PVTI_lAHOACo3ic4BVvO4zgvxnrg` are In review with fields set.
- [ ] Automated review has no blocking findings, or a CodeRabbit/Gemini reliability bypass is recorded with reviewer/head/reason; review threads are resolved/outdated/non-blocking.
- [ ] QA gate: controller verification PASS; independent QA not yet run.
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate

- [x] Task type: code behavior / RL flywheel dataset-gate diagnostics.
- [x] Expected observable outcome / named deliverable: E1 full-gate sample-floor failures now include actionable sample-cadence diagnostics and exact recovery commands.
- [x] Non-goals / accepted substitutes: no cron schedule changes, no official MMO writes, no paid/Tencent compute, no canary rollout.
- [x] Verification evidence required before Done: controller verification commands passed; durable gate verification artifact `runtime-artifacts/rl-control-loop/gate-outputs/e1-full-gate-1914-controller-20260615T1035Z/gate_summary.json` reports `ok=true`, `sampleCount=20`, `qualityChecksStatus=pass`, `liveEffect=false`, `officialMmoWrites=false`.
- [x] Project Evidence / Next action / Blocked by: #1914 and PR #1915 Project items are In review; Evidence/Next action/Blocked by cite commit `7dd4570d`, gate artifact `e1-full-gate-1914-controller-20260615T1035Z`, and remaining PR gate.
- [x] Post-merge/deploy/runtime proof: not applicable; scripts-only offline RL gate change, no deploy required.
- [x] Named deliverable proof: `scripts/screeps_rl_dataset_gate.py` now emits `sampleCadence` diagnostics; `scripts/test_screeps_rl_dataset_gate.py` covers the 9/20 insufficient-runtime-samples case.

## Issue closure gate

For every issue linked above in the PR body with a closing keyword:

- [x] #1914: acceptance is satisfied by the code/tests plus controller gate artifact proving a 20-sample full E1 gate can pass against current runtime-summary-console evidence.
- [x] No closed issue still needs post-merge validation, runtime/process proof, owner action, successor/follow-up work, partial-fix completion, or any other blocker.

## Runtime / deployment impact

- [x] No gameplay/runtime/deployment impact.
- [ ] Gameplay/runtime/deployment impact; Deployment Floor evidence or HELD blocker is recorded.

## Notes

- Review/merge gates still apply: wait at least 15 minutes after PR creation, require green checks, inspect bot comments/reviews and GraphQL review threads, keep issue/PR Project fields current, and do not merge on non-substantive automated-review evidence alone.

