### PR TITLE
[codex] worker: cover repair-heavy construction gap

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -31362,7 +31362,7 @@ function hasRepairCoverageForConstructionYield(creep, criticalRepairTarget, opti
   if (hasOtherLoadedWorkerAssignedToRepairTarget(creep, criticalRepairTarget)) {
     return true;
   }
-  return ((_a2 = options.allowRepairPoolCoverage) != null ? _a2 : true) && isWorkerAssignedToAnyRepairTarget(creep) && countOtherLoadedRepairWorkers(creep) >= REPAIR_HEAVY_CONSTRUCTION_YIELD_MIN_OTHER_LOADED_REPAIRERS;
+  return ((_a2 = options.allowRepairPoolCoverage) != null ? _a2 : true) && countOtherLoadedRepairWorkers(creep) >= REPAIR_HEAVY_CONSTRUCTION_YIELD_MIN_OTHER_LOADED_REPAIRERS;
 }
 function countOtherLoadedRepairWorkers(creep) {
   return getRoomOwnedCreeps2(creep.room).filter(

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -27792,6 +27792,7 @@ var HARVEST_ENERGY_PER_WORK_PART2 = 2;
 var SPAWN_EXTENSION_THROUGHPUT_STORAGE_REFILL_EMPTY_CAPACITY_RATIO = 0.2;
 var SPAWN_EXTENSION_REFILL_STORAGE_WITHDRAWAL_OPTIONS = { allowBelowReserve: true };
 var DEFAULT_BUILD_POWER = 5;
+var REPAIR_HEAVY_CONSTRUCTION_YIELD_MIN_OTHER_LOADED_REPAIRERS = 2;
 var NEARLY_COMPLETE_CONSTRUCTION_SITE_REMAINING_RATIO = 0.2;
 var NEARLY_COMPLETE_CONSTRUCTION_SITE_FINISH_PRIORITY_MULTIPLIER = 2;
 var FINISHABLE_CONSTRUCTION_SITE_PRIORITY_MULTIPLIER = 2;
@@ -27951,7 +27952,8 @@ function selectCriticalCpuWorkerTask(creep, cpuBudget) {
       creep,
       criticalRepairTarget,
       constructionSites,
-      constructionReservationContext
+      constructionReservationContext,
+      { allowRepairPoolCoverage: shouldRunConstructionCpuWork(cpuBudget) }
     );
     if (coveredRepairConstructionBacklogTask) {
       return coveredRepairConstructionBacklogTask;
@@ -31341,8 +31343,8 @@ function selectLowLoadConstructionCoverageTask(creep, constructionSites, constru
   );
   return constructionSite ? { type: "build", targetId: constructionSite.id } : null;
 }
-function selectConstructionBacklogTaskBeforeCoveredCriticalRepair(creep, criticalRepairTarget, constructionSites, constructionReservationContext) {
-  if (isCriticalOwnedSpawnRepairTarget(criticalRepairTarget) || constructionSites.length === 0 || hasVisibleHostilePresence3(creep.room) || hasOtherSameRoomBuildCoverageWorker(creep) || !hasMinimumProductiveWorkerCoverageForBoundedConstruction(creep) || !hasOtherLoadedWorkerAssignedToRepairTarget(creep, criticalRepairTarget)) {
+function selectConstructionBacklogTaskBeforeCoveredCriticalRepair(creep, criticalRepairTarget, constructionSites, constructionReservationContext, options = {}) {
+  if (isCriticalOwnedSpawnRepairTarget(criticalRepairTarget) || constructionSites.length === 0 || hasVisibleHostilePresence3(creep.room) || hasOtherSameRoomBuildCoverageWorker(creep) || !hasMinimumProductiveWorkerCoverageForBoundedConstruction(creep) || !hasRepairCoverageForConstructionYield(creep, criticalRepairTarget, options)) {
     return null;
   }
   const priorityContext = buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites);
@@ -31354,6 +31356,25 @@ function selectConstructionBacklogTaskBeforeCoveredCriticalRepair(creep, critica
     { priorityContext }
   );
   return constructionSite ? { type: "build", targetId: constructionSite.id } : null;
+}
+function hasRepairCoverageForConstructionYield(creep, criticalRepairTarget, options) {
+  var _a2;
+  if (hasOtherLoadedWorkerAssignedToRepairTarget(creep, criticalRepairTarget)) {
+    return true;
+  }
+  return ((_a2 = options.allowRepairPoolCoverage) != null ? _a2 : true) && isWorkerAssignedToAnyRepairTarget(creep) && countOtherLoadedRepairWorkers(creep) >= REPAIR_HEAVY_CONSTRUCTION_YIELD_MIN_OTHER_LOADED_REPAIRERS;
+}
+function countOtherLoadedRepairWorkers(creep) {
+  return getRoomOwnedCreeps2(creep.room).filter(
+    (worker) => {
+      var _a2;
+      return !isSameCreep3(worker, creep) && ((_a2 = worker.memory) == null ? void 0 : _a2.role) === "worker" && getUsedEnergy2(worker) > 0 && getActiveWorkParts2(worker) > 0 && isWorkerAssignedToAnyRepairTarget(worker);
+    }
+  ).length;
+}
+function isWorkerAssignedToAnyRepairTarget(worker) {
+  var _a2, _b;
+  return ((_b = (_a2 = worker.memory) == null ? void 0 : _a2.task) == null ? void 0 : _b.type) === "repair";
 }
 function hasOtherSameRoomBuildCoverageWorker(creep) {
   return getSameRoomLoadedWorkers(creep).some(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -134,6 +134,7 @@ const HARVEST_ENERGY_PER_WORK_PART = 2;
 const SPAWN_EXTENSION_THROUGHPUT_STORAGE_REFILL_EMPTY_CAPACITY_RATIO = 0.2;
 const SPAWN_EXTENSION_REFILL_STORAGE_WITHDRAWAL_OPTIONS = { allowBelowReserve: true } as const;
 const DEFAULT_BUILD_POWER = 5;
+const REPAIR_HEAVY_CONSTRUCTION_YIELD_MIN_OTHER_LOADED_REPAIRERS = 2;
 const NEARLY_COMPLETE_CONSTRUCTION_SITE_REMAINING_RATIO = 0.2;
 const NEARLY_COMPLETE_CONSTRUCTION_SITE_FINISH_PRIORITY_MULTIPLIER = 2;
 const FINISHABLE_CONSTRUCTION_SITE_PRIORITY_MULTIPLIER = 2;
@@ -474,7 +475,8 @@ function selectCriticalCpuWorkerTask(creep: Creep, cpuBudget: RuntimeCpuBudget):
       creep,
       criticalRepairTarget,
       constructionSites,
-      constructionReservationContext
+      constructionReservationContext,
+      { allowRepairPoolCoverage: shouldRunConstructionCpuWork(cpuBudget) }
     );
     if (coveredRepairConstructionBacklogTask) {
       return coveredRepairConstructionBacklogTask;
@@ -5707,11 +5709,16 @@ function selectLowLoadConstructionCoverageTask(
   return constructionSite ? { type: 'build', targetId: constructionSite.id } : null;
 }
 
+interface CoveredCriticalRepairConstructionOptions {
+  allowRepairPoolCoverage?: boolean;
+}
+
 function selectConstructionBacklogTaskBeforeCoveredCriticalRepair(
   creep: Creep,
   criticalRepairTarget: CriticalInfrastructureRepairTarget,
   constructionSites: ConstructionSite[],
-  constructionReservationContext: ConstructionReservationContext
+  constructionReservationContext: ConstructionReservationContext,
+  options: CoveredCriticalRepairConstructionOptions = {}
 ): Extract<CreepTaskMemory, { type: 'build' }> | null {
   if (
     isCriticalOwnedSpawnRepairTarget(criticalRepairTarget) ||
@@ -5719,7 +5726,7 @@ function selectConstructionBacklogTaskBeforeCoveredCriticalRepair(
     hasVisibleHostilePresence(creep.room) ||
     hasOtherSameRoomBuildCoverageWorker(creep) ||
     !hasMinimumProductiveWorkerCoverageForBoundedConstruction(creep) ||
-    !hasOtherLoadedWorkerAssignedToRepairTarget(creep, criticalRepairTarget)
+    !hasRepairCoverageForConstructionYield(creep, criticalRepairTarget, options)
   ) {
     return null;
   }
@@ -5733,6 +5740,37 @@ function selectConstructionBacklogTaskBeforeCoveredCriticalRepair(
     { priorityContext }
   );
   return constructionSite ? { type: 'build', targetId: constructionSite.id } : null;
+}
+
+function hasRepairCoverageForConstructionYield(
+  creep: Creep,
+  criticalRepairTarget: CriticalInfrastructureRepairTarget,
+  options: CoveredCriticalRepairConstructionOptions
+): boolean {
+  if (hasOtherLoadedWorkerAssignedToRepairTarget(creep, criticalRepairTarget)) {
+    return true;
+  }
+
+  return (
+    (options.allowRepairPoolCoverage ?? true) &&
+    isWorkerAssignedToAnyRepairTarget(creep) &&
+    countOtherLoadedRepairWorkers(creep) >= REPAIR_HEAVY_CONSTRUCTION_YIELD_MIN_OTHER_LOADED_REPAIRERS
+  );
+}
+
+function countOtherLoadedRepairWorkers(creep: Creep): number {
+  return getRoomOwnedCreeps(creep.room).filter(
+    (worker) =>
+      !isSameCreep(worker, creep) &&
+      worker.memory?.role === 'worker' &&
+      getUsedEnergy(worker) > 0 &&
+      getActiveWorkParts(worker) > 0 &&
+      isWorkerAssignedToAnyRepairTarget(worker)
+  ).length;
+}
+
+function isWorkerAssignedToAnyRepairTarget(worker: Creep): boolean {
+  return worker.memory?.task?.type === 'repair';
 }
 
 function hasOtherSameRoomBuildCoverageWorker(creep: Creep): boolean {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -5753,7 +5753,6 @@ function hasRepairCoverageForConstructionYield(
 
   return (
     (options.allowRepairPoolCoverage ?? true) &&
-    isWorkerAssignedToAnyRepairTarget(creep) &&
     countOtherLoadedRepairWorkers(creep) >= REPAIR_HEAVY_CONSTRUCTION_YIELD_MIN_OTHER_LOADED_REPAIRERS
   );
 }

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -14110,6 +14110,99 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'container-critical' });
   });
 
+  it('routes one repair-heavy E29N55 worker to construction during CPU recovery when no build energy is carried', () => {
+    const site = {
+      id: 'wall-site1',
+      my: true,
+      structureType: 'constructedWall',
+      progress: 109,
+      progressTotal: 500,
+      pos: makeRoomPosition(22, 21, 'E29N55')
+    } as ConstructionSite;
+    const criticalContainer = makeStoredEnergyContainerWithCapacity('critical-container1', 778, 2_000, {
+      hits: 600,
+      hitsMax: 2_000,
+      pos: makeRoomPosition(18, 24, 'E29N55')
+    });
+    const fullSpawn = makeFullSpawnEnergyStructure('spawn-full', 'E29N55');
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 6,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N55',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 300,
+      energyCapacityAvailable: 2_300,
+      myStructures: [fullSpawn as AnyOwnedStructure],
+      structures: [fullSpawn as AnyStructure, criticalContainer as AnyStructure]
+    });
+    const worker = {
+      name: 'worker-E29N55-repair-yield',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'repair', targetId: 'rampart-repair1' as Id<Structure> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+      },
+      pos: { getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'wall-site1' ? 4 : 2)) },
+      room
+    } as unknown as Creep;
+    const repairCoverageA = {
+      name: 'worker-E29N55-repair-a',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'repair', targetId: 'road-repair1' as Id<Structure> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      store: { getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)) },
+      room
+    } as unknown as Creep;
+    const repairCoverageB = {
+      name: 'worker-E29N55-repair-b',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'repair', targetId: 'wall-repair1' as Id<Structure> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      store: { getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)) },
+      room
+    } as unknown as Creep;
+    const repairCoverageC = {
+      name: 'worker-E29N55-repair-c',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'repair', targetId: 'container-repair2' as Id<Structure> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      store: { getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({
+      Worker: worker,
+      RepairCoverageA: repairCoverageA,
+      RepairCoverageB: repairCoverageB,
+      RepairCoverageC: repairCoverageC
+    });
+
+    setCpuBucket(43);
+    expect(selectWorkerTask(worker)).toEqual({ type: 'repair', targetId: 'critical-container1' });
+
+    setCpuSample({ bucket: 1_857, limit: 70, tickLimit: 500, used: 70.1 });
+
+    expect(selectWorkerTask(worker)).toEqual({ type: 'build', targetId: 'wall-site1' });
+  });
+
   it('keeps healthy-buffer construction behind critical container repair without live same-target coverage', () => {
     const site = {
       id: 'storage-site1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -14201,6 +14201,10 @@ describe('selectWorkerTask', () => {
     setCpuSample({ bucket: 1_857, limit: 70, tickLimit: 500, used: 70.1 });
 
     expect(selectWorkerTask(worker)).toEqual({ type: 'build', targetId: 'wall-site1' });
+
+    worker.memory.task = { type: 'build', targetId: 'wall-site1' as Id<ConstructionSite> };
+
+    expect(selectWorkerTask(worker)).toEqual({ type: 'build', targetId: 'wall-site1' });
   });
 
   it('keeps healthy-buffer construction behind critical container repair without live same-target coverage', () => {


### PR DESCRIPTION
Refs #1946.

## Summary
- Let the covered-critical-repair construction yield also recognize a repair-heavy room pool: an eligible loaded worker can yield or continue yielding to visible construction when at least two other loaded repair workers remain and no same-room build coverage exists.
- Keep critical spawn repair, emergency rampart repair, threatened barrier repair, minimum productive worker coverage, and hard construction CPU pressure guards intact.
- Regenerate `prod/dist/main.js` from the build.

## Failure Evidence Addressed
- PR #1948 deployed `cdc206da` through official workflow run `27652002506`; upload succeeded but the postdeploy health gate still failed.
- E29N55 remained blocked with `worker_assignment_gap`: `taskCounts.build=0`, `taskCounts.repair=4`, `buildCarriedEnergy=0`, `pendingBuildProgress=391`, `constructionSiteCount=1`, `owned_spawns=1`, `owned_creeps=10`, `hostiles=0`, `cpuBucket=1857`.
- Regression coverage now models that shape: visible generic construction backlog with no build-carried energy, repair-heavy worker assignments, CPU recovery bucket headroom, next-tick build-task continuity, and a hard critical-bucket assertion that still stays on repair.

## Verification
- `npm run typecheck`
- `npm test -- --runInBand` (105 suites, 2491 tests)
- `npm run build`
- `git diff --check HEAD~1 HEAD`

## Expected Post-Merge Deploy Acceptance
- E29N55 should regain construction acceptance after deploy: at least one eligible worker should carry/build against the visible backlog, clearing sustained `worker_assignment_gap` via `buildCarriedEnergy > 0` or build progress.
- E29N55 emergency/survival behavior should remain protected: hard critical CPU buckets keep the worker on critical repair, and spawn/emergency barrier repair paths are unchanged.

## Universal task Done gate
- [x] Task type: Production-code hotfix for issue #1946, restoring E29N55 construction assignment coverage.
- [x] Expected observable outcome / named deliverable: PR #1949 head `2b5ae590` changes worker task selection so one loaded worker yields to and remains on visible construction when the room has adequate other repair coverage and zero build coverage.
- [x] Non-goals / accepted substitutes: No expansion-strategy, reward-policy, Tencent-compute, or live-RL behavior change; scope is the repair-heavy construction assignment case only.
- [x] Verification evidence required before Done: Local PR verification listed above: `npm run typecheck`; `npm test -- --runInBand` with 105 suites and 2491 tests; `npm run build`; `git diff --check HEAD~1 HEAD`.
- [x] Project Evidence / Next action / Blocked by: Project issue #1946 and PR #1949 fields name head `2b5ae590`, Gemini thread `PRRT_kwDOSMSsO86KDf72` triage, current checks/review/15-minute gate hold reasons, and the next merge/deploy acceptance action.
- [x] Post-merge/deploy/runtime proof: Official deploy health gate for the merged commit must show E29N55 construction acceptance with build coverage or build progress and no `worker_assignment_gap` for the visible backlog.
- [x] Named deliverable proof: Commits `15ac5cca` and `2b5ae590` plus generated `prod/dist/main.js` and focused regression coverage in `prod/test/workerTasks.test.ts` prove the named hotfix deliverable on this PR branch.