### PR TITLE
[codex] Guard roadmap Project hydration

### DIFF
--- a/.github/workflows/roadmap-pages-refresh.yml
+++ b/.github/workflows/roadmap-pages-refresh.yml
@@ -24,6 +24,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.SCREEPS_ROADMAP_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.SCREEPS_ROADMAP_TOKEN }}
+      SCREEPS_ROADMAP_ALLOW_BROAD_PROJECT_SCAN: "1"
       SCREEPS_AUTH_TOKEN: ${{ secrets.SCREEPS_AUTH_TOKEN }}
       SCREEPS_MONITOR_CACHE_DIR: runtime-artifacts/screeps-monitor/terrain-cache
       SCREEPS_MONITOR_STATE_FILE: runtime-artifacts/screeps-monitor/state.json

--- a/scripts/generate-roadmap-page.py
+++ b/scripts/generate-roadmap-page.py
@@ -36,10 +36,13 @@ SOURCE_EVIDENCE_METRIC_KEYS = frozenset({"runtime_summary_samples", "kpi_artifac
 DEFAULT_OWNER = "lanyusea"
 DEFAULT_REPO = "screeps"
 DEFAULT_PROJECT_NUMBER = 3
-DEFAULT_PROJECT_ITEM_FETCH_LIMIT = 2000
+DEFAULT_PROJECT_ITEM_FETCH_LIMIT = 100
+BROAD_PROJECT_ITEM_FETCH_LIMIT = 2000
 DEFAULT_PROJECT_ITEM_FETCH_TIMEOUT_SECONDS = 180
 PROJECT_ITEM_FETCH_LIMIT_ENV = "SCREEPS_ROADMAP_PROJECT_ITEM_LIMIT"
+PROJECT_ITEM_FETCH_ALLOW_BROAD_ENV = "SCREEPS_ROADMAP_ALLOW_BROAD_PROJECT_SCAN"
 PROJECT_ITEM_FETCH_TIMEOUT_ENV = "SCREEPS_ROADMAP_PROJECT_ITEM_TIMEOUT_SECONDS"
+TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
 PAGE_TITLE = "Hermes Screeps Project Roadmap Report"
 PAGES_URL = "https://lanyusea.github.io/screeps/"
 GITHUB_PROJECT_URL = "https://github.com/users/lanyusea/projects/3"
@@ -1044,16 +1047,40 @@ def run_json(command: Sequence[str], cwd: Path, timeout: int = 30) -> tuple[Any 
         return None, {"command": command_list[:4], "exitCode": completed.returncode, "message": "invalid json output"}
 
 
-def project_item_fetch_limit(environ: Mapping[str, str] | None = None) -> int:
+def env_flag_enabled(name: str, environ: Mapping[str, str] | None = None) -> bool:
+    source = os.environ if environ is None else environ
+    return str(source.get(name) or "").strip().lower() in TRUTHY_ENV_VALUES
+
+
+def parse_project_item_fetch_limit(environ: Mapping[str, str] | None = None) -> int | None:
     source = os.environ if environ is None else environ
     raw_limit = str(source.get(PROJECT_ITEM_FETCH_LIMIT_ENV) or "").strip()
     if not raw_limit:
-        return DEFAULT_PROJECT_ITEM_FETCH_LIMIT
+        return None
     try:
         parsed = int(raw_limit)
     except ValueError:
-        return DEFAULT_PROJECT_ITEM_FETCH_LIMIT
+        return None
     return max(1, parsed)
+
+
+def project_item_fetch_limit(environ: Mapping[str, str] | None = None) -> int:
+    requested_limit = parse_project_item_fetch_limit(environ)
+    if env_flag_enabled(PROJECT_ITEM_FETCH_ALLOW_BROAD_ENV, environ):
+        return requested_limit if requested_limit is not None else BROAD_PROJECT_ITEM_FETCH_LIMIT
+    if requested_limit is None:
+        return DEFAULT_PROJECT_ITEM_FETCH_LIMIT
+    return min(requested_limit, DEFAULT_PROJECT_ITEM_FETCH_LIMIT)
+
+
+def project_item_fetch_safety_summary(fetch_limit: int, environ: Mapping[str, str] | None = None) -> JsonObject:
+    broad_allowed = env_flag_enabled(PROJECT_ITEM_FETCH_ALLOW_BROAD_ENV, environ)
+    return {
+        "limitMode": "broad" if broad_allowed and fetch_limit > DEFAULT_PROJECT_ITEM_FETCH_LIMIT else "rate-limit-safe",
+        "broadScanAllowed": broad_allowed,
+        "safeLimit": DEFAULT_PROJECT_ITEM_FETCH_LIMIT,
+        "broadLimit": BROAD_PROJECT_ITEM_FETCH_LIMIT,
+    }
 
 
 def project_item_fetch_timeout(environ: Mapping[str, str] | None = None) -> int:
@@ -1999,6 +2026,7 @@ def fetch_project_items_payload(
     ]
     payload, command_error = run_json(command, repo_root, timeout=project_item_fetch_timeout())
     completeness = summarize_project_item_completeness(payload, fetch_limit)
+    completeness.update(project_item_fetch_safety_summary(fetch_limit))
     if command_error:
         return payload, command_error, completeness
 
@@ -2075,6 +2103,20 @@ def project_item_completeness_error(completeness: JsonObject) -> JsonObject | No
             "limit": fetch_limit,
         }
     if returned_count < total_count:
+        if completeness.get("limitMode") == "rate-limit-safe":
+            return {
+                "command": ["gh", "project", "item-list"],
+                "exitCode": 0,
+                "message": (
+                    f"project item-list limited for GraphQL rate-limit safety: returned {returned_count} "
+                    f"of {total_count} items with limit {fetch_limit}; set "
+                    f"{PROJECT_ITEM_FETCH_ALLOW_BROAD_ENV}=1 to permit broad Project hydration"
+                ),
+                "reason": "limited",
+                "returnedCount": returned_count,
+                "totalCount": total_count,
+                "limit": fetch_limit,
+            }
         return {
             "command": ["gh", "project", "item-list"],
             "exitCode": 0,

--- a/scripts/test_generate_roadmap_page.py
+++ b/scripts/test_generate_roadmap_page.py
@@ -1733,6 +1733,36 @@ class GenerateRoadmapPageTest(unittest.TestCase):
             roadmap.DEFAULT_PROJECT_ITEM_FETCH_TIMEOUT_SECONDS,
         )
 
+    def test_project_item_fetch_limit_clamps_broad_requests_without_explicit_opt_in(self) -> None:
+        self.assertEqual(roadmap.project_item_fetch_limit({}), roadmap.DEFAULT_PROJECT_ITEM_FETCH_LIMIT)
+        self.assertEqual(
+            roadmap.project_item_fetch_limit({roadmap.PROJECT_ITEM_FETCH_LIMIT_ENV: "2"}),
+            2,
+        )
+        self.assertEqual(
+            roadmap.project_item_fetch_limit({roadmap.PROJECT_ITEM_FETCH_LIMIT_ENV: "2000"}),
+            roadmap.DEFAULT_PROJECT_ITEM_FETCH_LIMIT,
+        )
+        self.assertEqual(
+            roadmap.project_item_fetch_limit({roadmap.PROJECT_ITEM_FETCH_LIMIT_ENV: "invalid"}),
+            roadmap.DEFAULT_PROJECT_ITEM_FETCH_LIMIT,
+        )
+
+    def test_project_item_fetch_limit_allows_broad_requests_with_explicit_opt_in(self) -> None:
+        self.assertEqual(
+            roadmap.project_item_fetch_limit({roadmap.PROJECT_ITEM_FETCH_ALLOW_BROAD_ENV: "1"}),
+            roadmap.BROAD_PROJECT_ITEM_FETCH_LIMIT,
+        )
+        self.assertEqual(
+            roadmap.project_item_fetch_limit(
+                {
+                    roadmap.PROJECT_ITEM_FETCH_ALLOW_BROAD_ENV: "true",
+                    roadmap.PROJECT_ITEM_FETCH_LIMIT_ENV: "2500",
+                }
+            ),
+            2500,
+        )
+
     def test_fetch_project_items_payload_uses_configured_timeout(self) -> None:
         captured: dict[str, Any] = {}
 
@@ -1763,7 +1793,83 @@ class GenerateRoadmapPageTest(unittest.TestCase):
         self.assertEqual(captured["command"][:4], ["gh", "project", "item-list", "3"])
         self.assertEqual(captured["command"][captured["command"].index("--owner") + 1], "lanyusea")
         self.assertEqual(captured["command"][captured["command"].index("--limit") + 1], "2")
-        self.assertEqual(completeness, {"complete": True, "returnedCount": 2, "totalCount": 2, "limit": 2})
+        self.assertEqual(
+            completeness,
+            {
+                "complete": True,
+                "returnedCount": 2,
+                "totalCount": 2,
+                "limit": 2,
+                "limitMode": "rate-limit-safe",
+                "broadScanAllowed": False,
+                "safeLimit": roadmap.DEFAULT_PROJECT_ITEM_FETCH_LIMIT,
+                "broadLimit": roadmap.BROAD_PROJECT_ITEM_FETCH_LIMIT,
+            },
+        )
+
+    def test_fetch_project_items_payload_requires_opt_in_for_broad_live_hydration(self) -> None:
+        captured: dict[str, Any] = {}
+
+        def fake_run_json(command: list[str], cwd: Path, timeout: int = 30) -> tuple[Any | None, dict[str, Any] | None]:
+            del cwd, timeout
+            captured["command"] = command
+            items = [{"title": str(index)} for index in range(roadmap.DEFAULT_PROJECT_ITEM_FETCH_LIMIT)]
+            return {"totalCount": roadmap.BROAD_PROJECT_ITEM_FETCH_LIMIT, "items": items}, None
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            with (
+                patch.dict(
+                    "os.environ",
+                    {
+                        roadmap.PROJECT_ITEM_FETCH_LIMIT_ENV: str(roadmap.BROAD_PROJECT_ITEM_FETCH_LIMIT),
+                    },
+                ),
+                patch.object(roadmap, "run_json", side_effect=fake_run_json),
+            ):
+                payload, error, completeness = roadmap.fetch_project_items_payload(repo_root, "lanyusea", 3)
+
+        self.assertIsNotNone(payload)
+        self.assertEqual(
+            captured["command"][captured["command"].index("--limit") + 1],
+            str(roadmap.DEFAULT_PROJECT_ITEM_FETCH_LIMIT),
+        )
+        self.assertIsNotNone(error)
+        self.assertEqual(error["reason"], "limited")
+        self.assertIn("GraphQL rate-limit safety", error["message"])
+        self.assertIn(roadmap.PROJECT_ITEM_FETCH_ALLOW_BROAD_ENV, error["message"])
+        self.assertEqual(completeness["limit"], roadmap.DEFAULT_PROJECT_ITEM_FETCH_LIMIT)
+        self.assertEqual(completeness["limitMode"], "rate-limit-safe")
+        self.assertFalse(completeness["broadScanAllowed"])
+
+    def test_fetch_project_items_payload_uses_broad_limit_with_explicit_opt_in(self) -> None:
+        captured: dict[str, Any] = {}
+
+        def fake_run_json(command: list[str], cwd: Path, timeout: int = 30) -> tuple[Any | None, dict[str, Any] | None]:
+            del cwd, timeout
+            captured["command"] = command
+            return {"totalCount": 2, "items": [{"title": "one"}, {"title": "two"}]}, None
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            with (
+                patch.dict(
+                    "os.environ",
+                    {
+                        roadmap.PROJECT_ITEM_FETCH_ALLOW_BROAD_ENV: "1",
+                        roadmap.PROJECT_ITEM_FETCH_LIMIT_ENV: str(roadmap.BROAD_PROJECT_ITEM_FETCH_LIMIT),
+                    },
+                ),
+                patch.object(roadmap, "run_json", side_effect=fake_run_json),
+            ):
+                payload, error, completeness = roadmap.fetch_project_items_payload(repo_root, "lanyusea", 3)
+
+        self.assertIsNone(error)
+        self.assertEqual(payload, {"totalCount": 2, "items": [{"title": "one"}, {"title": "two"}]})
+        self.assertEqual(captured["command"][captured["command"].index("--limit") + 1], "2000")
+        self.assertEqual(completeness["limit"], roadmap.BROAD_PROJECT_ITEM_FETCH_LIMIT)
+        self.assertEqual(completeness["limitMode"], "broad")
+        self.assertTrue(completeness["broadScanAllowed"])
 
     def test_fetch_github_snapshot_rejects_incomplete_project_payload(self) -> None:
         project_payload = {
@@ -1794,7 +1900,7 @@ class GenerateRoadmapPageTest(unittest.TestCase):
                 return [], None
             if command[:3] == ["gh", "project", "item-list"]:
                 self.assertIn("--limit", command)
-                self.assertEqual(command[command.index("--limit") + 1], "2000")
+                self.assertEqual(command[command.index("--limit") + 1], str(roadmap.DEFAULT_PROJECT_ITEM_FETCH_LIMIT))
                 return project_payload, None
             raise AssertionError(f"unexpected command: {command}")
 
@@ -1814,11 +1920,21 @@ class GenerateRoadmapPageTest(unittest.TestCase):
         self.assertEqual(snapshot["projectItems"], [])
         self.assertEqual(
             snapshot["projectItemsCompleteness"],
-            {"complete": False, "returnedCount": 2, "totalCount": 3, "limit": 2000},
+            {
+                "complete": False,
+                "returnedCount": 2,
+                "totalCount": 3,
+                "limit": roadmap.DEFAULT_PROJECT_ITEM_FETCH_LIMIT,
+                "limitMode": "rate-limit-safe",
+                "broadScanAllowed": False,
+                "safeLimit": roadmap.DEFAULT_PROJECT_ITEM_FETCH_LIMIT,
+                "broadLimit": roadmap.BROAD_PROJECT_ITEM_FETCH_LIMIT,
+            },
         )
         project_errors = [error for error in snapshot["fetchErrors"] if error.get("source") == "project"]
         self.assertEqual(len(project_errors), 1)
-        self.assertEqual(project_errors[0]["reason"], "incomplete")
+        self.assertEqual(project_errors[0]["reason"], "limited")
+        self.assertIn("GraphQL rate-limit safety", project_errors[0]["message"])
         self.assertEqual(project_errors[0]["returnedCount"], 2)
         self.assertEqual(project_errors[0]["totalCount"], 3)
 


### PR DESCRIPTION
## Summary
- Lower the default roadmap Project item-list cap from the historical broad hydration limit to a safe recurring cap.
- Require `SCREEPS_ROADMAP_ALLOW_BROAD_PROJECT_SCAN=1` before high-limit/full Project hydration is allowed.
- Add completeness metadata and a `reason: limited` Project fetch error so reports explain when hydration was limited for GraphQL rate-limit safety.
- Cover default clamp and explicit override behavior in focused roadmap generator tests.

Refs #1780

## Universal task Done gate

- [x] Task type: code behavior / bugfix.
- [x] Expected observable outcome / named deliverable: roadmap generator default Project hydration is capped at 100 items and high/full hydration requires `SCREEPS_ROADMAP_ALLOW_BROAD_PROJECT_SCAN=1`.
- [x] Non-goals / accepted substitutes: no generated docs/data refresh, no Screeps deploy, and no paid Tencent compute.
- [x] Verification evidence required before Done: commit `ba76782c` passed Python compile, focused generator tests, roadmap Pages contract tests, full generator tests, and `git diff --check`.
- [x] Project Evidence / Next action / Blocked by: issue #1780 and PR #1991 Project items are `In review` with current Evidence/Next action; stale `Blocked by` text was cleared.
- [x] Post-merge/deploy/runtime proof: not applicable because this is script/test behavior and deploy/runtime execution was outside the requested scope.
- [x] Named deliverable proof: PR #1991 diff updates `scripts/generate-roadmap-page.py` safe-cap/override behavior and `scripts/test_generate_roadmap_page.py` default/override coverage.

## Validation
- `python3 -m py_compile scripts/generate-roadmap-page.py scripts/test_generate_roadmap_page.py scripts/test_roadmap_pages_contract.py`
- `python3 -m unittest scripts.test_generate_roadmap_page.GenerateRoadmapPageTest.test_project_item_fetch_limit_clamps_broad_requests_without_explicit_opt_in scripts.test_generate_roadmap_page.GenerateRoadmapPageTest.test_project_item_fetch_limit_allows_broad_requests_with_explicit_opt_in scripts.test_generate_roadmap_page.GenerateRoadmapPageTest.test_fetch_project_items_payload_requires_opt_in_for_broad_live_hydration scripts.test_generate_roadmap_page.GenerateRoadmapPageTest.test_fetch_project_items_payload_uses_broad_limit_with_explicit_opt_in scripts.test_generate_roadmap_page.GenerateRoadmapPageTest.test_fetch_github_snapshot_rejects_incomplete_project_payload`
- `python3 -m unittest scripts.test_roadmap_pages_contract.RoadmapPagesContractTests`
- `python3 -m unittest scripts.test_generate_roadmap_page`
- `git diff --check`