### PR TITLE
worker: recover assignment gap construction withdraw

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35397,7 +35397,11 @@ function selectWorkerTaskContext(creep, currentTask) {
     currentTask,
     (_a2 = spawnReservationRefillTask != null ? spawnReservationRefillTask : effectiveEnergyCriticalTask) != null ? _a2 : baseSelectedTask
   );
-  const constructionRecoveryTask = effectiveEnergyCriticalTask === null ? constructionBacklogEnergyAcquisitionTask : null;
+  const constructionRecoveryTask = effectiveEnergyCriticalTask === null || shouldYieldEnergyCriticalAcquisitionToConstructionBacklogRecovery(
+    creep,
+    effectiveEnergyCriticalTask,
+    constructionBacklogEnergyAcquisitionTask
+  ) ? constructionBacklogEnergyAcquisitionTask : null;
   const selectedTaskAfterBuildEnergyAcquisition = selectAssignedBuildEnergyAcquisitionTask(
     creep,
     currentTask,
@@ -35414,6 +35418,9 @@ function selectWorkerTaskContext(creep, currentTask) {
     selectedTask,
     spawnReservationRefillTask
   };
+}
+function shouldYieldEnergyCriticalAcquisitionToConstructionBacklogRecovery(creep, energyCriticalTask, constructionRecoveryTask) {
+  return constructionRecoveryTask !== null && energyCriticalTask !== null && isEnergyAcquisitionTask2(energyCriticalTask) && isConstructionWithdrawReservationTask(constructionRecoveryTask) && isRoomBelowMinimumWorkerSpawnEnergyFloor(creep.room) && isMinimumWorkerSpawnEnergyFloorCoveredForAssignmentGapRecovery(creep);
 }
 function selectConstructionBacklogEnergyAcquisitionRecoveryTask(creep, currentTask, selectedTask) {
   if (!shouldSelectConstructionBacklogEnergyAcquisitionRecoveryTask(creep, currentTask, selectedTask)) {
@@ -35666,6 +35673,10 @@ function isMinimumWorkerSpawnEnergyFloorCoveredForAssignmentGapRecovery(creep) {
   }
   const energyGap = Math.max(0, MINIMUM_WORKER_SPAWN_ENERGY - energyAvailable);
   return energyGap === 0 || getOtherSameRoomImmediateSpawnRefillEnergy(creep) >= energyGap;
+}
+function isRoomBelowMinimumWorkerSpawnEnergyFloor(room) {
+  const energyAvailable = getRoomEnergyAvailable13(room);
+  return energyAvailable !== null && energyAvailable < MINIMUM_WORKER_SPAWN_ENERGY;
 }
 function getOtherSameRoomImmediateSpawnRefillEnergy(creep) {
   const remainingCapacityByTargetId = /* @__PURE__ */ new Map();

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35426,7 +35426,7 @@ function shouldSelectConstructionBacklogEnergyAcquisitionRecoveryTask(creep, cur
   if (getFreeTransferEnergyCapacity(creep) <= 0 || getActiveWorkParts3(creep) <= 0 || hasVisibleHostileCreeps2(creep.room)) {
     return false;
   }
-  if (!hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room)) {
+  if (!hasRecoverableStoredEnergyForAssignmentGapRecoveryConstruction(creep)) {
     return false;
   }
   if (isDowngradeGuardUpgradeTask(creep, currentTask != null ? currentTask : null) || isDowngradeGuardUpgradeTask(creep, selectedTask)) {
@@ -35483,7 +35483,7 @@ function selectWorkerAssignmentGapRecoveryTask(creep, currentTask, selectionCont
   if (!isWorkerAssignmentGapRecoverySelection(creep, currentTask, selectionContext.selectedTask)) {
     return null;
   }
-  const hasStoredConstructionRecoveryEnergy = hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room);
+  const hasStoredConstructionRecoveryEnergy = hasRecoverableStoredEnergyForAssignmentGapRecoveryConstruction(creep);
   const hasMinimumWorkerCoverage = hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep) || hasStoredConstructionRecoveryEnergy && ((currentTask == null ? void 0 : currentTask.type) === "upgrade" || ((_a2 = selectionContext.selectedTask) == null ? void 0 : _a2.type) === "upgrade" || hasUncoveredStoredEnergyAssignmentGapRecovery(creep));
   if (getUsedTransferEnergy(creep) <= 0 || hasLowWorkerEnergyLoad(creep) && !shouldAllowLowLoadAssignmentGapRepairRecovery(creep, currentTask, selectionContext.selectedTask) || getActiveWorkParts3(creep) <= 0 || !hasMinimumWorkerCoverage || hasVisibleHostileCreeps2(creep.room) || currentTask && isDedicatedSourceContainerHarvestTask(creep, currentTask)) {
     return null;
@@ -35648,6 +35648,12 @@ function hasSafeAssignmentGapRecoveryConstructionEnergy(creep, recoveryTask) {
 function hasStoredEnergyForAssignmentGapRecoveryConstruction(room) {
   const energyAvailable = getRoomEnergyAvailable13(room);
   return energyAvailable !== null && energyAvailable >= MINIMUM_WORKER_SPAWN_ENERGY && getRoomStoredEnergyAvailableForConstruction(room) >= CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY;
+}
+function hasRecoverableStoredEnergyForAssignmentGapRecoveryConstruction(creep) {
+  if (hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room)) {
+    return true;
+  }
+  return getRoomStoredEnergyAvailableForConstruction(creep.room) >= CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY && isMinimumWorkerSpawnEnergyFloorCoveredForAssignmentGapRecovery(creep);
 }
 function hasCoveredStoredEnergyForAssignmentGapRecoveryConstruction(creep, site) {
   var _a2;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -519,7 +519,7 @@ function shouldSelectConstructionBacklogEnergyAcquisitionRecoveryTask(
     return false;
   }
 
-  if (!hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room)) {
+  if (!hasRecoverableStoredEnergyForAssignmentGapRecoveryConstruction(creep)) {
     return false;
   }
 
@@ -662,7 +662,7 @@ function selectWorkerAssignmentGapRecoveryTask(
     return null;
   }
 
-  const hasStoredConstructionRecoveryEnergy = hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room);
+  const hasStoredConstructionRecoveryEnergy = hasRecoverableStoredEnergyForAssignmentGapRecoveryConstruction(creep);
   const hasMinimumWorkerCoverage =
     hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep) ||
     (hasStoredConstructionRecoveryEnergy &&
@@ -975,6 +975,17 @@ function hasStoredEnergyForAssignmentGapRecoveryConstruction(room: Room): boolea
     energyAvailable !== null &&
     energyAvailable >= MINIMUM_WORKER_SPAWN_ENERGY &&
     getRoomStoredEnergyAvailableForConstruction(room) >= CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY
+  );
+}
+
+function hasRecoverableStoredEnergyForAssignmentGapRecoveryConstruction(creep: Creep): boolean {
+  if (hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room)) {
+    return true;
+  }
+
+  return (
+    getRoomStoredEnergyAvailableForConstruction(creep.room) >= CONSTRUCTION_SPENDING_MINIMUM_SPAWN_ENERGY &&
+    isMinimumWorkerSpawnEnergyFloorCoveredForAssignmentGapRecovery(creep)
   );
 }
 

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -470,7 +470,14 @@ function selectWorkerTaskContext(
     spawnReservationRefillTask ?? effectiveEnergyCriticalTask ?? baseSelectedTask
   );
   const constructionRecoveryTask =
-    effectiveEnergyCriticalTask === null ? constructionBacklogEnergyAcquisitionTask : null;
+    effectiveEnergyCriticalTask === null ||
+    shouldYieldEnergyCriticalAcquisitionToConstructionBacklogRecovery(
+      creep,
+      effectiveEnergyCriticalTask,
+      constructionBacklogEnergyAcquisitionTask
+    )
+      ? constructionBacklogEnergyAcquisitionTask
+      : null;
   const selectedTaskAfterBuildEnergyAcquisition = selectAssignedBuildEnergyAcquisitionTask(
     creep,
     currentTask,
@@ -491,6 +498,21 @@ function selectWorkerTaskContext(
     selectedTask,
     spawnReservationRefillTask
   };
+}
+
+function shouldYieldEnergyCriticalAcquisitionToConstructionBacklogRecovery(
+  creep: Creep,
+  energyCriticalTask: CreepTaskMemory | null,
+  constructionRecoveryTask: CreepTaskMemory | null
+): boolean {
+  return (
+    constructionRecoveryTask !== null &&
+    energyCriticalTask !== null &&
+    isEnergyAcquisitionTask(energyCriticalTask) &&
+    isConstructionWithdrawReservationTask(constructionRecoveryTask) &&
+    isRoomBelowMinimumWorkerSpawnEnergyFloor(creep.room) &&
+    isMinimumWorkerSpawnEnergyFloorCoveredForAssignmentGapRecovery(creep)
+  );
 }
 
 function selectConstructionBacklogEnergyAcquisitionRecoveryTask(
@@ -1013,6 +1035,11 @@ function isMinimumWorkerSpawnEnergyFloorCoveredForAssignmentGapRecovery(creep: C
 
   const energyGap = Math.max(0, MINIMUM_WORKER_SPAWN_ENERGY - energyAvailable);
   return energyGap === 0 || getOtherSameRoomImmediateSpawnRefillEnergy(creep) >= energyGap;
+}
+
+function isRoomBelowMinimumWorkerSpawnEnergyFloor(room: Room): boolean {
+  const energyAvailable = getRoomEnergyAvailable(room);
+  return energyAvailable !== null && energyAvailable < MINIMUM_WORKER_SPAWN_ENERGY;
 }
 
 function getOtherSameRoomImmediateSpawnRefillEnergy(creep: Creep): number {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -10075,9 +10075,6 @@ describe('runWorker', () => {
     } as unknown as Creep;
     roomCreeps.push(creep, spawnFloorCoverage);
     const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(null);
-    const selectWorkerEnergyCriticalTask = jest
-      .spyOn(workerTaskPolicy, 'selectWorkerEnergyCriticalTask')
-      .mockReturnValue(null);
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       creeps: { IdleBuilder: creep, SpawnFloorCoverage: spawnFloorCoverage },
       rooms: { E29N55: room },
@@ -10110,10 +10107,13 @@ describe('runWorker', () => {
         assignedTask: 'withdraw',
         assignedTargetId: 'storage1'
       });
+      expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+        energyCriticalTask: 'withdraw',
+        energyCriticalTargetId: 'storage1'
+      });
       expect(withdraw).toHaveBeenCalledWith(storage, RESOURCE_ENERGY, 100);
     } finally {
       selectWorkerTask.mockRestore();
-      selectWorkerEnergyCriticalTask.mockRestore();
     }
   });
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -9977,6 +9977,146 @@ describe('runWorker', () => {
     }
   });
 
+  it('assigns E29N55 construction storage withdrawal when refill coverage protects the spawn floor', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 0,
+      progressTotal: 1_500,
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'storage1' ? 4 : 99))
+      }
+    } as unknown as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      my: true,
+      structureType: 'spawn',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) =>
+          resource === RESOURCE_ENERGY ? MINIMUM_WORKER_SPAWN_ENERGY - 50 : 0
+        ),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 150 : 0))
+      }
+    } as unknown as StructureSpawn;
+    const storage = {
+      id: 'storage1',
+      my: true,
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 3_490 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(100_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 6,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N55',
+      energyAvailable: MINIMUM_WORKER_SPAWN_ENERGY - 50,
+      energyCapacityAvailable: 2_300,
+      controller,
+      storage,
+      find: jest.fn((type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES) {
+          const structures = [spawn, storage] as unknown as AnyOwnedStructure[];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+        }
+
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        if (type === FIND_HOSTILE_CREEPS || type === FIND_SOURCES || type === FIND_DROPPED_RESOURCES) {
+          return [];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const withdraw = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'IdleBuilder',
+      memory: { role: 'worker', colony: 'E29N55' },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      pos: {
+        getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'storage1' ? 3 : 99))
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room,
+      withdraw,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const spawnFloorCoverage = {
+      name: 'SpawnFloorCoverage',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'transfer', targetId: 'spawn1' as Id<AnyStoreStructure> }
+      },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, spawnFloorCoverage);
+    const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(null);
+    const selectWorkerEnergyCriticalTask = jest
+      .spyOn(workerTaskPolicy, 'selectWorkerEnergyCriticalTask')
+      .mockReturnValue(null);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { IdleBuilder: creep, SpawnFloorCoverage: spawnFloorCoverage },
+      rooms: { E29N55: room },
+      time: 2_260_649,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        if (id === 'spawn1') {
+          return spawn;
+        }
+
+        return id === 'storage1' ? storage : null;
+      })
+    };
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({
+        type: 'withdraw',
+        targetId: 'storage1',
+        constructionSiteId: 'road-site1'
+      });
+      expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+        reason: 'assigned_selected_task',
+        selectedTask: 'withdraw',
+        selectedTargetId: 'storage1',
+        assignedTask: 'withdraw',
+        assignedTargetId: 'storage1'
+      });
+      expect(withdraw).toHaveBeenCalledWith(storage, RESOURCE_ENERGY, 100);
+    } finally {
+      selectWorkerTask.mockRestore();
+      selectWorkerEnergyCriticalTask.mockRestore();
+    }
+  });
+
   it('keeps spawn-critical acquisition ahead of construction recovery for an idle empty worker', () => {
     const site = {
       id: 'road-site1',


### PR DESCRIPTION
## Linked issues

Intentional PR-body closing linkage:
- Fixes #1944

## Domain / Kind

- Domain: Territory/Economy
- Kind: bug

## Summary

- Allow assignment-gap construction energy acquisition when stored construction energy exists and same-room refill coverage protects the minimum worker spawn floor.
- Let the construction-scoped recovery withdraw override a generic energy-critical acquisition only in the below-floor, covered-floor recurrence shape.
- Add a runner regression for the E29N55 empty-worker construction backlog recurrence and keep the existing spawn-critical guard covered.
- Rebuild the Screeps bundle.

## Verification

- Local check: `npm run typecheck` PASS.
- Local check: `npm test -- --runInBand` PASS, 105 suites and 2489 tests.
- Local check: `npm run build` PASS and `prod/dist/main.js` regenerated.
- Focused check: `npm test -- --runInBand workerRunner.test.ts -t "assigns E29N55 construction storage withdrawal|keeps spawn-critical acquisition ahead of construction recovery"` PASS.
- GitHub checks on head `db1b47788469ac1b6cd4678de15c3cf6c0c644d6`: CodeRabbit pass; `issue-completion-gate` pass; `prod-ci` pass; roadmap Pages contracts pass.
- Automated review: chatgpt-codex finding was classified `FIX`, patched in `db1b47788469ac1b6cd4678de15c3cf6c0c644d6`, triage-recorded, and its thread was resolved; CodeRabbit latest-head review completed successfully.
- No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate

- [x] Task type: bugfix.
- [x] Expected observable outcome / named deliverable: owned-room workers in the assignment-gap construction recurrence can accept construction-scoped stored-energy withdrawal when construction sites exist, recoverable stored energy exists, and same-room refill coverage protects the minimum worker spawn floor.
- [x] Non-goals / accepted substitutes: no official MMO deploy; no broad worker/task rewrite; no routine #879/#1589 progress.
- [x] Verification evidence required before Done: `npm run typecheck`, `npm test -- --runInBand` with 105 suites and 2489 tests, focused workerRunner recurrence/guard tests, and `npm run build` passed on commit `db1b47788469ac1b6cd4678de15c3cf6c0c644d6`.
- [x] Project Evidence / Next action / Blocked by: #1944 and PR #1945 are in Project `screeps` under In review; evidence and next action are maintained for the live review/merge gate.
- [x] Post-merge/deploy/runtime proof: not applicable for this hotfix lane; the task explicitly excludes official MMO deploy.
- [x] Named deliverable proof: PR #1945 contains the workerRunner policy fix, the focused E29N55 storage-withdrawal regression, the spawn-critical guard verification, and regenerated `prod/dist/main.js` at commit `db1b47788469ac1b6cd4678de15c3cf6c0c644d6`.

## Issue closure gate

For every issue linked above in the PR body with a closing keyword:

- [x] #1944: acceptance criteria are satisfied by restoring construction-scoped stored-energy acquisition under covered spawn-floor conditions, adding the E29N55 recurrence regression, preserving spawn-critical acquisition priority, triaging/fixing the automated review finding, and passing typecheck/full Jest/build on commit `db1b47788469ac1b6cd4678de15c3cf6c0c644d6`.
- [x] No closed issue still needs post-merge validation, runtime/process proof, owner action, successor/follow-up work, partial-fix completion, or any other blocker.

## Runtime / deployment impact

- [x] Gameplay/runtime/deployment impact: Screeps worker assignment policy changes for construction recovery.
- [x] Deployment Floor evidence or HELD blocker: deployment is excluded by task scope; no official MMO deploy performed.

## Notes

- Review/merge gates still apply: wait at least 15 minutes after PR creation, require green checks, keep review threads resolved/outdated/non-blocking, and keep linked GitHub issue/PR/Project state current until merged or explicitly closed.
- Latest external state at final Codex check: Actions green, all review threads resolved, CodeRabbit latest-head status passed.