### PR TITLE
fix: restore runtime-summary cadence for RL telemetry

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -42758,6 +42758,7 @@ var RUNTIME_CPU_SUMMARY_PREFIX = "#cpu-summary ";
 var RUNTIME_SUMMARY_INTERVAL = 20;
 var DEGRADED_RUNTIME_SUMMARY_INTERVAL = RUNTIME_SUMMARY_INTERVAL * 5;
 var RUNTIME_CPU_SUMMARY_REPEAT_INTERVAL = 5;
+var LOW_BUCKET_LIVE_EVIDENCE_RUNTIME_SUMMARY_INTERVAL = RUNTIME_CPU_SUMMARY_REPEAT_INTERVAL;
 var MAX_REPORTED_EVENTS = 10;
 var MAX_WORKER_EFFICIENCY_SAMPLES = 5;
 var MAX_WORKER_BEHAVIOR_SAMPLES = 10;
@@ -42861,13 +42862,17 @@ function shouldEmitRuntimeSummary(tick, events, cpuBudget = getRuntimeCpuBudget(
     if (cpuBudget.critical) {
       return false;
     }
-    return tick > 0 && tick % DEGRADED_RUNTIME_SUMMARY_INTERVAL === 0;
+    const interval2 = shouldUseLiveEvidenceRuntimeSummaryCadence(cpuBudget) ? LOW_BUCKET_LIVE_EVIDENCE_RUNTIME_SUMMARY_INTERVAL : DEGRADED_RUNTIME_SUMMARY_INTERVAL;
+    return tick > 0 && tick % interval2 === 0;
   }
   if (hasImmediateRuntimeSummaryEvent(events)) {
     return true;
   }
   const interval = shouldThrottleRuntimeSummaryCadence(cpuBudget) ? DEGRADED_RUNTIME_SUMMARY_INTERVAL : RUNTIME_SUMMARY_INTERVAL;
   return tick > 0 && tick % interval === 0;
+}
+function shouldUseLiveEvidenceRuntimeSummaryCadence(cpuBudget) {
+  return cpuBudget.reasons.includes("lowBucket") || cpuBudget.reasons.includes("lowBucketRecovery");
 }
 function hasImmediateRuntimeSummaryEvent(events) {
   return events.some((event) => {

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -110,6 +110,7 @@ export const RUNTIME_CPU_SUMMARY_PREFIX = '#cpu-summary ';
 export const RUNTIME_SUMMARY_INTERVAL = 20;
 const DEGRADED_RUNTIME_SUMMARY_INTERVAL = RUNTIME_SUMMARY_INTERVAL * 5;
 const RUNTIME_CPU_SUMMARY_REPEAT_INTERVAL = 5;
+const LOW_BUCKET_LIVE_EVIDENCE_RUNTIME_SUMMARY_INTERVAL = RUNTIME_CPU_SUMMARY_REPEAT_INTERVAL;
 const MAX_REPORTED_EVENTS = 10;
 const MAX_WORKER_EFFICIENCY_SAMPLES = 5;
 const MAX_WORKER_BEHAVIOR_SAMPLES = 10;
@@ -1142,7 +1143,10 @@ export function shouldEmitRuntimeSummary(
       return false;
     }
 
-    return tick > 0 && tick % DEGRADED_RUNTIME_SUMMARY_INTERVAL === 0;
+    const interval = shouldUseLiveEvidenceRuntimeSummaryCadence(cpuBudget)
+      ? LOW_BUCKET_LIVE_EVIDENCE_RUNTIME_SUMMARY_INTERVAL
+      : DEGRADED_RUNTIME_SUMMARY_INTERVAL;
+    return tick > 0 && tick % interval === 0;
   }
 
   if (hasImmediateRuntimeSummaryEvent(events)) {
@@ -1153,6 +1157,10 @@ export function shouldEmitRuntimeSummary(
     ? DEGRADED_RUNTIME_SUMMARY_INTERVAL
     : RUNTIME_SUMMARY_INTERVAL;
   return tick > 0 && tick % interval === 0;
+}
+
+function shouldUseLiveEvidenceRuntimeSummaryCadence(cpuBudget: RuntimeCpuBudget): boolean {
+  return cpuBudget.reasons.includes('lowBucket') || cpuBudget.reasons.includes('lowBucketRecovery');
 }
 
 function hasImmediateRuntimeSummaryEvent(events: RuntimeTelemetryEvent[]): boolean {

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -451,6 +451,62 @@ describe('runtime telemetry summaries', () => {
     });
   });
 
+  it('emits low-bucket runtime evidence when compact CPU evidence is emitted on the short CPU cadence', () => {
+    const worker = makeWorker(
+      { role: 'worker', colony: 'W1N1', task: { type: 'build', targetId: 'site1' as Id<ConstructionSite> } },
+      40,
+      'Builder1'
+    );
+    const colony = makeColony({
+      time: 5,
+      constructionSites: [{ id: 'site1', structureType: TEST_GLOBALS.STRUCTURE_EXTENSION }],
+      creeps: [worker]
+    });
+    (Game as Partial<Game>).cpu = {
+      getUsed: jest.fn().mockReturnValue(18),
+      limit: 70,
+      bucket: 998,
+      tickLimit: 500
+    } as unknown as CPU;
+
+    emitRuntimeSummary([colony], [worker]);
+
+    const messages = logSpy.mock.calls.map(([message]) => message).filter((message): message is string =>
+      typeof message === 'string'
+    );
+    expect(messages).toHaveLength(2);
+    expect(messages[0].startsWith(RUNTIME_CPU_SUMMARY_PREFIX)).toBe(true);
+    expect(messages[1].startsWith(RUNTIME_SUMMARY_PREFIX)).toBe(true);
+    const payload = JSON.parse(messages[1].slice(RUNTIME_SUMMARY_PREFIX.length)) as Record<string, unknown>;
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    const resources = room.resources as Record<string, unknown>;
+    const productiveEnergy = resources.productiveEnergy as Record<string, unknown>;
+
+    expect(payload.cpu).toMatchObject({
+      used: 18,
+      limit: 70,
+      tickLimit: 500,
+      bucket: 998,
+      pressure: 'degraded',
+      reasons: ['lowBucket']
+    });
+    expect(room.taskCounts).toMatchObject({ build: 1 });
+    expect(room.constructionActivity).toMatchObject({
+      source: 'runtime-summary',
+      constructionSiteCount: 1
+    });
+    expect(typeof resources.storedEnergy).toBe('number');
+    expect(resources).toMatchObject({
+      workerCarriedEnergy: 40,
+      harvestedThisTick: 10
+    });
+    expect(productiveEnergy).toMatchObject({
+      buildCarriedEnergy: 40,
+      constructionSiteCount: 1,
+      constructionActivity: expect.objectContaining({ source: 'runtime-summary' })
+    });
+  });
+
   it('emits compact CPU alerts without a full room summary under degraded cadence', () => {
     const colony = makeColony({ time: 1 });
     (Game as Partial<Game>).cpu = {
@@ -4652,7 +4708,7 @@ describe('runtime telemetry summaries', () => {
     ).toBe(true);
   });
 
-  it('uses degraded cadence for low bucket pressure and suppresses noncritical summaries at critical bucket', () => {
+  it('uses live evidence cadence for low bucket pressure and suppresses noncritical summaries at critical bucket', () => {
     const lowBucketBudget = buildRuntimeCpuBudget({
       tick: RUNTIME_SUMMARY_INTERVAL,
       used: 21,
@@ -4736,17 +4792,19 @@ describe('runtime telemetry summaries', () => {
       y: 13
     };
 
-    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [], lowBucketBudget)).toBe(false);
+    expect(shouldEmitRuntimeSummary(1, [], lowBucketBudget)).toBe(false);
+    expect(shouldEmitRuntimeSummary(5, [], lowBucketBudget)).toBe(true);
+    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [], lowBucketBudget)).toBe(true);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL * 5, [], lowBucketBudget)).toBe(true);
-    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [spawnEvent], lowBucketBudget)).toBe(false);
+    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [spawnEvent], lowBucketBudget)).toBe(true);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL * 5, [spawnEvent], lowBucketBudget)).toBe(true);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [safeModeEvent], lowBucketBudget)).toBe(true);
     expect(postDeployRecoveryBudget.reasons).toEqual(['lowBucketRecovery']);
-    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [spawnEvent], postDeployRecoveryBudget)).toBe(false);
+    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [spawnEvent], postDeployRecoveryBudget)).toBe(true);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL * 5, [spawnEvent], postDeployRecoveryBudget)).toBe(true);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [safeModeEvent], postDeployRecoveryBudget)).toBe(true);
     expect(freshPostDeployRecoveryBudget.reasons).toEqual(['lowBucketRecovery', 'usedOverLimit']);
-    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [spawnEvent], freshPostDeployRecoveryBudget)).toBe(false);
+    expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [spawnEvent], freshPostDeployRecoveryBudget)).toBe(true);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL * 5, [spawnEvent], freshPostDeployRecoveryBudget)).toBe(true);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [safeModeEvent], freshPostDeployRecoveryBudget)).toBe(true);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL * 5, [], criticalBucketBudget)).toBe(false);


### PR DESCRIPTION
## Linked issues

Intentional PR-body closing linkage:
- None.

Related / non-closing linkage:
- Refs #1933.

## Domain / Kind

- Domain: Runtime monitor / RL flywheel
- Kind: code

## Summary

- Emit full room-bearing `#runtime-summary` records on the short CPU-summary cadence whenever the CPU budget is in `lowBucket` or `lowBucketRecovery`.
- Keep critical bucket behavior suppressed, but make degraded/low-bucket live evidence include room/resource fields instead of CPU-only console output.
- Add Jest coverage proving low-bucket captures now include `storedEnergy`, `workerCarriedEnergy`, `harvestedThisTick`, task counts, construction activity, and CPU budget context.

## Verification

- [x] Local check: `git diff --check origin/main...HEAD` passed.
- [x] Local check: `cd prod && npm run typecheck` passed.
- [x] Local check: `cd prod && npm test -- --runInBand` passed (`105` suites, `2487` tests).
- [x] Local check: `cd prod && npm run build` passed and regenerated `prod/dist/main.js`.
- [x] GitHub Project issue/PR fields are current (`Status`, `Evidence`, `Next action`; plus `Blocked by` when blocked).
- [ ] Automated review has no blocking findings, or a CodeRabbit/Gemini reliability bypass is recorded with reviewer/head/reason; review threads are resolved/outdated/non-blocking.
- [ ] QA gate: required before merge.
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate

- [x] Task type: code behavior bugfix.
- [x] Expected observable outcome / named deliverable: live console captures during low-bucket recovery should contain room-bearing `#runtime-summary` lines, not only `#cpu-summary` lines.
- [x] Non-goals / accepted substitutes: Related to issue 1933; live deploy/capture acceptance remains on that issue.
- [x] Verification evidence required before Done: local typecheck, Jest, build, CI/review gate, deployment if merged, and a postdeploy live console capture with `runtimeSummaryLineCount > 0`.
- [x] Project Evidence / Next action / Blocked by: PR and issue Project fields must record PR URL/head SHA and the next gate before merge; issue 1933 remains active until live capture acceptance lands.
- [x] Post-merge/deploy/runtime proof: not claimed by this PR; required closure evidence is a fresh live capture showing persisted room-bearing `#runtime-summary` records after deployment.
- [x] Named deliverable proof: code/test/build deliver the cadence change; runtime proof must be attached to issue 1933 before Done.

## Issue closure gate

For every issue linked above in the PR body with a closing keyword:

- [x] No closing-keyword issue linkage is present.
- [x] No closed issue still needs post-merge validation, runtime/process proof, owner action, successor/follow-up work, partial-fix completion, or any other blocker.

## Runtime / deployment impact

- [ ] No gameplay/runtime/deployment impact.
- [x] Gameplay/runtime/deployment impact; official deploy plus fresh live console capture are required if this PR merges.

## Notes

- Commit recovery note: Codex produced the dirty worktree diff, but its commit-only lane could not write the linked worktree git index (`index.lock` under `/root/screeps/.git/worktrees/...` was read-only in the Codex sandbox). The controller made a mechanical real-git commit preserving `lanyusea's bot <lanyusea@gmail.com>` authorship after full verification.


