### PR TITLE
worker-task: restore covered-rampart construction progress

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35521,7 +35521,14 @@ function isWorkerAssignmentGapRecoveryTask(creep, task, allowUpgradeRecovery, op
   return task === void 0 || task === null || isEnergyAcquisitionTask2(task) || task.type === "transfer" || options.allowRepair === true && isWorkerAssignmentGapRecoveryRepairTask(creep, task) || allowUpgradeRecovery && task.type === "upgrade";
 }
 function isWorkerAssignmentGapRecoveryRepairTask(creep, task) {
-  return (task == null ? void 0 : task.type) === "repair" && !isProtectedRepairTargetForConstructionBacklog(creep, getTaskTarget(task));
+  return (task == null ? void 0 : task.type) === "repair" && isRepairTargetPreemptibleForConstructionBacklog(creep, getTaskTarget(task));
+}
+function isRepairTargetPreemptibleForConstructionBacklog(creep, target) {
+  return !isProtectedRepairTargetForConstructionBacklog(creep, target) || hasCoveredProtectedRampartRepairForAssignmentGap(creep, target);
+}
+function hasCoveredProtectedRampartRepairForAssignmentGap(creep, target) {
+  var _a2;
+  return isRepairPreemptionStructure(target) && isBuildPreemptionOwnedRampart(target) && isCriticalOwnedRampartRepairTarget(target) && !isWorkerRepairTargetComplete(target) && ((_a2 = creep.room.controller) == null ? void 0 : _a2.my) === true && !isRoomThreatened(creep) && hasOtherSameRoomRepairAssignmentForTarget(creep, target);
 }
 function selectWorkerAssignmentGapRecoveryConstructionSite(creep) {
   var _a2, _b;
@@ -35789,7 +35796,7 @@ function shouldPreemptRepairTaskForConstructionBacklog(creep, task, selectedTask
   if (task.type !== "repair" || (selectedTask == null ? void 0 : selectedTask.type) !== "build" || isSameTask2(task, selectedTask)) {
     return false;
   }
-  return !isProtectedRepairTargetForConstructionBacklog(creep, getTaskTarget(task));
+  return isRepairTargetPreemptibleForConstructionBacklog(creep, getTaskTarget(task));
 }
 function isProtectedRepairTargetForConstructionBacklog(creep, target) {
   if (!isRepairPreemptionStructure(target) || isWorkerRepairTargetComplete(target)) {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -743,7 +743,26 @@ function isWorkerAssignmentGapRecoveryRepairTask(
   creep: Creep,
   task: CreepTaskMemory | null | undefined
 ): task is Extract<CreepTaskMemory, { type: 'repair' }> {
-  return task?.type === 'repair' && !isProtectedRepairTargetForConstructionBacklog(creep, getTaskTarget(task));
+  return task?.type === 'repair' && isRepairTargetPreemptibleForConstructionBacklog(creep, getTaskTarget(task));
+}
+
+function isRepairTargetPreemptibleForConstructionBacklog(creep: Creep, target: unknown): boolean {
+  return (
+    !isProtectedRepairTargetForConstructionBacklog(creep, target) ||
+    hasCoveredProtectedRampartRepairForAssignmentGap(creep, target)
+  );
+}
+
+function hasCoveredProtectedRampartRepairForAssignmentGap(creep: Creep, target: unknown): target is StructureRampart {
+  return (
+    isRepairPreemptionStructure(target) &&
+    isBuildPreemptionOwnedRampart(target) &&
+    isCriticalOwnedRampartRepairTarget(target) &&
+    !isWorkerRepairTargetComplete(target) &&
+    creep.room.controller?.my === true &&
+    !isRoomThreatened(creep) &&
+    hasOtherSameRoomRepairAssignmentForTarget(creep, target)
+  );
 }
 
 function selectWorkerAssignmentGapRecoveryConstructionSite(creep: Creep): ConstructionSite | null {
@@ -1161,7 +1180,7 @@ function shouldPreemptRepairTaskForConstructionBacklog(
     return false;
   }
 
-  return !isProtectedRepairTargetForConstructionBacklog(creep, getTaskTarget(task));
+  return isRepairTargetPreemptibleForConstructionBacklog(creep, getTaskTarget(task));
 }
 
 function isProtectedRepairTargetForConstructionBacklog(creep: Creep, target: unknown): boolean {

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -6712,6 +6712,30 @@ describe('planSpawn', () => {
     });
   });
 
+  it('keeps zero-worker recovery on the emergency body when construction and repair pressure coexist', () => {
+    const damagedContainer = {
+      id: 'container-repair',
+      structureType: 'container',
+      hits: 500,
+      hitsMax: 2_500
+    } as StructureContainer;
+    const { colony, spawn } = makeColony({
+      roomName: 'W1N12',
+      constructionSiteCount: 1,
+      energyAvailable: 400,
+      energyCapacityAvailable: 600,
+      controller: makeSafeOwnedController(),
+      structures: [damagedContainer as AnyStructure]
+    });
+
+    expect(planSpawn(colony, { worker: 0 }, 136)).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move'],
+      name: 'worker-W1N12-136',
+      memory: { role: 'worker', colony: 'W1N12' }
+    });
+  });
+
   it('plans local E29N56 worker recovery when counted workers are all off-room and construction remains', () => {
     const { colony, spawn } = makeColony({
       roomName: 'E29N56',

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -5433,6 +5433,298 @@ describe('runWorker', () => {
     expect(creep.build).not.toHaveBeenCalled();
   });
 
+  it('keeps the last E29N55 urgent rampart repair worker ahead of visible construction', () => {
+    const extensionSite = {
+      id: 'extension-site1',
+      my: true,
+      structureType: 'extension',
+      progress: 0,
+      progressTotal: 638
+    } as ConstructionSite;
+    const urgentRampart = {
+      id: 'rampart-critical',
+      my: true,
+      structureType: 'rampart',
+      hits: CRITICAL_OWNED_RAMPART_REPAIR_HITS_CEILING - 1,
+      hitsMax: 300_000_000
+    } as StructureRampart;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const room = {
+      name: 'E29N55',
+      energyAvailable: 800,
+      energyCapacityAvailable: 800,
+      controller,
+      find: jest.fn((type: number) => {
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [extensionSite];
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [urgentRampart];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const creep = {
+      name: 'worker-E29N55-rampart',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'repair', targetId: 'rampart-critical' as Id<Structure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0),
+        getCapacity: jest.fn().mockReturnValue(50)
+      },
+      room,
+      build: jest.fn().mockReturnValue(0),
+      repair: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 1_548_723,
+      creeps: { [creep.name]: creep },
+      getObjectById: jest.fn((id: string) =>
+        id === 'extension-site1' ? extensionSite : id === 'rampart-critical' ? urgentRampart : null
+      )
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'repair', targetId: 'rampart-critical' });
+    expect(creep.repair).toHaveBeenCalledWith(urgentRampart);
+    expect(creep.build).not.toHaveBeenCalled();
+  });
+
+  it('keeps bounded E29N55 construction alive when urgent rampart repair already has coverage', () => {
+    const extensionSite = {
+      id: 'extension-site1',
+      my: true,
+      structureType: 'extension',
+      progress: 0,
+      progressTotal: 638,
+      pos: { x: 18, y: 24, roomName: 'E29N55' } as RoomPosition
+    } as ConstructionSite;
+    const urgentRampart = {
+      id: 'rampart-critical',
+      my: true,
+      structureType: 'rampart',
+      hits: CRITICAL_OWNED_RAMPART_REPAIR_HITS_CEILING - 1,
+      hitsMax: 300_000_000,
+      pos: { x: 17, y: 24, roomName: 'E29N55' } as RoomPosition
+    } as StructureRampart;
+    const spawn = {
+      id: 'spawn1',
+      name: 'Spawn1',
+      my: true,
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(300),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      }
+    } as unknown as StructureSpawn;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const workers: Creep[] = [];
+    const room = {
+      name: 'E29N55',
+      energyAvailable: 800,
+      energyCapacityAvailable: 800,
+      controller,
+      find: jest.fn((type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [extensionSite];
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return workers;
+        }
+
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn] as AnyOwnedStructure[];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [spawn, urgentRampart] as unknown as AnyStructure[];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const makeWorker = (index: number): Creep =>
+      ({
+        name: `worker-E29N55-rampart-${index}`,
+        memory: {
+          role: 'worker',
+          colony: 'E29N55',
+          task: { type: 'repair', targetId: 'rampart-critical' as Id<Structure> }
+        },
+        store: {
+          getUsedCapacity: jest.fn().mockReturnValue(50),
+          getFreeCapacity: jest.fn().mockReturnValue(0),
+          getCapacity: jest.fn().mockReturnValue(50)
+        },
+        pos: { getRangeTo: jest.fn().mockReturnValue(2) },
+        room,
+        build: jest.fn().mockReturnValue(0),
+        repair: jest.fn().mockReturnValue(0),
+        moveTo: jest.fn()
+      }) as unknown as Creep;
+    workers.push(makeWorker(1), makeWorker(2), makeWorker(3));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 1_548_724,
+      creeps: Object.fromEntries(workers.map((worker) => [worker.name, worker])),
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'extension-site1') {
+          return extensionSite;
+        }
+
+        if (id === 'rampart-critical') {
+          return urgentRampart;
+        }
+
+        return id === 'spawn1' ? spawn : null;
+      })
+    };
+
+    workers.forEach(runWorker);
+
+    const assignedTasks = workers.map((worker) => worker.memory.task?.type);
+    expect(assignedTasks.filter((task) => task === 'build')).toHaveLength(2);
+    expect(assignedTasks.filter((task) => task === 'repair')).toHaveLength(1);
+    expect(workers.filter((worker) => (worker.build as jest.Mock).mock.calls.length > 0)).toHaveLength(2);
+    expect(workers.filter((worker) => (worker.repair as jest.Mock).mock.calls.length > 0)).toHaveLength(1);
+  });
+
+  it('keeps critical E29N55 spawn refill ahead of covered rampart construction recovery', () => {
+    const extensionSite = {
+      id: 'extension-site1',
+      my: true,
+      structureType: 'extension',
+      progress: 0,
+      progressTotal: 638
+    } as ConstructionSite;
+    const urgentRampart = {
+      id: 'rampart-critical',
+      my: true,
+      structureType: 'rampart',
+      hits: CRITICAL_OWNED_RAMPART_REPAIR_HITS_CEILING - 1,
+      hitsMax: 300_000_000
+    } as StructureRampart;
+    const spawn = {
+      id: 'spawn1',
+      name: 'Spawn1',
+      my: true,
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD - 1),
+        getFreeCapacity: jest.fn().mockReturnValue(101)
+      }
+    } as unknown as StructureSpawn;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const workers: Creep[] = [];
+    const room = {
+      name: 'E29N55',
+      energyAvailable: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+      energyCapacityAvailable: 800,
+      controller,
+      find: jest.fn((type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [extensionSite];
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return workers;
+        }
+
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn] as AnyOwnedStructure[];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [spawn, urgentRampart] as unknown as AnyStructure[];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const coveringWorker = {
+      name: 'worker-E29N55-rampart-cover',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'repair', targetId: 'rampart-critical' as Id<Structure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0),
+        getCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+    const creep = {
+      name: 'worker-E29N55-refill',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'repair', targetId: 'rampart-critical' as Id<Structure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0),
+        getCapacity: jest.fn().mockReturnValue(50)
+      },
+      room,
+      build: jest.fn(),
+      repair: jest.fn(),
+      transfer: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    workers.push(creep, coveringWorker);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 1_548_725,
+      creeps: Object.fromEntries(workers.map((worker) => [worker.name, worker])),
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'extension-site1') {
+          return extensionSite;
+        }
+
+        if (id === 'rampart-critical') {
+          return urgentRampart;
+        }
+
+        return id === 'spawn1' ? spawn : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(creep.transfer).toHaveBeenCalledWith(spawn, RESOURCE_ENERGY);
+    expect(creep.build).not.toHaveBeenCalled();
+    expect(creep.repair).not.toHaveBeenCalled();
+  });
+
   it('keeps the RCL2 downgrade guard above upgrade preemption', () => {
     const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
     const controller = {


### PR DESCRIPTION
## Summary

Related to #1918.

- Restores E29N55 construction progress when urgent rampart repair already has same-room worker coverage.
- Keeps the last critical rampart repair worker on repair, and keeps critical spawn refill ahead of construction preemption.
- Adds focused worker-runner and spawn-planner regression coverage, then rebuilds `prod/dist/main.js` from verified source.

## Evidence

- Source blocker: official deploy run `27548170208` uploaded/activated `50a8c33f` but postdeploy construction acceptance failed for `shardX/E29N55`: `constructionSiteCount=1`, `pendingBuildProgress=638`, `build=0`, `buildCarriedEnergy=0`, `buildProgress=0`, `buildBlockedReason=worker_assignment_gap`.
- Runtime follow-up: fresh monitor artifact `/root/screeps/runtime-artifacts/runtime-summary-console/runtime-summary-monitor-20260615T134919Z.log` still showed all three rooms alive and E29N55 construction backlog visible with `worker_assignment_gap`.
- Controller recovered the vanished Codex lane from `/root/screeps-worktrees/issue-1918-construction-acceptance` and preserved Codex authorship with commit `08ab0028e9c4b849f4b9666eea158bfb5a063b84`.

## Verification

- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand` — 105 suites / 2482 tests passed
- [x] `cd prod && npm run build`
- [x] Commit: `08ab0028e9c4b849f4b9666eea158bfb5a063b84` authored by `lanyusea's bot <lanyusea@gmail.com>`

## Universal task Done gate

- [x] Task type: P0 Territory/Economy runtime-acceptance hotfix PR.
- [x] Expected observable outcome / named deliverable: Commit `08ab0028` lets covered urgent rampart repair coexist with active construction recovery and adds regression tests for repair/build/refill priority boundaries.
- [x] Non-goals / accepted substitutes: Official deploy and live construction acceptance evidence remain on issue 1918; this PR supplies the code, tests, and bundle deliverable.
- [x] Verification evidence required before Done: `git diff --check`, `npm run typecheck`, `npm test -- --runInBand`, and `npm run build` all passed in the linked worktree.
- [x] Project Evidence / Next action / Blocked by: Project issue 1918 and this PR item record commit `08ab0028`, verification commands, PR gate state, and deploy acceptance route.
- [x] Post-merge/deploy/runtime proof: Official deploy workflow plus fresh all-owned construction acceptance evidence with `construction_acceptance.ok=true` / `pass_count=3` will be recorded on issue 1918 before Done.
- [x] Named deliverable proof: `prod/src/creeps/workerRunner.ts`, `prod/test/workerRunner.test.ts`, `prod/test/spawnPlanner.test.ts`, and `prod/dist/main.js` are the committed deliverable files in `08ab0028`.