### PR TITLE
[codex] Fix E29N56 low-bucket upgrade suppression

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -28062,16 +28062,15 @@ function selectCriticalCpuWorkerTask(creep, cpuBudget) {
   }
   const loadedControllerProgressTask = selectNonCriticalCpuLoadedControllerProgressTask(
     creep,
-    cpuBudget,
-    constructionSites
+    cpuBudget
   );
   if (loadedControllerProgressTask) {
     return applyMinimumUsefulLoadPolicy(creep, loadedControllerProgressTask);
   }
   return null;
 }
-function selectNonCriticalCpuLoadedControllerProgressTask(creep, cpuBudget, constructionSites) {
-  if (cpuBudget.critical || getUsedEnergy2(creep) <= 0 || constructionSites.length > 0 || hasVisibleHostilePresence3(creep.room) || !hasFullRoomEnergyForControllerProgress(creep.room)) {
+function selectNonCriticalCpuLoadedControllerProgressTask(creep, cpuBudget) {
+  if (cpuBudget.critical || !shouldRunConstructionCpuWork(cpuBudget) || getUsedEnergy2(creep) <= 0 || hasVisibleHostilePresence3(creep.room) || !hasFullRoomEnergyForControllerProgress(creep.room)) {
     return null;
   }
   const controller = creep.room.controller;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -527,8 +527,7 @@ function selectCriticalCpuWorkerTask(creep: Creep, cpuBudget: RuntimeCpuBudget):
 
   const loadedControllerProgressTask = selectNonCriticalCpuLoadedControllerProgressTask(
     creep,
-    cpuBudget,
-    constructionSites
+    cpuBudget
   );
   if (loadedControllerProgressTask) {
     return applyMinimumUsefulLoadPolicy(creep, loadedControllerProgressTask);
@@ -539,13 +538,12 @@ function selectCriticalCpuWorkerTask(creep: Creep, cpuBudget: RuntimeCpuBudget):
 
 function selectNonCriticalCpuLoadedControllerProgressTask(
   creep: Creep,
-  cpuBudget: RuntimeCpuBudget,
-  constructionSites: ConstructionSite[]
+  cpuBudget: RuntimeCpuBudget
 ): Extract<CreepTaskMemory, { type: 'upgrade' }> | null {
   if (
     cpuBudget.critical ||
+    !shouldRunConstructionCpuWork(cpuBudget) ||
     getUsedEnergy(creep) <= 0 ||
-    constructionSites.length > 0 ||
     hasVisibleHostilePresence(creep.room) ||
     !hasFullRoomEnergyForControllerProgress(creep.room)
   ) {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -15459,6 +15459,70 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(builder)).toEqual({ type: 'build', targetId: 'road-site1' });
   });
 
+  it('keeps one E29N56 worker upgrading during low-bucket construction recovery when build and repair are covered', () => {
+    const fullSpawn = makeFullSpawnEnergyStructure('spawn-full', 'E29N56');
+    const site = {
+      id: 'rampart-site1',
+      my: true,
+      structureType: 'rampart',
+      progress: 4_900,
+      progressTotal: 5_000,
+      pos: makeRoomPosition(24, 24, 'E29N56')
+    } as ConstructionSite;
+    const storage = makeStoredEnergyStructure('storage1', 'storage' as StructureConstant, 548_000, {
+      my: true,
+      pos: makeRoomPosition(20, 20, 'E29N56')
+    });
+    const road = makeStructure('road-covered-repair', 'road' as StructureConstant, 4_000, 5_000);
+    const controller = {
+      id: 'controller-e29n56',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N56',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      myStructures: [fullSpawn as AnyOwnedStructure],
+      structures: [fullSpawn as AnyStructure, storage as AnyStructure, road]
+    });
+    const upgradeCandidate = {
+      name: 'E29N56UpgradeCandidate',
+      memory: { role: 'worker', colony: 'E29N56' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room
+    } as unknown as Creep;
+    const coveredBuilder = {
+      name: 'E29N56CoveredBuilder',
+      memory: { role: 'worker', colony: 'E29N56', task: { type: 'build', targetId: 'rampart-site1' as Id<ConstructionSite> } },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    const coveredRepairer = {
+      name: 'E29N56CoveredRepairer',
+      memory: { role: 'worker', colony: 'E29N56', task: { type: 'repair', targetId: 'road-covered-repair' as Id<Structure> } },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({
+      E29N56UpgradeCandidate: upgradeCandidate,
+      E29N56CoveredBuilder: coveredBuilder,
+      E29N56CoveredRepairer: coveredRepairer
+    });
+    setCpuBucket(927);
+
+    expect(selectWorkerTask(upgradeCandidate)).toEqual({ type: 'upgrade', targetId: 'controller-e29n56' });
+  });
+
   it('suppresses generic construction recovery during critical CPU bucket pressure', () => {
     const fullSpawn = makeFullSpawnEnergyStructure('spawn-full', 'E29N55');
     const site = {


### PR DESCRIPTION
## Summary

Related to issue #1994.

This keeps one loaded E29N56 worker eligible for controller upgrade during low-bucket construction recovery once construction work is already covered. The degraded CPU path still tries construction recovery first, still blocks below the construction recovery floor, and still blocks during critical CPU pressure or hostile room conditions.

## Root Cause

After PR #2000, construction recovery resumed above the 750 CPU-bucket floor, but `selectNonCriticalCpuLoadedControllerProgressTask` still rejected controller progress whenever any construction site existed. A lingering covered construction site could therefore keep a full-energy, storage-rich room at `upgrade=0` while build/repair work continued.

## Changes

- Allow degraded-CPU loaded controller progress after construction recovery fails to find unreserved build work.
- Gate that controller progress with `shouldRunConstructionCpuWork`, preserving the 750 low-bucket construction recovery floor and critical/over-limit suppression.
- Add an E29N56 regression test for full room energy, large storage, covered build/repair work, and bucket 927.
- Regenerate `prod/dist/main.js` via `npm run build`.

## Verification

- `npm run typecheck`
- `npm test -- --runInBand workerTasks.test.ts`
- `npm test -- --runInBand`
- `npm run build`
- `git diff --check`

## Universal task Done gate

- [x] Task type: code
- [x] Expected observable outcome / named deliverable: PR #2001 provides a low-bucket E29N56 controller-upgrade fallback in `prod/src/tasks/workerTasks.ts` with a regression test in `prod/test/workerTasks.test.ts`.
- [x] Non-goals / accepted substitutes: No official MMO writes, no Tencent compute, no broad task planner rewrite.
- [x] Verification evidence required before Done: `npm run typecheck`, `npm test -- --runInBand workerTasks.test.ts`, `npm test -- --runInBand`, `npm run build`, and `git diff --check` passed on commit f406eb37280ce2fd5180f2ff7edb6fcd4686a88f.
- [x] Project Evidence / Next action / Blocked by: Project `screeps` issue #1994 and PR #2001 are In review with Evidence and Next action refreshed at head f406eb37280ce2fd5180f2ff7edb6fcd4686a88f.
- [x] Post-merge/deploy/runtime proof: Build artifact `prod/dist/main.js` regenerated from commit f406eb37280ce2fd5180f2ff7edb6fcd4686a88f; official deployment evidence is tracked by the release lane.
- [x] Named deliverable proof: PR #2001 diff contains `prod/src/tasks/workerTasks.ts`, `prod/test/workerTasks.test.ts`, and `prod/dist/main.js`.

## Notes

Automated review and merge gates should run separately.
