### PR TITLE
[codex] Fix CPU low-bucket construction recovery

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -962,6 +962,7 @@ function normalizeEnergyAmount(value) {
 var LOW_CPU_ACCOUNT_LIMIT = 20;
 var LOW_CPU_BUCKET_THRESHOLD = 1e3;
 var CRITICAL_CPU_BUCKET_THRESHOLD = 100;
+var CONSTRUCTION_LOW_BUCKET_RECOVERY_THRESHOLD = 750;
 var DEGRADED_OPTIONAL_WORK_INTERVAL = 5;
 var DEGRADED_ROOM_OPTIONAL_WORK_INTERVAL = 3;
 var CPU_BUCKET_MAX = 1e4;
@@ -1087,13 +1088,16 @@ function hasUsedOverLimitPressure(budget) {
   return budget.reasons.includes("usedOverLimit");
 }
 function hasHardConstructionCpuPressure(budget) {
-  if (budget.lowCpuLimit || budget.critical || budget.reasons.includes("lowBucket") || budget.reasons.includes("criticalBucket")) {
+  if (budget.lowCpuLimit || budget.critical || budget.reasons.includes("criticalBucket")) {
     return true;
   }
-  if (!hasUsedOverLimitPressure(budget)) {
-    return false;
+  if (hasUsedOverLimitPressure(budget)) {
+    return !hasConstructionRecoveryBucketHeadroom(budget.sample);
   }
-  return !hasConstructionRecoveryBucketHeadroom(budget.sample);
+  if (budget.reasons.includes("lowBucket")) {
+    return !hasConstructionLowBucketHeadroom(budget.sample);
+  }
+  return false;
 }
 function hasConstructionRecoveryBucketHeadroom(sample) {
   const projectedBucket = getProjectedPostTickBucket(sample);
@@ -1108,6 +1112,10 @@ function hasConstructionRecoveryBucketHeadroom(sample) {
     return true;
   }
   return isNearConstructionRecoveryBucket(sample.bucket, sample.limit, recoveryCeiling);
+}
+function hasConstructionLowBucketHeadroom(sample) {
+  const projectedBucket = getProjectedPostTickBucket(sample);
+  return projectedBucket !== void 0 && projectedBucket >= CONSTRUCTION_LOW_BUCKET_RECOVERY_THRESHOLD;
 }
 function getProjectedPostTickBucket(sample) {
   if (sample.bucket === void 0 || sample.used === void 0 || sample.limit === void 0 || sample.limit <= 0) {

--- a/prod/src/runtime/cpuBudget.ts
+++ b/prod/src/runtime/cpuBudget.ts
@@ -66,6 +66,7 @@ interface RuntimeCpuTelemetryState {
 export const LOW_CPU_ACCOUNT_LIMIT = 20;
 export const LOW_CPU_BUCKET_THRESHOLD = 1_000;
 export const CRITICAL_CPU_BUCKET_THRESHOLD = 100;
+export const CONSTRUCTION_LOW_BUCKET_RECOVERY_THRESHOLD = 750;
 export const DEGRADED_OPTIONAL_WORK_INTERVAL = 5;
 export const DEGRADED_ROOM_OPTIONAL_WORK_INTERVAL = 3;
 const CPU_BUCKET_MAX = 10_000;
@@ -258,17 +259,20 @@ function hasHardConstructionCpuPressure(budget: RuntimeCpuBudget): boolean {
   if (
     budget.lowCpuLimit ||
     budget.critical ||
-    budget.reasons.includes('lowBucket') ||
     budget.reasons.includes('criticalBucket')
   ) {
     return true;
   }
 
-  if (!hasUsedOverLimitPressure(budget)) {
-    return false;
+  if (hasUsedOverLimitPressure(budget)) {
+    return !hasConstructionRecoveryBucketHeadroom(budget.sample);
   }
 
-  return !hasConstructionRecoveryBucketHeadroom(budget.sample);
+  if (budget.reasons.includes('lowBucket')) {
+    return !hasConstructionLowBucketHeadroom(budget.sample);
+  }
+
+  return false;
 }
 
 function hasConstructionRecoveryBucketHeadroom(sample: RuntimeCpuSample): boolean {
@@ -287,6 +291,14 @@ function hasConstructionRecoveryBucketHeadroom(sample: RuntimeCpuSample): boolea
   }
 
   return isNearConstructionRecoveryBucket(sample.bucket, sample.limit, recoveryCeiling);
+}
+
+function hasConstructionLowBucketHeadroom(sample: RuntimeCpuSample): boolean {
+  const projectedBucket = getProjectedPostTickBucket(sample);
+  return (
+    projectedBucket !== undefined &&
+    projectedBucket >= CONSTRUCTION_LOW_BUCKET_RECOVERY_THRESHOLD
+  );
 }
 
 function getProjectedPostTickBucket(sample: RuntimeCpuSample): number | undefined {

--- a/prod/test/cpuBudget.test.ts
+++ b/prod/test/cpuBudget.test.ts
@@ -1,6 +1,7 @@
 import {
   buildRuntimeCpuBudget,
   buildRuntimeCpuTelemetrySummary,
+  CONSTRUCTION_LOW_BUCKET_RECOVERY_THRESHOLD,
   getRuntimeCpuBudget,
   isRuntimeCpuBucketCritical,
   isRuntimeCpuBucketLow,
@@ -140,6 +141,78 @@ describe('runtime CPU budget policy', () => {
         })
       )
     ).toBe(true);
+  });
+
+  it('keeps optional work paused but runs construction recovery above the low-bucket construction floor', () => {
+    const budgets = [
+      { tick: 2461915, used: 12.233448999992106, bucket: 786 },
+      { tick: 2461935, used: 17.77628489997005, bucket: 870 },
+      { tick: 2461936, used: 18, bucket: CONSTRUCTION_LOW_BUCKET_RECOVERY_THRESHOLD }
+    ].map((sample) =>
+      buildRuntimeCpuBudget({
+        ...sample,
+        limit: 70,
+        tickLimit: 500
+      })
+    );
+
+    for (const budget of budgets) {
+      expect(budget).toMatchObject({
+        pressure: 'degraded',
+        degraded: true,
+        critical: false,
+        lowCpuLimit: false,
+        reasons: ['lowBucket']
+      });
+      expect(shouldRunOptionalCpuWork(budget, 'economy-global-optional')).toBe(false);
+      expect(shouldRunOptionalCpuRoomWork(budget, 'E29N57')).toBe(false);
+      expect(shouldShedNonessentialCpuWork(budget)).toBe(true);
+      expect(shouldRunConstructionCpuWork(budget)).toBe(true);
+    }
+  });
+
+  it('keeps construction guarded below the low-bucket construction floor', () => {
+    const budget = buildRuntimeCpuBudget({
+      tick: 2461914,
+      used: 18,
+      limit: 70,
+      bucket: CONSTRUCTION_LOW_BUCKET_RECOVERY_THRESHOLD - 1,
+      tickLimit: 500
+    });
+
+    expect(budget).toMatchObject({
+      pressure: 'degraded',
+      degraded: true,
+      critical: false,
+      lowCpuLimit: false,
+      reasons: ['lowBucket']
+    });
+    expect(shouldRunOptionalCpuWork(budget, 'economy-global-optional')).toBe(false);
+    expect(shouldRunOptionalCpuRoomWork(budget, 'E29N57')).toBe(false);
+    expect(shouldShedNonessentialCpuWork(budget)).toBe(true);
+    expect(shouldRunConstructionCpuWork(budget)).toBe(false);
+  });
+
+  it('keeps construction guarded when low-bucket CPU is already over limit', () => {
+    const budget = buildRuntimeCpuBudget({
+      tick: 2461916,
+      used: 71,
+      limit: 70,
+      bucket: 870,
+      tickLimit: 500
+    });
+
+    expect(budget).toMatchObject({
+      pressure: 'degraded',
+      degraded: true,
+      critical: false,
+      lowCpuLimit: false,
+      reasons: ['lowBucket', 'usedOverLimit']
+    });
+    expect(shouldRunOptionalCpuWork(budget, 'economy-global-optional')).toBe(false);
+    expect(shouldRunOptionalCpuRoomWork(budget, 'E29N57')).toBe(false);
+    expect(shouldShedNonessentialCpuWork(budget)).toBe(true);
+    expect(shouldRunConstructionCpuWork(budget)).toBe(false);
   });
 
   it('sheds optional work but keeps construction enabled during safe low-bucket recovery', () => {

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -495,6 +495,11 @@ describe('runtime telemetry summaries', () => {
       source: 'runtime-summary',
       constructionSiteCount: 1
     });
+    expect(room.constructionScoring).toMatchObject({
+      source: 'runtime-summary',
+      loopRan: true,
+      skipped: false
+    });
     expect(typeof resources.storedEnergy).toBe('number');
     expect(resources).toMatchObject({
       workerCarriedEnergy: 40,

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -53,6 +53,7 @@ import {
   TERRITORY_RESERVATION_RENEWAL_TICKS
 } from '../src/territory/territoryPlanner';
 import { MINIMUM_WORKER_SPAWN_ENERGY } from '../src/economy/energyBuffer';
+import { CONSTRUCTION_LOW_BUCKET_RECOVERY_THRESHOLD } from '../src/runtime/cpuBudget';
 import { ensureVisibleOwnedRcl6ColonyRoom } from './helpers/territoryControlGate';
 
 const TEST_CRITICAL_SPAWN_REPAIR_HITS_RATIO = 0.25 as const;
@@ -15405,7 +15406,7 @@ describe('selectWorkerTask', () => {
       room
     } as unknown as Creep;
     setGameCreeps({ LowBucketBuilder: builder, IdleWorker: idleWorker });
-    setCpuBucket(948);
+    setCpuBucket(CONSTRUCTION_LOW_BUCKET_RECOVERY_THRESHOLD - 1);
 
     expect(selectWorkerTask(builder)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });


### PR DESCRIPTION
## Linked Issues

Related to #1975.

## Summary
- Allow construction-only recovery work to run when low-bucket pressure still has a 750 bucket floor and the tick is not over CPU limit.
- Keep optional work shed during low-bucket pressure and preserve hard guards for critical bucket, low CPU account limit, and over-limit low-bucket samples.
- Add focused CPU policy, runtime summary, and worker task coverage for the new boundary.

## Verification
- Local check: `npm run typecheck` passed.
- Local check: `npm test -- --runInBand` passed, 105 suites / 2517 tests.
- Local check: `npm run build` passed.
- Local check: `git diff --check` passed.
- GitHub Project issue/PR fields are current for #1975 and #2000.
- No secrets, unsafe local paths, or owner-facing raw attachment trigger lines are included.

## Universal task Done gate

- [x] Task type: bugfix.
- [x] Expected observable outcome / named deliverable: PR #2000 changes the construction CPU gate so low-bucket samples in the observed 786-870 range allow construction scoring/recovery while optional work remains shed.
- [x] Non-goals / accepted substitutes: no Screeps deploy/upload, no Tencent paid compute, no merge, and no broad CPU or construction rewrite.
- [x] Verification evidence required before Done: `npm run typecheck`, `npm test -- --runInBand`, `npm run build`, and `git diff --check` all passed locally at commit 09456a1b238c2862e48bb29f8f90bafb8f147ea0.
- [x] Project Evidence / Next action / Blocked by: #1975 and #2000 Project items are In review; Evidence records PR #2000, commit 09456a1b238c2862e48bb29f8f90bafb8f147ea0, and local verification; Blocked by is empty; Next action is steward merge gate.
- [x] Post-merge/deploy/runtime proof: local PR proof is code/tests/build; Project Next action routes steward merge gate and runtime monitor evidence collection for #1975 acceptance.
- [x] Named deliverable proof: PR #2000 is open at https://github.com/lanyusea/screeps/pull/2000 with branch `codex/1975-cpu-shed-repair` and commit 09456a1b238c2862e48bb29f8f90bafb8f147ea0.

## Runtime / Deployment Impact

Gameplay/runtime impact: CPU shed behavior changes for construction recovery only. No deploy/upload was run.

## Notes

Do not merge in this run; leave for the steward merge gate and live review/check validation.