### PR TITLE
[codex] Fix construction assignment gap recurrence

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -35553,6 +35553,9 @@ function shouldSelectConstructionBacklogEnergyAcquisitionRecoveryTask(creep, cur
   if (isCriticalSpawnRefillTask(currentTask) || isCriticalSpawnRefillTask(selectedTask)) {
     return false;
   }
+  if (shouldSpendCurrentBuildEnergyForAssignmentGapCoverage(creep, currentTask, selectedTask)) {
+    return false;
+  }
   return isConstructionBacklogEnergyAcquisitionRecoveryTask(creep, currentTask) && isConstructionBacklogEnergyAcquisitionRecoveryTask(creep, selectedTask);
 }
 function isConstructionBacklogEnergyAcquisitionRecoveryTask(creep, task) {
@@ -35568,6 +35571,9 @@ function selectAssignedBuildEnergyAcquisitionTask(creep, currentTask, selectedTa
     return selectedTask;
   }
   const carriedEnergy = getUsedTransferEnergy(creep);
+  if (shouldSpendCurrentBuildEnergyForAssignmentGapCoverage(creep, currentTask, selectedTask)) {
+    return selectedTask;
+  }
   if ((currentTask == null ? void 0 : currentTask.type) !== "build" && carriedEnergy > 0) {
     return selectedTask;
   }
@@ -35575,6 +35581,14 @@ function selectAssignedBuildEnergyAcquisitionTask(creep, currentTask, selectedTa
     return selectedTask;
   }
   return (_b = (_a2 = selectConstructionBacklogEnergyAcquisitionTask(creep)) != null ? _a2 : selectWorkerEnergyCriticalAcquisitionTask(creep)) != null ? _b : selectedTask;
+}
+function shouldSpendCurrentBuildEnergyForAssignmentGapCoverage(creep, currentTask, selectedTask) {
+  const buildTask = (selectedTask == null ? void 0 : selectedTask.type) === "build" ? selectedTask : (currentTask == null ? void 0 : currentTask.type) === "build" ? currentTask : null;
+  if ((currentTask == null ? void 0 : currentTask.type) !== "build" || buildTask === null || selectedTask !== null && selectedTask.type !== "build" || getUsedTransferEnergy(creep) <= 0 || getActiveWorkParts3(creep) <= 0 || getRuntimeCpuBudget().critical || hasVisibleHostileCreeps2(creep.room) || !hasRecoverableStoredEnergyForAssignmentGapRecoveryConstruction(creep) || hasOtherSameRoomBuildAssignment(creep)) {
+    return false;
+  }
+  const constructionSite = getTaskTarget(buildTask);
+  return isConstructionSite(constructionSite) && constructionSite.my !== false && !isBuildTargetSuppressedForWorker(creep, constructionSite) && canSpendWorkerEnergyOnAssignmentGapRecoveryConstructionSite(creep, constructionSite);
 }
 function selectConstructionWithdrawCompletionBuildTask(creep, currentTask, selectedTask) {
   if (!isConstructionWithdrawReservationTask(currentTask) || getUsedTransferEnergy(creep) <= 0 || getActiveWorkParts3(creep) <= 0 || hasVisibleHostileCreeps2(creep.room) || shouldKeepConstructionWithdrawTaskForMoreEnergy(creep, currentTask, selectedTask) || !canConstructionWithdrawCompletionOverrideSelectedTask(creep, selectedTask)) {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -558,6 +558,10 @@ function shouldSelectConstructionBacklogEnergyAcquisitionRecoveryTask(
     return false;
   }
 
+  if (shouldSpendCurrentBuildEnergyForAssignmentGapCoverage(creep, currentTask, selectedTask)) {
+    return false;
+  }
+
   return (
     isConstructionBacklogEnergyAcquisitionRecoveryTask(creep, currentTask) &&
     isConstructionBacklogEnergyAcquisitionRecoveryTask(creep, selectedTask)
@@ -602,6 +606,10 @@ function selectAssignedBuildEnergyAcquisitionTask(
   }
 
   const carriedEnergy = getUsedTransferEnergy(creep);
+  if (shouldSpendCurrentBuildEnergyForAssignmentGapCoverage(creep, currentTask, selectedTask)) {
+    return selectedTask;
+  }
+
   if (currentTask?.type !== 'build' && carriedEnergy > 0) {
     return selectedTask;
   }
@@ -614,6 +622,40 @@ function selectAssignedBuildEnergyAcquisitionTask(
     selectConstructionBacklogEnergyAcquisitionTask(creep) ??
     selectWorkerEnergyCriticalAcquisitionTask(creep) ??
     selectedTask
+  );
+}
+
+function shouldSpendCurrentBuildEnergyForAssignmentGapCoverage(
+  creep: Creep,
+  currentTask: CreepTaskMemory | null | undefined,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  const buildTask =
+    selectedTask?.type === 'build'
+      ? selectedTask
+      : currentTask?.type === 'build'
+        ? currentTask
+        : null;
+  if (
+    currentTask?.type !== 'build' ||
+    buildTask === null ||
+    (selectedTask !== null && selectedTask.type !== 'build') ||
+    getUsedTransferEnergy(creep) <= 0 ||
+    getActiveWorkParts(creep) <= 0 ||
+    getRuntimeCpuBudget().critical ||
+    hasVisibleHostileCreeps(creep.room) ||
+    !hasRecoverableStoredEnergyForAssignmentGapRecoveryConstruction(creep) ||
+    hasOtherSameRoomBuildAssignment(creep)
+  ) {
+    return false;
+  }
+
+  const constructionSite = getTaskTarget(buildTask);
+  return (
+    isConstructionSite(constructionSite) &&
+    constructionSite.my !== false &&
+    !isBuildTargetSuppressedForWorker(creep, constructionSite) &&
+    canSpendWorkerEnergyOnAssignmentGapRecoveryConstructionSite(creep, constructionSite)
   );
 }
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -9578,6 +9578,165 @@ describe('runWorker', () => {
     }
   });
 
+  it('keeps one current low-load build assignment building per room before fetching more energy', () => {
+    const makeBacklogRoom = (
+      roomName: 'E29N55' | 'E29N57',
+      siteId: string,
+      storageId: string,
+      carriedEnergy: number,
+      remainingProgress: number
+    ): { build: jest.Mock; creep: Creep; room: Room; site: ConstructionSite; storage: StructureStorage; withdraw: jest.Mock } => {
+      const site = {
+        id: siteId,
+        my: true,
+        structureType: 'road',
+        progress: 1_000 - remainingProgress,
+        progressTotal: 1_000,
+        pos: { x: 22, y: 21, roomName } as RoomPosition
+      } as ConstructionSite;
+      const storage = {
+        id: storageId,
+        structureType: 'storage',
+        store: {
+          getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 300_000 : 0)),
+          getFreeCapacity: jest.fn().mockReturnValue(100_000)
+        }
+      } as unknown as StructureStorage;
+      const controller = {
+        id: `${roomName}-controller`,
+        my: true,
+        level: roomName === 'E29N55' ? 6 : 5,
+        ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+      } as StructureController;
+      const roomCreeps: Creep[] = [];
+      const room = {
+        name: roomName,
+        energyAvailable: 1_800,
+        energyCapacityAvailable: 1_800,
+        controller,
+        storage,
+        find: jest.fn((type: number, options?: { filter?: (object: AnyOwnedStructure | Creep) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES || type === FIND_STRUCTURES) {
+            const structures = [storage] as unknown as AnyOwnedStructure[];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomCreeps.filter(options.filter) : roomCreeps;
+          }
+
+          if (type === FIND_CONSTRUCTION_SITES) {
+            return [site];
+          }
+
+          if (type === FIND_HOSTILE_CREEPS || type === FIND_SOURCES || type === FIND_DROPPED_RESOURCES) {
+            return [];
+          }
+
+          return [];
+        })
+      } as unknown as Room;
+      const build = jest.fn().mockReturnValue(0);
+      const withdraw = jest.fn();
+      const creep = {
+        name: `${roomName}-LowLoadBuilder`,
+        memory: {
+          role: 'worker',
+          colony: roomName,
+          task: { type: 'build', targetId: siteId as Id<ConstructionSite> }
+        },
+        getActiveBodyparts: jest.fn().mockReturnValue(1),
+        store: {
+          getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? carriedEnergy : 0)),
+          getFreeCapacity: jest.fn((resource?: ResourceConstant) =>
+            resource === RESOURCE_ENERGY ? 100 - carriedEnergy : 0
+          ),
+          getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+        },
+        room,
+        build,
+        withdraw,
+        moveTo: jest.fn()
+      } as unknown as Creep;
+      const supportWorker = {
+        name: `${roomName}-SupportWorker`,
+        memory: { role: 'worker', colony: roomName },
+        getActiveBodyparts: jest.fn().mockReturnValue(1),
+        store: {
+          getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+          getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 100 : 0))
+        },
+        room
+      } as unknown as Creep;
+      roomCreeps.push(creep, supportWorker);
+      return { build, creep, room, site, storage, withdraw };
+    };
+    const e29n55 = makeBacklogRoom('E29N55', 'e29n55-site1', 'e29n55-storage1', 12, 140);
+    const e29n57 = makeBacklogRoom('E29N57', 'e29n57-site1', 'e29n57-storage1', 20, 175);
+    const selectWorkerTask = jest
+      .spyOn(workerTasks, 'selectWorkerTask')
+      .mockImplementation((creep: Creep) => creep.memory.task ?? null);
+    const selectWorkerEnergyCriticalTask = jest
+      .spyOn(workerTaskPolicy, 'selectWorkerEnergyCriticalTask')
+      .mockReturnValue(null);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {
+        [e29n55.creep.name]: e29n55.creep,
+        [e29n57.creep.name]: e29n57.creep
+      },
+      rooms: { E29N55: e29n55.room, E29N57: e29n57.room },
+      time: 2_399_953,
+      getObjectById: jest.fn((id: string) => {
+        if (id === e29n55.site.id) {
+          return e29n55.site;
+        }
+
+        if (id === e29n55.storage.id) {
+          return e29n55.storage;
+        }
+
+        if (id === e29n57.site.id) {
+          return e29n57.site;
+        }
+
+        if (id === e29n57.storage.id) {
+          return e29n57.storage;
+        }
+
+        return null;
+      })
+    };
+
+    try {
+      runWorker(e29n55.creep);
+      runWorker(e29n57.creep);
+
+      expect(e29n55.creep.memory.task).toEqual({ type: 'build', targetId: 'e29n55-site1' });
+      expect(e29n57.creep.memory.task).toEqual({ type: 'build', targetId: 'e29n57-site1' });
+      expect(e29n55.creep.memory.workerDispatchDiagnostic).toMatchObject({
+        currentTask: 'build',
+        baseSelectedTask: 'build',
+        selectedTask: 'build',
+        assignedTask: 'build',
+        reason: 'selected_same_as_current'
+      });
+      expect(e29n57.creep.memory.workerDispatchDiagnostic).toMatchObject({
+        currentTask: 'build',
+        baseSelectedTask: 'build',
+        selectedTask: 'build',
+        assignedTask: 'build',
+        reason: 'selected_same_as_current'
+      });
+      expect(e29n55.build).toHaveBeenCalledWith(e29n55.site);
+      expect(e29n57.build).toHaveBeenCalledWith(e29n57.site);
+      expect(e29n55.withdraw).not.toHaveBeenCalled();
+      expect(e29n57.withdraw).not.toHaveBeenCalled();
+    } finally {
+      selectWorkerTask.mockRestore();
+      selectWorkerEnergyCriticalTask.mockRestore();
+    }
+  });
+
   it('recovers E29N55 build assignment from spawn-critical harvest when another worker covers spawn floor', () => {
     const source = {
       id: 'source1',


### PR DESCRIPTION
## Summary

- Keep a current low-load `build` assignment active when a room has construction backlog, stored construction energy is recoverable, and no other same-room worker is covering construction.
- Apply the guard before both construction-backlog acquisition recovery and assigned-build energy acquisition so a base-selected builder is not immediately converted back to `withdraw`.
- Add focused multi-room Jest coverage for the recurrence where E29N55/E29N57-style rooms both have carried-energy builders, construction backlog, and storage-backed recovery energy.
- Regenerate `prod/dist/main.js` via the production build.

## Root Cause

After #1983, a low-load worker could select `build` as the base task but then be preempted into a construction-scoped `withdraw` because the acquisition recovery path preferred topping up before spending carried energy. When every same-room builder followed that path, telemetry reported `worker_assignment_gap` even though workers had energy and backlog existed.

## Verification

- `npm run typecheck`
- `npm test -- --runInBand workerRunner.test.ts`
- `npm test -- --runInBand`
- `npm run build`
- `git diff --check HEAD~1 HEAD`
- `git status --short --branch`
- `git log -1 --oneline --format='%h %an <%ae> %s'`

Related to #1985

## Universal task Done gate
- [x] Task type: code PR handoff for the E29N55/E29N57 worker assignment gap recurrence.
- [x] Expected observable outcome / named deliverable: PR #1986 provides the runner behavior change and focused regression coverage for construction-assignment retention when carried-energy builders and storage-backed recovery coexist.
- [x] Non-goals / accepted substitutes: merge, deploy, official postdeploy acceptance, RL training, Tencent compute, deployment scripts, and docs churn are outside this PR handoff.
- [x] Verification evidence required before Done: `npm run typecheck`; `npm test -- --runInBand workerRunner.test.ts`; `npm test -- --runInBand`; `npm run build`; `git diff --check HEAD~1 HEAD`; clean git status and commit-author checks.
- [x] Project Evidence / Next action / Blocked by: PR #1986 and issue #1985 Project items are `In review` with current Evidence, Next action, and Blocked by fields from the 2026-06-20T06:18Z controller gate audit.
- [x] Post-merge/deploy/runtime proof: not applicable to this PR handoff; issue #1985 owns official runtime acceptance.
- [x] Named deliverable proof: `prod/test/workerRunner.test.ts` covers same-room construction retention for multiple rooms with carried-energy builders, construction backlog, and storage-backed recovery energy.

## Project state
- PR #1986 Project item: `Status=In review`; Evidence records head `dad316b2`, passing prod verification, passing roadmap check, and issue-completion body repair; Next action is rerun gate and review readiness.
- Issue #1985 Project item: `Status=In review`; Evidence records PR #1986, head `dad316b2`, and verification; Next action is PR gate/review, then merge/deploy/postdeploy construction acceptance.