### PR TITLE
[codex] Add CPU bucket emergency floor alert

### DIFF
--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -230,10 +230,12 @@ ENERGY_BUFFER_UNHEALTHY_ROUTES = [
     {"issue": "#907", "topic": "reward_decisions"},
 ]
 CPU_BUCKET_LOW_KIND = "cpu_bucket_low"
+CPU_BUCKET_EMERGENCY_FLOOR_KIND = "cpu_bucket_emergency_floor"
 CPU_BUCKET_CRITICAL_KIND = "cpu_bucket_critical"
 CPU_USED_OVER_LIMIT_KIND = "cpu_used_over_limit"
 CPU_TELEMETRY_MISSING_KIND = "cpu_telemetry_missing"
 CPU_BUCKET_LOW_THRESHOLD = 1_000
+CPU_BUCKET_EMERGENCY_FLOOR = 500
 CPU_BUCKET_CRITICAL_THRESHOLD = 100
 CPU_BUCKET_RECOVERY_ALERT_FLOOR = 900
 CPU_BUCKET_RECOVERY_ALERT_GRACE_TICKS = 20
@@ -531,6 +533,21 @@ TACTICAL_CATEGORY_RULES: dict[str, dict[str, Any]] = {
             "routes_to": CPU_BUCKET_ROUTES,
         },
     },
+    CPU_BUCKET_EMERGENCY_FLOOR_KIND: {
+        "severity": "high",
+        "decision": "codex_hotfix",
+        "actions": ["capture_runtime_context", "inspect_recent_deploy", "start_hotfix_gate"],
+        "metadata": {
+            "metric": "cpu.bucket",
+            "related_issues": ["#1955", "#1909", "#1490", "#906", "#924"],
+            "thresholds": {
+                "P1_emergency_floor": CPU_BUCKET_EMERGENCY_FLOOR,
+                "P1_low": CPU_BUCKET_LOW_THRESHOLD,
+                "P0": CPU_BUCKET_CRITICAL_THRESHOLD,
+            },
+            "routes_to": [{"issue": "#1955", "topic": "emergency_floor_alert"}, *CPU_BUCKET_ROUTES],
+        },
+    },
     CPU_BUCKET_LOW_KIND: {
         "severity": "high",
         "decision": "codex_hotfix",
@@ -646,6 +663,7 @@ TACTICAL_REASON_CATEGORY_MAP = {
     "runtime_deadlock": ["runtime_deadlock"],
     "resource_crisis": ["resource_crisis"],
     CPU_BUCKET_CRITICAL_KIND: [CPU_BUCKET_CRITICAL_KIND],
+    CPU_BUCKET_EMERGENCY_FLOOR_KIND: [CPU_BUCKET_EMERGENCY_FLOOR_KIND],
     CPU_BUCKET_LOW_KIND: [CPU_BUCKET_LOW_KIND],
     CPU_USED_OVER_LIMIT_KIND: [CPU_USED_OVER_LIMIT_KIND],
     CPU_TELEMETRY_MISSING_KIND: [CPU_TELEMETRY_MISSING_KIND],
@@ -1641,6 +1659,20 @@ def cpu_bucket_metadata() -> dict[str, Any]:
     }
 
 
+def cpu_bucket_emergency_floor_metadata() -> dict[str, Any]:
+    routes = [{"issue": "#1955", "topic": "emergency_floor_alert"}, *CPU_BUCKET_ROUTES]
+    return {
+        "metric": "cpu.bucket",
+        "related_issues": ["#1955", "#1909", *[str(route["issue"]) for route in CPU_BUCKET_ROUTES]],
+        "thresholds": {
+            "P1_emergency_floor": CPU_BUCKET_EMERGENCY_FLOOR,
+            "P1_low": CPU_BUCKET_LOW_THRESHOLD,
+            "P0": CPU_BUCKET_CRITICAL_THRESHOLD,
+        },
+        "routes_to": [dict(route) for route in routes],
+    }
+
+
 def cpu_used_over_limit_metadata() -> dict[str, Any]:
     return {
         "metric": "cpu.used",
@@ -1699,6 +1731,43 @@ def runtime_cpu_bucket(room: dict[str, Any]) -> int | float | None:
     )
 
 
+def runtime_cpu_emergency_floor_bucket(room: dict[str, Any]) -> int | float | None:
+    values = [
+        value
+        for value in (
+            runtime_cpu_bucket(room),
+            first_number_value(
+                room,
+                ("minCpuBucket",),
+                ("cpuBucketMin",),
+                ("bucketMin",),
+                ("minBucket",),
+                ("rollingCpuBucket",),
+                ("rolling_cpu_bucket",),
+                ("rollingBucket",),
+                ("rolling_bucket",),
+                ("cpu", "minCpuBucket"),
+                ("cpu", "cpuBucketMin"),
+                ("cpu", "bucketMin"),
+                ("cpu", "minBucket"),
+                ("cpu", "rollingCpuBucket"),
+                ("cpu", "rollingBucket"),
+                (RUNTIME_SUMMARY_CPU_METADATA_KEY, "minCpuBucket"),
+                (RUNTIME_SUMMARY_CPU_METADATA_KEY, "cpuBucketMin"),
+                (RUNTIME_SUMMARY_CPU_METADATA_KEY, "bucketMin"),
+                (RUNTIME_SUMMARY_CPU_METADATA_KEY, "minBucket"),
+                (RUNTIME_SUMMARY_CPU_METADATA_KEY, "rollingCpuBucket"),
+                (RUNTIME_SUMMARY_CPU_METADATA_KEY, "rollingBucket"),
+                ("rolling", "cpuBucket"),
+                ("rolling", "bucket"),
+                ("rolling", "cpu", "bucket"),
+            ),
+        )
+        if value is not None
+    ]
+    return min(values) if values else None
+
+
 def runtime_cpu_used(room: dict[str, Any]) -> int | float | None:
     return first_number_value(
         room,
@@ -1729,6 +1798,7 @@ def runtime_low_bucket_ticks(room: dict[str, Any]) -> int | float | None:
 def runtime_cpu_has_current_evidence(room: dict[str, Any]) -> bool:
     return (
         runtime_cpu_bucket(room) is not None
+        or runtime_cpu_emergency_floor_bucket(room) is not None
         or runtime_cpu_used(room) is not None
         or runtime_low_bucket_ticks(room) is not None
         or runtime_cpu_pressure(room) is not None
@@ -1791,6 +1861,10 @@ def detect_cpu_bucket_kind(runtime_room: dict[str, Any] | None) -> str | None:
     if critical_bucket:
         return CPU_BUCKET_CRITICAL_KIND
 
+    emergency_floor_bucket = runtime_cpu_emergency_floor_bucket(runtime_room)
+    if emergency_floor_bucket is not None and emergency_floor_bucket < CPU_BUCKET_EMERGENCY_FLOOR:
+        return CPU_BUCKET_EMERGENCY_FLOOR_KIND
+
     low_bucket = (
         "lowBucket" in alerts
         or "lowBucketRecovery" in alerts
@@ -1807,6 +1881,8 @@ def detect_cpu_bucket_kind(runtime_room: dict[str, Any] | None) -> str | None:
 
 def build_cpu_bucket_reason(ref: RoomRef, runtime_room: dict[str, Any], kind: str) -> dict[str, Any]:
     bucket = runtime_cpu_bucket(runtime_room)
+    emergency_floor_bucket = runtime_cpu_emergency_floor_bucket(runtime_room)
+    alert_bucket = emergency_floor_bucket if kind == CPU_BUCKET_EMERGENCY_FLOOR_KIND else bucket
     used = runtime_cpu_used(runtime_room)
     limit = runtime_cpu_limit(runtime_room)
     pressure = runtime_cpu_pressure(runtime_room)
@@ -1814,7 +1890,14 @@ def build_cpu_bucket_reason(ref: RoomRef, runtime_room: dict[str, Any], kind: st
     reasons = runtime_cpu_signal_values(runtime_room, "reasons")
     low_bucket_ticks = runtime_low_bucket_ticks(runtime_room)
     critical = kind == CPU_BUCKET_CRITICAL_KIND
-    threshold = CPU_BUCKET_CRITICAL_THRESHOLD if critical else CPU_BUCKET_LOW_THRESHOLD
+    emergency_floor = kind == CPU_BUCKET_EMERGENCY_FLOOR_KIND
+    threshold = (
+        CPU_BUCKET_CRITICAL_THRESHOLD
+        if critical
+        else CPU_BUCKET_EMERGENCY_FLOOR
+        if emergency_floor
+        else CPU_BUCKET_LOW_THRESHOLD
+    )
     severity = "critical" if critical else "high"
     priority = "P0" if critical else "P1"
     return {
@@ -1823,9 +1906,11 @@ def build_cpu_bucket_reason(ref: RoomRef, runtime_room: dict[str, Any], kind: st
         "room_name": ref.room,
         "severity": severity,
         "priority": priority,
-        "cpuBucket": bucket,
-        "cpu_bucket": bucket,
-        "bucket": bucket,
+        "cpuBucket": alert_bucket,
+        "cpu_bucket": alert_bucket,
+        "bucket": alert_bucket,
+        "currentCpuBucket": bucket,
+        "emergencyFloorBucket": emergency_floor_bucket,
         "cpuUsed": used,
         "cpuLimit": limit,
         "pressure": pressure,
@@ -1834,10 +1919,12 @@ def build_cpu_bucket_reason(ref: RoomRef, runtime_room: dict[str, Any], kind: st
         "lowBucketTicks": low_bucket_ticks,
         "threshold": threshold,
         "low_bucket_threshold": CPU_BUCKET_LOW_THRESHOLD,
+        "emergency_floor_threshold": CPU_BUCKET_EMERGENCY_FLOOR,
         "critical_bucket_threshold": CPU_BUCKET_CRITICAL_THRESHOLD,
-        "metadata": cpu_bucket_metadata(),
+        "metadata": cpu_bucket_emergency_floor_metadata() if emergency_floor else cpu_bucket_metadata(),
+        "owner_ping": False,
         "message": (
-            f"{kind} in {ref.key}: cpu bucket {format_energy_value(bucket)} below "
+            f"{kind} in {ref.key}: cpu bucket {format_energy_value(alert_bucket)} below "
             f"{threshold} threshold; pressure={pressure or 'unknown'}, alerts={alerts or []}, "
             f"reasons={reasons or []}."
         ),
@@ -5766,6 +5853,7 @@ def runtime_summary_room_has_worker_idle_fields(room: dict[str, Any]) -> bool:
 def runtime_summary_payload_has_cpu_fields(payload: dict[str, Any]) -> bool:
     return (
         runtime_cpu_bucket(payload) is not None
+        or runtime_cpu_emergency_floor_bucket(payload) is not None
         or runtime_cpu_used(payload) is not None
         or runtime_cpu_limit(payload) is not None
         or runtime_low_bucket_ticks(payload) is not None
@@ -5778,6 +5866,7 @@ def runtime_summary_payload_has_cpu_fields(payload: dict[str, Any]) -> bool:
 def runtime_summary_room_has_cpu_fields(room: dict[str, Any]) -> bool:
     return (
         runtime_cpu_bucket(room) is not None
+        or runtime_cpu_emergency_floor_bucket(room) is not None
         or runtime_cpu_used(room) is not None
         or runtime_cpu_limit(room) is not None
         or runtime_low_bucket_ticks(room) is not None
@@ -5942,6 +6031,17 @@ def runtime_cpu_summary_fields(cpu: dict[str, Any]) -> dict[str, Any]:
     bucket = number_value(cpu.get("bucket"))
     if bucket is not None:
         result["cpuBucket"] = bucket
+    min_bucket = first_number_value(
+        cpu,
+        ("minCpuBucket",),
+        ("cpuBucketMin",),
+        ("bucketMin",),
+        ("minBucket",),
+        ("rollingCpuBucket",),
+        ("rollingBucket",),
+    )
+    if min_bucket is not None:
+        result["minCpuBucket"] = min_bucket
     low_bucket_ticks = number_value(cpu.get("lowBucketTicks"))
     if low_bucket_ticks is not None:
         result["lowBucketTicks"] = low_bucket_ticks
@@ -5972,6 +6072,12 @@ def runtime_summary_room_with_cpu_fields(base: dict[str, Any], cpu_room: dict[st
         "cpuBucket",
         "cpuUsed",
         "cpuLimit",
+        "minCpuBucket",
+        "cpuBucketMin",
+        "bucketMin",
+        "minBucket",
+        "rollingCpuBucket",
+        "rollingBucket",
         "lowBucketTicks",
         "bucketEmptyTicks",
         "bucket",

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -3021,7 +3021,7 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         runtime_room = {
             "roomName": "E26S49",
             monitor.RUNTIME_SUMMARY_CPU_METADATA_KEY: {
-                "bucket": 499,
+                "bucket": 750,
                 "pressure": "degraded",
                 "alerts": ["lowBucket"],
                 "reasons": ["lowBucket"],
@@ -3039,6 +3039,7 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(suppressed, [])
         self.assertEqual([reason["kind"] for reason in emitted], [monitor.CPU_BUCKET_LOW_KIND])
         self.assertEqual(emitted[0]["priority"], "P1")
+        self.assertNotEqual(emitted[0]["kind"], monitor.CPU_BUCKET_EMERGENCY_FLOOR_KIND)
         report = monitor.build_tactical_response_report(
             {"ok": True, "mode": "alert", "alert": True, "reasons": emitted, "rooms": ["shardX/E26S49"]}
         )
@@ -3046,6 +3047,182 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(report["severity"], "high")
         self.assertEqual(report["priority"], "P1")
         self.assertEqual(report["categories"], [monitor.CPU_BUCKET_LOW_KIND])
+
+    def test_cpu_bucket_emergency_floor_current_bucket_alerts_health_gate_without_owner_ping(self) -> None:
+        snapshot = make_snapshot(
+            {
+                "spawn1": {
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "x": 25,
+                    "y": 25,
+                    "hits": 5000,
+                    "hitsMax": 5000,
+                },
+                "worker-1": {
+                    "type": "creep",
+                    "my": True,
+                    "owner": {"username": "owner"},
+                    "name": "worker-1",
+                    "x": 23,
+                    "y": 25,
+                },
+            }
+        )
+        runtime_room = {
+            "room": "shardX/E26S49",
+            "roomName": "E26S49",
+            "cpuUsed": 20.6,
+            "cpuLimit": 70,
+            "cpuBucket": 455,
+            monitor.RUNTIME_SUMMARY_CPU_METADATA_KEY: {
+                "used": 20.6,
+                "limit": 70,
+                "bucket": 455,
+                "pressure": "degraded",
+                "alerts": ["lowBucket"],
+                "reasons": ["lowBucket"],
+            },
+            "constructionSiteCount": 0,
+            "pendingBuildProgress": 0,
+        }
+
+        emitted, suppressed, _next_state = monitor.evaluate_room_alert(
+            snapshot,
+            {"baseline_established": True, "owner": "owner"},
+            now=100,
+            debounce_seconds=300,
+            runtime_room_summary=runtime_room,
+        )
+
+        self.assertEqual(suppressed, [])
+        self.assertEqual([reason["kind"] for reason in emitted], [monitor.CPU_BUCKET_EMERGENCY_FLOOR_KIND])
+        reason = emitted[0]
+        self.assertEqual(reason["priority"], "P1")
+        self.assertEqual(reason["severity"], "high")
+        self.assertEqual(reason["cpuBucket"], 455)
+        self.assertEqual(reason["currentCpuBucket"], 455)
+        self.assertEqual(reason["emergencyFloorBucket"], 455)
+        self.assertEqual(reason["threshold"], 500)
+        self.assertFalse(reason["owner_ping"])
+
+        alert_payload = {
+            "ok": True,
+            "mode": "alert",
+            "alert": True,
+            "reasons": emitted,
+            "rooms": ["shardX/E26S49"],
+        }
+        health = monitor.evaluate_postdeploy_health_gate(
+            {
+                "ok": True,
+                "mode": "summary",
+                "room_summaries": [
+                    {
+                        **runtime_room,
+                        "owned_creeps": 1,
+                        "owned_spawns": 1,
+                        "creeps": 1,
+                        "spawns": 1,
+                        "owner": "owner",
+                    }
+                ],
+            },
+            alert_payload,
+        )
+
+        self.assertFalse(health["ok"])
+        self.assertIn("postdeploy_active_alert", [health_reason["kind"] for health_reason in health["reasons"]])
+        self.assertIn(
+            monitor.CPU_BUCKET_EMERGENCY_FLOOR_KIND,
+            [
+                health_reason.get("source", health_reason).get("kind")
+                for health_reason in health["reasons"]
+                if isinstance(health_reason.get("source", health_reason), dict)
+            ],
+        )
+        self.assertNotIn(
+            monitor.CPU_BUCKET_EMERGENCY_FLOOR_KIND,
+            [health_reason["kind"] for health_reason in health.get("non_blocking_reasons", [])],
+        )
+
+        report = monitor.build_tactical_response_report(alert_payload)
+        self.assertTrue(report["emergency"])
+        self.assertFalse(report["silent"])
+        self.assertEqual(report["severity"], "high")
+        self.assertEqual(report["priority"], "P1")
+        self.assertEqual(report["categories"], [monitor.CPU_BUCKET_EMERGENCY_FLOOR_KIND])
+        self.assertFalse(report["scheduler"]["direct_discord_send"])
+        self.assertNotIn("decide_owner_action", {action["id"] for action in report["next_actions"]})
+        trigger = report["triggers"][0]
+        self.assertEqual(trigger["metadata"]["thresholds"]["P1_emergency_floor"], 500)
+
+    def test_cpu_bucket_emergency_floor_uses_rolling_min_bucket_evidence(self) -> None:
+        compact_cpu_payload = {
+            "used": 20.6,
+            "limit": 70,
+            "bucket": 579,
+            "minCpuBucket": 455,
+            "pressure": "degraded",
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runtime_dir = Path(temp_dir)
+            (runtime_dir / "runtime-summary-console-20260617T170300Z.log").write_text(
+                "#cpu-summary " + json.dumps(compact_cpu_payload) + "\n",
+                encoding="utf-8",
+            )
+            warnings: list[str] = []
+            runtime_rooms = monitor.load_latest_runtime_room_summaries(
+                runtime_dir,
+                [monitor.RoomRef(shard="shardX", room="E26S49")],
+                warnings,
+            )
+
+        self.assertEqual(warnings, [])
+        runtime_room = runtime_rooms["shardX/E26S49"]
+        self.assertEqual(runtime_room["cpuBucket"], 579)
+        self.assertEqual(runtime_room["minCpuBucket"], 455)
+
+        reason = monitor.detect_cpu_bucket_reason(
+            monitor.RoomRef(shard="shardX", room="E26S49"),
+            runtime_room,
+        )
+
+        self.assertIsNotNone(reason)
+        assert reason is not None
+        self.assertEqual(reason["kind"], monitor.CPU_BUCKET_EMERGENCY_FLOOR_KIND)
+        self.assertEqual(reason["cpuBucket"], 455)
+        self.assertEqual(reason["currentCpuBucket"], 579)
+        self.assertEqual(reason["emergencyFloorBucket"], 455)
+        self.assertFalse(reason["owner_ping"])
+
+    def test_cpu_bucket_at_or_above_emergency_floor_does_not_emit_floor_alert(self) -> None:
+        for bucket in (500, 750, 1000):
+            with self.subTest(bucket=bucket):
+                runtime_room = {
+                    "roomName": "E26S49",
+                    monitor.RUNTIME_SUMMARY_CPU_METADATA_KEY: {
+                        "used": 20.6,
+                        "limit": 70,
+                        "bucket": bucket,
+                        "pressure": "degraded" if bucket < 1000 else "normal",
+                    },
+                }
+
+                reason = monitor.detect_cpu_bucket_reason(
+                    monitor.RoomRef(shard="shardX", room="E26S49"),
+                    runtime_room,
+                )
+
+                if bucket < monitor.CPU_BUCKET_LOW_THRESHOLD:
+                    self.assertIsNotNone(reason)
+                    assert reason is not None
+                    self.assertEqual(reason["kind"], monitor.CPU_BUCKET_LOW_KIND)
+                else:
+                    self.assertIsNone(reason)
+                if reason is not None:
+                    self.assertNotEqual(reason["kind"], monitor.CPU_BUCKET_EMERGENCY_FLOOR_KIND)
 
     def test_near_threshold_under_limit_low_bucket_gets_short_recovery_grace(self) -> None:
         snapshot = make_snapshot(


### PR DESCRIPTION
## Linked Issues

- Fixes #1955
- Related to issue 1909 for broader CPU recovery/threshold tracking.

## Domain / Kind

- Domain: Runtime monitor
- Kind: code

## Summary

- Add a `cpu_bucket_emergency_floor` runtime alert kind for CPU bucket evidence below 500, after the existing P0 critical bucket path and before generic low-bucket recovery handling.
- Carry current and min/rolling bucket evidence through runtime-summary and compact `#cpu-summary` parsing so either current or rolling bucket evidence below 500 becomes actionable.
- Make the postdeploy health gate block the emergency-floor alert while preserving the existing non-blocking treatment for recoverable generic low-bucket noise; CPU bucket reasons explicitly keep `owner_ping: false`.

## Notes

- #1909 remains the broader CPU recovery/threshold tracking issue. This PR is only the narrow runtime alert/health-gate trigger for bucket evidence below 500.
- No production bot files were touched, and no Screeps destructive actions or Tencent paid compute were run.

## Verification

- [x] `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py` - passed
- [x] `python3 -m unittest scripts.test_screeps_runtime_monitor_tactical_response.TacticalResponseBridgeTest.test_cpu_bucket_low_runtime_summary_alerts_as_p1 scripts.test_screeps_runtime_monitor_tactical_response.TacticalResponseBridgeTest.test_cpu_bucket_emergency_floor_current_bucket_alerts_health_gate_without_owner_ping scripts.test_screeps_runtime_monitor_tactical_response.TacticalResponseBridgeTest.test_cpu_bucket_emergency_floor_uses_rolling_min_bucket_evidence scripts.test_screeps_runtime_monitor_tactical_response.TacticalResponseBridgeTest.test_cpu_bucket_at_or_above_emergency_floor_does_not_emit_floor_alert scripts.test_screeps_runtime_monitor_tactical_response.TacticalResponseBridgeTest.test_near_threshold_under_limit_low_bucket_gets_short_recovery_grace scripts.test_screeps_runtime_monitor_tactical_response.TacticalResponseBridgeTest.test_low_bucket_recovery_alerts_runtime_but_not_postdeploy_health_gate scripts.test_screeps_runtime_monitor_tactical_response.TacticalResponseBridgeTest.test_postdeploy_health_gate_allows_under_limit_cpu_bucket_recovery_noise` - passed, 7 tests
- [x] `python3 scripts/screeps-runtime-monitor.py self-test` - passed, 43 tests
- [x] `python3 -m unittest scripts.test_screeps_runtime_monitor_tactical_response` - passed, 163 tests
- [x] `git diff --check -- scripts/screeps-runtime-monitor.py scripts/test_screeps_runtime_monitor_tactical_response.py` - passed
- [x] GitHub Project issue/PR fields are current: issue #1955 and PR #1963 are in Project `screeps`, Status `In review`, with Evidence and Next action refreshed; Blocked by is empty.
- [x] Automated review gate is for the controller handoff; no blocking automated finding was present at PR creation time.
- [x] QA gate: local runtime-monitor offline verification passed; formal merge QA remains part of the later merge gate.
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate

- [x] Task type: code behavior bugfix.
- [x] Expected observable outcome / named deliverable: runtime monitor alert and health-gate trigger for current or min/rolling CPU bucket evidence below 500, with non-silent self-actionable output and no owner ping.
- [x] Non-goals / accepted substitutes: no prod bot logic change, no deployment, no Tencent paid compute, no Screeps destructive action; #1909 remains the broader CPU recovery tracker.
- [x] Verification evidence required before Done: py_compile, targeted CPU floor unittest, monitor self-test, full tactical response unittest, and diff check all passed as listed above.
- [x] Project Evidence / Next action / Blocked by: issue #1955 and PR #1963 Project items are In review with head SHA 2bd16f0481541ad6fce551a66b3cef84118e7296 evidence; Next action points to review and merge gates; Blocked by is empty.
- [x] Post-merge/deploy/runtime proof: not applicable for this narrow monitor-script PR; no live deployment or runtime action was requested for #1955 acceptance.
- [x] Named deliverable proof: PR #1963 changes `scripts/screeps-runtime-monitor.py` and `scripts/test_screeps_runtime_monitor_tactical_response.py` to prove the named runtime monitor and health-gate behavior.

## Issue closure gate

For every issue linked above in the PR body with a closing keyword:

- [x] #1955: acceptance is satisfied by `cpu_bucket_emergency_floor` for current/min bucket evidence below 500, health-gate blocking for that alert, boundary coverage at and above 500, and explicit `owner_ping: false`; verification commands above passed.
- [x] No closed issue has runtime proof, owner action, successor work, partial-fix scope, or another blocker for the #1955 acceptance criteria.

## Runtime / Deployment Impact

- [x] Runtime monitor behavior changes only: emergency-floor CPU bucket evidence now creates an actionable alert and health-gate blocker.
- [x] No production bot deployment or live Screeps action was performed.

## Handoff

- PR is draft for controller review-gate handoff.
- Head SHA: `2bd16f0481541ad6fce551a66b3cef84118e7296`.
- Do not merge until live checks, review threads, Project state, expected head SHA, and the 15-minute merge gate pass in the same run.