### PR TITLE
Fix E29N55 construction assignment gap

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35583,7 +35583,11 @@ function shouldBlockAssignmentGapRecoveryForCriticalSpawnRefill(creep, currentTa
   if (!isCriticalSpawnRefillTask(currentTask) && !isCriticalSpawnRefillTask(selectedTask)) {
     return false;
   }
-  return !shouldDeferSpawnReservationRefillForProductiveWork(creep, recoveryTask);
+  return !shouldDeferSpawnReservationRefillForProductiveWork(
+    creep,
+    recoveryTask,
+    selectSpawnEnergyReservationRefillTarget(creep)
+  );
 }
 function shouldAllowLowLoadAssignmentGapRepairRecovery(creep, currentTask, selectedTask) {
   return !hasOtherSameRoomBuildAssignment(creep) && ((currentTask == null ? void 0 : currentTask.type) === "build" || isWorkerAssignmentGapRecoveryRepairTask(creep, currentTask)) && isWorkerAssignmentGapRecoveryRepairTask(creep, selectedTask);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35569,10 +35569,21 @@ function selectWorkerAssignmentGapRecoveryTask(creep, currentTask, selectionCont
     type: "build",
     targetId: constructionSite.id
   };
-  if (!canExecuteTask(creep, recoveryTask) || isCriticalSpawnRefillTask(currentTask) || isCriticalSpawnRefillTask(selectionContext.selectedTask) || !shouldAllowAssignmentGapRecoveryBuildWorker(creep, currentTask, selectionContext.selectedTask, constructionSite) || !hasSafeAssignmentGapRecoveryConstructionEnergy(creep, recoveryTask)) {
+  if (!canExecuteTask(creep, recoveryTask) || shouldBlockAssignmentGapRecoveryForCriticalSpawnRefill(
+    creep,
+    currentTask,
+    selectionContext.selectedTask,
+    recoveryTask
+  ) || !shouldAllowAssignmentGapRecoveryBuildWorker(creep, currentTask, selectionContext.selectedTask, constructionSite) || !hasSafeAssignmentGapRecoveryConstructionEnergy(creep, recoveryTask)) {
     return null;
   }
   return recoveryTask;
+}
+function shouldBlockAssignmentGapRecoveryForCriticalSpawnRefill(creep, currentTask, selectedTask, recoveryTask) {
+  if (!isCriticalSpawnRefillTask(currentTask) && !isCriticalSpawnRefillTask(selectedTask)) {
+    return false;
+  }
+  return !shouldDeferSpawnReservationRefillForProductiveWork(creep, recoveryTask);
 }
 function shouldAllowLowLoadAssignmentGapRepairRecovery(creep, currentTask, selectedTask) {
   return !hasOtherSameRoomBuildAssignment(creep) && ((currentTask == null ? void 0 : currentTask.type) === "build" || isWorkerAssignmentGapRecoveryRepairTask(creep, currentTask)) && isWorkerAssignmentGapRecoveryRepairTask(creep, selectedTask);
@@ -36954,11 +36965,16 @@ function shouldPreemptTransferTaskForConstructionBacklog(creep, task, selectedTa
     return false;
   }
   const currentTarget = getTaskTarget(task);
-  if (!isNonCriticalSpawnExtensionTransferTarget(currentTarget) && !isNonCriticalTowerRefillTransferTarget(creep, currentTarget)) {
+  const canDeferCriticalSpawnRefill = isCriticalSpawnRefillTask(task) && shouldDeferSpawnReservationRefillForProductiveWork(
+    creep,
+    selectedTask,
+    selectSpawnEnergyReservationRefillTarget(creep)
+  );
+  if (!isNonCriticalSpawnExtensionTransferTarget(currentTarget) && !isNonCriticalTowerRefillTransferTarget(creep, currentTarget) && !canDeferCriticalSpawnRefill) {
     return false;
   }
   const canFollowSelectorNonCriticalSpawnExtensionYield = isNonCriticalSpawnExtensionTransferTarget(currentTarget) && shouldRunConstructionCpuWork(getRuntimeCpuBudget()) && !hasVisibleHostileCreeps2(creep.room);
-  if (!canFollowSelectorNonCriticalSpawnExtensionYield && !shouldDeferSpawnReservationRefillForProductiveWork(
+  if (!canFollowSelectorNonCriticalSpawnExtensionYield && !canDeferCriticalSpawnRefill && !shouldDeferSpawnReservationRefillForProductiveWork(
     creep,
     selectedTask,
     selectSpawnEnergyReservationRefillTarget(creep)

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -744,7 +744,11 @@ function shouldBlockAssignmentGapRecoveryForCriticalSpawnRefill(
     return false;
   }
 
-  return !shouldDeferSpawnReservationRefillForProductiveWork(creep, recoveryTask);
+  return !shouldDeferSpawnReservationRefillForProductiveWork(
+    creep,
+    recoveryTask,
+    selectSpawnEnergyReservationRefillTarget(creep)
+  );
 }
 
 function shouldAllowLowLoadAssignmentGapRepairRecovery(

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -719,8 +719,12 @@ function selectWorkerAssignmentGapRecoveryTask(
   };
   if (
     !canExecuteTask(creep, recoveryTask) ||
-    isCriticalSpawnRefillTask(currentTask) ||
-    isCriticalSpawnRefillTask(selectionContext.selectedTask) ||
+    shouldBlockAssignmentGapRecoveryForCriticalSpawnRefill(
+      creep,
+      currentTask,
+      selectionContext.selectedTask,
+      recoveryTask
+    ) ||
     !shouldAllowAssignmentGapRecoveryBuildWorker(creep, currentTask, selectionContext.selectedTask, constructionSite) ||
     !hasSafeAssignmentGapRecoveryConstructionEnergy(creep, recoveryTask)
   ) {
@@ -728,6 +732,19 @@ function selectWorkerAssignmentGapRecoveryTask(
   }
 
   return recoveryTask;
+}
+
+function shouldBlockAssignmentGapRecoveryForCriticalSpawnRefill(
+  creep: Creep,
+  currentTask: CreepTaskMemory | null | undefined,
+  selectedTask: CreepTaskMemory | null,
+  recoveryTask: Extract<CreepTaskMemory, { type: 'build' }>
+): boolean {
+  if (!isCriticalSpawnRefillTask(currentTask) && !isCriticalSpawnRefillTask(selectedTask)) {
+    return false;
+  }
+
+  return !shouldDeferSpawnReservationRefillForProductiveWork(creep, recoveryTask);
 }
 
 function shouldAllowLowLoadAssignmentGapRepairRecovery(
@@ -3031,9 +3048,17 @@ function shouldPreemptTransferTaskForConstructionBacklog(
   }
 
   const currentTarget = getTaskTarget(task);
+  const canDeferCriticalSpawnRefill =
+    isCriticalSpawnRefillTask(task) &&
+    shouldDeferSpawnReservationRefillForProductiveWork(
+      creep,
+      selectedTask,
+      selectSpawnEnergyReservationRefillTarget(creep)
+    );
   if (
     !isNonCriticalSpawnExtensionTransferTarget(currentTarget) &&
-    !isNonCriticalTowerRefillTransferTarget(creep, currentTarget)
+    !isNonCriticalTowerRefillTransferTarget(creep, currentTarget) &&
+    !canDeferCriticalSpawnRefill
   ) {
     return false;
   }
@@ -3044,6 +3069,7 @@ function shouldPreemptTransferTaskForConstructionBacklog(
     !hasVisibleHostileCreeps(creep.room);
   if (
     !canFollowSelectorNonCriticalSpawnExtensionYield &&
+    !canDeferCriticalSpawnRefill &&
     !shouldDeferSpawnReservationRefillForProductiveWork(
       creep,
       selectedTask,

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -14512,6 +14512,151 @@ describe('runWorker', () => {
     }
   });
 
+  it('seeds assignment-gap construction when healthy room buffer makes critical spawn refill deferrable', () => {
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      my: true,
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 150 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 150 : 0))
+      }
+    } as unknown as StructureSpawn;
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 0,
+      progressTotal: 300
+    } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 6,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N55',
+      energyAvailable: 815,
+      energyCapacityAvailable: 2_300,
+      controller,
+      find: jest.fn((type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn] as unknown as AnyOwnedStructure[];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+        }
+
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        if (type === FIND_HOSTILE_CREEPS || type === FIND_SOURCES || type === FIND_DROPPED_RESOURCES) {
+          return [];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const selectedSpawnRefillTask = { type: 'transfer', targetId: 'spawn1' as Id<AnyStoreStructure> } as const;
+    const build = jest.fn().mockReturnValue(0);
+    const transfer = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'Worker1',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: selectedSpawnRefillTask
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 32 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 68 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      pos: { getRangeTo: jest.fn().mockReturnValue(3) },
+      room,
+      build,
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const harvestWorker = {
+      name: 'Worker2',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'harvest', targetId: 'source1' as Id<Source> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room
+    } as unknown as Creep;
+    const supportWorker = {
+      name: 'Worker3',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'transfer', targetId: 'extension1' as Id<AnyStoreStructure> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 16 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 34 : 0))
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, harvestWorker, supportWorker);
+    const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(selectedSpawnRefillTask);
+    const selectWorkerEnergyCriticalTask = jest
+      .spyOn(workerTaskPolicy, 'selectWorkerEnergyCriticalTask')
+      .mockReturnValue(null);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Worker1: creep, Worker2: harvestWorker, Worker3: supportWorker },
+      rooms: { E29N55: room },
+      time: 2_356_240,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'spawn1') {
+          return spawn;
+        }
+
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        return null;
+      })
+    };
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({ type: 'build', targetId: 'road-site1' });
+      expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+        currentTask: 'transfer',
+        currentTargetId: 'spawn1',
+        baseSelectedTask: 'transfer',
+        baseSelectedTargetId: 'spawn1',
+        selectedTask: 'build',
+        selectedTargetId: 'road-site1',
+        assignedTask: 'build',
+        assignedTargetId: 'road-site1'
+      });
+      expect(build).toHaveBeenCalledWith(site);
+      expect(transfer).not.toHaveBeenCalled();
+    } finally {
+      selectWorkerTask.mockRestore();
+      selectWorkerEnergyCriticalTask.mockRestore();
+    }
+  });
+
   it('keeps spawn recovery transfer ahead of controller pressure preemption', () => {
     const spawn = {
       id: 'spawn1',

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -14657,6 +14657,162 @@ describe('runWorker', () => {
     }
   });
 
+  it('seeds assignment-gap construction when another worker covers critical spawn refill', () => {
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      my: true,
+      spawning: null,
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 150 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 150 : 0))
+      }
+    } as unknown as StructureSpawn;
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 0,
+      progressTotal: 300
+    } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 6,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const roomCreeps: Creep[] = [];
+    const room = {
+      name: 'E29N55',
+      energyAvailable: 250,
+      energyCapacityAvailable: 2_300,
+      controller,
+      find: jest.fn((type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn] as unknown as AnyOwnedStructure[];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_MY_CREEPS) {
+          return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+        }
+
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        if (type === FIND_HOSTILE_CREEPS || type === FIND_SOURCES || type === FIND_DROPPED_RESOURCES) {
+          return [];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const selectedSpawnRefillTask = { type: 'transfer', targetId: 'spawn1' as Id<AnyStoreStructure> } as const;
+    const build = jest.fn().mockReturnValue(0);
+    const transfer = jest.fn().mockReturnValue(0);
+    const creep = {
+      name: 'Worker1',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: selectedSpawnRefillTask
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 32 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 68 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      pos: { getRangeTo: jest.fn().mockReturnValue(3) },
+      room,
+      build,
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const refillWorker = {
+      name: 'Worker2',
+      memory: {
+        role: 'worker',
+        colony: 'E29N55',
+        task: { type: 'transfer', targetId: 'spawn1' as Id<AnyStoreStructure> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 150 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+      },
+      room
+    } as unknown as Creep;
+    roomCreeps.push(creep, refillWorker);
+    const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(selectedSpawnRefillTask);
+    const selectWorkerEnergyCriticalTask = jest
+      .spyOn(workerTaskPolicy, 'selectWorkerEnergyCriticalTask')
+      .mockReturnValue(null);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      economy: {
+        spawnEnergyReservation: {
+          updatedAt: 2_356_241,
+          rooms: {
+            E29N55: {
+              bodyCost: 800,
+              creepName: 'worker-E29N55-next',
+              reservedAt: 2_356_241,
+              reservedEnergy: 800,
+              role: 'worker',
+              roomName: 'E29N55',
+              updatedAt: 2_356_241
+            }
+          }
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Worker1: creep, Worker2: refillWorker },
+      rooms: { E29N55: room },
+      time: 2_356_241,
+      getObjectById: jest.fn((id: string) => {
+        if (id === 'spawn1') {
+          return spawn;
+        }
+
+        if (id === 'road-site1') {
+          return site;
+        }
+
+        return null;
+      })
+    };
+
+    try {
+      expect(selectSpawnEnergyReservationRefillTarget(creep)).toMatchObject({
+        spawn: { id: 'spawn1' },
+        spawnEnergy: 150,
+        threshold: 300,
+        unmetReservedEnergy: 550
+      });
+
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({ type: 'build', targetId: 'road-site1' });
+      expect(creep.memory.workerDispatchDiagnostic).toMatchObject({
+        currentTask: 'transfer',
+        currentTargetId: 'spawn1',
+        baseSelectedTask: 'transfer',
+        baseSelectedTargetId: 'spawn1',
+        selectedTask: 'build',
+        selectedTargetId: 'road-site1',
+        assignedTask: 'build',
+        assignedTargetId: 'road-site1'
+      });
+      expect(build).toHaveBeenCalledWith(site);
+      expect(transfer).not.toHaveBeenCalled();
+    } finally {
+      selectWorkerTask.mockRestore();
+      selectWorkerEnergyCriticalTask.mockRestore();
+    }
+  });
+
   it('keeps spawn recovery transfer ahead of controller pressure preemption', () => {
     const spawn = {
       id: 'spawn1',


### PR DESCRIPTION
Related: #1970.

## Domain / Kind

- Domain: RL flywheel / Territory/Economy
- Kind: code / bug

## Summary

- Classification: FIX.
- Runtime evidence shows E29N55 has pendingBuildProgress=6872, buildTasks=0, and buildCarriedEnergy=0 after energyBufferHealth becomes healthy.
- E29N56/E29N57 continue building in the same lowBucket window because they already have retained build coverage or durable stored construction energy; E29N55 entered the window with no build coverage and no stored construction surplus.
- This patch lets assignment-gap recovery seed one build over a critical-looking spawn refill only through the existing productive-work safety predicate: idle spawn, healthy or covered room buffer, no hostiles, and enough same-room worker coverage.
- `worker_assignment_gap` is actionable. The `spawn_reserving_energy` detail is partly imprecise because runtime also reports reservedSpawnEnergy=0 and unmetSpawnEnergyReservation=0, but it correctly points at spawn/refill work displacing build assignment.

## Verification

- [x] Local check: `npm run typecheck` PASS.
- [x] Local check: `npm test -- --runInBand` PASS, 105 suites / 2499 tests.
- [x] Local check: `npm run build` PASS.
- [x] Local check: `git diff --check` PASS.
- [x] GitHub Project issue/PR fields are current or checkpointed: #1970 comment records GraphQL quota reset and deferred Project field mutations.
- [x] No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate

- [x] Task type: code behavior bugfix.
- [x] Expected observable outcome / named deliverable: E29N55 assignment-gap recovery can seed build coverage once room energy buffer safety is satisfied.
- [x] Non-goals / accepted substitutes: no official deploy, no paid Tencent compute, no run-single, no PR merge.
- [x] Verification evidence required before Done: local typecheck, full Jest, bundle build, and diff check pass on commit `0f077ccd96d4b9e054350c54ea400e8d29c1b31c`.
- [x] Project Evidence / Next action / Blocked by: #1970 comment https://github.com/lanyusea/screeps/issues/1970#issuecomment-4748077024 records Project Evidence, Next action, third-field value, PR #1971 Project add, and GraphQL reset `2026-06-19T03:22:15Z`.
- [x] Post-merge/deploy/runtime proof: not applicable for this lane because official deploy and merge are excluded.
- [x] Named deliverable proof: commit `0f077ccd96d4b9e054350c54ea400e8d29c1b31c` and PR #1971 contain the code/test deliverable.

## Runtime / deployment impact

- [x] Gameplay/runtime/deployment impact; HELD from official deploy by lane rule.

## Notes

No deploy, no paid Tencent compute, no run-single, and no PR merge performed.