### PR TITLE
monitor: recognize typed build task evidence

### DIFF
--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -6375,7 +6375,7 @@ def object_has_build_task(value: Any) -> bool:
     if isinstance(value, dict):
         for key, item in value.items():
             lowered_key = str(key).lower()
-            if lowered_key in {"role", "task", "taskname", "action", "job", "intent"} and object_has_build_task(item):
+            if lowered_key in {"role", "task", "taskname", "type", "action", "job", "intent"} and object_has_build_task(item):
                 return True
             if isinstance(item, dict) and object_has_build_task(item):
                 return True

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -5025,6 +5025,86 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
             payload["rooms"][0]["constructionActivity"],
         )
 
+    def test_runtime_summary_payload_counts_build_task_type_carried_energy(self) -> None:
+        snapshot = monitor.RoomSnapshot(
+            ref=monitor.RoomRef(shard="shardX", room="E29N56"),
+            terrain="0" * monitor.TERRAIN_CELLS,
+            objects=monitor.normalize_objects(
+                {
+                    "site-1": {
+                        "_id": "site-1",
+                        "type": "constructionSite",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "structureType": "road",
+                        "progress": 415,
+                        "progressTotal": 500,
+                    },
+                    "worker-1": {
+                        "_id": "worker-1",
+                        "type": "creep",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "name": "worker-E29N56-1",
+                        "body": [
+                            {"type": "work", "hits": 100},
+                            {"type": "carry", "hits": 100},
+                        ],
+                        "store": {"energy": 26, "capacity": 50},
+                        "memory": {
+                            "role": "worker",
+                            "task": {"type": "build", "targetId": "site-1"},
+                        },
+                    },
+                    "worker-2": {
+                        "_id": "worker-2",
+                        "type": "creep",
+                        "my": True,
+                        "owner": {"username": "lanyusea"},
+                        "name": "worker-E29N56-2",
+                        "body": [
+                            {"type": "work", "hits": 100},
+                            {"type": "carry", "hits": 100},
+                        ],
+                        "store": {"energy": 50, "capacity": 50},
+                        "memory": {
+                            "role": "worker",
+                            "task": {"type": "repair", "targetId": "road-1"},
+                        },
+                    },
+                }
+            ),
+            tick=2228600,
+            owner="lanyusea",
+            info={"energyAvailable": 800},
+        )
+
+        payload = monitor.runtime_summary_payload_from_snapshots([snapshot])
+        room = payload["rooms"][0]
+        productive_energy = room["resources"]["productiveEnergy"]
+
+        self.assertEqual(room["taskCounts"]["build"], 1)
+        self.assertEqual(room["pendingBuildProgress"], 85)
+        self.assertEqual(room["buildCarriedEnergy"], 26)
+        self.assertEqual(productive_energy["buildCarriedEnergy"], 26)
+        self.assertNotIn("buildBlockedReason", room)
+        self.assertNotIn("buildBlockedReason", productive_energy)
+        self.assertEqual(
+            room["constructionActivity"],
+            {
+                "source": "runtime-summary",
+                "constructionSiteCount": 1,
+                "pendingBuildProgress": 85,
+                "buildCarriedEnergy": 26,
+                "buildProgress": 0,
+                "workerAssignmentEvidenceAvailable": True,
+                "state": "active",
+                "accepted": True,
+                "reason": "build_energy_carried",
+            },
+        )
+        self.assertEqual(productive_energy["constructionActivity"], room["constructionActivity"])
+
     def test_runtime_summary_payload_preserves_candidate_suppression_without_site_backlog(self) -> None:
         cases = {
             "spawn reservation": (


### PR DESCRIPTION
Related to issue 1930.

## Summary
- Recognize nested task objects that encode build work as `{type: "build"}` in runtime-summary classification.
- Add a focused regression test proving build task counts, build carried energy, and construction activity are accepted when worker memory uses `task.type`.
- This is a runtime-monitor/alert classifier fix only; it does not change official MMO bot behavior and does not require an official Screeps deploy.

## Verification
- [x] `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py`
- [x] `python3 -m unittest scripts.test_screeps_runtime_monitor_tactical_response.RuntimeKpiArtifactTests.test_runtime_summary_payload_counts_build_task_type_carried_energy -q`
- [x] `git diff --check`

## Universal task Done gate
- [x] Task type: runtime monitor / alert classifier bugfix for issue 1930.
- [x] Expected observable outcome / named deliverable: monitor logic treats `{type: "build"}` task evidence as build work and stops classifying those workers as construction assignment gaps.
- [x] Non-goals / accepted substitutes: no production bot behavior change, no Screeps code upload, no RL policy change, and no cron schedule change.
- [x] Verification evidence required before Done: controller py_compile, focused unittest, diff-check, and PR required checks pass on the pushed head.
- [x] Project Evidence / Next action / Blocked by: Project item for issue 1930 and this PR records head SHA, local verification, CI/review gate state, and runtime-alert acceptance evidence as the next gate.
- [x] Post-merge/deploy/runtime proof: official MMO deploy is not needed; runtime proof is a fresh runtime-alert or health-gate run from main showing typed build-task evidence is no longer counted as worker_assignment_gap.
- [x] Named deliverable proof: commit `933fb8fb90eab8879cd47b48cf97c7bae80d6f9e` changes only `scripts/screeps-runtime-monitor.py` and `scripts/test_screeps_runtime_monitor_tactical_response.py`.
