### PR TITLE
[codex] refresh storage balance during low-bucket recovery (#1952)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -53379,7 +53379,7 @@ function runEconomy(preludeTelemetryEvents = [], options = {}) {
   const shouldRunOptionalGlobalWork = () => shouldRunOptionalCpuWork(getRuntimeCpuBudget(), "economy-global-optional");
   const runOptionalGlobalWork = shouldRunOptionalCpuWork(cpuBudget, "economy-global-optional");
   const creeps = Object.values(Game.creeps);
-  if (runOptionalGlobalWork) {
+  if (!cpuBudget.critical) {
     balanceStorage();
   }
   if (runOptionalGlobalWork && featureGates.terminalEnergyTransfers) {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -187,7 +187,7 @@ export function runEconomy(
     shouldRunOptionalCpuWork(getRuntimeCpuBudget(), 'economy-global-optional');
   const runOptionalGlobalWork = shouldRunOptionalCpuWork(cpuBudget, 'economy-global-optional');
   const creeps = Object.values(Game.creeps);
-  if (runOptionalGlobalWork) {
+  if (!cpuBudget.critical) {
     balanceStorage();
   }
   if (runOptionalGlobalWork && featureGates.terminalEnergyTransfers) {

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -567,6 +567,136 @@ describe('runEconomy', () => {
     });
   });
 
+  it('refreshes multi-room energy routing during noncritical low-bucket recovery', () => {
+    Object.assign(globalThis, {
+      ERR_NO_PATH: -2,
+      FIND_HOSTILE_CREEPS: 101,
+      FIND_HOSTILE_STRUCTURES: 102,
+      FIND_SOURCES: 103,
+      RESOURCE_ENERGY: 'energy'
+    });
+    const gameTime = 2_322_135;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      economy: {
+        multiRoomEnergy: {
+          updatedAt: gameTime - 25,
+          corridor: ['E29N55', 'E29N56', 'E29N57'],
+          rooms: {
+            E29N55: {
+              roomName: 'E29N55',
+              mode: 'import',
+              storedEnergy: 2_174,
+              storageCapacity: 1_000_000,
+              storageRatio: 0.002174,
+              importDemand: 300_000,
+              exportableEnergy: 0,
+              plannedImportEnergy: 0,
+              plannedExportEnergy: 0,
+              localProductionEnergyPerTick: 20,
+              localHarvestCapacityEnergyPerTick: 20,
+              localHarvestCoverageRatio: 1,
+              localConsumptionEnergyPerTick: 15,
+              netLocalEnergyPerTick: 5,
+              spawnEnergyAvailable: 2_174,
+              spawnEnergyCapacity: 2_300,
+              spawnEnergyDeficit: 126,
+              spawnEnergyBufferThreshold: 800,
+              spawnEnergyBufferDeficit: 0,
+              criticalSpawnEnergyDeficit: 0,
+              storageDeficit: 300_000,
+              deficitEnergy: 300_000,
+              surplusEnergy: 0,
+              suppressedImportEnergy: 0,
+              blockedImportEnergy: 300_000,
+              bottleneck: 'no-exporter',
+              updatedAt: gameTime - 25
+            }
+          },
+          transfers: [
+            {
+              targetRoom: 'E29N55',
+              amount: 300_000,
+              status: 'blocked',
+              reason: 'no-exporter',
+              updatedAt: gameTime - 25
+            }
+          ]
+        }
+      }
+    };
+    const homeRoom = makeStorageEconomyRoom({
+      roomName: 'E29N55',
+      storageEnergy: 0,
+      storageCapacity: 1_000_000,
+      energyAvailable: 2_174,
+      energyCapacityAvailable: 2_300
+    });
+    const sourceRoomA = makeStorageEconomyRoom({
+      roomName: 'E29N56',
+      storageEnergy: 303_627,
+      storageCapacity: 1_000_000,
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300
+    });
+    const sourceRoomB = makeStorageEconomyRoom({
+      roomName: 'E29N57',
+      storageEnergy: 334_695,
+      storageCapacity: 1_000_000,
+      energyAvailable: 1_651,
+      energyCapacityAvailable: 1_800
+    });
+    const makeSpawn = (name: string, room: Room): StructureSpawn => ({
+      name,
+      room,
+      my: true,
+      spawning: null,
+      store: makeEnergyStore(300, 300),
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    }) as unknown as StructureSpawn;
+    const homeSpawn = makeSpawn('Spawn1', homeRoom);
+    const sourceSpawnA = makeSpawn('Spawn2', sourceRoomA);
+    const sourceSpawnB = makeSpawn('Spawn3', sourceRoomB);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: gameTime,
+      rooms: {
+        E29N55: homeRoom,
+        E29N56: sourceRoomA,
+        E29N57: sourceRoomB
+      },
+      spawns: {
+        Spawn1: homeSpawn,
+        Spawn2: sourceSpawnA,
+        Spawn3: sourceSpawnB
+      },
+      creeps: {
+        Worker1: { name: 'Worker1', memory: { role: 'worker', colony: 'E29N55' }, room: homeRoom } as Creep,
+        Worker2: { name: 'Worker2', memory: { role: 'worker', colony: 'E29N55' }, room: homeRoom } as Creep,
+        Worker3: { name: 'Worker3', memory: { role: 'worker', colony: 'E29N55' }, room: homeRoom } as Creep
+      },
+      map: {
+        findRoute: jest.fn((_fromRoom: string, targetRoom: string) => [{ exit: 1, room: targetRoom }])
+      } as unknown as GameMap,
+      cpu: {
+        getUsed: jest.fn().mockReturnValue(13.5),
+        limit: 70,
+        bucket: 997,
+        tickLimit: 500
+      } as unknown as CPU
+    };
+
+    runEconomy();
+
+    expect(Memory.economy?.storageBalance?.transfers).toEqual([
+      { sourceRoom: 'E29N57', targetRoom: 'E29N55', amount: 234_695, updatedAt: gameTime },
+      { sourceRoom: 'E29N56', targetRoom: 'E29N55', amount: 65_305, updatedAt: gameTime }
+    ]);
+    expect(Memory.economy?.multiRoomEnergy?.rooms.E29N55).toMatchObject({
+      plannedImportEnergy: 300_000,
+      blockedImportEnergy: 0
+    });
+    expect(Memory.economy?.multiRoomEnergy?.rooms.E29N55?.bottleneck).toBeUndefined();
+  });
+
   it('keeps local worker floor recovery planning under critical CPU when one counted worker remains', () => {
     const findSources = (globalThis as Record<string, unknown>).FIND_SOURCES;
     const room = {


### PR DESCRIPTION
## Summary

Related to #1952.

- Keeps `balanceStorage()` running during noncritical CPU pressure so storage balance and `Memory.economy.multiRoomEnergy` refresh even while optional global work is shed.
- Leaves terminal energy transfers, market trading, mineral spawning, and other optional global work behind the existing CPU gates.
- Adds an E29N55-shaped low-bucket regression that starts with stale `multiRoomEnergy.bottleneck=no-exporter` and verifies the tick refresh plans imports from E29N57/E29N56.
- Rebuilt `prod/dist/main.js` from `npm run build`.

## Root Cause

PR #1959 fixed the storage-support transfer limit, and the source-level E29N55 regression passes. The post-deploy runtime capture still reported `no-exporter` because the latest ticks were in low-bucket/degraded mode (`bucket` around 984-1006), and `runEconomy()` only called `balanceStorage()` inside optional global CPU work. When optional global work was suppressed, telemetry kept reporting stale `Memory.economy.multiRoomEnergy` with `blockedImportEnergy=300000` and `bottleneck=no-exporter`.

## Runtime Evidence

- Latest artifact: `runtime-artifacts/runtime-summary-console/runtime-summary-console-20260618T050236Z.log`.
- Tick `2322135`: E29N55 `multiRoomEnergy.bottleneck=no-exporter`, `importDemand=300000`, `blockedImportEnergy=300000`, `imports=0`, `exports=0`.
- Same tick: E29N56 `storageEnergy=303627`, `importDemand=0`, `exportableEnergy=0`; E29N57 `storageEnergy=334695`, `importDemand=0`, `exportableEnergy=0`; no hostiles reported.
- CPU stayed noncritical: latest bucket around `997`, with the capture window around `984-1006` and sub500 count `0`.

## Verification

- `npm test -- --runInBand prod/test/economyLoop.test.ts -t "refreshes multi-room energy routing"` failed before the production change with `storageBalance` undefined, then passed after the fix.
- `npm test -- --runInBand prod/test/economy/interRoomEnergyTransfers.test.ts prod/test/economyLoop.test.ts` passed: 2 suites, 85 tests.
- `npm run typecheck` passed.
- `npm test -- --runInBand` passed: 105 suites, 2,497 tests.
- `npm run build` passed and regenerated `prod/dist/main.js`.
- `git diff --check` passed.

## Universal task Done gate

- [x] Task type: P1 production behavior bug fix for inter-room energy routing telemetry and planning refresh.
- [x] Expected observable outcome / named deliverable: E29N55 multi-room energy routing refreshes during noncritical low-bucket ticks and plans imports from safe E29N56/E29N57 storage support instead of carrying stale no-exporter memory.
- [x] Non-goals / accepted substitutes: no merge, deploy, scale-out, Tencent compute, or CodeRabbit/Gemini finding repair outside this PR.
- [x] Verification evidence required before Done: targeted regression failed before the production change and passed after it; focused Jest, typecheck, full Jest 105/2,497, build, and diff check passed.
- [x] Project Evidence / Next action / Blocked by: Project screeps cards for #1952 and PR #1962 are Status=In review with Evidence and Next action refreshed; no active blocker exists for this lane.
- [x] Post-merge/deploy/runtime proof: build proof is npm run build with regenerated prod/dist/main.js; deploy-gate runtime recapture target is the E29N55 multiRoomEnergy KPI.
- [x] Named deliverable proof: economy-loop regression seeds stale E29N55 no-exporter memory at tick 2322135 with E29N56/E29N57 storage support and proves refreshed plannedImportEnergy=300000, blockedImportEnergy=0, and no bottleneck.

## Notes

This PR intentionally does not spawn extra work under critical CPU. `balanceStorage()` still uses its existing `STORAGE_BALANCE_REFRESH_INTERVAL` freshness guard, so the noncritical low-bucket path refreshes routing state without making terminal/market/mineral work run during CPU recovery.