### PR TITLE
fix: keep stranded local workers active under CPU shed

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -36655,11 +36655,12 @@ function runSpawnSupportMovement(creep) {
 function runAssignedOwnedColonyMovement(creep) {
   var _a2;
   const colonyRoomName = creep.memory.colony;
-  if (!isPlainLocalWorkerAssignment(creep, colonyRoomName) || ((_a2 = creep.room) == null ? void 0 : _a2.name) === colonyRoomName) {
+  const currentRoomName = (_a2 = creep.room) == null ? void 0 : _a2.name;
+  if (!isPlainLocalWorkerAssignment(creep, colonyRoomName) || typeof currentRoomName !== "string" || currentRoomName.length <= 0 || currentRoomName === colonyRoomName) {
     return false;
   }
   const controller = getVisibleRoomController2(colonyRoomName);
-  if ((controller == null ? void 0 : controller.my) !== true) {
+  if (controller !== void 0 && (controller == null ? void 0 : controller.my) !== true) {
     return false;
   }
   clearAssignedTask(creep);
@@ -36719,8 +36720,9 @@ function moveTowardRoom3(creep, roomName) {
   }
 }
 function getVisibleRoomController2(roomName) {
-  var _a2, _b, _c, _d;
-  return (_d = (_c = (_b = (_a2 = globalThis.Game) == null ? void 0 : _a2.rooms) == null ? void 0 : _b[roomName]) == null ? void 0 : _c.controller) != null ? _d : null;
+  var _a2, _b, _c;
+  const visibleRoom = (_b = (_a2 = globalThis.Game) == null ? void 0 : _a2.rooms) == null ? void 0 : _b[roomName];
+  return visibleRoom === void 0 ? void 0 : (_c = visibleRoom.controller) != null ? _c : null;
 }
 function selectControllerSustainHaulerEnergyTask(creep) {
   var _a2, _b;
@@ -53997,15 +53999,17 @@ function getWorkerShedCpuProbeRoomName(creep) {
   return typeof roomName === "string" && roomName.length > 0 ? roomName : null;
 }
 function isPlainLocalWorkerOutsideOwnedColony(creep) {
-  var _a2, _b;
+  var _a2;
   const memory = creep.memory;
   const colonyRoomName = memory == null ? void 0 : memory.colony;
   const currentRoomName = (_a2 = creep.room) == null ? void 0 : _a2.name;
-  return (memory == null ? void 0 : memory.role) === "worker" && isNonEmptyString44(colonyRoomName) && currentRoomName !== colonyRoomName && memory.controllerSustain === void 0 && memory.controllerUpgrade === void 0 && memory.interRoomEnergyHaul === void 0 && memory.spawnSupport === void 0 && memory.territory === void 0 && ((_b = getVisibleOwnedRoomController(colonyRoomName)) == null ? void 0 : _b.my) === true;
+  const colonyController = isNonEmptyString44(colonyRoomName) ? getVisibleRoomController4(colonyRoomName) : null;
+  return (memory == null ? void 0 : memory.role) === "worker" && isNonEmptyString44(colonyRoomName) && isNonEmptyString44(currentRoomName) && currentRoomName !== colonyRoomName && memory.controllerSustain === void 0 && memory.controllerUpgrade === void 0 && memory.interRoomEnergyHaul === void 0 && memory.spawnSupport === void 0 && memory.territory === void 0 && (colonyController === void 0 || (colonyController == null ? void 0 : colonyController.my) === true);
 }
-function getVisibleOwnedRoomController(roomName) {
+function getVisibleRoomController4(roomName) {
   var _a2, _b, _c;
-  return (_c = (_b = (_a2 = globalThis.Game) == null ? void 0 : _a2.rooms) == null ? void 0 : _b[roomName]) == null ? void 0 : _c.controller;
+  const visibleRoom = (_b = (_a2 = globalThis.Game) == null ? void 0 : _a2.rooms) == null ? void 0 : _b[roomName];
+  return visibleRoom === void 0 ? void 0 : (_c = visibleRoom.controller) != null ? _c : null;
 }
 function shouldRunShedCpuColonyPlanning(colony, roleCounts, survivalAssessment) {
   if (hasSpawnPresentLocalWorkerRecoveryShortfall2(colony, survivalAssessment)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -53975,6 +53975,9 @@ function shouldRunWorkerForShedCpu(creep, shedCpuIdleWorkerProbeRooms) {
   if (((_b = creep.memory) == null ? void 0 : _b.territory) !== void 0) {
     return false;
   }
+  if (isPlainLocalWorkerOutsideOwnedColony(creep)) {
+    return true;
+  }
   if (((_c = creep.memory) == null ? void 0 : _c.spawnSupport) !== void 0 || ((_d = creep.memory) == null ? void 0 : _d.task) != null || shedCpuIdleWorkerProbeRooms === void 0) {
     return true;
   }
@@ -53992,6 +53995,17 @@ function getWorkerShedCpuProbeRoomName(creep) {
   var _a2, _b, _c;
   const roomName = (_c = (_a2 = creep.room) == null ? void 0 : _a2.name) != null ? _c : (_b = creep.memory) == null ? void 0 : _b.colony;
   return typeof roomName === "string" && roomName.length > 0 ? roomName : null;
+}
+function isPlainLocalWorkerOutsideOwnedColony(creep) {
+  var _a2, _b;
+  const memory = creep.memory;
+  const colonyRoomName = memory == null ? void 0 : memory.colony;
+  const currentRoomName = (_a2 = creep.room) == null ? void 0 : _a2.name;
+  return (memory == null ? void 0 : memory.role) === "worker" && isNonEmptyString44(colonyRoomName) && currentRoomName !== colonyRoomName && memory.controllerSustain === void 0 && memory.controllerUpgrade === void 0 && memory.interRoomEnergyHaul === void 0 && memory.spawnSupport === void 0 && memory.territory === void 0 && ((_b = getVisibleOwnedRoomController(colonyRoomName)) == null ? void 0 : _b.my) === true;
+}
+function getVisibleOwnedRoomController(roomName) {
+  var _a2, _b, _c;
+  return (_c = (_b = (_a2 = globalThis.Game) == null ? void 0 : _a2.rooms) == null ? void 0 : _b[roomName]) == null ? void 0 : _c.controller;
 }
 function shouldRunShedCpuColonyPlanning(colony, roleCounts, survivalAssessment) {
   if (hasSpawnPresentLocalWorkerRecoveryShortfall2(colony, survivalAssessment)) {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -2263,12 +2263,18 @@ function runSpawnSupportMovement(creep: Creep): boolean {
 
 function runAssignedOwnedColonyMovement(creep: Creep): boolean {
   const colonyRoomName = creep.memory.colony;
-  if (!isPlainLocalWorkerAssignment(creep, colonyRoomName) || creep.room?.name === colonyRoomName) {
+  const currentRoomName = creep.room?.name;
+  if (
+    !isPlainLocalWorkerAssignment(creep, colonyRoomName) ||
+    typeof currentRoomName !== 'string' ||
+    currentRoomName.length <= 0 ||
+    currentRoomName === colonyRoomName
+  ) {
     return false;
   }
 
   const controller = getVisibleRoomController(colonyRoomName);
-  if (controller?.my !== true) {
+  if (controller !== undefined && controller?.my !== true) {
     return false;
   }
 
@@ -2370,8 +2376,9 @@ function moveTowardRoom(creep: Creep, roomName: string): void {
   }
 }
 
-function getVisibleRoomController(roomName: string): StructureController | null {
-  return (globalThis as { Game?: Partial<Pick<Game, 'rooms'>> }).Game?.rooms?.[roomName]?.controller ?? null;
+function getVisibleRoomController(roomName: string): StructureController | null | undefined {
+  const visibleRoom = (globalThis as { Game?: Partial<Pick<Game, 'rooms'>> }).Game?.rooms?.[roomName];
+  return visibleRoom === undefined ? undefined : visibleRoom.controller ?? null;
 }
 
 function selectControllerSustainHaulerEnergyTask(creep: Creep): CreepTaskMemory | null {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -530,6 +530,10 @@ function shouldRunWorkerForShedCpu(
     return false;
   }
 
+  if (isPlainLocalWorkerOutsideOwnedColony(creep)) {
+    return true;
+  }
+
   if (
     creep.memory?.spawnSupport !== undefined ||
     creep.memory?.task != null ||
@@ -554,6 +558,27 @@ function shouldRunWorkerForShedCpu(
 function getWorkerShedCpuProbeRoomName(creep: Creep): string | null {
   const roomName = creep.room?.name ?? creep.memory?.colony;
   return typeof roomName === 'string' && roomName.length > 0 ? roomName : null;
+}
+
+function isPlainLocalWorkerOutsideOwnedColony(creep: Creep): boolean {
+  const memory = creep.memory;
+  const colonyRoomName = memory?.colony;
+  const currentRoomName = creep.room?.name;
+  return (
+    memory?.role === 'worker' &&
+    isNonEmptyString(colonyRoomName) &&
+    currentRoomName !== colonyRoomName &&
+    memory.controllerSustain === undefined &&
+    memory.controllerUpgrade === undefined &&
+    memory.interRoomEnergyHaul === undefined &&
+    memory.spawnSupport === undefined &&
+    memory.territory === undefined &&
+    getVisibleOwnedRoomController(colonyRoomName)?.my === true
+  );
+}
+
+function getVisibleOwnedRoomController(roomName: string): StructureController | undefined {
+  return (globalThis as unknown as { Game?: Partial<Pick<Game, 'rooms'>> }).Game?.rooms?.[roomName]?.controller;
 }
 
 function shouldRunShedCpuColonyPlanning(

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -564,21 +564,28 @@ function isPlainLocalWorkerOutsideOwnedColony(creep: Creep): boolean {
   const memory = creep.memory;
   const colonyRoomName = memory?.colony;
   const currentRoomName = creep.room?.name;
+  const colonyController = isNonEmptyString(colonyRoomName)
+    ? getVisibleRoomController(colonyRoomName)
+    : null;
   return (
     memory?.role === 'worker' &&
     isNonEmptyString(colonyRoomName) &&
+    isNonEmptyString(currentRoomName) &&
     currentRoomName !== colonyRoomName &&
     memory.controllerSustain === undefined &&
     memory.controllerUpgrade === undefined &&
     memory.interRoomEnergyHaul === undefined &&
     memory.spawnSupport === undefined &&
     memory.territory === undefined &&
-    getVisibleOwnedRoomController(colonyRoomName)?.my === true
+    (colonyController === undefined || colonyController?.my === true)
   );
 }
 
-function getVisibleOwnedRoomController(roomName: string): StructureController | undefined {
-  return (globalThis as unknown as { Game?: Partial<Pick<Game, 'rooms'>> }).Game?.rooms?.[roomName]?.controller;
+function getVisibleRoomController(roomName: string): StructureController | null | undefined {
+  const visibleRoom = (globalThis as unknown as { Game?: Partial<Pick<Game, 'rooms'>> }).Game?.rooms?.[
+    roomName
+  ];
+  return visibleRoom === undefined ? undefined : visibleRoom.controller ?? null;
 }
 
 function shouldRunShedCpuColonyPlanning(

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -214,6 +214,42 @@ describe('runEconomy', () => {
     ).toBe(true);
   });
 
+  it('runs stranded local workers toward their owned colony under critical CPU bucket pressure', () => {
+    const criticalBudget = buildRuntimeCpuBudget({
+      tick: 127,
+      used: 21,
+      limit: 70,
+      bucket: 1,
+      tickLimit: 500
+    });
+    const currentRoom = {
+      name: 'W1N1',
+      controller: { my: true, ticksToDowngrade: CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS + 1 } as StructureController
+    } as Room;
+    const colonyRoom = {
+      name: 'W2N1',
+      controller: { my: true, ticksToDowngrade: CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS + 1 } as StructureController
+    } as Room;
+    const previousGame = (globalThis as unknown as { Game?: Partial<Game> }).Game;
+    (globalThis as unknown as { Game?: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: colonyRoom
+      } as unknown as Game['rooms']
+    };
+    const probedRooms = new Set<string>(['W1N1']);
+    const strandedWorker = {
+      name: 'worker-W2N1-stranded',
+      memory: { role: 'worker', colony: 'W2N1' },
+      room: currentRoom
+    } as unknown as Creep;
+
+    try {
+      expect(shouldRunCreepForCpuBudget(strandedWorker, criticalBudget, probedRooms)).toBe(true);
+    } finally {
+      (globalThis as unknown as { Game?: Partial<Game> }).Game = previousGame;
+    }
+  });
+
   it('sheds nonessential creep roles during noncritical low-bucket recovery', () => {
     const lowBucketBudget = buildRuntimeCpuBudget({
       tick: 126,

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -250,6 +250,38 @@ describe('runEconomy', () => {
     }
   });
 
+  it('runs stranded local workers toward an unseen assigned colony under critical CPU bucket pressure', () => {
+    const criticalBudget = buildRuntimeCpuBudget({
+      tick: 127,
+      used: 21,
+      limit: 70,
+      bucket: 1,
+      tickLimit: 500
+    });
+    const currentRoom = {
+      name: 'W1N1',
+      controller: { my: true, ticksToDowngrade: CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS + 1 } as StructureController
+    } as Room;
+    const previousGame = (globalThis as unknown as { Game?: Partial<Game> }).Game;
+    (globalThis as unknown as { Game?: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: currentRoom
+      } as unknown as Game['rooms']
+    };
+    const probedRooms = new Set<string>(['W1N1']);
+    const strandedWorker = {
+      name: 'worker-W2N1-stranded',
+      memory: { role: 'worker', colony: 'W2N1' },
+      room: currentRoom
+    } as unknown as Creep;
+
+    try {
+      expect(shouldRunCreepForCpuBudget(strandedWorker, criticalBudget, probedRooms)).toBe(true);
+    } finally {
+      (globalThis as unknown as { Game?: Partial<Game> }).Game = previousGame;
+    }
+  });
+
   it('sheds nonessential creep roles during noncritical low-bucket recovery', () => {
     const lowBucketBudget = buildRuntimeCpuBudget({
       tick: 126,

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -3070,6 +3070,62 @@ describe('runWorker', () => {
     expect(originRoom.find).not.toHaveBeenCalled();
   });
 
+  it('routes a plain worker toward its unseen assigned colony before retaining foreign-room work', () => {
+    const repairTarget = { id: 'road1', structureType: 'road' } as StructureRoad;
+    const originRoom = {
+      name: 'W2N1',
+      find: jest.fn().mockReturnValue([{ id: 'source1' } as Source])
+    } as unknown as Room;
+    const creep = {
+      memory: {
+        role: 'worker',
+        colony: 'W3N1',
+        task: { type: 'repair', targetId: 'road1' as Id<Structure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: originRoom,
+      repair: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const targetRoomPosition = { x: 25, y: 25, roomName: 'W3N1' } as RoomPosition;
+    const roomPositionCtor = jest.fn(() => targetRoomPosition);
+    const globalWithRoomPosition = globalThis as unknown as {
+      RoomPosition?: new (x: number, y: number, roomName: string) => RoomPosition;
+    };
+    const previousRoomPosition = globalWithRoomPosition.RoomPosition;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: originRoom
+      },
+      creeps: {},
+      getObjectById: jest.fn((id: string) => (id === 'road1' ? repairTarget : null)) as Game['getObjectById']
+    };
+    globalWithRoomPosition.RoomPosition = roomPositionCtor as unknown as new (
+      x: number,
+      y: number,
+      roomName: string
+    ) => RoomPosition;
+
+    try {
+      runWorker(creep);
+    } finally {
+      if (previousRoomPosition === undefined) {
+        delete globalWithRoomPosition.RoomPosition;
+      } else {
+        globalWithRoomPosition.RoomPosition = previousRoomPosition;
+      }
+    }
+
+    expect(creep.memory.task).toBeUndefined();
+    expect(creep.moveTo).toHaveBeenCalledWith(targetRoomPosition);
+    expect(roomPositionCtor).toHaveBeenCalledWith(25, 25, 'W3N1');
+    expect(creep.repair).not.toHaveBeenCalled();
+    expect(originRoom.find).not.toHaveBeenCalled();
+  });
+
   it('routes a plain worker home from foreign-room build work when territory intents are malformed', () => {
     const targetController = { id: 'controller2', my: true } as StructureController;
     const buildSite = { id: 'site1', my: true, structureType: 'extension' } as ConstructionSite;


### PR DESCRIPTION
## Summary
- Diagnosed official run 27932503468 as a real postdeploy runtime failure, not upload/capture failure: upload matched `main` at `64673c40`, console capture was clean, and E29N57 had an owned spawn/RCL5/no hostiles but `owned_creeps=0`, `build=0`, `upgrade=0`, and pending build backlog.
- The limiting path was not telemetry: bot runtime summary shortly before the monitor snapshot still counted three `worker-E29N57-*` creeps by memory, but the room monitor saw them physically in E29N56 while E29N57 had no physical owned creeps.
- Room spawn recovery was blocked by affordability/refill, not spawn reservation: E29N57 `Spawn3` was idle, but room energy was below the minimum worker body cost while storage energy existed outside spawn/extensions and no local worker was present to refill.
- Under critical/low CPU shedding, idle worker execution is capped per current room. This could keep stranded plain local workers from running their return-home movement, leaving E29N57 with no local refill/build path while the bucket is critical.
- Change: allow plain local workers outside their visible owned colony to run under CPU shedding so `runAssignedOwnedColonyMovement` can return them home. Territory workers, spawn-support workers, controller-sustain workers, and other special cross-room roles keep their existing behavior.

Related to #1989

## Verification
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`
- `git diff --check`

## Universal task Done gate
- [x] Task type: Screeps production recovery change for the E29N57 zero-physical-worker follow-up; parent issue is 1989 and prior PR is 2004.
- [x] Expected observable outcome / named deliverable: PR #2006 on branch `codex/1989-post2004-zero-creeps` changes critical CPU creep scheduling so plain local workers outside a visible owned colony still run return-home movement.
- [x] Non-goals / accepted substitutes: Official MMO deploy, merge, Tencent paid compute, E29N57 hard-code, and reopening prior PR are excluded by task scope.
- [x] Verification evidence required before Done: Local `npm run typecheck`, `npm test -- --runInBand` with 105 suites and 2524 tests, `npm run build`, and `git diff --check` all passed in `/root/screeps-worktrees/issue-1989-post2004-zero-creeps/prod`.
- [x] Project Evidence / Next action / Blocked by: Project `screeps` fields are updated for issue item 1989 and PR item 2006; Evidence names commit `7942837e`, Next action names review gate plus controller-run official validation, and Blocked by is set to None semantics.
- [x] Post-merge/deploy/runtime proof: Owner-scoped handoff records the postdeploy acceptance metric for the controller: E29N57 `owned_creeps > 0` stably plus build/upgrade activity, recovering energy buffer, or documented strategic hold telemetry.
- [x] Named deliverable proof: PR #2006 is open at https://github.com/lanyusea/screeps/pull/2006 and commit `7942837e127d96c78143636e12d999f03cf5568c` is pushed to `origin/codex/1989-post2004-zero-creeps`.

## Runtime Acceptance Metric
Controller-run official captures should prove E29N57 recovery with `owned_creeps > 0` stably and at least one of `build > 0`, `upgrade > 0`, healthy/recovering energy buffer, or a documented strategic hold with telemetry.