### PR TITLE
worker-task: refill low-load secondary builders for construction gaps

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35435,10 +35435,10 @@ function shouldSelectConstructionBacklogEnergyAcquisitionRecoveryTask(creep, cur
   if (isCriticalSpawnRefillTask(currentTask) || isCriticalSpawnRefillTask(selectedTask)) {
     return false;
   }
-  return isConstructionBacklogEnergyAcquisitionRecoveryTask(currentTask) && isConstructionBacklogEnergyAcquisitionRecoveryTask(selectedTask);
+  return isConstructionBacklogEnergyAcquisitionRecoveryTask(creep, currentTask) && isConstructionBacklogEnergyAcquisitionRecoveryTask(creep, selectedTask);
 }
-function isConstructionBacklogEnergyAcquisitionRecoveryTask(task) {
-  return task === void 0 || task === null || isEnergyAcquisitionTask2(task) && !isConstructionWithdrawReservationTask(task) || task.type === "transfer" || task.type === "upgrade";
+function isConstructionBacklogEnergyAcquisitionRecoveryTask(creep, task) {
+  return task === void 0 || task === null || isEnergyAcquisitionTask2(task) && !isConstructionWithdrawReservationTask(task) || task.type === "build" && hasLowWorkerEnergyLoad(creep) || task.type === "transfer" || task.type === "upgrade";
 }
 function selectAssignedBuildEnergyAcquisitionTask(creep, currentTask, selectedTask) {
   var _a2, _b;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -532,18 +532,20 @@ function shouldSelectConstructionBacklogEnergyAcquisitionRecoveryTask(
   }
 
   return (
-    isConstructionBacklogEnergyAcquisitionRecoveryTask(currentTask) &&
-    isConstructionBacklogEnergyAcquisitionRecoveryTask(selectedTask)
+    isConstructionBacklogEnergyAcquisitionRecoveryTask(creep, currentTask) &&
+    isConstructionBacklogEnergyAcquisitionRecoveryTask(creep, selectedTask)
   );
 }
 
 function isConstructionBacklogEnergyAcquisitionRecoveryTask(
+  creep: Creep,
   task: CreepTaskMemory | null | undefined
 ): boolean {
   return (
     task === undefined ||
     task === null ||
     (isEnergyAcquisitionTask(task) && !isConstructionWithdrawReservationTask(task)) ||
+    (task.type === 'build' && hasLowWorkerEnergyLoad(creep)) ||
     task.type === 'transfer' ||
     task.type === 'upgrade'
   );

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -8608,6 +8608,133 @@ describe('runWorker', () => {
     }
   });
 
+  it('refills a retained low-load secondary-room builder when current builders do not cover construction', () => {
+    const site = withRangeTo(
+      {
+        id: 'road-site1',
+        my: true,
+        structureType: 'road',
+        progress: 390,
+        progressTotal: 1_000
+      } as ConstructionSite,
+      { storage1: 6 }
+    );
+    const storage = {
+      id: 'storage1',
+      my: true,
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 338_162 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(200_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N57',
+      energyAvailable: 1_800,
+      energyCapacityAvailable: 1_800,
+      controller,
+      storage,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [storage] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [storage];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          if (type === FIND_HOSTILE_CREEPS) {
+            return [];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const withdraw = jest.fn().mockReturnValue(0);
+    const build = jest.fn();
+    const creep = {
+      name: 'LowLoadBuilder',
+      memory: {
+        role: 'worker',
+        colony: 'E29N57',
+        task: { type: 'build', targetId: 'road-site1' as Id<ConstructionSite> }
+      },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'storage1' ? 2 : 6))
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 20 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 80 : 0))
+      },
+      room,
+      build,
+      withdraw,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const loadedBuilder = {
+      name: 'LoadedBuilder',
+      memory: {
+        role: 'worker',
+        colony: 'E29N57',
+        task: { type: 'build', targetId: 'road-site1' as Id<ConstructionSite> }
+      },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, loadedBuilder);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { LowLoadBuilder: creep, LoadedBuilder: loadedBuilder },
+      rooms: { E29N57: room },
+      time: 2_224_943,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({
+      type: 'withdraw',
+      targetId: 'storage1',
+      constructionSiteId: 'road-site1'
+    });
+    expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+      currentTask: 'build',
+      baseSelectedTask: 'withdraw',
+      selectedTask: 'withdraw',
+      assignedTask: 'withdraw'
+    });
+    expect(withdraw).toHaveBeenCalledWith(storage, RESOURCE_ENERGY, 80);
+    expect(build).not.toHaveBeenCalled();
+  });
+
   it('recovers E29N55 build assignment from spawn-critical harvest when another worker covers spawn floor', () => {
     const source = {
       id: 'source1',


### PR DESCRIPTION
## Summary
- Related: #1927
- Refill a retained low-load builder in secondary construction rooms by allowing the construction-backlog energy recovery selector to replace a current build task when the worker is below the low-load energy threshold.
- Add regression coverage for an E29N57-style retained builder that should withdraw from storage instead of attempting to keep building with too little carried energy.
- Rebuild `prod/dist/main.js` from the verified source.

## Verification
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm test -- --runInBand` (105 suites, 2483 tests)
- [x] `npm run build`

## Universal task Done gate
- [x] Task type: production gameplay bugfix for a P0 Territory/Economy construction worker-assignment recurrence.
- [x] Expected observable outcome / named deliverable: low-load retained builders in secondary construction rooms switch to construction-linked energy withdrawal, enabling build energy delivery for worker-assignment-gap recurrence recovery.
- [x] Non-goals / accepted substitutes: no spawn planner, room targeting, RL policy, seasonal profile, or runtime monitor contract changes.
- [x] Verification evidence required before Done: controller verification passed `git diff --check`, `npm run typecheck`, `npm test -- --runInBand`, and `npm run build` on commit `5943c4d2ce00a7306373f04b163f3e79a53dec4b`.
- [x] Project Evidence / Next action / Blocked by: controller updates Project evidence to this PR head and keeps issue #1927 active for PR gates, deploy, and fresh all-room construction acceptance evidence.
- [x] Post-merge/deploy/runtime proof: official deploy plus fresh runtime monitor evidence should show all owned rooms alive and no sustained worker_assignment_gap alert for the rooms covered by #1927.
- [x] Named deliverable proof: `prod/src/creeps/workerRunner.ts`, `prod/test/workerRunner.test.ts`, and regenerated `prod/dist/main.js` are the complete deliverable set for the low-load-builder refill fix.

## Risk / rollback
- If post-deploy runtime monitor still reports worker_assignment_gap_sustained, keep issue #1927 active and dispatch the next smallest worker-assignment follow-up from fresh evidence.
