### PR TITLE
[codex] fix CPU-shed construction refill yield

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -27931,6 +27931,15 @@ function selectCriticalCpuWorkerTask(creep, cpuBudget) {
     spawnOrExtensionEnergySink
   ) : null;
   if (spawnExtensionConstructionBacklogTask) {
+    const criticalRepairTarget2 = selectCriticalInfrastructureRepairTarget(creep);
+    if (criticalRepairTarget2 && !hasRepairCoverageForConstructionYield(creep, criticalRepairTarget2, {
+      allowRepairPoolCoverage: shouldRunConstructionCpuWork(cpuBudget)
+    })) {
+      return applyMinimumUsefulLoadPolicy(creep, {
+        type: "repair",
+        targetId: criticalRepairTarget2.id
+      });
+    }
     return applyMinimumUsefulLoadPolicy(creep, spawnExtensionConstructionBacklogTask);
   }
   if (spawnOrExtensionEnergySink) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -36905,7 +36905,8 @@ function shouldPreemptTransferTaskForConstructionBacklog(creep, task, selectedTa
   if (!isNonCriticalSpawnExtensionTransferTarget(currentTarget) && !isNonCriticalTowerRefillTransferTarget(creep, currentTarget)) {
     return false;
   }
-  if (!shouldDeferSpawnReservationRefillForProductiveWork(
+  const canFollowSelectorNonCriticalSpawnExtensionYield = isNonCriticalSpawnExtensionTransferTarget(currentTarget) && shouldRunConstructionCpuWork(getRuntimeCpuBudget()) && !hasVisibleHostileCreeps2(creep.room);
+  if (!canFollowSelectorNonCriticalSpawnExtensionYield && !shouldDeferSpawnReservationRefillForProductiveWork(
     creep,
     selectedTask,
     selectSpawnEnergyReservationRefillTarget(creep)

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -27924,6 +27924,15 @@ function selectCriticalCpuWorkerTask(creep, cpuBudget) {
   if (storedProtectedConstructionBacklogTask) {
     return applyMinimumUsefulLoadPolicy(creep, storedProtectedConstructionBacklogTask);
   }
+  const spawnExtensionConstructionBacklogTask = spawnOrExtensionEnergySink && shouldRunConstructionCpuWork(cpuBudget) ? selectBoundedConstructionBacklogTaskBeforeNonCriticalRefill(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    spawnOrExtensionEnergySink
+  ) : null;
+  if (spawnExtensionConstructionBacklogTask) {
+    return applyMinimumUsefulLoadPolicy(creep, spawnExtensionConstructionBacklogTask);
+  }
   if (spawnOrExtensionEnergySink) {
     return {
       type: "transfer",
@@ -31306,7 +31315,13 @@ function selectBoundedConstructionBacklogTaskBeforeNonCriticalRefill(creep, cons
   return constructionSite ? { type: "build", targetId: constructionSite.id } : null;
 }
 function isNonCriticalRefillSinkForConstructionBacklog(creep, sink) {
-  return isTowerEnergySink(sink) && !hasVisibleHostilePresence3(creep.room);
+  if (hasVisibleHostilePresence3(creep.room)) {
+    return false;
+  }
+  if (isTowerEnergySink(sink)) {
+    return true;
+  }
+  return isSpawnOrExtensionEnergySink(sink) && !shouldKeepCurrentWorkerForEmergencySpawnExtensionRefill(creep, sink);
 }
 function shouldDeferIdleSpawnExtensionRefillForHealthyBuffer(creep, spawnOrExtensionEnergySink) {
   return spawnOrExtensionEnergySink !== null && !hasActiveSpawningSpawn(creep.room) && hasHealthyRoomEnergyBuffer(creep.room);

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -57,7 +57,12 @@ import {
   type RuntimeEnergyAcquisitionMethod
 } from '../telemetry/behaviorTelemetry';
 import { recordWorkerBuildActionResult } from '../telemetry/buildActionTelemetry';
-import { getRuntimeCpuBudget, isRuntimeCpuBucketLow, shouldShedNonessentialCpuWork } from '../runtime/cpuBudget';
+import {
+  getRuntimeCpuBudget,
+  isRuntimeCpuBucketLow,
+  shouldRunConstructionCpuWork,
+  shouldShedNonessentialCpuWork
+} from '../runtime/cpuBudget';
 import { isColonyRoomThreatened } from '../defense/colonyThreats';
 
 type TransferSinkStructureConstantGlobal =
@@ -2954,11 +2959,18 @@ function shouldPreemptTransferTaskForConstructionBacklog(
     return false;
   }
 
-  if (!shouldDeferSpawnReservationRefillForProductiveWork(
-    creep,
-    selectedTask,
-    selectSpawnEnergyReservationRefillTarget(creep)
-  )) {
+  const canFollowSelectorNonCriticalSpawnExtensionYield =
+    isNonCriticalSpawnExtensionTransferTarget(currentTarget) &&
+    shouldRunConstructionCpuWork(getRuntimeCpuBudget()) &&
+    !hasVisibleHostileCreeps(creep.room);
+  if (
+    !canFollowSelectorNonCriticalSpawnExtensionYield &&
+    !shouldDeferSpawnReservationRefillForProductiveWork(
+      creep,
+      selectedTask,
+      selectSpawnEnergyReservationRefillTarget(creep)
+    )
+  ) {
     return false;
   }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -442,6 +442,19 @@ function selectCriticalCpuWorkerTask(creep: Creep, cpuBudget: RuntimeCpuBudget):
     return applyMinimumUsefulLoadPolicy(creep, storedProtectedConstructionBacklogTask);
   }
 
+  const spawnExtensionConstructionBacklogTask =
+    spawnOrExtensionEnergySink && shouldRunConstructionCpuWork(cpuBudget)
+      ? selectBoundedConstructionBacklogTaskBeforeNonCriticalRefill(
+          creep,
+          constructionSites,
+          constructionReservationContext,
+          spawnOrExtensionEnergySink
+        )
+      : null;
+  if (spawnExtensionConstructionBacklogTask) {
+    return applyMinimumUsefulLoadPolicy(creep, spawnExtensionConstructionBacklogTask);
+  }
+
   if (spawnOrExtensionEnergySink) {
     return {
       type: 'transfer',
@@ -5625,7 +5638,15 @@ function selectBoundedConstructionBacklogTaskBeforeNonCriticalRefill(
 }
 
 function isNonCriticalRefillSinkForConstructionBacklog(creep: Creep, sink: FillableEnergySink): boolean {
-  return isTowerEnergySink(sink) && !hasVisibleHostilePresence(creep.room);
+  if (hasVisibleHostilePresence(creep.room)) {
+    return false;
+  }
+
+  if (isTowerEnergySink(sink)) {
+    return true;
+  }
+
+  return isSpawnOrExtensionEnergySink(sink) && !shouldKeepCurrentWorkerForEmergencySpawnExtensionRefill(creep, sink);
 }
 
 function shouldDeferIdleSpawnExtensionRefillForHealthyBuffer(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -452,6 +452,19 @@ function selectCriticalCpuWorkerTask(creep: Creep, cpuBudget: RuntimeCpuBudget):
         )
       : null;
   if (spawnExtensionConstructionBacklogTask) {
+    const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
+    if (
+      criticalRepairTarget &&
+      !hasRepairCoverageForConstructionYield(creep, criticalRepairTarget, {
+        allowRepairPoolCoverage: shouldRunConstructionCpuWork(cpuBudget)
+      })
+    ) {
+      return applyMinimumUsefulLoadPolicy(creep, {
+        type: 'repair',
+        targetId: criticalRepairTarget.id as Id<Structure>
+      });
+    }
+
     return applyMinimumUsefulLoadPolicy(creep, spawnExtensionConstructionBacklogTask);
   }
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -12794,6 +12794,152 @@ describe('runWorker', () => {
     expect(transfer).not.toHaveBeenCalled();
   });
 
+  it('preempts an E29N55 extension refill transfer for CPU-shed construction backlog', () => {
+    const site = {
+      id: 'wall-site1',
+      my: true,
+      structureType: 'constructedWall',
+      progress: 0,
+      progressTotal: 547,
+      pos: { x: 22, y: 21, roomName: 'E29N55' } as RoomPosition
+    } as ConstructionSite;
+    const fullSpawn = {
+      id: 'spawn-full',
+      structureType: 'spawn',
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 300 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      }
+    } as unknown as StructureSpawn;
+    const refillExtension = {
+      id: 'extension-open',
+      my: true,
+      structureType: 'extension',
+      pos: { x: 18, y: 24, roomName: 'E29N55' } as RoomPosition,
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+      }
+    } as unknown as StructureExtension;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 6,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N55',
+      energyAvailable: 300,
+      energyCapacityAvailable: 2_300,
+      controller,
+      find: jest.fn(
+        (type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [fullSpawn, refillExtension] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_STRUCTURES) {
+            return [fullSpawn, refillExtension];
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          return [];
+        }
+      )
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const transfer = jest.fn();
+    const creep = {
+      name: 'LoadedBuilder',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'transfer', targetId: 'extension-open' as Id<AnyStoreStructure> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => {
+          const ranges: Record<string, number> = {
+            'extension-open': 2,
+            'wall-site1': 4
+          };
+          return ranges[String(target.id)] ?? 20;
+        })
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+      },
+      room,
+      build,
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const productiveCoverage = {
+      name: 'ProductiveCoverage',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, productiveCoverage);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { LoadedBuilder: creep, ProductiveCoverage: productiveCoverage },
+      rooms: { E29N55: room },
+      time: 1_815_738,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(70.1),
+        limit: 70,
+        bucket: 1_857,
+        tickLimit: 500
+      } as unknown as CPU,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'wall-site1') {
+          return site;
+        }
+
+        if (id === 'extension-open') {
+          return refillExtension;
+        }
+
+        if (id === 'controller1') {
+          return controller;
+        }
+
+        return id === 'spawn-full' ? fullSpawn : null;
+      })
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'wall-site1' });
+    expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+      currentTask: 'transfer',
+      baseSelectedTask: 'build',
+      selectedTask: 'build',
+      assignedTask: 'build'
+    });
+    expect(build).toHaveBeenCalledWith(site);
+    expect(transfer).not.toHaveBeenCalled();
+  });
+
   it('keeps tower refill ahead of construction backlog while hostiles are visible', () => {
     const site = {
       id: 'road-site1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -14278,6 +14278,82 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(builder)).toEqual({ type: 'build', targetId: 'wall-site1' });
   });
 
+  it('keeps uncovered critical repair before CPU-shed non-emergency refill construction yield', () => {
+    const site = {
+      id: 'wall-site1',
+      my: true,
+      structureType: 'constructedWall',
+      progress: 0,
+      progressTotal: 547,
+      pos: makeRoomPosition(22, 21, 'E29N55')
+    } as ConstructionSite;
+    const criticalContainer = makeStructure('critical-container1', 'container' as StructureConstant, 600, 2_000, {
+      pos: makeRoomPosition(18, 24, 'E29N55')
+    });
+    const fullSpawn = makeFullSpawnEnergyStructure('spawn-full', 'E29N55');
+    const refillExtension = makeEnergySinkWithEnergy('extension-open', 'extension' as StructureConstant, 0, 50, {
+      my: true,
+      pos: makeRoomPosition(18, 24, 'E29N55')
+    }) as StructureExtension;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 6,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N55',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 300,
+      energyCapacityAvailable: 2_300,
+      myStructures: [fullSpawn as AnyOwnedStructure, refillExtension as AnyOwnedStructure],
+      structures: [fullSpawn as AnyStructure, criticalContainer]
+    });
+    const builder = {
+      name: 'worker-E29N55-cpu-shed-builder',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'transfer', targetId: 'extension-open' as Id<AnyStoreStructure> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => {
+          const ranges: Record<string, number> = {
+            'critical-container1': 1,
+            'extension-open': 2,
+            'wall-site1': 4
+          };
+          return ranges[String(target.id)] ?? 20;
+        })
+      },
+      room
+    } as unknown as Creep;
+    const productiveCoverage = {
+      name: 'worker-E29N55-productive-coverage',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ Builder: builder, ProductiveCoverage: productiveCoverage });
+    setCpuSample({ bucket: 1_857, limit: 70, tickLimit: 500, used: 70.1 });
+
+    expect(selectWorkerTask(builder)).toEqual({ type: 'repair', targetId: 'critical-container1' });
+  });
+
   it('keeps healthy-buffer construction behind critical container repair without live same-target coverage', () => {
     const site = {
       id: 'storage-site1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -14207,6 +14207,77 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(worker)).toEqual({ type: 'build', targetId: 'wall-site1' });
   });
 
+  it('routes CPU-shed E29N55 non-emergency refill to construction when recovery energy is safe', () => {
+    const site = {
+      id: 'wall-site1',
+      my: true,
+      structureType: 'constructedWall',
+      progress: 0,
+      progressTotal: 547,
+      pos: makeRoomPosition(22, 21, 'E29N55')
+    } as ConstructionSite;
+    const fullSpawn = makeFullSpawnEnergyStructure('spawn-full', 'E29N55');
+    const refillExtension = makeEnergySinkWithEnergy('extension-open', 'extension' as StructureConstant, 0, 50, {
+      my: true,
+      pos: makeRoomPosition(18, 24, 'E29N55')
+    }) as StructureExtension;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 6,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N55',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 300,
+      energyCapacityAvailable: 2_300,
+      myStructures: [fullSpawn as AnyOwnedStructure, refillExtension as AnyOwnedStructure]
+    });
+    const builder = {
+      name: 'worker-E29N55-cpu-shed-builder',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'transfer', targetId: 'extension-open' as Id<AnyStoreStructure> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => {
+          const ranges: Record<string, number> = {
+            'extension-open': 2,
+            'wall-site1': 4
+          };
+          return ranges[String(target.id)] ?? 20;
+        })
+      },
+      room
+    } as unknown as Creep;
+    const productiveCoverage = {
+      name: 'worker-E29N55-productive-coverage',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ Builder: builder, ProductiveCoverage: productiveCoverage });
+    setCpuSample({ bucket: 1_857, limit: 70, tickLimit: 500, used: 70.1 });
+
+    expect(selectWorkerTask(builder)).toEqual({ type: 'build', targetId: 'wall-site1' });
+  });
+
   it('keeps healthy-buffer construction behind critical container repair without live same-target coverage', () => {
     const site = {
       id: 'storage-site1',


### PR DESCRIPTION
## Summary
Refs #1946.

PR #1950 is already merged as `97ebe2b`, but the follow-up E29N55 monitor still showed a real worker behavior gap at tick `2275871`: owned spawn=1, creeps=14, hostiles=0, `buildBlockedReason=worker_assignment_gap`, `buildCarriedEnergy=0`, `pendingBuildProgress=547`.

This patch fixes the CPU-shed worker selector path that could return non-emergency spawn/extension refill before bounded construction-yield logic ran. Under safe construction CPU headroom, a loaded worker now gets the existing bounded construction backlog check before non-emergency spawn/extension refill. Emergency refill, hostile rooms, hard CPU pressure, missing worker coverage, and existing build coverage still block that yield.

## Evidence
- Earlier #1946 artifact rows showed E29N55 oscillating between build activity and CPU-shed rows with `build=0`, `buildCarriedEnergy=0`, `taskCounts` dominated by repair/transfer/upgrade, and `blockedDetail=spawn_reserving_energy` while CPU bucket was around `1798-1872`.
- The new regression models E29N55 at `bucket=1857`, `used=70.1`, visible construction backlog, non-emergency extension refill demand, and safe recovery energy; the selected task is now `build` instead of refill transfer.
- `prod/dist/main.js` was regenerated only through `npm run build`.

## Tests
- `npm test -- --runInBand workerTasks.test.ts`
- `npm run typecheck`
- `npm test -- --runInBand` (105 suites, 2492 tests)
- `npm run build`
- `git diff --check HEAD~1..HEAD`

## Project update
Project mutation was retried after the GraphQL reset. Project `screeps` items for #1946 and #1951 are being refreshed with `Status=In review`, `Priority=P0`, `Domain=Territory/Economy`, `Kind=code`, compact evidence for head `21c30dec`, and the review/deploy observation next action.

## Next action
Run automated review/check gates, refresh Project `screeps` evidence when GraphQL resets, then deploy/observe after merge for sustained E29N55 construction acceptance: no sustained `worker_assignment_gap`, `buildCarriedEnergy > 0` or visible build progress on backlog, and CPU bucket not worsening below the current recovery band.
## Universal task Done gate
- [x] Task type: production code change for issue #1946.
- [x] Expected observable outcome / named deliverable: worker task selection yields one loaded worker to visible E29N55-style construction backlog during CPU-shed non-emergency spawn/extension refill when recovery energy is safe.
- [x] Non-goals / accepted substitutes: no Tencent compute, no reward-policy change, no monitor-only acceptance tweak, no owner action.
- [x] Verification evidence required before Done: `npm run typecheck`, `npm test -- --runInBand`, `npm run build`, issue-completion gate, automated review, required checks, and runtime construction acceptance evidence for #1946 closure.
- [x] Project Evidence / Next action / Blocked by: #1946 and #1951 Project items set to In review with evidence `21c30dec`; next action is review gate plus official deploy observation; none.
- [x] Post-merge/deploy/runtime proof: official deploy health gate and runtime monitor observation must prove E29N55 construction acceptance before closing #1946.
- [x] Named deliverable proof: head `21c30dec` changes `prod/src/tasks/workerTasks.ts`, adds the E29N55 CPU-shed regression in `prod/test/workerTasks.test.ts`, and local typecheck/full Jest/build passed.


