### PR TITLE
[codex] Fix E29N55 worker assignment gap

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -27877,7 +27877,9 @@ function selectCriticalCpuWorkerTask(creep, cpuBudget) {
     constructionSites,
     constructionReservationContext
   );
-  if (controller && shouldGuardControllerDowngradeForWorkerLoad(creep, controller, { allowConstructionBacklogYield: false }) && canUpgradeController(controller) && !controllerSustainConstructionBacklogTask) {
+  if (controller && shouldGuardControllerDowngradeForWorkerLoad(creep, controller, {
+    allowConstructionBacklogYield: shouldRunConstructionCpuWork(cpuBudget)
+  }) && canUpgradeController(controller) && !controllerSustainConstructionBacklogTask) {
     return { type: "upgrade", targetId: controller.id };
   }
   const criticalSpawnRepairTarget = selectCriticalOwnedSpawnRepairTarget(creep);

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -384,7 +384,9 @@ function selectCriticalCpuWorkerTask(creep: Creep, cpuBudget: RuntimeCpuBudget):
   );
   if (
     controller &&
-    shouldGuardControllerDowngradeForWorkerLoad(creep, controller, { allowConstructionBacklogYield: false }) &&
+    shouldGuardControllerDowngradeForWorkerLoad(creep, controller, {
+      allowConstructionBacklogYield: shouldRunConstructionCpuWork(cpuBudget)
+    }) &&
     canUpgradeController(controller) &&
     !controllerSustainConstructionBacklogTask
   ) {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1765,6 +1765,67 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
   });
 
+  it('keeps one loaded builder on visible construction during critical CPU controller guard', () => {
+    const roadSite = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 258,
+      progressTotal: 500
+    } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 6,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N55',
+      constructionSites: [roadSite],
+      controller,
+      energyAvailable: 2_000,
+      energyCapacityAvailable: 2_300
+    });
+    const emptyWorker = {
+      name: 'EmptyConstructionWithdrawer',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: {
+          type: 'withdraw',
+          targetId: 'container1' as Id<AnyStoreStructure>,
+          constructionSiteId: 'road-site1' as Id<ConstructionSite>
+        }
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      room
+    } as unknown as Creep;
+    const loadedWorker = {
+      name: 'LoadedWorker',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      room
+    } as unknown as Creep;
+    setGameCreeps({ EmptyConstructionWithdrawer: emptyWorker, LoadedWorker: loadedWorker });
+    setCpuSample({ bucket: 1_856, limit: 70, used: 95 });
+
+    expect(selectWorkerTask(loadedWorker)).toEqual({ type: 'build', targetId: 'road-site1' });
+  });
+
   it('lets spare loaded workers finish construction below the general spend floor', () => {
     const constructionSite = {
       id: 'extension-site',


### PR DESCRIPTION
## Linked issues

Related to issue 1946.

## Domain / Kind

- Domain: Territory/Economy
- Kind: bug

## Summary

- Let the critical-CPU controller guard use the existing bounded construction-yield rule when construction CPU work is still allowed.
- Add a focused E29N55-style regression where an empty worker has reserved construction energy, one loaded worker is on controller upgrade, CPU is over limit with recovery headroom, and a visible road site needs build coverage.
- Regenerate `prod/dist/main.js` through `npm run build`.

## Root cause

After #1945, the critical/degraded CPU selector still forced loaded workers inside the broad controller downgrade guard to keep upgrading because `allowConstructionBacklogYield` was hard-disabled in `selectCriticalCpuWorkerTask`. In the postdeploy state, empty workers could reserve/acquire construction energy while the only loaded worker stayed on `upgrade`, leaving E29N55 with visible construction backlog but `build=0` and `buildCarriedEnergy=0`. The hotfix keeps the low-bucket safeguard intact by allowing the yield only when `shouldRunConstructionCpuWork(cpuBudget)` is true.

## Verification

- [x] Local check: `npm run typecheck` PASS.
- [x] Local check: `npm test -- --runInBand` PASS, 105 suites and 2490 tests.
- [x] Local check: `npm run build` PASS.
- [x] Local check: `git diff --check` PASS.
- [x] GitHub Project issue/PR fields are current: Status `In review`, Evidence refreshed, Next action refreshed, Blocked by empty.
- [x] Automated review has no blocking findings, or reliability bypass is recorded: CodeRabbit status is pass/skipped for head `363e9c8b`; no review threads exist at PR-body update time.
- [x] QA gate: local verification complete for the code hotfix; live deploy acceptance remains issue-tracked.
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate

- [x] Task type: bugfix / code behavior.
- [x] Expected observable outcome / named deliverable: E29N55 worker assignment hotfix PR keeps one loaded worker eligible for visible construction during critical-CPU controller guard when construction CPU work is allowed.
- [x] Non-goals / accepted substitutes: CPU recovery gate #1909 and official deploy execution are outside this code hotfix PR.
- [x] Verification evidence required before Done: `npm run typecheck`, `npm test -- --runInBand`, `npm run build`, `git diff --check`, generated bundle diff, and Project field readback all pass or are current.
- [x] Project Evidence / Next action / Blocked by: issue #1946 and PR #1948 are `In review`; Evidence and Next action are refreshed; Blocked by empty.
- [x] Post-merge/deploy/runtime proof: Not applicable for this PR's code deliverable; official deploy runtime acceptance is tracked in issue 1946 Project Next action.
- [x] Named deliverable proof: PR #1948 commit `363e9c8b` includes the selector hotfix, regression test, generated bundle, and passing local verification.

## Issue closure gate

No intentional closing linkage is used in this PR body because official deploy/runtime acceptance is tracked by issue 1946.

## Runtime / deployment impact

- [x] Gameplay/runtime/deployment impact; generated bundle updated through `npm run build`, and official deploy acceptance remains tracked by issue 1946.

## Notes

#1909 remains the separate CPU recovery gate; this PR only addresses construction assignment acceptance.