### PR TITLE
rl: clarify Tencent validation-plan readiness diagnostics

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -1186,12 +1186,36 @@ class Controller:
         signature = text_value(handoff.get("signature")) or "unknown"
         path = self.validation_plan_handoff_path(signature)
         handoff["path"] = str(path)
+        consumed_failure = dict_value(handoff.get("consumedFailure"))
         local_plan = dict_value(handoff.get("localDiagnosticPlan"))
+        if (
+            local_plan is None
+            and consumed_failure_is_private_server_http_readiness_timeout(consumed_failure)
+        ):
+            handoff["localDiagnosticPlan"] = build_local_private_server_http_readiness_diagnostic_plan(
+                consumed_failure,
+                current_run_id=self.run_id,
+                signature=signature,
+            )
+            local_plan = dict_value(handoff.get("localDiagnosticPlan"))
         if local_plan is not None:
             handoff["localDiagnosticPlan"] = enrich_local_private_server_http_readiness_diagnostic_plan_paths(
                 local_plan,
                 artifact_dir=self.artifact_dir,
                 handoff_path=path,
+            )
+            local_plan = dict_value(handoff.get("localDiagnosticPlan"))
+        if (
+            local_plan is not None
+            and consumed_failure_is_private_server_http_readiness_timeout(consumed_failure)
+        ):
+            handoff["localDiagnosticHandoff"] = build_local_private_server_http_readiness_diagnostic_handoff(
+                consumed_failure,
+                signature=signature,
+                validation_plan_path=path,
+                validation_plan_status=text_value(handoff.get("status")) or "validation_plan_required",
+                requested=handoff.get("requested") is True,
+                local_plan=local_plan,
             )
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(canonical_json(handoff), encoding="utf-8")
@@ -1213,6 +1237,9 @@ class Controller:
         local_plan = dict_value(handoff.get("localDiagnosticPlan"))
         if local_plan is not None:
             summary["localDiagnosticPlan"] = copy.deepcopy(local_plan)
+        local_diagnostic_handoff = dict_value(handoff.get("localDiagnosticHandoff"))
+        if local_diagnostic_handoff is not None:
+            summary["localDiagnosticHandoff"] = copy.deepcopy(local_diagnostic_handoff)
         self.result["validationPlanHandoff"] = summary
         return summary
 
@@ -3304,6 +3331,12 @@ def paid_failure_guard_requires_explicit_validation_plan(guard: dict[str, Any]) 
 
 def paid_failure_consumed_validation_needs_new_bounded_plan(validation: dict[str, Any]) -> bool:
     consumed_failure = paid_failure_consumed_validation_failure_summary(validation)
+    return consumed_failure_is_private_server_http_readiness_timeout(consumed_failure)
+
+
+def consumed_failure_is_private_server_http_readiness_timeout(
+    consumed_failure: dict[str, Any] | None,
+) -> bool:
     if consumed_failure is None:
         return False
     return (
@@ -3697,6 +3730,70 @@ def build_local_private_server_http_readiness_diagnostic_plan(
     }
 
 
+def build_local_private_server_http_readiness_diagnostic_handoff(
+    consumed_failure: dict[str, Any],
+    *,
+    signature: str,
+    validation_plan_path: Path,
+    validation_plan_status: str,
+    requested: bool,
+    local_plan: dict[str, Any],
+) -> dict[str, Any]:
+    diagnostic_steps = local_plan.get("diagnosticSteps")
+    step_ids = [
+        step["id"]
+        for step in diagnostic_steps
+        if isinstance(step, dict) and isinstance(step.get("id"), str)
+    ] if isinstance(diagnostic_steps, list) else []
+    paid_hold = dict_value(local_plan.get("paidTencentRerunHold")) or {}
+    blocked_actions = paid_hold.get("blockedActions")
+    if not isinstance(blocked_actions, list):
+        blocked_actions = [
+            "Tencent ASG scale-out",
+            "paid run-single rerun",
+            "remote training",
+            "--allow-paid-failure-recurrence-validation rerun",
+        ]
+    return {
+        "mode": LOCAL_NO_COMPUTE_PRIVATE_SERVER_HTTP_READINESS_DIAGNOSTIC_MODE,
+        "status": "private_server_http_readiness_timeout_local_diagnostic_required",
+        "failure": {
+            "priorAttemptRunId": text_value(consumed_failure.get("priorAttemptRunId")),
+            "summaryPath": text_value(consumed_failure.get("summaryPath")),
+            "classification": text_value(consumed_failure.get("failureClassification")),
+            "remoteTrainingFailureClass": text_value(consumed_failure.get("remoteTrainingFailureClass")),
+            "remoteTrainingTimeoutReason": text_value(consumed_failure.get("remoteTrainingTimeoutReason")),
+            "successfulEnvironmentRows": consumed_failure.get("successfulEnvironmentRows"),
+            "failedEnvironmentRows": consumed_failure.get("failedEnvironmentRows"),
+            "completedEnvironmentRows": consumed_failure.get("completedEnvironmentRows"),
+            "ticksRun": consumed_failure.get("ticksRun"),
+        },
+        "recommendedLocalDiagnosticNextStep": (
+            "complete the localDiagnosticPlan diagnosticSteps locally, record the diagnostic summary, "
+            "and keep paid Tencent compute held until the private-server HTTP readiness evidence is reviewed"
+        ),
+        "recommendedLocalDiagnosticStepIds": step_ids,
+        "validationPlan": {
+            "path": str(validation_plan_path),
+            "signature": signature,
+            "status": validation_plan_status,
+            "requested": requested,
+        },
+        "noPaidComputeGuard": {
+            "noCompute": True,
+            "noPaidRun": True,
+            "paidRunAttempted": False,
+            "computeAttempted": False,
+            "scaleOutAttempted": False,
+            "remoteTrainingAttempted": False,
+            "requiresTencentScaleOut": False,
+            "requiresPaidCompute": False,
+            "blockedActions": copy.deepcopy(blocked_actions),
+        },
+        "paidTencentRerunHold": copy.deepcopy(paid_hold),
+    }
+
+
 def build_paid_failure_validation_plan_handoff(
     guard: dict[str, Any],
     *,
@@ -3771,11 +3868,7 @@ def build_paid_failure_validation_plan_handoff(
         handoff["consumedFailure"] = consumed_failure
     if (
         status == PAID_FAILURE_RECURRENCE_CONSUMED_FAILURE_PLAN_REQUIRED_FINAL_STATUS
-        and consumed_failure is not None
-        and (
-            text_value(consumed_failure.get("failureClassification")) == "private_server_http_readiness_timeout"
-            or text_value(consumed_failure.get("remoteTrainingTimeoutReason")) == "private_server_http_readiness"
-        )
+        and consumed_failure_is_private_server_http_readiness_timeout(consumed_failure)
     ):
         handoff["localDiagnosticPlan"] = build_local_private_server_http_readiness_diagnostic_plan(
             consumed_failure,

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -5174,6 +5174,35 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertIn("private_server_http_readiness_timeout", plan_payload["reason"])
         self.assertIn("localDiagnosticPlan", handoff)
         self.assertEqual(plan_payload["localDiagnosticPlan"], handoff["localDiagnosticPlan"])
+        self.assertIn("localDiagnosticHandoff", handoff)
+        self.assertEqual(plan_payload["localDiagnosticHandoff"], handoff["localDiagnosticHandoff"])
+        local_handoff = handoff["localDiagnosticHandoff"]
+        self.assertEqual(
+            local_handoff["mode"],
+            runner.LOCAL_NO_COMPUTE_PRIVATE_SERVER_HTTP_READINESS_DIAGNOSTIC_MODE,
+        )
+        self.assertEqual(
+            local_handoff["status"],
+            "private_server_http_readiness_timeout_local_diagnostic_required",
+        )
+        self.assertEqual(local_handoff["failure"]["classification"], "private_server_http_readiness_timeout")
+        self.assertEqual(local_handoff["failure"]["remoteTrainingFailureClass"], "remote_training_timeout")
+        self.assertEqual(local_handoff["failure"]["remoteTrainingTimeoutReason"], "private_server_http_readiness")
+        self.assertEqual(local_handoff["failure"]["successfulEnvironmentRows"], 19)
+        self.assertEqual(local_handoff["failure"]["failedEnvironmentRows"], 1)
+        self.assertEqual(local_handoff["validationPlan"]["path"], handoff["path"])
+        self.assertEqual(
+            local_handoff["validationPlan"]["signature"],
+            runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+        )
+        self.assertEqual(local_handoff["validationPlan"]["status"], handoff["status"])
+        self.assertTrue(local_handoff["validationPlan"]["requested"])
+        self.assertTrue(local_handoff["noPaidComputeGuard"]["noCompute"])
+        self.assertTrue(local_handoff["noPaidComputeGuard"]["noPaidRun"])
+        self.assertFalse(local_handoff["noPaidComputeGuard"]["paidRunAttempted"])
+        self.assertFalse(local_handoff["noPaidComputeGuard"]["requiresPaidCompute"])
+        self.assertIn("private-server HTTP readiness", local_handoff["recommendedLocalDiagnosticNextStep"])
+        self.assertIn("record-diagnostic-summary", local_handoff["recommendedLocalDiagnosticStepIds"])
         local_plan = handoff["localDiagnosticPlan"]
         self.assertEqual(
             local_plan["mode"],
@@ -5238,6 +5267,132 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             self.assertFalse(step["requiresTencentScaleOut"])
             self.assertFalse(step["requiresPaidCompute"])
             self.assertFalse(step["printsSecrets"])
+
+    def test_paid_failure_recurrence_guard_hands_off_readiness_timeout_diagnostic_without_signature(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_root = Path(temp_dir) / "batch-runs"
+            for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD):
+                write_tencent_failure_summary(artifact_root, f"tencent-pg-room-busy-{index}")
+            prior_attempt_path = write_post_fix_validation_readiness_timeout_summary(
+                artifact_root,
+                "postfix-validation-run-20260601t231342z",
+            )
+            args = runner.parse_cli_args([
+                "run-single",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(artifact_root),
+                "--training-approach",
+                "policy_gradient",
+                "--scenario-id",
+                runner.MULTI_TIER_SCENARIO_ID,
+                "--ticks",
+                str(runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS),
+                "--workers",
+                "5",
+                "--scale-environments",
+                "5",
+                "--repetitions",
+                "20",
+                "--training-timeout-seconds",
+                "3600",
+            ])
+            artifact_dir = artifact_root / "new-run"
+
+            with mock.patch.object(
+                runner,
+                "paid_failure_recurrence_known_fix_status",
+                return_value={
+                    "signature": runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+                    "issue": "#1501",
+                    "pullRequest": "#1504",
+                    "mergeCommit": "95f960b2",
+                    "present": True,
+                    "evidence": "merge commit 95f960b2 is reachable from HEAD",
+                },
+            ):
+                events, controller, guard, summary = self.run_stubbed_compute(args, artifact_dir)
+            handoff = summary["outputs"]["validationPlanHandoff"]
+            plan_payload = json.loads(Path(handoff["path"]).read_text(encoding="utf-8"))
+
+        self.assertEqual(events, [])
+        self.assertEqual(
+            controller.final_status,
+            runner.PAID_FAILURE_RECURRENCE_VALIDATION_PLAN_REQUIRED_FINAL_STATUS,
+        )
+        self.assertEqual(
+            summary["finalStatus"],
+            runner.PAID_FAILURE_RECURRENCE_VALIDATION_PLAN_REQUIRED_FINAL_STATUS,
+        )
+        self.assertTrue(guard["blocked"])
+        self.assertEqual(guard["status"], runner.PAID_FAILURE_RECURRENCE_POST_FIX_VALIDATION_CONSUMED_STATUS)
+        validation = guard["postFixValidation"]
+        self.assertEqual(validation["status"], "consumed")
+        self.assertFalse(validation["requested"])
+        self.assertEqual(validation["priorAttempt"]["runId"], "postfix-validation-run-20260601t231342z")
+        self.assertEqual(validation["priorAttempt"]["remoteTrainingFailureClass"], "remote_training_timeout")
+        self.assertEqual(validation["priorAttempt"]["remoteTrainingTimeoutReason"], "private_server_http_readiness")
+        self.assertFalse(summary["execution"]["computeAttempted"])
+        self.assertFalse(summary["execution"]["paidRunAttempted"])
+        self.assertFalse(summary["execution"]["scaleOutAttempted"])
+        self.assertFalse(summary["execution"]["remoteTrainingAttempted"])
+        self.assertTrue(summary["execution"]["launchGuardNoCompute"])
+        self.assertEqual(handoff["status"], "validation_plan_required")
+        self.assertFalse(handoff["requested"])
+        self.assertEqual(
+            handoff["signature"],
+            runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+        )
+        self.assertIn("localDiagnosticPlan", handoff)
+        self.assertIn("localDiagnosticHandoff", handoff)
+        self.assertEqual(plan_payload["localDiagnosticPlan"], handoff["localDiagnosticPlan"])
+        self.assertEqual(plan_payload["localDiagnosticHandoff"], handoff["localDiagnosticHandoff"])
+        local_handoff = handoff["localDiagnosticHandoff"]
+        self.assertEqual(
+            local_handoff["mode"],
+            runner.LOCAL_NO_COMPUTE_PRIVATE_SERVER_HTTP_READINESS_DIAGNOSTIC_MODE,
+        )
+        self.assertEqual(
+            local_handoff["status"],
+            "private_server_http_readiness_timeout_local_diagnostic_required",
+        )
+        self.assertEqual(
+            local_handoff["failure"]["priorAttemptRunId"],
+            "postfix-validation-run-20260601t231342z",
+        )
+        self.assertEqual(local_handoff["failure"]["summaryPath"], str(prior_attempt_path))
+        self.assertEqual(local_handoff["failure"]["classification"], "private_server_http_readiness_timeout")
+        self.assertEqual(local_handoff["failure"]["remoteTrainingFailureClass"], "remote_training_timeout")
+        self.assertEqual(local_handoff["failure"]["remoteTrainingTimeoutReason"], "private_server_http_readiness")
+        self.assertEqual(local_handoff["failure"]["successfulEnvironmentRows"], 4)
+        self.assertEqual(local_handoff["failure"]["failedEnvironmentRows"], 1)
+        self.assertEqual(local_handoff["failure"]["completedEnvironmentRows"], 5)
+        self.assertEqual(local_handoff["validationPlan"]["path"], handoff["path"])
+        self.assertEqual(
+            local_handoff["validationPlan"]["signature"],
+            runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
+        )
+        self.assertEqual(local_handoff["validationPlan"]["status"], "validation_plan_required")
+        self.assertFalse(local_handoff["validationPlan"]["requested"])
+        self.assertTrue(local_handoff["noPaidComputeGuard"]["noCompute"])
+        self.assertTrue(local_handoff["noPaidComputeGuard"]["noPaidRun"])
+        self.assertFalse(local_handoff["noPaidComputeGuard"]["paidRunAttempted"])
+        self.assertFalse(local_handoff["noPaidComputeGuard"]["computeAttempted"])
+        self.assertFalse(local_handoff["noPaidComputeGuard"]["scaleOutAttempted"])
+        self.assertFalse(local_handoff["noPaidComputeGuard"]["remoteTrainingAttempted"])
+        self.assertFalse(local_handoff["noPaidComputeGuard"]["requiresPaidCompute"])
+        self.assertFalse(local_handoff["noPaidComputeGuard"]["requiresTencentScaleOut"])
+        self.assertIn("paid run-single rerun", local_handoff["noPaidComputeGuard"]["blockedActions"])
+        self.assertIn("private-server HTTP readiness", local_handoff["recommendedLocalDiagnosticNextStep"])
+        self.assertIn("before any paid Tencent rerun", handoff["localDiagnosticPlan"]["reason"])
+        self.assertIn("inspect-prior-controller-summary", local_handoff["recommendedLocalDiagnosticStepIds"])
+        self.assertIn("private-smoke-dry-run", local_handoff["recommendedLocalDiagnosticStepIds"])
+        self.assertIn("record-diagnostic-summary", local_handoff["recommendedLocalDiagnosticStepIds"])
+        self.assertEqual(
+            summary["outputs"]["launchGuard"]["validationPlanHandoff"]["localDiagnosticHandoff"],
+            local_handoff,
+        )
 
     def test_paid_failure_recurrence_guard_explains_timeout_recovery_when_signature_missing(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
Fixes #1916.

## Summary
- Clarifies Tencent post-fix validation readiness diagnostics when the prior validation failure was a private-server HTTP readiness timeout.
- Adds local guard/test coverage so the runner names the no-compute diagnostic handoff instead of retrying paid Tencent compute blindly.
- Keeps official MMO writes and Tencent scale-out disabled for this change.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest scripts/test_screeps_tencent_batch_rl_runner.py` (182 tests)
- No-compute preflight artifact: `runtime-artifacts/tencent-cloud/batch-runs/pr1916-controller-preflight-20260615t162740z/controller-summary.json` (`paidRunAttempted=false`, `scaleOutAttempted=false`, `remoteTrainingAttempted=false`; exited before compute on local experiment-card validation)
- Read-only ASG proof: `runtime-artifacts/tencent-cloud/batch-runs/pr1916-asg-readonly-20260615t1628z.json` (`desiredCapacity=0`, `instanceCount=0`, `inServiceInstanceCount=0`)

## Issue closure gate
- [x] #1916: Codex-authored commit `d5101f7d` implements the Tencent validation-plan readiness diagnostic path, targeted syntax/tests pass, and read-only/no-compute artifacts prove ASG `0/0/0` with no paid run.

## Universal task Done gate
- [x] Task type: RL flywheel bugfix / ops diagnostic guard.
- [x] Expected observable outcome / named deliverable: Tencent batch runner emits a private-server readiness-timeout diagnostic and local validation-plan handoff without paid compute.
- [x] Non-goals / accepted substitutes: no Tencent paid `run-single`, no scale-out, no official MMO writes; read-only ASG `0/0/0` evidence is the accepted no-compute proof.
- [x] Verification evidence required before Done: diff-check, Python compile, 182-test unittest run, no-compute controller summary, and read-only ASG proof are listed above.
- [x] Project Evidence / Next action / Blocked by: #1916 Project evidence records the PR/head/tests/no-compute proof; #1032/#1233/#1583 keep separate safety holds until their own gates clear.
- [x] Post-merge/deploy/runtime proof: merge of this scripts-only diagnostic PR is the landing proof; no official MMO deploy is required for this issue.
- [x] Named deliverable proof: commit `d5101f7d`, `scripts/screeps_tencent_batch_rl_runner.py`, `scripts/test_screeps_tencent_batch_rl_runner.py`, and the two no-compute artifact paths above.
