### PR TITLE
Recover low-worker construction from storage reserve

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -27863,6 +27863,7 @@ var WORKER_ENERGY_SURPLUS_SCORE_RATIO = 0.4;
 var HARVEST_ENERGY_PER_WORK_PART2 = 2;
 var SPAWN_EXTENSION_THROUGHPUT_STORAGE_REFILL_EMPTY_CAPACITY_RATIO = 0.2;
 var SPAWN_EXTENSION_REFILL_STORAGE_WITHDRAWAL_OPTIONS = { allowBelowReserve: true };
+var LOCAL_WORKER_RECOVERY_CONSTRUCTION_STORAGE_WITHDRAWAL_OPTIONS = { allowBelowReserve: true };
 var DEFAULT_BUILD_POWER = 5;
 var REPAIR_HEAVY_CONSTRUCTION_YIELD_MIN_OTHER_LOADED_REPAIRERS = 2;
 var NEARLY_COMPLETE_CONSTRUCTION_SITE_REMAINING_RATIO = 0.2;
@@ -30867,7 +30868,7 @@ function canSpendWorkerEnergyOnConstructionSite(creep, site) {
 }
 function canSpendCreepEnergyOnConstructionSite(creep, site, priorityContext) {
   const carriedEnergy = getUsedEnergy2(creep);
-  return carriedEnergy > 0 && isMissingSpawnRecoveryConstructionSite(creep.room, site) || carriedEnergy > 0 && checkEnergyBufferForConstructionSpending(creep.room) || carriedEnergy > 0 && checkEnergyBufferForStoredConstructionSpending(creep.room) || carriedEnergy > 0 && canSpendCarriedSurplusOnBoundedConstruction(creep, site) || carriedEnergy > 0 && isExtensionConstructionSite(site) && checkEnergyBufferForExtensionConstruction(creep.room, carriedEnergy) || carriedEnergy > 0 && !isExtensionConstructionSite(site) && isCapacityEnablingConstructionSite(site, priorityContext) && checkEnergyBufferForCapacityEnablingConstruction(creep.room, carriedEnergy) || carriedEnergy > 0 && canCompleteConstructionSiteWithCarriedEnergy(creep, site) || carriedEnergy > 0 && isLowWorkerThroughputRecoveryConstructionAllowed(creep, site) || carriedEnergy > 0 && hasMinimumWorkerSpawnEnergyForConstruction(creep.room) && isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext);
+  return carriedEnergy > 0 && isMissingSpawnRecoveryConstructionSite(creep.room, site) || carriedEnergy > 0 && checkEnergyBufferForConstructionSpending(creep.room) || carriedEnergy > 0 && checkEnergyBufferForStoredConstructionSpending(creep.room) || carriedEnergy > 0 && canSpendCarriedSurplusOnBoundedConstruction(creep, site) || carriedEnergy > 0 && isExtensionConstructionSite(site) && checkEnergyBufferForExtensionConstruction(creep.room, carriedEnergy) || carriedEnergy > 0 && !isExtensionConstructionSite(site) && isCapacityEnablingConstructionSite(site, priorityContext) && checkEnergyBufferForCapacityEnablingConstruction(creep.room, carriedEnergy) || carriedEnergy > 0 && canCompleteConstructionSiteWithCarriedEnergy(creep, site) || carriedEnergy > 0 && canUseLocalWorkerRecoveryConstructionEnergy(creep, site) || carriedEnergy > 0 && isLowWorkerThroughputRecoveryConstructionAllowed(creep, site) || carriedEnergy > 0 && hasMinimumWorkerSpawnEnergyForConstruction(creep.room) && isEnergyStarvationSourceLogisticsConstructionSite(site, priorityContext);
 }
 function canSpendCarriedSurplusOnBoundedConstruction(creep, site) {
   const room = creep.room;
@@ -30878,6 +30879,25 @@ function canSpendCarriedSurplusOnBoundedConstruction(creep, site) {
 }
 function isLowWorkerThroughputRecoveryConstructionAllowed(creep, site) {
   return site.my !== false && hasLowWorkerThroughputRecoveryPressure(creep);
+}
+function canUseLocalWorkerRecoveryConstructionEnergy(creep, site) {
+  const room = creep.room;
+  const controller = room.controller;
+  const energyAvailable = getRoomEnergyAvailable11(room);
+  const ownedSpawnCount = getOwnedSpawnCount(room);
+  return site.my !== false && isNormalLocalRecoveryWorker(creep) && getActiveWorkParts2(creep) > 0 && (controller == null ? void 0 : controller.my) === true && ownedSpawnCount !== 0 && energyAvailable !== null && energyAvailable >= MINIMUM_WORKER_SPAWN_ENERGY && !hasVisibleHostilePresence3(room) && !shouldGuardControllerDowngrade2(controller) && isConstructionSiteInRoom(site, room) && hasLoneLocalWorkerRecoveryPressure(creep);
+}
+function isNormalLocalRecoveryWorker(creep) {
+  const memory = creep.memory;
+  return (memory == null ? void 0 : memory.role) === "worker" && memory.controllerSustain === void 0 && memory.controllerUpgrade === void 0 && memory.interRoomEnergyHaul === void 0 && memory.spawnSupport === void 0 && memory.territory === void 0;
+}
+function isConstructionSiteInRoom(site, room) {
+  const siteRoomName = getPositionRoomName(site);
+  const roomName = getRoomName6(room);
+  return siteRoomName === null || roomName === null || siteRoomName === roomName;
+}
+function hasLoneLocalWorkerRecoveryPressure(creep) {
+  return !hasOtherSameRoomLoadedBuildWorker(creep) && getSameRoomCreepsIncludingCurrent(creep).filter(isNormalLocalRecoveryWorker).length <= 1;
 }
 function isMissingSpawnRecoveryConstructionSite(room, site) {
   return isSpawnConstructionSite(site) && getOwnedSpawnCount(room) === 0;
@@ -31790,6 +31810,18 @@ function createUnreservedBuilderStoredEnergyAcquisitionCandidate(creep, source, 
       constructionSiteId: constructionSite.id
     });
   }
+  const recoveryStorageCandidate = createLocalWorkerRecoveryStorageConstructionEnergyCandidate(
+    creep,
+    source,
+    energy,
+    task,
+    reservationContext,
+    minimumEnergy,
+    constructionSite
+  );
+  if (recoveryStorageCandidate) {
+    return recoveryStorageCandidate;
+  }
   const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
     creep,
     source,
@@ -31802,6 +31834,36 @@ function createUnreservedBuilderStoredEnergyAcquisitionCandidate(creep, source, 
     minimumEnergy
   );
   return candidate ? toBuilderEnergyAcquisitionCandidate(candidate) : null;
+}
+function createLocalWorkerRecoveryStorageConstructionEnergyCandidate(creep, source, energy, task, reservationContext, minimumEnergy, constructionSite) {
+  if (!isStorageStoredEnergySource(source) || !canUseLocalWorkerRecoveryConstructionEnergy(creep, constructionSite)) {
+    return null;
+  }
+  const reservedEnergy = getReservedWorkerEnergyAcquisitionAmount2(source, reservationContext);
+  const projectedEnergy = Math.max(0, energy - reservedEnergy);
+  const availableEnergy = getStorageEnergyAvailableForWithdrawal(
+    creep.room,
+    source,
+    projectedEnergy,
+    LOCAL_WORKER_RECOVERY_CONSTRUCTION_STORAGE_WITHDRAWAL_OPTIONS
+  );
+  const plannedWithdrawal = Math.min(availableEnergy, getFreeEnergyCapacity9(creep));
+  if (availableEnergy < minimumEnergy || plannedWithdrawal <= 0 || !withdrawFromStorage(
+    creep.room,
+    plannedWithdrawal,
+    source,
+    projectedEnergy,
+    LOCAL_WORKER_RECOVERY_CONSTRUCTION_STORAGE_WITHDRAWAL_OPTIONS
+  )) {
+    return null;
+  }
+  return createBuilderEnergyAcquisitionCandidate(creep, source, availableEnergy, {
+    ...task,
+    constructionSiteId: constructionSite.id
+  });
+}
+function isStorageStoredEnergySource(source) {
+  return matchesStructureType19(source.structureType, "STRUCTURE_STORAGE", "storage");
 }
 function isBuilderConstructionBufferSpawnSource(creep, structure, context, reservationContext) {
   return isSpawnEnergySource(structure) && isFriendlyStoredEnergySource(structure, context) && getSpawnConstructionEnergyAvailableForWithdrawal(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -133,6 +133,7 @@ const WORKER_ENERGY_SURPLUS_SCORE_RATIO = 0.4;
 const HARVEST_ENERGY_PER_WORK_PART = 2;
 const SPAWN_EXTENSION_THROUGHPUT_STORAGE_REFILL_EMPTY_CAPACITY_RATIO = 0.2;
 const SPAWN_EXTENSION_REFILL_STORAGE_WITHDRAWAL_OPTIONS = { allowBelowReserve: true } as const;
+const LOCAL_WORKER_RECOVERY_CONSTRUCTION_STORAGE_WITHDRAWAL_OPTIONS = { allowBelowReserve: true } as const;
 const DEFAULT_BUILD_POWER = 5;
 const REPAIR_HEAVY_CONSTRUCTION_YIELD_MIN_OTHER_LOADED_REPAIRERS = 2;
 const NEARLY_COMPLETE_CONSTRUCTION_SITE_REMAINING_RATIO = 0.2;
@@ -4764,6 +4765,7 @@ function canSpendCreepEnergyOnConstructionSite(
       isCapacityEnablingConstructionSite(site, priorityContext) &&
       checkEnergyBufferForCapacityEnablingConstruction(creep.room, carriedEnergy)) ||
     (carriedEnergy > 0 && canCompleteConstructionSiteWithCarriedEnergy(creep, site)) ||
+    (carriedEnergy > 0 && canUseLocalWorkerRecoveryConstructionEnergy(creep, site)) ||
     (carriedEnergy > 0 && isLowWorkerThroughputRecoveryConstructionAllowed(creep, site)) ||
     (carriedEnergy > 0 &&
       hasMinimumWorkerSpawnEnergyForConstruction(creep.room) &&
@@ -4793,6 +4795,51 @@ function canSpendCarriedSurplusOnBoundedConstruction(creep: Creep, site: Constru
 
 function isLowWorkerThroughputRecoveryConstructionAllowed(creep: Creep, site: ConstructionSite): boolean {
   return site.my !== false && hasLowWorkerThroughputRecoveryPressure(creep);
+}
+
+function canUseLocalWorkerRecoveryConstructionEnergy(creep: Creep, site: ConstructionSite): boolean {
+  const room = creep.room;
+  const controller = room.controller;
+  const energyAvailable = getRoomEnergyAvailable(room);
+  const ownedSpawnCount = getOwnedSpawnCount(room);
+  return (
+    site.my !== false &&
+    isNormalLocalRecoveryWorker(creep) &&
+    getActiveWorkParts(creep) > 0 &&
+    controller?.my === true &&
+    ownedSpawnCount !== 0 &&
+    energyAvailable !== null &&
+    energyAvailable >= MINIMUM_WORKER_SPAWN_ENERGY &&
+    !hasVisibleHostilePresence(room) &&
+    !shouldGuardControllerDowngrade(controller) &&
+    isConstructionSiteInRoom(site, room) &&
+    hasLoneLocalWorkerRecoveryPressure(creep)
+  );
+}
+
+function isNormalLocalRecoveryWorker(creep: Creep): boolean {
+  const memory = creep.memory;
+  return (
+    memory?.role === 'worker' &&
+    memory.controllerSustain === undefined &&
+    memory.controllerUpgrade === undefined &&
+    memory.interRoomEnergyHaul === undefined &&
+    memory.spawnSupport === undefined &&
+    memory.territory === undefined
+  );
+}
+
+function isConstructionSiteInRoom(site: ConstructionSite, room: Room): boolean {
+  const siteRoomName = getPositionRoomName(site);
+  const roomName = getRoomName(room);
+  return siteRoomName === null || roomName === null || siteRoomName === roomName;
+}
+
+function hasLoneLocalWorkerRecoveryPressure(creep: Creep): boolean {
+  return (
+    !hasOtherSameRoomLoadedBuildWorker(creep) &&
+    getSameRoomCreepsIncludingCurrent(creep).filter(isNormalLocalRecoveryWorker).length <= 1
+  );
 }
 
 function isMissingSpawnRecoveryConstructionSite(room: Room, site: ConstructionSite): boolean {
@@ -6346,6 +6393,19 @@ function createUnreservedBuilderStoredEnergyAcquisitionCandidate(
     });
   }
 
+  const recoveryStorageCandidate = createLocalWorkerRecoveryStorageConstructionEnergyCandidate(
+    creep,
+    source,
+    energy,
+    task,
+    reservationContext,
+    minimumEnergy,
+    constructionSite
+  );
+  if (recoveryStorageCandidate) {
+    return recoveryStorageCandidate;
+  }
+
   const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
     creep,
     source,
@@ -6358,6 +6418,52 @@ function createUnreservedBuilderStoredEnergyAcquisitionCandidate(
     minimumEnergy
   );
   return candidate ? toBuilderEnergyAcquisitionCandidate(candidate) : null;
+}
+
+function createLocalWorkerRecoveryStorageConstructionEnergyCandidate(
+  creep: Creep,
+  source: BuilderStoredEnergySource,
+  energy: number,
+  task: Extract<WorkerEnergyAcquisitionTask, { type: 'withdraw' }>,
+  reservationContext: WorkerEnergyAcquisitionReservationContext,
+  minimumEnergy: number,
+  constructionSite: ConstructionSite
+): BuilderEnergyAcquisitionCandidate | null {
+  if (!isStorageStoredEnergySource(source) || !canUseLocalWorkerRecoveryConstructionEnergy(creep, constructionSite)) {
+    return null;
+  }
+
+  const reservedEnergy = getReservedWorkerEnergyAcquisitionAmount(source, reservationContext);
+  const projectedEnergy = Math.max(0, energy - reservedEnergy);
+  const availableEnergy = getStorageEnergyAvailableForWithdrawal(
+    creep.room,
+    source,
+    projectedEnergy,
+    LOCAL_WORKER_RECOVERY_CONSTRUCTION_STORAGE_WITHDRAWAL_OPTIONS
+  );
+  const plannedWithdrawal = Math.min(availableEnergy, getFreeEnergyCapacity(creep));
+  if (
+    availableEnergy < minimumEnergy ||
+    plannedWithdrawal <= 0 ||
+    !withdrawFromStorage(
+      creep.room,
+      plannedWithdrawal,
+      source,
+      projectedEnergy,
+      LOCAL_WORKER_RECOVERY_CONSTRUCTION_STORAGE_WITHDRAWAL_OPTIONS
+    )
+  ) {
+    return null;
+  }
+
+  return createBuilderEnergyAcquisitionCandidate(creep, source, availableEnergy, {
+    ...task,
+    constructionSiteId: constructionSite.id
+  });
+}
+
+function isStorageStoredEnergySource(source: BuilderStoredEnergySource): source is StructureStorage {
+  return matchesStructureType(source.structureType, 'STRUCTURE_STORAGE', 'storage');
 }
 
 function isBuilderConstructionBufferSpawnSource(

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -15704,6 +15704,110 @@ describe('selectWorkerTask', () => {
     });
   });
 
+  it('uses owned storage below reserve for single-worker construction recovery when spawn energy is safe', () => {
+    const fullSpawn = makeFullSpawnEnergyStructure('spawn-full', 'E29N57');
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 0,
+      progressTotal: 1_564,
+      pos: makeRoomPosition(32, 20, 'E29N57')
+    } as ConstructionSite;
+    const storage = makeStoredEnergyStructure('storage-low', 'storage' as StructureConstant, 720, {
+      my: true,
+      pos: makeRoomPosition(35, 27, 'E29N57')
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N57',
+      constructionSites: [site],
+      controller,
+      energyAvailable: MINIMUM_WORKER_SPAWN_ENERGY,
+      energyCapacityAvailable: 1_800,
+      myStructures: [fullSpawn as AnyOwnedStructure],
+      structures: [fullSpawn as AnyStructure, storage as AnyStructure]
+    });
+    const worker = {
+      name: 'RecoveryWorker',
+      memory: { role: 'worker', colony: 'E29N57' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(100)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => {
+          const ranges: Record<string, number> = {
+            'storage-low': 2,
+            'road-site1': 6
+          };
+          return ranges[String(target.id)] ?? 99;
+        })
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ RecoveryWorker: worker });
+    setCpuBucket(748);
+
+    expect(selectWorkerTask(worker)).toEqual({
+      type: 'withdraw',
+      targetId: 'storage-low',
+      constructionSiteId: 'road-site1'
+    });
+  });
+
+  it('spends carried energy on single-worker construction recovery at the spawn energy floor', () => {
+    const fullSpawn = makeFullSpawnEnergyStructure('spawn-full', 'E29N57');
+    const site = {
+      id: 'road-site1',
+      my: true,
+      structureType: 'road',
+      progress: 0,
+      progressTotal: 1_564,
+      pos: makeRoomPosition(32, 20, 'E29N57')
+    } as ConstructionSite;
+    const storage = makeStoredEnergyStructure('storage-low', 'storage' as StructureConstant, 720, {
+      my: true,
+      pos: makeRoomPosition(35, 27, 'E29N57')
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N57',
+      constructionSites: [site],
+      controller,
+      energyAvailable: MINIMUM_WORKER_SPAWN_ENERGY,
+      energyCapacityAvailable: 1_800,
+      myStructures: [fullSpawn as AnyOwnedStructure],
+      structures: [fullSpawn as AnyStructure, storage as AnyStructure]
+    });
+    const worker = {
+      name: 'RecoveryBuilder',
+      memory: { role: 'worker', colony: 'E29N57' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === 'work' ? 1 : 0)),
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(100),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ RecoveryBuilder: worker });
+    setCpuBucket(748);
+
+    expect(canSpendWorkerEnergyOnConstructionSite(worker, site)).toBe(true);
+    expect(selectWorkerTask(worker)).toEqual({ type: 'build', targetId: 'road-site1' });
+  });
+
   it('suppresses generic construction acquisition during critical CPU bucket pressure', () => {
     const fullSpawn = makeFullSpawnEnergyStructure('spawn-full', 'E29N56');
     const site = {


### PR DESCRIPTION
## Summary
- Diagnose E29N57-like recovery as a worker task-selection gap after spawn recovery: a lone local worker could be spawned, but storage below the normal reserve left construction energy acquisition/spending unavailable while build/upgrade stayed at zero.
- Add a bounded local-worker recovery construction path that can use owned storage below the reserve only when the room is owned, safe, not downgrade-guarded, has an owned spawn, has spawn/extension energy at or above the worker-spawn floor, and has only one normal local worker without loaded build coverage.
- Preserve ordinary storage reserves, emergency refill/repair priority, specialized worker assignments, and missing-spawn bootstrap behavior.

Related to #1989

## Verification
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`
- `git diff --check`

## Runtime acceptance after merge/deploy
Fresh official MMO captures should show E29N57 `owned_creeps > 0` stably and at least one of: `build > 0`, `upgrade > 0`, energy buffer healthy/recovering, or a clearly documented strategic hold with telemetry.

No official MMO deploy or merge was performed in this lane.
## Universal task Done gate
- [x] Task type: code hotfix / runtime recovery.
- [x] Expected observable outcome / named deliverable: PR #2003 provides a bounded E29N57-style local worker recovery path that lets a lone safe local worker use owned storage below reserve for construction.
- [x] Non-goals / accepted substitutes: No official MMO deploy, no issue closure, no broad spawn-policy rewrite, and no learned-policy rollout in this PR.
- [x] Verification evidence required before Done: `npm run typecheck`; `npm test -- --runInBand`; `npm run build`; `git diff --check`; focused regression tests cover storage withdrawal and carried-energy build recovery.
- [x] Project Evidence / Next action / Blocked by: Issue #1989 and PR #2003 Project items are In review with Evidence and Next action refreshed; runtime acceptance remains tracked on #1989.
- [x] Post-merge/deploy/runtime proof: Fresh official MMO proof for #1989 requires stable E29N57 physical creeps plus build, upgrade, or energy-buffer recovery evidence.
- [x] Named deliverable proof: Commit `bfff373f` changes `prod/src/tasks/workerTasks.ts` and `prod/test/workerTasks.test.ts`; local verification produced 105 passed suites and 2521 passed tests.
