### PR TITLE
Fix E29N56 construction assignment gap

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35888,7 +35888,15 @@ function shouldPreemptRepairTaskForConstructionBacklog(creep, task, selectedTask
   if (task.type !== "repair" || (selectedTask == null ? void 0 : selectedTask.type) !== "build" || isSameTask2(task, selectedTask)) {
     return false;
   }
-  return isRepairTargetPreemptibleForConstructionBacklog(creep, getTaskTarget(task));
+  const repairTarget = getTaskTarget(task);
+  return isRepairTargetPreemptibleForConstructionBacklog(creep, repairTarget) || shouldPreemptProtectedInfrastructureRepairForAssignmentGapConstruction(
+    creep,
+    selectedTask,
+    repairTarget
+  );
+}
+function shouldPreemptProtectedInfrastructureRepairForAssignmentGapConstruction(creep, selectedTask, repairTarget) {
+  return isRepairPreemptionStructure(repairTarget) && isBuildPreemptionCriticalRoadOrContainerRepairTarget(repairTarget) && !hasOtherSameRoomRepairAssignmentForTargetIgnoringCoverage(creep, repairTarget) && getUsedTransferEnergy(creep) > 0 && getActiveWorkParts3(creep) > 0 && !hasOtherSameRoomBuildAssignment(creep) && hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep) && !hasVisibleHostileCreeps2(creep.room) && !isControllerDowngradeGuardActive2(creep.room) && hasSafeAssignmentGapRecoveryConstructionEnergy(creep, selectedTask);
 }
 function isProtectedRepairTargetForConstructionBacklog(creep, target) {
   if (!isRepairPreemptionStructure(target) || isWorkerRepairTargetComplete(target)) {
@@ -35936,6 +35944,20 @@ function hasOtherSameRoomRepairAssignmentForTarget(creep, target) {
     }
     const task = (_a2 = worker.memory) == null ? void 0 : _a2.task;
     return (task == null ? void 0 : task.type) === "repair" && String(task.targetId) === targetId && getUsedTransferEnergy(worker) > 0 && getActiveWorkParts3(worker) > 0;
+  });
+}
+function hasOtherSameRoomRepairAssignmentForTargetIgnoringCoverage(creep, target) {
+  const targetId = getObjectId10(target);
+  if (targetId.length === 0) {
+    return false;
+  }
+  return getRoomOwnedCreeps3(creep.room).some((worker) => {
+    var _a2;
+    if (isSameCreep4(worker, creep) || !isProductiveSameRoomWorker2(worker, creep.room)) {
+      return false;
+    }
+    const task = (_a2 = worker.memory) == null ? void 0 : _a2.task;
+    return (task == null ? void 0 : task.type) === "repair" && String(task.targetId) === targetId;
   });
 }
 function getActiveWorkParts3(creep) {
@@ -36178,7 +36200,7 @@ function hasOtherSameRoomBuildAssignment(creep) {
 }
 function isBuildCoverageWorker2(worker) {
   var _a2, _b;
-  return ((_b = (_a2 = worker.memory) == null ? void 0 : _a2.task) == null ? void 0 : _b.type) === "build" && getActiveWorkParts3(worker) > 0;
+  return ((_b = (_a2 = worker.memory) == null ? void 0 : _a2.task) == null ? void 0 : _b.type) === "build" && getActiveWorkParts3(worker) > 0 && getUsedTransferEnergy(worker) > 0;
 }
 function hasRecentFailedBuildCoverage2(worker, siteId) {
   if (!siteId) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35266,7 +35266,7 @@ function runWorker(creep) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
-  } else if (shouldPreemptTaskForUrgentRepair(currentTask, selectedTask)) {
+  } else if (shouldPreemptTaskForUrgentRepair(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForSeasonScore(currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
@@ -36826,14 +36826,25 @@ function shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, task, 
   }
   return isUrgentEnergySpendingTask(selectedTask) || isDowngradeGuardUpgradeTask(creep, selectedTask);
 }
-function shouldPreemptTaskForUrgentRepair(task, selectedTask) {
+function shouldPreemptTaskForUrgentRepair(creep, task, selectedTask) {
   if (task.type !== "build" && task.type !== "repair" && task.type !== "transfer") {
     return false;
   }
   if (!selectedTask || isSameTask2(task, selectedTask) || !isUrgentRepairTask(selectedTask)) {
     return false;
   }
+  if (shouldKeepAssignmentGapConstructionAheadOfCriticalRoadOrContainerRepair(creep, task, selectedTask)) {
+    return false;
+  }
   return true;
+}
+function shouldKeepAssignmentGapConstructionAheadOfCriticalRoadOrContainerRepair(creep, task, selectedTask) {
+  if (task.type !== "build" || selectedTask.type !== "repair") {
+    return false;
+  }
+  const constructionSite = getTaskTarget(task);
+  const repairTarget = getTaskTarget(selectedTask);
+  return isConstructionSite(constructionSite) && canSpendWorkerEnergyOnAssignmentGapRecoveryConstructionSite(creep, constructionSite) && isRepairPreemptionStructure(repairTarget) && isBuildPreemptionCriticalRoadOrContainerRepairTarget(repairTarget) && !hasOtherSameRoomRepairAssignmentForTargetIgnoringCoverage(creep, repairTarget) && getUsedTransferEnergy(creep) > 0 && getActiveWorkParts3(creep) > 0 && !hasOtherSameRoomBuildAssignment(creep) && hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep) && !hasVisibleHostileCreeps2(creep.room) && !isControllerDowngradeGuardActive2(creep.room) && hasSafeAssignmentGapRecoveryConstructionEnergy(creep, task);
 }
 function shouldPreemptEnergyAcquisitionTaskForSeasonScore(task, selectedTask) {
   return isEnergyAcquisitionTask2(task) && (selectedTask == null ? void 0 : selectedTask.type) === "collectScore" && !isSameTask2(task, selectedTask);

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -1249,7 +1249,34 @@ function shouldPreemptRepairTaskForConstructionBacklog(
     return false;
   }
 
-  return isRepairTargetPreemptibleForConstructionBacklog(creep, getTaskTarget(task));
+  const repairTarget = getTaskTarget(task);
+  return (
+    isRepairTargetPreemptibleForConstructionBacklog(creep, repairTarget) ||
+    shouldPreemptProtectedInfrastructureRepairForAssignmentGapConstruction(
+      creep,
+      selectedTask,
+      repairTarget
+    )
+  );
+}
+
+function shouldPreemptProtectedInfrastructureRepairForAssignmentGapConstruction(
+  creep: Creep,
+  selectedTask: Extract<CreepTaskMemory, { type: 'build' }>,
+  repairTarget: unknown
+): boolean {
+  return (
+    isRepairPreemptionStructure(repairTarget) &&
+    isBuildPreemptionCriticalRoadOrContainerRepairTarget(repairTarget) &&
+    !hasOtherSameRoomRepairAssignmentForTargetIgnoringCoverage(creep, repairTarget) &&
+    getUsedTransferEnergy(creep) > 0 &&
+    getActiveWorkParts(creep) > 0 &&
+    !hasOtherSameRoomBuildAssignment(creep) &&
+    hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep) &&
+    !hasVisibleHostileCreeps(creep.room) &&
+    !isControllerDowngradeGuardActive(creep.room) &&
+    hasSafeAssignmentGapRecoveryConstructionEnergy(creep, selectedTask)
+  );
 }
 
 function isProtectedRepairTargetForConstructionBacklog(creep: Creep, target: unknown): boolean {
@@ -1336,6 +1363,22 @@ function hasOtherSameRoomRepairAssignmentForTarget(creep: Creep, target: Structu
       getUsedTransferEnergy(worker) > 0 &&
       getActiveWorkParts(worker) > 0
     );
+  });
+}
+
+function hasOtherSameRoomRepairAssignmentForTargetIgnoringCoverage(creep: Creep, target: Structure): boolean {
+  const targetId = getObjectId(target);
+  if (targetId.length === 0) {
+    return false;
+  }
+
+  return getRoomOwnedCreeps(creep.room).some((worker) => {
+    if (isSameCreep(worker, creep) || !isProductiveSameRoomWorker(worker, creep.room)) {
+      return false;
+    }
+
+    const task = worker.memory?.task as Partial<CreepTaskMemory> | undefined;
+    return task?.type === 'repair' && String(task.targetId) === targetId;
   });
 }
 
@@ -1741,7 +1784,11 @@ function hasOtherSameRoomBuildAssignment(creep: Creep): boolean {
 function isBuildCoverageWorker(
   worker: Creep
 ): worker is Creep & { memory: CreepMemory & { task: Extract<CreepTaskMemory, { type: 'build' }> } } {
-  return worker.memory?.task?.type === 'build' && getActiveWorkParts(worker) > 0;
+  return (
+    worker.memory?.task?.type === 'build' &&
+    getActiveWorkParts(worker) > 0 &&
+    getUsedTransferEnergy(worker) > 0
+  );
 }
 
 function hasRecentFailedBuildCoverage(worker: Creep, siteId: string): boolean {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -211,7 +211,7 @@ export function runWorker(creep: Creep): void {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
-  } else if (shouldPreemptTaskForUrgentRepair(currentTask, selectedTask)) {
+  } else if (shouldPreemptTaskForUrgentRepair(creep, currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
   } else if (shouldPreemptEnergyAcquisitionTaskForSeasonScore(currentTask, selectedTask)) {
     taskAssignedThisTick = assignSelectedTask(creep, selectedTask, currentTask) !== null;
@@ -2775,6 +2775,7 @@ function shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(
 }
 
 function shouldPreemptTaskForUrgentRepair(
+  creep: Creep,
   task: CreepTaskMemory,
   selectedTask: CreepTaskMemory | null
 ): boolean {
@@ -2786,7 +2787,38 @@ function shouldPreemptTaskForUrgentRepair(
     return false;
   }
 
+  if (shouldKeepAssignmentGapConstructionAheadOfCriticalRoadOrContainerRepair(creep, task, selectedTask)) {
+    return false;
+  }
+
   return true;
+}
+
+function shouldKeepAssignmentGapConstructionAheadOfCriticalRoadOrContainerRepair(
+  creep: Creep,
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory
+): boolean {
+  if (task.type !== 'build' || selectedTask.type !== 'repair') {
+    return false;
+  }
+
+  const constructionSite = getTaskTarget(task);
+  const repairTarget = getTaskTarget(selectedTask);
+  return (
+    isConstructionSite(constructionSite) &&
+    canSpendWorkerEnergyOnAssignmentGapRecoveryConstructionSite(creep, constructionSite) &&
+    isRepairPreemptionStructure(repairTarget) &&
+    isBuildPreemptionCriticalRoadOrContainerRepairTarget(repairTarget) &&
+    !hasOtherSameRoomRepairAssignmentForTargetIgnoringCoverage(creep, repairTarget) &&
+    getUsedTransferEnergy(creep) > 0 &&
+    getActiveWorkParts(creep) > 0 &&
+    !hasOtherSameRoomBuildAssignment(creep) &&
+    hasMinimumProductiveWorkerCoverageForSpawnReservationYield(creep) &&
+    !hasVisibleHostileCreeps(creep.room) &&
+    !isControllerDowngradeGuardActive(creep.room) &&
+    hasSafeAssignmentGapRecoveryConstructionEnergy(creep, task)
+  );
 }
 
 function shouldPreemptEnergyAcquisitionTaskForSeasonScore(

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -14311,7 +14311,7 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
-  it('preempts retained road repair when construction is selected and no worker carries build energy', () => {
+  it('keeps assignment-gap road construction from ping-ponging back to urgent repair', () => {
     const site = {
       id: 'road-site1',
       my: true,
@@ -14372,7 +14372,7 @@ describe('runWorker', () => {
       })
     } as unknown as Room;
     const build = jest.fn().mockReturnValue(0);
-    const repair = jest.fn();
+    const repair = jest.fn().mockReturnValue(0);
     const creep = {
       name: 'RepairWorker',
       memory: {
@@ -14407,6 +14407,7 @@ describe('runWorker', () => {
     } as unknown as Creep;
     roomCreeps.push(creep, energyWorker);
     const selectedBuildTask = { type: 'build', targetId: 'road-site1' as Id<ConstructionSite> } as const;
+    const selectedRepairTask = { type: 'repair', targetId: 'road-repair1' as Id<Structure> } as const;
     const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(selectedBuildTask);
     const selectWorkerEnergyCriticalTask = jest
       .spyOn(workerTaskPolicy, 'selectWorkerEnergyCriticalTask')
@@ -14444,6 +14445,67 @@ describe('runWorker', () => {
       });
       expect(build).toHaveBeenCalledWith(site);
       expect(repair).not.toHaveBeenCalled();
+
+      selectWorkerTask.mockReturnValue(selectedRepairTask);
+      build.mockClear();
+      repair.mockClear();
+      (globalThis as unknown as { Game: Partial<Game> }).Game.time = 2_338_590;
+
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({ type: 'build', targetId: 'road-site1' });
+      expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+        currentTask: 'build',
+        currentTargetId: 'road-site1',
+        baseSelectedTask: 'repair',
+        baseSelectedTargetId: 'road-repair1',
+        selectedTask: 'repair',
+        selectedTargetId: 'road-repair1',
+        assignedTask: 'build',
+        assignedTargetId: 'road-site1'
+      });
+      expect(build).toHaveBeenCalledWith(site);
+      expect(repair).not.toHaveBeenCalled();
+
+      const otherBuilder = {
+        name: 'OtherBuilder',
+        memory: {
+          role: 'worker',
+          colony: 'E29N56',
+          task: selectedBuildTask
+        },
+        getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+        store: {
+          getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+          getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+        },
+        room
+      } as unknown as Creep;
+      roomCreeps.push(otherBuilder);
+      (globalThis as unknown as { Game: Partial<Game> }).Game.creeps = {
+        RepairWorker: creep,
+        EnergyWorker: energyWorker,
+        OtherBuilder: otherBuilder
+      };
+      (globalThis as unknown as { Game: Partial<Game> }).Game.time = 2_338_591;
+      build.mockClear();
+      repair.mockClear();
+
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({ type: 'repair', targetId: 'road-repair1' });
+      expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+        currentTask: 'build',
+        currentTargetId: 'road-site1',
+        baseSelectedTask: 'repair',
+        baseSelectedTargetId: 'road-repair1',
+        selectedTask: 'repair',
+        selectedTargetId: 'road-repair1',
+        assignedTask: 'repair',
+        assignedTargetId: 'road-repair1'
+      });
+      expect(repair).toHaveBeenCalledWith(damagedRoad);
+      expect(build).not.toHaveBeenCalled();
     } finally {
       selectWorkerTask.mockRestore();
       selectWorkerEnergyCriticalTask.mockRestore();

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -14311,6 +14311,145 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
+  it('preempts retained road repair when construction is selected and no worker carries build energy', () => {
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 0,
+      progressTotal: 300
+    } as ConstructionSite;
+    const damagedRoad = {
+      id: 'road-repair1',
+      structureType: 'road',
+      hits: 1_000,
+      hitsMax: 5_000
+    } as StructureRoad;
+    const storage = {
+      id: 'storage1',
+      structureType: 'storage',
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 350_000 : 0)),
+        getFreeCapacity: jest.fn().mockReturnValue(650_000)
+      }
+    } as unknown as StructureStorage;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N56',
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      controller,
+      storage,
+      find: jest.fn((type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [storage] as unknown as AnyOwnedStructure[];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [storage, damagedRoad];
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+        }
+
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        if (type === FIND_HOSTILE_CREEPS || type === FIND_SOURCES || type === FIND_DROPPED_RESOURCES) {
+          return [];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const build = jest.fn().mockReturnValue(0);
+    const repair = jest.fn();
+    const creep = {
+      name: 'RepairWorker',
+      memory: {
+        role: 'worker',
+        colony: 'E29N56',
+        task: { type: 'repair', targetId: 'road-repair1' as Id<Structure> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 16 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 84 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room,
+      build,
+      repair,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const energyWorker = {
+      name: 'EnergyWorker',
+      memory: {
+        role: 'worker',
+        colony: 'E29N56',
+        task: { type: 'withdraw', targetId: 'storage1' as Id<AnyStoreStructure> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, energyWorker);
+    const selectedBuildTask = { type: 'build', targetId: 'road-site1' as Id<ConstructionSite> } as const;
+    const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(selectedBuildTask);
+    const selectWorkerEnergyCriticalTask = jest
+      .spyOn(workerTaskPolicy, 'selectWorkerEnergyCriticalTask')
+      .mockReturnValue(null);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { RepairWorker: creep, EnergyWorker: energyWorker },
+      rooms: { E29N56: room },
+      time: 2_338_589,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        if (id === 'road-repair1') {
+          return damagedRoad;
+        }
+
+        if (id === 'storage1') {
+          return storage;
+        }
+
+        return null;
+      })
+    };
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({ type: 'build', targetId: 'road-site1' });
+      expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+        currentTask: 'repair',
+        baseSelectedTask: 'build',
+        selectedTask: 'build',
+        assignedTask: 'build'
+      });
+      expect(build).toHaveBeenCalledWith(site);
+      expect(repair).not.toHaveBeenCalled();
+    } finally {
+      selectWorkerTask.mockRestore();
+      selectWorkerEnergyCriticalTask.mockRestore();
+    }
+  });
+
   it('keeps spawn recovery transfer ahead of controller pressure preemption', () => {
     const spawn = {
       id: 'spawn1',


### PR DESCRIPTION
Fixes #1967

## Summary
- Require same-room build coverage to have carried energy before it can suppress assignment-gap recovery.
- Let a loaded worker switch from protected road/container repair to a selected construction task when no loaded builder or same-target repair handoff exists and the existing construction energy/spawn-reservation safety gates pass.
- Add a focused E29N56 regression for retained road repair bypassing selected construction while room storage and workers can safely cover construction.

## Verification
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`

## Universal task Done gate
- [x] Task type: code.
- [x] Expected observable outcome / named deliverable: PR #1968 changes worker assignment so E29N56 workers with carried energy select visible construction instead of retaining lone critical road/container repair when construction energy gates pass.
- [x] Non-goals / accepted substitutes: no merge or deployment in this PR; low-bucket CPU shedding, spawn-reservation refill, and critical spawn/barrier repair stay guarded by tests.
- [x] Verification evidence required before Done: `npm run typecheck`, `npm test -- --runInBand`, and `npm run build` passed; draft PR CI run 27777660148 has prod verify pass.
- [x] Project Evidence / Next action / Blocked by: #1967 and #1968 Project `screeps` items are In review with Evidence and Next action populated; Blocked by empty.
- [x] Post-merge/deploy/runtime proof: not applicable for draft code PR; runtime observation is tracked outside this PR by Project Next action.
- [x] Named deliverable proof: PR #1968 and commit 6386af2 are the named deliverable; local verification evidence is listed above.

## Issue closure gate
- [x] #1967: retained critical road/container repair assignment gap reproduced by new `workerRunner` Jest case and fixed by runner preemption plus loaded build coverage change; typecheck, Jest, and build passed.

## Notes
- Local git metadata is mounted read-only in this Codex sandbox, so the verified commit was created on the remote branch through GitHub's Git data API using the requested author identity.
