### PR TITLE
[codex] Add CPU bucket recovery telemetry

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -964,6 +964,7 @@ var LOW_CPU_BUCKET_THRESHOLD = 1e3;
 var CRITICAL_CPU_BUCKET_THRESHOLD = 100;
 var DEGRADED_OPTIONAL_WORK_INTERVAL = 5;
 var DEGRADED_ROOM_OPTIONAL_WORK_INTERVAL = 3;
+var CPU_BUCKET_MAX = 1e4;
 var CPU_BUCKET_RECOVERY_HEADROOM_MULTIPLIER = 12;
 var REPEATED_BUCKET_EMPTY_TICKS = 2;
 var SUSTAINED_OVER_LIMIT_TICKS = 2;
@@ -1030,6 +1031,7 @@ function buildRuntimeCpuTelemetrySummary(sample = readRuntimeCpuSample()) {
   const budget = buildRuntimeCpuBudget(sample);
   const state = updateRuntimeCpuTelemetryState(sample);
   const alerts = buildRuntimeCpuAlerts(sample, state);
+  const projectedBucket = budget.degraded ? getProjectedBucketAfterCurrentTick(sample) : void 0;
   return {
     tick: sample.tick,
     ...sample.used !== void 0 ? { used: sample.used } : {},
@@ -1041,7 +1043,11 @@ function buildRuntimeCpuTelemetrySummary(sample = readRuntimeCpuSample()) {
     ...alerts.length > 0 ? { alerts } : {},
     ...state.lowBucketTicks > 0 ? { lowBucketTicks: state.lowBucketTicks } : {},
     ...state.bucketEmptyTicks > 0 ? { bucketEmptyTicks: state.bucketEmptyTicks } : {},
-    ...state.overLimitTicks > 0 ? { overLimitTicks: state.overLimitTicks } : {}
+    ...state.overLimitTicks > 0 ? { overLimitTicks: state.overLimitTicks } : {},
+    ...budget.degraded && state.bucketDelta !== void 0 ? { bucketDelta: state.bucketDelta } : {},
+    ...budget.degraded && state.bucketDeltaTicks !== void 0 ? { bucketDeltaTicks: state.bucketDeltaTicks } : {},
+    ...budget.degraded && state.bucketDeltaPerTick !== void 0 ? { bucketDeltaPerTick: state.bucketDeltaPerTick } : {},
+    ...projectedBucket !== void 0 ? { projectedBucket } : {}
   };
 }
 function shouldRunOptionalCpuWork(budget, key, interval = DEGRADED_OPTIONAL_WORK_INTERVAL) {
@@ -1109,6 +1115,14 @@ function getProjectedPostTickBucket(sample) {
   }
   return sample.bucket - Math.max(0, sample.used - sample.limit);
 }
+function getProjectedBucketAfterCurrentTick(sample) {
+  if (sample.bucket === void 0 || sample.used === void 0 || sample.limit === void 0 || sample.limit <= 0) {
+    return void 0;
+  }
+  return roundCpuTelemetryNumber(
+    Math.min(CPU_BUCKET_MAX, Math.max(0, sample.bucket + sample.limit - sample.used))
+  );
+}
 function hasLowBucketRecoveryPressure(sample) {
   if (sample.bucket === void 0 || sample.bucket < LOW_CPU_BUCKET_THRESHOLD) {
     return false;
@@ -1135,6 +1149,7 @@ function getConstructionRecoveryEntryHeadroom(limit) {
 }
 function updateRuntimeCpuTelemetryState(sample) {
   resetRuntimeCpuTelemetryStateForTick(sample.tick);
+  updateRuntimeCpuBucketDelta(sample);
   const lowBucket = sample.bucket !== void 0 && sample.bucket < LOW_CPU_BUCKET_THRESHOLD;
   const bucketEmpty = sample.bucket !== void 0 && sample.bucket <= 0;
   const overLimit = sample.used !== void 0 && sample.limit !== void 0 && sample.limit > 0 && sample.used > sample.limit;
@@ -1142,6 +1157,25 @@ function updateRuntimeCpuTelemetryState(sample) {
   cpuTelemetryState.bucketEmptyTicks = bucketEmpty ? cpuTelemetryState.bucketEmptyTicks + 1 : 0;
   cpuTelemetryState.overLimitTicks = overLimit ? cpuTelemetryState.overLimitTicks + 1 : 0;
   return cpuTelemetryState;
+}
+function updateRuntimeCpuBucketDelta(sample) {
+  const previousBucket = cpuTelemetryState.lastBucket;
+  const previousBucketTick = cpuTelemetryState.lastBucketTick;
+  clearRuntimeCpuBucketDelta();
+  if (sample.bucket === void 0) {
+    delete cpuTelemetryState.lastBucket;
+    delete cpuTelemetryState.lastBucketTick;
+    return;
+  }
+  if (previousBucket !== void 0 && previousBucketTick !== void 0 && sample.tick > previousBucketTick) {
+    const deltaTicks = sample.tick - previousBucketTick;
+    const delta = sample.bucket - previousBucket;
+    cpuTelemetryState.bucketDelta = roundCpuTelemetryNumber(delta);
+    cpuTelemetryState.bucketDeltaTicks = deltaTicks;
+    cpuTelemetryState.bucketDeltaPerTick = roundCpuTelemetryNumber(delta / deltaTicks);
+  }
+  cpuTelemetryState.lastBucket = sample.bucket;
+  cpuTelemetryState.lastBucketTick = sample.tick;
 }
 function resetRuntimeCpuTelemetryStateForTick(tick) {
   const lastTick = cpuTelemetryState.lastTick;
@@ -1157,6 +1191,14 @@ function clearRuntimeCpuTelemetryCounters() {
   cpuTelemetryState.lowBucketTicks = 0;
   cpuTelemetryState.bucketEmptyTicks = 0;
   cpuTelemetryState.overLimitTicks = 0;
+  clearRuntimeCpuBucketDelta();
+  delete cpuTelemetryState.lastBucket;
+  delete cpuTelemetryState.lastBucketTick;
+}
+function clearRuntimeCpuBucketDelta() {
+  delete cpuTelemetryState.bucketDelta;
+  delete cpuTelemetryState.bucketDeltaTicks;
+  delete cpuTelemetryState.bucketDeltaPerTick;
 }
 function buildRuntimeCpuAlerts(sample, state) {
   const alerts = [];
@@ -1196,6 +1238,9 @@ function readCpuUsed(cpu) {
   } catch {
     return void 0;
   }
+}
+function roundCpuTelemetryNumber(value) {
+  return Math.round(value * 1e3) / 1e3;
 }
 function optionalFiniteNumber(key, value) {
   return typeof value === "number" && Number.isFinite(value) ? { [key]: value } : {};
@@ -45665,6 +45710,7 @@ function buildCpuSummary() {
 }
 function toRuntimeCpuSummary(summary) {
   return {
+    ...summary.pressure !== "normal" ? { tick: summary.tick } : {},
     ...summary.used !== void 0 ? { used: summary.used } : {},
     ...summary.limit !== void 0 ? { limit: summary.limit } : {},
     ...summary.tickLimit !== void 0 ? { tickLimit: summary.tickLimit } : {},
@@ -45674,7 +45720,11 @@ function toRuntimeCpuSummary(summary) {
     ...summary.reasons ? { reasons: summary.reasons } : {},
     ...summary.lowBucketTicks !== void 0 ? { lowBucketTicks: summary.lowBucketTicks } : {},
     ...summary.bucketEmptyTicks !== void 0 ? { bucketEmptyTicks: summary.bucketEmptyTicks } : {},
-    ...summary.overLimitTicks !== void 0 ? { overLimitTicks: summary.overLimitTicks } : {}
+    ...summary.overLimitTicks !== void 0 ? { overLimitTicks: summary.overLimitTicks } : {},
+    ...summary.bucketDelta !== void 0 ? { bucketDelta: summary.bucketDelta } : {},
+    ...summary.bucketDeltaTicks !== void 0 ? { bucketDeltaTicks: summary.bucketDeltaTicks } : {},
+    ...summary.bucketDeltaPerTick !== void 0 ? { bucketDeltaPerTick: summary.bucketDeltaPerTick } : {},
+    ...summary.projectedBucket !== void 0 ? { projectedBucket: summary.projectedBucket } : {}
   };
 }
 function emitRuntimeCpuSummary(cpu, tick) {

--- a/prod/src/runtime/cpuBudget.ts
+++ b/prod/src/runtime/cpuBudget.ts
@@ -35,6 +35,10 @@ export interface RuntimeCpuTelemetrySummary extends RuntimeCpuSample {
   lowBucketTicks?: number;
   bucketEmptyTicks?: number;
   overLimitTicks?: number;
+  bucketDelta?: number;
+  bucketDeltaTicks?: number;
+  bucketDeltaPerTick?: number;
+  projectedBucket?: number;
 }
 
 interface RuntimeGameLike {
@@ -49,9 +53,14 @@ interface RuntimeGameLike {
 
 interface RuntimeCpuTelemetryState {
   lastTick?: number;
+  lastBucket?: number;
+  lastBucketTick?: number;
   lowBucketTicks: number;
   bucketEmptyTicks: number;
   overLimitTicks: number;
+  bucketDelta?: number;
+  bucketDeltaTicks?: number;
+  bucketDeltaPerTick?: number;
 }
 
 export const LOW_CPU_ACCOUNT_LIMIT = 20;
@@ -59,6 +68,7 @@ export const LOW_CPU_BUCKET_THRESHOLD = 1_000;
 export const CRITICAL_CPU_BUCKET_THRESHOLD = 100;
 export const DEGRADED_OPTIONAL_WORK_INTERVAL = 5;
 export const DEGRADED_ROOM_OPTIONAL_WORK_INTERVAL = 3;
+const CPU_BUCKET_MAX = 10_000;
 const CPU_BUCKET_RECOVERY_HEADROOM_MULTIPLIER = 12;
 const REPEATED_BUCKET_EMPTY_TICKS = 2;
 const SUSTAINED_OVER_LIMIT_TICKS = 2;
@@ -153,6 +163,7 @@ export function buildRuntimeCpuTelemetrySummary(
   const budget = buildRuntimeCpuBudget(sample);
   const state = updateRuntimeCpuTelemetryState(sample);
   const alerts = buildRuntimeCpuAlerts(sample, state);
+  const projectedBucket = budget.degraded ? getProjectedBucketAfterCurrentTick(sample) : undefined;
 
   return {
     tick: sample.tick,
@@ -165,7 +176,13 @@ export function buildRuntimeCpuTelemetrySummary(
     ...(alerts.length > 0 ? { alerts } : {}),
     ...(state.lowBucketTicks > 0 ? { lowBucketTicks: state.lowBucketTicks } : {}),
     ...(state.bucketEmptyTicks > 0 ? { bucketEmptyTicks: state.bucketEmptyTicks } : {}),
-    ...(state.overLimitTicks > 0 ? { overLimitTicks: state.overLimitTicks } : {})
+    ...(state.overLimitTicks > 0 ? { overLimitTicks: state.overLimitTicks } : {}),
+    ...(budget.degraded && state.bucketDelta !== undefined ? { bucketDelta: state.bucketDelta } : {}),
+    ...(budget.degraded && state.bucketDeltaTicks !== undefined ? { bucketDeltaTicks: state.bucketDeltaTicks } : {}),
+    ...(budget.degraded && state.bucketDeltaPerTick !== undefined
+      ? { bucketDeltaPerTick: state.bucketDeltaPerTick }
+      : {}),
+    ...(projectedBucket !== undefined ? { projectedBucket } : {})
   };
 }
 
@@ -285,6 +302,21 @@ function getProjectedPostTickBucket(sample: RuntimeCpuSample): number | undefine
   return sample.bucket - Math.max(0, sample.used - sample.limit);
 }
 
+function getProjectedBucketAfterCurrentTick(sample: RuntimeCpuSample): number | undefined {
+  if (
+    sample.bucket === undefined ||
+    sample.used === undefined ||
+    sample.limit === undefined ||
+    sample.limit <= 0
+  ) {
+    return undefined;
+  }
+
+  return roundCpuTelemetryNumber(
+    Math.min(CPU_BUCKET_MAX, Math.max(0, sample.bucket + sample.limit - sample.used))
+  );
+}
+
 function hasLowBucketRecoveryPressure(sample: RuntimeCpuSample): boolean {
   if (sample.bucket === undefined || sample.bucket < LOW_CPU_BUCKET_THRESHOLD) {
     return false;
@@ -323,6 +355,7 @@ function getConstructionRecoveryEntryHeadroom(limit: number | undefined): number
 
 function updateRuntimeCpuTelemetryState(sample: RuntimeCpuSample): RuntimeCpuTelemetryState {
   resetRuntimeCpuTelemetryStateForTick(sample.tick);
+  updateRuntimeCpuBucketDelta(sample);
 
   const lowBucket = sample.bucket !== undefined && sample.bucket < LOW_CPU_BUCKET_THRESHOLD;
   const bucketEmpty = sample.bucket !== undefined && sample.bucket <= 0;
@@ -336,6 +369,33 @@ function updateRuntimeCpuTelemetryState(sample: RuntimeCpuSample): RuntimeCpuTel
   cpuTelemetryState.bucketEmptyTicks = bucketEmpty ? cpuTelemetryState.bucketEmptyTicks + 1 : 0;
   cpuTelemetryState.overLimitTicks = overLimit ? cpuTelemetryState.overLimitTicks + 1 : 0;
   return cpuTelemetryState;
+}
+
+function updateRuntimeCpuBucketDelta(sample: RuntimeCpuSample): void {
+  const previousBucket = cpuTelemetryState.lastBucket;
+  const previousBucketTick = cpuTelemetryState.lastBucketTick;
+  clearRuntimeCpuBucketDelta();
+
+  if (sample.bucket === undefined) {
+    delete cpuTelemetryState.lastBucket;
+    delete cpuTelemetryState.lastBucketTick;
+    return;
+  }
+
+  if (
+    previousBucket !== undefined &&
+    previousBucketTick !== undefined &&
+    sample.tick > previousBucketTick
+  ) {
+    const deltaTicks = sample.tick - previousBucketTick;
+    const delta = sample.bucket - previousBucket;
+    cpuTelemetryState.bucketDelta = roundCpuTelemetryNumber(delta);
+    cpuTelemetryState.bucketDeltaTicks = deltaTicks;
+    cpuTelemetryState.bucketDeltaPerTick = roundCpuTelemetryNumber(delta / deltaTicks);
+  }
+
+  cpuTelemetryState.lastBucket = sample.bucket;
+  cpuTelemetryState.lastBucketTick = sample.tick;
 }
 
 function resetRuntimeCpuTelemetryStateForTick(tick: number): void {
@@ -355,6 +415,15 @@ function clearRuntimeCpuTelemetryCounters(): void {
   cpuTelemetryState.lowBucketTicks = 0;
   cpuTelemetryState.bucketEmptyTicks = 0;
   cpuTelemetryState.overLimitTicks = 0;
+  clearRuntimeCpuBucketDelta();
+  delete cpuTelemetryState.lastBucket;
+  delete cpuTelemetryState.lastBucketTick;
+}
+
+function clearRuntimeCpuBucketDelta(): void {
+  delete cpuTelemetryState.bucketDelta;
+  delete cpuTelemetryState.bucketDeltaTicks;
+  delete cpuTelemetryState.bucketDeltaPerTick;
 }
 
 function buildRuntimeCpuAlerts(
@@ -406,6 +475,10 @@ function readCpuUsed(cpu: RuntimeGameLike['cpu']): number | undefined {
   } catch {
     return undefined;
   }
+}
+
+function roundCpuTelemetryNumber(value: number): number {
+  return Math.round(value * 1_000) / 1_000;
 }
 
 function optionalFiniteNumber<K extends keyof RuntimeCpuSample>(

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -1010,6 +1010,7 @@ interface RuntimeRefillTransferEvent {
 }
 
 interface RuntimeCpuSummary {
+  tick?: number;
   used?: number;
   limit?: number;
   tickLimit?: number;
@@ -1020,6 +1021,10 @@ interface RuntimeCpuSummary {
   lowBucketTicks?: number;
   bucketEmptyTicks?: number;
   overLimitTicks?: number;
+  bucketDelta?: number;
+  bucketDeltaTicks?: number;
+  bucketDeltaPerTick?: number;
+  projectedBucket?: number;
 }
 
 interface RuntimeCpuSummaryEmissionState {
@@ -5005,6 +5010,7 @@ function buildCpuSummary(): { cpu?: RuntimeCpuSummary } {
 
 function toRuntimeCpuSummary(summary: RuntimeCpuTelemetrySummary): RuntimeCpuSummary {
   return {
+    ...(summary.pressure !== 'normal' ? { tick: summary.tick } : {}),
     ...(summary.used !== undefined ? { used: summary.used } : {}),
     ...(summary.limit !== undefined ? { limit: summary.limit } : {}),
     ...(summary.tickLimit !== undefined ? { tickLimit: summary.tickLimit } : {}),
@@ -5014,7 +5020,11 @@ function toRuntimeCpuSummary(summary: RuntimeCpuTelemetrySummary): RuntimeCpuSum
     ...(summary.reasons ? { reasons: summary.reasons } : {}),
     ...(summary.lowBucketTicks !== undefined ? { lowBucketTicks: summary.lowBucketTicks } : {}),
     ...(summary.bucketEmptyTicks !== undefined ? { bucketEmptyTicks: summary.bucketEmptyTicks } : {}),
-    ...(summary.overLimitTicks !== undefined ? { overLimitTicks: summary.overLimitTicks } : {})
+    ...(summary.overLimitTicks !== undefined ? { overLimitTicks: summary.overLimitTicks } : {}),
+    ...(summary.bucketDelta !== undefined ? { bucketDelta: summary.bucketDelta } : {}),
+    ...(summary.bucketDeltaTicks !== undefined ? { bucketDeltaTicks: summary.bucketDeltaTicks } : {}),
+    ...(summary.bucketDeltaPerTick !== undefined ? { bucketDeltaPerTick: summary.bucketDeltaPerTick } : {}),
+    ...(summary.projectedBucket !== undefined ? { projectedBucket: summary.projectedBucket } : {})
   };
 }
 

--- a/prod/test/cpuBudget.test.ts
+++ b/prod/test/cpuBudget.test.ts
@@ -456,6 +456,58 @@ describe('runtime CPU budget policy', () => {
     expect(getUsed).not.toHaveBeenCalled();
   });
 
+  it('reports degraded bucket recovery delta and projected post-tick bucket', () => {
+    buildRuntimeCpuTelemetrySummary({
+      tick: 2387454,
+      used: 13.3,
+      limit: 70,
+      bucket: 1_007,
+      tickLimit: 500
+    });
+
+    const summary = buildRuntimeCpuTelemetrySummary({
+      tick: 2387455,
+      used: 17.558327400009148,
+      limit: 70,
+      bucket: 1_004,
+      tickLimit: 500
+    });
+
+    expect(summary).toMatchObject({
+      pressure: 'degraded',
+      reasons: ['lowBucketRecovery'],
+      bucketDelta: -3,
+      bucketDeltaTicks: 1,
+      bucketDeltaPerTick: -3,
+      projectedBucket: 1_056.442
+    });
+  });
+
+  it('keeps healthy CPU telemetry compact without recovery-only fields', () => {
+    buildRuntimeCpuTelemetrySummary({
+      tick: 40,
+      used: 12,
+      limit: 70,
+      bucket: 9_000,
+      tickLimit: 500
+    });
+
+    const summary = buildRuntimeCpuTelemetrySummary({
+      tick: 41,
+      used: 12,
+      limit: 70,
+      bucket: 9_050,
+      tickLimit: 500
+    });
+
+    expect(summary).toMatchObject({
+      pressure: 'normal',
+      bucket: 9_050
+    });
+    expect(summary).not.toHaveProperty('bucketDelta');
+    expect(summary).not.toHaveProperty('projectedBucket');
+  });
+
   it('alerts on repeated empty bucket and sustained used-over-limit samples', () => {
     buildRuntimeCpuTelemetrySummary({
       tick: 30,
@@ -506,5 +558,6 @@ describe('runtime CPU budget policy', () => {
       overLimitTicks: 1,
       alerts: ['lowBucket']
     });
+    expect(summary).not.toHaveProperty('bucketDelta');
   });
 });

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -507,6 +507,53 @@ describe('runtime telemetry summaries', () => {
     });
   });
 
+  it('emits low-bucket recovery deltas in compact CPU evidence', () => {
+    const firstColony = makeColony({ time: 4 });
+    (Game as Partial<Game>).cpu = {
+      getUsed: jest.fn().mockReturnValue(13.3),
+      limit: 70,
+      bucket: 1_007,
+      tickLimit: 500
+    } as unknown as CPU;
+    emitRuntimeSummary([firstColony], []);
+    logSpy.mockClear();
+
+    const secondColony = makeColony({ time: 5 });
+    (Game as Partial<Game>).cpu = {
+      getUsed: jest.fn().mockReturnValue(17.558327400009148),
+      limit: 70,
+      bucket: 1_004,
+      tickLimit: 500
+    } as unknown as CPU;
+
+    emitRuntimeSummary([secondColony], []);
+
+    const cpuSummaryMessages = logSpy.mock.calls
+      .map(([message]) => message)
+      .filter(
+        (message): message is string =>
+          typeof message === 'string' && message.startsWith(RUNTIME_CPU_SUMMARY_PREFIX)
+      );
+    expect(cpuSummaryMessages).toHaveLength(1);
+    const payload = JSON.parse(cpuSummaryMessages[0].slice(RUNTIME_CPU_SUMMARY_PREFIX.length)) as Record<
+      string,
+      unknown
+    >;
+    expect(payload).toMatchObject({
+      tick: 5,
+      used: 17.558327400009148,
+      limit: 70,
+      tickLimit: 500,
+      bucket: 1_004,
+      pressure: 'degraded',
+      reasons: ['lowBucketRecovery'],
+      bucketDelta: -3,
+      bucketDeltaTicks: 1,
+      bucketDeltaPerTick: -3,
+      projectedBucket: 1_056.442
+    });
+  });
+
   it('emits compact CPU alerts without a full room summary under degraded cadence', () => {
     const colony = makeColony({ time: 1 });
     (Game as Partial<Game>).cpu = {


### PR DESCRIPTION
## Summary
- Add degraded CPU recovery telemetry to runtime CPU summaries: observed bucket delta, delta ticks, per-tick delta, projected post-tick bucket, and degraded-summary tick.
- Keep the existing low-bucket recovery guard behavior unchanged; healthy CPU summaries remain compact.
- Synchronize `prod/dist/main.js` through the normal production build.

## Evidence
- Verified runtime artifact `/root/screeps/runtime-artifacts/runtime-summary-console/runtime-summary-console-20260619T212021Z.log`: 3 owned rooms alive, no hostiles, healthy energy buffers; CPU bucket stayed 983-1007 with last 1004, pressure degraded, reasons `lowBucket`/`lowBucketRecovery`, while logged CPU used was 13.323893699911423-20.655818699975498 of limit 70.
- Existing code intentionally marks a 70 CPU account as `lowBucketRecovery` through bucket 1840, so bucket 1004 being degraded is expected. The missing actionable evidence was whether the bucket is recovering between CPU samples.

## Validation
- `npm test -- --runInBand cpuBudget runtimeSummary`
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`
- `git diff --check HEAD~1..HEAD`

## Universal task Done gate

- [x] Task type: code behavior telemetry
- [x] Expected observable outcome / named deliverable: degraded runtime CPU summaries include `tick`, `bucketDelta`, `bucketDeltaTicks`, `bucketDeltaPerTick`, and `projectedBucket` so issue #1975 can distinguish actual bucket recovery from sampled CPU usage.
- [x] Non-goals / accepted substitutes: no official deploy, no Tencent paid compute, no merge, no RL live canary change, and no speculative CPU behavior rewrite.
- [x] Verification evidence required before Done: focused CPU/runtime Jest passed; full `npm run typecheck`, `npm test -- --runInBand`, `npm run build`, and `git diff --check HEAD~1..HEAD` passed locally.
- [x] Project Evidence / Next action / Blocked by: Project #1975 and PR #1979 are `In review`; Evidence and Next action fields cite PR #1979, e46b5290, verification, and the deploy hold state.
- [x] Post-merge/deploy/runtime proof: Not applicable: no deploy performed in this PR; issue acceptance requires runtime monitor proof before Done.
- [x] Named deliverable proof: `prod/test/cpuBudget.test.ts` and `prod/test/runtimeSummary.test.ts` assert the new CPU recovery fields; `prod/dist/main.js` was regenerated by `npm run build`.

Refs #1975