### PR TITLE
worker-task: prevent rotating construction assignment gaps

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35472,7 +35472,7 @@ function canConstructionWithdrawCompletionOverrideSelectedTask(creep, selectedTa
   return selectedTask === null || isEnergyAcquisitionTask2(selectedTask) || selectedTask.type === "build" || selectedTask.type === "transfer" && !isCriticalSpawnRefillTask(selectedTask) || selectedTask.type === "upgrade" && !isDowngradeGuardUpgradeTask(creep, selectedTask);
 }
 function shouldKeepConstructionWithdrawTaskForMoreEnergy(creep, currentTask, selectedTask) {
-  return getFreeTransferEnergyCapacity(creep) > 0 && selectedTask !== null && isSameTask2(currentTask, selectedTask) && hasOtherSameRoomBuildAssignment(creep);
+  return getFreeTransferEnergyCapacity(creep) > 0 && selectedTask !== null && isSameTask2(currentTask, selectedTask) && getOtherSameRoomBuildAssignmentProgress(creep) > 0;
 }
 function applyWorkerAssignmentGapRecoveryTask(creep, currentTask, selectionContext) {
   const recoveryTask = selectWorkerAssignmentGapRecoveryTask(creep, currentTask, selectionContext);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35472,7 +35472,7 @@ function canConstructionWithdrawCompletionOverrideSelectedTask(creep, selectedTa
   return selectedTask === null || isEnergyAcquisitionTask2(selectedTask) || selectedTask.type === "build" || selectedTask.type === "transfer" && !isCriticalSpawnRefillTask(selectedTask) || selectedTask.type === "upgrade" && !isDowngradeGuardUpgradeTask(creep, selectedTask);
 }
 function shouldKeepConstructionWithdrawTaskForMoreEnergy(creep, currentTask, selectedTask) {
-  return getFreeTransferEnergyCapacity(creep) > 0 && selectedTask !== null && isSameTask2(currentTask, selectedTask);
+  return getFreeTransferEnergyCapacity(creep) > 0 && selectedTask !== null && isSameTask2(currentTask, selectedTask) && hasOtherSameRoomBuildAssignment(creep);
 }
 function applyWorkerAssignmentGapRecoveryTask(creep, currentTask, selectionContext) {
   const recoveryTask = selectWorkerAssignmentGapRecoveryTask(creep, currentTask, selectionContext);

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -639,7 +639,8 @@ function shouldKeepConstructionWithdrawTaskForMoreEnergy(
   return (
     getFreeTransferEnergyCapacity(creep) > 0 &&
     selectedTask !== null &&
-    isSameTask(currentTask, selectedTask)
+    isSameTask(currentTask, selectedTask) &&
+    hasOtherSameRoomBuildAssignment(creep)
   );
 }
 

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -640,7 +640,7 @@ function shouldKeepConstructionWithdrawTaskForMoreEnergy(
     getFreeTransferEnergyCapacity(creep) > 0 &&
     selectedTask !== null &&
     isSameTask(currentTask, selectedTask) &&
-    hasOtherSameRoomBuildAssignment(creep)
+    getOtherSameRoomBuildAssignmentProgress(creep) > 0
   );
 }
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -8851,6 +8851,133 @@ describe('runWorker', () => {
     expect(build).not.toHaveBeenCalled();
   });
 
+  it('builds a low-load construction withdrawal when same-room build coverage has no carried energy', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 390,
+      progressTotal: 1_000,
+      pos: { x: 22, y: 21, roomName: 'E29N57' } as RoomPosition
+    } as ConstructionSite;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 338_162 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(200_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N57',
+      energyAvailable: 1_800,
+      energyCapacityAvailable: 1_800,
+      controller,
+      storage,
+      find: jest.fn((type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES) {
+          const structures = [storage] as unknown as AnyOwnedStructure[];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+        }
+
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        if (type === FIND_HOSTILE_CREEPS || type === FIND_SOURCES || type === FIND_DROPPED_RESOURCES) {
+          return [];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const withdraw = jest.fn();
+    const creep = {
+      name: 'LowLoadBuilder',
+      memory: {
+        role: 'worker',
+        colony: 'E29N57',
+        task: {
+          type: 'withdraw',
+          targetId: 'storage1' as Id<AnyStoreStructure>,
+          constructionSiteId: 'road-site1' as Id<ConstructionSite>
+        }
+      },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 20 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 80 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room,
+      build,
+      withdraw,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const emptyBuilder = {
+      name: 'EmptyBuilder',
+      memory: {
+        role: 'worker',
+        colony: 'E29N57',
+        task: { type: 'build', targetId: 'road-site1' as Id<ConstructionSite> }
+      },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, emptyBuilder);
+    const selectWorkerTask = jest
+      .spyOn(workerTasks, 'selectWorkerTask')
+      .mockImplementation((worker: Creep) => worker.memory.task ?? null);
+    const selectWorkerEnergyCriticalTask = jest
+      .spyOn(workerTaskPolicy, 'selectWorkerEnergyCriticalTask')
+      .mockReturnValue(null);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { LowLoadBuilder: creep, EmptyBuilder: emptyBuilder },
+      rooms: { E29N57: room },
+      time: 2_224_944,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({ type: 'build', targetId: 'road-site1' });
+      expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+        currentTask: 'withdraw',
+        baseSelectedTask: 'withdraw',
+        selectedTask: 'build',
+        assignedTask: 'build'
+      });
+      expect(build).toHaveBeenCalledWith(site);
+      expect(withdraw).not.toHaveBeenCalled();
+    } finally {
+      selectWorkerTask.mockRestore();
+      selectWorkerEnergyCriticalTask.mockRestore();
+    }
+  });
+
   it('keeps one low-load construction withdrawal building per room when no same-room builder covers backlog', () => {
     const makeBacklogRoom = (
       roomName: 'E29N56' | 'E29N57',

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -8851,6 +8851,172 @@ describe('runWorker', () => {
     expect(build).not.toHaveBeenCalled();
   });
 
+  it('keeps one low-load construction withdrawal building per room when no same-room builder covers backlog', () => {
+    const makeBacklogRoom = (
+      roomName: 'E29N56' | 'E29N57',
+      siteId: string,
+      storageId: string,
+      carriedEnergy: number,
+      remainingProgress: number
+    ): { build: jest.Mock; creep: Creep; room: Room; site: ConstructionSite; storage: StructureStorage; withdraw: jest.Mock } => {
+      const site = {
+        id: siteId,
+        my: true,
+        structureType: 'road',
+        progress: 1_000 - remainingProgress,
+        progressTotal: 1_000,
+        pos: { x: 22, y: 21, roomName } as RoomPosition
+      } as ConstructionSite;
+      const storage = {
+        id: storageId,
+        structureType: 'storage',
+        store: {
+          getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 300_000 : 0)),
+          getFreeCapacity: jest.fn().mockReturnValue(100_000)
+        }
+      } as unknown as StructureStorage;
+      const controller = {
+        id: `${roomName}-controller`,
+        my: true,
+        level: roomName === 'E29N56' ? 3 : 5,
+        ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+      } as StructureController;
+      const roomCreeps: Creep[] = [];
+      const room = {
+        name: roomName,
+        energyAvailable: 1_800,
+        energyCapacityAvailable: 1_800,
+        controller,
+        storage,
+        find: jest.fn((type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES) {
+            const structures = [storage] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          if (type === FIND_HOSTILE_CREEPS || type === FIND_SOURCES || type === FIND_DROPPED_RESOURCES) {
+            return [];
+          }
+
+          return [];
+        })
+      } as unknown as Room;
+      const build = jest.fn().mockReturnValue(0);
+      const withdraw = jest.fn();
+      const creep = {
+        name: `${roomName}-LowLoadBuilder`,
+        memory: {
+          role: 'worker',
+          colony: roomName,
+          task: {
+            type: 'withdraw',
+            targetId: storageId as Id<AnyStoreStructure>,
+            constructionSiteId: siteId as Id<ConstructionSite>
+          }
+        },
+        getActiveBodyparts: jest.fn().mockReturnValue(1),
+        store: {
+          getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? carriedEnergy : 0)),
+          getFreeCapacity: jest.fn((resource?: ResourceConstant) =>
+            resource === RESOURCE_ENERGY ? 100 - carriedEnergy : 0
+          ),
+          getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+        },
+        room,
+        build,
+        withdraw,
+        moveTo: jest.fn()
+      } as unknown as Creep;
+      roomCreeps.push(creep);
+      return { build, creep, room, site, storage, withdraw };
+    };
+    const e29n56 = makeBacklogRoom('E29N56', 'e29n56-site1', 'e29n56-storage1', 25, 120);
+    const e29n57 = makeBacklogRoom('E29N57', 'e29n57-site1', 'e29n57-storage1', 4, 18);
+    const otherRoomBuilder = {
+      name: 'E29N55-OtherBuilder',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'build', targetId: 'other-room-site' as Id<ConstructionSite> }
+      },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      },
+      room: { name: 'E29N55', find: jest.fn().mockReturnValue([]) } as unknown as Room
+    } as unknown as Creep;
+    const selectWorkerTask = jest
+      .spyOn(workerTasks, 'selectWorkerTask')
+      .mockImplementation((creep: Creep) => creep.memory.task ?? null);
+    const selectWorkerEnergyCriticalTask = jest
+      .spyOn(workerTaskPolicy, 'selectWorkerEnergyCriticalTask')
+      .mockReturnValue(null);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {
+        [e29n56.creep.name]: e29n56.creep,
+        [e29n57.creep.name]: e29n57.creep,
+        [otherRoomBuilder.name]: otherRoomBuilder
+      },
+      rooms: { E29N56: e29n56.room, E29N57: e29n57.room },
+      time: 2_235_632,
+      getObjectById: jest.fn((id: string) => {
+        if (id === e29n56.site.id) {
+          return e29n56.site;
+        }
+
+        if (id === e29n56.storage.id) {
+          return e29n56.storage;
+        }
+
+        if (id === e29n57.site.id) {
+          return e29n57.site;
+        }
+
+        if (id === e29n57.storage.id) {
+          return e29n57.storage;
+        }
+
+        return null;
+      })
+    };
+
+    try {
+      runWorker(e29n56.creep);
+      runWorker(e29n57.creep);
+
+      expect(e29n56.creep.memory.task).toEqual({ type: 'build', targetId: 'e29n56-site1' });
+      expect(e29n57.creep.memory.task).toEqual({ type: 'build', targetId: 'e29n57-site1' });
+      expect(e29n56.creep.memory.workerDispatchDiagnostic).toMatchObject({
+        currentTask: 'withdraw',
+        baseSelectedTask: 'withdraw',
+        selectedTask: 'build',
+        assignedTask: 'build'
+      });
+      expect(e29n57.creep.memory.workerDispatchDiagnostic).toMatchObject({
+        currentTask: 'withdraw',
+        baseSelectedTask: 'withdraw',
+        selectedTask: 'build',
+        assignedTask: 'build'
+      });
+      expect(e29n56.build).toHaveBeenCalledWith(e29n56.site);
+      expect(e29n57.build).toHaveBeenCalledWith(e29n57.site);
+      expect(e29n56.withdraw).not.toHaveBeenCalled();
+      expect(e29n57.withdraw).not.toHaveBeenCalled();
+    } finally {
+      selectWorkerTask.mockRestore();
+      selectWorkerEnergyCriticalTask.mockRestore();
+    }
+  });
+
   it('recovers E29N55 build assignment from spawn-critical harvest when another worker covers spawn floor', () => {
     const source = {
       id: 'source1',


### PR DESCRIPTION
## Summary
- Tightens construction-gap recovery so a low-load construction withdrawal only stays in refill mode when another same-room build assignment already covers the backlog.
- Adds multi-room regression coverage for E29N56/E29N57 rotating worker_assignment_gap symptoms and rebuilds `prod/dist/main.js`.

## Verification
- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand` — 105 suites / 2485 tests passed.
- [x] `cd prod && npm run build`

## Related runtime issue
- Related issue: 1930. The issue remains active for PR review, merge, official deploy, and multi-window official-runtime acceptance evidence after this PR lands.

## Universal task Done gate
- [x] Task type: production gameplay hotfix / worker assignment recovery.
- [x] Expected observable outcome / named deliverable: rooms with construction backlog retain or switch at least one low-load construction worker into build work when no same-room builder currently covers the backlog.
- [x] Non-goals / accepted substitutes: no RL policy writes, no room retarget, no cron changes, no paid Tencent compute, no owner-side decision, and no attempt to close the runtime issue from local tests alone.
- [x] Verification evidence required before Done: controller-verified diff check, typecheck, full Jest, and bundle build pass on commit `79254d9f51f4dae0621a98fc84f3e3d1892346f9`.
- [x] Project Evidence / Next action / Blocked by: Project should record this PR in review for issue 1930; next controller action is exact-head CI/CodeRabbit/thread/elapsed gate, then merge/deploy/runtime observation.
- [x] Post-merge/deploy/runtime proof: official-runtime proof target is fresh deploy plus runtime-summary/health-gate evidence showing no sustained worker_assignment_gap in backlog rooms on the landed gameplay commit.
- [x] Named deliverable proof: changed files are `prod/src/creeps/workerRunner.ts`, `prod/test/workerRunner.test.ts`, and generated `prod/dist/main.js`.
