### PR TITLE
fix(agent-os): sync runtime alert cron registry model

### DIFF
--- a/docs/ops/cron-and-route-registry.md
+++ b/docs/ops/cron-and-route-registry.md
@@ -92,7 +92,7 @@ Repeat policy values:
 Controller contract:
 
 - Default low-quota threshold: suppress non-P0 `openai-codex` jobs when weekly remaining quota is below `10%`.
-- Protected Codex runway: continuation worker `f66ed36d7be0`, runtime alert `1df5ef0c3835`, and RL flywheel steward `aed8362e4501`.
+- Protected Codex runway: continuation worker `f66ed36d7be0` and RL flywheel steward `aed8362e4501`. The high-frequency runtime alert `1df5ef0c3835` is intentionally on `deepseek/deepseek-v4-flash` to avoid consuming Codex quota during normal silent health checks.
 - Unknown, missing, or malformed quota telemetry fails safe by allowing protected P0 Codex jobs and suppressing non-P0 Codex jobs with an explicit `UNKNOWN_QUOTA` report.
 - Reset self-healing: if the telemetry `resetAt`/`resets_at` time is in the past, the guard treats the weekly budget as reset and previously suppressed jobs become eligible without manual state cleanup.
 - Do not attach raw Codex session logs to Discord or GitHub; pass a redacted quota JSON export when possible.
@@ -110,7 +110,7 @@ python3 scripts/check_codex_quota_budget.py \
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Screeps autonomous continuation worker | `f66ed36d7be0` | `8,28,48 * * * *` | `discord:#task-queue` | `openai-codex` | `gpt-5.5` | `/root/screeps` | `high-horizon` | P0 | Dispatcher/reconciler for safe work lanes. |
 | Screeps P0 agent operations monitor | `75cedbb77150` | `7,37 * * * *` | `discord:1497820688843800776` | `deepseek` | `deepseek-v4-flash` | `-` | `forever` | P0 | Autonomous-system health monitor, registry-drift detector, and consolidated Tencent Cloud cost guard. |
-| Screeps runtime room alert text check | `1df5ef0c3835` | `1,16,31,46 * * * *` | `discord:1497588512436785284` | `openai-codex` | `gpt-5.5` | `-` | `forever` | P0 | Runtime alert/tactical response for all owned rooms; no-alert runs return exactly `[SILENT]`. |
+| Screeps runtime room alert text check | `1df5ef0c3835` | `1,16,31,46 * * * *` | `discord:1497588512436785284` | `deepseek` | `deepseek-v4-flash` | `-` | `forever` | P0 | Runtime alert/tactical response for all owned rooms; no-alert runs return exactly `[SILENT]`; intentionally off Codex quota. |
 | Screeps owner-decision escalation fanout | `bbc7f783075e` | `3,13,23,33,43,53 * * * *` | `discord:1497586175580311654` | `deepseek` | `deepseek-v4-flash` | `-` | `high-horizon` | P0 | Mirrors fresh unresolved owner-action decisions to the canonical decisions route. |
 | Screeps runtime room summary images | `befcbb7b2d60` | `58 * * * *` | `discord:1497588267057680385` | `deepseek` | `deepseek-v4-flash` | `-` | `high-horizon` | P1 | Runtime summary report/images for all owned rooms. |
 | Screeps console capture (live energy telemetry) | `7ee147327ba6` | `*/30 * * * *` | `local` | `deepseek` | `deepseek-v4-flash` | `-` | `forever` | P1 | Local bounded console/energy telemetry collector. |

--- a/scripts/check_codex_quota_budget.py
+++ b/scripts/check_codex_quota_budget.py
@@ -32,7 +32,6 @@ DEFAULT_WEEKLY_WINDOW_MINUTES = 10080
 DEFAULT_RESERVED_CODEX_JOB_IDS = frozenset(
     {
         "f66ed36d7be0",  # autonomous continuation worker
-        "1df5ef0c3835",  # runtime room alert text check
         "aed8362e4501",  # RL flywheel steward
     }
 )


### PR DESCRIPTION
## Summary
- Sync the cron registry row for `1df5ef0c3835` to the live/P0-monitor expected `deepseek/deepseek-v4-flash` model.
- Remove `1df5ef0c3835` from the protected Codex quota reserve list so future Codex budget checks see only the two actual Codex jobs.
- Document that the high-frequency runtime alert is intentionally off Codex quota to prevent future registry-repair rollback.

## Linked issue
- related to issue 1135

## Roadmap category
- Agent OS / ops

## Verification
- `python3 -m py_compile scripts/check_cron_registry.py scripts/check_codex_quota_budget.py`
- `python3 scripts/check_cron_registry.py --strict`
- `python3 scripts/check_codex_quota_budget.py --quota-json /tmp/codex-quota-ok.json --job-id 1df5ef0c3835`
- `python3 -m pytest scripts/test_check_codex_quota_budget.py -q`
- `git diff --check`

## Universal task Done gate
- [x] Task type: ops/docs/script registry repair.
- [x] Expected observable outcome / named deliverable: repo registry/checker no longer treats `1df5ef0c3835` as an `openai-codex/gpt-5.5` job, matching the live scheduler and P0 monitor prompt.
- [x] Non-goals / accepted substitutes: no production bot code change and no official MMO deploy; this is a scheduler registry/quota-guard consistency fix.
- [x] Verification evidence required before Done: strict cron registry check passes, quota decision for `1df5ef0c3835` reports `not_codex_provider`, and quota summary shows two protected Codex jobs.
- [x] Project Evidence / Next action / Blocked by: controller records evidence on the related Agent OS issue/PR Project items; no owner-side action is required for this registry sync.
- [x] Post-merge/deploy/runtime proof: N/A for MMO deploy; live scheduler metadata was separately verified as `deepseek/deepseek-v4-flash`.
- [x] Named deliverable proof: this PR updates `docs/ops/cron-and-route-registry.md` and `scripts/check_codex_quota_budget.py` to align the durable expectation surfaces.
