### PR TITLE
rl: require full gradient-trust repetitions

### DIFF
--- a/scripts/screeps_tencent_batch_rl_runner.py
+++ b/scripts/screeps_tencent_batch_rl_runner.py
@@ -6903,14 +6903,12 @@ def validate_tencent_s3_validation_scale_cap(args: argparse.Namespace, scale_env
 
 
 def policy_gradient_samples_per_candidate(args: argparse.Namespace) -> int:
-    repetitions = max(1, int(getattr(args, "repetitions", 1) or 1))
-    scale_environments = resolve_scale_environment_count(args) or 1
-    return repetitions * scale_environments
+    # The card validator gates the weakest candidate after row expansion, not total rows.
+    return max(1, int(getattr(args, "repetitions", 1) or 1))
 
 
 def policy_gradient_min_repetitions_for_trust(args: argparse.Namespace) -> int:
-    scale_environments = resolve_scale_environment_count(args) or 1
-    return max(1, math.ceil(POLICY_GRADIENT_TRUST_MIN_SAMPLES_PER_CANDIDATE / scale_environments))
+    return POLICY_GRADIENT_TRUST_MIN_SAMPLES_PER_CANDIDATE
 
 
 def policy_gradient_trust_sample_request(args: argparse.Namespace) -> dict[str, Any] | None:

--- a/scripts/test_screeps_tencent_batch_rl_runner.py
+++ b/scripts/test_screeps_tencent_batch_rl_runner.py
@@ -4320,7 +4320,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 "--scale-environments",
                 "5",
                 "--repetitions",
-                "5",
+                "20",
                 "--allow-paid-failure-recurrence-validation",
                 runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
             ])
@@ -4358,7 +4358,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(guard["postFixValidation"]["priorAttempt"]["environmentsRun"], 0)
         self.assertEqual(
             guard["currentLaunch"]["policyGradientTrustSampleRequest"]["requestedSamplesPerCandidate"],
-            25,
+            20,
         )
         self.assertTrue(guard["currentLaunch"]["policyGradientTrustSampleRequest"]["meetsTrustSampleTarget"])
         self.assertEqual(controller.final_status, "completed")
@@ -4392,7 +4392,9 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 "--scale-environments",
                 "5",
                 "--repetitions",
-                "5",
+                "20",
+                "--training-timeout-seconds",
+                "7200",
                 "--postfix-validation-signature",
                 runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
             ])
@@ -4713,7 +4715,9 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
                 "--scale-environments",
                 "5",
                 "--repetitions",
-                "5",
+                "20",
+                "--training-timeout-seconds",
+                "7200",
                 "--postfix-validation-signature",
                 runner.PAID_FAILURE_PLACE_SPAWN_ROOM_BUSY_SIGNATURE,
             ])
@@ -6136,7 +6140,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
             {f"tencent-pg-room-busy-{index}" for index in range(runner.PAID_FAILURE_RECURRENCE_GUARD_THRESHOLD)},
         )
 
-    def test_no_arg_preflight_defaults_to_multi_tier_policy_gradient_without_repeat_guard(self) -> None:
+    def test_no_arg_preflight_defaults_to_multi_tier_policy_gradient_trust_repetitions(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             artifact_root = Path(temp_dir) / "batch-runs"
             for run_id in ("tencent-pg-1", "tencent-pg-2", "tencent-pg-3"):
@@ -6156,7 +6160,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(args.scenario_id, runner.MULTI_TIER_SCENARIO_ID)
         self.assertTrue(args.require_multi_tier_scenario)
         self.assertEqual(args.workers, 5)
-        self.assertEqual(args.repetitions, 4)
+        self.assertEqual(args.repetitions, 20)
         self.assertFalse(args.run_id.startswith("tencent-single-"))
         self.assertEqual(controller.final_status, "preflight_ok")
         self.assertEqual(summary["finalStatus"], "preflight_ok")
@@ -6197,9 +6201,76 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(args.scenario_id, runner.MULTI_TIER_SCENARIO_ID)
         self.assertTrue(args.require_multi_tier_scenario)
         self.assertEqual(args.workers, 5)
-        self.assertEqual(args.repetitions, 4)
+        self.assertEqual(args.repetitions, 20)
         self.assertEqual(runner.policy_gradient_samples_per_candidate(args), 20)
         self.assertEqual(runner.effective_training_ticks(args), runner.POLICY_GRADIENT_MIN_SIMULATION_TICKS)
+
+    def test_no_arg_policy_gradient_card_generation_satisfies_gradient_trust_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            args = runner.parse_cli_args([
+                "preflight",
+                "--run-id",
+                "new-run",
+                "--artifact-root",
+                str(root),
+            ])
+            controller = runner.Controller(args=args, run_id=args.run_id, artifact_dir=root / "new-run")
+            validate_called = False
+
+            def fake_run_cp(name: str, cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                nonlocal validate_called
+                if name == "generate_experiment_card":
+                    output = Path(cmd[cmd.index("--output") + 1])
+                    output.parent.mkdir(parents=True, exist_ok=True)
+                    requested_scenario_id = cmd[cmd.index("--scenario-id") + 1]
+                    payload = card_helper.build_card(
+                        dataset_run_id="dataset-test",
+                        code_commit="a" * 40,
+                        training_approach="policy_gradient",
+                        created_at="2026-06-15T16:27:40Z",
+                        loop_a_card_supply="--loop-a-policy-gradient-supply" in cmd,
+                        scenario_id=requested_scenario_id,
+                        require_multi_tier_scenario="--require-multi-tier-scenario" in cmd,
+                    )
+                    payload["simulation"]["repetitions"] = 1
+                    output.write_text(json.dumps(payload), encoding="utf-8")
+                elif name == "validate_experiment_card":
+                    validate_called = True
+                    card_path = Path(cmd[cmd.index("--input") + 1])
+                    card_helper.validate_card(json.loads(card_path.read_text(encoding="utf-8")))
+                return subprocess.CompletedProcess(cmd, 0, "{}", "")
+
+            with mock.patch.object(controller, "run_cp", side_effect=fake_run_cp):
+                controller.generate_experiment_card()
+
+            card = json.loads((root / "new-run" / "experiment_card.json").read_text(encoding="utf-8"))
+
+        self.assertTrue(validate_called)
+        self.assertEqual(card["training_approach"], "policy_gradient")
+        self.assertEqual(card["simulation"]["workers"], 5)
+        self.assertEqual(card["simulation"]["scale_environments"], 5)
+        self.assertEqual(card["simulation"]["repetitions"], 20)
+        self.assertEqual(
+            card["policy_gradient"]["validation_sample_request"]["requestedSamplesPerCandidate"],
+            20,
+        )
+        self.assertTrue(card["policy_gradient"]["validation_sample_request"]["meetsTrustSampleTarget"])
+        low_repetition_plan = card_helper.policy_gradient_trust_sample_plan(
+            repetitions=4,
+            scale_environments=5,
+            variant_count=len(card["strategy_variants"]),
+            required_samples_per_candidate=runner.POLICY_GRADIENT_TRUST_MIN_SAMPLES_PER_CANDIDATE,
+        )
+        self.assertEqual(low_repetition_plan["minimumSamplesPerCandidate"], 4)
+        self.assertEqual(low_repetition_plan["requiredRepetitions"], 20)
+        selected_plan = card_helper.policy_gradient_trust_sample_plan(
+            repetitions=card["simulation"]["repetitions"],
+            scale_environments=card["simulation"]["scale_environments"],
+            variant_count=len(card["strategy_variants"]),
+            required_samples_per_candidate=runner.POLICY_GRADIENT_TRUST_MIN_SAMPLES_PER_CANDIDATE,
+        )
+        self.assertEqual(selected_plan["minimumSamplesPerCandidate"], 20)
 
     def test_effective_training_ticks_preserves_non_policy_gradient_request(self) -> None:
         args = controller_args()
@@ -6572,7 +6643,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         self.assertEqual(args.scenario_id, runner.MULTI_TIER_SCENARIO_ID)
         self.assertTrue(args.require_multi_tier_scenario)
         self.assertEqual(args.workers, 5)
-        self.assertEqual(args.repetitions, 4)
+        self.assertEqual(args.repetitions, 20)
 
     def test_policy_gradient_legacy_v0_default_resolves_to_active_multi_tier_scenario(self) -> None:
         args = controller_args()
@@ -6618,7 +6689,7 @@ class TencentBatchRlRunnerTest(unittest.TestCase):
         runner.apply_cli_scenario_defaults(args)
 
         self.assertEqual(args.workers, 5)
-        self.assertEqual(args.repetitions, 4)
+        self.assertEqual(args.repetitions, 20)
 
     def test_generate_experiment_card_writes_multi_environment_scale_proof_spec(self) -> None:
         args = controller_args()


### PR DESCRIPTION
Fixes #1921.

## Summary
- Treat policy-gradient trust as per-candidate repetitions after row expansion instead of multiplying by scale environments.
- Raise no-argument policy-gradient/Tencent validation-card defaults to 20 repetitions so generated experiment cards satisfy the gradient-trust gate before any paid compute.
- Add a card-generation regression test that proves the generated validation request reaches 20 samples per candidate.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/screeps_tencent_batch_rl_runner.py scripts/test_screeps_tencent_batch_rl_runner.py`
- `python3 -m unittest -q scripts.test_screeps_tencent_batch_rl_runner.TencentBatchRlRunnerTest.test_no_arg_policy_gradient_card_generation_satisfies_gradient_trust_gate scripts.test_screeps_tencent_batch_rl_runner.TencentBatchRlRunnerTest.test_no_arg_preflight_defaults_to_multi_tier_policy_gradient_trust_repetitions scripts.test_screeps_tencent_batch_rl_runner.TencentBatchRlRunnerTest.test_no_arg_run_single_defaults_to_multi_tier_policy_gradient_compute_mode`
- `python3 -m unittest -q scripts.test_screeps_tencent_batch_rl_runner` (183 tests OK)
- No Tencent scale-out, no paid compute, and no official MMO writes performed.

## Issue closure gate
- [x] #1921: Codex-authored commit `c404e728` requires full 20 policy-gradient trust repetitions, updates the Tencent batch runner/tests, passes diff-check, Python compile, targeted unittest, and the full `scripts.test_screeps_tencent_batch_rl_runner` unittest file.

## Universal task Done gate
- [x] Task type: RL flywheel bugfix / validation-card gate repair.
- [x] Expected observable outcome / named deliverable: no-argument policy-gradient/Tencent preflight cards request 20 repetitions and report 20 requested samples per candidate.
- [x] Non-goals / accepted substitutes: no Tencent paid run, no scale-out, no official MMO writes; local validation-card and unittest proof are the accepted deliverables.
- [x] Verification evidence required before Done: diff-check, Python compile, targeted unittest, and 183-test runner unittest file all pass on commit `c404e728`.
- [x] Project Evidence / Next action / Blocked by: #1921 Project item records PR head `c404e728`, verification commands, and PR review gate as the executable next step.
- [x] Post-merge/deploy/runtime proof: merge of this scripts/test-only PR plus green required checks is the landing proof; no official MMO deploy is required for this issue.
- [x] Named deliverable proof: `scripts/screeps_tencent_batch_rl_runner.py`, `scripts/test_screeps_tencent_batch_rl_runner.py`, and commit `c404e728` implement the gradient-trust card repair.
