### PR TITLE
worker-task: recover stale refillers for construction gaps

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35484,7 +35484,7 @@ function selectWorkerAssignmentGapRecoveryTask(creep, currentTask, selectionCont
     return null;
   }
   const hasStoredConstructionRecoveryEnergy = hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room);
-  const hasMinimumWorkerCoverage = hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep) || hasStoredConstructionRecoveryEnergy && ((currentTask == null ? void 0 : currentTask.type) === "upgrade" || ((_a2 = selectionContext.selectedTask) == null ? void 0 : _a2.type) === "upgrade");
+  const hasMinimumWorkerCoverage = hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep) || hasStoredConstructionRecoveryEnergy && ((currentTask == null ? void 0 : currentTask.type) === "upgrade" || ((_a2 = selectionContext.selectedTask) == null ? void 0 : _a2.type) === "upgrade" || hasUncoveredStoredEnergyAssignmentGapRecovery(creep));
   if (getUsedTransferEnergy(creep) <= 0 || hasLowWorkerEnergyLoad(creep) || getActiveWorkParts3(creep) <= 0 || !hasMinimumWorkerCoverage || hasVisibleHostileCreeps2(creep.room) || currentTask && isDedicatedSourceContainerHarvestTask(creep, currentTask)) {
     return null;
   }
@@ -35500,6 +35500,9 @@ function selectWorkerAssignmentGapRecoveryTask(creep, currentTask, selectionCont
     return null;
   }
   return recoveryTask;
+}
+function hasUncoveredStoredEnergyAssignmentGapRecovery(creep) {
+  return selectSpawnEnergyReservationRefillTarget(creep) === null && !hasOtherSameRoomBuildAssignment(creep);
 }
 function isWorkerAssignmentGapRecoverySelection(creep, currentTask, selectedTask) {
   if (!currentTask && !selectedTask) {
@@ -36825,7 +36828,7 @@ function shouldPreemptTransferTaskForConstructionBacklog(creep, task, selectedTa
   if (task.type !== "transfer" || (selectedTask == null ? void 0 : selectedTask.type) !== "build" || isSameTask2(task, selectedTask)) {
     return false;
   }
-  if (getUsedTransferEnergy(creep) <= 0 || !hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep)) {
+  if (getUsedTransferEnergy(creep) <= 0 || !hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep) && !hasUncoveredStoredEnergyAssignmentGapRecovery(creep)) {
     return false;
   }
   const currentTarget = getTaskTarget(task);

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -665,7 +665,9 @@ function selectWorkerAssignmentGapRecoveryTask(
   const hasMinimumWorkerCoverage =
     hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep) ||
     (hasStoredConstructionRecoveryEnergy &&
-      (currentTask?.type === 'upgrade' || selectionContext.selectedTask?.type === 'upgrade'));
+      (currentTask?.type === 'upgrade' ||
+        selectionContext.selectedTask?.type === 'upgrade' ||
+        hasUncoveredStoredEnergyAssignmentGapRecovery(creep)));
   if (
     getUsedTransferEnergy(creep) <= 0 ||
     hasLowWorkerEnergyLoad(creep) ||
@@ -697,6 +699,10 @@ function selectWorkerAssignmentGapRecoveryTask(
   }
 
   return recoveryTask;
+}
+
+function hasUncoveredStoredEnergyAssignmentGapRecovery(creep: Creep): boolean {
+  return selectSpawnEnergyReservationRefillTarget(creep) === null && !hasOtherSameRoomBuildAssignment(creep);
 }
 
 function isWorkerAssignmentGapRecoverySelection(
@@ -2876,7 +2882,11 @@ function shouldPreemptTransferTaskForConstructionBacklog(
     return false;
   }
 
-  if (getUsedTransferEnergy(creep) <= 0 || !hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep)) {
+  if (
+    getUsedTransferEnergy(creep) <= 0 ||
+    (!hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep) &&
+      !hasUncoveredStoredEnergyAssignmentGapRecovery(creep))
+  ) {
     return false;
   }
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -8608,6 +8608,122 @@ describe('runWorker', () => {
     }
   });
 
+  it('recovers E29N57 build assignment from stale noncritical refill when no worker covers construction', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 275,
+      progressTotal: 300,
+      pos: { x: 22, y: 21, roomName: 'E29N57' } as RoomPosition
+    } as ConstructionSite;
+    const extension = {
+      id: 'extension1',
+      my: true,
+      structureType: 'extension',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+      }
+    } as unknown as StructureExtension;
+    const storage = {
+      id: 'storage1',
+      my: true,
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 335_357 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(200_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N57',
+      energyAvailable: 1_800,
+      energyCapacityAvailable: 1_800,
+      controller,
+      storage,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES) {
+            const structures = [extension, storage] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          if (type === FIND_HOSTILE_CREEPS) {
+            return [];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const transfer = jest.fn();
+    const creep = {
+      name: 'LoadedRefiller',
+      memory: {
+        role: 'worker',
+        colony: 'E29N57',
+        task: { type: 'transfer', targetId: 'extension1' as Id<AnyStoreStructure> }
+      },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'road-site1' ? 3 : 6))
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+      },
+      room,
+      build,
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    roomCreeps.push(creep);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { LoadedRefiller: creep },
+      rooms: { E29N57: room },
+      time: 2_231_575,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        if (id === 'extension1') {
+          return extension;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'road-site1' });
+    expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+      currentTask: 'transfer',
+      baseSelectedTask: 'build',
+      selectedTask: 'build',
+      assignedTask: 'build'
+    });
+    expect(build).toHaveBeenCalledWith(site);
+    expect(transfer).not.toHaveBeenCalled();
+  });
+
   it('refills a retained low-load secondary-room builder when current builders do not cover construction', () => {
     const site = withRangeTo(
       {


### PR DESCRIPTION
## Summary
- Extends construction-gap recovery so a loaded worker on stale noncritical refill can preempt into build work when no same-room builder currently covers an uncovered stored-energy construction gap.
- Adds E29N57 regression coverage for the observed stale-refiller scenario and rebuilds `prod/dist/main.js`.

## Verification
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand`
- [x] `cd prod && npm run build`
- [x] `git diff --check`

## Related runtime issue
- Related issue: 1930. The issue remains active for merge, deploy, and multi-window official-runtime acceptance evidence after this PR lands.

## Universal task Done gate
- [x] Task type: production gameplay hotfix / worker assignment recovery.
- [x] Expected observable outcome / named deliverable: stale loaded refill workers can switch to build work for uncovered construction gaps, with an E29N57 regression test and updated Screeps bundle.
- [x] Non-goals / accepted substitutes: no RL policy writes, no room retarget, no cron changes, no owner-side decision, and no attempt to close the runtime issue from local tests alone.
- [x] Verification evidence required before Done: controller-verified typecheck, full Jest run, bundle build, and `git diff --check` pass on commit `17ac2aed86d0bd8c479b1285946d9bafb8a07678`.
- [x] Project Evidence / Next action / Blocked by: Project should record this PR in review for issue 1930; next controller action is exact-head CI/CodeRabbit/thread/elapsed gate, then merge/deploy/runtime observation.
- [x] Post-merge/deploy/runtime proof: official-runtime proof target is fresh deploy plus runtime-summary/health-gate evidence showing construction-gap recovery on the landed gameplay commit.
- [x] Named deliverable proof: changed files are `prod/src/creeps/workerRunner.ts`, `prod/test/workerRunner.test.ts`, and generated `prod/dist/main.js`.