### PR TITLE
[codex] Preserve covered surplus controller progress

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -27988,6 +27988,11 @@ function selectCriticalCpuWorkerTask(creep, cpuBudget) {
       targetId: threatenedBarrierRepairTarget.id
     });
   }
+  const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
+  const coveredLowBucketControllerProgressTask = controller && !priorityTowerEnergySink && shouldRunConstructionCpuWork(cpuBudget) ? selectCoveredSurplusControllerProgressTask(creep, controller, constructionSites) : null;
+  if (coveredLowBucketControllerProgressTask) {
+    return applyMinimumUsefulLoadPolicy(creep, coveredLowBucketControllerProgressTask);
+  }
   const storedProtectedConstructionTask = selectStoredProtectedSourceContainerConstructionTask(creep);
   if (storedProtectedConstructionTask) {
     return applyMinimumUsefulLoadPolicy(creep, storedProtectedConstructionTask);
@@ -28020,7 +28025,6 @@ function selectCriticalCpuWorkerTask(creep, cpuBudget) {
       targetId: spawnOrExtensionEnergySink.id
     };
   }
-  const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
   const boundedConstructionBacklogTask = priorityTowerEnergySink ? selectBoundedConstructionBacklogTaskBeforeNonCriticalRefill(
     creep,
     constructionSites,

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -432,6 +432,15 @@ function selectCriticalCpuWorkerTask(creep: Creep, cpuBudget: RuntimeCpuBudget):
     });
   }
 
+  const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
+  const coveredLowBucketControllerProgressTask =
+    controller && !priorityTowerEnergySink && shouldRunConstructionCpuWork(cpuBudget)
+      ? selectCoveredSurplusControllerProgressTask(creep, controller, constructionSites)
+      : null;
+  if (coveredLowBucketControllerProgressTask) {
+    return applyMinimumUsefulLoadPolicy(creep, coveredLowBucketControllerProgressTask);
+  }
+
   const storedProtectedConstructionTask = selectStoredProtectedSourceContainerConstructionTask(creep);
   if (storedProtectedConstructionTask) {
     return applyMinimumUsefulLoadPolicy(creep, storedProtectedConstructionTask);
@@ -475,7 +484,6 @@ function selectCriticalCpuWorkerTask(creep: Creep, cpuBudget: RuntimeCpuBudget):
     };
   }
 
-  const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
   const boundedConstructionBacklogTask = priorityTowerEnergySink
     ? selectBoundedConstructionBacklogTaskBeforeNonCriticalRefill(
       creep,

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -15523,6 +15523,81 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(upgradeCandidate)).toEqual({ type: 'upgrade', targetId: 'controller-e29n56' });
   });
 
+  it('keeps one surplus worker upgrading during low-bucket recovery when build and critical repair are covered', () => {
+    const fullSpawn = makeFullSpawnEnergyStructure('spawn-full');
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 4_700,
+      progressTotal: 5_000,
+      pos: makeRoomPosition(24, 24)
+    } as ConstructionSite;
+    const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 560_000, {
+      my: true,
+      pos: makeRoomPosition(20, 20)
+    });
+    const criticalContainer = makeStructure(
+      'container-critical',
+      'container' as StructureConstant,
+      900,
+      2_000
+    );
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 4,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [site],
+      controller,
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      myStructures: [fullSpawn as AnyOwnedStructure],
+      structures: [fullSpawn as AnyStructure, storage as AnyStructure, criticalContainer]
+    });
+    const upgradeCandidate = {
+      name: 'UpgradeCandidate',
+      memory: { role: 'worker', colony: 'W1N1' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room
+    } as unknown as Creep;
+    const coveredBuilder = {
+      name: 'CoveredBuilder',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'build', targetId: 'road-site1' as Id<ConstructionSite> }
+      },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    const coveredRepairer = {
+      name: 'CoveredRepairer',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'repair', targetId: 'container-critical' as Id<Structure> }
+      },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({
+      UpgradeCandidate: upgradeCandidate,
+      CoveredBuilder: coveredBuilder,
+      CoveredRepairer: coveredRepairer
+    });
+    setCpuBucket(758);
+
+    expect(selectWorkerTask(upgradeCandidate)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
   it('suppresses generic construction recovery during critical CPU bucket pressure', () => {
     const fullSpawn = makeFullSpawnEnergyStructure('spawn-full', 'E29N55');
     const site = {


### PR DESCRIPTION
## Summary
- Reuses the covered surplus controller-progress guard inside low-bucket worker task selection before covered construction/repair can consume every loaded surplus worker.
- Adds a focused regression for a storage-rich owned room with active build coverage, active critical repair coverage, a non-maxed controller, and recoverable low-bucket CPU pressure.
- Regenerates `prod/dist/main.js` from the verified TypeScript build.

## Root cause
After PR #2001, the CPU-shed path could still return covered construction or critical repair work before reaching any controller-progress path. In the E29N56 proof, construction and repair stayed active, but every loaded surplus worker remained routed to those covered non-controller tasks, leaving `upgrade=0` despite massive stored energy and a non-maxed controller.

## Verification
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`
- `git diff --check`

## Universal task Done gate
- [x] Task type: production bug fix follow-up.
- [x] Expected observable outcome / named deliverable: PR #2002 preserves at least one safe covered-surplus controller-progress worker during recoverable low-bucket CPU pressure.
- [x] Non-goals / accepted substitutes: no official MMO deploy, no merge, no Tencent paid compute, and #1994 remains open for live acceptance proof.
- [x] Verification evidence required before Done: `npm run typecheck`; `npm test -- --runInBand` with 105 suites and 2519 tests; `npm run build`; `git diff --check`.
- [x] Project Evidence / Next action / Blocked by: Project `screeps` items for PR #2002 and issue #1994 are In review with refreshed Evidence and Next action; no blocker exists for this PR handoff.
- [x] Post-merge/deploy/runtime proof: owner-accepted substitute for this scoped task is local verification plus Project handoff; official runtime proof is delegated to #1994.
- [x] Named deliverable proof: draft PR #2002 at https://github.com/lanyusea/screeps/pull/2002 points to commit `6830a2f` and branch `codex/1994-e29n56-upgrade-followup`.

Related to #1994

Not deployed to the official MMO. Runtime acceptance for #1994 still requires post-merge official proof.