### PR TITLE
[codex] Fix E29N56 construction assignment gap

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35772,11 +35772,18 @@ function hasSafeAssignmentGapRecoveryConstructionEnergy(creep, recoveryTask) {
     return shouldDeferSpawnReservationRefillForProductiveWork(creep, recoveryTask, spawnReservationTarget) || hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room);
   }
   const hasStoredConstructionEnergy = hasStoredEnergyForAssignmentGapRecoveryConstruction(creep.room);
-  const hasSafeConstructionEnergy = hasHealthyRoomEnergyBuffer2(creep.room) || hasStoredConstructionEnergy || hasCoveredStoredEnergyForAssignmentGapRecoveryConstruction(creep, getTaskTarget(recoveryTask));
+  const hasSafeConstructionEnergy = hasHealthyRoomEnergyBuffer2(creep.room) || hasStoredConstructionEnergy || hasCoveredStoredEnergyForAssignmentGapRecoveryConstruction(creep, getTaskTarget(recoveryTask)) || hasSafeCarriedEnergyForUncoveredAssignmentGapConstruction(creep, recoveryTask);
   if (!hasSafeConstructionEnergy) {
     return false;
   }
   return !hasActiveSpawningSpawn2(creep.room) || hasStoredConstructionEnergy;
+}
+function hasSafeCarriedEnergyForUncoveredAssignmentGapConstruction(creep, recoveryTask) {
+  if (getRuntimeCpuBudget().critical || hasOtherSameRoomBuildAssignment(creep)) {
+    return false;
+  }
+  const constructionSite = getTaskTarget(recoveryTask);
+  return isConstructionSite(constructionSite) && hasUncoveredAssignmentGapConstructionProgress(creep, constructionSite) && canSpendWorkerEnergyOnConstructionSite(creep, constructionSite);
 }
 function hasStoredEnergyForAssignmentGapRecoveryConstruction(room) {
   const energyAvailable = getRoomEnergyAvailable13(room);

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -1008,13 +1008,30 @@ function hasSafeAssignmentGapRecoveryConstructionEnergy(
   const hasSafeConstructionEnergy =
     hasHealthyRoomEnergyBuffer(creep.room) ||
     hasStoredConstructionEnergy ||
-    hasCoveredStoredEnergyForAssignmentGapRecoveryConstruction(creep, getTaskTarget(recoveryTask));
+    hasCoveredStoredEnergyForAssignmentGapRecoveryConstruction(creep, getTaskTarget(recoveryTask)) ||
+    hasSafeCarriedEnergyForUncoveredAssignmentGapConstruction(creep, recoveryTask);
 
   if (!hasSafeConstructionEnergy) {
     return false;
   }
 
   return !hasActiveSpawningSpawn(creep.room) || hasStoredConstructionEnergy;
+}
+
+function hasSafeCarriedEnergyForUncoveredAssignmentGapConstruction(
+  creep: Creep,
+  recoveryTask: Extract<CreepTaskMemory, { type: 'build' }>
+): boolean {
+  if (getRuntimeCpuBudget().critical || hasOtherSameRoomBuildAssignment(creep)) {
+    return false;
+  }
+
+  const constructionSite = getTaskTarget(recoveryTask);
+  return (
+    isConstructionSite(constructionSite) &&
+    hasUncoveredAssignmentGapConstructionProgress(creep, constructionSite) &&
+    canSpendWorkerEnergyOnConstructionSite(creep, constructionSite)
+  );
 }
 
 function hasStoredEnergyForAssignmentGapRecoveryConstruction(room: Room): boolean {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -66,6 +66,148 @@ function makeControllerSigningMemory(
   };
 }
 
+function makeE29N56ControllerProgressConstructionScenario(options: {
+  constructionSites?: ConstructionSite[];
+  cpuBucket?: number;
+} = {}): {
+  build: jest.Mock;
+  creep: Creep;
+  selectWorkerTask: jest.SpyInstance;
+  site: ConstructionSite;
+  upgradeController: jest.Mock;
+} {
+  const site =
+    options.constructionSites?.[0] ??
+    ({
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 0,
+      progressTotal: 1_245,
+      pos: { x: 20, y: 24, roomName: 'E29N56' } as RoomPosition
+    } as ConstructionSite);
+  const constructionSites = options.constructionSites ?? [site];
+  const spawn = {
+    id: 'spawn1',
+    my: true,
+    structureType: 'spawn',
+    spawning: null,
+    store: {
+      getUsedCapacity: jest.fn((resource?: ResourceConstant) =>
+        resource === RESOURCE_ENERGY ? MINIMUM_WORKER_SPAWN_ENERGY : 0
+      ),
+      getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0))
+    }
+  } as unknown as StructureSpawn;
+  const controller = {
+    id: 'controller1',
+    my: true,
+    level: 3,
+    ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+  } as StructureController;
+  const roomCreeps: Creep[] = [];
+  const room = {
+    name: 'E29N56',
+    energyAvailable: MINIMUM_WORKER_SPAWN_ENERGY,
+    energyCapacityAvailable: 1_300,
+    controller,
+    find: jest.fn((type: number, findOptions?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+      if (type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES) {
+        const structures = [spawn] as unknown as AnyOwnedStructure[];
+        return findOptions?.filter ? structures.filter(findOptions.filter) : structures;
+      }
+
+      if (type === FIND_MY_CREEPS) {
+        return findOptions?.filter ? roomCreeps.filter(findOptions.filter) : roomCreeps;
+      }
+
+      if (type === FIND_CONSTRUCTION_SITES) {
+        return constructionSites;
+      }
+
+      if (
+        type === FIND_HOSTILE_CREEPS ||
+        type === FIND_HOSTILE_STRUCTURES ||
+        type === FIND_SOURCES ||
+        type === FIND_DROPPED_RESOURCES
+      ) {
+        return [];
+      }
+
+      return [];
+    })
+  } as unknown as Room;
+  const selectedUpgradeTask = { type: 'upgrade', targetId: 'controller1' as Id<StructureController> } as const;
+  const build = jest.fn().mockReturnValue(0);
+  const upgradeController = jest.fn().mockReturnValue(0);
+  const creep = {
+    name: 'worker-E29N56-upgrader-1',
+    memory: {
+      role: 'worker',
+      colony: 'E29N56',
+      task: selectedUpgradeTask
+    },
+    getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+    pos: {
+      getRangeTo: jest.fn((target: RoomObject) => (String((target as { id?: string }).id) === 'road-site1' ? 1 : 7))
+    },
+    store: {
+      getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0)),
+      getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+      getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+    },
+    room,
+    build,
+    upgradeController,
+    moveTo: jest.fn()
+  } as unknown as Creep;
+  const makeOtherUpgrader = (index: number): Creep =>
+    ({
+      name: `worker-E29N56-upgrader-${index}`,
+      memory: {
+        role: 'worker',
+        colony: 'E29N56',
+        task: selectedUpgradeTask
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+      },
+      room
+    }) as unknown as Creep;
+  roomCreeps.push(creep, makeOtherUpgrader(2), makeOtherUpgrader(3), makeOtherUpgrader(4));
+  const selectWorkerTask = jest.spyOn(workerTasks, 'selectWorkerTask').mockReturnValue(selectedUpgradeTask);
+  const game: Partial<Game> = {
+    creeps: Object.fromEntries(roomCreeps.map((worker) => [worker.name, worker])),
+    rooms: { E29N56: room },
+    time: 2_219_800,
+    getObjectById: jest.fn((id: string) => {
+      if (id === 'road-site1') {
+        return site;
+      }
+
+      if (id === 'spawn1') {
+        return spawn;
+      }
+
+      return id === 'controller1' ? controller : null;
+    }) as unknown as Game['getObjectById']
+  };
+  if (options.cpuBucket !== undefined) {
+    game.cpu = {
+      getUsed: jest.fn().mockReturnValue(18.09),
+      limit: 70,
+      bucket: options.cpuBucket,
+      tickLimit: 500
+    } as unknown as CPU;
+  }
+  (globalThis as unknown as { Game: Partial<Game> }).Game = game;
+
+  return { build, creep, selectWorkerTask, site, upgradeController };
+}
+
 describe('runWorker', () => {
   beforeEach(() => {
     (globalThis as unknown as { ERR_NOT_IN_RANGE: number; ERR_FULL: number; ERR_NOT_ENOUGH_RESOURCES: number; ERR_INVALID_TARGET: number; RESOURCE_ENERGY: ResourceConstant; FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; FIND_DROPPED_RESOURCES: number; FIND_STRUCTURES: number; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant; STRUCTURE_LINK: StructureConstant; STRUCTURE_ROAD: StructureConstant; STRUCTURE_CONTAINER: StructureConstant; STRUCTURE_STORAGE: StructureConstant; STRUCTURE_TERMINAL: StructureConstant; STRUCTURE_RAMPART: StructureConstant }).ERR_NOT_IN_RANGE = -9;
@@ -9861,6 +10003,57 @@ describe('runWorker', () => {
       });
       expect(build).toHaveBeenCalledWith(site);
       expect(upgradeController).not.toHaveBeenCalled();
+    } finally {
+      selectWorkerTask.mockRestore();
+    }
+  });
+
+  it('preempts E29N56 controller-progress-preferred workers for carried-energy construction coverage', () => {
+    const { build, creep, selectWorkerTask, site, upgradeController } =
+      makeE29N56ControllerProgressConstructionScenario({
+        cpuBucket: LOW_CPU_BUCKET_THRESHOLD - 205
+      });
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({ type: 'build', targetId: 'road-site1' });
+      expect(build).toHaveBeenCalledWith(site);
+      expect(upgradeController).not.toHaveBeenCalled();
+    } finally {
+      selectWorkerTask.mockRestore();
+    }
+  });
+
+  it('keeps E29N56 controller progress when no construction backlog is visible', () => {
+    const { build, creep, selectWorkerTask, upgradeController } =
+      makeE29N56ControllerProgressConstructionScenario({
+        constructionSites: []
+      });
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({ type: 'upgrade', targetId: 'controller1' });
+      expect(upgradeController).toHaveBeenCalled();
+      expect(build).not.toHaveBeenCalled();
+    } finally {
+      selectWorkerTask.mockRestore();
+    }
+  });
+
+  it('keeps E29N56 controller progress under critical CPU when construction only has carried-energy coverage', () => {
+    const { build, creep, selectWorkerTask, upgradeController } =
+      makeE29N56ControllerProgressConstructionScenario({
+        cpuBucket: 50
+      });
+
+    try {
+      runWorker(creep);
+
+      expect(creep.memory.task).toEqual({ type: 'upgrade', targetId: 'controller1' });
+      expect(upgradeController).toHaveBeenCalled();
+      expect(build).not.toHaveBeenCalled();
     } finally {
       selectWorkerTask.mockRestore();
     }


### PR DESCRIPTION
Fixes #1980

## Summary
- Allows assignment-gap recovery to spend an already-loaded worker's carried energy on uncovered same-room construction when the normal construction spendability checks pass.
- Keeps the recovery disabled for critical CPU and preserves existing spawn recovery/storage-backed safety gates.
- Adds E29N56 regression coverage for controller-progress-preferred workers, no-backlog behavior, and critical-CPU behavior.
- Rebuilds `prod/dist/main.js`.

## Root Cause
The runner had an assignment-gap recovery path, but its final safety gate still required a healthy room buffer, stored construction energy, or covered stored-energy construction. In the E29N56 postdeploy state, loaded workers could safely spend carried energy on the visible road site, yet the runner continued controller-progress-preferred upgrading.

## Verification
- `npm run typecheck`
- `npm test -- --runInBand` — 105 suites / 2506 tests passed.
- `npm run build`
- Controller reran the same commands at 2026-06-20T00:44Z on commit `a3dd5c1f` with a clean worktree.

## Universal task Done gate
- [x] Task type: runtime bug fix for Screeps worker task assignment.
- [x] Expected observable outcome / named deliverable: E29N56-style loaded worker with visible construction backlog takes a build task instead of controller-progress-preferred upgrade when CPU and energy safety gates allow it.
- [x] Non-goals / accepted substitutes: no Tencent compute, no RL live canary, no merge by Codex; this PR only changes worker assignment recovery and focused tests.
- [x] Verification evidence required before Done: `npm run typecheck`, `npm test -- --runInBand`, and `npm run build` pass on commit `a3dd5c1f`.
- [x] Project Evidence / Next action / Blocked by: Project fields for #1980 and #1981 are set to In review with Evidence and Next action refreshed; no blocker field value is set for this PR lane.
- [x] Post-merge/deploy/runtime proof: official deploy and postdeploy health workflows record deployment/runtime confirmation for the merged commit.
- [x] Named deliverable proof: focused tests in `prod/test/workerRunner.test.ts` cover E29N56 carried-energy construction recovery, no-backlog behavior, and critical-CPU behavior.

## Issue closure gate
- [x] Fixes #1980: commit `a3dd5c1f` adds carried-energy construction assignment recovery plus regression tests, and local verification passes.
