### PR TITLE
fix: recover construction when spawn buffer blocks withdraw

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -31734,11 +31734,14 @@ function canUseFallbackConstructionWithdrawTask(creep, task) {
 }
 function getVisibleStoreStructureById(room, targetId) {
   const gameObject = getGameObjectById4(targetId);
-  if (gameObject) {
+  if (isStoreStructure(gameObject)) {
     return gameObject;
   }
   const visibleStructure = findVisibleRoomStructures(room).find((structure) => String(structure.id) === targetId);
-  return visibleStructure ? visibleStructure : null;
+  return isStoreStructure(visibleStructure) ? visibleStructure : null;
+}
+function isStoreStructure(structure) {
+  return Boolean(structure && "store" in structure);
 }
 function findBuilderEnergyAcquisitionCandidates(creep, constructionSite) {
   const context = {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -31711,13 +31711,34 @@ function selectConstructionBacklogFallbackEnergyAcquisitionTask(creep) {
     return null;
   }
   const fallbackTask = selectWorkerEnergyAcquisitionTask(creep);
-  if ((fallbackTask == null ? void 0 : fallbackTask.type) !== "withdraw" || typeof fallbackTask.constructionSiteId === "string") {
-    return null;
+  if ((fallbackTask == null ? void 0 : fallbackTask.type) === "pickup") {
+    return fallbackTask;
   }
-  return {
-    ...fallbackTask,
-    constructionSiteId: constructionSite.id
-  };
+  if ((fallbackTask == null ? void 0 : fallbackTask.type) === "withdraw" && typeof fallbackTask.constructionSiteId !== "string") {
+    const constructionWithdrawTask = {
+      ...fallbackTask,
+      constructionSiteId: constructionSite.id
+    };
+    if (canUseFallbackConstructionWithdrawTask(creep, constructionWithdrawTask)) {
+      return constructionWithdrawTask;
+    }
+  }
+  return selectWorkerHarvestTask(creep, { allowPreHarvest: false });
+}
+function canUseFallbackConstructionWithdrawTask(creep, task) {
+  const target = getVisibleStoreStructureById(creep.room, String(task.targetId));
+  if (!target) {
+    return false;
+  }
+  return getSafeWorkerWithdrawEnergyAmount(creep, target, getFreeEnergyCapacity9(creep), task) > 0;
+}
+function getVisibleStoreStructureById(room, targetId) {
+  const gameObject = getGameObjectById4(targetId);
+  if (gameObject) {
+    return gameObject;
+  }
+  const visibleStructure = findVisibleRoomStructures(room).find((structure) => String(structure.id) === targetId);
+  return visibleStructure ? visibleStructure : null;
 }
 function findBuilderEnergyAcquisitionCandidates(creep, constructionSite) {
   const context = {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -60,6 +60,7 @@ import {
 } from '../economy/spawnEnergyReservation';
 import {
   createWorkerConstructionWithdrawReservationContext,
+  getSafeWorkerWithdrawEnergyAmount,
   getSpawnConstructionEnergyAvailableForWithdrawal,
   type WorkerConstructionWithdrawReservationContext
 } from '../economy/workerConstructionWithdrawBudget';
@@ -6213,7 +6214,7 @@ export function selectConstructionBacklogEnergyAcquisitionTask(
 
 function selectConstructionBacklogFallbackEnergyAcquisitionTask(
   creep: Creep
-): Extract<CreepTaskMemory, { type: 'withdraw' }> | null {
+): Extract<CreepTaskMemory, { type: 'harvest' | 'pickup' | 'withdraw' }> | null {
   if (getFreeEnergyCapacity(creep) <= 0 || getActiveWorkParts(creep) <= 0 || hasVisibleHostilePresence(creep.room)) {
     return null;
   }
@@ -6236,14 +6237,43 @@ function selectConstructionBacklogFallbackEnergyAcquisitionTask(
   }
 
   const fallbackTask = selectWorkerEnergyAcquisitionTask(creep);
-  if (fallbackTask?.type !== 'withdraw' || typeof fallbackTask.constructionSiteId === 'string') {
-    return null;
+  if (fallbackTask?.type === 'pickup') {
+    return fallbackTask;
   }
 
-  return {
-    ...fallbackTask,
-    constructionSiteId: constructionSite.id
-  };
+  if (fallbackTask?.type === 'withdraw' && typeof fallbackTask.constructionSiteId !== 'string') {
+    const constructionWithdrawTask = {
+      ...fallbackTask,
+      constructionSiteId: constructionSite.id
+    };
+    if (canUseFallbackConstructionWithdrawTask(creep, constructionWithdrawTask)) {
+      return constructionWithdrawTask;
+    }
+  }
+
+  return selectWorkerHarvestTask(creep, { allowPreHarvest: false });
+}
+
+function canUseFallbackConstructionWithdrawTask(
+  creep: Creep,
+  task: Extract<CreepTaskMemory, { type: 'withdraw' }>
+): boolean {
+  const target = getVisibleStoreStructureById(creep.room, String(task.targetId));
+  if (!target) {
+    return false;
+  }
+
+  return getSafeWorkerWithdrawEnergyAmount(creep, target, getFreeEnergyCapacity(creep), task) > 0;
+}
+
+function getVisibleStoreStructureById(room: Room, targetId: string): AnyStoreStructure | null {
+  const gameObject = getGameObjectById<AnyStoreStructure>(targetId);
+  if (gameObject) {
+    return gameObject;
+  }
+
+  const visibleStructure = findVisibleRoomStructures(room).find((structure) => String(structure.id) === targetId);
+  return visibleStructure ? (visibleStructure as AnyStoreStructure) : null;
 }
 
 export function findBuilderEnergyAcquisitionCandidates(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -6268,12 +6268,16 @@ function canUseFallbackConstructionWithdrawTask(
 
 function getVisibleStoreStructureById(room: Room, targetId: string): AnyStoreStructure | null {
   const gameObject = getGameObjectById<AnyStoreStructure>(targetId);
-  if (gameObject) {
+  if (isStoreStructure(gameObject)) {
     return gameObject;
   }
 
   const visibleStructure = findVisibleRoomStructures(room).find((structure) => String(structure.id) === targetId);
-  return visibleStructure ? (visibleStructure as AnyStoreStructure) : null;
+  return isStoreStructure(visibleStructure) ? visibleStructure : null;
+}
+
+function isStoreStructure(structure: RoomObject | null | undefined): structure is AnyStoreStructure {
+  return Boolean(structure && 'store' in structure);
 }
 
 export function findBuilderEnergyAcquisitionCandidates(

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -16095,6 +16095,61 @@ describe('selectWorkerTask', () => {
     });
   });
 
+  it('harvests for E29N57 source-container recovery when spawn construction energy is buffer-blocked under low bucket', () => {
+    const source = makeSource('source1', 20, 20, 'E29N57');
+    const site = {
+      id: 'container-site1',
+      structureType: 'container',
+      progress: 500,
+      progressTotal: 5_000,
+      pos: {
+        ...makeRoomPosition(20, 21, 'E29N57'),
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'spawn1' ? 1 : 99))
+      }
+    } as unknown as ConstructionSite;
+    const spawn = makeFullSpawnEnergyStructure('spawn1', 'E29N57');
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N57',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 300,
+      energyCapacityAvailable: 1_800,
+      myStructures: [spawn as AnyOwnedStructure],
+      sources: [source],
+      structures: [spawn as unknown as AnyStructure]
+    });
+    const creep = {
+      name: 'EmptyCpuShedBuilder',
+      memory: { role: 'worker', colony: 'E29N57' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      pos: {
+        ...makeRoomPosition(20, 20, 'E29N57'),
+        getRangeTo: jest.fn((target: { id?: string }) => {
+          if (target.id === 'spawn1') return 1;
+          if (target.id === 'source1') return 1;
+          return 99;
+        })
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ EmptyCpuShedBuilder: creep });
+    setGameObjectsById([site, spawn, source], { rooms: { E29N57: room }, time: 2_480_290 });
+    setCpuBucket(CONSTRUCTION_LOW_BUCKET_RECOVERY_THRESHOLD + 2);
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+  });
+
   it('keeps a loaded E29N57 road builder productive during low-bucket shedding when storage protects construction', () => {
     const site = {
       id: 'remote-road-site1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -16150,6 +16150,63 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
   });
 
+  it('does not tag fallback construction withdraws for targets without a store', () => {
+    const source = makeSource('source1', 20, 20, 'E29N57');
+    const site = {
+      id: 'container-site1',
+      structureType: 'container',
+      progress: 500,
+      progressTotal: 5_000,
+      pos: {
+        ...makeRoomPosition(20, 21, 'E29N57'),
+        getRangeTo: jest.fn(() => 99)
+      }
+    } as unknown as ConstructionSite;
+    const legacyContainer = makeStructure('legacy-container1', 'container' as StructureConstant, 2_000, 2_000, {
+      energy: 100,
+      pos: makeRoomPosition(20, 22, 'E29N57')
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 5,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 5_000
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      name: 'E29N57',
+      constructionSites: [site],
+      controller,
+      energyAvailable: 800,
+      energyCapacityAvailable: 1_800,
+      sources: [source],
+      structures: [legacyContainer]
+    });
+    const creep = {
+      name: 'NoStoreFallbackBuilder',
+      memory: { role: 'worker', colony: 'E29N57' },
+      getActiveBodyparts: jest.fn((part?: BodyPartConstant) => (part === WORK ? 1 : 0)),
+      pos: {
+        ...makeRoomPosition(20, 20, 'E29N57'),
+        getRangeTo: jest.fn((target: { id?: string }) => {
+          if (target.id === 'legacy-container1') return 1;
+          if (target.id === 'source1') return 1;
+          return 99;
+        })
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 0 : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0)),
+        getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 50 : 0))
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ NoStoreFallbackBuilder: creep });
+    setGameObjectsById([site, legacyContainer, source], { rooms: { E29N57: room }, time: 2_480_291 });
+    setCpuBucket(CONSTRUCTION_LOW_BUCKET_RECOVERY_THRESHOLD + 2);
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+  });
+
   it('keeps a loaded E29N57 road builder productive during low-bucket shedding when storage protects construction', () => {
     const site = {
       id: 'remote-road-site1',


### PR DESCRIPTION
## Summary

Related to issue 1989.

This follows up after PR #2006 merged/deployed successfully but official postdeploy acceptance still failed for E29N57.

## Diagnosis

Deploy evidence from run 27936374806 showed the uploaded `main` code matched the remote active world branch, so this was a runtime behavior issue rather than deployment drift.

The postdeploy health gate blocked only E29N57:

- `workerCount=3`, `energyAvailable=300`, `energyCapacity=1800`
- one critical container construction site with `pendingBuildProgress=1504`
- `build=0`, `buildCarriedEnergy=0`, `buildProgress=0`
- health gate reason `worker_assignment_gap`

The later clean official console capture at `2026-06-22T07:38:24Z` showed the same deadlock shape:

- `taskCounts.withdraw=1`, `taskCounts.none=2`, `taskCounts.harvest=0`, `taskCounts.build=0`
- `idleReasonCounts.cpu_shed_assignment_skipped=2`
- `constructionActivity.buildBlockedReason=energy_buffer_blocked`
- `constructionActivity.reason=cpu_shed`
- `combat.hostileCreepCount=0`, `hostileStructureCount=0`
- CPU bucket around `752`, so low-bucket safety remained relevant

Root cause: the low-bucket construction recovery fallback could issue a construction-scoped spawn withdraw even when `getSpawnConstructionEnergyAvailableForWithdrawal`/safe withdrawal budget was zero at the room’s 300-energy floor. That left one worker pinned to a doomed withdraw/no-carried-energy cycle while the remaining idle workers were shed by the low-bucket per-room probe limit.

## Changes

- Guard fallback construction withdraws with `getSafeWorkerWithdrawEnergyAmount` before tagging them with `constructionSiteId`.
- Preserve stored/container/dropped-energy construction recovery paths.
- Fall back to direct harvest when no safe construction withdraw exists, so the bounded low-bucket recovery worker can carry energy without draining the reserved spawn floor.
- Add a focused E29N57-like low-bucket regression: RCL5 owned room, 300 spawn energy, no stored construction energy, critical source-container site, empty worker, CPU bucket just above the construction recovery floor.
- Regenerate `prod/dist/main.js` via `npm run build`.

## Verification

From `prod/`:

- `npm run typecheck` ✅
- `npm test -- --runInBand` ✅ 105 suites, 2527 tests
- `npm run build` ✅

From worktree root:

- `git diff --check` ✅

Focused pre-fix reproduction:

- New Jest case failed before the production fix with `Received: null` instead of a harvest task.
- The same case passes after the fix.

## Universal task Done gate

- [x] Task type: Critical Screeps runtime-recovery code change with focused regression coverage.
- [x] Expected observable outcome / named deliverable: PR 2007 carries commit 6603f3d748f61008337183e5d7ede33eb856f2c5 with the low-bucket construction recovery path and regenerated bundle.
- [x] Non-goals / accepted substitutes: Official MMO deploy, merge, Tencent paid compute, and issue completion are outside this lane.
- [x] Verification evidence required before Done: Local typecheck, Jest runInBand, build, diff-check, prod CI, and CodeRabbit review all report success for PR 2007 head 6603f3d748f61008337183e5d7ede33eb856f2c5.
- [x] Project Evidence / Next action / Blocked by: Project screeps fields were updated for issue 1989 and PR 2007 with evidence, next action, and dependency status.
- [x] Post-merge/deploy/runtime proof: Official runtime proof criteria are documented for the controller path; this lane performs no official deploy or merge by instruction.
- [x] Named deliverable proof: Commit 6603f3d748f61008337183e5d7ede33eb856f2c5 is pushed on branch codex/1989-post2006-cpu-shed-energy-buffer and is attached to PR 2007.

## Runtime Acceptance Still Required

Issue 1989 should remain open until official runtime acceptance passes after merge/deploy. Acceptance requires fresh official captures showing E29N57 `workerCount/owned_creeps > 0` stably and at least one of:

- `build > 0`
- `buildCarriedEnergy > 0`
- `buildProgress > 0`
- `upgrade > 0`
- energy buffer healthy/recovering
- a documented strategic hold with telemetry that is not a `worker_assignment_gap` / `cpu_shed_assignment_skipped` deadlock

No official MMO deploy, merge, or Tencent paid compute was run from this lane.